### PR TITLE
[bytecode verifier] checks for friend list and public(friend)

### DIFF
--- a/language/bytecode-verifier/src/cyclic_dependencies.rs
+++ b/language/bytecode-verifier/src/cyclic_dependencies.rs
@@ -11,35 +11,37 @@ use vm::{
     file_format::CompiledModule,
 };
 
-pub fn verify_module<F: Fn(&ModuleId) -> PartialVMResult<Vec<ModuleId>>>(
-    module: &CompiledModule,
-    immediate_module_dependencies: F,
-) -> VMResult<()> {
-    verify_module_impl(module, immediate_module_dependencies)
-        .map_err(|e| e.finish(Location::Module(module.self_id())))
-}
-
-fn verify_module_impl<F: Fn(&ModuleId) -> PartialVMResult<Vec<ModuleId>>>(
-    module: &CompiledModule,
-    immediate_module_dependencies: F,
-) -> PartialVMResult<()> {
-    fn check_existence_in_dependency_recursive<
+// This function performs a DFS in the module graph starting from each node in `items_to_explore`
+// and explores the neighbors of a node using the `immediate_nexts` closure.
+//
+// During the DFS,
+// - 1) if the `target_module_id` is found, the exploration will be short-circuited and returns a
+//   PartialVMError bearing the StatusCode specified in `error_on_cycle`.
+// - 2) if the `target_module_id` is not found, the modules visited in the DFS will be returned at
+//   the end of function execution.
+fn collect_all_with_cycle_detection<F: Fn(&ModuleId) -> PartialVMResult<Vec<ModuleId>>>(
+    target_module_id: &ModuleId,
+    items_to_explore: &[ModuleId],
+    immediate_nexts: &F,
+    error_on_cycle: StatusCode,
+) -> PartialVMResult<BTreeSet<ModuleId>> {
+    fn collect_all_with_cycle_detection_recursive<
         F: Fn(&ModuleId) -> PartialVMResult<Vec<ModuleId>>,
     >(
         target_module_id: &ModuleId,
         cursor_module_id: &ModuleId,
-        immediate_module_dependencies: &F,
+        immediate_nexts: &F,
         visited_modules: &mut BTreeSet<ModuleId>,
     ) -> PartialVMResult<bool> {
         if cursor_module_id == target_module_id {
             return Ok(true);
         }
         if visited_modules.insert(cursor_module_id.clone()) {
-            for next in immediate_module_dependencies(cursor_module_id)? {
-                if check_existence_in_dependency_recursive(
+            for next in immediate_nexts(cursor_module_id)? {
+                if collect_all_with_cycle_detection_recursive(
                     target_module_id,
                     &next,
-                    immediate_module_dependencies,
+                    immediate_nexts,
                     visited_modules,
                 )? {
                     return Ok(true);
@@ -49,17 +51,65 @@ fn verify_module_impl<F: Fn(&ModuleId) -> PartialVMResult<Vec<ModuleId>>>(
         Ok(false)
     }
 
-    let self_id = module.self_id();
     let mut visited_modules = BTreeSet::new();
-    for dep in module.immediate_module_dependencies() {
-        if check_existence_in_dependency_recursive(
-            &self_id,
-            &dep,
-            &immediate_module_dependencies,
+    for item in items_to_explore {
+        if collect_all_with_cycle_detection_recursive(
+            target_module_id,
+            item,
+            immediate_nexts,
             &mut visited_modules,
         )? {
-            return Err(PartialVMError::new(StatusCode::CYCLIC_MODULE_DEPENDENCY));
+            return Err(PartialVMError::new(error_on_cycle));
         }
     }
-    Ok(())
+    Ok(visited_modules)
+}
+
+pub fn verify_module<D, F>(module: &CompiledModule, imm_deps: D, imm_friends: F) -> VMResult<()>
+where
+    D: Fn(&ModuleId) -> PartialVMResult<Vec<ModuleId>>,
+    F: Fn(&ModuleId) -> PartialVMResult<Vec<ModuleId>>,
+{
+    verify_module_impl(module, imm_deps, imm_friends)
+        .map_err(|e| e.finish(Location::Module(module.self_id())))
+}
+
+fn verify_module_impl<D, F>(
+    module: &CompiledModule,
+    imm_deps: D,
+    imm_friends: F,
+) -> PartialVMResult<()>
+where
+    D: Fn(&ModuleId) -> PartialVMResult<Vec<ModuleId>>,
+    F: Fn(&ModuleId) -> PartialVMResult<Vec<ModuleId>>,
+{
+    let self_id = module.self_id();
+
+    // collect and check that there is no cyclic dependency relation
+    let all_deps = collect_all_with_cycle_detection(
+        &self_id,
+        &module.immediate_dependencies(),
+        &imm_deps,
+        StatusCode::CYCLIC_MODULE_DEPENDENCY,
+    )?;
+
+    // collect and check that there is no cyclic friend relation
+    let all_friends = collect_all_with_cycle_detection(
+        &self_id,
+        &module.immediate_friends(),
+        &imm_friends,
+        StatusCode::CYCLIC_MODULE_FRIENDSHIP,
+    )?;
+
+    // check that any direct/transitive dependency is neither a direct nor transitive friend
+    match all_deps.intersection(&all_friends).next() {
+        Some(overlap) => Err(PartialVMError::new(
+            StatusCode::INVALID_FRIEND_DECL_WITH_MODULES_IN_DEPENDENCIES,
+        )
+        .with_message(format!(
+            "At least one module, {}, appears in both the dependency set and the friend set",
+            overlap
+        ))),
+        None => Ok(()),
+    }
 }

--- a/language/bytecode-verifier/src/dependencies.rs
+++ b/language/bytecode-verifier/src/dependencies.rs
@@ -72,7 +72,7 @@ impl<'a, 'b> Context<'a, 'b> {
 
         let mut dependency_visibilities = HashMap::new();
         for (module_id, module) in &context.dependency_map {
-            let friend_module_ids: BTreeSet<_> = module.friend_module_ids().into_iter().collect();
+            let friend_module_ids: BTreeSet<_> = module.immediate_friends().into_iter().collect();
 
             // Module::StructName -> def handle idx
             for struct_def in module.struct_defs() {

--- a/language/bytecode-verifier/src/friends.rs
+++ b/language/bytecode-verifier/src/friends.rs
@@ -1,0 +1,47 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module contains verification of usage of dependencies for modules
+use diem_types::vm_status::StatusCode;
+use vm::{
+    access::ModuleAccess,
+    errors::{Location, PartialVMError, PartialVMResult, VMResult},
+    file_format::CompiledModule,
+};
+
+pub fn verify_module(module: &CompiledModule) -> VMResult<()> {
+    verify_module_impl(module).map_err(|e| e.finish(Location::Module(module.self_id())))
+}
+
+fn verify_module_impl(module: &CompiledModule) -> PartialVMResult<()> {
+    // cannot make friends with the module itself
+    let self_handle = module.self_handle();
+    if module.friend_decls().contains(self_handle) {
+        return Err(PartialVMError::new(
+            StatusCode::INVALID_FRIEND_DECL_WITH_SELF,
+        ));
+    }
+
+    // cannot make friends with modules outside of the account address
+    //
+    // NOTE: this constraint is a policy decision rather than a technical requirement. The VM and
+    // other bytecode verifier passes do not rely on the assumption that friend modules must be
+    // declared within the same account address.
+    //
+    // However, lacking a definite use case of friending modules across account boundaries, and also
+    // to minimize the associated changes on the module publishing flow, we temporarily enforce this
+    // constraint and we may consider lifting this limitation in the future.
+    let self_address =
+        module.address_identifier_at(module.module_handle_at(module.self_handle_idx()).address);
+    let has_external_friend = module
+        .friend_decls()
+        .iter()
+        .any(|handle| module.address_identifier_at(handle.address) != self_address);
+    if has_external_friend {
+        return Err(PartialVMError::new(
+            StatusCode::INVALID_FRIEND_DECL_WITH_MODULES_OUTSIDE_ACCOUNT_ADDRESS,
+        ));
+    }
+
+    Ok(())
+}

--- a/language/bytecode-verifier/src/lib.rs
+++ b/language/bytecode-verifier/src/lib.rs
@@ -14,6 +14,7 @@ pub mod control_flow;
 pub mod control_flow_graph;
 pub mod cyclic_dependencies;
 pub mod dependencies;
+pub mod friends;
 pub mod instantiation_loops;
 pub mod instruction_consistency;
 pub mod script_signature;

--- a/language/bytecode-verifier/src/verifier.rs
+++ b/language/bytecode-verifier/src/verifier.rs
@@ -4,9 +4,9 @@
 //! This module contains the public APIs supported by the bytecode verifier.
 use crate::{
     ability_field_requirements, check_duplication::DuplicationChecker,
-    code_unit_verifier::CodeUnitVerifier, constants, instantiation_loops::InstantiationLoopChecker,
-    instruction_consistency::InstructionConsistency, script_signature, signature::SignatureChecker,
-    struct_defs::RecursiveStructDefChecker,
+    code_unit_verifier::CodeUnitVerifier, constants, friends,
+    instantiation_loops::InstantiationLoopChecker, instruction_consistency::InstructionConsistency,
+    script_signature, signature::SignatureChecker, struct_defs::RecursiveStructDefChecker,
 };
 use vm::{
     errors::VMResult,
@@ -17,13 +17,18 @@ use vm::{
 ///
 /// Clients that rely on verification should call the proper passes
 /// internally rather than using this function.
+///
 /// This function is intended to provide a verification path for clients
-/// that do not require full control over verification
+/// that do not require full control over verification. It is advised to
+/// call this umbrella function instead of each individual checkers to
+/// minimize the code locations that need to be updated should a new checker
+/// is introduced.
 pub fn verify_module(module: &CompiledModule) -> VMResult<()> {
     DuplicationChecker::verify_module(&module)?;
     SignatureChecker::verify_module(&module)?;
     InstructionConsistency::verify_module(&module)?;
     constants::verify_module(&module)?;
+    friends::verify_module(&module)?;
     ability_field_requirements::verify_module(&module)?;
     RecursiveStructDefChecker::verify_module(&module)?;
     InstantiationLoopChecker::verify_module(&module)?;
@@ -34,8 +39,12 @@ pub fn verify_module(module: &CompiledModule) -> VMResult<()> {
 ///
 /// Clients that rely on verification should call the proper passes
 /// internally rather than using this function.
+///
 /// This function is intended to provide a verification path for clients
-/// that do not require full control over verification
+/// that do not require full control over verification. It is advised to
+/// call this umbrella function instead of each individual checkers to
+/// minimize the code locations that need to be updated should a new checker
+/// is introduced.
 pub fn verify_script(script: &CompiledScript) -> VMResult<()> {
     DuplicationChecker::verify_script(&script)?;
     SignatureChecker::verify_script(&script)?;

--- a/language/diem-framework/compiled/src/lib.rs
+++ b/language/diem-framework/compiled/src/lib.rs
@@ -67,12 +67,21 @@ static COMPILED_MOVELANG_STDLIB_WITH_BYTES: Lazy<(Vec<Vec<u8>>, Vec<CompiledModu
             .map(|module| (module.self_id(), module))
             .collect();
         for module in modules_by_id.values() {
-            cyclic_dependencies::verify_module(module, |module_id| {
-                Ok(modules_by_id
-                    .get(module_id)
-                    .expect("missing module in stdlib")
-                    .immediate_module_dependencies())
-            })
+            cyclic_dependencies::verify_module(
+                module,
+                |module_id| {
+                    Ok(modules_by_id
+                        .get(module_id)
+                        .expect("missing module in stdlib")
+                        .immediate_dependencies())
+                },
+                |module_id| {
+                    Ok(modules_by_id
+                        .get(module_id)
+                        .expect("missing module in stdlib")
+                        .immediate_friends())
+                },
+            )
             .expect("stdlib module has cyclic dependencies");
         }
         (module_bytes, verified_modules)

--- a/language/diem-framework/src/lib.rs
+++ b/language/diem-framework/src/lib.rs
@@ -169,12 +169,21 @@ pub fn build_stdlib() -> BTreeMap<String, CompiledModule> {
         .map(|module| (module.self_id(), module))
         .collect();
     for module in modules_by_id.values() {
-        cyclic_dependencies::verify_module(module, |module_id| {
-            Ok(modules_by_id
-                .get(module_id)
-                .expect("missing module in stdlib")
-                .immediate_module_dependencies())
-        })
+        cyclic_dependencies::verify_module(
+            module,
+            |module_id| {
+                Ok(modules_by_id
+                    .get(module_id)
+                    .expect("missing module in stdlib")
+                    .immediate_dependencies())
+            },
+            |module_id| {
+                Ok(modules_by_id
+                    .get(module_id)
+                    .expect("missing module in stdlib")
+                    .immediate_friends())
+            },
+        )
         .expect("stdlib module has cyclic dependencies");
     }
     modules

--- a/language/move-core/types/src/vm_status.rs
+++ b/language/move-core/types/src/vm_status.rs
@@ -566,6 +566,14 @@ pub enum StatusCode {
     NUMBER_OF_SIGNER_ARGUMENTS_MISMATCH = 1101,
     CALLED_SCRIPT_VISIBLE_FROM_NON_SCRIPT_VISIBLE = 1102,
     EXECUTE_SCRIPT_FUNCTION_CALLED_ON_NON_SCRIPT_VISIBLE = 1103,
+    // Cannot mark the module itself as a friend
+    INVALID_FRIEND_DECL_WITH_SELF = 1104,
+    // Cannot declare modules outside of account address as friends
+    INVALID_FRIEND_DECL_WITH_MODULES_OUTSIDE_ACCOUNT_ADDRESS = 1105,
+    // Cannot declare modules that this module depends on as friends
+    INVALID_FRIEND_DECL_WITH_MODULES_IN_DEPENDENCIES = 1106,
+    // The updated module introduces a cyclic friendship (i.e., A friends B and B also friends A)
+    CYCLIC_MODULE_FRIENDSHIP = 1107,
 
     // These are errors that the VM might raise if a violation of internal
     // invariants takes place.

--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -1232,14 +1232,12 @@ impl<'env> ModuleEnv<'env> {
     }
 
     /// Return the set of language storage ModuleId's that this module's bytecode depends on
-    /// (including itself).
+    /// (including itself), friend modules are excluded from the return result.
     pub fn get_dependencies(&self) -> Vec<language_storage::ModuleId> {
         let compiled_module = &self.data.module;
-        compiled_module
-            .module_handles()
-            .iter()
-            .map(|h| compiled_module.module_id_for_handle(h))
-            .collect()
+        let mut deps = self.data.module.immediate_dependencies();
+        deps.push(compiled_module.self_id());
+        deps
     }
 
     /// Returns the set of modules that use this one.

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -122,11 +122,8 @@ impl VMRuntime {
         }
 
         // perform bytecode and loading verification
-        self.loader.verify_module_verify_no_missing_dependencies(
-            &compiled_module,
-            data_store,
-            log_context,
-        )?;
+        self.loader
+            .verify_module_for_publication(&compiled_module, data_store, log_context)?;
 
         data_store.publish_module(&module_id, module)
     }

--- a/language/tools/move-cli/src/lib.rs
+++ b/language/tools/move-cli/src/lib.rs
@@ -447,7 +447,7 @@ impl CodeCache {
         module: &CompiledModule,
     ) -> Result<Vec<&CompiledModule>> {
         module
-            .immediate_module_dependencies()
+            .immediate_dependencies()
             .into_iter()
             .map(|module_id| self.get_module(&module_id))
             .collect::<Result<Vec<_>>>()
@@ -464,7 +464,7 @@ impl CodeCache {
         ) -> Result<()> {
             if let btree_map::Entry::Vacant(entry) = all_deps.entry(module_id) {
                 let module = loader.get_module(entry.key())?;
-                let next_deps = module.immediate_module_dependencies();
+                let next_deps = module.immediate_dependencies();
                 entry.insert(module);
                 for next in next_deps {
                     get_all_module_dependencies_recursive(all_deps, next, loader)?;
@@ -474,7 +474,7 @@ impl CodeCache {
         }
 
         let mut all_deps = BTreeMap::new();
-        for dep in module.immediate_module_dependencies() {
+        for dep in module.immediate_dependencies() {
             get_all_module_dependencies_recursive(&mut all_deps, dep, self)?;
         }
         Ok(all_deps)

--- a/language/vm/src/access.rs
+++ b/language/vm/src/access.rs
@@ -188,7 +188,7 @@ pub trait ModuleAccess: Sync {
         self.as_module().self_id()
     }
 
-    fn immediate_module_dependencies(&self) -> Vec<ModuleId> {
+    fn immediate_dependencies(&self) -> Vec<ModuleId> {
         let self_handle = self.self_handle();
         self.module_handles()
             .iter()
@@ -197,7 +197,7 @@ pub trait ModuleAccess: Sync {
             .collect()
     }
 
-    fn friend_module_ids(&self) -> Vec<ModuleId> {
+    fn immediate_friends(&self) -> Vec<ModuleId> {
         self.friend_decls()
             .iter()
             .map(|handle| self.module_id_for_handle(handle))
@@ -280,7 +280,7 @@ pub trait ScriptAccess: Sync {
         &self.as_script().as_inner().code
     }
 
-    fn immediate_module_dependencies(&self) -> Vec<ModuleId> {
+    fn immediate_dependencies(&self) -> Vec<ModuleId> {
         self.module_handles()
             .iter()
             .map(|handle| {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Add checking rules to the bytecode verifier on checking the correctness of friend declarations as well as calls to `public(friend)` functions.

```
0x2 {
  module A {
    friend 0x2::B;                      --> subject to friend declaration rules
    friend 0x2::C;

    public(friend) fun foo() {}         --> subject to `public(friend)` visibility rules
    public(friend) fun bar() {}

    fun i_am_private() {}
    public fun i_am_public() {}
  }
}
```

### Friend declaration rules

1. Cannot declare the module itself as a friend (checked in `friends.rs`)
    - e.g., `0x2::M` cannot declare `0x2::M` as a friend.
2. Cannot declare modules at different addresses as a friend (checked in `friends.rs`)
    - e.g., `0x2::M` cannot declare `0x3::N` as a friend.
3. Cannot create a cycle in friendship relation (checked in `cyclic_dependencies.rs`)
    - e.g., `0x2::A` friends `0x2::B` friends `0x2::C` friends `0x2::A` is not allowed.
4. Cannot declare a module that is being used, directly or transitively, as a friend (checked in `cyclic_dependencies.rs`)
    - e.g., `0x2::A` friends `0x2::B` and `0x2::A` calls a function `0x2::B::foo()` is not allowed
    - described more precisely, for any module `M`, denote
      - `all_dependencies` - the set of modules it depends on, directly or transitively, 
      - `all_friends` - the set of modules it friends, directly or transitively,
      - `all_dependencies` ∩ `all_friends` = ∅
5. Cannot declare a module that does not exist when the module is published (checked in `loader.rs`)
    - e.g., `0x2::M` cannot declare `0x2::X` as a friend if `0x2::X` cannot be resolved by the loader.
 
### Friend function invocation rules (checked in `dependencies.rs`)

1. Functions in the same module can always call a `public(friend)` function defined in the same module.
2. Functions in a different module (say module `M`) can only call a `public(friend)` function defined in this module (say module `N`), if `N` declares `M` as a friend.

## ~~Conceptual Change~~

```rust
pub struct CompiledModuleMut {
   ...
   /// Handles to external dependency modules and self.
   pub module_handles: Vec<ModuleHandle>,
   ...
   /// Handles to external friend modules
   pub friend_decls: Vec<ModuleHandle>,
   ...
}
```

With #7738 landed, there is no conceptual changes anymore,
- `module_handles` continue to hold the handles for dependency modules
- `friend_decls` now hold the handles for friend modules

Correspondingly, `ModuleAccess` in `access.rs` is updated with
- `fn immediate_dependencies(&self) -> Vec<ModuleId>`
- `fn immediate_friends(&self) -> Vec<ModuleId>`

To ease the production of `ModuleId`s for corresponding handle list.

## ~~The need for the `unused` check~~

Also with `friend_decls` taking a separate table, the `unused` checker is no longer needed.

## Test Plan (updated)

Test cases exist in #7531, and in particular, commit 23aab3e. However, it is not included in this PR because the test cases require changes to the IR compiler to run. And changes to the IR compiler will be proposed in a follow-up PR.

## Related PRs

#7343, #7738 for file-format changes.
