### PR TITLE
[network] Allow inbound trusted peers to bypass connection limit

### DIFF
--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -459,54 +459,74 @@ where
         self.sample_connected_peers();
         match event {
             TransportNotification::NewConnection(mut conn) => {
-                let trusted_peers = self.trusted_peers.read().clone();
-                // TODO: This is right now a hack around having to feed trusted peers deeper in the outbound path.  Inbound ones are assigned at Noise handshake time.
-                if conn.metadata.origin == ConnectionOrigin::Outbound {
-                    let peer_role = trusted_peers
-                        .get(&conn.metadata.remote_peer_id)
-                        .map_or(PeerRole::Unknown, |auth_context| auth_context.role);
-                    conn.metadata.role = peer_role;
-                };
+                match conn.metadata.origin {
+                    ConnectionOrigin::Outbound => {
+                        // TODO: This is right now a hack around having to feed trusted peers deeper in the outbound path.  Inbound ones are assigned at Noise handshake time.
+                        conn.metadata.role = self
+                            .trusted_peers
+                            .read()
+                            .get(&conn.metadata.remote_peer_id)
+                            .map_or(PeerRole::Unknown, |auth_context| auth_context.role);
 
-                // TODO: Keep track of somewhere else to not take this hit in case of DDoS
-                // Count inbound connections, not made by trusted peers
-                let inbound_conns = self
-                    .active_peers
-                    .iter()
-                    .filter(|(peer_id, (metadata, _))| {
-                        metadata.origin == ConnectionOrigin::Inbound
-                            && !trusted_peers.contains_key(peer_id)
-                    })
-                    .count();
+                        if conn.metadata.role == PeerRole::Unknown {
+                            warn!(
+                                NetworkSchema::new(&self.network_context)
+                                    .connection_metadata_with_address(&conn.metadata),
+                                "{} Outbound connection made with unknown peer role: {}",
+                                self.network_context,
+                                conn.metadata
+                            )
+                        }
+                    }
+                    ConnectionOrigin::Inbound => {
+                        // Everything below here is meant for unknown peers only, role comes from
+                        // Noise handshake and if it's not `Unknown` it is trusted
+                        if conn.metadata.role == PeerRole::Unknown {
+                            // TODO: Keep track of somewhere else to not take this hit in case of DDoS
+                            // Count unknown inbound connections
+                            let unknown_inbound_conns = self
+                                .active_peers
+                                .iter()
+                                .filter(|(peer_id, (metadata, _))| {
+                                    metadata.origin == ConnectionOrigin::Inbound
+                                        && self
+                                            .trusted_peers
+                                            .read()
+                                            .get(peer_id)
+                                            .map_or(true, |peer| peer.role == PeerRole::Unknown)
+                                })
+                                .count();
 
-                // Reject excessive inbound connections by letting them just drop out of scope
-                // We control outbound connections with Connectivity manager before we even send them
-                // and we must allow connections that already exist to pass through tie breaking.
-                if conn.metadata.origin == ConnectionOrigin::Outbound
-                    || self
-                        .active_peers
-                        .contains_key(&conn.metadata.remote_peer_id)
-                    || trusted_peers.contains_key(&conn.metadata.remote_peer_id)
-                    || inbound_conns < self.inbound_connection_limit
-                {
-                    info!(
-                        NetworkSchema::new(&self.network_context)
-                            .connection_metadata_with_address(&conn.metadata),
-                        "{} New connection established: {}", self.network_context, conn.metadata
-                    );
-                    // Add new peer, updating counters and all
-                    self.add_peer(conn);
-                    self.update_connected_peers_metrics();
-                } else {
-                    info!(
-                        NetworkSchema::new(&self.network_context)
-                            .connection_metadata_with_address(&conn.metadata),
-                        "{} Connection rejected due to connection limit: {}",
-                        self.network_context,
-                        conn.metadata
-                    );
-                    self.disconnect(conn);
+                            // Reject excessive inbound connections made by unknown peers
+                            // We control outbound connections with Connectivity manager before we even send them
+                            // and we must allow connections that already exist to pass through tie breaking.
+                            if !self
+                                .active_peers
+                                .contains_key(&conn.metadata.remote_peer_id)
+                                && unknown_inbound_conns > self.inbound_connection_limit
+                            {
+                                info!(
+                                    NetworkSchema::new(&self.network_context)
+                                        .connection_metadata_with_address(&conn.metadata),
+                                    "{} Connection rejected due to connection limit: {}",
+                                    self.network_context,
+                                    conn.metadata
+                                );
+                                self.disconnect(conn);
+                                return;
+                            }
+                        }
+                    }
                 }
+
+                // Add new peer, updating counters and all
+                info!(
+                    NetworkSchema::new(&self.network_context)
+                        .connection_metadata_with_address(&conn.metadata),
+                    "{} New connection established: {}", self.network_context, conn.metadata
+                );
+                self.add_peer(conn);
+                self.update_connected_peers_metrics();
             }
             TransportNotification::Disconnected(lost_conn_metadata, reason) => {
                 // See: https://github.com/diem/diem/issues/3128#issuecomment-605351504 for


### PR DESCRIPTION
Inbound trusted peers ignore connection limits, and don't count against
them.  This allows VFNs to still connect to the network when the network
is saturated.

Likely will have to in the future either limit the connections that get through past the connection limit due to trusted peers, and / or prioritize which ones make it.

In this implementation trusted peers are never counted against the limit, and bypass the limit.

Related:
https://github.com/diem/diem/issues/6948