### PR TITLE
[language] move move-vm-test-utils::effects into move-core-types

### DIFF
--- a/language/diem-tools/transaction-replay/src/lib.rs
+++ b/language/diem-tools/transaction-replay/src/lib.rs
@@ -15,10 +15,13 @@ use diem_validator_interface::{
 };
 use diem_vm::{data_cache::RemoteStorage, txn_effects_to_writeset_and_events, DiemVM, VMExecutor};
 use move_cli::OnDiskStateView;
-use move_core_types::gas_schedule::{GasAlgebra, GasUnits};
+use move_core_types::{
+    effects::ChangeSet as MoveChanges,
+    gas_schedule::{GasAlgebra, GasUnits},
+};
 use move_lang::{compiled_unit::CompiledUnit, move_compile, shared::Address};
 use move_vm_runtime::{logging::NoContextLog, move_vm::MoveVM, session::Session};
-use move_vm_test_utils::{ChangeSet as MoveChanges, DeltaStorage};
+use move_vm_test_utils::DeltaStorage;
 use move_vm_types::gas_schedule::{zero_cost_schedule, CostStrategy};
 use resource_viewer::{AnnotatedAccountStateBlob, MoveValueAnnotator};
 use std::{

--- a/language/diem-tools/transaction-replay/src/main.rs
+++ b/language/diem-tools/transaction-replay/src/main.rs
@@ -6,7 +6,7 @@ use diem_framework::build_stdlib;
 use diem_transaction_replay::DiemDebugger;
 use diem_types::{account_address::AccountAddress, transaction::Version};
 use difference::Changeset;
-use move_vm_test_utils::ChangeSet;
+use move_core_types::effects::ChangeSet;
 use std::{fs, path::PathBuf};
 use structopt::StructOpt;
 

--- a/language/diem-tools/transaction-replay/src/unit_tests/bisection_tests.rs
+++ b/language/diem-tools/transaction-replay/src/unit_tests/bisection_tests.rs
@@ -8,8 +8,7 @@ use diem_types::{
     account_config::AccountResource,
     event::{EventHandle, EventKey},
 };
-use move_core_types::move_resource::MoveResource;
-use move_vm_test_utils::ChangeSet;
+use move_core_types::{effects::ChangeSet, move_resource::MoveResource};
 use std::path::PathBuf;
 
 #[test]

--- a/language/diem-tools/writeset-transaction-generator/src/writeset_builder.rs
+++ b/language/diem-tools/writeset-transaction-generator/src/writeset_builder.rs
@@ -11,6 +11,7 @@ use diem_types::{
 };
 use diem_vm::{data_cache::RemoteStorage, txn_effects_to_writeset_and_events};
 use move_core_types::{
+    effects::ChangeSet as MoveChanges,
     gas_schedule::{CostTable, GasAlgebra, GasUnits},
     identifier::Identifier,
     language_storage::{ModuleId, TypeTag},
@@ -20,7 +21,7 @@ use move_core_types::{
 use move_vm_runtime::{
     data_cache::RemoteCache, logging::NoContextLog, move_vm::MoveVM, session::Session,
 };
-use move_vm_test_utils::{ChangeSet as MoveChanges, DeltaStorage};
+use move_vm_test_utils::DeltaStorage;
 use move_vm_types::gas_schedule::{zero_cost_schedule, CostStrategy};
 use once_cell::sync::Lazy;
 use vm::CompiledModule;

--- a/language/move-core/types/src/effects.rs
+++ b/language/move-core/types/src/effects.rs
@@ -1,12 +1,12 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{format_err, Error, Result};
-use move_core_types::{
+use crate::{
     account_address::AccountAddress,
     identifier::Identifier,
     language_storage::{ModuleId, StructTag, TypeTag},
 };
+use anyhow::{format_err, Error, Result};
 use std::collections::btree_map::{self, BTreeMap};
 
 /// A collection of changes to modules and resources under a Move account.

--- a/language/move-core/types/src/lib.rs
+++ b/language/move-core/types/src/lib.rs
@@ -4,6 +4,7 @@
 //! Core types for Move.
 
 pub mod account_address;
+pub mod effects;
 pub mod gas_schedule;
 pub mod identifier;
 pub mod language_storage;

--- a/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
@@ -4,6 +4,7 @@
 use crate::compiler::{as_module, as_script, compile_units};
 use move_core_types::{
     account_address::AccountAddress,
+    effects::ChangeSet,
     gas_schedule::{GasAlgebra, GasUnits},
     identifier::Identifier,
     language_storage::{ModuleId, StructTag},
@@ -12,7 +13,7 @@ use move_core_types::{
 };
 use move_vm_runtime::{data_cache::RemoteCache, logging::NoContextLog, move_vm::MoveVM};
 use move_vm_test_utils::{
-    convert_txn_effects_to_move_changeset_and_events, ChangeSet, DeltaStorage, InMemoryStorage,
+    convert_txn_effects_to_move_changeset_and_events, DeltaStorage, InMemoryStorage,
 };
 use move_vm_types::gas_schedule::{zero_cost_schedule, CostStrategy};
 use vm::errors::{Location, PartialVMError, PartialVMResult, VMResult};

--- a/language/move-vm/test-utils/src/lib.rs
+++ b/language/move-vm/test-utils/src/lib.rs
@@ -3,10 +3,8 @@
 
 #![allow(clippy::new_without_default)]
 
-mod effects;
 mod misc;
 mod storage;
 
-pub use effects::{AccountChangeSet, ChangeSet, Event};
 pub use misc::convert_txn_effects_to_move_changeset_and_events;
 pub use storage::{BlankStorage, DeltaStorage, InMemoryStorage};

--- a/language/move-vm/test-utils/src/misc.rs
+++ b/language/move-vm/test-utils/src/misc.rs
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{format_err, Result};
+use move_core_types::effects::{ChangeSet, Event};
 use move_vm_runtime::data_cache::TransactionEffects;
-
-use crate::effects::{ChangeSet, Event};
 
 pub fn convert_txn_effects_to_move_changeset_and_events(
     txn_effects: TransactionEffects,

--- a/language/move-vm/test-utils/src/storage.rs
+++ b/language/move-vm/test-utils/src/storage.rs
@@ -4,6 +4,7 @@
 use anyhow::{format_err, Result};
 use move_core_types::{
     account_address::AccountAddress,
+    effects::{AccountChangeSet, ChangeSet},
     identifier::Identifier,
     language_storage::{ModuleId, StructTag},
 };
@@ -11,8 +12,6 @@ use move_vm_runtime::data_cache::RemoteCache;
 // use move_vm_txn_effect_converter::convert_txn_effects_to_move_changeset_and_events;
 use std::collections::{btree_map, BTreeMap};
 use vm::errors::{PartialVMResult, VMResult};
-
-use crate::effects::{AccountChangeSet, ChangeSet};
 
 /// A dummy storage containing no modules or resources.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
This moves `move-vm-test-utils::effects` into `move-core-types`. `effects::ChangeSet` will become the canonical representation of side effects produced by the Move VM and will replace `TransactionEffects`. A subsequent PR (#7599) will make the switch and let Move VM return serialized values.