### PR TITLE
Replacing integer arithmetic operations with wrapping/checked/saturating functions

### DIFF
--- a/common/proptest-helpers/src/growing_subset.rs
+++ b/common/proptest-helpers/src/growing_subset.rs
@@ -119,7 +119,7 @@ where
             if idx >= to_idx {
                 break;
             }
-            self.current_pos += 1;
+            self.current_pos = self.current_pos.saturating_add(1);
         }
     }
 }

--- a/common/proptest-helpers/src/growing_subset.rs
+++ b/common/proptest-helpers/src/growing_subset.rs
@@ -1,5 +1,6 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::integer_arithmetic)]
 
 use proptest::sample::Index;
 use std::iter::FromIterator;
@@ -118,7 +119,7 @@ where
             if idx >= to_idx {
                 break;
             }
-            self.current_pos = self.current_pos.saturating_add(1);
+            self.current_pos += 1;
         }
     }
 }

--- a/common/proptest-helpers/src/growing_subset.rs
+++ b/common/proptest-helpers/src/growing_subset.rs
@@ -118,7 +118,7 @@ where
             if idx >= to_idx {
                 break;
             }
-            self.current_pos += 1;
+            self.current_pos = self.current_pos.saturating_add(1);
         }
     }
 }

--- a/common/proptest-helpers/src/lib.rs
+++ b/common/proptest-helpers/src/lib.rs
@@ -1,6 +1,6 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
-
+#![allow(clippy::integer_arithmetic)]
 #![forbid(unsafe_code)]
 
 #[cfg(test)]
@@ -70,13 +70,13 @@ where
     // for a longer explanation. This is a variant that works with zero-indexing.
     let mut selected = BTreeSet::new();
     let to_select = indexes_len.min(max);
-    for (iter_idx, choice) in ((max.saturating_sub(to_select))..max).enumerate() {
+    for (iter_idx, choice) in ((max - to_select)..max).enumerate() {
         // "RandInt(1, J)" in the original algorithm means a number between 1
         // and choice, both inclusive. `PropIndex::index` picks a number between 0 and
         // whatever's passed in, with the latter exclusive. Pass in "+1" to ensure the same
         // range of values is picked from. (This also ensures that if choice is 0 then `index`
         // doesn't panic.
-        let idx = indexes[iter_idx].as_ref().index(choice.saturating_add(1));
+        let idx = indexes[iter_idx].as_ref().index(choice + 1);
         if !selected.insert(idx) {
             selected.insert(choice);
         }

--- a/common/proptest-helpers/src/lib.rs
+++ b/common/proptest-helpers/src/lib.rs
@@ -1,6 +1,5 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
-#![allow(clippy::integer_arithmetic)]
 #![forbid(unsafe_code)]
 
 #[cfg(test)]

--- a/common/proptest-helpers/src/lib.rs
+++ b/common/proptest-helpers/src/lib.rs
@@ -70,13 +70,13 @@ where
     // for a longer explanation. This is a variant that works with zero-indexing.
     let mut selected = BTreeSet::new();
     let to_select = indexes_len.min(max);
-    for (iter_idx, choice) in ((max - to_select)..max).enumerate() {
+    for (iter_idx, choice) in ((max.saturating_sub(to_select))..max).enumerate() {
         // "RandInt(1, J)" in the original algorithm means a number between 1
         // and choice, both inclusive. `PropIndex::index` picks a number between 0 and
         // whatever's passed in, with the latter exclusive. Pass in "+1" to ensure the same
         // range of values is picked from. (This also ensures that if choice is 0 then `index`
         // doesn't panic.
-        let idx = indexes[iter_idx].as_ref().index(choice + 1);
+        let idx = indexes[iter_idx].as_ref().index(choice.saturating_add(1));
         if !selected.insert(idx) {
             selected.insert(choice);
         }

--- a/common/proptest-helpers/src/repeat_vec.rs
+++ b/common/proptest-helpers/src/repeat_vec.rs
@@ -1,5 +1,6 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::integer_arithmetic)]
 
 use crate::pick_slice_idxs;
 use proptest::sample::Index;
@@ -103,7 +104,7 @@ impl<T> RepeatVec<T> {
         // Skip over zero-length elements to maintain the invariant on items.
         if size > 0 {
             self.items.push((self.len, item));
-            self.len = self.len.saturating_add(size);
+            self.len += size;
         }
     }
 
@@ -157,7 +158,7 @@ impl<T> RepeatVec<T> {
             Err(start_idx) => {
                 // This is the physical index after the logical item. Start reasoning from the
                 // previous index to match the Ok branch above.
-                start_idx.saturating_sub(1)
+                start_idx - 1
             }
         };
 
@@ -170,20 +171,20 @@ impl<T> RepeatVec<T> {
             let mut new_items = vec![];
 
             while let Some((current_logical_idx_old, current_elem)) = items.next() {
-                let current_logical_idx_new = current_logical_idx_old.saturating_sub(decrease);
+                let current_logical_idx_new = current_logical_idx_old - decrease;
 
                 let next_logical_idx_old = items.peek().map_or(self.len, |&(idx, _)| idx);
 
                 // Remove all indexes until the next logical index or sorted_indexes runs out.
                 while let Some(remove_idx) = logical_indexes.get(decrease) {
                     if *remove_idx < next_logical_idx_old {
-                        decrease = decrease.saturating_add(1);
+                        decrease += 1;
                     } else {
                         break;
                     }
                 }
 
-                let next_logical_idx_new = next_logical_idx_old.saturating_sub(decrease);
+                let next_logical_idx_new = next_logical_idx_old - decrease;
                 assert!(
                     next_logical_idx_new >= current_logical_idx_new,
                     "too many items removed from next"
@@ -198,7 +199,7 @@ impl<T> RepeatVec<T> {
         };
 
         self.items.extend(new_items);
-        self.len = self.len.saturating_sub(decrease);
+        self.len -= decrease;
     }
 
     /// Returns the item at location `at`. The return value is a reference to the stored item, plus
@@ -212,8 +213,8 @@ impl<T> RepeatVec<T> {
             Err(start_idx) => {
                 // start_idx can never be 0 because usize starts from 0 and items[0].0 is always 0.
                 // So start_idx is always at least 1.
-                let start_val = &self.items[start_idx.saturating_sub(1)];
-                let offset = at.saturating_sub(start_val.0);
+                let start_val = &self.items[start_idx - 1];
+                let offset = at - start_val.0;
                 Some((&start_val.1, offset))
             }
         }

--- a/common/proptest-helpers/src/repeat_vec.rs
+++ b/common/proptest-helpers/src/repeat_vec.rs
@@ -103,7 +103,7 @@ impl<T> RepeatVec<T> {
         // Skip over zero-length elements to maintain the invariant on items.
         if size > 0 {
             self.items.push((self.len, item));
-            self.len += size;
+            self.len = self.len.saturating_add(size);
         }
     }
 
@@ -157,7 +157,7 @@ impl<T> RepeatVec<T> {
             Err(start_idx) => {
                 // This is the physical index after the logical item. Start reasoning from the
                 // previous index to match the Ok branch above.
-                start_idx - 1
+                start_idx.saturating_sub(1)
             }
         };
 
@@ -170,20 +170,20 @@ impl<T> RepeatVec<T> {
             let mut new_items = vec![];
 
             while let Some((current_logical_idx_old, current_elem)) = items.next() {
-                let current_logical_idx_new = current_logical_idx_old - decrease;
+                let current_logical_idx_new = current_logical_idx_old.saturating_sub(decrease);
 
                 let next_logical_idx_old = items.peek().map_or(self.len, |&(idx, _)| idx);
 
                 // Remove all indexes until the next logical index or sorted_indexes runs out.
                 while let Some(remove_idx) = logical_indexes.get(decrease) {
                     if *remove_idx < next_logical_idx_old {
-                        decrease += 1;
+                        decrease = decrease.saturating_add(1);
                     } else {
                         break;
                     }
                 }
 
-                let next_logical_idx_new = next_logical_idx_old - decrease;
+                let next_logical_idx_new = next_logical_idx_old.saturating_sub(decrease);
                 assert!(
                     next_logical_idx_new >= current_logical_idx_new,
                     "too many items removed from next"
@@ -198,7 +198,7 @@ impl<T> RepeatVec<T> {
         };
 
         self.items.extend(new_items);
-        self.len -= decrease;
+        self.len = self.len.saturating_sub(decrease);
     }
 
     /// Returns the item at location `at`. The return value is a reference to the stored item, plus
@@ -212,8 +212,8 @@ impl<T> RepeatVec<T> {
             Err(start_idx) => {
                 // start_idx can never be 0 because usize starts from 0 and items[0].0 is always 0.
                 // So start_idx is always at least 1.
-                let start_val = &self.items[start_idx - 1];
-                let offset = at - start_val.0;
+                let start_val = &self.items[start_idx.saturating_sub(1)];
+                let offset = at.saturating_sub(start_val.0);
                 Some((&start_val.1, offset))
             }
         }

--- a/common/short-hex-str/src/lib.rs
+++ b/common/short-hex-str/src/lib.rs
@@ -1,5 +1,6 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::integer_arithmetic)]
 
 use mirai_annotations::debug_checked_precondition;
 use serde::{Serialize, Serializer};

--- a/common/short-hex-str/src/lib.rs
+++ b/common/short-hex-str/src/lib.rs
@@ -88,10 +88,15 @@ fn byte2hex(byte: u8) -> (u8, u8) {
 }
 
 /// Hex encode a byte slice into the destination byte slice.
-#[allow(clippy::integer_arithmetic)]
 #[inline(always)]
 fn hex_encode(src: &[u8], dst: &mut [u8]) {
-    debug_checked_precondition!(dst.len() == src.len().saturating_mul(2));
+    debug_checked_precondition!(
+        dst.len()
+            == src
+                .len()
+                .checked_mul(2)
+                .expect("integer overflow when encoding to hex string")
+    );
 
     for (byte, out) in src.iter().zip(dst.chunks_mut(2)) {
         let (hi, lo) = byte2hex(*byte);

--- a/common/short-hex-str/src/lib.rs
+++ b/common/short-hex-str/src/lib.rs
@@ -90,9 +90,7 @@ fn byte2hex(byte: u8) -> (u8, u8) {
 /// Hex encode a byte slice into the destination byte slice.
 #[inline(always)]
 fn hex_encode(src: &[u8], dst: &mut [u8]) {
-    #[allow(clippy::integer_arithmetic)]
-    debug_checked_precondition!(dst.len() == 2 * src.len());
-
+    debug_checked_precondition!(dst.len() == src.len().checked_mul(2).expect("should not happen"));
     for (byte, out) in src.iter().zip(dst.chunks_mut(2)) {
         let (hi, lo) = byte2hex(*byte);
         out[0] = hi;

--- a/common/short-hex-str/src/lib.rs
+++ b/common/short-hex-str/src/lib.rs
@@ -1,6 +1,5 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
-#![allow(clippy::integer_arithmetic)]
 
 use mirai_annotations::debug_checked_precondition;
 use serde::{Serialize, Serializer};
@@ -21,7 +20,7 @@ pub struct InputTooShortError;
 
 impl ShortHexStr {
     pub const SOURCE_LENGTH: usize = 4;
-    pub const LENGTH: usize = 2 * ShortHexStr::SOURCE_LENGTH;
+    pub const LENGTH: usize = ShortHexStr::SOURCE_LENGTH.saturating_mul(2);
 
     /// Format a new `ShortHexStr` from a byte slice.
     ///
@@ -80,6 +79,7 @@ const HEX_CHARS_LOWER: &[u8; 16] = b"0123456789abcdef";
 
 /// Format a byte as hex. Returns a tuple containing the first character and then
 /// the second character as ASCII bytes.
+#[allow(clippy::integer_arithmetic)]
 #[inline(always)]
 fn byte2hex(byte: u8) -> (u8, u8) {
     let hi = HEX_CHARS_LOWER[((byte >> 4) & 0x0f) as usize];
@@ -88,9 +88,10 @@ fn byte2hex(byte: u8) -> (u8, u8) {
 }
 
 /// Hex encode a byte slice into the destination byte slice.
+#[allow(clippy::integer_arithmetic)]
 #[inline(always)]
 fn hex_encode(src: &[u8], dst: &mut [u8]) {
-    debug_checked_precondition!(dst.len() == 2 * src.len());
+    debug_checked_precondition!(dst.len() == src.len().saturating_mul(2));
 
     for (byte, out) in src.iter().zip(dst.chunks_mut(2)) {
         let (hi, lo) = byte2hex(*byte);

--- a/common/short-hex-str/src/lib.rs
+++ b/common/short-hex-str/src/lib.rs
@@ -18,11 +18,10 @@ pub struct ShortHexStr([u8; ShortHexStr::LENGTH]);
 #[error("Input bytes are too short")]
 pub struct InputTooShortError;
 
-#[allow(clippy::integer_arithmetic)]
 impl ShortHexStr {
     pub const SOURCE_LENGTH: usize = 4;
+    #[allow(clippy::integer_arithmetic)]
     pub const LENGTH: usize = 2 * ShortHexStr::SOURCE_LENGTH;
-
     /// Format a new `ShortHexStr` from a byte slice.
     ///
     /// Returns `Err(InputTooShortError)` if the input byte slice length is less
@@ -89,9 +88,9 @@ fn byte2hex(byte: u8) -> (u8, u8) {
 }
 
 /// Hex encode a byte slice into the destination byte slice.
-#[allow(clippy::integer_arithmetic)]
 #[inline(always)]
 fn hex_encode(src: &[u8], dst: &mut [u8]) {
+    #[allow(clippy::integer_arithmetic)]
     debug_checked_precondition!(dst.len() == 2 * src.len());
 
     for (byte, out) in src.iter().zip(dst.chunks_mut(2)) {

--- a/common/short-hex-str/src/lib.rs
+++ b/common/short-hex-str/src/lib.rs
@@ -18,9 +18,10 @@ pub struct ShortHexStr([u8; ShortHexStr::LENGTH]);
 #[error("Input bytes are too short")]
 pub struct InputTooShortError;
 
+#[allow(clippy::integer_arithmetic)]
 impl ShortHexStr {
     pub const SOURCE_LENGTH: usize = 4;
-    pub const LENGTH: usize = ShortHexStr::SOURCE_LENGTH.saturating_mul(2);
+    pub const LENGTH: usize = 2 * ShortHexStr::SOURCE_LENGTH;
 
     /// Format a new `ShortHexStr` from a byte slice.
     ///
@@ -88,15 +89,10 @@ fn byte2hex(byte: u8) -> (u8, u8) {
 }
 
 /// Hex encode a byte slice into the destination byte slice.
+#[allow(clippy::integer_arithmetic)]
 #[inline(always)]
 fn hex_encode(src: &[u8], dst: &mut [u8]) {
-    debug_checked_precondition!(
-        dst.len()
-            == src
-                .len()
-                .checked_mul(2)
-                .expect("integer overflow when encoding to hex string")
-    );
+    debug_checked_precondition!(dst.len() == 2 * src.len());
 
     for (byte, out) in src.iter().zip(dst.chunks_mut(2)) {
         let (hi, lo) = byte2hex(*byte);

--- a/common/trace/src/trace.rs
+++ b/common/trace/src/trace.rs
@@ -452,9 +452,10 @@ pub fn is_selected(node: (&'static str, u64)) -> bool {
         match &SAMPLING_CONFIG {
             Some(Sampling(sampling)) => {
                 if let Some(sampling_rate) = sampling.get(node.0) {
-                    node.1.checked_rem(sampling_rate.denominator).expect(
-                        "Sampling rate denominator has a value of 0, resulting in integer overflow",
-                    ) < sampling_rate.nominator
+                    if sampling_rate.denominator == 0 {
+                        return true; // assume no sampling if samplng denominator is 0 and return true
+                    }
+                    node.1.wrapping_rem(sampling_rate.denominator) < sampling_rate.nominator
                 } else {
                     // assume no sampling if sampling category is not found and return true
                     true

--- a/common/trace/src/trace.rs
+++ b/common/trace/src/trace.rs
@@ -293,7 +293,7 @@ pub fn trace_node(entries: &[JsonLogEntry], node_name: &str) {
         if start_time.is_none() {
             start_time = Some(ts);
         }
-        let trace_time = ts - start_time.unwrap();
+        let trace_time = ts.saturating_sub(start_time.unwrap());
         let stage = entry
             .json
             .get("stage")
@@ -452,7 +452,7 @@ pub fn is_selected(node: (&'static str, u64)) -> bool {
         match &SAMPLING_CONFIG {
             Some(Sampling(sampling)) => {
                 if let Some(sampling_rate) = sampling.get(node.0) {
-                    node.1 % sampling_rate.denominator < sampling_rate.nominator
+                    node.1.wrapping_rem(sampling_rate.denominator) < sampling_rate.nominator
                 } else {
                     // assume no sampling if sampling category is not found and return true
                     true

--- a/common/trace/src/trace.rs
+++ b/common/trace/src/trace.rs
@@ -452,7 +452,9 @@ pub fn is_selected(node: (&'static str, u64)) -> bool {
         match &SAMPLING_CONFIG {
             Some(Sampling(sampling)) => {
                 if let Some(sampling_rate) = sampling.get(node.0) {
-                    node.1.wrapping_rem(sampling_rate.denominator) < sampling_rate.nominator
+                    node.1.checked_rem(sampling_rate.denominator).expect(
+                        "Sampling rate denominator has a value of 0, resulting in integer overflow",
+                    ) < sampling_rate.nominator
                 } else {
                     // assume no sampling if sampling category is not found and return true
                     true


### PR DESCRIPTION
## Motivation

Our goal is to prevent lines that can cause integer overflows in TCB and all its dependencies. 

To do so we will enable a clippy lint to detect all such lines that contain operations + - / * % and replace those operations with safer functions such as {overflowing/checked/wrapping/saturating}_{add/sub/mul/div/rem} . 

But before we can enable the lint to be landblocking, we need to fix all occurrences of + - / * % in TCB, or else we risk blocking all diffs once the lint is enabled.

For classes where we want to skip this lint, we can add #![allow(clippy::integer_arithmetic)] in the beggining.

This PR handles the violations of the lint in common/proptest-helpers and common/trace.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

**Yes**

## Test Plan

cargo x lint && cargo xfmt && cargo xclippy --all-targets

## Related PRs

N/A
