### PR TITLE
[backup] backup coordinator metrics

### DIFF
--- a/storage/backup/backup-cli/src/bin/db-backup.rs
+++ b/storage/backup/backup-cli/src/bin/db-backup.rs
@@ -17,6 +17,7 @@ use backup_cli::{
     },
 };
 use diem_logger::{prelude::*, Level, Logger};
+use diem_secure_push_metrics::MetricsPusher;
 use std::sync::Arc;
 use structopt::StructOpt;
 
@@ -129,6 +130,8 @@ async fn main() -> Result<()> {
 
 async fn main_impl() -> Result<()> {
     Logger::new().level(Level::Info).init();
+    let _mp = MetricsPusher::start();
+
     let cmd = Command::from_args();
     match cmd {
         Command::OneShot(one_shot_cmd) => match one_shot_cmd {

--- a/storage/backup/backup-cli/src/metrics/backup.rs
+++ b/storage/backup/backup-cli/src/metrics/backup.rs
@@ -1,0 +1,37 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use diem_secure_push_metrics::{register_int_gauge, IntGauge};
+use once_cell::sync::Lazy;
+
+pub static HEARTBEAT_TS: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "diem_db_backup_coordinator_heartbeat_timestamp_s",
+        "Timestamp when the backup coordinator successfully updates state from the backup service."
+    )
+    .unwrap()
+});
+
+pub static EPOCH_ENDING_EPOCH: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "diem_db_backup_coordinator_epoch_ending_epoch",
+        "Epoch of the latest epoch ending backed up."
+    )
+    .unwrap()
+});
+
+pub static STATE_SNAPSHOT_VERSION: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "diem_db_backup_coordinator_state_snapshot_version",
+        "The version of the latest state snapshot taken."
+    )
+    .unwrap()
+});
+
+pub static TRANSACTION_VERSION: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "diem_db_backup_coordinator_transaction_version",
+        "Version of the latest transaction backed up."
+    )
+    .unwrap()
+});

--- a/storage/backup/backup-cli/src/metrics/mod.rs
+++ b/storage/backup/backup-cli/src/metrics/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod backup;
 pub mod metadata;
 pub mod restore;
 pub mod verify;


### PR DESCRIPTION
## Motivation

We used to rely on metrics from the server side to dashboard and alert, but those are reported only when a backup is being done. If the node gets restarted and no new backup is needed, the gauge values will disappear from the dashboard and trigger alerts.

We now report those metrics from the coordinator and report periodically in case the push gateway gets restarted.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

on my testnet

## Related PRs
