### PR TITLE
[move-prover][refactoring] Integrating verification analysis into the transformation pipeline.

### DIFF
--- a/language/move-model/src/builder/model_builder.rs
+++ b/language/move-model/src/builder/model_builder.rs
@@ -302,7 +302,7 @@ impl<'env> ModelBuilder<'env> {
             let module_env = self.env.get_module(entry.module_id);
             // Warn about unused schema only if the module is a target and schema name
             // does not start with 'UNUSED'
-            if !module_env.is_dependency() && !schema_name.starts_with("UNUSED") {
+            if module_env.is_target() && !schema_name.starts_with("UNUSED") {
                 self.env.warn(
                     &entry.loc,
                     &format!("unused schema {}", name.display(self.env.symbol_pool())),

--- a/language/move-prover/abigen/src/abigen.rs
+++ b/language/move-prover/abigen/src/abigen.rs
@@ -69,7 +69,7 @@ impl<'env> Abigen<'env> {
     /// Generates ABIs for all script modules in the environment (excluding the dependency set).
     pub fn gen(&mut self) {
         for module in self.env.get_modules() {
-            if module.is_script_module() && !module.is_dependency() {
+            if module.is_script_module() && module.is_target() {
                 let mut path = PathBuf::from(&self.options.output_directory);
                 path.push(
                     PathBuf::from(module.get_source_path())

--- a/language/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/language/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -91,7 +91,7 @@ impl<'env> ModuleTranslator<'env> {
     /// Translates this module.
     fn translate(&mut self) {
         log!(
-            if self.module_env.is_dependency() {
+            if !self.module_env.is_target() {
                 Level::Debug
             } else {
                 Level::Info
@@ -106,10 +106,6 @@ impl<'env> ModuleTranslator<'env> {
         self.spec_translator.translate_spec_vars(&self.module_env);
         self.spec_translator.translate_spec_funs(&self.module_env);
         self.translate_structs();
-        // Don't translate functions if the module doesn't need to be translated
-        if !self.module_env.should_translate() {
-            return;
-        }
         self.translate_functions();
     }
 

--- a/language/move-prover/bytecode/src/annotations.rs
+++ b/language/move-prover/bytecode/src/annotations.rs
@@ -25,6 +25,16 @@ impl Annotations {
         self.map.get(&id).and_then(|d| d.downcast_ref::<T>())
     }
 
+    /// Gets annotation of type T or creates one from default.
+    pub fn get_or_default_mut<T: Any + Default>(&mut self) -> &mut T {
+        let id = TypeId::of::<T>();
+        self.map
+            .entry(id)
+            .or_insert_with(|| Box::new(T::default()))
+            .downcast_mut::<T>()
+            .expect("cast successful")
+    }
+
     /// Sets annotation of type T.
     pub fn set<T: Any>(&mut self, x: T) {
         let id = TypeId::of::<T>();

--- a/language/move-prover/bytecode/src/compositional_analysis.rs
+++ b/language/move-prover/bytecode/src/compositional_analysis.rs
@@ -36,7 +36,7 @@ impl<'a> SummaryCache<'a> {
             vec![FunctionVariant::Baseline]
         );
         self.targets
-            .get_target_data(&fun_id, FunctionVariant::Baseline)
+            .get_data(&fun_id, FunctionVariant::Baseline)
             .map(|fun_data| {
                 if self.global_env.get_function(fun_id).is_native() {
                     None

--- a/language/move-prover/bytecode/src/lib.rs
+++ b/language/move-prover/bytecode/src/lib.rs
@@ -28,6 +28,7 @@ pub mod stackless_bytecode;
 pub mod stackless_bytecode_generator;
 pub mod stackless_control_flow_graph;
 pub mod usage_analysis;
+pub mod verification_analysis;
 
 /// Print function targets for testing and debugging.
 pub fn print_targets_for_test(

--- a/language/move-prover/bytecode/src/verification_analysis.rs
+++ b/language/move-prover/bytecode/src/verification_analysis.rs
@@ -1,0 +1,204 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Analysis which computes an annotation for each function whether
+
+use crate::{
+    function_target::{FunctionData, FunctionTarget},
+    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant},
+    options::{ProverOptions, PROVER_DEFAULT_OPTIONS},
+    usage_analysis,
+};
+use move_model::model::{FunctionEnv, GlobalEnv, QualifiedId, StructId};
+use std::collections::BTreeSet;
+
+/// The annotation for information about verification.
+#[derive(Clone, Default)]
+pub struct VerificationInfo {
+    /// Whether the function is target of verification.
+    pub verified: bool,
+    /// Whether the function needs to have an inlined variant since it is called from a verified
+    /// function and is not opaque.
+    pub inlined: bool,
+}
+
+/// Get verification information for this function.
+pub fn get_info(target: &FunctionTarget<'_>) -> VerificationInfo {
+    target
+        .get_annotations()
+        .get::<VerificationInfo>()
+        .cloned()
+        .unwrap_or_else(VerificationInfo::default)
+}
+
+pub struct VerificationAnalysisProcessor();
+
+impl VerificationAnalysisProcessor {
+    pub fn new() -> Box<Self> {
+        Box::new(Self())
+    }
+}
+
+impl FunctionTargetProcessor for VerificationAnalysisProcessor {
+    fn process(
+        &self,
+        targets: &mut FunctionTargetsHolder,
+        fun_env: &FunctionEnv<'_>,
+        data: FunctionData,
+    ) -> FunctionData {
+        // When we are called, the data of this function is removed from targets so it can
+        // be mutated, as per pipeline processor design. We put it back temporarily to have
+        // a unique model of targets.
+        let fid = fun_env.get_qualified_id();
+        let variant = data.variant;
+        targets.insert_target_data(&fid, variant, data);
+
+        // Check the friend relation.
+        check_friend_relation(fun_env);
+
+        let options = fun_env
+            .module_env
+            .env
+            .get_extension::<ProverOptions>()
+            .unwrap_or_else(|| &*PROVER_DEFAULT_OPTIONS);
+        let is_verified =
+            if fun_env.module_env.is_target() && fun_env.should_verify(options.verify_scope) {
+                // This function needs to be verified because it is a user provided verification
+                // target.
+                true
+            } else {
+                // Get all memory mentioned in the invariants in target modules
+                let target_memory = get_target_invariant_memory(fun_env.module_env.env);
+
+                // Get all memory modified by this function.
+                let fun_target = targets.get_target(fun_env, variant);
+                let modified_memory = usage_analysis::get_directly_modified_memory(&fun_target);
+
+                // This function needs to be verified if it touches target memory.
+                !modified_memory.is_disjoint(&target_memory)
+            };
+        if is_verified {
+            mark_verified(fun_env, variant, targets);
+        }
+
+        targets.remove_target_data(&fid, variant)
+    }
+
+    fn name(&self) -> String {
+        "verification_analysis".to_string()
+    }
+}
+
+/// Checks whether the friend relation is correctly used.
+fn check_friend_relation(fun_env: &FunctionEnv<'_>) {
+    if fun_env.has_friend() {
+        let env = fun_env.module_env.env;
+        let loc = fun_env.get_loc();
+        if fun_env.is_opaque() {
+            env.error(&loc, "function with a friend cannot be declared as opaque");
+        }
+        let calling_functions = fun_env.get_calling_functions();
+
+        // Construct a set containing all friends of the function in the system.
+        // Right now there can be at most one friend.
+        let mut friends = BTreeSet::new();
+        if let Some(friend_env) = fun_env.get_friend_env() {
+            friends.insert(friend_env.get_qualified_id());
+        }
+
+        // If the set of callers is not a subset of the friends set,
+        // then some non-friend calls the function so generate an error message.
+        if !calling_functions.is_subset(&friends) {
+            env.error(&loc, &format!("function `{}` is called by other functions while it can only be called by its friend {}",
+                                         fun_env.get_name_string(),
+                                         fun_env.get_friend_name().unwrap())
+                );
+        }
+    }
+}
+
+/// Compute the set of resources which are used in invariants which are target of
+/// verification.
+fn get_target_invariant_memory(env: &GlobalEnv) -> BTreeSet<QualifiedId<StructId>> {
+    let mut target_resources = BTreeSet::new();
+    for module_env in env.get_modules() {
+        if module_env.is_target() {
+            let module_id = module_env.get_id();
+            let mentioned_resources: BTreeSet<QualifiedId<StructId>> = env
+                .get_global_invariants_by_module(module_id)
+                .iter()
+                .flat_map(|id| env.get_global_invariant(*id).unwrap().mem_usage.clone())
+                .collect();
+            target_resources.extend(mentioned_resources);
+        }
+    }
+    target_resources
+}
+
+/// Mark this function as being verified. If it has a friend and is verified only in the
+/// friends context, mark the friend instead. This also marks all functions directly or
+/// indirectly called by this function as inlined if they are not opaque.
+fn mark_verified(
+    fun_env: &FunctionEnv<'_>,
+    variant: FunctionVariant,
+    targets: &mut FunctionTargetsHolder,
+) {
+    let actual_env = fun_env.get_transitive_friend();
+    if actual_env.get_qualified_id() != fun_env.get_qualified_id() {
+        // Instead of verifying this function directly, we mark the friend as being verified,
+        // and this function as inlined.
+        mark_inlined(fun_env, variant, targets);
+    }
+    // The user can override with `pragma verify = false`, so respect this.
+    if !actual_env.is_explicitly_not_verified() {
+        let mut info = targets
+            .get_data_mut(&actual_env.get_qualified_id(), variant)
+            .expect("function data available")
+            .annotations
+            .get_or_default_mut::<VerificationInfo>();
+        if !info.verified {
+            info.verified = true;
+            mark_callees_inlined(&actual_env, variant, targets);
+        }
+    }
+}
+
+/// Mark this function as inlined if it is not opaque, as it is being called
+/// directly or indirectly from a verified function.
+fn mark_inlined(
+    fun_env: &FunctionEnv<'_>,
+    variant: FunctionVariant,
+    targets: &mut FunctionTargetsHolder,
+) {
+    if fun_env.is_native() || fun_env.is_intrinsic() {
+        return;
+    }
+    debug_assert!(
+        targets.get_target_variants(fun_env).contains(&variant),
+        "`{}` has variant `{:?}`",
+        fun_env.get_name().display(fun_env.symbol_pool()),
+        variant
+    );
+    let data = targets
+        .get_data_mut(&fun_env.get_qualified_id(), variant)
+        .expect("function data defined");
+    let info = data.annotations.get_or_default_mut::<VerificationInfo>();
+    if !info.inlined {
+        info.inlined = true;
+        mark_callees_inlined(fun_env, variant, targets);
+    }
+}
+
+/// Continue transitively marking callees as inlined.
+fn mark_callees_inlined(
+    fun_env: &FunctionEnv<'_>,
+    variant: FunctionVariant,
+    targets: &mut FunctionTargetsHolder,
+) {
+    for callee in fun_env.get_called_functions() {
+        let callee_env = fun_env.module_env.env.get_function(callee);
+        if !callee_env.is_opaque() {
+            mark_inlined(&callee_env, variant, targets);
+        }
+    }
+}

--- a/language/move-prover/bytecode/tests/spec_instrumentation/fun_spec.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/fun_spec.exp
@@ -172,28 +172,6 @@ fun Test::resource_with_old($t0|val: u64) {
 
 ============ after pipeline `spec_instrumentation` ================
 
-[variant baseline]
-fun Test::branching_result($t0|is_div: bool, $t1|a: u64, $t2|b: u64): u64 {
-     var $t3|tmp#$3: u64
-     var $t4: num
-  0: if ($t0) goto 3 else goto 1
-  1: label L1
-  2: goto 7
-  3: label L0
-  4: $t3 := /($t1, $t2)
-  5: on_abort goto 13 with $t4
-  6: goto 10
-  7: label L2
-  8: $t3 := *($t1, $t2)
-  9: on_abort goto 13 with $t4
- 10: label L3
- 11: label L4
- 12: return $t3
- 13: label L5
- 14: abort($t4)
-}
-
-
 [variant verification]
 fun Test::branching_result($t0|is_div: bool, $t1|a: u64, $t2|b: u64): u64 {
      var $t3|tmp#$3: u64
@@ -223,32 +201,6 @@ fun Test::branching_result($t0|is_div: bool, $t1|a: u64, $t2|b: u64): u64 {
      # VC: `function aborts under this condition but with the wrong code` at tests/spec_instrumentation/fun_spec.move:27:38+17
  18: assert Implies(And($t0, Eq<u64>($t2, 0)), Eq($t4, -1))
  19: abort($t4)
-}
-
-
-[variant baseline]
-fun Test::implicit_and_explicit_abort($t0|a: u64, $t1|b: u64): u64 {
-     var $t2: u64
-     var $t3: bool
-     var $t4: u64
-     var $t5: num
-     var $t6: u64
-  0: $t2 := 0
-  1: $t3 := !=($t1, $t2)
-  2: if ($t3) goto 5 else goto 3
-  3: label L1
-  4: goto 9
-  5: label L0
-  6: $t4 := 22
-  7: $t5 := move($t4)
-  8: goto 14
-  9: label L2
- 10: $t6 := /($t0, $t1)
- 11: on_abort goto 14 with $t5
- 12: label L3
- 13: return $t6
- 14: label L4
- 15: abort($t5)
 }
 
 
@@ -288,22 +240,6 @@ fun Test::implicit_and_explicit_abort($t0|a: u64, $t1|b: u64): u64 {
 }
 
 
-[variant baseline]
-fun Test::multiple_results($t0|a: u64, $t1|b: u64): (u64, u64) {
-     var $t2: u64
-     var $t3: num
-     var $t4: u64
-  0: $t2 := /($t0, $t1)
-  1: on_abort goto 6 with $t3
-  2: $t4 := %($t0, $t1)
-  3: on_abort goto 6 with $t3
-  4: label L1
-  5: return ($t2, $t4)
-  6: label L2
-  7: abort($t3)
-}
-
-
 [variant verification]
 fun Test::multiple_results($t0|a: u64, $t1|b: u64): (u64, u64) {
      var $t2: u64
@@ -327,35 +263,6 @@ fun Test::multiple_results($t0|a: u64, $t1|b: u64): (u64, u64) {
      # VC: `function aborts under this condition but with the wrong code` at tests/spec_instrumentation/fun_spec.move:18:28+17
  11: assert Implies(Eq<u64>($t1, 0), Eq($t3, -1))
  12: abort($t3)
-}
-
-
-[variant baseline]
-fun Test::mut_ref_param($t0|r: Test::R): (u64, Test::R) {
-     var $t1|x: u64
-     var $t2: Test::R
-     var $t3: &mut Test::R
-     var $t4: u64
-     var $t5: u64
-     var $t6: u64
-     var $t7: u64
-     var $t8: num
-     var $t9: &mut u64
-  0: $t2 := move($t0)
-  1: $t3 := borrow_local($t2)
-  2: $t4 := get_field<Test::R>.v($t3)
-  3: $t5 := get_field<Test::R>.v($t3)
-  4: $t6 := 1
-  5: $t7 := -($t5, $t6)
-  6: on_abort goto 13 with $t8
-  7: $t9 := borrow_field<Test::R>.v($t3)
-  8: write_ref($t9, $t7)
-  9: write_back[Reference($t3)]($t9)
- 10: write_back[LocalRoot($t2)]($t3)
- 11: label L1
- 12: return ($t4, $t2)
- 13: label L2
- 14: abort($t8)
 }
 
 
@@ -398,15 +305,6 @@ fun Test::mut_ref_param($t0|r: Test::R): (u64, Test::R) {
 }
 
 
-[variant baseline]
-fun Test::ref_param($t0|r: Test::R): u64 {
-     var $t1: u64
-  0: $t1 := get_field<Test::R>.v($t0)
-  1: label L1
-  2: return $t1
-}
-
-
 [variant verification]
 fun Test::ref_param($t0|r: Test::R): u64 {
      var $t1: u64
@@ -418,15 +316,6 @@ fun Test::ref_param($t0|r: Test::R): u64 {
 }
 
 
-[variant baseline]
-fun Test::ref_param_return_ref($t0|r: Test::R): u64 {
-     var $t1: u64
-  0: $t1 := get_field<Test::R>.v($t0)
-  1: label L1
-  2: return $t1
-}
-
-
 [variant verification]
 fun Test::ref_param_return_ref($t0|r: Test::R): u64 {
      var $t1: u64
@@ -435,47 +324,6 @@ fun Test::ref_param_return_ref($t0|r: Test::R): u64 {
      # VC: `post-condition does not hold` at tests/spec_instrumentation/fun_spec.move:58:6+22
   2: assert Eq<u64>($t1, select Test::R.v($t0))
   3: return $t1
-}
-
-
-[variant baseline]
-fun Test::resource_with_old($t0|val: u64) {
-     var $t1|r: &mut Test::R
-     var $t2: address
-     var $t3: bool
-     var $t4: bool
-     var $t5: u64
-     var $t6: num
-     var $t7: address
-     var $t8: u64
-     var $t9: u64
-     var $t10: &mut u64
-  0: assume Gt($t0, 0)
-  1: $t2 := 0x0
-  2: $t3 := exists<Test::R>($t2)
-  3: $t4 := !($t3)
-  4: if ($t4) goto 7 else goto 5
-  5: label L1
-  6: goto 11
-  7: label L0
-  8: $t5 := 33
-  9: $t6 := move($t5)
- 10: goto 24
- 11: label L2
- 12: $t7 := 0x0
- 13: $t1 := borrow_global<Test::R>($t7)
- 14: on_abort goto 24 with $t6
- 15: $t8 := get_field<Test::R>.v($t1)
- 16: $t9 := +($t8, $t0)
- 17: on_abort goto 24 with $t6
- 18: $t10 := borrow_field<Test::R>.v($t1)
- 19: write_ref($t10, $t9)
- 20: write_back[Reference($t1)]($t10)
- 21: write_back[Test::R]($t1)
- 22: label L3
- 23: return ()
- 24: label L4
- 25: abort($t6)
 }
 
 

--- a/language/move-prover/bytecode/tests/spec_instrumentation/modifies.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/modifies.exp
@@ -167,33 +167,13 @@ pub fun B::mutate_at_test_incorrect($t0|addr1: address, $t1|addr2: address) {
 
 ============ after pipeline `spec_instrumentation` ================
 
-[variant baseline]
-pub fun A::mutate_at($t0|addr: address) {
-     var $t1|s: &mut A::S
-     var $t2: num
-     var $t3: u64
-     var $t4: &mut u64
-  0: $t1 := borrow_global<A::S>($t0)
-  1: on_abort goto 9 with $t2
-  2: $t3 := 2
-  3: $t4 := borrow_field<A::S>.x($t1)
-  4: write_ref($t4, $t3)
-  5: write_back[Reference($t1)]($t4)
-  6: write_back[A::S]($t1)
-  7: label L1
-  8: return ()
-  9: label L2
- 10: abort($t2)
-}
-
-
 [variant verification]
 pub fun A::mutate_at($t0|addr: address) {
      var $t1|s: &mut A::S
      var $t2: num
      var $t3: u64
      var $t4: &mut u64
-  0: @2 := save_mem(A::S)
+  0: @1 := save_mem(A::S)
      # VC: `caller does not have permission to modify `A::S` at given address` at tests/spec_instrumentation/modifies.move:18:17+17
   1: assert CanModify<A::S>($t0)
   2: $t1 := borrow_global<A::S>($t0)
@@ -205,29 +185,14 @@ pub fun A::mutate_at($t0|addr: address) {
   8: write_back[A::S]($t1)
   9: label L1
      # VC: `function does not abort under this condition` at tests/spec_instrumentation/modifies.move:24:9+27
- 10: assert Not(Not(exists[@2]<A::S>($t0)))
+ 10: assert Not(Not(exists[@1]<A::S>($t0)))
      # VC: `post-condition does not hold` at tests/spec_instrumentation/modifies.move:23:9+31
  11: assert Eq<u64>(select A::S.x(global<A::S>($t0)), 2)
  12: return ()
  13: label L2
      # VC: `abort not covered by any of the `aborts_if` clauses` at tests/spec_instrumentation/modifies.move:17:5+115
- 14: assert Not(exists[@2]<A::S>($t0))
+ 14: assert Not(exists[@1]<A::S>($t0))
  15: abort($t2)
-}
-
-
-[variant baseline]
-pub fun A::read_at($t0|addr: address): u64 {
-     var $t1|s: A::S
-     var $t2: num
-     var $t3: u64
-  0: $t1 := get_global<A::S>($t0)
-  1: on_abort goto 5 with $t2
-  2: $t3 := get_field<A::S>.x($t1)
-  3: label L1
-  4: return $t3
-  5: label L2
-  6: abort($t2)
 }
 
 
@@ -253,36 +218,6 @@ pub fun A::read_at($t0|addr: address): u64 {
 }
 
 
-[variant baseline]
-pub fun B::move_from_test_incorrect($t0|addr1: address, $t1|addr2: address): B::T {
-     var $t2|v: B::T
-     var $t3|x0: u64
-     var $t4|x1: u64
-     var $t5: bool
-     var $t6: num
-     var $t7: bool
-     # original call of opaque function: $t3 := A::read_at($t6)
-  0: @14 := save_mem(A::S)
-  1: assume Eq($t5, Not(exists[@14]<A::S>($t1)))
-  2: if ($t5) goto 15 else goto 3
-  3: label L3
-  4: assume Eq<u64>($t3, select A::S.x(global<A::S>($t1)))
-  5: $t2 := move_from<B::T>($t0)
-  6: on_abort goto 15 with $t6
-     # original call of opaque function: $t4 := A::read_at($t6)
-  7: @15 := save_mem(A::S)
-  8: assume Eq($t7, Not(exists[@15]<A::S>($t1)))
-  9: if ($t7) goto 15 else goto 10
- 10: label L4
- 11: assume Eq<u64>($t4, select A::S.x(global<A::S>($t1)))
- 12: assert Eq<u64>($t3, $t4)
- 13: label L1
- 14: return $t2
- 15: label L2
- 16: abort($t6)
-}
-
-
 [variant verification]
 pub fun B::move_from_test_incorrect($t0|addr1: address, $t1|addr2: address): B::T {
      var $t2|v: B::T
@@ -292,8 +227,8 @@ pub fun B::move_from_test_incorrect($t0|addr1: address, $t1|addr2: address): B::
      var $t6: num
      var $t7: bool
      # original call of opaque function: $t3 := A::read_at($t6)
-  0: @12 := save_mem(A::S)
-  1: assume Eq($t5, Not(exists[@12]<A::S>($t1)))
+  0: @6 := save_mem(A::S)
+  1: assume Eq($t5, Not(exists[@6]<A::S>($t1)))
   2: if ($t5) goto 16 else goto 3
   3: label L3
   4: assume Eq<u64>($t3, select A::S.x(global<A::S>($t1)))
@@ -302,8 +237,8 @@ pub fun B::move_from_test_incorrect($t0|addr1: address, $t1|addr2: address): B::
   6: $t2 := move_from<B::T>($t0)
   7: on_abort goto 16 with $t6
      # original call of opaque function: $t4 := A::read_at($t6)
-  8: @13 := save_mem(A::S)
-  9: assume Eq($t7, Not(exists[@13]<A::S>($t1)))
+  8: @7 := save_mem(A::S)
+  9: assume Eq($t7, Not(exists[@7]<A::S>($t1)))
  10: if ($t7) goto 16 else goto 11
  11: label L4
  12: assume Eq<u64>($t4, select A::S.x(global<A::S>($t1)))
@@ -315,39 +250,6 @@ pub fun B::move_from_test_incorrect($t0|addr1: address, $t1|addr2: address): B::
 }
 
 
-[variant baseline]
-pub fun B::move_to_test_incorrect($t0|account: signer, $t1|addr2: address) {
-     var $t2|x0: u64
-     var $t3|x1: u64
-     var $t4: bool
-     var $t5: u64
-     var $t6: B::T
-     var $t7: num
-     var $t8: bool
-     # original call of opaque function: $t2 := A::read_at($t5)
-  0: @10 := save_mem(A::S)
-  1: assume Eq($t4, Not(exists[@10]<A::S>($t1)))
-  2: if ($t4) goto 17 else goto 3
-  3: label L3
-  4: assume Eq<u64>($t2, select A::S.x(global<A::S>($t1)))
-  5: $t5 := 2
-  6: $t6 := pack B::T($t5)
-  7: move_to<B::T>($t6, $t0)
-  8: on_abort goto 17 with $t7
-     # original call of opaque function: $t3 := A::read_at($t5)
-  9: @11 := save_mem(A::S)
- 10: assume Eq($t8, Not(exists[@11]<A::S>($t1)))
- 11: if ($t8) goto 17 else goto 12
- 12: label L4
- 13: assume Eq<u64>($t3, select A::S.x(global<A::S>($t1)))
- 14: assert Eq<u64>($t2, $t3)
- 15: label L1
- 16: return ()
- 17: label L2
- 18: abort($t7)
-}
-
-
 [variant verification]
 pub fun B::move_to_test_incorrect($t0|account: signer, $t1|addr2: address) {
      var $t2|x0: u64
@@ -358,8 +260,8 @@ pub fun B::move_to_test_incorrect($t0|account: signer, $t1|addr2: address) {
      var $t7: num
      var $t8: bool
      # original call of opaque function: $t2 := A::read_at($t5)
-  0: @8 := save_mem(A::S)
-  1: assume Eq($t4, Not(exists[@8]<A::S>($t1)))
+  0: @4 := save_mem(A::S)
+  1: assume Eq($t4, Not(exists[@4]<A::S>($t1)))
   2: if ($t4) goto 18 else goto 3
   3: label L3
   4: assume Eq<u64>($t2, select A::S.x(global<A::S>($t1)))
@@ -370,8 +272,8 @@ pub fun B::move_to_test_incorrect($t0|account: signer, $t1|addr2: address) {
   8: move_to<B::T>($t6, $t0)
   9: on_abort goto 18 with $t7
      # original call of opaque function: $t3 := A::read_at($t5)
- 10: @9 := save_mem(A::S)
- 11: assume Eq($t8, Not(exists[@9]<A::S>($t1)))
+ 10: @5 := save_mem(A::S)
+ 11: assume Eq($t8, Not(exists[@5]<A::S>($t1)))
  12: if ($t8) goto 18 else goto 13
  13: label L4
  14: assume Eq<u64>($t3, select A::S.x(global<A::S>($t1)))
@@ -383,43 +285,6 @@ pub fun B::move_to_test_incorrect($t0|account: signer, $t1|addr2: address) {
 }
 
 
-[variant baseline]
-pub fun B::mutate_S_test1_incorrect($t0|addr1: address, $t1|addr2: address) {
-     var $t2|x0: u64
-     var $t3|x1: u64
-     var $t4: bool
-     var $t5: bool
-     var $t6: bool
-     var $t7: num
-  0: assume Neq<address>($t0, $t1)
-     # original call of opaque function: $t2 := A::read_at($t5)
-  1: @25 := save_mem(A::S)
-  2: assume Eq($t4, Not(exists[@25]<A::S>($t1)))
-  3: if ($t4) goto 20 else goto 4
-  4: label L3
-  5: assume Eq<u64>($t2, select A::S.x(global<A::S>($t1)))
-     # original call of opaque function: A::mutate_at($t4)
-  6: @26 := save_mem(A::S)
-     # VC: `caller does not have permission to modify `A::S` at given address` at tests/spec_instrumentation/modifies.move:79:12+9
-  7: modifies global<A::S>($t0)
-  8: assume Eq($t5, Not(exists[@26]<A::S>($t0)))
-  9: if ($t5) goto 20 else goto 10
- 10: label L4
- 11: assume Eq<u64>(select A::S.x(global<A::S>($t0)), 2)
-     # original call of opaque function: $t3 := A::read_at($t5)
- 12: @27 := save_mem(A::S)
- 13: assume Eq($t6, Not(exists[@27]<A::S>($t1)))
- 14: if ($t6) goto 20 else goto 15
- 15: label L5
- 16: assume Eq<u64>($t3, select A::S.x(global<A::S>($t1)))
- 17: assert Eq<u64>($t2, $t3)
- 18: label L1
- 19: return ()
- 20: label L2
- 21: abort($t7)
-}
-
-
 [variant verification]
 pub fun B::mutate_S_test1_incorrect($t0|addr1: address, $t1|addr2: address) {
      var $t2|x0: u64
@@ -430,23 +295,23 @@ pub fun B::mutate_S_test1_incorrect($t0|addr1: address, $t1|addr2: address) {
      var $t7: num
   0: assume Neq<address>($t0, $t1)
      # original call of opaque function: $t2 := A::read_at($t5)
-  1: @22 := save_mem(A::S)
-  2: assume Eq($t4, Not(exists[@22]<A::S>($t1)))
+  1: @11 := save_mem(A::S)
+  2: assume Eq($t4, Not(exists[@11]<A::S>($t1)))
   3: if ($t4) goto 21 else goto 4
   4: label L3
   5: assume Eq<u64>($t2, select A::S.x(global<A::S>($t1)))
      # original call of opaque function: A::mutate_at($t4)
      # VC: `caller does not have permission to modify `A::S` at given address` at tests/spec_instrumentation/modifies.move:79:12+9
   6: assert CanModify<A::S>($t0)
-  7: @23 := save_mem(A::S)
+  7: @12 := save_mem(A::S)
   8: modifies global<A::S>($t0)
-  9: assume Eq($t5, Not(exists[@23]<A::S>($t0)))
+  9: assume Eq($t5, Not(exists[@12]<A::S>($t0)))
  10: if ($t5) goto 21 else goto 11
  11: label L4
  12: assume Eq<u64>(select A::S.x(global<A::S>($t0)), 2)
      # original call of opaque function: $t3 := A::read_at($t5)
- 13: @24 := save_mem(A::S)
- 14: assume Eq($t6, Not(exists[@24]<A::S>($t1)))
+ 13: @13 := save_mem(A::S)
+ 14: assume Eq($t6, Not(exists[@13]<A::S>($t1)))
  15: if ($t6) goto 21 else goto 16
  16: label L5
  17: assume Eq<u64>($t3, select A::S.x(global<A::S>($t1)))
@@ -458,42 +323,6 @@ pub fun B::mutate_S_test1_incorrect($t0|addr1: address, $t1|addr2: address) {
 }
 
 
-[variant baseline]
-pub fun B::mutate_S_test2_incorrect($t0|addr: address) {
-     var $t1|x0: u64
-     var $t2|x1: u64
-     var $t3: bool
-     var $t4: bool
-     var $t5: bool
-     var $t6: num
-     # original call of opaque function: $t1 := A::read_at($t3)
-  0: @19 := save_mem(A::S)
-  1: assume Eq($t3, Not(exists[@19]<A::S>($t0)))
-  2: if ($t3) goto 19 else goto 3
-  3: label L3
-  4: assume Eq<u64>($t1, select A::S.x(global<A::S>($t0)))
-     # original call of opaque function: A::mutate_at($t3)
-  5: @20 := save_mem(A::S)
-     # VC: `caller does not have permission to modify `A::S` at given address` at tests/spec_instrumentation/modifies.move:92:12+9
-  6: modifies global<A::S>($t0)
-  7: assume Eq($t4, Not(exists[@20]<A::S>($t0)))
-  8: if ($t4) goto 19 else goto 9
-  9: label L4
- 10: assume Eq<u64>(select A::S.x(global<A::S>($t0)), 2)
-     # original call of opaque function: $t2 := A::read_at($t3)
- 11: @21 := save_mem(A::S)
- 12: assume Eq($t5, Not(exists[@21]<A::S>($t0)))
- 13: if ($t5) goto 19 else goto 14
- 14: label L5
- 15: assume Eq<u64>($t2, select A::S.x(global<A::S>($t0)))
- 16: assert Eq<u64>($t1, $t2)
- 17: label L1
- 18: return ()
- 19: label L2
- 20: abort($t6)
-}
-
-
 [variant verification]
 pub fun B::mutate_S_test2_incorrect($t0|addr: address) {
      var $t1|x0: u64
@@ -503,23 +332,23 @@ pub fun B::mutate_S_test2_incorrect($t0|addr: address) {
      var $t5: bool
      var $t6: num
      # original call of opaque function: $t1 := A::read_at($t3)
-  0: @16 := save_mem(A::S)
-  1: assume Eq($t3, Not(exists[@16]<A::S>($t0)))
+  0: @8 := save_mem(A::S)
+  1: assume Eq($t3, Not(exists[@8]<A::S>($t0)))
   2: if ($t3) goto 20 else goto 3
   3: label L3
   4: assume Eq<u64>($t1, select A::S.x(global<A::S>($t0)))
      # original call of opaque function: A::mutate_at($t3)
      # VC: `caller does not have permission to modify `A::S` at given address` at tests/spec_instrumentation/modifies.move:92:12+9
   5: assert CanModify<A::S>($t0)
-  6: @17 := save_mem(A::S)
+  6: @9 := save_mem(A::S)
   7: modifies global<A::S>($t0)
-  8: assume Eq($t4, Not(exists[@17]<A::S>($t0)))
+  8: assume Eq($t4, Not(exists[@9]<A::S>($t0)))
   9: if ($t4) goto 20 else goto 10
  10: label L4
  11: assume Eq<u64>(select A::S.x(global<A::S>($t0)), 2)
      # original call of opaque function: $t2 := A::read_at($t3)
- 12: @18 := save_mem(A::S)
- 13: assume Eq($t5, Not(exists[@18]<A::S>($t0)))
+ 12: @10 := save_mem(A::S)
+ 13: assume Eq($t5, Not(exists[@10]<A::S>($t0)))
  14: if ($t5) goto 20 else goto 15
  15: label L5
  16: assume Eq<u64>($t2, select A::S.x(global<A::S>($t0)))
@@ -531,43 +360,6 @@ pub fun B::mutate_S_test2_incorrect($t0|addr: address) {
 }
 
 
-[variant baseline]
-pub fun B::mutate_at_test_incorrect($t0|addr1: address, $t1|addr2: address) {
-     var $t2|t: &mut B::T
-     var $t3|x0: u64
-     var $t4|x1: u64
-     var $t5: bool
-     var $t6: num
-     var $t7: u64
-     var $t8: &mut u64
-     var $t9: bool
-     # original call of opaque function: $t3 := A::read_at($t6)
-  0: @6 := save_mem(A::S)
-  1: assume Eq($t5, Not(exists[@6]<A::S>($t1)))
-  2: if ($t5) goto 20 else goto 3
-  3: label L3
-  4: assume Eq<u64>($t3, select A::S.x(global<A::S>($t1)))
-  5: $t2 := borrow_global<B::T>($t0)
-  6: on_abort goto 20 with $t6
-  7: $t7 := 2
-  8: $t8 := borrow_field<B::T>.x($t2)
-  9: write_ref($t8, $t7)
- 10: write_back[Reference($t2)]($t8)
- 11: write_back[B::T]($t2)
-     # original call of opaque function: $t4 := A::read_at($t6)
- 12: @7 := save_mem(A::S)
- 13: assume Eq($t9, Not(exists[@7]<A::S>($t1)))
- 14: if ($t9) goto 20 else goto 15
- 15: label L4
- 16: assume Eq<u64>($t4, select A::S.x(global<A::S>($t1)))
- 17: assert Eq<u64>($t3, $t4)
- 18: label L1
- 19: return ()
- 20: label L2
- 21: abort($t6)
-}
-
-
 [variant verification]
 pub fun B::mutate_at_test_incorrect($t0|addr1: address, $t1|addr2: address) {
      var $t2|t: &mut B::T
@@ -579,8 +371,8 @@ pub fun B::mutate_at_test_incorrect($t0|addr1: address, $t1|addr2: address) {
      var $t8: &mut u64
      var $t9: bool
      # original call of opaque function: $t3 := A::read_at($t6)
-  0: @4 := save_mem(A::S)
-  1: assume Eq($t5, Not(exists[@4]<A::S>($t1)))
+  0: @2 := save_mem(A::S)
+  1: assume Eq($t5, Not(exists[@2]<A::S>($t1)))
   2: if ($t5) goto 21 else goto 3
   3: label L3
   4: assume Eq<u64>($t3, select A::S.x(global<A::S>($t1)))
@@ -594,8 +386,8 @@ pub fun B::mutate_at_test_incorrect($t0|addr1: address, $t1|addr2: address) {
  11: write_back[Reference($t2)]($t8)
  12: write_back[B::T]($t2)
      # original call of opaque function: $t4 := A::read_at($t6)
- 13: @5 := save_mem(A::S)
- 14: assume Eq($t9, Not(exists[@5]<A::S>($t1)))
+ 13: @3 := save_mem(A::S)
+ 14: assume Eq($t9, Not(exists[@3]<A::S>($t1)))
  15: if ($t9) goto 21 else goto 16
  16: label L4
  17: assume Eq<u64>($t4, select A::S.x(global<A::S>($t1)))

--- a/language/move-prover/bytecode/tests/spec_instrumentation/opaque_call.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/opaque_call.exp
@@ -68,49 +68,6 @@ fun Test::incr_twice() {
 
 ============ after pipeline `spec_instrumentation` ================
 
-[variant baseline]
-fun Test::get_and_incr($t0|addr: address): u64 {
-     var $t1|r: &mut Test::R
-     var $t2|v: u64
-     var $t3: bool
-     var $t4: bool
-     var $t5: u64
-     var $t6: num
-     var $t7: u64
-     var $t8: u64
-     var $t9: u64
-     var $t10: u64
-     var $t11: &mut u64
-     # VC: `precondition does not hold at this call` at tests/spec_instrumentation/opaque_call.move:15:6+21
-  0: assume Neq<address>($t0, 0)
-  1: $t3 := exists<Test::R>($t0)
-  2: $t4 := !($t3)
-  3: if ($t4) goto 6 else goto 4
-  4: label L1
-  5: goto 10
-  6: label L0
-  7: $t5 := 33
-  8: $t6 := move($t5)
-  9: goto 24
- 10: label L2
- 11: $t1 := borrow_global<Test::R>($t0)
- 12: on_abort goto 24 with $t6
- 13: $t7 := get_field<Test::R>.v($t1)
- 14: $t8 := get_field<Test::R>.v($t1)
- 15: $t9 := 1
- 16: $t10 := +($t8, $t9)
- 17: on_abort goto 24 with $t6
- 18: $t11 := borrow_field<Test::R>.v($t1)
- 19: write_ref($t11, $t10)
- 20: write_back[Reference($t1)]($t11)
- 21: write_back[Test::R]($t1)
- 22: label L3
- 23: return $t7
- 24: label L4
- 25: abort($t6)
-}
-
-
 [variant verification]
 fun Test::get_and_incr($t0|addr: address): u64 {
      var $t1|r: &mut Test::R
@@ -169,44 +126,6 @@ fun Test::get_and_incr($t0|addr: address): u64 {
 }
 
 
-[variant baseline]
-fun Test::incr_twice() {
-     var $t0: address
-     var $t1: bool
-     var $t2: num
-     var $t3: u64
-     var $t4: address
-     var $t5: bool
-     var $t6: u64
-  0: $t0 := 0x1
-     # original call of opaque function: $t1 := Test::get_and_incr($t0)
-  1: assume Neq<address>($t0, 0)
-  2: @6 := save_mem(Test::R)
-  3: modifies global<Test::R>($t0)
-  4: assume Eq($t1, And(Or(Not(exists[@6]<Test::R>($t0)), Ge(Add(select Test::R.v(global[@6]<Test::R>($t0)), 1), 18446744073709551615)), Implies(Not(exists[@6]<Test::R>($t0)), Eq($t2, 33))))
-  5: if ($t1) goto 22 else goto 6
-  6: label L3
-  7: assume Eq<u64>(select Test::R.v(global<Test::R>($t0)), Add(select Test::R.v(global[@6]<Test::R>($t0)), 1))
-  8: assume Eq<u64>($t3, select Test::R.v(global<Test::R>($t0)))
-  9: destroy($t3)
- 10: $t4 := 0x1
-     # original call of opaque function: $t3 := Test::get_and_incr($t2)
- 11: assume Neq<address>($t0, 0)
- 12: @7 := save_mem(Test::R)
- 13: modifies global<Test::R>($t4)
- 14: assume Eq($t5, And(Or(Not(exists[@7]<Test::R>($t4)), Ge(Add(select Test::R.v(global[@7]<Test::R>($t4)), 1), 18446744073709551615)), Implies(Not(exists[@7]<Test::R>($t4)), Eq($t2, 33))))
- 15: if ($t5) goto 22 else goto 16
- 16: label L4
- 17: assume Eq<u64>(select Test::R.v(global<Test::R>($t4)), Add(select Test::R.v(global[@7]<Test::R>($t4)), 1))
- 18: assume Eq<u64>($t6, select Test::R.v(global<Test::R>($t4)))
- 19: destroy($t6)
- 20: label L1
- 21: return ()
- 22: label L2
- 23: abort($t2)
-}
-
-
 [variant verification]
 fun Test::incr_twice() {
      var $t0: address
@@ -216,40 +135,40 @@ fun Test::incr_twice() {
      var $t4: address
      var $t5: bool
      var $t6: u64
-  0: @2 := save_mem(Test::R)
+  0: @1 := save_mem(Test::R)
   1: $t0 := 0x1
      # original call of opaque function: $t1 := Test::get_and_incr($t0)
      # VC: `precondition does not hold at this call` at tests/spec_instrumentation/opaque_call.move:15:6+21
   2: assert Neq<address>($t0, 0)
-  3: @3 := save_mem(Test::R)
+  3: @2 := save_mem(Test::R)
   4: modifies global<Test::R>($t0)
-  5: assume Eq($t1, And(Or(Not(exists[@3]<Test::R>($t0)), Ge(Add(select Test::R.v(global[@3]<Test::R>($t0)), 1), 18446744073709551615)), Implies(Not(exists[@3]<Test::R>($t0)), Eq($t2, 33))))
+  5: assume Eq($t1, And(Or(Not(exists[@2]<Test::R>($t0)), Ge(Add(select Test::R.v(global[@2]<Test::R>($t0)), 1), 18446744073709551615)), Implies(Not(exists[@2]<Test::R>($t0)), Eq($t2, 33))))
   6: if ($t1) goto 25 else goto 7
   7: label L3
-  8: assume Eq<u64>(select Test::R.v(global<Test::R>($t0)), Add(select Test::R.v(global[@3]<Test::R>($t0)), 1))
+  8: assume Eq<u64>(select Test::R.v(global<Test::R>($t0)), Add(select Test::R.v(global[@2]<Test::R>($t0)), 1))
   9: assume Eq<u64>($t3, select Test::R.v(global<Test::R>($t0)))
  10: destroy($t3)
  11: $t4 := 0x1
      # original call of opaque function: $t3 := Test::get_and_incr($t2)
  12: assert Neq<address>($t0, 0)
- 13: @4 := save_mem(Test::R)
+ 13: @3 := save_mem(Test::R)
  14: modifies global<Test::R>($t4)
- 15: assume Eq($t5, And(Or(Not(exists[@4]<Test::R>($t4)), Ge(Add(select Test::R.v(global[@4]<Test::R>($t4)), 1), 18446744073709551615)), Implies(Not(exists[@4]<Test::R>($t4)), Eq($t2, 33))))
+ 15: assume Eq($t5, And(Or(Not(exists[@3]<Test::R>($t4)), Ge(Add(select Test::R.v(global[@3]<Test::R>($t4)), 1), 18446744073709551615)), Implies(Not(exists[@3]<Test::R>($t4)), Eq($t2, 33))))
  16: if ($t5) goto 25 else goto 17
  17: label L4
- 18: assume Eq<u64>(select Test::R.v(global<Test::R>($t4)), Add(select Test::R.v(global[@4]<Test::R>($t4)), 1))
+ 18: assume Eq<u64>(select Test::R.v(global<Test::R>($t4)), Add(select Test::R.v(global[@3]<Test::R>($t4)), 1))
  19: assume Eq<u64>($t6, select Test::R.v(global<Test::R>($t4)))
  20: destroy($t6)
  21: label L1
      # VC: `function does not abort under this condition` at tests/spec_instrumentation/opaque_call.move:28:6+34
- 22: assert Not(Not(exists[@2]<Test::R>(1)))
+ 22: assert Not(Not(exists[@1]<Test::R>(1)))
      # VC: `post-condition does not hold` at tests/spec_instrumentation/opaque_call.move:29:6+54
- 23: assert Eq<u64>(select Test::R.v(global<Test::R>(1)), Add(select Test::R.v(global[@2]<Test::R>(1)), 2))
+ 23: assert Eq<u64>(select Test::R.v(global<Test::R>(1)), Add(select Test::R.v(global[@1]<Test::R>(1)), 2))
  24: return ()
  25: label L2
      # VC: `abort not covered by any of the `aborts_if` clauses` at tests/spec_instrumentation/opaque_call.move:23:2+80
- 26: assert Not(exists[@2]<Test::R>(1))
+ 26: assert Not(exists[@1]<Test::R>(1))
      # VC: `function aborts under this condition but with the wrong code` at tests/spec_instrumentation/opaque_call.move:28:37+2
- 27: assert Implies(Not(exists[@2]<Test::R>(1)), Eq($t2, 33))
+ 27: assert Implies(Not(exists[@1]<Test::R>(1)), Eq($t2, 33))
  28: abort($t2)
 }

--- a/language/move-prover/bytecode/tests/testsuite.rs
+++ b/language/move-prover/bytecode/tests/testsuite.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 
 use codespan_reporting::term::termcolor::Buffer;
 
+use bytecode::options::ProverOptions;
 use bytecode::{
     borrow_analysis::BorrowAnalysisProcessor,
     clean_and_optimize::CleanAndOptimizeProcessor,

--- a/language/move-prover/bytecode/tests/testsuite.rs
+++ b/language/move-prover/bytecode/tests/testsuite.rs
@@ -6,7 +6,6 @@ use std::path::Path;
 
 use codespan_reporting::term::termcolor::Buffer;
 
-use bytecode::options::ProverOptions;
 use bytecode::{
     borrow_analysis::BorrowAnalysisProcessor,
     clean_and_optimize::CleanAndOptimizeProcessor,
@@ -18,7 +17,9 @@ use bytecode::{
     options::ProverOptions,
     print_targets_for_test,
     reaching_def_analysis::ReachingDefProcessor,
-    spec_instrumentation::SpecInstrumenter,
+    spec_instrumentation::SpecInstrumenterProcessor,
+    usage_analysis::UsageProcessor,
+    verification_analysis::VerificationAnalysisProcessor,
 };
 use move_model::{model::GlobalEnv, run_model_builder};
 use move_prover_test_utils::{baseline_test::verify_or_update_baseline, extract_test_directives};
@@ -93,7 +94,9 @@ fn get_tested_transformation_pipeline(
             pipeline.add_processor(BorrowAnalysisProcessor::new());
             pipeline.add_processor(MemoryInstrumentationProcessor::new());
             pipeline.add_processor(CleanAndOptimizeProcessor::new());
-            pipeline.add_processor(SpecInstrumenter::new());
+            pipeline.add_processor(UsageProcessor::new());
+            pipeline.add_processor(VerificationAnalysisProcessor::new());
+            pipeline.add_processor(SpecInstrumenterProcessor::new());
             Ok(Some(pipeline))
         }
 

--- a/language/move-prover/docgen/src/docgen.rs
+++ b/language/move-prover/docgen/src/docgen.rs
@@ -284,7 +284,7 @@ impl<'env> Docgen<'env> {
         // Generate documentation for standalone modules which are not included in the templates.
         for (id, info) in self.infos.clone() {
             let m = self.env.get_module(id);
-            if !info.is_included && !m.is_dependency() {
+            if !info.is_included && m.is_target() {
                 self.gen_module(&m, &info);
                 let mut path = PathBuf::from(&self.options.output_directory);
                 path.push(info.target_file);
@@ -444,7 +444,7 @@ impl<'env> Docgen<'env> {
                 m.get_name().display_full(m.symbol_pool()),
                 out_dir,
                 i.target_file,
-                if m.is_dependency() {
+                if !m.is_target() {
                     "exists"
                 } else {
                     "will be generated"
@@ -509,7 +509,7 @@ impl<'env> Docgen<'env> {
             .file_name()
             .expect("file name")
             .to_os_string();
-        if module_env.is_dependency() {
+        if !module_env.is_target() {
             // Try to locate the file in the provided search path.
             self.options.doc_path.iter().find_map(|dir| {
                 let mut path = PathBuf::from(dir);

--- a/language/move-prover/errmapgen/src/errmapgen.rs
+++ b/language/move-prover/errmapgen/src/errmapgen.rs
@@ -159,7 +159,7 @@ impl<'env> ErrmapGen<'env> {
 
     pub fn gen(&mut self) {
         for module in self.env.get_modules() {
-            if !module.is_script_module() && !module.is_dependency() {
+            if !module.is_script_module() && module.is_target() {
                 self.build_error_map(&module).unwrap()
             }
         }

--- a/language/move-prover/src/boogie_wrapper.rs
+++ b/language/move-prover/src/boogie_wrapper.rs
@@ -502,9 +502,7 @@ impl<'env> BoogieWrapper<'env> {
             _ => "",
         };
         if let Some(func_env) = self.env.get_enclosing_function(loc.clone()) {
-            let func_target = self
-                .targets
-                .get_target(&func_env, FunctionVariant::Baseline);
+            let func_target = self.targets.get_annotated_target(&func_env);
             let func_name = format!(
                 "{}",
                 func_target.get_name().display(func_target.symbol_pool())

--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -1622,10 +1622,9 @@ impl<'env> SpecTranslator<'env> {
             self.global_env()
                 .get_global_invariant(*id)
                 .map(|inv| {
-                    !self
-                        .global_env()
+                    self.global_env()
                         .get_module(inv.declaring_module)
-                        .is_dependency()
+                        .is_target()
                 })
                 .unwrap_or(true)
         };

--- a/language/move-prover/tests/sources/functional/ModifiesTypeTest.exp
+++ b/language/move-prover/tests/sources/functional/ModifiesTypeTest.exp
@@ -1,4 +1,4 @@
-Move prover returns: exiting with modifies checking errors
+Move prover returns: exiting with transformation errors
 error: caller `mutate_S_test1_incorrect` specifies modify targets for `A::S` but callee `mutate_at` does not
 
     ┌── tests/sources/functional/ModifiesTypeTest.move:29:5 ───

--- a/language/move-prover/tests/sources/functional/friend_error.exp
+++ b/language/move-prover/tests/sources/functional/friend_error.exp
@@ -1,12 +1,4 @@
-Move prover returns: exiting with analysis errors
-error: function `TestFriendError::f` is called by other functions while it can only be called by its friend M::some_other_fun
-
-   ┌── tests/sources/functional/friend_error.move:7:5 ───
-   │
- 7 │     public fun f() {}
-   │     ^^^^^^^^^^^^^^^^^
-   │
-
+Move prover returns: exiting with transformation errors
 error: function with a friend cannot be declared as opaque
 
     ┌── tests/sources/functional/friend_error.move:13:5 ───
@@ -22,3 +14,11 @@ error: function `TestFriendError::g` is called by other functions while it can o
  13 │     public fun g() {}
     │     ^^^^^^^^^^^^^^^^^
     │
+
+error: function `TestFriendError::f` is called by other functions while it can only be called by its friend M::some_other_fun
+
+   ┌── tests/sources/functional/friend_error.move:7:5 ───
+   │
+ 7 │     public fun f() {}
+   │     ^^^^^^^^^^^^^^^^^
+   │


### PR DESCRIPTION
This PR moves the analysis of what functions need to be verified in the presence of cross-module invariants into the transformation pipeline. This information is needed for the new SpecInstrumenter in the pipeline, but it was not available until now.

- Adds a new `verification_analysis.rs` step to the pipeline. This computes an annotation indicating whether a function is verified and/or whether it needs to be inlined because it is transitively called by a verified function. The implementations is derived from @emmazzz previous work on integrating this in the main prover's `lib.rs`.
- The new analysis replicates the old one, but also adds additional information regards whether a function is needed in it's inlined variant for verification (which is the case if it is transitively called from a verified function and is not opaque). The v2 compilation scheme exploits this and only generates Boogie for needed functions, which should drastically reduce the smt2lib output we pass to Z3.
- Also moves the `modifies` static analysis out of main prover's `lib.rs` and into spec instrumenter. The spec instrumenter decides what can be done for modifies at compile or runtime, so this is good place for this code.
- Extends generic pipeline infrastructure to be able to implement `initialize` and `finalize` trait functions, and other changes.
- Removes functionality from move-model for tracking verification info as this is now represented as an annotation.

Both new and old compilation scheme have been adopted to this change, which should be tested good by existing tests.

The major file to look at is `verification_analysis.rs`.

## Motivation

Prover refactoring.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests.

## Related PRs

NA
