### PR TITLE
[json-rpc] health-check for checking latest ledger info timestamp

### DIFF
--- a/json-rpc/Cargo.toml
+++ b/json-rpc/Cargo.toml
@@ -18,7 +18,7 @@ hyper = "0.14.2"
 once_cell = "1.4.1"
 rand = "0.7.3"
 serde_json = "1.0.61"
-serde = { version = "1.0.123", default-features = false }
+serde = { version = "1.0.123", features = ["derive"], default-features = false }
 tokio = { version = "1.1.0", features = ["full"] }
 warp = { version = "0.3.0", features = ["tls"] }
 reqwest = { version = "0.11.0", features = ["blocking", "json"], default_features = false, optional = true }


### PR DESCRIPTION
## Motivation

When fullnode db is lack behind the head of blocks, we may consider it is an unhealthy node and take it out.

This PR adds an optional param to the "/-/healthy" endpoint for validating the db latest ledger info timestamp and return 200 only for the case the ladger info timestamp is in the range given by the param.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

YES

## Test Plan

Manual and unit test