### PR TITLE
[language] switch tests to exp mode -- move-lang/move/borrow

### DIFF
--- a/language/move-lang/functional-tests/tests/move/borrow_tests/borrow_copy_ok.exp
+++ b/language/move-lang/functional-tests/tests/move/borrow_tests/borrow_copy_ok.exp
@@ -1,0 +1,6 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)
+[3] Transaction(1)
+[4] Move VM Status: EXECUTED
+[5] Transaction Status: Keep(EXECUTED)

--- a/language/move-lang/functional-tests/tests/move/borrow_tests/borrow_field_ok.exp
+++ b/language/move-lang/functional-tests/tests/move/borrow_tests/borrow_field_ok.exp
@@ -1,0 +1,6 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)
+[3] Transaction(1)
+[4] Move VM Status: EXECUTED
+[5] Transaction Status: Keep(EXECUTED)

--- a/language/move-lang/functional-tests/tests/move/borrow_tests/borrow_local_bad.exp
+++ b/language/move-lang/functional-tests/tests/move/borrow_tests/borrow_local_bad.exp
@@ -1,0 +1,6 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)
+[3] Transaction(1)
+[4] Move VM Status: EXECUTED
+[5] Transaction Status: Keep(EXECUTED)

--- a/language/move-lang/functional-tests/tests/move/borrow_tests/borrow_move_ok.exp
+++ b/language/move-lang/functional-tests/tests/move/borrow_tests/borrow_move_ok.exp
@@ -1,0 +1,6 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)
+[3] Transaction(1)
+[4] Move VM Status: EXECUTED
+[5] Transaction Status: Keep(EXECUTED)

--- a/language/move-lang/functional-tests/tests/move/borrow_tests/borrow_parens_ok.exp
+++ b/language/move-lang/functional-tests/tests/move/borrow_tests/borrow_parens_ok.exp
@@ -1,0 +1,6 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)
+[3] Transaction(1)
+[4] Move VM Status: EXECUTED
+[5] Transaction Status: Keep(EXECUTED)

--- a/language/move-lang/functional-tests/tests/move/borrow_tests/borrow_x_in_if_y_in_else.exp
+++ b/language/move-lang/functional-tests/tests/move/borrow_tests/borrow_x_in_if_y_in_else.exp
@@ -1,0 +1,3 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)

--- a/language/move-lang/functional-tests/tests/move/borrow_tests/imm_borrow_global.exp
+++ b/language/move-lang/functional-tests/tests/move/borrow_tests/imm_borrow_global.exp
@@ -1,0 +1,9 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)
+[3] Transaction(1)
+[4] Move VM Status: EXECUTED
+[5] Transaction Status: Keep(EXECUTED)
+[6] Transaction(2)
+[7] Move VM Status: EXECUTED
+[8] Transaction Status: Keep(EXECUTED)


### PR DESCRIPTION
Suspicious tests:
- `borrow_local_bad`: name doesn't seem to match test. I don't see why it's "bad".
- `borrow_parens`, `borrow_move_ok`: identical tests.