### PR TITLE
replacing + - / * operations in libra/consensus/consensus-types with …

### DIFF
--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -18,7 +18,6 @@ pub struct RocksdbConfig {
     pub max_total_wal_size: u64,
 }
 
-#[allow(clippy::integer_arithmetic)]
 impl Default for RocksdbConfig {
     fn default() -> Self {
         Self {
@@ -27,6 +26,7 @@ impl Default for RocksdbConfig {
             max_open_files: 10_000,
             // For now we set the max total WAL size to be 1G. This config can be useful when column
             // families are updated at non-uniform frequencies.
+            #[allow(clippy::integer_arithmetic)] // TODO: remove once clippy lint fixed
             max_total_wal_size: 1u64 << 30,
         }
     }

--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -18,6 +18,7 @@ pub struct RocksdbConfig {
     pub max_total_wal_size: u64,
 }
 
+#[allow(clippy::integer_arithmetic)]
 impl Default for RocksdbConfig {
     fn default() -> Self {
         Self {

--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -267,7 +267,7 @@ impl Block {
             // we can say that too far is 5 minutes in the future
             const TIMEBOUND: u64 = 300_000_000;
             ensure!(
-                self.timestamp_usecs() <= current_ts.as_micros() as u64 + TIMEBOUND,
+                self.timestamp_usecs() <= (current_ts.as_micros() as u64).saturating_add(TIMEBOUND),
                 "Blocks must not be too far in the future"
             );
         }

--- a/consensus/consensus-types/src/block_test_utils.rs
+++ b/consensus/consensus-types/src/block_test_utils.rs
@@ -1,5 +1,6 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::integer_arithmetic)]
 
 use crate::{
     block::Block,

--- a/consensus/consensus-types/src/proposal_msg.rs
+++ b/consensus/consensus-types/src/proposal_msg.rs
@@ -54,7 +54,7 @@ impl ProposalMsg {
             self.sync_info.highest_quorum_cert().certified_block().id(),
             self.proposal.parent_id(),
         );
-        let previous_round = self.proposal.round() - 1;
+        let previous_round = self.proposal.round().saturating_sub(1);
         let highest_certified_round = std::cmp::max(
             self.proposal.quorum_cert().certified_block().round(),
             self.sync_info

--- a/consensus/consensus-types/src/proposal_msg.rs
+++ b/consensus/consensus-types/src/proposal_msg.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{block::Block, common::Author, sync_info::SyncInfo};
-use anyhow::{ensure, format_err, Context, Result};
+use anyhow::{anyhow, ensure, format_err, Context, Result};
 use diem_types::validator_verifier::ValidatorVerifier;
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -54,7 +54,12 @@ impl ProposalMsg {
             self.sync_info.highest_quorum_cert().certified_block().id(),
             self.proposal.parent_id(),
         );
-        let previous_round = self.proposal.round().saturating_sub(1);
+        let previous_round = self
+            .proposal
+            .round()
+            .checked_sub(1)
+            .ok_or_else(|| anyhow!("proposal round overflowed!"))?;
+
         let highest_certified_round = std::cmp::max(
             self.proposal.quorum_cert().certified_block().round(),
             self.sync_info

--- a/consensus/consensus-types/src/quorum_cert.rs
+++ b/consensus/consensus-types/src/quorum_cert.rs
@@ -76,7 +76,10 @@ impl QuorumCert {
         genesis_id: HashValue,
     ) -> QuorumCert {
         let ancestor = BlockInfo::new(
-            ledger_info.epoch().saturating_add(1),
+            ledger_info
+                .epoch()
+                .checked_add(1)
+                .expect("Integer overflow when creating cert for genesis from ledger info"),
             0,
             genesis_id,
             ledger_info.transaction_accumulator_hash(),

--- a/consensus/consensus-types/src/quorum_cert.rs
+++ b/consensus/consensus-types/src/quorum_cert.rs
@@ -76,7 +76,7 @@ impl QuorumCert {
         genesis_id: HashValue,
     ) -> QuorumCert {
         let ancestor = BlockInfo::new(
-            ledger_info.epoch() + 1,
+            ledger_info.epoch().saturating_add(1),
             0,
             genesis_id,
             ledger_info.transaction_accumulator_hash(),


### PR DESCRIPTION
**Motivation**
Our goal is to prevent lines that can cause integer overflows in TCB and all its dependencies.

To do so we will enable a clippy lint to detect all such lines that contain operations + - / * % and replace those operations with safer functions such as {overflowing/checked/wrapping/saturating}_{add/sub/mul/div/rem} .

But before we can enable the lint to be landblocking, we need to fix all occurrences of + - / * % in TCB, or else we risk blocking all diffs once the lint is enabled.

For classes where we want to skip this lint, we can add #![allow(clippy::integer_arithmetic)] in the beggining.

This PR handles the violations of the lint in consensus/consensus-types  and config/src/config

**Have you read the Contributing Guidelines on pull requests?**
Yes

**Test Plan**
cargo x lint && cargo xfmt && cargo xclippy --all-targets

**Related PRs**
N/A