### PR TITLE
[move prover] Multiple variables in Quant AST nodes

### DIFF
--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -2183,8 +2183,8 @@ impl<'env> SpecTranslator<'env> {
         emit!(self.writer, " :: ");
         // Translate range constraints.
         let connective = match kind {
-            QuantKind::Forall => "==>",
-            QuantKind::Exists => "&&",
+            QuantKind::Forall => " ==> ",
+            QuantKind::Exists => " && ",
         };
         let mut separator = "";
         for (var, range) in ranges {
@@ -2240,7 +2240,7 @@ impl<'env> SpecTranslator<'env> {
             }
             separator = connective;
         }
-        emit!(self.writer, " {} ", connective);
+        emit!(self.writer, "{}", connective);
         // Translate range selectors.
         for (var, range) in ranges {
             let var_name = self.module_env().symbol_pool().string(var.name);


### PR DESCRIPTION
## Motivation

Finish https://github.com/diem/diem/pull/7218 by supporting multiple variables in the same quantifier (parser and translation).

## Test Plan

CI

```
cargo build -p move-prover && BOOGIE_EXE=$HOME/.dotnet/tools/boogie Z3_EXE= time target/debug/move-prover -d language/stdlib/modules language/stdlib/modules/DiemVersion.move
```

Example of generated code in `output.bbl` / `$DesignatedDealer_TierInfo_$pack_ref_deep`:
* Before
```
assert b#$Boolean($Boolean((var $range_5 := $Range($Integer(0), $vlen_value($SelectField($after, $DesignatedDealer_TierInfo_tiers))); (forall $i_4: int :: $InRange($range_5, $i_4) ==> (var i := $Integer($i_4); b#$Boolean($Boolean((var $range_7 := $Range($Integer(0), $vlen_value($SelectField($after, $DesignatedDealer_TierInfo_tiers))); (forall $i_6: int :: $InRange($range_7, $i_6) ==> (var j := $Integer($i_6); b#$Boolean($Boolean(b#$Boolean($Boolean(i#$Integer(i) < i#$Integer(j))) ==> b#$Boolean($Boolean(i#$Integer($select_vector_by_value($SelectField($after, $DesignatedDealer_TierInfo_tiers), i)) < i#$Integer($select_vector_by_value($SelectField($after, $DesignatedDealer_TierInfo_tiers), j))))))))))))))));
```
* After
```
assert b#$Boolean((var $range_4 := $Range($Integer(0), $vlen_value($SelectField($after, $DesignatedDealer_TierInfo_tiers))); (var $range_5 := $Range($Integer(0), $vlen_value($SelectField($after, $DesignatedDealer_TierInfo_tiers))); $Boolean((forall $i_6: int, $i_7: int :: $InRange($range_4, $i_6) ==> $InRange($range_5, $i_7) ==> (var i := $Integer($i_6); (var j := $Integer($i_7); b#$Boolean($Boolean(b#$Boolean($Boolean(i#$Integer(i) < i#$Integer(j))) ==> b#$Boolean($Boolean(i#$Integer($select_vector_by_value($SelectField($after, $DesignatedDealer_TierInfo_tiers), i)) < i#$Integer($select_vector_by_value($SelectField($after, $DesignatedDealer_TierInfo_tiers), j)))))))))))));
```