### PR TITLE
[language][vm] make execute_function return values (in serialized format)

### DIFF
--- a/language/diem-tools/writeset-transaction-generator/src/writeset_builder.rs
+++ b/language/diem-tools/writeset-transaction-generator/src/writeset_builder.rs
@@ -57,7 +57,7 @@ impl<'r, 'l, R: RemoteCache> GenesisSession<'r, 'l, R> {
                     function_name,
                     e.into_vm_status()
                 )
-            })
+            });
     }
 
     pub fn exec_script(&mut self, sender: AccountAddress, script: &Script) {

--- a/language/diem-vm/src/diem_transaction_executor.rs
+++ b/language/diem-vm/src/diem_transaction_executor.rs
@@ -444,6 +444,7 @@ impl DiemVM {
                 &mut cost_strategy,
                 log_context,
             )
+            .map(|_return_vals| ())
             .or_else(|e| {
                 expect_only_successful_execution(e, BLOCK_PROLOGUE.as_str(), log_context)
             })?;

--- a/language/diem-vm/src/diem_vm.rs
+++ b/language/diem-vm/src/diem_vm.rs
@@ -239,6 +239,7 @@ impl DiemVMImpl {
                 cost_strategy,
                 log_context,
             )
+            .map(|_return_vals| ())
             .map_err(|err| expect_no_verification_errors(err, log_context))
             .or_else(|err| convert_prologue_error(err, log_context))
     }
@@ -278,6 +279,7 @@ impl DiemVMImpl {
                 cost_strategy,
                 log_context,
             )
+            .map(|_return_vals| ())
             .map_err(|err| expect_no_verification_errors(err, log_context))
             .or_else(|err| convert_prologue_error(err, log_context))
     }
@@ -319,6 +321,7 @@ impl DiemVMImpl {
                 cost_strategy,
                 log_context,
             )
+            .map(|_return_vals| ())
             .map_err(|err| expect_no_verification_errors(err, log_context))
             .or_else(|err| convert_epilogue_error(err, log_context))
     }
@@ -354,6 +357,7 @@ impl DiemVMImpl {
                 cost_strategy,
                 log_context,
             )
+            .map(|_return_vals| ())
             .map_err(|err| expect_no_verification_errors(err, log_context))
             .or_else(|e| {
                 expect_only_successful_execution(e, USER_EPILOGUE_NAME.as_str(), log_context)
@@ -390,6 +394,7 @@ impl DiemVMImpl {
                 &mut cost_strategy,
                 log_context,
             )
+            .map(|_return_vals| ())
             .map_err(|err| expect_no_verification_errors(err, log_context))
             .or_else(|err| convert_prologue_error(err, log_context))
     }
@@ -418,6 +423,7 @@ impl DiemVMImpl {
                 &mut cost_strategy,
                 log_context,
             )
+            .map(|_return_vals| ())
             .map_err(|err| expect_no_verification_errors(err, log_context))
             .or_else(|e| {
                 expect_only_successful_execution(e, WRITESET_EPILOGUE_NAME.as_str(), log_context)

--- a/language/move-vm/integration-tests/src/tests/function_arg_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/function_arg_tests.rs
@@ -76,7 +76,9 @@ fn run(
         args,
         &mut cost_strategy,
         &context,
-    )
+    )?;
+
+    Ok(())
 }
 
 fn expect_err(params: &[&str], args: Vec<MoveValue>, expected_status: StatusCode) {

--- a/language/move-vm/integration-tests/src/tests/mod.rs
+++ b/language/move-vm/integration-tests/src/tests/mod.rs
@@ -6,3 +6,4 @@ mod bad_storage_tests;
 mod function_arg_tests;
 mod loader_tests;
 mod mutated_accounts_tests;
+mod return_value_tests;

--- a/language/move-vm/integration-tests/src/tests/return_value_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/return_value_tests.rs
@@ -1,0 +1,140 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::compiler::{as_module, compile_units};
+use move_core_types::{
+    account_address::AccountAddress,
+    gas_schedule::{GasAlgebra, GasUnits},
+    identifier::Identifier,
+    language_storage::{ModuleId, TypeTag},
+    value::{MoveTypeLayout, MoveValue},
+    vm_status::StatusCode,
+};
+use move_vm_runtime::{logging::NoContextLog, move_vm::MoveVM};
+use move_vm_test_utils::InMemoryStorage;
+use move_vm_types::gas_schedule::{zero_cost_schedule, CostStrategy};
+use vm::errors::VMResult;
+
+const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGTH]);
+
+fn run(
+    structs: &[&str],
+    fun_sig: &str,
+    fun_body: &str,
+    ty_args: Vec<TypeTag>,
+    args: Vec<MoveValue>,
+) -> VMResult<Vec<Vec<u8>>> {
+    let structs = structs.to_vec().join("\n");
+
+    let code = format!(
+        r#"
+        module M {{
+            {}
+
+            fun foo{} {{
+                {}
+            }}
+        }}
+    "#,
+        structs, fun_sig, fun_body
+    );
+
+    let mut units = compile_units(TEST_ADDR, &code).unwrap();
+    let m = as_module(units.pop().unwrap());
+    let mut blob = vec![];
+    m.serialize(&mut blob).unwrap();
+
+    let mut storage = InMemoryStorage::new();
+    let module_id = ModuleId::new(TEST_ADDR, Identifier::new("M").unwrap());
+    storage.publish_or_overwrite_module(module_id.clone(), blob);
+
+    let vm = MoveVM::new();
+    let mut sess = vm.new_session(&storage);
+
+    let fun_name = Identifier::new("foo").unwrap();
+    let cost_table = zero_cost_schedule();
+    let mut cost_strategy = CostStrategy::system(&cost_table, GasUnits::new(0));
+    let context = NoContextLog::new();
+
+    let args: Vec<_> = args
+        .into_iter()
+        .map(|val| val.simple_serialize().unwrap())
+        .collect();
+
+    let return_vals = sess.execute_function(
+        &module_id,
+        &fun_name,
+        ty_args,
+        args,
+        &mut cost_strategy,
+        &context,
+    )?;
+
+    Ok(return_vals)
+}
+
+fn expect_success(
+    structs: &[&str],
+    fun_sig: &str,
+    fun_body: &str,
+    ty_args: Vec<TypeTag>,
+    args: Vec<MoveValue>,
+    expected_layouts: &[MoveTypeLayout],
+) {
+    let return_vals = run(structs, fun_sig, fun_body, ty_args, args).unwrap();
+    assert!(return_vals.len() == expected_layouts.len());
+
+    for (blob, layout) in return_vals.iter().zip(expected_layouts.iter()) {
+        MoveValue::simple_deserialize(blob, layout).unwrap();
+    }
+}
+
+fn expect_failure(
+    structs: &[&str],
+    fun_sig: &str,
+    fun_body: &str,
+    ty_args: Vec<TypeTag>,
+    args: Vec<MoveValue>,
+    expected_status: StatusCode,
+) {
+    assert_eq!(
+        run(structs, fun_sig, fun_body, ty_args, args)
+            .unwrap_err()
+            .major_status(),
+        expected_status
+    );
+}
+
+#[test]
+fn return_nothing() {
+    expect_success(&[], "()", "", vec![], vec![], &[])
+}
+
+#[test]
+fn return_u64() {
+    expect_success(&[], "(): u64", "42", vec![], vec![], &[MoveTypeLayout::U64])
+}
+
+#[test]
+fn return_u64_bool() {
+    expect_success(
+        &[],
+        "(): (u64, bool)",
+        "(42, true)",
+        vec![],
+        vec![],
+        &[MoveTypeLayout::U64, MoveTypeLayout::Bool],
+    )
+}
+
+#[test]
+fn return_signer_ref() {
+    expect_failure(
+        &[],
+        "(s: &signer): &signer",
+        "s",
+        vec![],
+        vec![MoveValue::Signer(TEST_ADDR)],
+        StatusCode::INTERNAL_TYPE_ERROR,
+    )
+}

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -243,7 +243,7 @@ impl VMRuntime {
             .create_signers_and_arguments(&params, senders, args)
             .map_err(|err| err.finish(Location::Undefined))?;
         // run the script
-        Interpreter::entrypoint(
+        let return_vals = Interpreter::entrypoint(
             main,
             ty_args,
             signers_and_args,
@@ -251,7 +251,97 @@ impl VMRuntime {
             cost_strategy,
             &self.loader,
             log_context,
-        )
+        )?;
+
+        if !return_vals.is_empty() {
+            return Err(
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                    .with_message(
+                        "scripts cannot have return values -- this should not happen".to_string(),
+                    )
+                    .finish(Location::Undefined),
+            );
+        }
+
+        Ok(())
+    }
+
+    fn execute_function_impl<F>(
+        &self,
+        module: &ModuleId,
+        function_name: &IdentStr,
+        ty_args: Vec<TypeTag>,
+        make_args: F,
+        is_script_execution: bool,
+        data_store: &mut impl DataStore,
+        cost_strategy: &mut CostStrategy,
+        log_context: &impl LogContext,
+    ) -> VMResult<Vec<Vec<u8>>>
+    where
+        F: FnOnce(&VMRuntime, &[Type]) -> PartialVMResult<Vec<Value>>,
+    {
+        let (func, ty_args, params, return_tys) = self.loader.load_function(
+            function_name,
+            module,
+            &ty_args,
+            is_script_execution,
+            data_store,
+            log_context,
+        )?;
+
+        let return_layouts = return_tys
+            .iter()
+            .map(|ty| {
+                self.loader.type_to_type_layout(ty).map_err(|_err| {
+                    PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
+                        .with_message(
+                            "cannot be called with non-serializable return type".to_string(),
+                        )
+                        .finish(Location::Undefined)
+                })
+            })
+            .collect::<VMResult<Vec<_>>>()?;
+
+        let params = params
+            .into_iter()
+            .map(|ty| ty.subst(&ty_args))
+            .collect::<PartialVMResult<Vec<_>>>()
+            .map_err(|err| err.finish(Location::Undefined))?;
+
+        let args = make_args(self, &params).map_err(|err| err.finish(Location::Undefined))?;
+
+        let return_vals = Interpreter::entrypoint(
+            func,
+            ty_args,
+            args,
+            data_store,
+            cost_strategy,
+            &self.loader,
+            log_context,
+        )?;
+
+        if return_layouts.len() != return_vals.len() {
+            return Err(
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                    .with_message(format!(
+                        "declared {} return types, but got {} return values",
+                        return_layouts.len(),
+                        return_vals.len()
+                    ))
+                    .finish(Location::Undefined),
+            );
+        }
+
+        let mut serialized_vals = vec![];
+        for (val, layout) in return_vals.into_iter().zip(return_layouts.iter()) {
+            serialized_vals.push(val.simple_serialize(&layout).ok_or_else(|| {
+                PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
+                    .with_message("failed to serialize return values".to_string())
+                    .finish(Location::Undefined)
+            })?)
+        }
+
+        Ok(serialized_vals)
     }
 
     // See Session::execute_script_function for what contracts to follow.
@@ -265,28 +355,15 @@ impl VMRuntime {
         data_store: &mut impl DataStore,
         cost_strategy: &mut CostStrategy,
         log_context: &impl LogContext,
-    ) -> VMResult<()> {
-        let (func, ty_args, params) = self.loader.load_function(
-            function_name,
+    ) -> VMResult<Vec<Vec<u8>>> {
+        self.execute_function_impl(
             module,
-            &ty_args,
-            true, // is_script_execution
-            data_store,
-            log_context,
-        )?;
-
-        let signers_and_args = self
-            .create_signers_and_arguments(&params, senders, args)
-            .map_err(|err| err.finish(Location::Undefined))?;
-
-        // run the function
-        Interpreter::entrypoint(
-            func,
+            function_name,
             ty_args,
-            signers_and_args,
+            move |runtime, params| runtime.create_signers_and_arguments(params, senders, args),
+            true,
             data_store,
             cost_strategy,
-            &self.loader,
             log_context,
         )
     }
@@ -301,37 +378,15 @@ impl VMRuntime {
         data_store: &mut impl DataStore,
         cost_strategy: &mut CostStrategy,
         log_context: &impl LogContext,
-    ) -> VMResult<()> {
-        // load the function in the given module, perform verification of the module and
-        // its dependencies if the module was not loaded
-        let (func, ty_args, params) = self.loader.load_function(
-            function_name,
+    ) -> VMResult<Vec<Vec<u8>>> {
+        self.execute_function_impl(
             module,
-            &ty_args,
-            false, // is_script_execution
-            data_store,
-            log_context,
-        )?;
-
-        let params = params
-            .into_iter()
-            .map(|ty| ty.subst(&ty_args))
-            .collect::<PartialVMResult<Vec<_>>>()
-            .map_err(|err| err.finish(Location::Undefined))?;
-
-        // check the arguments provided are of restricted types
-        let args = self
-            .deserialize_args(&params, args)
-            .map_err(|err| err.finish(Location::Undefined))?;
-
-        // run the function
-        Interpreter::entrypoint(
-            func,
+            function_name,
             ty_args,
-            args,
+            move |runtime, params| runtime.deserialize_args(params, args),
+            false,
             data_store,
             cost_strategy,
-            &self.loader,
             log_context,
         )
     }

--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -44,7 +44,7 @@ impl<'r, 'l, R: RemoteCache> Session<'r, 'l, R> {
         args: Vec<Vec<u8>>,
         cost_strategy: &mut CostStrategy,
         log_context: &impl LogContext,
-    ) -> VMResult<()> {
+    ) -> VMResult<Vec<Vec<u8>>> {
         self.runtime.execute_function(
             module,
             function_name,
@@ -89,7 +89,7 @@ impl<'r, 'l, R: RemoteCache> Session<'r, 'l, R> {
         senders: Vec<AccountAddress>,
         cost_strategy: &mut CostStrategy,
         log_context: &impl LogContext,
-    ) -> VMResult<()> {
+    ) -> VMResult<Vec<Vec<u8>>> {
         self.runtime.execute_script_function(
             module,
             function_name,

--- a/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
@@ -298,7 +298,8 @@ fn call_script_function_with_args_ty_args_signers(
         signers,
         &mut cost_strategy,
         &log_context,
-    )
+    )?;
+    Ok(())
 }
 
 fn call_script_function(

--- a/language/testing-infra/test-generation/src/lib.rs
+++ b/language/testing-infra/test-generation/src/lib.rs
@@ -131,7 +131,8 @@ fn execute_function_in_module<S: StateView>(
                     &mut cost_strategy,
                     &log_context,
                 )
-                .map_err(|e| e.into_vm_status())
+                .map_err(|e| e.into_vm_status())?;
+            Ok(())
         })
     }
 }

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -191,7 +191,7 @@ fn exec_function(
                 function_name,
                 e.into_vm_status()
             )
-        })
+        });
 }
 
 fn exec_script(


### PR DESCRIPTION
This allows `execute_function` to return values in serialized format, which will make it easier for the adapter to query Move states.