### PR TITLE
[x] move default-members to subsets.production

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,45 +153,6 @@ members = [
     "vm-validator",
 ]
 
-# NOTE: default-members is the complete list of binaries that form the "production Diem codebase". These members should
-# never include crates that require fuzzing features or test features. These are the crates we want built with no extra
-# test-only code included.
-#
-# For more, see the "Conditional compilation for tests" section in documentation/coding_guidelines.md.
-default-members = [
-    "common/trace",
-    "common/rate-limiter",
-    "config/generate-key",
-    "config/management/genesis",
-    "config/management/operational",
-    "config/seed-peer-generator",
-    "consensus/safety-rules",
-    "client/faucet",
-    "client/swiss-knife",
-    "execution/db-bootstrapper",
-    "execution/execution-correctness",
-    "language/compiler",
-    "language/diem-framework",
-    "language/move-prover",
-    "language/move-prover/diagen",
-    "language/move-lang",
-    "language/tools/disassembler",
-    "language/tools/move-bytecode-viewer",
-    "language/tools/genesis-viewer",
-    "language/tools/move-cli",
-    "language/tools/move-coverage",
-    "language/diem-tools/diem-events-fetcher",
-    "language/diem-tools/transaction-replay",
-    "language/diem-tools/writeset-transaction-generator",
-    "language/tools/move-explain",
-    "language/transaction-builder/generator",
-    "diem-node",
-    "secure/key-manager",
-    "storage/backup/backup-cli",
-    "storage/diemsum",
-    "storage/inspector",
-]
-
 [profile.release]
 debug = true
 

--- a/devtools/x-core/src/graph.rs
+++ b/devtools/x-core/src/graph.rs
@@ -31,7 +31,7 @@ impl PackageGraphPlus {
                 cmd.build_graph()
                     .map_err(|err| SystemError::guppy("building package graph", err))?,
             ),
-            move |graph| WorkspaceSubsets::new(graph, project_root, &ctx.config().subsets),
+            move |graph| WorkspaceSubsets::new(graph, &ctx.config().subsets),
         )
     }
 }

--- a/devtools/x-lint/src/package.rs
+++ b/devtools/x-lint/src/package.rs
@@ -24,7 +24,7 @@ pub struct PackageContext<'l> {
     package_graph: &'l PackageGraph,
     workspace_path: &'l Path,
     metadata: PackageMetadata<'l>,
-    is_default_member: bool,
+    is_production: bool,
 }
 
 impl<'l> PackageContext<'l> {
@@ -34,13 +34,13 @@ impl<'l> PackageContext<'l> {
         workspace_path: &'l Path,
         metadata: PackageMetadata<'l>,
     ) -> Result<Self> {
-        let default_members = project_ctx.default_members()?;
+        let production_members = project_ctx.production_members()?;
         Ok(Self {
             project_ctx,
             package_graph,
             workspace_path,
             metadata,
-            is_default_member: default_members.status_of(metadata.id()) != WorkspaceStatus::Absent,
+            is_production: production_members.status_of(metadata.id()) != WorkspaceStatus::Absent,
         })
     }
 
@@ -64,9 +64,9 @@ impl<'l> PackageContext<'l> {
         &self.metadata
     }
 
-    /// Returns true if this is a default member of this workspace.
-    pub fn is_default_member(&self) -> bool {
-        self.is_default_member
+    /// Returns true if this is a production member of this workspace.
+    pub fn is_production(&self) -> bool {
+        self.is_production
     }
 }
 

--- a/devtools/x-lint/src/project.rs
+++ b/devtools/x-lint/src/project.rs
@@ -53,12 +53,12 @@ impl<'l> ProjectContext<'l> {
         self.core.project_root().join(path.as_ref())
     }
 
-    /// Returns information about the default workspace members.
+    /// Returns information about the production workspace members.
     ///
-    /// This includes all packages included by default in the default workspace members, but not
-    /// those that Cargo would ignore.
-    pub fn default_members(&self) -> Result<&WorkspaceSubset> {
-        Ok(self.core.subsets()?.default_members())
+    /// This includes all dependencies built with default features, but not those that Cargo
+    /// would ignore.
+    pub fn production_members(&self) -> Result<&WorkspaceSubset> {
+        Ok(self.core.subsets()?.production())
     }
 
     /// Returns Hakari information.

--- a/devtools/x/src/cargo/selected_package.rs
+++ b/devtools/x/src/cargo/selected_package.rs
@@ -144,9 +144,8 @@ impl<'a> SelectedInclude<'a> {
             let subsets = xctx.core().subsets()?;
 
             let name = name.as_ref();
-            // TODO: turn this into a subset in x.toml
             let subset = if name == "production" {
-                subsets.default_members()
+                subsets.production()
             } else {
                 subsets.get(name).ok_or_else(|| {
                     let known_subsets: Vec<_> = subsets.iter().map(|(name, _)| name).collect();

--- a/devtools/x/src/generate_summaries.rs
+++ b/devtools/x/src/generate_summaries.rs
@@ -50,16 +50,14 @@ pub fn run(args: Args, xctx: XContext) -> crate::Result<()> {
 
     fs::create_dir_all(&out_dir)?;
 
-    // TODO: figure out a way to unify this with WorkspaceSubset.
-
     // Create summaries for:
 
     let mut summary_count = 0;
 
-    // * default members (default features)
-    // (note that we aren't using the build set from default_members() as it may have different
+    // * production (default features)
+    // (note that we aren't using the existing build set in WorkspaceSubset as it may have different
     // options)
-    let initials = subsets.default_members().initials().clone();
+    let initials = subsets.production().initials().clone();
     write_summary(
         "default",
         initials,

--- a/devtools/x/src/lint/guppy.rs
+++ b/devtools/x/src/lint/guppy.rs
@@ -67,11 +67,11 @@ impl<'cfg> ProjectLinter for BannedDeps<'cfg> {
             }
         }
 
-        let default_members = ctx.default_members()?;
+        let production_members = ctx.production_members()?;
 
         let banned_default_build = &self.config.default_build;
         for (package, message) in filter_ban(banned_default_build) {
-            if default_members.status_of(package.id()) != WorkspaceStatus::Absent {
+            if production_members.status_of(package.id()) != WorkspaceStatus::Absent {
                 out.write(
                     LintLevel::Error,
                     format!(
@@ -325,7 +325,7 @@ impl<'cfg> PackageLinter for OverlayFeatures<'cfg> {
         out: &mut LintFormatter<'l, '_>,
     ) -> Result<RunStatus<'l>> {
         let package = ctx.metadata();
-        if !ctx.is_default_member() {
+        if !ctx.is_production() {
             return Ok(RunStatus::Skipped(SkipReason::UnsupportedPackage(
                 package.id(),
             )));

--- a/devtools/x/src/lint/workspace_classify.rs
+++ b/devtools/x/src/lint/workspace_classify.rs
@@ -35,7 +35,7 @@ impl<'cfg> PackageLinter for DefaultOrTestOnly<'cfg> {
         ctx: &PackageContext<'l>,
         out: &mut LintFormatter<'l, '_>,
     ) -> Result<RunStatus<'l>> {
-        let default_members = ctx.project_ctx().default_members()?;
+        let default_members = ctx.project_ctx().production_members()?;
         let package = ctx.metadata();
 
         let binary_kind = package
@@ -112,9 +112,9 @@ impl<'cfg> PackageLinter for DefaultOrTestOnly<'cfg> {
                 let msg = format!(
                     "{} {}",
                     indoc!(
-                        "library package, dependency of default members and test-only:
+                        "library package, dependency of x.toml's subsets.production and test-only:
                         * remove from test-only if production code
-                        * otherwise, ensure it is not a dependency of default members:",
+                        * otherwise, ensure it is not a dependency of subsets.production in x.toml:",
                     ),
                     reverse_str,
                 );
@@ -123,18 +123,18 @@ impl<'cfg> PackageLinter for DefaultOrTestOnly<'cfg> {
             (None, WorkspaceStatus::RootMember, false) => {
                 // Library, listed in default members. It shouldn't be.
                 let msg = indoc!(
-                    "library package, listed in default-members:
+                    "library package, listed in x.toml's subsets.production:
                      * if test-only, add to test-only in x.toml instead
-                     * otherwise, remove it from default-members and make it a dependency of a binary"
+                     * otherwise, remove it from subsets.production and make it a dependency of a binary"
                 );
                 out.write(LintLevel::Error, msg);
             }
             (None, WorkspaceStatus::RootMember, true) => {
                 // Library, listed in default members and in test-only. It shouldn't be.
                 let msg = indoc!(
-                    "library package, listed in default-members and test-only:
-                     * if test-only, add to test-only in x.toml and remove from default-members
-                     * otherwise, remove it from both and make it a dependency of a default-member"
+                    "library package, listed in x.toml's subsets.production and test-only:
+                     * if test-only, add to test-only in x.toml and remove from subsets.production
+                     * otherwise, remove it from both and make it a dependency of subsets.production"
                 );
                 out.write(LintLevel::Error, msg);
             }
@@ -144,9 +144,9 @@ impl<'cfg> PackageLinter for DefaultOrTestOnly<'cfg> {
                     "{} {}",
                     kind,
                     indoc!(
-                        "package, not listed in default-members:
+                        "package, not listed in x.toml's subsets.production:
                          * if test-only, add to test-only in x.toml
-                         * otherwise, list it in root Cargo.toml's default-members"
+                         * otherwise, list it in x.toml's subsets.production"
                     ),
                 );
                 out.write(LintLevel::Error, msg);
@@ -160,9 +160,9 @@ impl<'cfg> PackageLinter for DefaultOrTestOnly<'cfg> {
                     "{} {}",
                     kind,
                     indoc!(
-                        "package, not listed in default-members:
-                         * list it in root Cargo.toml's default-members
-                         (note: dependency of a default member, so assumed to be a production crate)"
+                        "package, not listed in x.toml's subsets.production:
+                         * list it in x.toml's subsets.production
+                         (note: dependency of subsets.production, so assumed to be a production crate)"
                     ),
                 );
                 out.write(LintLevel::Error, msg)
@@ -173,9 +173,9 @@ impl<'cfg> PackageLinter for DefaultOrTestOnly<'cfg> {
                     "{} {}",
                     kind,
                     indoc!(
-                        "package, not listed in default-members but a dependency, and in test-only:
+                        "package, a dependency of x.toml's subsets.production, and listed in test-only:
                          * remove it from test-only in x.toml, AND
-                         * list it in root Cargo.toml's default-members
+                         * list it in x.toml's subsets.production
                          (note: dependency of a default member, so assumed to be a production crate)"
                     ),
                 );
@@ -190,9 +190,9 @@ impl<'cfg> PackageLinter for DefaultOrTestOnly<'cfg> {
                     "{} {}",
                     kind,
                     indoc!(
-                        "package, listed in both default-members and test-only:
+                        "package, listed in both x.toml's subsets.production and test-only:
                          * remove it from test-only in x.toml
-                         (note: default member, so assumed to be a production crate)"
+                         (note: listed in subsets.production, so assumed to be a production crate)"
                     ),
                 );
                 out.write(LintLevel::Error, msg)

--- a/documentation/coding_guidelines.md
+++ b/documentation/coding_guidelines.md
@@ -317,7 +317,7 @@ As a consequence, it is recommended that you set up your test-only code in the f
 **For production crates:**
 
 Production crates are defined as the set of crates that create externally published artifacts, e.g. the Diem validator,
-the Move compiler, and so on.
+the Move compiler, and so on. Binary production crates are listed in `x.toml`'s `subsets.production`.
 
 For the sake of example, we'll consider you are defining a test-only helper function `foo` in `foo_crate`:
 

--- a/x.toml
+++ b/x.toml
@@ -147,16 +147,15 @@ features = ["fuzzing"]
 # *** IMPORTANT ***
 #
 # Published developer tools (e.g. Move compiler) ARE part of the production Diem codebase.
-# They should be listed in the root Cargo.toml's default-members, not here!
+# They should be listed in subsets.production, not here!
 #
 # Before adding a new crate to this list, ensure that it is *actually* test-only. If not, add it
-# (or a crate that depends on it) to the root Cargo.toml's default-members list!
+# (or a crate that depends on it) to subsets.production.
 #
 # For more, see the "Conditional compilation for tests" section in documentation/coding_guidelines.md.
 [workspace.test-only]
 members = [
     # Please keep this list in alphabetical order!
-
     "bytecode-verifier-tests",
     "cli",
     "cluster-test",
@@ -183,6 +182,7 @@ members = [
     "many-keys-stress-test",
     "memsocket",
     "module-generation",
+    "move-bytecode-viewer",
     "move-lang-functional-tests",
     "move-lang-ir-utils",
     "move-lang-test-utils",
@@ -201,6 +201,47 @@ members = [
 
 # Interesting subsets of the workspace, These are used for generating and
 # checking dependency summaries.
+
+[subsets.production]
+# The full list of binaries that form the "production Diem codebase". These should never include crates
+# that require fuzzing or test features: it is asserted that workspace.test-only and the non-dev dependencies
+# of this subset are disjoint.
+root-members = [
+    # Please keep this list in alphabetical order!
+
+    "backup-cli",
+    "compiler",
+    "db-bootstrapper",
+    "diagen",
+    "diem-events-fetcher",
+    "diem-faucet",
+    "diem-framework",
+    "diem-genesis-tool",
+    "diem-key-manager",
+    "diem-node",
+    "diem-operational-tool",
+    "diem-rate-limiter",
+    "diem-storage-inspector",
+    "diem-trace",
+    "diem-transaction-replay",
+    "diem-writeset-generator",
+    "diemsum",
+    "disassembler",
+    "execution-correctness",
+    "generate-key",
+    "genesis-viewer",
+    "move-cli",
+    "move-coverage",
+    "move-explain",
+    "move-lang",
+    "move-prover",
+    "safety-rules",
+    "seed-peer-generator",
+    "swiss-knife",
+    "transaction-builder-generator",
+
+    # Please keep this list in alphabetical order!
+]
 
 [subsets.lsr]
 # The Diem safety rules TCB.


### PR DESCRIPTION
Back when we used to use "cargo build" having the default members
defined in Cargo.toml made sense, but now "cargo xbuild" is the
canonical way to run the build. "cargo xbuild" never actually uses the
default members since it always passes in "--workspace". As such, having
a "default-members" that's not actually used is confusing.

There aren't any public interface changes: to do a production build you
can run `cargo xbuild --members production` as before.