### PR TITLE
[Logger] Add backtraces to error logs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "serde",
 ]
 
 [[package]]
@@ -1732,6 +1733,7 @@ dependencies = [
 name = "diem-logger"
 version = "0.1.0"
 dependencies = [
+ "backtrace",
  "chrono",
  "diem-infallible",
  "diem-log-derive",

--- a/common/logger/Cargo.toml
+++ b/common/logger/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 # Do NOT add any inter-project dependencies.
 # This is to avoid ever having a circular dependency with the diem-logger crate.
 [dependencies]
+backtrace = { version = "0.3", features = ["serde"] }
 chrono = "0.4.19"
 erased-serde = "0.3.12"
 hostname = "0.3.1"

--- a/common/logger/src/metadata.rs
+++ b/common/logger/src/metadata.rs
@@ -1,10 +1,11 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use backtrace::Backtrace;
 use serde::{Deserialize, Serialize};
 use std::{fmt, str::FromStr};
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Metadata {
     /// The level of verbosity of the event
     level: Level,
@@ -23,10 +24,14 @@ pub struct Metadata {
 
     /// The file name and line number together 'file:line'
     location: &'static str,
+
+    /// The program backtrace taken when the event occurred. Backtraces are
+    /// only supported for errors.
+    backtrace: Option<Backtrace>,
 }
 
 impl Metadata {
-    pub const fn new(
+    pub fn new(
         level: Level,
         target: &'static str,
         module_path: &'static str,
@@ -34,6 +39,18 @@ impl Metadata {
         line: u32,
         location: &'static str,
     ) -> Self {
+        let backtrace = match level {
+            Level::Error => {
+                let backtrace = Backtrace::new();
+                let mut frames = backtrace.frames().to_vec();
+                if frames.len() > 3 {
+                    frames.drain(0..3); // Remove the first 3 unnecessary frames to simplify backtrace
+                }
+                Some(frames.into())
+            }
+            _ => None,
+        };
+
         Self {
             level,
             target,
@@ -41,6 +58,7 @@ impl Metadata {
             file,
             line,
             location,
+            backtrace,
         }
     }
 
@@ -70,6 +88,10 @@ impl Metadata {
 
     pub fn location(&self) -> &'static str {
         self.location
+    }
+
+    pub fn backtrace(&self) -> Option<Backtrace> {
+        self.backtrace.clone()
     }
 }
 


### PR DESCRIPTION
## Motivation

This PR is a copy of a previously accepted but prematurely closed PR (https://github.com/diem/diem/pull/6778). The PR was prematurely closed for technical reasons (inability to rebase). 

Note: the only differences between this PR and the closed one are: (i) this PR has been rebased to the head of master (post rename); and (ii) this PR removes the first 3 unnecessary backtrace frames from each backtrace (see the diff by comparing the examples embedded in each PR).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally. Moreover, displaying the metadata error, we now get:
```
thread 'diem_logger::tests::basic' panicked at 'METADATA: Metadata { level: Error, target: "diem_logger", module_path: "diem_logger::diem_logger::tests", file: "common/logger/src/diem_logger.rs", line: 575, location: "common/logger/src/diem_logger.rs:575", backtrace: Some(   0: backtrace::capture::Backtrace::new
             at /Users/joshlind/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.55/src/capture.rs:140:22
   1: diem_logger::metadata::Metadata::new
             at src/metadata.rs:44:33
   2: diem_logger::diem_logger::tests::basic
             at src/diem_logger.rs:575:9
   3: diem_logger::diem_logger::tests::basic::{{closure}}
             at src/diem_logger.rs:519:5
   4: core::ops::function::FnOnce::call_once
             at /Users/joshlind/.rustup/toolchains/1.48.0-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:227:5
   5: core::ops::function::FnOnce::call_once
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/core/src/ops/function.rs:227:5
      test::__rust_begin_short_backtrace
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/test/src/lib.rs:516:5
   6: <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/alloc/src/boxed.rs:1042:9
      <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/panic.rs:308:9
      std::panicking::try::do_call
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/panicking.rs:381:40
      std::panicking::try
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/panicking.rs:345:19
      std::panic::catch_unwind
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/panic.rs:382:14
      test::run_test_in_process
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/test/src/lib.rs:543:18
      test::run_test::run_test_inner::{{closure}}
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/test/src/lib.rs:449:39
   7: std::sys_common::backtrace::__rust_begin_short_backtrace
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/sys_common/backtrace.rs:137:18
   8: std::thread::Builder::spawn_unchecked::{{closure}}::{{closure}}
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/thread/mod.rs:464:17
      <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/panic.rs:308:9
      std::panicking::try::do_call
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/panicking.rs:381:40
      std::panicking::try
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/panicking.rs:345:19
      std::panic::catch_unwind
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/panic.rs:382:14
      std::thread::Builder::spawn_unchecked::{{closure}}
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/thread/mod.rs:463:30
      core::ops::function::FnOnce::call_once{{vtable.shim}}
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/core/src/ops/function.rs:227:5
   9: <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/alloc/src/boxed.rs:1042:9
      <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/alloc/src/boxed.rs:1042:9
      std::sys::unix::thread::Thread::new::thread_start
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/sys/unix/thread.rs:87:17
  10: __pthread_start
) }', common/logger/src/diem_logger.rs:578:9
```


## Related PRs

https://github.com/diem/diem/pull/6778
