### PR TITLE
Various move-lang bug fixes

### DIFF
--- a/language/move-lang/functional-tests/tests/move/evaluation_order/short_circuiting.move
+++ b/language/move-lang/functional-tests/tests/move/evaluation_order/short_circuiting.move
@@ -20,5 +20,7 @@ fun main() {
     vfalse && X::error();
     vfalse && { let r = X::error(); r };
     { let x = vfalse; x} && X::error();
+    true || { abort 0 };
+    { true } || (abort 0);
 }
 }

--- a/language/move-lang/functional-tests/tests/move/evaluation_order/short_circuiting_invalid.move
+++ b/language/move-lang/functional-tests/tests/move/evaluation_order/short_circuiting_invalid.move
@@ -47,3 +47,13 @@ fun main() {
 // TODO(status_migration) remove duplicate check
 // check:"ABORTED { code: 42,"
 // check:"ABORTED { code: 42,"
+
+//! new-transaction
+script {
+fun main() {
+    false || { abort 0 };
+}
+}
+// TODO(status_migration) remove duplicate check
+// check:"ABORTED { code: 0,"
+// check:"ABORTED { code: 0,"

--- a/language/move-lang/src/cfgir/borrows/mod.rs
+++ b/language/move-lang/src/cfgir/borrows/mod.rs
@@ -121,7 +121,7 @@ fn command(context: &mut Context, sp!(loc, cmd_): &Command) {
             context.borrow_state.release_values(values);
         }
 
-        C::Return(e) => {
+        C::Return { exp: e, .. } => {
             let values = exp(context, e);
             let errors = context.borrow_state.return_(*loc, values);
             context.add_errors(errors);
@@ -131,7 +131,7 @@ fn command(context: &mut Context, sp!(loc, cmd_): &Command) {
             assert!(!value.is_ref());
             context.borrow_state.abort()
         }
-        C::Jump(_) => (),
+        C::Jump { .. } => (),
         C::Break | C::Continue => panic!("ICE break/continue not translated to jumps"),
     }
 }

--- a/language/move-lang/src/cfgir/borrows/mod.rs
+++ b/language/move-lang/src/cfgir/borrows/mod.rs
@@ -253,11 +253,12 @@ fn exp(context: &mut Context, parent_e: &Exp) -> Values {
         E::BinopExp(e1, sp!(_, BinOp_::Eq), e2) | E::BinopExp(e1, sp!(_, BinOp_::Neq), e2) => {
             let v1 = assert_single_value(exp(context, e1));
             let v2 = assert_single_value(exp(context, e2));
+            // must check separately incase of using a local with an unassigned value
             if v1.is_ref() {
-                // derefrence releases the id and checks that it is readable
-                assert!(v2.is_ref());
                 let (errors, _) = context.borrow_state.dereference(e1.exp.loc, v1);
                 assert!(errors.is_empty(), "ICE eq freezing failed");
+            }
+            if v2.is_ref() {
                 let (errors, _) = context.borrow_state.dereference(e1.exp.loc, v2);
                 assert!(errors.is_empty(), "ICE eq freezing failed");
             }

--- a/language/move-lang/src/cfgir/constant_fold.rs
+++ b/language/move-lang/src/cfgir/constant_fold.rs
@@ -36,11 +36,12 @@ fn optimize_cmd(sp!(_, cmd_): &mut Command) -> bool {
             let c2 = optimize_exp(el);
             c1 || c2
         }
-        C::Return(e) | C::Abort(e) | C::IgnoreAndPop { exp: e, .. } | C::JumpIf { cond: e, .. } => {
-            optimize_exp(e)
-        }
+        C::Return { exp: e, .. }
+        | C::Abort(e)
+        | C::IgnoreAndPop { exp: e, .. }
+        | C::JumpIf { cond: e, .. } => optimize_exp(e),
 
-        C::Jump(_) => false,
+        C::Jump { .. } => false,
         C::Break | C::Continue => panic!("ICE break/continue not translated to jumps"),
     }
 }

--- a/language/move-lang/src/cfgir/eliminate_locals.rs
+++ b/language/move-lang/src/cfgir/eliminate_locals.rs
@@ -112,12 +112,12 @@ mod count {
                 exp(context, er);
                 exp(context, el)
             }
-            C::Return(e)
+            C::Return { exp: e, .. }
             | C::Abort(e)
             | C::IgnoreAndPop { exp: e, .. }
             | C::JumpIf { cond: e, .. } => exp(context, e),
 
-            C::Jump(_) => (),
+            C::Jump { .. } => (),
             C::Break | C::Continue => panic!("ICE break/continue not translated to jumps"),
         }
     }
@@ -300,12 +300,12 @@ mod eliminate {
                 exp(context, er);
                 exp(context, el)
             }
-            C::Return(e)
+            C::Return { exp: e, .. }
             | C::Abort(e)
             | C::IgnoreAndPop { exp: e, .. }
             | C::JumpIf { cond: e, .. } => exp(context, e),
 
-            C::Jump(_) => (),
+            C::Jump { .. } => (),
             C::Break | C::Continue => panic!("ICE break/continue not translated to jumps"),
         }
     }
@@ -448,7 +448,12 @@ mod eliminate {
     fn unit(loc: Loc) -> Exp {
         H::exp(
             sp(loc, Type_::Unit),
-            sp(loc, UnannotatedExp_::Unit { trailing: false }),
+            sp(
+                loc,
+                UnannotatedExp_::Unit {
+                    case: UnitCase::Implicit,
+                },
+            ),
         )
     }
 }

--- a/language/move-lang/src/cfgir/inline_blocks.rs
+++ b/language/move-lang/src/cfgir/inline_blocks.rs
@@ -39,7 +39,7 @@ fn find_single_target_labels(start: Label, blocks: &BasicBlocks) -> BTreeSet<Lab
                 *counts.entry(*if_true).or_insert(0) += 1;
                 *counts.entry(*if_false).or_insert(0) += 1
             }
-            C::Jump(lbl) => *counts.entry(*lbl).or_insert(0) += 1,
+            C::Jump { target, .. } => *counts.entry(*target).or_insert(0) += 1,
             _ => (),
         }
     }
@@ -78,7 +78,7 @@ fn inline_single_target_blocks(
             // Do not need to worry about infinitely unwrapping loops as loop heads will always
             // be the target of at least 2 jumps: the jump to the loop and the "continue" jump
             // This is always true as long as we start the count for the start label at 1
-            sp!(_, Command_::Jump(target)) if single_jump_targets.contains(target) => {
+            sp!(_, Command_::Jump { target, .. }) if single_jump_targets.contains(target) => {
                 remapping.insert(cur, *target);
                 let target_block = working_blocks.remove(target).unwrap();
                 block.pop_back();

--- a/language/move-lang/src/cfgir/liveness/mod.rs
+++ b/language/move-lang/src/cfgir/liveness/mod.rs
@@ -91,11 +91,12 @@ fn command(state: &mut LivenessState, sp!(_, cmd_): &Command) {
             exp(state, er);
             exp(state, el)
         }
-        C::Return(e) | C::Abort(e) | C::IgnoreAndPop { exp: e, .. } | C::JumpIf { cond: e, .. } => {
-            exp(state, e)
-        }
+        C::Return { exp: e, .. }
+        | C::Abort(e)
+        | C::IgnoreAndPop { exp: e, .. }
+        | C::JumpIf { cond: e, .. } => exp(state, e),
 
-        C::Jump(_) => (),
+        C::Jump { .. } => (),
         C::Break | C::Continue => panic!("ICE break/continue not translated to jumps"),
     }
 }
@@ -270,12 +271,12 @@ mod last_usage {
                 exp(context, el);
                 exp(context, er)
             }
-            C::Return(e)
+            C::Return { exp: e, .. }
             | C::Abort(e)
             | C::IgnoreAndPop { exp: e, .. }
             | C::JumpIf { cond: e, .. } => exp(context, e),
 
-            C::Jump(_) => (),
+            C::Jump { .. } => (),
             C::Break | C::Continue => panic!("ICE break/continue not translated to jumps"),
         }
     }

--- a/language/move-lang/src/cfgir/locals/mod.rs
+++ b/language/move-lang/src/cfgir/locals/mod.rs
@@ -125,7 +125,7 @@ fn command(context: &mut Context, sp!(loc, cmd_): &Command) {
         }
         C::Abort(e) | C::IgnoreAndPop { exp: e, .. } | C::JumpIf { cond: e, .. } => exp(context, e),
 
-        C::Return(e) => {
+        C::Return { exp: e, .. } => {
             exp(context, e);
             let mut errors = Errors::new();
             for (local, state) in context.local_states.iter() {
@@ -169,7 +169,7 @@ fn command(context: &mut Context, sp!(loc, cmd_): &Command) {
             }
             errors.into_iter().for_each(|error| context.error(error))
         }
-        C::Jump(_) => (),
+        C::Jump { .. } => (),
         C::Break | C::Continue => panic!("ICE break/continue not translated to jumps"),
     }
 }

--- a/language/move-lang/src/cfgir/mod.rs
+++ b/language/move-lang/src/cfgir/mod.rs
@@ -32,8 +32,6 @@ pub fn refine_inference_and_verify(
     cfg: &mut BlockCFG,
     infinite_loop_starts: &BTreeSet<Label>,
 ) {
-    remove_no_ops::optimize(cfg);
-
     liveness::last_usage(errors, locals, cfg, infinite_loop_starts);
     let locals_states = locals::verify(errors, signature, acquires, locals, cfg);
 

--- a/language/move-lang/src/cfgir/simplify_jumps.rs
+++ b/language/move-lang/src/cfgir/simplify_jumps.rs
@@ -36,7 +36,10 @@ fn optimize_cmd(sp!(_, cmd_): &mut Command) -> bool {
             if_false,
         } => {
             let lbl = if *cond { *if_true } else { *if_false };
-            *cmd_ = C::Jump(lbl);
+            *cmd_ = C::Jump {
+                target: lbl,
+                from_user: false,
+            };
             true
         }
         _ => false,

--- a/language/move-lang/src/hlir/ast.rs
+++ b/language/move-lang/src/hlir/ast.rs
@@ -165,7 +165,6 @@ pub enum Statement_ {
     Loop {
         block: Block,
         has_break: bool,
-        has_return_abort: bool,
     },
 }
 pub type Statement = Spanned<Statement_>;
@@ -189,14 +188,20 @@ pub enum Command_ {
     Assign(Vec<LValue>, Box<Exp>),
     Mutate(Box<Exp>, Box<Exp>),
     Abort(Exp),
-    Return(Exp),
+    Return {
+        from_user: bool,
+        exp: Exp,
+    },
     Break,
     Continue,
     IgnoreAndPop {
         pop_num: usize,
         exp: Exp,
     },
-    Jump(Label),
+    Jump {
+        from_user: bool,
+        target: Label,
+    },
     JumpIf {
         cond: Exp,
         if_true: Label,
@@ -216,6 +221,13 @@ pub type LValue = Spanned<LValue_>;
 //**************************************************************************************************
 // Expressions
 //**************************************************************************************************
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum UnitCase {
+    Trailing,
+    Implicit,
+    FromUser,
+}
 
 #[derive(Debug, PartialEq)]
 pub struct ModuleCall {
@@ -237,7 +249,7 @@ pub type BuiltinFunction = Spanned<BuiltinFunction_>;
 
 #[derive(Debug, PartialEq)]
 pub enum UnannotatedExp_ {
-    Unit { trailing: bool },
+    Unit { case: UnitCase },
     Value(Value),
     Move { from_user: bool, var: Var },
     Copy { from_user: bool, var: Var },
@@ -299,7 +311,7 @@ impl Command_ {
         match self {
             Break | Continue => panic!("ICE break/continue not translated to jumps"),
             Assign(_, _) | Mutate(_, _) | IgnoreAndPop { .. } => false,
-            Abort(_) | Return(_) | Jump(_) | JumpIf { .. } => true,
+            Abort(_) | Return { .. } | Jump { .. } | JumpIf { .. } => true,
         }
     }
 
@@ -307,8 +319,10 @@ impl Command_ {
         use Command_::*;
         match self {
             Break | Continue => panic!("ICE break/continue not translated to jumps"),
-            Assign(_, _) | Mutate(_, _) | IgnoreAndPop { .. } | Jump(_) | JumpIf { .. } => false,
-            Abort(_) | Return(_) => true,
+            Assign(_, _) | Mutate(_, _) | IgnoreAndPop { .. } | Jump { .. } | JumpIf { .. } => {
+                false
+            }
+            Abort(_) | Return { .. } => true,
         }
     }
 
@@ -319,7 +333,7 @@ impl Command_ {
             Assign(ls, e) => ls.is_empty() && e.is_unit(),
             IgnoreAndPop { exp: e, .. } => e.is_unit(),
 
-            Mutate(_, _) | Return(_) | Abort(_) | JumpIf { .. } | Jump(_) => false,
+            Mutate(_, _) | Return { .. } | Abort(_) | JumpIf { .. } | Jump { .. } => false,
         }
     }
 
@@ -332,9 +346,9 @@ impl Command_ {
             Mutate(_, _) | Assign(_, _) | IgnoreAndPop { .. } => {
                 panic!("ICE Should not be last command in block")
             }
-            Abort(_) | Return(_) => (),
-            Jump(lbl) => {
-                successors.insert(*lbl);
+            Abort(_) | Return { .. } => (),
+            Jump { target, .. } => {
+                successors.insert(*target);
             }
             JumpIf {
                 if_true, if_false, ..
@@ -355,12 +369,7 @@ impl Exp {
 
 impl UnannotatedExp_ {
     pub fn is_unit(&self) -> bool {
-        matches!(
-            self,
-            UnannotatedExp_::Unit {
-                trailing: _trailing,
-            }
-        )
+        matches!(self, UnannotatedExp_::Unit { case: _case })
     }
 }
 
@@ -823,17 +832,10 @@ impl AstDebug for Statement_ {
                 w.write(")");
                 w.block(|w| block.ast_debug(w))
             }
-            S::Loop {
-                block,
-                has_break,
-                has_return_abort,
-            } => {
+            S::Loop { block, has_break } => {
                 w.write("loop");
                 if *has_break {
                     w.write("#has_break");
-                }
-                if *has_return_abort {
-                    w.write("#has_return_abort");
                 }
                 w.write(" ");
                 w.block(|w| block.ast_debug(w))
@@ -861,7 +863,11 @@ impl AstDebug for Command_ {
                 w.write("abort ");
                 e.ast_debug(w);
             }
-            C::Return(e) => {
+            C::Return { exp: e, from_user } if *from_user => {
+                w.write("return@");
+                e.ast_debug(w);
+            }
+            C::Return { exp: e, .. } => {
                 w.write("return ");
                 e.ast_debug(w);
             }
@@ -873,7 +879,8 @@ impl AstDebug for Command_ {
                 w.write(" = ");
                 exp.ast_debug(w);
             }
-            C::Jump(lbl) => w.write(&format!("jump {}", lbl.0)),
+            C::Jump { target, from_user } if *from_user => w.write(&format!("jump@{}", target.0)),
+            C::Jump { target, .. } => w.write(&format!("jump {}", target.0)),
             C::JumpIf {
                 cond,
                 if_true,
@@ -898,10 +905,15 @@ impl AstDebug for UnannotatedExp_ {
     fn ast_debug(&self, w: &mut AstWriter) {
         use UnannotatedExp_ as E;
         match self {
-            E::Unit { trailing } if !trailing => w.write("()"),
             E::Unit {
-                trailing: _trailing,
+                case: UnitCase::FromUser,
+            } => w.write("()"),
+            E::Unit {
+                case: UnitCase::Implicit,
             } => w.write("/*()*/"),
+            E::Unit {
+                case: UnitCase::Trailing,
+            } => w.write("/*;()*/"),
             E::Value(v) => v.ast_debug(w),
             E::Move {
                 from_user: false,

--- a/language/move-lang/src/hlir/translate.rs
+++ b/language/move-lang/src/hlir/translate.rs
@@ -1572,7 +1572,7 @@ fn bind_for_short_circuit(e: &T::Exp) -> bool {
 fn bind_for_short_circuit_sequence(seq: &T::Sequence) -> bool {
     use T::SequenceItem_ as TItem;
     seq.len() != 1
-        || match &seq[1].value {
+        || match &seq[0].value {
             TItem::Seq(e) => bind_for_short_circuit(e),
             item @ TItem::Declare(_) | item @ TItem::Bind(_, _, _) => {
                 panic!("ICE unexpected item in short circuit check: {:?}", item)

--- a/language/move-lang/src/to_bytecode/translate.rs
+++ b/language/move-lang/src/to_bytecode/translate.rs
@@ -703,7 +703,7 @@ fn command(context: &mut Context, code: &mut IR::BytecodeBlock, sp!(loc, cmd_): 
             exp_(context, code, ecode);
             code.push(sp(loc, B::Abort));
         }
-        C::Return(e) => {
+        C::Return { exp: e, .. } => {
             exp_(context, code, e);
             code.push(sp(loc, B::Ret));
         }
@@ -713,7 +713,7 @@ fn command(context: &mut Context, code: &mut IR::BytecodeBlock, sp!(loc, cmd_): 
                 code.push(sp(loc, B::Pop));
             }
         }
-        C::Jump(lbl) => code.push(sp(loc, B::Branch(label(lbl)))),
+        C::Jump { target, .. } => code.push(sp(loc, B::Branch(label(target)))),
         C::JumpIf {
             cond,
             if_true,

--- a/language/move-lang/src/typing/core.rs
+++ b/language/move-lang/src/typing/core.rs
@@ -1167,7 +1167,11 @@ pub fn instantiate(context: &mut Context, sp!(loc, t_): Type) -> Type {
         Unit => Unit,
         UnresolvedError => UnresolvedError,
         Anything => make_tvar(context, loc).value,
-        Ref(mut_, b) => Ref(mut_, Box::new(instantiate(context, *b))),
+        Ref(mut_, b) => {
+            let inner = *b;
+            context.add_base_type_constraint(loc, "Invalid reference type", inner.clone());
+            Ref(mut_, Box::new(instantiate(context, inner)))
+        }
         Apply(kopt, n, ty_args) => instantiate_apply(context, loc, kopt, n, ty_args),
         x @ Param(_) => x,
         Var(_) => panic!("ICE instantiate type variable"),

--- a/language/move-lang/tests/move_check/borrows/eq_unassigned_local.exp
+++ b/language/move-lang/tests/move_check/borrows/eq_unassigned_local.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/borrows/eq_unassigned_local.move:5:9 ───
+   │
+ 5 │         ref == &x;
+   │         ^^^ Invalid usage of local 'ref'
+   ·
+ 4 │         let ref;
+   │             --- The local does not have a value due to this position. The local must be assigned a value before being used
+   │
+

--- a/language/move-lang/tests/move_check/borrows/eq_unassigned_local.move
+++ b/language/move-lang/tests/move_check/borrows/eq_unassigned_local.move
@@ -1,0 +1,7 @@
+script {
+    fun main() {
+        let x = 5;
+        let ref;
+        ref == &x;
+    }
+}

--- a/language/move-lang/tests/move_check/control_flow/infinite_loop_with_dead_exits.exp
+++ b/language/move-lang/tests/move_check/control_flow/infinite_loop_with_dead_exits.exp
@@ -1,0 +1,16 @@
+error: 
+
+    ┌── tests/move_check/control_flow/infinite_loop_with_dead_exits.move:13:17 ───
+    │
+ 13 │             if (return) break;
+    │                 ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed. In some cases, this is necessary to prevent unused resource values.
+    │
+
+error: 
+
+    ┌── tests/move_check/control_flow/infinite_loop_with_dead_exits.move:13:25 ───
+    │
+ 13 │             if (return) break;
+    │                         ^^^^^ Unreachable code. This statement (and any following statements) will not be executed. In some cases, this will result in unused resource values.
+    │
+

--- a/language/move-lang/tests/move_check/control_flow/infinite_loop_with_dead_exits.move
+++ b/language/move-lang/tests/move_check/control_flow/infinite_loop_with_dead_exits.move
@@ -1,0 +1,18 @@
+address 0x42 {
+module M {
+
+    // fun t1() {
+    //     loop {
+    //         continue;
+    //         break
+    //     };
+    // }
+
+    fun t2() {
+        loop {
+            if (return) break;
+        }
+    }
+
+}
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/commands/dead_return_local.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/commands/dead_return_local.exp
@@ -6,3 +6,11 @@ error:
    │     ^^^^^^^^^^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed. In some cases, this will result in unused resource values.
    │
 
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/move/commands/dead_return_local.move:5:5 ───
+   │
+ 5 │     return ()
+   │     ^^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed. In some cases, this will result in unused resource values.
+   │
+

--- a/language/move-lang/tests/move_check/typing/borrow_divergent.exp
+++ b/language/move-lang/tests/move_check/typing/borrow_divergent.exp
@@ -1,0 +1,24 @@
+error: 
+
+   ┌── tests/move_check/typing/borrow_divergent.move:4:13 ───
+   │
+ 4 │            &break;
+   │             ^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed. In some cases, this is necessary to prevent unused resource values.
+   │
+
+error: 
+
+    ┌── tests/move_check/typing/borrow_divergent.move:11:12 ───
+    │
+ 11 │         &{ return };
+    │            ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed. In some cases, this is necessary to prevent unused resource values.
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/borrow_divergent.move:18:10 ───
+    │
+ 18 │         &(if (cond) return else return);
+    │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed. In some cases, this is necessary to prevent unused resource values.
+    │
+

--- a/language/move-lang/tests/move_check/typing/borrow_divergent.move
+++ b/language/move-lang/tests/move_check/typing/borrow_divergent.move
@@ -1,0 +1,20 @@
+script {
+    fun main1() {
+        loop {
+           &break;
+        }
+    }
+}
+
+script {
+    fun main2() {
+        &{ return };
+    }
+}
+
+
+script {
+    fun main3(cond: bool) {
+        &(if (cond) return else return);
+    }
+}

--- a/language/move-lang/tests/move_check/typing/break_outside_loop.exp
+++ b/language/move-lang/tests/move_check/typing/break_outside_loop.exp
@@ -6,3 +6,19 @@ error:
    │         ^^^^^ Invalid usage of 'break'. 'break' can only be used inside a loop body
    │
 
+error: 
+
+    ┌── tests/move_check/typing/break_outside_loop.move:10:9 ───
+    │
+ 10 │         break;
+    │         ^^^^^ Invalid usage of 'break'. 'break' can only be used inside a loop body
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/break_outside_loop.move:14:21 ───
+    │
+ 14 │         if (x >= 5) break;
+    │                     ^^^^^ Invalid usage of 'break'. 'break' can only be used inside a loop body
+    │
+

--- a/language/move-lang/tests/move_check/typing/break_outside_loop.move
+++ b/language/move-lang/tests/move_check/typing/break_outside_loop.move
@@ -5,4 +5,13 @@ module M {
         };
         break
     }
+
+    fun bar() {
+        break;
+    }
+
+    fun baz(x: u64): u64 {
+        if (x >= 5) break;
+        0
+    }
 }

--- a/language/move-lang/tests/move_check/typing/instantiate_signatures.exp
+++ b/language/move-lang/tests/move_check/typing/instantiate_signatures.exp
@@ -1,0 +1,378 @@
+error: 
+
+    ┌── tests/move_check/typing/instantiate_signatures.move:11:13 ───
+    │
+ 11 │         f1: S<R>,
+    │             ^^^^ Constraint not satisfied.
+    ·
+ 11 │         f1: S<R>,
+    │               - The resource type '0x42::M::R' does not satisfy the constraint 'copyable'
+    ·
+  4 │     resource struct R {}
+    │     -------- The type's constraint information was determined here
+    ·
+  3 │     struct S<T: copyable> {}
+    │                 -------- 'copyable' constraint declared here
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/instantiate_signatures.move:12:13 ───
+    │
+ 12 │         f2: S<&u64>,
+    │             ^^^^^^^ Invalid type argument
+    ·
+ 12 │         f2: S<&u64>,
+    │               ---- Expected a single non-reference type, but found: '&u64'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/instantiate_signatures.move:13:13 ───
+    │
+ 13 │         f3: &(&u64),
+    │             ^^^^^^^ Invalid reference type
+    ·
+ 13 │         f3: &(&u64),
+    │              ------ Expected a single non-reference type, but found: '&u64'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/instantiate_signatures.move:13:13 ───
+    │
+ 13 │         f3: &(&u64),
+    │             ^^^^^^^ Invalid field type
+    ·
+ 13 │         f3: &(&u64),
+    │             ------- Expected a single non-reference type, but found: '&&u64'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/instantiate_signatures.move:14:13 ───
+    │
+ 14 │         f4: S<(u64, u64)>,
+    │             ^^^^^^^^^^^^^ Invalid type argument
+    ·
+ 14 │         f4: S<(u64, u64)>,
+    │               ---------- Expected a single non-reference type, but found: '(u64, u64)'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/instantiate_signatures.move:18:14 ───
+    │
+ 18 │         _f1: S<R>,
+    │              ^^^^ Constraint not satisfied.
+    ·
+ 18 │         _f1: S<R>,
+    │                - The resource type '0x42::M::R' does not satisfy the constraint 'copyable'
+    ·
+  4 │     resource struct R {}
+    │     -------- The type's constraint information was determined here
+    ·
+  3 │     struct S<T: copyable> {}
+    │                 -------- 'copyable' constraint declared here
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/instantiate_signatures.move:19:14 ───
+    │
+ 19 │         _f2: S<&u64>,
+    │              ^^^^^^^ Invalid type argument
+    ·
+ 19 │         _f2: S<&u64>,
+    │                ---- Expected a single non-reference type, but found: '&u64'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/instantiate_signatures.move:20:14 ───
+    │
+ 20 │         _f3: &(&u64),
+    │              ^^^^^^^ Invalid reference type
+    ·
+ 20 │         _f3: &(&u64),
+    │               ------ Expected a single non-reference type, but found: '&u64'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/instantiate_signatures.move:21:14 ───
+    │
+ 21 │         _f4: S<(u64, u64)>,
+    │              ^^^^^^^^^^^^^ Invalid type argument
+    ·
+ 21 │         _f4: S<(u64, u64)>,
+    │                ---------- Expected a single non-reference type, but found: '(u64, u64)'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/instantiate_signatures.move:23:9 ───
+    │
+ 23 │         S<R>,
+    │         ^^^^ Constraint not satisfied.
+    ·
+ 23 │         S<R>,
+    │           - The resource type '0x42::M::R' does not satisfy the constraint 'copyable'
+    ·
+  4 │     resource struct R {}
+    │     -------- The type's constraint information was determined here
+    ·
+  3 │     struct S<T: copyable> {}
+    │                 -------- 'copyable' constraint declared here
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/instantiate_signatures.move:24:9 ───
+    │
+ 24 │         S<&u64>,
+    │         ^^^^^^^ Invalid type argument
+    ·
+ 24 │         S<&u64>,
+    │           ---- Expected a single non-reference type, but found: '&u64'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/instantiate_signatures.move:25:9 ───
+    │
+ 25 │         &(&u64),
+    │         ^^^^^^^ Invalid reference type
+    ·
+ 25 │         &(&u64),
+    │          ------ Expected a single non-reference type, but found: '&u64'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/instantiate_signatures.move:26:9 ───
+    │
+ 26 │         S<(u64, u64)>,
+    │         ^^^^^^^^^^^^^ Invalid type argument
+    ·
+ 26 │         S<(u64, u64)>,
+    │           ---------- Expected a single non-reference type, but found: '(u64, u64)'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/instantiate_signatures.move:32:17 ───
+    │
+ 32 │         let f1: S<R> = abort 0;
+    │                 ^^^^ Constraint not satisfied.
+    ·
+ 32 │         let f1: S<R> = abort 0;
+    │                   - The resource type '0x42::M::R' does not satisfy the constraint 'copyable'
+    ·
+  4 │     resource struct R {}
+    │     -------- The type's constraint information was determined here
+    ·
+  3 │     struct S<T: copyable> {}
+    │                 -------- 'copyable' constraint declared here
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/instantiate_signatures.move:33:17 ───
+    │
+ 33 │         let f2: S<&u64> = abort 0;
+    │                 ^^^^^^^ Invalid type argument
+    ·
+ 33 │         let f2: S<&u64> = abort 0;
+    │                   ---- Expected a single non-reference type, but found: '&u64'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/instantiate_signatures.move:34:17 ───
+    │
+ 34 │         let f3: &(&u64) = abort 0;
+    │                 ^^^^^^^ Invalid reference type
+    ·
+ 34 │         let f3: &(&u64) = abort 0;
+    │                  ------ Expected a single non-reference type, but found: '&u64'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/instantiate_signatures.move:35:17 ───
+    │
+ 35 │         let f4: S<(u64, u64)> = abort 0;
+    │                 ^^^^^^^^^^^^^ Invalid type argument
+    ·
+ 35 │         let f4: S<(u64, u64)> = abort 0;
+    │                   ---------- Expected a single non-reference type, but found: '(u64, u64)'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/instantiate_signatures.move:37:9 ───
+    │
+ 37 │         id<S<R>>(abort 0);
+    │         ^^^^^^^^^^^^^^^^^ Cannot ignore resource values. The value must be used
+    ·
+ 37 │         id<S<R>>(abort 0);
+    │            ---- The type: '0x42::M::S<0x42::M::R>'
+    ·
+  4 │     resource struct R {}
+    │     -------- Is found to be a non-copyable type here
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/instantiate_signatures.move:37:12 ───
+    │
+ 37 │         id<S<R>>(abort 0);
+    │            ^^^^ Constraint not satisfied.
+    ·
+ 37 │         id<S<R>>(abort 0);
+    │              - The resource type '0x42::M::R' does not satisfy the constraint 'copyable'
+    ·
+  4 │     resource struct R {}
+    │     -------- The type's constraint information was determined here
+    ·
+  3 │     struct S<T: copyable> {}
+    │                 -------- 'copyable' constraint declared here
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/instantiate_signatures.move:38:12 ───
+    │
+ 38 │         id<S<&u64>>(abort 0);
+    │            ^^^^^^^ Invalid type argument
+    ·
+ 38 │         id<S<&u64>>(abort 0);
+    │              ---- Expected a single non-reference type, but found: '&u64'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/instantiate_signatures.move:39:9 ───
+    │
+ 39 │         id<&(&u64)>(abort 0);
+    │         ^^^^^^^^^^^^^^^^^^^^ Invalid type argument
+    ·
+ 39 │         id<&(&u64)>(abort 0);
+    │            ------- Expected a single non-reference type, but found: '&&u64'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/instantiate_signatures.move:39:12 ───
+    │
+ 39 │         id<&(&u64)>(abort 0);
+    │            ^^^^^^^ Invalid reference type
+    ·
+ 39 │         id<&(&u64)>(abort 0);
+    │             ------ Expected a single non-reference type, but found: '&u64'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/instantiate_signatures.move:40:12 ───
+    │
+ 40 │         id<S<(u64, u64)>>(abort 0);
+    │            ^^^^^^^^^^^^^ Invalid type argument
+    ·
+ 40 │         id<S<(u64, u64)>>(abort 0);
+    │              ---------- Expected a single non-reference type, but found: '(u64, u64)'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/instantiate_signatures.move:42:9 ───
+    │
+ 42 │         S<S<R>> {};
+    │         ^^^^^^^^^^ Constraint not satisfied.
+    ·
+ 42 │         S<S<R>> {};
+    │           ---- The resource type '0x42::M::S<0x42::M::R>' does not satisfy the constraint 'copyable'
+    ·
+  4 │     resource struct R {}
+    │     -------- The type's constraint information was determined here
+    ·
+  3 │     struct S<T: copyable> {}
+    │                 -------- 'copyable' constraint declared here
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/instantiate_signatures.move:42:9 ───
+    │
+ 42 │         S<S<R>> {};
+    │         ^^^^^^^^^^ Cannot ignore resource values. The value must be used
+    ·
+ 42 │         S<S<R>> {};
+    │         ---------- The type: '0x42::M::S<0x42::M::S<0x42::M::R>>'
+    ·
+  4 │     resource struct R {}
+    │     -------- Is found to be a non-copyable type here
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/instantiate_signatures.move:42:11 ───
+    │
+ 42 │         S<S<R>> {};
+    │           ^^^^ Constraint not satisfied.
+    ·
+ 42 │         S<S<R>> {};
+    │             - The resource type '0x42::M::R' does not satisfy the constraint 'copyable'
+    ·
+  4 │     resource struct R {}
+    │     -------- The type's constraint information was determined here
+    ·
+  3 │     struct S<T: copyable> {}
+    │                 -------- 'copyable' constraint declared here
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/instantiate_signatures.move:43:11 ───
+    │
+ 43 │         S<S<&u64>> {};
+    │           ^^^^^^^ Invalid type argument
+    ·
+ 43 │         S<S<&u64>> {};
+    │             ---- Expected a single non-reference type, but found: '&u64'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/instantiate_signatures.move:44:9 ───
+    │
+ 44 │         S<&(&u64)> {};
+    │         ^^^^^^^^^^^^^ Invalid type argument
+    ·
+ 44 │         S<&(&u64)> {};
+    │           ------- Expected a single non-reference type, but found: '&&u64'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/instantiate_signatures.move:44:11 ───
+    │
+ 44 │         S<&(&u64)> {};
+    │           ^^^^^^^ Invalid reference type
+    ·
+ 44 │         S<&(&u64)> {};
+    │            ------ Expected a single non-reference type, but found: '&u64'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/instantiate_signatures.move:45:11 ───
+    │
+ 45 │         S<S<(u64, u64)>> {};
+    │           ^^^^^^^^^^^^^ Invalid type argument
+    ·
+ 45 │         S<S<(u64, u64)>> {};
+    │             ---------- Expected a single non-reference type, but found: '(u64, u64)'
+    │
+

--- a/language/move-lang/tests/move_check/typing/instantiate_signatures.move
+++ b/language/move-lang/tests/move_check/typing/instantiate_signatures.move
@@ -1,0 +1,48 @@
+address 0x42 {
+module M {
+    struct S<T: copyable> {}
+    resource struct R {}
+    fun id<T>(x: T): T { x }
+
+    // Written types with unsatisified constraints
+    // Checked in various positions
+
+    resource struct S1 {
+        f1: S<R>,
+        f2: S<&u64>,
+        f3: &(&u64),
+        f4: S<(u64, u64)>,
+    }
+
+    fun f1(
+        _f1: S<R>,
+        _f2: S<&u64>,
+        _f3: &(&u64),
+        _f4: S<(u64, u64)>,
+    ): (
+        S<R>,
+        S<&u64>,
+        &(&u64),
+        S<(u64, u64)>,
+    ) {
+        abort 0
+    }
+
+    fun f2() {
+        let f1: S<R> = abort 0;
+        let f2: S<&u64> = abort 0;
+        let f3: &(&u64) = abort 0;
+        let f4: S<(u64, u64)> = abort 0;
+
+        id<S<R>>(abort 0);
+        id<S<&u64>>(abort 0);
+        id<&(&u64)>(abort 0);
+        id<S<(u64, u64)>>(abort 0);
+
+        S<S<R>> {};
+        S<S<&u64>> {};
+        S<&(&u64)> {};
+        S<S<(u64, u64)>> {};
+    }
+}
+}

--- a/language/move-lang/tests/move_check/typing/recursive_local.exp
+++ b/language/move-lang/tests/move_check/typing/recursive_local.exp
@@ -1,0 +1,38 @@
+error: 
+
+   ┌── tests/move_check/typing/recursive_local.move:4:13 ───
+   │
+ 4 │         let x;
+   │             ^ Could not infer this type. Try adding an annotation
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/recursive_local.move:5:9 ───
+   │
+ 5 │         x = (x, 0);
+   │         ^ Invalid assignment to local 'x'
+   ·
+ 4 │         let x;
+   │             - Unable to infer the type. Recursive type found.
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/recursive_local.move:5:9 ───
+   │
+ 5 │         x = (x, 0);
+   │         ^ Invalid type for local
+   ·
+ 5 │         x = (x, 0);
+   │             ------ Expected a single type, but found expression list type: '(_, u64)'
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/recursive_local.move:5:14 ───
+   │
+ 5 │         x = (x, 0);
+   │              ^ Could not infer this type. Try adding an annotation
+   │
+

--- a/language/move-lang/tests/move_check/typing/recursive_local.move
+++ b/language/move-lang/tests/move_check/typing/recursive_local.move
@@ -1,0 +1,8 @@
+address 0x42 {
+module M {
+    fun t() {
+        let x;
+        x = (x, 0);
+    }
+}
+}


### PR DESCRIPTION
- Fixed bug where break was used outside of loop (with no other loop in the function)
- Fixed bug where there was a dead break/return/abort in an infinite loop. Causing invariants to break
- Fixed bug where recursive types were not checked when binding to a new tvar
- Borrow checker erroneously assumed both sides of an eq/neq would be a ref. This might not be true as one could be an unassigned local
- Fixed not binding unreachable for the tmp borrow case. Binding it lets it be caught by dead code detection
- Added missing constraint for Ref after last type system rework
- Fixed off by one index issue in hlir translate. 1->0

## Motivation

- Fixes #7560
- Fixes #7562
- Fixes #7568
- Fixes #7569
- Fixes #7570
- Fixes #7573
- Fixes #7574

## Test Plan

- New tests
