### PR TITLE
[diem framework] Add detailed comments to SlidingNonce. Fix generation of code decoration.

### DIFF
--- a/language/move-prover/docgen/tests/sources/code_block_test.move
+++ b/language/move-prover/docgen/tests/sources/code_block_test.move
@@ -1,0 +1,8 @@
+script {
+    /// # Explanation of the algorithm
+    /// ```
+    /// code block
+    /// ```
+    /// then `inline code`
+    fun main() { }
+}

--- a/language/move-prover/docgen/tests/sources/code_block_test.spec_inline.md
+++ b/language/move-prover/docgen/tests/sources/code_block_test.spec_inline.md
@@ -1,0 +1,39 @@
+
+<a name="main"></a>
+
+# Script `main`
+
+
+
+-  [Explanation of the algorithm](#@Explanation_of_the_algorithm_0)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="@Explanation_of_the_algorithm_0"></a>
+
+## Explanation of the algorithm
+
+```
+code block
+```
+then <code>inline code</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="code_block_test.md#main">main</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="code_block_test.md#main">main</a>() { }
+</code></pre>
+
+
+
+</details>

--- a/language/move-prover/docgen/tests/sources/code_block_test.spec_inline_no_fold.md
+++ b/language/move-prover/docgen/tests/sources/code_block_test.spec_inline_no_fold.md
@@ -1,0 +1,34 @@
+
+<a name="main"></a>
+
+# Script `main`
+
+
+
+-  [Explanation of the algorithm](#@Explanation_of_the_algorithm_0)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="@Explanation_of_the_algorithm_0"></a>
+
+## Explanation of the algorithm
+
+```
+code block
+```
+then <code>inline code</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="code_block_test.md#main">main</a>()
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>fun</b> <a href="code_block_test.md#main">main</a>() { }
+</code></pre>

--- a/language/move-prover/docgen/tests/sources/code_block_test.spec_separate.md
+++ b/language/move-prover/docgen/tests/sources/code_block_test.spec_separate.md
@@ -1,0 +1,39 @@
+
+<a name="main"></a>
+
+# Script `main`
+
+
+
+-  [Explanation of the algorithm](#@Explanation_of_the_algorithm_0)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="@Explanation_of_the_algorithm_0"></a>
+
+## Explanation of the algorithm
+
+```
+code block
+```
+then <code>inline code</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="code_block_test.md#main">main</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="code_block_test.md#main">main</a>() { }
+</code></pre>
+
+
+
+</details>

--- a/language/stdlib/modules/DiemAccount.move
+++ b/language/stdlib/modules/DiemAccount.move
@@ -2022,8 +2022,8 @@ module DiemAccount {
         invariant [global] forall token: type: forall addr: address where exists<Balance<token>>(addr):
             Roles::spec_can_hold_balance_addr(addr);
 
-        /// If there is a `DesignatedDealer::Dealer resource published at addr, the addr has a
-        /// DesignatedDealer role.
+        /// If there is a `DesignatedDealer::Dealer` resource published at `addr`, the `addr` has a
+        /// `Roles::DesignatedDealer` role.
         // Verified with additional target DesignatedDealer.move
         invariant [global] forall addr: address where exists<DesignatedDealer::Dealer>(addr):
             Roles::spec_has_designated_dealer_role_addr(addr);

--- a/language/stdlib/modules/DualAttestation.move
+++ b/language/stdlib/modules/DualAttestation.move
@@ -248,7 +248,7 @@ module DualAttestation {
         global<Credential>(addr).compliance_public_key
     }
 
-    /// Return the expiration date `addr
+    /// Return the expiration date `addr`
     /// Aborts if `addr` does not have a `Credential` resource.
     public fun expiration_date(addr: address): u64  acquires Credential {
         assert(exists<Credential>(addr), Errors::not_published(ECREDENTIAL));

--- a/language/stdlib/modules/RecoveryAddress.move
+++ b/language/stdlib/modules/RecoveryAddress.move
@@ -151,7 +151,7 @@ module RecoveryAddress {
     }
 
     /// Add `to_recover` to the `RecoveryAddress` resource under `recovery_address`.
-    /// Aborts if `to_recover.address` and `recovery_address belong to different VASPs, or if
+    /// Aborts if `to_recover.address` and `recovery_address` belong to different VASPs, or if
     /// `recovery_address` does not have a `RecoveryAddress` resource.
     public fun add_rotation_capability(to_recover: KeyRotationCapability, recovery_address: address)
     acquires RecoveryAddress {

--- a/language/stdlib/modules/Signature.move
+++ b/language/stdlib/modules/Signature.move
@@ -16,7 +16,7 @@ module Signature {
     /// - `signature` is not 64 bytes
     /// - `public_key` is not 32 bytes
     /// - `public_key` does not pass points-on-curve or small subgroup checks,
-    /// - `signature and `public_key` are valid, but the signature on `message` does not verify.
+    /// - `signature` and `public_key` are valid, but the signature on `message` does not verify.
     /// Does not abort.
     native public fun ed25519_verify(
         signature: vector<u8>,

--- a/language/stdlib/modules/doc/Diem.md
+++ b/language/stdlib/modules/doc/Diem.md
@@ -1086,10 +1086,9 @@ reference.
 <pre><code><b>pragma</b> opaque;
 <b>modifies</b> <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
 <b>ensures</b> <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
-<a name="0x1_Diem_currency_info$59"></a>
-<b>let</b> currency_info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
 <b>include</b> <a href="Diem.md#0x1_Diem_MintAbortsIf">MintAbortsIf</a>&lt;CoinType&gt;;
 <b>include</b> <a href="Diem.md#0x1_Diem_MintEnsures">MintEnsures</a>&lt;CoinType&gt;;
+<b>include</b> <a href="Diem.md#0x1_Diem_MintEmits">MintEmits</a>&lt;CoinType&gt;;
 </code></pre>
 
 
@@ -1118,9 +1117,29 @@ reference.
     <a name="0x1_Diem_currency_info$50"></a>
     <b>let</b> currency_info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
     <b>ensures</b> <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
-    <b>ensures</b> currency_info
-        == update_field(<b>old</b>(currency_info), total_value, <b>old</b>(currency_info.total_value) + value);
+    <b>ensures</b> currency_info == update_field(<b>old</b>(currency_info), total_value, <b>old</b>(currency_info.total_value) + value);
     <b>ensures</b> result.value == value;
+}
+</code></pre>
+
+
+
+
+<a name="0x1_Diem_MintEmits"></a>
+
+
+<pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_MintEmits">MintEmits</a>&lt;CoinType&gt; {
+    value: u64;
+    <a name="0x1_Diem_currency_info$51"></a>
+    <b>let</b> currency_info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
+    <a name="0x1_Diem_handle$52"></a>
+    <b>let</b> handle = currency_info.mint_events;
+    <a name="0x1_Diem_msg$53"></a>
+    <b>let</b> msg = <a href="Diem.md#0x1_Diem_MintEvent">MintEvent</a>{
+        amount: value,
+        currency_code: currency_info.currency_code,
+    };
+    emits msg <b>to</b> handle <b>if</b> !currency_info.is_synthetic;
 }
 </code></pre>
 
@@ -1396,7 +1415,7 @@ Calls to this function will fail if <code>account</code> does not have a
 
 
 
-<a name="0x1_Diem_preburn$60"></a>
+<a name="0x1_Diem_preburn$64"></a>
 
 
 <pre><code><b>let</b> preburn = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(<a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account));
@@ -1413,9 +1432,9 @@ Calls to this function will fail if <code>account</code> does not have a
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_PreburnToAbortsIf">PreburnToAbortsIf</a>&lt;CoinType&gt; {
     account: signer;
     amount: u64;
-    <a name="0x1_Diem_account_addr$51"></a>
+    <a name="0x1_Diem_account_addr$54"></a>
     <b>let</b> account_addr = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
-    <a name="0x1_Diem_preburn$52"></a>
+    <a name="0x1_Diem_preburn$55"></a>
     <b>let</b> preburn = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(account_addr);
 }
 </code></pre>
@@ -1664,9 +1683,9 @@ at <code>preburn_address</code> does not contain a pending burn request.
 
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_CancelBurnWithCapAbortsIf">CancelBurnWithCapAbortsIf</a>&lt;CoinType&gt; {
     preburn_address: address;
-    <a name="0x1_Diem_info$53"></a>
+    <a name="0x1_Diem_info$56"></a>
     <b>let</b> info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
-    <a name="0x1_Diem_amount$54"></a>
+    <a name="0x1_Diem_amount$57"></a>
     <b>let</b> amount = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(preburn_address).to_burn.value;
     <b>aborts_if</b> !<b>exists</b>&lt;<a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(preburn_address) <b>with</b> <a href="Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
     <b>include</b> <a href="Diem.md#0x1_Diem_AbortsIfNoCurrency">AbortsIfNoCurrency</a>&lt;CoinType&gt;;
@@ -1682,9 +1701,9 @@ at <code>preburn_address</code> does not contain a pending burn request.
 
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_CancelBurnWithCapEnsures">CancelBurnWithCapEnsures</a>&lt;CoinType&gt; {
     preburn_address: address;
-    <a name="0x1_Diem_preburn_value$55"></a>
+    <a name="0x1_Diem_preburn_value$58"></a>
     <b>let</b> preburn_value = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(preburn_address).to_burn.value;
-    <a name="0x1_Diem_total_preburn_value$56"></a>
+    <a name="0x1_Diem_total_preburn_value$59"></a>
     <b>let</b> total_preburn_value =
         <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>()).preburn_value;
     <b>ensures</b> preburn_value == 0;
@@ -1736,7 +1755,7 @@ used for administrative burns, like unpacking an XDX coin or charging fees.
 
 <pre><code><b>include</b> <a href="Diem.md#0x1_Diem_BurnNowAbortsIf">BurnNowAbortsIf</a>&lt;CoinType&gt;;
 <b>ensures</b> preburn.to_burn.value == 0;
-<a name="0x1_Diem_info$61"></a>
+<a name="0x1_Diem_info$65"></a>
 <b>let</b> info = <a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;();
 <b>ensures</b> info.total_value == <b>old</b>(info.total_value) - coin.value;
 </code></pre>
@@ -1752,7 +1771,7 @@ used for administrative burns, like unpacking an XDX coin or charging fees.
     preburn: <a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;;
     <b>aborts_if</b> coin.value == 0 <b>with</b> <a href="Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
     <b>include</b> <a href="Diem.md#0x1_Diem_PreburnWithResourceAbortsIf">PreburnWithResourceAbortsIf</a>&lt;CoinType&gt;{amount: coin.value};
-    <a name="0x1_Diem_info$57"></a>
+    <a name="0x1_Diem_info$60"></a>
     <b>let</b> info = <a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;();
     <b>aborts_if</b> info.total_value &lt; coin.value <b>with</b> <a href="Errors.md#0x1_Errors_LIMIT_EXCEEDED">Errors::LIMIT_EXCEEDED</a>;
 }
@@ -2483,7 +2502,7 @@ rate is needed.
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_ApproxXdmForValueAbortsIf">ApproxXdmForValueAbortsIf</a>&lt;CoinType&gt; {
     from_value: num;
     <b>include</b> <a href="Diem.md#0x1_Diem_AbortsIfNoCurrency">AbortsIfNoCurrency</a>&lt;CoinType&gt;;
-    <a name="0x1_Diem_xdx_exchange_rate$58"></a>
+    <a name="0x1_Diem_xdx_exchange_rate$61"></a>
     <b>let</b> xdx_exchange_rate = <a href="Diem.md#0x1_Diem_spec_xdx_exchange_rate">spec_xdx_exchange_rate</a>&lt;CoinType&gt;();
     <b>include</b> <a href="FixedPoint32.md#0x1_FixedPoint32_MultiplyAbortsIf">FixedPoint32::MultiplyAbortsIf</a>{val: from_value, multiplier: xdx_exchange_rate};
 }
@@ -2746,6 +2765,7 @@ Updates the <code>to_xdx_exchange_rate</code> held in the <code><a href="Diem.md
 
 <pre><code><b>include</b> <a href="Diem.md#0x1_Diem_UpdateXDXExchangeRateAbortsIf">UpdateXDXExchangeRateAbortsIf</a>&lt;FromCoinType&gt;;
 <b>include</b> <a href="Diem.md#0x1_Diem_UpdateXDXExchangeRateEnsures">UpdateXDXExchangeRateEnsures</a>&lt;FromCoinType&gt;;
+<b>include</b> <a href="Diem.md#0x1_Diem_UpdateXDXExchangeRateEmits">UpdateXDXExchangeRateEmits</a>&lt;FromCoinType&gt;;
 </code></pre>
 
 
@@ -2778,6 +2798,25 @@ Must abort if the account does not have the TreasuryCompliance Role [[H5]][PERMI
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_UpdateXDXExchangeRateEnsures">UpdateXDXExchangeRateEnsures</a>&lt;FromCoinType&gt; {
     xdx_exchange_rate: <a href="FixedPoint32.md#0x1_FixedPoint32">FixedPoint32</a>;
     <b>ensures</b> <a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;FromCoinType&gt;().to_xdx_exchange_rate == xdx_exchange_rate;
+}
+</code></pre>
+
+
+
+
+<a name="0x1_Diem_UpdateXDXExchangeRateEmits"></a>
+
+
+<pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_UpdateXDXExchangeRateEmits">UpdateXDXExchangeRateEmits</a>&lt;FromCoinType&gt; {
+    xdx_exchange_rate: <a href="FixedPoint32.md#0x1_FixedPoint32">FixedPoint32</a>;
+    <a name="0x1_Diem_handle$62"></a>
+    <b>let</b> handle = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;FromCoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>()).exchange_rate_update_events;
+    <a name="0x1_Diem_msg$63"></a>
+    <b>let</b> msg = <a href="Diem.md#0x1_Diem_ToXDXExchangeRateUpdateEvent">ToXDXExchangeRateUpdateEvent</a> {
+        currency_code: <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;FromCoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>()).currency_code,
+        new_to_xdx_exchange_rate: <a href="FixedPoint32.md#0x1_FixedPoint32_get_raw_value">FixedPoint32::get_raw_value</a>(xdx_exchange_rate)
+    };
+    emits msg <b>to</b> handle;
 }
 </code></pre>
 

--- a/language/stdlib/modules/doc/DiemAccount.md
+++ b/language/stdlib/modules/doc/DiemAccount.md
@@ -4587,8 +4587,8 @@ If an account has a balance, the role of the account is compatible with having a
 </code></pre>
 
 
-If there is a `DesignatedDealer::Dealer resource published at addr, the addr has a
-DesignatedDealer role.
+If there is a <code><a href="DesignatedDealer.md#0x1_DesignatedDealer_Dealer">DesignatedDealer::Dealer</a></code> resource published at <code>addr</code>, the <code>addr</code> has a
+<code>Roles::DesignatedDealer</code> role.
 
 
 <pre><code><b>invariant</b> [<b>global</b>] <b>forall</b> addr: address <b>where</b> <b>exists</b>&lt;<a href="DesignatedDealer.md#0x1_DesignatedDealer_Dealer">DesignatedDealer::Dealer</a>&gt;(addr):

--- a/language/stdlib/modules/doc/DiemTimestamp.md
+++ b/language/stdlib/modules/doc/DiemTimestamp.md
@@ -143,12 +143,14 @@ account.
 <summary>Specification</summary>
 
 
-Verification of this function is turned off because it cannot be verified without genesis execution
-context. After time has started, all invariants guarded by <code><a href="DiemTimestamp.md#0x1_DiemTimestamp_is_operating">DiemTimestamp::is_operating</a></code> will become
-activated and need to hold.
+The friend of this function is <code><a href="Genesis.md#0x1_Genesis_initialize">Genesis::initialize</a></code> which means that
+this function can't be verified on its own and has to be verified in
+context of Genesis execution.
+After time has started, all invariants guarded by <code><a href="DiemTimestamp.md#0x1_DiemTimestamp_is_operating">DiemTimestamp::is_operating</a></code>
+will become activated and need to hold.
 
 
-<pre><code><b>pragma</b> verify = <b>false</b>;
+<pre><code><b>pragma</b> friend = <a href="Genesis.md#0x1_Genesis_initialize">0x1::Genesis::initialize</a>;
 <b>include</b> <a href="DiemTimestamp.md#0x1_DiemTimestamp_AbortsIfNotGenesis">AbortsIfNotGenesis</a>;
 <b>include</b> <a href="CoreAddresses.md#0x1_CoreAddresses_AbortsIfNotDiemRoot">CoreAddresses::AbortsIfNotDiemRoot</a>{account: dr_account};
 <b>ensures</b> <a href="DiemTimestamp.md#0x1_DiemTimestamp_is_operating">is_operating</a>();

--- a/language/stdlib/modules/doc/DualAttestation.md
+++ b/language/stdlib/modules/doc/DualAttestation.md
@@ -764,8 +764,8 @@ Spec version of <code><a href="DualAttestation.md#0x1_DualAttestation_compliance
 
 ## Function `expiration_date`
 
-Return the expiration date <code>addr
-Aborts <b>if</b> </code>addr<code> does not have a </code>Credential` resource.
+Return the expiration date <code>addr</code>
+Aborts if <code>addr</code> does not have a <code><a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a></code> resource.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="DualAttestation.md#0x1_DualAttestation_expiration_date">expiration_date</a>(addr: address): u64

--- a/language/stdlib/modules/doc/Event.md
+++ b/language/stdlib/modules/doc/Event.md
@@ -292,13 +292,8 @@ Destroy a unique handle.
 
 
 
-> NOTE: specification and verification of event related functionality is currently not happening.
-> Since events cannot be observed from Move programs, this does not affect the verification of
-> other functionality; however, this should be completed at a later point to ensure the framework
-> generates events as expected.
-
 Functions of the event module are mocked out using the intrinsic
-pragma. They are implemented in the prover's prelude as no-ops.
+pragma. They are implemented in the prover's prelude.
 
 
 <pre><code><b>pragma</b> intrinsic = <b>true</b>;

--- a/language/stdlib/modules/doc/RecoveryAddress.md
+++ b/language/stdlib/modules/doc/RecoveryAddress.md
@@ -357,8 +357,8 @@ Aborts if <code>recovery_address</code> does not have the <code>KeyRotationCapab
 ## Function `add_rotation_capability`
 
 Add <code>to_recover</code> to the <code><a href="RecoveryAddress.md#0x1_RecoveryAddress">RecoveryAddress</a></code> resource under <code>recovery_address</code>.
-Aborts if <code>to_recover.address</code> and <code>recovery_address belong <b>to</b> different VASPs, or <b>if</b>
-</code>recovery_address<code> does not have a </code>RecoveryAddress` resource.
+Aborts if <code>to_recover.address</code> and <code>recovery_address</code> belong to different VASPs, or if
+<code>recovery_address</code> does not have a <code><a href="RecoveryAddress.md#0x1_RecoveryAddress">RecoveryAddress</a></code> resource.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_add_rotation_capability">add_rotation_capability</a>(to_recover: <a href="DiemAccount.md#0x1_DiemAccount_KeyRotationCapability">DiemAccount::KeyRotationCapability</a>, recovery_address: address)

--- a/language/stdlib/modules/doc/Signature.md
+++ b/language/stdlib/modules/doc/Signature.md
@@ -51,7 +51,7 @@ Returns <code><b>false</b></code> if:
 - <code>signature</code> is not 64 bytes
 - <code>public_key</code> is not 32 bytes
 - <code>public_key</code> does not pass points-on-curve or small subgroup checks,
-- <code>signature and </code>public_key<code> are valid, but the signature on </code>message` does not verify.
+- <code>signature</code> and <code>public_key</code> are valid, but the signature on <code>message</code> does not verify.
 Does not abort.
 
 

--- a/language/stdlib/modules/doc/SlidingNonce.md
+++ b/language/stdlib/modules/doc/SlidingNonce.md
@@ -14,8 +14,13 @@ When nonce X is recorded, all transactions with nonces lower then X-128 will abo
 -  [Constants](#@Constants_0)
 -  [Function `record_nonce_or_abort`](#0x1_SlidingNonce_record_nonce_or_abort)
 -  [Function `try_record_nonce`](#0x1_SlidingNonce_try_record_nonce)
+    -  [Explanation of the Algorithm](#@Explanation_of_the_Algorithm_1)
+    -  [Some Examples](#@Some_Examples_2)
+    -  [Example 1:](#@Example_1:_3)
+    -  [Example 2:](#@Example_2:_4)
+    -  [Example 3:](#@Example_3:_5)
 -  [Function `publish`](#0x1_SlidingNonce_publish)
--  [Module Specification](#@Module_Specification_1)
+-  [Module Specification](#@Module_Specification_6)
 
 
 <pre><code><b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
@@ -180,6 +185,165 @@ Calls <code>try_record_nonce</code> and aborts transaction if returned code is n
 
 ## Function `try_record_nonce`
 
+
+<a name="@Explanation_of_the_Algorithm_1"></a>
+
+### Explanation of the Algorithm
+
+
+We have an "infinite" bitvector. The <code>min_nonce</code> tells us the starting
+index of the window. The window size is the size of the bitmask we can
+represent in a 128-bit wide bitmap. The <code>seq_nonce</code> that is sent represents
+setting a bit at index <code>seq_nonce</code> in this infinite bitvector. Because of
+this, if the same <code>seq_nonce</code> is passed in multiple times, that bit will be
+set, and we can signal an error. In order to represent
+the <code>seq_nonce</code> the window we are looking at must be shifted so that
+<code>seq_nonce</code> lies within that 128-bit window and, since the <code>min_nonce</code>
+represents the left-hand-side of this window, it must be increased to be no
+less than <code>seq_nonce - 128</code>.
+
+The process of shifting window will invalidate other transactions that
+have a <code>seq_nonce</code> number that are to the "left" of this window (i.e., less
+than <code>min_nonce</code>) since it cannot be represented in the current window, and the
+window can only move forward and never backwards.
+
+In order to prevent shifting this window over too much at any one time, a
+<code>jump_limit</code> is imposed. If a <code>seq_nonce</code> is provided that would cause the
+<code>min_nonce</code> to need to be increased by more than the <code>jump_limit</code> this will
+cause a failure.
+
+
+<a name="@Some_Examples_2"></a>
+
+### Some Examples
+
+
+Let's say we start out with a clean <code><a href="SlidingNonce.md#0x1_SlidingNonce">SlidingNonce</a></code> published under <code>account</code>,
+this will look like this:
+```
+000000000000000000...00000000000000000000000000000...
+^             ...                ^
+|_____________...________________|
+min_nonce = 0             min_nonce + NONCE_MASK_SIZE = 0 + 64 = 64
+```
+
+
+<a name="@Example_1:_3"></a>
+
+### Example 1:
+
+
+Let's see what happens when we call<code><a href="SlidingNonce.md#0x1_SlidingNonce_try_record_nonce">SlidingNonce::try_record_nonce</a>(account, 8)</code>:
+
+1. Determine the bit position w.r.t. the current window:
+```
+bit_pos = 8 - min_nonce ~~~ 8 - 0 = 8
+```
+2. See if the bit position that was calculated is not within the current window:
+```
+bit_pos >= NONCE_MASK_SIZE ~~~ 8 >= 128 = FALSE
+```
+3. <code>bit_pos</code> is in window, so set the 8'th bit in the window:
+```
+000000010000000000...00000000000000000000000000000...
+^             ...                ^
+|_____________...________________|
+min_nonce = 0             min_nonce + NONCE_MASK_SIZE = 0 + 64 = 64
+```
+
+
+<a name="@Example_2:_4"></a>
+
+### Example 2:
+
+
+Let's see what happens when we call <code><a href="SlidingNonce.md#0x1_SlidingNonce_try_record_nonce">SlidingNonce::try_record_nonce</a>(account, 129)</code>:
+
+1. Figure out the bit position w.r.t. the current window:
+```
+bit_pos = 129 - min_nonce ~~~ 129 - 0 = 129
+```
+2. See if bit position calculated is not within the current window starting at <code>min_nonce</code>:
+```
+bit_pos >= NONCE_MASK_SIZE ~~~ 129 >= 128 = TRUE
+```
+3. <code>bit_pos</code> is outside of the current window. So we need to shift the window over. Now calculate the amount that
+the window needs to be shifted over (i.e., the amount that <code>min_nonce</code> needs to be increased by) so that
+<code>seq_nonce</code> lies within the <code><a href="SlidingNonce.md#0x1_SlidingNonce_NONCE_MASK_SIZE">NONCE_MASK_SIZE</a></code> window starting at <code>min_nonce</code>.
+3a. Calculate the amount that the window needs to be shifted for <code>bit_pos</code> to lie within it:
+```
+shift = bit_pos - NONCE_MASK_SIZE + 1 ~~~ 129 - 128 + 1 = 2
+```
+3b. See if there is no overlap between the new window that we need to shift to and the old window:
+```
+shift >= NONCE_MASK_SIZE ~~~ 2 >= 128 = FALSE
+```
+3c. Since there is an overlap between the new window that we need to shift to and the previous
+window, shift the window over, but keep the current set bits in the overlapping part of the window:
+```
+nonce_mask = nonce_mask >> shift; min_nonce += shift;
+```
+4. Now that the window has been shifted over so that the <code>seq_nonce</code> index lies within the new window we
+recompute the <code>bit_pos</code> w.r.t. to it (recall <code>min_nonce</code> was updated):
+```
+bit_pos = seq - min_nonce ~~~ 129 - 2 = 127
+```
+5. We set the bit_pos position bit within the new window:
+```
+00000001000000000000000...000000000000000000000000000000000000000000010...
+^               ...                                           ^^
+|               ...                                           ||
+|               ...                                 new_set_bit|
+|_______________...____________________________________________|
+min_nonce = 2                            min_nonce + NONCE_MASK_SIZE = 2 + 128 = 130
+```
+
+
+<a name="@Example_3:_5"></a>
+
+### Example 3:
+
+
+Let's see what happens when we call <code><a href="SlidingNonce.md#0x1_SlidingNonce_try_record_nonce">SlidingNonce::try_record_nonce</a>(account, 400)</code>:
+
+1. Figure out the bit position w.r.t. the current window:
+```
+bit_pos = 400 - min_nonce ~~~ 400 - 2 = 398
+```
+2. See if bit position calculated is not within the current window:
+```
+bit_pos >= NONCE_MASK_SIZE ~~~ 398 >= 128 = TRUE
+```
+3. <code>bit_pos</code> is out of the window. Now calculate the amount that
+the window needs to be shifted over (i.e., that <code>min_nonce</code> needs to be incremented) so
+<code>seq_nonce</code> lies within the <code><a href="SlidingNonce.md#0x1_SlidingNonce_NONCE_MASK_SIZE">NONCE_MASK_SIZE</a></code> window starting at min_nonce.
+3a. Calculate the amount that the window needs to be shifted for <code>bit_pos</code> to lie within it:
+```
+shift = bit_pos - NONCE_MASK_SIZE + 1 ~~~ 398 - 128 + 1 = 271
+```
+3b. See if there is no overlap between the new window that we need to shift to and the old window:
+```
+shift >= NONCE_MASK_SIZE ~~~ 271 >= 128 = TRUE
+```
+3c. Since there is no overlap between the new window that we need to shift to and the previous
+window we zero out the bitmap, and update the <code>min_nonce</code> to start at the out-of-range <code>seq_nonce</code>:
+```
+nonce_mask = 0; min_nonce = seq_nonce + 1 - NONCE_MASK_SIZE = 273;
+```
+4. Now that the window has been shifted over so that the <code>seq_nonce</code> index lies within the window we
+recompute the bit_pos:
+```
+bit_pos = seq_nonce - min_nonce ~~~ 400 - 273 = 127
+```
+5. We set the bit_pos position bit within the new window:
+```
+...00000001000000000000000...000000000000000000000000000000000000000000010...
+^               ...                                           ^^
+|               ...                                           ||
+|               ...                                 new_set_bit|
+|_______________...____________________________________________|
+min_nonce = 273                          min_nonce + NONCE_MASK_SIZE = 273 + 128 = 401
+```
 Tries to record this nonce in the account.
 Returns 0 if a nonce was recorded and non-0 otherwise
 
@@ -199,26 +363,47 @@ Returns 0 if a nonce was recorded and non-0 otherwise
     };
     <b>assert</b>(<b>exists</b>&lt;<a href="SlidingNonce.md#0x1_SlidingNonce">SlidingNonce</a>&gt;(<a href="Signer.md#0x1_Signer_address_of">Signer::address_of</a>(account)), <a href="Errors.md#0x1_Errors_not_published">Errors::not_published</a>(<a href="SlidingNonce.md#0x1_SlidingNonce_ESLIDING_NONCE">ESLIDING_NONCE</a>));
     <b>let</b> t = borrow_global_mut&lt;<a href="SlidingNonce.md#0x1_SlidingNonce">SlidingNonce</a>&gt;(<a href="Signer.md#0x1_Signer_address_of">Signer::address_of</a>(account));
+    // The `seq_nonce` is outside the current window <b>to</b> the "left" and is
+    // no longer valid since we can't shift the window back.
     <b>if</b> (t.min_nonce &gt; seq_nonce) {
         <b>return</b> <a href="SlidingNonce.md#0x1_SlidingNonce_ENONCE_TOO_OLD">ENONCE_TOO_OLD</a>
     };
-    <b>let</b> jump_limit = 10000; // Don't allow giant leaps in nonce <b>to</b> protect against nonce exhaustion
+    // Don't allow giant leaps in nonce <b>to</b> protect against nonce exhaustion
+    // If we try <b>to</b> <b>move</b> a window by more than this amount, we will fail.
+    <b>let</b> jump_limit = 10000;
     <b>if</b> (t.min_nonce + jump_limit &lt;= seq_nonce) {
         <b>return</b> <a href="SlidingNonce.md#0x1_SlidingNonce_ENONCE_TOO_NEW">ENONCE_TOO_NEW</a>
     };
+    // Calculate The bit position in the window that will be set in our window
     <b>let</b> bit_pos = seq_nonce - t.min_nonce;
+
+    // See <b>if</b> the bit position that we want <b>to</b> set lies outside the current
+    // window that we have under the current `min_nonce`.
     <b>if</b> (bit_pos &gt;= <a href="SlidingNonce.md#0x1_SlidingNonce_NONCE_MASK_SIZE">NONCE_MASK_SIZE</a>) {
+        // Determine how much we need <b>to</b> shift the current window over (<b>to</b>
+        // the "right") so that `bit_pos` lies within the new window.
         <b>let</b> shift = (bit_pos - <a href="SlidingNonce.md#0x1_SlidingNonce_NONCE_MASK_SIZE">NONCE_MASK_SIZE</a> + 1);
+
+        // If we are shifting the window over by more than one window's width
+        // reset the bits in the window, and <b>update</b> the
+        // new start of the `min_nonce` so that `seq_nonce` is the
+        // right-most bit in the new window.
         <b>if</b>(shift &gt;= <a href="SlidingNonce.md#0x1_SlidingNonce_NONCE_MASK_SIZE">NONCE_MASK_SIZE</a>) {
             t.nonce_mask = 0;
             t.min_nonce = seq_nonce + 1 - <a href="SlidingNonce.md#0x1_SlidingNonce_NONCE_MASK_SIZE">NONCE_MASK_SIZE</a>;
         } <b>else</b> {
+            // We are shifting the window over by less than a windows width,
+            // so we need <b>to</b> keep the current set bits in the window
             t.nonce_mask = t.nonce_mask &gt;&gt; (shift <b>as</b> u8);
             t.min_nonce = t.min_nonce + shift;
         }
     };
+    // The window has been (possibly) shifted over so that `seq_nonce` lies
+    // within the window. Recompute the bit positition that needs <b>to</b> be set
+    // within the (possibly) new window.
     <b>let</b> bit_pos = seq_nonce - t.min_nonce;
     <b>let</b> set = 1u128 &lt;&lt; (bit_pos <b>as</b> u8);
+    // The bit was already set, so <b>return</b> an error.
     <b>if</b> (t.nonce_mask & set != 0) {
         <b>return</b> <a href="SlidingNonce.md#0x1_SlidingNonce_ENONCE_ALREADY_RECORDED">ENONCE_ALREADY_RECORDED</a>
     };
@@ -264,7 +449,7 @@ Specification version of <code><a href="SlidingNonce.md#0x1_SlidingNonce_try_rec
 ## Function `publish`
 
 Publishes nonce resource for <code>account</code>
-This is required before other functions in this module can be called for `account
+This is required before other functions in this module can be called for <code>account</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="SlidingNonce.md#0x1_SlidingNonce_publish">publish</a>(account: &signer)
@@ -301,7 +486,7 @@ This is required before other functions in this module can be called for `accoun
 
 </details>
 
-<a name="@Module_Specification_1"></a>
+<a name="@Module_Specification_6"></a>
 
 ## Module Specification
 

--- a/language/stdlib/transaction_scripts/doc/transaction_script_documentation.md
+++ b/language/stdlib/transaction_scripts/doc/transaction_script_documentation.md
@@ -4769,6 +4769,8 @@ is given by <code>new_exchange_rate_numerator/new_exchange_rate_denominator</cod
     new_exchange_rate_denominator
 );
 <b>include</b> <a href="../../modules/doc/Diem.md#0x1_Diem_UpdateXDXExchangeRateAbortsIf">Diem::UpdateXDXExchangeRateAbortsIf</a>&lt;Currency&gt;;
+<b>include</b> <a href="../../modules/doc/Diem.md#0x1_Diem_UpdateXDXExchangeRateEnsures">Diem::UpdateXDXExchangeRateEnsures</a>&lt;Currency&gt;{xdx_exchange_rate: rate};
+<b>include</b> <a href="../../modules/doc/Diem.md#0x1_Diem_UpdateXDXExchangeRateEmits">Diem::UpdateXDXExchangeRateEmits</a>&lt;Currency&gt;{xdx_exchange_rate: rate};
 <b>aborts_with</b> [check]
     <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ADDRESS">Errors::REQUIRES_ADDRESS</a>,


### PR DESCRIPTION
This PR adds detailed doc comments explaining how `SlidingNonce` works.


In the process of writing these doc comments I discovered an issue in the document generator where a code block followed by inline code in the line below would cause the code block to not be generated correctly.

This PR also updates the decoration method to be simpler (no longer using a regex), and fixes this issue (see new test for this case). It also makes a missing '`' a hard error during the documentation generation process.