### PR TITLE
[time-service] Add TimeService for mocking async time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6875,6 +6875,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "time-service"
+version = "0.1.0"
+dependencies = [
+ "diem-infallible",
+ "diem-workspace-hack",
+ "enum_dispatch",
+ "futures 0.3.8",
+ "pin-project 1.0.2",
+ "thiserror",
+ "tokio",
+ "tokio-test",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6962,6 +6976,17 @@ dependencies = [
  "futures 0.1.30",
  "rand 0.4.6",
  "tokio-timer",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed0049c119b6d505c4447f5c64873636c7af6c75ab0d45fd9f618d82acb8016d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "common/short-hex-str",
     "common/subscription-service",
     "common/temppath",
+    "common/time-service",
     "common/trace",
     "common/workspace-hack",
     "config",

--- a/common/time-service/Cargo.toml
+++ b/common/time-service/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "time-service"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+description = "Time service"
+repository = "https://github.com/diem/diem"
+homepage = "https://diem.com"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+enum_dispatch = "0.3.4"
+futures = "0.3.8"
+pin-project = "1.0.2"
+thiserror = "1.0.22"
+tokio = { version = "0.2.22", features = ["macros", "rt-threaded", "time"] }
+
+diem-infallible = { path = "../infallible", version = "0.1.0" }
+diem-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
+
+[dev-dependencies]
+tokio-test = "0.2.1"
+
+[features]
+default = []
+fuzzing = []
+testing = []

--- a/common/time-service/src/interval.rs
+++ b/common/time-service/src/interval.rs
@@ -1,0 +1,43 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{Sleep, SleepTrait, ZERO_DURATION};
+use futures::{future::Future, ready, stream::Stream};
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+/// Stream returned by [`TimeService::interval`](crate::TimeService::interval).
+///
+/// Mostly taken from [`tokio::time::Interval`] but uses our `Sleep` future.
+#[must_use = "streams do nothing unless you `.await` or poll them"]
+pub struct Interval {
+    delay: Sleep,
+    period: Duration,
+}
+
+impl Interval {
+    pub fn new(delay: Sleep, period: Duration) -> Self {
+        assert!(period > ZERO_DURATION, "`period` must be non-zero.");
+
+        Self { delay, period }
+    }
+}
+
+impl Stream for Interval {
+    type Item = ();
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+
+        // Wait for the delay to be done
+        ready!(Pin::new(&mut this.delay).poll(cx));
+
+        // Reset the delay before next round
+        this.delay.reset(this.period);
+
+        Poll::Ready(Some(()))
+    }
+}

--- a/common/time-service/src/lib.rs
+++ b/common/time-service/src/lib.rs
@@ -1,0 +1,165 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+//! Abstract time service
+
+use enum_dispatch::enum_dispatch;
+use futures::future::Future;
+use std::{
+    fmt::Debug,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+pub mod interval;
+#[cfg(any(test, feature = "fuzzing", feature = "testing"))]
+pub mod mock;
+pub mod timeout;
+pub mod tokio;
+
+#[cfg(any(test, feature = "fuzzing", feature = "testing"))]
+pub use crate::mock::{MockSleep, MockTimeService};
+pub use crate::{
+    interval::Interval,
+    timeout::Timeout,
+    tokio::{TokioSleep, TokioTimeService},
+};
+
+// TODO(philiphayes): use Duration constants when those stabilize.
+const ZERO_DURATION: Duration = Duration::from_nanos(0);
+
+/// `TimeService` abstracts all time-related operations in one place that can be
+/// easily mocked-out and controlled in tests or delegated to the actual
+/// underlying runtime (usually tokio). It's provided as an enum so we don't have
+/// to infect everything with a generic tag.
+///
+/// `TimeService` is async-focused: the `sleep`, `interval`, and `timeout` methods
+/// all return `Future`s and `Stream`s.
+///
+/// `TimeService` tries to mirror the API provided by [`tokio::time`] to an
+/// extent. The key difference is that all time is expressed in relative
+/// [`Duration`]s. In other words, "sleep for 5s" vs "sleep until unix time
+/// 1607734460". Absolute time is provided by [`TimeService::now`] which returns
+/// the current unix time.
+///
+/// Note: we have to provide our own [`Timeout`] and [`Interval`] types that
+/// use the [`Sleep`] future.
+///
+/// Note: `TimeService`'s should be free (or very cheap) to clone and send around
+/// between threads. In production (without test features), this enum is a
+/// zero-sized type.
+#[enum_dispatch(TimeServiceTrait)]
+#[derive(Clone, Debug)]
+pub enum TimeService {
+    TokioTimeService(TokioTimeService),
+
+    #[cfg(any(test, feature = "fuzzing", feature = "testing"))]
+    MockTimeService(MockTimeService),
+}
+
+impl TimeService {
+    pub fn tokio() -> Self {
+        TokioTimeService::new().into()
+    }
+
+    #[cfg(any(test, feature = "fuzzing", feature = "testing"))]
+    pub fn mock() -> Self {
+        MockTimeService::new().into()
+    }
+
+    #[cfg(any(test, feature = "fuzzing", feature = "testing"))]
+    pub fn into_mock(self) -> MockTimeService {
+        match self {
+            TimeService::MockTimeService(inner) => inner,
+            ts => panic!("Unexpected TimeService, expected MockTimeService: {:?}", ts),
+        }
+    }
+}
+
+#[enum_dispatch]
+pub trait TimeServiceTrait: Send + Sync + Clone + Debug {
+    /// Query the time service for the current unix timestamp.
+    fn now(&self) -> Duration;
+
+    /// Return a [`Future`] that waits until `duration` has passed.
+    ///
+    /// No work is performed while awaiting on the sleep future to complete. `Sleep`
+    /// operates at millisecond granularity and should not be used for tasks that
+    /// require high-resolution timers.
+    ///
+    /// # Cancelation
+    ///
+    /// Canceling a sleep instance is done by dropping the returned future. No
+    /// additional cleanup work is required.
+    fn sleep(&self, duration: Duration) -> Sleep;
+
+    /// Creates new [`Interval`] that yields with interval of `period`. The first
+    /// tick completes immediately. An interval will tick indefinitely.
+    ///
+    /// # Cancelation
+    ///
+    /// At any time, the [`Interval`] value can be dropped. This cancels the interval.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if `period` is zero.
+    fn interval(&self, period: Duration) -> Interval {
+        let delay = self.sleep(ZERO_DURATION);
+        Interval::new(delay, period)
+    }
+
+    /// Require a [`Future`] to complete before the specified duration has elapsed.
+    ///
+    /// If the future completes before the duration has elapsed, then the completed
+    /// value is returned. Otherwise, `Err(Elapsed)` is returned and the future is
+    /// canceled.
+    ///
+    /// # Cancelation
+    ///
+    /// Cancelling a timeout is done by dropping the future. No additional cleanup
+    /// or other work is required.
+    ///
+    /// The original future may be obtained by calling [`Timeout::into_inner`]. This
+    /// consumes the [`Timeout`].
+    fn timeout<F: Future>(&self, duration: Duration, future: F) -> Timeout<F> {
+        let delay = self.sleep(duration);
+        Timeout::new(future, delay)
+    }
+}
+
+/// A [`Future`] that resolves after some time has elapsed (either real or
+/// simulated, depending on the parent [`TimeService`]).
+///
+/// `Sleep` is modeled after [`tokio::time::Delay`].
+#[enum_dispatch(SleepTrait)]
+#[derive(Debug)]
+pub enum Sleep {
+    TokioSleep,
+
+    #[cfg(any(test, feature = "fuzzing", feature = "testing"))]
+    MockSleep,
+}
+
+impl Future for Sleep {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.get_mut() {
+            Sleep::TokioSleep(inner) => Pin::new(inner).poll(cx),
+            #[cfg(any(test, feature = "fuzzing", feature = "testing"))]
+            Sleep::MockSleep(inner) => Pin::new(inner).poll(cx),
+        }
+    }
+}
+
+#[enum_dispatch]
+pub trait SleepTrait: Future<Output = ()> + Send + Sync + Unpin + Debug {
+    /// Returns `true` if this `Sleep`'s requested wait duration has elapsed.
+    fn is_elapsed(&self) -> bool;
+
+    /// Resets this `Sleep`'s wait duration.
+    fn reset(&mut self, duration: Duration);
+}

--- a/common/time-service/src/mock.rs
+++ b/common/time-service/src/mock.rs
@@ -1,0 +1,467 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{Sleep, SleepTrait, TimeServiceTrait, ZERO_DURATION};
+use diem_infallible::Mutex;
+use futures::future::Future;
+use std::{
+    cmp::max,
+    collections::hash_map::{DefaultHasher, HashMap},
+    fmt::Debug,
+    hash::BuildHasherDefault,
+    pin::Pin,
+    sync::{Arc, MutexGuard},
+    task::{Context, Poll, Waker},
+    time::Duration,
+};
+
+// TODO(philiphayes): use more robust solution that'll let us control the seed.
+type DeterministicHasher = BuildHasherDefault<DefaultHasher>;
+
+type SleepIndex = usize;
+
+/// A [`TimeService`] that simulates time and allows for fine-grained control over
+/// advancing time and waking up sleeping tasks.
+#[derive(Clone, Debug)]
+pub struct MockTimeService {
+    inner: Arc<Mutex<Inner>>,
+}
+
+#[derive(Debug)]
+struct Inner {
+    /// The current simulated time.
+    now: Duration,
+    /// The next free index in the `pending` queue that we can allocate to a new waiter.
+    next_sleep_index: SleepIndex,
+    /// A queue of pending `SleepEntry`s, each with a deadline for when we should
+    /// wake them.
+    ///
+    /// This `HashMap` also uses a hasher with constant seed (in the future the
+    /// seed should be configurable) to help improve test determinism.
+    pending: HashMap<SleepIndex, SleepEntry, DeterministicHasher>,
+}
+
+/// A timer entry owned by the `MockTimeService` in the `pending` queue.
+///
+/// These are indexed by `SleepIndex`, which you get when you `register_sleep` a
+/// new waiter.
+#[derive(Debug)]
+struct SleepEntry {
+    /// The time when this sleep task expires and should be woken up.
+    deadline: Duration,
+    /// When the corresponding `MockSleep` future polls and isn't expired
+    /// yet, it will register its `Waker` here for the `MockTimeService`
+    maybe_waker: Option<Waker>,
+}
+
+/// A [`Future`] that resolves when the simulated time in the [`MockTimeService`]
+/// advances past the deadline. When these are pending, they have a `SleepEntry`
+/// in the `MockTimeService`'s `pending` queue.
+#[derive(Debug)]
+pub struct MockSleep {
+    /// A handle to the `MockTimeService` so we can get the underlying `SleepEntry`.
+    time_service: MockTimeService,
+    /// The index of this `MockSleep`'s `SleepEntry` in the `MockTimeService`'s
+    /// `pending` queue. If the `pending` queue doesn't contain our entry, then
+    /// this sleep must be completed.
+    entry_index: SleepIndex,
+}
+
+/////////////////////
+// MockTimeService //
+/////////////////////
+
+impl MockTimeService {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Inner {
+                now: ZERO_DURATION,
+                next_sleep_index: 0,
+                pending: HashMap::default(),
+            })),
+        }
+    }
+
+    fn lock(&self) -> MutexGuard<'_, Inner> {
+        self.inner.lock()
+    }
+
+    /// Return the number of pending `Sleep` waiters.
+    pub fn num_waiters(&self) -> usize {
+        self.lock().pending.len()
+    }
+
+    /// Advance time to the next pending waiter, wake it up, and return the wake
+    /// time, or `None` if there are no waiters.
+    pub async fn advance_to_next(&self) -> Option<Duration> {
+        let wake_time = self.lock().advance_to_next();
+
+        // Yield to the executor to run any freshly awoken tasks (which might
+        // also create more `Sleep` futures).
+        //
+        // Imporant: don't hold the lock while yielding. We don't want to block
+        // creating new `Sleep`s or letting existing `Sleep`s run.
+        tokio::task::yield_now().await;
+
+        wake_time
+    }
+
+    /// Advance time by `duration` and wake any pending waiters whose sleep has
+    /// expired. Return the number of waiters that we woke up.
+    pub async fn advance(&self, duration: Duration) -> usize {
+        let num_woken = self.lock().advance(duration);
+
+        // Yield to the executor to run any freshly awoken tasks (which might
+        // also create more `Sleep` futures).
+        //
+        // Imporant: don't hold the lock while yielding. We don't want to block
+        // creating new `Sleep`s or letting existing `Sleep`s run.
+        tokio::task::yield_now().await;
+
+        num_woken
+    }
+}
+
+impl TimeServiceTrait for MockTimeService {
+    fn now(&self) -> Duration {
+        self.lock().now
+    }
+
+    fn sleep(&self, duration: Duration) -> Sleep {
+        MockSleep::new(self.clone(), duration).into()
+    }
+}
+
+///////////
+// Inner //
+///////////
+
+impl Inner {
+    fn advance_to_next(&mut self) -> Option<Duration> {
+        // Find the next entry with the smallest deadline. Exit early without
+        // advancing if there are no pending waiters.
+        let earliest_index = self
+            .pending
+            .iter()
+            .min_by_key(|(_index, entry)| entry.deadline)
+            .map(|(index, _entry)| *index)?;
+
+        // Wake up that entry.
+        let wake_time = self.trigger_sleep(earliest_index).unwrap();
+
+        // If the deadline was in the past, don't actually advance the time.
+        self.now = max(self.now, wake_time);
+
+        Some(self.now)
+    }
+
+    fn advance(&mut self, duration: Duration) -> usize {
+        // Advance the simulated time.
+        self.now += duration;
+
+        // Get the indices and deadlines of all expired waiters.
+        let mut expired_entries = self
+            .pending
+            .iter()
+            .map(|(index, entry)| (*index, entry.deadline))
+            .filter(|(_index, deadline)| deadline <= &self.now)
+            .collect::<Vec<_>>();
+
+        // Wake up the waiters in order.
+        // TODO(philiphayes): break ties (same deadline) randomly but with a controlled seed.
+        expired_entries.sort_by_key(|(_index, deadline)| *deadline);
+
+        // Wake up all the expired waiters.
+        let mut num_woken = 0;
+        for (index, _deadline) in expired_entries.into_iter() {
+            self.trigger_sleep(index).unwrap();
+            num_woken += 1;
+        }
+        num_woken
+    }
+
+    fn next_sleep_index(&mut self) -> SleepIndex {
+        let index = self.next_sleep_index;
+        self.next_sleep_index = self
+            .next_sleep_index
+            .checked_add(1)
+            .expect("too many sleep entries");
+        index
+    }
+
+    fn get_mut_sleep(&mut self, index: SleepIndex) -> Option<&mut SleepEntry> {
+        self.pending.get_mut(&index)
+    }
+
+    fn is_registered(&self, index: SleepIndex) -> bool {
+        self.pending.contains_key(&index)
+    }
+
+    // Register a new waiter that will sleep for `duration`. Return an index that
+    // can be used to query, trigger, or unregister this waiter later on.
+    fn register_sleep(&mut self, duration: Duration, maybe_waker: Option<Waker>) -> SleepIndex {
+        let entry = SleepEntry {
+            deadline: self.now + duration,
+            maybe_waker,
+        };
+        let index = self.next_sleep_index();
+        let prev_entry = self.pending.insert(index, entry);
+        assert!(
+            prev_entry.is_none(),
+            "there can never be a SleepEntry at an unused SleepIndex"
+        );
+        index
+    }
+
+    fn unregister_sleep(&mut self, index: SleepIndex) -> Option<SleepEntry> {
+        self.pending.remove(&index)
+    }
+
+    // Wake up a waiter at the given `index` and return the wake time. Return
+    // `None` if there is no waiter (presumably it was canceled).
+    fn trigger_sleep(&mut self, index: SleepIndex) -> Option<Duration> {
+        self.unregister_sleep(index).map(|entry| {
+            if let Some(waker) = entry.maybe_waker {
+                waker.wake();
+            }
+            entry.deadline
+        })
+    }
+}
+
+///////////////
+// MockSleep //
+///////////////
+
+impl MockSleep {
+    fn new(time_service: MockTimeService, duration: Duration) -> Self {
+        let entry_index = time_service.lock().register_sleep(duration, None);
+
+        Self {
+            time_service,
+            entry_index,
+        }
+    }
+}
+
+impl SleepTrait for MockSleep {
+    fn is_elapsed(&self) -> bool {
+        let inner = self.time_service.lock();
+        !inner.is_registered(self.entry_index)
+    }
+
+    fn reset(&mut self, duration: Duration) {
+        let mut inner = self.time_service.lock();
+
+        // Unregister us from the time service (if we're not triggered yet)
+        // and pull out our waker (if it's there).
+        let maybe_waker = inner
+            .unregister_sleep(self.entry_index)
+            .and_then(|entry| entry.maybe_waker);
+
+        // Register us with the time service with our new deadline.
+        self.entry_index = inner.register_sleep(duration, maybe_waker);
+    }
+}
+
+impl Future for MockSleep {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut inner = self.time_service.lock();
+
+        let maybe_entry = inner.get_mut_sleep(self.entry_index);
+        match maybe_entry {
+            Some(entry) => {
+                // We're still waiting. Update our `Waker` so we can get notified.
+                entry.maybe_waker = Some(cx.waker().clone());
+                Poll::Pending
+            }
+            // If we're not in the queue then we are done!
+            None => Poll::Ready(()),
+        }
+    }
+}
+
+impl Drop for MockSleep {
+    fn drop(&mut self) {
+        // Be sure to unregister us from the pending queue if we get dropped/canceled.
+        self.time_service.lock().unregister_sleep(self.entry_index);
+    }
+}
+
+///////////
+// Tests //
+///////////
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use futures::channel::oneshot;
+    use tokio_test::{
+        assert_pending, assert_ready, assert_ready_eq, assert_ready_err, assert_ready_ok, task,
+    };
+
+    #[tokio::test]
+    async fn test_sleep() {
+        let time = MockTimeService::new();
+
+        // Initial pending queue should be empty. Advancing time wakes nothing.
+        assert_eq!(time.num_waiters(), 0);
+        assert_eq!(time.advance_to_next().await, None);
+        let start = time.now();
+        assert_eq!(time.advance(ms(10)).await, 0);
+        assert_eq!(time.now() - start, ms(10));
+
+        // Create a new sleep future. Check that it's registered in the queue.
+        let mut sleep = task::spawn(time.sleep(ms(10)));
+        assert!(!sleep.is_woken());
+        assert_eq!(time.num_waiters(), 1);
+        assert_pending!(sleep.poll());
+
+        // It won't wake up until we pass its deadline.
+        assert_eq!(time.advance(ms(5)).await, 0);
+        assert!(!sleep.is_woken());
+        assert_pending!(sleep.poll());
+
+        // When we pass the deadline, the sleep future should be unregistered,
+        // woken, and resolved.
+        assert_eq!(time.advance(ms(5)).await, 1);
+        assert_eq!(time.num_waiters(), 0);
+        assert!(sleep.is_woken());
+        assert_ready!(sleep.poll());
+
+        // Resetting the sleep future should register it again.
+        sleep.reset(ms(5));
+        assert!(!sleep.is_woken());
+        assert_eq!(time.num_waiters(), 1);
+        assert_pending!(sleep.poll());
+
+        // Passing the deadline of a reset sleep future should also work.
+        assert_eq!(time.advance(ms(5)).await, 1);
+        assert_eq!(time.num_waiters(), 0);
+        assert!(sleep.is_woken());
+        assert_ready!(sleep.poll());
+
+        // Should still work if we don't poll the sleep future before advance.
+        sleep.reset(ms(5));
+        assert!(!sleep.is_woken());
+
+        assert_eq!(time.advance(ms(5)).await, 1);
+        assert_eq!(time.num_waiters(), 0);
+        assert!(!sleep.is_woken());
+        assert_ready!(sleep.poll());
+    }
+
+    #[tokio::test]
+    async fn test_many_sleep() {
+        let time = MockTimeService::new();
+
+        assert_eq!(time.num_waiters(), 0);
+
+        // Make a bunch of sleep futures.
+        let mut sleep_5ms = task::spawn(time.sleep(ms(5)));
+        let mut sleep_10ms_1 = task::spawn(time.sleep(ms(10)));
+        let mut sleep_10ms_2 = task::spawn(time.sleep(ms(10)));
+        let mut sleep_10ms_3 = task::spawn(time.sleep(ms(10)));
+        let mut sleep_15ms = task::spawn(time.sleep(ms(15)));
+        let mut sleep_20ms = task::spawn(time.sleep(ms(20)));
+
+        assert_eq!(time.num_waiters(), 6);
+
+        assert_pending!(sleep_5ms.poll());
+        assert_pending!(sleep_10ms_1.poll());
+        assert_pending!(sleep_10ms_2.poll());
+        assert_pending!(sleep_10ms_3.poll());
+        assert_pending!(sleep_15ms.poll());
+        assert_pending!(sleep_20ms.poll());
+
+        // Advance 10ms leaving just the 15ms and 20ms waiters.
+        assert_eq!(time.advance(ms(10)).await, 4);
+        assert_eq!(time.num_waiters(), 2);
+
+        assert_ready!(sleep_5ms.poll());
+        assert_ready!(sleep_10ms_1.poll());
+        assert_ready!(sleep_10ms_2.poll());
+        assert_ready!(sleep_10ms_3.poll());
+        assert_pending!(sleep_15ms.poll());
+        assert_pending!(sleep_20ms.poll());
+
+        // Advance to next, triggering the 15ms waiter.
+        assert_eq!(time.advance_to_next().await, Some(ms(15)));
+        assert_eq!(time.num_waiters(), 1);
+
+        assert_ready!(sleep_15ms.poll());
+        assert_pending!(sleep_20ms.poll());
+
+        // Advance to next, triggering the final 20ms waiter.
+        assert_eq!(time.advance_to_next().await, Some(ms(20)));
+        assert_eq!(time.num_waiters(), 0);
+
+        assert_ready!(sleep_20ms.poll());
+    }
+
+    #[tokio::test]
+    async fn test_interval() {
+        let time = MockTimeService::new();
+
+        let mut interval = task::spawn(time.interval(ms(10)));
+
+        assert_pending!(interval.poll_next());
+        assert!(!interval.is_woken());
+
+        // Interval should trigger immediately.
+        assert_eq!(time.advance_to_next().await, Some(ms(0)));
+        assert!(interval.is_woken());
+        assert_ready_eq!(interval.poll_next(), Some(()));
+        assert_pending!(interval.poll_next());
+
+        // Interval won't trigger until we pass the period.
+        assert_eq!(time.advance(ms(5)).await, 0);
+        assert!(!interval.is_woken());
+        assert_pending!(interval.poll_next());
+
+        // Interval should trigger again.
+        assert_eq!(time.advance(ms(5)).await, 1);
+        assert!(interval.is_woken());
+        assert_ready_eq!(interval.poll_next(), Some(()));
+        assert_pending!(interval.poll_next());
+    }
+
+    #[tokio::test]
+    async fn test_timeout() {
+        // Timeout with a future that's immediately ready.
+        let time = MockTimeService::new();
+        let mut timeout = task::spawn(time.timeout(ms(10), async {}));
+        assert_ready_ok!(timeout.poll());
+
+        // Timeout with future and deadline: future wins.
+        let time = MockTimeService::new();
+        let (tx, rx) = oneshot::channel();
+        let mut timeout = task::spawn(time.timeout(ms(10), rx));
+
+        assert_pending!(timeout.poll());
+        assert_eq!(time.advance(ms(5)).await, 0);
+        assert_pending!(timeout.poll());
+
+        tx.send(()).unwrap();
+
+        assert!(timeout.is_woken());
+        assert_ready_ok!(timeout.poll()).unwrap();
+
+        // Timeout with future and deadline: timeout wins.
+        let time = MockTimeService::new();
+        let (_tx, rx) = oneshot::channel::<()>();
+        let mut timeout = task::spawn(time.timeout(ms(10), rx));
+
+        assert_pending!(timeout.poll());
+        assert_eq!(time.advance(ms(15)).await, 1);
+        assert!(timeout.is_woken());
+
+        assert_ready_err!(timeout.poll());
+    }
+
+    fn ms(duration: u64) -> Duration {
+        Duration::from_millis(duration)
+    }
+}

--- a/common/time-service/src/timeout.rs
+++ b/common/time-service/src/timeout.rs
@@ -1,0 +1,55 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::Sleep;
+use futures::future::Future;
+use pin_project::pin_project;
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+use thiserror::Error;
+
+/// Error returned by [`Timeout`].
+#[derive(Debug, Error, Eq, PartialEq)]
+#[error("timeout elapsed")]
+pub struct Elapsed;
+
+/// Future returned by [`TimeService::timeout`](crate::TimeService::timeout).
+///
+/// Mostly taken from [`tokio::time::Timeout`] but uses our `Sleep` future.
+#[pin_project]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct Timeout<F> {
+    #[pin]
+    future: F,
+    #[pin]
+    delay: Sleep,
+}
+
+impl<F> Timeout<F> {
+    pub fn new(future: F, delay: Sleep) -> Self {
+        Self { future, delay }
+    }
+
+    /// Consumes this timeout, returning the underlying value.
+    pub fn into_inner(self) -> F {
+        self.future
+    }
+}
+
+impl<F: Future> Future for Timeout<F> {
+    type Output = Result<F::Output, Elapsed>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        // First, try polling the future
+        if let Poll::Ready(v) = this.future.poll(cx) {
+            return Poll::Ready(Ok(v));
+        }
+
+        // Now check the timer
+        this.delay.poll(cx).map(|_| Err(Elapsed))
+    }
+}

--- a/common/time-service/src/tokio.rs
+++ b/common/time-service/src/tokio.rs
@@ -1,0 +1,42 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{Sleep, SleepTrait, TimeServiceTrait};
+use std::time::Duration;
+
+/// The real production tokio [`TimeService`].
+///
+/// Note: `TokioTimeService` is just a zero-sized type whose methods only delegate
+/// to the respective [`tokio::time`] functions.
+#[derive(Copy, Clone, Debug, Default)]
+pub struct TokioTimeService;
+
+pub type TokioSleep = tokio::time::Delay;
+
+impl TokioTimeService {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl TimeServiceTrait for TokioTimeService {
+    fn now(&self) -> Duration {
+        diem_infallible::duration_since_epoch()
+    }
+
+    /// See [`tokio::time::delay_for`]
+    fn sleep(&self, duration: Duration) -> Sleep {
+        tokio::time::delay_for(duration).into()
+    }
+}
+
+impl SleepTrait for TokioSleep {
+    fn is_elapsed(&self) -> bool {
+        TokioSleep::is_elapsed(self)
+    }
+
+    fn reset(&mut self, duration: Duration) {
+        let deadline = self.deadline() + duration;
+        TokioSleep::reset(self, deadline);
+    }
+}

--- a/x.toml
+++ b/x.toml
@@ -147,6 +147,7 @@ members = [
     "smoke-test",
     "socket-bench-server",
     "test-generation",
+    "time-service",
     "x",
     "x-core",
     "x-lint",


### PR DESCRIPTION
### Motivation

TL;DR: got fed up with flaky tests for Peer rpc timeouts... wrote this as an experiment to mock async time.

Testing time-related things in network is kind of a pain. We get around this problem for interval-like things using a `ticker` mpsc channel, but that's kind of a hack and doesn't cover sleeping, timeouts, or querying the clock.

This problem is not unique to network; two other attempts exist in secure/time and consensus. The first is not async-aware, but works great for normal threading-only code.

Compared to the consensus time service, this one returns concrete `Future`s, which integrate more cleanly with the async ecosystem. The consensus time service also mandates spawning every sleep as a task, which sucks when we're setting/registering/polling timers on every rpc and socket read/write. It's also more convenient for the socket rate limiting work we're doing, which needs manual `AsyncRead`/`AsyncWrite` poll implementations.

This implementation also comes as a convenient enum so we don't have to infect literally every struct in network/ with a `T: TimeService` trait bound. Though perf is not really a goal here, it should be noted that the interfaces here are zero cost when we're running without testing features.

With this mock time service, I think it's actually not too far of a step to mock out the whole runtime so we can start fuzzing the full execution trace deterministically.

As an example, here's a test using the `MockTimeService`:

```rust
#[test]
fn peer_recv_rpc_timeout() {
    let mut rt = Runtime::new().unwrap();
    let time = MockTimeService::new();
    let /* .. */ = build_test_peer(rt.handle().clone(), time.clone().into(), ConnectionOrigin::Inbound);
    let (mut client_sink, mut _client_stream) = build_network_sink_stream(&mut connection);

    let send_msg = NetworkMessage::RpcRequest(RpcRequest { /* .. */ });
    let recv_msg = PeerNotification::RecvRpc(InboundRpcRequest { /* .. */ });

    let test = async move {
        // Client sends the rpc request.
        client_sink.send(&send_msg).await.unwrap();

        // Server receives the rpc request from client.
        let received = peer_notifs_rx.next().await.unwrap();
        assert_eq!(received, recv_msg);

        // Pull out the request completion handle.
        let mut res_tx = match received {
            PeerNotification::RecvRpc(req) => req.res_tx,
            _ => panic!("Unexpected PeerNotification: {:?}", received),
        };

        // The rpc response channel should still be open since we haven't timed out yet.
        assert!(!res_tx.is_canceled());

        // Advance time to timeout the inbound rpc.
        time.advance(INBOUND_RPC_TIMEOUT_MS).await;

        // The rpc response channel should be canceled from the timeout.
        assert!(res_tx.is_canceled());
        res_tx.cancellation().await;

        // Client then closes connection.
        client_sink.close().await.unwrap();
    };
    rt.block_on(future::join(peer.start(), test));
}
```