### PR TITLE
[gha] matching actions

### DIFF
--- a/.github/actions/matches/action.yml
+++ b/.github/actions/matches/action.yml
@@ -34,24 +34,26 @@ runs:
         if [[ -n "${CHANGES_FILE}" ]] && [[ -f "${CHANGES_FILE}" ]]; then
           TARGET_FILE="${CHANGES_FILE}"
         fi
-        set -x
-        INV=""
-        if [[ "${INVERT}" == "true" ]]; then
-          INV="-v"
-        fi
         result=true
         echo Target File: "${TARGET_FILE}" 1>&2
         echo PATTERN="${PATTERN}" 1>&2
         if [[ -f "${TARGET_FILE}" ]]; then
           echo found: 1>&2
-          cat "${TARGET_FILE}" | grep "${INV}" "${PATTERN}" || echo No matching files. 1>&2
-          count="$( cat "${TARGET_FILE}" | grep -c "${INV}" "${PATTERN}" || echo 0)"
+          if [[ "${INVERT}" == "true" ]]; then
+            cat "${TARGET_FILE}" | grep -v "${PATTERN}" || echo No matching files. 1>&2
+            count="$( cat "${TARGET_FILE}" | grep -c -v "${PATTERN}" || true)"
+          else
+            cat "${TARGET_FILE}" | grep "${PATTERN}" || echo No matching files. 1>&2
+            count="$( cat "${TARGET_FILE}" | grep -c "${PATTERN}" || true)"
+          fi
+          echo Found file count: "$count"
           if [[ "$count" == 0 ]]; then
             result=false
           fi
         else
           echo "::error::Target File was not set or was not found, will assume a change exists.   This is an error that should be corrected."
         fi
+        echo Perform build: ${result} 1>&2
         echo "::set-output name=changes::$(echo $result)"
       shell: bash
       env:


### PR DESCRIPTION
## Motivation

Okay, finally fixed the matching logic.    Before grep was receiving an empty parameter and erroring out on non-rust checkes, trigger a build.
I did intentional structure the code that unless it found zero matching files it would proceed with a build.    

This also cause rust to always build because it's output when no matches were found was "0\n0". 

Created two testing prs for the most relevant cases rust/non-rust and docker/non-docker:

https://github.com/diem/diem/pull/7284
https://github.com/diem/diem/pull/7285

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

These test prs:
https://github.com/diem/diem/pull/7284
https://github.com/diem/diem/pull/7285

## Related PRs

https://github.com/diem/diem/pull/7284
https://github.com/diem/diem/pull/7285
