### PR TITLE
[State Sync] Avoid using mocked services in the fuzzer.

### DIFF
--- a/state-synchronizer/Cargo.toml
+++ b/state-synchronizer/Cargo.toml
@@ -22,6 +22,7 @@ proptest = { version = "0.10.1", optional = true }
 
 channel = { path = "../common/channel", version = "0.1.0" }
 executor = { path = "../execution/executor", version = "0.1.0" }
+executor-test-helpers = { path = "../execution/executor-test-helpers", version = "0.1.0", optional = true }
 executor-types = { path = "../execution/executor-types", version = "0.1.0" }
 diem-config = { path = "../config", version = "0.1.0" }
 diem-crypto = { path = "../crypto/crypto", version = "0.1.0" }
@@ -68,4 +69,4 @@ vm-genesis = { path = "../language/tools/vm-genesis", version = "0.1.0" }
 [features]
 default = []
 failpoints = ["fail/failpoints"]
-fuzzing = ["vm-genesis", "proptest", "diem-network-address/fuzzing", "diem-config/fuzzing", "diem-mempool/fuzzing", "diem-types/fuzzing", "diem-proptest-helpers", "memsocket/fuzzing"]
+fuzzing = ["vm-genesis", "proptest", "executor-test-helpers", "diem-network-address/fuzzing", "diem-config/fuzzing", "diem-mempool/fuzzing", "diem-types/fuzzing", "diem-proptest-helpers", "memsocket/fuzzing"]

--- a/state-synchronizer/Cargo.toml
+++ b/state-synchronizer/Cargo.toml
@@ -21,6 +21,7 @@ itertools = { version = "0.10.0", default-features = false }
 proptest = { version = "0.10.1", optional = true }
 
 channel = { path = "../common/channel", version = "0.1.0" }
+executor = { path = "../execution/executor", version = "0.1.0" }
 executor-types = { path = "../execution/executor-types", version = "0.1.0" }
 diem-config = { path = "../config", version = "0.1.0" }
 diem-crypto = { path = "../crypto/crypto", version = "0.1.0" }
@@ -31,6 +32,7 @@ diem-mempool = { path = "../mempool", version = "0.1.0"}
 diem-metrics = { path = "../common/metrics", version = "0.1.0" }
 diem-network-address = { path = "../network/network-address", version = "0.1.0", optional = true }
 diem-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0", optional = true }
+diem-temppath = { path = "../common/temppath", version = "0.1.0" }
 diem-types = { path = "../types", version = "0.1.0" }
 diem-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
 memsocket = { path = "../network/memsocket", version = "0.1.0", optional = true }
@@ -48,14 +50,12 @@ proptest = "0.10.1"
 
 channel = { path = "../common/channel", version = "0.1.0" }
 compiled-stdlib = { path = "../language/stdlib/compiled",  version = "0.1.0" }
-executor = { path = "../execution/executor", version = "0.1.0" }
 executor-test-helpers = { path = "../execution/executor-test-helpers", version = "0.1.0" }
 diem-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 diem-genesis-tool = {path = "../config/management/genesis", version = "0.1.0", features = ["testing"] }
 diem-mempool = { path = "../mempool", version = "0.1.0", features = ["fuzzing"] }
 diem-network-address = { path = "../network/network-address", version = "0.1.0", features = ["fuzzing"] }
 diem-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0" }
-diem-temppath = { path = "../common/temppath", version = "0.1.0" }
 diemdb = { path = "../storage/diemdb", version = "0.1.0" }
 memsocket = { path = "../network/memsocket", version = "0.1.0" }
 network = { path = "../network", version = "0.1.0", features = ["testing"] }

--- a/state-synchronizer/src/tests/helpers.rs
+++ b/state-synchronizer/src/tests/helpers.rs
@@ -27,10 +27,6 @@ use std::sync::Arc;
 pub(crate) struct SynchronizerEnvHelper;
 
 impl SynchronizerEnvHelper {
-    pub(crate) fn default_handler() -> MockRpcHandler {
-        Box::new(|resp| -> Result<TransactionListWithProof> { Ok(resp) })
-    }
-
     // Returns the initial peers with their signatures
     pub(crate) fn initial_setup(
         count: usize,

--- a/state-synchronizer/src/tests/mod.rs
+++ b/state-synchronizer/src/tests/mod.rs
@@ -1,9 +1,11 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(test)]
 mod helpers;
 #[cfg(test)]
 mod integration_tests;
+#[cfg(test)]
 mod mock_storage;
 #[cfg(test)]
 mod on_chain_config;

--- a/state-synchronizer/src/tests/mod.rs
+++ b/state-synchronizer/src/tests/mod.rs
@@ -12,4 +12,5 @@ mod on_chain_config;
 #[cfg(test)]
 mod request_manager;
 
+#[cfg(any(feature = "fuzzing", test))]
 pub mod fuzzing;

--- a/testsuite/diem-fuzzer/src/fuzz_targets/state_sync.rs
+++ b/testsuite/diem-fuzzer/src/fuzz_targets/state_sync.rs
@@ -3,7 +3,7 @@
 
 use crate::{corpus_from_strategy, fuzz_data_to_value, FuzzTargetImpl};
 use diem_proptest_helpers::ValueGenerator;
-use state_synchronizer::fuzzing::{state_sync_msg_strategy, test_state_sync_msg_fuzzer_impl};
+use state_synchronizer::fuzzing::{arb_state_sync_msg, test_state_sync_msg_fuzzer_impl};
 
 #[derive(Debug, Default)]
 pub struct StateSyncMsg;
@@ -14,11 +14,11 @@ impl FuzzTargetImpl for StateSyncMsg {
     }
 
     fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
-        Some(corpus_from_strategy(state_sync_msg_strategy()))
+        Some(corpus_from_strategy(arb_state_sync_msg()))
     }
 
     fn fuzz(&self, data: &[u8]) {
-        let msg = fuzz_data_to_value(data, state_sync_msg_strategy());
+        let msg = fuzz_data_to_value(data, arb_state_sync_msg());
         test_state_sync_msg_fuzzer_impl(msg);
     }
 }


### PR DESCRIPTION
## Motivation

This PR offers several small clean ups to the StateSyncMsg fuzzing target and removes the use of mocked services from the fuzzer. It does so through the following commits:
1. Some small cleanups, refactors and renames of the fuzzing implementation.
2. Swapped out the mocked services previously used in the fuzzer for the real services (e.g., database and executor proxy). Having mocked services in the fuzzer isn't great because it produces false negatives (not testing the real services, only the mocked ones) and false positives (highlights issues that are in the mocked services, but not in the real services). We've already seen this happen.
3. Made the creation of the state sync coordinator, executor proxy and database static to reduce the fuzzing execution time.

Note: by moving away from mocked services in commit 2 the performance of the fuzzer was slightly reduced. To combat this, commit 3 creates the real services statically and thus increases performance. Before this PR, I saw 40 exec/s locally (mocked services), but with this PR I now see 45 exec/s locally (real services). Although performance still isn't great, we've moved forward a little.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Running the fuzzer locally seems to work.

## Related PRs

None, but this relates to: https://github.com/diem/diem/issues/6795