### PR TITLE
[faucet] Faucet sends CoinTradeMetadata with trade_id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1565,6 +1565,7 @@ dependencies = [
  "generate-key",
  "hex",
  "move-core-types",
+ "rand 0.8.3",
  "reqwest",
  "serde",
  "serde_derive",

--- a/client/faucet/Cargo.toml
+++ b/client/faucet/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.38"
 hex = "0.4.3"
+rand = "0.8.3"
 reqwest = { version = "0.11.1", features = ["blocking"], default-features = false }
 serde = "1.0.123"
 serde_derive = "1.0.117"

--- a/client/faucet/src/mint.rs
+++ b/client/faucet/src/mint.rs
@@ -4,9 +4,13 @@
 use anyhow::Result;
 use diem_client::{Client, MethodRequest};
 use diem_crypto::traits::SigningKey;
-use diem_types::account_config::{
-    testnet_dd_account_address, treasury_compliance_account_address, type_tag_for_currency_code,
-    XUS_NAME,
+use diem_logger::prelude::warn;
+use diem_types::{
+    account_config::{
+        testnet_dd_account_address, treasury_compliance_account_address,
+        type_tag_for_currency_code, XUS_NAME,
+    },
+    transaction::metadata,
 };
 use std::{convert::From, fmt};
 
@@ -34,6 +38,7 @@ pub struct MintParams {
     pub auth_key: diem_types::transaction::authenticator::AuthenticationKey,
     pub return_txns: Option<bool>,
     pub is_designated_dealer: Option<bool>,
+    pub trade_id: Option<String>,
 }
 
 impl MintParams {
@@ -79,10 +84,29 @@ impl MintParams {
                 self.currency_code(),
                 self.receiver(),
                 self.amount,
-                vec![],
+                self.bcs_metadata(),
                 vec![],
             ),
         )
+    }
+
+    fn bcs_metadata(&self) -> Vec<u8> {
+        match self.trade_id.clone() {
+            Some(trade_id) => {
+                let metadata = metadata::Metadata::CoinTradeMetadata(
+                    metadata::CoinTradeMetadata::CoinTradeMetadataV0(
+                        metadata::CoinTradeMetadataV0 {
+                            trade_ids: vec![trade_id],
+                        },
+                    ),
+                );
+                bcs::to_bytes(&metadata).unwrap_or_else(|e| {
+                    warn!("Unable to serialize trade_id: {}", e);
+                    vec![]
+                })
+            }
+            _ => vec![],
+        }
     }
 
     fn receiver(&self) -> diem_types::account_address::AccountAddress {


### PR DESCRIPTION
## Motivation
Have the faucet accept an optional trade_id value that, when it mints/sends currency to accounts in response, it includes in a `CoinTradeMetadata(trade_ids[$trade_id])`.
If none is sent, faucet doesn't send any metadata (current behaviour)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?
yes



## Test Plan
run new unit tests