### PR TITLE
[move-prover] Implemented the spec pragmas "emits_is_partial" and "emits_is_strict"

### DIFF
--- a/language/move-model/src/ast.rs
+++ b/language/move-model/src/ast.rs
@@ -655,7 +655,8 @@ pub enum Operation {
     UnboxValue,
     EmptyEventStore,
     ExtendEventStore,
-    CheckEventStore,
+    EventStoreIncludes,
+    EventStoreIncludedIn,
 
     // Operation with no effect
     NoOp,

--- a/language/move-model/src/pragmas.rs
+++ b/language/move-model/src/pragmas.rs
@@ -26,6 +26,12 @@ pub const INTRINSIC_PRAGMA: &str = "intrinsic";
 /// instead interpreted by its pre and post conditions only.
 pub const OPAQUE_PRAGMA: &str = "opaque";
 
+/// Pragma indicating whether emits specification should be considered partial.
+pub const EMITS_IS_PARTIAL_PRAGMA: &str = "emits_is_partial";
+
+/// Pragma indicating whether no emits specification should mean that no events are to be emitted.
+pub const EMITS_IS_STRICT_PRAGMA: &str = "emits_is_strict";
+
 /// Pragma indicating whether aborts_if specification should be considered partial.
 pub const ABORTS_IF_IS_PARTIAL_PRAGMA: &str = "aborts_if_is_partial";
 
@@ -70,6 +76,8 @@ pub fn is_pragma_valid_for_block(target: &SpecBlockContext<'_>, pragma: &str) ->
         Module => matches!(
             pragma,
             VERIFY_PRAGMA
+                | EMITS_IS_STRICT_PRAGMA
+                | EMITS_IS_PARTIAL_PRAGMA
                 | ABORTS_IF_IS_STRICT_PRAGMA
                 | ABORTS_IF_IS_PARTIAL_PRAGMA
                 | INTRINSIC_PRAGMA
@@ -82,6 +90,8 @@ pub fn is_pragma_valid_for_block(target: &SpecBlockContext<'_>, pragma: &str) ->
                 | VERIFY_DURATION_ESTIMATE_PRAGMA
                 | INTRINSIC_PRAGMA
                 | OPAQUE_PRAGMA
+                | EMITS_IS_STRICT_PRAGMA
+                | EMITS_IS_PARTIAL_PRAGMA
                 | ABORTS_IF_IS_PARTIAL_PRAGMA
                 | ABORTS_IF_IS_STRICT_PRAGMA
                 | REQUIRES_IF_ABORTS_PRAGMA

--- a/language/move-prover/tests/sources/functional/emits.exp
+++ b/language/move-prover/tests/sources/functional/emits.exp
@@ -112,6 +112,27 @@ error: function does not emit the expected event
     =     at tests/sources/functional/emits.move:70
     =     at tests/sources/functional/emits.move:71
 
+error: emitted event not covered by any of `emits` clauses
+
+     ┌── tests/sources/functional/emits.move:218:5 ───
+     │
+ 218 │ ╭     spec fun partial_incorrect {
+ 219 │ │         emits DummyEvent{msg: 0} to handle;
+ 220 │ │     }
+     │ ╰─────^
+     │
+     =     at tests/sources/functional/emits.move:214: partial_incorrect
+     =     at <internal>:1
+     =     at tests/sources/functional/emits.move:214: partial_incorrect
+     =         handle = <redacted>
+     =     at tests/sources/functional/emits.move:215: partial_incorrect
+     =     at tests/sources/functional/emits.move:215: partial_incorrect
+     =     at tests/sources/functional/emits.move:216: partial_incorrect
+     =     at tests/sources/functional/emits.move:216: partial_incorrect
+     =     at tests/sources/functional/emits.move:217: partial_incorrect
+     =     at tests/sources/functional/emits.move:219
+     =     at tests/sources/functional/emits.move:218
+
 error: function does not emit the expected event
 
     ┌── tests/sources/functional/emits.move:30:9 ───
@@ -144,3 +165,23 @@ error: function does not emit the expected event
     =     at tests/sources/functional/emits.move:20: simple_wrong_msg_incorrect
     =     at tests/sources/functional/emits.move:21: simple_wrong_msg_incorrect
     =     at tests/sources/functional/emits.move:23
+
+error: emitted event not covered by any of `emits` clauses
+
+     ┌── tests/sources/functional/emits.move:238:5 ───
+     │
+ 238 │ ╭     spec fun strict_incorrect {
+ 239 │ │         pragma emits_is_strict;
+ 240 │ │     }
+     │ ╰─────^
+     │
+     =     at tests/sources/functional/emits.move:234: strict_incorrect
+     =     at <internal>:1
+     =     at tests/sources/functional/emits.move:234: strict_incorrect
+     =         handle = <redacted>
+     =     at tests/sources/functional/emits.move:235: strict_incorrect
+     =     at tests/sources/functional/emits.move:235: strict_incorrect
+     =     at tests/sources/functional/emits.move:236: strict_incorrect
+     =     at tests/sources/functional/emits.move:236: strict_incorrect
+     =     at tests/sources/functional/emits.move:237: strict_incorrect
+     =     at tests/sources/functional/emits.move:238

--- a/language/move-prover/tests/sources/functional/emits.move
+++ b/language/move-prover/tests/sources/functional/emits.move
@@ -196,4 +196,46 @@ module TestEmits {
         handle: EventHandle<DummyEvent>;
         emits DummyEvent{msg: 0} to handle;
     }
+
+
+    // ----------------------------
+    // pragma emits_is_partial
+    // ----------------------------
+
+    public fun partial(handle: &mut EventHandle<DummyEvent>) {
+        Event::emit_event(handle, DummyEvent{msg: 0});
+        Event::emit_event(handle, DummyEvent{msg: 1});
+    }
+    spec fun partial {
+        pragma emits_is_partial;
+        emits DummyEvent{msg: 0} to handle;
+    }
+
+    public fun partial_incorrect(handle: &mut EventHandle<DummyEvent>) {
+        Event::emit_event(handle, DummyEvent{msg: 0});
+        Event::emit_event(handle, DummyEvent{msg: 1});
+    }
+    spec fun partial_incorrect {
+        emits DummyEvent{msg: 0} to handle;
+    }
+
+
+    // ----------------------------
+    // pragma emits_is_strict
+    // ----------------------------
+
+    public fun strict(handle: &mut EventHandle<DummyEvent>) {
+        Event::emit_event(handle, DummyEvent{msg: 0});
+        Event::emit_event(handle, DummyEvent{msg: 1});
+    }
+    spec fun strict {
+    }
+
+    public fun strict_incorrect(handle: &mut EventHandle<DummyEvent>) {
+        Event::emit_event(handle, DummyEvent{msg: 0});
+        Event::emit_event(handle, DummyEvent{msg: 1});
+    }
+    spec fun strict_incorrect {
+        pragma emits_is_strict;
+    }
 }


### PR DESCRIPTION
- (emits_is_partial == false) by default. If emits_is_partial == true, Prover skips the completeness check of the emits specs.

- By default, (emits_is_strict == false), and Prover checks nothing about events if a function has no emits spec. If emits_is_partial == true, Prover checks that each function with no emits specs actually emits no events.

TODO:
- Support the `emits` verification with `opaque` functions

## Motivation

To support the "emits_is_partial" and "emits_is_strict" pragmas

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test
