### PR TITLE
[x] bump grcov version

### DIFF
--- a/x.toml
+++ b/x.toml
@@ -1,5 +1,5 @@
 [grcov.installer]
-version = "0.5.15"
+version = "0.6.1"
 
 [system-tests]
 smoke-test = { path = "smoke-test" }


### PR DESCRIPTION
## Motivation

Since Young's tested grcov 0.6.1, lets bump to that version in X.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

This build
https://github.com/diem/diem/actions/runs/529238367

## Related PRs

None