### PR TITLE
[backup] fix failure with updated tokio

### DIFF
--- a/storage/backup/backup-cli/src/storage/command_adapter/command.rs
+++ b/storage/backup/backup-cli/src/storage/command_adapter/command.rs
@@ -139,9 +139,10 @@ impl<'a> AsyncRead for ChildStdoutAsDataSource<'a> {
         buf: &mut ReadBuf<'_>,
     ) -> Poll<::std::io::Result<()>> {
         if self.child.is_some() {
+            let filled_before_poll = buf.filled().len();
             let res = Pin::new(self.child.as_mut().unwrap().stdout()).poll_read(cx, buf);
             match res {
-                Poll::Ready(Ok(())) if buf.filled().is_empty() => {
+                Poll::Ready(Ok(())) if buf.filled().len() == filled_before_poll => {
                     // hit EOF, start joining self.child
                     self.join_fut = Some(self.child.take().unwrap().join().boxed());
                 }


### PR DESCRIPTION


## Motivation

`ChildStdoutAsDataSource` behaves wrongly with tokio 1.1.0. Issue is with the way we determine the EOF.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?
Y
## Test Plan
existing coverage. And with manual overwrite of tokio version to 1.1.0
## Related PRs

https://github.com/diem/diem/pull/7147