### PR TITLE
[storagte] state pruner: offload the first seek to the worker thread

### DIFF
--- a/storage/diemdb/src/pruner/test.rs
+++ b/storage/diemdb/src/pruner/test.rs
@@ -149,7 +149,7 @@ fn test_worker_quit_eagerly() {
             .unwrap();
         command_sender.send(Command::Quit).unwrap();
         // Worker quits immediately although `Command::Quit` is not the first command sent.
-        worker.work_loop();
+        worker.work();
         verify_state_in_store(state_store, address, Some(&value0), 0);
         verify_state_in_store(state_store, address, Some(&value1), 1);
         verify_state_in_store(state_store, address, Some(&value2), 2);


### PR DESCRIPTION
## Motivation

PR #6803 avoided repeatedly seeking to the beginning in the stale node index, which was costly, by doing it beforehand and only once at construction time. However that one time yet costly call sit in the critical path of the node start up, which can result in a slow node start if the pruning window was large.

This moves the initial seek to the work thread.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

existing coverage.

## Related PRs

#6803 