### PR TITLE
[gha] e2e tests, increase debugging and always push test results to slack (auto/canary)

### DIFF
--- a/.github/actions/slack-file/action.yml
+++ b/.github/actions/slack-file/action.yml
@@ -13,7 +13,7 @@ runs:
   steps:
     - run: |
         build_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-        ./.github/actions/slack-file/message_file_to_slack.sh -w "${WEBHOOK}" -f "${PAYLOAD_FILE}" -u "${build_url}"
+        ./.github/actions/slack-file/message_file_to_slack.sh -w "${WEBHOOK}" -f "${PAYLOAD_FILE}" -u "${build_url}" -d
       shell: bash
       env:
         PAYLOAD_FILE: ${{ inputs.payload-file }}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -243,11 +243,12 @@ jobs:
           fi
           if [[ $num_fails != 0 ]]; then
             echo -e "$num_fails test(s) failed:\n${failed_tests}"
+          else
+            echo -e "No issues detected in this build". > ${MESSAGE_PAYLOAD_FILE}
           fi
           exit $num_fails
       - name: "Send Message"
         uses: ./.github/actions/slack-file
-        if: ${{ failure() }}
         with:
           payload-file: ${{ env.MESSAGE_PAYLOAD_FILE }}
           webhook: ${{ secrets.WEBHOOK_FLAKY_TESTS }}


### PR DESCRIPTION
## Motivation

Push error messages from e2e tests on every run.   e2e tests aren't failing enough and it's suspicious.

Pushes do work.
https://toroeng.slack.com/archives/C011SK60RJ8/p1614017027000100

### Have you read the [Contributing Guidelines on pull requests]

Y

## Test Plan

This is a test, hoping to see messages in slack with canary.

## Related PRs

None