### PR TITLE
Cherry-pick PR #7039 into release-1.1: Add constructor and getters for GeneralMetadataV0 as inner fields are private

### DIFF
--- a/types/src/transaction/metadata.rs
+++ b/types/src/transaction/metadata.rs
@@ -42,6 +42,32 @@ pub struct GeneralMetadataV0 {
     referenced_event: Option<u64>,
 }
 
+impl GeneralMetadataV0 {
+    pub fn new(
+        to_subaddress: Option<Vec<u8>>,
+        from_subaddress: Option<Vec<u8>>,
+        referenced_event: Option<u64>,
+    ) -> Self {
+        GeneralMetadataV0 {
+            to_subaddress,
+            from_subaddress,
+            referenced_event,
+        }
+    }
+
+    pub fn to_subaddress(&self) -> &Option<Vec<u8>> {
+        &self.to_subaddress
+    }
+
+    pub fn from_subaddress(&self) -> &Option<Vec<u8>> {
+        &self.from_subaddress
+    }
+
+    pub fn referenced_event(&self) -> &Option<u64> {
+        &self.referenced_event
+    }
+}
+
 /// List of supported transaction metadata format versions for transactions
 /// subject to travel rule
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/types/src/unit_tests/transaction_test.rs
+++ b/types/src/unit_tests/transaction_test.rs
@@ -6,8 +6,8 @@ use crate::{
     account_config::XUS_NAME,
     chain_id::ChainId,
     transaction::{
-        GovernanceRole, RawTransaction, Script, SignedTransaction, Transaction, TransactionInfo,
-        TransactionListWithProof, TransactionPayload, TransactionWithProof,
+        metadata, GovernanceRole, RawTransaction, Script, SignedTransaction, Transaction,
+        TransactionInfo, TransactionListWithProof, TransactionPayload, TransactionWithProof,
     },
 };
 use bcs::test_helpers::assert_canonical_encode_decode;
@@ -52,6 +52,33 @@ fn test_role_ordering() {
 
     assert!(Validator.priority() == ValidatorOperator.priority());
     assert!(Validator.priority() == DesignatedDealer.priority());
+}
+
+#[test]
+fn test_general_metadata_constructor_and_setters() {
+    let raw_to_subaddr = b"to_subaddr".to_vec();
+    let to_subaddress = Some(raw_to_subaddr.clone());
+    let raw_from_subaddr = b"from_subaddr".to_vec();
+    let from_subaddress = Some(raw_from_subaddr.clone());
+    let referenced_event = Some(1337);
+    let general_metadata =
+        metadata::GeneralMetadataV0::new(to_subaddress, from_subaddress, referenced_event);
+
+    assert!(
+        general_metadata
+            .to_subaddress()
+            .as_ref()
+            .expect("incorrect to_subaddress")
+            == &raw_to_subaddr
+    );
+    assert!(
+        general_metadata
+            .from_subaddress()
+            .as_ref()
+            .expect("incorrect from suabbdress")
+            == &raw_from_subaddr
+    );
+    assert!(general_metadata.referenced_event() == &referenced_event);
 }
 
 proptest! {


### PR DESCRIPTION
- Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
Without this change, rust clients are unable to create a `GeneralMetadataV0` struct, which is critical for subaddressing within transactions. This should not be a breaking change (only adding a constructor).

- Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
Added unit test on constructor to verify its functionality and existing tests were not affected. 

- Why we must have it for V1 launch.
Enable rust clients who vendor this code to create `GeneralMetadataV0`

- What workarounds and alternative we have if we do not push the PR.
Rust clients can fork diem's release branch and edit this file themselves, or use master branch but risk future breaking changes

> ## Motivation
> I was following along with the DIP-4 source snippets and realized that the samples as-written do not work because the inner fields for the metadata structs are private. From discussion with @sblackshear and @n4ss, we agreed that a constructor for this data (and perhaps we should also consider the same for Travel Rule metadata, etc) would be useful. An alternative that I'm fine with is to make the fields `pub`, but I defer to the maintainers if they have a preference :) 
> 
> ### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?
> 
> ✅ 
> 
> ## Test Plan
> Added simple unit test, and ran:
> `cargo x lint && cargo xfmt && cargo xclippy --all-targets`
> 

            
cc @riyazdf