### PR TITLE
[move prover] basic support for manually added triggers

### DIFF
--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -262,7 +262,13 @@ pub enum Exp_ {
     Loop(Box<Exp>),
     Block(Sequence),
     Lambda(LValueList, Box<Exp>), // spec only
-    Quant(QuantKind, LValueWithRangeList, Option<Box<Exp>>, Box<Exp>), // spec only
+    Quant(
+        QuantKind,
+        LValueWithRangeList,
+        Vec<Vec<Exp>>,
+        Option<Box<Exp>>,
+        Box<Exp>,
+    ), // spec only
 
     Assign(LValueList, Box<Exp>),
     FieldMutate(Box<ExpDotted>, Box<Exp>),
@@ -278,7 +284,9 @@ pub enum Exp_ {
     BinopExp(Box<Exp>, BinOp, Box<Exp>),
 
     ExpList(Vec<Exp>),
-    Unit { trailing: bool },
+    Unit {
+        trailing: bool,
+    },
 
     Borrow(bool, Box<Exp>),
     ExpDotted(Box<ExpDotted>),
@@ -812,10 +820,11 @@ impl AstDebug for Exp_ {
                 w.write(" ");
                 e.ast_debug(w);
             }
-            E::Quant(kind, sp!(_, rs), c_opt, e) => {
+            E::Quant(kind, sp!(_, rs), trs, c_opt, e) => {
                 kind.ast_debug(w);
                 w.write(" ");
                 rs.ast_debug(w);
+                trs.ast_debug(w);
                 if let Some(c) = c_opt {
                     w.write(" where ");
                     c.ast_debug(w);
@@ -988,5 +997,15 @@ impl AstDebug for (LValue, Exp) {
         self.0.ast_debug(w);
         w.write(" in ");
         self.1.ast_debug(w);
+    }
+}
+
+impl AstDebug for Vec<Vec<Exp>> {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        for trigger in self {
+            w.write("{");
+            w.comma(trigger, |w, b| b.ast_debug(w));
+            w.write("}");
+        }
     }
 }

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -498,8 +498,14 @@ pub enum Exp_ {
     Block(Sequence),
     // fun (x1, ..., xn) e
     Lambda(BindList, Box<Exp>), // spec only
-    // forall/exists x1 : e1, ..., xn [where cond]: en.
-    Quant(QuantKind, BindWithRangeList, Option<Box<Exp>>, Box<Exp>), // spec only
+    // forall/exists x1 : e1, ..., xn [{ t1, .., tk } *] [where cond]: en.
+    Quant(
+        QuantKind,
+        BindWithRangeList,
+        Vec<Vec<Exp>>,
+        Option<Box<Exp>>,
+        Box<Exp>,
+    ), // spec only
     // (e1, ..., en)
     ExpList(Vec<Exp>),
     // ()
@@ -1372,10 +1378,11 @@ impl AstDebug for Exp_ {
                 w.write(" ");
                 e.ast_debug(w);
             }
-            E::Quant(kind, sp!(_, rs), c_opt, e) => {
+            E::Quant(kind, sp!(_, rs), trs, c_opt, e) => {
                 kind.ast_debug(w);
                 w.write(" ");
                 rs.ast_debug(w);
+                trs.ast_debug(w);
                 if let Some(c) = c_opt {
                     w.write(" where ");
                     c.ast_debug(w);
@@ -1529,6 +1536,16 @@ impl AstDebug for Vec<Bind> {
         w.comma(self, |w, b| b.ast_debug(w));
         if parens {
             w.write(")");
+        }
+    }
+}
+
+impl AstDebug for Vec<Vec<Exp>> {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        for trigger in self {
+            w.write("{");
+            w.comma(trigger, |w, b| b.ast_debug(w));
+            w.write("}");
         }
     }
 }

--- a/language/move-model/src/exp_rewriter.rs
+++ b/language/move-model/src/exp_rewriter.rs
@@ -77,7 +77,7 @@ impl<'env, 'rewriter> ExpRewriter<'env, 'rewriter> {
                 self.shadowed.pop_front();
                 res
             }
-            Quant(id, kind, ranges, condition, body) => {
+            Quant(id, kind, ranges, triggers, condition, body) => {
                 let ranges = ranges
                     .iter()
                     .map(|(decl, range)| (decl.clone(), self.rewrite(range)))
@@ -88,6 +88,10 @@ impl<'env, 'rewriter> ExpRewriter<'env, 'rewriter> {
                     self.rewrite_attrs(*id),
                     *kind,
                     ranges,
+                    triggers
+                        .iter()
+                        .map(|trigger| trigger.iter().map(|exp| self.rewrite(&*exp)).collect())
+                        .collect(),
                     condition.as_ref().map(|exp| Box::new(self.rewrite(&*exp))),
                     Box::new(self.rewrite(body)),
                 );

--- a/language/move-prover/boogie-backend/src/spec_translator.rs
+++ b/language/move-prover/boogie-backend/src/spec_translator.rs
@@ -358,9 +358,9 @@ impl<'env> SpecTranslator<'env> {
                 &self.env.get_node_loc(*node_id),
                 "`|x|e` (lambda) currently only supported as argument for `all` or `any`",
             ),
-            Exp::Quant(node_id, kind, ranges, condition, exp) => {
+            Exp::Quant(node_id, kind, ranges, triggers, condition, exp) => {
                 self.set_writer_location(*node_id);
-                self.translate_quant(*node_id, *kind, ranges, condition, exp)
+                self.translate_quant(*node_id, *kind, ranges, triggers, condition, exp)
             }
             Exp::Block(node_id, vars, scope) => {
                 self.set_writer_location(*node_id);
@@ -719,11 +719,58 @@ impl<'env> SpecTranslator<'env> {
         emit!(self.writer, ")])");
     }
 
+    fn with_range_selector_assignments<F>(
+        &self,
+        ranges: &[(LocalVarDecl, Exp)],
+        range_tmps: &HashMap<Symbol, String>,
+        quant_vars: &HashMap<Symbol, String>,
+        f: F,
+    ) where
+        F: Fn(),
+    {
+        // Translate range selectors.
+        for (var, range) in ranges {
+            let var_name = self.env.symbol_pool().string(var.name);
+            let quant_ty = self.env.get_node_type(range.node_id());
+            match quant_ty.skip_reference() {
+                Type::Vector(..) => {
+                    let range_tmp = range_tmps.get(&var.name).unwrap();
+                    let quant_var = quant_vars.get(&var.name).unwrap();
+                    emit!(
+                        self.writer,
+                        "(var {} := $select_vector({}, {}); ",
+                        var_name,
+                        range_tmp,
+                        quant_var,
+                    );
+                }
+                Type::Primitive(PrimitiveType::Range) => {
+                    let quant_var = quant_vars.get(&var.name).unwrap();
+                    emit!(
+                        self.writer,
+                        "(var {} := $Integer({}); ",
+                        var_name,
+                        quant_var
+                    );
+                }
+                _ => (),
+            }
+        }
+        f();
+        emit!(
+            self.writer,
+            &std::iter::repeat(")")
+                .take(range_tmps.len())
+                .collect::<String>()
+        );
+    }
+
     fn translate_quant(
         &self,
         node_id: NodeId,
         kind: QuantKind,
         ranges: &[(LocalVarDecl, Exp)],
+        triggers: &[Vec<Exp>],
         condition: &Option<Box<Exp>>,
         body: &Exp,
     ) {
@@ -736,12 +783,11 @@ impl<'env> SpecTranslator<'env> {
                 quant_ty.skip_reference(),
                 Type::Vector(..) | Type::Primitive(PrimitiveType::Range)
             ) {
-                let var_name = self.env.symbol_pool().string(var.name);
                 let range_tmp = self.fresh_var_name("range");
                 emit!(self.writer, "(var {} := ", range_tmp);
                 self.translate_exp(&range);
                 emit!(self.writer, "; ");
-                range_tmps.insert(var_name, range_tmp);
+                range_tmps.insert(var.name, range_tmp);
             }
         }
         // Translate quantified variables.
@@ -758,12 +804,27 @@ impl<'env> SpecTranslator<'env> {
                 _ => {
                     let quant_var = self.fresh_var_name("i");
                     emit!(self.writer, "{}{}: int", comma, quant_var);
-                    quant_vars.insert(var_name, quant_var);
+                    quant_vars.insert(var.name, quant_var);
                 }
             }
             comma = ", ";
         }
         emit!(self.writer, " :: ");
+        // Translate triggers.
+        if !triggers.is_empty() {
+            for trigger in triggers {
+                emit!(self.writer, "{");
+                let mut comma = "";
+                for p in trigger {
+                    emit!(self.writer, "{}", comma);
+                    self.with_range_selector_assignments(&ranges, &range_tmps, &quant_vars, || {
+                        self.translate_exp(p);
+                    });
+                    comma = ",";
+                }
+                emit!(self.writer, "}");
+            }
+        }
         // Translate range constraints.
         let connective = match kind {
             QuantKind::Forall => " ==> ",
@@ -793,8 +854,8 @@ impl<'env> SpecTranslator<'env> {
                     }
                 }
                 Type::Vector(..) => {
-                    let range_tmp = range_tmps.get(&var_name).unwrap();
-                    let quant_var = quant_vars.get(&var_name).unwrap();
+                    let range_tmp = range_tmps.get(&var.name).unwrap();
+                    let quant_var = quant_vars.get(&var.name).unwrap();
                     emit!(
                         self.writer,
                         "{}$InVectorRange({}, {})",
@@ -804,8 +865,8 @@ impl<'env> SpecTranslator<'env> {
                     );
                 }
                 Type::Primitive(PrimitiveType::Range) => {
-                    let range_tmp = range_tmps.get(&var_name).unwrap();
-                    let quant_var = quant_vars.get(&var_name).unwrap();
+                    let range_tmp = range_tmps.get(&var.name).unwrap();
+                    let quant_var = quant_vars.get(&var.name).unwrap();
                     emit!(
                         self.writer,
                         "{}$InRange({}, {})",
@@ -819,46 +880,21 @@ impl<'env> SpecTranslator<'env> {
             separator = connective;
         }
         emit!(self.writer, "{}", connective);
-        // Translate range selectors.
-        for (var, range) in ranges {
-            let var_name = self.env.symbol_pool().string(var.name);
-            let quant_ty = self.env.get_node_type(range.node_id());
-            match quant_ty.skip_reference() {
-                Type::Vector(..) => {
-                    let range_tmp = range_tmps.get(&var_name).unwrap();
-                    let quant_var = quant_vars.get(&var_name).unwrap();
-                    emit!(
-                        self.writer,
-                        "(var {} := $select_vector({}, {}); ",
-                        var_name,
-                        range_tmp,
-                        quant_var,
-                    );
-                }
-                Type::Primitive(PrimitiveType::Range) => {
-                    let quant_var = quant_vars.get(&var_name).unwrap();
-                    emit!(
-                        self.writer,
-                        "(var {} := $Integer({}); ",
-                        var_name,
-                        quant_var
-                    );
-                }
-                _ => (),
+        self.with_range_selector_assignments(&ranges, &range_tmps, &quant_vars, || {
+            // Translate body and "where" condition.
+            if let Some(cond) = condition {
+                emit!(self.writer, "b#$Boolean(");
+                self.translate_exp(cond);
+                emit!(self.writer, ") {}", connective);
             }
-        }
-        // Translate body and "where" condition.
-        if let Some(cond) = condition {
             emit!(self.writer, "b#$Boolean(");
-            self.translate_exp(cond);
-            emit!(self.writer, ") {}", connective);
-        }
-        emit!(self.writer, "b#$Boolean(");
-        self.translate_exp(body);
+            self.translate_exp(body);
+            emit!(self.writer, ")");
+        });
         emit!(
             self.writer,
             &std::iter::repeat(")")
-                .take(3 + 2 * range_tmps.len())
+                .take(range_tmps.len().checked_add(2).unwrap())
                 .collect::<String>()
         );
     }

--- a/language/move-prover/bytecode/src/spec_translator.rs
+++ b/language/move-prover/bytecode/src/spec_translator.rs
@@ -395,15 +395,26 @@ impl<'a, 'b> SpecTranslator<'a, 'b> {
                 self.shadowed.pop();
                 res
             }
-            Quant(node_id, kind, decls, where_opt, body) => {
+            Quant(node_id, kind, decls, triggers, where_opt, body) => {
                 let decls = self.translate_exp_quant_decls(decls, in_old);
                 self.shadowed
                     .push(decls.iter().map(|(d, _)| d.name).collect());
+                let triggers = triggers
+                    .iter()
+                    .map(|tr| tr.iter().map(|e| self.translate_exp(e, in_old)).collect())
+                    .collect();
                 let where_opt = where_opt
                     .as_ref()
                     .map(|e| Box::new(self.translate_exp(e, in_old)));
                 let body = Box::new(self.translate_exp(body, in_old));
-                let res = Quant(self.instantiate(*node_id), *kind, decls, where_opt, body);
+                let res = Quant(
+                    self.instantiate(*node_id),
+                    *kind,
+                    decls,
+                    triggers,
+                    where_opt,
+                    body,
+                );
                 self.shadowed.pop();
                 res
             }

--- a/language/move-prover/tests/sources/functional/invariants_with_quant.move
+++ b/language/move-prover/tests/sources/functional/invariants_with_quant.move
@@ -1,0 +1,24 @@
+// This file consists of test cases for invariants with hand-written triggers.
+module TestQuantInvariant {
+    use 0x1::Vector;
+
+    spec module {
+        pragma verify = true;
+    }
+
+    fun vector_of_proper_positives(): vector<u64> {
+        let v = Vector::empty();
+        Vector::push_back(&mut v, 1);
+        Vector::push_back(&mut v, 2);
+        Vector::push_back(&mut v, 3);
+        v
+    }
+    spec fun vector_of_proper_positives {
+        aborts_if false;
+        ensures forall n in result: n > 0;
+        ensures forall i in 0..len(result), j in 0..len(result) where result[i] == result[j] : i == j;
+        ensures forall i : u64, j : u64 { result[i], result[j] }
+            where result[i] == result[j] && i >= 0 && i < len(result) && j >= 0 && j < len(result) : i == j;
+        ensures forall i in 0..len(result) { result[i], result[i] } { result[i] }: {let i = result[i]; i > 0};
+    }
+}


### PR DESCRIPTION
## Motivation

Experiment with triggers

The syntax is similar to Boogie, except triggers are just after quantifiers:
```
forall x : V { trigger1 } .. { triggerN } where condition : expression
```

https://github.com/diem/diem/pull/7500 (abandonned) turns out to be unnecessary because let-bindings in triggers appear to be in fact correctly handled by Boogie and Z3.

## Test Plan

CI + new test file