### PR TITLE
[move-prover] Extend compositional analysis to allow summaries of different type

### DIFF
--- a/language/move-prover/bytecode/src/compositional_analysis.rs
+++ b/language/move-prover/bytecode/src/compositional_analysis.rs
@@ -63,7 +63,7 @@ where
     Self::State: AbstractDomain + 'static,
 {
     /// Specifies mapping from elements of dataflow analysis domain to elements of `Domain`.
-    fn to_summary (&self,state: Self::State) -> Domain;
+    fn to_summary(&self, state: Self::State) -> Domain;
 
     /// Computes a postcondition for the procedure `data` and then maps the postcondition to an
     /// element of abstract domain `Domain` by applying `to_summary` function. The result is stored
@@ -72,8 +72,8 @@ where
         &self,
         func_env: &FunctionEnv<'_>,
         initial_state: Self::State,
-        mut data: FunctionData
-        ) -> FunctionData {
+        mut data: FunctionData,
+    ) -> FunctionData {
         if !func_env.is_native() {
             let cfg = if Self::BACKWARD {
                 unimplemented!("backward compositional analysis")

--- a/language/move-prover/bytecode/src/packed_types_analysis.rs
+++ b/language/move-prover/bytecode/src/packed_types_analysis.rs
@@ -150,7 +150,10 @@ impl<'a> TransferFunctions for PackedTypesAnalysis<'a> {
 }
 
 impl<'a> DataflowAnalysis for PackedTypesAnalysis<'a> {}
-impl<'a> CompositionalAnalysis for PackedTypesAnalysis<'a> {}
+impl<'a> CompositionalAnalysis<PackedTypesState> for PackedTypesAnalysis<'a> {
+    fn to_summary(&self, state: PackedTypesState) -> PackedTypesState {state}
+}
+
 pub struct PackedTypesProcessor();
 impl PackedTypesProcessor {
     pub fn new() -> Box<Self> {

--- a/language/move-prover/bytecode/src/packed_types_analysis.rs
+++ b/language/move-prover/bytecode/src/packed_types_analysis.rs
@@ -151,7 +151,9 @@ impl<'a> TransferFunctions for PackedTypesAnalysis<'a> {
 
 impl<'a> DataflowAnalysis for PackedTypesAnalysis<'a> {}
 impl<'a> CompositionalAnalysis<PackedTypesState> for PackedTypesAnalysis<'a> {
-    fn to_summary(&self, state: PackedTypesState) -> PackedTypesState {state}
+    fn to_summary(&self, state: PackedTypesState) -> PackedTypesState {
+        state
+    }
 }
 
 pub struct PackedTypesProcessor();

--- a/language/move-prover/bytecode/src/usage_analysis.rs
+++ b/language/move-prover/bytecode/src/usage_analysis.rs
@@ -76,7 +76,9 @@ struct MemoryUsageAnalysis<'a> {
 }
 
 impl<'a> DataflowAnalysis for MemoryUsageAnalysis<'a> {}
-impl<'a> CompositionalAnalysis for MemoryUsageAnalysis<'a> {}
+impl<'a> CompositionalAnalysis<UsageState> for MemoryUsageAnalysis<'a> {
+    fn to_summary(&self, state: UsageState) -> UsageState {state}
+}
 pub struct UsageProcessor();
 
 impl UsageProcessor {

--- a/language/move-prover/bytecode/src/usage_analysis.rs
+++ b/language/move-prover/bytecode/src/usage_analysis.rs
@@ -77,7 +77,9 @@ struct MemoryUsageAnalysis<'a> {
 
 impl<'a> DataflowAnalysis for MemoryUsageAnalysis<'a> {}
 impl<'a> CompositionalAnalysis<UsageState> for MemoryUsageAnalysis<'a> {
-    fn to_summary(&self, state: UsageState) -> UsageState {state}
+    fn to_summary(&self, state: UsageState) -> UsageState {
+        state
+    }
 }
 pub struct UsageProcessor();
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Allow client to map summary of compositional analysis to new value.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

N/A (discussed)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/developers.libra.org, and link to your PR here.)
