### PR TITLE
Preloading accounts for executor in a parallel thread

### DIFF
--- a/storage/storage-interface/src/state_view.rs
+++ b/storage/storage-interface/src/state_view.rs
@@ -173,11 +173,16 @@ impl<'a> StateView for VerifiedStateView<'a> {
                             err
                         )
                     })?;
-                assert!(self
-                    .account_to_proof_cache
+                self.account_to_proof_cache
                     .write()
-                    .insert(address_hash, proof)
-                    .is_none());
+                    .insert(address_hash, proof);
+                // multiple threads may enter this code, and another thread might add
+                // an address before this one
+                /* assert!(self
+                .account_to_proof_cache
+                .write()
+                .insert(address_hash, proof)
+                .is_none()); */
                 blob
             }
         };


### PR DESCRIPTION
## Motivation

Currently execution spends a significant amount of time reading accounts from storage and verifying the proofs. This PR initiates a single thread to preload these accounts in parallel to the executor. The intuition confirmed by benchmarks is that this preloading thread runs faster and gets ahead of execution, preload required accounts.

For each transaction in a block we fetch sender’s address and all arguments of type address, put those in an ordered list and start a single thread, run in parallel to the executor, that loads accounts from the list in that order into the account_to_state_cache of the VerifiedStateView.

In case we manage to make execution faster than storage interfaces, we can run preloading in multiple threads!

## Benchmarking
Benchmarking was done in multiple ways by running executor's benchmark (note that this benchmark initiates simple p2p transfers with uniform distribution over the accounts):
* measuring cache hits and cache misses,
  * no preloading: cache misses ~= the number of transactions per block
  * parallel preloading: cache misses ~= 0
* measuring the time spent on preloading vs time spent on executing - about 6-12% (using Xcode Instruments/Time Profiler)
  * 100 accounts, 100 transactions per block: 6% of execution spent on preloading
  * 10k accounts, 5k transactions per block: 12% of execution spent on preloading
  * 10k accounts, 1k transactions per block: 10% of execution spend on preloading
* getting execution time per block and TPS: for large loads the execution time goes down 18%, TPS goes up 15-20%
  * 10k accounts, 5k txs/block
    * no preloading: execute_time = 4,748 ± 837, TPS = 807 ± 116
    * parallel preloading: execute_time = 3,817 ± 805, TPS = 972 ± 135
  * 100k accounts, 10k transactions per block
    * no preloading: execute_time = 14,030 ± 4,493, TPS = 558 ± 114
    * parallel preloading: execute_time = 11,476 ± 2,323, TPS = 650 ± 134

*Upcoming future work*: creating a batched Merkle proof for multiple accounts at once (to avoid duplication of hash values).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

The preloading should not affect correctness, it happens in the parallel thread and worst case does not preload anything useful.

## Related PRs

This PR is based on  https://github.com/diem/diem/pull/7277.