### PR TITLE
Getwithproof refactor

### DIFF
--- a/storage/jellyfish-merkle/src/lib.rs
+++ b/storage/jellyfish-merkle/src/lib.rs
@@ -555,7 +555,6 @@ where
 
         let mut siblings: Vec<HashValue> = internal_nodes
             .into_iter()
-            // .into_par_iter()
             .flat_map(|(internal_node, child_index)|
                       internal_node.get_sibling_hashes(child_index))
             .collect();


### PR DESCRIPTION
## Motivation

Get_with_proof method does a traversal that has relatively complex logic - it has to find the child of the nodes inner (up to) 4-level subtree pointing to where to continue traversal and at the same time gather hashes of siblings. This also leads to the inner node APIs that provide both of the aforementioned functionalities at once.
Instead, this refactor changes the logic to first find children and perform a traversal, simply recording the nodes on the path, then as a separate step gather all the required sibling hashes by a single chained call to a new inner node's API that just gathers sibling hashes (a separate one finds children).

Other than improving node's inner APIs and disentangling the logic, this should also make the function more optimizable - i.e. simply changing into_iter to into_par_iter would let us do sibling hash computations in parallel. Unfortunately we don't have green threads or pre-created threadpool yet and overhead isn't worth it, but this is an example of how an optimization that wouldn't be possible before is now possible.

mod.rs in node/ is also refactored in a corresponding way. A range bitmap computation that was sometimes done twice is also moved to the caller, but I can revert it, doesn't help performance and is just what I found personally more understandable. One more minor aspect is that the behavior of returning not the child but another leaf sometimes from get_child should be consistent to how it was before, it may be a bit leaky abstraction since it assumes something about the caller (wanting to do proofs) - but it seems well documented and left outside of the current scope (but if there are some good suggestions on naming the function differently happy to do it as well)

My first PR in rust so may be doing something totally wrong - please let me know.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Had a look before, reading right now.

## Test Plan

Cluster test for making sure performance isn't affected.
As I mentioned, my first PR - so I'll need some pointers on best practices for testing such changes.

## Related PRs

