### PR TITLE
[move cli] doctor command for detecting inconsistencies in storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4023,6 +4023,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
+ "bytecode-verifier",
  "compiled-stdlib",
  "datatest-stable",
  "diem-state-view",
@@ -4044,6 +4045,7 @@ dependencies = [
  "structopt 0.3.21",
  "vm",
  "vm-genesis",
+ "walkdir",
 ]
 
 [[package]]

--- a/language/tools/move-cli/Cargo.toml
+++ b/language/tools/move-cli/Cargo.toml
@@ -16,6 +16,8 @@ include_dir = { version = "0.6.0", features = ["search"] }
 once_cell = "1.4.1"
 structopt = "0.3.21"
 
+bcs = "0.1.2"
+bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
 compiled-stdlib = { path = "../../stdlib/compiled", version = "0.1.0" }
 disassembler = { path = "../disassembler", version = "0.1.0" }
 errmapgen = { path = "../../move-prover/errmapgen", version = "0.1.0" }
@@ -32,7 +34,7 @@ resource-viewer = { path = "../resource-viewer", version = "0.1.0" }
 stdlib = { path = "../../stdlib", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0" }
 vm-genesis = { path = "../vm-genesis", version = "0.1.0" }
-bcs = "0.1.2"
+walkdir = "2.3.1"
 
 [dev-dependencies]
 datatest-stable = { path = "../../../common/datatest-stable", version = "0.1.0" }

--- a/language/tools/move-cli/tests/testsuite/data_breaking_change/args.exp
+++ b/language/tools/move-cli/tests/testsuite/data_breaking_change/args.exp
@@ -2,4 +2,8 @@ Command `publish src/modules/`:
 Command `publish M.move`:
 Breaking change detected--publishing aborted. Re-run with --ignore-breaking-changes to publish anyway.
 Error: Layout API for structs of module 00000000000000000000000000000002::M has changed. Need to do a data migration of published structs
+Command `run src/scripts/publish.move --signers 0xA`:
+Command `doctor`:
 Command `publish --ignore-breaking-changes M.move`:
+Command `doctor`:
+Error: Failed to deserialize resource "0x00000000000000000000000000000002::M::R.bcs" stored under address "0x0000000000000000000000000000000A"

--- a/language/tools/move-cli/tests/testsuite/data_breaking_change/args.txt
+++ b/language/tools/move-cli/tests/testsuite/data_breaking_change/args.txt
@@ -1,3 +1,6 @@
 publish src/modules/
 publish M.move
+run src/scripts/publish.move --signers 0xA
+doctor
 publish --ignore-breaking-changes M.move
+doctor

--- a/language/tools/move-cli/tests/testsuite/data_breaking_change/src/modules/M.move
+++ b/language/tools/move-cli/tests/testsuite/data_breaking_change/src/modules/M.move
@@ -1,5 +1,9 @@
 address 0x2 {
 module M {
     resource struct R { f: u64 }
+
+    public fun publish(account: &signer) {
+        move_to(account, R { f: 10 })
+    }
 }
 }

--- a/language/tools/move-cli/tests/testsuite/data_breaking_change/src/scripts/publish.move
+++ b/language/tools/move-cli/tests/testsuite/data_breaking_change/src/scripts/publish.move
@@ -1,0 +1,6 @@
+script {
+use 0x2::M;
+fun publish(account: &signer) {
+    M::publish(account)
+}
+}

--- a/language/tools/move-cli/tests/testsuite/linking_breaking_change/args.exp
+++ b/language/tools/move-cli/tests/testsuite/linking_breaking_change/args.exp
@@ -2,4 +2,7 @@ Command `publish src/modules/`:
 Command `publish M.move`:
 Breaking change detected--publishing aborted. Re-run with --ignore-breaking-changes to publish anyway.
 Error: Linking API for structs/functions of module 00000000000000000000000000000002::M has changed. Need to redeploy all dependent modules.
+Command `doctor`:
 Command `publish --ignore-breaking-changes M.move`:
+Command `doctor`:
+Error: Failed to link module ModuleId { address: 00000000000000000000000000000002, name: Identifier("M2") } against its dependencies

--- a/language/tools/move-cli/tests/testsuite/linking_breaking_change/args.txt
+++ b/language/tools/move-cli/tests/testsuite/linking_breaking_change/args.txt
@@ -1,3 +1,5 @@
 publish src/modules/
 publish M.move
+doctor
 publish --ignore-breaking-changes M.move
+doctor

--- a/language/tools/move-cli/tests/testsuite/linking_breaking_change/src/modules/M2.move
+++ b/language/tools/move-cli/tests/testsuite/linking_breaking_change/src/modules/M2.move
@@ -1,0 +1,10 @@
+address 0x2 {
+module M2 {
+  use 0x2::M;
+
+  public fun h() {
+      M::f();
+      M::g();
+  }
+}
+}


### PR DESCRIPTION
This command does a bunch of sanity checks to ensure that the storage directory is well-formed. For now:
- All modules verify
- All modules link
- All resources deserialize w.r.t the current version of their declaring module

It does this in the obvious way: iterating through the global storage, collecting each module/resource, and doing the check.
This is useful for detecting breaking changes (both code and data layout) after-the-fact, as well as bugs in the CLI.

I was motivated to create this check when I noticed a bug where `move publish` sometimes publishes a module `M` without publishing library modules.
If you run `move doctor` on such a state, it would catch the issue. I am planning to add `move doctor` to a bunch of the publish tests once I fix this bug.
It will also be useful for testing the `--ignore-breaking-changes` flag in https://github.com/diem/diem/pull/6753.