### PR TITLE
[move cli] print number of bytes written in verbose output

### DIFF
--- a/language/tools/move-cli/tests/testsuite/compile_modules_and_scripts/args.exp
+++ b/language/tools/move-cli/tests/testsuite/compile_modules_and_scripts/args.exp
@@ -3,4 +3,5 @@ Checking Move files...
 Command `-v publish src/modules`:
 Compiling Move modules...
 Found and compiled 1 modules
-Publishing a new module 00000000000000000000000000000042::M
+Publishing a new module 00000000000000000000000000000042::M (wrote 56 bytes)
+Wrote 56 bytes of module ID's and code

--- a/language/tools/move-cli/tests/testsuite/diem_smoke/args.exp
+++ b/language/tools/move-cli/tests/testsuite/diem_smoke/args.exp
@@ -5,96 +5,97 @@ Emitted [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0
 Emitted [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 30, 85, 237, 1, 0, 0, 0, 0, 0, 0, 0] as the 1th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
 Changed resource(s) under 2 address(es):
   Changed 28 resource(s) under address 0000000000000000000000000A550C18:
-    Added type 0x1::AccountFreezing::FreezeEventsHolder: [0, 0, 0, 0, 0, 0, 0, 0, 24, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
-    Added type 0x1::AccountFreezing::FreezingBit: [0]
-    Added type 0x1::AccountLimits::LimitsDefinition<0x1::XDX::XDX>: [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 96, 215, 29, 20, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255]
-    Added type 0x1::AccountLimits::LimitsDefinition<0x1::XUS::XUS>: [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 96, 215, 29, 20, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255]
-    Added type 0x1::ChainId::ChainId: [0]
-    Added type 0x1::Diem::CurrencyInfo<0x1::XDX::XDX>: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 64, 66, 15, 0, 0, 0, 0, 0, 232, 3, 0, 0, 0, 0, 0, 0, 3, 88, 68, 88, 0, 0, 0, 0, 0, 0, 0, 0, 0, 24, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
-    Added type 0x1::Diem::CurrencyInfo<0x1::XUS::XUS>: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 64, 66, 15, 0, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 3, 88, 85, 83, 1, 0, 0, 0, 0, 0, 0, 0, 0, 24, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
-    Added type 0x1::DiemAccount::AccountOperationsCapability: [0, 2, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
-    Added type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0]
-    Added type 0x1::DiemAccount::DiemWriteSetManager: [0, 0, 0, 0, 0, 0, 0, 0, 24, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
-    Added type 0x1::DiemBlock::BlockMetadata: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 24, 17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
-    Added type 0x1::DiemConfig::Configuration: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 24, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
-    Added type 0x1::DiemConfig::DiemConfig<0x1::DiemSystem::DiemSystem>: [0, 0]
-    Added type 0x1::DiemConfig::DiemConfig<0x1::DiemTransactionPublishingOption::DiemTransactionPublishingOption>: [0, 1]
-    Added type 0x1::DiemConfig::DiemConfig<0x1::DiemVMConfig::DiemVMConfig>: [0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0, 88, 2, 0, 0, 0, 0, 0, 0, 88, 2, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 9, 61, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16, 39, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 232, 3, 0, 0, 0, 0, 0, 0, 32, 3, 0, 0, 0, 0, 0, 0]
-    Added type 0x1::DiemConfig::DiemConfig<0x1::DiemVersion::DiemVersion>: [1, 0, 0, 0, 0, 0, 0, 0]
-    Added type 0x1::DiemConfig::DiemConfig<0x1::RegisteredCurrencies::RegisteredCurrencies>: [2, 3, 88, 85, 83, 3, 88, 68, 88]
-    Added type 0x1::DiemConfig::ModifyConfigCapability<0x1::DiemTransactionPublishingOption::DiemTransactionPublishingOption>: [0]
-    Added type 0x1::DiemConfig::ModifyConfigCapability<0x1::DiemVMConfig::DiemVMConfig>: [0]
-    Added type 0x1::DiemConfig::ModifyConfigCapability<0x1::DiemVersion::DiemVersion>: [0]
-    Added type 0x1::DiemConfig::ModifyConfigCapability<0x1::RegisteredCurrencies::RegisteredCurrencies>: [0]
-    Added type 0x1::DiemSystem::CapabilityHolder: [0]
-    Added type 0x1::DiemTimestamp::CurrentTimeMicroseconds: [0, 0, 0, 0, 0, 0, 0, 0]
-    Added type 0x1::DualAttestation::Limit: [0, 202, 154, 59, 0, 0, 0, 0]
-    Added type 0x1::Event::EventHandleGenerator: [18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
-    Added type 0x1::Roles::RoleId: [0, 0, 0, 0, 0, 0, 0, 0]
-    Added type 0x1::SlidingNonce::SlidingNonce: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-    Added type 0x1::XDX::Reserve: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    Added type 0x1::AccountFreezing::FreezeEventsHolder: [0, 0, 0, 0, 0, 0, 0, 0, 24, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 119 bytes)
+    Added type 0x1::AccountFreezing::FreezingBit: [0] (wrote 47 bytes)
+    Added type 0x1::AccountLimits::LimitsDefinition<0x1::XDX::XDX>: [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 96, 215, 29, 20, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255] (wrote 107 bytes)
+    Added type 0x1::AccountLimits::LimitsDefinition<0x1::XUS::XUS>: [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 96, 215, 29, 20, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255] (wrote 107 bytes)
+    Added type 0x1::ChainId::ChainId: [0] (wrote 35 bytes)
+    Added type 0x1::Diem::CurrencyInfo<0x1::XDX::XDX>: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 64, 66, 15, 0, 0, 0, 0, 0, 232, 3, 0, 0, 0, 0, 0, 0, 3, 88, 68, 88, 0, 0, 0, 0, 0, 0, 0, 0, 0, 24, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 281 bytes)
+    Added type 0x1::Diem::CurrencyInfo<0x1::XUS::XUS>: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 64, 66, 15, 0, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 3, 88, 85, 83, 1, 0, 0, 0, 0, 0, 0, 0, 0, 24, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 281 bytes)
+    Added type 0x1::DiemAccount::AccountOperationsCapability: [0, 2, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 92 bytes)
+    Added type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
+    Added type 0x1::DiemAccount::DiemWriteSetManager: [0, 0, 0, 0, 0, 0, 0, 0, 24, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 83 bytes)
+    Added type 0x1::DiemBlock::BlockMetadata: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 24, 17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 83 bytes)
+    Added type 0x1::DiemConfig::Configuration: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 24, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 92 bytes)
+    Added type 0x1::DiemConfig::DiemConfig<0x1::DiemSystem::DiemSystem>: [0, 0] (wrote 82 bytes)
+    Added type 0x1::DiemConfig::DiemConfig<0x1::DiemTransactionPublishingOption::DiemTransactionPublishingOption>: [0, 1] (wrote 124 bytes)
+    Added type 0x1::DiemConfig::DiemConfig<0x1::DiemVMConfig::DiemVMConfig>: [0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0, 88, 2, 0, 0, 0, 0, 0, 0, 88, 2, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 9, 61, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16, 39, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 232, 3, 0, 0, 0, 0, 0, 0, 32, 3, 0, 0, 0, 0, 0, 0] (wrote 174 bytes)
+    Added type 0x1::DiemConfig::DiemConfig<0x1::DiemVersion::DiemVersion>: [1, 0, 0, 0, 0, 0, 0, 0] (wrote 90 bytes)
+    Added type 0x1::DiemConfig::DiemConfig<0x1::RegisteredCurrencies::RegisteredCurrencies>: [2, 3, 88, 85, 83, 3, 88, 68, 88] (wrote 109 bytes)
+    Added type 0x1::DiemConfig::ModifyConfigCapability<0x1::DiemTransactionPublishingOption::DiemTransactionPublishingOption>: [0] (wrote 135 bytes)
+    Added type 0x1::DiemConfig::ModifyConfigCapability<0x1::DiemVMConfig::DiemVMConfig>: [0] (wrote 97 bytes)
+    Added type 0x1::DiemConfig::ModifyConfigCapability<0x1::DiemVersion::DiemVersion>: [0] (wrote 95 bytes)
+    Added type 0x1::DiemConfig::ModifyConfigCapability<0x1::RegisteredCurrencies::RegisteredCurrencies>: [0] (wrote 113 bytes)
+    Added type 0x1::DiemSystem::CapabilityHolder: [0] (wrote 47 bytes)
+    Added type 0x1::DiemTimestamp::CurrentTimeMicroseconds: [0, 0, 0, 0, 0, 0, 0, 0] (wrote 64 bytes)
+    Added type 0x1::DualAttestation::Limit: [0, 202, 154, 59, 0, 0, 0, 0] (wrote 48 bytes)
+    Added type 0x1::Event::EventHandleGenerator: [18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 69 bytes)
+    Added type 0x1::Roles::RoleId: [0, 0, 0, 0, 0, 0, 0, 0] (wrote 39 bytes)
+    Added type 0x1::SlidingNonce::SlidingNonce: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 68 bytes)
+    Added type 0x1::XDX::Reserve: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 40 bytes)
   Changed 8 resource(s) under address 0000000000000000000000000B1E55ED:
-    Added type 0x1::AccountFreezing::FreezingBit: [0]
-    Added type 0x1::Diem::BurnCapability<0x1::XUS::XUS>: [0]
-    Added type 0x1::Diem::MintCapability<0x1::XUS::XUS>: [0]
-    Added type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 30, 85, 237, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 30, 85, 237, 0, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 30, 85, 237, 0, 0, 0, 0, 0, 0, 0, 0, 24, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 30, 85, 237, 0, 0, 0, 0, 0, 0, 0, 0]
-    Added type 0x1::Event::EventHandleGenerator: [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 30, 85, 237]
-    Added type 0x1::Roles::RoleId: [1, 0, 0, 0, 0, 0, 0, 0]
-    Added type 0x1::SlidingNonce::SlidingNonce: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-    Added type 0x1::TransactionFee::TransactionFee<0x1::XUS::XUS>: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    Added type 0x1::AccountFreezing::FreezingBit: [0] (wrote 47 bytes)
+    Added type 0x1::Diem::BurnCapability<0x1::XUS::XUS>: [0] (wrote 65 bytes)
+    Added type 0x1::Diem::MintCapability<0x1::XUS::XUS>: [0] (wrote 65 bytes)
+    Added type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 30, 85, 237, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 30, 85, 237, 0, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 30, 85, 237, 0, 0, 0, 0, 0, 0, 0, 0, 24, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 30, 85, 237, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
+    Added type 0x1::Event::EventHandleGenerator: [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 30, 85, 237] (wrote 69 bytes)
+    Added type 0x1::Roles::RoleId: [1, 0, 0, 0, 0, 0, 0, 0] (wrote 39 bytes)
+    Added type 0x1::SlidingNonce::SlidingNonce: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 68 bytes)
+    Added type 0x1::TransactionFee::TransactionFee<0x1::XUS::XUS>: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 90 bytes)
+Wrote 3530 bytes of resource ID's and data
 Command `run ../../../../../diem-framework/transaction_scripts/create_designated_dealer.move --mode diem --type-args 0x1::XDX::XDX --signers 0xB1E55ED --args 0 0xDD x"00000000000000000000000000000000" b"DD" true -v`:
 Compiling transaction script...
 Emitted 1 events:
 Emitted [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 2, 0, 0, 0, 0, 0, 0, 0] as the 2th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
 Changed resource(s) under 3 address(es):
   Changed 10 resource(s) under address 000000000000000000000000000000DD:
-    Added type 0x1::AccountFreezing::FreezingBit: [0]
-    Added type 0x1::DesignatedDealer::Dealer: [0, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]
-    Added type 0x1::DesignatedDealer::TierInfo<0x1::XUS::XUS>: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 136, 82, 106, 116, 0, 0, 0, 0, 80, 57, 39, 140, 4, 0, 0, 0, 32, 61, 136, 121, 45, 0, 0, 0, 64, 99, 82, 191, 198, 1, 0]
-    Added type 0x1::Diem::PreburnQueue<0x1::XUS::XUS>: [0]
-    Added type 0x1::DiemAccount::Balance<0x1::XDX::XDX>: [0, 0, 0, 0, 0, 0, 0, 0]
-    Added type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [0, 0, 0, 0, 0, 0, 0, 0]
-    Added type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 0, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 0, 0, 0, 0, 0, 0, 0, 0, 24, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 0, 0, 0, 0, 0, 0, 0, 0]
-    Added type 0x1::DualAttestation::Credential: [2, 68, 68, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 24, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 0, 0, 0, 0, 0, 0, 0, 0, 24, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]
-    Added type 0x1::Event::EventHandleGenerator: [5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]
-    Added type 0x1::Roles::RoleId: [2, 0, 0, 0, 0, 0, 0, 0]
+    Added type 0x1::AccountFreezing::FreezingBit: [0] (wrote 47 bytes)
+    Added type 0x1::DesignatedDealer::Dealer: [0, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221] (wrote 75 bytes)
+    Added type 0x1::DesignatedDealer::TierInfo<0x1::XUS::XUS>: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 136, 82, 106, 116, 0, 0, 0, 0, 80, 57, 39, 140, 4, 0, 0, 0, 32, 61, 136, 121, 45, 0, 0, 0, 64, 99, 82, 191, 198, 1, 0] (wrote 119 bytes)
+    Added type 0x1::Diem::PreburnQueue<0x1::XUS::XUS>: [0] (wrote 63 bytes)
+    Added type 0x1::DiemAccount::Balance<0x1::XDX::XDX>: [0, 0, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+    Added type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [0, 0, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+    Added type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 0, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 0, 0, 0, 0, 0, 0, 0, 0, 24, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
+    Added type 0x1::DualAttestation::Credential: [2, 68, 68, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 24, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 0, 0, 0, 0, 0, 0, 0, 0, 24, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221] (wrote 124 bytes)
+    Added type 0x1::Event::EventHandleGenerator: [5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221] (wrote 69 bytes)
+    Added type 0x1::Roles::RoleId: [2, 0, 0, 0, 0, 0, 0, 0] (wrote 39 bytes)
   Changed 1 resource(s) under address 0000000000000000000000000A550C18:
-    Changed type 0x1::DiemAccount::AccountOperationsCapability: [0, 3, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
-  Changed 0 resource(s) under address 0000000000000000000000000B1E55ED:
+    Changed type 0x1::DiemAccount::AccountOperationsCapability: [0, 3, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 92 bytes)
+  Wrote 955 bytes of resource ID's and data
 Command `run ../../../../../diem-framework/transaction_scripts/create_parent_vasp_account.move --mode diem --type-args 0x1::XDX::XDX --signers 0xB1E55ED --args 0 0xA x"00000000000000000000000000000000" b"VASP_A" true -v`:
 Compiling transaction script...
 Emitted 1 events:
 Emitted [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 5, 0, 0, 0, 0, 0, 0, 0] as the 3th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
 Changed resource(s) under 3 address(es):
   Changed 8 resource(s) under address 0000000000000000000000000000000A:
-    Added type 0x1::AccountFreezing::FreezingBit: [0]
-    Added type 0x1::DiemAccount::Balance<0x1::XDX::XDX>: [0, 0, 0, 0, 0, 0, 0, 0]
-    Added type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [0, 0, 0, 0, 0, 0, 0, 0]
-    Added type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 24, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0]
-    Added type 0x1::DualAttestation::Credential: [6, 86, 65, 83, 80, 95, 65, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 24, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
-    Added type 0x1::Event::EventHandleGenerator: [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
-    Added type 0x1::Roles::RoleId: [5, 0, 0, 0, 0, 0, 0, 0]
-    Added type 0x1::VASP::ParentVASP: [0, 0, 0, 0, 0, 0, 0, 0]
+    Added type 0x1::AccountFreezing::FreezingBit: [0] (wrote 47 bytes)
+    Added type 0x1::DiemAccount::Balance<0x1::XDX::XDX>: [0, 0, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+    Added type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [0, 0, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+    Added type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 24, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
+    Added type 0x1::DualAttestation::Credential: [6, 86, 65, 83, 80, 95, 65, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 24, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10] (wrote 128 bytes)
+    Added type 0x1::Event::EventHandleGenerator: [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10] (wrote 69 bytes)
+    Added type 0x1::Roles::RoleId: [5, 0, 0, 0, 0, 0, 0, 0] (wrote 39 bytes)
+    Added type 0x1::VASP::ParentVASP: [0, 0, 0, 0, 0, 0, 0, 0] (wrote 42 bytes)
   Changed 1 resource(s) under address 0000000000000000000000000A550C18:
-    Changed type 0x1::DiemAccount::AccountOperationsCapability: [0, 4, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
-  Changed 0 resource(s) under address 0000000000000000000000000B1E55ED:
+    Changed type 0x1::DiemAccount::AccountOperationsCapability: [0, 4, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 92 bytes)
+  Wrote 744 bytes of resource ID's and data
 Command `run ../../../../../diem-framework/transaction_scripts/create_parent_vasp_account.move --mode diem --type-args 0x1::XDX::XDX --signers 0xB1E55ED --args 0 0xB x"00000000000000000000000000000000" b"VASP_B" true -v`:
 Compiling transaction script...
 Emitted 1 events:
 Emitted [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 5, 0, 0, 0, 0, 0, 0, 0] as the 4th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
 Changed resource(s) under 3 address(es):
   Changed 8 resource(s) under address 0000000000000000000000000000000B:
-    Added type 0x1::AccountFreezing::FreezingBit: [0]
-    Added type 0x1::DiemAccount::Balance<0x1::XDX::XDX>: [0, 0, 0, 0, 0, 0, 0, 0]
-    Added type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [0, 0, 0, 0, 0, 0, 0, 0]
-    Added type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 24, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0]
-    Added type 0x1::DualAttestation::Credential: [6, 86, 65, 83, 80, 95, 66, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 24, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11]
-    Added type 0x1::Event::EventHandleGenerator: [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11]
-    Added type 0x1::Roles::RoleId: [5, 0, 0, 0, 0, 0, 0, 0]
-    Added type 0x1::VASP::ParentVASP: [0, 0, 0, 0, 0, 0, 0, 0]
+    Added type 0x1::AccountFreezing::FreezingBit: [0] (wrote 47 bytes)
+    Added type 0x1::DiemAccount::Balance<0x1::XDX::XDX>: [0, 0, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+    Added type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [0, 0, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+    Added type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 24, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
+    Added type 0x1::DualAttestation::Credential: [6, 86, 65, 83, 80, 95, 66, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 24, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11] (wrote 128 bytes)
+    Added type 0x1::Event::EventHandleGenerator: [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11] (wrote 69 bytes)
+    Added type 0x1::Roles::RoleId: [5, 0, 0, 0, 0, 0, 0, 0] (wrote 39 bytes)
+    Added type 0x1::VASP::ParentVASP: [0, 0, 0, 0, 0, 0, 0, 0] (wrote 42 bytes)
   Changed 1 resource(s) under address 0000000000000000000000000A550C18:
-    Changed type 0x1::DiemAccount::AccountOperationsCapability: [0, 5, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
-  Changed 0 resource(s) under address 0000000000000000000000000B1E55ED:
+    Changed type 0x1::DiemAccount::AccountOperationsCapability: [0, 5, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 92 bytes)
+  Wrote 744 bytes of resource ID's and data
 Command `run ../../../../../diem-framework/transaction_scripts/tiered_mint.move --mode diem --type-args 0x1::XUS::XUS --signers 0xB1E55ED --args 0 0xDD 1000 0 -v`:
 Compiling transaction script...
 Emitted 3 events:
@@ -103,13 +104,13 @@ Emitted [232, 3, 0, 0, 0, 0, 0, 0, 3, 88, 85, 83] as the 0th event to stream [5,
 Emitted [232, 3, 0, 0, 0, 0, 0, 0, 3, 88, 85, 83, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] as the 0th event to stream [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]
 Changed resource(s) under 3 address(es):
   Changed 4 resource(s) under address 000000000000000000000000000000DD:
-    Changed type 0x1::DesignatedDealer::Dealer: [1, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]
-    Changed type 0x1::DesignatedDealer::TierInfo<0x1::XUS::XUS>: [0, 0, 0, 0, 0, 0, 0, 0, 232, 3, 0, 0, 0, 0, 0, 0, 4, 0, 136, 82, 106, 116, 0, 0, 0, 0, 80, 57, 39, 140, 4, 0, 0, 0, 32, 61, 136, 121, 45, 0, 0, 0, 64, 99, 82, 191, 198, 1, 0]
-    Changed type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [232, 3, 0, 0, 0, 0, 0, 0]
-    Changed type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 0, 0, 0, 0, 0, 0, 0, 0, 24, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 0, 0, 0, 0, 0, 0, 0, 0]
+    Changed type 0x1::DesignatedDealer::Dealer: [1, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221] (wrote 75 bytes)
+    Changed type 0x1::DesignatedDealer::TierInfo<0x1::XUS::XUS>: [0, 0, 0, 0, 0, 0, 0, 0, 232, 3, 0, 0, 0, 0, 0, 0, 4, 0, 136, 82, 106, 116, 0, 0, 0, 0, 80, 57, 39, 140, 4, 0, 0, 0, 32, 61, 136, 121, 45, 0, 0, 0, 64, 99, 82, 191, 198, 1, 0] (wrote 119 bytes)
+    Changed type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [232, 3, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+    Changed type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 0, 0, 0, 0, 0, 0, 0, 0, 24, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
   Changed 1 resource(s) under address 0000000000000000000000000A550C18:
-    Changed type 0x1::Diem::CurrencyInfo<0x1::XUS::XUS>: [232, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 64, 66, 15, 0, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 3, 88, 85, 83, 1, 1, 0, 0, 0, 0, 0, 0, 0, 24, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
-  Changed 0 resource(s) under address 0000000000000000000000000B1E55ED:
+    Changed type 0x1::Diem::CurrencyInfo<0x1::XUS::XUS>: [232, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 64, 66, 15, 0, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 3, 88, 85, 83, 1, 1, 0, 0, 0, 0, 0, 0, 0, 24, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 281 bytes)
+  Wrote 730 bytes of resource ID's and data
 Command `run ../../../../../diem-framework/transaction_scripts/peer_to_peer_with_metadata.move --mode diem --type-args 0x1::XUS::XUS --signers 0xDD --args 0xA 700 x"" x"" -v`:
 Compiling transaction script...
 Emitted 2 events:
@@ -117,12 +118,12 @@ Emitted [188, 2, 0, 0, 0, 0, 0, 0, 3, 88, 85, 83, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
 Emitted [188, 2, 0, 0, 0, 0, 0, 0, 3, 88, 85, 83, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 0] as the 0th event to stream [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
 Changed resource(s) under 3 address(es):
   Changed 2 resource(s) under address 0000000000000000000000000000000A:
-    Changed type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [188, 2, 0, 0, 0, 0, 0, 0]
-    Changed type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 24, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0]
+    Changed type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [188, 2, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+    Changed type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 24, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
   Changed 2 resource(s) under address 000000000000000000000000000000DD:
-    Changed type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [44, 1, 0, 0, 0, 0, 0, 0]
-    Changed type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 24, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 0, 0, 0, 0, 0, 0, 0, 0]
-  Changed 0 resource(s) under address 0000000000000000000000000A550C18:
+    Changed type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [44, 1, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+    Changed type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 24, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
+  Wrote 510 bytes of resource ID's and data
 Command `run ../../../../../diem-framework/transaction_scripts/peer_to_peer_with_metadata.move --mode diem --type-args 0x1::XUS::XUS --signers 0xA --args 0xB 500 x"" x"" -v`:
 Compiling transaction script...
 Emitted 2 events:
@@ -130,10 +131,61 @@ Emitted [244, 1, 0, 0, 0, 0, 0, 0, 3, 88, 85, 83, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
 Emitted [244, 1, 0, 0, 0, 0, 0, 0, 3, 88, 85, 83, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0] as the 0th event to stream [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11]
 Changed resource(s) under 3 address(es):
   Changed 2 resource(s) under address 0000000000000000000000000000000A:
-    Changed type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [200, 0, 0, 0, 0, 0, 0, 0]
-    Changed type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 24, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0]
+    Changed type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [200, 0, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+    Changed type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 24, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
   Changed 2 resource(s) under address 0000000000000000000000000000000B:
-    Changed type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [244, 1, 0, 0, 0, 0, 0, 0]
-    Changed type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 1, 0, 0, 0, 0, 0, 0, 0, 24, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0]
-  Changed 0 resource(s) under address 0000000000000000000000000A550C18:
+    Changed type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [244, 1, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+    Changed type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 1, 0, 0, 0, 0, 0, 0, 0, 24, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
+  Wrote 510 bytes of resource ID's and data
+Command `run ../../../../../diem-framework/transaction_scripts/create_child_vasp_account.move --mode diem --type-args 0x1::XUS::XUS --signers 0xA --args 0xAA x"00000000000000000000000000000000" false 100 -v`:
+Compiling transaction script...
+Emitted 3 events:
+Emitted [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170, 6, 0, 0, 0, 0, 0, 0, 0] as the 5th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
+Emitted [100, 0, 0, 0, 0, 0, 0, 0, 3, 88, 85, 83, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170, 0] as the 1th event to stream [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
+Emitted [100, 0, 0, 0, 0, 0, 0, 0, 3, 88, 85, 83, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0] as the 0th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170]
+Changed resource(s) under 3 address(es):
+  Changed 3 resource(s) under address 0000000000000000000000000000000A:
+    Changed type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [100, 0, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+    Changed type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 24, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 2, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
+    Changed type 0x1::VASP::ParentVASP: [1, 0, 0, 0, 0, 0, 0, 0] (wrote 42 bytes)
+  Changed 6 resource(s) under address 000000000000000000000000000000AA:
+    Added type 0x1::AccountFreezing::FreezingBit: [0] (wrote 47 bytes)
+    Added type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [100, 0, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+    Added type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170, 1, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170, 0, 0, 0, 0, 0, 0, 0, 0, 24, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
+    Added type 0x1::Event::EventHandleGenerator: [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170] (wrote 69 bytes)
+    Added type 0x1::Roles::RoleId: [6, 0, 0, 0, 0, 0, 0, 0] (wrote 39 bytes)
+    Added type 0x1::VASP::ChildVASP: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10] (wrote 49 bytes)
+  Changed 1 resource(s) under address 0000000000000000000000000A550C18:
+    Changed type 0x1::DiemAccount::AccountOperationsCapability: [0, 6, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 92 bytes)
+Wrote 848 bytes of resource ID's and data
+Command `run ../../../../../diem-framework/transaction_scripts/create_child_vasp_account.move --mode diem --type-args 0x1::XUS::XUS --signers 0xB --args 0xBB x"00000000000000000000000000000000" false 0 -v`:
+Compiling transaction script...
+Emitted 1 events:
+Emitted [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187, 6, 0, 0, 0, 0, 0, 0, 0] as the 6th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
+Changed resource(s) under 3 address(es):
+  Changed 1 resource(s) under address 0000000000000000000000000000000B:
+    Changed type 0x1::VASP::ParentVASP: [1, 0, 0, 0, 0, 0, 0, 0] (wrote 42 bytes)
+  Changed 6 resource(s) under address 000000000000000000000000000000BB:
+    Added type 0x1::AccountFreezing::FreezingBit: [0] (wrote 47 bytes)
+    Added type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [0, 0, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+    Added type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187, 0, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187, 0, 0, 0, 0, 0, 0, 0, 0, 24, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
+    Added type 0x1::Event::EventHandleGenerator: [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187] (wrote 69 bytes)
+    Added type 0x1::Roles::RoleId: [6, 0, 0, 0, 0, 0, 0, 0] (wrote 39 bytes)
+    Added type 0x1::VASP::ChildVASP: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11] (wrote 49 bytes)
+  Changed 1 resource(s) under address 0000000000000000000000000A550C18:
+    Changed type 0x1::DiemAccount::AccountOperationsCapability: [0, 7, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 92 bytes)
+Wrote 593 bytes of resource ID's and data
+Command `run ../../../../../diem-framework/transaction_scripts/peer_to_peer_with_metadata.move --mode diem --type-args 0x1::XUS::XUS --signers 0xAA --args 0xBB 100 x"" x"" -v`:
+Compiling transaction script...
+Emitted 2 events:
+Emitted [100, 0, 0, 0, 0, 0, 0, 0, 3, 88, 85, 83, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187, 0] as the 0th event to stream [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170]
+Emitted [100, 0, 0, 0, 0, 0, 0, 0, 3, 88, 85, 83, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170, 0] as the 0th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187]
+Changed resource(s) under 5 address(es):
+      Changed 2 resource(s) under address 000000000000000000000000000000AA:
+    Changed type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [0, 0, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+    Changed type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170, 1, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170, 1, 0, 0, 0, 0, 0, 0, 0, 24, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
+  Changed 2 resource(s) under address 000000000000000000000000000000BB:
+    Changed type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [100, 0, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+    Changed type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187, 1, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187, 0, 0, 0, 0, 0, 0, 0, 0, 24, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
+  Wrote 510 bytes of resource ID's and data
 Command `doctor`:

--- a/language/tools/move-cli/tests/testsuite/diem_smoke/args.txt
+++ b/language/tools/move-cli/tests/testsuite/diem_smoke/args.txt
@@ -21,5 +21,14 @@ run ../../../../../diem-framework/transaction_scripts/peer_to_peer_with_metadata
 # transfer 500 XUS from 0xA to 0xB
 run ../../../../../diem-framework/transaction_scripts/peer_to_peer_with_metadata.move --mode diem --type-args 0x1::XUS::XUS --signers 0xA --args 0xB 500 x"" x"" -v
 
+# create a child VASP account for 0xA
+run ../../../../../diem-framework/transaction_scripts/create_child_vasp_account.move --mode diem --type-args 0x1::XUS::XUS --signers 0xA --args 0xAA x"00000000000000000000000000000000" false 100 -v
+
+# create a child VASP account for 0xB
+run ../../../../../diem-framework/transaction_scripts/create_child_vasp_account.move --mode diem --type-args 0x1::XUS::XUS --signers 0xB --args 0xBB x"00000000000000000000000000000000" false 0 -v
+
+# transfer 100 from child 0xAA to child 0xBB
+run ../../../../../diem-framework/transaction_scripts/peer_to_peer_with_metadata.move --mode diem --type-args 0x1::XUS::XUS --signers 0xAA --args 0xBB 100 x"" x"" -v
+
 # make sure state is still ok
 doctor

--- a/language/tools/move-cli/tests/testsuite/events_emit_view/args.exp
+++ b/language/tools/move-cli/tests/testsuite/events_emit_view/args.exp
@@ -1,15 +1,17 @@
 Command `publish src/modules -v`:
 Compiling Move modules...
 Found and compiled 1 modules
-Publishing a new module 00000000000000000000000000000002::Events
+Publishing a new module 00000000000000000000000000000002::Events (wrote 368 bytes)
+Wrote 368 bytes of module ID's and code
 Command `run src/scripts/emit.move --signers 0xA --args 5 -v`:
 Compiling transaction script...
 Emitted 1 events:
 Emitted [5, 0, 0, 0, 0, 0, 0, 0] as the 0th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
 Changed resource(s) under 1 address(es):
   Changed 2 resource(s) under address 0000000000000000000000000000000A:
-    Added type 0x1::Event::EventHandleGenerator: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
-    Added type 0x2::Events::Handle: [1, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
+    Added type 0x1::Event::EventHandleGenerator: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10] (wrote 69 bytes)
+    Added type 0x2::Events::Handle: [1, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10] (wrote 65 bytes)
+Wrote 134 bytes of resource ID's and data
 Command `view storage/0x0000000000000000000000000000000A/events/0.bcs`:
 copy drop store 0x2::Events::AnEvent {
     i: 5
@@ -20,7 +22,8 @@ Emitted 1 events:
 Emitted [6, 0, 0, 0, 0, 0, 0, 0] as the 1th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
 Changed resource(s) under 1 address(es):
   Changed 1 resource(s) under address 0000000000000000000000000000000A:
-    Changed type 0x2::Events::Handle: [2, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
+    Changed type 0x2::Events::Handle: [2, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10] (wrote 65 bytes)
+Wrote 65 bytes of resource ID's and data
 Command `view storage/0x0000000000000000000000000000000A/events/0.bcs`:
 copy drop store 0x2::Events::AnEvent {
     i: 5

--- a/language/tools/move-cli/tests/testsuite/module_publish_view/args.exp
+++ b/language/tools/move-cli/tests/testsuite/module_publish_view/args.exp
@@ -1,7 +1,8 @@
 Command `publish src -v`:
 Compiling Move modules...
 Found and compiled 1 modules
-Publishing a new module 00000000000000000000000000000042::Module
+Publishing a new module 00000000000000000000000000000042::Module (wrote 120 bytes)
+Wrote 120 bytes of module ID's and code
 Command `view storage/0x00000000000000000000000000000042/modules/Module.mv`:
 module 42.Module {
 resource S {

--- a/language/tools/move-cli/tests/testsuite/module_run_view/args.exp
+++ b/language/tools/move-cli/tests/testsuite/module_run_view/args.exp
@@ -1,14 +1,16 @@
 Command `publish src/modules -v`:
 Compiling Move modules...
 Found and compiled 1 modules
-Publishing a new module 00000000000000000000000000000002::Test
+Publishing a new module 00000000000000000000000000000002::Test (wrote 123 bytes)
+Wrote 123 bytes of module ID's and code
 Command `run src/scripts/script.move --signers 0xA 0xB --args 6 7 --dry-run -v`:
 Compiling transaction script...
 Changed resource(s) under 2 address(es):
   Changed 1 resource(s) under address 0000000000000000000000000000000A:
-    Added type 0x2::Test::R: [6, 0, 0, 0, 0, 0, 0, 0]
+    Added type 0x2::Test::R: [6, 0, 0, 0, 0, 0, 0, 0] (wrote 33 bytes)
   Changed 1 resource(s) under address 0000000000000000000000000000000B:
-    Added type 0x2::Test::R: [7, 0, 0, 0, 0, 0, 0, 0]
+    Added type 0x2::Test::R: [7, 0, 0, 0, 0, 0, 0, 0] (wrote 33 bytes)
+Wrote 66 bytes of resource ID's and data
 Discarding changes; re-run without --dry-run if you would like to keep them.
 Command `view storage/0x0000000000000000000000000000000A/resources/0x00000000000000000000000000000002::Test::R.bcs`:
 Error: `move view <file>` must point to a valid file under storage
@@ -18,9 +20,10 @@ Command `run src/scripts/script.move --signers 0xA 0xB --args 6 7 -v`:
 Compiling transaction script...
 Changed resource(s) under 2 address(es):
   Changed 1 resource(s) under address 0000000000000000000000000000000A:
-    Added type 0x2::Test::R: [6, 0, 0, 0, 0, 0, 0, 0]
+    Added type 0x2::Test::R: [6, 0, 0, 0, 0, 0, 0, 0] (wrote 33 bytes)
   Changed 1 resource(s) under address 0000000000000000000000000000000B:
-    Added type 0x2::Test::R: [7, 0, 0, 0, 0, 0, 0, 0]
+    Added type 0x2::Test::R: [7, 0, 0, 0, 0, 0, 0, 0] (wrote 33 bytes)
+Wrote 66 bytes of resource ID's and data
 Command `view storage/0x0000000000000000000000000000000A/resources/0x00000000000000000000000000000002::Test::R.bcs`:
 store key 0x2::Test::R {
     i: 6

--- a/language/tools/move-cli/tests/testsuite/republish/args.exp
+++ b/language/tools/move-cli/tests/testsuite/republish/args.exp
@@ -1,8 +1,9 @@
 Command `publish -v`:
 Compiling Move modules...
 Found and compiled 2 modules
-Publishing a new module 00000000000000000000000000000042::M
-Publishing a new module 00000000000000000000000000000043::N
+Publishing a new module 00000000000000000000000000000042::M (wrote 56 bytes)
+Publishing a new module 00000000000000000000000000000043::N (wrote 56 bytes)
+Wrote 112 bytes of module ID's and code
 Command `view storage/0x00000000000000000000000000000042/modules/M.mv`:
 module 42.M {
 
@@ -18,8 +19,9 @@ module 43.N {
 Command `publish -v`:
 Compiling Move modules...
 Found and compiled 2 modules
-Updating an existing module 00000000000000000000000000000042::M
-Updating an existing module 00000000000000000000000000000043::N
+Updating an existing module 00000000000000000000000000000042::M (wrote 56 bytes)
+Updating an existing module 00000000000000000000000000000043::N (wrote 56 bytes)
+Wrote 112 bytes of module ID's and code
 Command `view storage/0x00000000000000000000000000000042/modules/M.mv`:
 module 42.M {
 

--- a/language/tools/move-cli/tests/testsuite/republish_cyclic/args.exp
+++ b/language/tools/move-cli/tests/testsuite/republish_cyclic/args.exp
@@ -1,8 +1,9 @@
 Command `publish src1 -v`:
 Compiling Move modules...
 Found and compiled 2 modules
-Publishing a new module 00000000000000000000000000000042::M
-Publishing a new module 00000000000000000000000000000043::N
+Publishing a new module 00000000000000000000000000000042::M (wrote 113 bytes)
+Publishing a new module 00000000000000000000000000000043::N (wrote 82 bytes)
+Wrote 195 bytes of module ID's and code
 Command `view storage/0x00000000000000000000000000000042/modules/M.mv`:
 module 42.M {
 

--- a/language/tools/move-cli/tests/testsuite/republish_cyclic_transitive/args.exp
+++ b/language/tools/move-cli/tests/testsuite/republish_cyclic_transitive/args.exp
@@ -1,10 +1,11 @@
 Command `publish src1 -v`:
 Compiling Move modules...
 Found and compiled 4 modules
-Publishing a new module 00000000000000000000000000000042::A
-Publishing a new module 00000000000000000000000000000042::B
-Publishing a new module 00000000000000000000000000000042::C
-Publishing a new module 00000000000000000000000000000042::D
+Publishing a new module 00000000000000000000000000000042::A (wrote 93 bytes)
+Publishing a new module 00000000000000000000000000000042::B (wrote 93 bytes)
+Publishing a new module 00000000000000000000000000000042::C (wrote 93 bytes)
+Publishing a new module 00000000000000000000000000000042::D (wrote 80 bytes)
+Wrote 359 bytes of module ID's and code
 Command `publish src2 -v`:
 Compiling Move modules...
 Found and compiled 1 modules


### PR DESCRIPTION
This PR prints the # of bytes in the StructTag + the # of bytes in the resource blob for each element of a WriteSet. This makes it easier to eyeball changes to space consumption and get ballpark numbers to questions like "how big is a WriteSet in an average tx?"

I also added a few new txes to the diem_smoke test that show the WriteSet size of a typical P2P tx between VASP child accounts.