### PR TITLE
[ir-compiler] parser support for public(script)

### DIFF
--- a/language/compiler/ir-to-bytecode/src/compiler.rs
+++ b/language/compiler/ir-to-bytecode/src/compiler.rs
@@ -910,8 +910,9 @@ fn compile_function(
     let ast_function = ast_function.value;
 
     let visibility = match ast_function.visibility {
-        FunctionVisibility::Internal => Visibility::Private,
         FunctionVisibility::Public => Visibility::Public,
+        FunctionVisibility::Script => Visibility::Script,
+        FunctionVisibility::Internal => Visibility::Private,
     };
     let acquires_global_resources = ast_function
         .acquires

--- a/language/compiler/ir-to-bytecode/syntax/src/lexer.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/lexer.rs
@@ -84,6 +84,7 @@ pub enum Tok {
     Native,
     Old,
     Public,
+    Script,
     Requires,
     Resource,
     /// Return in the specification language
@@ -434,6 +435,7 @@ fn get_name_token(name: &str) -> Tok {
         "resource" => Tok::Resource,
         "RET" => Tok::SpecReturn,
         "return" => Tok::Return,
+        "script" => Tok::Script,
         "signer" => Tok::Signer,
         "struct" => Tok::Struct,
         "succeeds_if" => Tok::SucceedsIf,

--- a/language/compiler/src/unit_tests/function_tests.rs
+++ b/language/compiler/src/unit_tests/function_tests.rs
@@ -4,7 +4,7 @@
 use crate::unit_tests::testutils::compile_module_string;
 
 #[test]
-fn compile_script_with_functions() {
+fn compile_module_with_functions() {
     let code = String::from(
         "
         module Foobar {
@@ -68,7 +68,7 @@ fn generate_function(name: &str, num_formals: usize, num_locals: usize) -> Strin
 }
 
 #[test]
-fn compile_script_with_large_frame() {
+fn compile_module_with_large_frame() {
     let mut code = String::from(
         "
         module Foobar {
@@ -81,6 +81,26 @@ fn compile_script_with_large_frame() {
 
     code.push('}');
 
+    let compiled_module_res = compile_module_string(&code);
+    assert!(compiled_module_res.is_ok());
+}
+
+#[test]
+fn compile_module_with_script_visibility_functions() {
+    let code = String::from(
+        "
+        module Foobar {
+            public(script) foo() {
+                return;
+            }
+
+            public(script) bar() {
+                Self.foo();
+                return;
+            }
+        }
+        ",
+    );
     let compiled_module_res = compile_module_string(&code);
     assert!(compiled_module_res.is_ok());
 }

--- a/language/move-ir/types/src/ast.rs
+++ b/language/move-ir/types/src/ast.rs
@@ -318,6 +318,9 @@ pub enum FunctionVisibility {
     /// The procedure can be invoked anywhere
     /// `public`
     Public,
+    /// The procedure can only be invoked from a script context
+    /// `public(script)`
+    Script,
     /// The procedure can be invoked only internally
     /// `<no modifier>`
     Internal,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Fill the gap in `public(script)` implementation.

- #7534 adds the changes to file format and bytecode verifier
- This PR adds support in the IR compiler to parse `public(script)` and produce bytecode with the new `script` visibility (once #7534) lands.
- #7497 adds support in the source compiler, which will rely on this PR.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

A new test case, `compile_module_with_script_visibility_functions`, is added to the unit tests of the IR compiler.

