### PR TITLE
[move][cli] Support safe module republishing with breaking changes ch…

### DIFF
--- a/language/stdlib/src/lib.rs
+++ b/language/stdlib/src/lib.rs
@@ -13,7 +13,7 @@ use std::{
     io::{Read, Write},
     path::{Path, PathBuf},
 };
-use vm::{normalized::Module, CompiledModule};
+use vm::CompiledModule;
 
 pub mod utils;
 
@@ -350,119 +350,4 @@ pub fn generate_rust_transaction_builders() {
         .arg(TRANSACTION_BUILDERS_GENERATED_SOURCE_PATH)
         .status()
         .expect("Failed to run rustfmt on generated code");
-}
-
-/// The result of a linking and layoutcompatibility check. Here is what the different combinations
-/// mean:
-/// `{ struct: true, struct_layout: true }`: fully backward compatible
-/// `{ struct_and_function_linking: true, struct_layout: false }`: Dependent modules that reference functions or types in this module may not link. However, fixing, recompiling, and redeploying all dependent modules will work--no data migration needed.
-/// `{ type_and_function_linking: true, struct_layout: false }`: Attempting to read structs published by this module will now fail at runtime. However, dependent modules will continue to link. Requires data migration, but no changes to dependent modules.
-/// `{ type_and_function_linking: false, struct_layout: false }`: Everything is broken. Need both a data migration and changes to dependent modules.
-pub struct Compatibility {
-    /// If false, dependent modules that reference functions or structs in this module may not link
-    pub struct_and_function_linking: bool,
-    /// If false, attempting to read structs previously published by this module will fail at runtime
-    pub struct_layout: bool,
-}
-
-impl Compatibility {
-    /// Return true if the two module s compared in the compatiblity check are both linking and
-    /// layout compatible.
-    pub fn is_fully_compatible(&self) -> bool {
-        self.struct_and_function_linking && self.struct_layout
-    }
-
-    /// Return compatibility assessment for `new_module` relative to old module `old_module`
-    pub fn check(old_module: &Module, new_module: &Module) -> Compatibility {
-        let mut struct_and_function_linking = true;
-        let mut struct_layout = true;
-
-        // module's name and address are unchanged
-        if old_module.address != new_module.address || old_module.name != new_module.name {
-            struct_and_function_linking = false;
-        }
-
-        // old module's structs are a subset of the new module's structs
-        for old_struct in &old_module.structs {
-            match new_module
-                .structs
-                .iter()
-                .find(|s| s.name == old_struct.name)
-            {
-                Some(new_struct) => {
-                    if new_struct.kind != old_struct.kind
-                        || new_struct.type_parameters != old_struct.type_parameters
-                    {
-                        // Declared kind and/or type parameters changed. Existing modules that depend on this struct will fail to link with the new version of the module
-                        struct_and_function_linking = false;
-                        // This does not change the struct layout, but it may leave some published
-                        // values "orphaned". For example: if
-                        // `resource struct S<T: copyable> { t : T }` is changed to
-                        // `resource struct S<T: resource> { t : T}`, code can no longer access
-                        // published values of type (e.g.) `S<u64>`.
-                    }
-                    if new_struct.fields != old_struct.fields {
-                        // Fields changed. Code in this module will fail at runtime if it tries to
-                        // read a previously published struct value
-                        // TODO: this is a stricter definition than required. We could in principle
-                        // choose to label the following as compatible
-                        // (1) changing the name (but not position or type) of a field. The VM does
-                        //     not care about the name of a field (it's purely informational), but
-                        //     clients presumably do.
-                        // (2) changing the type of a field to a different, but layout and kind
-                        //     compatible type. E.g. `struct S { b: bool }` to `struct S { b: B }`
-                        // where
-                        //     B is struct B { some_name: bool }. TODO: does this affect clients? I
-                        //     think not--the serialization of the same data with these two types
-                        //     will be the same.
-                        struct_layout = false
-                    }
-                }
-                None => {
-                    // Struct not present in new . Existing modules that depend on this struct will fail to link with the new version of the module.
-                    struct_and_function_linking = false;
-                    // Note: we intentionally do *not* label this a layout compatibility violation.
-                    // Existing modules can still successfully read previously published values of
-                    // this struct `Parent::T`. That is, code like the function `foo` in
-                    // ```
-                    // struct S { t: Parent::T }
-                    // public fun foo(a: addr): S { move_from<S>(addr) }
-                    // ```
-                    // in module `Child` will continue to run without error. But values of type
-                    // `Parent::T` in `Child` are now "orphaned" in the sense that `Parent` no
-                    // longer exposes any API for reading/writing them.
-                }
-            }
-        }
-
-        // old module's public functions are a subset of the new module's public functions
-        for function in &old_module.public_functions {
-            if !new_module.public_functions.contains(&function) {
-                struct_and_function_linking = false;
-            }
-        }
-
-        Compatibility {
-            struct_and_function_linking,
-            struct_layout,
-        }
-    }
-
-    /// Return true if `new_module` can safely update `old_module`
-    pub fn can_update(
-        old_module: &Module,
-        new_module: &CompiledModule,
-        _new_module_dependencies: &[CompiledModule],
-    ) -> bool {
-        // (1) Verify new_module (TODO)
-        // (2) Link new_module against new_module dependencies. (TODO)
-        //     Note: this will *NOT* prevent cylic deps. We need to think about a different scheme
-        //     if we care about this (which we almost certainly do). One (probably too restrictive)
-        //     solution would be: insist that deps(new_module) are a subset of deps(old_module).
-        //     That would not only prevent cyclic deps, but also preclude the need for linking
-        //     entirely.
-        // (3) Extract the  for new_module and check compatibility with old_module
-        Self::is_fully_compatible(&Self::check(old_module, &Module::new(new_module)))
-            && panic!("TODO: implement verification, linking, cyclic deps checks")
-    }
 }

--- a/language/stdlib/src/main.rs
+++ b/language/stdlib/src/main.rs
@@ -13,7 +13,7 @@ use std::{
     time::Instant,
 };
 use stdlib::*;
-use vm::{normalized::Module, CompiledModule};
+use vm::{compatibility::Compatibility, normalized::Module, CompiledModule};
 
 // Generates the compiled stdlib and transaction scripts. Until this is run changes to the source
 // modules/scripts, and changes in the Move compiler will not be reflected in the stdlib used for

--- a/language/tools/move-cli/src/main.rs
+++ b/language/tools/move-cli/src/main.rs
@@ -24,8 +24,10 @@ use move_vm_runtime::{data_cache::TransactionEffects, logging::NoContextLog, mov
 use move_vm_types::{gas_schedule, values::Value};
 use vm::{
     access::ScriptAccess,
+    compatibility::Compatibility,
     errors::VMError,
     file_format::{CompiledModule, CompiledScript, SignatureToken},
+    normalized::Module,
 };
 
 use anyhow::{bail, Result};
@@ -91,6 +93,11 @@ enum Command {
         /// If set, modules will not override existing ones in storage
         #[structopt(long = "no-republish")]
         no_republish: bool,
+        /// By default, code that might cause breaking changes for bytecode
+        /// linking or data layout compatibility checks will not be published.
+        /// Set this flag to ignore breaking changes checks and publish anyway
+        #[structopt(long = "ignore-breaking-changes")]
+        ignore_breaking_changes: bool,
         /// If set, the effects of executing `script_file` (i.e., published, updated, and
         /// deleted resources) will NOT be committed to disk.
         #[structopt(long = "dry-run", short = "n")]
@@ -301,18 +308,25 @@ fn check(args: &Move, republish: bool, files: &[String]) -> Result<()> {
     Ok(())
 }
 
-fn publish(args: &Move, republish: bool, files: &[String]) -> Result<OnDiskStateView> {
+fn publish(
+    args: &Move,
+    files: &[String],
+    republish: bool,
+    ignore_breaking_changes: bool,
+) -> Result<OnDiskStateView> {
     let storage_dir = maybe_create_dir(&args.storage_dir)?;
 
     if args.verbose {
         println!("Compiling Move modules...")
     }
+
     let (files, result) =
         move_compile_to_and_shadow(args, files, republish, MovePass::Compilation)?;
     let compiled_units = match move_lang::unwrap_or_report_errors!(files, result) {
         MovePassResult::Compilation(units) => units,
         _ => unreachable!(),
     };
+
     let num_modules = compiled_units
         .iter()
         .filter(|u| matches!(u,  CompiledUnit::Module {..}))
@@ -336,10 +350,33 @@ fn publish(args: &Move, republish: bool, files: &[String]) -> Result<OnDiskState
             CompiledUnit::Module { module, .. } => modules.push(module),
         }
     }
-    Ok(OnDiskStateView::create(
-        storage_dir.to_path_buf(),
-        &modules,
-    )?)
+
+    if !ignore_breaking_changes {
+        let view = OnDiskStateView::create(storage_dir.to_path_buf(), &[])?;
+        for m in &modules {
+            let id = m.self_id();
+            if let Ok(old_m) = view.get_compiled_module(&m.self_id()) {
+                let old_api = Module::new(&old_m);
+                let new_api = Module::new(m);
+                let compat = Compatibility::check(&old_api, &new_api);
+                if !compat.is_fully_compatible() {
+                    eprintln!("Breaking change detected--publishing aborted. Re-run with --ignore-breaking-changes to publish anyway.")
+                }
+                if !compat.struct_layout {
+                    // TODO: we could choose to make this more precise by walking the global state and looking for published
+                    // structs of this type. but probably a bad idea
+                    bail!("Layout API for structs of module {} has changed. Need to do a data migration of published structs", id)
+                }
+                if !compat.struct_and_function_linking {
+                    // TODO: this will report false positives if we *are* simultaneously redeploying all dependent modules.
+                    // but this is not easy to check without walking the global state and looking for everything
+                    bail!("Linking API for structs/functions of module {} has changed. Need to redeploy all dependent modules.", id)
+                }
+            }
+        }
+    }
+
+    OnDiskStateView::create(storage_dir.to_path_buf(), &modules)
 }
 
 fn run(
@@ -388,6 +425,7 @@ fn run(
             }
         }
 
+        // TODO: run `move publish` here instead?
         // preload the modules to the storage
         let state =
             OnDiskStateView::create(storage_dir.to_path_buf(), &args.get_library_modules()?)?;
@@ -750,10 +788,16 @@ fn main() -> Result<()> {
         Command::Publish {
             source_files,
             no_republish,
+            ignore_breaking_changes,
             dry_run,
         } => {
             move_args.prepare_mode(true)?;
-            let state = publish(&move_args, !*no_republish, source_files)?;
+            let state = publish(
+                &move_args,
+                source_files,
+                !*no_republish,
+                *ignore_breaking_changes,
+            )?;
             maybe_commit_effects(&move_args, !*dry_run, None, &state)
         }
         Command::Run {

--- a/language/tools/move-cli/tests/testsuite/data_breaking_change/M.move
+++ b/language/tools/move-cli/tests/testsuite/data_breaking_change/M.move
@@ -1,0 +1,5 @@
+address 0x2 {
+module M {
+    resource struct R { f: u64, g: u64 } // extra field g
+}
+}

--- a/language/tools/move-cli/tests/testsuite/data_breaking_change/args.exp
+++ b/language/tools/move-cli/tests/testsuite/data_breaking_change/args.exp
@@ -1,0 +1,5 @@
+Command `publish src/modules/`:
+Command `publish M.move`:
+Breaking change detected--publishing aborted. Re-run with --ignore-breaking-changes to publish anyway.
+Error: Layout API for structs of module 00000000000000000000000000000002::M has changed. Need to do a data migration of published structs
+Command `publish --ignore-breaking-changes M.move`:

--- a/language/tools/move-cli/tests/testsuite/data_breaking_change/args.txt
+++ b/language/tools/move-cli/tests/testsuite/data_breaking_change/args.txt
@@ -1,0 +1,3 @@
+publish src/modules/
+publish M.move
+publish --ignore-breaking-changes M.move

--- a/language/tools/move-cli/tests/testsuite/data_breaking_change/src/modules/M.move
+++ b/language/tools/move-cli/tests/testsuite/data_breaking_change/src/modules/M.move
@@ -1,0 +1,5 @@
+address 0x2 {
+module M {
+    resource struct R { f: u64 }
+}
+}

--- a/language/tools/move-cli/tests/testsuite/linking_breaking_change/M.move
+++ b/language/tools/move-cli/tests/testsuite/linking_breaking_change/M.move
@@ -1,0 +1,6 @@
+address 0x2 {
+module M {
+    public fun f() {}
+    // g is missing
+}
+}

--- a/language/tools/move-cli/tests/testsuite/linking_breaking_change/args.exp
+++ b/language/tools/move-cli/tests/testsuite/linking_breaking_change/args.exp
@@ -1,0 +1,5 @@
+Command `publish src/modules/`:
+Command `publish M.move`:
+Breaking change detected--publishing aborted. Re-run with --ignore-breaking-changes to publish anyway.
+Error: Linking API for structs/functions of module 00000000000000000000000000000002::M has changed. Need to redeploy all dependent modules.
+Command `publish --ignore-breaking-changes M.move`:

--- a/language/tools/move-cli/tests/testsuite/linking_breaking_change/args.txt
+++ b/language/tools/move-cli/tests/testsuite/linking_breaking_change/args.txt
@@ -1,0 +1,3 @@
+publish src/modules/
+publish M.move
+publish --ignore-breaking-changes M.move

--- a/language/tools/move-cli/tests/testsuite/linking_breaking_change/src/modules/M.move
+++ b/language/tools/move-cli/tests/testsuite/linking_breaking_change/src/modules/M.move
@@ -1,0 +1,6 @@
+address 0x2 {
+module M {
+    public fun f() {}
+    public fun g() {}
+}
+}

--- a/language/tools/move-cli/tests/testsuite/publish_then_check/args.exp
+++ b/language/tools/move-cli/tests/testsuite/publish_then_check/args.exp
@@ -1,0 +1,2 @@
+Command `publish src/modules`:
+Command `check`:

--- a/language/tools/move-cli/tests/testsuite/publish_then_check/args.txt
+++ b/language/tools/move-cli/tests/testsuite/publish_then_check/args.txt
@@ -1,0 +1,2 @@
+publish src/modules
+check

--- a/language/tools/move-cli/tests/testsuite/publish_then_check/src/modules/M.move
+++ b/language/tools/move-cli/tests/testsuite/publish_then_check/src/modules/M.move
@@ -1,0 +1,5 @@
+address 0x2 {
+module M {
+    public fun f() {}
+}
+}

--- a/language/tools/move-cli/tests/testsuite/publish_then_run/args.exp
+++ b/language/tools/move-cli/tests/testsuite/publish_then_run/args.exp
@@ -1,0 +1,2 @@
+Command `publish src/modules`:
+Command `run src/scripts/main.move`:

--- a/language/tools/move-cli/tests/testsuite/publish_then_run/args.txt
+++ b/language/tools/move-cli/tests/testsuite/publish_then_run/args.txt
@@ -1,0 +1,2 @@
+publish src/modules
+run src/scripts/main.move

--- a/language/tools/move-cli/tests/testsuite/publish_then_run/src/modules/M.move
+++ b/language/tools/move-cli/tests/testsuite/publish_then_run/src/modules/M.move
@@ -1,0 +1,5 @@
+address 0x2 {
+module M {
+    public fun f() {}
+}
+}

--- a/language/tools/move-cli/tests/testsuite/publish_then_run/src/scripts/main.move
+++ b/language/tools/move-cli/tests/testsuite/publish_then_run/src/scripts/main.move
@@ -1,0 +1,3 @@
+script {
+fun main() {}
+}

--- a/language/tools/move-cli/tests/testsuite/republish_module/args.exp
+++ b/language/tools/move-cli/tests/testsuite/republish_module/args.exp
@@ -1,0 +1,2 @@
+Command `publish src/modules`:
+Command `publish src/modules`:

--- a/language/tools/move-cli/tests/testsuite/republish_module/args.txt
+++ b/language/tools/move-cli/tests/testsuite/republish_module/args.txt
@@ -1,0 +1,2 @@
+publish src/modules
+publish src/modules

--- a/language/tools/move-cli/tests/testsuite/republish_module/src/modules/M.move
+++ b/language/tools/move-cli/tests/testsuite/republish_module/src/modules/M.move
@@ -1,0 +1,5 @@
+address 0x2 {
+module M {
+    public fun f() {}
+}
+}

--- a/language/vm/src/compatibility.rs
+++ b/language/vm/src/compatibility.rs
@@ -1,0 +1,119 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{normalized::Module, CompiledModule};
+
+/// The result of a linking and layoutcompatibility check. Here is what the different combinations
+/// mean:
+/// `{ struct: true, struct_layout: true }`: fully backward compatible
+/// `{ struct_and_function_linking: true, struct_layout: false }`: Dependent modules that reference functions or types in this module may not link. However, fixing, recompiling, and redeploying all dependent modules will work--no data migration needed.
+/// `{ type_and_function_linking: true, struct_layout: false }`: Attempting to read structs published by this module will now fail at runtime. However, dependent modules will continue to link. Requires data migration, but no changes to dependent modules.
+/// `{ type_and_function_linking: false, struct_layout: false }`: Everything is broken. Need both a data migration and changes to dependent modules.
+pub struct Compatibility {
+    /// If false, dependent modules that reference functions or structs in this module may not link
+    pub struct_and_function_linking: bool,
+    /// If false, attempting to read structs previously published by this module will fail at runtime
+    pub struct_layout: bool,
+}
+
+impl Compatibility {
+    /// Return true if the two module s compared in the compatiblity check are both linking and
+    /// layout compatible.
+    pub fn is_fully_compatible(&self) -> bool {
+        self.struct_and_function_linking && self.struct_layout
+    }
+
+    /// Return compatibility assessment for `new_module` relative to old module `old_module`
+    pub fn check(old_module: &Module, new_module: &Module) -> Compatibility {
+        let mut struct_and_function_linking = true;
+        let mut struct_layout = true;
+
+        // module's name and address are unchanged
+        if old_module.address != new_module.address || old_module.name != new_module.name {
+            struct_and_function_linking = false;
+        }
+
+        // old module's structs are a subset of the new module's structs
+        for old_struct in &old_module.structs {
+            match new_module
+                .structs
+                .iter()
+                .find(|s| s.name == old_struct.name)
+            {
+                Some(new_struct) => {
+                    if new_struct.kind != old_struct.kind
+                        || new_struct.type_parameters != old_struct.type_parameters
+                    {
+                        // Declared kind and/or type parameters changed. Existing modules that depend on this struct will fail to link with the new version of the module
+                        struct_and_function_linking = false;
+                        // This does not change the struct layout, but it may leave some published
+                        // values "orphaned". For example: if
+                        // `resource struct S<T: copyable> { t : T }` is changed to
+                        // `resource struct S<T: resource> { t : T}`, code can no longer access
+                        // published values of type (e.g.) `S<u64>`.
+                    }
+                    if new_struct.fields != old_struct.fields {
+                        // Fields changed. Code in this module will fail at runtime if it tries to
+                        // read a previously published struct value
+                        // TODO: this is a stricter definition than required. We could in principle
+                        // choose to label the following as compatible
+                        // (1) changing the name (but not position or type) of a field. The VM does
+                        //     not care about the name of a field (it's purely informational), but
+                        //     clients presumably do.
+                        // (2) changing the type of a field to a different, but layout and kind
+                        //     compatible type. E.g. `struct S { b: bool }` to `struct S { b: B }`
+                        // where
+                        //     B is struct B { some_name: bool }. TODO: does this affect clients? I
+                        //     think not--the serialization of the same data with these two types
+                        //     will be the same.
+                        struct_layout = false
+                    }
+                }
+                None => {
+                    // Struct not present in new . Existing modules that depend on this struct will fail to link with the new version of the module.
+                    struct_and_function_linking = false;
+                    // Note: we intentionally do *not* label this a layout compatibility violation.
+                    // Existing modules can still successfully read previously published values of
+                    // this struct `Parent::T`. That is, code like the function `foo` in
+                    // ```
+                    // struct S { t: Parent::T }
+                    // public fun foo(a: addr): S { move_from<S>(addr) }
+                    // ```
+                    // in module `Child` will continue to run without error. But values of type
+                    // `Parent::T` in `Child` are now "orphaned" in the sense that `Parent` no
+                    // longer exposes any API for reading/writing them.
+                }
+            }
+        }
+
+        // old module's public functions are a subset of the new module's public functions
+        for function in &old_module.public_functions {
+            if !new_module.public_functions.contains(&function) {
+                struct_and_function_linking = false;
+            }
+        }
+
+        Compatibility {
+            struct_and_function_linking,
+            struct_layout,
+        }
+    }
+
+    /// Return true if `new_module` can safely update `old_module`
+    pub fn can_update(
+        old_module: &Module,
+        new_module: &CompiledModule,
+        _new_module_dependencies: &[CompiledModule],
+    ) -> bool {
+        // (1) Verify new_module (TODO)
+        // (2) Link new_module against new_module dependencies. (TODO)
+        //     Note: this will *NOT* prevent cylic deps. We need to think about a different scheme
+        //     if we care about this (which we almost certainly do). One (probably too restrictive)
+        //     solution would be: insist that deps(new_module) are a subset of deps(old_module).
+        //     That would not only prevent cyclic deps, but also preclude the need for linking
+        //     entirely.
+        // (3) Extract the  for new_module and check compatibility with old_module
+        Self::is_fully_compatible(&Self::check(old_module, &Module::new(new_module)))
+            && panic!("TODO: implement verification, linking, cyclic deps checks")
+    }
+}

--- a/language/vm/src/lib.rs
+++ b/language/vm/src/lib.rs
@@ -10,6 +10,7 @@ use std::fmt;
 
 pub mod access;
 pub mod check_bounds;
+pub mod compatibility;
 #[macro_use]
 pub mod errors;
 pub mod constant;


### PR DESCRIPTION
…ecks

- If the CLI is trying to compile `M.move`, the logic for finding compilation deps now removes `M.move` from the deps list.
More generally, any files directly or transitively reachable from the compilation targets are removed from the deps list. This
fixes the annoying "duplicate definition" warning that you used to get when trying to re-publish a module
- Before a `move publish`, the CLI runs the bytecode linking and data layout compatibility checks and reports an error if the
code to be published could cause a breaking change to either linking or data layout
- Added tests for republishing, running `move check M.move` after publishing `M.move`, and the breaking changes checks