### PR TITLE
[move vm][loader] Execute funciton should verify a missing module and function

### DIFF
--- a/language/diem-vm/src/diem_vm.rs
+++ b/language/diem-vm/src/diem_vm.rs
@@ -30,7 +30,7 @@ use move_core_types::{
 
 use move_vm_runtime::{
     data_cache::{RemoteCache, TransactionEffects},
-    logging::LogContext,
+    logging::{expect_no_verification_errors, LogContext},
     move_vm::MoveVM,
     session::Session,
 };
@@ -237,6 +237,7 @@ impl DiemVMImpl {
                 cost_strategy,
                 log_context,
             )
+            .map_err(|err| expect_no_verification_errors(err, log_context))
             .or_else(|err| convert_prologue_error(err, log_context))
     }
 
@@ -275,6 +276,7 @@ impl DiemVMImpl {
                 cost_strategy,
                 log_context,
             )
+            .map_err(|err| expect_no_verification_errors(err, log_context))
             .or_else(|err| convert_prologue_error(err, log_context))
     }
 
@@ -315,6 +317,7 @@ impl DiemVMImpl {
                 cost_strategy,
                 log_context,
             )
+            .map_err(|err| expect_no_verification_errors(err, log_context))
             .or_else(|err| convert_epilogue_error(err, log_context))
     }
 
@@ -349,6 +352,7 @@ impl DiemVMImpl {
                 cost_strategy,
                 log_context,
             )
+            .map_err(|err| expect_no_verification_errors(err, log_context))
             .or_else(|e| {
                 expect_only_successful_execution(e, USER_EPILOGUE_NAME.as_str(), log_context)
             })
@@ -384,6 +388,7 @@ impl DiemVMImpl {
                 &mut cost_strategy,
                 log_context,
             )
+            .map_err(|err| expect_no_verification_errors(err, log_context))
             .or_else(|err| convert_prologue_error(err, log_context))
     }
 
@@ -411,6 +416,7 @@ impl DiemVMImpl {
                 &mut cost_strategy,
                 log_context,
             )
+            .map_err(|err| expect_no_verification_errors(err, log_context))
             .or_else(|e| {
                 expect_only_successful_execution(e, WRITESET_EPILOGUE_NAME.as_str(), log_context)
             })

--- a/language/move-vm/integration-tests/src/tests/bad_entry_point_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/bad_entry_point_tests.rs
@@ -39,7 +39,7 @@ fn call_non_existent_module() {
         )
         .unwrap_err();
 
-    assert_eq!(err.status_type(), StatusType::InvariantViolation);
+    assert_eq!(err.status_type(), StatusType::Verification);
 }
 
 #[test]
@@ -76,5 +76,5 @@ fn call_non_existent_function() {
         )
         .unwrap_err();
 
-    assert_eq!(err.status_type(), StatusType::InvariantViolation);
+    assert_eq!(err.status_type(), StatusType::Verification);
 }

--- a/language/move-vm/runtime/src/logging.rs
+++ b/language/move-vm/runtime/src/logging.rs
@@ -1,7 +1,9 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use diem_logger::Schema;
+use diem_logger::{prelude::error, Schema};
+use move_core_types::vm_status::{StatusCode, StatusType};
+use vm::errors::{PartialVMError, VMError};
 
 // Trait used by the VM to log interesting data.
 // Clients are responsible for the implementation of alert.
@@ -26,4 +28,36 @@ impl NoContextLog {
 
 impl LogContext for NoContextLog {
     fn alert(&self) {}
+}
+
+//
+// Utility functions
+//
+
+pub fn expect_no_verification_errors(err: VMError, log_context: &impl LogContext) -> VMError {
+    match err.status_type() {
+        status_type @ StatusType::Deserialization | status_type @ StatusType::Verification => {
+            let message = format!(
+                "Unexpected verifier/deserialization error! This likely means there is code \
+                stored on chain that is unverifiable!\nError: {:?}",
+                &err
+            );
+            let (_old_status, _old_sub_status, _old_message, location, indices, offsets) =
+                err.all_data();
+            let major_status = match status_type {
+                StatusType::Deserialization => StatusCode::UNEXPECTED_DESERIALIZATION_ERROR,
+                StatusType::Verification => StatusCode::UNEXPECTED_VERIFIER_ERROR,
+                _ => unreachable!(),
+            };
+
+            log_context.alert();
+            error!(*log_context, "[VM] {}", message);
+            PartialVMError::new(major_status)
+                .with_message(message)
+                .at_indices(indices)
+                .at_code_offsets(offsets)
+                .finish(location)
+        }
+        _ => err,
+    }
 }


### PR DESCRIPTION
- Switches a missing module/function in 'load_function' to an invariant violation
- Moved invariant check to the diem adaptor

## Motivation

- Makes room for an execute_script_function that uses the same loading functionality


## Test Plan

- @runtian-zhou, any ideas?

## Related PRs

- #7534 