### PR TITLE
add jellyfish paper in papers page and adjust links

### DIFF
--- a/developers.diem.com/src/pages/papers.js
+++ b/developers.diem.com/src/pages/papers.js
@@ -12,21 +12,21 @@ const papersLocation = '/papers';
 // TODO (joshua): Automate the list of papers by looking at the directories.
 const paperMeta = {
   'The Diem Blockchain': {
-    abstractUrl: '/docs/core/the-diem-blockchain-paper/',
+    abstractUrl: '/docs/technical-papers/the-diem-blockchain-paper/',
     paperBase: `${papersLocation}/the-diem-blockchain`,
     dates: ['2020-05-26', '2020-04-09', '2019-09-26', '2019-09-18', '2019-06-25'],
     imgLoc: '/papers/illustrations/diem-blockchain-pdf.png',
     imgAlt: 'The Diem Blockchain PDF Download',
   },
   'Move Programming Language': {
-    abstractUrl: '/docs/move/move-paper/',
+    abstractUrl: '/docs/technical-papers/move-paper/',
     paperBase: `${papersLocation}/diem-move-a-language-with-programmable-resources`,
     dates: ['2020-05-26', '2020-04-09', '2019-09-26', '2019-06-18'],
     imgLoc: '/papers/illustrations/move-language-pdf.png',
     imgAlt: 'Move: A Language With Programmable Resources PDF Download',
   },
   'State Machine Replication': {
-    abstractUrl: '/docs/core/state-machine-replication-paper/',
+    abstractUrl: '/docs/technical-papers/state-machine-replication-paper/',
     paperBase: `${papersLocation}/diem-consensus-state-machine-replication-in-the-diem-blockchain`,
     dates: [
       '2020-05-26',
@@ -39,6 +39,15 @@ const paperMeta = {
     ],
     imgLoc: '/papers/illustrations/state-machine-pdf.png',
     imgAlt: 'State Machine Replication in the Diem Blockchain PDF Download',
+  },
+  'Jellyfish Merkle Tree': {
+    abstractUrl: '/docs/technical-papers/jellyfish-merkle-tree-paper',
+    paperBase: `${papersLocation}/jellyfish-merkle-tree`,
+    dates: [
+      '2021-01-14',
+    ],
+    imgLoc: '/img/docs/jellyfish-merkle-tree-pdf.png',
+    imgAlt: 'Jellyfish Merkle Tree Paper',
   },
 };
 


### PR DESCRIPTION
adds the jellyfish merkle tree paper section in the /papers page and adjusts the first link in each section