### PR TITLE
[deps] upgrade hyper from 0.13.9 to 0.13.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3386,9 +3386,9 @@ checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
 
 [[package]]
 name = "hyper"
-version = "0.13.9"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
+checksum = "8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb"
 dependencies = [
  "bytes",
  "futures-channel",


### PR DESCRIPTION
## Motivation
This addresses [RUSTSEC-2021-0020](https://rustsec.org/advisories/RUSTSEC-2021-0020).  The corresponding changelog can be found [here](https://github.com/hyperium/hyper/compare/v0.13.9...v0.13.10).

- This is not a breaking change.  It is transitive dep affecting backup-service, json-rpc-client, debug-interface.
- It was tested in CI and canary.
- It was needed for sec fix.
- No clear alternative at the moment. 

## Test Plan
cargo audit locally + CI
