### PR TITLE
[network] Integrate TimeService into PeerManager, DiemTransport, and HealthChecker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4467,6 +4467,7 @@ dependencies = [
  "diem-network-address",
  "diem-network-address-encryption",
  "diem-secure-storage",
+ "diem-time-service",
  "diem-types",
  "diem-workspace-hack",
  "futures 0.3.12",

--- a/common/time-service/src/interval.rs
+++ b/common/time-service/src/interval.rs
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{Sleep, SleepTrait, ZERO_DURATION};
-use futures::{future::Future, ready, stream::Stream};
+use futures::{
+    future::Future,
+    ready,
+    stream::{FusedStream, Stream},
+};
 use pin_project::pin_project;
 use std::{
     pin::Pin,
@@ -43,5 +47,16 @@ impl Stream for Interval {
         this.delay.reset(*this.period);
 
         Poll::Ready(Some(()))
+    }
+}
+
+impl FusedStream for Interval {
+    /// We implement [`FusedStream`] here to make it more convenient for API
+    /// consumers when using an [`Interval`] inside a `futures::select!`.
+    ///
+    /// Note: an [`Interval`] stream never ends, so this function always returns
+    /// `false`.
+    fn is_terminated(&self) -> bool {
+        false
     }
 }

--- a/network/builder/Cargo.toml
+++ b/network/builder/Cargo.toml
@@ -27,6 +27,7 @@ diem-metrics = {path = "../../common/metrics", version = "0.1.0"}
 diem-network-address = { path = "../../network/network-address", version = "0.1.0" }
 diem-network-address-encryption = {path = "../../config/management/network-address-encryption", version = "0.1.0"}
 diem-secure-storage = { path = "../../secure/storage", version = "0.1.0" }
+diem-time-service = { path = "../../common/time-service", version = "0.1.0", features = ["async"] }
 diem-types = { path = "../../types", version = "0.1.0" }
 diem-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 netcore = { path = "../../network/netcore", version = "0.1.0" }

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -25,6 +25,7 @@ use diem_logger::prelude::*;
 use diem_metrics::IntCounterVec;
 use diem_network_address::NetworkAddress;
 use diem_network_address_encryption::Encryptor;
+use diem_time_service::TimeService;
 use diem_types::{chain_id::ChainId, PeerId};
 use network::{
     connectivity_manager::{builder::ConnectivityManagerBuilder, ConnectivityRequest},
@@ -432,6 +433,7 @@ impl NetworkBuilder {
 
         self.health_checker_builder = Some(HealthCheckerBuilder::create(
             self.network_context(),
+            TimeService::real(),
             ping_interval_ms,
             ping_timeout_ms,
             ping_failures_tolerated,

--- a/network/src/peer_manager/builder.rs
+++ b/network/src/peer_manager/builder.rs
@@ -304,6 +304,7 @@ impl PeerManagerBuilder {
                     DiemNetTransport::new(
                         DIEM_TCP_TRANSPORT.clone(),
                         self.network_context.clone(),
+                        TimeService::real(),
                         key,
                         auth_mode,
                         HANDSHAKE_VERSION,
@@ -320,6 +321,7 @@ impl PeerManagerBuilder {
                     DiemNetTransport::new(
                         MemoryTransport,
                         self.network_context.clone(),
+                        TimeService::real(),
                         key,
                         auth_mode,
                         HANDSHAKE_VERSION,

--- a/network/src/peer_manager/builder.rs
+++ b/network/src/peer_manager/builder.rs
@@ -24,6 +24,7 @@ use diem_logger::prelude::*;
 use diem_metrics::IntCounterVec;
 use diem_network_address::NetworkAddress;
 use diem_rate_limiter::rate_limit::TokenBucketRateLimiter;
+use diem_time_service::TimeService;
 use diem_types::{chain_id::ChainId, PeerId};
 #[cfg(any(test, feature = "testing", feature = "fuzzing"))]
 use netcore::transport::memory::MemoryTransport;
@@ -366,6 +367,7 @@ impl PeerManagerBuilder {
         );
         let peer_mgr = PeerManager::new(
             executor.clone(),
+            TimeService::real(),
             transport,
             self.network_context.clone(),
             // TODO(philiphayes): peer manager should take `Vec<NetworkAddress>`

--- a/network/src/peer_manager/tests.rs
+++ b/network/src/peer_manager/tests.rs
@@ -22,6 +22,7 @@ use channel::{diem_channel, message_queues::QueueStyle};
 use diem_config::{config::MAX_INBOUND_CONNECTIONS, network_id::NetworkContext};
 use diem_network_address::NetworkAddress;
 use diem_rate_limiter::rate_limit::TokenBucketRateLimiter;
+use diem_time_service::TimeService;
 use diem_types::PeerId;
 use futures::{channel::oneshot, io::AsyncWriteExt, stream::StreamExt};
 use memsocket::MemorySocket;
@@ -95,6 +96,7 @@ fn build_test_peer_manager(
 
     let peer_manager = PeerManager::new(
         executor,
+        TimeService::mock(),
         build_test_transport(),
         NetworkContext::mock_with_peer_id(peer_id),
         "/memory/0".parse().unwrap(),

--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -196,8 +196,6 @@ impl HealthChecker {
         loop {
             futures::select! {
                 maybe_event = self.network_rx.next() => {
-                    trace!("maybe_event: {:?}", maybe_event);
-
                     // Shutdown the HealthChecker when this network instance shuts
                     // down. This happens when the `PeerManager` drops.
                     let event = match maybe_event {
@@ -224,6 +222,7 @@ impl HealthChecker {
                                         self.network_context,
                                         peer_id
                                     );
+                                    debug_assert!(false, "Unexpected rpc request");
                                 }
                             };
                         }
@@ -254,9 +253,8 @@ impl HealthChecker {
                         continue
                     }
 
-                    let peers: Vec<_> = self.connected.keys().cloned().collect();
-                    for peer_id in peers {
-                        let nonce = self.nonce();
+                    for &peer_id in self.connected.keys() {
+                        let nonce = self.rng.gen::<u32>();
                         trace!(
                             NetworkSchema::new(&self.network_context),
                             round = self.round,
@@ -433,9 +431,5 @@ impl HealthChecker {
                 _ => Err(RpcError::InvalidRpcResponse),
             });
         (peer_id, round, nonce, res_pong_msg)
-    }
-
-    fn nonce(&mut self) -> u32 {
-        self.rng.gen::<u32>()
     }
 }

--- a/network/src/protocols/health_checker/test.rs
+++ b/network/src/protocols/health_checker/test.rs
@@ -14,130 +14,146 @@ use crate::{
     ProtocolId,
 };
 use channel::{diem_channel, message_queues::QueueStyle};
-use diem_config::{config::RoleType, network_id::NetworkId};
 use diem_time_service::{MockTimeService, TimeService};
 use futures::{executor::block_on, future};
 
 const PING_INTERVAL: Duration = Duration::from_secs(1);
 const PING_TIMEOUT: Duration = Duration::from_millis(500);
 
-fn setup_permissive_health_checker(
-    ping_failures_tolerated: u64,
-) -> (
-    HealthChecker,
-    MockTimeService,
-    diem_channel::Receiver<(PeerId, ProtocolId), PeerManagerRequest>,
-    diem_channel::Sender<(PeerId, ProtocolId), PeerManagerNotification>,
-    diem_channel::Receiver<PeerId, ConnectionRequest>,
-    conn_notifs_channel::Sender,
-) {
-    let mock_time = TimeService::mock();
-
-    let (peer_mgr_reqs_tx, peer_mgr_reqs_rx) = diem_channel::new(QueueStyle::FIFO, 1, None);
-    let (connection_reqs_tx, connection_reqs_rx) = diem_channel::new(QueueStyle::FIFO, 1, None);
-    let (network_notifs_tx, network_notifs_rx) = diem_channel::new(QueueStyle::FIFO, 1, None);
-    let (connection_notifs_tx, connection_notifs_rx) = conn_notifs_channel::new();
-
-    let hc_network_tx = HealthCheckerNetworkSender::new(
-        PeerManagerRequestSender::new(peer_mgr_reqs_tx),
-        ConnectionRequestSender::new(connection_reqs_tx),
-    );
-    let hc_network_rx = HealthCheckerNetworkEvents::new(network_notifs_rx, connection_notifs_rx);
-    let network_context =
-        NetworkContext::new(NetworkId::Validator, RoleType::Validator, PeerId::ZERO);
-    let health_checker = HealthChecker::new(
-        Arc::new(network_context),
-        mock_time.clone(),
-        hc_network_tx,
-        hc_network_rx,
-        PING_INTERVAL,
-        PING_TIMEOUT,
-        ping_failures_tolerated,
-    );
-    (
-        health_checker,
-        mock_time.into_mock(),
-        peer_mgr_reqs_rx,
-        network_notifs_tx,
-        connection_reqs_rx,
-        connection_notifs_tx,
-    )
+struct TestHarness {
+    mock_time: MockTimeService,
+    peer_mgr_reqs_rx: diem_channel::Receiver<(PeerId, ProtocolId), PeerManagerRequest>,
+    peer_mgr_notifs_tx: diem_channel::Sender<(PeerId, ProtocolId), PeerManagerNotification>,
+    connection_reqs_rx: diem_channel::Receiver<PeerId, ConnectionRequest>,
+    connection_notifs_tx: conn_notifs_channel::Sender,
 }
 
-fn setup_strict_health_checker() -> (
-    HealthChecker,
-    MockTimeService,
-    diem_channel::Receiver<(PeerId, ProtocolId), PeerManagerRequest>,
-    diem_channel::Sender<(PeerId, ProtocolId), PeerManagerNotification>,
-    diem_channel::Receiver<PeerId, ConnectionRequest>,
-    conn_notifs_channel::Sender,
-) {
-    setup_permissive_health_checker(0 /* ping_failures_tolerated */)
-}
+impl TestHarness {
+    fn new_permissive(ping_failures_tolerated: u64) -> (Self, HealthChecker) {
+        ::diem_logger::Logger::init_for_testing();
+        let mock_time = TimeService::mock();
 
-async fn expect_ping(
-    network_reqs_rx: &mut diem_channel::Receiver<(PeerId, ProtocolId), PeerManagerRequest>,
-) -> (Ping, oneshot::Sender<Result<Bytes, RpcError>>) {
-    let req = network_reqs_rx.next().await.unwrap();
-    let rpc_req = match req {
-        PeerManagerRequest::SendRpc(_peer_id, rpc_req) => rpc_req,
-        _ => panic!("Unexpected PeerManagerRequest: {:?}", req),
-    };
+        let (peer_mgr_reqs_tx, peer_mgr_reqs_rx) = diem_channel::new(QueueStyle::FIFO, 1, None);
+        let (connection_reqs_tx, connection_reqs_rx) = diem_channel::new(QueueStyle::FIFO, 1, None);
+        let (peer_mgr_notifs_tx, peer_mgr_notifs_rx) = diem_channel::new(QueueStyle::FIFO, 1, None);
+        let (connection_notifs_tx, connection_notifs_rx) = conn_notifs_channel::new();
 
-    let protocol_id = rpc_req.protocol_id;
-    let req_data = rpc_req.data;
-    let res_tx = rpc_req.res_tx;
+        let hc_network_tx = HealthCheckerNetworkSender::new(
+            PeerManagerRequestSender::new(peer_mgr_reqs_tx),
+            ConnectionRequestSender::new(connection_reqs_tx),
+        );
+        let hc_network_rx =
+            HealthCheckerNetworkEvents::new(peer_mgr_notifs_rx, connection_notifs_rx);
+        let health_checker = HealthChecker::new(
+            NetworkContext::mock(),
+            mock_time.clone(),
+            hc_network_tx,
+            hc_network_rx,
+            PING_INTERVAL,
+            PING_TIMEOUT,
+            ping_failures_tolerated,
+        );
 
-    assert_eq!(protocol_id, ProtocolId::HealthCheckerRpc,);
-
-    match bcs::from_bytes(&req_data).unwrap() {
-        HealthCheckerMsg::Ping(ping) => (ping, res_tx),
-        msg => panic!("Unexpected HealthCheckerMsg: {:?}", msg),
-    }
-}
-
-async fn expect_ping_send_ok(
-    network_reqs_rx: &mut diem_channel::Receiver<(PeerId, ProtocolId), PeerManagerRequest>,
-) {
-    let (ping, res_tx) = expect_ping(network_reqs_rx).await;
-    let res_data = bcs::to_bytes(&HealthCheckerMsg::Pong(Pong(ping.0))).unwrap();
-    res_tx.send(Ok(res_data.into())).unwrap();
-}
-
-async fn expect_ping_send_notok(
-    network_reqs_rx: &mut diem_channel::Receiver<(PeerId, ProtocolId), PeerManagerRequest>,
-) {
-    let (_ping_msg, res_tx) = expect_ping(network_reqs_rx).await;
-    // This mock ping request must fail.
-    res_tx.send(Err(RpcError::TimedOut)).unwrap();
-}
-
-async fn send_inbound_ping(
-    peer_id: PeerId,
-    ping: u32,
-    network_notifs_tx: &mut diem_channel::Sender<(PeerId, ProtocolId), PeerManagerNotification>,
-) -> oneshot::Receiver<Result<Bytes, RpcError>> {
-    let protocol_id = ProtocolId::HealthCheckerRpc;
-    let data = bcs::to_bytes(&HealthCheckerMsg::Ping(Ping(ping)))
-        .unwrap()
-        .into();
-    let (res_tx, res_rx) = oneshot::channel();
-    let inbound_rpc_req = InboundRpcRequest {
-        protocol_id,
-        data,
-        res_tx,
-    };
-    let key = (peer_id, ProtocolId::HealthCheckerRpc);
-    let (delivered_tx, delivered_rx) = oneshot::channel();
-    network_notifs_tx
-        .push_with_feedback(
-            key,
-            PeerManagerNotification::RecvRpc(peer_id, inbound_rpc_req),
-            Some(delivered_tx),
+        (
+            Self {
+                mock_time: mock_time.into_mock(),
+                peer_mgr_reqs_rx,
+                peer_mgr_notifs_tx,
+                connection_reqs_rx,
+                connection_notifs_tx,
+            },
+            health_checker,
         )
-        .unwrap();
-    delivered_rx.await.unwrap();
-    res_rx
+    }
+
+    fn new_strict() -> (Self, HealthChecker) {
+        Self::new_permissive(0 /* ping_failures_tolerated */)
+    }
+
+    async fn trigger_ping(&self) {
+        self.mock_time.advance_async(PING_INTERVAL).await;
+    }
+
+    async fn expect_ping(&mut self) -> (Ping, oneshot::Sender<Result<Bytes, RpcError>>) {
+        let req = self.peer_mgr_reqs_rx.next().await.unwrap();
+        let rpc_req = match req {
+            PeerManagerRequest::SendRpc(_peer_id, rpc_req) => rpc_req,
+            _ => panic!("Unexpected PeerManagerRequest: {:?}", req),
+        };
+
+        let protocol_id = rpc_req.protocol_id;
+        let req_data = rpc_req.data;
+        let res_tx = rpc_req.res_tx;
+
+        assert_eq!(protocol_id, ProtocolId::HealthCheckerRpc);
+
+        match bcs::from_bytes(&req_data).unwrap() {
+            HealthCheckerMsg::Ping(ping) => (ping, res_tx),
+            msg => panic!("Unexpected HealthCheckerMsg: {:?}", msg),
+        }
+    }
+
+    async fn expect_ping_send_ok(&mut self) {
+        let (ping, res_tx) = self.expect_ping().await;
+        let res_data = bcs::to_bytes(&HealthCheckerMsg::Pong(Pong(ping.0))).unwrap();
+        res_tx.send(Ok(res_data.into())).unwrap();
+    }
+
+    async fn expect_ping_send_not_ok(&mut self) {
+        let (_ping_msg, res_tx) = self.expect_ping().await;
+        // This mock ping request must fail.
+        res_tx.send(Err(RpcError::TimedOut)).unwrap();
+    }
+
+    async fn send_inbound_ping(
+        &mut self,
+        peer_id: PeerId,
+        ping: u32,
+    ) -> oneshot::Receiver<Result<Bytes, RpcError>> {
+        let protocol_id = ProtocolId::HealthCheckerRpc;
+        let data = bcs::to_bytes(&HealthCheckerMsg::Ping(Ping(ping)))
+            .unwrap()
+            .into();
+        let (res_tx, res_rx) = oneshot::channel();
+        let inbound_rpc_req = InboundRpcRequest {
+            protocol_id,
+            data,
+            res_tx,
+        };
+        let key = (peer_id, ProtocolId::HealthCheckerRpc);
+        let (delivered_tx, delivered_rx) = oneshot::channel();
+        self.peer_mgr_notifs_tx
+            .push_with_feedback(
+                key,
+                PeerManagerNotification::RecvRpc(peer_id, inbound_rpc_req),
+                Some(delivered_tx),
+            )
+            .unwrap();
+        delivered_rx.await.unwrap();
+        res_rx
+    }
+
+    async fn expect_disconnect(&mut self, expected_peer_id: PeerId) {
+        let req = self.connection_reqs_rx.next().await.unwrap();
+        let (peer_id, res_tx) = match req {
+            ConnectionRequest::DisconnectPeer(peer_id, res_tx) => (peer_id, res_tx),
+            _ => panic!("Unexpected ConnectionRequest: {:?}", req),
+        };
+        assert_eq!(peer_id, expected_peer_id);
+        res_tx.send(Ok(())).unwrap();
+    }
+
+    async fn send_new_peer_notification(&mut self, peer_id: PeerId) {
+        let (delivered_tx, delivered_rx) = oneshot::channel();
+        let notif = peer_manager::ConnectionNotification::NewPeer(
+            ConnectionMetadata::mock(peer_id),
+            NetworkContext::mock(),
+        );
+        self.connection_notifs_tx
+            .push_with_feedback(peer_id, notif, Some(delivered_tx))
+            .unwrap();
+        delivered_rx.await.unwrap();
+    }
 }
 
 async fn expect_pong(res_rx: oneshot::Receiver<Result<Bytes, RpcError>>) {
@@ -148,227 +164,139 @@ async fn expect_pong(res_rx: oneshot::Receiver<Result<Bytes, RpcError>>) {
     };
 }
 
-async fn expect_disconnect(
-    expected_peer_id: PeerId,
-    connection_reqs_rx: &mut diem_channel::Receiver<PeerId, ConnectionRequest>,
-) {
-    let req = connection_reqs_rx.next().await.unwrap();
-    let (peer_id, res_tx) = match req {
-        ConnectionRequest::DisconnectPeer(peer_id, res_tx) => (peer_id, res_tx),
-        _ => panic!("Unexpected PeerManagerRequest: {:?}", req),
-    };
-    assert_eq!(peer_id, expected_peer_id);
-    res_tx.send(Ok(())).unwrap();
-}
-
-async fn send_new_peer_notification(
-    peer_id: PeerId,
-    connection_notifs_tx: &mut conn_notifs_channel::Sender,
-) {
-    let (delivered_tx, delivered_rx) = oneshot::channel();
-    let notif = peer_manager::ConnectionNotification::NewPeer(
-        ConnectionMetadata::mock(peer_id),
-        NetworkContext::mock(),
-    );
-    connection_notifs_tx
-        .push_with_feedback(peer_id, notif, Some(delivered_tx))
-        .unwrap();
-    delivered_rx.await.unwrap();
-}
-
 #[test]
 fn outbound() {
-    ::diem_logger::Logger::init_for_testing();
-    let (
-        health_checker,
-        mock_time,
-        mut network_reqs_rx,
-        network_notifs_tx,
-        _,
-        mut connection_notifs_tx,
-    ) = setup_strict_health_checker();
+    let (mut harness, health_checker) = TestHarness::new_strict();
 
     let test = async move {
         // Trigger ping to a peer. This should do nothing.
-        mock_time.advance_async(PING_INTERVAL).await;
+        harness.trigger_ping().await;
 
         // Notify HealthChecker of new connected node.
-        let peer_id = PeerId::random();
-        send_new_peer_notification(peer_id, &mut connection_notifs_tx).await;
+        let peer_id = PeerId::new([0x42; PeerId::LENGTH]);
+        harness.send_new_peer_notification(peer_id).await;
 
         // Trigger ping to a peer. This should ping the newly added peer.
-        mock_time.advance_async(PING_INTERVAL).await;
+        harness.trigger_ping().await;
 
         // Health Checker should attempt to ping the new peer.
-        expect_ping_send_ok(&mut network_reqs_rx).await;
-
-        // Shutdown Health Checker.
-        drop(network_notifs_tx);
-        drop(connection_notifs_tx);
+        harness.expect_ping_send_ok().await;
     };
     block_on(future::join(health_checker.start(), test));
 }
 
 #[test]
 fn inbound() {
-    ::diem_logger::Logger::init_for_testing();
-    let (
-        health_checker,
-        _mock_time,
-        _network_reqs_rx,
-        mut network_notifs_tx,
-        _,
-        mut connection_notifs_tx,
-    ) = setup_strict_health_checker();
+    let (mut harness, health_checker) = TestHarness::new_strict();
 
     let test = async move {
         // Notify HealthChecker of new connected node.
-        let peer_id = PeerId::random();
-        send_new_peer_notification(peer_id, &mut connection_notifs_tx).await;
+        let peer_id = PeerId::new([0x42; PeerId::LENGTH]);
+        harness.send_new_peer_notification(peer_id).await;
 
         // Receive ping from peer.
-        let res_rx = send_inbound_ping(peer_id, 0, &mut network_notifs_tx).await;
+        let res_rx = harness.send_inbound_ping(peer_id, 0).await;
 
         // HealthChecker should respond with a pong.
         expect_pong(res_rx).await;
-
-        // Shutdown Health Checker.
-        drop(network_notifs_tx);
-        drop(connection_notifs_tx);
     };
     block_on(future::join(health_checker.start(), test));
 }
 
 #[test]
 fn outbound_failure_permissive() {
-    ::diem_logger::Logger::init_for_testing();
     let ping_failures_tolerated = 10;
-    let (
-        health_checker,
-        mock_time,
-        mut network_reqs_rx,
-        network_notifs_tx,
-        mut connection_reqs_rx,
-        mut connection_notifs_tx,
-    ) = setup_permissive_health_checker(ping_failures_tolerated);
+    let (mut harness, health_checker) = TestHarness::new_permissive(ping_failures_tolerated);
 
     let test = async move {
         // Trigger ping to a peer. This should do nothing.
-        mock_time.advance_async(PING_INTERVAL).await;
+        harness.trigger_ping().await;
 
         // Notify HealthChecker of new connected node.
-        let peer_id = PeerId::random();
-        send_new_peer_notification(peer_id, &mut connection_notifs_tx).await;
+        let peer_id = PeerId::new([0x42; PeerId::LENGTH]);
+        harness.send_new_peer_notification(peer_id).await;
 
         // Trigger pings to a peer. These should ping the newly added peer, but not disconnect from
         // it.
         for _ in 0..=ping_failures_tolerated {
-            mock_time.advance_async(PING_INTERVAL).await;
             // Health checker should send a ping request which fails.
-            expect_ping_send_notok(&mut network_reqs_rx).await;
+            harness.trigger_ping().await;
+            harness.expect_ping_send_not_ok().await;
         }
 
         // Health checker should disconnect from peer after tolerated number of failures
-        expect_disconnect(peer_id, &mut connection_reqs_rx).await;
-
-        // Shutdown Health Checker.
-        drop(network_notifs_tx);
-        drop(connection_notifs_tx);
+        harness.expect_disconnect(peer_id).await;
     };
     block_on(future::join(health_checker.start(), test));
 }
 
 #[test]
 fn ping_success_resets_fail_counter() {
-    ::diem_logger::Logger::init_for_testing();
     let failures_triggered = 10;
     let ping_failures_tolerated = 2 * 10;
-    let (
-        health_checker,
-        mock_time,
-        mut network_reqs_rx,
-        network_notifs_tx,
-        mut connection_reqs_rx,
-        mut connection_notifs_tx,
-    ) = setup_permissive_health_checker(ping_failures_tolerated);
+    let (mut harness, health_checker) = TestHarness::new_permissive(ping_failures_tolerated);
 
     let test = async move {
         // Trigger ping to a peer. This should do nothing.
-        mock_time.advance_async(PING_INTERVAL).await;
+        harness.trigger_ping().await;
 
         // Notify HealthChecker of new connected node.
-        let peer_id = PeerId::random();
-        send_new_peer_notification(peer_id, &mut connection_notifs_tx).await;
+        let peer_id = PeerId::new([0x42; PeerId::LENGTH]);
+        harness.send_new_peer_notification(peer_id).await;
 
         // Trigger pings to a peer. These should ping the newly added peer, but not disconnect from
         // it.
         {
             for _ in 0..failures_triggered {
-                mock_time.advance_async(PING_INTERVAL).await;
                 // Health checker should send a ping request which fails.
-                expect_ping_send_notok(&mut network_reqs_rx).await;
+                harness.trigger_ping().await;
+                harness.expect_ping_send_not_ok().await;
             }
         }
 
         // Trigger successful ping. This should reset the counter of ping failures.
         {
-            mock_time.advance_async(PING_INTERVAL).await;
             // Health checker should send a ping request which succeeds
-            expect_ping_send_ok(&mut network_reqs_rx).await;
+            harness.trigger_ping().await;
+            harness.expect_ping_send_ok().await;
         }
 
         // We would then need to fail for more than `ping_failures_tolerated` times before
         // triggering disconnect.
         {
             for _ in 0..=ping_failures_tolerated {
-                mock_time.advance_async(PING_INTERVAL).await;
                 // Health checker should send a ping request which fails.
-                expect_ping_send_notok(&mut network_reqs_rx).await;
+                harness.trigger_ping().await;
+                harness.expect_ping_send_not_ok().await;
             }
         }
 
         // Health checker should disconnect from peer after tolerated number of failures
-        expect_disconnect(peer_id, &mut connection_reqs_rx).await;
-
-        // Shutdown Health Checker.
-        drop(network_notifs_tx);
-        drop(connection_notifs_tx);
+        harness.expect_disconnect(peer_id).await;
     };
     block_on(future::join(health_checker.start(), test));
 }
 
 #[test]
 fn outbound_failure_strict() {
-    ::diem_logger::Logger::init_for_testing();
-    let (
-        health_checker,
-        mock_time,
-        mut network_reqs_rx,
-        network_notifs_tx,
-        mut connection_reqs_rx,
-        mut connection_notifs_tx,
-    ) = setup_strict_health_checker();
+    let (mut harness, health_checker) = TestHarness::new_strict();
 
     let test = async move {
         // Trigger ping to a peer. This should do nothing.
-        mock_time.advance_async(PING_INTERVAL).await;
+        harness.trigger_ping().await;
 
         // Notify HealthChecker of new connected node.
-        let peer_id = PeerId::random();
-        send_new_peer_notification(peer_id, &mut connection_notifs_tx).await;
+        let peer_id = PeerId::new([0x42; PeerId::LENGTH]);
+        harness.send_new_peer_notification(peer_id).await;
 
         // Trigger ping to a peer. This should ping the newly added peer.
-        mock_time.advance_async(PING_INTERVAL).await;
+        harness.trigger_ping().await;
 
         // Health checker should send a ping request which fails.
-        expect_ping_send_notok(&mut network_reqs_rx).await;
+        harness.expect_ping_send_not_ok().await;
 
         // Health checker should disconnect from peer.
-        expect_disconnect(peer_id, &mut connection_reqs_rx).await;
-
-        // Shutdown Health Checker.
-        drop(network_notifs_tx);
-        drop(connection_notifs_tx);
+        harness.expect_disconnect(peer_id).await;
     };
     block_on(future::join(health_checker.start(), test));
 }

--- a/network/src/transport/mod.rs
+++ b/network/src/transport/mod.rs
@@ -16,6 +16,7 @@ use diem_config::{
 use diem_crypto::x25519;
 use diem_logger::prelude::*;
 use diem_network_address::{parse_dns_tcp, parse_ip_tcp, parse_memory, NetworkAddress};
+use diem_time_service::{timeout, TimeService, TimeServiceTrait};
 use diem_types::{chain_id::ChainId, PeerId};
 use futures::{
     future::{Future, FutureExt},
@@ -35,7 +36,6 @@ use std::{
     },
     time::Duration,
 };
-use tokio::time::timeout;
 
 #[cfg(test)]
 mod test;
@@ -176,14 +176,14 @@ pub struct Connection<TSocket> {
 }
 
 /// Convenience function for adding a timeout to a Future that returns an `io::Result`.
-async fn timeout_io<F, T>(duration: Duration, fut: F) -> io::Result<T>
+async fn timeout_io<F, T>(time_service: TimeService, duration: Duration, fut: F) -> io::Result<T>
 where
     F: Future<Output = io::Result<T>>,
 {
-    let res = timeout(duration, fut).await;
+    let res = time_service.timeout(duration, fut).await;
     match res {
         Ok(out) => out,
-        Err(err) => Err(io::Error::new(io::ErrorKind::TimedOut, err)),
+        Err(timeout::Elapsed) => Err(io::Error::new(io::ErrorKind::TimedOut, timeout::Elapsed)),
     }
 }
 
@@ -387,6 +387,7 @@ async fn upgrade_outbound<T: TSocket>(
 pub struct DiemNetTransport<TTransport> {
     base_transport: TTransport,
     ctxt: Arc<UpgradeContext>,
+    time_service: TimeService,
     identity_pubkey: x25519::PublicKey,
     enable_proxy_protocol: bool,
 }
@@ -402,6 +403,7 @@ where
     pub fn new(
         base_transport: TTransport,
         network_context: Arc<NetworkContext>,
+        time_service: TimeService,
         identity_key: x25519::PrivateKey,
         auth_mode: HandshakeAuthMode,
         handshake_version: u8,
@@ -425,8 +427,9 @@ where
         };
 
         Self {
-            ctxt: Arc::new(upgrade_context),
             base_transport,
+            ctxt: Arc::new(upgrade_context),
+            time_service,
             identity_pubkey,
             enable_proxy_protocol,
         }
@@ -525,7 +528,7 @@ where
 
         // outbound dial upgrade task
         let upgrade_fut = upgrade_outbound(self.ctxt.clone(), fut_socket, addr, peer_id, pubkey);
-        let upgrade_fut = timeout_io(TRANSPORT_TIMEOUT, upgrade_fut);
+        let upgrade_fut = timeout_io(self.time_service.clone(), TRANSPORT_TIMEOUT, upgrade_fut);
         Ok(upgrade_fut)
     }
 
@@ -571,6 +574,7 @@ where
 
         // need to move a ctxt into stream task
         let ctxt = self.ctxt.clone();
+        let time_service = self.time_service.clone();
         let enable_proxy_protocol = self.enable_proxy_protocol;
         // stream of inbound upgrade tasks
         let inbounds = listener.map_ok(move |(fut_socket, addr)| {
@@ -581,7 +585,7 @@ where
                 addr.clone(),
                 enable_proxy_protocol,
             );
-            let fut_upgrade = timeout_io(TRANSPORT_TIMEOUT, fut_upgrade);
+            let fut_upgrade = timeout_io(time_service.clone(), TRANSPORT_TIMEOUT, fut_upgrade);
             (fut_upgrade, addr)
         });
 


### PR DESCRIPTION
+ Integrate TimeService into PeerManager and its tests

+ Push TimeService into DiemTransport and tests 

+ Integrate `TimeService` into `HealthChecker` 

+ Remove the `TTicker` generic and just create a new `time_service.interval` in `HealthChecker::start`. This removes a bunch of extra type noise and a dependency on `tokio_stream`.

+ Add an impl for `FusedStream` to `diem_time_service::Interval`, so it's more convenient for API consumers to use intervals in `futures::select!`. We can do this because `Interval`s never end, so `FusedStream::is_terminated` just always returns `false`.

+ Remove some now unnecessary structs / type aliases in `health_checker::builder`.

+ Remove `ping_timeout` test, which was no longer testing anything different than the `outbound_failure_*` tests, as timeouts are now handled at a lower layer.


