### PR TITLE
[JSON-RPC] Adding a get_events_with_proof API

### DIFF
--- a/client/json-rpc/src/async_client/client.rs
+++ b/client/json-rpc/src/async_client/client.rs
@@ -171,6 +171,32 @@ impl<R: RetryStrategy> Client<R> {
         self.send(Request::get_events(key, start_seq, limit)).await
     }
 
+    pub async fn get_events_with_proofs(
+        &self,
+        key: &str,
+        start_seq: u64,
+        limit: u64,
+    ) -> Result<Response<Vec<jsonrpc::Event>>, Error> {
+        self.send(Request::get_events_with_proofs(key, start_seq, limit))
+            .await
+    }
+
+    pub async fn get_events_with_proofs_with_known_version(
+        &self,
+        key: &str,
+        start_seq: u64,
+        limit: u64,
+        known_version: u64,
+    ) -> Result<Response<Vec<jsonrpc::Event>>, Error> {
+        self.send(Request::get_events_with_proofs_with_known_version(
+            key,
+            start_seq,
+            limit,
+            known_version,
+        ))
+        .await
+    }
+
     pub async fn get_currencies(&self) -> Result<Response<Vec<jsonrpc::CurrencyInfo>>, Error> {
         self.send(Request::get_currencies()).await
     }

--- a/client/json-rpc/src/async_client/http_client.rs
+++ b/client/json-rpc/src/async_client/http_client.rs
@@ -50,6 +50,22 @@ impl Request {
         Self::new("get_events", json!([key, start_seq, limit]))
     }
 
+    pub fn get_events_with_proofs(key: &str, start_seq: u64, limit: u64) -> Self {
+        Self::new("get_events_with_proofs", json!([key, start_seq, limit]))
+    }
+
+    pub fn get_events_with_proofs_with_known_version(
+        key: &str,
+        start_seq: u64,
+        limit: u64,
+        known_version: u64,
+    ) -> Self {
+        Self::new(
+            "get_events_with_proofs",
+            json!([key, start_seq, limit, known_version]),
+        )
+    }
+
     pub fn get_transactions(start_seq: u64, limit: u64, include_events: bool) -> Self {
         Self::new(
             "get_transactions",

--- a/client/json-rpc/src/async_client/tests.rs
+++ b/client/json-rpc/src/async_client/tests.rs
@@ -379,6 +379,35 @@ async fn test_get_events() {
 }
 
 #[tokio::test]
+async fn test_get_events_with_proofs() {
+    let result = events_sample();
+    let client = setup(
+        ("get_events_with_proofs", json!(["key", 0, 1])),
+        new_response(result.clone()),
+    );
+
+    let ret = client.get_events_with_proofs("key", 0, 1).await.unwrap();
+
+    assert_eq!(result, to_value(&*ret).unwrap());
+}
+
+#[tokio::test]
+async fn test_get_events_with_proofs_with_known_version() {
+    let result = events_sample();
+    let client = setup(
+        ("get_events_with_proofs", json!(["key", 0, 1, 1])),
+        new_response(result.clone()),
+    );
+
+    let ret = client
+        .get_events_with_proofs_with_known_version("key", 0, 1, 1)
+        .await
+        .unwrap();
+
+    assert_eq!(result, to_value(&*ret).unwrap());
+}
+
+#[tokio::test]
 async fn test_get_currencies() {
     let result = currencies_sample();
     let client = setup(("get_currencies", json!([])), new_response(result.clone()));

--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -8,7 +8,7 @@ use diem_state_view::StateView;
 use diem_types::{
     account_address::AccountAddress,
     account_state_blob::{AccountStateBlob, AccountStateWithProof},
-    contract_event::ContractEvent,
+    contract_event::{ContractEvent, EventWithProof},
     epoch_change::EpochChangeProof,
     event::EventKey,
     ledger_info::LedgerInfoWithSignatures,
@@ -100,6 +100,17 @@ impl DbReader for FakeDb {
         _order: Order,
         _limit: u64,
     ) -> Result<Vec<(u64, ContractEvent)>> {
+        unimplemented!();
+    }
+
+    fn get_events_with_proofs(
+        &self,
+        _event_key: &EventKey,
+        _start: u64,
+        _order: Order,
+        _limit: u64,
+        _known_version: Option<u64>,
+    ) -> Result<Vec<EventWithProof>> {
         unimplemented!();
     }
 

--- a/json-rpc/API-CHANGELOG.md
+++ b/json-rpc/API-CHANGELOG.md
@@ -13,6 +13,11 @@ Please add the API change in the following format:
 
 ```
 
+## 2020-12-22 Add `get_events_with_proof` APIs
+
+This allows to verify events since transactions and their proofs are not covering all events.
+
+
 # 2020-12-07 Add a `X-Diem-Chain-Id`, `X-Diem-Ledger-Version` and `X-Diem-Ledger-TimestampUsec` to http response header
 
 The added headers are same with JSON-RPC response json same name fields. They are added for client to know chain id and server's latest block version and timestamp without decoding body json.

--- a/json-rpc/json-rpc-spec.md
+++ b/json-rpc/json-rpc-spec.md
@@ -115,3 +115,4 @@ The following APIs are experimental APIs. They are unstable and likely to be cha
 * get_state_proof
 * get_account_state_with_proof
 * get_transactions_with_proofs
+* get_events_with_proofs

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -613,6 +613,86 @@ fn test_json_rpc_protocol_invalid_requests() {
             }),
         ),
         (
+            "get_events_with_proofs: invalid event_key type",
+            json!({"jsonrpc": "2.0", "method": "get_events_with_proofs", "params": [false, 1, 10], "id": 1}),
+            json!({
+                "error": {
+                    "code": -32602,
+                    "message": "Invalid param event key(params[0]): should be hex-encoded string",
+                    "data": null
+                },
+                "id": 1,
+                "jsonrpc": "2.0",
+                "diem_chain_id": ChainId::test().id(),
+                "diem_ledger_timestampusec": timestamp,
+                "diem_ledger_version": version
+            }),
+        ),
+        (
+            "get_events_with_proofs: event_key is not hex-encoded string",
+            json!({"jsonrpc": "2.0", "method": "get_events_with_proofs", "params": ["helloworld", 1, 10], "id": 1}),
+            json!({
+                "error": {
+                    "code": -32602,
+                    "message": "Invalid param event key(params[0]): should be hex-encoded string",
+                    "data": null
+                },
+                "id": 1,
+                "jsonrpc": "2.0",
+                "diem_chain_id": ChainId::test().id(),
+                "diem_ledger_timestampusec": timestamp,
+                "diem_ledger_version": version
+            }),
+        ),
+        (
+            "get_events_with_proofs: invalid start param",
+            json!({"jsonrpc": "2.0", "method": "get_events_with_proofs", "params": ["13000000000000000000000000000000000000000a550c18", false, 1], "id": 1}),
+            json!({
+                "error": {
+                    "code": -32602,
+                    "message": "Invalid param start(params[1]): should be unsigned int64",
+                    "data": null
+                },
+                "id": 1,
+                "jsonrpc": "2.0",
+                "diem_chain_id": ChainId::test().id(),
+                "diem_ledger_timestampusec": timestamp,
+                "diem_ledger_version": version
+            }),
+        ),
+        (
+            "get_events_with_proofs: invalid limit param",
+            json!({"jsonrpc": "2.0", "method": "get_events_with_proofs", "params": ["13000000000000000000000000000000000000000a550c18", 1, "invalid"], "id": 1}),
+            json!({
+                "error": {
+                    "code": -32602,
+                    "message": "Invalid param limit(params[2]): should be unsigned int64",
+                    "data": null
+                },
+                "id": 1,
+                "jsonrpc": "2.0",
+                "diem_chain_id": ChainId::test().id(),
+                "diem_ledger_timestampusec": timestamp,
+                "diem_ledger_version": version
+            }),
+        ),
+        (
+            "get_events_with_proofs: invalid version param",
+            json!({"jsonrpc": "2.0", "method": "get_events_with_proofs", "params": ["13000000000000000000000000000000000000000a550c18", 1, 1, "invalid"], "id": 1}),
+            json!({
+                "error": {
+                    "code": -32602,
+                    "message": "Invalid param version(params[3]): should be unsigned int64",
+                    "data": null
+                },
+                "id": 1,
+                "jsonrpc": "2.0",
+                "diem_chain_id": ChainId::test().id(),
+                "diem_ledger_timestampusec": timestamp,
+                "diem_ledger_version": version
+            }),
+        ),
+        (
             "get_account_transaction: invalid account",
             json!({"jsonrpc": "2.0", "method": "get_account_transaction", "params": ["invalid", 1, false], "id": 1}),
             json!({

--- a/json-rpc/src/tests/utils.rs
+++ b/json-rpc/src/tests/utils.rs
@@ -12,7 +12,7 @@ use diem_types::{
     account_state_blob::{AccountStateBlob, AccountStateWithProof},
     block_info::BlockInfo,
     chain_id::ChainId,
-    contract_event::ContractEvent,
+    contract_event::{ContractEvent, EventWithProof},
     epoch_change::EpochChangeProof,
     event::EventKey,
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
@@ -209,6 +209,17 @@ impl DbReader for MockDiemDB {
             .cloned()
             .collect();
         Ok(events)
+    }
+
+    fn get_events_with_proofs(
+        &self,
+        _key: &EventKey,
+        _start: u64,
+        _order: Order,
+        _limit: u64,
+        _known_version: Option<u64>,
+    ) -> Result<Vec<EventWithProof>> {
+        unimplemented!()
     }
 
     fn get_state_proof(

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -129,6 +129,11 @@ pub struct EventView {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct EventWithProofView {
+    pub event_with_proof: BytesView,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
 pub enum EventDataView {
     #[serde(rename = "burn")]

--- a/secure/json-rpc/src/lib.rs
+++ b/secure/json-rpc/src/lib.rs
@@ -384,7 +384,7 @@ mod test {
         account_address::AccountAddress,
         account_state_blob::{AccountStateBlob, AccountStateWithProof},
         block_info::BlockInfo,
-        contract_event::ContractEvent,
+        contract_event::{ContractEvent, EventWithProof},
         epoch_change::EpochChangeProof,
         event::EventKey,
         ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
@@ -578,6 +578,17 @@ mod test {
             _order: Order,
             _limit: u64,
         ) -> Result<Vec<(u64, ContractEvent)>> {
+            unimplemented!()
+        }
+
+        fn get_events_with_proofs(
+            &self,
+            _event_key: &EventKey,
+            _start: u64,
+            _order: Order,
+            _limit: u64,
+            _known_version: Option<u64>,
+        ) -> Result<Vec<EventWithProof>> {
             unimplemented!()
         }
 

--- a/storage/storage-client/src/lib.rs
+++ b/storage/storage-client/src/lib.rs
@@ -11,7 +11,7 @@ use diem_secure_net::NetworkClient;
 use diem_types::{
     account_address::AccountAddress,
     account_state_blob::{AccountStateBlob, AccountStateWithProof},
-    contract_event::ContractEvent,
+    contract_event::{ContractEvent, EventWithProof},
     epoch_change::EpochChangeProof,
     event::EventKey,
     ledger_info::LedgerInfoWithSignatures,
@@ -139,6 +139,17 @@ impl DbReader for StorageClient {
         _limit: u64,
     ) -> Result<Vec<(u64, ContractEvent)>> {
         unimplemented!()
+    }
+
+    fn get_events_with_proofs(
+        &self,
+        _event_key: &EventKey,
+        _start: u64,
+        _order: Order,
+        _limit: u64,
+        _known_version: Option<u64>,
+    ) -> Result<Vec<EventWithProof>> {
+        unimplemented!();
     }
 
     fn get_state_proof(

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -8,7 +8,7 @@ use diem_types::{
     account_address::AccountAddress,
     account_state::AccountState,
     account_state_blob::{AccountStateBlob, AccountStateWithProof},
-    contract_event::ContractEvent,
+    contract_event::{ContractEvent, EventWithProof},
     epoch_change::EpochChangeProof,
     epoch_state::EpochState,
     event::EventKey,
@@ -193,6 +193,16 @@ pub trait DbReader: Send + Sync {
         order: Order,
         limit: u64,
     ) -> Result<Vec<(u64, ContractEvent)>>;
+
+    /// Returns events by given event key
+    fn get_events_with_proofs(
+        &self,
+        event_key: &EventKey,
+        start: u64,
+        order: Order,
+        limit: u64,
+        known_version: Option<u64>,
+    ) -> Result<Vec<EventWithProof>>;
 
     /// See [`DiemDB::get_block_timestamp`].
     ///

--- a/storage/storage-interface/src/mock.rs
+++ b/storage/storage-interface/src/mock.rs
@@ -11,7 +11,7 @@ use diem_types::{
     account_config::AccountResource,
     account_state::AccountState,
     account_state_blob::{AccountStateBlob, AccountStateWithProof},
-    contract_event::ContractEvent,
+    contract_event::{ContractEvent, EventWithProof},
     epoch_change::EpochChangeProof,
     event::{EventHandle, EventKey},
     ledger_info::LedgerInfoWithSignatures,
@@ -51,6 +51,18 @@ impl DbReader for MockDbReader {
         _order: Order,
         _limit: u64,
     ) -> Result<Vec<(u64, ContractEvent)>> {
+        unimplemented!()
+    }
+
+    /// Returns events by given event key
+    fn get_events_with_proofs(
+        &self,
+        _event_key: &EventKey,
+        _start: u64,
+        _order: Order,
+        _limit: u64,
+        _known_version: Option<u64>,
+    ) -> Result<Vec<EventWithProof>> {
         unimplemented!()
     }
 


### PR DESCRIPTION
## Motivation
This is necessary to build a verifying clients and thus to ensure a secure ecosystem.
Otherwise we are encouraging people to trust the full nodes.

This is adding a JSON-RPC call to get events with proofs, along with the necessary backend changes to get these.

## Test Plan

I'm working on adding unit and integration tests right now.

## Related PRs
#6399 