### PR TITLE
[consensus] Add reputation window proposals/vote metrics

### DIFF
--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -80,6 +80,24 @@ pub static VOTE_NIL_COUNT: Lazy<IntCounter> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Committed proposals from this validator when using LeaderReputation as the ProposerElection
+pub static COMMITTED_PROPOSALS_IN_WINDOW: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "diem_committed_proposals_in_window",
+        "Total number of this validator's committed proposals in the current reputation window"
+    )
+    .unwrap()
+});
+
+/// Committed votes from this validator when using LeaderReputation as the ProposerElection
+pub static COMMITTED_VOTES_IN_WINDOW: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "diem_committed_votes_in_window",
+        "Total number of this validator's committed votes in the current reputation window"
+    )
+    .unwrap()
+});
+
 //////////////////////
 // RoundState COUNTERS
 //////////////////////

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -171,6 +171,7 @@ impl EpochManager {
             ConsensusProposerType::LeaderReputation(heuristic_config) => {
                 let backend = Box::new(DiemDBBackend::new(proposers.len(), self.storage.diem_db()));
                 let heuristic = Box::new(ActiveInactiveHeuristic::new(
+                    self.author,
                     heuristic_config.active_weights,
                     heuristic_config.inactive_weights,
                 ));

--- a/consensus/src/liveness/leader_reputation_test.rs
+++ b/consensus/src/liveness/leader_reputation_test.rs
@@ -50,7 +50,7 @@ fn test_simple_heuristic() {
         proposers.push(signer.author());
         signers.push(signer);
     }
-    let heuristic = ActiveInactiveHeuristic::new(active_weight, inactive_weight);
+    let heuristic = ActiveInactiveHeuristic::new(proposers[0], active_weight, inactive_weight);
     // 1. Window size not enough
     let weights = heuristic.get_weights(&proposers, &[]);
     assert_eq!(weights.len(), proposers.len());
@@ -94,7 +94,11 @@ fn test_api() {
     let leader_reputation = LeaderReputation::new(
         proposers.clone(),
         Box::new(MockHistory::new(1, history)),
-        Box::new(ActiveInactiveHeuristic::new(active_weight, inactive_weight)),
+        Box::new(ActiveInactiveHeuristic::new(
+            proposers[0],
+            active_weight,
+            inactive_weight,
+        )),
     );
     let round = 42u64;
     // first metadata is ignored because of window size 1


### PR DESCRIPTION
Each validator will track its own proposals/votes in the current sliding window of LeaderReputation.  This will allow us to understand why a particular validator is or is not participating in leader election when using LeaderReputation.

## Motivation

https://github.com/diem/diem/issues/7628

## Test Plan

Existing unittests
