### PR TITLE
[diem-vm] Clean up unused mut, refactored out the api for executing single transaction

### DIFF
--- a/language/diem-tools/transaction-replay/src/lib.rs
+++ b/language/diem-tools/transaction-replay/src/lib.rs
@@ -123,7 +123,7 @@ impl DiemDebugger {
         save_write_set: bool,
     ) -> Result<TransactionOutput> {
         let state_view = DebuggerStateView::new(&*self.debugger, version + 1);
-        let mut vm = DiemVM::new(&state_view);
+        let vm = DiemVM::new(&state_view);
         let cache = diem_vm::data_cache::StateViewCache::new(&state_view);
         let log_context = NoContextLog::new();
         let mut txn_data = diem_vm::transaction_metadata::TransactionMetadata::default();


### PR DESCRIPTION
…ingle transaction.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Currently there's a number of unused mutable references in the diem_vm. This PR cleans up the usused `mut` and also refactored out the api for executing single transaction. This would be useful for our future experiements of transaction parallel execution.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?
Yes

## Test Plan

Should be a clean refactor. Need to pass all existing CIs.
