### PR TITLE
[State Sync] Begin adding unit tests for coordinator, better error support and cleaning up code.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6504,6 +6504,7 @@ dependencies = [
  "storage-interface",
  "storage-service",
  "subscription-service",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "transaction-builder",

--- a/state-sync/Cargo.toml
+++ b/state-sync/Cargo.toml
@@ -19,6 +19,7 @@ once_cell = "1.4.1"
 proptest = { version = "0.10.1", optional = true }
 rand = "0.7.3"
 serde = { version = "1.0.123", default-features = false }
+thiserror = "1.0.23"
 tokio = { version = "1.1.0", features = ["full"] }
 tokio-stream = "0.1.2"
 

--- a/state-sync/src/client.rs
+++ b/state-sync/src/client.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{coordinator::SyncState, counters};
+use crate::{counters, shared_components::SyncState};
 use anyhow::{format_err, Result};
 use diem_mempool::CommitResponse;
 use diem_types::{

--- a/state-sync/src/error.rs
+++ b/state-sync/src/error.rs
@@ -6,12 +6,16 @@ use diem_types::transaction::Version;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-#[derive(Debug, Deserialize, Error, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Error, PartialEq, Serialize)]
 pub enum Error {
     #[error("Failed to send callback: {0}")]
     CallbackSendFailed(String),
+    #[error("No transactions were committed, but received a commit notification!")]
+    NoTransactionsCommitted,
     #[error("Received an old sync request for version {0}, but our known version is: {1}")]
     OldSyncRequestVersion(Version, Version),
+    #[error("Synced beyond the target version. Synced version: {0}, target version: {1}")]
+    SyncedBeyondTarget(Version, Version),
     #[error("State sync is uninitialized! Error: {0}")]
     UninitializedError(String),
     #[error("Unexpected error: {0}")]

--- a/state-sync/src/error.rs
+++ b/state-sync/src/error.rs
@@ -1,0 +1,25 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::Error::UnexpectedError;
+use diem_types::transaction::Version;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Deserialize, Error, PartialEq, Serialize)]
+pub enum Error {
+    #[error("Received an old sync request for version {0}, but our known version is: {1}")]
+    OldSyncRequestVersion(Version, Version),
+    #[error("State sync is uninitialized! Error: {0}")]
+    UninitializedError(String),
+    #[error("Unexpected error: {0}")]
+    UnexpectedError(String),
+}
+
+// TODO(joshlind): remove this once we move from anyhow error to thiserror in state sync!
+impl From<anyhow::Error> for Error {
+    fn from(error: anyhow::Error) -> Self {
+        let error_message = format!("{}", error);
+        UnexpectedError(error_message)
+    }
+}

--- a/state-sync/src/error.rs
+++ b/state-sync/src/error.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 
 #[derive(Debug, Deserialize, Error, PartialEq, Serialize)]
 pub enum Error {
-    #[error("Failed to send callback in method: {0}")]
+    #[error("Failed to send callback: {0}")]
     CallbackSendFailed(String),
     #[error("Received an old sync request for version {0}, but our known version is: {1}")]
     OldSyncRequestVersion(Version, Version),

--- a/state-sync/src/error.rs
+++ b/state-sync/src/error.rs
@@ -8,6 +8,8 @@ use thiserror::Error;
 
 #[derive(Debug, Deserialize, Error, PartialEq, Serialize)]
 pub enum Error {
+    #[error("Failed to send callback in method: {0}")]
+    CallbackSendFailed(String),
     #[error("Received an old sync request for version {0}, but our known version is: {1}")]
     OldSyncRequestVersion(Version, Version),
     #[error("State sync is uninitialized! Error: {0}")]

--- a/state-sync/src/error.rs
+++ b/state-sync/src/error.rs
@@ -25,7 +25,6 @@ pub enum Error {
 // TODO(joshlind): remove this once we move from anyhow error to thiserror in state sync!
 impl From<anyhow::Error> for Error {
     fn from(error: anyhow::Error) -> Self {
-        let error_message = format!("{}", error);
-        UnexpectedError(error_message)
+        UnexpectedError(format!("{}", error))
     }
 }

--- a/state-sync/src/executor_proxy.rs
+++ b/state-sync/src/executor_proxy.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    coordinator::SyncState,
     counters,
     logging::{LogEntry, LogEvent, LogSchema},
+    shared_components::SyncState,
 };
 use anyhow::{format_err, Result};
 use diem_logger::prelude::*;

--- a/state-sync/src/fuzzing.rs
+++ b/state-sync/src/fuzzing.rs
@@ -5,30 +5,19 @@ use crate::{
     chunk_request::{GetChunkRequest, TargetType},
     chunk_response::{GetChunkResponse, ResponseLedgerInfo},
     coordinator::StateSyncCoordinator,
-    executor_proxy::{ExecutorProxy, ExecutorProxyTrait},
-    network::{StateSyncMessage, StateSyncSender},
+    executor_proxy::ExecutorProxy,
+    network::StateSyncMessage,
+    shared_components::test_utils,
 };
-use channel::{diem_channel, message_queues::QueueStyle};
 use diem_config::{
-    config::{PeerNetworkId, RoleType, StateSyncConfig, UpstreamConfig},
+    config::PeerNetworkId,
     network_id::{NetworkId, NodeNetworkId},
 };
 use diem_infallible::Mutex;
 use diem_types::{
-    ledger_info::LedgerInfoWithSignatures,
-    transaction::{Transaction, TransactionListWithProof, WriteSetPayload},
-    waypoint::Waypoint,
-    PeerId,
+    ledger_info::LedgerInfoWithSignatures, transaction::TransactionListWithProof, PeerId,
 };
-use diem_vm::DiemVM;
-use diemdb::DiemDB;
-use executor::Executor;
-use executor_test_helpers::bootstrap_genesis;
-use futures::{channel::mpsc, executor::block_on};
-use network::{
-    peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
-    protocols::network::NewNetworkSender,
-};
+use futures::executor::block_on;
 use once_cell::sync::Lazy;
 use proptest::{
     arbitrary::{any, Arbitrary},
@@ -36,61 +25,9 @@ use proptest::{
     prelude::*,
     strategy::Strategy,
 };
-use std::collections::HashMap;
-use storage_interface::DbReaderWriter;
 
-static STATE_SYNC_COORDINATOR: Lazy<Mutex<StateSyncCoordinator<ExecutorProxy>>> = Lazy::new(|| {
-    // Generate a genesis change set
-    let (genesis, _) = vm_genesis::test_genesis_change_set_and_validators(Some(1));
-
-    // Create test diem database
-    let db_path = diem_temppath::TempPath::new();
-    db_path.create_as_dir().unwrap();
-    let (db, db_rw) = DbReaderWriter::wrap(DiemDB::new_for_test(db_path.path()));
-
-    // Bootstrap the genesis transaction
-    let genesis_txn = Transaction::GenesisTransaction(WriteSetPayload::Direct(genesis));
-    bootstrap_genesis::<DiemVM>(&db_rw, &genesis_txn).unwrap();
-
-    // Create executor proxy
-    let chunk_executor = Box::new(Executor::<DiemVM>::new(db_rw));
-    let executor_proxy = ExecutorProxy::new(db, chunk_executor, vec![]);
-
-    // Get initial state
-    let initial_state = executor_proxy.get_local_storage_state().unwrap();
-
-    // Setup network senders
-    let (network_reqs_tx, _network_reqs_rx) = diem_channel::new(QueueStyle::FIFO, 8, None);
-    let (connection_reqs_tx, _) = diem_channel::new(QueueStyle::FIFO, 8, None);
-    let network_sender = StateSyncSender::new(
-        PeerManagerRequestSender::new(network_reqs_tx),
-        ConnectionRequestSender::new(connection_reqs_tx),
-    );
-    let node_network_id = NodeNetworkId::new(NetworkId::Validator, 0);
-    let network_senders = vec![(node_network_id, network_sender)]
-        .into_iter()
-        .collect::<HashMap<_, _>>();
-
-    // Create channel senders and receivers
-    let (_coordinator_sender, coordinator_receiver) = mpsc::unbounded();
-    let (mempool_sender, _mempool_receiver) = mpsc::channel(1);
-
-    // Start up coordinator
-    let coordinator = StateSyncCoordinator::new(
-        coordinator_receiver,
-        mempool_sender,
-        network_senders,
-        RoleType::Validator,
-        Waypoint::default(),
-        StateSyncConfig::default(),
-        UpstreamConfig::default(),
-        executor_proxy,
-        initial_state,
-    )
-    .unwrap();
-
-    Mutex::new(coordinator)
-});
+static STATE_SYNC_COORDINATOR: Lazy<Mutex<StateSyncCoordinator<ExecutorProxy>>> =
+    Lazy::new(|| Mutex::new(test_utils::create_state_sync_coordinator_for_tests()));
 
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(10))]

--- a/state-sync/src/lib.rs
+++ b/state-sync/src/lib.rs
@@ -17,6 +17,7 @@ pub mod executor_proxy;
 mod logging;
 pub mod network;
 mod request_manager;
+pub mod shared_components;
 
 #[cfg(any(feature = "fuzzing", test))]
 pub mod fuzzing;

--- a/state-sync/src/lib.rs
+++ b/state-sync/src/lib.rs
@@ -13,6 +13,7 @@ pub mod chunk_response;
 pub mod client;
 pub mod coordinator;
 mod counters;
+mod error;
 pub mod executor_proxy;
 mod logging;
 pub mod network;

--- a/state-sync/src/logging.rs
+++ b/state-sync/src/logging.rs
@@ -5,7 +5,6 @@ use crate::{
     chunk_request::GetChunkRequest, chunk_response::GetChunkResponse,
     request_manager::ChunkRequestInfo,
 };
-use anyhow::Error;
 use diem_config::config::PeerNetworkId;
 use diem_logger::Schema;
 use diem_types::{
@@ -18,7 +17,7 @@ pub struct LogSchema<'a> {
     name: LogEntry,
     event: Option<LogEvent>,
     #[schema(debug)]
-    error: Option<&'a Error>,
+    error: Option<&'a anyhow::Error>,
     #[schema(display)]
     peer: Option<&'a PeerNetworkId>,
     is_upstream_peer: Option<bool>,

--- a/state-sync/src/shared_components.rs
+++ b/state-sync/src/shared_components.rs
@@ -108,7 +108,7 @@ impl PendingLedgerInfos {
 /// Note: `committed_ledger_info` is used for helping other Diem nodes synchronize (i.e.,
 /// it corresponds to the highest version we have a proof for in storage). `synced_trees`
 /// is used locally for retrieving missing chunks for the local storage.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct SyncState {
     committed_ledger_info: LedgerInfoWithSignatures,
     synced_trees: ExecutedTrees,

--- a/state-sync/src/shared_components.rs
+++ b/state-sync/src/shared_components.rs
@@ -34,13 +34,13 @@ impl PendingLedgerInfos {
     }
 
     /// Adds `new_li` to the queue of pending LI's
-    pub(crate) fn add_li(&mut self, new_li: LedgerInfoWithSignatures) {
+    pub(crate) fn add_li(&mut self, new_ledger_info: LedgerInfoWithSignatures) {
         if self.pending_li_queue.len() >= self.max_pending_li_limit {
             warn!(
                 LogSchema::new(LogEntry::ProcessChunkResponse),
                 "pending LI store reached max capacity {}, failed to add LI {}",
                 self.max_pending_li_limit,
-                new_li
+                new_ledger_info
             );
             return;
         }
@@ -50,9 +50,9 @@ impl PendingLedgerInfos {
             .target_li
             .as_ref()
             .map_or(0, |li| li.ledger_info().version());
-        if new_li.ledger_info().version() > target_version {
-            self.pending_li_queue
-                .insert(new_li.ledger_info().version(), new_li);
+        let new_version = new_ledger_info.ledger_info().version();
+        if new_version > target_version {
+            self.pending_li_queue.insert(new_version, new_ledger_info);
         }
     }
 

--- a/state-sync/src/shared_components.rs
+++ b/state-sync/src/shared_components.rs
@@ -1,0 +1,241 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::logging::{LogEntry, LogSchema};
+use anyhow::{format_err, Result};
+use diem_logger::prelude::*;
+use diem_types::{
+    epoch_change::Verifier, epoch_state::EpochState, ledger_info::LedgerInfoWithSignatures,
+    transaction::Version,
+};
+use executor_types::ExecutedTrees;
+use std::{collections::BTreeMap, ops::Bound::Included};
+
+// DS to help sync requester to keep track of ledger infos in the future
+// if it is lagging far behind the upstream node
+// Should only be modified upon local storage sync
+pub(crate) struct PendingLedgerInfos {
+    // In-memory store of ledger infos that are pending commits
+    // (k, v) - (LI version, LI)
+    pending_li_queue: BTreeMap<Version, LedgerInfoWithSignatures>,
+    // max size limit on `pending_li_queue`, to prevent OOM
+    max_pending_li_limit: usize,
+    // target li
+    target_li: Option<LedgerInfoWithSignatures>,
+}
+
+impl PendingLedgerInfos {
+    pub(crate) fn new(max_pending_li_limit: usize) -> Self {
+        Self {
+            pending_li_queue: BTreeMap::new(),
+            max_pending_li_limit,
+            target_li: None,
+        }
+    }
+
+    /// Adds `new_li` to the queue of pending LI's
+    pub(crate) fn add_li(&mut self, new_li: LedgerInfoWithSignatures) {
+        if self.pending_li_queue.len() >= self.max_pending_li_limit {
+            warn!(
+                LogSchema::new(LogEntry::ProcessChunkResponse),
+                "pending LI store reached max capacity {}, failed to add LI {}",
+                self.max_pending_li_limit,
+                new_li
+            );
+            return;
+        }
+
+        // update pending_ledgers if new LI is ahead of target LI (in terms of version)
+        let target_version = self
+            .target_li
+            .as_ref()
+            .map_or(0, |li| li.ledger_info().version());
+        if new_li.ledger_info().version() > target_version {
+            self.pending_li_queue
+                .insert(new_li.ledger_info().version(), new_li);
+        }
+    }
+
+    pub(crate) fn update(&mut self, sync_state: &SyncState, chunk_limit: u64) -> Result<()> {
+        let highest_committed_li = sync_state.committed_version();
+        let highest_synced = sync_state.synced_version();
+
+        // prune any pending LIs that are older than the latest local synced version
+        let prune_version = highest_synced
+            .checked_add(1)
+            .ok_or_else(|| format_err!("Prune version has overflown!"))?;
+        self.pending_li_queue = self.pending_li_queue.split_off(&prune_version);
+
+        // pick target LI to use for sending ProgressiveTargetType requests.
+        self.target_li = if highest_committed_li == highest_synced {
+            // try to find LI with max version that will fit in a single chunk
+            let highest_version = highest_synced
+                .checked_add(chunk_limit)
+                .ok_or_else(|| format_err!("Highest version has overflown!"))?;
+            self.pending_li_queue
+                .range((Included(0), Included(highest_version)))
+                .rev()
+                .next()
+                .map(|(_version, ledger_info)| ledger_info.clone())
+        } else {
+            self.pending_li_queue
+                .iter()
+                .next()
+                .map(|(_version, ledger_info)| ledger_info.clone())
+        };
+        Ok(())
+    }
+
+    pub(crate) fn target_li(&self) -> Option<LedgerInfoWithSignatures> {
+        self.target_li.clone()
+    }
+
+    pub(crate) fn highest_version(&self) -> Option<Version> {
+        self.pending_li_queue.keys().last().cloned()
+    }
+}
+
+/// SyncState contains the following fields:
+/// * `committed_ledger_info` holds the latest certified ledger info (committed to storage),
+///    i.e., the ledger info for the highest version for which storage has all ledger state.
+/// * `synced_trees` holds the latest transaction accumulator and state tree (which may
+///    or may not be committed to storage), i.e., some ledger state for the next highest
+///    ledger info version is missing.
+/// * `trusted_epoch_state` corresponds to the current epoch if the highest committed
+///    ledger info (`committed_ledger_info`) is in the middle of the epoch, otherwise, it
+///    corresponds to the next epoch if the highest committed ledger info ends the epoch.
+///
+/// Note: `committed_ledger_info` is used for helping other Diem nodes synchronize (i.e.,
+/// it corresponds to the highest version we have a proof for in storage). `synced_trees`
+/// is used locally for retrieving missing chunks for the local storage.
+#[derive(Clone)]
+pub struct SyncState {
+    committed_ledger_info: LedgerInfoWithSignatures,
+    synced_trees: ExecutedTrees,
+    trusted_epoch_state: EpochState,
+}
+
+impl SyncState {
+    pub fn new(
+        committed_ledger_info: LedgerInfoWithSignatures,
+        synced_trees: ExecutedTrees,
+        current_epoch_state: EpochState,
+    ) -> Self {
+        let trusted_epoch_state = committed_ledger_info
+            .ledger_info()
+            .next_epoch_state()
+            .cloned()
+            .unwrap_or(current_epoch_state);
+
+        SyncState {
+            committed_ledger_info,
+            synced_trees,
+            trusted_epoch_state,
+        }
+    }
+
+    pub fn committed_epoch(&self) -> u64 {
+        self.committed_ledger_info.ledger_info().epoch()
+    }
+
+    pub fn committed_ledger_info(&self) -> LedgerInfoWithSignatures {
+        self.committed_ledger_info.clone()
+    }
+
+    pub fn committed_version(&self) -> u64 {
+        self.committed_ledger_info.ledger_info().version()
+    }
+
+    /// Returns the highest available version in the local storage, even if it's not
+    /// committed (i.e., covered by a ledger info).
+    pub fn synced_version(&self) -> u64 {
+        self.synced_trees.version().unwrap_or(0)
+    }
+
+    pub fn trusted_epoch(&self) -> u64 {
+        self.trusted_epoch_state.epoch
+    }
+
+    pub fn verify_ledger_info(&self, ledger_info: &LedgerInfoWithSignatures) -> Result<()> {
+        self.trusted_epoch_state.verify(ledger_info)
+    }
+}
+
+#[cfg(any(feature = "fuzzing", test))]
+pub(crate) mod test_utils {
+    use crate::{
+        coordinator::StateSyncCoordinator,
+        executor_proxy::{ExecutorProxy, ExecutorProxyTrait},
+        network::StateSyncSender,
+    };
+    use diem_types::waypoint::Waypoint;
+
+    use channel::{diem_channel, message_queues::QueueStyle};
+    use diem_config::{
+        config::{RoleType, StateSyncConfig, UpstreamConfig},
+        network_id::{NetworkId, NodeNetworkId},
+    };
+    use diem_types::transaction::{Transaction, WriteSetPayload};
+    use diem_vm::DiemVM;
+    use diemdb::DiemDB;
+    use executor::Executor;
+    use executor_test_helpers::bootstrap_genesis;
+    use futures::channel::mpsc;
+    use network::{
+        peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
+        protocols::network::NewNetworkSender,
+    };
+    use std::collections::HashMap;
+    use storage_interface::DbReaderWriter;
+
+    pub(crate) fn create_state_sync_coordinator_for_tests() -> StateSyncCoordinator<ExecutorProxy> {
+        // Generate a genesis change set
+        let (genesis, _) = vm_genesis::test_genesis_change_set_and_validators(Some(1));
+
+        // Create test diem database
+        let db_path = diem_temppath::TempPath::new();
+        db_path.create_as_dir().unwrap();
+        let (db, db_rw) = DbReaderWriter::wrap(DiemDB::new_for_test(db_path.path()));
+
+        // Bootstrap the genesis transaction
+        let genesis_txn = Transaction::GenesisTransaction(WriteSetPayload::Direct(genesis));
+        bootstrap_genesis::<DiemVM>(&db_rw, &genesis_txn).unwrap();
+
+        // Create executor proxy
+        let chunk_executor = Box::new(Executor::<DiemVM>::new(db_rw));
+        let executor_proxy = ExecutorProxy::new(db, chunk_executor, vec![]);
+
+        // Get initial state
+        let initial_state = executor_proxy.get_local_storage_state().unwrap();
+
+        // Setup network senders
+        let (network_reqs_tx, _network_reqs_rx) = diem_channel::new(QueueStyle::FIFO, 8, None);
+        let (connection_reqs_tx, _) = diem_channel::new(QueueStyle::FIFO, 8, None);
+        let network_sender = StateSyncSender::new(
+            PeerManagerRequestSender::new(network_reqs_tx),
+            ConnectionRequestSender::new(connection_reqs_tx),
+        );
+        let node_network_id = NodeNetworkId::new(NetworkId::Validator, 0);
+        let network_senders = vec![(node_network_id, network_sender)]
+            .into_iter()
+            .collect::<HashMap<_, _>>();
+
+        // Create channel senders and receivers
+        let (_coordinator_sender, coordinator_receiver) = mpsc::unbounded();
+        let (mempool_sender, _mempool_receiver) = mpsc::channel(1);
+
+        // Return the new state sync coordinator
+        StateSyncCoordinator::new(
+            coordinator_receiver,
+            mempool_sender,
+            network_senders,
+            RoleType::Validator,
+            Waypoint::default(),
+            StateSyncConfig::default(),
+            UpstreamConfig::default(),
+            executor_proxy,
+            initial_state,
+        )
+        .unwrap()
+    }
+}

--- a/state-sync/tests/test_harness.rs
+++ b/state-sync/tests/test_harness.rs
@@ -60,9 +60,9 @@ use rand::{rngs::StdRng, SeedableRng};
 use state_sync::{
     bootstrapper::StateSyncBootstrapper,
     client::StateSyncClient,
-    coordinator::SyncState,
     executor_proxy::ExecutorProxyTrait,
     network::{StateSyncEvents, StateSyncSender},
+    shared_components::SyncState,
 };
 use std::{
     cell::{Ref, RefCell},


### PR DESCRIPTION
## Motivation

This PR begins adding unit tests to StateSyncCoordinator. In addition, it also begins to move state sync away from anyhow errors into explicit error types (which will not only improve testing and error handling, but also observability and reduce code).

This PR offers the following commits:
1. Create a unit tests module for StateSyncCoordinator and move shared logic into a shared components file.
2. Clean up process_state_sync_request and add better error handling, as well as a unit test structure.
3. Clean up get_sync_state and add better error handling, as well as a unit test structure.
4. Clean up wait_for_initialization and add better error handling, as well as a unit test structure.
5. Clean up process_commit_notification and add better error handling, as well as a unit test structure.

Notes:
1. We'll still need to follow this process for 4 more message types: (i) new peer; (ii) lost peer; (iii) chunk requests; and (iv) chunk responses. We stopped here to prevent this PR from getting too large.
2 The benefits of this PR are that we'll start moving towards a model that will allow us to: (i) split up the state sync core logic from the message handling logic; (ii) clean up/remove the various e2e tests by providing more unit test coverage; (iii) test properties that we cannot currently test (e.g., that state sync and consensus shouldn't write to storage concurrently); and (iv) offer cleaner, simpler code and better observability.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally, including the newly added ones.

## Related PRs

This relates to: https://github.com/diem/diem/issues/6795