### PR TITLE
[Move] Fixed size_hint for unique map iterators. Fixed FunctionSourceMap::make_local_name_to_index_map

### DIFF
--- a/language/compiler/bytecode-source-map/src/source_map.rs
+++ b/language/compiler/bytecode-source-map/src/source_map.rs
@@ -236,9 +236,9 @@ impl<Location: Clone + Eq> FunctionSourceMap<Location> {
     }
 
     pub fn make_local_name_to_index_map(&self) -> BTreeMap<&String, LocalIndex> {
-        self.locals
+        self.parameters
             .iter()
-            .chain(self.parameters.iter())
+            .chain(&self.locals)
             .enumerate()
             .map(|(i, (n, _))| (n, i as LocalIndex))
             .collect()

--- a/language/move-lang/src/shared/remembering_unique_map.rs
+++ b/language/move-lang/src/shared/remembering_unique_map.rs
@@ -177,6 +177,10 @@ impl<K: TName, V> Iterator for IntoIter<K, V> {
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
 }
 
 impl<K: TName, V> IntoIterator for RememberingUniqueMap<K, V> {
@@ -199,6 +203,10 @@ impl<'a, K: TName, V> Iterator for Iter<'a, K, V> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
     }
 }
 
@@ -223,6 +231,10 @@ impl<'a, K: TName, V> Iterator for IterMut<'a, K, V> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
     }
 }
 


### PR DESCRIPTION
- Added size_hint to unique map iterators for proper integration with ast_debug
- Fixed FunctionSourceMap::make_local_name_to_index_map. Parameters should be first

## Motivation

- bugs are bad

## Test Plan

- Verified debug fix
- I am unsure of any tests for the source map