### PR TITLE
[state_view] Make state_view implement sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6627,6 +6627,7 @@ dependencies = [
  "diem-workspace-hack",
  "itertools 0.10.0",
  "move-core-types",
+ "parking_lot",
  "scratchpad",
  "serde",
  "thiserror",

--- a/language/diem-tools/diem-validator-interface/src/lib.rs
+++ b/language/diem-tools/diem-validator-interface/src/lib.rs
@@ -19,7 +19,7 @@ use diem_types::{
 };
 use vm::file_format::CompiledModule;
 
-pub trait DiemValidatorInterface {
+pub trait DiemValidatorInterface: Sync {
     fn get_account_state_by_version(
         &self,
         account: AccountAddress,

--- a/storage/state-view/src/lib.rs
+++ b/storage/state-view/src/lib.rs
@@ -12,7 +12,7 @@ use diem_types::{access_path::AccessPath, transaction::Version};
 /// `StateView` is a trait that defines a read-only snapshot of the global state. It is passed to
 /// the VM for transaction execution, during which the VM is guaranteed to read anything at the
 /// given state.
-pub trait StateView {
+pub trait StateView: Sync {
     /// For logging and debugging purpose, identifies what this view is for.
     fn id(&self) -> StateViewId {
         StateViewId::Miscellaneous

--- a/storage/storage-interface/Cargo.toml
+++ b/storage/storage-interface/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0.38"
 itertools = "0.10.0"
 serde = { version = "1.0.120", default-features = false }
 thiserror = "1.0.23"
+parking_lot = "0.11.1"
 
 bcs = "0.1.2"
 diem-crypto = { path = "../../crypto/crypto", version = "0.1.0" }

--- a/storage/storage-interface/src/state_view.rs
+++ b/storage/storage-interface/src/state_view.rs
@@ -15,9 +15,9 @@ use diem_types::{
     proof::SparseMerkleProof,
     transaction::{Version, PRE_GENESIS_VERSION},
 };
+use parking_lot::RwLock;
 use scratchpad::{AccountStatus, SparseMerkleTree};
 use std::{
-    cell::RefCell,
     collections::{hash_map::Entry, HashMap},
     convert::TryInto,
     sync::Arc,
@@ -78,8 +78,8 @@ pub struct VerifiedStateView<'a> {
     ///        | +------------------------------+ +--------------------+ |
     ///        +---------------------------------------------------------+
     /// ```
-    account_to_state_cache: RefCell<HashMap<AccountAddress, AccountState>>,
-    account_to_proof_cache: RefCell<HashMap<HashValue, SparseMerkleProof>>,
+    account_to_state_cache: RwLock<HashMap<AccountAddress, AccountState>>,
+    account_to_proof_cache: RwLock<HashMap<HashValue, SparseMerkleProof>>,
 }
 
 impl<'a> VerifiedStateView<'a> {
@@ -108,8 +108,8 @@ impl<'a> VerifiedStateView<'a> {
             latest_persistent_version,
             latest_persistent_state_root,
             speculative_state,
-            account_to_state_cache: RefCell::new(HashMap::new()),
-            account_to_proof_cache: RefCell::new(HashMap::new()),
+            account_to_state_cache: RwLock::new(HashMap::new()),
+            account_to_proof_cache: RwLock::new(HashMap::new()),
         }
     }
 }
@@ -141,55 +141,59 @@ impl<'a> StateView for VerifiedStateView<'a> {
     fn get(&self, access_path: &AccessPath) -> Result<Option<Vec<u8>>> {
         let address = access_path.address;
         let path = &access_path.path;
-        match self.account_to_state_cache.borrow_mut().entry(address) {
-            Entry::Occupied(occupied) => Ok(occupied.get().get(path).cloned()),
-            Entry::Vacant(vacant) => {
-                let address_hash = address.hash();
-                let account_blob_option = match self.speculative_state.get(address_hash) {
-                    AccountStatus::ExistsInScratchPad(blob) => Some(blob),
-                    AccountStatus::DoesNotExist => None,
-                    // No matter it is in db or unknown, we have to query from db since even the
-                    // former case, we don't have the blob data but only its hash.
-                    AccountStatus::ExistsInDB | AccountStatus::Unknown => {
-                        let (blob, proof) = match self.latest_persistent_version {
-                            Some(version) => self
-                                .reader
-                                .get_account_state_with_proof_by_version(address, version)?,
-                            None => (None, SparseMerkleProof::new(None, vec![])),
-                        };
-                        proof
-                            .verify(
-                                self.latest_persistent_state_root,
-                                address.hash(),
-                                blob.as_ref(),
-                            )
-                            .map_err(|err| {
-                                format_err!(
-                                "Proof is invalid for address {:?} with state root hash {:?}: {}",
-                                address,
-                                self.latest_persistent_state_root,
-                                err
-                            )
-                            })?;
-                        assert!(self
-                            .account_to_proof_cache
-                            .borrow_mut()
-                            .insert(address_hash, proof)
-                            .is_none());
-                        blob
-                    }
+
+        // Lock for read first:
+        if let Some(contents) = self.account_to_state_cache.read().get(&address) {
+            return Ok(contents.get(path).cloned());
+        }
+
+        // Do most of the work outside the write lock.
+        let address_hash = address.hash();
+        let account_blob_option = match self.speculative_state.get(address_hash) {
+            AccountStatus::ExistsInScratchPad(blob) => Some(blob),
+            AccountStatus::DoesNotExist => None,
+            // No matter it is in db or unknown, we have to query from db since even the
+            // former case, we don't have the blob data but only its hash.
+            AccountStatus::ExistsInDB | AccountStatus::Unknown => {
+                let (blob, proof) = match self.latest_persistent_version {
+                    Some(version) => self
+                        .reader
+                        .get_account_state_with_proof_by_version(address, version)?,
+                    None => (None, SparseMerkleProof::new(None, vec![])),
                 };
-                Ok(vacant
-                    .insert(
-                        account_blob_option
-                            .as_ref()
-                            .map(TryInto::try_into)
-                            .transpose()?
-                            .unwrap_or_default(),
+                proof
+                    .verify(
+                        self.latest_persistent_state_root,
+                        address.hash(),
+                        blob.as_ref(),
                     )
-                    .get(path)
-                    .cloned())
+                    .map_err(|err| {
+                        format_err!(
+                            "Proof is invalid for address {:?} with state root hash {:?}: {}",
+                            address,
+                            self.latest_persistent_state_root,
+                            err
+                        )
+                    })?;
+                assert!(self
+                    .account_to_proof_cache
+                    .write()
+                    .insert(address_hash, proof)
+                    .is_none());
+                blob
             }
+        };
+
+        // Now enter the locked region, and write if still empty.
+        let new_account_blob = account_blob_option
+            .as_ref()
+            .map(TryInto::try_into)
+            .transpose()?
+            .unwrap_or_default();
+
+        match self.account_to_state_cache.write().entry(address) {
+            Entry::Occupied(occupied) => Ok(occupied.get().get(path).cloned()),
+            Entry::Vacant(vacant) => Ok(vacant.insert(new_account_blob).get(path).cloned()),
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Make `StateView` implement Sync. This is a necessary step for us to start the parallel execution/account prefetching work.

I specifically picked RwLock from `parking_lot` crate rather than that from std due to performance reasons: The RwLock implemented by parking_lot uses an AtmoicUsize as synchronization primitive comparing to std::sync::Rwlock which is system dependent.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

`cargo test`