### PR TITLE
[move-prover] Added some "emits" specs to the Diem Framework

### DIFF
--- a/language/stdlib/modules/AccountFreezing.move
+++ b/language/stdlib/modules/AccountFreezing.move
@@ -107,6 +107,17 @@ module AccountFreezing {
         aborts_if frozen_address == CoreAddresses::TREASURY_COMPLIANCE_ADDRESS() with Errors::INVALID_ARGUMENT;
         aborts_if !exists<FreezingBit>(frozen_address) with Errors::NOT_PUBLISHED;
         ensures spec_account_is_frozen(frozen_address);
+        include FreezeAccountEmits;
+    }
+    spec schema FreezeAccountEmits {
+        account: &signer;
+        frozen_address: address;
+        let handle = global<FreezeEventsHolder>(CoreAddresses::DIEM_ROOT_ADDRESS()).freeze_event_handle;
+        let msg = FreezeAccountEvent {
+            initiator_address: Signer::spec_address_of(account),
+            frozen_address
+        };
+        emits msg to handle;
     }
 
     /// Unfreeze the account at `addr`.
@@ -133,6 +144,17 @@ module AccountFreezing {
         include Roles::AbortsIfNotTreasuryCompliance;
         aborts_if !exists<FreezingBit>(unfrozen_address) with Errors::NOT_PUBLISHED;
         ensures !spec_account_is_frozen(unfrozen_address);
+        include UnfreezeAccountEmits;
+    }
+    spec schema UnfreezeAccountEmits {
+        account: &signer;
+        unfrozen_address: address;
+        let handle = global<FreezeEventsHolder>(CoreAddresses::DIEM_ROOT_ADDRESS()).unfreeze_event_handle;
+        let msg = UnfreezeAccountEvent {
+            initiator_address: Signer::spec_address_of(account),
+            unfrozen_address
+        };
+        emits msg to handle;
     }
 
     /// Returns if the account at `addr` is frozen.

--- a/language/stdlib/modules/DiemBlock.move
+++ b/language/stdlib/modules/DiemBlock.move
@@ -100,6 +100,21 @@ module DiemBlock {
 
         /// The below counter overflow is assumed to be excluded from verification of callers.
         aborts_if [assume] get_current_block_height() + 1 > MAX_U64 with EXECUTION_FAILURE;
+        include BlockPrologueEmits;
+    }
+    spec schema BlockPrologueEmits {
+        round: u64;
+        timestamp: u64;
+        previous_block_votes: vector<address>;
+        proposer: address;
+        let handle = global<BlockMetadata>(CoreAddresses::DIEM_ROOT_ADDRESS()).new_block_events;
+        let msg = NewBlockEvent {
+            round,
+            proposer,
+            previous_block_votes,
+            time_microseconds: timestamp,
+        };
+        emits msg to handle;
     }
 
     /// Get the current block height

--- a/language/stdlib/modules/DiemConfig.move
+++ b/language/stdlib/modules/DiemConfig.move
@@ -380,6 +380,14 @@ module DiemConfig {
             },
         );
     }
+    spec fun emit_genesis_reconfiguration_event {
+        let config = global<Configuration>(CoreAddresses::DIEM_ROOT_ADDRESS());
+        let handle = config.events;
+        let msg = NewEpochEvent {
+                epoch: config.epoch,
+        };
+        emits msg to handle;
+    }
 
     // =================================================================
     // Module Specification

--- a/language/stdlib/modules/DualAttestation.move
+++ b/language/stdlib/modules/DualAttestation.move
@@ -137,6 +137,7 @@ module DualAttestation {
     spec fun rotate_base_url {
         include RotateBaseUrlAbortsIf;
         include RotateBaseUrlEnsures;
+        include RotateBaseUrlEmits;
     }
     spec schema RotateBaseUrlAbortsIf {
         account: signer;
@@ -161,6 +162,17 @@ module DualAttestation {
         ensures forall addr1:address where addr1 != sender:
             global<Credential>(addr1).base_url == old(global<Credential>(addr1).base_url);
     }
+    spec schema RotateBaseUrlEmits {
+        account: signer;
+        new_url: vector<u8>;
+        let sender = Signer::spec_address_of(account);
+        let handle = global<Credential>(sender).base_url_rotation_events;
+        let msg = BaseUrlRotationEvent {
+            new_base_url: new_url,
+            time_rotated_seconds: DiemTimestamp::spec_now_seconds(),
+        };
+        emits msg to handle;
+    }
 
     /// Rotate the compliance public key for `account` to `new_key`.
     public fun rotate_compliance_public_key(
@@ -181,6 +193,7 @@ module DualAttestation {
     spec fun rotate_compliance_public_key {
         include RotateCompliancePublicKeyAbortsIf;
         include RotateCompliancePublicKeyEnsures;
+        include RotateCompliancePublicKeyEmits;
     }
     spec schema RotateCompliancePublicKeyAbortsIf {
         account: signer;
@@ -202,6 +215,17 @@ module DualAttestation {
         /// The sender only rotates its own compliance_public_key [[H16]][PERMISSION].
         ensures forall addr1: address where addr1 != sender:
             global<Credential>(addr1).compliance_public_key == old(global<Credential>(addr1).compliance_public_key);
+    }
+    spec schema RotateCompliancePublicKeyEmits {
+        account: signer;
+        new_key: vector<u8>;
+        let sender = Signer::spec_address_of(account);
+        let handle = global<Credential>(sender).compliance_key_rotation_events;
+        let msg = ComplianceKeyRotationEvent {
+            new_compliance_public_key: new_key,
+            time_rotated_seconds: DiemTimestamp::spec_now_seconds(),
+        };
+        emits msg to handle;
     }
 
     /// Return the human-readable name for the VASP account.

--- a/language/stdlib/modules/Roles.move
+++ b/language/stdlib/modules/Roles.move
@@ -472,8 +472,7 @@ module Roles {
     /// # Helper Functions and Schemas
 
     spec module {
-        define spec_get_role_id(account: signer): u64 {
-            let addr = Signer::spec_address_of(account);
+        define spec_get_role_id(addr: address): u64 {
             global<RoleId>(addr).role_id
         }
 


### PR DESCRIPTION
This PR adds the emits spec for the following functions which "directly" emit events (i.e., call `Event::emit_event`):
- AccountFreezing::freeze_account
- AccountFreezing::unfreeze_account
- DualAttestation::rotate_compliance_public_key
- DualAttestation::rotate_base_url
- DiemAccount::withdraw_from
- DiemAccount::deposit
- DiemAccount::writeset_epilogue
- DiemAccount::make_account
- DiemBlock::block_prologue
- Diem::preburn_with_resource
- Diem::burn_with_resource_cap
- Diem::cancel_burn_with_capability
- DiemConfig::emit_genesis_reconfiguration_event

The following functions were specified in the previous PR:
- Diem::mint_with_capability
- Diem::update_xdx_exchange_rate

TODO: The following functions will be specified in an other PR later.
- DesignatedDealer::tiered_mint (calling an opaque function that emits another event)
- DiemConfig::reconfigure_ (having a too complex condition)

TODO: Specify the transaction scripts, and improve the method for checking "emits" spec (e.g, supporting the strictness checking, handling opaque function).

## Motivation

To specify and verify the event-emitting behavior of the Diem Framework

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test
