### PR TITLE
[transaction builder generator] make python test ready for CI

### DIFF
--- a/language/transaction-builder/generator/tests/cli.rs
+++ b/language/transaction-builder/generator/tests/cli.rs
@@ -12,7 +12,7 @@ fn test_examples_in_readme() -> std::io::Result<()> {
     let file = std::io::BufReader::new(std::fs::File::open("README.md")?);
     let quotes = get_bash_quotes(file)?;
     // Check that we have the expected number of examples starting with "```bash".
-    assert_eq!(quotes.len(), 9);
+    assert_eq!(quotes.len(), 10);
 
     let mut quotes = quotes.into_iter();
 


### PR DESCRIPTION
## Motivation

I had to make a few fixes in preparation of https://github.com/diem/diem/pull/7635 (adding CI to Move Sdk).
This PR lands them early on while we are figuring out what to do with CI.

The pyre fix is similar to https://github.com/novifinancial/serde-reflection/pull/83

## Test Plan

On my laptop:
```
cargo test -p transaction-builder-generator -- --ignored
```

Tested in CI as part of https://github.com/diem/diem/pull/7635