### PR TITLE
[diem-types] Update currency code restrictions now that we have the real codes.

### DIFF
--- a/types/src/account_config/constants/diem.rs
+++ b/types/src/account_config/constants/diem.rs
@@ -28,11 +28,17 @@ pub fn type_tag_for_currency_code(currency_code: Identifier) -> TypeTag {
     })
 }
 
+/// In addition to the constraints for valid Move identifiers, currency codes
+/// should consist entirely of uppercase alphanumeric characters (e.g., no underscores).
+pub fn allowed_currency_code_string(possible_currency_code_string: &str) -> bool {
+    possible_currency_code_string
+        .chars()
+        .all(|chr| matches!(chr, 'A'..='Z' | '0'..='9'))
+        && Identifier::is_valid(possible_currency_code_string)
+}
+
 pub fn from_currency_code_string(currency_code_string: &str) -> Result<Identifier> {
-    // In addition to the constraints for valid Move identifiers, currency codes
-    // should consist entirely of alphanumeric characters (e.g., no underscores).
-    // TODO: After XUS is renamed , this should require uppercase as well.
-    if !currency_code_string.chars().all(char::is_alphanumeric) {
+    if !allowed_currency_code_string(currency_code_string) {
         bail!("Invalid currency code '{}'", currency_code_string)
     }
     Identifier::new(currency_code_string)

--- a/types/src/unit_tests/currency_code_test.rs
+++ b/types/src/unit_tests/currency_code_test.rs
@@ -1,0 +1,36 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::account_config::allowed_currency_code_string;
+use proptest::prelude::*;
+
+static ALLOWED_CURRENCY_IDENTIFIERS: &str = r"[A-Z][A-Z0-9]*";
+
+#[test]
+fn simple_allowed_currency_codes() {
+    let acceptable_names = vec!["A", "AB", "ABC", "A1B", "AB1", "A"];
+    let unacceptable_names = vec![
+        "a", "Ab", "AbC", "A1b", "aB1", "1AB", "1", "", "´t", "©", "AB†", "ƒA", "AB_1", "A_B",
+        "_A", "_a", "_A_1", "0",
+    ];
+
+    assert!(
+        acceptable_names
+            .into_iter()
+            .all(allowed_currency_code_string),
+        "Acceptable currency code name not accepted"
+    );
+    assert!(
+        unacceptable_names
+            .into_iter()
+            .all(|code| !allowed_currency_code_string(code)),
+        "Unacceptable currency code name accepted"
+    );
+}
+
+proptest! {
+    #[test]
+    fn acceptable_currency_codes(s in ALLOWED_CURRENCY_IDENTIFIERS) {
+        prop_assert!(allowed_currency_code_string(&s))
+    }
+}

--- a/types/src/unit_tests/mod.rs
+++ b/types/src/unit_tests/mod.rs
@@ -6,6 +6,7 @@ mod block_metadata_test;
 mod canonical_serialization_examples;
 mod code_debug_fmt_test;
 mod contract_event_test;
+mod currency_code_test;
 mod transaction_test;
 mod trusted_state_test;
 mod validator_set_test;


### PR DESCRIPTION
This updates the currency code restrictions now that we have the actual currency codes, and to be in line with the restrictions described in the [DIP-20 draft](https://github.com/diem/dip/blob/master/dips/dip-20.md#operational-restrictions). 


## Testing
Adds two tests:
* A simple handwritten test to test out corner cases.
* A proptest to make sure all identifiers of the form `[A-Z][A-Z0-9]*` are accepted as valid currency codes.