### PR TITLE
[sccache] linux builds and a little cleanup

### DIFF
--- a/.github/actions/changes/get_pr_info.sh
+++ b/.github/actions/changes/get_pr_info.sh
@@ -86,13 +86,13 @@ fi
 $DEBUG && echo GITHUB_SLUG="$GITHUB_SLUG"
 
 BRANCH=
+TARGET_BRANCH=
 #Attempt to determine/normalize the branch.
 if  [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
   BRANCH=${GITHUB_REF//*\/}
 fi
 if  [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
   BRANCH=${GITHUB_BASE_REF}
-  TARGET_BRANCH=${BRANCH}
 fi
 $DEBUG && echoerr BRANCH="$BRANCH"
 
@@ -105,6 +105,7 @@ if [[ "${GITHUB_EVENT_NAME}" == "push" ]] && [[ "$BORS" == false || ( "$BRANCH" 
   if [[ -n "$QUERIED_GITHASH" ]] && [[ $(git merge-base --is-ancestor "$QUERIED_GITHASH" "$(git rev-parse HEAD)" 2>/dev/null; echo $?) == 0 ]]; then
     BASE_GITHASH="${QUERIED_GITHASH}"
   fi
+  TARGET_BRANCH=${BRANCH}
 fi
 $DEBUG && echoerr BASE_GITHASH="$BASE_GITHASH"
 

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -160,9 +160,13 @@ jobs:
           key: crates-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: "crates-${{ runner.os }}"
       - name: run unit tests
-        run: $pre_command && cargo x test --jobs ${max_threads} --unit --changed-since "origin/$TARGET_BRANCH"
+        run: |
+          $pre_command && cargo x test --jobs ${max_threads} --unit --changed-since "origin/$TARGET_BRANCH"
+          sccache -s
         env:
           TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
+          SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
+          SCCACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
       - uses: ./.github/actions/build-teardown
 
   e2e-test:

--- a/.github/workflows/ci-update-sccache.yml
+++ b/.github/workflows/ci-update-sccache.yml
@@ -1,0 +1,54 @@
+name: ci-update-sccache
+
+on:
+  push:
+    branches: [master, release-*, gha-test-*]
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  max_threads: 16
+  pre_command: cd /opt/git/diem/
+
+jobs:
+  update-sccache-osx:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # This ensures that the tip of the PR is checked out instead of the merge between the base ref and the tip
+          # On `push` this value will be empty and will "do-the-right-thing"
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0 #get all the history!!!
+      - id: changes
+        name: determine changes
+        uses: ./.github/actions/changes
+        with:
+          workflow-file: ci-update-sccache.yml
+      - id: rust-changes
+        name: find rust/cargo changes.
+        uses: ./.github/actions/matches
+        with:
+          pattern: '^documentation\|^docker\|^scripts\|^.circleci'
+          invert: "true"
+      - uses: ./.github/actions/build-setup
+        if: ${{ steps.rust-changes.outputs.changes-found == 'true' }}
+      - uses: actions/cache@v2
+        if: ${{ steps.rust-changes.outputs.changes-found == 'true' }}
+        with:
+          path: "/opt/cargo/git\n/opt/cargo/registry\n/opt/cargo/.package-cache"
+          key: crates-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: "crates-${{ runner.os }}"
+      - name: build all unit test code.
+        if: ${{ steps.rust-changes.outputs.changes-found == 'true' }}
+        run: |
+          $pre_command && cargo x test --no-run --jobs ${max_threads} --unit
+          echo stats:
+          sccache -s
+        env:
+          SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
+          SCCACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
+      - uses: ./.github/actions/build-teardown
+        if: ${{ steps.rust-changes.outputs.changes-found == 'true' }}


### PR DESCRIPTION
## Motivation

Cherry-pick of https://github.com/diem/diem/pull/7676
Fixes the ability to generate base images for CI (the branch wasn't being set, leading to failures).
Also gets linux/macos updates to sccache for release branches.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

CI / Master branch

## Related PRs

https://github.com/diem/diem/pull/7676

## Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
Release branch in CI is broken and nothing can be processed until this lands. No other code changes, no new releases.
Devs, Ops, DevOps.

## Comprehensive test results that demonstrate the fix working and not breaking existing workflows.

Running on top of my change in master:
https://github.com/diem/diem/actions/runs/590358682

Note this change didn't run as a result of the master commit, the selection criteria for the build are too narrow, the right way to fix this is to probably move the github actions to another repo, and reference them via version.

## Why we must have it for V1 launch.

This we make our process as automatable as it can be now without giving prs and the auto branch the ability to push docker images before build.... but that gives me an idea... 

## What workarounds and alternative we have if we do not push the PR.

I'll have to notice when a change occurs in dev-setup.sh and push it myself to gha-test-1 branch, with hacked branch info in it to build the base image.   It's a chicken/egg problem.  This is how the base image release-1.1 is running on now is built.