### PR TITLE
[language-benches] Split out txn_bench into a separate binary.

### DIFF
--- a/language/benchmarks/Cargo.toml
+++ b/language/benchmarks/Cargo.toml
@@ -29,5 +29,9 @@ vm = { path = "../vm", version = "0.1.0" }
 diem-vm = { path = "../diem-vm", version = "0.1.0" }
 
 [[bench]]
-name = "benchmarks"
+name = "vm_benches"
+harness = false
+
+[[bench]]
+name = "transaction_benches"
 harness = false

--- a/language/benchmarks/benches/transaction_benches.rs
+++ b/language/benchmarks/benches/transaction_benches.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use language_benchmarks::{move_vm::bench, transactions::TransactionBencher};
+use language_benchmarks::transactions::TransactionBencher;
 use language_e2e_tests::account_universe::P2PTransferGen;
 use proptest::prelude::*;
 
@@ -19,22 +19,4 @@ fn peer_to_peer(c: &mut Criterion) {
 
 criterion_group!(txn_benches, peer_to_peer);
 
-//
-// MoveVM benchmarks
-//
-
-fn arith(c: &mut Criterion) {
-    bench(c, "arith");
-}
-
-fn call(c: &mut Criterion) {
-    bench(c, "call");
-}
-
-fn natives(c: &mut Criterion) {
-    bench(c, "natives");
-}
-
-criterion_group!(vm_benches, arith, call, natives);
-
-criterion_main!(vm_benches);
+criterion_main!(txn_benches);

--- a/language/benchmarks/benches/vm_benches.rs
+++ b/language/benchmarks/benches/vm_benches.rs
@@ -1,0 +1,25 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use language_benchmarks::move_vm::bench;
+
+//
+// MoveVM benchmarks
+//
+
+fn arith(c: &mut Criterion) {
+    bench(c, "arith");
+}
+
+fn call(c: &mut Criterion) {
+    bench(c, "call");
+}
+
+fn natives(c: &mut Criterion) {
+    bench(c, "natives");
+}
+
+criterion_group!(vm_benches, arith, call, natives);
+
+criterion_main!(vm_benches);


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Create a separate bench target for measuring how many txns per second can a Diem Adapter process with a in memory storage. This will also help create a report in the CI for this metric.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan

`cargo bench` under `benchmarks`. Observed both `vm_benches` and `txn_benches` to be run.
