### PR TITLE
[gha] single job if needed for bors

### DIFF
--- a/.github/actions/matches/action.yml
+++ b/.github/actions/matches/action.yml
@@ -45,7 +45,7 @@ runs:
         if [[ -f "${TARGET_FILE}" ]]; then
           echo found: 1>&2
           cat "${TARGET_FILE}" | grep "${INV}" "${PATTERN}" || echo No matching files. 1>&2
-          count="$( cat "${TARGET_FILE}" | grep -c "${INV}" "${PATTERN}" )" || true
+          count="$( cat "${TARGET_FILE}" | grep -c "${INV}" "${PATTERN}" || echo 0)"
           if [[ "$count" == 0 ]]; then
             result=false
           fi

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -2,7 +2,7 @@ name: ci-test
 
 on:
   push:
-    branches: [auto, gha-test-*]
+    branches: [auto, canary, gha-test-*]
   pull_request:
     branches: [main, master, release-*, gha-test-*]
 
@@ -49,7 +49,7 @@ jobs:
         name: find shell/dockerfile changes
         uses: ./.github/actions/matches
         with:
-          pattern: 'Dockerfile$\|.sh$'
+          pattern: 'Dockerfile$\|.*.sh$'
       - id: dev-setup-sh-changes
         name: find dev-setup.sh/base docker image changes
         uses: ./.github/actions/matches
@@ -307,3 +307,45 @@ jobs:
           rustup target add powerpc-unknown-linux-gnu
           cargo xcheck -j ${max_threads} -p transaction-builder -p move-vm-types --target powerpc-unknown-linux-gnu
       - uses: ./.github/actions/build-teardown
+
+  success:
+    name: ci-test-success
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    #always run this job even if needed jobs failed or are skipped.
+    if: ${{ always() }}
+    needs:
+      - prepare
+      - dev-setup-sh-test
+      - non-rust-lint
+      - lint
+      - unit-test
+      - e2e-test
+      - crypto-unit-test
+      - build-benchmarks
+      - build-dev
+    steps:
+      - run: |
+          echo prepare: ${{ needs.prepare.result }}
+          echo dev-setup-sh-test: ${{ needs.dev-setup-sh-test.result }}
+          echo non-rust-lint: ${{ needs.non-rust-lint.result }}
+          echo lint: ${{ needs.lint.result }}
+          echo unit-test: ${{ needs.unit-test.result }}
+          echo e2e-test: ${{ needs.e2e-test.result }}
+          echo crypto-unit-test: ${{ needs.crypto-unit-test.result }}
+          echo build-benchmarks: ${{ needs.build-benchmarks.result }}
+          echo build-dev: ${{ needs.build-dev.result }}
+          success="${{
+            needs.prepare.result=='success'
+            && (needs.dev-setup-sh-test.result=='success' || needs.dev-setup-sh-test.result=='skipped')
+            && (needs.non-rust-lint.result=='success' || needs.non-rust-lint.result=='skipped')
+            && (needs.lint.result=='success' || needs.lint.result=='skipped')
+            && (needs.unit-test.result=='success' || needs.unit-test.result=='skipped')
+            && (needs.e2e-test.result=='success' || needs.e2e-test.result=='skipped')
+            && (needs.crypto-unit-test.result=='success' || needs.crypto-unit-test.result=='skipped')
+            && (needs.build-benchmarks.result=='success' || needs.build-benchmarks.result=='skipped')
+            && (needs.build-dev.result=='success' || needs.build-dev.result=='skipped')
+          }}"
+          if [[ "$success" != "true" ]]; then
+            exit 1;
+          fi

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -43,7 +43,7 @@ jobs:
         name: find rust/cargo changes.
         uses: ./.github/actions/matches
         with:
-          pattern: '^documentation\|^docker\|^scripts'
+          pattern: '^documentation\|^docker\|^scripts\|^.circleci'
           invert: "true"
       - id: non-rust-lint-changes
         name: find shell/dockerfile changes


### PR DESCRIPTION
## Motivation

GHA doesn't do a good job of providing the identity of a job that has succeeded/failed.   Less so for a workflow file.
In order for bors to have something to hold on to, creating a success job that'll fast fail if any job fails.

So this was a bit tricky.   The result from a job is a string of "failure","skipped","success" or "cancelled", see:

https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#needs-context

Fun to figure out.

Also if a needed job was skipped by default, the dependent job is skipped as well (hence the "always()" in the if line of the job).  Commented inline.

Need to test this by creating failure cases and testing, as well as success case.  Created a PR for each and tested there:

Success PR: https://github.com/diem/diem/actions/runs/494420181 -- notice it works with skips as well.

And failure PR:  https://github.com/diem/diem/actions/runs/494729561.

This is as easy as gha can make it for bors.

### Have you read the [Contributing Guidelines on pull requests]

Y

## Test Plan

Two draft PRs one forcing success and another failure.  Feel free to inspect, will close when merged/cancelled.
https://github.com/diem/diem/pull/7267
https://github.com/diem/diem/pull/7266


## Related PRs

https://github.com/diem/diem/pull/7267
https://github.com/diem/diem/pull/7266
