### PR TITLE
[gha] re-enable sccache

### DIFF
--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -64,6 +64,3 @@ runs:
         echo 'CARGO='$(rustup which cargo --toolchain "$(cat cargo-toolchain)") | tee -a $GITHUB_ENV
         # Pin the version of RUSTC used for all invocations of cargo
         echo 'RUSTUP_TOOLCHAIN='$(cat rust-toolchain) | tee -a $GITHUB_ENV
-
-        # Disable sccache from being used till https://github.com/mozilla/sccache/issues/804 is fixed
-        echo 'SKIP_SCCACHE=1' | tee -a $GITHUB_ENV


### PR DESCRIPTION
## Motivation

Let's re-enable sccache.
There are still a couple issues I'm tracking down (sccache fix to notice changes in CARGO's location) and a pr for trybuild to read the env location every time, but nothing is stopping us from using and benefiting from sccache today - to save a few minutes off of each build.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

CI.

## Related PRs

None
