### PR TITLE
[move-prover] Changes to bytecode instruction set to allow writeback to have edge information.

### DIFF
--- a/language/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/language/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -582,7 +582,7 @@ impl<'env> ModuleTranslator<'env> {
                     UnpackRef | UnpackRefDeep | PackRef | PackRefDeep => {
                         // No effect
                     }
-                    WriteBack(dest) => {
+                    WriteBack(dest, _) => {
                         use BorrowNode::*;
                         let src = srcs[0];
                         match dest {

--- a/language/move-prover/bytecode/src/borrow_analysis_v2.rs
+++ b/language/move-prover/bytecode/src/borrow_analysis_v2.rs
@@ -10,7 +10,7 @@ use crate::{
     function_target::{FunctionData, FunctionTarget},
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
     livevar_analysis::LiveVarAnnotation,
-    stackless_bytecode::{AssignKind, BorrowNode, Bytecode, Operation},
+    stackless_bytecode::{AssignKind, BorrowEdge, BorrowNode, Bytecode, Operation, StrongEdge},
     stackless_control_flow_graph::StacklessControlFlowGraph,
 };
 use itertools::Itertools;
@@ -20,29 +20,6 @@ use move_model::{
 };
 use std::collections::{BTreeMap, BTreeSet};
 use vm::file_format::CodeOffset;
-
-/// This enum denotes strong edges in the borrow graph
-#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
-pub enum StrongEdge {
-    Empty,
-    Offset(usize),
-}
-
-impl std::fmt::Display for StrongEdge {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            StrongEdge::Empty => write!(f, "E"),
-            StrongEdge::Offset(offset) => write!(f, "{}", offset),
-        }
-    }
-}
-
-/// An ede in the borrow graph
-#[derive(Eq, PartialEq)]
-pub enum BorrowEdge {
-    Weak,
-    Strong(StrongEdge),
-}
 
 /// Borrow graph edge abstract domain.
 #[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]

--- a/language/move-prover/bytecode/src/clean_and_optimize.rs
+++ b/language/move-prover/bytecode/src/clean_and_optimize.rs
@@ -88,7 +88,7 @@ impl<'a> TransferFunctions for Optimizer<'a> {
                 WriteRef => {
                     state.unwritten.insert(Reference(srcs[0]));
                 }
-                WriteBack(Reference(dest)) => {
+                WriteBack(Reference(dest), _) => {
                     if state.unwritten.contains(&Reference(srcs[0])) {
                         state.unwritten.insert(Reference(*dest));
                     }
@@ -131,7 +131,7 @@ impl<'a> Optimizer<'a> {
                 }
             }
             // Remove unnecessary WriteBack
-            if let Call(_, _, WriteBack(_), srcs, _) = &instr {
+            if let Call(_, _, WriteBack(_, _), srcs, _) = &instr {
                 if let Some(unwritten) =
                     data.get(&(code_offset as CodeOffset)).map(|d| &d.unwritten)
                 {

--- a/language/move-prover/bytecode/src/eliminate_mut_refs.rs
+++ b/language/move-prover/bytecode/src/eliminate_mut_refs.rs
@@ -233,10 +233,12 @@ impl<'a> EliminateMutRefs<'a> {
         use BorrowNode::*;
         use Operation::*;
         match oper {
-            WriteBack(LocalRoot(dest)) => {
-                WriteBack(LocalRoot(self.transform_index_for_local_root(dest)))
+            WriteBack(LocalRoot(dest), edge) => {
+                WriteBack(LocalRoot(self.transform_index_for_local_root(dest)), edge)
             }
-            WriteBack(Reference(dest)) => WriteBack(Reference(self.transform_index(dest))),
+            WriteBack(Reference(dest), edge) => {
+                WriteBack(Reference(self.transform_index(dest)), edge)
+            }
             _ => oper,
         }
     }

--- a/language/move-prover/bytecode/src/global_invariant_instrumentation.rs
+++ b/language/move-prover/bytecode/src/global_invariant_instrumentation.rs
@@ -183,7 +183,7 @@ impl<'a> Instrumenter<'a> {
         use Bytecode::*;
         use Operation::*;
         match &bc {
-            Call(_, _, WriteBack(GlobalRoot(mem)), ..) => {
+            Call(_, _, WriteBack(GlobalRoot(mem), _), ..) => {
                 self.emit_invariants_for_update(*mem, assumed_at_update, move |builder| {
                     builder.emit(bc);
                 })

--- a/language/move-prover/bytecode/src/memory_instrumentation.rs
+++ b/language/move-prover/bytecode/src/memory_instrumentation.rs
@@ -6,7 +6,7 @@ use crate::{
     function_target::{FunctionData, FunctionTarget},
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
     stackless_bytecode::{
-        AttrId, BorrowNode,
+        AttrId, BorrowEdge, BorrowNode,
         Bytecode::{self, *},
         Operation,
     },
@@ -263,7 +263,7 @@ impl<'a> Instrumenter<'a> {
                     instrumented_bytecodes.push(Bytecode::Call(
                         self.clone_attr(attr_id),
                         vec![],
-                        Operation::WriteBack(parent.clone()),
+                        Operation::WriteBack(parent.clone(), BorrowEdge::Weak),
                         vec![*idx],
                         None,
                     ));

--- a/language/move-prover/bytecode/src/reaching_def_analysis.rs
+++ b/language/move-prover/bytecode/src/reaching_def_analysis.rs
@@ -104,8 +104,8 @@ impl ReachingDefProcessor {
         code.iter()
             .filter_map(|bc| match bc {
                 Call(_, _, Operation::BorrowLoc, srcs, _) => Some(srcs[0]),
-                Call(_, _, Operation::WriteBack(BorrowNode::LocalRoot(src)), ..) => Some(*src),
-                Call(_, _, Operation::WriteBack(BorrowNode::Reference(src)), ..) => Some(*src),
+                Call(_, _, Operation::WriteBack(BorrowNode::LocalRoot(src), _), ..) => Some(*src),
+                Call(_, _, Operation::WriteBack(BorrowNode::Reference(src), _), ..) => Some(*src),
                 _ => None,
             })
             .collect()
@@ -213,7 +213,7 @@ impl<'a> TransferFunctions for ReachingDefAnalysis<'a> {
                 state.kill(*dest);
             }
             Call(_, dests, oper, _, on_abort) => {
-                if let WriteBack(LocalRoot(dest)) = oper {
+                if let WriteBack(LocalRoot(dest), _) = oper {
                     state.kill(*dest);
                 }
                 for dest in dests {

--- a/language/move-prover/bytecode/src/stackless_bytecode.rs
+++ b/language/move-prover/bytecode/src/stackless_bytecode.rs
@@ -819,6 +819,7 @@ impl<'env> fmt::Display for OperationDisplay<'env> {
             UnpackRefDeep => {
                 write!(f, "unpack_ref_deep")?;
             }
+            //TODO: add edge info to write back display
             WriteBack(node, _) => write!(f, "write_back[{}]", node.display(self.func_target))?,
             Splice(map) => write!(
                 f,

--- a/language/move-prover/bytecode/src/stackless_bytecode.rs
+++ b/language/move-prover/bytecode/src/stackless_bytecode.rs
@@ -233,29 +233,11 @@ pub enum StrongEdge {
     Offset(usize),
 }
 
-impl std::fmt::Display for StrongEdge {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            StrongEdge::Empty => write!(f, "E"),
-            StrongEdge::Offset(offset) => write!(f, "{}", offset),
-        }
-    }
-}
-
 /// A borrow edge -- used in memory operations
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub enum BorrowEdge {
     Weak,
     Strong(StrongEdge),
-}
-
-impl std::fmt::Display for BorrowEdge {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            BorrowEdge::Weak => write!(f, "*"),
-            BorrowEdge::Strong(se) => write!(f, "{}", se),
-        }
-    }
 }
 
 /// A specification property kind.
@@ -547,6 +529,24 @@ impl Bytecode {
             bytecode: self,
             func_target,
             label_offsets,
+        }
+    }
+}
+
+impl std::fmt::Display for BorrowEdge {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BorrowEdge::Weak => write!(f, "*"),
+            BorrowEdge::Strong(se) => write!(f, "{}", se),
+        }
+    }
+}
+
+impl std::fmt::Display for StrongEdge {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StrongEdge::Empty => write!(f, "E"),
+            StrongEdge::Offset(offset) => write!(f, "{}", offset),
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Changes to bytecode instruction writeback to allow for edge information.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan

Current coverage is fine (as edge information not actually used yet).
