### PR TITLE
[RFC][vm] take slice instead of vec in vm API arguments

### DIFF
--- a/language/benchmarks/src/move_vm.rs
+++ b/language/benchmarks/src/move_vm.rs
@@ -97,7 +97,7 @@ fn execute(c: &mut Criterion, move_vm: &MoveVM, modules: Vec<CompiledModule>, fu
                 .execute_function(
                     &module_id,
                     &fun_name,
-                    vec![],
+                    &[],
                     vec![],
                     sender,
                     &mut cost_strategy,

--- a/language/diem-tools/transaction-replay/src/lib.rs
+++ b/language/diem-tools/transaction-replay/src/lib.rs
@@ -304,10 +304,10 @@ impl DiemDebugger {
                 let mut cost_strategy = CostStrategy::system(&gas_table, GasUnits::new(0));
                 let log_context = NoContextLog::new();
                 session.execute_script(
-                    predicate.clone(),
+                    &predicate,
+                    &[],
                     vec![],
-                    vec![],
-                    vec![diem_root_address(), sender],
+                    &[diem_root_address(), sender],
                     &mut cost_strategy,
                     &log_context,
                 )

--- a/language/diem-tools/writeset-transaction-generator/src/writeset_builder.rs
+++ b/language/diem-tools/writeset-transaction-generator/src/writeset_builder.rs
@@ -65,10 +65,10 @@ impl<'r, 'l, R: RemoteCache> GenesisSession<'r, 'l, R> {
     pub fn exec_script(&mut self, sender: AccountAddress, script: &Script) {
         self.0
             .execute_script(
-                script.code().to_vec(),
-                script.ty_args().to_vec(),
+                script.code(),
+                script.ty_args(),
                 convert_txn_args(script.args()),
-                vec![sender],
+                &[sender],
                 &mut CostStrategy::system(&ZERO_COST_SCHEDULE, GasUnits::new(100_000_000)),
                 &NoContextLog::new(),
             )

--- a/language/diem-tools/writeset-transaction-generator/src/writeset_builder.rs
+++ b/language/diem-tools/writeset-transaction-generator/src/writeset_builder.rs
@@ -36,7 +36,7 @@ impl<'r, 'l, R: RemoteCache> GenesisSession<'r, 'l, R> {
         sender: AccountAddress,
         module_name: &str,
         function_name: &str,
-        ty_args: Vec<TypeTag>,
+        ty_args: &[TypeTag],
         args: Vec<Value>,
     ) {
         self.0
@@ -80,7 +80,7 @@ impl<'r, 'l, R: RemoteCache> GenesisSession<'r, 'l, R> {
             diem_root_address(),
             "DiemConfig",
             "disable_reconfiguration",
-            vec![],
+            &[],
             vec![Value::transaction_argument_signer_reference(
                 diem_root_address(),
             )],
@@ -92,7 +92,7 @@ impl<'r, 'l, R: RemoteCache> GenesisSession<'r, 'l, R> {
             diem_root_address(),
             "DiemConfig",
             "enable_reconfiguration",
-            vec![],
+            &[],
             vec![Value::transaction_argument_signer_reference(
                 diem_root_address(),
             )],
@@ -103,7 +103,7 @@ impl<'r, 'l, R: RemoteCache> GenesisSession<'r, 'l, R> {
             diem_root_address(),
             "DiemVersion",
             "set",
-            vec![],
+            &[],
             vec![
                 Value::transaction_argument_signer_reference(diem_root_address()),
                 Value::u64(version),

--- a/language/diem-vm/src/diem_transaction_executor.rs
+++ b/language/diem-vm/src/diem_transaction_executor.rs
@@ -175,10 +175,10 @@ impl DiemVM {
                 .map_err(|e| e.into_vm_status())?;
             session
                 .execute_script(
-                    script.code().to_vec(),
-                    script.ty_args().to_vec(),
+                    script.code(),
+                    script.ty_args(),
                     convert_txn_args(script.args()),
-                    vec![txn_data.sender()],
+                    &[txn_data.sender()],
                     cost_strategy,
                     log_context,
                 )
@@ -350,10 +350,10 @@ impl DiemVM {
                 };
                 let execution_result = tmp_session
                     .execute_script(
-                        script.code().to_vec(),
-                        script.ty_args().to_vec(),
+                        script.code(),
+                        script.ty_args(),
                         args,
-                        senders,
+                        &senders,
                         &mut cost_strategy,
                         log_context,
                     )

--- a/language/diem-vm/src/diem_transaction_executor.rs
+++ b/language/diem-vm/src/diem_transaction_executor.rs
@@ -439,7 +439,7 @@ impl DiemVM {
             .execute_function(
                 &DIEM_BLOCK_MODULE,
                 &BLOCK_PROLOGUE,
-                vec![],
+                &[],
                 args,
                 txn_data.sender,
                 &mut cost_strategy,

--- a/language/diem-vm/src/diem_vm.rs
+++ b/language/diem-vm/src/diem_vm.rs
@@ -225,7 +225,7 @@ impl DiemVMImpl {
             .execute_function(
                 &account_config::ACCOUNT_MODULE,
                 &SCRIPT_PROLOGUE_NAME,
-                vec![gas_currency_ty],
+                &[gas_currency_ty],
                 vec![
                     Value::transaction_argument_signer_reference(txn_data.sender),
                     Value::u64(txn_sequence_number),
@@ -265,7 +265,7 @@ impl DiemVMImpl {
             .execute_function(
                 &account_config::ACCOUNT_MODULE,
                 &MODULE_PROLOGUE_NAME,
-                vec![gas_currency_ty],
+                &[gas_currency_ty],
                 vec![
                     Value::transaction_argument_signer_reference(txn_data.sender),
                     Value::u64(txn_sequence_number),
@@ -308,7 +308,7 @@ impl DiemVMImpl {
             .execute_function(
                 &account_config::ACCOUNT_MODULE,
                 &USER_EPILOGUE_NAME,
-                vec![gas_currency_ty],
+                &[gas_currency_ty],
                 vec![
                     Value::transaction_argument_signer_reference(txn_data.sender),
                     Value::u64(txn_sequence_number),
@@ -343,7 +343,7 @@ impl DiemVMImpl {
             .execute_function(
                 &account_config::ACCOUNT_MODULE,
                 &USER_EPILOGUE_NAME,
-                vec![gas_currency_ty],
+                &[gas_currency_ty],
                 vec![
                     Value::transaction_argument_signer_reference(txn_data.sender),
                     Value::u64(txn_sequence_number),
@@ -379,7 +379,7 @@ impl DiemVMImpl {
             .execute_function(
                 &account_config::ACCOUNT_MODULE,
                 &WRITESET_PROLOGUE_NAME,
-                vec![],
+                &[],
                 vec![
                     Value::transaction_argument_signer_reference(txn_data.sender),
                     Value::u64(txn_sequence_number),
@@ -409,7 +409,7 @@ impl DiemVMImpl {
             .execute_function(
                 &account_config::ACCOUNT_MODULE,
                 &WRITESET_EPILOGUE_NAME,
-                vec![],
+                &[],
                 vec![
                     Value::transaction_argument_signer_reference(txn_data.sender),
                     Value::u64(txn_data.sequence_number),

--- a/language/e2e-testsuite/src/tests/emergency_admin_script.rs
+++ b/language/e2e-testsuite/src/tests/emergency_admin_script.rs
@@ -195,7 +195,7 @@ fn validator_batch_remove() {
         .try_exec(
             "DiemSystem",
             "remove_validator",
-            vec![],
+            &[],
             vec![
                 Value::transaction_argument_signer_reference(diem_root_address()),
                 Value::address(*validator_account_0.address())
@@ -207,7 +207,7 @@ fn validator_batch_remove() {
         .try_exec(
             "DiemSystem",
             "remove_validator",
-            vec![],
+            &[],
             vec![
                 Value::transaction_argument_signer_reference(diem_root_address()),
                 Value::address(*validator_account_1.address())

--- a/language/e2e-testsuite/src/tests/genesis_initializations.rs
+++ b/language/e2e-testsuite/src/tests/genesis_initializations.rs
@@ -14,7 +14,7 @@ fn test_diem_initialize() {
     let output = executor.try_exec(
         "Diem",
         "initialize",
-        vec![],
+        &[],
         vec![Value::transaction_argument_signer_reference(
             account_config::diem_root_address(),
         )],
@@ -26,7 +26,7 @@ fn test_diem_initialize() {
     executor.exec(
         "Roles",
         "grant_diem_root_role",
-        vec![],
+        &[],
         vec![Value::transaction_argument_signer_reference(
             account_config::diem_root_address(),
         )],
@@ -37,7 +37,7 @@ fn test_diem_initialize() {
     executor.exec(
         "Diem",
         "initialize",
-        vec![],
+        &[],
         vec![Value::transaction_argument_signer_reference(
             account_config::diem_root_address(),
         )],
@@ -49,7 +49,7 @@ fn test_diem_initialize() {
     let output = executor.try_exec(
         "Diem",
         "initialize",
-        vec![],
+        &[],
         vec![Value::transaction_argument_signer_reference(
             account_config::diem_root_address(),
         )],
@@ -67,7 +67,7 @@ fn test_diem_initialize_tc_account() {
     let output = executor.try_exec(
         "Diem",
         "initialize",
-        vec![],
+        &[],
         vec![Value::transaction_argument_signer_reference(
             account_config::diem_root_address(),
         )],
@@ -79,7 +79,7 @@ fn test_diem_initialize_tc_account() {
     executor.exec(
         "Roles",
         "grant_diem_root_role",
-        vec![],
+        &[],
         vec![Value::transaction_argument_signer_reference(
             account_config::diem_root_address(),
         )],
@@ -90,7 +90,7 @@ fn test_diem_initialize_tc_account() {
     executor.exec(
         "Roles",
         "grant_treasury_compliance_role",
-        vec![],
+        &[],
         vec![
             Value::transaction_argument_signer_reference(
                 account_config::treasury_compliance_account_address(),
@@ -104,7 +104,7 @@ fn test_diem_initialize_tc_account() {
     let output = executor.try_exec(
         "Diem",
         "initialize",
-        vec![],
+        &[],
         vec![Value::transaction_argument_signer_reference(
             account_config::treasury_compliance_account_address(),
         )],
@@ -117,7 +117,7 @@ fn test_diem_initialize_tc_account() {
     executor.exec(
         "Diem",
         "initialize",
-        vec![],
+        &[],
         vec![Value::transaction_argument_signer_reference(
             account_config::diem_root_address(),
         )],
@@ -129,7 +129,7 @@ fn test_diem_initialize_tc_account() {
     let output = executor.try_exec(
         "Diem",
         "initialize",
-        vec![],
+        &[],
         vec![Value::transaction_argument_signer_reference(
             account_config::treasury_compliance_account_address(),
         )],
@@ -148,7 +148,7 @@ fn test_diem_timestamp_time_has_started() {
     let output = executor.try_exec(
         "DiemTimestamp",
         "set_time_has_started",
-        vec![],
+        &[],
         vec![Value::transaction_argument_signer_reference(
             account_address,
         )],
@@ -159,7 +159,7 @@ fn test_diem_timestamp_time_has_started() {
     executor.exec(
         "DiemTimestamp",
         "set_time_has_started",
-        vec![],
+        &[],
         vec![Value::transaction_argument_signer_reference(
             account_config::diem_root_address(),
         )],
@@ -169,7 +169,7 @@ fn test_diem_timestamp_time_has_started() {
     let output = executor.try_exec(
         "DiemTimestamp",
         "set_time_has_started",
-        vec![],
+        &[],
         vec![Value::transaction_argument_signer_reference(
             account_config::diem_root_address(),
         )],
@@ -186,7 +186,7 @@ fn test_diem_block_double_init() {
     executor.exec(
         "Event",
         "publish_generator",
-        vec![],
+        &[],
         vec![Value::transaction_argument_signer_reference(
             account_config::diem_root_address(),
         )],
@@ -196,7 +196,7 @@ fn test_diem_block_double_init() {
     executor.exec(
         "DiemBlock",
         "initialize_block_metadata",
-        vec![],
+        &[],
         vec![Value::transaction_argument_signer_reference(
             account_config::diem_root_address(),
         )],
@@ -206,7 +206,7 @@ fn test_diem_block_double_init() {
     let output = executor.try_exec(
         "DiemBlock",
         "initialize_block_metadata",
-        vec![],
+        &[],
         vec![Value::transaction_argument_signer_reference(
             account_config::diem_root_address(),
         )],

--- a/language/e2e-testsuite/src/tests/vasps.rs
+++ b/language/e2e-testsuite/src/tests/vasps.rs
@@ -40,7 +40,7 @@ fn valid_creator_already_vasp() {
         .try_exec(
             "VASP",
             "publish_parent_vasp_credential",
-            vec![],
+            &[],
             vec![
                 Value::transaction_argument_signer_reference(*account.address()),
                 Value::transaction_argument_signer_reference(*treasury_compliance.address()),

--- a/language/e2e-testsuite/src/tests/verify_txn.rs
+++ b/language/e2e-testsuite/src/tests/verify_txn.rs
@@ -1248,7 +1248,7 @@ pub fn publish_and_register_new_currency() {
     executor.exec(
         "DesignatedDealer",
         "add_currency",
-        vec![coin_tag.clone()],
+        &[coin_tag.clone()],
         vec![
             Value::transaction_argument_signer_reference(*dd.address()),
             Value::transaction_argument_signer_reference(*tc_account.address()),
@@ -1299,7 +1299,7 @@ pub fn publish_and_register_new_currency() {
     executor.exec(
         "TransactionFee",
         "add_txn_fee_currency",
-        vec![coin_tag],
+        &[coin_tag],
         vec![Value::transaction_argument_signer_reference(
             *tc_account.address(),
         )],

--- a/language/move-vm/integration-tests/src/tests/bad_entry_point_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/bad_entry_point_tests.rs
@@ -31,7 +31,7 @@ fn call_non_existent_module() {
         .execute_function(
             &module_id,
             &fun_name,
-            vec![],
+            &[],
             vec![],
             TEST_ADDR,
             &mut cost_strategy,
@@ -69,7 +69,7 @@ fn call_non_existent_function() {
         .execute_function(
             &module_id,
             &fun_name,
-            vec![],
+            &[],
             vec![],
             TEST_ADDR,
             &mut cost_strategy,

--- a/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
@@ -97,10 +97,10 @@ fn test_malformed_resource() {
     s1.serialize(&mut script_blob).unwrap();
     let mut sess = vm.new_session(&storage);
     sess.execute_script(
-        script_blob,
+        &script_blob,
+        &[],
         vec![],
-        vec![],
-        vec![TEST_ADDR],
+        &[TEST_ADDR],
         &mut cost_strategy,
         &log_context,
     )
@@ -117,10 +117,10 @@ fn test_malformed_resource() {
     {
         let mut sess = vm.new_session(&storage);
         sess.execute_script(
-            script_blob.clone(),
+            &script_blob,
+            &[],
             vec![],
-            vec![],
-            vec![TEST_ADDR],
+            &[TEST_ADDR],
             &mut cost_strategy,
             &log_context,
         )
@@ -145,10 +145,10 @@ fn test_malformed_resource() {
         let mut sess = vm.new_session(&storage);
         let err = sess
             .execute_script(
-                script_blob,
+                &script_blob,
+                &[],
                 vec![],
-                vec![],
-                vec![TEST_ADDR],
+                &[TEST_ADDR],
                 &mut cost_strategy,
                 &log_context,
             )

--- a/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
@@ -189,7 +189,7 @@ fn test_malformed_module() {
         sess.execute_function(
             &module_id,
             &fun_name,
-            vec![],
+            &[],
             vec![],
             TEST_ADDR,
             &mut cost_strategy,
@@ -217,7 +217,7 @@ fn test_malformed_module() {
             .execute_function(
                 &module_id,
                 &fun_name,
-                vec![],
+                &[],
                 vec![],
                 TEST_ADDR,
                 &mut cost_strategy,
@@ -260,7 +260,7 @@ fn test_unverifiable_module() {
         sess.execute_function(
             &module_id,
             &fun_name,
-            vec![],
+            &[],
             vec![],
             TEST_ADDR,
             &mut cost_strategy,
@@ -288,7 +288,7 @@ fn test_unverifiable_module() {
             .execute_function(
                 &module_id,
                 &fun_name,
-                vec![],
+                &[],
                 vec![],
                 TEST_ADDR,
                 &mut cost_strategy,
@@ -344,7 +344,7 @@ fn test_missing_module_dependency() {
         sess.execute_function(
             &module_id,
             &fun_name,
-            vec![],
+            &[],
             vec![],
             TEST_ADDR,
             &mut cost_strategy,
@@ -366,7 +366,7 @@ fn test_missing_module_dependency() {
             .execute_function(
                 &module_id,
                 &fun_name,
-                vec![],
+                &[],
                 vec![],
                 TEST_ADDR,
                 &mut cost_strategy,
@@ -422,7 +422,7 @@ fn test_malformed_module_denpency() {
         sess.execute_function(
             &module_id,
             &fun_name,
-            vec![],
+            &[],
             vec![],
             TEST_ADDR,
             &mut cost_strategy,
@@ -450,7 +450,7 @@ fn test_malformed_module_denpency() {
             .execute_function(
                 &module_id,
                 &fun_name,
-                vec![],
+                &[],
                 vec![],
                 TEST_ADDR,
                 &mut cost_strategy,
@@ -507,7 +507,7 @@ fn test_unverifiable_module_dependency() {
         sess.execute_function(
             &module_id,
             &fun_name,
-            vec![],
+            &[],
             vec![],
             TEST_ADDR,
             &mut cost_strategy,
@@ -536,7 +536,7 @@ fn test_unverifiable_module_dependency() {
             .execute_function(
                 &module_id,
                 &fun_name,
-                vec![],
+                &[],
                 vec![],
                 TEST_ADDR,
                 &mut cost_strategy,
@@ -595,7 +595,7 @@ fn test_storage_returns_bogus_error_when_loading_module() {
             .execute_function(
                 &module_id,
                 &fun_name,
-                vec![],
+                &[],
                 vec![],
                 TEST_ADDR,
                 &mut cost_strategy,
@@ -664,7 +664,7 @@ fn test_storage_returns_bogus_error_when_loading_resource() {
         sess.execute_function(
             &m_id,
             &foo_name,
-            vec![],
+            &[],
             vec![],
             TEST_ADDR,
             &mut cost_strategy,
@@ -676,7 +676,7 @@ fn test_storage_returns_bogus_error_when_loading_resource() {
             .execute_function(
                 &m_id,
                 &bar_name,
-                vec![],
+                &[],
                 vec![Value::transaction_argument_signer_reference(TEST_ADDR)],
                 TEST_ADDR,
                 &mut cost_strategy,

--- a/language/move-vm/integration-tests/src/tests/loader_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/loader_tests.rs
@@ -94,7 +94,7 @@ impl Adapter {
                         .execute_function(
                             &module_id,
                             &name,
-                            vec![],
+                            &[],
                             vec![],
                             WORKING_ACCOUNT,
                             &mut cost_strategy,
@@ -120,7 +120,7 @@ impl Adapter {
             .execute_function(
                 module,
                 name,
-                vec![],
+                &[],
                 vec![],
                 WORKING_ACCOUNT,
                 &mut cost_strategy,

--- a/language/move-vm/integration-tests/src/tests/mutated_accounts_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/mutated_accounts_tests.rs
@@ -60,7 +60,7 @@ fn mutated_accounts() {
     sess.execute_function(
         &module_id,
         &publish,
-        vec![],
+        &[],
         vec![Value::transaction_argument_signer_reference(account1)],
         TEST_ADDR,
         &mut cost_strategy,
@@ -76,7 +76,7 @@ fn mutated_accounts() {
     sess.execute_function(
         &module_id,
         &get,
-        vec![],
+        &[],
         vec![Value::address(account1)],
         TEST_ADDR,
         &mut cost_strategy,
@@ -89,7 +89,7 @@ fn mutated_accounts() {
     sess.execute_function(
         &module_id,
         &flip,
-        vec![],
+        &[],
         vec![Value::address(account1)],
         TEST_ADDR,
         &mut cost_strategy,
@@ -106,7 +106,7 @@ fn mutated_accounts() {
     sess.execute_function(
         &module_id,
         &get,
-        vec![],
+        &[],
         vec![Value::address(account1)],
         TEST_ADDR,
         &mut cost_strategy,

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -174,7 +174,7 @@ impl VMRuntime {
         &self,
         module: &ModuleId,
         function_name: &IdentStr,
-        ty_args: Vec<TypeTag>,
+        ty_args: &[TypeTag],
         args: Vec<Value>,
         data_store: &mut impl DataStore,
         cost_strategy: &mut CostStrategy,
@@ -184,7 +184,7 @@ impl VMRuntime {
         // its dependencies if the module was not loaded
         let (func, type_params) =
             self.loader
-                .load_function(function_name, module, &ty_args, data_store, log_context)?;
+                .load_function(function_name, module, ty_args, data_store, log_context)?;
 
         // check the arguments provided are of restricted types
         check_args(&args).map_err(|e| e.finish(Location::Module(module.clone())))?;

--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -70,10 +70,10 @@ impl<'r, 'l, R: RemoteCache> Session<'r, 'l, R> {
     /// not proceed with effect generation.
     pub fn execute_script(
         &mut self,
-        script: Vec<u8>,
-        ty_args: Vec<TypeTag>,
+        script: &[u8],
+        ty_args: &[TypeTag],
         args: Vec<Value>,
-        senders: Vec<AccountAddress>,
+        senders: &[AccountAddress],
         cost_strategy: &mut CostStrategy,
         log_context: &impl LogContext,
     ) -> VMResult<()> {

--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -39,7 +39,7 @@ impl<'r, 'l, R: RemoteCache> Session<'r, 'l, R> {
         &mut self,
         module: &ModuleId,
         function_name: &IdentStr,
-        ty_args: Vec<TypeTag>,
+        ty_args: &[TypeTag],
         args: Vec<Value>,
         _sender: AccountAddress,
         cost_strategy: &mut CostStrategy,

--- a/language/testing-infra/e2e-tests/src/executor.rs
+++ b/language/testing-infra/e2e-tests/src/executor.rs
@@ -336,7 +336,7 @@ impl FakeExecutor {
         &mut self,
         module_name: &str,
         function_name: &str,
-        type_params: Vec<TypeTag>,
+        type_params: &[TypeTag],
         args: Vec<Value>,
         sender: &AccountAddress,
     ) {
@@ -377,7 +377,7 @@ impl FakeExecutor {
         &mut self,
         module_name: &str,
         function_name: &str,
-        type_params: Vec<TypeTag>,
+        type_params: &[TypeTag],
         args: Vec<Value>,
         sender: &AccountAddress,
     ) -> Result<WriteSet, VMStatus> {

--- a/language/testing-infra/test-generation/src/lib.rs
+++ b/language/testing-infra/test-generation/src/lib.rs
@@ -79,20 +79,14 @@ fn run_vm(module: CompiledModule) -> Result<(), VMStatus> {
         .collect();
 
     let executor = FakeExecutor::from_genesis_file();
-    execute_function_in_module(
-        module,
-        entry_idx,
-        vec![],
-        main_args,
-        executor.get_state_view(),
-    )
+    execute_function_in_module(module, entry_idx, &[], main_args, executor.get_state_view())
 }
 
 /// Execute the first function in a module
 fn execute_function_in_module<S: StateView>(
     module: CompiledModule,
     idx: FunctionDefinitionIndex,
-    ty_args: Vec<TypeTag>,
+    ty_args: &[TypeTag],
     args: Vec<Value>,
     state_view: &S,
 ) -> Result<(), VMStatus> {

--- a/language/tools/move-cli/src/main.rs
+++ b/language/tools/move-cli/src/main.rs
@@ -387,10 +387,10 @@ fn run(
     let mut session = vm.new_session(&state);
 
     let res = session.execute_script(
-        script_bytes,
-        vm_type_args.clone(),
+        &script_bytes,
+        &vm_type_args,
         vm_args,
-        signer_addresses.clone(),
+        &signer_addresses,
         &mut cost_strategy,
         &log_context,
     );

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -191,7 +191,7 @@ fn exec_function(
     sender: AccountAddress,
     module_name: &str,
     function_name: &str,
-    ty_args: Vec<TypeTag>,
+    ty_args: &[TypeTag],
     args: Vec<Value>,
 ) {
     session
@@ -272,7 +272,7 @@ fn create_and_initialize_main_accounts(
         root_diem_root_address,
         GENESIS_MODULE_NAME,
         "initialize",
-        vec![],
+        &[],
         vec![
             Value::transaction_argument_signer_reference(root_diem_root_address),
             Value::transaction_argument_signer_reference(tc_account_address),
@@ -296,7 +296,7 @@ fn create_and_initialize_main_accounts(
         root_diem_root_address,
         "DiemAccount",
         "epilogue",
-        vec![xdx_ty.clone()],
+        &[xdx_ty.clone()],
         vec![
             Value::transaction_argument_signer_reference(root_diem_root_address),
             Value::u64(/* txn_sequence_number */ 0),
@@ -343,7 +343,7 @@ fn create_and_initialize_testnet_minting(
         account_config::treasury_compliance_account_address(),
         "DesignatedDealer",
         "update_tier",
-        vec![account_config::xus_tag()],
+        &[account_config::xus_tag()],
         vec![
             Value::transaction_argument_signer_reference(
                 account_config::treasury_compliance_account_address(),
@@ -459,7 +459,7 @@ fn create_and_initialize_owners_operators(
             diem_root_address,
             "DiemSystem",
             "add_validator",
-            vec![],
+            &[],
             vec![
                 Value::transaction_argument_signer_reference(diem_root_address),
                 Value::address(owner_address),
@@ -505,7 +505,7 @@ fn reconfigure(session: &mut Session<StateViewCache>, log_context: &impl LogCont
         account_config::diem_root_address(),
         "DiemConfig",
         "emit_genesis_reconfiguration_event",
-        vec![],
+        &[],
         vec![],
     );
 }

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -225,10 +225,10 @@ fn exec_script(
 ) {
     session
         .execute_script(
-            script.code().to_vec(),
-            script.ty_args().to_vec(),
+            script.code(),
+            script.ty_args(),
             convert_txn_args(script.args()),
-            vec![sender],
+            &[sender],
             &mut CostStrategy::system(&ZERO_COST_SCHEDULE, GasUnits::new(100_000_000)),
             log_context,
         )


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

All changes rooted from VM's API change on `execute_function` and `execute_script`, and back propagated to related callsites.

```diff
    pub fn execute_function(
        &mut self,
        module: &ModuleId,
        function_name: &IdentStr,
-        ty_args: Vec<TypeTag>,
+        ty_args: &[TypeTag],
        args: Vec<Value>,
        _sender: AccountAddress,
        cost_strategy: &mut CostStrategy,
        log_context: &impl LogContext,
    ) -> VMResult<()>
```

```diff
    pub fn execute_script(
        &mut self,
-        script: Vec<u8>,
-        ty_args: Vec<TypeTag>,
+        script: &[u8],
+        ty_args: &[TypeTag],
        args: Vec<Value>,
-        senders: Vec<AccountAddress>,
+        senders: &[AccountAddress],
        cost_strategy: &mut CostStrategy,
        log_context: &impl LogContext,
    ) -> VMResult<()>
```

These changes are supposed to boost performance, but need a way to test it reliably.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

`cargo xtest`

[TODO] performance numbers

## Related PRs

[George's original PR](https://github.com/gdanezis/libra/pull/1)
