### PR TITLE
[storage] get_last_version_before_timestamp()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2473,6 +2473,7 @@ dependencies = [
  "diem-types",
  "diem-workspace-hack",
  "itertools 0.10.0",
+ "move-core-types",
  "num-derive",
  "num-traits",
  "num-variants",

--- a/storage/diemdb/Cargo.toml
+++ b/storage/diemdb/Cargo.toml
@@ -47,6 +47,7 @@ diem-jellyfish-merkle = { path = "../jellyfish-merkle", features = ["fuzzing"] }
 diem-proptest-helpers = { path = "../../common/proptest-helpers" }
 diem-temppath = { path = "../../common/temppath" }
 diem-types = { path = "../../types", features = ["fuzzing"] }
+move-core-types = {path = "../../language/move-core/types"}
 
 [features]
 default = []

--- a/storage/diemdb/src/diemdb_test.rs
+++ b/storage/diemdb/src/diemdb_test.rs
@@ -185,8 +185,13 @@ fn get_events_by_event_key(
 
     let mut ret = Vec::new();
     loop {
-        let events_with_proof =
-            db.get_events_by_event_key(event_key, cursor, order, LIMIT, ledger_info.version())?;
+        let events_with_proof = db.get_events_with_proof_by_event_key(
+            event_key,
+            cursor,
+            order,
+            LIMIT,
+            ledger_info.version(),
+        )?;
 
         let num_events = events_with_proof.len() as u64;
         if cursor == u64::max_value() {

--- a/storage/diemdb/src/event_store/test.rs
+++ b/storage/diemdb/src/event_store/test.rs
@@ -13,6 +13,7 @@ use diem_types::{
     proptest_types::{AccountInfoUniverse, ContractEventGen},
 };
 use itertools::Itertools;
+use move_core_types::{language_storage::TypeTag, move_resource::MoveResource};
 use proptest::{
     collection::{hash_set, vec},
     prelude::*,
@@ -262,4 +263,107 @@ fn test_index_get_impl(event_batches: Vec<Vec<ContractEvent>>) {
             let traversed = traverse_events_by_key(&store, &path, ledger_version_plus_one);
             assert_eq!(events, traversed);
         });
+}
+
+prop_compose! {
+    fn arb_new_block_events()(
+        address in any::<AccountAddress>(),
+        mut version in 1..10000u64,
+        mut timestamp in 0..1000000u64, // initial timestamp
+        block_bumps in vec(
+            prop_oneof![
+                Just((1, 0)), // NIL Block
+                (1..100u64, 1..100u64) // normal block
+            ], // version and timestamp bump
+            1..100,
+        )
+    ) -> Vec<(Version, ContractEvent)> {
+        let mut seq = 0;
+        block_bumps.into_iter().map(|(v, t)| {
+            version += v;
+            timestamp += t;
+            let new_block_event = NewBlockEvent::new(
+                seq, // round
+                address, // proposer
+                Vec::new(), // prev block voters
+                timestamp,
+            );
+            let event = ContractEvent::new(
+                new_block_event_key(),
+                seq,
+                TypeTag::Struct(NewBlockEvent::struct_tag()),
+                bcs::to_bytes(&new_block_event).unwrap(),
+            );
+            seq += 1;
+            (version, event)
+        }).collect()
+    }
+}
+
+fn test_get_last_version_before_timestamp_impl(new_block_events: Vec<(Version, ContractEvent)>) {
+    let tmp_dir = TempPath::new();
+    let db = DiemDB::new_for_test(&tmp_dir);
+    let store = &db.event_store;
+    // error on no blocks
+    assert!(store.get_last_version_before_timestamp(1000, 2000).is_err());
+
+    // save events to db
+    let mut cs = ChangeSet::new();
+    new_block_events.iter().for_each(|(ver, event)| {
+        store
+            .put_events(*ver as u64, &[event.clone()], &mut cs)
+            .unwrap();
+    });
+    store.db.write_schemas(cs.batch);
+
+    let ledger_version = new_block_events.last().unwrap().0;
+
+    // error on no block before timestamp
+    let (first_block_version, first_event) = new_block_events.first().unwrap();
+    let first_new_block_event: NewBlockEvent = first_event.try_into().unwrap();
+    let first_block_ts = first_new_block_event.proposed_time();
+    assert!(store
+        .get_last_version_before_timestamp(1000, *first_block_version)
+        .is_err());
+    assert!(store
+        .get_last_version_before_timestamp(first_block_ts, Version::max_value())
+        .is_err());
+
+    let mut last_block_ts = first_block_ts;
+    let mut last_block_version = *first_block_version;
+    for (version, event) in new_block_events.iter().skip(1) {
+        let new_block_event: NewBlockEvent = event.try_into().unwrap();
+        let ts = new_block_event.proposed_time();
+        if ts == last_block_ts {
+            // skip NIL blocks
+            continue;
+        }
+        assert_eq!(
+            store
+                .get_last_version_before_timestamp((last_block_ts + ts + 1) / 2, ledger_version)
+                .unwrap(),
+            version - 1,
+        );
+        assert_eq!(
+            store
+                .get_last_version_before_timestamp(ts, ledger_version)
+                .unwrap(),
+            version - 1,
+        );
+
+        last_block_version = *version;
+        last_block_ts = ts;
+    }
+
+    // error on no block after required ts
+    assert!(store
+        .get_last_version_before_timestamp(last_block_ts + 1, ledger_version)
+        .is_err());
+}
+
+proptest! {
+    #[test]
+    fn test_get_last_version_before_timestamp(new_block_events in arb_new_block_events()) {
+        test_get_last_version_before_timestamp_impl(new_block_events)
+    }
 }

--- a/storage/diemdb/src/lib.rs
+++ b/storage/diemdb/src/lib.rs
@@ -898,6 +898,17 @@ impl DbReader for DiemDB {
         })
     }
 
+    fn get_last_version_before_timestamp(
+        &self,
+        timestamp: u64,
+        ledger_version: Version,
+    ) -> Result<Version> {
+        gauged_api("get_last_version_before_timestamp", || {
+            self.event_store
+                .get_last_version_before_timestamp(timestamp, ledger_version)
+        })
+    }
+
     fn get_latest_transaction_info_option(&self) -> Result<Option<(Version, TransactionInfo)>> {
         gauged_api("get_latest_transaction_info_option", || {
             self.ledger_store.get_latest_transaction_info_option()

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -210,6 +210,17 @@ pub trait DbReader: Send + Sync {
     /// ../diemdb/struct.DiemDB.html#method.get_block_timestamp
     fn get_block_timestamp(&self, version: u64) -> Result<u64>;
 
+    /// Gets the version of the last transaction committed before timestamp,
+    /// a commited block at or after the required timestamp must exist (otherwise it's possible
+    /// the next block committed as a timestamp smaller than the one in the request).
+    fn get_last_version_before_timestamp(
+        &self,
+        _timestamp: u64,
+        _ledger_version: Version,
+    ) -> Result<Version> {
+        unimplemented!()
+    }
+
     /// See [`DiemDB::get_latest_account_state`].
     ///
     /// [`DiemDB::get_latest_account_state`]:

--- a/types/src/account_config/events/new_block.rs
+++ b/types/src/account_config/events/new_block.rs
@@ -31,6 +31,21 @@ impl NewBlockEvent {
     pub fn try_from_bytes(bytes: &[u8]) -> Result<Self> {
         bcs::from_bytes(bytes).map_err(Into::into)
     }
+
+    #[cfg(any(test, feature = "fuzzing"))]
+    pub fn new(
+        round: u64,
+        proposer: AccountAddress,
+        previous_block_votes: Vec<AccountAddress>,
+        time_micro_seconds: u64,
+    ) -> Self {
+        Self {
+            round,
+            proposer,
+            previous_block_votes,
+            time_micro_seconds,
+        }
+    }
 }
 
 impl MoveResource for NewBlockEvent {


### PR DESCRIPTION


## Motivation
Via binary search on the event by key index.
This is for audit report generation. There's on proof in this version, but proof can be two consecutive NewBlockEvents (with their proofs) showing the timestamp bump from before to at/after the timestamp in the request.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan
Unit test.
## Related PRs
