### PR TITLE
Upgrade enum_dispatch package to v0.3.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2601,9 +2601,9 @@ dependencies = [
 
 [[package]]
 name = "enum_dispatch"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b748aeb1b8c58d317739aa3171a2752ca3e76b8077c13dc748f327aebc0a72"
+checksum = "8946e241a7774d5327d92749c50806f275f57d031d2229ecbfd65469a8ad338e"
 dependencies = [
  "once_cell",
  "proc-macro2 1.0.24",

--- a/common/time-service/Cargo.toml
+++ b/common/time-service/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-enum_dispatch = "0.3.4"
+enum_dispatch = "0.3.5"
 futures = "0.3.8"
 pin-project = "1.0.3"
 thiserror = "1.0.23"

--- a/secure/storage/Cargo.toml
+++ b/secure/storage/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 base64 = "0.13.0"
 chrono = "0.4.19"
-enum_dispatch = "0.3.4"
+enum_dispatch = "0.3.5"
 rand = "0.7.3"
 serde = { version = "1.0.117", features = ["rc"], default-features = false }
 serde_json = "1.0.61"


### PR DESCRIPTION
enum_dispatch v0.3.4 is no longer compiling after an upgrade of its syn dependency.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/developers.libra.org, and link to your PR here.)
