### PR TITLE
[move prover] minor improvements to domains and utility functions

### DIFF
--- a/language/move-prover/bytecode/src/borrow_analysis.rs
+++ b/language/move-prover/bytecode/src/borrow_analysis.rs
@@ -477,7 +477,7 @@ struct PropagateSplicedAnalysis {
     borrow: BTreeMap<CodeOffset, BorrowInfoAtCodeOffset>,
 }
 
-#[derive(Default, Clone, Eq, PartialEq, PartialOrd)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, PartialOrd)]
 struct SplicedState {
     spliced: BTreeSet<BorrowNode>,
 }

--- a/language/move-prover/bytecode/src/clean_and_optimize.rs
+++ b/language/move-prover/bytecode/src/clean_and_optimize.rs
@@ -54,7 +54,7 @@ impl FunctionTargetProcessor for CleanAndOptimizeProcessor {
 
 /// A data flow analysis state used for optimization analysis. Currently it tracks the nodes
 /// which have been updated but not yet written back.
-#[derive(Clone, Default, Eq, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Default, Eq, PartialEq, PartialOrd)]
 struct AnalysisState {
     unwritten: BTreeSet<BorrowNode>,
 }

--- a/language/move-prover/bytecode/src/function_target.rs
+++ b/language/move-prover/bytecode/src/function_target.rs
@@ -13,10 +13,12 @@ use move_model::{
     symbol::{Symbol, SymbolPool},
     ty::{Type, TypeDisplayContext},
 };
+
 use std::{
     cell::RefCell,
     collections::{BTreeMap, BTreeSet},
     fmt,
+    ops::Range,
 };
 use vm::file_format::CodeOffset;
 
@@ -176,8 +178,14 @@ impl<'env> FunctionTarget<'env> {
         self.data.return_types.len()
     }
 
+    /// Return the number of parameters of this function
     pub fn get_parameter_count(&self) -> usize {
         self.func_env.get_parameter_count()
+    }
+
+    /// Return an iterator over this function's parameters
+    pub fn get_parameters(&self) -> Range<usize> {
+        0..self.func_env.get_parameter_count()
     }
 
     /// Get the name to be used for a local. If the local is an argument, use that for naming,

--- a/language/move-prover/bytecode/src/packed_types_analysis.rs
+++ b/language/move-prover/bytecode/src/packed_types_analysis.rs
@@ -72,7 +72,7 @@ pub fn get_packed_types(env: &GlobalEnv, targets: &FunctionTargetsHolder) -> BTr
     packed_types
 }
 
-#[derive(Clone, Default, Eq, PartialOrd, PartialEq)]
+#[derive(Debug, Clone, Default, Eq, PartialOrd, PartialEq)]
 struct PackedTypesState {
     // Closed types (i.e., with no free type variables) that may be directly or transitively packed by this function.
     closed_types: SetDomain<StructTag>,

--- a/language/move-prover/bytecode/src/usage_analysis.rs
+++ b/language/move-prover/bytecode/src/usage_analysis.rs
@@ -45,7 +45,7 @@ pub fn get_directly_modified_memory<'env>(
 }
 
 /// The annotation for usage of functions. This is computed by the function target processor.
-#[derive(Clone, Default, Eq, PartialOrd, PartialEq)]
+#[derive(Debug, Clone, Default, Eq, PartialOrd, PartialEq)]
 struct UsageState {
     // The memory which is directly and transitively accessed by this function.
     used_memory: SetDomain<QualifiedId<StructId>>,


### PR DESCRIPTION
These are all used by the upcoming read/write set analysis, but are unrelated/independently useful.

- Make `AbstractDomain` implement `Debug`, which makes it easier to do debug printing of analysis results
- Add a `join_insert` utility function for `MapDomain`
- Add a `singleton` utility function for `SetDomain`
- Allow a `FunctionTarget` to iterate over its parameter indexes
