### PR TITLE
[writeset-builder]  Implement a command to output WriteSetPayload

### DIFF
--- a/language/diem-tools/writeset-transaction-generator/src/lib.rs
+++ b/language/diem-tools/writeset-transaction-generator/src/lib.rs
@@ -5,7 +5,7 @@ mod admin_script_builder;
 mod writeset_builder;
 
 pub use admin_script_builder::{
-    encode_custom_script, encode_halt_network_transaction, encode_remove_validators_transaction,
+    encode_custom_script, encode_halt_network_payload, encode_remove_validators_payload,
 };
 
 pub use writeset_builder::{build_changeset, build_stdlib_upgrade_changeset, GenesisSession};


### PR DESCRIPTION
…he stdlib.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Fixed a number of issues around the writeset-builder tool:
1.  Added a flag to output either the WriteSetPayload(required by AOS writeset portal) or the Transaction (required by the db-bootstrapper tool)
2. Fixed the json argument for building custom script.

There will be more follow up items. The most important TODO item is to hook the tool up with real state and generate the release patch for the updateed stdlib.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Make sure `buid_custom_script` works with `remove_validators.move` via following command:
`cargo run -- -o out.bin build-custom-script remove_validators.move '{"addresses": ["00000000000000000000000000000000"]}'`
Fixed existing tests.   
