### PR TITLE
Remove NonZeroUsize from most places in the code

### DIFF
--- a/common/channel/many-keys-stress-test/src/main.rs
+++ b/common/channel/many-keys-stress-test/src/main.rs
@@ -5,7 +5,6 @@ use channel::{diem_channel, message_queues::QueueStyle};
 use futures::{executor::block_on, stream::StreamExt};
 use std::{
     io::{Cursor, Write},
-    num::NonZeroUsize,
     sync::atomic::{AtomicBool, AtomicUsize, Ordering},
     thread,
     time::Duration,
@@ -46,7 +45,7 @@ pub fn run(args: Args) {
 
     let (mut sender, mut receiver) = diem_channel::new::<[u8; KEY_SIZE_BYTES], [u8; MSG_SIZE_BYTES]>(
         QueueStyle::FIFO,
-        NonZeroUsize::new(args.max_queue_size).unwrap(),
+        args.max_queue_size,
         None,
     );
 

--- a/common/channel/src/diem_channel_test.rs
+++ b/common/channel/src/diem_channel_test.rs
@@ -9,13 +9,12 @@ use futures::{
     future::{join, FutureExt},
     stream::{FusedStream, StreamExt},
 };
-use std::{num::NonZeroUsize, time::Duration};
+use std::time::Duration;
 use tokio::{runtime::Runtime, time::delay_for};
 
 #[test]
 fn test_send_recv_order() {
-    let (mut sender, mut receiver) =
-        diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(10).unwrap(), None);
+    let (mut sender, mut receiver) = diem_channel::new(QueueStyle::FIFO, 10, None);
     sender.push(0, 0).unwrap();
     sender.push(0, 1).unwrap();
     sender.push(0, 2).unwrap();
@@ -34,16 +33,14 @@ fn test_send_recv_order() {
 
 #[test]
 fn test_empty() {
-    let (_, mut receiver) =
-        diem_channel::new::<u8, u8>(QueueStyle::FIFO, NonZeroUsize::new(10).unwrap(), None);
+    let (_, mut receiver) = diem_channel::new::<u8, u8>(QueueStyle::FIFO, 10, None);
     // Ensures that there is no other value which is ready
     assert_eq!(receiver.select_next_some().now_or_never(), None);
 }
 
 #[test]
 fn test_waker() {
-    let (mut sender, mut receiver) =
-        diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(10).unwrap(), None);
+    let (mut sender, mut receiver) = diem_channel::new(QueueStyle::FIFO, 10, None);
     // Ensures that there is no other value which is ready
     assert_eq!(receiver.select_next_some().now_or_never(), None);
     let f1 = async move {
@@ -65,8 +62,7 @@ fn test_waker() {
 
 #[test]
 fn test_sender_clone() {
-    let (mut sender, mut receiver) =
-        diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(5).unwrap(), None);
+    let (mut sender, mut receiver) = diem_channel::new(QueueStyle::FIFO, 5, None);
     // Ensures that there is no other value which is ready
     assert_eq!(receiver.select_next_some().now_or_never(), None);
 
@@ -96,8 +92,7 @@ fn test_multiple_validators_helper(
     num_messages_per_validator: usize,
     expected_last_message: usize,
 ) {
-    let (mut sender, mut receiver) =
-        diem_channel::new(queue_style, NonZeroUsize::new(1).unwrap(), None);
+    let (mut sender, mut receiver) = diem_channel::new(queue_style, 1, None);
     let num_validators = 128;
     for message in 0..num_messages_per_validator {
         for validator in 0..num_validators {
@@ -132,8 +127,7 @@ fn test_multiple_validators_lifo() {
 
 #[test]
 fn test_feedback_on_drop() {
-    let (mut sender, mut receiver) =
-        diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(3).unwrap(), None);
+    let (mut sender, mut receiver) = diem_channel::new(QueueStyle::FIFO, 3, None);
     sender.push(0, 'a').unwrap();
     sender.push(0, 'b').unwrap();
     let (c_status_tx, c_status_rx) = oneshot::channel();

--- a/common/channel/src/message_queues_test.rs
+++ b/common/channel/src/message_queues_test.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::message_queues::{PerKeyQueue, QueueStyle};
+use diem_infallible::NonZeroUsize;
 use diem_types::account_address::AccountAddress;
-use std::num::NonZeroUsize;
 
 /// This represents a proposal message from a validator
 #[derive(Debug, PartialEq)]
@@ -19,7 +19,7 @@ struct VoteMsg {
 
 #[test]
 fn test_fifo() {
-    let mut q = PerKeyQueue::new(QueueStyle::FIFO, NonZeroUsize::new(3).unwrap(), None);
+    let mut q = PerKeyQueue::new(QueueStyle::FIFO, NonZeroUsize!(3), None);
     let validator = AccountAddress::new([0u8; AccountAddress::LENGTH]);
 
     // Test order
@@ -78,7 +78,7 @@ fn test_fifo() {
 
 #[test]
 fn test_lifo() {
-    let mut q = PerKeyQueue::new(QueueStyle::LIFO, NonZeroUsize::new(3).unwrap(), None);
+    let mut q = PerKeyQueue::new(QueueStyle::LIFO, NonZeroUsize!(3), None);
     let validator = AccountAddress::new([0u8; AccountAddress::LENGTH]);
 
     // Test order
@@ -137,7 +137,7 @@ fn test_lifo() {
 
 #[test]
 fn test_klast() {
-    let mut q = PerKeyQueue::new(QueueStyle::KLAST, NonZeroUsize::new(3).unwrap(), None);
+    let mut q = PerKeyQueue::new(QueueStyle::KLAST, NonZeroUsize!(3), None);
     let validator = AccountAddress::new([0u8; AccountAddress::LENGTH]);
 
     // Test order
@@ -196,7 +196,7 @@ fn test_klast() {
 
 #[test]
 fn test_fifo_round_robin() {
-    let mut q = PerKeyQueue::new(QueueStyle::FIFO, NonZeroUsize::new(3).unwrap(), None);
+    let mut q = PerKeyQueue::new(QueueStyle::FIFO, NonZeroUsize!(3), None);
     let validator1 = AccountAddress::new([0u8; AccountAddress::LENGTH]);
     let validator2 = AccountAddress::new([1u8; AccountAddress::LENGTH]);
     let validator3 = AccountAddress::new([2u8; AccountAddress::LENGTH]);
@@ -267,7 +267,7 @@ fn test_fifo_round_robin() {
 
 #[test]
 fn test_lifo_round_robin() {
-    let mut q = PerKeyQueue::new(QueueStyle::LIFO, NonZeroUsize::new(3).unwrap(), None);
+    let mut q = PerKeyQueue::new(QueueStyle::LIFO, NonZeroUsize!(3), None);
     let validator1 = AccountAddress::new([0u8; AccountAddress::LENGTH]);
     let validator2 = AccountAddress::new([1u8; AccountAddress::LENGTH]);
     let validator3 = AccountAddress::new([2u8; AccountAddress::LENGTH]);
@@ -338,7 +338,7 @@ fn test_lifo_round_robin() {
 
 #[test]
 fn test_klast_round_robin() {
-    let mut q = PerKeyQueue::new(QueueStyle::KLAST, NonZeroUsize::new(3).unwrap(), None);
+    let mut q = PerKeyQueue::new(QueueStyle::KLAST, NonZeroUsize!(3), None);
     let validator1 = AccountAddress::new([0u8; AccountAddress::LENGTH]);
     let validator2 = AccountAddress::new([1u8; AccountAddress::LENGTH]);
     let validator3 = AccountAddress::new([2u8; AccountAddress::LENGTH]);
@@ -409,7 +409,7 @@ fn test_klast_round_robin() {
 
 #[test]
 fn test_message_queue_clear() {
-    let mut q = PerKeyQueue::new(QueueStyle::LIFO, NonZeroUsize::new(3).unwrap(), None);
+    let mut q = PerKeyQueue::new(QueueStyle::LIFO, NonZeroUsize!(3), None);
     let validator = AccountAddress::new([0u8; AccountAddress::LENGTH]);
 
     q.push(

--- a/common/infallible/src/lib.rs
+++ b/common/infallible/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod mutex;
+mod nonzero;
 mod rwlock;
 mod time;
 

--- a/common/infallible/src/nonzero.rs
+++ b/common/infallible/src/nonzero.rs
@@ -1,0 +1,35 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/// A wrapper around `std::num::NonZeroUsize` to no longer worry about `unwrap()`
+#[macro_export]
+macro_rules! NonZeroUsize {
+    ($num:expr) => {
+        NonZeroUsize!($num, "Must be non-zero")
+    };
+    ($num:expr, $message:literal) => {
+        std::num::NonZeroUsize::new($num).expect($message)
+    };
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn test_nonzero() {
+        assert_eq!(1, NonZeroUsize!(1).get());
+        assert_eq!(std::usize::MAX, NonZeroUsize!(std::usize::MAX).get());
+    }
+
+    #[test]
+    #[should_panic(expected = "Must be non-zero")]
+    fn test_zero() {
+        NonZeroUsize!(0);
+    }
+
+    #[test]
+    #[should_panic(expected = "Custom message")]
+    fn test_zero_custom_message() {
+        NonZeroUsize!(0, "Custom message");
+    }
+}

--- a/common/subscription-service/src/lib.rs
+++ b/common/subscription-service/src/lib.rs
@@ -14,7 +14,7 @@ use diem_types::{
     event::EventKey,
     on_chain_config::{ConfigID, OnChainConfigPayload},
 };
-use std::{collections::HashSet, num::NonZeroUsize};
+use std::collections::HashSet;
 
 pub struct SubscriptionService<T, U> {
     pub name: String,
@@ -26,8 +26,7 @@ impl<T: Clone, U> SubscriptionService<T, U> {
     /// Constructs an subscription object for `items`
     /// Returns the subscription object, and the receiving end of a channel that subscription will be sent to
     pub fn subscribe(name: &str, items: T) -> (Self, Receiver<(), U>) {
-        let (sender, receiver) =
-            diem_channel::new(QueueStyle::LIFO, NonZeroUsize::new(1).unwrap(), None);
+        let (sender, receiver) = diem_channel::new(QueueStyle::LIFO, 1, None);
         (
             Self {
                 name: name.to_string(),

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -25,7 +25,6 @@ use futures::{channel::oneshot, stream::select, SinkExt, Stream, StreamExt};
 use network::protocols::{network::Event, rpc::error::RpcError};
 use std::{
     mem::{discriminant, Discriminant},
-    num::NonZeroUsize,
     time::Duration,
 };
 
@@ -210,14 +209,11 @@ impl NetworkTask {
         network_events: ConsensusNetworkEvents,
         self_receiver: channel::Receiver<Event<ConsensusMsg>>,
     ) -> (NetworkTask, NetworkReceivers) {
-        let (consensus_messages_tx, consensus_messages) = diem_channel::new(
-            QueueStyle::LIFO,
-            NonZeroUsize::new(1).unwrap(),
-            Some(&counters::CONSENSUS_CHANNEL_MSGS),
-        );
+        let (consensus_messages_tx, consensus_messages) =
+            diem_channel::new(QueueStyle::LIFO, 1, Some(&counters::CONSENSUS_CHANNEL_MSGS));
         let (block_retrieval_tx, block_retrieval) = diem_channel::new(
             QueueStyle::LIFO,
-            NonZeroUsize::new(1).unwrap(),
+            1,
             Some(&counters::BLOCK_RETRIEVAL_CHANNEL_MSGS),
         );
         let all_events = Box::new(select(network_events, self_receiver));

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -32,7 +32,6 @@ use network::{
 };
 use std::{
     collections::{HashMap, HashSet},
-    num::NonZeroUsize,
     sync::Arc,
     time::Duration,
 };
@@ -534,12 +533,9 @@ mod tests {
         let peers: Vec<_> = signers.iter().map(|signer| signer.author()).collect();
 
         for (peer_id, peer) in peers.iter().enumerate() {
-            let (network_reqs_tx, network_reqs_rx) =
-                diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
-            let (connection_reqs_tx, _) =
-                diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
-            let (consensus_tx, consensus_rx) =
-                diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
+            let (network_reqs_tx, network_reqs_rx) = diem_channel::new(QueueStyle::FIFO, 8, None);
+            let (connection_reqs_tx, _) = diem_channel::new(QueueStyle::FIFO, 8, None);
+            let (consensus_tx, consensus_rx) = diem_channel::new(QueueStyle::FIFO, 8, None);
             let (_conn_mgr_reqs_tx, conn_mgr_reqs_rx) = channel::new_test(8);
             let (_, conn_status_rx) = conn_notifs_channel::new();
             let network_sender = ConsensusNetworkSender::new(
@@ -623,12 +619,9 @@ mod tests {
         let peers: Vec<_> = signers.iter().map(|signer| signer.author()).collect();
 
         for (peer_id, peer) in peers.iter().enumerate() {
-            let (network_reqs_tx, network_reqs_rx) =
-                diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
-            let (connection_reqs_tx, _) =
-                diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
-            let (consensus_tx, consensus_rx) =
-                diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
+            let (network_reqs_tx, network_reqs_rx) = diem_channel::new(QueueStyle::FIFO, 8, None);
+            let (connection_reqs_tx, _) = diem_channel::new(QueueStyle::FIFO, 8, None);
+            let (consensus_tx, consensus_rx) = diem_channel::new(QueueStyle::FIFO, 8, None);
             let (_conn_mgr_reqs_tx, conn_mgr_reqs_rx) = channel::new_test(8);
             let (_, conn_status_rx) = conn_notifs_channel::new();
             let network_sender = ConsensusNetworkSender::new(
@@ -707,9 +700,9 @@ mod tests {
     #[test]
     fn test_bad_message() {
         let (mut peer_mgr_notifs_tx, peer_mgr_notifs_rx) =
-            diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
+            diem_channel::new(QueueStyle::FIFO, 8, None);
         let (connection_notifs_tx, connection_notifs_rx) =
-            diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
+            diem_channel::new(QueueStyle::FIFO, 8, None);
         let consensus_network_events =
             ConsensusNetworkEvents::new(peer_mgr_notifs_rx, connection_notifs_rx);
         let (self_sender, self_receiver) = channel::new_test(8);

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -34,7 +34,7 @@ use network::{
 };
 use once_cell::sync::Lazy;
 use safety_rules::{test_utils, SafetyRules, TSafetyRules};
-use std::{collections::BTreeMap, num::NonZeroUsize, sync::Arc, time::Duration};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 use tokio::runtime::Runtime;
 
 // This generates a proposal for round 1
@@ -110,10 +110,8 @@ fn create_node_for_fuzzing() -> RoundManager {
     safety_rules.initialize(&proof).unwrap();
 
     // TODO: mock channels
-    let (network_reqs_tx, _network_reqs_rx) =
-        diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
-    let (connection_reqs_tx, _) =
-        diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
+    let (network_reqs_tx, _network_reqs_rx) = diem_channel::new(QueueStyle::FIFO, 8, None);
+    let (connection_reqs_tx, _) = diem_channel::new(QueueStyle::FIFO, 8, None);
     let network_sender = ConsensusNetworkSender::new(
         PeerManagerRequestSender::new(network_reqs_tx),
         ConnectionRequestSender::new(connection_reqs_tx),

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -55,7 +55,7 @@ use network::{
     protocols::network::{Event, NewNetworkEvents, NewNetworkSender},
 };
 use safety_rules::{PersistentSafetyStorage, SafetyRulesManager};
-use std::{num::NonZeroUsize, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 use tokio::runtime::Handle;
 
 /// Auxiliary struct that is setting up node environment for the test.
@@ -138,12 +138,9 @@ impl NodeSetup {
             verifier: storage.get_validator_set().into(),
         };
         let validators = epoch_state.verifier.clone();
-        let (network_reqs_tx, network_reqs_rx) =
-            diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
-        let (connection_reqs_tx, _) =
-            diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
-        let (consensus_tx, consensus_rx) =
-            diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
+        let (network_reqs_tx, network_reqs_rx) = diem_channel::new(QueueStyle::FIFO, 8, None);
+        let (connection_reqs_tx, _) = diem_channel::new(QueueStyle::FIFO, 8, None);
+        let (consensus_tx, consensus_rx) = diem_channel::new(QueueStyle::FIFO, 8, None);
         let (_conn_mgr_reqs_tx, conn_mgr_reqs_rx) = channel::new_test(8);
         let (_, conn_status_rx) = conn_notifs_channel::new();
         let network_sender = ConsensusNetworkSender::new(

--- a/consensus/src/twins/twins_node.rs
+++ b/consensus/src/twins/twins_node.rs
@@ -31,7 +31,7 @@ use network::{
     peer_manager::{conn_notifs_channel, ConnectionRequestSender, PeerManagerRequestSender},
     protocols::network::{NewNetworkEvents, NewNetworkSender},
 };
-use std::{collections::HashMap, num::NonZeroUsize, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 use tokio::runtime::{Builder, Runtime};
 
 /// Auxiliary struct that is preparing SMR for the test
@@ -55,12 +55,9 @@ impl SMRNode {
         storage: Arc<MockStorage>,
         twin_id: TwinId,
     ) -> Self {
-        let (network_reqs_tx, network_reqs_rx) =
-            diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
-        let (connection_reqs_tx, _) =
-            diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
-        let (consensus_tx, consensus_rx) =
-            diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
+        let (network_reqs_tx, network_reqs_rx) = diem_channel::new(QueueStyle::FIFO, 8, None);
+        let (connection_reqs_tx, _) = diem_channel::new(QueueStyle::FIFO, 8, None);
+        let (consensus_tx, consensus_rx) = diem_channel::new(QueueStyle::FIFO, 8, None);
         let (_conn_mgr_reqs_tx, conn_mgr_reqs_rx) = channel::new_test(8);
         let (_, conn_notifs_channel) = conn_notifs_channel::new();
         let network_sender = ConsensusNetworkSender::new(
@@ -83,8 +80,7 @@ impl SMRNode {
         let txn_manager = Arc::new(MockTransactionManager::new(Some(
             consensus_to_mempool_sender,
         )));
-        let (mut reconfig_sender, reconfig_events) =
-            diem_channel::new(QueueStyle::LIFO, NonZeroUsize::new(1).unwrap(), None);
+        let (mut reconfig_sender, reconfig_events) = diem_channel::new(QueueStyle::LIFO, 1, None);
         let mut configs = HashMap::new();
         configs.insert(
             ValidatorSet::CONFIG_ID,

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -23,7 +23,7 @@ use network::{
     peer_manager::{conn_notifs_channel, ConnectionRequestSender, PeerManagerRequestSender},
     protocols::network::{NewNetworkEvents, NewNetworkSender},
 };
-use std::{num::NonZeroUsize, sync::Arc};
+use std::sync::Arc;
 use storage_interface::mock::MockDbReader;
 use tokio::runtime::{Builder, Runtime};
 use vm_validator::mocks::mock_vm_validator::MockVMValidator;
@@ -57,12 +57,9 @@ impl MockSharedMempool {
         config.validator_network = Some(NetworkConfig::network_with_id(NetworkId::Validator));
 
         let mempool = Arc::new(Mutex::new(CoreMempool::new(&config)));
-        let (network_reqs_tx, _network_reqs_rx) =
-            diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
-        let (connection_reqs_tx, _) =
-            diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
-        let (_network_notifs_tx, network_notifs_rx) =
-            diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
+        let (network_reqs_tx, _network_reqs_rx) = diem_channel::new(QueueStyle::FIFO, 8, None);
+        let (connection_reqs_tx, _) = diem_channel::new(QueueStyle::FIFO, 8, None);
+        let (_network_notifs_tx, network_notifs_rx) = diem_channel::new(QueueStyle::FIFO, 8, None);
         let (_, conn_notifs_rx) = conn_notifs_channel::new();
         let network_sender = MempoolNetworkSender::new(
             PeerManagerRequestSender::new(network_reqs_tx),
@@ -79,7 +76,7 @@ impl MockSharedMempool {
             Some(state_sync) => (None, state_sync),
         };
         let (_reconfig_event_publisher, reconfig_event_subscriber) =
-            diem_channel::new(QueueStyle::LIFO, NonZeroUsize::new(1).unwrap(), None);
+            diem_channel::new(QueueStyle::LIFO, 1, None);
         let network_handles = vec![(
             NodeNetworkId::new(NetworkId::Validator, 0),
             network_sender,

--- a/mempool/src/tests/shared_mempool_test.rs
+++ b/mempool/src/tests/shared_mempool_test.rs
@@ -42,7 +42,6 @@ use network::{
 use rand::{rngs::StdRng, SeedableRng};
 use std::{
     collections::{HashMap, HashSet},
-    num::NonZeroUsize,
     sync::Arc,
 };
 use storage_interface::mock::MockDbReader;
@@ -71,12 +70,9 @@ fn init_single_shared_mempool(
     config: NodeConfig,
 ) {
     let mempool = Arc::new(Mutex::new(CoreMempool::new(&config)));
-    let (network_reqs_tx, network_reqs_rx) =
-        diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
-    let (connection_reqs_tx, _) =
-        diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
-    let (network_notifs_tx, network_notifs_rx) =
-        diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
+    let (network_reqs_tx, network_reqs_rx) = diem_channel::new(QueueStyle::FIFO, 8, None);
+    let (connection_reqs_tx, _) = diem_channel::new(QueueStyle::FIFO, 8, None);
+    let (network_notifs_tx, network_notifs_rx) = diem_channel::new(QueueStyle::FIFO, 8, None);
     let (conn_status_tx, conn_status_rx) = conn_notifs_channel::new();
     let network_sender = MempoolNetworkSender::new(
         PeerManagerRequestSender::new(network_reqs_tx),
@@ -92,8 +88,7 @@ fn init_single_shared_mempool(
     )];
     let (_consensus_sender, consensus_events) = mpsc::channel(1_024);
     let (_state_sync_sender, state_sync_events) = mpsc::channel(1_024);
-    let (_reconfig_events, reconfig_events_receiver) =
-        diem_channel::new(QueueStyle::LIFO, NonZeroUsize::new(1).unwrap(), None);
+    let (_reconfig_events, reconfig_events_receiver) = diem_channel::new(QueueStyle::LIFO, 1, None);
 
     let runtime = Builder::new()
         .thread_name("shared-mem")
@@ -134,12 +129,9 @@ fn init_smp_multiple_networks(
 
     let mut network_handles = vec![];
     for (idx, (network_id, peer_id)) in network_ids.iter().enumerate() {
-        let (network_reqs_tx, network_reqs_rx) =
-            diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
-        let (connection_reqs_tx, _) =
-            diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
-        let (network_notifs_tx, network_notifs_rx) =
-            diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
+        let (network_reqs_tx, network_reqs_rx) = diem_channel::new(QueueStyle::FIFO, 8, None);
+        let (connection_reqs_tx, _) = diem_channel::new(QueueStyle::FIFO, 8, None);
+        let (network_notifs_tx, network_notifs_rx) = diem_channel::new(QueueStyle::FIFO, 8, None);
         let (conn_status_tx, conn_status_rx) = conn_notifs_channel::new();
         let network_sender = MempoolNetworkSender::new(
             PeerManagerRequestSender::new(network_reqs_tx),
@@ -162,8 +154,7 @@ fn init_smp_multiple_networks(
     let (_ac_endpoint_sender, ac_endpoint_receiver) = mpsc::channel(1_024);
     let (_consensus_sender, consensus_events) = mpsc::channel(1_024);
     let (_state_sync_sender, state_sync_events) = mpsc::channel(1_024);
-    let (_reconfig_events, reconfig_events_receiver) =
-        diem_channel::new(QueueStyle::LIFO, NonZeroUsize::new(1).unwrap(), None);
+    let (_reconfig_events, reconfig_events_receiver) = diem_channel::new(QueueStyle::LIFO, 1, None);
 
     let runtime = Builder::new()
         .thread_name("shared-mem")

--- a/network/src/connectivity_manager/test.rs
+++ b/network/src/connectivity_manager/test.rs
@@ -15,7 +15,7 @@ use diem_network_address::NetworkAddress;
 use futures::SinkExt;
 use netcore::transport::ConnectionOrigin;
 use rand::rngs::StdRng;
-use std::{io, num::NonZeroUsize};
+use std::io;
 use tokio::runtime::Runtime;
 use tokio_retry::strategy::FixedInterval;
 
@@ -57,8 +57,7 @@ fn setup_conn_mgr_with_context(
     channel::Sender<ConnectivityRequest>,
     channel::Sender<()>,
 ) {
-    let (connection_reqs_tx, connection_reqs_rx) =
-        diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(1).unwrap(), None);
+    let (connection_reqs_tx, connection_reqs_rx) = diem_channel::new(QueueStyle::FIFO, 1, None);
     let (connection_notifs_tx, connection_notifs_rx) = conn_notifs_channel::new();
     let (conn_mgr_reqs_tx, conn_mgr_reqs_rx) = channel::new_test(0);
     let (ticker_tx, ticker_rx) = channel::new_test(0);
@@ -1277,8 +1276,7 @@ fn basic_update_eligible_peers() {
         RoleType::Validator,
         PeerId::random(),
     ));
-    let (connection_reqs_tx, _connection_reqs_rx) =
-        diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(1).unwrap(), None);
+    let (connection_reqs_tx, _connection_reqs_rx) = diem_channel::new(QueueStyle::FIFO, 1, None);
     let (_connection_notifs_tx, connection_notifs_rx) = conn_notifs_channel::new();
     let (_conn_mgr_reqs_tx, conn_mgr_reqs_rx) = channel::new_test(0);
     let (_ticker_tx, ticker_rx) = channel::new_test::<()>(0);

--- a/network/src/interface/mod.rs
+++ b/network/src/interface/mod.rs
@@ -32,7 +32,7 @@ use futures::{
     stream::StreamExt,
     FutureExt, SinkExt,
 };
-use std::{fmt::Debug, marker::PhantomData, num::NonZeroUsize, sync::Arc, time::Duration};
+use std::{fmt::Debug, marker::PhantomData, sync::Arc, time::Duration};
 use tokio::runtime::Handle;
 
 /// Requests [`NetworkProvider`] receives from the network interface.
@@ -119,13 +119,13 @@ where
         // TODO: Add label for peer.
         let (requests_tx, requests_rx) = diem_channel::new(
             QueueStyle::FIFO,
-            NonZeroUsize::new(channel_size).expect("diem_channel cannot be of size 0"),
+            channel_size,
             Some(&counters::PENDING_NETWORK_REQUESTS),
         );
         // TODO: Add label for peer.
         let (notifs_tx, notifs_rx) = diem_channel::new(
             QueueStyle::FIFO,
-            NonZeroUsize::new(channel_size).expect("diem_channel cannot be of size 0"),
+            channel_size,
             Some(&counters::PENDING_NETWORK_NOTIFICATIONS),
         );
 

--- a/network/src/peer_manager/builder.rs
+++ b/network/src/peer_manager/builder.rs
@@ -30,7 +30,6 @@ use std::{
     clone::Clone,
     collections::{HashMap, HashSet},
     fmt::Debug,
-    num::NonZeroUsize,
     sync::Arc,
 };
 use tokio::runtime::Handle;
@@ -208,15 +207,12 @@ impl PeerManagerBuilder {
         // Setup channel to send requests to peer manager.
         let (pm_reqs_tx, pm_reqs_rx) = diem_channel::new(
             QueueStyle::FIFO,
-            NonZeroUsize::new(channel_size).unwrap(),
+            channel_size,
             Some(&counters::PENDING_PEER_MANAGER_REQUESTS),
         );
         // Setup channel to send connection requests to peer manager.
-        let (connection_reqs_tx, connection_reqs_rx) = diem_channel::new(
-            QueueStyle::FIFO,
-            NonZeroUsize::new(channel_size).unwrap(),
-            None,
-        );
+        let (connection_reqs_tx, connection_reqs_rx) =
+            diem_channel::new(QueueStyle::FIFO, channel_size, None);
 
         Self {
             network_context,
@@ -421,11 +417,8 @@ impl PeerManagerBuilder {
             .augment_direct_send_protocols(direct_send_protocols.clone())
             .augment_rpc_protocols(rpc_protocols.clone());
 
-        let (network_notifs_tx, network_notifs_rx) = diem_channel::new(
-            queue_preference,
-            NonZeroUsize::new(max_queue_size_per_peer).unwrap(),
-            counter,
-        );
+        let (network_notifs_tx, network_notifs_rx) =
+            diem_channel::new(queue_preference, max_queue_size_per_peer, counter);
 
         let pm_context = self
             .peer_manager_context

--- a/network/src/peer_manager/conn_notifs_channel.rs
+++ b/network/src/peer_manager/conn_notifs_channel.rs
@@ -11,13 +11,12 @@
 use crate::peer_manager::ConnectionNotification;
 use channel::{diem_channel, message_queues::QueueStyle};
 use diem_types::PeerId;
-use std::num::NonZeroUsize;
 
 pub type Sender = diem_channel::Sender<PeerId, ConnectionNotification>;
 pub type Receiver = diem_channel::Receiver<PeerId, ConnectionNotification>;
 
 pub fn new() -> (Sender, Receiver) {
-    diem_channel::new(QueueStyle::LIFO, NonZeroUsize::new(1).unwrap(), None)
+    diem_channel::new(QueueStyle::LIFO, 1, None)
 }
 
 #[cfg(test)]

--- a/network/src/peer_manager/tests.rs
+++ b/network/src/peer_manager/tests.rs
@@ -28,7 +28,7 @@ use netcore::{
     compat::IoCompat,
     transport::{boxed::BoxedTransport, memory::MemoryTransport, ConnectionOrigin, TransportExt},
 };
-use std::{collections::HashMap, iter::FromIterator, num::NonZeroUsize};
+use std::{collections::HashMap, iter::FromIterator};
 use tokio::runtime::Handle;
 
 const TEST_PROTOCOL: ProtocolId = ProtocolId::ConsensusRpc;
@@ -85,11 +85,9 @@ fn build_test_peer_manager(
     conn_notifs_channel::Receiver,
 ) {
     let (peer_manager_request_tx, peer_manager_request_rx) =
-        diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(1).unwrap(), None);
-    let (connection_reqs_tx, connection_reqs_rx) =
-        diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(1).unwrap(), None);
-    let (hello_tx, hello_rx) =
-        diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(1).unwrap(), None);
+        diem_channel::new(QueueStyle::FIFO, 1, None);
+    let (connection_reqs_tx, connection_reqs_rx) = diem_channel::new(QueueStyle::FIFO, 1, None);
+    let (hello_tx, hello_rx) = diem_channel::new(QueueStyle::FIFO, 1, None);
     let (conn_status_tx, conn_status_rx) = conn_notifs_channel::new();
 
     let peer_manager = PeerManager::new(

--- a/network/src/protocols/health_checker/test.rs
+++ b/network/src/protocols/health_checker/test.rs
@@ -17,7 +17,7 @@ use diem_config::{config::RoleType, network_id::NetworkId};
 use diem_network_address::NetworkAddress;
 use futures::sink::SinkExt;
 use netcore::transport::ConnectionOrigin;
-use std::{num::NonZeroUsize, str::FromStr};
+use std::str::FromStr;
 use tokio::runtime::Runtime;
 
 const PING_TIMEOUT: Duration = Duration::from_millis(500);
@@ -34,12 +34,9 @@ fn setup_permissive_health_checker(
 ) {
     let (ticker_tx, ticker_rx) = channel::new_test(0);
 
-    let (peer_mgr_reqs_tx, peer_mgr_reqs_rx) =
-        diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(1).unwrap(), None);
-    let (connection_reqs_tx, connection_reqs_rx) =
-        diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(1).unwrap(), None);
-    let (network_notifs_tx, network_notifs_rx) =
-        diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(1).unwrap(), None);
+    let (peer_mgr_reqs_tx, peer_mgr_reqs_rx) = diem_channel::new(QueueStyle::FIFO, 1, None);
+    let (connection_reqs_tx, connection_reqs_rx) = diem_channel::new(QueueStyle::FIFO, 1, None);
+    let (network_notifs_tx, network_notifs_rx) = diem_channel::new(QueueStyle::FIFO, 1, None);
     let (connection_notifs_tx, connection_notifs_rx) = conn_notifs_channel::new();
 
     let hc_network_tx = HealthCheckerNetworkSender::new(

--- a/state-synchronizer/src/tests/fuzzing.rs
+++ b/state-synchronizer/src/tests/fuzzing.rs
@@ -33,7 +33,7 @@ use proptest::{
     prelude::*,
     strategy::Strategy,
 };
-use std::{collections::HashMap, num::NonZeroUsize, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 
 static PEER_ID: Lazy<PeerId> = Lazy::new(|| PeerId::new([0u8; PeerId::LENGTH]));
 
@@ -59,10 +59,8 @@ pub fn test_state_sync_msg_fuzzer_impl(msg: StateSynchronizerMsg) {
     let storage_proxy = Arc::new(RwLock::new(storage_inner));
 
     // mock network senders
-    let (network_reqs_tx, _network_reqs_rx) =
-        diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
-    let (connection_reqs_tx, _) =
-        diem_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
+    let (network_reqs_tx, _network_reqs_rx) = diem_channel::new(QueueStyle::FIFO, 8, None);
+    let (connection_reqs_tx, _) = diem_channel::new(QueueStyle::FIFO, 8, None);
     let network_sender = StateSynchronizerSender::new(
         PeerManagerRequestSender::new(network_reqs_tx),
         ConnectionRequestSender::new(connection_reqs_tx),

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -42,7 +42,6 @@ use network::{
 use network_builder::builder::NetworkBuilder;
 use std::{
     collections::{HashMap, HashSet},
-    num::NonZeroUsize,
     ops::DerefMut,
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -198,11 +197,10 @@ impl SynchronizerEnv {
                 // mock the StateSynchronizerEvents and StateSynchronizerSender to allow manually controlling
                 // msg delivery in test
                 let (network_reqs_tx, network_reqs_rx) =
-                    diem_channel::new(QueueStyle::LIFO, NonZeroUsize::new(1).unwrap(), None);
-                let (connection_reqs_tx, _) =
-                    diem_channel::new(QueueStyle::LIFO, NonZeroUsize::new(1).unwrap(), None);
+                    diem_channel::new(QueueStyle::LIFO, 1, None);
+                let (connection_reqs_tx, _) = diem_channel::new(QueueStyle::LIFO, 1, None);
                 let (network_notifs_tx, network_notifs_rx) =
-                    diem_channel::new(QueueStyle::LIFO, NonZeroUsize::new(1).unwrap(), None);
+                    diem_channel::new(QueueStyle::LIFO, 1, None);
                 let (conn_status_tx, conn_status_rx) = conn_notifs_channel::new();
                 let network_sender = StateSynchronizerSender::new(
                     PeerManagerRequestSender::new(network_reqs_tx),


### PR DESCRIPTION
## Motivation

After looking through the code base, we're using `NonZeroUsize` everywhere just because we're instantiating the `diem-channel` a ton of times.  Now, we can cut that out and just pass in the `usize` by itself, cutting down on a lot of unnecessary boilerplate.