### PR TITLE
[State Sync] Perform basic chunk request verification before processing.

### DIFF
--- a/state-sync/src/chunk_request.rs
+++ b/state-sync/src/chunk_request.rs
@@ -40,6 +40,16 @@ pub enum TargetType {
 }
 
 impl TargetType {
+    pub fn epoch(&self) -> Option<u64> {
+        match self {
+            TargetType::TargetLedgerInfo(li) => Some(li.ledger_info().epoch()),
+            TargetType::HighestAvailable { target_li, .. } => {
+                target_li.as_ref().map(|li| li.ledger_info().epoch())
+            }
+            TargetType::Waypoint(_) => None,
+        }
+    }
+
     pub fn version(&self) -> Option<u64> {
         match self {
             TargetType::TargetLedgerInfo(li) => Some(li.ledger_info().version()),

--- a/state-sync/src/error.rs
+++ b/state-sync/src/error.rs
@@ -16,6 +16,8 @@ pub enum Error {
     FullNodeSyncRequest,
     #[error("An integer overflow has occurred: {0}")]
     IntegerOverflow(String),
+    #[error("Received an invalid chunk request: {0}")]
+    InvalidChunkRequest(String),
     #[error("No peers are currently available!")]
     NoAvailablePeers,
     #[error("No transactions were committed, but received a commit notification!")]

--- a/state-sync/src/request_manager.rs
+++ b/state-sync/src/request_manager.rs
@@ -74,6 +74,7 @@ enum PeerScoreUpdateType {
     // that a peer would first timeout and would then be punished with ChunkVersionCannotBeApplied.
     ChunkVersionCannotBeApplied,
     InvalidChunk,
+    InvalidChunkRequest,
     TimeOut,
 }
 
@@ -180,7 +181,9 @@ impl RequestManager {
                     let new_score = peer_info.score * 0.8;
                     peer_info.score = new_score.max(MIN_SCORE);
                 }
-                PeerScoreUpdateType::TimeOut | PeerScoreUpdateType::EmptyChunk => {
+                PeerScoreUpdateType::TimeOut
+                | PeerScoreUpdateType::EmptyChunk
+                | PeerScoreUpdateType::InvalidChunkRequest => {
                     let new_score = peer_info.score * 0.95;
                     peer_info.score = new_score.max(MIN_SCORE);
                 }
@@ -352,6 +355,10 @@ impl RequestManager {
 
     pub fn process_invalid_chunk(&mut self, peer: &PeerNetworkId) {
         self.update_score(peer, PeerScoreUpdateType::InvalidChunk);
+    }
+
+    pub fn process_invalid_chunk_request(&mut self, peer: &PeerNetworkId) {
+        self.update_score(peer, PeerScoreUpdateType::InvalidChunkRequest);
     }
 
     pub fn process_success_response(&mut self, peer: &PeerNetworkId) {
@@ -680,6 +687,19 @@ mod tests {
         // Process multiple invalid chunk responses from validator 0
         for _ in 0..NUM_CHUNKS_TO_PROCESS {
             request_manager.process_invalid_chunk(&validators[0]);
+        }
+
+        // Verify validator 0 is chosen less often than the other validators
+        verify_validator_picked_least_often(&mut request_manager, &validators, 0);
+    }
+
+    #[test]
+    fn test_score_invalid_chunk_request() {
+        let (mut request_manager, validators) = generate_request_manager_and_validators(10, 4);
+
+        // Process multiple invalid chunk requests from validator 0
+        for _ in 0..NUM_CHUNKS_TO_PROCESS {
+            request_manager.process_invalid_chunk_request(&validators[0]);
         }
 
         // Verify validator 0 is chosen less often than the other validators


### PR DESCRIPTION
## Motivation

At present, state sync does not ensure chunk request are correctly formed before it attempts to process them. Specifically, it doesn't check if:
1. The known version of the chunk request is greater than the target version.
2. The current epoch of the chunk request is greater than the target epoch.
3. The chunk limit is set to 0 (in which case, the request is dubious).
4. The long poll timeout is set to 0 (in which case, the request is not well formed).

If any of these 4 properties are violated in the current version of state sync, they should ultimately be caught somewhere in the state sync pipeline (e.g., by storage, or the request manager, etc.). However, this leaves ambiguity about what can happen and whether or not there are potential vulnerabilities here. Moreover, it may burn unnecessary resources (e.g., CPU, storage, memory).

This PR updates state sync to perform these basic checks upfront. If the request fails any of these, it is discarded and the peer is penalized (similar to how a peer responding with an invalid chunk is penalized). The PR updates state sync with the following commits:
1. First, update the state sync code to verify the request properties, and add a unit test to ensure these checks are done for *all* chunk request types.
2. Update the state sync code to penalize the peer if a bad chunk request is received, and add a test for this penalization.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally, including the newly added ones.

## Related PRs

This relates to: https://github.com/diem/diem/issues/6795