### PR TITLE
[gha] Add a benchmark task in CI

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -325,6 +325,41 @@ jobs:
           cargo xcheck -j ${max_threads} -p transaction-builder -p move-vm-types --target powerpc-unknown-linux-gnu
       - uses: ./.github/actions/build-teardown
 
+  perf-benchmarks:
+    name: run-perf-benchmarks
+    runs-on: ubuntu-latest-xl
+    timeout-minutes: 30
+    needs:
+      - prepare
+      - build-benchmarks
+    env:
+      CRITERION_HOME: /tmp/benches
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/cache@v2
+        with:
+          path: "/opt/cargo/git\n/opt/cargo/registry\n/opt/cargo/.package-cache"
+          key: crates-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: "crates-${{ runner.os }}"
+      - name: Download the previous baseline
+        continue-on-error: true
+        uses: actions/download-artifact@v2
+        with:
+          name: bench-baseline
+      - name: Run performance benchamrks
+        run: |
+          # Replace this with a cargo x bench
+          cargo bench --package language-benchmarks
+      - name: Archive criterion results
+        uses: actions/upload-artifact@v2
+        with:
+          name: bench-baseline
+          retention-days: 5
+          path: |
+              /tmp/benches
+
   success:
     name: ci-test-success
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Write a primitive github task to do a benchmarking after the benmark build is done. I used language benchmarks for an example but we should replace it with `cargo x bench` later to get benches from all various crates.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

TBD
