### PR TITLE
[move-prover] Multiset implementation for verifying emits specs

### DIFF
--- a/language/move-prover/tests/sources/functional/emits.exp
+++ b/language/move-prover/tests/sources/functional/emits.exp
@@ -1,29 +1,84 @@
 Move prover returns: exiting with boogie verification errors
 error: function does not emit the expected event
 
-    ┌── tests/sources/functional/emits.move:62:9 ───
-    │
- 62 │         emits DummyEvent{msg: 0} to handle;
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    │
-    =     at tests/sources/functional/emits.move:56:5: conditional_missing_condition_incorrect
-    =         x = <redacted>,
-    =         handle = <redacted>,
-    =         result = <redacted>
-    =     at tests/sources/functional/emits.move:57:9: conditional_missing_condition_incorrect
+     ┌── tests/sources/functional/emits.move:112:9 ───
+     │
+ 112 │         emits DummyEvent{msg: 0} to handle;
+     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     │
+     =     at tests/sources/functional/emits.move:106:5: conditional_missing_condition_incorrect
+     =         x = <redacted>,
+     =         handle = <redacted>,
+     =         result = <redacted>
+     =     at tests/sources/functional/emits.move:107:9: conditional_missing_condition_incorrect
 
 error: function does not emit the expected event
 
-    ┌── tests/sources/functional/emits.move:53:9 ───
+     ┌── tests/sources/functional/emits.move:151:9 ───
+     │
+ 151 │         emits DummyEvent{msg: 2} to handle;
+     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     │
+     =     at tests/sources/functional/emits.move:141:5: conditional_multiple_incorrect
+     =         b = <redacted>,
+     =         handle = <redacted>,
+     =         result = <redacted>
+     =     at tests/sources/functional/emits.move:142:16: conditional_multiple_incorrect
+     =     at tests/sources/functional/emits.move:143:16: conditional_multiple_incorrect
+     =     at tests/sources/functional/emits.move:144:9: conditional_multiple_incorrect
+
+error: function does not emit the expected event
+
+     ┌── tests/sources/functional/emits.move:181:9 ───
+     │
+ 181 │         emits DummyEvent{msg: 0} to handle;
+     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     │
+     =     at tests/sources/functional/emits.move:171:5: conditional_multiple_same_incorrect
+     =         b = <redacted>,
+     =         handle = <redacted>,
+     =         result = <redacted>
+     =     at tests/sources/functional/emits.move:172:16: conditional_multiple_same_incorrect
+     =     at tests/sources/functional/emits.move:173:16: conditional_multiple_same_incorrect
+     =     at tests/sources/functional/emits.move:174:9: conditional_multiple_same_incorrect
+
+error: function does not emit the expected event
+
+     ┌── tests/sources/functional/emits.move:103:9 ───
+     │
+ 103 │         emits DummyEvent{msg: 0} to handle if x > 0;
+     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     │
+     =     at tests/sources/functional/emits.move:97:5: conditional_wrong_condition_incorrect
+     =         x = <redacted>,
+     =         handle = <redacted>,
+     =         result = <redacted>
+     =     at tests/sources/functional/emits.move:98:9: conditional_wrong_condition_incorrect
+
+error: function does not emit the expected event
+
+    ┌── tests/sources/functional/emits.move:54:9 ───
     │
- 53 │         emits DummyEvent{msg: 0} to handle if x > 0;
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 54 │         emits DummyEvent{msg: 2} to handle;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/emits.move:47:5: conditional_wrong_condition_incorrect
-    =         x = <redacted>,
+    =     at tests/sources/functional/emits.move:47:5: multiple_incorrect
     =         handle = <redacted>,
     =         result = <redacted>
-    =     at tests/sources/functional/emits.move:48:9: conditional_wrong_condition_incorrect
+    =     at tests/sources/functional/emits.move:48:16: multiple_incorrect
+    =     at tests/sources/functional/emits.move:49:16: multiple_incorrect
+
+error: function does not emit the expected event
+
+    ┌── tests/sources/functional/emits.move:71:9 ───
+    │
+ 71 │         emits DummyEvent{msg: 0} to handle;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/emits.move:66:5: multiple_same_incorrect
+    =         handle = <redacted>,
+    =         result = <redacted>
+    =     at tests/sources/functional/emits.move:67:16: multiple_same_incorrect
 
 error: function does not emit the expected event
 

--- a/language/move-prover/tests/sources/functional/emits.move
+++ b/language/move-prover/tests/sources/functional/emits.move
@@ -31,6 +31,56 @@ module TestEmits {
     }
 
 
+    // ---------------
+    // multiple events
+    // ---------------
+
+    public fun multiple(handle: &mut EventHandle<DummyEvent>) {
+        Event::emit_event(handle, DummyEvent{msg: 0});
+        Event::emit_event(handle, DummyEvent{msg: 1});
+    }
+    spec fun multiple {
+        emits DummyEvent{msg: 0} to handle;
+        emits DummyEvent{msg: 1} to handle;
+    }
+
+    public fun multiple_incorrect(handle: &mut EventHandle<DummyEvent>) {
+        Event::emit_event(handle, DummyEvent{msg: 0});
+        Event::emit_event(handle, DummyEvent{msg: 1});
+    }
+    spec fun multiple_incorrect {
+        emits DummyEvent{msg: 0} to handle;
+        emits DummyEvent{msg: 1} to handle;
+        emits DummyEvent{msg: 2} to handle;
+    }
+
+    public fun multiple_same(handle: &mut EventHandle<DummyEvent>) {
+        Event::emit_event(handle, DummyEvent{msg: 0});
+        Event::emit_event(handle, DummyEvent{msg: 0});
+    }
+    spec fun multiple_same {
+        emits DummyEvent{msg: 0} to handle;
+        emits DummyEvent{msg: 0} to handle;
+    }
+
+    public fun multiple_same_incorrect(handle: &mut EventHandle<DummyEvent>) {
+        Event::emit_event(handle, DummyEvent{msg: 0});
+    }
+    spec fun multiple_same_incorrect {
+        emits DummyEvent{msg: 0} to handle;
+        emits DummyEvent{msg: 0} to handle;
+    }
+
+    public fun multiple_different_handle(handle: &mut EventHandle<DummyEvent>, handle2: &mut EventHandle<DummyEvent>) {
+        Event::emit_event(handle, DummyEvent{msg: 0});
+        Event::emit_event(handle2, DummyEvent{msg: 0});
+    }
+    spec fun multiple_different_handle {
+        emits DummyEvent{msg: 0} to handle;
+        emits DummyEvent{msg: 0} to handle2;
+    }
+
+
     // ------------------------------
     // conditional `emits` statements
     // ------------------------------
@@ -59,6 +109,75 @@ module TestEmits {
         }
     }
     spec fun conditional_missing_condition_incorrect {
+        emits DummyEvent{msg: 0} to handle;
+    }
+
+    public fun conditional_bool(b: bool, handle: &mut EventHandle<DummyEvent>) {
+        if (b) {
+            Event::emit_event(handle, DummyEvent{msg: 0});
+        }
+    }
+    spec fun conditional_bool {
+        emits DummyEvent{msg: 0} to handle if b;
+    }
+
+    public fun conditional_multiple(b0: bool, b1: bool, b2: bool, handle: &mut EventHandle<DummyEvent>) {
+        if (b0) {
+            Event::emit_event(handle, DummyEvent{msg: 0});
+        };
+        if (b1) {
+            Event::emit_event(handle, DummyEvent{msg: 1});
+        };
+        if (b2) {
+            Event::emit_event(handle, DummyEvent{msg: 2});
+        }
+    }
+    spec fun conditional_multiple {
+        emits DummyEvent{msg: 0} to handle if b0;
+        emits DummyEvent{msg: 1} to handle if b1;
+        emits DummyEvent{msg: 2} to handle if b2;
+    }
+
+    public fun conditional_multiple_incorrect(b: bool, handle: &mut EventHandle<DummyEvent>) {
+        Event::emit_event(handle, DummyEvent{msg: 0});
+        Event::emit_event(handle, DummyEvent{msg: 1});
+        if (b) {
+            Event::emit_event(handle, DummyEvent{msg: 2});
+        }
+    }
+    spec fun conditional_multiple_incorrect {
+        emits DummyEvent{msg: 0} to handle;
+        emits DummyEvent{msg: 1} to handle;
+        emits DummyEvent{msg: 2} to handle;
+    }
+
+    public fun conditional_multiple_same(b0: bool, b1: bool, b2: bool, handle: &mut EventHandle<DummyEvent>) {
+        if (b0) {
+            Event::emit_event(handle, DummyEvent{msg: 0});
+        };
+        if (b1) {
+            Event::emit_event(handle, DummyEvent{msg: 0});
+        };
+        if (b2) {
+            Event::emit_event(handle, DummyEvent{msg: 0});
+        }
+    }
+    spec fun conditional_multiple_same {
+        emits DummyEvent{msg: 0} to handle if b0;
+        emits DummyEvent{msg: 0} to handle if b1;
+        emits DummyEvent{msg: 0} to handle if b2;
+    }
+
+    public fun conditional_multiple_same_incorrect(b: bool, handle: &mut EventHandle<DummyEvent>) {
+        Event::emit_event(handle, DummyEvent{msg: 0});
+        Event::emit_event(handle, DummyEvent{msg: 0});
+        if (b) {
+            Event::emit_event(handle, DummyEvent{msg: 0});
+        }
+    }
+    spec fun conditional_multiple_same_incorrect {
+        emits DummyEvent{msg: 0} to handle;
+        emits DummyEvent{msg: 0} to handle;
         emits DummyEvent{msg: 0} to handle;
     }
 


### PR DESCRIPTION
- Newly modeled EventStore (in Prelude) using "multiset" rather than
  array (due to the limitation of array)

- Updated the spec translator according to the updated EventStore model, 
  and added a comment in `spec_translators.rs` to explain the idea behind
  the verification conditions to generate

- To `functional/emits.move`, added the test cases of emitting events
  with the same message multiple times, and checked that Prover can
  correctly handle these scenarios thanks to multiset.

## Motivation

To re-model the EventStore using multiset

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

cargo test