### PR TITLE
[State Sync] Remove the pending_li_queue and use a single highest target for full node sync.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -12,9 +12,6 @@ pub struct StateSyncConfig {
     pub long_poll_timeout_ms: u64,
     // valid maximum chunk limit for sanity check
     pub max_chunk_limit: u64,
-    // max number of pending ledger info's to keep in memory
-    // This is to prevent OOM
-    pub max_pending_li_limit: usize,
     // valid maximum timeout limit for sanity check
     pub max_timeout_ms: u64,
     // default timeout to make state sync progress by sending chunk requests to a certain number of networks
@@ -34,7 +31,6 @@ impl Default for StateSyncConfig {
             chunk_limit: 1000,
             long_poll_timeout_ms: 10_000,
             max_chunk_limit: 1000,
-            max_pending_li_limit: 1000,
             max_timeout_ms: 120_000,
             multicast_timeout_ms: 30_000,
             sync_request_timeout_ms: 60_000,

--- a/state-sync/src/counters.rs
+++ b/state-sync/src/counters.rs
@@ -49,6 +49,10 @@ pub fn set_version(version_type: VersionType, version: u64) {
         .set(version as i64)
 }
 
+pub fn get_version(version_type: VersionType) -> u64 {
+    VERSION.with_label_values(&[version_type.as_str()]).get() as u64
+}
+
 pub enum VersionType {
     /// Version of latest ledger info committed.
     Committed,

--- a/state-sync/tests/integration_tests.rs
+++ b/state-sync/tests/integration_tests.rs
@@ -6,7 +6,7 @@ use crate::test_harness::{
 };
 use anyhow::{bail, Result};
 use diem_config::config::RoleType;
-use diem_types::{transaction::TransactionListWithProof, waypoint::Waypoint};
+use diem_types::{transaction::TransactionListWithProof, waypoint::Waypoint, PeerId};
 use netcore::transport::ConnectionOrigin::*;
 use network::protocols::direct_send::Message;
 use state_sync::network::StateSyncMessage;
@@ -296,21 +296,14 @@ fn test_lagging_upstream_long_poll() {
     drop(fullnode_1);
 
     // Validator and fullnode discover each other
-    env.send_peer_event(fullnode_0_peer_id_vfn, validator_0_peer_id, true, Inbound);
-    env.send_peer_event(validator_0_peer_id, fullnode_0_peer_id_vfn, true, Outbound);
+    send_connection_notifications(&mut env, validator_0_peer_id, fullnode_0_peer_id_vfn, true);
 
     // Fullnodes discover each other
-    env.send_peer_event(
-        fullnode_0_peer_id_pfn,
-        fullnode_1_peer_id_pfn,
-        true,
-        Inbound,
-    );
-    env.send_peer_event(
+    send_connection_notifications(
+        &mut env,
         fullnode_1_peer_id_pfn,
         fullnode_0_peer_id_pfn,
         true,
-        Outbound,
     );
 
     // Deliver messages and verify versions and targets
@@ -321,9 +314,7 @@ fn test_lagging_upstream_long_poll() {
     env.get_state_sync_peer(2).wait_for_version(250, None);
 
     // Validator loses fullnode
-    env.send_peer_event(fullnode_0_peer_id_vfn, validator_0_peer_id, false, Inbound);
-    // Fullnode loses validator
-    env.send_peer_event(validator_0_peer_id, fullnode_0_peer_id_vfn, false, Outbound);
+    send_connection_notifications(&mut env, validator_0_peer_id, fullnode_0_peer_id_vfn, false);
 
     // Fullnode sends chunk request to other fullnode
     let (_, message) = env.deliver_msg(fullnode_0_peer_id_pfn);
@@ -335,10 +326,7 @@ fn test_lagging_upstream_long_poll() {
     env.get_state_sync_peer(3).wait_for_version(500, Some(500));
 
     // Connect the validator and the failover fullnode so the fullnode can sync.
-    // Validator discovers fullnode
-    env.send_peer_event(fullnode_1_peer_id_vfn, validator_0_peer_id, true, Inbound);
-    // Fullnode discovers validator
-    env.send_peer_event(validator_0_peer_id, fullnode_1_peer_id_vfn, true, Outbound);
+    send_connection_notifications(&mut env, validator_0_peer_id, fullnode_1_peer_id_vfn, true);
 
     // Trigger another commit so that the fullnodes's commit will trigger subscription delivery
     env.get_state_sync_peer(0).commit(600);
@@ -373,8 +361,7 @@ fn test_fullnode_catch_up_moving_target_epochs() {
     let fullnode_peer_id = env.get_state_sync_peer(1).get_peer_id(VFN_NETWORK.clone());
 
     // Validator and fullnode discover each other.
-    env.send_peer_event(fullnode_peer_id, validator_peer_id, true, Inbound);
-    env.send_peer_event(validator_peer_id, fullnode_peer_id, true, Outbound);
+    send_connection_notifications(&mut env, validator_peer_id, fullnode_peer_id, true);
 
     // Versions to be committed by the validator
     let commit_versions = vec![
@@ -447,8 +434,7 @@ fn test_fullnode_catch_up_moving_target() {
     let fullnode_peer_id = env.get_state_sync_peer(1).get_peer_id(VFN_NETWORK.clone());
 
     // Validator and fullnode discover each other.
-    env.send_peer_event(fullnode_peer_id, validator_peer_id, true, Inbound);
-    env.send_peer_event(validator_peer_id, fullnode_peer_id, true, Outbound);
+    send_connection_notifications(&mut env, validator_peer_id, fullnode_peer_id, true);
 
     // Expected fullnode sync states (i.e., synced version and committed version)
     let expected_states = vec![
@@ -532,18 +518,14 @@ fn test_fn_failover() {
     drop(fullnode_2);
     drop(fullnode_3);
 
-    // vfn network:
-    // validator discovers fn_0
-    env.send_peer_event(fn_0_vfn_peer_id, validator_peer_id, true, Inbound);
-    // fn_0 discovers validator
-    env.send_peer_event(validator_peer_id, fn_0_vfn_peer_id, true, Outbound);
+    // Validator discovers fullnode 0
+    send_connection_notifications(&mut env, validator_peer_id, fn_0_vfn_peer_id, true);
 
     // public network:
     // fn_0 sends new peer event to all its upstream public peers
     let upstream_peer_ids = [fn_1_peer_id, fn_2_peer_id, fn_3_peer_id];
     for peer in upstream_peer_ids.iter() {
-        env.send_peer_event(fn_0_public_peer_id, *peer, true, Inbound);
-        env.send_peer_event(*peer, fn_0_public_peer_id, true, Outbound);
+        send_connection_notifications(&mut env, *peer, fn_0_public_peer_id, true);
     }
 
     // commit some txns on v
@@ -565,9 +547,8 @@ fn test_fn_failover() {
         }
     }
 
-    // bring down v
-    env.send_peer_event(fn_0_vfn_peer_id, validator_peer_id, false, Inbound);
-    env.send_peer_event(validator_peer_id, fn_0_vfn_peer_id, false, Outbound);
+    // Bring down the validator connection to fullnode 0
+    send_connection_notifications(&mut env, validator_peer_id, fn_0_vfn_peer_id, false);
 
     // deliver chunk response to fn_0 after the lost peer event
     // so that the next chunk request is guaranteed to be sent after the lost peer event
@@ -593,14 +574,11 @@ fn test_fn_failover() {
         }
     }
 
-    // bring down two public fallback
-    // disconnect fn_1 and fn_0
-    env.send_peer_event(fn_0_public_peer_id, fn_1_peer_id, false, Inbound);
-    env.send_peer_event(fn_1_peer_id, fn_0_public_peer_id, false, Outbound);
+    // Disconnect fullnode 1 and fullnode 0
+    send_connection_notifications(&mut env, fn_1_peer_id, fn_0_public_peer_id, false);
 
-    // disconnect fn_2 and fn_0
-    env.send_peer_event(fn_0_public_peer_id, fn_2_peer_id, false, Inbound);
-    env.send_peer_event(fn_2_peer_id, fn_0_public_peer_id, false, Outbound);
+    // Disconnect fullnode 2 and fullnode 0
+    send_connection_notifications(&mut env, fn_2_peer_id, fn_0_public_peer_id, false);
 
     // deliver chunk response to fn_0 after the lost peer events
     // so that the next chunk request is guaranteed to be sent after the lost peer events
@@ -624,10 +602,8 @@ fn test_fn_failover() {
         }
     }
 
-    // bring down everyone
-    // disconnect fn_3 and fn_0
-    env.send_peer_event(fn_3_peer_id, fn_0_public_peer_id, false, Outbound);
-    env.send_peer_event(fn_0_public_peer_id, fn_3_peer_id, false, Inbound);
+    // Disconnect fullnode 3 and fullnode 0
+    send_connection_notifications(&mut env, fn_3_peer_id, fn_0_public_peer_id, false);
 
     // deliver chunk response to fn_0 after the lost peer events
     // so that the next chunk request is guaranteed to be sent after the lost peer events
@@ -638,9 +614,8 @@ fn test_fn_failover() {
     env.assert_no_message_sent(fn_0_vfn_peer_id);
     env.assert_no_message_sent(fn_0_public_peer_id);
 
-    // bring back one fallback (fn_2)
-    env.send_peer_event(fn_2_peer_id, fn_0_public_peer_id, true, Outbound);
-    env.send_peer_event(fn_0_public_peer_id, fn_2_peer_id, true, Inbound);
+    // Connect fullnode 2 and fullnode 0
+    send_connection_notifications(&mut env, fn_2_peer_id, fn_0_public_peer_id, true);
 
     // check we only broadcast to the single live fallback peer (fn_2)
     for num_commit in 16..=20 {
@@ -659,9 +634,8 @@ fn test_fn_failover() {
         }
     }
 
-    // bring back v again
-    env.send_peer_event(fn_0_vfn_peer_id, validator_peer_id, true, Inbound);
-    env.send_peer_event(validator_peer_id, fn_0_vfn_peer_id, true, Outbound);
+    // Connect validator and fullnode 0
+    send_connection_notifications(&mut env, validator_peer_id, fn_0_vfn_peer_id, true);
 
     let (chunk_response_recipient, _) = env.deliver_msg(fn_2_peer_id);
     assert_eq!(chunk_response_recipient, fn_0_public_peer_id);
@@ -690,8 +664,7 @@ fn test_fn_failover() {
             .get_peer_id(VFN_NETWORK_2.clone()),
     ];
     for peer in upstream_peers_to_revive.iter() {
-        env.send_peer_event(fn_0_public_peer_id, *peer, true, Inbound);
-        env.send_peer_event(*peer, fn_0_public_peer_id, true, Outbound);
+        send_connection_notifications(&mut env, *peer, fn_0_public_peer_id, true);
     }
 
     // deliver validator's chunk response after fallback peers are revived
@@ -761,23 +734,14 @@ fn test_multicast_failover() {
     drop(fullnode_1);
     drop(fullnode_2);
 
-    // vfn network:
-    // validator discovers fn_0
-    env.send_peer_event(fn_0_vfn_peer_id, validator_peer_id, true, Inbound);
-    // fn_0 discovers validator
-    env.send_peer_event(validator_peer_id, fn_0_vfn_peer_id, true, Outbound);
+    // Validator discovers fullnode 0
+    send_connection_notifications(&mut env, validator_peer_id, fn_0_vfn_peer_id, true);
 
-    // second private network: fn_1 is upstream to fn_0
-    // fn_1 discovers fn_0
-    env.send_peer_event(fn_0_second_peer_id, fn_1_peer_id, true, Inbound);
-    // fn_0 discovers fn_1
-    env.send_peer_event(fn_1_peer_id, fn_0_second_peer_id, true, Outbound);
+    // Fullnode 0 discovers fullnode 1
+    send_connection_notifications(&mut env, fn_1_peer_id, fn_0_second_peer_id, true);
 
-    // public network: fn_2 is upstream to fn_1
-    // fn_2 discovers fn_0
-    env.send_peer_event(fn_0_public_peer_id, fn_2_peer_id, true, Inbound);
-    // fn_0 discovers fn_2
-    env.send_peer_event(fn_2_peer_id, fn_0_public_peer_id, true, Outbound);
+    // Fullnode 2 discovers fullnode 0
+    send_connection_notifications(&mut env, fn_2_peer_id, fn_0_public_peer_id, true);
 
     for num_commit in 1..=3 {
         env.get_state_sync_peer(0).commit(num_commit * 5);
@@ -959,4 +923,17 @@ fn check_chunk_response(
             )
         }
     }
+}
+
+// Sends a connection notification to the given peers (i.e., connecting/disconnecting peer_id_0 and
+// peer_id_1). If `new_peer_notification` is true, the connection notification is a "new peer"
+// (connect) notification, otherwise, a "lost peer" (disconnect) notification is sent.
+fn send_connection_notifications(
+    env: &mut StateSyncEnvironment,
+    peer_id_0: PeerId,
+    peer_id_1: PeerId,
+    new_peer_notification: bool,
+) {
+    env.send_peer_event(peer_id_0, peer_id_1, new_peer_notification, Outbound);
+    env.send_peer_event(peer_id_1, peer_id_0, new_peer_notification, Inbound);
 }

--- a/state-sync/tests/integration_tests.rs
+++ b/state-sync/tests/integration_tests.rs
@@ -8,6 +8,7 @@ use anyhow::{bail, Result};
 use diem_config::config::RoleType;
 use diem_types::{transaction::TransactionListWithProof, waypoint::Waypoint};
 use netcore::transport::ConnectionOrigin::*;
+use network::protocols::direct_send::Message;
 use state_sync::network::StateSyncMessage;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use test_harness::StateSyncEnvironment;
@@ -255,9 +256,11 @@ fn catch_up_with_waypoints() {
 fn test_lagging_upstream_long_poll() {
     let mut env = StateSyncEnvironment::new(4);
 
+    // Start 2 validators and 2 fullnodes
     env.start_validator_peer(0, true);
+    env.start_validator_peer(1, true);
     env.setup_state_sync_peer(
-        1,
+        2,
         default_handler(),
         RoleType::FullNode,
         Waypoint::default(),
@@ -267,168 +270,121 @@ fn test_lagging_upstream_long_poll() {
         Some(vec![VFN_NETWORK.clone(), PFN_NETWORK.clone()]),
     );
     env.start_state_sync_peer(
-        2,
+        3,
         default_handler(),
         RoleType::FullNode,
         Waypoint::default(),
         true,
         Some(vec![VFN_NETWORK.clone()]),
     );
-    // we treat this a standalone node whose local state we use as the baseline
-    // to clone state to the other nodes
-    env.start_validator_peer(3, true);
 
     let validator_0 = env.get_state_sync_peer(0);
-    let fullnode_0 = env.get_state_sync_peer(1);
-    let fullnode_1 = env.get_state_sync_peer(2);
+    let fullnode_0 = env.get_state_sync_peer(2);
+    let fullnode_1 = env.get_state_sync_peer(3);
 
-    // network handles for each node
-    let validator_peer_id = validator_0.get_peer_id(VALIDATOR_NETWORK.clone());
-    let full_node_vfn_network_peer_id = fullnode_0.get_peer_id(VFN_NETWORK.clone());
-    let full_node_failover_network_peer_id = fullnode_0.get_peer_id(PFN_NETWORK.clone());
-    let failover_fn_vfn_network_peer_id = fullnode_1.get_peer_id(VFN_NETWORK.clone());
-    let failover_fn_peer_id = fullnode_1.get_peer_id(PFN_NETWORK.clone());
+    // Get peer ids of nodes (across different networks)
+    let validator_0_peer_id = validator_0.get_peer_id(VALIDATOR_NETWORK.clone());
+    let fullnode_0_peer_id_vfn = fullnode_0.get_peer_id(VFN_NETWORK.clone());
+    let fullnode_0_peer_id_pfn = fullnode_0.get_peer_id(PFN_NETWORK.clone());
+    let fullnode_1_peer_id_vfn = fullnode_1.get_peer_id(VFN_NETWORK.clone());
+    let fullnode_1_peer_id_pfn = fullnode_1.get_peer_id(PFN_NETWORK.clone());
 
+    // Commit version 400 at the validator
     validator_0.commit(400);
-
     drop(validator_0);
     drop(fullnode_0);
     drop(fullnode_1);
 
-    // validator discovers FN
-    env.send_peer_event(
-        full_node_vfn_network_peer_id,
-        validator_peer_id,
-        true,
-        Inbound,
-    );
-    // fn discovers validator
-    env.send_peer_event(
-        validator_peer_id,
-        full_node_vfn_network_peer_id,
-        true,
-        Outbound,
-    );
+    // Validator and fullnode discover each other
+    env.send_peer_event(fullnode_0_peer_id_vfn, validator_0_peer_id, true, Inbound);
+    env.send_peer_event(validator_0_peer_id, fullnode_0_peer_id_vfn, true, Outbound);
 
-    // FN discovers failover upstream
+    // Fullnodes discover each other
     env.send_peer_event(
-        full_node_failover_network_peer_id,
-        failover_fn_peer_id,
+        fullnode_0_peer_id_pfn,
+        fullnode_1_peer_id_pfn,
         true,
         Inbound,
     );
     env.send_peer_event(
-        failover_fn_peer_id,
-        full_node_failover_network_peer_id,
+        fullnode_1_peer_id_pfn,
+        fullnode_0_peer_id_pfn,
         true,
         Outbound,
     );
 
-    let (_, msg) = env.deliver_msg(full_node_vfn_network_peer_id);
-    // expected: known_version 0, epoch 1, no target LI version
-    let req: StateSyncMessage = bcs::from_bytes(&msg.mdata).expect("failed bcs deserialization");
-    check_chunk_request(req, 0, None);
+    // Deliver messages and verify versions and targets
+    let (_, message) = env.deliver_msg(fullnode_0_peer_id_vfn);
+    check_chunk_request(message, 0, None);
+    let (_, message) = env.deliver_msg(validator_0_peer_id);
+    check_chunk_response(message, 400, 1, 250);
+    env.get_state_sync_peer(2).wait_for_version(250, None);
 
-    let (_, msg) = env.deliver_msg(validator_peer_id);
-    let resp: StateSyncMessage = bcs::from_bytes(&msg.mdata).expect("failed bcs deserialization");
-    check_chunk_response(resp, 400, 1, 250);
-    env.get_state_sync_peer(1).wait_for_version(250, None);
+    // Validator loses fullnode
+    env.send_peer_event(fullnode_0_peer_id_vfn, validator_0_peer_id, false, Inbound);
+    // Fullnode loses validator
+    env.send_peer_event(validator_0_peer_id, fullnode_0_peer_id_vfn, false, Outbound);
 
-    // validator loses FN
-    env.send_peer_event(
-        full_node_vfn_network_peer_id,
-        validator_peer_id,
-        false,
-        Inbound,
-    );
-    // fn loses validator
-    env.send_peer_event(
-        validator_peer_id,
-        full_node_vfn_network_peer_id,
-        false,
-        Outbound,
-    );
+    // Fullnode sends chunk request to other fullnode
+    let (_, message) = env.deliver_msg(fullnode_0_peer_id_pfn);
+    check_chunk_request(message, 250, Some(400));
 
-    // full_node sends chunk request to failover upstream for known_version 250 and target LI 400
-    let (_, msg) = env.deliver_msg(full_node_failover_network_peer_id);
-    let msg: StateSyncMessage = bcs::from_bytes(&msg.mdata).expect("failed bcs deserialization");
-    check_chunk_request(msg, 250, Some(400));
-
-    // update failover VFN from lagging state to updated state
-    // so it can deliver full_node's long-poll subscription
+    // Validator 0 commits to new version and fullnode 1 is fast forwarded
     env.get_state_sync_peer(0).commit(500);
-    // we directly sync up the storage of the failover upstream with this validator's for ease of testing
-    env.clone_storage(0, 2);
-    env.get_state_sync_peer(2).wait_for_version(500, Some(500));
+    env.clone_storage(0, 3);
+    env.get_state_sync_peer(3).wait_for_version(500, Some(500));
 
-    // connect the validator and the failover vfn so FN can sync to validator
-    // validator discovers FN
-    env.send_peer_event(
-        failover_fn_vfn_network_peer_id,
-        validator_peer_id,
-        true,
-        Inbound,
-    );
-    // fn discovers validator
-    env.send_peer_event(
-        validator_peer_id,
-        failover_fn_vfn_network_peer_id,
-        true,
-        Outbound,
-    );
+    // Connect the validator and the failover fullnode so the fullnode can sync.
+    // Validator discovers fullnode
+    env.send_peer_event(fullnode_1_peer_id_vfn, validator_0_peer_id, true, Inbound);
+    // Fullnode discovers validator
+    env.send_peer_event(validator_0_peer_id, fullnode_1_peer_id_vfn, true, Outbound);
 
-    // trigger another commit so that the failover fn's commit will trigger subscription delivery
+    // Trigger another commit so that the fullnodes's commit will trigger subscription delivery
     env.get_state_sync_peer(0).commit(600);
-    // failover fn sends chunk request to validator
-    let (_, msg) = env.deliver_msg(failover_fn_vfn_network_peer_id);
-    let msg: StateSyncMessage = bcs::from_bytes(&msg.mdata).expect("failed bcs deserialization");
-    check_chunk_request(msg, 500, None);
-    let (_, msg) = env.deliver_msg(validator_peer_id);
-    let resp: StateSyncMessage = bcs::from_bytes(&msg.mdata).expect("failed bcs deserialization");
-    check_chunk_response(resp, 600, 501, 100);
+    let (_, message) = env.deliver_msg(fullnode_1_peer_id_vfn);
+    check_chunk_request(message, 500, None);
+    let (_, message) = env.deliver_msg(validator_0_peer_id);
+    check_chunk_response(message, 600, 501, 100);
 
-    // failover sends long-poll subscription to fullnode
-    let (_, msg) = env.deliver_msg(failover_fn_peer_id);
-    let resp: StateSyncMessage = bcs::from_bytes(&msg.mdata).expect("failed bcs deserialization");
-    check_chunk_response(resp, 600, 251, 250);
+    // Fullnode 1 sends long-poll subscription to fullnode 0
+    let (_, message) = env.deliver_msg(fullnode_1_peer_id_pfn);
+    check_chunk_response(message, 600, 251, 250);
 
-    // full_node sends chunk request to failover upstream for known_version 250 and target LI 400
-    let (_, msg) = env.deliver_msg(full_node_failover_network_peer_id);
-    let msg: StateSyncMessage = bcs::from_bytes(&msg.mdata).expect("failed bcs deserialization");
-    // here we check that the next requested version is not the older target LI 400 - that should be
-    // pruned out from PendingLedgerInfos since it becomes outdated after the known_version advances to 500
-    check_chunk_request(msg, 500, None);
-
-    // check that fullnode successfully finishes sync to 600
-    let (_, msg) = env.deliver_msg(failover_fn_peer_id);
-    let resp: StateSyncMessage = bcs::from_bytes(&msg.mdata).expect("failed bcs deserialization");
-    check_chunk_response(resp, 600, 501, 100);
-    env.get_state_sync_peer(1).wait_for_version(600, Some(600));
+    // Fullnode 0 sends chunk request to fullnode 1 and commits to latest state
+    let (_, message) = env.deliver_msg(fullnode_0_peer_id_pfn);
+    check_chunk_request(message, 500, None);
+    let (_, message) = env.deliver_msg(fullnode_1_peer_id_pfn);
+    check_chunk_response(message, 600, 501, 100);
+    env.get_state_sync_peer(2).wait_for_version(600, Some(600));
 }
 
-// test full node catching up to validator that is also making progress
 #[test]
-fn test_sync_pending_ledger_infos() {
+fn test_fullnode_catch_up_moving_target_epochs() {
+    // Create validator and fullnode
     let mut env = StateSyncEnvironment::new(2);
-
     env.start_validator_peer(0, true);
     env.start_fullnode_peer(1, true);
 
+    // Get peer ids of nodes
     let validator_peer_id = env
         .get_state_sync_peer(0)
         .get_peer_id(VALIDATOR_NETWORK.clone());
     let fullnode_peer_id = env.get_state_sync_peer(1).get_peer_id(VFN_NETWORK.clone());
 
-    // validator discovers fn
+    // Validator and fullnode discover each other.
     env.send_peer_event(fullnode_peer_id, validator_peer_id, true, Inbound);
-
-    // fn discovers validator
     env.send_peer_event(validator_peer_id, fullnode_peer_id, true, Outbound);
 
+    // Versions to be committed by the validator
     let commit_versions = vec![
-        900, 1800, 2800, 3100, 3200, 3300, 3325, 3350, 3400, 3450, 3650, 4300,
+        900, 1800, 2800, 3100, 3200, 3300, 3325, 3350, 3400, 3450, 3650, 4300, 4549,
     ];
 
+    // Versions that will move to the next epoch
+    let versions_for_new_epochs = vec![2800, 3325, 4300];
+
+    // Expected fullnode sync states (i.e., synced version and committed version)
     let expected_states = vec![
         (250, 0),
         (500, 0),
@@ -437,36 +393,100 @@ fn test_sync_pending_ledger_infos() {
         (1150, 900),
         (1400, 900),
         (1650, 900),
-        (1800, 1800),
-        (2050, 1800),
-        (2300, 1800),
-        (2550, 1800),
+        (1900, 900),
+        (2150, 900),
+        (2400, 900),
+        (2650, 900),
         (2800, 2800),
         (3050, 2800),
-        (3100, 3100),
-        (3350, 3350),
-        (3450, 3450),
-        (3650, 3650),
-        (3900, 3650),
-        (4150, 3650),
+        (3300, 2800),
+        (3325, 3325),
+        (3575, 3325),
+        (3825, 3325),
+        (4075, 3325),
         (4300, 4300),
+        (4549, 4549),
     ];
 
-    for (idx, expected_state) in expected_states.iter().enumerate() {
-        // commit if applicable
-        if let Some(version) = commit_versions.get(idx) {
-            env.get_state_sync_peer(0).commit(*version);
+    // Update the versions at the validator and check the full node syncs correctly.
+    for (index, (synced_version, committed_version)) in expected_states.iter().enumerate() {
+        if let Some(committed_version) = commit_versions.get(index) {
+            let validator = env.get_state_sync_peer(0);
+            validator.commit(*committed_version);
+
+            if versions_for_new_epochs.contains(committed_version) {
+                let validator_infos = vec![validator.get_validator_info()];
+                validator.move_to_next_epoch(validator_infos, 0);
+            }
         }
+
         env.deliver_msg(fullnode_peer_id);
         env.deliver_msg(validator_peer_id);
-        let (sync_version, li_version) = expected_state;
-        assert!(
-            env.get_state_sync_peer(1)
-                .wait_for_version(*sync_version, Some(*li_version)),
-            "didn't reach synced version {} and highest LI version {}",
-            sync_version,
-            li_version
-        );
+
+        let fullnode = env.get_state_sync_peer(1);
+        if !fullnode.wait_for_version(*synced_version, Some(*committed_version)) {
+            panic!(
+                "Failed to reach synced version: {} and committed version: {}",
+                synced_version, committed_version
+            );
+        }
+    }
+}
+
+#[test]
+fn test_fullnode_catch_up_moving_target() {
+    // Create validator and fullnode
+    let mut env = StateSyncEnvironment::new(2);
+    env.start_validator_peer(0, true);
+    env.start_fullnode_peer(1, true);
+
+    // Get peer ids of nodes
+    let validator_peer_id = env
+        .get_state_sync_peer(0)
+        .get_peer_id(VALIDATOR_NETWORK.clone());
+    let fullnode_peer_id = env.get_state_sync_peer(1).get_peer_id(VFN_NETWORK.clone());
+
+    // Validator and fullnode discover each other.
+    env.send_peer_event(fullnode_peer_id, validator_peer_id, true, Inbound);
+    env.send_peer_event(validator_peer_id, fullnode_peer_id, true, Outbound);
+
+    // Expected fullnode sync states (i.e., synced version and committed version)
+    let expected_states = vec![
+        (250, 0),
+        (500, 500),
+        (750, 500),
+        (1000, 1000),
+        (1250, 1000),
+        (1500, 1000),
+        (1750, 1000),
+        (2000, 2000),
+        (2250, 2000),
+        (2500, 2000),
+        (2750, 2000),
+        (3000, 2000),
+        (3250, 2000),
+        (3500, 2000),
+        (3750, 2000),
+        (4000, 4000),
+    ];
+
+    // Update the versions at the validator and check the full node syncs correctly.
+    // Every iteration the validator commits another 500 transactions (i.e., the validator
+    // is committing at twice the rate the full node can sync).
+    for (index, (synced_version, committed_version)) in expected_states.iter().enumerate() {
+        let next_commit = (index + 1) * 500;
+        env.get_state_sync_peer(0).commit(next_commit as u64);
+
+        env.deliver_msg(fullnode_peer_id);
+        env.deliver_msg(validator_peer_id);
+
+        let fullnode = env.get_state_sync_peer(1);
+        if !fullnode.wait_for_version(*synced_version, Some(*committed_version)) {
+            panic!(
+                "Failed to reach synced version: {} and committed version: {}",
+                synced_version, committed_version
+            );
+        }
     }
 }
 
@@ -900,35 +920,43 @@ fn test_multicast_failover() {
     env.assert_no_message_sent(fn_0_public_peer_id);
 }
 
-fn check_chunk_request(msg: StateSyncMessage, known_version: u64, target_version: Option<u64>) {
-    match msg {
-        StateSyncMessage::GetChunkRequest(req) => {
-            assert_eq!(req.known_version, known_version);
-            assert_eq!(req.target.version(), target_version);
+fn check_chunk_request(message: Message, known_version: u64, target_version: Option<u64>) {
+    let chunk_request: StateSyncMessage = bcs::from_bytes(&message.mdata).unwrap();
+    match chunk_request {
+        StateSyncMessage::GetChunkRequest(chunk_request) => {
+            assert_eq!(chunk_request.known_version, known_version);
+            assert_eq!(chunk_request.target.version(), target_version);
         }
         StateSyncMessage::GetChunkResponse(_) => {
-            panic!("received chunk response when expecting chunk request");
+            panic!("Received chunk response but expecting chunk request!");
         }
     }
 }
 
 fn check_chunk_response(
-    msg: StateSyncMessage,
+    message: Message,
     response_li_version: u64,
     chunk_start_version: u64,
     chunk_length: usize,
 ) {
-    match msg {
+    let chunk_response: StateSyncMessage = bcs::from_bytes(&message.mdata).unwrap();
+    match chunk_response {
         StateSyncMessage::GetChunkRequest(_) => {
-            panic!("received chunk response when expecting chunk request");
+            panic!("Received chunk response but expecting chunk request!");
         }
-        StateSyncMessage::GetChunkResponse(resp) => {
-            assert_eq!(resp.response_li.version(), response_li_version);
+        StateSyncMessage::GetChunkResponse(chunk_response) => {
+            assert_eq!(chunk_response.response_li.version(), response_li_version);
             assert_eq!(
-                resp.txn_list_with_proof.first_transaction_version.unwrap(),
+                chunk_response
+                    .txn_list_with_proof
+                    .first_transaction_version
+                    .unwrap(),
                 chunk_start_version
             );
-            assert_eq!(resp.txn_list_with_proof.transactions.len(), chunk_length)
+            assert_eq!(
+                chunk_response.txn_list_with_proof.transactions.len(),
+                chunk_length
+            )
         }
     }
 }

--- a/state-sync/tests/test_harness.rs
+++ b/state-sync/tests/test_harness.rs
@@ -166,8 +166,9 @@ impl StateSyncPeer {
         for _ in 0..max_retries {
             let state = block_on(self.client.as_ref().unwrap().get_state()).unwrap();
             if state.synced_version() == target_version {
-                return highest_li_version
-                    .map_or(true, |li_version| li_version == state.committed_version());
+                return highest_li_version.map_or(true, |highest_li_version| {
+                    highest_li_version == state.committed_version()
+                });
             }
             std::thread::sleep(std::time::Duration::from_millis(1000));
         }


### PR DESCRIPTION
## Motivation

This PR replaces the PendingLedgerInfos structure from state sync with a single (rolling) highest target ledger info. PendingLedgerInfos is used by full nodes in state sync. It maintains a queue of ledger info's that have been received from other nodes. This allows a full node to incrementally sync to these ledger infos as it catches up to the head of the blockchain (as opposed to, e.g., syncing to a ledger info only on an epoch change). 

Unfortunately, the use of PendingLedgerInfos makes state sync a lot more complicated than it needs to be. This PR maintains "incremental commit" for state sync, but replaces PendingLedgerInfos with a single ledger info as the next highest target. When that target is reached, a new one is selected based on the responses of the peers.

This PR offers several commits:
1. Remove the structure entirely and replace it with a single target.
2. Update the failing tests and add a new test for a full node that is trying to catch up to a moving target without epoch changes.
3. Small clean up to code duplication in tests.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally (including the newly added one).

## Related PRs

This relates to: https://github.com/diem/diem/issues/6795