### PR TITLE
[diem] Don't use serde::export private types

### DIFF
--- a/language/move-model/src/builder/module_builder.rs
+++ b/language/move-model/src/builder/module_builder.rs
@@ -1,11 +1,13 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+};
 
 use itertools::Itertools;
 use regex::Regex;
-use serde::export::{fmt, Formatter};
 
 use bytecode_source_map::source_map::SourceMap;
 use move_ir_types::{ast::ConstantName, location::Spanned};
@@ -85,7 +87,7 @@ pub enum SpecBlockContext<'a> {
 }
 
 impl<'a> fmt::Display for SpecBlockContext<'a> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use SpecBlockContext::*;
         match self {
             Module => write!(f, "module context")?,

--- a/network/netcore/src/transport/mod.rs
+++ b/network/netcore/src/transport/mod.rs
@@ -14,7 +14,7 @@
 use diem_network_address::NetworkAddress;
 use diem_types::PeerId;
 use futures::{future::Future, stream::Stream};
-use serde::{export::Formatter, Serialize};
+use serde::Serialize;
 use std::fmt;
 
 pub mod and_then;
@@ -43,13 +43,13 @@ impl ConnectionOrigin {
 }
 
 impl fmt::Debug for ConnectionOrigin {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }
 }
 
 impl fmt::Display for ConnectionOrigin {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }
 }

--- a/network/src/connectivity_manager/mod.rs
+++ b/network/src/connectivity_manager/mod.rs
@@ -47,7 +47,7 @@ use rand::{
     prelude::{SeedableRng, SmallRng},
     seq::SliceRandom,
 };
-use serde::{export::Formatter, Serialize};
+use serde::Serialize;
 use std::{
     cmp::min,
     collections::{HashMap, HashSet},
@@ -110,13 +110,13 @@ pub enum DiscoverySource {
 }
 
 impl fmt::Debug for DiscoverySource {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self)
     }
 }
 
 impl fmt::Display for DiscoverySource {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{}",

--- a/network/src/peer/mod.rs
+++ b/network/src/peer/mod.rs
@@ -36,8 +36,8 @@ use futures::{
     FutureExt, SinkExt, TryFutureExt,
 };
 use netcore::compat::IoCompat;
-use serde::{export::Formatter, Serialize};
-use std::{fmt::Debug, sync::Arc, time::Duration};
+use serde::Serialize;
+use std::{fmt, sync::Arc, time::Duration};
 use tokio::runtime::Handle;
 
 #[cfg(test)]
@@ -65,8 +65,8 @@ pub enum DisconnectReason {
     ConnectionLost,
 }
 
-impl std::fmt::Display for DisconnectReason {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for DisconnectReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{}",

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -39,10 +39,10 @@ use futures::{
     stream::{Fuse, FuturesUnordered, StreamExt},
 };
 use netcore::transport::{ConnectionOrigin, Transport};
-use serde::{export::Formatter, Serialize};
+use serde::Serialize;
 use std::{
     collections::{hash_map::Entry, HashMap},
-    fmt::Debug,
+    fmt,
     marker::PhantomData,
     net::{IpAddr, Ipv4Addr},
     sync::Arc,
@@ -97,14 +97,14 @@ pub enum ConnectionNotification {
     LostPeer(ConnectionMetadata, Arc<NetworkContext>, DisconnectReason),
 }
 
-impl std::fmt::Debug for ConnectionNotification {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for ConnectionNotification {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self)
     }
 }
 
-impl std::fmt::Display for ConnectionNotification {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for ConnectionNotification {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ConnectionNotification::NewPeer(metadata, context) => {
                 write!(f, "[{},{}]", metadata, context)

--- a/network/src/protocols/wire/handshake/v1/mod.rs
+++ b/network/src/protocols/wire/handshake/v1/mod.rs
@@ -12,7 +12,7 @@
 
 use diem_config::network_id::NetworkId;
 use diem_types::chain_id::ChainId;
-use serde::{export::Formatter, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, convert::TryInto, fmt, iter::Iterator};
 use thiserror::Error;
 
@@ -119,13 +119,13 @@ pub enum MessagingProtocolVersion {
 }
 
 impl fmt::Debug for MessagingProtocolVersion {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self)
     }
 }
 
 impl fmt::Display for MessagingProtocolVersion {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{}",
@@ -232,13 +232,13 @@ impl HandshakeMsg {
 }
 
 impl fmt::Debug for HandshakeMsg {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self)
     }
 }
 
 impl fmt::Display for HandshakeMsg {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "[{},{},{:?}]",

--- a/network/src/transport/mod.rs
+++ b/network/src/transport/mod.rs
@@ -23,12 +23,11 @@ use futures::{
     stream::{Stream, StreamExt, TryStreamExt},
 };
 use netcore::transport::{proxy_protocol, tcp, ConnectionOrigin, Transport};
-use serde::{export::Formatter, Serialize};
+use serde::Serialize;
 use std::{
     collections::BTreeMap,
     convert::TryFrom,
-    fmt::Debug,
-    io,
+    fmt, io,
     pin::Pin,
     sync::{
         atomic::{AtomicU32, Ordering},
@@ -63,9 +62,9 @@ pub const DIEM_TCP_TRANSPORT: tcp::TcpTransport = tcp::TcpTransport {
 };
 
 /// A trait alias for "socket-like" things.
-pub trait TSocket: AsyncRead + AsyncWrite + Send + Debug + Unpin + 'static {}
+pub trait TSocket: AsyncRead + AsyncWrite + Send + fmt::Debug + Unpin + 'static {}
 
-impl<T> TSocket for T where T: AsyncRead + AsyncWrite + Send + Debug + Unpin + 'static {}
+impl<T> TSocket for T where T: AsyncRead + AsyncWrite + Send + fmt::Debug + Unpin + 'static {}
 
 /// Unique local identifier for a connection.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash, Serialize)]
@@ -151,14 +150,14 @@ impl ConnectionMetadata {
     }
 }
 
-impl std::fmt::Debug for ConnectionMetadata {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for ConnectionMetadata {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self)
     }
 }
 
-impl std::fmt::Display for ConnectionMetadata {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for ConnectionMetadata {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "[{},{},{},{},{:?}]",

--- a/storage/backup/backup-cli/src/metadata/view.rs
+++ b/storage/backup/backup-cli/src/metadata/view.rs
@@ -7,8 +7,7 @@ use crate::metadata::{
 use anyhow::{anyhow, ensure, Result};
 use diem_types::transaction::Version;
 use itertools::Itertools;
-use serde::export::Formatter;
-use std::{fmt::Display, str::FromStr};
+use std::{fmt, str::FromStr};
 
 pub struct MetadataView {
     epoch_ending_backups: Vec<EpochEndingBackupMeta>,
@@ -131,8 +130,8 @@ pub struct BackupStorageState {
     pub latest_transaction_version: Option<Version>,
 }
 
-impl Display for BackupStorageState {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for BackupStorageState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "latest_epoch_ending_epoch: {}, latest_state_snapshot_version: {}, latest_transaction_version: {}",

--- a/storage/diemdb/src/backup/backup_handler.rs
+++ b/storage/diemdb/src/backup/backup_handler.rs
@@ -22,8 +22,8 @@ use diem_types::{
     transaction::{Transaction, TransactionInfo, Version},
 };
 use itertools::zip_eq;
-use serde::{export::Formatter, Deserialize, Serialize};
-use std::{fmt::Display, sync::Arc};
+use serde::{Deserialize, Serialize};
+use std::{fmt, sync::Arc};
 
 /// `BackupHandler` provides functionalities for DiemDB data backup.
 #[derive(Clone)]
@@ -190,8 +190,8 @@ pub struct DbState {
     pub synced_version: Version,
 }
 
-impl Display for DbState {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for DbState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "epoch: {}, committed_version: {}, synced_version: {}",

--- a/types/src/account_state.rs
+++ b/types/src/account_state.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 use anyhow::{format_err, Error, Result};
 use move_core_types::{identifier::Identifier, move_resource::MoveResource};
-use serde::{de::DeserializeOwned, export::Formatter, Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{collections::btree_map::BTreeMap, convert::TryFrom, fmt};
 
 #[derive(Default, Deserialize, PartialEq, Serialize)]
@@ -214,7 +214,7 @@ impl AccountState {
 }
 
 impl fmt::Debug for AccountState {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // TODO: add support for other types of resources
         let account_resource_str = self
             .get_account_resource()

--- a/types/src/chain_id.rs
+++ b/types/src/chain_id.rs
@@ -1,12 +1,8 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 use anyhow::{ensure, format_err, Error, Result};
-use serde::{de::Visitor, export::fmt::Debug, Deserialize, Deserializer, Serialize};
-use std::{
-    convert::TryFrom,
-    fmt::{Display, Formatter},
-    str::FromStr,
-};
+use serde::{de::Visitor, Deserialize, Deserializer, Serialize};
+use std::{convert::TryFrom, fmt, str::FromStr};
 
 /// A registry of named chain IDs
 /// Its main purpose is to improve human readability of reserved chain IDs in config files and CLI
@@ -75,8 +71,8 @@ where
     impl<'de> Visitor<'de> for ChainIdVisitor {
         type Value = ChainId;
 
-        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            formatter.write_str("ChainId as string or u8")
+        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("ChainId as string or u8")
         }
 
         fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
@@ -99,14 +95,14 @@ where
     deserializer.deserialize_any(ChainIdVisitor)
 }
 
-impl Debug for ChainId {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+impl fmt::Debug for ChainId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self)
     }
 }
 
-impl Display for ChainId {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+impl fmt::Display for ChainId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
             "{}",
@@ -116,8 +112,8 @@ impl Display for ChainId {
     }
 }
 
-impl Display for NamedChain {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+impl fmt::Display for NamedChain {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
             "{}",


### PR DESCRIPTION
Serde had a `serde::export` module exposed for use in its proc-macro derive crates, though it was never intended to be used publicly.

With the latest serde release (1.0.119) the `serde::export` module was finally renamed to `serde::__private` to more clearly express that downstream crates should not depend on it: (https://github.com/serde-rs/serde/blob/master/serde/src/lib.rs#L275).

This diff removes all occurances of `use serde::export::{..}` and replaces them with their `use std::{..}` equivalents.