### PR TITLE
[operational] add a tool to validate the status of all validator set endpoints

### DIFF
--- a/config/management/operational/src/command.rs
+++ b/config/management/operational/src/command.rs
@@ -20,6 +20,8 @@ pub enum Command {
     AddValidator(crate::governance::AddValidator),
     #[structopt(about = "Check an endpoint for a listening socket")]
     CheckEndpoint(crate::network_checker::CheckEndpoint),
+    #[structopt(about = "Check all on-chain endpoints for a listening socket")]
+    CheckValidatorSetEndpoints(crate::network_checker::CheckValidatorSetEndpoints),
     #[structopt(about = "Create a new validator account")]
     CreateValidator(crate::governance::CreateValidator),
     #[structopt(about = "Create a new validator operator account")]
@@ -63,6 +65,7 @@ pub enum CommandName {
     AccountResource,
     AddValidator,
     CheckEndpoint,
+    CheckValidatorSetEndpoints,
     CreateValidator,
     CreateValidatorOperator,
     ExtractPrivateKey,
@@ -89,6 +92,7 @@ impl From<&Command> for CommandName {
             Command::AccountResource(_) => CommandName::AccountResource,
             Command::AddValidator(_) => CommandName::AddValidator,
             Command::CheckEndpoint(_) => CommandName::CheckEndpoint,
+            Command::CheckValidatorSetEndpoints(_) => CommandName::CheckValidatorSetEndpoints,
             Command::CreateValidator(_) => CommandName::CreateValidator,
             Command::CreateValidatorOperator(_) => CommandName::CreateValidatorOperator,
             Command::ExtractPrivateKey(_) => CommandName::ExtractPrivateKey,
@@ -117,6 +121,7 @@ impl std::fmt::Display for CommandName {
             CommandName::AccountResource => "account-resource",
             CommandName::AddValidator => "add-validator",
             CommandName::CheckEndpoint => "check-endpoint",
+            CommandName::CheckValidatorSetEndpoints => "check-validator-set-endpoints",
             CommandName::CreateValidator => "create-validator",
             CommandName::CreateValidatorOperator => "create-validator-operator",
             CommandName::ExtractPrivateKey => "extract-private-key",
@@ -146,6 +151,7 @@ impl Command {
             Command::AccountResource(cmd) => Self::pretty_print(cmd.execute()),
             Command::AddValidator(cmd) => Self::print_transaction_context(cmd.execute()),
             Command::CheckEndpoint(cmd) => Self::pretty_print(cmd.execute()),
+            Command::CheckValidatorSetEndpoints(cmd) => Self::pretty_print(cmd.execute()),
             Command::CreateValidator(cmd) => {
                 Self::print_transaction_context(cmd.execute().map(|(txn_ctx, _)| txn_ctx))
             }
@@ -223,6 +229,14 @@ impl Command {
 
     pub fn check_endpoint(self) -> Result<String, Error> {
         execute_command!(self, Command::CheckEndpoint, CommandName::CheckEndpoint)
+    }
+
+    pub fn check_validator_set_endpoints(self) -> Result<String, Error> {
+        execute_command!(
+            self,
+            Command::CheckValidatorSetEndpoints,
+            CommandName::CheckValidatorSetEndpoints
+        )
     }
 
     pub fn create_validator(self) -> Result<(TransactionContext, AccountAddress), Error> {

--- a/config/management/operational/src/validator_set.rs
+++ b/config/management/operational/src/validator_set.rs
@@ -5,6 +5,7 @@ use crate::{json_rpc::JsonRpcClientWrapper, validator_config::DecryptedValidator
 use diem_crypto::ed25519::Ed25519PublicKey;
 use diem_management::{config::ConfigPath, error::Error, secure_backend::ValidatorBackend};
 use diem_network_address::NetworkAddress;
+use diem_network_address_encryption::Encryptor;
 use diem_types::account_address::AccountAddress;
 use serde::Serialize;
 use structopt::StructOpt;
@@ -31,32 +32,41 @@ impl ValidatorSet {
             .override_validator_backend(&self.validator_backend.validator_backend)?;
         let encryptor = config.validator_backend().encryptor();
         let client = JsonRpcClientWrapper::new(config.json_server);
-        let set = client.validator_set(self.account_address)?;
 
-        let mut decoded_set = Vec::new();
-        for info in set {
-            let config = DecryptedValidatorConfig::from_validator_config(
-                info.config(),
-                *info.account_address(),
-                &encryptor,
-            )
-            .map_err(|e| Error::NetworkAddressDecodeError(e.to_string()))?;
-
-            let config_resource = client.validator_config(*info.account_address())?;
-            let name = DecryptedValidatorConfig::human_name(&config_resource.human_name);
-
-            let info = DecryptedValidatorInfo {
-                name,
-                account_address: *info.account_address(),
-                consensus_public_key: config.consensus_public_key,
-                fullnode_network_address: config.fullnode_network_address,
-                validator_network_address: config.validator_network_address,
-            };
-            decoded_set.push(info);
-        }
-
-        Ok(decoded_set)
+        decode_validator_set(encryptor, client, self.account_address)
     }
+}
+
+pub fn decode_validator_set(
+    encryptor: Encryptor,
+    client: JsonRpcClientWrapper,
+    account_address: Option<AccountAddress>,
+) -> Result<Vec<DecryptedValidatorInfo>, Error> {
+    let set = client.validator_set(account_address)?;
+
+    let mut decoded_set = Vec::new();
+    for info in set {
+        let config = DecryptedValidatorConfig::from_validator_config(
+            info.config(),
+            *info.account_address(),
+            &encryptor,
+        )
+        .map_err(|e| Error::NetworkAddressDecodeError(e.to_string()))?;
+
+        let config_resource = client.validator_config(*info.account_address())?;
+        let name = DecryptedValidatorConfig::human_name(&config_resource.human_name);
+
+        let info = DecryptedValidatorInfo {
+            name,
+            account_address: *info.account_address(),
+            consensus_public_key: config.consensus_public_key,
+            fullnode_network_address: config.fullnode_network_address,
+            validator_network_address: config.validator_network_address,
+        };
+        decoded_set.push(info);
+    }
+
+    Ok(decoded_set)
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
This makes it easy to see if all nodes are actively listening on public
addresses. Add a convenience factor so that folks that don't have
storage can provide a key for validators -- it isn't super flexible but
its a solid hack.

Output:

Running `/Users/davidiw/libra/target/debug/diem-operational-tool check-validator-set-endpoints --json-server 'https://...' --role validator --key ... -- version 0'
Trying address: ...
_ -- good
Trying address: ...
_ -- good
Trying address: ...
_ -- good
Trying address: ...
_ -- good
Trying address: ...
_ -- good
Trying address: ...
_ -- good
