### PR TITLE
[json-rpc-client] retry submit api call errors

### DIFF
--- a/client/json-rpc/src/async_client/client.rs
+++ b/client/json-rpc/src/async_client/client.rs
@@ -207,8 +207,8 @@ impl<R: RetryStrategy> Client<R> {
     }
 
     pub async fn submit(&self, txn: &SignedTransaction) -> Result<Response<()>, Error> {
-        let req = Request::submit(txn).map_err(Error::unexpected_bcs_error)?;
-        let resp = self.http_client.single_request(&req).await?;
+        let request = Request::submit(txn).map_err(Error::unexpected_bcs_error)?;
+        let resp = self.send_with_retry(&request, &self.retry).await?;
         Ok(Response {
             result: (),
             state: State::from_response(&resp),


### PR DESCRIPTION
## Motivation

We should retry submit API call to make client more reliable after we fixed #7169

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Unit tests

## Related PRs

#7174

