### PR TITLE
[deps][audit] ignore rustsec in hyper 0.13.9

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -29,7 +29,7 @@ jobs:
         run: cargo install --force cargo-audit
       - name: audit crates
         run: |
-          $CARGO $CARGOFLAGS audit >> $MESSAGE_PAYLOAD_FILE
+          $CARGO $CARGOFLAGS audit --ignore RUSTSEC-2021-0020 >> $MESSAGE_PAYLOAD_FILE
       - uses: ./.github/actions/slack-file
         with:
           webhook: ${{ secrets.WEBHOOK_AUDIT }}


### PR DESCRIPTION
## Motivation
[Justification and who does it affect]
hyper v0.13.9 was flagged in RUSTSEC-2021-0020, and the advisory was picked up in the nightly audit workflow.  Upon close discussion with folks in network, json-rpc and deployment, the vulnerability doesn't appear to impact the operation. As a result, there is no need to update the dependency.  The advisory  is added to the ignore list so as not to create spam and drawn out future advisory alerts. 

Separately, the advisory is addressed in the master branch.

[Breaking nature]
N/A.  This is not a breaking change. 

[What happens if we don't have this]
The nightly audit will continue to generate alert and lead to degraded fidelity. 

[What are the alternatives]
The alternative would be bump the hyper version, as in #7548.

## Test Plan
CI and cargo audit