### PR TITLE
add CoinTradeMetadata

### DIFF
--- a/testsuite/generate-format/src/diem.rs
+++ b/testsuite/generate-format/src/diem.rs
@@ -60,6 +60,7 @@ pub fn get_registry() -> Result<Registry> {
     tracer.trace_type::<transaction::metadata::TravelRuleMetadata>(&samples)?;
     tracer.trace_type::<transaction::metadata::RefundMetadata>(&samples)?;
     tracer.trace_type::<transaction::metadata::RefundReason>(&samples)?;
+    tracer.trace_type::<transaction::metadata::CoinTradeMetadata>(&samples)?;
     tracer.trace_type::<transaction::Transaction>(&samples)?;
     tracer.trace_type::<transaction::TransactionArgument>(&samples)?;
     tracer.trace_type::<transaction::TransactionPayload>(&samples)?;

--- a/testsuite/generate-format/tests/staged/diem.yaml
+++ b/testsuite/generate-format/tests/staged/diem.yaml
@@ -29,6 +29,16 @@ ChangeSet:
     - events:
         SEQ:
           TYPENAME: ContractEvent
+CoinTradeMetadata:
+  ENUM:
+    0:
+      CoinTradeMetadataV0:
+        NEWTYPE:
+          TYPENAME: CoinTradeMetadataV0
+CoinTradeMetadataV0:
+  STRUCT:
+    - trade_ids:
+        SEQ: STR
 ContractEvent:
   ENUM:
     0:
@@ -87,6 +97,10 @@ Metadata:
       RefundMetadata:
         NEWTYPE:
           TYPENAME: RefundMetadata
+    5:
+      CoinTradeMetadata:
+        NEWTYPE:
+          TYPENAME: CoinTradeMetadata
 Module:
   STRUCT:
     - code: BYTES

--- a/types/src/transaction/metadata.rs
+++ b/types/src/transaction/metadata.rs
@@ -16,6 +16,7 @@ pub enum Metadata {
     TravelRuleMetadata(TravelRuleMetadata),
     UnstructuredBytesMetadata(UnstructuredBytesMetadata),
     RefundMetadata(RefundMetadata),
+    CoinTradeMetadata(CoinTradeMetadata),
 }
 
 /// List of supported transaction metadata format versions for regular
@@ -113,4 +114,17 @@ pub enum RefundReason {
     InvalidSubaddress,
     UserInitiatedPartialRefund,
     UserInitiatedFullRefund,
+}
+
+/// List of supported transaction metadata format versions for coin trade transaction
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum CoinTradeMetadata {
+    CoinTradeMetadataV0(CoinTradeMetadataV0),
+}
+
+/// Transaction metadata format for coin trades (purchases/sells)
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct CoinTradeMetadataV0 {
+    /// A list of trade_ids this transaction wants to settle
+    pub trade_ids: Vec<String>,
 }


### PR DESCRIPTION
## Motivation

Currently there is no way no convey trade id(s) in a payment, for coin purchase/sell flows, without doing Travel Rule. [This proposal](https://docs.google.com/document/d/1DNaRzSjHGU7HD8xrEbU_cg3JY5apQI5VQcIpHM44EAI/edit?usp=sharing) suggests adding `CoinTradeMetadata` specifically for this use case. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo run -p generate-format -- --corpus diem --record


## Related PRs
n/a
