### PR TITLE
[writeset-generator] Remove lengthy prints.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6371,6 +6371,7 @@ dependencies = [
  "backup-cli",
  "bcs",
  "cli",
+ "compiled-stdlib",
  "debug-interface",
  "diem-config",
  "diem-crypto",
@@ -6407,7 +6408,6 @@ dependencies = [
  "rust_decimal",
  "rusty-fork",
  "statistical",
- "stdlib",
  "tokio",
  "transaction-builder",
 ]

--- a/language/diem-tools/writeset-transaction-generator/src/release_flow/mod.rs
+++ b/language/diem-tools/writeset-transaction-generator/src/release_flow/mod.rs
@@ -13,15 +13,12 @@ pub use create::create_release;
 pub use verify::verify_release;
 
 pub mod test_utils {
+    use compiled_stdlib::{stdlib_modules, StdLibOptions};
     use diem_types::account_config::CORE_CODE_ADDRESS;
-    use stdlib::build_stdlib;
     use vm::{file_format::empty_module, CompiledModule};
 
     pub fn release_modules() -> Vec<CompiledModule> {
-        let mut modules = build_stdlib()
-            .into_iter()
-            .map(|(_, m)| m)
-            .collect::<Vec<_>>();
+        let mut modules = stdlib_modules(StdLibOptions::Compiled).to_vec();
         // Publish a new dummy module
         let mut module = empty_module();
         module.address_identifiers[0] = CORE_CODE_ADDRESS;

--- a/language/diem-tools/writeset-transaction-generator/src/release_flow/verify.rs
+++ b/language/diem-tools/writeset-transaction-generator/src/release_flow/verify.rs
@@ -98,14 +98,8 @@ pub(crate) fn verify_payload_change(
                     };
 
                     match old_modules.insert(module_id.clone(), updated_module.clone()) {
-                        Some(_) => println!(
-                            "Updating existing module: {:?} \n {:#?}",
-                            module_id, updated_module
-                        ),
-                        None => println!(
-                            "Adding new module: {:?} \n {:#?}",
-                            module_id, updated_module
-                        ),
+                        Some(_) => println!("Updating existing module: {:?}", module_id),
+                        None => println!("Adding new module: {:?}", module_id),
                     }
                 }
             }

--- a/testsuite/smoke-test/Cargo.toml
+++ b/testsuite/smoke-test/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { version = "1.1.0", features = ["full"] }
 
 backup-cli = { path = "../../storage/backup/backup-cli", version = "0.1.0" }
 cli = { path = "../cli", version = "0.1.0", features = ["fuzzing"]  }
+compiled-stdlib = { path = "../../language/stdlib/compiled", version = "0.1.0" }
 debug-interface = { path = "../../common/debug-interface", version = "0.1.0" }
 generate-key = { path = "../../config/generate-key", version = "0.1.0" }
 bcs = "0.1.2"
@@ -52,5 +53,4 @@ diem-vault-client = { path = "../../secure/storage/vault", version = "0.1.0", fe
 diem-validator-interface = { path = "../../language/diem-tools/diem-validator-interface", version = "0.1.0" }
 diem-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 diem-writeset-generator = { path = "../../language/diem-tools/writeset-transaction-generator", version = "0.1.0" }
-stdlib = { path = "../../language/stdlib", version = "0.1.0" }
 transaction-builder = { path = "../../language/transaction-builder", version = "0.1.0" }

--- a/testsuite/smoke-test/src/release_flow.rs
+++ b/testsuite/smoke-test/src/release_flow.rs
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::test_utils::{diem_swarm_utils::get_json_rpc_url, setup_swarm_and_client_proxy};
+use compiled_stdlib::{stdlib_modules, StdLibOptions};
 use diem_types::{chain_id::ChainId, transaction::TransactionPayload};
 use diem_validator_interface::{DiemValidatorInterface, JsonRpcDebuggerInterface};
 use diem_writeset_generator::{
     create_release, release_flow::test_utils::release_modules, verify_release,
 };
 use std::collections::BTreeMap;
-use stdlib::build_stdlib;
 
 #[test]
 fn test_move_release_flow() {
@@ -17,18 +17,19 @@ fn test_move_release_flow() {
     let validator_interface = JsonRpcDebuggerInterface::new(&url).unwrap();
 
     let chain_id = ChainId::test();
-    let old_modules = build_stdlib()
-        .into_iter()
-        .map(|(_, m)| m)
-        .collect::<Vec<_>>();
+    let old_modules = stdlib_modules(StdLibOptions::Compiled).to_vec();
 
     let release_modules = release_modules();
 
+    // Execute some random transactions to make sure a new block is created.
+    client.create_next_account(false).unwrap();
+    client.mint_coins(&["mb", "0", "100", "XUS"], true).unwrap();
+
     // With no artifact for TESTING, creating a release should fail.
-    assert!(create_release(chain_id, url.clone(), 10, false, &release_modules).is_err());
+    assert!(create_release(chain_id, url.clone(), 1, false, &release_modules).is_err());
 
     // Generate the first release package. It should pass and verify.
-    let payload_1 = create_release(chain_id, url.clone(), 10, true, &release_modules).unwrap();
+    let payload_1 = create_release(chain_id, url.clone(), 1, true, &release_modules).unwrap();
     // Verifying the generated payload against release modules should pass.
     verify_release(chain_id, url.clone(), &payload_1, &release_modules).unwrap();
     // Verifying the generated payload against older modules should pass due to hash mismatch.
@@ -59,7 +60,6 @@ fn test_move_release_flow() {
     );
 
     // Execute some random transactions to make sure a new block is created.
-    client.create_next_account(false).unwrap();
     client.mint_coins(&["mb", "0", "100", "XUS"], true).unwrap();
 
     let latest_version = validator_interface.get_latest_version().unwrap();


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The println for modules aren't human readable at all and is spamming the log for testing. Remove the prints here to fix the issue.

This PR also fixes another issue in the release testing flow: The first release should be created on checked in `compiled_stdlib` instead of the freshly built stdlib to match the modules in the genesis.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

`cargo test`