### PR TITLE
network: enable having trusted peers even in non-validator networks

### DIFF
--- a/network/socket-bench-server/src/lib.rs
+++ b/network/socket-bench-server/src/lib.rs
@@ -91,7 +91,7 @@ pub fn build_memsocket_noise_transport() -> impl Transport<Output = NoiseStream<
         let noise_config = Arc::new(NoiseUpgrader::new(
             NetworkContext::mock_with_peer_id(peer_id),
             private,
-            HandshakeAuthMode::ServerOnly,
+            HandshakeAuthMode::server_only(),
         ));
         let remote_public_key = addr.find_noise_proto();
         let (_remote_static_key, socket) = noise_config
@@ -112,7 +112,7 @@ pub fn build_tcp_noise_transport() -> impl Transport<Output = NoiseStream<TcpSoc
         let noise_config = Arc::new(NoiseUpgrader::new(
             NetworkContext::mock_with_peer_id(peer_id),
             private,
-            HandshakeAuthMode::ServerOnly,
+            HandshakeAuthMode::server_only(),
         ));
         let remote_public_key = addr.find_noise_proto();
         let (_remote_static_key, socket) = noise_config

--- a/network/src/noise/fuzzing.rs
+++ b/network/src/noise/fuzzing.rs
@@ -91,7 +91,7 @@ fn generate_first_two_messages() -> (Vec<u8>, Vec<u8>) {
 
     // take result
     let initiator_session = initiator_session.unwrap();
-    let (responder_session, peer_id) = responder_session.unwrap();
+    let (responder_session, peer_id, _) = responder_session.unwrap();
 
     // some sanity checks
     assert_eq!(initiator_session.get_remote_static(), responder_public_key);

--- a/network/src/noise/fuzzing.rs
+++ b/network/src/noise/fuzzing.rs
@@ -68,12 +68,12 @@ fn generate_first_two_messages() -> (Vec<u8>, Vec<u8>) {
     let initiator = NoiseUpgrader::new(
         NetworkContext::mock_with_peer_id(initiator_peer_id),
         initiator_private_key,
-        HandshakeAuthMode::ServerOnly,
+        HandshakeAuthMode::server_only(),
     );
     let responder = NoiseUpgrader::new(
         NetworkContext::mock_with_peer_id(responder_peer_id),
         responder_private_key,
-        HandshakeAuthMode::ServerOnly,
+        HandshakeAuthMode::server_only(),
     );
 
     // create exposing socket
@@ -133,7 +133,7 @@ pub fn fuzz_initiator(data: &[u8]) {
     let initiator = NoiseUpgrader::new(
         NetworkContext::mock_with_peer_id(initiator_peer_id),
         initiator_private_key,
-        HandshakeAuthMode::ServerOnly,
+        HandshakeAuthMode::server_only(),
     );
 
     // setup NoiseStream
@@ -151,7 +151,7 @@ pub fn fuzz_responder(data: &[u8]) {
     let responder = NoiseUpgrader::new(
         NetworkContext::mock_with_peer_id(responder_peer_id),
         responder_private_key,
-        HandshakeAuthMode::ServerOnly,
+        HandshakeAuthMode::server_only(),
     );
 
     // setup NoiseStream

--- a/network/src/noise/mod.rs
+++ b/network/src/noise/mod.rs
@@ -68,7 +68,7 @@
 //!
 //! let mut client_session = client_session
 //!     .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
-//! let (mut server_session, _client_peer_id) = server_session
+//! let (mut server_session, _client_peer_id, _trust_level) = server_session
 //!     .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
 //!
 //! // client -> server

--- a/network/src/noise/stream.rs
+++ b/network/src/noise/stream.rs
@@ -608,7 +608,7 @@ mod test {
 
         //
         let client_session = client_session.unwrap();
-        let (server_session, _) = server_session.unwrap();
+        let (server_session, _, _) = server_session.unwrap();
         (client_session, server_session)
     }
 
@@ -714,7 +714,7 @@ mod test {
 
         // get session
         let mut client = client.unwrap();
-        let (mut server, _) = server.unwrap();
+        let (mut server, _, _) = server.unwrap();
 
         // test send and receive
         block_on(client.write_all(b"The Name of the Wind")).unwrap();

--- a/network/src/noise/stream.rs
+++ b/network/src/noise/stream.rs
@@ -580,12 +580,12 @@ mod test {
         let client = NoiseUpgrader::new(
             NetworkContext::mock_with_peer_id(client_peer_id),
             client_private,
-            HandshakeAuthMode::ServerOnly,
+            HandshakeAuthMode::server_only(),
         );
         let server = NoiseUpgrader::new(
             NetworkContext::mock_with_peer_id(server_peer_id),
             server_private,
-            HandshakeAuthMode::ServerOnly,
+            HandshakeAuthMode::server_only(),
         );
 
         ((client, client_public), (server, server_public))

--- a/network/src/peer/fuzzing.rs
+++ b/network/src/peer/fuzzing.rs
@@ -9,7 +9,7 @@ use crate::{
         messaging::v1::{NetworkMessage, NetworkMessageSink},
     },
     testutils::fake_socket::ReadOnlyTestSocketVec,
-    transport::{Connection, ConnectionId, ConnectionMetadata},
+    transport::{Connection, ConnectionId, ConnectionMetadata, TrustLevel},
     ProtocolId,
 };
 use diem_config::network_id::NetworkContext;
@@ -93,6 +93,7 @@ pub fn fuzz(data: &[u8]) {
             ]
             .iter(),
         ),
+        TrustLevel::Untrusted,
     );
     let connection = Connection { socket, metadata };
 

--- a/network/src/peer/test.rs
+++ b/network/src/peer/test.rs
@@ -15,7 +15,7 @@ use crate::{
             },
         },
     },
-    transport::{Connection, ConnectionId, ConnectionMetadata},
+    transport::{Connection, ConnectionId, ConnectionMetadata, TrustLevel},
     ProtocolId,
 };
 use bytes::Bytes;
@@ -59,6 +59,7 @@ fn build_test_peer(
             origin,
             MessagingProtocolVersion::V1,
             [].iter().into(),
+            TrustLevel::Untrusted,
         ),
         socket: a,
     };

--- a/network/src/peer_manager/tests.rs
+++ b/network/src/peer_manager/tests.rs
@@ -13,7 +13,7 @@ use crate::{
         messaging::v1::{ErrorCode, NetworkMessage, NetworkMessageSink, NetworkMessageStream},
     },
     transport,
-    transport::{Connection, ConnectionId, ConnectionMetadata},
+    transport::{Connection, ConnectionId, ConnectionMetadata, TrustLevel},
     ProtocolId,
 };
 use anyhow::anyhow;
@@ -51,6 +51,7 @@ pub fn build_test_transport(
                     origin,
                     MessagingProtocolVersion::V1,
                     [TEST_PROTOCOL].iter().into(),
+                    TrustLevel::Untrusted,
                 ),
             })
         })
@@ -229,6 +230,7 @@ fn create_connection<TSocket: transport::TSocket>(
             origin,
             MessagingProtocolVersion::V1,
             [TEST_PROTOCOL].iter().into(),
+            TrustLevel::Untrusted,
         ),
     }
 }
@@ -553,6 +555,7 @@ fn peer_manager_simultaneous_dial_disconnect_event() {
                 ConnectionOrigin::Inbound,
                 MessagingProtocolVersion::V1,
                 [TEST_PROTOCOL].iter().into(),
+                TrustLevel::Untrusted,
             ),
             DisconnectReason::ConnectionLost,
         );
@@ -610,6 +613,7 @@ fn test_dial_disconnect() {
                 ConnectionOrigin::Outbound,
                 MessagingProtocolVersion::V1,
                 [TEST_PROTOCOL].iter().into(),
+                TrustLevel::Untrusted,
             ),
             DisconnectReason::Requested,
         );

--- a/network/src/transport/mod.rs
+++ b/network/src/transport/mod.rs
@@ -14,7 +14,6 @@ use diem_config::{
     network_id::{NetworkContext, NetworkId},
 };
 use diem_crypto::x25519;
-use diem_infallible::RwLock;
 use diem_logger::prelude::*;
 use diem_network_address::{parse_dns_tcp, parse_ip_tcp, parse_memory, NetworkAddress};
 use diem_types::{chain_id::ChainId, PeerId};
@@ -26,7 +25,7 @@ use futures::{
 use netcore::transport::{proxy_protocol, tcp, ConnectionOrigin, Transport};
 use serde::{export::Formatter, Serialize};
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::BTreeMap,
     convert::TryFrom,
     fmt::Debug,
     io,
@@ -408,7 +407,7 @@ where
         base_transport: TTransport,
         network_context: Arc<NetworkContext>,
         identity_key: x25519::PrivateKey,
-        trusted_peers: Option<Arc<RwLock<HashMap<PeerId, HashSet<x25519::PublicKey>>>>>,
+        auth_mode: HandshakeAuthMode,
         handshake_version: u8,
         chain_id: ChainId,
         application_protocols: SupportedProtocols,
@@ -418,12 +417,6 @@ where
         let mut supported_protocols = BTreeMap::new();
         supported_protocols.insert(SUPPORTED_MESSAGING_PROTOCOL, application_protocols);
 
-        // create upgrade context
-        // TODO(mimoo): should we build this based on the networkid, and not on trusted peers
-        let auth_mode = match trusted_peers.as_ref() {
-            Some(trusted_peers) => HandshakeAuthMode::mutual(trusted_peers.clone()),
-            None => HandshakeAuthMode::server_only(),
-        };
         let identity_pubkey = identity_key.public_key();
         let network_id = network_context.network_id().clone();
 


### PR DESCRIPTION
Enable having "trusted peers" even in non-validator networks.

Ref #6790