### PR TITLE
[Small cleanups] Remove libra from network checker test and fix key manager smoke test. 

### DIFF
--- a/config/management/operational/src/network_checker.rs
+++ b/config/management/operational/src/network_checker.rs
@@ -91,16 +91,12 @@ pub mod tests {
     fn test_check_endpoint() {
         let op_tool = OperationalTool::new("unused-host".into(), ChainId::test());
 
-        // Check invalid DNS
-        let addr = NetworkAddress::from_str("/dns4/libra/tcp/80").unwrap();
+        // Ensure endpoint doesn't respond with data
+        let addr = NetworkAddress::from_str("/dns4/diem/tcp/80").unwrap();
         op_tool.check_endpoint(addr).unwrap_err();
 
-        // Check if endpoint responded with data
-        let addr = NetworkAddress::from_str("/dns4/libra.org/tcp/80").unwrap();
-        op_tool.check_endpoint(addr).unwrap_err();
-
-        // Check bad port
-        let addr = NetworkAddress::from_str("/dns4/libra.org/tcp/6180").unwrap();
+        // Check connection refused (bad port)
+        let addr = NetworkAddress::from_str("/dns4/diem/tcp/9999").unwrap();
         op_tool.check_endpoint(addr).unwrap_err();
     }
 }

--- a/testsuite/smoke-test/src/key_manager.rs
+++ b/testsuite/smoke-test/src/key_manager.rs
@@ -54,6 +54,9 @@ fn test_key_manager_consensus_rotation() {
         ChainId::test(),
     );
 
+    // Add some time padding to ensure the libra timestamp increases on-chain
+    sleep(Duration::from_secs(10));
+
     // Spawn the key manager and execute a rotation
     let _key_manager_thread = thread::spawn(move || key_manager.execute());
 


### PR DESCRIPTION
## Motivation

This PR offers two commits for simple code cleanups/improvements for tests:

1. First, remove "libra" from the network checker test and remove the redundant assertion.
2. Second, reduce the aggression of the key manager smoke test by adding a small time buffer.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally.

## Related PRs

None.