### PR TITLE
[move][file format] Add script visibility

### DIFF
--- a/language/bytecode-verifier/src/dependencies.rs
+++ b/language/bytecode-verifier/src/dependencies.rs
@@ -7,11 +7,12 @@ use diem_types::vm_status::StatusCode;
 use move_core_types::{identifier::Identifier, language_storage::ModuleId};
 use std::collections::{BTreeMap, HashMap};
 use vm::{
-    access::ModuleAccess,
+    access::{ModuleAccess, ScriptAccess},
     errors::{verification_error, Location, PartialVMError, PartialVMResult, VMResult},
     file_format::{
-        CompiledModule, CompiledScript, FunctionHandleIndex, ModuleHandleIndex, SignatureToken,
-        StructHandleIndex, TableIndex, Visibility,
+        Bytecode, CodeOffset, CompiledModule, CompiledScript, FunctionDefinitionIndex,
+        FunctionHandleIndex, ModuleHandleIndex, SignatureToken, StructHandleIndex, TableIndex,
+        Visibility,
     },
     IndexKind,
 };
@@ -24,6 +25,8 @@ struct Context<'a, 'b> {
     struct_id_to_handle_map: HashMap<(ModuleId, Identifier), StructHandleIndex>,
     // (Module::FunctionName -> handle) for all non-private functions of all dependencies
     func_id_to_handle_map: HashMap<(ModuleId, Identifier), FunctionHandleIndex>,
+    // (handle -> visibility) for all function handles found in the module being checked
+    function_visibilities: HashMap<FunctionHandleIndex, Visibility>,
 }
 
 impl<'a, 'b> Context<'a, 'b> {
@@ -46,6 +49,12 @@ impl<'a, 'b> Context<'a, 'b> {
         dependencies: impl IntoIterator<Item = &'b CompiledModule>,
     ) -> Self {
         let self_module = resolver.self_id();
+        let self_module_idx = resolver.self_handle_idx();
+        let empty_defs = &vec![];
+        let self_function_defs = match &resolver {
+            BinaryIndexedView::Module(m) => m.function_defs(),
+            BinaryIndexedView::Script(_) => empty_defs,
+        };
         let dependency_map = dependencies
             .into_iter()
             .filter(|d| Some(d.self_id()) != self_module)
@@ -57,8 +66,10 @@ impl<'a, 'b> Context<'a, 'b> {
             dependency_map,
             struct_id_to_handle_map: HashMap::new(),
             func_id_to_handle_map: HashMap::new(),
+            function_visibilities: HashMap::new(),
         };
 
+        let mut dependency_visibilities = HashMap::new();
         for (module_id, module) in &context.dependency_map {
             // Module::StructName -> def handle idx
             for struct_def in module.struct_defs() {
@@ -71,20 +82,49 @@ impl<'a, 'b> Context<'a, 'b> {
             }
             // Module::FuncName -> def handle idx
             for func_def in module.function_defs() {
-                let may_be_called = match func_def.visibility {
-                    Visibility::Public => true,
-                    Visibility::Private => false,
-                };
-                if !may_be_called {
-                    continue;
-                }
                 let func_handle = module.function_handle_at(func_def.function);
                 let func_name = module.identifier_at(func_handle.name);
-                context
-                    .func_id_to_handle_map
-                    .insert((module_id.clone(), func_name.to_owned()), func_def.function);
+                dependency_visibilities.insert(
+                    (module_id.clone(), func_name.to_owned()),
+                    func_def.visibility,
+                );
+                match func_def.visibility {
+                    Visibility::Private => continue,
+                    Visibility::Public | Visibility::Script => {
+                        context
+                            .func_id_to_handle_map
+                            .insert((module_id.clone(), func_name.to_owned()), func_def.function);
+                    }
+                }
             }
         }
+
+        for function_def in self_function_defs {
+            let visibility = function_def.visibility;
+            context
+                .function_visibilities
+                .insert(function_def.function, visibility);
+        }
+        for (idx, function_handle) in context.resolver.function_handles().iter().enumerate() {
+            if Some(function_handle.module) == self_module_idx {
+                continue;
+            }
+            let owner_module_id = context
+                .resolver
+                .module_id_for_handle(context.resolver.module_handle_at(function_handle.module));
+            let function_name = context.resolver.identifier_at(function_handle.name);
+            let visibility =
+                match dependency_visibilities.get(&(owner_module_id, function_name.to_owned())) {
+                    // The visibility does not need to be set here. If the function does not
+                    // link, it will be reported by verify_imported_functions
+                    None => continue,
+                    Some(vis) => *vis,
+                };
+            context
+                .function_visibilities
+                .insert(FunctionHandleIndex(idx as TableIndex), visibility);
+        }
+
         context
     }
 }
@@ -105,7 +145,8 @@ fn verify_module_impl<'a>(
 
     verify_imported_modules(context)?;
     verify_imported_structs(context)?;
-    verify_imported_functions(context)
+    verify_imported_functions(context)?;
+    verify_all_script_visibility_usage(context)
 }
 
 pub fn verify_script<'a>(
@@ -123,7 +164,8 @@ pub fn verify_script_impl<'a>(
 
     verify_imported_modules(context)?;
     verify_imported_structs(context)?;
-    verify_imported_functions(context)
+    verify_imported_functions(context)?;
+    verify_all_script_visibility_usage(context)
 }
 
 fn verify_imported_modules(context: &Context) -> PartialVMResult<()> {
@@ -342,4 +384,68 @@ fn compare_structs(
     } else {
         Ok(())
     }
+}
+
+fn verify_all_script_visibility_usage(context: &Context) -> PartialVMResult<()> {
+    match &context.resolver {
+        BinaryIndexedView::Module(m) => {
+            for (idx, fdef) in m.function_defs().iter().enumerate() {
+                let code = match &fdef.code {
+                    None => continue,
+                    Some(code) => &code.code,
+                };
+                verify_script_visibility_usage(
+                    context,
+                    fdef.visibility,
+                    FunctionDefinitionIndex(idx as TableIndex),
+                    code,
+                )?
+            }
+            Ok(())
+        }
+        BinaryIndexedView::Script(s) => verify_script_visibility_usage(
+            context,
+            Visibility::Script,
+            FunctionDefinitionIndex(0),
+            &s.code().code,
+        ),
+    }
+}
+
+fn verify_script_visibility_usage(
+    context: &Context,
+    current_visibility: Visibility,
+    fdef_idx: FunctionDefinitionIndex,
+    code: &[Bytecode],
+) -> PartialVMResult<()> {
+    for (idx, instr) in code.iter().enumerate() {
+        let idx = idx as CodeOffset;
+        let fhandle_idx = match instr {
+            Bytecode::Call(fhandle_idx) => fhandle_idx,
+            Bytecode::CallGeneric(finst_idx) => {
+                &context
+                    .resolver
+                    .function_instantiation_at(*finst_idx)
+                    .handle
+            }
+            _ => continue,
+        };
+        let fhandle_vis = context.function_visibilities[fhandle_idx];
+        match (current_visibility, fhandle_vis) {
+            (Visibility::Script, Visibility::Script) => (),
+            (_, Visibility::Script) => {
+                return Err(PartialVMError::new(
+                    StatusCode::CALLED_SCRIPT_VISIBLE_FROM_NON_SCRIPT_VISIBLE,
+                )
+                .at_code_offset(fdef_idx, idx)
+                .with_message(
+                    "script-visible functions can only be called from scripts or other \
+                    script-visibile functions"
+                        .to_string(),
+                ));
+            }
+            _ => (),
+        }
+    }
+    Ok(())
 }

--- a/language/move-core/types/src/vm_status.rs
+++ b/language/move-core/types/src/vm_status.rs
@@ -564,6 +564,7 @@ pub enum StatusCode {
     INVALID_PARAM_TYPE_FOR_DESERIALIZATION = 1099,
     FAILED_TO_DESERIALIZE_ARGUMENT = 1100,
     NUMBER_OF_SIGNER_ARGUMENTS_MISMATCH = 1101,
+    CALLED_SCRIPT_VISIBLE_FROM_NON_SCRIPT_VISIBLE = 1102,
 
     // These are errors that the VM might raise if a violation of internal
     // invariants takes place.

--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -2349,6 +2349,7 @@ impl<'env> FunctionEnv<'env> {
         self.module_env.is_script_module()
             || match self.definition_view().visibility() {
                 Visibility::Public => true,
+                Visibility::Script => panic!("Script visibility not yet supported"),
                 Visibility::Private => false,
             }
     }

--- a/language/tools/disassembler/src/disassembler.rs
+++ b/language/tools/disassembler/src/disassembler.rs
@@ -22,8 +22,8 @@ use vm::{
 /// Holds the various options that we support while disassembling code.
 #[derive(Debug, Default)]
 pub struct DisassemblerOptions {
-    /// Only print public functions
-    pub only_public: bool,
+    /// Only print non-private functions
+    pub only_externally_visible: bool,
 
     /// Print the bytecode for the instructions within the function.
     pub print_code: bool,
@@ -38,7 +38,7 @@ pub struct DisassemblerOptions {
 impl DisassemblerOptions {
     pub fn new() -> Self {
         Self {
-            only_public: false,
+            only_externally_visible: false,
             print_code: false,
             print_basic_blocks: false,
             print_locals: false,
@@ -854,14 +854,15 @@ impl<Location: Clone + Eq> Disassembler<Location> {
             .get_function_source_map(function_definition_index)?;
 
         if match function_definition.visibility {
-            Visibility::Public => false,
-            Visibility::Private => self.options.only_public,
+            Visibility::Script | Visibility::Public => false,
+            Visibility::Private => self.options.only_externally_visible,
         } {
             return Ok("".to_string());
         }
 
         let visibility_modifier = match function_definition.visibility {
             Visibility::Private => "",
+            Visibility::Script => "public(script) ",
             Visibility::Public => "public ",
         };
         let native_modifier = if function_definition.is_native() {

--- a/language/tools/disassembler/src/main.rs
+++ b/language/tools/disassembler/src/main.rs
@@ -83,7 +83,7 @@ fn main() {
 
     let mut disassembler_options = DisassemblerOptions::new();
     disassembler_options.print_code = !args.skip_code;
-    disassembler_options.only_public = args.skip_private;
+    disassembler_options.only_externally_visible = args.skip_private;
     disassembler_options.print_basic_blocks = !args.skip_basic_blocks;
     disassembler_options.print_locals = !args.skip_locals;
 

--- a/language/vm/src/compatibility.rs
+++ b/language/vm/src/compatibility.rs
@@ -87,8 +87,8 @@ impl Compatibility {
         }
 
         // old module's public functions are a subset of the new module's public functions
-        for function in &old_module.public_functions {
-            if !new_module.public_functions.contains(&function) {
+        for function in &old_module.externally_visible_functions {
+            if !new_module.externally_visible_functions.contains(&function) {
                 struct_and_function_linking = false;
             }
         }

--- a/language/vm/src/file_format.rs
+++ b/language/vm/src/file_format.rs
@@ -385,6 +385,8 @@ pub enum Visibility {
     Private = 0x0,
     /// Accessible by any module or script outside of its declaring module.
     Public = 0x1,
+    /// Accessible by any script or other `Script` functions from any module
+    Script = 0x2,
 }
 
 impl Default for Visibility {
@@ -400,6 +402,7 @@ impl std::convert::TryFrom<u8> for Visibility {
         match v {
             x if x == Visibility::Private as u8 => Ok(Visibility::Private),
             x if x == Visibility::Public as u8 => Ok(Visibility::Public),
+            x if x == Visibility::Script as u8 => Ok(Visibility::Script),
             _ => Err(()),
         }
     }

--- a/language/vm/src/file_format_common.rs
+++ b/language/vm/src/file_format_common.rs
@@ -368,12 +368,12 @@ pub fn read_uleb128_as_u64(cursor: &mut Cursor<&[u8]>) -> Result<u64> {
 //
 
 /// Version 1: the initial version
-pub const VERSION_1: u32 = 1u32;
+pub const VERSION_1: u32 = 1;
 
 /// Version 2: changes compared with version 1
 ///  + function visibility stored in separate byte before the flags byte
 ///  + the flags byte now contains only the is_native information (at bit 0x2)
-pub const VERSION_2: u32 = 2u32;
+pub const VERSION_2: u32 = 2;
 
 // Mark which version is the latest version
 pub const VERSION_MAX: u32 = VERSION_2;


### PR DESCRIPTION
- Script visible functions can only be called from scripts or other script visible functions
- Future work: Add new entry point to invoke these functions directly

## Motivation

- For Diem, script visible functions will let us kill the allow list, as we can just allow the invocation of any script visible function directly 
- This moves the control from being the hash of the allow list to the modifiers listed in the modules published on chain

## Test Plan

- I'm not sure this can be easily done at the moment...
- Once the IR gets syntax, we can test this, but it in general we really need to expand the IR's parsing to test the dependency verifier as a whole. 

## Related PRs

#7497 