### PR TITLE
[ci] check remote for target base branch

### DIFF
--- a/.circleci/get_pr_info.sh
+++ b/.circleci/get_pr_info.sh
@@ -120,7 +120,7 @@ if [[ -n ${PR_NUMBER} ]]; then
   fi
 
   #if we have a branch name, and the exact branch exists.
-  if [[ -n "$PR_BASE_BRANCH" ]] && [[ $(git branch -l --no-color | tr -d '*' | tr -d ' ' | grep -c '^'"$PR_BASE_BRANCH"'$') == 1 ]]; then
+  if [[ -n "$PR_BASE_BRANCH" ]] && [[ $(git branch -r --no-color | tr -d '*' | tr -d ' ' | grep -c '^origin/'"$PR_BASE_BRANCH"'$') == 1 ]]; then
     BASE_GITHASH=$(git merge-base HEAD origin/"$PR_BASE_BRANCH")
     TARGET_BRANCH="$PR_BASE_BRANCH"
   fi


### PR DESCRIPTION
## Motivation
CI may not pull the base branch consistently. 

## Test Plan
CI + canary fc57d76 in https://app.circleci.com/pipelines/github/diem/diem/37096/workflows/927b9918-7e13-4067-93d7-d0f92d2b6d5e/jobs/277166