### PR TITLE
Fix typos across Libra repository

### DIFF
--- a/benchmark/src/lib.rs
+++ b/benchmark/src/lib.rs
@@ -67,7 +67,7 @@ pub struct Benchmarker {
     clients: Vec<Arc<AdmissionControlClient>>,
     /// Use WalletLibrary to setup the benchmarking environment.
     wallet: WalletLibrary,
-    /// Interface to metric counters in validator nodes, e.g., #commited_txns in storage.
+    /// Interface to metric counters in validator nodes, e.g., #committed_txns in storage.
     debug_client: NodeDebugClient,
 }
 
@@ -86,7 +86,7 @@ impl Benchmarker {
         }
     }
 
-    /// Use debug client interface to query #commited TXNs in validator's storage.
+    /// Use debug client interface to query #committed TXNs in validator's storage.
     /// If it is not available, we can still count on timeout to terminate the wait.
     /// So in that case we return a default value 0.
     fn get_committed_txns_counter(&self) -> i64 {

--- a/benchmark/src/ruben_opt.rs
+++ b/benchmark/src/ruben_opt.rs
@@ -22,8 +22,8 @@ arg_enum! {
     about = "RuBen (Ru)ns The Libra (Ben)chmarker For You."
 )]
 pub struct Opt {
-    /// Validator address list seperated by whitespace: `ip_address:port ip_address:port ...`.
-    /// It is requried unless (and hence conflict with) swarm_config_dir is present.
+    /// Validator address list separated by whitespace: `ip_address:port ip_address:port ...`.
+    /// It is required unless (and hence conflict with) swarm_config_dir is present.
     #[structopt(
         short = "a",
         long = "validator_addresses",
@@ -33,7 +33,7 @@ pub struct Opt {
     )]
     pub validator_addresses: Vec<String>,
     /// Debug interface address in the form of ip_address:port.
-    /// It is requried unless (and hence conflict with) swarm_config_dir is present.
+    /// It is required unless (and hence conflict with) swarm_config_dir is present.
     #[structopt(
         short = "d",
         long = "debug_address",
@@ -43,7 +43,7 @@ pub struct Opt {
     )]
     pub debug_address: Option<String>,
     /// libra_swarm's config file directory, which holds libra_node's config .toml file(s).
-    /// It is requried unless (and hence conflict with)
+    /// It is required unless (and hence conflict with)
     /// validator_addresses and debug_address are both present.
     #[structopt(
         short = "s",

--- a/language/bytecode_verifier/src/absint.rs
+++ b/language/bytecode_verifier/src/absint.rs
@@ -50,7 +50,7 @@ pub trait TransferFunctions {
     /// Should return an AnalysisError if executing the instruction is unsuccessful, and () if
     /// the effects of successfully executing local@instr have been reflected by mutatating
     /// local@pre.
-    /// Auxilary data from the analysis that is not part of the abstract state can be collected by
+    /// Auxiliary data from the analysis that is not part of the abstract state can be collected by
     /// mutating local@self.
     /// The last instruction index in the current block is local@last_index. Knowing this
     /// information allows clients to detect the end of a basic block and special-case appropriately

--- a/language/compiler/ir_to_bytecode/src/compiler.rs
+++ b/language/compiler/ir_to_bytecode/src/compiler.rs
@@ -136,9 +136,9 @@ struct FunctionFrame {
     local_types: LocalsSignature,
     // i64 to allow the bytecode verifier to catch errors of
     // - negative stack sizes
-    // - excessivley large stack sizes
+    // - excessively large stack sizes
     // The max stack depth of the file_format is set as u16
-    // Theoritically, we could use a BigInt here, but that is probably overkill for any testing
+    // Theoretically, we could use a BigInt here, but that is probably overkill for any testing
     max_stack_depth: i64,
     cur_stack_depth: i64,
     loops: Vec<LoopInfo>,

--- a/language/vm/src/gas_schedule.rs
+++ b/language/vm/src/gas_schedule.rs
@@ -122,7 +122,7 @@ macro_rules! define_gas_unit {
 define_gas_unit! {
     name: AbstractMemorySize,
     carrier: GasCarrier,
-    doc: "A newtype wrapper that represents the (abstract) memory size that the instruciton will take up."
+    doc: "A newtype wrapper that represents the (abstract) memory size that the instruction will take up."
 }
 
 define_gas_unit! {

--- a/language/vm/src/resolver.rs
+++ b/language/vm/src/resolver.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module implements a resolver for importing a SignatureToken defined in one module into
-//! another. This functionaliy is used in verify_module_dependencies and verify_script_dependencies.
+//! another. This functionality is used in verify_module_dependencies and verify_script_dependencies.
 use crate::{
     access::ModuleAccess,
     errors::VMStaticViolation,

--- a/mempool/src/core_mempool/unit_tests/shared_mempool_test.rs
+++ b/mempool/src/core_mempool/unit_tests/shared_mempool_test.rs
@@ -105,7 +105,7 @@ impl SharedMempoolNetwork {
         }
     }
 
-    /// deliveres next message from given node to it's peer
+    /// delivers next message from given node to it's peer
     fn deliver_message(&mut self, peer: &PeerId) -> (SignedTransaction, PeerId) {
         // emulate timer tick
         self.timers

--- a/network/netcore/src/negotiate/outbound.rs
+++ b/network/netcore/src/negotiate/outbound.rs
@@ -25,7 +25,7 @@ where
     write_u16frame(&mut stream, PROTOCOL_INTERACTIVE).await?;
 
     let mut buf = BytesMut::new();
-    let mut recieved_header_ack = false;
+    let mut received_header_ack = false;
     for proto in supported_protocols.as_ref() {
         write_u16frame(&mut stream, proto.as_ref()).await?;
         stream.flush().await?;
@@ -34,7 +34,7 @@ where
         // Note that we do this after sending the first protocol id, allowing for the negotiation to
         // happen in a single round trip in case the remote node indeed speaks our preferred
         // protocol.
-        if !recieved_header_ack {
+        if !received_header_ack {
             read_u16frame(&mut stream, &mut buf).await?;
             if buf.as_ref() != PROTOCOL_INTERACTIVE {
                 // Remote side doesn't understand us, give up
@@ -44,7 +44,7 @@ where
                 ));
             }
 
-            recieved_header_ack = true;
+            received_header_ack = true;
         }
 
         read_u16frame(&mut stream, &mut buf).await?;

--- a/network/src/connectivity_manager/mod.rs
+++ b/network/src/connectivity_manager/mod.rs
@@ -7,7 +7,7 @@
 //! to system membership.
 //!
 //! In our current system design, the Consensus actor informs the ConnectivityManager of
-//! eligible nodes, and the Discovery actor infroms it about updates to addresses of eligible
+//! eligible nodes, and the Discovery actor informs it about updates to addresses of eligible
 //! nodes.
 use crate::{
     common::NetworkPublicKeys,

--- a/storage/schemadb/src/schema.rs
+++ b/storage/schemadb/src/schema.rs
@@ -46,7 +46,7 @@ use std::fmt::Debug;
 ///
 /// // And finally define a schema type and associate it with key and value types, as well as the
 /// // column family name, by generating code that implements the `Schema` trait for the type.
-/// define_schema!(ExampleSchema, Key, Value, "exmaple_cf_name");
+/// define_schema!(ExampleSchema, Key, Value, "example_cf_name");
 ///
 /// // SeekKeyCodec is automatically implemented for KeyCodec,
 /// // so you can seek an iterator with the Key type:

--- a/storage/sparse_merkle/src/sparse_merkle_test.rs
+++ b/storage/sparse_merkle/src/sparse_merkle_test.rs
@@ -212,7 +212,7 @@ fn setup_extension_case(db: &MockTreeStore, n: usize) -> (HashValue, HashValue) 
 }
 
 #[test]
-fn test_insert_at_extension_fork_at_begining() {
+fn test_insert_at_extension_fork_at_beginning() {
     let db = MockTreeStore::default();
     let (root, extension_child_hash) = setup_extension_case(&db, 6);
     let tree = SparseMerkleTree::new(&db);

--- a/types/src/account_config.rs
+++ b/types/src/account_config.rs
@@ -23,7 +23,7 @@ use std::{collections::BTreeMap, convert::TryInto};
 /// // Struct types defined by this account
 /// code: HashMap<Name, Code>,
 /// // Resurces owned by this account
-/// resoruces: HashMap<ObjectName, StructInstance>,
+/// resources: HashMap<ObjectName, StructInstance>,
 /// }
 
 // LibraCoin

--- a/types/src/validator_public_keys.rs
+++ b/types/src/validator_public_keys.rs
@@ -126,7 +126,7 @@ impl CanonicalSerialize for ValidatorPublicKeys {
 impl CanonicalDeserialize for ValidatorPublicKeys {
     fn deserialize(deserializer: &mut impl CanonicalDeserializer) -> Result<Self> {
         let account_address = deserializer.decode_struct::<AccountAddress>()?;
-        let concensus_public_key =
+        let consensus_public_key =
             Ed25519PublicKey::try_from(&deserializer.decode_variable_length_bytes()?[..])?;
         let network_identity_public_key =
             X25519PublicKey::from_slice(&deserializer.decode_variable_length_bytes()?)?;
@@ -134,7 +134,7 @@ impl CanonicalDeserialize for ValidatorPublicKeys {
             Ed25519PublicKey::try_from(&deserializer.decode_variable_length_bytes()?[..])?;
         Ok(ValidatorPublicKeys::new(
             account_address,
-            concensus_public_key,
+            consensus_public_key,
             network_signing_public_key,
             network_identity_public_key,
         ))


### PR DESCRIPTION
## Motivation

Fixing typos across the project

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

### Changes

```
libra/benchmark/src/lib.rs:70:64: "commited" is a misspelling of "committed"
libra/benchmark/src/lib.rs:89:45: "commited" is a misspelling of "committed"
libra/benchmark/src/ruben_opt.rs:25:31: "seperated" is a misspelling of "separated"
libra/benchmark/src/ruben_opt.rs:26:14: "requried" is a misspelling of "required"
libra/benchmark/src/ruben_opt.rs:36:14: "requried" is a misspelling of "required"
libra/benchmark/src/ruben_opt.rs:46:14: "requried" is a misspelling of "required"
libra/language/bytecode_verifier/src/absint.rs:53:8: "Auxilary" is a misspelling of "Auxiliary"
libra/language/compiler/ir_to_bytecode/src/compiler.rs:139:9: "excessivley" is a misspelling of "excessively"
libra/language/compiler/ir_to_bytecode/src/compiler.rs:141:7: "Theoritically" is a misspelling of "Theoretically"
libra/language/vm/src/gas_schedule.rs:125:80: "instruciton" is a misspelling of "instruction"
libra/language/vm/src/resolver.rs:5:18: "functionaliy" is a misspelling of "functionality"
libra/mempool/src/core_mempool/unit_tests/shared_mempool_test.rs:108:8: "deliveres" is a misspelling of "delivers"
libra/network/netcore/src/negotiate/outbound.rs:28:12: "recieved" is a misspelling of "received"
libra/network/netcore/src/negotiate/outbound.rs:37:12: "recieved" is a misspelling of "received"
libra/network/netcore/src/negotiate/outbound.rs:47:12: "recieved" is a misspelling of "received"
libra/network/src/connectivity_manager/mod.rs:10:44: "infroms" is a misspelling of "informs"
libra/storage/schemadb/src/schema.rs:49:47: "exmaple" is a misspelling of "example"
libra/storage/sparse_merkle/src/sparse_merkle_test.rs:215:36: "begining" is a misspelling of "beginning"
libra/types/src/account_config.rs:26:4: "resoruces" is a misspelling of "resources"
libra/types/src/validator_public_keys.rs:129:12: "concensus" is a misspelling of "consensus"
libra/types/src/validator_public_keys.rs:137:12: "concensus" is a misspelling of "consensus"
```