### PR TITLE
[move CLI] Add "create" command to create test scaffold

### DIFF
--- a/language/tools/move-cli/README.md
+++ b/language/tools/move-cli/README.md
@@ -325,6 +325,19 @@ Command `run scripts/debug_script.move --signers 0xf --mode bare`:
 ...
 ```
 
+The scaffolding for a new test that follows the above structure for tests can be created
+by passing the `--create` flag to `move test` along with the name of the test that you wish to create:
+
+```
+$ move test new_test_name --create
+$ tree new_test_name
+new_test_name
+├── args.txt
+└── src
+    ├── modules
+    └── scripts
+```
+
 ### Testing with code coverage tracking
 
 Code coverage has been an important metric in software testing. In Move CLI, we

--- a/language/tools/move-cli/src/main.rs
+++ b/language/tools/move-cli/src/main.rs
@@ -142,6 +142,9 @@ enum Command {
         /// By default, coverage will not be tracked nor shown.
         #[structopt(long = "track-cov")]
         track_cov: bool,
+        /// Create a new test directory scaffold with the specified <path>
+        #[structopt(long = "create")]
+        create: bool,
     },
     /// View Move resources, events files, and modules stored on disk
     #[structopt(name = "view")]
@@ -839,7 +842,16 @@ fn main() -> Result<()> {
                 move_args.verbose,
             )
         }
-        Command::Test { path, track_cov } => test::run_all(
+        Command::Test {
+            path,
+            track_cov: _,
+            create: true,
+        } => test::create_test_scaffold(path),
+        Command::Test {
+            path,
+            track_cov,
+            create: false,
+        } => test::run_all(
             path,
             &std::env::current_exe()?.to_string_lossy(),
             *track_cov,


### PR DESCRIPTION
This PR adds the `create` command to the Move CLI test sub-command to create a test scaffold as described in the README:
```
move-test 0.1.0
Run expected value tests using the given batch file

USAGE:
    move test [FLAGS] [OPTIONS] <path>

FLAGS:
        --create       Create a new test directory scaffold with the specified <path>
    -h, --help         Prints help information
        --track-cov    Show coverage information after tests are done. By default, coverage will not be tracked nor
                       shown
    -V, --version      Prints version information
    -v                 Print additional diagnostics

OPTIONS:
        --build-dir <build-dir>        Directory storing Move resources, events, and module bytecodes produced by script
                                       execution [default: build]
        --mode <mode>                  Dependency inclusion mode [default: stdlib]
        --storage-dir <storage-dir>    Directory storing Move resources, events, and module bytecodes produced by script
                                       execution [default: storage]

ARGS:
    <path>    a directory path in which all the tests will be executed
```

```
> move test test_dir --create
> tree test_dir
test_dir
├── args.txt
└── src
    ├── modules
    └── scripts
```