### PR TITLE
[move-cli] allow move doctor to pickup the library dependencies

### DIFF
--- a/language/tools/move-cli/src/lib.rs
+++ b/language/tools/move-cli/src/lib.rs
@@ -159,6 +159,11 @@ impl OnDiskStateView {
         }
     }
 
+    /// Check if a module at `addr`/`module_id` exists
+    pub fn has_module(&self, module_id: &ModuleId) -> bool {
+        self.get_module_path(module_id).exists()
+    }
+
     /// Deserialize and return the module stored on-disk at `addr`/`module_id`
     pub fn get_compiled_module(&self, module_id: &ModuleId) -> Result<CompiledModule> {
         CompiledModule::deserialize(

--- a/language/tools/move-cli/tests/testsuite/doctor_with_stdlib/args.exp
+++ b/language/tools/move-cli/tests/testsuite/doctor_with_stdlib/args.exp
@@ -1,0 +1,2 @@
+Command `publish src/modules`:
+Command `doctor`:

--- a/language/tools/move-cli/tests/testsuite/doctor_with_stdlib/args.txt
+++ b/language/tools/move-cli/tests/testsuite/doctor_with_stdlib/args.txt
@@ -1,0 +1,2 @@
+publish src/modules
+doctor

--- a/language/tools/move-cli/tests/testsuite/doctor_with_stdlib/src/modules/M.move
+++ b/language/tools/move-cli/tests/testsuite/doctor_with_stdlib/src/modules/M.move
@@ -1,0 +1,9 @@
+address 0x2 {
+module M {
+    use 0x1::Debug;
+
+    fun f() {
+        Debug::print(&7);
+    }
+}
+}


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Currently the `move doctor` command is not aware of the library dependencies when checking modules. This PR fills the information.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

A new test case (credit to Sam) is added.
