### PR TITLE
[network] Connection Manager and PeerRole improvements

### DIFF
--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -361,6 +361,8 @@ pub type PeerSet = HashMap<PeerId, Peer>;
 /// PreferredUpstream -> Always upstream, overriding any other discovery
 /// ValidatorFullNode -> Always upstream for incoming connections (including other ValidatorFullNodes)
 /// Upstream -> Upstream, if no ValidatorFullNode or PreferredUpstream.  Useful for initial seed discovery
+/// Downstream -> Downstream, defining a controlled downstream that I always want to connect
+/// Known -> A known peer, but it has no particular role assigned to it
 /// Unknown -> Undiscovered peer, likely due to a non-mutually authenticated connection always downstream
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub enum PeerRole {
@@ -368,6 +370,8 @@ pub enum PeerRole {
     PreferredUpstream,
     ValidatorFullNode,
     Upstream,
+    Downstream,
+    Known,
     Unknown,
 }
 


### PR DESCRIPTION
### Overview

This change moves ConnectionManager to use `Peer` instead of `Addresses` as a stepping stone to peer prioritization in making outbound connections.  There needs to be more done at a high level to move directly to a prioritization strategy that doesn't cause excess connections across multiple network interfaces.

Additionally, this provides a way for applications and connmgr to have a canonical way for identifying whether a peer is Upstream or Downstream, and a simple prioritization scheme in it, based on the tuple of `NetworkId` and `RoleType`.  This is however needed for `RoleType` to actually be the role of the node, and not the network see: https://github.com/diem/diem/pull/7604

### Future changes
* A few more tests that test the logic around the role choices.
* Possible ability to change Role type in the future via discovery
* Smarter peer choices in ConnManager, Mempool, StateSync