### PR TITLE
[network] Integrate Rate limiting on incoming messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
+dependencies = [
+ "const-random",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,6 +975,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f590d95d011aa80b063ffe3253422ed5aa462af4e9867d43ce8337562bac77c4"
+dependencies = [
+ "const-random-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "615f6e27d000a2bffbc7f2f6a8669179378fa27ee4d0a509e985dfc0a7defb40"
+dependencies = [
+ "getrandom 0.2.0",
+ "lazy_static",
+ "proc-macro-hack",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "const_fn"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1228,6 +1259,17 @@ dependencies = [
  "rand_core 0.5.1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "dashmap"
+version = "3.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f260e2fc850179ef410018660006951c1b55b79e8087e87111a2c388994b9b5"
+dependencies = [
+ "ahash",
+ "cfg-if 0.1.10",
+ "num_cpus",
 ]
 
 [[package]]
@@ -2932,6 +2974,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3112,6 +3160,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "governor"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f302dc68f4035178051bff107a8181379b8baa3354654672c2f1e7134af983"
+dependencies = [
+ "dashmap",
+ "futures 0.3.8",
+ "futures-timer",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot",
+ "quanta",
+ "rand 0.7.3",
+]
+
+[[package]]
 name = "guppy"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3184,6 +3248,16 @@ dependencies = [
  "quick-error 2.0.0",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
+dependencies = [
+ "ahash",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -3409,7 +3483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
 dependencies = [
  "autocfg 1.0.1",
- "hashbrown",
+ "hashbrown 0.9.1",
 ]
 
 [[package]]
@@ -4347,6 +4421,7 @@ dependencies = [
  "diem-workspace-hack",
  "futures 0.3.8",
  "futures-util",
+ "governor",
  "hex",
  "libra-canonical-serialization",
  "memsocket",
@@ -4445,6 +4520,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+dependencies = [
+ "hashbrown 0.8.2",
+]
+
+[[package]]
 name = "nom"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4453,6 +4537,12 @@ dependencies = [
  "memchr",
  "version_check",
 ]
+
+[[package]]
+name = "nonzero_ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44a1290799eababa63ea60af0cbc3f03363e328e58f32fb0294798ed3e85f444"
 
 [[package]]
 name = "num"
@@ -5092,6 +5182,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "quanta"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98dc777a7a39b76b1a26ae9d3f691f4c1bc0455090aa0b64dfa8cb7fc34c135"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0.34"
 bytes = { version = "0.5.6", features = ["serde"] }
 futures = "0.3.8"
 futures-util = "0.3.8"
+governor = "0.3.1"
 hex = "0.4.2"
 once_cell = "1.4.1"
 pin-project = "1.0.2"

--- a/network/network-address/src/lib.rs
+++ b/network/network-address/src/lib.rs
@@ -292,6 +292,17 @@ impl NetworkAddress {
         })
     }
 
+    /// Finds the `IpAddr` in the network address, returns `UNSPECIFIED` if it's DNS, and `None` if it has no IP
+    pub fn find_ip_addr(&self) -> Option<IpAddr> {
+        self.0.iter().find_map(|proto| match proto {
+            Protocol::Ip4(addr) => Some(IpAddr::V4(*addr)),
+            Protocol::Ip6(addr) => Some(IpAddr::V6(*addr)),
+            Protocol::Dns(_) | Protocol::Dns4(_) => Some(IpAddr::V4(Ipv4Addr::UNSPECIFIED)),
+            Protocol::Dns6(_) => Some(IpAddr::V6(Ipv6Addr::UNSPECIFIED)),
+            _ => None,
+        })
+    }
+
     /// A function to rotate public keys for `NoiseIK` protocols
     pub fn rotate_noise_public_key(
         &mut self,

--- a/network/src/interface/mod.rs
+++ b/network/src/interface/mod.rs
@@ -20,6 +20,7 @@ use crate::{
         direct_send::Message,
         rpc::{InboundRpcRequest, OutboundRpcRequest, Rpc, RpcNotification},
     },
+    rate_limiter::RateLimiter,
     transport::Connection,
     ProtocolId,
 };
@@ -32,7 +33,6 @@ use futures::{
     stream::StreamExt,
     FutureExt, SinkExt,
 };
-use governor::{clock::DefaultClock, state::keyed::DefaultKeyedStateStore, RateLimiter};
 use std::{
     fmt::Debug, marker::PhantomData, net::IpAddr, num::NonZeroUsize, sync::Arc, time::Duration,
 };
@@ -76,9 +76,7 @@ where
         max_concurrent_notifs: usize,
         channel_size: usize,
         max_frame_size: usize,
-        inbound_rate_limiter: Arc<
-            RateLimiter<IpAddr, DefaultKeyedStateStore<IpAddr>, DefaultClock>,
-        >,
+        inbound_rate_limiter: Arc<RateLimiter<IpAddr>>,
     ) -> (
         diem_channel::Sender<ProtocolId, NetworkRequest>,
         diem_channel::Receiver<ProtocolId, NetworkNotification>,

--- a/network/src/interface/mod.rs
+++ b/network/src/interface/mod.rs
@@ -76,7 +76,7 @@ where
         max_concurrent_notifs: usize,
         channel_size: usize,
         max_frame_size: usize,
-        inbound_rate_limiter: Arc<RateLimiter<IpAddr>>,
+        inbound_rate_limiter: Option<Arc<RateLimiter<IpAddr>>>,
     ) -> (
         diem_channel::Sender<ProtocolId, NetworkRequest>,
         diem_channel::Receiver<ProtocolId, NetworkNotification>,

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -22,6 +22,7 @@ pub mod transport;
 
 #[cfg(feature = "fuzzing")]
 pub mod fuzzing;
+mod rate_limiter;
 #[cfg(any(test, feature = "testing", feature = "fuzzing"))]
 pub mod testutils;
 

--- a/network/src/peer/fuzzing.rs
+++ b/network/src/peer/fuzzing.rs
@@ -8,6 +8,7 @@ use crate::{
         handshake::v1::{MessagingProtocolVersion, SupportedProtocols},
         messaging::v1::{NetworkMessage, NetworkMessageSink},
     },
+    rate_limiter,
     testutils::fake_socket::ReadOnlyTestSocketVec,
     transport::{Connection, ConnectionId, ConnectionMetadata},
     ProtocolId,
@@ -101,6 +102,8 @@ pub fn fuzz(data: &[u8]) {
     let max_concurrent_notifs = 8;
     let channel_size = 8;
 
+    let inbound_rate_limiter = rate_limiter::allow_all_keyed();
+
     // Spin up a new `Peer` actor through the `NetworkProvider` interface.
     let (network_reqs_tx, network_notifs_rx) = NetworkProvider::start(
         network_context,
@@ -111,6 +114,7 @@ pub fn fuzz(data: &[u8]) {
         max_concurrent_notifs,
         channel_size,
         MAX_FRAME_SIZE,
+        inbound_rate_limiter,
     );
 
     rt.block_on(async move {

--- a/network/src/peer/fuzzing.rs
+++ b/network/src/peer/fuzzing.rs
@@ -8,7 +8,6 @@ use crate::{
         handshake::v1::{MessagingProtocolVersion, SupportedProtocols},
         messaging::v1::{NetworkMessage, NetworkMessageSink},
     },
-    rate_limiter,
     testutils::fake_socket::ReadOnlyTestSocketVec,
     transport::{Connection, ConnectionId, ConnectionMetadata},
     ProtocolId,
@@ -102,8 +101,6 @@ pub fn fuzz(data: &[u8]) {
     let max_concurrent_notifs = 8;
     let channel_size = 8;
 
-    let inbound_rate_limiter = rate_limiter::allow_all_keyed();
-
     // Spin up a new `Peer` actor through the `NetworkProvider` interface.
     let (network_reqs_tx, network_notifs_rx) = NetworkProvider::start(
         network_context,
@@ -114,7 +111,7 @@ pub fn fuzz(data: &[u8]) {
         max_concurrent_notifs,
         channel_size,
         MAX_FRAME_SIZE,
-        inbound_rate_limiter,
+        None,
     );
 
     rt.block_on(async move {

--- a/network/src/peer/mod.rs
+++ b/network/src/peer/mod.rs
@@ -116,7 +116,7 @@ pub struct Peer<TSocket> {
     /// Currently, requests are only a single frame
     max_frame_size: usize,
     /// Inbound request rate limiter
-    inbound_rate_limiter: Arc<RateLimiter<IpAddr>>,
+    inbound_rate_limiter: Option<Arc<RateLimiter<IpAddr>>>,
 }
 
 impl<TSocket> Peer<TSocket>
@@ -131,7 +131,7 @@ where
         peer_notifs_tx: channel::Sender<PeerNotification>,
         rpc_notifs_tx: channel::Sender<PeerNotification>,
         max_frame_size: usize,
-        inbound_rate_limiter: Arc<RateLimiter<IpAddr>>,
+        inbound_rate_limiter: Option<Arc<RateLimiter<IpAddr>>>,
     ) -> Self {
         let Connection {
             metadata: connection_metadata,
@@ -178,7 +178,7 @@ where
             ip_addr,
             IoCompat::new(read_socket),
             self.max_frame_size,
-            Some(self.inbound_rate_limiter.clone()),
+            self.inbound_rate_limiter.clone(),
         )
         .fuse();
         let writer = NetworkMessageSink::new(IoCompat::new(write_socket), self.max_frame_size);

--- a/network/src/peer/mod.rs
+++ b/network/src/peer/mod.rs
@@ -18,6 +18,7 @@ use crate::{
             Priority, ReadError, WriteError,
         },
     },
+    rate_limiter::RateLimiter,
     transport,
     transport::{Connection, ConnectionMetadata},
     ProtocolId,
@@ -33,7 +34,6 @@ use futures::{
     stream::StreamExt,
     FutureExt, SinkExt, TryFutureExt,
 };
-use governor::{clock::DefaultClock, state::keyed::DefaultKeyedStateStore, RateLimiter};
 use netcore::compat::IoCompat;
 use serde::{export::Formatter, Serialize};
 use std::{
@@ -116,7 +116,7 @@ pub struct Peer<TSocket> {
     /// Currently, requests are only a single frame
     max_frame_size: usize,
     /// Inbound request rate limiter
-    inbound_rate_limiter: Arc<RateLimiter<IpAddr, DefaultKeyedStateStore<IpAddr>, DefaultClock>>,
+    inbound_rate_limiter: Arc<RateLimiter<IpAddr>>,
 }
 
 impl<TSocket> Peer<TSocket>
@@ -131,9 +131,7 @@ where
         peer_notifs_tx: channel::Sender<PeerNotification>,
         rpc_notifs_tx: channel::Sender<PeerNotification>,
         max_frame_size: usize,
-        inbound_rate_limiter: Arc<
-            RateLimiter<IpAddr, DefaultKeyedStateStore<IpAddr>, DefaultClock>,
-        >,
+        inbound_rate_limiter: Arc<RateLimiter<IpAddr>>,
     ) -> Self {
         let Connection {
             metadata: connection_metadata,

--- a/network/src/peer/test.rs
+++ b/network/src/peer/test.rs
@@ -13,7 +13,6 @@ use crate::{
             },
         },
     },
-    rate_limiter,
     transport::{Connection, ConnectionId, ConnectionMetadata},
     ProtocolId,
 };
@@ -57,7 +56,6 @@ fn build_test_peer(
     };
     let connection_metadata = connection.metadata.clone();
 
-    let rate_limiter = rate_limiter::allow_all_keyed();
     let peer = Peer::new(
         NetworkContext::mock(),
         executor,
@@ -66,7 +64,7 @@ fn build_test_peer(
         peer_notifs_tx,
         peer_rpc_notifs_tx,
         MAX_FRAME_SIZE,
-        rate_limiter,
+        None,
     );
     let peer_handle = PeerHandle::new(NetworkContext::mock(), connection_metadata, peer_req_tx);
 

--- a/network/src/peer/test.rs
+++ b/network/src/peer/test.rs
@@ -13,6 +13,7 @@ use crate::{
             },
         },
     },
+    rate_limiter,
     transport::{Connection, ConnectionId, ConnectionMetadata},
     ProtocolId,
 };
@@ -56,6 +57,7 @@ fn build_test_peer(
     };
     let connection_metadata = connection.metadata.clone();
 
+    let rate_limiter = rate_limiter::allow_all_keyed();
     let peer = Peer::new(
         NetworkContext::mock(),
         executor,
@@ -64,6 +66,7 @@ fn build_test_peer(
         peer_notifs_tx,
         peer_rpc_notifs_tx,
         MAX_FRAME_SIZE,
+        rate_limiter,
     );
     let peer_handle = PeerHandle::new(NetworkContext::mock(), connection_metadata, peer_req_tx);
 

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -55,7 +55,7 @@ mod error;
 mod tests;
 
 pub use self::error::PeerManagerError;
-use governor::{clock::DefaultClock, state::keyed::DefaultKeyedStateStore, RateLimiter};
+use crate::rate_limiter::RateLimiter;
 use serde::export::Formatter;
 use std::{net::IpAddr, num::NonZeroU32};
 
@@ -291,8 +291,8 @@ where
     max_frame_size: usize,
     /// Inbound connection limit separate of outbound connections
     inbound_connection_limit: usize,
-    /// Inbound request rate limiter TODO: adjust state store and clock
-    inbound_rate_limiter: Arc<RateLimiter<IpAddr, DefaultKeyedStateStore<IpAddr>, DefaultClock>>,
+    /// Inbound request rate limiter
+    inbound_rate_limiter: Arc<RateLimiter<IpAddr>>,
 }
 
 impl<TTransport, TSocket> PeerManager<TTransport, TSocket>

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -292,7 +292,7 @@ where
     /// Inbound connection limit separate of outbound connections
     inbound_connection_limit: usize,
     /// Inbound request rate limiter
-    inbound_rate_limiter: Arc<RateLimiter<IpAddr>>,
+    inbound_rate_limiter: Option<Arc<RateLimiter<IpAddr>>>,
 }
 
 impl<TTransport, TSocket> PeerManager<TTransport, TSocket>
@@ -361,7 +361,10 @@ where
             max_frame_size,
             inbound_connection_limit,
             // FIXME: Use a config configured quota
-            inbound_rate_limiter: rate_limiter::new_per_second_keyed(default_rate, default_rate),
+            inbound_rate_limiter: Some(rate_limiter::new_per_second_keyed(
+                default_rate,
+                default_rate,
+            )),
         }
     }
 

--- a/network/src/peer_manager/tests.rs
+++ b/network/src/peer_manager/tests.rs
@@ -105,6 +105,7 @@ fn build_test_peer_manager(
         constants::MAX_CONCURRENT_NETWORK_NOTIFS,
         constants::MAX_FRAME_SIZE,
         MAX_INBOUND_CONNECTIONS,
+        None,
     );
 
     (

--- a/network/src/rate_limiter.rs
+++ b/network/src/rate_limiter.rs
@@ -1,0 +1,74 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use diem_logger::prelude::*;
+use governor::{
+    clock::DefaultClock, state::keyed::DefaultKeyedStateStore, NegativeMultiDecision, Quota,
+    RateLimiter,
+};
+use std::{hash::Hash, num::NonZeroU32, sync::Arc};
+
+/// Directives for the synchronous usage of Rate limiting, the service using it could choose to
+/// drop the messages anyways in all situations.
+/// TODO: Add a wait directive for backpressure
+pub enum RateLimitError {
+    DropMessage,
+    MessageTooLarge,
+}
+
+/// Provides a maximum throttle for testing and "fully open" purposes
+/// TODO: Can we just make an implementation that doesn't do anything instead?
+pub fn allow_all_keyed<Key: Hash + Clone + Eq>(
+) -> Arc<RateLimiter<Key, DefaultKeyedStateStore<Key>, DefaultClock>> {
+    let max = NonZeroU32::new(u32::MAX).unwrap();
+    let quota = Quota::per_second(max);
+    Arc::new(governor::RateLimiter::keyed(quota))
+}
+
+/// Provides a per second throttle with arbitrary keys
+pub fn new_per_second_keyed<Key: Hash + Clone + Eq>(
+    max_burst: NonZeroU32,
+    max_rate: NonZeroU32,
+) -> Arc<RateLimiter<Key, DefaultKeyedStateStore<Key>, DefaultClock>> {
+    let quota = Quota::per_second(max_rate).allow_burst(max_burst);
+    Arc::new(governor::RateLimiter::keyed(quota))
+}
+
+/// Rate limits a message based on it's length
+pub fn rate_limit_msg<
+    Key: Hash + Clone + Eq,
+    S: governor::state::StateStore + governor::state::StateStore<Key = Key>,
+    C: governor::clock::Clock,
+>(
+    rate_limiter: &RateLimiter<Key, S, C>,
+    key: &Key,
+    msg_length: usize,
+) -> Result<(), RateLimitError> {
+    // Governor doesn't support larger than u32
+    if msg_length > u32::MAX as usize {
+        error!(
+            "Cannot process message, message size ({}) is greater than max possible u32",
+            msg_length
+        );
+        return Err(RateLimitError::MessageTooLarge);
+    } else if msg_length < 1 {
+        // We can't rate limit something of 0 size, allow it through
+        return Ok(());
+    }
+
+    let length = NonZeroU32::new(msg_length as u32).unwrap();
+
+    rate_limiter.check_key_n(key, length).map_err(|error| {
+        match error {
+            NegativeMultiDecision::BatchNonConforming(_max_allowed, _not_until) => {
+                // Here we can wait based on the `not_until` field for an expected time
+                // For now, drop the message
+                RateLimitError::DropMessage
+            }
+            NegativeMultiDecision::InsufficientCapacity(max_size) => {
+                error!("Cannot process message, message size ({}) is greater than rate limiter allows ({})", msg_length, max_size);
+                RateLimitError::MessageTooLarge
+            }
+        }
+    })
+}

--- a/network/src/rate_limiter.rs
+++ b/network/src/rate_limiter.rs
@@ -20,10 +20,10 @@ pub enum RateLimitError {
 
 /// Provides a per second throttle with arbitrary keys
 pub fn new_per_second_keyed<Key: Hash + Clone + Eq>(
-    max_burst: NonZeroU32,
-    max_rate: NonZeroU32,
+    throttle_rate: NonZeroU32,
+    throttle_burst: NonZeroU32,
 ) -> Arc<RateLimiter<Key>> {
-    let quota = Quota::per_second(max_rate).allow_burst(max_burst);
+    let quota = Quota::per_second(throttle_rate).allow_burst(throttle_burst);
     Arc::new(governor::RateLimiter::keyed(quota))
 }
 

--- a/network/src/rate_limiter.rs
+++ b/network/src/rate_limiter.rs
@@ -18,14 +18,6 @@ pub enum RateLimitError {
     MessageTooLarge,
 }
 
-/// Provides a maximum throttle for testing and "fully open" purposes
-/// TODO: Can we just make an implementation that doesn't do anything instead?
-pub fn allow_all_keyed<Key: Hash + Clone + Eq>() -> Arc<RateLimiter<Key>> {
-    let max = NonZeroU32::new(u32::MAX).unwrap();
-    let quota = Quota::per_second(max);
-    Arc::new(governor::RateLimiter::keyed(quota))
-}
-
 /// Provides a per second throttle with arbitrary keys
 pub fn new_per_second_keyed<Key: Hash + Clone + Eq>(
     max_burst: NonZeroU32,


### PR DESCRIPTION
## Summary
Using `Governor`, we now have a hardcoded rate limiting for incoming
messages.  This will be extended to outbound messages in a future PR.

This doesn't currently provide any backpressure, and instead drops messages on a per frame level.  Future plans are to provide for providing backpressure

## Planning Issue
https://github.com/diem/diem/issues/6859