### PR TITLE
[jf] add missing_root error type which can be downcasted to

### DIFF
--- a/storage/jellyfish-merkle/src/jellyfish_merkle_test.rs
+++ b/storage/jellyfish-merkle/src/jellyfish_merkle_test.rs
@@ -475,6 +475,19 @@ fn test_non_existence() {
 }
 
 #[test]
+fn test_missing_root() {
+    let db = MockTreeStore::default();
+    let tree = JellyfishMerkleTree::new(&db);
+    let err = tree
+        .get_with_proof(HashValue::random(), 0)
+        .err()
+        .unwrap()
+        .downcast::<MissingRootError>()
+        .unwrap();
+    assert_eq!(err.version, 0);
+}
+
+#[test]
 fn test_put_blob_sets() {
     let mut keys = vec![];
     let mut values = vec![];


### PR DESCRIPTION
Add a error subtype for anyhow::Error that can be downcast from.
## Motivation

The json-rpc api needs to know detailed error type.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

add a downcast test.


