### PR TITLE
[RFC][move-package] add the concept of a move package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1583,6 +1583,7 @@ dependencies = [
  "errmapgen",
  "log",
  "move-lang",
+ "move-package",
  "move-prover",
  "rayon",
  "sha2",
@@ -4355,6 +4356,23 @@ dependencies = [
  "once_cell",
  "regex",
  "serde",
+ "vm",
+]
+
+[[package]]
+name = "move-package"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bcs",
+ "bytecode-verifier",
+ "diem-crypto",
+ "diem-types",
+ "diem-workspace-hack",
+ "include_dir",
+ "move-core-types",
+ "once_cell",
+ "sha2",
  "vm",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,15 +968,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
- "bytecode-verifier",
  "diem-crypto",
- "diem-framework",
  "diem-types",
  "diem-workspace-hack",
  "include_dir",
+ "move-package",
  "once_cell",
  "sha2",
- "vm",
 ]
 
 [[package]]
@@ -1585,6 +1583,7 @@ dependencies = [
  "move-lang",
  "move-package",
  "move-prover",
+ "once_cell",
  "rayon",
  "sha2",
  "transaction-builder-generator",
@@ -2407,6 +2406,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-task",
  "futures-util",
  "hyper",
  "itertools 0.10.0",
@@ -3014,6 +3014,7 @@ dependencies = [
  "datatest-stable",
  "diem-config",
  "diem-crypto",
+ "diem-framework",
  "diem-state-view",
  "diem-types",
  "diem-vm",
@@ -4366,13 +4367,9 @@ dependencies = [
  "anyhow",
  "bcs",
  "bytecode-verifier",
- "diem-crypto",
  "diem-types",
  "diem-workspace-hack",
- "include_dir",
  "move-core-types",
- "once_cell",
- "sha2",
  "vm",
 ]
 
@@ -7477,6 +7474,7 @@ version = "0.1.0"
 dependencies = [
  "bcs",
  "compiled-stdlib",
+ "diem-framework",
  "diem-proptest-helpers",
  "diem-types",
  "diem-workspace-hack",
@@ -7756,6 +7754,7 @@ dependencies = [
  "compiled-stdlib",
  "diem-config",
  "diem-crypto",
+ "diem-framework",
  "diem-network-address",
  "diem-proptest-helpers",
  "diem-state-view",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ members = [
     "language/move-lang/ir-utils",
     "language/move-lang/test-utils",
     "language/move-model",
+    "language/move-package",
     "language/move-prover",
     "language/move-prover/abigen",
     "language/move-prover/boogie-backend",

--- a/client/transaction-builder/Cargo.toml
+++ b/client/transaction-builder/Cargo.toml
@@ -15,6 +15,7 @@ serde = { version = "1.0.123", features = ["derive"] }
 compiled-stdlib = { path = "../../language/diem-framework/compiled",  version = "0.1.0" }
 bcs = "0.1.2"
 move-core-types = { path = "../../language/move-core/types", version = "0.1.0" }
+diem-framework = { path = "../../language/diem-framework", version = "0.1.0" }
 diem-types = { path = "../../types", version = "0.1.0" }
 diem-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 

--- a/common/workspace-hack/Cargo.toml
+++ b/common/workspace-hack/Cargo.toml
@@ -25,6 +25,7 @@ futures-channel = { version = "0.3.12", features = ["alloc", "default", "futures
 futures-core = { version = "0.3.12", features = ["alloc", "default", "std"] }
 futures-io = { version = "0.3.12", features = ["default", "std"] }
 futures-sink = { version = "0.3.12", features = ["alloc", "default", "std"] }
+futures-task = { version = "0.3.12", default-features = false, features = ["alloc", "once_cell", "std"] }
 futures-util = { version = "0.3.12", features = ["alloc", "async-await", "async-await-macro", "channel", "default", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "proc-macro-hack", "proc-macro-nested", "sink", "slab", "std"] }
 hyper = { version = "0.14.4", features = ["client", "default", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
 itertools = { version = "0.10.0", features = ["default", "use_alloc", "use_std"] }
@@ -67,6 +68,7 @@ futures-channel = { version = "0.3.12", features = ["alloc", "default", "futures
 futures-core = { version = "0.3.12", features = ["alloc", "default", "std"] }
 futures-io = { version = "0.3.12", features = ["default", "std"] }
 futures-sink = { version = "0.3.12", features = ["alloc", "default", "std"] }
+futures-task = { version = "0.3.12", default-features = false, features = ["alloc", "once_cell", "std"] }
 futures-util = { version = "0.3.12", features = ["alloc", "async-await", "async-await-macro", "channel", "default", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "proc-macro-hack", "proc-macro-nested", "sink", "slab", "std"] }
 hyper = { version = "0.14.4", features = ["client", "default", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
 itertools = { version = "0.10.0", features = ["default", "use_alloc", "use_std"] }
@@ -112,6 +114,7 @@ futures-channel = { version = "0.3.12", features = ["alloc", "default", "futures
 futures-core = { version = "0.3.12", features = ["alloc", "default", "std"] }
 futures-io = { version = "0.3.12", features = ["default", "std"] }
 futures-sink = { version = "0.3.12", features = ["alloc", "default", "std"] }
+futures-task = { version = "0.3.12", default-features = false, features = ["alloc", "once_cell", "std"] }
 futures-util = { version = "0.3.12", features = ["alloc", "async-await", "async-await-macro", "channel", "default", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "proc-macro-hack", "proc-macro-nested", "sink", "slab", "std"] }
 hyper = { version = "0.14.4", features = ["client", "default", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
 itertools = { version = "0.10.0", features = ["default", "use_alloc", "use_std"] }
@@ -154,6 +157,7 @@ futures-channel = { version = "0.3.12", features = ["alloc", "default", "futures
 futures-core = { version = "0.3.12", features = ["alloc", "default", "std"] }
 futures-io = { version = "0.3.12", features = ["default", "std"] }
 futures-sink = { version = "0.3.12", features = ["alloc", "default", "std"] }
+futures-task = { version = "0.3.12", default-features = false, features = ["alloc", "once_cell", "std"] }
 futures-util = { version = "0.3.12", features = ["alloc", "async-await", "async-await-macro", "channel", "default", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "proc-macro-hack", "proc-macro-nested", "sink", "slab", "std"] }
 hyper = { version = "0.14.4", features = ["client", "default", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
 itertools = { version = "0.10.0", features = ["default", "use_alloc", "use_std"] }

--- a/json-rpc/src/tests/genesis.rs
+++ b/json-rpc/src/tests/genesis.rs
@@ -1,7 +1,6 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use compiled_stdlib::StdLibOptions;
 use diem_types::{
     account_address::AccountAddress,
     account_state_blob::AccountStateBlob,
@@ -18,7 +17,7 @@ pub fn generate_genesis_state() -> (
     HashMap<AccountAddress, AccountStateBlob>,
     Arc<SparseMerkleTree<AccountStateBlob>>,
 ) {
-    let change_set = generate_genesis_change_set_for_testing(StdLibOptions::Compiled);
+    let change_set = generate_genesis_change_set_for_testing(/* use_fresh_modules */ false);
     let txn = Transaction::GenesisTransaction(WriteSetPayload::Direct(change_set.clone()));
     let proof_reader = ProofReader::new(HashMap::new());
     let tree = SparseMerkleTree::default();

--- a/language/compiler/src/lib.rs
+++ b/language/compiler/src/lib.rs
@@ -10,7 +10,7 @@ mod unit_tests;
 
 use anyhow::Result;
 use bytecode_source_map::source_map::SourceMap;
-use compiled_stdlib::{stdlib_modules, StdLibOptions};
+use compiled_stdlib::stdlib_modules;
 use diem_types::{account_address::AccountAddress, account_config};
 use ir_to_bytecode::{
     compiler::{compile_module, compile_script},
@@ -114,9 +114,7 @@ impl Compiler {
         if self.skip_stdlib_deps {
             extra_deps
         } else {
-            let mut deps: Vec<CompiledModule> = stdlib_modules(StdLibOptions::Compiled)
-                .compiled_modules
-                .to_vec();
+            let mut deps: Vec<_> = stdlib_modules().modules_iter().cloned().collect();
             deps.extend(extra_deps);
             deps
         }

--- a/language/compiler/src/main.rs
+++ b/language/compiler/src/main.rs
@@ -5,7 +5,7 @@
 
 use anyhow::Context;
 use bytecode_verifier::{dependencies, verify_module, verify_script};
-use compiled_stdlib::{stdlib_modules, StdLibOptions};
+use compiled_stdlib::stdlib_modules;
 use compiler::{util, Compiler};
 use diem_types::{access_path::AccessPath, account_address::AccountAddress, account_config};
 use ir_to_bytecode::parser::{parse_module, parse_script};
@@ -130,9 +130,7 @@ fn main() {
         } else if args.no_stdlib {
             vec![]
         } else {
-            stdlib_modules(StdLibOptions::Compiled)
-                .compiled_modules
-                .to_vec()
+            stdlib_modules().modules_iter().cloned().collect()
         }
     };
 

--- a/language/compiler/src/unit_tests/testutils.rs
+++ b/language/compiler/src/unit_tests/testutils.rs
@@ -3,7 +3,7 @@
 
 use anyhow::Result;
 use bytecode_verifier::{verify_module, verify_script};
-use compiled_stdlib::{stdlib_modules, StdLibOptions};
+use compiled_stdlib::stdlib_modules;
 use diem_types::account_address::AccountAddress;
 use ir_to_bytecode::{
     compiler::{compile_module, compile_script},
@@ -146,7 +146,5 @@ pub fn compile_script_string_with_stdlib(code: &str) -> Result<CompiledScript> {
 }
 
 fn stdlib() -> Vec<CompiledModule> {
-    stdlib_modules(StdLibOptions::Compiled)
-        .compiled_modules
-        .to_vec()
+    stdlib_modules().modules_iter().cloned().collect()
 }

--- a/language/diem-framework/Cargo.toml
+++ b/language/diem-framework/Cargo.toml
@@ -28,6 +28,7 @@ transaction-builder-generator = { path = "../transaction-builder/generator", ver
 clap = "2.33.3"
 log = "0.4.14"
 rayon = "1.5.0"
+once_cell = "1.4.1"
 sha2 = "0.9.3"
 walkdir = "2.3.1"
 

--- a/language/diem-framework/Cargo.toml
+++ b/language/diem-framework/Cargo.toml
@@ -16,6 +16,7 @@ abigen = { path = "../move-prover/abigen" }
 docgen = { path = "../move-prover/docgen" }
 errmapgen = { path = "../move-prover/errmapgen" }
 move-lang = { path = "../move-lang" }
+move-package = { path = "../move-package" }
 move-prover = { path = "../move-prover" }
 diem-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 diem-types = { path = "../../types", version = "0.1.0" }

--- a/language/diem-framework/compiled/Cargo.toml
+++ b/language/diem-framework/compiled/Cargo.toml
@@ -11,15 +11,13 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.38"
-bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
+bcs = "0.1.2"
 diem-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }
 diem-types = { path = "../../../types", version = "0.1.0" }
 diem-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
-bcs = "0.1.2"
-vm = { path = "../../vm", version = "0.1.0" }
-diem-framework = { path = "../../diem-framework",  version = "0.1.0" }
-once_cell = "1.4.1"
 include_dir = "0.6.0"
+move-package = { path = "../../move-package" }
+once_cell = "1.4.1"
 sha2 = "0.9.3"
 
 [features]

--- a/language/diem-framework/compiled/src/lib.rs
+++ b/language/diem-framework/compiled/src/lib.rs
@@ -5,19 +5,9 @@
 
 pub mod transaction_scripts;
 
-use bytecode_verifier::{cyclic_dependencies, dependencies, verify_module};
-use diem_framework::build_stdlib;
 use include_dir::{include_dir, Dir};
+use move_package::package::{CompiledPackage, VerifiedPackage};
 use once_cell::sync::Lazy;
-use std::collections::BTreeMap;
-use vm::{access::ModuleAccess, file_format::CompiledModule};
-
-pub const NO_USE_COMPILED: &str = "MOVE_NO_USE_COMPILED";
-
-// The current stdlib that is freshly built. This will never be used in deployment so we don't need
-// to pull the same trick here in order to include this in the Rust binary.
-static FRESH_MOVELANG_STDLIB: Lazy<Vec<CompiledModule>> =
-    Lazy::new(|| build_stdlib().values().cloned().collect());
 
 // This needs to be a string literal due to restrictions imposed by include_bytes.
 /// The compiled library needs to be included in the Rust binary due to Docker deployment issues.
@@ -27,124 +17,27 @@ pub const COMPILED_STDLIB_DIR: Dir = include_dir!("stdlib");
 pub const ERROR_DESCRIPTIONS: &[u8] =
     std::include_bytes!("../error_descriptions/error_descriptions.errmap");
 
+static PACKAGE_NAME: &str = "diem-framework";
+
 // The compiled version of the Move standard library.
 // Similarly to genesis, we keep a compiled version of the standard library and scripts around, and
 // only periodically update these. This has the effect of decoupling the current leading edge of
 // compiler development from the current stdlib used in genesis/scripts.  In particular, changes in
 // the compiler will not affect the script hashes or stdlib until we have tested the changes to our
 // satisfaction. Then we can generate a new compiled version of the stdlib/scripts (and will need to
-// regenerate genesis). The compiled version of the stdlib/scripts are used unless otherwise
-// specified either by the MOVE_NO_USE_COMPILED env var, or by passing the "StdLibOptions::Fresh"
-// option to `stdlib_modules`.
-static COMPILED_MOVELANG_STDLIB_WITH_BYTES: Lazy<(Vec<Vec<u8>>, Vec<CompiledModule>)> =
-    Lazy::new(|| {
-        let modules: BTreeMap<&str, (Vec<u8>, CompiledModule)> = COMPILED_STDLIB_DIR
-            .files()
-            .iter()
-            .map(|file| {
-                let name = file.path().to_str().unwrap();
-                let bytes = file.contents().to_vec();
-                let module = CompiledModule::deserialize(&bytes).unwrap();
-                (name, (bytes, module))
-            })
-            .collect();
+// regenerate genesis).
+static PACKAGE_MOVELANG_STDLIB: Lazy<VerifiedPackage> = Lazy::new(|| {
+    let module_bytes = COMPILED_STDLIB_DIR
+        .files()
+        .iter()
+        .map(|file| file.contents().to_vec());
+    CompiledPackage::from_bytes(PACKAGE_NAME.to_owned(), module_bytes)
+        .unwrap_or_else(|_| panic!("{} modules failed to deserialize", PACKAGE_NAME))
+        .verify(vec![])
+        .unwrap_or_else(|_| panic!("{} modules failed to verify", PACKAGE_NAME))
+});
 
-        let mut module_bytes = vec![];
-        let mut verified_modules = vec![];
-        for (_, (bytes, module)) in modules.into_iter() {
-            verify_module(&module).expect("stdlib module failed to verify");
-            dependencies::verify_module(&module, &verified_modules)
-                .expect("stdlib module dependency failed to verify");
-            module_bytes.push(bytes);
-            verified_modules.push(module);
-        }
-        let modules_by_id: BTreeMap<_, _> = verified_modules
-            .iter()
-            .map(|module| (module.self_id(), module))
-            .collect();
-        for module in modules_by_id.values() {
-            cyclic_dependencies::verify_module(module, |module_id| {
-                Ok(modules_by_id
-                    .get(module_id)
-                    .expect("missing module in stdlib")
-                    .immediate_module_dependencies())
-            })
-            .expect("stdlib module has cyclic dependencies");
-        }
-        (module_bytes, verified_modules)
-    });
-
-/// An enum specifying whether the compiled stdlib/scripts should be used or freshly built versions
-/// should be used.
-#[derive(Debug, Eq, PartialEq)]
-pub enum StdLibOptions {
-    Compiled,
-    Fresh,
-}
-
-/// Return value of `stdlib_modules`. Gives a reference to the Compiled modules and a reference
-/// to the on disk bytes, if the `Compiled` option was used
-pub struct StdLibModules {
-    pub compiled_modules: &'static [CompiledModule],
-    pub bytes_opt: Option<&'static [Vec<u8>]>,
-}
-
-impl StdLibModules {
-    /// If bytes_opt is Some, returns an owned copy of the the types
-    /// If it is is None, it serializes `compiled_modules`
-    pub fn bytes_vec(&self) -> Vec<Vec<u8>> {
-        match self.bytes_opt {
-            Some(bytes) => bytes.to_vec(),
-            None => self
-                .compiled_modules
-                .iter()
-                .map(|m| {
-                    let mut bytes = vec![];
-                    m.serialize(&mut bytes).unwrap();
-                    bytes
-                })
-                .collect(),
-        }
-    }
-}
-
-/// Returns a reference to the standard library. Depending upon the `option` flag passed in
-/// either a compiled version of the standard library will be returned or a new freshly built stdlib
-/// will be used.
-/// For the `Compiled` option, both the on disk bytes and the deserialized modules will be returned
-/// For the `Fresh` option, only the compiled modules will be given as there are no serialized bytes
-/// to borrow and give a reference to
-pub fn stdlib_modules(option: StdLibOptions) -> StdLibModules {
-    match option {
-        StdLibOptions::Compiled => StdLibModules {
-            bytes_opt: Some(&*COMPILED_MOVELANG_STDLIB_WITH_BYTES.0),
-            compiled_modules: &*COMPILED_MOVELANG_STDLIB_WITH_BYTES.1,
-        },
-        StdLibOptions::Fresh => StdLibModules {
-            bytes_opt: None,
-            compiled_modules: &*FRESH_MOVELANG_STDLIB,
-        },
-    }
-}
-
-/// Returns a reference to the standard library built by move-lang compiler, compiled with the
-/// [default address](account_config::core_code_address).
-///
-/// The order the modules are presented in is important: later modules depend on earlier ones.
-/// The defualt is to return a compiled version of the stdlib unless it is otherwise specified by the
-/// `MOVE_NO_USE_COMPILED` environment variable.
-pub fn env_stdlib_modules() -> StdLibModules {
-    let option = if use_compiled() {
-        StdLibOptions::Compiled
-    } else {
-        StdLibOptions::Fresh
-    };
-    stdlib_modules(option)
-}
-
-/// A predicate detailing whether the compiled versions of scripts and the stdlib should be used or
-/// not. The default is that the compiled versions of the stdlib and transaction scripts should be
-/// used.
-pub fn use_compiled() -> bool {
-    std::env::var(NO_USE_COMPILED).is_err()
+/// Returns a reference to the standard library package.
+pub fn stdlib_modules() -> &'static VerifiedPackage {
+    &*PACKAGE_MOVELANG_STDLIB
 }

--- a/language/diem-tools/transaction-replay/src/unit_tests/mod.rs
+++ b/language/diem-tools/transaction-replay/src/unit_tests/mod.rs
@@ -5,7 +5,6 @@ mod bisection_tests;
 
 use crate::DiemValidatorInterface;
 use anyhow::{bail, Result};
-use compiled_stdlib::StdLibOptions;
 use diem_types::{
     account_address::AccountAddress,
     account_state::AccountState,
@@ -45,7 +44,7 @@ impl TestInterface {
     }
 
     pub fn genesis() -> Self {
-        let changeset = generate_genesis_change_set_for_testing(StdLibOptions::Compiled);
+        let changeset = generate_genesis_change_set_for_testing(/* use_fresh_modules */ false);
         let mut state_db = HashMap::new();
         for (ap, op) in changeset.write_set().iter() {
             match op {

--- a/language/diem-tools/writeset-transaction-generator/src/main.rs
+++ b/language/diem-tools/writeset-transaction-generator/src/main.rs
@@ -8,7 +8,7 @@ use diem_types::{
     transaction::{Transaction, WriteSetPayload},
 };
 
-use compiled_stdlib::{stdlib_modules as stdlib, StdLibModules, StdLibOptions};
+use compiled_stdlib::stdlib_modules as stdlib;
 use diem_writeset_generator::{
     create_release, encode_custom_script, encode_halt_network_payload,
     encode_remove_validators_payload, verify_release,
@@ -81,14 +81,9 @@ fn save_bytes(bytes: Vec<u8>, path: PathBuf) -> Result<()> {
 fn stdlib_modules() -> Vec<(Vec<u8>, CompiledModule)> {
     // Need to filter out Genesis module similiar to what is done in vmgenesis to make sure Genesis
     // module isn't published on-chain.
-    let StdLibModules {
-        bytes_opt,
-        compiled_modules,
-    } = stdlib(StdLibOptions::Compiled);
-    bytes_opt
-        .unwrap()
+    stdlib()
+        .bytes_and_modules()
         .iter()
-        .zip(compiled_modules)
         .filter(|(_bytes, module)| module.self_id().name().as_str() != GENESIS_MODULE_NAME)
         .map(|(bytes, module)| (bytes.clone(), module.clone()))
         .collect()

--- a/language/diem-tools/writeset-transaction-generator/src/release_flow/mod.rs
+++ b/language/diem-tools/writeset-transaction-generator/src/release_flow/mod.rs
@@ -13,21 +13,12 @@ pub use create::create_release;
 pub use verify::verify_release;
 
 pub mod test_utils {
-    use compiled_stdlib::{stdlib_modules, StdLibModules, StdLibOptions};
+    use compiled_stdlib::stdlib_modules;
     use diem_types::account_config::CORE_CODE_ADDRESS;
     use vm::{file_format::empty_module, CompiledModule};
 
     pub fn release_modules() -> Vec<(Vec<u8>, CompiledModule)> {
-        let StdLibModules {
-            bytes_opt,
-            compiled_modules,
-        } = stdlib_modules(StdLibOptions::Compiled);
-        let mut modules = bytes_opt
-            .unwrap()
-            .iter()
-            .cloned()
-            .zip(compiled_modules.iter().cloned())
-            .collect::<Vec<_>>();
+        let mut modules: Vec<_> = stdlib_modules().bytes_and_modules().to_vec();
         // Publish a new dummy module
         let mut module = empty_module();
         module.address_identifiers[0] = CORE_CODE_ADDRESS;

--- a/language/e2e-testsuite/src/tests/writeset_builder.rs
+++ b/language/e2e-testsuite/src/tests/writeset_builder.rs
@@ -42,8 +42,7 @@ fn build_upgrade_writeset() {
         |session| {
             session.set_diem_version(11);
         },
-        &[module_bytes],
-        &[module.clone()],
+        &[(module_bytes, module.clone())],
     );
 
     let writeset_txn = genesis_account

--- a/language/ir-testsuite/tests/testsuite.rs
+++ b/language/ir-testsuite/tests/testsuite.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use compiled_stdlib::{stdlib_modules, StdLibOptions};
+use compiled_stdlib::stdlib_modules;
 use diem_types::account_address::AccountAddress;
 use functional_tests::{
     compiler::{Compiler, ScriptOrModule},
@@ -62,11 +62,7 @@ impl Compiler for IRCompiler {
 
 fn run_test(path: &Path) -> datatest_stable::Result<()> {
     testsuite::functional_tests(
-        IRCompiler::new(
-            stdlib_modules(StdLibOptions::Compiled)
-                .compiled_modules
-                .to_vec(),
-        ),
+        IRCompiler::new(stdlib_modules().modules_iter().cloned().collect()),
         path,
     )
 }

--- a/language/move-package/Cargo.toml
+++ b/language/move-package/Cargo.toml
@@ -8,13 +8,8 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.38"
-include_dir = "0.6.0"
-once_cell = "1.4.1"
-sha2 = "0.9.3"
-
 bcs = "0.1.2"
 bytecode-verifier = { path = "../bytecode-verifier", version = "0.1.0" }
-diem-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 diem-types = { path = "../../types", version = "0.1.0" }
 diem-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 move-core-types = { path = "../move-core/types", version = "0.1.0" }

--- a/language/move-package/Cargo.toml
+++ b/language/move-package/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "move-package"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+publish = false
+edition = "2018"
+license = "Apache-2.0"
+
+[dependencies]
+anyhow = "1.0.38"
+include_dir = "0.6.0"
+once_cell = "1.4.1"
+sha2 = "0.9.3"
+
+bcs = "0.1.2"
+bytecode-verifier = { path = "../bytecode-verifier", version = "0.1.0" }
+diem-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+diem-types = { path = "../../types", version = "0.1.0" }
+diem-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
+move-core-types = { path = "../move-core/types", version = "0.1.0" }
+vm = { path = "../vm", version = "0.1.0" }
+
+[features]
+default = []
+fuzzing = ["diem-types/fuzzing"]

--- a/language/move-package/src/lib.rs
+++ b/language/move-package/src/lib.rs
@@ -1,0 +1,4 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod package;

--- a/language/move-package/src/package.rs
+++ b/language/move-package/src/package.rs
@@ -1,0 +1,128 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use std::collections::BTreeMap;
+
+use bytecode_verifier::{cyclic_dependencies, dependencies, verify_module};
+use diem_types::vm_status::StatusCode;
+use move_core_types::language_storage::ModuleId;
+use vm::{
+    access::ModuleAccess,
+    errors::{BinaryLoaderResult, Location, PartialVMError, VMResult},
+    file_format::CompiledModule,
+};
+
+pub struct CompiledPackage {
+    name: String,
+    modules_with_bytes: Vec<(Vec<u8>, CompiledModule)>,
+}
+
+#[derive(Clone)]
+pub struct VerifiedPackage {
+    name: String,
+    modules_with_bytes: Vec<(Vec<u8>, CompiledModule)>,
+    dependencies: Vec<VerifiedPackage>,
+}
+
+impl CompiledPackage {
+    pub fn from_bytes(
+        name: String,
+        module_bytes: impl IntoIterator<Item = Vec<u8>>,
+    ) -> BinaryLoaderResult<Self> {
+        let mut modules_with_bytes = vec![];
+        for bytes in module_bytes {
+            let module = CompiledModule::deserialize(&bytes)?;
+            modules_with_bytes.push((bytes, module));
+        }
+        Ok(Self {
+            name,
+            modules_with_bytes,
+        })
+    }
+
+    pub fn from_compilation(
+        name: String,
+        compiled_modules: impl IntoIterator<Item = CompiledModule>,
+    ) -> Result<Self> {
+        let mut modules_with_bytes = vec![];
+        for module in compiled_modules {
+            let mut bytes = vec![];
+            module.serialize(&mut bytes)?;
+            modules_with_bytes.push((bytes, module));
+        }
+        Ok(Self {
+            name,
+            modules_with_bytes,
+        })
+    }
+
+    pub fn verify(self, dependencies: Vec<VerifiedPackage>) -> VMResult<VerifiedPackage> {
+        fn collect_modules<'a>(
+            modules: &mut BTreeMap<ModuleId, &'a CompiledModule>,
+            package: &'a VerifiedPackage,
+        ) -> VMResult<()> {
+            for (_, module) in &package.modules_with_bytes {
+                if modules.insert(module.self_id(), module).is_some() {
+                    return Err(PartialVMError::new(StatusCode::DUPLICATE_MODULE_NAME)
+                        .finish(Location::Undefined));
+                }
+            }
+            for dep in &package.dependencies {
+                collect_modules(modules, dep)?;
+            }
+            Ok(())
+        }
+
+        let CompiledPackage {
+            name,
+            modules_with_bytes: compiled_modules_with_bytes,
+        } = self;
+
+        // per-module bytecode checking
+        let mut verified_modules_with_bytes = vec![];
+        for (bytes, module) in compiled_modules_with_bytes {
+            verify_module(&module)?;
+            verified_modules_with_bytes.push((bytes, module));
+        }
+
+        // linking/dependency checking
+        let mut all_modules = BTreeMap::new();
+        for (_, module) in &verified_modules_with_bytes {
+            if all_modules.insert(module.self_id(), module).is_some() {
+                return Err(PartialVMError::new(StatusCode::DUPLICATE_MODULE_NAME)
+                    .finish(Location::Undefined));
+            }
+        }
+        for dep in &dependencies {
+            collect_modules(&mut all_modules, dep)?;
+        }
+
+        for (_, module) in &verified_modules_with_bytes {
+            let imm_deps = module
+                .immediate_module_dependencies()
+                .into_iter()
+                .map(|module_id| {
+                    all_modules.get(&module_id).copied().ok_or_else(|| {
+                        PartialVMError::new(StatusCode::MISSING_DEPENDENCY)
+                            .finish(Location::Undefined)
+                    })
+                })
+                .collect::<VMResult<Vec<_>>>()?;
+            dependencies::verify_module(module, imm_deps.into_iter())?;
+
+            cyclic_dependencies::verify_module(module, |module_id| {
+                all_modules
+                    .get(module_id)
+                    .map(|dep| dep.immediate_module_dependencies())
+                    .ok_or_else(|| PartialVMError::new(StatusCode::MISSING_DEPENDENCY))
+            })?;
+        }
+
+        Ok(VerifiedPackage {
+            name,
+            modules_with_bytes: verified_modules_with_bytes,
+            dependencies,
+        })
+    }
+}

--- a/language/move-package/src/package.rs
+++ b/language/move-package/src/package.rs
@@ -126,3 +126,17 @@ impl CompiledPackage {
         })
     }
 }
+
+impl VerifiedPackage {
+    pub fn bytes_iter(&self) -> impl Iterator<Item = &Vec<u8>> {
+        self.modules_with_bytes.iter().map(|(bytes, _)| bytes)
+    }
+
+    pub fn modules_iter(&self) -> impl Iterator<Item = &CompiledModule> {
+        self.modules_with_bytes.iter().map(|(_, module)| module)
+    }
+
+    pub fn bytes_and_modules(&self) -> &[(Vec<u8>, CompiledModule)] {
+        self.modules_with_bytes.as_slice()
+    }
+}

--- a/language/testing-infra/e2e-tests/src/data_store.rs
+++ b/language/testing-infra/e2e-tests/src/data_store.rs
@@ -5,7 +5,6 @@
 
 use crate::account::AccountData;
 use anyhow::Result;
-use compiled_stdlib::StdLibOptions;
 use diem_state_view::StateView;
 use diem_types::{
     access_path::AccessPath,
@@ -26,10 +25,10 @@ use vm_genesis::generate_genesis_change_set_for_testing;
 
 /// Dummy genesis ChangeSet for testing
 pub static GENESIS_CHANGE_SET: Lazy<ChangeSet> =
-    Lazy::new(|| generate_genesis_change_set_for_testing(StdLibOptions::Compiled));
+    Lazy::new(|| generate_genesis_change_set_for_testing(false));
 
 pub static GENESIS_CHANGE_SET_FRESH: Lazy<ChangeSet> =
-    Lazy::new(|| generate_genesis_change_set_for_testing(StdLibOptions::Fresh));
+    Lazy::new(|| generate_genesis_change_set_for_testing(true));
 
 /// An in-memory implementation of [`StateView`] and [`RemoteCache`] for the VM.
 ///

--- a/language/testing-infra/functional-tests/Cargo.toml
+++ b/language/testing-infra/functional-tests/Cargo.toml
@@ -19,6 +19,7 @@ bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
 language-e2e-tests = { path = "../e2e-tests", version = "0.1.0" }
 diem-config = { path = "../../../config", version = "0.1.0", features = ["fuzzing"] }
 diem-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }
+diem-framework = { path = "../../diem-framework", version = "0.1.0" }
 diem-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 once_cell = "1.4.1"
 regex = { version = "1.4.3", default-features = false, features = ["std", "perf"] }

--- a/language/tools/genesis-viewer/src/main.rs
+++ b/language/tools/genesis-viewer/src/main.rs
@@ -1,7 +1,6 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use compiled_stdlib::StdLibOptions;
 use diem_types::{
     access_path::AccessPath,
     account_address::AccountAddress,
@@ -73,7 +72,8 @@ pub fn main() {
     // we default to `all`
     let arg_count = std::env::args().len();
     let args = Args::from_args();
-    let ws = vm_genesis::generate_genesis_change_set_for_testing(StdLibOptions::Compiled);
+    let ws =
+        vm_genesis::generate_genesis_change_set_for_testing(/* use_fresh_modules */ false);
     if args.all || arg_count == 3 {
         print_all(&ws);
     } else {

--- a/language/tools/resource-viewer/src/resolver.rs
+++ b/language/tools/resource-viewer/src/resolver.rs
@@ -6,7 +6,7 @@ use crate::{
     module_cache::ModuleCache,
 };
 use anyhow::{anyhow, Result};
-use compiled_stdlib::{stdlib_modules, StdLibOptions};
+use compiled_stdlib::stdlib_modules;
 use diem_types::account_address::AccountAddress;
 use move_core_types::{
     identifier::{IdentStr, Identifier},
@@ -32,8 +32,7 @@ impl<'a> Resolver<'a> {
     pub fn new(state: &'a dyn RemoteCache, use_stdlib: bool) -> Self {
         let cache = ModuleCache::new();
         if use_stdlib {
-            let modules = stdlib_modules(StdLibOptions::Compiled).compiled_modules;
-            for module in modules {
+            for module in stdlib_modules().modules_iter() {
                 cache.insert(module.self_id(), module.clone());
             }
         }

--- a/language/tools/vm-genesis/Cargo.toml
+++ b/language/tools/vm-genesis/Cargo.toml
@@ -18,6 +18,7 @@ bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
 bcs = "0.1.2"
 diem-config = { path = "../../../config", version = "0.1.0" }
 diem-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }
+diem-framework = { path = "../../diem-framework",  version = "0.1.0" }
 diem-state-view = { path = "../../../storage/state-view", version = "0.1.0" }
 diem-types = { path = "../../../types", version = "0.1.0" }
 diem-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }

--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -7,7 +7,6 @@ use crate::{
     AccountData, AccountStatus,
 };
 use anyhow::{bail, ensure, format_err, Error, Result};
-use compiled_stdlib::StdLibOptions;
 use compiler::Compiler;
 use diem_client::{views, WaitForTransactionError};
 use diem_crypto::{
@@ -639,7 +638,9 @@ impl ClientProxy {
         match self.diem_root_account {
             Some(_) => self.association_transaction_with_local_diem_root_account(
                 TransactionPayload::WriteSet(WriteSetPayload::Direct(
-                    transaction_builder::encode_stdlib_upgrade_transaction(StdLibOptions::Fresh),
+                    transaction_builder::encode_stdlib_upgrade_transaction(
+                        /* use_fresh_modules */ true,
+                    ),
                 )),
                 is_blocking,
             ),

--- a/testsuite/smoke-test/src/release_flow.rs
+++ b/testsuite/smoke-test/src/release_flow.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::test_utils::{diem_swarm_utils::get_json_rpc_url, setup_swarm_and_client_proxy};
-use compiled_stdlib::{stdlib_modules, StdLibModules, StdLibOptions};
+use compiled_stdlib::stdlib_modules;
 use diem_types::{chain_id::ChainId, transaction::TransactionPayload};
 use diem_validator_interface::{DiemValidatorInterface, JsonRpcDebuggerInterface};
 use diem_writeset_generator::{
@@ -17,16 +17,7 @@ fn test_move_release_flow() {
     let validator_interface = JsonRpcDebuggerInterface::new(&url).unwrap();
 
     let chain_id = ChainId::test();
-    let StdLibModules {
-        bytes_opt: old_modules_bytes,
-        compiled_modules: old_compiled_modules,
-    } = stdlib_modules(StdLibOptions::Compiled);
-    let old_modules = old_modules_bytes
-        .unwrap()
-        .iter()
-        .cloned()
-        .zip(old_compiled_modules.iter().cloned())
-        .collect::<Vec<_>>();
+    let old_modules = stdlib_modules().bytes_and_modules();
 
     let release_modules = release_modules();
 
@@ -42,7 +33,7 @@ fn test_move_release_flow() {
     // Verifying the generated payload against release modules should pass.
     verify_release(chain_id, url.clone(), &payload_1, &release_modules).unwrap();
     // Verifying the generated payload against older modules should pass due to hash mismatch.
-    assert!(verify_release(chain_id, url.clone(), &payload_1, &old_modules).is_err());
+    assert!(verify_release(chain_id, url.clone(), &payload_1, old_modules).is_err());
 
     // Commit the release
     client


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Experimental code on grouping several modules together and carry them over in the codebase. Also (hopefully) in preparation when `move-stdlib` is separated from the `diem-framework` and both become independent Move packages.

A `CompiledPackage` maintains the consistency of the raw bytes and the `CompiledModule`, and can be created in two ways:
- `from_bytes` to load existing, on-disk `CompiledModule` (and subject to deserialization and bound checks).
- `from_compilation` to load freshly compiled modules.

A `VerifiedPackage` can only be created by destructing a `CompiledPackage` and verify all its modules against the given dependencies, i.e., following the same flow of bytecode verifier checks.

NOTE: I hate to create a new Cargo.toml file for this simple code but I failed to find a proper location in the `language/` directory...

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Not quite needed as of now.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/master/developers.diem.com, and link to your PR here.)
