### PR TITLE
[network] Integrate `TimeService` into `Peer` actor and its tests.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4421,6 +4421,7 @@ dependencies = [
  "diem-network-address",
  "diem-proptest-helpers",
  "diem-rate-limiter",
+ "diem-time-service",
  "diem-types",
  "diem-workspace-hack",
  "futures 0.3.12",

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -41,6 +41,7 @@ diem-metrics = { path = "../common/metrics", version = "0.1.0" }
 diem-network-address = { path = "../network/network-address", version = "0.1.0" }
 diem-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0", optional = true }
 diem-rate-limiter = { path = "../common/rate-limiter", version = "0.1.0"}
+diem-time-service = { path = "../common/time-service", version = "0.1.0", features = ["async"] }
 diem-types = { path = "../types", version = "0.1.0" }
 diem-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
 memsocket = { path = "../network/memsocket", version = "0.1.0", optional = true }
@@ -62,8 +63,8 @@ socket-bench-server = { path = "../network/socket-bench-server", version = "0.1.
 
 [features]
 default = []
-fuzzing = ["bitvec/fuzzing", "diem-proptest-helpers", "diem-types/fuzzing", "diem-network-address/fuzzing", "diem-crypto/fuzzing", "memsocket/testing", "netcore/fuzzing", "proptest", "proptest-derive", "rand_core"]
-testing = ["diem-config/testing", "memsocket/testing", "netcore/testing"]
+fuzzing = ["bitvec/fuzzing", "diem-crypto/fuzzing", "diem-network-address/fuzzing", "diem-proptest-helpers", "diem-time-service/testing", "diem-types/fuzzing", "memsocket/testing", "netcore/fuzzing", "proptest", "proptest-derive", "rand_core"]
+testing = ["diem-config/testing", "diem-time-service/testing", "memsocket/testing", "netcore/testing"]
 
 [[bench]]
 name = "socket_bench"

--- a/network/src/peer/fuzzing.rs
+++ b/network/src/peer/fuzzing.rs
@@ -16,6 +16,7 @@ use channel::{diem_channel, message_queues::QueueStyle};
 use diem_config::network_id::NetworkContext;
 use diem_network_address::NetworkAddress;
 use diem_proptest_helpers::ValueGenerator;
+use diem_time_service::TimeService;
 use diem_types::PeerId;
 use futures::{executor::block_on, future, io::AsyncReadExt, sink::SinkExt, stream::StreamExt};
 use memsocket::MemorySocket;
@@ -108,6 +109,7 @@ pub fn fuzz(data: &[u8]) {
     let peer = Peer::new(
         network_context,
         executor.clone(),
+        TimeService::mock(),
         connection,
         connection_notifs_tx,
         peer_reqs_rx,

--- a/network/src/peer/mod.rs
+++ b/network/src/peer/mod.rs
@@ -34,6 +34,7 @@ use channel::diem_channel;
 use diem_config::network_id::NetworkContext;
 use diem_logger::prelude::*;
 use diem_rate_limiter::rate_limit::SharedBucket;
+use diem_time_service::{TimeService, TimeServiceTrait};
 use diem_types::PeerId;
 use futures::{
     self,
@@ -107,6 +108,8 @@ pub struct Peer<TSocket> {
     network_context: Arc<NetworkContext>,
     /// A handle to a tokio executor.
     executor: Handle,
+    /// A handle to a time service for easily mocking time-related operations.
+    time_service: TimeService,
     /// Connection specific information.
     connection_metadata: ConnectionMetadata,
     /// Underlying connection.
@@ -139,6 +142,7 @@ where
     pub fn new(
         network_context: Arc<NetworkContext>,
         executor: Handle,
+        time_service: TimeService,
         connection: Connection<TSocket>,
         connection_notifs_tx: channel::Sender<TransportNotification<TSocket>>,
         peer_reqs_rx: diem_channel::Receiver<ProtocolId, PeerRequest>,
@@ -158,6 +162,7 @@ where
         Self {
             network_context: network_context.clone(),
             executor,
+            time_service: time_service.clone(),
             connection_metadata,
             connection: Some(socket),
             connection_notifs_tx,
@@ -165,12 +170,14 @@ where
             peer_notifs_tx,
             inbound_rpcs: InboundRpcs::new(
                 network_context.clone(),
+                time_service.clone(),
                 remote_peer_id,
                 inbound_rpc_timeout,
                 max_concurrent_inbound_rpcs,
             ),
             outbound_rpcs: OutboundRpcs::new(
                 network_context,
+                time_service,
                 remote_peer_id,
                 max_concurrent_outbound_rpcs,
             ),
@@ -217,6 +224,7 @@ where
         //   2. `close_tx`: Handle to close the task and underlying connection.
         let (mut write_reqs_tx, writer_close_tx) = Self::start_writer_task(
             &self.executor,
+            self.time_service.clone(),
             self.connection_metadata.clone(),
             self.network_context.clone(),
             writer,
@@ -292,6 +300,7 @@ where
     // them and immediately closes the connection.
     fn start_writer_task(
         executor: &Handle,
+        time_service: TimeService,
         connection_metadata: ConnectionMetadata,
         network_context: Arc<NetworkContext>,
         mut writer: NetworkMessageSink<impl AsyncWrite + Unpin + Send + 'static>,
@@ -349,7 +358,10 @@ where
                 writer.close().await?;
                 Ok(()) as Result<(), WriteError>
             };
-            match tokio::time::timeout(transport::TRANSPORT_TIMEOUT, flush_and_close).await {
+            match time_service
+                .timeout(transport::TRANSPORT_TIMEOUT, flush_and_close)
+                .await
+            {
                 Err(_) => {
                     info!(
                         NetworkSchema::new(&network_context)

--- a/network/src/peer/test.rs
+++ b/network/src/peer/test.rs
@@ -26,6 +26,7 @@ use bytes::Bytes;
 use channel::{self, diem_channel, message_queues::QueueStyle};
 use diem_config::network_id::NetworkContext;
 use diem_network_address::NetworkAddress;
+use diem_time_service::TimeService;
 use diem_types::PeerId;
 use futures::{
     channel::oneshot,
@@ -78,6 +79,7 @@ fn build_test_peer(
     let peer = Peer::new(
         NetworkContext::mock(),
         executor,
+        TimeService::real(),
         connection,
         connection_notifs_tx,
         peer_reqs_rx,

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -30,6 +30,7 @@ use diem_config::network_id::NetworkContext;
 use diem_logger::prelude::*;
 use diem_network_address::NetworkAddress;
 use diem_rate_limiter::rate_limit::TokenBucketRateLimiter;
+use diem_time_service::TimeService;
 use diem_types::PeerId;
 use futures::{
     channel::oneshot,
@@ -797,6 +798,7 @@ where
         let peer = Peer::new(
             self.network_context.clone(),
             self.executor.clone(),
+            TimeService::real(),
             connection,
             self.transport_notifs_tx.clone(),
             peer_reqs_rx,

--- a/network/src/protocols/rpc/mod.rs
+++ b/network/src/protocols/rpc/mod.rs
@@ -61,6 +61,7 @@ use bytes::Bytes;
 use channel::diem_channel;
 use diem_config::network_id::NetworkContext;
 use diem_logger::prelude::*;
+use diem_time_service::{timeout, TimeService, TimeServiceTrait};
 use diem_types::PeerId;
 use error::RpcError;
 use futures::{
@@ -162,6 +163,8 @@ impl PartialEq for InboundRpcRequest {
 pub struct InboundRpcs {
     /// The network instance this Peer actor is running under.
     network_context: Arc<NetworkContext>,
+    /// A handle to a time service for easily mocking time-related operations.
+    time_service: TimeService,
     /// The PeerId of this connection's remote peer. Used for logging.
     remote_peer_id: PeerId,
     /// The core async queue of pending inbound rpc tasks. The tasks are driven
@@ -179,12 +182,14 @@ pub struct InboundRpcs {
 impl InboundRpcs {
     pub fn new(
         network_context: Arc<NetworkContext>,
+        time_service: TimeService,
         remote_peer_id: PeerId,
         inbound_rpc_timeout: Duration,
         max_concurrent_inbound_rpcs: u32,
     ) -> Self {
         Self {
             network_context,
+            time_service,
             remote_peer_id,
             inbound_rpc_tasks: FuturesUnordered::new(),
             inbound_rpc_timeout,
@@ -240,7 +245,9 @@ impl InboundRpcs {
         }
 
         // Create a new task that waits for a response from the upper layer with a timeout.
-        let inbound_rpc_task = tokio::time::timeout(self.inbound_rpc_timeout, response_rx)
+        let inbound_rpc_task = self
+            .time_service
+            .timeout(self.inbound_rpc_timeout, response_rx)
             .map(move |result| {
                 // Flatten the errors
                 let maybe_response = match result {
@@ -251,7 +258,7 @@ impl InboundRpcs {
                     }),
                     Ok(Ok(Err(err))) => Err(err),
                     Ok(Err(oneshot::Canceled)) => Err(RpcError::UnexpectedResponseChannelCancel),
-                    Err(_elapsed) => Err(RpcError::TimedOut),
+                    Err(timeout::Elapsed) => Err(RpcError::TimedOut),
                 };
                 // Only record latency of successful requests
                 match maybe_response {
@@ -324,6 +331,8 @@ impl InboundRpcs {
 pub struct OutboundRpcs {
     /// The network instance this Peer actor is running under.
     network_context: Arc<NetworkContext>,
+    /// A handle to a time service for easily mocking time-related operations.
+    time_service: TimeService,
     /// The PeerId of this connection's remote peer. Used for logging.
     remote_peer_id: PeerId,
     /// Generates the next RequestId to use for the next outbound RPC. Note that
@@ -349,11 +358,13 @@ pub struct OutboundRpcs {
 impl OutboundRpcs {
     pub fn new(
         network_context: Arc<NetworkContext>,
+        time_service: TimeService,
         remote_peer_id: PeerId,
         max_concurrent_outbound_rpcs: u32,
     ) -> Self {
         Self {
             network_context,
+            time_service,
             remote_peer_id,
             request_id_gen: RequestIdGenerator::new(),
             outbound_rpc_tasks: FuturesUnordered::new(),
@@ -437,14 +448,17 @@ impl OutboundRpcs {
         // A future that waits for the rpc response with a timeout. We create the
         // timeout out here to start the timer as soon as we push onto the queue
         // (as opposed to whenever it first gets polled on the queue).
-        let wait_for_response = tokio::time::timeout(timeout, response_rx).map(|result| {
-            // Flatten errors.
-            match result {
-                Ok(Ok(response)) => Ok(Bytes::from(response.raw_response)),
-                Ok(Err(oneshot::Canceled)) => Err(RpcError::UnexpectedResponseChannelCancel),
-                Err(_elapsed) => Err(RpcError::TimedOut),
-            }
-        });
+        let wait_for_response = self
+            .time_service
+            .timeout(timeout, response_rx)
+            .map(|result| {
+                // Flatten errors.
+                match result {
+                    Ok(Ok(response)) => Ok(Bytes::from(response.raw_response)),
+                    Ok(Err(oneshot::Canceled)) => Err(RpcError::UnexpectedResponseChannelCancel),
+                    Err(timeout::Elapsed) => Err(RpcError::TimedOut),
+                }
+            });
 
         // A future that waits for the response and sends it to the application.
         let notify_application = async move {


### PR DESCRIPTION
+ `Peer`, `InboundRpcs`, and `OutboundRpcs` now have a `TimeService` member, which they use to create async timeout futures.

+ `Peer` tests now use `TimeService::mock()`. For most tests, this effectively disables timeouts. For `peer_send_rpc_timeout` and `peer_recv_rpc_timeout`, we use the `MockTimeService` to advance time and trigger the request timeout.

+ Parent modules like `PeerManager` just hand `Peer` a real time service for now.