### PR TITLE
[network] Rename Network Role to Network Type

### DIFF
--- a/diem-node/src/lib.rs
+++ b/diem-node/src/lib.rs
@@ -5,7 +5,7 @@ use backup_service::start_backup_service;
 use consensus::{consensus_provider::start_consensus, gen_consensus_reconfig_subscription};
 use debug_interface::node_debug_service::NodeDebugService;
 use diem_config::{
-    config::{NetworkConfig, NodeConfig, RoleType},
+    config::{NetworkConfig, NodeConfig},
     network_id::NodeNetworkId,
     utils::get_genesis_txn,
 };
@@ -316,23 +316,22 @@ pub fn setup_environment(node_config: &NodeConfig, logger: Option<Arc<Logger>>) 
     }
 
     // Gather all network configs into a single vector.
-    // TODO:  consider explicitly encoding the role in the NetworkConfig
-    let mut network_configs: Vec<(RoleType, &NetworkConfig)> = node_config
-        .full_node_networks
-        .iter()
-        .map(|network_config| (RoleType::FullNode, network_config))
-        .collect();
+    let mut network_configs: Vec<&NetworkConfig> = node_config.full_node_networks.iter().collect();
     if let Some(network_config) = node_config.validator_network.as_ref() {
-        network_configs.push((RoleType::Validator, network_config));
+        network_configs.push(network_config);
     }
 
     let mut network_builders = Vec::new();
 
     // Instantiate every network and collect the requisite endpoints for state_sync, mempool, and consensus.
-    for (idx, (role, network_config)) in network_configs.into_iter().enumerate() {
+    for (idx, network_config) in network_configs.into_iter().enumerate() {
         // Perform common instantiation steps
-        let mut network_builder =
-            NetworkBuilder::create(chain_id, role, network_config, TimeService::real());
+        let mut network_builder = NetworkBuilder::create(
+            chain_id,
+            node_config.base.role,
+            network_config,
+            TimeService::real(),
+        );
         let network_id = network_config.network_id.clone();
 
         // Create the endpoints to connect the Network to State Sync.
@@ -349,27 +348,23 @@ pub fn setup_environment(node_config: &NodeConfig, logger: Option<Arc<Logger>>) 
             diem_mempool::network::network_endpoint_config(MEMPOOL_NETWORK_CHANNEL_BUFFER_SIZE),
         );
         mempool_network_handles.push((
-            NodeNetworkId::new(network_id, idx),
+            NodeNetworkId::new(network_id.clone(), idx),
             mempool_sender,
             mempool_events,
         ));
 
-        match role {
-            // Perform steps relevant specifically to Validator networks.
-            RoleType::Validator => {
-                // A valid config is allowed to have at most one ValidatorNetwork
-                // TODO:  `expect_none` would be perfect here, once it is stable.
-                if consensus_network_handles.is_some() {
-                    panic!("There can be at most one validator network!");
-                }
-
-                consensus_network_handles =
-                    Some(network_builder.add_protocol_handler(
-                        consensus::network_interface::network_endpoint_config(),
-                    ));
+        // Perform steps relevant specifically to Validator networks.
+        if network_id.is_validator_network() {
+            // A valid config is allowed to have at most one ValidatorNetwork
+            // TODO:  `expect_none` would be perfect here, once it is stable.
+            if consensus_network_handles.is_some() {
+                panic!("There can be at most one validator network!");
             }
-            // Currently no FullNode network specific steps.
-            RoleType::FullNode => (),
+
+            consensus_network_handles = Some(
+                network_builder
+                    .add_protocol_handler(consensus::network_interface::network_endpoint_config()),
+            );
         }
 
         reconfig_subscriptions.append(network_builder.reconfig_subscriptions());
@@ -382,11 +377,7 @@ pub fn setup_environment(node_config: &NodeConfig, logger: Option<Arc<Logger>>) 
         let network_context = network_builder.network_context();
         debug!("Creating runtime for {}", network_context);
         let runtime = Builder::new_multi_thread()
-            .thread_name(format!(
-                "network-{}-{}",
-                network_context.role(),
-                network_context.network_id()
-            ))
+            .thread_name(format!("network-{}", network_context.network_id()))
             .enable_all()
             .build()
             .expect("Failed to start runtime. Won't be able to start networking.");

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -179,8 +179,8 @@ impl NetworkBuilder {
         };
 
         let network_context = Arc::new(NetworkContext::new(
-            config.network_id.clone(),
             role,
+            config.network_id.clone(),
             peer_id,
         ));
 
@@ -340,7 +340,8 @@ impl NetworkBuilder {
         channel_size: usize,
     ) -> &mut Self {
         let pm_conn_mgr_notifs_rx = self.add_connection_event_listener();
-        let outbound_connection_limit = if let RoleType::FullNode = self.network_context.role() {
+        let outbound_connection_limit = if !self.network_context.network_id().is_validator_network()
+        {
             Some(max_outbound_connections)
         } else {
             None

--- a/network/builder/src/dummy.rs
+++ b/network/builder/src/dummy.rs
@@ -111,6 +111,7 @@ pub struct DummyNetwork {
 /// The following sets up a 2 peer network and verifies connectivity.
 pub fn setup_network() -> DummyNetwork {
     let runtime = Runtime::new().unwrap();
+    let role = RoleType::Validator;
     let network_id = NetworkId::Validator;
     let chain_id = ChainId::default();
     let dialer_peer_id = PeerId::random();
@@ -141,8 +142,8 @@ pub fn setup_network() -> DummyNetwork {
 
     // Set up the listener network
     let network_context = Arc::new(NetworkContext::new(
+        role,
         network_id.clone(),
-        RoleType::Validator,
         listener_peer_id,
     ));
     let mut network_builder = NetworkBuilder::new_for_test(
@@ -169,11 +170,7 @@ pub fn setup_network() -> DummyNetwork {
     let authentication_mode = AuthenticationMode::Mutual(dialer_identity_private_key);
 
     // Set up the dialer network
-    let network_context = Arc::new(NetworkContext::new(
-        network_id,
-        RoleType::Validator,
-        dialer_peer_id,
-    ));
+    let network_context = Arc::new(NetworkContext::new(role, network_id, dialer_peer_id));
 
     let trusted_peers = Arc::new(RwLock::new(HashMap::new()));
 

--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -60,7 +60,7 @@ pub static DIEM_NETWORK_PEER_CONNECTED: Lazy<IntGaugeVec> = Lazy::new(|| {
 });
 
 pub fn peer_connected(network_context: &NetworkContext, remote_peer_id: &PeerId, v: i64) {
-    if network_context.role().is_validator() {
+    if network_context.network_id().is_validator_network() {
         DIEM_NETWORK_PEER_CONNECTED
             .with_label_values(&[
                 network_context.role().as_str(),

--- a/network/src/noise/mod.rs
+++ b/network/src/noise/mod.rs
@@ -43,16 +43,16 @@
 //!
 //! let client_auth = HandshakeAuthMode::mutual(trusted_peers.clone());
 //! let client_context = Arc::new(NetworkContext::new(
-//!     NetworkId::Validator,
 //!     RoleType::Validator,
+//!     NetworkId::Validator,
 //!     client_peer_id,
 //! ));
 //! let client = NoiseUpgrader::new(client_context, client_private, client_auth);
 //!
 //! let server_auth = HandshakeAuthMode::mutual(trusted_peers);
 //! let server_context = Arc::new(NetworkContext::new(
-//!     NetworkId::Validator,
 //!     RoleType::Validator,
+//!     NetworkId::Validator,
 //!     server_peer_id,
 //! ));
 //! let server = NoiseUpgrader::new(server_context, server_private, server_auth);

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -379,10 +379,10 @@ where
             .filter(|(_, (metadata, _))| metadata.origin == ConnectionOrigin::Inbound)
             .count();
         let outbound = total.saturating_sub(inbound);
-        let role = self.network_context.role().as_str();
 
+        // TODO: Work with PEs to update this to be a `NetworkId` rather than `RoleType`
         counters::DIEM_NETWORK_PEERS
-            .with_label_values(&[role, "connected"])
+            .with_label_values(&[self.network_context.role().as_str(), "connected"])
             .set(total as i64);
 
         counters::connections(&self.network_context, ConnectionOrigin::Inbound).set(inbound as i64);

--- a/state-sync/tests/test_harness.rs
+++ b/state-sync/tests/test_harness.rs
@@ -374,8 +374,8 @@ impl StateSyncEnvironment {
             let peer = self.peers[index].borrow();
             let auth_mode = AuthenticationMode::Mutual(peer.network_key.clone());
             let network_context = Arc::new(NetworkContext::new(
+                *role,
                 VALIDATOR_NETWORK.clone(),
-                RoleType::Validator,
                 peer.peer_id,
             ));
 


### PR DESCRIPTION
RoleType usage in Network was so confusing, as it represented the type of network (Validator vs FullNode), which was kinda silly when it was one network Id vs all other network Ids.  This change replaces RoleType with NetworkType for appropriate usages, and puts the actual RoleType of the Node into the NetworkContext for logging and metrics purposes.