### PR TITLE
improve cli experience on testnet

### DIFF
--- a/sdk/client/src/retry.rs
+++ b/sdk/client/src/retry.rs
@@ -15,7 +15,7 @@ pub struct Retry {
 
 impl Default for Retry {
     fn default() -> Self {
-        Self::new(5, Duration::from_millis(50))
+        Self::new(20, Duration::from_millis(500))
     }
 }
 

--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -242,7 +242,8 @@ impl ClientProxy {
 
     /// Returns the ledger info corresonding to the latest epoch change
     /// (could further be used for e.g., generating a waypoint)
-    pub fn latest_epoch_change_li(&self) -> Option<&LedgerInfoWithSignatures> {
+    pub fn latest_epoch_change_li(&mut self) -> Option<&LedgerInfoWithSignatures> {
+        self.client.update_and_verify_state_proof().unwrap();
         self.client.latest_epoch_change_li()
     }
 
@@ -1021,7 +1022,8 @@ impl ClientProxy {
     }
 
     /// Get the latest version
-    pub fn get_latest_version(&self) -> Version {
+    pub fn get_latest_version(&mut self) -> Version {
+        self.client.update_and_verify_state_proof().unwrap();
         self.client.trusted_state().latest_version()
     }
 
@@ -1278,7 +1280,11 @@ impl ClientProxy {
         address: &AccountAddress,
     ) -> Result<Option<views::AccountView>> {
         let account = self.client.get_account(address)?;
-        self.client.update_and_verify_state_proof()?;
+        // This isn't used by anything except to keep track of the current version and to simulate
+        // some potential verifiable clients, which is yet to be implemented. It also has some
+        // challenges in handling retries if the upstream hasn't yet arrived at the expected
+        // version and breaks with our testnet deployment, so disabling this for now.
+        // self.client.update_and_verify_state_proof()?;
 
         if let Some(ref ac) = account.as_ref() {
             self.update_account_seq(address, ac.sequence_number)


### PR DESCRIPTION
* increasing timeout to effectively 10 seconds which matches our worst case time delay for synchronizing in low activity times
* disabling trusted state in cli since it is incompatible with our testnet json-rpc deployment

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/master/developers.diem.com, and link to your PR here.)
