### PR TITLE
[execution] tweak benchmark

### DIFF
--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -6,16 +6,16 @@ use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 struct Opt {
-    #[structopt(long, default_value = "1000000")]
+    #[structopt(long, default_value = "10000")]
     num_accounts: usize,
 
     #[structopt(long, default_value = "1000000")]
     init_account_balance: u64,
 
-    #[structopt(long, default_value = "500")]
+    #[structopt(long, default_value = "1000")]
     block_size: usize,
 
-    #[structopt(long, default_value = "1000")]
+    #[structopt(long, default_value = "20")]
     num_transfer_blocks: usize,
 
     #[structopt(long, parse(from_os_str))]

--- a/language/benchmarks/benches/benchmarks.rs
+++ b/language/benchmarks/benches/benchmarks.rs
@@ -33,4 +33,4 @@ fn call(c: &mut Criterion) {
 
 criterion_group!(vm_benches, arith, call);
 
-criterion_main!(vm_benches);
+criterion_main!(vm_benches, txn_benches);

--- a/language/benchmarks/src/transactions.rs
+++ b/language/benchmarks/src/transactions.rs
@@ -25,10 +25,10 @@ where
     S::Value: AUTransactionGen,
 {
     /// The number of accounts created by default.
-    pub const DEFAULT_NUM_ACCOUNTS: usize = 100;
+    pub const DEFAULT_NUM_ACCOUNTS: usize = 2000;
 
     /// The number of transactions created by default.
-    pub const DEFAULT_NUM_TRANSACTIONS: usize = 500;
+    pub const DEFAULT_NUM_TRANSACTIONS: usize = 1000;
 
     /// Creates a new transaction bencher with default settings.
     pub fn new(strategy: S) -> Self {

--- a/language/move-vm/runtime/src/tracing.rs
+++ b/language/move-vm/runtime/src/tracing.rs
@@ -18,6 +18,7 @@ use ::{
     vm::file_format::Bytecode,
 };
 
+#[cfg(debug_assertions)]
 use crate::{
     interpreter::Interpreter,
     loader::{Function, Loader},


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Separate txn generation with execution. Add txn_benches to vm benchmarks.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

cargo run --release -p executor-benchmark -- --num-accounts 1000 --block-size 1000 --num-transfer-blocks 10

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/libra/developers.libra.org, and link to your PR here.)
