### PR TITLE
[move prover] implement pragma friend restricting calling context

### DIFF
--- a/language/move-model/src/pragmas.rs
+++ b/language/move-model/src/pragmas.rs
@@ -50,6 +50,11 @@ pub const ASSUME_NO_ABORT_FROM_HERE_PRAGMA: &str = "assume_no_abort_from_here";
 /// to the verification context even if the implementation of the function is inlined.
 pub const EXPORT_ENSURES_PRAGMA: &str = "export_ensures";
 
+/// Pragma indicating that the function can only be called from certain caller.
+/// Unlike other pragmas, this pragma expects a function name like `0x1::M::f` instead
+/// of a boolean or a number.
+pub const FRIEND_PRAGMA: &str = "friend";
+
 /// Checks whether a pragma is valid in a specific spec block.
 pub fn is_pragma_valid_for_block(target: &SpecBlockContext<'_>, pragma: &str) -> bool {
     use crate::builder::module_builder::SpecBlockContext::*;
@@ -76,6 +81,7 @@ pub fn is_pragma_valid_for_block(target: &SpecBlockContext<'_>, pragma: &str) ->
                 | ADDITION_OVERFLOW_UNCHECKED_PRAGMA
                 | ASSUME_NO_ABORT_FROM_HERE_PRAGMA
                 | EXPORT_ENSURES_PRAGMA
+                | FRIEND_PRAGMA
         ),
         _ => false,
     }

--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -1585,9 +1585,6 @@ impl<'env> SpecTranslator<'env> {
                         .global_env()
                         .get_module(inv.declaring_module)
                         .is_dependency()
-                        || inv.mem_usage.iter().any(|used| {
-                            !self.global_env().get_module(used.module_id).is_dependency()
-                        })
                 })
                 .unwrap_or(true)
         };

--- a/language/move-prover/tests/sources/functional/friend.move
+++ b/language/move-prover/tests/sources/functional/friend.move
@@ -1,0 +1,38 @@
+module TestFriend {
+
+    resource struct R{
+        x: u64,
+    }
+
+
+    public fun f(account: &signer, val: u64) {
+        move_to(account, R{x: val});
+    }
+    spec fun f {
+        pragma friend = gg;
+    }
+
+    spec fun f {
+        /// This pragma declaration overwrites the previous one.
+        pragma friend = g;
+    }
+
+    public fun g(account: &signer, val: u64) {
+        f(account, val);
+    }
+
+    spec fun g {
+        pragma friend = h;
+    }
+
+    public fun h(account: &signer) {
+        g(account, 42);
+    }
+
+    spec module {
+        /// Function f and g both violate this invariant on their own.
+        /// However, since they can only be called from friend h's context, the following
+        /// invariant can't be violated and the prover verifies with no errors.
+        invariant [global] forall addr: address where exists<R>(addr): global<R>(addr).x == 42;
+    }
+}

--- a/language/move-prover/tests/sources/functional/friend_error.exp
+++ b/language/move-prover/tests/sources/functional/friend_error.exp
@@ -1,0 +1,24 @@
+Move prover returns: exiting with analysis errors
+error: function `TestFriendError::f` is called by other functions while it can only be called by its friend M::some_other_fun
+
+   ┌── tests/sources/functional/friend_error.move:7:5 ───
+   │
+ 7 │     public fun f() {}
+   │     ^^^^^^^^^^^^^^^^^
+   │
+
+error: function with a friend cannot be declared as opaque
+
+    ┌── tests/sources/functional/friend_error.move:13:5 ───
+    │
+ 13 │     public fun g() {}
+    │     ^^^^^^^^^^^^^^^^^
+    │
+
+error: function `TestFriendError::g` is called by other functions while it can only be called by its friend h
+
+    ┌── tests/sources/functional/friend_error.move:13:5 ───
+    │
+ 13 │     public fun g() {}
+    │     ^^^^^^^^^^^^^^^^^
+    │

--- a/language/move-prover/tests/sources/functional/friend_error.move
+++ b/language/move-prover/tests/sources/functional/friend_error.move
@@ -1,0 +1,32 @@
+module TestFriendError {
+
+    resource struct R{
+        x: u64,
+    }
+
+    public fun f() {}
+
+    spec fun f {
+        pragma friend = 0x1::M::some_other_fun;
+    }
+
+    public fun g() {}
+
+    spec fun g {
+        pragma friend = h;
+        pragma opaque; // Errors here since g can't be opaque with a friend
+    }
+
+    public fun h() {
+        f(); // Errors here since f can only be called from M::some_other_fun
+        g();
+    }
+
+    spec fun h {
+        pragma friend = i;
+    }
+
+    public fun i() {
+        g(); // Errors here since g can only be called from h
+    }
+}

--- a/language/stdlib/modules/DiemTimestamp.move
+++ b/language/stdlib/modules/DiemTimestamp.move
@@ -41,10 +41,12 @@ module DiemTimestamp {
         move_to(dr_account, timer);
     }
     spec fun set_time_has_started {
-        /// Verification of this function is turned off because it cannot be verified without genesis execution
-        /// context. After time has started, all invariants guarded by `DiemTimestamp::is_operating` will become
-        /// activated and need to hold.
-        pragma verify = false;
+        /// The friend of this function is `Genesis::initialize` which means that
+        /// this function can't be verified on its own and has to be verified in
+        /// context of Genesis execution.
+        /// After time has started, all invariants guarded by `DiemTimestamp::is_operating`
+        /// will become activated and need to hold.
+        pragma friend = 0x1::Genesis::initialize;
         include AbortsIfNotGenesis;
         include CoreAddresses::AbortsIfNotDiemRoot{account: dr_account};
         ensures is_operating();


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
This PR implements a new function level spec `pragma friend`, hoping to simulate the friend visibility feature in Move before it is available. Right now this pragma is only used in `DiemTimestamp`.

If a function `f` has `pragma friend = g` in its spec block, then:
- `f` will not be verified on its own(the same effect as `pragma verify = false`).
- When `f` is supposed to be verified against some global invariants, its friend will be verified instead.
- `f` can't be opaque.
- Functions other than `g` can't call `f`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Added two new tests.


