### PR TITLE
[State Sync] Use optimistic fetch when making waypoint and verifiable ledger info requests.

### DIFF
--- a/state-sync/src/error.rs
+++ b/state-sync/src/error.rs
@@ -18,8 +18,10 @@ pub enum Error {
     IntegerOverflow(String),
     #[error("Received an invalid chunk request: {0}")]
     InvalidChunkRequest(String),
-    #[error("No peers are currently available!")]
-    NoAvailablePeers,
+    #[error("No peers are currently available: {0}")]
+    NoAvailablePeers(String),
+    #[error("No sync request was issued by consensus: {0}")]
+    NoSyncRequestFound(String),
     #[error("No transactions were committed, but received a commit notification!")]
     NoTransactionsCommitted,
     #[error("Received an old sync request for version {0}, but our known version is: {1}")]

--- a/state-sync/src/logging.rs
+++ b/state-sync/src/logging.rs
@@ -122,7 +122,6 @@ pub enum LogEvent {
 
     // SendChunkRequest events
     MissingPeers,
-    OldSyncRequest,
     NetworkSendError,
     Success,
     ChunkRequestInfo,

--- a/state-sync/tests/integration_tests.rs
+++ b/state-sync/tests/integration_tests.rs
@@ -439,8 +439,8 @@ fn test_fullnode_catch_up_moving_target() {
     // Expected fullnode sync states (i.e., synced version and committed version)
     let expected_states = vec![
         (250, 0),
-        (500, 500),
-        (750, 500),
+        (500, 0),
+        (750, 0),
         (1000, 1000),
         (1250, 1000),
         (1500, 1000),


### PR DESCRIPTION
## Motivation

This PR updates state sync to perform optimistic chunk request fetching when processing waypoint and verifiable ledger info responses. This is in contrast to the approach of verifying the chunk response before making the request. As such, it should help to reduce the latency of chunk request/responses in the happy path.

Note: the code currently uses optimistic chunk request fetching when processing waypoint ledger infos. It doesn't do this for verifiable ledger infos (despite there being a code comment which says otherwise.. 😮)

To do this, the PR offers a single commit that updates the code to make the chunk request before verifying the response. Unfortunately, due to the way the code is structured, this is not as simple as just switching the order of a few lines of code -- it requires a small refactor of the way in which chunk requests are created. Nonetheless, the code should hopefully be a little cleaner now that we've removed the code duplication between the response processing paths.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally.

## Related PRs

This relates to: https://github.com/diem/diem/issues/6795