### PR TITLE
[time-service] Add `Instant` support to time service

### DIFF
--- a/common/time-service/src/real.rs
+++ b/common/time-service/src/real.rs
@@ -6,7 +6,10 @@ use crate::TimeServiceTrait;
 use crate::{Sleep, SleepTrait};
 #[cfg(any(test, feature = "async"))]
 use std::pin::Pin;
-use std::{thread, time::Duration};
+use std::{
+    thread,
+    time::{Duration, Instant},
+};
 
 /// The real production tokio [`TimeService`](crate::TimeService).
 ///
@@ -25,7 +28,11 @@ impl RealTimeService {
 }
 
 impl TimeServiceTrait for RealTimeService {
-    fn now(&self) -> Duration {
+    fn now(&self) -> Instant {
+        Instant::now()
+    }
+
+    fn now_unix_time(&self) -> Duration {
         diem_infallible::duration_since_epoch()
     }
 
@@ -48,5 +55,9 @@ impl SleepTrait for RealSleep {
     fn reset(self: Pin<&mut Self>, duration: Duration) {
         let deadline = self.deadline() + duration;
         RealSleep::reset(self, deadline);
+    }
+
+    fn reset_until(self: Pin<&mut Self>, deadline: Instant) {
+        RealSleep::reset(self, tokio::time::Instant::from_std(deadline));
     }
 }

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -77,7 +77,7 @@ impl<T: DiemInterface> Node<T> {
         // 1) Update the clock for potential reconfigurations
         self.time.advance_secs(1);
 
-        let timestamp = self.time.now().as_micros() as u64;
+        let timestamp = self.time.now_unix_time().as_micros() as u64;
         let owner_account = self.get_account_from_storage(OWNER_ACCOUNT);
         let block_id = HashValue::zero();
         let block_metadata = BlockMetadata::new(block_id, 0, timestamp, vec![], owner_account);


### PR DESCRIPTION
+ Now provides monotonic but opaque clock source (`Instant`) through
`TimeService::now`. Absolute but non-monotonic clock source is now
provided through `TimeService::now_unix_time`.

+ Add `deadline: Instant` APIs to `Sleep`, `Interval`, `Timeout`, etc...
Instead of specifying a relative duration to sleep, you can now specify
an absolute deadline. This should help support rate-limiter crate.

+ Make sure `Sleep` enum always dispatches to `SleepTrait`.
