### PR TITLE
[release] docker base image for each release/master branch and one single large layer so dotnet doesn't fail to install tooling.

### DIFF
--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -18,25 +18,6 @@ runs:
     - name: reconfigure container for gha runner
       shell: bash
       run: |
-        # prepare new user's home directory with symlink, mv takes a full minute.
-        # hard symlinks aren't allowed by os/docker.
-        # These lines exist so that the prior run of scripts/dev_setup.sh as root in the container build
-        # can be used as if they were installed in home directory (working_dir) setup by gha in the docker container.
-        ln -s /root/bin ${HOME}/bin
-        ln -s /root/.dotnet ${HOME}/.dotnet
-        ln -s /root/.rustup ${HOME}/.rustup
-        ln -s /root/.cargo ${HOME}/.cargo
-        ln -s /root/.local ${HOME}/.local
-        ln -s /root/.nuget ${HOME}/.nuget
-
-        # sccache setup
-        # Since sccache needs a standard location for cargo home and the build is currently configured in x.toml
-        # to expect /opt/cargo.  The standard source location expected by the build is handle by an extra docker
-        # mount point.
-        mkdir /opt || true
-        ln -s /root/.cargo /root/cargo
-        ln -s /root/cargo /opt/cargo
-
         # prepare move lang prover tooling.
         # By setting these values the dev-setup.sh script can detect already installed executables (and check versions).
         echo 'Z3_EXE='${HOME}/bin/z3 | tee -a $GITHUB_ENV
@@ -44,8 +25,8 @@ runs:
         echo 'BOOGIE_EXE='${HOME}/.dotnet/tools/boogie | tee -a $GITHUB_ENV
         echo "$HOME/bin" | tee -a $GITHUB_PATH
         echo "/opt/cargo/bin" | tee -a $GITHUB_PATH
-
-    - name: install common dependencies (should be ~ 10 seconds.)
+        echo 'CARGO_HOME=/opt/cargo/' | tee -a $GITHUB_ENV
+    - name: install common dependencies (should be ~ 10 seconds in a linux build, on mac it's a beast.)
       shell: bash
       run: scripts/dev_setup.sh -t -o -b -p -y
     - id: rust-environment
@@ -55,7 +36,6 @@ runs:
         echo 'DIEM_DUMP_LOGS=1' | tee -a $GITHUB_ENV
         echo 'CARGO_INCREMENTAL=0' | tee -a $GITHUB_ENV
         echo 'RUST_NIGHTLY='$(cat cargo-toolchain) | tee -a $GITHUB_ENV
-        echo 'CARGO_HOME=/opt/cargo/' | tee -a $GITHUB_ENV
 
         # Turn on the experimental feature resolver in cargo. See:
         # https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#features

--- a/.github/actions/dockerhub_login/action.yml
+++ b/.github/actions/dockerhub_login/action.yml
@@ -16,20 +16,40 @@ inputs:
   key_password:
     description: "The password for the base64 encoded key"
     required: false
+outputs:
+  dockerhub_logged_in:
+    description: Are we logged in to dockerhub, only true if u/p are provided
+    value: ${{ steps.login.outputs.dockerhub_logged_in }}
+  dockerhub_can_sign:
+    description: Is dockerhub image signing available, only true if all credentials are provided.
+    value: ${{ steps.login.outputs.dockerhub_can_sign }}
 runs:
   using: "composite"
   steps:
-    - run: |
-        echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-        if [ -n ${DOCKERHUB_KEY_MATERIAL} ] && [ -n ${DOCKERHUB_KEY_NAME} ] && [ -n ${DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE} ]; then
-          mkdir -p ~/.docker/trust/private/
-          echo ${DOCKERHUB_KEY_MATERIAL} | base64 -d > ~/.docker/trust/private/${DOCKERHUB_KEY_NAME}.key
-          chmod 600 ~/.docker/trust/private/${DOCKERHUB_KEY_NAME}.key
-          docker trust key load ~/.docker/trust/private/${DOCKERHUB_KEY_NAME}.key --name "$DOCKERHUB_USERNAME"
-          echo Docker hub is logged in, and signing is available.
+    - id: login
+      run: |
+        DOCKERHUB_LOGGED_IN=false
+        DOCKERHUB_CAN_SIGN=false
+        if [ -n "${DOCKERHUB_USERNAME}" ] && [ -n "${DOCKERHUB_PASSWORD}" ]; then
+          echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+          DOCKERHUB_LOGGED_IN=true
+          if [ -n "${DOCKERHUB_KEY_MATERIAL}" ] && [ -n "${DOCKERHUB_KEY_NAME}" ] && [ -n "${DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE}" ]; then
+            mkdir -p ~/.docker/trust/private/
+            echo ${DOCKERHUB_KEY_MATERIAL} | base64 -d > ~/.docker/trust/private/${DOCKERHUB_KEY_NAME}.key
+            chmod 600 ~/.docker/trust/private/${DOCKERHUB_KEY_NAME}.key
+            docker trust key load ~/.docker/trust/private/${DOCKERHUB_KEY_NAME}.key --name "$DOCKERHUB_USERNAME"
+            echo Docker hub is logged in, and signing is available.
+            DOCKERHUB_CAN_SIGN=true
+          else
+            echo Docker hub is logged in, no signing key is available.
+          fi
         else
-          echo Docker hub is logged in, no signing key is available.
+          echo Since no dockerhub credentials were provided, not logging in to dockerhub and no key signing is available.
         fi
+        echo "DOCKERHUB_LOGGED_IN=${DOCKERHUB_LOGGED_IN}" >> $GITHUB_ENV
+        echo "DOCKERHUB_CAN_SIGN=${DOCKERHUB_CAN_SIGN}" >> $GITHUB_ENV
+        echo "::set-output name=dockerhub_logged_in::$(echo $DOCKERHUB_LOGGED_IN)"
+        echo "::set-output name=dockerhub_can_sign::$(echo $DOCKERHUB_CAN_SIGN)"
       shell: bash
       env:
         DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ inputs.key_password }}

--- a/.github/workflows/ci-publish-base-image.yml
+++ b/.github/workflows/ci-publish-base-image.yml
@@ -2,13 +2,15 @@ name: Publish Base CI Image To Dockerhub
 
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, release-*, gha-test-*]
     paths:
       [
         .github/workflows/ci-publish-base-image.yml,
         .github/actions/dockerhub_login/action.yml,
         docker/ci/github/Dockerfile,
         scripts/dev_setup.sh,
+        rust-toolchain,
+        cargo-toolchain,
       ]
 
 jobs:
@@ -16,12 +18,23 @@ jobs:
     runs-on: ubuntu-latest-xl
     continue-on-error: false
     env:
-      TAG: github-1
-      DOCKERHUB_ORG: libra
+      DOCKERHUB_ORG: diem
     steps:
       - uses: actions/checkout@v2
+        with:
+          # This ensures that the tip of the PR is checked out instead of the merge between the base ref and the tip
+          # On `push` this value will be empty and will "do-the-right-thing"
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0 #get all the history!!!
+      - name: Git Hooks and Checks
+        run: ./scripts/git-checks.sh
+      - id: changes
+        name: determine changes
+        uses: ./.github/actions/changes
+        with:
+          workflow-file: ci-publish-base-image.yml
       - name: build image
-        run: docker build -f docker/ci/github/Dockerfile -t ${{ env.DOCKERHUB_ORG }}/build_environment:${{ env.TAG }} .
+        run: docker build -f docker/ci/github/Dockerfile -t ${{ env.DOCKERHUB_ORG }}/build_environment:${{ steps.changes.outputs.changes-target-branch }} .
       - name: Sign in to dockerhub, install image signing cert.
         uses: ./.github/actions/dockerhub_login
         with:
@@ -31,6 +44,13 @@ jobs:
           key_name: ${{ secrets.DOCKERHUB_KEY_NAME }}
           key_password: ${{ secrets.DOCKERHUB_KEY_PASSWORD }}
       - name: Push to dockerhub.
-        run: docker push --disable-content-trust=false ${{ env.DOCKERHUB_ORG }}/build_environment:${{ env.TAG }}
+        run: |
+          if [[ "$DOCKERHUB_LOGGED_IN" == true ]]; then
+            disable_content_trust=true
+            if [[ "$DOCKERHUB_CAN_SIGN" == true ]]; then
+              disable_content_trust=false
+            fi
+            docker push --disable-content-trust=${disable_content_trust} ${{ env.DOCKERHUB_ORG }}/build_environment:${{ steps.changes.outputs.changes-target-branch }}
+          fi
         env:
           DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKERHUB_KEY_PASSWORD }}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -68,7 +68,7 @@ jobs:
     if: ${{ needs.prepare.outputs.test-dev-setup == 'true' }}
     strategy:
       matrix:
-        target_os: [alpine, arch, centos, github]
+        target_os: [alpine, centos, github]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -77,7 +77,7 @@ jobs:
         with:
           webhook-gha-hardware: ${{ secrets.WEBHOOK_GHA_HARDWARE }}
       - name: build image with dev-setup.sh
-        run: docker build -f docker/ci/${{ matrix.target_os }}/Dockerfile -t libra/build_environment:test .
+        run: docker build -f docker/ci/${{ matrix.target_os }}/Dockerfile -t diem/build_environment:test .
 
   non-rust-lint:
     runs-on: ubuntu-latest
@@ -85,11 +85,12 @@ jobs:
     needs: prepare
     if: ${{ needs.prepare.outputs.test-non-rust-lint == 'true'  }}
     container:
-      image: libra/build_environment:github-1
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
     steps:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+      - uses: ./.github/actions/build-setup
       - uses: ./.github/actions/check-machine
         with:
           min-cpu: 2
@@ -111,7 +112,7 @@ jobs:
     needs: prepare
     #if: ${{ needs.prepare.outputs.test-rust == 'true' }}
     container:
-      image: libra/build_environment:github-1
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
         - "/home/runner/work/diem/diem:/opt/git/diem"
     steps:
@@ -141,7 +142,7 @@ jobs:
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' }}
     container:
-      image: libra/build_environment:github-1
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
         - "/home/runner/work/diem/diem:/opt/git/diem"
     steps:
@@ -170,7 +171,7 @@ jobs:
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' }}
     container:
-      image: libra/build_environment:github-1
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
         - "/home/runner/work/diem/diem:/opt/git/diem"
     strategy:
@@ -247,7 +248,7 @@ jobs:
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' }}
     container:
-      image: libra/build_environment:github-1
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
         - "/home/runner/work/diem/diem:/opt/git/diem"
     steps:
@@ -279,7 +280,7 @@ jobs:
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' }}
     container:
-      image: libra/build_environment:github-1
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
         - "/home/runner/work/diem/diem:/opt/git/diem"
     steps:
@@ -302,7 +303,7 @@ jobs:
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' }}
     container:
-      image: libra/build_environment:github-1
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
         - "/home/runner/work/diem/diem:/opt/git/diem"
     env:

--- a/docker/ci/github/Dockerfile
+++ b/docker/ci/github/Dockerfile
@@ -5,24 +5,23 @@ COPY rust-toolchain /diem/rust-toolchain
 COPY cargo-toolchain /diem/cargo-toolchain
 COPY scripts/dev_setup.sh /diem/scripts/dev_setup.sh
 
+#this is the default home on docker images in gha, until it's not?
+ENV HOME "/github/home"
+#Needed for sccache to function
+ENV CARGO_HOME "/opt/cargo/"
+
 # Batch mode and all operations tooling
-RUN /diem/scripts/dev_setup.sh -t -o -b -p -y && apt-get clean && rm -rf /var/lib/apt/lists/*
-ENV PATH "/root/.cargo/bin:/root/bin/:$PATH"
+RUN mkdir -p /github/home \
+    && mkdir -p /opt/cargo/ \
+    && mkdir -p /opt/git/ \
+    && /diem/scripts/dev_setup.sh -t -o -b -p -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
-# Since proper use of sccache demands the exact same path for source and crates, configure it so.
-# Paths that every use can choose to setup.
-RUN mkdir -p /opt/cargo/
-RUN mkdir -p /opt/git/
-
-# Since github actions may not run as root in the docker image, and it's behavior
-# is undocument, and all request for information about any invarients are not responded to....
-# So we may symlink this locations to whatever home directory gha creates, currently /github/home/
-RUN chmod -R o+rwx /root/bin
-RUN chmod -R o+rwx /root/.dotnet
-RUN chmod -R o+rwx /root/.rustup
-RUN chmod -R o+rwx /root/.cargo
-RUN chmod -R o+rwx /root/.local
-RUN chmod -R o+rwx /root/.nuget
+ENV PATH "/opt/cargo/bin:/github/home/bin/:$PATH"
+ENV DOTNET_ROOT "/github/home/.dotnet"
+ENV Z3_EXE "/github/home/bin/z3"
+ENV BOOGIE_EXE "/github/home/.dotnet/tools/boogie"
 
 FROM setup_ci as tested_ci
 

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -51,7 +51,12 @@ function add_to_profile {
 function update_path_and_profile {
   touch "${HOME}"/.profile
   mkdir -p "${HOME}"/bin
-  add_to_profile "export PATH=\"${HOME}/bin:${HOME}/.cargo/bin:\$PATH\""
+  if [ -n "$CARGO_HOME" ]; then
+    add_to_profile "export CARGO_HOME=\"${CARGO_HOME}\""
+    add_to_profile "export PATH=\"${HOME}/bin:${CARGO_HOME}/bin:\$PATH\""
+  else
+    add_to_profile "export PATH=\"${HOME}/bin:${HOME}/.cargo/bin:\$PATH\""
+  fi
   if [[ "$INSTALL_PROVER" == "true" ]]; then
      add_to_profile "export DOTNET_ROOT=\$HOME/.dotnet"
      add_to_profile "export PATH=\"${HOME}/.dotnet/tools:\$PATH\""


### PR DESCRIPTION
## Motivation

Make a single layer for all installed tools/created dirs in docker image so that dotnet installer doesn't shoot us in the foot.

Downgrading boogie via the dotnet installer worked... w00t: https://github.com/diem/diem/runs/1922801595?check_suite_focus=true#step:5:131

Removes busted arch build as well. (also blocking PR builds today)

And I've been building the docker image used by these builds in gha-test-1 branch with a hack (it'll be rebuilt once this lands on release-1.1.)

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

CI and more CI.   Tested docker builds in gha-test-1/gha-test-2 in several different ways outlined below.   And when PRs used those images in CI they worked as expected.

## Related PRs

All of 'em for release-1.1, and all to ever land in the future.

## Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)

Release branch in CI is broken and nothing can be processed until this lands.  No other code changes, no new releases. 
Devs, Ops, DevOps.

## Comprehensive test results that demonstrate the fix working and not breaking existing workflows.

The little green checks below show that this change is working.

Gha-test-1 runs that built the images this PR is using.

I also set up a downgrade test with a different docker base image having the new boogie version that would need to be downgraded in it, and it worked.  https://github.com/diem/diem/runs/1922801595?check_suite_focus=true#step:5:131

## Why we must have it for V1 launch.

CI for that  branch is busted, we can't currently land any other PR but this one.

This PR double taps the problem we see in releases-1.1 today.   First by making sure we shouldn't have to downgrade a docker image, and if we need to upgrade a dotnet tool in the docker image we can by having all relevant files in a single docker layer.

## What workarounds and alternative we have if we do not push the PR.

1) Another PR much like this one.

2) Move test could be written to be forward compatible with updated tooling and arch tests removed.