### PR TITLE
[tools] connect CLI to transaction replay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2237,6 +2237,7 @@ dependencies = [
  "reqwest",
  "scratchpad",
  "storage-interface",
+ "vm",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2179,6 +2179,7 @@ dependencies = [
  "diem-workspace-hack",
  "diemdb",
  "difference",
+ "move-cli",
  "move-core-types",
  "move-lang",
  "move-vm-runtime",

--- a/language/diem-tools/diem-validator-interface/Cargo.toml
+++ b/language/diem-tools/diem-validator-interface/Cargo.toml
@@ -22,4 +22,5 @@ diem-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.
 storage-interface = { path = "../../../storage/storage-interface", version = "0.1.0" }
 scratchpad = { path = "../../../storage/scratchpad", version = "0.1.0" }
 diem-state-view = { path = "../../../storage/state-view", version = "0.1.0" }
+vm = { path = "../../vm", version = "0.1.0" }
 bcs = "0.1.2"

--- a/language/diem-tools/transaction-replay/Cargo.toml
+++ b/language/diem-tools/transaction-replay/Cargo.toml
@@ -19,6 +19,7 @@ diem-validator-interface = { path = "../diem-validator-interface", version = "0.
 diemdb = { path = "../../../storage/diemdb", version = "0.1.0" }
 diem-vm = { path = "../../diem-vm", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0"}
+move-cli = { path = "../../tools/move-cli", version = "0.1.0" }
 move-vm-types = { path = "../../move-vm/types", version = "0.1.0" }
 move-core-types = { path = "../../move-core/types", version = "0.1.0" }
 move-vm-runtime = { path = "../../move-vm/runtime", version = "0.1.0" }

--- a/language/diem-tools/transaction-replay/src/lib.rs
+++ b/language/diem-tools/transaction-replay/src/lib.rs
@@ -25,7 +25,7 @@ use std::{
     convert::TryFrom,
     path::{Path, PathBuf},
 };
-use vm::errors::VMResult;
+use vm::{errors::VMResult, file_format::CompiledModule};
 
 #[cfg(test)]
 mod unit_tests;
@@ -135,6 +135,23 @@ impl DiemDebugger {
             state_view.save_contract_event(event.clone())?
         }
         Ok(())
+    }
+
+    pub fn get_diem_framework_modules_at_version(
+        &self,
+        version: Version,
+        save_write_sets: bool,
+    ) -> Result<Vec<CompiledModule>> {
+        let modules = self
+            .debugger
+            .get_diem_framework_modules_by_version(version)?;
+        if save_write_sets {
+            let state_view = OnDiskStateView::create(&self.build_dir, &self.storage_dir)?;
+            for m in &modules {
+                state_view.save_module(m)?
+            }
+        }
+        Ok(modules)
     }
 
     pub fn annotate_account_state_at_version(

--- a/language/diem-tools/transaction-replay/src/main.rs
+++ b/language/diem-tools/transaction-replay/src/main.rs
@@ -50,6 +50,9 @@ enum Command {
         base_version: Version,
         revision: Version,
     },
+    /// Get the bytecode for all Diem Framework modules at `version`
+    #[structopt(name = "get-modules")]
+    GetModules { version: Version },
     #[structopt(name = "bisect-transaction")]
     BisectTransaction {
         #[structopt(parse(from_os_str))]
@@ -133,6 +136,11 @@ fn main() -> Result<()> {
                 "{}",
                 Changeset::new(&base_annotation, &revision_annotation, "\n")
             );
+        }
+        Command::GetModules { version } => {
+            let modules =
+                debugger.get_diem_framework_modules_at_version(version, opt.save_write_sets)?;
+            println!("Fetched {} modules", modules.len())
         }
         Command::BisectTransaction {
             sender,

--- a/language/tools/move-cli/src/main.rs
+++ b/language/tools/move-cli/src/main.rs
@@ -40,7 +40,7 @@ use structopt::StructOpt;
     about = "CLI frontend for Move compiler and VM",
     rename_all = "kebab-case"
 )]
-struct Move {
+pub struct Move {
     /// Directory storing Move resources, events, and module bytecodes produced by module publishing
     /// and script execution.
     #[structopt(long, default_value = DEFAULT_STORAGE_DIR, global = true)]
@@ -64,7 +64,7 @@ struct Move {
 }
 
 #[derive(StructOpt)]
-enum Command {
+pub enum Command {
     /// Type check and verify the specified script and modules against the modules in `storage`
     #[structopt(name = "check")]
     Check {

--- a/testsuite/smoke-test/src/replay_tooling.rs
+++ b/testsuite/smoke-test/src/replay_tooling.rs
@@ -31,7 +31,7 @@ fn test_replay_tooling() {
         .unwrap();
 
     let replay_result = json_debugger
-        .execute_past_transactions(txn.version, 1)
+        .execute_past_transactions(txn.version, 1, false)
         .unwrap()
         .pop()
         .unwrap();

--- a/types/src/access_path.rs
+++ b/types/src/access_path.rs
@@ -41,7 +41,7 @@ use move_core_types::language_storage::{ModuleId, ResourceKey, StructTag, CODE_T
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
-use std::fmt;
+use std::{convert::TryFrom, fmt};
 
 #[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Ord, PartialOrd)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
@@ -143,5 +143,21 @@ impl From<&ModuleId> for AccessPath {
             address: *id.address(),
             path: id.access_vector(),
         }
+    }
+}
+
+impl TryFrom<&[u8]> for Path {
+    type Error = bcs::Error;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        bcs::from_bytes::<Path>(bytes)
+    }
+}
+
+impl TryFrom<&Vec<u8>> for Path {
+    type Error = bcs::Error;
+
+    fn try_from(bytes: &Vec<u8>) -> Result<Self, Self::Error> {
+        bcs::from_bytes::<Path>(bytes)
     }
 }

--- a/types/src/account_state.rs
+++ b/types/src/account_state.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    access_path::Path,
     account_address::AccountAddress,
     account_config::{
         type_tag_for_currency_code, AccountResource, AccountRole, BalanceResource, ChainIdResource,
@@ -199,6 +200,16 @@ impl AccountState {
 
     pub fn get_resource<T: MoveResource + DeserializeOwned>(&self) -> Result<Option<T>> {
         self.get_resource_impl(&T::struct_tag().access_vector())
+    }
+
+    /// Return an iterator over the module values stored under this account
+    pub fn get_modules(&self) -> impl Iterator<Item = &Vec<u8>> {
+        self.0.iter().filter_map(
+            |(k, v)| match Path::try_from(k).expect("Invalid access path") {
+                Path::Code(_) => Some(v),
+                Path::Resource(_) => None,
+            },
+        )
     }
 }
 

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -738,6 +738,10 @@ impl TransactionOutput {
         }
     }
 
+    pub fn into(self) -> (WriteSet, Vec<ContractEvent>) {
+        (self.write_set, self.events)
+    }
+
     pub fn write_set(&self) -> &WriteSet {
         &self.write_set
     }


### PR DESCRIPTION
Add save_write_sets option to transaction-replay CLI that converts each write set to the on-disk representation that the Move CLI
understands. This makes it easy to get a local mirror of a state of interest, then use the CLI to inspect the state, run `move doctor`,
experiment with running txes on top of the latest state, etc.

## Test Plan

```
cargo run --bin diem-transaction-replay -- --url https://mainnet.diem.com -s replay-transactions 0 1
move view storage/0x00000000000000000000000000000001/modules/XUS.mv 
move doctor
```