### PR TITLE
[State Sync] Further clean ups and small refactors

### DIFF
--- a/state-synchronizer/src/chunk_request.rs
+++ b/state-synchronizer/src/chunk_request.rs
@@ -5,7 +5,7 @@ use diem_types::{ledger_info::LedgerInfoWithSignatures, transaction::Version};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[derive(Clone, Deserialize, Eq, PartialEq, Serialize)]
 /// We're currently considering several types of chunk requests depending on the information
 /// available on the requesting side.
 pub enum TargetType {
@@ -79,7 +79,7 @@ impl fmt::Display for TargetType {
     }
 }
 
-#[derive(Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[derive(Clone, Deserialize, Eq, PartialEq, Serialize)]
 pub struct GetChunkRequest {
     /// The response should start with `known_version + 1`.
     pub known_version: Version,
@@ -88,7 +88,7 @@ pub struct GetChunkRequest {
     /// Max size of a chunk response.
     pub limit: u64,
     /// The target of the given request.
-    target: TargetType,
+    pub target: TargetType,
 }
 
 impl GetChunkRequest {
@@ -99,10 +99,6 @@ impl GetChunkRequest {
             limit,
             target,
         }
-    }
-
-    pub fn target(&self) -> &TargetType {
-        &self.target
     }
 }
 
@@ -117,10 +113,7 @@ impl fmt::Display for GetChunkRequest {
         write!(
             f,
             "[ChunkRequest: known version: {}, epoch: {}, limit: {}, target: {}]",
-            self.known_version,
-            self.current_epoch,
-            self.limit,
-            self.target(),
+            self.known_version, self.current_epoch, self.limit, self.target,
         )
     }
 }

--- a/state-synchronizer/src/chunk_response.rs
+++ b/state-synchronizer/src/chunk_response.rs
@@ -11,7 +11,7 @@ use std::fmt;
 /// The response can carry different LedgerInfo types depending on whether the verification
 /// is done via the local trusted validator set or a local waypoint.
 #[allow(clippy::large_enum_variant)]
-#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum ResponseLedgerInfo {
     /// A typical response carries a LedgerInfo with signatures that should be verified using the
     /// local trusted validator set.
@@ -49,14 +49,14 @@ impl ResponseLedgerInfo {
     }
 }
 
-#[derive(Deserialize, Serialize, Clone, PartialEq, Eq)]
 /// The returned chunk is bounded by the end of the known_epoch of the requester
 /// (i.e., a chunk never crosses epoch boundaries).
+#[derive(Clone, Deserialize, Eq, PartialEq, Serialize)]
 pub struct GetChunkResponse {
-    /// The proofs are built relative to the LedgerInfo in `response_ledger_info`.
+    /// The proofs are built relative to the LedgerInfo in `response_li`.
     /// The specifics of ledger info verification depend on its type.
     pub response_li: ResponseLedgerInfo,
-    /// chunk of transactions with proof corresponding to the ledger info carried by the response.
+    /// Chunk of transactions with proof corresponding to the ledger info carried by the response.
     pub txn_list_with_proof: TransactionListWithProof,
 }
 
@@ -71,6 +71,7 @@ impl GetChunkResponse {
         }
     }
 }
+
 impl fmt::Debug for GetChunkResponse {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self)

--- a/state-synchronizer/src/coordinator.rs
+++ b/state-synchronizer/src/coordinator.rs
@@ -626,7 +626,7 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
         });
         self.sync_state_with_local_storage()?;
 
-        match request.target().clone() {
+        match request.target.clone() {
             TargetType::TargetLedgerInfo(li) => self.process_request_target_li(peer, request, li),
             TargetType::HighestAvailable {
                 target_li,

--- a/state-synchronizer/src/coordinator.rs
+++ b/state-synchronizer/src/coordinator.rs
@@ -336,7 +336,7 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
                                 .peer(&peer)
                                 .error(&err)
                                 .local_li_version(self.local_state.committed_version())
-                                .chunk_req(&request)
+                                .chunk_request(*request)
                         );
                         counters::FAIL_LABEL
                     } else {
@@ -618,7 +618,7 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
         debug!(
             LogSchema::event_log(LogEntry::ProcessChunkRequest, LogEvent::Received)
                 .peer(&peer)
-                .chunk_req(&request)
+                .chunk_request(request.clone())
                 .local_li_version(self.local_state.committed_version())
         );
         fail_point!("state_sync::process_chunk_request", |_| {
@@ -779,7 +779,7 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
             .get_chunk(known_version, limit, response_li.version())?;
         let chunk_response = GetChunkResponse::new(response_li, txns);
         let log = LogSchema::event_log(LogEntry::ProcessChunkRequest, LogEvent::DeliverChunk)
-            .chunk_resp(&chunk_response)
+            .chunk_response(chunk_response.clone())
             .peer(&peer);
         let msg = StateSynchronizerMsg::GetChunkResponse(Box::new(chunk_response));
 
@@ -843,7 +843,7 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
     fn apply_chunk(&mut self, peer: &PeerNetworkId, response: GetChunkResponse) -> Result<()> {
         debug!(
             LogSchema::event_log(LogEntry::ProcessChunkResponse, LogEvent::Received)
-                .chunk_resp(&response)
+                .chunk_response(response.clone())
                 .peer(peer)
         );
         fail_point!("state_sync::apply_chunk", |_| {

--- a/state-synchronizer/src/coordinator.rs
+++ b/state-synchronizer/src/coordinator.rs
@@ -1087,10 +1087,7 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
         // transactions leading up to that end-of-epoch LI
         // * verify end-of-epoch-li actually ends an epoch
         let end_of_epoch_li = end_of_epoch_li
-            .map(|li| {
-                // verify end-of-epoch-li against local state
-                self.local_state.verify_ledger_info(&li).map(|_| li)
-            })
+            .map(|li| self.local_state.verify_ledger_info(&li).map(|_| li))
             .transpose()?
             .filter(|li| {
                 li.ledger_info().version() == new_version && li.ledger_info().ends_epoch()

--- a/state-synchronizer/src/coordinator.rs
+++ b/state-synchronizer/src/coordinator.rs
@@ -8,7 +8,7 @@ use crate::{
     executor_proxy::ExecutorProxyTrait,
     logging::{LogEntry, LogEvent, LogSchema},
     network::{StateSynchronizerEvents, StateSynchronizerMsg, StateSynchronizerSender},
-    request_manager::{PeerScoreUpdateType, RequestManager},
+    request_manager::RequestManager,
     state_synchronizer::SynchronizationState,
 };
 use anyhow::{bail, ensure, format_err, Result};
@@ -866,8 +866,7 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
             txn_list_with_proof
                 .first_transaction_version
                 .ok_or_else(|| {
-                    self.request_manager
-                        .update_score(&peer, PeerScoreUpdateType::EmptyChunk);
+                    self.request_manager.process_empty_chunk(&peer);
                     format_err!("[state sync] Empty chunk from {:?}", peer)
                 })?;
 
@@ -912,8 +911,7 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
             ),
         }
         .map_err(|e| {
-            self.request_manager
-                .update_score(peer, PeerScoreUpdateType::InvalidChunk);
+            self.request_manager.process_invalid_chunk(&peer);
             format_err!("[state sync] failed to apply chunk: {}", e)
         })?;
 

--- a/state-synchronizer/src/executor_proxy.rs
+++ b/state-synchronizer/src/executor_proxy.rs
@@ -52,13 +52,6 @@ pub trait ExecutorProxyTrait: Send {
     /// Returns the ledger's timestamp for the given version in microseconds
     fn get_version_timestamp(&self, version: u64) -> Result<u64>;
 
-    /// Load all on-chain configs from storage
-    /// Note: this method is being exposed as executor proxy trait temporarily because storage read is currently
-    /// using the tonic storage read client, which needs the tokio runtime to block on with no runtime/async issues
-    /// Once we make storage reads sync (by replacing the storage read client with direct DiemDB),
-    /// we can make this entirely internal to `ExecutorProxy`'s initialization procedure
-    fn load_on_chain_configs(&mut self) -> Result<()>;
-
     /// publishes on-chain config updates to subscribed components
     fn publish_on_chain_config_updates(&mut self, events: Vec<ContractEvent>) -> Result<()>;
 }
@@ -200,11 +193,6 @@ impl ExecutorProxyTrait for ExecutorProxy {
 
     fn get_version_timestamp(&self, version: u64) -> Result<u64> {
         self.storage.get_block_timestamp(version)
-    }
-
-    fn load_on_chain_configs(&mut self) -> Result<()> {
-        self.on_chain_configs = Self::fetch_all_configs(&*self.storage)?;
-        Ok(())
     }
 
     fn publish_on_chain_config_updates(&mut self, events: Vec<ContractEvent>) -> Result<()> {

--- a/state-synchronizer/src/logging.rs
+++ b/state-synchronizer/src/logging.rs
@@ -83,16 +83,6 @@ impl<'a> LogSchema<'a> {
             chunk_req_info: None,
         }
     }
-
-    pub fn chunk_req(mut self, request: &GetChunkRequest) -> Self {
-        self.chunk_request = Some(request.clone());
-        self
-    }
-
-    pub fn chunk_resp(mut self, response: &GetChunkResponse) -> Self {
-        self.chunk_response = Some(response.clone());
-        self
-    }
 }
 
 #[derive(Clone, Copy, Serialize)]

--- a/state-synchronizer/src/network.rs
+++ b/state-synchronizer/src/network.rs
@@ -15,6 +15,8 @@ use network::{
 };
 use serde::{Deserialize, Serialize};
 
+const STATE_SYNC_MAX_BUFFER_SIZE: usize = 1;
+
 /// StateSynchronizer network messages
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum StateSynchronizerMsg {
@@ -43,24 +45,6 @@ pub struct StateSynchronizerSender {
     inner: NetworkSender<StateSynchronizerMsg>,
 }
 
-/// Configuration for the network endpoints to support StateSynchronizer.
-pub fn network_endpoint_config() -> (
-    Vec<ProtocolId>,
-    Vec<ProtocolId>,
-    QueueStyle,
-    usize,
-    Option<&'static IntCounterVec>,
-) {
-    (
-        vec![],
-        vec![ProtocolId::StateSynchronizerDirectSend],
-        QueueStyle::LIFO,
-        // TODO:  Name this as a constant.
-        1,
-        Some(&counters::PENDING_STATE_SYNCHRONIZER_NETWORK_EVENTS),
-    )
-}
-
 impl NewNetworkSender for StateSynchronizerSender {
     fn new(
         peer_mgr_reqs_tx: PeerManagerRequestSender,
@@ -81,4 +65,21 @@ impl StateSynchronizerSender {
         let protocol = ProtocolId::StateSynchronizerDirectSend;
         self.inner.send_to(recipient, protocol, message)
     }
+}
+
+/// Configuration for the network endpoints to support StateSynchronizer.
+pub fn network_endpoint_config() -> (
+    Vec<ProtocolId>,
+    Vec<ProtocolId>,
+    QueueStyle,
+    usize,
+    Option<&'static IntCounterVec>,
+) {
+    (
+        vec![],
+        vec![ProtocolId::StateSynchronizerDirectSend],
+        QueueStyle::LIFO,
+        STATE_SYNC_MAX_BUFFER_SIZE,
+        Some(&counters::PENDING_STATE_SYNCHRONIZER_NETWORK_EVENTS),
+    )
 }

--- a/state-synchronizer/src/request_manager.rs
+++ b/state-synchronizer/src/request_manager.rs
@@ -396,7 +396,7 @@ impl RequestManager {
         }
     }
 
-    pub fn is_multicast_response(&self, version: u64, peer: &PeerNetworkId) -> bool {
+    fn is_multicast_response(&self, version: u64, peer: &PeerNetworkId) -> bool {
         self.requests.get(&version).map_or(false, |req| {
             req.last_request_peers.contains(peer) && req.last_request_peers.len() > 1
         })
@@ -414,7 +414,7 @@ impl RequestManager {
             .map(|req_info| req_info.first_request_time)
     }
 
-    pub fn get_multicast_start_time(&self, version: u64) -> Option<SystemTime> {
+    fn get_multicast_start_time(&self, version: u64) -> Option<SystemTime> {
         self.requests
             .get(&version)
             .map(|req_info| req_info.multicast_start_time)
@@ -477,7 +477,7 @@ impl RequestManager {
         is_timeout
     }
 
-    pub fn is_upstream_peer(&self, peer: &PeerNetworkId, origin: ConnectionOrigin) -> bool {
+     fn is_upstream_peer(&self, peer: &PeerNetworkId, origin: ConnectionOrigin) -> bool {
         let is_network_upstream = self
             .upstream_config
             .get_upstream_preference(peer.raw_network_id())

--- a/state-synchronizer/src/request_manager.rs
+++ b/state-synchronizer/src/request_manager.rs
@@ -271,7 +271,7 @@ impl RequestManager {
     }
 
     pub fn send_chunk_request(&mut self, req: GetChunkRequest) -> Result<()> {
-        let log = LogSchema::new(LogEntry::SendChunkRequest).chunk_req(&req);
+        let log = LogSchema::new(LogEntry::SendChunkRequest).chunk_request(req.clone());
 
         // update internal state
         let peers = self.pick_peers();

--- a/state-synchronizer/src/request_manager.rs
+++ b/state-synchronizer/src/request_manager.rs
@@ -28,7 +28,7 @@ const MAX_SCORE: f64 = 100.0;
 const MIN_SCORE: f64 = 1.0;
 const PRIMARY_NETWORK_PREFERENCE: usize = 0;
 
-#[derive(Default, Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct PeerInfo {
     is_alive: bool,
     score: f64,
@@ -41,7 +41,7 @@ impl PeerInfo {
 }
 
 /// Basic metadata about the chunk request.
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct ChunkRequestInfo {
     version: u64,
     first_request_time: SystemTime,

--- a/state-synchronizer/src/request_manager.rs
+++ b/state-synchronizer/src/request_manager.rs
@@ -29,7 +29,7 @@ const MIN_SCORE: f64 = 1.0;
 const PRIMARY_NETWORK_PREFERENCE: usize = 0;
 
 #[derive(Clone, Debug)]
-pub struct PeerInfo {
+struct PeerInfo {
     is_alive: bool,
     score: f64,
 }
@@ -66,7 +66,7 @@ impl ChunkRequestInfo {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum PeerScoreUpdateType {
+enum PeerScoreUpdateType {
     Success,
     EmptyChunk,
     // A received chunk cannot be directly applied (old / wrong version). Note that it could happen
@@ -152,7 +152,7 @@ impl RequestManager {
         self.eligible_peers.is_empty()
     }
 
-    pub fn update_score(&mut self, peer: &PeerNetworkId, update_type: PeerScoreUpdateType) {
+    fn update_score(&mut self, peer: &PeerNetworkId, update_type: PeerScoreUpdateType) {
         if let Some(peer_info) = self.peers.get_mut(peer) {
             let old_score = peer_info.score;
             match update_type {
@@ -342,6 +342,14 @@ impl RequestManager {
                 .expect("missing chunk request that was just added")
                 .clone()
         }
+    }
+
+    pub fn process_empty_chunk(&mut self, peer: &PeerNetworkId) {
+        self.update_score(&peer, PeerScoreUpdateType::EmptyChunk);
+    }
+
+    pub fn process_invalid_chunk(&mut self, peer: &PeerNetworkId) {
+        self.update_score(peer, PeerScoreUpdateType::InvalidChunk);
     }
 
     pub fn process_success_response(&mut self, peer: &PeerNetworkId) {

--- a/state-synchronizer/src/tests/helpers.rs
+++ b/state-synchronizer/src/tests/helpers.rs
@@ -158,10 +158,6 @@ impl ExecutorProxyTrait for MockExecutorProxy {
         Ok(0)
     }
 
-    fn load_on_chain_configs(&mut self) -> Result<()> {
-        Ok(())
-    }
-
     fn publish_on_chain_config_updates(&mut self, _events: Vec<ContractEvent>) -> Result<()> {
         Ok(())
     }

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -453,7 +453,7 @@ fn check_chunk_request(msg: StateSynchronizerMsg, known_version: u64, target_ver
     match msg {
         StateSynchronizerMsg::GetChunkRequest(req) => {
             assert_eq!(req.known_version, known_version);
-            assert_eq!(req.target().version(), target_version);
+            assert_eq!(req.target.version(), target_version);
         }
         StateSynchronizerMsg::GetChunkResponse(_) => {
             panic!("received chunk response when expecting chunk request");

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -339,7 +339,7 @@ impl SynchronizerEnv {
         let max_retries = 30;
         for _ in 0..max_retries {
             let state = block_on(self.clients[peer_id].get_state()).unwrap();
-            if state.highest_version_in_local_storage() == target_version {
+            if state.synced_version() == target_version {
                 return highest_li_version
                     .map_or(true, |li_version| li_version == state.committed_version());
             }

--- a/state-synchronizer/src/tests/on_chain_config_tests.rs
+++ b/state-synchronizer/src/tests/on_chain_config_tests.rs
@@ -54,11 +54,6 @@ fn test_on_chain_config_pub_sub() {
         "expect initial config notification",
     );
 
-    // start state sync with initial loading of on-chain configs
-    executor_proxy
-        .load_on_chain_configs()
-        .expect("failed to load on-chain configs");
-
     ////////////////////////////////////////////////////////
     // Case 1: don't publish for no reconfiguration event //
     ////////////////////////////////////////////////////////

--- a/state-synchronizer/src/tests/on_chain_config_tests.rs
+++ b/state-synchronizer/src/tests/on_chain_config_tests.rs
@@ -263,8 +263,8 @@ fn test_on_chain_config_pub_sub() {
     // out the storage/execution layer. We piggy-back on this expensive DB/runtime setup here in testing
     // on-chain reconfig to test the executor proxy interface against.
     let state = executor_proxy.get_local_storage_state().unwrap();
-    assert_eq!(state.epoch(), 4);
-    assert_eq!(state.highest_version_in_local_storage(), 7);
+    assert_eq!(state.trusted_epoch(), 4);
+    assert_eq!(state.synced_version(), 7);
 
     let txns = executor_proxy.get_chunk(0, 2, 2).unwrap();
     assert_eq!(txns.transactions, vec![txn1, txn2]);

--- a/state-synchronizer/src/tests/unit_tests.rs
+++ b/state-synchronizer/src/tests/unit_tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::request_manager::{PeerScoreUpdateType, RequestManager};
+use crate::request_manager::RequestManager;
 use diem_config::config::{PeerNetworkId, UpstreamConfig};
 use netcore::transport::ConnectionOrigin;
 use std::{collections::HashMap, time::Duration};
@@ -25,7 +25,7 @@ fn test_request_manager() {
     }
 
     for _ in 0..50 {
-        request_manager.update_score(&peers[0], PeerScoreUpdateType::InvalidChunk);
+        request_manager.process_invalid_chunk(&peers[0]);
     }
 
     let mut pick_counts = HashMap::new();


### PR DESCRIPTION
## Motivation

This PR offers several small cleanups and refactors for state synchronizer. No behaviours should change in this PR.
The commits this PR offers are:
1. Refactor SynchronizationState and rename fields/methods (see the previous discussion regarding committed and synced in https://github.com/diem/diem/pull/7017)
2. Remove unnecessary logging methods from schema (duplication)
3. Remove the getter from GetChunkRequest (unnecessary)
4. Small cleanups to chunk_response
5. Add constant for buffer size to network code (old TODO)
6. Remove default derive from PeerInfo (unused)
7. Remove unnecessary "load_on_chain_configs" method (no longer required)
8. Avoid leaking PeerScoreUpdateType enum outside of RequestManager (better encapsulation)
9. Remove public visibility from internal-only methods (better encapsulation)
10. Refactors methods to functions (easier to reason about)
11. Remove redundant comment from coordinator

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally.

## Related PRs

None, but this relates to: https://github.com/diem/diem/issues/6795
