### PR TITLE
[gha] report on all docker errors at end of each step:

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -51,13 +51,18 @@ jobs:
         run: |
           BRANCH="$CHANGES_TARGET_BRANCH"
           success=0
-          docker/build_push.sh -u -p -b ${BRANCH} -n client || success=-1
-          docker/build_push.sh -u -p -b ${BRANCH} -n init || success=-1
-          docker/build_push.sh -u -p -b ${BRANCH} -n faucet || success=-1
-          docker/build_push.sh -u -p -b ${BRANCH} -n tools || success=-1
-          docker/build_push.sh -u -p -b ${BRANCH} -n validator || success=-1
-          docker/build_push.sh -u -p -b ${BRANCH} -n validator-tcb || success=-1
-          docker/build_push.sh -u -p -b ${BRANCH} -n cluster-test || success=-1
+          tmpfile=$(mktemp)
+          echo "Failed to push:" > "${tmpfile}"
+          docker/build_push.sh -u -p -b ${BRANCH} -n client || success=$(echo "client" >> "${tmpfile}"; echo 1)
+          docker/build_push.sh -u -p -b ${BRANCH} -n init || success=$(echo "init" >> "${tmpfile}"; echo 1)
+          docker/build_push.sh -u -p -b ${BRANCH} -n faucet || success=$(echo "faucet" >> "${tmpfile}"; echo 1)
+          docker/build_push.sh -u -p -b ${BRANCH} -n tools || success=$(echo "tools" >> "${tmpfile}"; echo 1)
+          docker/build_push.sh -u -p -b ${BRANCH} -n validator || success=$(echo "validator" >> "${tmpfile}"; echo 1)
+          docker/build_push.sh -u -p -b ${BRANCH} -n validator-tcb || success=$(echo "validator-tcb" >> "${tmpfile}"; echo 1)
+          docker/build_push.sh -u -p -b ${BRANCH} -n cluster-test || success=$(echo "cluster-test" >> "${tmpfile}"; echo 1)
+          if [[ "$success" == "1" ]]; then
+            cat "${tmpfile}"
+          fi
           exit $success
         env:
           DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKERHUB_KEY_PASSWORD }}
@@ -67,13 +72,18 @@ jobs:
           set -x
           BRANCH=$(echo "$GITHUB_REF" | sed 's|.*/||' )
           success=0
-          docker/build_push.sh -u -b ${BRANCH} -n client || success=-1
-          docker/build_push.sh -u -b ${BRANCH} -n init || success=-1
-          docker/build_push.sh -u -b ${BRANCH} -n faucet || success=-1
-          docker/build_push.sh -u -b ${BRANCH} -n tools || success=-1
-          docker/build_push.sh -u -b ${BRANCH} -n validator || success=-1
-          docker/build_push.sh -u -b ${BRANCH} -n validator-tcb || success=-1
-          docker/build_push.sh -u -b ${BRANCH} -n cluster-test || success=-1
+          tmpfile=$(mktemp)
+          echo "Failed to push:" >> "${tmpfile}"
+          docker/build_push.sh -u -b ${BRANCH} -n client || success=$(echo "client" >> "${tmpfile}"; echo 1)
+          docker/build_push.sh -u -b ${BRANCH} -n init ||  success=$(echo "init" >> "${tmpfile}"; echo 1)
+          docker/build_push.sh -u -b ${BRANCH} -n faucet ||  success=$(echo "faucet" >> "${tmpfile}"; echo 1)
+          docker/build_push.sh -u -b ${BRANCH} -n tools ||  success=$(echo "tools" >> "${tmpfile}"; echo 1)
+          docker/build_push.sh -u -b ${BRANCH} -n validator || success=$(echo "validator" >> "${tmpfile}"; echo 1)
+          docker/build_push.sh -u -b ${BRANCH} -n validator-tcb || success=$(echo "validator-tcb" >> "${tmpfile}"; echo 1)
+          docker/build_push.sh -u -b ${BRANCH} -n cluster-test || success=$(echo "cluster-test" >> "${tmpfile}"; echo 1)
+          if [[ "$success" == "1" ]]; then
+            cat "${tmpfile}"
+          fi
           exit $success
         env:
           DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKERHUB_KEY_PASSWORD }}

--- a/docker/docker_republish.sh
+++ b/docker/docker_republish.sh
@@ -81,12 +81,20 @@ docker tag diem/validator_tcb:"$DOCKERHUB_TAG" "$TARGET_REPO"/"$TARGET_ORG"/vali
 docker tag diem/cluster_test:"$DOCKERHUB_TAG" "$TARGET_REPO"/"$TARGET_ORG"/cluster_test:"$OUTPUT_TAG"
 docker tag diem/client:"$DOCKERHUB_TAG" "$TARGET_REPO"/"$TARGET_ORG"/client:"$OUTPUT_TAG"
 
-docker push --disable-content-trust="$DISABLE_TRUST" "$TARGET_REPO"/"$TARGET_ORG"/init:"$OUTPUT_TAG"
-docker push --disable-content-trust="$DISABLE_TRUST" "$TARGET_REPO"/"$TARGET_ORG"/faucet:"$OUTPUT_TAG"
-docker push --disable-content-trust="$DISABLE_TRUST" "$TARGET_REPO"/"$TARGET_ORG"/tools:"$OUTPUT_TAG"
-docker push --disable-content-trust="$DISABLE_TRUST" "$TARGET_REPO"/"$TARGET_ORG"/validator:"$OUTPUT_TAG"
-docker push --disable-content-trust="$DISABLE_TRUST" "$TARGET_REPO"/"$TARGET_ORG"/validator_tcb:"$OUTPUT_TAG"
-docker push --disable-content-trust="$DISABLE_TRUST" "$TARGET_REPO"/"$TARGET_ORG"/cluster_test:"$OUTPUT_TAG"
-docker push --disable-content-trust="$DISABLE_TRUST" "$TARGET_REPO"/"$TARGET_ORG"/client:"$OUTPUT_TAG"
+tmpfile=$(mktemp)
+success=0;
+echo "Failed to republish" >> "${tmpfile}"
+docker push --disable-content-trust="$DISABLE_TRUST" "$TARGET_REPO"/"$TARGET_ORG"/init:"$OUTPUT_TAG" || success=$(echo "init" >> "${tmpfile}"; echo 1)
+docker push --disable-content-trust="$DISABLE_TRUST" "$TARGET_REPO"/"$TARGET_ORG"/faucet:"$OUTPUT_TAG" || success=$(echo "faucet" >> "${tmpfile}"; echo 1)
+docker push --disable-content-trust="$DISABLE_TRUST" "$TARGET_REPO"/"$TARGET_ORG"/tools:"$OUTPUT_TAG" || success=$(echo "tools" >> "${tmpfile}"; echo 1)
+docker push --disable-content-trust="$DISABLE_TRUST" "$TARGET_REPO"/"$TARGET_ORG"/validator:"$OUTPUT_TAG" || success=$(echo "validator" >> "${tmpfile}"; echo 1)
+docker push --disable-content-trust="$DISABLE_TRUST" "$TARGET_REPO"/"$TARGET_ORG"/validator_tcb:"$OUTPUT_TAG" || success=$(echo "validator_tcb" >> "${tmpfile}"; echo 1)
+docker push --disable-content-trust="$DISABLE_TRUST" "$TARGET_REPO"/"$TARGET_ORG"/cluster_test:"$OUTPUT_TAG" || success=$(echo "cluster_test" >> "${tmpfile}"; echo 1)
+docker push --disable-content-trust="$DISABLE_TRUST" "$TARGET_REPO"/"$TARGET_ORG"/client:"$OUTPUT_TAG" || success=$(echo "client" >> "${tmpfile}"; echo 1)
+
+if [[ "$success" == "1" ]]; then
+  cat "${tmpfile}"
+fi
 
 set +x
+exit "${success}"


### PR DESCRIPTION
## Motivation

Multiple steps run even if prior errors occur in gha docker push

First we build locally and tag and push to docker.io/diem/

Then republish to  docker.io/libra/

Then republish to ecr/diem/

If any image fails to push in a step, mark the step as a failure and print out the image name at the end of the step.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

gha-test-1 branch:

forced failure:  https://github.com/diem/diem/runs/1772453602?check_suite_focus=true
success: https://github.com/diem/diem/runs/1772302304?check_suite_focus=true

## Related PRs

None.