### PR TITLE
[bucket] sccache fix (and rebased version), correct bucket location

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -865,7 +865,7 @@ jobs:
           command: |
             set -x
             SUFFIX="$(date +"%Y-%m-%d")-$(git rev-parse --short=8 HEAD)"
-            PREFIX="ci-artifacts.libra.org/coverage";
+            PREFIX="ci-artifacts.diem.com/coverage";
             #Push grcov
             aws s3 cp --recursive ${CODECOV_OUTPUT}/grcovhtml "s3://${PREFIX}/unit-coverage/${SUFFIX}/";
             aws s3 cp --recursive ${CODECOV_OUTPUT}/grcovhtml "s3://${PREFIX}/unit-coverage/latest/";

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ aliases:
       only:
         - auto
         - canary
-  - &working_directory /opt/git/libra
+  - &working_directory /opt/git/diem
   - &image libra/build_environment:circleci-2
 
 version: 2.1

--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@
 ---
 
 [![Diem Rust Crate Documentation (master)](https://img.shields.io/badge/docs-master-59f)](https://developers.diem.com/docs/rustdocs/)
-[![CircleCI](https://circleci.com/gh/libra/libra.svg?style=shield)](https://circleci.com/gh/libra/libra)
+[![CircleCI](https://circleci.com/gh/diem/diem.svg?style=shield)](https://circleci.com/gh/diem/diem)
 [![License](https://img.shields.io/badge/license-Apache-green.svg)](LICENSE)
-[![codecov](https://codecov.io/gh/libra/libra/branch/master/graph/badge.svg)](https://codecov.io/gh/libra/libra)
+[![grcov](https://img.shields.io/badge/Coverage-grcov-green)](https://ci-artifacts.diem.com/coverage/unit-coverage/latest/index.html)
+[![codecov](https://codecov.io/gh/diem/diem/branch/master/graph/badge.svg)](https://codecov.io/gh/diem/diem)
 
 Diem Core implements a decentralized, programmable database which provides a financial infrastructure that can empower billions of people.
 
@@ -66,4 +67,4 @@ To begin contributing, [sign the CLA](https://diem.com/en-US/cla-sign/). You can
 
 ## License
 
-Diem Core is licensed as [Apache 2.0](https://github.com/libra/libra/blob/master/LICENSE).
+Diem Core is licensed as [Apache 2.0](https://github.com/diem/diem/blob/master/LICENSE).

--- a/x.toml
+++ b/x.toml
@@ -25,7 +25,7 @@ envs = [
 [cargo.sccache.installer]
 version = "0.2.14-alpha.0"
 git = "https://github.com/rexhoffman/sccache.git"
-git-rev = "19fef99c15765ea73460fd9ecb209c35313eac41"
+git-rev = "549babdd3866aa60dae01668c42ee00bf1e8c763"
 features = [ "s3" ]
 
 


### PR DESCRIPTION
## Motivation

Currently sccache is busted due to incorrect bucket name.   Suppose I should have it log.
Fix bucket location for code coverage and sccache.
Use the rebased version of my pr on sccache.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

CI

## Related PRs

Cory Hill's work on the bucket rename.