### PR TITLE
[language] switch diem tests to exp mode -- admin_scripts/authenticator/block

### DIFF
--- a/language/move-lang/functional-tests/tests/diem/admin_scripts/basic_admin_script.exp
+++ b/language/move-lang/functional-tests/tests/diem/admin_scripts/basic_admin_script.exp
@@ -1,0 +1,6 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)
+[3] Transaction(1)
+[4] Move VM Status: ERROR { status_code: REJECTED_WRITE_SET }
+[5] Transaction Status: Discard(REJECTED_WRITE_SET)

--- a/language/move-lang/functional-tests/tests/diem/admin_scripts/basic_admin_script.move
+++ b/language/move-lang/functional-tests/tests/diem/admin_scripts/basic_admin_script.move
@@ -10,7 +10,6 @@ fun main(dr: &signer, bob: &signer) {
     assert(Signer::address_of(bob) == {{bob}}, 1);
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: blessed
@@ -23,4 +22,3 @@ fun main(dr: &signer, bob: &signer) {
     assert(Signer::address_of(bob) == {{bob}}, 1);
 }
 }
-// check: REJECTED_WRITE_SET

--- a/language/move-lang/functional-tests/tests/diem/authenticator/authenticator.exp
+++ b/language/move-lang/functional-tests/tests/diem/authenticator/authenticator.exp
@@ -1,0 +1,21 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)
+[3] Transaction(1)
+[4] Move VM Status: ABORTED { code: 7, location: 00000000000000000000000000000001::Authenticator }
+[5] Transaction Status: Keep(ABORTED { code: 7, location: 00000000000000000000000000000001::Authenticator })
+[6] Transaction(2)
+[7] Move VM Status: ABORTED { code: 263, location: 00000000000000000000000000000001::Authenticator }
+[8] Transaction Status: Keep(ABORTED { code: 263, location: 00000000000000000000000000000001::Authenticator })
+[9] Transaction(3)
+[10] Move VM Status: ABORTED { code: 519, location: 00000000000000000000000000000001::Authenticator }
+[11] Transaction Status: Keep(ABORTED { code: 519, location: 00000000000000000000000000000001::Authenticator })
+[12] Transaction(4)
+[13] Move VM Status: ABORTED { code: 263, location: 00000000000000000000000000000001::Authenticator }
+[14] Transaction Status: Keep(ABORTED { code: 263, location: 00000000000000000000000000000001::Authenticator })
+[15] Transaction(5)
+[16] Move VM Status: ABORTED { code: 7, location: 00000000000000000000000000000001::Authenticator }
+[17] Transaction Status: Keep(ABORTED { code: 7, location: 00000000000000000000000000000001::Authenticator })
+[18] Transaction(6)
+[19] Move VM Status: EXECUTED
+[20] Transaction Status: Keep(EXECUTED)

--- a/language/move-lang/functional-tests/tests/diem/authenticator/authenticator.move
+++ b/language/move-lang/functional-tests/tests/diem/authenticator/authenticator.move
@@ -41,7 +41,6 @@ fun main() {
 }
 }
 
-// check: "Keep(EXECUTED)"
 
 // empty policy should  be rejected
 //! new-transaction
@@ -54,7 +53,6 @@ fun main() {
 }
 }
 
-// check: "Keep(ABORTED { code: 7,"
 
 // bad threshold should be rejected (threshold 1 for empty keys)
 //! new-transaction
@@ -67,7 +65,6 @@ fun main() {
 }
 }
 
-// check: "Keep(ABORTED { code: 263,"
 
 //! new-transaction
 script {
@@ -87,7 +84,6 @@ fun main() {
 }
 }
 
-// check: "Keep(ABORTED { code: 519,"
 
 // bad threshold should be rejected (threshold 2 for 1 key)
 //! new-transaction
@@ -104,7 +100,6 @@ fun main() {
 }
 }
 
-// check: "Keep(ABORTED { code: 263,"
 
 // bad threshold should be rejected (threshold 0 for 1 address)
 //! new-transaction
@@ -121,7 +116,6 @@ fun main() {
 }
 }
 
-// check: "Keep(ABORTED { code: 7,"
 
 // 1-of-1 multi-ed25519 should have a different auth key than ed25519 with the same public key
 //! new-transaction
@@ -150,5 +144,3 @@ fun main() {
     );
 }
 }
-
-// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/diem/block/block_prologue.exp
+++ b/language/move-lang/functional-tests/tests/diem/block/block_prologue.exp
@@ -1,0 +1,10 @@
+[0] Output(TransactionOutput(TransactionOutput { write_set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: 0000000000000000000000000a550c18, path: 01000000000000000000000000000000010d4469656d54696d657374616d701743757272656e7454696d654d6963726f7365636f6e647300 }, Value(40420f0000000000)), (AccessPath { address: 0000000000000000000000000a550c18, path: 0100000000000000000000000000000001094469656d426c6f636b0d426c6f636b4d6574616461746100 }, Value(010000000000000001000000000000001811000000000000000000000000000000000000000a550c18))] }), events: [ContractEvent { key: EventKey([17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]), index: 0, type: Struct(StructTag { address: 00000000000000000000000000000001, module: Identifier("DiemBlock"), name: Identifier("NewBlockEvent"), type_params: [] }), event_data: "000000000000000051c1b9fc2f32d6f2fff669823ef31cbe0040420f0000000000" }], gas_used: 100000000, status: Keep(EXECUTED) }))
+[1] Transaction(1)
+[2] Move VM Status: EXECUTED
+[3] Transaction Status: Keep(EXECUTED)
+[4] Transaction(2)
+[5] Move VM Status: EXECUTED
+[6] Transaction Status: Keep(EXECUTED)
+[7] Transaction(3)
+[8] Move VM Status: ABORTED { code: 514, location: 00000000000000000000000000000001::CoreAddresses }
+[9] Transaction Status: Keep(ABORTED { code: 514, location: 00000000000000000000000000000001::CoreAddresses })

--- a/language/move-lang/functional-tests/tests/diem/block/block_prologue.move
+++ b/language/move-lang/functional-tests/tests/diem/block/block_prologue.move
@@ -18,7 +18,6 @@ fun main() {
     assert(DiemTimestamp::now_microseconds() == 1000000, 76);
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 script{
@@ -28,7 +27,6 @@ fun main() {
     assert(DiemTimestamp::now_microseconds() != 2000000, 77);
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: vivian
@@ -39,4 +37,3 @@ fun main(account: &signer) {
     DiemTimestamp::update_global_time(account, {{vivian}}, 20);
 }
 }
-// check: "Keep(ABORTED { code: 514,"

--- a/language/move-lang/functional-tests/tests/diem/block/expired_transaction.exp
+++ b/language/move-lang/functional-tests/tests/diem/block/expired_transaction.exp
@@ -1,0 +1,23 @@
+[0] Output(TransactionOutput(TransactionOutput { write_set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: 0000000000000000000000000a550c18, path: 01000000000000000000000000000000010d4469656d54696d657374616d701743757272656e7454696d654d6963726f7365636f6e647300 }, Value(00e1f50500000000)), (AccessPath { address: 0000000000000000000000000a550c18, path: 0100000000000000000000000000000001094469656d426c6f636b0d426c6f636b4d6574616461746100 }, Value(010000000000000001000000000000001811000000000000000000000000000000000000000a550c18))] }), events: [ContractEvent { key: EventKey([17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]), index: 0, type: Struct(StructTag { address: 00000000000000000000000000000001, module: Identifier("DiemBlock"), name: Identifier("NewBlockEvent"), type_params: [] }), event_data: "000000000000000051c1b9fc2f32d6f2fff669823ef31cbe0000e1f50500000000" }], gas_used: 100000000, status: Keep(EXECUTED) }))
+[1] Transaction(1)
+[2] Move VM Status: ERROR { status_code: TRANSACTION_EXPIRED }
+[3] Transaction Status: Discard(TRANSACTION_EXPIRED)
+[4] Transaction(2)
+[5] Move VM Status: ERROR { status_code: TRANSACTION_EXPIRED }
+[6] Transaction Status: Discard(TRANSACTION_EXPIRED)
+[7] Transaction(3)
+[8] Move VM Status: EXECUTED
+[9] Transaction Status: Keep(EXECUTED)
+[10] Transaction(4)
+[11] Move VM Status: EXECUTED
+[12] Transaction Status: Keep(EXECUTED)
+[13] Output(TransactionOutput(TransactionOutput { write_set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: 0000000000000000000000000a550c18, path: 01000000000000000000000000000000010d4469656d54696d657374616d701743757272656e7454696d654d6963726f7365636f6e647300 }, Value(4023050600000000)), (AccessPath { address: 0000000000000000000000000a550c18, path: 0100000000000000000000000000000001094469656d426c6f636b0d426c6f636b4d6574616461746100 }, Value(020000000000000002000000000000001811000000000000000000000000000000000000000a550c18))] }), events: [ContractEvent { key: EventKey([17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]), index: 1, type: Struct(StructTag { address: 00000000000000000000000000000001, module: Identifier("DiemBlock"), name: Identifier("NewBlockEvent"), type_params: [] }), event_data: "000000000000000051c1b9fc2f32d6f2fff669823ef31cbe004023050600000000" }], gas_used: 100000000, status: Keep(EXECUTED) }))
+[14] Transaction(6)
+[15] Move VM Status: EXECUTED
+[16] Transaction Status: Keep(EXECUTED)
+[17] Transaction(7)
+[18] Move VM Status: ERROR { status_code: TRANSACTION_EXPIRED }
+[19] Transaction Status: Discard(TRANSACTION_EXPIRED)
+[20] Transaction(8)
+[21] Move VM Status: EXECUTED
+[22] Transaction Status: Keep(EXECUTED)

--- a/language/move-lang/functional-tests/tests/diem/block/expired_transaction.move
+++ b/language/move-lang/functional-tests/tests/diem/block/expired_transaction.move
@@ -10,7 +10,6 @@ script{
 fun main() {
 }
 }
-// check: TRANSACTION_EXPIRED
 
 //! new-transaction
 //! expiration-time: 100
@@ -18,7 +17,6 @@ script{
 fun main() {
 }
 }
-// check: TRANSACTION_EXPIRED
 
 //! new-transaction
 //! expiration-time: 101
@@ -26,7 +24,6 @@ script{
 fun main() {
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! expiration-time: 86500
@@ -34,7 +31,6 @@ script{
 fun main() {
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! block-prologue
 //! proposer: vivian
@@ -46,7 +42,6 @@ script{
 fun main() {
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! expiration-time: 101
@@ -54,7 +49,6 @@ script{
 fun main() {
 }
 }
-// check: TRANSACTION_EXPIRED
 
 //! new-transaction
 //! expiration-time: 18446744073710
@@ -62,4 +56,3 @@ script{
 fun main() {
 }
 }
-// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/diem/block/get_block_height.exp
+++ b/language/move-lang/functional-tests/tests/diem/block/get_block_height.exp
@@ -1,0 +1,11 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)
+[3] Output(TransactionOutput(TransactionOutput { write_set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: 0000000000000000000000000a550c18, path: 01000000000000000000000000000000010d4469656d54696d657374616d701743757272656e7454696d654d6963726f7365636f6e647300 }, Value(00e1f50500000000)), (AccessPath { address: 0000000000000000000000000a550c18, path: 0100000000000000000000000000000001094469656d426c6f636b0d426c6f636b4d6574616461746100 }, Value(010000000000000001000000000000001811000000000000000000000000000000000000000a550c18))] }), events: [ContractEvent { key: EventKey([17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]), index: 0, type: Struct(StructTag { address: 00000000000000000000000000000001, module: Identifier("DiemBlock"), name: Identifier("NewBlockEvent"), type_params: [] }), event_data: "000000000000000051c1b9fc2f32d6f2fff669823ef31cbe0000e1f50500000000" }], gas_used: 100000000, status: Keep(EXECUTED) }))
+[4] Transaction(2)
+[5] Move VM Status: EXECUTED
+[6] Transaction Status: Keep(EXECUTED)
+[7] Output(TransactionOutput(TransactionOutput { write_set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: 0000000000000000000000000a550c18, path: 01000000000000000000000000000000010d4469656d54696d657374616d701743757272656e7454696d654d6963726f7365636f6e647300 }, Value(4023050600000000)), (AccessPath { address: 0000000000000000000000000a550c18, path: 0100000000000000000000000000000001094469656d426c6f636b0d426c6f636b4d6574616461746100 }, Value(020000000000000002000000000000001811000000000000000000000000000000000000000a550c18))] }), events: [ContractEvent { key: EventKey([17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]), index: 1, type: Struct(StructTag { address: 00000000000000000000000000000001, module: Identifier("DiemBlock"), name: Identifier("NewBlockEvent"), type_params: [] }), event_data: "000000000000000051c1b9fc2f32d6f2fff669823ef31cbe004023050600000000" }], gas_used: 100000000, status: Keep(EXECUTED) }))
+[8] Transaction(4)
+[9] Move VM Status: EXECUTED
+[10] Transaction Status: Keep(EXECUTED)

--- a/language/move-lang/functional-tests/tests/diem/block/invalid_initialization_address.exp
+++ b/language/move-lang/functional-tests/tests/diem/block/invalid_initialization_address.exp
@@ -1,0 +1,3 @@
+[0] Transaction(0)
+[1] Move VM Status: ABORTED { code: 1, location: 00000000000000000000000000000001::DiemTimestamp }
+[2] Transaction Status: Keep(ABORTED { code: 1, location: 00000000000000000000000000000001::DiemTimestamp })

--- a/language/move-lang/functional-tests/tests/diem/block/invalid_initialization_address.move
+++ b/language/move-lang/functional-tests/tests/diem/block/invalid_initialization_address.move
@@ -4,4 +4,3 @@ fun main(account: &signer) {
     DiemBlock::initialize_block_metadata(account);
 }
 }
-// check: "Keep(ABORTED { code: 1,"

--- a/language/move-lang/functional-tests/tests/diem/block/none_validator_propser.exp
+++ b/language/move-lang/functional-tests/tests/diem/block/none_validator_propser.exp
@@ -1,0 +1,5 @@
+[0] Output(TransactionOutput(TransactionOutput { write_set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: 0000000000000000000000000a550c18, path: 01000000000000000000000000000000010d4469656d54696d657374616d701743757272656e7454696d654d6963726f7365636f6e647300 }, Value(40420f0000000000)), (AccessPath { address: 0000000000000000000000000a550c18, path: 0100000000000000000000000000000001094469656d426c6f636b0d426c6f636b4d6574616461746100 }, Value(010000000000000001000000000000001811000000000000000000000000000000000000000a550c18))] }), events: [ContractEvent { key: EventKey([17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]), index: 0, type: Struct(StructTag { address: 00000000000000000000000000000001, module: Identifier("DiemBlock"), name: Identifier("NewBlockEvent"), type_params: [] }), event_data: "000000000000000051c1b9fc2f32d6f2fff669823ef31cbe0040420f0000000000" }], gas_used: 100000000, status: Keep(EXECUTED) }))
+[1] Transaction(1)
+[2] Move VM Status: EXECUTED
+[3] Transaction Status: Keep(EXECUTED)
+[4] VerificationError(ERROR { status_code: UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION })

--- a/language/move-lang/functional-tests/tests/diem/block/none_validator_propser.move
+++ b/language/move-lang/functional-tests/tests/diem/block/none_validator_propser.move
@@ -15,10 +15,7 @@ fun main() {
     assert(DiemTimestamp::now_microseconds() == 1000000, 78);
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! block-prologue
 //! proposer: alice
 //! block-time: 1000000
-
-// check: UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION

--- a/language/move-lang/functional-tests/tests/diem/block/older_timestamp.exp
+++ b/language/move-lang/functional-tests/tests/diem/block/older_timestamp.exp
@@ -1,0 +1,5 @@
+[0] Output(TransactionOutput(TransactionOutput { write_set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: 0000000000000000000000000a550c18, path: 01000000000000000000000000000000010d4469656d54696d657374616d701743757272656e7454696d654d6963726f7365636f6e647300 }, Value(00e1f50500000000)), (AccessPath { address: 0000000000000000000000000a550c18, path: 0100000000000000000000000000000001094469656d426c6f636b0d426c6f636b4d6574616461746100 }, Value(010000000000000001000000000000001811000000000000000000000000000000000000000a550c18))] }), events: [ContractEvent { key: EventKey([17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]), index: 0, type: Struct(StructTag { address: 00000000000000000000000000000001, module: Identifier("DiemBlock"), name: Identifier("NewBlockEvent"), type_params: [] }), event_data: "000000000000000051c1b9fc2f32d6f2fff669823ef31cbe0000e1f50500000000" }], gas_used: 100000000, status: Keep(EXECUTED) }))
+[1] Transaction(1)
+[2] Move VM Status: EXECUTED
+[3] Transaction Status: Keep(EXECUTED)
+[4] VerificationError(ERROR { status_code: UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION })

--- a/language/move-lang/functional-tests/tests/diem/block/older_timestamp.move
+++ b/language/move-lang/functional-tests/tests/diem/block/older_timestamp.move
@@ -18,5 +18,3 @@ fun main() {
 //! block-prologue
 //! proposer: vivian
 //! block-time: 11000000
-
-// check: UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION

--- a/language/move-lang/functional-tests/tests/diem/block/vm_proposer.exp
+++ b/language/move-lang/functional-tests/tests/diem/block/vm_proposer.exp
@@ -1,0 +1,1 @@
+[0] VerificationError(ERROR { status_code: UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION })

--- a/language/move-lang/functional-tests/tests/diem/block/vm_proposer.move
+++ b/language/move-lang/functional-tests/tests/diem/block/vm_proposer.move
@@ -1,5 +1,3 @@
 //! block-prologue
 //! proposer-address:  0x0
 //! block-time: 1000000
-
-// check: UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION


### PR DESCRIPTION
Suspicious tests: none.

However I found that block prologue transactions do not print out a `Transaction(X)` header, making the log confusing. Will put up a fix for this.