### PR TITLE
[move-prover] Fix bugs in flow analysis

### DIFF
--- a/language/move-prover/bytecode/src/borrow_analysis.rs
+++ b/language/move-prover/bytecode/src/borrow_analysis.rs
@@ -526,7 +526,7 @@ impl PropagateSplicedAnalysis {
     }
 
     fn run(self, instrs: &[Bytecode]) -> BTreeMap<CodeOffset, BorrowInfoAtCodeOffset> {
-        let cfg = StacklessControlFlowGraph::new_backward(instrs);
+        let cfg = StacklessControlFlowGraph::new_backward(instrs, false);
         let state_map = self.analyze_function(SplicedState::default(), instrs, &cfg);
         let mut data = self.state_per_instruction(state_map, instrs, &cfg, |before, after| {
             (before.clone(), after.clone())

--- a/language/move-prover/bytecode/src/compositional_analysis.rs
+++ b/language/move-prover/bytecode/src/compositional_analysis.rs
@@ -81,9 +81,13 @@ where
                 StacklessControlFlowGraph::new_forward(&data.code)
             };
             let instrs = &data.code;
-            let state_map = self.analyze_function(initial_state, instrs, &cfg);
-            let exit_state = state_map[&cfg.exit_block()].post.clone();
-            data.annotations.set(self.to_summary(exit_state))
+            let state_map = self.analyze_function(initial_state.clone(), instrs, &cfg);
+            if let Some(exit_state) = state_map.get(&cfg.exit_block()) {
+                data.annotations
+                    .set(self.to_summary(exit_state.post.clone()))
+            } else {
+                data.annotations.set(self.to_summary(initial_state))
+            }
         } else {
             // TODO: not clear that this is desired, but some clients rely on
             // every function having a summary, even natives

--- a/language/move-prover/bytecode/src/dataflow_analysis.rs
+++ b/language/move-prover/bytecode/src/dataflow_analysis.rs
@@ -190,15 +190,14 @@ pub trait DataflowAnalysis: TransferFunctions {
             },
         );
         while let Some(block_id) = work_list.pop_front() {
-            let pre = state_map.remove(&block_id).expect("basic block").pre;
-            let post = self.execute_block(block_id, pre.clone(), &instrs, cfg);
+            let pre = state_map.get(&block_id).expect("basic block").pre.clone();
+            let post = self.execute_block(block_id, pre, &instrs, cfg);
 
             // propagate postcondition of this block to successor blocks
             for next_block_id in cfg.successors(block_id) {
                 match state_map.get_mut(next_block_id) {
                     Some(next_block_res) => {
                         let join_result = next_block_res.pre.join(&post);
-
                         match join_result {
                             JoinResult::Unchanged => {
                                 // Pre is the same after join. Reanalyzing this block would produce
@@ -225,7 +224,7 @@ pub trait DataflowAnalysis: TransferFunctions {
                     }
                 }
             }
-            state_map.insert(block_id, BlockState { pre, post });
+            state_map.get_mut(&block_id).expect("basic block").post = post;
         }
         state_map
     }

--- a/language/move-prover/bytecode/src/livevar_analysis.rs
+++ b/language/move-prover/bytecode/src/livevar_analysis.rs
@@ -113,7 +113,9 @@ impl LiveVarAnalysisProcessor {
         func_target: &FunctionTarget,
         code: &[Bytecode],
     ) -> BTreeMap<CodeOffset, LiveVarInfoAtCodeOffset> {
-        let cfg = StacklessControlFlowGraph::new_backward(&code);
+        // Perform backward analysis from all blocks just in case some block
+        // cannot reach an exit block
+        let cfg = StacklessControlFlowGraph::new_backward(&code, true);
         let analyzer = LiveVarAnalysis::new(&func_target);
         let state_map = analyzer.analyze_function(
             LiveVarState {


### PR DESCRIPTION

## Motivation

This  PR has two contributions:
1. It fixes an infinite loop in dataflow analysis that manifests when there is a self-loop on a block.
2. Live variable analysis won't be able to create information for blocks that cannot reach some exit block.  Absence of this information can cause a crash downstream.  So this PR makes allows backward analysis to happen from all blocks and uses this feature in live variable analysis.

These problems were discovered by running move prover on move-lang/tests/move_check/typing/loop_body.move.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests

## Related PRs


