### PR TITLE
[move prover] add VC for functions modifying target resources

### DIFF
--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -1581,9 +1581,13 @@ impl<'env> SpecTranslator<'env> {
             self.global_env()
                 .get_global_invariant(*id)
                 .map(|inv| {
-                    inv.mem_usage
-                        .iter()
-                        .any(|used| !self.global_env().get_module(used.module_id).is_dependency())
+                    !self
+                        .global_env()
+                        .get_module(inv.declaring_module)
+                        .is_dependency()
+                        || inv.mem_usage.iter().any(|used| {
+                            !self.global_env().get_module(used.module_id).is_dependency()
+                        })
                 })
                 .unwrap_or(true)
         };

--- a/language/move-prover/tests/sources/functional/cross_module_invariant.exp
+++ b/language/move-prover/tests/sources/functional/cross_module_invariant.exp
@@ -1,0 +1,64 @@
+Move prover returns: exiting with boogie verification errors
+error: global memory invariant does not hold
+
+    ┌── tests/sources/functional/cross_module_invariant.move:18:9 ───
+    │
+ 18 │         invariant [global] forall addr: address: exists<DiemAccount::Balance<XUS::XUS>>(addr) ==> addr == 0x1;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at ../stdlib/modules/DiemAccount.move:1337:5: add_currency
+    =         account = <redacted>
+    =     at ../stdlib/modules/DiemAccount.move:1339:15: add_currency
+    =     at ../stdlib/modules/Roles.move:228:5: can_hold_balance
+    =         account = <redacted>,
+    =         result = <redacted>
+    =     at ../stdlib/modules/Roles.move:214:5: has_parent_VASP_role
+    =         account = <redacted>,
+    =         result = <redacted>
+    =     at ../stdlib/modules/Roles.move:188:5: has_role
+    =         account = <redacted>,
+    =         role_id = <redacted>,
+    =         tmp#$3 = <redacted>,
+    =         result = <redacted>
+    =     at ../stdlib/modules/Roles.move:189:27: has_role
+    =     at ../stdlib/modules/Roles.move:190:8: has_role
+    =     at ../stdlib/modules/Roles.move:191:15: has_role
+    =     at ../stdlib/modules/Roles.move:190:8: has_role
+    =     at ../stdlib/modules/Roles.move:188:9: has_role
+    =     at ../stdlib/modules/Roles.move:215:9: has_parent_VASP_role
+    =     at ../stdlib/modules/Roles.move:214:16: has_parent_VASP_role
+    =     at ../stdlib/modules/Roles.move:232:9: can_hold_balance
+    =     at ../stdlib/modules/Roles.move:218:5: has_child_VASP_role
+    =         account = <redacted>,
+    =         result = <redacted>
+    =     at ../stdlib/modules/Roles.move:188:5: has_role
+    =     at ../stdlib/modules/Roles.move:189:27: has_role
+    =     at ../stdlib/modules/Roles.move:190:8: has_role
+    =     at ../stdlib/modules/Roles.move:191:15: has_role
+    =     at ../stdlib/modules/Roles.move:190:8: has_role
+    =     at ../stdlib/modules/Roles.move:188:9: has_role
+    =     at ../stdlib/modules/Roles.move:219:9: has_child_VASP_role
+    =     at ../stdlib/modules/Roles.move:218:16: has_child_VASP_role
+    =     at ../stdlib/modules/Roles.move:232:9: can_hold_balance
+    =     at ../stdlib/modules/Roles.move:202:5: has_designated_dealer_role
+    =         account = <redacted>,
+    =         result = <redacted>
+    =     at ../stdlib/modules/Roles.move:188:5: has_role
+    =     at ../stdlib/modules/Roles.move:189:27: has_role
+    =     at ../stdlib/modules/Roles.move:190:8: has_role
+    =     at ../stdlib/modules/Roles.move:191:15: has_role
+    =     at ../stdlib/modules/Roles.move:190:8: has_role
+    =     at ../stdlib/modules/Roles.move:188:9: has_role
+    =     at ../stdlib/modules/Roles.move:203:9: has_designated_dealer_role
+    =     at ../stdlib/modules/Roles.move:202:16: has_designated_dealer_role
+    =     at ../stdlib/modules/Roles.move:232:9: can_hold_balance
+    =     at ../stdlib/modules/DiemAccount.move:1342:20: add_currency
+    =     at ../stdlib/modules/DiemAccount.move:1343:21: add_currency
+    =     at ../stdlib/modules/DiemAccount.move:1341:9: add_currency
+    =     at ../stdlib/modules/DiemAccount.move:1346:28: add_currency
+    =     at ../stdlib/modules/DiemAccount.move:1347:55: add_currency
+    =     at ../stdlib/modules/Diem.move:723:5: zero
+    =         result = <redacted>
+    =     at ../stdlib/modules/Diem.move:1135:16: assert_is_currency
+    =     at ../stdlib/modules/Diem.move:725:9: zero
+    =     at ../stdlib/modules/DiemAccount.move:1349:54: add_currency

--- a/language/move-prover/tests/sources/functional/cross_module_invariant.move
+++ b/language/move-prover/tests/sources/functional/cross_module_invariant.move
@@ -1,0 +1,20 @@
+module TestCrossModuleInv {
+    use 0x1::DiemAccount;
+    use 0x1::XUS;
+    use 0x1::Signer;
+
+    public fun add_XUS_balance(account: &signer) {
+        assert(Signer::address_of(account) == 0x1, 1);
+        DiemAccount::add_currency<XUS::XUS>(account);
+    }
+
+    spec module {
+        /// When we verify module `TestCrossModuleInv`, although the code in this
+        /// module doesn't violate the invariant, prover would still generate
+        /// an error saying the invariant is violated at `DiemAccount::add_currency`.
+        /// `DiemAccount::add_currency` is verified even when `DiemAccount` is not
+        /// a target because `DiemAccount::add_currency` directly modifies Balance
+        /// resource, which is mentioned in the invariant here.
+        invariant [global] forall addr: address: exists<DiemAccount::Balance<XUS::XUS>>(addr) ==> addr == 0x1;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR is the second step of the implementation of the new invariant verification approach. In this PR, we filled in the verification analysis where, in addition to functions in target modules, a verification condition is added for all functions in non-target modules if they directly modify target resources(resources mentioned in target invariants).

A [test file](https://github.com/diem/diem/compare/master...emmazzz:inv2?expand=1#diff-6f883142cd37eba1fe67939369af66f7ff40bd6d7f357f26538a2e83c4216800) is added to show the difference made by this change. With the previous approach the test module would pass the prover with no errors, but with the current approach prover will generate an error since a function in the dependency module violates the invariant. See more details in the comments in the test.

The verification has to be turned off for functions `AccountLimits::publish_unrestricted_limits`, `DiemConfig::set`, `DiemConfig::set_with_capability_and_reconfigure` and `DiemConfig::publish_new_config_and_get_capability`, which are all generic functions violating invariants about specific types of resources. They will be dealt with and the verification will be turned back on when later features become available. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test

## Related PRs

#7009 
