### PR TITLE
[storage] get_latest_sequence_number with dedicated index

### DIFF
--- a/storage/diemdb/src/lib.rs
+++ b/storage/diemdb/src/lib.rs
@@ -120,6 +120,7 @@ impl DiemDB {
             EPOCH_BY_VERSION_CF_NAME,
             EVENT_ACCUMULATOR_CF_NAME,
             EVENT_BY_KEY_CF_NAME,
+            EVENT_BY_VERSION_CF_NAME,
             EVENT_CF_NAME,
             JELLYFISH_MERKLE_NODE_CF_NAME,
             LEDGER_COUNTERS_CF_NAME,

--- a/storage/diemdb/src/schema/event_by_version/mod.rs
+++ b/storage/diemdb/src/schema/event_by_version/mod.rs
@@ -1,0 +1,68 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module defines physical storage schema for an event index via which a ContractEvent (
+//! represented by a <txn_version, event_idx> tuple so that it can be fetched from `EventSchema`)
+//! can be found by <access_path, version, sequence_num> tuple.
+//!
+//! ```text
+//! |<--------------key------------>|<-value->|
+//! | event_key | txn_ver | seq_num |   idx   |
+//! ```
+
+use crate::schema::{ensure_slice_len_eq, EVENT_BY_VERSION_CF_NAME};
+use anyhow::Result;
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use diem_types::{event::EventKey, transaction::Version};
+use schemadb::{
+    define_schema,
+    schema::{KeyCodec, ValueCodec},
+};
+use std::{convert::TryFrom, mem::size_of};
+
+define_schema!(EventByVersionSchema, Key, Value, EVENT_BY_VERSION_CF_NAME);
+
+type SeqNum = u64;
+type Key = (EventKey, Version, SeqNum);
+
+type Index = u64;
+type Value = Index;
+
+impl KeyCodec<EventByVersionSchema> for Key {
+    fn encode_key(&self) -> Result<Vec<u8>> {
+        let (ref event_key, version, seq_num) = *self;
+
+        let mut encoded = event_key.to_vec();
+        encoded.write_u64::<BigEndian>(version)?;
+        encoded.write_u64::<BigEndian>(seq_num)?;
+
+        Ok(encoded)
+    }
+
+    fn decode_key(data: &[u8]) -> Result<Self> {
+        ensure_slice_len_eq(data, size_of::<Self>())?;
+
+        const EVENT_KEY_LEN: usize = size_of::<EventKey>();
+        const EVENT_KEY_AND_VER_LEN: usize = size_of::<(EventKey, Version)>();
+        let event_key = EventKey::try_from(&data[..EVENT_KEY_LEN])?;
+        let version = (&data[EVENT_KEY_LEN..]).read_u64::<BigEndian>()?;
+        let seq_num = (&data[EVENT_KEY_AND_VER_LEN..]).read_u64::<BigEndian>()?;
+
+        Ok((event_key, version, seq_num))
+    }
+}
+
+impl ValueCodec<EventByVersionSchema> for Value {
+    fn encode_value(&self) -> Result<Vec<u8>> {
+        Ok(self.to_be_bytes().to_vec())
+    }
+
+    fn decode_value(data: &[u8]) -> Result<Self> {
+        ensure_slice_len_eq(data, size_of::<Self>())?;
+
+        Ok((&data[..]).read_u64::<BigEndian>()?)
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/storage/diemdb/src/schema/event_by_version/test.rs
+++ b/storage/diemdb/src/schema/event_by_version/test.rs
@@ -1,0 +1,18 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use proptest::prelude::*;
+use schemadb::schema::assert_encode_decode;
+
+proptest! {
+    #[test]
+    fn test_encode_decode(
+        event_key in any::<EventKey>(),
+        seq_num in any::<u64>(),
+        version in any::<Version>(),
+        index in any::<u64>(),
+    ) {
+        assert_encode_decode::<EventByVersionSchema>(&(event_key, version, seq_num), &index);
+    }
+}

--- a/storage/diemdb/src/schema/mod.rs
+++ b/storage/diemdb/src/schema/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod epoch_by_version;
 pub(crate) mod event;
 pub(crate) mod event_accumulator;
 pub(crate) mod event_by_key;
+pub(crate) mod event_by_version;
 pub(crate) mod jellyfish_merkle_node;
 pub(crate) mod ledger_counters;
 pub(crate) mod ledger_info;
@@ -25,6 +26,7 @@ use schemadb::ColumnFamilyName;
 pub(super) const EPOCH_BY_VERSION_CF_NAME: ColumnFamilyName = "epoch_by_version";
 pub(super) const EVENT_ACCUMULATOR_CF_NAME: ColumnFamilyName = "event_accumulator";
 pub(super) const EVENT_BY_KEY_CF_NAME: ColumnFamilyName = "event_by_key";
+pub(super) const EVENT_BY_VERSION_CF_NAME: ColumnFamilyName = "event_by_version";
 pub(super) const EVENT_CF_NAME: ColumnFamilyName = "event";
 pub(super) const JELLYFISH_MERKLE_NODE_CF_NAME: ColumnFamilyName = "jellyfish_merkle_node";
 pub(super) const LEDGER_COUNTERS_CF_NAME: ColumnFamilyName = "ledger_counters";
@@ -72,6 +74,7 @@ pub mod fuzzing {
             decode_key_value!(super::event::EventSchema, data);
             decode_key_value!(super::event_accumulator::EventAccumulatorSchema, data);
             decode_key_value!(super::event_by_key::EventByKeySchema, data);
+            decode_key_value!(super::event_by_version::EventByVersionSchema, data);
             decode_key_value!(
                 super::jellyfish_merkle_node::JellyfishMerkleNodeSchema,
                 data


### PR DESCRIPTION



## Motivation

Add physical event by version index so that it's efficient to answer the question "what's the latest seq for this event at this version?", and it accommodates to the case where a same event stream emits multiple events in the same version.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
Y

## Test Plan

unit tests
## Related PRs
