### PR TITLE
[move-cli] add the option to show path cov after move-cli test

### DIFF
--- a/language/tools/move-cli/src/main.rs
+++ b/language/tools/move-cli/src/main.rs
@@ -115,6 +115,9 @@ enum Command {
         /// By default, coverage will not be tracked nor shown.
         #[structopt(long = "track-cov")]
         track_cov: bool,
+        /// Show path coverage instead of instruction coverage.
+        #[structopt(long = "use-path-cov")]
+        use_path_cov: bool,
     },
     /// View Move resources, events files, and modules stored on disk
     #[structopt(name = "view")]
@@ -610,10 +613,15 @@ fn main() -> Result<()> {
             *gas_budget,
             *dry_run,
         ),
-        Command::Test { path, track_cov } => test::run_all(
+        Command::Test {
+            path,
+            track_cov,
+            use_path_cov,
+        } => test::run_all(
             path,
             &std::env::current_exe()?.to_string_lossy(),
             *track_cov,
+            *use_path_cov,
         ),
         Command::View { file } => view(&move_args, file),
         Command::Clean {} => {

--- a/language/tools/move-cli/tests/cli_tests.rs
+++ b/language/tools/move-cli/tests/cli_tests.rs
@@ -23,8 +23,10 @@ fn run_metatest() {
     let path_cli_binary = get_cli_binary_path();
     let path_metatest = get_metatest_path();
 
-    // with coverage
-    assert!(test::run_all(&path_metatest, &path_cli_binary, true).is_ok());
+    // with instruction coverage
+    assert!(test::run_all(&path_metatest, &path_cli_binary, true, false).is_ok());
+    // with path coverage
+    assert!(test::run_all(&path_metatest, &path_cli_binary, true, true).is_ok());
     // without coverage
-    assert!(test::run_all(&path_metatest, &path_cli_binary, false).is_ok());
+    assert!(test::run_all(&path_metatest, &path_cli_binary, false, false).is_ok());
 }

--- a/language/tools/move-cli/tests/cli_testsuite.rs
+++ b/language/tools/move-cli/tests/cli_testsuite.rs
@@ -10,6 +10,7 @@ fn run_all(args_path: &Path) -> datatest_stable::Result<()> {
         args_path,
         "../../../target/debug/move-cli",
         false,
+        false,
     )?)
 }
 

--- a/language/tools/move-cli/tests/metatests/args.exp
+++ b/language/tools/move-cli/tests/metatests/args.exp
@@ -14,3 +14,27 @@ Module 00000000000000000000000000000042::M
 		% coverage: 100.00
 >>> % Module coverage: 100.00
 1 / 1 test(s) passed.
+Command `test cov --track-cov --use-path-cov`:
+Module 00000000000000000000000000000042::M
+	fun test
+		total: 1
+		covered: 1
+		% coverage: 100.00
+>>> % Module coverage: 100.00
+1 / 1 test(s) passed.
+Command `test cov-inst-vs-path --track-cov`:
+Module 00000000000000000000000000000042::M
+	fun test
+		total: 32
+		covered: 32
+		% coverage: 100.00
+>>> % Module coverage: 100.00
+1 / 1 test(s) passed.
+Command `test cov-inst-vs-path --track-cov --use-path-cov`:
+Module 00000000000000000000000000000042::M
+	fun test
+		total: 4
+		covered: 2
+		% coverage: 50.00
+>>> % Module coverage: 50.00
+1 / 1 test(s) passed.

--- a/language/tools/move-cli/tests/metatests/args.txt
+++ b/language/tools/move-cli/tests/metatests/args.txt
@@ -3,3 +3,6 @@ test dummy/test_2
 test dummy
 test cov
 test cov --track-cov
+test cov --track-cov --use-path-cov
+test cov-inst-vs-path --track-cov
+test cov-inst-vs-path --track-cov --use-path-cov

--- a/language/tools/move-cli/tests/metatests/cov-inst-vs-path/args.exp
+++ b/language/tools/move-cli/tests/metatests/cov-inst-vs-path/args.exp
@@ -1,0 +1,3 @@
+Command `publish move_src/modules`:
+Command `run move_src/scripts/test.move --args 0u8 --args 0u8 --dry-run`:
+Command `run move_src/scripts/test.move --args 1u8 --args 1u8 --dry-run`:

--- a/language/tools/move-cli/tests/metatests/cov-inst-vs-path/args.txt
+++ b/language/tools/move-cli/tests/metatests/cov-inst-vs-path/args.txt
@@ -1,0 +1,3 @@
+publish move_src/modules
+run move_src/scripts/test.move --args 0u8 --args 0u8 --dry-run
+run move_src/scripts/test.move --args 1u8 --args 1u8 --dry-run

--- a/language/tools/move-cli/tests/metatests/cov-inst-vs-path/move_src/modules/M.move
+++ b/language/tools/move-cli/tests/metatests/cov-inst-vs-path/move_src/modules/M.move
@@ -1,0 +1,19 @@
+address 0x42 {
+module M {
+    public fun test(x: u8, y: u8): u8  {
+        let a = if (x > 0) {
+            y + 1
+        } else {
+            y
+        };
+
+        let b = if (y > 0) {
+            x + 1
+        } else {
+            x
+        };
+
+        a + b
+    }
+}
+}

--- a/language/tools/move-cli/tests/metatests/cov-inst-vs-path/move_src/scripts/test.move
+++ b/language/tools/move-cli/tests/metatests/cov-inst-vs-path/move_src/scripts/test.move
@@ -1,0 +1,7 @@
+script {
+use 0x42::M;
+
+fun main(x: u8, y: u8) {
+    M::test(x, y);
+}
+}


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

#6486 allows instruction coverage to be shown after `move-cli test` and #6381 allows path coverage to be calculated. After both are merged, this PR allows path coverage to be shown in `move-cli test` too with an additional `--use-path-cov` option.

Usage: `move-cli test <path-to-args.txt> --track-cov --use-path-cov`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

The test cases are updated to check the additional code for `--use-path-cov` so `cargo xtest` should pass.

An additional dummy case, `cov-inst-vs-path` is added to show that path cov is different from instruction cov. In this case, we have 100% instruction coverage, but only 50% path coverage. The `metatest/args.exp` are updated accordingly for this new case.

## Related PRs

#6486, #6381 