### PR TITLE
[diemdb_bench] expose rocksdb stats after bench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2456,6 +2456,7 @@ dependencies = [
 name = "diemdb-benchmark"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "byteorder",
  "diem-config",
  "diem-types",

--- a/storage/diemdb-benchmark/Cargo.toml
+++ b/storage/diemdb-benchmark/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
+anyhow = "1.0.38"
 byteorder = "1.4.2"
 indicatif = "0.15.0"
 itertools = { version = "0.10.0", default-features = false }

--- a/storage/diemdb/src/metrics.rs
+++ b/storage/diemdb/src/metrics.rs
@@ -88,7 +88,7 @@ pub static DIEM_STORAGE_OTHER_TIMERS_SECONDS: Lazy<HistogramVec> = Lazy::new(|| 
 });
 
 /// Rocksdb metrics
-pub(crate) static DIEM_STORAGE_ROCKSDB_PROPERTIES: Lazy<IntGaugeVec> = Lazy::new(|| {
+pub static DIEM_STORAGE_ROCKSDB_PROPERTIES: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         // metric name
         "diem_rocksdb_properties",

--- a/storage/diemdb/src/schema/mod.rs
+++ b/storage/diemdb/src/schema/mod.rs
@@ -23,18 +23,18 @@ pub(crate) mod transaction_info;
 use anyhow::{ensure, Result};
 use schemadb::ColumnFamilyName;
 
-pub(super) const EPOCH_BY_VERSION_CF_NAME: ColumnFamilyName = "epoch_by_version";
-pub(super) const EVENT_ACCUMULATOR_CF_NAME: ColumnFamilyName = "event_accumulator";
-pub(super) const EVENT_BY_KEY_CF_NAME: ColumnFamilyName = "event_by_key";
-pub(super) const EVENT_BY_VERSION_CF_NAME: ColumnFamilyName = "event_by_version";
-pub(super) const EVENT_CF_NAME: ColumnFamilyName = "event";
-pub(super) const JELLYFISH_MERKLE_NODE_CF_NAME: ColumnFamilyName = "jellyfish_merkle_node";
-pub(super) const LEDGER_COUNTERS_CF_NAME: ColumnFamilyName = "ledger_counters";
-pub(super) const STALE_NODE_INDEX_CF_NAME: ColumnFamilyName = "stale_node_index";
-pub(super) const TRANSACTION_CF_NAME: ColumnFamilyName = "transaction";
-pub(super) const TRANSACTION_ACCUMULATOR_CF_NAME: ColumnFamilyName = "transaction_accumulator";
-pub(super) const TRANSACTION_BY_ACCOUNT_CF_NAME: ColumnFamilyName = "transaction_by_account";
-pub(super) const TRANSACTION_INFO_CF_NAME: ColumnFamilyName = "transaction_info";
+pub const EPOCH_BY_VERSION_CF_NAME: ColumnFamilyName = "epoch_by_version";
+pub const EVENT_ACCUMULATOR_CF_NAME: ColumnFamilyName = "event_accumulator";
+pub const EVENT_BY_KEY_CF_NAME: ColumnFamilyName = "event_by_key";
+pub const EVENT_BY_VERSION_CF_NAME: ColumnFamilyName = "event_by_version";
+pub const EVENT_CF_NAME: ColumnFamilyName = "event";
+pub const JELLYFISH_MERKLE_NODE_CF_NAME: ColumnFamilyName = "jellyfish_merkle_node";
+pub const LEDGER_COUNTERS_CF_NAME: ColumnFamilyName = "ledger_counters";
+pub const STALE_NODE_INDEX_CF_NAME: ColumnFamilyName = "stale_node_index";
+pub const TRANSACTION_CF_NAME: ColumnFamilyName = "transaction";
+pub const TRANSACTION_ACCUMULATOR_CF_NAME: ColumnFamilyName = "transaction_accumulator";
+pub const TRANSACTION_BY_ACCOUNT_CF_NAME: ColumnFamilyName = "transaction_by_account";
+pub const TRANSACTION_INFO_CF_NAME: ColumnFamilyName = "transaction_info";
 
 fn ensure_slice_len_eq(data: &[u8], len: usize) -> Result<()> {
     ensure!(


### PR DESCRIPTION
## Motivation

print out the live data size versus live sst file size after the benchmark

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

cargo run -- -n 1000 -v 100000 --db-dir=/tmp/test
