### PR TITLE
[gha] split code gen unit tests out, bump unit test timeout by 10 minutes

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -138,7 +138,7 @@ jobs:
 
   unit-test:
     runs-on: ubuntu-latest-xl
-    timeout-minutes: 40
+    timeout-minutes: 50
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' }}
     container:
@@ -167,6 +167,31 @@ jobs:
           TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
           SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
           SCCACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
+      - uses: ./.github/actions/build-teardown
+
+  codegen-unit-test:
+    runs-on: ubuntu-latest-xl
+    timeout-minutes: 60
+    needs: prepare
+    if: ${{ needs.prepare.outputs.test-rust == 'true' }}
+    container:
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      volumes:
+        - "/home/runner/work/diem/diem:/opt/git/diem"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0 #get all the history!!!
+      - uses: ./.github/actions/check-machine
+        with:
+          webhook-gha-hardware: ${{ secrets.WEBHOOK_GHA_HARDWARE }}
+      - uses: ./.github/actions/build-setup
+      - uses: actions/cache@v2.1.4
+        with:
+          path: "/opt/cargo/git\n/opt/cargo/registry\n/opt/cargo/.package-cache"
+          key: crates-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: "crates-${{ runner.os }}"
       - name: run codegen unit tests
         run: $pre_command && cargo x test --jobs ${max_threads} -p transaction-builder-generator --unit --changed-since "origin/$TARGET_BRANCH" -- --ignored
         env:
@@ -267,8 +292,8 @@ jobs:
           webhook-gha-hardware: ${{ secrets.WEBHOOK_GHA_HARDWARE }}
       - name: install expect
         run: |
-            sudo apt --assume-yes update
-            sudo apt --assume-yes install expect
+          sudo apt --assume-yes update
+          sudo apt --assume-yes install expect
       - name: build validator docker image
         run: docker/diem-build.sh docker/validator/Dockerfile libra/validator:test
       - name: build faucet image
@@ -409,6 +434,7 @@ jobs:
       - non-rust-lint
       - lint
       - unit-test
+      - codegen-unit-test
       - e2e-test
       - docker-compose-test
       - crypto-unit-test
@@ -421,6 +447,7 @@ jobs:
           echo non-rust-lint: ${{ needs.non-rust-lint.result }}
           echo lint: ${{ needs.lint.result }}
           echo unit-test: ${{ needs.unit-test.result }}
+          echo codegen-unit-test: ${{ needs.codegen-unit-test.result }}
           echo e2e-test: ${{ needs.e2e-test.result }}
           echo docker-compose-test: ${{ needs.docker-compose-test.result }}
           echo crypto-unit-test: ${{ needs.crypto-unit-test.result }}
@@ -432,6 +459,7 @@ jobs:
             && (needs.non-rust-lint.result=='success' || needs.non-rust-lint.result=='skipped')
             && (needs.lint.result=='success' || needs.lint.result=='skipped')
             && (needs.unit-test.result=='success' || needs.unit-test.result=='skipped')
+            && (needs.codegen-unit-test.result=='success' || needs.codegen-unit-test.result=='skipped')
             && (needs.e2e-test.result=='success' || needs.e2e-test.result=='skipped')
             && (needs.docker-compose-test.result=='success' || needs.docker-compose-test.result=='skipped')
             && (needs.crypto-unit-test.result=='success' || needs.crypto-unit-test.result=='skipped')


### PR DESCRIPTION
## Motivation

Prevent unit test timeouts, that will block prs from landing on CI.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

CI, hopefully.

## Related PRs

All of 'em you might want to land.

## If targetting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
