### PR TITLE
[vm] add OUT_OF_GAS special case in VMError::into_vm_status debug_assert

### DIFF
--- a/language/move-lang/functional-tests/tests/diem/epilogue/out_of_gas_after_execution.move
+++ b/language/move-lang/functional-tests/tests/diem/epilogue/out_of_gas_after_execution.move
@@ -1,0 +1,25 @@
+// Test for running out of gas when updating the global state in the diem-vm.
+// This is reported as VMStatus::Error(OUT_OF_GAS) instead of as
+// VMStatus::ExecutionFailure(OUT_OF_GAS) because the error does not occur
+// when running Move code and there is no associated location or offset.
+
+//! account: default, 100000XUS
+//! new-transaction
+//! gas-price: 1
+//! gas-currency: XUS
+//! max-gas: 4
+//! sender: default
+script {
+fun main() {
+    let x: u64;
+    let y: u64;
+
+    x = 3;
+    y = 5;
+
+    assert(x + y == 8, 42);
+}
+}
+// check: "ERROR { status_code: OUT_OF_GAS }"
+// check: "gas_used: 4,"
+// check: "Keep(OUT_OF_GAS)"

--- a/language/vm/src/errors.rs
+++ b/language/vm/src/errors.rs
@@ -62,12 +62,11 @@ impl VMError {
                 VMStatus::Error(StatusCode::ABORTED)
             }
 
-            // TODO Errors for OUT_OF_GAS do not always have index set
             (major_status, sub_status, location)
                 if major_status.status_type() == StatusType::Execution =>
             {
                 debug_assert!(
-                    offsets.len() == 1,
+                    offsets.len() == 1 || major_status == StatusCode::OUT_OF_GAS,
                     "Unexpected offsets. major_status: {:?}\
                     sub_status: {:?}\
                     location: {:?}\


### PR DESCRIPTION
A transaction may run out of gas when updating the global state, after executing the Move code, and in that case VMError:into_vm_status is called with no location or offset information. Ignoring the assertion (e.g., in a release build), the code does the right thing in that case: it reports VMStatus::Error(OUT_OF_GAS) instead of VMStatus::ExecutionFailure(OUT_OF_GAS). The ExecutionFailure status is supposed to be used for errors that occur while executing Move code, so an Error status seems correct. We generally do not use the same status code in different buckets, but OUT_OF_GAS is already handled that way elsewhere.

## Motivation

Fixes: #7614

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added a new test for this case