### PR TITLE
[Logger] Add backtraces to error logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "serde",
 ]
 
 [[package]]
@@ -3188,6 +3189,7 @@ dependencies = [
 name = "libra-logger"
 version = "0.1.0"
 dependencies = [
+ "backtrace",
  "chrono",
  "erased-serde",
  "hostname",

--- a/common/logger/Cargo.toml
+++ b/common/logger/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 # Do NOT add any inter-project dependencies.
 # This is to avoid ever having a circular dependency with the libra-logger crate.
 [dependencies]
+backtrace = { version = "0.3", features = ["serde"] }
 chrono = "0.4.19"
 erased-serde = "0.3.12"
 hostname = "0.3.1"

--- a/common/logger/src/metadata.rs
+++ b/common/logger/src/metadata.rs
@@ -1,10 +1,11 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use backtrace::Backtrace;
 use serde::{Deserialize, Serialize};
 use std::{fmt, str::FromStr};
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Metadata {
     /// The level of verbosity of the event
     level: Level,
@@ -23,10 +24,14 @@ pub struct Metadata {
 
     /// The file name and line number together 'file:line'
     location: &'static str,
+
+    /// The program backtrace taken when the event occurred. Backtraces are
+    /// only supported for errors.
+    backtrace: Option<Backtrace>,
 }
 
 impl Metadata {
-    pub const fn new(
+    pub fn new(
         level: Level,
         target: &'static str,
         module_path: &'static str,
@@ -34,6 +39,11 @@ impl Metadata {
         line: u32,
         location: &'static str,
     ) -> Self {
+        let backtrace = match level {
+            Level::Error => Some(Backtrace::new()),
+            _ => None,
+        };
+
         Self {
             level,
             target,
@@ -41,6 +51,7 @@ impl Metadata {
             file,
             line,
             location,
+            backtrace,
         }
     }
 
@@ -70,6 +81,10 @@ impl Metadata {
 
     pub fn location(&self) -> &'static str {
         self.location
+    }
+
+    pub fn backtrace(&self) -> Option<Backtrace> {
+        self.backtrace.clone()
     }
 }
 


### PR DESCRIPTION
## Motivation

This PR updates the metadata structure for logs to take backtraces when error! logs are created. This is useful for when you need to track down or identify the underlying cause of an error quickly (e.g., if you're an oncall responding to an error alarm in code you are not familiar with). 

### Why can't we just use the other logs around the error to identify/construct the backtrace?
- Ideally, this would be true. However, there is no guarantee that surrounding logs are informative enough to tell us what's happened (I've personally encountered this during my oncall rotation).
- Moreover, it's not completely true that our logs are strictly ordered according to execution ordering in the program. As far as I understand, our logs are ordered by timestamp, however, our timestamps only have a limited amount of precision. Thus, it's possible that multiple logs have the same timestamp, and there is no guarantee about the execution order of logs that share timestamps.

Note: this PR chooses not to take backtraces for all logs, but only for errors. This is because: (i) backtraces can be long, and we don't want to spam our logging pipelines; and (ii) backtraces do have some cost to construct (e.g., symbol resolution).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The existing logger tests have been updated to verify that a backtrace is taken for error logs. Moreover, running the test locally and forcing it to display the metadata contents of the error log shows the backtrace stack clearly, e.g.:

```
 LogEntry { metadata: Metadata { level: Error, target: "libra_logger", module_path: "libra_logger::libra_logger::tests", file: "common/logger/src/libra_logger.rs", line: 575, location: "common/logger/src/libra_logger.rs:575", backtrace: Some(   0: backtrace::backtrace::libunwind::trace
             at /Users/joshlind/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.55/src/backtrace/libunwind.rs:90:5
      backtrace::backtrace::trace_unsynchronized
             at /Users/joshlind/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.55/src/backtrace/mod.rs:66:5
   1: backtrace::backtrace::trace
             at /Users/joshlind/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.55/src/backtrace/mod.rs:53:14
   2: backtrace::capture::Backtrace::create
             at /Users/joshlind/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.55/src/capture.rs:176:9
   3: backtrace::capture::Backtrace::new
             at /Users/joshlind/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.55/src/capture.rs:140:22
   4: libra_logger::metadata::Metadata::new
             at src/metadata.rs:43:34
   5: libra_logger::libra_logger::tests::basic
             at src/libra_logger.rs:575:9
   6: libra_logger::libra_logger::tests::basic::{{closure}}
             at src/libra_logger.rs:519:5
   7: core::ops::function::FnOnce::call_once
             at /Users/joshlind/.rustup/toolchains/1.47.0-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:227:5
   8: core::ops::function::FnOnce::call_once
             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/core/src/ops/function.rs:227:5
      test::__rust_begin_short_backtrace
             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/test/src/lib.rs:517:5
   9: <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once
             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/alloc/src/boxed.rs:1042:9
      <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/panic.rs:308:9
      std::panicking::try::do_call
             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/panicking.rs:373:40
      std::panicking::try
             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/panicking.rs:337:19
      std::panic::catch_unwind
             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/panic.rs:379:14
      test::run_test_in_process
             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/test/src/lib.rs:544:18
      test::run_test::run_test_inner::{{closure}}
             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/test/src/lib.rs:450:39
  10: std::sys_common::backtrace::__rust_begin_short_backtrace
             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/sys_common/backtrace.rs:137:18
  11: std::thread::Builder::spawn_unchecked::{{closure}}::{{closure}}
             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/thread/mod.rs:458:17
      <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/panic.rs:308:9
      std::panicking::try::do_call
             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/panicking.rs:373:40
      std::panicking::try
             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/panicking.rs:337:19
      std::panic::catch_unwind
             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/panic.rs:379:14
      std::thread::Builder::spawn_unchecked::{{closure}}
             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/thread/mod.rs:457:30
      core::ops::function::FnOnce::call_once{{vtable.shim}}
             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/core/src/ops/function.rs:227:5
  12: <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once
             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/alloc/src/boxed.rs:1042:9
      <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once
             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/alloc/src/boxed.rs:1042:9
      std::sys::unix::thread::Thread::new::thread_start
             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/sys/unix/thread.rs:87:17
  13: __pthread_start
) 
```

The only open questions I have are how this will render in Kibana (i.e., with or without newline support), and whether or not we should consider trimming off a few of the backtrace frames to remove the various Backtrace::new() and Backtrace::create() calls. Either way, having this information for errors will be super useful!

## Related PRs

None.