### PR TITLE
[move lang] Make dep structs not native

### DIFF
--- a/language/move-lang/functional-tests/tests/move/dependencies/pack_unpack_private.exp
+++ b/language/move-lang/functional-tests/tests/move/dependencies/pack_unpack_private.exp
@@ -1,0 +1,5 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)
+[3] Transaction(1)
+[4] "\n\nerror: \n\n   ┌── (file):4:9 ───\n   │\n 4 │         C::T {}\n   │         ^^^^^^^ Invalid instantiation of \'0xA4A46D1B1421502568A4A6AC326D7250::C::T\'.\nAll structs can only be constructed in the module in which they are declared\n   │\n\nerror: \n\n   ┌── (file):7:13 ───\n   │\n 7 │         let C::T {} = c;\n   │             ^^^^^^^ Invalid deconstruction binding of \'0xA4A46D1B1421502568A4A6AC326D7250::C::T\'.\n All structs can only be deconstructed in the module in which they are declared\n   │\n\n\n"

--- a/language/move-lang/functional-tests/tests/move/dependencies/pack_unpack_private.move
+++ b/language/move-lang/functional-tests/tests/move/dependencies/pack_unpack_private.move
@@ -1,0 +1,14 @@
+module C {
+    struct T {}
+}
+
+//! new-transaction
+module B {
+    use {{default}}::C;
+    public fun foo(): C::T {
+        C::T {}
+    }
+    public fun bar(c: C::T) {
+        let C::T {} = c;
+    }
+}

--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -256,12 +256,7 @@ fn module_(context: &mut Context, mdef: P::ModuleDefinition) -> (ModuleIdent, E:
                 function(context, &mut functions, f)
             }
             P::ModuleMember::Constant(c) => constant(context, &mut constants, c),
-            P::ModuleMember::Struct(mut s) => {
-                if !context.is_source_module {
-                    s.fields = P::StructFields::Native(s.loc)
-                }
-                struct_def(context, &mut structs, s)
-            }
+            P::ModuleMember::Struct(s) => struct_def(context, &mut structs, s),
             P::ModuleMember::Spec(s) => specs.push(spec(context, s)),
         }
     }

--- a/language/move-lang/src/typing/translate.rs
+++ b/language/move-lang/src/typing/translate.rs
@@ -1555,7 +1555,7 @@ fn add_field_types<T>(
         N::StructFields::Native(nloc) => {
             let msg = format!(
                 "Invalid {} usage for native struct '{}::{}'. Native structs cannot be directly \
-                 constructed/deconstructd, and their fields cannot be dirctly accessed",
+                 constructed/deconstructed, and their fields cannot be dirctly accessed",
                 verb, m, n
             );
             context.error(vec![(loc, msg), (nloc, "Declared 'native' here".into())]);

--- a/language/move-lang/tests/move_check/typing/native_structs_pack_unpack.exp
+++ b/language/move-lang/tests/move_check/typing/native_structs_pack_unpack.exp
@@ -1,0 +1,59 @@
+error: 
+
+   ┌── tests/move_check/typing/native_structs_pack_unpack.move:9:9 ───
+   │
+ 9 │         C::T {}
+   │         ^^^^^^^ Invalid argument usage for native struct '0x42::C::T'. Native structs cannot be directly constructed/deconstructed, and their fields cannot be dirctly accessed
+   ·
+ 3 │     native struct T;
+   │     ------ Declared 'native' here
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/native_structs_pack_unpack.move:9:9 ───
+   │
+ 9 │         C::T {}
+   │         ^^^^^^^ Invalid instantiation of '0x42::C::T'.
+All structs can only be constructed in the module in which they are declared
+   │
+
+error: 
+
+    ┌── tests/move_check/typing/native_structs_pack_unpack.move:12:13 ───
+    │
+ 12 │         let C::T {} = c;
+    │             ^^^^^^^ Invalid binding usage for native struct '0x42::C::T'. Native structs cannot be directly constructed/deconstructed, and their fields cannot be dirctly accessed
+    ·
+  3 │     native struct T;
+    │     ------ Declared 'native' here
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/native_structs_pack_unpack.move:12:13 ───
+    │
+ 12 │         let C::T {} = c;
+    │             ^^^^^^^ Invalid deconstruction binding of '0x42::C::T'.
+ All structs can only be deconstructed in the module in which they are declared
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/native_structs_pack_unpack.move:15:17 ───
+    │
+ 15 │         let f = c.f;
+    │                 ^^^ Invalid access of field 'f' on '0x42::C::T'. Fields can only be accessed inside the struct's module
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/native_structs_pack_unpack.move:15:17 ───
+    │
+ 15 │         let f = c.f;
+    │                 ^^^ Unbound field 'f' for native struct '0x42::C::T'
+    ·
+  3 │     native struct T;
+    │     ------ Declared 'native' here
+    │
+

--- a/language/move-lang/tests/move_check/typing/native_structs_pack_unpack.move
+++ b/language/move-lang/tests/move_check/typing/native_structs_pack_unpack.move
@@ -1,0 +1,18 @@
+address 0x42 {
+module C {
+    native struct T;
+}
+
+module B {
+    use 0x42::C;
+    public fun foo(): C::T {
+        C::T {}
+    }
+    public fun bar(c: C::T) {
+        let C::T {} = c;
+    }
+    public fun baz(c: C::T) {
+        let f = c.f;
+    }
+}
+}


### PR DESCRIPTION
- Small spelling fix
- Quick fix to not make structs in deps native. it might make some things tiny bit slower, but it prevents really bizarre error messages


## Motivation

- Current edge case of trying to instantiate a struct declared in a dep produces some weird error messages

## Test Plan

- cargo test