### PR TITLE
[State Sync] Cleanups and simplifications for StateSyncClient and bootstrapper.

### DIFF
--- a/consensus/src/block_storage/block_store_and_lec_recovery_test.rs
+++ b/consensus/src/block_storage/block_store_and_lec_recovery_test.rs
@@ -16,7 +16,7 @@ use execution_correctness::{ExecutionCorrectness, ExecutionCorrectnessManager};
 use executor_test_helpers::start_storage_service;
 use executor_types::ExecutedTrees;
 use futures::channel::mpsc;
-use state_synchronizer::StateSynchronizerClient;
+use state_synchronizer::StateSyncClient;
 use std::sync::Arc;
 use storage_interface::DbReader;
 
@@ -67,7 +67,7 @@ fn build_inserter(
 
     let state_computer = Arc::new(ExecutionProxy::new(
         lec_client,
-        StateSynchronizerClient::new(coordinator_sender),
+        StateSyncClient::new(coordinator_sender),
     ));
 
     TreeInserter::new_with_store(

--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -18,7 +18,7 @@ use diem_mempool::ConsensusRequest;
 use diem_types::on_chain_config::OnChainConfigPayload;
 use execution_correctness::ExecutionCorrectnessManager;
 use futures::channel::mpsc;
-use state_synchronizer::StateSynchronizerClient;
+use state_synchronizer::StateSyncClient;
 use std::sync::Arc;
 use storage_interface::DbReader;
 use tokio::runtime::{self, Runtime};
@@ -28,7 +28,7 @@ pub fn start_consensus(
     node_config: &NodeConfig,
     network_sender: ConsensusNetworkSender,
     network_events: ConsensusNetworkEvents,
-    state_sync_client: StateSynchronizerClient,
+    state_sync_client: StateSyncClient,
     consensus_to_mempool_sender: mpsc::Sender<ConsensusRequest>,
     diem_db: Arc<dyn DbReader>,
     reconfig_events: diem_channel::Receiver<(), OnChainConfigPayload>,

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -12,20 +12,20 @@ use diem_types::ledger_info::LedgerInfoWithSignatures;
 use execution_correctness::ExecutionCorrectness;
 use executor_types::{Error as ExecutionError, StateComputeResult};
 use fail::fail_point;
-use state_synchronizer::StateSynchronizerClient;
+use state_synchronizer::StateSyncClient;
 use std::boxed::Box;
 
 /// Basic communication with the Execution module;
 /// implements StateComputer traits.
 pub struct ExecutionProxy {
     execution_correctness_client: Mutex<Box<dyn ExecutionCorrectness + Send + Sync>>,
-    synchronizer: StateSynchronizerClient,
+    synchronizer: StateSyncClient,
 }
 
 impl ExecutionProxy {
     pub fn new(
         execution_correctness_client: Box<dyn ExecutionCorrectness + Send + Sync>,
-        synchronizer: StateSynchronizerClient,
+        synchronizer: StateSyncClient,
     ) -> Self {
         Self {
             execution_correctness_client: Mutex::new(execution_correctness_client),

--- a/state-synchronizer/src/coordinator.rs
+++ b/state-synchronizer/src/coordinator.rs
@@ -270,7 +270,7 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
                         CoordinatorMessage::GetSyncState(callback) => {
                             self.get_state(callback);
                         }
-                        CoordinatorMessage::WaitUntilInitialized(cb_sender) => {
+                        CoordinatorMessage::WaitForInitialization(cb_sender) => {
                             self.set_initialization_listener(cb_sender);
                         }
                     };

--- a/state-synchronizer/src/lib.rs
+++ b/state-synchronizer/src/lib.rs
@@ -7,7 +7,7 @@
 //! Used for node restarts, network partitions, full node syncs
 #![recursion_limit = "1024"]
 
-pub use self::state_synchronizer::{StateSyncClient, StateSynchronizer};
+pub use self::state_synchronizer::{StateSyncClient, StateSyncBootstrapper};
 
 pub mod chunk_request;
 pub mod chunk_response;

--- a/state-synchronizer/src/lib.rs
+++ b/state-synchronizer/src/lib.rs
@@ -7,7 +7,7 @@
 //! Used for node restarts, network partitions, full node syncs
 #![recursion_limit = "1024"]
 
-pub use self::state_synchronizer::{StateSyncClient, StateSyncBootstrapper};
+pub use self::state_synchronizer::{StateSyncBootstrapper, StateSyncClient};
 
 pub mod chunk_request;
 pub mod chunk_response;

--- a/state-synchronizer/src/lib.rs
+++ b/state-synchronizer/src/lib.rs
@@ -7,7 +7,7 @@
 //! Used for node restarts, network partitions, full node syncs
 #![recursion_limit = "1024"]
 
-pub use self::state_synchronizer::{StateSynchronizer, StateSynchronizerClient};
+pub use self::state_synchronizer::{StateSyncClient, StateSynchronizer};
 
 pub mod chunk_request;
 pub mod chunk_response;

--- a/state-synchronizer/src/state_synchronizer.rs
+++ b/state-synchronizer/src/state_synchronizer.rs
@@ -101,12 +101,12 @@ impl SynchronizationState {
     }
 }
 
-pub struct StateSynchronizer {
+pub struct StateSyncBootstrapper {
     _runtime: Runtime,
     coordinator_sender: mpsc::UnboundedSender<CoordinatorMessage>,
 }
 
-impl StateSynchronizer {
+impl StateSyncBootstrapper {
     pub fn bootstrap(
         network: Vec<(
             NodeNetworkId,

--- a/state-synchronizer/src/state_synchronizer.rs
+++ b/state-synchronizer/src/state_synchronizer.rs
@@ -185,8 +185,8 @@ impl StateSynchronizer {
         }
     }
 
-    pub fn create_client(&self) -> StateSynchronizerClient {
-        StateSynchronizerClient::new(self.coordinator_sender.clone())
+    pub fn create_client(&self) -> StateSyncClient {
+        StateSyncClient::new(self.coordinator_sender.clone())
     }
 
     /// The function returns a future that is fulfilled when the state synchronizer is
@@ -201,11 +201,11 @@ impl StateSynchronizer {
     }
 }
 
-pub struct StateSynchronizerClient {
+pub struct StateSyncClient {
     coordinator_sender: mpsc::UnboundedSender<CoordinatorMessage>,
 }
 
-impl StateSynchronizerClient {
+impl StateSyncClient {
     pub fn new(coordinator_sender: mpsc::UnboundedSender<CoordinatorMessage>) -> Self {
         Self { coordinator_sender }
     }

--- a/state-synchronizer/src/state_synchronizer.rs
+++ b/state-synchronizer/src/state_synchronizer.rs
@@ -125,7 +125,7 @@ impl StateSyncBootstrapper {
             .threaded_scheduler()
             .enable_all()
             .build()
-            .expect("[state synchronizer] failed to create runtime");
+            .expect("[State Sync] Failed to create runtime!");
 
         let executor_proxy = ExecutorProxy::new(storage, executor, reconfig_event_subscriptions);
         Self::bootstrap_with_executor_proxy(
@@ -155,11 +155,9 @@ impl StateSyncBootstrapper {
         executor_proxy: E,
     ) -> Self {
         let (coordinator_sender, coordinator_receiver) = mpsc::unbounded();
-
         let initial_state = executor_proxy
             .get_local_storage_state()
-            .expect("[state sync] Start failure: cannot sync with storage.");
-
+            .expect("[State Sync] Starting failure: cannot sync with storage!");
         let network_senders: HashMap<_, _> = network
             .iter()
             .map(|(network_id, sender, _events)| (network_id.clone(), sender.clone()))
@@ -176,7 +174,7 @@ impl StateSyncBootstrapper {
             executor_proxy,
             initial_state,
         )
-        .expect("Unable to create sync coordinator");
+        .expect("[State Sync] Unable to create state sync coordinator!");
         runtime.spawn(coordinator.start(network));
 
         Self {

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     network::{StateSynchronizerEvents, StateSynchronizerMsg, StateSynchronizerSender},
-    state_synchronizer::{StateSyncClient, StateSyncBootstrapper},
+    state_synchronizer::{StateSyncBootstrapper, StateSyncClient},
     tests::{
         mock_executor_proxy::{MockExecutorProxy, MockRpcHandler},
         mock_storage::MockStorage,

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -802,7 +802,7 @@ fn catch_up_with_waypoints() {
     );
     block_on(
         env.peers[1]
-            .synchronizer
+            .client
             .as_ref()
             .unwrap()
             .wait_until_initialized(),

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     network::{StateSynchronizerEvents, StateSynchronizerMsg, StateSynchronizerSender},
-    state_synchronizer::{StateSynchronizer, StateSynchronizerClient},
+    state_synchronizer::{StateSyncClient, StateSynchronizer},
     tests::{
         mock_executor_proxy::{MockExecutorProxy, MockRpcHandler},
         mock_storage::MockStorage,
@@ -57,7 +57,7 @@ use std::{
 use tokio::runtime::Runtime;
 
 struct SynchronizerPeer {
-    client: Option<StateSynchronizerClient>,
+    client: Option<StateSyncClient>,
     mempool: Option<MockSharedMempool>,
     multi_peer_ids: Option<Vec<PeerId>>, // Holds the peer's PeerIds, to support nodes with multiple network IDs.
     network_addr: NetworkAddress,

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     network::{StateSynchronizerEvents, StateSynchronizerMsg, StateSynchronizerSender},
-    state_synchronizer::{StateSyncClient, StateSynchronizer},
+    state_synchronizer::{StateSyncClient, StateSyncBootstrapper},
     tests::{
         mock_executor_proxy::{MockExecutorProxy, MockRpcHandler},
         mock_storage::MockStorage,
@@ -66,7 +66,7 @@ struct SynchronizerPeer {
     public_key: ValidatorInfo,
     signer: ValidatorSigner,
     storage_proxy: Option<Arc<RwLock<MockStorage>>>,
-    synchronizer: Option<StateSynchronizer>,
+    synchronizer: Option<StateSyncBootstrapper>,
 }
 
 struct SynchronizerEnv {
@@ -193,7 +193,7 @@ impl SynchronizerEnv {
         )));
 
         let (mempool_channel, mempool_requests) = futures::channel::mpsc::channel(1_024);
-        let synchronizer = StateSynchronizer::bootstrap_with_executor_proxy(
+        let synchronizer = StateSyncBootstrapper::bootstrap_with_executor_proxy(
             Runtime::new().unwrap(),
             network_handles,
             mempool_channel,


### PR DESCRIPTION
## Motivation

When reading through the state_synchronization.rs file, I noticed a few messy pieces of code. This PR offers small fixes and cleanups to address these. Note: these changes are cosmetic and the logic of state sync doesn't change. 

This PR offers the following commits:
1. Rename "StateSynchronizerClient" to "StateSyncClient". We want to move away from using "Synchronizer" when we can and this PR begins that process.
2. Small comment and naming fixes to StateSyncClient.
3. Move "wait_until_initialized()" method out of StateSynchronizer and into StateSyncClient. This method is a client call so it's unnecessary to have another layer of indirection here.
4. Rename "StateSynchronizer" to "StateSyncBootstrapper". This name is more appropriate given that the code is not the state sync logic, but rather a bootstrapper or factory for it.
5. Small comment and naming fixes for StateSyncBootstrapper.
6. Move CoordinatorMessage and SyncRequest into state_sychronizer.rs file. Given that these are client messages sent to the server, it makes more sense for them to be here.
7. Clean up CoordinatorMessage and the surrounding structs. The names and comments weren't great and the inconsistent usage of structs wasn't helpful either.
8. Add a small TODO for refactoring CommitResponse.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally.

## Related PRs

None, but this relates to: https://github.com/diem/diem/issues/6795