### PR TITLE
[transaction builder generator] fix new pyre error

### DIFF
--- a/language/transaction-builder/generator/src/python3.rs
+++ b/language/transaction-builder/generator/src/python3.rs
@@ -353,7 +353,7 @@ def decode_{}_argument(arg: TransactionArgument) -> {}:
     fn quote_type(type_tag: &TypeTag) -> String {
         use TypeTag::*;
         match type_tag {
-            Bool => "st.bool".into(),
+            Bool => "bool".into(),
             U8 => "st.uint8".into(),
             U64 => "st.uint64".into(),
             U128 => "st.uint128".into(),


### PR DESCRIPTION
## Motivation

Suddenly, pyre doesn't like us aliasing `bool` into `serde_types.bool`.

## Test Plan

```
cargo test -p transaction-builder-generator -- --ignored
```

## Related PRs

https://github.com/novifinancial/serde-reflection/pull/81/commits/c591ca29ac0c8dc022155701f78fc34c920dd596