### PR TITLE
[cluster-test] Added new invalid tx suite

### DIFF
--- a/testsuite/cluster-test/src/experiments/compatibility_test.rs
+++ b/testsuite/cluster-test/src/experiments/compatibility_test.rs
@@ -162,10 +162,12 @@ impl Experiment for CompatibilityTest {
             context.cluster.validator_instances().to_vec(),
             context.global_emit_job_request,
             0,
+            0,
         );
         let fullnode_txn_job = EmitJobRequest::for_instances(
             context.cluster.fullnode_instances().to_vec(),
             context.global_emit_job_request,
+            0,
             0,
         );
         let job_duration = Duration::from_secs(3);
@@ -206,7 +208,7 @@ impl Experiment for CompatibilityTest {
             .tx_emitter
             .emit_txn_for(
                 job_duration,
-                EmitJobRequest::for_instances(first_node, context.global_emit_job_request, 0),
+                EmitJobRequest::for_instances(first_node, context.global_emit_job_request, 0, 0),
             )
             .await
             .map_err(|e| anyhow::format_err!("Storage backwards compat broken: {}", e))?;

--- a/testsuite/cluster-test/src/experiments/cpu_flamegraph.rs
+++ b/testsuite/cluster-test/src/experiments/cpu_flamegraph.rs
@@ -62,6 +62,7 @@ impl Experiment for CpuFlamegraph {
             context.cluster.validator_instances().to_vec(),
             context.global_emit_job_request,
             0,
+            0,
         );
         let emit_future = context
             .tx_emitter

--- a/testsuite/cluster-test/src/experiments/load_test.rs
+++ b/testsuite/cluster-test/src/experiments/load_test.rs
@@ -122,6 +122,7 @@ impl Experiment for LoadTest {
                         context.cluster.fullnode_instances().to_vec(),
                         context.global_emit_job_request,
                         0,
+                        0,
                     ))
                     .await?,
             );

--- a/testsuite/cluster-test/src/experiments/performance_benchmark_three_region_simulation.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark_three_region_simulation.rs
@@ -60,11 +60,13 @@ impl Experiment for PerformanceBenchmarkThreeRegionSimulation {
                 context.cluster.validator_instances().to_vec(),
                 context.global_emit_job_request,
                 0,
+                0,
             )
         } else {
             EmitJobRequest::for_instances(
                 context.cluster.fullnode_instances().to_vec(),
                 context.global_emit_job_request,
+                0,
                 0,
             )
         };

--- a/testsuite/cluster-test/src/experiments/reconfiguration_test.rs
+++ b/testsuite/cluster-test/src/experiments/reconfiguration_test.rs
@@ -118,6 +118,7 @@ impl Experiment for Reconfiguration {
                         instances,
                         context.global_emit_job_request,
                         0,
+                        0,
                     ))
                     .await?,
             )

--- a/testsuite/cluster-test/src/experiments/recovery_time.rs
+++ b/testsuite/cluster-test/src/experiments/recovery_time.rs
@@ -60,6 +60,7 @@ impl Experiment for RecoveryTime {
                     context.cluster.validator_instances().to_vec(),
                     context.global_emit_job_request,
                     0,
+                    0,
                 ),
                 self.params.num_accounts_to_mint as usize,
             )

--- a/testsuite/cluster-test/src/experiments/twin_validator.rs
+++ b/testsuite/cluster-test/src/experiments/twin_validator.rs
@@ -103,7 +103,7 @@ impl Experiment for TwinValidators {
         }
         let instances = self.instances.clone();
         let emit_job_request =
-            EmitJobRequest::for_instances(instances, context.global_emit_job_request, 0);
+            EmitJobRequest::for_instances(instances, context.global_emit_job_request, 0, 0);
         info!("Starting txn generation");
         let stats = context
             .tx_emitter

--- a/testsuite/cluster-test/src/experiments/versioning_test.rs
+++ b/testsuite/cluster-test/src/experiments/versioning_test.rs
@@ -96,6 +96,7 @@ impl Experiment for ValidatorVersioning {
                     context.cluster.validator_instances().to_vec(),
                     context.global_emit_job_request,
                     0,
+                    0,
                 ),
                 150,
             )

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -312,7 +312,7 @@ async fn emit_tx(cluster: &Cluster, args: &Args) -> Result<()> {
         wait_committed: !args.burst,
     };
     let duration = Duration::from_secs(args.duration);
-    let mut emitter = TxEmitter::new(cluster, args.vasp, args.invalid_tx);
+    let mut emitter = TxEmitter::new(cluster, args.vasp);
     let stats = emitter
         .emit_txn_for_with_stats(
             duration,
@@ -322,6 +322,7 @@ async fn emit_tx(cluster: &Cluster, args: &Args) -> Result<()> {
                 workers_per_ac,
                 thread_params,
                 gas_price: 0,
+                invalid_tx: args.invalid_tx,
             },
             10,
         )
@@ -370,7 +371,7 @@ impl BasicSwarmUtil {
     }
 
     pub async fn diag(&self, vasp: bool) -> Result<()> {
-        let emitter = TxEmitter::new(&self.cluster, vasp, 0);
+        let emitter = TxEmitter::new(&self.cluster, vasp);
         let mut faucet_account: Option<AccountData> = None;
         let instances: Vec<_> = self.cluster.validator_and_fullnode_instances().collect();
         for instance in &instances {
@@ -502,7 +503,7 @@ impl ClusterTestRunner {
         let slack_changelog_url = env::var("SLACK_CHANGELOG_URL")
             .map(|u| u.parse().expect("Failed to parse SLACK_CHANGELOG_URL"))
             .ok();
-        let tx_emitter = TxEmitter::new(&cluster, args.vasp, args.invalid_tx);
+        let tx_emitter = TxEmitter::new(&cluster, args.vasp);
         let github = GitHub::new();
         let report = SuiteReport::new();
         let global_emit_job_request = EmitJobRequest {
@@ -514,6 +515,7 @@ impl ClusterTestRunner {
                 wait_committed: !args.burst,
             },
             gas_price: 0,
+            invalid_tx: args.invalid_tx,
         };
         let emit_to_validator =
             if cluster.fullnode_instances().len() < cluster.validator_instances().len() {

--- a/testsuite/cluster-test/src/suite.rs
+++ b/testsuite/cluster-test/src/suite.rs
@@ -129,6 +129,17 @@ impl ExperimentSuite {
         Ok(Self { experiments })
     }
 
+    fn new_invalid_tx_suite(cluster: &Cluster) -> Self {
+        let mut experiments: Vec<Box<dyn Experiment>> = vec![];
+        experiments.push(Box::new(
+            PerformanceBenchmarkParams::new_nodes_down(0).build(cluster),
+        ));
+        experiments.push(Box::new(
+            PerformanceBenchmarkParams::mix_invalid_tx(0, 10).build(cluster),
+        ));
+        Self { experiments }
+    }
+
     pub fn new_by_name(cluster: &Cluster, name: &str) -> Result<Self> {
         match name {
             "perf" => Ok(Self::new_perf_suite(cluster)),
@@ -136,6 +147,7 @@ impl ExperimentSuite {
             "twin" => Ok(Self::new_twin_suite(cluster)),
             "land_blocking" => Ok(Self::new_land_blocking_suite(cluster)),
             "land_blocking_compat" => Self::new_land_blocking_compat_suite(cluster),
+            "invalid" => Ok(Self::new_invalid_tx_suite(cluster)),
             other => Err(format_err!("Unknown suite: {}", other)),
         }
     }


### PR DESCRIPTION
- Refactory current code path for flag --invalid-tx
- Added new experiment with mixing invalid tx
- Added new test suite ```--suite invalid```

Related PR: 
[cluster-test] new invalid tx type for duplication: https://github.com/diem/diem/pull/7422
[cluster-test] Add stat for CT burst mode: https://github.com/diem/diem/pull/7527 Postponed since the perf regression bug


## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan
./scripts/cti --pr 7583 --suite invalid

http://grafana.ct-0-k8s-testnet.aws.hlw3truzy4ls.com/d/performance/performance?orgId=1&from=1612920551000&to=1612921444000

Exposed related bug linked:
https://github.com/diem/diem/issues/7577

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/master/developers.diem.com, and link to your PR here.)
