### PR TITLE
[json-rpc] Support TLS on JSON-RPC port

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5641,6 +5641,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "024a1e66fea74c66c66624ee5622a7ff0e4b73a13b4f5c326ddb50c708944226"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "ripemd160"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5815,6 +5830,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "064fd21ff87c6e87ed4506e68beb42459caa4a0e2eb144932e6776768556980b"
+dependencies = [
+ "base64 0.13.0",
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
 name = "rusty-fork"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5947,6 +5975,16 @@ dependencies = [
  "diem-workspace-hack",
  "itertools 0.10.0",
  "proptest",
+]
+
+[[package]]
+name = "sct"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -6399,6 +6437,12 @@ dependencies = [
  "libc",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "stable_deref_trait"
@@ -7039,6 +7083,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7328,6 +7383,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "ureq"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7507,6 +7568,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded 0.7.0",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
@@ -7603,6 +7665,16 @@ checksum = "222b1ef9334f92a21d3fb53dc3fd80f30836959a90f9274a626d7e06315ba3c3"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]

--- a/config/src/config/json_rpc_config.rs
+++ b/config/src/config/json_rpc_config.rs
@@ -12,6 +12,8 @@ pub struct JsonRpcConfig {
     pub batch_size_limit: u16,
     pub page_size_limit: u16,
     pub content_length_limit: usize,
+    pub tls_cert_path: Option<String>,
+    pub tls_key_path: Option<String>,
 }
 
 pub const DEFAULT_JSON_RPC_ADDRESS: &str = "127.0.0.1";
@@ -29,6 +31,8 @@ impl Default for JsonRpcConfig {
             batch_size_limit: DEFAULT_BATCH_SIZE_LIMIT,
             page_size_limit: DEFAULT_PAGE_SIZE_LIMIT,
             content_length_limit: DEFAULT_CONTENT_LENGTH_LIMIT,
+            tls_cert_path: None,
+            tls_key_path: None,
         }
     }
 }

--- a/json-rpc/Cargo.toml
+++ b/json-rpc/Cargo.toml
@@ -20,7 +20,7 @@ rand = "0.7.3"
 serde_json = "1.0.61"
 serde = { version = "1.0.120", default-features = false }
 tokio = { version = "1.0.2", features = ["full"] }
-warp = "0.3.0"
+warp = { version = "0.3.0", features = ["tls"] }
 reqwest = { version = "0.11.0", features = ["blocking", "json"], default_features = false, optional = true }
 proptest = { version = "0.10.1", optional = true }
 

--- a/json-rpc/src/tests/utils.rs
+++ b/json-rpc/src/tests/utils.rs
@@ -45,6 +45,8 @@ pub fn test_bootstrap(
         DEFAULT_BATCH_SIZE_LIMIT,
         DEFAULT_PAGE_SIZE_LIMIT,
         DEFAULT_CONTENT_LENGTH_LIMIT,
+        &None,
+        &None,
         diem_db,
         mp_sender,
         RoleType::Validator,


### PR DESCRIPTION
If `tls_cert_path` and `tls_key_path` are provided, enable TLS on the
JSON-RPC port. This may be necessary in deployments without a load
balancer, or to provide additional security between a load balancer and
the node.

Test Plan: Ran fullnode with and without TLS, tested JSON-RPC request.