### PR TITLE
Cherry-pick PR #7150 into release-1.1: [secure-storage] support github branches

### DIFF
--- a/config/management/src/secure_backend.rs
+++ b/config/management/src/secure_backend.rs
@@ -85,6 +85,7 @@ impl TryInto<config::SecureBackend> for SecureBackend {
                     .parameters
                     .remove("repository")
                     .ok_or_else(|| Error::BackendParsingError("missing repository".into()))?;
+                let branch = self.parameters.remove("branch");
                 let token = self
                     .parameters
                     .remove("token")
@@ -93,6 +94,7 @@ impl TryInto<config::SecureBackend> for SecureBackend {
                     namespace: self.parameters.remove("namespace"),
                     repository_owner,
                     repository,
+                    branch,
                     token: Token::FromDisk(PathBuf::from(token)),
                 })
             }
@@ -147,6 +149,7 @@ pair: "k0=v0;k1=v1;...".  The current supported formats are:
         an optional namespace: "namespace=NAMESPACE"
         an optional server certificate: "ca_certificate=PATH_TO_CERT"
     GitHub: "backend=github;repository_owner=REPOSITORY_OWNER;repository=REPOSITORY;token=PATH_TO_TOKEN"
+        an optional branch: "branch=BRANCH", defaults to master
         an optional namespace: "namespace=NAMESPACE"
     InMemory: "backend=memory"
     OnDisk: "backend=disk;path=LOCAL_PATH"
@@ -211,7 +214,14 @@ mod tests {
         );
         storage(&github).unwrap();
 
+        let github = format!(
+            "backend=github;repository_owner=diem;repository=diem;branch=genesis;token={};namespace=test",
+            path_str
+        );
+        storage(&github).unwrap();
+
         let github = "backend=github";
+
         storage(github).unwrap_err();
     }
 

--- a/config/src/config/secure_backend_config.rs
+++ b/config/src/config/secure_backend_config.rs
@@ -24,6 +24,8 @@ pub struct GitHubConfig {
     pub repository_owner: String,
     /// The repository where storage will mount
     pub repository: String,
+    /// The branch containing storage, defaults to master
+    pub branch: Option<String>,
     /// The authorization token for accessing the repository
     pub token: Token,
     /// A namespace is an optional portion of the path to a key stored within GitHubConfig. For
@@ -146,6 +148,11 @@ impl From<&SecureBackend> for Storage {
                 let storage = Storage::from(GitHubStorage::new(
                     config.repository_owner.clone(),
                     config.repository.clone(),
+                    config
+                        .branch
+                        .as_ref()
+                        .cloned()
+                        .unwrap_or_else(|| "master".to_string()),
                     config.token.read_token().expect("Unable to read token"),
                 ));
                 if let Some(namespace) = &config.namespace {

--- a/secure/storage/github/src/lib.rs
+++ b/secure/storage/github/src/lib.rs
@@ -16,8 +16,8 @@ const URL: &str = "https://api.github.com";
 
 #[derive(Debug, Error, PartialEq)]
 pub enum Error {
-    #[error("Http error: {1}")]
-    HttpError(u16, String),
+    #[error("Http error, status code: {0}, status text: {1}, body: {2}")]
+    HttpError(u16, String, String),
     #[error("Internal error: {0}")]
     InternalError(String),
     #[error("Missing field {0}")]
@@ -36,7 +36,18 @@ impl From<std::io::Error> for Error {
 
 impl From<ureq::Response> for Error {
     fn from(resp: ureq::Response) -> Self {
-        Error::HttpError(resp.status(), resp.status_line().into())
+        if let Some(e) = resp.synthetic_error() {
+            // Local error
+            Error::InternalError(e.to_string())
+        } else {
+            // Clear the buffer
+            let status = resp.status();
+            let status_text = resp.status_text().to_string();
+            match resp.into_string() {
+                Ok(body) => Error::HttpError(status, status_text, body),
+                Err(e) => Error::InternalError(e.to_string()),
+            }
+        }
     }
 }
 
@@ -53,16 +64,18 @@ impl From<serde_json::Error> for Error {
 /// repository. The tooling is intended to be used to exchange data in an authenticated fashion
 /// across multiple peers.
 pub struct Client {
-    repository: String,
+    branch: String,
     owner: String,
+    repository: String,
     token: String,
 }
 
 impl Client {
-    pub fn new(owner: String, repository: String, token: String) -> Self {
+    pub fn new(owner: String, repository: String, branch: String, token: String) -> Self {
         Self {
-            repository,
+            branch,
             owner,
+            repository,
             token,
         }
     }
@@ -77,8 +90,10 @@ impl Client {
         };
 
         let resp = self
-            .upgrade_request(ureq::delete(&self.url(path)))
-            .send_json(json!({ "message": "diem-secure", "sha": hash }));
+            .upgrade_request(ureq::delete(&self.post_url(path)))
+            .send_json(
+                json!({ "branch": self.branch.to_string(), "message": "diem-secure", "sha": hash }),
+            );
 
         match resp.status() {
             200 => Ok(()),
@@ -88,7 +103,7 @@ impl Client {
 
     /// Recursively delete all files, which as a by product will delete all folders
     pub fn delete_directory(&self, path: &str) -> Result<(), Error> {
-        let files = self.get_directory(path)?;
+        let files = self.get_directory(path.trim_end_matches('/'))?;
         for file in files {
             if file.ends_with('/') {
                 self.delete_directory(&file[..file.len() - 1])?;
@@ -153,16 +168,16 @@ impl Client {
     pub fn put(&self, path: &str, content: &str) -> Result<(), Error> {
         let json = match self.get_sha(path) {
             Ok(hash) => {
-                json!({ "content": content, "message": format!("[diem-management] {}", path), "sha": hash })
+                json!({ "branch": self.branch.to_string(), "content": content, "message": format!("[diem-management] {}", path), "sha": hash })
             }
             Err(Error::NotFound(_)) => {
-                json!({ "content": content, "message": format!("[diem-management] {}", path) })
+                json!({ "branch": self.branch.to_string(), "content": content, "message": format!("[diem-management] {}", path) })
             }
             Err(e) => return Err(e),
         };
 
         let resp = self
-            .upgrade_request(ureq::put(&self.url(path)))
+            .upgrade_request(ureq::put(&self.post_url(path)))
             .send_json(json);
 
         match resp.status() {
@@ -191,7 +206,7 @@ impl Client {
 
     /// Get can read files or directories, this makes it easier to use
     fn get_internal(&self, path: &str) -> Result<Vec<GetResponse>, Error> {
-        let resp = self.upgrade_request(ureq::get(&self.url(path))).call();
+        let resp = self.upgrade_request(ureq::get(&self.get_url(path))).call();
         match resp.status() {
             200 => {
                 let resp = resp.into_string()?;
@@ -229,10 +244,17 @@ impl Client {
         }
     }
 
-    fn url(&self, path: &str) -> String {
+    fn post_url(&self, path: &str) -> String {
         format!(
             "{}/repos/{}/{}/contents/{}",
             URL, self.owner, self.repository, path
+        )
+    }
+
+    fn get_url(&self, path: &str) -> String {
+        format!(
+            "{}/repos/{}/{}/contents/{}?ref={}",
+            URL, self.owner, self.repository, path, self.branch
         )
     }
 }
@@ -266,6 +288,8 @@ mod tests {
 
     const OWNER: &str = "OWNER";
     const REPOSITORY: &str = "REPOSITORY";
+    // This framework will not create branches, it must already exist!
+    const BRANCH: &str = "BRANCH";
     const TOKEN: &str = "TOKEN";
 
     #[ignore]
@@ -277,7 +301,7 @@ mod tests {
         let value2 = "world";
         let value2_encoded = base64::encode(&value2);
 
-        let github = Client::new(OWNER.into(), REPOSITORY.into(), TOKEN.into());
+        let github = Client::new(OWNER.into(), REPOSITORY.into(), BRANCH.into(), TOKEN.into());
 
         // Try a create
         github.get_file(path).unwrap_err();
@@ -310,7 +334,7 @@ mod tests {
         let value2 = "world";
         let value2_encoded = base64::encode(&value2);
 
-        let github = Client::new(OWNER.into(), REPOSITORY.into(), TOKEN.into());
+        let github = Client::new(OWNER.into(), REPOSITORY.into(), BRANCH.into(), TOKEN.into());
 
         // Initialize two directories with a file each
         github.put(path1, &value1_encoded).unwrap();
@@ -349,7 +373,7 @@ mod tests {
         let value = "hello";
         let value_encoded = base64::encode(&value);
 
-        let github = Client::new(OWNER.into(), REPOSITORY.into(), TOKEN.into());
+        let github = Client::new(OWNER.into(), REPOSITORY.into(), BRANCH.into(), TOKEN.into());
 
         github.put(file0, &value_encoded).unwrap();
         github.put(file1, &value_encoded).unwrap();
@@ -370,9 +394,9 @@ mod tests {
     #[ignore]
     #[test]
     fn test_branches() {
-        let github = Client::new(OWNER.into(), REPOSITORY.into(), TOKEN.into());
+        let github = Client::new(OWNER.into(), REPOSITORY.into(), BRANCH.into(), TOKEN.into());
         let branches = github.get_branches().unwrap();
         assert!(!branches.is_empty());
-        assert!(branches.iter().any(|b| b == "master"));
+        assert!(branches.iter().any(|b| b == BRANCH));
     }
 }

--- a/secure/storage/src/error.rs
+++ b/secure/storage/src/error.rs
@@ -67,7 +67,7 @@ impl From<diem_github_client::Error> for Error {
     fn from(error: diem_github_client::Error) -> Self {
         match error {
             diem_github_client::Error::NotFound(key) => Self::KeyNotSet(key),
-            diem_github_client::Error::HttpError(403, _) => Self::PermissionDenied,
+            diem_github_client::Error::HttpError(403, _, _) => Self::PermissionDenied,
             _ => Self::InternalError(format!("{}", error)),
         }
     }

--- a/secure/storage/src/github.rs
+++ b/secure/storage/src/github.rs
@@ -14,9 +14,9 @@ pub struct GitHubStorage {
 }
 
 impl GitHubStorage {
-    pub fn new(owner: String, repository: String, token: String) -> Self {
+    pub fn new(owner: String, repository: String, branch: String, token: String) -> Self {
         Self {
-            client: Client::new(owner, repository, token),
+            client: Client::new(owner, repository, branch, token),
             time_service: RealTimeService::new(),
         }
     }

--- a/secure/storage/src/tests/github.rs
+++ b/secure/storage/src/tests/github.rs
@@ -5,6 +5,8 @@ use crate::{tests::suite, GitHubStorage, Storage};
 
 const OWNER: &str = "OWNER";
 const REPOSITORY: &str = "REPOSITORY";
+// This framework will not create branches, it must already exist!
+const BRANCH: &str = "BRANCH";
 const TOKEN: &str = "TOKEN";
 
 // These tests must be run in series via: `cargo xtest -- --ignored --test-threads=1`
@@ -16,6 +18,7 @@ fn github_storage() {
     let mut storage = Storage::from(GitHubStorage::new(
         OWNER.into(),
         REPOSITORY.into(),
+        BRANCH.into(),
         TOKEN.into(),
     ));
     suite::execute_all_storage_tests(&mut storage);

--- a/secure/storage/src/tests/suite.rs
+++ b/secure/storage/src/tests/suite.rs
@@ -41,6 +41,7 @@ const CRYPTO_NAME: &str = "Test_Key_Name";
 
 /// Executes all storage tests on a given storage backend.
 pub fn execute_all_storage_tests(storage: &mut Storage) {
+    storage.reset_and_clear().unwrap();
     for test in STORAGE_TESTS.iter() {
         test(storage);
         storage.reset_and_clear().unwrap();


### PR DESCRIPTION
We leverage github for genesis ceremonies and post genesis validator operations. Currently the code only supports a single branch. We cannot perform post genesis validator operations on the genesis repository without potentially corrupting the data that feeds into genesis. We also have operators generate genesis when onboarding. This adds support for branches so that we can lock genesis branch and still have folks build it when onboarding.

This is a tooling change only as github isn't used as a secure backend otherwise.

Tested via integration tests.