### PR TITLE
[Dependabot] Disable transitives

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     allow:
       # The undocumented default is to open prs for only direct dependencies.
-      - dependency-type: all
+      - dependency-type: direct
     schedule:
       interval: "daily"
     labels:


### PR DESCRIPTION
## Motivation

Given that dependabot transitive prs just clog the CI pipeline without offering any substantial benefit to CI (unless devs mistakenly code against the transitive dep, or devs of the dep code against internals of a transitive dep) lets turn off transitive prs from dependabot for crates.

Sec reviews can still occur in or out of band for the deps prior to release.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

CI

## Related PRs

None
