### PR TITLE
[cluster-test] Update naming of --premainnet to --vasp

### DIFF
--- a/testsuite/cluster-test/src/cluster.rs
+++ b/testsuite/cluster-test/src/cluster.rs
@@ -34,7 +34,7 @@ impl Cluster {
         peers: Vec<(String, u32, Option<u32>)>,
         mint_file: &str,
         chain_id: ChainId,
-        premainnet: bool,
+        vasp: bool,
     ) -> Self {
         let http_client = Client::new();
         let instances: Vec<Instance> = peers
@@ -50,7 +50,7 @@ impl Cluster {
             })
             .collect();
 
-        let mint_key_pair = if premainnet {
+        let mint_key_pair = if vasp {
             dummy_key_pair()
         } else {
             KeyPair::from(generate_key::load_key(mint_file))


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
Since arg --premainnet sometimes caused misleading, change it to --vasp, which can enable CT uses public FNs instead of localhost not only on premainnet but also mainnet

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/libra/developers.libra.org, and link to your PR here.)
