### PR TITLE
short-hex-str: use trait to eliminate dep for crypto and move-core-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,6 +1039,7 @@ dependencies = [
  "schemadb",
  "serde",
  "serde_json",
+ "short-hex-str",
  "state-sync",
  "storage-interface",
  "subscription-service",
@@ -1065,6 +1066,7 @@ dependencies = [
  "mirai-annotations",
  "proptest",
  "serde",
+ "short-hex-str",
 ]
 
 [[package]]
@@ -1452,6 +1454,7 @@ dependencies = [
  "rand 0.8.3",
  "serde",
  "serde_yaml",
+ "short-hex-str",
  "thiserror",
 ]
 
@@ -1487,7 +1490,6 @@ dependencies = [
  "serde_json",
  "sha2",
  "sha3",
- "short-hex-str",
  "static_assertions",
  "thiserror",
  "tiny-keccak",
@@ -4218,8 +4220,6 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "short-hex-str",
- "static_assertions",
  "thiserror",
 ]
 
@@ -4653,6 +4653,7 @@ dependencies = [
  "network",
  "once_cell",
  "rand 0.8.3",
+ "short-hex-str",
  "subscription-service",
  "tokio",
 ]
@@ -6503,6 +6504,7 @@ dependencies = [
  "mirai-annotations",
  "proptest",
  "serde",
+ "static_assertions",
  "thiserror",
 ]
 

--- a/common/short-hex-str/Cargo.toml
+++ b/common/short-hex-str/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 mirai-annotations = "1.10.1"
 serde = { version = "1.0.123", default-features = false }
+static_assertions = "1.1.0"
 thiserror = "1.0.23"
 
 diem-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }

--- a/common/short-hex-str/src/lib.rs
+++ b/common/short-hex-str/src/lib.rs
@@ -3,6 +3,7 @@
 
 use mirai_annotations::debug_checked_precondition;
 use serde::{Serialize, Serializer};
+use static_assertions::const_assert;
 use std::{fmt, str};
 use thiserror::Error;
 
@@ -95,6 +96,26 @@ fn hex_encode(src: &[u8], dst: &mut [u8]) {
         let (hi, lo) = byte2hex(*byte);
         out[0] = hi;
         out[1] = lo;
+    }
+}
+
+pub trait AsShortHexStr {
+    fn short_str(&self) -> ShortHexStr;
+}
+
+impl AsShortHexStr for [u8; 16] {
+    fn short_str(&self) -> ShortHexStr {
+        const_assert!(16 >= ShortHexStr::SOURCE_LENGTH);
+        ShortHexStr::try_from_bytes(self)
+            .expect("This can never fail since 16 >= ShortHexStr::SOURCE_LENGTH")
+    }
+}
+
+impl AsShortHexStr for [u8; 32] {
+    fn short_str(&self) -> ShortHexStr {
+        const_assert!(32 >= ShortHexStr::SOURCE_LENGTH);
+        ShortHexStr::try_from_bytes(self)
+            .expect("This can never fail since 32 >= ShortHexStr::SOURCE_LENGTH")
     }
 }
 

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -30,6 +30,7 @@ diem-secure-storage = { path = "../secure/storage", version = "0.1.0" }
 diem-temppath = { path = "../common/temppath", version = "0.1.0" }
 diem-types = { path = "../types", version = "0.1.0" }
 diem-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
+short-hex-str = { path = "../common/short-hex-str", version = "0.1.0" }
 
 [dev-dependencies]
 diem-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["fuzzing"] }

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -17,6 +17,7 @@ use rand::{
     Rng, SeedableRng,
 };
 use serde::{Deserialize, Serialize};
+use short_hex_str::AsShortHexStr;
 use std::{
     collections::{HashMap, HashSet},
     convert::TryFrom,

--- a/config/src/config/upstream_config.rs
+++ b/config/src/config/upstream_config.rs
@@ -4,6 +4,7 @@
 use crate::network_id::{NetworkId, NodeNetworkId};
 use diem_types::PeerId;
 use serde::{Deserialize, Serialize};
+use short_hex_str::AsShortHexStr;
 use std::fmt;
 
 /// If a node considers a network 'upstream', the node will broadcast transactions (via mempool) to and

--- a/config/src/network_id.rs
+++ b/config/src/network_id.rs
@@ -3,6 +3,7 @@
 use crate::config::RoleType;
 use diem_types::PeerId;
 use serde::{Deserialize, Serialize, Serializer};
+use short_hex_str::AsShortHexStr;
 use std::fmt;
 
 /// A grouping of common information between all networking code for logging.

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -50,6 +50,7 @@ diem-vm = { path = "../language/diem-vm", version = "0.1.0" }
 diem-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
 network = { path = "../network", version = "0.1.0" }
 safety-rules = { path = "safety-rules", version = "0.1.0" }
+short-hex-str = { path = "../common/short-hex-str", version = "0.1.0" }
 state-sync = { path = "../state-sync", version = "0.1.0" }
 schemadb = { path = "../storage/schemadb", version = "0.1.0" }
 storage-interface = { path = "../storage/storage-interface", version = "0.1.0" }

--- a/consensus/consensus-types/Cargo.toml
+++ b/consensus/consensus-types/Cargo.toml
@@ -19,6 +19,7 @@ diem-crypto-derive = { path = "../../crypto/crypto-derive", version = "0.1.0" }
 diem-infallible = { path = "../../common/infallible", version = "0.1.0" }
 diem-types = { path = "../../types", version = "0.1.0" }
 diem-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
+short-hex-str = { path = "../../common/short-hex-str", version = "0.1.0" }
 
 
 [dev-dependencies]

--- a/consensus/consensus-types/src/block_retrieval.rs
+++ b/consensus/consensus-types/src/block_retrieval.rs
@@ -6,6 +6,7 @@ use anyhow::ensure;
 use diem_crypto::hash::HashValue;
 use diem_types::validator_verifier::ValidatorVerifier;
 use serde::{Deserialize, Serialize};
+use short_hex_str::AsShortHexStr;
 use std::fmt;
 
 pub const MAX_BLOCKS_PER_REQUEST: u64 = 10;

--- a/consensus/consensus-types/src/proposal_msg.rs
+++ b/consensus/consensus-types/src/proposal_msg.rs
@@ -5,6 +5,7 @@ use crate::{block::Block, common::Author, sync_info::SyncInfo};
 use anyhow::{anyhow, ensure, format_err, Context, Result};
 use diem_types::validator_verifier::ValidatorVerifier;
 use serde::{Deserialize, Serialize};
+use short_hex_str::AsShortHexStr;
 use std::fmt;
 
 /// ProposalMsg contains the required information for the proposer election protocol to make its

--- a/consensus/consensus-types/src/vote.rs
+++ b/consensus/consensus-types/src/vote.rs
@@ -9,6 +9,7 @@ use diem_types::{
     validator_verifier::ValidatorVerifier,
 };
 use serde::{Deserialize, Serialize};
+use short_hex_str::AsShortHexStr;
 use std::fmt::{Debug, Display, Formatter};
 
 /// Vote is the struct that is ultimately sent by the voter in response for

--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -26,6 +26,7 @@ use diem_logger::prelude::*;
 use diem_trace::prelude::*;
 use diem_types::{ledger_info::LedgerInfoWithSignatures, transaction::TransactionStatus};
 use executor_types::{Error, StateComputeResult};
+use short_hex_str::AsShortHexStr;
 use std::{collections::vec_deque::VecDeque, sync::Arc, time::Duration};
 
 #[cfg(test)]

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -27,7 +27,6 @@ serde = { version = "1.0.123", features = ["derive"] }
 serde_bytes = "0.11.5"
 serde-name = "0.1.1"
 sha2 = "0.9.3"
-short-hex-str = { path = "../../common/short-hex-str", version = "0.1.0" }
 static_assertions = "1.1.0"
 thiserror = "1.0.23"
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }

--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -108,8 +108,6 @@ use once_cell::sync::{Lazy, OnceCell};
 use proptest_derive::Arbitrary;
 use rand::{rngs::OsRng, Rng};
 use serde::{de, ser};
-use short_hex_str::ShortHexStr;
-use static_assertions::const_assert;
 use std::{self, convert::AsRef, fmt, str::FromStr};
 use tiny_keccak::{Hasher, Sha3};
 
@@ -257,13 +255,6 @@ impl HashValue {
         })
     }
 
-    /// Returns first 4 bytes as hex-formatted string
-    pub fn short_str(&self) -> ShortHexStr {
-        const_assert!(HashValue::LENGTH >= ShortHexStr::SOURCE_LENGTH);
-        ShortHexStr::try_from_bytes(&self.hash)
-            .expect("This can never fail since HashValue::LENGTH >= ShortHexStr::SOURCE_LENGTH")
-    }
-
     /// Full hex representation of a given hash value.
     pub fn to_hex(&self) -> String {
         hex::encode(self.hash)
@@ -322,6 +313,14 @@ impl Default for HashValue {
 
 impl AsRef<[u8; HashValue::LENGTH]> for HashValue {
     fn as_ref(&self) -> &[u8; HashValue::LENGTH] {
+        &self.hash
+    }
+}
+
+impl std::ops::Deref for HashValue {
+    type Target = [u8; Self::LENGTH];
+
+    fn deref(&self) -> &Self::Target {
         &self.hash
     }
 }

--- a/language/move-core/types/Cargo.toml
+++ b/language/move-core/types/Cargo.toml
@@ -19,7 +19,6 @@ proptest-derive = { version = "0.2.0", default-features = false, optional = true
 ref-cast = "1.0.6"
 serde = { version = "1.0.123", default-features = false }
 serde_bytes = "0.11.5"
-static_assertions = "1.1.0"
 thiserror = "1.0.23"
 once_cell = "1.4.1"
 
@@ -27,7 +26,6 @@ bcs = "0.1.2"
 diem-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 diem-crypto = { path = "../../../crypto/crypto", version = "0.1.0", default-features = false }
 diem-crypto-derive = { path = "../../../crypto/crypto-derive", version = "0.1.0" }
-short-hex-str = { path = "../../../common/short-hex-str", version = "0.1.0" }
 
 [dev-dependencies]
 once_cell = "1.4.1"

--- a/language/move-core/types/src/account_address.rs
+++ b/language/move-core/types/src/account_address.rs
@@ -11,8 +11,6 @@ use diem_crypto_derive::CryptoHasher;
 use proptest_derive::Arbitrary;
 use rand::{rngs::OsRng, Rng};
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
-use short_hex_str::ShortHexStr;
-use static_assertions::const_assert;
 use std::{convert::TryFrom, fmt, str::FromStr};
 
 /// A struct that represents an account address.
@@ -35,14 +33,6 @@ impl AccountAddress {
         let mut rng = OsRng;
         let buf: [u8; Self::LENGTH] = rng.gen();
         Self(buf)
-    }
-
-    // Helpful in log messages
-    pub fn short_str(&self) -> ShortHexStr {
-        const_assert!(AccountAddress::LENGTH >= ShortHexStr::SOURCE_LENGTH);
-        ShortHexStr::try_from_bytes(&self.0).expect(
-            "This can never fail since AccountAddress::LENGTH >= ShortHexStr::SOURCE_LENGTH",
-        )
     }
 
     pub fn short_str_lossless(&self) -> String {
@@ -114,6 +104,14 @@ impl CryptoHash for AccountAddress {
 
 impl AsRef<[u8]> for AccountAddress {
     fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for AccountAddress {
+    type Target = [u8; Self::LENGTH];
+
+    fn deref(&self) -> &Self::Target {
         &self.0
     }
 }

--- a/network/simple-onchain-discovery/Cargo.toml
+++ b/network/simple-onchain-discovery/Cargo.toml
@@ -27,6 +27,7 @@ diem-types = {path = "../../types", version = "0.1.0"}
 diem-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 move-core-types = { path = "../../language/move-core/types", version = "0.1.0" }
 network = {path = "../../network", version = "0.1.0"}
+short-hex-str = { path = "../../common/short-hex-str" }
 subscription-service = { path = "../../common/subscription-service", version = "0.1.0" }
 
 [dev-dependencies]

--- a/network/simple-onchain-discovery/src/lib.rs
+++ b/network/simple-onchain-discovery/src/lib.rs
@@ -21,6 +21,7 @@ use network::{
     logging::NetworkSchema,
 };
 use once_cell::sync::Lazy;
+use short_hex_str::AsShortHexStr;
 use std::{collections::HashSet, sync::Arc};
 use subscription_service::ReconfigSubscription;
 

--- a/network/src/connectivity_manager/mod.rs
+++ b/network/src/connectivity_manager/mod.rs
@@ -52,6 +52,7 @@ use rand::{
     seq::SliceRandom,
 };
 use serde::Serialize;
+use short_hex_str::AsShortHexStr;
 use std::{
     cmp::min,
     collections::{hash_map::Entry, HashMap, HashSet},

--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -10,6 +10,7 @@ use diem_metrics::{
 use diem_types::PeerId;
 use netcore::transport::ConnectionOrigin;
 use once_cell::sync::Lazy;
+use short_hex_str::AsShortHexStr;
 
 // some type labels
 pub const REQUEST_LABEL: &str = "request";

--- a/network/src/noise/handshake.rs
+++ b/network/src/noise/handshake.rs
@@ -21,7 +21,7 @@ use diem_logger::trace;
 use diem_types::PeerId;
 use futures::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use netcore::transport::ConnectionOrigin;
-use short_hex_str::ShortHexStr;
+use short_hex_str::{AsShortHexStr, ShortHexStr};
 use std::{collections::HashMap, convert::TryFrom as _, fmt::Debug, sync::Arc};
 
 /// In a mutually authenticated network, a client message is accompanied with a timestamp.

--- a/network/src/peer/mod.rs
+++ b/network/src/peer/mod.rs
@@ -44,6 +44,7 @@ use futures::{
     FutureExt, SinkExt, TryFutureExt,
 };
 use serde::Serialize;
+use short_hex_str::AsShortHexStr;
 use std::{fmt, panic, sync::Arc, time::Duration};
 use tokio::runtime::Handle;
 use tokio_util::compat::{

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -41,6 +41,7 @@ use futures::{
 };
 use netcore::transport::{ConnectionOrigin, Transport};
 use serde::Serialize;
+use short_hex_str::AsShortHexStr;
 use std::{
     collections::{hash_map::Entry, HashMap},
     fmt,

--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -42,6 +42,7 @@ use futures::{
 };
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 use serde::{Deserialize, Serialize};
+use short_hex_str::AsShortHexStr;
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 pub mod builder;

--- a/network/src/protocols/network/mod.rs
+++ b/network/src/protocols/network/mod.rs
@@ -26,6 +26,7 @@ use futures::{
 };
 use pin_project::pin_project;
 use serde::{de::DeserializeOwned, Serialize};
+use short_hex_str::AsShortHexStr;
 use std::{cmp::min, marker::PhantomData, pin::Pin, time::Duration};
 
 pub trait Message: DeserializeOwned + Serialize {}

--- a/network/src/protocols/rpc/mod.rs
+++ b/network/src/protocols/rpc/mod.rs
@@ -71,6 +71,7 @@ use futures::{
     stream::{FuturesUnordered, StreamExt},
 };
 use serde::Serialize;
+use short_hex_str::AsShortHexStr;
 use std::{cmp::PartialEq, collections::HashMap, fmt::Debug, sync::Arc, time::Duration};
 
 pub mod error;

--- a/network/src/transport/mod.rs
+++ b/network/src/transport/mod.rs
@@ -25,6 +25,7 @@ use futures::{
 };
 use netcore::transport::{proxy_protocol, tcp, ConnectionOrigin, Transport};
 use serde::Serialize;
+use short_hex_str::AsShortHexStr;
 use std::{
     collections::BTreeMap,
     convert::TryFrom,


### PR DESCRIPTION
In an effort to reduce the number of crates that need to be published in order to publish a subset of our crates, lets try and eliminate the dep on short-hex-str from diem-crypto and move-core-types.