### PR TITLE
[RFC][diem-framework] Implemented an api for fetching diem framework in historic commits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,9 +973,12 @@ dependencies = [
  "diem-framework",
  "diem-types",
  "diem-workspace-hack",
+ "hex",
  "include_dir",
  "once_cell",
  "sha2",
+ "tar",
+ "tempfile",
  "vm",
 ]
 
@@ -2930,6 +2933,18 @@ name = "fiat-crypto"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72312b32704d99a969a55168f1f77edf8554fc7c7b978d457962aaf21404ef85"
+
+[[package]]
+name = "filetime"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall 0.2.4",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "fixedbitset"
@@ -6965,6 +6980,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36474e732d1affd3a6ed582781b3683df3d0563714c59c39591e8ff707cf078e"
 
 [[package]]
+name = "tar"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0bcfbd6a598361fda270d82469fff3d65089dc33e175c9a131f7b4cd395f228"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-spec"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8079,6 +8105,15 @@ dependencies = [
  "curve25519-dalek-fiat",
  "rand_core 0.6.2",
  "zeroize",
+]
+
+[[package]]
+name = "xattr"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/language/diem-framework/compiled/Cargo.toml
+++ b/language/diem-framework/compiled/Cargo.toml
@@ -11,6 +11,9 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.38"
+tempfile = "3.2.0"
+hex = "0.4.2"
+tar = "0.4.33"
 bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
 diem-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }
 diem-types = { path = "../../../types", version = "0.1.0" }

--- a/language/diem-framework/compiled/src/archived_files.rs
+++ b/language/diem-framework/compiled/src/archived_files.rs
@@ -1,0 +1,63 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{anyhow, Result};
+use std::{
+    borrow::Cow,
+    convert::AsRef,
+    ffi::{OsStr, OsString},
+    fmt,
+    path::{Path, PathBuf},
+    process::Command,
+};
+use tar::Archive;
+use tempfile::{tempdir, TempDir};
+
+/// A Git hash.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct GitHash([u8; 20]);
+
+impl GitHash {
+    /// Creates a new Git hash from a hex-encoded string.
+    pub fn from_hex(hex: impl AsRef<[u8]>) -> Result<Self> {
+        let hex = hex.as_ref();
+        Ok(GitHash(hex::FromHex::from_hex(hex).map_err(|err| {
+            anyhow!("parsing a Git hash: {:?} with error {:?}", hex, err)
+        })?))
+    }
+}
+
+impl<'a, 'b> From<&'a GitHash> for Cow<'b, OsStr> {
+    fn from(git_hash: &'a GitHash) -> Cow<'b, OsStr> {
+        OsString::from(format!("{:x}", git_hash)).into()
+    }
+}
+
+impl fmt::LowerHex for GitHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(&self.0))
+    }
+}
+
+pub(crate) fn get_archived_files<P: AsRef<Path>>(
+    path_to_repo_root: P,
+    hash: GitHash,
+) -> Result<TempDir> {
+    let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let tmp_dir = tempdir()?;
+    let git_output = Command::new("git")
+        .args(&["archive", "--format=tar"])
+        .args(&[
+            &format!("{:x}", hash),
+            path_to_repo_root
+                .as_ref()
+                .to_str()
+                .ok_or_else(|| anyhow!("Unexpected path for archived files"))?,
+        ])
+        .current_dir(&crate_dir)
+        .output()?;
+
+    let mut archive = Archive::new(&*git_output.stdout);
+    archive.unpack(tmp_dir.path())?;
+    Ok(tmp_dir)
+}

--- a/language/diem-framework/compiled/src/unit_tests/mod.rs
+++ b/language/diem-framework/compiled/src/unit_tests/mod.rs
@@ -1,0 +1,4 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod old_stdlib_tests;

--- a/language/diem-framework/compiled/src/unit_tests/old_stdlib_tests.rs
+++ b/language/diem-framework/compiled/src/unit_tests/old_stdlib_tests.rs
@@ -1,0 +1,13 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{old_stdlib_modules, stdlib_modules, GitHash, StdLibOptions};
+
+#[test]
+fn old_stdlib_tests() {
+    let master_modules = stdlib_modules(StdLibOptions::Compiled);
+    let (_, old_modules) =
+        old_stdlib_modules(GitHash::from_hex("5e81a74fcfae5e1be8632cb9dea5f0c7f1191050").unwrap())
+            .unwrap();
+    assert_eq!(master_modules.compiled_modules, &old_modules);
+}


### PR DESCRIPTION
…odes from historic git commits.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR implements a draft API for fetching the Diem Framework bytecodes in old historical commits by using `git archive`. We expect this api to be used for:
1. Future backward compatibility testing for Diem Framework across multiple releases
2. Generate release artifact for writesets upgrade.

This might also impact @vgao1996 's work on separating move stdlib out from the `diem-framework`. For better testing purpose we might want to have the future `move-stdlib` to have the same api. Feedbacks would be really appreciated.



### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan

I picked a recent commit on master to make sure the diem framework over there is in sync with the current master. Although this is not a robust test and will need to be modified. 
