### PR TITLE
[ci] switch build-dev to use xcheck rather than xbuild + more improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,19 +369,9 @@ jobs:
       - build_setup
       - restore_cargo_package_cache
       - run:
-          command: RUST_BACKTRACE=1 cargo xcheck -j 16
+          command: RUST_BACKTRACE=1 cargo xcheck -j 16 --production
       - run:
-          command: RUST_BACKTRACE=1 cargo xcheck -j 16 -p cli
-      - run:
-          command: RUST_BACKTRACE=1 cargo xcheck -j 16 -p cluster-test
-      - run:
-          command: RUST_BACKTRACE=1 cargo xcheck -j 16 -p language-benchmarks
-      - run:
-          command: RUST_BACKTRACE=1 cargo xcheck -j 16 -p diem-fuzzer
-      - run:
-          command: RUST_BACKTRACE=1 cargo xcheck -j 16 -p diem-swarm
-      - run:
-          command: RUST_BACKTRACE=1 cargo xcheck -j 16 -p test-generation
+          command: RUST_BACKTRACE=1 cargo xcheck -j 16 --workspace --all-targets
       - run:
           command: |
             rustup target add powerpc-unknown-linux-gnu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,23 +369,23 @@ jobs:
       - build_setup
       - restore_cargo_package_cache
       - run:
-          command: RUST_BACKTRACE=1 cargo xbuild -j 16
+          command: RUST_BACKTRACE=1 cargo xcheck -j 16
       - run:
-          command: RUST_BACKTRACE=1 cargo xbuild -j 16 -p cli
+          command: RUST_BACKTRACE=1 cargo xcheck -j 16 -p cli
       - run:
-          command: RUST_BACKTRACE=1 cargo xbuild -j 16 -p cluster-test
+          command: RUST_BACKTRACE=1 cargo xcheck -j 16 -p cluster-test
       - run:
-          command: RUST_BACKTRACE=1 cargo xbuild -j 16 -p language-benchmarks
+          command: RUST_BACKTRACE=1 cargo xcheck -j 16 -p language-benchmarks
       - run:
-          command: RUST_BACKTRACE=1 cargo xbuild -j 16 -p diem-fuzzer
+          command: RUST_BACKTRACE=1 cargo xcheck -j 16 -p diem-fuzzer
       - run:
-          command: RUST_BACKTRACE=1 cargo xbuild -j 16 -p diem-swarm
+          command: RUST_BACKTRACE=1 cargo xcheck -j 16 -p diem-swarm
       - run:
-          command: RUST_BACKTRACE=1 cargo xbuild -j 16 -p test-generation
+          command: RUST_BACKTRACE=1 cargo xcheck -j 16 -p test-generation
       - run:
           command: |
             rustup target add powerpc-unknown-linux-gnu
-            RUST_BACKTRACE=1 cargo xbuild -j 16 -p transaction-builder -p move-vm-types --target powerpc-unknown-linux-gnu
+            RUST_BACKTRACE=1 cargo xcheck -j 16 -p transaction-builder -p move-vm-types --target powerpc-unknown-linux-gnu
       - build_teardown
   run-e2e-test:
     working_directory: *working_directory

--- a/devtools/x/src/bench.rs
+++ b/devtools/x/src/bench.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    cargo::{selected_package::SelectedPackageArgs, CargoArgs, CargoCommand},
+    cargo::{selected_package::SelectedPackageArgs, CargoCommand},
     context::XContext,
     Result,
 };
@@ -37,7 +37,6 @@ pub fn run(mut args: Args, xctx: XContext) -> Result<()> {
         env: &[],
     };
 
-    let base_args = CargoArgs::default();
     let packages = args.package_args.to_selected_packages(&xctx)?;
-    cmd.run_on_packages(&packages, &base_args)
+    cmd.run_on_packages(&packages)
 }

--- a/devtools/x/src/bench.rs
+++ b/devtools/x/src/bench.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    cargo::{CargoArgs, CargoCommand, SelectedPackageArgs},
+    cargo::{selected_package::SelectedPackageArgs, CargoArgs, CargoCommand},
     context::XContext,
     Result,
 };

--- a/devtools/x/src/build.rs
+++ b/devtools/x/src/build.rs
@@ -1,232 +1,44 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
-    cargo::{selected_package::SelectedPackageArgs, CargoArgs, CargoCommand},
+    cargo::{
+        build_args::BuildArgs, selected_package::SelectedPackageArgs, CargoArgs, CargoCommand,
+    },
     context::XContext,
     Result,
 };
 use log::info;
 use std::ffi::OsString;
-use structopt::{clap::arg_enum, StructOpt};
-
-arg_enum! {
-    #[derive(Debug)]
-    enum Coloring {
-        Auto,
-        Always,
-        Never,
-    }
-}
+use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 pub struct Args {
-    #[structopt(long, short)]
-    /// No output printed to stdout
-    quiet: bool,
     #[structopt(flatten)]
     package_args: SelectedPackageArgs,
     #[structopt(long, number_of_values = 1)]
     /// Package to exclude (see `cargo help pkgid`)
     exclude: Vec<String>,
-    #[structopt(long, short)]
-    /// Number of parallel jobs, defaults to # of CPUs
-    jobs: Option<u16>,
-    #[structopt(long)]
-    /// Build only this package's library
-    lib: bool,
-    #[structopt(long, number_of_values = 1)]
-    /// Build only the specified binary
-    bin: Vec<String>,
-    #[structopt(long)]
-    /// Build all binaries
-    bins: bool,
-    #[structopt(long, number_of_values = 1)]
-    /// Build only the specified example
-    example: Vec<String>,
-    #[structopt(long)]
-    /// Build all examples
-    examples: bool,
-    #[structopt(long, number_of_values = 1)]
-    /// Build only the specified test target
-    test: Vec<String>,
-    #[structopt(long)]
-    /// Build all tests
-    tests: bool,
-    #[structopt(long, number_of_values = 1)]
-    /// Build only the specified bench target
-    bench: Vec<String>,
-    #[structopt(long)]
-    ///  Build all benches
-    benches: bool,
-    #[structopt(long)]
-    /// Build all targets
-    all_targets: bool,
-    #[structopt(long)]
-    /// Build artifacts in release mode, with optimizations
-    release: bool,
-    #[structopt(long)]
-    /// Build artifacts with the specified profile
-    profile: Option<String>,
-    #[structopt(long, number_of_values = 1)]
-    /// Space-separated list of features to activate
-    features: Vec<String>,
-    #[structopt(long)]
-    /// Activate all available features
-    all_features: bool,
-    #[structopt(long)]
-    /// Do not activate the `default` feature
-    no_default_features: bool,
-    #[structopt(long)]
-    /// TRIPLE
-    target: Option<String>,
-    #[structopt(long, parse(from_os_str))]
-    /// Directory for all generated artifacts
-    target_dir: Option<OsString>,
+    #[structopt(flatten)]
+    build_args: BuildArgs,
     #[structopt(long, parse(from_os_str))]
     /// Copy final artifacts to this directory (unstable)
     out_dir: Option<OsString>,
-    #[structopt(long, parse(from_os_str))]
-    /// Path to Cargo.toml
-    manifest_path: Option<OsString>,
-    #[structopt(long)]
-    /// Error format
-    message_format: Option<String>,
     #[structopt(long)]
     /// Output the build plan in JSON (unstable)
     build_plan: bool,
-    //TODO: support -vv?
-    #[structopt(long, short, parse(from_occurrences))]
-    ///  Use verbose output (-vv very verbose/build.rs output)
-    verbose: usize,
-    #[structopt(long, possible_values = &Coloring::variants(), default_value="Auto")]
-    ///  Coloring: auto, always, never
-    coloring: Coloring,
-    #[structopt(long)]
-    ///  Require Cargo.lock and cache are up to date
-    frozen: bool,
-    #[structopt(long)]
-    ///  Require Cargo.lock is up to date
-    locked: bool,
-    #[structopt(long)]
-    ///  Run without accessing the network
-    offline: bool,
 }
 
 pub fn convert_args(args: &Args) -> Vec<OsString> {
     let mut direct_args = Vec::new();
-    if args.quiet {
-        direct_args.push(OsString::from("--quiet"));
-    }
-    if let Some(jobs) = args.jobs {
-        direct_args.push(OsString::from("--jobs"));
-        direct_args.push(OsString::from(jobs.to_string()));
-    };
-    if args.lib {
-        direct_args.push(OsString::from("--lib"));
-    };
-    if !args.bin.is_empty() {
-        direct_args.push(OsString::from("--bin"));
-        for bin in &args.bin {
-            direct_args.push(OsString::from(bin));
-        }
-    }
-    if args.bins {
-        direct_args.push(OsString::from("--bins"));
-    };
-    if !args.example.is_empty() {
-        direct_args.push(OsString::from("--example"));
-        for example in &args.example {
-            direct_args.push(OsString::from(example));
-        }
-    }
-    if args.examples {
-        direct_args.push(OsString::from("--examples"));
-    };
-
-    if !args.test.is_empty() {
-        direct_args.push(OsString::from("--test"));
-        for test in &args.test {
-            direct_args.push(OsString::from(test));
-        }
-    }
-    if args.tests {
-        direct_args.push(OsString::from("--tests"));
-    };
-
-    if !args.bench.is_empty() {
-        direct_args.push(OsString::from("--bench"));
-        for bench in &args.bench {
-            direct_args.push(OsString::from(bench));
-        }
-    }
-    if args.benches {
-        direct_args.push(OsString::from("--benches"));
-    };
-
-    if args.all_targets {
-        direct_args.push(OsString::from("--all-targets"));
-    };
-    if args.release {
-        direct_args.push(OsString::from("--release"));
-    };
-
-    if let Some(profile) = &args.profile {
-        direct_args.push(OsString::from("--profile"));
-        direct_args.push(OsString::from(profile.to_string()));
-    };
-
-    if !args.features.is_empty() {
-        direct_args.push(OsString::from("--features"));
-        for features in &args.features {
-            direct_args.push(OsString::from(features));
-        }
-    }
-    if args.all_features {
-        direct_args.push(OsString::from("--all-features"));
-    };
-    if args.no_default_features {
-        direct_args.push(OsString::from("--no-default-features"));
-    };
-
-    if let Some(target) = &args.target {
-        direct_args.push(OsString::from("--target"));
-        direct_args.push(OsString::from(target.to_string()));
-    };
-    if let Some(target_dir) = &args.target_dir {
-        direct_args.push(OsString::from("--target-dir"));
-        direct_args.push(OsString::from(target_dir));
-    };
+    args.build_args.add_args(&mut direct_args);
     if let Some(out_dir) = &args.out_dir {
         direct_args.push(OsString::from("--out-dir"));
         direct_args.push(OsString::from(out_dir));
     };
-    if let Some(manifest_path) = &args.manifest_path {
-        direct_args.push(OsString::from("--manifest-path"));
-        direct_args.push(manifest_path.to_owned());
-    };
-    if let Some(message_format) = &args.message_format {
-        direct_args.push(OsString::from("--message-format"));
-        direct_args.push(OsString::from(message_format.to_string()));
-    };
     if args.build_plan {
         direct_args.push(OsString::from("--build-plan"));
     };
-    if args.verbose > 0 {
-        direct_args.push(OsString::from(format!("-{}", "v".repeat(args.verbose))));
-    };
-    if args.coloring.to_string() != Coloring::Auto.to_string() {
-        direct_args.push(OsString::from("--coloring"));
-        direct_args.push(OsString::from(args.coloring.to_string()));
-    };
-    if args.frozen {
-        direct_args.push(OsString::from("--frozen"));
-    };
-    if args.locked {
-        direct_args.push(OsString::from("--locked"));
-    };
-    if args.offline {
-        direct_args.push(OsString::from("--offline"));
-    };
+
     direct_args
 }
 

--- a/devtools/x/src/build.rs
+++ b/devtools/x/src/build.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
-    cargo::{CargoArgs, CargoCommand, SelectedPackageArgs},
+    cargo::{selected_package::SelectedPackageArgs, CargoArgs, CargoCommand},
     context::XContext,
     Result,
 };

--- a/devtools/x/src/build.rs
+++ b/devtools/x/src/build.rs
@@ -57,7 +57,7 @@ pub struct Args {
     bench: Vec<String>,
     #[structopt(long)]
     ///  Build all benches
-    benchs: bool,
+    benches: bool,
     #[structopt(long)]
     /// Build all targets
     all_targets: bool,
@@ -159,8 +159,8 @@ pub fn convert_args(args: &Args) -> Vec<OsString> {
             direct_args.push(OsString::from(bench));
         }
     }
-    if args.benchs {
-        direct_args.push(OsString::from("--benchs"));
+    if args.benches {
+        direct_args.push(OsString::from("--benches"));
     };
 
     if args.all_targets {

--- a/devtools/x/src/build.rs
+++ b/devtools/x/src/build.rs
@@ -1,9 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
-    cargo::{
-        build_args::BuildArgs, selected_package::SelectedPackageArgs, CargoArgs, CargoCommand,
-    },
+    cargo::{build_args::BuildArgs, selected_package::SelectedPackageArgs, CargoCommand},
     context::XContext,
     Result,
 };
@@ -55,5 +53,5 @@ pub fn run(args: Box<Args>, xctx: XContext) -> Result<()> {
     };
 
     let packages = args.package_args.to_selected_packages(&xctx)?;
-    cmd.run_on_packages(&packages, &CargoArgs::default())
+    cmd.run_on_packages(&packages)
 }

--- a/devtools/x/src/cargo.rs
+++ b/devtools/x/src/cargo.rs
@@ -2,25 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    changed_since::changed_since_impl,
+    cargo::selected_package::{SelectedInclude, SelectedPackages},
     config::CargoConfig,
-    context::XContext,
     utils::{apply_sccache_if_possible, project_root},
     Result,
 };
 use anyhow::anyhow;
-use guppy::graph::DependencyDirection;
 use indexmap::map::IndexMap;
 use log::{info, warn};
 use std::{
-    collections::BTreeSet,
     env,
     ffi::{OsStr, OsString},
     path::Path,
     process::{Command, Output, Stdio},
     time::Instant,
 };
-use structopt::StructOpt;
+
+pub mod selected_package;
 
 const RUST_TOOLCHAIN_VERSION: &str = include_str!("../../../rust-toolchain");
 const RUSTUP_TOOLCHAIN: &str = "RUSTUP_TOOLCHAIN";
@@ -389,178 +387,5 @@ impl<'a> CargoCommand<'a> {
         if args.all_targets {
             cargo.all_targets();
         }
-    }
-}
-
-/// Arguments for the Cargo package selector.
-#[derive(Debug, StructOpt)]
-pub struct SelectedPackageArgs {
-    #[structopt(long, short, number_of_values = 1)]
-    /// Run on the provided packages
-    pub(crate) package: Vec<String>,
-    #[structopt(long, short)]
-    /// Run on packages changed since the merge base of this commit
-    changed_since: Option<String>,
-    #[structopt(long)]
-    /// Run on all packages in the workspace
-    pub(crate) workspace: bool,
-}
-
-impl SelectedPackageArgs {
-    pub fn to_selected_packages<'a>(&'a self, xctx: &'a XContext) -> Result<SelectedPackages<'a>> {
-        // Mutually exclusive options -- only one of these can be provided.
-        {
-            let mut exclusive = vec![];
-            if self.changed_since.is_some() {
-                exclusive.push("--changed-since");
-            }
-            if !self.package.is_empty() {
-                exclusive.push("--package");
-            }
-            if self.workspace {
-                exclusive.push("--workspace");
-            }
-
-            if exclusive.len() > 1 {
-                let err_msg = exclusive.join(", ");
-                return Err(anyhow!("can only specify one of {}", err_msg));
-            }
-        }
-
-        if self.workspace {
-            Ok(SelectedPackages::workspace())
-        } else if !self.package.is_empty() {
-            Ok(SelectedPackages::includes(
-                self.package.iter().map(|s| s.as_str()),
-            ))
-        } else if let Some(base) = &self.changed_since {
-            let affected_set = changed_since_impl(&xctx, &base)?;
-
-            Ok(SelectedPackages::includes(
-                affected_set
-                    .packages(DependencyDirection::Forward)
-                    .map(|package| package.name()),
-            ))
-        } else {
-            SelectedPackages::default_cwd(xctx)
-        }
-    }
-}
-
-/// Package selector for Cargo commands.
-///
-/// This may represent any of the following:
-/// * the entire workspace
-/// * a single package without arguments
-/// * a list of packages
-///
-/// This may also exclude a set of packages. Note that currently, excludes only work in the "entire
-/// workspace" and "list of packages" situations. They are ignored if a specific local package is
-/// being built. (This is an extension on top of Cargo itself, which only supports --exclude
-/// together with --workspace.)
-///
-/// Excludes are applied after includes. This allows changed-since to support excludes, even if only
-/// a subset of the workspace changes.
-#[derive(Clone, Debug)]
-pub struct SelectedPackages<'a> {
-    includes: SelectedInclude<'a>,
-    excludes: BTreeSet<&'a str>,
-}
-
-impl<'a> SelectedPackages<'a> {
-    /// Returns a new `CargoPackages` that selects all packages in this workspace.
-    pub fn workspace() -> Self {
-        Self {
-            includes: SelectedInclude::Workspace,
-            excludes: BTreeSet::new(),
-        }
-    }
-
-    /// Returns a new `CargoPackages` that selects the default set of packages for the current
-    /// working directory. This may either be the entire workspace or a set of packages inside the
-    /// workspace.
-    pub fn default_cwd(xctx: &'a XContext) -> Result<Self> {
-        let includes = if xctx.core().current_dir_is_root() {
-            SelectedInclude::Workspace
-        } else {
-            // Select all packages that begin with the current rel dir.
-            let rel = xctx.core().current_rel_dir();
-            let workspace = xctx.core().package_graph()?.workspace();
-            let selected = workspace.iter_by_path().filter_map(|(path, package)| {
-                // If we're in devtools, run tests for all packages inside devtools.
-                // If we're in devtools/x/src, run tests for devtools/x.
-                if path.starts_with(rel) || rel.starts_with(path) {
-                    Some(package.name())
-                } else {
-                    None
-                }
-            });
-            SelectedInclude::Includes(selected.collect())
-        };
-        Ok(Self {
-            includes,
-            excludes: BTreeSet::new(),
-        })
-    }
-
-    /// Returns a new `CargoPackages` that selects the specified packages.
-    pub fn includes(package_names: impl IntoIterator<Item = &'a str>) -> Self {
-        Self {
-            includes: SelectedInclude::Includes(package_names.into_iter().collect()),
-            excludes: BTreeSet::new(),
-        }
-    }
-
-    /// Adds excludes for this `CargoPackages`.
-    ///
-    /// The excludes are currently ignored if the local package is built.
-    pub fn add_excludes(&mut self, exclude_names: impl IntoIterator<Item = &'a str>) -> &mut Self {
-        self.excludes.extend(exclude_names);
-        self
-    }
-
-    // ---
-    // Helper methods
-    // ---
-
-    fn should_invoke(&self) -> bool {
-        match &self.includes {
-            SelectedInclude::Workspace => true,
-            SelectedInclude::Includes(includes) => {
-                // If everything in the include set is excluded, a command invocation isn't needed.
-                includes.iter().any(|p| !self.excludes.contains(p))
-            }
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-enum SelectedInclude<'a> {
-    Workspace,
-    Includes(Vec<&'a str>),
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_should_invoke() {
-        let packages = SelectedPackages::workspace();
-        assert!(packages.should_invoke(), "workspace => invoke");
-
-        let mut packages = SelectedPackages::includes(vec!["foo", "bar"]);
-        packages.add_excludes(vec!["foo"]);
-        assert!(packages.should_invoke(), "non-empty packages => invoke");
-
-        let packages = SelectedPackages::includes(vec![]);
-        assert!(!packages.should_invoke(), "no packages => do not invoke");
-
-        let mut packages = SelectedPackages::includes(vec!["foo", "bar"]);
-        packages.add_excludes(vec!["foo", "bar"]);
-        assert!(
-            !packages.should_invoke(),
-            "all packages excluded => do not invoke"
-        );
     }
 }

--- a/devtools/x/src/cargo.rs
+++ b/devtools/x/src/cargo.rs
@@ -18,6 +18,7 @@ use std::{
     time::Instant,
 };
 
+pub mod build_args;
 pub mod selected_package;
 
 const RUST_TOOLCHAIN_VERSION: &str = include_str!("../../../rust-toolchain");

--- a/devtools/x/src/cargo.rs
+++ b/devtools/x/src/cargo.rs
@@ -274,6 +274,8 @@ impl Cargo {
     }
 }
 
+// TODO: this should really be a struct instead of an enum with repeated fields.
+
 /// Represents an invocations of cargo that will call multiple other invocations of
 /// cargo based on groupings implied by the contents of <workspace-root>/x.toml.
 pub enum CargoCommand<'a> {

--- a/devtools/x/src/cargo/build_args.rs
+++ b/devtools/x/src/cargo/build_args.rs
@@ -1,0 +1,208 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::ffi::OsString;
+use structopt::{clap::arg_enum, StructOpt};
+
+arg_enum! {
+    #[derive(Debug)]
+    pub enum Coloring {
+        Auto,
+        Always,
+        Never,
+    }
+}
+
+/// Arguments for controlling cargo build and other similar commands (like check).
+#[derive(Debug, StructOpt)]
+pub struct BuildArgs {
+    #[structopt(long, short)]
+    /// No output printed to stdout
+    pub(crate) quiet: bool,
+    #[structopt(long, short)]
+    /// Number of parallel jobs, defaults to # of CPUs
+    pub(crate) jobs: Option<u16>,
+    #[structopt(long)]
+    /// Only this package's library
+    pub(crate) lib: bool,
+    #[structopt(long, number_of_values = 1)]
+    /// Only the specified binary
+    pub(crate) bin: Vec<String>,
+    #[structopt(long)]
+    /// All binaries
+    pub(crate) bins: bool,
+    #[structopt(long, number_of_values = 1)]
+    /// Only the specified example
+    pub(crate) example: Vec<String>,
+    #[structopt(long)]
+    /// All examples
+    pub(crate) examples: bool,
+    #[structopt(long, number_of_values = 1)]
+    /// Only the specified test target
+    pub(crate) test: Vec<String>,
+    #[structopt(long)]
+    /// All tests
+    pub(crate) tests: bool,
+    #[structopt(long, number_of_values = 1)]
+    /// Only the specified bench target
+    pub(crate) bench: Vec<String>,
+    #[structopt(long)]
+    /// All benches
+    pub(crate) benches: bool,
+    #[structopt(long)]
+    /// All targets
+    pub(crate) all_targets: bool,
+    #[structopt(long)]
+    /// Artifacts in release mode, with optimizations
+    pub(crate) release: bool,
+    #[structopt(long)]
+    /// Artifacts with the specified profile
+    pub(crate) profile: Option<String>,
+    #[structopt(long, number_of_values = 1)]
+    /// Space-separated list of features to activate
+    pub(crate) features: Vec<String>,
+    #[structopt(long)]
+    /// Activate all available features
+    pub(crate) all_features: bool,
+    #[structopt(long)]
+    /// Do not activate the `default` feature
+    pub(crate) no_default_features: bool,
+    #[structopt(long)]
+    /// TRIPLE
+    pub(crate) target: Option<String>,
+    #[structopt(long, parse(from_os_str))]
+    /// Directory for all generated artifacts
+    pub(crate) target_dir: Option<OsString>,
+    #[structopt(long, parse(from_os_str))]
+    /// Path to Cargo.toml
+    pub(crate) manifest_path: Option<OsString>,
+    #[structopt(long)]
+    /// Error format
+    pub(crate) message_format: Option<String>,
+    #[structopt(long, short, parse(from_occurrences))]
+    /// Use verbose output (-vv very verbose/build.rs output)
+    pub(crate) verbose: usize,
+    #[structopt(long, possible_values = &Coloring::variants(), default_value="Auto")]
+    /// Coloring: auto, always, never
+    pub(crate) coloring: Coloring,
+    #[structopt(long)]
+    /// Require Cargo.lock and cache are up to date
+    pub(crate) frozen: bool,
+    #[structopt(long)]
+    /// Require Cargo.lock is up to date
+    pub(crate) locked: bool,
+    #[structopt(long)]
+    /// Run without accessing the network
+    pub(crate) offline: bool,
+}
+
+impl BuildArgs {
+    pub fn add_args(&self, direct_args: &mut Vec<OsString>) {
+        if self.quiet {
+            direct_args.push(OsString::from("--quiet"));
+        }
+        if let Some(jobs) = self.jobs {
+            direct_args.push(OsString::from("--jobs"));
+            direct_args.push(OsString::from(jobs.to_string()));
+        };
+        if self.lib {
+            direct_args.push(OsString::from("--lib"));
+        };
+        if !self.bin.is_empty() {
+            direct_args.push(OsString::from("--bin"));
+            for bin in &self.bin {
+                direct_args.push(OsString::from(bin));
+            }
+        }
+        if self.bins {
+            direct_args.push(OsString::from("--bins"));
+        };
+        if !self.example.is_empty() {
+            direct_args.push(OsString::from("--example"));
+            for example in &self.example {
+                direct_args.push(OsString::from(example));
+            }
+        }
+        if self.examples {
+            direct_args.push(OsString::from("--examples"));
+        };
+
+        if !self.test.is_empty() {
+            direct_args.push(OsString::from("--test"));
+            for test in &self.test {
+                direct_args.push(OsString::from(test));
+            }
+        }
+        if self.tests {
+            direct_args.push(OsString::from("--tests"));
+        };
+
+        if !self.bench.is_empty() {
+            direct_args.push(OsString::from("--bench"));
+            for bench in &self.bench {
+                direct_args.push(OsString::from(bench));
+            }
+        }
+        if self.benches {
+            direct_args.push(OsString::from("--benches"));
+        };
+
+        if self.all_targets {
+            direct_args.push(OsString::from("--all-targets"));
+        };
+        if self.release {
+            direct_args.push(OsString::from("--release"));
+        };
+
+        if let Some(profile) = &self.profile {
+            direct_args.push(OsString::from("--profile"));
+            direct_args.push(OsString::from(profile.to_string()));
+        };
+
+        if !self.features.is_empty() {
+            direct_args.push(OsString::from("--features"));
+            for features in &self.features {
+                direct_args.push(OsString::from(features));
+            }
+        }
+        if self.all_features {
+            direct_args.push(OsString::from("--all-features"));
+        };
+        if self.no_default_features {
+            direct_args.push(OsString::from("--no-default-features"));
+        };
+
+        if let Some(target) = &self.target {
+            direct_args.push(OsString::from("--target"));
+            direct_args.push(OsString::from(target.to_string()));
+        };
+        if let Some(target_dir) = &self.target_dir {
+            direct_args.push(OsString::from("--target-dir"));
+            direct_args.push(OsString::from(target_dir));
+        };
+        if let Some(manifest_path) = &self.manifest_path {
+            direct_args.push(OsString::from("--manifest-path"));
+            direct_args.push(manifest_path.to_owned());
+        };
+        if let Some(message_format) = &self.message_format {
+            direct_args.push(OsString::from("--message-format"));
+            direct_args.push(OsString::from(message_format.to_string()));
+        };
+        if self.verbose > 0 {
+            direct_args.push(OsString::from(format!("-{}", "v".repeat(self.verbose))));
+        };
+        if self.coloring.to_string() != Coloring::Auto.to_string() {
+            direct_args.push(OsString::from("--coloring"));
+            direct_args.push(OsString::from(self.coloring.to_string()));
+        };
+        if self.frozen {
+            direct_args.push(OsString::from("--frozen"));
+        };
+        if self.locked {
+            direct_args.push(OsString::from("--locked"));
+        };
+        if self.offline {
+            direct_args.push(OsString::from("--offline"));
+        };
+    }
+}

--- a/devtools/x/src/cargo/build_args.rs
+++ b/devtools/x/src/cargo/build_args.rs
@@ -84,7 +84,7 @@ pub struct BuildArgs {
     pub(crate) verbose: usize,
     #[structopt(long, possible_values = &Coloring::variants(), default_value="Auto")]
     /// Coloring: auto, always, never
-    pub(crate) coloring: Coloring,
+    pub(crate) color: Coloring,
     #[structopt(long)]
     /// Require Cargo.lock and cache are up to date
     pub(crate) frozen: bool,
@@ -191,9 +191,9 @@ impl BuildArgs {
         if self.verbose > 0 {
             direct_args.push(OsString::from(format!("-{}", "v".repeat(self.verbose))));
         };
-        if self.coloring.to_string() != Coloring::Auto.to_string() {
-            direct_args.push(OsString::from("--coloring"));
-            direct_args.push(OsString::from(self.coloring.to_string()));
+        if self.color.to_string() != Coloring::Auto.to_string() {
+            direct_args.push(OsString::from("--color"));
+            direct_args.push(OsString::from(self.color.to_string()));
         };
         if self.frozen {
             direct_args.push(OsString::from("--frozen"));

--- a/devtools/x/src/cargo/selected_package.rs
+++ b/devtools/x/src/cargo/selected_package.rs
@@ -1,0 +1,181 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{changed_since::changed_since_impl, context::XContext, Result};
+use anyhow::anyhow;
+use guppy::graph::DependencyDirection;
+use std::collections::BTreeSet;
+use structopt::StructOpt;
+
+/// Arguments for the Cargo package selector.
+#[derive(Debug, StructOpt)]
+pub struct SelectedPackageArgs {
+    #[structopt(long, short, number_of_values = 1)]
+    /// Run on the provided packages
+    pub(crate) package: Vec<String>,
+    #[structopt(long, short)]
+    /// Run on packages changed since the merge base of this commit
+    changed_since: Option<String>,
+    #[structopt(long)]
+    /// Run on all packages in the workspace
+    pub(crate) workspace: bool,
+}
+
+impl SelectedPackageArgs {
+    pub fn to_selected_packages<'a>(&'a self, xctx: &'a XContext) -> Result<SelectedPackages<'a>> {
+        // Mutually exclusive options -- only one of these can be provided.
+        {
+            let mut exclusive = vec![];
+            if self.changed_since.is_some() {
+                exclusive.push("--changed-since");
+            }
+            if !self.package.is_empty() {
+                exclusive.push("--package");
+            }
+            if self.workspace {
+                exclusive.push("--workspace");
+            }
+
+            if exclusive.len() > 1 {
+                let err_msg = exclusive.join(", ");
+                return Err(anyhow!("can only specify one of {}", err_msg));
+            }
+        }
+
+        if self.workspace {
+            Ok(SelectedPackages::workspace())
+        } else if !self.package.is_empty() {
+            Ok(SelectedPackages::includes(
+                self.package.iter().map(|s| s.as_str()),
+            ))
+        } else if let Some(base) = &self.changed_since {
+            let affected_set = changed_since_impl(&xctx, &base)?;
+
+            Ok(SelectedPackages::includes(
+                affected_set
+                    .packages(DependencyDirection::Forward)
+                    .map(|package| package.name()),
+            ))
+        } else {
+            SelectedPackages::default_cwd(xctx)
+        }
+    }
+}
+
+/// Package selector for Cargo commands.
+///
+/// This may represent any of the following:
+/// * the entire workspace
+/// * a single package without arguments
+/// * a list of packages
+///
+/// This may also exclude a set of packages. Note that currently, excludes only work in the "entire
+/// workspace" and "list of packages" situations. They are ignored if a specific local package is
+/// being built. (This is an extension on top of Cargo itself, which only supports --exclude
+/// together with --workspace.)
+///
+/// Excludes are applied after includes. This allows changed-since to support excludes, even if only
+/// a subset of the workspace changes.
+#[derive(Clone, Debug)]
+pub struct SelectedPackages<'a> {
+    pub(super) includes: SelectedInclude<'a>,
+    pub(super) excludes: BTreeSet<&'a str>,
+}
+
+impl<'a> SelectedPackages<'a> {
+    /// Returns a new `CargoPackages` that selects all packages in this workspace.
+    pub fn workspace() -> Self {
+        Self {
+            includes: SelectedInclude::Workspace,
+            excludes: BTreeSet::new(),
+        }
+    }
+
+    /// Returns a new `CargoPackages` that selects the default set of packages for the current
+    /// working directory. This may either be the entire workspace or a set of packages inside the
+    /// workspace.
+    pub fn default_cwd(xctx: &'a XContext) -> Result<Self> {
+        let includes = if xctx.core().current_dir_is_root() {
+            SelectedInclude::Workspace
+        } else {
+            // Select all packages that begin with the current rel dir.
+            let rel = xctx.core().current_rel_dir();
+            let workspace = xctx.core().package_graph()?.workspace();
+            let selected = workspace.iter_by_path().filter_map(|(path, package)| {
+                // If we're in devtools, run tests for all packages inside devtools.
+                // If we're in devtools/x/src, run tests for devtools/x.
+                if path.starts_with(rel) || rel.starts_with(path) {
+                    Some(package.name())
+                } else {
+                    None
+                }
+            });
+            SelectedInclude::Includes(selected.collect())
+        };
+        Ok(Self {
+            includes,
+            excludes: BTreeSet::new(),
+        })
+    }
+
+    /// Returns a new `CargoPackages` that selects the specified packages.
+    pub fn includes(package_names: impl IntoIterator<Item = &'a str>) -> Self {
+        Self {
+            includes: SelectedInclude::Includes(package_names.into_iter().collect()),
+            excludes: BTreeSet::new(),
+        }
+    }
+
+    /// Adds excludes for this `CargoPackages`.
+    ///
+    /// The excludes are currently ignored if the local package is built.
+    pub fn add_excludes(&mut self, exclude_names: impl IntoIterator<Item = &'a str>) -> &mut Self {
+        self.excludes.extend(exclude_names);
+        self
+    }
+
+    // ---
+    // Helper methods
+    // ---
+
+    pub(super) fn should_invoke(&self) -> bool {
+        match &self.includes {
+            SelectedInclude::Workspace => true,
+            SelectedInclude::Includes(includes) => {
+                // If everything in the include set is excluded, a command invocation isn't needed.
+                includes.iter().any(|p| !self.excludes.contains(p))
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) enum SelectedInclude<'a> {
+    Workspace,
+    Includes(Vec<&'a str>),
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_should_invoke() {
+        let packages = SelectedPackages::workspace();
+        assert!(packages.should_invoke(), "workspace => invoke");
+
+        let mut packages = SelectedPackages::includes(vec!["foo", "bar"]);
+        packages.add_excludes(vec!["foo"]);
+        assert!(packages.should_invoke(), "non-empty packages => invoke");
+
+        let packages = SelectedPackages::includes(vec![]);
+        assert!(!packages.should_invoke(), "no packages => do not invoke");
+
+        let mut packages = SelectedPackages::includes(vec!["foo", "bar"]);
+        packages.add_excludes(vec!["foo", "bar"]);
+        assert!(
+            !packages.should_invoke(),
+            "all packages excluded => do not invoke"
+        );
+    }
+}

--- a/devtools/x/src/check.rs
+++ b/devtools/x/src/check.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    cargo::{CargoArgs, CargoCommand, SelectedPackageArgs},
+    cargo::{selected_package::SelectedPackageArgs, CargoArgs, CargoCommand},
     context::XContext,
     Result,
 };

--- a/devtools/x/src/fix.rs
+++ b/devtools/x/src/fix.rs
@@ -1,27 +1,39 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{cargo::CargoCommand, check, context::XContext, Result};
+use crate::{
+    cargo::{build_args::BuildArgs, selected_package::SelectedPackageArgs, CargoCommand},
+    context::XContext,
+    Result,
+};
 use std::ffi::OsString;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 pub struct Args {
     #[structopt(flatten)]
-    check_args: check::Args,
+    pub(crate) package_args: SelectedPackageArgs,
+    #[structopt(flatten)]
+    pub(crate) build_args: BuildArgs,
     #[structopt(name = "ARGS", parse(from_os_str), last = true)]
     args: Vec<OsString>,
 }
 
-pub fn run(args: Args, xctx: XContext) -> Result<()> {
+pub fn run(mut args: Args, xctx: XContext) -> Result<()> {
     let mut pass_through_args = vec![];
     pass_through_args.extend(args.args);
 
-    let with_all_targets = check::Args {
-        all_targets: true,
-        ..args.check_args
-    };
+    // Always run fix on all targets.
+    args.build_args.all_targets = true;
 
-    let cmd = CargoCommand::Fix(xctx.config().cargo_config(), &pass_through_args);
-    check::run_with(cmd, with_all_targets, &xctx)
+    let mut direct_args = vec![];
+    args.build_args.add_args(&mut direct_args);
+
+    let cmd = CargoCommand::Fix {
+        cargo_config: xctx.config().cargo_config(),
+        direct_args: &direct_args,
+        args: &pass_through_args,
+    };
+    let packages = args.package_args.to_selected_packages(&xctx)?;
+    cmd.run_on_packages(&packages)
 }

--- a/devtools/x/src/test.rs
+++ b/devtools/x/src/test.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    cargo::{CargoArgs, CargoCommand, SelectedPackageArgs},
+    cargo::{selected_package::SelectedPackageArgs, CargoArgs, CargoCommand},
     context::XContext,
     utils::project_root,
     Result,

--- a/devtools/x/src/test.rs
+++ b/devtools/x/src/test.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    cargo::{selected_package::SelectedPackageArgs, CargoArgs, CargoCommand},
+    cargo::{selected_package::SelectedPackageArgs, CargoCommand},
     context::XContext,
     utils::project_root,
     Result,
@@ -110,7 +110,7 @@ pub fn run(mut args: Args, xctx: XContext) -> Result<()> {
         env: &env_vars,
     };
 
-    let cmd_result = cmd.run_on_packages(&packages, &CargoArgs::default());
+    let cmd_result = cmd.run_on_packages(&packages);
 
     if !args.no_fail_fast && cmd_result.is_err() {
         return cmd_result;


### PR DESCRIPTION
The main goal here is to cut down on build-dev times.

Previously we were doing a full check (without --all-targets), then checks on a few packages. Do this in a more principled manner:
* a check of all production code
* a check of all code in the workspace

Also refactor a bunch of code to be shared across build, check, test and a couple other commands.