### PR TITLE
[State Sync] Use checked arithmetic operations to avoid over/underflows.

### DIFF
--- a/state-synchronizer/src/chunk_response.rs
+++ b/state-synchronizer/src/chunk_response.rs
@@ -82,11 +82,14 @@ impl fmt::Display for GetChunkResponse {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let txns_repr = match self.txn_list_with_proof.first_transaction_version {
             None => "empty".to_string(),
-            Some(first_ver) => format!(
-                "versions [{} - {}]",
-                first_ver,
-                first_ver - 1 + self.txn_list_with_proof.len() as u64
-            ),
+            Some(first_version) => {
+                let last_version = first_version
+                    .checked_add(self.txn_list_with_proof.len() as u64)
+                    .and_then(|v| v.checked_sub(1)) // last_version = first_version + txns.len() - 1
+                    .map(|v| format!("{}", v)) // format last_version as a string
+                    .unwrap_or_else(|| "Last version has overflown!".into());
+                format!("versions [{} - {}]", first_version, last_version)
+            }
         };
         let response_li_repr = match &self.response_li {
             ResponseLedgerInfo::VerifiableLedgerInfo(li) => {

--- a/state-synchronizer/src/executor_proxy.rs
+++ b/state-synchronizer/src/executor_proxy.rs
@@ -175,16 +175,19 @@ impl ExecutorProxyTrait for ExecutorProxy {
         limit: u64,
         target_version: u64,
     ) -> Result<TransactionListWithProof> {
-        let start_version = known_version
+        let starting_version = known_version
             .checked_add(1)
-            .ok_or_else(|| format_err!("Known version too high"))?;
+            .ok_or_else(|| format_err!("Starting version has overflown!"))?;
         self.storage
-            .get_transactions(start_version, limit, target_version, false)
+            .get_transactions(starting_version, limit, target_version, false)
     }
 
     fn get_epoch_proof(&self, epoch: u64) -> Result<LedgerInfoWithSignatures> {
+        let next_epoch = epoch
+            .checked_add(1)
+            .ok_or_else(|| format_err!("Next epoch has overflown!"))?;
         self.storage
-            .get_epoch_ending_ledger_infos(epoch, epoch + 1)?
+            .get_epoch_ending_ledger_infos(epoch, next_epoch)?
             .ledger_info_with_sigs
             .pop()
             .ok_or_else(|| format_err!("Empty EpochChangeProof"))

--- a/state-synchronizer/src/state_synchronizer.rs
+++ b/state-synchronizer/src/state_synchronizer.rs
@@ -175,7 +175,8 @@ impl StateSynchronizer {
             upstream_config,
             executor_proxy,
             initial_state,
-        );
+        )
+        .expect("Unable to create sync coordinator");
         runtime.spawn(coordinator.start(network));
 
         Self {

--- a/state-synchronizer/src/tests/fuzzing.rs
+++ b/state-synchronizer/src/tests/fuzzing.rs
@@ -79,7 +79,8 @@ pub fn test_state_sync_msg_fuzzer_impl(msg: StateSynchronizerMsg) {
         config.upstream,
         MockExecutorProxy::new(SynchronizerEnvHelper::default_handler(), storage_proxy),
         initial_state,
-    );
+    )
+    .expect("Unable to create sync coordinator");
     let mut rt = tokio::runtime::Builder::new()
         .basic_scheduler()
         .build()

--- a/state-synchronizer/src/tests/unit_tests.rs
+++ b/state-synchronizer/src/tests/unit_tests.rs
@@ -91,7 +91,7 @@ fn test_request_manager_request_metadata() {
     assert!(request_manager.get_first_request_time(1).is_none());
 
     request_manager.add_request(1, vec![peers[0].clone()]);
-    request_manager.check_timeout(1);
+    request_manager.check_timeout(1).unwrap();
     request_manager.add_request(1, vec![peers[1].clone()]);
     assert!(request_manager.peer_score(&peers[0]).unwrap() < 99.0);
     assert!(request_manager.peer_score(&peers[1]).unwrap() > 99.0);


### PR DESCRIPTION
## Motivation

This PR updates state sync code to use checked arithmetic operations instead of regular operations. This is in response to recently found bugs caused by u64 overflows (e.g., https://github.com/diem/diem/pull/7060). While these overflows are arguably not high-priority (i.e., it has yet to be shown how they could be exploited in practice to cause negative behaviors), it's safer that we handle these cases explicitly now.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally.

## Related PRs

None, but this relates to: https://github.com/diem/diem/issues/6795