### PR TITLE
[move-prover][refactoring] Use indices instead of symbols to refer to temporaries, implement specs in code.

### DIFF
--- a/language/move-model/src/builder/exp_translator.rs
+++ b/language/move-model/src/builder/exp_translator.rs
@@ -349,11 +349,13 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
         name: Symbol,
         type_: Type,
         operation: Option<Operation>,
+        temp_index: Option<usize>,
     ) {
         let entry = LocalVarEntry {
             loc: loc.clone(),
             type_,
             operation,
+            temp_index,
         };
         if let Some(old) = self
             .local_table
@@ -364,25 +366,6 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
             let display = name.display(self.symbol_pool());
             self.error(loc, &format!("duplicate declaration of `{}`", display));
             self.error(&old.loc, &format!("previous declaration of `{}`", display));
-        } else {
-            // Check whether we do not shadow a variable.
-            // TODO(wrwg): remove once we have sorted out correct implementation of
-            //   shadowing. Currently there are some bugs, so better to disallow it.
-            for scope in self.local_table.iter().skip(1) {
-                if let Some(old_loc) = scope.get(&name).map(|e| e.loc.clone()) {
-                    let display = name.display(self.symbol_pool());
-                    self.error(
-                        loc,
-                        &format!(
-                            "shadowing of declaration of `{}` not allowed \
-                    (current implementation restriction)",
-                            display
-                        ),
-                    );
-                    self.error(&old_loc, &format!("previous declaration of `{}`", display));
-                    break;
-                }
-            }
         }
     }
 
@@ -426,13 +409,24 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
     pub fn analyze_and_add_params(
         &mut self,
         params: &[(PA::Var, EA::Type)],
+        for_move_fun: bool,
     ) -> Vec<(Symbol, Type)> {
         params
             .iter()
-            .map(|(v, ty)| {
+            .enumerate()
+            .map(|(idx, (v, ty))| {
                 let ty = self.translate_type(ty);
                 let sym = self.symbol_pool().make(v.0.value.as_str());
-                self.define_local(&self.to_loc(&v.0.loc), sym, ty.clone(), None);
+                self.define_local(
+                    &self.to_loc(&v.0.loc),
+                    sym,
+                    ty.clone(),
+                    None,
+                    // If this is for a proper Move function (not spec function), add the
+                    // index so we can resolve this to a `Temporary` expression instead of
+                    // a `LocalVar`.
+                    if for_move_fun { Some(idx) } else { None },
+                );
                 (sym, ty)
             })
             .collect_vec()
@@ -953,7 +947,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                             // thus entering a new scope.
                             self.enter_scope();
                             let name = self.symbol_pool().make(&name.value);
-                            self.define_local(&bind_loc, name, t.clone(), None);
+                            self.define_local(&bind_loc, name, t.clone(), None, None);
                             let id = self.new_node_id_with_type_loc(&t, &bind_loc);
                             decls.push(LocalVarDecl {
                                 id,
@@ -1098,11 +1092,19 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
     ) -> Option<Exp> {
         if let Some(entry) = self.lookup_local(sym, in_old) {
             let oper_opt = entry.operation.clone();
+            let index_opt = entry.temp_index;
             let ty = entry.type_.clone();
             let ty = self.check_type(loc, &ty, expected_type, "in name expression");
             let id = self.new_node_id_with_type_loc(&ty, loc);
             if let Some(oper) = oper_opt {
                 Some(Exp::Call(id, oper, vec![]))
+            } else if let Some(index) =
+                index_opt.filter(|_| !self.translating_fun_as_spec_fun && !self.in_let)
+            {
+                // Only create a temporary if we are not currently translating a move function as
+                // a spec function, or a let. In this case, the LocalVarEntry has a bytecode index, but
+                // we do not want to use this if interpreted as a spec fun.
+                Some(Exp::Temporary(id, index))
             } else {
                 if self.in_let {
                     // Mangle the name for context local of let.
@@ -1134,8 +1136,6 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
         }
 
         // Create the context args for this let.
-        // TODO(wrwg): here is a bug with name shadowing, which is also elsewhere.
-        //   A fix requires a rewrite to go away from symbols for locals to unique indices.
         let mut all_args = vec![];
         for (name, in_old) in decl
             .context_params
@@ -1760,7 +1760,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                     let name = self.symbol_pool().make(&n.value);
                     let ty = self.fresh_type_var();
                     let id = self.new_node_id_with_type_loc(&ty, &loc);
-                    self.define_local(&loc, name, ty.clone(), None);
+                    self.define_local(&loc, name, ty.clone(), None, None);
                     arg_types.push(ty);
                     decls.push(LocalVarDecl {
                         id,
@@ -1847,7 +1847,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                 ) => {
                     let name = self.symbol_pool().make(&n.value);
                     let id = self.new_node_id_with_type_loc(&ty, &loc);
-                    self.define_local(&loc, name, ty.clone(), None);
+                    self.define_local(&loc, name, ty.clone(), None, None);
                     let rbind = LocalVarDecl {
                         id,
                         name,

--- a/language/move-model/src/builder/model_builder.rs
+++ b/language/move-model/src/builder/model_builder.rs
@@ -392,4 +392,6 @@ pub(crate) struct LocalVarEntry {
     pub type_: Type,
     // If this local is associated with an operation, this is set.
     pub operation: Option<Operation>,
+    // If this a temporary from Move code, this is it's index.
+    pub temp_index: Option<usize>,
 }

--- a/language/move-prover/bytecode/src/borrow_analysis.rs
+++ b/language/move-prover/bytecode/src/borrow_analysis.rs
@@ -8,11 +8,14 @@ use crate::{
     function_target::{FunctionData, FunctionTarget},
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
     livevar_analysis::LiveVarAnnotation,
-    stackless_bytecode::{AssignKind, BorrowNode, Bytecode, Operation, TempIndex},
+    stackless_bytecode::{AssignKind, BorrowNode, Bytecode, Operation},
     stackless_control_flow_graph::StacklessControlFlowGraph,
 };
 use itertools::Itertools;
-use move_model::model::{FunctionEnv, QualifiedId};
+use move_model::{
+    ast::TempIndex,
+    model::{FunctionEnv, QualifiedId},
+};
 use std::collections::{BTreeMap, BTreeSet};
 use vm::file_format::CodeOffset;
 

--- a/language/move-prover/bytecode/src/eliminate_mut_refs.rs
+++ b/language/move-prover/bytecode/src/eliminate_mut_refs.rs
@@ -9,10 +9,10 @@ use crate::{
         Bytecode::{self, *},
         Operation,
         Operation::*,
-        TempIndex,
     },
 };
 use move_model::{
+    ast::TempIndex,
     model::{FunctionEnv, Loc},
     ty::Type,
 };

--- a/language/move-prover/bytecode/src/function_data_builder.rs
+++ b/language/move-prover/bytecode/src/function_data_builder.rs
@@ -6,12 +6,12 @@
 
 use crate::{
     function_target::{FunctionData, FunctionTarget},
-    stackless_bytecode::{AttrId, Bytecode, Label, PropKind, TempIndex},
+    stackless_bytecode::{AttrId, Bytecode, Label, PropKind},
 };
 use itertools::Itertools;
 use move_model::{
     ast,
-    ast::{Exp, Value},
+    ast::{Exp, TempIndex, Value},
     model::{
         ConditionInfo, ConditionTag, FunctionEnv, GlobalEnv, Loc, NodeId, QualifiedId, StructId,
     },
@@ -196,8 +196,7 @@ impl<'env> FunctionDataBuilder<'env> {
     pub fn mk_local(&self, temp: TempIndex) -> Exp {
         let ty = self.data.local_types[temp].clone();
         let node_id = self.global_env().new_node(self.current_loc.clone(), ty);
-        let sym = self.fun_env.get_local_name(temp);
-        Exp::LocalVar(node_id, sym)
+        Exp::Temporary(node_id, temp)
     }
 
     /// Get's the memory associated with a Call(Global,..) or Call(Exists, ..) node. Crashes

--- a/language/move-prover/bytecode/src/function_target_pipeline.rs
+++ b/language/move-prover/bytecode/src/function_target_pipeline.rs
@@ -69,8 +69,8 @@ pub struct FunctionTargetPipeline {
 
 impl FunctionTargetsHolder {
     /// Adds a new function target. The target will be initialized from the Move byte code.
-    pub fn add_target(&mut self, func_env: &FunctionEnv<'_>) {
-        let generator = StacklessBytecodeGenerator::new(func_env);
+    pub fn add_target(&mut self, func_env: &FunctionEnv<'_>, for_v2: bool) {
+        let generator = StacklessBytecodeGenerator::new(func_env, for_v2);
         let data = generator.generate_function();
         self.targets
             .entry(func_env.get_qualified_id())

--- a/language/move-prover/bytecode/src/livevar_analysis.rs
+++ b/language/move-prover/bytecode/src/livevar_analysis.rs
@@ -8,11 +8,11 @@ use crate::{
     dataflow_analysis::{AbstractDomain, DataflowAnalysis, JoinResult, TransferFunctions},
     function_target::{FunctionData, FunctionTarget},
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
-    stackless_bytecode::{AttrId, Bytecode, Label, Operation, TempIndex},
+    stackless_bytecode::{AttrId, Bytecode, Label, Operation},
     stackless_control_flow_graph::StacklessControlFlowGraph,
 };
 use itertools::Itertools;
-use move_model::{model::FunctionEnv, ty::Type};
+use move_model::{ast::TempIndex, model::FunctionEnv, ty::Type};
 use std::collections::{BTreeMap, BTreeSet};
 use vm::file_format::CodeOffset;
 
@@ -371,12 +371,9 @@ impl<'a> TransferFunctions for LiveVarAnalysis<'a> {
                 state.remove(&[*dst]);
             }
             Prop(_, _, exp) => {
-                let usage = exp
-                    .locals()
-                    .iter()
-                    .filter_map(|name| self.func_target.get_local_index(*name))
-                    .collect_vec();
-                state.insert(&usage);
+                for idx in exp.temporaries() {
+                    state.insert(&[idx]);
+                }
             }
             _ => {}
         }

--- a/language/move-prover/bytecode/src/memory_instrumentation.rs
+++ b/language/move-prover/bytecode/src/memory_instrumentation.rs
@@ -8,10 +8,13 @@ use crate::{
     stackless_bytecode::{
         AttrId, BorrowNode,
         Bytecode::{self, *},
-        Operation, TempIndex,
+        Operation,
     },
 };
-use move_model::model::{FunctionEnv, Loc};
+use move_model::{
+    ast::TempIndex,
+    model::{FunctionEnv, Loc},
+};
 use std::collections::BTreeMap;
 use vm::file_format::CodeOffset;
 

--- a/language/move-prover/bytecode/src/reaching_def_analysis.rs
+++ b/language/move-prover/bytecode/src/reaching_def_analysis.rs
@@ -10,11 +10,11 @@ use crate::{
     dataflow_analysis::{AbstractDomain, DataflowAnalysis, JoinResult, TransferFunctions},
     function_target::{FunctionData, FunctionTarget},
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
-    stackless_bytecode::{BorrowNode, Bytecode, Operation, TempIndex},
+    stackless_bytecode::{BorrowNode, Bytecode, Operation},
     stackless_control_flow_graph::StacklessControlFlowGraph,
 };
 use itertools::Itertools;
-use move_model::model::FunctionEnv;
+use move_model::{ast::TempIndex, model::FunctionEnv};
 use std::collections::{BTreeMap, BTreeSet};
 use vm::file_format::CodeOffset;
 

--- a/language/move-prover/bytecode/src/stackless_bytecode_generator.rs
+++ b/language/move-prover/bytecode/src/stackless_bytecode_generator.rs
@@ -6,12 +6,13 @@ use crate::{
     stackless_bytecode::{
         AssignKind, AttrId,
         Bytecode::{self},
-        Constant, Label, Operation, SpecBlockId, TempIndex,
+        Constant, Label, Operation, PropKind, SpecBlockId,
     },
 };
 use itertools::Itertools;
 use move_core_types::value::MoveValue;
 use move_model::{
+    ast::{ConditionKind, TempIndex},
     model::{FunctionEnv, Loc, ModuleEnv, StructId},
     ty::{PrimitiveType, Type},
 };
@@ -32,10 +33,11 @@ pub struct StacklessBytecodeGenerator<'a> {
     local_types: Vec<Type>,
     code: Vec<Bytecode>,
     location_table: BTreeMap<AttrId, Loc>,
+    for_v2: bool,
 }
 
 impl<'a> StacklessBytecodeGenerator<'a> {
-    pub fn new(func_env: &'a FunctionEnv<'a>) -> Self {
+    pub fn new(func_env: &'a FunctionEnv<'a>, for_v2: bool) -> Self {
         let local_types = (0..func_env.get_local_count())
             .map(|i| func_env.get_local_type(i))
             .collect_vec();
@@ -47,6 +49,7 @@ impl<'a> StacklessBytecodeGenerator<'a> {
             local_types,
             code: vec![],
             location_table: BTreeMap::new(),
+            for_v2,
         }
     }
 
@@ -116,6 +119,13 @@ impl<'a> StacklessBytecodeGenerator<'a> {
         attr
     }
 
+    /// Create a new attribute id and populate location table from node_id.
+    fn new_loc_attr_from_loc(&mut self, loc: Loc) -> AttrId {
+        let attr = AttrId::new(self.location_table.len());
+        self.location_table.insert(attr, loc);
+        attr
+    }
+
     fn get_field_info(&self, field_handle_index: FieldHandleIndex) -> (StructId, usize, Type) {
         let field_handle = self.module.field_handle_at(field_handle_index);
         let struct_id = self.func_env.module_env.get_struct_id(field_handle.owner);
@@ -144,13 +154,27 @@ impl<'a> StacklessBytecodeGenerator<'a> {
             self.code.push(Bytecode::Label(label_attr_id, *label));
         }
 
-        // Add spec block if defined at this code offset.
-        if self.func_env.get_spec().on_impl.get(&code_offset).is_some() {
-            let block_id = SpecBlockId::new(spec_blocks.len());
-            spec_blocks.insert(block_id, code_offset);
-            let spec_block_attr_id = self.new_loc_attr(code_offset);
-            self.code
-                .push(Bytecode::SpecBlock(spec_block_attr_id, block_id));
+        // Handle spec block if defined at this code offset.
+        if let Some(spec) = self.func_env.get_spec().on_impl.get(&code_offset) {
+            if self.for_v2 {
+                for cond in &spec.conditions {
+                    let attr_id = self.new_loc_attr_from_loc(cond.loc.clone());
+                    let kind = match cond.kind {
+                        ConditionKind::Assert => PropKind::Assert,
+                        ConditionKind::Assume => PropKind::Assume,
+                        _ => panic!("unsupported spec condition in code"),
+                    };
+                    self.code
+                        .push(Bytecode::Prop(attr_id, kind, cond.exp.clone()));
+                }
+            } else {
+                // Inject spec block instruction.
+                let block_id = SpecBlockId::new(spec_blocks.len());
+                spec_blocks.insert(block_id, code_offset);
+                let spec_block_attr_id = self.new_loc_attr(code_offset);
+                self.code
+                    .push(Bytecode::SpecBlock(spec_block_attr_id, block_id));
+            }
 
             // If the current instruction is just a Nop, skip it. It has been generated to support
             // spec blocks.

--- a/language/move-prover/bytecode/tests/borrow/basic_test.exp
+++ b/language/move-prover/bytecode/tests/borrow/basic_test.exp
@@ -2,9 +2,9 @@
 
 [variant baseline]
 fun TestBorrow::test1(): TestBorrow::R {
-     var r: TestBorrow::R
-     var r_ref: &mut TestBorrow::R
-     var x_ref: &mut u64
+     var $t0|r: TestBorrow::R
+     var $t1|r_ref: &mut TestBorrow::R
+     var $t2|x_ref: &mut u64
      var $t3: u64
      var $t4: TestBorrow::R
      var $t5: &mut TestBorrow::R
@@ -15,43 +15,43 @@ fun TestBorrow::test1(): TestBorrow::R {
      var $t10: TestBorrow::R
   0: $t3 := 3
   1: $t4 := pack TestBorrow::R($t3)
-  2: r := $t4
-  3: $t5 := borrow_local(r)
-  4: r_ref := $t5
-  5: $t6 := move(r_ref)
+  2: $t0 := $t4
+  3: $t5 := borrow_local($t0)
+  4: $t1 := $t5
+  5: $t6 := move($t1)
   6: $t7 := borrow_field<TestBorrow::R>.x($t6)
-  7: x_ref := $t7
+  7: $t2 := $t7
   8: $t8 := 0
-  9: $t9 := move(x_ref)
+  9: $t9 := move($t2)
  10: write_ref($t9, $t8)
- 11: $t10 := move(r)
+ 11: $t10 := move($t0)
  12: return $t10
 }
 
 
 [variant baseline]
-fun TestBorrow::test2(x_ref: &mut u64, v: u64) {
+fun TestBorrow::test2($t0|x_ref: &mut u64, $t1|v: u64) {
      var $t2: u64
      var $t3: &mut u64
-  0: $t2 := copy(v)
-  1: $t3 := move(x_ref)
+  0: $t2 := copy($t1)
+  1: $t3 := move($t0)
   2: write_ref($t3, $t2)
   3: return ()
 }
 
 
 [variant baseline]
-pub fun TestBorrow::test3(r_ref: &mut TestBorrow::R, v: u64) {
-     var x_ref: &mut u64
+pub fun TestBorrow::test3($t0|r_ref: &mut TestBorrow::R, $t1|v: u64) {
+     var $t2|x_ref: &mut u64
      var $t3: &mut TestBorrow::R
      var $t4: &mut u64
      var $t5: &mut u64
      var $t6: u64
-  0: $t3 := move(r_ref)
+  0: $t3 := move($t0)
   1: $t4 := borrow_field<TestBorrow::R>.x($t3)
-  2: x_ref := $t4
-  3: $t5 := move(x_ref)
-  4: $t6 := copy(v)
+  2: $t2 := $t4
+  3: $t5 := move($t2)
+  4: $t6 := copy($t1)
   5: TestBorrow::test2($t5, $t6)
   6: return ()
 }
@@ -59,8 +59,8 @@ pub fun TestBorrow::test3(r_ref: &mut TestBorrow::R, v: u64) {
 
 [variant baseline]
 fun TestBorrow::test4(): TestBorrow::R {
-     var r: TestBorrow::R
-     var r_ref: &mut TestBorrow::R
+     var $t0|r: TestBorrow::R
+     var $t1|r_ref: &mut TestBorrow::R
      var $t2: u64
      var $t3: TestBorrow::R
      var $t4: &mut TestBorrow::R
@@ -69,22 +69,22 @@ fun TestBorrow::test4(): TestBorrow::R {
      var $t7: TestBorrow::R
   0: $t2 := 3
   1: $t3 := pack TestBorrow::R($t2)
-  2: r := $t3
-  3: $t4 := borrow_local(r)
-  4: r_ref := $t4
-  5: $t5 := move(r_ref)
+  2: $t0 := $t3
+  3: $t4 := borrow_local($t0)
+  4: $t1 := $t4
+  5: $t5 := move($t1)
   6: $t6 := 0
   7: TestBorrow::test3($t5, $t6)
-  8: $t7 := move(r)
+  8: $t7 := move($t0)
   9: return $t7
 }
 
 
 [variant baseline]
-pub fun TestBorrow::test5(r_ref: &mut TestBorrow::R): &mut u64 {
+pub fun TestBorrow::test5($t0|r_ref: &mut TestBorrow::R): &mut u64 {
      var $t1: &mut TestBorrow::R
      var $t2: &mut u64
-  0: $t1 := move(r_ref)
+  0: $t1 := move($t0)
   1: $t2 := borrow_field<TestBorrow::R>.x($t1)
   2: return $t2
 }
@@ -92,9 +92,9 @@ pub fun TestBorrow::test5(r_ref: &mut TestBorrow::R): &mut u64 {
 
 [variant baseline]
 fun TestBorrow::test6(): TestBorrow::R {
-     var r: TestBorrow::R
-     var r_ref: &mut TestBorrow::R
-     var x_ref: &mut u64
+     var $t0|r: TestBorrow::R
+     var $t1|r_ref: &mut TestBorrow::R
+     var $t2|x_ref: &mut u64
      var $t3: u64
      var $t4: TestBorrow::R
      var $t5: &mut TestBorrow::R
@@ -105,25 +105,25 @@ fun TestBorrow::test6(): TestBorrow::R {
      var $t10: TestBorrow::R
   0: $t3 := 3
   1: $t4 := pack TestBorrow::R($t3)
-  2: r := $t4
-  3: $t5 := borrow_local(r)
-  4: r_ref := $t5
-  5: $t6 := move(r_ref)
+  2: $t0 := $t4
+  3: $t5 := borrow_local($t0)
+  4: $t1 := $t5
+  5: $t6 := move($t1)
   6: $t7 := TestBorrow::test5($t6)
-  7: x_ref := $t7
-  8: $t8 := move(x_ref)
+  7: $t2 := $t7
+  8: $t8 := move($t2)
   9: $t9 := 0
  10: TestBorrow::test2($t8, $t9)
- 11: $t10 := move(r)
+ 11: $t10 := move($t0)
  12: return $t10
 }
 
 
 [variant baseline]
-fun TestBorrow::test7(b: bool) {
-     var r1: TestBorrow::R
-     var r2: TestBorrow::R
-     var r_ref: &mut TestBorrow::R
+fun TestBorrow::test7($t0|b: bool) {
+     var $t1|r1: TestBorrow::R
+     var $t2|r2: TestBorrow::R
+     var $t3|r_ref: &mut TestBorrow::R
      var $t4: u64
      var $t5: TestBorrow::R
      var $t6: u64
@@ -136,24 +136,24 @@ fun TestBorrow::test7(b: bool) {
      var $t13: u64
   0: $t4 := 3
   1: $t5 := pack TestBorrow::R($t4)
-  2: r1 := $t5
+  2: $t1 := $t5
   3: $t6 := 4
   4: $t7 := pack TestBorrow::R($t6)
-  5: r2 := $t7
-  6: $t8 := borrow_local(r1)
-  7: r_ref := $t8
-  8: $t9 := copy(b)
+  5: $t2 := $t7
+  6: $t8 := borrow_local($t1)
+  7: $t3 := $t8
+  8: $t9 := copy($t0)
   9: if ($t9) goto L0 else goto L1
  10: L1:
  11: goto L2
  12: L0:
- 13: $t10 := move(r_ref)
+ 13: $t10 := move($t3)
  14: destroy($t10)
- 15: $t11 := borrow_local(r2)
- 16: r_ref := $t11
+ 15: $t11 := borrow_local($t2)
+ 16: $t3 := $t11
  17: goto L2
  18: L2:
- 19: $t12 := move(r_ref)
+ 19: $t12 := move($t3)
  20: $t13 := 0
  21: TestBorrow::test3($t12, $t13)
  22: return ()
@@ -161,10 +161,10 @@ fun TestBorrow::test7(b: bool) {
 
 
 [variant baseline]
-fun TestBorrow::test8(b: bool, n: u64, r_ref: &mut TestBorrow::R) {
-     var r1: TestBorrow::R
-     var r2: TestBorrow::R
-     var t_ref: &mut TestBorrow::R
+fun TestBorrow::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestBorrow::R) {
+     var $t3|r1: TestBorrow::R
+     var $t4|r2: TestBorrow::R
+     var $t5|t_ref: &mut TestBorrow::R
      var $t6: u64
      var $t7: TestBorrow::R
      var $t8: u64
@@ -193,24 +193,24 @@ fun TestBorrow::test8(b: bool, n: u64, r_ref: &mut TestBorrow::R) {
      var $t31: u64
   0: $t6 := 3
   1: $t7 := pack TestBorrow::R($t6)
-  2: r1 := $t7
+  2: $t3 := $t7
   3: $t8 := 4
   4: $t9 := pack TestBorrow::R($t8)
-  5: r2 := $t9
-  6: $t10 := borrow_local(r2)
-  7: t_ref := $t10
+  5: $t4 := $t9
+  6: $t10 := borrow_local($t4)
+  7: $t5 := $t10
   8: goto L7
   9: L7:
  10: $t11 := 0
- 11: $t12 := copy(n)
+ 11: $t12 := copy($t1)
  12: $t13 := <($t11, $t12)
  13: if ($t13) goto L0 else goto L1
  14: L1:
  15: goto L2
  16: L0:
- 17: $t14 := move(t_ref)
+ 17: $t14 := move($t5)
  18: destroy($t14)
- 19: $t15 := copy(n)
+ 19: $t15 := copy($t1)
  20: $t16 := 2
  21: $t17 := /($t15, $t16)
  22: $t18 := 0
@@ -219,35 +219,35 @@ fun TestBorrow::test8(b: bool, n: u64, r_ref: &mut TestBorrow::R) {
  25: L4:
  26: goto L5
  27: L3:
- 28: $t20 := borrow_local(r1)
- 29: t_ref := $t20
+ 28: $t20 := borrow_local($t3)
+ 29: $t5 := $t20
  30: goto L6
  31: L5:
- 32: $t21 := borrow_local(r2)
- 33: t_ref := $t21
+ 32: $t21 := borrow_local($t4)
+ 33: $t5 := $t21
  34: goto L6
  35: L6:
- 36: $t22 := copy(n)
+ 36: $t22 := copy($t1)
  37: $t23 := 1
  38: $t24 := -($t22, $t23)
- 39: n := $t24
+ 39: $t1 := $t24
  40: goto L7
  41: L2:
- 42: $t25 := copy(b)
+ 42: $t25 := copy($t0)
  43: if ($t25) goto L8 else goto L9
  44: L9:
  45: goto L10
  46: L8:
- 47: $t26 := move(t_ref)
+ 47: $t26 := move($t5)
  48: destroy($t26)
- 49: $t27 := move(r_ref)
+ 49: $t27 := move($t2)
  50: $t28 := 0
  51: TestBorrow::test3($t27, $t28)
  52: goto L11
  53: L10:
- 54: $t29 := move(r_ref)
+ 54: $t29 := move($t2)
  55: destroy($t29)
- 56: $t30 := move(t_ref)
+ 56: $t30 := move($t5)
  57: $t31 := 0
  58: TestBorrow::test3($t30, $t31)
  59: goto L11
@@ -259,57 +259,57 @@ fun TestBorrow::test8(b: bool, n: u64, r_ref: &mut TestBorrow::R) {
 
 [variant baseline]
 fun TestBorrow::test1(): TestBorrow::R {
-     var r: TestBorrow::R
-     var r_ref: &mut TestBorrow::R
-     var x_ref: &mut u64
+     var $t0|r: TestBorrow::R
+     var $t1|r_ref: &mut TestBorrow::R
+     var $t2|x_ref: &mut u64
      var $t3: u64
      var $t4: u64
   0: $t3 := 3
-  1: r := pack TestBorrow::R($t3)
-  2: r_ref := borrow_local(r)
-     // live_nodes: Reference(r_ref)
-     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}
-  3: x_ref := borrow_field<TestBorrow::R>.x(r_ref)
-     // live_nodes: Reference(x_ref)
-     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}, Reference(r_ref) -> {Reference(x_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}, Reference(x_ref) -> {Reference(r_ref)}
+  1: $t0 := pack TestBorrow::R($t3)
+  2: $t1 := borrow_local($t0)
+     // live_nodes: Reference($t1)
+     // borrowed_by: LocalRoot($t0) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {LocalRoot($t0)}
+  3: $t2 := borrow_field<TestBorrow::R>.x($t1)
+     // live_nodes: Reference($t2)
+     // borrowed_by: LocalRoot($t0) -> {Reference($t1)}, Reference($t1) -> {Reference($t2)}
+     // borrows_from: Reference($t1) -> {LocalRoot($t0)}, Reference($t2) -> {Reference($t1)}
   4: $t4 := 0
-     // live_nodes: Reference(x_ref)
-     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}, Reference(r_ref) -> {Reference(x_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}, Reference(x_ref) -> {Reference(r_ref)}
-  5: write_ref(x_ref, $t4)
-     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}, Reference(r_ref) -> {Reference(x_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}, Reference(x_ref) -> {Reference(r_ref)}
-  6: return r
+     // live_nodes: Reference($t2)
+     // borrowed_by: LocalRoot($t0) -> {Reference($t1)}, Reference($t1) -> {Reference($t2)}
+     // borrows_from: Reference($t1) -> {LocalRoot($t0)}, Reference($t2) -> {Reference($t1)}
+  5: write_ref($t2, $t4)
+     // borrowed_by: LocalRoot($t0) -> {Reference($t1)}, Reference($t1) -> {Reference($t2)}
+     // borrows_from: Reference($t1) -> {LocalRoot($t0)}, Reference($t2) -> {Reference($t1)}
+  6: return $t0
 }
 
 
 [variant baseline]
-fun TestBorrow::test2(x_ref: u64, v: u64): u64 {
+fun TestBorrow::test2($t0|x_ref: u64, $t1|v: u64): u64 {
      var $t2: u64
      var $t3: u64
      var $t4: &mut u64
-     // live_nodes: LocalRoot(x_ref), LocalRoot(v)
-     // unchecked_nodes: LocalRoot(x_ref)
-  0: $t2 := move(x_ref)
-     // live_nodes: LocalRoot(v), LocalRoot($t2)
+     // live_nodes: LocalRoot($t0), LocalRoot($t1)
+     // unchecked_nodes: LocalRoot($t0)
+  0: $t2 := move($t0)
+     // live_nodes: LocalRoot($t1), LocalRoot($t2)
      // unchecked_nodes: LocalRoot($t2)
-     // moved_nodes: LocalRoot(x_ref)
-  1: $t3 := move(v)
+     // moved_nodes: LocalRoot($t0)
+  1: $t3 := move($t1)
      // live_nodes: LocalRoot($t2), LocalRoot($t3)
      // unchecked_nodes: LocalRoot($t2)
-     // moved_nodes: LocalRoot(x_ref), LocalRoot(v)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
   2: $t4 := borrow_local($t2)
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t4)
      // unchecked_nodes: LocalRoot($t2), Reference($t4)
-     // moved_nodes: LocalRoot(x_ref), LocalRoot(v)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}
   3: write_ref($t4, $t3)
      // live_nodes: LocalRoot($t2), LocalRoot($t3)
      // unchecked_nodes: LocalRoot($t2), Reference($t4)
-     // moved_nodes: LocalRoot(x_ref), LocalRoot(v)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}
   4: return $t2
@@ -317,101 +317,101 @@ fun TestBorrow::test2(x_ref: u64, v: u64): u64 {
 
 
 [variant baseline]
-pub fun TestBorrow::test3(r_ref: TestBorrow::R, v: u64): TestBorrow::R {
-     var x_ref: &mut u64
+pub fun TestBorrow::test3($t0|r_ref: TestBorrow::R, $t1|v: u64): TestBorrow::R {
+     var $t2|x_ref: &mut u64
      var $t3: TestBorrow::R
      var $t4: u64
      var $t5: &mut TestBorrow::R
      var $t6: u64
-     // live_nodes: LocalRoot(r_ref), LocalRoot(v)
-  0: $t3 := move(r_ref)
-     // live_nodes: LocalRoot(v), LocalRoot($t3)
-     // moved_nodes: LocalRoot(r_ref)
-  1: $t4 := move(v)
+     // live_nodes: LocalRoot($t0), LocalRoot($t1)
+  0: $t3 := move($t0)
+     // live_nodes: LocalRoot($t1), LocalRoot($t3)
+     // moved_nodes: LocalRoot($t0)
+  1: $t4 := move($t1)
      // live_nodes: LocalRoot($t3), LocalRoot($t4)
-     // moved_nodes: LocalRoot(r_ref), LocalRoot(v)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
   2: $t5 := borrow_local($t3)
      // live_nodes: LocalRoot($t3), LocalRoot($t4), Reference($t5)
-     // moved_nodes: LocalRoot(r_ref), LocalRoot(v)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t3) -> {Reference($t5)}
      // borrows_from: Reference($t5) -> {LocalRoot($t3)}
-  3: x_ref := borrow_field<TestBorrow::R>.x($t5)
-     // live_nodes: LocalRoot($t3), LocalRoot($t4), Reference(x_ref)
-     // moved_nodes: LocalRoot(r_ref), LocalRoot(v)
-     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, Reference($t5) -> {Reference(x_ref)}
-     // borrows_from: Reference(x_ref) -> {Reference($t5)}, Reference($t5) -> {LocalRoot($t3)}
-  4: $t6 := read_ref(x_ref)
-     // live_nodes: LocalRoot($t3), LocalRoot($t4), Reference(x_ref)
-     // moved_nodes: LocalRoot(r_ref), LocalRoot(v)
-     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, Reference($t5) -> {Reference(x_ref)}
-     // borrows_from: Reference(x_ref) -> {Reference($t5)}, Reference($t5) -> {LocalRoot($t3)}
+  3: $t2 := borrow_field<TestBorrow::R>.x($t5)
+     // live_nodes: LocalRoot($t3), LocalRoot($t4), Reference($t2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, Reference($t5) -> {Reference($t2)}
+     // borrows_from: Reference($t2) -> {Reference($t5)}, Reference($t5) -> {LocalRoot($t3)}
+  4: $t6 := read_ref($t2)
+     // live_nodes: LocalRoot($t3), LocalRoot($t4), Reference($t2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, Reference($t5) -> {Reference($t2)}
+     // borrows_from: Reference($t2) -> {Reference($t5)}, Reference($t5) -> {LocalRoot($t3)}
   5: $t6 := TestBorrow::test2($t6, $t4)
-     // live_nodes: LocalRoot($t3), LocalRoot($t4), Reference(x_ref)
-     // moved_nodes: LocalRoot(r_ref), LocalRoot(v)
-     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, Reference($t5) -> {Reference(x_ref)}
-     // borrows_from: Reference(x_ref) -> {Reference($t5)}, Reference($t5) -> {LocalRoot($t3)}
-  6: write_ref(x_ref, $t6)
+     // live_nodes: LocalRoot($t3), LocalRoot($t4), Reference($t2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, Reference($t5) -> {Reference($t2)}
+     // borrows_from: Reference($t2) -> {Reference($t5)}, Reference($t5) -> {LocalRoot($t3)}
+  6: write_ref($t2, $t6)
      // live_nodes: LocalRoot($t3), LocalRoot($t4)
-     // moved_nodes: LocalRoot(r_ref), LocalRoot(v)
-     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, Reference($t5) -> {Reference(x_ref)}
-     // borrows_from: Reference(x_ref) -> {Reference($t5)}, Reference($t5) -> {LocalRoot($t3)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, Reference($t5) -> {Reference($t2)}
+     // borrows_from: Reference($t2) -> {Reference($t5)}, Reference($t5) -> {LocalRoot($t3)}
   7: return $t3
 }
 
 
 [variant baseline]
 fun TestBorrow::test4(): TestBorrow::R {
-     var r: TestBorrow::R
-     var r_ref: &mut TestBorrow::R
+     var $t0|r: TestBorrow::R
+     var $t1|r_ref: &mut TestBorrow::R
      var $t2: u64
      var $t3: u64
      var $t4: TestBorrow::R
   0: $t2 := 3
-  1: r := pack TestBorrow::R($t2)
-  2: r_ref := borrow_local(r)
-     // live_nodes: Reference(r_ref)
-     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+  1: $t0 := pack TestBorrow::R($t2)
+  2: $t1 := borrow_local($t0)
+     // live_nodes: Reference($t1)
+     // borrowed_by: LocalRoot($t0) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {LocalRoot($t0)}
   3: $t3 := 0
-     // live_nodes: Reference(r_ref)
-     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}
-  4: $t4 := read_ref(r_ref)
-     // live_nodes: Reference(r_ref)
-     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+     // live_nodes: Reference($t1)
+     // borrowed_by: LocalRoot($t0) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {LocalRoot($t0)}
+  4: $t4 := read_ref($t1)
+     // live_nodes: Reference($t1)
+     // borrowed_by: LocalRoot($t0) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {LocalRoot($t0)}
   5: $t4 := TestBorrow::test3($t4, $t3)
-     // live_nodes: Reference(r_ref)
-     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}
-  6: write_ref(r_ref, $t4)
-     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}
-  7: return r
+     // live_nodes: Reference($t1)
+     // borrowed_by: LocalRoot($t0) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {LocalRoot($t0)}
+  6: write_ref($t1, $t4)
+     // borrowed_by: LocalRoot($t0) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {LocalRoot($t0)}
+  7: return $t0
 }
 
 
 [variant baseline]
-pub fun TestBorrow::test5(r_ref: TestBorrow::R): (&mut u64, TestBorrow::R) {
+pub fun TestBorrow::test5($t0|r_ref: TestBorrow::R): (&mut u64, TestBorrow::R) {
      var $t1: TestBorrow::R
      var $t2: &mut TestBorrow::R
      var $t3: &mut u64
-     // live_nodes: LocalRoot(r_ref)
-     // unchecked_nodes: LocalRoot(r_ref)
-  0: $t1 := move(r_ref)
+     // live_nodes: LocalRoot($t0)
+     // unchecked_nodes: LocalRoot($t0)
+  0: $t1 := move($t0)
      // live_nodes: LocalRoot($t1)
      // unchecked_nodes: LocalRoot($t1)
-     // moved_nodes: LocalRoot(r_ref)
+     // moved_nodes: LocalRoot($t0)
   1: $t2 := borrow_local($t1)
      // live_nodes: LocalRoot($t1), Reference($t2)
      // unchecked_nodes: LocalRoot($t1), Reference($t2)
-     // moved_nodes: LocalRoot(r_ref)
+     // moved_nodes: LocalRoot($t0)
      // borrowed_by: LocalRoot($t1) -> {Reference($t2)}
      // borrows_from: Reference($t2) -> {LocalRoot($t1)}
   2: $t3 := borrow_field<TestBorrow::R>.x($t2)
      // live_nodes: LocalRoot($t1), Reference($t3)
      // unchecked_nodes: LocalRoot($t1), Reference($t2), Reference($t3)
-     // moved_nodes: LocalRoot(r_ref)
+     // moved_nodes: LocalRoot($t0)
      // borrowed_by: LocalRoot($t1) -> {Reference($t2)}, Reference($t2) -> {Reference($t3)}
      // borrows_from: Reference($t2) -> {LocalRoot($t1)}, Reference($t3) -> {Reference($t2)}
   3: return ($t3, $t1)
@@ -420,180 +420,180 @@ pub fun TestBorrow::test5(r_ref: TestBorrow::R): (&mut u64, TestBorrow::R) {
 
 [variant baseline]
 fun TestBorrow::test6(): TestBorrow::R {
-     var r: TestBorrow::R
-     var r_ref: &mut TestBorrow::R
-     var x_ref: &mut u64
+     var $t0|r: TestBorrow::R
+     var $t1|r_ref: &mut TestBorrow::R
+     var $t2|x_ref: &mut u64
      var $t3: u64
      var $t4: TestBorrow::R
      var $t5: &mut u64
      var $t6: u64
      var $t7: u64
   0: $t3 := 3
-  1: r := pack TestBorrow::R($t3)
-  2: r_ref := borrow_local(r)
-     // live_nodes: Reference(r_ref)
-     // spliced_nodes: Reference(r_ref)
-     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}
-  3: $t4 := read_ref(r_ref)
-     // live_nodes: Reference(r_ref)
-     // spliced_nodes: Reference(r_ref)
-     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+  1: $t0 := pack TestBorrow::R($t3)
+  2: $t1 := borrow_local($t0)
+     // live_nodes: Reference($t1)
+     // spliced_nodes: Reference($t1)
+     // borrowed_by: LocalRoot($t0) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {LocalRoot($t0)}
+  3: $t4 := read_ref($t1)
+     // live_nodes: Reference($t1)
+     // spliced_nodes: Reference($t1)
+     // borrowed_by: LocalRoot($t0) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {LocalRoot($t0)}
   4: ($t5, $t4) := TestBorrow::test5($t4)
-     // live_nodes: Reference(r_ref)
-     // spliced_nodes: Reference(r_ref)
-     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}
-  5: write_ref(r_ref, $t4)
-     // live_nodes: Reference(r_ref)
-     // spliced_nodes: Reference(r_ref)
-     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}
-  6: splice[0 -> r_ref]($t5)
+     // live_nodes: Reference($t1)
+     // spliced_nodes: Reference($t1)
+     // borrowed_by: LocalRoot($t0) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {LocalRoot($t0)}
+  5: write_ref($t1, $t4)
+     // live_nodes: Reference($t1)
+     // spliced_nodes: Reference($t1)
+     // borrowed_by: LocalRoot($t0) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {LocalRoot($t0)}
+  6: splice[0 -> $t1]($t5)
      // live_nodes: Reference($t5)
      // unchecked_nodes: Reference($t5)
-     // spliced_nodes: Reference(r_ref)
-     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}, Reference(r_ref) -> {Reference($t5)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}, Reference($t5) -> {Reference(r_ref)}
-  7: x_ref := $t5
-     // live_nodes: Reference(x_ref)
-     // unchecked_nodes: Reference(x_ref)
-     // spliced_nodes: Reference(r_ref)
+     // spliced_nodes: Reference($t1)
+     // borrowed_by: LocalRoot($t0) -> {Reference($t1)}, Reference($t1) -> {Reference($t5)}
+     // borrows_from: Reference($t1) -> {LocalRoot($t0)}, Reference($t5) -> {Reference($t1)}
+  7: $t2 := $t5
+     // live_nodes: Reference($t2)
+     // unchecked_nodes: Reference($t2)
+     // spliced_nodes: Reference($t1)
      // moved_nodes: Reference($t5)
-     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}, Reference(r_ref) -> {Reference(x_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}, Reference(x_ref) -> {Reference(r_ref)}
+     // borrowed_by: LocalRoot($t0) -> {Reference($t1)}, Reference($t1) -> {Reference($t2)}
+     // borrows_from: Reference($t1) -> {LocalRoot($t0)}, Reference($t2) -> {Reference($t1)}
   8: $t6 := 0
-     // live_nodes: Reference(x_ref)
-     // unchecked_nodes: Reference(x_ref)
-     // spliced_nodes: Reference(r_ref)
+     // live_nodes: Reference($t2)
+     // unchecked_nodes: Reference($t2)
+     // spliced_nodes: Reference($t1)
      // moved_nodes: Reference($t5)
-     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}, Reference(r_ref) -> {Reference(x_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}, Reference(x_ref) -> {Reference(r_ref)}
-  9: $t7 := read_ref(x_ref)
-     // live_nodes: Reference(x_ref)
-     // unchecked_nodes: Reference(x_ref)
-     // spliced_nodes: Reference(r_ref)
+     // borrowed_by: LocalRoot($t0) -> {Reference($t1)}, Reference($t1) -> {Reference($t2)}
+     // borrows_from: Reference($t1) -> {LocalRoot($t0)}, Reference($t2) -> {Reference($t1)}
+  9: $t7 := read_ref($t2)
+     // live_nodes: Reference($t2)
+     // unchecked_nodes: Reference($t2)
+     // spliced_nodes: Reference($t1)
      // moved_nodes: Reference($t5)
-     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}, Reference(r_ref) -> {Reference(x_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}, Reference(x_ref) -> {Reference(r_ref)}
+     // borrowed_by: LocalRoot($t0) -> {Reference($t1)}, Reference($t1) -> {Reference($t2)}
+     // borrows_from: Reference($t1) -> {LocalRoot($t0)}, Reference($t2) -> {Reference($t1)}
  10: $t7 := TestBorrow::test2($t7, $t6)
-     // live_nodes: Reference(x_ref)
-     // unchecked_nodes: Reference(x_ref)
-     // spliced_nodes: Reference(r_ref)
+     // live_nodes: Reference($t2)
+     // unchecked_nodes: Reference($t2)
+     // spliced_nodes: Reference($t1)
      // moved_nodes: Reference($t5)
-     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}, Reference(r_ref) -> {Reference(x_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}, Reference(x_ref) -> {Reference(r_ref)}
- 11: write_ref(x_ref, $t7)
-     // unchecked_nodes: Reference(x_ref)
-     // spliced_nodes: Reference(r_ref)
+     // borrowed_by: LocalRoot($t0) -> {Reference($t1)}, Reference($t1) -> {Reference($t2)}
+     // borrows_from: Reference($t1) -> {LocalRoot($t0)}, Reference($t2) -> {Reference($t1)}
+ 11: write_ref($t2, $t7)
+     // unchecked_nodes: Reference($t2)
+     // spliced_nodes: Reference($t1)
      // moved_nodes: Reference($t5)
-     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}, Reference(r_ref) -> {Reference(x_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}, Reference(x_ref) -> {Reference(r_ref)}
- 12: return r
+     // borrowed_by: LocalRoot($t0) -> {Reference($t1)}, Reference($t1) -> {Reference($t2)}
+     // borrows_from: Reference($t1) -> {LocalRoot($t0)}, Reference($t2) -> {Reference($t1)}
+ 12: return $t0
 }
 
 
 [variant baseline]
-fun TestBorrow::test7(b: bool) {
-     var r1: TestBorrow::R
-     var r2: TestBorrow::R
-     var r_ref: &mut TestBorrow::R
+fun TestBorrow::test7($t0|b: bool) {
+     var $t1|r1: TestBorrow::R
+     var $t2|r2: TestBorrow::R
+     var $t3|r_ref: &mut TestBorrow::R
      var $t4: bool
      var $t5: u64
      var $t6: u64
      var $t7: u64
      var $t8: TestBorrow::R
-     // live_nodes: LocalRoot(b)
-  0: $t4 := move(b)
+     // live_nodes: LocalRoot($t0)
+  0: $t4 := move($t0)
      // live_nodes: LocalRoot($t4)
-     // moved_nodes: LocalRoot(b)
+     // moved_nodes: LocalRoot($t0)
   1: $t5 := 3
      // live_nodes: LocalRoot($t4)
-     // moved_nodes: LocalRoot(b)
-  2: r1 := pack TestBorrow::R($t5)
+     // moved_nodes: LocalRoot($t0)
+  2: $t1 := pack TestBorrow::R($t5)
      // live_nodes: LocalRoot($t4)
-     // moved_nodes: LocalRoot(b)
+     // moved_nodes: LocalRoot($t0)
   3: $t6 := 4
      // live_nodes: LocalRoot($t4)
-     // moved_nodes: LocalRoot(b)
-  4: r2 := pack TestBorrow::R($t6)
+     // moved_nodes: LocalRoot($t0)
+  4: $t2 := pack TestBorrow::R($t6)
      // live_nodes: LocalRoot($t4)
-     // moved_nodes: LocalRoot(b)
-  5: r_ref := borrow_local(r1)
-     // live_nodes: LocalRoot($t4), Reference(r_ref)
-     // moved_nodes: LocalRoot(b)
-     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+     // moved_nodes: LocalRoot($t0)
+  5: $t3 := borrow_local($t1)
+     // live_nodes: LocalRoot($t4), Reference($t3)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t3)}
+     // borrows_from: Reference($t3) -> {LocalRoot($t1)}
   6: if ($t4) goto L0 else goto L1
-     // live_nodes: LocalRoot($t4), Reference(r_ref)
-     // moved_nodes: LocalRoot(b)
-     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+     // live_nodes: LocalRoot($t4), Reference($t3)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t3)}
+     // borrows_from: Reference($t3) -> {LocalRoot($t1)}
   7: L1:
-     // live_nodes: LocalRoot($t4), Reference(r_ref)
-     // moved_nodes: LocalRoot(b)
-     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+     // live_nodes: LocalRoot($t4), Reference($t3)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t3)}
+     // borrows_from: Reference($t3) -> {LocalRoot($t1)}
   8: goto L2
-     // live_nodes: LocalRoot($t4), Reference(r_ref)
-     // moved_nodes: LocalRoot(b)
-     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+     // live_nodes: LocalRoot($t4), Reference($t3)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t3)}
+     // borrows_from: Reference($t3) -> {LocalRoot($t1)}
   9: L0:
-     // live_nodes: LocalRoot($t4), Reference(r_ref)
-     // moved_nodes: LocalRoot(b)
-     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
- 10: destroy(r_ref)
+     // live_nodes: LocalRoot($t4), Reference($t3)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t3)}
+     // borrows_from: Reference($t3) -> {LocalRoot($t1)}
+ 10: destroy($t3)
      // live_nodes: LocalRoot($t4)
-     // moved_nodes: LocalRoot(b)
-     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
- 11: r_ref := borrow_local(r2)
-     // live_nodes: LocalRoot($t4), Reference(r_ref)
-     // moved_nodes: LocalRoot(b)
-     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t3)}
+     // borrows_from: Reference($t3) -> {LocalRoot($t1)}
+ 11: $t3 := borrow_local($t2)
+     // live_nodes: LocalRoot($t4), Reference($t3)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t3)}, LocalRoot($t2) -> {Reference($t3)}
+     // borrows_from: Reference($t3) -> {LocalRoot($t1), LocalRoot($t2)}
  12: goto L2
-     // live_nodes: LocalRoot($t4), Reference(r_ref)
-     // moved_nodes: LocalRoot(b)
-     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_nodes: LocalRoot($t4), Reference($t3)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t3)}, LocalRoot($t2) -> {Reference($t3)}
+     // borrows_from: Reference($t3) -> {LocalRoot($t1), LocalRoot($t2)}
  13: L2:
-     // live_nodes: LocalRoot($t4), Reference(r_ref)
-     // moved_nodes: LocalRoot(b)
-     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_nodes: LocalRoot($t4), Reference($t3)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t3)}, LocalRoot($t2) -> {Reference($t3)}
+     // borrows_from: Reference($t3) -> {LocalRoot($t1), LocalRoot($t2)}
  14: $t7 := 0
-     // live_nodes: LocalRoot($t4), Reference(r_ref)
-     // moved_nodes: LocalRoot(b)
-     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
- 15: $t8 := read_ref(r_ref)
-     // live_nodes: LocalRoot($t4), Reference(r_ref)
-     // moved_nodes: LocalRoot(b)
-     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_nodes: LocalRoot($t4), Reference($t3)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t3)}, LocalRoot($t2) -> {Reference($t3)}
+     // borrows_from: Reference($t3) -> {LocalRoot($t1), LocalRoot($t2)}
+ 15: $t8 := read_ref($t3)
+     // live_nodes: LocalRoot($t4), Reference($t3)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t3)}, LocalRoot($t2) -> {Reference($t3)}
+     // borrows_from: Reference($t3) -> {LocalRoot($t1), LocalRoot($t2)}
  16: $t8 := TestBorrow::test3($t8, $t7)
-     // live_nodes: LocalRoot($t4), Reference(r_ref)
-     // moved_nodes: LocalRoot(b)
-     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
- 17: write_ref(r_ref, $t8)
+     // live_nodes: LocalRoot($t4), Reference($t3)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t3)}, LocalRoot($t2) -> {Reference($t3)}
+     // borrows_from: Reference($t3) -> {LocalRoot($t1), LocalRoot($t2)}
+ 17: write_ref($t3, $t8)
      // live_nodes: LocalRoot($t4)
-     // moved_nodes: LocalRoot(b)
-     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)}
-     // borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t3)}, LocalRoot($t2) -> {Reference($t3)}
+     // borrows_from: Reference($t3) -> {LocalRoot($t1), LocalRoot($t2)}
  18: return ()
 }
 
 
 [variant baseline]
-fun TestBorrow::test8(b: bool, n: u64, r_ref: TestBorrow::R): TestBorrow::R {
-     var r1: TestBorrow::R
-     var r2: TestBorrow::R
-     var t_ref: &mut TestBorrow::R
+fun TestBorrow::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: TestBorrow::R): TestBorrow::R {
+     var $t3|r1: TestBorrow::R
+     var $t4|r2: TestBorrow::R
+     var $t5|t_ref: &mut TestBorrow::R
      var $t6: bool
      var $t7: u64
      var $t8: TestBorrow::R
@@ -610,325 +610,325 @@ fun TestBorrow::test8(b: bool, n: u64, r_ref: TestBorrow::R): TestBorrow::R {
      var $t19: u64
      var $t20: TestBorrow::R
      var $t21: u64
-     // live_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // unchecked_nodes: LocalRoot(r_ref)
-  0: $t6 := move(b)
-     // live_nodes: LocalRoot(n), LocalRoot(r_ref), LocalRoot($t6)
-     // unchecked_nodes: LocalRoot(r_ref)
-     // moved_nodes: LocalRoot(b)
-  1: $t7 := move(n)
-     // live_nodes: LocalRoot(r_ref), LocalRoot($t6), LocalRoot($t7)
-     // unchecked_nodes: LocalRoot(r_ref)
-     // moved_nodes: LocalRoot(b), LocalRoot(n)
-  2: $t8 := move(r_ref)
+     // live_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // unchecked_nodes: LocalRoot($t2)
+  0: $t6 := move($t0)
+     // live_nodes: LocalRoot($t1), LocalRoot($t2), LocalRoot($t6)
+     // unchecked_nodes: LocalRoot($t2)
+     // moved_nodes: LocalRoot($t0)
+  1: $t7 := move($t1)
+     // live_nodes: LocalRoot($t2), LocalRoot($t6), LocalRoot($t7)
+     // unchecked_nodes: LocalRoot($t2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
+  2: $t8 := move($t2)
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8)
      // unchecked_nodes: LocalRoot($t8)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
   3: $t9 := borrow_local($t8)
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      // borrowed_by: LocalRoot($t8) -> {Reference($t9)}
      // borrows_from: Reference($t9) -> {LocalRoot($t8)}
   4: $t10 := 3
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      // borrowed_by: LocalRoot($t8) -> {Reference($t9)}
      // borrows_from: Reference($t9) -> {LocalRoot($t8)}
-  5: r1 := pack TestBorrow::R($t10)
+  5: $t3 := pack TestBorrow::R($t10)
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      // borrowed_by: LocalRoot($t8) -> {Reference($t9)}
      // borrows_from: Reference($t9) -> {LocalRoot($t8)}
   6: $t11 := 4
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      // borrowed_by: LocalRoot($t8) -> {Reference($t9)}
      // borrows_from: Reference($t9) -> {LocalRoot($t8)}
-  7: r2 := pack TestBorrow::R($t11)
+  7: $t4 := pack TestBorrow::R($t11)
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      // borrowed_by: LocalRoot($t8) -> {Reference($t9)}
      // borrows_from: Reference($t9) -> {LocalRoot($t8)}
-  8: t_ref := borrow_local(r2)
-     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference(t_ref), Reference($t9)
+  8: $t5 := borrow_local($t4)
+     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
   9: goto L7
-     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference(t_ref), Reference($t9)
+     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  10: L7:
-     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference(t_ref), Reference($t9)
+     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  11: $t12 := 0
-     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference(t_ref), Reference($t9)
+     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  12: $t13 := <($t12, $t7)
-     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference(t_ref), Reference($t9)
+     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  13: if ($t13) goto L0 else goto L1
-     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference(t_ref), Reference($t9)
+     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  14: L1:
-     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference(t_ref), Reference($t9)
+     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  15: goto L2
-     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference(t_ref), Reference($t9)
+     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  16: L0:
-     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference(t_ref), Reference($t9)
+     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
- 17: destroy(t_ref)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
+ 17: destroy($t5)
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  18: $t14 := 2
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  19: $t15 := /($t7, $t14)
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  20: $t16 := 0
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  21: $t17 := ==($t15, $t16)
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  22: if ($t17) goto L3 else goto L4
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  23: L4:
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  24: goto L5
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  25: L3:
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
- 26: t_ref := borrow_local(r1)
-     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference(t_ref), Reference($t9)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
+ 26: $t5 := borrow_local($t3)
+     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  27: goto L6
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  28: L5:
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
- 29: t_ref := borrow_local(r2)
-     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference(t_ref), Reference($t9)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
+ 29: $t5 := borrow_local($t4)
+     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  30: goto L6
-     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference(t_ref), Reference($t9)
+     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  31: L6:
-     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference(t_ref), Reference($t9)
+     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  32: $t18 := 1
-     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference(t_ref), Reference($t9)
+     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  33: $t7 := -($t7, $t18)
-     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference(t_ref), Reference($t9)
+     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  34: goto L7
-     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference(t_ref), Reference($t9)
+     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  35: L2:
-     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference(t_ref), Reference($t9)
+     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  36: if ($t6) goto L8 else goto L9
-     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference(t_ref), Reference($t9)
+     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  37: L9:
-     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference(t_ref), Reference($t9)
+     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  38: goto L10
-     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference(t_ref), Reference($t9)
+     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  39: L8:
-     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference(t_ref), Reference($t9)
+     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
- 40: destroy(t_ref)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
+ 40: destroy($t5)
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  41: $t19 := 0
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  42: $t20 := read_ref($t9)
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  43: $t20 := TestBorrow::test3($t20, $t19)
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  44: write_ref($t9, $t20)
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  45: goto L11
-     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference(t_ref), Reference($t9)
+     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  46: L10:
-     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference(t_ref), Reference($t9)
+     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  47: destroy($t9)
-     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference(t_ref)
+     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  48: $t21 := 0
-     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference(t_ref)
+     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
- 49: $t20 := read_ref(t_ref)
-     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference(t_ref)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
+ 49: $t20 := read_ref($t5)
+     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  50: $t20 := TestBorrow::test3($t20, $t21)
-     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference(t_ref)
+     // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
- 51: write_ref(t_ref, $t20)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
+ 51: write_ref($t5, $t20)
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  52: goto L11
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  53: L11:
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
-     // moved_nodes: LocalRoot(b), LocalRoot(n), LocalRoot(r_ref)
-     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}, LocalRoot($t8) -> {Reference($t9)}
-     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t9) -> {LocalRoot($t8)}
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
  54: return $t8
 }

--- a/language/move-prover/bytecode/tests/borrow/pack_unpack.exp
+++ b/language/move-prover/bytecode/tests/borrow/pack_unpack.exp
@@ -1,8 +1,8 @@
 ============ initial translation from Move ================
 
 [variant baseline]
-pub fun TestPackUnpack::call_private_violating_invariant(r: &mut TestPackUnpack::R) {
-     var s: &mut TestPackUnpack::S
+pub fun TestPackUnpack::call_private_violating_invariant($t0|r: &mut TestPackUnpack::R) {
+     var $t1|s: &mut TestPackUnpack::S
      var $t2: &mut TestPackUnpack::R
      var $t3: &mut TestPackUnpack::S
      var $t4: &mut TestPackUnpack::S
@@ -10,14 +10,14 @@ pub fun TestPackUnpack::call_private_violating_invariant(r: &mut TestPackUnpack:
      var $t6: u64
      var $t7: &mut TestPackUnpack::S
      var $t8: &mut u64
-  0: $t2 := move(r)
+  0: $t2 := move($t0)
   1: $t3 := borrow_field<TestPackUnpack::R>.nested($t2)
-  2: s := $t3
-  3: $t4 := copy(s)
+  2: $t1 := $t3
+  3: $t4 := copy($t1)
   4: $t5 := 0
   5: TestPackUnpack::private_update_value($t4, $t5)
   6: $t6 := 1
-  7: $t7 := move(s)
+  7: $t7 := move($t1)
   8: $t8 := borrow_field<TestPackUnpack::S>.value($t7)
   9: write_ref($t8, $t6)
  10: return ()
@@ -25,8 +25,8 @@ pub fun TestPackUnpack::call_private_violating_invariant(r: &mut TestPackUnpack:
 
 
 [variant baseline]
-pub fun TestPackUnpack::call_public_violating_invariant_incorrect(r: &mut TestPackUnpack::R) {
-     var s: &mut TestPackUnpack::S
+pub fun TestPackUnpack::call_public_violating_invariant_incorrect($t0|r: &mut TestPackUnpack::R) {
+     var $t1|s: &mut TestPackUnpack::S
      var $t2: &mut TestPackUnpack::R
      var $t3: &mut TestPackUnpack::S
      var $t4: &mut TestPackUnpack::S
@@ -34,14 +34,14 @@ pub fun TestPackUnpack::call_public_violating_invariant_incorrect(r: &mut TestPa
      var $t6: u64
      var $t7: &mut TestPackUnpack::S
      var $t8: &mut u64
-  0: $t2 := move(r)
+  0: $t2 := move($t0)
   1: $t3 := borrow_field<TestPackUnpack::R>.nested($t2)
-  2: s := $t3
-  3: $t4 := copy(s)
+  2: $t1 := $t3
+  3: $t4 := copy($t1)
   4: $t5 := 0
   5: TestPackUnpack::public_update_value($t4, $t5)
   6: $t6 := 1
-  7: $t7 := move(s)
+  7: $t7 := move($t1)
   8: $t8 := borrow_field<TestPackUnpack::S>.value($t7)
   9: write_ref($t8, $t6)
  10: return ()
@@ -61,28 +61,28 @@ pub fun TestPackUnpack::create(): TestPackUnpack::R {
 
 
 [variant baseline]
-pub fun TestPackUnpack::destroy(r: TestPackUnpack::R): u64 {
-     var nested: TestPackUnpack::S
-     var value: u64
+pub fun TestPackUnpack::destroy($t0|r: TestPackUnpack::R): u64 {
+     var $t1|nested: TestPackUnpack::S
+     var $t2|value: u64
      var $t3: TestPackUnpack::R
      var $t4: TestPackUnpack::S
      var $t5: TestPackUnpack::S
      var $t6: u64
      var $t7: u64
-  0: $t3 := move(r)
+  0: $t3 := move($t0)
   1: $t4 := unpack TestPackUnpack::R($t3)
-  2: nested := $t4
-  3: $t5 := move(nested)
+  2: $t1 := $t4
+  3: $t5 := move($t1)
   4: $t6 := unpack TestPackUnpack::S($t5)
-  5: value := $t6
-  6: $t7 := copy(value)
+  5: $t2 := $t6
+  6: $t7 := copy($t2)
   7: return $t7
 }
 
 
 [variant baseline]
-pub fun TestPackUnpack::extract_and_update(r: TestPackUnpack::R): TestPackUnpack::S {
-     var nested: TestPackUnpack::S
+pub fun TestPackUnpack::extract_and_update($t0|r: TestPackUnpack::R): TestPackUnpack::S {
+     var $t1|nested: TestPackUnpack::S
      var $t2: TestPackUnpack::R
      var $t3: TestPackUnpack::S
      var $t4: &TestPackUnpack::S
@@ -93,28 +93,28 @@ pub fun TestPackUnpack::extract_and_update(r: TestPackUnpack::R): TestPackUnpack
      var $t9: &mut TestPackUnpack::S
      var $t10: &mut u64
      var $t11: TestPackUnpack::S
-  0: $t2 := move(r)
+  0: $t2 := move($t0)
   1: $t3 := unpack TestPackUnpack::R($t2)
-  2: nested := $t3
-  3: $t4 := borrow_local(nested)
+  2: $t1 := $t3
+  3: $t4 := borrow_local($t1)
   4: $t5 := borrow_field<TestPackUnpack::S>.value($t4)
   5: $t6 := read_ref($t5)
   6: $t7 := 3
   7: $t8 := +($t6, $t7)
-  8: $t9 := borrow_local(nested)
+  8: $t9 := borrow_local($t1)
   9: $t10 := borrow_field<TestPackUnpack::S>.value($t9)
  10: write_ref($t10, $t8)
- 11: $t11 := move(nested)
+ 11: $t11 := move($t1)
  12: return $t11
 }
 
 
 [variant baseline]
-fun TestPackUnpack::get_value_ref(r: &mut TestPackUnpack::R): &mut u64 {
+fun TestPackUnpack::get_value_ref($t0|r: &mut TestPackUnpack::R): &mut u64 {
      var $t1: &mut TestPackUnpack::R
      var $t2: &mut TestPackUnpack::S
      var $t3: &mut u64
-  0: $t1 := move(r)
+  0: $t1 := move($t0)
   1: $t2 := borrow_field<TestPackUnpack::R>.nested($t1)
   2: $t3 := borrow_field<TestPackUnpack::S>.value($t2)
   3: return $t3
@@ -122,7 +122,7 @@ fun TestPackUnpack::get_value_ref(r: &mut TestPackUnpack::R): &mut u64 {
 
 
 [variant baseline]
-pub fun TestPackUnpack::move_ref_unchanged(r1: &mut TestPackUnpack::R, r2: &mut TestPackUnpack::R) {
+pub fun TestPackUnpack::move_ref_unchanged($t0|r1: &mut TestPackUnpack::R, $t1|r2: &mut TestPackUnpack::R) {
      var $t2: &mut TestPackUnpack::R
      var $t3: &TestPackUnpack::S
      var $t4: &u64
@@ -141,23 +141,23 @@ pub fun TestPackUnpack::move_ref_unchanged(r1: &mut TestPackUnpack::R, r2: &mut 
      var $t17: &mut TestPackUnpack::R
      var $t18: &mut TestPackUnpack::S
      var $t19: &mut u64
-  0: $t2 := copy(r2)
+  0: $t2 := copy($t1)
   1: $t3 := borrow_field<TestPackUnpack::R>.nested($t2)
   2: $t4 := borrow_field<TestPackUnpack::S>.value($t3)
   3: $t5 := read_ref($t4)
-  4: $t6 := copy(r1)
+  4: $t6 := copy($t0)
   5: $t7 := borrow_field<TestPackUnpack::R>.nested($t6)
   6: $t8 := borrow_field<TestPackUnpack::S>.value($t7)
   7: $t9 := read_ref($t8)
   8: $t10 := +($t5, $t9)
   9: $t11 := 1
  10: $t12 := -($t10, $t11)
- 11: $t13 := move(r2)
+ 11: $t13 := move($t1)
  12: $t14 := borrow_field<TestPackUnpack::R>.nested($t13)
  13: $t15 := borrow_field<TestPackUnpack::S>.value($t14)
  14: write_ref($t15, $t12)
  15: $t16 := 1
- 16: $t17 := move(r1)
+ 16: $t17 := move($t0)
  17: $t18 := borrow_field<TestPackUnpack::R>.nested($t17)
  18: $t19 := borrow_field<TestPackUnpack::S>.value($t18)
  19: write_ref($t19, $t16)
@@ -166,7 +166,7 @@ pub fun TestPackUnpack::move_ref_unchanged(r1: &mut TestPackUnpack::R, r2: &mut 
 
 
 [variant baseline]
-pub fun TestPackUnpack::move_ref_unchanged_invariant_incorrect(r1: &mut TestPackUnpack::R, r2: &mut TestPackUnpack::R) {
+pub fun TestPackUnpack::move_ref_unchanged_invariant_incorrect($t0|r1: &mut TestPackUnpack::R, $t1|r2: &mut TestPackUnpack::R) {
      var $t2: &mut TestPackUnpack::R
      var $t3: &TestPackUnpack::S
      var $t4: &u64
@@ -183,21 +183,21 @@ pub fun TestPackUnpack::move_ref_unchanged_invariant_incorrect(r1: &mut TestPack
      var $t15: &mut TestPackUnpack::R
      var $t16: &mut TestPackUnpack::S
      var $t17: &mut u64
-  0: $t2 := copy(r2)
+  0: $t2 := copy($t1)
   1: $t3 := borrow_field<TestPackUnpack::R>.nested($t2)
   2: $t4 := borrow_field<TestPackUnpack::S>.value($t3)
   3: $t5 := read_ref($t4)
-  4: $t6 := copy(r1)
+  4: $t6 := copy($t0)
   5: $t7 := borrow_field<TestPackUnpack::R>.nested($t6)
   6: $t8 := borrow_field<TestPackUnpack::S>.value($t7)
   7: $t9 := read_ref($t8)
   8: $t10 := +($t5, $t9)
-  9: $t11 := move(r2)
+  9: $t11 := move($t1)
  10: $t12 := borrow_field<TestPackUnpack::R>.nested($t11)
  11: $t13 := borrow_field<TestPackUnpack::S>.value($t12)
  12: write_ref($t13, $t10)
  13: $t14 := 0
- 14: $t15 := move(r1)
+ 14: $t15 := move($t0)
  15: $t16 := borrow_field<TestPackUnpack::R>.nested($t15)
  16: $t17 := borrow_field<TestPackUnpack::S>.value($t16)
  17: write_ref($t17, $t14)
@@ -206,11 +206,11 @@ pub fun TestPackUnpack::move_ref_unchanged_invariant_incorrect(r1: &mut TestPack
 
 
 [variant baseline]
-fun TestPackUnpack::private_pass_value_violating_invariant_incorrect(s: &mut TestPackUnpack::S): u64 {
+fun TestPackUnpack::private_pass_value_violating_invariant_incorrect($t0|s: &mut TestPackUnpack::S): u64 {
      var $t1: &mut TestPackUnpack::S
      var $t2: &TestPackUnpack::S
      var $t3: u64
-  0: $t1 := move(s)
+  0: $t1 := move($t0)
   1: $t2 := freeze_ref($t1)
   2: $t3 := TestPackUnpack::read_S_from_immutable($t2)
   3: return $t3
@@ -218,11 +218,11 @@ fun TestPackUnpack::private_pass_value_violating_invariant_incorrect(s: &mut Tes
 
 
 [variant baseline]
-fun TestPackUnpack::private_select_value_violating_invariant_incorrect(r: &mut TestPackUnpack::R): u64 {
+fun TestPackUnpack::private_select_value_violating_invariant_incorrect($t0|r: &mut TestPackUnpack::R): u64 {
      var $t1: &mut TestPackUnpack::R
      var $t2: &TestPackUnpack::S
      var $t3: u64
-  0: $t1 := move(r)
+  0: $t1 := move($t0)
   1: $t2 := borrow_field<TestPackUnpack::R>.nested($t1)
   2: $t3 := TestPackUnpack::read_S_from_immutable($t2)
   3: return $t3
@@ -230,12 +230,12 @@ fun TestPackUnpack::private_select_value_violating_invariant_incorrect(r: &mut T
 
 
 [variant baseline]
-fun TestPackUnpack::private_update_value(s: &mut TestPackUnpack::S, v: u64) {
+fun TestPackUnpack::private_update_value($t0|s: &mut TestPackUnpack::S, $t1|v: u64) {
      var $t2: u64
      var $t3: &mut TestPackUnpack::S
      var $t4: &mut u64
-  0: $t2 := copy(v)
-  1: $t3 := move(s)
+  0: $t2 := copy($t1)
+  1: $t3 := move($t0)
   2: $t4 := borrow_field<TestPackUnpack::S>.value($t3)
   3: write_ref($t4, $t2)
   4: return ()
@@ -243,12 +243,12 @@ fun TestPackUnpack::private_update_value(s: &mut TestPackUnpack::S, v: u64) {
 
 
 [variant baseline]
-pub fun TestPackUnpack::public_update_value(s: &mut TestPackUnpack::S, v: u64) {
+pub fun TestPackUnpack::public_update_value($t0|s: &mut TestPackUnpack::S, $t1|v: u64) {
      var $t2: u64
      var $t3: &mut TestPackUnpack::S
      var $t4: &mut u64
-  0: $t2 := copy(v)
-  1: $t3 := move(s)
+  0: $t2 := copy($t1)
+  1: $t3 := move($t0)
   2: $t4 := borrow_field<TestPackUnpack::S>.value($t3)
   3: write_ref($t4, $t2)
   4: return ()
@@ -256,11 +256,11 @@ pub fun TestPackUnpack::public_update_value(s: &mut TestPackUnpack::S, v: u64) {
 
 
 [variant baseline]
-fun TestPackUnpack::read_S_from_immutable(s: &TestPackUnpack::S): u64 {
+fun TestPackUnpack::read_S_from_immutable($t0|s: &TestPackUnpack::S): u64 {
      var $t1: &TestPackUnpack::S
      var $t2: &u64
      var $t3: u64
-  0: $t1 := move(s)
+  0: $t1 := move($t0)
   1: $t2 := borrow_field<TestPackUnpack::S>.value($t1)
   2: $t3 := read_ref($t2)
   3: return $t3
@@ -268,21 +268,21 @@ fun TestPackUnpack::read_S_from_immutable(s: &TestPackUnpack::S): u64 {
 
 
 [variant baseline]
-pub fun TestPackUnpack::read_ref_unchanged(r: &mut TestPackUnpack::R): u64 {
-     var nested: &mut TestPackUnpack::S
-     var tmp#$2: &mut TestPackUnpack::R
+pub fun TestPackUnpack::read_ref_unchanged($t0|r: &mut TestPackUnpack::R): u64 {
+     var $t1|nested: &mut TestPackUnpack::S
+     var $t2|tmp#$2: &mut TestPackUnpack::R
      var $t3: &mut TestPackUnpack::R
      var $t4: &mut TestPackUnpack::R
      var $t5: &mut TestPackUnpack::S
      var $t6: &mut TestPackUnpack::S
      var $t7: &u64
      var $t8: u64
-  0: $t3 := move(r)
-  1: tmp#$2 := $t3
-  2: $t4 := move(tmp#$2)
+  0: $t3 := move($t0)
+  1: $t2 := $t3
+  2: $t4 := move($t2)
   3: $t5 := borrow_field<TestPackUnpack::R>.nested($t4)
-  4: nested := $t5
-  5: $t6 := move(nested)
+  4: $t1 := $t5
+  5: $t6 := move($t1)
   6: $t7 := borrow_field<TestPackUnpack::S>.value($t6)
   7: $t8 := read_ref($t7)
   8: return $t8
@@ -290,8 +290,8 @@ pub fun TestPackUnpack::read_ref_unchanged(r: &mut TestPackUnpack::R): u64 {
 
 
 [variant baseline]
-pub fun TestPackUnpack::select_value_violating_invariant_incorrect(r: &mut TestPackUnpack::R): u64 {
-     var s: &mut TestPackUnpack::S
+pub fun TestPackUnpack::select_value_violating_invariant_incorrect($t0|r: &mut TestPackUnpack::R): u64 {
+     var $t1|s: &mut TestPackUnpack::S
      var $t2: &mut TestPackUnpack::R
      var $t3: &mut TestPackUnpack::S
      var $t4: u64
@@ -300,14 +300,14 @@ pub fun TestPackUnpack::select_value_violating_invariant_incorrect(r: &mut TestP
      var $t7: &mut TestPackUnpack::S
      var $t8: &TestPackUnpack::S
      var $t9: u64
-  0: $t2 := move(r)
+  0: $t2 := move($t0)
   1: $t3 := borrow_field<TestPackUnpack::R>.nested($t2)
-  2: s := $t3
+  2: $t1 := $t3
   3: $t4 := 0
-  4: $t5 := copy(s)
+  4: $t5 := copy($t1)
   5: $t6 := borrow_field<TestPackUnpack::S>.value($t5)
   6: write_ref($t6, $t4)
-  7: $t7 := move(s)
+  7: $t7 := move($t1)
   8: $t8 := freeze_ref($t7)
   9: $t9 := TestPackUnpack::read_S_from_immutable($t8)
  10: return $t9
@@ -315,9 +315,9 @@ pub fun TestPackUnpack::select_value_violating_invariant_incorrect(r: &mut TestP
 
 
 [variant baseline]
-pub fun TestPackUnpack::update_ref_changed(r: &mut TestPackUnpack::R): u64 {
-     var nested: &mut TestPackUnpack::S
-     var tmp#$2: &mut TestPackUnpack::R
+pub fun TestPackUnpack::update_ref_changed($t0|r: &mut TestPackUnpack::R): u64 {
+     var $t1|nested: &mut TestPackUnpack::S
+     var $t2|tmp#$2: &mut TestPackUnpack::R
      var $t3: &mut TestPackUnpack::R
      var $t4: &mut TestPackUnpack::R
      var $t5: &mut TestPackUnpack::S
@@ -331,20 +331,20 @@ pub fun TestPackUnpack::update_ref_changed(r: &mut TestPackUnpack::R): u64 {
      var $t13: &mut TestPackUnpack::S
      var $t14: &u64
      var $t15: u64
-  0: $t3 := move(r)
-  1: tmp#$2 := $t3
-  2: $t4 := move(tmp#$2)
+  0: $t3 := move($t0)
+  1: $t2 := $t3
+  2: $t4 := move($t2)
   3: $t5 := borrow_field<TestPackUnpack::R>.nested($t4)
-  4: nested := $t5
-  5: $t6 := copy(nested)
+  4: $t1 := $t5
+  5: $t6 := copy($t1)
   6: $t7 := borrow_field<TestPackUnpack::S>.value($t6)
   7: $t8 := read_ref($t7)
   8: $t9 := 2
   9: $t10 := +($t8, $t9)
- 10: $t11 := copy(nested)
+ 10: $t11 := copy($t1)
  11: $t12 := borrow_field<TestPackUnpack::S>.value($t11)
  12: write_ref($t12, $t10)
- 13: $t13 := move(nested)
+ 13: $t13 := move($t1)
  14: $t14 := borrow_field<TestPackUnpack::S>.value($t13)
  15: $t15 := read_ref($t14)
  16: return $t15
@@ -353,8 +353,8 @@ pub fun TestPackUnpack::update_ref_changed(r: &mut TestPackUnpack::R): u64 {
 
 [variant baseline]
 pub fun TestPackUnpack::update_via_returned_ref(): TestPackUnpack::R {
-     var r: TestPackUnpack::R
-     var v_ref: &mut u64
+     var $t0|r: TestPackUnpack::R
+     var $t1|v_ref: &mut u64
      var $t2: u64
      var $t3: TestPackUnpack::S
      var $t4: TestPackUnpack::R
@@ -366,22 +366,22 @@ pub fun TestPackUnpack::update_via_returned_ref(): TestPackUnpack::R {
   0: $t2 := 1
   1: $t3 := pack TestPackUnpack::S($t2)
   2: $t4 := pack TestPackUnpack::R($t3)
-  3: r := $t4
-  4: $t5 := borrow_local(r)
+  3: $t0 := $t4
+  4: $t5 := borrow_local($t0)
   5: $t6 := TestPackUnpack::get_value_ref($t5)
-  6: v_ref := $t6
+  6: $t1 := $t6
   7: $t7 := 2
-  8: $t8 := move(v_ref)
+  8: $t8 := move($t1)
   9: write_ref($t8, $t7)
- 10: $t9 := move(r)
+ 10: $t9 := move($t0)
  11: return $t9
 }
 
 
 [variant baseline]
 pub fun TestPackUnpack::update_via_returned_ref_invariant_incorrect(): TestPackUnpack::R {
-     var r: TestPackUnpack::R
-     var v_ref: &mut u64
+     var $t0|r: TestPackUnpack::R
+     var $t1|v_ref: &mut u64
      var $t2: u64
      var $t3: TestPackUnpack::S
      var $t4: TestPackUnpack::R
@@ -393,22 +393,22 @@ pub fun TestPackUnpack::update_via_returned_ref_invariant_incorrect(): TestPackU
   0: $t2 := 1
   1: $t3 := pack TestPackUnpack::S($t2)
   2: $t4 := pack TestPackUnpack::R($t3)
-  3: r := $t4
-  4: $t5 := borrow_local(r)
+  3: $t0 := $t4
+  4: $t5 := borrow_local($t0)
   5: $t6 := TestPackUnpack::get_value_ref($t5)
-  6: v_ref := $t6
+  6: $t1 := $t6
   7: $t7 := 0
-  8: $t8 := move(v_ref)
+  8: $t8 := move($t1)
   9: write_ref($t8, $t7)
- 10: $t9 := move(r)
+ 10: $t9 := move($t0)
  11: return $t9
 }
 
 
 [variant baseline]
 pub fun TestPackUnpack::update_via_returned_ref_var_incorrect(): TestPackUnpack::R {
-     var r: TestPackUnpack::R
-     var v_ref: &mut u64
+     var $t0|r: TestPackUnpack::R
+     var $t1|v_ref: &mut u64
      var $t2: u64
      var $t3: TestPackUnpack::S
      var $t4: TestPackUnpack::R
@@ -420,139 +420,139 @@ pub fun TestPackUnpack::update_via_returned_ref_var_incorrect(): TestPackUnpack:
   0: $t2 := 1
   1: $t3 := pack TestPackUnpack::S($t2)
   2: $t4 := pack TestPackUnpack::R($t3)
-  3: r := $t4
-  4: $t5 := borrow_local(r)
+  3: $t0 := $t4
+  4: $t5 := borrow_local($t0)
   5: $t6 := TestPackUnpack::get_value_ref($t5)
-  6: v_ref := $t6
+  6: $t1 := $t6
   7: $t7 := 1
-  8: $t8 := move(v_ref)
+  8: $t8 := move($t1)
   9: write_ref($t8, $t7)
- 10: $t9 := move(r)
+ 10: $t9 := move($t0)
  11: return $t9
 }
 
 ============ after pipeline `borrow` ================
 
 [variant baseline]
-pub fun TestPackUnpack::call_private_violating_invariant(r: TestPackUnpack::R): TestPackUnpack::R {
-     var s: &mut TestPackUnpack::S
+pub fun TestPackUnpack::call_private_violating_invariant($t0|r: TestPackUnpack::R): TestPackUnpack::R {
+     var $t1|s: &mut TestPackUnpack::S
      var $t2: TestPackUnpack::R
      var $t3: &mut TestPackUnpack::R
      var $t4: u64
      var $t5: TestPackUnpack::S
      var $t6: u64
      var $t7: &mut u64
-     // live_nodes: LocalRoot(r)
-  0: $t2 := move(r)
+     // live_nodes: LocalRoot($t0)
+  0: $t2 := move($t0)
      // live_nodes: LocalRoot($t2)
-     // moved_nodes: LocalRoot(r)
+     // moved_nodes: LocalRoot($t0)
   1: $t3 := borrow_local($t2)
      // live_nodes: LocalRoot($t2), Reference($t3)
-     // moved_nodes: LocalRoot(r)
+     // moved_nodes: LocalRoot($t0)
      // borrowed_by: LocalRoot($t2) -> {Reference($t3)}
      // borrows_from: Reference($t3) -> {LocalRoot($t2)}
-  2: s := borrow_field<TestPackUnpack::R>.nested($t3)
-     // live_nodes: LocalRoot($t2), Reference(s)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference(s)}
-     // borrows_from: Reference(s) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}
+  2: $t1 := borrow_field<TestPackUnpack::R>.nested($t3)
+     // live_nodes: LocalRoot($t2), Reference($t1)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}
   3: $t4 := 0
-     // live_nodes: LocalRoot($t2), Reference(s)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference(s)}
-     // borrows_from: Reference(s) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}
-  4: $t5 := read_ref(s)
-     // live_nodes: LocalRoot($t2), Reference(s)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference(s)}
-     // borrows_from: Reference(s) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}
+     // live_nodes: LocalRoot($t2), Reference($t1)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}
+  4: $t5 := read_ref($t1)
+     // live_nodes: LocalRoot($t2), Reference($t1)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}
   5: $t5 := TestPackUnpack::private_update_value($t5, $t4)
-     // live_nodes: LocalRoot($t2), Reference(s)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference(s)}
-     // borrows_from: Reference(s) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}
-  6: write_ref(s, $t5)
-     // live_nodes: LocalRoot($t2), Reference(s)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference(s)}
-     // borrows_from: Reference(s) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}
+     // live_nodes: LocalRoot($t2), Reference($t1)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}
+  6: write_ref($t1, $t5)
+     // live_nodes: LocalRoot($t2), Reference($t1)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}
   7: $t6 := 1
-     // live_nodes: LocalRoot($t2), Reference(s)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference(s)}
-     // borrows_from: Reference(s) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}
-  8: $t7 := borrow_field<TestPackUnpack::S>.value(s)
+     // live_nodes: LocalRoot($t2), Reference($t1)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}
+  8: $t7 := borrow_field<TestPackUnpack::S>.value($t1)
      // live_nodes: LocalRoot($t2), Reference($t7)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference(s) -> {Reference($t7)}, Reference($t3) -> {Reference(s)}
-     // borrows_from: Reference(s) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}, Reference($t7) -> {Reference(s)}
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t1) -> {Reference($t7)}, Reference($t3) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}, Reference($t7) -> {Reference($t1)}
   9: write_ref($t7, $t6)
      // live_nodes: LocalRoot($t2)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference(s) -> {Reference($t7)}, Reference($t3) -> {Reference(s)}
-     // borrows_from: Reference(s) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}, Reference($t7) -> {Reference(s)}
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t1) -> {Reference($t7)}, Reference($t3) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}, Reference($t7) -> {Reference($t1)}
  10: return $t2
 }
 
 
 [variant baseline]
-pub fun TestPackUnpack::call_public_violating_invariant_incorrect(r: TestPackUnpack::R): TestPackUnpack::R {
-     var s: &mut TestPackUnpack::S
+pub fun TestPackUnpack::call_public_violating_invariant_incorrect($t0|r: TestPackUnpack::R): TestPackUnpack::R {
+     var $t1|s: &mut TestPackUnpack::S
      var $t2: TestPackUnpack::R
      var $t3: &mut TestPackUnpack::R
      var $t4: u64
      var $t5: TestPackUnpack::S
      var $t6: u64
      var $t7: &mut u64
-     // live_nodes: LocalRoot(r)
-  0: $t2 := move(r)
+     // live_nodes: LocalRoot($t0)
+  0: $t2 := move($t0)
      // live_nodes: LocalRoot($t2)
-     // moved_nodes: LocalRoot(r)
+     // moved_nodes: LocalRoot($t0)
   1: $t3 := borrow_local($t2)
      // live_nodes: LocalRoot($t2), Reference($t3)
-     // moved_nodes: LocalRoot(r)
+     // moved_nodes: LocalRoot($t0)
      // borrowed_by: LocalRoot($t2) -> {Reference($t3)}
      // borrows_from: Reference($t3) -> {LocalRoot($t2)}
-  2: s := borrow_field<TestPackUnpack::R>.nested($t3)
-     // live_nodes: LocalRoot($t2), Reference(s)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference(s)}
-     // borrows_from: Reference(s) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}
+  2: $t1 := borrow_field<TestPackUnpack::R>.nested($t3)
+     // live_nodes: LocalRoot($t2), Reference($t1)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}
   3: $t4 := 0
-     // live_nodes: LocalRoot($t2), Reference(s)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference(s)}
-     // borrows_from: Reference(s) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}
-  4: $t5 := read_ref(s)
-     // live_nodes: LocalRoot($t2), Reference(s)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference(s)}
-     // borrows_from: Reference(s) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}
+     // live_nodes: LocalRoot($t2), Reference($t1)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}
+  4: $t5 := read_ref($t1)
+     // live_nodes: LocalRoot($t2), Reference($t1)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}
   5: $t5 := TestPackUnpack::public_update_value($t5, $t4)
-     // live_nodes: LocalRoot($t2), Reference(s)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference(s)}
-     // borrows_from: Reference(s) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}
-  6: write_ref(s, $t5)
-     // live_nodes: LocalRoot($t2), Reference(s)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference(s)}
-     // borrows_from: Reference(s) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}
+     // live_nodes: LocalRoot($t2), Reference($t1)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}
+  6: write_ref($t1, $t5)
+     // live_nodes: LocalRoot($t2), Reference($t1)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}
   7: $t6 := 1
-     // live_nodes: LocalRoot($t2), Reference(s)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference(s)}
-     // borrows_from: Reference(s) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}
-  8: $t7 := borrow_field<TestPackUnpack::S>.value(s)
+     // live_nodes: LocalRoot($t2), Reference($t1)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}
+  8: $t7 := borrow_field<TestPackUnpack::S>.value($t1)
      // live_nodes: LocalRoot($t2), Reference($t7)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference(s) -> {Reference($t7)}, Reference($t3) -> {Reference(s)}
-     // borrows_from: Reference(s) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}, Reference($t7) -> {Reference(s)}
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t1) -> {Reference($t7)}, Reference($t3) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}, Reference($t7) -> {Reference($t1)}
   9: write_ref($t7, $t6)
      // live_nodes: LocalRoot($t2)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference(s) -> {Reference($t7)}, Reference($t3) -> {Reference(s)}
-     // borrows_from: Reference(s) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}, Reference($t7) -> {Reference(s)}
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t1) -> {Reference($t7)}, Reference($t3) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}, Reference($t7) -> {Reference($t1)}
  10: return $t2
 }
 
@@ -570,96 +570,96 @@ pub fun TestPackUnpack::create(): TestPackUnpack::R {
 
 
 [variant baseline]
-pub fun TestPackUnpack::destroy(r: TestPackUnpack::R): u64 {
-     var nested: TestPackUnpack::S
-     var value: u64
+pub fun TestPackUnpack::destroy($t0|r: TestPackUnpack::R): u64 {
+     var $t1|nested: TestPackUnpack::S
+     var $t2|value: u64
      var $t3: TestPackUnpack::R
-     // live_nodes: LocalRoot(r)
-  0: $t3 := move(r)
+     // live_nodes: LocalRoot($t0)
+  0: $t3 := move($t0)
      // live_nodes: LocalRoot($t3)
-     // moved_nodes: LocalRoot(r)
-  1: nested := unpack TestPackUnpack::R($t3)
+     // moved_nodes: LocalRoot($t0)
+  1: $t1 := unpack TestPackUnpack::R($t3)
      // live_nodes: LocalRoot($t3)
-     // moved_nodes: LocalRoot(r)
-  2: value := unpack TestPackUnpack::S(nested)
+     // moved_nodes: LocalRoot($t0)
+  2: $t2 := unpack TestPackUnpack::S($t1)
      // live_nodes: LocalRoot($t3)
-     // moved_nodes: LocalRoot(r)
-  3: return value
+     // moved_nodes: LocalRoot($t0)
+  3: return $t2
 }
 
 
 [variant baseline]
-pub fun TestPackUnpack::extract_and_update(r: TestPackUnpack::R): TestPackUnpack::S {
-     var nested: TestPackUnpack::S
+pub fun TestPackUnpack::extract_and_update($t0|r: TestPackUnpack::R): TestPackUnpack::S {
+     var $t1|nested: TestPackUnpack::S
      var $t2: TestPackUnpack::R
      var $t3: u64
      var $t4: u64
      var $t5: u64
      var $t6: &mut TestPackUnpack::S
      var $t7: &mut u64
-     // live_nodes: LocalRoot(r)
-  0: $t2 := move(r)
+     // live_nodes: LocalRoot($t0)
+  0: $t2 := move($t0)
      // live_nodes: LocalRoot($t2)
-     // moved_nodes: LocalRoot(r)
-  1: nested := unpack TestPackUnpack::R($t2)
+     // moved_nodes: LocalRoot($t0)
+  1: $t1 := unpack TestPackUnpack::R($t2)
      // live_nodes: LocalRoot($t2)
-     // moved_nodes: LocalRoot(r)
-  2: $t3 := get_field<TestPackUnpack::S>.value(nested)
+     // moved_nodes: LocalRoot($t0)
+  2: $t3 := get_field<TestPackUnpack::S>.value($t1)
      // live_nodes: LocalRoot($t2)
-     // moved_nodes: LocalRoot(r)
+     // moved_nodes: LocalRoot($t0)
   3: $t4 := 3
      // live_nodes: LocalRoot($t2)
-     // moved_nodes: LocalRoot(r)
+     // moved_nodes: LocalRoot($t0)
   4: $t5 := +($t3, $t4)
      // live_nodes: LocalRoot($t2)
-     // moved_nodes: LocalRoot(r)
-  5: $t6 := borrow_local(nested)
+     // moved_nodes: LocalRoot($t0)
+  5: $t6 := borrow_local($t1)
      // live_nodes: LocalRoot($t2), Reference($t6)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot(nested) -> {Reference($t6)}
-     // borrows_from: Reference($t6) -> {LocalRoot(nested)}
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t6)}
+     // borrows_from: Reference($t6) -> {LocalRoot($t1)}
   6: $t7 := borrow_field<TestPackUnpack::S>.value($t6)
      // live_nodes: LocalRoot($t2), Reference($t7)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot(nested) -> {Reference($t6)}, Reference($t6) -> {Reference($t7)}
-     // borrows_from: Reference($t6) -> {LocalRoot(nested)}, Reference($t7) -> {Reference($t6)}
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t6)}, Reference($t6) -> {Reference($t7)}
+     // borrows_from: Reference($t6) -> {LocalRoot($t1)}, Reference($t7) -> {Reference($t6)}
   7: write_ref($t7, $t5)
      // live_nodes: LocalRoot($t2)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot(nested) -> {Reference($t6)}, Reference($t6) -> {Reference($t7)}
-     // borrows_from: Reference($t6) -> {LocalRoot(nested)}, Reference($t7) -> {Reference($t6)}
-  8: return nested
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t6)}, Reference($t6) -> {Reference($t7)}
+     // borrows_from: Reference($t6) -> {LocalRoot($t1)}, Reference($t7) -> {Reference($t6)}
+  8: return $t1
 }
 
 
 [variant baseline]
-fun TestPackUnpack::get_value_ref(r: TestPackUnpack::R): (&mut u64, TestPackUnpack::R) {
+fun TestPackUnpack::get_value_ref($t0|r: TestPackUnpack::R): (&mut u64, TestPackUnpack::R) {
      var $t1: TestPackUnpack::R
      var $t2: &mut TestPackUnpack::R
      var $t3: &mut TestPackUnpack::S
      var $t4: &mut u64
-     // live_nodes: LocalRoot(r)
-     // unchecked_nodes: LocalRoot(r)
-  0: $t1 := move(r)
+     // live_nodes: LocalRoot($t0)
+     // unchecked_nodes: LocalRoot($t0)
+  0: $t1 := move($t0)
      // live_nodes: LocalRoot($t1)
      // unchecked_nodes: LocalRoot($t1)
-     // moved_nodes: LocalRoot(r)
+     // moved_nodes: LocalRoot($t0)
   1: $t2 := borrow_local($t1)
      // live_nodes: LocalRoot($t1), Reference($t2)
      // unchecked_nodes: LocalRoot($t1), Reference($t2)
-     // moved_nodes: LocalRoot(r)
+     // moved_nodes: LocalRoot($t0)
      // borrowed_by: LocalRoot($t1) -> {Reference($t2)}
      // borrows_from: Reference($t2) -> {LocalRoot($t1)}
   2: $t3 := borrow_field<TestPackUnpack::R>.nested($t2)
      // live_nodes: LocalRoot($t1), Reference($t3)
      // unchecked_nodes: LocalRoot($t1), Reference($t2), Reference($t3)
-     // moved_nodes: LocalRoot(r)
+     // moved_nodes: LocalRoot($t0)
      // borrowed_by: LocalRoot($t1) -> {Reference($t2)}, Reference($t2) -> {Reference($t3)}
      // borrows_from: Reference($t2) -> {LocalRoot($t1)}, Reference($t3) -> {Reference($t2)}
   3: $t4 := borrow_field<TestPackUnpack::S>.value($t3)
      // live_nodes: LocalRoot($t1), Reference($t4)
      // unchecked_nodes: LocalRoot($t1), Reference($t2), Reference($t3), Reference($t4)
-     // moved_nodes: LocalRoot(r)
+     // moved_nodes: LocalRoot($t0)
      // borrowed_by: LocalRoot($t1) -> {Reference($t2)}, Reference($t2) -> {Reference($t3)}, Reference($t3) -> {Reference($t4)}
      // borrows_from: Reference($t2) -> {LocalRoot($t1)}, Reference($t3) -> {Reference($t2)}, Reference($t4) -> {Reference($t3)}
   4: return ($t4, $t1)
@@ -667,7 +667,7 @@ fun TestPackUnpack::get_value_ref(r: TestPackUnpack::R): (&mut u64, TestPackUnpa
 
 
 [variant baseline]
-pub fun TestPackUnpack::move_ref_unchanged(r1: TestPackUnpack::R, r2: TestPackUnpack::R): (TestPackUnpack::R, TestPackUnpack::R) {
+pub fun TestPackUnpack::move_ref_unchanged($t0|r1: TestPackUnpack::R, $t1|r2: TestPackUnpack::R): (TestPackUnpack::R, TestPackUnpack::R) {
      var $t2: TestPackUnpack::R
      var $t3: TestPackUnpack::R
      var $t4: &mut TestPackUnpack::R
@@ -684,91 +684,91 @@ pub fun TestPackUnpack::move_ref_unchanged(r1: TestPackUnpack::R, r2: TestPackUn
      var $t15: u64
      var $t16: &mut TestPackUnpack::S
      var $t17: &mut u64
-     // live_nodes: LocalRoot(r1), LocalRoot(r2)
-  0: $t2 := move(r1)
-     // live_nodes: LocalRoot(r2), LocalRoot($t2)
-     // moved_nodes: LocalRoot(r1)
-  1: $t3 := move(r2)
+     // live_nodes: LocalRoot($t0), LocalRoot($t1)
+  0: $t2 := move($t0)
+     // live_nodes: LocalRoot($t1), LocalRoot($t2)
+     // moved_nodes: LocalRoot($t0)
+  1: $t3 := move($t1)
      // live_nodes: LocalRoot($t2), LocalRoot($t3)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
   2: $t4 := borrow_local($t2)
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t4)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}
   3: $t5 := borrow_local($t3)
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t4), Reference($t5)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, LocalRoot($t3) -> {Reference($t5)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {LocalRoot($t3)}
   4: $t6 := get_field<TestPackUnpack::R>.nested($t5)
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t4), Reference($t5)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, LocalRoot($t3) -> {Reference($t5)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {LocalRoot($t3)}
   5: $t7 := get_field<TestPackUnpack::S>.value($t6)
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t4), Reference($t5)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, LocalRoot($t3) -> {Reference($t5)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {LocalRoot($t3)}
   6: $t8 := get_field<TestPackUnpack::R>.nested($t4)
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t4), Reference($t5)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, LocalRoot($t3) -> {Reference($t5)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {LocalRoot($t3)}
   7: $t9 := get_field<TestPackUnpack::S>.value($t8)
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t4), Reference($t5)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, LocalRoot($t3) -> {Reference($t5)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {LocalRoot($t3)}
   8: $t10 := +($t7, $t9)
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t4), Reference($t5)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, LocalRoot($t3) -> {Reference($t5)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {LocalRoot($t3)}
   9: $t11 := 1
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t4), Reference($t5)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, LocalRoot($t3) -> {Reference($t5)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {LocalRoot($t3)}
  10: $t12 := -($t10, $t11)
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t4), Reference($t5)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, LocalRoot($t3) -> {Reference($t5)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {LocalRoot($t3)}
  11: $t13 := borrow_field<TestPackUnpack::R>.nested($t5)
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t4), Reference($t13)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, LocalRoot($t3) -> {Reference($t5)}, Reference($t5) -> {Reference($t13)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {LocalRoot($t3)}, Reference($t13) -> {Reference($t5)}
  12: $t14 := borrow_field<TestPackUnpack::S>.value($t13)
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t4), Reference($t14)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, LocalRoot($t3) -> {Reference($t5)}, Reference($t5) -> {Reference($t13)}, Reference($t13) -> {Reference($t14)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {LocalRoot($t3)}, Reference($t13) -> {Reference($t5)}, Reference($t14) -> {Reference($t13)}
  13: write_ref($t14, $t12)
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t4)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, LocalRoot($t3) -> {Reference($t5)}, Reference($t5) -> {Reference($t13)}, Reference($t13) -> {Reference($t14)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {LocalRoot($t3)}, Reference($t13) -> {Reference($t5)}, Reference($t14) -> {Reference($t13)}
  14: $t15 := 1
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t4)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, LocalRoot($t3) -> {Reference($t5)}, Reference($t5) -> {Reference($t13)}, Reference($t13) -> {Reference($t14)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {LocalRoot($t3)}, Reference($t13) -> {Reference($t5)}, Reference($t14) -> {Reference($t13)}
  15: $t16 := borrow_field<TestPackUnpack::R>.nested($t4)
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t16)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, LocalRoot($t3) -> {Reference($t5)}, Reference($t4) -> {Reference($t16)}, Reference($t5) -> {Reference($t13)}, Reference($t13) -> {Reference($t14)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {LocalRoot($t3)}, Reference($t13) -> {Reference($t5)}, Reference($t14) -> {Reference($t13)}, Reference($t16) -> {Reference($t4)}
  16: $t17 := borrow_field<TestPackUnpack::S>.value($t16)
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t17)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, LocalRoot($t3) -> {Reference($t5)}, Reference($t4) -> {Reference($t16)}, Reference($t5) -> {Reference($t13)}, Reference($t13) -> {Reference($t14)}, Reference($t16) -> {Reference($t17)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {LocalRoot($t3)}, Reference($t13) -> {Reference($t5)}, Reference($t14) -> {Reference($t13)}, Reference($t16) -> {Reference($t4)}, Reference($t17) -> {Reference($t16)}
  17: write_ref($t17, $t15)
      // live_nodes: LocalRoot($t2), LocalRoot($t3)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, LocalRoot($t3) -> {Reference($t5)}, Reference($t4) -> {Reference($t16)}, Reference($t5) -> {Reference($t13)}, Reference($t13) -> {Reference($t14)}, Reference($t16) -> {Reference($t17)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {LocalRoot($t3)}, Reference($t13) -> {Reference($t5)}, Reference($t14) -> {Reference($t13)}, Reference($t16) -> {Reference($t4)}, Reference($t17) -> {Reference($t16)}
  18: return ($t2, $t3)
@@ -776,7 +776,7 @@ pub fun TestPackUnpack::move_ref_unchanged(r1: TestPackUnpack::R, r2: TestPackUn
 
 
 [variant baseline]
-pub fun TestPackUnpack::move_ref_unchanged_invariant_incorrect(r1: TestPackUnpack::R, r2: TestPackUnpack::R): (TestPackUnpack::R, TestPackUnpack::R) {
+pub fun TestPackUnpack::move_ref_unchanged_invariant_incorrect($t0|r1: TestPackUnpack::R, $t1|r2: TestPackUnpack::R): (TestPackUnpack::R, TestPackUnpack::R) {
      var $t2: TestPackUnpack::R
      var $t3: TestPackUnpack::R
      var $t4: &mut TestPackUnpack::R
@@ -791,81 +791,81 @@ pub fun TestPackUnpack::move_ref_unchanged_invariant_incorrect(r1: TestPackUnpac
      var $t13: u64
      var $t14: &mut TestPackUnpack::S
      var $t15: &mut u64
-     // live_nodes: LocalRoot(r1), LocalRoot(r2)
-  0: $t2 := move(r1)
-     // live_nodes: LocalRoot(r2), LocalRoot($t2)
-     // moved_nodes: LocalRoot(r1)
-  1: $t3 := move(r2)
+     // live_nodes: LocalRoot($t0), LocalRoot($t1)
+  0: $t2 := move($t0)
+     // live_nodes: LocalRoot($t1), LocalRoot($t2)
+     // moved_nodes: LocalRoot($t0)
+  1: $t3 := move($t1)
      // live_nodes: LocalRoot($t2), LocalRoot($t3)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
   2: $t4 := borrow_local($t2)
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t4)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}
   3: $t5 := borrow_local($t3)
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t4), Reference($t5)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, LocalRoot($t3) -> {Reference($t5)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {LocalRoot($t3)}
   4: $t6 := get_field<TestPackUnpack::R>.nested($t5)
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t4), Reference($t5)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, LocalRoot($t3) -> {Reference($t5)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {LocalRoot($t3)}
   5: $t7 := get_field<TestPackUnpack::S>.value($t6)
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t4), Reference($t5)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, LocalRoot($t3) -> {Reference($t5)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {LocalRoot($t3)}
   6: $t8 := get_field<TestPackUnpack::R>.nested($t4)
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t4), Reference($t5)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, LocalRoot($t3) -> {Reference($t5)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {LocalRoot($t3)}
   7: $t9 := get_field<TestPackUnpack::S>.value($t8)
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t4), Reference($t5)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, LocalRoot($t3) -> {Reference($t5)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {LocalRoot($t3)}
   8: $t10 := +($t7, $t9)
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t4), Reference($t5)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, LocalRoot($t3) -> {Reference($t5)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {LocalRoot($t3)}
   9: $t11 := borrow_field<TestPackUnpack::R>.nested($t5)
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t4), Reference($t11)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, LocalRoot($t3) -> {Reference($t5)}, Reference($t5) -> {Reference($t11)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {LocalRoot($t3)}, Reference($t11) -> {Reference($t5)}
  10: $t12 := borrow_field<TestPackUnpack::S>.value($t11)
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t4), Reference($t12)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, LocalRoot($t3) -> {Reference($t5)}, Reference($t5) -> {Reference($t11)}, Reference($t11) -> {Reference($t12)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {LocalRoot($t3)}, Reference($t11) -> {Reference($t5)}, Reference($t12) -> {Reference($t11)}
  11: write_ref($t12, $t10)
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t4)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, LocalRoot($t3) -> {Reference($t5)}, Reference($t5) -> {Reference($t11)}, Reference($t11) -> {Reference($t12)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {LocalRoot($t3)}, Reference($t11) -> {Reference($t5)}, Reference($t12) -> {Reference($t11)}
  12: $t13 := 0
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t4)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, LocalRoot($t3) -> {Reference($t5)}, Reference($t5) -> {Reference($t11)}, Reference($t11) -> {Reference($t12)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {LocalRoot($t3)}, Reference($t11) -> {Reference($t5)}, Reference($t12) -> {Reference($t11)}
  13: $t14 := borrow_field<TestPackUnpack::R>.nested($t4)
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t14)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, LocalRoot($t3) -> {Reference($t5)}, Reference($t4) -> {Reference($t14)}, Reference($t5) -> {Reference($t11)}, Reference($t11) -> {Reference($t12)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {LocalRoot($t3)}, Reference($t11) -> {Reference($t5)}, Reference($t12) -> {Reference($t11)}, Reference($t14) -> {Reference($t4)}
  14: $t15 := borrow_field<TestPackUnpack::S>.value($t14)
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t15)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, LocalRoot($t3) -> {Reference($t5)}, Reference($t4) -> {Reference($t14)}, Reference($t5) -> {Reference($t11)}, Reference($t11) -> {Reference($t12)}, Reference($t14) -> {Reference($t15)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {LocalRoot($t3)}, Reference($t11) -> {Reference($t5)}, Reference($t12) -> {Reference($t11)}, Reference($t14) -> {Reference($t4)}, Reference($t15) -> {Reference($t14)}
  15: write_ref($t15, $t13)
      // live_nodes: LocalRoot($t2), LocalRoot($t3)
-     // moved_nodes: LocalRoot(r1), LocalRoot(r2)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, LocalRoot($t3) -> {Reference($t5)}, Reference($t4) -> {Reference($t14)}, Reference($t5) -> {Reference($t11)}, Reference($t11) -> {Reference($t12)}, Reference($t14) -> {Reference($t15)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {LocalRoot($t3)}, Reference($t11) -> {Reference($t5)}, Reference($t12) -> {Reference($t11)}, Reference($t14) -> {Reference($t4)}, Reference($t15) -> {Reference($t14)}
  16: return ($t2, $t3)
@@ -873,33 +873,33 @@ pub fun TestPackUnpack::move_ref_unchanged_invariant_incorrect(r1: TestPackUnpac
 
 
 [variant baseline]
-fun TestPackUnpack::private_pass_value_violating_invariant_incorrect(s: TestPackUnpack::S): (u64, TestPackUnpack::S) {
+fun TestPackUnpack::private_pass_value_violating_invariant_incorrect($t0|s: TestPackUnpack::S): (u64, TestPackUnpack::S) {
      var $t1: TestPackUnpack::S
      var $t2: &mut TestPackUnpack::S
      var $t3: TestPackUnpack::S
      var $t4: u64
-     // live_nodes: LocalRoot(s)
-     // unchecked_nodes: LocalRoot(s)
-  0: $t1 := move(s)
+     // live_nodes: LocalRoot($t0)
+     // unchecked_nodes: LocalRoot($t0)
+  0: $t1 := move($t0)
      // live_nodes: LocalRoot($t1)
      // unchecked_nodes: LocalRoot($t1)
-     // moved_nodes: LocalRoot(s)
+     // moved_nodes: LocalRoot($t0)
   1: $t2 := borrow_local($t1)
      // live_nodes: LocalRoot($t1), Reference($t2)
      // unchecked_nodes: LocalRoot($t1), Reference($t2)
-     // moved_nodes: LocalRoot(s)
+     // moved_nodes: LocalRoot($t0)
      // borrowed_by: LocalRoot($t1) -> {Reference($t2)}
      // borrows_from: Reference($t2) -> {LocalRoot($t1)}
   2: $t3 := read_ref($t2)
      // live_nodes: LocalRoot($t1)
      // unchecked_nodes: LocalRoot($t1), Reference($t2)
-     // moved_nodes: LocalRoot(s)
+     // moved_nodes: LocalRoot($t0)
      // borrowed_by: LocalRoot($t1) -> {Reference($t2)}
      // borrows_from: Reference($t2) -> {LocalRoot($t1)}
   3: $t4 := TestPackUnpack::read_S_from_immutable($t3)
      // live_nodes: LocalRoot($t1)
      // unchecked_nodes: LocalRoot($t1), Reference($t2)
-     // moved_nodes: LocalRoot(s)
+     // moved_nodes: LocalRoot($t0)
      // borrowed_by: LocalRoot($t1) -> {Reference($t2)}
      // borrows_from: Reference($t2) -> {LocalRoot($t1)}
   4: return ($t4, $t1)
@@ -907,33 +907,33 @@ fun TestPackUnpack::private_pass_value_violating_invariant_incorrect(s: TestPack
 
 
 [variant baseline]
-fun TestPackUnpack::private_select_value_violating_invariant_incorrect(r: TestPackUnpack::R): (u64, TestPackUnpack::R) {
+fun TestPackUnpack::private_select_value_violating_invariant_incorrect($t0|r: TestPackUnpack::R): (u64, TestPackUnpack::R) {
      var $t1: TestPackUnpack::R
      var $t2: &mut TestPackUnpack::R
      var $t3: TestPackUnpack::S
      var $t4: u64
-     // live_nodes: LocalRoot(r)
-     // unchecked_nodes: LocalRoot(r)
-  0: $t1 := move(r)
+     // live_nodes: LocalRoot($t0)
+     // unchecked_nodes: LocalRoot($t0)
+  0: $t1 := move($t0)
      // live_nodes: LocalRoot($t1)
      // unchecked_nodes: LocalRoot($t1)
-     // moved_nodes: LocalRoot(r)
+     // moved_nodes: LocalRoot($t0)
   1: $t2 := borrow_local($t1)
      // live_nodes: LocalRoot($t1), Reference($t2)
      // unchecked_nodes: LocalRoot($t1), Reference($t2)
-     // moved_nodes: LocalRoot(r)
+     // moved_nodes: LocalRoot($t0)
      // borrowed_by: LocalRoot($t1) -> {Reference($t2)}
      // borrows_from: Reference($t2) -> {LocalRoot($t1)}
   2: $t3 := get_field<TestPackUnpack::R>.nested($t2)
      // live_nodes: LocalRoot($t1)
      // unchecked_nodes: LocalRoot($t1), Reference($t2)
-     // moved_nodes: LocalRoot(r)
+     // moved_nodes: LocalRoot($t0)
      // borrowed_by: LocalRoot($t1) -> {Reference($t2)}
      // borrows_from: Reference($t2) -> {LocalRoot($t1)}
   3: $t4 := TestPackUnpack::read_S_from_immutable($t3)
      // live_nodes: LocalRoot($t1)
      // unchecked_nodes: LocalRoot($t1), Reference($t2)
-     // moved_nodes: LocalRoot(r)
+     // moved_nodes: LocalRoot($t0)
      // borrowed_by: LocalRoot($t1) -> {Reference($t2)}
      // borrows_from: Reference($t2) -> {LocalRoot($t1)}
   4: return ($t4, $t1)
@@ -941,37 +941,37 @@ fun TestPackUnpack::private_select_value_violating_invariant_incorrect(r: TestPa
 
 
 [variant baseline]
-fun TestPackUnpack::private_update_value(s: TestPackUnpack::S, v: u64): TestPackUnpack::S {
+fun TestPackUnpack::private_update_value($t0|s: TestPackUnpack::S, $t1|v: u64): TestPackUnpack::S {
      var $t2: TestPackUnpack::S
      var $t3: u64
      var $t4: &mut TestPackUnpack::S
      var $t5: &mut u64
-     // live_nodes: LocalRoot(s), LocalRoot(v)
-     // unchecked_nodes: LocalRoot(s)
-  0: $t2 := move(s)
-     // live_nodes: LocalRoot(v), LocalRoot($t2)
+     // live_nodes: LocalRoot($t0), LocalRoot($t1)
+     // unchecked_nodes: LocalRoot($t0)
+  0: $t2 := move($t0)
+     // live_nodes: LocalRoot($t1), LocalRoot($t2)
      // unchecked_nodes: LocalRoot($t2)
-     // moved_nodes: LocalRoot(s)
-  1: $t3 := move(v)
+     // moved_nodes: LocalRoot($t0)
+  1: $t3 := move($t1)
      // live_nodes: LocalRoot($t2), LocalRoot($t3)
      // unchecked_nodes: LocalRoot($t2)
-     // moved_nodes: LocalRoot(s), LocalRoot(v)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
   2: $t4 := borrow_local($t2)
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t4)
      // unchecked_nodes: LocalRoot($t2), Reference($t4)
-     // moved_nodes: LocalRoot(s), LocalRoot(v)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}
   3: $t5 := borrow_field<TestPackUnpack::S>.value($t4)
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t5)
      // unchecked_nodes: LocalRoot($t2), Reference($t4), Reference($t5)
-     // moved_nodes: LocalRoot(s), LocalRoot(v)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, Reference($t4) -> {Reference($t5)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {Reference($t4)}
   4: write_ref($t5, $t3)
      // live_nodes: LocalRoot($t2), LocalRoot($t3)
      // unchecked_nodes: LocalRoot($t2), Reference($t4), Reference($t5)
-     // moved_nodes: LocalRoot(s), LocalRoot(v)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, Reference($t4) -> {Reference($t5)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {Reference($t4)}
   5: return $t2
@@ -979,31 +979,31 @@ fun TestPackUnpack::private_update_value(s: TestPackUnpack::S, v: u64): TestPack
 
 
 [variant baseline]
-pub fun TestPackUnpack::public_update_value(s: TestPackUnpack::S, v: u64): TestPackUnpack::S {
+pub fun TestPackUnpack::public_update_value($t0|s: TestPackUnpack::S, $t1|v: u64): TestPackUnpack::S {
      var $t2: TestPackUnpack::S
      var $t3: u64
      var $t4: &mut TestPackUnpack::S
      var $t5: &mut u64
-     // live_nodes: LocalRoot(s), LocalRoot(v)
-  0: $t2 := move(s)
-     // live_nodes: LocalRoot(v), LocalRoot($t2)
-     // moved_nodes: LocalRoot(s)
-  1: $t3 := move(v)
+     // live_nodes: LocalRoot($t0), LocalRoot($t1)
+  0: $t2 := move($t0)
+     // live_nodes: LocalRoot($t1), LocalRoot($t2)
+     // moved_nodes: LocalRoot($t0)
+  1: $t3 := move($t1)
      // live_nodes: LocalRoot($t2), LocalRoot($t3)
-     // moved_nodes: LocalRoot(s), LocalRoot(v)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
   2: $t4 := borrow_local($t2)
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t4)
-     // moved_nodes: LocalRoot(s), LocalRoot(v)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}
   3: $t5 := borrow_field<TestPackUnpack::S>.value($t4)
      // live_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t5)
-     // moved_nodes: LocalRoot(s), LocalRoot(v)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, Reference($t4) -> {Reference($t5)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {Reference($t4)}
   4: write_ref($t5, $t3)
      // live_nodes: LocalRoot($t2), LocalRoot($t3)
-     // moved_nodes: LocalRoot(s), LocalRoot(v)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
      // borrowed_by: LocalRoot($t2) -> {Reference($t4)}, Reference($t4) -> {Reference($t5)}
      // borrows_from: Reference($t4) -> {LocalRoot($t2)}, Reference($t5) -> {Reference($t4)}
   5: return $t2
@@ -1011,106 +1011,106 @@ pub fun TestPackUnpack::public_update_value(s: TestPackUnpack::S, v: u64): TestP
 
 
 [variant baseline]
-fun TestPackUnpack::read_S_from_immutable(s: TestPackUnpack::S): u64 {
+fun TestPackUnpack::read_S_from_immutable($t0|s: TestPackUnpack::S): u64 {
      var $t1: TestPackUnpack::S
      var $t2: u64
-     // live_nodes: LocalRoot(s)
-  0: $t1 := move(s)
+     // live_nodes: LocalRoot($t0)
+  0: $t1 := move($t0)
      // live_nodes: LocalRoot($t1)
-     // moved_nodes: LocalRoot(s)
+     // moved_nodes: LocalRoot($t0)
   1: $t2 := get_field<TestPackUnpack::S>.value($t1)
      // live_nodes: LocalRoot($t1)
-     // moved_nodes: LocalRoot(s)
+     // moved_nodes: LocalRoot($t0)
   2: return $t2
 }
 
 
 [variant baseline]
-pub fun TestPackUnpack::read_ref_unchanged(r: TestPackUnpack::R): (u64, TestPackUnpack::R) {
-     var nested: &mut TestPackUnpack::S
-     var tmp#$2: &mut TestPackUnpack::R
+pub fun TestPackUnpack::read_ref_unchanged($t0|r: TestPackUnpack::R): (u64, TestPackUnpack::R) {
+     var $t1|nested: &mut TestPackUnpack::S
+     var $t2|tmp#$2: &mut TestPackUnpack::R
      var $t3: TestPackUnpack::R
      var $t4: &mut TestPackUnpack::R
      var $t5: u64
-     // live_nodes: LocalRoot(r)
-  0: $t3 := move(r)
+     // live_nodes: LocalRoot($t0)
+  0: $t3 := move($t0)
      // live_nodes: LocalRoot($t3)
-     // moved_nodes: LocalRoot(r)
+     // moved_nodes: LocalRoot($t0)
   1: $t4 := borrow_local($t3)
      // live_nodes: LocalRoot($t3), Reference($t4)
-     // moved_nodes: LocalRoot(r)
+     // moved_nodes: LocalRoot($t0)
      // borrowed_by: LocalRoot($t3) -> {Reference($t4)}
      // borrows_from: Reference($t4) -> {LocalRoot($t3)}
-  2: nested := borrow_field<TestPackUnpack::R>.nested($t4)
-     // live_nodes: LocalRoot($t3), Reference(nested)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t3) -> {Reference($t4)}, Reference($t4) -> {Reference(nested)}
-     // borrows_from: Reference(nested) -> {Reference($t4)}, Reference($t4) -> {LocalRoot($t3)}
-  3: $t5 := get_field<TestPackUnpack::S>.value(nested)
+  2: $t1 := borrow_field<TestPackUnpack::R>.nested($t4)
+     // live_nodes: LocalRoot($t3), Reference($t1)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t4)}, Reference($t4) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t4)}, Reference($t4) -> {LocalRoot($t3)}
+  3: $t5 := get_field<TestPackUnpack::S>.value($t1)
      // live_nodes: LocalRoot($t3)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t3) -> {Reference($t4)}, Reference($t4) -> {Reference(nested)}
-     // borrows_from: Reference(nested) -> {Reference($t4)}, Reference($t4) -> {LocalRoot($t3)}
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t4)}, Reference($t4) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t4)}, Reference($t4) -> {LocalRoot($t3)}
   4: return ($t5, $t3)
 }
 
 
 [variant baseline]
-pub fun TestPackUnpack::select_value_violating_invariant_incorrect(r: TestPackUnpack::R): (u64, TestPackUnpack::R) {
-     var s: &mut TestPackUnpack::S
+pub fun TestPackUnpack::select_value_violating_invariant_incorrect($t0|r: TestPackUnpack::R): (u64, TestPackUnpack::R) {
+     var $t1|s: &mut TestPackUnpack::S
      var $t2: TestPackUnpack::R
      var $t3: &mut TestPackUnpack::R
      var $t4: u64
      var $t5: &mut u64
      var $t6: TestPackUnpack::S
      var $t7: u64
-     // live_nodes: LocalRoot(r)
-  0: $t2 := move(r)
+     // live_nodes: LocalRoot($t0)
+  0: $t2 := move($t0)
      // live_nodes: LocalRoot($t2)
-     // moved_nodes: LocalRoot(r)
+     // moved_nodes: LocalRoot($t0)
   1: $t3 := borrow_local($t2)
      // live_nodes: LocalRoot($t2), Reference($t3)
-     // moved_nodes: LocalRoot(r)
+     // moved_nodes: LocalRoot($t0)
      // borrowed_by: LocalRoot($t2) -> {Reference($t3)}
      // borrows_from: Reference($t3) -> {LocalRoot($t2)}
-  2: s := borrow_field<TestPackUnpack::R>.nested($t3)
-     // live_nodes: LocalRoot($t2), Reference(s)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference(s)}
-     // borrows_from: Reference(s) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}
+  2: $t1 := borrow_field<TestPackUnpack::R>.nested($t3)
+     // live_nodes: LocalRoot($t2), Reference($t1)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}
   3: $t4 := 0
-     // live_nodes: LocalRoot($t2), Reference(s)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference(s)}
-     // borrows_from: Reference(s) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}
-  4: $t5 := borrow_field<TestPackUnpack::S>.value(s)
-     // live_nodes: LocalRoot($t2), Reference(s), Reference($t5)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference(s) -> {Reference($t5)}, Reference($t3) -> {Reference(s)}
-     // borrows_from: Reference(s) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}, Reference($t5) -> {Reference(s)}
+     // live_nodes: LocalRoot($t2), Reference($t1)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}
+  4: $t5 := borrow_field<TestPackUnpack::S>.value($t1)
+     // live_nodes: LocalRoot($t2), Reference($t1), Reference($t5)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t1) -> {Reference($t5)}, Reference($t3) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}, Reference($t5) -> {Reference($t1)}
   5: write_ref($t5, $t4)
-     // live_nodes: LocalRoot($t2), Reference(s)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference(s) -> {Reference($t5)}, Reference($t3) -> {Reference(s)}
-     // borrows_from: Reference(s) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}, Reference($t5) -> {Reference(s)}
-  6: $t6 := read_ref(s)
+     // live_nodes: LocalRoot($t2), Reference($t1)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t1) -> {Reference($t5)}, Reference($t3) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}, Reference($t5) -> {Reference($t1)}
+  6: $t6 := read_ref($t1)
      // live_nodes: LocalRoot($t2)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference(s) -> {Reference($t5)}, Reference($t3) -> {Reference(s)}
-     // borrows_from: Reference(s) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}, Reference($t5) -> {Reference(s)}
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t1) -> {Reference($t5)}, Reference($t3) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}, Reference($t5) -> {Reference($t1)}
   7: $t7 := TestPackUnpack::read_S_from_immutable($t6)
      // live_nodes: LocalRoot($t2)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference(s) -> {Reference($t5)}, Reference($t3) -> {Reference(s)}
-     // borrows_from: Reference(s) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}, Reference($t5) -> {Reference(s)}
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t2) -> {Reference($t3)}, Reference($t1) -> {Reference($t5)}, Reference($t3) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t3)}, Reference($t3) -> {LocalRoot($t2)}, Reference($t5) -> {Reference($t1)}
   8: return ($t7, $t2)
 }
 
 
 [variant baseline]
-pub fun TestPackUnpack::update_ref_changed(r: TestPackUnpack::R): (u64, TestPackUnpack::R) {
-     var nested: &mut TestPackUnpack::S
-     var tmp#$2: &mut TestPackUnpack::R
+pub fun TestPackUnpack::update_ref_changed($t0|r: TestPackUnpack::R): (u64, TestPackUnpack::R) {
+     var $t1|nested: &mut TestPackUnpack::S
+     var $t2|tmp#$2: &mut TestPackUnpack::R
      var $t3: TestPackUnpack::R
      var $t4: &mut TestPackUnpack::R
      var $t5: u64
@@ -1118,58 +1118,58 @@ pub fun TestPackUnpack::update_ref_changed(r: TestPackUnpack::R): (u64, TestPack
      var $t7: u64
      var $t8: &mut u64
      var $t9: u64
-     // live_nodes: LocalRoot(r)
-  0: $t3 := move(r)
+     // live_nodes: LocalRoot($t0)
+  0: $t3 := move($t0)
      // live_nodes: LocalRoot($t3)
-     // moved_nodes: LocalRoot(r)
+     // moved_nodes: LocalRoot($t0)
   1: $t4 := borrow_local($t3)
      // live_nodes: LocalRoot($t3), Reference($t4)
-     // moved_nodes: LocalRoot(r)
+     // moved_nodes: LocalRoot($t0)
      // borrowed_by: LocalRoot($t3) -> {Reference($t4)}
      // borrows_from: Reference($t4) -> {LocalRoot($t3)}
-  2: nested := borrow_field<TestPackUnpack::R>.nested($t4)
-     // live_nodes: LocalRoot($t3), Reference(nested)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t3) -> {Reference($t4)}, Reference($t4) -> {Reference(nested)}
-     // borrows_from: Reference(nested) -> {Reference($t4)}, Reference($t4) -> {LocalRoot($t3)}
-  3: $t5 := get_field<TestPackUnpack::S>.value(nested)
-     // live_nodes: LocalRoot($t3), Reference(nested)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t3) -> {Reference($t4)}, Reference($t4) -> {Reference(nested)}
-     // borrows_from: Reference(nested) -> {Reference($t4)}, Reference($t4) -> {LocalRoot($t3)}
+  2: $t1 := borrow_field<TestPackUnpack::R>.nested($t4)
+     // live_nodes: LocalRoot($t3), Reference($t1)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t4)}, Reference($t4) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t4)}, Reference($t4) -> {LocalRoot($t3)}
+  3: $t5 := get_field<TestPackUnpack::S>.value($t1)
+     // live_nodes: LocalRoot($t3), Reference($t1)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t4)}, Reference($t4) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t4)}, Reference($t4) -> {LocalRoot($t3)}
   4: $t6 := 2
-     // live_nodes: LocalRoot($t3), Reference(nested)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t3) -> {Reference($t4)}, Reference($t4) -> {Reference(nested)}
-     // borrows_from: Reference(nested) -> {Reference($t4)}, Reference($t4) -> {LocalRoot($t3)}
+     // live_nodes: LocalRoot($t3), Reference($t1)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t4)}, Reference($t4) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t4)}, Reference($t4) -> {LocalRoot($t3)}
   5: $t7 := +($t5, $t6)
-     // live_nodes: LocalRoot($t3), Reference(nested)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t3) -> {Reference($t4)}, Reference($t4) -> {Reference(nested)}
-     // borrows_from: Reference(nested) -> {Reference($t4)}, Reference($t4) -> {LocalRoot($t3)}
-  6: $t8 := borrow_field<TestPackUnpack::S>.value(nested)
-     // live_nodes: LocalRoot($t3), Reference(nested), Reference($t8)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t3) -> {Reference($t4)}, Reference(nested) -> {Reference($t8)}, Reference($t4) -> {Reference(nested)}
-     // borrows_from: Reference(nested) -> {Reference($t4)}, Reference($t4) -> {LocalRoot($t3)}, Reference($t8) -> {Reference(nested)}
+     // live_nodes: LocalRoot($t3), Reference($t1)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t4)}, Reference($t4) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t4)}, Reference($t4) -> {LocalRoot($t3)}
+  6: $t8 := borrow_field<TestPackUnpack::S>.value($t1)
+     // live_nodes: LocalRoot($t3), Reference($t1), Reference($t8)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t4)}, Reference($t1) -> {Reference($t8)}, Reference($t4) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t4)}, Reference($t4) -> {LocalRoot($t3)}, Reference($t8) -> {Reference($t1)}
   7: write_ref($t8, $t7)
-     // live_nodes: LocalRoot($t3), Reference(nested)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t3) -> {Reference($t4)}, Reference(nested) -> {Reference($t8)}, Reference($t4) -> {Reference(nested)}
-     // borrows_from: Reference(nested) -> {Reference($t4)}, Reference($t4) -> {LocalRoot($t3)}, Reference($t8) -> {Reference(nested)}
-  8: $t9 := get_field<TestPackUnpack::S>.value(nested)
+     // live_nodes: LocalRoot($t3), Reference($t1)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t4)}, Reference($t1) -> {Reference($t8)}, Reference($t4) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t4)}, Reference($t4) -> {LocalRoot($t3)}, Reference($t8) -> {Reference($t1)}
+  8: $t9 := get_field<TestPackUnpack::S>.value($t1)
      // live_nodes: LocalRoot($t3)
-     // moved_nodes: LocalRoot(r)
-     // borrowed_by: LocalRoot($t3) -> {Reference($t4)}, Reference(nested) -> {Reference($t8)}, Reference($t4) -> {Reference(nested)}
-     // borrows_from: Reference(nested) -> {Reference($t4)}, Reference($t4) -> {LocalRoot($t3)}, Reference($t8) -> {Reference(nested)}
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t3) -> {Reference($t4)}, Reference($t1) -> {Reference($t8)}, Reference($t4) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t4)}, Reference($t4) -> {LocalRoot($t3)}, Reference($t8) -> {Reference($t1)}
   9: return ($t9, $t3)
 }
 
 
 [variant baseline]
 pub fun TestPackUnpack::update_via_returned_ref(): TestPackUnpack::R {
-     var r: TestPackUnpack::R
-     var v_ref: &mut u64
+     var $t0|r: TestPackUnpack::R
+     var $t1|v_ref: &mut u64
      var $t2: u64
      var $t3: TestPackUnpack::S
      var $t4: &mut TestPackUnpack::R
@@ -1178,61 +1178,61 @@ pub fun TestPackUnpack::update_via_returned_ref(): TestPackUnpack::R {
      var $t7: u64
   0: $t2 := 1
   1: $t3 := pack TestPackUnpack::S($t2)
-  2: r := pack TestPackUnpack::R($t3)
-  3: $t4 := borrow_local(r)
+  2: $t0 := pack TestPackUnpack::R($t3)
+  3: $t4 := borrow_local($t0)
      // live_nodes: Reference($t4)
      // spliced_nodes: Reference($t4)
-     // borrowed_by: LocalRoot(r) -> {Reference($t4)}
-     // borrows_from: Reference($t4) -> {LocalRoot(r)}
+     // borrowed_by: LocalRoot($t0) -> {Reference($t4)}
+     // borrows_from: Reference($t4) -> {LocalRoot($t0)}
   4: $t5 := read_ref($t4)
      // live_nodes: Reference($t4)
      // spliced_nodes: Reference($t4)
-     // borrowed_by: LocalRoot(r) -> {Reference($t4)}
-     // borrows_from: Reference($t4) -> {LocalRoot(r)}
+     // borrowed_by: LocalRoot($t0) -> {Reference($t4)}
+     // borrows_from: Reference($t4) -> {LocalRoot($t0)}
   5: ($t6, $t5) := TestPackUnpack::get_value_ref($t5)
      // live_nodes: Reference($t4)
      // spliced_nodes: Reference($t4)
-     // borrowed_by: LocalRoot(r) -> {Reference($t4)}
-     // borrows_from: Reference($t4) -> {LocalRoot(r)}
+     // borrowed_by: LocalRoot($t0) -> {Reference($t4)}
+     // borrows_from: Reference($t4) -> {LocalRoot($t0)}
   6: write_ref($t4, $t5)
      // live_nodes: Reference($t4)
      // spliced_nodes: Reference($t4)
-     // borrowed_by: LocalRoot(r) -> {Reference($t4)}
-     // borrows_from: Reference($t4) -> {LocalRoot(r)}
+     // borrowed_by: LocalRoot($t0) -> {Reference($t4)}
+     // borrows_from: Reference($t4) -> {LocalRoot($t0)}
   7: splice[0 -> $t4]($t6)
      // live_nodes: Reference($t6)
      // unchecked_nodes: Reference($t6)
      // spliced_nodes: Reference($t4)
-     // borrowed_by: LocalRoot(r) -> {Reference($t4)}, Reference($t4) -> {Reference($t6)}
-     // borrows_from: Reference($t4) -> {LocalRoot(r)}, Reference($t6) -> {Reference($t4)}
-  8: v_ref := $t6
-     // live_nodes: Reference(v_ref)
-     // unchecked_nodes: Reference(v_ref)
+     // borrowed_by: LocalRoot($t0) -> {Reference($t4)}, Reference($t4) -> {Reference($t6)}
+     // borrows_from: Reference($t4) -> {LocalRoot($t0)}, Reference($t6) -> {Reference($t4)}
+  8: $t1 := $t6
+     // live_nodes: Reference($t1)
+     // unchecked_nodes: Reference($t1)
      // spliced_nodes: Reference($t4)
      // moved_nodes: Reference($t6)
-     // borrowed_by: LocalRoot(r) -> {Reference($t4)}, Reference($t4) -> {Reference(v_ref)}
-     // borrows_from: Reference(v_ref) -> {Reference($t4)}, Reference($t4) -> {LocalRoot(r)}
+     // borrowed_by: LocalRoot($t0) -> {Reference($t4)}, Reference($t4) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t4)}, Reference($t4) -> {LocalRoot($t0)}
   9: $t7 := 2
-     // live_nodes: Reference(v_ref)
-     // unchecked_nodes: Reference(v_ref)
+     // live_nodes: Reference($t1)
+     // unchecked_nodes: Reference($t1)
      // spliced_nodes: Reference($t4)
      // moved_nodes: Reference($t6)
-     // borrowed_by: LocalRoot(r) -> {Reference($t4)}, Reference($t4) -> {Reference(v_ref)}
-     // borrows_from: Reference(v_ref) -> {Reference($t4)}, Reference($t4) -> {LocalRoot(r)}
- 10: write_ref(v_ref, $t7)
-     // unchecked_nodes: Reference(v_ref)
+     // borrowed_by: LocalRoot($t0) -> {Reference($t4)}, Reference($t4) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t4)}, Reference($t4) -> {LocalRoot($t0)}
+ 10: write_ref($t1, $t7)
+     // unchecked_nodes: Reference($t1)
      // spliced_nodes: Reference($t4)
      // moved_nodes: Reference($t6)
-     // borrowed_by: LocalRoot(r) -> {Reference($t4)}, Reference($t4) -> {Reference(v_ref)}
-     // borrows_from: Reference(v_ref) -> {Reference($t4)}, Reference($t4) -> {LocalRoot(r)}
- 11: return r
+     // borrowed_by: LocalRoot($t0) -> {Reference($t4)}, Reference($t4) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t4)}, Reference($t4) -> {LocalRoot($t0)}
+ 11: return $t0
 }
 
 
 [variant baseline]
 pub fun TestPackUnpack::update_via_returned_ref_invariant_incorrect(): TestPackUnpack::R {
-     var r: TestPackUnpack::R
-     var v_ref: &mut u64
+     var $t0|r: TestPackUnpack::R
+     var $t1|v_ref: &mut u64
      var $t2: u64
      var $t3: TestPackUnpack::S
      var $t4: &mut TestPackUnpack::R
@@ -1241,61 +1241,61 @@ pub fun TestPackUnpack::update_via_returned_ref_invariant_incorrect(): TestPackU
      var $t7: u64
   0: $t2 := 1
   1: $t3 := pack TestPackUnpack::S($t2)
-  2: r := pack TestPackUnpack::R($t3)
-  3: $t4 := borrow_local(r)
+  2: $t0 := pack TestPackUnpack::R($t3)
+  3: $t4 := borrow_local($t0)
      // live_nodes: Reference($t4)
      // spliced_nodes: Reference($t4)
-     // borrowed_by: LocalRoot(r) -> {Reference($t4)}
-     // borrows_from: Reference($t4) -> {LocalRoot(r)}
+     // borrowed_by: LocalRoot($t0) -> {Reference($t4)}
+     // borrows_from: Reference($t4) -> {LocalRoot($t0)}
   4: $t5 := read_ref($t4)
      // live_nodes: Reference($t4)
      // spliced_nodes: Reference($t4)
-     // borrowed_by: LocalRoot(r) -> {Reference($t4)}
-     // borrows_from: Reference($t4) -> {LocalRoot(r)}
+     // borrowed_by: LocalRoot($t0) -> {Reference($t4)}
+     // borrows_from: Reference($t4) -> {LocalRoot($t0)}
   5: ($t6, $t5) := TestPackUnpack::get_value_ref($t5)
      // live_nodes: Reference($t4)
      // spliced_nodes: Reference($t4)
-     // borrowed_by: LocalRoot(r) -> {Reference($t4)}
-     // borrows_from: Reference($t4) -> {LocalRoot(r)}
+     // borrowed_by: LocalRoot($t0) -> {Reference($t4)}
+     // borrows_from: Reference($t4) -> {LocalRoot($t0)}
   6: write_ref($t4, $t5)
      // live_nodes: Reference($t4)
      // spliced_nodes: Reference($t4)
-     // borrowed_by: LocalRoot(r) -> {Reference($t4)}
-     // borrows_from: Reference($t4) -> {LocalRoot(r)}
+     // borrowed_by: LocalRoot($t0) -> {Reference($t4)}
+     // borrows_from: Reference($t4) -> {LocalRoot($t0)}
   7: splice[0 -> $t4]($t6)
      // live_nodes: Reference($t6)
      // unchecked_nodes: Reference($t6)
      // spliced_nodes: Reference($t4)
-     // borrowed_by: LocalRoot(r) -> {Reference($t4)}, Reference($t4) -> {Reference($t6)}
-     // borrows_from: Reference($t4) -> {LocalRoot(r)}, Reference($t6) -> {Reference($t4)}
-  8: v_ref := $t6
-     // live_nodes: Reference(v_ref)
-     // unchecked_nodes: Reference(v_ref)
+     // borrowed_by: LocalRoot($t0) -> {Reference($t4)}, Reference($t4) -> {Reference($t6)}
+     // borrows_from: Reference($t4) -> {LocalRoot($t0)}, Reference($t6) -> {Reference($t4)}
+  8: $t1 := $t6
+     // live_nodes: Reference($t1)
+     // unchecked_nodes: Reference($t1)
      // spliced_nodes: Reference($t4)
      // moved_nodes: Reference($t6)
-     // borrowed_by: LocalRoot(r) -> {Reference($t4)}, Reference($t4) -> {Reference(v_ref)}
-     // borrows_from: Reference(v_ref) -> {Reference($t4)}, Reference($t4) -> {LocalRoot(r)}
+     // borrowed_by: LocalRoot($t0) -> {Reference($t4)}, Reference($t4) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t4)}, Reference($t4) -> {LocalRoot($t0)}
   9: $t7 := 0
-     // live_nodes: Reference(v_ref)
-     // unchecked_nodes: Reference(v_ref)
+     // live_nodes: Reference($t1)
+     // unchecked_nodes: Reference($t1)
      // spliced_nodes: Reference($t4)
      // moved_nodes: Reference($t6)
-     // borrowed_by: LocalRoot(r) -> {Reference($t4)}, Reference($t4) -> {Reference(v_ref)}
-     // borrows_from: Reference(v_ref) -> {Reference($t4)}, Reference($t4) -> {LocalRoot(r)}
- 10: write_ref(v_ref, $t7)
-     // unchecked_nodes: Reference(v_ref)
+     // borrowed_by: LocalRoot($t0) -> {Reference($t4)}, Reference($t4) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t4)}, Reference($t4) -> {LocalRoot($t0)}
+ 10: write_ref($t1, $t7)
+     // unchecked_nodes: Reference($t1)
      // spliced_nodes: Reference($t4)
      // moved_nodes: Reference($t6)
-     // borrowed_by: LocalRoot(r) -> {Reference($t4)}, Reference($t4) -> {Reference(v_ref)}
-     // borrows_from: Reference(v_ref) -> {Reference($t4)}, Reference($t4) -> {LocalRoot(r)}
- 11: return r
+     // borrowed_by: LocalRoot($t0) -> {Reference($t4)}, Reference($t4) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t4)}, Reference($t4) -> {LocalRoot($t0)}
+ 11: return $t0
 }
 
 
 [variant baseline]
 pub fun TestPackUnpack::update_via_returned_ref_var_incorrect(): TestPackUnpack::R {
-     var r: TestPackUnpack::R
-     var v_ref: &mut u64
+     var $t0|r: TestPackUnpack::R
+     var $t1|v_ref: &mut u64
      var $t2: u64
      var $t3: TestPackUnpack::S
      var $t4: &mut TestPackUnpack::R
@@ -1304,52 +1304,52 @@ pub fun TestPackUnpack::update_via_returned_ref_var_incorrect(): TestPackUnpack:
      var $t7: u64
   0: $t2 := 1
   1: $t3 := pack TestPackUnpack::S($t2)
-  2: r := pack TestPackUnpack::R($t3)
-  3: $t4 := borrow_local(r)
+  2: $t0 := pack TestPackUnpack::R($t3)
+  3: $t4 := borrow_local($t0)
      // live_nodes: Reference($t4)
      // spliced_nodes: Reference($t4)
-     // borrowed_by: LocalRoot(r) -> {Reference($t4)}
-     // borrows_from: Reference($t4) -> {LocalRoot(r)}
+     // borrowed_by: LocalRoot($t0) -> {Reference($t4)}
+     // borrows_from: Reference($t4) -> {LocalRoot($t0)}
   4: $t5 := read_ref($t4)
      // live_nodes: Reference($t4)
      // spliced_nodes: Reference($t4)
-     // borrowed_by: LocalRoot(r) -> {Reference($t4)}
-     // borrows_from: Reference($t4) -> {LocalRoot(r)}
+     // borrowed_by: LocalRoot($t0) -> {Reference($t4)}
+     // borrows_from: Reference($t4) -> {LocalRoot($t0)}
   5: ($t6, $t5) := TestPackUnpack::get_value_ref($t5)
      // live_nodes: Reference($t4)
      // spliced_nodes: Reference($t4)
-     // borrowed_by: LocalRoot(r) -> {Reference($t4)}
-     // borrows_from: Reference($t4) -> {LocalRoot(r)}
+     // borrowed_by: LocalRoot($t0) -> {Reference($t4)}
+     // borrows_from: Reference($t4) -> {LocalRoot($t0)}
   6: write_ref($t4, $t5)
      // live_nodes: Reference($t4)
      // spliced_nodes: Reference($t4)
-     // borrowed_by: LocalRoot(r) -> {Reference($t4)}
-     // borrows_from: Reference($t4) -> {LocalRoot(r)}
+     // borrowed_by: LocalRoot($t0) -> {Reference($t4)}
+     // borrows_from: Reference($t4) -> {LocalRoot($t0)}
   7: splice[0 -> $t4]($t6)
      // live_nodes: Reference($t6)
      // unchecked_nodes: Reference($t6)
      // spliced_nodes: Reference($t4)
-     // borrowed_by: LocalRoot(r) -> {Reference($t4)}, Reference($t4) -> {Reference($t6)}
-     // borrows_from: Reference($t4) -> {LocalRoot(r)}, Reference($t6) -> {Reference($t4)}
-  8: v_ref := $t6
-     // live_nodes: Reference(v_ref)
-     // unchecked_nodes: Reference(v_ref)
+     // borrowed_by: LocalRoot($t0) -> {Reference($t4)}, Reference($t4) -> {Reference($t6)}
+     // borrows_from: Reference($t4) -> {LocalRoot($t0)}, Reference($t6) -> {Reference($t4)}
+  8: $t1 := $t6
+     // live_nodes: Reference($t1)
+     // unchecked_nodes: Reference($t1)
      // spliced_nodes: Reference($t4)
      // moved_nodes: Reference($t6)
-     // borrowed_by: LocalRoot(r) -> {Reference($t4)}, Reference($t4) -> {Reference(v_ref)}
-     // borrows_from: Reference(v_ref) -> {Reference($t4)}, Reference($t4) -> {LocalRoot(r)}
+     // borrowed_by: LocalRoot($t0) -> {Reference($t4)}, Reference($t4) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t4)}, Reference($t4) -> {LocalRoot($t0)}
   9: $t7 := 1
-     // live_nodes: Reference(v_ref)
-     // unchecked_nodes: Reference(v_ref)
+     // live_nodes: Reference($t1)
+     // unchecked_nodes: Reference($t1)
      // spliced_nodes: Reference($t4)
      // moved_nodes: Reference($t6)
-     // borrowed_by: LocalRoot(r) -> {Reference($t4)}, Reference($t4) -> {Reference(v_ref)}
-     // borrows_from: Reference(v_ref) -> {Reference($t4)}, Reference($t4) -> {LocalRoot(r)}
- 10: write_ref(v_ref, $t7)
-     // unchecked_nodes: Reference(v_ref)
+     // borrowed_by: LocalRoot($t0) -> {Reference($t4)}, Reference($t4) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t4)}, Reference($t4) -> {LocalRoot($t0)}
+ 10: write_ref($t1, $t7)
+     // unchecked_nodes: Reference($t1)
      // spliced_nodes: Reference($t4)
      // moved_nodes: Reference($t6)
-     // borrowed_by: LocalRoot(r) -> {Reference($t4)}, Reference($t4) -> {Reference(v_ref)}
-     // borrows_from: Reference(v_ref) -> {Reference($t4)}, Reference($t4) -> {LocalRoot(r)}
- 11: return r
+     // borrowed_by: LocalRoot($t0) -> {Reference($t4)}, Reference($t4) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {Reference($t4)}, Reference($t4) -> {LocalRoot($t0)}
+ 11: return $t0
 }

--- a/language/move-prover/bytecode/tests/clean_and_optimize/pack_unpack.exp
+++ b/language/move-prover/bytecode/tests/clean_and_optimize/pack_unpack.exp
@@ -1,8 +1,8 @@
 ============ initial translation from Move ================
 
 [variant baseline]
-pub fun TestPackUnpack::call_private_violating_invariant(r: &mut TestPackUnpack::R) {
-     var s: &mut TestPackUnpack::S
+pub fun TestPackUnpack::call_private_violating_invariant($t0|r: &mut TestPackUnpack::R) {
+     var $t1|s: &mut TestPackUnpack::S
      var $t2: &mut TestPackUnpack::R
      var $t3: &mut TestPackUnpack::S
      var $t4: &mut TestPackUnpack::S
@@ -10,14 +10,14 @@ pub fun TestPackUnpack::call_private_violating_invariant(r: &mut TestPackUnpack:
      var $t6: u64
      var $t7: &mut TestPackUnpack::S
      var $t8: &mut u64
-  0: $t2 := move(r)
+  0: $t2 := move($t0)
   1: $t3 := borrow_field<TestPackUnpack::R>.nested($t2)
-  2: s := $t3
-  3: $t4 := copy(s)
+  2: $t1 := $t3
+  3: $t4 := copy($t1)
   4: $t5 := 0
   5: TestPackUnpack::private_update_value($t4, $t5)
   6: $t6 := 1
-  7: $t7 := move(s)
+  7: $t7 := move($t1)
   8: $t8 := borrow_field<TestPackUnpack::S>.value($t7)
   9: write_ref($t8, $t6)
  10: return ()
@@ -25,8 +25,8 @@ pub fun TestPackUnpack::call_private_violating_invariant(r: &mut TestPackUnpack:
 
 
 [variant baseline]
-pub fun TestPackUnpack::call_public_violating_invariant_incorrect(r: &mut TestPackUnpack::R) {
-     var s: &mut TestPackUnpack::S
+pub fun TestPackUnpack::call_public_violating_invariant_incorrect($t0|r: &mut TestPackUnpack::R) {
+     var $t1|s: &mut TestPackUnpack::S
      var $t2: &mut TestPackUnpack::R
      var $t3: &mut TestPackUnpack::S
      var $t4: &mut TestPackUnpack::S
@@ -34,14 +34,14 @@ pub fun TestPackUnpack::call_public_violating_invariant_incorrect(r: &mut TestPa
      var $t6: u64
      var $t7: &mut TestPackUnpack::S
      var $t8: &mut u64
-  0: $t2 := move(r)
+  0: $t2 := move($t0)
   1: $t3 := borrow_field<TestPackUnpack::R>.nested($t2)
-  2: s := $t3
-  3: $t4 := copy(s)
+  2: $t1 := $t3
+  3: $t4 := copy($t1)
   4: $t5 := 0
   5: TestPackUnpack::public_update_value($t4, $t5)
   6: $t6 := 1
-  7: $t7 := move(s)
+  7: $t7 := move($t1)
   8: $t8 := borrow_field<TestPackUnpack::S>.value($t7)
   9: write_ref($t8, $t6)
  10: return ()
@@ -61,28 +61,28 @@ pub fun TestPackUnpack::create(): TestPackUnpack::R {
 
 
 [variant baseline]
-pub fun TestPackUnpack::destroy(r: TestPackUnpack::R): u64 {
-     var nested: TestPackUnpack::S
-     var value: u64
+pub fun TestPackUnpack::destroy($t0|r: TestPackUnpack::R): u64 {
+     var $t1|nested: TestPackUnpack::S
+     var $t2|value: u64
      var $t3: TestPackUnpack::R
      var $t4: TestPackUnpack::S
      var $t5: TestPackUnpack::S
      var $t6: u64
      var $t7: u64
-  0: $t3 := move(r)
+  0: $t3 := move($t0)
   1: $t4 := unpack TestPackUnpack::R($t3)
-  2: nested := $t4
-  3: $t5 := move(nested)
+  2: $t1 := $t4
+  3: $t5 := move($t1)
   4: $t6 := unpack TestPackUnpack::S($t5)
-  5: value := $t6
-  6: $t7 := copy(value)
+  5: $t2 := $t6
+  6: $t7 := copy($t2)
   7: return $t7
 }
 
 
 [variant baseline]
-pub fun TestPackUnpack::extract_and_update(r: TestPackUnpack::R): TestPackUnpack::S {
-     var nested: TestPackUnpack::S
+pub fun TestPackUnpack::extract_and_update($t0|r: TestPackUnpack::R): TestPackUnpack::S {
+     var $t1|nested: TestPackUnpack::S
      var $t2: TestPackUnpack::R
      var $t3: TestPackUnpack::S
      var $t4: &TestPackUnpack::S
@@ -93,28 +93,28 @@ pub fun TestPackUnpack::extract_and_update(r: TestPackUnpack::R): TestPackUnpack
      var $t9: &mut TestPackUnpack::S
      var $t10: &mut u64
      var $t11: TestPackUnpack::S
-  0: $t2 := move(r)
+  0: $t2 := move($t0)
   1: $t3 := unpack TestPackUnpack::R($t2)
-  2: nested := $t3
-  3: $t4 := borrow_local(nested)
+  2: $t1 := $t3
+  3: $t4 := borrow_local($t1)
   4: $t5 := borrow_field<TestPackUnpack::S>.value($t4)
   5: $t6 := read_ref($t5)
   6: $t7 := 3
   7: $t8 := +($t6, $t7)
-  8: $t9 := borrow_local(nested)
+  8: $t9 := borrow_local($t1)
   9: $t10 := borrow_field<TestPackUnpack::S>.value($t9)
  10: write_ref($t10, $t8)
- 11: $t11 := move(nested)
+ 11: $t11 := move($t1)
  12: return $t11
 }
 
 
 [variant baseline]
-fun TestPackUnpack::get_value_ref(r: &mut TestPackUnpack::R): &mut u64 {
+fun TestPackUnpack::get_value_ref($t0|r: &mut TestPackUnpack::R): &mut u64 {
      var $t1: &mut TestPackUnpack::R
      var $t2: &mut TestPackUnpack::S
      var $t3: &mut u64
-  0: $t1 := move(r)
+  0: $t1 := move($t0)
   1: $t2 := borrow_field<TestPackUnpack::R>.nested($t1)
   2: $t3 := borrow_field<TestPackUnpack::S>.value($t2)
   3: return $t3
@@ -122,7 +122,7 @@ fun TestPackUnpack::get_value_ref(r: &mut TestPackUnpack::R): &mut u64 {
 
 
 [variant baseline]
-pub fun TestPackUnpack::move_ref_unchanged(r1: &mut TestPackUnpack::R, r2: &mut TestPackUnpack::R) {
+pub fun TestPackUnpack::move_ref_unchanged($t0|r1: &mut TestPackUnpack::R, $t1|r2: &mut TestPackUnpack::R) {
      var $t2: &mut TestPackUnpack::R
      var $t3: &TestPackUnpack::S
      var $t4: &u64
@@ -141,23 +141,23 @@ pub fun TestPackUnpack::move_ref_unchanged(r1: &mut TestPackUnpack::R, r2: &mut 
      var $t17: &mut TestPackUnpack::R
      var $t18: &mut TestPackUnpack::S
      var $t19: &mut u64
-  0: $t2 := copy(r2)
+  0: $t2 := copy($t1)
   1: $t3 := borrow_field<TestPackUnpack::R>.nested($t2)
   2: $t4 := borrow_field<TestPackUnpack::S>.value($t3)
   3: $t5 := read_ref($t4)
-  4: $t6 := copy(r1)
+  4: $t6 := copy($t0)
   5: $t7 := borrow_field<TestPackUnpack::R>.nested($t6)
   6: $t8 := borrow_field<TestPackUnpack::S>.value($t7)
   7: $t9 := read_ref($t8)
   8: $t10 := +($t5, $t9)
   9: $t11 := 1
  10: $t12 := -($t10, $t11)
- 11: $t13 := move(r2)
+ 11: $t13 := move($t1)
  12: $t14 := borrow_field<TestPackUnpack::R>.nested($t13)
  13: $t15 := borrow_field<TestPackUnpack::S>.value($t14)
  14: write_ref($t15, $t12)
  15: $t16 := 1
- 16: $t17 := move(r1)
+ 16: $t17 := move($t0)
  17: $t18 := borrow_field<TestPackUnpack::R>.nested($t17)
  18: $t19 := borrow_field<TestPackUnpack::S>.value($t18)
  19: write_ref($t19, $t16)
@@ -166,7 +166,7 @@ pub fun TestPackUnpack::move_ref_unchanged(r1: &mut TestPackUnpack::R, r2: &mut 
 
 
 [variant baseline]
-pub fun TestPackUnpack::move_ref_unchanged_invariant_incorrect(r1: &mut TestPackUnpack::R, r2: &mut TestPackUnpack::R) {
+pub fun TestPackUnpack::move_ref_unchanged_invariant_incorrect($t0|r1: &mut TestPackUnpack::R, $t1|r2: &mut TestPackUnpack::R) {
      var $t2: &mut TestPackUnpack::R
      var $t3: &TestPackUnpack::S
      var $t4: &u64
@@ -183,21 +183,21 @@ pub fun TestPackUnpack::move_ref_unchanged_invariant_incorrect(r1: &mut TestPack
      var $t15: &mut TestPackUnpack::R
      var $t16: &mut TestPackUnpack::S
      var $t17: &mut u64
-  0: $t2 := copy(r2)
+  0: $t2 := copy($t1)
   1: $t3 := borrow_field<TestPackUnpack::R>.nested($t2)
   2: $t4 := borrow_field<TestPackUnpack::S>.value($t3)
   3: $t5 := read_ref($t4)
-  4: $t6 := copy(r1)
+  4: $t6 := copy($t0)
   5: $t7 := borrow_field<TestPackUnpack::R>.nested($t6)
   6: $t8 := borrow_field<TestPackUnpack::S>.value($t7)
   7: $t9 := read_ref($t8)
   8: $t10 := +($t5, $t9)
-  9: $t11 := move(r2)
+  9: $t11 := move($t1)
  10: $t12 := borrow_field<TestPackUnpack::R>.nested($t11)
  11: $t13 := borrow_field<TestPackUnpack::S>.value($t12)
  12: write_ref($t13, $t10)
  13: $t14 := 0
- 14: $t15 := move(r1)
+ 14: $t15 := move($t0)
  15: $t16 := borrow_field<TestPackUnpack::R>.nested($t15)
  16: $t17 := borrow_field<TestPackUnpack::S>.value($t16)
  17: write_ref($t17, $t14)
@@ -206,11 +206,11 @@ pub fun TestPackUnpack::move_ref_unchanged_invariant_incorrect(r1: &mut TestPack
 
 
 [variant baseline]
-fun TestPackUnpack::private_pass_value_violating_invariant_incorrect(s: &mut TestPackUnpack::S): u64 {
+fun TestPackUnpack::private_pass_value_violating_invariant_incorrect($t0|s: &mut TestPackUnpack::S): u64 {
      var $t1: &mut TestPackUnpack::S
      var $t2: &TestPackUnpack::S
      var $t3: u64
-  0: $t1 := move(s)
+  0: $t1 := move($t0)
   1: $t2 := freeze_ref($t1)
   2: $t3 := TestPackUnpack::read_S_from_immutable($t2)
   3: return $t3
@@ -218,11 +218,11 @@ fun TestPackUnpack::private_pass_value_violating_invariant_incorrect(s: &mut Tes
 
 
 [variant baseline]
-fun TestPackUnpack::private_select_value_violating_invariant_incorrect(r: &mut TestPackUnpack::R): u64 {
+fun TestPackUnpack::private_select_value_violating_invariant_incorrect($t0|r: &mut TestPackUnpack::R): u64 {
      var $t1: &mut TestPackUnpack::R
      var $t2: &TestPackUnpack::S
      var $t3: u64
-  0: $t1 := move(r)
+  0: $t1 := move($t0)
   1: $t2 := borrow_field<TestPackUnpack::R>.nested($t1)
   2: $t3 := TestPackUnpack::read_S_from_immutable($t2)
   3: return $t3
@@ -230,12 +230,12 @@ fun TestPackUnpack::private_select_value_violating_invariant_incorrect(r: &mut T
 
 
 [variant baseline]
-fun TestPackUnpack::private_update_value(s: &mut TestPackUnpack::S, v: u64) {
+fun TestPackUnpack::private_update_value($t0|s: &mut TestPackUnpack::S, $t1|v: u64) {
      var $t2: u64
      var $t3: &mut TestPackUnpack::S
      var $t4: &mut u64
-  0: $t2 := copy(v)
-  1: $t3 := move(s)
+  0: $t2 := copy($t1)
+  1: $t3 := move($t0)
   2: $t4 := borrow_field<TestPackUnpack::S>.value($t3)
   3: write_ref($t4, $t2)
   4: return ()
@@ -243,12 +243,12 @@ fun TestPackUnpack::private_update_value(s: &mut TestPackUnpack::S, v: u64) {
 
 
 [variant baseline]
-pub fun TestPackUnpack::public_update_value(s: &mut TestPackUnpack::S, v: u64) {
+pub fun TestPackUnpack::public_update_value($t0|s: &mut TestPackUnpack::S, $t1|v: u64) {
      var $t2: u64
      var $t3: &mut TestPackUnpack::S
      var $t4: &mut u64
-  0: $t2 := copy(v)
-  1: $t3 := move(s)
+  0: $t2 := copy($t1)
+  1: $t3 := move($t0)
   2: $t4 := borrow_field<TestPackUnpack::S>.value($t3)
   3: write_ref($t4, $t2)
   4: return ()
@@ -256,11 +256,11 @@ pub fun TestPackUnpack::public_update_value(s: &mut TestPackUnpack::S, v: u64) {
 
 
 [variant baseline]
-fun TestPackUnpack::read_S_from_immutable(s: &TestPackUnpack::S): u64 {
+fun TestPackUnpack::read_S_from_immutable($t0|s: &TestPackUnpack::S): u64 {
      var $t1: &TestPackUnpack::S
      var $t2: &u64
      var $t3: u64
-  0: $t1 := move(s)
+  0: $t1 := move($t0)
   1: $t2 := borrow_field<TestPackUnpack::S>.value($t1)
   2: $t3 := read_ref($t2)
   3: return $t3
@@ -268,21 +268,21 @@ fun TestPackUnpack::read_S_from_immutable(s: &TestPackUnpack::S): u64 {
 
 
 [variant baseline]
-pub fun TestPackUnpack::read_ref_unchanged(r: &mut TestPackUnpack::R): u64 {
-     var nested: &mut TestPackUnpack::S
-     var tmp#$2: &mut TestPackUnpack::R
+pub fun TestPackUnpack::read_ref_unchanged($t0|r: &mut TestPackUnpack::R): u64 {
+     var $t1|nested: &mut TestPackUnpack::S
+     var $t2|tmp#$2: &mut TestPackUnpack::R
      var $t3: &mut TestPackUnpack::R
      var $t4: &mut TestPackUnpack::R
      var $t5: &mut TestPackUnpack::S
      var $t6: &mut TestPackUnpack::S
      var $t7: &u64
      var $t8: u64
-  0: $t3 := move(r)
-  1: tmp#$2 := $t3
-  2: $t4 := move(tmp#$2)
+  0: $t3 := move($t0)
+  1: $t2 := $t3
+  2: $t4 := move($t2)
   3: $t5 := borrow_field<TestPackUnpack::R>.nested($t4)
-  4: nested := $t5
-  5: $t6 := move(nested)
+  4: $t1 := $t5
+  5: $t6 := move($t1)
   6: $t7 := borrow_field<TestPackUnpack::S>.value($t6)
   7: $t8 := read_ref($t7)
   8: return $t8
@@ -290,8 +290,8 @@ pub fun TestPackUnpack::read_ref_unchanged(r: &mut TestPackUnpack::R): u64 {
 
 
 [variant baseline]
-pub fun TestPackUnpack::select_value_violating_invariant_incorrect(r: &mut TestPackUnpack::R): u64 {
-     var s: &mut TestPackUnpack::S
+pub fun TestPackUnpack::select_value_violating_invariant_incorrect($t0|r: &mut TestPackUnpack::R): u64 {
+     var $t1|s: &mut TestPackUnpack::S
      var $t2: &mut TestPackUnpack::R
      var $t3: &mut TestPackUnpack::S
      var $t4: u64
@@ -300,14 +300,14 @@ pub fun TestPackUnpack::select_value_violating_invariant_incorrect(r: &mut TestP
      var $t7: &mut TestPackUnpack::S
      var $t8: &TestPackUnpack::S
      var $t9: u64
-  0: $t2 := move(r)
+  0: $t2 := move($t0)
   1: $t3 := borrow_field<TestPackUnpack::R>.nested($t2)
-  2: s := $t3
+  2: $t1 := $t3
   3: $t4 := 0
-  4: $t5 := copy(s)
+  4: $t5 := copy($t1)
   5: $t6 := borrow_field<TestPackUnpack::S>.value($t5)
   6: write_ref($t6, $t4)
-  7: $t7 := move(s)
+  7: $t7 := move($t1)
   8: $t8 := freeze_ref($t7)
   9: $t9 := TestPackUnpack::read_S_from_immutable($t8)
  10: return $t9
@@ -315,9 +315,9 @@ pub fun TestPackUnpack::select_value_violating_invariant_incorrect(r: &mut TestP
 
 
 [variant baseline]
-pub fun TestPackUnpack::update_ref_changed(r: &mut TestPackUnpack::R): u64 {
-     var nested: &mut TestPackUnpack::S
-     var tmp#$2: &mut TestPackUnpack::R
+pub fun TestPackUnpack::update_ref_changed($t0|r: &mut TestPackUnpack::R): u64 {
+     var $t1|nested: &mut TestPackUnpack::S
+     var $t2|tmp#$2: &mut TestPackUnpack::R
      var $t3: &mut TestPackUnpack::R
      var $t4: &mut TestPackUnpack::R
      var $t5: &mut TestPackUnpack::S
@@ -331,20 +331,20 @@ pub fun TestPackUnpack::update_ref_changed(r: &mut TestPackUnpack::R): u64 {
      var $t13: &mut TestPackUnpack::S
      var $t14: &u64
      var $t15: u64
-  0: $t3 := move(r)
-  1: tmp#$2 := $t3
-  2: $t4 := move(tmp#$2)
+  0: $t3 := move($t0)
+  1: $t2 := $t3
+  2: $t4 := move($t2)
   3: $t5 := borrow_field<TestPackUnpack::R>.nested($t4)
-  4: nested := $t5
-  5: $t6 := copy(nested)
+  4: $t1 := $t5
+  5: $t6 := copy($t1)
   6: $t7 := borrow_field<TestPackUnpack::S>.value($t6)
   7: $t8 := read_ref($t7)
   8: $t9 := 2
   9: $t10 := +($t8, $t9)
- 10: $t11 := copy(nested)
+ 10: $t11 := copy($t1)
  11: $t12 := borrow_field<TestPackUnpack::S>.value($t11)
  12: write_ref($t12, $t10)
- 13: $t13 := move(nested)
+ 13: $t13 := move($t1)
  14: $t14 := borrow_field<TestPackUnpack::S>.value($t13)
  15: $t15 := read_ref($t14)
  16: return $t15
@@ -353,8 +353,8 @@ pub fun TestPackUnpack::update_ref_changed(r: &mut TestPackUnpack::R): u64 {
 
 [variant baseline]
 pub fun TestPackUnpack::update_via_returned_ref(): TestPackUnpack::R {
-     var r: TestPackUnpack::R
-     var v_ref: &mut u64
+     var $t0|r: TestPackUnpack::R
+     var $t1|v_ref: &mut u64
      var $t2: u64
      var $t3: TestPackUnpack::S
      var $t4: TestPackUnpack::R
@@ -366,22 +366,22 @@ pub fun TestPackUnpack::update_via_returned_ref(): TestPackUnpack::R {
   0: $t2 := 1
   1: $t3 := pack TestPackUnpack::S($t2)
   2: $t4 := pack TestPackUnpack::R($t3)
-  3: r := $t4
-  4: $t5 := borrow_local(r)
+  3: $t0 := $t4
+  4: $t5 := borrow_local($t0)
   5: $t6 := TestPackUnpack::get_value_ref($t5)
-  6: v_ref := $t6
+  6: $t1 := $t6
   7: $t7 := 2
-  8: $t8 := move(v_ref)
+  8: $t8 := move($t1)
   9: write_ref($t8, $t7)
- 10: $t9 := move(r)
+ 10: $t9 := move($t0)
  11: return $t9
 }
 
 
 [variant baseline]
 pub fun TestPackUnpack::update_via_returned_ref_invariant_incorrect(): TestPackUnpack::R {
-     var r: TestPackUnpack::R
-     var v_ref: &mut u64
+     var $t0|r: TestPackUnpack::R
+     var $t1|v_ref: &mut u64
      var $t2: u64
      var $t3: TestPackUnpack::S
      var $t4: TestPackUnpack::R
@@ -393,22 +393,22 @@ pub fun TestPackUnpack::update_via_returned_ref_invariant_incorrect(): TestPackU
   0: $t2 := 1
   1: $t3 := pack TestPackUnpack::S($t2)
   2: $t4 := pack TestPackUnpack::R($t3)
-  3: r := $t4
-  4: $t5 := borrow_local(r)
+  3: $t0 := $t4
+  4: $t5 := borrow_local($t0)
   5: $t6 := TestPackUnpack::get_value_ref($t5)
-  6: v_ref := $t6
+  6: $t1 := $t6
   7: $t7 := 0
-  8: $t8 := move(v_ref)
+  8: $t8 := move($t1)
   9: write_ref($t8, $t7)
- 10: $t9 := move(r)
+ 10: $t9 := move($t0)
  11: return $t9
 }
 
 
 [variant baseline]
 pub fun TestPackUnpack::update_via_returned_ref_var_incorrect(): TestPackUnpack::R {
-     var r: TestPackUnpack::R
-     var v_ref: &mut u64
+     var $t0|r: TestPackUnpack::R
+     var $t1|v_ref: &mut u64
      var $t2: u64
      var $t3: TestPackUnpack::S
      var $t4: TestPackUnpack::R
@@ -420,45 +420,45 @@ pub fun TestPackUnpack::update_via_returned_ref_var_incorrect(): TestPackUnpack:
   0: $t2 := 1
   1: $t3 := pack TestPackUnpack::S($t2)
   2: $t4 := pack TestPackUnpack::R($t3)
-  3: r := $t4
-  4: $t5 := borrow_local(r)
+  3: $t0 := $t4
+  4: $t5 := borrow_local($t0)
   5: $t6 := TestPackUnpack::get_value_ref($t5)
-  6: v_ref := $t6
+  6: $t1 := $t6
   7: $t7 := 1
-  8: $t8 := move(v_ref)
+  8: $t8 := move($t1)
   9: write_ref($t8, $t7)
- 10: $t9 := move(r)
+ 10: $t9 := move($t0)
  11: return $t9
 }
 
 ============ after pipeline `clean_and_optimize` ================
 
 [variant baseline]
-pub fun TestPackUnpack::call_private_violating_invariant(r: TestPackUnpack::R): TestPackUnpack::R {
-     var s: &mut TestPackUnpack::S
+pub fun TestPackUnpack::call_private_violating_invariant($t0|r: TestPackUnpack::R): TestPackUnpack::R {
+     var $t1|s: &mut TestPackUnpack::S
      var $t2: TestPackUnpack::R
      var $t3: &mut TestPackUnpack::R
      var $t4: u64
      var $t5: TestPackUnpack::S
      var $t6: u64
      var $t7: &mut u64
-  0: $t2 := move(r)
+  0: $t2 := move($t0)
   1: $t3 := borrow_local($t2)
   2: unpack_ref($t3)
-  3: s := borrow_field<TestPackUnpack::R>.nested($t3)
-  4: unpack_ref(s)
+  3: $t1 := borrow_field<TestPackUnpack::R>.nested($t3)
+  4: unpack_ref($t1)
   5: $t4 := 0
-  6: $t5 := read_ref(s)
+  6: $t5 := read_ref($t1)
   7: $t5 := TestPackUnpack::private_update_value($t5, $t4)
-  8: write_ref(s, $t5)
+  8: write_ref($t1, $t5)
   9: $t6 := 1
- 10: $t7 := borrow_field<TestPackUnpack::S>.value(s)
+ 10: $t7 := borrow_field<TestPackUnpack::S>.value($t1)
  11: unpack_ref($t7)
  12: write_ref($t7, $t6)
  13: pack_ref($t7)
- 14: write_back[Reference(s)]($t7)
- 15: pack_ref(s)
- 16: write_back[Reference($t3)](s)
+ 14: write_back[Reference($t1)]($t7)
+ 15: pack_ref($t1)
+ 16: write_back[Reference($t3)]($t1)
  17: pack_ref($t3)
  18: write_back[LocalRoot($t2)]($t3)
  19: return $t2
@@ -466,31 +466,31 @@ pub fun TestPackUnpack::call_private_violating_invariant(r: TestPackUnpack::R): 
 
 
 [variant baseline]
-pub fun TestPackUnpack::call_public_violating_invariant_incorrect(r: TestPackUnpack::R): TestPackUnpack::R {
-     var s: &mut TestPackUnpack::S
+pub fun TestPackUnpack::call_public_violating_invariant_incorrect($t0|r: TestPackUnpack::R): TestPackUnpack::R {
+     var $t1|s: &mut TestPackUnpack::S
      var $t2: TestPackUnpack::R
      var $t3: &mut TestPackUnpack::R
      var $t4: u64
      var $t5: TestPackUnpack::S
      var $t6: u64
      var $t7: &mut u64
-  0: $t2 := move(r)
+  0: $t2 := move($t0)
   1: $t3 := borrow_local($t2)
   2: unpack_ref($t3)
-  3: s := borrow_field<TestPackUnpack::R>.nested($t3)
-  4: unpack_ref(s)
+  3: $t1 := borrow_field<TestPackUnpack::R>.nested($t3)
+  4: unpack_ref($t1)
   5: $t4 := 0
-  6: $t5 := read_ref(s)
+  6: $t5 := read_ref($t1)
   7: $t5 := TestPackUnpack::public_update_value($t5, $t4)
-  8: write_ref(s, $t5)
+  8: write_ref($t1, $t5)
   9: $t6 := 1
- 10: $t7 := borrow_field<TestPackUnpack::S>.value(s)
+ 10: $t7 := borrow_field<TestPackUnpack::S>.value($t1)
  11: unpack_ref($t7)
  12: write_ref($t7, $t6)
  13: pack_ref($t7)
- 14: write_back[Reference(s)]($t7)
- 15: pack_ref(s)
- 16: write_back[Reference($t3)](s)
+ 14: write_back[Reference($t1)]($t7)
+ 15: pack_ref($t1)
+ 16: write_back[Reference($t3)]($t1)
  17: pack_ref($t3)
  18: write_back[LocalRoot($t2)]($t3)
  19: return $t2
@@ -510,32 +510,32 @@ pub fun TestPackUnpack::create(): TestPackUnpack::R {
 
 
 [variant baseline]
-pub fun TestPackUnpack::destroy(r: TestPackUnpack::R): u64 {
-     var nested: TestPackUnpack::S
-     var value: u64
+pub fun TestPackUnpack::destroy($t0|r: TestPackUnpack::R): u64 {
+     var $t1|nested: TestPackUnpack::S
+     var $t2|value: u64
      var $t3: TestPackUnpack::R
-  0: $t3 := move(r)
-  1: nested := unpack TestPackUnpack::R($t3)
-  2: value := unpack TestPackUnpack::S(nested)
-  3: return value
+  0: $t3 := move($t0)
+  1: $t1 := unpack TestPackUnpack::R($t3)
+  2: $t2 := unpack TestPackUnpack::S($t1)
+  3: return $t2
 }
 
 
 [variant baseline]
-pub fun TestPackUnpack::extract_and_update(r: TestPackUnpack::R): TestPackUnpack::S {
-     var nested: TestPackUnpack::S
+pub fun TestPackUnpack::extract_and_update($t0|r: TestPackUnpack::R): TestPackUnpack::S {
+     var $t1|nested: TestPackUnpack::S
      var $t2: TestPackUnpack::R
      var $t3: u64
      var $t4: u64
      var $t5: u64
      var $t6: &mut TestPackUnpack::S
      var $t7: &mut u64
-  0: $t2 := move(r)
-  1: nested := unpack TestPackUnpack::R($t2)
-  2: $t3 := get_field<TestPackUnpack::S>.value(nested)
+  0: $t2 := move($t0)
+  1: $t1 := unpack TestPackUnpack::R($t2)
+  2: $t3 := get_field<TestPackUnpack::S>.value($t1)
   3: $t4 := 3
   4: $t5 := +($t3, $t4)
-  5: $t6 := borrow_local(nested)
+  5: $t6 := borrow_local($t1)
   6: unpack_ref($t6)
   7: $t7 := borrow_field<TestPackUnpack::S>.value($t6)
   8: unpack_ref($t7)
@@ -543,18 +543,18 @@ pub fun TestPackUnpack::extract_and_update(r: TestPackUnpack::R): TestPackUnpack
  10: pack_ref($t7)
  11: write_back[Reference($t6)]($t7)
  12: pack_ref($t6)
- 13: write_back[LocalRoot(nested)]($t6)
- 14: return nested
+ 13: write_back[LocalRoot($t1)]($t6)
+ 14: return $t1
 }
 
 
 [variant baseline]
-fun TestPackUnpack::get_value_ref(r: TestPackUnpack::R): (&mut u64, TestPackUnpack::R) {
+fun TestPackUnpack::get_value_ref($t0|r: TestPackUnpack::R): (&mut u64, TestPackUnpack::R) {
      var $t1: TestPackUnpack::R
      var $t2: &mut TestPackUnpack::R
      var $t3: &mut TestPackUnpack::S
      var $t4: &mut u64
-  0: $t1 := move(r)
+  0: $t1 := move($t0)
   1: $t2 := borrow_local($t1)
   2: $t3 := borrow_field<TestPackUnpack::R>.nested($t2)
   3: $t4 := borrow_field<TestPackUnpack::S>.value($t3)
@@ -563,7 +563,7 @@ fun TestPackUnpack::get_value_ref(r: TestPackUnpack::R): (&mut u64, TestPackUnpa
 
 
 [variant baseline]
-pub fun TestPackUnpack::move_ref_unchanged(r1: TestPackUnpack::R, r2: TestPackUnpack::R): (TestPackUnpack::R, TestPackUnpack::R) {
+pub fun TestPackUnpack::move_ref_unchanged($t0|r1: TestPackUnpack::R, $t1|r2: TestPackUnpack::R): (TestPackUnpack::R, TestPackUnpack::R) {
      var $t2: TestPackUnpack::R
      var $t3: TestPackUnpack::R
      var $t4: &mut TestPackUnpack::R
@@ -580,8 +580,8 @@ pub fun TestPackUnpack::move_ref_unchanged(r1: TestPackUnpack::R, r2: TestPackUn
      var $t15: u64
      var $t16: &mut TestPackUnpack::S
      var $t17: &mut u64
-  0: $t2 := move(r1)
-  1: $t3 := move(r2)
+  0: $t2 := move($t0)
+  1: $t3 := move($t1)
   2: $t4 := borrow_local($t2)
   3: unpack_ref($t4)
   4: $t5 := borrow_local($t3)
@@ -621,7 +621,7 @@ pub fun TestPackUnpack::move_ref_unchanged(r1: TestPackUnpack::R, r2: TestPackUn
 
 
 [variant baseline]
-pub fun TestPackUnpack::move_ref_unchanged_invariant_incorrect(r1: TestPackUnpack::R, r2: TestPackUnpack::R): (TestPackUnpack::R, TestPackUnpack::R) {
+pub fun TestPackUnpack::move_ref_unchanged_invariant_incorrect($t0|r1: TestPackUnpack::R, $t1|r2: TestPackUnpack::R): (TestPackUnpack::R, TestPackUnpack::R) {
      var $t2: TestPackUnpack::R
      var $t3: TestPackUnpack::R
      var $t4: &mut TestPackUnpack::R
@@ -636,8 +636,8 @@ pub fun TestPackUnpack::move_ref_unchanged_invariant_incorrect(r1: TestPackUnpac
      var $t13: u64
      var $t14: &mut TestPackUnpack::S
      var $t15: &mut u64
-  0: $t2 := move(r1)
-  1: $t3 := move(r2)
+  0: $t2 := move($t0)
+  1: $t3 := move($t1)
   2: $t4 := borrow_local($t2)
   3: unpack_ref($t4)
   4: $t5 := borrow_local($t3)
@@ -675,12 +675,12 @@ pub fun TestPackUnpack::move_ref_unchanged_invariant_incorrect(r1: TestPackUnpac
 
 
 [variant baseline]
-fun TestPackUnpack::private_pass_value_violating_invariant_incorrect(s: TestPackUnpack::S): (u64, TestPackUnpack::S) {
+fun TestPackUnpack::private_pass_value_violating_invariant_incorrect($t0|s: TestPackUnpack::S): (u64, TestPackUnpack::S) {
      var $t1: TestPackUnpack::S
      var $t2: &mut TestPackUnpack::S
      var $t3: TestPackUnpack::S
      var $t4: u64
-  0: $t1 := move(s)
+  0: $t1 := move($t0)
   1: $t2 := borrow_local($t1)
   2: $t3 := read_ref($t2)
   3: $t4 := TestPackUnpack::read_S_from_immutable($t3)
@@ -689,12 +689,12 @@ fun TestPackUnpack::private_pass_value_violating_invariant_incorrect(s: TestPack
 
 
 [variant baseline]
-fun TestPackUnpack::private_select_value_violating_invariant_incorrect(r: TestPackUnpack::R): (u64, TestPackUnpack::R) {
+fun TestPackUnpack::private_select_value_violating_invariant_incorrect($t0|r: TestPackUnpack::R): (u64, TestPackUnpack::R) {
      var $t1: TestPackUnpack::R
      var $t2: &mut TestPackUnpack::R
      var $t3: TestPackUnpack::S
      var $t4: u64
-  0: $t1 := move(r)
+  0: $t1 := move($t0)
   1: $t2 := borrow_local($t1)
   2: $t3 := get_field<TestPackUnpack::R>.nested($t2)
   3: $t4 := TestPackUnpack::read_S_from_immutable($t3)
@@ -703,13 +703,13 @@ fun TestPackUnpack::private_select_value_violating_invariant_incorrect(r: TestPa
 
 
 [variant baseline]
-fun TestPackUnpack::private_update_value(s: TestPackUnpack::S, v: u64): TestPackUnpack::S {
+fun TestPackUnpack::private_update_value($t0|s: TestPackUnpack::S, $t1|v: u64): TestPackUnpack::S {
      var $t2: TestPackUnpack::S
      var $t3: u64
      var $t4: &mut TestPackUnpack::S
      var $t5: &mut u64
-  0: $t2 := move(s)
-  1: $t3 := move(v)
+  0: $t2 := move($t0)
+  1: $t3 := move($t1)
   2: $t4 := borrow_local($t2)
   3: $t5 := borrow_field<TestPackUnpack::S>.value($t4)
   4: write_ref($t5, $t3)
@@ -720,13 +720,13 @@ fun TestPackUnpack::private_update_value(s: TestPackUnpack::S, v: u64): TestPack
 
 
 [variant baseline]
-pub fun TestPackUnpack::public_update_value(s: TestPackUnpack::S, v: u64): TestPackUnpack::S {
+pub fun TestPackUnpack::public_update_value($t0|s: TestPackUnpack::S, $t1|v: u64): TestPackUnpack::S {
      var $t2: TestPackUnpack::S
      var $t3: u64
      var $t4: &mut TestPackUnpack::S
      var $t5: &mut u64
-  0: $t2 := move(s)
-  1: $t3 := move(v)
+  0: $t2 := move($t0)
+  1: $t3 := move($t1)
   2: $t4 := borrow_local($t2)
   3: unpack_ref($t4)
   4: $t5 := borrow_field<TestPackUnpack::S>.value($t4)
@@ -741,57 +741,57 @@ pub fun TestPackUnpack::public_update_value(s: TestPackUnpack::S, v: u64): TestP
 
 
 [variant baseline]
-fun TestPackUnpack::read_S_from_immutable(s: TestPackUnpack::S): u64 {
+fun TestPackUnpack::read_S_from_immutable($t0|s: TestPackUnpack::S): u64 {
      var $t1: TestPackUnpack::S
      var $t2: u64
-  0: $t1 := move(s)
+  0: $t1 := move($t0)
   1: $t2 := get_field<TestPackUnpack::S>.value($t1)
   2: return $t2
 }
 
 
 [variant baseline]
-pub fun TestPackUnpack::read_ref_unchanged(r: TestPackUnpack::R): (u64, TestPackUnpack::R) {
-     var nested: &mut TestPackUnpack::S
-     var tmp#$2: &mut TestPackUnpack::R
+pub fun TestPackUnpack::read_ref_unchanged($t0|r: TestPackUnpack::R): (u64, TestPackUnpack::R) {
+     var $t1|nested: &mut TestPackUnpack::S
+     var $t2|tmp#$2: &mut TestPackUnpack::R
      var $t3: TestPackUnpack::R
      var $t4: &mut TestPackUnpack::R
      var $t5: u64
-  0: $t3 := move(r)
+  0: $t3 := move($t0)
   1: $t4 := borrow_local($t3)
   2: unpack_ref($t4)
-  3: nested := borrow_field<TestPackUnpack::R>.nested($t4)
-  4: unpack_ref(nested)
-  5: $t5 := get_field<TestPackUnpack::S>.value(nested)
-  6: pack_ref(nested)
+  3: $t1 := borrow_field<TestPackUnpack::R>.nested($t4)
+  4: unpack_ref($t1)
+  5: $t5 := get_field<TestPackUnpack::S>.value($t1)
+  6: pack_ref($t1)
   7: pack_ref($t4)
   8: return ($t5, $t3)
 }
 
 
 [variant baseline]
-pub fun TestPackUnpack::select_value_violating_invariant_incorrect(r: TestPackUnpack::R): (u64, TestPackUnpack::R) {
-     var s: &mut TestPackUnpack::S
+pub fun TestPackUnpack::select_value_violating_invariant_incorrect($t0|r: TestPackUnpack::R): (u64, TestPackUnpack::R) {
+     var $t1|s: &mut TestPackUnpack::S
      var $t2: TestPackUnpack::R
      var $t3: &mut TestPackUnpack::R
      var $t4: u64
      var $t5: &mut u64
      var $t6: TestPackUnpack::S
      var $t7: u64
-  0: $t2 := move(r)
+  0: $t2 := move($t0)
   1: $t3 := borrow_local($t2)
   2: unpack_ref($t3)
-  3: s := borrow_field<TestPackUnpack::R>.nested($t3)
-  4: unpack_ref(s)
+  3: $t1 := borrow_field<TestPackUnpack::R>.nested($t3)
+  4: unpack_ref($t1)
   5: $t4 := 0
-  6: $t5 := borrow_field<TestPackUnpack::S>.value(s)
+  6: $t5 := borrow_field<TestPackUnpack::S>.value($t1)
   7: unpack_ref($t5)
   8: write_ref($t5, $t4)
   9: pack_ref($t5)
- 10: write_back[Reference(s)]($t5)
- 11: $t6 := read_ref(s)
- 12: pack_ref(s)
- 13: write_back[Reference($t3)](s)
+ 10: write_back[Reference($t1)]($t5)
+ 11: $t6 := read_ref($t1)
+ 12: pack_ref($t1)
+ 13: write_back[Reference($t3)]($t1)
  14: pack_ref($t3)
  15: write_back[LocalRoot($t2)]($t3)
  16: $t7 := TestPackUnpack::read_S_from_immutable($t6)
@@ -800,9 +800,9 @@ pub fun TestPackUnpack::select_value_violating_invariant_incorrect(r: TestPackUn
 
 
 [variant baseline]
-pub fun TestPackUnpack::update_ref_changed(r: TestPackUnpack::R): (u64, TestPackUnpack::R) {
-     var nested: &mut TestPackUnpack::S
-     var tmp#$2: &mut TestPackUnpack::R
+pub fun TestPackUnpack::update_ref_changed($t0|r: TestPackUnpack::R): (u64, TestPackUnpack::R) {
+     var $t1|nested: &mut TestPackUnpack::S
+     var $t2|tmp#$2: &mut TestPackUnpack::R
      var $t3: TestPackUnpack::R
      var $t4: &mut TestPackUnpack::R
      var $t5: u64
@@ -810,22 +810,22 @@ pub fun TestPackUnpack::update_ref_changed(r: TestPackUnpack::R): (u64, TestPack
      var $t7: u64
      var $t8: &mut u64
      var $t9: u64
-  0: $t3 := move(r)
+  0: $t3 := move($t0)
   1: $t4 := borrow_local($t3)
   2: unpack_ref($t4)
-  3: nested := borrow_field<TestPackUnpack::R>.nested($t4)
-  4: unpack_ref(nested)
-  5: $t5 := get_field<TestPackUnpack::S>.value(nested)
+  3: $t1 := borrow_field<TestPackUnpack::R>.nested($t4)
+  4: unpack_ref($t1)
+  5: $t5 := get_field<TestPackUnpack::S>.value($t1)
   6: $t6 := 2
   7: $t7 := +($t5, $t6)
-  8: $t8 := borrow_field<TestPackUnpack::S>.value(nested)
+  8: $t8 := borrow_field<TestPackUnpack::S>.value($t1)
   9: unpack_ref($t8)
  10: write_ref($t8, $t7)
  11: pack_ref($t8)
- 12: write_back[Reference(nested)]($t8)
- 13: $t9 := get_field<TestPackUnpack::S>.value(nested)
- 14: pack_ref(nested)
- 15: write_back[Reference($t4)](nested)
+ 12: write_back[Reference($t1)]($t8)
+ 13: $t9 := get_field<TestPackUnpack::S>.value($t1)
+ 14: pack_ref($t1)
+ 15: write_back[Reference($t4)]($t1)
  16: pack_ref($t4)
  17: write_back[LocalRoot($t3)]($t4)
  18: return ($t9, $t3)
@@ -834,8 +834,8 @@ pub fun TestPackUnpack::update_ref_changed(r: TestPackUnpack::R): (u64, TestPack
 
 [variant baseline]
 pub fun TestPackUnpack::update_via_returned_ref(): TestPackUnpack::R {
-     var r: TestPackUnpack::R
-     var v_ref: &mut u64
+     var $t0|r: TestPackUnpack::R
+     var $t1|v_ref: &mut u64
      var $t2: u64
      var $t3: TestPackUnpack::S
      var $t4: &mut TestPackUnpack::R
@@ -844,27 +844,27 @@ pub fun TestPackUnpack::update_via_returned_ref(): TestPackUnpack::R {
      var $t7: u64
   0: $t2 := 1
   1: $t3 := pack TestPackUnpack::S($t2)
-  2: r := pack TestPackUnpack::R($t3)
-  3: $t4 := borrow_local(r)
+  2: $t0 := pack TestPackUnpack::R($t3)
+  3: $t4 := borrow_local($t0)
   4: unpack_ref_deep($t4)
   5: $t5 := read_ref($t4)
   6: ($t6, $t5) := TestPackUnpack::get_value_ref($t5)
   7: write_ref($t4, $t5)
   8: splice[0 -> $t4]($t6)
-  9: v_ref := $t6
+  9: $t1 := $t6
  10: $t7 := 2
- 11: write_ref(v_ref, $t7)
- 12: write_back[Reference($t4)](v_ref)
+ 11: write_ref($t1, $t7)
+ 12: write_back[Reference($t4)]($t1)
  13: pack_ref_deep($t4)
- 14: write_back[LocalRoot(r)]($t4)
- 15: return r
+ 14: write_back[LocalRoot($t0)]($t4)
+ 15: return $t0
 }
 
 
 [variant baseline]
 pub fun TestPackUnpack::update_via_returned_ref_invariant_incorrect(): TestPackUnpack::R {
-     var r: TestPackUnpack::R
-     var v_ref: &mut u64
+     var $t0|r: TestPackUnpack::R
+     var $t1|v_ref: &mut u64
      var $t2: u64
      var $t3: TestPackUnpack::S
      var $t4: &mut TestPackUnpack::R
@@ -873,27 +873,27 @@ pub fun TestPackUnpack::update_via_returned_ref_invariant_incorrect(): TestPackU
      var $t7: u64
   0: $t2 := 1
   1: $t3 := pack TestPackUnpack::S($t2)
-  2: r := pack TestPackUnpack::R($t3)
-  3: $t4 := borrow_local(r)
+  2: $t0 := pack TestPackUnpack::R($t3)
+  3: $t4 := borrow_local($t0)
   4: unpack_ref_deep($t4)
   5: $t5 := read_ref($t4)
   6: ($t6, $t5) := TestPackUnpack::get_value_ref($t5)
   7: write_ref($t4, $t5)
   8: splice[0 -> $t4]($t6)
-  9: v_ref := $t6
+  9: $t1 := $t6
  10: $t7 := 0
- 11: write_ref(v_ref, $t7)
- 12: write_back[Reference($t4)](v_ref)
+ 11: write_ref($t1, $t7)
+ 12: write_back[Reference($t4)]($t1)
  13: pack_ref_deep($t4)
- 14: write_back[LocalRoot(r)]($t4)
- 15: return r
+ 14: write_back[LocalRoot($t0)]($t4)
+ 15: return $t0
 }
 
 
 [variant baseline]
 pub fun TestPackUnpack::update_via_returned_ref_var_incorrect(): TestPackUnpack::R {
-     var r: TestPackUnpack::R
-     var v_ref: &mut u64
+     var $t0|r: TestPackUnpack::R
+     var $t1|v_ref: &mut u64
      var $t2: u64
      var $t3: TestPackUnpack::S
      var $t4: &mut TestPackUnpack::R
@@ -902,18 +902,18 @@ pub fun TestPackUnpack::update_via_returned_ref_var_incorrect(): TestPackUnpack:
      var $t7: u64
   0: $t2 := 1
   1: $t3 := pack TestPackUnpack::S($t2)
-  2: r := pack TestPackUnpack::R($t3)
-  3: $t4 := borrow_local(r)
+  2: $t0 := pack TestPackUnpack::R($t3)
+  3: $t4 := borrow_local($t0)
   4: unpack_ref_deep($t4)
   5: $t5 := read_ref($t4)
   6: ($t6, $t5) := TestPackUnpack::get_value_ref($t5)
   7: write_ref($t4, $t5)
   8: splice[0 -> $t4]($t6)
-  9: v_ref := $t6
+  9: $t1 := $t6
  10: $t7 := 1
- 11: write_ref(v_ref, $t7)
- 12: write_back[Reference($t4)](v_ref)
+ 11: write_ref($t1, $t7)
+ 12: write_back[Reference($t4)]($t1)
  13: pack_ref_deep($t4)
- 14: write_back[LocalRoot(r)]($t4)
- 15: return r
+ 14: write_back[LocalRoot($t0)]($t4)
+ 15: return $t0
 }

--- a/language/move-prover/bytecode/tests/eliminate_imm_refs/basic_test.exp
+++ b/language/move-prover/bytecode/tests/eliminate_imm_refs/basic_test.exp
@@ -2,9 +2,9 @@
 
 [variant baseline]
 fun TestEliminateImmRefs::test1(): TestEliminateImmRefs::R {
-     var r: TestEliminateImmRefs::R
-     var r_ref: &mut TestEliminateImmRefs::R
-     var x_ref: &mut u64
+     var $t0|r: TestEliminateImmRefs::R
+     var $t1|r_ref: &mut TestEliminateImmRefs::R
+     var $t2|x_ref: &mut u64
      var $t3: u64
      var $t4: TestEliminateImmRefs::R
      var $t5: &mut TestEliminateImmRefs::R
@@ -15,25 +15,25 @@ fun TestEliminateImmRefs::test1(): TestEliminateImmRefs::R {
      var $t10: TestEliminateImmRefs::R
   0: $t3 := 3
   1: $t4 := pack TestEliminateImmRefs::R($t3)
-  2: r := $t4
-  3: $t5 := borrow_local(r)
-  4: r_ref := $t5
-  5: $t6 := move(r_ref)
+  2: $t0 := $t4
+  3: $t5 := borrow_local($t0)
+  4: $t1 := $t5
+  5: $t6 := move($t1)
   6: $t7 := borrow_field<TestEliminateImmRefs::R>.x($t6)
-  7: x_ref := $t7
+  7: $t2 := $t7
   8: $t8 := 0
-  9: $t9 := move(x_ref)
+  9: $t9 := move($t2)
  10: write_ref($t9, $t8)
- 11: $t10 := move(r)
+ 11: $t10 := move($t0)
  12: return $t10
 }
 
 
 [variant baseline]
 fun TestEliminateImmRefs::test2(): u64 {
-     var r: TestEliminateImmRefs::R
-     var r_ref: &TestEliminateImmRefs::R
-     var x_ref: &u64
+     var $t0|r: TestEliminateImmRefs::R
+     var $t1|r_ref: &TestEliminateImmRefs::R
+     var $t2|x_ref: &u64
      var $t3: u64
      var $t4: TestEliminateImmRefs::R
      var $t5: &TestEliminateImmRefs::R
@@ -43,29 +43,29 @@ fun TestEliminateImmRefs::test2(): u64 {
      var $t9: u64
   0: $t3 := 3
   1: $t4 := pack TestEliminateImmRefs::R($t3)
-  2: r := $t4
-  3: $t5 := borrow_local(r)
-  4: r_ref := $t5
-  5: $t6 := move(r_ref)
+  2: $t0 := $t4
+  3: $t5 := borrow_local($t0)
+  4: $t1 := $t5
+  5: $t6 := move($t1)
   6: $t7 := borrow_field<TestEliminateImmRefs::R>.x($t6)
-  7: x_ref := $t7
-  8: $t8 := move(x_ref)
+  7: $t2 := $t7
+  8: $t8 := move($t2)
   9: $t9 := read_ref($t8)
  10: return $t9
 }
 
 
 [variant baseline]
-fun TestEliminateImmRefs::test3(r_ref: &TestEliminateImmRefs::R): u64 {
-     var x_ref: &u64
+fun TestEliminateImmRefs::test3($t0|r_ref: &TestEliminateImmRefs::R): u64 {
+     var $t1|x_ref: &u64
      var $t2: &TestEliminateImmRefs::R
      var $t3: &u64
      var $t4: &u64
      var $t5: u64
-  0: $t2 := move(r_ref)
+  0: $t2 := move($t0)
   1: $t3 := borrow_field<TestEliminateImmRefs::R>.x($t2)
-  2: x_ref := $t3
-  3: $t4 := move(x_ref)
+  2: $t1 := $t3
+  3: $t4 := move($t1)
   4: $t5 := read_ref($t4)
   5: return $t5
 }
@@ -73,8 +73,8 @@ fun TestEliminateImmRefs::test3(r_ref: &TestEliminateImmRefs::R): u64 {
 
 [variant baseline]
 fun TestEliminateImmRefs::test4(): u64 {
-     var r: TestEliminateImmRefs::R
-     var r_ref: &TestEliminateImmRefs::R
+     var $t0|r: TestEliminateImmRefs::R
+     var $t1|r_ref: &TestEliminateImmRefs::R
      var $t2: u64
      var $t3: TestEliminateImmRefs::R
      var $t4: &TestEliminateImmRefs::R
@@ -82,10 +82,10 @@ fun TestEliminateImmRefs::test4(): u64 {
      var $t6: u64
   0: $t2 := 3
   1: $t3 := pack TestEliminateImmRefs::R($t2)
-  2: r := $t3
-  3: $t4 := borrow_local(r)
-  4: r_ref := $t4
-  5: $t5 := move(r_ref)
+  2: $t0 := $t3
+  3: $t4 := borrow_local($t0)
+  4: $t1 := $t4
+  5: $t5 := move($t1)
   6: $t6 := TestEliminateImmRefs::test3($t5)
   7: return $t6
 }
@@ -94,9 +94,9 @@ fun TestEliminateImmRefs::test4(): u64 {
 
 [variant baseline]
 fun TestEliminateImmRefs::test1(): TestEliminateImmRefs::R {
-     var r: TestEliminateImmRefs::R
-     var r_ref: &mut TestEliminateImmRefs::R
-     var x_ref: &mut u64
+     var $t0|r: TestEliminateImmRefs::R
+     var $t1|r_ref: &mut TestEliminateImmRefs::R
+     var $t2|x_ref: &mut u64
      var $t3: u64
      var $t4: TestEliminateImmRefs::R
      var $t5: &mut TestEliminateImmRefs::R
@@ -107,25 +107,25 @@ fun TestEliminateImmRefs::test1(): TestEliminateImmRefs::R {
      var $t10: TestEliminateImmRefs::R
   0: $t3 := 3
   1: $t4 := pack TestEliminateImmRefs::R($t3)
-  2: r := $t4
-  3: $t5 := borrow_local(r)
-  4: r_ref := $t5
-  5: $t6 := move(r_ref)
+  2: $t0 := $t4
+  3: $t5 := borrow_local($t0)
+  4: $t1 := $t5
+  5: $t6 := move($t1)
   6: $t7 := borrow_field<TestEliminateImmRefs::R>.x($t6)
-  7: x_ref := $t7
+  7: $t2 := $t7
   8: $t8 := 0
-  9: $t9 := move(x_ref)
+  9: $t9 := move($t2)
  10: write_ref($t9, $t8)
- 11: $t10 := move(r)
+ 11: $t10 := move($t0)
  12: return $t10
 }
 
 
 [variant baseline]
 fun TestEliminateImmRefs::test2(): u64 {
-     var r: TestEliminateImmRefs::R
-     var r_ref: TestEliminateImmRefs::R
-     var x_ref: u64
+     var $t0|r: TestEliminateImmRefs::R
+     var $t1|r_ref: TestEliminateImmRefs::R
+     var $t2|x_ref: u64
      var $t3: u64
      var $t4: TestEliminateImmRefs::R
      var $t5: TestEliminateImmRefs::R
@@ -135,29 +135,29 @@ fun TestEliminateImmRefs::test2(): u64 {
      var $t9: u64
   0: $t3 := 3
   1: $t4 := pack TestEliminateImmRefs::R($t3)
-  2: r := $t4
-  3: $t5 := copy(r)
-  4: r_ref := $t5
-  5: $t6 := move(r_ref)
+  2: $t0 := $t4
+  3: $t5 := copy($t0)
+  4: $t1 := $t5
+  5: $t6 := move($t1)
   6: $t7 := get_field<TestEliminateImmRefs::R>.x($t6)
-  7: x_ref := $t7
-  8: $t8 := move(x_ref)
+  7: $t2 := $t7
+  8: $t8 := move($t2)
   9: $t9 := move($t8)
  10: return $t9
 }
 
 
 [variant baseline]
-fun TestEliminateImmRefs::test3(r_ref: TestEliminateImmRefs::R): u64 {
-     var x_ref: u64
+fun TestEliminateImmRefs::test3($t0|r_ref: TestEliminateImmRefs::R): u64 {
+     var $t1|x_ref: u64
      var $t2: TestEliminateImmRefs::R
      var $t3: u64
      var $t4: u64
      var $t5: u64
-  0: $t2 := move(r_ref)
+  0: $t2 := move($t0)
   1: $t3 := get_field<TestEliminateImmRefs::R>.x($t2)
-  2: x_ref := $t3
-  3: $t4 := move(x_ref)
+  2: $t1 := $t3
+  3: $t4 := move($t1)
   4: $t5 := move($t4)
   5: return $t5
 }
@@ -165,8 +165,8 @@ fun TestEliminateImmRefs::test3(r_ref: TestEliminateImmRefs::R): u64 {
 
 [variant baseline]
 fun TestEliminateImmRefs::test4(): u64 {
-     var r: TestEliminateImmRefs::R
-     var r_ref: TestEliminateImmRefs::R
+     var $t0|r: TestEliminateImmRefs::R
+     var $t1|r_ref: TestEliminateImmRefs::R
      var $t2: u64
      var $t3: TestEliminateImmRefs::R
      var $t4: TestEliminateImmRefs::R
@@ -174,10 +174,10 @@ fun TestEliminateImmRefs::test4(): u64 {
      var $t6: u64
   0: $t2 := 3
   1: $t3 := pack TestEliminateImmRefs::R($t2)
-  2: r := $t3
-  3: $t4 := copy(r)
-  4: r_ref := $t4
-  5: $t5 := move(r_ref)
+  2: $t0 := $t3
+  3: $t4 := copy($t0)
+  4: $t1 := $t4
+  5: $t5 := move($t1)
   6: $t6 := TestEliminateImmRefs::test3($t5)
   7: return $t6
 }

--- a/language/move-prover/bytecode/tests/eliminate_mut_refs/basic_test.exp
+++ b/language/move-prover/bytecode/tests/eliminate_mut_refs/basic_test.exp
@@ -2,9 +2,9 @@
 
 [variant baseline]
 fun TestEliminateMutRefs::test1(): TestEliminateMutRefs::R {
-     var r: TestEliminateMutRefs::R
-     var r_ref: &mut TestEliminateMutRefs::R
-     var x_ref: &mut u64
+     var $t0|r: TestEliminateMutRefs::R
+     var $t1|r_ref: &mut TestEliminateMutRefs::R
+     var $t2|x_ref: &mut u64
      var $t3: u64
      var $t4: TestEliminateMutRefs::R
      var $t5: &mut TestEliminateMutRefs::R
@@ -15,43 +15,43 @@ fun TestEliminateMutRefs::test1(): TestEliminateMutRefs::R {
      var $t10: TestEliminateMutRefs::R
   0: $t3 := 3
   1: $t4 := pack TestEliminateMutRefs::R($t3)
-  2: r := $t4
-  3: $t5 := borrow_local(r)
-  4: r_ref := $t5
-  5: $t6 := move(r_ref)
+  2: $t0 := $t4
+  3: $t5 := borrow_local($t0)
+  4: $t1 := $t5
+  5: $t6 := move($t1)
   6: $t7 := borrow_field<TestEliminateMutRefs::R>.x($t6)
-  7: x_ref := $t7
+  7: $t2 := $t7
   8: $t8 := 0
-  9: $t9 := move(x_ref)
+  9: $t9 := move($t2)
  10: write_ref($t9, $t8)
- 11: $t10 := move(r)
+ 11: $t10 := move($t0)
  12: return $t10
 }
 
 
 [variant baseline]
-fun TestEliminateMutRefs::test2(x_ref: &mut u64, v: u64) {
+fun TestEliminateMutRefs::test2($t0|x_ref: &mut u64, $t1|v: u64) {
      var $t2: u64
      var $t3: &mut u64
-  0: $t2 := copy(v)
-  1: $t3 := move(x_ref)
+  0: $t2 := copy($t1)
+  1: $t3 := move($t0)
   2: write_ref($t3, $t2)
   3: return ()
 }
 
 
 [variant baseline]
-pub fun TestEliminateMutRefs::test3(r_ref: &mut TestEliminateMutRefs::R, v: u64) {
-     var x_ref: &mut u64
+pub fun TestEliminateMutRefs::test3($t0|r_ref: &mut TestEliminateMutRefs::R, $t1|v: u64) {
+     var $t2|x_ref: &mut u64
      var $t3: &mut TestEliminateMutRefs::R
      var $t4: &mut u64
      var $t5: &mut u64
      var $t6: u64
-  0: $t3 := move(r_ref)
+  0: $t3 := move($t0)
   1: $t4 := borrow_field<TestEliminateMutRefs::R>.x($t3)
-  2: x_ref := $t4
-  3: $t5 := move(x_ref)
-  4: $t6 := copy(v)
+  2: $t2 := $t4
+  3: $t5 := move($t2)
+  4: $t6 := copy($t1)
   5: TestEliminateMutRefs::test2($t5, $t6)
   6: return ()
 }
@@ -59,8 +59,8 @@ pub fun TestEliminateMutRefs::test3(r_ref: &mut TestEliminateMutRefs::R, v: u64)
 
 [variant baseline]
 fun TestEliminateMutRefs::test4(): TestEliminateMutRefs::R {
-     var r: TestEliminateMutRefs::R
-     var r_ref: &mut TestEliminateMutRefs::R
+     var $t0|r: TestEliminateMutRefs::R
+     var $t1|r_ref: &mut TestEliminateMutRefs::R
      var $t2: u64
      var $t3: TestEliminateMutRefs::R
      var $t4: &mut TestEliminateMutRefs::R
@@ -69,22 +69,22 @@ fun TestEliminateMutRefs::test4(): TestEliminateMutRefs::R {
      var $t7: TestEliminateMutRefs::R
   0: $t2 := 3
   1: $t3 := pack TestEliminateMutRefs::R($t2)
-  2: r := $t3
-  3: $t4 := borrow_local(r)
-  4: r_ref := $t4
-  5: $t5 := move(r_ref)
+  2: $t0 := $t3
+  3: $t4 := borrow_local($t0)
+  4: $t1 := $t4
+  5: $t5 := move($t1)
   6: $t6 := 0
   7: TestEliminateMutRefs::test3($t5, $t6)
-  8: $t7 := move(r)
+  8: $t7 := move($t0)
   9: return $t7
 }
 
 
 [variant baseline]
-pub fun TestEliminateMutRefs::test5(r_ref: &mut TestEliminateMutRefs::R): &mut u64 {
+pub fun TestEliminateMutRefs::test5($t0|r_ref: &mut TestEliminateMutRefs::R): &mut u64 {
      var $t1: &mut TestEliminateMutRefs::R
      var $t2: &mut u64
-  0: $t1 := move(r_ref)
+  0: $t1 := move($t0)
   1: $t2 := borrow_field<TestEliminateMutRefs::R>.x($t1)
   2: return $t2
 }
@@ -92,9 +92,9 @@ pub fun TestEliminateMutRefs::test5(r_ref: &mut TestEliminateMutRefs::R): &mut u
 
 [variant baseline]
 fun TestEliminateMutRefs::test6(): TestEliminateMutRefs::R {
-     var r: TestEliminateMutRefs::R
-     var r_ref: &mut TestEliminateMutRefs::R
-     var x_ref: &mut u64
+     var $t0|r: TestEliminateMutRefs::R
+     var $t1|r_ref: &mut TestEliminateMutRefs::R
+     var $t2|x_ref: &mut u64
      var $t3: u64
      var $t4: TestEliminateMutRefs::R
      var $t5: &mut TestEliminateMutRefs::R
@@ -105,25 +105,25 @@ fun TestEliminateMutRefs::test6(): TestEliminateMutRefs::R {
      var $t10: TestEliminateMutRefs::R
   0: $t3 := 3
   1: $t4 := pack TestEliminateMutRefs::R($t3)
-  2: r := $t4
-  3: $t5 := borrow_local(r)
-  4: r_ref := $t5
-  5: $t6 := move(r_ref)
+  2: $t0 := $t4
+  3: $t5 := borrow_local($t0)
+  4: $t1 := $t5
+  5: $t6 := move($t1)
   6: $t7 := TestEliminateMutRefs::test5($t6)
-  7: x_ref := $t7
-  8: $t8 := move(x_ref)
+  7: $t2 := $t7
+  8: $t8 := move($t2)
   9: $t9 := 0
  10: TestEliminateMutRefs::test2($t8, $t9)
- 11: $t10 := move(r)
+ 11: $t10 := move($t0)
  12: return $t10
 }
 
 
 [variant baseline]
-fun TestEliminateMutRefs::test7(b: bool) {
-     var r1: TestEliminateMutRefs::R
-     var r2: TestEliminateMutRefs::R
-     var r_ref: &mut TestEliminateMutRefs::R
+fun TestEliminateMutRefs::test7($t0|b: bool) {
+     var $t1|r1: TestEliminateMutRefs::R
+     var $t2|r2: TestEliminateMutRefs::R
+     var $t3|r_ref: &mut TestEliminateMutRefs::R
      var $t4: u64
      var $t5: TestEliminateMutRefs::R
      var $t6: u64
@@ -136,24 +136,24 @@ fun TestEliminateMutRefs::test7(b: bool) {
      var $t13: u64
   0: $t4 := 3
   1: $t5 := pack TestEliminateMutRefs::R($t4)
-  2: r1 := $t5
+  2: $t1 := $t5
   3: $t6 := 4
   4: $t7 := pack TestEliminateMutRefs::R($t6)
-  5: r2 := $t7
-  6: $t8 := borrow_local(r1)
-  7: r_ref := $t8
-  8: $t9 := copy(b)
+  5: $t2 := $t7
+  6: $t8 := borrow_local($t1)
+  7: $t3 := $t8
+  8: $t9 := copy($t0)
   9: if ($t9) goto L0 else goto L1
  10: L1:
  11: goto L2
  12: L0:
- 13: $t10 := move(r_ref)
+ 13: $t10 := move($t3)
  14: destroy($t10)
- 15: $t11 := borrow_local(r2)
- 16: r_ref := $t11
+ 15: $t11 := borrow_local($t2)
+ 16: $t3 := $t11
  17: goto L2
  18: L2:
- 19: $t12 := move(r_ref)
+ 19: $t12 := move($t3)
  20: $t13 := 0
  21: TestEliminateMutRefs::test3($t12, $t13)
  22: return ()
@@ -161,10 +161,10 @@ fun TestEliminateMutRefs::test7(b: bool) {
 
 
 [variant baseline]
-fun TestEliminateMutRefs::test8(b: bool, n: u64, r_ref: &mut TestEliminateMutRefs::R) {
-     var r1: TestEliminateMutRefs::R
-     var r2: TestEliminateMutRefs::R
-     var t_ref: &mut TestEliminateMutRefs::R
+fun TestEliminateMutRefs::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestEliminateMutRefs::R) {
+     var $t3|r1: TestEliminateMutRefs::R
+     var $t4|r2: TestEliminateMutRefs::R
+     var $t5|t_ref: &mut TestEliminateMutRefs::R
      var $t6: u64
      var $t7: TestEliminateMutRefs::R
      var $t8: u64
@@ -193,24 +193,24 @@ fun TestEliminateMutRefs::test8(b: bool, n: u64, r_ref: &mut TestEliminateMutRef
      var $t31: u64
   0: $t6 := 3
   1: $t7 := pack TestEliminateMutRefs::R($t6)
-  2: r1 := $t7
+  2: $t3 := $t7
   3: $t8 := 4
   4: $t9 := pack TestEliminateMutRefs::R($t8)
-  5: r2 := $t9
-  6: $t10 := borrow_local(r2)
-  7: t_ref := $t10
+  5: $t4 := $t9
+  6: $t10 := borrow_local($t4)
+  7: $t5 := $t10
   8: goto L7
   9: L7:
  10: $t11 := 0
- 11: $t12 := copy(n)
+ 11: $t12 := copy($t1)
  12: $t13 := <($t11, $t12)
  13: if ($t13) goto L0 else goto L1
  14: L1:
  15: goto L2
  16: L0:
- 17: $t14 := move(t_ref)
+ 17: $t14 := move($t5)
  18: destroy($t14)
- 19: $t15 := copy(n)
+ 19: $t15 := copy($t1)
  20: $t16 := 2
  21: $t17 := /($t15, $t16)
  22: $t18 := 0
@@ -219,35 +219,35 @@ fun TestEliminateMutRefs::test8(b: bool, n: u64, r_ref: &mut TestEliminateMutRef
  25: L4:
  26: goto L5
  27: L3:
- 28: $t20 := borrow_local(r1)
- 29: t_ref := $t20
+ 28: $t20 := borrow_local($t3)
+ 29: $t5 := $t20
  30: goto L6
  31: L5:
- 32: $t21 := borrow_local(r2)
- 33: t_ref := $t21
+ 32: $t21 := borrow_local($t4)
+ 33: $t5 := $t21
  34: goto L6
  35: L6:
- 36: $t22 := copy(n)
+ 36: $t22 := copy($t1)
  37: $t23 := 1
  38: $t24 := -($t22, $t23)
- 39: n := $t24
+ 39: $t1 := $t24
  40: goto L7
  41: L2:
- 42: $t25 := copy(b)
+ 42: $t25 := copy($t0)
  43: if ($t25) goto L8 else goto L9
  44: L9:
  45: goto L10
  46: L8:
- 47: $t26 := move(t_ref)
+ 47: $t26 := move($t5)
  48: destroy($t26)
- 49: $t27 := move(r_ref)
+ 49: $t27 := move($t2)
  50: $t28 := 0
  51: TestEliminateMutRefs::test3($t27, $t28)
  52: goto L11
  53: L10:
- 54: $t29 := move(r_ref)
+ 54: $t29 := move($t2)
  55: destroy($t29)
- 56: $t30 := move(t_ref)
+ 56: $t30 := move($t5)
  57: $t31 := 0
  58: TestEliminateMutRefs::test3($t30, $t31)
  59: goto L11
@@ -259,9 +259,9 @@ fun TestEliminateMutRefs::test8(b: bool, n: u64, r_ref: &mut TestEliminateMutRef
 
 [variant baseline]
 fun TestEliminateMutRefs::test1(): TestEliminateMutRefs::R {
-     var r: TestEliminateMutRefs::R
-     var r_ref: &mut TestEliminateMutRefs::R
-     var x_ref: &mut u64
+     var $t0|r: TestEliminateMutRefs::R
+     var $t1|r_ref: &mut TestEliminateMutRefs::R
+     var $t2|x_ref: &mut u64
      var $t3: u64
      var $t4: TestEliminateMutRefs::R
      var $t5: &mut TestEliminateMutRefs::R
@@ -272,29 +272,29 @@ fun TestEliminateMutRefs::test1(): TestEliminateMutRefs::R {
      var $t10: TestEliminateMutRefs::R
   0: $t3 := 3
   1: $t4 := pack TestEliminateMutRefs::R($t3)
-  2: r := $t4
-  3: $t5 := borrow_local(r)
-  4: r_ref := $t5
-  5: $t6 := move(r_ref)
+  2: $t0 := $t4
+  3: $t5 := borrow_local($t0)
+  4: $t1 := $t5
+  5: $t6 := move($t1)
   6: $t7 := borrow_field<TestEliminateMutRefs::R>.x($t6)
-  7: x_ref := $t7
+  7: $t2 := $t7
   8: $t8 := 0
-  9: $t9 := move(x_ref)
+  9: $t9 := move($t2)
  10: write_ref($t9, $t8)
- 11: $t10 := move(r)
+ 11: $t10 := move($t0)
  12: return $t10
 }
 
 
 [variant baseline]
-fun TestEliminateMutRefs::test2(x_ref: u64, v: u64): u64 {
+fun TestEliminateMutRefs::test2($t0|x_ref: u64, $t1|v: u64): u64 {
      var $t2: u64
      var $t3: &mut u64
      var $t4: u64
      var $t5: &mut u64
      var $t6: u64
-  0: $t4 := move(x_ref)
-  1: $t6 := move(v)
+  0: $t4 := move($t0)
+  1: $t6 := move($t1)
   2: $t5 := borrow_local($t4)
   3: $t2 := copy($t6)
   4: $t3 := move($t5)
@@ -304,8 +304,8 @@ fun TestEliminateMutRefs::test2(x_ref: u64, v: u64): u64 {
 
 
 [variant baseline]
-pub fun TestEliminateMutRefs::test3(r_ref: TestEliminateMutRefs::R, v: u64): TestEliminateMutRefs::R {
-     var x_ref: &mut u64
+pub fun TestEliminateMutRefs::test3($t0|r_ref: TestEliminateMutRefs::R, $t1|v: u64): TestEliminateMutRefs::R {
+     var $t2|x_ref: &mut u64
      var $t3: &mut TestEliminateMutRefs::R
      var $t4: &mut u64
      var $t5: &mut u64
@@ -314,13 +314,13 @@ pub fun TestEliminateMutRefs::test3(r_ref: TestEliminateMutRefs::R, v: u64): Tes
      var $t8: &mut TestEliminateMutRefs::R
      var $t9: u64
      var $t10: u64
-  0: $t7 := move(r_ref)
-  1: $t9 := move(v)
+  0: $t7 := move($t0)
+  1: $t9 := move($t1)
   2: $t8 := borrow_local($t7)
   3: $t3 := move($t8)
   4: $t4 := borrow_field<TestEliminateMutRefs::R>.x($t3)
-  5: x_ref := $t4
-  6: $t5 := move(x_ref)
+  5: $t2 := $t4
+  6: $t5 := move($t2)
   7: $t6 := copy($t9)
   8: $t10 := read_ref($t5)
   9: $t10 := TestEliminateMutRefs::test2($t10, $t6)
@@ -331,8 +331,8 @@ pub fun TestEliminateMutRefs::test3(r_ref: TestEliminateMutRefs::R, v: u64): Tes
 
 [variant baseline]
 fun TestEliminateMutRefs::test4(): TestEliminateMutRefs::R {
-     var r: TestEliminateMutRefs::R
-     var r_ref: &mut TestEliminateMutRefs::R
+     var $t0|r: TestEliminateMutRefs::R
+     var $t1|r_ref: &mut TestEliminateMutRefs::R
      var $t2: u64
      var $t3: TestEliminateMutRefs::R
      var $t4: &mut TestEliminateMutRefs::R
@@ -342,26 +342,26 @@ fun TestEliminateMutRefs::test4(): TestEliminateMutRefs::R {
      var $t8: TestEliminateMutRefs::R
   0: $t2 := 3
   1: $t3 := pack TestEliminateMutRefs::R($t2)
-  2: r := $t3
-  3: $t4 := borrow_local(r)
-  4: r_ref := $t4
-  5: $t5 := move(r_ref)
+  2: $t0 := $t3
+  3: $t4 := borrow_local($t0)
+  4: $t1 := $t4
+  5: $t5 := move($t1)
   6: $t6 := 0
   7: $t8 := read_ref($t5)
   8: $t8 := TestEliminateMutRefs::test3($t8, $t6)
   9: write_ref($t5, $t8)
- 10: $t7 := move(r)
+ 10: $t7 := move($t0)
  11: return $t7
 }
 
 
 [variant baseline]
-pub fun TestEliminateMutRefs::test5(r_ref: TestEliminateMutRefs::R): (&mut u64, TestEliminateMutRefs::R) {
+pub fun TestEliminateMutRefs::test5($t0|r_ref: TestEliminateMutRefs::R): (&mut u64, TestEliminateMutRefs::R) {
      var $t1: &mut TestEliminateMutRefs::R
      var $t2: &mut u64
      var $t3: TestEliminateMutRefs::R
      var $t4: &mut TestEliminateMutRefs::R
-  0: $t3 := move(r_ref)
+  0: $t3 := move($t0)
   1: $t4 := borrow_local($t3)
   2: $t1 := move($t4)
   3: $t2 := borrow_field<TestEliminateMutRefs::R>.x($t1)
@@ -371,9 +371,9 @@ pub fun TestEliminateMutRefs::test5(r_ref: TestEliminateMutRefs::R): (&mut u64, 
 
 [variant baseline]
 fun TestEliminateMutRefs::test6(): TestEliminateMutRefs::R {
-     var r: TestEliminateMutRefs::R
-     var r_ref: &mut TestEliminateMutRefs::R
-     var x_ref: &mut u64
+     var $t0|r: TestEliminateMutRefs::R
+     var $t1|r_ref: &mut TestEliminateMutRefs::R
+     var $t2|x_ref: &mut u64
      var $t3: u64
      var $t4: TestEliminateMutRefs::R
      var $t5: &mut TestEliminateMutRefs::R
@@ -386,30 +386,30 @@ fun TestEliminateMutRefs::test6(): TestEliminateMutRefs::R {
      var $t12: TestEliminateMutRefs::R
   0: $t3 := 3
   1: $t4 := pack TestEliminateMutRefs::R($t3)
-  2: r := $t4
-  3: $t5 := borrow_local(r)
-  4: r_ref := $t5
-  5: $t6 := move(r_ref)
+  2: $t0 := $t4
+  3: $t5 := borrow_local($t0)
+  4: $t1 := $t5
+  5: $t6 := move($t1)
   6: $t12 := read_ref($t6)
   7: ($t7, $t12) := TestEliminateMutRefs::test5($t12)
   8: write_ref($t6, $t12)
   9: splice[0 -> $t6]($t7)
- 10: x_ref := $t7
- 11: $t8 := move(x_ref)
+ 10: $t2 := $t7
+ 11: $t8 := move($t2)
  12: $t9 := 0
  13: $t11 := read_ref($t8)
  14: $t11 := TestEliminateMutRefs::test2($t11, $t9)
  15: write_ref($t8, $t11)
- 16: $t10 := move(r)
+ 16: $t10 := move($t0)
  17: return $t10
 }
 
 
 [variant baseline]
-fun TestEliminateMutRefs::test7(b: bool) {
-     var r1: TestEliminateMutRefs::R
-     var r2: TestEliminateMutRefs::R
-     var r_ref: &mut TestEliminateMutRefs::R
+fun TestEliminateMutRefs::test7($t0|b: bool) {
+     var $t1|r1: TestEliminateMutRefs::R
+     var $t2|r2: TestEliminateMutRefs::R
+     var $t3|r_ref: &mut TestEliminateMutRefs::R
      var $t4: u64
      var $t5: TestEliminateMutRefs::R
      var $t6: u64
@@ -422,27 +422,27 @@ fun TestEliminateMutRefs::test7(b: bool) {
      var $t13: u64
      var $t14: bool
      var $t15: TestEliminateMutRefs::R
-  0: $t14 := move(b)
+  0: $t14 := move($t0)
   1: $t4 := 3
   2: $t5 := pack TestEliminateMutRefs::R($t4)
-  3: r1 := $t5
+  3: $t1 := $t5
   4: $t6 := 4
   5: $t7 := pack TestEliminateMutRefs::R($t6)
-  6: r2 := $t7
-  7: $t8 := borrow_local(r1)
-  8: r_ref := $t8
+  6: $t2 := $t7
+  7: $t8 := borrow_local($t1)
+  8: $t3 := $t8
   9: $t9 := copy($t14)
  10: if ($t9) goto L0 else goto L1
  11: L1:
  12: goto L2
  13: L0:
- 14: $t10 := move(r_ref)
+ 14: $t10 := move($t3)
  15: destroy($t10)
- 16: $t11 := borrow_local(r2)
- 17: r_ref := $t11
+ 16: $t11 := borrow_local($t2)
+ 17: $t3 := $t11
  18: goto L2
  19: L2:
- 20: $t12 := move(r_ref)
+ 20: $t12 := move($t3)
  21: $t13 := 0
  22: $t15 := read_ref($t12)
  23: $t15 := TestEliminateMutRefs::test3($t15, $t13)
@@ -452,10 +452,10 @@ fun TestEliminateMutRefs::test7(b: bool) {
 
 
 [variant baseline]
-fun TestEliminateMutRefs::test8(b: bool, n: u64, r_ref: TestEliminateMutRefs::R): TestEliminateMutRefs::R {
-     var r1: TestEliminateMutRefs::R
-     var r2: TestEliminateMutRefs::R
-     var t_ref: &mut TestEliminateMutRefs::R
+fun TestEliminateMutRefs::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: TestEliminateMutRefs::R): TestEliminateMutRefs::R {
+     var $t3|r1: TestEliminateMutRefs::R
+     var $t4|r2: TestEliminateMutRefs::R
+     var $t5|t_ref: &mut TestEliminateMutRefs::R
      var $t6: u64
      var $t7: TestEliminateMutRefs::R
      var $t8: u64
@@ -487,18 +487,18 @@ fun TestEliminateMutRefs::test8(b: bool, n: u64, r_ref: TestEliminateMutRefs::R)
      var $t34: TestEliminateMutRefs::R
      var $t35: &mut TestEliminateMutRefs::R
      var $t36: TestEliminateMutRefs::R
-  0: $t32 := move(b)
-  1: $t33 := move(n)
-  2: $t34 := move(r_ref)
+  0: $t32 := move($t0)
+  1: $t33 := move($t1)
+  2: $t34 := move($t2)
   3: $t35 := borrow_local($t34)
   4: $t6 := 3
   5: $t7 := pack TestEliminateMutRefs::R($t6)
-  6: r1 := $t7
+  6: $t3 := $t7
   7: $t8 := 4
   8: $t9 := pack TestEliminateMutRefs::R($t8)
-  9: r2 := $t9
- 10: $t10 := borrow_local(r2)
- 11: t_ref := $t10
+  9: $t4 := $t9
+ 10: $t10 := borrow_local($t4)
+ 11: $t5 := $t10
  12: goto L7
  13: L7:
  14: $t11 := 0
@@ -508,7 +508,7 @@ fun TestEliminateMutRefs::test8(b: bool, n: u64, r_ref: TestEliminateMutRefs::R)
  18: L1:
  19: goto L2
  20: L0:
- 21: $t14 := move(t_ref)
+ 21: $t14 := move($t5)
  22: destroy($t14)
  23: $t15 := copy($t33)
  24: $t16 := 2
@@ -519,12 +519,12 @@ fun TestEliminateMutRefs::test8(b: bool, n: u64, r_ref: TestEliminateMutRefs::R)
  29: L4:
  30: goto L5
  31: L3:
- 32: $t20 := borrow_local(r1)
- 33: t_ref := $t20
+ 32: $t20 := borrow_local($t3)
+ 33: $t5 := $t20
  34: goto L6
  35: L5:
- 36: $t21 := borrow_local(r2)
- 37: t_ref := $t21
+ 36: $t21 := borrow_local($t4)
+ 37: $t5 := $t21
  38: goto L6
  39: L6:
  40: $t22 := copy($t33)
@@ -538,7 +538,7 @@ fun TestEliminateMutRefs::test8(b: bool, n: u64, r_ref: TestEliminateMutRefs::R)
  48: L9:
  49: goto L10
  50: L8:
- 51: $t26 := move(t_ref)
+ 51: $t26 := move($t5)
  52: destroy($t26)
  53: $t27 := move($t35)
  54: $t28 := 0
@@ -549,7 +549,7 @@ fun TestEliminateMutRefs::test8(b: bool, n: u64, r_ref: TestEliminateMutRefs::R)
  59: L10:
  60: $t29 := move($t35)
  61: destroy($t29)
- 62: $t30 := move(t_ref)
+ 62: $t30 := move($t5)
  63: $t31 := 0
  64: $t36 := read_ref($t30)
  65: $t36 := TestEliminateMutRefs::test3($t36, $t31)

--- a/language/move-prover/bytecode/tests/eliminate_mut_refs/mut_ref_unpack.exp
+++ b/language/move-prover/bytecode/tests/eliminate_mut_refs/mut_ref_unpack.exp
@@ -1,10 +1,10 @@
 ============ initial translation from Move ================
 
 [variant baseline]
-pub fun TestMutRefs::unpack(r: &mut TestMutRefs::R): u64 {
-     var result: u64
-     var tmp#$2: &mut TestMutRefs::R
-     var value: &mut u64
+pub fun TestMutRefs::unpack($t0|r: &mut TestMutRefs::R): u64 {
+     var $t1|result: u64
+     var $t2|tmp#$2: &mut TestMutRefs::R
+     var $t3|value: &mut u64
      var $t4: &mut TestMutRefs::R
      var $t5: &mut TestMutRefs::R
      var $t6: &mut u64
@@ -13,52 +13,52 @@ pub fun TestMutRefs::unpack(r: &mut TestMutRefs::R): u64 {
      var $t9: u64
      var $t10: &mut u64
      var $t11: u64
-  0: $t4 := move(r)
-  1: tmp#$2 := $t4
-  2: $t5 := move(tmp#$2)
+  0: $t4 := move($t0)
+  1: $t2 := $t4
+  2: $t5 := move($t2)
   3: $t6 := borrow_field<TestMutRefs::R>.value($t5)
-  4: value := $t6
-  5: $t7 := copy(value)
+  4: $t3 := $t6
+  5: $t7 := copy($t3)
   6: $t8 := read_ref($t7)
-  7: result := $t8
+  7: $t1 := $t8
   8: $t9 := 0
-  9: $t10 := move(value)
+  9: $t10 := move($t3)
  10: write_ref($t10, $t9)
- 11: $t11 := copy(result)
+ 11: $t11 := copy($t1)
  12: return $t11
 }
 
 
 [variant baseline]
-pub fun TestMutRefs::unpack_incorrect(r: &mut TestMutRefs::R): u64 {
-     var result: u64
-     var tmp#$2: &mut TestMutRefs::R
-     var value: &mut u64
+pub fun TestMutRefs::unpack_incorrect($t0|r: &mut TestMutRefs::R): u64 {
+     var $t1|result: u64
+     var $t2|tmp#$2: &mut TestMutRefs::R
+     var $t3|value: &mut u64
      var $t4: &mut TestMutRefs::R
      var $t5: &mut TestMutRefs::R
      var $t6: &mut u64
      var $t7: &mut u64
      var $t8: u64
      var $t9: u64
-  0: $t4 := move(r)
-  1: tmp#$2 := $t4
-  2: $t5 := move(tmp#$2)
+  0: $t4 := move($t0)
+  1: $t2 := $t4
+  2: $t5 := move($t2)
   3: $t6 := borrow_field<TestMutRefs::R>.value($t5)
-  4: value := $t6
-  5: $t7 := move(value)
+  4: $t3 := $t6
+  5: $t7 := move($t3)
   6: $t8 := read_ref($t7)
-  7: result := $t8
-  8: $t9 := copy(result)
+  7: $t1 := $t8
+  8: $t9 := copy($t1)
   9: return $t9
 }
 
 ============ after pipeline `eliminate_mut_refs` ================
 
 [variant baseline]
-pub fun TestMutRefs::unpack(r: TestMutRefs::R): (u64, TestMutRefs::R) {
-     var result: u64
-     var tmp#$2: &mut TestMutRefs::R
-     var value: &mut u64
+pub fun TestMutRefs::unpack($t0|r: TestMutRefs::R): (u64, TestMutRefs::R) {
+     var $t1|result: u64
+     var $t2|tmp#$2: &mut TestMutRefs::R
+     var $t3|value: &mut u64
      var $t4: &mut TestMutRefs::R
      var $t5: &mut TestMutRefs::R
      var $t6: &mut u64
@@ -69,29 +69,29 @@ pub fun TestMutRefs::unpack(r: TestMutRefs::R): (u64, TestMutRefs::R) {
      var $t11: u64
      var $t12: TestMutRefs::R
      var $t13: &mut TestMutRefs::R
-  0: $t12 := move(r)
+  0: $t12 := move($t0)
   1: $t13 := borrow_local($t12)
   2: $t4 := move($t13)
-  3: tmp#$2 := $t4
-  4: $t5 := move(tmp#$2)
+  3: $t2 := $t4
+  4: $t5 := move($t2)
   5: $t6 := borrow_field<TestMutRefs::R>.value($t5)
-  6: value := $t6
-  7: $t7 := copy(value)
+  6: $t3 := $t6
+  7: $t7 := copy($t3)
   8: $t8 := read_ref($t7)
-  9: result := $t8
+  9: $t1 := $t8
  10: $t9 := 0
- 11: $t10 := move(value)
+ 11: $t10 := move($t3)
  12: write_ref($t10, $t9)
- 13: $t11 := copy(result)
+ 13: $t11 := copy($t1)
  14: return ($t11, $t12)
 }
 
 
 [variant baseline]
-pub fun TestMutRefs::unpack_incorrect(r: TestMutRefs::R): (u64, TestMutRefs::R) {
-     var result: u64
-     var tmp#$2: &mut TestMutRefs::R
-     var value: &mut u64
+pub fun TestMutRefs::unpack_incorrect($t0|r: TestMutRefs::R): (u64, TestMutRefs::R) {
+     var $t1|result: u64
+     var $t2|tmp#$2: &mut TestMutRefs::R
+     var $t3|value: &mut u64
      var $t4: &mut TestMutRefs::R
      var $t5: &mut TestMutRefs::R
      var $t6: &mut u64
@@ -100,16 +100,16 @@ pub fun TestMutRefs::unpack_incorrect(r: TestMutRefs::R): (u64, TestMutRefs::R) 
      var $t9: u64
      var $t10: TestMutRefs::R
      var $t11: &mut TestMutRefs::R
-  0: $t10 := move(r)
+  0: $t10 := move($t0)
   1: $t11 := borrow_local($t10)
   2: $t4 := move($t11)
-  3: tmp#$2 := $t4
-  4: $t5 := move(tmp#$2)
+  3: $t2 := $t4
+  4: $t5 := move($t2)
   5: $t6 := borrow_field<TestMutRefs::R>.value($t5)
-  6: value := $t6
-  7: $t7 := move(value)
+  6: $t3 := $t6
+  7: $t7 := move($t3)
   8: $t8 := read_ref($t7)
-  9: result := $t8
- 10: $t9 := copy(result)
+  9: $t1 := $t8
+ 10: $t9 := copy($t1)
  11: return ($t9, $t10)
 }

--- a/language/move-prover/bytecode/tests/from_move/regression_generic_and_native_type.exp
+++ b/language/move-prover/bytecode/tests/from_move/regression_generic_and_native_type.exp
@@ -1,7 +1,7 @@
 ============ initial translation from Move ================
 
 [variant baseline]
-pub fun Vector::append<$tv0>(lhs: &mut vector<#0>, other: vector<#0>) {
+pub fun Vector::append<$tv0>($t0|lhs: &mut vector<#0>, $t1|other: vector<#0>) {
      var $t2: &mut vector<#0>
      var $t3: &vector<#0>
      var $t4: bool
@@ -11,45 +11,45 @@ pub fun Vector::append<$tv0>(lhs: &mut vector<#0>, other: vector<#0>) {
      var $t8: #0
      var $t9: &mut vector<#0>
      var $t10: vector<#0>
-  0: $t2 := borrow_local(other)
+  0: $t2 := borrow_local($t1)
   1: Vector::reverse<#0>($t2)
   2: goto L3
   3: L3:
-  4: $t3 := borrow_local(other)
+  4: $t3 := borrow_local($t1)
   5: $t4 := Vector::is_empty<#0>($t3)
   6: $t5 := !($t4)
   7: if ($t5) goto L0 else goto L1
   8: L1:
   9: goto L2
  10: L0:
- 11: $t6 := copy(lhs)
- 12: $t7 := borrow_local(other)
+ 11: $t6 := copy($t0)
+ 12: $t7 := borrow_local($t1)
  13: $t8 := Vector::pop_back<#0>($t7)
  14: Vector::push_back<#0>($t6, $t8)
  15: goto L3
  16: L2:
- 17: $t9 := move(lhs)
+ 17: $t9 := move($t0)
  18: destroy($t9)
- 19: $t10 := move(other)
+ 19: $t10 := move($t1)
  20: Vector::destroy_empty<#0>($t10)
  21: return ()
 }
 
 
 [variant baseline]
-pub fun Vector::borrow<$tv0>(v: &vector<#0>, i: u64): &#0 {
+pub fun Vector::borrow<$tv0>($t0|v: &vector<#0>, $t1|i: u64): &#0 {
 }
 
 
 [variant baseline]
-pub fun Vector::borrow_mut<$tv0>(v: &mut vector<#0>, i: u64): &mut #0 {
+pub fun Vector::borrow_mut<$tv0>($t0|v: &mut vector<#0>, $t1|i: u64): &mut #0 {
 }
 
 
 [variant baseline]
-pub fun Vector::contains<$tv0>(v: &vector<#0>, e: &#0): bool {
-     var i: u64
-     var len: u64
+pub fun Vector::contains<$tv0>($t0|v: &vector<#0>, $t1|e: &#0): bool {
+     var $t2|i: u64
+     var $t3|len: u64
      var $t4: u64
      var $t5: &vector<#0>
      var $t6: u64
@@ -71,44 +71,44 @@ pub fun Vector::contains<$tv0>(v: &vector<#0>, e: &#0): bool {
      var $t22: &#0
      var $t23: bool
   0: $t4 := 0
-  1: i := $t4
-  2: $t5 := copy(v)
+  1: $t2 := $t4
+  2: $t5 := copy($t0)
   3: $t6 := Vector::length<#0>($t5)
-  4: len := $t6
+  4: $t3 := $t6
   5: goto L6
   6: L6:
-  7: $t7 := copy(i)
-  8: $t8 := copy(len)
+  7: $t7 := copy($t2)
+  8: $t8 := copy($t3)
   9: $t9 := <($t7, $t8)
  10: if ($t9) goto L0 else goto L1
  11: L1:
  12: goto L2
  13: L0:
- 14: $t10 := copy(v)
- 15: $t11 := copy(i)
+ 14: $t10 := copy($t0)
+ 15: $t11 := copy($t2)
  16: $t12 := Vector::borrow<#0>($t10, $t11)
- 17: $t13 := copy(e)
+ 17: $t13 := copy($t1)
  18: $t14 := ==($t12, $t13)
  19: if ($t14) goto L3 else goto L4
  20: L4:
  21: goto L5
  22: L3:
- 23: $t15 := move(v)
+ 23: $t15 := move($t0)
  24: destroy($t15)
- 25: $t16 := move(e)
+ 25: $t16 := move($t1)
  26: destroy($t16)
  27: $t17 := true
  28: return $t17
  29: L5:
- 30: $t18 := copy(i)
+ 30: $t18 := copy($t2)
  31: $t19 := 1
  32: $t20 := +($t18, $t19)
- 33: i := $t20
+ 33: $t2 := $t20
  34: goto L6
  35: L2:
- 36: $t21 := move(v)
+ 36: $t21 := move($t0)
  37: destroy($t21)
- 38: $t22 := move(e)
+ 38: $t22 := move($t1)
  39: destroy($t22)
  40: $t23 := false
  41: return $t23
@@ -116,7 +116,7 @@ pub fun Vector::contains<$tv0>(v: &vector<#0>, e: &#0): bool {
 
 
 [variant baseline]
-pub fun Vector::destroy_empty<$tv0>(v: vector<#0>) {
+pub fun Vector::destroy_empty<$tv0>($t0|v: vector<#0>) {
 }
 
 
@@ -126,9 +126,9 @@ pub fun Vector::empty<$tv0>(): vector<#0> {
 
 
 [variant baseline]
-pub fun Vector::index_of<$tv0>(v: &vector<#0>, e: &#0): (bool, u64) {
-     var i: u64
-     var len: u64
+pub fun Vector::index_of<$tv0>($t0|v: &vector<#0>, $t1|e: &#0): (bool, u64) {
+     var $t2|i: u64
+     var $t3|len: u64
      var $t4: u64
      var $t5: &vector<#0>
      var $t6: u64
@@ -152,45 +152,45 @@ pub fun Vector::index_of<$tv0>(v: &vector<#0>, e: &#0): (bool, u64) {
      var $t24: bool
      var $t25: u64
   0: $t4 := 0
-  1: i := $t4
-  2: $t5 := copy(v)
+  1: $t2 := $t4
+  2: $t5 := copy($t0)
   3: $t6 := Vector::length<#0>($t5)
-  4: len := $t6
+  4: $t3 := $t6
   5: goto L6
   6: L6:
-  7: $t7 := copy(i)
-  8: $t8 := copy(len)
+  7: $t7 := copy($t2)
+  8: $t8 := copy($t3)
   9: $t9 := <($t7, $t8)
  10: if ($t9) goto L0 else goto L1
  11: L1:
  12: goto L2
  13: L0:
- 14: $t10 := copy(v)
- 15: $t11 := copy(i)
+ 14: $t10 := copy($t0)
+ 15: $t11 := copy($t2)
  16: $t12 := Vector::borrow<#0>($t10, $t11)
- 17: $t13 := copy(e)
+ 17: $t13 := copy($t1)
  18: $t14 := ==($t12, $t13)
  19: if ($t14) goto L3 else goto L4
  20: L4:
  21: goto L5
  22: L3:
- 23: $t15 := move(v)
+ 23: $t15 := move($t0)
  24: destroy($t15)
- 25: $t16 := move(e)
+ 25: $t16 := move($t1)
  26: destroy($t16)
  27: $t17 := true
- 28: $t18 := copy(i)
+ 28: $t18 := copy($t2)
  29: return ($t17, $t18)
  30: L5:
- 31: $t19 := copy(i)
+ 31: $t19 := copy($t2)
  32: $t20 := 1
  33: $t21 := +($t19, $t20)
- 34: i := $t21
+ 34: $t2 := $t21
  35: goto L6
  36: L2:
- 37: $t22 := move(v)
+ 37: $t22 := move($t0)
  38: destroy($t22)
- 39: $t23 := move(e)
+ 39: $t23 := move($t1)
  40: destroy($t23)
  41: $t24 := false
  42: $t25 := 0
@@ -199,12 +199,12 @@ pub fun Vector::index_of<$tv0>(v: &vector<#0>, e: &#0): (bool, u64) {
 
 
 [variant baseline]
-pub fun Vector::is_empty<$tv0>(v: &vector<#0>): bool {
+pub fun Vector::is_empty<$tv0>($t0|v: &vector<#0>): bool {
      var $t1: &vector<#0>
      var $t2: u64
      var $t3: u64
      var $t4: bool
-  0: $t1 := move(v)
+  0: $t1 := move($t0)
   1: $t2 := Vector::length<#0>($t1)
   2: $t3 := 0
   3: $t4 := ==($t2, $t3)
@@ -213,25 +213,25 @@ pub fun Vector::is_empty<$tv0>(v: &vector<#0>): bool {
 
 
 [variant baseline]
-pub fun Vector::length<$tv0>(v: &vector<#0>): u64 {
+pub fun Vector::length<$tv0>($t0|v: &vector<#0>): u64 {
 }
 
 
 [variant baseline]
-pub fun Vector::pop_back<$tv0>(v: &mut vector<#0>): #0 {
+pub fun Vector::pop_back<$tv0>($t0|v: &mut vector<#0>): #0 {
 }
 
 
 [variant baseline]
-pub fun Vector::push_back<$tv0>(v: &mut vector<#0>, e: #0) {
+pub fun Vector::push_back<$tv0>($t0|v: &mut vector<#0>, $t1|e: #0) {
 }
 
 
 [variant baseline]
-pub fun Vector::remove<$tv0>(v: &mut vector<#0>, i: u64): #0 {
-     var len: u64
-     var tmp#$3: u64
-     var tmp#$4: &mut vector<#0>
+pub fun Vector::remove<$tv0>($t0|v: &mut vector<#0>, $t1|i: u64): #0 {
+     var $t2|len: u64
+     var $t3|tmp#$3: u64
+     var $t4|tmp#$4: &mut vector<#0>
      var $t5: &mut vector<#0>
      var $t6: &vector<#0>
      var $t7: u64
@@ -256,60 +256,60 @@ pub fun Vector::remove<$tv0>(v: &mut vector<#0>, i: u64): #0 {
      var $t26: u64
      var $t27: &mut vector<#0>
      var $t28: #0
-  0: $t5 := copy(v)
+  0: $t5 := copy($t0)
   1: $t6 := freeze_ref($t5)
   2: $t7 := Vector::length<#0>($t6)
-  3: len := $t7
-  4: $t8 := copy(i)
-  5: $t9 := copy(len)
+  3: $t2 := $t7
+  4: $t8 := copy($t1)
+  5: $t9 := copy($t2)
   6: $t10 := >=($t8, $t9)
   7: if ($t10) goto L0 else goto L1
   8: L1:
   9: goto L2
  10: L0:
- 11: $t11 := move(v)
+ 11: $t11 := move($t0)
  12: destroy($t11)
  13: $t12 := 0
  14: abort($t12)
  15: L2:
- 16: $t13 := copy(len)
+ 16: $t13 := copy($t2)
  17: $t14 := 1
  18: $t15 := -($t13, $t14)
- 19: len := $t15
+ 19: $t2 := $t15
  20: goto L6
  21: L6:
- 22: $t16 := copy(i)
- 23: $t17 := copy(len)
+ 22: $t16 := copy($t1)
+ 23: $t17 := copy($t2)
  24: $t18 := <($t16, $t17)
  25: if ($t18) goto L3 else goto L4
  26: L4:
  27: goto L5
  28: L3:
- 29: $t19 := copy(v)
- 30: tmp#$4 := $t19
- 31: $t20 := copy(i)
- 32: tmp#$3 := $t20
- 33: $t21 := copy(i)
+ 29: $t19 := copy($t0)
+ 30: $t4 := $t19
+ 31: $t20 := copy($t1)
+ 32: $t3 := $t20
+ 33: $t21 := copy($t1)
  34: $t22 := 1
  35: $t23 := +($t21, $t22)
- 36: i := $t23
- 37: $t24 := move(tmp#$4)
- 38: $t25 := move(tmp#$3)
- 39: $t26 := copy(i)
+ 36: $t1 := $t23
+ 37: $t24 := move($t4)
+ 38: $t25 := move($t3)
+ 39: $t26 := copy($t1)
  40: Vector::swap<#0>($t24, $t25, $t26)
  41: goto L6
  42: L5:
- 43: $t27 := move(v)
+ 43: $t27 := move($t0)
  44: $t28 := Vector::pop_back<#0>($t27)
  45: return $t28
 }
 
 
 [variant baseline]
-pub fun Vector::reverse<$tv0>(v: &mut vector<#0>) {
-     var back_index: u64
-     var front_index: u64
-     var len: u64
+pub fun Vector::reverse<$tv0>($t0|v: &mut vector<#0>) {
+     var $t1|back_index: u64
+     var $t2|front_index: u64
+     var $t3|len: u64
      var $t4: &mut vector<#0>
      var $t5: &vector<#0>
      var $t6: u64
@@ -334,81 +334,81 @@ pub fun Vector::reverse<$tv0>(v: &mut vector<#0>) {
      var $t25: u64
      var $t26: u64
      var $t27: &mut vector<#0>
-  0: $t4 := copy(v)
+  0: $t4 := copy($t0)
   1: $t5 := freeze_ref($t4)
   2: $t6 := Vector::length<#0>($t5)
-  3: len := $t6
-  4: $t7 := copy(len)
+  3: $t3 := $t6
+  4: $t7 := copy($t3)
   5: $t8 := 0
   6: $t9 := ==($t7, $t8)
   7: if ($t9) goto L0 else goto L1
   8: L1:
   9: goto L2
  10: L0:
- 11: $t10 := move(v)
+ 11: $t10 := move($t0)
  12: destroy($t10)
  13: return ()
  14: L2:
  15: $t11 := 0
- 16: front_index := $t11
- 17: $t12 := copy(len)
+ 16: $t2 := $t11
+ 17: $t12 := copy($t3)
  18: $t13 := 1
  19: $t14 := -($t12, $t13)
- 20: back_index := $t14
+ 20: $t1 := $t14
  21: goto L6
  22: L6:
- 23: $t15 := copy(front_index)
- 24: $t16 := copy(back_index)
+ 23: $t15 := copy($t2)
+ 24: $t16 := copy($t1)
  25: $t17 := <($t15, $t16)
  26: if ($t17) goto L3 else goto L4
  27: L4:
  28: goto L5
  29: L3:
- 30: $t18 := copy(v)
- 31: $t19 := copy(front_index)
- 32: $t20 := copy(back_index)
+ 30: $t18 := copy($t0)
+ 31: $t19 := copy($t2)
+ 32: $t20 := copy($t1)
  33: Vector::swap<#0>($t18, $t19, $t20)
- 34: $t21 := copy(front_index)
+ 34: $t21 := copy($t2)
  35: $t22 := 1
  36: $t23 := +($t21, $t22)
- 37: front_index := $t23
- 38: $t24 := copy(back_index)
+ 37: $t2 := $t23
+ 38: $t24 := copy($t1)
  39: $t25 := 1
  40: $t26 := -($t24, $t25)
- 41: back_index := $t26
+ 41: $t1 := $t26
  42: goto L6
  43: L5:
- 44: $t27 := move(v)
+ 44: $t27 := move($t0)
  45: destroy($t27)
  46: return ()
 }
 
 
 [variant baseline]
-pub fun Vector::singleton<$tv0>(e: #0): vector<#0> {
-     var v: vector<#0>
+pub fun Vector::singleton<$tv0>($t0|e: #0): vector<#0> {
+     var $t1|v: vector<#0>
      var $t2: vector<#0>
      var $t3: &mut vector<#0>
      var $t4: #0
      var $t5: vector<#0>
   0: $t2 := Vector::empty<#0>()
-  1: v := $t2
-  2: $t3 := borrow_local(v)
-  3: $t4 := move(e)
+  1: $t1 := $t2
+  2: $t3 := borrow_local($t1)
+  3: $t4 := move($t0)
   4: Vector::push_back<#0>($t3, $t4)
-  5: $t5 := move(v)
+  5: $t5 := move($t1)
   6: return $t5
 }
 
 
 [variant baseline]
-pub fun Vector::swap<$tv0>(v: &mut vector<#0>, i: u64, j: u64) {
+pub fun Vector::swap<$tv0>($t0|v: &mut vector<#0>, $t1|i: u64, $t2|j: u64) {
 }
 
 
 [variant baseline]
-pub fun Vector::swap_remove<$tv0>(v: &mut vector<#0>, i: u64): #0 {
-     var last_idx: u64
+pub fun Vector::swap_remove<$tv0>($t0|v: &mut vector<#0>, $t1|i: u64): #0 {
+     var $t2|last_idx: u64
      var $t3: &mut vector<#0>
      var $t4: &vector<#0>
      var $t5: u64
@@ -419,28 +419,28 @@ pub fun Vector::swap_remove<$tv0>(v: &mut vector<#0>, i: u64): #0 {
      var $t10: u64
      var $t11: &mut vector<#0>
      var $t12: #0
-  0: $t3 := copy(v)
+  0: $t3 := copy($t0)
   1: $t4 := freeze_ref($t3)
   2: $t5 := Vector::length<#0>($t4)
   3: $t6 := 1
   4: $t7 := -($t5, $t6)
-  5: last_idx := $t7
-  6: $t8 := copy(v)
-  7: $t9 := copy(i)
-  8: $t10 := copy(last_idx)
+  5: $t2 := $t7
+  6: $t8 := copy($t0)
+  7: $t9 := copy($t1)
+  8: $t10 := copy($t2)
   9: Vector::swap<#0>($t8, $t9, $t10)
- 10: $t11 := move(v)
+ 10: $t11 := move($t0)
  11: $t12 := Vector::pop_back<#0>($t11)
  12: return $t12
 }
 
 
 [variant baseline]
-pub fun Signer::address_of(s: &signer): address {
+pub fun Signer::address_of($t0|s: &signer): address {
      var $t1: &signer
      var $t2: &address
      var $t3: address
-  0: $t1 := move(s)
+  0: $t1 := move($t0)
   1: $t2 := Signer::borrow_address($t1)
   2: $t3 := read_ref($t2)
   3: return $t3
@@ -448,7 +448,7 @@ pub fun Signer::address_of(s: &signer): address {
 
 
 [variant baseline]
-pub fun Signer::borrow_address(s: &signer): &address {
+pub fun Signer::borrow_address($t0|s: &signer): &address {
 }
 
 
@@ -467,9 +467,9 @@ pub fun Diem::market_cap<$tv0>(): u128 {
 
 
 [variant baseline]
-pub fun Diem::preburn<$tv0>(preburn_ref: &mut Diem::Preburn<#0>, coin: Diem::T<#0>) {
-     var coin_value: u64
-     var market_cap: &mut Diem::Info<#0>
+pub fun Diem::preburn<$tv0>($t0|preburn_ref: &mut Diem::Preburn<#0>, $t1|coin: Diem::T<#0>) {
+     var $t2|coin_value: u64
+     var $t3|market_cap: &mut Diem::Info<#0>
      var $t4: &Diem::T<#0>
      var $t5: u64
      var $t6: &mut Diem::Preburn<#0>
@@ -484,22 +484,22 @@ pub fun Diem::preburn<$tv0>(preburn_ref: &mut Diem::Preburn<#0>, coin: Diem::T<#
      var $t15: u64
      var $t16: &mut Diem::Info<#0>
      var $t17: &mut u64
-  0: $t4 := borrow_local(coin)
+  0: $t4 := borrow_local($t1)
   1: $t5 := Diem::value<#0>($t4)
-  2: coin_value := $t5
-  3: $t6 := move(preburn_ref)
+  2: $t2 := $t5
+  3: $t6 := move($t0)
   4: $t7 := borrow_field<Diem::Preburn<#0>>.requests($t6)
-  5: $t8 := move(coin)
+  5: $t8 := move($t1)
   6: Vector::push_back<Diem::T<#0>>($t7, $t8)
   7: $t9 := 0xa550c18
   8: $t10 := borrow_global<Diem::Info<#0>>($t9)
-  9: market_cap := $t10
- 10: $t11 := copy(market_cap)
+  9: $t3 := $t10
+ 10: $t11 := copy($t3)
  11: $t12 := borrow_field<Diem::Info<#0>>.preburn_value($t11)
  12: $t13 := read_ref($t12)
- 13: $t14 := copy(coin_value)
+ 13: $t14 := copy($t2)
  14: $t15 := +($t13, $t14)
- 15: $t16 := move(market_cap)
+ 15: $t16 := move($t3)
  16: $t17 := borrow_field<Diem::Info<#0>>.preburn_value($t16)
  17: write_ref($t17, $t15)
  18: return ()
@@ -507,15 +507,15 @@ pub fun Diem::preburn<$tv0>(preburn_ref: &mut Diem::Preburn<#0>, coin: Diem::T<#
 
 
 [variant baseline]
-pub fun Diem::preburn_to<$tv0>(account: &signer, coin: Diem::T<#0>) {
+pub fun Diem::preburn_to<$tv0>($t0|account: &signer, $t1|coin: Diem::T<#0>) {
      var $t2: &signer
      var $t3: address
      var $t4: &mut Diem::Preburn<#0>
      var $t5: Diem::T<#0>
-  0: $t2 := move(account)
+  0: $t2 := move($t0)
   1: $t3 := Signer::address_of($t2)
   2: $t4 := borrow_global<Diem::Preburn<#0>>($t3)
-  3: $t5 := move(coin)
+  3: $t5 := move($t1)
   4: Diem::preburn<#0>($t4, $t5)
   5: return ()
 }
@@ -536,11 +536,11 @@ pub fun Diem::preburn_value<$tv0>(): u64 {
 
 
 [variant baseline]
-pub fun Diem::value<$tv0>(coin_ref: &Diem::T<#0>): u64 {
+pub fun Diem::value<$tv0>($t0|coin_ref: &Diem::T<#0>): u64 {
      var $t1: &Diem::T<#0>
      var $t2: &u64
      var $t3: u64
-  0: $t1 := move(coin_ref)
+  0: $t1 := move($t0)
   1: $t2 := borrow_field<Diem::T<#0>>.value($t1)
   2: $t3 := read_ref($t2)
   3: return $t3

--- a/language/move-prover/bytecode/tests/from_move/smoke_test.exp
+++ b/language/move-prover/bytecode/tests/from_move/smoke_test.exp
@@ -1,11 +1,11 @@
 ============ initial translation from Move ================
 
 [variant baseline]
-pub fun Signer::address_of(s: &signer): address {
+pub fun Signer::address_of($t0|s: &signer): address {
      var $t1: &signer
      var $t2: &address
      var $t3: address
-  0: $t1 := move(s)
+  0: $t1 := move($t0)
   1: $t2 := Signer::borrow_address($t1)
   2: $t3 := read_ref($t2)
   3: return $t3
@@ -13,13 +13,13 @@ pub fun Signer::address_of(s: &signer): address {
 
 
 [variant baseline]
-pub fun Signer::borrow_address(s: &signer): &address {
+pub fun Signer::borrow_address($t0|s: &signer): &address {
 }
 
 
 [variant baseline]
-fun SmokeTest::arithmetic_ops(a: u64): (u64, u64) {
-     var c: u64
+fun SmokeTest::arithmetic_ops($t0|a: u64): (u64, u64) {
+     var $t1|c: u64
      var $t2: u64
      var $t3: u64
      var $t4: u64
@@ -28,8 +28,8 @@ fun SmokeTest::arithmetic_ops(a: u64): (u64, u64) {
      var $t7: u64
      var $t8: u64
   0: $t2 := 2
-  1: c := $t2
-  2: $t3 := copy(c)
+  1: $t1 := $t2
+  2: $t3 := copy($t1)
   3: $t4 := 2
   4: $t5 := !=($t3, $t4)
   5: if ($t5) goto L0 else goto L1
@@ -39,18 +39,18 @@ fun SmokeTest::arithmetic_ops(a: u64): (u64, u64) {
   9: $t6 := 42
  10: abort($t6)
  11: L2:
- 12: $t7 := copy(c)
- 13: $t8 := copy(a)
+ 12: $t7 := copy($t1)
+ 13: $t8 := copy($t0)
  14: return ($t7, $t8)
 }
 
 
 [variant baseline]
-fun SmokeTest::bool_ops(a: u64, b: u64): (bool, bool) {
-     var c: bool
-     var d: bool
-     var tmp#$4: bool
-     var tmp#$5: bool
+fun SmokeTest::bool_ops($t0|a: u64, $t1|b: u64): (bool, bool) {
+     var $t2|c: bool
+     var $t3|d: bool
+     var $t4|tmp#$4: bool
+     var $t5|tmp#$5: bool
      var $t6: u64
      var $t7: u64
      var $t8: bool
@@ -74,46 +74,46 @@ fun SmokeTest::bool_ops(a: u64, b: u64): (bool, bool) {
      var $t26: u64
      var $t27: bool
      var $t28: bool
-  0: $t6 := copy(a)
-  1: $t7 := copy(b)
+  0: $t6 := copy($t0)
+  1: $t7 := copy($t1)
   2: $t8 := >($t6, $t7)
   3: if ($t8) goto L0 else goto L1
   4: L1:
   5: goto L2
   6: L0:
-  7: $t9 := copy(a)
-  8: $t10 := copy(b)
+  7: $t9 := copy($t0)
+  8: $t10 := copy($t1)
   9: $t11 := >=($t9, $t10)
- 10: tmp#$4 := $t11
+ 10: $t4 := $t11
  11: goto L3
  12: L2:
  13: $t12 := false
- 14: tmp#$4 := $t12
+ 14: $t4 := $t12
  15: goto L3
  16: L3:
- 17: $t13 := move(tmp#$4)
- 18: c := $t13
- 19: $t14 := copy(a)
- 20: $t15 := copy(b)
+ 17: $t13 := move($t4)
+ 18: $t2 := $t13
+ 19: $t14 := copy($t0)
+ 20: $t15 := copy($t1)
  21: $t16 := <($t14, $t15)
  22: if ($t16) goto L4 else goto L5
  23: L5:
  24: goto L6
  25: L4:
  26: $t17 := true
- 27: tmp#$5 := $t17
+ 27: $t5 := $t17
  28: goto L7
  29: L6:
- 30: $t18 := copy(a)
- 31: $t19 := copy(b)
+ 30: $t18 := copy($t0)
+ 31: $t19 := copy($t1)
  32: $t20 := <=($t18, $t19)
- 33: tmp#$5 := $t20
+ 33: $t5 := $t20
  34: goto L7
  35: L7:
- 36: $t21 := move(tmp#$5)
- 37: d := $t21
- 38: $t22 := copy(c)
- 39: $t23 := copy(d)
+ 36: $t21 := move($t5)
+ 37: $t3 := $t21
+ 38: $t22 := copy($t2)
+ 39: $t23 := copy($t3)
  40: $t24 := !=($t22, $t23)
  41: $t25 := !($t24)
  42: if ($t25) goto L8 else goto L9
@@ -123,42 +123,42 @@ fun SmokeTest::bool_ops(a: u64, b: u64): (bool, bool) {
  46: $t26 := 42
  47: abort($t26)
  48: L10:
- 49: $t27 := copy(c)
- 50: $t28 := copy(d)
+ 49: $t27 := copy($t2)
+ 50: $t28 := copy($t3)
  51: return ($t27, $t28)
 }
 
 
 [variant baseline]
-fun SmokeTest::borrow_global_mut_test(a: address) {
-     var r: &mut SmokeTest::R
-     var r2: &mut SmokeTest::R
+fun SmokeTest::borrow_global_mut_test($t0|a: address) {
+     var $t1|r: &mut SmokeTest::R
+     var $t2|r2: &mut SmokeTest::R
      var $t3: address
      var $t4: &mut SmokeTest::R
      var $t5: &mut SmokeTest::R
      var $t6: address
      var $t7: &mut SmokeTest::R
      var $t8: &mut SmokeTest::R
-  0: $t3 := copy(a)
+  0: $t3 := copy($t0)
   1: $t4 := borrow_global<SmokeTest::R>($t3)
-  2: r := $t4
-  3: $t5 := move(r)
+  2: $t1 := $t4
+  3: $t5 := move($t1)
   4: destroy($t5)
-  5: $t6 := copy(a)
+  5: $t6 := copy($t0)
   6: $t7 := borrow_global<SmokeTest::R>($t6)
-  7: r2 := $t7
-  8: $t8 := move(r2)
+  7: $t2 := $t7
+  8: $t8 := move($t2)
   9: destroy($t8)
  10: return ()
 }
 
 
 [variant baseline]
-fun SmokeTest::create_resource(sender: &signer) {
+fun SmokeTest::create_resource($t0|sender: &signer) {
      var $t1: &signer
      var $t2: u64
      var $t3: SmokeTest::R
-  0: $t1 := move(sender)
+  0: $t1 := move($t0)
   1: $t2 := 1
   2: $t3 := pack SmokeTest::R($t2)
   3: move_to<SmokeTest::R>($t3, $t1)
@@ -167,11 +167,11 @@ fun SmokeTest::create_resource(sender: &signer) {
 
 
 [variant baseline]
-fun SmokeTest::create_resoure_generic(sender: &signer) {
+fun SmokeTest::create_resoure_generic($t0|sender: &signer) {
      var $t1: &signer
      var $t2: u64
      var $t3: SmokeTest::G<u64>
-  0: $t1 := move(sender)
+  0: $t1 := move($t0)
   1: $t2 := 1
   2: $t3 := pack SmokeTest::G<u64>($t2)
   3: move_to<SmokeTest::G<u64>>($t3, $t1)
@@ -180,11 +180,11 @@ fun SmokeTest::create_resoure_generic(sender: &signer) {
 
 
 [variant baseline]
-fun SmokeTest::exists_resource(sender: &signer): bool {
+fun SmokeTest::exists_resource($t0|sender: &signer): bool {
      var $t1: &signer
      var $t2: address
      var $t3: bool
-  0: $t1 := move(sender)
+  0: $t1 := move($t0)
   1: $t2 := Signer::address_of($t1)
   2: $t3 := exists<SmokeTest::R>($t2)
   3: return $t3
@@ -192,28 +192,28 @@ fun SmokeTest::exists_resource(sender: &signer): bool {
 
 
 [variant baseline]
-fun SmokeTest::identity(a: SmokeTest::A, b: SmokeTest::B, c: SmokeTest::C): (SmokeTest::A, SmokeTest::B, SmokeTest::C) {
+fun SmokeTest::identity($t0|a: SmokeTest::A, $t1|b: SmokeTest::B, $t2|c: SmokeTest::C): (SmokeTest::A, SmokeTest::B, SmokeTest::C) {
      var $t3: SmokeTest::A
      var $t4: SmokeTest::B
      var $t5: SmokeTest::C
-  0: $t3 := move(a)
-  1: $t4 := move(b)
-  2: $t5 := move(c)
+  0: $t3 := move($t0)
+  1: $t4 := move($t1)
+  2: $t5 := move($t2)
   3: return ($t3, $t4, $t5)
 }
 
 
 [variant baseline]
-fun SmokeTest::move_from_addr(a: address) {
-     var r: SmokeTest::R
+fun SmokeTest::move_from_addr($t0|a: address) {
+     var $t1|r: SmokeTest::R
      var $t2: address
      var $t3: SmokeTest::R
      var $t4: SmokeTest::R
      var $t5: u64
-  0: $t2 := copy(a)
+  0: $t2 := copy($t0)
   1: $t3 := move_from<SmokeTest::R>($t2)
-  2: r := $t3
-  3: $t4 := move(r)
+  2: $t1 := $t3
+  3: $t4 := move($t1)
   4: $t5 := unpack SmokeTest::R($t4)
   5: destroy($t5)
   6: return ()
@@ -221,9 +221,9 @@ fun SmokeTest::move_from_addr(a: address) {
 
 
 [variant baseline]
-fun SmokeTest::move_from_addr_to_sender(sender: &signer, a: address) {
-     var r: SmokeTest::R
-     var x: u64
+fun SmokeTest::move_from_addr_to_sender($t0|sender: &signer, $t1|a: address) {
+     var $t2|r: SmokeTest::R
+     var $t3|x: u64
      var $t4: address
      var $t5: SmokeTest::R
      var $t6: SmokeTest::R
@@ -231,14 +231,14 @@ fun SmokeTest::move_from_addr_to_sender(sender: &signer, a: address) {
      var $t8: &signer
      var $t9: u64
      var $t10: SmokeTest::R
-  0: $t4 := copy(a)
+  0: $t4 := copy($t1)
   1: $t5 := move_from<SmokeTest::R>($t4)
-  2: r := $t5
-  3: $t6 := move(r)
+  2: $t2 := $t5
+  3: $t6 := move($t2)
   4: $t7 := unpack SmokeTest::R($t6)
-  5: x := $t7
-  6: $t8 := move(sender)
-  7: $t9 := copy(x)
+  5: $t3 := $t7
+  6: $t8 := move($t0)
+  7: $t9 := copy($t3)
   8: $t10 := pack SmokeTest::R($t9)
   9: move_to<SmokeTest::R>($t10, $t8)
  10: return ()
@@ -246,21 +246,21 @@ fun SmokeTest::move_from_addr_to_sender(sender: &signer, a: address) {
 
 
 [variant baseline]
-fun SmokeTest::pack_A(a: address, va: u64): SmokeTest::A {
+fun SmokeTest::pack_A($t0|a: address, $t1|va: u64): SmokeTest::A {
      var $t2: address
      var $t3: u64
      var $t4: SmokeTest::A
-  0: $t2 := copy(a)
-  1: $t3 := copy(va)
+  0: $t2 := copy($t0)
+  1: $t3 := copy($t1)
   2: $t4 := pack SmokeTest::A($t2, $t3)
   3: return $t4
 }
 
 
 [variant baseline]
-fun SmokeTest::pack_B(a: address, va: u64, vb: u64): SmokeTest::B {
-     var var_a: SmokeTest::A
-     var var_b: SmokeTest::B
+fun SmokeTest::pack_B($t0|a: address, $t1|va: u64, $t2|vb: u64): SmokeTest::B {
+     var $t3|var_a: SmokeTest::A
+     var $t4|var_b: SmokeTest::B
      var $t5: address
      var $t6: u64
      var $t7: SmokeTest::A
@@ -268,24 +268,24 @@ fun SmokeTest::pack_B(a: address, va: u64, vb: u64): SmokeTest::B {
      var $t9: SmokeTest::A
      var $t10: SmokeTest::B
      var $t11: SmokeTest::B
-  0: $t5 := copy(a)
-  1: $t6 := copy(va)
+  0: $t5 := copy($t0)
+  1: $t6 := copy($t1)
   2: $t7 := pack SmokeTest::A($t5, $t6)
-  3: var_a := $t7
-  4: $t8 := copy(vb)
-  5: $t9 := move(var_a)
+  3: $t3 := $t7
+  4: $t8 := copy($t2)
+  5: $t9 := move($t3)
   6: $t10 := pack SmokeTest::B($t8, $t9)
-  7: var_b := $t10
-  8: $t11 := move(var_b)
+  7: $t4 := $t10
+  8: $t11 := move($t4)
   9: return $t11
 }
 
 
 [variant baseline]
-fun SmokeTest::pack_C(a: address, va: u64, vb: u64, vc: u64): SmokeTest::C {
-     var var_a: SmokeTest::A
-     var var_b: SmokeTest::B
-     var var_c: SmokeTest::C
+fun SmokeTest::pack_C($t0|a: address, $t1|va: u64, $t2|vb: u64, $t3|vc: u64): SmokeTest::C {
+     var $t4|var_a: SmokeTest::A
+     var $t5|var_b: SmokeTest::B
+     var $t6|var_c: SmokeTest::C
      var $t7: address
      var $t8: u64
      var $t9: SmokeTest::A
@@ -296,30 +296,30 @@ fun SmokeTest::pack_C(a: address, va: u64, vb: u64, vc: u64): SmokeTest::C {
      var $t14: SmokeTest::B
      var $t15: SmokeTest::C
      var $t16: SmokeTest::C
-  0: $t7 := copy(a)
-  1: $t8 := copy(va)
+  0: $t7 := copy($t0)
+  1: $t8 := copy($t1)
   2: $t9 := pack SmokeTest::A($t7, $t8)
-  3: var_a := $t9
-  4: $t10 := copy(vb)
-  5: $t11 := move(var_a)
+  3: $t4 := $t9
+  4: $t10 := copy($t2)
+  5: $t11 := move($t4)
   6: $t12 := pack SmokeTest::B($t10, $t11)
-  7: var_b := $t12
-  8: $t13 := copy(vc)
-  9: $t14 := move(var_b)
+  7: $t5 := $t12
+  8: $t13 := copy($t3)
+  9: $t14 := move($t5)
  10: $t15 := pack SmokeTest::C($t13, $t14)
- 11: var_c := $t15
- 12: $t16 := move(var_c)
+ 11: $t6 := $t15
+ 12: $t16 := move($t6)
  13: return $t16
 }
 
 
 [variant baseline]
-fun SmokeTest::ref_A(a: address, b: bool): SmokeTest::A {
-     var b_val_ref: &u64
-     var b_var: u64
-     var tmp#$4: SmokeTest::A
-     var var_a: SmokeTest::A
-     var var_a_ref: &SmokeTest::A
+fun SmokeTest::ref_A($t0|a: address, $t1|b: bool): SmokeTest::A {
+     var $t2|b_val_ref: &u64
+     var $t3|b_var: u64
+     var $t4|tmp#$4: SmokeTest::A
+     var $t5|var_a: SmokeTest::A
+     var $t6|var_a_ref: &SmokeTest::A
      var $t7: bool
      var $t8: address
      var $t9: u64
@@ -338,34 +338,34 @@ fun SmokeTest::ref_A(a: address, b: bool): SmokeTest::A {
      var $t22: bool
      var $t23: u64
      var $t24: SmokeTest::A
-  0: $t7 := copy(b)
+  0: $t7 := copy($t1)
   1: if ($t7) goto L0 else goto L1
   2: L1:
   3: goto L2
   4: L0:
-  5: $t8 := copy(a)
+  5: $t8 := copy($t0)
   6: $t9 := 1
   7: $t10 := pack SmokeTest::A($t8, $t9)
-  8: tmp#$4 := $t10
+  8: $t4 := $t10
   9: goto L3
  10: L2:
- 11: $t11 := copy(a)
+ 11: $t11 := copy($t0)
  12: $t12 := 42
  13: $t13 := pack SmokeTest::A($t11, $t12)
- 14: tmp#$4 := $t13
+ 14: $t4 := $t13
  15: goto L3
  16: L3:
- 17: $t14 := move(tmp#$4)
- 18: var_a := $t14
- 19: $t15 := borrow_local(var_a)
- 20: var_a_ref := $t15
- 21: $t16 := move(var_a_ref)
+ 17: $t14 := move($t4)
+ 18: $t5 := $t14
+ 19: $t15 := borrow_local($t5)
+ 20: $t6 := $t15
+ 21: $t16 := move($t6)
  22: $t17 := borrow_field<SmokeTest::A>.val($t16)
- 23: b_val_ref := $t17
- 24: $t18 := move(b_val_ref)
+ 23: $t2 := $t17
+ 24: $t18 := move($t2)
  25: $t19 := read_ref($t18)
- 26: b_var := $t19
- 27: $t20 := copy(b_var)
+ 26: $t3 := $t19
+ 27: $t20 := copy($t3)
  28: $t21 := 42
  29: $t22 := !=($t20, $t21)
  30: if ($t22) goto L4 else goto L5
@@ -375,16 +375,16 @@ fun SmokeTest::ref_A(a: address, b: bool): SmokeTest::A {
  34: $t23 := 42
  35: abort($t23)
  36: L6:
- 37: $t24 := move(var_a)
+ 37: $t24 := move($t5)
  38: return $t24
 }
 
 
 [variant baseline]
-fun SmokeTest::unpack_A(a: address, va: u64): (address, u64) {
-     var aa: address
-     var v1: u64
-     var var_a: SmokeTest::A
+fun SmokeTest::unpack_A($t0|a: address, $t1|va: u64): (address, u64) {
+     var $t2|aa: address
+     var $t3|v1: u64
+     var $t4|var_a: SmokeTest::A
      var $t5: address
      var $t6: u64
      var $t7: SmokeTest::A
@@ -393,27 +393,27 @@ fun SmokeTest::unpack_A(a: address, va: u64): (address, u64) {
      var $t10: u64
      var $t11: address
      var $t12: u64
-  0: $t5 := copy(a)
-  1: $t6 := copy(va)
+  0: $t5 := copy($t0)
+  1: $t6 := copy($t1)
   2: $t7 := pack SmokeTest::A($t5, $t6)
-  3: var_a := $t7
-  4: $t8 := move(var_a)
+  3: $t4 := $t7
+  4: $t8 := move($t4)
   5: ($t9, $t10) := unpack SmokeTest::A($t8)
-  6: v1 := $t10
-  7: aa := $t9
-  8: $t11 := copy(aa)
-  9: $t12 := copy(v1)
+  6: $t3 := $t10
+  7: $t2 := $t9
+  8: $t11 := copy($t2)
+  9: $t12 := copy($t3)
  10: return ($t11, $t12)
 }
 
 
 [variant baseline]
-fun SmokeTest::unpack_B(a: address, va: u64, vb: u64): (address, u64, u64) {
-     var aa: address
-     var v1: u64
-     var v2: u64
-     var var_a: SmokeTest::A
-     var var_b: SmokeTest::B
+fun SmokeTest::unpack_B($t0|a: address, $t1|va: u64, $t2|vb: u64): (address, u64, u64) {
+     var $t3|aa: address
+     var $t4|v1: u64
+     var $t5|v2: u64
+     var $t6|var_a: SmokeTest::A
+     var $t7|var_b: SmokeTest::B
      var $t8: address
      var $t9: u64
      var $t10: SmokeTest::A
@@ -428,36 +428,36 @@ fun SmokeTest::unpack_B(a: address, va: u64, vb: u64): (address, u64, u64) {
      var $t19: address
      var $t20: u64
      var $t21: u64
-  0: $t8 := copy(a)
-  1: $t9 := copy(va)
+  0: $t8 := copy($t0)
+  1: $t9 := copy($t1)
   2: $t10 := pack SmokeTest::A($t8, $t9)
-  3: var_a := $t10
-  4: $t11 := copy(vb)
-  5: $t12 := move(var_a)
+  3: $t6 := $t10
+  4: $t11 := copy($t2)
+  5: $t12 := move($t6)
   6: $t13 := pack SmokeTest::B($t11, $t12)
-  7: var_b := $t13
-  8: $t14 := move(var_b)
+  7: $t7 := $t13
+  8: $t14 := move($t7)
   9: ($t15, $t16) := unpack SmokeTest::B($t14)
  10: ($t17, $t18) := unpack SmokeTest::A($t16)
- 11: v1 := $t18
- 12: aa := $t17
- 13: v2 := $t15
- 14: $t19 := copy(aa)
- 15: $t20 := copy(v1)
- 16: $t21 := copy(v2)
+ 11: $t4 := $t18
+ 12: $t3 := $t17
+ 13: $t5 := $t15
+ 14: $t19 := copy($t3)
+ 15: $t20 := copy($t4)
+ 16: $t21 := copy($t5)
  17: return ($t19, $t20, $t21)
 }
 
 
 [variant baseline]
-fun SmokeTest::unpack_C(a: address, va: u64, vb: u64, vc: u64): (address, u64, u64, u64) {
-     var aa: address
-     var v1: u64
-     var v2: u64
-     var v3: u64
-     var var_a: SmokeTest::A
-     var var_b: SmokeTest::B
-     var var_c: SmokeTest::C
+fun SmokeTest::unpack_C($t0|a: address, $t1|va: u64, $t2|vb: u64, $t3|vc: u64): (address, u64, u64, u64) {
+     var $t4|aa: address
+     var $t5|v1: u64
+     var $t6|v2: u64
+     var $t7|v3: u64
+     var $t8|var_a: SmokeTest::A
+     var $t9|var_b: SmokeTest::B
+     var $t10|var_c: SmokeTest::C
      var $t11: address
      var $t12: u64
      var $t13: SmokeTest::A
@@ -478,29 +478,29 @@ fun SmokeTest::unpack_C(a: address, va: u64, vb: u64, vc: u64): (address, u64, u
      var $t28: u64
      var $t29: u64
      var $t30: u64
-  0: $t11 := copy(a)
-  1: $t12 := copy(va)
+  0: $t11 := copy($t0)
+  1: $t12 := copy($t1)
   2: $t13 := pack SmokeTest::A($t11, $t12)
-  3: var_a := $t13
-  4: $t14 := copy(vb)
-  5: $t15 := move(var_a)
+  3: $t8 := $t13
+  4: $t14 := copy($t2)
+  5: $t15 := move($t8)
   6: $t16 := pack SmokeTest::B($t14, $t15)
-  7: var_b := $t16
-  8: $t17 := copy(vc)
-  9: $t18 := move(var_b)
+  7: $t9 := $t16
+  8: $t17 := copy($t3)
+  9: $t18 := move($t9)
  10: $t19 := pack SmokeTest::C($t17, $t18)
- 11: var_c := $t19
- 12: $t20 := move(var_c)
+ 11: $t10 := $t19
+ 12: $t20 := move($t10)
  13: ($t21, $t22) := unpack SmokeTest::C($t20)
  14: ($t23, $t24) := unpack SmokeTest::B($t22)
  15: ($t25, $t26) := unpack SmokeTest::A($t24)
- 16: v1 := $t26
- 17: aa := $t25
- 18: v2 := $t23
- 19: v3 := $t21
- 20: $t27 := copy(aa)
- 21: $t28 := copy(v1)
- 22: $t29 := copy(v2)
- 23: $t30 := copy(v3)
+ 16: $t5 := $t26
+ 17: $t4 := $t25
+ 18: $t6 := $t23
+ 19: $t7 := $t21
+ 20: $t27 := copy($t4)
+ 21: $t28 := copy($t5)
+ 22: $t29 := copy($t6)
+ 23: $t30 := copy($t7)
  24: return ($t27, $t28, $t29, $t30)
 }

--- a/language/move-prover/bytecode/tests/from_move/specs-in-fun.exp
+++ b/language/move-prover/bytecode/tests/from_move/specs-in-fun.exp
@@ -1,7 +1,7 @@
 ============ initial translation from Move ================
 
 [variant baseline]
-fun TestSpecBlock::looping(x: u64): u64 {
+fun TestSpecBlock::looping($t0|x: u64): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: bool
@@ -9,38 +9,38 @@ fun TestSpecBlock::looping(x: u64): u64 {
      var $t5: u64
      var $t6: u64
      var $t7: u64
-  0: spec at 592..616
+  0: assume Le($t0, 10)
   1: goto L3
   2: L3:
-  3: $t1 := copy(x)
+  3: $t1 := copy($t0)
   4: $t2 := 10
   5: $t3 := <($t1, $t2)
   6: if ($t3) goto L0 else goto L1
   7: L1:
   8: goto L2
   9: L0:
- 10: spec at 653..676
- 11: $t4 := copy(x)
+ 10: assume Lt($t0, 10)
+ 11: $t4 := copy($t0)
  12: $t5 := 1
  13: $t6 := +($t4, $t5)
- 14: x := $t6
+ 14: $t0 := $t6
  15: goto L3
  16: L2:
- 17: spec at 718..742
- 18: $t7 := copy(x)
+ 17: assert Eq<u64>($t0, 10)
+ 18: $t7 := copy($t0)
  19: return $t7
 }
 
 
 [variant baseline]
-fun TestSpecBlock::simple1(x: u64, y: u64) {
+fun TestSpecBlock::simple1($t0|x: u64, $t1|y: u64) {
      var $t2: u64
      var $t3: u64
      var $t4: bool
      var $t5: bool
      var $t6: u64
-  0: $t2 := copy(x)
-  1: $t3 := copy(y)
+  0: $t2 := copy($t0)
+  1: $t3 := copy($t1)
   2: $t4 := >($t2, $t3)
   3: $t5 := !($t4)
   4: if ($t5) goto L0 else goto L1
@@ -50,43 +50,45 @@ fun TestSpecBlock::simple1(x: u64, y: u64) {
   8: $t6 := 1
   9: abort($t6)
  10: L2:
- 11: spec at 97..139
+ 11: assert Gt($t0, $t1)
  12: return ()
 }
 
 
 [variant baseline]
-fun TestSpecBlock::simple2(x: u64) {
-     var y: u64
+fun TestSpecBlock::simple2($t0|x: u64) {
+     var $t1|y: u64
      var $t2: u64
      var $t3: u64
      var $t4: u64
-  0: $t2 := copy(x)
+  0: $t2 := copy($t0)
   1: $t3 := 1
   2: $t4 := +($t2, $t3)
-  3: y := $t4
-  4: spec at 220..267
+  3: $t1 := $t4
+  4: assert Eq<u64>($t0, Sub($t1, 1))
   5: return ()
 }
 
 
 [variant baseline]
-fun TestSpecBlock::simple3(x: u64, y: u64) {
-  0: spec at 317..386
-  1: return ()
+fun TestSpecBlock::simple3($t0|x: u64, $t1|y: u64) {
+  0: assume Gt($t0, $t1)
+  1: assert Ge($t0, $t1)
+  2: return ()
 }
 
 
 [variant baseline]
-fun TestSpecBlock::simple4(x: u64, y: u64) {
-     var z: u64
+fun TestSpecBlock::simple4($t0|x: u64, $t1|y: u64) {
+     var $t2|z: u64
      var $t3: u64
      var $t4: u64
      var $t5: u64
-  0: $t3 := copy(x)
-  1: $t4 := copy(y)
+  0: $t3 := copy($t0)
+  1: $t4 := copy($t1)
   2: $t5 := +($t3, $t4)
-  3: z := $t5
-  4: spec at 475..545
-  5: return ()
+  3: $t2 := $t5
+  4: assume Gt($t0, $t1)
+  5: assert Gt($t2, Mul(2, $t1))
+  6: return ()
 }

--- a/language/move-prover/bytecode/tests/livevar/basic_test.exp
+++ b/language/move-prover/bytecode/tests/livevar/basic_test.exp
@@ -1,26 +1,26 @@
 ============ initial translation from Move ================
 
 [variant baseline]
-fun TestLiveVars::test1(r_ref: &TestLiveVars::R): u64 {
-     var x_ref: &u64
+fun TestLiveVars::test1($t0|r_ref: &TestLiveVars::R): u64 {
+     var $t1|x_ref: &u64
      var $t2: &TestLiveVars::R
      var $t3: &u64
      var $t4: &u64
      var $t5: u64
-  0: $t2 := move(r_ref)
+  0: $t2 := move($t0)
   1: $t3 := borrow_field<TestLiveVars::R>.x($t2)
-  2: x_ref := $t3
-  3: $t4 := move(x_ref)
+  2: $t1 := $t3
+  3: $t4 := move($t1)
   4: $t5 := read_ref($t4)
   5: return $t5
 }
 
 
 [variant baseline]
-fun TestLiveVars::test2(b: bool): u64 {
-     var r1: TestLiveVars::R
-     var r2: TestLiveVars::R
-     var r_ref: &TestLiveVars::R
+fun TestLiveVars::test2($t0|b: bool): u64 {
+     var $t1|r1: TestLiveVars::R
+     var $t2|r2: TestLiveVars::R
+     var $t3|r_ref: &TestLiveVars::R
      var $t4: u64
      var $t5: TestLiveVars::R
      var $t6: u64
@@ -33,33 +33,33 @@ fun TestLiveVars::test2(b: bool): u64 {
      var $t13: u64
   0: $t4 := 3
   1: $t5 := pack TestLiveVars::R($t4)
-  2: r1 := $t5
+  2: $t1 := $t5
   3: $t6 := 4
   4: $t7 := pack TestLiveVars::R($t6)
-  5: r2 := $t7
-  6: $t8 := borrow_local(r1)
-  7: r_ref := $t8
-  8: $t9 := copy(b)
+  5: $t2 := $t7
+  6: $t8 := borrow_local($t1)
+  7: $t3 := $t8
+  8: $t9 := copy($t0)
   9: if ($t9) goto L0 else goto L1
  10: L1:
  11: goto L2
  12: L0:
- 13: $t10 := move(r_ref)
+ 13: $t10 := move($t3)
  14: destroy($t10)
- 15: $t11 := borrow_local(r2)
- 16: r_ref := $t11
+ 15: $t11 := borrow_local($t2)
+ 16: $t3 := $t11
  17: goto L2
  18: L2:
- 19: $t12 := move(r_ref)
+ 19: $t12 := move($t3)
  20: $t13 := TestLiveVars::test1($t12)
  21: return $t13
 }
 
 
 [variant baseline]
-fun TestLiveVars::test3(n: u64, r_ref: &TestLiveVars::R): u64 {
-     var r1: TestLiveVars::R
-     var r2: TestLiveVars::R
+fun TestLiveVars::test3($t0|n: u64, $t1|r_ref: &TestLiveVars::R): u64 {
+     var $t2|r1: TestLiveVars::R
+     var $t3|r2: TestLiveVars::R
      var $t4: u64
      var $t5: TestLiveVars::R
      var $t6: u64
@@ -82,22 +82,22 @@ fun TestLiveVars::test3(n: u64, r_ref: &TestLiveVars::R): u64 {
      var $t23: u64
   0: $t4 := 3
   1: $t5 := pack TestLiveVars::R($t4)
-  2: r1 := $t5
+  2: $t2 := $t5
   3: $t6 := 4
   4: $t7 := pack TestLiveVars::R($t6)
-  5: r2 := $t7
+  5: $t3 := $t7
   6: goto L7
   7: L7:
   8: $t8 := 0
-  9: $t9 := copy(n)
+  9: $t9 := copy($t0)
  10: $t10 := <($t8, $t9)
  11: if ($t10) goto L0 else goto L1
  12: L1:
  13: goto L2
  14: L0:
- 15: $t11 := move(r_ref)
+ 15: $t11 := move($t1)
  16: destroy($t11)
- 17: $t12 := copy(n)
+ 17: $t12 := copy($t0)
  18: $t13 := 2
  19: $t14 := /($t12, $t13)
  20: $t15 := 0
@@ -106,21 +106,21 @@ fun TestLiveVars::test3(n: u64, r_ref: &TestLiveVars::R): u64 {
  23: L4:
  24: goto L5
  25: L3:
- 26: $t17 := borrow_local(r1)
- 27: r_ref := $t17
+ 26: $t17 := borrow_local($t2)
+ 27: $t1 := $t17
  28: goto L6
  29: L5:
- 30: $t18 := borrow_local(r2)
- 31: r_ref := $t18
+ 30: $t18 := borrow_local($t3)
+ 31: $t1 := $t18
  32: goto L6
  33: L6:
- 34: $t19 := copy(n)
+ 34: $t19 := copy($t0)
  35: $t20 := 1
  36: $t21 := -($t19, $t20)
- 37: n := $t21
+ 37: $t0 := $t21
  38: goto L7
  39: L2:
- 40: $t22 := move(r_ref)
+ 40: $t22 := move($t1)
  41: $t23 := TestLiveVars::test1($t22)
  42: return $t23
 }
@@ -128,39 +128,39 @@ fun TestLiveVars::test3(n: u64, r_ref: &TestLiveVars::R): u64 {
 ============ after pipeline `livevar` ================
 
 [variant baseline]
-fun TestLiveVars::test1(r_ref: TestLiveVars::R): u64 {
-     var x_ref: u64
+fun TestLiveVars::test1($t0|r_ref: TestLiveVars::R): u64 {
+     var $t1|x_ref: u64
      var $t2: TestLiveVars::R
      // live vars: r_ref
-  0: $t2 := move(r_ref)
+  0: $t2 := move($t0)
      // live vars: $t2
-  1: x_ref := get_field<TestLiveVars::R>.x($t2)
+  1: $t1 := get_field<TestLiveVars::R>.x($t2)
      // live vars: x_ref
-  2: return x_ref
+  2: return $t1
 }
 
 
 [variant baseline]
-fun TestLiveVars::test2(b: bool): u64 {
-     var r1: TestLiveVars::R
-     var r2: TestLiveVars::R
-     var r_ref: TestLiveVars::R
+fun TestLiveVars::test2($t0|b: bool): u64 {
+     var $t1|r1: TestLiveVars::R
+     var $t2|r2: TestLiveVars::R
+     var $t3|r_ref: TestLiveVars::R
      var $t4: bool
      var $t5: u64
      var $t6: u64
      var $t7: u64
      // live vars: b
-  0: $t4 := move(b)
+  0: $t4 := move($t0)
      // live vars: $t4
   1: $t5 := 3
      // live vars: $t4, $t5
-  2: r1 := pack TestLiveVars::R($t5)
+  2: $t1 := pack TestLiveVars::R($t5)
      // live vars: r1, $t4
   3: $t6 := 4
      // live vars: r1, $t4, $t6
-  4: r2 := pack TestLiveVars::R($t6)
+  4: $t2 := pack TestLiveVars::R($t6)
      // live vars: r1, r2, $t4
-  5: r_ref := r1
+  5: $t3 := $t1
      // live vars: r2, r_ref, $t4
   6: if ($t4) goto L0 else goto L1
      // live vars: r_ref
@@ -170,24 +170,24 @@ fun TestLiveVars::test2(b: bool): u64 {
      // live vars: r2, r_ref
   9: L0:
      // live vars: r2, r_ref
- 10: destroy(r_ref)
+ 10: destroy($t3)
      // live vars: r2
- 11: r_ref := r2
+ 11: $t3 := $t2
      // live vars: r_ref
  12: goto L2
      // live vars: r_ref
  13: L2:
      // live vars: r_ref
- 14: $t7 := TestLiveVars::test1(r_ref)
+ 14: $t7 := TestLiveVars::test1($t3)
      // live vars: $t7
  15: return $t7
 }
 
 
 [variant baseline]
-fun TestLiveVars::test3(n: u64, r_ref: TestLiveVars::R): u64 {
-     var r1: TestLiveVars::R
-     var r2: TestLiveVars::R
+fun TestLiveVars::test3($t0|n: u64, $t1|r_ref: TestLiveVars::R): u64 {
+     var $t2|r1: TestLiveVars::R
+     var $t3|r2: TestLiveVars::R
      var $t4: u64
      var $t5: TestLiveVars::R
      var $t6: u64
@@ -201,17 +201,17 @@ fun TestLiveVars::test3(n: u64, r_ref: TestLiveVars::R): u64 {
      var $t14: u64
      var $t15: u64
      // live vars: n, r_ref
-  0: $t4 := move(n)
+  0: $t4 := move($t0)
      // live vars: r_ref, $t4
-  1: $t5 := move(r_ref)
+  1: $t5 := move($t1)
      // live vars: $t4, $t5
   2: $t6 := 3
      // live vars: $t4, $t5, $t6
-  3: r1 := pack TestLiveVars::R($t6)
+  3: $t2 := pack TestLiveVars::R($t6)
      // live vars: r1, $t4, $t5
   4: $t7 := 4
      // live vars: r1, $t4, $t5, $t7
-  5: r2 := pack TestLiveVars::R($t7)
+  5: $t3 := pack TestLiveVars::R($t7)
      // live vars: r1, r2, $t4, $t5
   6: goto L7
      // live vars: r1, r2, $t4, $t5
@@ -247,13 +247,13 @@ fun TestLiveVars::test3(n: u64, r_ref: TestLiveVars::R): u64 {
      // live vars: r1, r2, $t4
  22: L3:
      // live vars: r1, r2, $t4
- 23: $t5 := r1
+ 23: $t5 := $t2
      // live vars: r1, r2, $t4, $t5
  24: goto L6
      // live vars: r1, r2, $t4
  25: L5:
      // live vars: r1, r2, $t4
- 26: $t5 := r2
+ 26: $t5 := $t3
      // live vars: r1, r2, $t4, $t5
  27: goto L6
      // live vars: r1, r2, $t4, $t5

--- a/language/move-prover/bytecode/tests/livevar/mut_ref_unpack.exp
+++ b/language/move-prover/bytecode/tests/livevar/mut_ref_unpack.exp
@@ -1,10 +1,10 @@
 ============ initial translation from Move ================
 
 [variant baseline]
-pub fun TestMutRefs::unpack(r: &mut TestMutRefs::R): u64 {
-     var result: u64
-     var tmp#$2: &mut TestMutRefs::R
-     var value: &mut u64
+pub fun TestMutRefs::unpack($t0|r: &mut TestMutRefs::R): u64 {
+     var $t1|result: u64
+     var $t2|tmp#$2: &mut TestMutRefs::R
+     var $t3|value: &mut u64
      var $t4: &mut TestMutRefs::R
      var $t5: &mut TestMutRefs::R
      var $t6: &mut u64
@@ -13,87 +13,87 @@ pub fun TestMutRefs::unpack(r: &mut TestMutRefs::R): u64 {
      var $t9: u64
      var $t10: &mut u64
      var $t11: u64
-  0: $t4 := move(r)
-  1: tmp#$2 := $t4
-  2: $t5 := move(tmp#$2)
+  0: $t4 := move($t0)
+  1: $t2 := $t4
+  2: $t5 := move($t2)
   3: $t6 := borrow_field<TestMutRefs::R>.value($t5)
-  4: value := $t6
-  5: $t7 := copy(value)
+  4: $t3 := $t6
+  5: $t7 := copy($t3)
   6: $t8 := read_ref($t7)
-  7: result := $t8
+  7: $t1 := $t8
   8: $t9 := 0
-  9: $t10 := move(value)
+  9: $t10 := move($t3)
  10: write_ref($t10, $t9)
- 11: $t11 := copy(result)
+ 11: $t11 := copy($t1)
  12: return $t11
 }
 
 
 [variant baseline]
-pub fun TestMutRefs::unpack_incorrect(r: &mut TestMutRefs::R): u64 {
-     var result: u64
-     var tmp#$2: &mut TestMutRefs::R
-     var value: &mut u64
+pub fun TestMutRefs::unpack_incorrect($t0|r: &mut TestMutRefs::R): u64 {
+     var $t1|result: u64
+     var $t2|tmp#$2: &mut TestMutRefs::R
+     var $t3|value: &mut u64
      var $t4: &mut TestMutRefs::R
      var $t5: &mut TestMutRefs::R
      var $t6: &mut u64
      var $t7: &mut u64
      var $t8: u64
      var $t9: u64
-  0: $t4 := move(r)
-  1: tmp#$2 := $t4
-  2: $t5 := move(tmp#$2)
+  0: $t4 := move($t0)
+  1: $t2 := $t4
+  2: $t5 := move($t2)
   3: $t6 := borrow_field<TestMutRefs::R>.value($t5)
-  4: value := $t6
-  5: $t7 := move(value)
+  4: $t3 := $t6
+  5: $t7 := move($t3)
   6: $t8 := read_ref($t7)
-  7: result := $t8
-  8: $t9 := copy(result)
+  7: $t1 := $t8
+  8: $t9 := copy($t1)
   9: return $t9
 }
 
 ============ after pipeline `livevar` ================
 
 [variant baseline]
-pub fun TestMutRefs::unpack(r: TestMutRefs::R): (u64, TestMutRefs::R) {
-     var result: u64
-     var tmp#$2: &mut TestMutRefs::R
-     var value: &mut u64
+pub fun TestMutRefs::unpack($t0|r: TestMutRefs::R): (u64, TestMutRefs::R) {
+     var $t1|result: u64
+     var $t2|tmp#$2: &mut TestMutRefs::R
+     var $t3|value: &mut u64
      var $t4: TestMutRefs::R
      var $t5: &mut TestMutRefs::R
      var $t6: u64
      // live vars: r
-  0: $t4 := move(r)
+  0: $t4 := move($t0)
      // live vars: $t4
   1: $t5 := borrow_local($t4)
      // live vars: $t4, $t5
-  2: value := borrow_field<TestMutRefs::R>.value($t5)
+  2: $t3 := borrow_field<TestMutRefs::R>.value($t5)
      // live vars: value, $t4
-  3: result := read_ref(value)
+  3: $t1 := read_ref($t3)
      // live vars: result, value, $t4
   4: $t6 := 0
      // live vars: result, value, $t4, $t6
-  5: write_ref(value, $t6)
+  5: write_ref($t3, $t6)
      // live vars: result, $t4
-  6: return (result, $t4)
+  6: return ($t1, $t4)
 }
 
 
 [variant baseline]
-pub fun TestMutRefs::unpack_incorrect(r: TestMutRefs::R): (u64, TestMutRefs::R) {
-     var result: u64
-     var tmp#$2: &mut TestMutRefs::R
-     var value: &mut u64
+pub fun TestMutRefs::unpack_incorrect($t0|r: TestMutRefs::R): (u64, TestMutRefs::R) {
+     var $t1|result: u64
+     var $t2|tmp#$2: &mut TestMutRefs::R
+     var $t3|value: &mut u64
      var $t4: TestMutRefs::R
      var $t5: &mut TestMutRefs::R
      // live vars: r
-  0: $t4 := move(r)
+  0: $t4 := move($t0)
      // live vars: $t4
   1: $t5 := borrow_local($t4)
      // live vars: $t4, $t5
-  2: value := borrow_field<TestMutRefs::R>.value($t5)
+  2: $t3 := borrow_field<TestMutRefs::R>.value($t5)
      // live vars: value, $t4
-  3: result := read_ref(value)
+  3: $t1 := read_ref($t3)
      // live vars: result, $t4
-  4: return (result, $t4)
+  4: return ($t1, $t4)
 }

--- a/language/move-prover/bytecode/tests/memory_instr/basic_test.exp
+++ b/language/move-prover/bytecode/tests/memory_instr/basic_test.exp
@@ -2,9 +2,9 @@
 
 [variant baseline]
 fun TestPackref::test1(): TestPackref::R {
-     var r: TestPackref::R
-     var r_ref: &mut TestPackref::R
-     var x_ref: &mut u64
+     var $t0|r: TestPackref::R
+     var $t1|r_ref: &mut TestPackref::R
+     var $t2|x_ref: &mut u64
      var $t3: u64
      var $t4: TestPackref::R
      var $t5: &mut TestPackref::R
@@ -15,43 +15,43 @@ fun TestPackref::test1(): TestPackref::R {
      var $t10: TestPackref::R
   0: $t3 := 3
   1: $t4 := pack TestPackref::R($t3)
-  2: r := $t4
-  3: $t5 := borrow_local(r)
-  4: r_ref := $t5
-  5: $t6 := move(r_ref)
+  2: $t0 := $t4
+  3: $t5 := borrow_local($t0)
+  4: $t1 := $t5
+  5: $t6 := move($t1)
   6: $t7 := borrow_field<TestPackref::R>.x($t6)
-  7: x_ref := $t7
+  7: $t2 := $t7
   8: $t8 := 0
-  9: $t9 := move(x_ref)
+  9: $t9 := move($t2)
  10: write_ref($t9, $t8)
- 11: $t10 := move(r)
+ 11: $t10 := move($t0)
  12: return $t10
 }
 
 
 [variant baseline]
-fun TestPackref::test2(x_ref: &mut u64, v: u64) {
+fun TestPackref::test2($t0|x_ref: &mut u64, $t1|v: u64) {
      var $t2: u64
      var $t3: &mut u64
-  0: $t2 := copy(v)
-  1: $t3 := move(x_ref)
+  0: $t2 := copy($t1)
+  1: $t3 := move($t0)
   2: write_ref($t3, $t2)
   3: return ()
 }
 
 
 [variant baseline]
-pub fun TestPackref::test3(r_ref: &mut TestPackref::R, v: u64) {
-     var x_ref: &mut u64
+pub fun TestPackref::test3($t0|r_ref: &mut TestPackref::R, $t1|v: u64) {
+     var $t2|x_ref: &mut u64
      var $t3: &mut TestPackref::R
      var $t4: &mut u64
      var $t5: &mut u64
      var $t6: u64
-  0: $t3 := move(r_ref)
+  0: $t3 := move($t0)
   1: $t4 := borrow_field<TestPackref::R>.x($t3)
-  2: x_ref := $t4
-  3: $t5 := move(x_ref)
-  4: $t6 := copy(v)
+  2: $t2 := $t4
+  3: $t5 := move($t2)
+  4: $t6 := copy($t1)
   5: TestPackref::test2($t5, $t6)
   6: return ()
 }
@@ -59,8 +59,8 @@ pub fun TestPackref::test3(r_ref: &mut TestPackref::R, v: u64) {
 
 [variant baseline]
 fun TestPackref::test4(): TestPackref::R {
-     var r: TestPackref::R
-     var r_ref: &mut TestPackref::R
+     var $t0|r: TestPackref::R
+     var $t1|r_ref: &mut TestPackref::R
      var $t2: u64
      var $t3: TestPackref::R
      var $t4: &mut TestPackref::R
@@ -69,22 +69,22 @@ fun TestPackref::test4(): TestPackref::R {
      var $t7: TestPackref::R
   0: $t2 := 3
   1: $t3 := pack TestPackref::R($t2)
-  2: r := $t3
-  3: $t4 := borrow_local(r)
-  4: r_ref := $t4
-  5: $t5 := move(r_ref)
+  2: $t0 := $t3
+  3: $t4 := borrow_local($t0)
+  4: $t1 := $t4
+  5: $t5 := move($t1)
   6: $t6 := 0
   7: TestPackref::test3($t5, $t6)
-  8: $t7 := move(r)
+  8: $t7 := move($t0)
   9: return $t7
 }
 
 
 [variant baseline]
-pub fun TestPackref::test5(r_ref: &mut TestPackref::R): &mut u64 {
+pub fun TestPackref::test5($t0|r_ref: &mut TestPackref::R): &mut u64 {
      var $t1: &mut TestPackref::R
      var $t2: &mut u64
-  0: $t1 := move(r_ref)
+  0: $t1 := move($t0)
   1: $t2 := borrow_field<TestPackref::R>.x($t1)
   2: return $t2
 }
@@ -92,9 +92,9 @@ pub fun TestPackref::test5(r_ref: &mut TestPackref::R): &mut u64 {
 
 [variant baseline]
 fun TestPackref::test6(): TestPackref::R {
-     var r: TestPackref::R
-     var r_ref: &mut TestPackref::R
-     var x_ref: &mut u64
+     var $t0|r: TestPackref::R
+     var $t1|r_ref: &mut TestPackref::R
+     var $t2|x_ref: &mut u64
      var $t3: u64
      var $t4: TestPackref::R
      var $t5: &mut TestPackref::R
@@ -105,25 +105,25 @@ fun TestPackref::test6(): TestPackref::R {
      var $t10: TestPackref::R
   0: $t3 := 3
   1: $t4 := pack TestPackref::R($t3)
-  2: r := $t4
-  3: $t5 := borrow_local(r)
-  4: r_ref := $t5
-  5: $t6 := move(r_ref)
+  2: $t0 := $t4
+  3: $t5 := borrow_local($t0)
+  4: $t1 := $t5
+  5: $t6 := move($t1)
   6: $t7 := TestPackref::test5($t6)
-  7: x_ref := $t7
-  8: $t8 := move(x_ref)
+  7: $t2 := $t7
+  8: $t8 := move($t2)
   9: $t9 := 0
  10: TestPackref::test2($t8, $t9)
- 11: $t10 := move(r)
+ 11: $t10 := move($t0)
  12: return $t10
 }
 
 
 [variant baseline]
-fun TestPackref::test7(b: bool) {
-     var r1: TestPackref::R
-     var r2: TestPackref::R
-     var r_ref: &mut TestPackref::R
+fun TestPackref::test7($t0|b: bool) {
+     var $t1|r1: TestPackref::R
+     var $t2|r2: TestPackref::R
+     var $t3|r_ref: &mut TestPackref::R
      var $t4: u64
      var $t5: TestPackref::R
      var $t6: u64
@@ -136,24 +136,24 @@ fun TestPackref::test7(b: bool) {
      var $t13: u64
   0: $t4 := 3
   1: $t5 := pack TestPackref::R($t4)
-  2: r1 := $t5
+  2: $t1 := $t5
   3: $t6 := 4
   4: $t7 := pack TestPackref::R($t6)
-  5: r2 := $t7
-  6: $t8 := borrow_local(r1)
-  7: r_ref := $t8
-  8: $t9 := copy(b)
+  5: $t2 := $t7
+  6: $t8 := borrow_local($t1)
+  7: $t3 := $t8
+  8: $t9 := copy($t0)
   9: if ($t9) goto L0 else goto L1
  10: L1:
  11: goto L2
  12: L0:
- 13: $t10 := move(r_ref)
+ 13: $t10 := move($t3)
  14: destroy($t10)
- 15: $t11 := borrow_local(r2)
- 16: r_ref := $t11
+ 15: $t11 := borrow_local($t2)
+ 16: $t3 := $t11
  17: goto L2
  18: L2:
- 19: $t12 := move(r_ref)
+ 19: $t12 := move($t3)
  20: $t13 := 0
  21: TestPackref::test3($t12, $t13)
  22: return ()
@@ -161,10 +161,10 @@ fun TestPackref::test7(b: bool) {
 
 
 [variant baseline]
-fun TestPackref::test8(b: bool, n: u64, r_ref: &mut TestPackref::R) {
-     var r1: TestPackref::R
-     var r2: TestPackref::R
-     var t_ref: &mut TestPackref::R
+fun TestPackref::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestPackref::R) {
+     var $t3|r1: TestPackref::R
+     var $t4|r2: TestPackref::R
+     var $t5|t_ref: &mut TestPackref::R
      var $t6: u64
      var $t7: TestPackref::R
      var $t8: u64
@@ -193,24 +193,24 @@ fun TestPackref::test8(b: bool, n: u64, r_ref: &mut TestPackref::R) {
      var $t31: u64
   0: $t6 := 3
   1: $t7 := pack TestPackref::R($t6)
-  2: r1 := $t7
+  2: $t3 := $t7
   3: $t8 := 4
   4: $t9 := pack TestPackref::R($t8)
-  5: r2 := $t9
-  6: $t10 := borrow_local(r2)
-  7: t_ref := $t10
+  5: $t4 := $t9
+  6: $t10 := borrow_local($t4)
+  7: $t5 := $t10
   8: goto L7
   9: L7:
  10: $t11 := 0
- 11: $t12 := copy(n)
+ 11: $t12 := copy($t1)
  12: $t13 := <($t11, $t12)
  13: if ($t13) goto L0 else goto L1
  14: L1:
  15: goto L2
  16: L0:
- 17: $t14 := move(t_ref)
+ 17: $t14 := move($t5)
  18: destroy($t14)
- 19: $t15 := copy(n)
+ 19: $t15 := copy($t1)
  20: $t16 := 2
  21: $t17 := /($t15, $t16)
  22: $t18 := 0
@@ -219,35 +219,35 @@ fun TestPackref::test8(b: bool, n: u64, r_ref: &mut TestPackref::R) {
  25: L4:
  26: goto L5
  27: L3:
- 28: $t20 := borrow_local(r1)
- 29: t_ref := $t20
+ 28: $t20 := borrow_local($t3)
+ 29: $t5 := $t20
  30: goto L6
  31: L5:
- 32: $t21 := borrow_local(r2)
- 33: t_ref := $t21
+ 32: $t21 := borrow_local($t4)
+ 33: $t5 := $t21
  34: goto L6
  35: L6:
- 36: $t22 := copy(n)
+ 36: $t22 := copy($t1)
  37: $t23 := 1
  38: $t24 := -($t22, $t23)
- 39: n := $t24
+ 39: $t1 := $t24
  40: goto L7
  41: L2:
- 42: $t25 := copy(b)
+ 42: $t25 := copy($t0)
  43: if ($t25) goto L8 else goto L9
  44: L9:
  45: goto L10
  46: L8:
- 47: $t26 := move(t_ref)
+ 47: $t26 := move($t5)
  48: destroy($t26)
- 49: $t27 := move(r_ref)
+ 49: $t27 := move($t2)
  50: $t28 := 0
  51: TestPackref::test3($t27, $t28)
  52: goto L11
  53: L10:
- 54: $t29 := move(r_ref)
+ 54: $t29 := move($t2)
  55: destroy($t29)
- 56: $t30 := move(t_ref)
+ 56: $t30 := move($t5)
  57: $t31 := 0
  58: TestPackref::test3($t30, $t31)
  59: goto L11
@@ -259,34 +259,34 @@ fun TestPackref::test8(b: bool, n: u64, r_ref: &mut TestPackref::R) {
 
 [variant baseline]
 fun TestPackref::test1(): TestPackref::R {
-     var r: TestPackref::R
-     var r_ref: &mut TestPackref::R
-     var x_ref: &mut u64
+     var $t0|r: TestPackref::R
+     var $t1|r_ref: &mut TestPackref::R
+     var $t2|x_ref: &mut u64
      var $t3: u64
      var $t4: u64
   0: $t3 := 3
-  1: r := pack TestPackref::R($t3)
-  2: r_ref := borrow_local(r)
-  3: unpack_ref(r_ref)
-  4: x_ref := borrow_field<TestPackref::R>.x(r_ref)
-  5: unpack_ref(x_ref)
+  1: $t0 := pack TestPackref::R($t3)
+  2: $t1 := borrow_local($t0)
+  3: unpack_ref($t1)
+  4: $t2 := borrow_field<TestPackref::R>.x($t1)
+  5: unpack_ref($t2)
   6: $t4 := 0
-  7: write_ref(x_ref, $t4)
-  8: pack_ref(x_ref)
-  9: write_back[Reference(r_ref)](x_ref)
- 10: pack_ref(r_ref)
- 11: write_back[LocalRoot(r)](r_ref)
- 12: return r
+  7: write_ref($t2, $t4)
+  8: pack_ref($t2)
+  9: write_back[Reference($t1)]($t2)
+ 10: pack_ref($t1)
+ 11: write_back[LocalRoot($t0)]($t1)
+ 12: return $t0
 }
 
 
 [variant baseline]
-fun TestPackref::test2(x_ref: u64, v: u64): u64 {
+fun TestPackref::test2($t0|x_ref: u64, $t1|v: u64): u64 {
      var $t2: u64
      var $t3: u64
      var $t4: &mut u64
-  0: $t2 := move(x_ref)
-  1: $t3 := move(v)
+  0: $t2 := move($t0)
+  1: $t3 := move($t1)
   2: $t4 := borrow_local($t2)
   3: write_ref($t4, $t3)
   4: write_back[LocalRoot($t2)]($t4)
@@ -295,23 +295,23 @@ fun TestPackref::test2(x_ref: u64, v: u64): u64 {
 
 
 [variant baseline]
-pub fun TestPackref::test3(r_ref: TestPackref::R, v: u64): TestPackref::R {
-     var x_ref: &mut u64
+pub fun TestPackref::test3($t0|r_ref: TestPackref::R, $t1|v: u64): TestPackref::R {
+     var $t2|x_ref: &mut u64
      var $t3: TestPackref::R
      var $t4: u64
      var $t5: &mut TestPackref::R
      var $t6: u64
-  0: $t3 := move(r_ref)
-  1: $t4 := move(v)
+  0: $t3 := move($t0)
+  1: $t4 := move($t1)
   2: $t5 := borrow_local($t3)
   3: unpack_ref($t5)
-  4: x_ref := borrow_field<TestPackref::R>.x($t5)
-  5: unpack_ref(x_ref)
-  6: $t6 := read_ref(x_ref)
+  4: $t2 := borrow_field<TestPackref::R>.x($t5)
+  5: unpack_ref($t2)
+  6: $t6 := read_ref($t2)
   7: $t6 := TestPackref::test2($t6, $t4)
-  8: write_ref(x_ref, $t6)
-  9: pack_ref(x_ref)
- 10: write_back[Reference($t5)](x_ref)
+  8: write_ref($t2, $t6)
+  9: pack_ref($t2)
+ 10: write_back[Reference($t5)]($t2)
  11: pack_ref($t5)
  12: write_back[LocalRoot($t3)]($t5)
  13: return $t3
@@ -320,31 +320,31 @@ pub fun TestPackref::test3(r_ref: TestPackref::R, v: u64): TestPackref::R {
 
 [variant baseline]
 fun TestPackref::test4(): TestPackref::R {
-     var r: TestPackref::R
-     var r_ref: &mut TestPackref::R
+     var $t0|r: TestPackref::R
+     var $t1|r_ref: &mut TestPackref::R
      var $t2: u64
      var $t3: u64
      var $t4: TestPackref::R
   0: $t2 := 3
-  1: r := pack TestPackref::R($t2)
-  2: r_ref := borrow_local(r)
-  3: unpack_ref(r_ref)
+  1: $t0 := pack TestPackref::R($t2)
+  2: $t1 := borrow_local($t0)
+  3: unpack_ref($t1)
   4: $t3 := 0
-  5: $t4 := read_ref(r_ref)
+  5: $t4 := read_ref($t1)
   6: $t4 := TestPackref::test3($t4, $t3)
-  7: write_ref(r_ref, $t4)
-  8: pack_ref(r_ref)
-  9: write_back[LocalRoot(r)](r_ref)
- 10: return r
+  7: write_ref($t1, $t4)
+  8: pack_ref($t1)
+  9: write_back[LocalRoot($t0)]($t1)
+ 10: return $t0
 }
 
 
 [variant baseline]
-pub fun TestPackref::test5(r_ref: TestPackref::R): (&mut u64, TestPackref::R) {
+pub fun TestPackref::test5($t0|r_ref: TestPackref::R): (&mut u64, TestPackref::R) {
      var $t1: TestPackref::R
      var $t2: &mut TestPackref::R
      var $t3: &mut u64
-  0: $t1 := move(r_ref)
+  0: $t1 := move($t0)
   1: $t2 := borrow_local($t1)
   2: $t3 := borrow_field<TestPackref::R>.x($t2)
   3: write_back[Reference($t2)]($t3)
@@ -355,79 +355,79 @@ pub fun TestPackref::test5(r_ref: TestPackref::R): (&mut u64, TestPackref::R) {
 
 [variant baseline]
 fun TestPackref::test6(): TestPackref::R {
-     var r: TestPackref::R
-     var r_ref: &mut TestPackref::R
-     var x_ref: &mut u64
+     var $t0|r: TestPackref::R
+     var $t1|r_ref: &mut TestPackref::R
+     var $t2|x_ref: &mut u64
      var $t3: u64
      var $t4: TestPackref::R
      var $t5: &mut u64
      var $t6: u64
      var $t7: u64
   0: $t3 := 3
-  1: r := pack TestPackref::R($t3)
-  2: r_ref := borrow_local(r)
-  3: unpack_ref_deep(r_ref)
-  4: $t4 := read_ref(r_ref)
+  1: $t0 := pack TestPackref::R($t3)
+  2: $t1 := borrow_local($t0)
+  3: unpack_ref_deep($t1)
+  4: $t4 := read_ref($t1)
   5: ($t5, $t4) := TestPackref::test5($t4)
-  6: write_ref(r_ref, $t4)
-  7: splice[0 -> r_ref]($t5)
-  8: x_ref := $t5
-  9: write_back[Reference(r_ref)]($t5)
+  6: write_ref($t1, $t4)
+  7: splice[0 -> $t1]($t5)
+  8: $t2 := $t5
+  9: write_back[Reference($t1)]($t5)
  10: $t6 := 0
- 11: $t7 := read_ref(x_ref)
+ 11: $t7 := read_ref($t2)
  12: $t7 := TestPackref::test2($t7, $t6)
- 13: write_ref(x_ref, $t7)
- 14: write_back[Reference(r_ref)](x_ref)
- 15: pack_ref_deep(r_ref)
- 16: write_back[LocalRoot(r)](r_ref)
- 17: return r
+ 13: write_ref($t2, $t7)
+ 14: write_back[Reference($t1)]($t2)
+ 15: pack_ref_deep($t1)
+ 16: write_back[LocalRoot($t0)]($t1)
+ 17: return $t0
 }
 
 
 [variant baseline]
-fun TestPackref::test7(b: bool) {
-     var r1: TestPackref::R
-     var r2: TestPackref::R
-     var r_ref: &mut TestPackref::R
+fun TestPackref::test7($t0|b: bool) {
+     var $t1|r1: TestPackref::R
+     var $t2|r2: TestPackref::R
+     var $t3|r_ref: &mut TestPackref::R
      var $t4: bool
      var $t5: u64
      var $t6: u64
      var $t7: u64
      var $t8: TestPackref::R
-  0: $t4 := move(b)
+  0: $t4 := move($t0)
   1: $t5 := 3
-  2: r1 := pack TestPackref::R($t5)
+  2: $t1 := pack TestPackref::R($t5)
   3: $t6 := 4
-  4: r2 := pack TestPackref::R($t6)
-  5: r_ref := borrow_local(r1)
-  6: unpack_ref(r_ref)
+  4: $t2 := pack TestPackref::R($t6)
+  5: $t3 := borrow_local($t1)
+  6: unpack_ref($t3)
   7: if ($t4) goto L0 else goto L1
   8: L1:
   9: goto L2
  10: L0:
- 11: destroy(r_ref)
- 12: pack_ref(r_ref)
- 13: write_back[LocalRoot(r1)](r_ref)
- 14: r_ref := borrow_local(r2)
- 15: unpack_ref(r_ref)
+ 11: destroy($t3)
+ 12: pack_ref($t3)
+ 13: write_back[LocalRoot($t1)]($t3)
+ 14: $t3 := borrow_local($t2)
+ 15: unpack_ref($t3)
  16: goto L2
  17: L2:
  18: $t7 := 0
- 19: $t8 := read_ref(r_ref)
+ 19: $t8 := read_ref($t3)
  20: $t8 := TestPackref::test3($t8, $t7)
- 21: write_ref(r_ref, $t8)
- 22: pack_ref(r_ref)
- 23: write_back[LocalRoot(r1)](r_ref)
- 24: write_back[LocalRoot(r2)](r_ref)
+ 21: write_ref($t3, $t8)
+ 22: pack_ref($t3)
+ 23: write_back[LocalRoot($t1)]($t3)
+ 24: write_back[LocalRoot($t2)]($t3)
  25: return ()
 }
 
 
 [variant baseline]
-fun TestPackref::test8(b: bool, n: u64, r_ref: TestPackref::R): TestPackref::R {
-     var r1: TestPackref::R
-     var r2: TestPackref::R
-     var t_ref: &mut TestPackref::R
+fun TestPackref::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: TestPackref::R): TestPackref::R {
+     var $t3|r1: TestPackref::R
+     var $t4|r2: TestPackref::R
+     var $t5|t_ref: &mut TestPackref::R
      var $t6: bool
      var $t7: u64
      var $t8: TestPackref::R
@@ -444,16 +444,16 @@ fun TestPackref::test8(b: bool, n: u64, r_ref: TestPackref::R): TestPackref::R {
      var $t19: u64
      var $t20: TestPackref::R
      var $t21: u64
-  0: $t6 := move(b)
-  1: $t7 := move(n)
-  2: $t8 := move(r_ref)
+  0: $t6 := move($t0)
+  1: $t7 := move($t1)
+  2: $t8 := move($t2)
   3: $t9 := borrow_local($t8)
   4: $t10 := 3
-  5: r1 := pack TestPackref::R($t10)
+  5: $t3 := pack TestPackref::R($t10)
   6: $t11 := 4
-  7: r2 := pack TestPackref::R($t11)
-  8: t_ref := borrow_local(r2)
-  9: unpack_ref(t_ref)
+  7: $t4 := pack TestPackref::R($t11)
+  8: $t5 := borrow_local($t4)
+  9: unpack_ref($t5)
  10: goto L7
  11: L7:
  12: $t12 := 0
@@ -462,10 +462,10 @@ fun TestPackref::test8(b: bool, n: u64, r_ref: TestPackref::R): TestPackref::R {
  15: L1:
  16: goto L2
  17: L0:
- 18: destroy(t_ref)
- 19: pack_ref(t_ref)
- 20: write_back[LocalRoot(r1)](t_ref)
- 21: write_back[LocalRoot(r2)](t_ref)
+ 18: destroy($t5)
+ 19: pack_ref($t5)
+ 20: write_back[LocalRoot($t3)]($t5)
+ 21: write_back[LocalRoot($t4)]($t5)
  22: $t14 := 2
  23: $t15 := /($t7, $t14)
  24: $t16 := 0
@@ -474,12 +474,12 @@ fun TestPackref::test8(b: bool, n: u64, r_ref: TestPackref::R): TestPackref::R {
  27: L4:
  28: goto L5
  29: L3:
- 30: t_ref := borrow_local(r1)
- 31: unpack_ref(t_ref)
+ 30: $t5 := borrow_local($t3)
+ 31: unpack_ref($t5)
  32: goto L6
  33: L5:
- 34: t_ref := borrow_local(r2)
- 35: unpack_ref(t_ref)
+ 34: $t5 := borrow_local($t4)
+ 35: unpack_ref($t5)
  36: goto L6
  37: L6:
  38: $t18 := 1
@@ -490,10 +490,10 @@ fun TestPackref::test8(b: bool, n: u64, r_ref: TestPackref::R): TestPackref::R {
  43: L9:
  44: goto L10
  45: L8:
- 46: destroy(t_ref)
- 47: pack_ref(t_ref)
- 48: write_back[LocalRoot(r1)](t_ref)
- 49: write_back[LocalRoot(r2)](t_ref)
+ 46: destroy($t5)
+ 47: pack_ref($t5)
+ 48: write_back[LocalRoot($t3)]($t5)
+ 49: write_back[LocalRoot($t4)]($t5)
  50: $t19 := 0
  51: $t20 := read_ref($t9)
  52: $t20 := TestPackref::test3($t20, $t19)
@@ -504,12 +504,12 @@ fun TestPackref::test8(b: bool, n: u64, r_ref: TestPackref::R): TestPackref::R {
  57: destroy($t9)
  58: write_back[LocalRoot($t8)]($t9)
  59: $t21 := 0
- 60: $t20 := read_ref(t_ref)
+ 60: $t20 := read_ref($t5)
  61: $t20 := TestPackref::test3($t20, $t21)
- 62: write_ref(t_ref, $t20)
- 63: pack_ref(t_ref)
- 64: write_back[LocalRoot(r1)](t_ref)
- 65: write_back[LocalRoot(r2)](t_ref)
+ 62: write_ref($t5, $t20)
+ 63: pack_ref($t5)
+ 64: write_back[LocalRoot($t3)]($t5)
+ 65: write_back[LocalRoot($t4)]($t5)
  66: goto L11
  67: L11:
  68: return $t8

--- a/language/move-prover/bytecode/tests/memory_instr/mut_ref.exp
+++ b/language/move-prover/bytecode/tests/memory_instr/mut_ref.exp
@@ -1,14 +1,14 @@
 ============ initial translation from Move ================
 
 [variant baseline]
-pub fun TestMutRefs::data_invariant(_x: &mut TestMutRefs::T) {
+pub fun TestMutRefs::data_invariant($t0|_x: &mut TestMutRefs::T) {
   0: return ()
 }
 
 
 [variant baseline]
-pub fun TestMutRefs::decrement_invalid(x: &mut TestMutRefs::T) {
-     var r: &mut TestMutRefs::TSum
+pub fun TestMutRefs::decrement_invalid($t0|x: &mut TestMutRefs::T) {
+     var $t1|r: &mut TestMutRefs::TSum
      var $t2: &mut TestMutRefs::T
      var $t3: &u64
      var $t4: u64
@@ -25,23 +25,23 @@ pub fun TestMutRefs::decrement_invalid(x: &mut TestMutRefs::T) {
      var $t15: u64
      var $t16: &mut TestMutRefs::TSum
      var $t17: &mut u64
-  0: $t2 := copy(x)
+  0: $t2 := copy($t0)
   1: $t3 := borrow_field<TestMutRefs::T>.value($t2)
   2: $t4 := read_ref($t3)
   3: $t5 := 1
   4: $t6 := -($t4, $t5)
-  5: $t7 := move(x)
+  5: $t7 := move($t0)
   6: $t8 := borrow_field<TestMutRefs::T>.value($t7)
   7: write_ref($t8, $t6)
   8: $t9 := 0x0
   9: $t10 := borrow_global<TestMutRefs::TSum>($t9)
- 10: r := $t10
- 11: $t11 := copy(r)
+ 10: $t1 := $t10
+ 11: $t11 := copy($t1)
  12: $t12 := borrow_field<TestMutRefs::TSum>.sum($t11)
  13: $t13 := read_ref($t12)
  14: $t14 := 1
  15: $t15 := -($t13, $t14)
- 16: $t16 := move(r)
+ 16: $t16 := move($t1)
  17: $t17 := borrow_field<TestMutRefs::TSum>.sum($t16)
  18: write_ref($t17, $t15)
  19: return ()
@@ -49,9 +49,9 @@ pub fun TestMutRefs::decrement_invalid(x: &mut TestMutRefs::T) {
 
 
 [variant baseline]
-pub fun TestMutRefs::delete(x: TestMutRefs::T) {
-     var r: &mut TestMutRefs::TSum
-     var v: u64
+pub fun TestMutRefs::delete($t0|x: TestMutRefs::T) {
+     var $t1|r: &mut TestMutRefs::TSum
+     var $t2|v: u64
      var $t3: address
      var $t4: &mut TestMutRefs::TSum
      var $t5: TestMutRefs::T
@@ -65,16 +65,16 @@ pub fun TestMutRefs::delete(x: TestMutRefs::T) {
      var $t13: &mut u64
   0: $t3 := 0x0
   1: $t4 := borrow_global<TestMutRefs::TSum>($t3)
-  2: r := $t4
-  3: $t5 := move(x)
+  2: $t1 := $t4
+  3: $t5 := move($t0)
   4: $t6 := unpack TestMutRefs::T($t5)
-  5: v := $t6
-  6: $t7 := copy(r)
+  5: $t2 := $t6
+  6: $t7 := copy($t1)
   7: $t8 := borrow_field<TestMutRefs::TSum>.sum($t7)
   8: $t9 := read_ref($t8)
-  9: $t10 := copy(v)
+  9: $t10 := copy($t2)
  10: $t11 := -($t9, $t10)
- 11: $t12 := move(r)
+ 11: $t12 := move($t1)
  12: $t13 := borrow_field<TestMutRefs::TSum>.sum($t12)
  13: write_ref($t13, $t11)
  14: return ()
@@ -82,8 +82,8 @@ pub fun TestMutRefs::delete(x: TestMutRefs::T) {
 
 
 [variant baseline]
-pub fun TestMutRefs::increment(x: &mut TestMutRefs::T) {
-     var r: &mut TestMutRefs::TSum
+pub fun TestMutRefs::increment($t0|x: &mut TestMutRefs::T) {
+     var $t1|r: &mut TestMutRefs::TSum
      var $t2: &mut TestMutRefs::T
      var $t3: &u64
      var $t4: u64
@@ -100,23 +100,23 @@ pub fun TestMutRefs::increment(x: &mut TestMutRefs::T) {
      var $t15: u64
      var $t16: &mut TestMutRefs::TSum
      var $t17: &mut u64
-  0: $t2 := copy(x)
+  0: $t2 := copy($t0)
   1: $t3 := borrow_field<TestMutRefs::T>.value($t2)
   2: $t4 := read_ref($t3)
   3: $t5 := 1
   4: $t6 := +($t4, $t5)
-  5: $t7 := move(x)
+  5: $t7 := move($t0)
   6: $t8 := borrow_field<TestMutRefs::T>.value($t7)
   7: write_ref($t8, $t6)
   8: $t9 := 0x0
   9: $t10 := borrow_global<TestMutRefs::TSum>($t9)
- 10: r := $t10
- 11: $t11 := copy(r)
+ 10: $t1 := $t10
+ 11: $t11 := copy($t1)
  12: $t12 := borrow_field<TestMutRefs::TSum>.sum($t11)
  13: $t13 := read_ref($t12)
  14: $t14 := 1
  15: $t15 := +($t13, $t14)
- 16: $t16 := move(r)
+ 16: $t16 := move($t1)
  17: $t17 := borrow_field<TestMutRefs::TSum>.sum($t16)
  18: write_ref($t17, $t15)
  19: return ()
@@ -124,7 +124,7 @@ pub fun TestMutRefs::increment(x: &mut TestMutRefs::T) {
 
 
 [variant baseline]
-pub fun TestMutRefs::increment_invalid(x: &mut TestMutRefs::T) {
+pub fun TestMutRefs::increment_invalid($t0|x: &mut TestMutRefs::T) {
      var $t1: &mut TestMutRefs::T
      var $t2: &u64
      var $t3: u64
@@ -132,12 +132,12 @@ pub fun TestMutRefs::increment_invalid(x: &mut TestMutRefs::T) {
      var $t5: u64
      var $t6: &mut TestMutRefs::T
      var $t7: &mut u64
-  0: $t1 := copy(x)
+  0: $t1 := copy($t0)
   1: $t2 := borrow_field<TestMutRefs::T>.value($t1)
   2: $t3 := read_ref($t2)
   3: $t4 := 1
   4: $t5 := +($t3, $t4)
-  5: $t6 := move(x)
+  5: $t6 := move($t0)
   6: $t7 := borrow_field<TestMutRefs::T>.value($t6)
   7: write_ref($t7, $t5)
   8: return ()
@@ -145,8 +145,8 @@ pub fun TestMutRefs::increment_invalid(x: &mut TestMutRefs::T) {
 
 
 [variant baseline]
-pub fun TestMutRefs::new(x: u64): TestMutRefs::T {
-     var r: &mut TestMutRefs::TSum
+pub fun TestMutRefs::new($t0|x: u64): TestMutRefs::T {
+     var $t1|r: &mut TestMutRefs::TSum
      var $t2: address
      var $t3: &mut TestMutRefs::TSum
      var $t4: &mut TestMutRefs::TSum
@@ -160,30 +160,30 @@ pub fun TestMutRefs::new(x: u64): TestMutRefs::T {
      var $t12: TestMutRefs::T
   0: $t2 := 0x0
   1: $t3 := borrow_global<TestMutRefs::TSum>($t2)
-  2: r := $t3
-  3: $t4 := copy(r)
+  2: $t1 := $t3
+  3: $t4 := copy($t1)
   4: $t5 := borrow_field<TestMutRefs::TSum>.sum($t4)
   5: $t6 := read_ref($t5)
-  6: $t7 := copy(x)
+  6: $t7 := copy($t0)
   7: $t8 := +($t6, $t7)
-  8: $t9 := move(r)
+  8: $t9 := move($t1)
   9: $t10 := borrow_field<TestMutRefs::TSum>.sum($t9)
  10: write_ref($t10, $t8)
- 11: $t11 := copy(x)
+ 11: $t11 := copy($t0)
  12: $t12 := pack TestMutRefs::T($t11)
  13: return $t12
 }
 
 
 [variant baseline]
-fun TestMutRefs::private_data_invariant_invalid(_x: &mut TestMutRefs::T) {
+fun TestMutRefs::private_data_invariant_invalid($t0|_x: &mut TestMutRefs::T) {
   0: return ()
 }
 
 
 [variant baseline]
-fun TestMutRefs::private_decrement(x: &mut TestMutRefs::T) {
-     var r: &mut TestMutRefs::TSum
+fun TestMutRefs::private_decrement($t0|x: &mut TestMutRefs::T) {
+     var $t1|r: &mut TestMutRefs::TSum
      var $t2: &mut TestMutRefs::T
      var $t3: &u64
      var $t4: u64
@@ -200,23 +200,23 @@ fun TestMutRefs::private_decrement(x: &mut TestMutRefs::T) {
      var $t15: u64
      var $t16: &mut TestMutRefs::TSum
      var $t17: &mut u64
-  0: $t2 := copy(x)
+  0: $t2 := copy($t0)
   1: $t3 := borrow_field<TestMutRefs::T>.value($t2)
   2: $t4 := read_ref($t3)
   3: $t5 := 1
   4: $t6 := -($t4, $t5)
-  5: $t7 := move(x)
+  5: $t7 := move($t0)
   6: $t8 := borrow_field<TestMutRefs::T>.value($t7)
   7: write_ref($t8, $t6)
   8: $t9 := 0x0
   9: $t10 := borrow_global<TestMutRefs::TSum>($t9)
- 10: r := $t10
- 11: $t11 := copy(r)
+ 10: $t1 := $t10
+ 11: $t11 := copy($t1)
  12: $t12 := borrow_field<TestMutRefs::TSum>.sum($t11)
  13: $t13 := read_ref($t12)
  14: $t14 := 1
  15: $t15 := -($t13, $t14)
- 16: $t16 := move(r)
+ 16: $t16 := move($t1)
  17: $t17 := borrow_field<TestMutRefs::TSum>.sum($t16)
  18: write_ref($t17, $t15)
  19: return ()
@@ -224,9 +224,9 @@ fun TestMutRefs::private_decrement(x: &mut TestMutRefs::T) {
 
 
 [variant baseline]
-fun TestMutRefs::private_to_public_caller(r: &mut TestMutRefs::T) {
+fun TestMutRefs::private_to_public_caller($t0|r: &mut TestMutRefs::T) {
      var $t1: &mut TestMutRefs::T
-  0: $t1 := move(r)
+  0: $t1 := move($t0)
   1: TestMutRefs::increment($t1)
   2: return ()
 }
@@ -234,8 +234,8 @@ fun TestMutRefs::private_to_public_caller(r: &mut TestMutRefs::T) {
 
 [variant baseline]
 fun TestMutRefs::private_to_public_caller_invalid_data_invariant() {
-     var r: &mut TestMutRefs::T
-     var x: TestMutRefs::T
+     var $t0|r: &mut TestMutRefs::T
+     var $t1|x: TestMutRefs::T
      var $t2: u64
      var $t3: TestMutRefs::T
      var $t4: &mut TestMutRefs::T
@@ -243,12 +243,12 @@ fun TestMutRefs::private_to_public_caller_invalid_data_invariant() {
      var $t6: &mut TestMutRefs::T
   0: $t2 := 1
   1: $t3 := TestMutRefs::new($t2)
-  2: x := $t3
-  3: $t4 := borrow_local(x)
-  4: r := $t4
-  5: $t5 := copy(r)
+  2: $t1 := $t3
+  3: $t4 := borrow_local($t1)
+  4: $t0 := $t4
+  5: $t5 := copy($t0)
   6: TestMutRefs::private_decrement($t5)
-  7: $t6 := move(r)
+  7: $t6 := move($t0)
   8: TestMutRefs::increment($t6)
   9: return ()
 }
@@ -256,17 +256,17 @@ fun TestMutRefs::private_to_public_caller_invalid_data_invariant() {
 
 [variant baseline]
 pub fun TestMutRefsUser::valid() {
-     var x: TestMutRefs::T
+     var $t0|x: TestMutRefs::T
      var $t1: u64
      var $t2: TestMutRefs::T
      var $t3: &mut TestMutRefs::T
      var $t4: TestMutRefs::T
   0: $t1 := 4
   1: $t2 := TestMutRefs::new($t1)
-  2: x := $t2
-  3: $t3 := borrow_local(x)
+  2: $t0 := $t2
+  3: $t3 := borrow_local($t0)
   4: TestMutRefs::increment($t3)
-  5: $t4 := move(x)
+  5: $t4 := move($t0)
   6: TestMutRefs::delete($t4)
   7: return ()
 }
@@ -274,18 +274,18 @@ pub fun TestMutRefsUser::valid() {
 ============ after pipeline `memory_instr` ================
 
 [variant baseline]
-pub fun TestMutRefs::data_invariant(_x: TestMutRefs::T): TestMutRefs::T {
+pub fun TestMutRefs::data_invariant($t0|_x: TestMutRefs::T): TestMutRefs::T {
      var $t1: TestMutRefs::T
      var $t2: &mut TestMutRefs::T
-  0: $t1 := move(_x)
+  0: $t1 := move($t0)
   1: $t2 := borrow_local($t1)
   2: return $t1
 }
 
 
 [variant baseline]
-pub fun TestMutRefs::decrement_invalid(x: TestMutRefs::T): TestMutRefs::T {
-     var r: &mut TestMutRefs::TSum
+pub fun TestMutRefs::decrement_invalid($t0|x: TestMutRefs::T): TestMutRefs::T {
+     var $t1|r: &mut TestMutRefs::TSum
      var $t2: TestMutRefs::T
      var $t3: &mut TestMutRefs::T
      var $t4: u64
@@ -297,7 +297,7 @@ pub fun TestMutRefs::decrement_invalid(x: TestMutRefs::T): TestMutRefs::T {
      var $t10: u64
      var $t11: u64
      var $t12: &mut u64
-  0: $t2 := move(x)
+  0: $t2 := move($t0)
   1: $t3 := borrow_local($t2)
   2: unpack_ref($t3)
   3: $t4 := get_field<TestMutRefs::T>.value($t3)
@@ -311,52 +311,52 @@ pub fun TestMutRefs::decrement_invalid(x: TestMutRefs::T): TestMutRefs::T {
  11: pack_ref($t3)
  12: write_back[LocalRoot($t2)]($t3)
  13: $t8 := 0x0
- 14: r := borrow_global<TestMutRefs::TSum>($t8)
- 15: unpack_ref(r)
- 16: $t9 := get_field<TestMutRefs::TSum>.sum(r)
+ 14: $t1 := borrow_global<TestMutRefs::TSum>($t8)
+ 15: unpack_ref($t1)
+ 16: $t9 := get_field<TestMutRefs::TSum>.sum($t1)
  17: $t10 := 1
  18: $t11 := -($t9, $t10)
- 19: $t12 := borrow_field<TestMutRefs::TSum>.sum(r)
+ 19: $t12 := borrow_field<TestMutRefs::TSum>.sum($t1)
  20: unpack_ref($t12)
  21: write_ref($t12, $t11)
  22: pack_ref($t12)
- 23: write_back[Reference(r)]($t12)
- 24: pack_ref(r)
- 25: write_back[TestMutRefs::TSum](r)
+ 23: write_back[Reference($t1)]($t12)
+ 24: pack_ref($t1)
+ 25: write_back[TestMutRefs::TSum]($t1)
  26: return $t2
 }
 
 
 [variant baseline]
-pub fun TestMutRefs::delete(x: TestMutRefs::T) {
-     var r: &mut TestMutRefs::TSum
-     var v: u64
+pub fun TestMutRefs::delete($t0|x: TestMutRefs::T) {
+     var $t1|r: &mut TestMutRefs::TSum
+     var $t2|v: u64
      var $t3: TestMutRefs::T
      var $t4: address
      var $t5: u64
      var $t6: u64
      var $t7: &mut u64
-  0: $t3 := move(x)
+  0: $t3 := move($t0)
   1: $t4 := 0x0
-  2: r := borrow_global<TestMutRefs::TSum>($t4)
-  3: unpack_ref(r)
-  4: v := unpack TestMutRefs::T($t3)
-  5: $t5 := get_field<TestMutRefs::TSum>.sum(r)
-  6: $t6 := -($t5, v)
-  7: $t7 := borrow_field<TestMutRefs::TSum>.sum(r)
+  2: $t1 := borrow_global<TestMutRefs::TSum>($t4)
+  3: unpack_ref($t1)
+  4: $t2 := unpack TestMutRefs::T($t3)
+  5: $t5 := get_field<TestMutRefs::TSum>.sum($t1)
+  6: $t6 := -($t5, $t2)
+  7: $t7 := borrow_field<TestMutRefs::TSum>.sum($t1)
   8: unpack_ref($t7)
   9: write_ref($t7, $t6)
  10: pack_ref($t7)
- 11: write_back[Reference(r)]($t7)
- 12: pack_ref(r)
- 13: write_back[TestMutRefs::TSum](r)
+ 11: write_back[Reference($t1)]($t7)
+ 12: pack_ref($t1)
+ 13: write_back[TestMutRefs::TSum]($t1)
  14: return ()
 }
 
 
 [variant baseline]
-pub fun TestMutRefs::increment(x: TestMutRefs::T): TestMutRefs::T {
-     var r: &mut TestMutRefs::TSum
+pub fun TestMutRefs::increment($t0|x: TestMutRefs::T): TestMutRefs::T {
+     var $t1|r: &mut TestMutRefs::TSum
      var $t2: TestMutRefs::T
      var $t3: &mut TestMutRefs::T
      var $t4: u64
@@ -368,7 +368,7 @@ pub fun TestMutRefs::increment(x: TestMutRefs::T): TestMutRefs::T {
      var $t10: u64
      var $t11: u64
      var $t12: &mut u64
-  0: $t2 := move(x)
+  0: $t2 := move($t0)
   1: $t3 := borrow_local($t2)
   2: unpack_ref($t3)
   3: $t4 := get_field<TestMutRefs::T>.value($t3)
@@ -382,31 +382,31 @@ pub fun TestMutRefs::increment(x: TestMutRefs::T): TestMutRefs::T {
  11: pack_ref($t3)
  12: write_back[LocalRoot($t2)]($t3)
  13: $t8 := 0x0
- 14: r := borrow_global<TestMutRefs::TSum>($t8)
- 15: unpack_ref(r)
- 16: $t9 := get_field<TestMutRefs::TSum>.sum(r)
+ 14: $t1 := borrow_global<TestMutRefs::TSum>($t8)
+ 15: unpack_ref($t1)
+ 16: $t9 := get_field<TestMutRefs::TSum>.sum($t1)
  17: $t10 := 1
  18: $t11 := +($t9, $t10)
- 19: $t12 := borrow_field<TestMutRefs::TSum>.sum(r)
+ 19: $t12 := borrow_field<TestMutRefs::TSum>.sum($t1)
  20: unpack_ref($t12)
  21: write_ref($t12, $t11)
  22: pack_ref($t12)
- 23: write_back[Reference(r)]($t12)
- 24: pack_ref(r)
- 25: write_back[TestMutRefs::TSum](r)
+ 23: write_back[Reference($t1)]($t12)
+ 24: pack_ref($t1)
+ 25: write_back[TestMutRefs::TSum]($t1)
  26: return $t2
 }
 
 
 [variant baseline]
-pub fun TestMutRefs::increment_invalid(x: TestMutRefs::T): TestMutRefs::T {
+pub fun TestMutRefs::increment_invalid($t0|x: TestMutRefs::T): TestMutRefs::T {
      var $t1: TestMutRefs::T
      var $t2: &mut TestMutRefs::T
      var $t3: u64
      var $t4: u64
      var $t5: u64
      var $t6: &mut u64
-  0: $t1 := move(x)
+  0: $t1 := move($t0)
   1: $t2 := borrow_local($t1)
   2: unpack_ref($t2)
   3: $t3 := get_field<TestMutRefs::T>.value($t2)
@@ -424,45 +424,45 @@ pub fun TestMutRefs::increment_invalid(x: TestMutRefs::T): TestMutRefs::T {
 
 
 [variant baseline]
-pub fun TestMutRefs::new(x: u64): TestMutRefs::T {
-     var r: &mut TestMutRefs::TSum
+pub fun TestMutRefs::new($t0|x: u64): TestMutRefs::T {
+     var $t1|r: &mut TestMutRefs::TSum
      var $t2: u64
      var $t3: address
      var $t4: u64
      var $t5: u64
      var $t6: &mut u64
      var $t7: TestMutRefs::T
-  0: $t2 := move(x)
+  0: $t2 := move($t0)
   1: $t3 := 0x0
-  2: r := borrow_global<TestMutRefs::TSum>($t3)
-  3: unpack_ref(r)
-  4: $t4 := get_field<TestMutRefs::TSum>.sum(r)
+  2: $t1 := borrow_global<TestMutRefs::TSum>($t3)
+  3: unpack_ref($t1)
+  4: $t4 := get_field<TestMutRefs::TSum>.sum($t1)
   5: $t5 := +($t4, $t2)
-  6: $t6 := borrow_field<TestMutRefs::TSum>.sum(r)
+  6: $t6 := borrow_field<TestMutRefs::TSum>.sum($t1)
   7: unpack_ref($t6)
   8: write_ref($t6, $t5)
   9: pack_ref($t6)
- 10: write_back[Reference(r)]($t6)
- 11: pack_ref(r)
- 12: write_back[TestMutRefs::TSum](r)
+ 10: write_back[Reference($t1)]($t6)
+ 11: pack_ref($t1)
+ 12: write_back[TestMutRefs::TSum]($t1)
  13: $t7 := pack TestMutRefs::T($t2)
  14: return $t7
 }
 
 
 [variant baseline]
-fun TestMutRefs::private_data_invariant_invalid(_x: TestMutRefs::T): TestMutRefs::T {
+fun TestMutRefs::private_data_invariant_invalid($t0|_x: TestMutRefs::T): TestMutRefs::T {
      var $t1: TestMutRefs::T
      var $t2: &mut TestMutRefs::T
-  0: $t1 := move(_x)
+  0: $t1 := move($t0)
   1: $t2 := borrow_local($t1)
   2: return $t1
 }
 
 
 [variant baseline]
-fun TestMutRefs::private_decrement(x: TestMutRefs::T): TestMutRefs::T {
-     var r: &mut TestMutRefs::TSum
+fun TestMutRefs::private_decrement($t0|x: TestMutRefs::T): TestMutRefs::T {
+     var $t1|r: &mut TestMutRefs::TSum
      var $t2: TestMutRefs::T
      var $t3: &mut TestMutRefs::T
      var $t4: u64
@@ -474,7 +474,7 @@ fun TestMutRefs::private_decrement(x: TestMutRefs::T): TestMutRefs::T {
      var $t10: u64
      var $t11: u64
      var $t12: &mut u64
-  0: $t2 := move(x)
+  0: $t2 := move($t0)
   1: $t3 := borrow_local($t2)
   2: $t4 := get_field<TestMutRefs::T>.value($t3)
   3: $t5 := 1
@@ -484,28 +484,28 @@ fun TestMutRefs::private_decrement(x: TestMutRefs::T): TestMutRefs::T {
   7: write_back[Reference($t3)]($t7)
   8: write_back[LocalRoot($t2)]($t3)
   9: $t8 := 0x0
- 10: r := borrow_global<TestMutRefs::TSum>($t8)
- 11: unpack_ref(r)
- 12: $t9 := get_field<TestMutRefs::TSum>.sum(r)
+ 10: $t1 := borrow_global<TestMutRefs::TSum>($t8)
+ 11: unpack_ref($t1)
+ 12: $t9 := get_field<TestMutRefs::TSum>.sum($t1)
  13: $t10 := 1
  14: $t11 := -($t9, $t10)
- 15: $t12 := borrow_field<TestMutRefs::TSum>.sum(r)
+ 15: $t12 := borrow_field<TestMutRefs::TSum>.sum($t1)
  16: unpack_ref($t12)
  17: write_ref($t12, $t11)
  18: pack_ref($t12)
- 19: write_back[Reference(r)]($t12)
- 20: pack_ref(r)
- 21: write_back[TestMutRefs::TSum](r)
+ 19: write_back[Reference($t1)]($t12)
+ 20: pack_ref($t1)
+ 21: write_back[TestMutRefs::TSum]($t1)
  22: return $t2
 }
 
 
 [variant baseline]
-fun TestMutRefs::private_to_public_caller(r: TestMutRefs::T): TestMutRefs::T {
+fun TestMutRefs::private_to_public_caller($t0|r: TestMutRefs::T): TestMutRefs::T {
      var $t1: TestMutRefs::T
      var $t2: &mut TestMutRefs::T
      var $t3: TestMutRefs::T
-  0: $t1 := move(r)
+  0: $t1 := move($t0)
   1: $t2 := borrow_local($t1)
   2: $t3 := read_ref($t2)
   3: $t3 := TestMutRefs::increment($t3)
@@ -517,41 +517,41 @@ fun TestMutRefs::private_to_public_caller(r: TestMutRefs::T): TestMutRefs::T {
 
 [variant baseline]
 fun TestMutRefs::private_to_public_caller_invalid_data_invariant() {
-     var r: &mut TestMutRefs::T
-     var x: TestMutRefs::T
+     var $t0|r: &mut TestMutRefs::T
+     var $t1|x: TestMutRefs::T
      var $t2: u64
      var $t3: TestMutRefs::T
   0: $t2 := 1
-  1: x := TestMutRefs::new($t2)
-  2: r := borrow_local(x)
-  3: unpack_ref(r)
-  4: $t3 := read_ref(r)
+  1: $t1 := TestMutRefs::new($t2)
+  2: $t0 := borrow_local($t1)
+  3: unpack_ref($t0)
+  4: $t3 := read_ref($t0)
   5: $t3 := TestMutRefs::private_decrement($t3)
-  6: write_ref(r, $t3)
-  7: $t3 := read_ref(r)
+  6: write_ref($t0, $t3)
+  7: $t3 := read_ref($t0)
   8: $t3 := TestMutRefs::increment($t3)
-  9: write_ref(r, $t3)
- 10: pack_ref(r)
- 11: write_back[LocalRoot(x)](r)
+  9: write_ref($t0, $t3)
+ 10: pack_ref($t0)
+ 11: write_back[LocalRoot($t1)]($t0)
  12: return ()
 }
 
 
 [variant baseline]
 pub fun TestMutRefsUser::valid() {
-     var x: TestMutRefs::T
+     var $t0|x: TestMutRefs::T
      var $t1: u64
      var $t2: &mut TestMutRefs::T
      var $t3: TestMutRefs::T
   0: $t1 := 4
-  1: x := TestMutRefs::new($t1)
-  2: $t2 := borrow_local(x)
+  1: $t0 := TestMutRefs::new($t1)
+  2: $t2 := borrow_local($t0)
   3: unpack_ref($t2)
   4: $t3 := read_ref($t2)
   5: $t3 := TestMutRefs::increment($t3)
   6: write_ref($t2, $t3)
   7: pack_ref($t2)
-  8: write_back[LocalRoot(x)]($t2)
-  9: TestMutRefs::delete(x)
+  8: write_back[LocalRoot($t0)]($t2)
+  9: TestMutRefs::delete($t0)
  10: return ()
 }

--- a/language/move-prover/bytecode/tests/reaching_def/basic_test.exp
+++ b/language/move-prover/bytecode/tests/reaching_def/basic_test.exp
@@ -1,8 +1,8 @@
 ============ initial translation from Move ================
 
 [variant baseline]
-fun ReachingDefTest::basic(a: u64, b: u64): u64 {
-     var x: u64
+fun ReachingDefTest::basic($t0|a: u64, $t1|b: u64): u64 {
+     var $t2|x: u64
      var $t3: u64
      var $t4: u64
      var $t5: u64
@@ -11,13 +11,13 @@ fun ReachingDefTest::basic(a: u64, b: u64): u64 {
      var $t8: u64
      var $t9: u64
      var $t10: u64
-  0: $t3 := copy(a)
-  1: $t4 := copy(b)
+  0: $t3 := copy($t0)
+  1: $t4 := copy($t1)
   2: $t5 := +($t3, $t4)
-  3: $t6 := copy(a)
+  3: $t6 := copy($t0)
   4: $t7 := /($t5, $t6)
-  5: x := $t7
-  6: $t8 := copy(x)
+  5: $t2 := $t7
+  6: $t8 := copy($t2)
   7: $t9 := 1
   8: $t10 := +($t8, $t9)
   9: return $t10
@@ -25,13 +25,13 @@ fun ReachingDefTest::basic(a: u64, b: u64): u64 {
 
 
 [variant baseline]
-fun ReachingDefTest::create_resource(sender: &signer) {
-     var r: ReachingDefTest::R
+fun ReachingDefTest::create_resource($t0|sender: &signer) {
+     var $t1|r: ReachingDefTest::R
      var $t2: &signer
      var $t3: u64
      var $t4: bool
      var $t5: ReachingDefTest::R
-  0: $t2 := move(sender)
+  0: $t2 := move($t0)
   1: $t3 := 1
   2: $t4 := false
   3: $t5 := pack ReachingDefTest::R($t3, $t4)
@@ -42,8 +42,8 @@ fun ReachingDefTest::create_resource(sender: &signer) {
 ============ after pipeline `reaching_def` ================
 
 [variant baseline]
-fun ReachingDefTest::basic(a: u64, b: u64): u64 {
-     var x: u64
+fun ReachingDefTest::basic($t0|a: u64, $t1|b: u64): u64 {
+     var $t2|x: u64
      var $t3: u64
      var $t4: u64
      var $t5: u64
@@ -54,30 +54,30 @@ fun ReachingDefTest::basic(a: u64, b: u64): u64 {
      var $t10: u64
      var $t11: u64
      var $t12: u64
-  0: $t11 := move(a)
-  1: $t12 := move(b)
+  0: $t11 := move($t0)
+  1: $t12 := move($t1)
   2: $t3 := copy($t11)
   3: $t4 := copy($t12)
   4: $t5 := +($t11, $t12)
   5: $t6 := copy($t11)
   6: $t7 := /($t5, $t11)
-  7: x := $t7
-  8: $t8 := copy(x)
+  7: $t2 := $t7
+  8: $t8 := copy($t2)
   9: $t9 := 1
- 10: $t10 := +(x, $t9)
+ 10: $t10 := +($t2, $t9)
  11: return $t10
 }
 
 
 [variant baseline]
-fun ReachingDefTest::create_resource(sender: signer) {
-     var r: ReachingDefTest::R
+fun ReachingDefTest::create_resource($t0|sender: signer) {
+     var $t1|r: ReachingDefTest::R
      var $t2: signer
      var $t3: u64
      var $t4: bool
      var $t5: ReachingDefTest::R
      var $t6: signer
-  0: $t6 := move(sender)
+  0: $t6 := move($t0)
   1: $t2 := move($t6)
   2: $t3 := 1
   3: $t4 := false

--- a/language/move-prover/bytecode/tests/reaching_def/mut_ref_unpack.exp
+++ b/language/move-prover/bytecode/tests/reaching_def/mut_ref_unpack.exp
@@ -1,10 +1,10 @@
 ============ initial translation from Move ================
 
 [variant baseline]
-pub fun TestMutRefs::unpack(r: &mut TestMutRefs::R): u64 {
-     var result: u64
-     var tmp#$2: &mut TestMutRefs::R
-     var value: &mut u64
+pub fun TestMutRefs::unpack($t0|r: &mut TestMutRefs::R): u64 {
+     var $t1|result: u64
+     var $t2|tmp#$2: &mut TestMutRefs::R
+     var $t3|value: &mut u64
      var $t4: &mut TestMutRefs::R
      var $t5: &mut TestMutRefs::R
      var $t6: &mut u64
@@ -13,52 +13,52 @@ pub fun TestMutRefs::unpack(r: &mut TestMutRefs::R): u64 {
      var $t9: u64
      var $t10: &mut u64
      var $t11: u64
-  0: $t4 := move(r)
-  1: tmp#$2 := $t4
-  2: $t5 := move(tmp#$2)
+  0: $t4 := move($t0)
+  1: $t2 := $t4
+  2: $t5 := move($t2)
   3: $t6 := borrow_field<TestMutRefs::R>.value($t5)
-  4: value := $t6
-  5: $t7 := copy(value)
+  4: $t3 := $t6
+  5: $t7 := copy($t3)
   6: $t8 := read_ref($t7)
-  7: result := $t8
+  7: $t1 := $t8
   8: $t9 := 0
-  9: $t10 := move(value)
+  9: $t10 := move($t3)
  10: write_ref($t10, $t9)
- 11: $t11 := copy(result)
+ 11: $t11 := copy($t1)
  12: return $t11
 }
 
 
 [variant baseline]
-pub fun TestMutRefs::unpack_incorrect(r: &mut TestMutRefs::R): u64 {
-     var result: u64
-     var tmp#$2: &mut TestMutRefs::R
-     var value: &mut u64
+pub fun TestMutRefs::unpack_incorrect($t0|r: &mut TestMutRefs::R): u64 {
+     var $t1|result: u64
+     var $t2|tmp#$2: &mut TestMutRefs::R
+     var $t3|value: &mut u64
      var $t4: &mut TestMutRefs::R
      var $t5: &mut TestMutRefs::R
      var $t6: &mut u64
      var $t7: &mut u64
      var $t8: u64
      var $t9: u64
-  0: $t4 := move(r)
-  1: tmp#$2 := $t4
-  2: $t5 := move(tmp#$2)
+  0: $t4 := move($t0)
+  1: $t2 := $t4
+  2: $t5 := move($t2)
   3: $t6 := borrow_field<TestMutRefs::R>.value($t5)
-  4: value := $t6
-  5: $t7 := move(value)
+  4: $t3 := $t6
+  5: $t7 := move($t3)
   6: $t8 := read_ref($t7)
-  7: result := $t8
-  8: $t9 := copy(result)
+  7: $t1 := $t8
+  8: $t9 := copy($t1)
   9: return $t9
 }
 
 ============ after pipeline `reaching_def` ================
 
 [variant baseline]
-pub fun TestMutRefs::unpack(r: TestMutRefs::R): (u64, TestMutRefs::R) {
-     var result: u64
-     var tmp#$2: &mut TestMutRefs::R
-     var value: &mut u64
+pub fun TestMutRefs::unpack($t0|r: TestMutRefs::R): (u64, TestMutRefs::R) {
+     var $t1|result: u64
+     var $t2|tmp#$2: &mut TestMutRefs::R
+     var $t3|value: &mut u64
      var $t4: &mut TestMutRefs::R
      var $t5: &mut TestMutRefs::R
      var $t6: &mut u64
@@ -69,29 +69,29 @@ pub fun TestMutRefs::unpack(r: TestMutRefs::R): (u64, TestMutRefs::R) {
      var $t11: u64
      var $t12: TestMutRefs::R
      var $t13: &mut TestMutRefs::R
-  0: $t12 := move(r)
+  0: $t12 := move($t0)
   1: $t13 := borrow_local($t12)
   2: $t4 := move($t13)
-  3: tmp#$2 := $t13
+  3: $t2 := $t13
   4: $t5 := move($t13)
   5: $t6 := borrow_field<TestMutRefs::R>.value($t13)
-  6: value := $t6
-  7: $t7 := copy(value)
-  8: $t8 := read_ref(value)
-  9: result := $t8
+  6: $t3 := $t6
+  7: $t7 := copy($t3)
+  8: $t8 := read_ref($t3)
+  9: $t1 := $t8
  10: $t9 := 0
- 11: $t10 := move(value)
- 12: write_ref(value, $t9)
- 13: $t11 := copy(result)
- 14: return (result, $t12)
+ 11: $t10 := move($t3)
+ 12: write_ref($t3, $t9)
+ 13: $t11 := copy($t1)
+ 14: return ($t1, $t12)
 }
 
 
 [variant baseline]
-pub fun TestMutRefs::unpack_incorrect(r: TestMutRefs::R): (u64, TestMutRefs::R) {
-     var result: u64
-     var tmp#$2: &mut TestMutRefs::R
-     var value: &mut u64
+pub fun TestMutRefs::unpack_incorrect($t0|r: TestMutRefs::R): (u64, TestMutRefs::R) {
+     var $t1|result: u64
+     var $t2|tmp#$2: &mut TestMutRefs::R
+     var $t3|value: &mut u64
      var $t4: &mut TestMutRefs::R
      var $t5: &mut TestMutRefs::R
      var $t6: &mut u64
@@ -100,16 +100,16 @@ pub fun TestMutRefs::unpack_incorrect(r: TestMutRefs::R): (u64, TestMutRefs::R) 
      var $t9: u64
      var $t10: TestMutRefs::R
      var $t11: &mut TestMutRefs::R
-  0: $t10 := move(r)
+  0: $t10 := move($t0)
   1: $t11 := borrow_local($t10)
   2: $t4 := move($t11)
-  3: tmp#$2 := $t11
+  3: $t2 := $t11
   4: $t5 := move($t11)
   5: $t6 := borrow_field<TestMutRefs::R>.value($t11)
-  6: value := $t6
-  7: $t7 := move(value)
-  8: $t8 := read_ref(value)
-  9: result := $t8
- 10: $t9 := copy(result)
- 11: return (result, $t10)
+  6: $t3 := $t6
+  7: $t7 := move($t3)
+  8: $t8 := read_ref($t3)
+  9: $t1 := $t8
+ 10: $t9 := copy($t1)
+ 11: return ($t1, $t10)
 }

--- a/language/move-prover/bytecode/tests/reaching_def/test_branching.exp
+++ b/language/move-prover/bytecode/tests/reaching_def/test_branching.exp
@@ -1,61 +1,61 @@
 ============ initial translation from Move ================
 
 [variant baseline]
-fun TestBranching::branching(cond: bool): u64 {
-     var tmp#$1: u64
-     var x: u64
+fun TestBranching::branching($t0|cond: bool): u64 {
+     var $t1|tmp#$1: u64
+     var $t2|x: u64
      var $t3: bool
      var $t4: u64
      var $t5: u64
      var $t6: u64
      var $t7: u64
-  0: $t3 := copy(cond)
+  0: $t3 := copy($t0)
   1: if ($t3) goto L0 else goto L1
   2: L1:
   3: goto L2
   4: L0:
   5: $t4 := 3
-  6: tmp#$1 := $t4
+  6: $t1 := $t4
   7: goto L3
   8: L2:
   9: $t5 := 4
- 10: tmp#$1 := $t5
+ 10: $t1 := $t5
  11: goto L3
  12: L3:
- 13: $t6 := move(tmp#$1)
- 14: x := $t6
- 15: $t7 := copy(x)
+ 13: $t6 := move($t1)
+ 14: $t2 := $t6
+ 15: $t7 := copy($t2)
  16: return $t7
 }
 
 ============ after pipeline `reaching_def` ================
 
 [variant baseline]
-fun TestBranching::branching(cond: bool): u64 {
-     var tmp#$1: u64
-     var x: u64
+fun TestBranching::branching($t0|cond: bool): u64 {
+     var $t1|tmp#$1: u64
+     var $t2|x: u64
      var $t3: bool
      var $t4: u64
      var $t5: u64
      var $t6: u64
      var $t7: u64
      var $t8: bool
-  0: $t8 := move(cond)
+  0: $t8 := move($t0)
   1: $t3 := copy($t8)
   2: if ($t8) goto L0 else goto L1
   3: L1:
   4: goto L2
   5: L0:
   6: $t4 := 3
-  7: tmp#$1 := $t4
+  7: $t1 := $t4
   8: goto L3
   9: L2:
  10: $t5 := 4
- 11: tmp#$1 := $t5
+ 11: $t1 := $t5
  12: goto L3
  13: L3:
- 14: $t6 := move(tmp#$1)
- 15: x := tmp#$1
- 16: $t7 := copy(x)
- 17: return x
+ 14: $t6 := move($t1)
+ 15: $t2 := $t1
+ 16: $t7 := copy($t2)
+ 17: return $t2
 }

--- a/language/move-prover/bytecode/tests/spec_instrumentation/fun_spec.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/fun_spec.exp
@@ -1,8 +1,8 @@
 ============ initial translation from Move ================
 
 [variant baseline]
-fun Test::branching_result(is_div: bool, a: u64, b: u64): u64 {
-     var tmp#$3: u64
+fun Test::branching_result($t0|is_div: bool, $t1|a: u64, $t2|b: u64): u64 {
+     var $t3|tmp#$3: u64
      var $t4: bool
      var $t5: u64
      var $t6: u64
@@ -11,30 +11,30 @@ fun Test::branching_result(is_div: bool, a: u64, b: u64): u64 {
      var $t9: u64
      var $t10: u64
      var $t11: u64
-  0: $t4 := copy(is_div)
+  0: $t4 := copy($t0)
   1: if ($t4) goto L0 else goto L1
   2: L1:
   3: goto L2
   4: L0:
-  5: $t5 := copy(a)
-  6: $t6 := copy(b)
+  5: $t5 := copy($t1)
+  6: $t6 := copy($t2)
   7: $t7 := /($t5, $t6)
-  8: tmp#$3 := $t7
+  8: $t3 := $t7
   9: goto L3
  10: L2:
- 11: $t8 := copy(a)
- 12: $t9 := copy(b)
+ 11: $t8 := copy($t1)
+ 12: $t9 := copy($t2)
  13: $t10 := *($t8, $t9)
- 14: tmp#$3 := $t10
+ 14: $t3 := $t10
  15: goto L3
  16: L3:
- 17: $t11 := move(tmp#$3)
+ 17: $t11 := move($t3)
  18: return $t11
 }
 
 
 [variant baseline]
-fun Test::implicit_and_explicit_abort(a: u64, b: u64): u64 {
+fun Test::implicit_and_explicit_abort($t0|a: u64, $t1|b: u64): u64 {
      var $t2: u64
      var $t3: u64
      var $t4: bool
@@ -42,7 +42,7 @@ fun Test::implicit_and_explicit_abort(a: u64, b: u64): u64 {
      var $t6: u64
      var $t7: u64
      var $t8: u64
-  0: $t2 := copy(b)
+  0: $t2 := copy($t1)
   1: $t3 := 0
   2: $t4 := !=($t2, $t3)
   3: if ($t4) goto L0 else goto L1
@@ -52,34 +52,34 @@ fun Test::implicit_and_explicit_abort(a: u64, b: u64): u64 {
   7: $t5 := 22
   8: abort($t5)
   9: L2:
- 10: $t6 := copy(a)
- 11: $t7 := copy(b)
+ 10: $t6 := copy($t0)
+ 11: $t7 := copy($t1)
  12: $t8 := /($t6, $t7)
  13: return $t8
 }
 
 
 [variant baseline]
-fun Test::multiple_results(a: u64, b: u64): (u64, u64) {
+fun Test::multiple_results($t0|a: u64, $t1|b: u64): (u64, u64) {
      var $t2: u64
      var $t3: u64
      var $t4: u64
      var $t5: u64
      var $t6: u64
      var $t7: u64
-  0: $t2 := copy(a)
-  1: $t3 := copy(b)
+  0: $t2 := copy($t0)
+  1: $t3 := copy($t1)
   2: $t4 := /($t2, $t3)
-  3: $t5 := copy(a)
-  4: $t6 := copy(b)
+  3: $t5 := copy($t0)
+  4: $t6 := copy($t1)
   5: $t7 := %($t5, $t6)
   6: return ($t4, $t7)
 }
 
 
 [variant baseline]
-fun Test::mut_ref_param(r: &mut Test::R): u64 {
-     var x: u64
+fun Test::mut_ref_param($t0|r: &mut Test::R): u64 {
+     var $t1|x: u64
      var $t2: &mut Test::R
      var $t3: &u64
      var $t4: u64
@@ -91,29 +91,29 @@ fun Test::mut_ref_param(r: &mut Test::R): u64 {
      var $t10: &mut Test::R
      var $t11: &mut u64
      var $t12: u64
-  0: $t2 := copy(r)
+  0: $t2 := copy($t0)
   1: $t3 := borrow_field<Test::R>.v($t2)
   2: $t4 := read_ref($t3)
-  3: x := $t4
-  4: $t5 := copy(r)
+  3: $t1 := $t4
+  4: $t5 := copy($t0)
   5: $t6 := borrow_field<Test::R>.v($t5)
   6: $t7 := read_ref($t6)
   7: $t8 := 1
   8: $t9 := -($t7, $t8)
-  9: $t10 := move(r)
+  9: $t10 := move($t0)
  10: $t11 := borrow_field<Test::R>.v($t10)
  11: write_ref($t11, $t9)
- 12: $t12 := copy(x)
+ 12: $t12 := copy($t1)
  13: return $t12
 }
 
 
 [variant baseline]
-fun Test::ref_param(r: &Test::R): u64 {
+fun Test::ref_param($t0|r: &Test::R): u64 {
      var $t1: &Test::R
      var $t2: &u64
      var $t3: u64
-  0: $t1 := move(r)
+  0: $t1 := move($t0)
   1: $t2 := borrow_field<Test::R>.v($t1)
   2: $t3 := read_ref($t2)
   3: return $t3
@@ -121,18 +121,18 @@ fun Test::ref_param(r: &Test::R): u64 {
 
 
 [variant baseline]
-fun Test::ref_param_return_ref(r: &Test::R): &u64 {
+fun Test::ref_param_return_ref($t0|r: &Test::R): &u64 {
      var $t1: &Test::R
      var $t2: &u64
-  0: $t1 := move(r)
+  0: $t1 := move($t0)
   1: $t2 := borrow_field<Test::R>.v($t1)
   2: return $t2
 }
 
 
 [variant baseline]
-fun Test::resource_with_old(val: u64) {
-     var r: &mut Test::R
+fun Test::resource_with_old($t0|val: u64) {
+     var $t1|r: &mut Test::R
      var $t2: address
      var $t3: bool
      var $t4: bool
@@ -158,13 +158,13 @@ fun Test::resource_with_old(val: u64) {
   9: L2:
  10: $t6 := 0x0
  11: $t7 := borrow_global<Test::R>($t6)
- 12: r := $t7
- 13: $t8 := copy(r)
+ 12: $t1 := $t7
+ 13: $t8 := copy($t1)
  14: $t9 := borrow_field<Test::R>.v($t8)
  15: $t10 := read_ref($t9)
- 16: $t11 := copy(val)
+ 16: $t11 := copy($t0)
  17: $t12 := +($t10, $t11)
- 18: $t13 := move(r)
+ 18: $t13 := move($t1)
  19: $t14 := borrow_field<Test::R>.v($t13)
  20: write_ref($t14, $t12)
  21: return ()
@@ -173,68 +173,68 @@ fun Test::resource_with_old(val: u64) {
 ============ after pipeline `spec_instrumentation` ================
 
 [variant baseline]
-fun Test::branching_result(is_div: bool, a: u64, b: u64): u64 {
-     var tmp#$3: u64
+fun Test::branching_result($t0|is_div: bool, $t1|a: u64, $t2|b: u64): u64 {
+     var $t3|tmp#$3: u64
      var $t4: num
-  0: if (is_div) goto L0 else goto L1
+  0: if ($t0) goto L0 else goto L1
   1: L1:
   2: goto L2
   3: L0:
-  4: tmp#$3 := /(a, b)
+  4: $t3 := /($t1, $t2)
   5: on_abort(L5, $t4)
   6: goto L3
   7: L2:
-  8: tmp#$3 := *(a, b)
+  8: $t3 := *($t1, $t2)
   9: on_abort(L5, $t4)
  10: L3:
  11: L4:
- 12: return tmp#$3
+ 12: return $t3
  13: L5:
  14: abort($t4)
 }
 
 
 [variant verification]
-fun Test::branching_result(is_div: bool, a: u64, b: u64): u64 {
-     var tmp#$3: u64
+fun Test::branching_result($t0|is_div: bool, $t1|a: u64, $t2|b: u64): u64 {
+     var $t3|tmp#$3: u64
      var $t4: num
-  0: if (is_div) goto L0 else goto L1
+  0: if ($t0) goto L0 else goto L1
   1: L1:
   2: goto L2
   3: L0:
-  4: tmp#$3 := /(a, b)
+  4: $t3 := /($t1, $t2)
   5: on_abort(L5, $t4)
   6: goto L3
   7: L2:
-  8: tmp#$3 := *(a, b)
+  8: $t3 := *($t1, $t2)
   9: on_abort(L5, $t4)
  10: L3:
  11: L4:
      // VC: `function does not abort under this condition` at tests/spec_instrumentation/fun_spec.move:27:6+50
- 12: assert Not(And(is_div, Eq<u64>(b, 0)))
+ 12: assert Not(And($t0, Eq<u64>($t2, 0)))
      // VC: `post-condition does not hold` at tests/spec_instrumentation/fun_spec.move:28:6+35
- 13: assert Implies(is_div, Eq<u64>(tmp#$3, Div(a, b)))
+ 13: assert Implies($t0, Eq<u64>($t3, Div($t1, $t2)))
      // VC: `post-condition does not hold` at tests/spec_instrumentation/fun_spec.move:29:6+36
- 14: assert Implies(Not(is_div), Eq<u64>(tmp#$3, Mul(a, b)))
- 15: return tmp#$3
+ 14: assert Implies(Not($t0), Eq<u64>($t3, Mul($t1, $t2)))
+ 15: return $t3
  16: L5:
      // VC: `abort not covered by any of the `aborts_if` clauses` at tests/spec_instrumentation/fun_spec.move:23:2+94
- 17: assert And(is_div, Eq<u64>(b, 0))
+ 17: assert And($t0, Eq<u64>($t2, 0))
      // VC: `function aborts under this condition but with the wrong code` at tests/spec_instrumentation/fun_spec.move:27:38+17
- 18: assert Implies(And(is_div, Eq<u64>(b, 0)), Eq($t4, -1))
+ 18: assert Implies(And($t0, Eq<u64>($t2, 0)), Eq($t4, -1))
  19: abort($t4)
 }
 
 
 [variant baseline]
-fun Test::implicit_and_explicit_abort(a: u64, b: u64): u64 {
+fun Test::implicit_and_explicit_abort($t0|a: u64, $t1|b: u64): u64 {
      var $t2: u64
      var $t3: bool
      var $t4: u64
      var $t5: num
      var $t6: u64
   0: $t2 := 0
-  1: $t3 := !=(b, $t2)
+  1: $t3 := !=($t1, $t2)
   2: if ($t3) goto L0 else goto L1
   3: L1:
   4: goto L2
@@ -243,7 +243,7 @@ fun Test::implicit_and_explicit_abort(a: u64, b: u64): u64 {
   7: $t5 := move($t4)
   8: goto L4
   9: L2:
- 10: $t6 := /(a, b)
+ 10: $t6 := /($t0, $t1)
  11: on_abort(L4, $t5)
  12: L3:
  13: return $t6
@@ -253,14 +253,14 @@ fun Test::implicit_and_explicit_abort(a: u64, b: u64): u64 {
 
 
 [variant verification]
-fun Test::implicit_and_explicit_abort(a: u64, b: u64): u64 {
+fun Test::implicit_and_explicit_abort($t0|a: u64, $t1|b: u64): u64 {
      var $t2: u64
      var $t3: bool
      var $t4: u64
      var $t5: num
      var $t6: u64
   0: $t2 := 0
-  1: $t3 := !=(b, $t2)
+  1: $t3 := !=($t1, $t2)
   2: if ($t3) goto L0 else goto L1
   3: L1:
   4: goto L2
@@ -269,33 +269,33 @@ fun Test::implicit_and_explicit_abort(a: u64, b: u64): u64 {
   7: $t5 := move($t4)
   8: goto L4
   9: L2:
- 10: $t6 := /(a, b)
+ 10: $t6 := /($t0, $t1)
  11: on_abort(L4, $t5)
  12: L3:
      // VC: `function does not abort under this condition` at tests/spec_instrumentation/fun_spec.move:9:6+25
- 13: assert Not(Eq<u64>(b, 0))
+ 13: assert Not(Eq<u64>($t1, 0))
      // VC: `function does not abort under this condition` at tests/spec_instrumentation/fun_spec.move:10:6+17
- 14: assert Not(Eq<u64>(a, 0))
+ 14: assert Not(Eq<u64>($t0, 0))
      // VC: `post-condition does not hold` at tests/spec_instrumentation/fun_spec.move:11:6+24
- 15: assert Eq<u64>($t6, Div(a, b))
+ 15: assert Eq<u64>($t6, Div($t0, $t1))
  16: return $t6
  17: L4:
      // VC: `abort not covered by any of the `aborts_if` clauses` at tests/spec_instrumentation/fun_spec.move:4:2+96
- 18: assert Or(Eq<u64>(b, 0), Eq<u64>(a, 0))
+ 18: assert Or(Eq<u64>($t1, 0), Eq<u64>($t0, 0))
      // VC: `function aborts under this condition but with the wrong code` at tests/spec_instrumentation/fun_spec.move:9:28+2
- 19: assert Implies(Eq<u64>(b, 0), Eq($t5, 22))
+ 19: assert Implies(Eq<u64>($t1, 0), Eq($t5, 22))
  20: abort($t5)
 }
 
 
 [variant baseline]
-fun Test::multiple_results(a: u64, b: u64): (u64, u64) {
+fun Test::multiple_results($t0|a: u64, $t1|b: u64): (u64, u64) {
      var $t2: u64
      var $t3: num
      var $t4: u64
-  0: $t2 := /(a, b)
+  0: $t2 := /($t0, $t1)
   1: on_abort(L2, $t3)
-  2: $t4 := %(a, b)
+  2: $t4 := %($t0, $t1)
   3: on_abort(L2, $t3)
   4: L1:
   5: return ($t2, $t4)
@@ -305,34 +305,34 @@ fun Test::multiple_results(a: u64, b: u64): (u64, u64) {
 
 
 [variant verification]
-fun Test::multiple_results(a: u64, b: u64): (u64, u64) {
+fun Test::multiple_results($t0|a: u64, $t1|b: u64): (u64, u64) {
      var $t2: u64
      var $t3: num
      var $t4: u64
-  0: $t2 := /(a, b)
+  0: $t2 := /($t0, $t1)
   1: on_abort(L2, $t3)
-  2: $t4 := %(a, b)
+  2: $t4 := %($t0, $t1)
   3: on_abort(L2, $t3)
   4: L1:
      // VC: `function does not abort under this condition` at tests/spec_instrumentation/fun_spec.move:18:6+40
-  5: assert Not(Eq<u64>(b, 0))
+  5: assert Not(Eq<u64>($t1, 0))
      // VC: `post-condition does not hold` at tests/spec_instrumentation/fun_spec.move:19:6+26
-  6: assert Eq<u64>($t2, Div(a, b))
+  6: assert Eq<u64>($t2, Div($t0, $t1))
      // VC: `post-condition does not hold` at tests/spec_instrumentation/fun_spec.move:20:6+26
-  7: assert Eq<u64>($t4, Mod(a, b))
+  7: assert Eq<u64>($t4, Mod($t0, $t1))
   8: return ($t2, $t4)
   9: L2:
      // VC: `abort not covered by any of the `aborts_if` clauses` at tests/spec_instrumentation/fun_spec.move:14:2+73
- 10: assert Eq<u64>(b, 0)
+ 10: assert Eq<u64>($t1, 0)
      // VC: `function aborts under this condition but with the wrong code` at tests/spec_instrumentation/fun_spec.move:18:28+17
- 11: assert Implies(Eq<u64>(b, 0), Eq($t3, -1))
+ 11: assert Implies(Eq<u64>($t1, 0), Eq($t3, -1))
  12: abort($t3)
 }
 
 
 [variant baseline]
-fun Test::mut_ref_param(r: Test::R): (u64, Test::R) {
-     var x: u64
+fun Test::mut_ref_param($t0|r: Test::R): (u64, Test::R) {
+     var $t1|x: u64
      var $t2: Test::R
      var $t3: &mut Test::R
      var $t4: u64
@@ -341,7 +341,7 @@ fun Test::mut_ref_param(r: Test::R): (u64, Test::R) {
      var $t7: u64
      var $t8: num
      var $t9: &mut u64
-  0: $t2 := move(r)
+  0: $t2 := move($t0)
   1: $t3 := borrow_local($t2)
   2: $t4 := get_field<Test::R>.v($t3)
   3: $t5 := get_field<Test::R>.v($t3)
@@ -360,8 +360,8 @@ fun Test::mut_ref_param(r: Test::R): (u64, Test::R) {
 
 
 [variant verification]
-fun Test::mut_ref_param(r: Test::R): (u64, Test::R) {
-     var x: u64
+fun Test::mut_ref_param($t0|r: Test::R): (u64, Test::R) {
+     var $t1|x: u64
      var $t2: Test::R
      var $t3: &mut Test::R
      var $t4: u64
@@ -370,7 +370,7 @@ fun Test::mut_ref_param(r: Test::R): (u64, Test::R) {
      var $t7: u64
      var $t8: num
      var $t9: &mut u64
-  0: $t2 := move(r)
+  0: $t2 := move($t0)
   1: $t3 := borrow_local($t2)
   2: $t4 := get_field<Test::R>.v($t3)
   3: $t5 := get_field<Test::R>.v($t3)
@@ -383,64 +383,64 @@ fun Test::mut_ref_param(r: Test::R): (u64, Test::R) {
  10: write_back[LocalRoot($t2)]($t3)
  11: L1:
      // VC: `function does not abort under this condition` at tests/spec_instrumentation/fun_spec.move:67:6+42
- 12: assert Not(Eq<u64>(select Test::R.v(r), 0))
+ 12: assert Not(Eq<u64>(select Test::R.v($t0), 0))
      // VC: `post-condition does not hold` at tests/spec_instrumentation/fun_spec.move:68:6+27
- 13: assert Eq<u64>($t4, select Test::R.v(r))
+ 13: assert Eq<u64>($t4, select Test::R.v($t0))
      // VC: `post-condition does not hold` at tests/spec_instrumentation/fun_spec.move:69:6+28
- 14: assert Eq<u64>(select Test::R.v($t2), Add(select Test::R.v(r), 1))
+ 14: assert Eq<u64>(select Test::R.v($t2), Add(select Test::R.v($t0), 1))
  15: return ($t4, $t2)
  16: L2:
      // VC: `abort not covered by any of the `aborts_if` clauses` at tests/spec_instrumentation/fun_spec.move:61:2+83
- 17: assert Eq<u64>(select Test::R.v(r), 0)
+ 17: assert Eq<u64>(select Test::R.v($t0), 0)
      // VC: `function aborts under this condition but with the wrong code` at tests/spec_instrumentation/fun_spec.move:67:30+17
- 18: assert Implies(Eq<u64>(select Test::R.v(r), 0), Eq($t8, -1))
+ 18: assert Implies(Eq<u64>(select Test::R.v($t0), 0), Eq($t8, -1))
  19: abort($t8)
 }
 
 
 [variant baseline]
-fun Test::ref_param(r: Test::R): u64 {
+fun Test::ref_param($t0|r: Test::R): u64 {
      var $t1: u64
-  0: $t1 := get_field<Test::R>.v(r)
+  0: $t1 := get_field<Test::R>.v($t0)
   1: L1:
   2: return $t1
 }
 
 
 [variant verification]
-fun Test::ref_param(r: Test::R): u64 {
+fun Test::ref_param($t0|r: Test::R): u64 {
      var $t1: u64
-  0: $t1 := get_field<Test::R>.v(r)
+  0: $t1 := get_field<Test::R>.v($t0)
   1: L1:
      // VC: `post-condition does not hold` at tests/spec_instrumentation/fun_spec.move:51:6+22
-  2: assert Eq<u64>($t1, select Test::R.v(r))
+  2: assert Eq<u64>($t1, select Test::R.v($t0))
   3: return $t1
 }
 
 
 [variant baseline]
-fun Test::ref_param_return_ref(r: Test::R): u64 {
+fun Test::ref_param_return_ref($t0|r: Test::R): u64 {
      var $t1: u64
-  0: $t1 := get_field<Test::R>.v(r)
+  0: $t1 := get_field<Test::R>.v($t0)
   1: L1:
   2: return $t1
 }
 
 
 [variant verification]
-fun Test::ref_param_return_ref(r: Test::R): u64 {
+fun Test::ref_param_return_ref($t0|r: Test::R): u64 {
      var $t1: u64
-  0: $t1 := get_field<Test::R>.v(r)
+  0: $t1 := get_field<Test::R>.v($t0)
   1: L1:
      // VC: `post-condition does not hold` at tests/spec_instrumentation/fun_spec.move:58:6+22
-  2: assert Eq<u64>($t1, select Test::R.v(r))
+  2: assert Eq<u64>($t1, select Test::R.v($t0))
   3: return $t1
 }
 
 
 [variant baseline]
-fun Test::resource_with_old(val: u64) {
-     var r: &mut Test::R
+fun Test::resource_with_old($t0|val: u64) {
+     var $t1|r: &mut Test::R
      var $t2: address
      var $t3: bool
      var $t4: bool
@@ -450,7 +450,7 @@ fun Test::resource_with_old(val: u64) {
      var $t8: u64
      var $t9: u64
      var $t10: &mut u64
-  0: assume Gt(val, 0)
+  0: assume Gt($t0, 0)
   1: $t2 := 0x0
   2: $t3 := exists<Test::R>($t2)
   3: $t4 := !($t3)
@@ -463,19 +463,19 @@ fun Test::resource_with_old(val: u64) {
  10: goto L4
  11: L2:
  12: $t7 := 0x0
- 13: r := borrow_global<Test::R>($t7)
+ 13: $t1 := borrow_global<Test::R>($t7)
  14: on_abort(L4, $t6)
- 15: unpack_ref(r)
- 16: $t8 := get_field<Test::R>.v(r)
- 17: $t9 := +($t8, val)
+ 15: unpack_ref($t1)
+ 16: $t8 := get_field<Test::R>.v($t1)
+ 17: $t9 := +($t8, $t0)
  18: on_abort(L4, $t6)
- 19: $t10 := borrow_field<Test::R>.v(r)
+ 19: $t10 := borrow_field<Test::R>.v($t1)
  20: unpack_ref($t10)
  21: write_ref($t10, $t9)
  22: pack_ref($t10)
- 23: write_back[Reference(r)]($t10)
- 24: pack_ref(r)
- 25: write_back[Test::R](r)
+ 23: write_back[Reference($t1)]($t10)
+ 24: pack_ref($t1)
+ 25: write_back[Test::R]($t1)
  26: L3:
  27: return ()
  28: L4:
@@ -484,8 +484,8 @@ fun Test::resource_with_old(val: u64) {
 
 
 [variant verification]
-fun Test::resource_with_old(val: u64) {
-     var r: &mut Test::R
+fun Test::resource_with_old($t0|val: u64) {
+     var $t1|r: &mut Test::R
      var $t2: address
      var $t3: bool
      var $t4: bool
@@ -495,7 +495,7 @@ fun Test::resource_with_old(val: u64) {
      var $t8: u64
      var $t9: u64
      var $t10: &mut u64
-  0: assume Gt(val, 0)
+  0: assume Gt($t0, 0)
   1: @0 := save_mem(Test::R)
   2: $t2 := 0x0
   3: $t3 := exists<Test::R>($t2)
@@ -509,31 +509,31 @@ fun Test::resource_with_old(val: u64) {
  11: goto L4
  12: L2:
  13: $t7 := 0x0
- 14: r := borrow_global<Test::R>($t7)
+ 14: $t1 := borrow_global<Test::R>($t7)
  15: on_abort(L4, $t6)
- 16: unpack_ref(r)
- 17: $t8 := get_field<Test::R>.v(r)
- 18: $t9 := +($t8, val)
+ 16: unpack_ref($t1)
+ 17: $t8 := get_field<Test::R>.v($t1)
+ 18: $t9 := +($t8, $t0)
  19: on_abort(L4, $t6)
- 20: $t10 := borrow_field<Test::R>.v(r)
+ 20: $t10 := borrow_field<Test::R>.v($t1)
  21: unpack_ref($t10)
  22: write_ref($t10, $t9)
  23: pack_ref($t10)
- 24: write_back[Reference(r)]($t10)
- 25: pack_ref(r)
- 26: write_back[Test::R](r)
+ 24: write_back[Reference($t1)]($t10)
+ 25: pack_ref($t1)
+ 26: write_back[Test::R]($t1)
  27: L3:
      // VC: `function does not abort under this condition` at tests/spec_instrumentation/fun_spec.move:41:6+34
- 28: assert Not(Not(exists<Test::R>[@0]<Test::R>(0)))
+ 28: assert Not(Not(exists[@0]<Test::R>(0)))
      // VC: `function does not abort under this condition` at tests/spec_instrumentation/fun_spec.move:42:6+57
- 29: assert Not(Ge(Add(select Test::R.v(global<Test::R>[@0]<Test::R>(0)), val), 18446744073709551615))
+ 29: assert Not(Ge(Add(select Test::R.v(global[@0]<Test::R>(0)), $t0), 18446744073709551615))
      // VC: `post-condition does not hold` at tests/spec_instrumentation/fun_spec.move:43:6+56
- 30: assert Eq<u64>(select Test::R.v(global<Test::R><Test::R>(0)), Add(select Test::R.v(global<Test::R>[@0]<Test::R>(0)), val))
+ 30: assert Eq<u64>(select Test::R.v(global<Test::R>(0)), Add(select Test::R.v(global[@0]<Test::R>(0)), $t0))
  31: return ()
  32: L4:
      // VC: `abort not covered by any of the `aborts_if` clauses` at tests/spec_instrumentation/fun_spec.move:34:2+145
- 33: assert Or(Not(exists<Test::R>[@0]<Test::R>(0)), Ge(Add(select Test::R.v(global<Test::R>[@0]<Test::R>(0)), val), 18446744073709551615))
+ 33: assert Or(Not(exists[@0]<Test::R>(0)), Ge(Add(select Test::R.v(global[@0]<Test::R>(0)), $t0), 18446744073709551615))
      // VC: `function aborts under this condition but with the wrong code` at tests/spec_instrumentation/fun_spec.move:41:37+2
- 34: assert Implies(Not(exists<Test::R>[@0]<Test::R>(0)), Eq($t6, 33))
+ 34: assert Implies(Not(exists[@0]<Test::R>(0)), Eq($t6, 33))
  35: abort($t6)
 }

--- a/language/move-prover/bytecode/tests/spec_instrumentation/opaque_call.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/opaque_call.exp
@@ -1,9 +1,9 @@
 ============ initial translation from Move ================
 
 [variant baseline]
-fun Test::get_and_incr(addr: address): u64 {
-     var r: &mut Test::R
-     var v: u64
+fun Test::get_and_incr($t0|addr: address): u64 {
+     var $t1|r: &mut Test::R
+     var $t2|v: u64
      var $t3: address
      var $t4: bool
      var $t5: bool
@@ -21,7 +21,7 @@ fun Test::get_and_incr(addr: address): u64 {
      var $t17: &mut Test::R
      var $t18: &mut u64
      var $t19: u64
-  0: $t3 := copy(addr)
+  0: $t3 := copy($t0)
   1: $t4 := exists<Test::R>($t3)
   2: $t5 := !($t4)
   3: if ($t5) goto L0 else goto L1
@@ -31,22 +31,22 @@ fun Test::get_and_incr(addr: address): u64 {
   7: $t6 := 33
   8: abort($t6)
   9: L2:
- 10: $t7 := copy(addr)
+ 10: $t7 := copy($t0)
  11: $t8 := borrow_global<Test::R>($t7)
- 12: r := $t8
- 13: $t9 := copy(r)
+ 12: $t1 := $t8
+ 13: $t9 := copy($t1)
  14: $t10 := borrow_field<Test::R>.v($t9)
  15: $t11 := read_ref($t10)
- 16: v := $t11
- 17: $t12 := copy(r)
+ 16: $t2 := $t11
+ 17: $t12 := copy($t1)
  18: $t13 := borrow_field<Test::R>.v($t12)
  19: $t14 := read_ref($t13)
  20: $t15 := 1
  21: $t16 := +($t14, $t15)
- 22: $t17 := move(r)
+ 22: $t17 := move($t1)
  23: $t18 := borrow_field<Test::R>.v($t17)
  24: write_ref($t18, $t16)
- 25: $t19 := copy(v)
+ 25: $t19 := copy($t2)
  26: return $t19
 }
 
@@ -69,9 +69,9 @@ fun Test::incr_twice() {
 ============ after pipeline `spec_instrumentation` ================
 
 [variant baseline]
-fun Test::get_and_incr(addr: address): u64 {
-     var r: &mut Test::R
-     var v: u64
+fun Test::get_and_incr($t0|addr: address): u64 {
+     var $t1|r: &mut Test::R
+     var $t2|v: u64
      var $t3: bool
      var $t4: bool
      var $t5: u64
@@ -82,8 +82,8 @@ fun Test::get_and_incr(addr: address): u64 {
      var $t10: u64
      var $t11: &mut u64
      // VC: `precondition does not hold at this call` at tests/spec_instrumentation/opaque_call.move:15:6+21
-  0: assume Neq<address>(addr, 0)
-  1: $t3 := exists<Test::R>(addr)
+  0: assume Neq<address>($t0, 0)
+  1: $t3 := exists<Test::R>($t0)
   2: $t4 := !($t3)
   3: if ($t4) goto L0 else goto L1
   4: L1:
@@ -93,21 +93,21 @@ fun Test::get_and_incr(addr: address): u64 {
   8: $t6 := move($t5)
   9: goto L4
  10: L2:
- 11: r := borrow_global<Test::R>(addr)
+ 11: $t1 := borrow_global<Test::R>($t0)
  12: on_abort(L4, $t6)
- 13: unpack_ref(r)
- 14: $t7 := get_field<Test::R>.v(r)
- 15: $t8 := get_field<Test::R>.v(r)
+ 13: unpack_ref($t1)
+ 14: $t7 := get_field<Test::R>.v($t1)
+ 15: $t8 := get_field<Test::R>.v($t1)
  16: $t9 := 1
  17: $t10 := +($t8, $t9)
  18: on_abort(L4, $t6)
- 19: $t11 := borrow_field<Test::R>.v(r)
+ 19: $t11 := borrow_field<Test::R>.v($t1)
  20: unpack_ref($t11)
  21: write_ref($t11, $t10)
  22: pack_ref($t11)
- 23: write_back[Reference(r)]($t11)
- 24: pack_ref(r)
- 25: write_back[Test::R](r)
+ 23: write_back[Reference($t1)]($t11)
+ 24: pack_ref($t1)
+ 25: write_back[Test::R]($t1)
  26: L3:
  27: return $t7
  28: L4:
@@ -116,9 +116,9 @@ fun Test::get_and_incr(addr: address): u64 {
 
 
 [variant verification]
-fun Test::get_and_incr(addr: address): u64 {
-     var r: &mut Test::R
-     var v: u64
+fun Test::get_and_incr($t0|addr: address): u64 {
+     var $t1|r: &mut Test::R
+     var $t2|v: u64
      var $t3: bool
      var $t4: bool
      var $t5: u64
@@ -129,9 +129,9 @@ fun Test::get_and_incr(addr: address): u64 {
      var $t10: u64
      var $t11: &mut u64
      // VC: `precondition does not hold at this call` at tests/spec_instrumentation/opaque_call.move:15:6+21
-  0: assume Neq<address>(addr, 0)
+  0: assume Neq<address>($t0, 0)
   1: @0 := save_mem(Test::R)
-  2: $t3 := exists<Test::R>(addr)
+  2: $t3 := exists<Test::R>($t0)
   3: $t4 := !($t3)
   4: if ($t4) goto L0 else goto L1
   5: L1:
@@ -141,36 +141,36 @@ fun Test::get_and_incr(addr: address): u64 {
   9: $t6 := move($t5)
  10: goto L4
  11: L2:
- 12: r := borrow_global<Test::R>(addr)
+ 12: $t1 := borrow_global<Test::R>($t0)
  13: on_abort(L4, $t6)
- 14: unpack_ref(r)
- 15: $t7 := get_field<Test::R>.v(r)
- 16: $t8 := get_field<Test::R>.v(r)
+ 14: unpack_ref($t1)
+ 15: $t7 := get_field<Test::R>.v($t1)
+ 16: $t8 := get_field<Test::R>.v($t1)
  17: $t9 := 1
  18: $t10 := +($t8, $t9)
  19: on_abort(L4, $t6)
- 20: $t11 := borrow_field<Test::R>.v(r)
+ 20: $t11 := borrow_field<Test::R>.v($t1)
  21: unpack_ref($t11)
  22: write_ref($t11, $t10)
  23: pack_ref($t11)
- 24: write_back[Reference(r)]($t11)
- 25: pack_ref(r)
- 26: write_back[Test::R](r)
+ 24: write_back[Reference($t1)]($t11)
+ 25: pack_ref($t1)
+ 26: write_back[Test::R]($t1)
  27: L3:
      // VC: `function does not abort under this condition` at tests/spec_instrumentation/opaque_call.move:16:6+35
- 28: assert Not(Not(exists<Test::R>[@0]<Test::R>(addr)))
+ 28: assert Not(Not(exists[@0]<Test::R>($t0)))
      // VC: `function does not abort under this condition` at tests/spec_instrumentation/opaque_call.move:17:6+56
- 29: assert Not(Ge(Add(select Test::R.v(global<Test::R>[@0]<Test::R>(addr)), 1), 18446744073709551615))
+ 29: assert Not(Ge(Add(select Test::R.v(global[@0]<Test::R>($t0)), 1), 18446744073709551615))
      // VC: `post-condition does not hold` at tests/spec_instrumentation/opaque_call.move:19:6+56
- 30: assert Eq<u64>(select Test::R.v(global<Test::R><Test::R>(addr)), Add(select Test::R.v(global<Test::R>[@0]<Test::R>(addr)), 1))
+ 30: assert Eq<u64>(select Test::R.v(global<Test::R>($t0)), Add(select Test::R.v(global[@0]<Test::R>($t0)), 1))
      // VC: `post-condition does not hold` at tests/spec_instrumentation/opaque_call.move:20:6+36
- 31: assert Eq<u64>($t7, select Test::R.v(global<Test::R><Test::R>(addr)))
+ 31: assert Eq<u64>($t7, select Test::R.v(global<Test::R>($t0)))
  32: return $t7
  33: L4:
      // VC: `abort not covered by any of the `aborts_if` clauses` at tests/spec_instrumentation/opaque_call.move:6:2+175
- 34: assert Or(Not(exists<Test::R>[@0]<Test::R>(addr)), Ge(Add(select Test::R.v(global<Test::R>[@0]<Test::R>(addr)), 1), 18446744073709551615))
+ 34: assert Or(Not(exists[@0]<Test::R>($t0)), Ge(Add(select Test::R.v(global[@0]<Test::R>($t0)), 1), 18446744073709551615))
      // VC: `function aborts under this condition but with the wrong code` at tests/spec_instrumentation/opaque_call.move:16:38+2
- 35: assert Implies(Not(exists<Test::R>[@0]<Test::R>(addr)), Eq($t6, 33))
+ 35: assert Implies(Not(exists[@0]<Test::R>($t0)), Eq($t6, 33))
  36: abort($t6)
 }
 
@@ -186,24 +186,24 @@ fun Test::incr_twice() {
      var $t6: u64
   0: $t0 := 0x1
      // VC: `precondition does not hold at this call` at tests/spec_instrumentation/opaque_call.move:15:6+21
-  1: assert Neq<address>(addr, 0)
+  1: assert Neq<address>($t0, 0)
   2: @6 := save_mem(Test::R)
-  3: modifies global<Test::R><Test::R>($t0)
-  4: assume Eq($t1, And(Or(Not(exists<Test::R>[@6]<Test::R>($t0)), Ge(Add(select Test::R.v(global<Test::R>[@6]<Test::R>($t0)), 1), 18446744073709551615)), Implies(Not(exists<Test::R>[@6]<Test::R>($t0)), Eq($t2, 33))))
+  3: modifies global<Test::R>($t0)
+  4: assume Eq($t1, And(Or(Not(exists[@6]<Test::R>($t0)), Ge(Add(select Test::R.v(global[@6]<Test::R>($t0)), 1), 18446744073709551615)), Implies(Not(exists[@6]<Test::R>($t0)), Eq($t2, 33))))
   5: if ($t1) goto L2 else goto L3
   6: L3:
-  7: assume Eq<u64>(select Test::R.v(global<Test::R><Test::R>($t0)), Add(select Test::R.v(global<Test::R>[@6]<Test::R>($t0)), 1))
-  8: assume Eq<u64>($t3, select Test::R.v(global<Test::R><Test::R>($t0)))
+  7: assume Eq<u64>(select Test::R.v(global<Test::R>($t0)), Add(select Test::R.v(global[@6]<Test::R>($t0)), 1))
+  8: assume Eq<u64>($t3, select Test::R.v(global<Test::R>($t0)))
   9: destroy($t3)
  10: $t4 := 0x1
- 11: assert Neq<address>(addr, 0)
+ 11: assert Neq<address>($t0, 0)
  12: @7 := save_mem(Test::R)
- 13: modifies global<Test::R><Test::R>($t4)
- 14: assume Eq($t5, And(Or(Not(exists<Test::R>[@7]<Test::R>($t4)), Ge(Add(select Test::R.v(global<Test::R>[@7]<Test::R>($t4)), 1), 18446744073709551615)), Implies(Not(exists<Test::R>[@7]<Test::R>($t4)), Eq($t2, 33))))
+ 13: modifies global<Test::R>($t4)
+ 14: assume Eq($t5, And(Or(Not(exists[@7]<Test::R>($t4)), Ge(Add(select Test::R.v(global[@7]<Test::R>($t4)), 1), 18446744073709551615)), Implies(Not(exists[@7]<Test::R>($t4)), Eq($t2, 33))))
  15: if ($t5) goto L2 else goto L4
  16: L4:
- 17: assume Eq<u64>(select Test::R.v(global<Test::R><Test::R>($t4)), Add(select Test::R.v(global<Test::R>[@7]<Test::R>($t4)), 1))
- 18: assume Eq<u64>($t6, select Test::R.v(global<Test::R><Test::R>($t4)))
+ 17: assume Eq<u64>(select Test::R.v(global<Test::R>($t4)), Add(select Test::R.v(global[@7]<Test::R>($t4)), 1))
+ 18: assume Eq<u64>($t6, select Test::R.v(global<Test::R>($t4)))
  19: destroy($t6)
  20: L1:
  21: return ()
@@ -224,35 +224,35 @@ fun Test::incr_twice() {
   0: @2 := save_mem(Test::R)
   1: $t0 := 0x1
      // VC: `precondition does not hold at this call` at tests/spec_instrumentation/opaque_call.move:15:6+21
-  2: assert Neq<address>(addr, 0)
+  2: assert Neq<address>($t0, 0)
   3: @3 := save_mem(Test::R)
-  4: modifies global<Test::R><Test::R>($t0)
-  5: assume Eq($t1, And(Or(Not(exists<Test::R>[@3]<Test::R>($t0)), Ge(Add(select Test::R.v(global<Test::R>[@3]<Test::R>($t0)), 1), 18446744073709551615)), Implies(Not(exists<Test::R>[@3]<Test::R>($t0)), Eq($t2, 33))))
+  4: modifies global<Test::R>($t0)
+  5: assume Eq($t1, And(Or(Not(exists[@3]<Test::R>($t0)), Ge(Add(select Test::R.v(global[@3]<Test::R>($t0)), 1), 18446744073709551615)), Implies(Not(exists[@3]<Test::R>($t0)), Eq($t2, 33))))
   6: if ($t1) goto L2 else goto L3
   7: L3:
-  8: assume Eq<u64>(select Test::R.v(global<Test::R><Test::R>($t0)), Add(select Test::R.v(global<Test::R>[@3]<Test::R>($t0)), 1))
-  9: assume Eq<u64>($t3, select Test::R.v(global<Test::R><Test::R>($t0)))
+  8: assume Eq<u64>(select Test::R.v(global<Test::R>($t0)), Add(select Test::R.v(global[@3]<Test::R>($t0)), 1))
+  9: assume Eq<u64>($t3, select Test::R.v(global<Test::R>($t0)))
  10: destroy($t3)
  11: $t4 := 0x1
- 12: assert Neq<address>(addr, 0)
+ 12: assert Neq<address>($t0, 0)
  13: @4 := save_mem(Test::R)
- 14: modifies global<Test::R><Test::R>($t4)
- 15: assume Eq($t5, And(Or(Not(exists<Test::R>[@4]<Test::R>($t4)), Ge(Add(select Test::R.v(global<Test::R>[@4]<Test::R>($t4)), 1), 18446744073709551615)), Implies(Not(exists<Test::R>[@4]<Test::R>($t4)), Eq($t2, 33))))
+ 14: modifies global<Test::R>($t4)
+ 15: assume Eq($t5, And(Or(Not(exists[@4]<Test::R>($t4)), Ge(Add(select Test::R.v(global[@4]<Test::R>($t4)), 1), 18446744073709551615)), Implies(Not(exists[@4]<Test::R>($t4)), Eq($t2, 33))))
  16: if ($t5) goto L2 else goto L4
  17: L4:
- 18: assume Eq<u64>(select Test::R.v(global<Test::R><Test::R>($t4)), Add(select Test::R.v(global<Test::R>[@4]<Test::R>($t4)), 1))
- 19: assume Eq<u64>($t6, select Test::R.v(global<Test::R><Test::R>($t4)))
+ 18: assume Eq<u64>(select Test::R.v(global<Test::R>($t4)), Add(select Test::R.v(global[@4]<Test::R>($t4)), 1))
+ 19: assume Eq<u64>($t6, select Test::R.v(global<Test::R>($t4)))
  20: destroy($t6)
  21: L1:
      // VC: `function does not abort under this condition` at tests/spec_instrumentation/opaque_call.move:28:6+34
- 22: assert Not(Not(exists<Test::R>[@2]<Test::R>(1)))
+ 22: assert Not(Not(exists[@2]<Test::R>(1)))
      // VC: `post-condition does not hold` at tests/spec_instrumentation/opaque_call.move:29:6+54
- 23: assert Eq<u64>(select Test::R.v(global<Test::R><Test::R>(1)), Add(select Test::R.v(global<Test::R>[@2]<Test::R>(1)), 2))
+ 23: assert Eq<u64>(select Test::R.v(global<Test::R>(1)), Add(select Test::R.v(global[@2]<Test::R>(1)), 2))
  24: return ()
  25: L2:
      // VC: `abort not covered by any of the `aborts_if` clauses` at tests/spec_instrumentation/opaque_call.move:23:2+80
- 26: assert Not(exists<Test::R>[@2]<Test::R>(1))
+ 26: assert Not(exists[@2]<Test::R>(1))
      // VC: `function aborts under this condition but with the wrong code` at tests/spec_instrumentation/opaque_call.move:28:37+2
- 27: assert Implies(Not(exists<Test::R>[@2]<Test::R>(1)), Eq($t2, 33))
+ 27: assert Implies(Not(exists[@2]<Test::R>(1)), Eq($t2, 33))
  28: abort($t2)
 }

--- a/language/move-prover/bytecode/tests/testsuite.rs
+++ b/language/move-prover/bytecode/tests/testsuite.rs
@@ -123,7 +123,7 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
         let mut targets = FunctionTargetsHolder::default();
         for module_env in env.get_modules() {
             for func_env in module_env.get_functions() {
-                targets.add_target(&func_env);
+                targets.add_target(&func_env, true);
             }
         }
         text += &print_targets_for_test(&env, "initial translation from Move", &targets);

--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -19,7 +19,7 @@ use bytecode::{
     stackless_bytecode::{
         AssignKind, BorrowNode,
         Bytecode::{self, *},
-        Constant, Label, Operation, SpecBlockId, TempIndex,
+        Constant, Label, Operation, SpecBlockId,
     },
     stackless_control_flow_graph::{BlockId, StacklessControlFlowGraph},
 };
@@ -53,6 +53,7 @@ use crate::{
     spec_translator::{ConditionDistribution, FunctionEntryPoint, SpecEnv, SpecTranslator},
 };
 use bytecode::function_target_pipeline::FunctionVariant;
+use move_model::ast::TempIndex;
 
 const MODIFY_RESOURCE_FAILS_MESSAGE: &str =
     "caller does not have permission for this resource modification";

--- a/language/move-prover/src/lib.rs
+++ b/language/move-prover/src/lib.rs
@@ -393,7 +393,7 @@ fn create_and_process_bytecode(options: &Options, env: &GlobalEnv) -> FunctionTa
     // Add function targets for all functions in the environment.
     for module_env in env.get_modules() {
         for func_env in module_env.get_functions() {
-            targets.add_target(&func_env)
+            targets.add_target(&func_env, options.trans_v2)
         }
     }
 

--- a/language/move-prover/tests/sources/functional/defines.move
+++ b/language/move-prover/tests/sources/functional/defines.move
@@ -45,4 +45,18 @@ module TestDefines {
         aborts_if !exists_both(addr1, addr2);
         ensures result == (get(addr1) == get(addr2));
     }
+
+    // ------------------------------------------
+    // Spec functions derived from Move functions
+    // ------------------------------------------
+
+    fun add_as_spec_fun(x: u64, y: u64): u64 { x + y }
+    fun add_fun(x: u64, y: u64): u64 { x + y }
+    spec fun add_fun {
+        include AddOk;
+    }
+    spec schema AddOk {
+        x: num; y: num; result: num;
+        ensures result == add_as_spec_fun(x, y);
+    }
 }

--- a/language/move-prover/tests/sources/functional/specs_in_fun.exp
+++ b/language/move-prover/tests/sources/functional/specs_in_fun.exp
@@ -7,9 +7,9 @@ error:  This assertion might not hold.
     │             ^^^^^^^^^^^^^^
     │
     =     at tests/sources/functional/specs_in_fun.move:42:5: simple1_incorrect
+    =     at tests/sources/functional/specs_in_fun.move:43:9: simple1_incorrect
     =         x = <redacted>,
     =         y = <redacted>
-    =     at tests/sources/functional/specs_in_fun.move:43:9: simple1_incorrect
 
 error:  This assertion might not hold.
 
@@ -19,9 +19,9 @@ error:  This assertion might not hold.
     │             ^^^^^^^^^^^^^^
     │
     =     at tests/sources/functional/specs_in_fun.move:49:5: simple2_incorrect
+    =     at tests/sources/functional/specs_in_fun.move:51:17: simple2_incorrect
     =         x = <redacted>,
     =         y = <redacted>
-    =     at tests/sources/functional/specs_in_fun.move:51:15: simple2_incorrect
     =     at tests/sources/functional/specs_in_fun.move:53:13: simple2_incorrect
 
 error:  This assertion might not hold.
@@ -32,9 +32,9 @@ error:  This assertion might not hold.
     │             ^^^^^^^^^^^^^
     │
     =     at tests/sources/functional/specs_in_fun.move:57:5: simple3_incorrect
+    =     at tests/sources/functional/specs_in_fun.move:59:13: simple3_incorrect
     =         x = <redacted>,
     =         y = <redacted>
-    =     at tests/sources/functional/specs_in_fun.move:59:13: simple3_incorrect
 
 error:  This assertion might not hold.
 
@@ -44,8 +44,8 @@ error:  This assertion might not hold.
     │             ^^^^^^^^^^^^^^^
     │
     =     at tests/sources/functional/specs_in_fun.move:64:5: simple4_incorrect
+    =     at tests/sources/functional/specs_in_fun.move:66:15: simple4_incorrect
     =         x = <redacted>,
     =         y = <redacted>,
     =         z = <redacted>
-    =     at tests/sources/functional/specs_in_fun.move:66:15: simple4_incorrect
     =     at tests/sources/functional/specs_in_fun.move:68:13: simple4_incorrect

--- a/language/move-prover/tests/sources/functional/specs_in_fun.move
+++ b/language/move-prover/tests/sources/functional/specs_in_fun.move
@@ -1,6 +1,6 @@
+// flag: --v2
 module TestAssertAndAssume {
     // Tests that should verify
-
     spec module {
         pragma verify = true;
     }

--- a/language/move-prover/tests/sources/functional/specs_in_fun_ref.exp
+++ b/language/move-prover/tests/sources/functional/specs_in_fun_ref.exp
@@ -1,4 +1,32 @@
 Move prover returns: exiting with boogie verification errors
+error:  This assertion might not hold.
+
+    ┌── tests/sources/functional/specs_in_fun_ref.move:74:13 ───
+    │
+ 74 │             assert x == n;
+    │             ^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/specs_in_fun_ref.move:63:5: simple5
+    =     at tests/sources/functional/specs_in_fun_ref.move:64:17: simple5
+    =         n = <redacted>,
+    =         x = <redacted>
+    =     at tests/sources/functional/specs_in_fun_ref.move:67:13: simple5
+    =     at tests/sources/functional/specs_in_fun_ref.move:70:13: simple5
+
+error:  This assertion might not hold.
+
+    ┌── tests/sources/functional/specs_in_fun_ref.move:96:13 ───
+    │
+ 96 │             assert x == n;
+    │             ^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/specs_in_fun_ref.move:84:5: simple6
+    =     at tests/sources/functional/specs_in_fun_ref.move:85:17: simple6
+    =         n = <redacted>,
+    =         x = <redacted>
+    =     at tests/sources/functional/specs_in_fun_ref.move:88:13: simple6
+    =     at tests/sources/functional/specs_in_fun_ref.move:87:9: simple6
+
 error:  This loop invariant might not be maintained by the loop.
 
      ┌── tests/sources/functional/specs_in_fun_ref.move:111:17 ───
@@ -7,10 +35,10 @@ error:  This loop invariant might not be maintained by the loop.
      │                 ^^^^^^^^^^^^^^
      │
      =     at tests/sources/functional/specs_in_fun_ref.move:106:5: simple7
+     =     at tests/sources/functional/specs_in_fun_ref.move:107:17: simple7
      =         n = <redacted>,
-     =         x = <redacted>,
      =         x = <redacted>
-     =     at tests/sources/functional/specs_in_fun_ref.move:107:13: simple7
      =     at tests/sources/functional/specs_in_fun_ref.move:110:13: simple7
      =     at tests/sources/functional/specs_in_fun_ref.move:109:9: simple7
+     =         x = <redacted>
      =     at tests/sources/functional/specs_in_fun_ref.move:115:19: simple7

--- a/language/move-prover/tests/sources/functional/specs_in_fun_ref.move
+++ b/language/move-prover/tests/sources/functional/specs_in_fun_ref.move
@@ -1,8 +1,8 @@
+// flag: --v2
 module TestAssertWithReferences {
     spec module {
         pragma verify = true;
     }
-
     // This function verifies.
     // Feature: An input parameter is mutated
     fun simple1(x: u64, y: u64) {


### PR DESCRIPTION
This PR provides a long-wanted refactoring to eliminate the symbolic reference to bytecode temporaries by index-based references. The new exp variant `Temporary(id, index)` serve for this purpose. `LocalVar(id, symbol)` is still used for names introduced by spec expressions.

 This removes a long-standing bug regards name shadowing of temporaries which the prover cannot correctly resolve based on bytecode only. Also, spec blocks in code are now using the indices provided by the Move compiler instead of symbolic lookup. This allows to remove a number of TODO's and simplifications. 

This PR also enables spec blocks in code for the V2 compilation scheme which are now reduced to `Bytecode::Prop(..)` instructions at time of stackless bytecode generation.

After this PR, we are ready to re-visit loop invariants for the V2 compilation scheme.

A lot of baseline diffs in the bytecode crate stem from that temporaries are not longer symbolically displayed but by index.

## Motivation

Simplify prover

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Ported spec-in-code tests for V2 scheme

## Related PRs

NA
