### PR TITLE
[x] add a custom rule abi -> transaction-builder-generator

### DIFF
--- a/language/transaction-builder/generator/tests/generation.rs
+++ b/language/transaction-builder/generator/tests/generation.rs
@@ -17,6 +17,7 @@ fn get_diem_registry() -> Registry {
 }
 
 fn get_stdlib_script_abis() -> Vec<ScriptABI> {
+    // This is also a custom rule in diem/x.toml.
     let path = "../../stdlib/compiled/transaction_scripts/abi";
     buildgen::read_abis(path).expect("reading ABI files should not fail")
 }

--- a/x.toml
+++ b/x.toml
@@ -213,6 +213,12 @@ mark-changed = []
 globs = ["diem.png", ".assets/diem.png", "storage/data.png"]
 mark-changed = []
 
+[[determinator.path-rule]]
+# Required by get_stdlib_script_abis in transaction-builder-generator.
+globs = ["language/stdlib/compiled/transaction_scripts/abi/**/*"]
+mark-changed = ["transaction-builder-generator"]
+post-rule = "skip-rules"
+
 [[determinator.package-rule]]
 # x controls the build process, so if it changes, build everything.
 on-affected = ["x"]


### PR DESCRIPTION
This was originally caught in #7449.

Tested through:
```
echo >> language/stdlib/compiled/transaction_scripts/abi/burn_txn_fees.abi
git commit -am 'test'
cargo x changed-since HEAD^
```

(I really should make it easier to just test a path, whoops)