### PR TITLE
[mempool] Refactors towards PeerRole based prioritization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,6 +1928,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "short-hex-str",
  "storage-interface",
  "storage-service",
  "subscription-service",

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -38,6 +38,7 @@ network = { path = "../network", version = "0.1.0" }
 rand = "0.8.3"
 netcore = { path = "../network/netcore", version = "0.1.0" }
 serde_json = "1.0.62"
+short-hex-str = { path = "../common/short-hex-str", version = "0.1.0" }
 storage-interface = { path = "../storage/storage-interface", version = "0.1.0" }
 subscription-service = { path = "../common/subscription-service", version = "0.1.0" }
 vm-validator = { path = "../vm-validator", version = "0.1.0" }

--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -157,21 +157,26 @@ impl TransactionStore {
     }
 
     fn track_indices(&self) {
-        counters::CORE_MEMPOOL_INDEX_SIZE
-            .with_label_values(&[counters::SYSTEM_TTL_INDEX_LABEL])
-            .set(self.system_ttl_index.size() as i64);
-        counters::CORE_MEMPOOL_INDEX_SIZE
-            .with_label_values(&[counters::EXPIRATION_TIME_INDEX_LABEL])
-            .set(self.expiration_time_index.size() as i64);
-        counters::CORE_MEMPOOL_INDEX_SIZE
-            .with_label_values(&[counters::PRIORITY_INDEX_LABEL])
-            .set(self.priority_index.size() as i64);
-        counters::CORE_MEMPOOL_INDEX_SIZE
-            .with_label_values(&[counters::PARKING_LOT_INDEX_LABEL])
-            .set(self.parking_lot_index.size() as i64);
-        counters::CORE_MEMPOOL_INDEX_SIZE
-            .with_label_values(&[counters::TIMELINE_INDEX_LABEL])
-            .set(self.timeline_index.size() as i64);
+        counters::core_mempool_index_size(
+            counters::SYSTEM_TTL_INDEX_LABEL,
+            self.system_ttl_index.size(),
+        );
+        counters::core_mempool_index_size(
+            counters::EXPIRATION_TIME_INDEX_LABEL,
+            self.expiration_time_index.size(),
+        );
+        counters::core_mempool_index_size(
+            counters::PRIORITY_INDEX_LABEL,
+            self.priority_index.size(),
+        );
+        counters::core_mempool_index_size(
+            counters::PARKING_LOT_INDEX_LABEL,
+            self.parking_lot_index.size(),
+        );
+        counters::core_mempool_index_size(
+            counters::TIMELINE_INDEX_LABEL,
+            self.timeline_index.size(),
+        );
     }
 
     /// Checks if Mempool is full.

--- a/mempool/src/counters.rs
+++ b/mempool/src/counters.rs
@@ -1,12 +1,16 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use diem_config::{config::PeerNetworkId, network_id::NetworkId};
 use diem_metrics::{
     register_histogram, register_histogram_vec, register_int_counter, register_int_counter_vec,
-    register_int_gauge, register_int_gauge_vec, DurationHistogram, HistogramVec, IntCounter,
-    IntCounterVec, IntGauge, IntGaugeVec,
+    register_int_gauge, register_int_gauge_vec, DurationHistogram, HistogramTimer, HistogramVec,
+    IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
 };
+use diem_types::PeerId;
 use once_cell::sync::Lazy;
+use short_hex_str::AsShortHexStr;
+use std::time::Duration;
 
 // Core mempool index labels
 pub const PRIORITY_INDEX_LABEL: &str = "priority";
@@ -73,7 +77,7 @@ pub const INVALID_REQUEST_ID: &str = "invalid_req_id";
 pub const UNKNOWN_PEER: &str = "unknown_peer";
 
 /// Counter tracking size of various indices in core mempool
-pub static CORE_MEMPOOL_INDEX_SIZE: Lazy<IntGaugeVec> = Lazy::new(|| {
+static CORE_MEMPOOL_INDEX_SIZE: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         "diem_core_mempool_index_size",
         "Size of a core mempool index",
@@ -81,6 +85,12 @@ pub static CORE_MEMPOOL_INDEX_SIZE: Lazy<IntGaugeVec> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+pub fn core_mempool_index_size(label: &'static str, size: usize) {
+    CORE_MEMPOOL_INDEX_SIZE
+        .with_label_values(&[label])
+        .set(size as i64)
+}
 
 /// Counter tracking number of txns removed from core mempool
 pub static CORE_MEMPOOL_REMOVED_TXNS: Lazy<IntCounter> = Lazy::new(|| {
@@ -134,7 +144,7 @@ pub static PENDING_MEMPOOL_NETWORK_EVENTS: Lazy<IntCounterVec> = Lazy::new(|| {
 
 /// Counter of number of txns processed in each consensus/state sync message
 /// (e.g. # txns in block pulled by consensus, # txns committed from state sync)
-pub static MEMPOOL_SERVICE_TXNS: Lazy<HistogramVec> = Lazy::new(|| {
+static MEMPOOL_SERVICE_TXNS: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "diem_mempool_service_transactions",
         "Number of transactions handled in one request/response between mempool and consensus/state sync",
@@ -143,9 +153,15 @@ pub static MEMPOOL_SERVICE_TXNS: Lazy<HistogramVec> = Lazy::new(|| {
         .unwrap()
 });
 
+pub fn mempool_service_transactions(label: &'static str, num: usize) {
+    MEMPOOL_SERVICE_TXNS
+        .with_label_values(&[label])
+        .observe(num as f64)
+}
+
 /// Counter for tracking latency of mempool processing requests from consensus/state sync
 /// A 'fail' result means the mempool's callback response to consensus/state sync failed.
-pub static MEMPOOL_SERVICE_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
+static MEMPOOL_SERVICE_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "diem_mempool_service_latency_ms",
         "Latency of mempool processing request from consensus/state sync",
@@ -154,8 +170,14 @@ pub static MEMPOOL_SERVICE_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
     .unwrap()
 });
 
+pub fn mempool_service_latency(label: &'static str, result: &str, duration: Duration) {
+    MEMPOOL_SERVICE_LATENCY
+        .with_label_values(&[label, result])
+        .observe(duration.as_secs_f64());
+}
+
 /// Counter for types of network messages received by shared mempool
-pub static SHARED_MEMPOOL_EVENTS: Lazy<IntCounterVec> = Lazy::new(|| {
+static SHARED_MEMPOOL_EVENTS: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "diem_shared_mempool_events",
         "Number of network events received by shared mempool",
@@ -164,8 +186,12 @@ pub static SHARED_MEMPOOL_EVENTS: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
+pub fn shared_mempool_event_inc(event: &'static str) {
+    SHARED_MEMPOOL_EVENTS.with_label_values(&[event]).inc();
+}
+
 /// Counter for tracking e2e latency for mempool to process txn submission requests from clients and peers
-pub static PROCESS_TXN_SUBMISSION_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
+static PROCESS_TXN_SUBMISSION_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "diem_shared_mempool_request_latency",
         "Latency of mempool processing txn submission requests",
@@ -173,6 +199,12 @@ pub static PROCESS_TXN_SUBMISSION_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+pub fn process_txn_submit_latency_timer(network: &str, sender: &str) -> HistogramTimer {
+    PROCESS_TXN_SUBMISSION_LATENCY
+        .with_label_values(&[network, sender])
+        .start_timer()
+}
 
 /// Tracks latency of different stages of txn processing (e.g. vm validation, storage read)
 pub static PROCESS_TXN_BREAKDOWN_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
@@ -205,7 +237,7 @@ pub static SHARED_MEMPOOL_BROADCAST_RTT: Lazy<HistogramVec> = Lazy::new(|| {
 });
 
 /// Counter tracking number of mempool broadcasts that have not been ACK'ed for
-pub static SHARED_MEMPOOL_PENDING_BROADCASTS_COUNT: Lazy<IntGaugeVec> = Lazy::new(|| {
+static SHARED_MEMPOOL_PENDING_BROADCASTS_COUNT: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         "diem_shared_mempool_pending_broadcasts_count",
         "Number of mempool broadcasts not ACK'ed for yet",
@@ -214,18 +246,31 @@ pub static SHARED_MEMPOOL_PENDING_BROADCASTS_COUNT: Lazy<IntGaugeVec> = Lazy::ne
     .unwrap()
 });
 
-pub static SHARED_MEMPOOL_TRANSACTIONS_PROCESSED: Lazy<IntCounterVec> = Lazy::new(|| {
+pub fn shared_mempool_pending_broadcasts(peer: &PeerNetworkId) -> IntGauge {
+    SHARED_MEMPOOL_PENDING_BROADCASTS_COUNT.with_label_values(&[
+        peer.raw_network_id().as_str(),
+        peer.peer_id().short_str().as_str(),
+    ])
+}
+
+static SHARED_MEMPOOL_TRANSACTIONS_PROCESSED: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "diem_shared_mempool_transactions_processed",
         "Number of transactions received and handled by shared mempool",
         &[
-            // state of transaction processing: "received", "success", status code from failed txn processing
             "status", // state of transaction processing: "received", "success", status code from failed txn processing
-            "network", "sender" // sender of the txns
+            "network", // state of transaction processing: "received", "success", status code from failed txn processing
+            "sender"   // sender of the txns
         ]
     )
     .unwrap()
 });
+
+pub fn shared_mempool_transactions_processed_inc(status: &str, network: &str, sender: &str) {
+    SHARED_MEMPOOL_TRANSACTIONS_PROCESSED
+        .with_label_values(&[status, network, sender])
+        .inc();
+}
 
 /// Counter for number of transactions in each mempool broadcast sent
 pub static SHARED_MEMPOOL_TRANSACTION_BROADCAST_SIZE: Lazy<HistogramVec> = Lazy::new(|| {
@@ -246,7 +291,7 @@ pub static SHARED_MEMPOOL_BROADCAST_TYPE_COUNT: Lazy<IntCounterVec> = Lazy::new(
     .unwrap()
 });
 
-pub static SHARED_MEMPOOL_ACK_TYPE_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
+static SHARED_MEMPOOL_ACK_TYPE_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "diem_shared_mempool_ack_count",
         "Number of various types of ACKs sent/received by shared mempool",
@@ -255,7 +300,18 @@ pub static SHARED_MEMPOOL_ACK_TYPE_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
-pub static TASK_SPAWN_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
+pub fn shared_mempool_ack_inc(peer: &PeerNetworkId, direction: &str, label: &'static str) {
+    SHARED_MEMPOOL_ACK_TYPE_COUNT
+        .with_label_values(&[
+            peer.raw_network_id().as_str(),
+            peer.peer_id().short_str().as_str(),
+            direction,
+            label,
+        ])
+        .inc();
+}
+
+static TASK_SPAWN_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "diem_mempool_bounded_executor_spawn_latency",
         "Time it takes for mempool's coordinator to spawn async tasks",
@@ -263,6 +319,12 @@ pub static TASK_SPAWN_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+pub fn task_spawn_latency_timer(task: &'static str, stage: &'static str) -> HistogramTimer {
+    TASK_SPAWN_LATENCY
+        .with_label_values(&[task, stage])
+        .start_timer()
+}
 
 pub static CORE_MEMPOOL_INVARIANT_VIOLATION_COUNT: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(
@@ -281,7 +343,7 @@ pub static VM_RECONFIG_UPDATE_FAIL_COUNT: Lazy<IntCounter> = Lazy::new(|| {
 });
 
 /// Counter for failed Diem network sends
-pub static NETWORK_SEND_FAIL: Lazy<IntCounterVec> = Lazy::new(|| {
+static NETWORK_SEND_FAIL: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "diem_mempool_network_send_fail_count",
         "Number of times mempool network send failure occurs",
@@ -290,7 +352,11 @@ pub static NETWORK_SEND_FAIL: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
-pub static UNEXPECTED_NETWORK_MSG_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
+pub fn network_send_fail_inc(label: &'static str) {
+    NETWORK_SEND_FAIL.with_label_values(&[label]).inc();
+}
+
+static UNEXPECTED_NETWORK_MSG_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "diem_mempool_unexpected_network_count",
         "Number of unexpected network msgs received",
@@ -298,6 +364,12 @@ pub static UNEXPECTED_NETWORK_MSG_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+pub fn unexpected_msg_count_inc(network_id: &NetworkId, peer_id: &PeerId) {
+    UNEXPECTED_NETWORK_MSG_COUNT
+        .with_label_values(&[network_id.as_str(), peer_id.short_str().as_str()])
+        .inc();
+}
 
 /// Counter for failed callback response to JSON RPC
 pub static CLIENT_CALLBACK_FAIL: Lazy<IntCounter> = Lazy::new(|| {
@@ -310,7 +382,7 @@ pub static CLIENT_CALLBACK_FAIL: Lazy<IntCounter> = Lazy::new(|| {
 
 /// Counter for how many ACKs were received with an invalid request_id that this node's mempool
 /// did not send
-pub static INVALID_ACK_RECEIVED_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
+static INVALID_ACK_RECEIVED_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "diem_mempool_unrecognized_ack_received_count",
         "Number of ACK messages received with an invalid request_id that this node's mempool did not send",
@@ -318,6 +390,16 @@ pub static INVALID_ACK_RECEIVED_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
     )
         .unwrap()
 });
+
+pub fn invalid_ack_inc(peer: &PeerNetworkId, label: &'static str) {
+    INVALID_ACK_RECEIVED_COUNT
+        .with_label_values(&[
+            peer.raw_network_id().as_str(),
+            peer.peer_id().short_str().as_str(),
+            label,
+        ])
+        .inc();
+}
 
 /// Counter for number of times a DB read resulted in error
 pub static DB_ERROR: Lazy<IntCounter> = Lazy::new(|| {
@@ -332,7 +414,7 @@ pub static DB_ERROR: Lazy<IntCounter> = Lazy::new(|| {
 /// to broadcast to
 /// See `UpstreamConfig::get_upstream_preference` for details on the numerical value of the preference
 /// ranking of a network
-pub static UPSTREAM_NETWORK: Lazy<IntGauge> = Lazy::new(|| {
+static UPSTREAM_NETWORK: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
         "diem_mempool_upstream_network",
         "The preference of the network mempool is broadcasting to"
@@ -340,9 +422,13 @@ pub static UPSTREAM_NETWORK: Lazy<IntGauge> = Lazy::new(|| {
     .unwrap()
 });
 
+pub fn upstream_network(network: usize) {
+    UPSTREAM_NETWORK.set(network as i64)
+}
+
 /// Counter for the current number of active upstream peers mempool can
 /// broadcast to, summed across each of its networks
-pub static ACTIVE_UPSTREAM_PEERS_COUNT: Lazy<IntGaugeVec> = Lazy::new(|| {
+static ACTIVE_UPSTREAM_PEERS_COUNT: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         "diem_mempool_active_upstream_peers_count",
         "Number of active upstream peers for the node of this mempool",
@@ -350,6 +436,10 @@ pub static ACTIVE_UPSTREAM_PEERS_COUNT: Lazy<IntGaugeVec> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+pub fn active_upstream_peers(network_id: &NetworkId) -> IntGauge {
+    ACTIVE_UPSTREAM_PEERS_COUNT.with_label_values(&[network_id.as_str()])
+}
 
 /// Duration of each run of the event loop.
 pub static MAIN_LOOP: Lazy<DurationHistogram> = Lazy::new(|| {

--- a/mempool/src/logging.rs
+++ b/mempool/src/logging.rs
@@ -86,7 +86,7 @@ pub struct LogSchema<'a> {
     consensus_msg: Option<&'a ConsensusRequest>,
     #[schema(display)]
     state_sync_msg: Option<&'a CommitNotification>,
-    network_level: Option<u64>,
+    network_level: Option<usize>,
     upstream_network: Option<&'a NetworkId>,
     #[schema(debug)]
     batch_id: Option<&'a BatchId>,

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -63,7 +63,6 @@ pub(crate) async fn coordinator<V>(
         .map(|(network_id, events)| events.map(move |e| (network_id.clone(), e)))
         .collect();
     let mut events = select_all(smp_events).fuse();
-    let mempool = smp.mempool.clone();
     let mut scheduled_broadcasts = FuturesUnordered::new();
 
     // Use a BoundedExecutor to restrict only `workers_available` concurrent
@@ -78,7 +77,7 @@ pub(crate) async fn coordinator<V>(
                 handle_client_event(&mut smp, &bounded_executor, msg, callback).await;
             },
             msg = consensus_requests.select_next_some() => {
-                tasks::process_consensus_request(&mempool, msg).await;
+                tasks::process_consensus_request(&smp.mempool, msg).await;
             }
             msg = state_sync_requests.select_next_some() => {
                 handle_state_sync_request(&mut smp, msg);

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -172,7 +172,7 @@ async fn handle_event<V>(
             counters::shared_mempool_event_inc("new_peer");
             let origin = metadata.origin;
             let peer = PeerNetworkId(network_id, metadata.remote_peer_id);
-            let is_new_peer = smp.peer_manager.add_peer(peer.clone(), origin);
+            let is_new_peer = smp.peer_manager.add_peer(peer.clone(), metadata);
             let is_upstream_peer = smp.peer_manager.is_upstream_peer(&peer, Some(origin));
             debug!(LogSchema::new(LogEntry::NewPeer)
                 .peer(&peer)

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -32,7 +32,6 @@ use futures::{
     StreamExt,
 };
 use std::{
-    ops::Deref,
     sync::Arc,
     time::{Duration, SystemTime},
 };
@@ -175,7 +174,7 @@ async fn handle_event<V>(
     match event {
         Event::NewPeer(metadata) => {
             counters::SHARED_MEMPOOL_EVENTS
-                .with_label_values(&["new_peer".to_string().deref()])
+                .with_label_values(&["new_peer"])
                 .inc();
             let origin = metadata.origin;
             let peer = PeerNetworkId(network_id, metadata.remote_peer_id);
@@ -191,7 +190,7 @@ async fn handle_event<V>(
         }
         Event::LostPeer(metadata) => {
             counters::SHARED_MEMPOOL_EVENTS
-                .with_label_values(&["lost_peer".to_string().deref()])
+                .with_label_values(&["lost_peer"])
                 .inc();
             let peer = PeerNetworkId(network_id, metadata.remote_peer_id);
             debug!(LogSchema::new(LogEntry::LostPeer)
@@ -205,7 +204,7 @@ async fn handle_event<V>(
         }
         Event::Message(peer_id, msg) => {
             counters::SHARED_MEMPOOL_EVENTS
-                .with_label_values(&["message".to_string().deref()])
+                .with_label_values(&["message"])
                 .inc();
             match msg {
                 MempoolSyncMsg::BroadcastTransactionsRequest {


### PR DESCRIPTION
Currently, Mempool prioritizes upstream peers based on a loose connection of NetworkId, and preferred peers.  This doesn't provide much fine grained control, and cause a few rough edges as a result.  This PR is me adding ConnectionMetadata to the SyncState so it can be used for mempool, along with a couple of refactors I built up while I was trying to understand mempool.