### PR TITLE
[json-rpc] health-check for checking latest ledger info timestamp

### DIFF
--- a/json-rpc/src/runtime.rs
+++ b/json-rpc/src/runtime.rs
@@ -7,6 +7,7 @@ use crate::{
     methods::{build_registry, JsonRpcRequest, JsonRpcService, RpcRegistry},
     response::{JsonRpcResponse, X_DIEM_CHAIN_ID, X_DIEM_TIMESTAMP_USEC_ID, X_DIEM_VERSION_ID},
 };
+use anyhow::{ensure, Result};
 use diem_config::config::{NodeConfig, RoleType};
 use diem_logger::{debug, Level, Schema};
 use diem_mempool::MempoolClientSender;
@@ -14,7 +15,12 @@ use diem_types::{chain_id::ChainId, ledger_info::LedgerInfoWithSignatures};
 use futures::future::join_all;
 use rand::{rngs::OsRng, RngCore};
 use serde_json::{map::Map, Value};
-use std::{net::SocketAddr, sync::Arc};
+use std::{
+    net::SocketAddr,
+    ops::Sub,
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 use storage_interface::DbReader;
 use tokio::runtime::{Builder, Runtime};
 use warp::{
@@ -55,6 +61,15 @@ struct RpcResponseLog<'a> {
     is_batch: bool,
     response_error: bool,
     response: &'a JsonRpcResponse,
+}
+
+// HealthCheckParams is optional params for different layer's health check.
+// If no param is provided, server return 200 by default to indicate HTTP server is running health.
+#[derive(serde::Deserialize)]
+struct HealthCheckParams {
+    // Health check returns 200 when this param is provided and meet the following condition:
+    //   server latest ledger info timestamp >= server current time timestamp + duration_secs
+    pub duration_secs: Option<u64>,
 }
 
 #[macro_export]
@@ -99,7 +114,7 @@ pub fn bootstrap(
 
     let registry = Arc::new(build_registry());
     let service = JsonRpcService::new(
-        diem_db,
+        diem_db.clone(),
         mp_sender,
         role,
         chain_id,
@@ -150,7 +165,10 @@ pub fn bootstrap(
 
     let health_route = warp::path!("-" / "healthy")
         .and(warp::path::end())
-        .map(|| "diem-node:ok");
+        .and(warp::query().map(move |params: HealthCheckParams| params))
+        .and(warp::any().map(move || diem_db.clone()))
+        .and(warp::any().map(SystemTime::now))
+        .and_then(health_check);
 
     let full_route = health_route.or(route_v1.or(route_root));
 
@@ -183,6 +201,39 @@ pub fn bootstrap_from_config(
         config.base.role,
         chain_id,
     )
+}
+
+async fn health_check(
+    params: HealthCheckParams,
+    db: Arc<dyn DbReader>,
+    now: SystemTime,
+) -> Result<Box<dyn warp::Reply>, warp::Rejection> {
+    if let Some(duration) = params.duration_secs {
+        let ledger_info = db
+            .get_latest_ledger_info()
+            .map_err(|_| reject::custom(HealthCheckError))?;
+        let timestamp = ledger_info.ledger_info().timestamp_usecs();
+
+        check_latest_ledger_info_timestamp(duration, timestamp, now)
+            .map_err(|_| reject::custom(HealthCheckError))?;
+    }
+    Ok(Box::new("diem-node:ok"))
+}
+
+pub fn check_latest_ledger_info_timestamp(
+    duration_sec: u64,
+    timestamp_usecs: u64,
+    now: SystemTime,
+) -> Result<()> {
+    let timestamp = Duration::from_micros(timestamp_usecs);
+    let expectation = now
+        .sub(Duration::from_secs(duration_sec))
+        .duration_since(UNIX_EPOCH)?;
+    ensure!(
+        timestamp >= expectation,
+        "Blockchain timestamp delta with current time"
+    );
+    Ok(())
 }
 
 /// JSON RPC entry point
@@ -469,3 +520,7 @@ fn verify_protocol(request: &Map<String, Value>) -> Result<(), JsonRpcError> {
 struct DatabaseError;
 
 impl Reject for DatabaseError {}
+
+#[derive(Debug)]
+struct HealthCheckError;
+impl warp::reject::Reject for HealthCheckError {}

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     errors::{JsonRpcError, ServerCode},
+    runtime::check_latest_ledger_info_timestamp,
     tests::{
         genesis::generate_genesis_state,
         utils::{test_bootstrap, MockDiemDB},
@@ -55,8 +56,10 @@ use std::{
     cmp::{max, min},
     collections::HashMap,
     convert::TryFrom,
+    ops::Sub,
     str::FromStr,
     sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 use storage_interface::DbReader;
 use tokio::runtime::Runtime;
@@ -1521,6 +1524,52 @@ fn test_get_network_status() {
     } else {
         panic!("did not receive expected json rpc response");
     }
+}
+
+#[test]
+fn test_health_check() {
+    let (_mock_db, _runtime, url, _) = create_db_and_runtime();
+
+    let client = reqwest::blocking::Client::new();
+    let healthy_url = format!("{}/-/healthy", url);
+    let resp = client.get(&healthy_url).send().unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let healthy_url = format!(
+        "{}/-/healthy?duration={}",
+        url,
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    );
+    let resp = client.get(&healthy_url).send().unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+#[test]
+fn test_check_latest_ledger_info_timestamp() {
+    let now = SystemTime::now();
+    let ledger_latest_timestamp_lack = 10;
+
+    let ledger_latest_timestamp = now
+        .sub(Duration::from_secs(ledger_latest_timestamp_lack))
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_micros() as u64;
+
+    assert!(check_latest_ledger_info_timestamp(
+        ledger_latest_timestamp_lack - 1,
+        ledger_latest_timestamp,
+        now
+    )
+    .is_err());
+    assert!(check_latest_ledger_info_timestamp(
+        ledger_latest_timestamp_lack + 1,
+        ledger_latest_timestamp,
+        now
+    )
+    .is_ok());
 }
 
 /// Creates and returns a MockDiemDB, JsonRpcAsyncClient and corresponding server Runtime tuple for


### PR DESCRIPTION
Justification: Provides a way to validate a meaningful healthcheck of the node via json-rpc
Verification: Comprehensive tests
Requirement: Necessary to build a JSON-RPC load balancer that takes into consideration the state of the chain at a given node
Workarounds: Constructing a service that sits between the ALB and the json-rpc server that would perform this query (ALB only supports querying a URL and receiving back a 200 or error)