### PR TITLE
[move prover] build a GlobalEnv from bytecodes

### DIFF
--- a/language/move-model/tests/sources/structs_ok.move
+++ b/language/move-model/tests/sources/structs_ok.move
@@ -19,6 +19,10 @@ module M {
     x: u64
   }
 
+  public fun f(r: R): T {
+    T { x: r.s.x }
+  }
+
   spec module {
 
     define struct_access(s: S): u64 {


### PR DESCRIPTION
In order to deploy the read/write set analysis, the Diem adapter will need to build a GlobalEnv from raw bytecodes stored on-chain. This PR makes that possible by adding a new builder for the GlobalEnv that needs only a list of modules topologically sorted by the module dependency relation.

To test the change, I run the bytecode builder on the modules extracted from each GlobalEnv in the existing test harness + do some sanity checks to ensure that both environments contain the same code.