### PR TITLE
[cherry-pick-release-1.1][network] Metric if network identity doesn't match onchain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4475,8 +4475,10 @@ dependencies = [
  "diem-workspace-hack",
  "futures 0.3.8",
  "move-core-types",
+ "netcore",
  "network",
  "once_cell",
+ "rand 0.7.3",
  "subscription-service",
  "tokio",
 ]

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -19,7 +19,7 @@ use diem_config::{
     },
     network_id::NetworkContext,
 };
-use diem_crypto::x25519;
+use diem_crypto::{x25519, x25519::PublicKey};
 use diem_infallible::RwLock;
 use diem_logger::prelude::*;
 use diem_metrics::IntCounterVec;
@@ -161,6 +161,7 @@ impl NetworkBuilder {
     pub fn create(chain_id: ChainId, role: RoleType, config: &NetworkConfig) -> NetworkBuilder {
         let peer_id = config.peer_id();
         let identity_key = config.identity_key();
+        let pubkey = identity_key.public_key();
 
         let authentication_mode = if config.mutual_authentication {
             AuthenticationMode::Mutual(identity_key)
@@ -231,7 +232,7 @@ impl NetworkBuilder {
 
         match &config.discovery_method {
             DiscoveryMethod::Onchain => {
-                network_builder.add_configuration_change_listener(config.encryptor());
+                network_builder.add_configuration_change_listener(pubkey, config.encryptor());
             }
             DiscoveryMethod::None => {}
         }
@@ -364,7 +365,11 @@ impl NetworkBuilder {
         self
     }
 
-    fn add_configuration_change_listener(&mut self, encryptor: Encryptor) -> &mut Self {
+    fn add_configuration_change_listener(
+        &mut self,
+        pubkey: PublicKey,
+        encryptor: Encryptor,
+    ) -> &mut Self {
         let conn_mgr_reqs_tx = self
             .conn_mgr_reqs_tx()
             .expect("ConnectivityManager must be installed for validator");
@@ -376,6 +381,7 @@ impl NetworkBuilder {
         self.configuration_change_listener_builder =
             Some(ConfigurationChangeListenerBuilder::create(
                 self.network_context.clone(),
+                pubkey,
                 encryptor,
                 conn_mgr_reqs_tx,
                 simple_discovery_reconfig_rx,

--- a/network/simple-onchain-discovery/Cargo.toml
+++ b/network/simple-onchain-discovery/Cargo.toml
@@ -28,3 +28,9 @@ diem-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" 
 move-core-types = { path = "../../language/move-core/types", version = "0.1.0" }
 network = {path = "../../network", version = "0.1.0"}
 subscription-service = { path = "../../common/subscription-service", version = "0.1.0" }
+
+[dev-dependencies]
+diem-network-address = {path = "../../network/network-address", version = "0.1.0", features = ["fuzzing"]}
+diem-config = { path = "../../config", version = "0.1.0", features = ["testing"]}
+netcore = { path = "../netcore", version = "0.1.0", features = ["testing"] }
+rand = "0.7.3"

--- a/network/simple-onchain-discovery/src/lib.rs
+++ b/network/simple-onchain-discovery/src/lib.rs
@@ -3,10 +3,11 @@
 
 use channel::diem_channel::{self, Receiver};
 use diem_config::{config::RoleType, network_id::NetworkContext};
-use diem_crypto::x25519;
+use diem_crypto::{x25519, x25519::PublicKey};
 use diem_logger::prelude::*;
 use diem_metrics::{
-    register_histogram, register_int_counter_vec, DurationHistogram, IntCounterVec,
+    register_histogram, register_int_counter_vec, register_int_gauge_vec, DurationHistogram,
+    IntCounterVec, IntGaugeVec,
 };
 use diem_network_address::NetworkAddress;
 use diem_network_address_encryption::{Encryptor, Error as EncryptorError};
@@ -58,10 +59,20 @@ pub static DISCOVERY_COUNTS: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static NETWORK_KEY_MISMATCH: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "diem_network_key_mismatch",
+        "Gauge of whether the network key mismatches onchain state",
+        &["role_type", "network_id", "peer_id"]
+    )
+    .unwrap()
+});
+
 /// Listener which converts published  updates from the OnChainConfig to ConnectivityRequests
 /// for the ConnectivityManager.
 pub struct ConfigurationChangeListener {
     network_context: Arc<NetworkContext>,
+    expected_pubkey: PublicKey,
     encryptor: Encryptor,
     conn_mgr_reqs_tx: channel::Sender<ConnectivityRequest>,
     reconfig_events: diem_channel::Receiver<(), OnChainConfigPayload>,
@@ -140,12 +151,14 @@ impl ConfigurationChangeListener {
     /// Creates a new ConfigurationListener
     pub fn new(
         network_context: Arc<NetworkContext>,
+        expected_pubkey: PublicKey,
         encryptor: Encryptor,
         conn_mgr_reqs_tx: channel::Sender<ConnectivityRequest>,
         reconfig_events: diem_channel::Receiver<(), OnChainConfigPayload>,
     ) -> Self {
         Self {
             network_context,
+            expected_pubkey,
             encryptor,
             conn_mgr_reqs_tx,
             reconfig_events,
@@ -160,6 +173,36 @@ impl ConfigurationChangeListener {
             .expect("failed to get ValidatorSet from payload");
 
         let updates = extract_updates(self.network_context.clone(), &self.encryptor, node_set);
+
+        // Ensure that the public key matches what's onchain for this peer
+        if let Some(ConnectivityRequest::UpdateEligibleNodes(_, peer_updates)) = updates
+            .iter()
+            .find(|requests| matches!(requests, ConnectivityRequest::UpdateEligibleNodes(_, _)))
+        {
+            let mismatch = peer_updates
+                .get(&self.network_context.peer_id())
+                .map_or(0, |pubkeys| {
+                    if !pubkeys.contains(&self.expected_pubkey) {
+                        error!(
+                            NetworkSchema::new(&self.network_context),
+                            "Onchain pubkey {:?} differs from local pubkey {}",
+                            pubkeys,
+                            self.expected_pubkey
+                        );
+                        1
+                    } else {
+                        0
+                    }
+                });
+
+            NETWORK_KEY_MISMATCH
+                .with_label_values(&[
+                    self.network_context.role().as_str(),
+                    self.network_context.network_id().as_str(),
+                    self.network_context.peer_id().short_str().as_str(),
+                ])
+                .set(mismatch);
+        };
 
         inc_by_with_context(
             &DISCOVERY_COUNTS,
@@ -209,5 +252,120 @@ impl ConfigurationChangeListener {
             EVENT_PROCESSING_LOOP_IDLE_DURATION_S.observe_duration(idle_duration);
             EVENT_PROCESSING_LOOP_BUSY_DURATION_S.observe_duration(process_duration);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use diem_config::config::HANDSHAKE_VERSION;
+    use diem_crypto::{
+        ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
+        x25519::PrivateKey,
+        PrivateKey as PK, Uniform,
+    };
+    use diem_types::{
+        on_chain_config::OnChainConfig, validator_config::ValidatorConfig,
+        validator_info::ValidatorInfo, PeerId,
+    };
+    use futures::executor::block_on;
+    use rand::{rngs::StdRng, SeedableRng};
+    use std::time::Instant;
+    use tokio::{
+        runtime::Runtime,
+        time::{timeout_at, Duration},
+    };
+
+    #[test]
+    fn metric_if_key_mismatch() {
+        diem_logger::DiemLogger::init_for_testing();
+        let runtime = Runtime::new().unwrap();
+        let consensus_private_key = Ed25519PrivateKey::generate_for_testing();
+        let consensus_pubkey = consensus_private_key.public_key();
+        let pubkey = test_pubkey([0u8; 32]);
+        let different_pubkey = test_pubkey([1u8; 32]);
+        let peer_id = PeerId::from_identity_public_key(pubkey);
+
+        // Build up the Reconfig Listener
+        let (conn_mgr_reqs_tx, _rx) = channel::new_test(1);
+        let (mut reconfig_tx, reconfig_rx) = gen_simple_discovery_reconfig_subscription();
+        let network_context = NetworkContext::mock_with_peer_id(peer_id);
+        let listener = ConfigurationChangeListener::new(
+            network_context.clone(),
+            pubkey,
+            Encryptor::for_testing(),
+            conn_mgr_reqs_tx,
+            reconfig_rx,
+        );
+
+        // Build up and send an update with a different pubkey
+        send_pubkey_update(
+            peer_id,
+            consensus_pubkey,
+            different_pubkey,
+            &mut reconfig_tx,
+        );
+
+        let listener_future = async move {
+            // Run the test, ensuring we actually stop after a couple seconds in case it fails to fail
+            timeout_at(
+                tokio::time::Instant::from(Instant::now() + Duration::from_secs(1)),
+                listener.start(),
+            )
+            .await
+            .expect_err("Expect timeout");
+        };
+
+        // Ensure the metric is updated
+        check_network_key_mismatch_metric(0, &network_context);
+        block_on(runtime.spawn(listener_future)).unwrap();
+        check_network_key_mismatch_metric(1, &network_context);
+    }
+
+    fn check_network_key_mismatch_metric(expected: i64, network_context: &NetworkContext) {
+        assert_eq!(
+            expected,
+            NETWORK_KEY_MISMATCH
+                .get_metric_with_label_values(&[
+                    network_context.role().as_str(),
+                    network_context.network_id().as_str(),
+                    network_context.peer_id().short_str().as_str()
+                ])
+                .unwrap()
+                .get()
+        )
+    }
+
+    fn send_pubkey_update(
+        peer_id: PeerId,
+        consensus_pubkey: Ed25519PublicKey,
+        pubkey: PublicKey,
+        reconfig_tx: &mut ReconfigSubscription,
+    ) {
+        let validator_address =
+            NetworkAddress::mock().append_prod_protos(pubkey, HANDSHAKE_VERSION);
+        let addresses = vec![validator_address];
+        let encryptor = Encryptor::for_testing();
+        let encrypted_addresses = encryptor.encrypt(&addresses, peer_id, 0).unwrap();
+        let encoded_addresses = bcs::to_bytes(&addresses).unwrap();
+        let validator = ValidatorInfo::new(
+            peer_id,
+            0,
+            ValidatorConfig::new(consensus_pubkey, encrypted_addresses, encoded_addresses),
+        );
+        let validator_set = ValidatorSet::new(vec![validator]);
+        let mut configs = HashMap::new();
+        configs.insert(
+            ValidatorSet::CONFIG_ID,
+            bcs::to_bytes(&validator_set).unwrap(),
+        );
+        let payload = OnChainConfigPayload::new(1, Arc::new(configs));
+        reconfig_tx.publish(payload).unwrap();
+    }
+
+    fn test_pubkey(seed: [u8; 32]) -> PublicKey {
+        let mut rng: StdRng = SeedableRng::from_seed(seed);
+        let private_key = PrivateKey::generate(&mut rng);
+        private_key.public_key()
     }
 }


### PR DESCRIPTION
### Background
Original: https://github.com/diem/diem/pull/7217
It's possible that a user could set their network identity onchain and
then continue communicating on the network with the wrong network
identity.  This causes a strange 1 way communication, which makes it
very confusing.  The metric allows us to know that there's an issue and that we can mitigate it faster

### Motivation
#### Justification
On several occasions, it's been clear that a validator key mismatched the one onchain, causing confusion for both those trying to connect, and the person running the node.  The reason for this change is to make that mismatch visible to operators and oncalls.

#### Breaking Nature
None, since attempting to make the NetworkIdentity mismatch crash the node caused more issues (basically nodes never really started up after rotation), this only adds a new metric, and log which are additive and do not affect previous code.

#### Who does this affect?
It affects any nodes that have onchain identities at this point (Validators, ValidatorFullNodes).  It can be used by Operators and Oncalls for triage.

#### What happens if we don't have this?
We spend some investigation time trying to figure out why some key was partially rotated incorrectly each time.  Seems to be a relatively common occurrence, and it would just slow triage time and MTTR without it.

#### What are the workarounds / alternatives?
We spend time investigating each change.  There are some telltale metrics that show symptoms, but it's hard to tell without catching specific times when it changes and looking at logs.  The metric should bypass this 5-10+ minute triage to < 1 minute.  I'll add this triage process either way to the runbooks.