### PR TITLE
[storage] fix flaky pruner test

### DIFF
--- a/storage/diemdb/src/pruner/mod.rs
+++ b/storage/diemdb/src/pruner/mod.rs
@@ -234,10 +234,12 @@ impl Worker {
             .db
             .iter::<StaleNodeIndexSchema>(ReadOptions::default())?;
         iter.seek_to_first();
-        Ok(iter
-            .next()
-            .transpose()?
-            .map_or(0, |(index, _)| index.stale_since_version))
+        Ok(iter.next().transpose()?.map_or(0, |(index, _)| {
+            index
+                .stale_since_version
+                .checked_sub(1)
+                .expect("Nothing is stale since version 0.")
+        }))
     }
 
     /// Log the progress.


### PR DESCRIPTION
## Motivation

The pruner initial seek result should be substituted by 1, otherwise it confuses the test.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

existing coverage

## Related PRs

flaky since #6803