### PR TITLE
[safety-rules] error when no execution pubkey, but a vote proposal has a signature

### DIFF
--- a/consensus/safety-rules/src/error.rs
+++ b/consensus/safety-rules/src/error.rs
@@ -41,6 +41,8 @@ pub enum Error {
     ValidatorNotInSet(String),
     #[error("Vote proposal missing expected signature")]
     VoteProposalSignatureNotFound,
+    #[error("execution signature present, but no public key to validate it")]
+    ExecutionSignatureButNoPublicKey,
 }
 
 impl From<bcs::Error> for Error {

--- a/consensus/safety-rules/src/safety_rules.rs
+++ b/consensus/safety-rules/src/safety_rules.rs
@@ -347,6 +347,8 @@ impl SafetyRules {
                 .ok_or(Error::VoteProposalSignatureNotFound)?
                 .verify(vote_proposal, public_key)
                 .map_err(|error| Error::InternalError(error.to_string()))?;
+        } else if execution_signature.is_some() {
+            return Err(Error::ExecutionSignatureButNoPublicKey);
         }
 
         let proposed_block = vote_proposal.block();


### PR DESCRIPTION
I can't think of any malicious scenario that would trigger this, but this is probably a misconfiguration and we want to be alerted as soon as possible that something is going on.

Note that someone could use this to DoS the TCB by adding a signature to this request when the TCB is not configured to handle execution signatures. But there are many other ways to DoS the TCB (for example by sending an initialization request with a fake epoch change proof) so the assumption is that malicious consensus performing a DoS are out of scope.