### PR TITLE
[Key Manager] Make the key manager smoke test less aggressive.

### DIFF
--- a/testsuite/smoke-test/src/key_manager.rs
+++ b/testsuite/smoke-test/src/key_manager.rs
@@ -54,6 +54,9 @@ fn test_key_manager_consensus_rotation() {
         ChainId::test(),
     );
 
+    // Add some time padding to ensure the libra timestamp increases on-chain
+    sleep(Duration::from_secs(10));
+
     // Spawn the key manager and execute a rotation
     let _key_manager_thread = thread::spawn(move || key_manager.execute());
 


### PR DESCRIPTION
## Motivation

This PR reduces the aggression of the key manager smoke test. It's a duplicate of the previous PR which wouldn't land because of flaky land blocking tests and the fact that the rename has borked my ability to update the PR after the conflict 😢 (https://github.com/diem/diem/pull/6868)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Tests pass locally.

## Related PRs

https://github.com/diem/diem/pull/6868
