### PR TITLE
diem-types and move-core-types dependency cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4236,8 +4236,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
- "diem-crypto",
- "diem-crypto-derive",
  "diem-workspace-hack",
  "hex",
  "mirai-annotations",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2291,7 +2291,6 @@ dependencies = [
  "diem-crypto-derive",
  "diem-infallible",
  "diem-network-address",
- "diem-proptest-helpers",
  "diem-workspace-hack",
  "fallible",
  "hex",

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -216,11 +216,13 @@ impl NetworkConfig {
             Identity::None => {
                 let mut rng = StdRng::from_seed(OsRng.gen());
                 let key = x25519::PrivateKey::generate(&mut rng);
-                let peer_id = PeerId::from_identity_public_key(key.public_key());
+                let peer_id =
+                    diem_types::account_address::from_identity_public_key(key.public_key());
                 self.identity = Identity::from_config(key, peer_id);
             }
             Identity::FromConfig(config) => {
-                let peer_id = PeerId::from_identity_public_key(config.key.public_key());
+                let peer_id =
+                    diem_types::account_address::from_identity_public_key(config.key.public_key());
                 if config.peer_id == PeerId::ZERO {
                     config.peer_id = peer_id;
                 }

--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -36,7 +36,7 @@ use diem_logger::prelude::*;
 use diem_state_view::StateViewId;
 use diem_trace::prelude::*;
 use diem_types::{
-    account_address::AccountAddress,
+    account_address::{AccountAddress, HashAccountAddress},
     account_state::AccountState,
     account_state_blob::AccountStateBlob,
     contract_event::ContractEvent,

--- a/language/move-core/types/Cargo.toml
+++ b/language/move-core/types/Cargo.toml
@@ -11,31 +11,26 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.38"
+bcs = "0.1.2"
 hex = "0.4.2"
-rand = "0.8.3"
-proptest = { version = "1.0.0", default-features = false, optional = true }
 mirai-annotations = "1.10.1"
+once_cell = "1.6.0"
+proptest = { version = "1.0.0", default-features = false, optional = true }
 proptest-derive = { version = "0.3.0", default-features = false, optional = true }
+rand = "0.8.3"
 ref-cast = "1.0.6"
 serde = { version = "1.0.123", default-features = false }
 serde_bytes = "0.11.5"
 thiserror = "1.0.24"
-once_cell = "1.6.0"
 
-bcs = "0.1.2"
 diem-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
-diem-crypto = { path = "../../../crypto/crypto", version = "0.1.0", default-features = false }
-diem-crypto-derive = { path = "../../../crypto/crypto-derive", version = "0.1.0" }
 
 [dev-dependencies]
-once_cell = "1.6.0"
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
 regex = "1.4.3"
 serde_json = "1.0.62"
 
 [features]
-default = ["fiat"]
-fiat = ["diem-crypto/fiat"]
-u64 = ["diem-crypto/u64"]
+default = []
 fuzzing = ["proptest", "proptest-derive"]

--- a/language/move-core/types/src/account_address.rs
+++ b/language/move-core/types/src/account_address.rs
@@ -2,20 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{ensure, Error, Result};
-use diem_crypto::{
-    hash::{CryptoHash, CryptoHasher},
-    x25519, HashValue,
-};
-use diem_crypto_derive::CryptoHasher;
-#[cfg(any(test, feature = "fuzzing"))]
-use proptest_derive::Arbitrary;
 use rand::{rngs::OsRng, Rng};
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
 use std::{convert::TryFrom, fmt, str::FromStr};
 
 /// A struct that represents an account address.
-#[derive(Ord, PartialOrd, Eq, PartialEq, Hash, Clone, Copy, CryptoHasher)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[derive(Ord, PartialOrd, Eq, PartialEq, Hash, Clone, Copy)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
 pub struct AccountAddress([u8; AccountAddress::LENGTH]);
 
 impl AccountAddress {
@@ -76,29 +69,6 @@ impl AccountAddress {
         };
 
         AccountAddress::try_from(padded_result)
-    }
-
-    // Note: This is inconsistent with current types because AccountAddress is derived
-    // from consensus key which is of type Ed25519PublicKey. Since AccountAddress does
-    // not mean anything in a setting without remote authentication, we use the network
-    // public key to generate a peer_id for the peer.
-    // See this issue for potential improvements: https://github.com/diem/diem/issues/3960
-    pub fn from_identity_public_key(identity_public_key: x25519::PublicKey) -> Self {
-        let mut array = [0u8; Self::LENGTH];
-        let pubkey_slice = identity_public_key.as_slice();
-        // keep only the last 16 bytes
-        array.copy_from_slice(&pubkey_slice[x25519::PUBLIC_KEY_SIZE - Self::LENGTH..]);
-        Self(array)
-    }
-}
-
-impl CryptoHash for AccountAddress {
-    type Hasher = AccountAddressHasher;
-
-    fn hash(&self) -> HashValue {
-        let mut state = Self::Hasher::default();
-        state.update(&self.0);
-        state.finish()
     }
 }
 

--- a/language/move-core/types/src/language_storage.rs
+++ b/language/move-core/types/src/language_storage.rs
@@ -5,7 +5,6 @@ use crate::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
 };
-use diem_crypto_derive::{BCSCryptoHash, CryptoHasher};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -30,19 +29,7 @@ pub enum TypeTag {
     Struct(StructTag),
 }
 
-#[derive(
-    Serialize,
-    Deserialize,
-    Debug,
-    PartialEq,
-    Hash,
-    Eq,
-    Clone,
-    PartialOrd,
-    Ord,
-    CryptoHasher,
-    BCSCryptoHash,
-)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord)]
 pub struct StructTag {
     pub address: AccountAddress,
     pub module: Identifier,
@@ -91,19 +78,7 @@ impl ResourceKey {
 
 /// Represents the initial key into global storage where we first index by the address, and then
 /// the struct tag
-#[derive(
-    Serialize,
-    Deserialize,
-    Debug,
-    PartialEq,
-    Hash,
-    Eq,
-    Clone,
-    PartialOrd,
-    Ord,
-    CryptoHasher,
-    BCSCryptoHash,
-)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
 pub struct ModuleId {

--- a/language/move-core/types/src/unit_tests/address_test.rs
+++ b/language/move-core/types/src/unit_tests/address_test.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::account_address::AccountAddress;
-use diem_crypto::{hash::CryptoHash, HashValue};
 use hex::FromHex;
 use proptest::prelude::*;
 use std::{
@@ -54,15 +53,6 @@ fn test_address() {
         )
     });
 
-    let hash_vec =
-        &Vec::from_hex("6403c4906e79cf4536edada922040805c6a8d0e735fa4516a9cc40038bd125c8")
-            .expect("You must provide a valid Hex format");
-
-    let mut hash = [0u8; 32];
-    let bytes = &hash_vec[..32];
-    hash.copy_from_slice(&bytes);
-
-    assert_eq!(address.hash(), HashValue::new(hash));
     assert_eq!(address.as_ref().to_vec(), hex);
 }
 

--- a/network/simple-onchain-discovery/src/lib.rs
+++ b/network/simple-onchain-discovery/src/lib.rs
@@ -286,7 +286,7 @@ mod tests {
         let consensus_pubkey = consensus_private_key.public_key();
         let pubkey = test_pubkey([0u8; 32]);
         let different_pubkey = test_pubkey([1u8; 32]);
-        let peer_id = PeerId::from_identity_public_key(pubkey);
+        let peer_id = diem_types::account_address::from_identity_public_key(pubkey);
 
         // Build up the Reconfig Listener
         let (conn_mgr_reqs_tx, _rx) = channel::new_test(1);

--- a/network/socket-bench-server/src/lib.rs
+++ b/network/socket-bench-server/src/lib.rs
@@ -7,7 +7,6 @@ use diem_config::network_id::NetworkContext;
 use diem_crypto::{test_utils::TEST_SEED, x25519, Uniform as _};
 use diem_logger::prelude::*;
 use diem_network_address::NetworkAddress;
-use diem_types::PeerId;
 use futures::{
     future::Future,
     io::{AsyncRead, AsyncWrite},
@@ -84,7 +83,7 @@ pub fn build_memsocket_noise_transport() -> impl Transport<Output = NoiseStream<
         let mut rng: StdRng = SeedableRng::from_seed(TEST_SEED);
         let private = x25519::PrivateKey::generate(&mut rng);
         let public = private.public_key();
-        let peer_id = PeerId::from_identity_public_key(public);
+        let peer_id = diem_types::account_address::from_identity_public_key(public);
         let noise_config = Arc::new(NoiseUpgrader::new(
             NetworkContext::mock_with_peer_id(peer_id),
             private,
@@ -105,7 +104,7 @@ pub fn build_tcp_noise_transport() -> impl Transport<Output = NoiseStream<TcpSoc
         let mut rng: StdRng = SeedableRng::from_seed(TEST_SEED);
         let private = x25519::PrivateKey::generate(&mut rng);
         let public = private.public_key();
-        let peer_id = PeerId::from_identity_public_key(public);
+        let peer_id = diem_types::account_address::from_identity_public_key(public);
         let noise_config = Arc::new(NoiseUpgrader::new(
             NetworkContext::mock_with_peer_id(peer_id),
             private,

--- a/network/src/noise/fuzzing.rs
+++ b/network/src/noise/fuzzing.rs
@@ -38,11 +38,13 @@ pub static KEYPAIRS: Lazy<(
 
     let initiator_private_key = x25519::PrivateKey::generate(&mut rng);
     let initiator_public_key = initiator_private_key.public_key();
-    let initiator_peer_id = PeerId::from_identity_public_key(initiator_public_key);
+    let initiator_peer_id =
+        diem_types::account_address::from_identity_public_key(initiator_public_key);
 
     let responder_private_key = x25519::PrivateKey::generate(&mut rng);
     let responder_public_key = responder_private_key.public_key();
-    let responder_peer_id = PeerId::from_identity_public_key(responder_public_key);
+    let responder_peer_id =
+        diem_types::account_address::from_identity_public_key(responder_public_key);
 
     (
         (

--- a/network/src/noise/handshake.rs
+++ b/network/src/noise/handshake.rs
@@ -367,7 +367,9 @@ impl NoiseUpgrader {
                     None => {
                         // if not, verify that their peerid is constructed correctly from their public key
                         let derived_remote_peer_id =
-                            PeerId::from_identity_public_key(remote_public_key);
+                            diem_types::account_address::from_identity_public_key(
+                                remote_public_key,
+                            );
                         if derived_remote_peer_id != remote_peer_id {
                             Err(NoiseHandshakeError::ClientPeerIdMismatch(
                                 remote_peer_short,
@@ -509,8 +511,10 @@ mod test {
             let server_auth = HandshakeAuthMode::mutual(trusted_peers);
             (client_auth, server_auth, client_peer_id, server_peer_id)
         } else {
-            let client_peer_id = PeerId::from_identity_public_key(client_public_key);
-            let server_peer_id = PeerId::from_identity_public_key(server_public_key);
+            let client_peer_id =
+                diem_types::account_address::from_identity_public_key(client_public_key);
+            let server_peer_id =
+                diem_types::account_address::from_identity_public_key(server_public_key);
             (
                 HandshakeAuthMode::server_only(),
                 HandshakeAuthMode::server_only(),

--- a/network/src/noise/stream.rs
+++ b/network/src/noise/stream.rs
@@ -552,7 +552,6 @@ mod test {
     };
     use diem_config::network_id::NetworkContext;
     use diem_crypto::{test_utils::TEST_SEED, traits::Uniform as _, x25519};
-    use diem_types::PeerId;
     use futures::{
         executor::block_on,
         future::join,
@@ -571,11 +570,11 @@ mod test {
 
         let client_private = x25519::PrivateKey::generate(&mut rng);
         let client_public = client_private.public_key();
-        let client_peer_id = PeerId::from_identity_public_key(client_public);
+        let client_peer_id = diem_types::account_address::from_identity_public_key(client_public);
 
         let server_private = x25519::PrivateKey::generate(&mut rng);
         let server_public = server_private.public_key();
-        let server_peer_id = PeerId::from_identity_public_key(server_public);
+        let server_peer_id = diem_types::account_address::from_identity_public_key(server_public);
 
         let client = NoiseUpgrader::new(
             NetworkContext::mock_with_peer_id(client_peer_id),

--- a/network/src/transport/test.rs
+++ b/network/src/transport/test.rs
@@ -100,8 +100,11 @@ where
                 )
             }
             Auth::MaybeMutual => {
-                let listener_peer_id = PeerId::from_identity_public_key(listener_key.public_key());
-                let dialer_peer_id = PeerId::from_identity_public_key(dialer_key.public_key());
+                let listener_peer_id = diem_types::account_address::from_identity_public_key(
+                    listener_key.public_key(),
+                );
+                let dialer_peer_id =
+                    diem_types::account_address::from_identity_public_key(dialer_key.public_key());
                 let trusted_peers = build_trusted_peers(
                     dialer_peer_id,
                     &dialer_key,
@@ -120,8 +123,11 @@ where
                 )
             }
             Auth::ServerOnly => {
-                let listener_peer_id = PeerId::from_identity_public_key(listener_key.public_key());
-                let dialer_peer_id = PeerId::from_identity_public_key(dialer_key.public_key());
+                let listener_peer_id = diem_types::account_address::from_identity_public_key(
+                    listener_key.public_key(),
+                );
+                let dialer_peer_id =
+                    diem_types::account_address::from_identity_public_key(dialer_key.public_key());
                 let trusted_peers = Arc::new(RwLock::new(HashMap::new()));
 
                 (

--- a/storage/diemdb/src/diemdb_test.rs
+++ b/storage/diemdb/src/diemdb_test.rs
@@ -13,6 +13,7 @@ use diem_jellyfish_merkle::node_type::{Node, NodeKey};
 use diem_temppath::TempPath;
 #[allow(unused_imports)]
 use diem_types::{
+    account_address::{AccountAddress, HashAccountAddress},
     account_config::AccountResource,
     contract_event::ContractEvent,
     ledger_info::LedgerInfo,

--- a/storage/diemdb/src/event_store/test.rs
+++ b/storage/diemdb/src/event_store/test.rs
@@ -174,7 +174,7 @@ proptest! {
             .into_iter()
             .map(|gens| {
                 gens.into_iter()
-                    .map(|(index, gen)| gen.materialize(index, &mut universe))
+                    .map(|(index, gen)| gen.materialize(*index, &mut universe))
                     .collect()
             })
             .collect();

--- a/storage/diemdb/src/state_store/mod.rs
+++ b/storage/diemdb/src/state_store/mod.rs
@@ -14,12 +14,12 @@ use crate::{
     },
 };
 use anyhow::Result;
-use diem_crypto::{hash::CryptoHash, HashValue};
+use diem_crypto::HashValue;
 use diem_jellyfish_merkle::{
     node_type::NodeKey, JellyfishMerkleTree, TreeReader, TreeWriter, ROOT_NIBBLE_HEIGHT,
 };
 use diem_types::{
-    account_address::AccountAddress,
+    account_address::{AccountAddress, HashAccountAddress},
     account_state_blob::AccountStateBlob,
     proof::{SparseMerkleProof, SparseMerkleRangeProof},
     transaction::Version,

--- a/storage/diemdb/src/state_store/state_store_test.rs
+++ b/storage/diemdb/src/state_store/state_store_test.rs
@@ -3,10 +3,12 @@
 
 use super::*;
 use crate::{pruner, DiemDB};
-use diem_crypto::hash::CryptoHash;
 use diem_jellyfish_merkle::restore::JellyfishMerkleRestore;
 use diem_temppath::TempPath;
-use diem_types::{account_address::AccountAddress, account_state_blob::AccountStateBlob};
+use diem_types::{
+    account_address::{AccountAddress, HashAccountAddress},
+    account_state_blob::AccountStateBlob,
+};
 use proptest::{collection::hash_map, prelude::*};
 
 fn put_account_state_set(

--- a/storage/diemdb/src/transaction_store/test.rs
+++ b/storage/diemdb/src/transaction_store/test.rs
@@ -160,7 +160,7 @@ fn init_store(
     let txns = gens
         .into_iter()
         .map(|(index, gen)| {
-            Transaction::UserTransaction(gen.materialize(index, &mut universe).into_inner())
+            Transaction::UserTransaction(gen.materialize(*index, &mut universe).into_inner())
         })
         .collect::<Vec<_>>();
 

--- a/storage/storage-interface/src/state_view.rs
+++ b/storage/storage-interface/src/state_view.rs
@@ -3,14 +3,11 @@
 
 use crate::DbReader;
 use anyhow::{format_err, Result};
-use diem_crypto::{
-    hash::{CryptoHash, SPARSE_MERKLE_PLACEHOLDER_HASH},
-    HashValue,
-};
+use diem_crypto::{hash::SPARSE_MERKLE_PLACEHOLDER_HASH, HashValue};
 use diem_state_view::{StateView, StateViewId};
 use diem_types::{
     access_path::AccessPath,
-    account_address::AccountAddress,
+    account_address::{AccountAddress, HashAccountAddress},
     account_state::AccountState,
     account_state_blob::AccountStateBlob,
     proof::SparseMerkleProof,

--- a/storage/storage-service/src/storage_service_test.rs
+++ b/storage/storage-service/src/storage_service_test.rs
@@ -3,7 +3,7 @@
 
 use super::*;
 use diem_config::{config::NodeConfig, utils};
-use diem_crypto::hash::CryptoHash;
+use diem_types::account_address::HashAccountAddress;
 #[cfg(test)]
 use diemdb::test_helper::arb_blocks_to_commit;
 use itertools::zip_eq;

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -31,7 +31,6 @@ diem-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 diem-crypto-derive = { path = "../crypto/crypto-derive", version = "0.1.0" }
 diem-infallible = { path = "../common/infallible", version = "0.1.0" }
 diem-network-address = { path = "../network/network-address", version = "0.1.0" }
-diem-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0", optional = true }
 diem-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
 fallible = { path = "../common/fallible" }
 move-core-types = { path = "../language/move-core/types", version = "0.1.0" }
@@ -44,9 +43,8 @@ serde_json = "1.0.62"
 
 diem-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["fuzzing"] }
 diem-network-address = { path = "../network/network-address", version = "0.1.0", features = ["fuzzing"] }
-diem-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0" }
 move-core-types = { path = "../language/move-core/types", version = "0.1.0", features = ["fuzzing"]  }
 
 [features]
 default = []
-fuzzing = ["proptest", "proptest-derive", "diem-proptest-helpers", "diem-crypto/fuzzing", "diem-network-address/fuzzing", "move-core-types/fuzzing"]
+fuzzing = ["proptest", "proptest-derive", "diem-crypto/fuzzing", "diem-network-address/fuzzing", "move-core-types/fuzzing"]

--- a/types/src/account_address.rs
+++ b/types/src/account_address.rs
@@ -1,10 +1,70 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 use crate::transaction::authenticator::AuthenticationKey;
-use diem_crypto::ed25519::Ed25519PublicKey;
+use diem_crypto::{
+    ed25519::Ed25519PublicKey,
+    hash::{CryptoHasher, HashValue},
+    x25519,
+};
 
 pub use move_core_types::account_address::AccountAddress;
 
 pub fn from_public_key(public_key: &Ed25519PublicKey) -> AccountAddress {
     AuthenticationKey::ed25519(public_key).derived_address()
+}
+
+// Note: This is inconsistent with current types because AccountAddress is derived
+// from consensus key which is of type Ed25519PublicKey. Since AccountAddress does
+// not mean anything in a setting without remote authentication, we use the network
+// public key to generate a peer_id for the peer.
+// See this issue for potential improvements: https://github.com/diem/diem/issues/3960
+pub fn from_identity_public_key(identity_public_key: x25519::PublicKey) -> AccountAddress {
+    let mut array = [0u8; AccountAddress::LENGTH];
+    let pubkey_slice = identity_public_key.as_slice();
+    // keep only the last 16 bytes
+    array.copy_from_slice(&pubkey_slice[x25519::PUBLIC_KEY_SIZE - AccountAddress::LENGTH..]);
+    AccountAddress::new(array)
+}
+
+// Define the Hasher used for hashing AccountAddress types. In order to properly use the
+// CryptoHasher derive macro we need to have this in its own module so that it doesn't conflict
+// with the imported `AccountAddress` from move-core-types. It needs to have the same name since
+// the hash salt is calculated using the name of the type.
+mod hasher {
+    #[derive(serde::Deserialize, diem_crypto_derive::CryptoHasher)]
+    struct AccountAddress;
+}
+
+pub trait HashAccountAddress {
+    fn hash(&self) -> HashValue;
+}
+
+impl HashAccountAddress for AccountAddress {
+    fn hash(&self) -> HashValue {
+        let mut state = hasher::AccountAddressHasher::default();
+        state.update(self.as_ref());
+        state.finish()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{AccountAddress, HashAccountAddress};
+    use diem_crypto::hash::HashValue;
+    use hex::FromHex;
+
+    #[test]
+    fn address_hash() {
+        let address: AccountAddress = "ca843279e3427144cead5e4d5999a3d0".parse().unwrap();
+
+        let hash_vec =
+            &Vec::from_hex("6403c4906e79cf4536edada922040805c6a8d0e735fa4516a9cc40038bd125c8")
+                .expect("You must provide a valid Hex format");
+
+        let mut hash = [0u8; 32];
+        let bytes = &hash_vec[..32];
+        hash.copy_from_slice(&bytes);
+
+        assert_eq!(address.hash(), HashValue::new(hash));
+    }
 }

--- a/types/src/account_state_blob.rs
+++ b/types/src/account_state_blob.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    account_address::AccountAddress,
+    account_address::{AccountAddress, HashAccountAddress},
     account_config::{AccountResource, BalanceResource},
     account_state::AccountState,
     ledger_info::LedgerInfo,

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -33,12 +33,12 @@ use diem_crypto::{
     traits::*,
     HashValue,
 };
-use diem_proptest_helpers::Index;
 use move_core_types::language_storage::TypeTag;
 use proptest::{
     collection::{vec, SizeRange},
     option,
     prelude::*,
+    sample::Index,
 };
 use proptest_derive::Arbitrary;
 use serde_json::Value;


### PR DESCRIPTION
This PR does 2 things:
* Remove the dependency on proptest-helpers for diem-types
* remove the dependency on diem-crypto for move-core-types