### PR TITLE
[language] add vector<address> and vector<u64> for transaction_argument.rs

### DIFF
--- a/language/diem-tools/writeset-transaction-generator/src/writeset_builder.rs
+++ b/language/diem-tools/writeset-transaction-generator/src/writeset_builder.rs
@@ -123,7 +123,7 @@ fn convert_txn_args(args: &[TransactionArgument]) -> Vec<Value> {
             TransactionArgument::Bool(b) => Value::bool(*b),
             TransactionArgument::AddressVector(v) => Value::vector_address(v.clone()),
             TransactionArgument::U8Vector(v) => Value::vector_u8(v.clone()),
-            TransactionArgument::U64Vector(v)=>Value::vector_u64(v.clone()),
+            TransactionArgument::U64Vector(v) => Value::vector_u64(v.clone()),
         })
         .collect()
 }

--- a/language/diem-tools/writeset-transaction-generator/src/writeset_builder.rs
+++ b/language/diem-tools/writeset-transaction-generator/src/writeset_builder.rs
@@ -121,7 +121,9 @@ fn convert_txn_args(args: &[TransactionArgument]) -> Vec<Value> {
             TransactionArgument::U128(i) => Value::u128(*i),
             TransactionArgument::Address(a) => Value::address(*a),
             TransactionArgument::Bool(b) => Value::bool(*b),
+            TransactionArgument::AddressVector(v) => Value::vector_address(v.clone()),
             TransactionArgument::U8Vector(v) => Value::vector_u8(v.clone()),
+            TransactionArgument::U64Vector(v)=>Value::vector_u64(v.clone()),
         })
         .collect()
 }

--- a/language/diem-vm/src/diem_transaction_executor.rs
+++ b/language/diem-vm/src/diem_transaction_executor.rs
@@ -800,7 +800,9 @@ fn convert_txn_args(args: &[TransactionArgument]) -> Vec<Value> {
             TransactionArgument::U128(i) => Value::u128(*i),
             TransactionArgument::Address(a) => Value::address(*a),
             TransactionArgument::Bool(b) => Value::bool(*b),
+            TransactionArgument::AddressVector(v) => Value::vector_address(v.clone()),
             TransactionArgument::U8Vector(v) => Value::vector_u8(v.clone()),
+            TransactionArgument::U64Vector(v)=>Value::vector_u64(v.clone()),
         })
         .collect()
 }

--- a/language/diem-vm/src/diem_transaction_executor.rs
+++ b/language/diem-vm/src/diem_transaction_executor.rs
@@ -802,7 +802,7 @@ fn convert_txn_args(args: &[TransactionArgument]) -> Vec<Value> {
             TransactionArgument::Bool(b) => Value::bool(*b),
             TransactionArgument::AddressVector(v) => Value::vector_address(v.clone()),
             TransactionArgument::U8Vector(v) => Value::vector_u8(v.clone()),
-            TransactionArgument::U64Vector(v)=>Value::vector_u64(v.clone()),
+            TransactionArgument::U64Vector(v) => Value::vector_u64(v.clone()),
         })
         .collect()
 }

--- a/language/move-core/types/src/transaction_argument.rs
+++ b/language/move-core/types/src/transaction_argument.rs
@@ -12,6 +12,8 @@ pub enum TransactionArgument {
     U128(u128),
     Address(AccountAddress),
     U8Vector(#[serde(with = "serde_bytes")] Vec<u8>),
+    U64Vector(Vec<u64>),
+    AddressVector(Vec<AccountAddress>),
     Bool(bool),
 }
 
@@ -25,7 +27,9 @@ impl fmt::Debug for TransactionArgument {
             TransactionArgument::Address(address) => write!(f, "{{ADDRESS: {:?}}}", address),
             TransactionArgument::U8Vector(vector) => {
                 write!(f, "{{U8Vector: 0x{}}}", hex::encode(vector))
-            }
+            },
+            TransactionArgument::U64Vector(vector) => write!(f, "{{U64Vector: {:?}}}", vector),
+            TransactionArgument::AddressVector(vector) => write!(f, "{{AddressVector: {:?}}}", vector),
         }
     }
 }

--- a/language/move-core/types/src/transaction_argument.rs
+++ b/language/move-core/types/src/transaction_argument.rs
@@ -27,9 +27,11 @@ impl fmt::Debug for TransactionArgument {
             TransactionArgument::Address(address) => write!(f, "{{ADDRESS: {:?}}}", address),
             TransactionArgument::U8Vector(vector) => {
                 write!(f, "{{U8Vector: 0x{}}}", hex::encode(vector))
-            },
+            }
             TransactionArgument::U64Vector(vector) => write!(f, "{{U64Vector: {:?}}}", vector),
-            TransactionArgument::AddressVector(vector) => write!(f, "{{AddressVector: {:?}}}", vector),
+            TransactionArgument::AddressVector(vector) => {
+                write!(f, "{{AddressVector: {:?}}}", vector)
+            }
         }
     }
 }

--- a/language/tools/move-cli/src/main.rs
+++ b/language/tools/move-cli/src/main.rs
@@ -449,7 +449,9 @@ fn run(
             TransactionArgument::U128(i) => Value::u128(*i),
             TransactionArgument::Address(a) => Value::address(*a),
             TransactionArgument::Bool(b) => Value::bool(*b),
+            TransactionArgument::AddressVector(v) => Value::vector_address(v.clone()),
             TransactionArgument::U8Vector(v) => Value::vector_u8(v.clone()),
+            TransactionArgument::U64Vector(v)=>Value::vector_u64(v.clone()),
         })
         .collect();
 

--- a/language/tools/move-cli/src/main.rs
+++ b/language/tools/move-cli/src/main.rs
@@ -451,7 +451,7 @@ fn run(
             TransactionArgument::Bool(b) => Value::bool(*b),
             TransactionArgument::AddressVector(v) => Value::vector_address(v.clone()),
             TransactionArgument::U8Vector(v) => Value::vector_u8(v.clone()),
-            TransactionArgument::U64Vector(v)=>Value::vector_u64(v.clone()),
+            TransactionArgument::U64Vector(v) => Value::vector_u64(v.clone()),
         })
         .collect();
 

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -182,7 +182,7 @@ fn convert_txn_args(args: &[TransactionArgument]) -> Vec<Value> {
             TransactionArgument::Bool(b) => Value::bool(*b),
             TransactionArgument::AddressVector(v) => Value::vector_address(v.clone()),
             TransactionArgument::U8Vector(v) => Value::vector_u8(v.clone()),
-            TransactionArgument::U64Vector(v)=>Value::vector_u64(v.clone()),
+            TransactionArgument::U64Vector(v) => Value::vector_u64(v.clone()),
         })
         .collect()
 }

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -180,7 +180,9 @@ fn convert_txn_args(args: &[TransactionArgument]) -> Vec<Value> {
             TransactionArgument::U128(i) => Value::u128(*i),
             TransactionArgument::Address(a) => Value::address(*a),
             TransactionArgument::Bool(b) => Value::bool(*b),
+            TransactionArgument::AddressVector(v) => Value::vector_address(v.clone()),
             TransactionArgument::U8Vector(v) => Value::vector_u8(v.clone()),
+            TransactionArgument::U64Vector(v)=>Value::vector_u64(v.clone()),
         })
         .collect()
 }

--- a/language/transaction-builder/generator/src/common.rs
+++ b/language/transaction-builder/generator/src/common.rs
@@ -30,6 +30,8 @@ fn quote_type_as_format(type_tag: &TypeTag) -> Format {
         Address => Format::TypeName("AccountAddress".into()),
         Vector(type_tag) => match type_tag.as_ref() {
             U8 => Format::Bytes,
+            U64 => Format::Seq(Box::new(Format::U64)),
+            Address => Format::Seq(Box::new(Format::TypeName("AccountAddress".into()))),
             _ => type_not_allowed(type_tag),
         },
 
@@ -83,6 +85,8 @@ pub(crate) fn mangle_type(type_tag: &TypeTag) -> String {
         Address => "address".into(),
         Vector(type_tag) => match type_tag.as_ref() {
             U8 => "u8vector".into(),
+            U64 => "u64vector".into(),
+            Address => "addressvector".into(),
             _ => type_not_allowed(type_tag),
         },
 

--- a/language/transaction-builder/generator/src/rust.rs
+++ b/language/transaction-builder/generator/src/rust.rs
@@ -364,6 +364,8 @@ static SCRIPT_DECODER_MAP: once_cell::sync::Lazy<DecoderMap> = once_cell::sync::
             Address => ("Address", "Some(value)".to_string()),
             Vector(type_tag) => match type_tag.as_ref() {
                 U8 => ("U8Vector", "Some(value)".to_string()),
+                U64 => ("U64Vector", "Some(value)".to_string()),
+                Address => ("AddressVector", "Some(value)".to_string()),
                 _ => common::type_not_allowed(type_tag),
             },
             Struct(_) | Signer => common::type_not_allowed(type_tag),
@@ -448,7 +450,21 @@ fn decode_{}_argument(arg: TransactionArgument) -> Option<{}> {{
                     } else {
                         "Bytes".into()
                     }
-                }
+                },
+                U64 => {
+                    if local_types {
+                        "Vec<u64>".into()
+                    } else{
+                        "U64Vector".into()
+                    }
+                },
+                Address => {
+                    if local_types {
+                        "Vec<AccountAddress>".into()
+                    } else {
+                        "AddressVector".into()
+                    }
+                },
                 _ => common::type_not_allowed(type_tag),
             },
 
@@ -466,6 +482,8 @@ fn decode_{}_argument(arg: TransactionArgument) -> Option<{}> {{
             Address => format!("TransactionArgument::Address({})", name),
             Vector(type_tag) => match type_tag.as_ref() {
                 U8 => format!("TransactionArgument::U8Vector({})", name),
+                U64 => format!("TransactionArgument::U64Vector({})", name),
+                Address => format!("TransactionArgument::AddressVector({})", name),
                 _ => common::type_not_allowed(type_tag),
             },
 

--- a/language/transaction-builder/generator/src/rust.rs
+++ b/language/transaction-builder/generator/src/rust.rs
@@ -450,21 +450,21 @@ fn decode_{}_argument(arg: TransactionArgument) -> Option<{}> {{
                     } else {
                         "Bytes".into()
                     }
-                },
+                }
                 U64 => {
                     if local_types {
                         "Vec<u64>".into()
-                    } else{
+                    } else {
                         "U64Vector".into()
                     }
-                },
+                }
                 Address => {
                     if local_types {
                         "Vec<AccountAddress>".into()
                     } else {
                         "AddressVector".into()
                     }
-                },
+                }
                 _ => common::type_not_allowed(type_tag),
             },
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Currently, the TransactionArgument/move script don't have `vector<address>` and `vector<64>` as its input types; However, there are numbers of use cases that need input a sequence of address and numbers. such as Airdrop, One-To-Many transfer(multi-send). So I add address and u64 implementations in TransactionArgument and related places.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

1, add test script in `language/stdlib/transaction_scripts`
```
script {
    use 0x1::Signer;
    fun test_hello<CoinType>(
        account: &signer,
        _designated_dealer_address: vector<address>,
        _mint_amount: vector<u64>,
        _tier_index: u64
    ) {
        assert(Signer::borrow_address(account)== &0x0, 12)
    }
}
```

2, run `cargo run -p stdlib` 
3. it should work if no error raised.
4. Here we can see the result from stdlib generation:
```
pub fn encode_test_hello_script(
    coin_type: TypeTag,
    _designated_dealer_address: Vec<AccountAddress>,
    _mint_amount: Vec<u64>,
    _tier_index: u64,
) -> Script {
    Script::new(
        TEST_HELLO_CODE.to_vec(),
        vec![coin_type],
        vec![
            TransactionArgument::AddressVector(_designated_dealer_address),
            TransactionArgument::U64Vector(_mint_amount),
            TransactionArgument::U64(_tier_index),
        ],
    )
}
```
5, Here is the result of `cargo x lint && cargo xfmt && cargo xclippy --all-targets`
```
    Finished dev [unoptimized + debuginfo] target(s) in 5m 03s
        INFO [11:18:50.759] - Completed in 306250ms: "cargo" "clippy" "--all-targets" "--workspace" "--" "-D" "warnings" "-A" "clippy::unit_arg" "-A" "clippy::mutable_key_type" "-A" "clippy::eval-order-dependence" "-A" "clippy::new-without-default" "-A" "clippy::rc_buffer" "-W" "clippy::wildcard_dependencies"

```
all tests passed

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/developers.libra.org, and link to your PR here.)
