### PR TITLE
Integer overflow in crypto and execution/executor-types

### DIFF
--- a/crypto/crypto/src/ed25519.rs
+++ b/crypto/crypto/src/ed25519.rs
@@ -29,6 +29,7 @@
 //! ```
 //! **Note**: The above example generates a private key using a private function intended only for
 //! testing purposes. Production code should find an alternate means for secure key generation.
+#[allow(clippy::integer_arithmetic)]
 #[cfg(any(feature = "vanilla-u64", feature = "vanilla-u32"))]
 use vanilla_curve25519_dalek as curve25519_dalek;
 #[cfg(any(feature = "vanilla-u64", feature = "vanilla-u32"))]

--- a/crypto/crypto/src/ed25519.rs
+++ b/crypto/crypto/src/ed25519.rs
@@ -29,7 +29,7 @@
 //! ```
 //! **Note**: The above example generates a private key using a private function intended only for
 //! testing purposes. Production code should find an alternate means for secure key generation.
-#[allow(clippy::integer_arithmetic)]
+#![allow(clippy::integer_arithmetic)]
 #[cfg(any(feature = "vanilla-u64", feature = "vanilla-u32"))]
 use vanilla_curve25519_dalek as curve25519_dalek;
 #[cfg(any(feature = "vanilla-u64", feature = "vanilla-u32"))]

--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -98,7 +98,7 @@
 //! hasher.update("Test message".as_bytes());
 //! let hash_value = hasher.finish();
 //! ```
-
+#[allow(clippy::integer_arithmetic)]
 use anyhow::{ensure, Error, Result};
 use bytes::Bytes;
 use diem_nibble::Nibble;

--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -98,7 +98,7 @@
 //! hasher.update("Test message".as_bytes());
 //! let hash_value = hasher.finish();
 //! ```
-#[allow(clippy::integer_arithmetic)]
+#![allow(clippy::integer_arithmetic)]
 use anyhow::{ensure, Error, Result};
 use bytes::Bytes;
 use diem_nibble::Nibble;

--- a/crypto/crypto/src/noise.rs
+++ b/crypto/crypto/src/noise.rs
@@ -55,6 +55,7 @@
 //! # }
 //! ```
 //!
+#![allow(clippy::integer_arithmetic)]
 
 use crate::{hash::HashValue, hkdf::Hkdf, traits::Uniform as _, x25519};
 use aes_gcm::{

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -261,11 +261,7 @@ impl ExecutedTrees {
 
     pub fn version(&self) -> Option<Version> {
         let num_elements = self.txn_accumulator().num_leaves() as u64;
-        let version: (u64, bool) = num_elements.overflowing_sub(1);
-        if version.1 {
-            return None;
-        }
-        Some(version.0)
+        num_elements.checked_sub(1)
     }
 
     pub fn state_id(&self) -> HashValue {

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -157,7 +157,9 @@ impl StateComputeResult {
 
 impl StateComputeResult {
     pub fn version(&self) -> Version {
-        max(self.num_leaves, 1) - 1
+        max(self.num_leaves, 1)
+            .checked_sub(1)
+            .expect("Integer overflow occurred")
     }
 
     pub fn root_hash(&self) -> HashValue {
@@ -259,11 +261,11 @@ impl ExecutedTrees {
 
     pub fn version(&self) -> Option<Version> {
         let num_elements = self.txn_accumulator().num_leaves() as u64;
-        if num_elements > 0 {
-            Some(num_elements - 1)
-        } else {
-            None
+        let version: (u64, bool) = num_elements.overflowing_sub(1);
+        if version.1 {
+            return None;
         }
+        Some(version.0)
     }
 
     pub fn state_id(&self) -> HashValue {

--- a/execution/executor/src/db_bootstrapper.rs
+++ b/execution/executor/src/db_bootstrapper.rs
@@ -131,8 +131,12 @@ pub fn calculate_genesis<V: VMExecutor>(
         // TODO(aldenhu): fix existing tests before using real timestamp and check on-chain epoch.
         GENESIS_TIMESTAMP_USECS
     } else {
+        let next_epoch = epoch
+            .checked_add(1)
+            .ok_or_else(|| format_err!("integer overflow occurred"))?;
+
         ensure!(
-            epoch + 1 == get_state_epoch(&state_view)?,
+            next_epoch == get_state_epoch(&state_view)?,
             "Genesis txn didn't bump epoch."
         );
         get_state_timestamp(&state_view)?

--- a/testsuite/cluster-test/src/cluster_swarm/templates/vault_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/templates/vault_spec_template.yaml
@@ -25,7 +25,7 @@ spec:
       securityContext:
         capabilities:
           add: ["IPC_LOCK"]
-      image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/vault:1.4.0
+      image: vault:1.4.0
       imagePullPolicy: IfNotPresent
       command:
       args:
@@ -96,7 +96,7 @@ spec:
       securityContext:
         capabilities:
           add: ["IPC_LOCK"]
-      image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/vault:1.4.0
+      image: vault:1.4.0
       imagePullPolicy: IfNotPresent
       command:
         - "sh"


### PR DESCRIPTION
Motivation
Our goal is to prevent lines that can cause integer overflows in TCB and all its dependencies.

To do so we will enable a clippy lint to detect all such lines that contain operations + - / * % and replace those operations with safer functions such as {overflowing/checked/wrapping/saturating}_{add/sub/mul/div/rem} .

But before we can enable the lint to be landblocking, we need to fix all occurrences of + - / * % in TCB, or else we risk blocking all diffs once the lint is enabled.

For classes where we want to skip this lint, we can add #![allow(clippy::integer_arithmetic)] in the beggining.

This PR handles the violations of the lint in libra/crypto  and libra/execution/executor-types.

Have you read the Contributing Guidelines on pull requests?
Yes

Test Plan
cargo x lint && cargo xfmt && cargo xclippy --all-targets

Related PRs
N/A