### PR TITLE
[move-prover] Run CVC4 tests only when special environment variable is set

### DIFF
--- a/language/move-prover/tests/sources/functional/invariants_resources.exp
+++ b/language/move-prover/tests/sources/functional/invariants_resources.exp
@@ -1,0 +1,15 @@
+Move prover returns: exiting with boogie verification errors
+error: post-condition does not hold
+
+    ┌── tests/sources/functional/invariants_resources.move:31:9 ───
+    │
+ 31 │         ensures result < 1;
+    │         ^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/invariants_resources.move:31
+    =     at tests/sources/functional/invariants_resources.move:27: get_invalid
+    =         a = <redacted>
+    =     at tests/sources/functional/invariants_resources.move:28: get_invalid
+    =         result = <redacted>
+    =     at tests/sources/functional/invariants_resources.move:29: get_invalid
+    =     at tests/sources/functional/invariants_resources.move:31

--- a/language/move-prover/tests/sources/functional/invariants_resources.move
+++ b/language/move-prover/tests/sources/functional/invariants_resources.move
@@ -28,11 +28,6 @@ module TestInvariants {
         borrow_global<R<T>>(a).x
     }
     spec fun get_invalid {
-        // TODO(refactoring): This test seems to sometime succeed not producing an error when run
-        //   via `cargo test`. However, we cannot reproduce this on the command line, or with
-        //   `check_stability.sh <source> 100`. It might be an issue with the test driver or a crash
-        //   downstream in z3 which is not reported back in tests
-        pragma verify = false;
         ensures result < 1;
     }
 }


### PR DESCRIPTION
This adds a guard for running CVC4 tests in addition to Z3 tests: those tests are now only run if env var `MVP_TEST_CVC4` is set, independent of whether `CVC4_EXE` is set.

Background: the `CVC4_EXE` flags is *always* set in regular user environments as well as CI, because of the uniform setup via `devsetup.sh`. I added a new test `invariants_resources.move` leading to unexplained non-deterministic failures which I debugged for hours not knowing that the failure came from cvc4 (new tests are not by default in the blacklist). 

It appears better to only run the cvc4 tests if requested, both for CI stability and transparency when debugging failures, as well as speed.

Resolves https://github.com/diem/diem/issues/7650.

## Motivation

Test stability


### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests

## Related PRs

NA
