### PR TITLE
[backup] fix flaky test_save_and_list_metadata_files

### DIFF
--- a/storage/backup/backup-cli/src/storage/mod.rs
+++ b/storage/backup/backup-cli/src/storage/mod.rs
@@ -156,6 +156,8 @@ pub trait BackupStorage: Send + Sync {
     /// handle, or the same file handle when accessed later, so there's no need to return one. This
     /// also means a local cache must download each metadata file from remote at least once, to
     /// uncover potential storage glitch sooner.
+    /// Behavior on duplicated names is undefined, overwriting the content upon an existing name
+    /// is straightforward and acceptable.
     /// See `list_metadata_files`.
     async fn save_metadata_line(&self, name: &ShellSafeName, content: &TextLine) -> Result<()>;
     /// The backup system always asks for all metadata files and cache and build index on top of

--- a/storage/backup/backup-cli/src/storage/test_util.rs
+++ b/storage/backup/backup-cli/src/storage/test_util.rs
@@ -98,5 +98,7 @@ pub async fn test_save_and_list_metadata_files_impl(
 }
 
 pub fn arb_metadata_files() -> impl Strategy<Value = Vec<(ShellSafeName, TextLine)>> {
-    vec(any::<(ShellSafeName, TextLine)>(), 0..10)
+    hash_map(any::<ShellSafeName>(), any::<TextLine>(), 0..10)
+        .prop_map(HashMap::into_iter)
+        .prop_map(Iterator::collect)
 }


### PR DESCRIPTION
## Motivation

`test_save_and_list_metadata_files()` has been flaky because input metadata files with duplicated names were allowed and they overwrite each other.  The problem existed but was shadowed by more obvious failures that have been fixed previously... shame :(

Given it some thought and I think the behavior of overwriting is acceptable but doesn't need to be required.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Test data generating code updated. Proptest seed committed. 

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/master/developers.diem.com, and link to your PR here.)
