### PR TITLE
updating guppy-summaries

### DIFF
--- a/devtools/x/src/diff_summary.rs
+++ b/devtools/x/src/diff_summary.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::context::XContext;
+use anyhow::anyhow;
 use guppy::graph::summaries::{diff::SummaryDiff, Summary};
 use std::{fs, path::PathBuf};
 use structopt::StructOpt;
@@ -30,7 +31,8 @@ pub fn run(args: Args, _xctx: XContext) -> crate::Result<()> {
     match args.output_format.as_deref() {
         Some("json") => println!("{}", serde_json::to_string(&summary_diff)?),
         Some("toml") => println!("{}", toml::to_string(&summary_diff)?),
-        _ => println!("{}", summary_diff.report()),
+        Some("text") | None => println!("{}", summary_diff.report()),
+        _ => return Err(anyhow!("--output-format only accepts json, html or text")),
     };
 
     Ok(())

--- a/devtools/x/src/diff_summary.rs
+++ b/devtools/x/src/diff_summary.rs
@@ -14,6 +14,9 @@ pub struct Args {
     #[structopt(name = "COMPARE_SUMMARY")]
     /// Path to the comparison summary
     compare_summary: PathBuf,
+    #[structopt(name = "OUTPUT_FORMAT")]
+    /// optionally, output can be formated as json or toml
+    output_format: Option<String>,
 }
 
 pub fn run(args: Args, _xctx: XContext) -> crate::Result<()> {
@@ -23,6 +26,12 @@ pub fn run(args: Args, _xctx: XContext) -> crate::Result<()> {
     let compare_summary = Summary::parse(&compare_summary_text)?;
 
     let summary_diff = SummaryDiff::new(&base_summary, &compare_summary);
-    println!("{}", summary_diff.report());
+
+    match args.output_format.as_deref() {
+        Some("json") => println!("{}", serde_json::to_string(&summary_diff)?),
+        Some("toml") => println!("{}", toml::to_string(&summary_diff)?),
+        _ => println!("{}", summary_diff.report()),
+    };
+
     Ok(())
 }


### PR DESCRIPTION
<img width="998" alt="Screen Shot 2020-12-09 at 4 37 39 PM" src="https://user-images.githubusercontent.com/1316043/101705908-dd4a1280-3a3c-11eb-9814-8cdbda0f9b24.png">

<img width="1014" alt="Screen Shot 2020-12-09 at 4 38 38 PM" src="https://user-images.githubusercontent.com/1316043/101705966-ff439500-3a3c-11eb-9fd3-95eed34ace6b.png">

weirdly the output doesn't show that guppy-summaries has changed as well:

<details>
```json
{
  "target-packages": {
    "changed": [
      {
        "name": "serde",
        "version": "1.0.117",
        "crates-io": true,
        "change": "modified",
        "old-version": "1.0.118",
        "old-source": null,
        "old-status": null,
        "new-status": "direct",
        "added-features": [],
        "removed-features": [],
        "unchanged-features": [
          "alloc",
          "default",
          "derive",
          "rc",
          "serde_derive",
          "std"
        ]
      }
    ],
    "unchanged": [
      {
        "name": "abigen",
        "version": "0.1.0",
        "workspace-path": "language/move-prover/abigen",
        "status": "workspace",
        "features": []
      },
      {
        "name": "accumulator",
        "version": "0.1.0",
        "workspace-path": "storage/accumulator",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "addr2line",
        "version": "0.14.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "adler",
        "version": "0.2.3",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "aead",
        "version": "0.3.2",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "alloc"
        ]
      },
      {
        "name": "aes",
        "version": "0.6.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "aes-gcm",
        "version": "0.8.0",
        "crates-io": true,
        "status": "direct",
        "features": [
          "aes",
          "alloc",
          "default"
        ]
      },
      {
        "name": "aesni",
        "version": "0.10.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "aho-corasick",
        "version": "0.7.15",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "std"
        ]
      },
      {
        "name": "ansi_term",
        "version": "0.11.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "anyhow",
        "version": "1.0.34",
        "crates-io": true,
        "status": "direct",
        "features": [
          "default",
          "std"
        ]
      },
      {
        "name": "arc-swap",
        "version": "1.0.0",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "arrayvec",
        "version": "0.5.2",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "std"
        ]
      },
      {
        "name": "atty",
        "version": "0.2.14",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "backtrace",
        "version": "0.3.55",
        "crates-io": true,
        "status": "direct",
        "features": [
          "addr2line",
          "default",
          "gimli-symbolize",
          "miniz_oxide",
          "object",
          "std"
        ]
      },
      {
        "name": "backup-cli",
        "version": "0.1.0",
        "workspace-path": "storage/backup/backup-cli",
        "status": "initial",
        "features": []
      },
      {
        "name": "backup-service",
        "version": "0.1.0",
        "workspace-path": "storage/backup/backup-service",
        "status": "workspace",
        "features": []
      },
      {
        "name": "base64",
        "version": "0.12.3",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "std"
        ]
      },
      {
        "name": "base64",
        "version": "0.13.0",
        "crates-io": true,
        "status": "direct",
        "features": [
          "default",
          "std"
        ]
      },
      {
        "name": "bincode",
        "version": "1.3.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "bitflags",
        "version": "1.2.1",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default"
        ]
      },
      {
        "name": "block-buffer",
        "version": "0.7.3",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "block-buffer",
        "version": "0.9.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "block-padding",
        "version": "0.1.5",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "borrow-graph",
        "version": "0.0.1",
        "workspace-path": "language/borrow-graph",
        "status": "workspace",
        "features": []
      },
      {
        "name": "bounded-executor",
        "version": "0.1.0",
        "workspace-path": "common/bounded-executor",
        "status": "workspace",
        "features": []
      },
      {
        "name": "buf_redux",
        "version": "0.8.4",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "byte-tools",
        "version": "0.3.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "bytecode",
        "version": "0.1.0",
        "workspace-path": "language/move-prover/bytecode",
        "status": "workspace",
        "features": []
      },
      {
        "name": "bytecode-source-map",
        "version": "0.1.0",
        "workspace-path": "language/compiler/bytecode-source-map",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "bytecode-verifier",
        "version": "0.1.0",
        "workspace-path": "language/bytecode-verifier",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "byteorder",
        "version": "1.3.4",
        "crates-io": true,
        "status": "direct",
        "features": [
          "default",
          "i128",
          "std"
        ]
      },
      {
        "name": "bytes",
        "version": "0.5.6",
        "crates-io": true,
        "status": "direct",
        "features": [
          "default",
          "serde",
          "std"
        ]
      },
      {
        "name": "c_linked_list",
        "version": "1.1.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "cfg-if",
        "version": "0.1.10",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "cfg-if",
        "version": "1.0.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "channel",
        "version": "0.1.0",
        "workspace-path": "common/channel",
        "status": "workspace",
        "features": []
      },
      {
        "name": "chrono",
        "version": "0.4.19",
        "crates-io": true,
        "status": "direct",
        "features": [
          "clock",
          "default",
          "libc",
          "oldtime",
          "std",
          "time",
          "winapi"
        ]
      },
      {
        "name": "chunked_transfer",
        "version": "1.3.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "cipher",
        "version": "0.2.5",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "clap",
        "version": "2.33.3",
        "crates-io": true,
        "status": "direct",
        "features": [
          "ansi_term",
          "atty",
          "color",
          "default",
          "strsim",
          "suggestions",
          "vec_map"
        ]
      },
      {
        "name": "codespan",
        "version": "0.8.0",
        "crates-io": true,
        "status": "direct",
        "features": [
          "serde",
          "serialization"
        ]
      },
      {
        "name": "codespan-reporting",
        "version": "0.8.0",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "compiled-stdlib",
        "version": "0.1.0",
        "workspace-path": "language/stdlib/compiled",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "consensus",
        "version": "0.1.0",
        "workspace-path": "consensus",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "consensus-types",
        "version": "0.1.0",
        "workspace-path": "consensus/consensus-types",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "cpuid-bool",
        "version": "0.1.2",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "crash-handler",
        "version": "0.1.0",
        "workspace-path": "common/crash-handler",
        "status": "workspace",
        "features": []
      },
      {
        "name": "crossbeam-channel",
        "version": "0.5.0",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "crossbeam-utils",
          "default",
          "std"
        ]
      },
      {
        "name": "crossbeam-deque",
        "version": "0.8.0",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "crossbeam-epoch",
          "crossbeam-utils",
          "default",
          "std"
        ]
      },
      {
        "name": "crossbeam-epoch",
        "version": "0.9.0",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "alloc",
          "lazy_static",
          "std"
        ]
      },
      {
        "name": "crossbeam-utils",
        "version": "0.7.2",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "lazy_static",
          "std"
        ]
      },
      {
        "name": "crossbeam-utils",
        "version": "0.8.0",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "lazy_static",
          "std"
        ]
      },
      {
        "name": "crunchy",
        "version": "0.2.2",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "limit_128"
        ]
      },
      {
        "name": "crypto-mac",
        "version": "0.10.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "ctr",
        "version": "0.6.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "curve25519-dalek",
        "version": "3.0.0",
        "source": "git+https://github.com/novifinancial/curve25519-dalek.git?branch=fiat3#2940429efd0e6482af1531cff079e6605cbc9cf2",
        "status": "direct",
        "features": [
          "alloc",
          "fiat-crypto",
          "fiat_u64_backend",
          "std"
        ]
      },
      {
        "name": "datatest-stable",
        "version": "0.1.0",
        "workspace-path": "common/datatest-stable",
        "status": "workspace",
        "features": []
      },
      {
        "name": "db-bootstrapper",
        "version": "0.1.0",
        "workspace-path": "execution/db-bootstrapper",
        "status": "initial",
        "features": []
      },
      {
        "name": "debug-interface",
        "version": "0.1.0",
        "workspace-path": "common/debug-interface",
        "status": "workspace",
        "features": []
      },
      {
        "name": "diem-bitvec",
        "version": "0.1.0",
        "workspace-path": "common/bitvec",
        "status": "workspace",
        "features": []
      },
      {
        "name": "diem-config",
        "version": "0.1.0",
        "workspace-path": "config",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "diem-crypto",
        "version": "0.1.0",
        "workspace-path": "crypto/crypto",
        "status": "workspace",
        "features": [
          "curve25519-dalek",
          "default",
          "ed25519-dalek",
          "fiat",
          "x25519-dalek"
        ]
      },
      {
        "name": "diem-genesis-tool",
        "version": "0.1.0",
        "workspace-path": "config/management/genesis",
        "status": "initial",
        "features": [
          "testing"
        ]
      },
      {
        "name": "diem-github-client",
        "version": "0.1.0",
        "workspace-path": "secure/storage/github",
        "status": "workspace",
        "features": []
      },
      {
        "name": "diem-global-constants",
        "version": "0.1.0",
        "workspace-path": "config/global-constants",
        "status": "workspace",
        "features": []
      },
      {
        "name": "diem-infallible",
        "version": "0.1.0",
        "workspace-path": "common/infallible",
        "status": "workspace",
        "features": []
      },
      {
        "name": "diem-jellyfish-merkle",
        "version": "0.1.0",
        "workspace-path": "storage/jellyfish-merkle",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "diem-json-rpc",
        "version": "0.1.0",
        "workspace-path": "json-rpc",
        "status": "workspace",
        "features": []
      },
      {
        "name": "diem-json-rpc-types",
        "version": "0.1.0",
        "workspace-path": "json-rpc/types",
        "status": "workspace",
        "features": []
      },
      {
        "name": "diem-key-manager",
        "version": "0.1.0",
        "workspace-path": "secure/key-manager",
        "status": "initial",
        "features": []
      },
      {
        "name": "diem-logger",
        "version": "0.1.0",
        "workspace-path": "common/logger",
        "status": "workspace",
        "features": []
      },
      {
        "name": "diem-management",
        "version": "0.1.0",
        "workspace-path": "config/management",
        "status": "workspace",
        "features": []
      },
      {
        "name": "diem-mempool",
        "version": "0.1.0",
        "workspace-path": "mempool",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "diem-metrics",
        "version": "0.1.0",
        "workspace-path": "common/metrics",
        "status": "workspace",
        "features": []
      },
      {
        "name": "diem-metrics-core",
        "version": "0.1.0",
        "workspace-path": "common/metrics-core",
        "status": "workspace",
        "features": []
      },
      {
        "name": "diem-network-address",
        "version": "0.1.0",
        "workspace-path": "network/network-address",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "diem-network-address-encryption",
        "version": "0.1.0",
        "workspace-path": "config/management/network-address-encryption",
        "status": "workspace",
        "features": []
      },
      {
        "name": "diem-nibble",
        "version": "0.1.0",
        "workspace-path": "common/nibble",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "diem-node",
        "version": "0.1.0",
        "workspace-path": "diem-node",
        "status": "initial",
        "features": [
          "default"
        ]
      },
      {
        "name": "diem-secure-json-rpc",
        "version": "0.1.0",
        "workspace-path": "secure/json-rpc",
        "status": "workspace",
        "features": []
      },
      {
        "name": "diem-secure-net",
        "version": "0.1.0",
        "workspace-path": "secure/net",
        "status": "workspace",
        "features": []
      },
      {
        "name": "diem-secure-push-metrics",
        "version": "0.1.0",
        "workspace-path": "secure/push-metrics",
        "status": "workspace",
        "features": []
      },
      {
        "name": "diem-secure-storage",
        "version": "0.1.0",
        "workspace-path": "secure/storage",
        "status": "workspace",
        "features": []
      },
      {
        "name": "diem-secure-time",
        "version": "0.1.0",
        "workspace-path": "secure/time",
        "status": "workspace",
        "features": []
      },
      {
        "name": "diem-state-view",
        "version": "0.1.0",
        "workspace-path": "storage/state-view",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "diem-temppath",
        "version": "0.1.0",
        "workspace-path": "common/temppath",
        "status": "workspace",
        "features": []
      },
      {
        "name": "diem-trace",
        "version": "0.1.0",
        "workspace-path": "common/trace",
        "status": "workspace",
        "features": []
      },
      {
        "name": "diem-types",
        "version": "0.1.0",
        "workspace-path": "types",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "diem-vault-client",
        "version": "0.1.0",
        "workspace-path": "secure/storage/vault",
        "status": "workspace",
        "features": []
      },
      {
        "name": "diem-vm",
        "version": "0.1.0",
        "workspace-path": "language/diem-vm",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "diemdb",
        "version": "0.1.0",
        "workspace-path": "storage/diemdb",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "difference",
        "version": "2.0.0",
        "crates-io": true,
        "status": "direct",
        "features": [
          "default"
        ]
      },
      {
        "name": "digest",
        "version": "0.8.1",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "std"
        ]
      },
      {
        "name": "digest",
        "version": "0.9.0",
        "crates-io": true,
        "status": "direct",
        "features": [
          "alloc",
          "std"
        ]
      },
      {
        "name": "docgen",
        "version": "0.1.0",
        "workspace-path": "language/move-prover/docgen",
        "status": "workspace",
        "features": []
      },
      {
        "name": "dtoa",
        "version": "0.4.6",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "ed25519",
        "version": "1.0.3",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "serde",
          "std"
        ]
      },
      {
        "name": "ed25519-dalek",
        "version": "1.0.1",
        "source": "git+https://github.com/novifinancial/ed25519-dalek.git?branch=fiat5#88603ebf0196015e9b4106844f9f47ed6c01e951",
        "status": "direct",
        "features": [
          "fiat_u64_backend",
          "rand",
          "serde",
          "serde_bytes",
          "serde_crate",
          "std"
        ]
      },
      {
        "name": "either",
        "version": "1.6.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "encoding_rs",
        "version": "0.8.26",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "erased-serde",
        "version": "0.3.12",
        "crates-io": true,
        "status": "direct",
        "features": [
          "default",
          "std"
        ]
      },
      {
        "name": "errmapgen",
        "version": "0.1.0",
        "workspace-path": "language/move-prover/errmapgen",
        "status": "workspace",
        "features": []
      },
      {
        "name": "execution-correctness",
        "version": "0.1.0",
        "workspace-path": "execution/execution-correctness",
        "status": "workspace",
        "features": []
      },
      {
        "name": "executor",
        "version": "0.1.0",
        "workspace-path": "execution/executor",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "executor-types",
        "version": "0.1.0",
        "workspace-path": "execution/executor-types",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "fail",
        "version": "0.4.0",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "fake-simd",
        "version": "0.1.2",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "fiat-crypto",
        "version": "0.1.5",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "fixedbitset",
        "version": "0.2.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "fnv",
        "version": "1.0.7",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "std"
        ]
      },
      {
        "name": "foreign-types",
        "version": "0.3.2",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "foreign-types-shared",
        "version": "0.1.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "form_urlencoded",
        "version": "1.0.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "futures",
        "version": "0.1.30",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "use_std",
          "with-deprecated"
        ]
      },
      {
        "name": "futures",
        "version": "0.3.8",
        "crates-io": true,
        "status": "direct",
        "features": [
          "alloc",
          "async-await",
          "default",
          "executor",
          "futures-executor",
          "std"
        ]
      },
      {
        "name": "futures-channel",
        "version": "0.3.8",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "alloc",
          "default",
          "futures-sink",
          "sink",
          "std"
        ]
      },
      {
        "name": "futures-core",
        "version": "0.3.8",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "alloc",
          "default",
          "std"
        ]
      },
      {
        "name": "futures-executor",
        "version": "0.3.8",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "std"
        ]
      },
      {
        "name": "futures-io",
        "version": "0.3.8",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "std"
        ]
      },
      {
        "name": "futures-sink",
        "version": "0.3.8",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "alloc",
          "default",
          "std"
        ]
      },
      {
        "name": "futures-task",
        "version": "0.3.8",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "alloc",
          "once_cell",
          "std"
        ]
      },
      {
        "name": "futures-util",
        "version": "0.3.8",
        "crates-io": true,
        "status": "direct",
        "features": [
          "alloc",
          "async-await",
          "async-await-macro",
          "channel",
          "default",
          "futures-channel",
          "futures-io",
          "futures-macro",
          "futures-sink",
          "io",
          "memchr",
          "proc-macro-hack",
          "proc-macro-nested",
          "sink",
          "slab",
          "std"
        ]
      },
      {
        "name": "generate-key",
        "version": "0.1.0",
        "workspace-path": "config/generate-key",
        "status": "workspace",
        "features": []
      },
      {
        "name": "generic-array",
        "version": "0.12.3",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "generic-array",
        "version": "0.14.4",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "get_if_addrs",
        "version": "0.5.3",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "getrandom",
        "version": "0.1.15",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "std"
        ]
      },
      {
        "name": "ghash",
        "version": "0.3.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "gimli",
        "version": "0.23.0",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "read"
        ]
      },
      {
        "name": "glob",
        "version": "0.3.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "h2",
        "version": "0.2.7",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "handlebars",
        "version": "3.5.1",
        "crates-io": true,
        "status": "direct",
        "features": [
          "default"
        ]
      },
      {
        "name": "hashbrown",
        "version": "0.9.1",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "raw"
        ]
      },
      {
        "name": "headers",
        "version": "0.3.2",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "headers-core",
        "version": "0.2.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "heck",
        "version": "0.3.1",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "hex",
        "version": "0.4.2",
        "crates-io": true,
        "status": "direct",
        "features": [
          "default",
          "std"
        ]
      },
      {
        "name": "hkdf",
        "version": "0.10.0",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "hmac",
        "version": "0.10.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "hostname",
        "version": "0.3.1",
        "crates-io": true,
        "status": "direct",
        "features": [
          "default"
        ]
      },
      {
        "name": "http",
        "version": "0.2.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "http-body",
        "version": "0.3.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "httparse",
        "version": "1.3.4",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "std"
        ]
      },
      {
        "name": "httpdate",
        "version": "0.3.2",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "hyper",
        "version": "0.13.9",
        "crates-io": true,
        "status": "direct",
        "features": [
          "default",
          "runtime",
          "socket2",
          "stream",
          "tcp"
        ]
      },
      {
        "name": "idna",
        "version": "0.2.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "include_dir",
        "version": "0.6.0",
        "crates-io": true,
        "status": "direct",
        "features": [
          "default",
          "glob",
          "search"
        ]
      },
      {
        "name": "indexmap",
        "version": "1.6.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "input_buffer",
        "version": "0.3.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "instant",
        "version": "0.1.8",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "iovec",
        "version": "0.1.4",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "ipnet",
        "version": "2.3.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "ir-to-bytecode",
        "version": "0.1.0",
        "workspace-path": "language/compiler/ir-to-bytecode",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "ir-to-bytecode-syntax",
        "version": "0.1.0",
        "workspace-path": "language/compiler/ir-to-bytecode/syntax",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "itertools",
        "version": "0.9.0",
        "crates-io": true,
        "status": "direct",
        "features": [
          "default",
          "use_std"
        ]
      },
      {
        "name": "itoa",
        "version": "0.4.6",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "std"
        ]
      },
      {
        "name": "jemalloc-sys",
        "version": "0.3.2",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "background_threads_runtime_support",
          "profiling",
          "unprefixed_malloc_on_supported_platforms"
        ]
      },
      {
        "name": "jemallocator",
        "version": "0.3.2",
        "crates-io": true,
        "status": "direct",
        "features": [
          "background_threads_runtime_support",
          "default",
          "profiling",
          "unprefixed_malloc_on_supported_platforms"
        ]
      },
      {
        "name": "lazy_static",
        "version": "1.4.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "libc",
        "version": "0.2.80",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "std"
        ]
      },
      {
        "name": "libra-canonical-serialization",
        "version": "0.1.0",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "librocksdb-sys",
        "version": "6.11.4",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "lz4",
          "static"
        ]
      },
      {
        "name": "linked-hash-map",
        "version": "0.5.3",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "lock_api",
        "version": "0.4.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "log",
        "version": "0.4.11",
        "crates-io": true,
        "status": "direct",
        "features": [
          "serde",
          "std"
        ]
      },
      {
        "name": "maplit",
        "version": "1.0.2",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "match_cfg",
        "version": "0.1.0",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "use_core"
        ]
      },
      {
        "name": "matches",
        "version": "0.1.8",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "memchr",
        "version": "2.3.4",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "std",
          "use_std"
        ]
      },
      {
        "name": "memoffset",
        "version": "0.5.6",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default"
        ]
      },
      {
        "name": "mime",
        "version": "0.3.16",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "mime_guess",
        "version": "2.0.3",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "rev-mappings"
        ]
      },
      {
        "name": "miniz_oxide",
        "version": "0.4.3",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "mio",
        "version": "0.6.22",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "with-deprecated"
        ]
      },
      {
        "name": "mio-uds",
        "version": "0.6.8",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "mirai-annotations",
        "version": "1.10.1",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "move-core-types",
        "version": "0.1.0",
        "workspace-path": "language/move-core/types",
        "status": "workspace",
        "features": [
          "default",
          "fiat"
        ]
      },
      {
        "name": "move-explain",
        "version": "0.1.0",
        "workspace-path": "language/tools/move-explain",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "move-ir-types",
        "version": "0.1.0",
        "workspace-path": "language/move-ir/types",
        "status": "workspace",
        "features": []
      },
      {
        "name": "move-lang",
        "version": "0.0.1",
        "workspace-path": "language/move-lang",
        "status": "workspace",
        "features": []
      },
      {
        "name": "move-prover",
        "version": "0.1.0",
        "workspace-path": "language/move-prover",
        "status": "workspace",
        "features": []
      },
      {
        "name": "move-vm-natives",
        "version": "0.1.0",
        "workspace-path": "language/move-vm/natives",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "move-vm-runtime",
        "version": "0.1.0",
        "workspace-path": "language/move-vm/runtime",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "move-vm-types",
        "version": "0.1.0",
        "workspace-path": "language/move-vm/types",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "multipart",
        "version": "0.17.0",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "buf_redux",
          "httparse",
          "quick-error",
          "safemem",
          "server",
          "twoway"
        ]
      },
      {
        "name": "native-tls",
        "version": "0.2.6",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "net2",
        "version": "0.2.35",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "duration"
        ]
      },
      {
        "name": "netcore",
        "version": "0.1.0",
        "workspace-path": "network/netcore",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "network",
        "version": "0.1.0",
        "workspace-path": "network",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "network-builder",
        "version": "0.1.0",
        "workspace-path": "network/builder",
        "status": "workspace",
        "features": []
      },
      {
        "name": "network-simple-onchain-discovery",
        "version": "0.1.0",
        "workspace-path": "network/simple-onchain-discovery",
        "status": "workspace",
        "features": []
      },
      {
        "name": "num",
        "version": "0.3.1",
        "crates-io": true,
        "status": "direct",
        "features": [
          "default",
          "num-bigint",
          "std"
        ]
      },
      {
        "name": "num-bigint",
        "version": "0.3.1",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "std"
        ]
      },
      {
        "name": "num-complex",
        "version": "0.3.1",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "std"
        ]
      },
      {
        "name": "num-integer",
        "version": "0.1.44",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "i128",
          "std"
        ]
      },
      {
        "name": "num-iter",
        "version": "0.1.42",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "i128",
          "std"
        ]
      },
      {
        "name": "num-rational",
        "version": "0.3.2",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "num-bigint",
          "num-bigint-std",
          "std"
        ]
      },
      {
        "name": "num-traits",
        "version": "0.2.14",
        "crates-io": true,
        "status": "direct",
        "features": [
          "default",
          "i128",
          "std"
        ]
      },
      {
        "name": "num_cpus",
        "version": "1.13.0",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "numtoa",
        "version": "0.1.0",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "std"
        ]
      },
      {
        "name": "object",
        "version": "0.22.0",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "archive",
          "coff",
          "elf",
          "macho",
          "pe",
          "read_core",
          "unaligned"
        ]
      },
      {
        "name": "once_cell",
        "version": "1.5.2",
        "crates-io": true,
        "status": "direct",
        "features": [
          "alloc",
          "default",
          "std"
        ]
      },
      {
        "name": "opaque-debug",
        "version": "0.2.3",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "opaque-debug",
        "version": "0.3.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "openssl",
        "version": "0.10.30",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "openssl-probe",
        "version": "0.1.2",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "openssl-sys",
        "version": "0.9.58",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "parking_lot",
        "version": "0.11.0",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default"
        ]
      },
      {
        "name": "parking_lot_core",
        "version": "0.8.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "percent-encoding",
        "version": "2.1.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "pest",
        "version": "2.1.3",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "petgraph",
        "version": "0.5.1",
        "crates-io": true,
        "status": "direct",
        "features": [
          "default",
          "graphmap",
          "matrix_graph",
          "stable_graph"
        ]
      },
      {
        "name": "pin-project",
        "version": "0.4.27",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "pin-project",
        "version": "1.0.2",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "pin-project-lite",
        "version": "0.1.11",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "pin-project-lite",
        "version": "0.2.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "pin-utils",
        "version": "0.1.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "polyval",
        "version": "0.4.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "ppv-lite86",
        "version": "0.2.10",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "simd",
          "std"
        ]
      },
      {
        "name": "pretty",
        "version": "0.10.0",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "proc-macro-nested",
        "version": "0.1.6",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "prometheus",
        "version": "0.11.0",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "prost",
        "version": "0.6.1",
        "crates-io": true,
        "status": "direct",
        "features": [
          "default",
          "prost-derive"
        ]
      },
      {
        "name": "qstring",
        "version": "0.7.2",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "quick-error",
        "version": "1.2.3",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "quick-error",
        "version": "2.0.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "rand",
        "version": "0.4.6",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "libc",
          "std"
        ]
      },
      {
        "name": "rand",
        "version": "0.6.5",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "alloc",
          "default",
          "rand_os",
          "std"
        ]
      },
      {
        "name": "rand",
        "version": "0.7.3",
        "crates-io": true,
        "status": "direct",
        "features": [
          "alloc",
          "default",
          "getrandom",
          "getrandom_package",
          "libc",
          "rand_pcg",
          "small_rng",
          "std"
        ]
      },
      {
        "name": "rand_chacha",
        "version": "0.1.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "rand_chacha",
        "version": "0.2.2",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "std"
        ]
      },
      {
        "name": "rand_core",
        "version": "0.3.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "rand_core",
        "version": "0.4.2",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "alloc",
          "std"
        ]
      },
      {
        "name": "rand_core",
        "version": "0.5.1",
        "crates-io": true,
        "status": "direct",
        "features": [
          "alloc",
          "getrandom",
          "std"
        ]
      },
      {
        "name": "rand_hc",
        "version": "0.1.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "rand_isaac",
        "version": "0.1.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "rand_jitter",
        "version": "0.1.4",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "std"
        ]
      },
      {
        "name": "rand_os",
        "version": "0.1.3",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "rand_pcg",
        "version": "0.1.2",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "rand_pcg",
        "version": "0.2.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "rand_xorshift",
        "version": "0.1.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "rayon",
        "version": "1.5.0",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "rayon-core",
        "version": "1.9.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "ref-cast",
        "version": "1.0.3",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "regex",
        "version": "1.4.2",
        "crates-io": true,
        "status": "direct",
        "features": [
          "aho-corasick",
          "default",
          "memchr",
          "perf",
          "perf-cache",
          "perf-dfa",
          "perf-inline",
          "perf-literal",
          "std",
          "thread_local",
          "unicode",
          "unicode-age",
          "unicode-bool",
          "unicode-case",
          "unicode-gencat",
          "unicode-perl",
          "unicode-script",
          "unicode-segment"
        ]
      },
      {
        "name": "regex-syntax",
        "version": "0.6.21",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "unicode",
          "unicode-age",
          "unicode-bool",
          "unicode-case",
          "unicode-gencat",
          "unicode-perl",
          "unicode-script",
          "unicode-segment"
        ]
      },
      {
        "name": "remove_dir_all",
        "version": "0.5.3",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "reqwest",
        "version": "0.10.9",
        "crates-io": true,
        "status": "direct",
        "features": [
          "blocking",
          "json",
          "serde_json",
          "stream"
        ]
      },
      {
        "name": "rocksdb",
        "version": "0.15.0",
        "crates-io": true,
        "status": "direct",
        "features": [
          "lz4"
        ]
      },
      {
        "name": "rustc-demangle",
        "version": "0.1.18",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "ryu",
        "version": "1.0.5",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "safemem",
        "version": "0.3.3",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "std"
        ]
      },
      {
        "name": "safety-rules",
        "version": "0.1.0",
        "workspace-path": "consensus/safety-rules",
        "status": "initial",
        "features": [
          "default"
        ]
      },
      {
        "name": "same-file",
        "version": "1.0.6",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "schemadb",
        "version": "0.1.0",
        "workspace-path": "storage/schemadb",
        "status": "workspace",
        "features": []
      },
      {
        "name": "scoped-tls",
        "version": "1.0.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "scopeguard",
        "version": "1.1.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "scratchpad",
        "version": "0.1.0",
        "workspace-path": "storage/scratchpad",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "serde-generate",
        "version": "0.16.1",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "serde-name",
        "version": "0.1.1",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "serde-reflection",
        "version": "0.3.2",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "serde_bytes",
        "version": "0.11.5",
        "crates-io": true,
        "status": "direct",
        "features": [
          "default",
          "std"
        ]
      },
      {
        "name": "serde_json",
        "version": "1.0.60",
        "crates-io": true,
        "status": "direct",
        "features": [
          "default",
          "std"
        ]
      },
      {
        "name": "serde_urlencoded",
        "version": "0.6.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "serde_urlencoded",
        "version": "0.7.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "serde_yaml",
        "version": "0.8.14",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "sha-1",
        "version": "0.8.2",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "std"
        ]
      },
      {
        "name": "sha-1",
        "version": "0.9.2",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "std"
        ]
      },
      {
        "name": "sha2",
        "version": "0.9.2",
        "crates-io": true,
        "status": "direct",
        "features": [
          "default",
          "std"
        ]
      },
      {
        "name": "short-hex-str",
        "version": "0.1.0",
        "workspace-path": "common/short-hex-str",
        "status": "workspace",
        "features": []
      },
      {
        "name": "signal-hook-registry",
        "version": "1.2.2",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "signature",
        "version": "1.2.2",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "std"
        ]
      },
      {
        "name": "simplelog",
        "version": "0.8.0",
        "crates-io": true,
        "status": "direct",
        "features": [
          "default",
          "termcolor"
        ]
      },
      {
        "name": "slab",
        "version": "0.4.2",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "smallvec",
        "version": "1.4.2",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "socket2",
        "version": "0.3.15",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "spec-lang",
        "version": "0.1.0",
        "workspace-path": "language/move-prover/spec-lang",
        "status": "workspace",
        "features": []
      },
      {
        "name": "state-synchronizer",
        "version": "0.1.0",
        "workspace-path": "state-synchronizer",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "static_assertions",
        "version": "1.1.0",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "stdlib",
        "version": "0.1.0",
        "workspace-path": "language/stdlib",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "storage-client",
        "version": "0.1.0",
        "workspace-path": "storage/storage-client",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "storage-interface",
        "version": "0.1.0",
        "workspace-path": "storage/storage-interface",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "storage-service",
        "version": "0.1.0",
        "workspace-path": "storage/storage-service",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "strsim",
        "version": "0.8.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "structopt",
        "version": "0.3.21",
        "crates-io": true,
        "status": "direct",
        "features": [
          "default"
        ]
      },
      {
        "name": "subscription-service",
        "version": "0.1.0",
        "workspace-path": "common/subscription-service",
        "status": "workspace",
        "features": []
      },
      {
        "name": "subtle",
        "version": "2.3.0",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "std"
        ]
      },
      {
        "name": "tempfile",
        "version": "3.1.0",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "termcolor",
        "version": "1.1.2",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "termion",
        "version": "1.5.5",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "textwrap",
        "version": "0.11.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "textwrap",
        "version": "0.12.1",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "thiserror",
        "version": "1.0.22",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "thread_local",
        "version": "1.0.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "time",
        "version": "0.1.44",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "tiny-keccak",
        "version": "2.0.2",
        "crates-io": true,
        "status": "direct",
        "features": [
          "default",
          "sha3"
        ]
      },
      {
        "name": "tinyvec",
        "version": "0.3.4",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "alloc",
          "default"
        ]
      },
      {
        "name": "tokio",
        "version": "0.2.22",
        "crates-io": true,
        "status": "direct",
        "features": [
          "blocking",
          "default",
          "dns",
          "fnv",
          "fs",
          "full",
          "futures-core",
          "io-driver",
          "io-std",
          "io-util",
          "iovec",
          "lazy_static",
          "libc",
          "macros",
          "memchr",
          "mio",
          "mio-named-pipes",
          "mio-uds",
          "net",
          "num_cpus",
          "process",
          "rt-core",
          "rt-threaded",
          "rt-util",
          "signal",
          "signal-hook-registry",
          "slab",
          "stream",
          "sync",
          "tcp",
          "time",
          "tokio-macros",
          "udp",
          "uds",
          "winapi"
        ]
      },
      {
        "name": "tokio-executor",
        "version": "0.1.10",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "tokio-retry",
        "version": "0.2.0",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "tokio-timer",
        "version": "0.2.13",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "tokio-tungstenite",
        "version": "0.11.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "tokio-util",
        "version": "0.3.1",
        "crates-io": true,
        "status": "direct",
        "features": [
          "codec",
          "compat",
          "default",
          "futures-io"
        ]
      },
      {
        "name": "toml",
        "version": "0.5.7",
        "crates-io": true,
        "status": "direct",
        "features": [
          "default"
        ]
      },
      {
        "name": "tower-service",
        "version": "0.3.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "tracing",
        "version": "0.1.21",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "log",
          "std"
        ]
      },
      {
        "name": "tracing-core",
        "version": "0.1.17",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "lazy_static",
          "std"
        ]
      },
      {
        "name": "tracing-futures",
        "version": "0.2.4",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "pin-project",
          "std-future"
        ]
      },
      {
        "name": "transaction-builder",
        "version": "0.1.0",
        "workspace-path": "language/transaction-builder",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "transaction-builder-generated",
        "version": "0.1.0",
        "workspace-path": "client/transaction-builder",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "transaction-builder-generator",
        "version": "0.1.0",
        "workspace-path": "language/transaction-builder/generator",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "try-lock",
        "version": "0.2.3",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "tungstenite",
        "version": "0.11.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "twoway",
        "version": "0.1.8",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "use_std"
        ]
      },
      {
        "name": "typed-arena",
        "version": "2.0.1",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "std"
        ]
      },
      {
        "name": "typenum",
        "version": "1.12.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "ucd-trie",
        "version": "0.1.3",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "std"
        ]
      },
      {
        "name": "unicase",
        "version": "2.6.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "unicode-bidi",
        "version": "0.3.4",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default"
        ]
      },
      {
        "name": "unicode-normalization",
        "version": "0.1.13",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "std"
        ]
      },
      {
        "name": "unicode-segmentation",
        "version": "1.6.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "unicode-width",
        "version": "0.1.8",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default"
        ]
      },
      {
        "name": "universal-hash",
        "version": "0.4.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "ureq",
        "version": "1.5.2",
        "crates-io": true,
        "status": "direct",
        "features": [
          "json",
          "native-tls",
          "serde",
          "serde_json"
        ]
      },
      {
        "name": "url",
        "version": "2.2.0",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "urlencoding",
        "version": "1.1.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "utf-8",
        "version": "0.7.5",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "vec_map",
        "version": "0.8.2",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "vm",
        "version": "0.1.0",
        "workspace-path": "language/vm",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "vm-genesis",
        "version": "0.1.0",
        "workspace-path": "language/tools/vm-genesis",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "vm-validator",
        "version": "0.1.0",
        "workspace-path": "vm-validator",
        "status": "workspace",
        "features": [
          "default"
        ]
      },
      {
        "name": "walkdir",
        "version": "2.3.1",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "want",
        "version": "0.3.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "warp",
        "version": "0.2.5",
        "crates-io": true,
        "status": "direct",
        "features": [
          "default",
          "multipart",
          "tokio-tungstenite",
          "websocket"
        ]
      },
      {
        "name": "x25519-dalek",
        "version": "1.1.0",
        "source": "git+https://github.com/novifinancial/x25519-dalek.git?branch=fiat4#4d6e37cee0a2ae0d3df522b3c6286fab6ce607b6",
        "status": "direct",
        "features": [
          "fiat_u64_backend",
          "std"
        ]
      },
      {
        "name": "yaml-rust",
        "version": "0.4.4",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "zeroize",
        "version": "1.1.1",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "alloc",
          "zeroize_derive"
        ]
      }
    ]
  },
  "host-packages": {
    "changed": [
      {
        "name": "serde_derive",
        "version": "1.0.117",
        "crates-io": true,
        "change": "modified",
        "old-version": "1.0.118",
        "old-source": null,
        "old-status": null,
        "new-status": "transitive",
        "added-features": [],
        "removed-features": [],
        "unchanged-features": [
          "default"
        ]
      }
    ],
    "unchanged": [
      {
        "name": "aho-corasick",
        "version": "0.7.15",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "std"
        ]
      },
      {
        "name": "ansi_term",
        "version": "0.11.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "anyhow",
        "version": "1.0.34",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "std"
        ]
      },
      {
        "name": "async-trait",
        "version": "0.1.42",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "atty",
        "version": "0.2.14",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "autocfg",
        "version": "0.1.7",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "autocfg",
        "version": "1.0.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "bindgen",
        "version": "0.54.0",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "clap",
          "default",
          "env_logger",
          "log",
          "logging",
          "runtime",
          "which",
          "which-rustfmt"
        ]
      },
      {
        "name": "bitflags",
        "version": "1.2.1",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default"
        ]
      },
      {
        "name": "bytes",
        "version": "0.5.6",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "std"
        ]
      },
      {
        "name": "cc",
        "version": "1.0.66",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "jobserver",
          "parallel"
        ]
      },
      {
        "name": "cexpr",
        "version": "0.4.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "cfg-if",
        "version": "0.1.10",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "clang-sys",
        "version": "0.29.3",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "clang_6_0",
          "gte_clang_3_6",
          "gte_clang_3_7",
          "gte_clang_3_8",
          "gte_clang_3_9",
          "gte_clang_4_0",
          "gte_clang_5_0",
          "gte_clang_6_0",
          "libloading",
          "runtime"
        ]
      },
      {
        "name": "clap",
        "version": "2.33.3",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "ansi_term",
          "atty",
          "color",
          "default",
          "strsim",
          "suggestions",
          "vec_map"
        ]
      },
      {
        "name": "const_fn",
        "version": "0.4.3",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "diem-crypto-derive",
        "version": "0.1.0",
        "workspace-path": "crypto/crypto-derive",
        "status": "workspace",
        "features": []
      },
      {
        "name": "diem-log-derive",
        "version": "0.1.0",
        "workspace-path": "common/logger/derive",
        "status": "workspace",
        "features": []
      },
      {
        "name": "either",
        "version": "1.6.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "enum_dispatch",
        "version": "0.3.4",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "env_logger",
        "version": "0.7.1",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "atty",
          "default",
          "humantime",
          "regex",
          "termcolor"
        ]
      },
      {
        "name": "fixedbitset",
        "version": "0.2.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "fs_extra",
        "version": "1.2.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "futures-macro",
        "version": "0.3.8",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "getrandom",
        "version": "0.1.15",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "std"
        ]
      },
      {
        "name": "glob",
        "version": "0.3.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "hashbrown",
        "version": "0.9.1",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "raw"
        ]
      },
      {
        "name": "heck",
        "version": "0.3.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "humantime",
        "version": "1.3.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "include_dir_impl",
        "version": "0.6.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "indexmap",
        "version": "1.6.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "itertools",
        "version": "0.8.2",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "use_std"
        ]
      },
      {
        "name": "jobserver",
        "version": "0.1.21",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "lazy_static",
        "version": "1.4.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "lazycell",
        "version": "1.3.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "libc",
        "version": "0.2.80",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "std"
        ]
      },
      {
        "name": "libloading",
        "version": "0.5.2",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "log",
        "version": "0.4.11",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "std"
        ]
      },
      {
        "name": "maplit",
        "version": "1.0.2",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "memchr",
        "version": "2.3.4",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "std",
          "use_std"
        ]
      },
      {
        "name": "multimap",
        "version": "0.8.2",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "nom",
        "version": "5.1.2",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "alloc",
          "std"
        ]
      },
      {
        "name": "num-derive",
        "version": "0.3.3",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "num-variants",
        "version": "0.1.0",
        "workspace-path": "common/num-variants",
        "status": "workspace",
        "features": []
      },
      {
        "name": "once_cell",
        "version": "1.5.2",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "alloc",
          "default",
          "std"
        ]
      },
      {
        "name": "peeking_take_while",
        "version": "0.1.2",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "pest",
        "version": "2.1.3",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "pest_derive",
        "version": "2.1.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "pest_generator",
        "version": "2.1.3",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "pest_meta",
        "version": "2.1.3",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "petgraph",
        "version": "0.5.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "pin-project-internal",
        "version": "0.4.27",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "pin-project-internal",
        "version": "1.0.2",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "pkg-config",
        "version": "0.3.19",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "ppv-lite86",
        "version": "0.2.10",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "simd",
          "std"
        ]
      },
      {
        "name": "proc-macro-error",
        "version": "1.0.4",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "syn",
          "syn-error"
        ]
      },
      {
        "name": "proc-macro-error-attr",
        "version": "1.0.4",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "proc-macro-hack",
        "version": "0.5.19",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "proc-macro2",
        "version": "1.0.24",
        "crates-io": true,
        "status": "direct",
        "features": [
          "default",
          "proc-macro"
        ]
      },
      {
        "name": "prost",
        "version": "0.6.1",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "prost-derive"
        ]
      },
      {
        "name": "prost-build",
        "version": "0.6.1",
        "crates-io": true,
        "status": "direct",
        "features": []
      },
      {
        "name": "prost-derive",
        "version": "0.6.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "prost-types",
        "version": "0.6.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "quick-error",
        "version": "1.2.3",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "quote",
        "version": "1.0.7",
        "crates-io": true,
        "status": "direct",
        "features": [
          "default",
          "proc-macro"
        ]
      },
      {
        "name": "rand",
        "version": "0.7.3",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "alloc",
          "default",
          "getrandom",
          "getrandom_package",
          "libc",
          "std"
        ]
      },
      {
        "name": "rand_chacha",
        "version": "0.2.2",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "std"
        ]
      },
      {
        "name": "rand_core",
        "version": "0.5.1",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "alloc",
          "getrandom",
          "std"
        ]
      },
      {
        "name": "ref-cast-impl",
        "version": "1.0.3",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "regex",
        "version": "1.4.2",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "aho-corasick",
          "default",
          "memchr",
          "perf",
          "perf-cache",
          "perf-dfa",
          "perf-inline",
          "perf-literal",
          "std",
          "thread_local",
          "unicode",
          "unicode-age",
          "unicode-bool",
          "unicode-case",
          "unicode-gencat",
          "unicode-perl",
          "unicode-script",
          "unicode-segment"
        ]
      },
      {
        "name": "regex-syntax",
        "version": "0.6.21",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "unicode",
          "unicode-age",
          "unicode-bool",
          "unicode-case",
          "unicode-gencat",
          "unicode-perl",
          "unicode-script",
          "unicode-segment"
        ]
      },
      {
        "name": "remove_dir_all",
        "version": "0.5.3",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "rustc-hash",
        "version": "1.1.0",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "std"
        ]
      },
      {
        "name": "shlex",
        "version": "0.1.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "strsim",
        "version": "0.8.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "structopt-derive",
        "version": "0.4.14",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "syn",
        "version": "1.0.53",
        "crates-io": true,
        "status": "direct",
        "features": [
          "clone-impls",
          "default",
          "derive",
          "extra-traits",
          "full",
          "parsing",
          "printing",
          "proc-macro",
          "quote",
          "visit",
          "visit-mut"
        ]
      },
      {
        "name": "synstructure",
        "version": "0.12.4",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "proc-macro"
        ]
      },
      {
        "name": "tempfile",
        "version": "3.1.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "termcolor",
        "version": "1.1.2",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "textwrap",
        "version": "0.11.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "thiserror-impl",
        "version": "1.0.22",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "thread_local",
        "version": "1.0.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "tokio-macros",
        "version": "0.2.5",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "ucd-trie",
        "version": "0.1.3",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default",
          "std"
        ]
      },
      {
        "name": "unicase",
        "version": "2.6.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "unicode-segmentation",
        "version": "1.6.0",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "unicode-width",
        "version": "0.1.8",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default"
        ]
      },
      {
        "name": "unicode-xid",
        "version": "0.2.1",
        "crates-io": true,
        "status": "transitive",
        "features": [
          "default"
        ]
      },
      {
        "name": "vec_map",
        "version": "0.8.2",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "version_check",
        "version": "0.9.2",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "which",
        "version": "3.1.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      },
      {
        "name": "zeroize_derive",
        "version": "1.0.1",
        "crates-io": true,
        "status": "transitive",
        "features": []
      }
    ]
  }
}
```
</details>