### PR TITLE
[move-prover] Update boogie

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -23,7 +23,7 @@ VAULT_VERSION=1.5.0
 Z3_VERSION=4.8.9
 CVC4_VERSION=aac53f51
 DOTNET_VERSION=3.1
-BOOGIE_VERSION=2.7.35
+BOOGIE_VERSION=2.8.25
 
 SCRIPT_PATH="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
 cd "$SCRIPT_PATH/.." || exit


### PR DESCRIPTION

## Motivation

This PR updates Boogie to 2.8.25.  To distinguish Boogie compilation errors from verification errors, a different strategy is used.  Move Prover exits early if compilation errors are detected.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests.

## Related PRs
