### PR TITLE
[common] adding a new fallible wrapper for copy_from_slice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1017,6 +1017,7 @@ dependencies = [
  "executor-test-helpers",
  "executor-types",
  "fail",
+ "fallible",
  "futures 0.3.12",
  "itertools 0.10.0",
  "mirai-annotations",
@@ -2065,6 +2066,7 @@ dependencies = [
  "diem-temppath",
  "diem-types",
  "diem-workspace-hack",
+ "fallible",
  "hex",
  "serde",
  "serde_json",
@@ -2288,6 +2290,7 @@ dependencies = [
  "diem-network-address",
  "diem-proptest-helpers",
  "diem-workspace-hack",
+ "fallible",
  "hex",
  "itertools 0.10.0",
  "mirai-annotations",
@@ -2930,6 +2933,14 @@ name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
+name = "fallible"
+version = "0.1.0"
+dependencies = [
+ "diem-workspace-hack",
+ "thiserror",
+]
 
 [[package]]
 name = "fiat-crypto"
@@ -4294,6 +4305,7 @@ dependencies = [
  "diem-types",
  "diem-workspace-hack",
  "difference",
+ "fallible",
  "hex",
  "ir-to-bytecode",
  "move-core-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "common/datatest-stable",
     "common/debug-interface",
     "common/diemdoc",
+    "common/fallible",
     "common/infallible",
     "common/logger",
     "common/logger/derive",

--- a/common/fallible/Cargo.toml
+++ b/common/fallible/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "fallible"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+description = "Diem diem-infallible"
+repository = "https://github.com/diem/diem"
+homepage = "https://diem.com"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+thiserror = "1.0"
+
+diem-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }

--- a/common/fallible/src/copy_from_slice.rs
+++ b/common/fallible/src/copy_from_slice.rs
@@ -1,0 +1,22 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use thiserror::Error;
+
+/// A fallible wrapper around [`std::vec::Vec::copy_from_slice`]
+pub fn copy_slice_to_vec<T>(slice: &[T], vec: &mut [T]) -> Result<(), CopySliceError>
+where
+    T: Copy,
+{
+    if slice.len() != vec.len() {
+        return Err(CopySliceError);
+    }
+
+    vec.copy_from_slice(slice);
+
+    Ok(())
+}
+
+#[derive(Error, Debug)]
+#[error("can't copy source slice into destination slice: sizes don't match")]
+pub struct CopySliceError;

--- a/common/fallible/src/lib.rs
+++ b/common/fallible/src/lib.rs
@@ -1,0 +1,4 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod copy_from_slice;

--- a/config/management/operational/Cargo.toml
+++ b/config/management/operational/Cargo.toml
@@ -30,6 +30,7 @@ diem-secure-storage = { path = "../../../secure/storage", version = "0.1.0" }
 diem-types = { path = "../../../types", version = "0.1.0" }
 diem-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 diem-temppath = { path = "../../../common/temppath", version = "0.1.0" }
+fallible = { path = "../../../common/fallible" }
 transaction-builder = { path = "../../../language/transaction-builder", version = "0.1.0" }
 
 [features]

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -34,6 +34,7 @@ consensus-types = { path = "consensus-types", version = "0.1.0", default-feature
 execution-correctness = { path = "../execution/execution-correctness", version = "0.1.0" }
 executor = { path = "../execution/executor", version = "0.1.0" }
 executor-types = { path = "../execution/executor-types", version = "0.1.0" }
+fallible = { path = "../common/fallible" }
 bcs = "0.1.2"
 diem-config = { path = "../config", version = "0.1.0" }
 diem-crypto = { path = "../crypto/crypto", version = "0.1.0" }

--- a/consensus/src/liveness/proposer_election.rs
+++ b/consensus/src/liveness/proposer_election.rs
@@ -5,6 +5,7 @@ use consensus_types::{
     block::Block,
     common::{Author, Round},
 };
+use fallible::copy_from_slice::copy_slice_to_vec;
 
 /// ProposerElection incorporates the logic of choosing a leader among multiple candidates.
 /// We are open to a possibility for having multiple proposers per round, the ultimate choice
@@ -34,7 +35,7 @@ pub(crate) fn next(state: &mut Vec<u8>) -> u64 {
     // state = SHA-3-256(state)
     *state = diem_crypto::HashValue::sha3_256_of(state).to_vec();
     let mut temp = [0u8; 8];
-    temp.copy_from_slice(&state[..8]);
+    copy_slice_to_vec(&state[..8], &mut temp).expect("next failed");
     // return state[0..8]
     u64::from_le_bytes(temp)
 }

--- a/language/move-lang/Cargo.toml
+++ b/language/move-lang/Cargo.toml
@@ -18,6 +18,7 @@ petgraph = "0.5.1"
 walkdir = "2.3.1"
 tempfile = "3.2.0"
 
+fallible = { path = "../../common/fallible" }
 move-vm = { path = "../vm", package = "vm" }
 move-core-types = { path = "../move-core/types" }
 move-bytecode-verifier = { path = "../bytecode-verifier", package = "bytecode-verifier" }

--- a/language/move-lang/src/shared/mod.rs
+++ b/language/move-lang/src/shared/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use fallible::copy_from_slice::copy_slice_to_vec;
 use move_ir_types::location::*;
 use petgraph::{algo::astar as petgraph_astar, graphmap::DiGraphMap};
 use std::{
@@ -118,7 +119,7 @@ impl TryFrom<&[u8]> for Address {
             Err(format!("The Address {:?} is of invalid length", bytes))
         } else {
             let mut addr = [0u8; ADDRESS_LENGTH];
-            addr.copy_from_slice(bytes);
+            copy_slice_to_vec(bytes, &mut addr).map_err(|e| format!("{}", e))?;
             Ok(Address(addr))
         }
     }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -33,6 +33,7 @@ diem-infallible = { path = "../common/infallible", version = "0.1.0" }
 diem-network-address = { path = "../network/network-address", version = "0.1.0" }
 diem-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0", optional = true }
 diem-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
+fallible = { path = "../common/fallible" }
 move-core-types = { path = "../language/move-core/types", version = "0.1.0" }
 
 [dev-dependencies]

--- a/types/src/event.rs
+++ b/types/src/event.rs
@@ -3,6 +3,7 @@
 
 use crate::account_address::AccountAddress;
 use anyhow::{ensure, Error, Result};
+use fallible::copy_from_slice::copy_slice_to_vec;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 #[cfg(any(test, feature = "fuzzing"))]
@@ -42,7 +43,11 @@ impl EventKey {
     /// Get the account address part in this event key
     pub fn get_creator_address(&self) -> AccountAddress {
         let mut arr_bytes = [0u8; AccountAddress::LENGTH];
-        arr_bytes.copy_from_slice(&self.0[EventKey::LENGTH - AccountAddress::LENGTH..]);
+        copy_slice_to_vec(
+            &self.0[EventKey::LENGTH - AccountAddress::LENGTH..],
+            &mut arr_bytes,
+        )
+        .expect("get_creator_address failed");
 
         AccountAddress::new(arr_bytes)
     }


### PR DESCRIPTION
If you remember the first audit we had, they found a reachable panic in admission control which as a call to `copy_from_slice` with arguments of different sizes. Since then, we were wondering why the stdlib didn't provide a fallible alternative, and what other std functions could panic (perhaps surprisingly) in our code.

Talking to the SLEDGE people, they pointed us to [code that looks like this](https://github.com/diem/diem/blob/2ce5695e65313724c16f010b8587a55b42711912/crypto/crypto/src/ed25519.rs#L367:L372): 

```rust
if bytes.len() != ED25519_PUBLIC_KEY_LENGTH {
            return Err(CryptoMaterialError::WrongLengthError);
        }

        let mut bits = [0u8; ED25519_PUBLIC_KEY_LENGTH];
        bits.copy_from_slice(&bytes[..ED25519_PUBLIC_KEY_LENGTH]);
```

and we had a discussion on if this was good enough, or if we could do better. The problem with code like this is that people copy/paste code, or refactor things, and assumptions end up changing. 

I compare that snippet to checking for integer overflow in most languages: you check first for the edge-case, and hopefully if you did it well and nobody changes that code, the rest of the code will be safe from integer overflows. In Rust, there's a much stronger approach: make the mistake, see if it returns an error (or an option more accurately), and then handle the edge-case explicitly.

So why not do the same here? and bundle the copy_from_slice behind a safer API that is fallible? (The reverse of what we did by wrapping fallible APIs in the `common/infallible` library. This way there's no mistake that can be made, and if you really want to panic instead of returning an error, then it is clearly documented with an `expect()`.

