### PR TITLE
[State Sync] Remove unnecessary panic and clean up the network senders code.

### DIFF
--- a/state-sync/src/executor_proxy.rs
+++ b/state-sync/src/executor_proxy.rs
@@ -263,12 +263,9 @@ impl ExecutorProxyTrait for ExecutorProxy {
             .configs()
             .iter()
             .filter(|(id, cfg)| {
-                &self
-                    .on_chain_configs
-                    .configs()
-                    .get(id)
-                    .expect("missing on-chain config value in local copy")
-                    != cfg
+                &self.on_chain_configs.configs().get(id).unwrap_or_else(|| {
+                    panic!("Missing on-chain config value in local copy: {}", id)
+                }) != cfg
             })
             .map(|(id, _)| *id)
             .collect::<HashSet<_>>();


### PR DESCRIPTION
## Motivation

This PR removes an unnecessary panic in the state sync code. It also updates the code so that the request manager handles the "network senders" associated with each peer. This avoids us having to duplicate the "network senders" in both the coordinator and the request manager. 

Note: the fact that the coordinator contains so much state means that it's really easy for state sync components to leak into each other. At some point, it might make sense to reason about encapsulation and a correct code structure, but it's probably not worth it giving the direction state sync is going to take.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass.

## Related PRs

This relates to: https://github.com/diem/diem/issues/6795