### PR TITLE
[gha] add ignore list to audit

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -28,8 +28,10 @@ jobs:
       - name: install cargo-audit
         run: cargo install --force cargo-audit
       - name: audit crates
+        # List of ignored RUSTSEC
+        # 1. RUSTSEC-2021-0020 - Not impacted, see #7723
         run: |
-          $CARGO $CARGOFLAGS audit >> $MESSAGE_PAYLOAD_FILE
+          $CARGO $CARGOFLAGS audit --ignore RUSTSEC-2021-0020 >> $MESSAGE_PAYLOAD_FILE
       - uses: ./.github/actions/slack-file
         with:
           webhook: ${{ secrets.WEBHOOK_AUDIT }}


### PR DESCRIPTION
## Motivation
The ignore list is used to suppress advisories that don't affect operation.

## Test Plan
CI