### PR TITLE
[language][functional tests] fix transaction header in the log

### DIFF
--- a/language/move-lang/functional-tests/tests/diem/block/block_prologue.exp
+++ b/language/move-lang/functional-tests/tests/diem/block/block_prologue.exp
@@ -1,10 +1,11 @@
-[0] Output(TransactionOutput(TransactionOutput { write_set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: 0000000000000000000000000a550c18, path: 01000000000000000000000000000000010d4469656d54696d657374616d701743757272656e7454696d654d6963726f7365636f6e647300 }, Value(40420f0000000000)), (AccessPath { address: 0000000000000000000000000a550c18, path: 0100000000000000000000000000000001094469656d426c6f636b0d426c6f636b4d6574616461746100 }, Value(010000000000000001000000000000001811000000000000000000000000000000000000000a550c18))] }), events: [ContractEvent { key: EventKey([17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]), index: 0, type: Struct(StructTag { address: 00000000000000000000000000000001, module: Identifier("DiemBlock"), name: Identifier("NewBlockEvent"), type_params: [] }), event_data: "000000000000000051c1b9fc2f32d6f2fff669823ef31cbe0040420f0000000000" }], gas_used: 100000000, status: Keep(EXECUTED) }))
-[1] Transaction(1)
-[2] Move VM Status: EXECUTED
-[3] Transaction Status: Keep(EXECUTED)
-[4] Transaction(2)
-[5] Move VM Status: EXECUTED
-[6] Transaction Status: Keep(EXECUTED)
-[7] Transaction(3)
-[8] Move VM Status: ABORTED { code: 514, location: 00000000000000000000000000000001::CoreAddresses }
-[9] Transaction Status: Keep(ABORTED { code: 514, location: 00000000000000000000000000000001::CoreAddresses })
+[0] Transaction(0)
+[1] Output(TransactionOutput(TransactionOutput { write_set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: 0000000000000000000000000a550c18, path: 01000000000000000000000000000000010d4469656d54696d657374616d701743757272656e7454696d654d6963726f7365636f6e647300 }, Value(40420f0000000000)), (AccessPath { address: 0000000000000000000000000a550c18, path: 0100000000000000000000000000000001094469656d426c6f636b0d426c6f636b4d6574616461746100 }, Value(010000000000000001000000000000001811000000000000000000000000000000000000000a550c18))] }), events: [ContractEvent { key: EventKey([17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]), index: 0, type: Struct(StructTag { address: 00000000000000000000000000000001, module: Identifier("DiemBlock"), name: Identifier("NewBlockEvent"), type_params: [] }), event_data: "000000000000000051c1b9fc2f32d6f2fff669823ef31cbe0040420f0000000000" }], gas_used: 100000000, status: Keep(EXECUTED) }))
+[2] Transaction(1)
+[3] Move VM Status: EXECUTED
+[4] Transaction Status: Keep(EXECUTED)
+[5] Transaction(2)
+[6] Move VM Status: EXECUTED
+[7] Transaction Status: Keep(EXECUTED)
+[8] Transaction(3)
+[9] Move VM Status: ABORTED { code: 514, location: 00000000000000000000000000000001::CoreAddresses }
+[10] Transaction Status: Keep(ABORTED { code: 514, location: 00000000000000000000000000000001::CoreAddresses })

--- a/language/move-lang/functional-tests/tests/diem/block/expired_transaction.exp
+++ b/language/move-lang/functional-tests/tests/diem/block/expired_transaction.exp
@@ -1,23 +1,25 @@
-[0] Output(TransactionOutput(TransactionOutput { write_set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: 0000000000000000000000000a550c18, path: 01000000000000000000000000000000010d4469656d54696d657374616d701743757272656e7454696d654d6963726f7365636f6e647300 }, Value(00e1f50500000000)), (AccessPath { address: 0000000000000000000000000a550c18, path: 0100000000000000000000000000000001094469656d426c6f636b0d426c6f636b4d6574616461746100 }, Value(010000000000000001000000000000001811000000000000000000000000000000000000000a550c18))] }), events: [ContractEvent { key: EventKey([17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]), index: 0, type: Struct(StructTag { address: 00000000000000000000000000000001, module: Identifier("DiemBlock"), name: Identifier("NewBlockEvent"), type_params: [] }), event_data: "000000000000000051c1b9fc2f32d6f2fff669823ef31cbe0000e1f50500000000" }], gas_used: 100000000, status: Keep(EXECUTED) }))
-[1] Transaction(1)
-[2] Move VM Status: ERROR { status_code: TRANSACTION_EXPIRED }
-[3] Transaction Status: Discard(TRANSACTION_EXPIRED)
-[4] Transaction(2)
-[5] Move VM Status: ERROR { status_code: TRANSACTION_EXPIRED }
-[6] Transaction Status: Discard(TRANSACTION_EXPIRED)
-[7] Transaction(3)
-[8] Move VM Status: EXECUTED
-[9] Transaction Status: Keep(EXECUTED)
-[10] Transaction(4)
-[11] Move VM Status: EXECUTED
-[12] Transaction Status: Keep(EXECUTED)
-[13] Output(TransactionOutput(TransactionOutput { write_set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: 0000000000000000000000000a550c18, path: 01000000000000000000000000000000010d4469656d54696d657374616d701743757272656e7454696d654d6963726f7365636f6e647300 }, Value(4023050600000000)), (AccessPath { address: 0000000000000000000000000a550c18, path: 0100000000000000000000000000000001094469656d426c6f636b0d426c6f636b4d6574616461746100 }, Value(020000000000000002000000000000001811000000000000000000000000000000000000000a550c18))] }), events: [ContractEvent { key: EventKey([17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]), index: 1, type: Struct(StructTag { address: 00000000000000000000000000000001, module: Identifier("DiemBlock"), name: Identifier("NewBlockEvent"), type_params: [] }), event_data: "000000000000000051c1b9fc2f32d6f2fff669823ef31cbe004023050600000000" }], gas_used: 100000000, status: Keep(EXECUTED) }))
-[14] Transaction(6)
-[15] Move VM Status: EXECUTED
-[16] Transaction Status: Keep(EXECUTED)
-[17] Transaction(7)
-[18] Move VM Status: ERROR { status_code: TRANSACTION_EXPIRED }
-[19] Transaction Status: Discard(TRANSACTION_EXPIRED)
-[20] Transaction(8)
-[21] Move VM Status: EXECUTED
-[22] Transaction Status: Keep(EXECUTED)
+[0] Transaction(0)
+[1] Output(TransactionOutput(TransactionOutput { write_set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: 0000000000000000000000000a550c18, path: 01000000000000000000000000000000010d4469656d54696d657374616d701743757272656e7454696d654d6963726f7365636f6e647300 }, Value(00e1f50500000000)), (AccessPath { address: 0000000000000000000000000a550c18, path: 0100000000000000000000000000000001094469656d426c6f636b0d426c6f636b4d6574616461746100 }, Value(010000000000000001000000000000001811000000000000000000000000000000000000000a550c18))] }), events: [ContractEvent { key: EventKey([17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]), index: 0, type: Struct(StructTag { address: 00000000000000000000000000000001, module: Identifier("DiemBlock"), name: Identifier("NewBlockEvent"), type_params: [] }), event_data: "000000000000000051c1b9fc2f32d6f2fff669823ef31cbe0000e1f50500000000" }], gas_used: 100000000, status: Keep(EXECUTED) }))
+[2] Transaction(1)
+[3] Move VM Status: ERROR { status_code: TRANSACTION_EXPIRED }
+[4] Transaction Status: Discard(TRANSACTION_EXPIRED)
+[5] Transaction(2)
+[6] Move VM Status: ERROR { status_code: TRANSACTION_EXPIRED }
+[7] Transaction Status: Discard(TRANSACTION_EXPIRED)
+[8] Transaction(3)
+[9] Move VM Status: EXECUTED
+[10] Transaction Status: Keep(EXECUTED)
+[11] Transaction(4)
+[12] Move VM Status: EXECUTED
+[13] Transaction Status: Keep(EXECUTED)
+[14] Transaction(5)
+[15] Output(TransactionOutput(TransactionOutput { write_set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: 0000000000000000000000000a550c18, path: 01000000000000000000000000000000010d4469656d54696d657374616d701743757272656e7454696d654d6963726f7365636f6e647300 }, Value(4023050600000000)), (AccessPath { address: 0000000000000000000000000a550c18, path: 0100000000000000000000000000000001094469656d426c6f636b0d426c6f636b4d6574616461746100 }, Value(020000000000000002000000000000001811000000000000000000000000000000000000000a550c18))] }), events: [ContractEvent { key: EventKey([17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]), index: 1, type: Struct(StructTag { address: 00000000000000000000000000000001, module: Identifier("DiemBlock"), name: Identifier("NewBlockEvent"), type_params: [] }), event_data: "000000000000000051c1b9fc2f32d6f2fff669823ef31cbe004023050600000000" }], gas_used: 100000000, status: Keep(EXECUTED) }))
+[16] Transaction(6)
+[17] Move VM Status: EXECUTED
+[18] Transaction Status: Keep(EXECUTED)
+[19] Transaction(7)
+[20] Move VM Status: ERROR { status_code: TRANSACTION_EXPIRED }
+[21] Transaction Status: Discard(TRANSACTION_EXPIRED)
+[22] Transaction(8)
+[23] Move VM Status: EXECUTED
+[24] Transaction Status: Keep(EXECUTED)

--- a/language/move-lang/functional-tests/tests/diem/block/get_block_height.exp
+++ b/language/move-lang/functional-tests/tests/diem/block/get_block_height.exp
@@ -1,11 +1,13 @@
 [0] Transaction(0)
 [1] Move VM Status: EXECUTED
 [2] Transaction Status: Keep(EXECUTED)
-[3] Output(TransactionOutput(TransactionOutput { write_set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: 0000000000000000000000000a550c18, path: 01000000000000000000000000000000010d4469656d54696d657374616d701743757272656e7454696d654d6963726f7365636f6e647300 }, Value(00e1f50500000000)), (AccessPath { address: 0000000000000000000000000a550c18, path: 0100000000000000000000000000000001094469656d426c6f636b0d426c6f636b4d6574616461746100 }, Value(010000000000000001000000000000001811000000000000000000000000000000000000000a550c18))] }), events: [ContractEvent { key: EventKey([17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]), index: 0, type: Struct(StructTag { address: 00000000000000000000000000000001, module: Identifier("DiemBlock"), name: Identifier("NewBlockEvent"), type_params: [] }), event_data: "000000000000000051c1b9fc2f32d6f2fff669823ef31cbe0000e1f50500000000" }], gas_used: 100000000, status: Keep(EXECUTED) }))
-[4] Transaction(2)
-[5] Move VM Status: EXECUTED
-[6] Transaction Status: Keep(EXECUTED)
-[7] Output(TransactionOutput(TransactionOutput { write_set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: 0000000000000000000000000a550c18, path: 01000000000000000000000000000000010d4469656d54696d657374616d701743757272656e7454696d654d6963726f7365636f6e647300 }, Value(4023050600000000)), (AccessPath { address: 0000000000000000000000000a550c18, path: 0100000000000000000000000000000001094469656d426c6f636b0d426c6f636b4d6574616461746100 }, Value(020000000000000002000000000000001811000000000000000000000000000000000000000a550c18))] }), events: [ContractEvent { key: EventKey([17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]), index: 1, type: Struct(StructTag { address: 00000000000000000000000000000001, module: Identifier("DiemBlock"), name: Identifier("NewBlockEvent"), type_params: [] }), event_data: "000000000000000051c1b9fc2f32d6f2fff669823ef31cbe004023050600000000" }], gas_used: 100000000, status: Keep(EXECUTED) }))
-[8] Transaction(4)
-[9] Move VM Status: EXECUTED
-[10] Transaction Status: Keep(EXECUTED)
+[3] Transaction(1)
+[4] Output(TransactionOutput(TransactionOutput { write_set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: 0000000000000000000000000a550c18, path: 01000000000000000000000000000000010d4469656d54696d657374616d701743757272656e7454696d654d6963726f7365636f6e647300 }, Value(00e1f50500000000)), (AccessPath { address: 0000000000000000000000000a550c18, path: 0100000000000000000000000000000001094469656d426c6f636b0d426c6f636b4d6574616461746100 }, Value(010000000000000001000000000000001811000000000000000000000000000000000000000a550c18))] }), events: [ContractEvent { key: EventKey([17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]), index: 0, type: Struct(StructTag { address: 00000000000000000000000000000001, module: Identifier("DiemBlock"), name: Identifier("NewBlockEvent"), type_params: [] }), event_data: "000000000000000051c1b9fc2f32d6f2fff669823ef31cbe0000e1f50500000000" }], gas_used: 100000000, status: Keep(EXECUTED) }))
+[5] Transaction(2)
+[6] Move VM Status: EXECUTED
+[7] Transaction Status: Keep(EXECUTED)
+[8] Transaction(3)
+[9] Output(TransactionOutput(TransactionOutput { write_set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: 0000000000000000000000000a550c18, path: 01000000000000000000000000000000010d4469656d54696d657374616d701743757272656e7454696d654d6963726f7365636f6e647300 }, Value(4023050600000000)), (AccessPath { address: 0000000000000000000000000a550c18, path: 0100000000000000000000000000000001094469656d426c6f636b0d426c6f636b4d6574616461746100 }, Value(020000000000000002000000000000001811000000000000000000000000000000000000000a550c18))] }), events: [ContractEvent { key: EventKey([17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]), index: 1, type: Struct(StructTag { address: 00000000000000000000000000000001, module: Identifier("DiemBlock"), name: Identifier("NewBlockEvent"), type_params: [] }), event_data: "000000000000000051c1b9fc2f32d6f2fff669823ef31cbe004023050600000000" }], gas_used: 100000000, status: Keep(EXECUTED) }))
+[10] Transaction(4)
+[11] Move VM Status: EXECUTED
+[12] Transaction Status: Keep(EXECUTED)

--- a/language/move-lang/functional-tests/tests/diem/block/none_validator_propser.exp
+++ b/language/move-lang/functional-tests/tests/diem/block/none_validator_propser.exp
@@ -1,5 +1,7 @@
-[0] Output(TransactionOutput(TransactionOutput { write_set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: 0000000000000000000000000a550c18, path: 01000000000000000000000000000000010d4469656d54696d657374616d701743757272656e7454696d654d6963726f7365636f6e647300 }, Value(40420f0000000000)), (AccessPath { address: 0000000000000000000000000a550c18, path: 0100000000000000000000000000000001094469656d426c6f636b0d426c6f636b4d6574616461746100 }, Value(010000000000000001000000000000001811000000000000000000000000000000000000000a550c18))] }), events: [ContractEvent { key: EventKey([17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]), index: 0, type: Struct(StructTag { address: 00000000000000000000000000000001, module: Identifier("DiemBlock"), name: Identifier("NewBlockEvent"), type_params: [] }), event_data: "000000000000000051c1b9fc2f32d6f2fff669823ef31cbe0040420f0000000000" }], gas_used: 100000000, status: Keep(EXECUTED) }))
-[1] Transaction(1)
-[2] Move VM Status: EXECUTED
-[3] Transaction Status: Keep(EXECUTED)
-[4] VerificationError(ERROR { status_code: UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION })
+[0] Transaction(0)
+[1] Output(TransactionOutput(TransactionOutput { write_set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: 0000000000000000000000000a550c18, path: 01000000000000000000000000000000010d4469656d54696d657374616d701743757272656e7454696d654d6963726f7365636f6e647300 }, Value(40420f0000000000)), (AccessPath { address: 0000000000000000000000000a550c18, path: 0100000000000000000000000000000001094469656d426c6f636b0d426c6f636b4d6574616461746100 }, Value(010000000000000001000000000000001811000000000000000000000000000000000000000a550c18))] }), events: [ContractEvent { key: EventKey([17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]), index: 0, type: Struct(StructTag { address: 00000000000000000000000000000001, module: Identifier("DiemBlock"), name: Identifier("NewBlockEvent"), type_params: [] }), event_data: "000000000000000051c1b9fc2f32d6f2fff669823ef31cbe0040420f0000000000" }], gas_used: 100000000, status: Keep(EXECUTED) }))
+[2] Transaction(1)
+[3] Move VM Status: EXECUTED
+[4] Transaction Status: Keep(EXECUTED)
+[5] Transaction(2)
+[6] VerificationError(ERROR { status_code: UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION })

--- a/language/move-lang/functional-tests/tests/diem/block/older_timestamp.exp
+++ b/language/move-lang/functional-tests/tests/diem/block/older_timestamp.exp
@@ -1,5 +1,7 @@
-[0] Output(TransactionOutput(TransactionOutput { write_set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: 0000000000000000000000000a550c18, path: 01000000000000000000000000000000010d4469656d54696d657374616d701743757272656e7454696d654d6963726f7365636f6e647300 }, Value(00e1f50500000000)), (AccessPath { address: 0000000000000000000000000a550c18, path: 0100000000000000000000000000000001094469656d426c6f636b0d426c6f636b4d6574616461746100 }, Value(010000000000000001000000000000001811000000000000000000000000000000000000000a550c18))] }), events: [ContractEvent { key: EventKey([17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]), index: 0, type: Struct(StructTag { address: 00000000000000000000000000000001, module: Identifier("DiemBlock"), name: Identifier("NewBlockEvent"), type_params: [] }), event_data: "000000000000000051c1b9fc2f32d6f2fff669823ef31cbe0000e1f50500000000" }], gas_used: 100000000, status: Keep(EXECUTED) }))
-[1] Transaction(1)
-[2] Move VM Status: EXECUTED
-[3] Transaction Status: Keep(EXECUTED)
-[4] VerificationError(ERROR { status_code: UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION })
+[0] Transaction(0)
+[1] Output(TransactionOutput(TransactionOutput { write_set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: 0000000000000000000000000a550c18, path: 01000000000000000000000000000000010d4469656d54696d657374616d701743757272656e7454696d654d6963726f7365636f6e647300 }, Value(00e1f50500000000)), (AccessPath { address: 0000000000000000000000000a550c18, path: 0100000000000000000000000000000001094469656d426c6f636b0d426c6f636b4d6574616461746100 }, Value(010000000000000001000000000000001811000000000000000000000000000000000000000a550c18))] }), events: [ContractEvent { key: EventKey([17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]), index: 0, type: Struct(StructTag { address: 00000000000000000000000000000001, module: Identifier("DiemBlock"), name: Identifier("NewBlockEvent"), type_params: [] }), event_data: "000000000000000051c1b9fc2f32d6f2fff669823ef31cbe0000e1f50500000000" }], gas_used: 100000000, status: Keep(EXECUTED) }))
+[2] Transaction(1)
+[3] Move VM Status: EXECUTED
+[4] Transaction Status: Keep(EXECUTED)
+[5] Transaction(2)
+[6] VerificationError(ERROR { status_code: UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION })

--- a/language/move-lang/functional-tests/tests/diem/block/vm_proposer.exp
+++ b/language/move-lang/functional-tests/tests/diem/block/vm_proposer.exp
@@ -1,1 +1,2 @@
-[0] VerificationError(ERROR { status_code: UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION })
+[0] Transaction(0)
+[1] VerificationError(ERROR { status_code: UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION })

--- a/language/testing-infra/functional-tests/src/evaluator.rs
+++ b/language/testing-infra/functional-tests/src/evaluator.rs
@@ -538,7 +538,6 @@ fn eval_transaction<TComp: Compiler>(
     global_config: &GlobalConfig,
     compiler: &mut TComp,
     exec: &mut FakeExecutor,
-    idx: usize,
     transaction: &Transaction,
     log: &mut EvaluationLog,
 ) -> Result<Status> {
@@ -558,8 +557,6 @@ fn eval_transaction<TComp: Compiler>(
     let sender_addr = *transaction.config.sender.address();
 
     // Start processing a new transaction.
-    log.append(EvaluationOutput::Transaction(idx));
-
     // stage 1: Compile the script/module
     if transaction.config.is_stage_disabled(Stage::Compiler) {
         return Ok(Status::Success);
@@ -748,10 +745,11 @@ pub fn eval<TComp: Compiler>(
     }
 
     for (idx, command) in commands.iter().enumerate() {
+        log.append(EvaluationOutput::Transaction(idx));
         match command {
             Command::Transaction(transaction) => {
                 let status =
-                    eval_transaction(config, &mut compiler, &mut exec, idx, transaction, &mut log)?;
+                    eval_transaction(config, &mut compiler, &mut exec, transaction, &mut log)?;
                 if !config.exp_mode {
                     log.append(EvaluationOutput::Status(status));
                 }


### PR DESCRIPTION
This fixes the bug that transaction headers (e.g. "Transaction(4)") only get emitted by regular transactions, but not block prologue transactions.