### PR TITLE
[move][testing] Make dependencies in IR tests unique

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3528,6 +3528,7 @@ dependencies = [
  "diem-workspace-hack",
  "functional-tests",
  "ir-to-bytecode",
+ "move-core-types",
  "move-ir-types",
  "vm",
 ]

--- a/language/ir-testsuite/Cargo.toml
+++ b/language/ir-testsuite/Cargo.toml
@@ -19,6 +19,7 @@ diem-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" 
 move-ir-types = { path = "../move-ir/types", version = "0.1.0" }
 compiled-stdlib = { path = "../stdlib/compiled",  version = "0.1.0" }
 vm = { path = "../vm", version = "0.1.0" }
+move-core-types = { path = "../move-core/types", version = "0.1.0" }
 
 
 [[test]]


### PR DESCRIPTION
- Keyed compiled module dependencies in the IRCompiler instance of the testing Compiler trait

## Motivation

- Uniqueness is needed in an upcoming IR update

## Test Plan

- ran tests
- Theoretically a perf increase if there were a TON of duplicate modules, as the IR compiler generates the dep before adding it to it's own map (and shadowing the old one). In practice, no change as there really aren't duplicate modules except for about 5 IR tests