### PR TITLE
[network] Merge PeerPubkeys and PeerAddresses

### DIFF
--- a/config/seed-peer-generator/Cargo.toml
+++ b/config/seed-peer-generator/Cargo.toml
@@ -27,5 +27,8 @@ diem-temppath = { path = "../../common/temppath", version = "0.1.0" }
 diem-types = { path = "../../types", version = "0.1.0" }
 diem-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 
+[dev-dependencies]
+diem-network-address = {path = "../../network/network-address", version = "0.1.0", features = ["fuzzing"]}
+
 [features]
 default = []

--- a/config/seed-peer-generator/src/main.rs
+++ b/config/seed-peer-generator/src/main.rs
@@ -3,14 +3,9 @@
 
 #![forbid(unsafe_code)]
 
-use diem_config::config::PersistableConfig;
-use diem_network_address::NetworkAddress;
-use diem_types::PeerId;
-use std::{collections::HashMap, path::PathBuf};
+use diem_config::config::{PersistableConfig, RoleType};
+use std::path::PathBuf;
 use structopt::StructOpt;
-
-// TODO: Use the definition from network?
-pub type SeedPeersConfig = HashMap<PeerId, Vec<NetworkAddress>>;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, StructOpt)]
@@ -22,12 +17,20 @@ struct Args {
     #[structopt(short = "e", long)]
     /// JSON RPC endpoint
     endpoint: String,
+    #[structopt(short = "r", long)]
+    role: RoleType,
 }
 
 fn main() {
     let args = Args::from_args();
 
-    let seed_peers_config = seed_peer_generator::utils::gen_seed_peer_config(args.endpoint);
+    let seed_peers_config = match args.role {
+        RoleType::FullNode => {
+            seed_peer_generator::utils::gen_full_node_seed_peer_config(args.endpoint)
+        }
+        _ => panic!("{} not yet supported", args.role),
+    }
+    .expect("Should have generated a trusted peer set");
 
     // Save to a file for loading later
     seed_peers_config

--- a/config/seed-peer-generator/src/utils.rs
+++ b/config/seed-peer-generator/src/utils.rs
@@ -3,6 +3,8 @@
 
 #![forbid(unsafe_code)]
 
+use anyhow::Error;
+use diem_config::config::{TrustedPeer, TrustedPeerSet};
 use diem_logger::prelude::*;
 use diem_network_address::NetworkAddress;
 use diem_secure_json_rpc::JsonRpcClient;
@@ -10,46 +12,124 @@ use diem_types::{
     account_config::diem_root_address, on_chain_config::ValidatorSet,
     validator_info::ValidatorInfo, PeerId,
 };
-use std::collections::HashMap;
 
-// TODO: Use the definition from network?
-pub type SeedPeersConfig = HashMap<PeerId, Vec<NetworkAddress>>;
+/// Retrieve the Fullnode seed peers from JSON-RPC
+pub fn gen_full_node_seed_peer_config(client_endpoint: String) -> anyhow::Result<TrustedPeerSet> {
+    let validator_set = get_validator_set(client_endpoint)?;
 
-pub fn gen_seed_peer_config(client_endpoint: String) -> SeedPeersConfig {
-    let validator_set = get_validator_set(client_endpoint, diem_root_address())
-        .unwrap()
-        .expect("No validator set found.");
-
-    // Collect the validators
-    validator_set
-        .payload()
-        .iter()
-        .filter_map(|v| match to_seed_peer(v) {
-            Ok(result) => Some(result),
-            Err(error) => {
-                warn!(
-                    "Unable to read peer id for validator {} {}",
-                    v.account_address(),
-                    error
-                );
-                None
-            }
-        })
-        .collect::<SeedPeersConfig>()
+    gen_trusted_peers(&validator_set, to_fullnode_addresses)
 }
 
-/// Retrieve validator set from the JSON-RPC endpoint
-fn get_validator_set(endpoint: String, peer_id: PeerId) -> anyhow::Result<Option<ValidatorSet>> {
-    let json_rpc = JsonRpcClient::new(endpoint);
-    let account_state = json_rpc.get_account_state(peer_id, None)?;
-    Ok(account_state.get_validator_set()?)
+pub(crate) fn to_fullnode_addresses(
+    validator_info: &ValidatorInfo,
+) -> Result<Vec<NetworkAddress>, bcs::Error> {
+    validator_info.config().fullnode_network_addresses()
+}
+
+/// Retrieve the validator set from a JSON RPC endpoint
+fn get_validator_set(client_endpoint: String) -> anyhow::Result<ValidatorSet> {
+    let root_account_address = diem_root_address();
+    let json_rpc = JsonRpcClient::new(client_endpoint);
+    let account_state = json_rpc.get_account_state(root_account_address, None)?;
+    if let Some(val) = account_state.get_validator_set()? {
+        Ok(val)
+    } else {
+        Err(Error::msg("No validator set"))
+    }
+}
+
+// TODO: Merge with OnchainDiscovery
+pub(crate) fn gen_trusted_peers<
+    ToAddresses: Fn(&ValidatorInfo) -> Result<Vec<NetworkAddress>, bcs::Error>,
+>(
+    validator_set: &ValidatorSet,
+    to_addresses: ToAddresses,
+) -> anyhow::Result<TrustedPeerSet> {
+    let set = validator_set
+        .payload()
+        .iter()
+        .filter_map(|validator_info| {
+            to_seed_peer(validator_info, &to_addresses).map_or_else(
+                |error| {
+                    warn!(
+                        "Unable to generate seed for validator {} {}",
+                        validator_info.account_address(),
+                        error
+                    );
+                    None
+                },
+                Some,
+            )
+        })
+        .collect::<TrustedPeerSet>();
+
+    if set.is_empty() {
+        Err(Error::msg("No seed peers were generated"))
+    } else {
+        Ok(set)
+    }
 }
 
 /// Convert ValidatorInfo to a seed peer
-fn to_seed_peer(
+fn to_seed_peer<T: Fn(&ValidatorInfo) -> Result<Vec<NetworkAddress>, bcs::Error>>(
     validator_info: &ValidatorInfo,
-) -> Result<(PeerId, Vec<NetworkAddress>), bcs::Error> {
+    to_addresses: &T,
+) -> Result<(PeerId, TrustedPeer), bcs::Error> {
     let peer_id = *validator_info.account_address();
-    let addrs = validator_info.config().fullnode_network_addresses()?;
-    Ok((peer_id, addrs))
+    let addrs = to_addresses(validator_info)?;
+    Ok((peer_id, TrustedPeer::from(addrs)))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::utils::{gen_trusted_peers, to_fullnode_addresses};
+    use diem_config::config::{TrustedPeer, TrustedPeerSet, HANDSHAKE_VERSION};
+    use diem_crypto::{ed25519::Ed25519PrivateKey, x25519, PrivateKey as PK, Uniform};
+    use diem_network_address::NetworkAddress;
+    use diem_types::{
+        on_chain_config::ValidatorSet, validator_config::ValidatorConfig,
+        validator_info::ValidatorInfo, PeerId,
+    };
+    use rand::{prelude::StdRng, SeedableRng};
+
+    fn validator_set(
+        peer_id: PeerId,
+        fullnode_network_addresses: &[NetworkAddress],
+    ) -> ValidatorSet {
+        let consensus_private_key = Ed25519PrivateKey::generate_for_testing();
+        let consensus_pubkey = consensus_private_key.public_key();
+        let validator_config = ValidatorConfig::new(
+            consensus_pubkey,
+            vec![],
+            bcs::to_bytes(fullnode_network_addresses).unwrap(),
+        );
+        let validator_info = ValidatorInfo::new(peer_id, 0, validator_config);
+        ValidatorSet::new(vec![validator_info])
+    }
+
+    fn generate_network_addresses(num: u64) -> Vec<NetworkAddress> {
+        let mut addresses = Vec::new();
+        let mut rng: StdRng = SeedableRng::seed_from_u64(0);
+        for _ in 0..num {
+            let private_key = x25519::PrivateKey::generate(&mut rng);
+            let pubkey = private_key.public_key();
+            let network_address =
+                NetworkAddress::mock().append_prod_protos(pubkey, HANDSHAKE_VERSION);
+            addresses.push(network_address);
+        }
+
+        addresses
+    }
+
+    #[test]
+    fn fullnode_test() {
+        let peer_id = PeerId::random();
+        let fullnode_addresses = generate_network_addresses(3);
+        let validator_set = validator_set(peer_id, &fullnode_addresses);
+        let result = gen_trusted_peers(&validator_set, to_fullnode_addresses).unwrap();
+
+        let mut expected_trusted_peers = TrustedPeerSet::new();
+        expected_trusted_peers.insert(peer_id, TrustedPeer::from(fullnode_addresses));
+        assert_eq!(expected_trusted_peers, result);
+    }
 }

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -42,21 +42,6 @@ pub const CONNECTION_BACKOFF_BASE: u64 = 2;
 pub const IP_BYTE_BUCKET_RATE: usize = 102400 /* 100 KiB */;
 pub const IP_BYTE_BUCKET_SIZE: usize = IP_BYTE_BUCKET_RATE;
 
-/// TODO: For migration compatibility remove later
-pub fn seeds_to_addrs(seeds: &TrustedPeerSet) -> HashMap<PeerId, Vec<NetworkAddress>> {
-    seeds
-        .iter()
-        .map(|(peer_id, TrustedPeer { addresses, .. })| (*peer_id, addresses.clone()))
-        .collect()
-}
-
-pub fn seeds_to_keys(seeds: &TrustedPeerSet) -> HashMap<PeerId, HashSet<x25519::PublicKey>> {
-    seeds
-        .iter()
-        .map(|(peer_id, TrustedPeer { keys, .. })| (*peer_id, keys.clone()))
-        .collect()
-}
-
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct NetworkConfig {

--- a/config/src/config/test_data/validator_full_node.yaml
+++ b/config/src/config/test_data/validator_full_node.yaml
@@ -28,9 +28,11 @@ full_node_networks:
     - listen_address: "/ip4/0.0.0.0/tcp/7180"
       network_id:
           private: "vfn"
-      seed_addrs:
-          "c227da54069989f283712e4016704660":
-              - "/ip4/127.0.0.1/tcp/58259/ln-noise-ik/c998dcd54c3daf48e0ad516d94b7be0b0b7a27caa00541f2b2c14b13500df10b/ln-handshake/0"
+      seeds:
+        "c227da54069989f283712e4016704660":
+          addresses:
+            - "/ip4/127.0.0.1/tcp/58259/ln-noise-ik/c998dcd54c3daf48e0ad516d94b7be0b0b7a27caa00541f2b2c14b13500df10b/ln-handshake/0"
+          keys: ["c998dcd54c3daf48e0ad516d94b7be0b0b7a27caa00541f2b2c14b13500df10b"]
     - discovery_method: "onchain"
       listen_address: "/ip4/0.0.0.0/tcp/8180"
       network_id: "public"

--- a/config/src/generator.rs
+++ b/config/src/generator.rs
@@ -6,12 +6,13 @@
 
 use crate::{
     config::{
-        DiscoveryMethod, NetworkConfig, NodeConfig, SeedAddresses, TestConfig, HANDSHAKE_VERSION,
+        DiscoveryMethod, NetworkConfig, NodeConfig, TestConfig, TrustedPeer, TrustedPeerSet,
+        HANDSHAKE_VERSION,
     },
     network_id::NetworkId,
 };
-use diem_network_address::NetworkAddress;
 use rand::{rngs::StdRng, SeedableRng};
+use std::collections::{HashMap, HashSet};
 
 pub struct ValidatorSwarm {
     pub nodes: Vec<NodeConfig>,
@@ -43,10 +44,10 @@ pub fn validator_swarm(
 
     // set the first validator as every validators' initial configured seed peer.
     let seed_config = &nodes[0].validator_network.as_ref().unwrap();
-    let seed_addrs = build_seed_addrs(&seed_config, seed_config.listen_address.clone());
+    let seeds = build_seed_for_network(&seed_config);
     for node in &mut nodes {
         let network = node.validator_network.as_mut().unwrap();
-        network.seed_addrs = seed_addrs.clone();
+        network.seeds = seeds.clone();
     }
 
     ValidatorSwarm { nodes }
@@ -58,17 +59,22 @@ pub fn validator_swarm_for_testing(nodes: usize) -> ValidatorSwarm {
     validator_swarm(&NodeConfig::default(), nodes, [1u8; 32], true)
 }
 
-/// Convenience function that builds a `SeedAddresses` containing a single peer
+/// Convenience function that builds a `TrustedPeerSet` containing a single peer for testing
 /// with a fully formatted `NetworkAddress` containing its network identity pubkey
 /// and handshake protocol version.
-pub fn build_seed_addrs(
-    seed_config: &NetworkConfig,
-    seed_base_addr: NetworkAddress,
-) -> SeedAddresses {
+pub fn build_seed_for_network(seed_config: &NetworkConfig) -> TrustedPeerSet {
     let seed_pubkey = diem_crypto::PrivateKey::public_key(&seed_config.identity_key());
-    let seed_addr = seed_base_addr.append_prod_protos(seed_pubkey, HANDSHAKE_VERSION);
+    let seed_addr = seed_config
+        .listen_address
+        .clone()
+        .append_prod_protos(seed_pubkey, HANDSHAKE_VERSION);
 
-    let mut seed_addrs = SeedAddresses::default();
-    seed_addrs.insert(seed_config.peer_id(), vec![seed_addr]);
-    seed_addrs
+    let mut keys = HashSet::new();
+    keys.insert(seed_pubkey);
+    let mut seeds = HashMap::default();
+    seeds.insert(
+        seed_config.peer_id(),
+        TrustedPeer::new(vec![seed_addr], keys),
+    );
+    seeds
 }

--- a/docker/compose/public_full_node/public_full_node.yaml
+++ b/docker/compose/public_full_node/public_full_node.yaml
@@ -20,9 +20,10 @@ full_node_networks:
       listen_address: "/ip4/127.0.0.1/tcp/6180"
       network_id: "public"
       # Testnet does not have the right discovery entry points on-chain so this is used instead
-      seed_addrs:
-          D4C4FB4956D899E55289083F45AC5D84:
-              - "/dns4/fn.testnet.diem.com/tcp/6182/ln-noise-ik/d29d01bed8ab6c30921b327823f7e92c63f8371456fb110256e8c0e8911f4938/ln-handshake/0"
+      seeds:
+        D4C4FB4956D899E55289083F45AC5D84:
+          addresses:
+            - "/dns4/fn.testnet.diem.com/tcp/6182/ln-noise-ik/d29d01bed8ab6c30921b327823f7e92c63f8371456fb110256e8c0e8911f4938/ln-handshake/0"
 
 json_rpc:
     # This specifies your JSON-RPC endpoint. Intentionally on public so that Docker can export it.

--- a/network/builder/src/dummy.rs
+++ b/network/builder/src/dummy.rs
@@ -133,7 +133,6 @@ pub fn setup_network() -> DummyNetwork {
     seeds.insert(dialer_peer_id, TrustedPeer::from(dialer_pubkeys));
 
     let trusted_peers = Arc::new(RwLock::new(HashMap::new()));
-
     let authentication_mode = AuthenticationMode::Mutual(listener_identity_private_key);
 
     // Set up the listener network

--- a/network/simple-onchain-discovery/src/lib.rs
+++ b/network/simple-onchain-discovery/src/lib.rs
@@ -193,17 +193,12 @@ impl ConfigurationChangeListener {
 
         // Ensure that the public key matches what's onchain for this peer
         for request in &updates {
-            match request {
-                ConnectivityRequest::UpdateEligibleNodes(_, peer_updates) => {
-                    self.find_key_mismatches(peer_updates.get(&self.network_context.peer_id()))
-                }
-                ConnectivityRequest::UpdateDiscoveredPeers(_, peer_updates) => self
-                    .find_key_mismatches(
-                        peer_updates
-                            .get(&self.network_context.peer_id())
-                            .map(|peer| &peer.keys),
-                    ),
-                _ => {}
+            if let ConnectivityRequest::UpdateDiscoveredPeers(_, peer_updates) = request {
+                self.find_key_mismatches(
+                    peer_updates
+                        .get(&self.network_context.peer_id())
+                        .map(|peer| &peer.keys),
+                )
             }
         }
 

--- a/state-sync/tests/test_harness.rs
+++ b/state-sync/tests/test_harness.rs
@@ -4,7 +4,7 @@
 use anyhow::{bail, format_err, Result};
 use channel::{diem_channel, message_queues::QueueStyle};
 use diem_config::{
-    config::{NodeConfig, RoleType, HANDSHAKE_VERSION},
+    config::{NodeConfig, RoleType, TrustedPeer, HANDSHAKE_VERSION},
     network_id::{NetworkContext, NetworkId, NodeNetworkId},
 };
 use diem_crypto::{
@@ -379,15 +379,14 @@ impl StateSyncEnvironment {
                 peer.peer_id,
             ));
 
-            let seed_addrs: HashMap<_, _> = self
+            let seeds: HashMap<_, _> = self
                 .peers
                 .iter()
                 .map(|peer| {
                     let peer = peer.borrow();
-                    (peer.peer_id, vec![peer.network_addr.clone()])
+                    (peer.peer_id, TrustedPeer::from(peer.network_addr.clone()))
                 })
                 .collect();
-            let seed_pubkeys = HashMap::new();
             let trusted_peers = Arc::new(RwLock::new(HashMap::new()));
 
             // Recover the base address we bound previously.
@@ -397,8 +396,7 @@ impl StateSyncEnvironment {
 
             let mut network_builder = NetworkBuilder::new_for_test(
                 ChainId::default(),
-                seed_addrs,
-                seed_pubkeys,
+                &seeds,
                 trusted_peers,
                 network_context,
                 base_addr,


### PR DESCRIPTION
### Overview
Merging PeerPubkeys and PeerAddresses, so that there is one object that carries around state from peers found in discovery.  This will allow us to add additional state e.g. PeerRole in this space, which can also be found via discovery.

Once these changes are in, I'll move on to adding role.