### PR TITLE
[backup] backup events with transactions

### DIFF
--- a/storage/backup/backup-cli/src/backup_types/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/tests.rs
@@ -154,10 +154,20 @@ fn test_end_to_end_impl(d: TestData) {
     )
     .unwrap();
     assert_eq!(
-        d.db.get_transactions(d.txn_start_ver, num_txns_to_backup, d.target_ver, false)
-            .unwrap(),
+        d.db.get_transactions(
+            d.txn_start_ver,
+            num_txns_to_backup,
+            d.target_ver,
+            true /* fetch_events */
+        )
+        .unwrap(),
         tgt_db
-            .get_transactions(d.txn_start_ver, num_txns_to_backup, d.target_ver, false)
+            .get_transactions(
+                d.txn_start_ver,
+                num_txns_to_backup,
+                d.target_ver,
+                true /* fetch_events */
+            )
             .unwrap()
     );
     if let Some(state_snapshot_ver) = d.state_snapshot_ver {

--- a/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
@@ -116,17 +116,30 @@ fn end_to_end() {
             first_ver_to_backup,
             num_txns_to_restore as u64,
             target_version,
-            false,
+            true, /* fetch_events */
         )
-        .unwrap()
-        .transactions;
+        .unwrap();
 
     assert_eq!(
-        recovered_transactions,
+        recovered_transactions.transactions,
         txns.into_iter()
             .skip(first_ver_to_backup as usize)
             .take(num_txns_to_restore)
             .cloned()
+            .collect::<Vec<_>>()
+    );
+
+    assert_eq!(
+        recovered_transactions.events.unwrap(),
+        blocks
+            .iter()
+            .map(|(txns, _li)| {
+                txns.iter()
+                    .map(|txn_to_commit| txn_to_commit.events().to_vec())
+            })
+            .flatten()
+            .skip(first_ver_to_backup as usize)
+            .take(num_txns_to_restore)
             .collect::<Vec<_>>()
     );
 

--- a/storage/diemdb/src/backup/backup_handler.rs
+++ b/storage/diemdb/src/backup/backup_handler.rs
@@ -58,7 +58,7 @@ impl BackupHandler {
             .get_transaction_info_iter(start_version, num_transactions)?;
         let zipped = zip_eq(txn_iter, txn_info_iter).enumerate().map(
             move |(idx, (txn_res, txn_info_res))| {
-                BACKUP_TXN_VERSION.set((start_version + idx as u64) as i64);
+                BACKUP_TXN_VERSION.set((start_version.wrapping_add(idx as u64)) as i64);
                 Ok((txn_res?, txn_info_res?))
             },
         );

--- a/storage/diemdb/src/event_store/test.rs
+++ b/storage/diemdb/src/event_store/test.rs
@@ -196,6 +196,15 @@ fn test_index_get_impl(event_batches: Vec<Vec<ContractEvent>>) {
     store.db.write_schemas(cs.batch);
     let ledger_version_plus_one = event_batches.len() as u64;
 
+    assert_eq!(
+        store
+            .get_events_by_version_iter(0, event_batches.len())
+            .unwrap()
+            .collect::<Result<Vec<_>>>()
+            .unwrap(),
+        event_batches,
+    );
+
     // Calculate expected event sequence per access_path.
     let mut events_by_event_key = HashMap::new();
     event_batches

--- a/storage/diemdb/src/lib.rs
+++ b/storage/diemdb/src/lib.rs
@@ -108,7 +108,7 @@ pub struct DiemDB {
     ledger_store: Arc<LedgerStore>,
     transaction_store: Arc<TransactionStore>,
     state_store: Arc<StateStore>,
-    event_store: EventStore,
+    event_store: Arc<EventStore>,
     system_store: SystemStore,
     pruner: Option<Pruner>,
 }
@@ -137,7 +137,7 @@ impl DiemDB {
 
         DiemDB {
             db: Arc::clone(&db),
-            event_store: EventStore::new(Arc::clone(&db)),
+            event_store: Arc::new(EventStore::new(Arc::clone(&db))),
             ledger_store: Arc::new(LedgerStore::new(Arc::clone(&db))),
             state_store: Arc::new(StateStore::new(Arc::clone(&db))),
             transaction_store: Arc::new(TransactionStore::new(Arc::clone(&db))),
@@ -320,6 +320,7 @@ impl DiemDB {
             Arc::clone(&self.ledger_store),
             Arc::clone(&self.transaction_store),
             Arc::clone(&self.state_store),
+            Arc::clone(&self.event_store),
         )
     }
 
@@ -911,6 +912,7 @@ impl GetRestoreHandler for Arc<DiemDB> {
             Arc::clone(&self.ledger_store),
             Arc::clone(&self.transaction_store),
             Arc::clone(&self.state_store),
+            Arc::clone(&self.event_store),
         )
     }
 }


### PR DESCRIPTION
## Motivation



Events as part of the "ledger history" should accompany the transactions in a transaction backup.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

unit tests. smoke tests.
## Related PRs
