### PR TITLE
[move-prover][refactoring] Implementing data invariants for the v2 compilation scheme.

### DIFF
--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -1769,6 +1769,15 @@ impl<'env> StructEnv<'env> {
         self.data.name
     }
 
+    /// Gets full name as string.
+    pub fn get_full_name_str(&self) -> String {
+        format!(
+            "{}:{}",
+            self.module_env.get_name().display(self.symbol_pool()),
+            self.get_name().display(self.symbol_pool())
+        )
+    }
+
     /// Returns the VM identifier for this struct
     pub fn get_identifier(&self) -> Identifier {
         let handle = self
@@ -2173,6 +2182,15 @@ impl<'env> FunctionEnv<'env> {
     /// Returns the name of this function.
     pub fn get_name(&self) -> Symbol {
         self.data.name
+    }
+
+    /// Gets full name as string.
+    pub fn get_full_name_str(&self) -> String {
+        format!(
+            "{}:{}",
+            self.module_env.get_name().display(self.symbol_pool()),
+            self.get_name().display(self.symbol_pool())
+        )
     }
 
     /// Returns the VM identifier for this function

--- a/language/move-model/src/ty.rs
+++ b/language/move-model/src/ty.rs
@@ -119,6 +119,11 @@ impl Type {
         matches!(self, Type::Reference(false, _))
     }
 
+    /// Determines whether this type is a struct.
+    pub fn is_struct(&self) -> bool {
+        matches!(self, Type::Struct(..))
+    }
+
     /// Returns true if this type is a specification language only type or contains specification
     /// language only types
     pub fn is_spec(&self) -> bool {

--- a/language/move-prover/bytecode/src/data_invariant_instrumentation.rs
+++ b/language/move-prover/bytecode/src/data_invariant_instrumentation.rs
@@ -1,0 +1,256 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Transformation which injects data invariants into the bytecode.
+
+use crate::{
+    function_data_builder::FunctionDataBuilder,
+    function_target::FunctionData,
+    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant},
+    options::{ProverOptions, PROVER_DEFAULT_OPTIONS},
+    stackless_bytecode::{Bytecode, Operation, PropKind},
+};
+
+use move_model::{
+    ast,
+    ast::{ConditionKind, Exp, TempIndex},
+    model::{ConditionTag, FunctionEnv, StructEnv},
+};
+
+const INVARIANT_FAILS_MESSAGE: &str = "data invariant does not hold";
+
+pub struct DataInvariantInstrumentationProcessor {}
+
+impl DataInvariantInstrumentationProcessor {
+    pub fn new() -> Box<Self> {
+        Box::new(Self {})
+    }
+}
+
+impl FunctionTargetProcessor for DataInvariantInstrumentationProcessor {
+    fn process(
+        &self,
+        _targets: &mut FunctionTargetsHolder,
+        fun_env: &FunctionEnv<'_>,
+        data: FunctionData,
+    ) -> FunctionData {
+        if fun_env.is_native()
+            || fun_env.is_intrinsic()
+            || data.variant != FunctionVariant::Verification
+        {
+            // Nothing to do.
+            return data;
+        }
+
+        let options = fun_env
+            .module_env
+            .env
+            .get_extension::<ProverOptions>()
+            .unwrap_or_else(|| &*PROVER_DEFAULT_OPTIONS);
+
+        Instrumenter::run(options, fun_env, data)
+    }
+
+    fn name(&self) -> String {
+        "data_invariant_instrumenter".to_string()
+    }
+}
+
+struct Instrumenter<'a> {
+    _options: &'a ProverOptions,
+    builder: FunctionDataBuilder<'a>,
+}
+
+impl<'a> Instrumenter<'a> {
+    fn run(
+        options: &'a ProverOptions,
+        fun_env: &FunctionEnv<'a>,
+        data: FunctionData,
+    ) -> FunctionData {
+        let builder = FunctionDataBuilder::new(fun_env, data);
+        let mut instrumenter = Instrumenter {
+            _options: options,
+            builder,
+        };
+        instrumenter.instrument();
+        instrumenter.builder.data
+    }
+
+    fn instrument(&mut self) {
+        // Extract and clear current code
+        let old_code = std::mem::take(&mut self.builder.data.code);
+
+        // Emit entrypoint assumptions.
+        self.instrument_entrypoint();
+
+        // Instrument and generate new code
+        for bc in old_code {
+            self.instrument_bytecode(bc.clone());
+        }
+    }
+
+    fn instrument_entrypoint(&mut self) {
+        // For all parameters of struct type which are not &mut, assume their invariants.
+        for param in 0..self.builder.fun_env.get_parameter_count() {
+            let ty = self.builder.fun_env.get_local_type(param);
+            if ty.is_mutable_reference() {
+                // Invariant does not hold for mutable references.
+                continue;
+            }
+            if ty.skip_reference().is_struct() {
+                // Emit deep assume of the invariant.
+                self.emit_data_invariant_for_temp(true, PropKind::Assume, param);
+            }
+        }
+    }
+
+    fn instrument_bytecode(&mut self, bc: Bytecode) {
+        use Bytecode::*;
+        use Operation::*;
+        match bc {
+            // Remove Unpack, we currently don't need it.
+            Call(_, _, UnpackRef, _) | Call(_, _, UnpackRefDeep, _) => {}
+
+            // Instructions which lead to asserting data invariants.
+            Call(id, dests, Pack(mid, sid, targs), srcs) => {
+                let struct_temp = dests[0];
+                self.builder
+                    .emit(Call(id, dests, Pack(mid, sid, targs), srcs));
+                // Emit a shallow assert of the data invariant.
+                self.emit_data_invariant_for_temp(false, PropKind::Assert, struct_temp);
+            }
+            Call(_, _, PackRef, srcs) => {
+                // Emit a shallow assert of the data invariant.
+                self.emit_data_invariant_for_temp(false, PropKind::Assert, srcs[0]);
+            }
+            Call(_, _, PackRefDeep, srcs) => {
+                // Emit a deep assert of the data invariant.
+                self.emit_data_invariant_for_temp(true, PropKind::Assert, srcs[0]);
+            }
+
+            // Instructions which lead to assuming data invariants.
+            Call(id, dests, BorrowGlobal(mid, sid, targs), srcs) => {
+                let struct_temp = dests[0];
+                self.builder
+                    .emit(Call(id, dests, BorrowGlobal(mid, sid, targs), srcs));
+                // Emit deep assume of the data invariant.
+                self.emit_data_invariant_for_temp(true, PropKind::Assume, struct_temp);
+            }
+            Call(id, dests, GetGlobal(mid, sid, targs), srcs) => {
+                let struct_temp = dests[0];
+                self.builder
+                    .emit(Call(id, dests, GetGlobal(mid, sid, targs), srcs));
+                // Emit deep assume of the data invariant.
+                self.emit_data_invariant_for_temp(true, PropKind::Assume, struct_temp);
+            }
+
+            _ => self.builder.emit(bc),
+        }
+    }
+
+    /// Emits a data invariant, shallow or deep, assume or assert, for the value in temporary.
+    pub fn emit_data_invariant_for_temp(
+        &mut self,
+        deep: bool,
+        kind: PropKind,
+        struct_temp: TempIndex,
+    ) {
+        let (mid, sid, _) = self
+            .builder
+            .get_target()
+            .get_local_type(struct_temp)
+            .skip_reference()
+            .require_struct();
+        let struct_env = self.builder.global_env().get_module(mid).into_struct(sid);
+        if deep {
+            self.emit_data_invariant_deep(kind, &struct_env, &mut |_| struct_temp);
+        } else {
+            self.emit_data_invariant(kind, &struct_env, &mut |_| struct_temp);
+        }
+    }
+
+    /// Emits a data invariant for the given struct hold in `struct_temp(_)`. Depending
+    /// on `kind`, this will be an assert or assume.
+    fn emit_data_invariant(
+        &mut self,
+        kind: PropKind,
+        struct_env: &StructEnv<'_>,
+        struct_temp_fun: &mut dyn FnMut(&mut FunctionDataBuilder) -> TempIndex,
+    ) {
+        use ast::Operation::*;
+        use Exp::*;
+        self.builder.set_next_debug_comment(format!(
+            "data invariant for `{}`",
+            struct_env.get_full_name_str()
+        ));
+        for cond in struct_env.get_spec().filter_kind(ConditionKind::Invariant) {
+            // Rewrite the invariant expression, inserting `temp_exp` for the struct target.
+            // By convention, selection from the target is represented as a `Select` operation with
+            // an empty argument list. It is guaranteed that this uniquely identifies the
+            // target, as any other `Select` will have exactly one argument.
+            let struct_temp = struct_temp_fun(&mut self.builder);
+            let temp_exp = self.builder.mk_local(struct_temp);
+            let exp = cond.exp.clone().rewrite(&mut |e| match e {
+                Call(id, oper @ Select(..), args) if args.is_empty() => {
+                    (true, Call(id, oper, vec![temp_exp.clone()]))
+                }
+                _ => (false, e),
+            });
+            if kind == PropKind::Assert {
+                self.builder.set_loc_and_vc_info(
+                    cond.loc.clone(),
+                    ConditionTag::Requires,
+                    INVARIANT_FAILS_MESSAGE,
+                );
+            }
+            self.builder.emit_with(|id| Bytecode::Prop(id, kind, exp));
+        }
+        self.builder.clear_next_debug_comment();
+    }
+
+    /// Emits a data invariant for this struct and all its transitive fields.
+    fn emit_data_invariant_deep(
+        &mut self,
+        kind: PropKind,
+        struct_env: &StructEnv<'_>,
+        struct_temp_fun: &mut dyn FnMut(&mut FunctionDataBuilder) -> TempIndex,
+    ) {
+        self.emit_data_invariant(kind, struct_env, struct_temp_fun);
+        for field_env in struct_env.get_fields() {
+            let ty = field_env.get_type();
+            if ty.is_struct() {
+                let (mid, sid, targs) = ty.require_struct();
+                let field_struct_env = self.builder.global_env().get_module(mid).into_struct(sid);
+                let mut field_temp_opt: Option<TempIndex> = None;
+
+                // Function which lazily creates a temporary which holds a selected field value.
+                // This is lazy because we do not know whether we actually need it unless we have
+                // descended into the field and found an invariant somewhere.
+                let mut field_temp_fun = |builder: &mut FunctionDataBuilder| {
+                    if let Some(temp) = field_temp_opt {
+                        temp
+                    } else {
+                        let parent_temp = struct_temp_fun(builder);
+                        let new_temp = builder.new_temp(ty.clone());
+                        builder.emit_with(|id| {
+                            Bytecode::Call(
+                                id,
+                                vec![new_temp],
+                                Operation::GetField(
+                                    struct_env.module_env.get_id(),
+                                    struct_env.get_id(),
+                                    targs.to_vec(),
+                                    field_env.get_offset(),
+                                ),
+                                vec![parent_temp],
+                            )
+                        });
+                        field_temp_opt = Some(new_temp);
+                        new_temp
+                    }
+                };
+                self.emit_data_invariant_deep(kind, &field_struct_env, &mut field_temp_fun);
+            }
+        }
+    }
+}

--- a/language/move-prover/bytecode/src/lib.rs
+++ b/language/move-prover/bytecode/src/lib.rs
@@ -10,6 +10,7 @@ pub mod annotations;
 pub mod borrow_analysis;
 pub mod clean_and_optimize;
 pub mod compositional_analysis;
+pub mod data_invariant_instrumentation;
 pub mod dataflow_analysis;
 pub mod debug_instrumentation;
 pub mod eliminate_imm_refs;

--- a/language/move-prover/bytecode/src/spec_instrumentation.rs
+++ b/language/move-prover/bytecode/src/spec_instrumentation.rs
@@ -70,15 +70,15 @@ fn modify_check_fails_message(
 //  ================================================================================================
 /// # Spec Instrumenter
 
-pub struct SpecInstrumenterProcessor {}
+pub struct SpecInstrumentationProcessor {}
 
-impl SpecInstrumenterProcessor {
+impl SpecInstrumentationProcessor {
     pub fn new() -> Box<Self> {
         Box::new(Self {})
     }
 }
 
-impl FunctionTargetProcessor for SpecInstrumenterProcessor {
+impl FunctionTargetProcessor for SpecInstrumentationProcessor {
     fn initialize(&self, env: &GlobalEnv, targets: &mut FunctionTargetsHolder) {
         // Perform static analysis part of modifies check.
         check_modifies(env, targets);

--- a/language/move-prover/bytecode/src/stackless_bytecode.rs
+++ b/language/move-prover/bytecode/src/stackless_bytecode.rs
@@ -225,7 +225,7 @@ impl BorrowNode {
 }
 
 /// A specification property kind.
-#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 pub enum PropKind {
     Assert,
     Assume,
@@ -395,6 +395,12 @@ impl Bytecode {
                 attr,
                 vec![],
                 WriteBack(LocalRoot(f(false, dest))),
+                map(true, f, srcs),
+            ),
+            Call(attr, _, WriteBack(Reference(dest)), srcs) => Call(
+                attr,
+                vec![],
+                WriteBack(Reference(f(false, dest))),
                 map(true, f, srcs),
             ),
             Call(attr, dests, Splice(m), srcs) => {

--- a/language/move-prover/bytecode/tests/data_invariant_instrumentation/borrow.exp
+++ b/language/move-prover/bytecode/tests/data_invariant_instrumentation/borrow.exp
@@ -1,0 +1,202 @@
+============ initial translation from Move ================
+
+[variant baseline]
+pub fun Test::test_borrow_imm(): u64 {
+     var $t0|r: &Test::R
+     var $t1: address
+     var $t2: &Test::R
+     var $t3: &Test::R
+     var $t4: &u64
+     var $t5: u64
+  0: $t1 := 0x1
+  1: $t2 := borrow_global<Test::R>($t1)
+  2: $t0 := $t2
+  3: $t3 := move($t0)
+  4: $t4 := borrow_field<Test::R>.x($t3)
+  5: $t5 := read_ref($t4)
+  6: return $t5
+}
+
+
+[variant baseline]
+pub fun Test::test_borrow_mut(): u64 {
+     var $t0|r: &mut Test::R
+     var $t1: address
+     var $t2: &mut Test::R
+     var $t3: u64
+     var $t4: &mut Test::R
+     var $t5: &mut Test::S
+     var $t6: &mut u64
+     var $t7: u64
+     var $t8: &mut Test::R
+     var $t9: &mut u64
+     var $t10: &mut Test::R
+     var $t11: &u64
+     var $t12: u64
+  0: $t1 := 0x1
+  1: $t2 := borrow_global<Test::R>($t1)
+  2: $t0 := $t2
+  3: $t3 := 2
+  4: $t4 := copy($t0)
+  5: $t5 := borrow_field<Test::R>.s($t4)
+  6: $t6 := borrow_field<Test::S>.y($t5)
+  7: write_ref($t6, $t3)
+  8: $t7 := 3
+  9: $t8 := copy($t0)
+ 10: $t9 := borrow_field<Test::R>.x($t8)
+ 11: write_ref($t9, $t7)
+ 12: $t10 := move($t0)
+ 13: $t11 := borrow_field<Test::R>.x($t10)
+ 14: $t12 := read_ref($t11)
+ 15: return $t12
+}
+
+
+[variant baseline]
+pub fun Test::test_borrow_mut_local(): Test::R {
+     var $t0|d: Test::R
+     var $t1|r: &mut Test::R
+     var $t2: u64
+     var $t3: u64
+     var $t4: Test::S
+     var $t5: Test::R
+     var $t6: &mut Test::R
+     var $t7: u64
+     var $t8: &mut Test::R
+     var $t9: &mut Test::S
+     var $t10: &mut u64
+     var $t11: u64
+     var $t12: &mut Test::R
+     var $t13: &mut u64
+     var $t14: Test::R
+  0: $t2 := 2
+  1: $t3 := 1
+  2: $t4 := pack Test::S($t3)
+  3: $t5 := pack Test::R($t2, $t4)
+  4: $t0 := $t5
+  5: $t6 := borrow_local($t0)
+  6: $t1 := $t6
+  7: $t7 := 2
+  8: $t8 := copy($t1)
+  9: $t9 := borrow_field<Test::R>.s($t8)
+ 10: $t10 := borrow_field<Test::S>.y($t9)
+ 11: write_ref($t10, $t7)
+ 12: $t11 := 3
+ 13: $t12 := move($t1)
+ 14: $t13 := borrow_field<Test::R>.x($t12)
+ 15: write_ref($t13, $t11)
+ 16: $t14 := move($t0)
+ 17: return $t14
+}
+
+============ after pipeline `data_invariant_instrumentation` ================
+
+[variant verification]
+pub fun Test::test_borrow_imm(): u64 {
+     var $t0|r: Test::R
+     var $t1: address
+     var $t2: num
+     var $t3: u64
+     var $t4: Test::S
+  0: $t1 := 0x1
+  1: $t0 := get_global<Test::R>($t1)
+     # data invariant for `Test:R`
+  2: assume Gt(select Test::R.x($t0), select Test::S.y(select Test::R.s($t0)))
+     # data invariant for `Test:S`
+  3: $t4 := get_field<Test::R>.s($t0)
+  4: assume Gt(select Test::S.y($t4), 0)
+  5: on_abort goto 9 with $t2
+  6: $t3 := get_field<Test::R>.x($t0)
+  7: label L1
+  8: return $t3
+  9: label L2
+ 10: abort($t2)
+}
+
+
+[variant verification]
+pub fun Test::test_borrow_mut(): u64 {
+     var $t0|r: &mut Test::R
+     var $t1: address
+     var $t2: num
+     var $t3: u64
+     var $t4: &mut Test::S
+     var $t5: &mut u64
+     var $t6: u64
+     var $t7: &mut u64
+     var $t8: u64
+     var $t9: Test::S
+  0: $t1 := 0x1
+  1: $t0 := borrow_global<Test::R>($t1)
+     # data invariant for `Test:R`
+  2: assume Gt(select Test::R.x($t0), select Test::S.y(select Test::R.s($t0)))
+     # data invariant for `Test:S`
+  3: $t9 := get_field<Test::R>.s($t0)
+  4: assume Gt(select Test::S.y($t9), 0)
+  5: on_abort goto 22 with $t2
+  6: $t3 := 2
+  7: $t4 := borrow_field<Test::R>.s($t0)
+  8: $t5 := borrow_field<Test::S>.y($t4)
+  9: write_ref($t5, $t3)
+ 10: write_back[Reference($t4)]($t5)
+     # data invariant for `Test:S`
+     # VC: `data invariant does not hold` at tests/data_invariant_instrumentation/borrow.move:16:9+16
+ 11: assert Gt(select Test::S.y($t4), 0)
+ 12: write_back[Reference($t0)]($t4)
+ 13: $t6 := 3
+ 14: $t7 := borrow_field<Test::R>.x($t0)
+ 15: write_ref($t7, $t6)
+ 16: write_back[Reference($t0)]($t7)
+ 17: $t8 := get_field<Test::R>.x($t0)
+     # data invariant for `Test:R`
+     # VC: `data invariant does not hold` at tests/data_invariant_instrumentation/borrow.move:12:9+18
+ 18: assert Gt(select Test::R.x($t0), select Test::S.y(select Test::R.s($t0)))
+ 19: write_back[Test::R]($t0)
+ 20: label L1
+ 21: return $t8
+ 22: label L2
+ 23: abort($t2)
+}
+
+
+[variant verification]
+pub fun Test::test_borrow_mut_local(): Test::R {
+     var $t0|d: Test::R
+     var $t1|r: &mut Test::R
+     var $t2: u64
+     var $t3: u64
+     var $t4: Test::S
+     var $t5: u64
+     var $t6: &mut Test::S
+     var $t7: &mut u64
+     var $t8: u64
+     var $t9: &mut u64
+  0: $t2 := 2
+  1: $t3 := 1
+  2: $t4 := pack Test::S($t3)
+     # data invariant for `Test:S`
+     # VC: `data invariant does not hold` at tests/data_invariant_instrumentation/borrow.move:16:9+16
+  3: assert Gt(select Test::S.y($t4), 0)
+  4: $t0 := pack Test::R($t2, $t4)
+     # data invariant for `Test:R`
+     # VC: `data invariant does not hold` at tests/data_invariant_instrumentation/borrow.move:12:9+18
+  5: assert Gt(select Test::R.x($t0), select Test::S.y(select Test::R.s($t0)))
+  6: $t1 := borrow_local($t0)
+  7: $t5 := 2
+  8: $t6 := borrow_field<Test::R>.s($t1)
+  9: $t7 := borrow_field<Test::S>.y($t6)
+ 10: write_ref($t7, $t5)
+ 11: write_back[Reference($t6)]($t7)
+     # data invariant for `Test:S`
+ 12: assert Gt(select Test::S.y($t6), 0)
+ 13: write_back[Reference($t1)]($t6)
+ 14: $t8 := 3
+ 15: $t9 := borrow_field<Test::R>.x($t1)
+ 16: write_ref($t9, $t8)
+ 17: write_back[Reference($t1)]($t9)
+     # data invariant for `Test:R`
+ 18: assert Gt(select Test::R.x($t1), select Test::S.y(select Test::R.s($t1)))
+ 19: write_back[LocalRoot($t0)]($t1)
+ 20: label L1
+ 21: return $t0
+}

--- a/language/move-prover/bytecode/tests/data_invariant_instrumentation/borrow.move
+++ b/language/move-prover/bytecode/tests/data_invariant_instrumentation/borrow.move
@@ -1,0 +1,38 @@
+module Test {
+    resource struct R {
+        x: u64,
+        s: S
+    }
+
+    struct S {
+        y: u64
+    }
+
+    spec struct R {
+        invariant x > s.y;
+    }
+
+    spec struct S {
+        invariant y > 0;
+    }
+
+    public fun test_borrow_imm(): u64 acquires R {
+        let r = borrow_global<R>(0x1);
+        r.x
+    }
+
+    public fun test_borrow_mut(): u64 acquires R {
+        let r = borrow_global_mut<R>(0x1);
+        r.s.y = 2;
+        r.x = 3;
+        r.x
+    }
+
+    public fun test_borrow_mut_local(): R {
+        let d = R{x: 2, s: S{y:1}};
+        let r = &mut d;
+        r.s.y = 2;
+        r.x = 3;
+        d
+    }
+}

--- a/language/move-prover/bytecode/tests/data_invariant_instrumentation/pack.exp
+++ b/language/move-prover/bytecode/tests/data_invariant_instrumentation/pack.exp
@@ -1,0 +1,40 @@
+============ initial translation from Move ================
+
+[variant baseline]
+pub fun Test::test_pack(): Test::R {
+     var $t0|r: Test::R
+     var $t1|s: Test::S
+     var $t2: u64
+     var $t3: u64
+     var $t4: Test::S
+     var $t5: Test::R
+  0: $t2 := 3
+  1: $t3 := 1
+  2: $t4 := pack Test::S($t3)
+  3: $t5 := pack Test::R($t2, $t4)
+  4: return $t5
+}
+
+============ after pipeline `data_invariant_instrumentation` ================
+
+[variant verification]
+pub fun Test::test_pack(): Test::R {
+     var $t0|r: Test::R
+     var $t1|s: Test::S
+     var $t2: u64
+     var $t3: u64
+     var $t4: Test::S
+     var $t5: Test::R
+  0: $t2 := 3
+  1: $t3 := 1
+  2: $t4 := pack Test::S($t3)
+     # data invariant for `Test:S`
+     # VC: `data invariant does not hold` at tests/data_invariant_instrumentation/pack.move:16:9+16
+  3: assert Gt(select Test::S.y($t4), 0)
+  4: $t5 := pack Test::R($t2, $t4)
+     # data invariant for `Test:R`
+     # VC: `data invariant does not hold` at tests/data_invariant_instrumentation/pack.move:12:9+18
+  5: assert Gt(select Test::R.x($t5), select Test::S.y(select Test::R.s($t5)))
+  6: label L1
+  7: return $t5
+}

--- a/language/move-prover/bytecode/tests/data_invariant_instrumentation/pack.move
+++ b/language/move-prover/bytecode/tests/data_invariant_instrumentation/pack.move
@@ -1,0 +1,24 @@
+module Test {
+    struct R {
+        x: u64,
+        s: S,
+    }
+
+    struct S {
+        y: u64
+    }
+
+    spec struct R {
+        invariant x > s.y;
+    }
+
+    spec struct S {
+        invariant y > 0;
+    }
+
+    public fun test_pack() : R {
+        let s = S {y: 1};
+        let r = R {x: 3, s: s};
+        r
+    }
+}

--- a/language/move-prover/bytecode/tests/data_invariant_instrumentation/params.exp
+++ b/language/move-prover/bytecode/tests/data_invariant_instrumentation/params.exp
@@ -1,0 +1,32 @@
+============ initial translation from Move ================
+
+[variant baseline]
+pub fun Test::test_param($t0|_simple_R: Test::R, $t1|_ref_R: &Test::R, $t2|_simple_S: Test::S, $t3|_mut_R: &mut Test::R) {
+  0: return ()
+}
+
+============ after pipeline `data_invariant_instrumentation` ================
+
+[variant verification]
+pub fun Test::test_param($t0|_simple_R: Test::R, $t1|_ref_R: Test::R, $t2|_simple_S: Test::S, $t3|_mut_R: Test::R): Test::R {
+     var $t4: Test::R
+     var $t5: &mut Test::R
+     var $t6: Test::S
+     var $t7: Test::S
+     # data invariant for `Test:R`
+  0: assume Gt(select Test::R.x($t0), select Test::S.y(select Test::R.s($t0)))
+     # data invariant for `Test:S`
+  1: $t6 := get_field<Test::R>.s($t0)
+  2: assume Gt(select Test::S.y($t6), 0)
+     # data invariant for `Test:R`
+  3: assume Gt(select Test::R.x($t1), select Test::S.y(select Test::R.s($t1)))
+     # data invariant for `Test:S`
+  4: $t7 := get_field<Test::R>.s($t1)
+  5: assume Gt(select Test::S.y($t7), 0)
+     # data invariant for `Test:S`
+  6: assume Gt(select Test::S.y($t2), 0)
+  7: $t4 := move($t3)
+  8: $t5 := borrow_local($t4)
+  9: label L1
+ 10: return $t4
+}

--- a/language/move-prover/bytecode/tests/data_invariant_instrumentation/params.move
+++ b/language/move-prover/bytecode/tests/data_invariant_instrumentation/params.move
@@ -1,0 +1,20 @@
+module Test {
+    struct R {
+        x: u64,
+        s: S,
+    }
+
+    struct S {
+        y: u64
+    }
+
+    spec struct R {
+        invariant x > s.y;
+    }
+
+    spec struct S {
+        invariant y > 0;
+    }
+
+    public fun test_param(_simple_R: R, _ref_R: &R, _simple_S: S, _mut_R: &mut R) {}
+}

--- a/language/move-prover/bytecode/tests/testsuite.rs
+++ b/language/move-prover/bytecode/tests/testsuite.rs
@@ -9,6 +9,7 @@ use codespan_reporting::term::termcolor::Buffer;
 use bytecode::{
     borrow_analysis::BorrowAnalysisProcessor,
     clean_and_optimize::CleanAndOptimizeProcessor,
+    data_invariant_instrumentation::DataInvariantInstrumentationProcessor,
     eliminate_imm_refs::EliminateImmRefsProcessor,
     eliminate_mut_refs::EliminateMutRefsProcessor,
     function_target_pipeline::{FunctionTargetPipeline, FunctionTargetsHolder},
@@ -17,7 +18,7 @@ use bytecode::{
     options::ProverOptions,
     print_targets_for_test,
     reaching_def_analysis::ReachingDefProcessor,
-    spec_instrumentation::SpecInstrumenterProcessor,
+    spec_instrumentation::SpecInstrumentationProcessor,
     usage_analysis::UsageProcessor,
     verification_analysis::VerificationAnalysisProcessor,
 };
@@ -96,7 +97,22 @@ fn get_tested_transformation_pipeline(
             pipeline.add_processor(CleanAndOptimizeProcessor::new());
             pipeline.add_processor(UsageProcessor::new());
             pipeline.add_processor(VerificationAnalysisProcessor::new());
-            pipeline.add_processor(SpecInstrumenterProcessor::new());
+            pipeline.add_processor(SpecInstrumentationProcessor::new());
+            Ok(Some(pipeline))
+        }
+        "data_invariant_instrumentation" => {
+            let mut pipeline = FunctionTargetPipeline::default();
+            pipeline.add_processor(EliminateImmRefsProcessor::new());
+            pipeline.add_processor(EliminateMutRefsProcessor::new());
+            pipeline.add_processor(ReachingDefProcessor::new());
+            pipeline.add_processor(LiveVarAnalysisProcessor::new());
+            pipeline.add_processor(BorrowAnalysisProcessor::new());
+            pipeline.add_processor(MemoryInstrumentationProcessor::new());
+            pipeline.add_processor(CleanAndOptimizeProcessor::new());
+            pipeline.add_processor(UsageProcessor::new());
+            pipeline.add_processor(VerificationAnalysisProcessor::new());
+            pipeline.add_processor(SpecInstrumentationProcessor::new());
+            pipeline.add_processor(DataInvariantInstrumentationProcessor::new());
             Ok(Some(pipeline))
         }
 

--- a/language/move-prover/src/lib.rs
+++ b/language/move-prover/src/lib.rs
@@ -12,10 +12,11 @@ use crate::{
 use abigen::Abigen;
 use anyhow::anyhow;
 use bytecode::{
+    data_invariant_instrumentation::DataInvariantInstrumentationProcessor,
     debug_instrumentation::DebugInstrumenter,
     function_target_pipeline::{FunctionTargetPipeline, FunctionTargetsHolder},
     packed_types_analysis::PackedTypesProcessor,
-    spec_instrumentation::SpecInstrumenterProcessor,
+    spec_instrumentation::SpecInstrumentationProcessor,
 };
 use codespan_reporting::term::termcolor::{ColorChoice, StandardStream, WriteColor};
 use docgen::Docgen;
@@ -297,7 +298,8 @@ fn create_bytecode_processing_pipeline(options: &Options) -> FunctionTargetPipel
         .into_iter()
         .for_each(|processor| res.add_processor(processor));
     if options.trans_v2 {
-        res.add_processor(SpecInstrumenterProcessor::new());
+        res.add_processor(SpecInstrumentationProcessor::new());
+        res.add_processor(DataInvariantInstrumentationProcessor::new());
     } else {
         res.add_processor(PackedTypesProcessor::new());
     }

--- a/language/move-prover/tests/sources/functional/invariants.exp
+++ b/language/move-prover/tests/sources/functional/invariants.exp
@@ -16,12 +16,13 @@ error: data invariant does not hold
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^
     │
     =     at tests/sources/functional/invariants.move:112:5: lifetime_invalid_R
+    =     at tests/sources/functional/invariants.move:113:13: lifetime_invalid_R
+    =     at tests/sources/functional/invariants.move:114:13: lifetime_invalid_R
     =         r = <redacted>,
-    =         r_ref = <redacted>,
+    =         r_ref = <redacted>
+    =     at tests/sources/functional/invariants.move:115:13: lifetime_invalid_R
     =         x_ref = <redacted>
-    =     at tests/sources/functional/invariants.move:113:17: lifetime_invalid_R
-    =     at tests/sources/functional/invariants.move:114:21: lifetime_invalid_R
-    =     at tests/sources/functional/invariants.move:116:9: lifetime_invalid_R
+    =     at tests/sources/functional/invariants.move:116:18: lifetime_invalid_R
 
 error: data invariant does not hold
 
@@ -31,16 +32,16 @@ error: data invariant does not hold
      │         ^^^^^^^^^^^^^^^^
      │
      =     at tests/sources/functional/invariants.move:153:5: lifetime_invalid_S_branching
+     =     at tests/sources/functional/invariants.move:154:21: lifetime_invalid_S_branching
      =         cond = <redacted>,
-     =         a = <redacted>,
-     =         a_ref = <redacted>,
-     =         b = <redacted>,
-     =         b_ref = <redacted>,
-     =         <redacted> = <redacted>,
-     =         x_ref = <redacted>,
-     =         x_ref = <redacted>
-     =     at tests/sources/functional/invariants.move:154:15: lifetime_invalid_S_branching
+     =         a = <redacted>
      =     at tests/sources/functional/invariants.move:155:21: lifetime_invalid_S_branching
+     =         b = <redacted>
+     =     at tests/sources/functional/invariants.move:156:11: lifetime_invalid_S_branching
+     =         a_ref = <redacted>
+     =     at tests/sources/functional/invariants.move:157:11: lifetime_invalid_S_branching
+     =         b_ref = <redacted>
      =     at tests/sources/functional/invariants.move:158:19: lifetime_invalid_S_branching
+     =         <redacted> = <redacted>,
+     =         x_ref = <redacted>
      =     at tests/sources/functional/invariants.move:160:7: lifetime_invalid_S_branching
-     =     at tests/sources/functional/invariants.move:163:11: lifetime_invalid_S_branching

--- a/language/move-prover/tests/sources/functional/invariants.move
+++ b/language/move-prover/tests/sources/functional/invariants.move
@@ -1,5 +1,5 @@
+// flag: --v2
 module TestInvariants {
-
     spec module {
         pragma verify = true;
     }

--- a/language/move-prover/tests/sources/functional/nested_invariants.exp
+++ b/language/move-prover/tests/sources/functional/nested_invariants.exp
@@ -7,11 +7,11 @@ error: data invariant does not hold
     │         ^^^^^^^^^^^^^^^^
     │
     =     at tests/sources/functional/nested_invariants.move:63:5: mutate_inner_data_invariant_invalid
-    =         o = <redacted>,
+    =     at tests/sources/functional/nested_invariants.move:64:13: mutate_inner_data_invariant_invalid
+    =     at tests/sources/functional/nested_invariants.move:65:13: mutate_inner_data_invariant_invalid
+    =         o = <redacted>
+    =     at tests/sources/functional/nested_invariants.move:66:17: mutate_inner_data_invariant_invalid
     =         r = <redacted>
-    =     at tests/sources/functional/nested_invariants.move:64:17: mutate_inner_data_invariant_invalid
-    =     at tests/sources/functional/nested_invariants.move:65:17: mutate_inner_data_invariant_invalid
-    =     at tests/sources/functional/nested_invariants.move:66:9: mutate_inner_data_invariant_invalid
 
 error: data invariant does not hold
 
@@ -21,11 +21,11 @@ error: data invariant does not hold
     │         ^^^^^^^^^^^^^^^^^^
     │
     =     at tests/sources/functional/nested_invariants.move:57:5: mutate_outer_data_invariant_invalid
-    =         o = <redacted>,
+    =     at tests/sources/functional/nested_invariants.move:58:13: mutate_outer_data_invariant_invalid
+    =     at tests/sources/functional/nested_invariants.move:59:13: mutate_outer_data_invariant_invalid
+    =         o = <redacted>
+    =     at tests/sources/functional/nested_invariants.move:60:15: mutate_outer_data_invariant_invalid
     =         r = <redacted>
-    =     at tests/sources/functional/nested_invariants.move:58:17: mutate_outer_data_invariant_invalid
-    =     at tests/sources/functional/nested_invariants.move:59:17: mutate_outer_data_invariant_invalid
-    =     at tests/sources/functional/nested_invariants.move:60:9: mutate_outer_data_invariant_invalid
 
 error: data invariant does not hold
 

--- a/language/move-prover/tests/sources/functional/nested_invariants.move
+++ b/language/move-prover/tests/sources/functional/nested_invariants.move
@@ -1,5 +1,5 @@
+// flag: --v2
 module TestNestedInvariants {
-
     spec module {
         pragma verify = true;
     }


### PR DESCRIPTION
This adds a new processor `data_invariant_instrumentation.rs` to the v2 pipeline. The processor handles data invariants (not global invariants). It injects assumes/asserts for data invariants into the bytecode for the Pack instruction and for the PackRef/PackRefDeep instructions introduced by the memory model. It also adds assumes for data invariants for parameters of verified functions as well as when data is loaded from resource memory.

This processor does *not* implement spec var related pack/unpack functionality, which we currently plan to drop for v2.

Some bytecode baseline test have been added, as well as existing tests which do not use spec vars migrated.

## Motivation

Prover refactoring.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

New bytecode tests, as well as migrated verification tests.

## Related PRs

NA
