### PR TITLE
gha: disable sccach

### DIFF
--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -64,3 +64,6 @@ runs:
         echo 'CARGO='$(rustup which cargo --toolchain "$(cat cargo-toolchain)") | tee -a $GITHUB_ENV
         # Pin the version of RUSTC used for all invocations of cargo
         echo 'RUSTUP_TOOLCHAIN='$(cat rust-toolchain) | tee -a $GITHUB_ENV
+
+        # Disable sccache from being used till https://github.com/mozilla/sccache/issues/804 is fixed
+        echo 'SKIP_SCCACHE=1' | tee -a $GITHUB_ENV


### PR DESCRIPTION
We're currently seeing an issue with some tests that use the trybuild
    crate to run. When trybuild is compiled it looks at the `CARGO` env var
    in order to determine which `cargo` binary to use during tests.
    Unfortunately sccache isn't able to properly cache artifacts which
    depend on environment variables at compile time, resulting in the cached
    version of trybuild trying to use a nonexistent version of cargo. This
    should be fixed once https://github.com/mozilla/sccache/issues/804 is
    fixed.