### PR TITLE
[move-prover] Extend compositional analysis to allow summaries of different type v2

### DIFF
--- a/language/move-prover/bytecode/src/packed_types_analysis.rs
+++ b/language/move-prover/bytecode/src/packed_types_analysis.rs
@@ -150,7 +150,12 @@ impl<'a> TransferFunctions for PackedTypesAnalysis<'a> {
 }
 
 impl<'a> DataflowAnalysis for PackedTypesAnalysis<'a> {}
-impl<'a> CompositionalAnalysis for PackedTypesAnalysis<'a> {}
+impl<'a> CompositionalAnalysis<PackedTypesState> for PackedTypesAnalysis<'a> {
+    fn to_summary(&self, state: PackedTypesState) -> PackedTypesState {
+        state
+    }
+}
+
 pub struct PackedTypesProcessor();
 impl PackedTypesProcessor {
     pub fn new() -> Box<Self> {

--- a/language/move-prover/bytecode/src/usage_analysis.rs
+++ b/language/move-prover/bytecode/src/usage_analysis.rs
@@ -76,7 +76,11 @@ struct MemoryUsageAnalysis<'a> {
 }
 
 impl<'a> DataflowAnalysis for MemoryUsageAnalysis<'a> {}
-impl<'a> CompositionalAnalysis for MemoryUsageAnalysis<'a> {}
+impl<'a> CompositionalAnalysis<UsageState> for MemoryUsageAnalysis<'a> {
+    fn to_summary(&self, state: UsageState) -> UsageState {
+        state
+    }
+}
 pub struct UsageProcessor();
 
 impl UsageProcessor {


### PR DESCRIPTION
…sults to new domain

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Resubmitting https://github.com/diem/diem/pulls?page=2&q=is%3Apr+is%3Aopen with clean git history. Initial motivation to allow client to map summary of compositional analysis to new value.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

