### PR TITLE
Fix semantic error response checks for JSON RPC

### DIFF
--- a/json-rpc/types/src/errors.rs
+++ b/json-rpc/types/src/errors.rs
@@ -60,12 +60,12 @@ pub enum InvalidRequestCode {
     InvalidFormat = -32604,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub enum ErrorData {
     StatusCode(StatusCode),
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct JsonRpcError {
     pub code: i16,
     pub message: String,

--- a/json-rpc/types/src/response.rs
+++ b/json-rpc/types/src/response.rs
@@ -9,7 +9,7 @@ pub const X_DIEM_CHAIN_ID: &str = "X-Diem-Chain-Id";
 pub const X_DIEM_VERSION_ID: &str = "X-Diem-Ledger-Version";
 pub const X_DIEM_TIMESTAMP_USEC_ID: &str = "X-Diem-Ledger-TimestampUsec";
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct JsonRpcResponse {
     pub diem_chain_id: u8,
     pub diem_ledger_version: u64,


### PR DESCRIPTION
The JSON-RPC tests currently use string matching that can vary based on the JSON stringification that is subject to out-of-order fields:

---- async_client::tests::test_batch_send_requests_and_response_id_not_matched_error stdout ----
thread 'async_client::tests::test_batch_send_requests_and_response_id_not_matched_error' panicked at 'assertion failed: `(left == right)`
  left: `"Err(UnexpectedError(InvalidResponseId(JsonRpcResponse { diem_chain_id: 4, diem_ledger_version: 1, diem_ledger_timestampusec: 1602888396000000, jsonrpc: \"2.0\", id: Some(Number(2)), result: Some(Object({\"chain_id\": Number(4), \"timestamp\": Number(234234), \"version\": Number(1)})), error: None })))"`,
 right: `"Err(UnexpectedError(InvalidResponseId(JsonRpcResponse { diem_chain_id: 4, diem_ledger_version: 1, diem_ledger_timestampusec: 1602888396000000, jsonrpc: \"2.0\", id: Some(Number(2)), result: Some(Object({\"version\": Number(1), \"timestamp\": Number(234234), \"chain_id\": Number(4)})), error: None })))"`', client/json-rpc/src/async_client/tests.rs:766:9
stack backtrace:

This change does the equivalence prior to stringification to avoid these types of false, flaky test failures while preserving the full checking of the response.
