### PR TITLE
[move-prover] Extending the Prover for the `emits` statements

### DIFF
--- a/language/move-prover/tests/sources/functional/emits.exp
+++ b/language/move-prover/tests/sources/functional/emits.exp
@@ -1,0 +1,52 @@
+Move prover returns: exiting with boogie verification errors
+error: function does not emit the expected event
+
+    ┌── tests/sources/functional/emits.move:62:9 ───
+    │
+ 62 │         emits DummyEvent{msg: 0} to handle;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/emits.move:56:5: conditional_missing_condition_incorrect
+    =         x = <redacted>,
+    =         handle = <redacted>,
+    =         result = <redacted>
+    =     at tests/sources/functional/emits.move:57:9: conditional_missing_condition_incorrect
+
+error: function does not emit the expected event
+
+    ┌── tests/sources/functional/emits.move:53:9 ───
+    │
+ 53 │         emits DummyEvent{msg: 0} to handle if x > 0;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/emits.move:47:5: conditional_wrong_condition_incorrect
+    =         x = <redacted>,
+    =         handle = <redacted>,
+    =         result = <redacted>
+    =     at tests/sources/functional/emits.move:48:9: conditional_wrong_condition_incorrect
+
+error: function does not emit the expected event
+
+    ┌── tests/sources/functional/emits.move:30:9 ───
+    │
+ 30 │         emits DummyEvent{msg: 0} to _handle2;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/emits.move:26:5: simple_wrong_handle_incorrect
+    =         handle = <redacted>,
+    =         _handle2 = <redacted>,
+    =         result_1 = <redacted>,
+    =         result_2 = <redacted>
+    =     at tests/sources/functional/emits.move:27:16: simple_wrong_handle_incorrect
+
+error: function does not emit the expected event
+
+    ┌── tests/sources/functional/emits.move:23:9 ───
+    │
+ 23 │         emits DummyEvent{msg: 1} to handle;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/emits.move:19:5: simple_wrong_msg_incorrect
+    =         handle = <redacted>,
+    =         result = <redacted>
+    =     at tests/sources/functional/emits.move:20:16: simple_wrong_msg_incorrect

--- a/language/move-prover/tests/sources/functional/emits.move
+++ b/language/move-prover/tests/sources/functional/emits.move
@@ -1,0 +1,80 @@
+module TestEmits {
+    use 0x1::Event::{Self, EventHandle};
+
+    struct DummyEvent {
+        msg: u64
+    }
+
+    // -------------------------
+    // simple `emits` statements
+    // -------------------------
+
+    public fun simple(handle: &mut EventHandle<DummyEvent>) {
+        Event::emit_event(handle, DummyEvent{msg: 0});
+    }
+    spec fun simple {
+        emits DummyEvent{msg: 0} to handle;
+    }
+
+    public fun simple_wrong_msg_incorrect(handle: &mut EventHandle<DummyEvent>) {
+        Event::emit_event(handle, DummyEvent{msg: 0});
+    }
+    spec fun simple_wrong_msg_incorrect {
+        emits DummyEvent{msg: 1} to handle;
+    }
+
+    public fun simple_wrong_handle_incorrect(handle: &mut EventHandle<DummyEvent>, _handle2: &mut EventHandle<DummyEvent>) {
+        Event::emit_event(handle, DummyEvent{msg: 0});
+    }
+    spec fun simple_wrong_handle_incorrect {
+        emits DummyEvent{msg: 0} to _handle2;
+    }
+
+
+    // ------------------------------
+    // conditional `emits` statements
+    // ------------------------------
+
+    public fun conditional(x: u64, handle: &mut EventHandle<DummyEvent>) {
+        if (x > 7) {
+            Event::emit_event(handle, DummyEvent{msg: 0});
+        }
+    }
+    spec fun conditional {
+        emits DummyEvent{msg: 0} to handle if x > 7;
+    }
+
+    public fun conditional_wrong_condition_incorrect(x: u64, handle: &mut EventHandle<DummyEvent>) {
+        if (x > 7) {
+            Event::emit_event(handle, DummyEvent{msg: 0});
+        }
+    }
+    spec fun conditional_wrong_condition_incorrect {
+        emits DummyEvent{msg: 0} to handle if x > 0;
+    }
+
+    public fun conditional_missing_condition_incorrect(x: u64, handle: &mut EventHandle<DummyEvent>) {
+        if (x > 7) {
+            Event::emit_event(handle, DummyEvent{msg: 0});
+        }
+    }
+    spec fun conditional_missing_condition_incorrect {
+        emits DummyEvent{msg: 0} to handle;
+    }
+
+
+    // ----------------------------
+    // `emits` statements in schema
+    // ----------------------------
+
+    public fun emits_in_schema(handle: &mut EventHandle<DummyEvent>) {
+        Event::emit_event(handle, DummyEvent{msg: 0});
+    }
+    spec fun emits_in_schema {
+        include EmitsInSchemaEmits;
+    }
+    spec schema EmitsInSchemaEmits {
+        handle: EventHandle<DummyEvent>;
+        emits DummyEvent{msg: 0} to handle;
+    }
+}

--- a/language/stdlib/modules/Event.move
+++ b/language/stdlib/modules/Event.move
@@ -86,13 +86,8 @@ module Event {
     spec module {} // switch documentation context to module
 
     spec module {
-        /// > NOTE: specification and verification of event related functionality is currently not happening.
-        /// > Since events cannot be observed from Move programs, this does not affect the verification of
-        /// > other functionality; however, this should be completed at a later point to ensure the framework
-        /// > generates events as expected.
-        ///
         /// Functions of the event module are mocked out using the intrinsic
-        /// pragma. They are implemented in the prover's prelude as no-ops.
+        /// pragma. They are implemented in the prover's prelude.
         pragma intrinsic = true;
     }
 }

--- a/language/stdlib/transaction_scripts/update_exchange_rate.move
+++ b/language/stdlib/transaction_scripts/update_exchange_rate.move
@@ -68,6 +68,8 @@ spec fun update_exchange_rate {
         new_exchange_rate_denominator
     );
     include Diem::UpdateXDXExchangeRateAbortsIf<Currency>;
+    include Diem::UpdateXDXExchangeRateEnsures<Currency>{xdx_exchange_rate: rate};
+    include Diem::UpdateXDXExchangeRateEmits<Currency>{xdx_exchange_rate: rate};
 
     aborts_with [check]
         Errors::INVALID_ARGUMENT,


### PR DESCRIPTION
This PR updates the Prover in the following parts:

(1) The Prelude includes
  - the definition of EventStore in Boogie,
  - the Boogie model of the native function `write_to_event_store` to update EventStore properly,
  - the Boogie model of `emit_event` that abstracts away the `counter` behavior (i.e., `counter` is not mutated in the verification world)

(2) `spec_translator.rs` converts the `emits` specs into the corresponding postconditions of the Boogie procedures

(3) Examples
  - multiple test cases are added to `tests/sources/functional/emits.move`. Some are proved, and others are disproved by the Prover.
  - `Diem::update_xdx_exchange_rate` and `Diem::mint_with_capability` are specified and verified.
  - The transaction script `update_exchange_rate` is specified and verified

TODOs:
- Correctly handle "opaque" functions in the event verification
- Allow the strictness in the event verification  (i.e., verifying that no other events are emitted)
- One TODO is left in `$Event_emit_event` in the Prelude

## Motivation

To verify events in Prover

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test
