### PR TITLE
[move-lang] add support for friend visibility (parser to typing)

### DIFF
--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -46,6 +46,7 @@ pub struct Script {
 pub struct ModuleDefinition {
     pub loc: Loc,
     pub is_source_module: bool,
+    pub friends: UniqueMap<ModuleIdent, Loc>,
     pub structs: UniqueMap<StructName, StructDefinition>,
     pub functions: UniqueMap<FunctionName, Function>,
     pub constants: UniqueMap<ConstantName, Constant>,
@@ -84,7 +85,6 @@ pub struct FunctionSignature {
 }
 
 #[derive(PartialEq, Clone, Debug)]
-
 pub enum FunctionBody_ {
     Defined(Sequence),
     Native,
@@ -417,6 +417,7 @@ impl AstDebug for ModuleDefinition {
         let ModuleDefinition {
             loc: _loc,
             is_source_module,
+            friends,
             structs,
             functions,
             constants,
@@ -427,6 +428,10 @@ impl AstDebug for ModuleDefinition {
         } else {
             "library module"
         });
+        for (mident, _loc) in friends.key_cloned_iter() {
+            w.write(&format!("friend {};", mident));
+            w.new_line();
+        }
         for sdef in structs.key_cloned_iter() {
             sdef.ast_debug(w);
             w.new_line();

--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -305,7 +305,9 @@ fn script_(context: &mut Context, pscript: P::Script) -> E::Script {
 
     let (function_name, function) = function_(context, pfunction);
     match &function.visibility {
-        FunctionVisibility::Public(loc) | FunctionVisibility::Script(loc) => {
+        FunctionVisibility::Public(loc)
+        | FunctionVisibility::Script(loc)
+        | FunctionVisibility::Friend(loc) => {
             let msg = format!(
                 "Extraneous '{}' modifier. Script functions are always '{}'",
                 function.visibility,

--- a/language/move-lang/src/naming/ast.rs
+++ b/language/move-lang/src/naming/ast.rs
@@ -47,6 +47,7 @@ pub struct ModuleDefinition {
     /// `dependency_order` is the topological order/rank in the dependency graph.
     /// `dependency_order` is initialized at `0` and set in the uses pass
     pub dependency_order: usize,
+    pub friends: UniqueMap<ModuleIdent, Loc>,
     pub structs: UniqueMap<StructName, StructDefinition>,
     pub constants: UniqueMap<ConstantName, Constant>,
     pub functions: UniqueMap<FunctionName, Function>,
@@ -547,6 +548,7 @@ impl AstDebug for ModuleDefinition {
         let ModuleDefinition {
             is_source_module,
             dependency_order,
+            friends,
             structs,
             constants,
             functions,
@@ -557,6 +559,10 @@ impl AstDebug for ModuleDefinition {
             w.writeln("source module")
         }
         w.writeln(&format!("dependency order #{}", dependency_order));
+        for (mident, _loc) in friends.key_cloned_iter() {
+            w.write(&format!("friend {};", mident));
+            w.new_line();
+        }
         for sdef in structs.key_cloned_iter() {
             sdef.ast_debug(w);
             w.new_line();

--- a/language/move-lang/src/naming/translate.rs
+++ b/language/move-lang/src/naming/translate.rs
@@ -411,12 +411,15 @@ fn friend(context: &mut Context, mident: ModuleIdent, loc: Loc) -> Option<Loc> {
         // rather than a technical requirement. The compiler, VM, and bytecode verifier DO NOT
         // rely on the assumption that friend modules must reside within the same account address.
         let msg = "Cannot declare modules out of the current address as a friend";
-        context.error(vec![(loc, "Invalid friend declaration"), (loc, msg)]);
+        context.error(vec![
+            (loc, "Invalid friend declaration"),
+            (mident.loc(), msg),
+        ]);
         None
     } else if &mident == current_mident {
         context.error(vec![
             (loc, "Invalid friend declaration"),
-            (loc, "Cannot declare the module itself as a friend"),
+            (mident.loc(), "Cannot declare the module itself as a friend"),
         ]);
         None
     } else if context.resolve_module(loc, &mident) {

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -149,6 +149,7 @@ pub struct FunctionSignature {
 pub enum FunctionVisibility {
     Public(Loc),
     Script(Loc),
+    Friend(Loc),
     Internal,
 }
 
@@ -767,6 +768,7 @@ impl BinOp_ {
 impl FunctionVisibility {
     pub const PUBLIC: &'static str = "public";
     pub const SCRIPT: &'static str = "public(script)";
+    pub const FRIEND: &'static str = "public(friend)";
     pub const INTERNAL: &'static str = "";
 }
 
@@ -810,6 +812,7 @@ impl fmt::Display for FunctionVisibility {
             match &self {
                 FunctionVisibility::Public(_) => FunctionVisibility::PUBLIC,
                 FunctionVisibility::Script(_) => FunctionVisibility::SCRIPT,
+                FunctionVisibility::Friend(_) => FunctionVisibility::FRIEND,
                 FunctionVisibility::Internal => FunctionVisibility::INTERNAL,
             }
         )

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -105,8 +105,21 @@ pub enum ModuleMember {
     Struct(StructDefinition),
     Spec(SpecBlock),
     Use(Use),
+    Friend(Friend),
     Constant(Constant),
 }
+
+//**************************************************************************************************
+// Friends
+//**************************************************************************************************
+
+#[derive(Debug, PartialEq)]
+pub enum Friend_ {
+    Module(ModuleName),
+    QualifiedModule(ModuleIdent),
+}
+
+pub type Friend = Spanned<Friend_>;
 
 //**************************************************************************************************
 // Structs
@@ -903,6 +916,7 @@ impl AstDebug for ModuleMember {
             ModuleMember::Struct(s) => s.ast_debug(w),
             ModuleMember::Spec(s) => s.ast_debug(w),
             ModuleMember::Use(u) => u.ast_debug(w),
+            ModuleMember::Friend(f) => f.ast_debug(w),
             ModuleMember::Constant(c) => c.ast_debug(w),
         }
     }
@@ -927,6 +941,24 @@ impl AstDebug for Use {
                         }
                     })
                 })
+            }
+        }
+        w.write(";")
+    }
+}
+
+impl AstDebug for Friend {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let Friend {
+            loc: _loc,
+            value: friend,
+        } = self;
+        match friend {
+            Friend_::Module(m_name) => {
+                w.write(&format!("friend {}", m_name));
+            }
+            Friend_::QualifiedModule(m_id) => {
+                w.write(&format!("friend {}", m_id));
             }
         }
         w.write(";")

--- a/language/move-lang/src/parser/lexer.rs
+++ b/language/move-lang/src/parser/lexer.rs
@@ -78,6 +78,7 @@ pub enum Tok {
     Fun,
     Script,
     Const,
+    Friend,
 }
 
 impl fmt::Display for Tok {
@@ -154,6 +155,7 @@ impl fmt::Display for Tok {
             Fun => "fun",
             Script => "script",
             Const => "const",
+            Friend => "friend",
         };
         fmt::Display::fmt(s, formatter)
     }
@@ -487,6 +489,7 @@ fn get_name_token(name: &str) -> Tok {
         "else" => Tok::Else,
         "false" => Tok::False,
         "fun" => Tok::Fun,
+        "friend" => Tok::Friend,
         "if" => Tok::If,
         "invariant" => Tok::Invariant,
         "let" => Tok::Let,

--- a/language/move-lang/src/shared/unique_map.rs
+++ b/language/move-lang/src/shared/unique_map.rs
@@ -90,6 +90,21 @@ impl<K: TName, V> UniqueMap<K, V> {
         )
     }
 
+    pub fn filter_map<V2, F>(self, mut f: F) -> UniqueMap<K, V2>
+    where
+        F: FnMut(K, V) -> Option<V2>,
+    {
+        UniqueMap(
+            self.0
+                .into_iter()
+                .filter_map(|(k_, (loc, v))| {
+                    let v2_opt = f(K::add_loc(loc, k_.clone()), v);
+                    v2_opt.map(|v2| (k_, (loc, v2)))
+                })
+                .collect(),
+        )
+    }
+
     pub fn ref_map<V2, F>(&self, mut f: F) -> UniqueMap<K, V2>
     where
         F: FnMut(K, &V) -> V2,

--- a/language/move-lang/src/to_bytecode/translate.rs
+++ b/language/move-lang/src/to_bytecode/translate.rs
@@ -452,6 +452,7 @@ fn visibility(v: FunctionVisibility) -> IR::FunctionVisibility {
     match v {
         FunctionVisibility::Public(_) => IR::FunctionVisibility::Public,
         FunctionVisibility::Script(_) => IR::FunctionVisibility::Script,
+        FunctionVisibility::Friend(_) => IR::FunctionVisibility::Friend,
         FunctionVisibility::Internal => IR::FunctionVisibility::Internal,
     }
 }

--- a/language/move-lang/src/typing/ast.rs
+++ b/language/move-lang/src/typing/ast.rs
@@ -47,6 +47,7 @@ pub struct ModuleDefinition {
     pub is_source_module: bool,
     /// `dependency_order` is the topological order/rank in the dependency graph.
     pub dependency_order: usize,
+    pub friends: UniqueMap<ModuleIdent, Loc>,
     pub structs: UniqueMap<StructName, StructDefinition>,
     pub constants: UniqueMap<ConstantName, Constant>,
     pub functions: UniqueMap<FunctionName, Function>,
@@ -279,6 +280,7 @@ impl AstDebug for ModuleDefinition {
         let ModuleDefinition {
             is_source_module,
             dependency_order,
+            friends,
             structs,
             constants,
             functions,
@@ -289,6 +291,10 @@ impl AstDebug for ModuleDefinition {
             w.writeln("source module")
         }
         w.writeln(&format!("dependency order #{}", dependency_order));
+        for (mident, _loc) in friends.key_cloned_iter() {
+            w.write(&format!("friend {};", mident));
+            w.new_line();
+        }
         for sdef in structs.key_cloned_iter() {
             sdef.ast_debug(w);
             w.new_line();

--- a/language/move-lang/src/typing/core.rs
+++ b/language/move-lang/src/typing/core.rs
@@ -837,7 +837,7 @@ pub fn make_function_type(
             if in_current_module || context.current_module_is_a_friend_of(m) => {}
         FunctionVisibility::Friend(vis_loc) => {
             let internal_msg = format!(
-                "This function can only be called from a friend of module '{}'",
+                "This function can only be called from a 'friend' of module '{}'",
                 m
             );
             context.error(vec![

--- a/language/move-lang/src/typing/core.rs
+++ b/language/move-lang/src/typing/core.rs
@@ -51,6 +51,7 @@ pub struct ConstantInfo {
 }
 
 pub struct ModuleInfo {
+    pub friends: UniqueMap<ModuleIdent, Loc>,
     pub structs: UniqueMap<StructName, StructDefinition>,
     pub functions: UniqueMap<FunctionName, FunctionInfo>,
     pub constants: UniqueMap<ConstantName, ConstantInfo>,
@@ -96,6 +97,7 @@ impl Context {
                 signature: cdef.signature.clone(),
             });
             ModuleInfo {
+                friends: mdef.friends.clone(),
                 structs,
                 functions,
                 constants,

--- a/language/move-lang/src/typing/core.rs
+++ b/language/move-lang/src/typing/core.rs
@@ -277,7 +277,9 @@ impl Context {
             (Some(current_m), Some(current_f)) => {
                 let current_finfo = self.function_info(current_m, current_f);
                 match &current_finfo.visibility {
-                    FunctionVisibility::Public(_) | FunctionVisibility::Internal => false,
+                    FunctionVisibility::Public(_)
+                    | FunctionVisibility::Friend(_)
+                    | FunctionVisibility::Internal => false,
                     FunctionVisibility::Script(_) => true,
                 }
             }
@@ -797,9 +799,10 @@ pub fn make_function_type(
             if !in_current_module {
                 let internal_msg = format!(
                     "This function is internal to its module. \
-                    Only '{}' and '{}' functions can be called outside of their module",
+                    Only '{}', '{}', and '{}' functions can be called outside of their module",
                     FunctionVisibility::PUBLIC,
-                    FunctionVisibility::SCRIPT
+                    FunctionVisibility::SCRIPT,
+                    FunctionVisibility::FRIEND
                 );
                 context.error(vec![
                     (loc, format!("Invalid call to '{}::{}'", m, f)),
@@ -819,6 +822,14 @@ pub fn make_function_type(
                     (defined_loc, internal_msg),
                 ])
             }
+        }
+        FunctionVisibility::Friend(_) => {
+            // TODO: implement typing rule for calling a friend function
+            let internal_msg = "Calling a friend function is not implemented yet".to_owned();
+            context.error(vec![
+                (loc, format!("Invalid call to '{}::{}'", m, f)),
+                (defined_loc, internal_msg),
+            ])
         }
         FunctionVisibility::Public(_) => (),
     };

--- a/language/move-lang/src/typing/translate.rs
+++ b/language/move-lang/src/typing/translate.rs
@@ -51,10 +51,12 @@ fn module(
     let N::ModuleDefinition {
         is_source_module,
         dependency_order,
+        friends,
         mut structs,
         functions: n_functions,
         constants: nconstants,
     } = mdef;
+    // TODO: translate friends
     structs
         .iter_mut()
         .for_each(|(_, _, s)| struct_def(context, s));
@@ -64,6 +66,7 @@ fn module(
     T::ModuleDefinition {
         is_source_module,
         dependency_order,
+        friends,
         structs,
         functions,
         constants,

--- a/language/move-lang/tests/move_check/expansion/friend_decl_aliased_duplicates.exp
+++ b/language/move-lang/tests/move_check/expansion/friend_decl_aliased_duplicates.exp
@@ -6,6 +6,6 @@ error:
    │     ^^^^^^^^^^^^^^^^ Duplicate friend declaration '0x42::A'. Friend declarations in a module must be unique
    ·
  6 │     friend 0x42::A;
-   │     --------------- Previously declared here
+   │            ------- Previously declared here
    │
 

--- a/language/move-lang/tests/move_check/expansion/friend_decl_aliased_duplicates.exp
+++ b/language/move-lang/tests/move_check/expansion/friend_decl_aliased_duplicates.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/expansion/friend_decl_aliased_duplicates.move:7:5 ───
+   │
+ 7 │     friend AliasedA;
+   │     ^^^^^^^^^^^^^^^^ Duplicate friend declaration '0x42::A'. Friend declarations in a module must be unique
+   ·
+ 6 │     friend 0x42::A;
+   │     --------------- Previously declared here
+   │
+

--- a/language/move-lang/tests/move_check/expansion/friend_decl_aliased_duplicates.move
+++ b/language/move-lang/tests/move_check/expansion/friend_decl_aliased_duplicates.move
@@ -1,0 +1,9 @@
+address 0x42 {
+module A {}
+
+module M {
+    use 0x42::A as AliasedA;
+    friend 0x42::A;
+    friend AliasedA;
+}
+}

--- a/language/move-lang/tests/move_check/expansion/friend_decl_aliased_function.exp
+++ b/language/move-lang/tests/move_check/expansion/friend_decl_aliased_function.exp
@@ -1,0 +1,8 @@
+error: 
+
+   ┌── tests/move_check/expansion/friend_decl_aliased_function.move:8:12 ───
+   │
+ 8 │     friend a;
+   │            ^ Unbound module alias 'a'
+   │
+

--- a/language/move-lang/tests/move_check/expansion/friend_decl_aliased_function.move
+++ b/language/move-lang/tests/move_check/expansion/friend_decl_aliased_function.move
@@ -1,0 +1,14 @@
+address 0x42 {
+module A {
+    public fun a() {}
+}
+
+module M {
+    use 0x42::A::a;
+    friend a;
+
+    public(friend) fun m() {
+        a()
+    }
+}
+}

--- a/language/move-lang/tests/move_check/expansion/friend_decl_aliased_struct.exp
+++ b/language/move-lang/tests/move_check/expansion/friend_decl_aliased_struct.exp
@@ -1,0 +1,8 @@
+error: 
+
+   ┌── tests/move_check/expansion/friend_decl_aliased_struct.move:8:12 ───
+   │
+ 8 │     friend A;
+   │            ^ Unbound module alias 'A'
+   │
+

--- a/language/move-lang/tests/move_check/expansion/friend_decl_aliased_struct.move
+++ b/language/move-lang/tests/move_check/expansion/friend_decl_aliased_struct.move
@@ -1,0 +1,12 @@
+address 0x42 {
+module A {
+    struct A {}
+}
+
+module M {
+    use 0x42::A::A;
+    friend A;
+
+    public(friend) fun m(_a: A) {}
+}
+}

--- a/language/move-lang/tests/move_check/expansion/friend_decl_imported_duplicates.exp
+++ b/language/move-lang/tests/move_check/expansion/friend_decl_imported_duplicates.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/expansion/friend_decl_imported_duplicates.move:7:5 ───
+   │
+ 7 │     friend A;
+   │     ^^^^^^^^^ Duplicate friend declaration '0x42::A'. Friend declarations in a module must be unique
+   ·
+ 6 │     friend 0x42::A;
+   │     --------------- Previously declared here
+   │
+

--- a/language/move-lang/tests/move_check/expansion/friend_decl_imported_duplicates.exp
+++ b/language/move-lang/tests/move_check/expansion/friend_decl_imported_duplicates.exp
@@ -6,6 +6,6 @@ error:
    │     ^^^^^^^^^ Duplicate friend declaration '0x42::A'. Friend declarations in a module must be unique
    ·
  6 │     friend 0x42::A;
-   │     --------------- Previously declared here
+   │            ------- Previously declared here
    │
 

--- a/language/move-lang/tests/move_check/expansion/friend_decl_imported_duplicates.move
+++ b/language/move-lang/tests/move_check/expansion/friend_decl_imported_duplicates.move
@@ -1,0 +1,9 @@
+address 0x42 {
+module A {}
+
+module M {
+    use 0x42::A;
+    friend 0x42::A;
+    friend A;
+}
+}

--- a/language/move-lang/tests/move_check/expansion/friend_decl_inner_scope_alias.exp
+++ b/language/move-lang/tests/move_check/expansion/friend_decl_inner_scope_alias.exp
@@ -1,0 +1,8 @@
+error: 
+
+   ┌── tests/move_check/expansion/friend_decl_inner_scope_alias.move:7:12 ───
+   │
+ 7 │     friend A;
+   │            ^ Unbound module alias 'A'
+   │
+

--- a/language/move-lang/tests/move_check/expansion/friend_decl_inner_scope_alias.move
+++ b/language/move-lang/tests/move_check/expansion/friend_decl_inner_scope_alias.move
@@ -1,0 +1,14 @@
+address 0x42 {
+module A {
+    public fun a() {}
+}
+
+module M {
+    friend A;
+
+    public(friend) fun m() {
+        use 0x42::A;
+        A::a()
+    }
+}
+}

--- a/language/move-lang/tests/move_check/expansion/friend_decl_nonexistent_alias.exp
+++ b/language/move-lang/tests/move_check/expansion/friend_decl_nonexistent_alias.exp
@@ -1,0 +1,8 @@
+error: 
+
+   ┌── tests/move_check/expansion/friend_decl_nonexistent_alias.move:3:12 ───
+   │
+ 3 │     friend Nonexistent;
+   │            ^^^^^^^^^^^ Unbound module alias 'Nonexistent'
+   │
+

--- a/language/move-lang/tests/move_check/expansion/friend_decl_nonexistent_alias.move
+++ b/language/move-lang/tests/move_check/expansion/friend_decl_nonexistent_alias.move
@@ -1,0 +1,5 @@
+address 0x42 {
+module M {
+    friend Nonexistent;
+}
+}

--- a/language/move-lang/tests/move_check/expansion/friend_decl_qualified_duplicates.exp
+++ b/language/move-lang/tests/move_check/expansion/friend_decl_qualified_duplicates.exp
@@ -6,6 +6,6 @@ error:
    │     ^^^^^^^^^^^^^^^ Duplicate friend declaration '0x42::A'. Friend declarations in a module must be unique
    ·
  5 │     friend 0x42::A;
-   │     --------------- Previously declared here
+   │            ------- Previously declared here
    │
 

--- a/language/move-lang/tests/move_check/expansion/friend_decl_qualified_duplicates.exp
+++ b/language/move-lang/tests/move_check/expansion/friend_decl_qualified_duplicates.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/expansion/friend_decl_qualified_duplicates.move:6:5 ───
+   │
+ 6 │     friend 0x42::A;
+   │     ^^^^^^^^^^^^^^^ Duplicate friend declaration '0x42::A'. Friend declarations in a module must be unique
+   ·
+ 5 │     friend 0x42::A;
+   │     --------------- Previously declared here
+   │
+

--- a/language/move-lang/tests/move_check/expansion/friend_decl_qualified_duplicates.move
+++ b/language/move-lang/tests/move_check/expansion/friend_decl_qualified_duplicates.move
@@ -1,0 +1,8 @@
+address 0x42 {
+module A {}
+
+module M {
+    friend 0x42::A;
+    friend 0x42::A;
+}
+}

--- a/language/move-lang/tests/move_check/expansion/public_friend_main.exp
+++ b/language/move-lang/tests/move_check/expansion/public_friend_main.exp
@@ -1,0 +1,8 @@
+error: 
+
+   ┌── tests/move_check/expansion/public_friend_main.move:2:1 ───
+   │
+ 2 │ public(friend) fun main() {
+   │ ^^^^^^^^^^^^^^ Extraneous 'public(friend)' modifier. Script functions are always 'public(script)'
+   │
+

--- a/language/move-lang/tests/move_check/expansion/public_friend_main.move
+++ b/language/move-lang/tests/move_check/expansion/public_friend_main.move
@@ -1,0 +1,4 @@
+script {
+public(friend) fun main() {
+}
+}

--- a/language/move-lang/tests/move_check/naming/friend_decl_out_of_account_addr.exp
+++ b/language/move-lang/tests/move_check/naming/friend_decl_out_of_account_addr.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/naming/friend_decl_out_of_account_addr.move:7:5 ───
+   │
+ 7 │     friend 0x2::M;
+   │     ^^^^^^^^^^^^^^ Invalid friend declaration
+   ·
+ 7 │     friend 0x2::M;
+   │     -------------- Cannot declare modules out of the current address as a friend
+   │
+

--- a/language/move-lang/tests/move_check/naming/friend_decl_out_of_account_addr.exp
+++ b/language/move-lang/tests/move_check/naming/friend_decl_out_of_account_addr.exp
@@ -6,6 +6,6 @@ error:
    │     ^^^^^^^^^^^^^^ Invalid friend declaration
    ·
  7 │     friend 0x2::M;
-   │     -------------- Cannot declare modules out of the current address as a friend
+   │            ------ Cannot declare modules out of the current address as a friend
    │
 

--- a/language/move-lang/tests/move_check/naming/friend_decl_out_of_account_addr.move
+++ b/language/move-lang/tests/move_check/naming/friend_decl_out_of_account_addr.move
@@ -1,0 +1,9 @@
+address 0x2 {
+module M {}
+}
+
+address 0x3 {
+module M {
+    friend 0x2::M;
+}
+}

--- a/language/move-lang/tests/move_check/naming/friend_decl_self.exp
+++ b/language/move-lang/tests/move_check/naming/friend_decl_self.exp
@@ -1,0 +1,22 @@
+error: 
+
+   ┌── tests/move_check/naming/friend_decl_self.move:3:5 ───
+   │
+ 3 │     friend Self;
+   │     ^^^^^^^^^^^^ Invalid friend declaration
+   ·
+ 3 │     friend Self;
+   │     ------------ Cannot declare the module itself as a friend
+   │
+
+error: 
+
+   ┌── tests/move_check/naming/friend_decl_self.move:9:5 ───
+   │
+ 9 │     friend 0x43::M;
+   │     ^^^^^^^^^^^^^^^ Invalid friend declaration
+   ·
+ 9 │     friend 0x43::M;
+   │     --------------- Cannot declare the module itself as a friend
+   │
+

--- a/language/move-lang/tests/move_check/naming/friend_decl_self.exp
+++ b/language/move-lang/tests/move_check/naming/friend_decl_self.exp
@@ -6,7 +6,7 @@ error:
    │     ^^^^^^^^^^^^ Invalid friend declaration
    ·
  3 │     friend Self;
-   │     ------------ Cannot declare the module itself as a friend
+   │            ---- Cannot declare the module itself as a friend
    │
 
 error: 
@@ -17,6 +17,6 @@ error:
    │     ^^^^^^^^^^^^^^^ Invalid friend declaration
    ·
  9 │     friend 0x43::M;
-   │     --------------- Cannot declare the module itself as a friend
+   │            ------- Cannot declare the module itself as a friend
    │
 

--- a/language/move-lang/tests/move_check/naming/friend_decl_self.move
+++ b/language/move-lang/tests/move_check/naming/friend_decl_self.move
@@ -1,0 +1,11 @@
+address 0x42 {
+module M {
+    friend Self;
+}
+}
+
+address 0x43 {
+module M {
+    friend 0x43::M;
+}
+}

--- a/language/move-lang/tests/move_check/naming/friend_decl_unbound_module.exp
+++ b/language/move-lang/tests/move_check/naming/friend_decl_unbound_module.exp
@@ -1,0 +1,8 @@
+error: 
+
+   ┌── tests/move_check/naming/friend_decl_unbound_module.move:3:5 ───
+   │
+ 3 │     friend 0x42::Nonexistent;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^ Unbound module '0x42::Nonexistent'
+   │
+

--- a/language/move-lang/tests/move_check/naming/friend_decl_unbound_module.move
+++ b/language/move-lang/tests/move_check/naming/friend_decl_unbound_module.move
@@ -1,0 +1,5 @@
+address 0x42 {
+module M {
+    friend 0x42::Nonexistent;
+}
+}

--- a/language/move-lang/tests/move_check/parser/friend_decl_address_only.exp
+++ b/language/move-lang/tests/move_check/parser/friend_decl_address_only.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/parser/friend_decl_address_only.move:3:16 ───
+   │
+ 3 │     friend 0x42;
+   │                ^ Unexpected ';'
+   ·
+ 3 │     friend 0x42;
+   │                - Expected '::'
+   │
+

--- a/language/move-lang/tests/move_check/parser/friend_decl_address_only.move
+++ b/language/move-lang/tests/move_check/parser/friend_decl_address_only.move
@@ -1,0 +1,5 @@
+address 0x42 {
+module M {
+    friend 0x42;
+}
+}

--- a/language/move-lang/tests/move_check/parser/friend_decl_inside_function.exp
+++ b/language/move-lang/tests/move_check/parser/friend_decl_inside_function.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/parser/friend_decl_inside_function.move:6:9 ───
+   │
+ 6 │         friend 0x42::A;
+   │         ^^^^^^ Unexpected 'friend'
+   ·
+ 6 │         friend 0x42::A;
+   │         ------ Expected an expression term
+   │
+

--- a/language/move-lang/tests/move_check/parser/friend_decl_inside_function.move
+++ b/language/move-lang/tests/move_check/parser/friend_decl_inside_function.move
@@ -1,0 +1,9 @@
+address 0x42 {
+module A {}
+
+module M {
+    fun M() {
+        friend 0x42::A;
+    }
+}
+}

--- a/language/move-lang/tests/move_check/parser/friend_decl_missing_semicolon.exp
+++ b/language/move-lang/tests/move_check/parser/friend_decl_missing_semicolon.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/parser/friend_decl_missing_semicolon.move:6:1 ───
+   │
+ 6 │ }
+   │ ^ Unexpected '}'
+   ·
+ 6 │ }
+   │ - Expected ';'
+   │
+

--- a/language/move-lang/tests/move_check/parser/friend_decl_missing_semicolon.move
+++ b/language/move-lang/tests/move_check/parser/friend_decl_missing_semicolon.move
@@ -1,0 +1,7 @@
+address 0x42 {
+module A {}
+
+module M {
+    friend 0x42::A
+}
+}

--- a/language/move-lang/tests/move_check/parser/friend_decl_more_than_one_module.exp
+++ b/language/move-lang/tests/move_check/parser/friend_decl_more_than_one_module.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/parser/friend_decl_more_than_one_module.move:7:14 ───
+   │
+ 7 │     friend A 0x42::B;
+   │              ^^^^ Unexpected '0x42'
+   ·
+ 7 │     friend A 0x42::B;
+   │              ---- Expected ';'
+   │
+

--- a/language/move-lang/tests/move_check/parser/friend_decl_more_than_one_module.move
+++ b/language/move-lang/tests/move_check/parser/friend_decl_more_than_one_module.move
@@ -1,0 +1,9 @@
+address 0x42 {
+module A {}
+module B {}
+
+module M {
+    use 0x42::A;
+    friend A 0x42::B;
+}
+}

--- a/language/move-lang/tests/move_check/parser/friend_decl_qualified_function.exp
+++ b/language/move-lang/tests/move_check/parser/friend_decl_qualified_function.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/parser/friend_decl_qualified_function.move:7:19 ───
+   │
+ 7 │     friend 0x42::A::a;
+   │                   ^^ Unexpected '::'
+   ·
+ 7 │     friend 0x42::A::a;
+   │                   -- Expected ';'
+   │
+

--- a/language/move-lang/tests/move_check/parser/friend_decl_qualified_function.move
+++ b/language/move-lang/tests/move_check/parser/friend_decl_qualified_function.move
@@ -1,0 +1,9 @@
+address 0x42 {
+module A {
+    fun a() {}
+}
+
+module M {
+    friend 0x42::A::a;
+}
+}

--- a/language/move-lang/tests/move_check/parser/friend_decl_qualified_struct.exp
+++ b/language/move-lang/tests/move_check/parser/friend_decl_qualified_struct.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/parser/friend_decl_qualified_struct.move:7:19 ───
+   │
+ 7 │     friend 0x42::A::A;
+   │                   ^^ Unexpected '::'
+   ·
+ 7 │     friend 0x42::A::A;
+   │                   -- Expected ';'
+   │
+

--- a/language/move-lang/tests/move_check/parser/friend_decl_qualified_struct.move
+++ b/language/move-lang/tests/move_check/parser/friend_decl_qualified_struct.move
@@ -1,0 +1,9 @@
+address 0x42 {
+module A {
+    struct A {}
+}
+
+module M {
+    friend 0x42::A::A;
+}
+}

--- a/language/move-lang/tests/move_check/parser/friend_decl_valid.move
+++ b/language/move-lang/tests/move_check/parser/friend_decl_valid.move
@@ -1,0 +1,18 @@
+address 0x42 {
+module A {}
+module B {}
+module C {}
+
+module M {
+    // friend with fully qualified module id
+    friend 0x42::A;
+
+    // friend with imported name
+    use 0x42::B;
+    friend B;
+
+    // friend with asliased name
+    use 0x42::C as AliasedC;
+    friend AliasedC;
+}
+}

--- a/language/move-lang/tests/move_check/parser/function_visibility_empty.exp
+++ b/language/move-lang/tests/move_check/parser/function_visibility_empty.exp
@@ -3,6 +3,6 @@ error:
    ┌── tests/move_check/parser/function_visibility_empty.move:2:5 ───
    │
  2 │     public() fun f() {}
-   │     ^^^^^^^^ Invalid visibility modifier. Consider removing it or using one of 'public' or 'public(script)'
+   │     ^^^^^^^^ Invalid visibility modifier. Consider removing it or using one of 'public', 'public(script)', or 'public(friend)'
    │
 

--- a/language/move-lang/tests/move_check/parser/function_visibility_friend.move
+++ b/language/move-lang/tests/move_check/parser/function_visibility_friend.move
@@ -1,0 +1,5 @@
+module M {
+    public(friend) fun f() {}
+    public (friend) fun g() {}
+    public ( friend ) fun h() {}
+}

--- a/language/move-lang/tests/move_check/parser/function_visibility_invalid.exp
+++ b/language/move-lang/tests/move_check/parser/function_visibility_invalid.exp
@@ -3,6 +3,6 @@ error:
    ┌── tests/move_check/parser/function_visibility_invalid.move:2:5 ───
    │
  2 │     public(invalid_modifier) fun f() {}
-   │     ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid visibility modifier. Consider removing it or using one of 'public' or 'public(script)'
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid visibility modifier. Consider removing it or using one of 'public', 'public(script)', or 'public(friend)'
    │
 

--- a/language/move-lang/tests/move_check/typing/constant_unsupported_exps.exp
+++ b/language/move-lang/tests/move_check/typing/constant_unsupported_exps.exp
@@ -1,91 +1,72 @@
 error: 
 
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:14:9 ───
-    │
- 14 │         let x = 0;
-    │         ^^^^^^^^^ 'let' declarations are not supported in constants
-    │
-
-error: 
-
     ┌── tests/move_check/typing/constant_unsupported_exps.move:15:9 ───
     │
- 15 │         let s: signer = abort 0;
-    │         ^^^^^^^^^^^^^^^^^^^^^^^ 'let' declarations are not supported in constants
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:15:25 ───
-    │
- 15 │         let s: signer = abort 0;
-    │                         ^^^^^^^ 'abort' expressions are not supported in constants
+ 15 │         let x = 0;
+    │         ^^^^^^^^^ 'let' declarations are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:16:9 ───
     │
- 16 │         let b = B { f: 0 };
-    │         ^^^^^^^^^^^^^^^^^^ 'let' declarations are not supported in constants
+ 16 │         let s: signer = abort 0;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^ 'let' declarations are not supported in constants
     │
 
 error: 
 
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:16:17 ───
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:16:25 ───
     │
- 16 │         let b = B { f: 0 };
-    │                 ^^^^^^^^^^ Structs are not supported in constants
+ 16 │         let s: signer = abort 0;
+    │                         ^^^^^^^ 'abort' expressions are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:17:9 ───
     │
- 17 │         spec { };
-    │         ^^^^^^^^ Spec blocks are not supported in constants
+ 17 │         let b = B { f: 0 };
+    │         ^^^^^^^^^^^^^^^^^^ 'let' declarations are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:17:17 ───
+    │
+ 17 │         let b = B { f: 0 };
+    │                 ^^^^^^^^^^ Structs are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:18:9 ───
     │
- 18 │         &x;
-    │         ^^ References (and reference operations) are not supported in constants
+ 18 │         spec { };
+    │         ^^^^^^^^ Spec blocks are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:19:9 ───
     │
- 19 │         &mut x;
-    │         ^^^^^^ References (and reference operations) are not supported in constants
+ 19 │         &x;
+    │         ^^ References (and reference operations) are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:20:9 ───
     │
- 20 │         f_public();
-    │         ^^^^^^^^^^ Module calls are not supported in constants
+ 20 │         &mut x;
+    │         ^^^^^^ References (and reference operations) are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:21:9 ───
     │
- 21 │         f_script();
-    │         ^^^^^^^^^^ Invalid call to '0x42::M::f_script'
-    ·
- 48 │     public(script) fun f_script() {}
-    │                        -------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:21:9 ───
-    │
- 21 │         f_script();
+ 21 │         f_public();
     │         ^^^^^^^^^^ Module calls are not supported in constants
     │
 
@@ -93,307 +74,353 @@ error:
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:22:9 ───
     │
- 22 │         f_private();
-    │         ^^^^^^^^^^^ Module calls are not supported in constants
+ 22 │         f_script();
+    │         ^^^^^^^^^^ Invalid call to '0x42::M::f_script'
+    ·
+ 51 │     public(script) fun f_script() {}
+    │     -------------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:22:9 ───
+    │
+ 22 │         f_script();
+    │         ^^^^^^^^^^ Module calls are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:23:9 ───
     │
- 23 │         0x42::X::f_public();
-    │         ^^^^^^^^^^^^^^^^^^^ Module calls are not supported in constants
+ 23 │         f_friend();
+    │         ^^^^^^^^^^ Module calls are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:24:9 ───
     │
- 24 │         0x42::X::f_script();
-    │         ^^^^^^^^^^^^^^^^^^^ Invalid call to '0x42::X::f_script'
-    ·
-  4 │     public(script) fun f_script() {}
-    │                        -------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
+ 24 │         f_private();
+    │         ^^^^^^^^^^^ Module calls are not supported in constants
     │
 
 error: 
 
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:24:9 ───
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:25:9 ───
     │
- 24 │         0x42::X::f_script();
+ 25 │         0x42::X::f_public();
     │         ^^^^^^^^^^^^^^^^^^^ Module calls are not supported in constants
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:25:9 ───
-    │
- 25 │         0x42::X::f_private();
-    │         ^^^^^^^^^^^^^^^^^^^^ Invalid call to '0x42::X::f_private'
-    ·
-  5 │     fun f_private() {}
-    │         --------- This function is internal to its module. Only 'public', 'public(script)', and 'public(friend)' functions can be called outside of their module
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:25:9 ───
-    │
- 25 │         0x42::X::f_private();
-    │         ^^^^^^^^^^^^^^^^^^^^ Module calls are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:26:9 ───
     │
- 26 │         borrow_global<R>(0x42);
-    │         ^^^^^^^^^^^^^^^^^^^^^^ 'borrow_global' is not supported in constants
+ 26 │         0x42::X::f_script();
+    │         ^^^^^^^^^^^^^^^^^^^ Invalid call to '0x42::X::f_script'
+    ·
+  4 │     public(script) fun f_script() {}
+    │     -------------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:26:9 ───
+    │
+ 26 │         0x42::X::f_script();
+    │         ^^^^^^^^^^^^^^^^^^^ Module calls are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:27:9 ───
     │
- 27 │         borrow_global_mut<R>(0x42);
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ 'borrow_global_mut' is not supported in constants
+ 27 │         0x42::X::f_friend();
+    │         ^^^^^^^^^^^^^^^^^^^ Invalid call to '0x42::X::f_friend'
+    ·
+  5 │     public(friend) fun f_friend() {}
+    │     -------------- This function can only be called from a friend of module '0x42::X'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:27:9 ───
+    │
+ 27 │         0x42::X::f_friend();
+    │         ^^^^^^^^^^^^^^^^^^^ Module calls are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:28:9 ───
     │
- 28 │         move_to(s, R{});
-    │         ^^^^^^^^^^^^^^^ Invalid call of 'move_to'. Invalid argument for parameter '0'
+ 28 │         0x42::X::f_private();
+    │         ^^^^^^^^^^^^^^^^^^^^ Invalid call to '0x42::X::f_private'
     ·
- 15 │         let s: signer = abort 0;
-    │                ------ The type: 'signer'
-    ·
- 28 │         move_to(s, R{});
-    │         ------- Is not compatible with: '&signer'
+  6 │     fun f_private() {}
+    │         --------- This function is internal to its module. Only 'public', 'public(script)', and 'public(friend)' functions can be called outside of their module
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:28:9 ───
     │
- 28 │         move_to(s, R{});
-    │         ^^^^^^^^^^^^^^^ 'move_to' is not supported in constants
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:28:16 ───
-    │
- 28 │         move_to(s, R{});
-    │                ^^^^^^^^ Expression lists are not supported in constants
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:28:20 ───
-    │
- 28 │         move_to(s, R{});
-    │                    ^^^ Structs are not supported in constants
+ 28 │         0x42::X::f_private();
+    │         ^^^^^^^^^^^^^^^^^^^^ Module calls are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:29:9 ───
     │
- 29 │         R{} = move_from(0x42);
-    │         ^^^^^^^^^^^^^^^^^^^^^ Assignments are not supported in constants
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:29:15 ───
-    │
- 29 │         R{} = move_from(0x42);
-    │               ^^^^^^^^^^^^^^^ 'move_from' is not supported in constants
+ 29 │         borrow_global<R>(0x42);
+    │         ^^^^^^^^^^^^^^^^^^^^^^ 'borrow_global' is not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:30:9 ───
     │
- 30 │         freeze(&mut x);
-    │         ^^^^^^^^^^^^^^ 'freeze' is not supported in constants
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:30:16 ───
-    │
- 30 │         freeze(&mut x);
-    │                ^^^^^^ References (and reference operations) are not supported in constants
+ 30 │         borrow_global_mut<R>(0x42);
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ 'borrow_global_mut' is not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:31:9 ───
     │
- 31 │         assert(true, 42);
-    │         ^^^^^^^^^^^^^^^^ 'assert' is not supported in constants
+ 31 │         move_to(s, R{});
+    │         ^^^^^^^^^^^^^^^ Invalid call of 'move_to'. Invalid argument for parameter '0'
+    ·
+ 16 │         let s: signer = abort 0;
+    │                ------ The type: 'signer'
+    ·
+ 31 │         move_to(s, R{});
+    │         ------- Is not compatible with: '&signer'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:31:15 ───
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:31:9 ───
     │
- 31 │         assert(true, 42);
-    │               ^^^^^^^^^^ Expression lists are not supported in constants
+ 31 │         move_to(s, R{});
+    │         ^^^^^^^^^^^^^^^ 'move_to' is not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:31:16 ───
+    │
+ 31 │         move_to(s, R{});
+    │                ^^^^^^^^ Expression lists are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:31:20 ───
+    │
+ 31 │         move_to(s, R{});
+    │                    ^^^ Structs are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:32:9 ───
     │
- 32 │         if (true) 0 else 1;
-    │         ^^^^^^^^^^^^^^^^^^ 'if' expressions are not supported in constants
+ 32 │         R{} = move_from(0x42);
+    │         ^^^^^^^^^^^^^^^^^^^^^ Assignments are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:32:15 ───
+    │
+ 32 │         R{} = move_from(0x42);
+    │               ^^^^^^^^^^^^^^^ 'move_from' is not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:33:9 ───
     │
- 33 │         loop ();
-    │         ^^^^^^^ 'loop' expressions are not supported in constants
+ 33 │         freeze(&mut x);
+    │         ^^^^^^^^^^^^^^ 'freeze' is not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:33:16 ───
+    │
+ 33 │         freeze(&mut x);
+    │                ^^^^^^ References (and reference operations) are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:34:9 ───
     │
- 34 │         loop { break; continue; };
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ 'loop' expressions are not supported in constants
+ 34 │         assert(true, 42);
+    │         ^^^^^^^^^^^^^^^^ 'assert' is not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:34:15 ───
+    │
+ 34 │         assert(true, 42);
+    │               ^^^^^^^^^^ Expression lists are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:35:9 ───
     │
- 35 │         while (true) ();
-    │         ^^^^^^^^^^^^^^^ 'while' expressions are not supported in constants
+ 35 │         if (true) 0 else 1;
+    │         ^^^^^^^^^^^^^^^^^^ 'if' expressions are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:36:9 ───
     │
- 36 │         x = 1;
-    │         ^^^^^ Assignments are not supported in constants
+ 36 │         loop ();
+    │         ^^^^^^^ 'loop' expressions are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:37:9 ───
     │
- 37 │         return 0;
-    │         ^^^^^^^^ 'return' expressions are not supported in constants
+ 37 │         loop { break; continue; };
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ 'loop' expressions are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:38:9 ───
     │
- 38 │         abort 0;
-    │         ^^^^^^^ 'abort' expressions are not supported in constants
+ 38 │         while (true) ();
+    │         ^^^^^^^^^^^^^^^ 'while' expressions are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:39:9 ───
     │
- 39 │         *(&mut 0) = 0;
-    │         ^^^^^^^^^^^^^ References (and reference operations) are not supported in constants
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:39:10 ───
-    │
- 39 │         *(&mut 0) = 0;
-    │          ^^^^^^^^ References (and reference operations) are not supported in constants
+ 39 │         x = 1;
+    │         ^^^^^ Assignments are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:40:9 ───
     │
- 40 │         b.f = 0;
-    │         ^ References (and reference operations) are not supported in constants
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:40:9 ───
-    │
- 40 │         b.f = 0;
-    │         ^^^ References (and reference operations) are not supported in constants
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:40:9 ───
-    │
- 40 │         b.f = 0;
-    │         ^^^^^^^ References (and reference operations) are not supported in constants
+ 40 │         return 0;
+    │         ^^^^^^^^ 'return' expressions are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:41:9 ───
     │
- 41 │         b.f;
-    │         ^ References (and reference operations) are not supported in constants
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:41:9 ───
-    │
- 41 │         b.f;
-    │         ^^^ References (and reference operations) are not supported in constants
+ 41 │         abort 0;
+    │         ^^^^^^^ 'abort' expressions are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:42:9 ───
     │
- 42 │         *&b.f;
-    │         ^^^^^ References (and reference operations) are not supported in constants
+ 42 │         *(&mut 0) = 0;
+    │         ^^^^^^^^^^^^^ References (and reference operations) are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:42:10 ───
     │
- 42 │         *&b.f;
-    │          ^^^^ References (and reference operations) are not supported in constants
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:42:11 ───
-    │
- 42 │         *&b.f;
-    │           ^ References (and reference operations) are not supported in constants
+ 42 │         *(&mut 0) = 0;
+    │          ^^^^^^^^ References (and reference operations) are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:43:9 ───
     │
- 43 │         (0, 1);
-    │         ^^^^^^ Expression lists are not supported in constants
+ 43 │         b.f = 0;
+    │         ^ References (and reference operations) are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:43:9 ───
+    │
+ 43 │         b.f = 0;
+    │         ^^^ References (and reference operations) are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:43:9 ───
+    │
+ 43 │         b.f = 0;
+    │         ^^^^^^^ References (and reference operations) are not supported in constants
     │
 
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:44:9 ───
     │
- 44 │         FLAG;
+ 44 │         b.f;
+    │         ^ References (and reference operations) are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:44:9 ───
+    │
+ 44 │         b.f;
+    │         ^^^ References (and reference operations) are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:45:9 ───
+    │
+ 45 │         *&b.f;
+    │         ^^^^^ References (and reference operations) are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:45:10 ───
+    │
+ 45 │         *&b.f;
+    │          ^^^^ References (and reference operations) are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:45:11 ───
+    │
+ 45 │         *&b.f;
+    │           ^ References (and reference operations) are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:46:9 ───
+    │
+ 46 │         (0, 1);
+    │         ^^^^^^ Expression lists are not supported in constants
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/constant_unsupported_exps.move:47:9 ───
+    │
+ 47 │         FLAG;
     │         ^^^^ Other constants are not supported in constants
     │
 

--- a/language/move-lang/tests/move_check/typing/constant_unsupported_exps.exp
+++ b/language/move-lang/tests/move_check/typing/constant_unsupported_exps.exp
@@ -140,7 +140,7 @@ error:
     │         ^^^^^^^^^^^^^^^^^^^ Invalid call to '0x42::X::f_friend'
     ·
   5 │     public(friend) fun f_friend() {}
-    │     -------------- This function can only be called from a friend of module '0x42::X'
+    │     -------------- This function can only be called from a 'friend' of module '0x42::X'
     │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/constant_unsupported_exps.exp
+++ b/language/move-lang/tests/move_check/typing/constant_unsupported_exps.exp
@@ -132,7 +132,7 @@ error:
     │         ^^^^^^^^^^^^^^^^^^^^ Invalid call to '0x42::X::f_private'
     ·
   5 │     fun f_private() {}
-    │         --------- This function is internal to its module. Only 'public' and 'public(script)' functions can be called outside of their module
+    │         --------- This function is internal to its module. Only 'public', 'public(script)', and 'public(friend)' functions can be called outside of their module
     │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/constant_unsupported_exps.move
+++ b/language/move-lang/tests/move_check/typing/constant_unsupported_exps.move
@@ -2,6 +2,7 @@ address 0x42 {
 module X {
     public fun f_public() {}
     public(script) fun f_script() {}
+    public(friend) fun f_friend() {}
     fun f_private() {}
 }
 
@@ -19,9 +20,11 @@ module M {
         &mut x;
         f_public();
         f_script();
+        f_friend();
         f_private();
         0x42::X::f_public();
         0x42::X::f_script();
+        0x42::X::f_friend();
         0x42::X::f_private();
         borrow_global<R>(0x42);
         borrow_global_mut<R>(0x42);
@@ -46,6 +49,7 @@ module M {
     };
     public fun f_public() {}
     public(script) fun f_script() {}
+    public(friend) fun f_friend() {}
     fun f_private() {}
 }
 }

--- a/language/move-lang/tests/move_check/typing/main_call_visibility_friend.exp
+++ b/language/move-lang/tests/move_check/typing/main_call_visibility_friend.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/typing/main_call_visibility_friend.move:9:5 ───
+   │
+ 9 │     0x2::X::foo()
+   │     ^^^^^^^^^^^^^ Invalid call to '0x2::X::foo'
+   ·
+ 3 │     public(friend) fun foo() {}
+   │     -------------- This function can only be called from a friend of module '0x2::X'
+   │
+

--- a/language/move-lang/tests/move_check/typing/main_call_visibility_friend.exp
+++ b/language/move-lang/tests/move_check/typing/main_call_visibility_friend.exp
@@ -6,6 +6,6 @@ error:
    │     ^^^^^^^^^^^^^ Invalid call to '0x2::X::foo'
    ·
  3 │     public(friend) fun foo() {}
-   │     -------------- This function can only be called from a friend of module '0x2::X'
+   │     -------------- This function can only be called from a 'friend' of module '0x2::X'
    │
 

--- a/language/move-lang/tests/move_check/typing/main_call_visibility_friend.move
+++ b/language/move-lang/tests/move_check/typing/main_call_visibility_friend.move
@@ -1,0 +1,11 @@
+address 0x2 {
+module X {
+    public(friend) fun foo() {}
+}
+}
+
+script {
+fun main() {
+    0x2::X::foo()
+}
+}

--- a/language/move-lang/tests/move_check/typing/module_call_internal.exp
+++ b/language/move-lang/tests/move_check/typing/module_call_internal.exp
@@ -6,6 +6,6 @@ error:
     │         ^^^^^^^^ Invalid call to '0x2::X::foo'
     ·
   4 │     fun foo() {}
-    │         --- This function is internal to its module. Only 'public' and 'public(script)' functions can be called outside of their module
+    │         --- This function is internal to its module. Only 'public', 'public(script)', and 'public(friend)' functions can be called outside of their module
     │
 

--- a/language/move-lang/tests/move_check/typing/module_call_visibility_friend.move
+++ b/language/move-lang/tests/move_check/typing/module_call_visibility_friend.move
@@ -1,0 +1,43 @@
+address 0x2 {
+
+module X {
+    public fun f_public() {}
+}
+
+module Y {
+    friend 0x2::M;
+    public(friend) fun f_friend() {}
+}
+
+module M {
+    use 0x2::X;
+    use 0x2::Y;
+
+    public fun f_public() {}
+    public(friend) fun f_friend() {}
+    fun f_private() {}
+
+    // a public(friend) fun can call public funs in another module
+    public(friend) fun f_friend_call_public() { X::f_public() }
+
+    // a public(friend) fun can call private and public funs defined in its own module
+    public(friend) fun f_friend_call_self_private() { Self::f_private() }
+    public(friend) fun f_friend_call_self_public() { Self::f_public() }
+
+    // a public functions can call a public(friend) function defined in the same module
+    // as well as friend functions defined in other modules (subject to friend list)
+    public fun f_public_call_friend() { Y::f_friend() }
+    public fun f_public_call_self_friend() { Self::f_friend() }
+
+    // a public(friend) functions can call a public(friend) function defined in the same module
+    // as well as friend functions defined in other modules (subject to friend list)
+    public(friend) fun f_friend_call_friend() { Y::f_friend() }
+    public(friend) fun f_friend_call_self_friend() { Self::f_friend() }
+
+    // a private functions can call a public(friend) function defined in the same module
+    // as well as friend functions defined in other modules (subject to friend list)
+    fun f_private_call_friend() { Y::f_friend() }
+    fun f_private_call_self_friend() { Self::f_friend() }
+}
+
+}

--- a/language/move-lang/tests/move_check/typing/module_call_visibility_friend_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/module_call_visibility_friend_invalid.exp
@@ -1,0 +1,33 @@
+error: 
+
+    ┌── tests/move_check/typing/module_call_visibility_friend_invalid.move:18:49 ───
+    │
+ 18 │     public(friend) fun f_friend_call_friend() { X::f_friend() }
+    │                                                 ^^^^^^^^^^^^^ Invalid call to '0x2::X::f_friend'
+    ·
+  5 │     public(friend) fun f_friend() {}
+    │     -------------- This function can only be called from a friend of module '0x2::X'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/module_call_visibility_friend_invalid.move:22:52 ───
+    │
+ 22 │     public(friend) fun f_friend_call_private_1() { X::f_private() }
+    │                                                    ^^^^^^^^^^^^^^ Invalid call to '0x2::X::f_private'
+    ·
+  4 │     fun f_private() {}
+    │         --------- This function is internal to its module. Only 'public', 'public(script)', and 'public(friend)' functions can be called outside of their module
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/module_call_visibility_friend_invalid.move:23:52 ───
+    │
+ 23 │     public(friend) fun f_friend_call_private_2() { Y::f_private() }
+    │                                                    ^^^^^^^^^^^^^^ Invalid call to '0x2::Y::f_private'
+    ·
+ 10 │     fun f_private() {}
+    │         --------- This function is internal to its module. Only 'public', 'public(script)', and 'public(friend)' functions can be called outside of their module
+    │
+

--- a/language/move-lang/tests/move_check/typing/module_call_visibility_friend_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/module_call_visibility_friend_invalid.exp
@@ -6,7 +6,7 @@ error:
     │                                                 ^^^^^^^^^^^^^ Invalid call to '0x2::X::f_friend'
     ·
   5 │     public(friend) fun f_friend() {}
-    │     -------------- This function can only be called from a friend of module '0x2::X'
+    │     -------------- This function can only be called from a 'friend' of module '0x2::X'
     │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/module_call_visibility_friend_invalid.move
+++ b/language/move-lang/tests/move_check/typing/module_call_visibility_friend_invalid.move
@@ -1,0 +1,26 @@
+address 0x2 {
+
+module X {
+    fun f_private() {}
+    public(friend) fun f_friend() {}
+}
+
+module Y {
+    friend 0x2::M;
+    fun f_private() {}
+}
+
+module M {
+    use 0x2::X;
+    use 0x2::Y;
+
+    // a public(friend) fun cannot call friend funs in other modules if not being in the friend list
+    public(friend) fun f_friend_call_friend() { X::f_friend() }
+
+    // a public(friend) fun cannot call private funs in other modules, regardless of whether being
+    // in the friend list of not.
+    public(friend) fun f_friend_call_private_1() { X::f_private() }
+    public(friend) fun f_friend_call_private_2() { Y::f_private() }
+}
+
+}

--- a/language/move-lang/tests/move_check/typing/module_call_visibility_script.move
+++ b/language/move-lang/tests/move_check/typing/module_call_visibility_script.move
@@ -5,22 +5,36 @@ module X {
     public(script) fun f_script() {}
 }
 
+module Y {
+    friend 0x2::M;
+    public(friend) fun f_friend() {}
+}
+
 module M {
     use 0x2::X;
+    use 0x2::Y;
 
     public fun f_public() {}
-    public fun f_private() {}
+    public(friend) fun f_friend() {}
+    public(script) fun f_script() {}
+    fun f_private() {}
 
     // a public(script) fun can call public(script) funs in another module
     public(script) fun f_script_call_script() { X::f_script() }
 
+    // a public(script) fun can call public(friend) funs in another module (subject to the
+    // constraints of the friend list)
+    public(script) fun f_script_call_friend() { Y::f_friend() }
+
     // a public(script) fun can call public funs in another module
     public(script) fun f_script_call_public() { X::f_public() }
 
-    // a public(script) fun can call private, public, and public(script) funs in its own module
+    // a public(script) fun can call private, public, public(friend), and public(script) funs
+    // defined in its own module
     public(script) fun f_script_call_self_private() { Self::f_private() }
     public(script) fun f_script_call_self_public() { Self::f_public() }
-    public(script) fun f_script_call_self_script() { Self::f_script_call_script() }
+    public(script) fun f_script_call_self_friend() { Self::f_friend() }
+    public(script) fun f_script_call_self_script() { Self::f_script() }
 }
 
 }

--- a/language/move-lang/tests/move_check/typing/module_call_visibility_script_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/module_call_visibility_script_invalid.exp
@@ -83,6 +83,6 @@ error:
     │                                                 ^^^^^^^^^^^^^ Invalid call to '0x2::X::f_friend'
     ·
   6 │     public(friend) fun f_friend() {}
-    │     -------------- This function can only be called from a friend of module '0x2::X'
+    │     -------------- This function can only be called from a 'friend' of module '0x2::X'
     │
 

--- a/language/move-lang/tests/move_check/typing/module_call_visibility_script_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/module_call_visibility_script_invalid.exp
@@ -1,55 +1,88 @@
 error: 
 
-    ┌── tests/move_check/typing/module_call_visibility_script_invalid.move:15:35 ───
+    ┌── tests/move_check/typing/module_call_visibility_script_invalid.move:16:35 ───
     │
- 15 │     fun f_private_call_script() { X::f_script() }
+ 16 │     fun f_private_call_script() { X::f_script() }
     │                                   ^^^^^^^^^^^^^ Invalid call to '0x2::X::f_script'
     ·
   5 │     public(script) fun f_script() {}
-    │                        -------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
+    │     -------------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_visibility_script_invalid.move:16:41 ───
+    ┌── tests/move_check/typing/module_call_visibility_script_invalid.move:17:49 ───
     │
- 16 │     public fun f_public_call_script() { X::f_script() }
+ 17 │     public(friend) fun f_friend_call_script() { X::f_script() }
+    │                                                 ^^^^^^^^^^^^^ Invalid call to '0x2::X::f_script'
+    ·
+  5 │     public(script) fun f_script() {}
+    │     -------------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/module_call_visibility_script_invalid.move:18:41 ───
+    │
+ 18 │     public fun f_public_call_script() { X::f_script() }
     │                                         ^^^^^^^^^^^^^ Invalid call to '0x2::X::f_script'
     ·
   5 │     public(script) fun f_script() {}
-    │                        -------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
+    │     -------------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_visibility_script_invalid.move:20:40 ───
+    ┌── tests/move_check/typing/module_call_visibility_script_invalid.move:22:40 ───
     │
- 20 │     fun f_private_call_self_script() { f_script_call_script() }
+ 22 │     fun f_private_call_self_script() { f_script_call_script() }
     │                                        ^^^^^^^^^^^^^^^^^^^^^^ Invalid call to '0x2::M::f_script_call_script'
     ·
- 11 │     public(script) fun f_script_call_script() { X::f_script() }
-    │                        -------------------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
+ 12 │     public(script) fun f_script_call_script() { X::f_script() }
+    │     -------------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_visibility_script_invalid.move:21:46 ───
+    ┌── tests/move_check/typing/module_call_visibility_script_invalid.move:23:54 ───
     │
- 21 │     public fun f_public_call_self_script() { f_script_call_script() }
+ 23 │     public(friend) fun f_friend_call_self_script() { f_script_call_script() }
+    │                                                      ^^^^^^^^^^^^^^^^^^^^^^ Invalid call to '0x2::M::f_script_call_script'
+    ·
+ 12 │     public(script) fun f_script_call_script() { X::f_script() }
+    │     -------------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/module_call_visibility_script_invalid.move:24:46 ───
+    │
+ 24 │     public fun f_public_call_self_script() { f_script_call_script() }
     │                                              ^^^^^^^^^^^^^^^^^^^^^^ Invalid call to '0x2::M::f_script_call_script'
     ·
- 11 │     public(script) fun f_script_call_script() { X::f_script() }
-    │                        -------------------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
+ 12 │     public(script) fun f_script_call_script() { X::f_script() }
+    │     -------------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_visibility_script_invalid.move:24:50 ───
+    ┌── tests/move_check/typing/module_call_visibility_script_invalid.move:27:50 ───
     │
- 24 │     public(script) fun f_script_call_private() { X::f_private() }
+ 27 │     public(script) fun f_script_call_private() { X::f_private() }
     │                                                  ^^^^^^^^^^^^^^ Invalid call to '0x2::X::f_private'
     ·
   4 │     fun f_private() {}
     │         --------- This function is internal to its module. Only 'public', 'public(script)', and 'public(friend)' functions can be called outside of their module
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/module_call_visibility_script_invalid.move:31:49 ───
+    │
+ 31 │     public(script) fun f_script_call_friend() { X::f_friend() }
+    │                                                 ^^^^^^^^^^^^^ Invalid call to '0x2::X::f_friend'
+    ·
+  6 │     public(friend) fun f_friend() {}
+    │     -------------- This function can only be called from a friend of module '0x2::X'
     │
 

--- a/language/move-lang/tests/move_check/typing/module_call_visibility_script_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/module_call_visibility_script_invalid.exp
@@ -50,6 +50,6 @@ error:
     │                                                  ^^^^^^^^^^^^^^ Invalid call to '0x2::X::f_private'
     ·
   4 │     fun f_private() {}
-    │         --------- This function is internal to its module. Only 'public' and 'public(script)' functions can be called outside of their module
+    │         --------- This function is internal to its module. Only 'public', 'public(script)', and 'public(friend)' functions can be called outside of their module
     │
 

--- a/language/move-lang/tests/move_check/typing/module_call_visibility_script_invalid.move
+++ b/language/move-lang/tests/move_check/typing/module_call_visibility_script_invalid.move
@@ -3,6 +3,7 @@ address 0x2 {
 module X {
     fun f_private() {}
     public(script) fun f_script() {}
+    public(friend) fun f_friend() {}
 }
 
 module M {
@@ -13,15 +14,21 @@ module M {
     // a public(script) fun in another module can only be called
     // by a public(script) fun from this module
     fun f_private_call_script() { X::f_script() }
+    public(friend) fun f_friend_call_script() { X::f_script() }
     public fun f_public_call_script() { X::f_script() }
 
     // a public(script) fun in this module can only be called
     // by a public(script) fun from this module
     fun f_private_call_self_script() { f_script_call_script() }
+    public(friend) fun f_friend_call_self_script() { f_script_call_script() }
     public fun f_public_call_self_script() { f_script_call_script() }
 
     // a public(script) fun cannot call private funs in other modules
     public(script) fun f_script_call_private() { X::f_private() }
+
+    // a public(script) fun cannot call public(friend) funs in other modules
+    // if the current module is not in the friend list
+    public(script) fun f_script_call_friend() { X::f_friend() }
 }
 
 }

--- a/language/move-model/src/builder/module_builder.rs
+++ b/language/move-model/src/builder/module_builder.rs
@@ -2412,6 +2412,10 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                     // TODO: model script visibility properly
                     unimplemented!("Script visibility not supported yet")
                 }
+                PA::FunctionVisibility::Friend(..) => {
+                    // TODO: model friend visibility properly
+                    unimplemented!("Friend visibility not supported yet")
+                }
             }
         }
         let rex = Regex::new(&format!(

--- a/language/move-model/src/lib.rs
+++ b/language/move-model/src/lib.rs
@@ -230,6 +230,7 @@ fn run_spec_checker(env: &mut GlobalEnv, units: Vec<CompiledUnit>, mut eprog: Pr
                     let expanded_module = ModuleDefinition {
                         loc,
                         is_source_module: true,
+                        friends: UniqueMap::new(),
                         structs: UniqueMap::new(),
                         constants,
                         functions,


### PR DESCRIPTION
- parse `public(friend)` as a function visibility modifier
- parse and compile (up to typing) of the friend list declarations
- unit tests for the parser, expansion, naming, and typing passes

## Motivation

This is the first piece of move source compiler changes for friend visibility. This PR covers the changes in parser, expansion, naming, and typing. Expects more PRs to follow that cover dependency checking and translation to IR.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

New test cases for the source compiler are added
