### PR TITLE
[logging] Add documentation to all structs and macros

### DIFF
--- a/common/logger/src/counters.rs
+++ b/common/logger/src/counters.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//! Logging metrics for determining quality of log submission
 use once_cell::sync::Lazy;
 use prometheus::{register_int_counter, IntCounter};
 

--- a/common/logger/src/event.rs
+++ b/common/logger/src/event.rs
@@ -4,9 +4,11 @@
 use crate::{Metadata, Schema};
 use std::fmt;
 
+/// An individual structured logging event from a log line.  Includes the
 #[derive(Debug)]
 pub struct Event<'a> {
     metadata: &'a Metadata,
+    /// The format message given from the log macros
     message: Option<fmt::Arguments<'a>>,
     keys_and_values: KeysAndValues<'a>,
 }
@@ -46,6 +48,7 @@ impl<'a> Event<'a> {
     }
 }
 
+/// Keys and values given from the log `a = b` macros
 #[derive(Clone)]
 struct KeysAndValues<'a>(&'a [&'a dyn Schema]);
 

--- a/common/logger/src/filter.rs
+++ b/common/logger/src/filter.rs
@@ -1,11 +1,14 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//! Filtering definitions for controlling what modules and levels are logged
+
 use crate::{Level, Metadata};
 use std::{env, str::FromStr};
 
 pub struct FilterParseError;
 
+/// A definition of the most verbose `Level` allowed, or completely off.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum LevelFilter {
     Off,
@@ -49,6 +52,7 @@ impl From<Level> for LevelFilter {
     }
 }
 
+/// A builder for `Filter` deriving it's `Directive`s from specified modules
 #[derive(Default, Debug)]
 pub struct Builder {
     directives: Vec<Directive>,
@@ -118,6 +122,7 @@ impl Builder {
     }
 }
 
+/// A logging filter to determine which logs to keep or remove based on `Directive`s
 #[derive(Debug)]
 pub struct Filter {
     directives: Vec<Directive>,
@@ -140,6 +145,7 @@ impl Filter {
     }
 }
 
+/// A `Filter` directive for which logs to keep based on a module `name` based filter
 #[derive(Debug)]
 struct Directive {
     name: Option<String>,

--- a/common/logger/src/kv.rs
+++ b/common/logger/src/kv.rs
@@ -1,11 +1,20 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! Key-Value definitions
+//! Key-Value definitions for macros
+//!
+//! Example:
+//! ```
+//! use diem_logger::info;
+//! info!(
+//!   key = "value"
+//! );
+//! ```
 
 use serde::Serialize;
 use std::fmt;
 
+/// The key part of a logging key value pair e.g. `info!(key = value)`
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize)]
 pub struct Key(&'static str);
 
@@ -19,6 +28,7 @@ impl Key {
     }
 }
 
+/// The value part of a logging key value pair e.g. `info!(key = value)`
 #[derive(Clone, Copy)]
 pub enum Value<'v> {
     Debug(&'v (dyn fmt::Debug)),
@@ -55,6 +65,7 @@ impl<'v> Value<'v> {
     }
 }
 
+/// The logging key value pair e.g. `info!(key = value)`
 #[derive(Clone, Debug)]
 pub struct KeyValue<'v> {
     key: Key,

--- a/common/logger/src/logger.rs
+++ b/common/logger/src/logger.rs
@@ -1,11 +1,14 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//! Global logger definition and functions
+
 use crate::{counters::STRUCT_LOG_COUNT, Event, Metadata};
 
 use once_cell::sync::OnceCell;
 use std::sync::Arc;
 
+/// The global `Logger`
 static LOGGER: OnceCell<Arc<dyn Logger>> = OnceCell::new();
 
 /// A trait encapsulating the operations required of a logger.
@@ -20,6 +23,7 @@ pub trait Logger: Sync + Send + 'static {
     fn flush(&self);
 }
 
+/// Record a logging event to the global `Logger`
 pub(crate) fn dispatch(event: &Event) {
     if let Some(logger) = LOGGER.get() {
         STRUCT_LOG_COUNT.inc();
@@ -27,6 +31,7 @@ pub(crate) fn dispatch(event: &Event) {
     }
 }
 
+/// Check if the global `Logger` is enabled
 pub(crate) fn enabled(metadata: &Metadata) -> bool {
     LOGGER
         .get()
@@ -34,12 +39,14 @@ pub(crate) fn enabled(metadata: &Metadata) -> bool {
         .unwrap_or(false)
 }
 
+/// Sets the global `Logger` exactly once
 pub fn set_global_logger(logger: Arc<dyn Logger>) {
     if LOGGER.set(logger).is_err() {
         eprintln!("Global logger has already been set");
     }
 }
 
+/// Flush the global `Logger`
 pub fn flush() {
     if let Some(logger) = LOGGER.get() {
         logger.flush();

--- a/common/logger/src/macros.rs
+++ b/common/logger/src/macros.rs
@@ -1,6 +1,9 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//! Macros for sending logs at predetermined log `Level`s
+
+/// Log at the given level, it's recommended to use a specific level macro instead
 #[macro_export]
 macro_rules! log {
     // Entry, Log Level + stuff
@@ -24,6 +27,7 @@ macro_rules! log {
     }};
 }
 
+/// Log at the `trace` level
 #[macro_export]
 macro_rules! trace {
     ($($arg:tt)+) => {
@@ -31,6 +35,7 @@ macro_rules! trace {
     };
 }
 
+/// Log at the `debug` level
 #[macro_export]
 macro_rules! debug {
     ($($arg:tt)+) => {
@@ -38,6 +43,7 @@ macro_rules! debug {
     };
 }
 
+/// Log at the `info` level
 #[macro_export]
 macro_rules! info {
     ($($arg:tt)+) => {
@@ -45,6 +51,7 @@ macro_rules! info {
     };
 }
 
+/// Log at the `warn` level
 #[macro_export]
 macro_rules! warn {
     ($($arg:tt)+) => {
@@ -52,6 +59,7 @@ macro_rules! warn {
     };
 }
 
+/// Log at the `error` level
 #[macro_export]
 macro_rules! error {
     ($($arg:tt)+) => {

--- a/common/logger/src/metadata.rs
+++ b/common/logger/src/metadata.rs
@@ -4,6 +4,7 @@
 use serde::{Deserialize, Serialize};
 use std::{fmt, str::FromStr};
 
+/// Associated metadata with every log to identify what kind of log and where it came from
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct Metadata {
     /// The level of verbosity of the event
@@ -75,6 +76,7 @@ impl Metadata {
 
 static LOG_LEVEL_NAMES: &[&str] = &["ERROR", "WARN", "INFO", "DEBUG", "TRACE"];
 
+/// Logging levels, used for stratifying logs, and disabling less important ones for performance reasons
 #[repr(usize)]
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
@@ -116,6 +118,7 @@ impl Level {
     }
 }
 
+/// An error given when no `Level` matches the inputted string
 #[derive(Debug)]
 pub struct LevelParseError;
 

--- a/common/logger/src/sample.rs
+++ b/common/logger/src/sample.rs
@@ -1,13 +1,14 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! Implement periodic sampling for logs
+//! Periodic sampling for logs, metrics, and other use cases through a simple macro
 
 use std::{
     sync::atomic::{AtomicU64, Ordering},
     time::{Duration, SystemTime},
 };
 
+/// The rate at which a `sample!` macro will run it's given function
 #[derive(Debug)]
 pub enum SampleRate {
     /// Only sample a single time during a window of time. This rate only has a resolution in
@@ -21,6 +22,7 @@ pub enum SampleRate {
     Always,
 }
 
+/// An internal struct that can be checked if a sample is ready for the `sample!` macro
 pub struct Sampling {
     rate: SampleRate,
     state: AtomicU64,
@@ -77,6 +79,8 @@ impl Sampling {
     }
 }
 
+/// Samples a given function at a `SampleRate`, useful for periodically emitting logs or metrics on
+/// high throughput pieces of code.
 #[macro_export]
 macro_rules! sample {
     ($sample_rate:expr, $($args:expr)+ ,) => {

--- a/common/logger/src/security.rs
+++ b/common/logger/src/security.rs
@@ -5,6 +5,8 @@
 //! The security module gathers security-related logs:
 //! logs to detect malicious behavior from other validators.
 //!
+//! TODO: This likely belongs outside of the logging crate
+//!
 //! ```
 //! use diem_logger::{error, SecurityEvent};
 //!

--- a/common/logger/src/struct_log.rs
+++ b/common/logger/src/struct_log.rs
@@ -1,5 +1,11 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
+
+//! Implementations for sending logs to external log processes e.g. Logstash
+//!
+//! Handles sending logs under disconnects, and retries.  Tries to continue to make progress on a
+//! log but eventually drops older logs to continue to make progress on newer logs.
+
 use crate::counters::{STRUCT_LOG_CONNECT_ERROR_COUNT, STRUCT_LOG_TCP_CONNECT_COUNT};
 use std::{
     io,


### PR DESCRIPTION
I looked at the logging docs when I referred someone to them, and realized I had some weird confusion earlier about the difference between `Filter` vs `DiemFilter` and `Logger` vs `DiemLogger` etc.  So, I just tried to fill in a bunch of the gaps in docs, even if they're not much just to give a little clue about the difference between all these structs and what they're used for.

Feel free to be critical about what I wrote, mostly because this is from my understanding of what I know about it.  I also figured now is a good time to slap down some docs, since it's not changing much now.