### PR TITLE
[Vault Storage] Reduce default timeouts and support custom timeouts for operator tooling

### DIFF
--- a/config/management/src/secure_backend.rs
+++ b/config/management/src/secure_backend.rs
@@ -17,6 +17,10 @@ pub const GITHUB: &str = "github";
 pub const MEMORY: &str = "memory";
 pub const VAULT: &str = "vault";
 
+// Custom timeouts for vault backend operations when using the management tooling.
+const CONNECTION_TIMEOUT_MS: u64 = 10_000;
+const RESPONSE_TIMEOUT_MS: u64 = 10_000;
+
 /// SecureBackend is a parameter that is stored as set of semi-colon separated key/value pairs. The
 /// only expected key is backend which defines which of the SecureBackends the parameters refer to.
 /// Some backends require parameters others do not, so that requires a conversion into the
@@ -116,8 +120,8 @@ impl TryInto<config::SecureBackend> for SecureBackend {
                     token: Token::FromDisk(PathBuf::from(token)),
                     renew_ttl_secs: None,
                     disable_cas: Some(true),
-                    connection_timeout_ms: None,
-                    response_timeout_ms: None,
+                    connection_timeout_ms: Some(CONNECTION_TIMEOUT_MS),
+                    response_timeout_ms: Some(RESPONSE_TIMEOUT_MS),
                 })
             }
             _ => panic!("Invalid backend: {}", self.backend),

--- a/secure/storage/vault/src/lib.rs
+++ b/secure/storage/vault/src/lib.rs
@@ -28,8 +28,8 @@ pub mod fuzzing;
 const MAX_NUM_KEY_VERSIONS: u32 = 4;
 
 /// Default request timeouts for vault operations.
-const DEFAULT_CONNECTION_TIMEOUT_MS: u64 = 10_000;
-const DEFAULT_RESPONSE_TIMEOUT_MS: u64 = 10_000;
+const DEFAULT_CONNECTION_TIMEOUT_MS: u64 = 100;
+const DEFAULT_RESPONSE_TIMEOUT_MS: u64 = 1_000;
 
 #[derive(Debug, Error, PartialEq)]
 pub enum Error {


### PR DESCRIPTION
## Motivation

This PR:
- Reduces the default timeout for vault from 10 seconds (for connections and all other operations) to 0.1 seconds for connections and 1 seconds for all other operations (e.g., reads and writes).
- Updates the operator tool to maintain custom timeouts of 10 seconds for vault (as are the current defaults). This is preferable in the case of the operator tooling because operators may connect to vault deployments further away and also don't require aggressive timeouts.

Notes:
- We may have to discuss whether or not we want to be more or less aggressive for the corresponding timeouts, but I'll leave that up to the reviewers 😄

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally.

## Related PRs

This relates to an issue we're seeing with transient vault outages for safety rules (https://github.com/diem/partners/issues/727) and is a follow up to a previous PR (https://github.com/diem/diem/pull/7675)
