### PR TITLE
[move source language] Add default aliases for standard library

### DIFF
--- a/language/move-lang/tests/move_check/expansion/diem_prelude.move
+++ b/language/move-lang/tests/move_check/expansion/diem_prelude.move
@@ -1,0 +1,21 @@
+address 0x42 {
+module M {
+    struct S {
+        f1: Option<u64>,
+        f2: Option::Option<u64>,
+    }
+
+    fun ex(
+        _a1: Option<u64>,
+        _a2: Option::Option<u64>,
+        s: &signer,
+    ) {
+        Option::none<u64>();
+        Option::some(0);
+        Signer::borrow_address(s);
+        Signer::address_of(s);
+        Vector::empty<u64>();
+        Vector::push_back(&mut Vector::empty(), 0);
+    }
+}
+}

--- a/language/move-lang/tests/move_check/expansion/diem_prelude_errors.exp
+++ b/language/move-lang/tests/move_check/expansion/diem_prelude_errors.exp
@@ -1,0 +1,123 @@
+error: 
+
+    ┌── tests/move_check/expansion/diem_prelude_errors.move:10:17 ───
+    │
+ 10 │             f1: 0,
+    │                 ^ Invalid argument for field 'f1' for '0x42::M::S'
+    ·
+ 10 │             f1: 0,
+    │                 - The type: integer
+    ·
+  4 │         f1: Option<u64>,
+    │             ----------- Is not compatible with: '0x1::Option::Option<u64>'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/diem_prelude_errors.move:16:14 ───
+    │
+ 16 │         _a1: Option<u64, u64>,
+    │              ^^^^^^^^^^^^^^^^ Invalid instantiation of '0x1::Option::Option'. Expected 1 type argument(s) but got 2
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/diem_prelude_errors.move:19:9 ───
+    │
+ 19 │         Option::none<u64>(0);
+    │         ^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::Option::none'. The call expected 0 argument(s) but got 1
+    ·
+ 19 │         Option::none<u64>(0);
+    │                          --- Found 1 argument(s) here
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/diem_prelude_errors.move:20:9 ───
+    │
+ 20 │         Option::some();
+    │         ^^^^^^^^^^^^^^ Invalid call of '0x1::Option::some'. The call expected 1 argument(s) but got 0
+    ·
+ 20 │         Option::some();
+    │                     -- Found 0 argument(s) here
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/diem_prelude_errors.move:20:9 ───
+    │
+ 20 │         Option::some();
+    │         ^^^^^^^^^^^^^^ Cannot ignore resource values. The value must be used
+    │
+
+    ┌── ../stdlib/modules/Option.move:10:19 ───
+    │
+ 40 │     public fun some<Element>(e: Element): Option<Element> {
+    │                                           --------------- The type: '0x1::Option::Option<_>'
+    ·
+ 10 │     struct Option<Element> {
+    │                   ------- Is found to be a non-copyable type here
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/diem_prelude_errors.move:21:9 ───
+    │
+ 21 │         Signer::borrow_address(0x0);
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::Signer::borrow_address'. Invalid argument for parameter 's'
+    ·
+ 21 │         Signer::borrow_address(0x0);
+    │                                --- The type: 'address'
+    │
+
+    ┌── ../stdlib/modules/Signer.move:10:41 ───
+    │
+ 10 │     native public fun borrow_address(s: &signer): &address;
+    │                                         ------- Is not compatible with: '&signer'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/diem_prelude_errors.move:22:9 ───
+    │
+ 22 │         Signer::address_of(0x0);
+    │         ^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::Signer::address_of'. Invalid argument for parameter 's'
+    ·
+ 22 │         Signer::address_of(0x0);
+    │                            --- The type: 'address'
+    │
+
+    ┌── ../stdlib/modules/Signer.move:13:30 ───
+    │
+ 13 │     public fun address_of(s: &signer): address {
+    │                              ------- Is not compatible with: '&signer'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/diem_prelude_errors.move:23:9 ───
+    │
+ 23 │         Vector::empty<u64>(0);
+    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::Vector::empty'. The call expected 0 argument(s) but got 1
+    ·
+ 23 │         Vector::empty<u64>(0);
+    │                           --- Found 1 argument(s) here
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/diem_prelude_errors.move:24:9 ───
+    │
+ 24 │         Vector::push_back(0, 0);
+    │         ^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::Vector::push_back'. Invalid argument for parameter 'v'
+    ·
+ 24 │         Vector::push_back(0, 0);
+    │                           - The type: integer
+    │
+
+    ┌── ../stdlib/modules/Vector.move:29:45 ───
+    │
+ 29 │     native public fun push_back<Element>(v: &mut vector<Element>, e: Element);
+    │                                             -------------------- Is not compatible with: '&mut vector<_>'
+    │
+

--- a/language/move-lang/tests/move_check/expansion/diem_prelude_errors.move
+++ b/language/move-lang/tests/move_check/expansion/diem_prelude_errors.move
@@ -1,0 +1,27 @@
+address 0x42 {
+module M {
+    struct S {
+        f1: Option<u64>,
+        f2: Option::Option<u64>,
+    }
+
+    fun bad_S(): S {
+        S {
+            f1: 0,
+            f2: Option::none(),
+        }
+    }
+
+    fun ex(
+        _a1: Option<u64, u64>,
+        s: &signer,
+    ) {
+        Option::none<u64>(0);
+        Option::some();
+        Signer::borrow_address(0x0);
+        Signer::address_of(0x0);
+        Vector::empty<u64>(0);
+        Vector::push_back(0, 0);
+    }
+}
+}

--- a/language/move-lang/tests/move_check/expansion/diem_prelude_missing_function.exp
+++ b/language/move-lang/tests/move_check/expansion/diem_prelude_missing_function.exp
@@ -1,0 +1,24 @@
+error: 
+
+   ┌── tests/move_check/expansion/diem_prelude_missing_function.move:4:9 ───
+   │
+ 4 │         Option::no();
+   │         ^^^^^^^^^^ Invalid module access. Unbound function 'no' in module '0x1::Option'
+   │
+
+error: 
+
+   ┌── tests/move_check/expansion/diem_prelude_missing_function.move:5:9 ───
+   │
+ 5 │         Signer::no();
+   │         ^^^^^^^^^^ Invalid module access. Unbound function 'no' in module '0x1::Signer'
+   │
+
+error: 
+
+   ┌── tests/move_check/expansion/diem_prelude_missing_function.move:6:9 ───
+   │
+ 6 │         Vector::no();
+   │         ^^^^^^^^^^ Invalid module access. Unbound function 'no' in module '0x1::Vector'
+   │
+

--- a/language/move-lang/tests/move_check/expansion/diem_prelude_missing_function.move
+++ b/language/move-lang/tests/move_check/expansion/diem_prelude_missing_function.move
@@ -1,0 +1,9 @@
+address 0x42 {
+module M {
+    fun ex() {
+        Option::no();
+        Signer::no();
+        Vector::no();
+    }
+}
+}

--- a/language/move-lang/tests/move_check/expansion/diem_prelude_missing_type.exp
+++ b/language/move-lang/tests/move_check/expansion/diem_prelude_missing_type.exp
@@ -1,0 +1,24 @@
+error: 
+
+   ┌── tests/move_check/expansion/diem_prelude_missing_type.move:4:13 ───
+   │
+ 4 │         f1: Option::No,
+   │             ^^^^^^^^^^ Invalid module access. Unbound struct 'No' in module '0x1::Option'
+   │
+
+error: 
+
+   ┌── tests/move_check/expansion/diem_prelude_missing_type.move:5:13 ───
+   │
+ 5 │         f2: Signer::No,
+   │             ^^^^^^^^^^ Invalid module access. Unbound struct 'No' in module '0x1::Signer'
+   │
+
+error: 
+
+   ┌── tests/move_check/expansion/diem_prelude_missing_type.move:6:13 ───
+   │
+ 6 │         f3: Vector::No,
+   │             ^^^^^^^^^^ Invalid module access. Unbound struct 'No' in module '0x1::Vector'
+   │
+

--- a/language/move-lang/tests/move_check/expansion/diem_prelude_missing_type.move
+++ b/language/move-lang/tests/move_check/expansion/diem_prelude_missing_type.move
@@ -1,0 +1,10 @@
+address 0x42 {
+module M {
+    struct S {
+        f1: Option::No,
+        f2: Signer::No,
+        f3: Vector::No,
+    }
+
+}
+}

--- a/language/move-lang/tests/move_check/expansion/diem_prelude_shadow.move
+++ b/language/move-lang/tests/move_check/expansion/diem_prelude_shadow.move
@@ -1,0 +1,21 @@
+address 0x42 {
+    module M {
+        struct Option { f: u64 }
+        public fun ex(): Option {
+            Option { f: 0 }
+        }
+    }
+
+    module N {
+        use 0x42::M as Option;
+        use 0x42::M as Signer;
+        use 0x42::M as Vector;
+
+        fun t() {
+            Option::ex();
+            Signer::ex();
+            Vector::ex();
+        }
+
+    }
+}

--- a/language/stdlib/modules/DiemAccount.move
+++ b/language/stdlib/modules/DiemAccount.move
@@ -19,16 +19,13 @@ module DiemAccount {
     use 0x1::DiemConfig;
     use 0x1::DiemTimestamp;
     use 0x1::DiemTransactionPublishingOption;
-    use 0x1::Signer;
     use 0x1::SlidingNonce;
     use 0x1::TransactionFee;
     use 0x1::ValidatorConfig;
     use 0x1::ValidatorOperatorConfig;
     use 0x1::VASP;
-    use 0x1::Vector;
     use 0x1::DesignatedDealer;
     use 0x1::Diem::{Self, Diem};
-    use 0x1::Option::{Self, Option};
     use 0x1::Roles;
 
     /// An `address` is a Diem Account iff it has a published DiemAccount resource.


### PR DESCRIPTION
- Adds aliases for "standard library" modules
- Adds aliases for standard library types, Option and FixedPoint32
- TODO ideally this should be configurable somehow

## Motivation

It's real annoying to have to write use 0x1::Vector and use 0x1::Signer and use 0x1::Errors everywhere

## Test Plan

- new tests