### PR TITLE
[move cli] finish move doctor by detecting event breaking changes + a…

### DIFF
--- a/language/tools/move-cli/tests/testsuite/diem_smoke/args.exp
+++ b/language/tools/move-cli/tests/testsuite/diem_smoke/args.exp
@@ -130,3 +130,4 @@ Changed resource(s) under 2 address(es):
   Changed 2 resource(s) under address 0000000000000000000000000000000B:
     Changed type 0x1::DiemAccount::DiemAccount: [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11], [[[Address(b)]]], [[[Address(b)]]], [U64(1), [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11]], [U64(0), [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11]], U64(0)]
     Changed type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [[U64(500)]]
+Command `doctor`:

--- a/language/tools/move-cli/tests/testsuite/diem_smoke/args.txt
+++ b/language/tools/move-cli/tests/testsuite/diem_smoke/args.txt
@@ -20,3 +20,6 @@ run ../../../../../stdlib/transaction_scripts/peer_to_peer_with_metadata.move --
 
 # transfer 500 XUS from 0xA to 0xB
 run ../../../../../stdlib/transaction_scripts/peer_to_peer_with_metadata.move --mode diem --type-args 0x1::XUS::XUS --signers 0xA --args 0xB 500 x"" x"" -v
+
+# make sure state is still ok
+doctor

--- a/language/tools/move-cli/tests/testsuite/event_breaking_change/Events.move
+++ b/language/tools/move-cli/tests/testsuite/event_breaking_change/Events.move
@@ -1,0 +1,21 @@
+address 0x2 {
+module Events {
+    use 0x1::Event;
+    use 0x1::Signer;
+
+    struct AnEvent { i: u64, b: bool }
+    resource struct Handle { h: Event::EventHandle<AnEvent> }
+
+    public fun emit(account: &signer, i: u64) acquires Handle {
+        let addr = Signer::address_of(account);
+        if (!exists<Handle>(addr)) {
+            Event::publish_generator(account);
+            move_to(account, Handle { h: Event::new_event_handle(account) })
+        };
+
+        let handle = borrow_global_mut<Handle>(addr);
+
+        Event::emit_event(&mut handle.h, AnEvent { i, b: false })
+    }
+}
+}

--- a/language/tools/move-cli/tests/testsuite/event_breaking_change/args.exp
+++ b/language/tools/move-cli/tests/testsuite/event_breaking_change/args.exp
@@ -1,0 +1,9 @@
+Command `publish src/modules/`:
+Command `run src/scripts/emit.move --signers 0xA --args 5`:
+Command `doctor`:
+Command `publish Events.move`:
+Breaking change detected--publishing aborted. Re-run with --ignore-breaking-changes to publish anyway.
+Error: Layout API for structs of module 00000000000000000000000000000002::Events has changed. Need to do a data migration of published structs
+Command `publish --ignore-breaking-changes Events.move`:
+Command `doctor`:
+Error: Failed to deserialize event "0.bcs" stored under address "0x0000000000000000000000000000000A"

--- a/language/tools/move-cli/tests/testsuite/event_breaking_change/args.txt
+++ b/language/tools/move-cli/tests/testsuite/event_breaking_change/args.txt
@@ -1,0 +1,6 @@
+publish src/modules/
+run src/scripts/emit.move --signers 0xA --args 5
+doctor
+publish Events.move
+publish --ignore-breaking-changes Events.move
+doctor

--- a/language/tools/move-cli/tests/testsuite/event_breaking_change/src/modules/Events.move
+++ b/language/tools/move-cli/tests/testsuite/event_breaking_change/src/modules/Events.move
@@ -1,0 +1,21 @@
+address 0x2 {
+module Events {
+    use 0x1::Event;
+    use 0x1::Signer;
+
+    struct AnEvent { i: u64 }
+    resource struct Handle { h: Event::EventHandle<AnEvent> }
+
+    public fun emit(account: &signer, i: u64) acquires Handle {
+        let addr = Signer::address_of(account);
+        if (!exists<Handle>(addr)) {
+            Event::publish_generator(account);
+            move_to(account, Handle { h: Event::new_event_handle(account) })
+        };
+
+        let handle = borrow_global_mut<Handle>(addr);
+
+        Event::emit_event(&mut handle.h, AnEvent { i })
+    }
+}
+}

--- a/language/tools/move-cli/tests/testsuite/event_breaking_change/src/scripts/emit.move
+++ b/language/tools/move-cli/tests/testsuite/event_breaking_change/src/scripts/emit.move
@@ -1,0 +1,7 @@
+script {
+    use 0x2::Events;
+
+    fun emit(account: &signer, i: u64) {
+        Events::emit(account, i)
+    }
+}

--- a/language/tools/move-cli/tests/testsuite/event_breaking_change/src/scripts/publish.move
+++ b/language/tools/move-cli/tests/testsuite/event_breaking_change/src/scripts/publish.move
@@ -1,0 +1,6 @@
+script {
+use 0x2::M;
+fun publish(account: &signer) {
+    M::publish(account)
+}
+}


### PR DESCRIPTION
…dding docs

Previously, `move doctor` checked that resources deserialize correctly, but not events. This PR adds the event check + updates the README with documentation for breaking changes detection via `move publish` and `move doctor`. Finally, added a `doctor` command to the diem smoke test as a stress-test for `doctor`.