### PR TITLE
[language] filter out file names in compiler error messages

### DIFF
--- a/language/ir-testsuite/tests/move/commands/if_branch_diverges_5.mvir
+++ b/language/ir-testsuite/tests/move/commands/if_branch_diverges_5.mvir
@@ -1,6 +1,3 @@
-// check: BoundsCheckErrors
-// check: INDEX_OUT_OF_BOUNDS
-
 main() {
     let ret_if_val: bool;
     ret_if_val = true;
@@ -15,3 +12,5 @@ main() {
         return;
     }
 }
+// check: "Post-compile bounds check errors"
+// check: INDEX_OUT_OF_BOUNDS

--- a/language/ir-testsuite/tests/move/commands/if_branch_diverges_6.mvir
+++ b/language/ir-testsuite/tests/move/commands/if_branch_diverges_6.mvir
@@ -1,6 +1,3 @@
-// check: BoundsCheckErrors
-// check: INDEX_OUT_OF_BOUNDS
-
 main() {
     let ret_if_val: bool;
     ret_if_val = true;
@@ -11,3 +8,5 @@ main() {
         return;
     }
 }
+// check: "Post-compile bounds check errors"
+// check: INDEX_OUT_OF_BOUNDS

--- a/language/ir-testsuite/tests/move/commands/if_branch_diverges_8.mvir
+++ b/language/ir-testsuite/tests/move/commands/if_branch_diverges_8.mvir
@@ -1,6 +1,3 @@
-// check: BoundsCheckErrors
-// check: INDEX_OUT_OF_BOUNDS
-
 main() {
     let ret_if_val: bool;
     ret_if_val = true;
@@ -11,3 +8,5 @@ main() {
         return;
     }
 }
+// check: "Post-compile bounds check errors"
+// check: INDEX_OUT_OF_BOUNDS

--- a/language/move-lang/functional-tests/tests/move/commands/unpack_top_level.move
+++ b/language/move-lang/functional-tests/tests/move/commands/unpack_top_level.move
@@ -17,4 +17,4 @@ fun main() {
     Test { b: _ } = t;
 }
 }
-// check: MoveSourceCompilerError
+// check: "Unbound type" "in current scope"


### PR DESCRIPTION
Currently in functional tests, temporary files (with random names) are used as inputs to the Move compiler. This causes the tests to be non-deterministic as the file names may appear in error messages. This gets it fixed by filtering out those file names in the compiler error messages with regex. 

This hack should work reasonably well in the short term. We will keep evaluating other solutions.