### PR TITLE
[dev-setup.sh] boogie install

### DIFF
--- a/.github/actions/dockerhub_login/action.yml
+++ b/.github/actions/dockerhub_login/action.yml
@@ -16,20 +16,40 @@ inputs:
   key_password:
     description: "The password for the base64 encoded key"
     required: false
+outputs:
+  dockerhub_logged_in:
+    description: Are we logged in to dockerhub, only true if u/p are provided
+    value: ${{ steps.login.outputs.dockerhub_logged_in }}
+  dockerhub_can_sign:
+    description: Is dockerhub image signing available, only true if all credentials are provided.
+    value: ${{ steps.login.outputs.dockerhub_can_sign }}
 runs:
   using: "composite"
   steps:
-    - run: |
-        echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-        if [ -n ${DOCKERHUB_KEY_MATERIAL} ] && [ -n ${DOCKERHUB_KEY_NAME} ] && [ -n ${DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE} ]; then
-          mkdir -p ~/.docker/trust/private/
-          echo ${DOCKERHUB_KEY_MATERIAL} | base64 -d > ~/.docker/trust/private/${DOCKERHUB_KEY_NAME}.key
-          chmod 600 ~/.docker/trust/private/${DOCKERHUB_KEY_NAME}.key
-          docker trust key load ~/.docker/trust/private/${DOCKERHUB_KEY_NAME}.key --name "$DOCKERHUB_USERNAME"
-          echo Docker hub is logged in, and signing is available.
+    - id: login
+      run: |
+        DOCKERHUB_LOGGED_IN=false
+        DOCKERHUB_CAN_SIGN=false
+        if [ -n "${DOCKERHUB_USERNAME}" ] && [ -n "${DOCKERHUB_PASSWORD}" ]; then
+          echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+          DOCKERHUB_LOGGED_IN=true
+          if [ -n "${DOCKERHUB_KEY_MATERIAL}" ] && [ -n "${DOCKERHUB_KEY_NAME}" ] && [ -n "${DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE}" ]; then
+            mkdir -p ~/.docker/trust/private/
+            echo ${DOCKERHUB_KEY_MATERIAL} | base64 -d > ~/.docker/trust/private/${DOCKERHUB_KEY_NAME}.key
+            chmod 600 ~/.docker/trust/private/${DOCKERHUB_KEY_NAME}.key
+            docker trust key load ~/.docker/trust/private/${DOCKERHUB_KEY_NAME}.key --name "$DOCKERHUB_USERNAME"
+            echo Docker hub is logged in, and signing is available.
+            DOCKERHUB_CAN_SIGN=true
+          else
+            echo Docker hub is logged in, no signing key is available.
+          fi
         else
-          echo Docker hub is logged in, no signing key is available.
+          echo Since no dockerhub credentials were provided, not logging in to dockerhub and no key signing is available.
         fi
+        echo "DOCKERHUB_LOGGED_IN=${DOCKERHUB_LOGGED_IN}" >> $GITHUB_ENV
+        echo "DOCKERHUB_CAN_SIGN=${DOCKERHUB_CAN_SIGN}" >> $GITHUB_ENV
+        echo "::set-output name=dockerhub_logged_in::$(echo $DOCKERHUB_LOGGED_IN)"
+        echo "::set-output name=dockerhub_can_sign::$(echo $DOCKERHUB_CAN_SIGN)"
       shell: bash
       env:
         DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ inputs.key_password }}

--- a/.github/workflows/ci-publish-base-image.yml
+++ b/.github/workflows/ci-publish-base-image.yml
@@ -2,26 +2,43 @@ name: Publish Base CI Image To Dockerhub
 
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, release-*, gha-test-*]
     paths:
       [
         .github/workflows/ci-publish-base-image.yml,
         .github/actions/dockerhub_login/action.yml,
         docker/ci/github/Dockerfile,
         scripts/dev_setup.sh,
+        rust-toolchain,
+        cargo-toolchain,
       ]
+  pull_request:
+    branches: [main, master, release-*, gha-test-*]
 
 jobs:
   build_docker_images:
     runs-on: ubuntu-latest-xl
     continue-on-error: false
     env:
-      TAG: github-1
-      DOCKERHUB_ORG: libra
+      DOCKERHUB_ORG: diem
     steps:
       - uses: actions/checkout@v2
+        with:
+          # This ensures that the tip of the PR is checked out instead of the merge between the base ref and the tip
+          # On `push` this value will be empty and will "do-the-right-thing"
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0 #get all the history!!!
+      - name: Git Hooks and Checks
+        run: ./scripts/git-checks.sh
+      - id: changes
+        # name: determine changes
+        # uses: ./.github/actions/changes
+        # with:
+        #   workflow-file: ci-publish-base-image.yml
+        #testing only....
+        run: echo "::set-output name=changes-target-branch::release-1.1"
       - name: build image
-        run: docker build -f docker/ci/github/Dockerfile -t ${{ env.DOCKERHUB_ORG }}/build_environment:${{ env.TAG }} .
+        run: docker build -f docker/ci/github/Dockerfile -t ${{ env.DOCKERHUB_ORG }}/build_environment:${{ steps.changes.outputs.changes-target-branch }} .
       - name: Sign in to dockerhub, install image signing cert.
         uses: ./.github/actions/dockerhub_login
         with:
@@ -31,6 +48,13 @@ jobs:
           key_name: ${{ secrets.DOCKERHUB_KEY_NAME }}
           key_password: ${{ secrets.DOCKERHUB_KEY_PASSWORD }}
       - name: Push to dockerhub.
-        run: docker push --disable-content-trust=false ${{ env.DOCKERHUB_ORG }}/build_environment:${{ env.TAG }}
+        run: |
+          if [[ "$DOCKERHUB_LOGGED_IN" == true ]]; then
+            disable_content_trust=true
+            if [[ "$DOCKERHUB_CAN_SIGN" == true ]]; then
+              disable_content_trust=false
+            fi
+            docker push --disable-content-trust=${disable_content_trust} ${{ env.DOCKERHUB_ORG }}/build_environment:${{ steps.changes.outputs.changes-target-branch }}
+          fi
         env:
           DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKERHUB_KEY_PASSWORD }}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -68,7 +68,7 @@ jobs:
     if: ${{ needs.prepare.outputs.test-dev-setup == 'true' }}
     strategy:
       matrix:
-        target_os: [alpine, arch, centos, github]
+        target_os: [alpine, centos, github]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -77,7 +77,7 @@ jobs:
         with:
           webhook-gha-hardware: ${{ secrets.WEBHOOK_GHA_HARDWARE }}
       - name: build image with dev-setup.sh
-        run: docker build -f docker/ci/${{ matrix.target_os }}/Dockerfile -t libra/build_environment:test .
+        run: docker build -f docker/ci/${{ matrix.target_os }}/Dockerfile -t diem/build_environment:test .
 
   non-rust-lint:
     runs-on: ubuntu-latest
@@ -85,7 +85,7 @@ jobs:
     needs: prepare
     if: ${{ needs.prepare.outputs.test-non-rust-lint == 'true'  }}
     container:
-      image: libra/build_environment:github-1
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -111,7 +111,7 @@ jobs:
     needs: prepare
     #if: ${{ needs.prepare.outputs.test-rust == 'true' }}
     container:
-      image: libra/build_environment:github-1
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
         - "/home/runner/work/diem/diem:/opt/git/diem"
     steps:
@@ -141,7 +141,7 @@ jobs:
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' }}
     container:
-      image: libra/build_environment:github-1
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
         - "/home/runner/work/diem/diem:/opt/git/diem"
     steps:
@@ -170,7 +170,7 @@ jobs:
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' }}
     container:
-      image: libra/build_environment:github-1
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
         - "/home/runner/work/diem/diem:/opt/git/diem"
     strategy:
@@ -247,7 +247,7 @@ jobs:
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' }}
     container:
-      image: libra/build_environment:github-1
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
         - "/home/runner/work/diem/diem:/opt/git/diem"
     steps:
@@ -279,7 +279,7 @@ jobs:
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' }}
     container:
-      image: libra/build_environment:github-1
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
         - "/home/runner/work/diem/diem:/opt/git/diem"
     steps:
@@ -302,7 +302,7 @@ jobs:
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' }}
     container:
-      image: libra/build_environment:github-1
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
         - "/home/runner/work/diem/diem:/opt/git/diem"
     env:


### PR DESCRIPTION
## Motivation

Couple of problems.
1) the base image is built from master and has a newer version of the boogie checker/prover.
2) the tests fail in release-1.1 as a result.
3) dev-setup.sh script can't seem to downgrade boogie.

This fixes #3, and hides 1 & 2.   Though 1 should be fixed seperately.


### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

This pr.

## Related PRs

Everything targeting 1.1 would need this.