### PR TITLE
[bytecode-verifier] add missing signature checks to a few generic bytecode instructions

### DIFF
--- a/language/ir-testsuite/tests/move/generics/signatures/reference_as_type_actual_in_struct_inst_for_bytecode_instruction.mvir
+++ b/language/ir-testsuite/tests/move/generics/signatures/reference_as_type_actual_in_struct_inst_for_bytecode_instruction.mvir
@@ -1,0 +1,114 @@
+module M {
+    import 0x1.Signer;
+
+    resource Some<T> { item: T }
+
+    foo(account: &signer) acquires Some {
+        move_from<Some<&u64>>(Signer.address_of(move(account)));
+        return;
+    }
+}
+// check: INVALID_SIGNATURE_TOKEN
+
+//! new-transaction
+module M {
+    import 0x1.Signer;
+
+    resource Some<T> { item: T }
+
+    foo(account: &signer) {
+        let v: Self.Some<u64>;
+        move_to<Some<&u64>>(copy(account), move(v));
+        return;
+    }
+}
+// check: INVALID_SIGNATURE_TOKEN
+
+//! new-transaction
+module M {
+    import 0x1.Signer;
+
+    resource Some<T> { item: T }
+
+    foo(account: &signer) {
+        exists<Some<&u64>>(Signer.address_of(move(account)));
+        return;
+    }
+}
+// check: INVALID_SIGNATURE_TOKEN
+
+//! new-transaction
+module M {
+    import 0x1.Signer;
+
+    resource Some<T> { item: T }
+
+    foo(account: &signer) {
+        borrow_global<Some<&u64>>(Signer.address_of(move(account)));
+        return;
+    }
+}
+// check: INVALID_SIGNATURE_TOKEN
+
+//! new-transaction
+module M {
+    import 0x1.Signer;
+
+    resource Some<T> { item: T }
+
+    foo(account: &signer) {
+        borrow_global_mut<Some<&u64>>(Signer.address_of(move(account)));
+        return;
+    }
+}
+// check: INVALID_SIGNATURE_TOKEN
+
+//! new-transaction
+module M {
+    struct Some<T> { item: T }
+
+    foo() {
+        let x: u64;
+        let y: &u64;
+        let v: Self.Some<u64>;
+
+        y = &x;
+        v = Some<&u64> { item: move(y) };
+        return;
+    }
+}
+// check: INVALID_SIGNATURE_TOKEN
+
+//! new-transaction
+module M {
+    struct Some<T> { item: T }
+
+    foo() {
+        let x: &u64;
+        let v: Self.Some<u64>;
+
+        Some<&u64> { item: x } = move(v);
+        return;
+    }
+}
+// check: INVALID_SIGNATURE_TOKEN
+
+//! new-transaction
+module M {
+    struct S<T> { v: T }
+
+    foo(s: Self.S<&u64>): u64 {
+        return *(*(&(&s).v));
+    }
+}
+// check: INVALID_SIGNATURE_TOKEN
+
+//! new-transaction
+module M {
+    struct S<T> { v: T }
+
+    foo(s: Self.S<&u64>): u64 {
+        return *(*(&mut (&mut s).v));
+    }
+}
+// check: INVALID_SIGNATURE_TOKEN


### PR DESCRIPTION
Three generic bytecode instructions are accidentally missed in the
signature checker

- MoveToGeneric
- ImmBorrowFieldGeneric
- MutBorrowFieldGeneric

This commit adds them back and explicitly list all other bytecodes such
that future additions of bytecodes will not go by this pass undetected
(a compile error will be produced).

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Found this while working in #6991, seems to be an accidental omission.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Test cases added to the IR testsuite.
