### PR TITLE
add RefundMetadata struct for generating types

### DIFF
--- a/testsuite/generate-format/src/diem.rs
+++ b/testsuite/generate-format/src/diem.rs
@@ -58,6 +58,8 @@ pub fn get_registry() -> Result<Registry> {
     tracer.trace_type::<transaction::metadata::Metadata>(&samples)?;
     tracer.trace_type::<transaction::metadata::GeneralMetadata>(&samples)?;
     tracer.trace_type::<transaction::metadata::TravelRuleMetadata>(&samples)?;
+    tracer.trace_type::<transaction::metadata::RefundMetadata>(&samples)?;
+    tracer.trace_type::<transaction::metadata::RefundReason>(&samples)?;
     tracer.trace_type::<transaction::Transaction>(&samples)?;
     tracer.trace_type::<transaction::TransactionArgument>(&samples)?;
     tracer.trace_type::<transaction::TransactionPayload>(&samples)?;

--- a/testsuite/generate-format/tests/staged/diem.yaml
+++ b/testsuite/generate-format/tests/staged/diem.yaml
@@ -83,6 +83,10 @@ Metadata:
       UnstructuredBytesMetadata:
         NEWTYPE:
           TYPENAME: UnstructuredBytesMetadata
+    4:
+      RefundMetadata:
+        NEWTYPE:
+          TYPENAME: RefundMetadata
 Module:
   STRUCT:
     - code: BYTES
@@ -103,6 +107,27 @@ RawTransaction:
     - expiration_timestamp_secs: U64
     - chain_id:
         TYPENAME: ChainId
+RefundMetadata:
+  ENUM:
+    0:
+      RefundMetadataV0:
+        NEWTYPE:
+          TYPENAME: RefundMetadataV0
+RefundMetadataV0:
+  STRUCT:
+    - transaction_version: U64
+    - reason:
+        TYPENAME: RefundReason
+RefundReason:
+  ENUM:
+    0:
+      OtherReason: UNIT
+    1:
+      InvalidSubaddress: UNIT
+    2:
+      UserInitiatedPartialRefund: UNIT
+    3:
+      UserInitiatedFullRefund: UNIT
 Script:
   STRUCT:
     - code: BYTES

--- a/types/src/transaction/metadata.rs
+++ b/types/src/transaction/metadata.rs
@@ -15,6 +15,7 @@ pub enum Metadata {
     GeneralMetadata(GeneralMetadata),
     TravelRuleMetadata(TravelRuleMetadata),
     UnstructuredBytesMetadata(UnstructuredBytesMetadata),
+    RefundMetadata(RefundMetadata),
 }
 
 /// List of supported transaction metadata format versions for regular
@@ -89,4 +90,27 @@ pub struct UnstructuredBytesMetadata {
     /// Unstructured byte vector metadata
     #[serde(with = "serde_bytes")]
     metadata: Option<Vec<u8>>,
+}
+
+/// List of supported transaction metadata format versions for refund transaction
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum RefundMetadata {
+    RefundMetadataV0(RefundMetadataV0),
+}
+
+/// Transaction metadata format for transactions subject to refund transaction
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct RefundMetadataV0 {
+    /// Transaction version that is refunded
+    pub transaction_version: u64,
+    /// The reason of the refund
+    pub reason: RefundReason,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum RefundReason {
+    OtherReason,
+    InvalidSubaddress,
+    UserInitiatedPartialRefund,
+    UserInitiatedFullRefund,
 }


### PR DESCRIPTION

## Motivation

New RefundMetadata struct is proposed for refund transaction to store original transaction version.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

YES

## Test Plan

Unit test