### PR TITLE
[move-prover][refactoring] Examples for presentation + fixes.

### DIFF
--- a/language/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/language/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -478,7 +478,7 @@ impl<'env> ModuleTranslator<'env> {
         emitln!(
             self.writer,
             "// {} {}",
-            bytecode.display(func_target),
+            bytecode.display(func_target, &BTreeMap::default()),
             loc.display(self.module_env.env)
         );
 

--- a/language/move-prover/bytecode/src/function_target.rs
+++ b/language/move-prover/bytecode/src/function_target.rs
@@ -546,13 +546,14 @@ impl<'env> fmt::Display for FunctionTarget<'env> {
             writeln!(f)?;
         }
         let mut loc_vc_shown = BTreeSet::new();
+        let label_offsets = Bytecode::label_offsets(self.get_bytecode());
         for (offset, code) in self.get_bytecode().iter().enumerate() {
             let annotations = self
                 .annotation_formatters
                 .borrow()
                 .iter()
                 .filter_map(|f| f(self, offset as CodeOffset))
-                .map(|s| format!("     // {}", s.replace("\n", "\n     // ")))
+                .map(|s| format!("     // {}", s.replace("\n", "\n     // ").trim()))
                 .join("\n");
             if !annotations.is_empty() {
                 writeln!(f, "{}", annotations)?;
@@ -564,7 +565,7 @@ impl<'env> fmt::Display for FunctionTarget<'env> {
                     }
                 }
             }
-            writeln!(f, "{:>3}: {}", offset, code.display(self))?;
+            writeln!(f, "{:>3}: {}", offset, code.display(self, &label_offsets))?;
         }
         writeln!(f, "}}")?;
         Ok(())

--- a/language/move-prover/bytecode/src/function_target_pipeline.rs
+++ b/language/move-prover/bytecode/src/function_target_pipeline.rs
@@ -251,9 +251,10 @@ impl FunctionTargetPipeline {
             if let Some(base_name) = &dump_to_file {
                 let dump =
                     print_targets_for_test(env, &format!("after processor `{}`", name), targets);
+                let trimmed = format!("{}\n", dump.trim());
                 let file_name = format!("{}_{}_{}.bytecode", base_name, step_count, name);
                 debug!("dumping bytecode to `{}`", file_name);
-                fs::write(&file_name, &dump).expect("dumping bytecode");
+                fs::write(&file_name, &trimmed).expect("dumping bytecode");
             }
         };
         dump_to_file(0, "stackless", targets);

--- a/language/move-prover/bytecode/src/livevar_analysis.rs
+++ b/language/move-prover/bytecode/src/livevar_analysis.rs
@@ -339,7 +339,6 @@ impl<'a> TransferFunctions for LiveVarAnalysis<'a> {
 
     fn execute(&self, state: &mut LiveVarState, instr: &Bytecode, _idx: CodeOffset) {
         use Bytecode::*;
-        use Operation::*;
         match instr {
             Assign(_, dst, src, _) => {
                 if state.remove(&[*dst]) {
@@ -348,11 +347,6 @@ impl<'a> TransferFunctions for LiveVarAnalysis<'a> {
             }
             Load(_, dst, _) => {
                 state.remove(&[*dst]);
-            }
-            Call(_, _, TraceAbort, _)
-            | Call(_, _, TraceLocal(..), _)
-            | Call(_, _, TraceReturn(..), _) => {
-                // Skip trace instructions for liveness
             }
             Call(_, dsts, oper, srcs) => {
                 state.remove(dsts);

--- a/language/move-prover/bytecode/tests/borrow/basic_test.exp
+++ b/language/move-prover/bytecode/tests/borrow/basic_test.exp
@@ -143,16 +143,16 @@ fun TestBorrow::test7($t0|b: bool) {
   6: $t8 := borrow_local($t1)
   7: $t3 := $t8
   8: $t9 := copy($t0)
-  9: if ($t9) goto L0 else goto L1
- 10: L1:
- 11: goto L2
- 12: L0:
+  9: if ($t9) goto 12 else goto 10
+ 10: label L1
+ 11: goto 18
+ 12: label L0
  13: $t10 := move($t3)
  14: destroy($t10)
  15: $t11 := borrow_local($t2)
  16: $t3 := $t11
- 17: goto L2
- 18: L2:
+ 17: goto 18
+ 18: label L2
  19: $t12 := move($t3)
  20: $t13 := 0
  21: TestBorrow::test3($t12, $t13)
@@ -199,15 +199,15 @@ fun TestBorrow::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestBorrow::R) {
   5: $t4 := $t9
   6: $t10 := borrow_local($t4)
   7: $t5 := $t10
-  8: goto L7
-  9: L7:
+  8: goto 9
+  9: label L7
  10: $t11 := 0
  11: $t12 := copy($t1)
  12: $t13 := <($t11, $t12)
- 13: if ($t13) goto L0 else goto L1
- 14: L1:
- 15: goto L2
- 16: L0:
+ 13: if ($t13) goto 16 else goto 14
+ 14: label L1
+ 15: goto 41
+ 16: label L0
  17: $t14 := move($t5)
  18: destroy($t14)
  19: $t15 := copy($t1)
@@ -215,43 +215,43 @@ fun TestBorrow::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestBorrow::R) {
  21: $t17 := /($t15, $t16)
  22: $t18 := 0
  23: $t19 := ==($t17, $t18)
- 24: if ($t19) goto L3 else goto L4
- 25: L4:
- 26: goto L5
- 27: L3:
+ 24: if ($t19) goto 27 else goto 25
+ 25: label L4
+ 26: goto 31
+ 27: label L3
  28: $t20 := borrow_local($t3)
  29: $t5 := $t20
- 30: goto L6
- 31: L5:
+ 30: goto 35
+ 31: label L5
  32: $t21 := borrow_local($t4)
  33: $t5 := $t21
- 34: goto L6
- 35: L6:
+ 34: goto 35
+ 35: label L6
  36: $t22 := copy($t1)
  37: $t23 := 1
  38: $t24 := -($t22, $t23)
  39: $t1 := $t24
- 40: goto L7
- 41: L2:
+ 40: goto 9
+ 41: label L2
  42: $t25 := copy($t0)
- 43: if ($t25) goto L8 else goto L9
- 44: L9:
- 45: goto L10
- 46: L8:
+ 43: if ($t25) goto 46 else goto 44
+ 44: label L9
+ 45: goto 53
+ 46: label L8
  47: $t26 := move($t5)
  48: destroy($t26)
  49: $t27 := move($t2)
  50: $t28 := 0
  51: TestBorrow::test3($t27, $t28)
- 52: goto L11
- 53: L10:
+ 52: goto 60
+ 53: label L10
  54: $t29 := move($t2)
  55: destroy($t29)
  56: $t30 := move($t5)
  57: $t31 := 0
  58: TestBorrow::test3($t30, $t31)
- 59: goto L11
- 60: L11:
+ 59: goto 60
+ 60: label L11
  61: return ()
 }
 
@@ -525,22 +525,22 @@ fun TestBorrow::test7($t0|b: bool) {
      // moved_nodes: LocalRoot($t0)
      // borrowed_by: LocalRoot($t1) -> {Reference($t3)}
      // borrows_from: Reference($t3) -> {LocalRoot($t1)}
-  6: if ($t4) goto L0 else goto L1
+  6: if ($t4) goto 9 else goto 7
      // live_nodes: LocalRoot($t4), Reference($t3)
      // moved_nodes: LocalRoot($t0)
      // borrowed_by: LocalRoot($t1) -> {Reference($t3)}
      // borrows_from: Reference($t3) -> {LocalRoot($t1)}
-  7: L1:
+  7: label L1
      // live_nodes: LocalRoot($t4), Reference($t3)
      // moved_nodes: LocalRoot($t0)
      // borrowed_by: LocalRoot($t1) -> {Reference($t3)}
      // borrows_from: Reference($t3) -> {LocalRoot($t1)}
-  8: goto L2
+  8: goto 13
      // live_nodes: LocalRoot($t4), Reference($t3)
      // moved_nodes: LocalRoot($t0)
      // borrowed_by: LocalRoot($t1) -> {Reference($t3)}
      // borrows_from: Reference($t3) -> {LocalRoot($t1)}
-  9: L0:
+  9: label L0
      // live_nodes: LocalRoot($t4), Reference($t3)
      // moved_nodes: LocalRoot($t0)
      // borrowed_by: LocalRoot($t1) -> {Reference($t3)}
@@ -555,12 +555,12 @@ fun TestBorrow::test7($t0|b: bool) {
      // moved_nodes: LocalRoot($t0)
      // borrowed_by: LocalRoot($t1) -> {Reference($t3)}, LocalRoot($t2) -> {Reference($t3)}
      // borrows_from: Reference($t3) -> {LocalRoot($t1), LocalRoot($t2)}
- 12: goto L2
+ 12: goto 13
      // live_nodes: LocalRoot($t4), Reference($t3)
      // moved_nodes: LocalRoot($t0)
      // borrowed_by: LocalRoot($t1) -> {Reference($t3)}, LocalRoot($t2) -> {Reference($t3)}
      // borrows_from: Reference($t3) -> {LocalRoot($t1), LocalRoot($t2)}
- 13: L2:
+ 13: label L2
      // live_nodes: LocalRoot($t4), Reference($t3)
      // moved_nodes: LocalRoot($t0)
      // borrowed_by: LocalRoot($t1) -> {Reference($t3)}, LocalRoot($t2) -> {Reference($t3)}
@@ -660,13 +660,13 @@ fun TestBorrow::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: TestBorrow::R): TestBo
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      // borrowed_by: LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      // borrows_from: Reference($t5) -> {LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
-  9: goto L7
+  9: goto 10
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 10: L7:
+ 10: label L7
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
@@ -684,25 +684,25 @@ fun TestBorrow::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: TestBorrow::R): TestBo
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 13: if ($t13) goto L0 else goto L1
+ 13: if ($t13) goto 16 else goto 14
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 14: L1:
+ 14: label L1
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 15: goto L2
+ 15: goto 35
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 16: L0:
+ 16: label L0
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
@@ -738,25 +738,25 @@ fun TestBorrow::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: TestBorrow::R): TestBo
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 22: if ($t17) goto L3 else goto L4
+ 22: if ($t17) goto 25 else goto 23
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 23: L4:
+ 23: label L4
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 24: goto L5
+ 24: goto 28
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 25: L3:
+ 25: label L3
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
@@ -768,13 +768,13 @@ fun TestBorrow::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: TestBorrow::R): TestBo
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 27: goto L6
+ 27: goto 31
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 28: L5:
+ 28: label L5
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
@@ -786,13 +786,13 @@ fun TestBorrow::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: TestBorrow::R): TestBo
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 30: goto L6
+ 30: goto 31
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 31: L6:
+ 31: label L6
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
@@ -810,37 +810,37 @@ fun TestBorrow::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: TestBorrow::R): TestBo
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 34: goto L7
+ 34: goto 10
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 35: L2:
+ 35: label L2
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 36: if ($t6) goto L8 else goto L9
+ 36: if ($t6) goto 39 else goto 37
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 37: L9:
+ 37: label L9
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 38: goto L10
+ 38: goto 46
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 39: L8:
+ 39: label L8
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
@@ -876,13 +876,13 @@ fun TestBorrow::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: TestBorrow::R): TestBo
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 45: goto L11
+ 45: goto 53
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 46: L10:
+ 46: label L10
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
@@ -918,13 +918,13 @@ fun TestBorrow::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: TestBorrow::R): TestBo
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 52: goto L11
+ 52: goto 53
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      // borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      // borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 53: L11:
+ 53: label L11
      // live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8)
      // unchecked_nodes: LocalRoot($t8), Reference($t9)
      // moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)

--- a/language/move-prover/bytecode/tests/clean_and_optimize/pack_unpack.exp
+++ b/language/move-prover/bytecode/tests/clean_and_optimize/pack_unpack.exp
@@ -453,15 +453,13 @@ pub fun TestPackUnpack::call_private_violating_invariant($t0|r: TestPackUnpack::
   8: write_ref($t1, $t5)
   9: $t6 := 1
  10: $t7 := borrow_field<TestPackUnpack::S>.value($t1)
- 11: unpack_ref($t7)
- 12: write_ref($t7, $t6)
- 13: pack_ref($t7)
- 14: write_back[Reference($t1)]($t7)
- 15: pack_ref($t1)
- 16: write_back[Reference($t3)]($t1)
- 17: pack_ref($t3)
- 18: write_back[LocalRoot($t2)]($t3)
- 19: return $t2
+ 11: write_ref($t7, $t6)
+ 12: write_back[Reference($t1)]($t7)
+ 13: pack_ref($t1)
+ 14: write_back[Reference($t3)]($t1)
+ 15: pack_ref($t3)
+ 16: write_back[LocalRoot($t2)]($t3)
+ 17: return $t2
 }
 
 
@@ -481,13 +479,13 @@ pub fun TestPackUnpack::call_public_violating_invariant_incorrect($t0|r: TestPac
   4: unpack_ref($t1)
   5: $t4 := 0
   6: $t5 := read_ref($t1)
-  7: $t5 := TestPackUnpack::public_update_value($t5, $t4)
-  8: write_ref($t1, $t5)
-  9: $t6 := 1
- 10: $t7 := borrow_field<TestPackUnpack::S>.value($t1)
- 11: unpack_ref($t7)
- 12: write_ref($t7, $t6)
- 13: pack_ref($t7)
+  7: pack_ref($t5)
+  8: $t5 := TestPackUnpack::public_update_value($t5, $t4)
+  9: unpack_ref($t5)
+ 10: write_ref($t1, $t5)
+ 11: $t6 := 1
+ 12: $t7 := borrow_field<TestPackUnpack::S>.value($t1)
+ 13: write_ref($t7, $t6)
  14: write_back[Reference($t1)]($t7)
  15: pack_ref($t1)
  16: write_back[Reference($t3)]($t1)
@@ -538,13 +536,11 @@ pub fun TestPackUnpack::extract_and_update($t0|r: TestPackUnpack::R): TestPackUn
   5: $t6 := borrow_local($t1)
   6: unpack_ref($t6)
   7: $t7 := borrow_field<TestPackUnpack::S>.value($t6)
-  8: unpack_ref($t7)
-  9: write_ref($t7, $t5)
- 10: pack_ref($t7)
- 11: write_back[Reference($t6)]($t7)
- 12: pack_ref($t6)
- 13: write_back[LocalRoot($t1)]($t6)
- 14: return $t1
+  8: write_ref($t7, $t5)
+  9: write_back[Reference($t6)]($t7)
+ 10: pack_ref($t6)
+ 11: write_back[LocalRoot($t1)]($t6)
+ 12: return $t1
 }
 
 
@@ -596,27 +592,23 @@ pub fun TestPackUnpack::move_ref_unchanged($t0|r1: TestPackUnpack::R, $t1|r2: Te
  13: $t13 := borrow_field<TestPackUnpack::R>.nested($t5)
  14: unpack_ref($t13)
  15: $t14 := borrow_field<TestPackUnpack::S>.value($t13)
- 16: unpack_ref($t14)
- 17: write_ref($t14, $t12)
- 18: pack_ref($t14)
- 19: write_back[Reference($t13)]($t14)
- 20: pack_ref($t13)
- 21: write_back[Reference($t5)]($t13)
- 22: pack_ref($t5)
- 23: write_back[LocalRoot($t3)]($t5)
- 24: $t15 := 1
- 25: $t16 := borrow_field<TestPackUnpack::R>.nested($t4)
- 26: unpack_ref($t16)
- 27: $t17 := borrow_field<TestPackUnpack::S>.value($t16)
- 28: unpack_ref($t17)
- 29: write_ref($t17, $t15)
- 30: pack_ref($t17)
- 31: write_back[Reference($t16)]($t17)
- 32: pack_ref($t16)
- 33: write_back[Reference($t4)]($t16)
- 34: pack_ref($t4)
- 35: write_back[LocalRoot($t2)]($t4)
- 36: return ($t2, $t3)
+ 16: write_ref($t14, $t12)
+ 17: write_back[Reference($t13)]($t14)
+ 18: pack_ref($t13)
+ 19: write_back[Reference($t5)]($t13)
+ 20: pack_ref($t5)
+ 21: write_back[LocalRoot($t3)]($t5)
+ 22: $t15 := 1
+ 23: $t16 := borrow_field<TestPackUnpack::R>.nested($t4)
+ 24: unpack_ref($t16)
+ 25: $t17 := borrow_field<TestPackUnpack::S>.value($t16)
+ 26: write_ref($t17, $t15)
+ 27: write_back[Reference($t16)]($t17)
+ 28: pack_ref($t16)
+ 29: write_back[Reference($t4)]($t16)
+ 30: pack_ref($t4)
+ 31: write_back[LocalRoot($t2)]($t4)
+ 32: return ($t2, $t3)
 }
 
 
@@ -650,27 +642,23 @@ pub fun TestPackUnpack::move_ref_unchanged_invariant_incorrect($t0|r1: TestPackU
  11: $t11 := borrow_field<TestPackUnpack::R>.nested($t5)
  12: unpack_ref($t11)
  13: $t12 := borrow_field<TestPackUnpack::S>.value($t11)
- 14: unpack_ref($t12)
- 15: write_ref($t12, $t10)
- 16: pack_ref($t12)
- 17: write_back[Reference($t11)]($t12)
- 18: pack_ref($t11)
- 19: write_back[Reference($t5)]($t11)
- 20: pack_ref($t5)
- 21: write_back[LocalRoot($t3)]($t5)
- 22: $t13 := 0
- 23: $t14 := borrow_field<TestPackUnpack::R>.nested($t4)
- 24: unpack_ref($t14)
- 25: $t15 := borrow_field<TestPackUnpack::S>.value($t14)
- 26: unpack_ref($t15)
- 27: write_ref($t15, $t13)
- 28: pack_ref($t15)
- 29: write_back[Reference($t14)]($t15)
- 30: pack_ref($t14)
- 31: write_back[Reference($t4)]($t14)
- 32: pack_ref($t4)
- 33: write_back[LocalRoot($t2)]($t4)
- 34: return ($t2, $t3)
+ 14: write_ref($t12, $t10)
+ 15: write_back[Reference($t11)]($t12)
+ 16: pack_ref($t11)
+ 17: write_back[Reference($t5)]($t11)
+ 18: pack_ref($t5)
+ 19: write_back[LocalRoot($t3)]($t5)
+ 20: $t13 := 0
+ 21: $t14 := borrow_field<TestPackUnpack::R>.nested($t4)
+ 22: unpack_ref($t14)
+ 23: $t15 := borrow_field<TestPackUnpack::S>.value($t14)
+ 24: write_ref($t15, $t13)
+ 25: write_back[Reference($t14)]($t15)
+ 26: pack_ref($t14)
+ 27: write_back[Reference($t4)]($t14)
+ 28: pack_ref($t4)
+ 29: write_back[LocalRoot($t2)]($t4)
+ 30: return ($t2, $t3)
 }
 
 
@@ -730,13 +718,11 @@ pub fun TestPackUnpack::public_update_value($t0|s: TestPackUnpack::S, $t1|v: u64
   2: $t4 := borrow_local($t2)
   3: unpack_ref($t4)
   4: $t5 := borrow_field<TestPackUnpack::S>.value($t4)
-  5: unpack_ref($t5)
-  6: write_ref($t5, $t3)
-  7: pack_ref($t5)
-  8: write_back[Reference($t4)]($t5)
-  9: pack_ref($t4)
- 10: write_back[LocalRoot($t2)]($t4)
- 11: return $t2
+  5: write_ref($t5, $t3)
+  6: write_back[Reference($t4)]($t5)
+  7: pack_ref($t4)
+  8: write_back[LocalRoot($t2)]($t4)
+  9: return $t2
 }
 
 
@@ -785,17 +771,15 @@ pub fun TestPackUnpack::select_value_violating_invariant_incorrect($t0|r: TestPa
   4: unpack_ref($t1)
   5: $t4 := 0
   6: $t5 := borrow_field<TestPackUnpack::S>.value($t1)
-  7: unpack_ref($t5)
-  8: write_ref($t5, $t4)
-  9: pack_ref($t5)
- 10: write_back[Reference($t1)]($t5)
- 11: $t6 := read_ref($t1)
- 12: pack_ref($t1)
- 13: write_back[Reference($t3)]($t1)
- 14: pack_ref($t3)
- 15: write_back[LocalRoot($t2)]($t3)
- 16: $t7 := TestPackUnpack::read_S_from_immutable($t6)
- 17: return ($t7, $t2)
+  7: write_ref($t5, $t4)
+  8: write_back[Reference($t1)]($t5)
+  9: $t6 := read_ref($t1)
+ 10: pack_ref($t1)
+ 11: write_back[Reference($t3)]($t1)
+ 12: pack_ref($t3)
+ 13: write_back[LocalRoot($t2)]($t3)
+ 14: $t7 := TestPackUnpack::read_S_from_immutable($t6)
+ 15: return ($t7, $t2)
 }
 
 
@@ -819,16 +803,14 @@ pub fun TestPackUnpack::update_ref_changed($t0|r: TestPackUnpack::R): (u64, Test
   6: $t6 := 2
   7: $t7 := +($t5, $t6)
   8: $t8 := borrow_field<TestPackUnpack::S>.value($t1)
-  9: unpack_ref($t8)
- 10: write_ref($t8, $t7)
- 11: pack_ref($t8)
- 12: write_back[Reference($t1)]($t8)
- 13: $t9 := get_field<TestPackUnpack::S>.value($t1)
- 14: pack_ref($t1)
- 15: write_back[Reference($t4)]($t1)
- 16: pack_ref($t4)
- 17: write_back[LocalRoot($t3)]($t4)
- 18: return ($t9, $t3)
+  9: write_ref($t8, $t7)
+ 10: write_back[Reference($t1)]($t8)
+ 11: $t9 := get_field<TestPackUnpack::S>.value($t1)
+ 12: pack_ref($t1)
+ 13: write_back[Reference($t4)]($t1)
+ 14: pack_ref($t4)
+ 15: write_back[LocalRoot($t3)]($t4)
+ 16: return ($t9, $t3)
 }
 
 

--- a/language/move-prover/bytecode/tests/eliminate_mut_refs/basic_test.exp
+++ b/language/move-prover/bytecode/tests/eliminate_mut_refs/basic_test.exp
@@ -143,16 +143,16 @@ fun TestEliminateMutRefs::test7($t0|b: bool) {
   6: $t8 := borrow_local($t1)
   7: $t3 := $t8
   8: $t9 := copy($t0)
-  9: if ($t9) goto L0 else goto L1
- 10: L1:
- 11: goto L2
- 12: L0:
+  9: if ($t9) goto 12 else goto 10
+ 10: label L1
+ 11: goto 18
+ 12: label L0
  13: $t10 := move($t3)
  14: destroy($t10)
  15: $t11 := borrow_local($t2)
  16: $t3 := $t11
- 17: goto L2
- 18: L2:
+ 17: goto 18
+ 18: label L2
  19: $t12 := move($t3)
  20: $t13 := 0
  21: TestEliminateMutRefs::test3($t12, $t13)
@@ -199,15 +199,15 @@ fun TestEliminateMutRefs::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestEli
   5: $t4 := $t9
   6: $t10 := borrow_local($t4)
   7: $t5 := $t10
-  8: goto L7
-  9: L7:
+  8: goto 9
+  9: label L7
  10: $t11 := 0
  11: $t12 := copy($t1)
  12: $t13 := <($t11, $t12)
- 13: if ($t13) goto L0 else goto L1
- 14: L1:
- 15: goto L2
- 16: L0:
+ 13: if ($t13) goto 16 else goto 14
+ 14: label L1
+ 15: goto 41
+ 16: label L0
  17: $t14 := move($t5)
  18: destroy($t14)
  19: $t15 := copy($t1)
@@ -215,43 +215,43 @@ fun TestEliminateMutRefs::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestEli
  21: $t17 := /($t15, $t16)
  22: $t18 := 0
  23: $t19 := ==($t17, $t18)
- 24: if ($t19) goto L3 else goto L4
- 25: L4:
- 26: goto L5
- 27: L3:
+ 24: if ($t19) goto 27 else goto 25
+ 25: label L4
+ 26: goto 31
+ 27: label L3
  28: $t20 := borrow_local($t3)
  29: $t5 := $t20
- 30: goto L6
- 31: L5:
+ 30: goto 35
+ 31: label L5
  32: $t21 := borrow_local($t4)
  33: $t5 := $t21
- 34: goto L6
- 35: L6:
+ 34: goto 35
+ 35: label L6
  36: $t22 := copy($t1)
  37: $t23 := 1
  38: $t24 := -($t22, $t23)
  39: $t1 := $t24
- 40: goto L7
- 41: L2:
+ 40: goto 9
+ 41: label L2
  42: $t25 := copy($t0)
- 43: if ($t25) goto L8 else goto L9
- 44: L9:
- 45: goto L10
- 46: L8:
+ 43: if ($t25) goto 46 else goto 44
+ 44: label L9
+ 45: goto 53
+ 46: label L8
  47: $t26 := move($t5)
  48: destroy($t26)
  49: $t27 := move($t2)
  50: $t28 := 0
  51: TestEliminateMutRefs::test3($t27, $t28)
- 52: goto L11
- 53: L10:
+ 52: goto 60
+ 53: label L10
  54: $t29 := move($t2)
  55: destroy($t29)
  56: $t30 := move($t5)
  57: $t31 := 0
  58: TestEliminateMutRefs::test3($t30, $t31)
- 59: goto L11
- 60: L11:
+ 59: goto 60
+ 60: label L11
  61: return ()
 }
 
@@ -432,16 +432,16 @@ fun TestEliminateMutRefs::test7($t0|b: bool) {
   7: $t8 := borrow_local($t1)
   8: $t3 := $t8
   9: $t9 := copy($t14)
- 10: if ($t9) goto L0 else goto L1
- 11: L1:
- 12: goto L2
- 13: L0:
+ 10: if ($t9) goto 13 else goto 11
+ 11: label L1
+ 12: goto 19
+ 13: label L0
  14: $t10 := move($t3)
  15: destroy($t10)
  16: $t11 := borrow_local($t2)
  17: $t3 := $t11
- 18: goto L2
- 19: L2:
+ 18: goto 19
+ 19: label L2
  20: $t12 := move($t3)
  21: $t13 := 0
  22: $t15 := read_ref($t12)
@@ -499,15 +499,15 @@ fun TestEliminateMutRefs::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: TestEliminat
   9: $t4 := $t9
  10: $t10 := borrow_local($t4)
  11: $t5 := $t10
- 12: goto L7
- 13: L7:
+ 12: goto 13
+ 13: label L7
  14: $t11 := 0
  15: $t12 := copy($t33)
  16: $t13 := <($t11, $t12)
- 17: if ($t13) goto L0 else goto L1
- 18: L1:
- 19: goto L2
- 20: L0:
+ 17: if ($t13) goto 20 else goto 18
+ 18: label L1
+ 19: goto 45
+ 20: label L0
  21: $t14 := move($t5)
  22: destroy($t14)
  23: $t15 := copy($t33)
@@ -515,29 +515,29 @@ fun TestEliminateMutRefs::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: TestEliminat
  25: $t17 := /($t15, $t16)
  26: $t18 := 0
  27: $t19 := ==($t17, $t18)
- 28: if ($t19) goto L3 else goto L4
- 29: L4:
- 30: goto L5
- 31: L3:
+ 28: if ($t19) goto 31 else goto 29
+ 29: label L4
+ 30: goto 35
+ 31: label L3
  32: $t20 := borrow_local($t3)
  33: $t5 := $t20
- 34: goto L6
- 35: L5:
+ 34: goto 39
+ 35: label L5
  36: $t21 := borrow_local($t4)
  37: $t5 := $t21
- 38: goto L6
- 39: L6:
+ 38: goto 39
+ 39: label L6
  40: $t22 := copy($t33)
  41: $t23 := 1
  42: $t24 := -($t22, $t23)
  43: $t33 := $t24
- 44: goto L7
- 45: L2:
+ 44: goto 13
+ 45: label L2
  46: $t25 := copy($t32)
- 47: if ($t25) goto L8 else goto L9
- 48: L9:
- 49: goto L10
- 50: L8:
+ 47: if ($t25) goto 50 else goto 48
+ 48: label L9
+ 49: goto 59
+ 50: label L8
  51: $t26 := move($t5)
  52: destroy($t26)
  53: $t27 := move($t35)
@@ -545,8 +545,8 @@ fun TestEliminateMutRefs::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: TestEliminat
  55: $t36 := read_ref($t27)
  56: $t36 := TestEliminateMutRefs::test3($t36, $t28)
  57: write_ref($t27, $t36)
- 58: goto L11
- 59: L10:
+ 58: goto 68
+ 59: label L10
  60: $t29 := move($t35)
  61: destroy($t29)
  62: $t30 := move($t5)
@@ -554,7 +554,7 @@ fun TestEliminateMutRefs::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: TestEliminat
  64: $t36 := read_ref($t30)
  65: $t36 := TestEliminateMutRefs::test3($t36, $t31)
  66: write_ref($t30, $t36)
- 67: goto L11
- 68: L11:
+ 67: goto 68
+ 68: label L11
  69: return $t34
 }

--- a/language/move-prover/bytecode/tests/from_move/regression_generic_and_native_type.exp
+++ b/language/move-prover/bytecode/tests/from_move/regression_generic_and_native_type.exp
@@ -13,21 +13,21 @@ pub fun Vector::append<$tv0>($t0|lhs: &mut vector<#0>, $t1|other: vector<#0>) {
      var $t10: vector<#0>
   0: $t2 := borrow_local($t1)
   1: Vector::reverse<#0>($t2)
-  2: goto L3
-  3: L3:
+  2: goto 3
+  3: label L3
   4: $t3 := borrow_local($t1)
   5: $t4 := Vector::is_empty<#0>($t3)
   6: $t5 := !($t4)
-  7: if ($t5) goto L0 else goto L1
-  8: L1:
-  9: goto L2
- 10: L0:
+  7: if ($t5) goto 10 else goto 8
+  8: label L1
+  9: goto 16
+ 10: label L0
  11: $t6 := copy($t0)
  12: $t7 := borrow_local($t1)
  13: $t8 := Vector::pop_back<#0>($t7)
  14: Vector::push_back<#0>($t6, $t8)
- 15: goto L3
- 16: L2:
+ 15: goto 3
+ 16: label L2
  17: $t9 := move($t0)
  18: destroy($t9)
  19: $t10 := move($t1)
@@ -75,37 +75,37 @@ pub fun Vector::contains<$tv0>($t0|v: &vector<#0>, $t1|e: &#0): bool {
   2: $t5 := copy($t0)
   3: $t6 := Vector::length<#0>($t5)
   4: $t3 := $t6
-  5: goto L6
-  6: L6:
+  5: goto 6
+  6: label L6
   7: $t7 := copy($t2)
   8: $t8 := copy($t3)
   9: $t9 := <($t7, $t8)
- 10: if ($t9) goto L0 else goto L1
- 11: L1:
- 12: goto L2
- 13: L0:
+ 10: if ($t9) goto 13 else goto 11
+ 11: label L1
+ 12: goto 35
+ 13: label L0
  14: $t10 := copy($t0)
  15: $t11 := copy($t2)
  16: $t12 := Vector::borrow<#0>($t10, $t11)
  17: $t13 := copy($t1)
  18: $t14 := ==($t12, $t13)
- 19: if ($t14) goto L3 else goto L4
- 20: L4:
- 21: goto L5
- 22: L3:
+ 19: if ($t14) goto 22 else goto 20
+ 20: label L4
+ 21: goto 29
+ 22: label L3
  23: $t15 := move($t0)
  24: destroy($t15)
  25: $t16 := move($t1)
  26: destroy($t16)
  27: $t17 := true
  28: return $t17
- 29: L5:
+ 29: label L5
  30: $t18 := copy($t2)
  31: $t19 := 1
  32: $t20 := +($t18, $t19)
  33: $t2 := $t20
- 34: goto L6
- 35: L2:
+ 34: goto 6
+ 35: label L2
  36: $t21 := move($t0)
  37: destroy($t21)
  38: $t22 := move($t1)
@@ -156,24 +156,24 @@ pub fun Vector::index_of<$tv0>($t0|v: &vector<#0>, $t1|e: &#0): (bool, u64) {
   2: $t5 := copy($t0)
   3: $t6 := Vector::length<#0>($t5)
   4: $t3 := $t6
-  5: goto L6
-  6: L6:
+  5: goto 6
+  6: label L6
   7: $t7 := copy($t2)
   8: $t8 := copy($t3)
   9: $t9 := <($t7, $t8)
- 10: if ($t9) goto L0 else goto L1
- 11: L1:
- 12: goto L2
- 13: L0:
+ 10: if ($t9) goto 13 else goto 11
+ 11: label L1
+ 12: goto 36
+ 13: label L0
  14: $t10 := copy($t0)
  15: $t11 := copy($t2)
  16: $t12 := Vector::borrow<#0>($t10, $t11)
  17: $t13 := copy($t1)
  18: $t14 := ==($t12, $t13)
- 19: if ($t14) goto L3 else goto L4
- 20: L4:
- 21: goto L5
- 22: L3:
+ 19: if ($t14) goto 22 else goto 20
+ 20: label L4
+ 21: goto 30
+ 22: label L3
  23: $t15 := move($t0)
  24: destroy($t15)
  25: $t16 := move($t1)
@@ -181,13 +181,13 @@ pub fun Vector::index_of<$tv0>($t0|v: &vector<#0>, $t1|e: &#0): (bool, u64) {
  27: $t17 := true
  28: $t18 := copy($t2)
  29: return ($t17, $t18)
- 30: L5:
+ 30: label L5
  31: $t19 := copy($t2)
  32: $t20 := 1
  33: $t21 := +($t19, $t20)
  34: $t2 := $t21
- 35: goto L6
- 36: L2:
+ 35: goto 6
+ 36: label L2
  37: $t22 := move($t0)
  38: destroy($t22)
  39: $t23 := move($t1)
@@ -263,28 +263,28 @@ pub fun Vector::remove<$tv0>($t0|v: &mut vector<#0>, $t1|i: u64): #0 {
   4: $t8 := copy($t1)
   5: $t9 := copy($t2)
   6: $t10 := >=($t8, $t9)
-  7: if ($t10) goto L0 else goto L1
-  8: L1:
-  9: goto L2
- 10: L0:
+  7: if ($t10) goto 10 else goto 8
+  8: label L1
+  9: goto 15
+ 10: label L0
  11: $t11 := move($t0)
  12: destroy($t11)
  13: $t12 := 0
  14: abort($t12)
- 15: L2:
+ 15: label L2
  16: $t13 := copy($t2)
  17: $t14 := 1
  18: $t15 := -($t13, $t14)
  19: $t2 := $t15
- 20: goto L6
- 21: L6:
+ 20: goto 21
+ 21: label L6
  22: $t16 := copy($t1)
  23: $t17 := copy($t2)
  24: $t18 := <($t16, $t17)
- 25: if ($t18) goto L3 else goto L4
- 26: L4:
- 27: goto L5
- 28: L3:
+ 25: if ($t18) goto 28 else goto 26
+ 26: label L4
+ 27: goto 42
+ 28: label L3
  29: $t19 := copy($t0)
  30: $t4 := $t19
  31: $t20 := copy($t1)
@@ -297,8 +297,8 @@ pub fun Vector::remove<$tv0>($t0|v: &mut vector<#0>, $t1|i: u64): #0 {
  38: $t25 := move($t3)
  39: $t26 := copy($t1)
  40: Vector::swap<#0>($t24, $t25, $t26)
- 41: goto L6
- 42: L5:
+ 41: goto 21
+ 42: label L5
  43: $t27 := move($t0)
  44: $t28 := Vector::pop_back<#0>($t27)
  45: return $t28
@@ -341,29 +341,29 @@ pub fun Vector::reverse<$tv0>($t0|v: &mut vector<#0>) {
   4: $t7 := copy($t3)
   5: $t8 := 0
   6: $t9 := ==($t7, $t8)
-  7: if ($t9) goto L0 else goto L1
-  8: L1:
-  9: goto L2
- 10: L0:
+  7: if ($t9) goto 10 else goto 8
+  8: label L1
+  9: goto 14
+ 10: label L0
  11: $t10 := move($t0)
  12: destroy($t10)
  13: return ()
- 14: L2:
+ 14: label L2
  15: $t11 := 0
  16: $t2 := $t11
  17: $t12 := copy($t3)
  18: $t13 := 1
  19: $t14 := -($t12, $t13)
  20: $t1 := $t14
- 21: goto L6
- 22: L6:
+ 21: goto 22
+ 22: label L6
  23: $t15 := copy($t2)
  24: $t16 := copy($t1)
  25: $t17 := <($t15, $t16)
- 26: if ($t17) goto L3 else goto L4
- 27: L4:
- 28: goto L5
- 29: L3:
+ 26: if ($t17) goto 29 else goto 27
+ 27: label L4
+ 28: goto 43
+ 29: label L3
  30: $t18 := copy($t0)
  31: $t19 := copy($t2)
  32: $t20 := copy($t1)
@@ -376,8 +376,8 @@ pub fun Vector::reverse<$tv0>($t0|v: &mut vector<#0>) {
  39: $t25 := 1
  40: $t26 := -($t24, $t25)
  41: $t1 := $t26
- 42: goto L6
- 43: L5:
+ 42: goto 22
+ 43: label L5
  44: $t27 := move($t0)
  45: destroy($t27)
  46: return ()

--- a/language/move-prover/bytecode/tests/from_move/smoke_test.exp
+++ b/language/move-prover/bytecode/tests/from_move/smoke_test.exp
@@ -32,13 +32,13 @@ fun SmokeTest::arithmetic_ops($t0|a: u64): (u64, u64) {
   2: $t3 := copy($t1)
   3: $t4 := 2
   4: $t5 := !=($t3, $t4)
-  5: if ($t5) goto L0 else goto L1
-  6: L1:
-  7: goto L2
-  8: L0:
+  5: if ($t5) goto 8 else goto 6
+  6: label L1
+  7: goto 11
+  8: label L0
   9: $t6 := 42
  10: abort($t6)
- 11: L2:
+ 11: label L2
  12: $t7 := copy($t1)
  13: $t8 := copy($t0)
  14: return ($t7, $t8)
@@ -77,52 +77,52 @@ fun SmokeTest::bool_ops($t0|a: u64, $t1|b: u64): (bool, bool) {
   0: $t6 := copy($t0)
   1: $t7 := copy($t1)
   2: $t8 := >($t6, $t7)
-  3: if ($t8) goto L0 else goto L1
-  4: L1:
-  5: goto L2
-  6: L0:
+  3: if ($t8) goto 6 else goto 4
+  4: label L1
+  5: goto 12
+  6: label L0
   7: $t9 := copy($t0)
   8: $t10 := copy($t1)
   9: $t11 := >=($t9, $t10)
  10: $t4 := $t11
- 11: goto L3
- 12: L2:
+ 11: goto 16
+ 12: label L2
  13: $t12 := false
  14: $t4 := $t12
- 15: goto L3
- 16: L3:
+ 15: goto 16
+ 16: label L3
  17: $t13 := move($t4)
  18: $t2 := $t13
  19: $t14 := copy($t0)
  20: $t15 := copy($t1)
  21: $t16 := <($t14, $t15)
- 22: if ($t16) goto L4 else goto L5
- 23: L5:
- 24: goto L6
- 25: L4:
+ 22: if ($t16) goto 25 else goto 23
+ 23: label L5
+ 24: goto 29
+ 25: label L4
  26: $t17 := true
  27: $t5 := $t17
- 28: goto L7
- 29: L6:
+ 28: goto 35
+ 29: label L6
  30: $t18 := copy($t0)
  31: $t19 := copy($t1)
  32: $t20 := <=($t18, $t19)
  33: $t5 := $t20
- 34: goto L7
- 35: L7:
+ 34: goto 35
+ 35: label L7
  36: $t21 := move($t5)
  37: $t3 := $t21
  38: $t22 := copy($t2)
  39: $t23 := copy($t3)
  40: $t24 := !=($t22, $t23)
  41: $t25 := !($t24)
- 42: if ($t25) goto L8 else goto L9
- 43: L9:
- 44: goto L10
- 45: L8:
+ 42: if ($t25) goto 45 else goto 43
+ 43: label L9
+ 44: goto 48
+ 45: label L8
  46: $t26 := 42
  47: abort($t26)
- 48: L10:
+ 48: label L10
  49: $t27 := copy($t2)
  50: $t28 := copy($t3)
  51: return ($t27, $t28)
@@ -339,22 +339,22 @@ fun SmokeTest::ref_A($t0|a: address, $t1|b: bool): SmokeTest::A {
      var $t23: u64
      var $t24: SmokeTest::A
   0: $t7 := copy($t1)
-  1: if ($t7) goto L0 else goto L1
-  2: L1:
-  3: goto L2
-  4: L0:
+  1: if ($t7) goto 4 else goto 2
+  2: label L1
+  3: goto 10
+  4: label L0
   5: $t8 := copy($t0)
   6: $t9 := 1
   7: $t10 := pack SmokeTest::A($t8, $t9)
   8: $t4 := $t10
-  9: goto L3
- 10: L2:
+  9: goto 16
+ 10: label L2
  11: $t11 := copy($t0)
  12: $t12 := 42
  13: $t13 := pack SmokeTest::A($t11, $t12)
  14: $t4 := $t13
- 15: goto L3
- 16: L3:
+ 15: goto 16
+ 16: label L3
  17: $t14 := move($t4)
  18: $t5 := $t14
  19: $t15 := borrow_local($t5)
@@ -368,13 +368,13 @@ fun SmokeTest::ref_A($t0|a: address, $t1|b: bool): SmokeTest::A {
  27: $t20 := copy($t3)
  28: $t21 := 42
  29: $t22 := !=($t20, $t21)
- 30: if ($t22) goto L4 else goto L5
- 31: L5:
- 32: goto L6
- 33: L4:
+ 30: if ($t22) goto 33 else goto 31
+ 31: label L5
+ 32: goto 36
+ 33: label L4
  34: $t23 := 42
  35: abort($t23)
- 36: L6:
+ 36: label L6
  37: $t24 := move($t5)
  38: return $t24
 }

--- a/language/move-prover/bytecode/tests/from_move/specs-in-fun.exp
+++ b/language/move-prover/bytecode/tests/from_move/specs-in-fun.exp
@@ -10,22 +10,22 @@ fun TestSpecBlock::looping($t0|x: u64): u64 {
      var $t6: u64
      var $t7: u64
   0: assume Le($t0, 10)
-  1: goto L3
-  2: L3:
+  1: goto 2
+  2: label L3
   3: $t1 := copy($t0)
   4: $t2 := 10
   5: $t3 := <($t1, $t2)
-  6: if ($t3) goto L0 else goto L1
-  7: L1:
-  8: goto L2
-  9: L0:
+  6: if ($t3) goto 9 else goto 7
+  7: label L1
+  8: goto 16
+  9: label L0
  10: assume Lt($t0, 10)
  11: $t4 := copy($t0)
  12: $t5 := 1
  13: $t6 := +($t4, $t5)
  14: $t0 := $t6
- 15: goto L3
- 16: L2:
+ 15: goto 2
+ 16: label L2
  17: assert Eq<u64>($t0, 10)
  18: $t7 := copy($t0)
  19: return $t7
@@ -43,13 +43,13 @@ fun TestSpecBlock::simple1($t0|x: u64, $t1|y: u64) {
   1: $t3 := copy($t1)
   2: $t4 := >($t2, $t3)
   3: $t5 := !($t4)
-  4: if ($t5) goto L0 else goto L1
-  5: L1:
-  6: goto L2
-  7: L0:
+  4: if ($t5) goto 7 else goto 5
+  5: label L1
+  6: goto 10
+  7: label L0
   8: $t6 := 1
   9: abort($t6)
- 10: L2:
+ 10: label L2
  11: assert Gt($t0, $t1)
  12: return ()
 }

--- a/language/move-prover/bytecode/tests/livevar/basic_test.exp
+++ b/language/move-prover/bytecode/tests/livevar/basic_test.exp
@@ -40,16 +40,16 @@ fun TestLiveVars::test2($t0|b: bool): u64 {
   6: $t8 := borrow_local($t1)
   7: $t3 := $t8
   8: $t9 := copy($t0)
-  9: if ($t9) goto L0 else goto L1
- 10: L1:
- 11: goto L2
- 12: L0:
+  9: if ($t9) goto 12 else goto 10
+ 10: label L1
+ 11: goto 18
+ 12: label L0
  13: $t10 := move($t3)
  14: destroy($t10)
  15: $t11 := borrow_local($t2)
  16: $t3 := $t11
- 17: goto L2
- 18: L2:
+ 17: goto 18
+ 18: label L2
  19: $t12 := move($t3)
  20: $t13 := TestLiveVars::test1($t12)
  21: return $t13
@@ -86,15 +86,15 @@ fun TestLiveVars::test3($t0|n: u64, $t1|r_ref: &TestLiveVars::R): u64 {
   3: $t6 := 4
   4: $t7 := pack TestLiveVars::R($t6)
   5: $t3 := $t7
-  6: goto L7
-  7: L7:
+  6: goto 7
+  7: label L7
   8: $t8 := 0
   9: $t9 := copy($t0)
  10: $t10 := <($t8, $t9)
- 11: if ($t10) goto L0 else goto L1
- 12: L1:
- 13: goto L2
- 14: L0:
+ 11: if ($t10) goto 14 else goto 12
+ 12: label L1
+ 13: goto 39
+ 14: label L0
  15: $t11 := move($t1)
  16: destroy($t11)
  17: $t12 := copy($t0)
@@ -102,24 +102,24 @@ fun TestLiveVars::test3($t0|n: u64, $t1|r_ref: &TestLiveVars::R): u64 {
  19: $t14 := /($t12, $t13)
  20: $t15 := 0
  21: $t16 := ==($t14, $t15)
- 22: if ($t16) goto L3 else goto L4
- 23: L4:
- 24: goto L5
- 25: L3:
+ 22: if ($t16) goto 25 else goto 23
+ 23: label L4
+ 24: goto 29
+ 25: label L3
  26: $t17 := borrow_local($t2)
  27: $t1 := $t17
- 28: goto L6
- 29: L5:
+ 28: goto 33
+ 29: label L5
  30: $t18 := borrow_local($t3)
  31: $t1 := $t18
- 32: goto L6
- 33: L6:
+ 32: goto 33
+ 33: label L6
  34: $t19 := copy($t0)
  35: $t20 := 1
  36: $t21 := -($t19, $t20)
  37: $t0 := $t21
- 38: goto L7
- 39: L2:
+ 38: goto 7
+ 39: label L2
  40: $t22 := move($t1)
  41: $t23 := TestLiveVars::test1($t22)
  42: return $t23
@@ -162,21 +162,21 @@ fun TestLiveVars::test2($t0|b: bool): u64 {
      // live vars: r1, r2, $t4
   5: $t3 := $t1
      // live vars: r2, r_ref, $t4
-  6: if ($t4) goto L0 else goto L1
+  6: if ($t4) goto 9 else goto 7
      // live vars: r_ref
-  7: L1:
+  7: label L1
      // live vars: r_ref
-  8: goto L2
+  8: goto 13
      // live vars: r2, r_ref
-  9: L0:
+  9: label L0
      // live vars: r2, r_ref
  10: destroy($t3)
      // live vars: r2
  11: $t3 := $t2
      // live vars: r_ref
- 12: goto L2
+ 12: goto 13
      // live vars: r_ref
- 13: L2:
+ 13: label L2
      // live vars: r_ref
  14: $t7 := TestLiveVars::test1($t3)
      // live vars: $t7
@@ -213,21 +213,21 @@ fun TestLiveVars::test3($t0|n: u64, $t1|r_ref: TestLiveVars::R): u64 {
      // live vars: r1, $t4, $t5, $t7
   5: $t3 := pack TestLiveVars::R($t7)
      // live vars: r1, r2, $t4, $t5
-  6: goto L7
+  6: goto 7
      // live vars: r1, r2, $t4, $t5
-  7: L7:
+  7: label L7
      // live vars: r1, r2, $t4, $t5
   8: $t8 := 0
      // live vars: r1, r2, $t4, $t5, $t8
   9: $t9 := <($t8, $t4)
      // live vars: r1, r2, $t4, $t5, $t9
- 10: if ($t9) goto L0 else goto L1
+ 10: if ($t9) goto 13 else goto 11
      // live vars: $t5
- 11: L1:
+ 11: label L1
      // live vars: $t5
- 12: goto L2
+ 12: goto 32
      // live vars: r1, r2, $t4, $t5
- 13: L0:
+ 13: label L0
      // live vars: r1, r2, $t4, $t5
  14: destroy($t5)
      // live vars: r1, r2, $t4
@@ -239,33 +239,33 @@ fun TestLiveVars::test3($t0|n: u64, $t1|r_ref: TestLiveVars::R): u64 {
      // live vars: r1, r2, $t4, $t11, $t12
  18: $t13 := ==($t11, $t12)
      // live vars: r1, r2, $t4, $t13
- 19: if ($t13) goto L3 else goto L4
+ 19: if ($t13) goto 22 else goto 20
      // live vars: r1, r2, $t4
- 20: L4:
+ 20: label L4
      // live vars: r1, r2, $t4
- 21: goto L5
+ 21: goto 25
      // live vars: r1, r2, $t4
- 22: L3:
+ 22: label L3
      // live vars: r1, r2, $t4
  23: $t5 := $t2
      // live vars: r1, r2, $t4, $t5
- 24: goto L6
+ 24: goto 28
      // live vars: r1, r2, $t4
- 25: L5:
+ 25: label L5
      // live vars: r1, r2, $t4
  26: $t5 := $t3
      // live vars: r1, r2, $t4, $t5
- 27: goto L6
+ 27: goto 28
      // live vars: r1, r2, $t4, $t5
- 28: L6:
+ 28: label L6
      // live vars: r1, r2, $t4, $t5
  29: $t14 := 1
      // live vars: r1, r2, $t4, $t5, $t14
  30: $t4 := -($t4, $t14)
      // live vars: r1, r2, $t4, $t5
- 31: goto L7
+ 31: goto 7
      // live vars: $t5
- 32: L2:
+ 32: label L2
      // live vars: $t5
  33: $t15 := TestLiveVars::test1($t5)
      // live vars: $t15

--- a/language/move-prover/bytecode/tests/memory_instr/basic_test.exp
+++ b/language/move-prover/bytecode/tests/memory_instr/basic_test.exp
@@ -143,16 +143,16 @@ fun TestPackref::test7($t0|b: bool) {
   6: $t8 := borrow_local($t1)
   7: $t3 := $t8
   8: $t9 := copy($t0)
-  9: if ($t9) goto L0 else goto L1
- 10: L1:
- 11: goto L2
- 12: L0:
+  9: if ($t9) goto 12 else goto 10
+ 10: label L1
+ 11: goto 18
+ 12: label L0
  13: $t10 := move($t3)
  14: destroy($t10)
  15: $t11 := borrow_local($t2)
  16: $t3 := $t11
- 17: goto L2
- 18: L2:
+ 17: goto 18
+ 18: label L2
  19: $t12 := move($t3)
  20: $t13 := 0
  21: TestPackref::test3($t12, $t13)
@@ -199,15 +199,15 @@ fun TestPackref::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestPackref::R) 
   5: $t4 := $t9
   6: $t10 := borrow_local($t4)
   7: $t5 := $t10
-  8: goto L7
-  9: L7:
+  8: goto 9
+  9: label L7
  10: $t11 := 0
  11: $t12 := copy($t1)
  12: $t13 := <($t11, $t12)
- 13: if ($t13) goto L0 else goto L1
- 14: L1:
- 15: goto L2
- 16: L0:
+ 13: if ($t13) goto 16 else goto 14
+ 14: label L1
+ 15: goto 41
+ 16: label L0
  17: $t14 := move($t5)
  18: destroy($t14)
  19: $t15 := copy($t1)
@@ -215,43 +215,43 @@ fun TestPackref::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestPackref::R) 
  21: $t17 := /($t15, $t16)
  22: $t18 := 0
  23: $t19 := ==($t17, $t18)
- 24: if ($t19) goto L3 else goto L4
- 25: L4:
- 26: goto L5
- 27: L3:
+ 24: if ($t19) goto 27 else goto 25
+ 25: label L4
+ 26: goto 31
+ 27: label L3
  28: $t20 := borrow_local($t3)
  29: $t5 := $t20
- 30: goto L6
- 31: L5:
+ 30: goto 35
+ 31: label L5
  32: $t21 := borrow_local($t4)
  33: $t5 := $t21
- 34: goto L6
- 35: L6:
+ 34: goto 35
+ 35: label L6
  36: $t22 := copy($t1)
  37: $t23 := 1
  38: $t24 := -($t22, $t23)
  39: $t1 := $t24
- 40: goto L7
- 41: L2:
+ 40: goto 9
+ 41: label L2
  42: $t25 := copy($t0)
- 43: if ($t25) goto L8 else goto L9
- 44: L9:
- 45: goto L10
- 46: L8:
+ 43: if ($t25) goto 46 else goto 44
+ 44: label L9
+ 45: goto 53
+ 46: label L8
  47: $t26 := move($t5)
  48: destroy($t26)
  49: $t27 := move($t2)
  50: $t28 := 0
  51: TestPackref::test3($t27, $t28)
- 52: goto L11
- 53: L10:
+ 52: goto 60
+ 53: label L10
  54: $t29 := move($t2)
  55: destroy($t29)
  56: $t30 := move($t5)
  57: $t31 := 0
  58: TestPackref::test3($t30, $t31)
- 59: goto L11
- 60: L11:
+ 59: goto 60
+ 60: label L11
  61: return ()
 }
 
@@ -267,16 +267,12 @@ fun TestPackref::test1(): TestPackref::R {
   0: $t3 := 3
   1: $t0 := pack TestPackref::R($t3)
   2: $t1 := borrow_local($t0)
-  3: unpack_ref($t1)
-  4: $t2 := borrow_field<TestPackref::R>.x($t1)
-  5: unpack_ref($t2)
-  6: $t4 := 0
-  7: write_ref($t2, $t4)
-  8: pack_ref($t2)
-  9: write_back[Reference($t1)]($t2)
- 10: pack_ref($t1)
- 11: write_back[LocalRoot($t0)]($t1)
- 12: return $t0
+  3: $t2 := borrow_field<TestPackref::R>.x($t1)
+  4: $t4 := 0
+  5: write_ref($t2, $t4)
+  6: write_back[Reference($t1)]($t2)
+  7: write_back[LocalRoot($t0)]($t1)
+  8: return $t0
 }
 
 
@@ -304,17 +300,13 @@ pub fun TestPackref::test3($t0|r_ref: TestPackref::R, $t1|v: u64): TestPackref::
   0: $t3 := move($t0)
   1: $t4 := move($t1)
   2: $t5 := borrow_local($t3)
-  3: unpack_ref($t5)
-  4: $t2 := borrow_field<TestPackref::R>.x($t5)
-  5: unpack_ref($t2)
-  6: $t6 := read_ref($t2)
-  7: $t6 := TestPackref::test2($t6, $t4)
-  8: write_ref($t2, $t6)
-  9: pack_ref($t2)
- 10: write_back[Reference($t5)]($t2)
- 11: pack_ref($t5)
- 12: write_back[LocalRoot($t3)]($t5)
- 13: return $t3
+  3: $t2 := borrow_field<TestPackref::R>.x($t5)
+  4: $t6 := read_ref($t2)
+  5: $t6 := TestPackref::test2($t6, $t4)
+  6: write_ref($t2, $t6)
+  7: write_back[Reference($t5)]($t2)
+  8: write_back[LocalRoot($t3)]($t5)
+  9: return $t3
 }
 
 
@@ -328,14 +320,12 @@ fun TestPackref::test4(): TestPackref::R {
   0: $t2 := 3
   1: $t0 := pack TestPackref::R($t2)
   2: $t1 := borrow_local($t0)
-  3: unpack_ref($t1)
-  4: $t3 := 0
-  5: $t4 := read_ref($t1)
-  6: $t4 := TestPackref::test3($t4, $t3)
-  7: write_ref($t1, $t4)
-  8: pack_ref($t1)
-  9: write_back[LocalRoot($t0)]($t1)
- 10: return $t0
+  3: $t3 := 0
+  4: $t4 := read_ref($t1)
+  5: $t4 := TestPackref::test3($t4, $t3)
+  6: write_ref($t1, $t4)
+  7: write_back[LocalRoot($t0)]($t1)
+  8: return $t0
 }
 
 
@@ -366,21 +356,19 @@ fun TestPackref::test6(): TestPackref::R {
   0: $t3 := 3
   1: $t0 := pack TestPackref::R($t3)
   2: $t1 := borrow_local($t0)
-  3: unpack_ref_deep($t1)
-  4: $t4 := read_ref($t1)
-  5: ($t5, $t4) := TestPackref::test5($t4)
-  6: write_ref($t1, $t4)
-  7: splice[0 -> $t1]($t5)
-  8: $t2 := $t5
-  9: write_back[Reference($t1)]($t5)
- 10: $t6 := 0
- 11: $t7 := read_ref($t2)
- 12: $t7 := TestPackref::test2($t7, $t6)
- 13: write_ref($t2, $t7)
- 14: write_back[Reference($t1)]($t2)
- 15: pack_ref_deep($t1)
- 16: write_back[LocalRoot($t0)]($t1)
- 17: return $t0
+  3: $t4 := read_ref($t1)
+  4: ($t5, $t4) := TestPackref::test5($t4)
+  5: write_ref($t1, $t4)
+  6: splice[0 -> $t1]($t5)
+  7: $t2 := $t5
+  8: write_back[Reference($t1)]($t5)
+  9: $t6 := 0
+ 10: $t7 := read_ref($t2)
+ 11: $t7 := TestPackref::test2($t7, $t6)
+ 12: write_ref($t2, $t7)
+ 13: write_back[Reference($t1)]($t2)
+ 14: write_back[LocalRoot($t0)]($t1)
+ 15: return $t0
 }
 
 
@@ -400,26 +388,22 @@ fun TestPackref::test7($t0|b: bool) {
   3: $t6 := 4
   4: $t2 := pack TestPackref::R($t6)
   5: $t3 := borrow_local($t1)
-  6: unpack_ref($t3)
-  7: if ($t4) goto L0 else goto L1
-  8: L1:
-  9: goto L2
- 10: L0:
- 11: destroy($t3)
- 12: pack_ref($t3)
- 13: write_back[LocalRoot($t1)]($t3)
- 14: $t3 := borrow_local($t2)
- 15: unpack_ref($t3)
- 16: goto L2
- 17: L2:
- 18: $t7 := 0
- 19: $t8 := read_ref($t3)
- 20: $t8 := TestPackref::test3($t8, $t7)
- 21: write_ref($t3, $t8)
- 22: pack_ref($t3)
- 23: write_back[LocalRoot($t1)]($t3)
- 24: write_back[LocalRoot($t2)]($t3)
- 25: return ()
+  6: if ($t4) goto 9 else goto 7
+  7: label L1
+  8: goto 14
+  9: label L0
+ 10: destroy($t3)
+ 11: write_back[LocalRoot($t1)]($t3)
+ 12: $t3 := borrow_local($t2)
+ 13: goto 14
+ 14: label L2
+ 15: $t7 := 0
+ 16: $t8 := read_ref($t3)
+ 17: $t8 := TestPackref::test3($t8, $t7)
+ 18: write_ref($t3, $t8)
+ 19: write_back[LocalRoot($t1)]($t3)
+ 20: write_back[LocalRoot($t2)]($t3)
+ 21: return ()
 }
 
 
@@ -453,64 +437,58 @@ fun TestPackref::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: TestPackref::R): Test
   6: $t11 := 4
   7: $t4 := pack TestPackref::R($t11)
   8: $t5 := borrow_local($t4)
-  9: unpack_ref($t5)
- 10: goto L7
- 11: L7:
- 12: $t12 := 0
- 13: $t13 := <($t12, $t7)
- 14: if ($t13) goto L0 else goto L1
- 15: L1:
- 16: goto L2
- 17: L0:
- 18: destroy($t5)
- 19: pack_ref($t5)
- 20: write_back[LocalRoot($t3)]($t5)
- 21: write_back[LocalRoot($t4)]($t5)
- 22: $t14 := 2
- 23: $t15 := /($t7, $t14)
- 24: $t16 := 0
- 25: $t17 := ==($t15, $t16)
- 26: if ($t17) goto L3 else goto L4
- 27: L4:
- 28: goto L5
- 29: L3:
- 30: $t5 := borrow_local($t3)
- 31: unpack_ref($t5)
- 32: goto L6
- 33: L5:
- 34: $t5 := borrow_local($t4)
- 35: unpack_ref($t5)
- 36: goto L6
- 37: L6:
- 38: $t18 := 1
- 39: $t7 := -($t7, $t18)
- 40: goto L7
- 41: L2:
- 42: if ($t6) goto L8 else goto L9
- 43: L9:
- 44: goto L10
- 45: L8:
- 46: destroy($t5)
- 47: pack_ref($t5)
- 48: write_back[LocalRoot($t3)]($t5)
- 49: write_back[LocalRoot($t4)]($t5)
- 50: $t19 := 0
- 51: $t20 := read_ref($t9)
- 52: $t20 := TestPackref::test3($t20, $t19)
- 53: write_ref($t9, $t20)
- 54: write_back[LocalRoot($t8)]($t9)
- 55: goto L11
- 56: L10:
- 57: destroy($t9)
- 58: write_back[LocalRoot($t8)]($t9)
- 59: $t21 := 0
- 60: $t20 := read_ref($t5)
- 61: $t20 := TestPackref::test3($t20, $t21)
- 62: write_ref($t5, $t20)
- 63: pack_ref($t5)
- 64: write_back[LocalRoot($t3)]($t5)
- 65: write_back[LocalRoot($t4)]($t5)
- 66: goto L11
- 67: L11:
- 68: return $t8
+  9: goto 10
+ 10: label L7
+ 11: $t12 := 0
+ 12: $t13 := <($t12, $t7)
+ 13: if ($t13) goto 16 else goto 14
+ 14: label L1
+ 15: goto 37
+ 16: label L0
+ 17: destroy($t5)
+ 18: write_back[LocalRoot($t3)]($t5)
+ 19: write_back[LocalRoot($t4)]($t5)
+ 20: $t14 := 2
+ 21: $t15 := /($t7, $t14)
+ 22: $t16 := 0
+ 23: $t17 := ==($t15, $t16)
+ 24: if ($t17) goto 27 else goto 25
+ 25: label L4
+ 26: goto 30
+ 27: label L3
+ 28: $t5 := borrow_local($t3)
+ 29: goto 33
+ 30: label L5
+ 31: $t5 := borrow_local($t4)
+ 32: goto 33
+ 33: label L6
+ 34: $t18 := 1
+ 35: $t7 := -($t7, $t18)
+ 36: goto 10
+ 37: label L2
+ 38: if ($t6) goto 41 else goto 39
+ 39: label L9
+ 40: goto 51
+ 41: label L8
+ 42: destroy($t5)
+ 43: write_back[LocalRoot($t3)]($t5)
+ 44: write_back[LocalRoot($t4)]($t5)
+ 45: $t19 := 0
+ 46: $t20 := read_ref($t9)
+ 47: $t20 := TestPackref::test3($t20, $t19)
+ 48: write_ref($t9, $t20)
+ 49: write_back[LocalRoot($t8)]($t9)
+ 50: goto 61
+ 51: label L10
+ 52: destroy($t9)
+ 53: write_back[LocalRoot($t8)]($t9)
+ 54: $t21 := 0
+ 55: $t20 := read_ref($t5)
+ 56: $t20 := TestPackref::test3($t20, $t21)
+ 57: write_ref($t5, $t20)
+ 58: write_back[LocalRoot($t3)]($t5)
+ 59: write_back[LocalRoot($t4)]($t5)
+ 60: goto 61
+ 61: label L11
+ 62: return $t8
 }

--- a/language/move-prover/bytecode/tests/memory_instr/mut_ref.exp
+++ b/language/move-prover/bytecode/tests/memory_instr/mut_ref.exp
@@ -299,31 +299,23 @@ pub fun TestMutRefs::decrement_invalid($t0|x: TestMutRefs::T): TestMutRefs::T {
      var $t12: &mut u64
   0: $t2 := move($t0)
   1: $t3 := borrow_local($t2)
-  2: unpack_ref($t3)
-  3: $t4 := get_field<TestMutRefs::T>.value($t3)
-  4: $t5 := 1
-  5: $t6 := -($t4, $t5)
-  6: $t7 := borrow_field<TestMutRefs::T>.value($t3)
-  7: unpack_ref($t7)
-  8: write_ref($t7, $t6)
-  9: pack_ref($t7)
- 10: write_back[Reference($t3)]($t7)
- 11: pack_ref($t3)
- 12: write_back[LocalRoot($t2)]($t3)
- 13: $t8 := 0x0
- 14: $t1 := borrow_global<TestMutRefs::TSum>($t8)
- 15: unpack_ref($t1)
- 16: $t9 := get_field<TestMutRefs::TSum>.sum($t1)
- 17: $t10 := 1
- 18: $t11 := -($t9, $t10)
- 19: $t12 := borrow_field<TestMutRefs::TSum>.sum($t1)
- 20: unpack_ref($t12)
- 21: write_ref($t12, $t11)
- 22: pack_ref($t12)
- 23: write_back[Reference($t1)]($t12)
- 24: pack_ref($t1)
- 25: write_back[TestMutRefs::TSum]($t1)
- 26: return $t2
+  2: $t4 := get_field<TestMutRefs::T>.value($t3)
+  3: $t5 := 1
+  4: $t6 := -($t4, $t5)
+  5: $t7 := borrow_field<TestMutRefs::T>.value($t3)
+  6: write_ref($t7, $t6)
+  7: write_back[Reference($t3)]($t7)
+  8: write_back[LocalRoot($t2)]($t3)
+  9: $t8 := 0x0
+ 10: $t1 := borrow_global<TestMutRefs::TSum>($t8)
+ 11: $t9 := get_field<TestMutRefs::TSum>.sum($t1)
+ 12: $t10 := 1
+ 13: $t11 := -($t9, $t10)
+ 14: $t12 := borrow_field<TestMutRefs::TSum>.sum($t1)
+ 15: write_ref($t12, $t11)
+ 16: write_back[Reference($t1)]($t12)
+ 17: write_back[TestMutRefs::TSum]($t1)
+ 18: return $t2
 }
 
 
@@ -339,18 +331,14 @@ pub fun TestMutRefs::delete($t0|x: TestMutRefs::T) {
   0: $t3 := move($t0)
   1: $t4 := 0x0
   2: $t1 := borrow_global<TestMutRefs::TSum>($t4)
-  3: unpack_ref($t1)
-  4: $t2 := unpack TestMutRefs::T($t3)
-  5: $t5 := get_field<TestMutRefs::TSum>.sum($t1)
-  6: $t6 := -($t5, $t2)
-  7: $t7 := borrow_field<TestMutRefs::TSum>.sum($t1)
-  8: unpack_ref($t7)
-  9: write_ref($t7, $t6)
- 10: pack_ref($t7)
- 11: write_back[Reference($t1)]($t7)
- 12: pack_ref($t1)
- 13: write_back[TestMutRefs::TSum]($t1)
- 14: return ()
+  3: $t2 := unpack TestMutRefs::T($t3)
+  4: $t5 := get_field<TestMutRefs::TSum>.sum($t1)
+  5: $t6 := -($t5, $t2)
+  6: $t7 := borrow_field<TestMutRefs::TSum>.sum($t1)
+  7: write_ref($t7, $t6)
+  8: write_back[Reference($t1)]($t7)
+  9: write_back[TestMutRefs::TSum]($t1)
+ 10: return ()
 }
 
 
@@ -370,31 +358,23 @@ pub fun TestMutRefs::increment($t0|x: TestMutRefs::T): TestMutRefs::T {
      var $t12: &mut u64
   0: $t2 := move($t0)
   1: $t3 := borrow_local($t2)
-  2: unpack_ref($t3)
-  3: $t4 := get_field<TestMutRefs::T>.value($t3)
-  4: $t5 := 1
-  5: $t6 := +($t4, $t5)
-  6: $t7 := borrow_field<TestMutRefs::T>.value($t3)
-  7: unpack_ref($t7)
-  8: write_ref($t7, $t6)
-  9: pack_ref($t7)
- 10: write_back[Reference($t3)]($t7)
- 11: pack_ref($t3)
- 12: write_back[LocalRoot($t2)]($t3)
- 13: $t8 := 0x0
- 14: $t1 := borrow_global<TestMutRefs::TSum>($t8)
- 15: unpack_ref($t1)
- 16: $t9 := get_field<TestMutRefs::TSum>.sum($t1)
- 17: $t10 := 1
- 18: $t11 := +($t9, $t10)
- 19: $t12 := borrow_field<TestMutRefs::TSum>.sum($t1)
- 20: unpack_ref($t12)
- 21: write_ref($t12, $t11)
- 22: pack_ref($t12)
- 23: write_back[Reference($t1)]($t12)
- 24: pack_ref($t1)
- 25: write_back[TestMutRefs::TSum]($t1)
- 26: return $t2
+  2: $t4 := get_field<TestMutRefs::T>.value($t3)
+  3: $t5 := 1
+  4: $t6 := +($t4, $t5)
+  5: $t7 := borrow_field<TestMutRefs::T>.value($t3)
+  6: write_ref($t7, $t6)
+  7: write_back[Reference($t3)]($t7)
+  8: write_back[LocalRoot($t2)]($t3)
+  9: $t8 := 0x0
+ 10: $t1 := borrow_global<TestMutRefs::TSum>($t8)
+ 11: $t9 := get_field<TestMutRefs::TSum>.sum($t1)
+ 12: $t10 := 1
+ 13: $t11 := +($t9, $t10)
+ 14: $t12 := borrow_field<TestMutRefs::TSum>.sum($t1)
+ 15: write_ref($t12, $t11)
+ 16: write_back[Reference($t1)]($t12)
+ 17: write_back[TestMutRefs::TSum]($t1)
+ 18: return $t2
 }
 
 
@@ -408,18 +388,14 @@ pub fun TestMutRefs::increment_invalid($t0|x: TestMutRefs::T): TestMutRefs::T {
      var $t6: &mut u64
   0: $t1 := move($t0)
   1: $t2 := borrow_local($t1)
-  2: unpack_ref($t2)
-  3: $t3 := get_field<TestMutRefs::T>.value($t2)
-  4: $t4 := 1
-  5: $t5 := +($t3, $t4)
-  6: $t6 := borrow_field<TestMutRefs::T>.value($t2)
-  7: unpack_ref($t6)
-  8: write_ref($t6, $t5)
-  9: pack_ref($t6)
- 10: write_back[Reference($t2)]($t6)
- 11: pack_ref($t2)
- 12: write_back[LocalRoot($t1)]($t2)
- 13: return $t1
+  2: $t3 := get_field<TestMutRefs::T>.value($t2)
+  3: $t4 := 1
+  4: $t5 := +($t3, $t4)
+  5: $t6 := borrow_field<TestMutRefs::T>.value($t2)
+  6: write_ref($t6, $t5)
+  7: write_back[Reference($t2)]($t6)
+  8: write_back[LocalRoot($t1)]($t2)
+  9: return $t1
 }
 
 
@@ -435,18 +411,14 @@ pub fun TestMutRefs::new($t0|x: u64): TestMutRefs::T {
   0: $t2 := move($t0)
   1: $t3 := 0x0
   2: $t1 := borrow_global<TestMutRefs::TSum>($t3)
-  3: unpack_ref($t1)
-  4: $t4 := get_field<TestMutRefs::TSum>.sum($t1)
-  5: $t5 := +($t4, $t2)
-  6: $t6 := borrow_field<TestMutRefs::TSum>.sum($t1)
-  7: unpack_ref($t6)
-  8: write_ref($t6, $t5)
-  9: pack_ref($t6)
- 10: write_back[Reference($t1)]($t6)
- 11: pack_ref($t1)
- 12: write_back[TestMutRefs::TSum]($t1)
- 13: $t7 := pack TestMutRefs::T($t2)
- 14: return $t7
+  3: $t4 := get_field<TestMutRefs::TSum>.sum($t1)
+  4: $t5 := +($t4, $t2)
+  5: $t6 := borrow_field<TestMutRefs::TSum>.sum($t1)
+  6: write_ref($t6, $t5)
+  7: write_back[Reference($t1)]($t6)
+  8: write_back[TestMutRefs::TSum]($t1)
+  9: $t7 := pack TestMutRefs::T($t2)
+ 10: return $t7
 }
 
 
@@ -485,18 +457,14 @@ fun TestMutRefs::private_decrement($t0|x: TestMutRefs::T): TestMutRefs::T {
   8: write_back[LocalRoot($t2)]($t3)
   9: $t8 := 0x0
  10: $t1 := borrow_global<TestMutRefs::TSum>($t8)
- 11: unpack_ref($t1)
- 12: $t9 := get_field<TestMutRefs::TSum>.sum($t1)
- 13: $t10 := 1
- 14: $t11 := -($t9, $t10)
- 15: $t12 := borrow_field<TestMutRefs::TSum>.sum($t1)
- 16: unpack_ref($t12)
- 17: write_ref($t12, $t11)
- 18: pack_ref($t12)
- 19: write_back[Reference($t1)]($t12)
- 20: pack_ref($t1)
- 21: write_back[TestMutRefs::TSum]($t1)
- 22: return $t2
+ 11: $t9 := get_field<TestMutRefs::TSum>.sum($t1)
+ 12: $t10 := 1
+ 13: $t11 := -($t9, $t10)
+ 14: $t12 := borrow_field<TestMutRefs::TSum>.sum($t1)
+ 15: write_ref($t12, $t11)
+ 16: write_back[Reference($t1)]($t12)
+ 17: write_back[TestMutRefs::TSum]($t1)
+ 18: return $t2
 }
 
 
@@ -524,16 +492,14 @@ fun TestMutRefs::private_to_public_caller_invalid_data_invariant() {
   0: $t2 := 1
   1: $t1 := TestMutRefs::new($t2)
   2: $t0 := borrow_local($t1)
-  3: unpack_ref($t0)
-  4: $t3 := read_ref($t0)
-  5: $t3 := TestMutRefs::private_decrement($t3)
-  6: write_ref($t0, $t3)
-  7: $t3 := read_ref($t0)
-  8: $t3 := TestMutRefs::increment($t3)
-  9: write_ref($t0, $t3)
- 10: pack_ref($t0)
- 11: write_back[LocalRoot($t1)]($t0)
- 12: return ()
+  3: $t3 := read_ref($t0)
+  4: $t3 := TestMutRefs::private_decrement($t3)
+  5: write_ref($t0, $t3)
+  6: $t3 := read_ref($t0)
+  7: $t3 := TestMutRefs::increment($t3)
+  8: write_ref($t0, $t3)
+  9: write_back[LocalRoot($t1)]($t0)
+ 10: return ()
 }
 
 
@@ -546,12 +512,10 @@ pub fun TestMutRefsUser::valid() {
   0: $t1 := 4
   1: $t0 := TestMutRefs::new($t1)
   2: $t2 := borrow_local($t0)
-  3: unpack_ref($t2)
-  4: $t3 := read_ref($t2)
-  5: $t3 := TestMutRefs::increment($t3)
-  6: write_ref($t2, $t3)
-  7: pack_ref($t2)
-  8: write_back[LocalRoot($t0)]($t2)
-  9: TestMutRefs::delete($t0)
- 10: return ()
+  3: $t3 := read_ref($t2)
+  4: $t3 := TestMutRefs::increment($t3)
+  5: write_ref($t2, $t3)
+  6: write_back[LocalRoot($t0)]($t2)
+  7: TestMutRefs::delete($t0)
+  8: return ()
 }

--- a/language/move-prover/bytecode/tests/reaching_def/test_branching.exp
+++ b/language/move-prover/bytecode/tests/reaching_def/test_branching.exp
@@ -10,18 +10,18 @@ fun TestBranching::branching($t0|cond: bool): u64 {
      var $t6: u64
      var $t7: u64
   0: $t3 := copy($t0)
-  1: if ($t3) goto L0 else goto L1
-  2: L1:
-  3: goto L2
-  4: L0:
+  1: if ($t3) goto 4 else goto 2
+  2: label L1
+  3: goto 8
+  4: label L0
   5: $t4 := 3
   6: $t1 := $t4
-  7: goto L3
-  8: L2:
+  7: goto 12
+  8: label L2
   9: $t5 := 4
  10: $t1 := $t5
- 11: goto L3
- 12: L3:
+ 11: goto 12
+ 12: label L3
  13: $t6 := move($t1)
  14: $t2 := $t6
  15: $t7 := copy($t2)
@@ -42,18 +42,18 @@ fun TestBranching::branching($t0|cond: bool): u64 {
      var $t8: bool
   0: $t8 := move($t0)
   1: $t3 := copy($t8)
-  2: if ($t8) goto L0 else goto L1
-  3: L1:
-  4: goto L2
-  5: L0:
+  2: if ($t8) goto 5 else goto 3
+  3: label L1
+  4: goto 9
+  5: label L0
   6: $t4 := 3
   7: $t1 := $t4
-  8: goto L3
-  9: L2:
+  8: goto 13
+  9: label L2
  10: $t5 := 4
  11: $t1 := $t5
- 12: goto L3
- 13: L3:
+ 12: goto 13
+ 13: label L3
  14: $t6 := move($t1)
  15: $t2 := $t1
  16: $t7 := copy($t2)

--- a/language/move-prover/bytecode/tests/spec_instrumentation/fun_spec.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/fun_spec.exp
@@ -12,22 +12,22 @@ fun Test::branching_result($t0|is_div: bool, $t1|a: u64, $t2|b: u64): u64 {
      var $t10: u64
      var $t11: u64
   0: $t4 := copy($t0)
-  1: if ($t4) goto L0 else goto L1
-  2: L1:
-  3: goto L2
-  4: L0:
+  1: if ($t4) goto 4 else goto 2
+  2: label L1
+  3: goto 10
+  4: label L0
   5: $t5 := copy($t1)
   6: $t6 := copy($t2)
   7: $t7 := /($t5, $t6)
   8: $t3 := $t7
-  9: goto L3
- 10: L2:
+  9: goto 16
+ 10: label L2
  11: $t8 := copy($t1)
  12: $t9 := copy($t2)
  13: $t10 := *($t8, $t9)
  14: $t3 := $t10
- 15: goto L3
- 16: L3:
+ 15: goto 16
+ 16: label L3
  17: $t11 := move($t3)
  18: return $t11
 }
@@ -45,13 +45,13 @@ fun Test::implicit_and_explicit_abort($t0|a: u64, $t1|b: u64): u64 {
   0: $t2 := copy($t1)
   1: $t3 := 0
   2: $t4 := !=($t2, $t3)
-  3: if ($t4) goto L0 else goto L1
-  4: L1:
-  5: goto L2
-  6: L0:
+  3: if ($t4) goto 6 else goto 4
+  4: label L1
+  5: goto 9
+  6: label L0
   7: $t5 := 22
   8: abort($t5)
-  9: L2:
+  9: label L2
  10: $t6 := copy($t0)
  11: $t7 := copy($t1)
  12: $t8 := /($t6, $t7)
@@ -149,13 +149,13 @@ fun Test::resource_with_old($t0|val: u64) {
   0: $t2 := 0x0
   1: $t3 := exists<Test::R>($t2)
   2: $t4 := !($t3)
-  3: if ($t4) goto L0 else goto L1
-  4: L1:
-  5: goto L2
-  6: L0:
+  3: if ($t4) goto 6 else goto 4
+  4: label L1
+  5: goto 9
+  6: label L0
   7: $t5 := 33
   8: abort($t5)
-  9: L2:
+  9: label L2
  10: $t6 := 0x0
  11: $t7 := borrow_global<Test::R>($t6)
  12: $t1 := $t7
@@ -176,20 +176,20 @@ fun Test::resource_with_old($t0|val: u64) {
 fun Test::branching_result($t0|is_div: bool, $t1|a: u64, $t2|b: u64): u64 {
      var $t3|tmp#$3: u64
      var $t4: num
-  0: if ($t0) goto L0 else goto L1
-  1: L1:
-  2: goto L2
-  3: L0:
+  0: if ($t0) goto 3 else goto 1
+  1: label L1
+  2: goto 7
+  3: label L0
   4: $t3 := /($t1, $t2)
-  5: on_abort(L5, $t4)
-  6: goto L3
-  7: L2:
+  5: on_abort goto 13 code := $t4
+  6: goto 10
+  7: label L2
   8: $t3 := *($t1, $t2)
-  9: on_abort(L5, $t4)
- 10: L3:
- 11: L4:
+  9: on_abort goto 13 code := $t4
+ 10: label L3
+ 11: label L4
  12: return $t3
- 13: L5:
+ 13: label L5
  14: abort($t4)
 }
 
@@ -198,18 +198,18 @@ fun Test::branching_result($t0|is_div: bool, $t1|a: u64, $t2|b: u64): u64 {
 fun Test::branching_result($t0|is_div: bool, $t1|a: u64, $t2|b: u64): u64 {
      var $t3|tmp#$3: u64
      var $t4: num
-  0: if ($t0) goto L0 else goto L1
-  1: L1:
-  2: goto L2
-  3: L0:
+  0: if ($t0) goto 3 else goto 1
+  1: label L1
+  2: goto 7
+  3: label L0
   4: $t3 := /($t1, $t2)
-  5: on_abort(L5, $t4)
-  6: goto L3
-  7: L2:
+  5: on_abort goto 16 code := $t4
+  6: goto 10
+  7: label L2
   8: $t3 := *($t1, $t2)
-  9: on_abort(L5, $t4)
- 10: L3:
- 11: L4:
+  9: on_abort goto 16 code := $t4
+ 10: label L3
+ 11: label L4
      // VC: `function does not abort under this condition` at tests/spec_instrumentation/fun_spec.move:27:6+50
  12: assert Not(And($t0, Eq<u64>($t2, 0)))
      // VC: `post-condition does not hold` at tests/spec_instrumentation/fun_spec.move:28:6+35
@@ -217,7 +217,7 @@ fun Test::branching_result($t0|is_div: bool, $t1|a: u64, $t2|b: u64): u64 {
      // VC: `post-condition does not hold` at tests/spec_instrumentation/fun_spec.move:29:6+36
  14: assert Implies(Not($t0), Eq<u64>($t3, Mul($t1, $t2)))
  15: return $t3
- 16: L5:
+ 16: label L5
      // VC: `abort not covered by any of the `aborts_if` clauses` at tests/spec_instrumentation/fun_spec.move:23:2+94
  17: assert And($t0, Eq<u64>($t2, 0))
      // VC: `function aborts under this condition but with the wrong code` at tests/spec_instrumentation/fun_spec.move:27:38+17
@@ -235,19 +235,19 @@ fun Test::implicit_and_explicit_abort($t0|a: u64, $t1|b: u64): u64 {
      var $t6: u64
   0: $t2 := 0
   1: $t3 := !=($t1, $t2)
-  2: if ($t3) goto L0 else goto L1
-  3: L1:
-  4: goto L2
-  5: L0:
+  2: if ($t3) goto 5 else goto 3
+  3: label L1
+  4: goto 9
+  5: label L0
   6: $t4 := 22
   7: $t5 := move($t4)
-  8: goto L4
-  9: L2:
+  8: goto 14
+  9: label L2
  10: $t6 := /($t0, $t1)
- 11: on_abort(L4, $t5)
- 12: L3:
+ 11: on_abort goto 14 code := $t5
+ 12: label L3
  13: return $t6
- 14: L4:
+ 14: label L4
  15: abort($t5)
 }
 
@@ -261,17 +261,17 @@ fun Test::implicit_and_explicit_abort($t0|a: u64, $t1|b: u64): u64 {
      var $t6: u64
   0: $t2 := 0
   1: $t3 := !=($t1, $t2)
-  2: if ($t3) goto L0 else goto L1
-  3: L1:
-  4: goto L2
-  5: L0:
+  2: if ($t3) goto 5 else goto 3
+  3: label L1
+  4: goto 9
+  5: label L0
   6: $t4 := 22
   7: $t5 := move($t4)
-  8: goto L4
-  9: L2:
+  8: goto 17
+  9: label L2
  10: $t6 := /($t0, $t1)
- 11: on_abort(L4, $t5)
- 12: L3:
+ 11: on_abort goto 17 code := $t5
+ 12: label L3
      // VC: `function does not abort under this condition` at tests/spec_instrumentation/fun_spec.move:9:6+25
  13: assert Not(Eq<u64>($t1, 0))
      // VC: `function does not abort under this condition` at tests/spec_instrumentation/fun_spec.move:10:6+17
@@ -279,7 +279,7 @@ fun Test::implicit_and_explicit_abort($t0|a: u64, $t1|b: u64): u64 {
      // VC: `post-condition does not hold` at tests/spec_instrumentation/fun_spec.move:11:6+24
  15: assert Eq<u64>($t6, Div($t0, $t1))
  16: return $t6
- 17: L4:
+ 17: label L4
      // VC: `abort not covered by any of the `aborts_if` clauses` at tests/spec_instrumentation/fun_spec.move:4:2+96
  18: assert Or(Eq<u64>($t1, 0), Eq<u64>($t0, 0))
      // VC: `function aborts under this condition but with the wrong code` at tests/spec_instrumentation/fun_spec.move:9:28+2
@@ -294,12 +294,12 @@ fun Test::multiple_results($t0|a: u64, $t1|b: u64): (u64, u64) {
      var $t3: num
      var $t4: u64
   0: $t2 := /($t0, $t1)
-  1: on_abort(L2, $t3)
+  1: on_abort goto 6 code := $t3
   2: $t4 := %($t0, $t1)
-  3: on_abort(L2, $t3)
-  4: L1:
+  3: on_abort goto 6 code := $t3
+  4: label L1
   5: return ($t2, $t4)
-  6: L2:
+  6: label L2
   7: abort($t3)
 }
 
@@ -310,10 +310,10 @@ fun Test::multiple_results($t0|a: u64, $t1|b: u64): (u64, u64) {
      var $t3: num
      var $t4: u64
   0: $t2 := /($t0, $t1)
-  1: on_abort(L2, $t3)
+  1: on_abort goto 9 code := $t3
   2: $t4 := %($t0, $t1)
-  3: on_abort(L2, $t3)
-  4: L1:
+  3: on_abort goto 9 code := $t3
+  4: label L1
      // VC: `function does not abort under this condition` at tests/spec_instrumentation/fun_spec.move:18:6+40
   5: assert Not(Eq<u64>($t1, 0))
      // VC: `post-condition does not hold` at tests/spec_instrumentation/fun_spec.move:19:6+26
@@ -321,7 +321,7 @@ fun Test::multiple_results($t0|a: u64, $t1|b: u64): (u64, u64) {
      // VC: `post-condition does not hold` at tests/spec_instrumentation/fun_spec.move:20:6+26
   7: assert Eq<u64>($t4, Mod($t0, $t1))
   8: return ($t2, $t4)
-  9: L2:
+  9: label L2
      // VC: `abort not covered by any of the `aborts_if` clauses` at tests/spec_instrumentation/fun_spec.move:14:2+73
  10: assert Eq<u64>($t1, 0)
      // VC: `function aborts under this condition but with the wrong code` at tests/spec_instrumentation/fun_spec.move:18:28+17
@@ -347,14 +347,14 @@ fun Test::mut_ref_param($t0|r: Test::R): (u64, Test::R) {
   3: $t5 := get_field<Test::R>.v($t3)
   4: $t6 := 1
   5: $t7 := -($t5, $t6)
-  6: on_abort(L2, $t8)
+  6: on_abort goto 13 code := $t8
   7: $t9 := borrow_field<Test::R>.v($t3)
   8: write_ref($t9, $t7)
   9: write_back[Reference($t3)]($t9)
  10: write_back[LocalRoot($t2)]($t3)
- 11: L1:
+ 11: label L1
  12: return ($t4, $t2)
- 13: L2:
+ 13: label L2
  14: abort($t8)
 }
 
@@ -376,12 +376,12 @@ fun Test::mut_ref_param($t0|r: Test::R): (u64, Test::R) {
   3: $t5 := get_field<Test::R>.v($t3)
   4: $t6 := 1
   5: $t7 := -($t5, $t6)
-  6: on_abort(L2, $t8)
+  6: on_abort goto 16 code := $t8
   7: $t9 := borrow_field<Test::R>.v($t3)
   8: write_ref($t9, $t7)
   9: write_back[Reference($t3)]($t9)
  10: write_back[LocalRoot($t2)]($t3)
- 11: L1:
+ 11: label L1
      // VC: `function does not abort under this condition` at tests/spec_instrumentation/fun_spec.move:67:6+42
  12: assert Not(Eq<u64>(select Test::R.v($t0), 0))
      // VC: `post-condition does not hold` at tests/spec_instrumentation/fun_spec.move:68:6+27
@@ -389,7 +389,7 @@ fun Test::mut_ref_param($t0|r: Test::R): (u64, Test::R) {
      // VC: `post-condition does not hold` at tests/spec_instrumentation/fun_spec.move:69:6+28
  14: assert Eq<u64>(select Test::R.v($t2), Add(select Test::R.v($t0), 1))
  15: return ($t4, $t2)
- 16: L2:
+ 16: label L2
      // VC: `abort not covered by any of the `aborts_if` clauses` at tests/spec_instrumentation/fun_spec.move:61:2+83
  17: assert Eq<u64>(select Test::R.v($t0), 0)
      // VC: `function aborts under this condition but with the wrong code` at tests/spec_instrumentation/fun_spec.move:67:30+17
@@ -402,7 +402,7 @@ fun Test::mut_ref_param($t0|r: Test::R): (u64, Test::R) {
 fun Test::ref_param($t0|r: Test::R): u64 {
      var $t1: u64
   0: $t1 := get_field<Test::R>.v($t0)
-  1: L1:
+  1: label L1
   2: return $t1
 }
 
@@ -411,7 +411,7 @@ fun Test::ref_param($t0|r: Test::R): u64 {
 fun Test::ref_param($t0|r: Test::R): u64 {
      var $t1: u64
   0: $t1 := get_field<Test::R>.v($t0)
-  1: L1:
+  1: label L1
      // VC: `post-condition does not hold` at tests/spec_instrumentation/fun_spec.move:51:6+22
   2: assert Eq<u64>($t1, select Test::R.v($t0))
   3: return $t1
@@ -422,7 +422,7 @@ fun Test::ref_param($t0|r: Test::R): u64 {
 fun Test::ref_param_return_ref($t0|r: Test::R): u64 {
      var $t1: u64
   0: $t1 := get_field<Test::R>.v($t0)
-  1: L1:
+  1: label L1
   2: return $t1
 }
 
@@ -431,7 +431,7 @@ fun Test::ref_param_return_ref($t0|r: Test::R): u64 {
 fun Test::ref_param_return_ref($t0|r: Test::R): u64 {
      var $t1: u64
   0: $t1 := get_field<Test::R>.v($t0)
-  1: L1:
+  1: label L1
      // VC: `post-condition does not hold` at tests/spec_instrumentation/fun_spec.move:58:6+22
   2: assert Eq<u64>($t1, select Test::R.v($t0))
   3: return $t1
@@ -454,32 +454,28 @@ fun Test::resource_with_old($t0|val: u64) {
   1: $t2 := 0x0
   2: $t3 := exists<Test::R>($t2)
   3: $t4 := !($t3)
-  4: if ($t4) goto L0 else goto L1
-  5: L1:
-  6: goto L2
-  7: L0:
+  4: if ($t4) goto 7 else goto 5
+  5: label L1
+  6: goto 11
+  7: label L0
   8: $t5 := 33
   9: $t6 := move($t5)
- 10: goto L4
- 11: L2:
+ 10: goto 24
+ 11: label L2
  12: $t7 := 0x0
  13: $t1 := borrow_global<Test::R>($t7)
- 14: on_abort(L4, $t6)
- 15: unpack_ref($t1)
- 16: $t8 := get_field<Test::R>.v($t1)
- 17: $t9 := +($t8, $t0)
- 18: on_abort(L4, $t6)
- 19: $t10 := borrow_field<Test::R>.v($t1)
- 20: unpack_ref($t10)
- 21: write_ref($t10, $t9)
- 22: pack_ref($t10)
- 23: write_back[Reference($t1)]($t10)
- 24: pack_ref($t1)
- 25: write_back[Test::R]($t1)
- 26: L3:
- 27: return ()
- 28: L4:
- 29: abort($t6)
+ 14: on_abort goto 24 code := $t6
+ 15: $t8 := get_field<Test::R>.v($t1)
+ 16: $t9 := +($t8, $t0)
+ 17: on_abort goto 24 code := $t6
+ 18: $t10 := borrow_field<Test::R>.v($t1)
+ 19: write_ref($t10, $t9)
+ 20: write_back[Reference($t1)]($t10)
+ 21: write_back[Test::R]($t1)
+ 22: label L3
+ 23: return ()
+ 24: label L4
+ 25: abort($t6)
 }
 
 
@@ -500,42 +496,38 @@ fun Test::resource_with_old($t0|val: u64) {
   2: $t2 := 0x0
   3: $t3 := exists<Test::R>($t2)
   4: $t4 := !($t3)
-  5: if ($t4) goto L0 else goto L1
-  6: L1:
-  7: goto L2
-  8: L0:
+  5: if ($t4) goto 8 else goto 6
+  6: label L1
+  7: goto 12
+  8: label L0
   9: $t5 := 33
  10: $t6 := move($t5)
- 11: goto L4
- 12: L2:
+ 11: goto 29
+ 12: label L2
  13: $t7 := 0x0
      // VC: `caller does not have permission to modify `Test::R` at given address` at tests/spec_instrumentation/fun_spec.move:36:14+17
  14: assert CanModify<Test::R>($t7)
  15: $t1 := borrow_global<Test::R>($t7)
- 16: on_abort(L4, $t6)
- 17: unpack_ref($t1)
- 18: $t8 := get_field<Test::R>.v($t1)
- 19: $t9 := +($t8, $t0)
- 20: on_abort(L4, $t6)
- 21: $t10 := borrow_field<Test::R>.v($t1)
- 22: unpack_ref($t10)
- 23: write_ref($t10, $t9)
- 24: pack_ref($t10)
- 25: write_back[Reference($t1)]($t10)
- 26: pack_ref($t1)
- 27: write_back[Test::R]($t1)
- 28: L3:
+ 16: on_abort goto 29 code := $t6
+ 17: $t8 := get_field<Test::R>.v($t1)
+ 18: $t9 := +($t8, $t0)
+ 19: on_abort goto 29 code := $t6
+ 20: $t10 := borrow_field<Test::R>.v($t1)
+ 21: write_ref($t10, $t9)
+ 22: write_back[Reference($t1)]($t10)
+ 23: write_back[Test::R]($t1)
+ 24: label L3
      // VC: `function does not abort under this condition` at tests/spec_instrumentation/fun_spec.move:41:6+34
- 29: assert Not(Not(exists[@0]<Test::R>(0)))
+ 25: assert Not(Not(exists[@0]<Test::R>(0)))
      // VC: `function does not abort under this condition` at tests/spec_instrumentation/fun_spec.move:42:6+57
- 30: assert Not(Ge(Add(select Test::R.v(global[@0]<Test::R>(0)), $t0), 18446744073709551615))
+ 26: assert Not(Ge(Add(select Test::R.v(global[@0]<Test::R>(0)), $t0), 18446744073709551615))
      // VC: `post-condition does not hold` at tests/spec_instrumentation/fun_spec.move:43:6+56
- 31: assert Eq<u64>(select Test::R.v(global<Test::R>(0)), Add(select Test::R.v(global[@0]<Test::R>(0)), $t0))
- 32: return ()
- 33: L4:
+ 27: assert Eq<u64>(select Test::R.v(global<Test::R>(0)), Add(select Test::R.v(global[@0]<Test::R>(0)), $t0))
+ 28: return ()
+ 29: label L4
      // VC: `abort not covered by any of the `aborts_if` clauses` at tests/spec_instrumentation/fun_spec.move:34:2+145
- 34: assert Or(Not(exists[@0]<Test::R>(0)), Ge(Add(select Test::R.v(global[@0]<Test::R>(0)), $t0), 18446744073709551615))
+ 30: assert Or(Not(exists[@0]<Test::R>(0)), Ge(Add(select Test::R.v(global[@0]<Test::R>(0)), $t0), 18446744073709551615))
      // VC: `function aborts under this condition but with the wrong code` at tests/spec_instrumentation/fun_spec.move:41:37+2
- 35: assert Implies(Not(exists[@0]<Test::R>(0)), Eq($t6, 33))
- 36: abort($t6)
+ 31: assert Implies(Not(exists[@0]<Test::R>(0)), Eq($t6, 33))
+ 32: abort($t6)
 }

--- a/language/move-prover/bytecode/tests/spec_instrumentation/modifies.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/modifies.exp
@@ -174,20 +174,16 @@ pub fun A::mutate_at($t0|addr: address) {
      var $t3: u64
      var $t4: &mut u64
   0: $t1 := borrow_global<A::S>($t0)
-  1: on_abort(L2, $t2)
-  2: unpack_ref($t1)
-  3: $t3 := 2
-  4: $t4 := borrow_field<A::S>.x($t1)
-  5: unpack_ref($t4)
-  6: write_ref($t4, $t3)
-  7: pack_ref($t4)
-  8: write_back[Reference($t1)]($t4)
-  9: pack_ref($t1)
- 10: write_back[A::S]($t1)
- 11: L1:
- 12: return ()
- 13: L2:
- 14: abort($t2)
+  1: on_abort goto 9 code := $t2
+  2: $t3 := 2
+  3: $t4 := borrow_field<A::S>.x($t1)
+  4: write_ref($t4, $t3)
+  5: write_back[Reference($t1)]($t4)
+  6: write_back[A::S]($t1)
+  7: label L1
+  8: return ()
+  9: label L2
+ 10: abort($t2)
 }
 
 
@@ -201,26 +197,22 @@ pub fun A::mutate_at($t0|addr: address) {
      // VC: `caller does not have permission to modify `A::S` at given address` at tests/spec_instrumentation/modifies.move:18:17+17
   1: assert CanModify<A::S>($t0)
   2: $t1 := borrow_global<A::S>($t0)
-  3: on_abort(L2, $t2)
-  4: unpack_ref($t1)
-  5: $t3 := 2
-  6: $t4 := borrow_field<A::S>.x($t1)
-  7: unpack_ref($t4)
-  8: write_ref($t4, $t3)
-  9: pack_ref($t4)
- 10: write_back[Reference($t1)]($t4)
- 11: pack_ref($t1)
- 12: write_back[A::S]($t1)
- 13: L1:
+  3: on_abort goto 13 code := $t2
+  4: $t3 := 2
+  5: $t4 := borrow_field<A::S>.x($t1)
+  6: write_ref($t4, $t3)
+  7: write_back[Reference($t1)]($t4)
+  8: write_back[A::S]($t1)
+  9: label L1
      // VC: `function does not abort under this condition` at tests/spec_instrumentation/modifies.move:24:9+27
- 14: assert Not(Not(exists[@2]<A::S>($t0)))
+ 10: assert Not(Not(exists[@2]<A::S>($t0)))
      // VC: `post-condition does not hold` at tests/spec_instrumentation/modifies.move:23:9+31
- 15: assert Eq<u64>(select A::S.x(global<A::S>($t0)), 2)
- 16: return ()
- 17: L2:
+ 11: assert Eq<u64>(select A::S.x(global<A::S>($t0)), 2)
+ 12: return ()
+ 13: label L2
      // VC: `abort not covered by any of the `aborts_if` clauses` at tests/spec_instrumentation/modifies.move:17:5+115
- 18: assert Not(exists[@2]<A::S>($t0))
- 19: abort($t2)
+ 14: assert Not(exists[@2]<A::S>($t0))
+ 15: abort($t2)
 }
 
 
@@ -230,11 +222,11 @@ pub fun A::read_at($t0|addr: address): u64 {
      var $t2: num
      var $t3: u64
   0: $t1 := get_global<A::S>($t0)
-  1: on_abort(L2, $t2)
+  1: on_abort goto 5 code := $t2
   2: $t3 := get_field<A::S>.x($t1)
-  3: L1:
+  3: label L1
   4: return $t3
-  5: L2:
+  5: label L2
   6: abort($t2)
 }
 
@@ -246,15 +238,15 @@ pub fun A::read_at($t0|addr: address): u64 {
      var $t3: u64
   0: @0 := save_mem(A::S)
   1: $t1 := get_global<A::S>($t0)
-  2: on_abort(L2, $t2)
+  2: on_abort goto 8 code := $t2
   3: $t3 := get_field<A::S>.x($t1)
-  4: L1:
+  4: label L1
      // VC: `function does not abort under this condition` at tests/spec_instrumentation/modifies.move:13:9+27
   5: assert Not(Not(exists[@0]<A::S>($t0)))
      // VC: `post-condition does not hold` at tests/spec_instrumentation/modifies.move:14:9+36
   6: assert Eq<u64>($t3, select A::S.x(global<A::S>($t0)))
   7: return $t3
-  8: L2:
+  8: label L2
      // VC: `abort not covered by any of the `aborts_if` clauses` at tests/spec_instrumentation/modifies.move:7:5+109
   9: assert Not(exists[@0]<A::S>($t0))
  10: abort($t2)
@@ -271,20 +263,20 @@ pub fun B::move_from_test_incorrect($t0|addr1: address, $t1|addr2: address): B::
      var $t7: bool
   0: @14 := save_mem(A::S)
   1: assume Eq($t5, Not(exists[@14]<A::S>($t1)))
-  2: if ($t5) goto L2 else goto L3
-  3: L3:
+  2: if ($t5) goto 15 else goto 3
+  3: label L3
   4: assume Eq<u64>($t3, select A::S.x(global<A::S>($t1)))
   5: $t2 := move_from<B::T>($t0)
-  6: on_abort(L2, $t6)
+  6: on_abort goto 15 code := $t6
   7: @15 := save_mem(A::S)
   8: assume Eq($t7, Not(exists[@15]<A::S>($t1)))
-  9: if ($t7) goto L2 else goto L4
- 10: L4:
+  9: if ($t7) goto 15 else goto 10
+ 10: label L4
  11: assume Eq<u64>($t4, select A::S.x(global<A::S>($t1)))
  12: assert Eq<u64>($t3, $t4)
- 13: L1:
+ 13: label L1
  14: return $t2
- 15: L2:
+ 15: label L2
  16: abort($t6)
 }
 
@@ -299,22 +291,22 @@ pub fun B::move_from_test_incorrect($t0|addr1: address, $t1|addr2: address): B::
      var $t7: bool
   0: @12 := save_mem(A::S)
   1: assume Eq($t5, Not(exists[@12]<A::S>($t1)))
-  2: if ($t5) goto L2 else goto L3
-  3: L3:
+  2: if ($t5) goto 16 else goto 3
+  3: label L3
   4: assume Eq<u64>($t3, select A::S.x(global<A::S>($t1)))
      // VC: `caller does not have permission to modify `B::T` at given address` at tests/spec_instrumentation/modifies.move:65:17+9
   5: assert CanModify<B::T>($t0)
   6: $t2 := move_from<B::T>($t0)
-  7: on_abort(L2, $t6)
+  7: on_abort goto 16 code := $t6
   8: @13 := save_mem(A::S)
   9: assume Eq($t7, Not(exists[@13]<A::S>($t1)))
- 10: if ($t7) goto L2 else goto L4
- 11: L4:
+ 10: if ($t7) goto 16 else goto 11
+ 11: label L4
  12: assume Eq<u64>($t4, select A::S.x(global<A::S>($t1)))
  13: assert Eq<u64>($t3, $t4)
- 14: L1:
+ 14: label L1
  15: return $t2
- 16: L2:
+ 16: label L2
  17: abort($t6)
 }
 
@@ -330,22 +322,22 @@ pub fun B::move_to_test_incorrect($t0|account: signer, $t1|addr2: address) {
      var $t8: bool
   0: @10 := save_mem(A::S)
   1: assume Eq($t4, Not(exists[@10]<A::S>($t1)))
-  2: if ($t4) goto L2 else goto L3
-  3: L3:
+  2: if ($t4) goto 17 else goto 3
+  3: label L3
   4: assume Eq<u64>($t2, select A::S.x(global<A::S>($t1)))
   5: $t5 := 2
   6: $t6 := pack B::T($t5)
   7: move_to<B::T>($t6, $t0)
-  8: on_abort(L2, $t7)
+  8: on_abort goto 17 code := $t7
   9: @11 := save_mem(A::S)
  10: assume Eq($t8, Not(exists[@11]<A::S>($t1)))
- 11: if ($t8) goto L2 else goto L4
- 12: L4:
+ 11: if ($t8) goto 17 else goto 12
+ 12: label L4
  13: assume Eq<u64>($t3, select A::S.x(global<A::S>($t1)))
  14: assert Eq<u64>($t2, $t3)
- 15: L1:
+ 15: label L1
  16: return ()
- 17: L2:
+ 17: label L2
  18: abort($t7)
 }
 
@@ -361,24 +353,24 @@ pub fun B::move_to_test_incorrect($t0|account: signer, $t1|addr2: address) {
      var $t8: bool
   0: @8 := save_mem(A::S)
   1: assume Eq($t4, Not(exists[@8]<A::S>($t1)))
-  2: if ($t4) goto L2 else goto L3
-  3: L3:
+  2: if ($t4) goto 18 else goto 3
+  3: label L3
   4: assume Eq<u64>($t2, select A::S.x(global<A::S>($t1)))
   5: $t5 := 2
   6: $t6 := pack B::T($t5)
      // VC: `caller does not have permission to modify `B::T` at given address` at tests/spec_instrumentation/modifies.move:52:9+7
   7: assert CanModify<B::T>($t0)
   8: move_to<B::T>($t6, $t0)
-  9: on_abort(L2, $t7)
+  9: on_abort goto 18 code := $t7
  10: @9 := save_mem(A::S)
  11: assume Eq($t8, Not(exists[@9]<A::S>($t1)))
- 12: if ($t8) goto L2 else goto L4
- 13: L4:
+ 12: if ($t8) goto 18 else goto 13
+ 13: label L4
  14: assume Eq<u64>($t3, select A::S.x(global<A::S>($t1)))
  15: assert Eq<u64>($t2, $t3)
- 16: L1:
+ 16: label L1
  17: return ()
- 18: L2:
+ 18: label L2
  19: abort($t7)
 }
 
@@ -394,25 +386,25 @@ pub fun B::mutate_S_test1_incorrect($t0|addr1: address, $t1|addr2: address) {
   0: assume Neq<address>($t0, $t1)
   1: @25 := save_mem(A::S)
   2: assume Eq($t4, Not(exists[@25]<A::S>($t1)))
-  3: if ($t4) goto L2 else goto L3
-  4: L3:
+  3: if ($t4) goto 20 else goto 4
+  4: label L3
   5: assume Eq<u64>($t2, select A::S.x(global<A::S>($t1)))
   6: @26 := save_mem(A::S)
      // VC: `caller does not have permission to modify `A::S` at given address` at tests/spec_instrumentation/modifies.move:79:12+9
   7: modifies global<A::S>($t0)
   8: assume Eq($t5, Not(exists[@26]<A::S>($t0)))
-  9: if ($t5) goto L2 else goto L4
- 10: L4:
+  9: if ($t5) goto 20 else goto 10
+ 10: label L4
  11: assume Eq<u64>(select A::S.x(global<A::S>($t0)), 2)
  12: @27 := save_mem(A::S)
  13: assume Eq($t6, Not(exists[@27]<A::S>($t1)))
- 14: if ($t6) goto L2 else goto L5
- 15: L5:
+ 14: if ($t6) goto 20 else goto 15
+ 15: label L5
  16: assume Eq<u64>($t3, select A::S.x(global<A::S>($t1)))
  17: assert Eq<u64>($t2, $t3)
- 18: L1:
+ 18: label L1
  19: return ()
- 20: L2:
+ 20: label L2
  21: abort($t7)
 }
 
@@ -428,26 +420,26 @@ pub fun B::mutate_S_test1_incorrect($t0|addr1: address, $t1|addr2: address) {
   0: assume Neq<address>($t0, $t1)
   1: @22 := save_mem(A::S)
   2: assume Eq($t4, Not(exists[@22]<A::S>($t1)))
-  3: if ($t4) goto L2 else goto L3
-  4: L3:
+  3: if ($t4) goto 21 else goto 4
+  4: label L3
   5: assume Eq<u64>($t2, select A::S.x(global<A::S>($t1)))
      // VC: `caller does not have permission to modify `A::S` at given address` at tests/spec_instrumentation/modifies.move:79:12+9
   6: assert CanModify<A::S>($t0)
   7: @23 := save_mem(A::S)
   8: modifies global<A::S>($t0)
   9: assume Eq($t5, Not(exists[@23]<A::S>($t0)))
- 10: if ($t5) goto L2 else goto L4
- 11: L4:
+ 10: if ($t5) goto 21 else goto 11
+ 11: label L4
  12: assume Eq<u64>(select A::S.x(global<A::S>($t0)), 2)
  13: @24 := save_mem(A::S)
  14: assume Eq($t6, Not(exists[@24]<A::S>($t1)))
- 15: if ($t6) goto L2 else goto L5
- 16: L5:
+ 15: if ($t6) goto 21 else goto 16
+ 16: label L5
  17: assume Eq<u64>($t3, select A::S.x(global<A::S>($t1)))
  18: assert Eq<u64>($t2, $t3)
- 19: L1:
+ 19: label L1
  20: return ()
- 21: L2:
+ 21: label L2
  22: abort($t7)
 }
 
@@ -462,25 +454,25 @@ pub fun B::mutate_S_test2_incorrect($t0|addr: address) {
      var $t6: num
   0: @19 := save_mem(A::S)
   1: assume Eq($t3, Not(exists[@19]<A::S>($t0)))
-  2: if ($t3) goto L2 else goto L3
-  3: L3:
+  2: if ($t3) goto 19 else goto 3
+  3: label L3
   4: assume Eq<u64>($t1, select A::S.x(global<A::S>($t0)))
   5: @20 := save_mem(A::S)
      // VC: `caller does not have permission to modify `A::S` at given address` at tests/spec_instrumentation/modifies.move:92:12+9
   6: modifies global<A::S>($t0)
   7: assume Eq($t4, Not(exists[@20]<A::S>($t0)))
-  8: if ($t4) goto L2 else goto L4
-  9: L4:
+  8: if ($t4) goto 19 else goto 9
+  9: label L4
  10: assume Eq<u64>(select A::S.x(global<A::S>($t0)), 2)
  11: @21 := save_mem(A::S)
  12: assume Eq($t5, Not(exists[@21]<A::S>($t0)))
- 13: if ($t5) goto L2 else goto L5
- 14: L5:
+ 13: if ($t5) goto 19 else goto 14
+ 14: label L5
  15: assume Eq<u64>($t2, select A::S.x(global<A::S>($t0)))
  16: assert Eq<u64>($t1, $t2)
- 17: L1:
+ 17: label L1
  18: return ()
- 19: L2:
+ 19: label L2
  20: abort($t6)
 }
 
@@ -495,26 +487,26 @@ pub fun B::mutate_S_test2_incorrect($t0|addr: address) {
      var $t6: num
   0: @16 := save_mem(A::S)
   1: assume Eq($t3, Not(exists[@16]<A::S>($t0)))
-  2: if ($t3) goto L2 else goto L3
-  3: L3:
+  2: if ($t3) goto 20 else goto 3
+  3: label L3
   4: assume Eq<u64>($t1, select A::S.x(global<A::S>($t0)))
      // VC: `caller does not have permission to modify `A::S` at given address` at tests/spec_instrumentation/modifies.move:92:12+9
   5: assert CanModify<A::S>($t0)
   6: @17 := save_mem(A::S)
   7: modifies global<A::S>($t0)
   8: assume Eq($t4, Not(exists[@17]<A::S>($t0)))
-  9: if ($t4) goto L2 else goto L4
- 10: L4:
+  9: if ($t4) goto 20 else goto 10
+ 10: label L4
  11: assume Eq<u64>(select A::S.x(global<A::S>($t0)), 2)
  12: @18 := save_mem(A::S)
  13: assume Eq($t5, Not(exists[@18]<A::S>($t0)))
- 14: if ($t5) goto L2 else goto L5
- 15: L5:
+ 14: if ($t5) goto 20 else goto 15
+ 15: label L5
  16: assume Eq<u64>($t2, select A::S.x(global<A::S>($t0)))
  17: assert Eq<u64>($t1, $t2)
- 18: L1:
+ 18: label L1
  19: return ()
- 20: L2:
+ 20: label L2
  21: abort($t6)
 }
 
@@ -531,30 +523,26 @@ pub fun B::mutate_at_test_incorrect($t0|addr1: address, $t1|addr2: address) {
      var $t9: bool
   0: @6 := save_mem(A::S)
   1: assume Eq($t5, Not(exists[@6]<A::S>($t1)))
-  2: if ($t5) goto L2 else goto L3
-  3: L3:
+  2: if ($t5) goto 20 else goto 3
+  3: label L3
   4: assume Eq<u64>($t3, select A::S.x(global<A::S>($t1)))
   5: $t2 := borrow_global<B::T>($t0)
-  6: on_abort(L2, $t6)
-  7: unpack_ref($t2)
-  8: $t7 := 2
-  9: $t8 := borrow_field<B::T>.x($t2)
- 10: unpack_ref($t8)
- 11: write_ref($t8, $t7)
- 12: pack_ref($t8)
- 13: write_back[Reference($t2)]($t8)
- 14: pack_ref($t2)
- 15: write_back[B::T]($t2)
- 16: @7 := save_mem(A::S)
- 17: assume Eq($t9, Not(exists[@7]<A::S>($t1)))
- 18: if ($t9) goto L2 else goto L4
- 19: L4:
- 20: assume Eq<u64>($t4, select A::S.x(global<A::S>($t1)))
- 21: assert Eq<u64>($t3, $t4)
- 22: L1:
- 23: return ()
- 24: L2:
- 25: abort($t6)
+  6: on_abort goto 20 code := $t6
+  7: $t7 := 2
+  8: $t8 := borrow_field<B::T>.x($t2)
+  9: write_ref($t8, $t7)
+ 10: write_back[Reference($t2)]($t8)
+ 11: write_back[B::T]($t2)
+ 12: @7 := save_mem(A::S)
+ 13: assume Eq($t9, Not(exists[@7]<A::S>($t1)))
+ 14: if ($t9) goto 20 else goto 15
+ 15: label L4
+ 16: assume Eq<u64>($t4, select A::S.x(global<A::S>($t1)))
+ 17: assert Eq<u64>($t3, $t4)
+ 18: label L1
+ 19: return ()
+ 20: label L2
+ 21: abort($t6)
 }
 
 
@@ -570,30 +558,26 @@ pub fun B::mutate_at_test_incorrect($t0|addr1: address, $t1|addr2: address) {
      var $t9: bool
   0: @4 := save_mem(A::S)
   1: assume Eq($t5, Not(exists[@4]<A::S>($t1)))
-  2: if ($t5) goto L2 else goto L3
-  3: L3:
+  2: if ($t5) goto 21 else goto 3
+  3: label L3
   4: assume Eq<u64>($t3, select A::S.x(global<A::S>($t1)))
      // VC: `caller does not have permission to modify `B::T` at given address` at tests/spec_instrumentation/modifies.move:38:17+17
   5: assert CanModify<B::T>($t0)
   6: $t2 := borrow_global<B::T>($t0)
-  7: on_abort(L2, $t6)
-  8: unpack_ref($t2)
-  9: $t7 := 2
- 10: $t8 := borrow_field<B::T>.x($t2)
- 11: unpack_ref($t8)
- 12: write_ref($t8, $t7)
- 13: pack_ref($t8)
- 14: write_back[Reference($t2)]($t8)
- 15: pack_ref($t2)
- 16: write_back[B::T]($t2)
- 17: @5 := save_mem(A::S)
- 18: assume Eq($t9, Not(exists[@5]<A::S>($t1)))
- 19: if ($t9) goto L2 else goto L4
- 20: L4:
- 21: assume Eq<u64>($t4, select A::S.x(global<A::S>($t1)))
- 22: assert Eq<u64>($t3, $t4)
- 23: L1:
- 24: return ()
- 25: L2:
- 26: abort($t6)
+  7: on_abort goto 21 code := $t6
+  8: $t7 := 2
+  9: $t8 := borrow_field<B::T>.x($t2)
+ 10: write_ref($t8, $t7)
+ 11: write_back[Reference($t2)]($t8)
+ 12: write_back[B::T]($t2)
+ 13: @5 := save_mem(A::S)
+ 14: assume Eq($t9, Not(exists[@5]<A::S>($t1)))
+ 15: if ($t9) goto 21 else goto 16
+ 16: label L4
+ 17: assume Eq<u64>($t4, select A::S.x(global<A::S>($t1)))
+ 18: assert Eq<u64>($t3, $t4)
+ 19: label L1
+ 20: return ()
+ 21: label L2
+ 22: abort($t6)
 }

--- a/language/move-prover/bytecode/tests/spec_instrumentation/opaque_call.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/opaque_call.exp
@@ -24,13 +24,13 @@ fun Test::get_and_incr($t0|addr: address): u64 {
   0: $t3 := copy($t0)
   1: $t4 := exists<Test::R>($t3)
   2: $t5 := !($t4)
-  3: if ($t5) goto L0 else goto L1
-  4: L1:
-  5: goto L2
-  6: L0:
+  3: if ($t5) goto 6 else goto 4
+  4: label L1
+  5: goto 9
+  6: label L0
   7: $t6 := 33
   8: abort($t6)
-  9: L2:
+  9: label L2
  10: $t7 := copy($t0)
  11: $t8 := borrow_global<Test::R>($t7)
  12: $t1 := $t8
@@ -85,33 +85,29 @@ fun Test::get_and_incr($t0|addr: address): u64 {
   0: assume Neq<address>($t0, 0)
   1: $t3 := exists<Test::R>($t0)
   2: $t4 := !($t3)
-  3: if ($t4) goto L0 else goto L1
-  4: L1:
-  5: goto L2
-  6: L0:
+  3: if ($t4) goto 6 else goto 4
+  4: label L1
+  5: goto 10
+  6: label L0
   7: $t5 := 33
   8: $t6 := move($t5)
-  9: goto L4
- 10: L2:
+  9: goto 24
+ 10: label L2
  11: $t1 := borrow_global<Test::R>($t0)
- 12: on_abort(L4, $t6)
- 13: unpack_ref($t1)
- 14: $t7 := get_field<Test::R>.v($t1)
- 15: $t8 := get_field<Test::R>.v($t1)
- 16: $t9 := 1
- 17: $t10 := +($t8, $t9)
- 18: on_abort(L4, $t6)
- 19: $t11 := borrow_field<Test::R>.v($t1)
- 20: unpack_ref($t11)
- 21: write_ref($t11, $t10)
- 22: pack_ref($t11)
- 23: write_back[Reference($t1)]($t11)
- 24: pack_ref($t1)
- 25: write_back[Test::R]($t1)
- 26: L3:
- 27: return $t7
- 28: L4:
- 29: abort($t6)
+ 12: on_abort goto 24 code := $t6
+ 13: $t7 := get_field<Test::R>.v($t1)
+ 14: $t8 := get_field<Test::R>.v($t1)
+ 15: $t9 := 1
+ 16: $t10 := +($t8, $t9)
+ 17: on_abort goto 24 code := $t6
+ 18: $t11 := borrow_field<Test::R>.v($t1)
+ 19: write_ref($t11, $t10)
+ 20: write_back[Reference($t1)]($t11)
+ 21: write_back[Test::R]($t1)
+ 22: label L3
+ 23: return $t7
+ 24: label L4
+ 25: abort($t6)
 }
 
 
@@ -133,47 +129,43 @@ fun Test::get_and_incr($t0|addr: address): u64 {
   1: @0 := save_mem(Test::R)
   2: $t3 := exists<Test::R>($t0)
   3: $t4 := !($t3)
-  4: if ($t4) goto L0 else goto L1
-  5: L1:
-  6: goto L2
-  7: L0:
+  4: if ($t4) goto 7 else goto 5
+  5: label L1
+  6: goto 11
+  7: label L0
   8: $t5 := 33
   9: $t6 := move($t5)
- 10: goto L4
- 11: L2:
+ 10: goto 30
+ 11: label L2
      // VC: `caller does not have permission to modify `Test::R` at given address` at tests/spec_instrumentation/opaque_call.move:8:14+17
  12: assert CanModify<Test::R>($t0)
  13: $t1 := borrow_global<Test::R>($t0)
- 14: on_abort(L4, $t6)
- 15: unpack_ref($t1)
- 16: $t7 := get_field<Test::R>.v($t1)
- 17: $t8 := get_field<Test::R>.v($t1)
- 18: $t9 := 1
- 19: $t10 := +($t8, $t9)
- 20: on_abort(L4, $t6)
- 21: $t11 := borrow_field<Test::R>.v($t1)
- 22: unpack_ref($t11)
- 23: write_ref($t11, $t10)
- 24: pack_ref($t11)
- 25: write_back[Reference($t1)]($t11)
- 26: pack_ref($t1)
- 27: write_back[Test::R]($t1)
- 28: L3:
+ 14: on_abort goto 30 code := $t6
+ 15: $t7 := get_field<Test::R>.v($t1)
+ 16: $t8 := get_field<Test::R>.v($t1)
+ 17: $t9 := 1
+ 18: $t10 := +($t8, $t9)
+ 19: on_abort goto 30 code := $t6
+ 20: $t11 := borrow_field<Test::R>.v($t1)
+ 21: write_ref($t11, $t10)
+ 22: write_back[Reference($t1)]($t11)
+ 23: write_back[Test::R]($t1)
+ 24: label L3
      // VC: `function does not abort under this condition` at tests/spec_instrumentation/opaque_call.move:16:6+35
- 29: assert Not(Not(exists[@0]<Test::R>($t0)))
+ 25: assert Not(Not(exists[@0]<Test::R>($t0)))
      // VC: `function does not abort under this condition` at tests/spec_instrumentation/opaque_call.move:17:6+56
- 30: assert Not(Ge(Add(select Test::R.v(global[@0]<Test::R>($t0)), 1), 18446744073709551615))
+ 26: assert Not(Ge(Add(select Test::R.v(global[@0]<Test::R>($t0)), 1), 18446744073709551615))
      // VC: `post-condition does not hold` at tests/spec_instrumentation/opaque_call.move:19:6+56
- 31: assert Eq<u64>(select Test::R.v(global<Test::R>($t0)), Add(select Test::R.v(global[@0]<Test::R>($t0)), 1))
+ 27: assert Eq<u64>(select Test::R.v(global<Test::R>($t0)), Add(select Test::R.v(global[@0]<Test::R>($t0)), 1))
      // VC: `post-condition does not hold` at tests/spec_instrumentation/opaque_call.move:20:6+36
- 32: assert Eq<u64>($t7, select Test::R.v(global<Test::R>($t0)))
- 33: return $t7
- 34: L4:
+ 28: assert Eq<u64>($t7, select Test::R.v(global<Test::R>($t0)))
+ 29: return $t7
+ 30: label L4
      // VC: `abort not covered by any of the `aborts_if` clauses` at tests/spec_instrumentation/opaque_call.move:6:2+175
- 35: assert Or(Not(exists[@0]<Test::R>($t0)), Ge(Add(select Test::R.v(global[@0]<Test::R>($t0)), 1), 18446744073709551615))
+ 31: assert Or(Not(exists[@0]<Test::R>($t0)), Ge(Add(select Test::R.v(global[@0]<Test::R>($t0)), 1), 18446744073709551615))
      // VC: `function aborts under this condition but with the wrong code` at tests/spec_instrumentation/opaque_call.move:16:38+2
- 36: assert Implies(Not(exists[@0]<Test::R>($t0)), Eq($t6, 33))
- 37: abort($t6)
+ 32: assert Implies(Not(exists[@0]<Test::R>($t0)), Eq($t6, 33))
+ 33: abort($t6)
 }
 
 
@@ -191,8 +183,8 @@ fun Test::incr_twice() {
   2: @6 := save_mem(Test::R)
   3: modifies global<Test::R>($t0)
   4: assume Eq($t1, And(Or(Not(exists[@6]<Test::R>($t0)), Ge(Add(select Test::R.v(global[@6]<Test::R>($t0)), 1), 18446744073709551615)), Implies(Not(exists[@6]<Test::R>($t0)), Eq($t2, 33))))
-  5: if ($t1) goto L2 else goto L3
-  6: L3:
+  5: if ($t1) goto 22 else goto 6
+  6: label L3
   7: assume Eq<u64>(select Test::R.v(global<Test::R>($t0)), Add(select Test::R.v(global[@6]<Test::R>($t0)), 1))
   8: assume Eq<u64>($t3, select Test::R.v(global<Test::R>($t0)))
   9: destroy($t3)
@@ -201,14 +193,14 @@ fun Test::incr_twice() {
  12: @7 := save_mem(Test::R)
  13: modifies global<Test::R>($t4)
  14: assume Eq($t5, And(Or(Not(exists[@7]<Test::R>($t4)), Ge(Add(select Test::R.v(global[@7]<Test::R>($t4)), 1), 18446744073709551615)), Implies(Not(exists[@7]<Test::R>($t4)), Eq($t2, 33))))
- 15: if ($t5) goto L2 else goto L4
- 16: L4:
+ 15: if ($t5) goto 22 else goto 16
+ 16: label L4
  17: assume Eq<u64>(select Test::R.v(global<Test::R>($t4)), Add(select Test::R.v(global[@7]<Test::R>($t4)), 1))
  18: assume Eq<u64>($t6, select Test::R.v(global<Test::R>($t4)))
  19: destroy($t6)
- 20: L1:
+ 20: label L1
  21: return ()
- 22: L2:
+ 22: label L2
  23: abort($t2)
 }
 
@@ -229,8 +221,8 @@ fun Test::incr_twice() {
   3: @3 := save_mem(Test::R)
   4: modifies global<Test::R>($t0)
   5: assume Eq($t1, And(Or(Not(exists[@3]<Test::R>($t0)), Ge(Add(select Test::R.v(global[@3]<Test::R>($t0)), 1), 18446744073709551615)), Implies(Not(exists[@3]<Test::R>($t0)), Eq($t2, 33))))
-  6: if ($t1) goto L2 else goto L3
-  7: L3:
+  6: if ($t1) goto 25 else goto 7
+  7: label L3
   8: assume Eq<u64>(select Test::R.v(global<Test::R>($t0)), Add(select Test::R.v(global[@3]<Test::R>($t0)), 1))
   9: assume Eq<u64>($t3, select Test::R.v(global<Test::R>($t0)))
  10: destroy($t3)
@@ -239,18 +231,18 @@ fun Test::incr_twice() {
  13: @4 := save_mem(Test::R)
  14: modifies global<Test::R>($t4)
  15: assume Eq($t5, And(Or(Not(exists[@4]<Test::R>($t4)), Ge(Add(select Test::R.v(global[@4]<Test::R>($t4)), 1), 18446744073709551615)), Implies(Not(exists[@4]<Test::R>($t4)), Eq($t2, 33))))
- 16: if ($t5) goto L2 else goto L4
- 17: L4:
+ 16: if ($t5) goto 25 else goto 17
+ 17: label L4
  18: assume Eq<u64>(select Test::R.v(global<Test::R>($t4)), Add(select Test::R.v(global[@4]<Test::R>($t4)), 1))
  19: assume Eq<u64>($t6, select Test::R.v(global<Test::R>($t4)))
  20: destroy($t6)
- 21: L1:
+ 21: label L1
      // VC: `function does not abort under this condition` at tests/spec_instrumentation/opaque_call.move:28:6+34
  22: assert Not(Not(exists[@2]<Test::R>(1)))
      // VC: `post-condition does not hold` at tests/spec_instrumentation/opaque_call.move:29:6+54
  23: assert Eq<u64>(select Test::R.v(global<Test::R>(1)), Add(select Test::R.v(global[@2]<Test::R>(1)), 2))
  24: return ()
- 25: L2:
+ 25: label L2
      // VC: `abort not covered by any of the `aborts_if` clauses` at tests/spec_instrumentation/opaque_call.move:23:2+80
  26: assert Not(exists[@2]<Test::R>(1))
      // VC: `function aborts under this condition but with the wrong code` at tests/spec_instrumentation/opaque_call.move:28:37+2

--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -942,7 +942,11 @@ impl<'env> ModuleTranslator<'env> {
         // Set location of this code in the CodeWriter.
         let loc = func_target.get_bytecode_loc(bytecode.get_attr_id());
         self.writer.set_location(&loc);
-        emitln!(self.writer, "// {}", bytecode.display(func_target));
+        emitln!(
+            self.writer,
+            "// {}",
+            bytecode.display(func_target, &BTreeMap::default())
+        );
 
         // Helper function to get an Rc<String> for a local.
         let str_local = |idx: usize| {

--- a/language/move-prover/tests/xsources/design/README.md
+++ b/language/move-prover/tests/xsources/design/README.md
@@ -1,0 +1,10 @@
+A set of examples for illustrating how the bytecode transformation pipeline works.
+
+Run as in:
+
+```
+mvp -k --v2 --dump-bytecode <example>.move
+```
+
+The current directory will contain bytecode dumps for each phase in `<example>_*.bytecode`,
+as well as `output.bpl` with the Boogie code.

--- a/language/move-prover/tests/xsources/design/opaque.move
+++ b/language/move-prover/tests/xsources/design/opaque.move
@@ -1,0 +1,22 @@
+// flag: --v2
+address 0x0 {
+/// Example for opaque function calls.
+module Trafo {
+  public fun opaque_decr(x: u64): u64 {
+      x - 1
+  }
+  spec fun opaque_decr {
+      pragma opaque;
+      aborts_if x == 0;
+      ensures result == x - 1;
+  }
+
+  public fun opaque_caller(x: u64): u64 {
+      opaque_decr(opaque_decr(x))
+  }
+  spec fun opaque_caller {
+      aborts_if x < 2;
+      ensures result == x - 2;
+  }
+}
+}

--- a/language/move-prover/tests/xsources/design/opaque_0_stackless.bytecode
+++ b/language/move-prover/tests/xsources/design/opaque_0_stackless.bytecode
@@ -1,0 +1,24 @@
+============ after processor `stackless` ================
+
+[variant baseline]
+pub fun Trafo::opaque_caller($t0|x: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t1 := copy($t0)
+  1: $t2 := Trafo::opaque_decr($t1)
+  2: $t3 := Trafo::opaque_decr($t2)
+  3: return $t3
+}
+
+
+[variant baseline]
+pub fun Trafo::opaque_decr($t0|x: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t1 := copy($t0)
+  1: $t2 := 1
+  2: $t3 := -($t1, $t2)
+  3: return $t3
+}

--- a/language/move-prover/tests/xsources/design/opaque_10_spec_instrumenter.bytecode
+++ b/language/move-prover/tests/xsources/design/opaque_10_spec_instrumenter.bytecode
@@ -1,0 +1,94 @@
+============ after processor `spec_instrumenter` ================
+
+[variant baseline]
+pub fun Trafo::opaque_caller($t0|x: u64): u64 {
+     var $t1: bool
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: num
+  0: trace_local[x]($t0)
+  1: assume Eq($t1, Eq<u64>($t0, 0))
+  2: if ($t1) goto 12 else goto 3
+  3: label L3
+  4: assume Eq<u64>($t2, Sub($t0, 1))
+  5: assume Eq($t3, Eq<u64>($t2, 0))
+  6: if ($t3) goto 12 else goto 7
+  7: label L4
+  8: assume Eq<u64>($t4, Sub($t2, 1))
+  9: trace_return[0]($t4)
+ 10: label L1
+ 11: return $t4
+ 12: label L2
+ 13: abort($t5)
+}
+
+
+[variant verification]
+pub fun Trafo::opaque_caller($t0|x: u64): u64 {
+     var $t1: bool
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: num
+  0: trace_local[x]($t0)
+  1: assume Eq($t1, Eq<u64>($t0, 0))
+  2: if ($t1) goto 14 else goto 3
+  3: label L3
+  4: assume Eq<u64>($t2, Sub($t0, 1))
+  5: assume Eq($t3, Eq<u64>($t2, 0))
+  6: if ($t3) goto 14 else goto 7
+  7: label L4
+  8: assume Eq<u64>($t4, Sub($t2, 1))
+  9: trace_return[0]($t4)
+ 10: label L1
+     // VC: `function does not abort under this condition` at opaque.move:18:7+16
+ 11: assert Not(Lt($t0, 2))
+     // VC: `post-condition does not hold` at opaque.move:19:7+24
+ 12: assert Eq<u64>($t4, Sub($t0, 2))
+ 13: return $t4
+ 14: label L2
+     // VC: `abort not covered by any of the `aborts_if` clauses` at opaque.move:14:3+77
+ 15: assert Lt($t0, 2)
+ 16: abort($t5)
+}
+
+
+[variant baseline]
+pub fun Trafo::opaque_decr($t0|x: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: num
+  0: trace_local[x]($t0)
+  1: $t1 := 1
+  2: $t2 := -($t0, $t1)
+  3: on_abort goto 7 code := $t3
+  4: trace_return[0]($t2)
+  5: label L1
+  6: return $t2
+  7: label L2
+  8: abort($t3)
+}
+
+
+[variant verification]
+pub fun Trafo::opaque_decr($t0|x: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: num
+  0: trace_local[x]($t0)
+  1: $t1 := 1
+  2: $t2 := -($t0, $t1)
+  3: on_abort goto 9 code := $t3
+  4: trace_return[0]($t2)
+  5: label L1
+     // VC: `function does not abort under this condition` at opaque.move:10:7+17
+  6: assert Not(Eq<u64>($t0, 0))
+     // VC: `post-condition does not hold` at opaque.move:11:7+24
+  7: assert Eq<u64>($t2, Sub($t0, 1))
+  8: return $t2
+  9: label L2
+     // VC: `abort not covered by any of the `aborts_if` clauses` at opaque.move:5:3+53
+ 10: assert Eq<u64>($t0, 0)
+ 11: abort($t3)
+}

--- a/language/move-prover/tests/xsources/design/opaque_1_debug_instrumenter.bytecode
+++ b/language/move-prover/tests/xsources/design/opaque_1_debug_instrumenter.bytecode
@@ -1,0 +1,28 @@
+============ after processor `debug_instrumenter` ================
+
+[variant baseline]
+pub fun Trafo::opaque_caller($t0|x: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: trace_local[x]($t0)
+  1: $t1 := copy($t0)
+  2: $t2 := Trafo::opaque_decr($t1)
+  3: $t3 := Trafo::opaque_decr($t2)
+  4: trace_return[0]($t3)
+  5: return $t3
+}
+
+
+[variant baseline]
+pub fun Trafo::opaque_decr($t0|x: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: trace_local[x]($t0)
+  1: $t1 := copy($t0)
+  2: $t2 := 1
+  3: $t3 := -($t1, $t2)
+  4: trace_return[0]($t3)
+  5: return $t3
+}

--- a/language/move-prover/tests/xsources/design/opaque_2_eliminate_imm_refs.bytecode
+++ b/language/move-prover/tests/xsources/design/opaque_2_eliminate_imm_refs.bytecode
@@ -1,0 +1,28 @@
+============ after processor `eliminate_imm_refs` ================
+
+[variant baseline]
+pub fun Trafo::opaque_caller($t0|x: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: trace_local[x]($t0)
+  1: $t1 := copy($t0)
+  2: $t2 := Trafo::opaque_decr($t1)
+  3: $t3 := Trafo::opaque_decr($t2)
+  4: trace_return[0]($t3)
+  5: return $t3
+}
+
+
+[variant baseline]
+pub fun Trafo::opaque_decr($t0|x: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: trace_local[x]($t0)
+  1: $t1 := copy($t0)
+  2: $t2 := 1
+  3: $t3 := -($t1, $t2)
+  4: trace_return[0]($t3)
+  5: return $t3
+}

--- a/language/move-prover/tests/xsources/design/opaque_3_eliminate_mut_refs.bytecode
+++ b/language/move-prover/tests/xsources/design/opaque_3_eliminate_mut_refs.bytecode
@@ -1,0 +1,32 @@
+============ after processor `eliminate_mut_refs` ================
+
+[variant baseline]
+pub fun Trafo::opaque_caller($t0|x: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+  0: $t4 := move($t0)
+  1: trace_local[x]($t4)
+  2: $t1 := copy($t4)
+  3: $t2 := Trafo::opaque_decr($t1)
+  4: $t3 := Trafo::opaque_decr($t2)
+  5: trace_return[0]($t3)
+  6: return $t3
+}
+
+
+[variant baseline]
+pub fun Trafo::opaque_decr($t0|x: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+  0: $t4 := move($t0)
+  1: trace_local[x]($t4)
+  2: $t1 := copy($t4)
+  3: $t2 := 1
+  4: $t3 := -($t1, $t2)
+  5: trace_return[0]($t3)
+  6: return $t3
+}

--- a/language/move-prover/tests/xsources/design/opaque_4_reaching_def_analysis.bytecode
+++ b/language/move-prover/tests/xsources/design/opaque_4_reaching_def_analysis.bytecode
@@ -1,0 +1,32 @@
+============ after processor `reaching_def_analysis` ================
+
+[variant baseline]
+pub fun Trafo::opaque_caller($t0|x: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+  0: $t4 := move($t0)
+  1: trace_local[x]($t4)
+  2: $t1 := copy($t4)
+  3: $t2 := Trafo::opaque_decr($t4)
+  4: $t3 := Trafo::opaque_decr($t2)
+  5: trace_return[0]($t3)
+  6: return $t3
+}
+
+
+[variant baseline]
+pub fun Trafo::opaque_decr($t0|x: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+  0: $t4 := move($t0)
+  1: trace_local[x]($t4)
+  2: $t1 := copy($t4)
+  3: $t2 := 1
+  4: $t3 := -($t4, $t2)
+  5: trace_return[0]($t3)
+  6: return $t3
+}

--- a/language/move-prover/tests/xsources/design/opaque_5_livevar_analysis.bytecode
+++ b/language/move-prover/tests/xsources/design/opaque_5_livevar_analysis.bytecode
@@ -1,0 +1,40 @@
+============ after processor `livevar_analysis` ================
+
+[variant baseline]
+pub fun Trafo::opaque_caller($t0|x: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     // live vars: x
+  0: $t1 := move($t0)
+     // live vars: $t1
+  1: trace_local[x]($t1)
+     // live vars: $t1
+  2: $t2 := Trafo::opaque_decr($t1)
+     // live vars: $t2
+  3: $t3 := Trafo::opaque_decr($t2)
+     // live vars: $t3
+  4: trace_return[0]($t3)
+     // live vars: $t3
+  5: return $t3
+}
+
+
+[variant baseline]
+pub fun Trafo::opaque_decr($t0|x: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     // live vars: x
+  0: $t1 := move($t0)
+     // live vars: $t1
+  1: trace_local[x]($t1)
+     // live vars: $t1
+  2: $t2 := 1
+     // live vars: $t1, $t2
+  3: $t3 := -($t1, $t2)
+     // live vars: $t3
+  4: trace_return[0]($t3)
+     // live vars: $t3
+  5: return $t3
+}

--- a/language/move-prover/tests/xsources/design/opaque_6_borrow_analysis.bytecode
+++ b/language/move-prover/tests/xsources/design/opaque_6_borrow_analysis.bytecode
@@ -1,0 +1,50 @@
+============ after processor `borrow_analysis` ================
+
+[variant baseline]
+pub fun Trafo::opaque_caller($t0|x: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     // live_nodes: LocalRoot($t0)
+  0: $t1 := move($t0)
+     // live_nodes: LocalRoot($t1)
+     // moved_nodes: LocalRoot($t0)
+  1: trace_local[x]($t1)
+     // live_nodes: LocalRoot($t1)
+     // moved_nodes: LocalRoot($t0)
+  2: $t2 := Trafo::opaque_decr($t1)
+     // live_nodes: LocalRoot($t1)
+     // moved_nodes: LocalRoot($t0)
+  3: $t3 := Trafo::opaque_decr($t2)
+     // live_nodes: LocalRoot($t1)
+     // moved_nodes: LocalRoot($t0)
+  4: trace_return[0]($t3)
+     // live_nodes: LocalRoot($t1)
+     // moved_nodes: LocalRoot($t0)
+  5: return $t3
+}
+
+
+[variant baseline]
+pub fun Trafo::opaque_decr($t0|x: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     // live_nodes: LocalRoot($t0)
+  0: $t1 := move($t0)
+     // live_nodes: LocalRoot($t1)
+     // moved_nodes: LocalRoot($t0)
+  1: trace_local[x]($t1)
+     // live_nodes: LocalRoot($t1)
+     // moved_nodes: LocalRoot($t0)
+  2: $t2 := 1
+     // live_nodes: LocalRoot($t1)
+     // moved_nodes: LocalRoot($t0)
+  3: $t3 := -($t1, $t2)
+     // live_nodes: LocalRoot($t1)
+     // moved_nodes: LocalRoot($t0)
+  4: trace_return[0]($t3)
+     // live_nodes: LocalRoot($t1)
+     // moved_nodes: LocalRoot($t0)
+  5: return $t3
+}

--- a/language/move-prover/tests/xsources/design/opaque_7_memory_instr.bytecode
+++ b/language/move-prover/tests/xsources/design/opaque_7_memory_instr.bytecode
@@ -1,0 +1,28 @@
+============ after processor `memory_instr` ================
+
+[variant baseline]
+pub fun Trafo::opaque_caller($t0|x: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t1 := move($t0)
+  1: trace_local[x]($t1)
+  2: $t2 := Trafo::opaque_decr($t1)
+  3: $t3 := Trafo::opaque_decr($t2)
+  4: trace_return[0]($t3)
+  5: return $t3
+}
+
+
+[variant baseline]
+pub fun Trafo::opaque_decr($t0|x: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t1 := move($t0)
+  1: trace_local[x]($t1)
+  2: $t2 := 1
+  3: $t3 := -($t1, $t2)
+  4: trace_return[0]($t3)
+  5: return $t3
+}

--- a/language/move-prover/tests/xsources/design/opaque_8_clean_and_optimize.bytecode
+++ b/language/move-prover/tests/xsources/design/opaque_8_clean_and_optimize.bytecode
@@ -1,0 +1,28 @@
+============ after processor `clean_and_optimize` ================
+
+[variant baseline]
+pub fun Trafo::opaque_caller($t0|x: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t1 := move($t0)
+  1: trace_local[x]($t1)
+  2: $t2 := Trafo::opaque_decr($t1)
+  3: $t3 := Trafo::opaque_decr($t2)
+  4: trace_return[0]($t3)
+  5: return $t3
+}
+
+
+[variant baseline]
+pub fun Trafo::opaque_decr($t0|x: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t1 := move($t0)
+  1: trace_local[x]($t1)
+  2: $t2 := 1
+  3: $t3 := -($t1, $t2)
+  4: trace_return[0]($t3)
+  5: return $t3
+}

--- a/language/move-prover/tests/xsources/design/opaque_9_usage_analysis.bytecode
+++ b/language/move-prover/tests/xsources/design/opaque_9_usage_analysis.bytecode
@@ -1,0 +1,28 @@
+============ after processor `usage_analysis` ================
+
+[variant baseline]
+pub fun Trafo::opaque_caller($t0|x: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t1 := move($t0)
+  1: trace_local[x]($t1)
+  2: $t2 := Trafo::opaque_decr($t1)
+  3: $t3 := Trafo::opaque_decr($t2)
+  4: trace_return[0]($t3)
+  5: return $t3
+}
+
+
+[variant baseline]
+pub fun Trafo::opaque_decr($t0|x: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t1 := move($t0)
+  1: trace_local[x]($t1)
+  2: $t2 := 1
+  3: $t3 := -($t1, $t2)
+  4: trace_return[0]($t3)
+  5: return $t3
+}

--- a/language/move-prover/tests/xsources/design/references.move
+++ b/language/move-prover/tests/xsources/design/references.move
@@ -1,0 +1,28 @@
+// flag: --v2
+address 0x0 {
+/// Example for reference elimination.
+module Trafo {
+
+  struct R { x: u64 }
+
+  public fun incr_ref(r: &mut u64) {
+      *r = *r + 1;
+  }
+  spec fun incr_ref {
+    ensures r == old(r) + 1;
+  }
+
+  public fun use_incr_ref(b: bool): R {
+      let r1 = R{x:1};
+      let r2 = R{x:2};
+      let r_ref = if (b) &mut r1 else &mut r2;
+      incr_ref(&mut r_ref.x);
+      r2
+  }
+  spec fun use_incr_ref {
+      ensures b ==> result == R{x:2};
+      ensures !b ==> result == R{x:3};
+  }
+
+}
+}

--- a/language/move-prover/tests/xsources/design/references_0_stackless.bytecode
+++ b/language/move-prover/tests/xsources/design/references_0_stackless.bytecode
@@ -1,0 +1,63 @@
+============ after processor `stackless` ================
+
+[variant baseline]
+pub fun Trafo::incr_ref($t0|r: &mut u64) {
+     var $t1: &mut u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: &mut u64
+  0: $t1 := copy($t0)
+  1: $t2 := read_ref($t1)
+  2: $t3 := 1
+  3: $t4 := +($t2, $t3)
+  4: $t5 := move($t0)
+  5: write_ref($t5, $t4)
+  6: return ()
+}
+
+
+[variant baseline]
+pub fun Trafo::use_incr_ref($t0|b: bool): Trafo::R {
+     var $t1|r1: Trafo::R
+     var $t2|r2: Trafo::R
+     var $t3|r_ref: &mut Trafo::R
+     var $t4|tmp#$4: &mut Trafo::R
+     var $t5: u64
+     var $t6: Trafo::R
+     var $t7: u64
+     var $t8: Trafo::R
+     var $t9: bool
+     var $t10: &mut Trafo::R
+     var $t11: &mut Trafo::R
+     var $t12: &mut Trafo::R
+     var $t13: &mut Trafo::R
+     var $t14: &mut u64
+     var $t15: Trafo::R
+  0: $t5 := 1
+  1: $t6 := pack Trafo::R($t5)
+  2: $t1 := $t6
+  3: $t7 := 2
+  4: $t8 := pack Trafo::R($t7)
+  5: $t2 := $t8
+  6: $t9 := copy($t0)
+  7: if ($t9) goto 10 else goto 8
+  8: label L1
+  9: goto 14
+ 10: label L0
+ 11: $t10 := borrow_local($t1)
+ 12: $t4 := $t10
+ 13: goto 18
+ 14: label L2
+ 15: $t11 := borrow_local($t2)
+ 16: $t4 := $t11
+ 17: goto 18
+ 18: label L3
+ 19: $t12 := move($t4)
+ 20: $t3 := $t12
+ 21: $t13 := move($t3)
+ 22: $t14 := borrow_field<Trafo::R>.x($t13)
+ 23: Trafo::incr_ref($t14)
+ 24: $t15 := move($t2)
+ 25: return $t15
+}

--- a/language/move-prover/tests/xsources/design/references_10_spec_instrumenter.bytecode
+++ b/language/move-prover/tests/xsources/design/references_10_spec_instrumenter.bytecode
@@ -1,0 +1,156 @@
+============ after processor `spec_instrumenter` ================
+
+[variant baseline]
+pub fun Trafo::incr_ref($t0|r: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: num
+  0: $t1 := move($t0)
+  1: $t2 := borrow_local($t1)
+  2: trace_local[r]($t2)
+  3: $t3 := read_ref($t2)
+  4: $t4 := 1
+  5: $t5 := +($t3, $t4)
+  6: on_abort goto 11 code := $t6
+  7: write_ref($t2, $t5)
+  8: write_back[LocalRoot($t1)]($t2)
+  9: label L1
+ 10: return $t1
+ 11: label L2
+ 12: abort($t6)
+}
+
+
+[variant verification]
+pub fun Trafo::incr_ref($t0|r: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: num
+  0: $t1 := move($t0)
+  1: $t2 := borrow_local($t1)
+  2: trace_local[r]($t2)
+  3: $t3 := read_ref($t2)
+  4: $t4 := 1
+  5: $t5 := +($t3, $t4)
+  6: on_abort goto 12 code := $t6
+  7: write_ref($t2, $t5)
+  8: write_back[LocalRoot($t1)]($t2)
+  9: label L1
+     // VC: `post-condition does not hold` at references.move:12:5+24
+ 10: assert Eq<u64>($t1, Add($t0, 1))
+ 11: return $t1
+ 12: label L2
+ 13: abort($t6)
+}
+
+
+[variant baseline]
+pub fun Trafo::use_incr_ref($t0|b: bool): Trafo::R {
+     var $t1|r1: Trafo::R
+     var $t2|r2: Trafo::R
+     var $t3|r_ref: &mut Trafo::R
+     var $t4|tmp#$4: &mut Trafo::R
+     var $t5: u64
+     var $t6: u64
+     var $t7: &mut Trafo::R
+     var $t8: &mut Trafo::R
+     var $t9: &mut u64
+     var $t10: u64
+     var $t11: num
+  0: trace_local[b]($t0)
+  1: $t5 := 1
+  2: $t1 := pack Trafo::R($t5)
+  3: trace_local[r1]($t1)
+  4: $t6 := 2
+  5: $t2 := pack Trafo::R($t6)
+  6: trace_local[r2]($t2)
+  7: if ($t0) goto 10 else goto 8
+  8: label L1
+  9: goto 15
+ 10: label L0
+ 11: $t7 := borrow_local($t1)
+ 12: $t4 := $t7
+ 13: trace_local[tmp#$4]($t7)
+ 14: goto 19
+ 15: label L2
+ 16: $t8 := borrow_local($t2)
+ 17: $t4 := $t8
+ 18: trace_local[tmp#$4]($t8)
+ 19: label L3
+ 20: $t3 := $t4
+ 21: trace_local[r_ref]($t3)
+ 22: $t9 := borrow_field<Trafo::R>.x($t3)
+ 23: $t10 := read_ref($t9)
+ 24: $t10 := Trafo::incr_ref($t10)
+ 25: on_abort goto 33 code := $t11
+ 26: write_ref($t9, $t10)
+ 27: write_back[Reference($t3)]($t9)
+ 28: write_back[LocalRoot($t1)]($t3)
+ 29: write_back[LocalRoot($t2)]($t3)
+ 30: trace_return[0]($t2)
+ 31: label L4
+ 32: return $t2
+ 33: label L5
+ 34: abort($t11)
+}
+
+
+[variant verification]
+pub fun Trafo::use_incr_ref($t0|b: bool): Trafo::R {
+     var $t1|r1: Trafo::R
+     var $t2|r2: Trafo::R
+     var $t3|r_ref: &mut Trafo::R
+     var $t4|tmp#$4: &mut Trafo::R
+     var $t5: u64
+     var $t6: u64
+     var $t7: &mut Trafo::R
+     var $t8: &mut Trafo::R
+     var $t9: &mut u64
+     var $t10: u64
+     var $t11: num
+  0: trace_local[b]($t0)
+  1: $t5 := 1
+  2: $t1 := pack Trafo::R($t5)
+  3: trace_local[r1]($t1)
+  4: $t6 := 2
+  5: $t2 := pack Trafo::R($t6)
+  6: trace_local[r2]($t2)
+  7: if ($t0) goto 10 else goto 8
+  8: label L1
+  9: goto 15
+ 10: label L0
+ 11: $t7 := borrow_local($t1)
+ 12: $t4 := $t7
+ 13: trace_local[tmp#$4]($t7)
+ 14: goto 19
+ 15: label L2
+ 16: $t8 := borrow_local($t2)
+ 17: $t4 := $t8
+ 18: trace_local[tmp#$4]($t8)
+ 19: label L3
+ 20: $t3 := $t4
+ 21: trace_local[r_ref]($t3)
+ 22: $t9 := borrow_field<Trafo::R>.x($t3)
+ 23: $t10 := read_ref($t9)
+ 24: $t10 := Trafo::incr_ref($t10)
+ 25: on_abort goto 35 code := $t11
+ 26: write_ref($t9, $t10)
+ 27: write_back[Reference($t3)]($t9)
+ 28: write_back[LocalRoot($t1)]($t3)
+ 29: write_back[LocalRoot($t2)]($t3)
+ 30: trace_return[0]($t2)
+ 31: label L4
+     // VC: `post-condition does not hold` at references.move:23:7+31
+ 32: assert Implies($t0, Eq<Trafo::R>($t2, pack Trafo::R(2)))
+     // VC: `post-condition does not hold` at references.move:24:7+32
+ 33: assert Implies(Not($t0), Eq<Trafo::R>($t2, pack Trafo::R(3)))
+ 34: return $t2
+ 35: label L5
+ 36: abort($t11)
+}

--- a/language/move-prover/tests/xsources/design/references_1_debug_instrumenter.bytecode
+++ b/language/move-prover/tests/xsources/design/references_1_debug_instrumenter.bytecode
@@ -1,0 +1,70 @@
+============ after processor `debug_instrumenter` ================
+
+[variant baseline]
+pub fun Trafo::incr_ref($t0|r: &mut u64) {
+     var $t1: &mut u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: &mut u64
+  0: trace_local[r]($t0)
+  1: $t1 := copy($t0)
+  2: $t2 := read_ref($t1)
+  3: $t3 := 1
+  4: $t4 := +($t2, $t3)
+  5: $t5 := move($t0)
+  6: write_ref($t5, $t4)
+  7: return ()
+}
+
+
+[variant baseline]
+pub fun Trafo::use_incr_ref($t0|b: bool): Trafo::R {
+     var $t1|r1: Trafo::R
+     var $t2|r2: Trafo::R
+     var $t3|r_ref: &mut Trafo::R
+     var $t4|tmp#$4: &mut Trafo::R
+     var $t5: u64
+     var $t6: Trafo::R
+     var $t7: u64
+     var $t8: Trafo::R
+     var $t9: bool
+     var $t10: &mut Trafo::R
+     var $t11: &mut Trafo::R
+     var $t12: &mut Trafo::R
+     var $t13: &mut Trafo::R
+     var $t14: &mut u64
+     var $t15: Trafo::R
+  0: trace_local[b]($t0)
+  1: $t5 := 1
+  2: $t6 := pack Trafo::R($t5)
+  3: $t1 := $t6
+  4: trace_local[r1]($t1)
+  5: $t7 := 2
+  6: $t8 := pack Trafo::R($t7)
+  7: $t2 := $t8
+  8: trace_local[r2]($t2)
+  9: $t9 := copy($t0)
+ 10: if ($t9) goto 13 else goto 11
+ 11: label L1
+ 12: goto 18
+ 13: label L0
+ 14: $t10 := borrow_local($t1)
+ 15: $t4 := $t10
+ 16: trace_local[tmp#$4]($t4)
+ 17: goto 22
+ 18: label L2
+ 19: $t11 := borrow_local($t2)
+ 20: $t4 := $t11
+ 21: trace_local[tmp#$4]($t4)
+ 22: label L3
+ 23: $t12 := move($t4)
+ 24: $t3 := $t12
+ 25: trace_local[r_ref]($t3)
+ 26: $t13 := move($t3)
+ 27: $t14 := borrow_field<Trafo::R>.x($t13)
+ 28: Trafo::incr_ref($t14)
+ 29: $t15 := move($t2)
+ 30: trace_return[0]($t15)
+ 31: return $t15
+}

--- a/language/move-prover/tests/xsources/design/references_2_eliminate_imm_refs.bytecode
+++ b/language/move-prover/tests/xsources/design/references_2_eliminate_imm_refs.bytecode
@@ -1,0 +1,70 @@
+============ after processor `eliminate_imm_refs` ================
+
+[variant baseline]
+pub fun Trafo::incr_ref($t0|r: &mut u64) {
+     var $t1: &mut u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: &mut u64
+  0: trace_local[r]($t0)
+  1: $t1 := copy($t0)
+  2: $t2 := read_ref($t1)
+  3: $t3 := 1
+  4: $t4 := +($t2, $t3)
+  5: $t5 := move($t0)
+  6: write_ref($t5, $t4)
+  7: return ()
+}
+
+
+[variant baseline]
+pub fun Trafo::use_incr_ref($t0|b: bool): Trafo::R {
+     var $t1|r1: Trafo::R
+     var $t2|r2: Trafo::R
+     var $t3|r_ref: &mut Trafo::R
+     var $t4|tmp#$4: &mut Trafo::R
+     var $t5: u64
+     var $t6: Trafo::R
+     var $t7: u64
+     var $t8: Trafo::R
+     var $t9: bool
+     var $t10: &mut Trafo::R
+     var $t11: &mut Trafo::R
+     var $t12: &mut Trafo::R
+     var $t13: &mut Trafo::R
+     var $t14: &mut u64
+     var $t15: Trafo::R
+  0: trace_local[b]($t0)
+  1: $t5 := 1
+  2: $t6 := pack Trafo::R($t5)
+  3: $t1 := $t6
+  4: trace_local[r1]($t1)
+  5: $t7 := 2
+  6: $t8 := pack Trafo::R($t7)
+  7: $t2 := $t8
+  8: trace_local[r2]($t2)
+  9: $t9 := copy($t0)
+ 10: if ($t9) goto 13 else goto 11
+ 11: label L1
+ 12: goto 18
+ 13: label L0
+ 14: $t10 := borrow_local($t1)
+ 15: $t4 := $t10
+ 16: trace_local[tmp#$4]($t4)
+ 17: goto 22
+ 18: label L2
+ 19: $t11 := borrow_local($t2)
+ 20: $t4 := $t11
+ 21: trace_local[tmp#$4]($t4)
+ 22: label L3
+ 23: $t12 := move($t4)
+ 24: $t3 := $t12
+ 25: trace_local[r_ref]($t3)
+ 26: $t13 := move($t3)
+ 27: $t14 := borrow_field<Trafo::R>.x($t13)
+ 28: Trafo::incr_ref($t14)
+ 29: $t15 := move($t2)
+ 30: trace_return[0]($t15)
+ 31: return $t15
+}

--- a/language/move-prover/tests/xsources/design/references_3_eliminate_mut_refs.bytecode
+++ b/language/move-prover/tests/xsources/design/references_3_eliminate_mut_refs.bytecode
@@ -1,0 +1,79 @@
+============ after processor `eliminate_mut_refs` ================
+
+[variant baseline]
+pub fun Trafo::incr_ref($t0|r: u64): u64 {
+     var $t1: &mut u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: &mut u64
+     var $t6: u64
+     var $t7: &mut u64
+  0: $t6 := move($t0)
+  1: $t7 := borrow_local($t6)
+  2: trace_local[r]($t7)
+  3: $t1 := copy($t7)
+  4: $t2 := read_ref($t1)
+  5: $t3 := 1
+  6: $t4 := +($t2, $t3)
+  7: $t5 := move($t7)
+  8: write_ref($t5, $t4)
+  9: return $t6
+}
+
+
+[variant baseline]
+pub fun Trafo::use_incr_ref($t0|b: bool): Trafo::R {
+     var $t1|r1: Trafo::R
+     var $t2|r2: Trafo::R
+     var $t3|r_ref: &mut Trafo::R
+     var $t4|tmp#$4: &mut Trafo::R
+     var $t5: u64
+     var $t6: Trafo::R
+     var $t7: u64
+     var $t8: Trafo::R
+     var $t9: bool
+     var $t10: &mut Trafo::R
+     var $t11: &mut Trafo::R
+     var $t12: &mut Trafo::R
+     var $t13: &mut Trafo::R
+     var $t14: &mut u64
+     var $t15: Trafo::R
+     var $t16: bool
+     var $t17: u64
+  0: $t16 := move($t0)
+  1: trace_local[b]($t16)
+  2: $t5 := 1
+  3: $t6 := pack Trafo::R($t5)
+  4: $t1 := $t6
+  5: trace_local[r1]($t1)
+  6: $t7 := 2
+  7: $t8 := pack Trafo::R($t7)
+  8: $t2 := $t8
+  9: trace_local[r2]($t2)
+ 10: $t9 := copy($t16)
+ 11: if ($t9) goto 14 else goto 12
+ 12: label L1
+ 13: goto 19
+ 14: label L0
+ 15: $t10 := borrow_local($t1)
+ 16: $t4 := $t10
+ 17: trace_local[tmp#$4]($t4)
+ 18: goto 23
+ 19: label L2
+ 20: $t11 := borrow_local($t2)
+ 21: $t4 := $t11
+ 22: trace_local[tmp#$4]($t4)
+ 23: label L3
+ 24: $t12 := move($t4)
+ 25: $t3 := $t12
+ 26: trace_local[r_ref]($t3)
+ 27: $t13 := move($t3)
+ 28: $t14 := borrow_field<Trafo::R>.x($t13)
+ 29: $t17 := read_ref($t14)
+ 30: $t17 := Trafo::incr_ref($t17)
+ 31: write_ref($t14, $t17)
+ 32: $t15 := move($t2)
+ 33: trace_return[0]($t15)
+ 34: return $t15
+}

--- a/language/move-prover/tests/xsources/design/references_4_reaching_def_analysis.bytecode
+++ b/language/move-prover/tests/xsources/design/references_4_reaching_def_analysis.bytecode
@@ -1,0 +1,79 @@
+============ after processor `reaching_def_analysis` ================
+
+[variant baseline]
+pub fun Trafo::incr_ref($t0|r: u64): u64 {
+     var $t1: &mut u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: &mut u64
+     var $t6: u64
+     var $t7: &mut u64
+  0: $t6 := move($t0)
+  1: $t7 := borrow_local($t6)
+  2: trace_local[r]($t7)
+  3: $t1 := copy($t7)
+  4: $t2 := read_ref($t7)
+  5: $t3 := 1
+  6: $t4 := +($t2, $t3)
+  7: $t5 := move($t7)
+  8: write_ref($t7, $t4)
+  9: return $t6
+}
+
+
+[variant baseline]
+pub fun Trafo::use_incr_ref($t0|b: bool): Trafo::R {
+     var $t1|r1: Trafo::R
+     var $t2|r2: Trafo::R
+     var $t3|r_ref: &mut Trafo::R
+     var $t4|tmp#$4: &mut Trafo::R
+     var $t5: u64
+     var $t6: Trafo::R
+     var $t7: u64
+     var $t8: Trafo::R
+     var $t9: bool
+     var $t10: &mut Trafo::R
+     var $t11: &mut Trafo::R
+     var $t12: &mut Trafo::R
+     var $t13: &mut Trafo::R
+     var $t14: &mut u64
+     var $t15: Trafo::R
+     var $t16: bool
+     var $t17: u64
+  0: $t16 := move($t0)
+  1: trace_local[b]($t16)
+  2: $t5 := 1
+  3: $t6 := pack Trafo::R($t5)
+  4: $t1 := $t6
+  5: trace_local[r1]($t1)
+  6: $t7 := 2
+  7: $t8 := pack Trafo::R($t7)
+  8: $t2 := $t8
+  9: trace_local[r2]($t2)
+ 10: $t9 := copy($t16)
+ 11: if ($t16) goto 14 else goto 12
+ 12: label L1
+ 13: goto 19
+ 14: label L0
+ 15: $t10 := borrow_local($t1)
+ 16: $t4 := $t10
+ 17: trace_local[tmp#$4]($t10)
+ 18: goto 23
+ 19: label L2
+ 20: $t11 := borrow_local($t2)
+ 21: $t4 := $t11
+ 22: trace_local[tmp#$4]($t11)
+ 23: label L3
+ 24: $t12 := move($t4)
+ 25: $t3 := $t4
+ 26: trace_local[r_ref]($t3)
+ 27: $t13 := move($t3)
+ 28: $t14 := borrow_field<Trafo::R>.x($t3)
+ 29: $t17 := read_ref($t14)
+ 30: $t17 := Trafo::incr_ref($t17)
+ 31: write_ref($t14, $t17)
+ 32: $t15 := move($t2)
+ 33: trace_return[0]($t2)
+ 34: return $t2
+}

--- a/language/move-prover/tests/xsources/design/references_5_livevar_analysis.bytecode
+++ b/language/move-prover/tests/xsources/design/references_5_livevar_analysis.bytecode
@@ -1,0 +1,100 @@
+============ after processor `livevar_analysis` ================
+
+[variant baseline]
+pub fun Trafo::incr_ref($t0|r: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     // live vars: r
+  0: $t1 := move($t0)
+     // live vars: $t1
+  1: $t2 := borrow_local($t1)
+     // live vars: $t1, $t2
+  2: trace_local[r]($t2)
+     // live vars: $t1, $t2
+  3: $t3 := read_ref($t2)
+     // live vars: $t1, $t2, $t3
+  4: $t4 := 1
+     // live vars: $t1, $t2, $t3, $t4
+  5: $t5 := +($t3, $t4)
+     // live vars: $t1, $t2, $t5
+  6: write_ref($t2, $t5)
+     // live vars: $t1
+  7: return $t1
+}
+
+
+[variant baseline]
+pub fun Trafo::use_incr_ref($t0|b: bool): Trafo::R {
+     var $t1|r1: Trafo::R
+     var $t2|r2: Trafo::R
+     var $t3|r_ref: &mut Trafo::R
+     var $t4|tmp#$4: &mut Trafo::R
+     var $t5: bool
+     var $t6: u64
+     var $t7: u64
+     var $t8: &mut Trafo::R
+     var $t9: &mut Trafo::R
+     var $t10: &mut u64
+     var $t11: u64
+     // live vars: b
+  0: $t5 := move($t0)
+     // live vars: $t5
+  1: trace_local[b]($t5)
+     // live vars: $t5
+  2: $t6 := 1
+     // live vars: $t5, $t6
+  3: $t1 := pack Trafo::R($t6)
+     // live vars: r1, $t5
+  4: trace_local[r1]($t1)
+     // live vars: r1, $t5
+  5: $t7 := 2
+     // live vars: r1, $t5, $t7
+  6: $t2 := pack Trafo::R($t7)
+     // live vars: r1, r2, $t5
+  7: trace_local[r2]($t2)
+     // live vars: r1, r2, $t5
+  8: if ($t5) goto 11 else goto 9
+     // live vars: r2
+  9: label L1
+     // live vars: r2
+ 10: goto 16
+     // live vars: r1, r2
+ 11: label L0
+     // live vars: r1, r2
+ 12: $t8 := borrow_local($t1)
+     // live vars: r2, $t8
+ 13: $t4 := $t8
+     // live vars: r2, tmp#$4, $t8
+ 14: trace_local[tmp#$4]($t8)
+     // live vars: r2, tmp#$4
+ 15: goto 20
+     // live vars: r2
+ 16: label L2
+     // live vars: r2
+ 17: $t9 := borrow_local($t2)
+     // live vars: r2, $t9
+ 18: $t4 := $t9
+     // live vars: r2, tmp#$4, $t9
+ 19: trace_local[tmp#$4]($t9)
+     // live vars: r2, tmp#$4
+ 20: label L3
+     // live vars: r2, tmp#$4
+ 21: $t3 := $t4
+     // live vars: r2, r_ref
+ 22: trace_local[r_ref]($t3)
+     // live vars: r2, r_ref
+ 23: $t10 := borrow_field<Trafo::R>.x($t3)
+     // live vars: r2, $t10
+ 24: $t11 := read_ref($t10)
+     // live vars: r2, $t10, $t11
+ 25: $t11 := Trafo::incr_ref($t11)
+     // live vars: r2, $t10, $t11
+ 26: write_ref($t10, $t11)
+     // live vars: r2
+ 27: trace_return[0]($t2)
+     // live vars: r2
+ 28: return $t2
+}

--- a/language/move-prover/tests/xsources/design/references_6_borrow_analysis.bytecode
+++ b/language/move-prover/tests/xsources/design/references_6_borrow_analysis.bytecode
@@ -1,0 +1,175 @@
+============ after processor `borrow_analysis` ================
+
+[variant baseline]
+pub fun Trafo::incr_ref($t0|r: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     // live_nodes: LocalRoot($t0)
+  0: $t1 := move($t0)
+     // live_nodes: LocalRoot($t1)
+     // moved_nodes: LocalRoot($t0)
+  1: $t2 := borrow_local($t1)
+     // live_nodes: LocalRoot($t1), Reference($t2)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t2)}
+     // borrows_from: Reference($t2) -> {LocalRoot($t1)}
+  2: trace_local[r]($t2)
+     // live_nodes: LocalRoot($t1), Reference($t2)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t2)}
+     // borrows_from: Reference($t2) -> {LocalRoot($t1)}
+  3: $t3 := read_ref($t2)
+     // live_nodes: LocalRoot($t1), Reference($t2)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t2)}
+     // borrows_from: Reference($t2) -> {LocalRoot($t1)}
+  4: $t4 := 1
+     // live_nodes: LocalRoot($t1), Reference($t2)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t2)}
+     // borrows_from: Reference($t2) -> {LocalRoot($t1)}
+  5: $t5 := +($t3, $t4)
+     // live_nodes: LocalRoot($t1), Reference($t2)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t2)}
+     // borrows_from: Reference($t2) -> {LocalRoot($t1)}
+  6: write_ref($t2, $t5)
+     // live_nodes: LocalRoot($t1)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t2)}
+     // borrows_from: Reference($t2) -> {LocalRoot($t1)}
+  7: return $t1
+}
+
+
+[variant baseline]
+pub fun Trafo::use_incr_ref($t0|b: bool): Trafo::R {
+     var $t1|r1: Trafo::R
+     var $t2|r2: Trafo::R
+     var $t3|r_ref: &mut Trafo::R
+     var $t4|tmp#$4: &mut Trafo::R
+     var $t5: bool
+     var $t6: u64
+     var $t7: u64
+     var $t8: &mut Trafo::R
+     var $t9: &mut Trafo::R
+     var $t10: &mut u64
+     var $t11: u64
+     // live_nodes: LocalRoot($t0)
+  0: $t5 := move($t0)
+     // live_nodes: LocalRoot($t5)
+     // moved_nodes: LocalRoot($t0)
+  1: trace_local[b]($t5)
+     // live_nodes: LocalRoot($t5)
+     // moved_nodes: LocalRoot($t0)
+  2: $t6 := 1
+     // live_nodes: LocalRoot($t5)
+     // moved_nodes: LocalRoot($t0)
+  3: $t1 := pack Trafo::R($t6)
+     // live_nodes: LocalRoot($t5)
+     // moved_nodes: LocalRoot($t0)
+  4: trace_local[r1]($t1)
+     // live_nodes: LocalRoot($t5)
+     // moved_nodes: LocalRoot($t0)
+  5: $t7 := 2
+     // live_nodes: LocalRoot($t5)
+     // moved_nodes: LocalRoot($t0)
+  6: $t2 := pack Trafo::R($t7)
+     // live_nodes: LocalRoot($t5)
+     // moved_nodes: LocalRoot($t0)
+  7: trace_local[r2]($t2)
+     // live_nodes: LocalRoot($t5)
+     // moved_nodes: LocalRoot($t0)
+  8: if ($t5) goto 11 else goto 9
+     // live_nodes: LocalRoot($t5)
+     // moved_nodes: LocalRoot($t0)
+  9: label L1
+     // live_nodes: LocalRoot($t5)
+     // moved_nodes: LocalRoot($t0)
+ 10: goto 16
+     // live_nodes: LocalRoot($t5)
+     // moved_nodes: LocalRoot($t0)
+ 11: label L0
+     // live_nodes: LocalRoot($t5)
+     // moved_nodes: LocalRoot($t0)
+ 12: $t8 := borrow_local($t1)
+     // live_nodes: LocalRoot($t5), Reference($t8)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t8)}
+     // borrows_from: Reference($t8) -> {LocalRoot($t1)}
+ 13: $t4 := $t8
+     // live_nodes: LocalRoot($t5), Reference($t4)
+     // moved_nodes: LocalRoot($t0), Reference($t8)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t4)}
+     // borrows_from: Reference($t4) -> {LocalRoot($t1)}
+ 14: trace_local[tmp#$4]($t8)
+     // live_nodes: LocalRoot($t5), Reference($t4)
+     // moved_nodes: LocalRoot($t0), Reference($t8)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t4)}
+     // borrows_from: Reference($t4) -> {LocalRoot($t1)}
+ 15: goto 20
+     // live_nodes: LocalRoot($t5)
+     // moved_nodes: LocalRoot($t0)
+ 16: label L2
+     // live_nodes: LocalRoot($t5)
+     // moved_nodes: LocalRoot($t0)
+ 17: $t9 := borrow_local($t2)
+     // live_nodes: LocalRoot($t5), Reference($t9)
+     // moved_nodes: LocalRoot($t0)
+     // borrowed_by: LocalRoot($t2) -> {Reference($t9)}
+     // borrows_from: Reference($t9) -> {LocalRoot($t2)}
+ 18: $t4 := $t9
+     // live_nodes: LocalRoot($t5), Reference($t4)
+     // moved_nodes: LocalRoot($t0), Reference($t9)
+     // borrowed_by: LocalRoot($t2) -> {Reference($t4)}
+     // borrows_from: Reference($t4) -> {LocalRoot($t2)}
+ 19: trace_local[tmp#$4]($t9)
+     // live_nodes: LocalRoot($t5), Reference($t4)
+     // moved_nodes: LocalRoot($t0), Reference($t8), Reference($t9)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t4)}, LocalRoot($t2) -> {Reference($t4)}
+     // borrows_from: Reference($t4) -> {LocalRoot($t1), LocalRoot($t2)}
+ 20: label L3
+     // live_nodes: LocalRoot($t5), Reference($t4)
+     // moved_nodes: LocalRoot($t0), Reference($t8), Reference($t9)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t4)}, LocalRoot($t2) -> {Reference($t4)}
+     // borrows_from: Reference($t4) -> {LocalRoot($t1), LocalRoot($t2)}
+ 21: $t3 := $t4
+     // live_nodes: LocalRoot($t5), Reference($t3)
+     // moved_nodes: LocalRoot($t0), Reference($t4), Reference($t8), Reference($t9)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t3)}, LocalRoot($t2) -> {Reference($t3)}
+     // borrows_from: Reference($t3) -> {LocalRoot($t1), LocalRoot($t2)}
+ 22: trace_local[r_ref]($t3)
+     // live_nodes: LocalRoot($t5), Reference($t3)
+     // moved_nodes: LocalRoot($t0), Reference($t4), Reference($t8), Reference($t9)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t3)}, LocalRoot($t2) -> {Reference($t3)}
+     // borrows_from: Reference($t3) -> {LocalRoot($t1), LocalRoot($t2)}
+ 23: $t10 := borrow_field<Trafo::R>.x($t3)
+     // live_nodes: LocalRoot($t5), Reference($t10)
+     // moved_nodes: LocalRoot($t0), Reference($t4), Reference($t8), Reference($t9)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t3)}, LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference($t10)}
+     // borrows_from: Reference($t3) -> {LocalRoot($t1), LocalRoot($t2)}, Reference($t10) -> {Reference($t3)}
+ 24: $t11 := read_ref($t10)
+     // live_nodes: LocalRoot($t5), Reference($t10)
+     // moved_nodes: LocalRoot($t0), Reference($t4), Reference($t8), Reference($t9)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t3)}, LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference($t10)}
+     // borrows_from: Reference($t3) -> {LocalRoot($t1), LocalRoot($t2)}, Reference($t10) -> {Reference($t3)}
+ 25: $t11 := Trafo::incr_ref($t11)
+     // live_nodes: LocalRoot($t5), Reference($t10)
+     // moved_nodes: LocalRoot($t0), Reference($t4), Reference($t8), Reference($t9)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t3)}, LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference($t10)}
+     // borrows_from: Reference($t3) -> {LocalRoot($t1), LocalRoot($t2)}, Reference($t10) -> {Reference($t3)}
+ 26: write_ref($t10, $t11)
+     // live_nodes: LocalRoot($t5)
+     // moved_nodes: LocalRoot($t0), Reference($t4), Reference($t8), Reference($t9)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t3)}, LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference($t10)}
+     // borrows_from: Reference($t3) -> {LocalRoot($t1), LocalRoot($t2)}, Reference($t10) -> {Reference($t3)}
+ 27: trace_return[0]($t2)
+     // live_nodes: LocalRoot($t5)
+     // moved_nodes: LocalRoot($t0), Reference($t4), Reference($t8), Reference($t9)
+     // borrowed_by: LocalRoot($t1) -> {Reference($t3)}, LocalRoot($t2) -> {Reference($t3)}, Reference($t3) -> {Reference($t10)}
+     // borrows_from: Reference($t3) -> {LocalRoot($t1), LocalRoot($t2)}, Reference($t10) -> {Reference($t3)}
+ 28: return $t2
+}

--- a/language/move-prover/tests/xsources/design/references_7_memory_instr.bytecode
+++ b/language/move-prover/tests/xsources/design/references_7_memory_instr.bytecode
@@ -1,0 +1,71 @@
+============ after processor `memory_instr` ================
+
+[variant baseline]
+pub fun Trafo::incr_ref($t0|r: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t1 := move($t0)
+  1: $t2 := borrow_local($t1)
+  2: trace_local[r]($t2)
+  3: $t3 := read_ref($t2)
+  4: $t4 := 1
+  5: $t5 := +($t3, $t4)
+  6: write_ref($t2, $t5)
+  7: write_back[LocalRoot($t1)]($t2)
+  8: return $t1
+}
+
+
+[variant baseline]
+pub fun Trafo::use_incr_ref($t0|b: bool): Trafo::R {
+     var $t1|r1: Trafo::R
+     var $t2|r2: Trafo::R
+     var $t3|r_ref: &mut Trafo::R
+     var $t4|tmp#$4: &mut Trafo::R
+     var $t5: bool
+     var $t6: u64
+     var $t7: u64
+     var $t8: &mut Trafo::R
+     var $t9: &mut Trafo::R
+     var $t10: &mut u64
+     var $t11: u64
+  0: $t5 := move($t0)
+  1: trace_local[b]($t5)
+  2: $t6 := 1
+  3: $t1 := pack Trafo::R($t6)
+  4: trace_local[r1]($t1)
+  5: $t7 := 2
+  6: $t2 := pack Trafo::R($t7)
+  7: trace_local[r2]($t2)
+  8: if ($t5) goto 11 else goto 9
+  9: label L1
+ 10: goto 17
+ 11: label L0
+ 12: $t8 := borrow_local($t1)
+ 13: $t4 := $t8
+ 14: write_back[LocalRoot($t1)]($t8)
+ 15: trace_local[tmp#$4]($t8)
+ 16: goto 22
+ 17: label L2
+ 18: $t9 := borrow_local($t2)
+ 19: $t4 := $t9
+ 20: write_back[LocalRoot($t2)]($t9)
+ 21: trace_local[tmp#$4]($t9)
+ 22: label L3
+ 23: $t3 := $t4
+ 24: write_back[LocalRoot($t1)]($t4)
+ 25: write_back[LocalRoot($t2)]($t4)
+ 26: trace_local[r_ref]($t3)
+ 27: $t10 := borrow_field<Trafo::R>.x($t3)
+ 28: $t11 := read_ref($t10)
+ 29: $t11 := Trafo::incr_ref($t11)
+ 30: write_ref($t10, $t11)
+ 31: write_back[Reference($t3)]($t10)
+ 32: write_back[LocalRoot($t1)]($t3)
+ 33: write_back[LocalRoot($t2)]($t3)
+ 34: trace_return[0]($t2)
+ 35: return $t2
+}

--- a/language/move-prover/tests/xsources/design/references_8_clean_and_optimize.bytecode
+++ b/language/move-prover/tests/xsources/design/references_8_clean_and_optimize.bytecode
@@ -1,0 +1,67 @@
+============ after processor `clean_and_optimize` ================
+
+[variant baseline]
+pub fun Trafo::incr_ref($t0|r: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t1 := move($t0)
+  1: $t2 := borrow_local($t1)
+  2: trace_local[r]($t2)
+  3: $t3 := read_ref($t2)
+  4: $t4 := 1
+  5: $t5 := +($t3, $t4)
+  6: write_ref($t2, $t5)
+  7: write_back[LocalRoot($t1)]($t2)
+  8: return $t1
+}
+
+
+[variant baseline]
+pub fun Trafo::use_incr_ref($t0|b: bool): Trafo::R {
+     var $t1|r1: Trafo::R
+     var $t2|r2: Trafo::R
+     var $t3|r_ref: &mut Trafo::R
+     var $t4|tmp#$4: &mut Trafo::R
+     var $t5: bool
+     var $t6: u64
+     var $t7: u64
+     var $t8: &mut Trafo::R
+     var $t9: &mut Trafo::R
+     var $t10: &mut u64
+     var $t11: u64
+  0: $t5 := move($t0)
+  1: trace_local[b]($t5)
+  2: $t6 := 1
+  3: $t1 := pack Trafo::R($t6)
+  4: trace_local[r1]($t1)
+  5: $t7 := 2
+  6: $t2 := pack Trafo::R($t7)
+  7: trace_local[r2]($t2)
+  8: if ($t5) goto 11 else goto 9
+  9: label L1
+ 10: goto 16
+ 11: label L0
+ 12: $t8 := borrow_local($t1)
+ 13: $t4 := $t8
+ 14: trace_local[tmp#$4]($t8)
+ 15: goto 20
+ 16: label L2
+ 17: $t9 := borrow_local($t2)
+ 18: $t4 := $t9
+ 19: trace_local[tmp#$4]($t9)
+ 20: label L3
+ 21: $t3 := $t4
+ 22: trace_local[r_ref]($t3)
+ 23: $t10 := borrow_field<Trafo::R>.x($t3)
+ 24: $t11 := read_ref($t10)
+ 25: $t11 := Trafo::incr_ref($t11)
+ 26: write_ref($t10, $t11)
+ 27: write_back[Reference($t3)]($t10)
+ 28: write_back[LocalRoot($t1)]($t3)
+ 29: write_back[LocalRoot($t2)]($t3)
+ 30: trace_return[0]($t2)
+ 31: return $t2
+}

--- a/language/move-prover/tests/xsources/design/references_9_usage_analysis.bytecode
+++ b/language/move-prover/tests/xsources/design/references_9_usage_analysis.bytecode
@@ -1,0 +1,67 @@
+============ after processor `usage_analysis` ================
+
+[variant baseline]
+pub fun Trafo::incr_ref($t0|r: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t1 := move($t0)
+  1: $t2 := borrow_local($t1)
+  2: trace_local[r]($t2)
+  3: $t3 := read_ref($t2)
+  4: $t4 := 1
+  5: $t5 := +($t3, $t4)
+  6: write_ref($t2, $t5)
+  7: write_back[LocalRoot($t1)]($t2)
+  8: return $t1
+}
+
+
+[variant baseline]
+pub fun Trafo::use_incr_ref($t0|b: bool): Trafo::R {
+     var $t1|r1: Trafo::R
+     var $t2|r2: Trafo::R
+     var $t3|r_ref: &mut Trafo::R
+     var $t4|tmp#$4: &mut Trafo::R
+     var $t5: bool
+     var $t6: u64
+     var $t7: u64
+     var $t8: &mut Trafo::R
+     var $t9: &mut Trafo::R
+     var $t10: &mut u64
+     var $t11: u64
+  0: $t5 := move($t0)
+  1: trace_local[b]($t5)
+  2: $t6 := 1
+  3: $t1 := pack Trafo::R($t6)
+  4: trace_local[r1]($t1)
+  5: $t7 := 2
+  6: $t2 := pack Trafo::R($t7)
+  7: trace_local[r2]($t2)
+  8: if ($t5) goto 11 else goto 9
+  9: label L1
+ 10: goto 16
+ 11: label L0
+ 12: $t8 := borrow_local($t1)
+ 13: $t4 := $t8
+ 14: trace_local[tmp#$4]($t8)
+ 15: goto 20
+ 16: label L2
+ 17: $t9 := borrow_local($t2)
+ 18: $t4 := $t9
+ 19: trace_local[tmp#$4]($t9)
+ 20: label L3
+ 21: $t3 := $t4
+ 22: trace_local[r_ref]($t3)
+ 23: $t10 := borrow_field<Trafo::R>.x($t3)
+ 24: $t11 := read_ref($t10)
+ 25: $t11 := Trafo::incr_ref($t11)
+ 26: write_ref($t10, $t11)
+ 27: write_back[Reference($t3)]($t10)
+ 28: write_back[LocalRoot($t1)]($t3)
+ 29: write_back[LocalRoot($t2)]($t3)
+ 30: trace_return[0]($t2)
+ 31: return $t2
+}

--- a/language/move-prover/tests/xsources/design/resource.move
+++ b/language/move-prover/tests/xsources/design/resource.move
@@ -1,0 +1,24 @@
+// flag: --v2
+address 0x0 {
+/// Example for resources.
+module Trafo {
+  use 0x1::Signer;
+
+  resource struct R { x: u64 }
+
+  public fun publish(account: &signer, x: u64) {
+      move_to<R>(account, R{x: x})
+  }
+  spec fun publish {
+      let addr = Signer::spec_address_of(account);
+      aborts_if exists<R>(addr);
+      ensures exists<R>(addr);
+      ensures global<R>(addr).x == x;
+  }
+
+  public fun dummy_need_signer_use_in_move(account: &signer): address {
+      // Move bug: we can't use Signer in specs if not also used in code.
+      Signer::address_of(account)
+  }
+}
+}

--- a/language/move-prover/tests/xsources/design/resource_0_stackless.bytecode
+++ b/language/move-prover/tests/xsources/design/resource_0_stackless.bytecode
@@ -1,0 +1,40 @@
+============ after processor `stackless` ================
+
+[variant baseline]
+pub fun Signer::address_of($t0|s: &signer): address {
+     var $t1: &signer
+     var $t2: &address
+     var $t3: address
+  0: $t1 := move($t0)
+  1: $t2 := Signer::borrow_address($t1)
+  2: $t3 := read_ref($t2)
+  3: return $t3
+}
+
+
+[variant baseline]
+pub fun Signer::borrow_address($t0|s: &signer): &address {
+}
+
+
+[variant baseline]
+pub fun Trafo::dummy_need_signer_use_in_move($t0|account: &signer): address {
+     var $t1: &signer
+     var $t2: address
+  0: $t1 := move($t0)
+  1: $t2 := Signer::address_of($t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+pub fun Trafo::publish($t0|account: &signer, $t1|x: u64) {
+     var $t2: &signer
+     var $t3: u64
+     var $t4: Trafo::R
+  0: $t2 := move($t0)
+  1: $t3 := copy($t1)
+  2: $t4 := pack Trafo::R($t3)
+  3: move_to<Trafo::R>($t4, $t2)
+  4: return ()
+}

--- a/language/move-prover/tests/xsources/design/resource_10_spec_instrumenter.bytecode
+++ b/language/move-prover/tests/xsources/design/resource_10_spec_instrumenter.bytecode
@@ -1,0 +1,97 @@
+============ after processor `spec_instrumenter` ================
+
+[variant baseline]
+pub fun Signer::address_of($t0|s: signer): address {
+     var $t1: address
+     var $t2: num
+  0: trace_local[s]($t0)
+  1: $t1 := Signer::borrow_address($t0)
+  2: on_abort goto 6 code := $t2
+  3: trace_return[0]($t1)
+  4: label L1
+  5: return $t1
+  6: label L2
+  7: abort($t2)
+}
+
+
+[variant baseline]
+pub fun Signer::borrow_address($t0|s: signer): address {
+}
+
+
+[variant baseline]
+pub fun Trafo::dummy_need_signer_use_in_move($t0|account: signer): address {
+     var $t1: bool
+     var $t2: address
+     var $t3: num
+  0: trace_local[account]($t0)
+  1: assume Eq($t1, false)
+  2: if ($t1) goto 8 else goto 3
+  3: label L3
+  4: assume Eq<address>($t2, Signer::spec_address_of($t0))
+  5: trace_return[0]($t2)
+  6: label L1
+  7: return $t2
+  8: label L2
+  9: abort($t3)
+}
+
+
+[variant verification]
+pub fun Trafo::dummy_need_signer_use_in_move($t0|account: signer): address {
+     var $t1: bool
+     var $t2: address
+     var $t3: num
+  0: trace_local[account]($t0)
+  1: assume Eq($t1, false)
+  2: if ($t1) goto 8 else goto 3
+  3: label L3
+  4: assume Eq<address>($t2, Signer::spec_address_of($t0))
+  5: trace_return[0]($t2)
+  6: label L1
+  7: return $t2
+  8: label L2
+  9: abort($t3)
+}
+
+
+[variant baseline]
+pub fun Trafo::publish($t0|account: signer, $t1|x: u64) {
+     var $t2: Trafo::R
+     var $t3: num
+  0: trace_local[account]($t0)
+  1: trace_local[x]($t1)
+  2: $t2 := pack Trafo::R($t1)
+  3: move_to<Trafo::R>($t2, $t0)
+  4: on_abort goto 7 code := $t3
+  5: label L1
+  6: return ()
+  7: label L2
+  8: abort($t3)
+}
+
+
+[variant verification]
+pub fun Trafo::publish($t0|account: signer, $t1|x: u64) {
+     var $t2: Trafo::R
+     var $t3: num
+  0: @0 := save_mem(Trafo::R)
+  1: trace_local[account]($t0)
+  2: trace_local[x]($t1)
+  3: $t2 := pack Trafo::R($t1)
+  4: move_to<Trafo::R>($t2, $t0)
+  5: on_abort goto 11 code := $t3
+  6: label L1
+     // VC: `function does not abort under this condition` at resource.move:14:7+26
+  7: assert Not(exists[@0]<Trafo::R>(Trafo::addr$2[]($t0)))
+     // VC: `post-condition does not hold` at resource.move:15:7+24
+  8: assert exists<Trafo::R>(Trafo::addr$2($t0))
+     // VC: `post-condition does not hold` at resource.move:16:7+31
+  9: assert Eq<u64>(select Trafo::R.x(global<Trafo::R>(Trafo::addr$2($t0))), $t1)
+ 10: return ()
+ 11: label L2
+     // VC: `abort not covered by any of the `aborts_if` clauses` at resource.move:9:3+85
+ 12: assert exists[@0]<Trafo::R>(Trafo::addr$2[]($t0))
+ 13: abort($t3)
+}

--- a/language/move-prover/tests/xsources/design/resource_1_debug_instrumenter.bytecode
+++ b/language/move-prover/tests/xsources/design/resource_1_debug_instrumenter.bytecode
@@ -1,0 +1,46 @@
+============ after processor `debug_instrumenter` ================
+
+[variant baseline]
+pub fun Signer::address_of($t0|s: &signer): address {
+     var $t1: &signer
+     var $t2: &address
+     var $t3: address
+  0: trace_local[s]($t0)
+  1: $t1 := move($t0)
+  2: $t2 := Signer::borrow_address($t1)
+  3: $t3 := read_ref($t2)
+  4: trace_return[0]($t3)
+  5: return $t3
+}
+
+
+[variant baseline]
+pub fun Signer::borrow_address($t0|s: &signer): &address {
+}
+
+
+[variant baseline]
+pub fun Trafo::dummy_need_signer_use_in_move($t0|account: &signer): address {
+     var $t1: &signer
+     var $t2: address
+  0: trace_local[account]($t0)
+  1: $t1 := move($t0)
+  2: $t2 := Signer::address_of($t1)
+  3: trace_return[0]($t2)
+  4: return $t2
+}
+
+
+[variant baseline]
+pub fun Trafo::publish($t0|account: &signer, $t1|x: u64) {
+     var $t2: &signer
+     var $t3: u64
+     var $t4: Trafo::R
+  0: trace_local[account]($t0)
+  1: trace_local[x]($t1)
+  2: $t2 := move($t0)
+  3: $t3 := copy($t1)
+  4: $t4 := pack Trafo::R($t3)
+  5: move_to<Trafo::R>($t4, $t2)
+  6: return ()
+}

--- a/language/move-prover/tests/xsources/design/resource_2_eliminate_imm_refs.bytecode
+++ b/language/move-prover/tests/xsources/design/resource_2_eliminate_imm_refs.bytecode
@@ -1,0 +1,46 @@
+============ after processor `eliminate_imm_refs` ================
+
+[variant baseline]
+pub fun Signer::address_of($t0|s: signer): address {
+     var $t1: signer
+     var $t2: address
+     var $t3: address
+  0: trace_local[s]($t0)
+  1: $t1 := move($t0)
+  2: $t2 := Signer::borrow_address($t1)
+  3: $t3 := move($t2)
+  4: trace_return[0]($t3)
+  5: return $t3
+}
+
+
+[variant baseline]
+pub fun Signer::borrow_address($t0|s: signer): address {
+}
+
+
+[variant baseline]
+pub fun Trafo::dummy_need_signer_use_in_move($t0|account: signer): address {
+     var $t1: signer
+     var $t2: address
+  0: trace_local[account]($t0)
+  1: $t1 := move($t0)
+  2: $t2 := Signer::address_of($t1)
+  3: trace_return[0]($t2)
+  4: return $t2
+}
+
+
+[variant baseline]
+pub fun Trafo::publish($t0|account: signer, $t1|x: u64) {
+     var $t2: signer
+     var $t3: u64
+     var $t4: Trafo::R
+  0: trace_local[account]($t0)
+  1: trace_local[x]($t1)
+  2: $t2 := move($t0)
+  3: $t3 := copy($t1)
+  4: $t4 := pack Trafo::R($t3)
+  5: move_to<Trafo::R>($t4, $t2)
+  6: return ()
+}

--- a/language/move-prover/tests/xsources/design/resource_3_eliminate_mut_refs.bytecode
+++ b/language/move-prover/tests/xsources/design/resource_3_eliminate_mut_refs.bytecode
@@ -1,0 +1,54 @@
+============ after processor `eliminate_mut_refs` ================
+
+[variant baseline]
+pub fun Signer::address_of($t0|s: signer): address {
+     var $t1: signer
+     var $t2: address
+     var $t3: address
+     var $t4: signer
+  0: $t4 := move($t0)
+  1: trace_local[s]($t4)
+  2: $t1 := move($t4)
+  3: $t2 := Signer::borrow_address($t1)
+  4: $t3 := move($t2)
+  5: trace_return[0]($t3)
+  6: return $t3
+}
+
+
+[variant baseline]
+pub fun Signer::borrow_address($t0|s: signer): address {
+}
+
+
+[variant baseline]
+pub fun Trafo::dummy_need_signer_use_in_move($t0|account: signer): address {
+     var $t1: signer
+     var $t2: address
+     var $t3: signer
+  0: $t3 := move($t0)
+  1: trace_local[account]($t3)
+  2: $t1 := move($t3)
+  3: $t2 := Signer::address_of($t1)
+  4: trace_return[0]($t2)
+  5: return $t2
+}
+
+
+[variant baseline]
+pub fun Trafo::publish($t0|account: signer, $t1|x: u64) {
+     var $t2: signer
+     var $t3: u64
+     var $t4: Trafo::R
+     var $t5: signer
+     var $t6: u64
+  0: $t5 := move($t0)
+  1: $t6 := move($t1)
+  2: trace_local[account]($t5)
+  3: trace_local[x]($t6)
+  4: $t2 := move($t5)
+  5: $t3 := copy($t6)
+  6: $t4 := pack Trafo::R($t3)
+  7: move_to<Trafo::R>($t4, $t2)
+  8: return ()
+}

--- a/language/move-prover/tests/xsources/design/resource_4_reaching_def_analysis.bytecode
+++ b/language/move-prover/tests/xsources/design/resource_4_reaching_def_analysis.bytecode
@@ -1,0 +1,54 @@
+============ after processor `reaching_def_analysis` ================
+
+[variant baseline]
+pub fun Signer::address_of($t0|s: signer): address {
+     var $t1: signer
+     var $t2: address
+     var $t3: address
+     var $t4: signer
+  0: $t4 := move($t0)
+  1: trace_local[s]($t4)
+  2: $t1 := move($t4)
+  3: $t2 := Signer::borrow_address($t4)
+  4: $t3 := move($t2)
+  5: trace_return[0]($t2)
+  6: return $t2
+}
+
+
+[variant baseline]
+pub fun Signer::borrow_address($t0|s: signer): address {
+}
+
+
+[variant baseline]
+pub fun Trafo::dummy_need_signer_use_in_move($t0|account: signer): address {
+     var $t1: signer
+     var $t2: address
+     var $t3: signer
+  0: $t3 := move($t0)
+  1: trace_local[account]($t3)
+  2: $t1 := move($t3)
+  3: $t2 := Signer::address_of($t3)
+  4: trace_return[0]($t2)
+  5: return $t2
+}
+
+
+[variant baseline]
+pub fun Trafo::publish($t0|account: signer, $t1|x: u64) {
+     var $t2: signer
+     var $t3: u64
+     var $t4: Trafo::R
+     var $t5: signer
+     var $t6: u64
+  0: $t5 := move($t0)
+  1: $t6 := move($t1)
+  2: trace_local[account]($t5)
+  3: trace_local[x]($t6)
+  4: $t2 := move($t5)
+  5: $t3 := copy($t6)
+  6: $t4 := pack Trafo::R($t6)
+  7: move_to<Trafo::R>($t4, $t5)
+  8: return ()
+}

--- a/language/move-prover/tests/xsources/design/resource_5_livevar_analysis.bytecode
+++ b/language/move-prover/tests/xsources/design/resource_5_livevar_analysis.bytecode
@@ -1,0 +1,61 @@
+============ after processor `livevar_analysis` ================
+
+[variant baseline]
+pub fun Signer::address_of($t0|s: signer): address {
+     var $t1: signer
+     var $t2: address
+     // live vars: s
+  0: $t1 := move($t0)
+     // live vars: $t1
+  1: trace_local[s]($t1)
+     // live vars: $t1
+  2: $t2 := Signer::borrow_address($t1)
+     // live vars: $t2
+  3: trace_return[0]($t2)
+     // live vars: $t2
+  4: return $t2
+}
+
+
+[variant baseline]
+pub fun Signer::borrow_address($t0|s: signer): address {
+}
+
+
+[variant baseline]
+pub fun Trafo::dummy_need_signer_use_in_move($t0|account: signer): address {
+     var $t1: signer
+     var $t2: address
+     // live vars: account
+  0: $t1 := move($t0)
+     // live vars: $t1
+  1: trace_local[account]($t1)
+     // live vars: $t1
+  2: $t2 := Signer::address_of($t1)
+     // live vars: $t2
+  3: trace_return[0]($t2)
+     // live vars: $t2
+  4: return $t2
+}
+
+
+[variant baseline]
+pub fun Trafo::publish($t0|account: signer, $t1|x: u64) {
+     var $t2: signer
+     var $t3: u64
+     var $t4: Trafo::R
+     // live vars: account, x
+  0: $t2 := move($t0)
+     // live vars: x, $t2
+  1: $t3 := move($t1)
+     // live vars: $t2, $t3
+  2: trace_local[account]($t2)
+     // live vars: $t2, $t3
+  3: trace_local[x]($t3)
+     // live vars: $t2, $t3
+  4: $t4 := pack Trafo::R($t3)
+     // live vars: $t2, $t4
+  5: move_to<Trafo::R>($t4, $t2)
+     // live vars:
+  6: return ()
+}

--- a/language/move-prover/tests/xsources/design/resource_6_borrow_analysis.bytecode
+++ b/language/move-prover/tests/xsources/design/resource_6_borrow_analysis.bytecode
@@ -1,0 +1,75 @@
+============ after processor `borrow_analysis` ================
+
+[variant baseline]
+pub fun Signer::address_of($t0|s: signer): address {
+     var $t1: signer
+     var $t2: address
+     // live_nodes: LocalRoot($t0)
+  0: $t1 := move($t0)
+     // live_nodes: LocalRoot($t1)
+     // moved_nodes: LocalRoot($t0)
+  1: trace_local[s]($t1)
+     // live_nodes: LocalRoot($t1)
+     // moved_nodes: LocalRoot($t0)
+  2: $t2 := Signer::borrow_address($t1)
+     // live_nodes: LocalRoot($t1)
+     // moved_nodes: LocalRoot($t0)
+  3: trace_return[0]($t2)
+     // live_nodes: LocalRoot($t1)
+     // moved_nodes: LocalRoot($t0)
+  4: return $t2
+}
+
+
+[variant baseline]
+pub fun Signer::borrow_address($t0|s: signer): address {
+}
+
+
+[variant baseline]
+pub fun Trafo::dummy_need_signer_use_in_move($t0|account: signer): address {
+     var $t1: signer
+     var $t2: address
+     // live_nodes: LocalRoot($t0)
+  0: $t1 := move($t0)
+     // live_nodes: LocalRoot($t1)
+     // moved_nodes: LocalRoot($t0)
+  1: trace_local[account]($t1)
+     // live_nodes: LocalRoot($t1)
+     // moved_nodes: LocalRoot($t0)
+  2: $t2 := Signer::address_of($t1)
+     // live_nodes: LocalRoot($t1)
+     // moved_nodes: LocalRoot($t0)
+  3: trace_return[0]($t2)
+     // live_nodes: LocalRoot($t1)
+     // moved_nodes: LocalRoot($t0)
+  4: return $t2
+}
+
+
+[variant baseline]
+pub fun Trafo::publish($t0|account: signer, $t1|x: u64) {
+     var $t2: signer
+     var $t3: u64
+     var $t4: Trafo::R
+     // live_nodes: LocalRoot($t0), LocalRoot($t1)
+  0: $t2 := move($t0)
+     // live_nodes: LocalRoot($t1), LocalRoot($t2)
+     // moved_nodes: LocalRoot($t0)
+  1: $t3 := move($t1)
+     // live_nodes: LocalRoot($t2), LocalRoot($t3)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
+  2: trace_local[account]($t2)
+     // live_nodes: LocalRoot($t2), LocalRoot($t3)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
+  3: trace_local[x]($t3)
+     // live_nodes: LocalRoot($t2), LocalRoot($t3)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
+  4: $t4 := pack Trafo::R($t3)
+     // live_nodes: LocalRoot($t2), LocalRoot($t3)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
+  5: move_to<Trafo::R>($t4, $t2)
+     // live_nodes: LocalRoot($t2), LocalRoot($t3)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
+  6: return ()
+}

--- a/language/move-prover/tests/xsources/design/resource_7_memory_instr.bytecode
+++ b/language/move-prover/tests/xsources/design/resource_7_memory_instr.bytecode
@@ -1,0 +1,44 @@
+============ after processor `memory_instr` ================
+
+[variant baseline]
+pub fun Signer::address_of($t0|s: signer): address {
+     var $t1: signer
+     var $t2: address
+  0: $t1 := move($t0)
+  1: trace_local[s]($t1)
+  2: $t2 := Signer::borrow_address($t1)
+  3: trace_return[0]($t2)
+  4: return $t2
+}
+
+
+[variant baseline]
+pub fun Signer::borrow_address($t0|s: signer): address {
+}
+
+
+[variant baseline]
+pub fun Trafo::dummy_need_signer_use_in_move($t0|account: signer): address {
+     var $t1: signer
+     var $t2: address
+  0: $t1 := move($t0)
+  1: trace_local[account]($t1)
+  2: $t2 := Signer::address_of($t1)
+  3: trace_return[0]($t2)
+  4: return $t2
+}
+
+
+[variant baseline]
+pub fun Trafo::publish($t0|account: signer, $t1|x: u64) {
+     var $t2: signer
+     var $t3: u64
+     var $t4: Trafo::R
+  0: $t2 := move($t0)
+  1: $t3 := move($t1)
+  2: trace_local[account]($t2)
+  3: trace_local[x]($t3)
+  4: $t4 := pack Trafo::R($t3)
+  5: move_to<Trafo::R>($t4, $t2)
+  6: return ()
+}

--- a/language/move-prover/tests/xsources/design/resource_8_clean_and_optimize.bytecode
+++ b/language/move-prover/tests/xsources/design/resource_8_clean_and_optimize.bytecode
@@ -1,0 +1,44 @@
+============ after processor `clean_and_optimize` ================
+
+[variant baseline]
+pub fun Signer::address_of($t0|s: signer): address {
+     var $t1: signer
+     var $t2: address
+  0: $t1 := move($t0)
+  1: trace_local[s]($t1)
+  2: $t2 := Signer::borrow_address($t1)
+  3: trace_return[0]($t2)
+  4: return $t2
+}
+
+
+[variant baseline]
+pub fun Signer::borrow_address($t0|s: signer): address {
+}
+
+
+[variant baseline]
+pub fun Trafo::dummy_need_signer_use_in_move($t0|account: signer): address {
+     var $t1: signer
+     var $t2: address
+  0: $t1 := move($t0)
+  1: trace_local[account]($t1)
+  2: $t2 := Signer::address_of($t1)
+  3: trace_return[0]($t2)
+  4: return $t2
+}
+
+
+[variant baseline]
+pub fun Trafo::publish($t0|account: signer, $t1|x: u64) {
+     var $t2: signer
+     var $t3: u64
+     var $t4: Trafo::R
+  0: $t2 := move($t0)
+  1: $t3 := move($t1)
+  2: trace_local[account]($t2)
+  3: trace_local[x]($t3)
+  4: $t4 := pack Trafo::R($t3)
+  5: move_to<Trafo::R>($t4, $t2)
+  6: return ()
+}

--- a/language/move-prover/tests/xsources/design/resource_9_usage_analysis.bytecode
+++ b/language/move-prover/tests/xsources/design/resource_9_usage_analysis.bytecode
@@ -1,0 +1,44 @@
+============ after processor `usage_analysis` ================
+
+[variant baseline]
+pub fun Signer::address_of($t0|s: signer): address {
+     var $t1: signer
+     var $t2: address
+  0: $t1 := move($t0)
+  1: trace_local[s]($t1)
+  2: $t2 := Signer::borrow_address($t1)
+  3: trace_return[0]($t2)
+  4: return $t2
+}
+
+
+[variant baseline]
+pub fun Signer::borrow_address($t0|s: signer): address {
+}
+
+
+[variant baseline]
+pub fun Trafo::dummy_need_signer_use_in_move($t0|account: signer): address {
+     var $t1: signer
+     var $t2: address
+  0: $t1 := move($t0)
+  1: trace_local[account]($t1)
+  2: $t2 := Signer::address_of($t1)
+  3: trace_return[0]($t2)
+  4: return $t2
+}
+
+
+[variant baseline]
+pub fun Trafo::publish($t0|account: signer, $t1|x: u64) {
+     var $t2: signer
+     var $t3: u64
+     var $t4: Trafo::R
+  0: $t2 := move($t0)
+  1: $t3 := move($t1)
+  2: trace_local[account]($t2)
+  3: trace_local[x]($t3)
+  4: $t4 := pack Trafo::R($t3)
+  5: move_to<Trafo::R>($t4, $t2)
+  6: return ()
+}

--- a/language/move-prover/tests/xsources/design/simple.move
+++ b/language/move-prover/tests/xsources/design/simple.move
@@ -1,0 +1,15 @@
+// flag: --v2
+address 0x0 {
+/// Example for simple pre/post conditions.
+module Trafo {
+
+  public fun div(x: u64, y: u64): u64 {
+      x / y
+  }
+  spec fun div {
+      aborts_if y == 0;
+      ensures result == x / y;
+  }
+
+}
+}

--- a/language/move-prover/tests/xsources/design/simple_0_stackless.bytecode
+++ b/language/move-prover/tests/xsources/design/simple_0_stackless.bytecode
@@ -1,0 +1,12 @@
+============ after processor `stackless` ================
+
+[variant baseline]
+pub fun Trafo::div($t0|x: u64, $t1|y: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+  0: $t2 := copy($t0)
+  1: $t3 := copy($t1)
+  2: $t4 := /($t2, $t3)
+  3: return $t4
+}

--- a/language/move-prover/tests/xsources/design/simple_10_spec_instrumenter.bytecode
+++ b/language/move-prover/tests/xsources/design/simple_10_spec_instrumenter.bytecode
@@ -1,0 +1,38 @@
+============ after processor `spec_instrumenter` ================
+
+[variant baseline]
+pub fun Trafo::div($t0|x: u64, $t1|y: u64): u64 {
+     var $t2: u64
+     var $t3: num
+  0: trace_local[x]($t0)
+  1: trace_local[y]($t1)
+  2: $t2 := /($t0, $t1)
+  3: on_abort goto 7 code := $t3
+  4: trace_return[0]($t2)
+  5: label L1
+  6: return $t2
+  7: label L2
+  8: abort($t3)
+}
+
+
+[variant verification]
+pub fun Trafo::div($t0|x: u64, $t1|y: u64): u64 {
+     var $t2: u64
+     var $t3: num
+  0: trace_local[x]($t0)
+  1: trace_local[y]($t1)
+  2: $t2 := /($t0, $t1)
+  3: on_abort goto 9 code := $t3
+  4: trace_return[0]($t2)
+  5: label L1
+     // VC: `function does not abort under this condition` at simple.move:10:7+17
+  6: assert Not(Eq<u64>($t1, 0))
+     // VC: `post-condition does not hold` at simple.move:11:7+24
+  7: assert Eq<u64>($t2, Div($t0, $t1))
+  8: return $t2
+  9: label L2
+     // VC: `abort not covered by any of the `aborts_if` clauses` at simple.move:6:3+53
+ 10: assert Eq<u64>($t1, 0)
+ 11: abort($t3)
+}

--- a/language/move-prover/tests/xsources/design/simple_1_debug_instrumenter.bytecode
+++ b/language/move-prover/tests/xsources/design/simple_1_debug_instrumenter.bytecode
@@ -1,0 +1,15 @@
+============ after processor `debug_instrumenter` ================
+
+[variant baseline]
+pub fun Trafo::div($t0|x: u64, $t1|y: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+  0: trace_local[x]($t0)
+  1: trace_local[y]($t1)
+  2: $t2 := copy($t0)
+  3: $t3 := copy($t1)
+  4: $t4 := /($t2, $t3)
+  5: trace_return[0]($t4)
+  6: return $t4
+}

--- a/language/move-prover/tests/xsources/design/simple_2_eliminate_imm_refs.bytecode
+++ b/language/move-prover/tests/xsources/design/simple_2_eliminate_imm_refs.bytecode
@@ -1,0 +1,15 @@
+============ after processor `eliminate_imm_refs` ================
+
+[variant baseline]
+pub fun Trafo::div($t0|x: u64, $t1|y: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+  0: trace_local[x]($t0)
+  1: trace_local[y]($t1)
+  2: $t2 := copy($t0)
+  3: $t3 := copy($t1)
+  4: $t4 := /($t2, $t3)
+  5: trace_return[0]($t4)
+  6: return $t4
+}

--- a/language/move-prover/tests/xsources/design/simple_3_eliminate_mut_refs.bytecode
+++ b/language/move-prover/tests/xsources/design/simple_3_eliminate_mut_refs.bytecode
@@ -1,0 +1,19 @@
+============ after processor `eliminate_mut_refs` ================
+
+[variant baseline]
+pub fun Trafo::div($t0|x: u64, $t1|y: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+  0: $t5 := move($t0)
+  1: $t6 := move($t1)
+  2: trace_local[x]($t5)
+  3: trace_local[y]($t6)
+  4: $t2 := copy($t5)
+  5: $t3 := copy($t6)
+  6: $t4 := /($t2, $t3)
+  7: trace_return[0]($t4)
+  8: return $t4
+}

--- a/language/move-prover/tests/xsources/design/simple_4_reaching_def_analysis.bytecode
+++ b/language/move-prover/tests/xsources/design/simple_4_reaching_def_analysis.bytecode
@@ -1,0 +1,19 @@
+============ after processor `reaching_def_analysis` ================
+
+[variant baseline]
+pub fun Trafo::div($t0|x: u64, $t1|y: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+  0: $t5 := move($t0)
+  1: $t6 := move($t1)
+  2: trace_local[x]($t5)
+  3: trace_local[y]($t6)
+  4: $t2 := copy($t5)
+  5: $t3 := copy($t6)
+  6: $t4 := /($t5, $t6)
+  7: trace_return[0]($t4)
+  8: return $t4
+}

--- a/language/move-prover/tests/xsources/design/simple_5_livevar_analysis.bytecode
+++ b/language/move-prover/tests/xsources/design/simple_5_livevar_analysis.bytecode
@@ -1,0 +1,22 @@
+============ after processor `livevar_analysis` ================
+
+[variant baseline]
+pub fun Trafo::div($t0|x: u64, $t1|y: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     // live vars: x, y
+  0: $t2 := move($t0)
+     // live vars: y, $t2
+  1: $t3 := move($t1)
+     // live vars: $t2, $t3
+  2: trace_local[x]($t2)
+     // live vars: $t2, $t3
+  3: trace_local[y]($t3)
+     // live vars: $t2, $t3
+  4: $t4 := /($t2, $t3)
+     // live vars: $t4
+  5: trace_return[0]($t4)
+     // live vars: $t4
+  6: return $t4
+}

--- a/language/move-prover/tests/xsources/design/simple_6_borrow_analysis.bytecode
+++ b/language/move-prover/tests/xsources/design/simple_6_borrow_analysis.bytecode
@@ -1,0 +1,28 @@
+============ after processor `borrow_analysis` ================
+
+[variant baseline]
+pub fun Trafo::div($t0|x: u64, $t1|y: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     // live_nodes: LocalRoot($t0), LocalRoot($t1)
+  0: $t2 := move($t0)
+     // live_nodes: LocalRoot($t1), LocalRoot($t2)
+     // moved_nodes: LocalRoot($t0)
+  1: $t3 := move($t1)
+     // live_nodes: LocalRoot($t2), LocalRoot($t3)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
+  2: trace_local[x]($t2)
+     // live_nodes: LocalRoot($t2), LocalRoot($t3)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
+  3: trace_local[y]($t3)
+     // live_nodes: LocalRoot($t2), LocalRoot($t3)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
+  4: $t4 := /($t2, $t3)
+     // live_nodes: LocalRoot($t2), LocalRoot($t3)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
+  5: trace_return[0]($t4)
+     // live_nodes: LocalRoot($t2), LocalRoot($t3)
+     // moved_nodes: LocalRoot($t0), LocalRoot($t1)
+  6: return $t4
+}

--- a/language/move-prover/tests/xsources/design/simple_7_memory_instr.bytecode
+++ b/language/move-prover/tests/xsources/design/simple_7_memory_instr.bytecode
@@ -1,0 +1,15 @@
+============ after processor `memory_instr` ================
+
+[variant baseline]
+pub fun Trafo::div($t0|x: u64, $t1|y: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+  0: $t2 := move($t0)
+  1: $t3 := move($t1)
+  2: trace_local[x]($t2)
+  3: trace_local[y]($t3)
+  4: $t4 := /($t2, $t3)
+  5: trace_return[0]($t4)
+  6: return $t4
+}

--- a/language/move-prover/tests/xsources/design/simple_8_clean_and_optimize.bytecode
+++ b/language/move-prover/tests/xsources/design/simple_8_clean_and_optimize.bytecode
@@ -1,0 +1,15 @@
+============ after processor `clean_and_optimize` ================
+
+[variant baseline]
+pub fun Trafo::div($t0|x: u64, $t1|y: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+  0: $t2 := move($t0)
+  1: $t3 := move($t1)
+  2: trace_local[x]($t2)
+  3: trace_local[y]($t3)
+  4: $t4 := /($t2, $t3)
+  5: trace_return[0]($t4)
+  6: return $t4
+}

--- a/language/move-prover/tests/xsources/design/simple_9_usage_analysis.bytecode
+++ b/language/move-prover/tests/xsources/design/simple_9_usage_analysis.bytecode
@@ -1,0 +1,15 @@
+============ after processor `usage_analysis` ================
+
+[variant baseline]
+pub fun Trafo::div($t0|x: u64, $t1|y: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+  0: $t2 := move($t0)
+  1: $t3 := move($t1)
+  2: trace_local[x]($t2)
+  3: trace_local[y]($t3)
+  4: $t4 := /($t2, $t3)
+  5: trace_return[0]($t4)
+  6: return $t4
+}


### PR DESCRIPTION
This PR adds examples to illustrate transformation and compilation to `tests/xsources/design`. It also fixes a bug in copy progragation which was found with those examples. Finally, it optimizes the readability of the bytecode dump by filtering out packref/unpackref instructions which are unneeded already at memory instrumentation time. The later leads to a bunch of baseline updates.

## Motivation

Prover refactoring.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests.

## Related PRs

NA
