### PR TITLE
[diem framework] Update hex in comments to reflect new "XDX" name

### DIFF
--- a/language/move-prover/docgen/tests/sources/DiemTest.move
+++ b/language/move-prover/docgen/tests/sources/DiemTest.move
@@ -137,7 +137,7 @@ module DiemTest {
         /// 10^2 for `XUS` cents)
         fractional_part: u64,
         /// The code symbol for this `CoinType`. ASCII encoded.
-        /// e.g. for "XDX" this is x"4C4252". No character limit.
+        /// e.g. for "XDX" this is x"584458". No character limit.
         currency_code: vector<u8>,
         /// We may want to disable the ability to mint further coins of a
         /// currency while that currency is still around. This allows us to

--- a/language/move-prover/docgen/tests/sources/DiemTest.spec_inline.md
+++ b/language/move-prover/docgen/tests/sources/DiemTest.spec_inline.md
@@ -496,7 +496,7 @@ currency would be the XDX.
 </dt>
 <dd>
  The code symbol for this <code>CoinType</code>. ASCII encoded.
- e.g. for "XDX" this is x"4C4252". No character limit.
+ e.g. for "XDX" this is x"584458". No character limit.
 </dd>
 <dt>
 <code>can_mint: bool</code>

--- a/language/move-prover/docgen/tests/sources/DiemTest.spec_inline_no_fold.md
+++ b/language/move-prover/docgen/tests/sources/DiemTest.spec_inline_no_fold.md
@@ -465,7 +465,7 @@ currency would be the XDX.
 </dt>
 <dd>
  The code symbol for this <code>CoinType</code>. ASCII encoded.
- e.g. for "XDX" this is x"4C4252". No character limit.
+ e.g. for "XDX" this is x"584458". No character limit.
 </dd>
 <dt>
 <code>can_mint: bool</code>

--- a/language/move-prover/docgen/tests/sources/DiemTest.spec_separate.md
+++ b/language/move-prover/docgen/tests/sources/DiemTest.spec_separate.md
@@ -497,7 +497,7 @@ currency would be the XDX.
 </dt>
 <dd>
  The code symbol for this <code>CoinType</code>. ASCII encoded.
- e.g. for "XDX" this is x"4C4252". No character limit.
+ e.g. for "XDX" this is x"584458". No character limit.
 </dd>
 <dt>
 <code>can_mint: bool</code>

--- a/language/stdlib/modules/Diem.move
+++ b/language/stdlib/modules/Diem.move
@@ -127,7 +127,7 @@ module Diem {
         /// 10^2 for `XUS` cents)
         fractional_part: u64,
         /// The code symbol for this `CoinType`. ASCII encoded.
-        /// e.g. for "XDX" this is x"4C4252". No character limit.
+        /// e.g. for "XDX" this is x"584458". No character limit.
         currency_code: vector<u8>,
         /// Minting of new currency of CoinType is allowed only if this field is true.
         /// We may want to disable the ability to mint further coins of a

--- a/language/stdlib/modules/doc/Diem.md
+++ b/language/stdlib/modules/doc/Diem.md
@@ -451,7 +451,7 @@ currency would be the XDX.
 </dt>
 <dd>
  The code symbol for this <code>CoinType</code>. ASCII encoded.
- e.g. for "XDX" this is x"4C4252". No character limit.
+ e.g. for "XDX" this is x"584458". No character limit.
 </dd>
 <dt>
 <code>can_mint: bool</code>


### PR DESCRIPTION
Fixes a couple places where the ASCII hex encoding of "LBR" wasn't updated to the hex encoding of "XDX" in comments