### PR TITLE
[for comments only][language][testing-infra] dump transactions executed in E2E tests which can be picked up for analysis later

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3822,6 +3822,8 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rand 0.7.3",
+ "serde",
+ "serde_json",
  "vm",
  "vm-genesis",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6853,6 +6853,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-explore"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bcs",
+ "compiled-stdlib",
+ "diem-crypto",
+ "diem-types",
+ "diem-workspace-hack",
+ "hex",
+ "move-core-types",
+ "move-vm-runtime",
+ "move-vm-types",
+ "serde",
+ "serde_json",
+ "structopt 0.3.21",
+ "vm",
+]
+
+[[package]]
 name = "test-generation"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ members = [
     "language/tools/move-coverage",
     "language/tools/move-explain",
     "language/tools/resource-viewer",
+    "language/tools/test-explore",
     "language/tools/vm-genesis",
     "language/transaction-builder",
     "language/transaction-builder/generator",

--- a/language/testing-infra/e2e-tests/Cargo.toml
+++ b/language/testing-infra/e2e-tests/Cargo.toml
@@ -28,7 +28,9 @@ diem-vm = { path = "../../diem-vm", version = "0.1.0" }
 proptest = "0.10.1"
 proptest-derive = "0.2.0"
 diem-proptest-helpers = { path = "../../../common/proptest-helpers", version = "0.1.0" }
-diem-config =  { path = "../../../config", version = "0.1.0" }
-compiled-stdlib = { path = "../../stdlib/compiled",  version = "0.1.0" }
+diem-config = { path = "../../../config", version = "0.1.0" }
+compiled-stdlib = { path = "../../stdlib/compiled", version = "0.1.0" }
 diem-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 hex = "0.4.2"
+serde = { version = "1.0.117", features = ["derive"] }
+serde_json = "1.0.60"

--- a/language/tools/test-explore/Cargo.toml
+++ b/language/tools/test-explore/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "test-explore"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+description = "Extracting information from various Move testing infrastructures"
+repository = "https://github.com/diem/diem"
+homepage = "https://diem.com"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0.37"
+hex = "0.4.2"
+serde_json = "1.0.61"
+serde = { version = "1.0.117", features = ["derive", "rc"] }
+structopt = "0.3.21"
+
+bcs = "0.1.2"
+compiled-stdlib = { path = "../../stdlib/compiled", version = "0.1.0" }
+diem-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }
+diem-types = { path = "../../../types", version = "0.1.0" }
+diem-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
+move-core-types = { path = "../../move-core/types", version = "0.1.0" }
+move-vm-runtime = { path = "../../move-vm/runtime", version = "0.1.0" }
+move-vm-types = { path = "../../move-vm/types", version = "0.1.0" }
+vm = { path = "../../vm", version = "0.1.0" }

--- a/language/tools/test-explore/src/analyzer_e2e.rs
+++ b/language/tools/test-explore/src/analyzer_e2e.rs
@@ -1,0 +1,93 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use std::{
+    collections::{BTreeMap, HashSet},
+    fs::{self, File},
+    io::BufReader,
+    path::{Path, PathBuf},
+};
+
+use compiled_stdlib::transaction_scripts::StdlibScript;
+use diem_crypto::HashValue;
+use diem_types::transaction::{Transaction, TransactionPayload, WriteSetPayload};
+
+use crate::ScriptExecPack;
+
+pub struct AnalyzerE2E {
+    diem_scripts: BTreeMap<HashValue, StdlibScript>,
+    _output_dir: PathBuf,
+}
+
+impl AnalyzerE2E {
+    pub fn new(output_dir: PathBuf) -> Self {
+        Self {
+            diem_scripts: StdlibScript::all()
+                .into_iter()
+                .map(|script| (script.hash(), script))
+                .collect(),
+            _output_dir: output_dir,
+        }
+    }
+
+    fn follow_one_trace(
+        &self,
+        dir: &Path,
+        exec_packs: &mut BTreeMap<HashValue, HashSet<ScriptExecPack>>,
+    ) -> Result<()> {
+        for entry in fs::read_dir(dir)? {
+            let item = entry?.path();
+            let file = File::open(item)?;
+            let txn: Transaction = serde_json::from_reader(BufReader::new(file))?;
+
+            if let Transaction::UserTransaction(signed_txn) = txn {
+                let sender_script_opt = match signed_txn.payload() {
+                    TransactionPayload::Script(script) => Some((signed_txn.sender(), script)),
+                    TransactionPayload::Module(_) => None,
+                    TransactionPayload::WriteSet(WriteSetPayload::Direct(_)) => None,
+                    TransactionPayload::WriteSet(WriteSetPayload::Script {
+                        execute_as,
+                        script,
+                    }) => Some((*execute_as, script)),
+                };
+
+                if let Some((sender, script)) = sender_script_opt {
+                    let hash = HashValue::sha3_256_of(script.code());
+                    if self.diem_scripts.get(&hash).is_some() {
+                        let pack = ScriptExecPack {
+                            sender,
+                            ty_args: script.ty_args().to_vec(),
+                            args: script.args().to_vec(),
+                        };
+                        exec_packs
+                            .entry(hash)
+                            .or_insert_with(HashSet::new)
+                            .insert(pack);
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn run_on_trace_dir<P: AsRef<Path>>(&self, trace_dir: P) -> Result<()> {
+        let mut exec_packs = BTreeMap::new();
+        for entry in fs::read_dir(trace_dir)? {
+            let item = entry?.path();
+            self.follow_one_trace(&item, &mut exec_packs)?
+        }
+        for (hash, packs) in exec_packs.into_iter() {
+            let diem_script = self.diem_scripts.get(&hash).unwrap();
+            println!(
+                "Diem script {} is invoked {} times",
+                diem_script.name(),
+                packs.len()
+            );
+            for pack in packs {
+                println!("\t{}", pack);
+            }
+        }
+        Ok(())
+    }
+}

--- a/language/tools/test-explore/src/lib.rs
+++ b/language/tools/test-explore/src/lib.rs
@@ -1,0 +1,38 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+use diem_types::transaction::TransactionArgument;
+use move_core_types::{account_address::AccountAddress, language_storage::TypeTag};
+
+// script invocation package
+#[derive(Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+struct ScriptExecPack {
+    sender: AccountAddress,
+    ty_args: Vec<TypeTag>,
+    args: Vec<TransactionArgument>,
+}
+
+impl fmt::Display for ScriptExecPack {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} [{}] ({}))",
+            self.sender,
+            self.ty_args
+                .iter()
+                .map(|tag| tag.to_string())
+                .collect::<Vec<_>>()
+                .join(", "),
+            self.args
+                .iter()
+                .map(|arg| format!("{:?}", arg))
+                .collect::<Vec<_>>()
+                .join(", "),
+        )
+    }
+}
+
+pub mod analyzer_e2e;

--- a/language/tools/test-explore/src/main.rs
+++ b/language/tools/test-explore/src/main.rs
@@ -1,0 +1,47 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+use test_explore::analyzer_e2e::AnalyzerE2E;
+
+#[derive(StructOpt)]
+#[structopt(rename_all = "kebab-case")]
+pub struct Args {
+    /// type of testing trace to analyze
+    #[structopt(subcommand)]
+    cmd: Command,
+
+    /// directory for the txn traces
+    #[structopt(
+        short = "o",
+        long,
+        default_value = ".",
+        parse(from_os_str),
+        global = true
+    )]
+    output: PathBuf,
+}
+
+#[derive(StructOpt)]
+pub enum Command {
+    /// run on e2e tests
+    #[structopt(name = "e2e")]
+    E2E {
+        /// directory for the txn traces
+        #[structopt(parse(from_os_str))]
+        trace_dir: PathBuf,
+    },
+}
+
+fn main() -> Result<()> {
+    let Args { cmd, output } = Args::from_args();
+    match cmd {
+        Command::E2E { trace_dir } => {
+            let analyzer = AnalyzerE2E::new(output);
+            analyzer.run_on_trace_dir(trace_dir)
+        }
+    }
+}

--- a/x.toml
+++ b/x.toml
@@ -146,6 +146,7 @@ members = [
     "serializer-tests",
     "smoke-test",
     "socket-bench-server",
+    "test-explore",
     "test-generation",
     "x",
     "x-core",


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR is partly for my own curiosity on finding how the Diem stdlib scripts are actually called, i.e., with what type tags and transaction arguments, in those E2E tests. So, I did two things, which correspond to the two commits in this PR:

1. Hook up the `FakeExecutor` and serialize each transaction it executes into a designated directory, controlled by an environment variable `TRACE_TXN=<path-to-trace-dir>`.
2. Wrote a small explorer program to pick up the trace files and collect the actual script invocation pack (i.e., sender address, type tags, and transaction arguments).

I don't have an actual use case beyond my curiosity but this tool may help answer questions like:
1. Which Diem script needs more attention for testing
2. What can be a proper payload to profile the Move VM or more parts in the stack
3. What are the seeding cases for generating random multi-transaction sequences, (i.e., fuzzing)

And just in case someone finds it useful in one way or another, feel free to cherry pick things and play around with it.

## Test Plan

1. To test E2E transaction dumping
```
cd language/e2e-testsuite
TRACE_TXN=<some-dir> cargo xtest
cd <some-dir>
```
You will find a list of directories `language_e2e_testsuite::tests::*` in the trace dir.

2. To get some stats on how each Diem script is invoked
```
cd language/tools/test-explore
cargo run e2e <some-dir>
```
You will find the stats similar to [e2e-test-stats.txt](https://github.com/diem/diem/files/5804170/e2e-test-stats.txt)
