### PR TITLE
[x] allow workspace subsets to be specified for xbuild etc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -394,7 +394,7 @@ jobs:
           command: cargo xclippy --workspace --all-targets
       - run:
           name: cargo clippy tcb
-          command: cargo xclippy -p safety-rules  -p execution-correctness -p diem-key-manager
+          command: cargo xclippy --members lec --members lsr --members key-manager
       - run:
           name: cargo fmt
           command: cargo xfmt --check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -421,7 +421,7 @@ jobs:
       - build_setup
       - restore_cargo_package_cache
       - run:
-          command: RUST_BACKTRACE=1 cargo xcheck -j 8 --production
+          command: RUST_BACKTRACE=1 cargo xcheck -j 16 --members production
       - run:
           command: RUST_BACKTRACE=1 cargo xcheck -j 8 --workspace --all-targets
       - run:

--- a/.github/workflows/dep-summaries.yml
+++ b/.github/workflows/dep-summaries.yml
@@ -64,6 +64,7 @@ jobs:
           cd libra-base
           cargo x generate-summaries
 
+      # TODO (sunshowers): add key-manager TCB
       - name: diff LSR summary
         id: verify-lsr
         run: |

--- a/devtools/x-core/src/core_config.rs
+++ b/devtools/x-core/src/core_config.rs
@@ -15,6 +15,6 @@ pub struct XCoreConfig {
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct SubsetConfig {
-    /// The members in this subset
-    pub members: Vec<String>,
+    /// The root members in this subset
+    pub root_members: Vec<String>,
 }

--- a/devtools/x-core/src/core_config.rs
+++ b/devtools/x-core/src/core_config.rs
@@ -1,0 +1,20 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Core configuration for x.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub struct XCoreConfig {
+    /// Subsets of this workspace
+    pub subsets: BTreeMap<String, SubsetConfig>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub struct SubsetConfig {
+    /// The members in this subset
+    pub members: Vec<String>,
+}

--- a/devtools/x-core/src/git.rs
+++ b/devtools/x-core/src/git.rs
@@ -123,7 +123,10 @@ impl GitCli {
         let scratch = self.get_or_init_scratch(commit_ref)?;
 
         // Compute the package graph for the scratch worktree.
-        Ok(MetadataCommand::new().current_dir(scratch).build_graph()?)
+        MetadataCommand::new()
+            .current_dir(scratch)
+            .build_graph()
+            .map_err(|err| SystemError::guppy("building package graph", err))
     }
 
     // ---

--- a/devtools/x-core/src/graph.rs
+++ b/devtools/x-core/src/graph.rs
@@ -1,18 +1,18 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{Result, SystemError, WorkspaceSubset, XCoreContext};
+use crate::{Result, SystemError, WorkspaceSubsets, XCoreContext};
 use guppy::MetadataCommand;
 
 rental! {
     mod rent_package_graph {
-        use crate::WorkspaceSubset;
+        use crate::WorkspaceSubsets;
         use guppy::graph::PackageGraph;
 
         #[rental(covariant)]
         pub(crate) struct PackageGraphPlus {
             g: Box<PackageGraph>,
-            default_members: WorkspaceSubset<'g>,
+            subsets: WorkspaceSubsets<'g>,
         }
     }
 }
@@ -31,7 +31,7 @@ impl PackageGraphPlus {
                 cmd.build_graph()
                     .map_err(|err| SystemError::guppy("building package graph", err))?,
             ),
-            move |graph| WorkspaceSubset::default_members(graph, project_root),
+            move |graph| WorkspaceSubsets::new(graph, project_root, &ctx.config().subsets),
         )
     }
 }

--- a/devtools/x-core/src/graph.rs
+++ b/devtools/x-core/src/graph.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{Result, WorkspaceSubset, XCoreContext};
+use crate::{Result, SystemError, WorkspaceSubset, XCoreContext};
 use guppy::MetadataCommand;
 
 rental! {
@@ -26,8 +26,12 @@ impl PackageGraphPlus {
         let project_root = ctx.project_root();
         cmd.current_dir(project_root);
 
-        Self::try_new_or_drop(Box::new(cmd.build_graph()?), move |graph| {
-            WorkspaceSubset::default_members(graph, project_root)
-        })
+        Self::try_new_or_drop(
+            Box::new(
+                cmd.build_graph()
+                    .map_err(|err| SystemError::guppy("building package graph", err))?,
+            ),
+            move |graph| WorkspaceSubset::default_members(graph, project_root),
+        )
     }
 }

--- a/devtools/x-core/src/workspace_subset.rs
+++ b/devtools/x-core/src/workspace_subset.rs
@@ -55,7 +55,7 @@ impl<'g> WorkspaceSubsets<'g> {
             .iter()
             .map(|(name, config)| {
                 let query = graph
-                    .query_workspace_names(&config.members)
+                    .query_workspace_names(&config.root_members)
                     .map_err(|err| {
                         SystemError::guppy(format!("querying members for subset '{}'", name), err)
                     })?;

--- a/devtools/x-core/src/workspace_subset.rs
+++ b/devtools/x-core/src/workspace_subset.rs
@@ -71,12 +71,13 @@ impl<'g> WorkspaceSubset<'g> {
         let cargo_opts = CargoOptions::new()
             .with_version(CargoResolverVersion::V2)
             .with_dev_deps(false);
-        Ok(Self::new(
+        Self::new(
             package_graph,
             default_members,
             default_filter(),
             &cargo_opts,
-        )?)
+        )
+        .map_err(|err| SystemError::guppy("parsing default members", err))
     }
 
     /// Returns the status of the given package ID in the subset.

--- a/devtools/x-core/src/workspace_subset.rs
+++ b/devtools/x-core/src/workspace_subset.rs
@@ -1,22 +1,121 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{Result, SystemError};
+use crate::{core_config::SubsetConfig, Result, SystemError};
 use guppy::{
     graph::{
         cargo::{CargoOptions, CargoResolverVersion, CargoSet},
-        feature::{default_filter, FeatureFilter, FeatureSet},
-        PackageGraph, PackageMetadata,
+        feature::{default_filter, FeatureFilter, FeatureQuery, FeatureSet},
+        PackageGraph, PackageMetadata, PackageQuery,
     },
     PackageId,
 };
 use serde::Deserialize;
-use std::{fs, path::Path};
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+};
 use toml::de;
+
+/// Contains information about all the subsets specified in this workspace.
+#[derive(Clone, Debug)]
+pub struct WorkspaceSubsets<'g> {
+    // TODO: default members should become a subset in x.toml
+    default_members: WorkspaceSubset<'g>,
+    subsets: BTreeMap<String, WorkspaceSubset<'g>>,
+}
+
+impl<'g> WorkspaceSubsets<'g> {
+    /// Constructs a new store for workspace subsets.
+    ///
+    /// This is done with respect to a "standard build", which assumes:
+    /// * any platform
+    /// * v2 resolver
+    /// * no dev dependencies
+    pub fn new(
+        graph: &'g PackageGraph,
+        project_root: &Path,
+        config: &BTreeMap<String, SubsetConfig>,
+    ) -> Result<Self> {
+        let cargo_opts = CargoOptions::new()
+            .with_version(CargoResolverVersion::V2)
+            .with_dev_deps(false);
+
+        let default_members = Self::read_default_members(project_root)?;
+
+        // Look up default members by path.
+        let default_query = graph
+            .query_workspace_paths(&default_members)
+            .map_err(|err| SystemError::guppy("querying default members", err))?;
+        let default_members = WorkspaceSubset::new(&default_query, default_filter(), &cargo_opts);
+
+        // For each of the subset configs, look up the packages by name.
+        let subsets = config
+            .iter()
+            .map(|(name, config)| {
+                let query = graph
+                    .query_workspace_names(&config.members)
+                    .map_err(|err| {
+                        SystemError::guppy(format!("querying members for subset '{}'", name), err)
+                    })?;
+                let subset = WorkspaceSubset::new(&query, default_filter(), &cargo_opts);
+                Ok((name.clone(), subset))
+            })
+            .collect::<Result<_, _>>()?;
+
+        Ok(Self {
+            default_members,
+            subsets,
+        })
+    }
+
+    /// Returns information about default members.
+    pub fn default_members(&self) -> &WorkspaceSubset<'g> {
+        &self.default_members
+    }
+
+    /// Returns information about the subset by name.
+    pub fn get(&self, name: impl AsRef<str>) -> Option<&WorkspaceSubset<'g>> {
+        self.subsets.get(name.as_ref())
+    }
+
+    /// Iterate over all named subsets.
+    pub fn iter<'a>(&'a self) -> impl Iterator<Item = (&'a str, &'a WorkspaceSubset<'g>)> + 'a {
+        self.subsets
+            .iter()
+            .map(|(name, subset)| (name.as_str(), subset))
+    }
+
+    // ---
+    // Helper methods
+    // ---
+
+    fn read_default_members(project_root: &Path) -> Result<Vec<PathBuf>> {
+        #[derive(Deserialize)]
+        struct RootToml {
+            workspace: Workspace,
+        }
+
+        #[derive(Deserialize)]
+        struct Workspace {
+            #[serde(rename = "default-members")]
+            default_members: Vec<PathBuf>,
+        }
+
+        let root_toml = project_root.join("Cargo.toml");
+        let contents =
+            fs::read(&root_toml).map_err(|err| SystemError::io("reading root Cargo.toml", err))?;
+        let contents: RootToml = de::from_slice(&contents)
+            .map_err(|err| SystemError::de("deserializing root Cargo.toml", err))?;
+        Ok(contents.workspace.default_members)
+    }
+}
 
 /// Information collected about a subset of members of a workspace.
 ///
 /// Some subsets of this workspace have special properties that are enforced through linters.
+#[derive(Clone, Debug)]
 pub struct WorkspaceSubset<'g> {
     build_set: CargoSet<'g>,
     unified_set: FeatureSet<'g>,
@@ -26,58 +125,26 @@ impl<'g> WorkspaceSubset<'g> {
     /// Creates a new subset by simulating a Cargo build on the specified workspace paths, with
     /// the given feature filter.
     pub fn new<'a>(
-        package_graph: &'g PackageGraph,
-        paths: impl IntoIterator<Item = &'a Path>,
+        package_query: &PackageQuery<'g>,
         feature_filter: impl FeatureFilter<'g>,
         cargo_opts: &CargoOptions<'_>,
-    ) -> Result<Self, guppy::Error> {
+    ) -> Self {
         // Use the Cargo resolver to figure out which packages will be included.
-        let build_set = package_graph
-            .query_workspace_paths(paths)?
+        let build_set = package_query
             .to_feature_query(feature_filter)
-            .resolve_cargo(cargo_opts)?;
+            .resolve_cargo(cargo_opts)
+            .expect("resolve cargo should always succeed");
         let unified_set = build_set.host_features().union(build_set.target_features());
 
-        Ok(Self {
+        Self {
             build_set,
             unified_set,
-        })
+        }
     }
 
-    /// Creates a new subset of default members by reading the root `Cargo.toml` file.
-    ///
-    /// This does not include dev-dependencies.
-    pub fn default_members(package_graph: &'g PackageGraph, project_root: &Path) -> Result<Self> {
-        #[derive(Deserialize)]
-        struct RootToml<'a> {
-            #[serde(borrow)]
-            workspace: Workspace<'a>,
-        }
-
-        #[derive(Deserialize)]
-        struct Workspace<'a> {
-            #[serde(borrow)]
-            #[serde(rename = "default-members")]
-            default_members: Vec<&'a Path>,
-        }
-
-        let root_toml = project_root.join("Cargo.toml");
-        let contents =
-            fs::read(&root_toml).map_err(|err| SystemError::io("reading root Cargo.toml", err))?;
-        let contents: RootToml = de::from_slice(&contents)
-            .map_err(|err| SystemError::de("deserializing root Cargo.toml", err))?;
-        let default_members = contents.workspace.default_members;
-
-        let cargo_opts = CargoOptions::new()
-            .with_version(CargoResolverVersion::V2)
-            .with_dev_deps(false);
-        Self::new(
-            package_graph,
-            default_members,
-            default_filter(),
-            &cargo_opts,
-        )
-        .map_err(|err| SystemError::guppy("parsing default members", err))
+    /// Returns the original query that this subset was constructed from.
+    pub fn query(&self) -> &FeatureQuery<'g> {
+        self.build_set.original_query()
     }
 
     /// Returns the status of the given package ID in the subset.

--- a/devtools/x-lint/src/project.rs
+++ b/devtools/x-lint/src/project.rs
@@ -52,7 +52,7 @@ impl<'l> ProjectContext<'l> {
     /// This includes all packages included by default in the default workspace members, but not
     /// those that Cargo would ignore.
     pub fn default_members(&self) -> Result<&WorkspaceSubset> {
-        self.core.default_members()
+        Ok(self.core.subsets()?.default_members())
     }
 }
 

--- a/devtools/x/src/cargo/selected_package.rs
+++ b/devtools/x/src/cargo/selected_package.rs
@@ -129,7 +129,7 @@ pub(super) enum SelectedInclude<'a> {
 impl<'a> SelectedInclude<'a> {
     /// Returns a `SelectedInclude` that selects production crates (non-test-only code).
     pub fn production(xctx: &'a XContext) -> Result<Self> {
-        let default_members = xctx.core().default_members()?;
+        let default_members = xctx.core().subsets()?.default_members();
         let workspace = xctx.core().package_graph()?.workspace();
 
         let selected = workspace.iter().filter_map(|package| {

--- a/devtools/x/src/context.rs
+++ b/devtools/x/src/context.rs
@@ -1,7 +1,12 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{config::Config, installer::Installer, utils::project_root, Result};
+use crate::{
+    config::{Config, XConfig},
+    installer::Installer,
+    utils::project_root,
+    Result,
+};
 use anyhow::Context;
 use x_core::XCoreContext;
 
@@ -15,15 +20,16 @@ pub struct XContext {
 impl XContext {
     /// Creates a new `GlobalContext` by reading the config in the project root.
     pub fn new() -> Result<Self> {
-        Self::with_config(Config::from_project_root()?)
+        Self::with_config(XConfig::from_project_root()?)
     }
 
     /// Creates a new `GlobalContext` based on the given config.
-    pub fn with_config(config: Config) -> Result<Self> {
+    pub fn with_config(x_config: XConfig) -> Result<Self> {
         let current_dir =
             std::env::current_dir().with_context(|| "error while fetching current dir")?;
+        let XConfig { core, config } = x_config;
         Ok(Self {
-            core: XCoreContext::new(project_root(), current_dir)?,
+            core: XCoreContext::new(project_root(), current_dir, core)?,
             installer: Installer::new(config.cargo_config().clone(), config.tools()),
             config,
         })

--- a/x.toml
+++ b/x.toml
@@ -170,6 +170,12 @@ root-members = [
     "execution-correctness",
 ]
 
+[subsets.key-manager]
+# The Diem key manager TCB.
+root-members = [
+    "diem-key-manager",
+]
+
 [subsets.release]
 # The Diem release binaries
 root-members = [

--- a/x.toml
+++ b/x.toml
@@ -158,19 +158,19 @@ members = [
 # Interesting subsets of the workspace, These are used for generating and
 # checking dependency summaries.
 
-[workspace.subsets.lsr]
+[subsets.lsr]
 # The Diem safety rules TCB.
 members = [
     "safety-rules",
 ]
 
-[workspace.subsets.lec]
+[subsets.lec]
 # The Diem execution correctness TCB.
 members = [
     "execution-correctness",
 ]
 
-[workspace.subsets.release]
+[subsets.release]
 # The Diem release binaries
 members = [
     "backup-cli",

--- a/x.toml
+++ b/x.toml
@@ -160,19 +160,19 @@ members = [
 
 [subsets.lsr]
 # The Diem safety rules TCB.
-members = [
+root-members = [
     "safety-rules",
 ]
 
 [subsets.lec]
 # The Diem execution correctness TCB.
-members = [
+root-members = [
     "execution-correctness",
 ]
 
 [subsets.release]
 # The Diem release binaries
-members = [
+root-members = [
     "backup-cli",
     "db-bootstrapper",
     "diem-genesis-tool",


### PR DESCRIPTION
Add a new option `--members` which allows for specifying workspace subsets.

Also make `--changed-since` work with `--members`, so that you can say e.g. build anything in LEC that changed since origin/master.
