### PR TITLE
[language] switch diem tests to exp mode -- designated_dealer - diem_…

### DIFF
--- a/language/move-lang/functional-tests/tests/diem/designated_dealer/currencies.exp
+++ b/language/move-lang/functional-tests/tests/diem/designated_dealer/currencies.exp
@@ -1,0 +1,3 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)

--- a/language/move-lang/functional-tests/tests/diem/designated_dealer/currencies.move
+++ b/language/move-lang/functional-tests/tests/diem/designated_dealer/currencies.move
@@ -27,5 +27,3 @@ script {
         assert(DiemAccount::accepts_currency<XDX>(0x3), 5);
     }
 }
-
-// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/diem/designated_dealer/tiered_mint.exp
+++ b/language/move-lang/functional-tests/tests/diem/designated_dealer/tiered_mint.exp
@@ -1,0 +1,24 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)
+[3] Transaction(1)
+[4] Move VM Status: EXECUTED
+[5] Transaction Status: Keep(EXECUTED)
+[6] Transaction(2)
+[7] Move VM Status: ABORTED { code: 1287, location: 00000000000000000000000000000001::DesignatedDealer }
+[8] Transaction Status: Keep(ABORTED { code: 1287, location: 00000000000000000000000000000001::DesignatedDealer })
+[9] Transaction(3)
+[10] Move VM Status: EXECUTED
+[11] Transaction Status: Keep(EXECUTED)
+[12] Transaction(4)
+[13] Move VM Status: EXECUTED
+[14] Transaction Status: Keep(EXECUTED)
+[15] Transaction(5)
+[16] Move VM Status: ABORTED { code: 1287, location: 00000000000000000000000000000001::DesignatedDealer }
+[17] Transaction Status: Keep(ABORTED { code: 1287, location: 00000000000000000000000000000001::DesignatedDealer })
+[18] Transaction(6)
+[19] Move VM Status: ABORTED { code: 775, location: 00000000000000000000000000000001::DesignatedDealer }
+[20] Transaction Status: Keep(ABORTED { code: 775, location: 00000000000000000000000000000001::DesignatedDealer })
+[21] Transaction(7)
+[22] Move VM Status: ABORTED { code: 258, location: 00000000000000000000000000000001::CoreAddresses }
+[23] Transaction Status: Keep(ABORTED { code: 258, location: 00000000000000000000000000000001::CoreAddresses })

--- a/language/move-lang/functional-tests/tests/diem/diem/blessing.exp
+++ b/language/move-lang/functional-tests/tests/diem/diem/blessing.exp
@@ -1,0 +1,27 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)
+[3] Transaction(1)
+[4] Move VM Status: ABORTED { code: 257, location: 00000000000000000000000000000001::Diem }
+[5] Transaction Status: Keep(ABORTED { code: 257, location: 00000000000000000000000000000001::Diem })
+[6] Transaction(2)
+[7] Move VM Status: ABORTED { code: 261, location: 00000000000000000000000000000001::Diem }
+[8] Transaction Status: Keep(ABORTED { code: 261, location: 00000000000000000000000000000001::Diem })
+[9] Transaction(3)
+[10] Move VM Status: ABORTED { code: 258, location: 00000000000000000000000000000001::CoreAddresses }
+[11] Transaction Status: Keep(ABORTED { code: 258, location: 00000000000000000000000000000001::CoreAddresses })
+[12] Transaction(4)
+[13] Move VM Status: ABORTED { code: 258, location: 00000000000000000000000000000001::CoreAddresses }
+[14] Transaction Status: Keep(ABORTED { code: 258, location: 00000000000000000000000000000001::CoreAddresses })
+[15] Transaction(5)
+[16] Move VM Status: EXECUTED
+[17] Transaction Status: Keep(EXECUTED)
+[18] Transaction(6)
+[19] Move VM Status: ABORTED { code: 262, location: 00000000000000000000000000000001::Diem }
+[20] Transaction Status: Keep(ABORTED { code: 262, location: 00000000000000000000000000000001::Diem })
+[21] Transaction(7)
+[22] Move VM Status: ABORTED { code: 263, location: 00000000000000000000000000000001::Diem }
+[23] Transaction Status: Keep(ABORTED { code: 263, location: 00000000000000000000000000000001::Diem })
+[24] Transaction(8)
+[25] Move VM Status: ABORTED { code: 263, location: 00000000000000000000000000000001::Diem }
+[26] Transaction Status: Keep(ABORTED { code: 263, location: 00000000000000000000000000000001::Diem })

--- a/language/move-lang/functional-tests/tests/diem/diem/blessing.move
+++ b/language/move-lang/functional-tests/tests/diem/diem/blessing.move
@@ -13,7 +13,6 @@ fun main() {
     Diem::assert_is_SCS_currency<XUS>();
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 script {
@@ -23,7 +22,6 @@ fun main() {
     Diem::assert_is_SCS_currency<XDX>();
 }
 }
-// check: "Keep(ABORTED { code: 257,"
 
 //! new-transaction
 script {
@@ -32,7 +30,6 @@ fun main() {
     Diem::assert_is_currency<u64>();
 }
 }
-// check: "Keep(ABORTED { code: 261,"
 
 //! new-transaction
 script {
@@ -43,7 +40,6 @@ fun main(account: &signer) {
     Diem::update_xdx_exchange_rate<XUS>(account, FixedPoint32::create_from_rational(1, 3));
 }
 }
-// check: "Keep(ABORTED { code: 258,"
 
 //! new-transaction
 script {
@@ -53,7 +49,6 @@ fun main(account: &signer) {
     Diem::update_minting_ability<XUS>(account, false);
 }
 }
-// check: "Keep(ABORTED { code: 258,"
 
 //! new-transaction
 module Holder {
@@ -68,7 +63,6 @@ module Holder {
        x
     }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: diemroot
@@ -91,7 +85,6 @@ fun main(dr_account: &signer) {
     Holder::hold(dr_account, b);
 }
 }
-// check: "Keep(ABORTED { code: 262,"
 
 //! new-transaction
 //! sender: diemroot
@@ -112,7 +105,6 @@ fun main(dr_account: &signer) {
     Holder::hold(dr_account, b);
 }
 }
-// check: "Keep(ABORTED { code: 263,"
 
 //! new-transaction
 //! sender: diemroot
@@ -133,4 +125,3 @@ fun main(dr_account: &signer) {
     Holder::hold(dr_account, b);
 }
 }
-// check: "Keep(ABORTED { code: 263,"

--- a/language/move-lang/functional-tests/tests/diem/diem/functionality.exp
+++ b/language/move-lang/functional-tests/tests/diem/diem/functionality.exp
@@ -1,0 +1,51 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)
+[3] Transaction(1)
+[4] Move VM Status: EXECUTED
+[5] Transaction Status: Keep(EXECUTED)
+[6] Transaction(2)
+[7] Move VM Status: ABORTED { code: 2055, location: 00000000000000000000000000000001::Diem }
+[8] Transaction Status: Keep(ABORTED { code: 2055, location: 00000000000000000000000000000001::Diem })
+[9] Transaction(3)
+[10] Move VM Status: EXECUTED
+[11] Transaction Status: Keep(EXECUTED)
+[12] Transaction(4)
+[13] Move VM Status: ABORTED { code: 261, location: 00000000000000000000000000000001::Diem }
+[14] Transaction Status: Keep(ABORTED { code: 261, location: 00000000000000000000000000000001::Diem })
+[15] Transaction(5)
+[16] Move VM Status: EXECUTED
+[17] Transaction Status: Keep(EXECUTED)
+[18] Transaction(6)
+[19] Move VM Status: EXECUTED
+[20] Transaction Status: Keep(EXECUTED)
+[21] Transaction(7)
+[22] Move VM Status: ABORTED { code: 258, location: 00000000000000000000000000000001::CoreAddresses }
+[23] Transaction Status: Keep(ABORTED { code: 258, location: 00000000000000000000000000000001::CoreAddresses })
+[24] Transaction(8)
+[25] Move VM Status: ABORTED { code: 2, location: 00000000000000000000000000000001::CoreAddresses }
+[26] Transaction Status: Keep(ABORTED { code: 2, location: 00000000000000000000000000000001::CoreAddresses })
+[27] Transaction(9)
+[28] Move VM Status: ABORTED { code: 258, location: 00000000000000000000000000000001::CoreAddresses }
+[29] Transaction Status: Keep(ABORTED { code: 258, location: 00000000000000000000000000000001::CoreAddresses })
+[30] Transaction(10)
+[31] Move VM Status: ABORTED { code: 258, location: 00000000000000000000000000000001::CoreAddresses }
+[32] Transaction Status: Keep(ABORTED { code: 258, location: 00000000000000000000000000000001::CoreAddresses })
+[33] Transaction(11)
+[34] Move VM Status: ABORTED { code: 1539, location: 00000000000000000000000000000001::Roles }
+[35] Transaction Status: Keep(ABORTED { code: 1539, location: 00000000000000000000000000000001::Roles })
+[36] Transaction(12)
+[37] Move VM Status: ABORTED { code: 1539, location: 00000000000000000000000000000001::Roles }
+[38] Transaction Status: Keep(ABORTED { code: 1539, location: 00000000000000000000000000000001::Roles })
+[39] Transaction(13)
+[40] Move VM Status: ABORTED { code: 2568, location: 00000000000000000000000000000001::Diem }
+[41] Transaction Status: Keep(ABORTED { code: 2568, location: 00000000000000000000000000000001::Diem })
+[42] Transaction(14)
+[43] Move VM Status: EXECUTED
+[44] Transaction Status: Keep(EXECUTED)
+[45] Transaction(15)
+[46] Move VM Status: ABORTED { code: 770, location: 00000000000000000000000000000001::CoreAddresses }
+[47] Transaction Status: Keep(ABORTED { code: 770, location: 00000000000000000000000000000001::CoreAddresses })
+[48] Transaction(16)
+[49] Move VM Status: ABORTED { code: 1800, location: 00000000000000000000000000000001::Diem }
+[50] Transaction Status: Keep(ABORTED { code: 1800, location: 00000000000000000000000000000001::Diem })

--- a/language/move-lang/functional-tests/tests/diem/diem/functionality.move
+++ b/language/move-lang/functional-tests/tests/diem/diem/functionality.move
@@ -6,7 +6,6 @@ module Holder {
         move_to(account, Holder<T> { x })
     }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: blessed
@@ -33,7 +32,6 @@ fun main(account: &signer) {
     Diem::destroy_zero(Diem::zero<XUS>());
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: blessed
@@ -44,7 +42,6 @@ fun main(account: &signer) {
     Diem::destroy_zero(Diem::mint<XUS>(account, 1));
 }
 }
-// check: "Keep(ABORTED { code: 2055,"
 
 //! new-transaction
 //! sender: bob
@@ -58,7 +55,6 @@ script {
         Diem::destroy_zero(coins);
     }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 script {
@@ -69,7 +65,6 @@ script {
         );
     }
 }
-// check: "Keep(ABORTED { code: 261"
 
 //! new-transaction
 script {
@@ -82,7 +77,6 @@ script {
         assert(!Diem::is_synthetic_currency<u64>(), 11);
     }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: blessed
@@ -97,7 +91,6 @@ script {
         );
     }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: diemroot
@@ -113,7 +106,6 @@ fun main(account: &signer) {
     Holder::hold(account, mint_cap);
 }
 }
-// check: "Keep(ABORTED { code: 258,"
 
 //! new-transaction
 //! sender: blessed
@@ -129,7 +121,6 @@ fun main(account: &signer) {
     Holder::hold(account, burn_cap);
 }
 }
-// check: "Keep(ABORTED { code: 2,"
 
 //! new-transaction
 //! sender: diemroot
@@ -142,7 +133,6 @@ fun main(account: &signer) {
     );
 }
 }
-// check: "Keep(ABORTED { code: 258,"
 
 //! new-transaction
 //! sender: diemroot
@@ -154,7 +144,6 @@ fun main(account: &signer) {
     Holder::hold(account, Diem::create_preburn<XUS>(account));
 }
 }
-// check: "Keep(ABORTED { code: 258,")
 
 //! new-transaction
 //! sender: diemroot
@@ -165,7 +154,6 @@ fun main(account: &signer) {
     Diem::publish_preburn_to_account<XDX>(account, account);
 }
 }
-// check: "Keep(ABORTED { code: 1539,")
 
 //! new-transaction
 //! sender: diemroot
@@ -176,7 +164,6 @@ fun main(account: &signer) {
     Diem::publish_preburn_to_account<XUS>(account, account);
 }
 }
-// check: "Keep(ABORTED { code: 1539,")
 
 //! new-transaction
 //! sender: blessed
@@ -190,7 +177,6 @@ fun main(account: &signer) {
     Diem::destroy_zero(xus);
 }
 }
-// check: "Keep(ABORTED { code: 2568,"
 
 //! new-transaction
 script {
@@ -204,7 +190,6 @@ fun main() {
     assert(Diem::is_synthetic_currency<XDX>(), 96);
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: blessed
@@ -214,7 +199,6 @@ fun main(account: &signer) {
     CoreAddresses::assert_currency_info(account)
 }
 }
-// check: "Keep(ABORTED { code: 770,"
 
 //! new-transaction
 //! sender: blessed
@@ -229,4 +213,3 @@ fun main(tc_account: &signer) {
     Diem::destroy_zero(coin1);
 }
 }
-// check: "Keep(ABORTED { code: 1800,"

--- a/language/move-lang/functional-tests/tests/diem/diem/initialize.exp
+++ b/language/move-lang/functional-tests/tests/diem/diem/initialize.exp
@@ -1,0 +1,3 @@
+[0] Transaction(0)
+[1] Move VM Status: ABORTED { code: 1, location: 00000000000000000000000000000001::DiemTimestamp }
+[2] Transaction Status: Keep(ABORTED { code: 1, location: 00000000000000000000000000000001::DiemTimestamp })

--- a/language/move-lang/functional-tests/tests/diem/diem/initialize.move
+++ b/language/move-lang/functional-tests/tests/diem/diem/initialize.move
@@ -6,4 +6,3 @@ fun main(account: &signer) {
     Diem::initialize(account);
 }
 }
-// check: "Keep(ABORTED { code: 1,"

--- a/language/move-lang/functional-tests/tests/diem/diem/multi_currency.exp
+++ b/language/move-lang/functional-tests/tests/diem/diem/multi_currency.exp
@@ -1,0 +1,46 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)
+[3] Transaction(1)
+[4] Output(TransactionOutput(TransactionOutput { write_set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: 0000000000000000000000000a550c18, path: 01000000000000000000000000000000010d4469656d54696d657374616d701743757272656e7454696d654d6963726f7365636f6e647300 }, Value(0300000000000000)), (AccessPath { address: 0000000000000000000000000a550c18, path: 0100000000000000000000000000000001094469656d426c6f636b0d426c6f636b4d6574616461746100 }, Value(010000000000000001000000000000001811000000000000000000000000000000000000000a550c18))] }), events: [ContractEvent { key: EventKey([17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]), index: 0, type: Struct(StructTag { address: 00000000000000000000000000000001, module: Identifier("DiemBlock"), name: Identifier("NewBlockEvent"), type_params: [] }), event_data: "000000000000000051c1b9fc2f32d6f2fff669823ef31cbe000300000000000000" }], gas_used: 100000000, status: Keep(EXECUTED) }))
+[5] Transaction(2)
+[6] Move VM Status: EXECUTED
+[7] Transaction Status: Keep(EXECUTED)
+[8] Transaction(3)
+[9] Output(TransactionOutput(TransactionOutput { write_set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: 0000000000000000000000000a550c18, path: 01000000000000000000000000000000010d4469656d54696d657374616d701743757272656e7454696d654d6963726f7365636f6e647300 }, Value(0400000000000000)), (AccessPath { address: 0000000000000000000000000a550c18, path: 0100000000000000000000000000000001094469656d426c6f636b0d426c6f636b4d6574616461746100 }, Value(020000000000000002000000000000001811000000000000000000000000000000000000000a550c18))] }), events: [ContractEvent { key: EventKey([17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]), index: 1, type: Struct(StructTag { address: 00000000000000000000000000000001, module: Identifier("DiemBlock"), name: Identifier("NewBlockEvent"), type_params: [] }), event_data: "000000000000000051c1b9fc2f32d6f2fff669823ef31cbe000400000000000000" }], gas_used: 100000000, status: Keep(EXECUTED) }))
+[10] Transaction(4)
+[11] Move VM Status: EXECUTED
+[12] Transaction Status: Keep(EXECUTED)
+[13] Transaction(5)
+[14] Move VM Status: EXECUTED
+[15] Transaction Status: Keep(EXECUTED)
+[16] Transaction(6)
+[17] Move VM Status: EXECUTED
+[18] Transaction Status: Keep(EXECUTED)
+[19] Transaction(7)
+[20] Move VM Status: EXECUTED
+[21] Transaction Status: Keep(EXECUTED)
+[22] Transaction(8)
+[23] Move VM Status: EXECUTED
+[24] Transaction Status: Keep(EXECUTED)
+[25] Transaction(9)
+[26] Move VM Status: EXECUTED
+[27] Transaction Status: Keep(EXECUTED)
+[28] Transaction(10)
+[29] Move VM Status: EXECUTED
+[30] Transaction Status: Keep(EXECUTED)
+[31] Transaction(11)
+[32] Move VM Status: EXECUTED
+[33] Transaction Status: Keep(EXECUTED)
+[34] Transaction(12)
+[35] Move VM Status: ABORTED { code: 261, location: 00000000000000000000000000000001::Diem }
+[36] Transaction Status: Keep(ABORTED { code: 261, location: 00000000000000000000000000000001::Diem })
+[37] Transaction(13)
+[38] Move VM Status: ABORTED { code: 3846, location: 00000000000000000000000000000001::DiemAccount }
+[39] Transaction Status: Keep(ABORTED { code: 3846, location: 00000000000000000000000000000001::DiemAccount })
+[40] Transaction(14)
+[41] Move VM Status: EXECUTED
+[42] Transaction Status: Keep(EXECUTED)
+[43] Transaction(15)
+[44] Move VM Status: EXECUTED
+[45] Transaction Status: Keep(EXECUTED)

--- a/language/move-lang/functional-tests/tests/diem/diem/multi_currency.move
+++ b/language/move-lang/functional-tests/tests/diem/diem/multi_currency.move
@@ -15,7 +15,6 @@ fun main(config: &signer) {
     DiemTransactionPublishingOption::set_open_module(config, false)
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! block-prologue
 //! proposer: validator
@@ -44,7 +43,6 @@ module COIN {
     }
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! block-prologue
 //! proposer: validator
@@ -61,7 +59,6 @@ fun main(dr_account: &signer, tc_account: &signer) {
     TransactionFee::add_txn_fee_currency<COIN>(tc_account);
 }
 }
-// check: "Keep(EXECUTED)"
 
 // END: registration of a currency
 
@@ -70,7 +67,6 @@ fun main(dr_account: &signer, tc_account: &signer) {
 //! type-args: 0x1::COIN::COIN
 //! args: 0, {{sally}}, {{sally::auth_key}}, b"bob", false
 stdlib_script::create_designated_dealer
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: blessed
@@ -109,7 +105,6 @@ fun main(tc_account: &signer) {
     );
 }
 }
-// check: "Keep(EXECUTED)"
 
 // Give alice money from richie
 //! new-transaction
@@ -123,7 +118,6 @@ fun main(account: &signer) {
     DiemAccount::restore_withdraw_capability(with_cap);
 }
 }
-// check: "Keep(EXECUTED)"
 
 // Give bob money from sally
 //! new-transaction
@@ -137,7 +131,6 @@ fun main(account: &signer) {
     DiemAccount::restore_withdraw_capability(with_cap);
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -148,7 +141,6 @@ fun main(account: &signer) {
     DiemAccount::add_currency<COIN>(account);
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -159,7 +151,6 @@ fun main(account: &signer) {
     DiemAccount::add_currency<XUS>(account);
 }
 }
-// check: "Keep(EXECUTED)"
 
 // Adding a bogus currency should abort
 //! new-transaction
@@ -170,7 +161,6 @@ fun main(account: &signer) {
     DiemAccount::add_currency<u64>(account);
 }
 }
-// check: "Keep(ABORTED { code: 261,"
 
 // Adding XUS a second time should fail with ADD_EXISTING_CURRENCY
 //! new-transaction
@@ -182,7 +172,6 @@ fun main(account: &signer) {
     DiemAccount::add_currency<XUS>(account);
 }
 }
-// check: "Keep(ABORTED { code: 3846,"
 
 //! new-transaction
 //! sender: alice
@@ -197,7 +186,6 @@ fun main(account: &signer) {
     assert(DiemAccount::balance<XUS>({{bob}}) == 10, 1);
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -216,4 +204,3 @@ fun main(account: &signer) {
     assert(DiemAccount::balance<COIN>({{alice}}) == 10, 5);
 }
 }
-// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/diem/diem/stop_minting.exp
+++ b/language/move-lang/functional-tests/tests/diem/diem/stop_minting.exp
@@ -1,0 +1,28 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)
+[3] Transaction(1)
+[4] Output(TransactionOutput(TransactionOutput { write_set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: 0000000000000000000000000a550c18, path: 01000000000000000000000000000000010d4469656d54696d657374616d701743757272656e7454696d654d6963726f7365636f6e647300 }, Value(0300000000000000)), (AccessPath { address: 0000000000000000000000000a550c18, path: 0100000000000000000000000000000001094469656d426c6f636b0d426c6f636b4d6574616461746100 }, Value(010000000000000001000000000000001811000000000000000000000000000000000000000a550c18))] }), events: [ContractEvent { key: EventKey([17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]), index: 0, type: Struct(StructTag { address: 00000000000000000000000000000001, module: Identifier("DiemBlock"), name: Identifier("NewBlockEvent"), type_params: [] }), event_data: "000000000000000051c1b9fc2f32d6f2fff669823ef31cbe000300000000000000" }], gas_used: 100000000, status: Keep(EXECUTED) }))
+[5] Transaction(2)
+[6] Move VM Status: EXECUTED
+[7] Transaction Status: Keep(EXECUTED)
+[8] Transaction(3)
+[9] Output(TransactionOutput(TransactionOutput { write_set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: 0000000000000000000000000a550c18, path: 01000000000000000000000000000000010d4469656d54696d657374616d701743757272656e7454696d654d6963726f7365636f6e647300 }, Value(0400000000000000)), (AccessPath { address: 0000000000000000000000000a550c18, path: 0100000000000000000000000000000001094469656d426c6f636b0d426c6f636b4d6574616461746100 }, Value(020000000000000002000000000000001811000000000000000000000000000000000000000a550c18))] }), events: [ContractEvent { key: EventKey([17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]), index: 1, type: Struct(StructTag { address: 00000000000000000000000000000001, module: Identifier("DiemBlock"), name: Identifier("NewBlockEvent"), type_params: [] }), event_data: "000000000000000051c1b9fc2f32d6f2fff669823ef31cbe000400000000000000" }], gas_used: 100000000, status: Keep(EXECUTED) }))
+[10] Transaction(4)
+[11] Move VM Status: EXECUTED
+[12] Transaction Status: Keep(EXECUTED)
+[13] Transaction(5)
+[14] Move VM Status: EXECUTED
+[15] Transaction Status: Keep(EXECUTED)
+[16] Transaction(6)
+[17] Move VM Status: EXECUTED
+[18] Transaction Status: Keep(EXECUTED)
+[19] Transaction(7)
+[20] Move VM Status: EXECUTED
+[21] Transaction Status: Keep(EXECUTED)
+[22] Transaction(8)
+[23] Move VM Status: EXECUTED
+[24] Transaction Status: Keep(EXECUTED)
+[25] Transaction(9)
+[26] Move VM Status: ABORTED { code: 1281, location: 00000000000000000000000000000001::Diem }
+[27] Transaction Status: Keep(ABORTED { code: 1281, location: 00000000000000000000000000000001::Diem })

--- a/language/move-lang/functional-tests/tests/diem/diem/stop_minting.move
+++ b/language/move-lang/functional-tests/tests/diem/diem/stop_minting.move
@@ -13,7 +13,6 @@ fun main(config: &signer) {
     DiemTransactionPublishingOption::set_open_module(config, false)
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! block-prologue
 //! proposer: vivian
@@ -42,7 +41,6 @@ module COIN {
     }
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! block-prologue
 //! proposer: vivian
@@ -59,7 +57,6 @@ fun main(dr_account: &signer, tc_account: &signer) {
     TransactionFee::add_txn_fee_currency<COIN>(tc_account);
 }
 }
-// check: "Keep(EXECUTED)"
 
 // END: registration of a currency
 
@@ -105,7 +102,6 @@ fun main(account: &signer) {
     assert(Diem::market_cap<COIN>() - prev_mcap2 == 100, 8);
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: dd1
@@ -120,7 +116,6 @@ fun main(account: &signer) {
     DiemAccount::restore_withdraw_capability(with_cap);
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: dd2
@@ -135,7 +130,6 @@ fun main(account: &signer) {
     DiemAccount::restore_withdraw_capability(with_cap);
 }
 }
-// check: "Keep(EXECUTED)"
 
 
 // do some burning
@@ -155,7 +149,6 @@ fun main(account: &signer) {
     assert(prev_mcap2 - Diem::market_cap<COIN>() == 100, 10);
 }
 }
-// check: "Keep(EXECUTED)"
 
 // check that stop minting works
 //! new-transaction
@@ -170,4 +163,3 @@ fun main(account: &signer) {
     Diem::destroy_zero(coin);
 }
 }
-// check: "Keep(ABORTED { code: 1281,"

--- a/language/move-lang/functional-tests/tests/diem/diem_account/add_currency.exp
+++ b/language/move-lang/functional-tests/tests/diem/diem_account/add_currency.exp
@@ -1,0 +1,40 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)
+[3] Transaction(1)
+[4] Output(TransactionOutput(TransactionOutput { write_set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: 0000000000000000000000000a550c18, path: 01000000000000000000000000000000010d4469656d54696d657374616d701743757272656e7454696d654d6963726f7365636f6e647300 }, Value(0300000000000000)), (AccessPath { address: 0000000000000000000000000a550c18, path: 0100000000000000000000000000000001094469656d426c6f636b0d426c6f636b4d6574616461746100 }, Value(010000000000000001000000000000001811000000000000000000000000000000000000000a550c18))] }), events: [ContractEvent { key: EventKey([17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]), index: 0, type: Struct(StructTag { address: 00000000000000000000000000000001, module: Identifier("DiemBlock"), name: Identifier("NewBlockEvent"), type_params: [] }), event_data: "000000000000000051c1b9fc2f32d6f2fff669823ef31cbe000300000000000000" }], gas_used: 100000000, status: Keep(EXECUTED) }))
+[5] Transaction(2)
+[6] Move VM Status: EXECUTED
+[7] Transaction Status: Keep(EXECUTED)
+[8] Transaction(3)
+[9] Output(TransactionOutput(TransactionOutput { write_set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: 0000000000000000000000000a550c18, path: 01000000000000000000000000000000010d4469656d54696d657374616d701743757272656e7454696d654d6963726f7365636f6e647300 }, Value(0400000000000000)), (AccessPath { address: 0000000000000000000000000a550c18, path: 0100000000000000000000000000000001094469656d426c6f636b0d426c6f636b4d6574616461746100 }, Value(020000000000000002000000000000001811000000000000000000000000000000000000000a550c18))] }), events: [ContractEvent { key: EventKey([17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]), index: 1, type: Struct(StructTag { address: 00000000000000000000000000000001, module: Identifier("DiemBlock"), name: Identifier("NewBlockEvent"), type_params: [] }), event_data: "000000000000000051c1b9fc2f32d6f2fff669823ef31cbe000400000000000000" }], gas_used: 100000000, status: Keep(EXECUTED) }))
+[10] Transaction(4)
+[11] Move VM Status: EXECUTED
+[12] Transaction Status: Keep(EXECUTED)
+[13] Transaction(5)
+[14] Move VM Status: ABORTED { code: 1031, location: 00000000000000000000000000000001::DiemAccount }
+[15] Transaction Status: Keep(ABORTED { code: 1031, location: 00000000000000000000000000000001::DiemAccount })
+[16] Transaction(6)
+[17] Move VM Status: ABORTED { code: 1031, location: 00000000000000000000000000000001::DiemAccount }
+[18] Transaction Status: Keep(ABORTED { code: 1031, location: 00000000000000000000000000000001::DiemAccount })
+[19] Transaction(7)
+[20] Move VM Status: EXECUTED
+[21] Transaction Status: Keep(EXECUTED)
+[22] Transaction(8)
+[23] Move VM Status: ABORTED { code: 1031, location: 00000000000000000000000000000001::DiemAccount }
+[24] Transaction Status: Keep(ABORTED { code: 1031, location: 00000000000000000000000000000001::DiemAccount })
+[25] Transaction(9)
+[26] Move VM Status: ABORTED { code: 1031, location: 00000000000000000000000000000001::DiemAccount }
+[27] Transaction Status: Keep(ABORTED { code: 1031, location: 00000000000000000000000000000001::DiemAccount })
+[28] Transaction(10)
+[29] Move VM Status: EXECUTED
+[30] Transaction Status: Keep(EXECUTED)
+[31] Transaction(11)
+[32] Move VM Status: EXECUTED
+[33] Transaction Status: Keep(EXECUTED)
+[34] Transaction(12)
+[35] Move VM Status: EXECUTED
+[36] Transaction Status: Keep(EXECUTED)
+[37] Transaction(13)
+[38] Move VM Status: EXECUTED
+[39] Transaction Status: Keep(EXECUTED)

--- a/language/move-lang/functional-tests/tests/diem/diem_account/add_currency.move
+++ b/language/move-lang/functional-tests/tests/diem/diem_account/add_currency.move
@@ -16,7 +16,6 @@ fun main(config: &signer) {
     DiemTransactionPublishingOption::set_open_module(config, false)
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! block-prologue
 //! proposer: validator
@@ -45,7 +44,6 @@ module COIN {
     }
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! block-prologue
 //! proposer: validator
@@ -62,7 +60,6 @@ fun main(dr_account: &signer, tc_account: &signer) {
     TransactionFee::add_txn_fee_currency<COIN>(tc_account);
 }
 }
-// check: "Keep(EXECUTED)"
 
 // END: registration of a currency
 
@@ -76,7 +73,6 @@ fun main(account: &signer) {
     DiemAccount::add_currency<XUS>(account);
 }
 }
-// check: "Keep(ABORTED { code: 1031,"
 
 // TreasuryCompliance should not be able to add a balance
 //! new-transaction
@@ -88,7 +84,6 @@ fun main(account: &signer) {
     DiemAccount::add_currency<XUS>(account);
 }
 }
-// check: "Keep(ABORTED { code: 1031,"
 
 
 // Validators and ValidatorOperators should not be able to add a balance
@@ -102,7 +97,6 @@ fun main(account: &signer) {
 
 }
 }
-// check: "Keep(EXECUTED)"
 
 // check Validator case
 //! new-transaction
@@ -114,7 +108,6 @@ fun main(account: &signer) {
     DiemAccount::add_currency<XUS>(account);
 }
 }
-// check: "Keep(ABORTED { code: 1031,"
 
 // check ValidatorOperator case
 //! new-transaction
@@ -126,31 +119,26 @@ fun main(account: &signer) {
     DiemAccount::add_currency<XUS>(account);
 }
 }
-// check: "Keep(ABORTED { code: 1031,"
 
 //! new-transaction
 //! sender: blessed
 //! type-args: 0x1::XUS::XUS
 //! args: 0, {{vasp}}, {{vasp::auth_key}}, b"bob", false
 stdlib_script::create_parent_vasp_account
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: vasp
 //! type-args: 0x1::COIN::COIN
 stdlib_script::add_currency_to_account
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: vasp
 //! type-args: 0x1::COIN::COIN
 //! args: {{child}}, {{child::auth_key}}, false, 0
 stdlib_script::create_child_vasp_account
-// check: "Keep(EXECUTED)"
 
 // can't add a balance of XDX right now
 //! new-transaction
 //! sender: child
 //! type-args: 0x1::XDX::XDX
 stdlib_script::add_currency_to_account
-// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/diem/diem_account/basics.exp
+++ b/language/move-lang/functional-tests/tests/diem/diem_account/basics.exp
@@ -1,0 +1,48 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)
+[3] Transaction(1)
+[4] Move VM Status: ABORTED { code: 1, location: 00000000000000000000000000000001::DiemTimestamp }
+[5] Transaction Status: Keep(ABORTED { code: 1, location: 00000000000000000000000000000001::DiemTimestamp })
+[6] Transaction(2)
+[7] Move VM Status: EXECUTED
+[8] Transaction Status: Keep(EXECUTED)
+[9] Transaction(3)
+[10] Move VM Status: ABORTED { code: 4357, location: 00000000000000000000000000000001::DiemAccount }
+[11] Transaction Status: Keep(ABORTED { code: 4357, location: 00000000000000000000000000000001::DiemAccount })
+[12] Transaction(4)
+[13] Move VM Status: ABORTED { code: 4869, location: 00000000000000000000000000000001::DiemAccount }
+[14] Transaction Status: Keep(ABORTED { code: 4869, location: 00000000000000000000000000000001::DiemAccount })
+[15] Transaction(5)
+[16] Move VM Status: ABORTED { code: 4615, location: 00000000000000000000000000000001::DiemAccount }
+[17] Transaction Status: Keep(ABORTED { code: 4615, location: 00000000000000000000000000000001::DiemAccount })
+[18] Transaction(6)
+[19] Move VM Status: ABORTED { code: 2055, location: 00000000000000000000000000000001::DiemAccount }
+[20] Transaction Status: Keep(ABORTED { code: 2055, location: 00000000000000000000000000000001::DiemAccount })
+[21] Transaction(7)
+[22] Move VM Status: ABORTED { code: 2305, location: 00000000000000000000000000000001::DiemAccount }
+[23] Transaction Status: Keep(ABORTED { code: 2305, location: 00000000000000000000000000000001::DiemAccount })
+[24] Transaction(8)
+[25] Move VM Status: EXECUTED
+[26] Transaction Status: Keep(EXECUTED)
+[27] Transaction(9)
+[28] Move VM Status: EXECUTED
+[29] Transaction Status: Keep(EXECUTED)
+[30] Transaction(10)
+[31] Move VM Status: ABORTED { code: 2567, location: 00000000000000000000000000000001::DiemAccount }
+[32] Transaction Status: Keep(ABORTED { code: 2567, location: 00000000000000000000000000000001::DiemAccount })
+[33] Transaction(11)
+[34] Move VM Status: ABORTED { code: 2055, location: 00000000000000000000000000000001::DiemAccount }
+[35] Transaction Status: Keep(ABORTED { code: 2055, location: 00000000000000000000000000000001::DiemAccount })
+[36] Transaction(12)
+[37] Move VM Status: ABORTED { code: 5, location: 00000000000000000000000000000001::DiemAccount }
+[38] Transaction Status: Keep(ABORTED { code: 5, location: 00000000000000000000000000000001::DiemAccount })
+[39] Transaction(13)
+[40] Move VM Status: ABORTED { code: 5, location: 00000000000000000000000000000001::DiemAccount }
+[41] Transaction Status: Keep(ABORTED { code: 5, location: 00000000000000000000000000000001::DiemAccount })
+[42] Transaction(14)
+[43] Move VM Status: ABORTED { code: 5, location: 00000000000000000000000000000001::DiemAccount }
+[44] Transaction Status: Keep(ABORTED { code: 5, location: 00000000000000000000000000000001::DiemAccount })
+[45] Transaction(15)
+[46] Move VM Status: ABORTED { code: 5, location: 00000000000000000000000000000001::DiemAccount }
+[47] Transaction Status: Keep(ABORTED { code: 5, location: 00000000000000000000000000000001::DiemAccount })

--- a/language/move-lang/functional-tests/tests/diem/diem_account/basics.move
+++ b/language/move-lang/functional-tests/tests/diem/diem_account/basics.move
@@ -28,7 +28,6 @@ script {
         DiemAccount::initialize(sender, x"00000000000000000000000000000000");
     }
 }
-// check: "Keep(ABORTED { code: 1,"
 
 //! new-transaction
 //! sender: bob
@@ -41,7 +40,6 @@ script {
         DiemAccount::restore_withdraw_capability(with_cap);
     }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -54,7 +52,6 @@ script {
         DiemAccount::restore_withdraw_capability(with_cap);
     }
 }
-// check: "Keep(ABORTED { code: 4357,"
 
 //! new-transaction
 //! sender: bob
@@ -67,7 +64,6 @@ script {
         DiemAccount::restore_withdraw_capability(with_cap);
     }
 }
-// check: "Keep(ABORTED { code: 4869,"
 
 //! new-transaction
 //! sender: bob
@@ -80,7 +76,6 @@ script {
         DiemAccount::restore_withdraw_capability(with_cap);
     }
 }
-// check: "Keep(ABORTED { code: 4615,"
 
 //! new-transaction
 //! sender: bob
@@ -92,7 +87,6 @@ script {
         DiemAccount::restore_key_rotation_capability(rot_cap);
     }
 }
-// check: "Keep(ABORTED { code: 2055,"
 
 //! new-transaction
 script {
@@ -109,7 +103,6 @@ script {
         );
     }
 }
-// check: "Keep(ABORTED { code: 2305,"
 
 //! new-transaction
 script {
@@ -130,7 +123,6 @@ script {
         DiemAccount::restore_withdraw_capability(with_cap);
     }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -144,21 +136,18 @@ script {
         assert(DiemAccount::balance<XDX>({{alice}}) == 10000, 60)
     }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: blessed
 //! type-args: 0x1::XUS::XUS
 //! args: 0, 0x0, {{bob::auth_key}}, b"bob", true
 stdlib_script::create_parent_vasp_account
-// check: "Keep(ABORTED { code: 2567,"
 
 //! new-transaction
 //! sender: blessed
 //! type-args: 0x1::XUS::XUS
 //! args: 0, {{abby}}, x"", b"bob", true
 stdlib_script::create_parent_vasp_account
-// check: "Keep(ABORTED { code: 2055,"
 
 //! new-transaction
 script {
@@ -167,7 +156,6 @@ fun main() {
     DiemAccount::sequence_number(0x1);
 }
 }
-// check: "Keep(ABORTED { code: 5,"
 
 //! new-transaction
 script {
@@ -176,7 +164,6 @@ fun main() {
     DiemAccount::authentication_key(0x1);
 }
 }
-// check: "Keep(ABORTED { code: 5,"
 
 //! new-transaction
 script {
@@ -185,7 +172,6 @@ fun main() {
     DiemAccount::delegated_key_rotation_capability(0x1);
 }
 }
-// check: "Keep(ABORTED { code: 5,"
 
 //! new-transaction
 script {
@@ -194,4 +180,3 @@ fun main() {
     DiemAccount::delegated_withdraw_capability(0x1);
 }
 }
-// check: "Keep(ABORTED { code: 5,"

--- a/language/move-lang/functional-tests/tests/diem/diem_account/create_account.exp
+++ b/language/move-lang/functional-tests/tests/diem/diem_account/create_account.exp
@@ -1,0 +1,6 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)
+[3] Transaction(1)
+[4] Move VM Status: EXECUTED
+[5] Transaction Status: Keep(EXECUTED)

--- a/language/move-lang/functional-tests/tests/diem/diem_account/create_reserved.exp
+++ b/language/move-lang/functional-tests/tests/diem/diem_account/create_reserved.exp
@@ -1,0 +1,12 @@
+[0] Transaction(0)
+[1] Move VM Status: ABORTED { code: 2567, location: 00000000000000000000000000000001::DiemAccount }
+[2] Transaction Status: Keep(ABORTED { code: 2567, location: 00000000000000000000000000000001::DiemAccount })
+[3] Transaction(1)
+[4] Move VM Status: ABORTED { code: 258, location: 00000000000000000000000000000001::CoreAddresses }
+[5] Transaction Status: Keep(ABORTED { code: 258, location: 00000000000000000000000000000001::CoreAddresses })
+[6] Transaction(2)
+[7] Move VM Status: ABORTED { code: 6151, location: 00000000000000000000000000000001::DiemAccount }
+[8] Transaction Status: Keep(ABORTED { code: 6151, location: 00000000000000000000000000000001::DiemAccount })
+[9] Transaction(3)
+[10] Move VM Status: ABORTED { code: 258, location: 00000000000000000000000000000001::CoreAddresses }
+[11] Transaction Status: Keep(ABORTED { code: 258, location: 00000000000000000000000000000001::CoreAddresses })

--- a/language/move-lang/functional-tests/tests/diem/diem_account/create_reserved.move
+++ b/language/move-lang/functional-tests/tests/diem/diem_account/create_reserved.move
@@ -11,7 +11,6 @@ fun main(account: &signer) {
         account, 0x0, x"00000000000000000000000000000000", x"", false);
 }
 }
-// check: "Keep(ABORTED { code: 2567,"
 
 //! new-transaction
 //! sender: diemroot
@@ -23,7 +22,6 @@ fun main(account: &signer) {
         account, 0x0, x"00000000000000000000000000000000", x"", false);
 }
 }
-// check: "Keep(ABORTED { code: 258,"
 
 //! new-transaction
 //! sender: blessed
@@ -35,7 +33,6 @@ fun main(account: &signer) {
         account, 0x1, x"00000000000000000000000000000000", x"", false);
 }
 }
-// check: "Keep(ABORTED { code: 6151,"
 
 //! new-transaction
 //! sender: diemroot
@@ -47,4 +44,3 @@ fun main(account: &signer) {
         account, 0x1, x"00000000000000000000000000000000", x"", false);
 }
 }
-// check: "Keep(ABORTED { code: 258,"

--- a/language/move-lang/functional-tests/tests/diem/diem_account/delegate_rotation_capability.exp
+++ b/language/move-lang/functional-tests/tests/diem/diem_account/delegate_rotation_capability.exp
@@ -1,0 +1,21 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)
+[3] Transaction(1)
+[4] Move VM Status: EXECUTED
+[5] Transaction Status: Keep(EXECUTED)
+[6] Transaction(2)
+[7] Move VM Status: EXECUTED
+[8] Transaction Status: Keep(EXECUTED)
+[9] Transaction(3)
+[10] Move VM Status: EXECUTED
+[11] Transaction Status: Keep(EXECUTED)
+[12] Transaction(4)
+[13] Move VM Status: ERROR { status_code: INVALID_AUTH_KEY }
+[14] Transaction Status: Discard(INVALID_AUTH_KEY)
+[15] Transaction(5)
+[16] Move VM Status: EXECUTED
+[17] Transaction Status: Keep(EXECUTED)
+[18] Transaction(6)
+[19] Move VM Status: EXECUTED
+[20] Transaction Status: Keep(EXECUTED)

--- a/language/move-lang/functional-tests/tests/diem/diem_account/delegate_rotation_capability.move
+++ b/language/move-lang/functional-tests/tests/diem/diem_account/delegate_rotation_capability.move
@@ -84,7 +84,6 @@ script {
 fun main() {
 }
 }
-// check: Discard(INVALID_AUTH_KEY)
 
 //! new-transaction
 //! sender: bob

--- a/language/move-lang/functional-tests/tests/diem/diem_account/delegate_withdrawal_capability.exp
+++ b/language/move-lang/functional-tests/tests/diem/diem_account/delegate_withdrawal_capability.exp
@@ -1,0 +1,15 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)
+[3] Transaction(1)
+[4] Move VM Status: EXECUTED
+[5] Transaction Status: Keep(EXECUTED)
+[6] Transaction(2)
+[7] Move VM Status: ABORTED { code: 1793, location: 00000000000000000000000000000001::DiemAccount }
+[8] Transaction Status: Keep(ABORTED { code: 1793, location: 00000000000000000000000000000001::DiemAccount })
+[9] Transaction(3)
+[10] Move VM Status: EXECUTED
+[11] Transaction Status: Keep(EXECUTED)
+[12] Transaction(4)
+[13] Move VM Status: EXECUTED
+[14] Transaction Status: Keep(EXECUTED)

--- a/language/move-lang/functional-tests/tests/diem/diem_account/delegate_withdrawal_capability.move
+++ b/language/move-lang/functional-tests/tests/diem/diem_account/delegate_withdrawal_capability.move
@@ -39,7 +39,6 @@ fun main(sender: &signer) {
     SillyColdWallet::publish(sender, cap, {{bob}});
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -55,7 +54,6 @@ fun main(account: &signer) {
     DiemAccount::restore_withdraw_capability(with_cap);
 }
 }
-// check: "Keep(ABORTED { code: 1793,"
 
 //! new-transaction
 //! sender: bob

--- a/language/move-lang/functional-tests/tests/diem/diem_account/different_currency.exp
+++ b/language/move-lang/functional-tests/tests/diem/diem_account/different_currency.exp
@@ -1,0 +1,3 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)

--- a/language/move-lang/functional-tests/tests/diem/diem_account/different_currency.move
+++ b/language/move-lang/functional-tests/tests/diem/diem_account/different_currency.move
@@ -8,4 +8,3 @@ script {
 fun main() {
 }
 }
-// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/diem/diem_account/failure_epilogue_limit_exceeded.exp
+++ b/language/move-lang/functional-tests/tests/diem/diem_account/failure_epilogue_limit_exceeded.exp
@@ -1,0 +1,15 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)
+[3] Transaction(1)
+[4] Move VM Status: EXECUTED
+[5] Transaction Status: Keep(EXECUTED)
+[6] Transaction(2)
+[7] Move VM Status: EXECUTED
+[8] Transaction Status: Keep(EXECUTED)
+[9] Transaction(3)
+[10] Move VM Status: EXECUTED
+[11] Transaction Status: Keep(EXECUTED)
+[12] Transaction(4)
+[13] Move VM Status: ABORTED { code: 0, location: Script }
+[14] Transaction Status: Keep(ABORTED { code: 0, location: Script })

--- a/language/move-lang/functional-tests/tests/diem/diem_account/failure_epilogue_limit_exceeded.move
+++ b/language/move-lang/functional-tests/tests/diem/diem_account/failure_epilogue_limit_exceeded.move
@@ -5,7 +5,6 @@
 //! type-args: 0x1::XUS::XUS
 //! args: 0, {{alice}}, {{alice::auth_key}}, b"alice", false
 stdlib_script::create_parent_vasp_account
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: diemroot
@@ -23,14 +22,12 @@ fun main(dr_account: &signer, vasp: &signer) {
     );
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: testnetdd
 //! type-args: 0x1::XUS::XUS
 //! args: {{alice}}, 1000000, b"", b""
 stdlib_script::peer_to_peer_with_metadata
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: blessed
@@ -61,4 +58,3 @@ script {
         abort 0
     }
 }
-// check: "Keep(ABORTED { code: 0, location: Script })"

--- a/language/move-lang/functional-tests/tests/diem/diem_account/pay_with_capability.exp
+++ b/language/move-lang/functional-tests/tests/diem/diem_account/pay_with_capability.exp
@@ -1,0 +1,9 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)
+[3] Transaction(1)
+[4] Move VM Status: EXECUTED
+[5] Transaction Status: Keep(EXECUTED)
+[6] Transaction(2)
+[7] Move VM Status: EXECUTED
+[8] Transaction Status: Keep(EXECUTED)

--- a/language/move-lang/functional-tests/tests/diem/diem_account/pay_with_capability.move
+++ b/language/move-lang/functional-tests/tests/diem/diem_account/pay_with_capability.move
@@ -29,7 +29,6 @@ module AlicePays {
     }
 }
 
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -40,7 +39,6 @@ fun main(sender: &signer) {
 }
 }
 
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -57,4 +55,3 @@ fun main() {
     assert(alice_prev_balance - 10 == DiemAccount::balance<XUS>({{alice}}), 1);
 }
 }
-// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/diem/diem_account/prologue_invalid_gas_currency.exp
+++ b/language/move-lang/functional-tests/tests/diem/diem_account/prologue_invalid_gas_currency.exp
@@ -1,0 +1,12 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)
+[3] Transaction(1)
+[4] Move VM Status: EXECUTED
+[5] Transaction Status: Keep(EXECUTED)
+[6] Transaction(2)
+[7] Move VM Status: EXECUTED
+[8] Transaction Status: Keep(EXECUTED)
+[9] Transaction(3)
+[10] Move VM Status: ERROR { status_code: BAD_TRANSACTION_FEE_CURRENCY }
+[11] Transaction Status: Discard(BAD_TRANSACTION_FEE_CURRENCY)

--- a/language/move-lang/functional-tests/tests/diem/diem_account/prologue_invalid_gas_currency.move
+++ b/language/move-lang/functional-tests/tests/diem/diem_account/prologue_invalid_gas_currency.move
@@ -5,7 +5,6 @@
 //! type-args: 0x1::XUS::XUS
 //! args: 0, {{alice}}, {{alice::auth_key}}, b"alice", false
 stdlib_script::create_parent_vasp_account
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: diemroot
@@ -23,7 +22,6 @@ fun main(dr_account: &signer, vasp: &signer) {
     );
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: testnetdd
@@ -43,4 +41,3 @@ script {
     }
 }
 // XXX/FIXME
-// check: "Discard(BAD_TRANSACTION_FEE_CURRENCY)"

--- a/language/move-lang/functional-tests/tests/diem/diem_account/remove_then_replace_rotation_capability.exp
+++ b/language/move-lang/functional-tests/tests/diem/diem_account/remove_then_replace_rotation_capability.exp
@@ -1,0 +1,6 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)
+[3] Transaction(1)
+[4] Move VM Status: ABORTED { code: 2305, location: 00000000000000000000000000000001::DiemAccount }
+[5] Transaction Status: Keep(ABORTED { code: 2305, location: 00000000000000000000000000000001::DiemAccount })

--- a/language/move-lang/functional-tests/tests/diem/diem_account/remove_then_replace_rotation_capability.move
+++ b/language/move-lang/functional-tests/tests/diem/diem_account/remove_then_replace_rotation_capability.move
@@ -20,7 +20,6 @@ fun main(account: &signer) {
     assert(!DiemAccount::delegated_key_rotation_capability(sender), 52);
 }
 }
-// check: "Keep(EXECUTED)"
 
 // Extracting the capability should preclude rotation
 //! new-transaction
@@ -36,5 +35,3 @@ fun main(account: &signer) {
     DiemAccount::restore_key_rotation_capability(cap2);
 }
 }
-// check: "Keep(ABORTED { code: 2305,"
-// check: location: ::DiemAccount

--- a/language/move-lang/functional-tests/tests/diem/diem_account/remove_then_replace_withdrawal_capability.exp
+++ b/language/move-lang/functional-tests/tests/diem/diem_account/remove_then_replace_withdrawal_capability.exp
@@ -1,0 +1,3 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)

--- a/language/move-lang/functional-tests/tests/diem/diem_account/success_epilogue_limit_exceeded.exp
+++ b/language/move-lang/functional-tests/tests/diem/diem_account/success_epilogue_limit_exceeded.exp
@@ -1,0 +1,15 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)
+[3] Transaction(1)
+[4] Move VM Status: EXECUTED
+[5] Transaction Status: Keep(EXECUTED)
+[6] Transaction(2)
+[7] Move VM Status: EXECUTED
+[8] Transaction Status: Keep(EXECUTED)
+[9] Transaction(3)
+[10] Move VM Status: EXECUTED
+[11] Transaction Status: Keep(EXECUTED)
+[12] Transaction(4)
+[13] Move VM Status: EXECUTED
+[14] Transaction Status: Keep(EXECUTED)

--- a/language/move-lang/functional-tests/tests/diem/diem_account/success_epilogue_limit_exceeded.move
+++ b/language/move-lang/functional-tests/tests/diem/diem_account/success_epilogue_limit_exceeded.move
@@ -5,7 +5,6 @@
 //! type-args: 0x1::XUS::XUS
 //! args: 0, {{alice}}, {{alice::auth_key}}, b"alice", false
 stdlib_script::create_parent_vasp_account
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: diemroot
@@ -23,14 +22,12 @@ fun main(dr_account: &signer, vasp: &signer) {
     );
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: testnetdd
 //! type-args: 0x1::XUS::XUS
 //! args: {{alice}}, 1000000, b"", b""
 stdlib_script::peer_to_peer_with_metadata
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: blessed
@@ -49,7 +46,6 @@ fun main(account: &signer) {
     );
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -60,4 +56,3 @@ script {
     fun main() {
     }
 }
-// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/diem/diem_timestamp/basic.exp
+++ b/language/move-lang/functional-tests/tests/diem/diem_timestamp/basic.exp
@@ -1,0 +1,10 @@
+[0] Transaction(0)
+[1] VerificationError(ERROR { status_code: UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION })
+[2] Transaction(1)
+[3] Output(TransactionOutput(TransactionOutput { write_set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: 0000000000000000000000000a550c18, path: 01000000000000000000000000000000010d4469656d54696d657374616d701743757272656e7454696d654d6963726f7365636f6e647300 }, Value(0000000000000000)), (AccessPath { address: 0000000000000000000000000a550c18, path: 0100000000000000000000000000000001094469656d426c6f636b0d426c6f636b4d6574616461746100 }, Value(010000000000000001000000000000001811000000000000000000000000000000000000000a550c18))] }), events: [ContractEvent { key: EventKey([17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]), index: 0, type: Struct(StructTag { address: 00000000000000000000000000000001, module: Identifier("DiemBlock"), name: Identifier("NewBlockEvent"), type_params: [] }), event_data: "000000000000000000000000000000000000000000000000000000000000000000" }], gas_used: 100000000, status: Keep(EXECUTED) }))
+[4] Transaction(2)
+[5] Move VM Status: ABORTED { code: 1, location: 00000000000000000000000000000001::DiemTimestamp }
+[6] Transaction Status: Keep(ABORTED { code: 1, location: 00000000000000000000000000000001::DiemTimestamp })
+[7] Transaction(3)
+[8] Move VM Status: ABORTED { code: 1, location: 00000000000000000000000000000001::DiemTimestamp }
+[9] Transaction Status: Keep(ABORTED { code: 1, location: 00000000000000000000000000000001::DiemTimestamp })

--- a/language/move-lang/functional-tests/tests/diem/diem_timestamp/basic.move
+++ b/language/move-lang/functional-tests/tests/diem/diem_timestamp/basic.move
@@ -4,7 +4,6 @@
 //! proposer-address: 0x0
 //! block-time: 1
 
-// check: UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION
 
 //! block-prologue
 //! proposer-address: 0x0
@@ -17,7 +16,6 @@ script {
         DiemTimestamp::set_time_has_started(account);
     }
 }
-// check: "Keep(ABORTED { code: 1,"
 
 //! new-transaction
 //! sender: diemroot
@@ -27,4 +25,3 @@ script {
         DiemTimestamp::set_time_has_started(account);
     }
 }
-// check: "Keep(ABORTED { code: 1,"

--- a/language/move-lang/functional-tests/tests/diem/diem_version/tests.exp
+++ b/language/move-lang/functional-tests/tests/diem/diem_version/tests.exp
@@ -1,0 +1,9 @@
+[0] Transaction(0)
+[1] Move VM Status: ABORTED { code: 1, location: 00000000000000000000000000000001::DiemTimestamp }
+[2] Transaction Status: Keep(ABORTED { code: 1, location: 00000000000000000000000000000001::DiemTimestamp })
+[3] Transaction(1)
+[4] Move VM Status: ABORTED { code: 2, location: 00000000000000000000000000000001::CoreAddresses }
+[5] Transaction Status: Keep(ABORTED { code: 2, location: 00000000000000000000000000000001::CoreAddresses })
+[6] Transaction(2)
+[7] Move VM Status: ABORTED { code: 7, location: 00000000000000000000000000000001::DiemVersion }
+[8] Transaction Status: Keep(ABORTED { code: 7, location: 00000000000000000000000000000001::DiemVersion })

--- a/language/move-lang/functional-tests/tests/diem/diem_version/tests.move
+++ b/language/move-lang/functional-tests/tests/diem/diem_version/tests.move
@@ -5,7 +5,6 @@ fun main(account: &signer) {
     DiemVersion::initialize(account);
 }
 }
-// check: "Keep(ABORTED { code: 1,"
 
 //! new-transaction
 script{
@@ -14,7 +13,6 @@ fun main(account: &signer) {
     DiemVersion::set(account, 0);
 }
 }
-// check: "Keep(ABORTED { code: 2,"
 
 //! new-transaction
 //! sender: diemroot
@@ -24,4 +22,3 @@ fun main(account: &signer) {
     DiemVersion::set(account, 0);
 }
 }
-// check: "Keep(ABORTED { code: 7,"


### PR DESCRIPTION
There are few tests I can't migrate right now due to events not being included in the log:
- designated_dealer
  - basics.move
  - burns.move
  - tiered_mint.move
- diem
  - add_currency_to_system.move
  - mint.move
  - preburn_burn.move
  - xus.move
- diem_account
  - freezing.move
  - payment_metadata.move
 
Will put up additional PRs to 
- Add an option to include events in the log
- Migrate these tests

There's also a test with an unresolved FIXME:
- `diem_account/prologue_invalid_gas_currency`