### PR TITLE
[network] Add AsyncRead Byte Rate Limiting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2000,6 +2000,7 @@ name = "diem-rate-limiter"
 version = "0.1.0"
 dependencies = [
  "diem-infallible",
+ "diem-logger",
  "diem-workspace-hack",
  "futures 0.3.8",
  "pin-project 1.0.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4505,6 +4505,7 @@ dependencies = [
  "diem-metrics",
  "diem-network-address",
  "diem-proptest-helpers",
+ "diem-rate-limiter",
  "diem-types",
  "diem-workspace-hack",
  "futures 0.3.8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,6 +1996,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "diem-rate-limiter"
+version = "0.1.0"
+dependencies = [
+ "diem-infallible",
+ "diem-workspace-hack",
+ "futures 0.3.8",
+ "pin-project 1.0.3",
+ "tokio 0.2.24",
+]
+
+[[package]]
 name = "diem-retrier"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,6 +158,7 @@ members = [
 # For more, see the "Conditional compilation for tests" section in documentation/coding_guidelines.md.
 default-members = [
     "common/trace",
+    "common/rate-limiter",
     "config/generate-key",
     "config/management/genesis",
     "config/management/operational",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "common/num-variants",
     "common/proptest-helpers",
     "common/proxy",
+    "common/rate-limiter",
     "common/retrier",
     "common/short-hex-str",
     "common/subscription-service",

--- a/common/rate-limiter/Cargo.toml
+++ b/common/rate-limiter/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "diem-rate-limiter"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+description = "Diem implementation for rate limiter"
+repository = "https://github.com/diem/diem"
+homepage = "https://diem.com"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+diem-infallible = { path="../infallible", version = "0.1.0" }
+diem-workspace-hack = { path = "..//workspace-hack", version = "0.1.0" }
+futures = "0.3.8"
+pin-project = "1.0.2"
+tokio = { version = "0.2.22", features = ["full"] }

--- a/common/rate-limiter/Cargo.toml
+++ b/common/rate-limiter/Cargo.toml
@@ -11,7 +11,8 @@ edition = "2018"
 
 [dependencies]
 diem-infallible = { path="../infallible", version = "0.1.0" }
-diem-workspace-hack = { path = "..//workspace-hack", version = "0.1.0" }
+diem-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
+diem-logger = { path = "../logger", version = "0.1.0" }
 futures = "0.3.8"
 pin-project = "1.0.2"
 tokio = { version = "0.2.22", features = ["full"] }

--- a/common/rate-limiter/src/async_lib.rs
+++ b/common/rate-limiter/src/async_lib.rs
@@ -1,0 +1,166 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::rate_limit::{Bucket, SharedBucket};
+use diem_infallible::Mutex;
+use futures::{
+    io::AsyncRead,
+    ready,
+    task::{Context, Poll},
+    AsyncWrite, Future,
+};
+use pin_project::pin_project;
+use std::{io, pin::Pin, sync::Arc};
+use tokio::time::{delay_until, Delay};
+
+/// An inner struct for keeping track of the delay, and bucket of rate limiting
+struct PollRateLimiter {
+    bucket: SharedBucket,
+    delay: Option<Delay>,
+}
+
+impl PollRateLimiter {
+    fn new(bucket: Option<SharedBucket>) -> Self {
+        let bucket = bucket.unwrap_or_else(|| Arc::new(Mutex::new(Bucket::open())));
+        PollRateLimiter {
+            bucket,
+            delay: None,
+        }
+    }
+
+    /// Poll and attempt to acquire the `requested` amount of tokens.
+    /// Keep trying until some amount of tokens are acquired.  Note: This doesn't provide
+    /// fairness so if two pollers hold the same bucket, one could continually lose.
+    fn poll_acquire(&mut self, cx: &mut Context<'_>, requested: usize) -> Poll<usize> {
+        loop {
+            // Wait until the delay is finished.
+            if let Some(ref mut delay) = self.delay {
+                ready!(Pin::new(delay).poll(cx));
+                self.delay = None;
+            }
+            // Try to acquire some tokens. If we're rate limited, we have to wait
+            // before trying again.
+            match self.bucket.lock().acquire_tokens(requested) {
+                Ok(allowed) => return Poll::Ready(allowed),
+                Err(wait_time) => {
+                    self.delay = Some(delay_until(tokio::time::Instant::from_std(wait_time)));
+                }
+            }
+        }
+    }
+
+    /// Poll an inner reader or writer, rate limited by the `bucket`.  This will provide an amount
+    /// of bytes allowed ot be read including partial reads.  It will return unused tokens back to
+    /// the bucket on partial reads / writes.
+    pub fn poll_limited<
+        T,
+        Action: FnOnce(Pin<&mut T>, &mut Context<'_>, usize) -> Poll<io::Result<usize>>,
+    >(
+        &mut self,
+        resource: Pin<&mut T>,
+        cx: &mut Context<'_>,
+        requested: usize,
+        poll_resource: Action,
+    ) -> Poll<io::Result<usize>> {
+        let allowed = ready!(self.poll_acquire(cx, requested));
+        let result = poll_resource(resource, cx, allowed);
+
+        // In order to have an accurate throttle rate, we remove tokens, and then add ones we don't use
+        let tokens_to_return = match &result {
+            Poll::Ready(Ok(actual)) => allowed.saturating_sub(*actual),
+            _ => allowed,
+        };
+        self.bucket.lock().add_tokens(tokens_to_return);
+
+        result
+    }
+}
+
+/// A rate limiter for `AsyncRead` or `AsyncWrite` interfaces to rate limit read/write bytes
+///
+/// This will pause and wait to send any future bytes until it's permitted to in the future
+#[pin_project]
+pub struct AsyncRateLimiter<T> {
+    #[pin]
+    inner: T,
+    rate_limiter: PollRateLimiter,
+}
+
+impl<T> AsyncRateLimiter<T> {
+    pub fn new(inner: T, bucket: Option<SharedBucket>) -> Self {
+        Self {
+            inner,
+            rate_limiter: PollRateLimiter::new(bucket),
+        }
+    }
+}
+
+impl<T: AsyncRead> AsyncRead for AsyncRateLimiter<T> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        let this = self.project();
+        this.rate_limiter
+            .poll_limited(this.inner, cx, buf.len(), |resource, cx, allowed| {
+                resource.poll_read(cx, &mut buf[..allowed])
+            })
+    }
+}
+
+impl<T: AsyncWrite> AsyncWrite for AsyncRateLimiter<T> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let this = self.project();
+        this.rate_limiter
+            .poll_limited(this.inner, cx, buf.len(), |resource, cx, allowed| {
+                resource.poll_write(cx, &buf[..allowed])
+            })
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.project().inner.poll_flush(cx)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.project().inner.poll_close(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::AsyncReadExt;
+
+    #[tokio::test]
+    async fn test_async_read() {
+        let source: &[u8] = b"12345678901234567890123456";
+        let rate_limiter = Arc::new(Mutex::new(Bucket::new(15, 15, 5)));
+        let mut reader = AsyncRateLimiter::new(source, Some(rate_limiter));
+
+        let mut buf: [u8; 30] = [0; 30];
+        assert_eq!(15, reader.read(&mut buf).await.expect("Successful read"));
+        assert_eq!(
+            5,
+            reader.read(&mut buf[15..]).await.expect("Successful read")
+        );
+        assert_eq!(
+            5,
+            reader.read(&mut buf[20..]).await.expect("Successful read")
+        );
+        assert_eq!(
+            1,
+            reader.read(&mut buf[25..]).await.expect("Successful read")
+        );
+        assert_eq!(
+            0,
+            reader.read(&mut buf[26..]).await.expect("Successful read")
+        );
+
+        assert_eq!(&buf[..26], source);
+    }
+}

--- a/common/rate-limiter/src/lib.rs
+++ b/common/rate-limiter/src/lib.rs
@@ -1,0 +1,6 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+pub mod rate_limit;

--- a/common/rate-limiter/src/lib.rs
+++ b/common/rate-limiter/src/lib.rs
@@ -3,4 +3,5 @@
 
 #![forbid(unsafe_code)]
 
+pub mod async_lib;
 pub mod rate_limit;

--- a/common/rate-limiter/src/main.rs
+++ b/common/rate-limiter/src/main.rs
@@ -1,0 +1,251 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use diem_infallible::Mutex;
+use diem_rate_limiter::{
+    async_lib::AsyncRateLimiter,
+    rate_limit::{Bucket, SharedBucket},
+};
+use futures::{channel::mpsc::channel, executor::block_on, Future, SinkExt, StreamExt};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
+use tokio::{
+    io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+    runtime::Runtime,
+};
+
+// Parameters for running the tests, change the port if there's a conflict
+/// Where to run the test read/write
+const ADDRESS: &str = "localhost:7777";
+/// Total # of bytes to transfer.  May transfer more, but won't transfer less
+const BYTES_TO_TRANSFER: usize = 1_000_000;
+/// Expected throughput to be configured on the rate limiter
+const ALLOWED_BYTES_PER_SEC: usize = 10_000;
+/// Chunk size to write bytes to the stream at a time
+const CHUNK_SIZE: usize = 10_000;
+
+/// Holder for statistics of a single experiment and reader/writer
+struct RunStats {
+    pub label: &'static str,
+    pub num_actions: usize,
+    pub num_bytes: usize,
+    pub actions_per_s: f64,
+    pub bytes_per_s: f64,
+    pub elapsed: Duration,
+}
+
+/// A main function for testing rate limiting throughput and backpressure
+fn main() {
+    println!("Starting experiments");
+    println!(
+        "Bytes to test: {}, Expected Throughput(actions/s): {}, Expected Throughput(bytes/s): {}, ",
+        BYTES_TO_TRANSFER,
+        ALLOWED_BYTES_PER_SEC / CHUNK_SIZE,
+        ALLOWED_BYTES_PER_SEC
+    );
+
+    let runtime = Runtime::new().unwrap();
+
+    run_experiment(
+        "No Read or Write Limiting",
+        &runtime,
+        test_no_rate_limit(BYTES_TO_TRANSFER),
+    );
+    run_experiment(
+        "Read Limited",
+        &runtime,
+        test_rate_limit_read(BYTES_TO_TRANSFER, ALLOWED_BYTES_PER_SEC),
+    );
+    run_experiment(
+        "Write Limited",
+        &runtime,
+        test_rate_limit_write(BYTES_TO_TRANSFER, ALLOWED_BYTES_PER_SEC),
+    );
+    run_experiment(
+        "Read & Write Limited",
+        &runtime,
+        test_rate_limit_read_write(BYTES_TO_TRANSFER, ALLOWED_BYTES_PER_SEC),
+    );
+}
+
+/// Runs an experiment and prints out the run stats
+fn run_experiment<F: Future<Output = Vec<RunStats>> + 'static + Send>(
+    label: &'static str,
+    runtime: &Runtime,
+    experiment: F,
+) {
+    println!("\n== {} ==", label);
+    let stats = block_on(runtime.spawn(experiment)).expect("Expect experiment to finish");
+    for run in stats {
+        println!(
+            "{} stats\t|\tTotal actions: {}\t|\tTotal bytes: {}\t|\tThroughput(actions/s): {}\t|\tThroughput(bytes/s): {}\t|\tTime elapsed: {:?}",
+            run.label, run.num_actions, run.num_bytes, run.actions_per_s, run.bytes_per_s, run.elapsed
+        );
+    }
+}
+
+/// A helper to get stats of a read / write operation
+async fn stats<F: Future<Output = (usize, usize)>, Block: FnOnce() -> F>(
+    label: &'static str,
+    block: Block,
+) -> RunStats {
+    let start = Instant::now();
+    let (num_actions, num_bytes) = block().await;
+    let end = Instant::now();
+
+    let elapsed = end - start;
+    let elapsed_s = (elapsed.as_millis() as f64) / 1000.0;
+
+    let actions_per_s = num_actions as f64 / elapsed_s;
+    let bytes_per_s = num_bytes as f64 / elapsed_s;
+
+    RunStats {
+        label,
+        num_actions,
+        num_bytes,
+        actions_per_s,
+        bytes_per_s,
+        elapsed,
+    }
+}
+
+/// A generalized test of the rate limiter, allowing for turning off rate limiting on either
+/// read or write sides.  `total_test_bytes` is the lower bound of send / receive bytes
+async fn test_rate_limiter<
+    R: AsyncRead + Unpin + Send,
+    W: AsyncWrite + Unpin + Send,
+    Reader: FnOnce(TcpStream) -> R + Send + 'static,
+    Writer: FnOnce(TcpStream) -> W + Send + 'static,
+>(
+    total_test_bytes: usize,
+    reader: Reader,
+    writer: Writer,
+) -> Vec<RunStats> {
+    // Startup the socket connections first, and the stats line
+    let mut listener = TcpListener::bind(ADDRESS)
+        .await
+        .expect("Must bind to address");
+    let out_stream = TcpStream::connect(ADDRESS)
+        .await
+        .expect("Must connect to address");
+
+    // Shrink the buffer to increase the affects of backpressure
+    out_stream
+        .set_send_buffer_size(CHUNK_SIZE)
+        .expect("Should be able to change buffer size");
+    let mut writer = writer(out_stream);
+
+    let (stats_sender, mut stats_receiver) = channel(2);
+    let mut read_stats = stats_sender.clone();
+    let mut write_stats = stats_sender.clone();
+
+    // Ensure we're listening first
+    let read_future = async move {
+        let in_stream = listener
+            .next()
+            .await
+            .expect("Should not have an error connecting")
+            .expect("Should have an incoming connection");
+
+        // Shrink the buffer to increase the affects of backpressure
+        in_stream
+            .set_recv_buffer_size(CHUNK_SIZE)
+            .expect("Should be able to change buffer size");
+
+        // Read in the expected number of bytes
+        let mut reader = reader(in_stream);
+        let stats = stats("Read", || async {
+            let mut buf: [u8; CHUNK_SIZE] = [0; CHUNK_SIZE];
+            let mut num_reads: usize = 0;
+            let mut num_bytes: usize = 0;
+            loop {
+                num_bytes = num_bytes.saturating_add(reader.read(&mut buf).await.unwrap());
+                num_reads = num_reads.saturating_add(1);
+                if num_bytes >= total_test_bytes {
+                    break;
+                }
+            }
+            (num_reads, num_bytes)
+        })
+        .await;
+        read_stats.send(stats).await.unwrap();
+    };
+
+    let write_future = async move {
+        // Write the expected number of bytes
+        let stats = stats("Write", || async {
+            let source: [u8; CHUNK_SIZE] = [1; CHUNK_SIZE];
+            let mut num_writes: usize = 0;
+            let mut num_bytes: usize = 0;
+            loop {
+                num_bytes = num_bytes.saturating_add(writer.write(&source).await.unwrap());
+                num_writes = num_writes.saturating_add(1);
+                if num_bytes >= total_test_bytes {
+                    break;
+                }
+            }
+            (num_writes, num_bytes)
+        })
+        .await;
+        write_stats.send(stats).await.unwrap();
+    };
+
+    // Wait for both to finish
+    futures::future::join(read_future, write_future).await;
+
+    // Output statistics from the reader & writer
+    let mut results: Vec<RunStats> = vec![];
+    for _ in 0u8..2u8 {
+        results.push(stats_receiver.next().await.unwrap());
+    }
+    results
+}
+
+fn simple_shared_bucket(size: usize) -> SharedBucket {
+    Arc::new(Mutex::new(Bucket::new(size, size, size)))
+}
+
+/// For comparison, no rate limiting
+async fn test_no_rate_limit(num_bytes: usize) -> Vec<RunStats> {
+    test_rate_limiter(num_bytes, |reader| reader, |writer| writer).await
+}
+
+/// Tests backpressure, where only the reader is limited.  Using a socket adds a buffer
+/// that causes the backpressure only to occur after a large amount of traffic first. (> 500k bytes)
+/// > 55 chunks could cause backpressure, for a proper test > 100 or > 200 give good results.
+async fn test_rate_limit_read(num_bytes: usize, throughput: usize) -> Vec<RunStats> {
+    let inbound_rate_limiter = simple_shared_bucket(throughput);
+    test_rate_limiter(
+        num_bytes,
+        |reader| AsyncRateLimiter::new(reader, Some(inbound_rate_limiter)),
+        |writer| writer,
+    )
+    .await
+}
+
+/// Tests only if the writer is rate limited, which should provide a smoother read rate
+async fn test_rate_limit_write(num_bytes: usize, throughput: usize) -> Vec<RunStats> {
+    let outbound_rate_limiter = simple_shared_bucket(throughput);
+    test_rate_limiter(
+        num_bytes,
+        |reader| reader,
+        |writer| AsyncRateLimiter::new(writer, Some(outbound_rate_limiter)),
+    )
+    .await
+}
+
+/// Tests if both are rate limited.  Results should be roughly the same in the long term as
+/// the other two
+async fn test_rate_limit_read_write(num_bytes: usize, throughput: usize) -> Vec<RunStats> {
+    let inbound_rate_limiter = simple_shared_bucket(throughput);
+    let outbound_rate_limiter = simple_shared_bucket(throughput);
+    test_rate_limiter(
+        num_bytes,
+        |reader| AsyncRateLimiter::new(reader, Some(inbound_rate_limiter)),
+        |writer| AsyncRateLimiter::new(writer, Some(outbound_rate_limiter)),
+    )
+    .await
+}

--- a/common/rate-limiter/src/rate_limit.rs
+++ b/common/rate-limiter/src/rate_limit.rs
@@ -90,6 +90,15 @@ impl TokenBucketConfig {
             open,
         }
     }
+
+    pub fn open() -> Self {
+        TokenBucketConfig {
+            new_bucket_start_percentage: 100,
+            default_bucket_size: std::usize::MAX,
+            default_fill_rate: std::usize::MAX,
+            open: true,
+        }
+    }
 }
 
 impl<Key: Eq + Hash + Clone + Debug> TokenBucketRateLimiter<Key> {
@@ -111,12 +120,7 @@ impl<Key: Eq + Hash + Clone + Debug> TokenBucketRateLimiter<Key> {
 
     /// Used for testing and to not have a rate limiter
     pub fn open() -> Self {
-        Self::new_from_config(TokenBucketConfig {
-            new_bucket_start_percentage: 100,
-            default_bucket_size: std::usize::MAX,
-            default_fill_rate: std::usize::MAX,
-            open: true,
-        })
+        Self::new_from_config(TokenBucketConfig::open())
     }
 
     /// Retrieve bucket, or create a new one

--- a/common/rate-limiter/src/rate_limit.rs
+++ b/common/rate-limiter/src/rate_limit.rs
@@ -1,0 +1,477 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use diem_infallible::{Mutex, RwLock};
+use std::{
+    cmp::min, collections::HashMap, fmt::Debug, hash::Hash, num::NonZeroUsize, sync::Arc,
+    time::Instant,
+};
+use tokio::time::Duration;
+
+pub type SharedBucket = Arc<Mutex<Bucket>>;
+
+const ONE_SEC: Duration = Duration::from_secs(1);
+
+/// A generic token bucket filter
+///
+/// # Terms
+/// ## Key
+/// A `key` is an identifier of the item being rate limited
+///
+/// ## Token
+/// A `token` is the smallest discrete value that we want to rate limit by.  In a situation involving
+/// network requests, this may represent a request or a byte.  `Tokens` are the counters for the
+/// rate limiting, and when there are no `tokens` left in a `bucket`, the `key` is throttled.
+///
+/// ## Bucket
+/// A `bucket` is the tracker of the number of `tokens`.  It has a `bucket size`, and any additional
+/// tokens added to it will "spill" out of the `bucket`.  The `buckets` are filled at an `interval`
+/// with a given `fill rate`.
+///
+/// ## Interval
+/// The `interval` at which we refill *all* of the `buckets` in the token bucket filter. Configured
+/// across the whole token bucket filter.
+///
+/// ## Fill Rate
+/// The rate at which we fill a `bucket` with tokens. Configured per bucket.
+///
+/// ## Bucket Size
+/// Maximum size of a bucket.  A bucket saturates at this size.  Configured per bucket.
+///
+/// # Features
+/// ## Keys
+/// The token bucket takes any key as long as it's hashable.  This should allow it to apply to
+/// many applications that need rate limiters.
+///
+/// ## Bucket sizes and Rates
+/// ### Defaults
+/// There are defaults for bucket size and fill rate, which will apply to unknown keys.
+///
+/// ### Refill Interval
+/// Buckets are refilled automatically at an interval.  To do this synchronously, it calculates the
+/// number of intervals that have passed.  This is done synchronously and in the future may be done
+/// asynchronously.
+///
+pub struct TokenBucketRateLimiter<Key: Eq + Hash + Clone + Debug> {
+    buckets: RwLock<HashMap<Key, SharedBucket>>,
+    config: TokenBucketConfig,
+}
+
+/// A configuration of token bucket settings, in the future it can be used for
+/// setting overrides for specific keys
+#[derive(Debug, Copy, Clone)]
+pub struct TokenBucketConfig {
+    new_bucket_start_percentage: u8,
+    default_bucket_size: usize,
+    default_fill_rate: usize,
+    open: bool,
+}
+
+impl TokenBucketConfig {
+    /// Input is `NonZeroUsize` to ensure the config doesn't just block all traffic
+    pub fn new(
+        new_bucket_start_percentage: u8,
+        default_bucket_size: usize,
+        default_fill_rate: usize,
+        open: bool,
+    ) -> Self {
+        assert!(
+            new_bucket_start_percentage <= 100,
+            "Start percentage must be less than or equal to 100%"
+        );
+        Self {
+            new_bucket_start_percentage,
+            default_bucket_size: NonZeroUsize::new(default_bucket_size)
+                .expect("Bucket size must not be 0")
+                .get(),
+            default_fill_rate: NonZeroUsize::new(default_fill_rate)
+                .expect("Fill rate must not be 0")
+                .get(),
+            open,
+        }
+    }
+}
+
+impl<Key: Eq + Hash + Clone + Debug> TokenBucketRateLimiter<Key> {
+    pub fn new_from_config(config: TokenBucketConfig) -> Self {
+        Self {
+            buckets: RwLock::new(HashMap::new()),
+            config,
+        }
+    }
+
+    pub fn new(default_bucket_size: usize, default_fill_rate: usize) -> Self {
+        Self::new_from_config(TokenBucketConfig {
+            new_bucket_start_percentage: 100,
+            default_bucket_size,
+            default_fill_rate,
+            open: false,
+        })
+    }
+
+    /// Used for testing and to not have a rate limiter
+    pub fn open() -> Self {
+        Self::new_from_config(TokenBucketConfig {
+            new_bucket_start_percentage: 100,
+            default_bucket_size: std::usize::MAX,
+            default_fill_rate: std::usize::MAX,
+            open: true,
+        })
+    }
+
+    /// Retrieve bucket, or create a new one
+    pub fn bucket(&self, key: Key) -> SharedBucket {
+        if !self.config.open {
+            self.bucket_inner(key, |initial, size, rate| {
+                Arc::new(Mutex::new(Bucket::new(initial, size, rate)))
+            })
+        } else {
+            self.bucket_inner(key, |_, _, _| Arc::new(Mutex::new(Bucket::open())))
+        }
+    }
+
+    fn bucket_inner<F: FnOnce(usize, usize, usize) -> SharedBucket>(
+        &self,
+        key: Key,
+        bucket_create: F,
+    ) -> SharedBucket {
+        // Attempt to do a weaker read lock first, followed by a write lock if it's missing
+        // For the common (read) case, there should be higher throughput
+        // Note: This read must happen in a separate block, to ensure the read unlock for the write
+        let maybe_bucket = { self.buckets.read().get(&key).cloned() };
+        if let Some(bucket) = maybe_bucket {
+            bucket
+        } else {
+            let size = self.config.default_bucket_size;
+            let rate = self.config.default_fill_rate;
+
+            // Write in a bucket, but make sure again that it isn't there first
+            self.buckets
+                .write()
+                .entry(key)
+                .or_insert_with(|| {
+                    bucket_create(
+                        size.saturating_mul(self.config.new_bucket_start_percentage as usize) / 100,
+                        size,
+                        rate,
+                    )
+                })
+                .clone()
+        }
+    }
+
+    /// Garbage collects a single key, if we know what it is
+    pub fn try_garbage_collect_key(&self, key: &Key) -> bool {
+        let mut write = self.buckets.write();
+        let arc = write.get(key);
+        let remove = arc.map(|arc| Arc::strong_count(arc) <= 1).unwrap_or(false);
+
+        if remove {
+            write.remove(key);
+        }
+
+        remove
+    }
+}
+
+/// A token bucket object that keeps track of everything related to a key
+/// This can be used as a standalone rate limiter; however, to make it more useful
+/// it should be wrapped in an `Arc` and a `Mutex` to be shared across threads.
+#[derive(Debug)]
+pub struct Bucket {
+    /// The current number of available tokens to be used
+    tokens: usize,
+    /// Maximum number of `tokens` in the bucket
+    size: usize,
+    /// The fill rate of the bucket (`tokens/s`).  Amount added to `tokens` on a `refill`
+    rate: usize,
+    /// The last time buckets were refilled, to keep track of for amount to refill
+    last_refresh_time: Instant,
+    /// Determines whether the rate limiting should be ignored, useful for testing
+    open: bool,
+}
+
+impl Bucket {
+    pub fn new(initial: usize, size: usize, rate: usize) -> Self {
+        assert!(
+            size >= rate,
+            "Bucket size must be greater than or equal to fill rate"
+        );
+        Self {
+            tokens: initial,
+            size,
+            rate,
+            last_refresh_time: Instant::now(),
+            open: false,
+        }
+    }
+
+    /// A fully open rate limiter, to allow for ignoring rate limiting for tests
+    pub fn open() -> Self {
+        Self {
+            tokens: std::usize::MAX,
+            size: std::usize::MAX,
+            rate: std::usize::MAX,
+            last_refresh_time: Instant::now(),
+            open: true,
+        }
+    }
+
+    /// Refill tokens based on how many seconds have passed since last refresh
+    pub(crate) fn refill(&mut self) {
+        let num_intervals = self.last_refresh_time.elapsed().as_secs();
+        if num_intervals > 0 {
+            self.add_tokens((num_intervals as usize).saturating_mul(self.rate));
+
+            // We have to base everything off the original time, or we'll have drift where we slowly slow the bucket refill rate
+            self.last_refresh_time += Duration::from_secs(num_intervals);
+        }
+    }
+
+    /// Determine if an entire batch can be passed through
+    /// This is important for message based rate limiting, where the whole message has
+    /// to make it through, or else it must be rejected.  A result of `None` means it cannot
+    /// ever be allowed through, as it's bigger than the size of the bucket.
+    pub fn acquire_all_tokens(&mut self, requested: usize) -> Result<(), Option<Instant>> {
+        // Skip over if we purposely have an open throttle
+        if self.open || requested == 0 {
+            return Ok(());
+        }
+
+        // Refill if needed
+        self.refill();
+
+        if self.tokens >= requested {
+            self.deduct_tokens(requested);
+            Ok(())
+        } else {
+            Err(self.time_of_tokens_needed(requested))
+        }
+    }
+
+    /// Returns `usize` of tokens allowed.  May be less than requested.
+    /// For best effort, caller should return unused tokens with `add_tokens`
+    pub fn acquire_tokens(&mut self, requested: usize) -> Result<usize, Instant> {
+        // Skip over if we purposely have an open throttle
+        if self.open || requested == 0 {
+            return Ok(requested);
+        }
+
+        // Refill if needed
+        self.refill();
+
+        let allowed = self.deduct_tokens(requested);
+        if allowed > 0 {
+            Ok(allowed)
+        } else {
+            Err(self.time_of_next_refill())
+        }
+    }
+
+    /// Retrieve the maximum amount of tokens up to `count`
+    /// Tells us how much of the requested size we can send
+    fn deduct_tokens(&mut self, requested: usize) -> usize {
+        let tokens_allowed = min(self.tokens, requested);
+        self.tokens = self.tokens.saturating_sub(requested);
+
+        tokens_allowed
+    }
+
+    /// Tells us when the next refill is
+    pub fn time_of_next_refill(&self) -> Instant {
+        self.last_refresh_time + ONE_SEC
+    }
+
+    /// Tells us when an entire batch will make it through.  Useful for Async work to wait until
+    /// all tokens are ready.  Returns `None` if it is never possible.
+    pub fn time_of_tokens_needed(&self, requested: usize) -> Option<Instant> {
+        if self.open {
+            Some(Instant::now())
+        } else if self.size < requested {
+            // This means the batch can never succeed
+            None
+        } else {
+            let tokens_needed = requested.saturating_sub(self.tokens);
+
+            let intervals = (tokens_needed as f64 / self.rate as f64).ceil() as u32;
+            Some(self.last_refresh_time + (ONE_SEC * intervals))
+        }
+    }
+
+    /// Add new tokens, this can also be used to add unused tokens back
+    /// Ensures bucket doesn't overfill
+    pub fn add_tokens(&mut self, new_tokens: usize) {
+        self.tokens = min(self.size, self.tokens.saturating_add(new_tokens));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{sync::MutexGuard, thread::sleep};
+    use tokio::time::Duration;
+
+    // Helper function, checks the throttle limit
+    fn assert_acquire(rate_limiter: &mut MutexGuard<Bucket>, num_allowed: usize) {
+        assert_eq!(
+            num_allowed,
+            rate_limiter
+                .acquire_tokens(num_allowed)
+                .expect("Expected tokens")
+        );
+        rate_limiter
+            .acquire_tokens(1)
+            .expect_err("Expected time to wait");
+    }
+
+    // Check number of keys in the rate limiter
+    fn assert_num_keys(rate_limiters: &TokenBucketRateLimiter<&str>, num_keys: usize) {
+        assert_eq!(num_keys, rate_limiters.buckets.read().len())
+    }
+
+    #[test]
+    fn test_rate_limiting() {
+        let bucket_size = 5;
+        let bucket_rate = 1;
+        let key = "Key";
+        let rate_limiter = TokenBucketRateLimiter::new(bucket_size, bucket_rate);
+
+        let bucket_arc = rate_limiter.bucket(key);
+        let mut bucket = bucket_arc.lock();
+        assert_acquire(&mut bucket, bucket_size);
+
+        // After adding 2 token, only 2 should be allowed
+        bucket.add_tokens(2);
+        assert_acquire(&mut bucket, 2);
+
+        // Adding more tokens than the bucket size, should only give bucket size
+        bucket.add_tokens(bucket_size + 1);
+        assert_acquire(&mut bucket, bucket_size);
+    }
+
+    #[test]
+    fn test_message_rate_limiting() {
+        let bucket_size = 5;
+        let bucket_rate = 3;
+        let key = "Key";
+        let rate_limiter = TokenBucketRateLimiter::new(bucket_size, bucket_rate);
+
+        let bucket_arc = rate_limiter.bucket(key);
+        let mut bucket = bucket_arc.lock();
+
+        // Larger than bucket, should never succeed
+        let result = bucket.acquire_all_tokens(bucket_size + 1);
+        assert!(result.expect_err("Should not give tokens").is_none());
+
+        // Normal case
+        let result = bucket.acquire_all_tokens(bucket_size);
+        result.expect("Should be successful");
+
+        // Test future wait
+        let result = bucket.acquire_all_tokens(bucket_size);
+        let wait_time = result
+            .expect_err("Should not succeed, but will in future")
+            .expect("Should have a time it succeeds");
+
+        sleep(wait_time.duration_since(Instant::now()));
+        let result = bucket.acquire_all_tokens(bucket_size);
+        result.expect("Should be successful");
+    }
+
+    #[test]
+    fn test_refill() {
+        let bucket_size = 5;
+        let bucket_rate = 1;
+        let key = "Key";
+        let rate_limiter = TokenBucketRateLimiter::new(bucket_size, bucket_rate);
+
+        let bucket_arc = rate_limiter.bucket(key);
+        let mut bucket = bucket_arc.lock();
+        assert_acquire(&mut bucket, bucket_size);
+
+        // After 1 refill period, we should be at least 1 rate change if not more
+        // TODO: Put in a mock time service
+        sleep(bucket.time_of_next_refill().duration_since(Instant::now()));
+        bucket.refill();
+        let num_tokens = bucket.tokens;
+        assert!(num_tokens >= bucket_rate);
+
+        // Test the autorefill
+        assert_acquire(&mut bucket, num_tokens);
+        sleep(bucket.time_of_next_refill().duration_since(Instant::now()));
+        bucket.acquire_tokens(1).unwrap();
+    }
+
+    #[test]
+    fn test_time_checks() {
+        let bucket_size = 5;
+        let bucket_rate = 1;
+        let rate_limiter = TokenBucketRateLimiter::new(bucket_size, bucket_rate);
+
+        let bucket_arc = rate_limiter.bucket("Key");
+        let mut bucket = bucket_arc.lock();
+
+        // Should always be less than 1 second
+        assert!(bucket.time_of_next_refill() < Instant::now() + Duration::from_secs(1));
+
+        // If we have all the tokens, it should take 0 time
+        assert!(
+            bucket
+                .time_of_tokens_needed(bucket_size)
+                .expect("Should have a duration")
+                <= Instant::now()
+        );
+        assert_acquire(&mut bucket, bucket_size);
+
+        // Should have all the tokens after 5 periods
+        assert!(
+            bucket
+                .time_of_tokens_needed(bucket_size)
+                .expect("Should have a duration")
+                > Instant::now() + Duration::from_secs(bucket_size as u64 - 1)
+        );
+
+        // Greater than bucket size will never succeed
+        assert!(bucket.time_of_tokens_needed(bucket_size + 1).is_none());
+    }
+
+    #[test]
+    fn test_bucket_creation() {
+        let key = "key";
+        let rate_limiter = TokenBucketRateLimiter::new(1, 1);
+        assert_num_keys(&rate_limiter, 0);
+
+        // Ensure the buckets aren't being recreated
+        let bucket1 = rate_limiter.bucket(key);
+        let bucket2 = rate_limiter.bucket(key);
+
+        assert_eq!(Arc::as_ptr(&bucket1), Arc::as_ptr(&bucket2));
+        assert_eq!(3, Arc::strong_count(&bucket1));
+    }
+
+    #[test]
+    fn test_garbage_collection() {
+        let key_to_keep = "don't gc";
+        let key_to_gc = "do gc";
+        let rate_limiter = TokenBucketRateLimiter::new(1, 1);
+        assert_num_keys(&rate_limiter, 0);
+
+        // Create a bucket to hold onto
+        let _bucket_arc = rate_limiter.bucket(key_to_keep);
+        assert_num_keys(&rate_limiter, 1);
+
+        // Create this bucket, and let go of it!
+        {
+            let _bucket_arc = rate_limiter.bucket(key_to_gc);
+        }
+        assert_num_keys(&rate_limiter, 2);
+
+        // After garbage collect, the reference should disappear only to the second one
+        assert!(rate_limiter.try_garbage_collect_key(&key_to_gc));
+        assert_num_keys(&rate_limiter, 1);
+
+        // Can't GC something that's in use
+        assert!(!rate_limiter.try_garbage_collect_key(&key_to_keep));
+        assert_num_keys(&rate_limiter, 1);
+    }
+}

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -41,6 +41,8 @@ pub const MAX_FULLNODE_OUTBOUND_CONNECTIONS: usize = 3;
 pub const MAX_INBOUND_CONNECTIONS: usize = 100;
 pub const MAX_FRAME_SIZE: usize = 8 * 1024 * 1024; /* 8 MiB */
 pub const CONNECTION_BACKOFF_BASE: u64 = 2;
+pub const INBOUND_IP_BYTE_BUCKET_RATE: usize = MAX_FRAME_SIZE;
+pub const INBOUND_IP_BYTE_BUCKET_SIZE: usize = INBOUND_IP_BYTE_BUCKET_RATE;
 
 pub type SeedPublicKeys = HashMap<PeerId, HashSet<x25519::PublicKey>>;
 pub type SeedAddresses = HashMap<PeerId, Vec<NetworkAddress>>;
@@ -96,6 +98,10 @@ pub struct NetworkConfig {
     pub max_outbound_connections: usize,
     // Maximum number of outbound connections, limited by PeerManager
     pub max_inbound_connections: usize,
+    // Maximum number of bytes/s for an IP
+    pub inbound_ip_byte_bucket_rate: usize,
+    // Maximum burst of bytes for an IP
+    pub inbound_ip_byte_bucket_size: usize,
 }
 
 impl Default for NetworkConfig {
@@ -128,6 +134,8 @@ impl NetworkConfig {
             ping_failures_tolerated: PING_FAILURES_TOLERATED,
             max_outbound_connections: MAX_FULLNODE_OUTBOUND_CONNECTIONS,
             max_inbound_connections: MAX_INBOUND_CONNECTIONS,
+            inbound_ip_byte_bucket_rate: INBOUND_IP_BYTE_BUCKET_RATE,
+            inbound_ip_byte_bucket_size: INBOUND_IP_BYTE_BUCKET_SIZE,
         };
         config.prepare_identity();
         config

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -134,8 +134,8 @@ impl NetworkConfig {
             ping_failures_tolerated: PING_FAILURES_TOLERATED,
             max_outbound_connections: MAX_FULLNODE_OUTBOUND_CONNECTIONS,
             max_inbound_connections: MAX_INBOUND_CONNECTIONS,
-            inbound_rate_limit_config: Some(RateLimitConfig::default()),
-            outbound_rate_limit_config: Some(RateLimitConfig::default()),
+            inbound_rate_limit_config: None,
+            outbound_rate_limit_config: None,
         };
         config.prepare_identity();
         config
@@ -189,6 +189,18 @@ impl NetworkConfig {
             return Err(Error::InvariantViolation(
                 "Set NetworkId::Validator network for a non-validator network".to_string(),
             ));
+        }
+
+        // Fullnodes require a rate limiting config
+        if role == RoleType::FullNode {
+            self.inbound_rate_limit_config = Some(
+                self.inbound_rate_limit_config
+                    .map_or(RateLimitConfig::default(), |config| config),
+            );
+            self.outbound_rate_limit_config = Some(
+                self.outbound_rate_limit_config
+                    .map_or(RateLimitConfig::default(), |config| config),
+            );
         }
 
         self.prepare_identity();

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -98,10 +98,8 @@ pub struct NetworkConfig {
     pub max_outbound_connections: usize,
     // Maximum number of outbound connections, limited by PeerManager
     pub max_inbound_connections: usize,
-    // Maximum number of bytes/s for an IP
-    pub inbound_ip_byte_bucket_rate: usize,
-    // Maximum burst of bytes for an IP
-    pub inbound_ip_byte_bucket_size: usize,
+    // Inbound rate limiting configuration, if not specified, no rate limiting
+    pub inbound_rate_limit_config: Option<RateLimitConfig>,
 }
 
 impl Default for NetworkConfig {
@@ -134,8 +132,7 @@ impl NetworkConfig {
             ping_failures_tolerated: PING_FAILURES_TOLERATED,
             max_outbound_connections: MAX_FULLNODE_OUTBOUND_CONNECTIONS,
             max_inbound_connections: MAX_INBOUND_CONNECTIONS,
-            inbound_ip_byte_bucket_rate: INBOUND_IP_BYTE_BUCKET_RATE,
-            inbound_ip_byte_bucket_size: INBOUND_IP_BYTE_BUCKET_SIZE,
+            inbound_rate_limit_config: Some(RateLimitConfig::default()),
         };
         config.prepare_identity();
         config
@@ -309,4 +306,24 @@ pub struct IdentityFromStorage {
     pub backend: SecureBackend,
     pub key_name: String,
     pub peer_id_name: String,
+}
+
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct RateLimitConfig {
+    /// Maximum number of bytes/s for an IP
+    pub ip_byte_bucket_rate: usize,
+    /// Maximum burst of bytes for an IP
+    pub ip_byte_bucket_size: usize,
+    /// Initial amount of tokens initially in the bucket
+    pub initial_bucket_fill_percentage: u8,
+}
+
+impl Default for RateLimitConfig {
+    fn default() -> Self {
+        Self {
+            ip_byte_bucket_rate: INBOUND_IP_BYTE_BUCKET_RATE,
+            ip_byte_bucket_size: INBOUND_IP_BYTE_BUCKET_SIZE,
+            initial_bucket_fill_percentage: 25,
+        }
+    }
 }

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -100,6 +100,8 @@ pub struct NetworkConfig {
     pub max_inbound_connections: usize,
     // Inbound rate limiting configuration, if not specified, no rate limiting
     pub inbound_rate_limit_config: Option<RateLimitConfig>,
+    // Outbound rate limiting configuration, if not specified, no rate limiting
+    pub outbound_rate_limit_config: Option<RateLimitConfig>,
 }
 
 impl Default for NetworkConfig {
@@ -133,6 +135,7 @@ impl NetworkConfig {
             max_outbound_connections: MAX_FULLNODE_OUTBOUND_CONNECTIONS,
             max_inbound_connections: MAX_INBOUND_CONNECTIONS,
             inbound_rate_limit_config: Some(RateLimitConfig::default()),
+            outbound_rate_limit_config: Some(RateLimitConfig::default()),
         };
         config.prepare_identity();
         config

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -39,6 +39,7 @@ diem-logger = { path = "../common/logger", version = "0.1.0" }
 diem-metrics = { path = "../common/metrics", version = "0.1.0" }
 diem-network-address = { path = "../network/network-address", version = "0.1.0" }
 diem-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0", optional = true }
+diem-rate-limiter = { path = "../common/rate-limiter", version = "0.1.0"}
 diem-types = { path = "../types", version = "0.1.0" }
 diem-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
 memsocket = { path = "../network/memsocket", version = "0.1.0", optional = true }

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -91,6 +91,8 @@ impl NetworkBuilder {
         max_concurrent_network_reqs: usize,
         max_concurrent_network_notifs: usize,
         inbound_connection_limit: usize,
+        inbound_ip_byte_bucket_rate: usize,
+        inbound_ip_byte_bucket_size: usize,
     ) -> Self {
         // A network cannot exist without a PeerManager
         // TODO:  construct this in create and pass it to new() as a parameter. The complication is manual construction of NetworkBuilder in various tests.
@@ -106,6 +108,8 @@ impl NetworkBuilder {
             max_frame_size,
             enable_proxy_protocol,
             inbound_connection_limit,
+            inbound_ip_byte_bucket_rate,
+            inbound_ip_byte_bucket_size,
         );
 
         NetworkBuilder {
@@ -141,6 +145,8 @@ impl NetworkBuilder {
             MAX_CONCURRENT_NETWORK_REQS,
             MAX_CONCURRENT_NETWORK_NOTIFS,
             MAX_INBOUND_CONNECTIONS,
+            MAX_FRAME_SIZE,
+            MAX_FRAME_SIZE,
         );
 
         builder.add_connectivity_manager(
@@ -188,6 +194,8 @@ impl NetworkBuilder {
             config.max_concurrent_network_reqs,
             config.max_concurrent_network_notifs,
             config.max_inbound_connections,
+            config.inbound_ip_byte_bucket_rate,
+            config.inbound_ip_byte_bucket_size,
         );
 
         network_builder.add_connection_monitoring(

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -12,7 +12,7 @@
 use channel::{self, message_queues::QueueStyle};
 use diem_config::{
     config::{
-        DiscoveryMethod, NetworkConfig, RoleType, CONNECTION_BACKOFF_BASE,
+        DiscoveryMethod, NetworkConfig, RateLimitConfig, RoleType, CONNECTION_BACKOFF_BASE,
         CONNECTIVITY_CHECK_INTERVAL_MS, MAX_CONCURRENT_NETWORK_NOTIFS, MAX_CONCURRENT_NETWORK_REQS,
         MAX_CONNECTION_DELAY_MS, MAX_FRAME_SIZE, MAX_FULLNODE_OUTBOUND_CONNECTIONS,
         MAX_INBOUND_CONNECTIONS, NETWORK_CHANNEL_SIZE,
@@ -91,8 +91,7 @@ impl NetworkBuilder {
         max_concurrent_network_reqs: usize,
         max_concurrent_network_notifs: usize,
         inbound_connection_limit: usize,
-        inbound_ip_byte_bucket_rate: usize,
-        inbound_ip_byte_bucket_size: usize,
+        inbound_rate_limit_config: Option<RateLimitConfig>,
     ) -> Self {
         // A network cannot exist without a PeerManager
         // TODO:  construct this in create and pass it to new() as a parameter. The complication is manual construction of NetworkBuilder in various tests.
@@ -108,8 +107,7 @@ impl NetworkBuilder {
             max_frame_size,
             enable_proxy_protocol,
             inbound_connection_limit,
-            inbound_ip_byte_bucket_rate,
-            inbound_ip_byte_bucket_size,
+            inbound_rate_limit_config,
         );
 
         NetworkBuilder {
@@ -145,8 +143,7 @@ impl NetworkBuilder {
             MAX_CONCURRENT_NETWORK_REQS,
             MAX_CONCURRENT_NETWORK_NOTIFS,
             MAX_INBOUND_CONNECTIONS,
-            MAX_FRAME_SIZE,
-            MAX_FRAME_SIZE,
+            None,
         );
 
         builder.add_connectivity_manager(
@@ -194,8 +191,7 @@ impl NetworkBuilder {
             config.max_concurrent_network_reqs,
             config.max_concurrent_network_notifs,
             config.max_inbound_connections,
-            config.inbound_ip_byte_bucket_rate,
-            config.inbound_ip_byte_bucket_size,
+            config.inbound_rate_limit_config,
         );
 
         network_builder.add_connection_monitoring(

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -92,6 +92,7 @@ impl NetworkBuilder {
         max_concurrent_network_notifs: usize,
         inbound_connection_limit: usize,
         inbound_rate_limit_config: Option<RateLimitConfig>,
+        outbound_rate_limit_config: Option<RateLimitConfig>,
     ) -> Self {
         // A network cannot exist without a PeerManager
         // TODO:  construct this in create and pass it to new() as a parameter. The complication is manual construction of NetworkBuilder in various tests.
@@ -108,6 +109,7 @@ impl NetworkBuilder {
             enable_proxy_protocol,
             inbound_connection_limit,
             inbound_rate_limit_config,
+            outbound_rate_limit_config,
         );
 
         NetworkBuilder {
@@ -143,6 +145,7 @@ impl NetworkBuilder {
             MAX_CONCURRENT_NETWORK_REQS,
             MAX_CONCURRENT_NETWORK_NOTIFS,
             MAX_INBOUND_CONNECTIONS,
+            None,
             None,
         );
 
@@ -192,6 +195,7 @@ impl NetworkBuilder {
             config.max_concurrent_network_notifs,
             config.max_inbound_connections,
             config.inbound_rate_limit_config,
+            config.outbound_rate_limit_config,
         );
 
         network_builder.add_connection_monitoring(

--- a/network/network-address/src/lib.rs
+++ b/network/network-address/src/lib.rs
@@ -282,6 +282,15 @@ impl NetworkAddress {
         parse_diemnet_protos(self.as_slice()).is_some()
     }
 
+    /// Retrieves the IP address from the network address
+    pub fn find_ip_addr(&self) -> Option<IpAddr> {
+        self.0.iter().find_map(|proto| match proto {
+            Protocol::Ip4(addr) => Some(IpAddr::V4(*addr)),
+            Protocol::Ip6(addr) => Some(IpAddr::V6(*addr)),
+            _ => None,
+        })
+    }
+
     /// A temporary, hacky function to parse out the first `/ln-noise-ik/<pubkey>` from
     /// a `NetworkAddress`. We can remove this soon, when we move to the interim
     /// "monolithic" transport model.

--- a/network/src/interface/mod.rs
+++ b/network/src/interface/mod.rs
@@ -75,6 +75,7 @@ where
         channel_size: usize,
         max_frame_size: usize,
         inbound_rate_limiter: Option<SharedBucket>,
+        outbound_rate_limiter: Option<SharedBucket>,
     ) -> (
         diem_channel::Sender<ProtocolId, NetworkRequest>,
         diem_channel::Receiver<ProtocolId, NetworkNotification>,
@@ -104,6 +105,7 @@ where
             constants::MAX_CONCURRENT_INBOUND_RPCS,
             max_frame_size,
             inbound_rate_limiter,
+            outbound_rate_limiter,
         );
         executor.spawn(peer.start());
 

--- a/network/src/interface/mod.rs
+++ b/network/src/interface/mod.rs
@@ -26,6 +26,7 @@ use crate::{
 use channel::{self, diem_channel, message_queues::QueueStyle};
 use diem_config::network_id::NetworkContext;
 use diem_logger::prelude::*;
+use diem_rate_limiter::rate_limit::SharedBucket;
 use diem_types::PeerId;
 use futures::{
     io::{AsyncRead, AsyncWrite},
@@ -73,6 +74,7 @@ where
         max_concurrent_notifs: usize,
         channel_size: usize,
         max_frame_size: usize,
+        inbound_rate_limiter: Option<SharedBucket>,
     ) -> (
         diem_channel::Sender<ProtocolId, NetworkRequest>,
         diem_channel::Receiver<ProtocolId, NetworkNotification>,
@@ -101,6 +103,7 @@ where
             Duration::from_millis(constants::INBOUND_RPC_TIMEOUT_MS),
             constants::MAX_CONCURRENT_INBOUND_RPCS,
             max_frame_size,
+            inbound_rate_limiter,
         );
         executor.spawn(peer.start());
 

--- a/network/src/peer/fuzzing.rs
+++ b/network/src/peer/fuzzing.rs
@@ -27,7 +27,7 @@ pub fn generate_corpus(gen: &mut ValueGenerator) -> Vec<u8> {
     let network_msgs = gen.generate(vec(any::<NetworkMessage>(), 1..20));
 
     let (write_socket, mut read_socket) = MemorySocket::new_pair();
-    let mut writer = NetworkMessageSink::new(write_socket, MAX_FRAME_SIZE);
+    let mut writer = NetworkMessageSink::new(write_socket, MAX_FRAME_SIZE, None);
 
     // Write the `NetworkMessage`s to a fake socket
     let f_send = async move {
@@ -112,6 +112,7 @@ pub fn fuzz(data: &[u8]) {
         max_concurrent_notifs,
         channel_size,
         MAX_FRAME_SIZE,
+        None,
         None,
     );
 

--- a/network/src/peer/fuzzing.rs
+++ b/network/src/peer/fuzzing.rs
@@ -112,6 +112,7 @@ pub fn fuzz(data: &[u8]) {
         max_concurrent_notifs,
         channel_size,
         MAX_FRAME_SIZE,
+        None,
     );
 
     rt.block_on(async move {

--- a/network/src/peer/test.rs
+++ b/network/src/peer/test.rs
@@ -75,6 +75,7 @@ fn build_test_peer(
         Duration::from_millis(INBOUND_RPC_TIMEOUT_MS),
         MAX_CONCURRENT_INBOUND_RPCS,
         MAX_FRAME_SIZE,
+        None,
     );
     let peer_handle = PeerHandle::new(NetworkContext::mock(), connection_metadata, peer_req_tx);
 
@@ -127,7 +128,7 @@ fn build_network_sink_stream<'a>(
 ) {
     let (read_half, write_half) = tokio::io::split(IoCompat::new(connection));
     let sink = NetworkMessageSink::new(IoCompat::new(write_half), MAX_FRAME_SIZE);
-    let stream = NetworkMessageStream::new(IoCompat::new(read_half), MAX_FRAME_SIZE);
+    let stream = NetworkMessageStream::new(IoCompat::new(read_half), MAX_FRAME_SIZE, None);
     (sink, stream)
 }
 

--- a/network/src/peer/test.rs
+++ b/network/src/peer/test.rs
@@ -76,6 +76,7 @@ fn build_test_peer(
         MAX_CONCURRENT_INBOUND_RPCS,
         MAX_FRAME_SIZE,
         None,
+        None,
     );
     let peer_handle = PeerHandle::new(NetworkContext::mock(), connection_metadata, peer_req_tx);
 
@@ -127,7 +128,7 @@ fn build_network_sink_stream<'a>(
     NetworkMessageStream<impl AsyncRead + 'a>,
 ) {
     let (read_half, write_half) = tokio::io::split(IoCompat::new(connection));
-    let sink = NetworkMessageSink::new(IoCompat::new(write_half), MAX_FRAME_SIZE);
+    let sink = NetworkMessageSink::new(IoCompat::new(write_half), MAX_FRAME_SIZE, None);
     let stream = NetworkMessageStream::new(IoCompat::new(read_half), MAX_FRAME_SIZE, None);
     (sink, stream)
 }
@@ -207,7 +208,7 @@ fn peer_recv_message() {
     });
 
     let client = async move {
-        let mut connection = NetworkMessageSink::new(connection, MAX_FRAME_SIZE);
+        let mut connection = NetworkMessageSink::new(connection, MAX_FRAME_SIZE, None);
         for _ in 0..30 {
             // The client should then send the network message.
             connection.send(&send_msg).await.unwrap();

--- a/network/src/peer_manager/builder.rs
+++ b/network/src/peer_manager/builder.rs
@@ -358,8 +358,10 @@ impl PeerManagerBuilder {
             .peer_manager_context
             .take()
             .expect("PeerManager can only be built once");
-        let inbound_rate_limiters = token_bucket_rate_limiter(self.inbound_rate_limit_config);
-        let outbound_rate_limiters = token_bucket_rate_limiter(self.outbound_rate_limit_config);
+        let inbound_rate_limiters =
+            token_bucket_rate_limiter("inbound", self.inbound_rate_limit_config);
+        let outbound_rate_limiters =
+            token_bucket_rate_limiter("outbound", self.outbound_rate_limit_config);
         let peer_mgr = PeerManager::new(
             executor.clone(),
             transport,
@@ -457,14 +459,18 @@ impl PeerManagerBuilder {
     }
 }
 
-fn token_bucket_rate_limiter(input: Option<RateLimitConfig>) -> TokenBucketRateLimiter<IpAddr> {
+fn token_bucket_rate_limiter(
+    label: &'static str,
+    input: Option<RateLimitConfig>,
+) -> TokenBucketRateLimiter<IpAddr> {
     if let Some(config) = input {
         TokenBucketRateLimiter::new(
+            label,
             config.initial_bucket_fill_percentage,
             config.ip_byte_bucket_size,
             config.ip_byte_bucket_rate,
         )
     } else {
-        TokenBucketRateLimiter::open()
+        TokenBucketRateLimiter::open(label)
     }
 }

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -287,6 +287,8 @@ where
     inbound_connection_limit: usize,
     /// Keyed storage of all inbound rate limiters
     inbound_rate_limiters: TokenBucketRateLimiter<IpAddr>,
+    /// Keyed storage of all outbound rate limiters
+    outbound_rate_limiters: TokenBucketRateLimiter<IpAddr>,
 }
 
 impl<TTransport, TSocket> PeerManager<TTransport, TSocket>
@@ -314,6 +316,7 @@ where
         max_frame_size: usize,
         inbound_connection_limit: usize,
         inbound_rate_limiters: TokenBucketRateLimiter<IpAddr>,
+        outbound_rate_limiters: TokenBucketRateLimiter<IpAddr>,
     ) -> Self {
         let (transport_notifs_tx, transport_notifs_rx) = channel::new(
             channel_size,
@@ -355,6 +358,7 @@ where
             max_frame_size,
             inbound_connection_limit,
             inbound_rate_limiters,
+            outbound_rate_limiters,
         }
     }
 
@@ -541,6 +545,8 @@ where
 
                 // Garbage collect unused rate limit buckets
                 self.inbound_rate_limiters.try_garbage_collect_key(&ip_addr);
+                self.outbound_rate_limiters
+                    .try_garbage_collect_key(&ip_addr);
             }
         }
     }
@@ -775,6 +781,7 @@ where
             .find_ip_addr()
             .unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
         let inbound_rate_limiter = self.inbound_rate_limiters.bucket(ip_addr);
+        let outbound_rate_limiter = self.outbound_rate_limiters.bucket(ip_addr);
 
         // Initialize a new network stack for this connection.
         let (network_reqs_tx, network_notifs_rx) = NetworkProvider::start(
@@ -787,6 +794,7 @@ where
             self.channel_size,
             self.max_frame_size,
             Some(inbound_rate_limiter),
+            Some(outbound_rate_limiter),
         );
         // Start background task to handle events (RPCs and DirectSend messages) received from
         // peer.

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -233,6 +233,8 @@ impl ConnectionRequestSender {
     }
 }
 
+pub type IpAddrTokenBucketLimiter = TokenBucketRateLimiter<IpAddr>;
+
 /// Responsible for handling and maintaining connections to other Peers
 pub struct PeerManager<TTransport, TSocket>
 where
@@ -286,9 +288,9 @@ where
     /// Inbound connection limit separate of outbound connections
     inbound_connection_limit: usize,
     /// Keyed storage of all inbound rate limiters
-    inbound_rate_limiters: TokenBucketRateLimiter<IpAddr>,
+    inbound_rate_limiters: IpAddrTokenBucketLimiter,
     /// Keyed storage of all outbound rate limiters
-    outbound_rate_limiters: TokenBucketRateLimiter<IpAddr>,
+    outbound_rate_limiters: IpAddrTokenBucketLimiter,
 }
 
 impl<TTransport, TSocket> PeerManager<TTransport, TSocket>
@@ -315,8 +317,8 @@ where
         max_concurrent_network_notifs: usize,
         max_frame_size: usize,
         inbound_connection_limit: usize,
-        inbound_rate_limiters: TokenBucketRateLimiter<IpAddr>,
-        outbound_rate_limiters: TokenBucketRateLimiter<IpAddr>,
+        inbound_rate_limiters: IpAddrTokenBucketLimiter,
+        outbound_rate_limiters: IpAddrTokenBucketLimiter,
     ) -> Self {
         let (transport_notifs_tx, transport_notifs_rx) = channel::new(
             channel_size,

--- a/network/src/peer_manager/tests.rs
+++ b/network/src/peer_manager/tests.rs
@@ -106,6 +106,7 @@ fn build_test_peer_manager(
         constants::MAX_FRAME_SIZE,
         MAX_INBOUND_CONNECTIONS,
         TokenBucketRateLimiter::open(),
+        TokenBucketRateLimiter::open(),
     );
 
     (
@@ -119,7 +120,8 @@ fn build_test_peer_manager(
 
 async fn ping_pong(connection: &mut MemorySocket) -> Result<(), PeerManagerError> {
     let (read_half, write_half) = tokio::io::split(IoCompat::new(connection));
-    let mut msg_tx = NetworkMessageSink::new(IoCompat::new(write_half), constants::MAX_FRAME_SIZE);
+    let mut msg_tx =
+        NetworkMessageSink::new(IoCompat::new(write_half), constants::MAX_FRAME_SIZE, None);
     let mut msg_rx =
         NetworkMessageStream::new(IoCompat::new(read_half), constants::MAX_FRAME_SIZE, None);
 

--- a/network/src/peer_manager/tests.rs
+++ b/network/src/peer_manager/tests.rs
@@ -105,8 +105,8 @@ fn build_test_peer_manager(
         constants::MAX_CONCURRENT_NETWORK_NOTIFS,
         constants::MAX_FRAME_SIZE,
         MAX_INBOUND_CONNECTIONS,
-        TokenBucketRateLimiter::open(),
-        TokenBucketRateLimiter::open(),
+        TokenBucketRateLimiter::open("inbound"),
+        TokenBucketRateLimiter::open("outbound"),
     );
 
     (

--- a/network/src/protocols/wire/messaging/v1/test.rs
+++ b/network/src/protocols/wire/messaging/v1/test.rs
@@ -66,7 +66,7 @@ fn libranet_wire_test_vectors() {
     // test reading and deserializing gives us the expected message
 
     let socket_rx = ReadOnlyTestSocket::new(&message_bytes);
-    let message_rx = NetworkMessageStream::new(socket_rx, 128);
+    let message_rx = NetworkMessageStream::new(socket_rx, 128, None);
 
     let recv_messages = block_on(message_rx.collect::<Vec<_>>());
     let recv_messages = recv_messages
@@ -108,7 +108,7 @@ fn recv_fails_when_larger_than_frame_limit() {
     // sender won't error b/c their max frame size is larger
     let mut message_tx = NetworkMessageSink::new(memsocket_tx, 128);
     // receiver will reject the message b/c the frame size is > 64 bytes max
-    let mut message_rx = NetworkMessageStream::new(memsocket_rx, 64);
+    let mut message_rx = NetworkMessageStream::new(memsocket_rx, 64, None);
 
     let message = NetworkMessage::DirectSendMsg(DirectSendMsg {
         protocol_id: ProtocolId::ConsensusRpc,
@@ -203,7 +203,7 @@ proptest! {
         }
 
         let mut message_tx = NetworkMessageSink::new(socket_tx, 128);
-        let message_rx = NetworkMessageStream::new(socket_rx, 128);
+        let message_rx = NetworkMessageStream::new(socket_rx, 128, None);
 
         let f_send_all = async {
             for message in &messages {

--- a/network/src/protocols/wire/messaging/v1/test.rs
+++ b/network/src/protocols/wire/messaging/v1/test.rs
@@ -81,7 +81,7 @@ fn libranet_wire_test_vectors() {
     let mut write_buf = Vec::new();
     socket_tx.save_writing(&mut write_buf);
 
-    let mut message_tx = NetworkMessageSink::new(socket_tx, 128);
+    let mut message_tx = NetworkMessageSink::new(socket_tx, 128, None);
     block_on(message_tx.send(&message)).unwrap();
 
     assert_eq!(&write_buf, &message_bytes);
@@ -90,7 +90,7 @@ fn libranet_wire_test_vectors() {
 #[test]
 fn send_fails_when_larger_than_frame_limit() {
     let (memsocket_tx, _memsocket_rx) = MemorySocket::new_pair();
-    let mut message_tx = NetworkMessageSink::new(memsocket_tx, 64);
+    let mut message_tx = NetworkMessageSink::new(memsocket_tx, 64, None);
 
     // attempting to send an outbound message larger than your frame size will
     // return an Err
@@ -106,7 +106,7 @@ fn send_fails_when_larger_than_frame_limit() {
 fn recv_fails_when_larger_than_frame_limit() {
     let (memsocket_tx, memsocket_rx) = MemorySocket::new_pair();
     // sender won't error b/c their max frame size is larger
-    let mut message_tx = NetworkMessageSink::new(memsocket_tx, 128);
+    let mut message_tx = NetworkMessageSink::new(memsocket_tx, 128, None);
     // receiver will reject the message b/c the frame size is > 64 bytes max
     let mut message_rx = NetworkMessageStream::new(memsocket_rx, 64, None);
 
@@ -202,7 +202,7 @@ proptest! {
             socket_tx.set_fragmented_write();
         }
 
-        let mut message_tx = NetworkMessageSink::new(socket_tx, 128);
+        let mut message_tx = NetworkMessageSink::new(socket_tx, 128, None);
         let message_rx = NetworkMessageStream::new(socket_rx, 128, None);
 
         let f_send_all = async {

--- a/x.toml
+++ b/x.toml
@@ -121,6 +121,7 @@ members = [
     "diem-fuzz",
     "diem-fuzzer",
     "diem-proptest-helpers",
+    "diem-rate-limiter",
     "diem-retrier",
     "diem-smoke-test-attribute",
     "diem-swarm",

--- a/x.toml
+++ b/x.toml
@@ -121,7 +121,6 @@ members = [
     "diem-fuzz",
     "diem-fuzzer",
     "diem-proptest-helpers",
-    "diem-rate-limiter",
     "diem-retrier",
     "diem-smoke-test-attribute",
     "diem-swarm",


### PR DESCRIPTION
### Overview
This adds inbound and outbound rate limiting at a byte throughput controlled level.  Backpressure will occur when the reader is rate limiting *and* the `TcpSocket` buffer has filled.  Therefore, rate limit throughputs of reading on the application side will be the expected throughput, but the actual wire read throughput would be maximum `bufferSize` over the rate limit.  This would then even out as if the rate limiting continues, the buffer would already be full.

To add Inbound and Outbound rate limiting, we now have a configuration in the `TokenBucketConfig` of `NetworkConfig` to change each independently.  In addition, each one can be turned on or off independently.

Garbage collection is handled at disconnects.  If there are no references to the `Bucket` at disconnect time, it will release the bucket.  Buckets are initialized to 1/4 of their full size to prevent abusing this behavior.

I've also spent time to simplify down some of the extra features I had added in the previous implementation, to just be the following:
* One bucket size / rate for all buckets
* Only use the top level for management of buckets, use the bucket for all rate limiting
* Allow for making an `open` rate limiter, which just lets all traffic through for testing purposes
* Garbage collection, based on reference counting
* Fill the buckets only when you try to use them
* Allow for adding back unused tokens (for something like a `read` where you might not use all of them)

### Why not use a third party library?
I spent time looking at Governor, and after some back and forth, it didn't give us quite what we wanted, plus had to pull in more dependencies that we didn't necessarily need like Dashmap.  Now, the map operations are entirely off of the critical path, just garbage collection remains, which should only be periodic.

### Testing
From the integration test in the RateLimiting main function, here's an output of one of the runs
```
Starting experiments
Bytes to test: 1000000, Expected Throughput(actions/s): 1, Expected Throughput(bytes/s): 10000, 

== No Read or Write Limiting ==
Write stats	|	Total actions: 100	|	Total bytes: 1000000	|	Throughput(actions/s): 20000	|	Throughput(bytes/s): 200000000	|	Time elapsed: 5.46656ms
Read stats	|	Total actions: 100	|	Total bytes: 1000000	|	Throughput(actions/s): 20000	|	Throughput(bytes/s): 200000000	|	Time elapsed: 5.534616ms

== Read Limited ==
Write stats	|	Total actions: 100	|	Total bytes: 1000000	|	Throughput(actions/s): 1.8828491272994297	|	Throughput(bytes/s): 18828.491272994295	|	Time elapsed: 53.111312588s
Read stats	|	Total actions: 100	|	Total bytes: 1000000	|	Throughput(actions/s): 1.0101112132445782	|	Throughput(bytes/s): 10101.112132445784	|	Time elapsed: 98.99958156s

== Write Limited ==
Write stats	|	Total actions: 100	|	Total bytes: 1000000	|	Throughput(actions/s): 1.010070401907013	|	Throughput(bytes/s): 10100.70401907013	|	Time elapsed: 99.003092829s
Read stats	|	Total actions: 100	|	Total bytes: 1000000	|	Throughput(actions/s): 1.010070401907013	|	Throughput(bytes/s): 10100.70401907013	|	Time elapsed: 99.003324322s

== Read & Write Limited ==
Write stats	|	Total actions: 100	|	Total bytes: 1000000	|	Throughput(actions/s): 1.0101010101010102	|	Throughput(bytes/s): 10101.0101010101	|	Time elapsed: 99.000364369s
Read stats	|	Total actions: 100	|	Total bytes: 1000000	|	Throughput(actions/s): 1.0101010101010102	|	Throughput(bytes/s): 10101.0101010101	|	Time elapsed: 99.000589412s
```

And a bigger one to show that average throughput approaches the rate limiting with a higher sample size.
```
Starting experiments
Bytes to test: 10000000, Expected Throughput(actions/s): 1, Expected Throughput(bytes/s): 10000, 

== No Read or Write Limiting ==
Write stats	|	Total actions: 1000	|	Total bytes: 10000000	|	Throughput(actions/s): 21276.59574468085	|	Throughput(bytes/s): 212765957.44680852	|	Time elapsed: 47.88036ms
Read stats	|	Total actions: 1000	|	Total bytes: 10000000	|	Throughput(actions/s): 21276.59574468085	|	Throughput(bytes/s): 212765957.44680852	|	Time elapsed: 47.960291ms

== Read Limited ==
Write stats	|	Total actions: 1000	|	Total bytes: 10000000	|	Throughput(actions/s): 1.04808180068838	|	Throughput(bytes/s): 10480.818006883801	|	Time elapsed: 954.124338916s
Read stats	|	Total actions: 1000	|	Total bytes: 10000000	|	Throughput(actions/s): 1.001001001001001	|	Throughput(bytes/s): 10010.01001001001	|	Time elapsed: 999.000938076s

== Write Limited ==
Write stats	|	Total actions: 1000	|	Total bytes: 10000000	|	Throughput(actions/s): 1.00099398702912	|	Throughput(bytes/s): 10009.9398702912	|	Time elapsed: 999.007847151s
Read stats	|	Total actions: 1000	|	Total bytes: 10000000	|	Throughput(actions/s): 1.0009929850411607	|	Throughput(bytes/s): 10009.929850411609	|	Time elapsed: 999.008094395s

== Read & Write Limited ==
Write stats	|	Total actions: 1000	|	Total bytes: 10000000	|	Throughput(actions/s): 1.001001001001001	|	Throughput(bytes/s): 10010.01001001001	|	Time elapsed: 999.00025048s
Read stats	|	Total actions: 1000	|	Total bytes: 10000000	|	Throughput(actions/s): 1.001001001001001	|	Throughput(bytes/s): 10010.01001001001	|	Time elapsed: 999.000346919s
```

### Other Reading
* https://en.wikipedia.org/wiki/Token_bucket