### PR TITLE
[file-format] make a separate vec of module handles for friend decls

### DIFF
--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/bounds_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/bounds_tests.rs
@@ -138,10 +138,22 @@ fn invalid_struct_as_type_actual_in_exists() {
 }
 
 #[test]
-fn invalid_friend() {
+fn invalid_friend_module_address() {
     let mut m = basic_test_module();
-    m.friend_decls
-        .push(ModuleHandleIndex(m.module_handles.len() as TableIndex));
+    m.friend_decls.push(ModuleHandle {
+        address: AddressIdentifierIndex::new(m.address_identifiers.len() as TableIndex),
+        name: IdentifierIndex::new(0),
+    });
+    m.freeze().unwrap_err();
+}
+
+#[test]
+fn invalid_friend_module_name() {
+    let mut m = basic_test_module();
+    m.friend_decls.push(ModuleHandle {
+        address: AddressIdentifierIndex::new(0),
+        name: IdentifierIndex::new(m.identifiers.len() as TableIndex),
+    });
     m.freeze().unwrap_err();
 }
 

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/duplication_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/duplication_tests.rs
@@ -8,8 +8,12 @@ use vm::file_format::*;
 #[test]
 fn duplicated_friend_decls() {
     let mut m = basic_test_module();
-    m.friend_decls.push(ModuleHandleIndex(0));
-    m.friend_decls.push(ModuleHandleIndex(0));
+    let handle = ModuleHandle {
+        address: AddressIdentifierIndex::new(0),
+        name: IdentifierIndex::new(0),
+    };
+    m.friend_decls.push(handle.clone());
+    m.friend_decls.push(handle);
     DuplicationChecker::verify_module(&m.freeze().unwrap()).unwrap_err();
 }
 

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/generic_ops_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/generic_ops_tests.rs
@@ -163,10 +163,10 @@ fn make_module() -> CompiledModuleMut {
             },
         ],
         field_handles: vec![],
+        friend_decls: vec![],
         struct_def_instantiations: vec![],
         function_instantiations: vec![],
         field_instantiations: vec![],
-        friend_decls: vec![],
     }
 }
 

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
@@ -86,6 +86,7 @@ fn no_verify_locals_good() {
             },
         ],
         field_handles: vec![],
+        friend_decls: vec![],
         struct_def_instantiations: vec![],
         function_instantiations: vec![],
         field_instantiations: vec![],
@@ -117,7 +118,6 @@ fn no_verify_locals_good() {
                 }),
             },
         ],
-        friend_decls: vec![],
     };
     assert!(verify_module(&compiled_module_good.freeze().unwrap()).is_ok());
 }

--- a/language/bytecode-verifier/invalid-mutations/src/bounds.rs
+++ b/language/bytecode-verifier/invalid-mutations/src/bounds.rs
@@ -59,7 +59,7 @@ impl PointerKind {
             ],
             StructDefinition => &[One(StructHandle), Star(StructHandle)],
             FunctionDefinition => &[One(FunctionHandle), One(Signature)],
-            FriendDeclaration => &[One(ModuleHandle)],
+            FriendDeclaration => &[One(AddressIdentifier), One(Identifier)],
             Signature => &[Star(StructHandle)],
             FieldHandle => &[One(StructDefinition)],
             _ => &[],
@@ -311,8 +311,11 @@ impl ApplyOutOfBoundsContext {
             (FieldHandle, StructDefinition) => {
                 self.module.field_handles[src_idx].owner = StructDefinitionIndex(new_idx)
             }
-            (FriendDeclaration, ModuleHandle) => {
-                self.module.friend_decls[src_idx] = ModuleHandleIndex(new_idx)
+            (FriendDeclaration, AddressIdentifier) => {
+                self.module.friend_decls[src_idx].address = AddressIdentifierIndex(new_idx)
+            }
+            (FriendDeclaration, Identifier) => {
+                self.module.friend_decls[src_idx].name = IdentifierIndex(new_idx)
             }
             _ => panic!("Invalid pointer kind: {:?} -> {:?}", src_kind, dst_kind),
         }

--- a/language/bytecode-verifier/src/check_duplication.rs
+++ b/language/bytecode-verifier/src/check_duplication.rs
@@ -37,6 +37,7 @@ impl<'a> DuplicationChecker<'a> {
         Self::check_constants(module.constant_pool())?;
         Self::check_signatures(module.signatures())?;
         Self::check_module_handles(module.module_handles())?;
+        Self::check_module_handles(module.friend_decls())?;
         Self::check_struct_handles(module.struct_handles())?;
         Self::check_function_handles(module.function_handles())?;
         Self::check_function_instantiations(module.function_instantiations())?;
@@ -46,8 +47,7 @@ impl<'a> DuplicationChecker<'a> {
         checker.check_field_instantiations()?;
         checker.check_function_defintions()?;
         checker.check_struct_definitions()?;
-        checker.check_struct_instantiations()?;
-        checker.check_friend_declarations()
+        checker.check_struct_instantiations()
     }
 
     pub fn verify_script(module: &'a CompiledScript) -> VMResult<()> {
@@ -305,17 +305,6 @@ impl<'a> DuplicationChecker<'a> {
                 StatusCode::UNIMPLEMENTED_HANDLE,
                 IndexKind::FunctionHandle,
                 idx as TableIndex,
-            ));
-        }
-        Ok(())
-    }
-
-    fn check_friend_declarations(&self) -> PartialVMResult<()> {
-        if let Some(idx) = Self::first_duplicate_element(self.module.friend_decls()) {
-            return Err(verification_error(
-                StatusCode::DUPLICATE_ELEMENT,
-                IndexKind::FriendDeclaration,
-                idx,
             ));
         }
         Ok(())

--- a/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
@@ -173,7 +173,6 @@ fn make_module_with_function(
             type_parameters,
         }],
         field_handles: vec![],
-
         friend_decls: vec![],
 
         struct_def_instantiations: vec![],

--- a/language/vm/src/access.rs
+++ b/language/vm/src/access.rs
@@ -176,7 +176,7 @@ pub trait ModuleAccess: Sync {
         &self.as_module().as_inner().function_defs
     }
 
-    fn friend_decls(&self) -> &[ModuleHandleIndex] {
+    fn friend_decls(&self) -> &[ModuleHandle] {
         &self.as_module().as_inner().friend_decls
     }
 
@@ -200,7 +200,7 @@ pub trait ModuleAccess: Sync {
     fn friend_module_ids(&self) -> Vec<ModuleId> {
         self.friend_decls()
             .iter()
-            .map(|index| self.module_id_for_handle(self.module_handle_at(*index)))
+            .map(|handle| self.module_id_for_handle(handle))
             .collect()
     }
 }

--- a/language/vm/src/check_bounds.rs
+++ b/language/vm/src/check_bounds.rs
@@ -9,8 +9,8 @@ use crate::{
     file_format::{
         Bytecode, CodeOffset, CompiledModuleMut, Constant, FieldHandle, FieldInstantiation,
         FunctionDefinition, FunctionDefinitionIndex, FunctionHandle, FunctionInstantiation,
-        ModuleHandle, ModuleHandleIndex, Signature, SignatureToken, StructDefInstantiation,
-        StructDefinition, StructFieldInformation, StructHandle, TableIndex,
+        ModuleHandle, Signature, SignatureToken, StructDefInstantiation, StructDefinition,
+        StructFieldInformation, StructHandle, TableIndex,
     },
     internals::ModuleIndex,
     IndexKind,
@@ -56,7 +56,7 @@ impl<'a> BoundsChecker<'a> {
             bounds_check.check_field_handle(field_handle)?
         }
         for friend_decl in &bounds_check.module.friend_decls {
-            bounds_check.check_friend_decl(friend_decl)?
+            bounds_check.check_module_handle(friend_decl)?
         }
         for struct_instantiation in &bounds_check.module.struct_def_instantiations {
             bounds_check.check_struct_instantiation(struct_instantiation)?
@@ -133,10 +133,6 @@ impl<'a> BoundsChecker<'a> {
             }
         }
         Ok(())
-    }
-
-    fn check_friend_decl(&mut self, friend_declaration: &ModuleHandleIndex) -> PartialVMResult<()> {
-        check_bounds_impl(&self.module.module_handles, *friend_declaration)
     }
 
     fn check_struct_instantiation(

--- a/language/vm/src/deserializer.rs
+++ b/language/vm/src/deserializer.rs
@@ -553,7 +553,7 @@ fn build_module_tables(
                 load_field_instantiations(binary, table, &mut module.field_instantiations)?;
             }
             TableType::FRIEND_DECLS => {
-                load_friend_decls(binary, table, &mut module.friend_decls)?;
+                load_module_handles(binary, table, &mut module.friend_decls)?;
             }
             TableType::MODULE_HANDLES
             | TableType::STRUCT_HANDLES
@@ -1233,24 +1233,6 @@ fn load_struct_definition_indices(
         indices.push(load_struct_def_index(cursor)?);
     }
     Ok(indices)
-}
-
-/// Builds the `Vec<ModuleHandleIndex>` table serving as friend declarations.
-fn load_friend_decls(
-    binary: &VersionedBinary,
-    table: &Table,
-    friend_decls: &mut Vec<ModuleHandleIndex>,
-) -> BinaryLoaderResult<()> {
-    let start = table.offset as usize;
-    let end = start
-        .checked_add(table.count as usize)
-        .expect("Unexpected overflow as the error should be detected early by `check_tables`");
-    let mut cursor = binary.new_cursor(start, end);
-    while cursor.position() < u64::from(table.count) {
-        let module = load_module_handle_index(&mut cursor)?;
-        friend_decls.push(module);
-    }
-    Ok(())
 }
 
 /// Deserializes a `CodeUnit`.

--- a/language/vm/src/file_format.rs
+++ b/language/vm/src/file_format.rs
@@ -1781,7 +1781,6 @@ impl CompiledScriptMut {
             struct_handles: self.struct_handles,
             function_handles: self.function_handles,
             field_handles: vec![],
-
             friend_decls: vec![],
 
             struct_def_instantiations: vec![],
@@ -1817,7 +1816,7 @@ pub struct CompiledModule(CompiledModuleMut);
 pub struct CompiledModuleMut {
     /// Handle to self.
     pub self_module_handle_idx: ModuleHandleIndex,
-    /// Handles to external modules and self.
+    /// Handles to external dependency modules and self.
     pub module_handles: Vec<ModuleHandle>,
     /// Handles to external and internal types.
     pub struct_handles: Vec<StructHandle>,
@@ -1825,9 +1824,9 @@ pub struct CompiledModuleMut {
     pub function_handles: Vec<FunctionHandle>,
     /// Handles to fields.
     pub field_handles: Vec<FieldHandle>,
+    /// Friend declarations, represented as a collection of handles to external friend modules.
+    pub friend_decls: Vec<ModuleHandle>,
 
-    /// Friend declarations.
-    pub friend_decls: Vec<ModuleHandleIndex>,
     /// Struct instantiations.
     pub struct_def_instantiations: Vec<StructDefInstantiation>,
     /// Function instantiations.
@@ -1919,7 +1918,7 @@ impl Arbitrary for CompiledModuleMut {
                 vec(any::<FunctionHandle>(), 0..=size),
             ),
             any::<ModuleHandleIndex>(),
-            vec(any::<ModuleHandleIndex>(), 0..=size),
+            vec(any::<ModuleHandle>(), 0..=size),
             vec(any_with::<Signature>(size), 0..=size),
             (
                 vec(any::<Identifier>(), 0..=size),

--- a/language/vm/src/proptest_types.rs
+++ b/language/vm/src/proptest_types.rs
@@ -25,7 +25,7 @@ use functions::{
 };
 
 use crate::proptest_types::types::{StDefnMaterializeState, StructDefinitionGen, StructHandleGen};
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap};
 
 /// Represents how large [`CompiledModule`] tables can be.
 pub type TableSize = u16;
@@ -174,7 +174,7 @@ impl CompiledModuleStrategyGen {
         //
         // Friend generator
         //
-        let friends_strat = vec(any::<PropIndex>(), 0..=self.size);
+        let friends_strat = vec(any::<(PropIndex, PropIndex)>(), 1..=self.size);
 
         // Note that prop_test only allows a tuple of length up to 10
         (
@@ -220,12 +220,13 @@ impl CompiledModuleStrategyGen {
 
                     //
                     // Friend Declarations
-                    let friend_decl_set: HashSet<_> = friend_decl_gens
+                    let friend_decl_set: BTreeSet<_> = friend_decl_gens
                         .into_iter()
-                        .map(|friend_decl_gen| {
-                            ModuleHandleIndex(
-                                friend_decl_gen.index(module_handles_len) as TableIndex
-                            )
+                        .map(|(address_gen, name_gen)| ModuleHandle {
+                            address: AddressIdentifierIndex(
+                                address_gen.index(address_identifiers_len) as TableIndex,
+                            ),
+                            name: IdentifierIndex(name_gen.index(identifiers_len) as TableIndex),
                         })
                         .collect();
                     let friend_decls = friend_decl_set.into_iter().collect();
@@ -315,7 +316,6 @@ impl CompiledModuleStrategyGen {
                         struct_handles,
                         function_handles,
                         field_handles,
-
                         friend_decls,
 
                         struct_def_instantiations,

--- a/language/vm/src/serializer.rs
+++ b/language/vm/src/serializer.rs
@@ -1254,13 +1254,13 @@ impl ModuleSerializer {
     fn serialize_friend_declarations(
         &mut self,
         binary: &mut BinaryData,
-        friend_declarations: &[ModuleHandleIndex],
+        friend_declarations: &[ModuleHandle],
     ) -> Result<()> {
         if !friend_declarations.is_empty() {
             self.common.table_count = self.common.table_count.wrapping_add(1); // the count will bound to a small number
             self.friend_decls.0 = check_index_in_binary(binary.len())?;
             for module in friend_declarations {
-                serialize_module_handle_index(binary, module)?;
+                serialize_module_handle(binary, module)?;
             }
             self.friend_decls.1 = checked_calculate_table_size(binary, self.friend_decls.0)?;
         }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Friend modules and dependencies modules should not overlap, therefore, it might be good to keep them separate in the file format.

The original design repurposes `module_handles` and ask the `friend_decls` to take a `ModuleHandleIndex` off the `module_handles` table. This essentially overloads  `module_handles` to contain both dependencies modules as well as friend modules, which changed its semantic meaning and leads to a series of complexities, such as
- the need for an `unused` checker
- loaded APIs in `ModuleAccess`
- complicated logic in the compatibility checker

For detailed discussions, see #7640.

The new format escalates `friend_decls` from being a vector of `ModuleHandleIndex` into a vector of `ModuleHandle`. In this way, `friend_decls` and `module_handles` have clear and distinct meanings and are independent of each other.
- `module_handles` contains dependencies of this module
- `friend_decls` contains friends of this module.

And for a `CompiledModule` to be valid, these two tables must be disjoint (this will be checked by the bytecode verifier).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Bounds checking, proptests, valid and invalid mutation strategies are updated accordingly. So all tests should pass.
