### PR TITLE
[State Sync] Fix "Synchronization/Sync" consistency issues in network code.

### DIFF
--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -94,7 +94,7 @@ impl StateComputer for ExecutionProxy {
         // Here to start to do state synchronization where ChunkExecutor inside will
         // process chunks and commit to Storage. However, after block execution and
         // commitments, the the sync state of ChunkExecutor may be not up to date so
-        // it is required to reset the cache of ChunkExecutor in StateSynchronizer
+        // it is required to reset the cache of ChunkExecutor in State Sync
         // when requested to sync.
         let res = monitor!("sync_to", self.synchronizer.sync_to(target).await);
         // Similarily, after the state synchronization, we have to reset the cache

--- a/diem-node/src/lib.rs
+++ b/diem-node/src/lib.rs
@@ -333,7 +333,7 @@ pub fn setup_environment(node_config: &NodeConfig, logger: Option<Arc<Logger>>) 
         let mut network_builder = NetworkBuilder::create(chain_id, role, network_config);
         let network_id = network_config.network_id.clone();
 
-        // Create the endpoints to connect the Network to StateSynchronizer.
+        // Create the endpoints to connect the Network to State Sync.
         let (state_sync_sender, state_sync_events) =
             network_builder.add_protocol_handler(state_sync::network::network_endpoint_config());
         state_sync_network_handles.push((
@@ -446,10 +446,10 @@ pub fn setup_environment(node_config: &NodeConfig, logger: Option<Arc<Logger>>) 
         // (in case it's present). There is no sense to start consensus prior to that.
         // TODO: Note that we need the networking layer to be able to discover & connect to the
         // peers with potentially outdated network identity public keys.
-        debug!("Wait until state synchronizer is initialized");
+        debug!("Wait until state sync is initialized");
         block_on(state_sync_client.wait_until_initialized())
-            .expect("State synchronizer initialization failure");
-        debug!("State synchronizer initialization complete.");
+            .expect("State sync initialization failure");
+        debug!("State sync initialization complete.");
 
         // Initialize and start consensus.
         instant = Instant::now();

--- a/network/src/peer/fuzzing.rs
+++ b/network/src/peer/fuzzing.rs
@@ -88,7 +88,7 @@ pub fn fuzz(data: &[u8]) {
                 ProtocolId::ConsensusRpc,
                 ProtocolId::ConsensusDirectSend,
                 ProtocolId::MempoolDirectSend,
-                ProtocolId::StateSynchronizerDirectSend,
+                ProtocolId::StateSyncDirectSend,
                 ProtocolId::DiscoveryDirectSend,
                 ProtocolId::HealthCheckerRpc,
             ]

--- a/network/src/protocols/wire/handshake/v1/mod.rs
+++ b/network/src/protocols/wire/handshake/v1/mod.rs
@@ -36,7 +36,7 @@ pub enum ProtocolId {
     ConsensusRpc = 0,
     ConsensusDirectSend = 1,
     MempoolDirectSend = 2,
-    StateSynchronizerDirectSend = 3,
+    StateSyncDirectSend = 3,
     DiscoveryDirectSend = 4,
     HealthCheckerRpc = 5,
 }
@@ -48,7 +48,7 @@ impl ProtocolId {
             ConsensusRpc => "ConsensusRpc",
             ConsensusDirectSend => "ConsensusDirectSend",
             MempoolDirectSend => "MempoolDirectSend",
-            StateSynchronizerDirectSend => "StateSynchronizerDirectSend",
+            StateSyncDirectSend => "StateSyncDirectSend",
             DiscoveryDirectSend => "DiscoveryDirectSend",
             HealthCheckerRpc => "HealthCheckerRpc",
         }
@@ -175,7 +175,7 @@ impl HandshakeMsg {
         let mut supported_protocols = BTreeMap::new();
         supported_protocols.insert(
             MessagingProtocolVersion::V1,
-            [ProtocolId::StateSynchronizerDirectSend].iter().into(),
+            [ProtocolId::StateSyncDirectSend].iter().into(),
         );
         Self {
             chain_id: ChainId::test(),

--- a/specifications/network/messaging-v1.md
+++ b/specifications/network/messaging-v1.md
@@ -26,7 +26,7 @@ enum ProtocolId {
     ConsensusRpc = 0,
     ConsensusDirectSend = 1,
     MempoolDirectSend = 2,
-    StateSynchronizerDirectSend = 3,
+    StateSyncDirectSend = 3,
     DiscoveryDirectSend = 4,
     HealthCheckerRpc = 5,
     IdentityDirectSend = 6,

--- a/specifications/state_sync/README.md
+++ b/specifications/state_sync/README.md
@@ -275,7 +275,7 @@ specification.
 
 ```rust
 /// Sends `message` to `recipient`
-fn send_to(recipient: PeerId, message: StateSynchronizerMsg)
+fn send_to(recipient: PeerId, message: StateSyncMessage)
 ```
 
 ### Consensus

--- a/state-sync/src/client.rs
+++ b/state-sync/src/client.rs
@@ -33,7 +33,7 @@ pub struct CommitNotification {
 pub enum CoordinatorMessage {
     SyncRequest(Box<SyncRequest>), // Initiate a new sync request for a given target.
     CommitNotification(Box<CommitNotification>), // Notify state sync about committed transactions.
-    GetSyncState(oneshot::Sender<SyncState>), // Return the local synchronization state.
+    GetSyncState(oneshot::Sender<SyncState>), // Return the local sync state.
     WaitForInitialization(oneshot::Sender<Result<()>>), // Wait until state sync is initialized to the waypoint.
 }
 

--- a/state-sync/src/coordinator.rs
+++ b/state-sync/src/coordinator.rs
@@ -385,7 +385,7 @@ impl<T: ExecutorProxyTrait> StateSyncCoordinator<T> {
     /// The caller will be notified about request completion via request.callback oneshot:
     /// at that moment it's guaranteed that the highest LI exposed by the storage is equal to the
     /// target LI.
-    /// StateSynchronizer assumes that it's the only one modifying the storage (consensus is not
+    /// State sync assumes that it's the only one modifying the storage (consensus is not
     /// trying to commit transactions concurrently).
     fn request_sync(&mut self, request: SyncRequest) -> Result<()> {
         fail_point!("state_sync::request_sync", |_| {
@@ -1128,7 +1128,7 @@ impl<T: ExecutorProxyTrait> StateSyncCoordinator<T> {
             .execute_chunk(txn_list_with_proof, target, intermediate_end_of_epoch_li)
     }
 
-    /// Ensures that StateSynchronizer is making progress:
+    /// Ensures that state sync is making progress:
     /// * kick-starts initial sync process (= initialization syncing to waypoint)
     /// * issue a new request if too much time passed since requesting highest_synced_version + 1.
     fn check_progress(&mut self) {

--- a/state-sync/src/counters.rs
+++ b/state-sync/src/counters.rs
@@ -89,13 +89,14 @@ pub const STATE_SYNC_LABEL: &str = "state_sync";
 pub const COMPLETE_LABEL: &str = "complete";
 pub const TIMEOUT_LABEL: &str = "timeout";
 
-/// Counter of pending network events to State Synchronizer
+/// Counter of pending network events to State Sync
 pub static PENDING_STATE_SYNC_NETWORK_EVENTS: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "diem_state_sync_pending_network_events",
-        "Counters(queued,dequeued,dropped) related to pending network notifications for State Synchronizer",
+        "Counters(queued,dequeued,dropped) related to pending network notifications for State Sync",
         &["state"]
-    ).unwrap()
+    )
+    .unwrap()
 });
 
 /// Number of chunk requests sent from a node

--- a/state-sync/src/fuzzing.rs
+++ b/state-sync/src/fuzzing.rs
@@ -6,7 +6,7 @@ use crate::{
     chunk_response::{GetChunkResponse, ResponseLedgerInfo},
     coordinator::StateSyncCoordinator,
     executor_proxy::{ExecutorProxy, ExecutorProxyTrait},
-    network::{StateSyncSender, StateSynchronizerMsg},
+    network::{StateSyncMessage, StateSyncSender},
 };
 use channel::{diem_channel, message_queues::QueueStyle};
 use diem_config::{
@@ -101,7 +101,7 @@ proptest! {
     }
 }
 
-pub fn test_state_sync_msg_fuzzer_impl(msg: StateSynchronizerMsg) {
+pub fn test_state_sync_msg_fuzzer_impl(msg: StateSyncMessage) {
     block_on(async move {
         STATE_SYNC_COORDINATOR
             .lock()
@@ -116,13 +116,13 @@ pub fn test_state_sync_msg_fuzzer_impl(msg: StateSynchronizerMsg) {
     });
 }
 
-pub fn arb_state_sync_msg() -> impl Strategy<Value = StateSynchronizerMsg> {
+pub fn arb_state_sync_msg() -> impl Strategy<Value = StateSyncMessage> {
     prop_oneof![
         (any::<GetChunkRequest>()).prop_map(|chunk_request| {
-            StateSynchronizerMsg::GetChunkRequest(Box::new(chunk_request))
+            StateSyncMessage::GetChunkRequest(Box::new(chunk_request))
         }),
         (any::<GetChunkResponse>()).prop_map(|chunk_response| {
-            StateSynchronizerMsg::GetChunkResponse(Box::new(chunk_response))
+            StateSyncMessage::GetChunkResponse(Box::new(chunk_response))
         })
     ]
 }

--- a/state-sync/src/network.rs
+++ b/state-sync/src/network.rs
@@ -62,7 +62,7 @@ impl StateSyncSender {
         recipient: PeerId,
         message: StateSynchronizerMsg,
     ) -> Result<(), NetworkError> {
-        let protocol = ProtocolId::StateSynchronizerDirectSend;
+        let protocol = ProtocolId::StateSyncDirectSend;
         self.inner.send_to(recipient, protocol, message)
     }
 }
@@ -77,7 +77,7 @@ pub fn network_endpoint_config() -> (
 ) {
     (
         vec![],
-        vec![ProtocolId::StateSynchronizerDirectSend],
+        vec![ProtocolId::StateSyncDirectSend],
         QueueStyle::LIFO,
         STATE_SYNC_MAX_BUFFER_SIZE,
         Some(&counters::PENDING_STATE_SYNC_NETWORK_EVENTS),

--- a/state-sync/src/request_manager.rs
+++ b/state-sync/src/request_manager.rs
@@ -5,7 +5,7 @@ use crate::{
     chunk_request::GetChunkRequest,
     counters,
     logging::{LogEntry, LogEvent, LogSchema},
-    network::{StateSyncSender, StateSynchronizerMsg},
+    network::{StateSyncMessage, StateSyncSender},
 };
 use anyhow::{bail, format_err, Result};
 use diem_config::{
@@ -273,7 +273,7 @@ impl RequestManager {
             .event(LogEvent::ChunkRequestInfo)
             .chunk_req_info(&req_info));
 
-        let msg = StateSynchronizerMsg::GetChunkRequest(Box::new(req));
+        let msg = StateSyncMessage::GetChunkRequest(Box::new(req));
         let mut failed_peer_sends = vec![];
 
         for peer in peers {

--- a/state-sync/tests/test_harness.rs
+++ b/state-sync/tests/test_harness.rs
@@ -424,7 +424,7 @@ impl StateSyncEnvironment {
             let receiver_network_notif_tx = self.network_notifs_txs.get_mut(&receiver_id).unwrap();
             receiver_network_notif_tx
                 .push(
-                    (sender_peer_id, ProtocolId::StateSynchronizerDirectSend),
+                    (sender_peer_id, ProtocolId::StateSyncDirectSend),
                     PeerManagerNotification::RecvMessage(sender_peer_id, msg.clone()),
                 )
                 .unwrap();

--- a/state-sync/tests/test_harness.rs
+++ b/state-sync/tests/test_harness.rs
@@ -146,7 +146,7 @@ impl StateSyncPeer {
 
     // Moves to the next epoch. Note that other peers are not going to be able to discover
     // their new signers: they're going to learn about the new epoch public key through state
-    // synchronization. Private keys are discovered separately.
+    // sync. Private keys are discovered separately.
     pub fn move_to_next_epoch(&self, validator_infos: Vec<ValidatorInfo>, validator_index: usize) {
         let (validator_set, validator_signers) = create_new_validator_set(validator_infos);
         self.storage_proxy
@@ -346,7 +346,7 @@ impl StateSyncEnvironment {
                 let peer_id = PeerId::random();
                 peer.multi_peer_ids.insert(network.clone(), peer_id);
 
-                // mock the StateSynchronizerEvents and StateSynchronizerSender to allow manually controlling
+                // mock the StateSyncEvents and StateSyncSender to allow manually controlling
                 // msg delivery in test
                 let (network_reqs_tx, network_reqs_rx) =
                     diem_channel::new(QueueStyle::LIFO, 1, None);

--- a/testsuite/cluster-test/src/experiments/load_test.rs
+++ b/testsuite/cluster-test/src/experiments/load_test.rs
@@ -439,9 +439,8 @@ async fn state_sync_load_test(
     let mut bytes = 0_u64;
     let mut msg_num = 0_u64;
     while Instant::now().duration_since(task_start) < duration {
-        let msg = state_sync::network::StateSynchronizerMsg::GetChunkRequest(Box::new(
-            chunk_request.clone(),
-        ));
+        let msg =
+            state_sync::network::StateSyncMessage::GetChunkRequest(Box::new(chunk_request.clone()));
         bytes += bcs::to_bytes(&msg)?.len() as u64;
         msg_num += 1;
         sender.send_to(vfn, msg)?;
@@ -449,8 +448,7 @@ async fn state_sync_load_test(
         // await response from remote peer
         let response = events.select_next_some().await;
         if let Event::Message(_remote_peer, payload) = response {
-            if let state_sync::network::StateSynchronizerMsg::GetChunkResponse(chunk_response) =
-                payload
+            if let state_sync::network::StateSyncMessage::GetChunkResponse(chunk_response) = payload
             {
                 // TODO analyze response and update StateSyncResult with stats accordingly
                 served_txns += chunk_response.txn_list_with_proof.transactions.len() as u64;

--- a/testsuite/generate-format/tests/staged/network.yaml
+++ b/testsuite/generate-format/tests/staged/network.yaml
@@ -131,7 +131,7 @@ ProtocolId:
     2:
       MempoolDirectSend: UNIT
     3:
-      StateSynchronizerDirectSend: UNIT
+      StateSyncDirectSend: UNIT
     4:
       DiscoveryDirectSend: UNIT
     5:


### PR DESCRIPTION
## Motivation

Note: no logic changes in this PR. 😄

This PR concludes the efforts to address the consistency issues in state sync by replacing instances of "synchronization/synchronizer" with "sync" (see https://github.com/diem/diem/pull/7299 for the first PR). Nothing should semantically change in this PR.

The PR offers the following commits:
1. Rename "StateSynchronizerDirectSend" to "StateSyncDirectSend".
2. Rename "StateSynchronizerMsg" to "StateSyncMessage"
3. Clean up a few remaining comments and strings.

Note: these changes *should all be backward compatible*:
1. In commit 1, we change the name of the protocol, but the underlying protocol id integer is the same. This id is the data that is sent across the wire. 
2. In commit 2, we rename the state sync messages sent between validators and full nodes when making chunk requests and responses. These messages are serialized using BCS (https://github.com/diem/bcs#structures), which doesn't take into account the name of the struct, but rather the format. Thus, the rename shouldn't affect old code versions.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally.

## Related PRs

This relates to: https://github.com/diem/diem/issues/6795