### PR TITLE
[draft][diem_vm] Implement a naive parallel execution strategy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2447,6 +2447,8 @@ dependencies = [
  "move-core-types",
  "move-vm-runtime",
  "move-vm-types",
+ "mvhashmap",
+ "num_cpus",
  "once_cell",
  "proptest",
  "rayon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4759,6 +4759,7 @@ dependencies = [
  "move-vm-natives",
  "move-vm-types",
  "once_cell",
+ "parking_lot",
  "proptest",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4812,6 +4812,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mvhashmap"
+version = "0.1.0"
+dependencies = [
+ "num_cpus",
+ "once_cell",
+ "rayon",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ members = [
     "language/diem-tools/transaction-replay",
     "language/diem-tools/writeset-transaction-generator",
     "language/diem-vm",
+    "language/diem-vm/mvhashmap",
     "language/e2e-testsuite",
     "language/ir-testsuite",
     "language/move-binary-format",

--- a/language/benchmarks/benches/transaction_benches.rs
+++ b/language/benchmarks/benches/transaction_benches.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use criterion::{criterion_group, criterion_main, measurement::Measurement, Criterion};
-use language_benchmarks::{measurement::cpu_time_measurement, transactions::TransactionBencher};
+use language_benchmarks::{measurement::wall_time_measurement, transactions::TransactionBencher};
 use language_e2e_tests::account_universe::P2PTransferGen;
 use proptest::prelude::*;
 
@@ -19,7 +19,7 @@ fn peer_to_peer<M: Measurement + 'static>(c: &mut Criterion<M>) {
 
 criterion_group!(
     name = txn_benches;
-    config = cpu_time_measurement();
+    config = wall_time_measurement().sample_size(10);
     targets = peer_to_peer
 );
 

--- a/language/benchmarks/src/transactions.rs
+++ b/language/benchmarks/src/transactions.rs
@@ -28,10 +28,10 @@ where
     S::Value: AUTransactionGen,
 {
     /// The number of accounts created by default.
-    pub const DEFAULT_NUM_ACCOUNTS: usize = 100;
+    pub const DEFAULT_NUM_ACCOUNTS: usize = 1000;
 
     /// The number of transactions created by default.
-    pub const DEFAULT_NUM_TRANSACTIONS: usize = 500;
+    pub const DEFAULT_NUM_TRANSACTIONS: usize = 10000;
 
     /// Creates a new transaction bencher with default settings.
     pub fn new(strategy: S) -> Self {

--- a/language/diem-vm/Cargo.toml
+++ b/language/diem-vm/Cargo.toml
@@ -15,6 +15,7 @@ fail = "0.4.0"
 once_cell = "1.7.2"
 rayon = "1.5.0"
 mirai-annotations = "1.10.1"
+num_cpus = "1.13.0"
 
 bcs = "0.1.2"
 diem-crypto = { path = "../../crypto/crypto" }
@@ -29,6 +30,7 @@ move-vm-types = { path = "../move-vm/types" }
 move-binary-format = { path = "../move-binary-format" }
 serde_json = "1.0.64"
 serde = { version = "1.0.124", default-features = false }
+mvhashmap = { path = "mvhashmap" }
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/language/diem-vm/mvhashmap/Cargo.toml
+++ b/language/diem-vm/mvhashmap/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "mvhashmap"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+description = "Diem VM runtime"
+repository = "https://github.com/diem/diem"
+homepage = "https://diem.com"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+once_cell = "1.7.2"
+rayon = "1.5.0"
+num_cpus = "1.13.0"

--- a/language/diem-vm/mvhashmap/src/lib.rs
+++ b/language/diem-vm/mvhashmap/src/lib.rs
@@ -1,0 +1,271 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use once_cell::sync::OnceCell;
+use std::{
+    cmp::{max, PartialOrd},
+    collections::{btree_map::BTreeMap, HashMap},
+    hash::Hash,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+/// A structure that holds placeholders for each write to the database
+//
+//  The structure is created by one thread creating the scheduling, and
+//  at that point it is used as a &mut by that single thread.
+//
+//  Then it is passed to all threads executing as a shared reference. At
+//  this point only a single thread must write to any entry, and others
+//  can read from it. Only entries are mutated using interior mutability,
+//  but no entries can be added or deleted.
+//
+
+pub type Version = usize;
+
+const FLAG_UNASSIGNED: usize = 0;
+const FLAG_DONE: usize = 2;
+const FLAG_SKIP: usize = 3;
+
+pub struct MVHashMap<K, V> {
+    data: HashMap<K, BTreeMap<Version, WriteVersionValue<V>>>,
+}
+
+#[cfg_attr(any(target_arch = "x86_64"), repr(align(128)))]
+pub(crate) struct WriteVersionValue<V> {
+    flag: AtomicUsize,
+    data: OnceCell<Option<V>>,
+}
+
+impl<V> WriteVersionValue<V> {
+    pub fn new() -> WriteVersionValue<V> {
+        WriteVersionValue {
+            flag: AtomicUsize::new(FLAG_UNASSIGNED),
+            data: OnceCell::new(),
+        }
+    }
+}
+
+impl<K: Hash + Clone + Eq, V: Clone> MVHashMap<K, V> {
+    pub fn new() -> MVHashMap<K, V> {
+        MVHashMap {
+            data: HashMap::new(),
+        }
+    }
+
+    pub fn new_from(possible_writes: Vec<(K, Version)>) -> (usize, MVHashMap<K, V>) {
+        let mut map: HashMap<K, BTreeMap<Version, WriteVersionValue<V>>> = HashMap::new();
+        for (key, version) in possible_writes.into_iter() {
+            map.entry(key)
+                .or_default()
+                .insert(version, WriteVersionValue::new());
+        }
+        (
+            map.values()
+                .fold(0, |max_depth, map| max(max_depth, map.len())),
+            MVHashMap { data: map },
+        )
+    }
+
+    pub fn get_change_set(&self) -> Vec<(K, Option<V>)> {
+        let mut change_set = Vec::with_capacity(self.data.len());
+        for (k, _) in self.data.iter() {
+            let val = self.read(k, usize::MAX).unwrap();
+            change_set.push((k.clone(), val.clone()));
+        }
+        change_set
+    }
+
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    pub fn write(&self, key: &K, version: Version, data: Option<V>) -> Result<(), ()> {
+        // By construction there will only be a single writer, before the
+        // write there will be no readers on the variable.
+        // So it is safe to go ahead and write without any further check.
+        // Then update the flag to enable reads.
+
+        let entry = self
+            .data
+            .get(key)
+            .ok_or_else(|| ())?
+            .get(&version)
+            .ok_or_else(|| ())?;
+
+        #[cfg(test)]
+        {
+            // Test the invariant holds
+            let flag = entry.flag.load(Ordering::Acquire);
+            if flag != FLAG_UNASSIGNED {
+                panic!("Cannot write twice to same entry.");
+            }
+        }
+
+        entry.data.set(data).map_err(|_| ())?;
+
+        entry.flag.store(FLAG_DONE, Ordering::Release);
+        Ok(())
+    }
+
+    pub fn skip_if_not_set(&self, key: &K, version: Version) -> Result<(), ()> {
+        // We only write or skip once per entry
+        // So it is safe to go ahead and just do it.
+        let entry = self
+            .data
+            .get(key)
+            .ok_or_else(|| ())?
+            .get(&version)
+            .ok_or_else(|| ())?;
+
+        // Test the invariant holds
+        let flag = entry.flag.load(Ordering::Acquire);
+        if flag == FLAG_UNASSIGNED {
+            entry.flag.store(FLAG_SKIP, Ordering::Release);
+        }
+
+        Ok(())
+    }
+
+    pub fn skip(&self, key: &K, version: Version) -> Result<(), ()> {
+        // We only write or skip once per entry
+        // So it is safe to go ahead and just do it.
+        let entry = self
+            .data
+            .get(key)
+            .ok_or_else(|| ())?
+            .get(&version)
+            .ok_or_else(|| ())?;
+
+        #[cfg(test)]
+        {
+            // Test the invariant holds
+            let flag = entry.flag.load(Ordering::Acquire);
+            if flag != FLAG_UNASSIGNED {
+                panic!("Cannot write twice to same entry.");
+            }
+        }
+
+        entry.flag.store(FLAG_SKIP, Ordering::Release);
+        Ok(())
+    }
+
+    pub fn read(&self, key: &K, version: Version) -> Result<&Option<V>, Option<Version>> {
+        // Get the smaller key
+        let tree = self.data.get(key).ok_or_else(|| None)?;
+
+        let mut iter = tree.range(0..version);
+
+        while let Some((entry_key, entry_val)) = iter.next_back() {
+            if *entry_key < version {
+                let flag = entry_val.flag.load(Ordering::Acquire);
+
+                // Return this key, must wait.
+                if flag == FLAG_UNASSIGNED {
+                    return Err(Some(*entry_key));
+                }
+
+                // If we are to skip this entry, pick the next one
+                if flag == FLAG_SKIP {
+                    continue;
+                }
+
+                // The entry is populated so return its contents
+                if flag == FLAG_DONE {
+                    return Ok(entry_val.data.get().unwrap());
+                }
+
+                unreachable!();
+            }
+        }
+
+        Err(None)
+    }
+}
+
+impl<K, V> MVHashMap<K, V>
+where
+    K: PartialOrd + Send + Clone + Hash + Eq,
+    V: Send,
+{
+    fn split_merge(
+        num_cpus: usize,
+        num: usize,
+        split: Vec<(K, Version)>,
+    ) -> (usize, HashMap<K, BTreeMap<Version, WriteVersionValue<V>>>) {
+        if ((2 << num) > num_cpus) || split.len() < 1000 {
+            let mut data = HashMap::new();
+            let mut max_len = 0;
+            for (path, version) in split.into_iter() {
+                let place = data.entry(path).or_insert(BTreeMap::new());
+                place.insert(version, WriteVersionValue::new());
+                max_len = max(max_len, place.len());
+            }
+            (max_len, data)
+        } else {
+            let pivot_address = split[split.len() / 2].0.clone();
+            let (left, right): (Vec<_>, Vec<_>) =
+                split.into_iter().partition(|(p, _)| *p < pivot_address);
+            let ((m0, mut left_map), (m1, right_map)) = rayon::join(
+                || Self::split_merge(num_cpus, num + 1, left),
+                || Self::split_merge(num_cpus, num + 1, right),
+            );
+            left_map.extend(right_map);
+            (max(m0, m1), left_map)
+        }
+    }
+
+    pub fn new_from_parallel(possible_writes: Vec<(K, Version)>) -> (usize, MVHashMap<K, V>) {
+        let num_cpus = num_cpus::get();
+
+        let (max_dependency_depth, data) = Self::split_merge(num_cpus, 0, possible_writes);
+        (max_dependency_depth, MVHashMap { data })
+    }
+}
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn create_write_read_placeholder_struct() {
+        let ap1 = b"/foo/b".to_vec();
+        let ap2 = b"/foo/c".to_vec();
+
+        let data = vec![(ap1.clone(), 10), (ap2.clone(), 10), (ap2.clone(), 20)];
+
+        let (max_dep, mvtbl) = MVHashMap::new_from(data);
+
+        assert_eq!(2, max_dep);
+
+        assert_eq!(2, mvtbl.len());
+
+        // Reads that should go the the DB return Err(None)
+        let r1 = mvtbl.read(&ap1, 5);
+        assert_eq!(Err(None), r1);
+
+        // Reads at a version return the previous versions, not this
+        // version.
+        let r1 = mvtbl.read(&ap1, 10);
+        assert_eq!(Err(None), r1);
+
+        // Check reads into non-ready structs return the Err(entry)
+
+        // Reads at a higher version return the previous version
+        let r1 = mvtbl.read(&ap1, 15);
+        assert_eq!(Err(Some(10)), r1);
+
+        // Writes populate the entry
+        mvtbl.write(&ap1, 10, Some(vec![0, 0, 0])).unwrap();
+
+        // Subsequent higher reads read this entry
+        let r1 = mvtbl.read(&ap1, 15);
+        assert_eq!(Ok(&Some(vec![0, 0, 0])), r1);
+
+        // Set skip works
+        assert!(mvtbl.skip(&ap1, 20).is_err());
+
+        // Higher reads skip this entry
+        let r1 = mvtbl.read(&ap1, 25);
+        assert_eq!(Ok(&Some(vec![0, 0, 0])), r1);
+    }
+}

--- a/language/diem-vm/src/data_cache.rs
+++ b/language/diem-vm/src/data_cache.rs
@@ -20,7 +20,7 @@ use move_core_types::{
     language_storage::{ModuleId, StructTag},
 };
 use move_vm_runtime::data_cache::MoveStorage;
-use std::collections::btree_map::BTreeMap;
+use std::{borrow::Cow, collections::btree_map::BTreeMap};
 
 /// A local cache for a given a `StateView`. The cache is private to the Diem layer
 /// but can be used as a one shot cache for systems that need a simple `RemoteCache`
@@ -66,19 +66,16 @@ impl<'a> StateViewCache<'a> {
             }
         }
     }
-}
 
-impl<'block> StateView for StateViewCache<'block> {
-    // Get some data either through the cache or the `StateView` on a cache miss.
-    fn get(&self, access_path: &AccessPath) -> anyhow::Result<Option<Vec<u8>>> {
+    pub fn get_bytes(&self, access_path: &AccessPath) -> anyhow::Result<Option<Cow<[u8]>>> {
         fail_point!("move_adapter::data_cache::get", |_| Err(format_err!(
             "Injected failure in data_cache::get"
         )));
 
         match self.data_map.get(access_path) {
-            Some(opt_data) => Ok(opt_data.clone()),
+            Some(opt_data) => Ok(opt_data.as_ref().map(|v| Cow::Borrowed(v.as_ref()))),
             None => match self.data_view.get(&access_path) {
-                Ok(remote_data) => Ok(remote_data),
+                Ok(remote_data) => Ok(remote_data.map(Cow::from)),
                 // TODO: should we forward some error info?
                 Err(e) => {
                     // create an AdapterLogSchema from the `data_view` in scope. This log_context
@@ -96,6 +93,13 @@ impl<'block> StateView for StateViewCache<'block> {
                 }
             },
         }
+    }
+}
+
+impl<'block> StateView for StateViewCache<'block> {
+    // Get some data either through the cache or the `StateView` on a cache miss.
+    fn get(&self, access_path: &AccessPath) -> anyhow::Result<Option<Vec<u8>>> {
+        Ok(self.get_bytes(access_path)?.map(Cow::into_owned))
     }
 
     fn is_genesis(&self) -> bool {
@@ -116,8 +120,10 @@ impl<'block> MoveStorage for StateViewCache<'block> {
         &self,
         address: &AccountAddress,
         tag: &StructTag,
-    ) -> PartialVMResult<Option<Vec<u8>>> {
-        RemoteStorage::new(self).get_resource(address, tag)
+    ) -> PartialVMResult<Option<Cow<[u8]>>> {
+        let ap = create_access_path(*address, tag.clone());
+        self.get_bytes(&ap)
+            .map_err(|_| PartialVMError::new(StatusCode::STORAGE_ERROR))
     }
 }
 
@@ -153,9 +159,9 @@ impl<'a, S: StateView> MoveStorage for RemoteStorage<'a, S> {
         &self,
         address: &AccountAddress,
         struct_tag: &StructTag,
-    ) -> PartialVMResult<Option<Vec<u8>>> {
+    ) -> PartialVMResult<Option<Cow<[u8]>>> {
         let ap = create_access_path(*address, struct_tag.clone());
-        self.get(&ap)
+        Ok(self.get(&ap)?.map(Cow::from))
     }
 }
 

--- a/language/diem-vm/src/lib.rs
+++ b/language/diem-vm/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
+// #![forbid(unsafe_code)]
 
 //! # The VM runtime
 //!
@@ -112,6 +112,7 @@ pub mod foreign_contracts;
 
 mod diem_vm;
 mod errors;
+mod parallel_executor;
 pub mod transaction_metadata;
 
 pub mod diem_transaction_executor;

--- a/language/diem-vm/src/parallel_executor/data_cache.rs
+++ b/language/diem-vm/src/parallel_executor/data_cache.rs
@@ -1,0 +1,217 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{anyhow, Result};
+use diem_state_view::StateView;
+use diem_types::{
+    access_path::AccessPath, transaction::TransactionOutput, vm_status::StatusCode,
+    write_set::WriteOp,
+};
+use move_binary_format::errors::*;
+use move_core_types::{
+    account_address::AccountAddress,
+    language_storage::{ModuleId, StructTag},
+};
+use move_vm_runtime::data_cache::MoveStorage;
+use mvhashmap::MVHashMap;
+use std::{borrow::Cow, convert::AsRef, thread, time::Duration, collections::HashSet};
+
+pub struct VersionedDataCache(MVHashMap<AccessPath, Vec<u8>>);
+
+pub struct VersionedStateView<'view> {
+    version: usize,
+    base_view: &'view dyn StateView,
+    placeholder: &'view VersionedDataCache,
+}
+
+const ONE_MILLISEC: Duration = Duration::from_millis(10);
+
+impl VersionedDataCache {
+    pub fn new(write_sequence: Vec<(AccessPath, usize)>) -> (usize, Self) {
+        let (max_dependency_length, mv_hashmap) = MVHashMap::new_from_parallel(write_sequence);
+        (max_dependency_length, VersionedDataCache(mv_hashmap))
+    }
+
+    pub fn set_skip_all(&self, version: usize, estimated_writes: impl Iterator<Item = AccessPath>) {
+        // Put skip in all entires.
+        for w in estimated_writes {
+            // It should be safe to unwrap here since the MVMap was construted using
+            // this estimated writes. If not it is a bug.
+            self.as_ref().skip(&w, version).unwrap();
+        }
+    }
+
+    pub fn apply_output(
+        &self,
+        output: &TransactionOutput,
+        version: usize,
+        estimated_writes: impl Iterator<Item = AccessPath>,
+    ) -> Result<(), ()> {
+        if !output.status().is_discarded() {
+            // First make sure all outputs have entries in the MVMap
+            let estimated_writes_hs: HashSet<_> = estimated_writes.collect();
+            for (k, _) in output.write_set() {
+                if !estimated_writes_hs.contains(k) {
+                    println!("Missing entry: {:?}", k);
+
+                    // Put skip in all entires.
+                    self.set_skip_all(version, estimated_writes_hs.into_iter());
+                    return Err(());
+                }
+            }
+
+            // We are sure all entries are present -- now update them all
+            for (k, v) in output.write_set() {
+                let val = match v {
+                    WriteOp::Deletion => None,
+                    WriteOp::Value(data) => Some(data.clone()),
+                };
+
+                // Safe because we checked that the entry exists
+                self.as_ref().write(k, version, val).unwrap();
+            }
+
+            // If any entries are not updated, write a 'skip' flag into them
+            for w in estimated_writes_hs {
+                // It should be safe to unwrap here since the MVMap was construted using
+                // this estimated writes. If not it is a bug.
+                self.as_ref()
+                    .skip_if_not_set(&w, version)
+                    .expect("Entry must exist.");
+            }
+        } else {
+            self.set_skip_all(version, estimated_writes);
+        }
+        Ok(())
+    }
+}
+
+impl AsRef<MVHashMap<AccessPath, Vec<u8>>> for VersionedDataCache {
+    fn as_ref(&self) -> &MVHashMap<AccessPath, Vec<u8>> {
+        &self.0
+    }
+}
+
+impl<'view> VersionedStateView<'view> {
+    pub fn new(
+        version: usize,
+        base_view: &'view dyn StateView,
+        placeholder: &'view VersionedDataCache,
+    ) -> VersionedStateView<'view> {
+        VersionedStateView {
+            version,
+            base_view,
+            placeholder,
+        }
+    }
+
+    pub fn will_read_block(&self, access_path: &AccessPath) -> bool {
+        let read = self.placeholder.as_ref().read(access_path, self.version);
+        if let Err(Some(_)) = read {
+            return true;
+        }
+        return false;
+    }
+
+    fn get_bytes_ref(&self, access_path: &AccessPath) -> PartialVMResult<Option<Cow<[u8]>>> {
+        let mut loop_iterations = 0;
+        loop {
+            let read = self.placeholder.as_ref().read(access_path, self.version);
+
+            // Go to the Database
+            if let Err(None) = read {
+                return self
+                    .base_view
+                    .get(access_path)
+                    .map(|opt| opt.map(Cow::from))
+                    .map_err(|_| PartialVMError::new(StatusCode::STORAGE_ERROR));
+            }
+
+            // Read is a success
+            if let Ok(data) = read {
+                return Ok(data.as_ref().map(Cow::from));
+            }
+
+            loop_iterations += 1;
+            if loop_iterations < 500 {
+                ::std::hint::spin_loop();
+            } else {
+                thread::sleep(ONE_MILLISEC);
+            }
+        }
+    }
+
+    fn get_bytes(&self, access_path: &AccessPath) -> PartialVMResult<Option<Vec<u8>>> {
+        self.get_bytes_ref(access_path)
+            .map(|opt| opt.map(Cow::into_owned))
+    }
+}
+
+impl<'view> MoveStorage for VersionedStateView<'view> {
+    fn get_module(&self, module_id: &ModuleId) -> VMResult<Option<Vec<u8>>> {
+        // REVIEW: cache this?
+        let ap = AccessPath::from(module_id);
+        self.get_bytes(&ap)
+            .map_err(|e| e.finish(Location::Undefined))
+    }
+
+    fn get_resource(
+        &self,
+        address: &AccountAddress,
+        struct_tag: &StructTag,
+    ) -> PartialVMResult<Option<Cow<[u8]>>> {
+        let ap = AccessPath::new(
+            *address,
+            AccessPath::resource_access_vec(struct_tag.clone()),
+        );
+        self.get_bytes_ref(&ap)
+    }
+}
+
+impl<'view> StateView for VersionedStateView<'view> {
+    fn get(&self, access_path: &AccessPath) -> Result<Option<Vec<u8>>> {
+        self.get_bytes(access_path)
+            .map_err(|_| anyhow!("Failed to get data from VersionedStateView"))
+    }
+
+    fn is_genesis(&self) -> bool {
+        self.base_view.is_genesis()
+    }
+}
+
+//
+// pub struct SingleThreadReadCache<'view> {
+//     base_view : &'view dyn StateView,
+//     cache : RefCell<HashMap<AccessPath, Option<Vec<u8>>>>,
+// }
+//
+// impl<'view> SingleThreadReadCache<'view> {
+//     pub fn new(base_view: &'view StateView) -> SingleThreadReadCache<'view> {
+//         SingleThreadReadCache {
+//             base_view,
+//             cache : RefCell::new(HashMap::new()),
+//         }
+//     }
+// }
+//
+// impl<'view> StateView for SingleThreadReadCache<'view> {
+//     // Get some data either through the cache or the `StateView` on a cache miss.
+//     fn get(&self, access_path: &AccessPath) -> anyhow::Result<Option<Vec<u8>>> {
+//         if self.cache.borrow().contains_key(access_path) {
+//             Ok(self.cache.borrow().get(access_path).unwrap().clone())
+//         }
+//         else {
+//             let val = self.base_view.get(access_path)?;
+//             self.cache.borrow_mut().insert(access_path.clone(), val.clone());
+//             Ok(val)
+//         }
+//     }
+//
+//     fn multi_get(&self, _access_paths: &[AccessPath]) -> anyhow::Result<Vec<Option<Vec<u8>>>> {
+//         unimplemented!()
+//     }
+//
+//     fn is_genesis(&self) -> bool {
+//         self.base_view.is_genesis()
+//     }
+// }

--- a/language/diem-vm/src/parallel_executor/dependency_analyzer.rs
+++ b/language/diem-vm/src/parallel_executor/dependency_analyzer.rs
@@ -1,0 +1,258 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    data_cache::StateViewCache,
+    diem_transaction_executor::{preprocess_transaction, PreprocessedTransaction},
+    logging::AdapterLogSchema,
+    DiemVM,
+};
+use diem_state_view::StateView;
+use diem_types::{
+    access_path::AccessPath,
+    account_address::AccountAddress,
+    transaction::{Transaction, TransactionArgument, TransactionPayload},
+};
+use move_core_types::vm_status::{KeptVMStatus, StatusCode, VMStatus};
+use std::collections::{HashMap, HashSet};
+
+// Structure that holds infered read/write sets
+
+#[derive(Debug, Clone)]
+enum ScriptReadWriteSetVar {
+    Const,
+    Param(usize),
+}
+
+#[derive(Debug)]
+struct ScriptReadWriteSet {
+    reads: Vec<(ScriptReadWriteSetVar, AccessPath)>,
+    writes: Vec<(ScriptReadWriteSetVar, AccessPath)>,
+}
+
+impl ScriptReadWriteSet {
+    // Given a set of address parameters, by convention [Sender, Address, Address, ...], and some read and write
+    // access paths, it infers which are static and which dynamic, stores the structure to allow inference about others.
+    pub fn new(
+        params: &[AccountAddress],
+        reads: Vec<AccessPath>,
+        writes: Vec<AccessPath>,
+    ) -> ScriptReadWriteSet {
+        ScriptReadWriteSet {
+            reads: reads
+                .into_iter()
+                .map(|path| {
+                    let var = match params.iter().position(|&x| x == path.address) {
+                        None => ScriptReadWriteSetVar::Const,
+                        Some(i) => ScriptReadWriteSetVar::Param(i),
+                    };
+                    (var, path)
+                })
+                .collect(),
+            writes: writes
+                .into_iter()
+                .map(|path| {
+                    let var = match params.iter().position(|&x| x == path.address) {
+                        None => ScriptReadWriteSetVar::Const,
+                        Some(i) => ScriptReadWriteSetVar::Param(i),
+                    };
+                    (var, path)
+                })
+                .collect(),
+        }
+    }
+
+    // Return the read access paths specialized for these parameters
+    // TODO: return a result in case the params are not long enough.
+    pub fn reads<'a>(&'a self, params: &'a TransactionParameters) -> ScriptReadWriteSetVarIter {
+        return ScriptReadWriteSetVarIter::new(&self.reads, params);
+    }
+
+    // Return the write access paths specialized for these parameters
+    // TODO: return a result in case the params are not long enough.
+    pub fn writes<'a>(
+        &'a self,
+        params: &'a TransactionParameters,
+    ) -> ScriptReadWriteSetVarIter<'a> {
+        return ScriptReadWriteSetVarIter::new(&self.writes, params);
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct TransactionParameters(Vec<AccountAddress>);
+
+impl TransactionParameters {
+    pub fn new_from(txn: &PreprocessedTransaction) -> Self {
+        if let PreprocessedTransaction::UserTransaction(user_txn) = txn {
+            match user_txn.payload() {
+                TransactionPayload::Script(script) => {
+                    // If the transaction is not known, then execute it to infer its read/write logic.
+                    let mut params = Vec::with_capacity(5);
+                    params.push(user_txn.sender());
+                    for arg in script.args() {
+                        if let TransactionArgument::Address(address) = arg {
+                            params.push(address.clone());
+                        }
+                    }
+                    Self(params)
+                }
+                _ => {
+                    unimplemented!("FIXME")
+                }
+            }
+        } else {
+            unimplemented!("FIXME")
+        }
+    }
+
+    pub fn args(&self) -> &[AccountAddress] {
+        &self.0
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct ScriptReadWriteSetVarIter<'a> {
+    // A link to the array we iterate over
+    array: &'a [(ScriptReadWriteSetVar, AccessPath)],
+    // The parameters we use to popular the read-write set
+    params: &'a TransactionParameters,
+    // the position we are in the array.
+    seq: usize,
+}
+
+impl<'a> ScriptReadWriteSetVarIter<'a> {
+    fn new(
+        array: &'a Vec<(ScriptReadWriteSetVar, AccessPath)>,
+        params: &'a TransactionParameters,
+    ) -> ScriptReadWriteSetVarIter<'a> {
+        ScriptReadWriteSetVarIter {
+            array,
+            params,
+            seq: 0,
+        }
+    }
+}
+
+impl<'a> Iterator for ScriptReadWriteSetVarIter<'a> {
+    // we will be counting with usize
+    type Item = AccessPath;
+
+    // next() is the only required method
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.seq < self.array.len() {
+            let (v, p) = &self.array[self.seq];
+            let current_item = match v {
+                ScriptReadWriteSetVar::Const => p.clone(),
+                ScriptReadWriteSetVar::Param(i) => {
+                    let mut p = p.clone();
+                    p.address = self.params.args()[*i];
+                    p
+                }
+            };
+            self.seq += 1;
+            Some(current_item)
+        } else {
+            None
+        }
+    }
+}
+
+pub(crate) struct DependencyAnalyzer {
+    script_map: HashMap<Vec<u8>, ScriptReadWriteSet>,
+}
+
+impl DependencyAnalyzer {
+    pub fn new_from_transactions(
+        transactions: &[PreprocessedTransaction],
+        data_cache: &StateViewCache,
+    ) -> Result<Self, VMStatus> {
+        // STARTS -- DEPENDENCY INFERENCE HACK / Replace with static analysis of write set
+        let mut read_write_infer = HashMap::<Vec<u8>, ScriptReadWriteSet>::new();
+        let diem_vm = DiemVM::new(data_cache);
+
+        for txn in transactions.iter() {
+            if let PreprocessedTransaction::UserTransaction(user_txn) = txn {
+                if let TransactionPayload::Script(script) = user_txn.payload() {
+                    // If the transaction is not known, then execute it to infer its read/write logic.
+                    if !read_write_infer.contains_key(script.code()) {
+                        let xref = &*data_cache;
+                        let local_state_view_cache = StateViewCache::new_recorder(xref);
+                        let log_context = AdapterLogSchema::new(xref.id(), 0);
+                        // Execute the transaction
+                        if let Ok((status, output, _)) = diem_vm.execute_single_transaction(
+                            &txn,
+                            &local_state_view_cache,
+                            &log_context,
+                        ) {
+                            match status.keep_or_discard() {
+                                Ok(KeptVMStatus::Executed) => (),
+                                _ => continue,
+                            };
+                            // Record the read-set
+                            let read_set = local_state_view_cache.read_set();
+
+                            // Create a params list
+                            let params = TransactionParameters::new_from(txn);
+
+                            let mut reads = Vec::new();
+                            let mut writes = Vec::new();
+                            let write_set: HashSet<AccessPath> =
+                                output.write_set().iter().map(|(k, _)| k).cloned().collect();
+
+                            for path in read_set {
+                                if write_set.contains(&path) {
+                                    reads.push(path.clone());
+                                    writes.push(path.clone());
+                                // println!("  -W {}", path);
+                                } else {
+                                    reads.push(path.clone());
+                                    // println!("  -R {}", path);
+                                }
+                            }
+
+                            read_write_infer.insert(
+                                script.code().to_vec(),
+                                ScriptReadWriteSet::new(params.args(), reads, writes),
+                            );
+                        } else {
+                            panic!("NO LOGIC TO INFER READ/WRITE SET");
+                        }
+                    }
+                } else {
+                    unimplemented!();
+                }
+            } else {
+                unimplemented!();
+            }
+        }
+
+        // ENDS
+        Ok(Self {
+            script_map: read_write_infer,
+        })
+    }
+
+    pub fn get_inferred_read_write_set<'a>(
+        &'a self,
+        txn: &PreprocessedTransaction,
+        params: &'a TransactionParameters,
+    ) -> Result<
+        (
+            impl Iterator<Item = AccessPath> + 'a + Copy,
+            impl Iterator<Item = AccessPath> + 'a + Copy,
+        ),
+        VMStatus,
+    > {
+        if let PreprocessedTransaction::UserTransaction(user_txn) = txn {
+            if let TransactionPayload::Script(script) = user_txn.payload() {
+                let deps = match self.script_map.get(script.code()) {
+                    Some(deps) => deps,
+                    None => return Err(VMStatus::Error(StatusCode::UNKNOWN_VALIDATION_STATUS)),
+                };
+
+                return Ok((deps.reads(params), deps.writes(params)));
+            }
+        }
+        Err(VMStatus::Error(StatusCode::UNKNOWN_VALIDATION_STATUS))
+    }
+}

--- a/language/diem-vm/src/parallel_executor/mod.rs
+++ b/language/diem-vm/src/parallel_executor/mod.rs
@@ -1,0 +1,7 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod data_cache;
+pub mod dependency_analyzer;
+mod outcome_array;
+pub mod parallel_transaction_executor;

--- a/language/diem-vm/src/parallel_executor/outcome_array.rs
+++ b/language/diem-vm/src/parallel_executor/outcome_array.rs
@@ -1,0 +1,67 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use diem_types::{
+    transaction::{TransactionOutput, TransactionStatus},
+    write_set::WriteSet,
+};
+use move_core_types::vm_status::VMStatus;
+use once_cell::sync::OnceCell;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+unsafe impl Send for OutcomeArray {}
+unsafe impl Sync for OutcomeArray {}
+
+pub(crate) struct OutcomeArray {
+    results: Vec<OnceCell<(VMStatus, TransactionOutput)>>,
+
+    success_num: AtomicUsize,
+    failure_num: AtomicUsize,
+}
+
+impl OutcomeArray {
+    pub fn new(len: usize) -> OutcomeArray {
+        OutcomeArray {
+            results: (0..len).map(|_| OnceCell::new()).collect(),
+
+            success_num: AtomicUsize::new(0),
+            failure_num: AtomicUsize::new(0),
+        }
+    }
+
+    pub fn set_result(&self, idx: usize, res: (VMStatus, TransactionOutput), success: bool) {
+        // Only one thread can write at the time, so just set it.
+
+        let entry = &self.results[idx];
+        entry.set(res).unwrap();
+
+        // #[cfg(test)]
+        {
+            if success {
+                self.success_num.fetch_add(1, Ordering::Relaxed);
+            } else {
+                self.failure_num.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+
+    pub fn get_stats(&self) -> (usize, usize) {
+        return (
+            self.success_num.load(Ordering::Relaxed),
+            self.failure_num.load(Ordering::Relaxed),
+        );
+    }
+
+    pub fn get_all_results(
+        self,
+        valid_length: usize,
+    ) -> Result<Vec<(VMStatus, TransactionOutput)>, VMStatus> {
+        let mut results = self.results.into_iter()
+            .map(|cell| cell.into_inner())
+            .collect::<Option<Vec<_>>>()
+            .unwrap();
+
+        let _ = results.split_off(valid_length);
+        Ok(results)
+    }
+}

--- a/language/diem-vm/src/parallel_executor/parallel_transaction_executor.rs
+++ b/language/diem-vm/src/parallel_executor/parallel_transaction_executor.rs
@@ -1,0 +1,239 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::parallel_executor::dependency_analyzer::TransactionParameters;
+use crate::{
+    data_cache::StateViewCache,
+    diem_transaction_executor::{
+        is_reconfiguration, preprocess_transaction, PreprocessedTransaction,
+    },
+    logging::AdapterLogSchema,
+    parallel_executor::{
+        data_cache::{VersionedDataCache, VersionedStateView},
+        dependency_analyzer::DependencyAnalyzer,
+        outcome_array::OutcomeArray,
+    },
+    DiemVM,
+};
+use diem_state_view::StateView;
+use diem_types::{
+    access_path::AccessPath,
+    transaction::{Transaction, TransactionOutput},
+};
+use move_core_types::vm_status::VMStatus;
+use num_cpus;
+use rayon::{prelude::*, scope};
+use std::{
+    cmp::{max, min},
+    collections::VecDeque,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+pub struct ParallelTransactionExecutor {
+    num_cpus: usize,
+    txn_per_thread: u64,
+}
+
+impl ParallelTransactionExecutor {
+    pub fn new() -> Self {
+        Self {
+            num_cpus: num_cpus::get(),
+            txn_per_thread: 50,
+        }
+    }
+
+    pub(crate) fn execute_transactions_parallel(
+        &self,
+        signature_verified_block: Vec<PreprocessedTransaction>,
+        data_cache: &mut StateViewCache,
+    ) -> Result<Vec<(VMStatus, TransactionOutput)>, VMStatus> {
+        let num_txns = signature_verified_block.len();
+        let chunks = max(1, num_txns / self.num_cpus);
+
+        // Update the dependency analysis structure. We only do this for blocks that
+        // purely consist of UserTransactions (Extending this is a TODO). If non-user
+        // transactions are detected this returns and err, and we revert to sequential
+        // block processing.
+
+        let inferer =
+            DependencyAnalyzer::new_from_transactions(&signature_verified_block, data_cache);
+        let read_write_infer = match inferer {
+            Err(_) => {
+                return DiemVM::new(data_cache)
+                    .execute_block_impl(signature_verified_block, data_cache)
+            }
+            Ok(val) => val,
+        };
+
+        let args: Vec<_> = signature_verified_block
+            .par_iter()
+            .with_min_len(chunks)
+            .map(TransactionParameters::new_from)
+            .collect();
+
+        let infer_result: Vec<_> = {
+            match signature_verified_block
+                .par_iter()
+                .zip(args.par_iter())
+                .with_min_len(chunks)
+                .map(|(txn, args)| read_write_infer.get_inferred_read_write_set(txn, args))
+                .collect::<Result<Vec<_>, VMStatus>>()
+            {
+                Ok(res) => res,
+                Err(_) => {
+                    return DiemVM::new(data_cache)
+                        .execute_block_impl(signature_verified_block, data_cache)
+                }
+            }
+        };
+
+        // Analyse each user script for its write-set and create the placeholder structure
+        // that allows for parallel execution.
+        let path_version_tuples: Vec<(AccessPath, usize)> = infer_result
+            .par_iter()
+            .enumerate()
+            .with_min_len(chunks)
+            .fold(
+                || Vec::new(),
+                |mut acc, (idx, (_, txn_writes))| {
+                    acc.extend(txn_writes.map(|ap| (ap, idx)));
+                    acc
+                },
+            )
+            .reduce(
+                || Vec::new(),
+                |mut lhs, mut rhs| {
+                    lhs.append(&mut rhs);
+                    lhs
+                },
+            );
+
+        let ((max_dependency_level, versioned_data_cache), outcomes) = rayon::join(
+            || VersionedDataCache::new(path_version_tuples),
+            || OutcomeArray::new(num_txns),
+        );
+
+        let curent_idx = AtomicUsize::new(0);
+        let stop_when = AtomicUsize::new(signature_verified_block.len());
+
+        scope(|s| {
+            // How many threads to use?
+            let compute_cpus = min(1 + (num_txns / 50), self.num_cpus - 1); // Ensure we have at least 50 tx per thread.
+            let compute_cpus = min(num_txns / max_dependency_level, compute_cpus); // Ensure we do not higher rate of conflict than concurrency.
+
+            println!(
+                "Launching {} threads to execute (Max conflict {}) ... total txns: {:?}",
+                compute_cpus,
+                max_dependency_level,
+                stop_when.load(Ordering::Relaxed),
+            );
+            for _ in 0..(compute_cpus) {
+                s.spawn(|_| {
+                    // Make a new VM per thread -- with its own module cache
+                    let thread_vm = DiemVM::new(data_cache);
+
+                    let mut tx_idx_ring_buffer = VecDeque::with_capacity(10);
+
+                    loop {
+                        if tx_idx_ring_buffer.len() < 10 {
+                            // How many transactions to have in the buffer.
+
+                            let idx = curent_idx.fetch_add(1, Ordering::Relaxed);
+                            if idx < stop_when.load(Ordering::Relaxed) {
+                                let txn = &signature_verified_block[idx];
+                                let (reads, writes) = infer_result[idx];
+
+                                tx_idx_ring_buffer.push_back((idx, txn, (reads, writes)));
+                            }
+                        }
+                        if tx_idx_ring_buffer.len() == 0 {
+                            break;
+                        }
+
+                        // Pop one transaction from the buffer
+                        let (idx, txn, (reads, writes)) = tx_idx_ring_buffer.pop_front().unwrap(); // safe due to previous check
+
+                        // Ensure this transaction is still to be executed
+                        if !(idx < stop_when.load(Ordering::Relaxed)) {
+                            continue;
+                        }
+
+                        let versioned_state_view =
+                            VersionedStateView::new(idx, data_cache, &versioned_data_cache);
+
+                        // Delay and move to next tx if cannot execure now.
+                        if reads
+                            .clone()
+                            .any(|k| versioned_state_view.will_read_block(&k))
+                        {
+                            tx_idx_ring_buffer.push_back((idx, txn, (reads, writes)));
+
+                            // This causes a PAUSE on an x64 arch, and takes 140 cycles. Allows other
+                            // core to take resources and better HT.
+                            ::std::sync::atomic::spin_loop_hint();
+                            continue;
+                        }
+
+                        // Execute the transaction
+                        let log_context = AdapterLogSchema::new(versioned_state_view.id(), idx);
+                        let res = thread_vm.execute_single_transaction(
+                            txn,
+                            &versioned_state_view,
+                            &log_context,
+                        );
+                        match res {
+                            Ok((vm_status, output, _sender)) => {
+                                if versioned_data_cache
+                                    .apply_output(&output, idx, writes)
+                                    .is_err()
+                                {
+                                    // An error occured when estimating the write-set of this transaction.
+                                    // We therefore cut the execution of the block short here. We set
+                                    // decrese the transaction index at which we stop, by seeting it
+                                    // to be this one or lower.
+                                    println!("Adjust boundary {}", idx);
+                                    stop_when.fetch_min(idx, Ordering::SeqCst);
+                                    continue;
+                                }
+
+                                if is_reconfiguration(&output) {
+                                    // TODO: Log reconfiguration?
+
+                                    // This transacton is correct, but all subsequent transactions
+                                    // must be rejected (with retry status) since it forced a
+                                    // reconfiguration.
+                                    stop_when.fetch_min(idx + 1, Ordering::SeqCst);
+                                    let success = !output.status().is_discarded();
+                                    outcomes.set_result(idx, (vm_status, output), success);
+                                    continue;
+                                } else {
+                                    let success = !output.status().is_discarded();
+                                    outcomes.set_result(idx, (vm_status, output), success);
+                                }
+                            }
+                            Err(_e) => {
+                                panic!("TODO STOP VM & RETURN ERROR");
+                            }
+                        }
+                    }
+                });
+            }
+        });
+
+        // Splits the head of the vec of results that are valid
+        let valid_results_length = stop_when.load(Ordering::SeqCst);
+        println!("Valid length: {}", valid_results_length);
+        let all_results = outcomes.get_all_results(valid_results_length);
+
+        drop(infer_result);
+
+        // Dropping large structures is expensive -- do this is a separate thread.
+        ::std::thread::spawn(move || {
+            drop(signature_verified_block); // Explicit drops to measure their cost.
+            drop(versioned_data_cache);
+        });
+
+        assert!(all_results.as_ref().unwrap().len() == valid_results_length);
+        all_results
+    }
+}

--- a/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
@@ -14,6 +14,7 @@ use move_core_types::{
 use move_vm_runtime::{data_cache::MoveStorage, logging::NoContextLog, move_vm::MoveVM};
 use move_vm_test_utils::{DeltaStorage, InMemoryStorage};
 use move_vm_types::gas_schedule::GasStatus;
+use std::borrow::Cow;
 
 const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGTH]);
 
@@ -541,7 +542,7 @@ impl MoveStorage for BogusStorage {
         &self,
         _address: &AccountAddress,
         _tag: &StructTag,
-    ) -> PartialVMResult<Option<Vec<u8>>> {
+    ) -> PartialVMResult<Option<Cow<[u8]>>> {
         Err(PartialVMError::new(self.bad_status_code))
     }
 }

--- a/language/move-vm/runtime/Cargo.toml
+++ b/language/move-vm/runtime/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 fail = "0.4.0"
 mirai-annotations = "1.10.1"
 once_cell = "1.7.2"
+parking_lot = "0.11.1"
 
 bytecode-verifier = { path = "../../bytecode-verifier" }
 diem-crypto = { path = "../../../crypto/crypto" }

--- a/language/move-vm/runtime/src/data_cache.rs
+++ b/language/move-vm/runtime/src/data_cache.rs
@@ -17,7 +17,7 @@ use move_vm_types::{
     loaded_data::runtime_types::Type,
     values::{GlobalValue, GlobalValueEffect, Value},
 };
-use std::collections::btree_map::BTreeMap;
+use std::{borrow::Cow, collections::btree_map::BTreeMap};
 
 /// Trait for the Move VM to abstract storage operations.
 ///
@@ -44,7 +44,7 @@ pub trait MoveStorage {
         &self,
         address: &AccountAddress,
         tag: &StructTag,
-    ) -> PartialVMResult<Option<Vec<u8>>>;
+    ) -> PartialVMResult<Option<Cow<[u8]>>>;
 }
 
 pub struct AccountDataCache {

--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -7,7 +7,6 @@ use crate::{
 };
 use bytecode_verifier::{self, cyclic_dependencies, dependencies, script_signature};
 use diem_crypto::HashValue;
-use diem_infallible::Mutex;
 use diem_logger::prelude::*;
 use move_binary_format::{
     access::{ModuleAccess, ScriptAccess},
@@ -32,10 +31,11 @@ use move_vm_types::{
     loaded_data::runtime_types::{StructType, Type},
 };
 use std::{collections::HashMap, fmt::Debug, hash::Hash, sync::Arc};
+use parking_lot::RwLock;
 
 // A simple cache that offers both a HashMap and a Vector lookup.
 // Values are forced into a `Arc` so they can be used from multiple thread.
-// Access to this cache is always under a `Mutex`.
+// Access to this cache is always under a `RwLock`.
 struct BinaryCache<K, V> {
     id_map: HashMap<K, usize>,
     binaries: Vec<Arc<V>>,
@@ -412,22 +412,22 @@ impl ModuleCache {
 //
 
 // A Loader is responsible to load scripts and modules and holds the cache of all loaded
-// entities. Each cache is protected by a `Mutex`. Operation in the Loader must be thread safe
+// entities. Each cache is protected by a `RwLock`. Operation in the Loader must be thread safe
 // (operating on values on the stack) and when cache needs updating the mutex must be taken.
 // The `pub(crate)` API is what a Loader offers to the runtime.
 pub(crate) struct Loader {
-    scripts: Mutex<ScriptCache>,
-    module_cache: Mutex<ModuleCache>,
-    type_cache: Mutex<TypeCache>,
+    scripts: RwLock<ScriptCache>,
+    module_cache: RwLock<ModuleCache>,
+    type_cache: RwLock<TypeCache>,
 }
 
 impl Loader {
     pub(crate) fn new() -> Self {
         //println!("new loader");
         Self {
-            scripts: Mutex::new(ScriptCache::new()),
-            module_cache: Mutex::new(ModuleCache::new()),
-            type_cache: Mutex::new(TypeCache::new()),
+            scripts: RwLock::new(ScriptCache::new()),
+            module_cache: RwLock::new(ModuleCache::new()),
+            type_cache: RwLock::new(TypeCache::new()),
         }
     }
 
@@ -453,13 +453,13 @@ impl Loader {
         // retrieve or load the script
         let hash_value = HashValue::sha3_256_of(script_blob);
 
-        let mut scripts = self.scripts.lock();
+        let mut scripts = self.scripts.write();
         let (main, parameter_tys) = match scripts.get(&hash_value) {
             Some(main) => main,
             None => {
                 let ver_script =
                     self.deserialize_and_verify_script(script_blob, data_store, log_context)?;
-                let script = Script::new(ver_script, &hash_value, &self.module_cache.lock())?;
+                let script = Script::new(ver_script, &hash_value, &self.module_cache.read())?;
                 scripts.insert(hash_value, script)
             }
         };
@@ -560,16 +560,16 @@ impl Loader {
         let module = self.load_module_verify_not_missing(module_id, data_store, log_context)?;
         let idx = self
             .module_cache
-            .lock()
+            .read()
             .resolve_function_by_name(function_name, module_id)
             .map_err(|err| err.finish(Location::Undefined))?;
-        let func = self.module_cache.lock().function_at(idx);
+        let func = self.module_cache.read().function_at(idx);
 
         let parameter_tys = func
             .parameters
             .0
             .iter()
-            .map(|tok| self.module_cache.lock().make_type(module.module(), tok))
+            .map(|tok| self.module_cache.read().make_type(module.module(), tok))
             .collect::<PartialVMResult<Vec<_>>>()
             .map_err(|err| err.finish(Location::Undefined))?;
 
@@ -577,7 +577,7 @@ impl Loader {
             .return_
             .0
             .iter()
-            .map(|tok| self.module_cache.lock().make_type(module.module(), tok))
+            .map(|tok| self.module_cache.read().make_type(module.module(), tok))
             .collect::<PartialVMResult<Vec<_>>>()
             .map_err(|err| err.finish(Location::Undefined))?;
 
@@ -693,7 +693,7 @@ impl Loader {
     }
 
     fn verify_module_cyclic_relations(&self, module: &CompiledModule) -> VMResult<()> {
-        let module_cache = self.module_cache.lock();
+        let module_cache = self.module_cache.read();
         cyclic_dependencies::verify_module(
             module,
             |module_id| {
@@ -778,7 +778,7 @@ impl Loader {
                 self.load_module_verify_not_missing(&module_id, data_store, log_context)?;
                 let (idx, struct_type) = self
                     .module_cache
-                    .lock()
+                    .read()
                     // GOOD module was loaded above
                     .resolve_struct_by_name(&struct_tag.name, &module_id)
                     .map_err(|e| e.finish(Location::Undefined))?;
@@ -837,7 +837,7 @@ impl Loader {
             Ok(module)
         }
 
-        if let Some(module) = self.module_cache.lock().module_at(id) {
+        if let Some(module) = self.module_cache.read().module_at(id) {
             return Ok(module);
         }
 
@@ -855,7 +855,7 @@ impl Loader {
             .map_err(|err| expect_no_verification_errors(err, log_context))?;
         let module_ref = self
             .module_cache
-            .lock()
+            .write()
             .insert(id.clone(), module, log_context)?;
 
         // friendship is an upward edge in the dependencies DAG, so it has to be checked after the
@@ -933,13 +933,13 @@ impl Loader {
     //
 
     fn function_at(&self, idx: usize) -> Arc<Function> {
-        self.module_cache.lock().function_at(idx)
+        self.module_cache.read().function_at(idx)
     }
 
     fn get_module(&self, idx: &ModuleId) -> Arc<Module> {
         Arc::clone(
             self.module_cache
-                .lock()
+                .read()
                 .modules
                 .get(idx)
                 .expect("ModuleId on Function must exist"),
@@ -949,7 +949,7 @@ impl Loader {
     fn get_script(&self, hash: &HashValue) -> Arc<Script> {
         Arc::clone(
             self.scripts
-                .lock()
+                .read()
                 .scripts
                 .get(hash)
                 .expect("Script hash on Function must exist"),
@@ -974,9 +974,9 @@ impl Loader {
                 AbilitySet::VECTOR,
                 vec![self.abilities(ty)?].into_iter(),
             )),
-            Type::Struct(idx) => Ok(self.module_cache.lock().struct_at(*idx).abilities),
+            Type::Struct(idx) => Ok(self.module_cache.read().struct_at(*idx).abilities),
             Type::StructInstantiation(idx, type_args) => {
-                let declared_abilities = self.module_cache.lock().struct_at(*idx).abilities;
+                let declared_abilities = self.module_cache.read().struct_at(*idx).abilities;
                 let type_argument_abilities = type_args
                     .iter()
                     .map(|ty| self.abilities(ty))
@@ -1748,7 +1748,7 @@ const VALUE_DEPTH_MAX: usize = 256;
 
 impl Loader {
     fn struct_gidx_to_type_tag(&self, gidx: usize, ty_args: &[Type]) -> PartialVMResult<StructTag> {
-        if let Some(struct_map) = self.type_cache.lock().structs.get(&gidx) {
+        if let Some(struct_map) = self.type_cache.read().structs.get(&gidx) {
             if let Some(struct_info) = struct_map.get(ty_args) {
                 if let Some(struct_tag) = &struct_info.struct_tag {
                     return Ok(struct_tag.clone());
@@ -1760,7 +1760,7 @@ impl Loader {
             .iter()
             .map(|ty| self.type_to_type_tag(ty))
             .collect::<PartialVMResult<Vec<_>>>()?;
-        let struct_type = self.module_cache.lock().struct_at(gidx);
+        let struct_type = self.module_cache.read().struct_at(gidx);
         let struct_tag = StructTag {
             address: *struct_type.module.address(),
             module: struct_type.module.name().to_owned(),
@@ -1769,7 +1769,7 @@ impl Loader {
         };
 
         self.type_cache
-            .lock()
+            .write()
             .structs
             .entry(gidx)
             .or_insert_with(HashMap::new)
@@ -1808,7 +1808,7 @@ impl Loader {
         ty_args: &[Type],
         depth: usize,
     ) -> PartialVMResult<MoveStructLayout> {
-        if let Some(struct_map) = self.type_cache.lock().structs.get(&gidx) {
+        if let Some(struct_map) = self.type_cache.read().structs.get(&gidx) {
             if let Some(struct_info) = struct_map.get(ty_args) {
                 if let Some(layout) = &struct_info.struct_layout {
                     return Ok(layout.clone());
@@ -1816,7 +1816,7 @@ impl Loader {
             }
         }
 
-        let struct_type = self.module_cache.lock().struct_at(gidx);
+        let struct_type = self.module_cache.read().struct_at(gidx);
         let field_tys = struct_type
             .fields
             .iter()
@@ -1829,7 +1829,7 @@ impl Loader {
         let struct_layout = MoveStructLayout::new(field_layouts);
 
         self.type_cache
-            .lock()
+            .write()
             .structs
             .entry(gidx)
             .or_insert_with(HashMap::new)

--- a/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
@@ -23,6 +23,7 @@ use move_core_types::{
     vm_status::{StatusCode, StatusType},
 };
 use move_vm_types::gas_schedule::GasStatus;
+use std::borrow::Cow;
 
 // make a script with a given signature for main.
 fn make_script(parameters: Signature) -> Vec<u8> {
@@ -246,7 +247,7 @@ impl MoveStorage for RemoteStore {
         &self,
         _address: &AccountAddress,
         _tag: &StructTag,
-    ) -> PartialVMResult<Option<Vec<u8>>> {
+    ) -> PartialVMResult<Option<Cow<[u8]>>> {
         Ok(None)
     }
 }

--- a/language/move-vm/test-utils/src/storage.rs
+++ b/language/move-vm/test-utils/src/storage.rs
@@ -11,7 +11,10 @@ use move_core_types::{
 use move_vm_runtime::data_cache::MoveStorage;
 // use move_vm_txn_effect_converter::convert_txn_effects_to_move_changeset_and_events;
 use move_binary_format::errors::{PartialVMResult, VMResult};
-use std::collections::{btree_map, BTreeMap};
+use std::{
+    borrow::Cow,
+    collections::{btree_map, BTreeMap},
+};
 
 /// A dummy storage containing no modules or resources.
 #[derive(Debug, Clone)]
@@ -32,7 +35,7 @@ impl MoveStorage for BlankStorage {
         &self,
         _address: &AccountAddress,
         _tag: &StructTag,
-    ) -> PartialVMResult<Option<Vec<u8>>> {
+    ) -> PartialVMResult<Option<Cow<[u8]>>> {
         Ok(None)
     }
 }
@@ -60,10 +63,10 @@ impl<'a, 'b, S: MoveStorage> MoveStorage for DeltaStorage<'a, 'b, S> {
         &self,
         address: &AccountAddress,
         tag: &StructTag,
-    ) -> PartialVMResult<Option<Vec<u8>>> {
+    ) -> PartialVMResult<Option<Cow<[u8]>>> {
         if let Some(account_storage) = self.delta.accounts().get(address) {
             if let Some(blob_opt) = account_storage.resources().get(tag) {
-                return Ok(blob_opt.clone());
+                 return Ok(blob_opt.as_ref().map(Cow::from));
             }
         }
 
@@ -197,9 +200,9 @@ impl MoveStorage for InMemoryStorage {
         &self,
         address: &AccountAddress,
         tag: &StructTag,
-    ) -> PartialVMResult<Option<Vec<u8>>> {
+    ) -> PartialVMResult<Option<Cow<[u8]>>> {
         if let Some(account_storage) = self.accounts.get(address) {
-            return Ok(account_storage.resources.get(tag).cloned());
+            return Ok(account_storage.resources.get(tag).map(Cow::from));
         }
         Ok(None)
     }

--- a/language/testing-infra/e2e-tests/src/data_store.rs
+++ b/language/testing-infra/e2e-tests/src/data_store.rs
@@ -20,7 +20,7 @@ use move_core_types::{
 };
 use move_vm_runtime::data_cache::MoveStorage;
 use once_cell::sync::Lazy;
-use std::collections::HashMap;
+use std::{borrow::Cow, collections::HashMap};
 use vm_genesis::{generate_genesis_change_set_for_testing, GenesisOptions};
 
 /// Dummy genesis ChangeSet for testing
@@ -116,7 +116,9 @@ impl MoveStorage for FakeDataStore {
         &self,
         address: &AccountAddress,
         tag: &StructTag,
-    ) -> PartialVMResult<Option<Vec<u8>>> {
-        RemoteStorage::new(self).get_resource(address, tag)
+    ) -> PartialVMResult<Option<Cow<[u8]>>> {
+        Ok(RemoteStorage::new(self)
+            .get_resource(address, tag)?
+            .map(|bytes| Cow::from(bytes.into_owned())))
     }
 }

--- a/language/tools/move-cli/src/on_disk_state_view.rs
+++ b/language/tools/move-cli/src/on_disk_state_view.rs
@@ -24,6 +24,7 @@ use resource_viewer::{AnnotatedMoveStruct, AnnotatedMoveValue, MoveValueAnnotato
 
 use anyhow::{anyhow, bail, Result};
 use std::{
+    borrow::Cow,
     collections::{btree_map, BTreeMap},
     convert::TryFrom,
     fs,
@@ -422,8 +423,9 @@ impl MoveStorage for OnDiskStateView {
         &self,
         address: &AccountAddress,
         struct_tag: &StructTag,
-    ) -> PartialVMResult<Option<Vec<u8>>> {
+    ) -> PartialVMResult<Option<Cow<[u8]>>> {
         self.get_resource_bytes(*address, struct_tag.clone())
+            .map(|o| o.map(Cow::from))
             .map_err(|_| PartialVMError::new(StatusCode::STORAGE_ERROR))
     }
 }

--- a/language/tools/resource-viewer/src/lib.rs
+++ b/language/tools/resource-viewer/src/lib.rs
@@ -22,6 +22,7 @@ use move_core_types::{
 };
 use move_vm_runtime::data_cache::MoveStorage;
 use std::{
+    borrow::Cow,
     collections::btree_map::BTreeMap,
     convert::TryInto,
     fmt::{Display, Formatter},
@@ -300,7 +301,7 @@ impl MoveStorage for NullStateView {
         &self,
         _address: &AccountAddress,
         _tag: &StructTag,
-    ) -> PartialVMResult<Option<Vec<u8>>> {
+    ) -> PartialVMResult<Option<Cow<[u8]>>> {
         Ok(None)
     }
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This is a draft version of parallel transaction execution. This PR has four major commits:
1. Clean up the `DataStore` api to be able to return references when needed.
2. Create a separate crate called `mvhashmap` to capture most of the unsafe logic going to be needed for the VM's parallel data cache.
3. Cleaned up the internal api of `DiemVM` to make it generic.
4. Implement a naive scheduler

This work bases mostly on @gdanezis 's previous experiment on parallizing transaction execution, where we assume we have an over approximation of the read/writeset of a transaction and perform parallel scheduling based on the estimate.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan

Still WIP.
