### PR TITLE
[move source language] Fix arity bug in pack/unpack

### DIFF
--- a/language/move-lang/tests/move_check/typing/bad_type_argument_arity_struct_pack.exp
+++ b/language/move-lang/tests/move_check/typing/bad_type_argument_arity_struct_pack.exp
@@ -1,0 +1,30 @@
+error: 
+
+   ┌── tests/move_check/typing/bad_type_argument_arity_struct_pack.move:7:9 ───
+   │
+ 7 │         S<> { f: 0 };
+   │         ^^^^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/bad_type_argument_arity_struct_pack.move:7:9 ───
+   │
+ 7 │         S<> { f: 0 };
+   │         ^^^^^^^^^^^^ Cannot ignore resource values. The value must be used
+   ·
+ 7 │         S<> { f: 0 };
+   │         ------------ The type: '0x42::M::S<_>'
+   ·
+ 4 │     struct S<T> { f: T }
+   │              - Is found to be a non-copyable type here
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/bad_type_argument_arity_struct_pack.move:8:9 ───
+   │
+ 8 │         S<u64, u64> { f: 0 };
+   │         ^^^^^^^^^^^^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 2
+   │
+

--- a/language/move-lang/tests/move_check/typing/bad_type_argument_arity_struct_pack.move
+++ b/language/move-lang/tests/move_check/typing/bad_type_argument_arity_struct_pack.move
@@ -1,0 +1,12 @@
+address 0x42 {
+module M {
+
+    struct S<T> { f: T }
+
+    fun ex() {
+        S<> { f: 0 };
+        S<u64, u64> { f: 0 };
+    }
+}
+
+}

--- a/language/move-lang/tests/move_check/typing/bad_type_argument_arity_struct_unpack.exp
+++ b/language/move-lang/tests/move_check/typing/bad_type_argument_arity_struct_unpack.exp
@@ -1,0 +1,16 @@
+error: 
+
+   ┌── tests/move_check/typing/bad_type_argument_arity_struct_unpack.move:7:13 ───
+   │
+ 7 │         let S<> { f } = copy s;
+   │             ^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/bad_type_argument_arity_struct_unpack.move:9:13 ───
+   │
+ 9 │         let S<u64, u64> { f } = copy s;
+   │             ^^^^^^^^^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 2
+   │
+

--- a/language/move-lang/tests/move_check/typing/bad_type_argument_arity_struct_unpack.move
+++ b/language/move-lang/tests/move_check/typing/bad_type_argument_arity_struct_unpack.move
@@ -1,0 +1,14 @@
+address 0x42 {
+module M {
+
+    struct S<T> { f: T }
+
+    fun ex(s: S<u64>) {
+        let S<> { f } = copy s;
+        f;
+        let S<u64, u64> { f } = copy s;
+        f;
+    }
+}
+
+}


### PR DESCRIPTION
- Fixes #7385 
- Caused by #6630
  - The old instantiation code would have caught this, but the logic for this case was not moved to Naming with the rest of the arity checks for apply types 

## Test Plan

- new tests