### PR TITLE
[Logger] Format backtraces into strings to avoid auto-serialization.

### DIFF
--- a/common/logger/src/metadata.rs
+++ b/common/logger/src/metadata.rs
@@ -27,7 +27,7 @@ pub struct Metadata {
 
     /// The program backtrace taken when the event occurred. Backtraces are
     /// only supported for errors.
-    backtrace: Option<Backtrace>,
+    backtrace: Option<String>,
 }
 
 impl Metadata {
@@ -41,12 +41,13 @@ impl Metadata {
     ) -> Self {
         let backtrace = match level {
             Level::Error => {
-                let backtrace = Backtrace::new();
+                let mut backtrace = Backtrace::new();
                 let mut frames = backtrace.frames().to_vec();
                 if frames.len() > 3 {
                     frames.drain(0..3); // Remove the first 3 unnecessary frames to simplify backtrace
                 }
-                Some(frames.into())
+                backtrace = frames.into();
+                Some(format!("{:?}", backtrace))
             }
             _ => None,
         };
@@ -90,8 +91,8 @@ impl Metadata {
         self.location
     }
 
-    pub fn backtrace(&self) -> Option<Backtrace> {
-        self.backtrace.clone()
+    pub fn backtrace(&self) -> Option<&str> {
+        self.backtrace.as_deref()
     }
 }
 


### PR DESCRIPTION
## Motivation

Our logging system currently auto-serializes backtrace objects when sent to the logger. Unfortunately, the auto-serialization isn't very human friendly. Instead, this PR forces the backtrace format to be a human-readable string in our logs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Displaying the backtraces locally shows they are forced to be human readable.

## Related PRs

None.
