### PR TITLE
Fix docker-compose issues in faucet/validator_testnet

### DIFF
--- a/docker/compose/README.md
+++ b/docker/compose/README.md
@@ -16,14 +16,14 @@ To use these compositions:
 To build your own complete testnet:
 0. Review both **validator-testnet** and **mint** docker-compose.yaml and ensure the image points to the same tagged image.
 1. Start the **validator-testnet**:
-    1. Enter the **validator-testnet** diretory `cd validator-testnet`
+    1. Enter the **validator-testnet** directory `cd validator-testnet`
     2. Start the composition `docker-compose up -d`
     3. Confirm that waypoint.txt is not empty
     4. Return to the compose directory: `cd ..`
 2. Start **mint**:
     1. Enter the **mint** directory: `cd mint`
     2. Copy the testnet waypoint: `cp ../validator-testnet/waypoint.txt .`
-    3. Copy the testnet mint.key: `cp ../validator-testnet/diem_root_key mint.key`
+    3. Copy the testnet diem_root_key as the mint.key: `cp ../validator-testnet/diem_root_key mint.key`
     4. Start the composition `docker-compose up -d`
     5. Return to the compose directory: `cd ..`
 3. Enjoy your testnet:

--- a/docker/compose/mint/.gitignore
+++ b/docker/compose/mint/.gitignore
@@ -1,0 +1,2 @@
+# Generated files from running docker containers
+waypoint.txt

--- a/docker/compose/mint/docker-compose.yaml
+++ b/docker/compose/mint/docker-compose.yaml
@@ -7,12 +7,12 @@
 # * waypoint.txt
 #
 # Additional notes:
-# * Images can be found at https://hub.docker.com/r/diem/mint/tags, obtain the latest tag and
+# * Images can be found at https://hub.docker.com/r/diem/faucet/tags, obtain the latest tag and
 # update below.
 version: "3.8"
 services:
-    mint:
-        image: libra/mint:master_f53da21f
+    faucet:
+        image: libra/faucet:devnet
         environment:
             AC_HOST: "172.16.1.3"
             AC_PORT: "8080"
@@ -24,22 +24,16 @@ services:
             - type: bind
               source: ./mint.key
               target: /opt/diem/etc/mint.key
-            - type: bind
-              source: ./waypoint.txt
-              target: /opt/diem/etc/waypoint.txt
         command: [
-            "gunicorn",
-            "--bind",
-            "0.0.0.0:8000",
-            "--access-logfile",
-            "-",
-            "--error-logfile",
-            "-",
-            "--log-level",
-            "info",
-            "--pythonpath",
-            "/opt/diem/bin",
-            "server",
+            "/opt/diem/bin/diem-faucet",
+            "--address",
+            "0.0.0.0",
+            "--port",
+            "8000",
+            "--mint-key-file-path",
+            "/opt/diem/etc/mint.key",
+            "--server-url",
+            "${AC_HOST:-172.16.1.3}"
         ]
         ports:
             - "8000:8000"

--- a/docker/compose/public_full_node/docker-compose.yaml
+++ b/docker/compose/public_full_node/docker-compose.yaml
@@ -31,7 +31,7 @@
 version: "3.8"
 services:
     fullnode:
-        image: libra/validator:testnet
+        image: libra/validator:devnet
         volumes:
             - type: volume
               source: db

--- a/docker/compose/validator-testnet/docker-compose.yaml
+++ b/docker/compose/validator-testnet/docker-compose.yaml
@@ -3,7 +3,7 @@
 # * JSON-RPC endpoint at http://127.0.0.1:8080.
 # * waypoint file at waypoint.txt in the same directory as this compose
 # * genesis.blob at genesis.blob in the same directory as this compose
-# * diem_root_key (mint.key) in the same directory as this compose
+# * mint.key (diem_root_key) in the same directory as this compose
 # * chain_id of 4 / TESTING
 #
 # Additional information:
@@ -19,7 +19,7 @@ services:
     validator:
         # Note this image currently does not support this, will update to the appropriate minimum
         # version shortly
-        image: libra/validator:master_f53da21f
+        image: libra/validator:devnet
         networks:
             shared:
                 ipv4_address: 172.16.1.3


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
Fix docker-compose issues in faucet/validator_testnet for #7477:
- validator_testnet version was missing from dockerhub (updated it)
- mint was renamed faucet(?) at some point, but the compose.yml was never updated. I renamed the directories and updated the file so it works


### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?
yes

## Test Plan
`docker-compose up` in `diem/docker/compose/faucet` and `diem/docker/compose/validator-testnet`; they should work and be able to speak to one another

Also test CLI:
```
➜  diem git:(mkaplan-make-existing-docker-work) ✗ cargo run -p cli -- --url http://127.0.0.1:8080 --waypoint 0:35d330c20e15f9d5e0c0e3cc3b794082cf4a908730b7e04196070750cc54a3ab --chain-id TESTNET
    Finished dev [unoptimized + debuginfo] target(s) in 0.57s
     Running `target/debug/cli --url 'http://127.0.0.1:8080' --waypoint '0:35d330c20e15f9d5e0c0e3cc3b794082cf4a908730b7e04196070750cc54a3ab' --chain-id TESTNET`
Connected to validator at: http://127.0.0.1:8080, latest version = 2289700, timestamp = 2021-02-09 17:52:20.294720 UTC
...

diem% a c
>> Creating/retrieving next local account from wallet
Created/retrieved local account #0 address 89b53daace7f0b780ec10498ed93f5ee
```

