### PR TITLE
[move-prover] Add syntax for first-class quantifiers

### DIFF
--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -1363,8 +1363,8 @@ fn bind_with_range_list(
     let rs_: Option<Vec<E::LValueWithRange>> = prs_
         .into_iter()
         .map(|sp!(loc, (pb, pr))| -> Option<E::LValueWithRange> {
-            let b = bind(context, pb)?;
             let r = exp_(context, pr);
+            let b = bind(context, pb)?;
             Some(sp(loc, (b, r)))
         })
         .collect();
@@ -1617,8 +1617,8 @@ fn unbound_names_binds_with_range(
     sp!(_, rs_): &E::LValueWithRangeList,
 ) {
     rs_.iter().rev().for_each(|sp!(_, (b, r))| {
-        unbound_names_exp(unbound, r);
-        unbound_names_bind(unbound, b)
+        unbound_names_bind(unbound, b);
+        unbound_names_exp(unbound, r)
     })
 }
 

--- a/language/move-lang/src/naming/translate.rs
+++ b/language/move-lang/src/naming/translate.rs
@@ -908,7 +908,7 @@ fn exp_(context: &mut Context, e: E::Exp) -> N::Exp {
             NE::UnresolvedError
         }
         // `Name` matches name variants only allowed in specs (we handle the allowed ones above)
-        EE::Index(..) | EE::Lambda(..) | EE::Name(_, Some(_)) => {
+        EE::Index(..) | EE::Lambda(..) | EE::Quant(..) | EE::Name(_, Some(_)) => {
             panic!("ICE unexpected specification construct")
         }
     };

--- a/language/move-model/src/ast.rs
+++ b/language/move-model/src/ast.rs
@@ -515,8 +515,6 @@ pub enum Operation {
 
     // Builtin functions
     Len,
-    All,
-    Any,
     TypeValue,
     TypeDomain,
     Global(Option<MemoryLabel>),

--- a/language/move-model/src/builder/spec_builtins.rs
+++ b/language/move-model/src/builder/spec_builtins.rs
@@ -125,8 +125,6 @@ pub(crate) fn declare_spec_builtins(trans: &mut ModelBuilder<'_>) {
         let vector_t = &Type::Vector(Box::new(param_t.clone()));
         let type_t = &Type::Primitive(PrimitiveType::TypeValue);
         let domain_t = &Type::TypeDomain(Box::new(param_t.clone()));
-        let pred_t = &Type::Fun(vec![param_t.clone()], Box::new(bool_t.clone()));
-        let pred_num_t = &Type::Fun(vec![num_t.clone()], Box::new(bool_t.clone()));
 
         // Constants (max_u8(), etc.)
         trans.define_spec_fun(
@@ -174,26 +172,6 @@ pub(crate) fn declare_spec_builtins(trans: &mut ModelBuilder<'_>) {
             },
         );
         trans.define_spec_fun(
-            trans.builtin_qualified_symbol("$spec_all"),
-            SpecFunEntry {
-                loc: loc.clone(),
-                oper: Operation::All,
-                type_params: vec![param_t.clone()],
-                arg_types: vec![vector_t.clone(), pred_t.clone()],
-                result_type: bool_t.clone(),
-            },
-        );
-        trans.define_spec_fun(
-            trans.builtin_qualified_symbol("$spec_any"),
-            SpecFunEntry {
-                loc: loc.clone(),
-                oper: Operation::Any,
-                type_params: vec![param_t.clone()],
-                arg_types: vec![vector_t.clone(), pred_t.clone()],
-                result_type: bool_t.clone(),
-            },
-        );
-        trans.define_spec_fun(
             trans.builtin_qualified_symbol("update_vector"),
             SpecFunEntry {
                 loc: loc.clone(),
@@ -231,28 +209,6 @@ pub(crate) fn declare_spec_builtins(trans: &mut ModelBuilder<'_>) {
                 type_params: vec![param_t.clone()],
                 arg_types: vec![vector_t.clone(), vector_t.clone()],
                 result_type: vector_t.clone(),
-            },
-        );
-
-        // Ranges
-        trans.define_spec_fun(
-            trans.builtin_qualified_symbol("$spec_all"),
-            SpecFunEntry {
-                loc: loc.clone(),
-                oper: Operation::All,
-                type_params: vec![],
-                arg_types: vec![range_t.clone(), pred_num_t.clone()],
-                result_type: bool_t.clone(),
-            },
-        );
-        trans.define_spec_fun(
-            trans.builtin_qualified_symbol("$spec_any"),
-            SpecFunEntry {
-                loc: loc.clone(),
-                oper: Operation::Any,
-                type_params: vec![],
-                arg_types: vec![range_t.clone(), pred_num_t.clone()],
-                result_type: bool_t.clone(),
             },
         );
 
@@ -320,26 +276,6 @@ pub(crate) fn declare_spec_builtins(trans: &mut ModelBuilder<'_>) {
                 type_params: vec![param_t.clone()],
                 arg_types: vec![],
                 result_type: domain_t.clone(),
-            },
-        );
-        trans.define_spec_fun(
-            trans.builtin_qualified_symbol("$spec_all"),
-            SpecFunEntry {
-                loc: loc.clone(),
-                oper: Operation::All,
-                type_params: vec![param_t.clone()],
-                arg_types: vec![domain_t.clone(), pred_t.clone()],
-                result_type: bool_t.clone(),
-            },
-        );
-        trans.define_spec_fun(
-            trans.builtin_qualified_symbol("$spec_any"),
-            SpecFunEntry {
-                loc: loc.clone(),
-                oper: Operation::Any,
-                type_params: vec![param_t.clone()],
-                arg_types: vec![domain_t.clone(), pred_t.clone()],
-                result_type: bool_t.clone(),
             },
         );
 

--- a/language/move-model/src/exp_rewriter.rs
+++ b/language/move-model/src/exp_rewriter.rs
@@ -67,6 +67,21 @@ impl<'env, 'rewriter> ExpRewriter<'env, 'rewriter> {
                 self.shadowed.pop_front();
                 res
             }
+            Quant(id, kind, ranges, body) => {
+                self.shadowed
+                    .push_front(ranges.iter().map(|(decl, _)| decl.name).collect());
+                let res = Quant(
+                    self.rewrite_attrs(*id),
+                    *kind,
+                    ranges
+                        .iter()
+                        .map(|(decl, range)| (decl.clone(), self.rewrite(range)))
+                        .collect(),
+                    Box::new(self.rewrite(body)),
+                );
+                self.shadowed.pop_front();
+                res
+            }
             Block(id, vars, body) => {
                 self.shadowed
                     .push_front(vars.iter().map(|decl| decl.name).collect());

--- a/language/move-model/src/exp_rewriter.rs
+++ b/language/move-model/src/exp_rewriter.rs
@@ -68,15 +68,16 @@ impl<'env, 'rewriter> ExpRewriter<'env, 'rewriter> {
                 res
             }
             Quant(id, kind, ranges, body) => {
+                let ranges = ranges
+                    .iter()
+                    .map(|(decl, range)| (decl.clone(), self.rewrite(range)))
+                    .collect_vec();
                 self.shadowed
                     .push_front(ranges.iter().map(|(decl, _)| decl.name).collect());
                 let res = Quant(
                     self.rewrite_attrs(*id),
                     *kind,
-                    ranges
-                        .iter()
-                        .map(|(decl, range)| (decl.clone(), self.rewrite(range)))
-                        .collect(),
+                    ranges,
                     Box::new(self.rewrite(body)),
                 );
                 self.shadowed.pop_front();

--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -1973,24 +1973,6 @@ impl<'env> SpecTranslator<'env> {
             Operation::Exists(None) => self.translate_resource_exists(node_id, args),
             Operation::Exists(_) => unimplemented!(),
             Operation::Len => self.translate_primitive_call("$vlen_value", args),
-            Operation::All => {
-                let range = &args[0];
-                match &args[1] {
-                    Exp::Lambda(_, vars, exp) if vars.len() == 1 => {
-                        self.translate_all_or_exists(&loc, QuantKind::Forall, &vars[0], range, exp)
-                    }
-                    _ => self.error(&loc, "2nd argument must be a 1-adic lambda"),
-                }
-            }
-            Operation::Any => {
-                let range = &args[0];
-                match &args[1] {
-                    Exp::Lambda(_, vars, exp) if vars.len() == 1 => {
-                        self.translate_all_or_exists(&loc, QuantKind::Exists, &vars[0], range, exp)
-                    }
-                    _ => self.error(&loc, "2nd argument must be a 1-adic lambda"),
-                }
-            }
             Operation::TypeValue => self.translate_type_value(node_id),
             Operation::TypeDomain => self.error(
                 &loc,


### PR DESCRIPTION
## Motivation

Currently, quantified formulas are represented as a call of the form `$spec_{all,any}(range_expr, lambda_expr)` for each quantified variable. This is limiting our ability to generate accurate triggers.

In this PR, we make quantifiers a proper AST node in Move specs and the Move model AST.
The new AST nodes support quantification of multiple variables but this is not parsed or translated as such yet.

## Test Plan

CI
