### PR TITLE
[rustsec] Bump ordered-float to 2.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4679,9 +4679,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fe9037165d7023b1228bc4ae9a2fa1a2b0095eca6c2998c624723dfd01314a5"
+checksum = "dacdec97876ef3ede8c50efc429220641a0b11ba0048b4b0c357bccbc47c5204"
 dependencies = [
  "num-traits",
 ]


### PR DESCRIPTION
## Motivation
Bump the ordered-float crate to 2.0.1 to address RUSTSEC-2020-0082 (https://rustsec.org/advisories/RUSTSEC-2020-0082). 

## Test Plan
Cargo audit locally + CI