### PR TITLE
[State Sync] Fix potential storage race condition with consensus.

### DIFF
--- a/state-sync/src/logging.rs
+++ b/state-sync/src/logging.rs
@@ -125,6 +125,7 @@ pub enum LogEvent {
     ChunkRequestInfo,
 
     // ProcessChunkResponse events
+    ConsensusIsRunning,
     Received,
     SendChunkRequestFail,
     ApplyChunkSuccess,


### PR DESCRIPTION
## Motivation

This PR fixes a potential storage race condition between state sync and consensus. At a high-level, both state sync and consensus share a storage instance. To avoid race conditions on writes, state sync assumes that either only it is operating (e.g. during initialization to a waypoint, or when syncing to a target), or consensus is operating (at which point state sync will only perform storage reads by processing chunk requests). 

However, the code currently does not enforce this property for chunk response messages. It's currently possible for consensus to be executing, and another node to send an unplanned chunk response to state sync. If the chunk response is valid, it will attempt to execute and commit it (potentially interfering with consensus). To avoid this, we simply drop chunk response messages when consensus is running.

Note 1: it's unclear how easy it is to exploit this race condition in practice (i.e., to get into a position where both consensus and state sync have valid txs to commit).

Note 2: due to the current testing infrastructure for state sync, adding a test to ensure this property is not trivial. It would either require: (i) hacking the code to expose internal state to the integration tests; (ii) or to perform a large restructure of the tests.. As such, my next step is to take the plunge and restructure the tests so that we can verify these properties. However, to avoid this PR blowing up, I've not done this here.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All existing tests pass locally.

## Related PRs

This relates to: https://github.com/diem/diem/issues/6795