### PR TITLE
network: properly handle http_proxy, https_proxy, and no_proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4384,6 +4384,7 @@ dependencies = [
  "futures 0.3.8",
  "memsocket",
  "pin-project 1.0.2",
+ "proxy",
  "serde",
  "tokio",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1574,6 +1574,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.13.0",
  "diem-workspace-hack",
+ "proxy",
  "serde",
  "serde_json",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1997,6 +1997,7 @@ dependencies = [
  "futures 0.3.8",
  "hex",
  "proptest",
+ "proxy",
  "serde",
  "serde_json",
  "storage-interface",
@@ -5144,6 +5145,14 @@ checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
 dependencies = [
  "bytes",
  "prost",
+]
+
+[[package]]
+name = "proxy"
+version = "0.1.0"
+dependencies = [
+ "diem-workspace-hack",
+ "ipnet",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "common/nibble",
     "common/num-variants",
     "common/proptest-helpers",
+    "common/proxy",
     "common/retrier",
     "common/short-hex-str",
     "common/subscription-service",

--- a/common/proxy/Cargo.toml
+++ b/common/proxy/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "proxy"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+description = "Diem proxy"
+repository = "https://github.com/diem/diem"
+homepage = "https://diem.com"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+ipnet = "2.3"
+
+diem-workspace-hack = { path = "../workspace-hack" }

--- a/common/proxy/src/lib.rs
+++ b/common/proxy/src/lib.rs
@@ -1,0 +1,152 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use ipnet::IpNet;
+use std::{env, net::IpAddr};
+
+/// Represents a possible matching entry for an IP address
+#[derive(Clone, Debug)]
+enum Ip {
+    Address(IpAddr),
+    Network(IpNet),
+}
+
+/// A wrapper around a list of IP cidr blocks or addresses with a [IpMatcher::contains] method for
+/// checking if an IP address is contained within the matcher
+#[derive(Clone, Debug, Default)]
+struct IpMatcher(Vec<Ip>);
+
+/// A wrapper around a list of domains with a [DomainMatcher::contains] method for checking if a
+/// domain is contained within the matcher
+#[derive(Clone, Debug, Default)]
+struct DomainMatcher(Vec<String>);
+
+/// A configuration for filtering out requests that shouldn't be proxied
+#[derive(Clone, Debug, Default)]
+struct NoProxy {
+    ips: IpMatcher,
+    domains: DomainMatcher,
+}
+
+pub struct Proxy {
+    http_proxy: Option<String>,
+    https_proxy: Option<String>,
+    no_proxy: Option<NoProxy>,
+}
+
+impl Proxy {
+    pub fn new() -> Self {
+        let http_proxy = env::var("http_proxy")
+            .or_else(|_| env::var("HTTP_PROXY"))
+            .ok();
+        let https_proxy = env::var("https_proxy")
+            .or_else(|_| env::var("HTTPS_PROXY"))
+            .ok();
+        let no_proxy = NoProxy::new();
+
+        Self {
+            http_proxy,
+            https_proxy,
+            no_proxy,
+        }
+    }
+
+    pub fn http(&self, host: &str) -> Option<&str> {
+        if let Some(no_proxy) = &self.no_proxy {
+            if no_proxy.contains(host) {
+                return None;
+            }
+        }
+        self.http_proxy.as_deref()
+    }
+
+    pub fn https(&self, host: &str) -> Option<&str> {
+        if let Some(no_proxy) = &self.no_proxy {
+            if no_proxy.contains(host) {
+                return None;
+            }
+        }
+        self.https_proxy.as_deref()
+    }
+}
+
+impl NoProxy {
+    /// Returns a new no proxy configration if the no_proxy/NO_PROXY environment variable is set.
+    /// Returns None otherwise
+    fn new() -> Option<Self> {
+        let raw = env::var("no_proxy")
+            .or_else(|_| env::var("NO_PROXY"))
+            .unwrap_or_default();
+        if raw.is_empty() {
+            return None;
+        }
+        let mut ips = Vec::new();
+        let mut domains = Vec::new();
+        let parts = raw.split(',');
+        for part in parts {
+            match part.parse::<IpNet>() {
+                // If we can parse an IP net or address, then use it, otherwise, assume it is a domain
+                Ok(ip) => ips.push(Ip::Network(ip)),
+                Err(_) => match part.parse::<IpAddr>() {
+                    Ok(addr) => ips.push(Ip::Address(addr)),
+                    Err(_) => domains.push(part.to_owned()),
+                },
+            }
+        }
+        Some(NoProxy {
+            ips: IpMatcher(ips),
+            domains: DomainMatcher(domains),
+        })
+    }
+
+    fn contains(&self, host: &str) -> bool {
+        // According to RFC3986, raw IPv6 hosts will be wrapped in []. So we need to strip those off
+        // the end in order to parse correctly
+        let host = if host.starts_with('[') {
+            let x: &[_] = &['[', ']'];
+            host.trim_matches(x)
+        } else {
+            host
+        };
+        match host.parse::<IpAddr>() {
+            // If we can parse an IP addr, then use it, otherwise, assume it is a domain
+            Ok(ip) => self.ips.contains(ip),
+            Err(_) => self.domains.contains(host),
+        }
+    }
+}
+
+impl IpMatcher {
+    fn contains(&self, addr: IpAddr) -> bool {
+        for ip in self.0.iter() {
+            match ip {
+                Ip::Address(address) => {
+                    if &addr == address {
+                        return true;
+                    }
+                }
+                Ip::Network(net) => {
+                    if net.contains(&addr) {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    }
+}
+
+impl DomainMatcher {
+    fn contains(&self, domain: &str) -> bool {
+        for d in self.0.iter() {
+            // First check for a "wildcard" domain match. A single "." will match anything.
+            // Otherwise, check that the domains are equal
+            if (d.starts_with('.') && domain.ends_with(d.get(1..).unwrap_or_default()))
+                || d == domain
+            {
+                return true;
+            }
+        }
+        false
+    }
+}

--- a/network/netcore/Cargo.toml
+++ b/network/netcore/Cargo.toml
@@ -21,6 +21,7 @@ diem-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" 
 diem-network-address = { path = "../network-address", version = "0.1.0" }
 diem-types = { path = "../../types" }
 memsocket = { path = "../memsocket", version = "0.1.0", optional = true }
+proxy = { path = "../../common/proxy" }
 
 [dev-dependencies]
 diem-logger = { path = "../../common/logger", version = "0.1.0" }

--- a/network/netcore/Cargo.toml
+++ b/network/netcore/Cargo.toml
@@ -24,6 +24,7 @@ memsocket = { path = "../memsocket", version = "0.1.0", optional = true }
 
 [dev-dependencies]
 diem-logger = { path = "../../common/logger", version = "0.1.0" }
+diem-network-address = { path = "../network-address", version = "0.1.0", features = ["fuzzing"] }
 memsocket = { path = "../memsocket", version = "0.1.0" }
 
 [features]

--- a/secure/json-rpc/Cargo.toml
+++ b/secure/json-rpc/Cargo.toml
@@ -22,6 +22,7 @@ diem-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 diem-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0", optional = true }
 diem-types = { path = "../../types", version = "0.1.0" }
 diem-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
+proxy = { path = "../../common/proxy" }
 
 [dev-dependencies]
 anyhow = "1.0.34"

--- a/secure/json-rpc/src/lib.rs
+++ b/secure/json-rpc/src/lib.rs
@@ -517,7 +517,7 @@ mod test {
     /// with the given database to handle each JSON RPC request. If mock_validator is set to true,
     /// the server is also given a mock vm validator to validate any submitted transactions.
     fn create_client_and_server(db: MockDiemDB, mock_validator: bool) -> (JsonRpcClient, Runtime) {
-        let address = "0.0.0.0";
+        let address = "127.0.0.1";
         let port = utils::get_available_port();
         let host = format!("{}:{}", address, port);
         let (mp_sender, mut mp_events) = channel(1024);

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -417,7 +417,7 @@ fn setup_secure_storage(
 // that serves the JSON RPC requests. The server communicates with the given database reader/writer
 // to handle each JSON RPC request.
 fn setup_diem_interface_and_json_server(db_rw: DbReaderWriter) -> (JsonRpcDiemInterface, Runtime) {
-    let address = "0.0.0.0";
+    let address = "127.0.0.1";
     let port = utils::get_available_port();
     let host = format!("{}:{}", address, port);
 

--- a/secure/storage/github/Cargo.toml
+++ b/secure/storage/github/Cargo.toml
@@ -16,6 +16,7 @@ thiserror = "1.0.22"
 ureq = { version = "1.5.4", features = ["json", "native-tls"], default-features = false }
 
 diem-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
+proxy = { path = "../../../common/proxy" }
 
 [dev-dependencies]
 base64 = "0.13.0"

--- a/secure/storage/github/src/lib.rs
+++ b/secure/storage/github/src/lib.rs
@@ -3,9 +3,9 @@
 
 #![forbid(unsafe_code)]
 
+use proxy::Proxy;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::env;
 use thiserror::Error;
 
 /// Request timeout for github operations
@@ -178,15 +178,14 @@ impl Client {
             .set("Authorization", &format!("token {}", self.token))
             .set(ACCEPT_HEADER, ACCEPT_VALUE)
             .timeout_connect(TIMEOUT);
-        match env::var("https_proxy") {
-            Ok(proxy) => request
-                .set_proxy(
-                    ureq::Proxy::new(proxy)
-                        .expect("Unable to parse https_proxy environment variable"),
-                )
-                .build(),
-            Err(_e) => request,
+
+        let proxy = Proxy::new();
+        let host = request.get_host().expect("unable to get the host");
+        let proxy_url = proxy.https(&host);
+        if let Some(proxy_url) = proxy_url {
+            request.set_proxy(ureq::Proxy::new(proxy_url).expect("Unable to parse proxy_url"));
         }
+        request
     }
 
     /// Get can read files or directories, this makes it easier to use


### PR DESCRIPTION
This PR adds proper handling of `http_proxy`, `https_proxy` and `no_proxy` throughout diem. Prior we weren't respecting the `no_proxy` env var resulting in requests to localhost being proxied causing networking related tests to fail.