### PR TITLE
Make AccountState::get_resource_impl public again

### DIFF
--- a/types/src/account_state.rs
+++ b/types/src/account_state.rs
@@ -173,7 +173,7 @@ impl AccountState {
         self.0.get(key)
     }
 
-    fn get_resource_impl<T: DeserializeOwned>(&self, key: &[u8]) -> Result<Option<T>> {
+    pub fn get_resource_impl<T: DeserializeOwned>(&self, key: &[u8]) -> Result<Option<T>> {
         self.0
             .get(key)
             .map(|bytes| lcs::from_bytes(bytes))


### PR DESCRIPTION
The get_resource function used to be public: AOS is currently using it for retrieving the DD tier info for the specific currencies.
One of the recent changes closed this function, but we should still keep it available.

On a side note, we should probably define some sort of `DesignatedDealerTierInfoResource` in diem/diem, similarly to `PreburnResource`.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/developers.libra.org, and link to your PR here.)
