### PR TITLE
Add PeerRole to identify known peers in the network

### DIFF
--- a/config/management/genesis/src/config_builder.rs
+++ b/config/management/genesis/src/config_builder.rs
@@ -296,7 +296,7 @@ impl FullnodeBuilder {
         let fn_vfn = &mut full_node_config
             .full_node_networks
             .iter_mut()
-            .find(|n| matches!(n.network_id, NetworkId::Private(_)))
+            .find(|n| n.network_id.is_vfn_network())
             .expect("vfn missing vfn full node network in config");
         fn_vfn.seeds = seeds;
 

--- a/config/seed-peer-generator/src/main.rs
+++ b/config/seed-peer-generator/src/main.rs
@@ -26,7 +26,7 @@ fn main() {
 
     let seed_peers_config = match args.role {
         RoleType::FullNode => {
-            seed_peer_generator::utils::gen_full_node_seed_peer_config(args.endpoint)
+            seed_peer_generator::utils::gen_validator_full_node_seed_peer_config(args.endpoint)
         }
         _ => panic!("{} not yet supported", args.role),
     }

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -343,29 +343,29 @@ impl Default for RateLimitConfig {
 pub type PeerSet = HashMap<PeerId, Peer>;
 
 // TODO: Combine with RoleType?
+/// Represents the Role that a peer plays in the network ecosystem rather than the type of node.
+/// Determines how nodes are connected to other nodes, and how discovery views them.
+///
+/// Rules for upstream nodes via Peer Role:
+///
+/// Validator -> Always upstream if not Validator else P2P
+/// PreferredUpstream -> Always upstream, overriding any other discovery
+/// ValidatorFullNode -> Always upstream for incoming connections (including other ValidatorFullNodes)
+/// Upstream -> Upstream, if no ValidatorFullNode or PreferredUpstream.  Useful for initial seed discovery
+/// Unknown -> Undiscovered peer, likely due to a non-mutually authenticated connection always downstream
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub enum PeerRole {
     Validator = 0,
+    PreferredUpstream,
     ValidatorFullNode,
-    Preferred,
     Upstream,
-    Known,
     Unknown,
 }
 
 impl Default for PeerRole {
+    /// Default to least trusted
     fn default() -> Self {
-        // Default to least trusted
         PeerRole::Unknown
-    }
-}
-
-impl From<RoleType> for PeerRole {
-    fn from(role_type: RoleType) -> PeerRole {
-        match role_type {
-            RoleType::Validator => PeerRole::Validator,
-            RoleType::FullNode => PeerRole::ValidatorFullNode,
-        }
     }
 }
 

--- a/config/src/config/test_data/validator_full_node.yaml
+++ b/config/src/config/test_data/validator_full_node.yaml
@@ -33,6 +33,7 @@ full_node_networks:
           addresses:
             - "/ip4/127.0.0.1/tcp/58259/ln-noise-ik/c998dcd54c3daf48e0ad516d94b7be0b0b7a27caa00541f2b2c14b13500df10b/ln-handshake/0"
           keys: ["c998dcd54c3daf48e0ad516d94b7be0b0b7a27caa00541f2b2c14b13500df10b"]
+          role: "Validator"
     - discovery_method: "onchain"
       listen_address: "/ip4/0.0.0.0/tcp/8180"
       network_id: "public"

--- a/config/src/generator.rs
+++ b/config/src/generator.rs
@@ -69,7 +69,7 @@ pub fn build_seed_for_network(seed_config: &NetworkConfig) -> PeerSet {
             if network_id.is_vfn_network() {
                 PeerRole::ValidatorFullNode
             } else {
-                PeerRole::Known
+                PeerRole::Upstream
             }
         }
     };

--- a/config/src/generator.rs
+++ b/config/src/generator.rs
@@ -6,8 +6,7 @@
 
 use crate::{
     config::{
-        DiscoveryMethod, NetworkConfig, NodeConfig, TestConfig, TrustedPeer, TrustedPeerSet,
-        HANDSHAKE_VERSION,
+        DiscoveryMethod, NetworkConfig, NodeConfig, Peer, PeerSet, TestConfig, HANDSHAKE_VERSION,
     },
     network_id::NetworkId,
 };
@@ -59,10 +58,10 @@ pub fn validator_swarm_for_testing(nodes: usize) -> ValidatorSwarm {
     validator_swarm(&NodeConfig::default(), nodes, [1u8; 32], true)
 }
 
-/// Convenience function that builds a `TrustedPeerSet` containing a single peer for testing
+/// Convenience function that builds a `PeerSet` containing a single peer for testing
 /// with a fully formatted `NetworkAddress` containing its network identity pubkey
 /// and handshake protocol version.
-pub fn build_seed_for_network(seed_config: &NetworkConfig) -> TrustedPeerSet {
+pub fn build_seed_for_network(seed_config: &NetworkConfig) -> PeerSet {
     let seed_pubkey = diem_crypto::PrivateKey::public_key(&seed_config.identity_key());
     let seed_addr = seed_config
         .listen_address
@@ -72,9 +71,6 @@ pub fn build_seed_for_network(seed_config: &NetworkConfig) -> TrustedPeerSet {
     let mut keys = HashSet::new();
     keys.insert(seed_pubkey);
     let mut seeds = HashMap::default();
-    seeds.insert(
-        seed_config.peer_id(),
-        TrustedPeer::new(vec![seed_addr], keys),
-    );
+    seeds.insert(seed_config.peer_id(), Peer::new(vec![seed_addr], keys));
     seeds
 }

--- a/config/src/network_id.rs
+++ b/config/src/network_id.rs
@@ -135,10 +135,16 @@ impl fmt::Display for NetworkId {
     }
 }
 
+const VFN_NETWORK: &str = "vfn";
+
 impl NetworkId {
     /// Convenience function to specify the VFN network
     pub fn vfn_network() -> NetworkId {
-        NetworkId::Private("vfn".to_string())
+        NetworkId::Private(VFN_NETWORK.to_string())
+    }
+
+    pub fn is_vfn_network(&self) -> bool {
+        matches!(self, NetworkId::Private(network) if network == VFN_NETWORK)
     }
 
     pub fn as_str(&self) -> &str {
@@ -169,7 +175,7 @@ mod test {
 
     #[test]
     fn test_serialization() {
-        let id = NetworkId::Private("fooo".to_string());
+        let id = NetworkId::vfn_network();
         let encoded = serde_yaml::to_string(&id).unwrap();
         let decoded: NetworkId = serde_yaml::from_str(encoded.as_str()).unwrap();
         assert_eq!(id, decoded);
@@ -188,13 +194,12 @@ mod test {
 
     #[test]
     fn test_network_context_serialization() {
-        let network_name = "Awesome".to_string();
         let role = RoleType::Validator;
         let peer_id = PeerId::random();
-        let context = NetworkContext::new(NetworkId::Private(network_name.clone()), role, peer_id);
+        let context = NetworkContext::new(NetworkId::vfn_network(), role, peer_id);
         let expected = format!(
             "---\nnetwork_id: {}\nrole: {}\npeer_id: {}",
-            network_name, role, peer_id
+            VFN_NETWORK, role, peer_id
         );
         assert_eq!(expected, serde_yaml::to_string(&context).unwrap());
     }

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -273,11 +273,11 @@ impl NetworkTask {
                         continue;
                     }
                 },
-                Event::NewPeer(peer_id, _origin) => {
-                    debug!(remote_peer = peer_id, "Peer connected");
+                Event::NewPeer(metadata) => {
+                    debug!(remote_peer = metadata.remote_peer_id, "Peer connected");
                 }
-                Event::LostPeer(peer_id, _origin) => {
-                    debug!(remote_peer = peer_id, "Peer disconnected");
+                Event::LostPeer(metadata) => {
+                    debug!(remote_peer = metadata.remote_peer_id, "Peer disconnected");
                 }
             }
         }

--- a/docker/compose/public_full_node/public_full_node.yaml
+++ b/docker/compose/public_full_node/public_full_node.yaml
@@ -24,6 +24,7 @@ full_node_networks:
         D4C4FB4956D899E55289083F45AC5D84:
           addresses:
             - "/dns4/fn.testnet.diem.com/tcp/6182/ln-noise-ik/d29d01bed8ab6c30921b327823f7e92c63f8371456fb110256e8c0e8911f4938/ln-handshake/0"
+          role: "ValidatorFullNode"
 
 json_rpc:
     # This specifies your JSON-RPC endpoint. Intentionally on public so that Docker can export it.

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -12,7 +12,7 @@
 use channel::{self, message_queues::QueueStyle};
 use diem_config::{
     config::{
-        DiscoveryMethod, NetworkConfig, Peer, PeerSet, RateLimitConfig, RoleType,
+        DiscoveryMethod, NetworkConfig, Peer, PeerRole, PeerSet, RateLimitConfig, RoleType,
         CONNECTION_BACKOFF_BASE, CONNECTIVITY_CHECK_INTERVAL_MS, MAX_CONCURRENT_NETWORK_REQS,
         MAX_CONNECTION_DELAY_MS, MAX_FRAME_SIZE, MAX_FULLNODE_OUTBOUND_CONNECTIONS,
         MAX_INBOUND_CONNECTIONS, NETWORK_CHANNEL_SIZE,
@@ -224,10 +224,15 @@ impl NetworkBuilder {
             config
                 .seed_addrs
                 .iter()
-                .map(|(peer_id, addrs)| (peer_id, Peer::from(addrs.clone())))
+                .map(|(peer_id, addrs)| {
+                    (
+                        peer_id,
+                        Peer::from_addrs(PeerRole::from(role), addrs.clone()),
+                    )
+                })
                 .for_each(|(peer_id, peer)| {
                     let seed = seeds.entry(*peer_id).or_default();
-                    seed.extend(peer)
+                    seed.extend(peer).unwrap();
                 });
 
             network_builder.add_connectivity_manager(

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -12,7 +12,7 @@
 use channel::{self, message_queues::QueueStyle};
 use diem_config::{
     config::{
-        DiscoveryMethod, NetworkConfig, RateLimitConfig, RoleType, TrustedPeer, TrustedPeerSet,
+        DiscoveryMethod, NetworkConfig, Peer, PeerSet, RateLimitConfig, RoleType,
         CONNECTION_BACKOFF_BASE, CONNECTIVITY_CHECK_INTERVAL_MS, MAX_CONCURRENT_NETWORK_REQS,
         MAX_CONNECTION_DELAY_MS, MAX_FRAME_SIZE, MAX_FULLNODE_OUTBOUND_CONNECTIONS,
         MAX_INBOUND_CONNECTIONS, NETWORK_CHANNEL_SIZE,
@@ -125,7 +125,7 @@ impl NetworkBuilder {
 
     pub fn new_for_test(
         chain_id: ChainId,
-        seeds: &TrustedPeerSet,
+        seeds: &PeerSet,
         trusted_peers: Arc<RwLock<HashMap<PeerId, HashSet<x25519::PublicKey>>>>,
         network_context: Arc<NetworkContext>,
         listen_address: NetworkAddress,
@@ -224,7 +224,7 @@ impl NetworkBuilder {
             config
                 .seed_addrs
                 .iter()
-                .map(|(peer_id, addrs)| (peer_id, TrustedPeer::from(addrs.clone())))
+                .map(|(peer_id, addrs)| (peer_id, Peer::from(addrs.clone())))
                 .for_each(|(peer_id, peer)| {
                     let seed = seeds.entry(*peer_id).or_default();
                     seed.extend(peer)
@@ -318,7 +318,7 @@ impl NetworkBuilder {
     /// permissioned.
     pub fn add_connectivity_manager(
         &mut self,
-        seeds: &TrustedPeerSet,
+        seeds: &PeerSet,
         trusted_peers: Arc<RwLock<HashMap<PeerId, HashSet<x25519::PublicKey>>>>,
         max_outbound_connections: usize,
         connection_backoff_base: u64,
@@ -336,7 +336,7 @@ impl NetworkBuilder {
         // Merge pubkeys that may be in the seed addresses
         let mut seeds = seeds.clone();
         seeds.values_mut().for_each(
-            |TrustedPeer {
+            |Peer {
                  addresses, keys, ..
              }| {
                 addresses

--- a/network/builder/src/dummy.rs
+++ b/network/builder/src/dummy.rs
@@ -6,7 +6,7 @@
 use crate::builder::NetworkBuilder;
 use channel::message_queues::QueueStyle;
 use diem_config::{
-    config::{RoleType, TrustedPeer, TrustedPeerSet, NETWORK_CHANNEL_SIZE},
+    config::{Peer, PeerSet, RoleType, NETWORK_CHANNEL_SIZE},
     network_id::{NetworkContext, NetworkId},
 };
 use diem_crypto::{test_utils::TEST_SEED, x25519, Uniform};
@@ -129,8 +129,8 @@ pub fn setup_network() -> DummyNetwork {
     let listener_addr: NetworkAddress = "/ip4/127.0.0.1/tcp/0".parse().unwrap();
 
     // Setup seed peers
-    let mut seeds = TrustedPeerSet::new();
-    seeds.insert(dialer_peer_id, TrustedPeer::from(dialer_pubkeys));
+    let mut seeds = PeerSet::new();
+    seeds.insert(dialer_peer_id, Peer::from(dialer_pubkeys));
 
     let trusted_peers = Arc::new(RwLock::new(HashMap::new()));
     let authentication_mode = AuthenticationMode::Mutual(listener_identity_private_key);
@@ -156,7 +156,7 @@ pub fn setup_network() -> DummyNetwork {
 
     // Add the listener address with port
     let listener_addr = network_builder.listen_address();
-    seeds.insert(listener_peer_id, TrustedPeer::from(listener_addr));
+    seeds.insert(listener_peer_id, Peer::from(listener_addr));
 
     let authentication_mode = AuthenticationMode::Mutual(dialer_identity_private_key);
 

--- a/network/builder/src/dummy.rs
+++ b/network/builder/src/dummy.rs
@@ -6,7 +6,7 @@
 use crate::builder::NetworkBuilder;
 use channel::message_queues::QueueStyle;
 use diem_config::{
-    config::{Peer, PeerSet, RoleType, NETWORK_CHANNEL_SIZE},
+    config::{Peer, PeerRole, PeerSet, RoleType, NETWORK_CHANNEL_SIZE},
     network_id::{NetworkContext, NetworkId},
 };
 use diem_crypto::{test_utils::TEST_SEED, x25519, Uniform};
@@ -130,7 +130,10 @@ pub fn setup_network() -> DummyNetwork {
 
     // Setup seed peers
     let mut seeds = PeerSet::new();
-    seeds.insert(dialer_peer_id, Peer::from(dialer_pubkeys));
+    seeds.insert(
+        dialer_peer_id,
+        Peer::new(vec![], dialer_pubkeys, PeerRole::Validator),
+    );
 
     let trusted_peers = Arc::new(RwLock::new(HashMap::new()));
     let authentication_mode = AuthenticationMode::Mutual(listener_identity_private_key);
@@ -156,7 +159,10 @@ pub fn setup_network() -> DummyNetwork {
 
     // Add the listener address with port
     let listener_addr = network_builder.listen_address();
-    seeds.insert(listener_peer_id, Peer::from(listener_addr));
+    seeds.insert(
+        listener_peer_id,
+        Peer::from_addrs(PeerRole::Validator, vec![listener_addr]),
+    );
 
     let authentication_mode = AuthenticationMode::Mutual(dialer_identity_private_key);
 

--- a/network/network-address/src/lib.rs
+++ b/network/network-address/src/lib.rs
@@ -106,11 +106,11 @@ const MAX_DNS_NAME_SIZE: usize = 255;
 ///
 /// [multiaddr]: https://multiformats.io/multiaddr/
 /// [`Transport`]: ../netcore/transport/trait.Transport.html
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, Hash, PartialEq)]
 pub struct NetworkAddress(Vec<Protocol>);
 
 /// A single protocol in the [`NetworkAddress`] protocol stack.
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub enum Protocol {
     Ip4(Ipv4Addr),
@@ -146,7 +146,7 @@ pub enum Protocol {
 /// is a valid unicode string. We do this because '/' characters are already our
 /// protocol delimiter and Rust's [`std::net::ToSocketAddrs`] API requires a
 /// `&str`.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
 pub struct DnsName(String);
 
 /// Possible errors when parsing a human-readable [`NetworkAddress`].

--- a/network/simple-onchain-discovery/src/lib.rs
+++ b/network/simple-onchain-discovery/src/lib.rs
@@ -3,7 +3,7 @@
 
 use channel::diem_channel::{self, Receiver};
 use diem_config::{
-    config::{Peer, RoleType},
+    config::{Peer, PeerRole, RoleType},
     network_id::NetworkContext,
 };
 use diem_crypto::x25519::PublicKey;
@@ -123,7 +123,7 @@ fn extract_updates(
             })
             .unwrap_or_default();
 
-            (peer_id, Peer::from(addrs))
+            (peer_id, Peer::from_addrs(PeerRole::from(role), addrs))
         })
         .collect();
 

--- a/network/simple-onchain-discovery/src/lib.rs
+++ b/network/simple-onchain-discovery/src/lib.rs
@@ -123,7 +123,11 @@ fn extract_updates(
             })
             .unwrap_or_default();
 
-            (peer_id, Peer::from_addrs(PeerRole::from(role), addrs))
+            let peer_role = match role {
+                RoleType::Validator => PeerRole::Validator,
+                RoleType::FullNode => PeerRole::ValidatorFullNode,
+            };
+            (peer_id, Peer::from_addrs(peer_role, addrs))
         })
         .collect();
 

--- a/network/simple-onchain-discovery/src/lib.rs
+++ b/network/simple-onchain-discovery/src/lib.rs
@@ -3,7 +3,7 @@
 
 use channel::diem_channel::{self, Receiver};
 use diem_config::{
-    config::{RoleType, TrustedPeer},
+    config::{Peer, RoleType},
     network_id::NetworkContext,
 };
 use diem_crypto::x25519::PublicKey;
@@ -123,7 +123,7 @@ fn extract_updates(
             })
             .unwrap_or_default();
 
-            (peer_id, TrustedPeer::from(addrs))
+            (peer_id, Peer::from(addrs))
         })
         .collect();
 

--- a/network/src/connectivity_manager/builder.rs
+++ b/network/src/connectivity_manager/builder.rs
@@ -6,7 +6,7 @@ use crate::{
     counters,
     peer_manager::{conn_notifs_channel, ConnectionRequestSender},
 };
-use diem_config::{config::TrustedPeerSet, network_id::NetworkContext};
+use diem_config::{config::PeerSet, network_id::NetworkContext};
 use diem_crypto::x25519;
 use diem_infallible::RwLock;
 use diem_types::PeerId;
@@ -27,7 +27,7 @@ pub type ConnectivityManagerService = ConnectivityManager<Fuse<IntervalStream>, 
 struct ConnectivityManagerBuilderConfig {
     network_context: Arc<NetworkContext>,
     eligible: Arc<RwLock<HashMap<PeerId, HashSet<x25519::PublicKey>>>>,
-    seeds: TrustedPeerSet,
+    seeds: PeerSet,
     connectivity_check_interval_ms: u64,
     backoff_base: u64,
     max_connection_delay_ms: u64,
@@ -55,7 +55,7 @@ impl ConnectivityManagerBuilder {
     pub fn create(
         network_context: Arc<NetworkContext>,
         eligible: Arc<RwLock<HashMap<PeerId, HashSet<x25519::PublicKey>>>>,
-        seeds: TrustedPeerSet,
+        seeds: PeerSet,
         connectivity_check_interval_ms: u64,
         backoff_base: u64,
         max_connection_delay_ms: u64,

--- a/network/src/connectivity_manager/builder.rs
+++ b/network/src/connectivity_manager/builder.rs
@@ -7,16 +7,10 @@ use crate::{
     peer_manager::{conn_notifs_channel, ConnectionRequestSender},
 };
 use diem_config::{config::PeerSet, network_id::NetworkContext};
-use diem_crypto::x25519;
 use diem_infallible::RwLock;
-use diem_types::PeerId;
 use futures::stream::StreamExt;
 use futures_util::stream::Fuse;
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-    time::Duration,
-};
+use std::{sync::Arc, time::Duration};
 use tokio::{runtime::Handle, time::interval};
 use tokio_retry::strategy::ExponentialBackoff;
 use tokio_stream::wrappers::IntervalStream;
@@ -26,7 +20,7 @@ pub type ConnectivityManagerService = ConnectivityManager<Fuse<IntervalStream>, 
 /// The configuration fields for ConnectivityManager
 struct ConnectivityManagerBuilderConfig {
     network_context: Arc<NetworkContext>,
-    eligible: Arc<RwLock<HashMap<PeerId, HashSet<x25519::PublicKey>>>>,
+    eligible: Arc<RwLock<PeerSet>>,
     seeds: PeerSet,
     connectivity_check_interval_ms: u64,
     backoff_base: u64,
@@ -54,7 +48,7 @@ pub struct ConnectivityManagerBuilder {
 impl ConnectivityManagerBuilder {
     pub fn create(
         network_context: Arc<NetworkContext>,
-        eligible: Arc<RwLock<HashMap<PeerId, HashSet<x25519::PublicKey>>>>,
+        eligible: Arc<RwLock<PeerSet>>,
         seeds: PeerSet,
         connectivity_check_interval_ms: u64,
         backoff_base: u64,

--- a/network/src/connectivity_manager/mod.rs
+++ b/network/src/connectivity_manager/mod.rs
@@ -31,7 +31,7 @@ use crate::{
     logging::NetworkSchema,
     peer_manager::{self, conn_notifs_channel, ConnectionRequestSender, PeerManagerError},
 };
-use diem_config::{config::TrustedPeerSet, network_id::NetworkContext};
+use diem_config::{config::PeerSet, network_id::NetworkContext};
 use diem_crypto::x25519;
 use diem_infallible::RwLock;
 use diem_logger::prelude::*;
@@ -130,7 +130,7 @@ impl fmt::Display for DiscoverySource {
 #[derive(Debug, Serialize)]
 pub enum ConnectivityRequest {
     /// Update set of discovered peers and associated info
-    UpdateDiscoveredPeers(DiscoverySource, TrustedPeerSet),
+    UpdateDiscoveredPeers(DiscoverySource, PeerSet),
     /// Gets current size of connected peers. This is useful in tests.
     #[serde(skip)]
     GetConnectedSize(oneshot::Sender<usize>),
@@ -206,7 +206,7 @@ where
     pub fn new(
         network_context: Arc<NetworkContext>,
         eligible: Arc<RwLock<HashMap<PeerId, HashSet<x25519::PublicKey>>>>,
-        seeds: &TrustedPeerSet,
+        seeds: &PeerSet,
         ticker: TTicker,
         connection_reqs_tx: ConnectionRequestSender,
         connection_notifs_rx: conn_notifs_channel::Receiver,
@@ -549,7 +549,7 @@ where
     fn handle_update_discovered_peers(
         &mut self,
         src: DiscoverySource,
-        new_discovered_peers: TrustedPeerSet,
+        new_discovered_peers: PeerSet,
     ) {
         let self_peer_id = self.network_context.peer_id();
         let mut keys_updated = false;

--- a/network/src/noise/handshake.rs
+++ b/network/src/noise/handshake.rs
@@ -10,23 +10,19 @@
 //!
 //! [stream]: crate::noise::stream
 
-use crate::{
-    noise::{error::NoiseHandshakeError, stream::NoiseStream},
-    transport::TrustLevel,
+use crate::noise::{error::NoiseHandshakeError, stream::NoiseStream};
+use diem_config::{
+    config::{Peer, PeerRole, PeerSet},
+    network_id::NetworkContext,
 };
-use diem_config::network_id::NetworkContext;
 use diem_crypto::{noise, x25519};
 use diem_infallible::{duration_since_epoch, RwLock};
 use diem_logger::trace;
 use diem_types::PeerId;
 use futures::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use netcore::transport::ConnectionOrigin;
-use std::{
-    collections::{HashMap, HashSet},
-    convert::TryFrom as _,
-    fmt::Debug,
-    sync::Arc,
-};
+use short_hex_str::ShortHexStr;
+use std::{collections::HashMap, convert::TryFrom as _, fmt::Debug, sync::Arc};
 
 /// In a mutually authenticated network, a client message is accompanied with a timestamp.
 /// This is in order to prevent replay attacks, where the attacker does not know the client's static key,
@@ -91,25 +87,23 @@ pub enum HandshakeAuthMode {
         // mutual-auth scenarios because we have a bounded set of trusted peers
         // that rarely changes.
         anti_replay_timestamps: RwLock<AntiReplayTimestamps>,
-        trusted_peers: Arc<RwLock<HashMap<PeerId, HashSet<x25519::PublicKey>>>>,
+        trusted_peers: Arc<RwLock<PeerSet>>,
     },
     /// In `MaybeMutual` mode, the dialer authenticates the server and the server will allow all
     /// inbound connections from any peer but will mark connections as `Trusted` if the incoming
     /// connection is apart of its trusted peers set.
-    MaybeMutual(Arc<RwLock<HashMap<PeerId, HashSet<x25519::PublicKey>>>>),
+    MaybeMutual(Arc<RwLock<PeerSet>>),
 }
 
 impl HandshakeAuthMode {
-    pub fn mutual(trusted_peers: Arc<RwLock<HashMap<PeerId, HashSet<x25519::PublicKey>>>>) -> Self {
+    pub fn mutual(trusted_peers: Arc<RwLock<PeerSet>>) -> Self {
         HandshakeAuthMode::Mutual {
             anti_replay_timestamps: RwLock::new(AntiReplayTimestamps::default()),
             trusted_peers,
         }
     }
 
-    pub fn maybe_mutual(
-        trusted_peers: Arc<RwLock<HashMap<PeerId, HashSet<x25519::PublicKey>>>>,
-    ) -> Self {
+    pub fn maybe_mutual(trusted_peers: Arc<RwLock<PeerSet>>) -> Self {
         HandshakeAuthMode::MaybeMutual(trusted_peers)
     }
 
@@ -304,7 +298,7 @@ impl NoiseUpgrader {
     pub async fn upgrade_inbound<TSocket>(
         &self,
         mut socket: TSocket,
-    ) -> Result<(NoiseStream<TSocket>, PeerId, TrustLevel), NoiseHandshakeError>
+    ) -> Result<(NoiseStream<TSocket>, PeerId, PeerRole), NoiseHandshakeError>
     where
         TSocket: AsyncRead + AsyncWrite + Debug + Unpin,
     {
@@ -353,53 +347,40 @@ impl NoiseUpgrader {
             .map_err(|err| NoiseHandshakeError::ServerParseClient(remote_peer_short, err))?;
 
         // if mutual auth mode, verify the remote pubkey is in our set of trusted peers
-        let trust_level = match &self.auth_mode {
+        let peer_role = match &self.auth_mode {
             HandshakeAuthMode::Mutual { trusted_peers, .. } => {
                 match trusted_peers.read().get(&remote_peer_id) {
-                    Some(remote_pubkey_set) => {
-                        if !remote_pubkey_set.contains(&remote_public_key) {
-                            return Err(NoiseHandshakeError::UnauthenticatedClientPubkey(
-                                remote_peer_short,
-                                hex::encode(remote_public_key.as_slice()),
-                            ));
-                        }
+                    Some(peer) => {
+                        Self::authenticate_inbound(remote_peer_short, peer, &remote_public_key)
                     }
-                    None => {
-                        return Err(NoiseHandshakeError::UnauthenticatedClient(
-                            remote_peer_short,
-                            remote_peer_id,
-                        ))
-                    }
-                };
-                TrustLevel::Trusted
+                    None => Err(NoiseHandshakeError::UnauthenticatedClient(
+                        remote_peer_short,
+                        remote_peer_id,
+                    )),
+                }
             }
             HandshakeAuthMode::MaybeMutual(trusted_peers) => {
                 match trusted_peers.read().get(&remote_peer_id) {
-                    Some(remote_pubkey_set) => {
-                        if !remote_pubkey_set.contains(&remote_public_key) {
-                            return Err(NoiseHandshakeError::UnauthenticatedClientPubkey(
-                                remote_peer_short,
-                                hex::encode(remote_public_key.as_slice()),
-                            ));
-                        }
-                        TrustLevel::Trusted
+                    Some(peer) => {
+                        Self::authenticate_inbound(remote_peer_short, peer, &remote_public_key)
                     }
                     None => {
                         // if not, verify that their peerid is constructed correctly from their public key
                         let derived_remote_peer_id =
                             PeerId::from_identity_public_key(remote_public_key);
                         if derived_remote_peer_id != remote_peer_id {
-                            return Err(NoiseHandshakeError::ClientPeerIdMismatch(
+                            Err(NoiseHandshakeError::ClientPeerIdMismatch(
                                 remote_peer_short,
                                 remote_peer_id,
                                 derived_remote_peer_id,
-                            ));
+                            ))
+                        } else {
+                            Ok(PeerRole::Unknown)
                         }
-                        TrustLevel::Untrusted
                     }
                 }
             }
-        };
+        }?;
 
         // if on a mutually authenticated network,
         // the payload should contain a u64 client timestamp
@@ -455,11 +436,21 @@ impl NoiseUpgrader {
             self.network_context,
             remote_peer_short,
         );
-        Ok((
-            NoiseStream::new(socket, session),
-            remote_peer_id,
-            trust_level,
-        ))
+        Ok((NoiseStream::new(socket, session), remote_peer_id, peer_role))
+    }
+
+    fn authenticate_inbound(
+        remote_peer_short: ShortHexStr,
+        peer: &Peer,
+        remote_public_key: &x25519::PublicKey,
+    ) -> Result<PeerRole, NoiseHandshakeError> {
+        if !peer.keys.contains(&remote_public_key) {
+            return Err(NoiseHandshakeError::UnauthenticatedClientPubkey(
+                remote_peer_short,
+                hex::encode(remote_public_key.as_slice()),
+            ));
+        }
+        Ok(peer.role)
     }
 }
 
@@ -472,6 +463,7 @@ impl NoiseUpgrader {
 mod test {
     use super::*;
     use crate::testutils::fake_socket::ReadWriteTestSocket;
+    use diem_config::config::{Peer, PeerRole};
     use diem_crypto::{test_utils::TEST_SEED, traits::Uniform as _};
     use futures::{executor::block_on, future::join};
     use memsocket::MemorySocket;
@@ -501,8 +493,14 @@ mod test {
             let server_pubkey_set = [server_public_key].iter().copied().collect();
             let trusted_peers = Arc::new(RwLock::new(
                 vec![
-                    (client_peer_id, client_pubkey_set),
-                    (server_peer_id, server_pubkey_set),
+                    (
+                        client_peer_id,
+                        Peer::new(Vec::new(), client_pubkey_set, PeerRole::Validator),
+                    ),
+                    (
+                        server_peer_id,
+                        Peer::new(Vec::new(), server_pubkey_set, PeerRole::Validator),
+                    ),
                 ]
                 .into_iter()
                 .collect(),
@@ -542,7 +540,7 @@ mod test {
         server_public_key: x25519::PublicKey,
     ) -> (
         Result<NoiseStream<MemorySocket>, NoiseHandshakeError>,
-        Result<(NoiseStream<MemorySocket>, PeerId, TrustLevel), NoiseHandshakeError>,
+        Result<(NoiseStream<MemorySocket>, PeerId, PeerRole), NoiseHandshakeError>,
     ) {
         // create an in-memory socket for testing
         let (dialer_socket, listener_socket) = MemorySocket::new_pair();

--- a/network/src/noise/mod.rs
+++ b/network/src/noise/mod.rs
@@ -14,7 +14,7 @@
 //! use network::noise::{AntiReplayTimestamps, HandshakeAuthMode, NoiseUpgrader};
 //! use futures::{executor, future, io::{AsyncReadExt, AsyncWriteExt}};
 //! use memsocket::MemorySocket;
-//! use diem_config::{config::RoleType, network_id::{NetworkContext, NetworkId}};
+//! use diem_config::{config::{Peer, PeerRole, RoleType}, network_id::{NetworkContext, NetworkId}};
 //! use diem_crypto::{x25519, ed25519, Uniform, PrivateKey, test_utils::TEST_SEED};
 //! use diem_infallible::RwLock;
 //! use rand::{rngs::StdRng, SeedableRng};
@@ -36,8 +36,8 @@
 //! let client_pubkey_set: HashSet<_> = vec![client_public].into_iter().collect();
 //! let server_pubkey_set: HashSet<_> = vec![server_public].into_iter().collect();
 //! let trusted_peers: HashMap<_, _> = vec![
-//!     (client_peer_id, client_pubkey_set),
-//!     (server_peer_id, server_pubkey_set)
+//!     (client_peer_id, Peer::new(Vec::new(), client_pubkey_set, PeerRole::Validator)),
+//!     (server_peer_id, Peer::new(Vec::new(), server_pubkey_set, PeerRole::Validator))
 //! ].into_iter().collect();
 //! let trusted_peers = Arc::new(RwLock::new(trusted_peers));
 //!

--- a/network/src/peer/fuzzing.rs
+++ b/network/src/peer/fuzzing.rs
@@ -9,7 +9,7 @@ use crate::{
         messaging::v1::{NetworkMessage, NetworkMessageSink},
     },
     testutils::fake_socket::ReadOnlyTestSocketVec,
-    transport::{Connection, ConnectionId, ConnectionMetadata, TrustLevel},
+    transport::{Connection, ConnectionId, ConnectionMetadata},
     ProtocolId,
 };
 use channel::{diem_channel, message_queues::QueueStyle};
@@ -95,7 +95,6 @@ pub fn fuzz(data: &[u8]) {
             ]
             .iter(),
         ),
-        TrustLevel::Untrusted,
         PeerRole::Unknown,
     );
     let connection = Connection { socket, metadata };

--- a/network/src/peer/fuzzing.rs
+++ b/network/src/peer/fuzzing.rs
@@ -13,7 +13,7 @@ use crate::{
     ProtocolId,
 };
 use channel::{diem_channel, message_queues::QueueStyle};
-use diem_config::network_id::NetworkContext;
+use diem_config::{config::PeerRole, network_id::NetworkContext};
 use diem_network_address::NetworkAddress;
 use diem_proptest_helpers::ValueGenerator;
 use diem_time_service::TimeService;
@@ -96,6 +96,7 @@ pub fn fuzz(data: &[u8]) {
             .iter(),
         ),
         TrustLevel::Untrusted,
+        PeerRole::Unknown,
     );
     let connection = Connection { socket, metadata };
 

--- a/network/src/peer/test.rs
+++ b/network/src/peer/test.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 use bytes::Bytes;
 use channel::{self, diem_channel, message_queues::QueueStyle};
-use diem_config::network_id::NetworkContext;
+use diem_config::{config::PeerRole, network_id::NetworkContext};
 use diem_network_address::NetworkAddress;
 use diem_time_service::{MockTimeService, TimeService};
 use diem_types::PeerId;
@@ -67,6 +67,7 @@ fn build_test_peer(
             MessagingProtocolVersion::V1,
             [].iter().into(),
             TrustLevel::Untrusted,
+            PeerRole::Unknown,
         ),
         socket: a,
     };

--- a/network/src/peer/test.rs
+++ b/network/src/peer/test.rs
@@ -19,7 +19,7 @@ use crate::{
             },
         },
     },
-    transport::{Connection, ConnectionId, ConnectionMetadata, TrustLevel},
+    transport::{Connection, ConnectionId, ConnectionMetadata},
     ProtocolId,
 };
 use bytes::Bytes;
@@ -66,7 +66,6 @@ fn build_test_peer(
             origin,
             MessagingProtocolVersion::V1,
             [].iter().into(),
-            TrustLevel::Untrusted,
             PeerRole::Unknown,
         ),
         socket: a,
@@ -160,8 +159,8 @@ async fn assert_disconnected_event(
     connection_notifs_rx: &mut channel::Receiver<TransportNotification<MemorySocket>>,
 ) {
     match connection_notifs_rx.next().await {
-        Some(TransportNotification::Disconnected(conn_info, actual_reason)) => {
-            assert_eq!(conn_info.remote_peer_id, peer_id);
+        Some(TransportNotification::Disconnected(metadata, actual_reason)) => {
+            assert_eq!(metadata.remote_peer_id, peer_id);
             assert_eq!(actual_reason, reason);
         }
         event => panic!("Expected a Disconnected, received: {:?}", event),

--- a/network/src/peer_manager/builder.rs
+++ b/network/src/peer_manager/builder.rs
@@ -102,6 +102,7 @@ struct PeerManagerContext {
     connection_reqs_tx: diem_channel::Sender<PeerId, ConnectionRequest>,
     connection_reqs_rx: diem_channel::Receiver<PeerId, ConnectionRequest>,
 
+    trusted_peers: Arc<RwLock<PeerSet>>,
     upstream_handlers:
         HashMap<ProtocolId, diem_channel::Sender<(PeerId, ProtocolId), PeerManagerNotification>>,
     connection_event_handlers: Vec<conn_notifs_channel::Sender>,
@@ -118,6 +119,7 @@ impl PeerManagerContext {
         connection_reqs_tx: diem_channel::Sender<PeerId, ConnectionRequest>,
         connection_reqs_rx: diem_channel::Receiver<PeerId, ConnectionRequest>,
 
+        trusted_peers: Arc<RwLock<PeerSet>>,
         upstream_handlers: HashMap<
             ProtocolId,
             diem_channel::Sender<(PeerId, ProtocolId), PeerManagerNotification>,
@@ -134,6 +136,7 @@ impl PeerManagerContext {
             connection_reqs_tx,
             connection_reqs_rx,
 
+            trusted_peers,
             upstream_handlers,
             connection_event_handlers,
 
@@ -222,13 +225,14 @@ impl PeerManagerBuilder {
                 Vec::new(),
                 Vec::new(),
                 authentication_mode,
-                trusted_peers,
+                trusted_peers.clone(),
             )),
             peer_manager_context: Some(PeerManagerContext::new(
                 pm_reqs_tx,
                 pm_reqs_rx,
                 connection_reqs_tx,
                 connection_reqs_rx,
+                trusted_peers,
                 HashMap::new(),
                 Vec::new(),
                 max_concurrent_network_reqs,
@@ -369,6 +373,7 @@ impl PeerManagerBuilder {
             // TODO(philiphayes): peer manager should take `Vec<NetworkAddress>`
             // (which could be empty, like in client use case)
             self.listen_address.clone(),
+            pm_context.trusted_peers,
             pm_context.pm_reqs_rx,
             pm_context.connection_reqs_rx,
             pm_context.upstream_handlers,

--- a/network/src/peer_manager/builder.rs
+++ b/network/src/peer_manager/builder.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use channel::{self, diem_channel, message_queues::QueueStyle};
 use diem_config::{
-    config::{RateLimitConfig, HANDSHAKE_VERSION},
+    config::{PeerSet, RateLimitConfig, HANDSHAKE_VERSION},
     network_id::NetworkContext,
 };
 use diem_crypto::x25519;
@@ -32,13 +32,7 @@ use netcore::transport::{
     tcp::{TcpSocket, TcpTransport},
     Transport,
 };
-use std::{
-    clone::Clone,
-    collections::{HashMap, HashSet},
-    fmt::Debug,
-    net::IpAddr,
-    sync::Arc,
-};
+use std::{clone::Clone, collections::HashMap, fmt::Debug, net::IpAddr, sync::Arc};
 use tokio::runtime::Handle;
 
 // TODO:  This is the wrong logical location for this code to exist.  Determine the better location.
@@ -60,7 +54,7 @@ struct TransportContext {
     direct_send_protocols: Vec<ProtocolId>,
     rpc_protocols: Vec<ProtocolId>,
     authentication_mode: AuthenticationMode,
-    trusted_peers: Arc<RwLock<HashMap<PeerId, HashSet<x25519::PublicKey>>>>,
+    trusted_peers: Arc<RwLock<PeerSet>>,
 }
 
 impl TransportContext {
@@ -69,7 +63,7 @@ impl TransportContext {
         direct_send_protocols: Vec<ProtocolId>,
         rpc_protocols: Vec<ProtocolId>,
         authentication_mode: AuthenticationMode,
-        trusted_peers: Arc<RwLock<HashMap<PeerId, HashSet<x25519::PublicKey>>>>,
+        trusted_peers: Arc<RwLock<PeerSet>>,
     ) -> Self {
         Self {
             chain_id,
@@ -201,7 +195,7 @@ impl PeerManagerBuilder {
         network_context: Arc<NetworkContext>,
         // TODO(philiphayes): better support multiple listening addrs
         listen_address: NetworkAddress,
-        trusted_peers: Arc<RwLock<HashMap<PeerId, HashSet<x25519::PublicKey>>>>,
+        trusted_peers: Arc<RwLock<PeerSet>>,
         authentication_mode: AuthenticationMode,
         channel_size: usize,
         max_concurrent_network_reqs: usize,

--- a/network/src/peer_manager/tests.rs
+++ b/network/src/peer_manager/tests.rs
@@ -23,6 +23,7 @@ use diem_config::{
     config::{PeerRole, MAX_INBOUND_CONNECTIONS},
     network_id::NetworkContext,
 };
+use diem_infallible::RwLock;
 use diem_network_address::NetworkAddress;
 use diem_rate_limiter::rate_limit::TokenBucketRateLimiter;
 use diem_time_service::TimeService;
@@ -32,7 +33,7 @@ use memsocket::MemorySocket;
 use netcore::transport::{
     boxed::BoxedTransport, memory::MemoryTransport, ConnectionOrigin, TransportExt,
 };
-use std::{collections::HashMap, iter::FromIterator};
+use std::{collections::HashMap, iter::FromIterator, sync::Arc};
 use tokio::runtime::Handle;
 use tokio_util::compat::{
     FuturesAsyncReadCompatExt, TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt,
@@ -103,6 +104,7 @@ fn build_test_peer_manager(
         build_test_transport(),
         NetworkContext::mock_with_peer_id(peer_id),
         "/memory/0".parse().unwrap(),
+        Arc::new(RwLock::new(HashMap::new())),
         peer_manager_request_rx,
         connection_reqs_rx,
         HashMap::from_iter([(TEST_PROTOCOL, hello_tx)].iter().cloned()),

--- a/network/src/peer_manager/tests.rs
+++ b/network/src/peer_manager/tests.rs
@@ -13,7 +13,7 @@ use crate::{
         messaging::v1::{ErrorCode, NetworkMessage, NetworkMessageSink, NetworkMessageStream},
     },
     transport,
-    transport::{Connection, ConnectionId, ConnectionMetadata, TrustLevel},
+    transport::{Connection, ConnectionId, ConnectionMetadata},
     ProtocolId,
 };
 use anyhow::anyhow;
@@ -58,7 +58,6 @@ pub fn build_test_transport(
                     origin,
                     MessagingProtocolVersion::V1,
                     [TEST_PROTOCOL].iter().into(),
-                    TrustLevel::Untrusted,
                     PeerRole::Unknown,
                 ),
             })
@@ -239,7 +238,6 @@ fn create_connection<TSocket: transport::TSocket>(
             origin,
             MessagingProtocolVersion::V1,
             [TEST_PROTOCOL].iter().into(),
-            TrustLevel::Untrusted,
             PeerRole::Unknown,
         ),
     }
@@ -565,7 +563,6 @@ fn peer_manager_simultaneous_dial_disconnect_event() {
                 ConnectionOrigin::Inbound,
                 MessagingProtocolVersion::V1,
                 [TEST_PROTOCOL].iter().into(),
-                TrustLevel::Untrusted,
                 PeerRole::Unknown,
             ),
             DisconnectReason::ConnectionLost,
@@ -621,7 +618,6 @@ fn test_dial_disconnect() {
                 ConnectionOrigin::Outbound,
                 MessagingProtocolVersion::V1,
                 [TEST_PROTOCOL].iter().into(),
-                TrustLevel::Untrusted,
                 PeerRole::Unknown,
             ),
             DisconnectReason::Requested,

--- a/network/src/peer_manager/tests.rs
+++ b/network/src/peer_manager/tests.rs
@@ -19,7 +19,10 @@ use crate::{
 use anyhow::anyhow;
 use bytes::Bytes;
 use channel::{diem_channel, message_queues::QueueStyle};
-use diem_config::{config::MAX_INBOUND_CONNECTIONS, network_id::NetworkContext};
+use diem_config::{
+    config::{PeerRole, MAX_INBOUND_CONNECTIONS},
+    network_id::NetworkContext,
+};
 use diem_network_address::NetworkAddress;
 use diem_rate_limiter::rate_limit::TokenBucketRateLimiter;
 use diem_time_service::TimeService;
@@ -56,6 +59,7 @@ pub fn build_test_transport(
                     MessagingProtocolVersion::V1,
                     [TEST_PROTOCOL].iter().into(),
                     TrustLevel::Untrusted,
+                    PeerRole::Unknown,
                 ),
             })
         })
@@ -236,6 +240,7 @@ fn create_connection<TSocket: transport::TSocket>(
             MessagingProtocolVersion::V1,
             [TEST_PROTOCOL].iter().into(),
             TrustLevel::Untrusted,
+            PeerRole::Unknown,
         ),
     }
 }
@@ -561,6 +566,7 @@ fn peer_manager_simultaneous_dial_disconnect_event() {
                 MessagingProtocolVersion::V1,
                 [TEST_PROTOCOL].iter().into(),
                 TrustLevel::Untrusted,
+                PeerRole::Unknown,
             ),
             DisconnectReason::ConnectionLost,
         );
@@ -616,6 +622,7 @@ fn test_dial_disconnect() {
                 MessagingProtocolVersion::V1,
                 [TEST_PROTOCOL].iter().into(),
                 TrustLevel::Untrusted,
+                PeerRole::Unknown,
             ),
             DisconnectReason::Requested,
         );

--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -204,11 +204,11 @@ impl HealthChecker {
                     };
 
                     match event {
-                        Event::NewPeer(peer_id, _origin) => {
-                            self.connected.insert(peer_id, (self.round, 0));
+                        Event::NewPeer(metadata) => {
+                            self.connected.insert(metadata.remote_peer_id, (self.round, 0));
                         }
-                        Event::LostPeer(peer_id, _origin) => {
-                            self.connected.remove(&peer_id);
+                        Event::LostPeer(metadata) => {
+                            self.connected.remove(&metadata.remote_peer_id);
                         }
                         Event::RpcRequest(peer_id, msg, res_tx) => {
                             match msg {

--- a/network/src/protocols/network/mod.rs
+++ b/network/src/protocols/network/mod.rs
@@ -10,6 +10,7 @@ use crate::{
         ConnectionNotification, ConnectionRequestSender, PeerManagerNotification,
         PeerManagerRequestSender,
     },
+    transport::ConnectionMetadata,
     ProtocolId,
 };
 use bytes::Bytes;
@@ -23,7 +24,6 @@ use futures::{
     stream::{FilterMap, FusedStream, Map, Select, Stream, StreamExt},
     task::{Context, Poll},
 };
-use netcore::transport::ConnectionOrigin;
 use pin_project::pin_project;
 use serde::{de::DeserializeOwned, Serialize};
 use std::{cmp::min, marker::PhantomData, pin::Pin, time::Duration};
@@ -49,9 +49,9 @@ pub enum Event<TMessage> {
     /// layer will handle sending the response over-the-wire.
     RpcRequest(PeerId, TMessage, oneshot::Sender<Result<Bytes, RpcError>>),
     /// Peer which we have a newly established connection with.
-    NewPeer(PeerId, ConnectionOrigin),
+    NewPeer(ConnectionMetadata),
     /// Peer with which we've lost our connection.
-    LostPeer(PeerId, ConnectionOrigin),
+    LostPeer(ConnectionMetadata),
 }
 
 /// impl PartialEq for simpler testing
@@ -62,10 +62,8 @@ impl<TMessage: PartialEq> PartialEq for Event<TMessage> {
             (Message(pid1, msg1), Message(pid2, msg2)) => pid1 == pid2 && msg1 == msg2,
             // ignore oneshot::Sender in comparison
             (RpcRequest(pid1, msg1, _), RpcRequest(pid2, msg2, _)) => pid1 == pid2 && msg1 == msg2,
-            (NewPeer(pid1, origin1), NewPeer(pid2, origin2)) => pid1 == pid2 && origin1 == origin2,
-            (LostPeer(pid1, origin1), LostPeer(pid2, origin2)) => {
-                pid1 == pid2 && origin1 == origin2
-            }
+            (NewPeer(metadata1), NewPeer(metadata2)) => metadata1 == metadata2,
+            (LostPeer(metadata1), LostPeer(metadata2)) => metadata1 == metadata2,
             _ => false,
         }
     }
@@ -175,12 +173,8 @@ fn peer_mgr_notif_to_event<TMessage: Message>(
 
 fn control_msg_to_event<TMessage>(notif: ConnectionNotification) -> Event<TMessage> {
     match notif {
-        ConnectionNotification::NewPeer(metadata, _context) => {
-            Event::NewPeer(metadata.remote_peer_id, metadata.origin)
-        }
-        ConnectionNotification::LostPeer(metadata, _context, _reason) => {
-            Event::LostPeer(metadata.remote_peer_id, metadata.origin)
-        }
+        ConnectionNotification::NewPeer(metadata, _context) => Event::NewPeer(metadata),
+        ConnectionNotification::LostPeer(metadata, _context, _reason) => Event::LostPeer(metadata),
     }
 }
 

--- a/network/src/protocols/wire/handshake/v1/test.rs
+++ b/network/src/protocols/wire/handshake/v1/test.rs
@@ -30,7 +30,7 @@ fn protocols_to_from_vec() {
 #[test]
 fn represents_same_network() {
     let mut handshake_msg = HandshakeMsg::new_for_testing();
-    handshake_msg.network_id = NetworkId::Private("h1".to_string());
+    handshake_msg.network_id = NetworkId::vfn_network();
 
     // succeeds: Positive case
     let h1 = handshake_msg.clone();

--- a/network/src/transport/mod.rs
+++ b/network/src/transport/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     },
 };
 use diem_config::{
-    config::HANDSHAKE_VERSION,
+    config::{PeerRole, HANDSHAKE_VERSION},
     network_id::{NetworkContext, NetworkId},
 };
 use diem_crypto::x25519;
@@ -110,6 +110,7 @@ pub struct ConnectionMetadata {
     pub messaging_protocol: MessagingProtocolVersion,
     pub application_protocols: SupportedProtocols,
     pub trust_level: TrustLevel,
+    pub role: PeerRole,
 }
 
 impl ConnectionMetadata {
@@ -121,6 +122,7 @@ impl ConnectionMetadata {
         messaging_protocol: MessagingProtocolVersion,
         application_protocols: SupportedProtocols,
         trust_level: TrustLevel,
+        role: PeerRole,
     ) -> ConnectionMetadata {
         ConnectionMetadata {
             remote_peer_id,
@@ -130,6 +132,7 @@ impl ConnectionMetadata {
             messaging_protocol,
             application_protocols,
             trust_level,
+            role,
         }
     }
 
@@ -143,6 +146,7 @@ impl ConnectionMetadata {
             messaging_protocol: MessagingProtocolVersion::V1,
             application_protocols: [].iter().into(),
             trust_level: TrustLevel::Untrusted,
+            role: PeerRole::Unknown,
         }
     }
 }
@@ -157,12 +161,13 @@ impl fmt::Display for ConnectionMetadata {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "[{},{},{},{},{:?}]",
+            "[{},{},{},{},{:?},{:?}]",
             self.remote_peer_id,
             self.addr,
             self.origin,
             self.messaging_protocol,
-            self.application_protocols
+            self.application_protocols,
+            self.role
         )
     }
 }
@@ -298,6 +303,8 @@ async fn upgrade_inbound<T: TSocket>(
             messaging_protocol,
             application_protocols,
             trust_level,
+            // TODO: Load correct role
+            PeerRole::Unknown,
         ),
     })
 }
@@ -368,6 +375,8 @@ async fn upgrade_outbound<T: TSocket>(
             messaging_protocol,
             application_protocols,
             TrustLevel::Trusted,
+            // TODO: Fix role
+            PeerRole::Unknown,
         ),
     })
 }

--- a/state-sync/src/coordinator.rs
+++ b/state-sync/src/coordinator.rs
@@ -197,13 +197,13 @@ impl<T: ExecutorProxyTrait> StateSyncCoordinator<T> {
                 },
                 (network_id, event) = network_events.select_next_some() => {
                     match event {
-                        Event::NewPeer(peer_id, origin) => {
-                            if let Err(e) = self.process_new_peer(network_id, peer_id, origin) {
+                        Event::NewPeer(metadata) => {
+                            if let Err(e) = self.process_new_peer(network_id, metadata.remote_peer_id, metadata.origin) {
                                 error!(LogSchema::new(LogEntry::NewPeer).error(&e.into()));
                             }
                         }
-                        Event::LostPeer(peer_id, origin) => {
-                            if let Err(e) = self.process_lost_peer(network_id, peer_id, origin) {
+                        Event::LostPeer(metadata) => {
+                            if let Err(e) = self.process_lost_peer(network_id, metadata.remote_peer_id, metadata.origin) {
                                 error!(LogSchema::new(LogEntry::LostPeer).error(&e.into()));
                             }
                         }

--- a/state-sync/tests/test_harness.rs
+++ b/state-sync/tests/test_harness.rs
@@ -76,7 +76,7 @@ use vm_genesis::GENESIS_KEYPAIR;
 
 // Networks for validators and fullnodes.
 pub static VALIDATOR_NETWORK: Lazy<NetworkId> = Lazy::new(|| NetworkId::Validator);
-pub static VFN_NETWORK: Lazy<NetworkId> = Lazy::new(|| NetworkId::Private("VFN".into()));
+pub static VFN_NETWORK: Lazy<NetworkId> = Lazy::new(NetworkId::vfn_network);
 pub static VFN_NETWORK_2: Lazy<NetworkId> = Lazy::new(|| NetworkId::Private("Second VFN".into()));
 pub static PFN_NETWORK: Lazy<NetworkId> = Lazy::new(|| NetworkId::Public);
 

--- a/state-sync/tests/test_harness.rs
+++ b/state-sync/tests/test_harness.rs
@@ -4,7 +4,7 @@
 use anyhow::{bail, format_err, Result};
 use channel::{diem_channel, message_queues::QueueStyle};
 use diem_config::{
-    config::{NodeConfig, RoleType, TrustedPeer, HANDSHAKE_VERSION},
+    config::{NodeConfig, Peer, RoleType, HANDSHAKE_VERSION},
     network_id::{NetworkContext, NetworkId, NodeNetworkId},
 };
 use diem_crypto::{
@@ -382,7 +382,7 @@ impl StateSyncEnvironment {
                 .iter()
                 .map(|peer| {
                     let peer = peer.borrow();
-                    (peer.peer_id, TrustedPeer::from(peer.network_addr.clone()))
+                    (peer.peer_id, Peer::from(peer.network_addr.clone()))
                 })
                 .collect();
             let trusted_peers = Arc::new(RwLock::new(HashMap::new()));

--- a/state-sync/tests/test_harness.rs
+++ b/state-sync/tests/test_harness.rs
@@ -4,7 +4,7 @@
 use anyhow::{bail, format_err, Result};
 use channel::{diem_channel, message_queues::QueueStyle};
 use diem_config::{
-    config::{NodeConfig, Peer, RoleType, HANDSHAKE_VERSION},
+    config::{NodeConfig, Peer, PeerRole, RoleType, HANDSHAKE_VERSION},
     network_id::{NetworkContext, NetworkId, NodeNetworkId},
 };
 use diem_crypto::{
@@ -382,7 +382,10 @@ impl StateSyncEnvironment {
                 .iter()
                 .map(|peer| {
                     let peer = peer.borrow();
-                    (peer.peer_id, Peer::from(peer.network_addr.clone()))
+                    (
+                        peer.peer_id,
+                        Peer::from_addrs(PeerRole::Validator, vec![peer.network_addr.clone()]),
+                    )
                 })
                 .collect();
             let trusted_peers = Arc::new(RwLock::new(HashMap::new()));

--- a/testsuite/cluster-test/src/cluster_swarm/configs/fullnode.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/configs/fullnode.yaml
@@ -14,9 +14,11 @@ full_node_networks:
 - network_id:
     private: "vfn"
   listen_address: "/ip4/0.0.0.0/tcp/6181"
-  seed_addrs:
+  seeds:
     d58bc7bb154b38039bc9096ce04e1237:
-    - "/ip4/{seed_peer_ip}/tcp/6181/ln-noise-ik/f0274c2774519281a8332d0bb9d8101bd58bc7bb154b38039bc9096ce04e1237/ln-handshake/0"
+      addresses:
+        - "/ip4/{seed_peer_ip}/tcp/6181/ln-noise-ik/f0274c2774519281a8332d0bb9d8101bd58bc7bb154b38039bc9096ce04e1237/ln-handshake/0"
+      role: "Validator"
 - network_id: "public"
   listen_address: "/ip4/0.0.0.0/tcp/6182"
   identity:

--- a/testsuite/cluster-test/src/experiments/load_test.rs
+++ b/testsuite/cluster-test/src/experiments/load_test.rs
@@ -307,8 +307,8 @@ async fn mempool_load_test(
     mut events: MempoolNetworkEvents,
 ) -> Result<MempoolStats> {
     let new_peer_event = events.select_next_some().await;
-    let vfn = if let Event::NewPeer(peer_id, _) = new_peer_event {
-        peer_id
+    let vfn = if let Event::NewPeer(metadata) = new_peer_event {
+        metadata.remote_peer_id
     } else {
         return Err(anyhow::format_err!(
             "received unexpected network event for mempool load test"
@@ -401,8 +401,8 @@ async fn state_sync_load_test(
     mut events: StateSyncEvents,
 ) -> Result<StateSyncStats> {
     let new_peer_event = events.select_next_some().await;
-    let vfn = if let Event::NewPeer(peer_id, _) = new_peer_event {
-        peer_id
+    let vfn = if let Event::NewPeer(metadata) = new_peer_event {
+        metadata.remote_peer_id
     } else {
         return Err(anyhow::format_err!(
             "received unexpected network event for state sync load test"

--- a/testsuite/cluster-test/src/experiments/load_test.rs
+++ b/testsuite/cluster-test/src/experiments/load_test.rs
@@ -245,7 +245,8 @@ impl StubbedNode {
     async fn launch(node_endpoint: String, runtime_handle: Handle, index: usize) -> Self {
         // generate seed peers config from querying node endpoint
         let seed_peers =
-            seed_peer_generator::utils::gen_full_node_seed_peer_config(node_endpoint).unwrap();
+            seed_peer_generator::utils::gen_validator_full_node_seed_peer_config(node_endpoint)
+                .unwrap();
 
         // build sparse network runner
 


### PR DESCRIPTION
### Overview
This adds requirement to specify the role for seed peers.  It additionally will determine the correct role for discovery / seed peer generation to put into place.  This now properly loads from Discovery for known peers, and it is threaded in the `ConnectionMetadata` peer events that go to the downstream applications.  Additionally, ConnectivityManager keeps track of the **first** role that a peer is given.  That means if it has an override seed role, it will be taken instead.  

#### Why not just use `RoleType`?
RoleType is great for some portions in the code, but it's become apparent that we need a more fine-grained delimiter between types of full nodes.  In the spirit of not refactoring the entire code base for `RoleType` to support these types, I've added a new type `PeerRole`.

#### Does this do any smart selection based on `Peers`?
Not yet, it will eventually be able to select peers based on this information, but it looked like a decent amount of refactoring, so I'm putting this out first.