### PR TITLE
[gha] docker pushes and release audit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -488,16 +488,16 @@ workflows:
   # Will publish release images to dockerhub and aws when commits land on a release/testing branch.                    #
   # Will also push base images to novi aws ecr to prevent dockerhub api limit violations.                              #
   ######################################################################################################################
-  release-dockerhub-publish:
-    jobs:
-      - docker-publish:
-          context: docker
-          filters:
-            branches:
-              only:
-                - /^test-[\d|.]+$/
-                - /^release-[\d|.]+$/
-                - master
+  #release-dockerhub-publish:
+  #  jobs:
+  #    - docker-publish:
+  #        context: docker
+  #        filters:
+  #          branches:
+  #            only:
+  #              - /^test-[\d|.]+$/
+  #              - /^release-[\d|.]+$/
+  #              - master
 
   ######################################################################################################################
   # Updates documentation when code is committed to master, and checks for breaking changes.
@@ -511,7 +511,6 @@ workflows:
       - check-breaking-change:
           requires:
             - prefetch-crates
-
   ######################################################################################################################
   # Used by bors to test prs on master's head before committing to master.                                             #
   # The "commit-workflow" must support auto and canary branchs...                                                      #
@@ -519,8 +518,13 @@ workflows:
   ######################################################################################################################
   commit-workflow:
     jobs:
-      - docker-pre-publish:
-          context: docker
+      #using as a no-op until bors can be updated (this change is merged in release-1.1)
+      - prefetch-crates:
           filters:
             branches:
               only: auto
+  #    - docker-pre-publish:
+  #        context: docker
+  #        filters:
+  #          branches:
+  #            only: auto

--- a/.github/workflows/ci-publish-base-image.yml
+++ b/.github/workflows/ci-publish-base-image.yml
@@ -2,7 +2,7 @@ name: Publish Base CI Image To Dockerhub
 
 on:
   push:
-    branches: [main, master, release-*, gha-test-*]
+    branches: [main, master]
     paths:
       [
         .github/workflows/ci-publish-base-image.yml,
@@ -15,7 +15,6 @@ jobs:
   build_docker_images:
     runs-on: ubuntu-latest-xl
     continue-on-error: false
-    environment: Docker
     env:
       TAG: github-1
       DOCKERHUB_ORG: libra

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -2,7 +2,7 @@ name: ci-test
 
 on:
   push:
-    branches: [auto, canary, gha-test-*]
+    branches: [auto, canary]
   pull_request:
     branches: [main, master, release-*, gha-test-*]
 

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -12,8 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: libra/build_environment:github-1
+    strategy:
+      fail-fast: false
+      matrix:
+        #this is a painful solution since it doesn't pick up new branches, other option is lotsa shell in one job....
+        target-branch: [master, release-1.1]
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ matrix.target-branch }}
       - uses: ./.github/actions/build-setup
       - name: install cargo-audit
         run: cargo install --force cargo-audit

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,91 @@
+name: docker-publish.yml
+
+on:
+  push:
+    branches: [main, master, gha-test-*]
+
+jobs:
+  build-images:
+    runs-on: ubuntu-latest-xl
+    continue-on-error: false
+    env:
+      TAG: github-1
+      DOCKERHUB_ORG: libra
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 #get all the history!!!
+      - id: changes
+        name: determine changes
+        uses: ./.github/actions/changes
+        with:
+          workflow-file: docker-publish.yml
+      - name: setup_aws_erc_login
+        run: |
+          echo 'AWS_ECR_ACCOUNT_URL=${{ secrets.AWS_ECR_ACCOUNT_NUM }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com' >> $GITHUB_ENV
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+      - name: Sign in to dockerhub, install image signing cert.
+        uses: ./.github/actions/dockerhub_login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          key_material: ${{ secrets.DOCKERHUB_KEY_MATERIAL }}
+          key_name: ${{ secrets.DOCKERHUB_KEY_NAME }}
+          key_password: ${{ secrets.DOCKERHUB_KEY_PASSWORD }}
+      - name: should pre build docker images (targeting a release branch)?
+        if: ${{ github.ref == 'refs/heads/auto' }}
+        run: |
+          if  [[ ! "$CHANGES_TARGET_BRANCH" =~ "^release-[0-9|.]+$" ]] && [[ ! "$CHANGES_TARGET_BRANCH" =~ "^gha-test-[0-9|.]+$" ]] ; then
+            echo Targeting branch $CHANGES_TARGET_BRANCH will not pre-publish docker images.
+          fi
+      - name: pre-release docker images
+        if: ${{ github.ref == 'refs/heads/auto' }}
+        run: |
+          BRANCH="$CHANGES_TARGET_BRANCH"
+          success=0
+          docker/build_push.sh -u -p -b ${BRANCH} -n client || success=-1
+          docker/build_push.sh -u -p -b ${BRANCH} -n init || success=-1
+          docker/build_push.sh -u -p -b ${BRANCH} -n faucet || success=-1
+          docker/build_push.sh -u -p -b ${BRANCH} -n tools || success=-1
+          docker/build_push.sh -u -p -b ${BRANCH} -n validator || success=-1
+          docker/build_push.sh -u -p -b ${BRANCH} -n validator-tcb || success=-1
+          docker/build_push.sh -u -p -b ${BRANCH} -n cluster-test || success=-1
+          exit $success
+        env:
+          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKERHUB_KEY_PASSWORD }}
+      - name: pull pre images (or build if not pullable) and push release docker images if not on auto branch.
+        if: ${{ github.ref != 'refs/heads/auto' }}
+        run: |
+          set -x
+          BRANCH=$(echo "$GITHUB_REF" | sed 's|.*/||' )
+          success=0
+          docker/build_push.sh -u -b ${BRANCH} -n client || success=-1
+          docker/build_push.sh -u -b ${BRANCH} -n init || success=-1
+          docker/build_push.sh -u -b ${BRANCH} -n faucet || success=-1
+          docker/build_push.sh -u -b ${BRANCH} -n tools || success=-1
+          docker/build_push.sh -u -b ${BRANCH} -n validator || success=-1
+          docker/build_push.sh -u -b ${BRANCH} -n validator-tcb || success=-1
+          docker/build_push.sh -u -b ${BRANCH} -n cluster-test || success=-1
+          exit $success
+        env:
+          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKERHUB_KEY_PASSWORD }}
+      - name: docker image pruning.
+        run: |
+          scripts/dockerhub_prune.sh -u "${{ secrets.DOCKERHUB_USERNAME }}" -p "${{ secrets.DOCKERHUB_PASSWORD }}" -x
+      - name: push to novi ecr
+        if: ${{ always() }}
+        run: |
+          #push to novi ecr with standard names
+          BRANCH=$(echo "$GITHUB_REF" | sed 's|.*/||' )
+          GIT_REV=$(git rev-parse --short=8 HEAD)
+          aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | \
+          docker login --username AWS --password-stdin "${AWS_ECR_ACCOUNT_URL}"
+          docker/dockerhub_to_novi_ecr.sh -t ${BRANCH}_${GIT_REV} -r ${AWS_ECR_ACCOUNT_URL}


### PR DESCRIPTION
## Motivation

Since we have a better relationship with, and are provided more capacity by gha migrating docker image builds to gha.
Leaving the config to perform docker image release in circleci, just disabled intentionally as a fall back until we've rock solid confidence in gha and a manual release playbook.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

A test branch in diem/diem:  run is here:

https://github.com/diem/diem/runs/1750457255?check_suite_focus=true

An older build had the release audit working on both branches.

## Related PRs

None.