### PR TITLE
[State Sync] Remove anyhow and use structured errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6638,7 +6638,6 @@ dependencies = [
 name = "state-sync"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "bcs",
  "bytes 1.0.1",
  "channel",

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -100,7 +100,10 @@ impl StateComputer for ExecutionProxy {
         // Similarily, after the state synchronization, we have to reset the cache
         // of BlockExecutor to guarantee the latest committed state is up to date.
         self.execution_correctness_client.lock().reset()?;
-        res?;
-        Ok(())
+
+        res.map_err(|error| {
+            let anyhow_error: anyhow::Error = error.into();
+            anyhow_error.into()
+        })
     }
 }

--- a/state-sync/Cargo.toml
+++ b/state-sync/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0.38"
 bcs = "0.1.2"
 fail = "0.4.0"
 futures = "0.3.12"

--- a/state-sync/src/chunk_response.rs
+++ b/state-sync/src/chunk_response.rs
@@ -86,7 +86,7 @@ impl fmt::Display for GetChunkResponse {
                 let last_version = first_version
                     .checked_add(self.txn_list_with_proof.len() as u64)
                     .and_then(|v| v.checked_sub(1)) // last_version = first_version + txns.len() - 1
-                    .map(|v| format!("{}", v)) // format last_version as a string
+                    .map(|v| v.to_string())
                     .unwrap_or_else(|| "Last version has overflown!".into());
                 format!("versions [{} - {}]", first_version, last_version)
             }

--- a/state-sync/src/client.rs
+++ b/state-sync/src/client.rs
@@ -1,8 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{counters, shared_components::SyncState};
-use anyhow::{format_err, Result};
+use crate::{counters, error::Error, shared_components::SyncState};
 use diem_mempool::CommitResponse;
 use diem_types::{
     contract_event::ContractEvent, ledger_info::LedgerInfoWithSignatures, transaction::Transaction,
@@ -17,14 +16,14 @@ use tokio::time::timeout;
 
 /// A sync request for a specified target ledger info.
 pub struct SyncRequest {
-    pub callback: oneshot::Sender<Result<()>>,
+    pub callback: oneshot::Sender<Result<(), Error>>,
     pub last_commit_timestamp: SystemTime,
     pub target: LedgerInfoWithSignatures,
 }
 
 /// A commit notification to notify state sync of new commits.
 pub struct CommitNotification {
-    pub callback: oneshot::Sender<Result<CommitResponse>>,
+    pub callback: oneshot::Sender<Result<CommitResponse, Error>>,
     pub committed_transactions: Vec<Transaction>,
     pub reconfiguration_events: Vec<ContractEvent>,
 }
@@ -34,7 +33,7 @@ pub enum CoordinatorMessage {
     SyncRequest(Box<SyncRequest>), // Initiate a new sync request for a given target.
     CommitNotification(Box<CommitNotification>), // Notify state sync about committed transactions.
     GetSyncState(oneshot::Sender<SyncState>), // Return the local sync state.
-    WaitForInitialization(oneshot::Sender<Result<()>>), // Wait until state sync is initialized to the waypoint.
+    WaitForInitialization(oneshot::Sender<Result<(), Error>>), // Wait until state sync is initialized to the waypoint.
 }
 
 /// A client used for communicating with a StateSyncCoordinator.
@@ -58,7 +57,10 @@ impl StateSyncClient {
 
     /// Sync node's state to target ledger info (LI).
     /// In case of success (`Result::Ok`) the LI of storage is at the given target.
-    pub fn sync_to(&self, target: LedgerInfoWithSignatures) -> impl Future<Output = Result<()>> {
+    pub fn sync_to(
+        &self,
+        target: LedgerInfoWithSignatures,
+    ) -> impl Future<Output = Result<(), Error>> {
         let mut sender = self.coordinator_sender.clone();
         let (cb_sender, cb_receiver) = oneshot::channel();
         let request = SyncRequest {
@@ -80,7 +82,7 @@ impl StateSyncClient {
         &self,
         committed_txns: Vec<Transaction>,
         reconfig_events: Vec<ContractEvent>,
-    ) -> impl Future<Output = Result<()>> {
+    ) -> impl Future<Output = Result<(), Error>> {
         let mut sender = self.coordinator_sender.clone();
         let (cb_sender, cb_receiver) = oneshot::channel();
 
@@ -103,8 +105,8 @@ impl StateSyncClient {
                     counters::COMMIT_FLOW_FAIL
                         .with_label_values(&[counters::STATE_SYNC_LABEL])
                         .inc();
-                    Err(format_err!(
-                        "[State Sync Client] Timeout: failed to receive commit() ack in time!"
+                    Err(Error::UnexpectedError(
+                        "State sync client timeout: failed to receive commit() ack in time!".into(),
                     ))
                 }
                 Ok(response) => {
@@ -112,10 +114,10 @@ impl StateSyncClient {
                     if response.success {
                         Ok(())
                     } else {
-                        Err(format_err!(
-                            "[State Sync Client] Failed: commit() returned an error: {:?}",
+                        Err(Error::UnexpectedError(format!(
+                            "State sync client failed: commit() returned an error: {:?}",
                             response.error_message
-                        ))
+                        )))
                     }
                 }
             }
@@ -125,7 +127,7 @@ impl StateSyncClient {
     /// Returns information about the state sync internal state. This should only
     /// be used by tests.
     // TODO(joshlind): remove this once unit tests are added!
-    pub fn get_state(&self) -> impl Future<Output = Result<SyncState>> {
+    pub fn get_state(&self) -> impl Future<Output = Result<SyncState, Error>> {
         let mut sender = self.coordinator_sender.clone();
         let (cb_sender, cb_receiver) = oneshot::channel();
 
@@ -138,7 +140,7 @@ impl StateSyncClient {
     }
 
     /// Waits until state sync is caught up with the waypoint specified in the local config.
-    pub fn wait_until_initialized(&self) -> impl Future<Output = Result<()>> {
+    pub fn wait_until_initialized(&self) -> impl Future<Output = Result<(), Error>> {
         let mut sender = self.coordinator_sender.clone();
         let (cb_sender, cb_receiver) = oneshot::channel();
 

--- a/state-sync/src/coordinator.rs
+++ b/state-sync/src/coordinator.rs
@@ -448,7 +448,7 @@ impl<T: ExecutorProxyTrait> StateSyncCoordinator<T> {
             Ok(()) => CommitResponse::success(),
             Err(error) => {
                 error!(LogSchema::new(LogEntry::CommitFlow).error(&error));
-                CommitResponse::error(format!("{}", error))
+                CommitResponse::error(error.to_string())
             }
         };
 
@@ -827,10 +827,10 @@ impl<T: ExecutorProxyTrait> StateSyncCoordinator<T> {
                 .executor_proxy
                 .get_epoch_change_ledger_info(request.current_epoch)?;
             if end_of_epoch_li.ledger_info().version() < request.known_version {
-                return Err(Error::UnexpectedError(format!(                "Waypoint request's current_epoch (epoch {}, version {}) < waypoint request's known_version {}",
-                                                                          end_of_epoch_li.ledger_info().epoch(),
-                                                                          end_of_epoch_li.ledger_info().version(),
-                                                                          request.known_version,)));
+                return Err(Error::UnexpectedError(format!("Waypoint request's current_epoch (epoch {}, version {}) < waypoint request's known_version {}",
+                                                          end_of_epoch_li.ledger_info().epoch(),
+                                                          end_of_epoch_li.ledger_info().version(),
+                                                          request.known_version,)));
             }
             let num_txns_until_end_of_epoch =
                 end_of_epoch_li.ledger_info().version() - request.known_version;
@@ -972,7 +972,7 @@ impl<T: ExecutorProxyTrait> StateSyncCoordinator<T> {
         }
         .map_err(|error| {
             self.request_manager.process_invalid_chunk(&peer);
-            Error::ProcessInvalidChunk(format!("{}", error))
+            Error::ProcessInvalidChunk(error.to_string())
         })?;
 
         // Update counters and logs with processed chunk information

--- a/state-sync/src/coordinator.rs
+++ b/state-sync/src/coordinator.rs
@@ -887,7 +887,7 @@ impl<T: ExecutorProxyTrait> StateSyncCoordinator<T> {
             .inc();
 
         send_result.map_err(|e| {
-            error!(log.error(&e.into()));
+            error!(log.error(&e));
             format_err!("Network error in sending chunk response to {}", peer)
         })
     }

--- a/state-sync/src/coordinator.rs
+++ b/state-sync/src/coordinator.rs
@@ -1429,7 +1429,11 @@ impl<T: ExecutorProxyTrait> StateSyncCoordinator<T> {
         } else {
             None
         };
-        self.waypoint.verify(waypoint_li.ledger_info())?;
+        self.waypoint
+            .verify(waypoint_li.ledger_info())
+            .map_err(|error| {
+                Error::UnexpectedError(format!("Waypoint verification failed: {}", error))
+            })?;
 
         self.validate_and_store_chunk(txn_list_with_proof, waypoint_li, end_of_epoch_li_to_commit)?;
         self.log_highest_seen_version(None);

--- a/state-sync/src/error.rs
+++ b/state-sync/src/error.rs
@@ -57,18 +57,18 @@ pub enum Error {
 
 impl From<NetworkError> for Error {
     fn from(error: NetworkError) -> Self {
-        Error::NetworkError(format!("{}", error))
+        Error::NetworkError(error.to_string())
     }
 }
 
 impl From<SendError> for Error {
     fn from(error: SendError) -> Self {
-        Error::UnexpectedError(format!("{}", error))
+        Error::UnexpectedError(error.to_string())
     }
 }
 
 impl From<Canceled> for Error {
     fn from(canceled: Canceled) -> Self {
-        Error::SenderDroppedError(format!("{}", canceled))
+        Error::SenderDroppedError(canceled.to_string())
     }
 }

--- a/state-sync/src/error.rs
+++ b/state-sync/src/error.rs
@@ -56,7 +56,6 @@ pub enum Error {
     UnexpectedError(String),
 }
 
-// TODO(joshlind): remove this once we move from anyhow error to thiserror in state sync!
 impl From<anyhow::Error> for Error {
     fn from(error: anyhow::Error) -> Self {
         UnexpectedError(format!("{}", error))

--- a/state-sync/src/error.rs
+++ b/state-sync/src/error.rs
@@ -3,6 +3,7 @@
 
 use crate::error::Error::UnexpectedError;
 use diem_types::transaction::Version;
+use network::error::NetworkError;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -18,6 +19,8 @@ pub enum Error {
     IntegerOverflow(String),
     #[error("Received an invalid chunk request: {0}")]
     InvalidChunkRequest(String),
+    #[error("Encountered a network error: {0}")]
+    NetworkError(String),
     #[error("No peers are currently available: {0}")]
     NoAvailablePeers(String),
     #[error("No sync request was issued by consensus: {0}")]
@@ -54,5 +57,11 @@ pub enum Error {
 impl From<anyhow::Error> for Error {
     fn from(error: anyhow::Error) -> Self {
         UnexpectedError(format!("{}", error))
+    }
+}
+
+impl From<NetworkError> for Error {
+    fn from(error: NetworkError) -> Self {
+        Error::NetworkError(format!("{}", error))
     }
 }

--- a/state-sync/src/error.rs
+++ b/state-sync/src/error.rs
@@ -1,7 +1,6 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::error::Error::UnexpectedError;
 use diem_types::transaction::Version;
 use futures::channel::{mpsc::SendError, oneshot::Canceled};
 use network::error::NetworkError;
@@ -54,12 +53,6 @@ pub enum Error {
     UninitializedError(String),
     #[error("Unexpected error: {0}")]
     UnexpectedError(String),
-}
-
-impl From<anyhow::Error> for Error {
-    fn from(error: anyhow::Error) -> Self {
-        UnexpectedError(format!("{}", error))
-    }
 }
 
 impl From<NetworkError> for Error {

--- a/state-sync/src/executor_proxy.rs
+++ b/state-sync/src/executor_proxy.rs
@@ -216,7 +216,7 @@ impl ExecutorProxyTrait for ExecutorProxy {
         let mut epoch_ending_ledger_infos = self
             .storage
             .get_epoch_ending_ledger_infos(epoch, next_epoch)
-            .map_err(|error| Error::UnexpectedError(format!("{}", error)))?;
+            .map_err(|error| Error::UnexpectedError(error.to_string()))?;
 
         epoch_ending_ledger_infos
             .ledger_info_with_sigs
@@ -235,13 +235,13 @@ impl ExecutorProxyTrait for ExecutorProxy {
     ) -> Result<LedgerInfoWithSignatures, Error> {
         self.storage
             .get_epoch_ending_ledger_info(version)
-            .map_err(|error| Error::UnexpectedError(format!("{}", error)))
+            .map_err(|error| Error::UnexpectedError(error.to_string()))
     }
 
     fn get_version_timestamp(&self, version: u64) -> Result<u64, Error> {
         self.storage
             .get_block_timestamp(version)
-            .map_err(|error| Error::UnexpectedError(format!("{}", error)))
+            .map_err(|error| Error::UnexpectedError(error.to_string()))
     }
 
     fn publish_on_chain_config_updates(&mut self, events: Vec<ContractEvent>) -> Result<(), Error> {
@@ -287,7 +287,7 @@ impl ExecutorProxyTrait for ExecutorProxy {
                     error!(
                         LogSchema::event_log(LogEntry::Reconfig, LogEvent::PublishError)
                             .subscription_name(subscription.name.clone())
-                            .error(&Error::UnexpectedError(format!("{}", e))),
+                            .error(&Error::UnexpectedError(e.to_string())),
                         "Failed to publish reconfig notification to subscription {}",
                         subscription.name
                     );

--- a/state-sync/src/lib.rs
+++ b/state-sync/src/lib.rs
@@ -13,7 +13,7 @@ pub mod chunk_response;
 pub mod client;
 pub mod coordinator;
 mod counters;
-mod error;
+pub mod error;
 pub mod executor_proxy;
 mod logging;
 pub mod network;

--- a/state-sync/src/logging.rs
+++ b/state-sync/src/logging.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    chunk_request::GetChunkRequest, chunk_response::GetChunkResponse,
+    chunk_request::GetChunkRequest, chunk_response::GetChunkResponse, error::Error,
     request_manager::ChunkRequestInfo,
 };
 use diem_config::config::PeerNetworkId;
@@ -17,7 +17,7 @@ pub struct LogSchema<'a> {
     name: LogEntry,
     event: Option<LogEvent>,
     #[schema(debug)]
-    error: Option<&'a anyhow::Error>, // TODO(joshlind): remove anyhow once we migrate!
+    error: Option<&'a Error>,
     #[schema(display)]
     peer: Option<&'a PeerNetworkId>,
     is_upstream_peer: Option<bool>,

--- a/state-sync/src/network.rs
+++ b/state-sync/src/network.rs
@@ -3,12 +3,13 @@
 
 //! Interface between State Sync and Network layers.
 
-use crate::{chunk_request::GetChunkRequest, chunk_response::GetChunkResponse, counters};
+use crate::{
+    chunk_request::GetChunkRequest, chunk_response::GetChunkResponse, counters, error::Error,
+};
 use channel::message_queues::QueueStyle;
 use diem_metrics::IntCounterVec;
 use diem_types::PeerId;
 use network::{
-    error::NetworkError,
     peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
     protocols::network::{NetworkEvents, NetworkSender, NewNetworkSender},
     ProtocolId,
@@ -57,13 +58,9 @@ impl NewNetworkSender for StateSyncSender {
 }
 
 impl StateSyncSender {
-    pub fn send_to(
-        &mut self,
-        recipient: PeerId,
-        message: StateSyncMessage,
-    ) -> Result<(), NetworkError> {
+    pub fn send_to(&mut self, recipient: PeerId, message: StateSyncMessage) -> Result<(), Error> {
         let protocol = ProtocolId::StateSyncDirectSend;
-        self.inner.send_to(recipient, protocol, message)
+        Ok(self.inner.send_to(recipient, protocol, message)?)
     }
 }
 

--- a/state-sync/src/request_manager.rs
+++ b/state-sync/src/request_manager.rs
@@ -305,7 +305,7 @@ impl RequestManager {
             let curr_log = log.clone().peer(&peer);
             let result_label = if let Err(e) = send_result {
                 failed_peer_sends.push(peer.clone());
-                error!(curr_log.event(LogEvent::NetworkSendError).error(&e.into()));
+                error!(curr_log.event(LogEvent::NetworkSendError).error(&e));
                 counters::SEND_FAIL_LABEL
             } else {
                 debug!(curr_log.event(LogEvent::Success));
@@ -323,10 +323,10 @@ impl RequestManager {
         if failed_peer_sends.is_empty() {
             Ok(())
         } else {
-            return Err(Error::UnexpectedError(format!(
+            Err(Error::UnexpectedError(format!(
                 "Failed to send chunk request to: {:?}",
                 failed_peer_sends
-            )));
+            )))
         }
     }
 

--- a/state-sync/src/shared_components.rs
+++ b/state-sync/src/shared_components.rs
@@ -69,7 +69,9 @@ impl SyncState {
     }
 
     pub fn verify_ledger_info(&self, ledger_info: &LedgerInfoWithSignatures) -> Result<(), Error> {
-        self.trusted_epoch_state.verify(ledger_info)
+        self.trusted_epoch_state
+            .verify(ledger_info)
+            .map_err(|error| error.into())
     }
 }
 

--- a/state-sync/src/shared_components.rs
+++ b/state-sync/src/shared_components.rs
@@ -71,7 +71,7 @@ impl SyncState {
     pub fn verify_ledger_info(&self, ledger_info: &LedgerInfoWithSignatures) -> Result<(), Error> {
         self.trusted_epoch_state
             .verify(ledger_info)
-            .map_err(|error| Error::UnexpectedError(format!("{}", error)))
+            .map_err(|error| Error::UnexpectedError(error.to_string()))
     }
 }
 

--- a/state-sync/src/shared_components.rs
+++ b/state-sync/src/shared_components.rs
@@ -71,7 +71,7 @@ impl SyncState {
     pub fn verify_ledger_info(&self, ledger_info: &LedgerInfoWithSignatures) -> Result<(), Error> {
         self.trusted_epoch_state
             .verify(ledger_info)
-            .map_err(|error| error.into())
+            .map_err(|error| Error::UnexpectedError(format!("{}", error)))
     }
 }
 

--- a/state-sync/src/shared_components.rs
+++ b/state-sync/src/shared_components.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
+use crate::error::Error;
 use diem_types::{
     epoch_change::Verifier, epoch_state::EpochState, ledger_info::LedgerInfoWithSignatures,
 };
@@ -68,7 +68,7 @@ impl SyncState {
         self.trusted_epoch_state.epoch
     }
 
-    pub fn verify_ledger_info(&self, ledger_info: &LedgerInfoWithSignatures) -> Result<()> {
+    pub fn verify_ledger_info(&self, ledger_info: &LedgerInfoWithSignatures) -> Result<(), Error> {
         self.trusted_epoch_state.verify(ledger_info)
     }
 }

--- a/state-sync/tests/test_harness.rs
+++ b/state-sync/tests/test_harness.rs
@@ -61,6 +61,7 @@ use rand::{rngs::StdRng, SeedableRng};
 use state_sync::{
     bootstrapper::StateSyncBootstrapper,
     client::StateSyncClient,
+    error::Error,
     executor_proxy::ExecutorProxyTrait,
     network::{StateSyncEvents, StateSyncSender},
     shared_components::SyncState,
@@ -484,7 +485,7 @@ impl StateSyncEnvironment {
 }
 
 pub fn default_handler() -> MockRpcHandler {
-    Box::new(|resp| -> Result<TransactionListWithProof> { Ok(resp) })
+    Box::new(|resp| -> Result<TransactionListWithProof, Error> { Ok(resp) })
 }
 
 // Returns the initial peers with their signatures
@@ -814,7 +815,10 @@ impl MockStorage {
 }
 
 pub type MockRpcHandler = Box<
-    dyn Fn(TransactionListWithProof) -> Result<TransactionListWithProof> + Send + Sync + 'static,
+    dyn Fn(TransactionListWithProof) -> Result<TransactionListWithProof, Error>
+        + Send
+        + Sync
+        + 'static,
 >;
 
 pub struct MockExecutorProxy {


### PR DESCRIPTION
## Motivation

This PR cleans up error handling in the state sync code base. Specifically, it: (i) removes the use of anyhow errors and replaces them with the structured error types; and (ii) makes the code more consistent regarding failure cases and error messages (e.g., we remove the use of anyhow::bail and anyhow::ensure, and standardize the error outputs). The PR offers a number of commits going through each of the files in state sync.

Note:
- This change doesn't affect backward compatibility. Error types on messages passed between components within each node have changed (e.g., see client.rs), but these messages are not passed between nodes, so we shouldn't need to worry about breaking changes.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass.

## Related PRs

This relates to: https://github.com/diem/diem/issues/6795