### PR TITLE
[json-rpc] minimum doc for expiremental verifying APIs

### DIFF
--- a/json-rpc/json-rpc-spec.md
+++ b/json-rpc/json-rpc-spec.md
@@ -103,3 +103,11 @@ All Diem JSON-RPC server responses include the following headers:
 * `X-Diem-Ledger-TimestampUsec`: server-side latest ledger timestamp microseconds
 
 These headers are similar with [Diem extensions](#diem-extensions), except the value type is all string.
+
+## Experimental APIs
+
+The following APIs are experimental APIs. They are unstable and likely to be changed.
+
+* get_state_proof
+* get_account_state_with_proof
+* get_transactions_with_proofs

--- a/json-rpc/types/src/proto/jsonrpc.proto
+++ b/json-rpc/types/src/proto/jsonrpc.proto
@@ -331,6 +331,9 @@ message CurrencyInfo {
   string exchange_rate_update_events_key = 9 [json_name="exchange_rate_update_events_key"];
 }
 
+/**
+ * This is for experimental API get_state_proof response. It is unstable and likely to be changed.
+ */
 message StateProof {
   // hex-encoded lcs bytes
   string ledger_info_with_signatures = 1 [json_name="ledger_info_with_signatures"];
@@ -340,6 +343,9 @@ message StateProof {
   string ledger_consistency_proof = 3 [json_name="ledger_consistency_proof"];
 }
 
+/**
+ * This is for experimental API get_account_state_with_proof response. It is unstable and likely to be changed.
+ */
 message AccountStateWithProof {
   uint64 version = 1;
   // hex-encoded lcs bytes
@@ -349,6 +355,9 @@ message AccountStateWithProof {
 }
 
 
+/**
+ * This is for experimental API get_account_state_with_proof response. It is unstable and likely to be changed.
+ */
 message AccountStateProof {
   // hex-encoded lcs bytes
   string ledger_info_to_transaction_info_proof = 1 [json_name="ledger_info_to_transaction_info_proof"];


### PR DESCRIPTION
## Motivation

We didn't document these APIs because they are not ready for public usage, and maybe changed in near future.
This PR just specifically call it out, so that anyone discovered them won't be surprised when we change these APIs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

YES

