### PR TITLE
[move-prover] Upgrade immutable ref elimination to new tools in v2

### DIFF
--- a/language/move-prover/bytecode/src/function_data_builder.rs
+++ b/language/move-prover/bytecode/src/function_data_builder.rs
@@ -69,9 +69,8 @@ impl<'env> FunctionDataBuilder<'env> {
         self.current_loc = loc;
     }
 
-    /// Sets the default location as well as information about verification conditions
-    /// at this location. The later is stored in the global environment where it can later be
-    /// retrieved based on location when mapping verification failures back to source level.
+    /// Sets the default location as well as information about the verification condition
+    /// message associated with the next instruction generated with `emit_with`.
     pub fn set_loc_and_vc_info(&mut self, loc: Loc, message: &str) {
         self.next_vc_info = Some(message.to_string());
         self.set_loc(loc);

--- a/language/move-prover/bytecode/tests/borrow/basic_test.exp
+++ b/language/move-prover/bytecode/tests/borrow/basic_test.exp
@@ -535,7 +535,7 @@ fun TestBorrow::test7($t0|b: bool) {
      # moved_nodes: LocalRoot($t0)
      # borrowed_by: LocalRoot($t1) -> {Reference($t3)}
      # borrows_from: Reference($t3) -> {LocalRoot($t1)}
-  8: goto 13
+  8: goto 12
      # live_nodes: LocalRoot($t4), Reference($t3)
      # moved_nodes: LocalRoot($t0)
      # borrowed_by: LocalRoot($t1) -> {Reference($t3)}
@@ -555,37 +555,32 @@ fun TestBorrow::test7($t0|b: bool) {
      # moved_nodes: LocalRoot($t0)
      # borrowed_by: LocalRoot($t1) -> {Reference($t3)}, LocalRoot($t2) -> {Reference($t3)}
      # borrows_from: Reference($t3) -> {LocalRoot($t1), LocalRoot($t2)}
- 12: goto 13
+ 12: label L2
      # live_nodes: LocalRoot($t4), Reference($t3)
      # moved_nodes: LocalRoot($t0)
      # borrowed_by: LocalRoot($t1) -> {Reference($t3)}, LocalRoot($t2) -> {Reference($t3)}
      # borrows_from: Reference($t3) -> {LocalRoot($t1), LocalRoot($t2)}
- 13: label L2
+ 13: $t7 := 0
      # live_nodes: LocalRoot($t4), Reference($t3)
      # moved_nodes: LocalRoot($t0)
      # borrowed_by: LocalRoot($t1) -> {Reference($t3)}, LocalRoot($t2) -> {Reference($t3)}
      # borrows_from: Reference($t3) -> {LocalRoot($t1), LocalRoot($t2)}
- 14: $t7 := 0
+ 14: $t8 := read_ref($t3)
      # live_nodes: LocalRoot($t4), Reference($t3)
      # moved_nodes: LocalRoot($t0)
      # borrowed_by: LocalRoot($t1) -> {Reference($t3)}, LocalRoot($t2) -> {Reference($t3)}
      # borrows_from: Reference($t3) -> {LocalRoot($t1), LocalRoot($t2)}
- 15: $t8 := read_ref($t3)
+ 15: $t8 := TestBorrow::test3($t8, $t7)
      # live_nodes: LocalRoot($t4), Reference($t3)
      # moved_nodes: LocalRoot($t0)
      # borrowed_by: LocalRoot($t1) -> {Reference($t3)}, LocalRoot($t2) -> {Reference($t3)}
      # borrows_from: Reference($t3) -> {LocalRoot($t1), LocalRoot($t2)}
- 16: $t8 := TestBorrow::test3($t8, $t7)
-     # live_nodes: LocalRoot($t4), Reference($t3)
-     # moved_nodes: LocalRoot($t0)
-     # borrowed_by: LocalRoot($t1) -> {Reference($t3)}, LocalRoot($t2) -> {Reference($t3)}
-     # borrows_from: Reference($t3) -> {LocalRoot($t1), LocalRoot($t2)}
- 17: write_ref($t3, $t8)
+ 16: write_ref($t3, $t8)
      # live_nodes: LocalRoot($t4)
      # moved_nodes: LocalRoot($t0)
      # borrowed_by: LocalRoot($t1) -> {Reference($t3)}, LocalRoot($t2) -> {Reference($t3)}
      # borrows_from: Reference($t3) -> {LocalRoot($t1), LocalRoot($t2)}
- 18: return ()
+ 17: return ()
 }
 
 
@@ -658,277 +653,259 @@ fun TestBorrow::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: TestBorrow::R): TestBo
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
-     # borrowed_by: LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
-     # borrows_from: Reference($t5) -> {LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
-  9: goto 10
+     # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
+     # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
+  9: label L7
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 10: label L7
+ 10: $t12 := 0
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 11: $t12 := 0
+ 11: $t13 := <($t12, $t7)
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 12: $t13 := <($t12, $t7)
+ 12: if ($t13) goto 15 else goto 13
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 13: if ($t13) goto 16 else goto 14
+ 13: label L1
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 14: label L1
+ 14: goto 33
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 15: goto 35
+ 15: label L0
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 16: label L0
-     # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
-     # unchecked_nodes: LocalRoot($t8), Reference($t9)
-     # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
-     # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
-     # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 17: destroy($t5)
+ 16: destroy($t5)
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 18: $t14 := 2
+ 17: $t14 := 2
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 19: $t15 := /($t7, $t14)
+ 18: $t15 := /($t7, $t14)
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 20: $t16 := 0
+ 19: $t16 := 0
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 21: $t17 := ==($t15, $t16)
+ 20: $t17 := ==($t15, $t16)
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 22: if ($t17) goto 25 else goto 23
+ 21: if ($t17) goto 24 else goto 22
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 23: label L4
+ 22: label L4
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 24: goto 28
+ 23: goto 27
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 25: label L3
+ 24: label L3
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 26: $t5 := borrow_local($t3)
+ 25: $t5 := borrow_local($t3)
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 27: goto 31
+ 26: goto 29
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 28: label L5
+ 27: label L5
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 29: $t5 := borrow_local($t4)
+ 28: $t5 := borrow_local($t4)
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 30: goto 31
+ 29: label L6
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 31: label L6
+ 30: $t18 := 1
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 32: $t18 := 1
+ 31: $t7 := -($t7, $t18)
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 33: $t7 := -($t7, $t18)
+ 32: goto 9
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 34: goto 10
+ 33: label L2
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 35: label L2
+ 34: if ($t6) goto 37 else goto 35
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 36: if ($t6) goto 39 else goto 37
+ 35: label L9
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 37: label L9
+ 36: goto 44
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 38: goto 46
+ 37: label L8
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 39: label L8
-     # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
-     # unchecked_nodes: LocalRoot($t8), Reference($t9)
-     # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
-     # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
-     # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 40: destroy($t5)
+ 38: destroy($t5)
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 41: $t19 := 0
+ 39: $t19 := 0
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 42: $t20 := read_ref($t9)
+ 40: $t20 := read_ref($t9)
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 43: $t20 := TestBorrow::test3($t20, $t19)
+ 41: $t20 := TestBorrow::test3($t20, $t19)
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 44: write_ref($t9, $t20)
+ 42: write_ref($t9, $t20)
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 45: goto 53
+ 43: goto 50
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 46: label L10
+ 44: label L10
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5), Reference($t9)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 47: destroy($t9)
+ 45: destroy($t9)
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 48: $t21 := 0
+ 46: $t21 := 0
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 49: $t20 := read_ref($t5)
+ 47: $t20 := read_ref($t5)
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 50: $t20 := TestBorrow::test3($t20, $t21)
+ 48: $t20 := TestBorrow::test3($t20, $t21)
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8), Reference($t5)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 51: write_ref($t5, $t20)
+ 49: write_ref($t5, $t20)
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 52: goto 53
+ 50: label L11
      # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8)
      # unchecked_nodes: LocalRoot($t8), Reference($t9)
      # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 53: label L11
-     # live_nodes: LocalRoot($t6), LocalRoot($t7), LocalRoot($t8)
-     # unchecked_nodes: LocalRoot($t8), Reference($t9)
-     # moved_nodes: LocalRoot($t0), LocalRoot($t1), LocalRoot($t2)
-     # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}, LocalRoot($t8) -> {Reference($t9)}
-     # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}, Reference($t9) -> {LocalRoot($t8)}
- 54: return $t8
+ 51: return $t8
 }

--- a/language/move-prover/bytecode/tests/eliminate_mut_refs/basic_test.exp
+++ b/language/move-prover/bytecode/tests/eliminate_mut_refs/basic_test.exp
@@ -434,20 +434,19 @@ fun TestEliminateMutRefs::test7($t0|b: bool) {
   9: $t9 := copy($t14)
  10: if ($t9) goto 13 else goto 11
  11: label L1
- 12: goto 19
+ 12: goto 18
  13: label L0
  14: $t10 := move($t3)
  15: destroy($t10)
  16: $t11 := borrow_local($t2)
  17: $t3 := $t11
- 18: goto 19
- 19: label L2
- 20: $t12 := move($t3)
- 21: $t13 := 0
- 22: $t15 := read_ref($t12)
- 23: $t15 := TestEliminateMutRefs::test3($t15, $t13)
- 24: write_ref($t12, $t15)
- 25: return ()
+ 18: label L2
+ 19: $t12 := move($t3)
+ 20: $t13 := 0
+ 21: $t15 := read_ref($t12)
+ 22: $t15 := TestEliminateMutRefs::test3($t15, $t13)
+ 23: write_ref($t12, $t15)
+ 24: return ()
 }
 
 
@@ -499,62 +498,59 @@ fun TestEliminateMutRefs::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: TestEliminat
   9: $t4 := $t9
  10: $t10 := borrow_local($t4)
  11: $t5 := $t10
- 12: goto 13
- 13: label L7
- 14: $t11 := 0
- 15: $t12 := copy($t33)
- 16: $t13 := <($t11, $t12)
- 17: if ($t13) goto 20 else goto 18
- 18: label L1
- 19: goto 45
- 20: label L0
- 21: $t14 := move($t5)
- 22: destroy($t14)
- 23: $t15 := copy($t33)
- 24: $t16 := 2
- 25: $t17 := /($t15, $t16)
- 26: $t18 := 0
- 27: $t19 := ==($t17, $t18)
- 28: if ($t19) goto 31 else goto 29
- 29: label L4
- 30: goto 35
- 31: label L3
- 32: $t20 := borrow_local($t3)
- 33: $t5 := $t20
- 34: goto 39
- 35: label L5
- 36: $t21 := borrow_local($t4)
- 37: $t5 := $t21
- 38: goto 39
- 39: label L6
- 40: $t22 := copy($t33)
- 41: $t23 := 1
- 42: $t24 := -($t22, $t23)
- 43: $t33 := $t24
- 44: goto 13
- 45: label L2
- 46: $t25 := copy($t32)
- 47: if ($t25) goto 50 else goto 48
- 48: label L9
- 49: goto 59
- 50: label L8
- 51: $t26 := move($t5)
- 52: destroy($t26)
- 53: $t27 := move($t35)
- 54: $t28 := 0
- 55: $t36 := read_ref($t27)
- 56: $t36 := TestEliminateMutRefs::test3($t36, $t28)
- 57: write_ref($t27, $t36)
- 58: goto 68
- 59: label L10
- 60: $t29 := move($t35)
- 61: destroy($t29)
- 62: $t30 := move($t5)
- 63: $t31 := 0
- 64: $t36 := read_ref($t30)
- 65: $t36 := TestEliminateMutRefs::test3($t36, $t31)
- 66: write_ref($t30, $t36)
- 67: goto 68
- 68: label L11
- 69: return $t34
+ 12: label L7
+ 13: $t11 := 0
+ 14: $t12 := copy($t33)
+ 15: $t13 := <($t11, $t12)
+ 16: if ($t13) goto 19 else goto 17
+ 17: label L1
+ 18: goto 43
+ 19: label L0
+ 20: $t14 := move($t5)
+ 21: destroy($t14)
+ 22: $t15 := copy($t33)
+ 23: $t16 := 2
+ 24: $t17 := /($t15, $t16)
+ 25: $t18 := 0
+ 26: $t19 := ==($t17, $t18)
+ 27: if ($t19) goto 30 else goto 28
+ 28: label L4
+ 29: goto 34
+ 30: label L3
+ 31: $t20 := borrow_local($t3)
+ 32: $t5 := $t20
+ 33: goto 37
+ 34: label L5
+ 35: $t21 := borrow_local($t4)
+ 36: $t5 := $t21
+ 37: label L6
+ 38: $t22 := copy($t33)
+ 39: $t23 := 1
+ 40: $t24 := -($t22, $t23)
+ 41: $t33 := $t24
+ 42: goto 12
+ 43: label L2
+ 44: $t25 := copy($t32)
+ 45: if ($t25) goto 48 else goto 46
+ 46: label L9
+ 47: goto 57
+ 48: label L8
+ 49: $t26 := move($t5)
+ 50: destroy($t26)
+ 51: $t27 := move($t35)
+ 52: $t28 := 0
+ 53: $t36 := read_ref($t27)
+ 54: $t36 := TestEliminateMutRefs::test3($t36, $t28)
+ 55: write_ref($t27, $t36)
+ 56: goto 65
+ 57: label L10
+ 58: $t29 := move($t35)
+ 59: destroy($t29)
+ 60: $t30 := move($t5)
+ 61: $t31 := 0
+ 62: $t36 := read_ref($t30)
+ 63: $t36 := TestEliminateMutRefs::test3($t36, $t31)
+ 64: write_ref($t30, $t36)
+ 65: label L11
+ 66: return $t34
 }

--- a/language/move-prover/bytecode/tests/livevar/basic_test.exp
+++ b/language/move-prover/bytecode/tests/livevar/basic_test.exp
@@ -166,7 +166,7 @@ fun TestLiveVars::test2($t0|b: bool): u64 {
      # live vars: r_ref
   7: label L1
      # live vars: r_ref
-  8: goto 13
+  8: goto 12
      # live vars: r2, r_ref
   9: label L0
      # live vars: r2, r_ref
@@ -174,13 +174,11 @@ fun TestLiveVars::test2($t0|b: bool): u64 {
      # live vars: r2
  11: $t3 := $t2
      # live vars: r_ref
- 12: goto 13
+ 12: label L2
      # live vars: r_ref
- 13: label L2
-     # live vars: r_ref
- 14: $t7 := TestLiveVars::test1($t3)
+ 13: $t7 := TestLiveVars::test1($t3)
      # live vars: $t7
- 15: return $t7
+ 14: return $t7
 }
 
 
@@ -213,61 +211,57 @@ fun TestLiveVars::test3($t0|n: u64, $t1|r_ref: TestLiveVars::R): u64 {
      # live vars: r1, $t4, $t5, $t7
   5: $t3 := pack TestLiveVars::R($t7)
      # live vars: r1, r2, $t4, $t5
-  6: goto 7
+  6: label L7
      # live vars: r1, r2, $t4, $t5
-  7: label L7
-     # live vars: r1, r2, $t4, $t5
-  8: $t8 := 0
+  7: $t8 := 0
      # live vars: r1, r2, $t4, $t5, $t8
-  9: $t9 := <($t8, $t4)
+  8: $t9 := <($t8, $t4)
      # live vars: r1, r2, $t4, $t5, $t9
- 10: if ($t9) goto 13 else goto 11
+  9: if ($t9) goto 12 else goto 10
      # live vars: $t5
- 11: label L1
+ 10: label L1
      # live vars: $t5
- 12: goto 32
+ 11: goto 30
      # live vars: r1, r2, $t4, $t5
- 13: label L0
+ 12: label L0
      # live vars: r1, r2, $t4, $t5
- 14: destroy($t5)
+ 13: destroy($t5)
      # live vars: r1, r2, $t4
- 15: $t10 := 2
+ 14: $t10 := 2
      # live vars: r1, r2, $t4, $t10
- 16: $t11 := /($t4, $t10)
+ 15: $t11 := /($t4, $t10)
      # live vars: r1, r2, $t4, $t11
- 17: $t12 := 0
+ 16: $t12 := 0
      # live vars: r1, r2, $t4, $t11, $t12
- 18: $t13 := ==($t11, $t12)
+ 17: $t13 := ==($t11, $t12)
      # live vars: r1, r2, $t4, $t13
- 19: if ($t13) goto 22 else goto 20
+ 18: if ($t13) goto 21 else goto 19
      # live vars: r1, r2, $t4
- 20: label L4
+ 19: label L4
      # live vars: r1, r2, $t4
- 21: goto 25
+ 20: goto 24
      # live vars: r1, r2, $t4
- 22: label L3
+ 21: label L3
      # live vars: r1, r2, $t4
- 23: $t5 := $t2
+ 22: $t5 := $t2
      # live vars: r1, r2, $t4, $t5
- 24: goto 28
+ 23: goto 26
      # live vars: r1, r2, $t4
- 25: label L5
+ 24: label L5
      # live vars: r1, r2, $t4
- 26: $t5 := $t3
+ 25: $t5 := $t3
      # live vars: r1, r2, $t4, $t5
- 27: goto 28
+ 26: label L6
      # live vars: r1, r2, $t4, $t5
- 28: label L6
-     # live vars: r1, r2, $t4, $t5
- 29: $t14 := 1
+ 27: $t14 := 1
      # live vars: r1, r2, $t4, $t5, $t14
- 30: $t4 := -($t4, $t14)
+ 28: $t4 := -($t4, $t14)
      # live vars: r1, r2, $t4, $t5
- 31: goto 7
+ 29: goto 6
      # live vars: $t5
- 32: label L2
+ 30: label L2
      # live vars: $t5
- 33: $t15 := TestLiveVars::test1($t5)
+ 31: $t15 := TestLiveVars::test1($t5)
      # live vars: $t15
- 34: return $t15
+ 32: return $t15
 }

--- a/language/move-prover/bytecode/tests/memory_instr/basic_test.exp
+++ b/language/move-prover/bytecode/tests/memory_instr/basic_test.exp
@@ -390,20 +390,19 @@ fun TestPackref::test7($t0|b: bool) {
   5: $t3 := borrow_local($t1)
   6: if ($t4) goto 9 else goto 7
   7: label L1
-  8: goto 14
+  8: goto 13
   9: label L0
  10: destroy($t3)
  11: write_back[LocalRoot($t1)]($t3)
  12: $t3 := borrow_local($t2)
- 13: goto 14
- 14: label L2
- 15: $t7 := 0
- 16: $t8 := read_ref($t3)
- 17: $t8 := TestPackref::test3($t8, $t7)
- 18: write_ref($t3, $t8)
- 19: write_back[LocalRoot($t1)]($t3)
- 20: write_back[LocalRoot($t2)]($t3)
- 21: return ()
+ 13: label L2
+ 14: $t7 := 0
+ 15: $t8 := read_ref($t3)
+ 16: $t8 := TestPackref::test3($t8, $t7)
+ 17: write_ref($t3, $t8)
+ 18: write_back[LocalRoot($t1)]($t3)
+ 19: write_back[LocalRoot($t2)]($t3)
+ 20: return ()
 }
 
 
@@ -437,58 +436,55 @@ fun TestPackref::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: TestPackref::R): Test
   6: $t11 := 4
   7: $t4 := pack TestPackref::R($t11)
   8: $t5 := borrow_local($t4)
-  9: goto 10
- 10: label L7
- 11: $t12 := 0
- 12: $t13 := <($t12, $t7)
- 13: if ($t13) goto 16 else goto 14
- 14: label L1
- 15: goto 37
- 16: label L0
- 17: destroy($t5)
- 18: write_back[LocalRoot($t3)]($t5)
- 19: write_back[LocalRoot($t4)]($t5)
- 20: $t14 := 2
- 21: $t15 := /($t7, $t14)
- 22: $t16 := 0
- 23: $t17 := ==($t15, $t16)
- 24: if ($t17) goto 27 else goto 25
- 25: label L4
- 26: goto 30
- 27: label L3
- 28: $t5 := borrow_local($t3)
- 29: goto 33
- 30: label L5
- 31: $t5 := borrow_local($t4)
- 32: goto 33
- 33: label L6
- 34: $t18 := 1
- 35: $t7 := -($t7, $t18)
- 36: goto 10
- 37: label L2
- 38: if ($t6) goto 41 else goto 39
- 39: label L9
- 40: goto 51
- 41: label L8
- 42: destroy($t5)
- 43: write_back[LocalRoot($t3)]($t5)
- 44: write_back[LocalRoot($t4)]($t5)
- 45: $t19 := 0
- 46: $t20 := read_ref($t9)
- 47: $t20 := TestPackref::test3($t20, $t19)
- 48: write_ref($t9, $t20)
- 49: write_back[LocalRoot($t8)]($t9)
- 50: goto 61
- 51: label L10
- 52: destroy($t9)
- 53: write_back[LocalRoot($t8)]($t9)
- 54: $t21 := 0
- 55: $t20 := read_ref($t5)
- 56: $t20 := TestPackref::test3($t20, $t21)
- 57: write_ref($t5, $t20)
- 58: write_back[LocalRoot($t3)]($t5)
- 59: write_back[LocalRoot($t4)]($t5)
- 60: goto 61
- 61: label L11
- 62: return $t8
+  9: label L7
+ 10: $t12 := 0
+ 11: $t13 := <($t12, $t7)
+ 12: if ($t13) goto 15 else goto 13
+ 13: label L1
+ 14: goto 35
+ 15: label L0
+ 16: destroy($t5)
+ 17: write_back[LocalRoot($t3)]($t5)
+ 18: write_back[LocalRoot($t4)]($t5)
+ 19: $t14 := 2
+ 20: $t15 := /($t7, $t14)
+ 21: $t16 := 0
+ 22: $t17 := ==($t15, $t16)
+ 23: if ($t17) goto 26 else goto 24
+ 24: label L4
+ 25: goto 29
+ 26: label L3
+ 27: $t5 := borrow_local($t3)
+ 28: goto 31
+ 29: label L5
+ 30: $t5 := borrow_local($t4)
+ 31: label L6
+ 32: $t18 := 1
+ 33: $t7 := -($t7, $t18)
+ 34: goto 9
+ 35: label L2
+ 36: if ($t6) goto 39 else goto 37
+ 37: label L9
+ 38: goto 49
+ 39: label L8
+ 40: destroy($t5)
+ 41: write_back[LocalRoot($t3)]($t5)
+ 42: write_back[LocalRoot($t4)]($t5)
+ 43: $t19 := 0
+ 44: $t20 := read_ref($t9)
+ 45: $t20 := TestPackref::test3($t20, $t19)
+ 46: write_ref($t9, $t20)
+ 47: write_back[LocalRoot($t8)]($t9)
+ 48: goto 58
+ 49: label L10
+ 50: destroy($t9)
+ 51: write_back[LocalRoot($t8)]($t9)
+ 52: $t21 := 0
+ 53: $t20 := read_ref($t5)
+ 54: $t20 := TestPackref::test3($t20, $t21)
+ 55: write_ref($t5, $t20)
+ 56: write_back[LocalRoot($t3)]($t5)
+ 57: write_back[LocalRoot($t4)]($t5)
+ 58: label L11
+ 59: return $t8
 }

--- a/language/move-prover/bytecode/tests/reaching_def/test_branching.exp
+++ b/language/move-prover/bytecode/tests/reaching_def/test_branching.exp
@@ -48,14 +48,13 @@ fun TestBranching::branching($t0|cond: bool): u64 {
   5: label L0
   6: $t4 := 3
   7: $t1 := $t4
-  8: goto 13
+  8: goto 12
   9: label L2
  10: $t5 := 4
  11: $t1 := $t5
- 12: goto 13
- 13: label L3
- 14: $t6 := move($t1)
- 15: $t2 := $t1
- 16: $t7 := copy($t2)
- 17: return $t2
+ 12: label L3
+ 13: $t6 := move($t1)
+ 14: $t2 := $t1
+ 15: $t7 := copy($t2)
+ 16: return $t2
 }


### PR DESCRIPTION
This is the first of a number of smaller PRs which upgrade the transformation pipeline processors which already existed in v1 to the new tooling available in v2 (specifically the [`FunctionDataBuilder`](https://github.com/diem/diem/blob/master/language/move-prover/bytecode/src/function_data_builder.rs)).

The new version of the `eliminate_imm_refs.rs` module is also now a good minimal example (~120 lines) to see how the v2 framework works.

## Motivation

Cleanup after refactoring.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests. Baseline updates are due to that the `FunctionDataBuilder::emit` function does some peephole optimizations.

## Related PRs

NA
