### PR TITLE
Add custom formatter to diem_logger

### DIFF
--- a/common/logger/tests/logger_custom_format.rs
+++ b/common/logger/tests/logger_custom_format.rs
@@ -17,22 +17,30 @@ impl Writer for VecWriter {
 }
 
 #[test]
-fn verify_end_to_end() {
+fn test_custom_formatter() {
     let writer = VecWriter::default();
     let logs = writer.logs.clone();
     DiemLogger::builder()
         .is_async(false)
         .printer(Box::new(writer))
+        .custom_format(|entry| {
+            use std::fmt::Write;
+            let mut w = String::new();
+            write!(w, "0000-00-00")?;
+            write!(w, " [{}]", entry.metadata().level())?;
+            if let Some(message) = entry.message() {
+                write!(w, " {}", message)?;
+            }
+            if !entry.data().is_empty() {
+                write!(w, " {}", serde_json::to_string(&entry.data()).unwrap())?;
+            }
+            Ok(w)
+        })
         .build();
 
     assert_eq!(logs.read().len(), 0);
     info!("Hello");
     assert_eq!(logs.read().len(), 1);
     let string = logs.write().remove(0);
-    assert!(string.contains("INFO"));
-    assert!(string.ends_with("Hello"));
-    info!(foo = 5, bar = 10, foobar = 15);
-    let string = logs.write().remove(0);
-    let expect = r#"{"bar":10,"foo":5,"foobar":15}"#;
-    assert!(string.ends_with(expect));
+    assert_eq!(string, "0000-00-00 [INFO] Hello");
 }


### PR DESCRIPTION
## Motivation

Currently diem_logger doesn't allow custom formatting of log messages. This PR introduces custom format as part of logger builder and diem logger.


## Test Plan

Added test and verified manually
