### PR TITLE
[Observability] Improve error observability for safety rules and the key manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1690,6 +1690,7 @@ name = "diem-key-manager"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "crash-handler",
  "diem-config",
  "diem-crypto",
  "diem-genesis-tool",

--- a/consensus/safety-rules/src/safety_rules_manager.rs
+++ b/consensus/safety-rules/src/safety_rules_manager.rs
@@ -18,9 +18,9 @@ use std::{convert::TryInto, net::SocketAddr, sync::Arc};
 pub fn storage(config: &SafetyRulesConfig) -> PersistentSafetyStorage {
     let backend = &config.backend;
     let internal_storage: Storage = backend.try_into().expect("Unable to initialize storage");
-    internal_storage
-        .available()
-        .expect("Storage is not available");
+    if let Err(error) = internal_storage.available() {
+        panic!("Storage is not available: {:?}", error);
+    }
 
     if let Some(test_config) = &config.test {
         let author = test_config.author;

--- a/secure/key-manager/Cargo.toml
+++ b/secure/key-manager/Cargo.toml
@@ -14,6 +14,7 @@ once_cell = "1.4.1"
 serde = { version = "1.0.117", features = ["rc"], default-features = false }
 thiserror = "1.0.22"
 
+crash-handler = { path = "../../common/crash-handler", version = "0.1.0" }
 diem-config = { path = "../../config", version = "0.1.0"}
 diem-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 diem-global-constants = { path = "../../config/global-constants", version = "0.1.0"}

--- a/secure/key-manager/src/main.rs
+++ b/secure/key-manager/src/main.rs
@@ -41,6 +41,7 @@ fn main() {
         .read_env()
         .init();
 
+    crash_handler::setup_panic_handler();
     let _mp = MetricsPusher::start();
     counters::initialize_all_metric_counters();
 


### PR DESCRIPTION
## Motivation

This PR offers two tiny commits to improve the observability of errors in our code:
1. First, display the storage error when panicking in safety rules after failing to initialize storage. ('cc @snakech, this will give us better insight into the cluster test flakiness)
2. Second, add the crash handler to the key manager to better handle panics

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally.

## Related PRs

None.
