### PR TITLE
[move-lang] report errors for global storage builtins in script contexts

### DIFF
--- a/language/move-lang/src/typing/globals.rs
+++ b/language/move-lang/src/typing/globals.rs
@@ -235,7 +235,7 @@ fn check_acquire_listed<F>(
     }
 }
 
-pub fn check_global_access<'a, F>(
+fn check_global_access<'a, F>(
     context: &mut Context,
     loc: &Loc,
     msg: F,
@@ -297,6 +297,13 @@ where
                 ty_debug
             );
             context.error(vec![(*loc, msg()), (*tloc, tmsg)]);
+            return None;
+        }
+        None => {
+            context.error(vec![(
+                *loc,
+                "Global storage operator cannot be used from a 'script' function",
+            )]);
             return None;
         }
         _ => (),

--- a/language/move-lang/tests/move_check/typing/global_builtins_script.exp
+++ b/language/move-lang/tests/move_check/typing/global_builtins_script.exp
@@ -1,0 +1,16 @@
+error: 
+
+   ┌── tests/move_check/typing/global_builtins_script.move:6:5 ───
+   │
+ 6 │     borrow_global<DiemAccount::DiemAccount>(0x1);
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Global storage operator cannot be used from a 'script' function
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/global_builtins_script.move:7:5 ───
+   │
+ 7 │     move_to(account, withdraw_cap);
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Global storage operator cannot be used from a 'script' function
+   │
+

--- a/language/move-lang/tests/move_check/typing/global_builtins_script.move
+++ b/language/move-lang/tests/move_check/typing/global_builtins_script.move
@@ -1,0 +1,9 @@
+script {
+use 0x1::DiemAccount;
+
+fun test<Token>(account: &signer) {
+    let withdraw_cap = DiemAccount::extract_withdraw_capability(account);
+    borrow_global<DiemAccount::DiemAccount>(0x1);
+    move_to(account, withdraw_cap);
+}
+}


### PR DESCRIPTION
Global storage operators can only be used from within the module that defines the resources -- never from a transaction script. Previously the compiler would crash during code generation, so this changes it to report an error message.

## Motivation

Fixed #4577

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added a test for this.