### PR TITLE
[move-prover][diem-framework] Support the `emits` verification with opaque functions

### DIFF
--- a/language/diem-framework/modules/DiemConfig.move
+++ b/language/diem-framework/modules/DiemConfig.move
@@ -170,6 +170,7 @@ module DiemConfig {
         include ReconfigureAbortsIf;
         modifies global<DiemConfig<Config>>(CoreAddresses::DIEM_ROOT_ADDRESS());
         include SetEnsures<Config>;
+        include ReconfigureEmits;
     }
 
     /// Private function to temporarily halt reconfiguration.

--- a/language/diem-framework/modules/doc/DiemAccount.md
+++ b/language/diem-framework/modules/doc/DiemAccount.md
@@ -1066,7 +1066,7 @@ Record a payment of <code>to_deposit</code> from <code>payer</code> to <code>pay
     == <b>old</b>(<b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payee).withdraw_capability);
 <b>ensures</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payee).authentication_key
     == <b>old</b>(<b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payee).authentication_key);
-<a name="0x1_DiemAccount_amount$85"></a>
+<a name="0x1_DiemAccount_amount$84"></a>
 <b>let</b> amount = to_deposit.value;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_DepositAbortsIf">DepositAbortsIf</a>&lt;Token&gt;{amount: amount};
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_DepositOverflowAbortsIf">DepositOverflowAbortsIf</a>&lt;Token&gt;{amount: amount};
@@ -1320,6 +1320,12 @@ The balance of designated dealer increases by <code>amount</code>.
 <b>include</b> <a href="Diem.md#0x1_Diem_CancelBurnWithCapEmits">Diem::CancelBurnWithCapEmits</a>&lt;Token&gt;;
 <b>include</b> <a href="Diem.md#0x1_Diem_CancelBurnWithCapEnsures">Diem::CancelBurnWithCapEnsures</a>&lt;Token&gt;;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_DepositEnsures">DepositEnsures</a>&lt;Token&gt;{payee: preburn_address};
+<b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_DepositEmits">DepositEmits</a>&lt;Token&gt;{
+    payer: preburn_address,
+    payee: preburn_address,
+    amount: amount,
+    metadata: x""
+};
 </code></pre>
 
 
@@ -1516,7 +1522,7 @@ Withdraw <code>amount</code> <code><a href="Diem.md#0x1_Diem">Diem</a>&lt;Token&
 
 
 
-<a name="0x1_DiemAccount_payer$86"></a>
+<a name="0x1_DiemAccount_payer$85"></a>
 
 
 <pre><code><b>let</b> payer = cap.account_address;
@@ -1644,9 +1650,9 @@ resource under <code>dd</code>.
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_DiemAccount_dd_addr$87"></a>
+<a name="0x1_DiemAccount_dd_addr$86"></a>
 <b>let</b> dd_addr = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(dd);
-<a name="0x1_DiemAccount_payer$88"></a>
+<a name="0x1_DiemAccount_payer$87"></a>
 <b>let</b> payer = cap.account_address;
 <b>modifies</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payer);
 <b>ensures</b> <b>exists</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payer);
@@ -1766,7 +1772,7 @@ Return a unique capability granting permission to withdraw from the sender's acc
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_DiemAccount_sender_addr$89"></a>
+<a name="0x1_DiemAccount_sender_addr$88"></a>
 <b>let</b> sender_addr = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
 <b>modifies</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(sender_addr);
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ExtractWithdrawCapAbortsIf">ExtractWithdrawCapAbortsIf</a>{sender_addr};
@@ -1834,7 +1840,7 @@ Return the withdraw capability to the account it originally came from
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_DiemAccount_cap_addr$90"></a>
+<a name="0x1_DiemAccount_cap_addr$89"></a>
 <b>let</b> cap_addr = cap.account_address;
 <b>modifies</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(cap_addr);
 <b>aborts_if</b> !<a href="DiemAccount.md#0x1_DiemAccount_exists_at">exists_at</a>(cap_addr) <b>with</b> <a href="Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
@@ -1893,7 +1899,7 @@ attestation protocol
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_DiemAccount_payer$91"></a>
+<a name="0x1_DiemAccount_payer$90"></a>
 <b>let</b> payer = cap.account_address;
 <b>modifies</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payer);
 <b>modifies</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payee);
@@ -2264,7 +2270,7 @@ then add for both token types.
 
 
 
-<a name="0x1_DiemAccount_new_account_addr$92"></a>
+<a name="0x1_DiemAccount_new_account_addr$91"></a>
 
 
 <pre><code><b>let</b> new_account_addr = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(new_account);
@@ -2396,7 +2402,7 @@ Creating an account at address 0x0 will abort as it is a reserved address for th
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_DiemAccount_new_account_addr$93"></a>
+<a name="0x1_DiemAccount_new_account_addr$92"></a>
 <b>let</b> new_account_addr = <a href="Signer.md#0x1_Signer_address_of">Signer::address_of</a>(new_account);
 <b>modifies</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(new_account_addr);
 <b>modifies</b> <b>global</b>&lt;<a href="AccountFreezing.md#0x1_AccountFreezing_FreezingBit">AccountFreezing::FreezingBit</a>&gt;(new_account_addr);
@@ -2406,12 +2412,12 @@ Creating an account at address 0x0 will abort as it is a reserved address for th
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_MakeAccountAbortsIf">MakeAccountAbortsIf</a>{addr: new_account_addr};
 <b>ensures</b> <a href="DiemAccount.md#0x1_DiemAccount_exists_at">exists_at</a>(new_account_addr);
 <b>ensures</b> <a href="AccountFreezing.md#0x1_AccountFreezing_spec_account_is_not_frozen">AccountFreezing::spec_account_is_not_frozen</a>(new_account_addr);
-<a name="0x1_DiemAccount_account_ops_cap$94"></a>
+<a name="0x1_DiemAccount_account_ops_cap$93"></a>
 <b>let</b> account_ops_cap = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_AccountOperationsCapability">AccountOperationsCapability</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>());
 <b>ensures</b> account_ops_cap == update_field(<b>old</b>(account_ops_cap), creation_events, account_ops_cap.creation_events);
 <b>ensures</b> <a href="DiemAccount.md#0x1_DiemAccount_spec_holds_own_key_rotation_cap">spec_holds_own_key_rotation_cap</a>(new_account_addr);
 <b>ensures</b> <a href="DiemAccount.md#0x1_DiemAccount_spec_holds_own_withdraw_cap">spec_holds_own_withdraw_cap</a>(new_account_addr);
-<b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_MakeAccountEmits">MakeAccountEmits</a>;
+<b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_MakeAccountEmits">MakeAccountEmits</a>{new_account_address: <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(new_account)};
 </code></pre>
 
 
@@ -2440,15 +2446,13 @@ Creating an account at address 0x0 will abort as it is a reserved address for th
 
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_MakeAccountEmits">MakeAccountEmits</a> {
-    new_account: signer;
-    <a name="0x1_DiemAccount_new_account_addr$71"></a>
-    <b>let</b> new_account_addr = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(new_account);
-    <a name="0x1_DiemAccount_handle$72"></a>
+    new_account_address: address;
+    <a name="0x1_DiemAccount_handle$71"></a>
     <b>let</b> handle = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_AccountOperationsCapability">AccountOperationsCapability</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>()).creation_events;
-    <a name="0x1_DiemAccount_msg$73"></a>
+    <a name="0x1_DiemAccount_msg$72"></a>
     <b>let</b> msg = <a href="DiemAccount.md#0x1_DiemAccount_CreateAccountEvent">CreateAccountEvent</a> {
-        created: new_account_addr,
-        role_id: <a href="Roles.md#0x1_Roles_spec_get_role_id">Roles::spec_get_role_id</a>(new_account_addr)
+        created: new_account_address,
+        role_id: <a href="Roles.md#0x1_Roles_spec_get_role_id">Roles::spec_get_role_id</a>(new_account_address)
     };
     emits msg <b>to</b> handle;
 }
@@ -2601,6 +2605,7 @@ AccountOperationsCapability, WriteSetManager, and finally makes the account.
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateDiemRootAccountModifies">CreateDiemRootAccountModifies</a>;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateDiemRootAccountAbortsIf">CreateDiemRootAccountAbortsIf</a>;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateDiemRootAccountEnsures">CreateDiemRootAccountEnsures</a>;
+<b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_MakeAccountEmits">MakeAccountEmits</a>{new_account_address: <a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>()};
 </code></pre>
 
 
@@ -2609,7 +2614,7 @@ AccountOperationsCapability, WriteSetManager, and finally makes the account.
 <a name="0x1_DiemAccount_CreateDiemRootAccountModifies"></a>
 
 
-<a name="0x1_DiemAccount_dr_addr$74"></a>
+<a name="0x1_DiemAccount_dr_addr$73"></a>
 
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateDiemRootAccountModifies">CreateDiemRootAccountModifies</a> {
@@ -2651,7 +2656,7 @@ AccountOperationsCapability, WriteSetManager, and finally makes the account.
 <a name="0x1_DiemAccount_CreateDiemRootAccountEnsures"></a>
 
 
-<a name="0x1_DiemAccount_dr_addr$75"></a>
+<a name="0x1_DiemAccount_dr_addr$74"></a>
 
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateDiemRootAccountEnsures">CreateDiemRootAccountEnsures</a> {
@@ -2715,16 +2720,17 @@ event handle generator, then makes the account.
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_DiemAccount_tc_addr$95"></a>
+<a name="0x1_DiemAccount_tc_addr$94"></a>
 <b>let</b> tc_addr = <a href="CoreAddresses.md#0x1_CoreAddresses_TREASURY_COMPLIANCE_ADDRESS">CoreAddresses::TREASURY_COMPLIANCE_ADDRESS</a>();
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateTreasuryComplianceAccountModifies">CreateTreasuryComplianceAccountModifies</a>;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateTreasuryComplianceAccountAbortsIf">CreateTreasuryComplianceAccountAbortsIf</a>;
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotDiemRoot">Roles::AbortsIfNotDiemRoot</a>{account: dr_account};
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_MakeAccountAbortsIf">MakeAccountAbortsIf</a>{addr: <a href="CoreAddresses.md#0x1_CoreAddresses_TREASURY_COMPLIANCE_ADDRESS">CoreAddresses::TREASURY_COMPLIANCE_ADDRESS</a>()};
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateTreasuryComplianceAccountEnsures">CreateTreasuryComplianceAccountEnsures</a>;
-<a name="0x1_DiemAccount_account_ops_cap$96"></a>
+<a name="0x1_DiemAccount_account_ops_cap$95"></a>
 <b>let</b> account_ops_cap = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_AccountOperationsCapability">AccountOperationsCapability</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>());
 <b>ensures</b> account_ops_cap == update_field(<b>old</b>(account_ops_cap), creation_events, account_ops_cap.creation_events);
+<b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_MakeAccountEmits">MakeAccountEmits</a>{new_account_address: <a href="CoreAddresses.md#0x1_CoreAddresses_TREASURY_COMPLIANCE_ADDRESS">CoreAddresses::TREASURY_COMPLIANCE_ADDRESS</a>()};
 </code></pre>
 
 
@@ -2733,7 +2739,7 @@ event handle generator, then makes the account.
 <a name="0x1_DiemAccount_CreateTreasuryComplianceAccountModifies"></a>
 
 
-<a name="0x1_DiemAccount_tc_addr$76"></a>
+<a name="0x1_DiemAccount_tc_addr$75"></a>
 
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateTreasuryComplianceAccountModifies">CreateTreasuryComplianceAccountModifies</a> {
@@ -2769,7 +2775,7 @@ event handle generator, then makes the account.
 <a name="0x1_DiemAccount_CreateTreasuryComplianceAccountEnsures"></a>
 
 
-<a name="0x1_DiemAccount_tc_addr$77"></a>
+<a name="0x1_DiemAccount_tc_addr$76"></a>
 
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateTreasuryComplianceAccountEnsures">CreateTreasuryComplianceAccountEnsures</a> {
@@ -2833,6 +2839,7 @@ Creates Preburn resource under account 'new_account_address'
 
 <pre><code><b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateDesignatedDealerAbortsIf">CreateDesignatedDealerAbortsIf</a>&lt;CoinType&gt;;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateDesignatedDealerEnsures">CreateDesignatedDealerEnsures</a>&lt;CoinType&gt;;
+<b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_MakeAccountEmits">MakeAccountEmits</a>;
 </code></pre>
 
 
@@ -2922,6 +2929,7 @@ all available currencies in the system will also be added.
 
 <pre><code><b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateParentVASPAccountAbortsIf">CreateParentVASPAccountAbortsIf</a>&lt;Token&gt;;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateParentVASPAccountEnsures">CreateParentVASPAccountEnsures</a>&lt;Token&gt;;
+<b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_MakeAccountEmits">MakeAccountEmits</a>;
 </code></pre>
 
 
@@ -3015,6 +3023,7 @@ also be added. This account will be a child of <code>creator</code>, which must 
     child_addr: new_account_address,
 };
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_AddCurrencyForAccountEnsures">AddCurrencyForAccountEnsures</a>&lt;Token&gt;{addr: new_account_address};
+<b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_MakeAccountEmits">MakeAccountEmits</a>;
 </code></pre>
 
 
@@ -3580,11 +3589,11 @@ The prologue for module transaction
 
 
 
-<a name="0x1_DiemAccount_transaction_sender$97"></a>
+<a name="0x1_DiemAccount_transaction_sender$96"></a>
 
 
 <pre><code><b>let</b> transaction_sender = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
-<a name="0x1_DiemAccount_max_transaction_fee$98"></a>
+<a name="0x1_DiemAccount_max_transaction_fee$97"></a>
 <b>let</b> max_transaction_fee = txn_gas_price * txn_max_gas_units;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ModulePrologueAbortsIf">ModulePrologueAbortsIf</a>&lt;Token&gt; {
     max_transaction_fee,
@@ -3606,7 +3615,7 @@ The prologue for module transaction
     chain_id: u8;
     max_transaction_fee: u128;
     txn_expiration_time_seconds: u64;
-    <a name="0x1_DiemAccount_transaction_sender$78"></a>
+    <a name="0x1_DiemAccount_transaction_sender$77"></a>
     <b>let</b> transaction_sender = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
     <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_PrologueCommonAbortsIf">PrologueCommonAbortsIf</a>&lt;Token&gt; {
         transaction_sender,
@@ -3693,11 +3702,11 @@ The prologue for script transaction
 
 
 
-<a name="0x1_DiemAccount_transaction_sender$99"></a>
+<a name="0x1_DiemAccount_transaction_sender$98"></a>
 
 
 <pre><code><b>let</b> transaction_sender = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
-<a name="0x1_DiemAccount_max_transaction_fee$100"></a>
+<a name="0x1_DiemAccount_max_transaction_fee$99"></a>
 <b>let</b> max_transaction_fee = txn_gas_price * txn_max_gas_units;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ScriptPrologueAbortsIf">ScriptPrologueAbortsIf</a>&lt;Token&gt;{
     max_transaction_fee,
@@ -3720,7 +3729,7 @@ The prologue for script transaction
     max_transaction_fee: u128;
     txn_expiration_time_seconds: u64;
     script_hash: vector&lt;u8&gt;;
-    <a name="0x1_DiemAccount_transaction_sender$79"></a>
+    <a name="0x1_DiemAccount_transaction_sender$78"></a>
     <b>let</b> transaction_sender = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
     <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_PrologueCommonAbortsIf">PrologueCommonAbortsIf</a>&lt;Token&gt; {transaction_sender};
 }
@@ -3816,7 +3825,7 @@ The prologue for WriteSet transaction
     txn_public_key: vector&lt;u8&gt;;
     txn_expiration_time_seconds: u64;
     chain_id: u8;
-    <a name="0x1_DiemAccount_transaction_sender$80"></a>
+    <a name="0x1_DiemAccount_transaction_sender$79"></a>
     <b>let</b> transaction_sender = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
 }
 </code></pre>
@@ -3966,11 +3975,11 @@ The main properties that it verifies:
 
 
 
-<a name="0x1_DiemAccount_transaction_sender$101"></a>
+<a name="0x1_DiemAccount_transaction_sender$100"></a>
 
 
 <pre><code><b>let</b> transaction_sender = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
-<a name="0x1_DiemAccount_max_transaction_fee$102"></a>
+<a name="0x1_DiemAccount_max_transaction_fee$101"></a>
 <b>let</b> max_transaction_fee = txn_gas_price * txn_max_gas_units;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_PrologueCommonAbortsIf">PrologueCommonAbortsIf</a>&lt;Token&gt; {
     transaction_sender,
@@ -4259,12 +4268,12 @@ Epilogue for WriteSet trasnaction
 <a name="0x1_DiemAccount_WritesetEpiloguEmits"></a>
 
 
-<a name="0x1_DiemAccount_handle$81"></a>
+<a name="0x1_DiemAccount_handle$80"></a>
 
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_WritesetEpiloguEmits">WritesetEpiloguEmits</a> {
     <b>let</b> handle = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_DiemWriteSetManager">DiemWriteSetManager</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>()).upgrade_events;
-    <a name="0x1_DiemAccount_msg$82"></a>
+    <a name="0x1_DiemAccount_msg$81"></a>
     <b>let</b> msg = <a href="DiemAccount.md#0x1_DiemAccount_AdminTransactionEvent">AdminTransactionEvent</a> {
         committed_timestamp_secs: <a href="DiemTimestamp.md#0x1_DiemTimestamp_spec_now_seconds">DiemTimestamp::spec_now_seconds</a>()
     };
@@ -4494,7 +4503,7 @@ or the key rotation capability for addr itself [[H17]][PERMISSION].
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_EnsuresHasKeyRotationCap">EnsuresHasKeyRotationCap</a> {
     account: signer;
-    <a name="0x1_DiemAccount_addr$83"></a>
+    <a name="0x1_DiemAccount_addr$82"></a>
     <b>let</b> addr = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>ensures</b> <a href="DiemAccount.md#0x1_DiemAccount_spec_holds_own_key_rotation_cap">spec_holds_own_key_rotation_cap</a>(addr);
 }
@@ -4556,7 +4565,7 @@ or the withdraw capability for addr itself [[H18]][PERMISSION].
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_EnsuresWithdrawCap">EnsuresWithdrawCap</a> {
     account: signer;
-    <a name="0x1_DiemAccount_addr$84"></a>
+    <a name="0x1_DiemAccount_addr$83"></a>
     <b>let</b> addr = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>ensures</b> <a href="DiemAccount.md#0x1_DiemAccount_spec_holds_own_withdraw_cap">spec_holds_own_withdraw_cap</a>(addr);
 }

--- a/language/diem-framework/modules/doc/DiemConfig.md
+++ b/language/diem-framework/modules/doc/DiemConfig.md
@@ -531,6 +531,7 @@ generic type/specific invariant issue
 <b>include</b> <a href="DiemConfig.md#0x1_DiemConfig_ReconfigureAbortsIf">ReconfigureAbortsIf</a>;
 <b>modifies</b> <b>global</b>&lt;<a href="DiemConfig.md#0x1_DiemConfig">DiemConfig</a>&lt;Config&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>());
 <b>include</b> <a href="DiemConfig.md#0x1_DiemConfig_SetEnsures">SetEnsures</a>&lt;Config&gt;;
+<b>include</b> <a href="DiemConfig.md#0x1_DiemConfig_ReconfigureEmits">ReconfigureEmits</a>;
 </code></pre>
 
 

--- a/language/diem-framework/modules/doc/DiemSystem.md
+++ b/language/diem-framework/modules/doc/DiemSystem.md
@@ -341,7 +341,7 @@ Must be invoked by the Diem root a single time in Genesis.
 <pre><code><b>modifies</b> <b>global</b>&lt;<a href="DiemConfig.md#0x1_DiemConfig_DiemConfig">DiemConfig::DiemConfig</a>&lt;<a href="DiemSystem.md#0x1_DiemSystem">DiemSystem</a>&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>());
 <b>include</b> <a href="DiemTimestamp.md#0x1_DiemTimestamp_AbortsIfNotGenesis">DiemTimestamp::AbortsIfNotGenesis</a>;
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotDiemRoot">Roles::AbortsIfNotDiemRoot</a>{account: dr_account};
-<a name="0x1_DiemSystem_dr_addr$19"></a>
+<a name="0x1_DiemSystem_dr_addr$20"></a>
 <b>let</b> dr_addr = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(dr_account);
 <b>aborts_if</b> <a href="DiemConfig.md#0x1_DiemConfig_spec_is_published">DiemConfig::spec_is_published</a>&lt;<a href="DiemSystem.md#0x1_DiemSystem">DiemSystem</a>&gt;() <b>with</b> <a href="Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>;
 <b>aborts_if</b> <b>exists</b>&lt;<a href="DiemSystem.md#0x1_DiemSystem_CapabilityHolder">CapabilityHolder</a>&gt;(dr_addr) <b>with</b> <a href="Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>;
@@ -406,6 +406,7 @@ Called by the add, remove, and update functions.
 
 
 <pre><code><b>ensures</b> <b>global</b>&lt;<a href="DiemConfig.md#0x1_DiemConfig_DiemConfig">DiemConfig::DiemConfig</a>&lt;<a href="DiemSystem.md#0x1_DiemSystem">DiemSystem</a>&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>()).payload == value;
+<b>include</b> <a href="DiemConfig.md#0x1_DiemConfig_ReconfigureEmits">DiemConfig::ReconfigureEmits</a>;
 </code></pre>
 
 
@@ -477,6 +478,7 @@ Adds a new validator to the validator set.
 <pre><code><b>modifies</b> <b>global</b>&lt;<a href="DiemConfig.md#0x1_DiemConfig_DiemConfig">DiemConfig::DiemConfig</a>&lt;<a href="DiemSystem.md#0x1_DiemSystem">DiemSystem</a>&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>());
 <b>include</b> <a href="DiemSystem.md#0x1_DiemSystem_AddValidatorAbortsIf">AddValidatorAbortsIf</a>;
 <b>include</b> <a href="DiemSystem.md#0x1_DiemSystem_AddValidatorEnsures">AddValidatorEnsures</a>;
+<b>include</b> <a href="DiemConfig.md#0x1_DiemConfig_ReconfigureEmits">DiemConfig::ReconfigureEmits</a>;
 </code></pre>
 
 
@@ -583,6 +585,7 @@ Removes a validator, aborts unless called by diem root account
 <pre><code><b>modifies</b> <b>global</b>&lt;<a href="DiemConfig.md#0x1_DiemConfig_DiemConfig">DiemConfig::DiemConfig</a>&lt;<a href="DiemSystem.md#0x1_DiemSystem">DiemSystem</a>&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>());
 <b>include</b> <a href="DiemSystem.md#0x1_DiemSystem_RemoveValidatorAbortsIf">RemoveValidatorAbortsIf</a>;
 <b>include</b> <a href="DiemSystem.md#0x1_DiemSystem_RemoveValidatorEnsures">RemoveValidatorEnsures</a>;
+<b>include</b> <a href="DiemConfig.md#0x1_DiemConfig_ReconfigureEmits">DiemConfig::ReconfigureEmits</a>;
 </code></pre>
 
 
@@ -689,7 +692,7 @@ and emits a reconfigurationevent.
 <b>include</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_AbortsIfGetOperator">ValidatorConfig::AbortsIfGetOperator</a>{addr: validator_addr};
 <b>include</b> <a href="DiemSystem.md#0x1_DiemSystem_UpdateConfigAndReconfigureAbortsIf">UpdateConfigAndReconfigureAbortsIf</a>;
 <b>include</b> <a href="DiemSystem.md#0x1_DiemSystem_UpdateConfigAndReconfigureEnsures">UpdateConfigAndReconfigureEnsures</a>;
-<a name="0x1_DiemSystem_is_validator_info_updated$20"></a>
+<a name="0x1_DiemSystem_is_validator_info_updated$21"></a>
 <b>let</b> is_validator_info_updated =
     <a href="ValidatorConfig.md#0x1_ValidatorConfig_is_valid">ValidatorConfig::is_valid</a>(validator_addr) &&
     (<b>exists</b> v_info in <a href="DiemSystem.md#0x1_DiemSystem_spec_get_validators">spec_get_validators</a>():
@@ -778,6 +781,24 @@ DIP-6 property
 
 <pre><code><b>schema</b> <a href="DiemSystem.md#0x1_DiemSystem_UpdateConfigAndReconfigureEnsures">UpdateConfigAndReconfigureEnsures</a> {
     <b>ensures</b> <a href="Roles.md#0x1_Roles_spec_has_validator_role_addr">Roles::spec_has_validator_role_addr</a>(validator_addr);
+}
+</code></pre>
+
+
+
+
+<a name="0x1_DiemSystem_UpdateConfigAndReconfigureEmits"></a>
+
+
+<pre><code><b>schema</b> <a href="DiemSystem.md#0x1_DiemSystem_UpdateConfigAndReconfigureEmits">UpdateConfigAndReconfigureEmits</a> {
+    validator_addr: address;
+    <a name="0x1_DiemSystem_is_validator_info_updated$19"></a>
+    <b>let</b> is_validator_info_updated =
+        <a href="ValidatorConfig.md#0x1_ValidatorConfig_is_valid">ValidatorConfig::is_valid</a>(validator_addr) &&
+        (<b>exists</b> v_info in <a href="DiemSystem.md#0x1_DiemSystem_spec_get_validators">spec_get_validators</a>():
+            v_info.addr == validator_addr
+            && v_info.config != <a href="ValidatorConfig.md#0x1_ValidatorConfig_spec_get_config">ValidatorConfig::spec_get_config</a>(validator_addr));
+    <b>include</b> is_validator_info_updated ==&gt; <a href="DiemConfig.md#0x1_DiemConfig_ReconfigureEmits">DiemConfig::ReconfigureEmits</a>;
 }
 </code></pre>
 
@@ -1055,7 +1076,7 @@ It has a loop, so there are spec blocks in the code to assert loop invariants.
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
-<a name="0x1_DiemSystem_size$21"></a>
+<a name="0x1_DiemSystem_size$22"></a>
 <b>let</b> size = len(validators);
 </code></pre>
 
@@ -1137,7 +1158,7 @@ This function never aborts.
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
-<a name="0x1_DiemSystem_new_validator_config$22"></a>
+<a name="0x1_DiemSystem_new_validator_config$23"></a>
 <b>let</b> new_validator_config = <a href="ValidatorConfig.md#0x1_ValidatorConfig_spec_get_config">ValidatorConfig::spec_get_config</a>(validators[i].addr);
 </code></pre>
 

--- a/language/diem-framework/transaction_scripts/add_validator_and_reconfigure.move
+++ b/language/diem-framework/transaction_scripts/add_validator_and_reconfigure.move
@@ -66,6 +66,7 @@ spec fun add_validator_and_reconfigure {
     use 0x1::DiemAccount;
     use 0x1::Errors;
     use 0x1::Roles;
+    use 0x1::DiemConfig;
 
     include DiemAccount::TransactionChecks{sender: dr_account}; // properties checked by the prologue.
     include SlidingNonce::RecordNonceAbortsIf{seq_nonce: sliding_nonce, account: dr_account};
@@ -89,6 +90,8 @@ spec fun add_validator_and_reconfigure {
         Errors::INVALID_STATE,
         Errors::LIMIT_EXCEEDED,
         Errors::REQUIRES_ROLE;
+
+    include DiemConfig::ReconfigureEmits;
 
     /// **Access Control:**
     /// Only the Diem Root account can add Validators [[H13]][PERMISSION].

--- a/language/diem-framework/transaction_scripts/cancel_burn_with_amount.move
+++ b/language/diem-framework/transaction_scripts/cancel_burn_with_amount.move
@@ -76,6 +76,12 @@ spec fun cancel_burn_with_amount {
     ensures balance_at_addr == old(balance_at_addr) + amount;
 
     include Diem::CancelBurnWithCapEmits<Token>;
+    include DiemAccount::DepositEmits<Token>{
+        payer: preburn_address,
+        payee: preburn_address,
+        amount: amount,
+        metadata: x""
+    };
 
     aborts_with [check]
         Errors::REQUIRES_CAPABILITY,

--- a/language/diem-framework/transaction_scripts/create_parent_vasp_account.move
+++ b/language/diem-framework/transaction_scripts/create_parent_vasp_account.move
@@ -77,6 +77,8 @@ spec fun create_parent_vasp_account {
         Errors::ALREADY_PUBLISHED,
         Errors::REQUIRES_ROLE;
 
+    include DiemAccount::MakeAccountEmits;
+
     /// **Access Control:**
     /// Only the Treasury Compliance account can create Parent VASP accounts [[A6]][ROLE].
     include Roles::AbortsIfNotTreasuryCompliance{account: tc_account};

--- a/language/diem-framework/transaction_scripts/create_validator_account.move
+++ b/language/diem-framework/transaction_scripts/create_validator_account.move
@@ -85,6 +85,8 @@ spec fun create_validator_account {
         Errors::ALREADY_PUBLISHED,
         Errors::REQUIRES_ROLE;
 
+    include DiemAccount::MakeAccountEmits;
+
     /// **Access Control:**
     /// Only the Diem Root account can create Validator accounts [[A3]][ROLE].
     include Roles::AbortsIfNotDiemRoot{account: dr_account};

--- a/language/diem-framework/transaction_scripts/create_validator_operator_account.move
+++ b/language/diem-framework/transaction_scripts/create_validator_operator_account.move
@@ -80,6 +80,8 @@ spec fun create_validator_operator_account {
         Errors::ALREADY_PUBLISHED,
         Errors::REQUIRES_ROLE;
 
+    include DiemAccount::MakeAccountEmits;
+
     /// **Access Control:**
     /// Only the Diem Root account can create Validator Operator accounts [[A4]][ROLE].
     include Roles::AbortsIfNotDiemRoot{account: dr_account};

--- a/language/diem-framework/transaction_scripts/doc/cancel_burn_with_amount.md
+++ b/language/diem-framework/transaction_scripts/doc/cancel_burn_with_amount.md
@@ -139,6 +139,12 @@ The balance of <code>Token</code> at <code>preburn_address</code> should increas
 
 <pre><code><b>ensures</b> balance_at_addr == <b>old</b>(balance_at_addr) + amount;
 <b>include</b> <a href="../../modules/doc/Diem.md#0x1_Diem_CancelBurnWithCapEmits">Diem::CancelBurnWithCapEmits</a>&lt;Token&gt;;
+<b>include</b> <a href="../../modules/doc/DiemAccount.md#0x1_DiemAccount_DepositEmits">DiemAccount::DepositEmits</a>&lt;Token&gt;{
+    payer: preburn_address,
+    payee: preburn_address,
+    amount: amount,
+    metadata: x""
+};
 <b>aborts_with</b> [check]
     <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_CAPABILITY">Errors::REQUIRES_CAPABILITY</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>,

--- a/language/diem-framework/transaction_scripts/doc/transaction_script_documentation.md
+++ b/language/diem-framework/transaction_scripts/doc/transaction_script_documentation.md
@@ -1020,6 +1020,7 @@ only Diem root has the Diem root role.
     <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ADDRESS">Errors::REQUIRES_ADDRESS</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>;
+<b>include</b> <a href="../../modules/doc/DiemAccount.md#0x1_DiemAccount_MakeAccountEmits">DiemAccount::MakeAccountEmits</a>;
 </code></pre>
 
 
@@ -1163,6 +1164,7 @@ only Diem root has the Diem root role.
     <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ADDRESS">Errors::REQUIRES_ADDRESS</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>;
+<b>include</b> <a href="../../modules/doc/DiemAccount.md#0x1_DiemAccount_MakeAccountEmits">DiemAccount::MakeAccountEmits</a>;
 </code></pre>
 
 
@@ -1300,6 +1302,7 @@ also be added. This can only be invoked by an TreasuryCompliance account.
     <a href="../../modules/doc/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>;
+<b>include</b> <a href="../../modules/doc/DiemAccount.md#0x1_DiemAccount_MakeAccountEmits">DiemAccount::MakeAccountEmits</a>;
 </code></pre>
 
 
@@ -2940,6 +2943,7 @@ in practice because it aborts with NOT_PUBLISHED or REQUIRES_ADDRESS, first.
     <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_LIMIT_EXCEEDED">Errors::LIMIT_EXCEEDED</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>;
+<b>include</b> <a href="../../modules/doc/DiemConfig.md#0x1_DiemConfig_ReconfigureEmits">DiemConfig::ReconfigureEmits</a>;
 </code></pre>
 
 
@@ -3219,6 +3223,7 @@ in practice because it aborts with NOT_PUBLISHED or REQUIRES_ADDRESS, first.
     <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ADDRESS">Errors::REQUIRES_ADDRESS</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>;
+<b>include</b> <a href="../../modules/doc/DiemConfig.md#0x1_DiemConfig_ReconfigureEmits">DiemConfig::ReconfigureEmits</a>;
 </code></pre>
 
 

--- a/language/diem-framework/transaction_scripts/remove_validator_and_reconfigure.move
+++ b/language/diem-framework/transaction_scripts/remove_validator_and_reconfigure.move
@@ -62,6 +62,7 @@ spec fun remove_validator_and_reconfigure {
     use 0x1::DiemAccount;
     use 0x1::Errors;
     use 0x1::Roles;
+    use 0x1::DiemConfig;
 
     include DiemAccount::TransactionChecks{sender: dr_account}; // properties checked by the prologue.
     include SlidingNonce::RecordNonceAbortsIf{seq_nonce: sliding_nonce, account: dr_account};
@@ -84,6 +85,8 @@ spec fun remove_validator_and_reconfigure {
         Errors::REQUIRES_ADDRESS,
         Errors::INVALID_STATE,
         Errors::REQUIRES_ROLE;
+
+    include DiemConfig::ReconfigureEmits;
 
     /// **Access Control:**
     /// Only the Diem Root account can remove Validators [[H13]][PERMISSION].

--- a/language/move-prover/bytecode/src/stackless_bytecode.rs
+++ b/language/move-prover/bytecode/src/stackless_bytecode.rs
@@ -151,6 +151,10 @@ pub enum Operation {
     TraceLocal(TempIndex),
     TraceReturn(usize),
     TraceAbort,
+
+    // Event
+    EmitEvent,
+    EventStoreDiverge,
 }
 
 impl Operation {
@@ -204,6 +208,8 @@ impl Operation {
             Operation::TraceLocal(..) => false,
             Operation::TraceAbort => false,
             Operation::TraceReturn(..) => false,
+            Operation::EmitEvent => false,
+            Operation::EventStoreDiverge => false,
         }
     }
 }
@@ -868,6 +874,8 @@ impl<'env> fmt::Display for OperationDisplay<'env> {
             }
             TraceAbort => write!(f, "trace_abort")?,
             TraceReturn(r) => write!(f, "trace_return[{}]", r)?,
+            EmitEvent => write!(f, "emit_event")?,
+            EventStoreDiverge => write!(f, "event_store_diverge")?,
         }
         Ok(())
     }

--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -674,6 +674,10 @@ function {:inline} $EventStore__is_subset(es1: $EventStore, es2: $EventStore): b
     )
 }
 
+procedure {:inline 1} $EventStore__diverge(es: $EventStore) returns (es': $EventStore) {
+    assume $EventStore__is_subset(es, es');
+}
+
 function {:builtin "MapConst"} $ConstEventStoreContent(s: $ValueMultiset): [$Value]$ValueMultiset;
 
 const $EmptyEventStore: $EventStore;

--- a/language/move-prover/tests/sources/functional/emits.exp
+++ b/language/move-prover/tests/sources/functional/emits.exp
@@ -101,24 +101,96 @@ error: function does not emit the expected event
     =     at tests/sources/functional/emits.move:70
     =     at tests/sources/functional/emits.move:71
 
-error: emitted event not covered by any of `emits` clauses
+error: emitted event not covered by any of the `emits` clauses
 
-     ┌── tests/sources/functional/emits.move:218:5 ───
+     ┌── tests/sources/functional/emits.move:296:5 ───
      │
- 218 │ ╭     spec fun partial_incorrect {
- 219 │ │         emits DummyEvent{msg: 0} to handle;
- 220 │ │     }
+ 296 │ ╭     spec fun opaque_completeness_incorrect {
+ 297 │ │         emits DummyEvent{msg: 0} to handle;
+ 298 │ │         emits DummyEvent{msg: 7} to handle;
+ 299 │ │         emits DummyEvent{msg: 1} to handle;
+ 300 │ │     }
      │ ╰─────^
      │
-     =     at tests/sources/functional/emits.move:214: partial_incorrect
+     =     at tests/sources/functional/emits.move:291: opaque_completeness_incorrect
      =         handle = <redacted>
-     =     at tests/sources/functional/emits.move:215: partial_incorrect
-     =     at tests/sources/functional/emits.move:216: partial_incorrect
-     =     at tests/sources/functional/emits.move:216: partial_incorrect
+     =     at tests/sources/functional/emits.move:292: opaque_completeness_incorrect
+     =     at tests/sources/functional/emits.move:293: opaque_completeness_incorrect
+     =     at tests/sources/functional/emits.move:294: opaque_completeness_incorrect
+     =     at tests/sources/functional/emits.move:294: opaque_completeness_incorrect
      =         handle = <redacted>
-     =     at tests/sources/functional/emits.move:217: partial_incorrect
-     =     at tests/sources/functional/emits.move:219
-     =     at tests/sources/functional/emits.move:218
+     =     at tests/sources/functional/emits.move:295: opaque_completeness_incorrect
+     =     at tests/sources/functional/emits.move:297
+     =     at tests/sources/functional/emits.move:298
+     =     at tests/sources/functional/emits.move:299
+     =     at tests/sources/functional/emits.move:296
+
+error: function does not emit the expected event
+
+     ┌── tests/sources/functional/emits.move:288:9 ───
+     │
+ 288 │         emits DummyEvent{msg: 2} to handle;
+     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     │
+     =     at tests/sources/functional/emits.move:278: opaque_incorrect
+     =         handle = <redacted>
+     =     at tests/sources/functional/emits.move:279: opaque_incorrect
+     =     at tests/sources/functional/emits.move:280: opaque_incorrect
+     =     at tests/sources/functional/emits.move:281: opaque_incorrect
+     =     at tests/sources/functional/emits.move:281: opaque_incorrect
+     =         handle = <redacted>
+     =     at tests/sources/functional/emits.move:282: opaque_incorrect
+     =     at tests/sources/functional/emits.move:284
+     =     at tests/sources/functional/emits.move:285
+     =     at tests/sources/functional/emits.move:286
+     =     at tests/sources/functional/emits.move:287
+     =     at tests/sources/functional/emits.move:288
+
+error: emitted event not covered by any of the `emits` clauses
+
+     ┌── tests/sources/functional/emits.move:337:5 ───
+     │
+ 337 │ ╭     spec fun opaque_partial_incorrect {
+ 338 │ │         emits DummyEvent{msg: 0} to handle;
+ 339 │ │         emits DummyEvent{msg: 7} to handle;
+ 340 │ │         emits DummyEvent{msg: 77} to handle;
+ 341 │ │         emits DummyEvent{msg: 1} to handle;
+ 342 │ │         // The completeness check of the `emits` spec of this function should fail.
+ 343 │ │     }
+     │ ╰─────^
+     │
+     =     at tests/sources/functional/emits.move:332: opaque_partial_incorrect
+     =         handle = <redacted>
+     =     at tests/sources/functional/emits.move:333: opaque_partial_incorrect
+     =     at tests/sources/functional/emits.move:334: opaque_partial_incorrect
+     =     at tests/sources/functional/emits.move:335: opaque_partial_incorrect
+     =     at tests/sources/functional/emits.move:335: opaque_partial_incorrect
+     =         handle = <redacted>
+     =     at tests/sources/functional/emits.move:336: opaque_partial_incorrect
+     =     at tests/sources/functional/emits.move:338
+     =     at tests/sources/functional/emits.move:339
+     =     at tests/sources/functional/emits.move:340
+     =     at tests/sources/functional/emits.move:341
+     =     at tests/sources/functional/emits.move:337
+
+error: emitted event not covered by any of the `emits` clauses
+
+     ┌── tests/sources/functional/emits.move:227:5 ───
+     │
+ 227 │ ╭     spec fun partial_incorrect {
+ 228 │ │         emits DummyEvent{msg: 0} to handle;
+ 229 │ │     }
+     │ ╰─────^
+     │
+     =     at tests/sources/functional/emits.move:223: partial_incorrect
+     =         handle = <redacted>
+     =     at tests/sources/functional/emits.move:224: partial_incorrect
+     =     at tests/sources/functional/emits.move:225: partial_incorrect
+     =     at tests/sources/functional/emits.move:225: partial_incorrect
+     =         handle = <redacted>
+     =     at tests/sources/functional/emits.move:226: partial_incorrect
+     =     at tests/sources/functional/emits.move:228
+     =     at tests/sources/functional/emits.move:227
 
 error: function does not emit the expected event
 
@@ -152,20 +224,20 @@ error: function does not emit the expected event
     =     at tests/sources/functional/emits.move:21: simple_wrong_msg_incorrect
     =     at tests/sources/functional/emits.move:23
 
-error: emitted event not covered by any of `emits` clauses
+error: emitted event not covered by any of the `emits` clauses
 
-     ┌── tests/sources/functional/emits.move:238:5 ───
+     ┌── tests/sources/functional/emits.move:247:5 ───
      │
- 238 │ ╭     spec fun strict_incorrect {
- 239 │ │         pragma emits_is_strict;
- 240 │ │     }
+ 247 │ ╭     spec fun strict_incorrect {
+ 248 │ │         pragma emits_is_strict;
+ 249 │ │     }
      │ ╰─────^
      │
-     =     at tests/sources/functional/emits.move:234: strict_incorrect
+     =     at tests/sources/functional/emits.move:243: strict_incorrect
      =         handle = <redacted>
-     =     at tests/sources/functional/emits.move:235: strict_incorrect
-     =     at tests/sources/functional/emits.move:236: strict_incorrect
-     =     at tests/sources/functional/emits.move:236: strict_incorrect
+     =     at tests/sources/functional/emits.move:244: strict_incorrect
+     =     at tests/sources/functional/emits.move:245: strict_incorrect
+     =     at tests/sources/functional/emits.move:245: strict_incorrect
      =         handle = <redacted>
-     =     at tests/sources/functional/emits.move:237: strict_incorrect
-     =     at tests/sources/functional/emits.move:238
+     =     at tests/sources/functional/emits.move:246: strict_incorrect
+     =     at tests/sources/functional/emits.move:247


### PR DESCRIPTION
- When a function calls an opaque function with a emits spec, Prover generate the corresponding `emit_event` bytecode in order to simulate the side effect of the opaque function to the EventStore.

- If the opaque function has a partial emits spec, then Prover generate the bytecode `event_store_diverge` which performs some kind of “havoc” to the EventStore. It makes the EventStore grow in an abitrary way, but never shirnk.

- [NOTE & TODO] If the opaque function has no emits spec, the current implementation automatically treats the absence of the emits spec “strictly” even though the `emits_is_strict`is not on for the opaque function. This tentative remedy may sound suprising, but is convenient. Otherwise, the user needs to add `emits_is_strict` to every opaque function that emits no event. There are many of them in the Diem Framework. This matter needs to be discussed and decided as a group.

- emits specs in the conditional schema inclusion is now correctly supported
  - For example, consider `spec schema EmitsSchema { emits msg to handle if cond };`
  - Then, `include P ==> EmitsSchema;` yields `emits msg to handle if P && cond`

- Added more of the emits specs to the DiemFramework.
  - modules
    - DiemAccount
    - DiemConfig
    - DiemSystem
  - transaction scripts
    - add_validator_and_reconfigure
    - cancel_burn_with_amount
    - create_parent_vasp_account
    - create_validator_account
    - create_validator_operator_account
    - remove_validator_and_reconfigure

## Motivation

To support the `emits` verification with opaque functions

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

yes 

## Test Plan

cargo test
