### PR TITLE
[x] add initial support for automatic workspace-hack management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +230,17 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.8",
  "syn 1.0.60",
+]
+
+[[package]]
+name = "atomicwrites"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a2baf2feb820299c53c7ad1cc4f5914a220a1cb76d7ce321d2522a94b54651f"
+dependencies = [
+ "nix 0.14.1",
+ "tempdir",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2355,22 +2375,52 @@ dependencies = [
 name = "diem-workspace-hack"
 version = "0.1.0"
 dependencies = [
+ "bstr",
  "byteorder",
  "bytes 1.0.1",
  "cc",
  "chrono",
+ "clap",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils 0.8.0",
+ "either",
+ "fail",
+ "futures 0.3.12",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-util",
+ "hyper",
  "itertools 0.10.0",
  "itoa",
+ "libc",
  "log",
  "memchr",
  "num-integer",
  "num-traits",
  "once_cell",
  "petgraph",
+ "proc-macro2 0.4.30",
+ "prost",
+ "quote 0.6.13",
+ "rand 0.7.3",
+ "regex",
+ "regex-syntax",
+ "reqwest",
+ "rusty-fork",
  "serde",
- "sha-1 0.9.3",
+ "serde_json",
+ "standback",
  "subtle",
+ "syn 0.15.44",
  "syn 1.0.60",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "warp",
+ "zeroize",
 ]
 
 [[package]]
@@ -2482,6 +2532,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d3b0f382a0651ab91518390f16df755c6e2ca11f52a8e06b301fd3f7dfb576c"
 dependencies = [
  "itertools 0.8.2",
+]
+
+[[package]]
+name = "diffy"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1ff48e3f358d3158f88b2c95071f28d136be31d89e5fa843095032a70bff56"
+dependencies = [
+ "ansi_term 0.12.1",
 ]
 
 [[package]]
@@ -3285,6 +3344,23 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-futures",
+]
+
+[[package]]
+name = "hakari"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6df4223056a2e8e6b57232c1ada51cae77744098d62fa7a955f0decfb43b4de2"
+dependencies = [
+ "atomicwrites",
+ "cfg-if 1.0.0",
+ "diffy",
+ "guppy",
+ "pathdiff",
+ "rayon",
+ "serde",
+ "toml",
+ "twox-hash",
 ]
 
 [[package]]
@@ -4538,6 +4614,19 @@ dependencies = [
  "rand 0.7.3",
  "subscription-service",
  "tokio",
+]
+
+[[package]]
+name = "nix"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 0.1.10",
+ "libc",
+ "void",
 ]
 
 [[package]]
@@ -6857,6 +6946,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7366,6 +7465,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "twox-hash"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04f8ab788026715fa63b31960869617cba39117e520eb415b0139543e325ab59"
+dependencies = [
+ "cfg-if 0.1.10",
+ "static_assertions",
+]
+
+[[package]]
 name = "typed-arena"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7583,6 +7692,12 @@ dependencies = [
  "transaction-builder",
  "vm-genesis",
 ]
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wait-timeout"
@@ -7828,6 +7943,7 @@ dependencies = [
  "env_logger 0.8.2",
  "globset",
  "guppy",
+ "hakari",
  "indexmap",
  "indoc",
  "log",
@@ -7848,6 +7964,7 @@ dependencies = [
  "determinator",
  "diem-workspace-hack",
  "guppy",
+ "hakari",
  "hex",
  "indoc",
  "log",
@@ -7863,6 +7980,7 @@ version = "0.1.0"
 dependencies = [
  "diem-workspace-hack",
  "guppy",
+ "hakari",
  "once_cell",
  "serde",
  "toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,13 +655,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
 
 [[package]]
-name = "cargo_metadata"
-version = "0.12.1"
+name = "cargo-platform"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f95cf4bf0dda0ac2e65371ae7215d0dce3c187613a9dbf23aaa9374186f97a"
+checksum = "0226944a63d1bf35a3b5f948dd7c59e263db83695c9e8bffc4037de02e30f1d7"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714a157da7991e23d90686b9524b9e12e0407a108647f52e9328f4b3d51ac7f"
+dependencies = [
+ "cargo-platform",
  "semver 0.11.0",
- "semver-parser 0.10.0",
+ "semver-parser 0.10.2",
  "serde",
  "serde_json",
 ]
@@ -695,9 +705,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3029692edb3cd77a7fb51dbbbdc4b550c958f7b2147cb7691e38b070f96b5d"
+checksum = "cb4f9cf6cb58661f5cdcda0240ab42788e009bd957ba56c1367aa01c7c6fbc05"
 dependencies = [
  "smallvec",
 ]
@@ -1355,13 +1365,13 @@ dependencies = [
 
 [[package]]
 name = "determinator"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc34c72c766278fa177275fc2173e0237899065ba55e7934db753db01518a59"
+checksum = "f67196df4b7b51e340ba1adfc9361414c51321336b59c148d18da7acf8fe7f71"
 dependencies = [
  "globset",
  "guppy",
- "itertools 0.9.0",
+ "itertools 0.10.0",
  "once_cell",
  "petgraph",
  "rayon",
@@ -3224,15 +3234,15 @@ dependencies = [
 
 [[package]]
 name = "guppy"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7302fa4f62b368b384f44d0346e5b3dbc46e1e940db65f094e684e04dbc0656"
+checksum = "63cc63895eaea7ace65b2818019602b5d150556954e25048e5a1b56c0b0da4af"
 dependencies = [
  "cargo_metadata",
  "fixedbitset",
  "guppy-summaries",
  "indexmap",
- "itertools 0.9.0",
+ "itertools 0.10.0",
  "nested",
  "once_cell",
  "pathdiff",
@@ -6094,7 +6104,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
- "semver-parser 0.10.0",
+ "semver-parser 0.10.2",
  "serde",
 ]
 
@@ -6106,12 +6116,11 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "semver-parser"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e012c6c5380fb91897ba7b9261a0f565e624e869d42fe1a1d03fa0d68a083d5"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
 dependencies = [
  "pest",
- "pest_derive",
 ]
 
 [[package]]
@@ -6839,9 +6848,9 @@ checksum = "36474e732d1affd3a6ed582781b3683df3d0563714c59c39591e8ff707cf078e"
 
 [[package]]
 name = "target-spec"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e124d078c7958d618b8322f040d72eccfd02a30e12f050307f5ad3bbcf904e"
+checksum = "956c2aeccd9cc67a543e04559d46aedc8aa9cda15e5884bcfabb8217fd130e2a"
 dependencies = [
  "cfg-expr",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,7 +2375,6 @@ dependencies = [
 name = "diem-workspace-hack"
 version = "0.1.0"
 dependencies = [
- "bstr",
  "byteorder",
  "bytes 1.0.1",
  "cc",
@@ -2406,8 +2405,6 @@ dependencies = [
  "prost",
  "quote 0.6.13",
  "rand 0.7.3",
- "regex",
- "regex-syntax",
  "reqwest",
  "rusty-fork",
  "serde",
@@ -7939,7 +7936,6 @@ dependencies = [
  "chrono",
  "colored-diff",
  "determinator",
- "diem-workspace-hack",
  "env_logger 0.8.2",
  "globset",
  "guppy",
@@ -7962,7 +7958,6 @@ name = "x-core"
 version = "0.1.0"
 dependencies = [
  "determinator",
- "diem-workspace-hack",
  "guppy",
  "hakari",
  "hex",
@@ -7978,7 +7973,6 @@ dependencies = [
 name = "x-lint"
 version = "0.1.0"
 dependencies = [
- "diem-workspace-hack",
  "guppy",
  "hakari",
  "once_cell",

--- a/common/workspace-hack/.gitattributes
+++ b/common/workspace-hack/.gitattributes
@@ -1,0 +1,3 @@
+# Avoid putting conflict markers in the generated Cargo.toml file since it gets in the way of compiling
+# anything.
+Cargo.toml merge=binary

--- a/common/workspace-hack/Cargo.toml
+++ b/common/workspace-hack/Cargo.toml
@@ -9,22 +9,187 @@ license = "Apache-2.0"
 publish = false
 edition = "2018"
 
-[dependencies]
-byteorder = { version = "1.4.2", features = ["i128", "std"] }
-bytes = { version = "1.0.1", features = ["serde", "std"] }
-cc = { version = "1.0.66", features = ["jobserver", "parallel"] }
-chrono = "0.4.19"
-itertools = "0.10.0"
-itoa = "0.4.7"
-log = { version = "0.4.14", features = ["serde", "std"] }
-memchr = { version = "2.3.4", features = ["std", "use_std"] }
-num-integer = { version = "0.1.44", features = ["i128", "std"] }
-num-traits = { version = "0.2.14", features = ["i128", "std"] }
-once_cell = "1.5.2"
-petgraph = { version = "0.5.1", features = ["graphmap", "matrix_graph", "stable_graph"] }
-serde = { version = "1.0.123", features = ["derive", "rc"] }
-sha-1 = { version = "0.9.3", features = ["std"] }
-subtle = { version = "2.4.0", features = ["i128", "std"] }
+### BEGIN HAKARI SECTION
+[target.x86_64-unknown-linux-gnu.dependencies]
+bstr = { version = "0.2.14", features = ["default", "lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
+byteorder = { version = "1.4.2", features = ["default", "i128", "std"] }
+bytes = { version = "1.0.1", features = ["default", "serde", "std"] }
+chrono = { version = "0.4.19", features = ["clock", "default", "libc", "oldtime", "serde", "std", "time", "winapi"] }
+clap = { version = "2.33.3", features = ["ansi_term", "atty", "color", "default", "strsim", "suggestions", "vec_map"] }
+crossbeam-channel = { version = "0.5.0", features = ["crossbeam-utils", "default", "std"] }
+crossbeam-deque = { version = "0.8.0", features = ["crossbeam-epoch", "crossbeam-utils", "default", "std"] }
+crossbeam-utils = { version = "0.8.0", features = ["default", "lazy_static", "std"] }
+either = { version = "1.6.1", features = ["default", "use_std"] }
+fail = { version = "0.4.0", default-features = false, features = ["failpoints"] }
+futures = { version = "0.3.12", features = ["alloc", "async-await", "default", "executor", "futures-executor", "std"] }
+futures-channel = { version = "0.3.12", features = ["alloc", "default", "futures-sink", "sink", "std"] }
+futures-core = { version = "0.3.12", features = ["alloc", "default", "std"] }
+futures-io = { version = "0.3.12", features = ["default", "std"] }
+futures-sink = { version = "0.3.12", features = ["alloc", "default", "std"] }
+futures-util = { version = "0.3.12", features = ["alloc", "async-await", "async-await-macro", "channel", "default", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "proc-macro-hack", "proc-macro-nested", "sink", "slab", "std"] }
+hyper = { version = "0.14.2", features = ["client", "default", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
+itertools = { version = "0.10.0", features = ["default", "use_alloc", "use_std"] }
+itoa = { version = "0.4.7", features = ["default", "std"] }
+libc = { version = "0.2.85", features = ["align", "default", "extra_traits", "std"] }
+log = { version = "0.4.14", default-features = false, features = ["serde", "std"] }
+memchr = { version = "2.3.4", features = ["default", "std", "use_std"] }
+num-integer = { version = "0.1.44", default-features = false, features = ["i128", "std"] }
+num-traits = { version = "0.2.14", features = ["default", "i128", "std"] }
+once_cell = { version = "1.5.2", features = ["alloc", "default", "std"] }
+petgraph = { version = "0.5.1", features = ["default", "graphmap", "matrix_graph", "stable_graph"] }
+prost = { version = "0.7.0", features = ["default", "prost-derive", "std"] }
+rand = { version = "0.7.3", features = ["alloc", "default", "getrandom", "getrandom_package", "libc", "rand_pcg", "small_rng", "std"] }
+regex = { version = "1.4.3", features = ["aho-corasick", "default", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+regex-syntax = { version = "0.6.22", features = ["default", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+reqwest = { version = "0.11.0", features = ["__tls", "async-compression", "blocking", "default", "default-tls", "gzip", "hyper-tls", "json", "native-tls", "native-tls-crate", "serde_json", "stream", "tokio-native-tls", "tokio-util"] }
+rusty-fork = { version = "0.3.0", features = ["default", "timeout", "wait-timeout"] }
+serde = { version = "1.0.123", features = ["alloc", "default", "derive", "rc", "serde_derive", "std"] }
+serde_json = { version = "1.0.61", features = ["default", "indexmap", "preserve_order", "std", "unbounded_depth"] }
+standback = { version = "0.2.14", default-features = false, features = ["std"] }
+subtle = { version = "2.4.0", default-features = false, features = ["std"] }
+tokio = { version = "1.1.1", features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "test-util", "time", "tokio-macros", "winapi"] }
+tokio-util = { version = "0.6.3", features = ["codec", "compat", "default", "futures-io", "io"] }
+tracing = { version = "0.1.22", default-features = false, features = ["log", "std"] }
+warp = { version = "0.3.0", features = ["default", "multipart", "tls", "tokio-rustls", "tokio-tungstenite", "websocket"] }
+zeroize = { version = "1.2.0", features = ["alloc", "default", "zeroize_derive"] }
 
-[build-dependencies]
-syn = { version = "1.0.58", features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
+[target.x86_64-unknown-linux-gnu.build-dependencies]
+bstr = { version = "0.2.14", features = ["default", "lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
+byteorder = { version = "1.4.2", features = ["default", "i128", "std"] }
+bytes = { version = "1.0.1", features = ["default", "serde", "std"] }
+cc = { version = "1.0.66", default-features = false, features = ["jobserver", "parallel"] }
+chrono = { version = "0.4.19", features = ["clock", "default", "libc", "oldtime", "serde", "std", "time", "winapi"] }
+clap = { version = "2.33.3", features = ["ansi_term", "atty", "color", "default", "strsim", "suggestions", "vec_map"] }
+crossbeam-channel = { version = "0.5.0", features = ["crossbeam-utils", "default", "std"] }
+crossbeam-deque = { version = "0.8.0", features = ["crossbeam-epoch", "crossbeam-utils", "default", "std"] }
+crossbeam-utils = { version = "0.8.0", features = ["default", "lazy_static", "std"] }
+either = { version = "1.6.1", features = ["default", "use_std"] }
+fail = { version = "0.4.0", default-features = false, features = ["failpoints"] }
+futures = { version = "0.3.12", features = ["alloc", "async-await", "default", "executor", "futures-executor", "std"] }
+futures-channel = { version = "0.3.12", features = ["alloc", "default", "futures-sink", "sink", "std"] }
+futures-core = { version = "0.3.12", features = ["alloc", "default", "std"] }
+futures-io = { version = "0.3.12", features = ["default", "std"] }
+futures-sink = { version = "0.3.12", features = ["alloc", "default", "std"] }
+futures-util = { version = "0.3.12", features = ["alloc", "async-await", "async-await-macro", "channel", "default", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "proc-macro-hack", "proc-macro-nested", "sink", "slab", "std"] }
+hyper = { version = "0.14.2", features = ["client", "default", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
+itertools = { version = "0.10.0", features = ["default", "use_alloc", "use_std"] }
+itoa = { version = "0.4.7", features = ["default", "std"] }
+libc = { version = "0.2.85", features = ["align", "default", "extra_traits", "std"] }
+log = { version = "0.4.14", default-features = false, features = ["serde", "std"] }
+memchr = { version = "2.3.4", features = ["default", "std", "use_std"] }
+num-integer = { version = "0.1.44", default-features = false, features = ["i128", "std"] }
+num-traits = { version = "0.2.14", features = ["default", "i128", "std"] }
+once_cell = { version = "1.5.2", features = ["alloc", "default", "std"] }
+petgraph = { version = "0.5.1", features = ["default", "graphmap", "matrix_graph", "stable_graph"] }
+proc-macro2 = { version = "0.4.30", features = ["default", "proc-macro"] }
+prost = { version = "0.7.0", features = ["default", "prost-derive", "std"] }
+quote = { version = "0.6.13", features = ["default", "proc-macro"] }
+rand = { version = "0.7.3", features = ["alloc", "default", "getrandom", "getrandom_package", "libc", "rand_pcg", "small_rng", "std"] }
+regex = { version = "1.4.3", features = ["aho-corasick", "default", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+regex-syntax = { version = "0.6.22", features = ["default", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+reqwest = { version = "0.11.0", features = ["__tls", "async-compression", "blocking", "default", "default-tls", "gzip", "hyper-tls", "json", "native-tls", "native-tls-crate", "serde_json", "stream", "tokio-native-tls", "tokio-util"] }
+rusty-fork = { version = "0.3.0", features = ["default", "timeout", "wait-timeout"] }
+serde = { version = "1.0.123", features = ["alloc", "default", "derive", "rc", "serde_derive", "std"] }
+serde_json = { version = "1.0.61", features = ["default", "indexmap", "preserve_order", "std", "unbounded_depth"] }
+standback = { version = "0.2.14", default-features = false, features = ["std"] }
+subtle = { version = "2.4.0", default-features = false, features = ["std"] }
+syn-3575ec1268b04181 = { package = "syn", version = "0.15.44", features = ["clone-impls", "default", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
+syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.60", features = ["clone-impls", "default", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
+tokio = { version = "1.1.1", features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "test-util", "time", "tokio-macros", "winapi"] }
+tokio-util = { version = "0.6.3", features = ["codec", "compat", "default", "futures-io", "io"] }
+tracing = { version = "0.1.22", default-features = false, features = ["log", "std"] }
+warp = { version = "0.3.0", features = ["default", "multipart", "tls", "tokio-rustls", "tokio-tungstenite", "websocket"] }
+zeroize = { version = "1.2.0", features = ["alloc", "default", "zeroize_derive"] }
+
+[target.x86_64-apple-darwin.dependencies]
+bstr = { version = "0.2.14", features = ["default", "lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
+byteorder = { version = "1.4.2", features = ["default", "i128", "std"] }
+bytes = { version = "1.0.1", features = ["default", "serde", "std"] }
+chrono = { version = "0.4.19", features = ["clock", "default", "libc", "oldtime", "serde", "std", "time", "winapi"] }
+clap = { version = "2.33.3", features = ["ansi_term", "atty", "color", "default", "strsim", "suggestions", "vec_map"] }
+crossbeam-channel = { version = "0.5.0", features = ["crossbeam-utils", "default", "std"] }
+crossbeam-deque = { version = "0.8.0", features = ["crossbeam-epoch", "crossbeam-utils", "default", "std"] }
+crossbeam-utils = { version = "0.8.0", features = ["default", "lazy_static", "std"] }
+either = { version = "1.6.1", features = ["default", "use_std"] }
+fail = { version = "0.4.0", default-features = false, features = ["failpoints"] }
+futures = { version = "0.3.12", features = ["alloc", "async-await", "default", "executor", "futures-executor", "std"] }
+futures-channel = { version = "0.3.12", features = ["alloc", "default", "futures-sink", "sink", "std"] }
+futures-core = { version = "0.3.12", features = ["alloc", "default", "std"] }
+futures-io = { version = "0.3.12", features = ["default", "std"] }
+futures-sink = { version = "0.3.12", features = ["alloc", "default", "std"] }
+futures-util = { version = "0.3.12", features = ["alloc", "async-await", "async-await-macro", "channel", "default", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "proc-macro-hack", "proc-macro-nested", "sink", "slab", "std"] }
+hyper = { version = "0.14.2", features = ["client", "default", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
+itertools = { version = "0.10.0", features = ["default", "use_alloc", "use_std"] }
+itoa = { version = "0.4.7", features = ["default", "std"] }
+libc = { version = "0.2.85", features = ["align", "default", "extra_traits", "std"] }
+log = { version = "0.4.14", default-features = false, features = ["serde", "std"] }
+memchr = { version = "2.3.4", features = ["default", "std", "use_std"] }
+num-integer = { version = "0.1.44", default-features = false, features = ["i128", "std"] }
+num-traits = { version = "0.2.14", features = ["default", "i128", "std"] }
+once_cell = { version = "1.5.2", features = ["alloc", "default", "std"] }
+petgraph = { version = "0.5.1", features = ["default", "graphmap", "matrix_graph", "stable_graph"] }
+prost = { version = "0.7.0", features = ["default", "prost-derive", "std"] }
+rand = { version = "0.7.3", features = ["alloc", "default", "getrandom", "getrandom_package", "libc", "rand_pcg", "small_rng", "std"] }
+regex = { version = "1.4.3", features = ["aho-corasick", "default", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+regex-syntax = { version = "0.6.22", features = ["default", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+reqwest = { version = "0.11.0", features = ["__tls", "async-compression", "blocking", "default", "default-tls", "gzip", "hyper-tls", "json", "native-tls", "native-tls-crate", "serde_json", "stream", "tokio-native-tls", "tokio-util"] }
+rusty-fork = { version = "0.3.0", features = ["default", "timeout", "wait-timeout"] }
+serde = { version = "1.0.123", features = ["alloc", "default", "derive", "rc", "serde_derive", "std"] }
+serde_json = { version = "1.0.61", features = ["default", "indexmap", "preserve_order", "std", "unbounded_depth"] }
+standback = { version = "0.2.14", default-features = false, features = ["std"] }
+subtle = { version = "2.4.0", default-features = false, features = ["std"] }
+tokio = { version = "1.1.1", features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "test-util", "time", "tokio-macros", "winapi"] }
+tokio-util = { version = "0.6.3", features = ["codec", "compat", "default", "futures-io", "io"] }
+tracing = { version = "0.1.22", default-features = false, features = ["log", "std"] }
+warp = { version = "0.3.0", features = ["default", "multipart", "tls", "tokio-rustls", "tokio-tungstenite", "websocket"] }
+zeroize = { version = "1.2.0", features = ["alloc", "default", "zeroize_derive"] }
+
+[target.x86_64-apple-darwin.build-dependencies]
+bstr = { version = "0.2.14", features = ["default", "lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
+byteorder = { version = "1.4.2", features = ["default", "i128", "std"] }
+bytes = { version = "1.0.1", features = ["default", "serde", "std"] }
+cc = { version = "1.0.66", default-features = false, features = ["jobserver", "parallel"] }
+chrono = { version = "0.4.19", features = ["clock", "default", "libc", "oldtime", "serde", "std", "time", "winapi"] }
+clap = { version = "2.33.3", features = ["ansi_term", "atty", "color", "default", "strsim", "suggestions", "vec_map"] }
+crossbeam-channel = { version = "0.5.0", features = ["crossbeam-utils", "default", "std"] }
+crossbeam-deque = { version = "0.8.0", features = ["crossbeam-epoch", "crossbeam-utils", "default", "std"] }
+crossbeam-utils = { version = "0.8.0", features = ["default", "lazy_static", "std"] }
+either = { version = "1.6.1", features = ["default", "use_std"] }
+fail = { version = "0.4.0", default-features = false, features = ["failpoints"] }
+futures = { version = "0.3.12", features = ["alloc", "async-await", "default", "executor", "futures-executor", "std"] }
+futures-channel = { version = "0.3.12", features = ["alloc", "default", "futures-sink", "sink", "std"] }
+futures-core = { version = "0.3.12", features = ["alloc", "default", "std"] }
+futures-io = { version = "0.3.12", features = ["default", "std"] }
+futures-sink = { version = "0.3.12", features = ["alloc", "default", "std"] }
+futures-util = { version = "0.3.12", features = ["alloc", "async-await", "async-await-macro", "channel", "default", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "proc-macro-hack", "proc-macro-nested", "sink", "slab", "std"] }
+hyper = { version = "0.14.2", features = ["client", "default", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
+itertools = { version = "0.10.0", features = ["default", "use_alloc", "use_std"] }
+itoa = { version = "0.4.7", features = ["default", "std"] }
+libc = { version = "0.2.85", features = ["align", "default", "extra_traits", "std"] }
+log = { version = "0.4.14", default-features = false, features = ["serde", "std"] }
+memchr = { version = "2.3.4", features = ["default", "std", "use_std"] }
+num-integer = { version = "0.1.44", default-features = false, features = ["i128", "std"] }
+num-traits = { version = "0.2.14", features = ["default", "i128", "std"] }
+once_cell = { version = "1.5.2", features = ["alloc", "default", "std"] }
+petgraph = { version = "0.5.1", features = ["default", "graphmap", "matrix_graph", "stable_graph"] }
+proc-macro2 = { version = "0.4.30", features = ["default", "proc-macro"] }
+prost = { version = "0.7.0", features = ["default", "prost-derive", "std"] }
+quote = { version = "0.6.13", features = ["default", "proc-macro"] }
+rand = { version = "0.7.3", features = ["alloc", "default", "getrandom", "getrandom_package", "libc", "rand_pcg", "small_rng", "std"] }
+regex = { version = "1.4.3", features = ["aho-corasick", "default", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+regex-syntax = { version = "0.6.22", features = ["default", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+reqwest = { version = "0.11.0", features = ["__tls", "async-compression", "blocking", "default", "default-tls", "gzip", "hyper-tls", "json", "native-tls", "native-tls-crate", "serde_json", "stream", "tokio-native-tls", "tokio-util"] }
+rusty-fork = { version = "0.3.0", features = ["default", "timeout", "wait-timeout"] }
+serde = { version = "1.0.123", features = ["alloc", "default", "derive", "rc", "serde_derive", "std"] }
+serde_json = { version = "1.0.61", features = ["default", "indexmap", "preserve_order", "std", "unbounded_depth"] }
+standback = { version = "0.2.14", default-features = false, features = ["std"] }
+subtle = { version = "2.4.0", default-features = false, features = ["std"] }
+syn-3575ec1268b04181 = { package = "syn", version = "0.15.44", features = ["clone-impls", "default", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
+syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.60", features = ["clone-impls", "default", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
+tokio = { version = "1.1.1", features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "test-util", "time", "tokio-macros", "winapi"] }
+tokio-util = { version = "0.6.3", features = ["codec", "compat", "default", "futures-io", "io"] }
+tracing = { version = "0.1.22", default-features = false, features = ["log", "std"] }
+warp = { version = "0.3.0", features = ["default", "multipart", "tls", "tokio-rustls", "tokio-tungstenite", "websocket"] }
+zeroize = { version = "1.2.0", features = ["alloc", "default", "zeroize_derive"] }
+
+### END HAKARI SECTION

--- a/common/workspace-hack/Cargo.toml
+++ b/common/workspace-hack/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2018"
 
 ### BEGIN HAKARI SECTION
 [target.x86_64-unknown-linux-gnu.dependencies]
-bstr = { version = "0.2.14", features = ["default", "lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
 byteorder = { version = "1.4.2", features = ["default", "i128", "std"] }
 bytes = { version = "1.0.1", features = ["default", "serde", "std"] }
 chrono = { version = "0.4.19", features = ["clock", "default", "libc", "oldtime", "serde", "std", "time", "winapi"] }
@@ -39,12 +38,10 @@ once_cell = { version = "1.5.2", features = ["alloc", "default", "std"] }
 petgraph = { version = "0.5.1", features = ["default", "graphmap", "matrix_graph", "stable_graph"] }
 prost = { version = "0.7.0", features = ["default", "prost-derive", "std"] }
 rand = { version = "0.7.3", features = ["alloc", "default", "getrandom", "getrandom_package", "libc", "rand_pcg", "small_rng", "std"] }
-regex = { version = "1.4.3", features = ["aho-corasick", "default", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
-regex-syntax = { version = "0.6.22", features = ["default", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 reqwest = { version = "0.11.0", features = ["__tls", "async-compression", "blocking", "default", "default-tls", "gzip", "hyper-tls", "json", "native-tls", "native-tls-crate", "serde_json", "stream", "tokio-native-tls", "tokio-util"] }
 rusty-fork = { version = "0.3.0", features = ["default", "timeout", "wait-timeout"] }
 serde = { version = "1.0.123", features = ["alloc", "default", "derive", "rc", "serde_derive", "std"] }
-serde_json = { version = "1.0.61", features = ["default", "indexmap", "preserve_order", "std", "unbounded_depth"] }
+serde_json = { version = "1.0.61", features = ["default", "indexmap", "preserve_order", "std"] }
 standback = { version = "0.2.14", default-features = false, features = ["std"] }
 subtle = { version = "2.4.0", default-features = false, features = ["std"] }
 tokio = { version = "1.1.1", features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "test-util", "time", "tokio-macros", "winapi"] }
@@ -54,7 +51,6 @@ warp = { version = "0.3.0", features = ["default", "multipart", "tls", "tokio-ru
 zeroize = { version = "1.2.0", features = ["alloc", "default", "zeroize_derive"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
-bstr = { version = "0.2.14", features = ["default", "lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
 byteorder = { version = "1.4.2", features = ["default", "i128", "std"] }
 bytes = { version = "1.0.1", features = ["default", "serde", "std"] }
 cc = { version = "1.0.66", default-features = false, features = ["jobserver", "parallel"] }
@@ -85,12 +81,10 @@ proc-macro2 = { version = "0.4.30", features = ["default", "proc-macro"] }
 prost = { version = "0.7.0", features = ["default", "prost-derive", "std"] }
 quote = { version = "0.6.13", features = ["default", "proc-macro"] }
 rand = { version = "0.7.3", features = ["alloc", "default", "getrandom", "getrandom_package", "libc", "rand_pcg", "small_rng", "std"] }
-regex = { version = "1.4.3", features = ["aho-corasick", "default", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
-regex-syntax = { version = "0.6.22", features = ["default", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 reqwest = { version = "0.11.0", features = ["__tls", "async-compression", "blocking", "default", "default-tls", "gzip", "hyper-tls", "json", "native-tls", "native-tls-crate", "serde_json", "stream", "tokio-native-tls", "tokio-util"] }
 rusty-fork = { version = "0.3.0", features = ["default", "timeout", "wait-timeout"] }
 serde = { version = "1.0.123", features = ["alloc", "default", "derive", "rc", "serde_derive", "std"] }
-serde_json = { version = "1.0.61", features = ["default", "indexmap", "preserve_order", "std", "unbounded_depth"] }
+serde_json = { version = "1.0.61", features = ["default", "indexmap", "preserve_order", "std"] }
 standback = { version = "0.2.14", default-features = false, features = ["std"] }
 subtle = { version = "2.4.0", default-features = false, features = ["std"] }
 syn-3575ec1268b04181 = { package = "syn", version = "0.15.44", features = ["clone-impls", "default", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
@@ -102,7 +96,6 @@ warp = { version = "0.3.0", features = ["default", "multipart", "tls", "tokio-ru
 zeroize = { version = "1.2.0", features = ["alloc", "default", "zeroize_derive"] }
 
 [target.x86_64-apple-darwin.dependencies]
-bstr = { version = "0.2.14", features = ["default", "lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
 byteorder = { version = "1.4.2", features = ["default", "i128", "std"] }
 bytes = { version = "1.0.1", features = ["default", "serde", "std"] }
 chrono = { version = "0.4.19", features = ["clock", "default", "libc", "oldtime", "serde", "std", "time", "winapi"] }
@@ -130,12 +123,10 @@ once_cell = { version = "1.5.2", features = ["alloc", "default", "std"] }
 petgraph = { version = "0.5.1", features = ["default", "graphmap", "matrix_graph", "stable_graph"] }
 prost = { version = "0.7.0", features = ["default", "prost-derive", "std"] }
 rand = { version = "0.7.3", features = ["alloc", "default", "getrandom", "getrandom_package", "libc", "rand_pcg", "small_rng", "std"] }
-regex = { version = "1.4.3", features = ["aho-corasick", "default", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
-regex-syntax = { version = "0.6.22", features = ["default", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 reqwest = { version = "0.11.0", features = ["__tls", "async-compression", "blocking", "default", "default-tls", "gzip", "hyper-tls", "json", "native-tls", "native-tls-crate", "serde_json", "stream", "tokio-native-tls", "tokio-util"] }
 rusty-fork = { version = "0.3.0", features = ["default", "timeout", "wait-timeout"] }
 serde = { version = "1.0.123", features = ["alloc", "default", "derive", "rc", "serde_derive", "std"] }
-serde_json = { version = "1.0.61", features = ["default", "indexmap", "preserve_order", "std", "unbounded_depth"] }
+serde_json = { version = "1.0.61", features = ["default", "indexmap", "preserve_order", "std"] }
 standback = { version = "0.2.14", default-features = false, features = ["std"] }
 subtle = { version = "2.4.0", default-features = false, features = ["std"] }
 tokio = { version = "1.1.1", features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "test-util", "time", "tokio-macros", "winapi"] }
@@ -145,7 +136,6 @@ warp = { version = "0.3.0", features = ["default", "multipart", "tls", "tokio-ru
 zeroize = { version = "1.2.0", features = ["alloc", "default", "zeroize_derive"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
-bstr = { version = "0.2.14", features = ["default", "lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
 byteorder = { version = "1.4.2", features = ["default", "i128", "std"] }
 bytes = { version = "1.0.1", features = ["default", "serde", "std"] }
 cc = { version = "1.0.66", default-features = false, features = ["jobserver", "parallel"] }
@@ -176,12 +166,10 @@ proc-macro2 = { version = "0.4.30", features = ["default", "proc-macro"] }
 prost = { version = "0.7.0", features = ["default", "prost-derive", "std"] }
 quote = { version = "0.6.13", features = ["default", "proc-macro"] }
 rand = { version = "0.7.3", features = ["alloc", "default", "getrandom", "getrandom_package", "libc", "rand_pcg", "small_rng", "std"] }
-regex = { version = "1.4.3", features = ["aho-corasick", "default", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
-regex-syntax = { version = "0.6.22", features = ["default", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 reqwest = { version = "0.11.0", features = ["__tls", "async-compression", "blocking", "default", "default-tls", "gzip", "hyper-tls", "json", "native-tls", "native-tls-crate", "serde_json", "stream", "tokio-native-tls", "tokio-util"] }
 rusty-fork = { version = "0.3.0", features = ["default", "timeout", "wait-timeout"] }
 serde = { version = "1.0.123", features = ["alloc", "default", "derive", "rc", "serde_derive", "std"] }
-serde_json = { version = "1.0.61", features = ["default", "indexmap", "preserve_order", "std", "unbounded_depth"] }
+serde_json = { version = "1.0.61", features = ["default", "indexmap", "preserve_order", "std"] }
 standback = { version = "0.2.14", default-features = false, features = ["std"] }
 subtle = { version = "2.4.0", default-features = false, features = ["std"] }
 syn-3575ec1268b04181 = { package = "syn", version = "0.15.44", features = ["clone-impls", "default", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }

--- a/devtools/x-core/Cargo.toml
+++ b/devtools/x-core/Cargo.toml
@@ -11,6 +11,7 @@ license = "Apache-2.0"
 determinator = "0.2.0"
 guppy = "0.7.0"
 indoc = "1.0.3"
+hakari = { version = "0.1.0", features = ["summaries"] }
 hex = "0.4.2"
 diem-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 log = "0.4.14"

--- a/devtools/x-core/Cargo.toml
+++ b/devtools/x-core/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 license = "Apache-2.0"
 
 [dependencies]
-determinator = "0.1.0"
-guppy = "0.6.3"
+determinator = "0.2.0"
+guppy = "0.7.0"
 indoc = "1.0.3"
 hex = "0.4.2"
 diem-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }

--- a/devtools/x-core/Cargo.toml
+++ b/devtools/x-core/Cargo.toml
@@ -13,7 +13,6 @@ guppy = "0.7.0"
 indoc = "1.0.3"
 hakari = { version = "0.1.0", features = ["summaries"] }
 hex = "0.4.2"
-diem-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 log = "0.4.14"
 toml = "0.5.8"
 once_cell = "1.4.1"

--- a/devtools/x-core/src/core_config.rs
+++ b/devtools/x-core/src/core_config.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use hakari::summaries::HakariBuilderSummary;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -10,6 +11,9 @@ use std::collections::BTreeMap;
 pub struct XCoreConfig {
     /// Subsets of this workspace
     pub subsets: BTreeMap<String, SubsetConfig>,
+
+    /// Config for Hakari (workspace-hack management).
+    pub hakari: HakariBuilderSummary,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]

--- a/devtools/x-core/src/lib.rs
+++ b/devtools/x-core/src/lib.rs
@@ -19,6 +19,7 @@ use crate::{core_config::XCoreConfig, git::GitCli};
 pub use debug_ignore::*;
 pub use errors::*;
 use graph::PackageGraphPlus;
+use hakari::{HakariBuilder, TomlOptions};
 pub use workspace_subset::*;
 
 /// Core context shared across all of x.
@@ -98,6 +99,22 @@ impl XCoreContext {
     /// Returns information about the subsets for this workspace.
     pub fn subsets(&self) -> Result<&WorkspaceSubsets> {
         Ok(self.package_graph_plus()?.suffix())
+    }
+
+    /// Returns a Hakari builder for this workspace.
+    pub fn hakari_builder<'a>(&'a self) -> Result<HakariBuilder<'a, 'static>> {
+        let graph = self.package_graph()?;
+        self.config
+            .hakari
+            .to_hakari_builder(graph)
+            .map_err(|err| SystemError::guppy("while resolving Hakari config", err))
+    }
+
+    /// Returns the default Hakari TOML options for this workspace.
+    pub fn hakari_toml_options(&self) -> TomlOptions {
+        let mut options = TomlOptions::new();
+        options.set_exact_versions(true);
+        options
     }
 
     // ---

--- a/devtools/x-lint/Cargo.toml
+++ b/devtools/x-lint/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 license = "Apache-2.0"
 
 [dependencies]
-guppy = "0.6.3"
+guppy = "0.7.0"
 diem-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 once_cell = "1.4.1"
 toml = "0.5.8"

--- a/devtools/x-lint/Cargo.toml
+++ b/devtools/x-lint/Cargo.toml
@@ -10,7 +10,6 @@ license = "Apache-2.0"
 [dependencies]
 guppy = "0.7.0"
 hakari = "0.1.0"
-diem-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 once_cell = "1.4.1"
 toml = "0.5.8"
 serde = { version = "1.0.123", features = ["derive"] }

--- a/devtools/x-lint/Cargo.toml
+++ b/devtools/x-lint/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 
 [dependencies]
 guppy = "0.7.0"
+hakari = "0.1.0"
 diem-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 once_cell = "1.4.1"
 toml = "0.5.8"

--- a/devtools/x-lint/src/project.rs
+++ b/devtools/x-lint/src/project.rs
@@ -3,6 +3,7 @@
 
 use crate::{prelude::*, LintContext};
 use guppy::graph::PackageGraph;
+use hakari::Hakari;
 use std::path::{Path, PathBuf};
 use x_core::{WorkspaceSubset, XCoreContext};
 
@@ -32,6 +33,11 @@ impl<'l> ProjectContext<'l> {
         Self { core }
     }
 
+    /// Returns the core context.
+    pub fn core(&self) -> &'l XCoreContext {
+        self.core
+    }
+
     /// Returns the project root.
     pub fn project_root(&self) -> &'l Path {
         self.core.project_root()
@@ -53,6 +59,11 @@ impl<'l> ProjectContext<'l> {
     /// those that Cargo would ignore.
     pub fn default_members(&self) -> Result<&WorkspaceSubset> {
         Ok(self.core.subsets()?.default_members())
+    }
+
+    /// Returns Hakari information.
+    pub fn hakari(&self) -> Result<Hakari<'l, 'static>> {
+        Ok(self.core.hakari_builder()?.compute())
     }
 }
 

--- a/devtools/x/Cargo.toml
+++ b/devtools/x/Cargo.toml
@@ -8,13 +8,13 @@ publish = false
 license = "Apache-2.0"
 
 [dependencies]
-determinator = "0.1.1"
+determinator = "0.2.0"
 serde = { version = "1.0.123", features = ["derive"] }
 serde_json = "1.0.61"
 structopt = "0.3.21"
 anyhow = "1.0.38"
 colored-diff = "0.2.2"
-guppy = { version = "0.6.3", features = ["summaries"] }
+guppy = { version = "0.7.0", features = ["summaries"] }
 indoc = "1.0.3"
 toml = "0.5.8"
 env_logger = "0.8.2"

--- a/devtools/x/Cargo.toml
+++ b/devtools/x/Cargo.toml
@@ -15,6 +15,7 @@ structopt = "0.3.21"
 anyhow = "1.0.38"
 colored-diff = "0.2.2"
 guppy = { version = "0.7.0", features = ["summaries"] }
+hakari = "0.1.0"
 indoc = "1.0.3"
 toml = "0.5.8"
 env_logger = "0.8.2"

--- a/devtools/x/Cargo.toml
+++ b/devtools/x/Cargo.toml
@@ -27,4 +27,3 @@ rayon = "1.5.0"
 indexmap = "1.6.1"
 x-core = { version = "0.1.0", path = "../x-core" }
 x-lint = { version = "0.1.0", path = "../x-lint" }
-diem-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }

--- a/devtools/x/src/generate_workspace_hack.rs
+++ b/devtools/x/src/generate_workspace_hack.rs
@@ -1,0 +1,87 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{context::XContext, Result};
+use anyhow::bail;
+use log::{info, warn};
+use structopt::{clap::arg_enum, StructOpt};
+
+#[derive(Debug, StructOpt)]
+pub struct Args {
+    /// Mode to run in
+    #[structopt(long, case_insensitive = true, possible_values = &WorkspaceHackMode::variants(), default_value = "write")]
+    mode: WorkspaceHackMode,
+}
+
+arg_enum! {
+    #[derive(Clone, Copy, Debug)]
+    /// Valid modes for generate-workspace-hack
+    pub enum WorkspaceHackMode {
+        Write,
+        Diff,
+        Check,
+        Verify,
+    }
+}
+
+pub fn run(args: Args, xctx: XContext) -> Result<()> {
+    let mut hakari_builder = xctx.core().hakari_builder()?;
+
+    match args.mode {
+        WorkspaceHackMode::Verify => {
+            hakari_builder.set_verify_mode(true);
+            let hakari = hakari_builder.compute();
+            if hakari.output_map.is_empty() {
+                info!("workspace-hack is valid");
+            } else {
+                for ((platform_idx, package_id), v) in &hakari.computed_map {
+                    for &(build_platform, inner_map) in v.inner_maps().iter() {
+                        if inner_map.len() > 1 {
+                            println!(
+                                "platform idx {:?} on {:?}, package ID: {}",
+                                platform_idx, build_platform, package_id
+                            );
+                            for (feature_set, packages) in inner_map {
+                                let features: Vec<_> = feature_set.iter().copied().collect();
+                                println!("  for features {}:", features.join(", "));
+                                for (package, f) in packages {
+                                    println!("    * {} ({:?})", package.name(), f);
+                                }
+                            }
+                        }
+                    }
+                }
+                warn!("workspace-hack doesn't unify everything successfully");
+            }
+        }
+        _other => {
+            let hakari = hakari_builder.compute();
+            let existing_toml = hakari
+                .read_toml()
+                .expect("hakari package specified by builder")?;
+            let new_toml = hakari.to_toml_string(&xctx.core().hakari_toml_options())?;
+
+            match args.mode {
+                WorkspaceHackMode::Write => {
+                    // Write out the contents to the TOML file.
+                    existing_toml.write_to_file(&new_toml)?;
+                }
+                WorkspaceHackMode::Diff => {
+                    let patch = existing_toml.diff_toml(&new_toml);
+                    // TODO: add global coloring options to x
+                    let formatter = hakari::diffy::PatchFormatter::new().with_color();
+                    let diff = formatter.fmt_patch(&patch);
+                    println!("{}", diff);
+                }
+                WorkspaceHackMode::Check => {
+                    if existing_toml.is_changed(&new_toml) {
+                        bail!("existing TOML is different from generated version (run with --mode diff for diff)");
+                    }
+                }
+                WorkspaceHackMode::Verify => unreachable!("already processed in outer match"),
+            }
+        }
+    };
+
+    Ok(())
+}

--- a/devtools/x/src/generate_workspace_hack.rs
+++ b/devtools/x/src/generate_workspace_hack.rs
@@ -21,6 +21,7 @@ arg_enum! {
         Diff,
         Check,
         Verify,
+        Disable,
     }
 }
 
@@ -54,6 +55,16 @@ pub fn run(args: Args, xctx: XContext) -> Result<()> {
                 warn!("workspace-hack doesn't unify everything successfully");
             }
         }
+        WorkspaceHackMode::Disable => {
+            let existing_toml = hakari_builder
+                .read_toml()
+                .expect("hakari package specified by builder")?;
+            let disabled_msg = "\n\
+            # Disabled through `cargo x generate-workspace-hack --mode disable`.\n\
+            # To re-enable, `run cargo x generate-workspace-hack`.\n\
+            \n";
+            existing_toml.write_to_file(disabled_msg)?;
+        }
         _other => {
             let hakari = hakari_builder.compute();
             let existing_toml = hakari
@@ -78,7 +89,9 @@ pub fn run(args: Args, xctx: XContext) -> Result<()> {
                         bail!("existing TOML is different from generated version (run with --mode diff for diff)");
                     }
                 }
-                WorkspaceHackMode::Verify => unreachable!("already processed in outer match"),
+                WorkspaceHackMode::Disable | WorkspaceHackMode::Verify => {
+                    unreachable!("already processed in outer match")
+                }
             }
         }
     };

--- a/devtools/x/src/lint/guppy.rs
+++ b/devtools/x/src/lint/guppy.rs
@@ -282,6 +282,10 @@ impl ProjectLinter for DirectDepDups {
         package_graph.query_workspace().resolve_with_fn(|_, link| {
             // Collect direct dependencies of workspace packages.
             let (from, to) = link.endpoints();
+            if ctx.core().config().hakari.hakari_package.as_deref() == Some(from.name()) {
+                // Skip the workspace hack package.
+                return false;
+            }
             if from.in_workspace() && !to.in_workspace() {
                 direct_deps
                     .entry(to.name())

--- a/devtools/x/src/lint/mod.rs
+++ b/devtools/x/src/lint/mod.rs
@@ -13,6 +13,7 @@ mod license;
 mod toml;
 mod whitespace;
 mod workspace_classify;
+mod workspace_hack;
 
 #[derive(Debug, StructOpt)]
 pub struct Args {
@@ -26,6 +27,7 @@ pub fn run(args: Args, xctx: XContext) -> crate::Result<()> {
     let project_linters: &[&dyn ProjectLinter] = &[
         &guppy::BannedDeps::new(&workspace_config.banned_deps),
         &guppy::DirectDepDups,
+        &workspace_hack::GenerateWorkspaceHack,
     ];
 
     let package_linters: &[&dyn PackageLinter] = &[

--- a/devtools/x/src/lint/mod.rs
+++ b/devtools/x/src/lint/mod.rs
@@ -22,11 +22,12 @@ pub struct Args {
 }
 
 pub fn run(args: Args, xctx: XContext) -> crate::Result<()> {
+    let core_config = xctx.core().config();
     let workspace_config = xctx.config().workspace_config();
 
     let project_linters: &[&dyn ProjectLinter] = &[
         &guppy::BannedDeps::new(&workspace_config.banned_deps),
-        &guppy::DirectDepDups,
+        &guppy::DirectDepDups::new(&core_config.hakari)?,
         &workspace_hack::GenerateWorkspaceHack,
     ];
 
@@ -35,11 +36,11 @@ pub fn run(args: Args, xctx: XContext) -> crate::Result<()> {
         &guppy::CrateNamesPaths,
         &guppy::IrrelevantBuildDeps,
         &guppy::OverlayFeatures::new(&workspace_config.overlay),
-        &guppy::WorkspaceHack,
         &workspace_classify::DefaultOrTestOnly::new(
             xctx.core().package_graph()?,
             &workspace_config.test_only,
         )?,
+        &workspace_hack::WorkspaceHackDep::new(xctx.core())?,
     ];
 
     let file_path_linters: &[&dyn FilePathLinter] = &[

--- a/devtools/x/src/lint/workspace_hack.rs
+++ b/devtools/x/src/lint/workspace_hack.rs
@@ -1,0 +1,62 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use x_lint::prelude::*;
+
+/// Check that the workspace hack is up-to-date.
+#[derive(Debug)]
+pub struct GenerateWorkspaceHack;
+
+impl Linter for GenerateWorkspaceHack {
+    fn name(&self) -> &'static str {
+        "generate-workspace-hack"
+    }
+}
+
+impl ProjectLinter for GenerateWorkspaceHack {
+    fn run<'l>(
+        &self,
+        ctx: &ProjectContext<'l>,
+        out: &mut LintFormatter<'l, '_>,
+    ) -> Result<RunStatus<'l>> {
+        let hakari = ctx.hakari()?;
+        let existing_toml = hakari
+            .read_toml()
+            .expect("workspace-hack package was specified")
+            .map_err(|err| {
+                SystemError::hakari_cargo_toml("while reading workspace-hack Cargo.toml", err)
+            })?;
+        let new_toml = hakari
+            .to_toml_string(&ctx.core().hakari_toml_options())
+            .map_err(|err| {
+                SystemError::hakari_toml_out("while generating expected Cargo.toml", err)
+            })?;
+        if existing_toml.is_changed(&new_toml) {
+            let patch = existing_toml.diff_toml(&new_toml);
+            // TODO: add global coloring options to x
+            let formatter = hakari::diffy::PatchFormatter::new().with_color();
+            let diff = formatter.fmt_patch(&patch);
+            let hakari_package = hakari
+                .builder()
+                .hakari_package()
+                .expect("package was specified at build time");
+            out.write(
+                LintLevel::Error,
+                format!(
+                    "existing contents of {}/Cargo.toml do not match generated contents\n\n\
+                * diff:\n\
+                {}\n\n\
+                * run \"cargo x generate-workspace-hack\" to regenerate",
+                    hakari_package
+                        .source()
+                        .workspace_path()
+                        .expect("hakari package is in workspace")
+                        .display(),
+                    diff
+                ),
+            );
+        }
+
+        Ok(RunStatus::Executed)
+    }
+}

--- a/devtools/x/src/lint/workspace_hack.rs
+++ b/devtools/x/src/lint/workspace_hack.rs
@@ -1,6 +1,10 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::anyhow;
+use guppy::PackageId;
+use hakari::HakariBuilder;
+use x_core::XCoreContext;
 use x_lint::prelude::*;
 
 /// Check that the workspace hack is up-to-date.
@@ -55,6 +59,62 @@ impl ProjectLinter for GenerateWorkspaceHack {
                     diff
                 ),
             );
+        }
+
+        Ok(RunStatus::Executed)
+    }
+}
+
+/// Ensure the workspace-hack package is a dependency
+#[derive(Debug)]
+pub struct WorkspaceHackDep<'cfg> {
+    hakari_builder: HakariBuilder<'cfg, 'static>,
+    hakari_id: &'cfg PackageId,
+}
+
+impl<'cfg> WorkspaceHackDep<'cfg> {
+    pub fn new(ctx: &'cfg XCoreContext) -> crate::Result<Self> {
+        let hakari_builder = ctx.hakari_builder()?;
+        let hakari_id = hakari_builder
+            .hakari_package()
+            .map(|package| package.id())
+            .ok_or_else(|| anyhow!("hakari.hakari-package not specified in x.toml"))?;
+        Ok(Self {
+            hakari_builder,
+            hakari_id,
+        })
+    }
+}
+impl<'cfg> Linter for WorkspaceHackDep<'cfg> {
+    fn name(&self) -> &'static str {
+        "workspace-hack-dep"
+    }
+}
+
+impl<'cfg> PackageLinter for WorkspaceHackDep<'cfg> {
+    fn run<'l>(
+        &self,
+        ctx: &PackageContext<'l>,
+        out: &mut LintFormatter<'l, '_>,
+    ) -> Result<RunStatus<'l>> {
+        let package = ctx.metadata();
+        let pkg_graph = ctx.package_graph();
+
+        // Exclude omitted packages (including the workspace-hack package itself) from consideration.
+        if self
+            .hakari_builder
+            .omits_package(package.id())
+            .expect("valid package ID")
+        {
+            return Ok(RunStatus::Executed);
+        }
+
+        let has_links = package.direct_links().next().is_some();
+        let has_hack_dep = pkg_graph
+            .directly_depends_on(package.id(), self.hakari_id)
+            .expect("valid package ID");
+        if has_links && !has_hack_dep {
+            out.write(LintLevel::Error, "missing diem-workspace-hack dependency");
         }
 
         Ok(RunStatus::Executed)

--- a/devtools/x/src/main.rs
+++ b/devtools/x/src/main.rs
@@ -21,6 +21,7 @@ mod diff_summary;
 mod fix;
 mod fmt;
 mod generate_summaries;
+mod generate_workspace_hack;
 mod installer;
 mod lint;
 mod playground;
@@ -81,6 +82,9 @@ enum Command {
     #[structopt(name = "diff-summary")]
     /// Diff build summaries for important subsets
     DiffSummary(diff_summary::Args),
+    #[structopt(name = "generate-workspace-hack")]
+    /// Update workspace-hack contents
+    GenerateWorkspaceHack(generate_workspace_hack::Args),
 }
 
 fn main() -> Result<()> {
@@ -122,5 +126,6 @@ fn main() -> Result<()> {
         Command::Playground(args) => playground::run(args, xctx),
         Command::GenerateSummaries(args) => generate_summaries::run(args, xctx),
         Command::DiffSummary(args) => diff_summary::run(args, xctx),
+        Command::GenerateWorkspaceHack(args) => generate_workspace_hack::run(args, xctx),
     }
 }

--- a/docker/build-common.sh
+++ b/docker/build-common.sh
@@ -14,7 +14,13 @@ export CARGO=$(rustup which --toolchain $RUST_NIGHTLY cargo)
 export CARGOFLAGS=$(cat cargo-flags)
 export CARGO_PROFILE_RELEASE_LTO=thin # override lto setting to turn on thin-LTO for release builds
 
-# Build release binaries
+# Disable the workspace-hack package to prevent extra features and packages from being enabled.
+# Can't use ${CARGO} because of https://github.com/rust-lang/rustup/issues/2647 and
+# https://github.com/env-logger-rs/env_logger/issues/190.
+# TODO: consider using ${CARGO} once upstream issues are fixed.
+cargo x generate-workspace-hack --mode disable
+
+# Build release binaries (TODO: use x to run this?)
 ${CARGO} ${CARGOFLAGS} build --release \
          -p diem-genesis-tool \
          -p diem-operational-tool \

--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -237,7 +237,9 @@ async fn submit(mut service: JsonRpcService, request: JsonRpcRequest) -> Result<
     let (req_sender, callback) = oneshot::channel();
 
     fail_point!("jsonrpc::method::submit::mempool_sender", |_| {
-        Err(anyhow::anyhow!("Injected error for mempool_sender call error").into())
+        Err(anyhow::anyhow!(
+            "Injected error for mempool_sender call error"
+        ))
     });
 
     service

--- a/language/move-prover/Cargo.toml
+++ b/language/move-prover/Cargo.toml
@@ -32,7 +32,7 @@ futures = "0.3.12"
 handlebars = "3.5.2"
 hex = "0.4.2"
 itertools = "0.10.0"
-log = "0.4.14"
+log = { version = "0.4.14", features = ["serde"] }
 num = "0.3.0"
 pretty = "0.10.0"
 rand = "0.7.3"

--- a/x.toml
+++ b/x.toml
@@ -45,6 +45,34 @@ warn = [
     "clippy::wildcard_dependencies",
 ]
 
+[hakari]
+version = "v2"
+hakari-package = "diem-workspace-hack"
+unify-target-host = "replicate-target-as-host"
+
+[[hakari.platforms]]
+triple = "x86_64-unknown-linux-gnu"
+target-features = "unknown"
+
+[[hakari.platforms]]
+triple = "x86_64-apple-darwin"
+target-features = "unknown"
+
+# Ideally we'd have powerpc-unknown-linux-gnu here as well, but unification causes openssl-sys to be included,
+# and openssl can't be cross-compiled without extra work. This may need to be fixed in hakari through being able
+# to say "consider only these packages for these target platforms".
+
+# Don't consider the crypto packages as they do weird things with mutually exclusive features.
+[[hakari.omitted-packages]]
+name = "diem-crypto"
+version = "0.1.0"
+workspace-path = "crypto/crypto"
+
+[[hakari.omitted-packages]]
+name = "diem-crypto-derive"
+version = "0.1.0"
+workspace-path = "crypto/crypto-derive"
+
 # This follows the same syntax as CargoOptionsSummary in guppy.
 [summaries.default]
 version = "v2"

--- a/x.toml
+++ b/x.toml
@@ -49,7 +49,7 @@ warn = [
 [summaries.default]
 version = "v2"
 include-dev = false
-proc-macros-on-target = false
+initials-platform = "standard"
 
 [summaries.default.target-platform]
 triple = "x86_64-unknown-linux-gnu"
@@ -67,7 +67,7 @@ workspace-path = "common/workspace-hack"
 [summaries.full]
 version = "v2"
 include-dev = true
-proc-macros-on-target = false
+initials-platform = "standard"
 # Don't set target or host platforms, or omitted packages, for the full set.
 
 [workspace]

--- a/x.toml
+++ b/x.toml
@@ -73,6 +73,22 @@ name = "diem-crypto-derive"
 version = "0.1.0"
 workspace-path = "crypto/crypto-derive"
 
+# Also exclude the devtools packages since they get compiled with a different set of options.
+[[hakari.omitted-packages]]
+name = "x"
+version = "0.1.0"
+workspace-path = "devtools/x"
+
+[[hakari.omitted-packages]]
+name = "x-core"
+version = "0.1.0"
+workspace-path = "devtools/x-core"
+
+[[hakari.omitted-packages]]
+name = "x-lint"
+version = "0.1.0"
+workspace-path = "devtools/x-lint"
+
 # This follows the same syntax as CargoOptionsSummary in guppy.
 [summaries.default]
 version = "v2"


### PR DESCRIPTION
# Automatic workspace-hack management

tl;dr: **faster local and CI builds** through automating feature unification in Diem Core; run `cargo x generate-workspace-hack` to regenerate contents.

## What are workspace-hack packages?

Diem, like many other large Rust workspaces, tends to have trouble with slow rebuilds because of feature unification issues. The way we’ve addressed these issues is to introduce a [*workspace-hack* package](https://github.com/diem/diem/blob/master/common/workspace-hack/Cargo.toml), which every other crate depends upon and which ensures that features are unified for the listed third-party dependencies.

For more details about workspace-hack packages, see [this documentation](https://facebookincubator.github.io/cargo-guppy/rustdoc/hakari/).

## What’s changing?

So far we, and other projects like us, have maintained these workspace-hack packages by hand. However, I’ve been working on a tool called [hakari](https://github.com/facebookincubator/cargo-guppy/tree/main/tools/hakari), which leverages [guppy](https://crates.io/crates/guppy) to automate management of these packages.

Once this PR lands:

* the contents of the diem-workspace-hack package will be automatically managed
* there will be a new lint which ensures that the contents are up-to-date
* if they’re out of date then the lint will tell you to run a new command, `cargo x generate-workspace-hack`, which will regenerate the contents

## What are the benefits?

The main invariant hakari upholds is that no matter which package or set of packages you build in the workspace, **all third-party dependencies will be built with exactly the same feature set**. In our tests, this improves caching and reduces local + CI build times quite significantly.

The following figures were taken on a MacBook Pro 16“ with a Intel(R) Core(TM) i9-9980HK CPU (8c/16t) running macOS 10.15.7. The command run was:

`cargo clean && time cargo x --help && time cargo xbuild -p diem-vm && time cargo xbuild -p diem-types && time cargo xbuild -p diem-key-manager && time cargo xbuild -p execution-correctness && time cargo xbuild -p diem-node`

|Command	|Before, wall (s)	|After, wall (s)	|Difference (s, negative means after is faster)	|% difference (from before)	|Cumulative difference (s)	|Comment	|
|---	|---	|---	|---	|---	|---	|---	|
|cargo x —help	|45.23	|45.58	|0.35	|0.77%	|0.35	|Negligible impact	|
|cargo xbuild -p diem-vm	|53.76	|77.24	|23.48	|43.68%	|23.83	|First build takes longer because more dependencies have to be unified	|
|cargo xbuild -p diem-types	|13.35	|0.91	|-12.44	|-93.18%	|11.39	|Core package, build becomes a no-op	|
|cargo xbuild -p diem-key-manager	|52.42	|45.58	|-6.84	|-13.05%	|4.55	|Requires more third-party deps	|
|cargo xbuild -p execution-correctness	|20.07	|14.02	|-6.05	|-30.14%	|-1.50	|	|
|cargo xbuild -p diem-node	|171.16	|146.97	|-24.19	|-14.13%	|-25.69	|Builds most of Diem, still much faster	|

For the raw data, including results from a Linux desktop, see [this gist](https://gist.github.com/sunshowers/9852d3fb0e46a7a468886a9084015405).

## What are the tradeoffs?

1. Merge conflicts are may arise in the workspace-hack’s Cargo.toml; this file is configured to not leave conflict markers, and you can run `cargo x generate-workspace-hack` to resolve them locally. Unfortunately we don’t yet have the ability to resolve them automatically on GitHub—doing so may be possible in some circumstances but is quite complicated and will require prioritization.

2. If we left the workspace-hack in place for our release artifacts (Docker images), we’d be including a ton more code in the TCB than necessary. This is undesirable, so we now **disable the workspace hack** while performing the Docker build. This means that our effective TCB will become smaller thanks to this PR (the dependency numbers we currently report were already with the workspace-hack disabled, but our build process didn’t actually do that before this PR.
    
    The tradeoff is that this introduces a divergence between developer and production builds — based on the factors involved, we believe that this is the best choice. To replicate production builds and disable the workspace-hack locally, run `cargo x generate-workspace-hack --mode disable`. To re-enable the workspace-hack, simply run `cargo x generate-workspace-hack` again.