### PR TITLE
[mover-prover] Give all cfgs dummy exit/entry node.

### DIFF
--- a/language/move-prover/bytecode/src/compositional_analysis.rs
+++ b/language/move-prover/bytecode/src/compositional_analysis.rs
@@ -82,17 +82,8 @@ where
             };
             let instrs = &data.code;
             let state_map = self.analyze_function(initial_state, instrs, &cfg);
-            let exit_states: Vec<Self::State> = cfg
-                .exit_blocks(instrs)
-                .iter()
-                .map(|block_id| state_map[block_id].post.clone())
-                .collect();
-            // Join exit states to create summary
-            let mut acc = exit_states[0].clone();
-            for exit_state in exit_states.iter().skip(1) {
-                acc.join(&exit_state);
-            }
-            data.annotations.set(self.to_summary(acc))
+            let exit_state = state_map[&cfg.exit_block()].post.clone();
+            data.annotations.set(self.to_summary(exit_state))
         } else {
             // TODO: not clear that this is desired, but some clients rely on
             // every function having a summary, even natives

--- a/language/move-prover/bytecode/src/dataflow_analysis.rs
+++ b/language/move-prover/bytecode/src/dataflow_analysis.rs
@@ -151,13 +151,17 @@ pub trait TransferFunctions {
         instrs: &[Bytecode],
         cfg: &StacklessControlFlowGraph,
     ) -> Self::State {
+        if cfg.is_dummmy(block_id) {
+            return state;
+        }
+        let instr_inds = cfg.instr_indexes(block_id).unwrap();
         if Self::BACKWARD {
-            for offset in cfg.instr_indexes(block_id).rev() {
+            for offset in instr_inds.rev() {
                 let instr = &instrs[offset as usize];
                 self.execute(&mut state, instr, offset);
             }
         } else {
-            for offset in cfg.instr_indexes(block_id) {
+            for offset in instr_inds {
                 let instr = &instrs[offset as usize];
                 self.execute(&mut state, instr, offset);
             }
@@ -177,16 +181,14 @@ pub trait DataflowAnalysis: TransferFunctions {
     ) -> StateMap<Self::State> {
         let mut state_map: StateMap<Self::State> = StateMap::new();
         let mut work_list = VecDeque::new();
-        for entry_block_id in cfg.entry_blocks() {
-            work_list.push_back(entry_block_id);
-            state_map.insert(
-                entry_block_id,
-                BlockState {
-                    pre: initial_state.clone(),
-                    post: initial_state.clone(),
-                },
-            );
-        }
+        work_list.push_back(cfg.entry_block());
+        state_map.insert(
+            cfg.entry_block(),
+            BlockState {
+                pre: initial_state.clone(),
+                post: initial_state.clone(),
+            },
+        );
         while let Some(block_id) = work_list.pop_front() {
             let pre = state_map.remove(&block_id).expect("basic block").pre;
             let post = self.execute_block(block_id, pre.clone(), &instrs, cfg);
@@ -225,7 +227,6 @@ pub trait DataflowAnalysis: TransferFunctions {
             }
             state_map.insert(block_id, BlockState { pre, post });
         }
-
         state_map
     }
 
@@ -247,17 +248,20 @@ pub trait DataflowAnalysis: TransferFunctions {
         let mut result = BTreeMap::new();
         for (block_id, block_state) in state_map {
             let mut state = block_state.pre;
-            if Self::BACKWARD {
-                for offset in cfg.instr_indexes(block_id).rev() {
-                    let after = state.clone();
-                    self.execute(&mut state, &instrs[offset as usize], offset);
-                    result.insert(offset, f(&state, &after));
-                }
-            } else {
-                for offset in cfg.instr_indexes(block_id) {
-                    let before = state.clone();
-                    self.execute(&mut state, &instrs[offset as usize], offset);
-                    result.insert(offset, f(&before, &state));
+            if !cfg.is_dummmy(block_id) {
+                let instr_inds = cfg.instr_indexes(block_id).unwrap();
+                if Self::BACKWARD {
+                    for offset in instr_inds.rev() {
+                        let after = state.clone();
+                        self.execute(&mut state, &instrs[offset as usize], offset);
+                        result.insert(offset, f(&state, &after));
+                    }
+                } else {
+                    for offset in instr_inds {
+                        let before = state.clone();
+                        self.execute(&mut state, &instrs[offset as usize], offset);
+                        result.insert(offset, f(&before, &state));
+                    }
                 }
             }
         }

--- a/language/move-prover/bytecode/src/stackless_control_flow_graph.rs
+++ b/language/move-prover/bytecode/src/stackless_control_flow_graph.rs
@@ -12,24 +12,33 @@ type Map<K, V> = BTreeMap<K, V>;
 type Set<V> = BTreeSet<V>;
 pub type BlockId = CodeOffset;
 
-struct BasicBlock {
-    lower: CodeOffset,
-    upper: CodeOffset,
+struct Block {
     successors: Vec<BlockId>,
+    content: BlockContent,
+}
+
+#[derive(Copy, Clone)]
+pub enum BlockContent {
+    Basic {
+        lower: CodeOffset,
+        upper: CodeOffset,
+    },
+    Dummy,
 }
 
 pub struct StacklessControlFlowGraph {
-    entry_block_ids: Vec<BlockId>,
-    blocks: Map<BlockId, BasicBlock>,
+    entry_block_id: BlockId,
+    blocks: Map<BlockId, Block>,
     backward: bool,
 }
 
-const ENTRY_BLOCK_ID: BlockId = 0;
+const DUMMY_ENTRACE: BlockId = 0;
+const DUMMY_EXIT: BlockId = 1;
 
 impl StacklessControlFlowGraph {
     pub fn new_forward(code: &[Bytecode]) -> Self {
         Self {
-            entry_block_ids: vec![ENTRY_BLOCK_ID],
+            entry_block_id: DUMMY_ENTRACE,
             blocks: Self::collect_blocks(code),
             backward: false,
         }
@@ -46,26 +55,15 @@ impl StacklessControlFlowGraph {
             }
         }
         Self {
-            entry_block_ids: blocks
-                .iter()
-                .map(|(block_id, block)| {
-                    if code[block.upper as usize].is_exit() {
-                        Some(*block_id)
-                    } else {
-                        None
-                    }
-                })
-                .flatten()
-                .collect(),
+            entry_block_id: DUMMY_EXIT,
             blocks: block_id_to_predecessors
                 .into_iter()
                 .map(|(block_id, predecessors)| {
                     (
                         block_id,
-                        BasicBlock {
-                            lower: blocks[&block_id].lower,
-                            upper: blocks[&block_id].upper,
+                        Block {
                             successors: predecessors,
+                            content: blocks[&block_id].content,
                         },
                     )
                 })
@@ -74,38 +72,79 @@ impl StacklessControlFlowGraph {
         }
     }
 
-    fn collect_blocks(code: &[Bytecode]) -> Map<BlockId, BasicBlock> {
-        // First go through and collect block ids, i.e., offsets that begin basic blocks.
+    fn collect_blocks(code: &[Bytecode]) -> Map<BlockId, Block> {
+        // First go through and collect basic block offsets.
         // Need to do this first in order to handle backwards edges.
         let label_offsets = Bytecode::label_offsets(code);
-        let mut block_ids = Set::new();
-        block_ids.insert(ENTRY_BLOCK_ID);
+        let mut bb_offsets = Set::new();
+        bb_offsets.insert(0);
         for pc in 0..code.len() {
             StacklessControlFlowGraph::record_block_ids(
                 pc as CodeOffset,
                 code,
-                &mut block_ids,
+                &mut bb_offsets,
                 &label_offsets,
             );
         }
         // Now construct blocks
         let mut blocks = Map::new();
-        let mut entry = 0;
+        // Maps basic block entry offsets to their key in blocks
+        let mut offset_to_key = Map::new();
+        // Block counter starts at 2 because entry and exit will be block 0 and 1
+        let mut bcounter = 2;
+        let mut block_entry = 0;
         for pc in 0..code.len() {
             let co_pc: CodeOffset = pc as CodeOffset;
             // Create a basic block
-            if StacklessControlFlowGraph::is_end_of_block(co_pc, code, &block_ids) {
-                let successors = Bytecode::get_successors(co_pc, code, &label_offsets);
-                let bb = BasicBlock {
-                    lower: entry,
+            if StacklessControlFlowGraph::is_end_of_block(co_pc, code, &bb_offsets) {
+                let mut successors = Bytecode::get_successors(co_pc, code, &label_offsets);
+                for successors in successors.iter_mut() {
+                    if offset_to_key.contains_key(&successors.clone()) {
+                        *successors = *offset_to_key.get(&successors.clone()).unwrap();
+                    } else {
+                        offset_to_key.insert(successors.clone(), bcounter);
+                        *successors = bcounter;
+                        bcounter = bcounter + 1;
+                    }
+                }
+                if code[co_pc as usize].is_exit() {
+                    successors.push(DUMMY_EXIT);
+                }
+                let bb = BlockContent::Basic {
+                    lower: block_entry,
                     upper: co_pc,
-                    successors,
                 };
-                blocks.insert(entry, bb);
-                entry = co_pc + 1;
+                if !(offset_to_key.contains_key(&block_entry)) {
+                    offset_to_key.insert(block_entry, bcounter);
+                    bcounter = bcounter + 1;
+                }
+                let key = *offset_to_key.get(&block_entry).unwrap();
+                blocks.insert(
+                    key,
+                    Block {
+                        successors,
+                        content: bb,
+                    },
+                );
+                block_entry = co_pc + 1;
             }
         }
-        assert_eq!(entry, code.len() as CodeOffset);
+        assert_eq!(block_entry, code.len() as CodeOffset);
+        let entry_bb = *offset_to_key.get(&0).unwrap();
+        blocks.insert(
+            DUMMY_ENTRACE,
+            Block {
+                successors: vec![entry_bb],
+                content: BlockContent::Dummy,
+            },
+        );
+        blocks.insert(
+            DUMMY_EXIT,
+            Block {
+                successors: Vec::new(),
+                content: BlockContent::Dummy,
+            },
+        );
         blocks
     }
 
@@ -132,51 +171,48 @@ impl StacklessControlFlowGraph {
 }
 
 impl StacklessControlFlowGraph {
-    pub fn block_start(&self, block_id: BlockId) -> CodeOffset {
-        self.blocks[&block_id].lower
-    }
-
-    pub fn block_end(&self, block_id: BlockId) -> CodeOffset {
-        self.blocks[&block_id].upper
-    }
-
     pub fn successors(&self, block_id: BlockId) -> &Vec<BlockId> {
         &self.blocks[&block_id].successors
+    }
+
+    pub fn content(&self, block_id: BlockId) -> &BlockContent {
+        &self.blocks[&block_id].content
     }
 
     pub fn blocks(&self) -> Vec<BlockId> {
         self.blocks.keys().cloned().collect()
     }
 
-    pub fn entry_blocks(&self) -> Vec<BlockId> {
-        self.entry_block_ids.clone()
+    pub fn entry_block(&self) -> BlockId {
+        self.entry_block_id.clone()
     }
 
-    pub fn exit_blocks(&self, code: &[Bytecode]) -> Vec<BlockId> {
+    pub fn exit_block(&self) -> BlockId {
         if self.backward {
-            vec![ENTRY_BLOCK_ID]
+            DUMMY_ENTRACE
         } else {
-            self.blocks
-                .iter()
-                .filter_map(|(block_id, block)| {
-                    if code[block.upper as usize].is_exit() {
-                        Some(*block_id)
-                    } else {
-                        None
-                    }
-                })
-                .collect()
+            DUMMY_EXIT
         }
     }
 
     pub fn instr_indexes(
         &self,
         block_id: BlockId,
-    ) -> Box<dyn DoubleEndedIterator<Item = CodeOffset>> {
-        Box::new(self.block_start(block_id)..=self.block_end(block_id))
+    ) -> Option<Box<dyn DoubleEndedIterator<Item = CodeOffset>>> {
+        match self.blocks[&block_id].content {
+            BlockContent::Basic { lower, upper } => Some(Box::new(lower..=upper)),
+            BlockContent::Dummy => None,
+        }
     }
 
     pub fn num_blocks(&self) -> u16 {
         self.blocks.len() as u16
+    }
+
+    pub fn is_dummmy(&self, block_id: BlockId) -> bool {
+        match self.blocks[&block_id].content {
+            BlockContent::Dummy => true,
+            _ => false,
+        }
     }
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

These changes standardize cfgs in mover-prover. Specifically, all cfgs now have a single (dummy) entry/exit point. This will allows forward and backward analyses over the cfg to look essentially the same.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Current tests provide good coverage of these changes.
