### PR TITLE
[faucet] lazy load key file to allow lazy creation and update

### DIFF
--- a/client/faucet/src/main.rs
+++ b/client/faucet/src/main.rs
@@ -18,7 +18,7 @@ struct Args {
     #[structopt(short = "a", long, default_value = "127.0.0.1")]
     pub address: String,
     /// Faucet service listen port
-    #[structopt(short = "p", long, default_value = "80")]
+    #[structopt(short = "p", long, default_value = "8000")]
     pub port: u16,
     /// Diem fullnode/validator server URL
     #[structopt(short = "s", long, default_value = "https://testnet.diem.com/v1")]


### PR DESCRIPTION

## Motivation

When starting validator docker with faucet, faucet need private_key at start up, thus can't start without waiting for private key generated from validator server.
This change lazy loads private key, so that faucet server can start without waiting for anything, the key file can be created later.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

YES

## Test Plan

Unit test
