### PR TITLE
[vm] minimize vec allocation and de-allocation in calls to native functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3755,6 +3755,7 @@ dependencies = [
  "move-lang",
  "move-vm-runtime",
  "move-vm-types",
+ "once_cell",
  "proptest",
  "vm",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4283,6 +4283,7 @@ dependencies = [
  "move-vm-types",
  "once_cell",
  "sha2",
+ "smallvec",
  "vm",
 ]
 
@@ -4334,6 +4335,7 @@ dependencies = [
  "proptest",
  "serde",
  "sha2",
+ "smallvec",
  "vm",
 ]
 

--- a/language/benchmarks/Cargo.toml
+++ b/language/benchmarks/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.38"
 criterion = "0.3.3"
+once_cell = "1.4.1"
 proptest = "0.10.1"
 
 bytecode-verifier = { path = "../bytecode-verifier", version = "0.1.0" }

--- a/language/benchmarks/benches/benchmarks.rs
+++ b/language/benchmarks/benches/benchmarks.rs
@@ -31,6 +31,10 @@ fn call(c: &mut Criterion) {
     bench(c, "call");
 }
 
-criterion_group!(vm_benches, arith, call);
+fn natives(c: &mut Criterion) {
+    bench(c, "natives");
+}
+
+criterion_group!(vm_benches, arith, call, natives);
 
 criterion_main!(vm_benches);

--- a/language/benchmarks/src/bench.move
+++ b/language/benchmarks/src/bench.move
@@ -3,6 +3,7 @@
 // `benches/transaction.rs` contains the calling code.
 // The idea is that you build your scenario with a public entry point and a bunch of private functions as needed.
 module Bench {
+    use 0x1::Vector;
 
     //
     // Global helpers
@@ -69,5 +70,43 @@ module Bench {
 
     fun call_2_2(): u64 {
         100 + 300
+    }
+
+    //
+    // `natives` benchmark
+    //
+    fun test_vector_ops<T>(x1: T, x2: T): (T, T) {
+        let v: vector<T> = Vector::empty();
+        check(Vector::length(&v) == 0, 100);
+        Vector::push_back(&mut v, x1);
+        check(Vector::length(&v) == 1, 101);
+        Vector::push_back(&mut v, x2);
+        check(Vector::length(&v) == 2, 102);
+        Vector::swap(&mut v, 0, 1);
+        x1 = Vector::pop_back(&mut v);
+        check(Vector::length(&v) == 1, 103);
+        x2 = Vector::pop_back(&mut v);
+        check(Vector::length(&v) == 0, 104);
+        Vector::destroy_empty(v);
+        (x1, x2)
+    }
+
+    fun test_vector() {
+        test_vector_ops<u8>(1u8, 2u8);
+        test_vector_ops<u64>(1u64, 2u64);
+        test_vector_ops<u128>(1u128, 2u128);
+        test_vector_ops<bool>(true, false);
+        test_vector_ops<address>(0x1, 0x2);
+        test_vector_ops<vector<u8>>(Vector::empty(), Vector::empty());
+    }
+
+    public fun natives() {
+        let i = 0;
+        // 300 is the number of loops to make the benchmark run for a couple of minutes, which is an eternity.
+        // Adjust according to your needs, it's just a reference
+        while (i < 300) {
+            test_vector();
+            i = i + 1;
+        }
     }
 }

--- a/language/benchmarks/src/move_vm.rs
+++ b/language/benchmarks/src/move_vm.rs
@@ -14,44 +14,61 @@ use move_core_types::{
 use move_lang::{compiled_unit::CompiledUnit, shared::Address};
 use move_vm_runtime::{logging::NoContextLog, move_vm::MoveVM};
 use move_vm_types::gas_schedule::{zero_cost_schedule, CostStrategy};
+use once_cell::sync::Lazy;
 use std::path::PathBuf;
 use vm::CompiledModule;
 
+static MOVE_BENCH_SRC_PATH: Lazy<PathBuf> = Lazy::new(|| {
+    vec![env!("CARGO_MANIFEST_DIR"), "src", "bench.move"]
+        .into_iter()
+        .collect()
+});
+
+static STDLIB_VECTOR_SRC_PATH: Lazy<PathBuf> = Lazy::new(|| {
+    vec![
+        env!("CARGO_MANIFEST_DIR"),
+        "..",
+        "stdlib",
+        "modules",
+        "Vector.move",
+    ]
+    .into_iter()
+    .collect()
+});
+
 /// Entry point for the bench, provide a function name to invoke in Module Bench in bench.move.
 pub fn bench(c: &mut Criterion, fun: &str) {
+    let modules = compile_modules();
     let move_vm = MoveVM::new();
-
-    let addr = [0u8; AccountAddress::LENGTH];
-    let module = compile_module(&addr);
-    let sender = AccountAddress::new(addr);
-    execute(c, &move_vm, sender, module, fun);
+    execute(c, &move_vm, modules, fun);
 }
 
-// Compile `bench.move`
-fn compile_module(addr: &[u8; AccountAddress::LENGTH]) -> CompiledModule {
-    // TODO: this has only been tried with `cargo bench` from `diem/src/language/benchmarks`
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    path.push("src/bench.move");
-    let s = path.to_str().expect("no path specified").to_owned();
-
-    let (_files, mut compiled_units) =
-        move_lang::move_compile_and_report(&[s], &[], Some(Address::new(*addr)), None, false)
-            .expect("Error compiling...");
-    match compiled_units.remove(0) {
-        CompiledUnit::Module { module, .. } => module,
-        CompiledUnit::Script { .. } => panic!("Expected a module but received a script"),
-    }
+// Compile `bench.move` and its dependencies
+fn compile_modules() -> Vec<CompiledModule> {
+    let (_files, compiled_units) = move_lang::move_compile_and_report(
+        &[
+            STDLIB_VECTOR_SRC_PATH.to_str().unwrap().to_owned(),
+            MOVE_BENCH_SRC_PATH.to_str().unwrap().to_owned(),
+        ],
+        &[],
+        Some(Address::DIEM_CORE),
+        None,
+        false,
+    )
+    .expect("Error compiling...");
+    compiled_units
+        .into_iter()
+        .map(|unit| match unit {
+            CompiledUnit::Module { module, .. } => module,
+            CompiledUnit::Script { .. } => panic!("Expected a module but received a script"),
+        })
+        .collect()
 }
 
 // execute a given function in the Bench module
-fn execute(
-    c: &mut Criterion,
-    move_vm: &MoveVM,
-    sender: AccountAddress,
-    module: CompiledModule,
-    fun: &str,
-) {
+fn execute(c: &mut Criterion, move_vm: &MoveVM, modules: Vec<CompiledModule>, fun: &str) {
     // establish running context
+    let sender = AccountAddress::new(Address::DIEM_CORE.to_u8());
     let state = EmptyStateView;
     let gas_schedule = zero_cost_schedule();
     let data_cache = StateViewCache::new(&state);
@@ -59,16 +76,18 @@ fn execute(
     let mut session = move_vm.new_session(&data_cache);
     let mut cost_strategy = CostStrategy::system(&gas_schedule, GasUnits::new(100_000_000));
 
-    let mut mod_blob = vec![];
-    module
-        .serialize(&mut mod_blob)
-        .expect("Module serialization error");
-    session
-        .publish_module(mod_blob, sender, &mut cost_strategy, &log_context)
-        .expect("Module must load");
+    for module in modules {
+        let mut mod_blob = vec![];
+        module
+            .serialize(&mut mod_blob)
+            .expect("Module serialization error");
+        session
+            .publish_module(mod_blob, sender, &mut cost_strategy, &log_context)
+            .expect("Module must load");
+    }
 
     // module and function to call
-    let module_id = ModuleId::new(AccountAddress::ZERO, Identifier::new("Bench").unwrap());
+    let module_id = ModuleId::new(sender, Identifier::new("Bench").unwrap());
     let fun_name = IdentStr::new(fun).unwrap_or_else(|_| panic!("Invalid identifier name {}", fun));
 
     // benchmark

--- a/language/move-vm/natives/Cargo.toml
+++ b/language/move-vm/natives/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 once_cell = "1.4.1"
 mirai-annotations = "1.10.1"
 sha2 = "0.9.3"
+smallvec = "1.6.1"
 
 diem-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }
 diem-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }

--- a/language/move-vm/natives/src/account.rs
+++ b/language/move-vm/natives/src/account.rs
@@ -8,6 +8,7 @@ use move_vm_types::{
     natives::function::{native_gas, NativeContext, NativeResult},
     values::Value,
 };
+use smallvec::smallvec;
 use std::collections::VecDeque;
 use vm::errors::PartialVMResult;
 
@@ -21,7 +22,7 @@ pub fn native_create_signer(
 
     let address = pop_arg!(arguments, AccountAddress);
     let cost = native_gas(context.cost_table(), NativeCostIndex::CREATE_SIGNER, 0);
-    Ok(NativeResult::ok_one(cost, Value::signer(address)))
+    Ok(NativeResult::ok(cost, smallvec![Value::signer(address)]))
 }
 
 pub fn native_destroy_signer(
@@ -33,5 +34,5 @@ pub fn native_destroy_signer(
     debug_assert!(arguments.len() == 1);
 
     let cost = native_gas(context.cost_table(), NativeCostIndex::DESTROY_SIGNER, 0);
-    Ok(NativeResult::ok_none(cost))
+    Ok(NativeResult::ok(cost, smallvec![]))
 }

--- a/language/move-vm/natives/src/account.rs
+++ b/language/move-vm/natives/src/account.rs
@@ -21,7 +21,7 @@ pub fn native_create_signer(
 
     let address = pop_arg!(arguments, AccountAddress);
     let cost = native_gas(context.cost_table(), NativeCostIndex::CREATE_SIGNER, 0);
-    Ok(NativeResult::ok(cost, vec![Value::signer(address)]))
+    Ok(NativeResult::ok_one(cost, Value::signer(address)))
 }
 
 pub fn native_destroy_signer(
@@ -33,5 +33,5 @@ pub fn native_destroy_signer(
     debug_assert!(arguments.len() == 1);
 
     let cost = native_gas(context.cost_table(), NativeCostIndex::DESTROY_SIGNER, 0);
-    Ok(NativeResult::ok(cost, vec![]))
+    Ok(NativeResult::ok_none(cost))
 }

--- a/language/move-vm/natives/src/bcs.rs
+++ b/language/move-vm/natives/src/bcs.rs
@@ -43,8 +43,8 @@ pub fn native_to_bytes(
         serialized_value.len(),
     );
 
-    Ok(NativeResult::ok(
+    Ok(NativeResult::ok_one(
         cost,
-        vec![Value::vector_u8(serialized_value)],
+        Value::vector_u8(serialized_value),
     ))
 }

--- a/language/move-vm/natives/src/bcs.rs
+++ b/language/move-vm/natives/src/bcs.rs
@@ -8,6 +8,7 @@ use move_vm_types::{
     natives::function::{native_gas, NativeContext, NativeResult},
     values::{values_impl::Reference, Value},
 };
+use smallvec::smallvec;
 use std::collections::VecDeque;
 use vm::errors::PartialVMResult;
 
@@ -43,8 +44,8 @@ pub fn native_to_bytes(
         serialized_value.len(),
     );
 
-    Ok(NativeResult::ok_one(
+    Ok(NativeResult::ok(
         cost,
-        Value::vector_u8(serialized_value),
+        smallvec![Value::vector_u8(serialized_value)],
     ))
 }

--- a/language/move-vm/natives/src/debug.rs
+++ b/language/move-vm/natives/src/debug.rs
@@ -33,7 +33,7 @@ pub fn native_print(
         println!("[debug] {}", buf);
     }
 
-    Ok(NativeResult::ok(ONE_GAS_UNIT, vec![]))
+    Ok(NativeResult::ok_none(ONE_GAS_UNIT))
 }
 
 #[allow(unused_variables)]
@@ -52,5 +52,5 @@ pub fn native_print_stack_trace(
         println!("{}", s);
     }
 
-    Ok(NativeResult::ok(ONE_GAS_UNIT, vec![]))
+    Ok(NativeResult::ok_none(ONE_GAS_UNIT))
 }

--- a/language/move-vm/natives/src/debug.rs
+++ b/language/move-vm/natives/src/debug.rs
@@ -9,6 +9,7 @@ use move_vm_types::{
     natives::function::{NativeContext, NativeResult},
     values::Value,
 };
+use smallvec::smallvec;
 use std::collections::VecDeque;
 use vm::errors::PartialVMResult;
 
@@ -33,7 +34,7 @@ pub fn native_print(
         println!("[debug] {}", buf);
     }
 
-    Ok(NativeResult::ok_none(ONE_GAS_UNIT))
+    Ok(NativeResult::ok(ONE_GAS_UNIT, smallvec![]))
 }
 
 #[allow(unused_variables)]
@@ -52,5 +53,5 @@ pub fn native_print_stack_trace(
         println!("{}", s);
     }
 
-    Ok(NativeResult::ok_none(ONE_GAS_UNIT))
+    Ok(NativeResult::ok(ONE_GAS_UNIT, smallvec![]))
 }

--- a/language/move-vm/natives/src/event.rs
+++ b/language/move-vm/natives/src/event.rs
@@ -8,6 +8,7 @@ use move_vm_types::{
     natives::function::{native_gas, NativeContext, NativeResult},
     values::Value,
 };
+use smallvec::smallvec;
 use std::collections::VecDeque;
 use vm::errors::PartialVMResult;
 
@@ -34,5 +35,5 @@ pub fn native_emit_event(
         return Ok(NativeResult::err(cost, 0));
     }
 
-    Ok(NativeResult::ok_none(cost))
+    Ok(NativeResult::ok(cost, smallvec![]))
 }

--- a/language/move-vm/natives/src/event.rs
+++ b/language/move-vm/natives/src/event.rs
@@ -34,5 +34,5 @@ pub fn native_emit_event(
         return Ok(NativeResult::err(cost, 0));
     }
 
-    Ok(NativeResult::ok(cost, vec![]))
+    Ok(NativeResult::ok_none(cost))
 }

--- a/language/move-vm/natives/src/hash.rs
+++ b/language/move-vm/natives/src/hash.rs
@@ -29,8 +29,7 @@ pub fn native_sha2_256(
     );
 
     let hash_vec = Sha256::digest(hash_arg.as_slice()).to_vec();
-    let return_values = vec![Value::vector_u8(hash_vec)];
-    Ok(NativeResult::ok(cost, return_values))
+    Ok(NativeResult::ok_one(cost, Value::vector_u8(hash_vec)))
 }
 
 pub fn native_sha3_256(
@@ -50,6 +49,5 @@ pub fn native_sha3_256(
     );
 
     let hash_vec = HashValue::sha3_256_of(hash_arg.as_slice()).to_vec();
-    let return_values = vec![Value::vector_u8(hash_vec)];
-    Ok(NativeResult::ok(cost, return_values))
+    Ok(NativeResult::ok_one(cost, Value::vector_u8(hash_vec)))
 }

--- a/language/move-vm/natives/src/hash.rs
+++ b/language/move-vm/natives/src/hash.rs
@@ -9,6 +9,7 @@ use move_vm_types::{
     values::Value,
 };
 use sha2::{Digest, Sha256};
+use smallvec::smallvec;
 use std::collections::VecDeque;
 use vm::errors::PartialVMResult;
 
@@ -29,7 +30,10 @@ pub fn native_sha2_256(
     );
 
     let hash_vec = Sha256::digest(hash_arg.as_slice()).to_vec();
-    Ok(NativeResult::ok_one(cost, Value::vector_u8(hash_vec)))
+    Ok(NativeResult::ok(
+        cost,
+        smallvec![Value::vector_u8(hash_vec)],
+    ))
 }
 
 pub fn native_sha3_256(
@@ -49,5 +53,8 @@ pub fn native_sha3_256(
     );
 
     let hash_vec = HashValue::sha3_256_of(hash_arg.as_slice()).to_vec();
-    Ok(NativeResult::ok_one(cost, Value::vector_u8(hash_vec)))
+    Ok(NativeResult::ok(
+        cost,
+        smallvec![Value::vector_u8(hash_vec)],
+    ))
 }

--- a/language/move-vm/natives/src/signature.rs
+++ b/language/move-vm/natives/src/signature.rs
@@ -29,8 +29,7 @@ pub fn native_ed25519_publickey_validation(
 
     // This deserialization performs point-on-curve and small subgroup checks
     let valid = ed25519::Ed25519PublicKey::try_from(&key_bytes[..]).is_ok();
-    let return_values = vec![Value::bool(valid)];
-    Ok(NativeResult::ok(cost, return_values))
+    Ok(NativeResult::ok_one(cost, Value::bool(valid)))
 }
 
 pub fn native_ed25519_signature_verification(
@@ -54,16 +53,16 @@ pub fn native_ed25519_signature_verification(
     let sig = match ed25519::Ed25519Signature::try_from(signature.as_slice()) {
         Ok(sig) => sig,
         Err(_) => {
-            return Ok(NativeResult::ok(cost, vec![Value::bool(false)]));
+            return Ok(NativeResult::ok_one(cost, Value::bool(false)));
         }
     };
     let pk = match ed25519::Ed25519PublicKey::try_from(pubkey.as_slice()) {
         Ok(pk) => pk,
         Err(_) => {
-            return Ok(NativeResult::ok(cost, vec![Value::bool(false)]));
+            return Ok(NativeResult::ok_one(cost, Value::bool(false)));
         }
     };
 
     let verify_result = sig.verify_arbitrary_msg(msg.as_slice(), &pk).is_ok();
-    Ok(NativeResult::ok(cost, vec![Value::bool(verify_result)]))
+    Ok(NativeResult::ok_one(cost, Value::bool(verify_result)))
 }

--- a/language/move-vm/natives/src/signature.rs
+++ b/language/move-vm/natives/src/signature.rs
@@ -8,6 +8,7 @@ use move_vm_types::{
     natives::function::{native_gas, NativeContext, NativeResult},
     values::Value,
 };
+use smallvec::smallvec;
 use std::{collections::VecDeque, convert::TryFrom};
 use vm::errors::PartialVMResult;
 
@@ -29,7 +30,7 @@ pub fn native_ed25519_publickey_validation(
 
     // This deserialization performs point-on-curve and small subgroup checks
     let valid = ed25519::Ed25519PublicKey::try_from(&key_bytes[..]).is_ok();
-    Ok(NativeResult::ok_one(cost, Value::bool(valid)))
+    Ok(NativeResult::ok(cost, smallvec![Value::bool(valid)]))
 }
 
 pub fn native_ed25519_signature_verification(
@@ -53,16 +54,19 @@ pub fn native_ed25519_signature_verification(
     let sig = match ed25519::Ed25519Signature::try_from(signature.as_slice()) {
         Ok(sig) => sig,
         Err(_) => {
-            return Ok(NativeResult::ok_one(cost, Value::bool(false)));
+            return Ok(NativeResult::ok(cost, smallvec![Value::bool(false)]));
         }
     };
     let pk = match ed25519::Ed25519PublicKey::try_from(pubkey.as_slice()) {
         Ok(pk) => pk,
         Err(_) => {
-            return Ok(NativeResult::ok_one(cost, Value::bool(false)));
+            return Ok(NativeResult::ok(cost, smallvec![Value::bool(false)]));
         }
     };
 
     let verify_result = sig.verify_arbitrary_msg(msg.as_slice(), &pk).is_ok();
-    Ok(NativeResult::ok_one(cost, Value::bool(verify_result)))
+    Ok(NativeResult::ok(
+        cost,
+        smallvec![Value::bool(verify_result)],
+    ))
 }

--- a/language/move-vm/natives/src/signer.rs
+++ b/language/move-vm/natives/src/signer.rs
@@ -21,8 +21,8 @@ pub fn native_borrow_address(
     let signer_reference = pop_arg!(arguments, SignerRef);
     let cost = native_gas(context.cost_table(), NativeCostIndex::SIGNER_BORROW, 1);
 
-    Ok(NativeResult::ok(
+    Ok(NativeResult::ok_one(
         cost,
-        vec![signer_reference.borrow_signer()?],
+        signer_reference.borrow_signer()?,
     ))
 }

--- a/language/move-vm/natives/src/signer.rs
+++ b/language/move-vm/natives/src/signer.rs
@@ -7,6 +7,7 @@ use move_vm_types::{
     natives::function::{native_gas, NativeContext, NativeResult},
     values::{values_impl::SignerRef, Value},
 };
+use smallvec::smallvec;
 use std::collections::VecDeque;
 use vm::errors::PartialVMResult;
 
@@ -21,8 +22,8 @@ pub fn native_borrow_address(
     let signer_reference = pop_arg!(arguments, SignerRef);
     let cost = native_gas(context.cost_table(), NativeCostIndex::SIGNER_BORROW, 1);
 
-    Ok(NativeResult::ok_one(
+    Ok(NativeResult::ok(
         cost,
-        signer_reference.borrow_signer()?,
+        smallvec![signer_reference.borrow_signer()?],
     ))
 }

--- a/language/move-vm/natives/src/vector.rs
+++ b/language/move-vm/natives/src/vector.rs
@@ -8,6 +8,7 @@ use move_vm_types::{
     natives::function::{native_gas, NativeContext, NativeResult},
     values::{Value, Vector, VectorRef},
 };
+use smallvec::smallvec;
 use std::collections::VecDeque;
 use vm::errors::PartialVMResult;
 
@@ -36,7 +37,7 @@ pub fn native_length(
     let cost = native_gas(context.cost_table(), NativeCostIndex::LENGTH, 1);
 
     let len = r.len(&ty_args[0], context)?;
-    Ok(NativeResult::ok_one(cost, len))
+    Ok(NativeResult::ok(cost, smallvec![len]))
 }
 
 pub fn native_push_back(
@@ -57,7 +58,7 @@ pub fn native_push_back(
     );
 
     r.push_back(e, &ty_args[0], context)?;
-    Ok(NativeResult::ok_none(cost))
+    Ok(NativeResult::ok(cost, smallvec![]))
 }
 
 pub fn native_borrow(

--- a/language/move-vm/natives/src/vector.rs
+++ b/language/move-vm/natives/src/vector.rs
@@ -36,7 +36,7 @@ pub fn native_length(
     let cost = native_gas(context.cost_table(), NativeCostIndex::LENGTH, 1);
 
     let len = r.len(&ty_args[0], context)?;
-    Ok(NativeResult::ok(cost, vec![len]))
+    Ok(NativeResult::ok_one(cost, len))
 }
 
 pub fn native_push_back(
@@ -57,7 +57,7 @@ pub fn native_push_back(
     );
 
     r.push_back(e, &ty_args[0], context)?;
-    Ok(NativeResult::ok(cost, vec![]))
+    Ok(NativeResult::ok_none(cost))
 }
 
 pub fn native_borrow(

--- a/language/move-vm/types/Cargo.toml
+++ b/language/move-vm/types/Cargo.toml
@@ -15,9 +15,10 @@ once_cell = "1.4.1"
 proptest = { version = "0.10.1", optional = true }
 sha2 = "0.9.3"
 serde = { version = "1.0.123", features = ["derive", "rc"] }
+smallvec = "1.6.1"
 
 bcs = "0.1.2"
-diem-crypto = { path = "../../../crypto/crypto", version = "0.1.0"}
+diem-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }
 diem-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 move-core-types = { path = "../../move-core/types", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0" }

--- a/language/move-vm/types/src/natives/function.rs
+++ b/language/move-vm/types/src/natives/function.rs
@@ -50,6 +50,17 @@ pub trait NativeContext {
     fn type_to_type_layout(&self, ty: &Type) -> PartialVMResult<Option<MoveTypeLayout>>;
 }
 
+/// The return value(s) of a native function
+///
+/// None - The native function does not return any thing
+/// One  - The native function returns exactly one value
+/// Many - The native function returns a vector of values
+pub enum NativeReturnValues {
+    None,
+    One(Value),
+    Many(Vec<Value>),
+}
+
 /// Result of a native function execution requires charges for execution cost.
 ///
 /// An execution that causes an invariant violation would not return a `NativeResult` but
@@ -63,15 +74,31 @@ pub struct NativeResult {
     /// The cost for running that function, whether successfully or not.
     pub cost: GasUnits<GasCarrier>,
     /// Result of execution. This is either the return values or the error to report.
-    pub result: Result<Vec<Value>, u64>,
+    pub result: Result<NativeReturnValues, u64>,
 }
 
 impl NativeResult {
-    /// Return values of a successful execution.
-    pub fn ok(cost: GasUnits<GasCarrier>, values: Vec<Value>) -> Self {
+    /// Return values of a successful execution (no return values).
+    pub fn ok_none(cost: GasUnits<GasCarrier>) -> Self {
         NativeResult {
             cost,
-            result: Ok(values),
+            result: Ok(NativeReturnValues::None),
+        }
+    }
+
+    /// Return values of a successful execution (exactly one return value).
+    pub fn ok_one(cost: GasUnits<GasCarrier>, value: Value) -> Self {
+        NativeResult {
+            cost,
+            result: Ok(NativeReturnValues::One(value)),
+        }
+    }
+
+    /// Return values of a successful execution (many return values).
+    pub fn ok_many(cost: GasUnits<GasCarrier>, values: Vec<Value>) -> Self {
+        NativeResult {
+            cost,
+            result: Ok(NativeReturnValues::Many(values)),
         }
     }
 

--- a/language/move-vm/types/src/natives/function.rs
+++ b/language/move-vm/types/src/natives/function.rs
@@ -55,6 +55,15 @@ pub trait NativeContext {
 /// None - The native function does not return any thing
 /// One  - The native function returns exactly one value
 /// Many - The native function returns a vector of values
+///
+/// In theory we could use a Vec<Value> to unify all cases. However, given that currently none of
+/// the native functions return more than one value, using a Vec may introduce extra overhead on
+/// heap allocation and de-allocation, especially for one-element vectors, hence this performance
+/// optimization that cases on the number of return values.
+///
+/// An alternative is to use `smallvec` which stores a small number of elements on stack and falls
+/// back to the heap for larger allocations. The reason not using `smallvec` now is just to avoid
+/// an extra dependency.
 pub enum NativeReturnValues {
     None,
     One(Value),

--- a/language/move-vm/types/src/values/values_impl.rs
+++ b/language/move-vm/types/src/values/values_impl.rs
@@ -1763,10 +1763,7 @@ impl VectorRef {
         if idx >= c.len() {
             return Ok(NativeResult::err(cost, INDEX_OUT_OF_BOUNDS));
         }
-        Ok(NativeResult::ok(
-            cost,
-            vec![Value(self.0.borrow_elem(idx)?)],
-        ))
+        Ok(NativeResult::ok_one(cost, Value(self.0.borrow_elem(idx)?)))
     }
 
     pub fn pop(
@@ -1816,7 +1813,7 @@ impl VectorRef {
 
         self.0.mark_dirty();
 
-        Ok(NativeResult::ok(cost, vec![res]))
+        Ok(NativeResult::ok_one(cost, res))
     }
 
     pub fn swap(
@@ -1853,7 +1850,7 @@ impl VectorRef {
 
         self.0.mark_dirty();
 
-        Ok(NativeResult::ok(cost, vec![]))
+        Ok(NativeResult::ok_none(cost))
     }
 }
 
@@ -1884,7 +1881,7 @@ impl Vector {
             }
         };
 
-        Ok(NativeResult::ok(cost, vec![container]))
+        Ok(NativeResult::ok_one(cost, container))
     }
 
     pub fn destroy_empty(
@@ -1907,7 +1904,7 @@ impl Vector {
         };
 
         if is_empty {
-            Ok(NativeResult::ok(cost, vec![]))
+            Ok(NativeResult::ok_none(cost))
         } else {
             Ok(NativeResult::err(cost, DESTROY_NON_EMPTY_VEC))
         }

--- a/language/move-vm/types/src/values/values_impl.rs
+++ b/language/move-vm/types/src/values/values_impl.rs
@@ -11,6 +11,7 @@ use move_core_types::{
     value::{MoveStructLayout, MoveTypeLayout},
     vm_status::{sub_status::NFE_VECTOR_ERROR_BASE, StatusCode},
 };
+use smallvec::smallvec;
 use std::{
     cell::RefCell,
     fmt::{self, Debug, Display},
@@ -1763,7 +1764,10 @@ impl VectorRef {
         if idx >= c.len() {
             return Ok(NativeResult::err(cost, INDEX_OUT_OF_BOUNDS));
         }
-        Ok(NativeResult::ok_one(cost, Value(self.0.borrow_elem(idx)?)))
+        Ok(NativeResult::ok(
+            cost,
+            smallvec![Value(self.0.borrow_elem(idx)?)],
+        ))
     }
 
     pub fn pop(
@@ -1813,7 +1817,7 @@ impl VectorRef {
 
         self.0.mark_dirty();
 
-        Ok(NativeResult::ok_one(cost, res))
+        Ok(NativeResult::ok(cost, smallvec![res]))
     }
 
     pub fn swap(
@@ -1850,7 +1854,7 @@ impl VectorRef {
 
         self.0.mark_dirty();
 
-        Ok(NativeResult::ok_none(cost))
+        Ok(NativeResult::ok(cost, smallvec![]))
     }
 }
 
@@ -1881,7 +1885,7 @@ impl Vector {
             }
         };
 
-        Ok(NativeResult::ok_one(cost, container))
+        Ok(NativeResult::ok(cost, smallvec![container]))
     }
 
     pub fn destroy_empty(
@@ -1904,7 +1908,7 @@ impl Vector {
         };
 
         if is_empty {
-            Ok(NativeResult::ok_none(cost))
+            Ok(NativeResult::ok(cost, smallvec![]))
         } else {
             Ok(NativeResult::err(cost, DESTROY_NON_EMPTY_VEC))
         }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(part of the effort in porting [George's PR](https://github.com/gdanezis/libra/pull/1))

In current implementation of native functions,
1) allocation of a `Vec` (even we know it is going to be an empty `Vec`) is needed every time a native function returns, and
2) a `Vec` de-allocation is needed when the return values get consumed soon afterwards.

However, the allocation and de-allocation is not necessary. Currently, the native functions in the VM return either zero or one value, and none of them returns multiple values. This creates an optimization opportunity and there are two ways for this:

1) Converting the native return values from a `Vec` into an `enum` that has three  variants: `None`, `One`, and `Many` and only the `Many` variant will lead to vector allocation and de-allocation (which does not exist yet as of now). (We could make it an `Optional`, but to maintain compatibility and future-proof, we need the three-variant enum). This option is implemented up to commit ab07220

2) Replacing `Vec` with a `SmallVec<[Value; 1]>` that stores one value on stack and spills over automatically onto heap. This option is implemented in commit dad1f0f. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Running the `execution/executor-benchmark` does not show any difference in terms of TPS because the testing scope of the benchmark is too large. A new benchmark is added in `diem/language/benchmark` to benchmark VM's perf on native functions only.

However, the benchmark is very sensitive to fluctuations, and I haven't found a reliable way of measure the performance.

The most reliable number I can get is given through the following command, and by running it on an idle linux machine....:
`taskset -c 4 cargo bench --bench benchmarks -- --sample-size 1000 --measurement-time 20`
where `taskset` pins the process to a particular CPU core (CPU 4 in this case) and the sample size is increased to 1000 (default is 100).

Running it before and after optimization commits yields the following result:
```
arith                   time:   [14.989 ms 15.005 ms 15.024 ms]
                        change: [-0.7628% -0.6246% -0.4829%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 87 outliers among 1000 measurements (8.70%)

call                    time:   [14.162 ms 14.166 ms 14.169 ms]
                        change: [+2.6035% +2.6754% +2.7435%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 49 outliers among 1000 measurements (4.90%)

natives                 time:   [17.454 ms 17.464 ms 17.475 ms]
                        change: [-10.551% -10.471% -10.395%] (p = 0.00 < 0.05)
                        Performance has improved
Found 102 outliers among 1000 measurements (10.20%)
```

This profile shows in general 10% improvement on VM's performance on native functions, but I won't read too much into the number, as the benchmark is highly sensitive and I have seen better and worse numbers as well. Let me know if you have better ways of making the test runs stable!

## Related PRs

[George's original PR](https://github.com/gdanezis/libra/pull/1)