### PR TITLE
[deps] kube update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3688,12 +3688,12 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcaa8ea719de24e21fe6fddb2ea996ca4e312d467c119f827551c4768d97dc5c"
+checksum = "bcc1f973542059e6d5a6d63de6a9539d0ec784f82b2327f3c1915d33200bc6a4"
 dependencies = [
  "base64 0.13.0",
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "chrono",
  "serde",
  "serde-value",
@@ -3708,9 +3708,9 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "kube"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bb7bdbc1449790093a734b06a0bca7493395694f6e6e6f21e8006108085b3e"
+checksum = "65b653297fc54118e32fd198c3afea77481550ada03267c68e658714c716d72a"
 dependencies = [
  "Inflector",
  "base64 0.13.0",

--- a/testsuite/cluster-test/Cargo.toml
+++ b/testsuite/cluster-test/Cargo.toml
@@ -65,6 +65,6 @@ futures = "0.3.12"
 tokio = { version = "1.0.2", features = ["full"] }
 async-trait = "0.1.42"
 
-kube = "0.47.0"
+kube = "0.48.0"
 
-k8s-openapi = { version = "0.10.0", default-features = false, features = ["v1_15"] }
+k8s-openapi = { version = "0.11.0", default-features = false, features = ["v1_15"] }


### PR DESCRIPTION
## Motivation

Handle the oh-so-annoying shared update of kube/k8s-openapi which must be updated together.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

A kinda-sorta-speedy CI run.

## Related PRs

kube update: https://github.com/diem/diem/pull/7344
k8s-openapi update: https://github.com/diem/diem/pull/7350