### PR TITLE
[move-lang] disallow odd-length hex strings

### DIFF
--- a/language/move-lang/functional-tests/tests/diem/diem_account/delegate_rotation_capability.move
+++ b/language/move-lang/functional-tests/tests/diem/diem_account/delegate_rotation_capability.move
@@ -56,7 +56,7 @@ fun main(account: &signer) {
     SharedKeyRotation::rotate(
         account,
         {{alice}},
-        x"8a88082abf9fbb576bdb6969143ee6384066e363c48e041c8da1e08b9fc931f",
+        x"08a88082abf9fbb576bdb6969143ee6384066e363c48e041c8da1e08b9fc931f",
     );
 }
 }

--- a/language/move-lang/functional-tests/tests/diem/diem_account/freezing.move
+++ b/language/move-lang/functional-tests/tests/diem/diem_account/freezing.move
@@ -89,7 +89,7 @@ fun main(dr_account: &signer) {
         dr_account,
         {{vasp}},
         {{vasp::auth_key}},
-        x"A",
+        x"0A",
         true,
     );
 }

--- a/language/move-lang/functional-tests/tests/diem/natives/signature.move
+++ b/language/move-lang/functional-tests/tests/diem/natives/signature.move
@@ -7,9 +7,9 @@ fun main() {
 
     // from RFC 8032
     let valid_pubkey =  x"3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c";
-    let short_pubkey = x"100";
+    let short_pubkey = x"0100";
     // concatenation of the two above
-    let long_pubkey = x"1003d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c";
+    let long_pubkey = x"01003d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c";
     let invalid_pubkey = x"0000000000000000000000000000000000000000000000000000000000000000";
 
     assert(Signature::ed25519_validate_pubkey(copy valid_pubkey), 9003);
@@ -17,7 +17,7 @@ fun main() {
     assert(!Signature::ed25519_validate_pubkey(copy long_pubkey), 9005);
     assert(!Signature::ed25519_validate_pubkey(copy invalid_pubkey), 9006);
 
-    let short_signature = x"100";
+    let short_signature = x"0100";
     let long_signature = x"0062d6be393b8ec77fb2c12ff44ca8b5bd8bba83b805171bc99f0af3bdc619b20b8bd529452fe62dac022c80752af2af02fb610c20f01fb67a4d72789db2b8b703";
     let valid_signature = x"62d6be393b8ec77fb2c12ff44ca8b5bd8bba83b805171bc99f0af3bdc619b20b8bd529452fe62dac022c80752af2af02fb610c20f01fb67a4d72789db2b8b703";
 

--- a/language/move-lang/functional-tests/tests/diem/shared_ed25519_public_key/shared_key.move
+++ b/language/move-lang/functional-tests/tests/diem/shared_ed25519_public_key/shared_key.move
@@ -41,7 +41,7 @@ fun main(account: &signer) {
 script {
 use 0x1::SharedEd25519PublicKey;
 fun main(account: &signer) {
-    let invalid_pubkey = x"000";
+    let invalid_pubkey = x"0000";
     SharedEd25519PublicKey::publish(account, invalid_pubkey)
 }
 }
@@ -80,7 +80,7 @@ fun main(account: &signer) {
     let valid_pubkey =  x"3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c";
     SharedEd25519PublicKey::publish(account, valid_pubkey);
     // now rotate to an invalid key
-    let invalid_pubkey = x"10000";
+    let invalid_pubkey = x"010000";
     SharedEd25519PublicKey::rotate_key(account, invalid_pubkey)
 }
 }

--- a/language/move-lang/functional-tests/tests/diem/smoke_tests/approved_payment.move
+++ b/language/move-lang/functional-tests/tests/diem/smoke_tests/approved_payment.move
@@ -294,7 +294,7 @@ script {
 use {{default}}::ApprovedPayment;
 use 0x1::XDX::XDX;
 fun main(account: &signer) {
-    let payment_id = x"7";
+    let payment_id = x"07";
     let signature = x"62d6be393b8ec77fb2c12ff44ca8b5bd8bba83b805171bc99f0af3bdc619b20b8bd529452fe62dac022c80752af2af02fb610c20f01fb67a4d72789db2b8b703";
     ApprovedPayment::deposit_to_payee<XDX>(account, {{alice3}}, 1000, payment_id, signature);
 }
@@ -307,7 +307,7 @@ fun main(account: &signer) {
 script {
 use {{default}}::ApprovedPayment;
 fun main(account: &signer) {
-    let pubkey = x"10000000000000000000000000000000000000000000000000000000000000000";
+    let pubkey = x"010000000000000000000000000000000000000000000000000000000000000000";
     ApprovedPayment::publish(account, pubkey);
 }
 }
@@ -320,7 +320,7 @@ fun main(account: &signer) {
 script {
 use {{default}}::ApprovedPayment;
 fun main(account: &signer) {
-    let pubkey = x"100";
+    let pubkey = x"0100";
     ApprovedPayment::publish(account, pubkey);
 }
 }

--- a/language/move-lang/functional-tests/tests/move/constants/folding_complex.move
+++ b/language/move-lang/functional-tests/tests/move/constants/folding_complex.move
@@ -12,14 +12,14 @@ script {
         0 == 1;
         false == true;
         0x42 == 0x43;
-        x"42" == x"422";
+        x"42" == x"0422";
         b"hello" == b"XhelloX";
         0 != 1;
         0 != 1;
         0 != 1;
         false != true;
         0x42 != 0x43;
-        x"42" != x"422";
+        x"42" != x"0422";
         b"hello" != b"XhelloX";
         0 != 0;
         0 != 0;

--- a/language/move-lang/functional-tests/tests/move/constants/folding_equality.move
+++ b/language/move-lang/functional-tests/tests/move/constants/folding_equality.move
@@ -12,7 +12,7 @@ script {
     const EQ_F_U128: bool = 0 == 1;
     const EQ_F_BOOL: bool = false == true;
     const EQ_F_ADDR: bool = 0x42 == 0x43;
-    const EQ_F_HEX: bool = x"42" == x"422";
+    const EQ_F_HEX: bool = x"42" == x"0422";
     const EQ_F_BYTES: bool = b"hello" == b"XhelloX";
 
     const NEQ_T_U8: bool = 0 != 1;
@@ -20,7 +20,7 @@ script {
     const NEQ_T_U128: bool = 0 != 1;
     const NEQ_T_BOOL: bool = false != true;
     const NEQ_T_ADDR: bool = 0x42 != 0x43;
-    const NEQ_T_HEX: bool = x"42" != x"422";
+    const NEQ_T_HEX: bool = x"42" != x"0422";
     const NEQ_T_BYTES: bool = b"hello" != b"XhelloX";
 
     const NEQ_F_U8: bool = 0 != 0;

--- a/language/move-lang/src/expansion/hex_string.rs
+++ b/language/move-lang/src/expansion/hex_string.rs
@@ -5,25 +5,24 @@ use crate::{errors::*, parser::syntax::make_loc};
 use move_ir_types::location::*;
 
 pub fn decode(loc: Loc, s: &str) -> Result<Vec<u8>, Errors> {
-    let mut text = s.to_string();
-    let adjust = if text.len() % 2 != 0 {
-        text.insert(0, '0');
-        1
-    } else {
-        0
-    };
-    match hex::decode(&text) {
+    match hex::decode(s) {
         Ok(vec) => Ok(vec),
         Err(hex::FromHexError::InvalidHexCharacter { c, index }) => {
             let filename = loc.file();
             let start_offset = loc.span().start().0 as usize;
-            let offset = start_offset + 2 - adjust + index;
+            let offset = start_offset + 2 + index;
             let loc = make_loc(filename, offset, offset);
             Err(vec![vec![(
                 loc,
                 format!("Invalid hexadecimal character: '{}'", c),
             )]])
         }
+        Err(hex::FromHexError::OddLength) => Err(vec![vec![(
+            loc,
+            "Odd number of characters in hex string. \
+                Expected 2 hexadecimal digits for each byte"
+                .to_string(),
+        )]]),
         Err(_) => unreachable!("unexpected error parsing hex byte string value"),
     }
 }

--- a/language/move-lang/tests/move_check/expansion/hexstring_bad_value.exp
+++ b/language/move-lang/tests/move_check/expansion/hexstring_bad_value.exp
@@ -1,0 +1,16 @@
+error: 
+
+   ┌── tests/move_check/expansion/hexstring_bad_value.move:3:11 ───
+   │
+ 3 │         x"g0"
+   │           ^ Invalid hexadecimal character: 'g'
+   │
+
+error: 
+
+   ┌── tests/move_check/expansion/hexstring_bad_value.move:6:9 ───
+   │
+ 6 │         x"123"
+   │         ^^^^^^ Odd number of characters in hex string. Expected 2 hexadecimal digits for each byte
+   │
+

--- a/language/move-lang/tests/move_check/expansion/hexstring_bad_value.move
+++ b/language/move-lang/tests/move_check/expansion/hexstring_bad_value.move
@@ -1,0 +1,8 @@
+module M {
+    public fun bad_value(): vector<u8> {
+        x"g0"
+    }
+    public fun odd_length(): vector<u8> {
+        x"123"
+    }
+}

--- a/language/move-lang/tests/move_check/parser/hexstring.move
+++ b/language/move-lang/tests/move_check/parser/hexstring.move
@@ -2,7 +2,4 @@ module M {
     public fun hexstring(): vector<u8> {
         x"abcd"
     }
-    public fun odd_length(): vector<u8> {
-        x"123"
-    }
 }

--- a/language/move-lang/tests/move_check/parser/hexstring_bad_value1.exp
+++ b/language/move-lang/tests/move_check/parser/hexstring_bad_value1.exp
@@ -1,8 +1,0 @@
-error: 
-
-   ┌── tests/move_check/parser/hexstring_bad_value1.move:4:11 ───
-   │
- 4 │         x"g"
-   │           ^ Invalid hexadecimal character: 'g'
-   │
-

--- a/language/move-lang/tests/move_check/parser/hexstring_bad_value1.move
+++ b/language/move-lang/tests/move_check/parser/hexstring_bad_value1.move
@@ -1,6 +1,0 @@
-module M {
-    public fun bad_value1(): vector<u8> {
-	// Test with an odd number of characters
-        x"g"
-    }
-}

--- a/language/move-lang/tests/move_check/parser/hexstring_bad_value2.exp
+++ b/language/move-lang/tests/move_check/parser/hexstring_bad_value2.exp
@@ -1,8 +1,0 @@
-error: 
-
-   ┌── tests/move_check/parser/hexstring_bad_value2.move:4:16 ───
-   │
- 4 │         x"bcdefg"
-   │                ^ Invalid hexadecimal character: 'g'
-   │
-

--- a/language/move-lang/tests/move_check/parser/hexstring_bad_value2.move
+++ b/language/move-lang/tests/move_check/parser/hexstring_bad_value2.move
@@ -1,6 +1,0 @@
-module M {
-    public fun bad_value2(): vector<u8> {
-	// Test with an even number of characters
-        x"bcdefg"
-    }
-}

--- a/language/tools/move-cli/tests/testsuite/compare_smoke/src/scripts/compare.move
+++ b/language/tools/move-cli/tests/testsuite/compare_smoke/src/scripts/compare.move
@@ -15,7 +15,7 @@ fun main() {
     assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&1), &BCS::to_bytes(&1)) == equal, 8003);
     assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&1u128), &BCS::to_bytes(&1u128)) == equal, 8004);
     assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&0x1), &BCS::to_bytes(&0x1)) == equal, 8005);
-    assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&x"1"), &BCS::to_bytes(&x"1")) == equal, 8006);
+    assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&x"01"), &BCS::to_bytes(&x"01")) == equal, 8006);
 
     // inequality of simple types
     assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&true), &BCS::to_bytes(&false)) != equal, 8007);
@@ -23,7 +23,7 @@ fun main() {
     assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&1), &BCS::to_bytes(&0)) != equal, 8009);
     assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&1u128), &BCS::to_bytes(&0u128)) != equal, 8010);
     assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&0x1), &BCS::to_bytes(&0x0)) != equal, 8011);
-    assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&x"1"), &BCS::to_bytes(&x"0")) != equal, 8012);
+    assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&x"01"), &BCS::to_bytes(&x"00")) != equal, 8012);
 
     // less than for types with a natural ordering exposed via bytecode operations
     assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&false), &BCS::to_bytes(&true)) == less_than, 8013);
@@ -35,10 +35,10 @@ fun main() {
     assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&0x0), &BCS::to_bytes(&0x1)) == less_than, 8017); // sensible
     assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&0x01), &BCS::to_bytes(&0x10)) == less_than, 8018); // sensible
     assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&0x100), &BCS::to_bytes(&0x001)) == less_than, 8019); // potentially confusing
-    assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&x"0"), &BCS::to_bytes(&x"1")) == less_than, 8020); // sensible
+    assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&x"00"), &BCS::to_bytes(&x"01")) == less_than, 8020); // sensible
     assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&x"01"), &BCS::to_bytes(&x"10")) == less_than, 8021); // sensible
-    assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&x"000"), &BCS::to_bytes(&x"01")) == less_than, 8022); //
-    assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&x"100"), &BCS::to_bytes(&x"001")) == less_than, 8023); // potentially confusing
+    assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&x"0000"), &BCS::to_bytes(&x"01")) == less_than, 8022); //
+    assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&x"0100"), &BCS::to_bytes(&x"0001")) == less_than, 8023); // potentially confusing
 
     // greater than for types with a natural ordering exposed by bytecode operations
     assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&true), &BCS::to_bytes(&false)) == greater_than, 8024);
@@ -50,9 +50,9 @@ fun main() {
     assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&0x1), &BCS::to_bytes(&0x0)) == greater_than, 8028); // sensible
     assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&0x10), &BCS::to_bytes(&0x01)) == greater_than, 8029); // sensible
     assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&0x001), &BCS::to_bytes(&0x100)) == greater_than, 8030); // potentially confusing
-    assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&x"1"), &BCS::to_bytes(&x"0")) == greater_than, 8031); // sensible
+    assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&x"01"), &BCS::to_bytes(&x"00")) == greater_than, 8031); // sensible
     assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&x"10"), &BCS::to_bytes(&x"01")) == greater_than, 8032); // sensible
-    assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&x"01"), &BCS::to_bytes(&x"000")) == greater_than, 8033); // sensible
-    assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&x"001"), &BCS::to_bytes(&x"100")) == greater_than, 8034); // potentially confusing
+    assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&x"01"), &BCS::to_bytes(&x"0000")) == greater_than, 8033); // sensible
+    assert(Compare::cmp_bcs_bytes(&BCS::to_bytes(&x"0001"), &BCS::to_bytes(&x"0100")) == greater_than, 8034); // potentially confusing
 }
 }


### PR DESCRIPTION
Hex strings with an odd number of characters are ambiguous and confusing. The compiler previously added a "0" prefix at the beginning of an odd-length string, e.g., x"123" was interpreted as x"0123", but that goes against thinking of the value as a string, especially for longer values where it is hard to tell from a glance if the string will be padded in that way. This changes the compiler to make odd-length hex strings invalid.

## Motivation

Fixes #6577

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I had to adjust a few test cases that were relying on the previous behavior.  I moved the test for bad hex string values, including the new case of odd-length strings, into `move_check/expansion` because those values are no longer checked during parsing (even before this change). We also had two separate tests for invalid hex characters to make sure that the source location was correctly reported for both even and odd-length strings, so I removed one of those tests since the one version is no longer relevant.