### PR TITLE
[State Sync] Clean up and refactor small parts of state sync

### DIFF
--- a/diem-node/src/lib.rs
+++ b/diem-node/src/lib.rs
@@ -413,7 +413,7 @@ pub fn setup_environment(node_config: &NodeConfig, logger: Option<Arc<Logger>>) 
         state_sync_to_mempool_sender,
         Arc::clone(&db_rw.reader),
         chunk_executor,
-        &node_config,
+        node_config,
         genesis_waypoint,
         reconfig_subscriptions,
     );

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -365,13 +365,7 @@ pub(crate) async fn process_state_sync_request(
         .with_label_values(&[counters::COMMIT_STATE_SYNC_LABEL])
         .observe(req.transactions.len() as f64);
     commit_txns(&mempool, req.transactions, req.block_timestamp_usecs, false).await;
-    let result = if req
-        .callback
-        .send(Ok(CommitResponse {
-            msg: "".to_string(),
-        }))
-        .is_err()
-    {
+    let result = if req.callback.send(Ok(CommitResponse::success())).is_err() {
         error!(LogSchema::event_log(
             LogEntry::StateSyncCommit,
             LogEvent::CallbackFail

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -188,8 +188,27 @@ impl fmt::Display for CommitNotification {
 
 #[derive(Debug)]
 pub struct CommitResponse {
-    /// error msg if applicable - empty string if commit was processed successfully by mempool
-    pub msg: String,
+    pub success: bool,
+    /// The error message if `success` is false.
+    pub error_message: Option<String>,
+}
+
+impl CommitResponse {
+    // Returns a new CommitResponse without an error.
+    pub fn success() -> Self {
+        CommitResponse {
+            success: true,
+            error_message: None,
+        }
+    }
+
+    // Returns a new CommitResponse holding the given error message.
+    pub fn error(error_message: String) -> Self {
+        CommitResponse {
+            success: false,
+            error_message: Some(error_message),
+        }
+    }
 }
 
 /// Successfully executed and committed txn

--- a/state-sync/src/bootstrapper.rs
+++ b/state-sync/src/bootstrapper.rs
@@ -6,10 +6,7 @@ use crate::{
     executor_proxy::{ExecutorProxy, ExecutorProxyTrait},
     network::{StateSyncEvents, StateSyncSender},
 };
-use diem_config::{
-    config::{NodeConfig, RoleType, StateSyncConfig, UpstreamConfig},
-    network_id::NodeNetworkId,
-};
+use diem_config::{config::NodeConfig, network_id::NodeNetworkId};
 use diem_types::waypoint::Waypoint;
 use executor_types::ChunkExecutor;
 use futures::channel::mpsc;
@@ -31,7 +28,7 @@ impl StateSyncBootstrapper {
         state_sync_to_mempool_sender: mpsc::Sender<diem_mempool::CommitNotification>,
         storage: Arc<dyn DbReader>,
         executor: Box<dyn ChunkExecutor>,
-        config: &NodeConfig,
+        node_config: &NodeConfig,
         waypoint: Waypoint,
         reconfig_event_subscriptions: Vec<ReconfigSubscription>,
     ) -> Self {
@@ -46,10 +43,8 @@ impl StateSyncBootstrapper {
             runtime,
             network,
             state_sync_to_mempool_sender,
-            config.base.role,
+            node_config,
             waypoint,
-            &config.state_sync,
-            config.upstream.clone(),
             executor_proxy,
         )
     }
@@ -58,10 +53,8 @@ impl StateSyncBootstrapper {
         runtime: Runtime,
         network: Vec<(NodeNetworkId, StateSyncSender, StateSyncEvents)>,
         state_sync_to_mempool_sender: mpsc::Sender<diem_mempool::CommitNotification>,
-        role: RoleType,
+        node_config: &NodeConfig,
         waypoint: Waypoint,
-        state_sync_config: &StateSyncConfig,
-        upstream_config: UpstreamConfig,
         executor_proxy: E,
     ) -> Self {
         let (coordinator_sender, coordinator_receiver) = mpsc::unbounded();
@@ -77,10 +70,8 @@ impl StateSyncBootstrapper {
             coordinator_receiver,
             state_sync_to_mempool_sender,
             network_senders,
-            role,
+            node_config,
             waypoint,
-            state_sync_config.clone(),
-            upstream_config,
             executor_proxy,
             initial_state,
         )

--- a/state-sync/src/client.rs
+++ b/state-sync/src/client.rs
@@ -104,17 +104,15 @@ impl StateSyncClient {
                         "[State Sync Client] Timeout: failed to receive commit() ack in time!"
                     ))
                 }
-                // TODO(joshlind): clean up the use of CommitResponse.. having a string.is_empty()
-                // to check the presence of an error isn't great :(
                 Ok(response) => {
-                    let CommitResponse { msg } = response??;
-                    if msg != "" {
+                    let response = response??; // Unwrap the futures result to get the body
+                    if response.success {
+                        Ok(())
+                    } else {
                         Err(format_err!(
                             "[State Sync Client] Failed: commit() returned an error: {:?}",
-                            msg
+                            response.error_message
                         ))
-                    } else {
-                        Ok(())
                     }
                 }
             }

--- a/state-sync/src/coordinator.rs
+++ b/state-sync/src/coordinator.rs
@@ -715,7 +715,9 @@ impl<T: ExecutorProxyTrait> StateSyncCoordinator<T> {
 
         // Txns are up to the end of request epoch with the proofs relative to the waypoint LI.
         let end_of_epoch_li = if waypoint_li.ledger_info().epoch() > request.current_epoch {
-            let end_of_epoch_li = self.executor_proxy.get_epoch_proof(request.current_epoch)?;
+            let end_of_epoch_li = self
+                .executor_proxy
+                .get_epoch_change_ledger_info(request.current_epoch)?;
             ensure!(
                 end_of_epoch_li.ledger_info().version() >= request.known_version,
                 "waypoint request's current_epoch (epoch {}, version {}) < waypoint request's known_version {}",
@@ -799,7 +801,9 @@ impl<T: ExecutorProxyTrait> StateSyncCoordinator<T> {
         let mut target_li = target.unwrap_or_else(|| self.local_state.committed_ledger_info());
         let target_epoch = target_li.ledger_info().epoch();
         if target_epoch > request_epoch {
-            let end_of_epoch_li = self.executor_proxy.get_epoch_proof(request_epoch)?;
+            let end_of_epoch_li = self
+                .executor_proxy
+                .get_epoch_change_ledger_info(request_epoch)?;
             debug!(LogSchema::event_log(
                 LogEntry::ProcessChunkRequest,
                 LogEvent::PastEpochRequested

--- a/state-sync/src/shared_components.rs
+++ b/state-sync/src/shared_components.rs
@@ -172,7 +172,7 @@ pub(crate) mod test_utils {
 
     use channel::{diem_channel, message_queues::QueueStyle};
     use diem_config::{
-        config::{RoleType, StateSyncConfig, UpstreamConfig},
+        config::NodeConfig,
         network_id::{NetworkId, NodeNetworkId},
     };
     use diem_types::transaction::{Transaction, WriteSetPayload};
@@ -229,10 +229,8 @@ pub(crate) mod test_utils {
             coordinator_receiver,
             mempool_sender,
             network_senders,
-            RoleType::Validator,
+            &NodeConfig::default(),
             Waypoint::default(),
-            StateSyncConfig::default(),
-            UpstreamConfig::default(),
             executor_proxy,
             initial_state,
         )

--- a/state-sync/tests/test_harness.rs
+++ b/state-sync/tests/test_harness.rs
@@ -309,10 +309,8 @@ impl StateSyncEnvironment {
             Runtime::new().unwrap(),
             network_handles,
             mempool_channel,
-            role,
+            &config,
             waypoint,
-            &config.state_sync,
-            config.upstream,
             MockExecutorProxy::new(handler, storage_proxy.clone()),
         );
 

--- a/state-sync/tests/test_harness.rs
+++ b/state-sync/tests/test_harness.rs
@@ -864,7 +864,7 @@ impl ExecutorProxyTrait for MockExecutorProxy {
         (self.handler)(txns_with_proof)
     }
 
-    fn get_epoch_proof(&self, epoch: u64) -> Result<LedgerInfoWithSignatures> {
+    fn get_epoch_change_ledger_info(&self, epoch: u64) -> Result<LedgerInfoWithSignatures> {
         self.storage.read().get_epoch_changes(epoch)
     }
 


### PR DESCRIPTION
## Motivation

This PR refactors and cleans up some of the logic in state sync. Nothing in state sync should change behaviorally. This PR offers the following commits:
1. Clean up the creation of StateSyncCoordinator (so we're not passing so many objects around).
2. Refactor some of the logic in "process_request_waypoint" in StateSyncCoordinator.
3. Rename "get_epoch_proof" to "get_epoch_change_proof" in executor proxy.
4. Clean up CommitResponse. Right now, if the message in CommitResponse is an empty string, that means no error occurred. Otherwise, the message contains an error.. This isn't clear. Instead, let's add an error flag and a message in CommitResponse.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally.

## Related PRs

This relates to: https://github.com/diem/diem/issues/6795