### PR TITLE
[move-lang] allow _x to bind but do not warn as unused local

### DIFF
--- a/language/move-lang/src/cfgir/liveness/mod.rs
+++ b/language/move-lang/src/cfgir/liveness/mod.rs
@@ -295,16 +295,11 @@ mod last_usage {
                         DisplayVar::Tmp => (),
                         DisplayVar::Orig(v_str) => {
                             if !v.starts_with_underscore() {
-                                let verb = if context.is_resourceful(&v) {
-                                    // do not suggest prefixing for resource bindings
-                                    "replacing"
-                                } else {
-                                    "replacing / prefixing"
-                                };
                                 let msg = format!(
                                     "Unused assignment or binding for local '{}'. \
-                                    Consider removing or {} it with '_'",
-                                    v_str, verb
+                                    Consider removing, replacing with '_', \
+                                    or prefixing with '_' (e.g., '_{}')",
+                                    v_str, v_str
                                 );
                                 context.error(vec![(l.loc, msg)]);
                             }

--- a/language/move-lang/src/cfgir/liveness/mod.rs
+++ b/language/move-lang/src/cfgir/liveness/mod.rs
@@ -294,12 +294,14 @@ mod last_usage {
                     match display_var(v.value()) {
                         DisplayVar::Tmp => (),
                         DisplayVar::Orig(v_str) => {
-                            let msg = format!(
-                                "Unused assignment or binding for local '{}'. Consider removing \
-                                 or replacing it with '_'",
-                                v_str
-                            );
-                            context.error(vec![(l.loc, msg)]);
+                            if !v_str.starts_with('_') {
+                                let msg = format!(
+                                    "Unused assignment or binding for local '{}'. \
+                                    Consider removing or replacing it with '_'",
+                                    v_str
+                                );
+                                context.error(vec![(l.loc, msg)]);
+                            }
                             if !context.is_resourceful(v) {
                                 l.value = L::Ignore
                             }

--- a/language/move-lang/src/cfgir/liveness/mod.rs
+++ b/language/move-lang/src/cfgir/liveness/mod.rs
@@ -294,11 +294,17 @@ mod last_usage {
                     match display_var(v.value()) {
                         DisplayVar::Tmp => (),
                         DisplayVar::Orig(v_str) => {
-                            if !v_str.starts_with('_') {
+                            if !v.starts_with_underscore() {
+                                let verb = if context.is_resourceful(&v) {
+                                    // do not suggest prefixing for resource bindings
+                                    "replacing"
+                                } else {
+                                    "replacing / prefixing"
+                                };
                                 let msg = format!(
                                     "Unused assignment or binding for local '{}'. \
-                                    Consider removing or replacing it with '_'",
-                                    v_str
+                                    Consider removing or {} it with '_'",
+                                    v_str, verb
                                 );
                                 context.error(vec![(l.loc, msg)]);
                             }

--- a/language/move-lang/src/naming/translate.rs
+++ b/language/move-lang/src/naming/translate.rs
@@ -953,7 +953,7 @@ fn lvalue(context: &mut Context, case: LValueCase, sp!(loc, l_): E::LValue) -> O
     let nl_ = match l_ {
         EL::Var(sp!(_, E::ModuleAccess_::Name(n)), None) => {
             let v = Var(n);
-            if v.starts_with_underscore() {
+            if v.is_underscore() {
                 NL::Ignore
             } else {
                 NL::Var(v)

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -595,6 +595,10 @@ impl ModuleName {
 }
 
 impl Var {
+    pub fn is_underscore(&self) -> bool {
+        self.0.value == "_"
+    }
+
     pub fn starts_with_underscore(&self) -> bool {
         self.0.value.starts_with('_')
     }

--- a/language/move-lang/tests/move_check/expansion/almost_invalid_local_name.move
+++ b/language/move-lang/tests/move_check/expansion/almost_invalid_local_name.move
@@ -5,11 +5,17 @@ module M {
     }
 
     fun t2() {
-        let _No;
+        let _No = 100;
     }
 
     fun t3() {
+        let _No;
+        _No = 100;
+    }
+
+    fun t4() {
         let _No = 100;
+        F { No: _No };
     }
 
 }

--- a/language/move-lang/tests/move_check/expansion/invalid_local_name.exp
+++ b/language/move-lang/tests/move_check/expansion/invalid_local_name.exp
@@ -38,3 +38,11 @@ error:
     │             ^^ Unbound constant 'No'
     │
 
+error: 
+
+    ┌── tests/move_check/expansion/invalid_local_name.move:19:13 ───
+    │
+ 19 │         let _No;
+    │             ^^^ Could not infer this type. Try adding an annotation
+    │
+

--- a/language/move-lang/tests/move_check/expansion/invalid_local_name.move
+++ b/language/move-lang/tests/move_check/expansion/invalid_local_name.move
@@ -15,4 +15,8 @@ module M {
         F { No };
     }
 
+    fun t4() {
+        let _No;
+    }
+
 }

--- a/language/move-lang/tests/move_check/liveness/trailing_semi_loops.exp
+++ b/language/move-lang/tests/move_check/liveness/trailing_semi_loops.exp
@@ -112,7 +112,7 @@ error:
     ┌── tests/move_check/liveness/trailing_semi_loops.move:76:17 ───
     │
  76 │                 x = 2;
-    │                 ^ Unused assignment or binding for local 'x'. Consider removing or replacing it with '_'
+    │                 ^ Unused assignment or binding for local 'x'. Consider removing or replacing / prefixing it with '_'
     │
 
 error: 

--- a/language/move-lang/tests/move_check/liveness/trailing_semi_loops.exp
+++ b/language/move-lang/tests/move_check/liveness/trailing_semi_loops.exp
@@ -112,7 +112,7 @@ error:
     ┌── tests/move_check/liveness/trailing_semi_loops.move:76:17 ───
     │
  76 │                 x = 2;
-    │                 ^ Unused assignment or binding for local 'x'. Consider removing or replacing / prefixing it with '_'
+    │                 ^ Unused assignment or binding for local 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
     │
 
 error: 

--- a/language/move-lang/tests/move_check/liveness/unused_assignment.exp
+++ b/language/move-lang/tests/move_check/liveness/unused_assignment.exp
@@ -3,7 +3,7 @@ error:
    ┌── tests/move_check/liveness/unused_assignment.move:3:13 ───
    │
  3 │         let x = 0;
-   │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing it with '_'
+   │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing / prefixing it with '_'
    │
 
 error: 
@@ -11,7 +11,7 @@ error:
    ┌── tests/move_check/liveness/unused_assignment.move:7:13 ───
    │
  7 │         let x = 0;
-   │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing it with '_'
+   │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing / prefixing it with '_'
    │
 
 error: 
@@ -19,7 +19,7 @@ error:
    ┌── tests/move_check/liveness/unused_assignment.move:8:9 ───
    │
  8 │         x = 0;
-   │         ^ Unused assignment or binding for local 'x'. Consider removing or replacing it with '_'
+   │         ^ Unused assignment or binding for local 'x'. Consider removing or replacing / prefixing it with '_'
    │
 
 error: 
@@ -27,7 +27,7 @@ error:
     ┌── tests/move_check/liveness/unused_assignment.move:13:17 ───
     │
  13 │             let x = 0;
-    │                 ^ Unused assignment or binding for local 'x'. Consider removing or replacing it with '_'
+    │                 ^ Unused assignment or binding for local 'x'. Consider removing or replacing / prefixing it with '_'
     │
 
 error: 
@@ -35,7 +35,7 @@ error:
     ┌── tests/move_check/liveness/unused_assignment.move:21:13 ───
     │
  21 │             x = 0;
-    │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing it with '_'
+    │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing / prefixing it with '_'
     │
 
 error: 
@@ -43,7 +43,7 @@ error:
     ┌── tests/move_check/liveness/unused_assignment.move:26:13 ───
     │
  26 │         let x = 0;
-    │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing it with '_'
+    │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing / prefixing it with '_'
     │
 
 error: 
@@ -51,7 +51,7 @@ error:
     ┌── tests/move_check/liveness/unused_assignment.move:28:13 ───
     │
  28 │             x = 1;
-    │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing it with '_'
+    │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing / prefixing it with '_'
     │
 
 error: 
@@ -59,7 +59,7 @@ error:
     ┌── tests/move_check/liveness/unused_assignment.move:30:13 ───
     │
  30 │             x = 2;
-    │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing it with '_'
+    │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing / prefixing it with '_'
     │
 
 error: 
@@ -67,6 +67,6 @@ error:
     ┌── tests/move_check/liveness/unused_assignment.move:41:13 ───
     │
  41 │             x = 1;
-    │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing it with '_'
+    │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing / prefixing it with '_'
     │
 

--- a/language/move-lang/tests/move_check/liveness/unused_assignment.exp
+++ b/language/move-lang/tests/move_check/liveness/unused_assignment.exp
@@ -3,7 +3,7 @@ error:
    ┌── tests/move_check/liveness/unused_assignment.move:3:13 ───
    │
  3 │         let x = 0;
-   │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing / prefixing it with '_'
+   │             ^ Unused assignment or binding for local 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
    │
 
 error: 
@@ -11,7 +11,7 @@ error:
    ┌── tests/move_check/liveness/unused_assignment.move:7:13 ───
    │
  7 │         let x = 0;
-   │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing / prefixing it with '_'
+   │             ^ Unused assignment or binding for local 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
    │
 
 error: 
@@ -19,7 +19,7 @@ error:
    ┌── tests/move_check/liveness/unused_assignment.move:8:9 ───
    │
  8 │         x = 0;
-   │         ^ Unused assignment or binding for local 'x'. Consider removing or replacing / prefixing it with '_'
+   │         ^ Unused assignment or binding for local 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
    │
 
 error: 
@@ -27,7 +27,7 @@ error:
     ┌── tests/move_check/liveness/unused_assignment.move:13:17 ───
     │
  13 │             let x = 0;
-    │                 ^ Unused assignment or binding for local 'x'. Consider removing or replacing / prefixing it with '_'
+    │                 ^ Unused assignment or binding for local 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
     │
 
 error: 
@@ -35,7 +35,7 @@ error:
     ┌── tests/move_check/liveness/unused_assignment.move:21:13 ───
     │
  21 │             x = 0;
-    │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing / prefixing it with '_'
+    │             ^ Unused assignment or binding for local 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
     │
 
 error: 
@@ -43,7 +43,7 @@ error:
     ┌── tests/move_check/liveness/unused_assignment.move:26:13 ───
     │
  26 │         let x = 0;
-    │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing / prefixing it with '_'
+    │             ^ Unused assignment or binding for local 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
     │
 
 error: 
@@ -51,7 +51,7 @@ error:
     ┌── tests/move_check/liveness/unused_assignment.move:28:13 ───
     │
  28 │             x = 1;
-    │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing / prefixing it with '_'
+    │             ^ Unused assignment or binding for local 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
     │
 
 error: 
@@ -59,7 +59,7 @@ error:
     ┌── tests/move_check/liveness/unused_assignment.move:30:13 ───
     │
  30 │             x = 2;
-    │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing / prefixing it with '_'
+    │             ^ Unused assignment or binding for local 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
     │
 
 error: 
@@ -67,6 +67,6 @@ error:
     ┌── tests/move_check/liveness/unused_assignment.move:41:13 ───
     │
  41 │             x = 1;
-    │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing / prefixing it with '_'
+    │             ^ Unused assignment or binding for local 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
     │
 

--- a/language/move-lang/tests/move_check/locals/assign_partial_resource.exp
+++ b/language/move-lang/tests/move_check/locals/assign_partial_resource.exp
@@ -3,7 +3,7 @@ error:
    ┌── tests/move_check/locals/assign_partial_resource.move:6:21 ───
    │
  6 │         if (cond) { r = R{}; };
-   │                     ^ Unused assignment or binding for local 'r'. Consider removing or replacing it with '_'
+   │                     ^ Unused assignment or binding for local 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
    │
 
 error: 
@@ -22,7 +22,7 @@ error:
     ┌── tests/move_check/locals/assign_partial_resource.move:13:29 ───
     │
  13 │         if (cond) {} else { r = R{}; };
-    │                             ^ Unused assignment or binding for local 'r'. Consider removing or replacing it with '_'
+    │                             ^ Unused assignment or binding for local 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
     │
 
 error: 
@@ -41,7 +41,7 @@ error:
     ┌── tests/move_check/locals/assign_partial_resource.move:20:24 ───
     │
  20 │         while (cond) { r = R{} };
-    │                        ^ Unused assignment or binding for local 'r'. Consider removing or replacing it with '_'
+    │                        ^ Unused assignment or binding for local 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
     │
 
 error: 
@@ -71,7 +71,7 @@ error:
     ┌── tests/move_check/locals/assign_partial_resource.move:27:16 ───
     │
  27 │         loop { r = R{} }
-    │                ^ Unused assignment or binding for local 'r'. Consider removing or replacing it with '_'
+    │                ^ Unused assignment or binding for local 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
     │
 
 error: 

--- a/language/move-lang/tests/move_check/locals/assign_resource.exp
+++ b/language/move-lang/tests/move_check/locals/assign_resource.exp
@@ -3,7 +3,7 @@ error:
    ┌── tests/move_check/locals/assign_resource.move:5:13 ───
    │
  5 │         let r = R{};
-   │             ^ Unused assignment or binding for local 'r'. Consider removing or replacing it with '_'
+   │             ^ Unused assignment or binding for local 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
    │
 
 error: 
@@ -55,7 +55,7 @@ error:
     ┌── tests/move_check/locals/assign_resource.move:29:13 ───
     │
  29 │         let r = R{};
-    │             ^ Unused assignment or binding for local 'r'. Consider removing or replacing it with '_'
+    │             ^ Unused assignment or binding for local 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
     │
 
 error: 

--- a/language/move-lang/tests/move_check/locals/unused_copyable.exp
+++ b/language/move-lang/tests/move_check/locals/unused_copyable.exp
@@ -19,6 +19,6 @@ error:
    ┌── tests/move_check/locals/unused_copyable.move:9:13 ───
    │
  9 │         let s = S{};
-   │             ^ Unused assignment or binding for local 's'. Consider removing or replacing / prefixing it with '_'
+   │             ^ Unused assignment or binding for local 's'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_s')
    │
 

--- a/language/move-lang/tests/move_check/locals/unused_copyable.exp
+++ b/language/move-lang/tests/move_check/locals/unused_copyable.exp
@@ -1,16 +1,24 @@
 error: 
 
-   ┌── tests/move_check/locals/unused_copyable.move:5:16 ───
+   ┌── tests/move_check/locals/unused_copyable.move:5:12 ───
    │
- 5 │     fun unused(i: u64, s: S) {
-   │                ^ Unused parameter 'i'. Consider removing or prefixing with an underscore: '_i'
+ 5 │     fun t0(i: u64, s: S) {
+   │            ^ Unused parameter 'i'. Consider removing or prefixing with an underscore: '_i'
    │
 
 error: 
 
-   ┌── tests/move_check/locals/unused_copyable.move:5:24 ───
+   ┌── tests/move_check/locals/unused_copyable.move:5:20 ───
    │
- 5 │     fun unused(i: u64, s: S) {
-   │                        ^ Unused parameter 's'. Consider removing or prefixing with an underscore: '_s'
+ 5 │     fun t0(i: u64, s: S) {
+   │                    ^ Unused parameter 's'. Consider removing or prefixing with an underscore: '_s'
+   │
+
+error: 
+
+   ┌── tests/move_check/locals/unused_copyable.move:9:13 ───
+   │
+ 9 │         let s = S{};
+   │             ^ Unused assignment or binding for local 's'. Consider removing or replacing / prefixing it with '_'
    │
 

--- a/language/move-lang/tests/move_check/locals/unused_copyable.move
+++ b/language/move-lang/tests/move_check/locals/unused_copyable.move
@@ -2,6 +2,15 @@ module M {
     struct S {}
 
     // this produces unused parameter warnings for i and s, but not unused resource warnings
-    fun unused(i: u64, s: S) {
+    fun t0(i: u64, s: S) {
+    }
+
+    fun t1() {
+        let s = S{};
+    }
+
+    fun t2() {
+        // prefixing an unused non-resource with _ suppresses the warning
+        let _s = S{};
     }
 }

--- a/language/move-lang/tests/move_check/locals/unused_resource.exp
+++ b/language/move-lang/tests/move_check/locals/unused_resource.exp
@@ -3,7 +3,7 @@ error:
    ┌── tests/move_check/locals/unused_resource.move:5:13 ───
    │
  5 │         let r = R{};
-   │             ^ Unused assignment or binding for local 'r'. Consider removing or replacing it with '_'
+   │             ^ Unused assignment or binding for local 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
    │
 
 error: 
@@ -33,7 +33,7 @@ error:
     ┌── tests/move_check/locals/unused_resource.move:15:21 ───
     │
  15 │         if (cond) { r = R{}; };
-    │                     ^ Unused assignment or binding for local 'r'. Consider removing or replacing it with '_'
+    │                     ^ Unused assignment or binding for local 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
     │
 
 error: 
@@ -52,7 +52,7 @@ error:
     ┌── tests/move_check/locals/unused_resource.move:20:29 ───
     │
  20 │         if (cond) {} else { r = R{}; };
-    │                             ^ Unused assignment or binding for local 'r'. Consider removing or replacing it with '_'
+    │                             ^ Unused assignment or binding for local 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
     │
 
 error: 
@@ -71,7 +71,7 @@ error:
     ┌── tests/move_check/locals/unused_resource.move:25:24 ───
     │
  25 │         while (cond) { r = R{} };
-    │                        ^ Unused assignment or binding for local 'r'. Consider removing or replacing it with '_'
+    │                        ^ Unused assignment or binding for local 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
     │
 
 error: 
@@ -101,7 +101,7 @@ error:
     ┌── tests/move_check/locals/unused_resource.move:29:20 ───
     │
  29 │         loop { let r = R{}; }
-    │                    ^ Unused assignment or binding for local 'r'. Consider removing or replacing it with '_'
+    │                    ^ Unused assignment or binding for local 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
     │
 
 error: 

--- a/language/move-lang/tests/move_check/locals/unused_resource.exp
+++ b/language/move-lang/tests/move_check/locals/unused_resource.exp
@@ -21,110 +21,121 @@ error:
 
     ┌── tests/move_check/locals/unused_resource.move:10:21 ───
     │
- 10 │         if (cond) { r = R{}; };
+ 10 │         let _r = R{};
+    │                     ^ Invalid return
+    ·
+ 10 │         let _r = R{};
+    │             -- The local '_r' still contains a resource value due to this assignment. The resource must be consumed before the function returns
+    │
+
+error: 
+
+    ┌── tests/move_check/locals/unused_resource.move:15:21 ───
+    │
+ 15 │         if (cond) { r = R{}; };
     │                     ^ Unused assignment or binding for local 'r'. Consider removing or replacing it with '_'
     │
 
 error: 
 
-    ┌── tests/move_check/locals/unused_resource.move:10:31 ───
+    ┌── tests/move_check/locals/unused_resource.move:15:31 ───
     │
- 10 │         if (cond) { r = R{}; };
+ 15 │         if (cond) { r = R{}; };
     │                               ^ Invalid return
     ·
- 10 │         if (cond) { r = R{}; };
+ 15 │         if (cond) { r = R{}; };
     │                     - The local 'r' might still contain a resource value due to this assignment. The resource must be consumed before the function returns
     │
 
 error: 
 
-    ┌── tests/move_check/locals/unused_resource.move:15:29 ───
+    ┌── tests/move_check/locals/unused_resource.move:20:29 ───
     │
- 15 │         if (cond) {} else { r = R{}; };
+ 20 │         if (cond) {} else { r = R{}; };
     │                             ^ Unused assignment or binding for local 'r'. Consider removing or replacing it with '_'
     │
 
 error: 
 
-    ┌── tests/move_check/locals/unused_resource.move:15:39 ───
+    ┌── tests/move_check/locals/unused_resource.move:20:39 ───
     │
- 15 │         if (cond) {} else { r = R{}; };
+ 20 │         if (cond) {} else { r = R{}; };
     │                                       ^ Invalid return
     ·
- 15 │         if (cond) {} else { r = R{}; };
+ 20 │         if (cond) {} else { r = R{}; };
     │                             - The local 'r' might still contain a resource value due to this assignment. The resource must be consumed before the function returns
     │
 
 error: 
 
-    ┌── tests/move_check/locals/unused_resource.move:20:24 ───
+    ┌── tests/move_check/locals/unused_resource.move:25:24 ───
     │
- 20 │         while (cond) { r = R{} };
+ 25 │         while (cond) { r = R{} };
     │                        ^ Unused assignment or binding for local 'r'. Consider removing or replacing it with '_'
     │
 
 error: 
 
-    ┌── tests/move_check/locals/unused_resource.move:20:24 ───
+    ┌── tests/move_check/locals/unused_resource.move:25:24 ───
     │
- 20 │         while (cond) { r = R{} };
+ 25 │         while (cond) { r = R{} };
     │                        ^ Invalid assignment to local 'r'
     ·
- 20 │         while (cond) { r = R{} };
+ 25 │         while (cond) { r = R{} };
     │                        - The local might contain a resource value due to this assignment. The resource must be used before you assign to this local again
     │
 
 error: 
 
-    ┌── tests/move_check/locals/unused_resource.move:20:33 ───
+    ┌── tests/move_check/locals/unused_resource.move:25:33 ───
     │
- 20 │         while (cond) { r = R{} };
+ 25 │         while (cond) { r = R{} };
     │                                 ^ Invalid return
     ·
- 20 │         while (cond) { r = R{} };
+ 25 │         while (cond) { r = R{} };
     │                        - The local 'r' might still contain a resource value due to this assignment. The resource must be consumed before the function returns
     │
 
 error: 
 
-    ┌── tests/move_check/locals/unused_resource.move:24:20 ───
+    ┌── tests/move_check/locals/unused_resource.move:29:20 ───
     │
- 24 │         loop { let r = R{}; }
+ 29 │         loop { let r = R{}; }
     │                    ^ Unused assignment or binding for local 'r'. Consider removing or replacing it with '_'
     │
 
 error: 
 
-    ┌── tests/move_check/locals/unused_resource.move:24:20 ───
+    ┌── tests/move_check/locals/unused_resource.move:29:20 ───
     │
- 24 │         loop { let r = R{}; }
+ 29 │         loop { let r = R{}; }
     │                    ^ Invalid assignment to local 'r'
     ·
- 24 │         loop { let r = R{}; }
+ 29 │         loop { let r = R{}; }
     │                    - The local might contain a resource value due to this assignment. The resource must be used before you assign to this local again
     │
 
 error: 
 
-    ┌── tests/move_check/locals/unused_resource.move:28:21 ───
+    ┌── tests/move_check/locals/unused_resource.move:33:21 ───
     │
- 28 │         let _ = &R{};
+ 33 │         let _ = &R{};
     │                     ^ Invalid return
     ·
- 28 │         let _ = &R{};
+ 33 │         let _ = &R{};
     │                  --- The resource is created but not used. The resource must be consumed before the function returns
     │
 
 error: 
 
-    ┌── tests/move_check/locals/unused_resource.move:31:22 ───
+    ┌── tests/move_check/locals/unused_resource.move:36:22 ───
     │
- 31 │       fun t6<T>(_x: R) {
+ 36 │       fun t7<T>(_x: R) {
     │ ╭──────────────────────^
- 32 │ │     }
+ 37 │ │     }
     │ ╰─────^ Invalid return
     ·
- 31 │     fun t6<T>(_x: R) {
+ 36 │     fun t7<T>(_x: R) {
     │               -- The parameter '_x' still contains a resource value. The resource must be consumed before the function returns
     │
 

--- a/language/move-lang/tests/move_check/locals/unused_resource.move
+++ b/language/move-lang/tests/move_check/locals/unused_resource.move
@@ -5,30 +5,35 @@ module M {
         let r = R{};
     }
 
-    fun t1(cond: bool) {
-        let r;
-        if (cond) { r = R{}; };
+    fun t1() {
+        // prefixing an unused resource with _ does not work
+        let _r = R{};
     }
 
     fun t2(cond: bool) {
         let r;
-        if (cond) {} else { r = R{}; };
+        if (cond) { r = R{}; };
     }
 
     fun t3(cond: bool) {
         let r;
+        if (cond) {} else { r = R{}; };
+    }
+
+    fun t4(cond: bool) {
+        let r;
         while (cond) { r = R{} };
     }
 
-    fun t4() {
+    fun t5() {
         loop { let r = R{}; }
     }
 
-    fun t5() {
+    fun t6() {
         let _ = &R{};
     }
 
-    fun t6<T>(_x: R) {
+    fun t7<T>(_x: R) {
     }
 
 }

--- a/language/move-lang/tests/move_check/locals/unused_resource_explicit_return.exp
+++ b/language/move-lang/tests/move_check/locals/unused_resource_explicit_return.exp
@@ -3,7 +3,7 @@ error:
    ┌── tests/move_check/locals/unused_resource_explicit_return.move:5:13 ───
    │
  5 │         let r = R{};
-   │             ^ Unused assignment or binding for local 'r'. Consider removing or replacing it with '_'
+   │             ^ Unused assignment or binding for local 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
    │
 
 error: 
@@ -55,7 +55,7 @@ error:
     ┌── tests/move_check/locals/unused_resource_explicit_return.move:28:13 ───
     │
  28 │         let r = R{};
-    │             ^ Unused assignment or binding for local 'r'. Consider removing or replacing it with '_'
+    │             ^ Unused assignment or binding for local 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
     │
 
 error: 
@@ -74,7 +74,7 @@ error:
     ┌── tests/move_check/locals/unused_resource_explicit_return.move:33:13 ───
     │
  33 │         let x = &R{};
-    │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing / prefixing it with '_'
+    │             ^ Unused assignment or binding for local 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
     │
 
 error: 

--- a/language/move-lang/tests/move_check/locals/unused_resource_explicit_return.exp
+++ b/language/move-lang/tests/move_check/locals/unused_resource_explicit_return.exp
@@ -74,7 +74,7 @@ error:
     ┌── tests/move_check/locals/unused_resource_explicit_return.move:33:13 ───
     │
  33 │         let x = &R{};
-    │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing it with '_'
+    │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing / prefixing it with '_'
     │
 
 error: 

--- a/language/move-lang/tests/move_check/locals/use_before_assign_while.exp
+++ b/language/move-lang/tests/move_check/locals/use_before_assign_while.exp
@@ -47,6 +47,6 @@ error:
     ┌── tests/move_check/locals/use_before_assign_while.move:19:60 ───
     │
  19 │         while (cond) { let y = &x; _ = move y; if (cond) { x = 0 }; break }
-    │                                                            ^ Unused assignment or binding for local 'x'. Consider removing or replacing / prefixing it with '_'
+    │                                                            ^ Unused assignment or binding for local 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
     │
 

--- a/language/move-lang/tests/move_check/locals/use_before_assign_while.exp
+++ b/language/move-lang/tests/move_check/locals/use_before_assign_while.exp
@@ -47,6 +47,6 @@ error:
     ┌── tests/move_check/locals/use_before_assign_while.move:19:60 ───
     │
  19 │         while (cond) { let y = &x; _ = move y; if (cond) { x = 0 }; break }
-    │                                                            ^ Unused assignment or binding for local 'x'. Consider removing or replacing it with '_'
+    │                                                            ^ Unused assignment or binding for local 'x'. Consider removing or replacing / prefixing it with '_'
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/commands/move_before_assign.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/commands/move_before_assign.exp
@@ -3,7 +3,7 @@ error:
    ┌── tests/move_check/translated_ir_tests/move/commands/move_before_assign.move:4:9 ───
    │
  4 │     let y = move x;
-   │         ^ Unused assignment or binding for local 'y'. Consider removing or replacing / prefixing it with '_'
+   │         ^ Unused assignment or binding for local 'y'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_y')
    │
 
 error: 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/commands/move_before_assign.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/commands/move_before_assign.exp
@@ -3,7 +3,7 @@ error:
    ┌── tests/move_check/translated_ir_tests/move/commands/move_before_assign.move:4:9 ───
    │
  4 │     let y = move x;
-   │         ^ Unused assignment or binding for local 'y'. Consider removing or replacing it with '_'
+   │         ^ Unused assignment or binding for local 'y'. Consider removing or replacing / prefixing it with '_'
    │
 
 error: 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/commands/use_before_assign.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/commands/use_before_assign.exp
@@ -3,7 +3,7 @@ error:
    ┌── tests/move_check/translated_ir_tests/move/commands/use_before_assign.move:4:9 ───
    │
  4 │     let y = x;
-   │         ^ Unused assignment or binding for local 'y'. Consider removing or replacing / prefixing it with '_'
+   │         ^ Unused assignment or binding for local 'y'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_y')
    │
 
 error: 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/commands/use_before_assign.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/commands/use_before_assign.exp
@@ -3,7 +3,7 @@ error:
    ┌── tests/move_check/translated_ir_tests/move/commands/use_before_assign.move:4:9 ───
    │
  4 │     let y = x;
-   │         ^ Unused assignment or binding for local 'y'. Consider removing or replacing it with '_'
+   │         ^ Unused assignment or binding for local 'y'. Consider removing or replacing / prefixing it with '_'
    │
 
 error: 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/signer/is_resource_transitive.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/signer/is_resource_transitive.exp
@@ -3,7 +3,7 @@ error:
    ┌── tests/move_check/translated_ir_tests/move/signer/is_resource_transitive.move:7:13 ───
    │
  7 │         let x = S<signer> { f: s };
-   │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing it with '_'
+   │             ^ Unused assignment or binding for local 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
    │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/bind_pop_resource.exp
+++ b/language/move-lang/tests/move_check/typing/bind_pop_resource.exp
@@ -14,20 +14,6 @@ error:
 
 error: 
 
-   ┌── tests/move_check/typing/bind_pop_resource.move:6:13 ───
-   │
- 6 │         let _r: R = R{};
-   │             ^^ Cannot ignore resource values. The value must be used
-   ·
- 6 │         let _r: R = R{};
-   │                 - The type: '0x8675309::M::R'
-   ·
- 2 │     resource struct R {}
-   │     -------- Is found to be a non-copyable type here
-   │
-
-error: 
-
    ┌── tests/move_check/typing/bind_pop_resource.move:7:14 ───
    │
  7 │         let (_, _):(R, R) = (R{}, R{});

--- a/language/move-lang/tests/move_check/typing/bind_pop_resource.exp
+++ b/language/move-lang/tests/move_check/typing/bind_pop_resource.exp
@@ -14,12 +14,12 @@ error:
 
 error: 
 
-   ┌── tests/move_check/typing/bind_pop_resource.move:7:14 ───
+   ┌── tests/move_check/typing/bind_pop_resource.move:9:14 ───
    │
- 7 │         let (_, _):(R, R) = (R{}, R{});
+ 9 │         let (_, _):(R, R) = (R{}, R{});
    │              ^ Cannot ignore resource values. The value must be used
    ·
- 7 │         let (_, _):(R, R) = (R{}, R{});
+ 9 │         let (_, _):(R, R) = (R{}, R{});
    │                     - The type: '0x8675309::M::R'
    ·
  2 │     resource struct R {}
@@ -28,12 +28,12 @@ error:
 
 error: 
 
-   ┌── tests/move_check/typing/bind_pop_resource.move:7:17 ───
+   ┌── tests/move_check/typing/bind_pop_resource.move:9:17 ───
    │
- 7 │         let (_, _):(R, R) = (R{}, R{});
+ 9 │         let (_, _):(R, R) = (R{}, R{});
    │                 ^ Cannot ignore resource values. The value must be used
    ·
- 7 │         let (_, _):(R, R) = (R{}, R{});
+ 9 │         let (_, _):(R, R) = (R{}, R{});
    │                        - The type: '0x8675309::M::R'
    ·
  2 │     resource struct R {}

--- a/language/move-lang/tests/move_check/typing/bind_pop_resource.move
+++ b/language/move-lang/tests/move_check/typing/bind_pop_resource.move
@@ -3,6 +3,8 @@ module M {
 
     fun t0() {
         let _: R = R{};
+        // the following is an invalid binding too but its error message will
+        // not show because the compilation fails early at the typing phase
         let _r: R = R{};
         let (_, _):(R, R) = (R{}, R{});
     }

--- a/language/move-lang/tests/move_check/typing/declare_pop_resource.exp
+++ b/language/move-lang/tests/move_check/typing/declare_pop_resource.exp
@@ -14,20 +14,6 @@ error:
 
 error: 
 
-   ┌── tests/move_check/typing/declare_pop_resource.move:6:13 ───
-   │
- 6 │         let _r: R;
-   │             ^^ Cannot ignore resource values. The value must be used
-   ·
- 6 │         let _r: R;
-   │                 - The type: '0x8675309::M::R'
-   ·
- 2 │     resource struct R {f: u64}
-   │     -------- Is found to be a non-copyable type here
-   │
-
-error: 
-
    ┌── tests/move_check/typing/declare_pop_resource.move:7:14 ───
    │
  7 │         let (_, _):(R, R);

--- a/language/move-lang/tests/move_check/typing/declare_pop_resource.exp
+++ b/language/move-lang/tests/move_check/typing/declare_pop_resource.exp
@@ -14,12 +14,12 @@ error:
 
 error: 
 
-   ┌── tests/move_check/typing/declare_pop_resource.move:7:14 ───
+   ┌── tests/move_check/typing/declare_pop_resource.move:9:14 ───
    │
- 7 │         let (_, _):(R, R);
+ 9 │         let (_, _):(R, R);
    │              ^ Cannot ignore resource values. The value must be used
    ·
- 7 │         let (_, _):(R, R);
+ 9 │         let (_, _):(R, R);
    │                     - The type: '0x8675309::M::R'
    ·
  2 │     resource struct R {f: u64}
@@ -28,12 +28,12 @@ error:
 
 error: 
 
-   ┌── tests/move_check/typing/declare_pop_resource.move:7:17 ───
+   ┌── tests/move_check/typing/declare_pop_resource.move:9:17 ───
    │
- 7 │         let (_, _):(R, R);
+ 9 │         let (_, _):(R, R);
    │                 ^ Cannot ignore resource values. The value must be used
    ·
- 7 │         let (_, _):(R, R);
+ 9 │         let (_, _):(R, R);
    │                        - The type: '0x8675309::M::R'
    ·
  2 │     resource struct R {f: u64}

--- a/language/move-lang/tests/move_check/typing/declare_pop_resource.move
+++ b/language/move-lang/tests/move_check/typing/declare_pop_resource.move
@@ -3,6 +3,8 @@ module M {
 
     fun t0() {
         let _: R;
+        // the following is an invalid binding too but its error message will
+        // not show because the compilation fails early at the typing phase
         let _r: R;
         let (_, _):(R, R);
     }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

`_` patterns are used to not introduce a binding, e.g. `let (x, _, z) = (0, 1, 2);`
- In Rust, if you do `_y` instead of `_`, e.g. `let (x, _y, z) = (0, 1, 2);` This introduces a binding `_y = 1` but it will not complain if you don't use it
- In Move currently `_y` is just sugar for `_` which isn't really helpful

The fix:
- make `_y` not remap to `_`, this will automatically fix being able to use it
- add an exclusion for underscore prefixed locals in the unused local warning

## Test Plan

`cargo xtest`
