### PR TITLE
[State Sync/Mempool/Consensus] Make inter-component communication timeouts configurable

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -12,6 +12,8 @@ pub struct ConsensusConfig {
     pub contiguous_rounds: u32,
     pub max_block_size: u64,
     pub max_pruned_blocks_in_mem: usize,
+    // Timeout for consensus to get an ack from mempool for executed transactions (in milliseconds)
+    pub mempool_executed_txn_timeout_ms: u64,
     // Timeout for consensus to pull transactions from mempool and get a response (in milliseconds)
     pub mempool_txn_pull_timeout_ms: u64,
     pub round_initial_timeout_ms: u64,
@@ -31,6 +33,7 @@ impl Default for ConsensusConfig {
             max_block_size: 1000,
             max_pruned_blocks_in_mem: 100,
             mempool_txn_pull_timeout_ms: 1000,
+            mempool_executed_txn_timeout_ms: 1000,
             round_initial_timeout_ms: 1000,
             proposer_type: ConsensusProposerType::LeaderReputation(LeaderReputationConfig {
                 active_weights: 99,

--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -12,6 +12,8 @@ pub struct ConsensusConfig {
     pub contiguous_rounds: u32,
     pub max_block_size: u64,
     pub max_pruned_blocks_in_mem: usize,
+    // Timeout for consensus to pull transactions from mempool and get a response (in milliseconds)
+    pub mempool_txn_pull_timeout_ms: u64,
     pub round_initial_timeout_ms: u64,
     pub proposer_type: ConsensusProposerType,
     pub safety_rules: SafetyRulesConfig,
@@ -28,6 +30,7 @@ impl Default for ConsensusConfig {
             contiguous_rounds: 2,
             max_block_size: 1000,
             max_pruned_blocks_in_mem: 100,
+            mempool_txn_pull_timeout_ms: 1000,
             round_initial_timeout_ms: 1000,
             proposer_type: ConsensusProposerType::LeaderReputation(LeaderReputationConfig {
                 active_weights: 99,

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -16,6 +16,8 @@ pub struct StateSyncConfig {
     pub max_chunk_limit: u64,
     // valid maximum timeout limit for sanity check
     pub max_timeout_ms: u64,
+    // The timeout of the state sync coordinator to receive a commit ack from mempool (in milliseconds)
+    pub mempool_commit_timeout_ms: u64,
     // default timeout to make state sync progress by sending chunk requests to a certain number of networks
     // if no progress is made by sending chunk requests to a number of networks,
     // the next sync request will be multicasted, i.e. sent to more networks
@@ -35,6 +37,7 @@ impl Default for StateSyncConfig {
             long_poll_timeout_ms: 10_000,
             max_chunk_limit: 1000,
             max_timeout_ms: 120_000,
+            mempool_commit_timeout_ms: 5_000,
             multicast_timeout_ms: 30_000,
             sync_request_timeout_ms: 60_000,
             tick_interval_ms: 100,

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Serialize};
 pub struct StateSyncConfig {
     // Size of chunk to request for state synchronization
     pub chunk_limit: u64,
+    // The timeout of the state sync client to process a commit notification (in milliseconds)
+    pub client_commit_timeout_ms: u64,
     // default timeout used for long polling to remote peer
     pub long_poll_timeout_ms: u64,
     // valid maximum chunk limit for sanity check
@@ -29,6 +31,7 @@ impl Default for StateSyncConfig {
     fn default() -> Self {
         Self {
             chunk_limit: 1000,
+            client_commit_timeout_ms: 5_000,
             long_poll_timeout_ms: 10_000,
             max_chunk_limit: 1000,
             max_timeout_ms: 120_000,

--- a/consensus/src/block_storage/block_store_and_lec_recovery_test.rs
+++ b/consensus/src/block_storage/block_store_and_lec_recovery_test.rs
@@ -64,10 +64,11 @@ fn build_inserter(
     lec_client: Box<dyn ExecutionCorrectness + Send + Sync>,
 ) -> TreeInserter {
     let (coordinator_sender, _coordinator_receiver) = mpsc::unbounded();
+    let client_commit_timeout_ms = config.state_sync.client_commit_timeout_ms;
 
     let state_computer = Arc::new(ExecutionProxy::new(
         lec_client,
-        StateSyncClient::new(coordinator_sender),
+        StateSyncClient::new(coordinator_sender, client_commit_timeout_ms),
     ));
 
     TreeInserter::new_with_store(

--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -43,6 +43,7 @@ pub fn start_consensus(
         consensus_to_mempool_sender,
         node_config.consensus.mempool_poll_count,
         node_config.consensus.mempool_txn_pull_timeout_ms,
+        node_config.consensus.mempool_executed_txn_timeout_ms,
     ));
     let execution_correctness_manager = ExecutionCorrectnessManager::new(node_config);
     let state_computer = Arc::new(ExecutionProxy::new(

--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -42,6 +42,7 @@ pub fn start_consensus(
     let txn_manager = Arc::new(MempoolProxy::new(
         consensus_to_mempool_sender,
         node_config.consensus.mempool_poll_count,
+        node_config.consensus.mempool_txn_pull_timeout_ms,
     ));
     let execution_correctness_manager = ExecutionCorrectnessManager::new(node_config);
     let state_computer = Arc::new(ExecutionProxy::new(

--- a/consensus/src/test_utils/mock_txn_manager.rs
+++ b/consensus/src/test_utils/mock_txn_manager.rs
@@ -25,7 +25,7 @@ pub struct MockTransactionManager {
 
 impl MockTransactionManager {
     pub fn new(consensus_to_mempool_sender: Option<mpsc::Sender<ConsensusRequest>>) -> Self {
-        let mempool_proxy = consensus_to_mempool_sender.map(|s| MempoolProxy::new(s, 1, 1));
+        let mempool_proxy = consensus_to_mempool_sender.map(|s| MempoolProxy::new(s, 1, 1, 1));
         Self {
             rejected_txns: vec![],
             mempool_proxy,

--- a/consensus/src/test_utils/mock_txn_manager.rs
+++ b/consensus/src/test_utils/mock_txn_manager.rs
@@ -25,7 +25,7 @@ pub struct MockTransactionManager {
 
 impl MockTransactionManager {
     pub fn new(consensus_to_mempool_sender: Option<mpsc::Sender<ConsensusRequest>>) -> Self {
-        let mempool_proxy = consensus_to_mempool_sender.map(|s| MempoolProxy::new(s, 1));
+        let mempool_proxy = consensus_to_mempool_sender.map(|s| MempoolProxy::new(s, 1, 1));
         Self {
             rejected_txns: vec![],
             mempool_proxy,

--- a/diem-node/src/lib.rs
+++ b/diem-node/src/lib.rs
@@ -433,7 +433,8 @@ pub fn setup_environment(node_config: &NodeConfig, logger: Option<Arc<Logger>>) 
     // network provider -> consensus -> state synchronizer -> network provider.  This has resulted
     // in a deadlock as observed in GitHub issue #749.
     if let Some((consensus_network_sender, consensus_network_events)) = consensus_network_handles {
-        let state_sync_client = state_sync_bootstrapper.create_client();
+        let state_sync_client =
+            state_sync_bootstrapper.create_client(node_config.state_sync.client_commit_timeout_ms);
 
         // Make sure that state synchronizer is caught up at least to its waypoint
         // (in case it's present). There is no sense to start consensus prior to that.

--- a/state-sync/src/bootstrapper.rs
+++ b/state-sync/src/bootstrapper.rs
@@ -84,7 +84,7 @@ impl StateSyncBootstrapper {
         }
     }
 
-    pub fn create_client(&self) -> StateSyncClient {
-        StateSyncClient::new(self.coordinator_sender.clone())
+    pub fn create_client(&self, commit_timeout_secs: u64) -> StateSyncClient {
+        StateSyncClient::new(self.coordinator_sender.clone(), commit_timeout_secs)
     }
 }

--- a/state-sync/src/coordinator.rs
+++ b/state-sync/src/coordinator.rs
@@ -43,8 +43,6 @@ use std::{
 use tokio::time::{interval, timeout};
 use tokio_stream::wrappers::IntervalStream;
 
-const MEMPOOL_COMMIT_ACK_TIMEOUT_SECS: u64 = 5;
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct PendingRequestInfo {
     expiration_time: SystemTime,
@@ -573,7 +571,7 @@ impl<T: ExecutorProxyTrait> StateSyncCoordinator<T> {
                 error
             )))
         } else if let Err(error) = timeout(
-            Duration::from_secs(MEMPOOL_COMMIT_ACK_TIMEOUT_SECS),
+            Duration::from_millis(self.config.mempool_commit_timeout_ms),
             callback_receiver,
         )
         .await

--- a/state-sync/tests/test_harness.rs
+++ b/state-sync/tests/test_harness.rs
@@ -316,7 +316,7 @@ impl StateSyncEnvironment {
             MockExecutorProxy::new(handler, storage_proxy.clone()),
         );
 
-        peer.client = Some(bootstrapper.create_client());
+        peer.client = Some(bootstrapper.create_client(config.state_sync.client_commit_timeout_ms));
         peer.bootstrapper = Some(bootstrapper);
         peer.mempool = Some(MockSharedMempool::new(Some(mempool_requests)));
         peer.storage_proxy = Some(storage_proxy);


### PR DESCRIPTION
## Motivation

At present, the communication timeouts between state sync, mempool and consensus are hard coded into each node. While the chosen values are acceptable for normal operating environments, we've already seen legitimate cases where the timeouts are being hit (e.g., during load and stress testing of mempool). Ideally, these timeouts should be configurable, so that honest (but slow) nodes don't encounter errors when they are otherwise operating correctly.

This PR makes 4 different timeouts configurable, using the following commits:
1. First, make the state sync commit ack timeout configurable (i.e., the timeout when consensus notifies state sync of newly committed transactions and waits for an ack).
2. Second, make the mempool commit ack timeout configurable (i.e., the timeout when state sync notifies mempool of newly committed transactions and waits for an ack).
3. Third, make the mempool transaction pulling timeout configurable (i.e., the timeout when consensus pulls transactions from mempool and waits for an ack). <-- This is an example of a timeout we've already seen being hit in stress tests.
4. Finally, make the consensus transaction execution timeout configurable (i.e., the timeout when consensus notifies mempool of executed transactions and waits for an ack).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally.

## Related PRs

This PR also relates to: https://github.com/diem/diem/issues/6795