### PR TITLE
[move source language] Fix spec context bugs

### DIFF
--- a/language/move-lang/src/cfgir/liveness/mod.rs
+++ b/language/move-lang/src/cfgir/liveness/mod.rs
@@ -296,9 +296,9 @@ mod last_usage {
                         DisplayVar::Orig(v_str) => {
                             if !v.starts_with_underscore() {
                                 let msg = format!(
-                                    "Unused assignment or binding for local '{}'. \
-                                    Consider removing, replacing with '_', \
-                                    or prefixing with '_' (e.g., '_{}')",
+                                    "Unused assignment or binding for local '{}'. Consider \
+                                     removing, replacing with '_', or prefixing with '_' (e.g., \
+                                     '_{}')",
                                     v_str, v_str
                                 );
                                 context.error(vec![(l.loc, msg)]);

--- a/language/move-lang/src/naming/translate.rs
+++ b/language/move-lang/src/naming/translate.rs
@@ -989,7 +989,7 @@ fn lvalue(context: &mut Context, case: LValueCase, sp!(loc, l_): E::LValue) -> O
                 nfields.expect("ICE fields were already unique"),
             )
         }
-        EL::Var(..) => panic!("unexpected specification construct"),
+        EL::Var(_, _) => panic!("unexpected specification construct"),
     };
     Some(sp(loc, nl_))
 }

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -324,9 +324,9 @@ pub enum InvariantKind {
 pub enum ModuleAccess_ {
     // N
     Name(Name),
-    // M.S
+    // M::S
     ModuleAccess(ModuleName, Name),
-    // OxADDR.M.S
+    // OxADDR::M::S
     QualifiedModuleAccess(ModuleIdent, Name),
 }
 pub type ModuleAccess = Spanned<ModuleAccess_>;
@@ -740,6 +740,16 @@ impl BinOp_ {
 impl fmt::Display for ModuleIdent {
     fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}::{}", self.0.value.address, &self.0.value.name)
+    }
+}
+
+impl fmt::Display for ModuleAccess_ {
+    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
+        match self {
+            ModuleAccess_::Name(n) => write!(f, "{}", n),
+            ModuleAccess_::ModuleAccess(m, n) => write!(f, "{}::{}", m, n),
+            ModuleAccess_::QualifiedModuleAccess(m, n) => write!(f, "{}::{}", m, n),
+        }
     }
 }
 
@@ -1229,11 +1239,7 @@ impl AstDebug for Vec<Type> {
 
 impl AstDebug for ModuleAccess_ {
     fn ast_debug(&self, w: &mut AstWriter) {
-        w.write(&match self {
-            ModuleAccess_::Name(n) => format!("{}", n),
-            ModuleAccess_::ModuleAccess(m, n) => format!("{}::{}", m, n),
-            ModuleAccess_::QualifiedModuleAccess(m, n) => format!("{}::{}", m, n),
-        })
+        w.write(&format!("{}", self))
     }
 }
 

--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -1809,7 +1809,8 @@ fn parse_spec_block_member<'input>(tokens: &mut Lexer<'input>) -> Result<SpecBlo
         _ => Err(unexpected_token_error(
             tokens,
             "one of `assert`, `assume`, `decreases`, `aborts_if`, `aborts_with`, `succeeds_if`, \
-            `modifies`, `emits`, `ensures`, `requires`, `include`, `apply`, `pragma`, `global`, or a name",
+             `modifies`, `emits`, `ensures`, `requires`, `include`, `apply`, `pragma`, `global`, \
+             or a name",
         )),
     }
 }

--- a/language/move-lang/tests/move_check/expansion/assign_non_simple_name.exp
+++ b/language/move-lang/tests/move_check/expansion/assign_non_simple_name.exp
@@ -1,0 +1,107 @@
+error: 
+
+    ┌── tests/move_check/expansion/assign_non_simple_name.move:16:9 ───
+    │
+ 16 │         X::S = ();
+    │         ^^^^ Unexpected assignment of module access without fields outside of a spec context.
+If you are trying to unpack a struct, try adding fields, e.g. 'X::S {}'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/assign_non_simple_name.move:17:9 ───
+    │
+ 17 │         Self::S<u64> = ();
+    │         ^^^^^^^^^^^^ Unexpected assignment of module access without fields outside of a spec context.
+If you are trying to unpack a struct, try adding fields, e.g. 'Self::S {}'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/assign_non_simple_name.move:18:9 ───
+    │
+ 18 │         Self::R = ();
+    │         ^^^^^^^ Unexpected assignment of module access without fields outside of a spec context.
+If you are trying to unpack a struct, try adding fields, e.g. 'Self::R {}'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/assign_non_simple_name.move:22:9 ───
+    │
+ 22 │         0x42::X::S = ();
+    │         ^^^^^^^^^^ Unexpected assignment of module access without fields outside of a spec context.
+If you are trying to unpack a struct, try adding fields, e.g. '0x42::X::S {}'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/assign_non_simple_name.move:23:9 ───
+    │
+ 23 │         0x42::M::S<u64> = ();
+    │         ^^^^^^^^^^^^^^^ Unexpected assignment of module access without fields outside of a spec context.
+If you are trying to unpack a struct, try adding fields, e.g. '0x42::M::S {}'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/assign_non_simple_name.move:24:9 ───
+    │
+ 24 │         0x42::M::R = ();
+    │         ^^^^^^^^^^ Unexpected assignment of module access without fields outside of a spec context.
+If you are trying to unpack a struct, try adding fields, e.g. '0x42::M::R {}'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/assign_non_simple_name.move:28:9 ───
+    │
+ 28 │         x<u64> = ();
+    │         ^^^^^^ Unexpected assignment of instantiated type without fields outside of a spec context.
+If you are trying to unpack a struct, try adding fields, e.g. 'x {}'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/assign_non_simple_name.move:29:9 ───
+    │
+ 29 │         S<u64> = ();
+    │         ^^^^^^ Unexpected assignment of instantiated type without fields outside of a spec context.
+If you are trying to unpack a struct, try adding fields, e.g. 'S {}'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/assign_non_simple_name.move:33:9 ───
+    │
+ 33 │         X = ();
+    │         ^ Unexpected assignment of module access without fields outside of a spec context.
+If you are trying to unpack a struct, try adding fields, e.g. '0x42::X::S {}'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/assign_non_simple_name.move:34:9 ───
+    │
+ 34 │         S = ();
+    │         ^ Unexpected assignment of module access without fields outside of a spec context.
+If you are trying to unpack a struct, try adding fields, e.g. '0x42::M::S {}'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/assign_non_simple_name.move:35:9 ───
+    │
+ 35 │         R = ();
+    │         ^ Unexpected assignment of module access without fields outside of a spec context.
+If you are trying to unpack a struct, try adding fields, e.g. '0x42::M::R {}'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/assign_non_simple_name.move:39:9 ───
+    │
+ 39 │         Y = 0;
+    │         ^ Invalid assignment. Unbound local 'Y'
+    │
+

--- a/language/move-lang/tests/move_check/expansion/assign_non_simple_name.move
+++ b/language/move-lang/tests/move_check/expansion/assign_non_simple_name.move
@@ -1,0 +1,42 @@
+address 0x42 {
+module X {
+    struct S {}
+}
+module M {
+    use 0x42::X;
+    use 0x42::X::S as X;
+
+    struct R {}
+    struct S<T> { f: T }
+
+
+    fun t() {
+        // Assign to qualified name
+        // should fail in non spec context
+        X::S = ();
+        Self::S<u64> = ();
+        Self::R = ();
+
+        // Assign to fully qualified name
+        // should fail in non spec context
+        0x42::X::S = ();
+        0x42::M::S<u64> = ();
+        0x42::M::R = ();
+
+        // Assign to name with type args, qualified/nonqualified/struct doesnt matter
+        // should fail in non spec context
+        x<u64> = ();
+        S<u64> = ();
+
+        // Assign to a name that is aliased in local context
+        // should fail in non spec context
+        X = ();
+        S = ();
+        R = ();
+
+        // Assign to a name that starts with A-Z
+        // Should fail with unbound local even though it is not a valid local name
+        Y = 0;
+    }
+}
+}

--- a/language/move-lang/tests/move_check/expansion/invalid_local_name.exp
+++ b/language/move-lang/tests/move_check/expansion/invalid_local_name.exp
@@ -3,7 +3,7 @@ error:
    ┌── tests/move_check/expansion/invalid_local_name.move:4:11 ───
    │
  4 │     fun t(No: u64) {
-   │           ^^ Invalid local name 'No'. Local names must start with 'a'..'z' (or '_')
+   │           ^^ Invalid local variable name 'No'. Local variable names must start with 'a'..'z' (or '_')
    │
 
 error: 
@@ -19,7 +19,7 @@ error:
    ┌── tests/move_check/expansion/invalid_local_name.move:9:13 ───
    │
  9 │         let No;
-   │             ^^ Invalid local name 'No'. Local names must start with 'a'..'z' (or '_')
+   │             ^^ Invalid local variable name 'No'. Local variable names must start with 'a'..'z' (or '_')
    │
 
 error: 
@@ -27,7 +27,7 @@ error:
     ┌── tests/move_check/expansion/invalid_local_name.move:14:13 ───
     │
  14 │         let No = 100;
-    │             ^^ Invalid local name 'No'. Local names must start with 'a'..'z' (or '_')
+    │             ^^ Invalid local variable name 'No'. Local variable names must start with 'a'..'z' (or '_')
     │
 
 error: 

--- a/language/move-lang/tests/move_check/expansion/spec_block_in_spec_context.exp
+++ b/language/move-lang/tests/move_check/expansion/spec_block_in_spec_context.exp
@@ -1,0 +1,8 @@
+error: 
+
+   ┌── tests/move_check/expansion/spec_block_in_spec_context.move:5:13 ───
+   │
+ 5 │             spec {};
+   │             ^^^^^^^ 'spec' blocks cannot be used inside of a spec context
+   │
+

--- a/language/move-lang/tests/move_check/expansion/spec_block_in_spec_context.move
+++ b/language/move-lang/tests/move_check/expansion/spec_block_in_spec_context.move
@@ -1,0 +1,16 @@
+address 0x42 {
+module M {
+    spec module {
+        define S(): () {
+            spec {};
+        }
+    }
+
+    fun t(): () {
+        spec {};
+    }
+
+    fun a() {}
+    fun z() {}
+}
+}


### PR DESCRIPTION
- Fixed #7387. Spec blocks should not be allowed in a spec context.
- Fixed #7385. Expansion needs to check for module accesses after resolving lvalue names. Caused by alias refactor.
- Some other unrelated formatting changes

## Motivation

- bugs are bad

## Test Plan

- new tests