### PR TITLE
[for discussion only][vm] fully backword compatible bytecode format with function visibility info

### DIFF
--- a/language/vm/src/file_format_common.rs
+++ b/language/vm/src/file_format_common.rs
@@ -64,6 +64,8 @@ pub const CONSTANT_SIZE_MAX: u64 = 65535;
 
 pub const SIGNATURE_SIZE_MAX: u64 = 255;
 
+pub const VISIBILITY_FRIENDLIST_COUNT_MAX: u64 = 255;
+
 pub const ACQUIRES_COUNT_MAX: u64 = 255;
 
 pub const FIELD_COUNT_MAX: u64 = 255;


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Here is a fully backward compatible bytecode format for the function visibility scheme I have in mind. I'll explain later what do I mean by fully-backward compatible.

But before that, this PR is based on the following assumptions:
- We prefer callee-side friend list declaration (so we don’t need to look at multiple files to know who can call a particular function).
- Module-level friend list seems to be a reasonable granularity to start with.

In other words, the friend list will be embedded in the function definition bytecode. This is similar to what is currently done (i.e., the `is_public` bit is stored in the function definition bytecode).

Now, here is the explanation on why this change is backward compatible:

The current layout for the bytecode of a function definition:
```
| ULEB128: function_index | U8: flags | Vec<ULEB128>: acquires_list | Optional<Vec<U8>>: code_unit |
```
Note that this `flags` is a bit mysterious here, as it is essentially capturing two information in the current scheme
1. Whether this function `is_public`
2. Whether this function `is_native`

Decomposing this flag, we get essentially the following:
- For public functions:
```
| ULEB128: function_index | U8: (0x1 | is_native) | Vec<ULEB128>: acquires_list | Optional<Vec<U8>>: code_unit |
```
- For private functions:
```
| ULEB128: function_index | U8: (0x0 | is_native) | Vec<ULEB128>: acquires_list | Optional<Vec<U8>>: code_unit |
```

Now here is the new layout in this PR:
```
| ULEB128: function_index | U8: flags | Optional<Vec<ULEB128>>: friends | Vec<ULEB128>: acquires_list | Optional<Vec<U8>>: code_unit |
```

Note that a new section, `| Optional<Vec<ULEB128>>: friends |` is added, which maps to a vector of `ModuleHandleIndex`. But this section is Optional, meaning that it only exists when `flags & IS_PROTECTED_BIT != 0`, and if we further unroll the layout casing on the visibility flag, it means:

- For public functions:
```
| ULEB128: function_index | U8: (0x1 | is_native) | Vec<ULEB128>: acquires_list | Optional<Vec<U8>>: code_unit |
```
- For private functions:
```
| ULEB128: function_index | U8: (0x0 | is_native) | Vec<ULEB128>: acquires_list | Optional<Vec<U8>>: code_unit |
```
- For protected functions:
```
| ULEB128: function_index | U8: (0x4 | is_native) | Vec<ULEB128>: friends | Vec<ULEB128>: acquires_list | Optional<Vec<U8>>: code_unit |
```

Note that in the `public` and `private` case, the new and old layout are exactly the same! Hence, the scheme is fully backward compatible.