### PR TITLE
[Mempool] Remove `deny(missing_docs)]` annotation and clean up redundant documentation.

### DIFF
--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! mempool is used to track transactions which have been submitted but not yet
+//! Mempool is used to track transactions which have been submitted but not yet
 //! agreed upon.
 use crate::{
     core_mempool::{
@@ -28,13 +28,13 @@ use std::{
 };
 
 pub struct Mempool {
-    // stores metadata of all transactions in mempool (of all states)
+    // Stores the metadata of all transactions in mempool (of all states).
     transactions: TransactionStore,
 
     sequence_number_cache: TtlCache<AccountAddress, u64>,
-    // for each transaction, entry with timestamp is added when transaction enters mempool
-    // used to measure e2e latency of transaction in system, as well as time it takes to pick it up
-    // by consensus
+    // For each transaction, an entry with a timestamp is added when the transaction enters mempool.
+    // This is used to measure e2e latency of transactions in the system, as well as the time it
+    // takes to pick it up by consensus.
     pub(crate) metrics_cache: TtlCache<(AccountAddress, u64), SystemTime>,
     pub system_transaction_timeout: Duration,
 }
@@ -51,7 +51,7 @@ impl Mempool {
         }
     }
 
-    /// This function will be called once the transaction has been stored
+    /// This function will be called once the transaction has been stored.
     pub(crate) fn remove_transaction(
         &mut self,
         sender: &AccountAddress,
@@ -100,8 +100,8 @@ impl Mempool {
         }
     }
 
-    /// Used to add a transaction to the Mempool
-    /// Performs basic validation: checks account's sequence number
+    /// Used to add a transaction to the Mempool.
+    /// Performs basic validation: checks account's sequence number.
     pub(crate) fn add_txn(
         &mut self,
         txn: SignedTransaction,
@@ -151,10 +151,10 @@ impl Mempool {
         self.transactions.insert(txn_info, sequence_number)
     }
 
-    /// Fetches next block of transactions for consensus
-    /// `batch_size` - size of requested block
-    /// `seen_txns` - transactions that were sent to Consensus but were not committed yet
-    ///  Mempool should filter out such transactions
+    /// Fetches next block of transactions for consensus.
+    /// `batch_size` - size of requested block.
+    /// `seen_txns` - transactions that were sent to Consensus but were not committed yet,
+    ///  mempool should filter out such transactions.
     #[allow(clippy::explicit_counter_loop)]
     pub(crate) fn get_block(
         &mut self,
@@ -235,9 +235,9 @@ impl Mempool {
         block
     }
 
-    /// periodic core mempool garbage collection
-    /// removes all expired transactions
-    /// clears expired entries in metrics cache and sequence number cache
+    /// Periodic core mempool garbage collection.
+    /// Removes all expired transactions and clears expired entries in metrics
+    /// cache and sequence number cache.
     pub(crate) fn gc(&mut self) {
         let now = SystemTime::now();
         self.transactions.gc_by_system_ttl(&self.metrics_cache);
@@ -245,14 +245,14 @@ impl Mempool {
         self.sequence_number_cache.gc(now);
     }
 
-    /// Garbage collection based on client-specified expiration time
+    /// Garbage collection based on client-specified expiration time.
     pub(crate) fn gc_by_expiration_time(&mut self, block_time: Duration) {
         self.transactions
             .gc_by_expiration_time(block_time, &self.metrics_cache);
     }
 
-    /// Read `count` transactions from timeline since `timeline_id`
-    /// Returns block of transactions and new last_timeline_id
+    /// Read `count` transactions from timeline since `timeline_id`.
+    /// Returns block of transactions and new last_timeline_id.
     pub(crate) fn read_timeline(
         &mut self,
         timeline_id: u64,
@@ -261,7 +261,7 @@ impl Mempool {
         self.transactions.read_timeline(timeline_id, count)
     }
 
-    /// Read transactions from timeline from `start_id` (exclusive) to `end_id` (inclusive)
+    /// Read transactions from timeline from `start_id` (exclusive) to `end_id` (inclusive).
     pub(crate) fn timeline_range(&mut self, start_id: u64, end_id: u64) -> Vec<SignedTransaction> {
         self.transactions.timeline_range(start_id, end_id)
     }

--- a/mempool/src/core_mempool/transaction.rs
+++ b/mempool/src/core_mempool/transaction.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 #[derive(Clone)]
 pub struct MempoolTransaction {
     pub txn: SignedTransaction,
-    // system expiration time of transaction. It should be removed from mempool by that time
+    // System expiration time of the transaction. It should be removed from mempool by that time.
     pub expiration_time: Duration,
     pub gas_amount: u64,
     pub ranking_score: u64,
@@ -50,13 +50,12 @@ impl MempoolTransaction {
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Deserialize, Hash, Serialize)]
 pub enum TimelineState {
-    // transaction is ready for broadcast
-    // Associated integer represents it's position in log of such transactions
+    // The transaction is ready for broadcast.
+    // Associated integer represents it's position in the log of such transactions.
     Ready(u64),
-    // transaction is not yet ready for broadcast
-    // but it might change in a future
+    // Transaction is not yet ready for broadcast, but it might change in a future.
     NotReady,
-    // transaction will never be qualified for broadcasting
-    // currently we don't broadcast transactions originated on other peers
+    // Transaction will never be qualified for broadcasting.
+    // Currently we don't broadcast transactions originated on other peers.
     NonQualified,
 }

--- a/mempool/src/core_mempool/ttl_cache.rs
+++ b/mempool/src/core_mempool/ttl_cache.rs
@@ -36,13 +36,13 @@ where
     }
 
     pub fn insert(&mut self, key: K, value: V) {
-        // remove old entry if it exists
+        // Remove old entry if it exists.
         match self.data.get(&key) {
             Some(info) => {
                 self.ttl_index.remove(&info.ttl);
             }
             None => {
-                // remove oldest entry if cache is still full
+                // Remove oldest entry if cache is still full.
                 if self.data.len() == self.capacity {
                     let first_entry = self.ttl_index.keys().next().cloned();
                     if let Some(tst) = first_entry {
@@ -54,7 +54,7 @@ where
             }
         }
 
-        // insert new one
+        // Insert the new transaction.
         if let Some(expiration_time) = SystemTime::now().checked_add(self.default_timeout) {
             self.ttl_index.insert(expiration_time, key.clone());
             let value_info = ValueInfo {
@@ -76,7 +76,7 @@ where
     }
 
     pub fn gc(&mut self, gc_time: SystemTime) {
-        // remove expired entries
+        // Remove the expired entries.
         let mut active = self.ttl_index.split_off(&gc_time);
         for key in self.ttl_index.values() {
             self.data.remove(key);

--- a/mempool/src/lib.rs
+++ b/mempool/src/lib.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]
-#![deny(missing_docs)]
 // Increase recursion limit to allow for use of select! macro.
 #![recursion_limit = "1024"]
 

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -75,12 +75,12 @@ pub(crate) async fn coordinator<V>(
         ::futures::select! {
             (msg, callback) = client_events.select_next_some() => {
                 trace_event!("mempool::client_event", {"txn", msg.sender(), msg.sequence_number()});
-                // this timer measures how long it took for the bounded executor to *schedule* the
-                // task
+                // This timer measures how long it took for the bounded executor to *schedule* the
+                // task.
                 let _timer = counters::TASK_SPAWN_LATENCY
                     .with_label_values(&[counters::CLIENT_EVENT_LABEL, counters::SPAWN_LABEL])
                     .start_timer();
-                // this timer measures how long it took for the task to go from scheduled to started
+                // This timer measures how long it took for the task to go from scheduled to started.
                 let task_start_timer = counters::TASK_SPAWN_LATENCY
                     .with_label_values(&[counters::CLIENT_EVENT_LABEL, counters::START_LABEL])
                     .start_timer();
@@ -155,13 +155,13 @@ pub(crate) async fn coordinator<V>(
                                     true => TimelineState::NonQualified,
                                     false => TimelineState::NotReady,
                                 };
-                                // this timer measures how long it took for the bounded executor to
-                                // *schedule* the task
+                                // This timer measures how long it took for the bounded executor to
+                                // *schedule* the task.
                                 let _timer = counters::TASK_SPAWN_LATENCY
                                     .with_label_values(&[counters::PEER_BROADCAST_EVENT_LABEL, counters::SPAWN_LABEL])
                                     .start_timer();
-                                // this timer measures how long it took for the task to go from scheduled
-                                // to started
+                                // This timer measures how long it took for the task to go from scheduled
+                                // to started.
                                 let task_start_timer = counters::TASK_SPAWN_LATENCY
                                     .with_label_values(&[counters::PEER_BROADCAST_EVENT_LABEL, counters::START_LABEL])
                                     .start_timer();
@@ -205,7 +205,7 @@ pub(crate) async fn coordinator<V>(
     ));
 }
 
-/// GC all expired transactions by SystemTTL
+/// Garbage collect all expired transactions by SystemTTL.
 pub(crate) async fn gc_coordinator(mempool: Arc<Mutex<CoreMempool>>, gc_interval_ms: u64) {
     info!(LogSchema::event_log(LogEntry::GCRuntime, LogEvent::Start));
     let mut interval = interval(Duration::from_millis(gc_interval_ms));
@@ -223,9 +223,9 @@ pub(crate) async fn gc_coordinator(mempool: Arc<Mutex<CoreMempool>>, gc_interval
     ));
 }
 
-/// Periodically logs a snapshot of transactions in core mempool
-/// In the future we may want a interactive way to directly query mempool's internal state
-/// For now, we will rely on this periodic snapshot to observe the internal state
+/// Periodically logs a snapshot of transactions in core mempool.
+/// In the future we may want an interactive way to directly query mempool's internal state.
+/// For now, we will rely on this periodic snapshot to observe the internal state.
 pub(crate) async fn snapshot_job(mempool: Arc<Mutex<CoreMempool>>, snapshot_interval_secs: u64) {
     let mut interval = interval(Duration::from_secs(snapshot_interval_secs));
     while let Some(_interval) = interval.next().await {

--- a/mempool/src/shared_mempool/network.rs
+++ b/mempool/src/shared_mempool/network.rs
@@ -16,29 +16,27 @@ use network::{
 };
 use serde::{Deserialize, Serialize};
 
-/// Container for exchanging transactions with other Mempools
+/// Container for exchanging transactions with other Mempools.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum MempoolSyncMsg {
-    /// broadcast request issued by the sender
+    /// Broadcast request issued by the sender.
     BroadcastTransactionsRequest {
-        /// unique id of sync request. Can be used by sender for rebroadcast analysis
+        /// Unique id of sync request. Can be used by sender for rebroadcast analysis
         request_id: Vec<u8>,
-        /// shared transactions in this batch
         transactions: Vec<SignedTransaction>,
     },
-    /// broadcast ack issued by the receiver
+    /// Broadcast ack issued by the receiver.
     BroadcastTransactionsResponse {
-        /// unique id of received broadcast request
         request_id: Vec<u8>,
-        /// retry signal from recipient if there are txns in corresponding broadcast
-        /// that were rejected from mempool but may succeed on resend
+        /// Retry signal from recipient if there are txns in corresponding broadcast
+        /// that were rejected from mempool but may succeed on resend.
         retry: bool,
-        /// backpressure signal from recipient when it is overwhelmed (e.g. mempool is full)
+        /// A backpressure signal from the recipient when it is overwhelmed (e.g., mempool is full).
         backoff: bool,
     },
 }
 
-/// Protocol id for mempool direct-send calls
+/// Protocol id for mempool direct-send calls.
 pub const MEMPOOL_DIRECT_SEND_PROTOCOL: &[u8] = b"/diem/direct-send/0.1.0/mempool/0.1.0";
 
 /// The interface from Network to Mempool layer.
@@ -63,7 +61,7 @@ pub struct MempoolNetworkSender {
 }
 
 /// Create a new Sender that only sends for the `MEMPOOL_DIRECT_SEND_PROTOCOL` ProtocolId and a
-/// Receiver (Events) that explicitly returns only said ProtocolId.
+/// Receiver (Events) that explicitly returns only said ProtocolId..
 pub fn network_endpoint_config(
     max_broadcasts_per_peer: usize,
 ) -> (
@@ -83,7 +81,6 @@ pub fn network_endpoint_config(
 }
 
 impl NewNetworkSender for MempoolNetworkSender {
-    /// Returns a Sender that only sends for the `MEMPOOL_DIRECT_SEND_PROTOCOL` ProtocolId.
     fn new(
         peer_mgr_reqs_tx: PeerManagerRequestSender,
         connection_reqs_tx: ConnectionRequestSender,
@@ -95,8 +92,6 @@ impl NewNetworkSender for MempoolNetworkSender {
 }
 
 impl MempoolNetworkSender {
-    /// Send a single message to the destination peer using the `MEMPOOL_DIRECT_SEND_PROTOCOL`
-    /// ProtocolId.
     pub fn send_to(
         &mut self,
         recipient: PeerId,

--- a/mempool/src/shared_mempool/peer_manager.rs
+++ b/mempool/src/shared_mempool/peer_manager.rs
@@ -30,10 +30,10 @@ use vm_validator::vm_validator::TransactionValidation;
 
 const PRIMARY_NETWORK_PREFERENCE: i64 = 0;
 
-/// stores only peers that receive txns from this node
+/// Peers that receive txns from this node.
 pub(crate) type PeerInfo = HashMap<PeerNetworkId, PeerSyncState>;
 
-/// state of last sync with peer
+/// State of last sync with peer:
 /// `timeline_id` is position in log of ready transactions
 /// `is_alive` - is connection healthy
 #[derive(Clone)]
@@ -47,16 +47,16 @@ pub(crate) struct PeerManager {
     upstream_config: UpstreamConfig,
     mempool_config: MempoolConfig,
     peer_info: Mutex<PeerInfo>,
-    // the upstream peer to failover to if all peers in the primary upstream network are dead
-    // the number of failover peers is limited to 1 to avoid network competition in the failover networks
+    // The upstream peer to failover to if all peers in the primary upstream network are dead.
+    // The number of failover peers is limited to 1 to avoid network competition in the failover networks.
     failover_peer: Mutex<Option<PeerNetworkId>>,
-    // set of `mempool_config.default_failover` number of peers in the non-primary networks to
-    // broadcast to in addition to the primary network when the primary network is up
+    // The set of `mempool_config.default_failover` number of peers in the non-primary networks to
+    // broadcast to in addition to the primary network when the primary network is up.
     default_failovers: Mutex<HashSet<PeerNetworkId>>,
 }
-/// Identifier for a broadcasted batch of txns
+/// Identifier for a broadcasted batch of txns.
 /// For BatchId(`start_id`, `end_id`), (`start_id`, `end_id`) is the range of timeline IDs read from
-/// the core mempool timeline index that produced the txns in this batch
+/// the core mempool timeline index that produced the txns in this batch.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct BatchId(pub u64, pub u64);
 
@@ -72,14 +72,14 @@ impl Ord for BatchId {
     }
 }
 
-/// Txn broadcast-related info for a given remote peer
+/// Txn broadcast-related info for a given remote peer.
 #[derive(Clone)]
 pub struct BroadcastInfo {
-    // sent broadcasts that have not yet received an ACK
+    // Sent broadcasts that have not yet received an ack.
     pub sent_batches: BTreeMap<BatchId, SystemTime>,
-    // broadcasts that have received a retry ACK and are pending a resend
+    // Broadcasts that have received a retry ack and are pending a resend.
     pub retry_batches: BTreeSet<BatchId>,
-    // whether braodcasting to this peer is in backoff mode, e.g. broadcasting at longer intervals
+    // Whether broadcasting to this peer is in backoff mode, e.g. broadcasting at longer intervals.
     pub backoff_mode: bool,
 }
 
@@ -95,7 +95,7 @@ impl BroadcastInfo {
 
 impl PeerManager {
     pub fn new(mempool_config: MempoolConfig, upstream_config: UpstreamConfig) -> Self {
-        // primary network is always chosen at initialization
+        // Primary network is always chosen at initialization.
         counters::UPSTREAM_NETWORK.set(PRIMARY_NETWORK_PREFERENCE);
         info!(LogSchema::new(LogEntry::UpstreamNetwork)
             .network_level(PRIMARY_NETWORK_PREFERENCE as u64));
@@ -108,7 +108,7 @@ impl PeerManager {
         }
     }
 
-    // returns true if `peer` is discovered for first time, else false
+    // Returns true if `peer` is discovered for the first time, else false.
     pub fn add_peer(&self, peer: PeerNetworkId, origin: ConnectionOrigin) -> bool {
         let mut peer_info = self.peer_info.lock();
         let is_new_peer = !peer_info.contains_key(&peer);
@@ -117,8 +117,8 @@ impl PeerManager {
                 .with_label_values(&[&peer.raw_network_id().to_string()])
                 .inc();
             if peer.raw_network_id() == NetworkId::Validator {
-                // For a validator network, resume broadcasting from previous state
-                // we can afford to not re-broadcast here since the transaction is already in a validator
+                // For a validator network, resume broadcasting from previous state.
+                // We can afford to not re-broadcast here since the transaction is already in a validator.
                 peer_info
                     .entry(peer)
                     .or_insert(PeerSyncState {
@@ -129,8 +129,8 @@ impl PeerManager {
                     .is_alive = true;
             } else {
                 // For a non-validator network, potentially re-broadcast any transactions that have not been
-                // committed yet
-                // This is to ensure better reliability of transactions reaching the validator network
+                // committed yet.
+                // This is to ensure better reliability of transactions reaching the validator network.
                 peer_info.insert(
                     peer,
                     PeerSyncState {
@@ -177,7 +177,7 @@ impl PeerManager {
     ) where
         V: TransactionValidation,
     {
-        // start timer for tracking broadcast latency
+        // Start timer for tracking broadcast latency.
         let start_time = Instant::now();
 
         let mut peer_info = self.peer_info.lock();
@@ -185,14 +185,14 @@ impl PeerManager {
             .get_mut(&peer)
             .expect("missing peer info for peer");
 
-        // only broadcast to peer that is both alive and picked
+        // Only broadcast to peer that is both alive and picked.
         if !state.is_alive || !self.is_picked_peer(&peer) {
             return;
         }
 
-        // If backoff mode is on for this peer, only execute broadcasts that were scheduled as a backoff broadcast
+        // If backoff mode is on for this peer, only execute broadcasts that were scheduled as a backoff broadcast.
         // This is to ensure the backoff mode is actually honored (there is a chance a broadcast was scheduled
-        // in non-backoff mode before backoff mode was turned on - ignore such scheduled broadcasts)
+        // in non-backoff mode before backoff mode was turned on - ignore such scheduled broadcasts).
         if state.broadcast_info.backoff_mode && !scheduled_backoff {
             return;
         }
@@ -203,9 +203,9 @@ impl PeerManager {
         {
             let mut mempool = smp.mempool.lock();
 
-            // Sync peer's pending broadcasts with latest mempool state
+            // Sync peer's pending broadcasts with latest mempool state.
             // A pending broadcast might become empty if the corresponding txns were committed through
-            // another peer, so don't track broadcasts for committed txns
+            // another peer, so don't track broadcasts for committed txns.
             state.broadcast_info.sent_batches = state
                 .broadcast_info
                 .sent_batches
@@ -214,13 +214,13 @@ impl PeerManager {
                 .filter(|(id, _batch)| !mempool.timeline_range(id.0, id.1).is_empty())
                 .collect::<BTreeMap<BatchId, SystemTime>>();
 
-            // check for batch to rebroadcast:
-            // 1. batch that did not receive ACK in configured window of time
-            // 2. batch that an earlier ACK marked as retriable
+            // Check for batch to rebroadcast:
+            // 1. Batch that did not receive ACK in configured window of time
+            // 2. Batch that an earlier ACK marked as retriable
             let mut pending_broadcasts = 0;
             let mut expired = None;
 
-            // find earliest batch in timeline index that expired
+            // Find earliest batch in timeline index that expired.
             // Note that state.broadcast_info.sent_batches is ordered in decreasing order in the timeline index
             for (batch, sent_time) in state.broadcast_info.sent_batches.iter() {
                 let deadline = sent_time.add(Duration::from_millis(
@@ -232,11 +232,11 @@ impl PeerManager {
                     pending_broadcasts += 1;
                 }
 
-                // The maximum number of broadcasts sent to a single peer that are pending a response ACK at any point
+                // The maximum number of broadcasts sent to a single peer that are pending a response ACK at any point.
                 // If the number of un-ACK'ed un-expired broadcasts reaches this threshold, we do not broadcast anymore
-                // and wait until an ACK is received or a sent broadcast expires
+                // and wait until an ACK is received or a sent broadcast expires.
                 // This helps rate-limit egress network bandwidth and not overload a remote peer or this
-                // node's Diem network sender
+                // node's Diem network sender.
                 if pending_broadcasts >= self.mempool_config.max_broadcasts_per_peer {
                     return;
                 }
@@ -255,7 +255,7 @@ impl PeerManager {
                     (*id, txns)
                 }
                 None => {
-                    // fresh broadcast
+                    // Fresh broadcast
                     let (txns, new_timeline_id) = mempool.read_timeline(
                         state.timeline_id,
                         self.mempool_config.shared_mempool_batch_size,
@@ -272,7 +272,6 @@ impl PeerManager {
             return;
         }
 
-        // execute actual network send
         let mut network_sender = smp
             .network_senders
             .get_mut(&peer.network_id())
@@ -298,9 +297,9 @@ impl PeerManager {
             );
             return;
         }
-        // update peer sync state with info from above broadcast
+        // Update peer sync state with info from above broadcast.
         state.timeline_id = std::cmp::max(state.timeline_id, batch_id.1);
-        // turn off backoff mode after every broadcast
+        // Turn off backoff mode after every broadcast.
         state.broadcast_info.backoff_mode = false;
         state
             .broadcast_info
@@ -341,15 +340,15 @@ impl PeerManager {
         }
     }
 
-    // updates the peer chosen to failover to if all peers in the primary upstream network are down
-    // tries to pick more `default_peers` until there are `mempool_config.default_peers` number of them
+    // Updates the peer chosen to failover to if all peers in the primary upstream network are down.
+    // Tries to pick more `default_peers` until there are `mempool_config.default_peers` number of them.
     fn update_failover(&self) {
-        // failover is enabled only if there are multiple upstream networks
+        // Failover is enabled only if there are multiple upstream networks.
         if self.upstream_config.networks.len() < 2 {
             return;
         }
 
-        // declare `failover` as standalone to satisfy lifetime requirement
+        // Declare `failover` as standalone to satisfy lifetime requirement.
         let mut failover = self.failover_peer.lock();
         let current_failover = failover.deref_mut();
         let peer_info = self.peer_info.lock();
@@ -364,7 +363,7 @@ impl PeerManager {
             })
             .into_group_map();
 
-        // update default_failovers
+        // Update default_failovers.
         // NOTE: this block of code, and maintaining even this concept of `default_failovers`, is a
         // *temporary* patch to improve the reliability of txn delivery in case of the primary
         // upstream network is lagging behind, and the txns delivered to it will not be ready for further
@@ -394,11 +393,11 @@ impl PeerManager {
             .get(0)
             .expect("missing primary upstream network");
         if active_peers_by_network.get(primary_upstream).is_none() {
-            // there are no live peers in the primary upstream network - pick a failover peer
+            // There are no live peers in the primary upstream network - pick a failover peer.
 
             let mut failover_candidate = None;
-            // find the highest-pref'ed network (based on preference defined in upstream config)
-            // with any live peer and pick a peer from that network
+            // Find the highest-pref'ed network (based on preference defined in upstream config)
+            // with any live peer and pick a peer from that network.
             for failover_network in self.upstream_config.networks[1..].iter() {
                 if let Some(active_peers) = active_peers_by_network.get(failover_network) {
                     failover_candidate = active_peers.choose(&mut rand::thread_rng());
@@ -413,22 +412,22 @@ impl PeerManager {
                     if chosen.raw_network_id() == candidate.raw_network_id()
                         && peer_info.get(chosen).expect("missing peer state").is_alive
                     {
-                        // if current chosen failover peer is alive, then do not overwrite it
-                        // with another live peer of the same network
-                        // for mempool broadcasts, broadcasting to the same peer consistently makes
-                        // faster progress
+                        // If current chosen failover peer is alive, then do not overwrite it
+                        // with another live peer of the same network.
+                        // For mempool broadcasts, broadcasting to the same peer consistently makes
+                        // faster progress.
                         return;
                     }
                 }
             }
             *current_failover = failover_candidate.cloned().cloned();
         } else {
-            // there is at least one peer alive in the primary upstream network, so don't pick
-            // a failover peer
+            // There is at least one peer alive in the primary upstream network, so don't pick
+            // a failover peer.
             *current_failover = None;
         }
 
-        // log/update metric for the updated failover network
+        // Log/update metric for the updated failover network.
         match failover.as_ref() {
             Some(peer) => {
                 let failover_network = peer.raw_network_id();
@@ -457,7 +456,6 @@ impl PeerManager {
         request_id_bytes: Vec<u8>,
         retry: bool,
         backoff: bool,
-        // timestamp of ACK received
         timestamp: SystemTime,
     ) {
         let peer_id = &peer.peer_id().to_string();
@@ -483,7 +481,6 @@ impl PeerManager {
         };
 
         if let Some(sent_timestamp) = sync_state.broadcast_info.sent_batches.remove(&batch_id) {
-            // track broadcast roundtrip latency
             let rtt = timestamp
                 .duration_since(sent_timestamp)
                 .expect("failed to calculate mempool broadcast RTT");
@@ -491,12 +488,10 @@ impl PeerManager {
                 .with_label_values(&[network_id, peer_id])
                 .observe(rtt.as_secs_f64());
 
-            // update ACK counter
             counters::SHARED_MEMPOOL_PENDING_BROADCASTS_COUNT
                 .with_label_values(&[network_id, peer_id])
                 .dec();
         } else {
-            // log and return
             trace!(
                 LogSchema::new(LogEntry::ReceiveACK)
                     .peer(&peer)
@@ -519,17 +514,17 @@ impl PeerManager {
             sync_state.broadcast_info.retry_batches.insert(batch_id);
         }
 
-        // if backoff mode can only be turned off by executing a broadcast that was scheduled
-        // as a backoff broadcast
-        // This ensures backpressure request from remote peer is honored at least once
+        // Backoff mode can only be turned off by executing a broadcast that was scheduled
+        // as a backoff broadcast.
+        // This ensures backpressure request from remote peer is honored at least once.
         if backoff {
             sync_state.broadcast_info.backoff_mode = true;
         }
     }
 
-    // if the origin is provided, checks whether this peer is an upstream peer based on configured preferences and
-    // connection origin
-    // if the origin is not provided, checks whether this peer is an upstream peer that was seen before
+    // If the origin is provided, checks whether this peer is an upstream peer based on configured preferences and
+    // connection origin.
+    // If the origin is not provided, checks whether this peer is an upstream peer that was seen before.
     pub fn is_upstream_peer(&self, peer: &PeerNetworkId, origin: Option<ConnectionOrigin>) -> bool {
         if let Some(origin) = origin {
             if Self::is_public_downstream(peer.raw_network_id(), origin) {
@@ -554,10 +549,10 @@ impl PeerManager {
         network_id == NetworkId::Public && origin == ConnectionOrigin::Inbound
     }
 
-    // checks whether a peer is a chosen broadcast recipient:
+    // Checks whether a peer is a chosen broadcast recipient:
     // - all primary peers
     // - fallback peers, if k-policy is enabled
-    // this does NOT check for whether this peer is alive
+    // This does NOT check for whether this peer is alive.
     pub fn is_picked_peer(&self, peer: &PeerNetworkId) -> bool {
         if self.is_primary_upstream_peer(&peer) {
             return true;
@@ -565,8 +560,8 @@ impl PeerManager {
 
         let failover = self.failover_peer.lock();
         if let Some(failover_peer) = failover.as_ref() {
-            // in failover mode (i.e. primary network is down).
-            // broadcast to all peers in the same network as this chosen upstream failover peer
+            // In failover mode (i.e. primary network is down).
+            // broadcast to all peers in the same network as this chosen upstream failover peer.
 
             // NOTE: originally mempool should only broadcast to one peer in the failover network. This is
             // to avoid creating too much competition for traffic in the failover network, which is in most

--- a/mempool/src/shared_mempool/runtime.rs
+++ b/mempool/src/shared_mempool/runtime.rs
@@ -25,17 +25,17 @@ use storage_interface::DbReader;
 use tokio::runtime::{Builder, Handle, Runtime};
 use vm_validator::vm_validator::{TransactionValidation, VMValidator};
 
-/// bootstrap of SharedMempool
-/// creates separate Tokio Runtime that runs following routines:
-///   - outbound_sync_task (task that periodically broadcasts transactions to peers)
-///   - inbound_network_task (task that handles inbound mempool messages and network events)
-///   - gc_task (task that performs GC of all expired transactions by SystemTTL)
+/// Bootstrap of SharedMempool.
+/// Creates a separate Tokio Runtime that runs the following routines:
+///   - outbound_sync_task (task that periodically broadcasts transactions to peers).
+///   - inbound_network_task (task that handles inbound mempool messages and network events).
+///   - gc_task (task that performs GC of all expired transactions by SystemTTL).
 pub(crate) fn start_shared_mempool<V>(
     executor: &Handle,
     config: &NodeConfig,
     mempool: Arc<Mutex<CoreMempool>>,
-    // First element in tuple is the network ID
-    // See `NodeConfig::is_upstream_peer` for the definition of network ID
+    // First element in tuple is the network ID.
+    // See `NodeConfig::is_upstream_peer` for the definition of network ID.
     mempool_network_handles: Vec<(NodeNetworkId, MempoolNetworkSender, MempoolNetworkEvents)>,
     client_events: mpsc::Receiver<(SignedTransaction, oneshot::Sender<Result<SubmissionStatus>>)>,
     consensus_requests: mpsc::Receiver<ConsensusRequest>,
@@ -88,12 +88,11 @@ pub(crate) fn start_shared_mempool<V>(
     ));
 }
 
-/// method used to bootstrap shared mempool for a node
 pub fn bootstrap(
     config: &NodeConfig,
     db: Arc<dyn DbReader>,
-    // The first element in the tuple is the ID of the network that this network is a handle to
-    // See `NodeConfig::is_upstream_peer` for the definition of network ID
+    // The first element in the tuple is the ID of the network that this network is a handle to.
+    // See `NodeConfig::is_upstream_peer` for the definition of network ID.
     mempool_network_handles: Vec<(NodeNetworkId, MempoolNetworkSender, MempoolNetworkEvents)>,
     client_events: Receiver<(SignedTransaction, oneshot::Sender<Result<SubmissionStatus>>)>,
     consensus_requests: Receiver<ConsensusRequest>,

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -32,7 +32,7 @@ use subscription_service::ReconfigSubscription;
 use tokio::runtime::Handle;
 use vm_validator::vm_validator::TransactionValidation;
 
-/// Struct that owns all dependencies required by shared mempool routines
+/// Struct that owns all dependencies required by shared mempool routines.
 #[derive(Clone)]
 pub(crate) struct SharedMempool<V>
 where
@@ -66,13 +66,10 @@ pub(crate) fn notify_subscribers(
 
 /// A future that represents a scheduled mempool txn broadcast
 pub(crate) struct ScheduledBroadcast {
-    /// time of scheduled broadcast
+    /// Time of scheduled broadcast
     deadline: Instant,
-    /// broadcast recipient
     peer: PeerNetworkId,
-    /// whether this broadcast was scheduled in backoff mode
     backoff: bool,
-    /// the waker that will be used to notify the executor when the broadcast is ready
     waker: Arc<Mutex<Option<Waker>>>,
 }
 
@@ -117,22 +114,19 @@ impl Future for ScheduledBroadcast {
     }
 }
 
-/// Message sent from consensus to mempool
+/// Message sent from consensus to mempool.
 pub enum ConsensusRequest {
-    /// request to pull block to submit to consensus
+    /// Request to pull block to submit to consensus.
     GetBlockRequest(
         // max block size
         u64,
         // transactions to exclude from requested block
         Vec<TransactionExclusion>,
-        // callback to send response back to sender
         oneshot::Sender<Result<ConsensusResponse>>,
     ),
-    /// notifications about *rejected* committed txns
+    /// Notifications about *rejected* committed txns.
     RejectNotification(
-        // committed transactions
         Vec<CommittedTransaction>,
-        // callback to send response back to sender
         oneshot::Sender<Result<ConsensusResponse>>,
     ),
 }
@@ -162,25 +156,21 @@ impl fmt::Display for ConsensusRequest {
     }
 }
 
-/// Response setn from mempool to consensus
+/// Response sent from mempool to consensus.
 pub enum ConsensusResponse {
-    /// block to submit to consensus
+    /// Block to submit to consensus
     GetBlockResponse(
-        // transactions in block
         Vec<SignedTransaction>,
     ),
-    /// ACK for commit notification
     CommitResponse(),
 }
 
-/// notification from state sync to mempool of commit event
-/// This notifies mempool to remove committed txns
+/// Notification from state sync to mempool of commit event.
+/// This notifies mempool to remove committed txns.
 pub struct CommitNotification {
-    /// committed transactions
     pub transactions: Vec<CommittedTransaction>,
-    /// timestamp of committed block
+    /// Timestamp of committed block.
     pub block_timestamp_usecs: u64,
-    /// callback to send back response from mempool to State Sync
     pub callback: oneshot::Sender<Result<CommitResponse>>,
 }
 
@@ -198,18 +188,15 @@ impl fmt::Display for CommitNotification {
     }
 }
 
-/// ACK response to commit notification
 #[derive(Debug)]
 pub struct CommitResponse {
     /// error msg if applicable - empty string if commit was processed successfully by mempool
     pub msg: String,
 }
 
-/// successfully executed and committed txn
+/// Successfully executed and committed txn
 pub struct CommittedTransaction {
-    /// sender
     pub sender: AccountAddress,
-    /// sequence number
     pub sequence_number: u64,
 }
 
@@ -219,12 +206,9 @@ impl fmt::Display for CommittedTransaction {
     }
 }
 
-/// excluded txn
 #[derive(Clone)]
 pub struct TransactionExclusion {
-    /// sender
     pub sender: AccountAddress,
-    /// sequence number
     pub sequence_number: u64,
 }
 
@@ -234,20 +218,15 @@ impl fmt::Display for TransactionExclusion {
     }
 }
 
-/// Submission Status is represented as combination of vm_validator internal status and core mempool insertion status
 pub type SubmissionStatus = (MempoolStatus, Option<DiscardedVMStatus>);
 
-/// A txn's submission status coupled with the txn itself.
 pub type SubmissionStatusBundle = (SignedTransaction, SubmissionStatus);
 
-/// sender type: used to enqueue new transactions to shared mempool by client endpoints
 pub type MempoolClientSender =
     mpsc::Sender<(SignedTransaction, oneshot::Sender<Result<SubmissionStatus>>)>;
 
-/// On-chain configs that mempool subscribes to for reconfiguration
 const MEMPOOL_SUBSCRIBED_CONFIGS: &[ConfigID] = &[DiemVersion::CONFIG_ID, VMConfig::CONFIG_ID];
 
-/// Creates mempool's subscription bundle for on-chain reconfiguration
 pub fn gen_mempool_reconfig_subscription(
 ) -> (ReconfigSubscription, Receiver<(), OnChainConfigPayload>) {
     ReconfigSubscription::subscribe_all("mempool", MEMPOOL_SUBSCRIBED_CONFIGS.to_vec(), vec![])

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -159,9 +159,7 @@ impl fmt::Display for ConsensusRequest {
 /// Response sent from mempool to consensus.
 pub enum ConsensusResponse {
     /// Block to submit to consensus
-    GetBlockResponse(
-        Vec<SignedTransaction>,
-    ),
+    GetBlockResponse(Vec<SignedTransaction>),
     CommitResponse(),
 }
 

--- a/mempool/src/tests/common.rs
+++ b/mempool/src/tests/common.rs
@@ -98,7 +98,6 @@ impl TestTransaction {
     }
 }
 
-// adds transactions to mempool
 pub(crate) fn add_txns_to_mempool(
     pool: &mut CoreMempool,
     txns: Vec<TestTransaction>,
@@ -152,7 +151,7 @@ pub(crate) fn batch_add_signed_txn(
     Ok(())
 }
 
-// helper struct that keeps state between `.get_block` calls. Imitates work of Consensus
+// Helper struct that keeps state between `.get_block` calls. Imitates work of Consensus.
 pub struct ConsensusMock(HashSet<TxnPointer>);
 
 impl ConsensusMock {

--- a/mempool/src/tests/fuzzing.rs
+++ b/mempool/src/tests/fuzzing.rs
@@ -17,7 +17,6 @@ use std::{collections::HashMap, sync::Arc};
 use storage_interface::mock::MockDbReader;
 use vm_validator::mocks::mock_vm_validator::MockVMValidator;
 
-/// Proptest strategy for fuzzing input to mempool incoming transactions endpoint
 pub fn mempool_incoming_transactions_strategy(
 ) -> impl Strategy<Value = (Vec<SignedTransaction>, TimelineState)> {
     (
@@ -29,12 +28,10 @@ pub fn mempool_incoming_transactions_strategy(
     )
 }
 
-/// Test that takes in fuzzer-generated inputs to mempool's `process_incoming_transactions_impl` endpoint
 pub fn test_mempool_process_incoming_transactions_impl(
     txns: Vec<SignedTransaction>,
     timeline_state: TimelineState,
 ) {
-    // set up mock Shared Mempool
     let config = NodeConfig::default();
     let mock_db = MockDbReader;
     let vm_validator = Arc::new(RwLock::new(MockVMValidator));

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -31,13 +31,9 @@ use vm_validator::mocks::mock_vm_validator::MockVMValidator;
 /// Mock of a running instance of shared mempool
 pub struct MockSharedMempool {
     _runtime: Runtime,
-    /// sender from admission control to shared mempool
     pub ac_client: mpsc::Sender<(SignedTransaction, oneshot::Sender<Result<SubmissionStatus>>)>,
-    /// mempool
     pub mempool: Arc<Mutex<CoreMempool>>,
-    /// sender from consensus to shared mempool
     pub consensus_sender: mpsc::Sender<ConsensusRequest>,
-    /// sender from state sync to shared mempool
     pub state_sync_sender: Option<mpsc::Sender<CommitNotification>>,
 }
 

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -28,7 +28,7 @@ use storage_interface::mock::MockDbReader;
 use tokio::runtime::{Builder, Runtime};
 use vm_validator::mocks::mock_vm_validator::MockVMValidator;
 
-/// Mock of a running instance of shared mempool
+/// Mock of a running instance of shared mempool.
 pub struct MockSharedMempool {
     _runtime: Runtime,
     pub ac_client: mpsc::Sender<(SignedTransaction, oneshot::Sender<Result<SubmissionStatus>>)>,
@@ -38,9 +38,9 @@ pub struct MockSharedMempool {
 }
 
 impl MockSharedMempool {
-    /// Creates a mock of a running instance of shared mempool
+    /// Creates a mock of a running instance of shared mempool.
     /// Returns the runtime on which the shared mempool is running
-    /// and the channel through which shared mempool receives client events
+    /// and the channel through which shared mempool receives client events.
     pub fn new(state_sync: Option<mpsc::Receiver<CommitNotification>>) -> Self {
         let runtime = Builder::new()
             .thread_name("mock-shared-mem")
@@ -102,7 +102,6 @@ impl MockSharedMempool {
         }
     }
 
-    /// add txns to mempool
     pub fn add_txns(&self, txns: Vec<SignedTransaction>) -> Result<()> {
         {
             let mut pool = self.mempool.lock();
@@ -126,7 +125,7 @@ impl MockSharedMempool {
         Ok(())
     }
 
-    /// true if all given txns are in mempool, else false
+    /// True if all the given txns are in mempool, else false.
     pub fn read_timeline(&self, timeline_id: u64, count: usize) -> Vec<SignedTransaction> {
         let mut pool = self.mempool.lock();
         pool.read_timeline(timeline_id, count)

--- a/mempool/src/tests/mod.rs
+++ b/mempool/src/tests/mod.rs
@@ -8,9 +8,6 @@ mod core_mempool_test;
 #[cfg(test)]
 mod shared_mempool_test;
 
-/// Mocks used for testing
+pub mod fuzzing;
 #[cfg(any(feature = "fuzzing", test))]
 pub mod mocks;
-
-/// Fuzzing
-pub mod fuzzing;

--- a/mempool/src/tests/shared_mempool_test.rs
+++ b/mempool/src/tests/shared_mempool_test.rs
@@ -61,8 +61,8 @@ struct SharedMempoolNetwork {
     peer_ids: HashMap<PeerId, PeerId>,
 }
 
-// start a shared mempool for a node `peer_id` with config `config`
-// and add it to `smp` network
+// Start a shared mempool for a node `peer_id` with config `config`
+// and add it to `smp` network.
 fn init_single_shared_mempool(
     smp: &mut SharedMempoolNetwork,
     peer_id: PeerId,
@@ -119,7 +119,7 @@ fn init_single_shared_mempool(
     smp.runtimes.insert(peer_id, runtime);
 }
 
-// first PeerId in `network_ids` will be key in SharedMempoolNetwork
+// First PeerId in `network_ids` will be key in SharedMempoolNetwork.
 fn init_smp_multiple_networks(
     smp: &mut SharedMempoolNetwork,
     network_ids: Vec<(NetworkId, PeerId)>,
@@ -203,7 +203,7 @@ impl SharedMempoolNetwork {
             config.validator_network = Some(NetworkConfig::network_with_id(NetworkId::Validator));
             let peer_id = config.validator_network.as_ref().unwrap().peer_id();
             config.mempool.shared_mempool_batch_size = broadcast_batch_size;
-            // set the ack timeout duration to 0 to avoid sleeping to test rebroadcast scenario (broadcast must timeout for this)
+            // Set the ack timeout duration to 0 to avoid sleeping to test rebroadcast scenario (broadcast must timeout for this).
             config.mempool.shared_mempool_ack_timeout_ms =
                 if max_ack_timeout { u64::MAX } else { 0 };
             config.mempool.capacity = mempool_size.unwrap_or(config.mempool.capacity);
@@ -217,8 +217,8 @@ impl SharedMempoolNetwork {
         (smp, peers)
     }
 
-    /// creates a shared mempool network of one full node and one validator
-    /// returns the newly created SharedMempoolNetwork, and the ID of validator and full node, in that order
+    /// Creates a shared mempool network of one full node and one validator.
+    /// Returns the newly created SharedMempoolNetwork, and the ID of validator and full node, in that order.
     fn bootstrap_vfn_network(
         broadcast_batch_size: usize,
         validator_mempool_size: Option<usize>,
@@ -226,17 +226,16 @@ impl SharedMempoolNetwork {
     ) -> (Self, PeerId, PeerId) {
         let mut smp = Self::default();
 
-        // declare peers in network
+        // Declare peers in network.
         let validator = PeerId::random();
         let full_node = PeerId::random();
 
-        // validator config
         let mut rng = StdRng::from_seed([0u8; 32]);
         let mut config = NodeConfig::random_with_template(0, &NodeConfig::default(), &mut rng);
 
         config.mempool.shared_mempool_batch_size = broadcast_batch_size;
         config.mempool.shared_mempool_backoff_interval_ms = 50;
-        // set the ack timeout duration to 0 to avoid sleeping to test rebroadcast scenario (broadcast must timeout for this)
+        // Set the ack timeout duration to 0 to avoid sleeping to test rebroadcast scenario (broadcast must timeout for this).
         config.mempool.shared_mempool_ack_timeout_ms = 0;
         if let Some(capacity) = validator_mempool_size {
             config.mempool.capacity = capacity
@@ -246,12 +245,11 @@ impl SharedMempoolNetwork {
         }
         init_single_shared_mempool(&mut smp, validator, NetworkId::vfn_network(), config);
 
-        // full node
         let mut fn_config = NodeConfig::random_with_template(1, &NodeConfig::default(), &mut rng);
         fn_config.base.role = RoleType::FullNode;
         fn_config.mempool.shared_mempool_batch_size = broadcast_batch_size;
         fn_config.mempool.shared_mempool_backoff_interval_ms = 50;
-        // set the ack timeout duration to 0 to avoid sleeping to test rebroadcast scenario (broadcast must timeout for this)
+        // Set the ack timeout duration to 0 to avoid sleeping to test rebroadcast scenario (broadcast must timeout for this).
         fn_config.mempool.shared_mempool_ack_timeout_ms = 0;
 
         let mut upstream_config = UpstreamConfig::default();
@@ -328,30 +326,29 @@ impl SharedMempoolNetwork {
         assert!(subscriber.select_next_some().now_or_never().is_none());
     }
 
-    // checks that a node has no pending messages to send
+    // Checks that a node has no pending messages to send.
     fn assert_no_message_sent(&mut self, peer: &PeerId) {
         self.check_no_events(peer);
 
-        // await next message from node
         let network_reqs_rx = self.network_reqs_rxs.get_mut(peer).unwrap();
         assert!(network_reqs_rx.select_next_some().now_or_never().is_none());
     }
 
-    /// delivers next broadcast message from `peer`
+    /// Delivers next broadcast message from `peer`.
     fn deliver_message(
         &mut self,
         peer: &PeerId,
         num_messages: usize,
-        check_txns_in_mempool: bool, // check whether all txns in this broadcast are accepted into recipient's mempool
-        execute_send: bool, // if true, actually delivers msg to remote peer; else, drop the message (useful for testing unreliable msg delivery)
-        drop_ack: bool,     // if true, drop ack from remote peer to this peer
+        check_txns_in_mempool: bool, // Check whether all txns in this broadcast are accepted into recipient's mempool
+        execute_send: bool, // If true, actually delivers msg to remote peer; else, drop the message (useful for testing unreliable msg delivery)
+        drop_ack: bool,     // If true, drop ack from remote peer to this peer
     ) -> (Vec<SignedTransaction>, PeerId) {
-        // await broadcast notification
+        // Await broadcast notification
         for _ in 0..num_messages {
             self.wait_for_event(peer, SharedMempoolNotification::Broadcast);
         }
 
-        // await next message from node
+        // Await next message from node
         let network_reqs_rx = self.network_reqs_rxs.get_mut(peer).unwrap();
         let network_req = block_on(network_reqs_rx.next()).unwrap();
 
@@ -362,7 +359,7 @@ impl SharedMempoolNetwork {
                     return (transactions, peer_id);
                 }
 
-                // send it to peer
+                // Send it to peer
                 let receiver_network_notif_tx = self.network_notifs_txs.get_mut(&peer_id).unwrap();
                 receiver_network_notif_tx
                     .push(
@@ -371,10 +368,9 @@ impl SharedMempoolNetwork {
                     )
                     .unwrap();
 
-                // await message delivery
                 self.wait_for_event(&peer_id, SharedMempoolNotification::NewTransactions);
 
-                // verify transaction was inserted into Mempool
+                // Verify transaction was inserted into Mempool
                 if check_txns_in_mempool {
                     let mempool = self.mempools.get(&peer_id).unwrap();
                     let block = mempool.lock().get_block(100, HashSet::new());
@@ -383,7 +379,6 @@ impl SharedMempoolNetwork {
                     }
                 }
 
-                // deliver ACK for this request
                 if !drop_ack {
                     self.deliver_response(&peer_id);
                 }
@@ -396,7 +391,7 @@ impl SharedMempoolNetwork {
         }
     }
 
-    /// delivers broadcast ACK from `peer`
+    /// Delivers broadcast ACK from `peer`.
     fn deliver_response(&mut self, peer: &PeerId) {
         self.wait_for_event(&peer, SharedMempoolNotification::ACK);
         let network_reqs_rx = self.network_reqs_rxs.get_mut(peer).unwrap();
@@ -503,7 +498,7 @@ fn test_interruption_in_sync() {
     // A discovers first peer
     smp.send_new_peer_event(peer_a, peer_b, true);
 
-    // make sure first txn delivered to first peer
+    // Make sure first txn delivered to first peer
     assert_eq!(
         *peer_b,
         smp.deliver_message(&peer_a, 1, true, true, false).1
@@ -512,7 +507,7 @@ fn test_interruption_in_sync() {
     // A discovers second peer
     smp.send_new_peer_event(peer_a, peer_c, true);
 
-    // make sure first txn delivered to second peer
+    // Make sure first txn delivered to second peer
     assert_eq!(
         *peer_c,
         smp.deliver_message(&peer_a, 1, true, true, false).1
@@ -521,7 +516,7 @@ fn test_interruption_in_sync() {
     // A loses connection to B
     smp.send_lost_peer_event(peer_a, peer_b);
 
-    // only C receives following transactions
+    // Only C receives the following transactions
     smp.add_txns(&peer_a, vec![TestTransaction::new(1, 1, 1)]);
     let (txn, peer_id) = smp.deliver_message(&peer_a, 1, true, true, false);
     assert_eq!(peer_id, *peer_c);
@@ -550,11 +545,11 @@ fn test_ready_transactions() {
         &peer_a,
         vec![TestTransaction::new(1, 0, 1), TestTransaction::new(1, 2, 1)],
     );
-    // first message delivery
+    // First message delivery
     smp.send_new_peer_event(peer_a, peer_b, true);
     smp.deliver_message(&peer_a, 1, true, true, false);
 
-    // add txn1 to Mempool
+    // Add txn1 to mempool
     smp.add_txns(&peer_a, vec![TestTransaction::new(1, 1, 1)]);
     // txn1 unlocked txn2. Now all transactions can go through in correct order
     let txn = &smp.deliver_message(&peer_a, 1, true, true, false).0;
@@ -577,10 +572,10 @@ fn test_broadcast_self_transactions() {
     // A sends txn to B
     smp.deliver_message(&peer_a, 1, true, true, false);
 
-    // add new txn to B
+    // Add new txn to B
     smp.add_txns(&peer_b, vec![TestTransaction::new(1, 0, 1)]);
 
-    // verify that A will receive only second transaction from B
+    // Verify that A will receive only second transaction from B
     let (txn, _) = smp.deliver_message(&peer_b, 1, true, true, false);
     assert_eq!(
         txn.get(0).unwrap().sender(),
@@ -607,10 +602,10 @@ fn test_broadcast_dependencies() {
 
     // B receives 0
     smp.deliver_message(&peer_a, 1, true, true, false);
-    // now B can broadcast 1
+    // Now B can broadcast 1
     let txn = smp.deliver_message(&peer_b, 1, true, true, false).0;
     assert_eq!(txn.get(0).unwrap().sequence_number(), 1);
-    // now A can broadcast 2
+    // Now A can broadcast 2
     let txn = smp.deliver_message(&peer_a, 1, true, true, false).0;
     assert_eq!(txn.get(0).unwrap().sequence_number(), 2);
 }
@@ -636,7 +631,7 @@ fn test_broadcast_updated_transaction() {
     // Update the gas price of the transaction with sequence 0 after B has already received 0
     smp.add_txns(&peer_a, vec![TestTransaction::new(0, 0, 5)]);
 
-    // trigger send from A to B and check B has updated gas price for sequence 0
+    // Trigger send from A to B and check B has updated gas price for sequence 0
     let txn = smp.deliver_message(&peer_a, 1, true, true, false).0;
     assert_eq!(txn.get(0).unwrap().sequence_number(), 0);
     assert_eq!(txn.get(0).unwrap().gas_unit_price(), 5);
@@ -646,10 +641,10 @@ fn test_broadcast_updated_transaction() {
 fn test_consensus_events_rejected_txns() {
     let smp = MockSharedMempool::new(None);
 
-    // add txns 1, 2, 3, 4
-    // txn 1: committed successfully
-    // txn 2: not committed but older than gc block timestamp
-    // txn 3: not committed and newer than block timestamp
+    // Add txns 1, 2, 3, 4
+    // Txn 1: committed successfully
+    // Txn 2: not committed but older than gc block timestamp
+    // Txn 3: not committed and newer than block timestamp
     let committed_txn =
         TestTransaction::new(0, 0, 1).make_signed_transaction_with_expiration_time(0);
     let kept_txn = TestTransaction::new(1, 0, 1).make_signed_transaction(); // not committed or cleaned out by block timestamp gc
@@ -658,13 +653,12 @@ fn test_consensus_events_rejected_txns() {
         TestTransaction::new(0, 1, 1).make_signed_transaction_with_expiration_time(0),
         kept_txn.clone(),
     ];
-    // add txns to mempool
+    // Add txns to mempool
     {
         let mut pool = smp.mempool.lock();
         assert!(batch_add_signed_txn(&mut pool, txns).is_ok());
     }
 
-    // send commit notif
     let committed_txns = vec![CommittedTransaction {
         sender: committed_txn.sender(),
         sequence_number: committed_txn.sequence_number(),
@@ -677,7 +671,6 @@ fn test_consensus_events_rejected_txns() {
         assert!(callback_rcv.await.is_ok());
     });
 
-    // check mempool
     let mut pool = smp.mempool.lock();
     let (timeline, _) = pool.read_timeline(0, 10);
     assert_eq!(timeline.len(), 1);
@@ -689,10 +682,10 @@ fn test_state_sync_events_committed_txns() {
     let (mut state_sync_sender, state_sync_events) = mpsc::channel(1_024);
     let smp = MockSharedMempool::new(Some(state_sync_events));
 
-    // add txns 1, 2, 3, 4
-    // txn 1: committed successfully
-    // txn 2: not committed but older than gc block timestamp
-    // txn 3: not committed and newer than block timestamp
+    // Add txns 1, 2, 3, 4
+    // Txn 1: committed successfully
+    // Txn 2: not committed but older than gc block timestamp
+    // Txn 3: not committed and newer than block timestamp
     let committed_txn =
         TestTransaction::new(0, 0, 1).make_signed_transaction_with_expiration_time(0);
     let kept_txn = TestTransaction::new(1, 0, 1).make_signed_transaction(); // not committed or cleaned out by block timestamp gc
@@ -701,13 +694,12 @@ fn test_state_sync_events_committed_txns() {
         TestTransaction::new(0, 1, 1).make_signed_transaction_with_expiration_time(0),
         kept_txn.clone(),
     ];
-    // add txns to mempool
+    // Add txns to mempool
     {
         let mut pool = smp.mempool.lock();
         assert!(batch_add_signed_txn(&mut pool, txns).is_ok());
     }
 
-    // send commit notif
     let committed_txns = vec![CommittedTransaction {
         sender: committed_txn.sender(),
         sequence_number: committed_txn.sequence_number(),
@@ -724,14 +716,13 @@ fn test_state_sync_events_committed_txns() {
         assert!(callback_rcv.await.is_ok());
     });
 
-    // check mempool
     let mut pool = smp.mempool.lock();
     let (timeline, _) = pool.read_timeline(0, 10);
     assert_eq!(timeline.len(), 1);
     assert_eq!(timeline.get(0).unwrap(), &kept_txn);
 }
 
-// tests VFN properly identifying upstream peers in a network with both upstream and downstream peers
+// Tests VFN properly identifying upstream peers in a network with both upstream and downstream peers
 #[test]
 fn test_vfn_multi_network() {
     let vfn_0 = PeerId::random();
@@ -769,32 +760,32 @@ fn test_vfn_multi_network() {
     );
     init_single_shared_mempool(&mut smp, pfn, NetworkId::Public, pfn_config);
 
-    //vfn 0 discovers pfn as inbound
+    // Vfn 0 discovers pfn as inbound
     smp.send_new_peer_event(&vfn_0_public_network_id, &pfn, true);
-    // vfn 0 discovers vfn 1 as outbound
+    // Vfn 0 discovers vfn 1 as outbound
     smp.send_new_peer_event(&vfn_0_public_network_id, &vfn_1_public_network_id, false);
 
-    // add txn to fn_0
+    // Add txn to fn_0
     smp.add_txns(&vfn_0, vec![TestTransaction::new(1, 0, 1)]);
 
-    // vfn should broadcast to failover upstream vfn in public network
+    // Vfn should broadcast to failover upstream vfn in public network
     assert_eq!(
         vfn_1_public_network_id,
         smp.deliver_message(&vfn_0_public_network_id, 1, false, true, false)
             .1
     );
 
-    // vfn should not broadcast to downstream peer in public network
+    // Vfn should not broadcast to downstream peer in public network
     smp.assert_no_message_sent(&vfn_0_public_network_id);
-    // sanity check, vfn doesn't broadcast to incorrect network
+    // Sanity check, vfn doesn't broadcast to incorrect network
     smp.assert_no_message_sent(&vfn_0);
 }
 
 #[test]
 fn test_fn_failover() {
-    // test vfn failing over to fallback network
+    // Test vfn failing over to fallback network
 
-    // set up network with fn with 1 primary v upstream and 3 fallback upstream fn
+    // Set up network with fn with 1 primary v upstream and 3 fallback upstream fn
     let v_0 = PeerId::random();
     let fn_0 = PeerId::random();
     let fn_0_fallback_network_id = PeerId::random();
@@ -833,42 +824,42 @@ fn test_fn_failover() {
     init_single_shared_mempool(&mut smp, fn_2, NetworkId::Public, fn_2_config);
     init_single_shared_mempool(&mut smp, fn_3, NetworkId::Public, fn_3_config);
 
-    // fn_0 discovers primary and fallback upstream peers
+    // Fn_0 discovers primary and fallback upstream peers
     smp.send_new_peer_event(&fn_0, &v_0, true);
     for fallback_peer in fallback_peers.iter() {
         smp.send_new_peer_event(&fn_0_fallback_network_id, fallback_peer, false);
     }
 
-    // add txn to fn_0
+    // Add txn to fn_0
     smp.add_txns(&fn_0, vec![TestTransaction::new(1, 0, 1)]);
 
-    // make sure it delivers txn to primary peer
+    // Make sure it delivers txn to primary peer
     let recipient_peer = smp.deliver_message(&fn_0, 1, true, true, false).1;
     assert_eq!(recipient_peer, v_0);
-    // check that no messages have been sent to fallback upstream peers
+    // Check that no messages have been sent to fallback upstream peers
     smp.assert_no_message_sent(&fn_0_fallback_network_id);
 
-    // bring v down
+    // Bring v down
     smp.send_lost_peer_event(&fn_0, &v_0);
 
-    // add txn to fn_0
+    // Add txn to fn_0
     smp.add_txns(&fn_0, vec![TestTransaction::new(1, 1, 1)]);
 
-    // make sure it delivers txn to fallback peer
+    // Make sure it delivers txn to fallback peer
     let mut actual_fallback_recipients = vec![];
     for _ in 0..fallback_peers.len() {
         let (txn, fallback_recipient) =
             smp.deliver_message(&fn_0_fallback_network_id, 1, true, true, false);
         assert!(fallback_peers.contains(&fallback_recipient));
         assert_eq!(txn.get(0).unwrap().sequence_number(), 0);
-        // check that no messages have been sent to primary upstream peer
+        // Check that no messages have been sent to primary upstream peer
         assert!(!actual_fallback_recipients.contains(&fallback_recipient));
         actual_fallback_recipients.push(fallback_recipient);
     }
     smp.assert_no_message_sent(&fn_0);
     assert_eq!(actual_fallback_recipients.len(), fallback_peers.len());
 
-    // add some more txns to fn_0
+    // Add some more txns to fn_0
     smp.add_txns(
         &fn_0,
         vec![TestTransaction::new(1, 2, 1), TestTransaction::new(1, 3, 1)],
@@ -886,15 +877,15 @@ fn test_fn_failover() {
             assert_eq!(txn.get(0).unwrap().sequence_number(), seq_num);
         }
     }
-    // check that no messages have been sent to primary upstream peer
+    // Check that no messages have been sent to primary upstream peer
     smp.assert_no_message_sent(&fn_0);
 
-    // bring down one fallback peer
+    // Bring down one fallback peer
     smp.send_lost_peer_event(&fn_0_fallback_network_id, &fn_1);
 
-    // add txn
+    // Add txn
     smp.add_txns(&fn_0, vec![TestTransaction::new(1, 4, 1)]);
-    // make sure it gets broadcast to another fallback peer
+    // Make sure it gets broadcast to another fallback peer
     for _ in 0..2 {
         let mut actual_fallback_recipients = vec![];
         let (txn, fallback_recipient) =
@@ -904,29 +895,29 @@ fn test_fn_failover() {
         assert!(!actual_fallback_recipients.contains(&fallback_recipient));
         actual_fallback_recipients.push(fallback_recipient);
 
-        // check txn seq num
+        // Check txn seq num
         assert_eq!(txn.get(0).unwrap().sequence_number(), 4);
     }
-    // check that no messages have been sent to primary upstream peer
+    // Check that no messages have been sent to primary upstream peer
     smp.assert_no_message_sent(&fn_0);
 
-    // bring down all upstream peers
+    // Bring down all upstream peers
     for fallback_peer in fallback_peers.iter() {
         if fallback_peer != &fn_1 {
             smp.send_lost_peer_event(&fn_0_fallback_network_id, fallback_peer);
         }
     }
-    // check that no messages get sent
+    // Check that no messages get sent
     smp.add_txns(&fn_0, vec![TestTransaction::new(1, 5, 1)]);
     smp.assert_no_message_sent(&fn_0);
     smp.assert_no_message_sent(&fn_0_fallback_network_id);
 
-    // bring back v up
+    // Bring back v up
     smp.send_new_peer_event(&fn_0, &v_0, true);
 
-    // add txn
+    // Add txn
     smp.add_txns(&fn_0, vec![TestTransaction::new(1, 6, 1)]);
-    // check that we don't broadcast to failovers, only v
+    // Check that we don't broadcast to failovers, only v
 
     for expected_seq_num in 0..=3 {
         let (txn, recipient) = smp.deliver_message(&fn_0, 1, true, true, false);
@@ -936,7 +927,7 @@ fn test_fn_failover() {
         smp.assert_no_message_sent(&fn_0_fallback_network_id);
     }
 
-    // bring back all fallback peers back
+    // Bring back all fallback peers back
     for fallback_peer in fallback_peers.iter() {
         smp.send_new_peer_event(&fn_0_fallback_network_id, fallback_peer, false);
     }
@@ -982,14 +973,14 @@ fn test_rebroadcast_mempool_is_full() {
         assert_eq!(expected_broadcast, seq_nums);
     }
 
-    // Test getting out of rebroadcasting mode: checking we can move past rebroadcasting after receiving non-retry ACK
-    // make space for retried txns
+    // Test getting out of rebroadcasting mode: checking we can move past rebroadcasting after receiving non-retry ACK.
+    // Make space for retried txns
     smp.commit_txns(&val, all_txns[..1].to_vec());
 
-    // send retry batch again, this time should be processed
+    // Send retry batch again, this time it should be processed
     smp.deliver_message(&full_node, 1, true, true, false);
 
-    // retry batch sent above should be processed successfully, and FN should move on to broadcasting later txns
+    // Retry batch sent above should be processed successfully, and FN should move on to broadcasting later txns
     let (txns, _recipient) = smp.deliver_message(&full_node, 1, false, true, false);
     let seq_nums = txns
         .iter()
@@ -1000,7 +991,7 @@ fn test_rebroadcast_mempool_is_full() {
 
 #[test]
 fn test_rebroadcast_missing_ack() {
-    // create 2 validators A and B
+    // Create 2 validators A and B
     let (mut smp, peers) =
         SharedMempoolNetwork::bootstrap_validator_network(2, 1, None, None, false);
     let (peer_a, peer_b) = (peers.get(0).unwrap(), peers.get(1).unwrap());
@@ -1015,7 +1006,7 @@ fn test_rebroadcast_missing_ack() {
     smp.send_new_peer_event(peer_a, peer_b, true);
     smp.send_new_peer_event(peer_b, peer_a, false);
 
-    // test that for txn broadcasts that don't receive an ACK, A rebroadcasts the unACK'ed batch of txns
+    // Test that txn broadcasts that don't receive an ACK, A rebroadcasts the unACK'ed batch of txns
     for _ in 0..3 {
         let (txns, _recipient) = smp.deliver_message(&peer_a, 1, true, false, false);
         let seq_nums = txns
@@ -1025,7 +1016,7 @@ fn test_rebroadcast_missing_ack() {
         assert_eq!(seq_nums, vec![0]);
     }
 
-    // getting out of rebroadcasting mode scenario 1: B sends back ACK eventually
+    // Getting out of rebroadcasting mode scenario 1: B sends back ACK eventually
     let (txns, _recipient) = smp.deliver_message(&peer_a, 1, true, true, false);
     let seq_nums = txns
         .iter()
@@ -1042,7 +1033,7 @@ fn test_rebroadcast_missing_ack() {
         assert_eq!(seq_nums, vec![1]);
     }
 
-    // getting out of rebroadcasting mode scenario 2: txns in unACK'ed batch gets committed
+    // Getting out of rebroadcasting mode scenario 2: txns in unACK'ed batch gets committed
     smp.commit_txns(&peer_a, vec![pool_txns[1].clone()]);
 
     let (txns, _recipient) = smp.deliver_message(&peer_a, 1, true, false, false);
@@ -1055,7 +1046,7 @@ fn test_rebroadcast_missing_ack() {
 
 #[test]
 fn test_max_broadcast_limit() {
-    // create 2 validators A and B
+    // Create 2 validators A and B
     let (mut smp, peers) =
         SharedMempoolNetwork::bootstrap_validator_network(2, 1, None, Some(3), true);
     let (peer_a, peer_b) = (peers.get(0).unwrap(), peers.get(1).unwrap());
@@ -1069,7 +1060,7 @@ fn test_max_broadcast_limit() {
     smp.send_new_peer_event(peer_a, peer_b, true);
     smp.send_new_peer_event(peer_b, peer_a, false);
 
-    // test that for mempool broadcasts txns up till max broadcast, even if they are not ACK'ed
+    // Test that for mempool broadcasts txns up till max broadcast, even if they are not ACK'ed
     let (txns, _recipient) = smp.deliver_message(&peer_a, 1, true, true, true);
     let seq_nums = txns
         .iter()
@@ -1085,14 +1076,14 @@ fn test_max_broadcast_limit() {
         assert_eq!(seq_nums, vec![expected_seq_num]);
     }
 
-    // check that mempool doesn't broadcast more than max_broadcasts_per_peer, even
-    // if there are more txns in mempool
+    // Check that mempool doesn't broadcast more than max_broadcasts_per_peer, even
+    // if there are more txns in mempool.
     for _ in 0..10 {
         smp.assert_no_message_sent(&peer_a);
     }
 
-    // deliver ACK from B to A
-    // this should unblock A to send more broadcasts
+    // Deliver ACK from B to A.
+    // This should unblock A to send more broadcasts.
     smp.deliver_response(&peer_b);
     let (txns, _recipient) = smp.deliver_message(&peer_a, 1, false, true, true);
     let seq_nums = txns
@@ -1101,8 +1092,8 @@ fn test_max_broadcast_limit() {
         .collect::<Vec<_>>();
     assert_eq!(seq_nums, vec![3]);
 
-    // check that mempool doesn't broadcast more than max_broadcasts_per_peer, even
-    // if there are more txns in mempool
+    // Check that mempool doesn't broadcast more than max_broadcasts_per_peer, even
+    // if there are more txns in mempool.
     for _ in 0..10 {
         smp.assert_no_message_sent(&peer_a);
     }


### PR DESCRIPTION
## Motivation

This PR removes the `#![deny(missing_docs)]` annotation from the mempool component code. The use of this annotation forces mandatory documentation (e.g., on methods and structs). However, this results in developers just adding documentation for the sake of it, rather than documentation that is actually useful (see the various examples removed in this PR). 

To address this, we remove the annotation from mempool and clean up redundant documentation. This PR offers the following commits:
1. Remove the `#![deny(missing_docs)]` annotation and remove/clean up documentation from core_mempool.
2. Remove/clean up documentation from shared_mempool.
3. Remove/clean up documentation from tests.

Note: this PR doesn't verify the correctness of the current comments/documentation (someone with more mempool experience will need to do that 😄). It just cleans things up.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally.

## Related PRs

None.
