### PR TITLE
[prover] fine-grained read and write set analysis

### DIFF
--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -48,8 +48,8 @@ use vm::{
         StructDefinitionIndex, StructFieldInformation, StructHandleIndex, Visibility,
     },
     views::{
-        FunctionDefinitionView, FunctionHandleView, SignatureTokenView, StructDefinitionView,
-        StructHandleView,
+        FieldDefinitionView, FunctionDefinitionView, FunctionHandleView, SignatureTokenView,
+        StructDefinitionView, StructHandleView,
     },
     CompiledModule,
 };
@@ -1953,6 +1953,16 @@ impl<'env> FieldEnv<'env> {
         FieldId(self.data.name)
     }
 
+    /// Returns the VM identifier for this field
+    pub fn get_identifier(&'env self) -> Identifier {
+        let m = &self.struct_env.module_env.data.module;
+        let def = m.struct_def_at(self.data.def_idx);
+        let offset = self.data.offset;
+        FieldDefinitionView::new(m, def.field(offset).expect("Bad field offset"))
+            .name()
+            .to_owned()
+    }
+
     /// Get documentation associated with this field.
     pub fn get_doc(&self) -> &str {
         if let Ok(smap) = self
@@ -2522,7 +2532,6 @@ impl<'env> FunctionEnv<'env> {
     /// `get_local_count`.
     pub fn get_local_type(&self, idx: usize) -> Type {
         let view = self.definition_view();
-
         let parameters = view.parameters();
 
         if idx < parameters.len() {

--- a/language/move-model/src/ty.rs
+++ b/language/move-model/src/ty.rs
@@ -8,7 +8,7 @@ use crate::{
     model::{GlobalEnv, ModuleId, StructEnv, StructId},
     symbol::{Symbol, SymbolPool},
 };
-use move_core_types::language_storage::TypeTag;
+use move_core_types::language_storage::{StructTag, TypeTag};
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt,
@@ -324,6 +324,23 @@ impl Type {
             Reference(_, bt) => bt.module_usage(usage),
             TypeDomain(bt) => bt.module_usage(usage),
             _ => {}
+        }
+    }
+
+    pub fn into_struct_tag(self, env: &GlobalEnv) -> Option<StructTag> {
+        use Type::*;
+        if self.is_open() {
+            None
+        } else {
+            Some (
+                match self {
+		    Struct(mid, sid, ts) =>
+                        env.get_struct_tag(mid, sid, &ts)
+                            .expect("Invariant violation: struct type argument contains incomplete, tuple, reference, or spec type"),
+
+                    _ => return None
+		}
+	    )
         }
     }
 

--- a/language/move-prover/bytecode/src/access_path.rs
+++ b/language/move-prover/bytecode/src/access_path.rs
@@ -1,0 +1,746 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! This file contains an abstraction of concrete *access paths*, which are canonical names for a particular cell in
+//! memory. Some examples of concrete paths are:
+//! * `0x7/M::T/f` (i.e., the field `f` of the `M::T` resource stored at address `0x7`
+//! * `Formal(0)/[2]` (i.e., the value stored at index 2 of the array bound the 0th formal of the current procedure)
+//! An abstract path is similar; it consists of the following components:
+//! * A *root*, which is either an abstract address or a local
+//! * Zero or more *offsets*, where an offset is a field, an unknown vector index, or an abstract struct type
+//!
+//! Abstract addresses are a set containing constants and abstract access paths read from the environment. For example,
+//! in the following Move code:
+//!```ignore
+//! struct S { f: u64 }
+//!
+//! fun foo(x: S) {
+//!   let a = if (*) { 0x1 } else { *&x.f }
+//!    ... // program point 1
+//! }
+//!```
+//!, the value of `a` will be `{ 0x1, Footprint(x/f) }` at program point 1.
+
+use crate::{
+    dataflow_analysis::{AbstractDomain, SetDomain},
+    function_target::FunctionTarget,
+};
+use move_core_types::language_storage::StructTag;
+use move_model::{
+    ast::TempIndex,
+    model::{GlobalEnv, ModuleId, QualifiedId, StructId},
+    ty::{PrimitiveType, Type, TypeDisplayContext},
+};
+use num::BigUint;
+use std::{fmt, fmt::Formatter};
+
+type Address = BigUint;
+
+// =================================================================================================
+// Data Model
+
+/// Fully qualified type identifier `base` bound to type actuals `types`
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AbsStructType {
+    /// Module ID and struct ID
+    base: QualifiedId<StructId>,
+    /// Instantiation of generic type parameters
+    types: Vec<Type>,
+}
+
+/// Building block for abstraction of addresses
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Addr {
+    /// Account address constant
+    Constant(Address),
+    /// Account address read from given access path. This represents the value read from the given path at the beginning of
+    /// the current function
+    Footprint(AccessPath),
+}
+
+/// Abstraction of an address: non-empty set of constant or footprint address values
+pub type AbsAddr = SetDomain<Addr>;
+
+/// Abstraction of a key of type `addr`::`ty` in global storage
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct GlobalKey {
+    /// Account address of key
+    addr: AbsAddr,
+    /// Type of key
+    ty: AbsStructType,
+}
+
+/// Root of an access path: a global, local, or return variable
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Root {
+    /// A key in global storage
+    Global(GlobalKey), // TODO: this could (and maybe should) be AbsAddr + Offset::Global
+    /// A local variable or formal parameter
+    Local(TempIndex),
+    /// A return variable
+    Return(usize),
+}
+
+/// Offset of an access path: either a field, vector index, or global key
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Offset {
+    /// Index into contents of a struct by field offset
+    Field(usize),
+    /// Unknown index into a vector
+    VectorIndex,
+    /// A type index into global storage. Only follows a field or vector index of type address
+    Global(AbsStructType),
+}
+
+/// A unique identifier for a memory cell: root followed by zero or more offsets
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AccessPath {
+    root: Root,
+    offsets: Vec<Offset>,
+}
+
+// =================================================================================================
+// Abstract domain operations
+
+/// Trait for a domain that can be viewed as a partial map from access paths to values
+pub trait AccessPathMap<T: AbstractDomain> {
+    fn get_access_path(&self, ap: AccessPath) -> Option<&T>;
+}
+
+/// Trait for an abstract domain that can represent footprint values
+pub trait FootprintDomain: AbstractDomain {
+    /// Create a footprint value for access path `ap`
+    fn make_footprint(ap: AccessPath) -> Option<Self>;
+}
+
+impl Addr {
+    /// Create a constant address from concrete address `a`
+    pub fn constant(a: Address) -> Self {
+        Addr::Constant(a)
+    }
+
+    /// Create a footprint address from access path `ap`
+    pub fn footprint(ap: AccessPath) -> Self {
+        Self::Footprint(ap)
+    }
+
+    /// Return `true` if `self` is a constant
+    pub fn is_constant(&self) -> bool {
+        match self {
+            Self::Constant(_) => true,
+            Self::Footprint(_) => false,
+        }
+    }
+
+    /// Convert this address-typed abstract value A into an access path A/mid::sid::types
+    pub fn add_struct_offset(self, mid: &ModuleId, sid: StructId, types: Vec<Type>) -> AccessPath {
+        match self {
+            Self::Footprint(mut ap) => {
+                // TODO: assert type address?
+                ap.add_offset(Offset::global(mid, sid, types));
+                ap
+            }
+            Self::Constant(a) => AccessPath::new_address_constant(a, mid, sid, types),
+        }
+    }
+
+    /// Return a wrapper of `self` that implements `Display` using `env`
+    pub fn display<'a>(&'a self, env: &'a FunctionTarget) -> AddrDisplay<'a> {
+        AddrDisplay { addr: self, env }
+    }
+}
+
+impl AbsAddr {
+    /// Create a constant address from concrete address `a`
+    pub fn constant(a: Address) -> Self {
+        SetDomain::singleton(Addr::Constant(a))
+    }
+
+    /// Create a footprint address from access path `ap`
+    pub fn footprint(ap: AccessPath) -> Self {
+        SetDomain::singleton(Addr::Footprint(ap))
+    }
+
+    /// Create a footprint address read from formal `temp_index`
+    pub fn formal(formal_index: TempIndex) -> Self {
+        SetDomain::footprint(AccessPath::new_local(formal_index))
+    }
+
+    /// Return `true` if `self` is a constant
+    pub fn is_constant(&self) -> bool {
+        self.0.iter().all(|a| a.is_constant())
+    }
+
+    /// Substitute all occurences of Footprint(ap) in `self` by resolving the accesss path
+    /// `ap` in `sub_map`
+    pub fn substitute_footprint(
+        &mut self,
+        actuals: &[AbsAddr],
+        type_actuals: &[Type],
+        sub_map: &dyn AccessPathMap<AbsAddr>,
+    ) {
+        let mut acc = SetDomain::default();
+        for a in self.0.iter() {
+            match a {
+                Addr::Footprint(ap) => {
+                    acc.join(&ap.substitute_footprint(actuals, type_actuals, sub_map));
+                }
+                c => {
+                    acc.insert(c.clone());
+                }
+            }
+        }
+        *self = acc
+    }
+
+    /// Return a new abstract address by adding the offset `mid::sid<types>` to each element
+    /// of `self`
+    pub fn add_struct_offset(self, mid: &ModuleId, sid: StructId, types: Vec<Type>) -> Self {
+        let mut acc = Self::default();
+        for v in self.0.into_iter() {
+            acc.insert(Addr::Footprint(v.add_struct_offset(
+                mid,
+                sid,
+                types.clone(),
+            )));
+        }
+        acc
+    }
+
+    /// Return a new abstract address by adding the offset `offset` to each element of `self`
+    pub fn add_offset(&self, offset: Offset) -> Self {
+        let mut extended_aps: AbsAddr = AbsAddr::default();
+        for p in self.iter() {
+            match p {
+                Addr::Footprint(ap) => {
+                    let mut extended_ap = ap.clone();
+                    extended_ap.add_offset(offset.clone());
+                    extended_aps.insert(Addr::Footprint(extended_ap));
+                }
+                Addr::Constant(_) => {
+                    panic!("Type error: address constant as base")
+                }
+            }
+        }
+        extended_aps
+    }
+
+    /// Produce a new version of `self` with `prefix` prepended to each footprint
+    /// value
+    pub fn prepend(self, prefix: AccessPath) -> Self {
+        let mut acc = Self::default();
+        for v in self.0.into_iter() {
+            match v {
+                Addr::Footprint(ap) => {
+                    let mut new_ap = ap.clone();
+                    new_ap.prepend(prefix.clone());
+                    acc.insert(Addr::Footprint(new_ap));
+                }
+                a => {
+                    acc.insert(a);
+                }
+            }
+        }
+        acc
+    }
+
+    /// return an iterator over the footprint paths in `self`
+    pub fn footprint_paths(&self) -> impl Iterator<Item = &AccessPath> {
+        self.iter().filter_map(|a| match a {
+            Addr::Footprint(ap) => Some(ap),
+            Addr::Constant(_) => None,
+        })
+    }
+
+    /// Return a wrapper of `self` that implements `Display` using `env`
+    pub fn display<'a>(&'a self, env: &'a FunctionTarget) -> AbsAddrDisplay<'a> {
+        AbsAddrDisplay { addr: self, env }
+    }
+}
+
+impl FootprintDomain for AbsAddr {
+    fn make_footprint(ap: AccessPath) -> Option<Self> {
+        Some(AbsAddr::footprint(ap))
+    }
+}
+
+impl GlobalKey {
+    pub fn new(addr: AbsAddr, mid: &ModuleId, sid: StructId, types: Vec<Type>) -> Self {
+        Self {
+            addr,
+            ty: AbsStructType::new(mid, sid, types),
+        }
+    }
+
+    /// Create a constant `GlobalKey` using constant `addr` and type `ty`
+    pub fn constant(addr: BigUint, ty: AbsStructType) -> Self {
+        Self {
+            addr: AbsAddr::constant(addr),
+            ty,
+        }
+    }
+
+    /// Return true if the address and type parameters of this global key are known statically
+    pub fn is_statically_known(&self) -> bool {
+        self.addr.is_constant() && self.ty.is_closed()
+    }
+
+    /// Substitute all occurences of Footprint(ap) in `self.addr` by resolving the accesss path
+    /// `ap` in `sub_map`.
+    pub fn substitute_footprint(
+        &mut self,
+        actuals: &[AbsAddr],
+        type_actuals: &[Type],
+        sub_map: &dyn AccessPathMap<AbsAddr>,
+    ) {
+        self.addr
+            .substitute_footprint(actuals, type_actuals, sub_map);
+        self.ty.substitute_footprint(type_actuals);
+    }
+
+    /// Return a wrapper of `self` that implements `Display` using `env`
+    pub fn display<'a>(&'a self, env: &'a FunctionTarget) -> GlobalKeyDisplay<'a> {
+        GlobalKeyDisplay { g: self, env }
+    }
+}
+
+impl Root {
+    /// Create a `Root` from local variable `index`
+    pub fn local(index: TempIndex) -> Self {
+        Root::Local(index)
+    }
+
+    /// Create a `Root` from global storage key `key`
+    pub fn global(key: GlobalKey) -> Self {
+        Root::Global(key)
+    }
+
+    /// Create a `Root` from return variable `index`
+    pub fn ret(index: usize) -> Self {
+        Root::Return(index)
+    }
+
+    /// Return the type of `self` in `fun`
+    pub fn get_type(&self, fun: &FunctionTarget) -> Type {
+        match self {
+            Self::Global(g) => g.ty.get_type(),
+            Self::Local(i) => fun.get_local_type(*i).clone(),
+            Self::Return(i) => fun.get_return_type(*i).clone(),
+        }
+    }
+
+    /// Return true if this variable is a formal parameter of `fun`
+    pub fn is_formal(&self, fun: &FunctionTarget) -> bool {
+        match self {
+            Self::Local(i) => fun.func_env.is_parameter(*i),
+            Self::Global(_) => false,
+            Self::Return(_) => false,
+        }
+    }
+
+    /// Replace all footprint paths in `self` using `actuals` and `sub_map`.
+    /// Bind free type variables to `type_actuals`.
+    pub fn substitute_footprint(
+        &mut self,
+        actuals: &[AbsAddr],
+        type_actuals: &[Type],
+        sub_map: &dyn AccessPathMap<AbsAddr>,
+    ) {
+        match self {
+            Self::Global(g) => g.substitute_footprint(actuals, type_actuals, sub_map),
+            Self::Local(_) | Self::Return(_) => (),
+        }
+    }
+
+    /// Return a wrapper of `self` that implements `Display` using `env`
+    pub fn display<'a>(&'a self, env: &'a FunctionTarget) -> RootDisplay<'a> {
+        RootDisplay { root: self, env }
+    }
+}
+
+impl Offset {
+    pub fn global(mid: &ModuleId, sid: StructId, types: Vec<Type>) -> Self {
+        Offset::Global(AbsStructType::new(mid, sid, types))
+    }
+
+    pub fn field(f: usize) -> Self {
+        Offset::Field(f)
+    }
+
+    /// Get the type of offset `base`/`self` in function `fun`
+    pub fn get_type(&self, base: &Type, env: &GlobalEnv) -> Type {
+        match (base.skip_reference(), self) {
+            (Type::Struct(mid, sid, types), Offset::Field(f)) => {
+                let field_type = env
+                    .get_module(*mid)
+                    .get_struct(*sid)
+                    .get_field_by_offset(*f)
+                    .get_type();
+                field_type.instantiate(types)
+            }
+            (Type::Vector(t), Offset::VectorIndex) => (*t.clone()),
+            (Type::Primitive(PrimitiveType::Address), Offset::Global(s)) => s.get_type(),
+            (Type::Primitive(PrimitiveType::Signer), Offset::Global(s)) => {
+                // we conflate address and signer, so this can happen
+                s.get_type()
+            }
+            _ => panic!(
+                "Invalid base type {:?} for offset {:?} in get_type",
+                base, self
+            ),
+        }
+    }
+
+    /// Bind free type variables in `self` to `type_actuals`
+    pub fn substitute_footprint(&mut self, type_actuals: &[Type]) {
+        match self {
+            Offset::Global(g) => g.substitute_footprint(type_actuals),
+            Offset::Field(..) | Offset::VectorIndex => (),
+        }
+    }
+
+    /// Return true if this offset is the same in all concrete program executions
+    pub fn is_statically_known(&self) -> bool {
+        use Offset::*;
+        match self {
+            Field(..) => true,
+            Global(..) | VectorIndex => false,
+        }
+    }
+
+    /// Return a wrapper of `self` that implements `Display` using `env`
+    pub fn display<'a>(&'a self, base_type: &'a Type, env: &'a GlobalEnv) -> OffsetDisplay<'a> {
+        OffsetDisplay {
+            offset: self,
+            base_type,
+            env,
+        }
+    }
+}
+
+impl AccessPath {
+    pub fn new(root: Root, offsets: Vec<Offset>) -> Self {
+        AccessPath { root, offsets }
+    }
+
+    pub fn new_root(root: Root) -> Self {
+        AccessPath {
+            root,
+            offsets: vec![],
+        }
+    }
+
+    pub fn new_global(addr: AbsAddr, mid: &ModuleId, sid: StructId, types: Vec<Type>) -> Self {
+        Self::new_root(Root::Global(GlobalKey::new(addr, mid, sid, types)))
+    }
+
+    pub fn new_address_constant(
+        addr: BigUint,
+        mid: &ModuleId,
+        sid: StructId,
+        types: Vec<Type>,
+    ) -> Self {
+        Self::new_global(AbsAddr::constant(addr), mid, sid, types)
+    }
+
+    pub fn new_global_constant(addr: BigUint, ty: AbsStructType) -> Self {
+        Self::new_root(Root::Global(GlobalKey::constant(addr, ty)))
+    }
+
+    pub fn new_local(i: TempIndex) -> Self {
+        Self::new_root(Root::Local(i))
+    }
+
+    /// Unpack `self` into its root and offsets
+    pub fn into(self) -> (Root, Vec<Offset>) {
+        (self.root, self.offsets)
+    }
+
+    pub fn root(&self) -> &Root {
+        &self.root
+    }
+
+    pub fn offsets(&self) -> &[Offset] {
+        &self.offsets
+    }
+
+    /// extend this access path by adding offset `o` to the end
+    pub fn add_offset(&mut self, o: Offset) {
+        self.offsets.push(o)
+    }
+
+    /// Return the type of this access path
+    pub fn get_type(&self, fun: &FunctionTarget) -> Type {
+        let mut ty = self.root.get_type(fun);
+        for offset in &self.offsets {
+            let offset_ty = offset.get_type(&ty, fun.module_env().env);
+            ty = offset_ty;
+        }
+        ty
+    }
+
+    /// prepend `prefix` to self by swapping `self`'s root for prefix.root and
+    /// replacing `self`'s accesses with prefix.accesses :: self.accesses
+    pub fn prepend(&mut self, prefix: Self) {
+        // TODO: assert root is a formal
+        self.root = prefix.root;
+        let mut suffix_offsets = self.offsets.clone();
+        self.offsets = prefix.offsets;
+        self.offsets.append(&mut suffix_offsets)
+    }
+
+    /// Construct a new abstract address by prepending the addresses in `addrs` to `self`
+    pub fn prepend_addrs(&self, addrs: &AbsAddr) -> AbsAddr {
+        let mut acc = AbsAddr::default();
+        for a in addrs.iter() {
+            match a {
+                Addr::Footprint(ap) => {
+                    let mut new_ap = self.clone();
+                    new_ap.prepend(ap.clone());
+                    acc.insert(Addr::footprint(new_ap));
+                }
+                Addr::Constant(c) => {
+                    if self.offsets.is_empty() {
+                        acc.insert(Addr::constant(c.clone()));
+                    } else {
+                        // access path with constant base and offsets (e.g., 0x1/M::S/f/g)
+                        // normalize by converting into a path with a global base instead
+                        match &self.offsets[0] {
+                            Offset::Global(struct_type) => {
+                                let root = Root::Global(GlobalKey::constant(
+                                    c.clone(),
+                                    struct_type.clone(),
+                                ));
+                                let mut new_offsets = vec![];
+                                for v in self.offsets.iter().skip(0) {
+                                    new_offsets.push(v.clone())
+                                }
+                                acc.insert(Addr::footprint(AccessPath::new(root, new_offsets)));
+                            }
+                            _ => panic!(
+                                "Invariant violation: constant root with bad offsets {:?}",
+                                self.offsets
+                            ),
+                        }
+                    }
+                }
+            }
+        }
+        acc
+    }
+
+    /// Replace all footprint paths in `self` using `actuals` and `sub_map`.
+    /// Bind free type variables to `type_actuals`.
+    pub fn substitute_footprint(
+        &self,
+        actuals: &[AbsAddr],
+        type_actuals: &[Type],
+        sub_map: &dyn AccessPathMap<AbsAddr>,
+    ) -> AbsAddr {
+        let mut acc = AbsAddr::default();
+        match &self.root {
+            Root::Local(i) => {
+                acc.join(&self.prepend_addrs(&actuals[*i]));
+            }
+            Root::Global(g) => {
+                let mut new_g = g.clone();
+                new_g.substitute_footprint(actuals, type_actuals, sub_map);
+                let mut new_offsets = self.offsets.clone();
+                new_offsets.iter_mut().for_each(|o| {
+                    o.substitute_footprint(type_actuals);
+                });
+                acc.insert(Addr::footprint(AccessPath::new(
+                    Root::Global(new_g),
+                    new_offsets,
+                )));
+            }
+            Root::Return(_) => (),
+        }
+        acc
+    }
+
+    /// Return a wrapper of `self` that implements `Display` using `env`
+    pub fn display<'a>(&'a self, env: &'a FunctionTarget) -> AccessPathDisplay<'a> {
+        AccessPathDisplay { ap: self, env }
+    }
+}
+
+impl AbsStructType {
+    pub fn new(mid: &ModuleId, sid: StructId, types: Vec<Type>) -> Self {
+        AbsStructType {
+            base: mid.qualified(sid),
+            types,
+        }
+    }
+
+    /// Return the concrete type of `self`
+    pub fn get_type(&self) -> Type {
+        Type::Struct(self.base.module_id, self.base.id, self.types.clone())
+    }
+
+    /// Substitue the open types in self.types with caller `type_actuals`
+    pub fn substitute_footprint(&mut self, type_actuals: &[Type]) {
+        for t in self.types.iter_mut() {
+            *t = t.instantiate(type_actuals)
+        }
+    }
+
+    /// Returns a normalized representation of this type if it closed,
+    /// None if it is open
+    pub fn normalize(&self, env: &GlobalEnv) -> Option<StructTag> {
+        self.get_type().into_struct_tag(env)
+    }
+
+    /// Return `true` if `self` has no type variables or if all of `self`'s type variables are bound
+    pub fn is_closed(&self) -> bool {
+        self.types.iter().all(|t| t.is_open())
+    }
+
+    /// Return a wrapper of `self` that implements `Display` using `env`
+    pub fn display<'a>(&'a self, env: &'a GlobalEnv) -> AbsStructTypeDisplay<'a> {
+        AbsStructTypeDisplay { s: self, env }
+    }
+}
+
+// =================================================================================================
+// Formatting
+
+pub struct AbsStructTypeDisplay<'a> {
+    s: &'a AbsStructType,
+    env: &'a GlobalEnv,
+}
+
+impl<'a> fmt::Display for AbsStructTypeDisplay<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self.s.normalize(self.env) {
+            Some(t) => {
+                write!(f, "{}", t)
+            }
+            None => {
+                let tctx = TypeDisplayContext::WithEnv {
+                    env: self.env,
+                    type_param_names: None,
+                };
+                let dummy_type =
+                    Type::Struct(self.s.base.module_id, self.s.base.id, self.s.types.clone());
+                write!(f, "{}", dummy_type.display(&tctx))
+            }
+        }
+    }
+}
+
+pub struct AddrDisplay<'a> {
+    addr: &'a Addr,
+    env: &'a FunctionTarget<'a>,
+}
+
+impl<'a> fmt::Display for AddrDisplay<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self.addr {
+            Addr::Constant(a) => write!(f, "{:#x}", a),
+            Addr::Footprint(ap) => write!(f, "{}", ap.display(self.env)),
+        }
+    }
+}
+
+pub struct AbsAddrDisplay<'a> {
+    addr: &'a AbsAddr,
+    env: &'a FunctionTarget<'a>,
+}
+
+impl<'a> fmt::Display for AbsAddrDisplay<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        if self.addr.len() == 1 {
+            write!(f, "{}", self.addr.iter().next().unwrap().display(self.env))
+        } else {
+            f.write_str("{")?;
+            for a in self.addr.iter() {
+                write!(f, "{}", a.display(self.env))?;
+                // TODO: nice comma-separated list
+                f.write_str(", ")?;
+            }
+            f.write_str("}")
+        }
+    }
+}
+
+pub struct GlobalKeyDisplay<'a> {
+    g: &'a GlobalKey,
+    env: &'a FunctionTarget<'a>,
+}
+
+impl<'a> fmt::Display for GlobalKeyDisplay<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}/{}",
+            self.g.addr.display(self.env),
+            self.g.ty.display(self.env.module_env().env)
+        )
+    }
+}
+
+pub struct RootDisplay<'a> {
+    root: &'a Root,
+    env: &'a FunctionTarget<'a>,
+}
+
+impl<'a> fmt::Display for RootDisplay<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self.root {
+            Root::Global(g) => write!(f, "{}", g.display(self.env)),
+            Root::Local(i) => write!(f, "Loc({})", i), // TODO: print name if available
+            Root::Return(i) => write!(f, "Ret({})", i),
+        }
+    }
+}
+
+pub struct OffsetDisplay<'a> {
+    offset: &'a Offset,
+    base_type: &'a Type,
+    env: &'a GlobalEnv,
+}
+
+impl<'a> fmt::Display for OffsetDisplay<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        use Offset::*;
+        match self.offset {
+            Field(fld) => match self.base_type.skip_reference() {
+                Type::Struct(mid, sid, _types) => f.write_str(
+                    self.env
+                        .get_module(*mid)
+                        .get_struct(*sid)
+                        .get_field_by_offset(*fld)
+                        .get_identifier()
+                        .as_str(),
+                ),
+                _ => panic!(
+                    "Invalid base type {:?} for field offset {:?}",
+                    self.base_type, self.offset
+                ),
+            },
+            VectorIndex => f.write_str("[_]"),
+            Global(g) => write!(f, "{}", g.display(self.env)),
+        }
+    }
+}
+
+pub struct AccessPathDisplay<'a> {
+    ap: &'a AccessPath,
+    env: &'a FunctionTarget<'a>,
+}
+
+impl<'a> fmt::Display for AccessPathDisplay<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let genv = self.env.func_env.module_env.env;
+        write!(f, "{}", self.ap.root.display(self.env))?;
+        let mut root_ty = self.ap.root.get_type(self.env);
+        for offset in &self.ap.offsets {
+            f.write_str("/")?;
+            write!(f, "{}", offset.display(&root_ty, genv))?;
+            let offset_ty = offset.get_type(&root_ty, genv);
+            root_ty = offset_ty;
+        }
+        Ok(())
+    }
+}

--- a/language/move-prover/bytecode/src/access_path_trie.rs
+++ b/language/move-prover/bytecode/src/access_path_trie.rs
@@ -1,0 +1,424 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! The obvious approach to abstracting a set of concrete paths is using a set of abstract paths.
+//! An access path trie represents a set of paths in a way that avoids redundant representations of
+//! the same memory. Root nodes are access path roots and each internal node is an access path offset.
+//! Each node is (optionally) associated with abstract value of a generic type `T`.
+
+use crate::{
+    access_path::{AbsAddr, AccessPath, AccessPathMap, FootprintDomain, Offset, Root},
+    dataflow_analysis::{AbstractDomain, JoinResult, MapDomain},
+    function_target::FunctionTarget,
+};
+use move_model::{ast::TempIndex, ty::Type};
+use std::{
+    collections::btree_map::Entry,
+    fmt,
+    fmt::Formatter,
+    ops::{Deref, DerefMut},
+};
+
+// =================================================================================================
+// Data model
+
+/// A node in the access Trie: `data` associated with the parent node + `children` mapping offsets to child nodes
+#[derive(Debug, Clone, PartialOrd, PartialEq, Eq)]
+pub struct TrieNode<T: FootprintDomain> {
+    /// Optional data associated with the parent in the trie
+    data: Option<T>,
+    /// Child pointers labeled by offsets
+    children: MapDomain<Offset, TrieNode<T>>,
+}
+
+/// Set of (root node, child) associations
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd)]
+pub struct AccessPathTrie<T: FootprintDomain>(MapDomain<Root, TrieNode<T>>);
+
+// =================================================================================================
+// Abstract domain operations
+
+impl<T: FootprintDomain> TrieNode<T> {
+    pub fn new(data: T) -> Self {
+        TrieNode {
+            data: Some(data),
+            children: MapDomain::default(),
+        }
+    }
+
+    pub fn new_opt(data: Option<T>) -> Self {
+        TrieNode {
+            data,
+            children: MapDomain::default(),
+        }
+    }
+
+    /// Like join, but gracefully handles `Non` data fields by treating None as Bottom
+    pub fn join_data_opt(&mut self, other: &Option<T>) -> JoinResult {
+        match (&mut self.data, other) {
+            (Some(data1), Some(data2)) => data1.join(data2),
+            (None, Some(data)) => {
+                self.data = Some(data.clone());
+                JoinResult::Changed
+            }
+            (_, None) => JoinResult::Unchanged,
+        }
+    }
+
+    pub fn data(&self) -> &Option<T> {
+        &self.data
+    }
+
+    pub fn children(&self) -> &MapDomain<Offset, TrieNode<T>> {
+        &self.children
+    }
+
+    pub fn entry(&mut self, o: Offset) -> Entry<Offset, TrieNode<T>> {
+        self.children.entry(o)
+    }
+
+    /// Return the node mapped to `o` from self (if any)
+    pub fn get_offset(&self, o: &Offset) -> Option<&Self> {
+        self.children.get(o)
+    }
+
+    /// Bind caller data in `actuals`, `type_actuals`, and `sub_map` to `self`.
+    /// (1) Bind all free type variables in `self` to `type_actuals`
+    /// (2) Apply `sub_data` to `self.data` and (recursively) to the `data` fields of `self.children`
+    pub fn substitute_footprint<F>(
+        mut self,
+        actuals: &[AbsAddr],
+        type_actuals: &[Type],
+        sub_map: &dyn AccessPathMap<AbsAddr>,
+        mut sub_data: F,
+    ) -> Self
+    where
+        F: FnMut(&mut T, &[AbsAddr], &[Type], &dyn AccessPathMap<AbsAddr>) + Copy,
+    {
+        match &mut self.data {
+            Some(d) => sub_data(d, actuals, type_actuals, sub_map),
+            None => (),
+        }
+        let mut acc = Self::new_opt(self.data);
+        for (mut k, v) in self.children.0.into_iter() {
+            k.substitute_footprint(type_actuals);
+            acc.children.insert_join(
+                k,
+                v.substitute_footprint(actuals, type_actuals, sub_map, sub_data),
+            )
+        }
+        acc
+    }
+
+    /// Apply `f` to each node in `self`
+    pub fn iter_values<F>(&mut self, f: F)
+    where
+        F: FnMut(&mut TrieNode<T>) + Copy,
+    {
+        for (_k, v) in self.children.iter_mut() {
+            v.iter_values(f)
+        }
+    }
+
+    /// Apply `f` to all (access path, Option<data>) pairs encoded in `self`
+    fn iter_paths_opt<F>(&self, ap: &AccessPath, mut f: F) -> F
+    where
+        F: FnMut(&AccessPath, &Option<&T>),
+    {
+        f(ap, &self.data.as_ref());
+        for (k, v) in self.children.iter() {
+            let mut new_ap = ap.clone();
+            new_ap.add_offset(k.clone());
+            f = v.iter_paths_opt(&new_ap, f)
+        }
+        // have to thread F through to avoid constraining it with Copy
+        f
+    }
+}
+
+impl<T: FootprintDomain> AbstractDomain for TrieNode<T> {
+    fn join(&mut self, other: &Self) -> JoinResult {
+        let data_result = self.join_data_opt(&other.data);
+        let children_result = self.children.join(&other.children);
+        if data_result == JoinResult::Unchanged && children_result == JoinResult::Unchanged {
+            JoinResult::Unchanged
+        } else {
+            JoinResult::Changed
+        }
+    }
+}
+
+impl<T: FootprintDomain> AbstractDomain for AccessPathTrie<T> {
+    fn join(&mut self, other: &Self) -> JoinResult {
+        if self == other {
+            return JoinResult::Unchanged;
+        }
+        let mut acc = AccessPathTrie::default();
+        acc.join_footprint(self, other);
+        acc.join_footprint(other, self);
+        *self = acc;
+        JoinResult::Changed
+    }
+}
+
+impl<T: FootprintDomain> AccessPathMap<T> for AccessPathTrie<T> {
+    fn get_access_path(&self, ap: AccessPath) -> Option<&T> {
+        match self.get_node(ap) {
+            Some(n) => n.data.as_ref(),
+            None => None,
+        }
+    }
+}
+
+impl<T: FootprintDomain> AccessPathTrie<T> {
+    fn join_footprint(&mut self, t1: &Self, t2: &Self) {
+        t1.iter_paths_opt(|ap, data1_opt| {
+            let data2_opt = t2.get_access_path(ap.clone());
+            match (*data1_opt, data2_opt) {
+                (Some(data1), Some(data2)) => {
+                    let mut new_data = data1.clone();
+                    new_data.join(&data2);
+                    self.update_access_path_weak(ap.clone(), Some(new_data));
+                }
+                (None, Some(data)) | (Some(data), None) => {
+                    let mut new_data = data.clone();
+                    if let Some(footprint) = T::make_footprint(ap.clone()) {
+                        new_data.join(&footprint);
+                    }
+                    self.update_access_path_weak(ap.clone(), Some(new_data));
+                }
+                (None, None) => (),
+            }
+        })
+    }
+
+    fn get_node(&self, ap: AccessPath) -> Option<&TrieNode<T>> {
+        let mut node = match self.0.get(ap.root()) {
+            Some(n) => n,
+            None => return None,
+        };
+        for offset in ap.offsets() {
+            node = match node.get_offset(offset) {
+                Some(n) => n,
+                None => return None,
+            }
+        }
+        Some(node)
+    }
+
+    /// Like `update_access_path`, but always performs a weak update
+    pub fn update_access_path_weak(&mut self, ap: AccessPath, data: Option<T>) {
+        self.update_access_path_(ap, TrieNode::new_opt(data), true)
+    }
+
+    /// Update `ap` in `global`.
+    /// Performs a strong update if the base of `ap` is a local and all offsets are Field's.
+    /// Otherwise, performs a weak update (TODO: more details).
+    /// Creates nodes for each offset in `ap` if they do not already exist
+    pub fn update_access_path(&mut self, ap: AccessPath, data: Option<T>) {
+        self.update_access_path_(ap, TrieNode::new_opt(data), false)
+    }
+
+    /// Join the value bound to `ap` with `node`
+    pub fn join_access_path(&mut self, ap: AccessPath, node: TrieNode<T>) {
+        self.update_access_path_(ap, node, true)
+    }
+
+    /// Update the value bound to `ap` with `new_node`.
+    /// If `weak_update` is true, do this by joining `new_node` with the old value`
+    /// If `weak_update` is false, attempt to replace the old value with `new_node`.
+    /// However, this may still result in a weak update if `ap` does not permit a strong
+    /// update (e.g., if it contains a vector index)
+    fn update_access_path_(
+        &mut self,
+        ap: AccessPath,
+        new_node: TrieNode<T>,
+        mut weak_update: bool,
+    ) {
+        let (root, offsets) = ap.into();
+        let key = match root {
+            Root::Local(i) =>
+            // local base. strong update possible because of Move aliasing semantics
+            {
+                Root::local(i)
+            }
+            Root::Global(g) =>
+            // global base. must do weak update unless g is statically known
+            {
+                weak_update = weak_update || !g.is_statically_known();
+                Root::global(g)
+            }
+            Root::Return(_) => panic!("Invalid: updating return"),
+        };
+
+        let mut node = self.0.entry(key).or_insert_with(TrieNode::default);
+        for offset in offsets.into_iter() {
+            // if one of the offsets is not statically known, we must do a weak update
+            weak_update = weak_update || !offset.is_statically_known();
+            node = node.entry(offset).or_insert_with(TrieNode::default);
+        }
+        if weak_update {
+            node.join(&new_node);
+        } else {
+            // strong update; overwrite data
+            *node = new_node
+        }
+    }
+
+    /// Bind `data` to `local_index` in the trie, overwriting the old value of `local_index`
+    pub fn bind_local(&mut self, local_index: TempIndex, data: T) {
+        self.bind_root(Root::local(local_index), data)
+    }
+
+    /// Bind `node` to `local_index` in the trie, overwriting the old value of `local_index`
+    pub fn bind_local_node(&mut self, local_index: TempIndex, node: TrieNode<T>) {
+        self.0.insert(Root::local(local_index), node);
+    }
+
+    /// Remove the value bound to the local variable `local_index`
+    pub fn remove_local(&mut self, local_index: TempIndex) {
+        self.0.remove(&Root::Local(local_index));
+    }
+
+    /// Bind `data` to the return variable `return_index`
+    pub fn bind_return(&mut self, return_index: usize, data: T) {
+        self.bind_root(Root::ret(return_index), data)
+    }
+
+    fn bind_root(&mut self, root: Root, data: T) {
+        self.0.insert(root, TrieNode::new(data));
+    }
+
+    /// Retrieve the data associated with `local_index` in the trie. Returns `None` if there is no associated data
+    pub fn get_local(&self, local_index: TempIndex) -> Option<&T> {
+        self.get_local_node(local_index)
+            .map(|n| n.data.as_ref())
+            .flatten()
+    }
+
+    /// Retrieve the node associated with `local_index` in the trie. Returns `None` if there is no associated node
+    pub fn get_local_node(&self, local_index: TempIndex) -> Option<&TrieNode<T>> {
+        self.0.get(&Root::local(local_index))
+    }
+
+    /// Return `true` if there is a value bound to local variable `local_index`
+    pub fn local_exists(&self, local_index: TempIndex) -> bool {
+        self.0.contains_key(&Root::local(local_index))
+    }
+
+    /// Bind caller data in `actuals`, `type_actuals`, and `sub_map` to `self`.
+    /// (1) Bind all free type variables in `self` to `type_actuals`
+    /// (2) Apply `sub_data` to `self.data` and (recursively) to the `data` fields of `self.children`
+    pub fn substitute_footprint<F>(
+        self,
+        actuals: &[AbsAddr],
+        type_actuals: &[Type],
+        sub_map: &dyn AccessPathMap<AbsAddr>,
+        sub_data: F,
+    ) -> Self
+    where
+        F: FnMut(&mut T, &[AbsAddr], &[Type], &dyn AccessPathMap<AbsAddr>) + Copy,
+    {
+        let mut acc = Self::default();
+        for (mut k, v) in self.0 .0.into_iter() {
+            k.substitute_footprint(actuals, type_actuals, sub_map);
+            let new_v = v.substitute_footprint(actuals, type_actuals, sub_map, sub_data);
+            acc.0.insert_join(k, new_v)
+        }
+        acc
+    }
+
+    /// Same as `substitute_footprint`, but does not change the `data` field of any node
+    pub fn substitute_footprint_skip_data(
+        self,
+        actuals: &[AbsAddr],
+        type_actuals: &[Type],
+        sub_map: &dyn AccessPathMap<AbsAddr>,
+    ) -> Self {
+        // TODO: is there a less hacky way to do this?
+        fn no_op<T>(_: &mut T, _: &[AbsAddr], _: &[Type], _: &dyn AccessPathMap<AbsAddr>) {}
+        self.substitute_footprint(actuals, type_actuals, sub_map, no_op)
+    }
+
+    /// Apply `f` to each node in `self`
+    pub fn iter_values<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&mut TrieNode<T>) + Copy,
+    {
+        for (_, mut node) in self.0.iter_mut() {
+            f(&mut node);
+            node.iter_values(f)
+        }
+    }
+
+    /// Apply `f` to each (access path, Option(data)) pair encoded in `self`
+    pub fn iter_paths_opt<F>(&self, mut f: F)
+    where
+        F: FnMut(&AccessPath, &Option<&T>),
+    {
+        for (root, node) in self.0.iter() {
+            let ap = AccessPath::new_root(root.clone());
+            f = node.iter_paths_opt(&ap, f)
+        }
+    }
+
+    /// Apply `f` to each (access path, data) pair encoded in `self`
+    pub fn iter_paths<F>(&self, mut f: F)
+    where
+        F: FnMut(&AccessPath, &T),
+    {
+        self.iter_paths_opt(|ap, t_opt| {
+            t_opt.map(|t| f(ap, t));
+        })
+    }
+
+    /// Return a wrapper that of `self` that implements `Display` using `env`
+    pub fn display<'a>(&'a self, env: &'a FunctionTarget) -> AccessPathTrieDisplay<'a, T> {
+        AccessPathTrieDisplay { t: self, env }
+    }
+}
+
+// =================================================================================================
+// Boilerplate traits and formatting
+
+impl<T: FootprintDomain> Default for TrieNode<T> {
+    fn default() -> Self {
+        TrieNode {
+            data: None,
+            children: MapDomain::default(),
+        }
+    }
+}
+
+impl<T: FootprintDomain> Default for AccessPathTrie<T> {
+    fn default() -> Self {
+        AccessPathTrie(MapDomain::default())
+    }
+}
+
+impl<T: FootprintDomain> Deref for AccessPathTrie<T> {
+    type Target = MapDomain<Root, TrieNode<T>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T: FootprintDomain> DerefMut for AccessPathTrie<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+pub struct AccessPathTrieDisplay<'a, T: FootprintDomain> {
+    t: &'a AccessPathTrie<T>,
+    env: &'a FunctionTarget<'a>,
+}
+
+impl<'a, T: FootprintDomain> fmt::Display for AccessPathTrieDisplay<'a, T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.t
+            .iter_paths(|path, v| writeln!(f, "{}: {:?}", path.display(self.env), v).unwrap());
+        Ok(())
+    }
+}

--- a/language/move-prover/bytecode/src/function_target.rs
+++ b/language/move-prover/bytecode/src/function_target.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     annotations::Annotations,
-    borrow_analysis, livevar_analysis, reaching_def_analysis,
+    borrow_analysis, livevar_analysis, reaching_def_analysis, read_write_set_analysis,
     stackless_bytecode::{AttrId, Bytecode},
 };
 use itertools::Itertools;
@@ -235,6 +235,11 @@ impl<'env> FunctionTarget<'env> {
         self.func_env.get_local_count()
     }
 
+    /// Return an iterator over the non-parameter local variables of this function
+    pub fn get_non_parameter_locals(&self) -> Range<usize> {
+        self.get_parameter_count()..self.get_local_count()
+    }
+
     /// Returns true if the index is for a temporary, not user declared local.
     pub fn is_temporary(&self, idx: usize) -> bool {
         self.func_env.is_temporary(idx)
@@ -455,6 +460,9 @@ impl<'env> FunctionTarget<'env> {
         self.register_annotation_formatter(Box::new(borrow_analysis::format_borrow_annotation));
         self.register_annotation_formatter(Box::new(
             reaching_def_analysis::format_reaching_def_annotation,
+        ));
+        self.register_annotation_formatter(Box::new(
+            read_write_set_analysis::format_read_write_set_annotation,
         ));
     }
 }

--- a/language/move-prover/bytecode/src/lib.rs
+++ b/language/move-prover/bytecode/src/lib.rs
@@ -6,6 +6,8 @@
 use crate::function_target_pipeline::FunctionTargetsHolder;
 use move_model::model::GlobalEnv;
 
+pub mod access_path;
+pub mod access_path_trie;
 pub mod annotations;
 pub mod borrow_analysis;
 pub mod borrow_analysis_v2;
@@ -27,6 +29,7 @@ pub mod memory_instrumentation_v2;
 pub mod options;
 pub mod packed_types_analysis;
 pub mod reaching_def_analysis;
+pub mod read_write_set_analysis;
 pub mod spec_instrumentation;
 mod spec_translator;
 pub mod stackless_bytecode;

--- a/language/move-prover/bytecode/src/packed_types_analysis.rs
+++ b/language/move-prover/bytecode/src/packed_types_analysis.rs
@@ -6,7 +6,7 @@ use crate::{
     dataflow_analysis::{
         AbstractDomain, DataflowAnalysis, JoinResult, SetDomain, TransferFunctions,
     },
-    function_target::FunctionData,
+    function_target::{FunctionData, FunctionTarget},
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant},
     stackless_bytecode::{Bytecode, Operation},
 };
@@ -151,7 +151,11 @@ impl<'a> TransferFunctions for PackedTypesAnalysis<'a> {
 
 impl<'a> DataflowAnalysis for PackedTypesAnalysis<'a> {}
 impl<'a> CompositionalAnalysis<PackedTypesState> for PackedTypesAnalysis<'a> {
-    fn to_summary(&self, state: PackedTypesState) -> PackedTypesState {
+    fn to_summary(
+        &self,
+        state: PackedTypesState,
+        _fun_target: &FunctionTarget,
+    ) -> PackedTypesState {
         state
     }
 }

--- a/language/move-prover/bytecode/src/read_write_set_analysis.rs
+++ b/language/move-prover/bytecode/src/read_write_set_analysis.rs
@@ -1,0 +1,645 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! The read/write set analysis is a compositional analysis that starts from the leaves of the
+//! call graph and analyzes each procedure once. The result is a summary of the abstract paths
+//! read/written by each procedure and the value(s) returned by the procedure.
+//!
+//! When the analysis encounters a call, it fetches the summary for the callee and applies it to the
+//! current state. This logic (implemented in `apply_summary`) is by far the most complex part of the
+//! analysis.
+
+use crate::{
+    access_path::{AbsAddr, AccessPath, Addr, FootprintDomain, Offset, Root},
+    access_path_trie::AccessPathTrie,
+    compositional_analysis::{CompositionalAnalysis, SummaryCache},
+    dataflow_analysis::{AbstractDomain, DataflowAnalysis, JoinResult, TransferFunctions},
+    function_target::{FunctionData, FunctionTarget},
+    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant},
+    stackless_bytecode::{Bytecode, Constant, Operation},
+};
+use move_model::{
+    ast::TempIndex,
+    model::{FunctionEnv, GlobalEnv, ModuleId, StructId},
+    ty::Type,
+};
+use std::{cmp::Ordering, fmt, fmt::Formatter};
+use vm::file_format::CodeOffset;
+
+// =================================================================================================
+// Data Model
+
+/// An access to local or global state
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum Access {
+    /// Not read or written; only accessed via a field borrow &, Vector::borrow, or borrow_global
+    /// E.g., in *&x.f.g = 7, f is Borrow, g is Write
+    Borrow,
+    /// Read via RHS * or exists
+    Read,
+    /// Written via LHS *, move_to, or move_from
+    Write,
+    /// Could be read, written, or borrowed
+    ReadWriteBorrow,
+}
+
+/// A record of the glocals and locals accessed by the current procedure + the address values stored
+/// by locals or globals
+#[derive(Debug, Clone, Eq, PartialOrd, PartialEq)]
+struct ReadWriteSetState {
+    /// memory accessed so far
+    accesses: AccessPathTrie<Access>,
+    /// mapping from locals to formal or global roots
+    locals: AccessPathTrie<AbsAddr>,
+}
+
+// =================================================================================================
+// Abstract Domain Operations
+
+impl ReadWriteSetState {
+    /// Aplly `callee_summary` to the caller state in `self`. There are three steps.
+    /// 1. Substitute footprint values in the callee summary with their values in the caller state (including both actuals and values read from globals)
+    /// 2. Bind return values in the callee summary to the return variables in the caller state
+    /// 3. Join caller accesses and callee accesses
+    pub fn apply_summary(
+        &mut self, // caller state
+        callee_summary_: &Self,
+        actuals: &[TempIndex],
+        type_actuals: &[Type],
+        returns: &[TempIndex],
+    ) {
+        // TODO: refactor this to work without copies
+        let callee_summary = callee_summary_.clone();
+        let actual_values: Vec<AbsAddr> = actuals
+            .iter()
+            .map(|i| self.locals.get_local(*i).cloned().unwrap_or_default())
+            .collect();
+        // (1) bind all footprint values and types in callee locals to their caller values
+        let mut new_callee_locals = callee_summary.locals.substitute_footprint(
+            &actual_values,
+            type_actuals,
+            &self.locals,
+            AbsAddr::substitute_footprint,
+        );
+        // (2) bind all footprint values and types in callee accesses to their caller values
+        let mut new_callee_accesses = callee_summary.accesses.substitute_footprint_skip_data(
+            &actual_values,
+            type_actuals,
+            &self.locals,
+        );
+        // (3) bind footprint paths in callee accesses with their caller values
+        for (i, actual_v) in actual_values.iter().enumerate() {
+            let formal_i = Root::Local(i);
+            if let Some(node) = new_callee_accesses.0.remove(&formal_i) {
+                let formal_ap = AccessPath::new(formal_i, vec![]);
+                for v in formal_ap.prepend_addrs(actual_v).iter() {
+                    match v {
+                        Addr::Footprint(ap) => {
+                            self.accesses.join_access_path(ap.clone(), node.clone())
+                        }
+                        Addr::Constant(c) => {
+                            for (offset, child) in node.children().iter() {
+                                match offset {
+                                    Offset::Global(g) => {
+                                        // create new root out of c/g, add c/g/child to summary
+                                        self.accesses.join_access_path(
+                                            AccessPath::new_global_constant(c.clone(), g.clone()),
+                                            child.clone(),
+                                        )
+                                    }
+                                    o => panic!("Bad offset type {:?} for address base", o),
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        // (4) bind return values in caller locals
+        for (i, ret) in returns.iter().enumerate() {
+            let retvar_i = Root::Return(i);
+            if let Some(node) = new_callee_locals.0.remove(&retvar_i) {
+                self.locals.bind_local_node(*ret, node)
+            }
+        }
+        // (5) join caller and callee accesses
+        // TODO: can we do a strong update here in some cases?
+        self.accesses.join(&new_callee_accesses);
+    }
+
+    /// Copy the contents of `rhs_index` into `lhs_index`. Fails if `rhs_index` is not bound
+    pub fn copy_local(&mut self, lhs_index: TempIndex, rhs_index: TempIndex) {
+        let rhs_value = self
+            .locals
+            .get_local(rhs_index)
+            .unwrap_or_else(|| panic!("Unbound local {:?}", rhs_index))
+            .clone();
+        self.locals.bind_local(lhs_index, rhs_value)
+    }
+
+    /// Return the local access paths rooted in `addr_idx`/`mid`::`sid`<`types`>
+    fn get_global_paths(
+        &self,
+        addr_idx: TempIndex,
+        mid: &ModuleId,
+        sid: StructId,
+        types: &[Type],
+    ) -> Vec<AccessPath> {
+        let mut acc = vec![];
+        for v in self
+            .locals
+            .get_local(addr_idx)
+            .unwrap_or_else(|| panic!("Untracked local {:?} of address type", addr_idx))
+            .iter()
+        {
+            acc.push(v.clone().add_struct_offset(mid, sid, types.to_vec()))
+        }
+        acc
+    }
+
+    /// Remove the local access paths rooted `addr_idx`/`mid`::`sid`<`types`>
+    pub fn remove_global(
+        &mut self,
+        addr_idx: TempIndex,
+        mid: &ModuleId,
+        sid: StructId,
+        types: &[Type],
+    ) {
+        for ap in self.get_global_paths(addr_idx, mid, sid, types) {
+            self.locals.update_access_path(ap, None)
+        }
+    }
+
+    /// Record an access of type `access` to the path `local_idx`/`mid`::`sid`<`types`>
+    fn add_global_access(
+        &mut self,
+        local_idx: TempIndex,
+        mid: &ModuleId,
+        sid: StructId,
+        types: &[Type],
+        access: Access,
+    ) {
+        for ap in self.get_global_paths(local_idx, mid, sid, types) {
+            self.accesses.update_access_path_weak(ap, Some(access))
+        }
+    }
+
+    /// Record an access of type `access` to the local variable `local_idx`
+    fn record_access(&mut self, local_idx: TempIndex, access: Access) {
+        for p in self
+            .locals
+            .get_local(local_idx)
+            .expect("Unbound local")
+            .iter()
+        {
+            if let Addr::Footprint(ap) = p {
+                self.accesses.update_access_path(ap.clone(), Some(access))
+            }
+        }
+    }
+
+    /// Record an access of type `access_type` to the path `base`/`offset`
+    pub fn access_offset(&mut self, base: TempIndex, offset: Offset, access_type: Access) {
+        let borrowed = self.locals.get_local(base).expect("Unbound local").clone();
+        let extended_aps = borrowed.add_offset(offset);
+        for ap in extended_aps.footprint_paths() {
+            self.accesses
+                .update_access_path(ap.clone(), Some(access_type))
+        }
+    }
+
+    /// Assign `ret` = `base`/`offset` and record an access of type `access_type` to `base`/`offset`
+    pub fn assign_offset(
+        &mut self,
+        ret: TempIndex,
+        base: TempIndex,
+        offset: Offset,
+        access_type: Access,
+    ) {
+        let borrowed = self.locals.get_local(base).expect("Unbound local").clone();
+        let extended_aps = borrowed.add_offset(offset);
+        for ap in extended_aps.footprint_paths() {
+            self.locals
+                .update_access_path(ap.clone(), Some(AbsAddr::footprint(ap.clone())));
+            self.accesses
+                .update_access_path(ap.clone(), Some(access_type))
+        }
+        self.locals.bind_local(ret, extended_aps)
+    }
+
+    /// Write rh
+    pub fn write_ref(&mut self, lhs_ref: TempIndex, rhs: TempIndex) {
+        if let Some(rhs_val) = self.locals.get_local(rhs).cloned() {
+            let lhs_paths = self
+                .locals
+                .get_local(lhs_ref)
+                .expect("Unbound local")
+                .clone();
+            for ap in lhs_paths.footprint_paths() {
+                self.locals
+                    .update_access_path(ap.clone(), Some(rhs_val.clone()))
+            }
+        }
+    }
+
+    /// Return a wrapper of `self` that implements `Display` using `env`
+    pub fn display<'a>(&'a self, env: &'a FunctionTarget) -> ReadWriteSetStateDisplay<'a> {
+        ReadWriteSetStateDisplay { state: self, env }
+    }
+}
+
+// =================================================================================================
+// Joins
+
+impl AbstractDomain for ReadWriteSetState {
+    fn join(&mut self, other: &Self) -> JoinResult {
+        match (
+            self.accesses.join(&other.accesses),
+            self.locals.join(&other.locals),
+        ) {
+            (JoinResult::Unchanged, JoinResult::Unchanged) => JoinResult::Unchanged,
+            _ => JoinResult::Changed,
+        }
+    }
+}
+
+impl FootprintDomain for Access {
+    fn make_footprint(_ap: AccessPath) -> Option<Self> {
+        None
+    }
+}
+
+impl PartialOrd for Access {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        if self == other {
+            return Some(Ordering::Equal);
+        }
+        match (self, other) {
+            (Access::Borrow, _) => Some(Ordering::Less),
+            (_, Access::Borrow) => Some(Ordering::Greater),
+            (Access::ReadWriteBorrow, _) => Some(Ordering::Greater),
+            (_, Access::ReadWriteBorrow) => Some(Ordering::Less),
+            _ => None,
+        }
+    }
+}
+
+impl AbstractDomain for Access {
+    fn join(&mut self, other: &Self) -> JoinResult {
+        if self == other {
+            return JoinResult::Unchanged;
+        }
+        let res = match (*self, *other) {
+            (Access::Borrow, x) | (x, Access::Borrow) => x,
+            _ => Access::ReadWriteBorrow,
+        };
+        *self = res;
+        JoinResult::Changed
+    }
+}
+
+// =================================================================================================
+// Transfer functions
+
+struct ReadWriteSetAnalysis<'a> {
+    cache: SummaryCache<'a>,
+}
+
+impl<'a> TransferFunctions for ReadWriteSetAnalysis<'a> {
+    type State = ReadWriteSetState;
+    const BACKWARD: bool = false;
+
+    fn execute(&self, state: &mut Self::State, instr: &Bytecode, _offset: CodeOffset) {
+        use Bytecode::*;
+        use Operation::*;
+
+        match instr {
+            Call(_, rets, oper, args, _abort_action) => match oper {
+                BorrowField(_mid, _sid, _types, fld) => {
+                    if state.locals.local_exists(args[0]) {
+                        state.assign_offset(rets[0], args[0], Offset::field(*fld), Access::Borrow);
+                    }
+                }
+                ReadRef => {
+                    if state.locals.local_exists(args[0]) {
+                        state.record_access(args[0], Access::Read);
+                        // rets[0] = args[0]
+                        state.copy_local(rets[0], args[0])
+                    }
+                }
+                WriteRef => {
+                    state.record_access(args[0], Access::Write);
+                    // *args[0] = args1
+                    state.write_ref(args[0], args[1])
+                }
+                FreezeRef | BorrowLoc => {
+                    if state.locals.local_exists(args[0]) {
+                        state.copy_local(rets[0], args[0])
+                    }
+                }
+                BorrowGlobal(mid, sid, types) => {
+                    state.add_global_access(args[0], mid, *sid, types, Access::Borrow);
+                    // borrow_global<T>(a). bind ret to a/T
+                    let addrs = state
+                        .locals
+                        .get_local(args[0])
+                        .expect("Unbound address local")
+                        .clone();
+                    let offset = Offset::global(mid, *sid, types.clone());
+                    let mut extended_aps: AbsAddr = AbsAddr::default();
+                    for p in addrs.iter() {
+                        match p {
+                            Addr::Footprint(ap) => {
+                                let mut extended_ap = ap.clone();
+                                extended_ap.add_offset(offset.clone());
+                                extended_aps.insert(Addr::Footprint(extended_ap.clone()));
+                                state.locals.update_access_path(extended_ap.clone(), None);
+                                state
+                                    .accesses
+                                    .update_access_path(extended_ap, Some(Access::Borrow))
+                            }
+                            Addr::Constant(c) => {
+                                let extended_ap = AccessPath::new_address_constant(
+                                    c.clone(),
+                                    mid,
+                                    *sid,
+                                    types.clone(),
+                                );
+                                extended_aps.insert(Addr::footprint(extended_ap));
+                            }
+                        }
+                    }
+                    state.locals.bind_local(rets[0], extended_aps)
+                }
+                MoveFrom(mid, sid, types) => {
+                    state.add_global_access(args[0], mid, *sid, types, Access::Write);
+                    state.remove_global(args[0], mid, *sid, types)
+                }
+                MoveTo(mid, sid, types) => {
+                    state.add_global_access(args[1], mid, *sid, types, Access::Write);
+                }
+                Exists(mid, sid, types) => {
+                    state.add_global_access(args[0], mid, *sid, types, Access::Read)
+                }
+                Function(mid, fid, types) => {
+                    let fun_id = mid.qualified(*fid);
+                    let global_env = self.cache.global_env();
+                    let callee_fun_env = global_env.get_function(fun_id);
+                    if let Some(callee_summary) = self.cache.get::<ReadWriteSetState>(fun_id) {
+                        state.apply_summary(callee_summary, args, types, rets);
+                    } else {
+                        // native fun. use handwritten model
+                        call_native_function(
+                            state,
+                            callee_fun_env.module_env.get_identifier().as_str(),
+                            callee_fun_env.get_identifier().as_str(),
+                            args,
+                            rets,
+                        )
+                    }
+                }
+                Destroy => state.locals.remove_local(args[0]),
+                Eq | Neq => {
+                    // These operations read reference types passed to them. Add Access::Read's for both operands
+                    if state.locals.local_exists(args[0]) {
+                        state.record_access(args[0], Access::Read)
+                    }
+                    if state.locals.local_exists(args[1]) {
+                        state.record_access(args[1], Access::Read)
+                    }
+                }
+                Pack(_mid, _sid, _types) => {
+                    // rets[0] = Pack<mid::sid<types>>(args)
+                }
+                Unpack(..) => {
+                    // rets = Unpack<mid::sid<types>>(args[0])
+                    // pack and unpack touch non-reference values; nothing to do
+                }
+                CastU8 | CastU64 | CastU128 | Not | Add | Sub | Mul | Div | Mod | BitOr
+                | BitAnd | Xor | Shl | Shr | Lt | Gt | Le | Ge | Or | And => {
+                    // These operations touch non-reference values; nothing to do
+                }
+                oper => panic!("unsupported oper {:?}", oper),
+            },
+            Load(_attr_id, lhs, constant) => {
+                if let Constant::Address(a) = constant {
+                    state.locals.bind_local(*lhs, AbsAddr::constant(a.clone()))
+                }
+            }
+            Assign(_attr_id, lhs, rhs, _assign_kind) => {
+                if let Some(rhs_data) = state.locals.get_local(*rhs).cloned() {
+                    state.locals.bind_local(*lhs, rhs_data)
+                } else {
+                    state.locals.remove_local(*lhs)
+                }
+            }
+            Ret(_attr_id, rets) => {
+                let ret_vals: Vec<Option<AbsAddr>> = rets
+                    .iter()
+                    .map(|ret| state.locals.get_local(*ret).cloned())
+                    .collect();
+                for (ret_index, ret_val_opt) in ret_vals.iter().enumerate() {
+                    if let Some(ret_val) = ret_val_opt {
+                        state.locals.bind_return(ret_index, ret_val.clone())
+                    }
+                }
+            }
+            Abort(..) => {}
+            SaveMem(..) | Prop(..) | SaveSpecVar(..) | Branch(..) | Jump(..) | Label(..)
+            | SpecBlock(..) | Nop(..) => (),
+        }
+    }
+}
+
+/// Execute `rets` = call `module_name`::`function_name`(`args`) in `state`
+fn call_native_function(
+    state: &mut ReadWriteSetState,
+    module_name: &str,
+    fun_name: &str,
+    args: &[TempIndex],
+    rets: &[TempIndex],
+) {
+    // native fun. use handwritten model
+    match (module_name, fun_name) {
+        ("BCS", "to_bytes") => {
+            if state.locals.local_exists(args[0]) {
+                state.record_access(args[0], Access::Read)
+            }
+        }
+        ("Signer", "borrow_address") => {
+            if state.locals.local_exists(args[0]) {
+                // treat as identity function
+                state.record_access(args[0], Access::Borrow);
+                state.copy_local(rets[0], args[0])
+            }
+        }
+        ("Vector", "borrow_mut") | ("Vector", "borrow") => {
+            if state.locals.local_exists(args[0]) {
+                // this will look at vector length. record as read of an index
+                state.access_offset(args[0], Offset::VectorIndex, Access::Read);
+                state.assign_offset(rets[0], args[0], Offset::VectorIndex, Access::Borrow)
+            }
+        }
+        ("Vector", "length") | ("Vector", "is_empty") => {
+            if state.locals.local_exists(args[0]) {
+                state.record_access(args[0], Access::Read)
+            }
+        }
+        ("Vector", "pop_back") => {
+            if state.locals.local_exists(args[0]) {
+                // this will look at vector length. record as read of an index
+                state.access_offset(args[0], Offset::VectorIndex, Access::Read);
+                state.access_offset(args[0], Offset::VectorIndex, Access::Write);
+                state.assign_offset(rets[0], args[0], Offset::VectorIndex, Access::Read)
+            }
+        }
+        ("Vector", "push_back") | ("Vector", "append") | ("Vector", "swap") => {
+            if state.locals.local_exists(args[0]) {
+                // this will look at vector length. record as read of an index
+                state.access_offset(args[0], Offset::VectorIndex, Access::Read);
+                // writes an index (or several indexes)
+                state.access_offset(args[0], Offset::VectorIndex, Access::Write);
+            }
+        }
+        ("Vector", "contains") => {
+            if state.locals.local_exists(args[0]) {
+                state.record_access(args[0], Access::Read); // reads the length + contents
+            }
+        }
+        ("DiemAccount", "create_signer") => {
+            if state.locals.local_exists(args[0]) {
+                state.record_access(args[0], Access::Read); // reads the input address
+                                                            // treat as assignment
+                state.copy_local(rets[0], args[0])
+            }
+        }
+        ("Vector", "empty") | ("Vector", "destroy_empty") => (),
+        ("Event", "write_to_event_store") => (),
+        ("Hash", "sha3_256") | ("Hash", "sha2_256") => (),
+        ("Signature", "ed25519_validate_pubkey") | ("Signature", "ed25519_verify") => (),
+        ("DiemAccount", "destroy_signer") => (),
+        (m, f) => {
+            unimplemented!("Unsupported native function {:?}::{:?}", m, f)
+        }
+    }
+}
+
+impl<'a> DataflowAnalysis for ReadWriteSetAnalysis<'a> {}
+impl<'a> CompositionalAnalysis<ReadWriteSetState> for ReadWriteSetAnalysis<'a> {
+    fn to_summary(&self, mut state: Self::State, fun_target: &FunctionTarget) -> ReadWriteSetState {
+        // remove locals to keep summary compact
+        for i in fun_target.get_non_parameter_locals() {
+            state.locals.remove_local(i)
+        }
+        // remove locals with no offsets
+        for i in fun_target.get_parameters() {
+            if let Some(node) = state.locals.get_local_node(i) {
+                if node.children().is_empty() {
+                    state.locals.remove_local(i)
+                }
+            }
+        }
+        // TODO: if the data associated with path P is Footprint(P), remove it
+
+        state
+    }
+}
+pub struct ReadWriteSetProcessor();
+impl ReadWriteSetProcessor {
+    pub fn new() -> Box<Self> {
+        Box::new(ReadWriteSetProcessor())
+    }
+}
+
+impl FunctionTargetProcessor for ReadWriteSetProcessor {
+    fn process(
+        &self,
+        targets: &mut FunctionTargetsHolder,
+        func_env: &FunctionEnv<'_>,
+        data: FunctionData,
+    ) -> FunctionData {
+        let fun_target = FunctionTarget::new(func_env, &data);
+        let mut initial_state = ReadWriteSetState::default();
+        // initialize_formals
+        for param_index in fun_target.get_parameters() {
+            initial_state
+                .locals
+                .bind_local(param_index, AbsAddr::formal(param_index))
+        }
+        let cache = SummaryCache::new(targets, func_env.module_env.env);
+        let analysis = ReadWriteSetAnalysis { cache };
+        analysis.summarize(func_env, initial_state, data)
+    }
+
+    fn name(&self) -> String {
+        "read_write_set_analysis".to_string()
+    }
+}
+
+// =================================================================================================
+// Entrypoint for clients
+
+pub fn get_read_write_set(env: &GlobalEnv, targets: &FunctionTargetsHolder) {
+    for module_env in env.get_modules() {
+        let module_name = module_env.get_identifier().to_string();
+        for func_env in module_env.get_functions() {
+            let fun_target = targets.get_target(&func_env, FunctionVariant::Baseline);
+            let annotation = fun_target
+                .get_annotations()
+                .get::<ReadWriteSetState>()
+                .expect(
+                "Invariant violation: read/write set analysis should be run before calling this",
+            );
+            println!("{}::{}", module_name, func_env.get_identifier());
+            println!("{}", annotation.display(&fun_target))
+        }
+    }
+}
+
+// =================================================================================================
+// Formatting
+
+/// Return a string representation of the summary for `target`
+pub fn format_read_write_set_annotation(
+    target: &FunctionTarget<'_>,
+    code_offset: CodeOffset,
+) -> Option<String> {
+    // hack: the summary only contains the state at the exit block, but the
+    // caller of this function wants to print at every `code_offset`. This
+    // allows us to only print once/function
+    // TODO: change printing interface to allow optional per-procedure and per-bytecode printing
+    if code_offset != 0 {
+        return None;
+    }
+    if let Some(a) = target.get_annotations().get::<ReadWriteSetState>() {
+        Some(format!("{}", a.display(target)))
+    } else {
+        None
+    }
+}
+
+struct ReadWriteSetStateDisplay<'a> {
+    state: &'a ReadWriteSetState,
+    env: &'a FunctionTarget<'a>,
+}
+
+impl<'a> fmt::Display for ReadWriteSetStateDisplay<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str("Accesses:\n")?;
+        writeln!(f, "{}", self.state.accesses.display(self.env))?;
+        f.write_str("Locals:\n")?;
+        self.state.locals.iter_paths(|path, v| {
+            writeln!(f, "{}: {}", path.display(self.env), v.display(self.env)).unwrap();
+        });
+        Ok(())
+    }
+}
+
+impl Default for ReadWriteSetState {
+    fn default() -> Self {
+        Self {
+            accesses: AccessPathTrie::default(),
+            locals: AccessPathTrie::default(),
+        }
+    }
+}

--- a/language/move-prover/bytecode/src/usage_analysis.rs
+++ b/language/move-prover/bytecode/src/usage_analysis.rs
@@ -77,7 +77,7 @@ struct MemoryUsageAnalysis<'a> {
 
 impl<'a> DataflowAnalysis for MemoryUsageAnalysis<'a> {}
 impl<'a> CompositionalAnalysis<UsageState> for MemoryUsageAnalysis<'a> {
-    fn to_summary(&self, state: UsageState) -> UsageState {
+    fn to_summary(&self, state: UsageState, _fun_target: &FunctionTarget) -> UsageState {
         state
     }
 }

--- a/language/move-prover/bytecode/tests/read_write_set/exists.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/exists.exp
@@ -1,0 +1,187 @@
+============ initial translation from Move ================
+
+[variant baseline]
+pub fun Exists::call_with_type_param1($t0|a: address): bool {
+     var $t1: address
+     var $t2: bool
+  0: $t1 := copy($t0)
+  1: $t2 := Exists::exists_generic<Exists::T>($t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+pub fun Exists::call_with_type_param2<$tv0, $tv1>($t0|a: address): bool {
+     var $t1: address
+     var $t2: bool
+  0: $t1 := copy($t0)
+  1: $t2 := Exists::exists_generic<#1>($t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+pub fun Exists::exists_const(): bool {
+     var $t0: address
+     var $t1: bool
+  0: $t0 := 0x1
+  1: $t1 := exists<Exists::T>($t0)
+  2: return $t1
+}
+
+
+[variant baseline]
+pub fun Exists::exists_field($t0|s: &Exists::S): bool {
+     var $t1: &Exists::S
+     var $t2: &address
+     var $t3: address
+     var $t4: bool
+  0: $t1 := move($t0)
+  1: $t2 := borrow_field<Exists::S>.f($t1)
+  2: $t3 := read_ref($t2)
+  3: $t4 := exists<Exists::T>($t3)
+  4: return $t4
+}
+
+
+[variant baseline]
+pub fun Exists::exists_formal($t0|a: address): bool {
+     var $t1: address
+     var $t2: bool
+  0: $t1 := copy($t0)
+  1: $t2 := exists<Exists::T>($t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+pub fun Exists::exists_generic<$tv0>($t0|a: address): bool {
+     var $t1: address
+     var $t2: bool
+  0: $t1 := copy($t0)
+  1: $t2 := exists<Exists::V<#0>>($t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+pub fun Exists::exists_generic_instantiated($t0|a: address): bool {
+     var $t1: address
+     var $t2: bool
+  0: $t1 := copy($t0)
+  1: $t2 := exists<Exists::V<Exists::T>>($t1)
+  2: return $t2
+}
+
+============ after pipeline `read_write_set` ================
+
+[variant baseline]
+pub fun Exists::call_with_type_param1($t0|a: address): bool {
+     var $t1: address
+     var $t2: bool
+     # Accesses:
+     # Loc(0)/0x2::Exists::V<0x2::Exists::T>: Read
+     #
+     # Locals:
+     #
+  0: $t1 := copy($t0)
+  1: $t2 := Exists::exists_generic<Exists::T>($t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+pub fun Exists::call_with_type_param2<$tv0, $tv1>($t0|a: address): bool {
+     var $t1: address
+     var $t2: bool
+     # Accesses:
+     # Loc(0)/Exists::V<#1>: Read
+     #
+     # Locals:
+     #
+  0: $t1 := copy($t0)
+  1: $t2 := Exists::exists_generic<#1>($t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+pub fun Exists::exists_const(): bool {
+     var $t0: address
+     var $t1: bool
+     # Accesses:
+     # 0x1/0x2::Exists::T: Read
+     #
+     # Locals:
+     #
+  0: $t0 := 0x1
+  1: $t1 := exists<Exists::T>($t0)
+  2: return $t1
+}
+
+
+[variant baseline]
+pub fun Exists::exists_field($t0|s: &Exists::S): bool {
+     var $t1: &Exists::S
+     var $t2: &address
+     var $t3: address
+     var $t4: bool
+     # Accesses:
+     # Loc(0)/f: Read
+     # Loc(0)/f/0x2::Exists::T: Read
+     #
+     # Locals:
+     # Loc(0): Loc(0)
+     # Loc(0)/f: Loc(0)/f
+     #
+  0: $t1 := move($t0)
+  1: $t2 := borrow_field<Exists::S>.f($t1)
+  2: $t3 := read_ref($t2)
+  3: $t4 := exists<Exists::T>($t3)
+  4: return $t4
+}
+
+
+[variant baseline]
+pub fun Exists::exists_formal($t0|a: address): bool {
+     var $t1: address
+     var $t2: bool
+     # Accesses:
+     # Loc(0)/0x2::Exists::T: Read
+     #
+     # Locals:
+     #
+  0: $t1 := copy($t0)
+  1: $t2 := exists<Exists::T>($t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+pub fun Exists::exists_generic<$tv0>($t0|a: address): bool {
+     var $t1: address
+     var $t2: bool
+     # Accesses:
+     # Loc(0)/Exists::V<#0>: Read
+     #
+     # Locals:
+     #
+  0: $t1 := copy($t0)
+  1: $t2 := exists<Exists::V<#0>>($t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+pub fun Exists::exists_generic_instantiated($t0|a: address): bool {
+     var $t1: address
+     var $t2: bool
+     # Accesses:
+     # Loc(0)/0x2::Exists::V<0x2::Exists::T>: Read
+     #
+     # Locals:
+     #
+  0: $t1 := copy($t0)
+  1: $t2 := exists<Exists::V<Exists::T>>($t1)
+  2: return $t2
+}

--- a/language/move-prover/bytecode/tests/read_write_set/exists.move
+++ b/language/move-prover/bytecode/tests/read_write_set/exists.move
@@ -1,0 +1,38 @@
+address 0x2 {
+module Exists {
+    resource struct T {}
+
+    resource struct S { f: address }
+
+    resource struct V<A> { }
+
+    public fun exists_const(): bool {
+        exists<T>(0x1)
+    }
+
+    public fun exists_formal(a: address): bool {
+        exists<T>(a)
+    }
+
+    public fun exists_field(s: &S): bool {
+        exists<T>(s.f)
+    }
+
+    public fun exists_generic_instantiated(a: address): bool {
+        exists<V<T>>(a)
+    }
+
+    public fun exists_generic<X>(a: address): bool {
+        exists<V<X>>(a)
+    }
+
+    public fun call_with_type_param1(a: address): bool {
+        exists_generic<T>(a)
+    }
+
+    public fun call_with_type_param2<X, Y>(a: address): bool {
+        exists_generic<Y>(a)
+    }
+
+}
+}

--- a/language/move-prover/bytecode/tests/read_write_set/fields.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/fields.exp
@@ -1,0 +1,65 @@
+============ initial translation from Move ================
+
+[variant baseline]
+pub fun Fields::borrow_read($t0|s: &Fields::S): u64 {
+     var $t1: &Fields::S
+     var $t2: &u64
+     var $t3: u64
+  0: $t1 := move($t0)
+  1: $t2 := borrow_field<Fields::S>.f($t1)
+  2: $t3 := read_ref($t2)
+  3: return $t3
+}
+
+
+[variant baseline]
+pub fun Fields::borrow_read_generic<$tv0>($t0|t: &Fields::T<#0>): u64 {
+     var $t1: &Fields::T<#0>
+     var $t2: &u64
+     var $t3: u64
+  0: $t1 := move($t0)
+  1: $t2 := borrow_field<Fields::T<#0>>.f($t1)
+  2: $t3 := read_ref($t2)
+  3: return $t3
+}
+
+============ after pipeline `read_write_set` ================
+
+[variant baseline]
+pub fun Fields::borrow_read($t0|s: &Fields::S): u64 {
+     var $t1: &Fields::S
+     var $t2: &u64
+     var $t3: u64
+     # Accesses:
+     # Loc(0)/f: Read
+     #
+     # Locals:
+     # Loc(0): Loc(0)
+     # Loc(0)/f: Loc(0)/f
+     # Ret(0): Loc(0)/f
+     #
+  0: $t1 := move($t0)
+  1: $t2 := borrow_field<Fields::S>.f($t1)
+  2: $t3 := read_ref($t2)
+  3: return $t3
+}
+
+
+[variant baseline]
+pub fun Fields::borrow_read_generic<$tv0>($t0|t: &Fields::T<#0>): u64 {
+     var $t1: &Fields::T<#0>
+     var $t2: &u64
+     var $t3: u64
+     # Accesses:
+     # Loc(0)/f: Read
+     #
+     # Locals:
+     # Loc(0): Loc(0)
+     # Loc(0)/f: Loc(0)/f
+     # Ret(0): Loc(0)/f
+     #
+  0: $t1 := move($t0)
+  1: $t2 := borrow_field<Fields::T<#0>>.f($t1)
+  2: $t3 := read_ref($t2)
+  3: return $t3
+}

--- a/language/move-prover/bytecode/tests/read_write_set/fields.move
+++ b/language/move-prover/bytecode/tests/read_write_set/fields.move
@@ -1,0 +1,15 @@
+address 0x2 {
+module Fields {
+    resource struct S { f: u64 }
+
+    resource struct T<A> { f: u64 }
+
+    public fun borrow_read(s: &S): u64 {
+        s.f
+    }
+
+    public fun borrow_read_generic<A>(t: &T<A>): u64 {
+        t.f
+    }
+}
+}

--- a/language/move-prover/bytecode/tests/read_write_set/footprint.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/footprint.exp
@@ -1,0 +1,196 @@
+============ initial translation from Move ================
+
+[variant baseline]
+pub fun Footprint::reassign_cond($t0|a: address, $t1|b: bool): address {
+     var $t2: bool
+     var $t3: address
+     var $t4: u64
+     var $t5: address
+  0: $t2 := copy($t1)
+  1: if ($t2) goto 4 else goto 2
+  2: label L1
+  3: goto 8
+  4: label L0
+  5: $t3 := 0x2
+  6: $t0 := $t3
+  7: goto 8
+  8: label L2
+  9: $t4 := 4
+ 10: destroy($t4)
+ 11: $t5 := copy($t0)
+ 12: return $t5
+}
+
+
+[variant baseline]
+pub fun Footprint::reassign_constant($t0|a: address): address {
+     var $t1: address
+     var $t2: address
+  0: $t1 := 0x2
+  1: $t0 := $t1
+  2: $t2 := copy($t0)
+  3: return $t2
+}
+
+
+[variant baseline]
+pub fun Footprint::reassign_field($t0|s: &mut Footprint::S) {
+     var $t1: address
+     var $t2: &mut Footprint::S
+     var $t3: &mut address
+  0: $t1 := 0x2
+  1: $t2 := move($t0)
+  2: $t3 := borrow_field<Footprint::S>.f($t2)
+  3: write_ref($t3, $t1)
+  4: return ()
+}
+
+
+[variant baseline]
+pub fun Footprint::reassign_field_cond($t0|s: &mut Footprint::S, $t1|b: bool) {
+     var $t2: bool
+     var $t3: address
+     var $t4: &mut Footprint::S
+     var $t5: &mut address
+     var $t6: &mut Footprint::S
+  0: $t2 := copy($t1)
+  1: if ($t2) goto 4 else goto 2
+  2: label L1
+  3: goto 10
+  4: label L0
+  5: $t3 := 0x2
+  6: $t4 := move($t0)
+  7: $t5 := borrow_field<Footprint::S>.f($t4)
+  8: write_ref($t5, $t3)
+  9: goto 14
+ 10: label L2
+ 11: $t6 := move($t0)
+ 12: destroy($t6)
+ 13: goto 14
+ 14: label L3
+ 15: return ()
+}
+
+
+[variant baseline]
+pub fun Footprint::reassign_other_param($t0|a1: address, $t1|a2: address): address {
+     var $t2: address
+     var $t3: address
+  0: $t2 := copy($t1)
+  1: $t0 := $t2
+  2: $t3 := copy($t0)
+  3: return $t3
+}
+
+============ after pipeline `read_write_set` ================
+
+[variant baseline]
+pub fun Footprint::reassign_cond($t0|a: address, $t1|b: bool): address {
+     var $t2: bool
+     var $t3: address
+     var $t4: u64
+     var $t5: address
+     # Accesses:
+     #
+     # Locals:
+     # Ret(0): {0x2, Loc(0), }
+     #
+  0: $t2 := copy($t1)
+  1: if ($t2) goto 4 else goto 2
+  2: label L1
+  3: goto 8
+  4: label L0
+  5: $t3 := 0x2
+  6: $t0 := $t3
+  7: goto 8
+  8: label L2
+  9: $t4 := 4
+ 10: destroy($t4)
+ 11: $t5 := copy($t0)
+ 12: return $t5
+}
+
+
+[variant baseline]
+pub fun Footprint::reassign_constant($t0|a: address): address {
+     var $t1: address
+     var $t2: address
+     # Accesses:
+     #
+     # Locals:
+     # Ret(0): 0x2
+     #
+  0: $t1 := 0x2
+  1: $t0 := $t1
+  2: $t2 := copy($t0)
+  3: return $t2
+}
+
+
+[variant baseline]
+pub fun Footprint::reassign_field($t0|s: &mut Footprint::S) {
+     var $t1: address
+     var $t2: &mut Footprint::S
+     var $t3: &mut address
+     # Accesses:
+     # Loc(0)/f: Write
+     #
+     # Locals:
+     # Loc(0): Loc(0)
+     # Loc(0)/f: 0x2
+     #
+  0: $t1 := 0x2
+  1: $t2 := move($t0)
+  2: $t3 := borrow_field<Footprint::S>.f($t2)
+  3: write_ref($t3, $t1)
+  4: return ()
+}
+
+
+[variant baseline]
+pub fun Footprint::reassign_field_cond($t0|s: &mut Footprint::S, $t1|b: bool) {
+     var $t2: bool
+     var $t3: address
+     var $t4: &mut Footprint::S
+     var $t5: &mut address
+     var $t6: &mut Footprint::S
+     # Accesses:
+     # Loc(0)/f: Write
+     #
+     # Locals:
+     # Loc(0): Loc(0)
+     # Loc(0)/f: {0x2, Loc(0)/f, }
+     #
+  0: $t2 := copy($t1)
+  1: if ($t2) goto 4 else goto 2
+  2: label L1
+  3: goto 10
+  4: label L0
+  5: $t3 := 0x2
+  6: $t4 := move($t0)
+  7: $t5 := borrow_field<Footprint::S>.f($t4)
+  8: write_ref($t5, $t3)
+  9: goto 14
+ 10: label L2
+ 11: $t6 := move($t0)
+ 12: destroy($t6)
+ 13: goto 14
+ 14: label L3
+ 15: return ()
+}
+
+
+[variant baseline]
+pub fun Footprint::reassign_other_param($t0|a1: address, $t1|a2: address): address {
+     var $t2: address
+     var $t3: address
+     # Accesses:
+     #
+     # Locals:
+     # Ret(0): Loc(1)
+     #
+  0: $t2 := copy($t1)
+  1: $t0 := $t2
+  2: $t3 := copy($t0)
+  3: return $t3
+}

--- a/language/move-prover/bytecode/tests/read_write_set/footprint.move
+++ b/language/move-prover/bytecode/tests/read_write_set/footprint.move
@@ -1,0 +1,38 @@
+address 0x2 {
+module Footprint {
+    resource struct S { f: address }
+
+    // expected: empty summary
+    public fun reassign_constant(a: address): address {
+        a = 0x2;
+        a
+    }
+
+    // expected: returns Footprint(a2)
+    public fun reassign_other_param(a1: address, a2: address): address {
+        a1 = a2;
+        a1
+    }
+
+    // expected: returns Footprint({a, 0x2})
+    public fun reassign_cond(a: address, b: bool): address {
+        if (b) {
+            a = 0x2;
+        };
+        _ = 2 + 2;
+        a
+    }
+
+    // expected: s.f |-> 0x2
+    public fun reassign_field(s: &mut S) {
+        s.f = 0x2;
+    }
+
+    // expected: s.f |-> {0x2, Footprint(s.f)}
+    public fun reassign_field_cond(s: &mut S, b: bool) {
+        if (b) {
+            s.f = 0x2
+        }
+    }
+}
+}

--- a/language/move-prover/bytecode/tests/read_write_set/functions.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/functions.exp
@@ -1,0 +1,206 @@
+============ initial translation from Move ================
+
+[variant baseline]
+pub fun Funtions::call_write_vec($t0|a: address, $t1|v: vector<u8>) {
+     var $t2: address
+     var $t3: &mut Funtions::R
+     var $t4: vector<u8>
+  0: $t2 := copy($t0)
+  1: $t3 := borrow_global<Funtions::R>($t2)
+  2: $t4 := move($t1)
+  3: Funtions::write_vec($t3, $t4)
+  4: return ()
+}
+
+
+[variant baseline]
+pub fun Funtions::choice($t0|a: vector<address>, $t1|b: vector<address>, $t2|c: bool): vector<address> {
+     var $t3|tmp#$3: vector<address>
+     var $t4: bool
+     var $t5: vector<address>
+     var $t6: vector<address>
+     var $t7: vector<address>
+  0: $t4 := copy($t2)
+  1: if ($t4) goto 4 else goto 2
+  2: label L1
+  3: goto 8
+  4: label L0
+  5: $t5 := move($t0)
+  6: $t3 := $t5
+  7: goto 12
+  8: label L2
+  9: $t6 := move($t1)
+ 10: $t3 := $t6
+ 11: goto 12
+ 12: label L3
+ 13: $t7 := move($t3)
+ 14: return $t7
+}
+
+
+[variant baseline]
+pub fun Funtions::id($t0|a: address): address {
+     var $t1: address
+  0: $t1 := copy($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+pub fun Funtions::id_generic<$tv0>($t0|t: #0): #0 {
+     var $t1: #0
+  0: $t1 := move($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+pub fun Funtions::id_ref($t0|a: &address): &address {
+     var $t1: &address
+  0: $t1 := move($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+pub fun Funtions::id_ref_generic<$tv0>($t0|t: &#0): &#0 {
+     var $t1: &#0
+  0: $t1 := move($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+pub fun Funtions::write_vec($t0|r: &mut Funtions::R, $t1|v: vector<u8>) {
+     var $t2: vector<u8>
+     var $t3: &mut Funtions::R
+     var $t4: &mut vector<u8>
+  0: $t2 := move($t1)
+  1: $t3 := move($t0)
+  2: $t4 := borrow_field<Funtions::R>.v($t3)
+  3: write_ref($t4, $t2)
+  4: return ()
+}
+
+============ after pipeline `read_write_set` ================
+
+[variant baseline]
+pub fun Funtions::call_write_vec($t0|a: address, $t1|v: vector<u8>) {
+     var $t2: address
+     var $t3: &mut Funtions::R
+     var $t4: vector<u8>
+     # Accesses:
+     # Loc(0)/0x1::Funtions::R: Borrow
+     # Loc(0)/0x1::Funtions::R/v: Write
+     #
+     # Locals:
+     # Loc(0): Loc(0)
+     #
+  0: $t2 := copy($t0)
+  1: $t3 := borrow_global<Funtions::R>($t2)
+  2: $t4 := move($t1)
+  3: Funtions::write_vec($t3, $t4)
+  4: return ()
+}
+
+
+[variant baseline]
+pub fun Funtions::choice($t0|a: vector<address>, $t1|b: vector<address>, $t2|c: bool): vector<address> {
+     var $t3|tmp#$3: vector<address>
+     var $t4: bool
+     var $t5: vector<address>
+     var $t6: vector<address>
+     var $t7: vector<address>
+     # Accesses:
+     #
+     # Locals:
+     # Ret(0): {Loc(0), Loc(1), }
+     #
+  0: $t4 := copy($t2)
+  1: if ($t4) goto 4 else goto 2
+  2: label L1
+  3: goto 8
+  4: label L0
+  5: $t5 := move($t0)
+  6: $t3 := $t5
+  7: goto 12
+  8: label L2
+  9: $t6 := move($t1)
+ 10: $t3 := $t6
+ 11: goto 12
+ 12: label L3
+ 13: $t7 := move($t3)
+ 14: return $t7
+}
+
+
+[variant baseline]
+pub fun Funtions::id($t0|a: address): address {
+     var $t1: address
+     # Accesses:
+     #
+     # Locals:
+     # Ret(0): Loc(0)
+     #
+  0: $t1 := copy($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+pub fun Funtions::id_generic<$tv0>($t0|t: #0): #0 {
+     var $t1: #0
+     # Accesses:
+     #
+     # Locals:
+     # Ret(0): Loc(0)
+     #
+  0: $t1 := move($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+pub fun Funtions::id_ref($t0|a: &address): &address {
+     var $t1: &address
+     # Accesses:
+     #
+     # Locals:
+     # Ret(0): Loc(0)
+     #
+  0: $t1 := move($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+pub fun Funtions::id_ref_generic<$tv0>($t0|t: &#0): &#0 {
+     var $t1: &#0
+     # Accesses:
+     #
+     # Locals:
+     # Ret(0): Loc(0)
+     #
+  0: $t1 := move($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+pub fun Funtions::write_vec($t0|r: &mut Funtions::R, $t1|v: vector<u8>) {
+     var $t2: vector<u8>
+     var $t3: &mut Funtions::R
+     var $t4: &mut vector<u8>
+     # Accesses:
+     # Loc(0)/v: Write
+     #
+     # Locals:
+     # Loc(0): Loc(0)
+     # Loc(0)/v: Loc(1)
+     #
+  0: $t2 := move($t1)
+  1: $t3 := move($t0)
+  2: $t4 := borrow_field<Funtions::R>.v($t3)
+  3: write_ref($t4, $t2)
+  4: return ()
+}

--- a/language/move-prover/bytecode/tests/read_write_set/functions.move
+++ b/language/move-prover/bytecode/tests/read_write_set/functions.move
@@ -1,0 +1,26 @@
+address 0x1 {
+module Funtions {
+    resource struct R { v: vector<u8> }
+
+    public fun id(a: address): address { a }
+
+    public fun id_ref(a: &address): &address { a }
+
+    public fun id_generic<T>(t: T): T { t }
+
+    public fun id_ref_generic<T>(t: &T): &T { t }
+
+    public fun choice(a: vector<address>, b: vector<address>, c: bool): vector<address> {
+        if (c) { a } else { b }
+    }
+
+    public fun write_vec(r: &mut R, v: vector<u8>) {
+        r.v = v
+    }
+
+    public fun call_write_vec(a: address, v: vector<u8>) acquires R {
+        write_vec(borrow_global_mut<R>(a), v)
+    }
+
+}
+}

--- a/language/move-prover/bytecode/tests/read_write_set/summary.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/summary.exp
@@ -1,0 +1,123 @@
+============ initial translation from Move ================
+
+[variant baseline]
+pub fun Summary::write_addr() {
+     var $t0: address
+  0: $t0 := 0x777
+  1: Summary::write_caller2($t0)
+  2: return ()
+}
+
+
+[variant baseline]
+pub fun Summary::write_callee($t0|s2: &mut Summary::S2) {
+     var $t1: u64
+     var $t2: &mut Summary::S2
+     var $t3: &mut u64
+  0: $t1 := 7
+  1: $t2 := move($t0)
+  2: $t3 := borrow_field<Summary::S2>.f($t2)
+  3: write_ref($t3, $t1)
+  4: return ()
+}
+
+
+[variant baseline]
+pub fun Summary::write_caller1($t0|a: address) {
+     var $t1: address
+     var $t2: &mut Summary::S2
+  0: $t1 := copy($t0)
+  1: $t2 := borrow_global<Summary::S2>($t1)
+  2: Summary::write_callee($t2)
+  3: return ()
+}
+
+
+[variant baseline]
+pub fun Summary::write_caller2($t0|a: address) {
+     var $t1: address
+     var $t2: &mut Summary::S1
+     var $t3: &mut Summary::S2
+  0: $t1 := copy($t0)
+  1: $t2 := borrow_global<Summary::S1>($t1)
+  2: $t3 := borrow_field<Summary::S1>.s2($t2)
+  3: Summary::write_callee($t3)
+  4: return ()
+}
+
+============ after pipeline `read_write_set` ================
+
+[variant baseline]
+pub fun Summary::write_addr() {
+     var $t0: address
+     # Accesses:
+     # 0x777/0x2::Summary::S1: Borrow
+     # 0x777/0x2::Summary::S1/s2: Borrow
+     # 0x777/0x2::Summary::S1/s2/f: Write
+     #
+     # Locals:
+     #
+  0: $t0 := 0x777
+  1: Summary::write_caller2($t0)
+  2: return ()
+}
+
+
+[variant baseline]
+pub fun Summary::write_callee($t0|s2: &mut Summary::S2) {
+     var $t1: u64
+     var $t2: &mut Summary::S2
+     var $t3: &mut u64
+     # Accesses:
+     # Loc(0)/f: Write
+     #
+     # Locals:
+     # Loc(0): Loc(0)
+     # Loc(0)/f: Loc(0)/f
+     #
+  0: $t1 := 7
+  1: $t2 := move($t0)
+  2: $t3 := borrow_field<Summary::S2>.f($t2)
+  3: write_ref($t3, $t1)
+  4: return ()
+}
+
+
+[variant baseline]
+pub fun Summary::write_caller1($t0|a: address) {
+     var $t1: address
+     var $t2: &mut Summary::S2
+     # Accesses:
+     # Loc(0)/0x2::Summary::S2: Borrow
+     # Loc(0)/0x2::Summary::S2/f: Write
+     #
+     # Locals:
+     # Loc(0): Loc(0)
+     #
+  0: $t1 := copy($t0)
+  1: $t2 := borrow_global<Summary::S2>($t1)
+  2: Summary::write_callee($t2)
+  3: return ()
+}
+
+
+[variant baseline]
+pub fun Summary::write_caller2($t0|a: address) {
+     var $t1: address
+     var $t2: &mut Summary::S1
+     var $t3: &mut Summary::S2
+     # Accesses:
+     # Loc(0)/0x2::Summary::S1: Borrow
+     # Loc(0)/0x2::Summary::S1/s2: Borrow
+     # Loc(0)/0x2::Summary::S1/s2/f: Write
+     #
+     # Locals:
+     # Loc(0): Loc(0)
+     # Loc(0)/0x2::Summary::S1/s2: Loc(0)/0x2::Summary::S1/s2
+     #
+  0: $t1 := copy($t0)
+  1: $t2 := borrow_global<Summary::S1>($t1)
+  2: $t3 := borrow_field<Summary::S1>.s2($t2)
+  3: Summary::write_callee($t3)
+  4: return ()
+}

--- a/language/move-prover/bytecode/tests/read_write_set/summary.move
+++ b/language/move-prover/bytecode/tests/read_write_set/summary.move
@@ -1,0 +1,23 @@
+address 0x2 {
+module Summary {
+    resource struct S1 { s2: S2 }
+    resource struct S2 { f: u64 }
+
+    public fun write_callee(s2: &mut S2) {
+        s2.f = 7;
+    }
+
+    public fun write_caller1(a: address) acquires S2 {
+        write_callee(borrow_global_mut<S2>(a))
+    }
+
+    public fun write_caller2(a: address) acquires S1 {
+        write_callee(&mut borrow_global_mut<S1>(a).s2)
+    }
+
+    public fun write_addr() acquires S1 {
+        write_caller2(0x777);
+    }
+
+}
+}

--- a/language/move-prover/bytecode/tests/testsuite.rs
+++ b/language/move-prover/bytecode/tests/testsuite.rs
@@ -19,6 +19,7 @@ use bytecode::{
     options::ProverOptions,
     print_targets_for_test,
     reaching_def_analysis::ReachingDefProcessor,
+    read_write_set_analysis::ReadWriteSetProcessor,
     spec_instrumentation::SpecInstrumentationProcessor,
     usage_analysis::UsageProcessor,
     verification_analysis::VerificationAnalysisProcessor,
@@ -130,6 +131,11 @@ fn get_tested_transformation_pipeline(
             pipeline.add_processor(SpecInstrumentationProcessor::new());
             pipeline.add_processor(DataInvariantInstrumentationProcessor::new());
             pipeline.add_processor(GlobalInvariantInstrumentationProcessor::new());
+            Ok(Some(pipeline))
+        }
+        "read_write_set" => {
+            let mut pipeline = FunctionTargetPipeline::default();
+            pipeline.add_processor(Box::new(ReadWriteSetProcessor {}));
             Ok(Some(pipeline))
         }
 

--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -50,6 +50,8 @@ pub struct Options {
     pub run_abigen: bool,
     /// Whether to run the error map generator instead of the prover.
     pub run_errmapgen: bool,
+    /// Whether to run the read write set analysis instead of the prover
+    pub run_read_write_set: bool,
     /// An account address to use if none is specified in the source.
     pub account_address: String,
     /// The paths to the Move sources.
@@ -81,6 +83,7 @@ impl Default for Options {
             run_docgen: false,
             run_abigen: false,
             run_errmapgen: false,
+            run_read_write_set: false,
             account_address: "0x234567".to_string(),
             verbosity_level: LevelFilter::Info,
             move_sources: vec![],
@@ -258,6 +261,11 @@ impl Options {
                     .help("run the packed types generator instead of the prover.")
             )
             .arg(
+                Arg::with_name("read-write-set")
+                    .long("read-write-set")
+                    .help("run the read/write set analysis instead of the prover.")
+            )
+            .arg(
                 Arg::with_name("verify")
                     .long("verify")
                     .takes_value(true)
@@ -425,6 +433,9 @@ impl Options {
         }
         if matches.is_present("errmapgen") {
             options.run_errmapgen = true;
+        }
+        if matches.is_present("read-write-set") {
+            options.run_read_write_set = true;
         }
         if matches.is_present("warn") {
             options.prover.report_warnings = true;

--- a/language/vm/src/file_format.rs
+++ b/language/vm/src/file_format.rs
@@ -360,6 +360,13 @@ impl StructDefinition {
             StructFieldInformation::Declared(fields) => Ok(fields.len() as u16),
         }
     }
+
+    pub fn field(&self, offset: usize) -> Option<&FieldDefinition> {
+        match &self.field_information {
+            StructFieldInformation::Native => None,
+            StructFieldInformation::Declared(fields) => fields.get(offset),
+        }
+    }
 }
 
 /// A `FieldDefinition` is the definition of a field: its name and the field type.


### PR DESCRIPTION
### Overview

The analysis introduced in this PR seeks to overapproximate the set of *concrete access paths* that may be read/written by a given procedure. An access path is a canonical name for a location in memory; some examples of are:

`0x7/M::T/f` (i.e., the field `f` of the `M::T` resource stored at address `0x7`)

`Formal(0)/[2]` (i.e., the value stored at index 2 of the array bound the 0th formal of the current procedure)

The analysis uses an abstraction of access paths with the following components

- A *root*, which is either an abstract address or a local
- Zero or more *offsets*, where an offset is a field, an unknown vector index, or an abstract struct type

Abstract addresses are a set containing constants and abstract access paths read from the environment (or "footprint"). For example, in the following code:

```
struct S { f: u64 }

fun foo(x: S) {
  let a = if (*) { 0x1 } else { *&x.f }
   ...
}
```

we will represent `a` as `{ 0x1, Footprint(x/f) }`

### Access Path Trie

The obvious approach to abstracting a set of concrete paths is using a set of abstract paths. The analysis does exactly this, but using an implementation that avoids redundant representations of the same memory: an *access path trie* where roots nodes are access path roots and each internal node is an access path offset. Each node is (optionally) associated with abstract value of a generic type `T`.

The read/write set analysis state consists of two such tries: an `AccessPathTrie<Access>` to track the accesses to global state, and an `AccessPathTrie<AbsAddr>` to track the set of address values at each program point. An access is either Borrow, Read, Write, or ReadWriteBorrow (top value). The Borrow value is not strictly needed, but it helps for debugging.

### Read/Write Set Analysis

The read/write set analysis is a compositional analysis that starts from the leaves of the call graph and analyzes each procedure once. The result is a summary of the abstract paths read/written by each procedure and the value(s) returned by the procedure.

When the analysis encounters a call, it fetches the summary for the callee and applies it to the current state. This logic (implemented in `apply_summary`) is by far the most complex part of the analysis. There are three steps:

1. Substitute footprint values in the callee summary with their values in the caller state (including both actuals and values read from globals)
2. Bind return values in the callee summary to the return variables in the caller state
3. Join caller accesses and callee accesses

### Running

You can point the analysis at modules or transaction scripts via the prover frontend. For example, `mvp --read-write-set rotate_authentication_key.move` yields

```
Accesses:
Loc(0): Read
Loc(0)/0x1::DiemAccount::DiemAccount: Read
Loc(0)/0x1::DiemAccount::DiemAccount/key_rotation_capability: Borrow
Loc(0)/0x1::DiemAccount::DiemAccount/key_rotation_capability/vec: Read
Loc(0)/0x1::DiemAccount::DiemAccount/key_rotation_capability/vec/[_]: ReadWriteBorrow
Loc(0)/0x1::DiemAccount::DiemAccount/key_rotation_capability/vec/[_]/account_address: Read
Loc(0)/0x1::DiemAccount::DiemAccount/key_rotation_capability/vec/[_]/account_address/0x1::DiemAccount::DiemAccount: Read
Loc(0)/0x1::DiemAccount::DiemAccount/key_rotation_capability/vec/[_]/account_address/0x1::DiemAccount::DiemAccount/authentication_key: Write
Loc(0)/0x1::DiemAccount::DiemAccount/key_rotation_capability/vec/[_]/account_address/0x1::DiemAccount::DiemAccount/key_rotation_capability: Borrow
Loc(0)/0x1::DiemAccount::DiemAccount/key_rotation_capability/vec/[_]/account_address/0x1::DiemAccount::DiemAccount/key_rotation_capability/vec: Read
Loc(0)/0x1::DiemAccount::DiemAccount/key_rotation_capability/vec/[_]/account_address/0x1::DiemAccount::DiemAccount/key_rotation_capability/vec/[_]: ReadWriteBorrow
Loc(1): Read
```

### Future Work

There is a lot left to do before this analysis is useful/mature:
- Add many, many more tests. There are a few in this PR, and I have run on the Diem Framework/eyeballed several scripts to make sure the results look reasonable. But there are a ton of corner cases to test here.
- Expand the analysis from procedures to transactions: we must substitute in the concrete values provided in a transaction into the summary + (possibly) read some values from the current on-chain state. In addition, this analysis must take the prologue and epilogue into account.
- Make it possible to build a `GlobalEnv` from bytecode
- Address the termination issues by adding widening. Today, the analysis will hang if you write "address linked list" code that creates access paths of unknown length. We don't have any code like this in the framework, but it is important to handle this case in an open system
- Improve the precision of the analysis by adding guards to each access node. This would help us with the "all txes conflict because of gas issue", at least in the case where the price is nonzero.
