### PR TITLE
[diem-framework] Specified the "emits" specs for some transaction scripts

### DIFF
--- a/language/diem-framework/modules/Diem.move
+++ b/language/diem-framework/modules/Diem.move
@@ -287,6 +287,7 @@ module Diem {
     spec fun burn {
         include BurnAbortsIf<CoinType>;
         include BurnEnsures<CoinType>;
+        include BurnWithResourceCapEmits<CoinType>{preburn: global<Preburn<CoinType>>(preburn_address)};
     }
     spec schema BurnAbortsIf<CoinType> {
         account: signer;
@@ -330,6 +331,7 @@ module Diem {
         aborts_if !exists<BurnCapability<CoinType>>(Signer::spec_address_of(account)) with Errors::REQUIRES_CAPABILITY;
         include CancelBurnWithCapAbortsIf<CoinType>;
         include CancelBurnWithCapEnsures<CoinType>;
+        include CancelBurnWithCapEmits<CoinType>;
     }
 
     /// Mint a new `Diem` coin of `CoinType` currency worth `value`. The
@@ -533,6 +535,7 @@ module Diem {
         let preburn = global<Preburn<CoinType>>(Signer::spec_address_of(account));
         include PreburnToAbortsIf<CoinType>{amount: coin.value};
         include PreburnEnsures<CoinType>{preburn: preburn, amount: coin.value};
+        include PreburnWithResourceEmits<CoinType>{preburn_address: Signer::spec_address_of(account)};
     }
 
     spec schema PreburnToAbortsIf<CoinType> {
@@ -568,6 +571,7 @@ module Diem {
         include AbortsIfNoPreburn<CoinType>;
         include BurnWithResourceCapAbortsIf<CoinType>{preburn: global<Preburn<CoinType>>(preburn_address)};
         include BurnWithResourceCapEnsures<CoinType>{preburn: global<Preburn<CoinType>>(preburn_address)};
+        include BurnWithResourceCapEmits<CoinType>{preburn: global<Preburn<CoinType>>(preburn_address)};
     }
 
     /// Permanently removes the coins held in the `Preburn` resource (in `to_burn` field)
@@ -726,6 +730,8 @@ module Diem {
         ensures preburn.to_burn.value == 0;
         let info = spec_currency_info<CoinType>();
         ensures info.total_value == old(info.total_value) - coin.value;
+        include PreburnWithResourceEmits<CoinType>{coin: coin, preburn_address: preburn_address};
+        include BurnWithResourceCapEmits<CoinType>{preburn: Preburn<CoinType>{to_burn: coin}};
     }
     spec schema BurnNowAbortsIf<CoinType> {
         coin: Diem<CoinType>;

--- a/language/diem-framework/transaction_scripts/burn.move
+++ b/language/diem-framework/transaction_scripts/burn.move
@@ -73,6 +73,8 @@ spec fun burn {
         Errors::INVALID_STATE,
         Errors::LIMIT_EXCEEDED;
 
+    include Diem::BurnWithResourceCapEmits<Token>{preburn: global<Diem::Preburn<Token>>(preburn_address)};
+
     /// **Access Control:**
     /// Only the account with the burn capability can burn coins [[H3]][PERMISSION].
     include Diem::AbortsIfNoBurnCapability<Token>{account: account};

--- a/language/diem-framework/transaction_scripts/cancel_burn.move
+++ b/language/diem-framework/transaction_scripts/cancel_burn.move
@@ -74,6 +74,8 @@ spec fun cancel_burn {
     /// The balance of `Token` at `preburn_address` should increase by the preburned amount.
     ensures balance_at_addr == old(balance_at_addr) + old(preburn_value_at_addr);
 
+    include Diem::CancelBurnWithCapEmits<Token>;
+
     aborts_with [check]
         Errors::REQUIRES_CAPABILITY,
         Errors::NOT_PUBLISHED,

--- a/language/diem-framework/transaction_scripts/rotate_dual_attestation_info.move
+++ b/language/diem-framework/transaction_scripts/rotate_dual_attestation_info.move
@@ -57,6 +57,9 @@ spec fun rotate_dual_attestation_info {
         Errors::NOT_PUBLISHED,
         Errors::INVALID_ARGUMENT;
 
+    include DualAttestation::RotateBaseUrlEmits;
+    include DualAttestation::RotateCompliancePublicKeyEmits;
+
     /// **Access Control:**
     /// Only the account having Credential can rotate the info.
     /// Credential is granted to either a Parent VASP or a designated dealer [[H16]][PERMISSION].


### PR DESCRIPTION
This PR adds the emits specs to:

- DiemConfig::reconfigure_
- Diem::burn
- Diem::cancel_burn
- Diem::preburn_to
- Diem::burn_with_capability
- Diem::burn_now
- DiemAccount::cancel_burn
- DiemAccount::preburn
- txn_script::burn
- txn_script::cancel_burn
- txn_script::rotate_dual_attestation_info

TODO:
The rest of the functions/scripts will be specified once Prover supports the emits spec verification with opaque functions.

## Motivation

To verify the event emitting behavior of the Diem Framework

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

cargo test
