### PR TITLE
[JSON RPC] Update failing integration test by increasing timeout.

### DIFF
--- a/json-rpc/tests/testing.rs
+++ b/json-rpc/tests/testing.rs
@@ -226,7 +226,7 @@ impl Env {
                     return result;
                 }
             }
-            ::std::thread::sleep(::std::time::Duration::from_millis(100));
+            ::std::thread::sleep(::std::time::Duration::from_millis(500));
         }
         panic!("transaction not executed?");
     }


### PR DESCRIPTION
## Motivation

The "test_interface" test located in json-rpc/tests/integration_test.rs seems to fail locally. This appears to be because recent changes to the logger mean that execution of the test takes longer now. As a result, we need to increase the test timeout from 6 seconds to 30 seconds (conservative).

Moreover, as part of this PR, we also create a log file for the node being tested so that on future failures, it'll be easier to debug.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Running the tests locally now works!

## Related PRs

None.