### PR TITLE
[move][vm] Remove resource specialization in VM values

### DIFF
--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -97,7 +97,7 @@ fn mock_db() -> MockDiemDB {
         // Record all account states.
         for (address, blob) in account_states.into_iter() {
             let mut state = AccountState::try_from(&blob).unwrap();
-            let freezing_bit = Value::struct_(Struct::pack(vec![Value::bool(false)], true))
+            let freezing_bit = Value::struct_(Struct::pack(vec![Value::bool(false)]))
                 .value_as::<Struct>()
                 .unwrap()
                 .simple_serialize(&MoveStructLayout::new(vec![MoveTypeLayout::Bool]))

--- a/language/move-core/types/src/value.rs
+++ b/language/move-core/types/src/value.rs
@@ -40,59 +40,6 @@ pub enum MoveTypeLayout {
     Signer,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub enum MoveKind {
-    Copyable,
-    Resource,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum MoveKindInfo {
-    Base(MoveKind),
-    Vector(MoveKind, Box<MoveKindInfo>),
-    Struct(MoveKind, Vec<MoveKindInfo>),
-}
-
-impl MoveKind {
-    pub fn is_resource(&self) -> bool {
-        match self {
-            Self::Resource => true,
-            Self::Copyable => false,
-        }
-    }
-
-    pub fn is_copyable(&self) -> bool {
-        match self {
-            Self::Resource => false,
-            Self::Copyable => true,
-        }
-    }
-
-    pub fn from_bool(is_resource: bool) -> Self {
-        if is_resource {
-            Self::Resource
-        } else {
-            Self::Copyable
-        }
-    }
-}
-
-impl MoveKindInfo {
-    pub fn is_resource(&self) -> bool {
-        self.kind().is_resource()
-    }
-
-    pub fn is_copyable(&self) -> bool {
-        self.kind().is_copyable()
-    }
-
-    pub fn kind(&self) -> MoveKind {
-        match self {
-            Self::Base(k) | Self::Vector(k, _) | Self::Struct(k, _) => *k,
-        }
-    }
-}
-
 impl MoveValue {
     pub fn simple_deserialize(blob: &[u8], ty: &MoveTypeLayout) -> AResult<Self> {
         Ok(bcs::from_bytes_seed(ty, blob)?)

--- a/language/move-vm/runtime/src/data_cache.rs
+++ b/language/move-vm/runtime/src/data_cache.rs
@@ -208,8 +208,7 @@ impl<'r, 'l, C: RemoteCache> DataStore for TransactionDataCache<'r, 'l, C> {
 
             let gv = match self.remote.get_resource(&addr, &ty_tag) {
                 Ok(Some(blob)) => {
-                    let ty_kind_info = self.loader.type_to_kind_info(ty)?;
-                    let val = match Value::simple_deserialize(&blob, &ty_kind_info, &ty_layout) {
+                    let val = match Value::simple_deserialize(&blob, &ty_layout) {
                         Some(val) => val,
                         None => {
                             let msg =

--- a/language/move-vm/runtime/src/native_functions.rs
+++ b/language/move-vm/runtime/src/native_functions.rs
@@ -170,8 +170,4 @@ impl<'a, L: LogContext> NativeContext for FunctionContext<'a, L> {
             Err(_) => Ok(None),
         }
     }
-
-    fn is_resource(&self, ty: &Type) -> bool {
-        self.resolver.is_resource(ty)
-    }
 }

--- a/language/move-vm/types/src/natives/function.rs
+++ b/language/move-vm/types/src/natives/function.rs
@@ -48,8 +48,6 @@ pub trait NativeContext {
     ) -> PartialVMResult<bool>;
     /// Get the a data layout via the type.
     fn type_to_type_layout(&self, ty: &Type) -> PartialVMResult<Option<MoveTypeLayout>>;
-    /// Whether a type is a resource or not.
-    fn is_resource(&self, ty: &Type) -> bool;
 }
 
 /// Result of a native function execution requires charges for execution cost.

--- a/language/move-vm/types/src/values/value_prop_tests.rs
+++ b/language/move-vm/types/src/values/value_prop_tests.rs
@@ -1,15 +1,15 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::values::{prop::layout_kinfo_and_value_strategy, Value};
+use crate::values::{prop::layout_and_value_strategy, Value};
 use move_core_types::value::MoveValue;
 use proptest::prelude::*;
 
 proptest! {
     #[test]
-    fn serializer_round_trip((layout, kinfo, value) in layout_kinfo_and_value_strategy()) {
+    fn serializer_round_trip((layout, value) in layout_and_value_strategy()) {
         let blob = value.simple_serialize(&layout).expect("must serialize");
-        let value_deserialized = Value::simple_deserialize(&blob, &kinfo, &layout).expect("must deserialize");
+        let value_deserialized = Value::simple_deserialize(&blob, &layout).expect("must deserialize");
         assert!(value.equals(&value_deserialized).unwrap());
 
         let move_value = value.as_move_value(&layout);

--- a/language/testing-infra/e2e-tests/src/account.rs
+++ b/language/testing-infra/e2e-tests/src/account.rs
@@ -321,7 +321,7 @@ impl Balance {
 
     /// Returns the Move Value for the account balance
     pub fn to_value(&self) -> Value {
-        Value::struct_(Struct::pack(vec![Value::u64(self.coin)], true))
+        Value::struct_(Struct::pack(vec![Value::u64(self.coin)]))
     }
 
     /// Returns the value layout for the account balance
@@ -363,7 +363,7 @@ impl AccountRoleSpecifier {
     }
 
     pub fn to_value(&self) -> Value {
-        Value::struct_(Struct::pack(vec![Value::u64(self.id())], true))
+        Value::struct_(Struct::pack(vec![Value::u64(self.id())]))
     }
 
     pub fn role_id_struct_tag() -> StructTag {
@@ -445,10 +445,10 @@ impl EventHandleGenerator {
     }
 
     pub fn to_value(&self) -> Value {
-        Value::struct_(Struct::pack(
-            vec![Value::u64(self.counter), Value::address(self.addr)],
-            true,
-        ))
+        Value::struct_(Struct::pack(vec![
+            Value::u64(self.counter),
+            Value::address(self.addr),
+        ]))
     }
     pub fn layout() -> MoveStructLayout {
         MoveStructLayout::new(vec![MoveTypeLayout::U64, MoveTypeLayout::Address])
@@ -630,30 +630,21 @@ impl AccountData {
             .collect();
         let event_generator = self.event_generator.to_value();
         let role_id = self.account_role.account_specifier.to_value();
-        let account = Value::struct_(Struct::pack(
-            vec![
-                // TODO: this needs to compute the auth key instead
-                Value::vector_u8(AuthenticationKey::ed25519(&self.account.pubkey).to_vec()),
-                self.withdrawal_capability.as_ref().unwrap().value(),
-                self.key_rotation_capability.as_ref().unwrap().value(),
-                Value::struct_(Struct::pack(
-                    vec![
-                        Value::u64(self.received_events.count()),
-                        Value::vector_u8(self.received_events.key().to_vec()),
-                    ],
-                    true,
-                )),
-                Value::struct_(Struct::pack(
-                    vec![
-                        Value::u64(self.sent_events.count()),
-                        Value::vector_u8(self.sent_events.key().to_vec()),
-                    ],
-                    true,
-                )),
-                Value::u64(self.sequence_number),
-            ],
-            true,
-        ));
+        let account = Value::struct_(Struct::pack(vec![
+            // TODO: this needs to compute the auth key instead
+            Value::vector_u8(AuthenticationKey::ed25519(&self.account.pubkey).to_vec()),
+            self.withdrawal_capability.as_ref().unwrap().value(),
+            self.key_rotation_capability.as_ref().unwrap().value(),
+            Value::struct_(Struct::pack(vec![
+                Value::u64(self.received_events.count()),
+                Value::vector_u8(self.received_events.key().to_vec()),
+            ])),
+            Value::struct_(Struct::pack(vec![
+                Value::u64(self.sent_events.count()),
+                Value::vector_u8(self.sent_events.key().to_vec()),
+            ])),
+            Value::u64(self.sequence_number),
+        ]));
         (account, balances, event_generator, role_id)
     }
 
@@ -795,10 +786,9 @@ impl WithdrawCapability {
     }
 
     pub fn value(&self) -> Value {
-        Value::vector_resource_for_testing_only(vec![Value::struct_(Struct::pack(
-            vec![Value::address(self.account_address)],
-            true,
-        ))])
+        Value::vector_for_testing_only(vec![Value::struct_(Struct::pack(vec![Value::address(
+            self.account_address,
+        )]))])
     }
 }
 
@@ -816,10 +806,9 @@ impl KeyRotationCapability {
     }
 
     pub fn value(&self) -> Value {
-        Value::vector_resource_for_testing_only(vec![Value::struct_(Struct::pack(
-            vec![Value::address(self.account_address)],
-            true,
-        ))])
+        Value::vector_for_testing_only(vec![Value::struct_(Struct::pack(vec![Value::address(
+            self.account_address,
+        )]))])
     }
 }
 
@@ -834,6 +823,6 @@ impl FreezingBit {
     }
 
     pub fn value() -> Value {
-        Value::struct_(Struct::pack(vec![Value::bool(false)], true))
+        Value::struct_(Struct::pack(vec![Value::bool(false)]))
     }
 }

--- a/language/tools/move-cli/tests/testsuite/diem_smoke/args.exp
+++ b/language/tools/move-cli/tests/testsuite/diem_smoke/args.exp
@@ -1,8 +1,8 @@
 Command `run genesis.move --mode diem --signers 0xA550C18 0xB1E55ED -v`:
 Compiling transaction script...
 Emitted 2 events:
-Emitted Value(Container(StructC(RefCell { value: [Address(0000000000000000000000000A550C18), U64(0)] }))) as the 0th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
-Emitted Value(Container(StructC(RefCell { value: [Address(0000000000000000000000000B1E55ED), U64(1)] }))) as the 1th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
+Emitted Value(Container(Struct(RefCell { value: [Address(0000000000000000000000000A550C18), U64(0)] }))) as the 0th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
+Emitted Value(Container(Struct(RefCell { value: [Address(0000000000000000000000000B1E55ED), U64(1)] }))) as the 1th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
 Changed resource(s) under 2 address(es):
   Changed 28 resource(s) under address 0000000000000000000000000A550C18:
     Added type 0x1::DiemTimestamp::CurrentTimeMicroseconds: [U64(0)]
@@ -45,7 +45,7 @@ Changed resource(s) under 2 address(es):
 Command `run ../../../../../stdlib/transaction_scripts/create_designated_dealer.move --mode diem --type-args 0x1::XDX::XDX --signers 0xB1E55ED --args 0 0xDD x"00000000000000000000000000000000" b"DD" true -v`:
 Compiling transaction script...
 Emitted 1 events:
-Emitted Value(Container(StructC(RefCell { value: [Address(000000000000000000000000000000DD), U64(2)] }))) as the 2th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
+Emitted Value(Container(Struct(RefCell { value: [Address(000000000000000000000000000000DD), U64(2)] }))) as the 2th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
 Changed resource(s) under 2 address(es):
   Changed 10 resource(s) under address 000000000000000000000000000000DD:
     Added type 0x1::Event::EventHandleGenerator: [U64(5), Address(dd)]
@@ -63,7 +63,7 @@ Changed resource(s) under 2 address(es):
 Command `run ../../../../../stdlib/transaction_scripts/create_parent_vasp_account.move --mode diem --type-args 0x1::XDX::XDX --signers 0xB1E55ED --args 0 0xA x"00000000000000000000000000000000" b"VASP_A" true -v`:
 Compiling transaction script...
 Emitted 1 events:
-Emitted Value(Container(StructC(RefCell { value: [Address(0000000000000000000000000000000A), U64(5)] }))) as the 3th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
+Emitted Value(Container(Struct(RefCell { value: [Address(0000000000000000000000000000000A), U64(5)] }))) as the 3th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
 Changed resource(s) under 2 address(es):
   Changed 8 resource(s) under address 0000000000000000000000000000000A:
     Added type 0x1::Event::EventHandleGenerator: [U64(4), Address(a)]
@@ -79,7 +79,7 @@ Changed resource(s) under 2 address(es):
 Command `run ../../../../../stdlib/transaction_scripts/create_parent_vasp_account.move --mode diem --type-args 0x1::XDX::XDX --signers 0xB1E55ED --args 0 0xB x"00000000000000000000000000000000" b"VASP_B" true -v`:
 Compiling transaction script...
 Emitted 1 events:
-Emitted Value(Container(StructC(RefCell { value: [Address(0000000000000000000000000000000B), U64(5)] }))) as the 4th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
+Emitted Value(Container(Struct(RefCell { value: [Address(0000000000000000000000000000000B), U64(5)] }))) as the 4th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
 Changed resource(s) under 2 address(es):
   Changed 8 resource(s) under address 0000000000000000000000000000000B:
     Added type 0x1::Event::EventHandleGenerator: [U64(4), Address(b)]
@@ -95,9 +95,9 @@ Changed resource(s) under 2 address(es):
 Command `run ../../../../../stdlib/transaction_scripts/tiered_mint.move --mode diem --type-args 0x1::XUS::XUS --signers 0xB1E55ED --args 0 0xDD 1000 0 -v`:
 Compiling transaction script...
 Emitted 3 events:
-Emitted Value(Container(StructC(RefCell { value: [Container(VecU8(RefCell { value: [88, 85, 83] })), Address(000000000000000000000000000000DD), U64(1000)] }))) as the 0th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]
-Emitted Value(Container(StructC(RefCell { value: [U64(1000), Container(VecU8(RefCell { value: [88, 85, 83] }))] }))) as the 0th event to stream [5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
-Emitted Value(Container(StructC(RefCell { value: [U64(1000), Container(VecU8(RefCell { value: [88, 85, 83] })), Address(00000000000000000000000000000000), Container(VecU8(RefCell { value: [] }))] }))) as the 0th event to stream [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]
+Emitted Value(Container(Struct(RefCell { value: [Container(VecU8(RefCell { value: [88, 85, 83] })), Address(000000000000000000000000000000DD), U64(1000)] }))) as the 0th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]
+Emitted Value(Container(Struct(RefCell { value: [U64(1000), Container(VecU8(RefCell { value: [88, 85, 83] }))] }))) as the 0th event to stream [5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
+Emitted Value(Container(Struct(RefCell { value: [U64(1000), Container(VecU8(RefCell { value: [88, 85, 83] })), Address(00000000000000000000000000000000), Container(VecU8(RefCell { value: [] }))] }))) as the 0th event to stream [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]
 Changed resource(s) under 2 address(es):
   Changed 4 resource(s) under address 000000000000000000000000000000DD:
     Changed type 0x1::DesignatedDealer::Dealer: [[U64(1), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]]]
@@ -109,8 +109,8 @@ Changed resource(s) under 2 address(es):
 Command `run ../../../../../stdlib/transaction_scripts/peer_to_peer_with_metadata.move --mode diem --type-args 0x1::XUS::XUS --signers 0xDD --args 0xA 700 x"" x"" -v`:
 Compiling transaction script...
 Emitted 2 events:
-Emitted Value(Container(StructC(RefCell { value: [U64(700), Container(VecU8(RefCell { value: [88, 85, 83] })), Address(0000000000000000000000000000000A), Container(VecU8(RefCell { value: [] }))] }))) as the 0th event to stream [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]
-Emitted Value(Container(StructC(RefCell { value: [U64(700), Container(VecU8(RefCell { value: [88, 85, 83] })), Address(000000000000000000000000000000DD), Container(VecU8(RefCell { value: [] }))] }))) as the 0th event to stream [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
+Emitted Value(Container(Struct(RefCell { value: [U64(700), Container(VecU8(RefCell { value: [88, 85, 83] })), Address(0000000000000000000000000000000A), Container(VecU8(RefCell { value: [] }))] }))) as the 0th event to stream [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]
+Emitted Value(Container(Struct(RefCell { value: [U64(700), Container(VecU8(RefCell { value: [88, 85, 83] })), Address(000000000000000000000000000000DD), Container(VecU8(RefCell { value: [] }))] }))) as the 0th event to stream [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
 Changed resource(s) under 2 address(es):
   Changed 2 resource(s) under address 0000000000000000000000000000000A:
     Changed type 0x1::DiemAccount::DiemAccount: [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10], [[[Address(a)]]], [[[Address(a)]]], [U64(1), [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]], [U64(0), [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]], U64(0)]
@@ -121,8 +121,8 @@ Changed resource(s) under 2 address(es):
 Command `run ../../../../../stdlib/transaction_scripts/peer_to_peer_with_metadata.move --mode diem --type-args 0x1::XUS::XUS --signers 0xA --args 0xB 500 x"" x"" -v`:
 Compiling transaction script...
 Emitted 2 events:
-Emitted Value(Container(StructC(RefCell { value: [U64(500), Container(VecU8(RefCell { value: [88, 85, 83] })), Address(0000000000000000000000000000000B), Container(VecU8(RefCell { value: [] }))] }))) as the 0th event to stream [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
-Emitted Value(Container(StructC(RefCell { value: [U64(500), Container(VecU8(RefCell { value: [88, 85, 83] })), Address(0000000000000000000000000000000A), Container(VecU8(RefCell { value: [] }))] }))) as the 0th event to stream [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11]
+Emitted Value(Container(Struct(RefCell { value: [U64(500), Container(VecU8(RefCell { value: [88, 85, 83] })), Address(0000000000000000000000000000000B), Container(VecU8(RefCell { value: [] }))] }))) as the 0th event to stream [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
+Emitted Value(Container(Struct(RefCell { value: [U64(500), Container(VecU8(RefCell { value: [88, 85, 83] })), Address(0000000000000000000000000000000A), Container(VecU8(RefCell { value: [] }))] }))) as the 0th event to stream [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11]
 Changed resource(s) under 2 address(es):
   Changed 2 resource(s) under address 0000000000000000000000000000000A:
     Changed type 0x1::DiemAccount::DiemAccount: [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10], [[[Address(a)]]], [[[Address(a)]]], [U64(1), [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]], [U64(1), [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]], U64(0)]

--- a/language/tools/move-cli/tests/testsuite/events_emit_view/args.exp
+++ b/language/tools/move-cli/tests/testsuite/events_emit_view/args.exp
@@ -5,7 +5,7 @@ Publishing a new module 00000000000000000000000000000002::Events
 Command `run src/scripts/emit.move --signers 0xA --args 5 -v`:
 Compiling transaction script...
 Emitted 1 events:
-Emitted Value(Container(StructC(RefCell { value: [U64(5)] }))) as the 0th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
+Emitted Value(Container(Struct(RefCell { value: [U64(5)] }))) as the 0th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
 Changed resource(s) under 1 address(es):
   Changed 2 resource(s) under address 0000000000000000000000000000000A:
     Added type 0x1::Event::EventHandleGenerator: [U64(1), Address(a)]
@@ -17,7 +17,7 @@ Command `view storage/0x0000000000000000000000000000000A/events/0.bcs`:
 Command `run src/scripts/emit.move --signers 0xA --args 6 -v`:
 Compiling transaction script...
 Emitted 1 events:
-Emitted Value(Container(StructC(RefCell { value: [U64(6)] }))) as the 1th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
+Emitted Value(Container(Struct(RefCell { value: [U64(6)] }))) as the 1th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
 Changed resource(s) under 1 address(es):
   Changed 1 resource(s) under address 0000000000000000000000000000000A:
     Changed type 0x2::Events::Handle: [[U64(2), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]]]

--- a/testsuite/diem-fuzzer/src/fuzz_targets/move_vm.rs
+++ b/testsuite/diem-fuzzer/src/fuzz_targets/move_vm.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::FuzzTargetImpl;
-use anyhow::{bail, format_err, Result};
+use anyhow::{bail, Result};
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use diem_proptest_helpers::ValueGenerator;
-use move_core_types::value::{MoveKindInfo, MoveTypeLayout};
-use move_vm_types::values::{prop::layout_kinfo_and_value_strategy, Value};
+use move_core_types::value::MoveTypeLayout;
+use move_vm_types::values::{prop::layout_and_value_strategy, Value};
 use std::io::Cursor;
 
 #[derive(Clone, Debug, Default)]
@@ -18,22 +18,18 @@ impl FuzzTargetImpl for ValueTarget {
     }
 
     fn generate(&self, _idx: usize, gen: &mut ValueGenerator) -> Option<Vec<u8>> {
-        let (layout, kinfo, value) = gen.generate(layout_kinfo_and_value_strategy());
+        let (layout, value) = gen.generate(layout_and_value_strategy());
 
         // Values as currently serialized are not self-describing, so store a serialized form of the
         // layout + kind info along with the value as well.
         let layout_blob = bcs::to_bytes(&layout).unwrap();
-        let kinfo_blob = bcs::to_bytes(&kinfo).unwrap();
         let value_blob = value.simple_serialize(&layout).expect("must serialize");
 
         let mut blob = vec![];
         // Prefix the layout blob with its length.
         blob.write_u64::<BigEndian>(layout_blob.len() as u64)
             .expect("writing should work");
-        blob.write_u64::<BigEndian>(kinfo_blob.len() as u64)
-            .expect("writing should work");
         blob.extend_from_slice(&layout_blob);
-        blob.extend_from_slice(&kinfo_blob);
         blob.extend_from_slice(&value_blob);
         Some(blob)
     }
@@ -60,36 +56,20 @@ fn is_valid_layout(layout: &MoveTypeLayout) -> bool {
     }
 }
 
-fn is_valid_kinfo(kinfo: &MoveKindInfo) -> bool {
-    use MoveKindInfo as K;
-
-    match kinfo {
-        K::Base(_) => true,
-        K::Vector(_, inner) => is_valid_kinfo(inner),
-        K::Struct(_, field_info) => !field_info.is_empty() && field_info.iter().all(is_valid_kinfo),
-    }
-}
-
 fn deserialize(data: &[u8]) -> Result<()> {
     let mut data = Cursor::new(data);
     // Read the length of the layout blob.
     let layout_len = data.read_u64::<BigEndian>()? as usize;
-    let kinfo_len = data.read_u64::<BigEndian>()? as usize;
     let position = data.position() as usize;
     let data = &data.into_inner()[position..];
 
-    let n = layout_len
-        .checked_add(kinfo_len)
-        .ok_or_else(|| format_err!("bad sizes"))?;
-    if data.len() < n {
+    if data.len() < layout_len {
         bail!("too little data");
     }
     let layout_data = &data[..layout_len];
-    let kinfo_data = &data[layout_len..n];
-    let value_data = &data[n..];
+    let value_data = &data[layout_len..];
 
     let layout: MoveTypeLayout = bcs::from_bytes(layout_data)?;
-    let kinfo: MoveKindInfo = bcs::from_bytes(kinfo_data)?;
 
     // The fuzzer may alter the raw bytes, resulting in invalid layouts that will not
     // pass the bytecode verifier. We need to filter these out as they can show up as
@@ -98,10 +78,6 @@ fn deserialize(data: &[u8]) -> Result<()> {
         bail!("bad layout")
     }
 
-    if !is_valid_kinfo(&kinfo) {
-        bail!("bad kinfo")
-    }
-
-    let _ = Value::simple_deserialize(value_data, &kinfo, &layout);
+    let _ = Value::simple_deserialize(value_data, &layout);
     Ok(())
 }


### PR DESCRIPTION
- Remove resource variants for structs and vectors in VM values to make way for ability/constraint system
- Cleaned up related code

## Motivation

- While having low cost, additional levels of safety for resources is nice, it is not really feasible in the new constraint+ability system
- This cleanup is to make that PR easier

## Test Plan

- cargo test

## Related PRs

#7376 