### PR TITLE
[State Sync] Complete unit test skeleton for coordinator, better error support and clean up code.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -21,7 +21,8 @@ pub struct StateSyncConfig {
     // if no progress is made by sending chunk requests to a number of networks,
     // the next sync request will be multicasted, i.e. sent to more networks
     pub multicast_timeout_ms: u64,
-    // default timeout for sync request
+    // The timeout for ensuring sync requests are making progress (i.e., the maximum time between
+    // commits when processing a sync request).
     pub sync_request_timeout_ms: u64,
     // interval used for checking state synchronization progress
     pub tick_interval_ms: u64,

--- a/state-sync/src/client.rs
+++ b/state-sync/src/client.rs
@@ -18,8 +18,8 @@ use tokio::time::timeout;
 /// A sync request for a specified target ledger info.
 pub struct SyncRequest {
     pub callback: oneshot::Sender<Result<()>>,
+    pub last_commit_timestamp: SystemTime,
     pub target: LedgerInfoWithSignatures,
-    pub last_progress_tst: SystemTime,
 }
 
 /// A commit notification to notify state sync of new commits.
@@ -58,7 +58,7 @@ impl StateSyncClient {
         let request = SyncRequest {
             callback: cb_sender,
             target,
-            last_progress_tst: SystemTime::now(),
+            last_commit_timestamp: SystemTime::now(),
         };
 
         async move {

--- a/state-sync/src/error.rs
+++ b/state-sync/src/error.rs
@@ -24,6 +24,18 @@ pub enum Error {
     OldSyncRequestVersion(Version, Version),
     #[error("Unable to add peer as they are not an upstream peer: {0}. Connection origin: {1}")]
     PeerIsNotUpstream(String, String),
+    #[error("Processed an invalid chunk! Failed to apply the chunk: {0}")]
+    ProcessInvalidChunk(String),
+    #[error(
+        "Received a chunk for an outdated request from peer {0}. Known version: {1}, received: {2}"
+    )]
+    ReceivedChunkForOutdatedRequest(String, String, String),
+    #[error("Received a chunk response from a downstream peer: {0}")]
+    ReceivedChunkFromDownstream(String),
+    #[error("Received an empty chunk response from a peer: {0}")]
+    ReceivedEmptyChunk(String),
+    #[error("Receivd a non-sequential chunk from {0}. Known version: {1}, received: {2}")]
+    ReceivedNonSequentialChunk(String, String, String),
     #[error("Synced beyond the target version. Synced version: {0}, target version: {1}")]
     SyncedBeyondTarget(Version, Version),
     #[error("State sync is uninitialized! Error: {0}")]

--- a/state-sync/src/error.rs
+++ b/state-sync/src/error.rs
@@ -10,6 +10,14 @@ use thiserror::Error;
 pub enum Error {
     #[error("Failed to send callback: {0}")]
     CallbackSendFailed(String),
+    #[error("Consensus is executing. There is no need for state sync to drive synchronization.")]
+    ConsensusIsExecuting,
+    #[error("A sync request was sent to a full node, but this isn't supported.")]
+    FullNodeSyncRequest,
+    #[error("An integer overflow has occurred: {0}")]
+    IntegerOverflow(String),
+    #[error("No peers are currently available!")]
+    NoAvailablePeers,
     #[error("No transactions were committed, but received a commit notification!")]
     NoTransactionsCommitted,
     #[error("Received an old sync request for version {0}, but our known version is: {1}")]

--- a/state-sync/src/error.rs
+++ b/state-sync/src/error.rs
@@ -22,6 +22,8 @@ pub enum Error {
     NoTransactionsCommitted,
     #[error("Received an old sync request for version {0}, but our known version is: {1}")]
     OldSyncRequestVersion(Version, Version),
+    #[error("Unable to add peer as they are not an upstream peer: {0}. Connection origin: {1}")]
+    PeerIsNotUpstream(String, String),
     #[error("Synced beyond the target version. Synced version: {0}, target version: {1}")]
     SyncedBeyondTarget(Version, Version),
     #[error("State sync is uninitialized! Error: {0}")]

--- a/state-sync/src/fuzzing.rs
+++ b/state-sync/src/fuzzing.rs
@@ -9,10 +9,7 @@ use crate::{
     network::StateSyncMessage,
     shared_components::test_utils,
 };
-use diem_config::{
-    config::PeerNetworkId,
-    network_id::{NetworkId, NodeNetworkId},
-};
+use diem_config::network_id::{NetworkId, NodeNetworkId};
 use diem_infallible::Mutex;
 use diem_types::{
     ledger_info::LedgerInfoWithSignatures, transaction::TransactionListWithProof, PeerId,
@@ -38,16 +35,14 @@ proptest! {
     }
 }
 
-pub fn test_state_sync_msg_fuzzer_impl(msg: StateSyncMessage) {
+pub fn test_state_sync_msg_fuzzer_impl(message: StateSyncMessage) {
     block_on(async move {
-        STATE_SYNC_COORDINATOR
+        let _ = STATE_SYNC_COORDINATOR
             .lock()
-            .process_one_message(
-                PeerNetworkId(
-                    NodeNetworkId::new(NetworkId::Validator, 0),
-                    PeerId::new([0u8; PeerId::LENGTH]),
-                ),
-                msg,
+            .process_chunk_message(
+                NodeNetworkId::new(NetworkId::Validator, 0),
+                PeerId::new([0u8; PeerId::LENGTH]),
+                message,
             )
             .await;
     });

--- a/state-sync/src/fuzzing.rs
+++ b/state-sync/src/fuzzing.rs
@@ -27,7 +27,7 @@ use proptest::{
 };
 
 static STATE_SYNC_COORDINATOR: Lazy<Mutex<StateSyncCoordinator<ExecutorProxy>>> =
-    Lazy::new(|| Mutex::new(test_utils::create_state_sync_coordinator_for_tests()));
+    Lazy::new(|| Mutex::new(test_utils::create_validator_coordinator()));
 
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(10))]

--- a/state-sync/src/logging.rs
+++ b/state-sync/src/logging.rs
@@ -17,7 +17,7 @@ pub struct LogSchema<'a> {
     name: LogEntry,
     event: Option<LogEvent>,
     #[schema(debug)]
-    error: Option<&'a anyhow::Error>,
+    error: Option<&'a anyhow::Error>, // TODO(joshlind): remove anyhow once we migrate!
     #[schema(display)]
     peer: Option<&'a PeerNetworkId>,
     is_upstream_peer: Option<bool>,
@@ -99,6 +99,7 @@ pub enum LogEntry {
     SendChunkRequest,
     ProcessChunkRequest,
     ProcessChunkResponse,
+    ProcessChunkMessage,
     NetworkError,
     EpochChange,
     CommitFlow,
@@ -110,12 +111,14 @@ pub enum LogEntry {
 #[derive(Clone, Copy, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LogEvent {
-    Initialize,
+    // Generic events
     CallbackFail,
     Complete,
+    Fail,
+    Initialize,
     Timeout,
     PublishError,
-    Fail,
+    Received,
 
     // SendChunkRequest events
     MissingPeers,
@@ -125,8 +128,7 @@ pub enum LogEvent {
     ChunkRequestInfo,
 
     // ProcessChunkResponse events
-    ConsensusIsRunning,
-    Received,
+    ReceivedChunkWithoutRequest,
     SendChunkRequestFail,
     ApplyChunkSuccess,
     ApplyChunkFail,

--- a/state-sync/src/logging.rs
+++ b/state-sync/src/logging.rs
@@ -104,6 +104,7 @@ pub enum LogEntry {
     CommitFlow,
     Multicast,
     SubscriptionDeliveryFail,
+    ProgressCheck,
 }
 
 #[derive(Clone, Copy, Serialize)]

--- a/state-sync/src/request_manager.rs
+++ b/state-sync/src/request_manager.rs
@@ -432,8 +432,8 @@ impl RequestManager {
     }
 
     /// Checks whether the request sent with known_version = `version` has timed out
-    /// Returns true if such a request timed out or does not exist, else false
-    pub fn check_timeout(&mut self, version: u64) -> Result<bool> {
+    /// Returns true if such a request timed out (or does not exist), else false.
+    pub fn check_request_timeout(&mut self, version: u64) -> Result<bool> {
         let last_request_time = self.get_last_request_time(version).unwrap_or(UNIX_EPOCH);
 
         let timeout = is_timeout(last_request_time, self.request_timeout);
@@ -590,7 +590,7 @@ mod tests {
         // Process multiple request timeouts from validator 0
         for _ in 0..NUM_CHUNKS_TO_PROCESS {
             request_manager.add_request(1, validator_0.clone());
-            assert!(request_manager.check_timeout(1).unwrap());
+            assert!(request_manager.check_request_timeout(1).unwrap());
         }
 
         // Verify validator 0 is chosen less often than the other validators

--- a/state-sync/src/shared_components.rs
+++ b/state-sync/src/shared_components.rs
@@ -172,7 +172,7 @@ pub(crate) mod test_utils {
 
     use channel::{diem_channel, message_queues::QueueStyle};
     use diem_config::{
-        config::NodeConfig,
+        config::{NodeConfig, RoleType},
         network_id::{NetworkId, NodeNetworkId},
     };
     use diem_types::transaction::{Transaction, WriteSetPayload};
@@ -188,7 +188,33 @@ pub(crate) mod test_utils {
     use std::collections::HashMap;
     use storage_interface::DbReaderWriter;
 
-    pub(crate) fn create_state_sync_coordinator_for_tests() -> StateSyncCoordinator<ExecutorProxy> {
+    #[cfg(test)]
+    pub(crate) fn create_coordinator_with_config_and_waypoint(
+        node_config: NodeConfig,
+        waypoint: Waypoint,
+    ) -> StateSyncCoordinator<ExecutorProxy> {
+        create_state_sync_coordinator_for_tests(node_config, waypoint)
+    }
+
+    pub(crate) fn create_validator_coordinator() -> StateSyncCoordinator<ExecutorProxy> {
+        let mut node_config = NodeConfig::default();
+        node_config.base.role = RoleType::Validator;
+
+        create_state_sync_coordinator_for_tests(node_config, Waypoint::default())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn create_full_node_coordinator() -> StateSyncCoordinator<ExecutorProxy> {
+        let mut node_config = NodeConfig::default();
+        node_config.base.role = RoleType::FullNode;
+
+        create_state_sync_coordinator_for_tests(node_config, Waypoint::default())
+    }
+
+    fn create_state_sync_coordinator_for_tests(
+        node_config: NodeConfig,
+        waypoint: Waypoint,
+    ) -> StateSyncCoordinator<ExecutorProxy> {
         // Generate a genesis change set
         let (genesis, _) = vm_genesis::test_genesis_change_set_and_validators(Some(1));
 
@@ -229,8 +255,8 @@ pub(crate) mod test_utils {
             coordinator_receiver,
             mempool_sender,
             network_senders,
-            &NodeConfig::default(),
-            Waypoint::default(),
+            &node_config,
+            waypoint,
             executor_proxy,
             initial_state,
         )


### PR DESCRIPTION
## Motivation

This PR completes the skeleton set of unit tests for StateSyncCoordinator as well as improves error handling (continuing on from https://github.com/diem/diem/pull/7394).

This PR offers the following commits:
1. Clean up the check_progress method and add better error handling, as well as a unit test structure.
2. Clean up new and lost peer message logic and add better error handling, as well as a unit test structure.
3. Clean up process_chunk_message and add better error handling, as well as a unit test structure.

With this PR in place, we now have a basic "test skeleton" that will allow us to change StateSyncCoordinator logic in future PRs and add appropriate tests to verify correctness!

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally, including the newly added ones.

## Related PRs

This PR continues on from https://github.com/diem/diem/pull/7394.

This relates to: https://github.com/diem/diem/issues/6795