### PR TITLE
Perf-test of crypto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3495,6 +3495,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tiny-keccak",
+ "unroll",
 ]
 
 [[package]]
@@ -6962,6 +6963,16 @@ checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
 dependencies = [
  "generic-array 0.14.4",
  "subtle",
+]
+
+[[package]]
+name = "unroll"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ad948c1cb799b1a70f836077721a92a35ac177d4daddf4c20a633786d4cf618"
+dependencies = [
+ "quote 1.0.7",
+ "syn 1.0.42",
 ]
 
 [[package]]

--- a/crypto/crypto/src/ed25519.rs
+++ b/crypto/crypto/src/ed25519.rs
@@ -44,6 +44,7 @@ use libra_crypto_derive::{DeserializeKey, SerializeKey, SilentDebug, SilentDispl
 use mirai_annotations::*;
 use serde::Serialize;
 use std::{cmp::Ordering, fmt};
+// use std::{thread, time};
 
 /// The length of the Ed25519PrivateKey
 pub const ED25519_PRIVATE_KEY_LENGTH: usize = ed25519_dalek::SECRET_KEY_LENGTH;
@@ -418,6 +419,7 @@ impl Signature for Ed25519Signature {
         message: &T,
         public_key: &Ed25519PublicKey,
     ) -> Result<()> {
+        // Ok(())
         // Public keys should be validated to be safe against small subgroup attacks, etc.
         precondition!(has_tag!(public_key, ValidatedPublicKeyTag));
         let mut bytes = <T::Hasher as CryptoHasher>::seed().to_vec();
@@ -430,6 +432,10 @@ impl Signature for Ed25519Signature {
     /// Outside of this crate, this particular function should only be used for native signature
     /// verification in move
     fn verify_arbitrary_msg(&self, message: &[u8], public_key: &Ed25519PublicKey) -> Result<()> {
+        // Ok(())
+        // let one_second = time::Duration::from_millis(1000);
+        // thread::sleep(one_second);
+
         // Public keys should be validated to be safe against small subgroup attacks, etc.
         precondition!(has_tag!(public_key, ValidatedPublicKeyTag));
         Ed25519Signature::check_malleability(&self.to_bytes())?;
@@ -453,6 +459,10 @@ impl Signature for Ed25519Signature {
         message: &T,
         keys_and_signatures: Vec<(Self::VerifyingKeyMaterial, Self)>,
     ) -> Result<()> {
+        // Ok(())
+        // let one_second = time::Duration::from_millis(1000);
+        // thread::sleep(one_second);
+
         for (_, sig) in keys_and_signatures.iter() {
             Ed25519Signature::check_malleability(&sig.to_bytes())?
         }

--- a/testsuite/cluster-test/src/suite.rs
+++ b/testsuite/cluster-test/src/suite.rs
@@ -88,6 +88,7 @@ impl ExperimentSuite {
         experiments.push(Box::new(
             PerformanceBenchmarkParams::new_nodes_down(0).build(cluster),
         ));
+        /*
         experiments.push(Box::new(
             PerformanceBenchmarkParams::new_nodes_down(10).build(cluster),
         ));
@@ -97,6 +98,7 @@ impl ExperimentSuite {
         experiments.push(Box::new(
             PerformanceBenchmarkParams::new_fixed_tps(0, 10).build(cluster),
         ));
+         */
         Self { experiments }
     }
 

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -36,6 +36,8 @@ libra-time = { path = "../common/time", version = "0.1.0" }
 libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
 move-core-types = { path = "../language/move-core/types", version = "0.1.0" }
 
+unroll = "0.1.5"
+
 [dev-dependencies]
 regex = "1.3.9"
 proptest = "0.10.1"


### PR DESCRIPTION
Not supposed to be committed.
This PR will switch-off various presumably expensive components (e.g. signature verifications, SHA3 hashes, etc.) and run performance test to compare the TPS.

Results so far (for default 4500 accounts):
[1] all up (base-line): 1010 TPS
[2] all up without signature verifications: 1035 TPS (2.5% rise)
[3] all up with signature verifications done twice (i.e. slowed down by 2x): 904 TPS (10.5% drop)
[4] all up with verifications done 5 times (slowed down by 5x): 549 TPS (54% drop)

[5] all up without hashing of internal Merkle Nodes: 1125 TPS (10% rise)
he CryptoHash for MerkleTreeInternalNode is made to be:
```
        let mut result = [0u8; HashValue::LENGTH];
        for i in 0..HashValue::LENGTH {
            result[i] = self.left_child[i] ^ self.right_child[i];
        }
        HashValue::new(result)
```
[6] all up with hashing of internal Merkle Nodes done twice, which simulates a tree with 20 million accounts (4500^2), tree of height 24: 904 TPS (10% drop)
[7] all up with hashing of internal Merkle Nodes repeated three times (simulates 4500^2 = 91 billion accounts, tree of height 36): 824 TPS (18% drop), 23% raise in latency

Full output:
```
[1]
all up : 1010 TPS, 4475 ms latency, 5400 ms p99 latency, no expired txns
10% down : 995 TPS, 4092 ms latency, 5000 ms p99 latency, no expired txns
3 Region Simulation : 756 TPS, 6002 ms latency, 7750 ms p99 latency, no expired txns
fixed tps 10 : 10 TPS, 603 ms latency, 800 ms p99 latency, no expired txns
```
```
[2]
all up : 1035 TPS, 4373 ms latency, 5300 ms p99 latency, no expired txns
10% down : 987 TPS, 4113 ms latency, 6600 ms p99 latency, no expired txns
3 Region Simulation : 781 TPS, 5799 ms latency, 7700 ms p99 latency, no expired txns
fixed tps 10 : 10 TPS, 577 ms latency, 600 ms p99 latency, no expired txns
```
```
[3]
all up : 904 TPS, 5015 ms latency, 5900 ms p99 latency, no expired txns
10% down : 883 TPS, 4621 ms latency, 7600 ms p99 latency, no expired txns
3 Region Simulation : 709 TPS, 6386 ms latency, 8500 ms p99 latency, no expired txns
fixed tps 10 : 10 TPS, 712 ms latency, 800 ms p99 latency, no expired txns
```
```
[4]
all up : 549 TPS, 8280 ms latency, 11150 ms p99 latency, no expired txns
```
```
[5]
all up : 1125 TPS, 4023 ms latency, 4850 ms p99 latency, no expired txns
```
```
[6]
all up : 904 TPS, 5017 ms latency, 6050 ms p99 latency, no expired txns
```
```
[7] 824 TPS, 5509 ms latency, 6950 ms p99 latency, no expired txns
```