### PR TITLE
[cluster-test] break down cluster test runner timeframe

### DIFF
--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -475,6 +475,7 @@ impl ClusterTestRunner {
 
     /// Discovers cluster, setup log, etc
     pub async fn setup(args: &Args) -> Result<Self> {
+        let start_time = Instant::now();
         let current_tag = args.deploy.as_deref().unwrap_or("master");
         let cluster_swarm = ClusterSwarmKube::new()
             .await
@@ -505,7 +506,9 @@ impl ClusterTestRunner {
             .ok();
         let tx_emitter = TxEmitter::new(&cluster, args.vasp);
         let github = GitHub::new();
-        let report = SuiteReport::new();
+        let mut report = SuiteReport::new();
+        let end_time = (Instant::now() - start_time).as_secs() as u64;
+        report.report_text(format!("Test runner setup time spent {} secs", end_time));
         let global_emit_job_request = EmitJobRequest {
             instances: vec![],
             accounts_per_client: args.accounts_per_client,
@@ -590,16 +593,20 @@ impl ClusterTestRunner {
         info!("Starting suite");
         let suite_started = Instant::now();
         for experiment in suite.experiments {
+            let start_time = Instant::now();
             let experiment_name = format!("{}", experiment);
             let experiment_result = self
                 .run_single_experiment(experiment, None)
                 .await
                 .map_err(move |e| format_err!("Experiment `{}` failed: `{}`", experiment_name, e));
+            let end_time = (Instant::now() - start_time).as_secs() as u64;
             if let Err(e) = experiment_result.as_ref() {
                 self.report.report_text(e.to_string());
                 self.print_report();
                 experiment_result?;
             }
+            self.report
+                .report_text_same_line(format!(", time spent {} secs", end_time))
         }
         info!(
             "Suite completed in {:?}",

--- a/testsuite/cluster-test/src/report.rs
+++ b/testsuite/cluster-test/src/report.rs
@@ -43,6 +43,10 @@ impl SuiteReport {
         self.text.push_str(&text);
     }
 
+    pub fn report_text_same_line(&mut self, text: String) {
+        self.text.push_str(&text);
+    }
+
     pub fn report_txn_stats(
         &mut self,
         experiment: String,


### PR DESCRIPTION
Add time breakdown into suite test report and changelog

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan
./scripts/cti --pr 7735 --suite perf

Before:
```
all up : 926 TPS, 4902 ms latency, 5600 ms p99 latency, no expired txns
10% down : 894 TPS, 4563 ms latency, 7650 ms p99 latency, no expired txns
3 Region Simulation : 733 TPS, 6209 ms latency, 7850 ms p99 latency, no expired txns
fixed tps 10 : 10 TPS, 924 ms latency, 1200 ms p99 latency, no expired txns
```

After:
```
Test runner setup time spent 298 secs
all up : 910 TPS, 4994 ms latency, 5700 ms p99 latency, no expired txns
Time spent 274 secs
10% down : 887 TPS, 4610 ms latency, 6500 ms p99 latency, no expired txns
Time spent 419 secs
3 Region Simulation : 724 TPS, 6305 ms latency, 7800 ms p99 latency, no expired txns
Time spent 267 secs
fixed tps 10 : 10 TPS, 913 ms latency, 1000 ms p99 latency, no expired txns
Time spent 248 secs
```

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/master/developers.diem.com, and link to your PR here.)
