### PR TITLE
Cherry-pick PR #7329 into release-1.1: [backup] support for specifying trusted waypoints in restore / verify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,6 +276,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml",
+ "warp",
 ]
 
 [[package]]

--- a/storage/backup/backup-cli/Cargo.toml
+++ b/storage/backup/backup-cli/Cargo.toml
@@ -47,6 +47,7 @@ storage-interface = { path = "../../storage-interface", version = "0.1.0" }
 
 [dev-dependencies]
 proptest = "0.10.1"
+warp = "0.3.0"
 
 backup-service = { path = "../backup-service", version = "0.1.0" }
 executor-test-helpers = { path = "../../../execution/executor-test-helpers", version = "0.1.0" }

--- a/storage/backup/backup-cli/src/backup_types/epoch_ending/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/epoch_ending/tests.rs
@@ -4,25 +4,35 @@
 use crate::{
     backup_types::epoch_ending::{
         backup::{EpochEndingBackupController, EpochEndingBackupOpt},
-        restore::{EpochEndingRestoreController, EpochEndingRestoreOpt},
+        restore::{
+            EpochEndingRestoreController, EpochEndingRestoreOpt, EpochHistoryRestoreController,
+        },
     },
     storage::{local_fs::LocalFs, BackupStorage},
     utils::{
         backup_service_client::BackupServiceClient, test_utils::tmp_db_with_random_content,
-        GlobalBackupOpt, GlobalRestoreOpt, RocksdbOpt,
+        GlobalBackupOpt, GlobalRestoreOpt, RocksdbOpt, TrustedWaypointOpt,
     },
 };
 use backup_service::start_backup_service;
 use diem_config::{config::RocksdbConfig, utils::get_available_port};
 use diem_temppath::TempPath;
+use diem_types::{
+    ledger_info::LedgerInfoWithSignatures,
+    proptest_types::{AccountInfoUniverse, LedgerInfoWithSignaturesGen},
+    waypoint::Waypoint,
+};
 use diemdb::DiemDB;
+use proptest::{collection::vec, prelude::*, std_facade::BTreeMap};
 use std::{
     convert::TryInto,
+    io::Write,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     sync::Arc,
 };
 use storage_interface::DbReader;
-use tokio::time::Duration;
+use tokio::{runtime::Runtime, time::Duration};
+use warp::Filter;
 
 #[test]
 fn end_to_end() {
@@ -70,6 +80,7 @@ fn end_to_end() {
                 db_dir: Some(tgt_db_dir.path().to_path_buf()),
                 dry_run: false,
                 target_version: Some(target_version),
+                trusted_waypoints: TrustedWaypointOpt::default(),
                 rocksdb_opt: RocksdbOpt::default(),
             }
             .try_into()
@@ -106,4 +117,147 @@ fn end_to_end() {
     );
 
     rt.shutdown_timeout(Duration::from_secs(1));
+}
+
+prop_compose! {
+    fn arb_epoch_endings_with_trusted_waypoints()(
+        num_blocks in 1..10usize,
+    )(
+        mut universe in any_with::<AccountInfoUniverse>(3),
+        blocks in vec(
+            (
+                1..100usize, // block size
+                any::<LedgerInfoWithSignaturesGen>(),
+                any::<bool>(), // overwrite validator set
+                any::<bool>(), // trusted even if not overwriting validator set
+            ),
+            num_blocks
+        )
+    ) -> (Vec<LedgerInfoWithSignatures>, Vec<Waypoint>, bool) {
+        let mut should_fail_without_waypoints = false;
+        let mut res_lis = Vec::new();
+        let mut res_waypoints = Vec::new();
+        for (block_size, gen, overwrite, trusted) in blocks {
+            let mut li = gen.materialize(&mut universe, block_size);
+            if li.ledger_info().ends_epoch() {
+                if overwrite && li.ledger_info().epoch() != 0 {
+                    li = LedgerInfoWithSignatures::new(
+                        li.ledger_info().clone(),
+                        BTreeMap::new(),
+                    );
+                    should_fail_without_waypoints = true;
+                }
+                if overwrite || trusted {
+                    res_waypoints.push(Waypoint::new_epoch_boundary(&li.ledger_info()).unwrap())
+                }
+                res_lis.push(li);
+
+            }
+        }
+        (res_lis, res_waypoints, should_fail_without_waypoints)
+    }
+}
+
+async fn mock_backup_service_get_epoch_ending_lis(lis: Vec<LedgerInfoWithSignatures>) -> u16 {
+    let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
+    let route = warp::path!("epoch_ending_ledger_infos" / usize / usize).map(move |start, end| {
+        let mut response = Vec::<u8>::new();
+        for li in &lis[start..end] {
+            let bytes = bcs::to_bytes(&li).unwrap();
+            let size_bytes = (bytes.len() as u32).to_be_bytes();
+            response.write_all(&size_bytes).unwrap();
+            response.write_all(&bytes).unwrap();
+        }
+        response
+    });
+    let (addr, svr) = warp::serve(route).bind_ephemeral(address);
+    tokio::spawn(svr);
+    addr.port()
+}
+
+async fn test_trusted_waypoints_impl(
+    lis: Vec<LedgerInfoWithSignatures>,
+    trusted_waypoints: Vec<Waypoint>,
+    should_fail_without: bool,
+) {
+    let backup_dir = TempPath::new();
+    backup_dir.create_as_dir().unwrap();
+    let store: Arc<dyn BackupStorage> = Arc::new(LocalFs::new(backup_dir.path().to_path_buf()));
+    let port = mock_backup_service_get_epoch_ending_lis(lis.clone()).await;
+    let client = Arc::new(BackupServiceClient::new(format!(
+        "http://localhost:{}",
+        port
+    )));
+
+    let mut manifests = Vec::new();
+    let mut start = 0;
+    while start < lis.len() {
+        let m = EpochEndingBackupController::new(
+            EpochEndingBackupOpt {
+                start_epoch: start as u64,
+                end_epoch: std::cmp::min(start + 2, lis.len()) as u64,
+            },
+            GlobalBackupOpt {
+                max_chunk_size: 1024,
+            },
+            client.clone(),
+            Arc::clone(&store),
+        )
+        .run()
+        .await
+        .unwrap();
+        manifests.push(m);
+        start += 2;
+    }
+
+    let res_without_waypoints = EpochHistoryRestoreController::new(
+        manifests.clone(),
+        GlobalRestoreOpt {
+            db_dir: None,
+            dry_run: true,
+            target_version: None,
+            trusted_waypoints: TrustedWaypointOpt::default(),
+            rocksdb_opt: RocksdbOpt::default(),
+        }
+        .try_into()
+        .unwrap(),
+        Arc::clone(&store),
+    )
+    .run()
+    .await;
+    assert_eq!(should_fail_without, res_without_waypoints.is_err());
+
+    let restored = EpochHistoryRestoreController::new(
+        manifests,
+        GlobalRestoreOpt {
+            db_dir: None,
+            dry_run: true,
+            target_version: None,
+            trusted_waypoints: TrustedWaypointOpt {
+                trust_waypoint: trusted_waypoints,
+            },
+            rocksdb_opt: RocksdbOpt::default(),
+        }
+        .try_into()
+        .unwrap(),
+        Arc::clone(&store),
+    )
+    .run()
+    .await
+    .unwrap();
+    assert_eq!(
+        lis.into_iter()
+            .map(|li| li.ledger_info().clone())
+            .collect::<Vec<_>>(),
+        restored.epoch_endings,
+    );
+}
+
+proptest! {
+    #[test]
+    fn trusted_waypoints(
+        (lis, trusted_waypoints, should_fail_without) in arb_epoch_endings_with_trusted_waypoints()
+    ) {
+        Runtime::new().unwrap().block_on(test_trusted_waypoints_impl(lis, trusted_waypoints, should_fail_without))
+    }
 }

--- a/storage/backup/backup-cli/src/backup_types/state_snapshot/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/state_snapshot/tests.rs
@@ -10,7 +10,7 @@ use crate::{
     utils::{
         backup_service_client::BackupServiceClient,
         test_utils::{start_local_backup_service, tmp_db_with_random_content},
-        GlobalBackupOpt, GlobalRestoreOpt, RocksdbOpt,
+        GlobalBackupOpt, GlobalRestoreOpt, RocksdbOpt, TrustedWaypointOpt,
     },
 };
 use diem_config::config::RocksdbConfig;
@@ -64,6 +64,7 @@ fn end_to_end() {
                 dry_run: false,
                 db_dir: Some(tgt_db_dir.path().to_path_buf()),
                 target_version: None, // max
+                trusted_waypoints: TrustedWaypointOpt::default(),
                 rocksdb_opt: RocksdbOpt::default(),
             }
             .try_into()

--- a/storage/backup/backup-cli/src/backup_types/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/tests.rs
@@ -15,7 +15,7 @@ use crate::{
     storage::{local_fs::LocalFs, BackupStorage},
     utils::{
         backup_service_client::BackupServiceClient, test_utils::start_local_backup_service,
-        GlobalBackupOpt, GlobalRestoreOpt, GlobalRestoreOptions, RocksdbOpt,
+        GlobalBackupOpt, GlobalRestoreOpt, GlobalRestoreOptions, RocksdbOpt, TrustedWaypointOpt,
     },
 };
 use diem_config::config::RocksdbConfig;
@@ -110,6 +110,7 @@ fn test_end_to_end_impl(d: TestData) {
         dry_run: false,
         db_dir: Some(tgt_db_dir.path().to_path_buf()),
         target_version: Some(d.target_ver),
+        trusted_waypoints: TrustedWaypointOpt::default(),
         rocksdb_opt: RocksdbOpt::default(),
     }
     .try_into()

--- a/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
@@ -10,7 +10,7 @@ use crate::{
     utils::{
         backup_service_client::BackupServiceClient,
         test_utils::{start_local_backup_service, tmp_db_with_random_content},
-        GlobalBackupOpt, GlobalRestoreOpt, RocksdbOpt,
+        GlobalBackupOpt, GlobalRestoreOpt, RocksdbOpt, TrustedWaypointOpt,
     },
 };
 use diem_config::config::RocksdbConfig;
@@ -82,6 +82,7 @@ fn end_to_end() {
                 dry_run: false,
                 db_dir: Some(tgt_db_dir.path().to_path_buf()),
                 target_version: Some(target_version),
+                trusted_waypoints: TrustedWaypointOpt::default(),
                 rocksdb_opt: RocksdbOpt::default(),
             }
             .try_into()

--- a/storage/backup/backup-cli/src/bin/db-backup.rs
+++ b/storage/backup/backup-cli/src/bin/db-backup.rs
@@ -1,7 +1,11 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use anyhow::Result;
+use structopt::StructOpt;
+
 use backup_cli::{
     backup_types::{
         epoch_ending::backup::{EpochEndingBackupController, EpochEndingBackupOpt},
@@ -18,8 +22,6 @@ use backup_cli::{
 };
 use diem_logger::{prelude::*, Level, Logger};
 use diem_secure_push_metrics::MetricsPusher;
-use std::sync::Arc;
-use structopt::StructOpt;
 
 #[derive(StructOpt)]
 #[structopt(about = "Diem backup tool.")]

--- a/storage/backup/backup-cli/src/coordinators/verify.rs
+++ b/storage/backup/backup-cli/src/coordinators/verify.rs
@@ -67,6 +67,7 @@ impl VerifyCoordinator {
 
         let global_opt = GlobalRestoreOptions {
             target_version: ver_max,
+            trusted_waypoints: Default::default(),
             run_mode: Arc::new(RestoreRunMode::Verify),
         };
 

--- a/storage/backup/backup-cli/src/utils/mod.rs
+++ b/storage/backup/backup-cli/src/utils/mod.rs
@@ -14,9 +14,10 @@ use diem_config::config::RocksdbConfig;
 use diem_crypto::HashValue;
 use diem_infallible::duration_since_epoch;
 use diem_jellyfish_merkle::{restore::JellyfishMerkleRestore, NodeBatch, TreeWriter};
-use diem_types::transaction::Version;
+use diem_types::{transaction::Version, waypoint::Waypoint};
 use diemdb::{backup::restore_handler::RestoreHandler, DiemDB, GetRestoreHandler};
 use std::{
+    collections::HashMap,
     convert::TryFrom,
     mem::size_of,
     path::{Path, PathBuf},
@@ -83,6 +84,9 @@ pub struct GlobalRestoreOpt {
     pub target_version: Option<Version>,
 
     #[structopt(flatten)]
+    pub trusted_waypoints: TrustedWaypointOpt,
+
+    #[structopt(flatten)]
     pub rocksdb_opt: RocksdbOpt,
 }
 
@@ -135,6 +139,7 @@ impl RestoreRunMode {
 #[derive(Clone)]
 pub struct GlobalRestoreOptions {
     pub target_version: Version,
+    pub trusted_waypoints: Arc<HashMap<Version, Waypoint>>,
     pub run_mode: Arc<RestoreRunMode>,
 }
 
@@ -157,8 +162,40 @@ impl TryFrom<GlobalRestoreOpt> for GlobalRestoreOptions {
         };
         Ok(Self {
             target_version,
+            trusted_waypoints: Arc::new(opt.trusted_waypoints.verify()?),
             run_mode: Arc::new(run_mode),
         })
+    }
+}
+
+#[derive(Clone, Default, StructOpt)]
+pub struct TrustedWaypointOpt {
+    #[structopt(
+        long,
+        help = "(multiple) When provided, an epoch ending LedgerInfo at the waypoint version will be \
+        checked against the hash in the waypoint, but signatures on it are NOT checked. \
+        Use this for two purposes: \
+        1. set the genesis or the latest waypoint to confirm the backup is compatible. \
+        2. set waypoints at versions where writeset transactions were used to overwrite the \
+        validator set, so that the signature check is skipped. \
+        N.B. LedgerInfos are verified only when restoring / verifying the epoch ending backups, \
+        i.e. they are NOT checked at all when doing one-shot restoring of the transaction \
+        and state backups."
+    )]
+    pub trust_waypoint: Vec<Waypoint>,
+}
+
+impl TrustedWaypointOpt {
+    pub fn verify(self) -> Result<HashMap<Version, Waypoint>> {
+        let mut trusted_waypoints = HashMap::new();
+        for w in self.trust_waypoint {
+            trusted_waypoints
+                .insert(w.version(), w)
+                .map_or(Ok(()), |w| {
+                    Err(anyhow!("Duplicated waypoints at version {}", w.version()))
+                })?;
+        }
+        Ok(trusted_waypoints)
     }
 }
 


### PR DESCRIPTION
This cherry-pick was triggerd by a request on #7329
Please review the diff to ensure there are not any unexpected changes.

> Two possible uses:
> 1. set the genesis or the latest waypoint to confirm the backup is compatible.
> 2. set waypoints at versions where writeset transactions were used to overwrite the validator set, so that the signature check is skipped.
> 
> <!--
> Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.
> 
> The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
> -->
> 
> ## Motivation
> 
> (Write your motivation for proposed changes here.)
> 
> ### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?
> 
> (Write your answer here.)
> 
> ## Test Plan
> 
> (Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)
> 
> ## Related PRs
> 
> (If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/master/developers.diem.com, and link to your PR here.)

            
cc @msmouse