### PR TITLE
[network][docs] Fixup network documentation. Fix rustdocs links.

### DIFF
--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -25,9 +25,8 @@ use std::{
 
 // TODO: We could possibly move these constants somewhere else, but since they are defaults for the
 //   configurations of the system, we'll leave it here for now.
-/// Current supported protocol negotiation handshake version.
-///
-/// See [`perform_handshake`] in `network/src/transport.rs`
+/// Current supported protocol negotiation handshake version. See
+/// [`network::protocols::wire::v1`](../../network/protocols/wire/handshake/v1/index.html).
 pub const HANDSHAKE_VERSION: u8 = 0;
 pub const NETWORK_CHANNEL_SIZE: usize = 1024;
 pub const PING_INTERVAL_MS: u64 = 1000;

--- a/network/network-address/src/encrypted.rs
+++ b/network/network-address/src/encrypted.rs
@@ -55,7 +55,7 @@ pub const HKDF_SALT: [u8; 32] = [
     0x59, 0x2c, 0x85, 0xe0, 0x24, 0x45, 0xb8, 0x75, 0xf0, 0x2d, 0xed, 0x51, 0xa5, 0x20, 0xba, 0x2a,
 ];
 
-/// An encrypted `NetworkAddress`.
+/// An encrypted [`NetworkAddress`].
 ///
 /// ### Threat Model
 ///
@@ -65,7 +65,7 @@ pub const HKDF_SALT: [u8; 32] = [
 /// to other validators.
 ///
 /// These encrypted network addresses are intended to be stored on-chain under
-/// each validator's advertised network addresses in their `ValidatorConfig`s.
+/// each validator's advertised network addresses in their [`ValidatorConfig`]s.
 /// All validators share the secret `shared_val_netaddr_key`, though each validator's addresses
 /// are encrypted using a per-validator `derived_key`.
 ///
@@ -80,9 +80,9 @@ pub const HKDF_SALT: [u8; 32] = [
 /// )
 /// ```
 ///
-/// where `hkdf_sha3_256_extract_and_expand` is
+/// where `HKDF-SHA3-256::extract_and_expand` is
 /// [HKDF extract-and-expand](https://tools.ietf.org/html/rfc5869) with SHA3-256,
-/// `HKDF_SALT` is a constant salt for application separation, `shared_val_netaddr_key` is the
+/// [`HKDF_SALT`] is a constant salt for application separation, `shared_val_netaddr_key` is the
 /// shared secret distributed amongst all the validators, and `account_address`
 /// is the specific validator's [`AccountAddress`].
 ///
@@ -105,7 +105,7 @@ pub const HKDF_SALT: [u8; 32] = [
 ///
 /// where `nonce` is a 96-bit integer as described below, `key_version` is
 /// the key version as a u32 big-endian integer, `addr` is the serialized
-/// `NetworkAddress`, and `enc_addr` is the encrypted network address
+/// [`NetworkAddress`], and `enc_addr` is the encrypted network address
 /// concatenated with the 16-byte authentication tag.
 ///
 /// ### Nonce
@@ -128,6 +128,8 @@ pub const HKDF_SALT: [u8; 32] = [
 /// The `EncNetworkAddress` struct contains a `key_version` field, which
 /// identifies the specific `shared_val_netaddr_key` used to encrypt/decrypt the
 /// `EncNetworkAddress`.
+///
+/// [`ValidatorConfig`]: https://github.com/diem/diem/blob/master/language/stdlib/modules/doc/ValidatorConfig.md
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct EncNetworkAddress {
     key_version: KeyVersion,

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -6,6 +6,10 @@
 #![recursion_limit = "1024"]
 // </Black magic>
 
+// TODO(philiphayes): uncomment when feature stabilizes (est. 1.50.0)
+// tracking issue: https://github.com/rust-lang/rust/issues/78835
+// #![doc = include_str!("../README.md")]
+
 pub mod connectivity_manager;
 pub mod constants;
 pub mod counters;

--- a/network/src/noise/handshake.rs
+++ b/network/src/noise/handshake.rs
@@ -5,10 +5,10 @@
 //! This module also implements additional anti-DoS mitigation,
 //! by including a timestamp in each handshake initialization message.
 //! Refer to the module's documentation for more information.
-//! A successful handshake returns a `NoiseStream` which is defined in the
+//! A successful handshake returns a [`NoiseStream`] which is defined in the
 //! [stream] module.
 //!
-//! [stream]: network::noise::stream
+//! [stream]: crate::noise::stream
 
 use crate::{
     noise::{error::NoiseHandshakeError, stream::NoiseStream},
@@ -693,8 +693,8 @@ mod test {
         client.network_context = NetworkContext::mock_with_peer_id(PeerId::random());
         let (client_res, server_res) = perform_handshake(&client, &server, server_public_key);
 
-        trace!("client_res: {}", client_res.unwrap_err());
-        trace!("server_res: {}", server_res.unwrap_err());
+        client_res.unwrap_err();
+        server_res.unwrap_err();
     }
 
     #[test]

--- a/network/src/noise/stream.rs
+++ b/network/src/noise/stream.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! The socket module implements the post-handshake part of the protocol.
-//! Its main type (`NoiseStream`) is returned after a successful [handshake].
+//! Its main type [`NoiseStream`] is returned after a successful [handshake].
 //! functions in this module enables encrypting and decrypting messages from a socket.
 //! Note that since noise is length-unaware, we have to prefix every noise message with its length
 //!
-//! [handshake]: network::noise::handshake
+//! [handshake]: crate::noise::handshake
 
 use futures::{
     io::{AsyncRead, AsyncWrite},
@@ -68,7 +68,7 @@ impl<TSocket> NoiseStream<TSocket> {
 // ----------------
 //
 
-/// Possible read states for a [NoiseStream]
+/// Possible read states for a [`NoiseStream`]
 #[derive(Debug)]
 enum ReadState {
     /// Initial State
@@ -206,7 +206,7 @@ where
 // ----------------
 //
 
-/// Possible write states for a [NoiseStream]
+/// Possible write states for a [`NoiseStream`]
 #[derive(Debug)]
 enum WriteState {
     /// Initial State
@@ -431,7 +431,7 @@ where
 const MAX_WRITE_BUFFER_LENGTH: usize = noise::decrypted_len(noise::MAX_SIZE_NOISE_MSG);
 
 /// Collection of buffers used for buffering data during the various read/write states of a
-/// NoiseStream
+/// [`NoiseStream`]
 struct NoiseBuffers {
     /// A read buffer, used for both a received ciphertext and then for its decrypted content.
     read_buffer: [u8; noise::MAX_SIZE_NOISE_MSG],


### PR DESCRIPTION
+ Docs now reflect the current state of the network module after the `Peer` refactor: #6800

+ Fixed the rustdoc documentation links so they resolve correctly.

+ Link to the specifications where relevant.