### PR TITLE
[bytecode-verifier] add compatibility checking for friend visibility

### DIFF
--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -878,7 +878,7 @@ impl Loader {
     }
 
     // Expects all modules to be on chain. Gives an invariant violation if it is not found
-    fn load_module_expect_not_missing(
+    pub(crate) fn load_module_expect_not_missing(
         &self,
         id: &ModuleId,
         data_store: &mut impl DataStore,
@@ -1367,7 +1367,7 @@ impl Module {
         self.struct_instantiations[idx as usize].field_count
     }
 
-    fn module(&self) -> &CompiledModule {
+    pub(crate) fn module(&self) -> &CompiledModule {
         &self.module
     }
 

--- a/language/vm/src/normalized.rs
+++ b/language/vm/src/normalized.rs
@@ -11,8 +11,9 @@ use crate::{
 use move_core_types::{
     account_address::AccountAddress,
     identifier::Identifier,
-    language_storage::{StructTag, TypeTag},
+    language_storage::{ModuleId, StructTag, TypeTag},
 };
+use std::collections::BTreeMap;
 
 /// Defines normalized representations of Move types, fields, kinds, structs, functions, and
 /// modules. These representations are useful in situations that require require comparing
@@ -24,7 +25,7 @@ use move_core_types::{
 /// A normalized version of `SignatureToken`, a type expression appearing in struct or function
 /// declarations. Unlike `SignatureToken`s, `normalized::Type`s from different modules can safely be
 /// compared.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
 pub enum Type {
     Bool,
     U8,
@@ -66,7 +67,7 @@ pub struct Struct {
 
 /// Normalized version of a `FunctionDefinition`. Not safe to compare without an associated
 /// `ModuleId` or `Module`.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
 pub struct FunctionSignature {
     pub name: Identifier,
     pub type_parameters: Vec<AbilitySet>,
@@ -80,8 +81,9 @@ pub struct FunctionSignature {
 pub struct Module {
     pub address: AccountAddress,
     pub name: Identifier,
+    pub friends: Vec<ModuleId>,
     pub structs: Vec<Struct>,
-    pub externally_visible_functions: Vec<(Visibility, FunctionSignature)>,
+    pub exposed_functions: BTreeMap<FunctionSignature, Visibility>,
 }
 
 impl Module {
@@ -89,24 +91,34 @@ impl Module {
     /// Nothing will break here if that is not the case, but there is little point in computing a
     /// normalized representation of a module that won't verify (since it can't be published).
     pub fn new(m: &CompiledModule) -> Self {
+        let friends = m.immediate_friends();
         let structs = m.struct_defs().iter().map(|d| Struct::new(m, d)).collect();
-        let externally_visible_functions = m
+        let exposed_functions = m
             .function_defs()
             .iter()
-            .filter_map(|f| match f.visibility {
-                v @ Visibility::Public | v @ Visibility::Script | v @ Visibility::Friend => Some((
-                    v,
-                    FunctionSignature::new(m, m.function_handle_at(f.function)),
-                )),
-                Visibility::Private => None,
+            .filter(|func_def| match func_def.visibility {
+                Visibility::Public | Visibility::Script | Visibility::Friend => true,
+                Visibility::Private => false,
+            })
+            .map(|func_def| {
+                (
+                    FunctionSignature::new(m, m.function_handle_at(func_def.function)),
+                    func_def.visibility,
+                )
             })
             .collect();
+
         Self {
             address: *m.address(),
             name: m.name().to_owned(),
+            friends,
             structs,
-            externally_visible_functions,
+            exposed_functions,
         }
+    }
+
+    pub fn module_id(&self) -> ModuleId {
+        ModuleId::new(self.address, self.name.clone())
     }
 }
 


### PR DESCRIPTION
Two versions (denoted as `OLD` and `NEW`) of the module are compatible if
- The structs defined are compatible (not changed in this commit)

* The **exposed** functions defined are compatible (updated in this commit), in particular
   - `OLD` module's `public` functions are a subset of the `NEW` module's public functions
   - `OLD` module's `public(script)` functions are a subset of the `NEW` module's script functions
   * for any `public(friend)` function that is removed or changed in the `OLD` module:
     * if the function visibility is upgraded to `public`, it is OK
     * otherwise, it is considered incompatible
  
* The friend declarations are compatible (newly introduced in this commit), in particular,
  * Adding a new module in the friend list is compatible
  * Removing a module from the friend list is incompatible

## Motivation

Compatibility checking is important for module republishing.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Test cases available in d9eb5e4b6740ddd085e609c522385b921431e71f

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/master/developers.diem.com, and link to your PR here.)
