### PR TITLE
[network] emit metadata on new and lost peers

### DIFF
--- a/network/src/connectivity_manager/test.rs
+++ b/network/src/connectivity_manager/test.rs
@@ -5,6 +5,7 @@ use super::*;
 use crate::{
     peer::DisconnectReason,
     peer_manager::{conn_notifs_channel, ConnectionRequest},
+    transport::ConnectionMetadata,
 };
 use channel::{diem_channel, message_queues::QueueStyle};
 use core::str::FromStr;
@@ -13,7 +14,6 @@ use diem_crypto::{test_utils::TEST_SEED, x25519, Uniform};
 use diem_logger::info;
 use diem_network_address::NetworkAddress;
 use futures::SinkExt;
-use netcore::transport::ConnectionOrigin;
 use rand::rngs::StdRng;
 use std::io;
 use tokio::runtime::Runtime;
@@ -124,12 +124,9 @@ async fn send_new_peer_await_delivery(
     notif_peer_id: PeerId,
     address: NetworkAddress,
 ) {
-    let notif = peer_manager::ConnectionNotification::NewPeer(
-        notif_peer_id,
-        address,
-        ConnectionOrigin::Inbound,
-        NetworkContext::mock(),
-    );
+    let mut metadata = ConnectionMetadata::mock(notif_peer_id);
+    metadata.addr = address;
+    let notif = peer_manager::ConnectionNotification::NewPeer(metadata, NetworkContext::mock());
     send_notification_await_delivery(connection_notifs_tx, peer_id, notif).await;
 }
 
@@ -140,12 +137,10 @@ async fn send_lost_peer_await_delivery(
     address: NetworkAddress,
     reason: DisconnectReason,
 ) {
-    let notif = peer_manager::ConnectionNotification::LostPeer(
-        notif_peer_id,
-        address,
-        ConnectionOrigin::Inbound,
-        reason,
-    );
+    let mut metadata = ConnectionMetadata::mock(notif_peer_id);
+    metadata.addr = address;
+    let notif =
+        peer_manager::ConnectionNotification::LostPeer(metadata, NetworkContext::mock(), reason);
     send_notification_await_delivery(connection_notifs_tx, peer_id, notif).await;
 }
 

--- a/network/src/peer_manager/tests.rs
+++ b/network/src/peer_manager/tests.rs
@@ -588,10 +588,7 @@ fn test_dial_disconnect() {
 
         // Expect NewPeer notification from PeerManager.
         let conn_notif = conn_status_rx.next().await.unwrap();
-        assert!(matches!(
-            conn_notif,
-            ConnectionNotification::NewPeer(_, _, _, _)
-        ));
+        assert!(matches!(conn_notif, ConnectionNotification::NewPeer(_, _)));
 
         // Send DisconnectPeer request to PeerManager.
         let (disconnect_resp_tx, disconnect_resp_rx) = oneshot::channel();
@@ -621,7 +618,7 @@ fn test_dial_disconnect() {
         let conn_notif = conn_status_rx.next().await.unwrap();
         assert!(matches!(
             conn_notif,
-            ConnectionNotification::LostPeer(_, _, _, _)
+            ConnectionNotification::LostPeer(_, _, _)
         ));
 
         // Sender of disconnect request should receive acknowledgement once connection is closed.

--- a/network/src/protocols/health_checker/test.rs
+++ b/network/src/protocols/health_checker/test.rs
@@ -10,14 +10,12 @@ use crate::{
         network::{NewNetworkEvents, NewNetworkSender},
         rpc::InboundRpcRequest,
     },
+    transport::ConnectionMetadata,
     ProtocolId,
 };
 use channel::{diem_channel, message_queues::QueueStyle};
 use diem_config::{config::RoleType, network_id::NetworkId};
-use diem_network_address::NetworkAddress;
 use futures::sink::SinkExt;
-use netcore::transport::ConnectionOrigin;
-use std::str::FromStr;
 use tokio::runtime::Runtime;
 
 const PING_TIMEOUT: Duration = Duration::from_millis(500);
@@ -176,9 +174,7 @@ async fn send_new_peer_notification(
 ) {
     let (delivered_tx, delivered_rx) = oneshot::channel();
     let notif = peer_manager::ConnectionNotification::NewPeer(
-        peer_id,
-        NetworkAddress::from_str("/ip6/::1/tcp/8081").unwrap(),
-        ConnectionOrigin::Inbound,
+        ConnectionMetadata::mock(peer_id),
         NetworkContext::mock(),
     );
     connection_notifs_tx

--- a/network/src/protocols/network/mod.rs
+++ b/network/src/protocols/network/mod.rs
@@ -175,11 +175,11 @@ fn peer_mgr_notif_to_event<TMessage: Message>(
 
 fn control_msg_to_event<TMessage>(notif: ConnectionNotification) -> Event<TMessage> {
     match notif {
-        ConnectionNotification::NewPeer(peer_id, _addr, origin, _context) => {
-            Event::NewPeer(peer_id, origin)
+        ConnectionNotification::NewPeer(metadata, _context) => {
+            Event::NewPeer(metadata.remote_peer_id, metadata.origin)
         }
-        ConnectionNotification::LostPeer(peer_id, _addr, origin, _reason) => {
-            Event::LostPeer(peer_id, origin)
+        ConnectionNotification::LostPeer(metadata, _context, _reason) => {
+            Event::LostPeer(metadata.remote_peer_id, metadata.origin)
         }
     }
 }

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -37,6 +37,7 @@ use network::{
         direct_send::Message,
         network::{NewNetworkEvents, NewNetworkSender},
     },
+    transport::ConnectionMetadata,
     DisconnectReason, ProtocolId,
 };
 use network_builder::builder::NetworkBuilder;
@@ -427,18 +428,15 @@ impl SynchronizerEnv {
         direction: ConnectionOrigin,
     ) {
         let sender_id = self.get_peer_network_id(sender);
+        let mut metadata = ConnectionMetadata::mock(sender_id);
+        metadata.origin = direction;
+
         let notif = if new_peer {
-            ConnectionNotification::NewPeer(
-                sender_id,
-                NetworkAddress::mock(),
-                direction,
-                NetworkContext::mock(),
-            )
+            ConnectionNotification::NewPeer(metadata, NetworkContext::mock())
         } else {
             ConnectionNotification::LostPeer(
-                sender_id,
-                NetworkAddress::mock(),
-                direction,
+                metadata,
+                NetworkContext::mock(),
                 DisconnectReason::ConnectionLost,
             )
         };


### PR DESCRIPTION
When a new connection is formed, there is a lot of information available
and rather than just expose what we need for now, let's expose all that
information and let the recipients take what they need.

1. We have already extended the data here once if not twice
2. We have another requirement to extend it to include trusted peer / role

The interesting thing is that state sync and mempool already translate
these events into yet another event so there will need to be ensuing PRs
to address that.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/developers.libra.org, and link to your PR here.)
