### PR TITLE
[Vault Storage] Make the vault client support configurable timeouts

### DIFF
--- a/config/management/network-address-encryption/src/lib.rs
+++ b/config/management/network-address-encryption/src/lib.rs
@@ -275,6 +275,8 @@ mod tests {
             None,
             None,
             true,
+            None,
+            None,
         ));
         let mut encryptor = Encryptor::new(storage);
         encryptor.initialize().unwrap();

--- a/config/management/src/config.rs
+++ b/config/management/src/config.rs
@@ -178,6 +178,8 @@ mod tests {
                 token: Token::FromConfig("test".to_string()),
                 renew_ttl_secs: None,
                 disable_cas: None,
+                connection_timeout_ms: None,
+                response_timeout_ms: None,
             }),
             validator_backend: SecureBackend::Vault(VaultConfig {
                 namespace: None,
@@ -186,6 +188,8 @@ mod tests {
                 token: Token::FromConfig("test".to_string()),
                 renew_ttl_secs: None,
                 disable_cas: None,
+                connection_timeout_ms: None,
+                response_timeout_ms: None,
             }),
         };
 

--- a/config/management/src/secure_backend.rs
+++ b/config/management/src/secure_backend.rs
@@ -116,6 +116,8 @@ impl TryInto<config::SecureBackend> for SecureBackend {
                     token: Token::FromDisk(PathBuf::from(token)),
                     renew_ttl_secs: None,
                     disable_cas: Some(true),
+                    connection_timeout_ms: None,
+                    response_timeout_ms: None,
                 })
             }
             _ => panic!("Invalid backend: {}", self.backend),

--- a/consensus/safety-rules/benches/safety_rules.rs
+++ b/consensus/safety-rules/benches/safety_rules.rs
@@ -124,14 +124,7 @@ fn vault(n: u64) {
     let signer = ValidatorSigner::from_int(0);
     let waypoint = test_utils::validator_signers_to_waypoint(&[&signer]);
 
-    let mut storage = VaultStorage::new(
-        VAULT_HOST.to_string(),
-        VAULT_TOKEN.to_string(),
-        None,
-        None,
-        None,
-        true,
-    );
+    let mut storage = create_vault_storage();
     storage.reset_and_clear().unwrap();
 
     let storage = PersistentSafetyStorage::initialize(
@@ -153,14 +146,7 @@ pub fn benchmark(c: &mut Criterion) {
     let duration_secs = 5;
     let samples = 10;
 
-    let storage = VaultStorage::new(
-        VAULT_HOST.to_string(),
-        VAULT_TOKEN.to_string(),
-        None,
-        None,
-        None,
-        true,
-    );
+    let storage = create_vault_storage();
 
     let enable_vault = if storage.available().is_err() {
         println!(
@@ -184,6 +170,19 @@ pub fn benchmark(c: &mut Criterion) {
     if enable_vault {
         group.bench_function("Vault", |b| b.iter(|| vault(black_box(count))));
     }
+}
+
+fn create_vault_storage() -> VaultStorage {
+    VaultStorage::new(
+        VAULT_HOST.to_string(),
+        VAULT_TOKEN.to_string(),
+        None,
+        None,
+        None,
+        true,
+        None,
+        None,
+    )
 }
 
 criterion_group!(benches, benchmark);

--- a/consensus/safety-rules/src/tests/vault.rs
+++ b/consensus/safety-rules/src/tests/vault.rs
@@ -40,6 +40,8 @@ fn safety_rules(
             None,
             None,
             true,
+            None,
+            None,
         ));
         storage.reset_and_clear().unwrap();
 

--- a/secure/storage/src/vault.rs
+++ b/secure/storage/src/vault.rs
@@ -48,9 +48,17 @@ impl VaultStorage {
         certificate: Option<String>,
         renew_ttl_secs: Option<u32>,
         use_cas: bool,
+        connection_timeout_ms: Option<u64>,
+        response_timeout_ms: Option<u64>,
     ) -> Self {
         Self {
-            client: Client::new(host, token, certificate),
+            client: Client::new(
+                host,
+                token,
+                certificate,
+                connection_timeout_ms,
+                response_timeout_ms,
+            ),
             time_service: TimeService::real(),
             namespace,
             renew_ttl_secs,

--- a/secure/storage/vault/src/dev.rs
+++ b/secure/storage/vault/src/dev.rs
@@ -119,7 +119,13 @@ impl VaultRunner {
     }
 
     pub fn client(&self) -> Client {
-        Client::new(self.host().to_string(), self.root_token().to_string(), None)
+        Client::new(
+            self.host().to_string(),
+            self.root_token().to_string(),
+            None,
+            None,
+            None,
+        )
     }
 }
 
@@ -141,7 +147,7 @@ fn run_vault() {
 #[test]
 fn run_test_vault() {
     if let Some(host) = test_host_safe() {
-        Client::new(host, ROOT_TOKEN.to_string(), None)
+        Client::new(host, ROOT_TOKEN.to_string(), None, None, None)
             .unsealed()
             .unwrap();
     }

--- a/secure/storage/vault/src/lib.rs
+++ b/secure/storage/vault/src/lib.rs
@@ -27,9 +27,9 @@ pub mod fuzzing;
 /// Keys are trimmed in FIFO order.
 const MAX_NUM_KEY_VERSIONS: u32 = 4;
 
-/// Request timeouts for vault operations.
-const CONNECT_TIMEOUT_MILLISECS: u64 = 10_000;
-const TIMEOUT_MILLISECS: u64 = 10_000;
+/// Default request timeouts for vault operations.
+const DEFAULT_CONNECTION_TIMEOUT_MS: u64 = 10_000;
+const DEFAULT_RESPONSE_TIMEOUT_MS: u64 = 10_000;
 
 #[derive(Debug, Error, PartialEq)]
 pub enum Error {
@@ -108,10 +108,21 @@ pub struct Client {
     host: String,
     token: String,
     tls_connector: Arc<native_tls::TlsConnector>,
+
+    /// Timeout for new socket connections to vault.
+    connection_timeout_ms: u64,
+    /// Timeout for generic vault responses (e.g., reads and writes).
+    response_timeout_ms: u64,
 }
 
 impl Client {
-    pub fn new(host: String, token: String, ca_certificate: Option<String>) -> Self {
+    pub fn new(
+        host: String,
+        token: String,
+        ca_certificate: Option<String>,
+        connection_timeout_ms: Option<u64>,
+        response_timeout_ms: Option<u64>,
+    ) -> Self {
         let mut tls_builder = native_tls::TlsConnector::builder();
         tls_builder.min_protocol_version(Some(native_tls::Protocol::Tlsv12));
         if let Some(certificate) = ca_certificate {
@@ -124,11 +135,16 @@ impl Client {
         }
         let tls_connector = Arc::new(tls_builder.build().unwrap());
 
+        let connection_timeout_ms = connection_timeout_ms.unwrap_or(DEFAULT_CONNECTION_TIMEOUT_MS);
+        let response_timeout_ms = response_timeout_ms.unwrap_or(DEFAULT_RESPONSE_TIMEOUT_MS);
+
         Self {
             agent: ureq::Agent::new().set("connection", "keep-alive").build(),
             host,
             token,
             tls_connector,
+            connection_timeout_ms,
+            response_timeout_ms,
         }
     }
 
@@ -456,8 +472,8 @@ impl Client {
     }
 
     fn upgrade_request_without_token(&self, mut request: ureq::Request) -> ureq::Request {
-        request.timeout_connect(CONNECT_TIMEOUT_MILLISECS);
-        request.timeout(Duration::from_millis(TIMEOUT_MILLISECS));
+        request.timeout_connect(self.connection_timeout_ms);
+        request.timeout(Duration::from_millis(self.response_timeout_ms));
         request.set_tls_connector(self.tls_connector.clone());
         request
     }

--- a/testsuite/cluster-test/src/cluster_builder.rs
+++ b/testsuite/cluster-test/src/cluster_builder.rs
@@ -370,6 +370,8 @@ impl ClusterBuilder {
                 None,
                 None,
                 true,
+                None,
+                None,
             ));
             if validator_index == 0 {
                 vault_storage.create_key(DIEM_ROOT_KEY).map_err(|e| {


### PR DESCRIPTION
## Motivation

This PR updates the vault client to support configurable timeouts for: (i) creating new connections to vault; and (ii) performing vault operations (e.g., reading and writing data).  The values chosen for these timeouts can now be specified in the various component config files (e.g., key manager and safety rules configs), however, they aren't required. If no values are provided for these timeouts, the default timeout value will be chosen (as hard coded in the vault client).

This change relates to the ongoing investigation into transient vault outages we're seeing for safety rules requests (https://github.com/diem/partners/issues/727). With this PR, we'll be able to reduce the timeouts in the future and thus avoid having the vault client hang for too long (rather, it should now timeout more quickly on a failed request).

Notes:
- The default timeout values have not been changed in this PR, they are still set at 10 seconds.
- This PR does not expose these configurable timeouts for the operational management tools. These tools shouldn't need to change the timeouts.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally, including the newly added one for backend config parsing.

## Related PRs

This relates to an issue we're seeing with transient vault outages for safety rules (https://github.com/diem/partners/issues/727)
