### PR TITLE
[move-lang] move the shadow compilation logic from move-cli to source compiler

### DIFF
--- a/language/benchmarks/src/move_vm.rs
+++ b/language/benchmarks/src/move_vm.rs
@@ -35,7 +35,7 @@ fn compile_module(addr: &[u8; AccountAddress::LENGTH]) -> CompiledModule {
     let s = path.to_str().expect("no path specified").to_owned();
 
     let (_files, mut compiled_units) =
-        move_lang::move_compile_and_report(&[s], &[], Some(Address::new(*addr)), None)
+        move_lang::move_compile_and_report(&[s], &[], Some(Address::new(*addr)), None, false)
             .expect("Error compiling...");
     match compiled_units.remove(0) {
         CompiledUnit::Module { module, .. } => module,

--- a/language/diem-tools/transaction-replay/src/lib.rs
+++ b/language/diem-tools/transaction-replay/src/lib.rs
@@ -230,7 +230,7 @@ fn compile_move_script(file_path: &str, sender: AccountAddress) -> Result<Vec<u8
     let targets = &vec![cur_path];
     let sender_opt = Some(sender_addr);
     let (files, units_or_errors) =
-        move_compile(targets, &stdlib::stdlib_files(), sender_opt, None)?;
+        move_compile(targets, &stdlib::stdlib_files(), sender_opt, None, false)?;
     let unit = match units_or_errors {
         Err(errors) => {
             let error_buffer = move_lang::errors::report_errors_to_color_buffer(files, errors);

--- a/language/move-lang/functional-tests/tests/functional_testsuite.rs
+++ b/language/move-lang/functional-tests/tests/functional_testsuite.rs
@@ -56,7 +56,7 @@ impl Compiler for MoveSourceCompiler {
 
         let targets = &vec![cur_path.clone()];
         let sender = Some(sender_addr);
-        let (files, units_or_errors) = move_compile(targets, &self.deps, sender, None)?;
+        let (files, units_or_errors) = move_compile(targets, &self.deps, sender, None, false)?;
         let unit = match units_or_errors {
             Err(errors) => {
                 let error_buffer = if read_bool_env_var(testsuite::PRETTY) {

--- a/language/move-lang/src/bin/move-build.rs
+++ b/language/move-lang/src/bin/move-build.rs
@@ -42,14 +42,14 @@ pub struct Options {
     )]
     pub out_dir: String,
 
-    /// If set, allow modules defined in source_files to shadow modules of the same id that exist
-    /// in dependencies
+    /// If set, do not allow modules defined in source_files to shadow modules of the same id that
+    /// exist in dependencies. Compilation will fail in this case.
     #[structopt(
-        name = "SOURCES_SHADOW_DEPS",
-        short = cli::SHADOW_SHORT,
-        long = cli::SHADOW,
+        name = "SOURCES_DO_NOT_SHADOW_DEPS",
+        short = cli::NO_SHADOW_SHORT,
+        long = cli::NO_SHADOW,
     )]
-    pub shadow: bool,
+    pub no_shadow: bool,
 
     /// Save bytecode source map to disk
     #[structopt(
@@ -66,7 +66,7 @@ pub fn main() -> anyhow::Result<()> {
         dependencies,
         sender,
         out_dir,
-        shadow,
+        no_shadow,
         emit_source_map,
     } = Options::from_args();
 
@@ -76,7 +76,7 @@ pub fn main() -> anyhow::Result<()> {
         &dependencies,
         sender,
         Some(interface_files_dir),
-        shadow,
+        !no_shadow,
     )?;
     move_lang::output_compiled_units(emit_source_map, files, compiled_units, &out_dir)
 }

--- a/language/move-lang/src/bin/move-build.rs
+++ b/language/move-lang/src/bin/move-build.rs
@@ -42,6 +42,15 @@ pub struct Options {
     )]
     pub out_dir: String,
 
+    /// If set, allow modules defined in source_files to shadow modules of the same id that exist
+    /// in dependencies
+    #[structopt(
+        name = "SOURCES_SHADOW_DEPS",
+        short = cli::SHADOW_SHORT,
+        long = cli::SHADOW,
+    )]
+    pub shadow: bool,
+
     /// Save bytecode source map to disk
     #[structopt(
         name = "",
@@ -57,6 +66,7 @@ pub fn main() -> anyhow::Result<()> {
         dependencies,
         sender,
         out_dir,
+        shadow,
         emit_source_map,
     } = Options::from_args();
 
@@ -66,6 +76,7 @@ pub fn main() -> anyhow::Result<()> {
         &dependencies,
         sender,
         Some(interface_files_dir),
+        shadow,
     )?;
     move_lang::output_compiled_units(emit_source_map, files, compiled_units, &out_dir)
 }

--- a/language/move-lang/src/bin/move-check.rs
+++ b/language/move-lang/src/bin/move-check.rs
@@ -45,14 +45,14 @@ pub struct Options {
     )]
     pub out_dir: Option<String>,
 
-    /// If set, allow modules defined in source_files to shadow modules of the same id that exist
-    /// in dependencies
+    /// If set, do not allow modules defined in source_files to shadow modules of the same id that
+    /// exist in dependencies. Checking will fail in this case.
     #[structopt(
-        name = "SOURCES_SHADOW_DEPS",
-        short = cli::SHADOW_SHORT,
-        long = cli::SHADOW,
+        name = "SOURCES_DO_NOT_SHADOW_DEPS",
+        short = cli::NO_SHADOW_SHORT,
+        long = cli::NO_SHADOW,
     )]
-    pub shadow: bool,
+    pub no_shadow: bool,
 }
 
 pub fn main() -> anyhow::Result<()> {
@@ -61,10 +61,15 @@ pub fn main() -> anyhow::Result<()> {
         dependencies,
         sender,
         out_dir,
-        shadow,
+        no_shadow,
     } = Options::from_args();
 
-    let _files =
-        move_lang::move_check_and_report(&source_files, &dependencies, sender, out_dir, shadow)?;
+    let _files = move_lang::move_check_and_report(
+        &source_files,
+        &dependencies,
+        sender,
+        out_dir,
+        !no_shadow,
+    )?;
     Ok(())
 }

--- a/language/move-lang/src/bin/move-check.rs
+++ b/language/move-lang/src/bin/move-check.rs
@@ -44,6 +44,15 @@ pub struct Options {
         long = cli::OUT_DIR,
     )]
     pub out_dir: Option<String>,
+
+    /// If set, allow modules defined in source_files to shadow modules of the same id that exist
+    /// in dependencies
+    #[structopt(
+        name = "SOURCES_SHADOW_DEPS",
+        short = cli::SHADOW_SHORT,
+        long = cli::SHADOW,
+    )]
+    pub shadow: bool,
 }
 
 pub fn main() -> anyhow::Result<()> {
@@ -52,8 +61,10 @@ pub fn main() -> anyhow::Result<()> {
         dependencies,
         sender,
         out_dir,
+        shadow,
     } = Options::from_args();
 
-    let _files = move_lang::move_check_and_report(&source_files, &dependencies, sender, out_dir)?;
+    let _files =
+        move_lang::move_check_and_report(&source_files, &dependencies, sender, out_dir, shadow)?;
     Ok(())
 }

--- a/language/move-lang/src/command_line/mod.rs
+++ b/language/move-lang/src/command_line/mod.rs
@@ -13,6 +13,9 @@ pub const OUT_DIR: &str = "out-dir";
 pub const OUT_DIR_SHORT: &str = "o";
 pub const DEFAULT_OUTPUT_DIR: &str = "build";
 
+pub const SHADOW: &str = "shadow";
+pub const SHADOW_SHORT: &str = "f";
+
 pub const SOURCE_MAP: &str = "source-map";
 pub const SOURCE_MAP_SHORT: &str = "m";
 

--- a/language/move-lang/src/command_line/mod.rs
+++ b/language/move-lang/src/command_line/mod.rs
@@ -13,8 +13,8 @@ pub const OUT_DIR: &str = "out-dir";
 pub const OUT_DIR_SHORT: &str = "o";
 pub const DEFAULT_OUTPUT_DIR: &str = "build";
 
-pub const SHADOW: &str = "shadow";
-pub const SHADOW_SHORT: &str = "f";
+pub const NO_SHADOW: &str = "no-shadow";
+pub const NO_SHADOW_SHORT: &str = "S";
 
 pub const SOURCE_MAP: &str = "source-map";
 pub const SOURCE_MAP_SHORT: &str = "m";

--- a/language/move-lang/src/lib.rs
+++ b/language/move-lang/src/lib.rs
@@ -180,6 +180,14 @@ pub fn move_continue_up_to(pass: PassResult, until: Pass) -> Result<PassResult, 
     run(pass, until)
 }
 
+/// Similar to `move_compile`, but with an additional `allow_shadow` flag to indicate that modules
+/// defined in targets can shadow (i.e., override) the modules in dependencies. In other words,
+/// if the same module id (<address::name>) is found in both targets and dependencies, the module
+/// definition in targets takes priority.
+///
+/// This function also allows to specify a stopping point of the compilation process. Similar to
+/// `move_continue_up_to`, the stopping point is inclusive, meaning that the pass specified by
+/// `until: Pass` will be run
 pub fn move_compile_up_to(
     targets: &[String],
     deps: &[String],
@@ -382,6 +390,8 @@ pub fn generate_interface_files(
     Ok(Some(all_addr_dir.into_os_string().into_string().unwrap()))
 }
 
+/// Given a parsed program, if a module id is found in both the source and lib definitions, filter
+/// out the lib definition and re-construct a new parsed program
 fn shadow_lib_module_definitions(
     pprog: parser::ast::Program,
     sender_opt: Option<Address>,

--- a/language/move-lang/tests/move_check_testsuite.rs
+++ b/language/move-lang/tests/move_check_testsuite.rs
@@ -51,7 +51,7 @@ fn move_check_testsuite(path: &Path) -> datatest_stable::Result<()> {
     let exp_path = path.with_extension(EXP_EXT);
     let out_path = path.with_extension(OUT_EXT);
 
-    let (files, units_or_errors) = move_compile(&targets, &deps, sender, None)?;
+    let (files, units_or_errors) = move_compile(&targets, &deps, sender, None, false)?;
     let errors = match units_or_errors {
         Err(errors) => errors,
         Ok(units) => move_lang::compiled_unit::verify_units(units).1,

--- a/language/move-lang/tests/stdlib_sanity_check.rs
+++ b/language/move-lang/tests/stdlib_sanity_check.rs
@@ -26,7 +26,7 @@ fn sanity_check_testsuite_impl(
 
     let out_path = path.with_extension(OUT_EXT);
 
-    let (files, units_or_errors) = move_compile(&targets, &deps, sender, None)?;
+    let (files, units_or_errors) = move_compile(&targets, &deps, sender, None, false)?;
     let errors = match units_or_errors {
         Err(errors) => errors,
         Ok(units) => move_lang::compiled_unit::verify_units(units).1,

--- a/language/move-vm/integration-tests/src/compiler.rs
+++ b/language/move-vm/integration-tests/src/compiler.rs
@@ -22,6 +22,7 @@ pub fn compile_units(addr: AccountAddress, s: &str) -> Result<Vec<CompiledUnit>>
         &[],
         Some(Address::new(addr.to_u8())),
         None,
+        false,
     )?;
 
     dir.close()?;
@@ -44,6 +45,7 @@ pub fn compile_modules_in_file(addr: AccountAddress, path: &Path) -> Result<Vec<
         &[],
         Some(Address::new(addr.to_u8())),
         None,
+        false,
     )?;
 
     expect_modules(units).collect()

--- a/language/stdlib/src/lib.rs
+++ b/language/stdlib/src/lib.rs
@@ -144,7 +144,8 @@ pub fn script_files() -> Vec<String> {
 
 pub fn build_stdlib() -> BTreeMap<String, CompiledModule> {
     let (_files, compiled_units) =
-        move_compile_and_report(&stdlib_files(), &[], Some(Address::DIEM_CORE), None).unwrap();
+        move_compile_and_report(&stdlib_files(), &[], Some(Address::DIEM_CORE), None, false)
+            .unwrap();
     let mut modules = BTreeMap::new();
     for (i, compiled_unit) in compiled_units.into_iter().enumerate() {
         let name = compiled_unit.name();
@@ -169,6 +170,7 @@ pub fn compile_script(source_file_str: String) -> Vec<u8> {
         &stdlib_files(),
         Some(Address::DIEM_CORE),
         None,
+        false,
     )
     .unwrap();
     let mut script_bytes = vec![];

--- a/language/tools/move-cli/src/package.rs
+++ b/language/tools/move-cli/src/package.rs
@@ -163,8 +163,13 @@ impl MovePackage {
             fs::create_dir_all(&pkg_bin_path)?;
 
             // compile the source files
-            let (_files, compiled_units) =
-                move_compile_and_report(&[path_to_string(&pkg_src_path)?], &src_dirs, None, None)?;
+            let (_files, compiled_units) = move_compile_and_report(
+                &[path_to_string(&pkg_src_path)?],
+                &src_dirs,
+                None,
+                None,
+                false,
+            )?;
 
             // save modules and ignore scripts
             for unit in compiled_units {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The feature to allow Move module compilation with duplicating/conflicting definitions against library modules is experimented in Move CLI. But ideally, this feature should live in the source compiler. This PR moves the logic there.

It also simplifies the filtering logic by only looking at the `parser::ast::Program` instead of going through the `mv_interfaces` directory with filename matching.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

`cargo xtest`
