### PR TITLE
[diemdb] create a thread to report rocksdb integer-format properties

### DIFF
--- a/storage/diemdb/src/metrics.rs
+++ b/storage/diemdb/src/metrics.rs
@@ -19,18 +19,6 @@ pub static DIEM_STORAGE_LEDGER: Lazy<IntGaugeVec> = Lazy::new(|| {
     .unwrap()
 });
 
-pub static DIEM_STORAGE_CF_SIZE_BYTES: Lazy<IntGaugeVec> = Lazy::new(|| {
-    register_int_gauge_vec!(
-        // metric name
-        "diem_storage_cf_size_bytes",
-        // metric description
-        "Diem storage Column Family size in bytes",
-        // metric labels (dimensions)
-        &["cf_name"]
-    )
-    .unwrap()
-});
-
 pub static DIEM_STORAGE_COMMITTED_TXNS: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(
         "diem_storage_committed_txns",
@@ -95,6 +83,19 @@ pub static DIEM_STORAGE_OTHER_TIMERS_SECONDS: Lazy<HistogramVec> = Lazy::new(|| 
         "Various timers below public API level.",
         // metric labels (dimensions)
         &["name"]
+    )
+    .unwrap()
+});
+
+/// Rocksdb metrics
+pub(crate) static DIEM_STORAGE_ROCKSDB_PROPERTIES: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        // metric name
+        "diem_rocksdb_properties",
+        // metric description
+        "rocksdb integer properties",
+        // metric labels (dimensions)
+        &["cf_name", "property_name",]
     )
     .unwrap()
 });

--- a/storage/schemadb/tests/db.rs
+++ b/storage/schemadb/tests/db.rs
@@ -368,8 +368,19 @@ fn test_report_size() {
 
     db.flush_all().unwrap();
 
-    let cf_sizes = db.get_approximate_sizes_cf().unwrap();
-    assert!(*cf_sizes.get("TestCF1").unwrap() > 0);
-    assert!(*cf_sizes.get("TestCF2").unwrap() > 0);
-    assert_eq!(*cf_sizes.get("default").unwrap(), 0);
+    assert!(
+        db.get_property("TestCF1", "rocksdb.estimate-live-data-size")
+            .unwrap()
+            > 0
+    );
+    assert!(
+        db.get_property("TestCF2", "rocksdb.estimate-live-data-size")
+            .unwrap()
+            > 0
+    );
+    assert_eq!(
+        db.get_property("default", "rocksdb.estimate-live-data-size")
+            .unwrap(),
+        0
+    );
 }


### PR DESCRIPTION
## Motivation

Expose more rocksdb properties that may benefit our system monitoring.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo run -p diem-node --test
```
~ curl --silent "http://localhost:9101/metrics" | grep rocksdb
# HELP diem_rocksdb_properties rocksdb integer properties
# TYPE diem_rocksdb_properties gauge
diem_rocksdb_properties{cf_name="default",property_name="diem_rocksdb_block_cache_usage_bytes"} 0
diem_storage_other_timers_seconds_bucket{name="update_rocksdb_properties",le="0.005"} 98
diem_storage_other_timers_seconds_bucket{name="update_rocksdb_properties",le="0.01"} 98
diem_storage_other_timers_seconds_bucket{name="update_rocksdb_properties",le="0.025"} 98
diem_storage_other_timers_seconds_bucket{name="update_rocksdb_properties",le="0.05"} 98
diem_storage_other_timers_seconds_bucket{name="update_rocksdb_properties",le="0.1"} 98
diem_storage_other_timers_seconds_bucket{name="update_rocksdb_properties",le="0.25"} 98
diem_storage_other_timers_seconds_bucket{name="update_rocksdb_properties",le="0.5"} 98
diem_storage_other_timers_seconds_bucket{name="update_rocksdb_properties",le="1"} 98
diem_storage_other_timers_seconds_bucket{name="update_rocksdb_properties",le="2.5"} 98
diem_storage_other_timers_seconds_bucket{name="update_rocksdb_properties",le="5"} 98
diem_storage_other_timers_seconds_bucket{name="update_rocksdb_properties",le="10"} 98
diem_storage_other_timers_seconds_bucket{name="update_rocksdb_properties",le="+Inf"} 98
diem_storage_other_timers_seconds_sum{name="update_rocksdb_properties"} 0.005109009000000003
diem_storage_other_timers_seconds_count{name="update_rocksdb_properties"} 98
```