### PR TITLE
[move][vm] Versioned deserializer

### DIFF
--- a/language/vm/src/unit_tests/signature_token_tests.rs
+++ b/language/vm/src/unit_tests/signature_token_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    deserializer::load_signature_token,
+    deserializer::load_signature_token_test_entry,
     file_format::{SignatureToken, StructHandleIndex},
     file_format_common::{BinaryData, SIGNATURE_TOKEN_DEPTH_MAX},
     serializer::{serialize_signature_token, serialize_signature_token_unchecked},
@@ -17,8 +17,8 @@ fn serialize_and_deserialize_nested_types_max() {
         let mut binary = BinaryData::new();
         serialize_signature_token(&mut binary, &ty).expect("serialization should succeed");
 
-        let mut cursor = Cursor::new(binary.as_inner());
-        load_signature_token(&mut cursor).expect("deserialization should succeed");
+        let cursor = Cursor::new(binary.as_inner());
+        load_signature_token_test_entry(cursor).expect("deserialization should succeed");
     }
 }
 
@@ -39,7 +39,7 @@ fn serialize_nested_types_too_deep() {
         serialize_signature_token_unchecked(&mut binary, &ty)
             .expect("serialization (unchecked) should succeed");
 
-        let mut cursor = Cursor::new(binary.as_inner());
-        load_signature_token(&mut cursor).expect_err("deserialization should fail");
+        let cursor = Cursor::new(binary.as_inner());
+        load_signature_token_test_entry(cursor).expect_err("deserialization should fail");
     }
 }


### PR DESCRIPTION
- Threaded version information through the VM's deserializer
- It was a bit tricky to do this because the deserializer was so light weight
- An alternative option would be to stick the whole thing in some sort of deserializer struct/object and add the environment variable as a version, but that felt weird since there was only one thing in the env...

## Motivation

- We will need to case on the version information for future work

## Test Plan

- none yet really, the code is not used yet