### PR TITLE
[move] Used compiled module bytes in various tools

### DIFF
--- a/client/transaction-builder/src/misc.rs
+++ b/client/transaction-builder/src/misc.rs
@@ -20,12 +20,9 @@ pub fn encode_block_prologue_script(block_metadata: BlockMetadata) -> Transactio
 /// Update WriteSet
 pub fn encode_stdlib_upgrade_transaction(option: StdLibOptions) -> ChangeSet {
     let mut write_set = WriteSetMut::new(vec![]);
-    let stdlib = compiled_stdlib::stdlib_modules(option);
-    for module in stdlib {
-        let mut bytes = vec![];
-        module
-            .serialize(&mut bytes)
-            .expect("Failed to serialize module");
+    let stdlib_modules = compiled_stdlib::stdlib_modules(option);
+    let bytes = stdlib_modules.bytes_vec();
+    for (module, bytes) in stdlib_modules.compiled_modules.iter().zip(bytes) {
         write_set.push((
             AccessPath::code_access_path(module.self_id()),
             WriteOp::Value(bytes),

--- a/language/compiler/src/lib.rs
+++ b/language/compiler/src/lib.rs
@@ -114,7 +114,9 @@ impl Compiler {
         if self.skip_stdlib_deps {
             extra_deps
         } else {
-            let mut deps: Vec<CompiledModule> = stdlib_modules(StdLibOptions::Compiled).to_vec();
+            let mut deps: Vec<CompiledModule> = stdlib_modules(StdLibOptions::Compiled)
+                .compiled_modules
+                .to_vec();
             deps.extend(extra_deps);
             deps
         }

--- a/language/compiler/src/main.rs
+++ b/language/compiler/src/main.rs
@@ -130,7 +130,9 @@ fn main() {
         } else if args.no_stdlib {
             vec![]
         } else {
-            stdlib_modules(StdLibOptions::Compiled).to_vec()
+            stdlib_modules(StdLibOptions::Compiled)
+                .compiled_modules
+                .to_vec()
         }
     };
 

--- a/language/compiler/src/unit_tests/testutils.rs
+++ b/language/compiler/src/unit_tests/testutils.rs
@@ -146,5 +146,7 @@ pub fn compile_script_string_with_stdlib(code: &str) -> Result<CompiledScript> {
 }
 
 fn stdlib() -> Vec<CompiledModule> {
-    stdlib_modules(StdLibOptions::Compiled).to_vec()
+    stdlib_modules(StdLibOptions::Compiled)
+        .compiled_modules
+        .to_vec()
 }

--- a/language/diem-tools/writeset-transaction-generator/src/release_flow/create.rs
+++ b/language/diem-tools/writeset-transaction-generator/src/release_flow/create.rs
@@ -12,7 +12,6 @@ use diem_types::{
     write_set::{WriteOp, WriteSetMut},
 };
 use diem_validator_interface::{DiemValidatorInterface, JsonRpcDebuggerInterface};
-
 use std::collections::{BTreeMap, BTreeSet};
 use vm::CompiledModule;
 
@@ -26,12 +25,16 @@ pub fn create_release(
     version: u64,
     // Set the flag to true in the first release. This will manually create the first release artifact on disk.
     first_release: bool,
-    release_modules: &[CompiledModule],
+    release_modules: &[(Vec<u8>, CompiledModule)],
 ) -> Result<WriteSetPayload> {
     let release_artifact = ReleaseArtifact {
         chain_id,
         version,
-        stdlib_hash: hash_for_modules(release_modules)?,
+        stdlib_hash: hash_for_modules(
+            release_modules
+                .iter()
+                .map(|(bytes, module)| (module.self_id(), bytes)),
+        )?,
     };
 
     if first_release {
@@ -55,7 +58,12 @@ pub fn create_release(
 
     let remote = Box::new(JsonRpcDebuggerInterface::new(url.as_str())?);
     let payload = create_release_from_artifact(&release_artifact, url.as_str(), release_modules)?;
-    verify_payload_change(remote, Some(version), &payload, release_modules)?;
+    verify_payload_change(
+        remote,
+        Some(version),
+        &payload,
+        release_modules.iter().map(|(_bytes, m)| m),
+    )?;
     save_release_artifact(release_artifact)?;
     Ok(payload)
 }
@@ -63,16 +71,16 @@ pub fn create_release(
 pub(crate) fn create_release_from_artifact(
     artifact: &ReleaseArtifact,
     remote_url: &str,
-    release_modules: &[CompiledModule],
+    release_modules: &[(Vec<u8>, CompiledModule)],
 ) -> Result<WriteSetPayload> {
     let remote = JsonRpcDebuggerInterface::new(remote_url)?;
     let remote_modules = remote.get_diem_framework_modules_by_version(artifact.version)?;
-    create_release_writeset(remote_modules.as_slice(), release_modules)
+    create_release_writeset(&remote_modules, release_modules)
 }
 
 pub(crate) fn create_release_writeset(
     remote_frameworks: &[CompiledModule],
-    local_frameworks: &[CompiledModule],
+    local_frameworks: &[(Vec<u8>, CompiledModule)],
 ) -> Result<WriteSetPayload> {
     let remote_framework_map = remote_frameworks
         .iter()
@@ -81,7 +89,7 @@ pub(crate) fn create_release_writeset(
     let remote_ids = remote_framework_map.keys().collect::<BTreeSet<_>>();
     let local_framework_map = local_frameworks
         .iter()
-        .map(|m| (m.self_id(), m))
+        .map(|(bytes, module)| (module.self_id(), (bytes, module)))
         .collect::<BTreeMap<_, _>>();
     let local_ids = local_framework_map.keys().collect::<BTreeSet<_>>();
 
@@ -89,7 +97,7 @@ pub(crate) fn create_release_writeset(
 
     // 1. Insert new modules to be published.
     for module_id in local_ids.difference(&remote_ids) {
-        let module = local_framework_map
+        let module = *local_framework_map
             .get(*module_id)
             .expect("ModuleID not found in local stdlib");
         framework_changes.insert(*module_id, Some(module));
@@ -102,25 +110,23 @@ pub(crate) fn create_release_writeset(
 
     // 3. Check the diff between on chain modules and local modules, update when local bytes is different.
     for module_id in local_ids.intersection(&remote_ids) {
-        let local_module = local_framework_map
+        let (local_bytes, local_module) = *local_framework_map
             .get(*module_id)
             .expect("ModuleID not found in local stdlib");
         let remote_module = remote_framework_map
             .get(*module_id)
             .expect("ModuleID not found in local stdlib");
-        if local_module != remote_module {
-            framework_changes.insert(*module_id, Some(local_module));
+        if &local_module != remote_module {
+            framework_changes.insert(*module_id, Some((local_bytes, local_module)));
         }
     }
 
     let mut write_patch = WriteSetMut::new(vec![]);
-    for (id, module) in framework_changes.into_iter() {
+    for (id, module_opt) in framework_changes.into_iter() {
         let path = AccessPath::code_access_path(id.clone());
-        match module {
-            Some(m) => {
-                let mut bytes = vec![];
-                m.serialize(&mut bytes)?;
-                write_patch.push((path, WriteOp::Value(bytes)));
+        match module_opt {
+            Some((bytes, _)) => {
+                write_patch.push((path, WriteOp::Value((*bytes).clone())));
             }
             None => write_patch.push((path, WriteOp::Deletion)),
         }

--- a/language/diem-tools/writeset-transaction-generator/src/release_flow/mod.rs
+++ b/language/diem-tools/writeset-transaction-generator/src/release_flow/mod.rs
@@ -13,17 +13,30 @@ pub use create::create_release;
 pub use verify::verify_release;
 
 pub mod test_utils {
-    use compiled_stdlib::{stdlib_modules, StdLibOptions};
+    use compiled_stdlib::{stdlib_modules, StdLibModules, StdLibOptions};
     use diem_types::account_config::CORE_CODE_ADDRESS;
     use vm::{file_format::empty_module, CompiledModule};
 
-    pub fn release_modules() -> Vec<CompiledModule> {
-        let mut modules = stdlib_modules(StdLibOptions::Compiled).to_vec();
+    pub fn release_modules() -> Vec<(Vec<u8>, CompiledModule)> {
+        let StdLibModules {
+            bytes_opt,
+            compiled_modules,
+        } = stdlib_modules(StdLibOptions::Compiled);
+        let mut modules = bytes_opt
+            .unwrap()
+            .iter()
+            .cloned()
+            .zip(compiled_modules.iter().cloned())
+            .collect::<Vec<_>>();
         // Publish a new dummy module
         let mut module = empty_module();
         module.address_identifiers[0] = CORE_CODE_ADDRESS;
-
-        modules.push(module.freeze().unwrap());
+        let bytes = {
+            let mut buf = vec![];
+            module.serialize(&mut buf).unwrap();
+            buf
+        };
+        modules.push((bytes, module.freeze().unwrap()));
         // TODO: See if there's a module that we can remove and if we can modify an existing module
         modules
     }

--- a/language/e2e-testsuite/src/tests/writeset_builder.rs
+++ b/language/e2e-testsuite/src/tests/writeset_builder.rs
@@ -32,12 +32,17 @@ fn build_upgrade_writeset() {
 
     let module =
         compile_module_with_address(&account_config::CORE_CODE_ADDRESS, "file_name", &program).0;
-
+    let module_bytes = {
+        let mut v = vec![];
+        module.serialize(&mut v).unwrap();
+        v
+    };
     let change_set = build_changeset(
         executor.get_state_view(),
         |session| {
             session.set_diem_version(11);
         },
+        &[module_bytes],
         &[module.clone()],
     );
 

--- a/language/ir-testsuite/tests/testsuite.rs
+++ b/language/ir-testsuite/tests/testsuite.rs
@@ -62,7 +62,11 @@ impl Compiler for IRCompiler {
 
 fn run_test(path: &Path) -> datatest_stable::Result<()> {
     testsuite::functional_tests(
-        IRCompiler::new(stdlib_modules(StdLibOptions::Compiled).to_vec()),
+        IRCompiler::new(
+            stdlib_modules(StdLibOptions::Compiled)
+                .compiled_modules
+                .to_vec(),
+        ),
         path,
     )
 }

--- a/language/stdlib/compiled/src/lib.rs
+++ b/language/stdlib/compiled/src/lib.rs
@@ -36,27 +36,30 @@ pub const ERROR_DESCRIPTIONS: &[u8] =
 // regenerate genesis). The compiled version of the stdlib/scripts are used unless otherwise
 // specified either by the MOVE_NO_USE_COMPILED env var, or by passing the "StdLibOptions::Fresh"
 // option to `stdlib_modules`.
-static COMPILED_MOVELANG_STDLIB: Lazy<Vec<CompiledModule>> = Lazy::new(|| {
-    let modules: BTreeMap<&str, CompiledModule> = COMPILED_STDLIB_DIR
-        .files()
-        .iter()
-        .map(|file| {
-            (
-                file.path().to_str().unwrap(),
-                CompiledModule::deserialize(&file.contents()).unwrap(),
-            )
-        })
-        .collect();
+static COMPILED_MOVELANG_STDLIB_WITH_BYTES: Lazy<(Vec<Vec<u8>>, Vec<CompiledModule>)> =
+    Lazy::new(|| {
+        let modules: BTreeMap<&str, (Vec<u8>, CompiledModule)> = COMPILED_STDLIB_DIR
+            .files()
+            .iter()
+            .map(|file| {
+                let name = file.path().to_str().unwrap();
+                let bytes = file.contents().to_vec();
+                let module = CompiledModule::deserialize(&bytes).unwrap();
+                (name, (bytes, module))
+            })
+            .collect();
 
-    let mut verified_modules = vec![];
-    for (_, module) in modules.into_iter() {
-        verify_module(&module).expect("stdlib module failed to verify");
-        dependencies::verify_module(&module, &verified_modules)
-            .expect("stdlib module dependency failed to verify");
-        verified_modules.push(module)
-    }
-    verified_modules
-});
+        let mut module_bytes = vec![];
+        let mut verified_modules = vec![];
+        for (_, (bytes, module)) in modules.into_iter() {
+            verify_module(&module).expect("stdlib module failed to verify");
+            dependencies::verify_module(&module, &verified_modules)
+                .expect("stdlib module dependency failed to verify");
+            module_bytes.push(bytes);
+            verified_modules.push(module);
+        }
+        (module_bytes, verified_modules)
+    });
 
 /// An enum specifying whether the compiled stdlib/scripts should be used or freshly built versions
 /// should be used.
@@ -66,13 +69,48 @@ pub enum StdLibOptions {
     Fresh,
 }
 
+/// Return value of `stdlib_modules`. Gives a reference to the Compiled modules and a reference
+/// to the on disk bytes, if the `Compiled` option was used
+pub struct StdLibModules {
+    pub compiled_modules: &'static [CompiledModule],
+    pub bytes_opt: Option<&'static [Vec<u8>]>,
+}
+
+impl StdLibModules {
+    /// If bytes_opt is Some, returns an owned copy of the the types
+    /// If it is is None, it serializes `compiled_modules`
+    pub fn bytes_vec(&self) -> Vec<Vec<u8>> {
+        match self.bytes_opt {
+            Some(bytes) => bytes.to_vec(),
+            None => self
+                .compiled_modules
+                .iter()
+                .map(|m| {
+                    let mut bytes = vec![];
+                    m.serialize(&mut bytes).unwrap();
+                    bytes
+                })
+                .collect(),
+        }
+    }
+}
+
 /// Returns a reference to the standard library. Depending upon the `option` flag passed in
 /// either a compiled version of the standard library will be returned or a new freshly built stdlib
 /// will be used.
-pub fn stdlib_modules(option: StdLibOptions) -> &'static [CompiledModule] {
+/// For the `Compiled` option, both the on disk bytes and the deserialized modules will be returned
+/// For the `Fresh` option, only the compiled modules will be given as there are no serialized bytes
+/// to borrow and give a reference to
+pub fn stdlib_modules(option: StdLibOptions) -> StdLibModules {
     match option {
-        StdLibOptions::Compiled => &*COMPILED_MOVELANG_STDLIB,
-        StdLibOptions::Fresh => &*FRESH_MOVELANG_STDLIB,
+        StdLibOptions::Compiled => StdLibModules {
+            bytes_opt: Some(&*COMPILED_MOVELANG_STDLIB_WITH_BYTES.0),
+            compiled_modules: &*COMPILED_MOVELANG_STDLIB_WITH_BYTES.1,
+        },
+        StdLibOptions::Fresh => StdLibModules {
+            bytes_opt: None,
+            compiled_modules: &*FRESH_MOVELANG_STDLIB,
+        },
     }
 }
 
@@ -82,7 +120,7 @@ pub fn stdlib_modules(option: StdLibOptions) -> &'static [CompiledModule] {
 /// The order the modules are presented in is important: later modules depend on earlier ones.
 /// The defualt is to return a compiled version of the stdlib unless it is otherwise specified by the
 /// `MOVE_NO_USE_COMPILED` environment variable.
-pub fn env_stdlib_modules() -> &'static [CompiledModule] {
+pub fn env_stdlib_modules() -> StdLibModules {
     let option = if use_compiled() {
         StdLibOptions::Compiled
     } else {

--- a/language/testing-infra/e2e-tests/src/data_store.rs
+++ b/language/testing-infra/e2e-tests/src/data_store.rs
@@ -21,7 +21,7 @@ use move_core_types::{
 use move_vm_runtime::data_cache::RemoteCache;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
-use vm::{errors::*, CompiledModule};
+use vm::errors::*;
 use vm_genesis::generate_genesis_change_set_for_testing;
 
 /// Dummy genesis ChangeSet for testing
@@ -83,12 +83,8 @@ impl FakeDataStore {
     /// Adds a [`CompiledModule`] to this data store.
     ///
     /// Does not do any sort of verification on the module.
-    pub fn add_module(&mut self, module_id: &ModuleId, module: &CompiledModule) {
+    pub fn add_module(&mut self, module_id: &ModuleId, blob: Vec<u8>) {
         let access_path = AccessPath::from(module_id);
-        let mut blob = vec![];
-        module
-            .serialize(&mut blob)
-            .expect("serializing this module should work");
         self.set(access_path, blob);
     }
 }

--- a/language/testing-infra/functional-tests/src/evaluator.rs
+++ b/language/testing-infra/functional-tests/src/evaluator.rs
@@ -744,15 +744,16 @@ pub fn eval<TComp: Compiler>(
             FakeExecutor::from_fresh_genesis()
         }
     } else {
+        let stdlib_modules = stdlib_modules(if compiler.use_compiled_genesis() {
+            StdLibOptions::Compiled
+        } else {
+            StdLibOptions::Fresh
+        });
+        let module_bytes = stdlib_modules.bytes_vec();
         // use custom validator set. this requires dynamically generating a new genesis tx and
         // is thus more expensive.
         FakeExecutor::custom_genesis(
-            stdlib_modules(if compiler.use_compiled_genesis() {
-                StdLibOptions::Compiled
-            } else {
-                StdLibOptions::Fresh
-            })
-            .to_vec(),
+            &module_bytes,
             Some(config.validator_accounts),
             VMPublishingOption::open(),
         )

--- a/language/tools/resource-viewer/src/resolver.rs
+++ b/language/tools/resource-viewer/src/resolver.rs
@@ -32,7 +32,7 @@ impl<'a> Resolver<'a> {
     pub fn new(state: &'a dyn RemoteCache, use_stdlib: bool) -> Self {
         let cache = ModuleCache::new();
         if use_stdlib {
-            let modules = stdlib_modules(StdLibOptions::Compiled);
+            let modules = stdlib_modules(StdLibOptions::Compiled).compiled_modules;
             for module in modules {
                 cache.insert(module.self_id(), module.clone());
             }

--- a/language/tools/vm-genesis/src/genesis_context.rs
+++ b/language/tools/vm-genesis/src/genesis_context.rs
@@ -8,7 +8,6 @@ use diem_state_view::StateView;
 use diem_types::access_path::AccessPath;
 use move_core_types::language_storage::ModuleId;
 use std::collections::HashMap;
-use vm::CompiledModule;
 
 // `StateView` has no data given we are creating the genesis
 pub(crate) struct GenesisStateView {
@@ -22,13 +21,9 @@ impl GenesisStateView {
         }
     }
 
-    pub(crate) fn add_module(&mut self, module_id: &ModuleId, module: &CompiledModule) {
+    pub(crate) fn add_module(&mut self, module_id: &ModuleId, blob: &[u8]) {
         let access_path = AccessPath::from(module_id);
-        let mut blob = vec![];
-        module
-            .serialize(&mut blob)
-            .expect("serializing stdlib must work");
-        self.data.insert(access_path, blob);
+        self.data.insert(access_path, blob.to_vec());
     }
 }
 

--- a/testsuite/smoke-test/src/release_flow.rs
+++ b/testsuite/smoke-test/src/release_flow.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::test_utils::{diem_swarm_utils::get_json_rpc_url, setup_swarm_and_client_proxy};
-use compiled_stdlib::{stdlib_modules, StdLibOptions};
+use compiled_stdlib::{stdlib_modules, StdLibModules, StdLibOptions};
 use diem_types::{chain_id::ChainId, transaction::TransactionPayload};
 use diem_validator_interface::{DiemValidatorInterface, JsonRpcDebuggerInterface};
 use diem_writeset_generator::{
@@ -17,7 +17,16 @@ fn test_move_release_flow() {
     let validator_interface = JsonRpcDebuggerInterface::new(&url).unwrap();
 
     let chain_id = ChainId::test();
-    let old_modules = stdlib_modules(StdLibOptions::Compiled).to_vec();
+    let StdLibModules {
+        bytes_opt: old_modules_bytes,
+        compiled_modules: old_compiled_modules,
+    } = stdlib_modules(StdLibOptions::Compiled);
+    let old_modules = old_modules_bytes
+        .unwrap()
+        .iter()
+        .cloned()
+        .zip(old_compiled_modules.iter().cloned())
+        .collect::<Vec<_>>();
 
     let release_modules = release_modules();
 
@@ -55,7 +64,7 @@ fn test_move_release_flow() {
             .collect::<BTreeMap<_, _>>(),
         release_modules
             .iter()
-            .map(|m| (m.self_id(), m))
+            .map(|(_, m)| (m.self_id(), m))
             .collect::<BTreeMap<_, _>>(),
     );
 
@@ -97,7 +106,7 @@ fn test_move_release_flow() {
             .collect::<BTreeMap<_, _>>(),
         old_modules
             .iter()
-            .map(|m| (m.self_id(), m))
+            .map(|(_, m)| (m.self_id(), m))
             .collect::<BTreeMap<_, _>>(),
     );
 }


### PR DESCRIPTION
- Various tools re-serialized the CompiledModule bytes stored on disk
- But there is no guarantee that ser(de(m)) == m with versioned file format

## Motivation

- This frees our ability to make changes to the deserializer that are not inversible. Which is important for visibility and abilities

## Test Plan

- ran tests

## Related PRs

#7418