### PR TITLE
[executor] storage based sequence number assignment

### DIFF
--- a/execution/executor/src/sequence_number_assigner.rs
+++ b/execution/executor/src/sequence_number_assigner.rs
@@ -1,0 +1,47 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use diem_types::{event::EventKey, transaction::Version};
+use std::{
+    collections::{hash_map, HashMap},
+    sync::Arc,
+};
+use storage_interface::DbReader;
+
+pub(crate) struct SequenceNumberAssigner {
+    db_reader: Arc<dyn DbReader>,
+    block_start_version: Version,
+    assigned: HashMap<EventKey, u64>,
+}
+
+impl SequenceNumberAssigner {
+    pub fn new(db_reader: Arc<dyn DbReader>, block_start_version: Version) -> Self {
+        Self {
+            db_reader,
+            block_start_version,
+            assigned: Default::default(),
+        }
+    }
+
+    pub fn assign(&mut self, key: &EventKey) -> Result<u64> {
+        let ret = match self.assigned.entry(*key) {
+            hash_map::Entry::Occupied(mut entry) => {
+                let assigned = entry.get_mut();
+                *assigned += 1;
+                *assigned
+            }
+            hash_map::Entry::Vacant(entry) => {
+                let next = if self.block_start_version == 0 {
+                    0
+                } else {
+                    self.db_reader
+                        .get_next_sequence_number(self.block_start_version - 1, key)?
+                };
+                *entry.insert(next)
+            }
+        };
+
+        Ok(ret)
+    }
+}

--- a/storage/diemdb/src/event_store/mod.rs
+++ b/storage/diemdb/src/event_store/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     ledger_counters::{LedgerCounter, LedgerCounterBumps},
     schema::{
         event::EventSchema, event_accumulator::EventAccumulatorSchema,
-        event_by_key::EventByKeySchema,
+        event_by_key::EventByKeySchema, event_by_version::EventByVersionSchema,
     },
 };
 use accumulator::{HashReader, MerkleAccumulator};
@@ -102,45 +102,26 @@ impl EventStore {
         ledger_version: Version,
         event_key: &EventKey,
     ) -> Result<Option<u64>> {
-        let mut iter = self.db.iter::<EventByKeySchema>(ReadOptions::default())?;
-        iter.seek_for_prev(&(*event_key, u64::max_value()));
-        if let Some(res) = iter.next() {
-            let ((key, mut seq), (ver, _idx)) = res?;
-            if key == *event_key {
-                if ver <= ledger_version {
-                    return Ok(Some(seq));
-                }
+        let mut iter = self
+            .db
+            .iter::<EventByVersionSchema>(ReadOptions::default())?;
+        iter.seek_for_prev(&(*event_key, ledger_version, u64::max_value()));
 
-                // Queries tend to base on very recent ledger infos, so first try to linear search
-                // from the most recent end, for limited tries.
-                // TODO: Optimize: Physical store use reverse order.
-                let mut n_try_recent = 10;
-                #[cfg(test)]
-                let mut n_try_recent = 1;
-                while seq > 0 && n_try_recent > 0 {
-                    seq -= 1;
-                    n_try_recent -= 1;
-                    let ver = self.get_txn_ver_by_seq_num(event_key, seq)?;
-                    if ver <= ledger_version {
-                        return Ok(Some(seq));
-                    }
-                }
+        Ok(iter.next().transpose()?.and_then(
+            |((key, _version, seq), _idx)| if &key == event_key { Some(seq) } else { None },
+        ))
+    }
 
-                // Fall back to binary search if the above short linear search didn't work out.
-                let (mut begin, mut end) = (0, seq);
-                while begin < end {
-                    let mid = end - (end - begin) / 2;
-                    let ver = self.get_txn_ver_by_seq_num(event_key, mid)?;
-                    if ver <= ledger_version {
-                        begin = mid;
-                    } else {
-                        end = mid - 1;
-                    }
-                }
-                return Ok(Some(begin));
-            }
-        }
-        Ok(None)
+    /// Get the next sequence number for specified event key.
+    /// Returns 0 if there's no events already in the event stream.
+    pub fn get_next_sequence_number(
+        &self,
+        ledger_version: Version,
+        event_key: &EventKey,
+    ) -> Result<u64> {
+        Ok(self
+            .get_latest_sequence_number(ledger_version, event_key)?
+            .map_or(0, |seq| seq + 1))
     }
 
     /// Given `event_key` and `start_seq_num`, returns events identified by transaction version and
@@ -193,7 +174,7 @@ impl EventStore {
         cs.counter_bumps(version)
             .bump(LedgerCounter::EventsCreated, events.len());
 
-        // EventSchema and EventByKeySchema updates
+        // Event table and indices updates
         events
             .iter()
             .enumerate()
@@ -202,6 +183,10 @@ impl EventStore {
                 cs.batch.put::<EventByKeySchema>(
                     &(*event.key(), event.sequence_number()),
                     &(version, idx as u64),
+                )?;
+                cs.batch.put::<EventByVersionSchema>(
+                    &(*event.key(), version, event.sequence_number()),
+                    &(idx as u64),
                 )?;
                 Ok(())
             })

--- a/storage/diemdb/src/lib.rs
+++ b/storage/diemdb/src/lib.rs
@@ -120,6 +120,7 @@ impl DiemDB {
             EPOCH_BY_VERSION_CF_NAME,
             EVENT_ACCUMULATOR_CF_NAME,
             EVENT_BY_KEY_CF_NAME,
+            EVENT_BY_VERSION_CF_NAME,
             EVENT_CF_NAME,
             JELLYFISH_MERKLE_NODE_CF_NAME,
             LEDGER_COUNTERS_CF_NAME,

--- a/storage/diemdb/src/lib.rs
+++ b/storage/diemdb/src/lib.rs
@@ -797,6 +797,17 @@ impl DbReader for DiemDB {
             self.ledger_store.get_root_hash(version)
         })
     }
+
+    fn get_next_sequence_number(
+        &self,
+        ledger_version: Version,
+        event_key: &EventKey,
+    ) -> Result<u64> {
+        gauged_api("get_next_sequence_number", || {
+            self.event_store
+                .get_next_sequence_number(ledger_version, event_key)
+        })
+    }
 }
 
 impl DbWriter for DiemDB {

--- a/storage/diemdb/src/schema/event_by_version/mod.rs
+++ b/storage/diemdb/src/schema/event_by_version/mod.rs
@@ -1,0 +1,67 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module defines physical storage schema for an event index via which a ContractEvent (
+//! represented by a <txn_version, event_idx> tuple so that it can be fetched from `EventSchema`)
+//! can be found by <access_path, version, sequence_num> tuple.
+//!
+//! ```text
+//! |<--------------key------------>|<-value->|
+//! | event_key | txn_ver | seq_num |   idx   |
+//! ```
+
+use crate::schema::{ensure_slice_len_eq, EVENT_BY_VERSION_CF_NAME};
+use anyhow::Result;
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use diem_types::{event::EventKey, transaction::Version};
+use schemadb::{
+    define_schema,
+    schema::{KeyCodec, ValueCodec},
+};
+use std::{convert::TryFrom, mem::size_of};
+
+define_schema!(EventByVersionSchema, Key, Value, EVENT_BY_VERSION_CF_NAME);
+
+type SeqNum = u64;
+type Key = (EventKey, Version, SeqNum);
+
+type Index = u64;
+type Value = Index;
+
+impl KeyCodec<EventByVersionSchema> for Key {
+    fn encode_key(&self) -> Result<Vec<u8>> {
+        let (ref event_key, version, seq_num) = *self;
+
+        let mut encoded = event_key.to_vec();
+        encoded.write_u64::<BigEndian>(version)?;
+        encoded.write_u64::<BigEndian>(seq_num)?;
+
+        Ok(encoded)
+    }
+
+    fn decode_key(data: &[u8]) -> Result<Self> {
+        ensure_slice_len_eq(data, size_of::<Self>())?;
+
+        const EVENT_KEY_LEN: usize = size_of::<EventKey>();
+        let event_key = EventKey::try_from(&data[..EVENT_KEY_LEN])?;
+        let version = (&data[EVENT_KEY_LEN..]).read_u64::<BigEndian>()?;
+        let seq_num = (&data[(EVENT_KEY_LEN + size_of::<Version>())..]).read_u64::<BigEndian>()?;
+
+        Ok((event_key, version, seq_num))
+    }
+}
+
+impl ValueCodec<EventByVersionSchema> for Value {
+    fn encode_value(&self) -> Result<Vec<u8>> {
+        Ok(self.to_be_bytes().to_vec())
+    }
+
+    fn decode_value(data: &[u8]) -> Result<Self> {
+        ensure_slice_len_eq(data, size_of::<Self>())?;
+
+        Ok((&data[..]).read_u64::<BigEndian>()?)
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/storage/diemdb/src/schema/event_by_version/test.rs
+++ b/storage/diemdb/src/schema/event_by_version/test.rs
@@ -1,0 +1,18 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use proptest::prelude::*;
+use schemadb::schema::assert_encode_decode;
+
+proptest! {
+    #[test]
+    fn test_encode_decode(
+        event_key in any::<EventKey>(),
+        seq_num in any::<u64>(),
+        version in any::<Version>(),
+        index in any::<u64>(),
+    ) {
+        assert_encode_decode::<EventByVersionSchema>(&(event_key, version, seq_num), &index);
+    }
+}

--- a/storage/diemdb/src/schema/mod.rs
+++ b/storage/diemdb/src/schema/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod epoch_by_version;
 pub(crate) mod event;
 pub(crate) mod event_accumulator;
 pub(crate) mod event_by_key;
+pub(crate) mod event_by_version;
 pub(crate) mod jellyfish_merkle_node;
 pub(crate) mod ledger_counters;
 pub(crate) mod ledger_info;
@@ -25,6 +26,7 @@ use schemadb::ColumnFamilyName;
 pub(super) const EPOCH_BY_VERSION_CF_NAME: ColumnFamilyName = "epoch_by_version";
 pub(super) const EVENT_ACCUMULATOR_CF_NAME: ColumnFamilyName = "event_accumulator";
 pub(super) const EVENT_BY_KEY_CF_NAME: ColumnFamilyName = "event_by_key";
+pub(super) const EVENT_BY_VERSION_CF_NAME: ColumnFamilyName = "event_by_version";
 pub(super) const EVENT_CF_NAME: ColumnFamilyName = "event";
 pub(super) const JELLYFISH_MERKLE_NODE_CF_NAME: ColumnFamilyName = "jellyfish_merkle_node";
 pub(super) const LEDGER_COUNTERS_CF_NAME: ColumnFamilyName = "ledger_counters";
@@ -72,6 +74,7 @@ pub mod fuzzing {
             decode_key_value!(super::event::EventSchema, data);
             decode_key_value!(super::event_accumulator::EventAccumulatorSchema, data);
             decode_key_value!(super::event_by_key::EventByKeySchema, data);
+            decode_key_value!(super::event_by_version::EventByVersionSchema, data);
             decode_key_value!(
                 super::jellyfish_merkle_node::JellyfishMerkleNodeSchema,
                 data

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -303,6 +303,16 @@ pub trait DbReader: Send + Sync {
     fn get_accumulator_root_hash(&self, _version: Version) -> Result<HashValue> {
         unimplemented!()
     }
+
+    /// Gets the sequence number for the next emit of a specified event stream.
+    /// Resturns 0 if no such event exists in the stream yet.
+    fn get_next_sequence_number(
+        &self,
+        _ledger_version: Version,
+        _event_key: &EventKey,
+    ) -> Result<u64> {
+        unimplemented!()
+    }
 }
 
 impl MoveStorage for &dyn DbReader {


### PR DESCRIPTION


## Motivation

Executor gains the ability to assign sequence numbers for events, based on the latest sequence number in storage.
Since this the VM is relieved of such responsibility, we can refactor it out. But for now we check that the sequence numbers assigned by both match each other.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y
## Test Plan
existing coverage
## Related PRs
