### PR TITLE
[move-prover] Add native "where" conditions to quantifier AST nodes

### DIFF
--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -261,8 +261,8 @@ pub enum Exp_ {
     While(Box<Exp>, Box<Exp>),
     Loop(Box<Exp>),
     Block(Sequence),
-    Lambda(LValueList, Box<Exp>),                    // spec only
-    Quant(QuantKind, LValueWithRangeList, Box<Exp>), // spec only
+    Lambda(LValueList, Box<Exp>), // spec only
+    Quant(QuantKind, LValueWithRangeList, Option<Box<Exp>>, Box<Exp>), // spec only
 
     Assign(LValueList, Box<Exp>),
     FieldMutate(Box<ExpDotted>, Box<Exp>),
@@ -812,11 +812,15 @@ impl AstDebug for Exp_ {
                 w.write(" ");
                 e.ast_debug(w);
             }
-            E::Quant(kind, sp!(_, rs), e) => {
+            E::Quant(kind, sp!(_, rs), c_opt, e) => {
                 kind.ast_debug(w);
                 w.write(" ");
                 rs.ast_debug(w);
-                w.write(": ");
+                if let Some(c) = c_opt {
+                    w.write(" where ");
+                    c.ast_debug(w);
+                }
+                w.write(" : ");
                 e.ast_debug(w);
             }
             E::ExpList(es) => {

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -497,8 +497,8 @@ pub enum Exp_ {
     Block(Sequence),
     // fun (x1, ..., xn) e
     Lambda(BindList, Box<Exp>), // spec only
-    // forall/exists x1 : e1, ..., xn : en.
-    Quant(QuantKind, BindWithRangeList, Box<Exp>), // spec only
+    // forall/exists x1 : e1, ..., xn [where cond]: en.
+    Quant(QuantKind, BindWithRangeList, Option<Box<Exp>>, Box<Exp>), // spec only
     // (e1, ..., en)
     ExpList(Vec<Exp>),
     // ()
@@ -1348,11 +1348,15 @@ impl AstDebug for Exp_ {
                 w.write(" ");
                 e.ast_debug(w);
             }
-            E::Quant(kind, sp!(_, rs), e) => {
+            E::Quant(kind, sp!(_, rs), c_opt, e) => {
                 kind.ast_debug(w);
                 w.write(" ");
                 rs.ast_debug(w);
-                w.write(" ");
+                if let Some(c) = c_opt {
+                    w.write(" where ");
+                    c.ast_debug(w);
+                }
+                w.write(" : ");
                 e.ast_debug(w);
             }
             E::ExpList(es) => {

--- a/language/move-model/src/ast.rs
+++ b/language/move-model/src/ast.rs
@@ -326,7 +326,13 @@ pub enum Exp {
     /// Represents a lambda.
     Lambda(NodeId, Vec<LocalVarDecl>, Box<Exp>),
     /// Represents a quantified formula over multiple variables and ranges.
-    Quant(NodeId, QuantKind, Vec<(LocalVarDecl, Exp)>, Box<Exp>),
+    Quant(
+        NodeId,
+        QuantKind,
+        Vec<(LocalVarDecl, Exp)>,
+        Option<Box<Exp>>,
+        Box<Exp>,
+    ),
     /// Represents a block which contains a set of variable bindings and an expression
     /// for which those are defined.
     Block(NodeId, Vec<LocalVarDecl>, Box<Exp>),
@@ -432,9 +438,12 @@ impl Exp {
                 }
             }
             Lambda(_, _, body) => body.visit_pre_post(visitor),
-            Quant(_, _, ranges, body) => {
+            Quant(_, _, ranges, condition, body) => {
                 for (_, range) in ranges {
                     range.visit_pre_post(visitor);
+                }
+                if let Some(exp) = &condition {
+                    exp.visit_pre_post(visitor);
                 }
                 body.visit_pre_post(visitor);
             }

--- a/language/move-model/src/exp_rewriter.rs
+++ b/language/move-model/src/exp_rewriter.rs
@@ -67,7 +67,7 @@ impl<'env, 'rewriter> ExpRewriter<'env, 'rewriter> {
                 self.shadowed.pop_front();
                 res
             }
-            Quant(id, kind, ranges, body) => {
+            Quant(id, kind, ranges, condition, body) => {
                 let ranges = ranges
                     .iter()
                     .map(|(decl, range)| (decl.clone(), self.rewrite(range)))
@@ -78,6 +78,7 @@ impl<'env, 'rewriter> ExpRewriter<'env, 'rewriter> {
                     self.rewrite_attrs(*id),
                     *kind,
                     ranges,
+                    condition.as_ref().map(|exp| Box::new(self.rewrite(&*exp))),
                     Box::new(self.rewrite(body)),
                 );
                 self.shadowed.pop_front();

--- a/language/move-prover/boogie-backend/src/spec_translator.rs
+++ b/language/move-prover/boogie-backend/src/spec_translator.rs
@@ -3,7 +3,7 @@
 
 //! This module translates specification conditions to Boogie code.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 
 use itertools::Itertools;
 #[allow(unused_imports)]
@@ -354,15 +354,7 @@ impl<'env> SpecTranslator<'env> {
             ),
             Exp::Quant(node_id, kind, ranges, exp) => {
                 self.set_writer_location(*node_id);
-                let loc = self.env.get_node_loc(*node_id);
-                if ranges.len() == 1 {
-                    self.translate_all_or_exists(&loc, *kind, &ranges[0].0, &ranges[0].1, exp);
-                } else {
-                    self.error(
-                        &loc,
-                        "only one variable per quantifier is currently supported",
-                    );
-                }
+                self.translate_quant(*node_id, *kind, ranges, exp)
             }
             Exp::Block(node_id, vars, scope) => {
                 self.set_writer_location(*node_id);
@@ -694,89 +686,142 @@ impl<'env> SpecTranslator<'env> {
         });
     }
 
-    fn translate_all_or_exists(
+    fn translate_quant(
         &self,
-        loc: &Loc,
+        node_id: NodeId,
         kind: QuantKind,
-        var: &LocalVarDecl,
-        range: &Exp,
+        ranges: &[(LocalVarDecl, Exp)],
         exp: &Exp,
     ) {
-        let quant_ty = self.env.get_node_type(range.node_id());
-        let connective = match kind {
-            QuantKind::Forall => "==>",
-            QuantKind::Exists => "&&",
-        };
-        let var_name = self.env.symbol_pool().string(var.name);
-        let quant_var = self.fresh_var_name("i");
-        match quant_ty.skip_reference() {
-            Type::TypeDomain(domain_ty) => {
-                let type_check = boogie_well_formed_expr(self.env, &var_name, &domain_ty);
-                if type_check.is_empty() {
-                    let tctx = TypeDisplayContext::WithEnv {
-                        env: self.env,
-                        type_param_names: None,
-                    };
-                    self.error(
-                        loc,
-                        &format!(
-                            "cannot quantify over `{}` because the type is not concrete",
-                            Type::TypeDomain(domain_ty.clone()).display(&tctx)
-                        ),
-                    );
-                } else {
-                    emit!(
-                        self.writer,
-                        "$Boolean(({} {}: $Value :: {} {} ",
-                        kind,
-                        var_name,
-                        type_check,
-                        connective
-                    );
-                    emit!(self.writer, "b#$Boolean(");
-                    self.translate_exp(exp);
-                    emit!(self.writer, ")))");
+        let loc = self.env.get_node_loc(node_id);
+        // Translate range expressions.
+        let mut range_tmps = HashMap::new();
+        for (var, range) in ranges {
+            let quant_ty = self.env.get_node_type(range.node_id());
+            if matches!(
+                quant_ty.skip_reference(),
+                Type::Vector(..) | Type::Primitive(PrimitiveType::Range)
+            ) {
+                let var_name = self.env.symbol_pool().string(var.name);
+                let range_tmp = self.fresh_var_name("range");
+                emit!(self.writer, "(var {} := ", range_tmp);
+                self.translate_exp(&range);
+                emit!(self.writer, "; ");
+                range_tmps.insert(var_name, range_tmp);
+            }
+        }
+        // Translate quantified variables.
+        emit!(self.writer, "$Boolean(({} ", kind);
+        let mut quant_vars = HashMap::new();
+        let mut comma = "";
+        for (var, range) in ranges {
+            let var_name = self.env.symbol_pool().string(var.name);
+            let quant_ty = self.env.get_node_type(range.node_id());
+            match quant_ty.skip_reference() {
+                Type::TypeDomain(_) => {
+                    emit!(self.writer, "{}{}: $Value", comma, var_name);
+                }
+                _ => {
+                    let quant_var = self.fresh_var_name("i");
+                    emit!(self.writer, "{}{}: int", comma, quant_var);
+                    quant_vars.insert(var_name, quant_var);
                 }
             }
-            Type::Vector(..) => {
-                let range_tmp = self.fresh_var_name("range");
-                emit!(self.writer, "$Boolean((var {} := ", range_tmp);
-                self.translate_exp(&range);
-                emit!(self.writer, "; ({} {}: int :: ", kind, quant_var);
-                emit!(
-                    self.writer,
-                    "$InVectorRange({}, {}) {} (var {} := $select_vector({}, {}); ",
-                    range_tmp,
-                    quant_var,
-                    connective,
-                    var_name,
-                    range_tmp,
-                    quant_var,
-                );
-                emit!(self.writer, "b#$Boolean(");
-                self.translate_exp(exp);
-                emit!(self.writer, ")))))");
-            }
-            Type::Primitive(PrimitiveType::Range) => {
-                let range_tmp = self.fresh_var_name("range");
-                emit!(self.writer, "$Boolean((var {} := ", range_tmp);
-                self.translate_exp(&range);
-                emit!(self.writer, "; ({} {}: int :: ", kind, quant_var);
-                emit!(
-                    self.writer,
-                    "$InRange({}, {}) {} (var {} := $Integer({}); ",
-                    range_tmp,
-                    quant_var,
-                    connective,
-                    var_name,
-                    quant_var,
-                );
-                emit!(self.writer, "b#$Boolean(");
-                self.translate_exp(exp);
-                emit!(self.writer, ")))))");
-            }
-            _ => panic!("unexpected type"),
+            comma = ", ";
         }
+        emit!(self.writer, " :: ");
+        // Translate range constraints.
+        let connective = match kind {
+            QuantKind::Forall => " ==> ",
+            QuantKind::Exists => " && ",
+        };
+        let mut separator = "";
+        for (var, range) in ranges {
+            let var_name = self.env.symbol_pool().string(var.name);
+            let quant_ty = self.env.get_node_type(range.node_id());
+            match quant_ty.skip_reference() {
+                Type::TypeDomain(domain_ty) => {
+                    let type_check = boogie_well_formed_expr(self.env, &var_name, &domain_ty);
+                    if type_check.is_empty() {
+                        let tctx = TypeDisplayContext::WithEnv {
+                            env: self.env,
+                            type_param_names: None,
+                        };
+                        self.error(
+                            &loc,
+                            &format!(
+                                "cannot quantify over `{}` because the type is not concrete",
+                                Type::TypeDomain(domain_ty.clone()).display(&tctx)
+                            ),
+                        );
+                    } else {
+                        emit!(self.writer, "{}{}", separator, type_check);
+                    }
+                }
+                Type::Vector(..) => {
+                    let range_tmp = range_tmps.get(&var_name).unwrap();
+                    let quant_var = quant_vars.get(&var_name).unwrap();
+                    emit!(
+                        self.writer,
+                        "{}$InVectorRange({}, {})",
+                        separator,
+                        range_tmp,
+                        quant_var,
+                    );
+                }
+                Type::Primitive(PrimitiveType::Range) => {
+                    let range_tmp = range_tmps.get(&var_name).unwrap();
+                    let quant_var = quant_vars.get(&var_name).unwrap();
+                    emit!(
+                        self.writer,
+                        "{}$InRange({}, {})",
+                        separator,
+                        range_tmp,
+                        quant_var,
+                    );
+                }
+                _ => panic!("unexpected type"),
+            }
+            separator = connective;
+        }
+        emit!(self.writer, "{}", connective);
+        // Translate range selectors.
+        for (var, range) in ranges {
+            let var_name = self.env.symbol_pool().string(var.name);
+            let quant_ty = self.env.get_node_type(range.node_id());
+            match quant_ty.skip_reference() {
+                Type::Vector(..) => {
+                    let range_tmp = range_tmps.get(&var_name).unwrap();
+                    let quant_var = quant_vars.get(&var_name).unwrap();
+                    emit!(
+                        self.writer,
+                        "(var {} := $select_vector({}, {}); ",
+                        var_name,
+                        range_tmp,
+                        quant_var,
+                    );
+                }
+                Type::Primitive(PrimitiveType::Range) => {
+                    let quant_var = quant_vars.get(&var_name).unwrap();
+                    emit!(
+                        self.writer,
+                        "(var {} := $Integer({}); ",
+                        var_name,
+                        quant_var
+                    );
+                }
+                _ => (),
+            }
+        }
+        // Translate body.
+        emit!(self.writer, "b#$Boolean(");
+        self.translate_exp(exp);
+        emit!(
+            self.writer,
+            &std::iter::repeat(")")
+                .take(3 + 2 * range_tmps.len())
+                .collect::<String>()
+        );
     }
 
     fn translate_eq_neq(&self, boogie_val_fun: &str, args: &[Exp]) {

--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -1760,9 +1760,9 @@ impl<'env> SpecTranslator<'env> {
                 &self.module_env().env.get_node_loc(*node_id),
                 "`|x|e` (lambda) currently only supported as argument for `all` or `any`",
             ),
-            Exp::Quant(node_id, kind, ranges, exp) => {
+            Exp::Quant(node_id, kind, ranges, condition, exp) => {
                 self.set_writer_location(*node_id);
-                self.translate_quant(*node_id, *kind, ranges, exp)
+                self.translate_quant(*node_id, *kind, ranges, condition, exp)
             }
             Exp::Block(node_id, vars, scope) => {
                 self.set_writer_location(*node_id);
@@ -2142,7 +2142,8 @@ impl<'env> SpecTranslator<'env> {
         node_id: NodeId,
         kind: QuantKind,
         ranges: &[(LocalVarDecl, Exp)],
-        exp: &Exp,
+        condition: &Option<Box<Exp>>,
+        body: &Exp,
     ) {
         let loc = self.module_env().env.get_node_loc(node_id);
         // Translate range expressions.
@@ -2269,9 +2270,14 @@ impl<'env> SpecTranslator<'env> {
                 _ => (),
             }
         }
-        // Translate body.
+        // Translate body and "where" condition.
+        if let Some(cond) = condition {
+            emit!(self.writer, "b#$Boolean(");
+            self.translate_exp(cond);
+            emit!(self.writer, ") {}", connective);
+        }
         emit!(self.writer, "b#$Boolean(");
-        self.translate_exp(exp);
+        self.translate_exp(body);
         emit!(
             self.writer,
             &std::iter::repeat(")")


### PR DESCRIPTION
## Motivation

* Previously "where" conditions were translated during parsing.
* Keep them in the AST instead so that we can interpret them in different ways later on (e.g. adding triggers). Arguably, the code is also cleaner that way.

## Test Plan

CI

```
cargo build -p move-prover && BOOGIE_EXE=/Users/mathieubaudet/.dotnet/tools/boogie Z3_EXE= time target/debug/move-prover -d language/stdlib/modules language/stdlib/modules/DiemVersion.move
```

## Related PRs

#7262