### PR TITLE
[move prover] fix broken link in prover guide

### DIFF
--- a/language/move-prover/doc/user/prover-guide.md
+++ b/language/move-prover/doc/user/prover-guide.md
@@ -1,7 +1,7 @@
 # Move Prover User Guide (DRAFT)
 
 This is the user guide for the Move prover. This document does not describe the
-[Move specification language](move-model.md), but accompanies it.
+[Move specification language](spec-lang.md), but accompanies it.
 
 This guide is currently specific for the usage of the prover within the Diem repo.
 


### PR DESCRIPTION
This PR fixes a broken link in the move prover guide.