### PR TITLE
[network] Fix incorrect usage of `select_next_some` in onchain discovery 

### DIFF
--- a/diem-node/src/lib.rs
+++ b/diem-node/src/lib.rs
@@ -48,26 +48,10 @@ pub struct DiemHandle {
     _rpc: Runtime,
     _mempool: Runtime,
     _state_synchronizer: StateSynchronizer,
-    network_runtimes: Vec<Runtime>,
+    _network_runtimes: Vec<Runtime>,
     _consensus_runtime: Option<Runtime>,
     _debug: NodeDebugService,
     _backup: Runtime,
-}
-
-impl DiemHandle {
-    pub fn shutdown(&mut self) {
-        // Shutdown network runtimes to avoid panic error log after DiemHandle is dropped:
-        // thread ‘network-’ panicked at ‘SelectNextSome polled after terminated’,...
-        // stack backtrace:
-        //    ......
-        //    8: network_simple_onchain_discovery::ConfigurationChangeListener::start::{{closure}}
-        //      at network/simple-onchain-discovery/src/lib.rs:175
-        //    ......
-        // Other runtimes don't have same problem.
-        while !self.network_runtimes.is_empty() {
-            self.network_runtimes.remove(0).shutdown_background();
-        }
-    }
 }
 
 pub fn start(config: &NodeConfig, log_file: Option<PathBuf>) {
@@ -482,7 +466,7 @@ pub fn setup_environment(node_config: &NodeConfig, logger: Option<Arc<Logger>>) 
         .spawn(periodic_state_dump(node_config.to_owned(), db_rw));
 
     DiemHandle {
-        network_runtimes,
+        _network_runtimes: network_runtimes,
         _rpc: rpc_runtime,
         _mempool: mempool,
         _state_synchronizer: state_synchronizer,

--- a/json-rpc/tests/node.rs
+++ b/json-rpc/tests/node.rs
@@ -9,14 +9,8 @@ use diem_logger::prelude::FileWriter;
 pub struct Node {
     pub config: NodeConfig,
     pub root_key: diem_crypto::ed25519::Ed25519PrivateKey,
-    node: diem_node::DiemHandle,
+    _node: diem_node::DiemHandle,
     _temp_dir: diem_temppath::TempPath,
-}
-
-impl Drop for Node {
-    fn drop(&mut self) {
-        self.node.shutdown();
-    }
 }
 
 impl Node {
@@ -53,7 +47,7 @@ impl Node {
         Ok(Self {
             root_key,
             config,
-            node,
+            _node: node,
             _temp_dir: temp_dir,
         })
     }


### PR DESCRIPTION
`stream.select_next_some()` returns a `FusedFuture`, which expects callers to check `is_terminated` before polling to ensure callers don't poll the future after it's completed.

In this case, `simple-onchain-discovery` was incorrectly using `select_next_some` inside a loop, expecting that the `reconfig_events` channel would never close. However, it appears that we get occasional panics during node shutdown, as referenced by this comment in diem-node:

> Shutdown network runtimes to avoid panic error log after DiemHandle is dropped:
> thread ‘network-’ panicked at ‘SelectNextSome polled after terminated’,...
> stack backtrace:
>    ......
>    8: network_simple_onchain_discovery::ConfigurationChangeListener::start::{{closure}}
>      at network/simple-onchain-discovery/src/lib.rs:175
>    ......
> Other runtimes don't have same problem.

Then, remove the `DiemHandle::shutdown`, which is no longer necessary after this change.