### PR TITLE
[move-lang] parser and typing for the public(script) visibility modifier

### DIFF
--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -304,9 +304,15 @@ fn script_(context: &mut Context, pscript: P::Script) -> E::Script {
     }
 
     let (function_name, function) = function_(context, pfunction);
-    if let FunctionVisibility::Public(loc) = &function.visibility {
-        let msg = "Extraneous 'public' modifier. Script functions are always public";
-        context.error(vec![(*loc, msg)]);
+    match &function.visibility {
+        FunctionVisibility::Public(loc) | FunctionVisibility::Script(loc) => {
+            let msg = format!(
+                "Extraneous '{}' modifier. Script functions are always public(script)",
+                function.visibility
+            );
+            context.error(vec![(*loc, msg)]);
+        }
+        FunctionVisibility::Internal => (),
     }
     match &function.body {
         sp!(_, E::FunctionBody_::Defined(_)) => (),

--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -307,8 +307,9 @@ fn script_(context: &mut Context, pscript: P::Script) -> E::Script {
     match &function.visibility {
         FunctionVisibility::Public(loc) | FunctionVisibility::Script(loc) => {
             let msg = format!(
-                "Extraneous '{}' modifier. Script functions are always public(script)",
-                function.visibility
+                "Extraneous '{}' modifier. Script functions are always '{}'",
+                function.visibility,
+                FunctionVisibility::SCRIPT,
             );
             context.error(vec![(*loc, msg)]);
         }

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -734,6 +734,12 @@ impl BinOp_ {
     }
 }
 
+impl FunctionVisibility {
+    pub const PUBLIC: &'static str = "public";
+    pub const SCRIPT: &'static str = "public(script)";
+    pub const INTERNAL: &'static str = "";
+}
+
 //**************************************************************************************************
 // Display
 //**************************************************************************************************
@@ -768,11 +774,15 @@ impl fmt::Display for BinOp_ {
 
 impl fmt::Display for FunctionVisibility {
     fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
-        match &self {
-            FunctionVisibility::Public(_) => write!(f, "public"),
-            FunctionVisibility::Script(_) => write!(f, "public(script)"),
-            FunctionVisibility::Internal => write!(f, ""),
-        }
+        write!(
+            f,
+            "{}",
+            match &self {
+                FunctionVisibility::Public(_) => FunctionVisibility::PUBLIC,
+                FunctionVisibility::Script(_) => FunctionVisibility::SCRIPT,
+                FunctionVisibility::Internal => FunctionVisibility::INTERNAL,
+            }
+        )
     }
 }
 

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -147,6 +147,7 @@ pub struct FunctionSignature {
 #[derive(PartialEq, Debug, Clone)]
 pub enum FunctionVisibility {
     Public(Loc),
+    Script(Loc),
     Internal,
 }
 
@@ -765,6 +766,16 @@ impl fmt::Display for BinOp_ {
     }
 }
 
+impl fmt::Display for FunctionVisibility {
+    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
+        match &self {
+            FunctionVisibility::Public(_) => write!(f, "public"),
+            FunctionVisibility::Script(_) => write!(f, "public(script)"),
+            FunctionVisibility::Internal => write!(f, ""),
+        }
+    }
+}
+
 //**************************************************************************************************
 // Debug
 //**************************************************************************************************
@@ -1119,10 +1130,7 @@ impl AstDebug for Function {
 
 impl AstDebug for FunctionVisibility {
     fn ast_debug(&self, w: &mut AstWriter) {
-        match self {
-            FunctionVisibility::Internal => (),
-            FunctionVisibility::Public(_) => w.write("public "),
-        }
+        w.write(&format!("{} ", self))
     }
 }
 

--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -336,9 +336,13 @@ fn parse_function_visibility<'input>(
             None => FunctionVisibility::Public(loc),
             Some(Tok::Script) => FunctionVisibility::Script(loc),
             _ => {
-                let msg = "Invalid visibility modifier. \
-                Consider removing it or using one of `public` or `public(script)`";
-                return Err(vec![(loc, msg.to_owned())]);
+                let msg = format!(
+                    "Invalid visibility modifier. \
+                    Consider removing it or using one of '{}' or '{}'",
+                    FunctionVisibility::PUBLIC,
+                    FunctionVisibility::SCRIPT
+                );
+                return Err(vec![(loc, msg)]);
             }
         }
     } else {

--- a/language/move-lang/src/to_bytecode/translate.rs
+++ b/language/move-lang/src/to_bytecode/translate.rs
@@ -449,6 +449,7 @@ fn function(
 fn visibility(v: FunctionVisibility) -> IR::FunctionVisibility {
     match v {
         FunctionVisibility::Public(_) => IR::FunctionVisibility::Public,
+        FunctionVisibility::Script(_) => IR::FunctionVisibility::Script,
         FunctionVisibility::Internal => IR::FunctionVisibility::Internal,
     }
 }

--- a/language/move-lang/src/typing/core.rs
+++ b/language/move-lang/src/typing/core.rs
@@ -751,22 +751,28 @@ pub fn make_function_type(
     match &finfo.visibility {
         FunctionVisibility::Internal => {
             if !in_current_module {
-                let internal_msg =
+                let internal_msg = format!(
                     "This function is internal to its module. \
-                    Only 'public' and 'public(script)' functions can be called outside of their module";
+                    Only '{}' and '{}' functions can be called outside of their module",
+                    FunctionVisibility::PUBLIC,
+                    FunctionVisibility::SCRIPT
+                );
                 context.error(vec![
                     (loc, format!("Invalid call to '{}::{}'", m, f)),
-                    (defined_loc, internal_msg.into()),
+                    (defined_loc, internal_msg),
                 ])
             }
         }
         FunctionVisibility::Script(_) => {
             if !context.is_in_script_context() {
-                let internal_msg = "This function can only be called from a script context, \
-                                i.e. a 'script' function or a 'public(script)' function";
+                let internal_msg = format!(
+                    "This function can only be called from a script context, \
+                                i.e. a 'script' function or a '{}' function",
+                    FunctionVisibility::SCRIPT
+                );
                 context.error(vec![
                     (loc, format!("Invalid call to '{}::{}'", m, f)),
-                    (defined_loc, internal_msg.into()),
+                    (defined_loc, internal_msg),
                 ])
             }
         }

--- a/language/move-lang/tests/move_check/expansion/public_main.exp
+++ b/language/move-lang/tests/move_check/expansion/public_main.exp
@@ -3,6 +3,6 @@ error:
    ┌── tests/move_check/expansion/public_main.move:2:1 ───
    │
  2 │ public fun main() {
-   │ ^^^^^^ Extraneous 'public' modifier. Script functions are always public
+   │ ^^^^^^ Extraneous 'public' modifier. Script functions are always 'public(script)'
    │
 

--- a/language/move-lang/tests/move_check/expansion/public_script_main.exp
+++ b/language/move-lang/tests/move_check/expansion/public_script_main.exp
@@ -3,6 +3,6 @@ error:
    ┌── tests/move_check/expansion/public_script_main.move:2:1 ───
    │
  2 │ public(script) fun main() {
-   │ ^^^^^^^^^^^^^^ Extraneous 'public(script)' modifier. Script functions are always public(script)
+   │ ^^^^^^^^^^^^^^ Extraneous 'public(script)' modifier. Script functions are always 'public(script)'
    │
 

--- a/language/move-lang/tests/move_check/expansion/public_script_main.exp
+++ b/language/move-lang/tests/move_check/expansion/public_script_main.exp
@@ -1,0 +1,8 @@
+error: 
+
+   ┌── tests/move_check/expansion/public_script_main.move:2:1 ───
+   │
+ 2 │ public(script) fun main() {
+   │ ^^^^^^^^^^^^^^ Extraneous 'public(script)' modifier. Script functions are always public(script)
+   │
+

--- a/language/move-lang/tests/move_check/expansion/public_script_main.move
+++ b/language/move-lang/tests/move_check/expansion/public_script_main.move
@@ -1,0 +1,4 @@
+script {
+public(script) fun main() {
+}
+}

--- a/language/move-lang/tests/move_check/parser/function_visibility_empty.exp
+++ b/language/move-lang/tests/move_check/parser/function_visibility_empty.exp
@@ -1,0 +1,8 @@
+error: 
+
+   ┌── tests/move_check/parser/function_visibility_empty.move:2:5 ───
+   │
+ 2 │     public() fun f() {}
+   │     ^^^^^^^^ Invalid visibility modifier. Consider removing it or using one of `public` or `public(script)`
+   │
+

--- a/language/move-lang/tests/move_check/parser/function_visibility_empty.exp
+++ b/language/move-lang/tests/move_check/parser/function_visibility_empty.exp
@@ -3,6 +3,6 @@ error:
    ┌── tests/move_check/parser/function_visibility_empty.move:2:5 ───
    │
  2 │     public() fun f() {}
-   │     ^^^^^^^^ Invalid visibility modifier. Consider removing it or using one of `public` or `public(script)`
+   │     ^^^^^^^^ Invalid visibility modifier. Consider removing it or using one of 'public' or 'public(script)'
    │
 

--- a/language/move-lang/tests/move_check/parser/function_visibility_empty.move
+++ b/language/move-lang/tests/move_check/parser/function_visibility_empty.move
@@ -1,0 +1,3 @@
+module M {
+    public() fun f() {}
+}

--- a/language/move-lang/tests/move_check/parser/function_visibility_invalid.exp
+++ b/language/move-lang/tests/move_check/parser/function_visibility_invalid.exp
@@ -3,6 +3,6 @@ error:
    ┌── tests/move_check/parser/function_visibility_invalid.move:2:5 ───
    │
  2 │     public(invalid_modifier) fun f() {}
-   │     ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid visibility modifier. Consider removing it or using one of `public` or `public(script)`
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid visibility modifier. Consider removing it or using one of 'public' or 'public(script)'
    │
 

--- a/language/move-lang/tests/move_check/parser/function_visibility_invalid.exp
+++ b/language/move-lang/tests/move_check/parser/function_visibility_invalid.exp
@@ -1,0 +1,8 @@
+error: 
+
+   ┌── tests/move_check/parser/function_visibility_invalid.move:2:5 ───
+   │
+ 2 │     public(invalid_modifier) fun f() {}
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid visibility modifier. Consider removing it or using one of `public` or `public(script)`
+   │
+

--- a/language/move-lang/tests/move_check/parser/function_visibility_invalid.move
+++ b/language/move-lang/tests/move_check/parser/function_visibility_invalid.move
@@ -1,0 +1,3 @@
+module M {
+    public(invalid_modifier) fun f() {}
+}

--- a/language/move-lang/tests/move_check/parser/function_visibility_multiple.exp
+++ b/language/move-lang/tests/move_check/parser/function_visibility_multiple.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/parser/function_visibility_multiple.move:2:19 ───
+   │
+ 2 │     public(script script) fun f() {}
+   │                   ^^^^^^ Unexpected 'script'
+   ·
+ 2 │     public(script script) fun f() {}
+   │                   ------ Expected ')'
+   │
+

--- a/language/move-lang/tests/move_check/parser/function_visibility_multiple.move
+++ b/language/move-lang/tests/move_check/parser/function_visibility_multiple.move
@@ -1,0 +1,3 @@
+module M {
+    public(script script) fun f() {}
+}

--- a/language/move-lang/tests/move_check/parser/function_visibility_script.move
+++ b/language/move-lang/tests/move_check/parser/function_visibility_script.move
@@ -1,0 +1,5 @@
+module M {
+    public(script) fun f() {}
+    public (script) fun g() {}
+    public ( script ) fun h() {}
+}

--- a/language/move-lang/tests/move_check/typing/constant_unsupported_exps.exp
+++ b/language/move-lang/tests/move_check/typing/constant_unsupported_exps.exp
@@ -1,326 +1,399 @@
 error: 
 
-   ┌── tests/move_check/typing/constant_unsupported_exps.move:8:9 ───
-   │
- 8 │         let x = 0;
-   │         ^^^^^^^^^ 'let' declarations are not supported in constants
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/constant_unsupported_exps.move:9:9 ───
-   │
- 9 │         let s: signer = abort 0;
-   │         ^^^^^^^^^^^^^^^^^^^^^^^ 'let' declarations are not supported in constants
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/constant_unsupported_exps.move:9:25 ───
-   │
- 9 │         let s: signer = abort 0;
-   │                         ^^^^^^^ 'abort' expressions are not supported in constants
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:10:9 ───
-    │
- 10 │         let b = B { f: 0 };
-    │         ^^^^^^^^^^^^^^^^^^ 'let' declarations are not supported in constants
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:10:17 ───
-    │
- 10 │         let b = B { f: 0 };
-    │                 ^^^^^^^^^^ Structs are not supported in constants
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:11:9 ───
-    │
- 11 │         spec { };
-    │         ^^^^^^^^ Spec blocks are not supported in constants
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:12:9 ───
-    │
- 12 │         &x;
-    │         ^^ References (and reference operations) are not supported in constants
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:13:9 ───
-    │
- 13 │         &mut x;
-    │         ^^^^^^ References (and reference operations) are not supported in constants
-    │
-
-error: 
-
     ┌── tests/move_check/typing/constant_unsupported_exps.move:14:9 ───
     │
- 14 │         foo();
-    │         ^^^^^ Module calls are not supported in constants
+ 14 │         let x = 0;
+    │         ^^^^^^^^^ 'let' declarations are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:15:9 ───
     │
- 15 │         borrow_global<R>(0x42);
-    │         ^^^^^^^^^^^^^^^^^^^^^^ 'borrow_global' is not supported in constants
+ 15 │         let s: signer = abort 0;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^ 'let' declarations are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:15:25 ───
+    │
+ 15 │         let s: signer = abort 0;
+    │                         ^^^^^^^ 'abort' expressions are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:16:9 ───
     │
- 16 │         borrow_global_mut<R>(0x42);
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ 'borrow_global_mut' is not supported in constants
+ 16 │         let b = B { f: 0 };
+    │         ^^^^^^^^^^^^^^^^^^ 'let' declarations are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:16:17 ───
+    │
+ 16 │         let b = B { f: 0 };
+    │                 ^^^^^^^^^^ Structs are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:17:9 ───
     │
- 17 │         move_to(s, R{});
-    │         ^^^^^^^^^^^^^^^ Invalid call of 'move_to'. Invalid argument for parameter '0'
-    ·
-  9 │         let s: signer = abort 0;
-    │                ------ The type: 'signer'
-    ·
- 17 │         move_to(s, R{});
-    │         ------- Is not compatible with: '&signer'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:17:9 ───
-    │
- 17 │         move_to(s, R{});
-    │         ^^^^^^^^^^^^^^^ 'move_to' is not supported in constants
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:17:16 ───
-    │
- 17 │         move_to(s, R{});
-    │                ^^^^^^^^ Expression lists are not supported in constants
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:17:20 ───
-    │
- 17 │         move_to(s, R{});
-    │                    ^^^ Structs are not supported in constants
+ 17 │         spec { };
+    │         ^^^^^^^^ Spec blocks are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:18:9 ───
     │
- 18 │         R{} = move_from(0x42);
-    │         ^^^^^^^^^^^^^^^^^^^^^ Assignments are not supported in constants
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:18:15 ───
-    │
- 18 │         R{} = move_from(0x42);
-    │               ^^^^^^^^^^^^^^^ 'move_from' is not supported in constants
+ 18 │         &x;
+    │         ^^ References (and reference operations) are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:19:9 ───
     │
- 19 │         freeze(&mut x);
-    │         ^^^^^^^^^^^^^^ 'freeze' is not supported in constants
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:19:16 ───
-    │
- 19 │         freeze(&mut x);
-    │                ^^^^^^ References (and reference operations) are not supported in constants
+ 19 │         &mut x;
+    │         ^^^^^^ References (and reference operations) are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:20:9 ───
     │
- 20 │         assert(true, 42);
-    │         ^^^^^^^^^^^^^^^^ 'assert' is not supported in constants
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:20:15 ───
-    │
- 20 │         assert(true, 42);
-    │               ^^^^^^^^^^ Expression lists are not supported in constants
+ 20 │         f_public();
+    │         ^^^^^^^^^^ Module calls are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:21:9 ───
     │
- 21 │         if (true) 0 else 1;
-    │         ^^^^^^^^^^^^^^^^^^ 'if' expressions are not supported in constants
+ 21 │         f_script();
+    │         ^^^^^^^^^^ Invalid call to '0x42::M::f_script'
+    ·
+ 48 │     public(script) fun f_script() {}
+    │                        -------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:21:9 ───
+    │
+ 21 │         f_script();
+    │         ^^^^^^^^^^ Module calls are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:22:9 ───
     │
- 22 │         loop ();
-    │         ^^^^^^^ 'loop' expressions are not supported in constants
+ 22 │         f_private();
+    │         ^^^^^^^^^^^ Module calls are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:23:9 ───
     │
- 23 │         loop { break; continue; };
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ 'loop' expressions are not supported in constants
+ 23 │         0x42::X::f_public();
+    │         ^^^^^^^^^^^^^^^^^^^ Module calls are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:24:9 ───
     │
- 24 │         while (true) ();
-    │         ^^^^^^^^^^^^^^^ 'while' expressions are not supported in constants
+ 24 │         0x42::X::f_script();
+    │         ^^^^^^^^^^^^^^^^^^^ Invalid call to '0x42::X::f_script'
+    ·
+  4 │     public(script) fun f_script() {}
+    │                        -------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:24:9 ───
+    │
+ 24 │         0x42::X::f_script();
+    │         ^^^^^^^^^^^^^^^^^^^ Module calls are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:25:9 ───
     │
- 25 │         x = 1;
-    │         ^^^^^ Assignments are not supported in constants
+ 25 │         0x42::X::f_private();
+    │         ^^^^^^^^^^^^^^^^^^^^ Invalid call to '0x42::X::f_private'
+    ·
+  5 │     fun f_private() {}
+    │         --------- This function is internal to its module. Only 'public' and 'public(script)' functions can be called outside of their module
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:25:9 ───
+    │
+ 25 │         0x42::X::f_private();
+    │         ^^^^^^^^^^^^^^^^^^^^ Module calls are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:26:9 ───
     │
- 26 │         return 0;
-    │         ^^^^^^^^ 'return' expressions are not supported in constants
+ 26 │         borrow_global<R>(0x42);
+    │         ^^^^^^^^^^^^^^^^^^^^^^ 'borrow_global' is not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:27:9 ───
     │
- 27 │         abort 0;
-    │         ^^^^^^^ 'abort' expressions are not supported in constants
+ 27 │         borrow_global_mut<R>(0x42);
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ 'borrow_global_mut' is not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:28:9 ───
     │
- 28 │         *(&mut 0) = 0;
-    │         ^^^^^^^^^^^^^ References (and reference operations) are not supported in constants
+ 28 │         move_to(s, R{});
+    │         ^^^^^^^^^^^^^^^ Invalid call of 'move_to'. Invalid argument for parameter '0'
+    ·
+ 15 │         let s: signer = abort 0;
+    │                ------ The type: 'signer'
+    ·
+ 28 │         move_to(s, R{});
+    │         ------- Is not compatible with: '&signer'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:28:10 ───
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:28:9 ───
     │
- 28 │         *(&mut 0) = 0;
-    │          ^^^^^^^^ References (and reference operations) are not supported in constants
+ 28 │         move_to(s, R{});
+    │         ^^^^^^^^^^^^^^^ 'move_to' is not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:28:16 ───
+    │
+ 28 │         move_to(s, R{});
+    │                ^^^^^^^^ Expression lists are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:28:20 ───
+    │
+ 28 │         move_to(s, R{});
+    │                    ^^^ Structs are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:29:9 ───
     │
- 29 │         b.f = 0;
-    │         ^ References (and reference operations) are not supported in constants
+ 29 │         R{} = move_from(0x42);
+    │         ^^^^^^^^^^^^^^^^^^^^^ Assignments are not supported in constants
     │
 
 error: 
 
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:29:9 ───
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:29:15 ───
     │
- 29 │         b.f = 0;
-    │         ^^^ References (and reference operations) are not supported in constants
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:29:9 ───
-    │
- 29 │         b.f = 0;
-    │         ^^^^^^^ References (and reference operations) are not supported in constants
+ 29 │         R{} = move_from(0x42);
+    │               ^^^^^^^^^^^^^^^ 'move_from' is not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:30:9 ───
     │
- 30 │         b.f;
-    │         ^ References (and reference operations) are not supported in constants
+ 30 │         freeze(&mut x);
+    │         ^^^^^^^^^^^^^^ 'freeze' is not supported in constants
     │
 
 error: 
 
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:30:9 ───
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:30:16 ───
     │
- 30 │         b.f;
-    │         ^^^ References (and reference operations) are not supported in constants
+ 30 │         freeze(&mut x);
+    │                ^^^^^^ References (and reference operations) are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:31:9 ───
     │
- 31 │         *&b.f;
-    │         ^^^^^ References (and reference operations) are not supported in constants
+ 31 │         assert(true, 42);
+    │         ^^^^^^^^^^^^^^^^ 'assert' is not supported in constants
     │
 
 error: 
 
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:31:10 ───
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:31:15 ───
     │
- 31 │         *&b.f;
-    │          ^^^^ References (and reference operations) are not supported in constants
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:31:11 ───
-    │
- 31 │         *&b.f;
-    │           ^ References (and reference operations) are not supported in constants
+ 31 │         assert(true, 42);
+    │               ^^^^^^^^^^ Expression lists are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:32:9 ───
     │
- 32 │         (0, 1);
-    │         ^^^^^^ Expression lists are not supported in constants
+ 32 │         if (true) 0 else 1;
+    │         ^^^^^^^^^^^^^^^^^^ 'if' expressions are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:33:9 ───
     │
- 33 │         FLAG;
+ 33 │         loop ();
+    │         ^^^^^^^ 'loop' expressions are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:34:9 ───
+    │
+ 34 │         loop { break; continue; };
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ 'loop' expressions are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:35:9 ───
+    │
+ 35 │         while (true) ();
+    │         ^^^^^^^^^^^^^^^ 'while' expressions are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:36:9 ───
+    │
+ 36 │         x = 1;
+    │         ^^^^^ Assignments are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:37:9 ───
+    │
+ 37 │         return 0;
+    │         ^^^^^^^^ 'return' expressions are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:38:9 ───
+    │
+ 38 │         abort 0;
+    │         ^^^^^^^ 'abort' expressions are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:39:9 ───
+    │
+ 39 │         *(&mut 0) = 0;
+    │         ^^^^^^^^^^^^^ References (and reference operations) are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:39:10 ───
+    │
+ 39 │         *(&mut 0) = 0;
+    │          ^^^^^^^^ References (and reference operations) are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:40:9 ───
+    │
+ 40 │         b.f = 0;
+    │         ^ References (and reference operations) are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:40:9 ───
+    │
+ 40 │         b.f = 0;
+    │         ^^^ References (and reference operations) are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:40:9 ───
+    │
+ 40 │         b.f = 0;
+    │         ^^^^^^^ References (and reference operations) are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:41:9 ───
+    │
+ 41 │         b.f;
+    │         ^ References (and reference operations) are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:41:9 ───
+    │
+ 41 │         b.f;
+    │         ^^^ References (and reference operations) are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:42:9 ───
+    │
+ 42 │         *&b.f;
+    │         ^^^^^ References (and reference operations) are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:42:10 ───
+    │
+ 42 │         *&b.f;
+    │          ^^^^ References (and reference operations) are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:42:11 ───
+    │
+ 42 │         *&b.f;
+    │           ^ References (and reference operations) are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:43:9 ───
+    │
+ 43 │         (0, 1);
+    │         ^^^^^^ Expression lists are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:44:9 ───
+    │
+ 44 │         FLAG;
     │         ^^^^ Other constants are not supported in constants
     │
 

--- a/language/move-lang/tests/move_check/typing/constant_unsupported_exps.move
+++ b/language/move-lang/tests/move_check/typing/constant_unsupported_exps.move
@@ -1,4 +1,10 @@
 address 0x42 {
+module X {
+    public fun f_public() {}
+    public(script) fun f_script() {}
+    fun f_private() {}
+}
+
 module M {
     resource struct R {}
     struct B { f: u64 }
@@ -11,7 +17,12 @@ module M {
         spec { };
         &x;
         &mut x;
-        foo();
+        f_public();
+        f_script();
+        f_private();
+        0x42::X::f_public();
+        0x42::X::f_script();
+        0x42::X::f_private();
         borrow_global<R>(0x42);
         borrow_global_mut<R>(0x42);
         move_to(s, R{});
@@ -33,6 +44,8 @@ module M {
         FLAG;
         0
     };
-    fun foo() {}
+    public fun f_public() {}
+    public(script) fun f_script() {}
+    fun f_private() {}
 }
 }

--- a/language/move-lang/tests/move_check/typing/main_call_visibility_script.move
+++ b/language/move-lang/tests/move_check/typing/main_call_visibility_script.move
@@ -1,0 +1,11 @@
+address 0x2 {
+module X {
+    public(script) fun foo() {}
+}
+}
+
+script {
+fun main() {
+    0x2::X::foo()
+}
+}

--- a/language/move-lang/tests/move_check/typing/module_call_internal.exp
+++ b/language/move-lang/tests/move_check/typing/module_call_internal.exp
@@ -6,6 +6,6 @@ error:
     │         ^^^^^^^^ Invalid call to '0x2::X::foo'
     ·
   4 │     fun foo() {}
-    │         --- This function is internal to its module. Only 'public' functions can be called outside of their module
+    │         --- This function is internal to its module. Only 'public' and 'public(script)' functions can be called outside of their module
     │
 

--- a/language/move-lang/tests/move_check/typing/module_call_visibility_script.move
+++ b/language/move-lang/tests/move_check/typing/module_call_visibility_script.move
@@ -1,0 +1,26 @@
+address 0x2 {
+
+module X {
+    public fun f_public() {}
+    public(script) fun f_script() {}
+}
+
+module M {
+    use 0x2::X;
+
+    public fun f_public() {}
+    public fun f_private() {}
+
+    // a public(script) fun can call public(script) funs in another module
+    public(script) fun f_script_call_script() { X::f_script() }
+
+    // a public(script) fun can call public funs in another module
+    public(script) fun f_script_call_public() { X::f_public() }
+
+    // a public(script) fun can call private, public, and public(script) funs in its own module
+    public(script) fun f_script_call_self_private() { Self::f_private() }
+    public(script) fun f_script_call_self_public() { Self::f_public() }
+    public(script) fun f_script_call_self_script() { Self::f_script_call_script() }
+}
+
+}

--- a/language/move-lang/tests/move_check/typing/module_call_visibility_script_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/module_call_visibility_script_invalid.exp
@@ -1,0 +1,55 @@
+error: 
+
+    ┌── tests/move_check/typing/module_call_visibility_script_invalid.move:15:35 ───
+    │
+ 15 │     fun f_private_call_script() { X::f_script() }
+    │                                   ^^^^^^^^^^^^^ Invalid call to '0x2::X::f_script'
+    ·
+  5 │     public(script) fun f_script() {}
+    │                        -------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/module_call_visibility_script_invalid.move:16:41 ───
+    │
+ 16 │     public fun f_public_call_script() { X::f_script() }
+    │                                         ^^^^^^^^^^^^^ Invalid call to '0x2::X::f_script'
+    ·
+  5 │     public(script) fun f_script() {}
+    │                        -------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/module_call_visibility_script_invalid.move:20:40 ───
+    │
+ 20 │     fun f_private_call_self_script() { f_script_call_script() }
+    │                                        ^^^^^^^^^^^^^^^^^^^^^^ Invalid call to '0x2::M::f_script_call_script'
+    ·
+ 11 │     public(script) fun f_script_call_script() { X::f_script() }
+    │                        -------------------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/module_call_visibility_script_invalid.move:21:46 ───
+    │
+ 21 │     public fun f_public_call_self_script() { f_script_call_script() }
+    │                                              ^^^^^^^^^^^^^^^^^^^^^^ Invalid call to '0x2::M::f_script_call_script'
+    ·
+ 11 │     public(script) fun f_script_call_script() { X::f_script() }
+    │                        -------------------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/module_call_visibility_script_invalid.move:24:50 ───
+    │
+ 24 │     public(script) fun f_script_call_private() { X::f_private() }
+    │                                                  ^^^^^^^^^^^^^^ Invalid call to '0x2::X::f_private'
+    ·
+  4 │     fun f_private() {}
+    │         --------- This function is internal to its module. Only 'public' and 'public(script)' functions can be called outside of their module
+    │
+

--- a/language/move-lang/tests/move_check/typing/module_call_visibility_script_invalid.move
+++ b/language/move-lang/tests/move_check/typing/module_call_visibility_script_invalid.move
@@ -1,0 +1,27 @@
+address 0x2 {
+
+module X {
+    fun f_private() {}
+    public(script) fun f_script() {}
+}
+
+module M {
+    use 0x2::X;
+
+    public(script) fun f_script_call_script() { X::f_script() }
+
+    // a public(script) fun in another module can only be called
+    // by a public(script) fun from this module
+    fun f_private_call_script() { X::f_script() }
+    public fun f_public_call_script() { X::f_script() }
+
+    // a public(script) fun in this module can only be called
+    // by a public(script) fun from this module
+    fun f_private_call_self_script() { f_script_call_script() }
+    public fun f_public_call_self_script() { f_script_call_script() }
+
+    // a public(script) fun cannot call private funs in other modules
+    public(script) fun f_script_call_private() { X::f_private() }
+}
+
+}

--- a/language/move-model/src/builder/module_builder.rs
+++ b/language/move-model/src/builder/module_builder.rs
@@ -2398,6 +2398,10 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                         return false;
                     }
                 }
+                PA::FunctionVisibility::Script(..) => {
+                    // TODO: model script visibility properly
+                    unimplemented!("Script visibility not supported yet")
+                }
             }
         }
         let rex = Regex::new(&format!(


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

- Recognize `public(script)` in source compiler lexer
- Enforce rules for calls to and from `public(script)` functions:
  - A `public(script) fun` can only be called from a script context, i.e., a transaction script (the main function) or another `public(script) fun`.
  - A `public(script) fun` can only call other `public(script) fun` or `public fun`.

For testing purpose, `public(script)` is mapped to `public` on IR generation. This behavior will be changed once the bytecode for script visibility is ready.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

New parser and typing tests are added.
