### PR TITLE
[move][bytecode verifier] Restructure dependency verifications

### DIFF
--- a/language/bytecode-verifier/src/binary_views.rs
+++ b/language/bytecode-verifier/src/binary_views.rs
@@ -32,6 +32,27 @@ pub(crate) enum BinaryIndexedView<'a> {
 }
 
 impl<'a> BinaryIndexedView<'a> {
+    pub(crate) fn module_handles(&self) -> &[ModuleHandle] {
+        match self {
+            BinaryIndexedView::Module(module) => module.module_handles(),
+            BinaryIndexedView::Script(script) => script.module_handles(),
+        }
+    }
+
+    pub(crate) fn struct_handles(&self) -> &[StructHandle] {
+        match self {
+            BinaryIndexedView::Module(module) => module.struct_handles(),
+            BinaryIndexedView::Script(script) => script.struct_handles(),
+        }
+    }
+
+    pub(crate) fn function_handles(&self) -> &[FunctionHandle] {
+        match self {
+            BinaryIndexedView::Module(module) => module.function_handles(),
+            BinaryIndexedView::Script(script) => script.function_handles(),
+        }
+    }
+
     pub(crate) fn identifier_at(&self, idx: IdentifierIndex) -> &IdentStr {
         match self {
             BinaryIndexedView::Module(module) => module.identifier_at(idx),
@@ -192,11 +213,25 @@ impl<'a> BinaryIndexedView<'a> {
         }
     }
 
+    pub(crate) fn self_handle_idx(&self) -> Option<ModuleHandleIndex> {
+        match self {
+            BinaryIndexedView::Module(m) => Some(m.self_handle_idx()),
+            BinaryIndexedView::Script(_) => None,
+        }
+    }
+
     pub(crate) fn module_id_for_handle(&self, module_handle: &ModuleHandle) -> ModuleId {
         ModuleId::new(
             *self.address_identifier_at(module_handle.address),
             self.identifier_at(module_handle.name).to_owned(),
         )
+    }
+
+    pub(crate) fn self_id(&self) -> Option<ModuleId> {
+        match self {
+            BinaryIndexedView::Module(m) => Some(m.self_id()),
+            BinaryIndexedView::Script(_) => None,
+        }
     }
 }
 

--- a/language/bytecode-verifier/src/cyclic_dependencies.rs
+++ b/language/bytecode-verifier/src/cyclic_dependencies.rs
@@ -1,0 +1,65 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module contains verification of usage of dependencies for modules
+use diem_types::vm_status::StatusCode;
+use move_core_types::language_storage::ModuleId;
+use std::collections::BTreeSet;
+use vm::{
+    access::ModuleAccess,
+    errors::{Location, PartialVMError, PartialVMResult, VMResult},
+    file_format::CompiledModule,
+};
+
+pub fn verify_module<F: Fn(&ModuleId) -> PartialVMResult<Vec<ModuleId>>>(
+    module: &CompiledModule,
+    immediate_module_dependencies: F,
+) -> VMResult<()> {
+    verify_module_impl(module, immediate_module_dependencies)
+        .map_err(|e| e.finish(Location::Module(module.self_id())))
+}
+
+fn verify_module_impl<F: Fn(&ModuleId) -> PartialVMResult<Vec<ModuleId>>>(
+    module: &CompiledModule,
+    immediate_module_dependencies: F,
+) -> PartialVMResult<()> {
+    fn check_existence_in_dependency_recursive<
+        F: Fn(&ModuleId) -> PartialVMResult<Vec<ModuleId>>,
+    >(
+        target_module_id: &ModuleId,
+        cursor_module_id: &ModuleId,
+        immediate_module_dependencies: &F,
+        visited_modules: &mut BTreeSet<ModuleId>,
+    ) -> PartialVMResult<bool> {
+        if cursor_module_id == target_module_id {
+            return Ok(true);
+        }
+        if visited_modules.insert(cursor_module_id.clone()) {
+            for next in immediate_module_dependencies(cursor_module_id)? {
+                if check_existence_in_dependency_recursive(
+                    target_module_id,
+                    &next,
+                    immediate_module_dependencies,
+                    visited_modules,
+                )? {
+                    return Ok(true);
+                }
+            }
+        }
+        Ok(false)
+    }
+
+    let self_id = module.self_id();
+    let mut visited_modules = BTreeSet::new();
+    for dep in module.immediate_module_dependencies() {
+        if check_existence_in_dependency_recursive(
+            &self_id,
+            &dep,
+            &immediate_module_dependencies,
+            &mut visited_modules,
+        )? {
+            return Err(PartialVMError::new(StatusCode::CYCLIC_MODULE_DEPENDENCY));
+        }
+    }
+    Ok(())
+}

--- a/language/bytecode-verifier/src/dependencies.rs
+++ b/language/bytecode-verifier/src/dependencies.rs
@@ -1,103 +1,70 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! This module contains the public APIs supported by the bytecode verifier.
+//! This module contains verification of usage of dependencies for modules and scripts.
 use crate::binary_views::BinaryIndexedView;
 use diem_types::vm_status::StatusCode;
 use move_core_types::{identifier::Identifier, language_storage::ModuleId};
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, HashMap};
 use vm::{
-    access::{ModuleAccess, ScriptAccess},
+    access::ModuleAccess,
     errors::{verification_error, Location, PartialVMError, PartialVMResult, VMResult},
     file_format::{
-        CompiledModule, CompiledScript, FunctionHandle, FunctionHandleIndex, ModuleHandle,
-        ModuleHandleIndex, SignatureToken, StructHandle, StructHandleIndex, TableIndex,
+        CompiledModule, CompiledScript, FunctionHandleIndex, ModuleHandleIndex, SignatureToken,
+        StructHandleIndex, TableIndex,
     },
     IndexKind,
 };
 
-pub struct DependencyChecker<'a> {
+struct Context<'a, 'b> {
     resolver: BinaryIndexedView<'a>,
     // (Module -> CompiledModule) for (at least) all immediate dependencies
-    dependency_map: BTreeMap<ModuleId, &'a CompiledModule>,
+    dependency_map: BTreeMap<ModuleId, &'b CompiledModule>,
     // (Module::StructName -> handle) for all types of all dependencies
     struct_id_to_handle_map: HashMap<(ModuleId, Identifier), StructHandleIndex>,
-    // (Module::FunctionName -> handle) for all public functions of all dependencies
+    // (Module::FunctionName -> handle) for all non-private functions of all dependencies
     func_id_to_handle_map: HashMap<(ModuleId, Identifier), FunctionHandleIndex>,
 }
 
-impl<'a> DependencyChecker<'a> {
-    pub fn verify_module(
+impl<'a, 'b> Context<'a, 'b> {
+    fn module(
         module: &'a CompiledModule,
-        dependencies: impl IntoIterator<Item = &'a CompiledModule>,
-    ) -> VMResult<()> {
-        Self::verify_module_impl(module, dependencies)
-            .map_err(|e| e.finish(Location::Module(module.self_id())))
+        dependencies: impl IntoIterator<Item = &'b CompiledModule>,
+    ) -> Self {
+        Self::new(BinaryIndexedView::Module(module), dependencies)
     }
 
-    fn verify_module_impl(
-        module: &'a CompiledModule,
-        dependencies: impl IntoIterator<Item = &'a CompiledModule>,
-    ) -> PartialVMResult<()> {
-        let module_id = module.self_id();
-        let mut dependency_map = BTreeMap::new();
-        for dependency in dependencies {
-            let dependency_id = dependency.self_id();
-            if module_id != dependency_id {
-                dependency_map.insert(dependency_id, dependency);
-            }
-        }
+    fn script(
+        script: &'a CompiledScript,
+        dependencies: impl IntoIterator<Item = &'b CompiledModule>,
+    ) -> Self {
+        Self::new(BinaryIndexedView::Script(script), dependencies)
+    }
 
-        let mut checker = Self {
-            resolver: BinaryIndexedView::Module(module),
+    fn new(
+        resolver: BinaryIndexedView<'a>,
+        dependencies: impl IntoIterator<Item = &'b CompiledModule>,
+    ) -> Self {
+        let self_module = resolver.self_id();
+        let dependency_map = dependencies
+            .into_iter()
+            .filter(|d| Some(d.self_id()) != self_module)
+            .map(|d| (d.self_id(), d))
+            .collect();
+
+        let mut context = Self {
+            resolver,
             dependency_map,
             struct_id_to_handle_map: HashMap::new(),
             func_id_to_handle_map: HashMap::new(),
         };
-        checker.build_deps_entry_point();
 
-        // verify dependencies
-        checker.verify_imported_modules(module.module_handles(), Some(module.self_handle_idx()))?;
-        checker.verify_imported_structs(module.struct_handles(), Some(module.self_handle_idx()))?;
-        checker.verify_imported_functions(module.function_handles(), Some(module.self_handle_idx()))
-    }
-
-    pub fn verify_script(
-        script: &'a CompiledScript,
-        dependencies: impl IntoIterator<Item = &'a CompiledModule>,
-    ) -> VMResult<()> {
-        Self::verify_script_impl(script, dependencies).map_err(|e| e.finish(Location::Script))
-    }
-
-    pub fn verify_script_impl(
-        script: &'a CompiledScript,
-        dependencies: impl IntoIterator<Item = &'a CompiledModule>,
-    ) -> PartialVMResult<()> {
-        let mut dependency_map = BTreeMap::new();
-        for dependency in dependencies {
-            let dependency_id = dependency.self_id();
-            dependency_map.insert(dependency_id, dependency);
-        }
-        let mut checker = Self {
-            resolver: BinaryIndexedView::Script(script),
-            dependency_map,
-            struct_id_to_handle_map: HashMap::new(),
-            func_id_to_handle_map: HashMap::new(),
-        };
-        checker.build_deps_entry_point();
-
-        checker.verify_imported_modules(script.module_handles(), None)?;
-        checker.verify_imported_structs(script.struct_handles(), None)?;
-        checker.verify_imported_functions(script.function_handles(), None)
-    }
-
-    fn build_deps_entry_point(&mut self) {
-        for (module_id, module) in &self.dependency_map {
+        for (module_id, module) in &context.dependency_map {
             // Module::StructName -> def handle idx
             for struct_def in module.struct_defs() {
                 let struct_handle = module.struct_handle_at(struct_def.struct_handle);
                 let struct_name = module.identifier_at(struct_handle.name);
-                self.struct_id_to_handle_map.insert(
+                context.struct_id_to_handle_map.insert(
                     (module_id.clone(), struct_name.to_owned()),
                     struct_def.struct_handle,
                 );
@@ -109,289 +76,266 @@ impl<'a> DependencyChecker<'a> {
                 }
                 let func_handle = module.function_handle_at(func_def.function);
                 let func_name = module.identifier_at(func_handle.name);
-                self.func_id_to_handle_map
+                context
+                    .func_id_to_handle_map
                     .insert((module_id.clone(), func_name.to_owned()), func_def.function);
             }
         }
+        context
     }
+}
 
-    fn verify_imported_modules(
-        &self,
-        module_handles: &[ModuleHandle],
-        self_module: Option<ModuleHandleIndex>,
-    ) -> PartialVMResult<()> {
-        for (idx, module_handle) in module_handles.iter().enumerate() {
-            let module_id = self.resolver.module_id_for_handle(module_handle);
-            if Some(ModuleHandleIndex(idx as u16)) != self_module
-                && !self.dependency_map.contains_key(&module_id)
-            {
-                return Err(verification_error(
-                    StatusCode::MISSING_DEPENDENCY,
-                    IndexKind::ModuleHandle,
-                    idx as TableIndex,
-                ));
-            }
+pub fn verify_module<'a>(
+    module: &CompiledModule,
+    dependencies: impl IntoIterator<Item = &'a CompiledModule>,
+) -> VMResult<()> {
+    verify_module_impl(module, dependencies)
+        .map_err(|e| e.finish(Location::Module(module.self_id())))
+}
+
+fn verify_module_impl<'a>(
+    module: &CompiledModule,
+    dependencies: impl IntoIterator<Item = &'a CompiledModule>,
+) -> PartialVMResult<()> {
+    let context = &Context::module(module, dependencies);
+
+    verify_imported_modules(context)?;
+    verify_imported_structs(context)?;
+    verify_imported_functions(context)
+}
+
+pub fn verify_script<'a>(
+    script: &CompiledScript,
+    dependencies: impl IntoIterator<Item = &'a CompiledModule>,
+) -> VMResult<()> {
+    verify_script_impl(script, dependencies).map_err(|e| e.finish(Location::Script))
+}
+
+pub fn verify_script_impl<'a>(
+    script: &CompiledScript,
+    dependencies: impl IntoIterator<Item = &'a CompiledModule>,
+) -> PartialVMResult<()> {
+    let context = &Context::script(script, dependencies);
+
+    verify_imported_modules(context)?;
+    verify_imported_structs(context)?;
+    verify_imported_functions(context)
+}
+
+fn verify_imported_modules(context: &Context) -> PartialVMResult<()> {
+    let self_module = context.resolver.self_handle_idx();
+    for (idx, module_handle) in context.resolver.module_handles().iter().enumerate() {
+        let module_id = context.resolver.module_id_for_handle(module_handle);
+        if Some(ModuleHandleIndex(idx as u16)) != self_module
+            && !context.dependency_map.contains_key(&module_id)
+        {
+            return Err(verification_error(
+                StatusCode::MISSING_DEPENDENCY,
+                IndexKind::ModuleHandle,
+                idx as TableIndex,
+            ));
         }
-        Ok(())
     }
+    Ok(())
+}
 
-    fn verify_imported_structs(
-        &self,
-        struct_handles: &[StructHandle],
-        self_module: Option<ModuleHandleIndex>,
-    ) -> PartialVMResult<()> {
-        for (idx, struct_handle) in struct_handles.iter().enumerate() {
-            if Some(struct_handle.module) == self_module {
-                continue;
-            }
-            let owner_module_id = self
-                .resolver
-                .module_id_for_handle(self.resolver.module_handle_at(struct_handle.module));
-            // TODO: remove unwrap
-            let owner_module = self.dependency_map.get(&owner_module_id).unwrap();
-            let struct_name = self.resolver.identifier_at(struct_handle.name);
-            match self
-                .struct_id_to_handle_map
-                .get(&(owner_module_id, struct_name.to_owned()))
-            {
-                Some(def_idx) => {
-                    let def_handle = owner_module.struct_handle_at(*def_idx);
-                    if struct_handle.is_nominal_resource != def_handle.is_nominal_resource
-                        || struct_handle.type_parameters != def_handle.type_parameters
-                    {
-                        return Err(verification_error(
-                            StatusCode::TYPE_MISMATCH,
-                            IndexKind::StructHandle,
-                            idx as TableIndex,
-                        ));
-                    }
-                }
-                None => {
+fn verify_imported_structs(context: &Context) -> PartialVMResult<()> {
+    let self_module = context.resolver.self_handle_idx();
+    for (idx, struct_handle) in context.resolver.struct_handles().iter().enumerate() {
+        if Some(struct_handle.module) == self_module {
+            continue;
+        }
+        let owner_module_id = context
+            .resolver
+            .module_id_for_handle(context.resolver.module_handle_at(struct_handle.module));
+        // TODO: remove unwrap
+        let owner_module = context.dependency_map.get(&owner_module_id).unwrap();
+        let struct_name = context.resolver.identifier_at(struct_handle.name);
+        match context
+            .struct_id_to_handle_map
+            .get(&(owner_module_id, struct_name.to_owned()))
+        {
+            Some(def_idx) => {
+                let def_handle = owner_module.struct_handle_at(*def_idx);
+                if struct_handle.is_nominal_resource != def_handle.is_nominal_resource
+                    || struct_handle.type_parameters != def_handle.type_parameters
+                {
                     return Err(verification_error(
-                        StatusCode::LOOKUP_FAILED,
+                        StatusCode::TYPE_MISMATCH,
                         IndexKind::StructHandle,
-                        idx as TableIndex,
-                    ))
-                }
-            }
-        }
-        Ok(())
-    }
-
-    fn verify_imported_functions(
-        &self,
-        function_handles: &[FunctionHandle],
-        self_module: Option<ModuleHandleIndex>,
-    ) -> PartialVMResult<()> {
-        for (idx, function_handle) in function_handles.iter().enumerate() {
-            if Some(function_handle.module) == self_module {
-                continue;
-            }
-            let owner_module_id = self
-                .resolver
-                .module_id_for_handle(self.resolver.module_handle_at(function_handle.module));
-            let function_name = self.resolver.identifier_at(function_handle.name);
-            // TODO: remove unwrap
-            let owner_module = self.dependency_map.get(&owner_module_id).unwrap();
-            match self
-                .func_id_to_handle_map
-                .get(&(owner_module_id.clone(), function_name.to_owned()))
-            {
-                Some(def_idx) => {
-                    let def_handle = owner_module.function_handle_at(*def_idx);
-                    // same type parameter constraints
-                    if function_handle.type_parameters != def_handle.type_parameters {
-                        return Err(verification_error(
-                            StatusCode::TYPE_MISMATCH,
-                            IndexKind::FunctionHandle,
-                            idx as TableIndex,
-                        ));
-                    }
-                    // same parameters
-                    let handle_params = self.resolver.signature_at(function_handle.parameters);
-                    let def_params = match self.dependency_map.get(&owner_module_id) {
-                        Some(module) => module.signature_at(def_handle.parameters),
-                        None => {
-                            return Err(verification_error(
-                                StatusCode::LOOKUP_FAILED,
-                                IndexKind::FunctionHandle,
-                                idx as TableIndex,
-                            ))
-                        }
-                    };
-                    self.compare_cross_module_signatures(
-                        &handle_params.0,
-                        &def_params.0,
-                        owner_module,
-                    )
-                    .map_err(|e| e.at_index(IndexKind::FunctionHandle, idx as TableIndex))?;
-
-                    // same return_
-                    let handle_return = self.resolver.signature_at(function_handle.return_);
-                    let def_return = match self.dependency_map.get(&owner_module_id) {
-                        Some(module) => module.signature_at(def_handle.return_),
-                        None => {
-                            return Err(verification_error(
-                                StatusCode::LOOKUP_FAILED,
-                                IndexKind::FunctionHandle,
-                                idx as TableIndex,
-                            ))
-                        }
-                    };
-                    self.compare_cross_module_signatures(
-                        &handle_return.0,
-                        &def_return.0,
-                        owner_module,
-                    )
-                    .map_err(|e| e.at_index(IndexKind::FunctionHandle, idx as TableIndex))?;
-                }
-                None => {
-                    return Err(verification_error(
-                        StatusCode::LOOKUP_FAILED,
-                        IndexKind::FunctionHandle,
                         idx as TableIndex,
                     ));
                 }
             }
+            None => {
+                return Err(verification_error(
+                    StatusCode::LOOKUP_FAILED,
+                    IndexKind::StructHandle,
+                    idx as TableIndex,
+                ))
+            }
         }
-        Ok(())
     }
+    Ok(())
+}
 
-    pub fn compare_cross_module_signatures(
-        &self,
-        handle_sig: &[SignatureToken],
-        def_sig: &[SignatureToken],
-        def_module: &CompiledModule,
-    ) -> PartialVMResult<()> {
-        if handle_sig.len() != def_sig.len() {
-            return Err(PartialVMError::new(StatusCode::TYPE_MISMATCH));
+fn verify_imported_functions(context: &Context) -> PartialVMResult<()> {
+    let self_module = context.resolver.self_handle_idx();
+    for (idx, function_handle) in context.resolver.function_handles().iter().enumerate() {
+        if Some(function_handle.module) == self_module {
+            continue;
         }
-        for (handle_type, def_type) in handle_sig.iter().zip(def_sig) {
-            self.compare_types(handle_type, def_type, def_module)?;
-        }
-        Ok(())
-    }
-
-    fn compare_types(
-        &self,
-        handle_type: &SignatureToken,
-        def_type: &SignatureToken,
-        def_module: &CompiledModule,
-    ) -> PartialVMResult<()> {
-        match (handle_type, def_type) {
-            (SignatureToken::Bool, SignatureToken::Bool)
-            | (SignatureToken::U8, SignatureToken::U8)
-            | (SignatureToken::U64, SignatureToken::U64)
-            | (SignatureToken::U128, SignatureToken::U128)
-            | (SignatureToken::Address, SignatureToken::Address)
-            | (SignatureToken::Signer, SignatureToken::Signer) => Ok(()),
-            (SignatureToken::Vector(ty1), SignatureToken::Vector(ty2)) => {
-                self.compare_types(ty1, ty2, def_module)
-            }
-            (SignatureToken::Struct(idx1), SignatureToken::Struct(idx2)) => {
-                self.compare_structs(*idx1, *idx2, def_module)
-            }
-            (
-                SignatureToken::StructInstantiation(idx1, inst1),
-                SignatureToken::StructInstantiation(idx2, inst2),
-            ) => {
-                self.compare_structs(*idx1, *idx2, def_module)?;
-                self.compare_cross_module_signatures(inst1, inst2, def_module)
-            }
-            (SignatureToken::Reference(ty1), SignatureToken::Reference(ty2))
-            | (SignatureToken::MutableReference(ty1), SignatureToken::MutableReference(ty2)) => {
-                self.compare_types(ty1, ty2, def_module)
-            }
-            (SignatureToken::TypeParameter(idx1), SignatureToken::TypeParameter(idx2)) => {
-                if idx1 != idx2 {
-                    Err(PartialVMError::new(StatusCode::TYPE_MISMATCH))
-                } else {
-                    Ok(())
+        let owner_module_id = context
+            .resolver
+            .module_id_for_handle(context.resolver.module_handle_at(function_handle.module));
+        let function_name = context.resolver.identifier_at(function_handle.name);
+        // TODO: remove unwrap
+        let owner_module = context.dependency_map.get(&owner_module_id).unwrap();
+        match context
+            .func_id_to_handle_map
+            .get(&(owner_module_id.clone(), function_name.to_owned()))
+        {
+            Some(def_idx) => {
+                let def_handle = owner_module.function_handle_at(*def_idx);
+                // same type parameter constraints
+                if function_handle.type_parameters != def_handle.type_parameters {
+                    return Err(verification_error(
+                        StatusCode::TYPE_MISMATCH,
+                        IndexKind::FunctionHandle,
+                        idx as TableIndex,
+                    ));
                 }
+                // same parameters
+                let handle_params = context.resolver.signature_at(function_handle.parameters);
+                let def_params = match context.dependency_map.get(&owner_module_id) {
+                    Some(module) => module.signature_at(def_handle.parameters),
+                    None => {
+                        return Err(verification_error(
+                            StatusCode::LOOKUP_FAILED,
+                            IndexKind::FunctionHandle,
+                            idx as TableIndex,
+                        ))
+                    }
+                };
+
+                compare_cross_module_signatures(
+                    context,
+                    &handle_params.0,
+                    &def_params.0,
+                    owner_module,
+                )
+                .map_err(|e| e.at_index(IndexKind::FunctionHandle, idx as TableIndex))?;
+
+                // same return_
+                let handle_return = context.resolver.signature_at(function_handle.return_);
+                let def_return = match context.dependency_map.get(&owner_module_id) {
+                    Some(module) => module.signature_at(def_handle.return_),
+                    None => {
+                        return Err(verification_error(
+                            StatusCode::LOOKUP_FAILED,
+                            IndexKind::FunctionHandle,
+                            idx as TableIndex,
+                        ))
+                    }
+                };
+
+                compare_cross_module_signatures(
+                    context,
+                    &handle_return.0,
+                    &def_return.0,
+                    owner_module,
+                )
+                .map_err(|e| e.at_index(IndexKind::FunctionHandle, idx as TableIndex))?;
             }
-            _ => Err(PartialVMError::new(StatusCode::TYPE_MISMATCH)),
+            None => {
+                return Err(verification_error(
+                    StatusCode::LOOKUP_FAILED,
+                    IndexKind::FunctionHandle,
+                    idx as TableIndex,
+                ));
+            }
         }
     }
+    Ok(())
+}
 
-    fn compare_structs(
-        &self,
-        idx1: StructHandleIndex,
-        idx2: StructHandleIndex,
-        def_module: &CompiledModule,
-    ) -> PartialVMResult<()> {
-        // grab ModuleId and struct name for the module being verified
-        let struct_handle = self.resolver.struct_handle_at(idx1);
-        let module_handle = self.resolver.module_handle_at(struct_handle.module);
-        let module_id = self.resolver.module_id_for_handle(module_handle);
-        let struct_name = self.resolver.identifier_at(struct_handle.name);
+fn compare_cross_module_signatures(
+    context: &Context,
+    handle_sig: &[SignatureToken],
+    def_sig: &[SignatureToken],
+    def_module: &CompiledModule,
+) -> PartialVMResult<()> {
+    if handle_sig.len() != def_sig.len() {
+        return Err(PartialVMError::new(StatusCode::TYPE_MISMATCH));
+    }
+    for (handle_type, def_type) in handle_sig.iter().zip(def_sig) {
+        compare_types(context, handle_type, def_type, def_module)?;
+    }
+    Ok(())
+}
 
-        // grab ModuleId and struct name for the definition
-        let def_struct_handle = def_module.struct_handle_at(idx2);
-        let def_module_handle = def_module.module_handle_at(def_struct_handle.module);
-        let def_module_id = def_module.module_id_for_handle(def_module_handle);
-        let def_struct_name = def_module.identifier_at(def_struct_handle.name);
-
-        if module_id != def_module_id || struct_name != def_struct_name {
-            Err(PartialVMError::new(StatusCode::TYPE_MISMATCH))
-        } else {
-            Ok(())
+fn compare_types(
+    context: &Context,
+    handle_type: &SignatureToken,
+    def_type: &SignatureToken,
+    def_module: &CompiledModule,
+) -> PartialVMResult<()> {
+    match (handle_type, def_type) {
+        (SignatureToken::Bool, SignatureToken::Bool)
+        | (SignatureToken::U8, SignatureToken::U8)
+        | (SignatureToken::U64, SignatureToken::U64)
+        | (SignatureToken::U128, SignatureToken::U128)
+        | (SignatureToken::Address, SignatureToken::Address)
+        | (SignatureToken::Signer, SignatureToken::Signer) => Ok(()),
+        (SignatureToken::Vector(ty1), SignatureToken::Vector(ty2)) => {
+            compare_types(context, ty1, ty2, def_module)
         }
+        (SignatureToken::Struct(idx1), SignatureToken::Struct(idx2)) => {
+            compare_structs(context, *idx1, *idx2, def_module)
+        }
+        (
+            SignatureToken::StructInstantiation(idx1, inst1),
+            SignatureToken::StructInstantiation(idx2, inst2),
+        ) => {
+            compare_structs(context, *idx1, *idx2, def_module)?;
+            compare_cross_module_signatures(context, inst1, inst2, def_module)
+        }
+        (SignatureToken::Reference(ty1), SignatureToken::Reference(ty2))
+        | (SignatureToken::MutableReference(ty1), SignatureToken::MutableReference(ty2)) => {
+            compare_types(context, ty1, ty2, def_module)
+        }
+        (SignatureToken::TypeParameter(idx1), SignatureToken::TypeParameter(idx2)) => {
+            if idx1 != idx2 {
+                Err(PartialVMError::new(StatusCode::TYPE_MISMATCH))
+            } else {
+                Ok(())
+            }
+        }
+        _ => Err(PartialVMError::new(StatusCode::TYPE_MISMATCH)),
     }
 }
 
-pub struct CyclicModuleDependencyChecker {}
+fn compare_structs(
+    context: &Context,
+    idx1: StructHandleIndex,
+    idx2: StructHandleIndex,
+    def_module: &CompiledModule,
+) -> PartialVMResult<()> {
+    // grab ModuleId and struct name for the module being verified
+    let struct_handle = context.resolver.struct_handle_at(idx1);
+    let module_handle = context.resolver.module_handle_at(struct_handle.module);
+    let module_id = context.resolver.module_id_for_handle(module_handle);
+    let struct_name = context.resolver.identifier_at(struct_handle.name);
 
-impl CyclicModuleDependencyChecker {
-    pub fn verify_module<F: Fn(&ModuleId) -> PartialVMResult<Vec<ModuleId>>>(
-        module: &CompiledModule,
-        immediate_module_dependencies: F,
-    ) -> VMResult<()> {
-        Self::verify_module_impl(module, immediate_module_dependencies)
-            .map_err(|e| e.finish(Location::Module(module.self_id())))
-    }
+    // grab ModuleId and struct name for the definition
+    let def_struct_handle = def_module.struct_handle_at(idx2);
+    let def_module_handle = def_module.module_handle_at(def_struct_handle.module);
+    let def_module_id = def_module.module_id_for_handle(def_module_handle);
+    let def_struct_name = def_module.identifier_at(def_struct_handle.name);
 
-    fn verify_module_impl<F: Fn(&ModuleId) -> PartialVMResult<Vec<ModuleId>>>(
-        module: &CompiledModule,
-        immediate_module_dependencies: F,
-    ) -> PartialVMResult<()> {
-        fn check_existence_in_dependency_recursive<
-            F: Fn(&ModuleId) -> PartialVMResult<Vec<ModuleId>>,
-        >(
-            target_module_id: &ModuleId,
-            cursor_module_id: &ModuleId,
-            immediate_module_dependencies: &F,
-            visited_modules: &mut BTreeSet<ModuleId>,
-        ) -> PartialVMResult<bool> {
-            if cursor_module_id == target_module_id {
-                return Ok(true);
-            }
-            if visited_modules.insert(cursor_module_id.clone()) {
-                for next in immediate_module_dependencies(cursor_module_id)? {
-                    if check_existence_in_dependency_recursive(
-                        target_module_id,
-                        &next,
-                        immediate_module_dependencies,
-                        visited_modules,
-                    )? {
-                        return Ok(true);
-                    }
-                }
-            }
-            Ok(false)
-        }
-
-        let self_id = module.self_id();
-        let mut visited_modules = BTreeSet::new();
-        for dep in module.immediate_module_dependencies() {
-            if check_existence_in_dependency_recursive(
-                &self_id,
-                &dep,
-                &immediate_module_dependencies,
-                &mut visited_modules,
-            )? {
-                return Err(PartialVMError::new(StatusCode::CYCLIC_MODULE_DEPENDENCY));
-            }
-        }
+    if module_id != def_module_id || struct_name != def_struct_name {
+        Err(PartialVMError::new(StatusCode::TYPE_MISMATCH))
+    } else {
         Ok(())
     }
 }

--- a/language/bytecode-verifier/src/lib.rs
+++ b/language/bytecode-verifier/src/lib.rs
@@ -11,6 +11,7 @@ pub mod code_unit_verifier;
 pub mod constants;
 pub mod control_flow;
 pub mod control_flow_graph;
+pub mod cyclic_dependencies;
 pub mod dependencies;
 pub mod instantiation_loops;
 pub mod instruction_consistency;
@@ -21,7 +22,6 @@ pub mod verifier;
 
 pub use check_duplication::DuplicationChecker;
 pub use code_unit_verifier::CodeUnitVerifier;
-pub use dependencies::{CyclicModuleDependencyChecker, DependencyChecker};
 pub use instruction_consistency::InstructionConsistency;
 pub use resources::ResourceTransitiveChecker;
 pub use signature::SignatureChecker;

--- a/language/compiler/src/main.rs
+++ b/language/compiler/src/main.rs
@@ -4,7 +4,7 @@
 #![forbid(unsafe_code)]
 
 use anyhow::Context;
-use bytecode_verifier::{verify_module, verify_script, DependencyChecker};
+use bytecode_verifier::{dependencies, verify_module, verify_script};
 use compiled_stdlib::{stdlib_modules, StdLibOptions};
 use compiler::{util, Compiler};
 use diem_types::{access_path::AccessPath, account_address::AccountAddress, account_config};
@@ -55,7 +55,7 @@ fn print_error_and_exit(verification_error: &VMError) -> ! {
 
 fn do_verify_module(module: CompiledModule, dependencies: &[CompiledModule]) -> CompiledModule {
     verify_module(&module).unwrap_or_else(|err| print_error_and_exit(&err));
-    if let Err(err) = DependencyChecker::verify_module(&module, dependencies) {
+    if let Err(err) = dependencies::verify_module(&module, dependencies) {
         print_error_and_exit(&err);
     }
     module

--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -3,9 +3,9 @@
 
 use crate::{logging::LogContext, native_functions::NativeFunction};
 use bytecode_verifier::{
-    constants, instantiation_loops::InstantiationLoopChecker, verify_main_signature,
-    CodeUnitVerifier, CyclicModuleDependencyChecker, DependencyChecker, DuplicationChecker,
-    InstructionConsistency, RecursiveStructDefChecker, ResourceTransitiveChecker, SignatureChecker,
+    constants, cyclic_dependencies, dependencies, instantiation_loops::InstantiationLoopChecker,
+    verify_main_signature, CodeUnitVerifier, DuplicationChecker, InstructionConsistency,
+    RecursiveStructDefChecker, ResourceTransitiveChecker, SignatureChecker,
 };
 use diem_crypto::HashValue;
 use diem_infallible::Mutex;
@@ -549,7 +549,7 @@ impl Loader {
         for dep in &dependencies {
             deps.push(dep.module());
         }
-        DependencyChecker::verify_script(script, deps)
+        dependencies::verify_script(script, deps)
     }
 
     //
@@ -659,10 +659,10 @@ impl Loader {
             .iter()
             .map(|module| module.module())
             .collect();
-        DependencyChecker::verify_module(module, imm_deps)?;
+        dependencies::verify_module(module, imm_deps)?;
 
         let module_cache = self.module_cache.lock();
-        CyclicModuleDependencyChecker::verify_module(module, |module_id| {
+        cyclic_dependencies::verify_module(module, |module_id| {
             module_cache
                 .modules
                 .get(module_id)

--- a/language/stdlib/compiled/src/lib.rs
+++ b/language/stdlib/compiled/src/lib.rs
@@ -5,7 +5,7 @@
 
 pub mod transaction_scripts;
 
-use bytecode_verifier::{verify_module, DependencyChecker};
+use bytecode_verifier::{dependencies, verify_module};
 use include_dir::{include_dir, Dir};
 use once_cell::sync::Lazy;
 use std::collections::BTreeMap;
@@ -51,7 +51,7 @@ static COMPILED_MOVELANG_STDLIB: Lazy<Vec<CompiledModule>> = Lazy::new(|| {
     let mut verified_modules = vec![];
     for (_, module) in modules.into_iter() {
         verify_module(&module).expect("stdlib module failed to verify");
-        DependencyChecker::verify_module(&module, &verified_modules)
+        dependencies::verify_module(&module, &verified_modules)
             .expect("stdlib module dependency failed to verify");
         verified_modules.push(module)
     }

--- a/language/stdlib/src/lib.rs
+++ b/language/stdlib/src/lib.rs
@@ -3,7 +3,7 @@
 
 #![forbid(unsafe_code)]
 
-use bytecode_verifier::{verify_module, DependencyChecker};
+use bytecode_verifier::{dependencies, verify_module};
 use log::LevelFilter;
 use move_lang::{compiled_unit::CompiledUnit, move_compile_and_report, shared::Address};
 use sha2::{Digest, Sha256};
@@ -152,7 +152,7 @@ pub fn build_stdlib() -> BTreeMap<String, CompiledModule> {
         match compiled_unit {
             CompiledUnit::Module { module, .. } => {
                 verify_module(&module).expect("stdlib module failed to verify");
-                DependencyChecker::verify_module(&module, modules.values())
+                dependencies::verify_module(&module, modules.values())
                     .expect("stdlib module dependency failed to verify");
                 // Tag each module with its index in the module dependency order. Needed for
                 // when they are deserialized and verified later on.

--- a/language/testing-infra/functional-tests/src/evaluator.rs
+++ b/language/testing-infra/functional-tests/src/evaluator.rs
@@ -6,7 +6,7 @@ use crate::{
     config::{global::Config as GlobalConfig, transaction::Config as TransactionConfig},
     errors::*,
 };
-use bytecode_verifier::DependencyChecker;
+use bytecode_verifier::dependencies;
 use compiled_stdlib::{stdlib_modules, transaction_scripts::StdlibScript, StdLibOptions};
 use diem_crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
 use diem_state_view::StateView;
@@ -276,7 +276,7 @@ pub fn verify_script(
     deps: &[CompiledModule],
 ) -> std::result::Result<CompiledScript, VMError> {
     bytecode_verifier::verify_script(&script)?;
-    DependencyChecker::verify_script(&script, deps)?;
+    dependencies::verify_script(&script, deps)?;
     Ok(script)
 }
 
@@ -286,7 +286,7 @@ pub fn verify_module(
     deps: &[CompiledModule],
 ) -> std::result::Result<CompiledModule, VMError> {
     bytecode_verifier::verify_module(&module)?;
-    DependencyChecker::verify_module(&module, deps)?;
+    dependencies::verify_module(&module, deps)?;
     Ok(module)
 }
 

--- a/language/tools/move-cli/src/main.rs
+++ b/language/tools/move-cli/src/main.rs
@@ -806,7 +806,7 @@ fn doctor(state: OnDiskStateView) -> Result<()> {
         }
 
         let imm_deps = code_cache.get_immediate_module_dependencies(module)?;
-        if bytecode_verifier::DependencyChecker::verify_module(module, imm_deps).is_err() {
+        if bytecode_verifier::dependencies::verify_module(module, imm_deps).is_err() {
             bail!(
                 "Failed to link module {:?} against its dependencies",
                 module.self_id()
@@ -814,7 +814,7 @@ fn doctor(state: OnDiskStateView) -> Result<()> {
         }
 
         let cyclic_check_result =
-            bytecode_verifier::CyclicModuleDependencyChecker::verify_module(module, |module_id| {
+            bytecode_verifier::cyclic_dependencies::verify_module(module, |module_id| {
                 code_cache
                     .get_module(module_id)
                     .map_err(|_| PartialVMError::new(StatusCode::MISSING_DEPENDENCY))


### PR DESCRIPTION
- Cleanup for dependency checker
- Should make new visibility checks easier

## Motivation

- The code had a lot of function parameters that were not needed, and the generation of this "checker" object was very brittle 

## Test Plan

- ran tests

## Related PRs

Conflicts with #7399
