### PR TITLE
[move-prover] Fix hanging if boogie is not found and print which path was tried.

### DIFF
--- a/language/move-prover/src/boogie_wrapper.rs
+++ b/language/move-prover/src/boogie_wrapper.rs
@@ -123,11 +123,19 @@ impl<'env> BoogieWrapper<'env> {
             // different random seeds cause significant instabilities in verification times.
             // Thus by running multiple instances of Boogie with different random seeds, we can
             // potentially alleviate the instability.
-            let (seed, output) = ProverTaskRunner::run_tasks(
+            let (seed, output_res) = ProverTaskRunner::run_tasks(
                 task,
                 self.options.prover.num_instances,
                 self.options.prover.sequential_task,
             );
+            let output = match output_res {
+                Err(err) => panic!(
+                    "cannot execute boogie `{}`: {}",
+                    self.options.get_boogie_command("")[0],
+                    err
+                ),
+                Ok(out) => out,
+            };
             if self.options.prover.num_instances > 1 {
                 debug!("Boogie instance with seed {} finished first", seed);
             }


### PR DESCRIPTION
If the BOOGIE_EXE is not found, the current prover_task_runner hangs. That is because a panicking thread does not terminate the program, but just dies, blocking other threads waiting for it. This PR propagates the error out of the task runner to the caller and panics in the main thread. It also prints the path where the boogie program was looked for.

## Motivation

Better UX

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

manual
## Related PRs

NA
