### PR TITLE
[secure-storage] support github branches

### DIFF
--- a/config/management/src/secure_backend.rs
+++ b/config/management/src/secure_backend.rs
@@ -85,6 +85,7 @@ impl TryInto<config::SecureBackend> for SecureBackend {
                     .parameters
                     .remove("repository")
                     .ok_or_else(|| Error::BackendParsingError("missing repository".into()))?;
+                let branch = self.parameters.remove("branch");
                 let token = self
                     .parameters
                     .remove("token")
@@ -93,6 +94,7 @@ impl TryInto<config::SecureBackend> for SecureBackend {
                     namespace: self.parameters.remove("namespace"),
                     repository_owner,
                     repository,
+                    branch,
                     token: Token::FromDisk(PathBuf::from(token)),
                 })
             }
@@ -147,6 +149,7 @@ pair: "k0=v0;k1=v1;...".  The current supported formats are:
         an optional namespace: "namespace=NAMESPACE"
         an optional server certificate: "ca_certificate=PATH_TO_CERT"
     GitHub: "backend=github;repository_owner=REPOSITORY_OWNER;repository=REPOSITORY;token=PATH_TO_TOKEN"
+        an optional branch: "branch=BRANCH", defaults to master
         an optional namespace: "namespace=NAMESPACE"
     InMemory: "backend=memory"
     OnDisk: "backend=disk;path=LOCAL_PATH"
@@ -211,7 +214,14 @@ mod tests {
         );
         storage(&github).unwrap();
 
+        let github = format!(
+            "backend=github;repository_owner=diem;repository=diem;branch=genesis;token={};namespace=test",
+            path_str
+        );
+        storage(&github).unwrap();
+
         let github = "backend=github";
+
         storage(github).unwrap_err();
     }
 

--- a/config/src/config/secure_backend_config.rs
+++ b/config/src/config/secure_backend_config.rs
@@ -24,6 +24,8 @@ pub struct GitHubConfig {
     pub repository_owner: String,
     /// The repository where storage will mount
     pub repository: String,
+    /// The branch containing storage, defaults to master
+    pub branch: Option<String>,
     /// The authorization token for accessing the repository
     pub token: Token,
     /// A namespace is an optional portion of the path to a key stored within GitHubConfig. For
@@ -146,6 +148,11 @@ impl From<&SecureBackend> for Storage {
                 let storage = Storage::from(GitHubStorage::new(
                     config.repository_owner.clone(),
                     config.repository.clone(),
+                    config
+                        .branch
+                        .as_ref()
+                        .cloned()
+                        .unwrap_or_else(|| "master".to_string()),
                     config.token.read_token().expect("Unable to read token"),
                 ));
                 if let Some(namespace) = &config.namespace {

--- a/secure/storage/src/error.rs
+++ b/secure/storage/src/error.rs
@@ -67,7 +67,7 @@ impl From<diem_github_client::Error> for Error {
     fn from(error: diem_github_client::Error) -> Self {
         match error {
             diem_github_client::Error::NotFound(key) => Self::KeyNotSet(key),
-            diem_github_client::Error::HttpError(403, _) => Self::PermissionDenied,
+            diem_github_client::Error::HttpError(403, _, _) => Self::PermissionDenied,
             _ => Self::InternalError(format!("{}", error)),
         }
     }

--- a/secure/storage/src/github.rs
+++ b/secure/storage/src/github.rs
@@ -14,9 +14,9 @@ pub struct GitHubStorage {
 }
 
 impl GitHubStorage {
-    pub fn new(owner: String, repository: String, token: String) -> Self {
+    pub fn new(owner: String, repository: String, branch: String, token: String) -> Self {
         Self {
-            client: Client::new(owner, repository, token),
+            client: Client::new(owner, repository, branch, token),
             time_service: RealTimeService::new(),
         }
     }

--- a/secure/storage/src/tests/github.rs
+++ b/secure/storage/src/tests/github.rs
@@ -5,6 +5,8 @@ use crate::{tests::suite, GitHubStorage, Storage};
 
 const OWNER: &str = "OWNER";
 const REPOSITORY: &str = "REPOSITORY";
+// This framework will not create branches, it must already exist!
+const BRANCH: &str = "BRANCH";
 const TOKEN: &str = "TOKEN";
 
 // These tests must be run in series via: `cargo xtest -- --ignored --test-threads=1`
@@ -16,6 +18,7 @@ fn github_storage() {
     let mut storage = Storage::from(GitHubStorage::new(
         OWNER.into(),
         REPOSITORY.into(),
+        BRANCH.into(),
         TOKEN.into(),
     ));
     suite::execute_all_storage_tests(&mut storage);

--- a/secure/storage/src/tests/suite.rs
+++ b/secure/storage/src/tests/suite.rs
@@ -41,6 +41,7 @@ const CRYPTO_NAME: &str = "Test_Key_Name";
 
 /// Executes all storage tests on a given storage backend.
 pub fn execute_all_storage_tests(storage: &mut Storage) {
+    storage.reset_and_clear().unwrap();
     for test in STORAGE_TESTS.iter() {
         test(storage);
         storage.reset_and_clear().unwrap();


### PR DESCRIPTION
* add branch support which is different for get versus post
* moved the storage reset on tests to be the first operation rather than
  only after tests to mitigate cases where storage is dirty
* improved error handling on ureq