### PR TITLE
Cherry-pick PR #7197 into release-1.1: [storage] smaller prune_window

### DIFF
--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -56,8 +56,13 @@ impl Default for StorageConfig {
             backup_service_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 6186),
             dir: PathBuf::from("db"),
             grpc_max_receive_len: Some(100_000_000),
-            // ~50GB state tree history (about 1 day at 100 tps)
-            prune_window: Some(10_000_000),
+            // The prune window must at least out live a RPC request because its sub requests are
+            // to return a consistent view of the DB at exactly same version. Considering a few
+            // thousand TPS we are potentially going to achieve, and a few minutes a consistent view
+            // of the DB might require, 10k (TPS)  * 100 (seconds)  =  1 Million might be a
+            // conservatively safe minimal prune window. It'll take a few Gigabytes of disk space
+            // depending on the size of an average account blob.
+            prune_window: Some(1_000_000),
             data_dir: PathBuf::from("/opt/diem/data"),
             // Default read/write/connection timeout, in milliseconds
             timeout_ms: 30_000,


### PR DESCRIPTION
This cherry-pick was triggerd by a request on #7197
Please review the diff to ensure there are not any unexpected changes.

> ## Motivation
> 
> Considering we don't currently open APIs for querying state history, it's agreed we should use a minimal prune_window, to be more friendly to any one who aims to clone a full chain to their disk.
> 
> (discussion is in https://github.com/diem/partners/issues/724)
> 
> ### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?
> 
> Y
> ## Test Plan
> 
> Will deploy a testnet with the new config.
> 
> ## Related PRs
> 
> 
> 
> (https://github.com/diem/partners/pull/733 removes overrides from configs, so this value is in effect for both the validator and the fullnode)

            
cc @msmouse