### PR TITLE
[rate-limiter] Add Optional Rate limit metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2018,6 +2018,7 @@ version = "0.1.0"
 dependencies = [
  "diem-infallible",
  "diem-logger",
+ "diem-metrics",
  "diem-workspace-hack",
  "futures 0.3.12",
  "pin-project 1.0.4",

--- a/common/rate-limiter/Cargo.toml
+++ b/common/rate-limiter/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 diem-infallible = { path="../infallible", version = "0.1.0" }
 diem-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
 diem-logger = { path = "../logger", version = "0.1.0" }
+diem-metrics = { path = "../metrics", version = "0.1.0" }
 futures = "0.3.12"
 pin-project = "1.0.4"
 tokio = { version = "1.0.2", features = ["full"] }

--- a/common/rate-limiter/src/async_lib.rs
+++ b/common/rate-limiter/src/async_lib.rs
@@ -178,7 +178,14 @@ mod tests {
     #[tokio::test]
     async fn test_async_read() {
         let source: &[u8] = b"12345678901234567890123456";
-        let rate_limiter = Arc::new(Mutex::new(Bucket::new("test".to_string(), 15, 15, 5)));
+        let rate_limiter = Arc::new(Mutex::new(Bucket::new(
+            "test".to_string(),
+            "test".to_string(),
+            15,
+            15,
+            5,
+            None,
+        )));
         let mut reader = AsyncRateLimiter::new(source, Some(rate_limiter));
 
         let mut buf: [u8; 30] = [0; 30];

--- a/common/rate-limiter/src/async_lib.rs
+++ b/common/rate-limiter/src/async_lib.rs
@@ -181,6 +181,7 @@ mod tests {
         let rate_limiter = Arc::new(Mutex::new(Bucket::new(
             "test".to_string(),
             "test".to_string(),
+            "test".to_string(),
             15,
             15,
             5,

--- a/common/rate-limiter/src/main.rs
+++ b/common/rate-limiter/src/main.rs
@@ -242,7 +242,14 @@ async fn test_rate_limiter<
 }
 
 fn simple_shared_bucket(label: &'static str, size: usize) -> SharedBucket {
-    Arc::new(Mutex::new(Bucket::new(label.to_string(), size, size, size)))
+    Arc::new(Mutex::new(Bucket::new(
+        label.to_string(),
+        "key".to_string(),
+        size,
+        size,
+        size,
+        None,
+    )))
 }
 
 /// For comparison, no rate limiting

--- a/common/rate-limiter/src/main.rs
+++ b/common/rate-limiter/src/main.rs
@@ -244,6 +244,7 @@ async fn test_rate_limiter<
 fn simple_shared_bucket(label: &'static str, size: usize) -> SharedBucket {
     Arc::new(Mutex::new(Bucket::new(
         label.to_string(),
+        String::new(),
         "key".to_string(),
         size,
         size,

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -39,8 +39,8 @@ pub const MAX_FULLNODE_OUTBOUND_CONNECTIONS: usize = 3;
 pub const MAX_INBOUND_CONNECTIONS: usize = 100;
 pub const MAX_FRAME_SIZE: usize = 8 * 1024 * 1024; /* 8 MiB */
 pub const CONNECTION_BACKOFF_BASE: u64 = 2;
-pub const INBOUND_IP_BYTE_BUCKET_RATE: usize = MAX_FRAME_SIZE;
-pub const INBOUND_IP_BYTE_BUCKET_SIZE: usize = INBOUND_IP_BYTE_BUCKET_RATE;
+pub const IP_BYTE_BUCKET_RATE: usize = 102400 /* 100 KiB */;
+pub const IP_BYTE_BUCKET_SIZE: usize = IP_BYTE_BUCKET_RATE;
 
 pub type SeedPublicKeys = HashMap<PeerId, HashSet<x25519::PublicKey>>;
 pub type SeedAddresses = HashMap<PeerId, Vec<NetworkAddress>>;
@@ -321,8 +321,8 @@ pub struct RateLimitConfig {
 impl Default for RateLimitConfig {
     fn default() -> Self {
         Self {
-            ip_byte_bucket_rate: INBOUND_IP_BYTE_BUCKET_RATE,
-            ip_byte_bucket_size: INBOUND_IP_BYTE_BUCKET_SIZE,
+            ip_byte_bucket_rate: IP_BYTE_BUCKET_RATE,
+            ip_byte_bucket_size: IP_BYTE_BUCKET_SIZE,
             initial_bucket_fill_percentage: 25,
             enabled: true,
         }

--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -452,3 +452,12 @@ pub static PENDING_PEER_NETWORK_NOTIFICATIONS: Lazy<IntGauge> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+pub static NETWORK_RATE_LIMIT_METRICS: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "diem_network_rate_limit_test",
+        "Network Rate Limiting Metrics",
+        &["direction", "key", "metric"]
+    )
+    .unwrap()
+});

--- a/network/src/peer_manager/builder.rs
+++ b/network/src/peer_manager/builder.rs
@@ -464,6 +464,7 @@ fn token_bucket_rate_limiter(
                 config.initial_bucket_fill_percentage,
                 config.ip_byte_bucket_size,
                 config.ip_byte_bucket_rate,
+                None,
             );
         }
     }


### PR DESCRIPTION
Adding rate limit metrics at the rate limiter level.  Logging provides more detail, but to not cause excess cardinality issues in the metrics system, metrics are not at a key level.