### PR TITLE
[RFC][vm] Reduce unneeded copy for obtaining resource bytes

### DIFF
--- a/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
@@ -14,6 +14,7 @@ use move_core_types::{
 use move_vm_runtime::{data_cache::RemoteCache, logging::NoContextLog, move_vm::MoveVM};
 use move_vm_test_utils::{DeltaStorage, InMemoryStorage};
 use move_vm_types::gas_schedule::{zero_cost_schedule, CostStrategy};
+use std::borrow::Cow;
 use vm::errors::{Location, PartialVMError, PartialVMResult, VMResult};
 
 const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGTH]);
@@ -547,7 +548,7 @@ impl RemoteCache for BogusStorage {
         &self,
         _address: &AccountAddress,
         _tag: &StructTag,
-    ) -> PartialVMResult<Option<Vec<u8>>> {
+    ) -> PartialVMResult<Option<Cow<[u8]>>> {
         Err(PartialVMError::new(self.bad_status_code))
     }
 }

--- a/language/move-vm/runtime/src/data_cache.rs
+++ b/language/move-vm/runtime/src/data_cache.rs
@@ -16,7 +16,7 @@ use move_vm_types::{
     loaded_data::runtime_types::Type,
     values::{GlobalValue, GlobalValueEffect, Value},
 };
-use std::collections::btree_map::BTreeMap;
+use std::{borrow::Cow, collections::btree_map::BTreeMap};
 use vm::errors::*;
 
 /// Trait for the Move VM to abstract storage operations.
@@ -44,7 +44,7 @@ pub trait RemoteCache {
         &self,
         address: &AccountAddress,
         tag: &StructTag,
-    ) -> PartialVMResult<Option<Vec<u8>>>;
+    ) -> PartialVMResult<Option<Cow<[u8]>>>;
 }
 
 pub struct AccountDataCache {

--- a/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
@@ -13,6 +13,7 @@ use move_core_types::{
     vm_status::{StatusCode, StatusType},
 };
 use move_vm_types::gas_schedule::{zero_cost_schedule, CostStrategy};
+use std::borrow::Cow;
 use vm::{
     errors::{PartialVMResult, VMResult},
     file_format::{
@@ -245,7 +246,7 @@ impl RemoteCache for RemoteStore {
         &self,
         _address: &AccountAddress,
         _tag: &StructTag,
-    ) -> PartialVMResult<Option<Vec<u8>>> {
+    ) -> PartialVMResult<Option<Cow<[u8]>>> {
         Ok(None)
     }
 }

--- a/language/move-vm/test-utils/src/storage.rs
+++ b/language/move-vm/test-utils/src/storage.rs
@@ -10,7 +10,10 @@ use move_core_types::{
 };
 use move_vm_runtime::data_cache::RemoteCache;
 // use move_vm_txn_effect_converter::convert_txn_effects_to_move_changeset_and_events;
-use std::collections::{btree_map, BTreeMap};
+use std::{
+    borrow::Cow,
+    collections::{btree_map, BTreeMap},
+};
 use vm::errors::{PartialVMResult, VMResult};
 
 /// A dummy storage containing no modules or resources.
@@ -32,7 +35,7 @@ impl RemoteCache for BlankStorage {
         &self,
         _address: &AccountAddress,
         _tag: &StructTag,
-    ) -> PartialVMResult<Option<Vec<u8>>> {
+    ) -> PartialVMResult<Option<Cow<[u8]>>> {
         Ok(None)
     }
 }
@@ -60,10 +63,10 @@ impl<'a, 'b, S: RemoteCache> RemoteCache for DeltaStorage<'a, 'b, S> {
         &self,
         address: &AccountAddress,
         tag: &StructTag,
-    ) -> PartialVMResult<Option<Vec<u8>>> {
+    ) -> PartialVMResult<Option<Cow<[u8]>>> {
         if let Some(account_storage) = self.delta.accounts.get(address) {
             if let Some(blob_opt) = account_storage.resources.get(tag) {
-                return Ok(blob_opt.clone());
+                return Ok(blob_opt.as_ref().map(Cow::from));
             }
         }
 
@@ -204,9 +207,9 @@ impl RemoteCache for InMemoryStorage {
         &self,
         address: &AccountAddress,
         tag: &StructTag,
-    ) -> PartialVMResult<Option<Vec<u8>>> {
+    ) -> PartialVMResult<Option<Cow<[u8]>>> {
         if let Some(account_storage) = self.accounts.get(address) {
-            return Ok(account_storage.resources.get(tag).cloned());
+            return Ok(account_storage.resources.get(tag).map(Cow::from));
         }
         Ok(None)
     }

--- a/language/testing-infra/e2e-tests/src/data_store.rs
+++ b/language/testing-infra/e2e-tests/src/data_store.rs
@@ -20,7 +20,7 @@ use move_core_types::{
 };
 use move_vm_runtime::data_cache::RemoteCache;
 use once_cell::sync::Lazy;
-use std::collections::HashMap;
+use std::{borrow::Cow, collections::HashMap};
 use vm::errors::*;
 use vm_genesis::generate_genesis_change_set_for_testing;
 
@@ -121,7 +121,9 @@ impl RemoteCache for FakeDataStore {
         &self,
         address: &AccountAddress,
         tag: &StructTag,
-    ) -> PartialVMResult<Option<Vec<u8>>> {
-        RemoteStorage::new(self).get_resource(address, tag)
+    ) -> PartialVMResult<Option<Cow<[u8]>>> {
+        Ok(RemoteStorage::new(self)
+            .get_resource(address, tag)?
+            .map(|bytes| Cow::from(bytes.into_owned())))
     }
 }

--- a/language/tools/move-cli/src/lib.rs
+++ b/language/tools/move-cli/src/lib.rs
@@ -22,6 +22,7 @@ use vm::{
 
 use anyhow::{anyhow, bail, Result};
 use std::{
+    borrow::Cow,
     collections::{btree_map, BTreeMap},
     convert::TryFrom,
     fs,
@@ -421,8 +422,9 @@ impl RemoteCache for OnDiskStateView {
         &self,
         address: &AccountAddress,
         struct_tag: &StructTag,
-    ) -> PartialVMResult<Option<Vec<u8>>> {
+    ) -> PartialVMResult<Option<Cow<[u8]>>> {
         self.get_resource_bytes(*address, struct_tag.clone())
+            .map(|o| o.map(Cow::from))
             .map_err(|_| PartialVMError::new(StatusCode::STORAGE_ERROR))
     }
 }

--- a/language/tools/resource-viewer/src/lib.rs
+++ b/language/tools/resource-viewer/src/lib.rs
@@ -18,6 +18,7 @@ use move_core_types::{
 };
 use move_vm_runtime::data_cache::RemoteCache;
 use std::{
+    borrow::Cow,
     collections::btree_map::BTreeMap,
     convert::TryInto,
     fmt::{Display, Formatter},
@@ -293,7 +294,7 @@ impl RemoteCache for NullStateView {
         &self,
         _address: &AccountAddress,
         _tag: &StructTag,
-    ) -> PartialVMResult<Option<Vec<u8>>> {
+    ) -> PartialVMResult<Option<Cow<[u8]>>> {
         Ok(None)
     }
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

In our code there's multiple reads from the cache which doesn't really require owning the bytes: only those reads straight from the `StateView` will return the owned instance of vector bytes. This PR cleans these unnecessary allocations up by using a referenence when possible.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I ran the `cargo bench` on `txn_benchs`. The perf was improved by 2%.