### PR TITLE
[infallible] Reexport lock guard types

### DIFF
--- a/common/infallible/src/lib.rs
+++ b/common/infallible/src/lib.rs
@@ -5,6 +5,6 @@ mod mutex;
 mod rwlock;
 mod time;
 
-pub use mutex::Mutex;
-pub use rwlock::RwLock;
+pub use mutex::{Mutex, MutexGuard};
+pub use rwlock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 pub use time::duration_since_epoch;

--- a/common/infallible/src/mutex.rs
+++ b/common/infallible/src/mutex.rs
@@ -1,7 +1,9 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::{Mutex as StdMutex, MutexGuard};
+use std::sync::Mutex as StdMutex;
+
+pub use std::sync::MutexGuard;
 
 /// A simple wrapper around the lock() function of a std::sync::Mutex
 /// The only difference is that you don't need to call unwrap() on it.

--- a/common/infallible/src/rwlock.rs
+++ b/common/infallible/src/rwlock.rs
@@ -1,17 +1,19 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::{RwLock as RwLockImpl, RwLockReadGuard, RwLockWriteGuard};
+use std::sync::RwLock as StdRwLock;
+
+pub use std::sync::{RwLockReadGuard, RwLockWriteGuard};
 
 /// A simple wrapper around the lock() function of a std::sync::RwLock
 /// The only difference is that you don't need to call unwrap() on it.
 #[derive(Debug, Default)]
-pub struct RwLock<T>(RwLockImpl<T>);
+pub struct RwLock<T>(StdRwLock<T>);
 
 impl<T> RwLock<T> {
     /// creates a read-write lock
     pub fn new(t: T) -> Self {
-        Self(RwLockImpl::new(t))
+        Self(StdRwLock::new(t))
     }
 
     /// lock the rwlock in read mode

--- a/storage/scratchpad/src/sparse_merkle/node.rs
+++ b/storage/scratchpad/src/sparse_merkle/node.rs
@@ -21,12 +21,12 @@ use diem_crypto::{
     hash::{CryptoHash, SPARSE_MERKLE_PLACEHOLDER_HASH},
     HashValue,
 };
-use diem_infallible::RwLock;
+use diem_infallible::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use diem_types::{
     account_state_blob::AccountStateBlob,
     proof::{SparseMerkleInternalNode, SparseMerkleLeafNode},
 };
-use std::sync::{Arc, RwLockReadGuard, RwLockWriteGuard};
+use std::sync::Arc;
 
 /// We wrap the node in `RwLock`. The only case when we will update the node is when we
 /// drop a subtree originated from this node and commit things to storage. In that case we will


### PR DESCRIPTION
Minor code cleanliness change. Reexport lock guard types `MutexGuard`,
`RwLockReadGuard`, and `RwLockWriteGuard` through `diem-infallible` so
you can do:

```rust
use diem_infallible::{Mutex, MutexGuard};
```

instead of:

```rust
use diem_infallible::Mutex;
use std::sync::MutexGuard;
```