### PR TITLE
Add printing of x25519 keys to optool

### DIFF
--- a/config/management/operational/src/command.rs
+++ b/config/management/operational/src/command.rs
@@ -34,8 +34,12 @@ pub enum Command {
     InsertWaypoint(diem_management::waypoint::InsertWaypoint),
     #[structopt(about = "Prints an account from the validator storage")]
     PrintAccount(crate::print::PrintAccount),
-    #[structopt(about = "Prints a public key from the validator storage")]
+    #[structopt(about = "Prints an ed25519 public key from the validator storage")]
     PrintKey(crate::print::PrintKey),
+    #[structopt(
+        about = "Prints an x25519 public key from the validator storage, suitable for noise handshakes"
+    )]
+    PrintXKey(crate::print::PrintXKey),
     #[structopt(about = "Prints a waypoint from the validator storage")]
     PrintWaypoint(crate::print::PrintWaypoint),
     #[structopt(about = "Remove a validator from ValidatorSet")]
@@ -73,6 +77,7 @@ pub enum CommandName {
     InsertWaypoint,
     PrintAccount,
     PrintKey,
+    PrintXKey,
     PrintWaypoint,
     RemoveValidator,
     RotateConsensusKey,
@@ -100,6 +105,7 @@ impl From<&Command> for CommandName {
             Command::InsertWaypoint(_) => CommandName::InsertWaypoint,
             Command::PrintAccount(_) => CommandName::PrintAccount,
             Command::PrintKey(_) => CommandName::PrintKey,
+            Command::PrintXKey(_) => CommandName::PrintXKey,
             Command::PrintWaypoint(_) => CommandName::PrintWaypoint,
             Command::RemoveValidator(_) => CommandName::RemoveValidator,
             Command::RotateConsensusKey(_) => CommandName::RotateConsensusKey,
@@ -129,6 +135,7 @@ impl std::fmt::Display for CommandName {
             CommandName::InsertWaypoint => "insert-waypoint",
             CommandName::PrintAccount => "print-account",
             CommandName::PrintKey => "print-key",
+            CommandName::PrintXKey => "print-x-key",
             CommandName::PrintWaypoint => "print-waypoint",
             CommandName::RemoveValidator => "remove-validator",
             CommandName::RotateConsensusKey => "rotate-consensus-key",
@@ -163,6 +170,7 @@ impl Command {
             Command::ExtractPublicKey(cmd) => Self::print_success(cmd.execute()),
             Command::PrintAccount(cmd) => Self::pretty_print(cmd.execute()),
             Command::PrintKey(cmd) => Self::pretty_print(cmd.execute()),
+            Command::PrintXKey(cmd) => Self::pretty_print(cmd.execute()),
             Command::PrintWaypoint(cmd) => Self::pretty_print(cmd.execute()),
             Command::RemoveValidator(cmd) => Self::print_transaction_context(cmd.execute()),
             Command::RotateConsensusKey(cmd) => {
@@ -277,6 +285,10 @@ impl Command {
 
     pub fn print_key(self) -> Result<Ed25519PublicKey, Error> {
         execute_command!(self, Command::PrintKey, CommandName::PrintKey)
+    }
+
+    pub fn print_x_key(self) -> Result<x25519::PublicKey, Error> {
+        execute_command!(self, Command::PrintXKey, CommandName::PrintXKey)
     }
 
     pub fn print_waypoint(self) -> Result<Waypoint, Error> {

--- a/config/management/operational/src/print.rs
+++ b/config/management/operational/src/print.rs
@@ -1,7 +1,8 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use diem_crypto::ed25519::Ed25519PublicKey;
+use diem_crypto::{ed25519::Ed25519PublicKey, x25519};
+
 use diem_management::{config::ConfigPath, error::Error, secure_backend::ValidatorBackend};
 use diem_types::{account_address::AccountAddress, waypoint::Waypoint};
 use structopt::StructOpt;
@@ -51,6 +52,30 @@ impl PrintKey {
         let storage = config.validator_backend();
         let key_name = Box::leak(self.key_name.into_boxed_str());
         storage.ed25519_public_from_private(key_name)
+    }
+}
+
+#[derive(Debug, StructOpt)]
+pub struct PrintXKey {
+    #[structopt(flatten)]
+    config: ConfigPath,
+    /// The key name in storage
+    #[structopt(long)]
+    key_name: String,
+    #[structopt(flatten)]
+    validator_backend: ValidatorBackend,
+}
+
+impl PrintXKey {
+    pub fn execute(self) -> Result<x25519::PublicKey, Error> {
+        let config = self
+            .config
+            .load()?
+            .override_validator_backend(&self.validator_backend.validator_backend)?;
+
+        let storage = config.validator_backend();
+        let key_name = Box::leak(self.key_name.into_boxed_str());
+        storage.x25519_public_from_private(key_name)
     }
 }
 


### PR DESCRIPTION
## Motivation
Currently there is no easy way to get x25519 public keys from the private keys in storage, which significantly complicates docker-compose setups. https://github.com/diem/diem/issues/7477

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?
yes

## Test Plan
run tool on storage, get expected x25519