### PR TITLE
[move source language] Don't inline asisgnments to parameters

### DIFF
--- a/language/move-lang/functional-tests/tests/move/commands/if_assignment.move
+++ b/language/move-lang/functional-tests/tests/move/commands/if_assignment.move
@@ -1,0 +1,19 @@
+address {{default}} {
+module ReassignCond {
+    public fun reassign_cond(a: address, b: bool): address {
+        if (b) {
+            a = 0x2;
+        };
+        a
+    }
+}
+}
+
+//! new-transaction
+
+script {
+    use {{default}}::ReassignCond::reassign_cond;
+    fun main() {
+        assert(reassign_cond(0x1, false) == 0x1, 42);
+    }
+}

--- a/language/move-lang/src/cfgir/eliminate_locals.rs
+++ b/language/move-lang/src/cfgir/eliminate_locals.rs
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::cfg::BlockCFG;
-use crate::parser::ast::Var;
+use crate::{hlir::ast::FunctionSignature, parser::ast::Var};
 use std::collections::BTreeSet;
 
 /// returns true if anything changed
-pub fn optimize(cfg: &mut BlockCFG) -> bool {
+pub fn optimize(signature: &FunctionSignature, cfg: &mut BlockCFG) -> bool {
     let mut changed = super::remove_no_ops::optimize(cfg);
     loop {
         let ssa_temps = {
-            let s = count(cfg);
+            let s = count(signature, cfg);
             if s.is_empty() {
                 break changed;
             }
@@ -28,8 +28,8 @@ pub fn optimize(cfg: &mut BlockCFG) -> bool {
 // Count assignment and usage
 //**************************************************************************************************
 
-fn count(cfg: &BlockCFG) -> BTreeSet<Var> {
-    let mut context = count::Context::new();
+fn count(signature: &FunctionSignature, cfg: &BlockCFG) -> BTreeSet<Var> {
+    let mut context = count::Context::new(signature);
     for block in cfg.blocks().values() {
         for cmd in block {
             count::command(&mut context, cmd)
@@ -40,7 +40,7 @@ fn count(cfg: &BlockCFG) -> BTreeSet<Var> {
 
 mod count {
     use crate::{
-        hlir::ast::*,
+        hlir::ast::{FunctionSignature, *},
         parser::ast::{BinOp, UnaryOp, Var},
     };
     use std::collections::{BTreeMap, BTreeSet};
@@ -51,11 +51,15 @@ mod count {
     }
 
     impl Context {
-        pub fn new() -> Self {
-            Context {
+        pub fn new(signature: &FunctionSignature) -> Self {
+            let mut ctx = Context {
                 assigned: BTreeMap::new(),
                 used: BTreeMap::new(),
+            };
+            for (v, _) in &signature.parameters {
+                ctx.assign(v, false);
             }
+            ctx
         }
 
         fn assign(&mut self, var: &Var, substitutable: bool) {

--- a/language/move-lang/src/cfgir/mod.rs
+++ b/language/move-lang/src/cfgir/mod.rs
@@ -42,13 +42,13 @@ pub fn refine_inference_and_verify(
 }
 
 pub fn optimize(
-    _signature: &FunctionSignature,
+    signature: &FunctionSignature,
     _locals: &UniqueMap<Var, SingleType>,
     cfg: &mut BlockCFG,
 ) {
     loop {
         let mut changed = false;
-        changed |= eliminate_locals::optimize(cfg);
+        changed |= eliminate_locals::optimize(signature, cfg);
         changed |= constant_fold::optimize(cfg);
         changed |= simplify_jumps::optimize(cfg);
         changed |= inline_blocks::optimize(cfg);


### PR DESCRIPTION
- Fixed bug where the eliminate_locals pass would inline assignments to function parameters
- The eliminate_locals pass heavily relies on the invariants of Move for correctness. It had has no knowledge of blocks or control flow and assumes that if a local was assigned only once, and never borrowed, that value can be inline. It did not consider the initial "assignment" of the parameter, causing a bug when that parameter was assigned in the function 

## Motivation

- Bugs are bad

## Test Plan

- new test