### PR TITLE
[prover] separate functions for is_native and is_intrinsic

### DIFF
--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -2248,11 +2248,15 @@ impl<'env> FunctionEnv<'env> {
         }
     }
 
-    /// Returns true if this function is native. The function is also marked as native
-    /// if it has the pragma intrinsic set to true.
+    /// Returns true if this function is native.
     pub fn is_native(&self) -> bool {
         let view = self.definition_view();
-        view.is_native() || self.is_pragma_true(INTRINSIC_PRAGMA, || false)
+        view.is_native()
+    }
+
+    /// Returns true if this function has the pragma intrinsic set to true.
+    pub fn is_intrinsic(&self) -> bool {
+        self.is_pragma_true(INTRINSIC_PRAGMA, || false)
     }
 
     /// Returns true if this function is opaque.

--- a/language/move-prover/bytecode/src/function_target.rs
+++ b/language/move-prover/bytecode/src/function_target.rs
@@ -136,6 +136,11 @@ impl<'env> FunctionTarget<'env> {
         self.func_env.is_native()
     }
 
+    /// Returns true if this function is marked as intrinsic
+    pub fn is_intrinsic(&self) -> bool {
+        self.func_env.is_intrinsic()
+    }
+
     /// Returns true if this function is opaque.
     pub fn is_opaque(&self) -> bool {
         self.func_env.is_opaque()

--- a/language/move-prover/bytecode/src/spec_instrumentation.rs
+++ b/language/move-prover/bytecode/src/spec_instrumentation.rs
@@ -48,7 +48,7 @@ impl FunctionTargetProcessor for SpecInstrumenter {
         fun_env: &FunctionEnv<'_>,
         data: FunctionData,
     ) -> FunctionData {
-        if fun_env.is_native() {
+        if fun_env.is_native() || fun_env.is_intrinsic() {
             // Nothing to do
             return data;
         }


### PR DESCRIPTION
Previously, is_native conflated these two concepts, which frustrates analysis clients that want to treat these differently.
The motivation for this change is to support the read/write set analysis, which needs to analyze the body of functions marked as intrinsic.

The PR changes all uses of `is_native` in bytecode_translator.rs and spec_instrumentation.rs to `is_native && is_intrinsic`. There are more uses of `is_native` in some of the other bytecode analyses/transformations (e.g., borrow_analysis), but I left them as is because it seems like they also want to ignore the intrinsic pragma. Let me know if this wrong and I can fix them.