### PR TITLE
[move-lang] Added UniqueSet. Cleanup around UniqueMap

### DIFF
--- a/language/move-lang/src/cfgir/ast.rs
+++ b/language/move-lang/src/cfgir/ast.rs
@@ -165,7 +165,7 @@ fn remap_labels_cmd(remapping: &BTreeMap<Label, Label>, sp!(_, cmd_): &mut Comma
 impl AstDebug for Program {
     fn ast_debug(&self, w: &mut AstWriter) {
         let Program { modules, scripts } = self;
-        for (m, mdef) in modules {
+        for (m, mdef) in modules.key_cloned_iter() {
             w.write(&format!("module {}", m));
             w.block(|w| mdef.ast_debug(w));
             w.new_line();
@@ -187,7 +187,7 @@ impl AstDebug for Script {
             function_name,
             function,
         } = self;
-        for cdef in constants {
+        for cdef in constants.key_cloned_iter() {
             cdef.ast_debug(w);
             w.new_line();
         }
@@ -210,15 +210,15 @@ impl AstDebug for ModuleDefinition {
             w.writeln("source module")
         }
         w.writeln(&format!("dependency order #{}", dependency_order));
-        for sdef in structs {
+        for sdef in structs.key_cloned_iter() {
             sdef.ast_debug(w);
             w.new_line();
         }
-        for cdef in constants {
+        for cdef in constants.key_cloned_iter() {
             cdef.ast_debug(w);
             w.new_line();
         }
-        for fdef in functions {
+        for fdef in functions.key_cloned_iter() {
             fdef.ast_debug(w);
             w.new_line();
         }
@@ -296,7 +296,7 @@ impl AstDebug for (FunctionName, &Function) {
             } => w.block(|w| {
                 w.write("locals:");
                 w.indent(4, |w| {
-                    w.list(locals, ",", |w, (v, st)| {
+                    w.list(locals, ",", |w, (_, v, st)| {
                         w.write(&format!("{}: ", v));
                         st.ast_debug(w);
                         true

--- a/language/move-lang/src/cfgir/borrows/mod.rs
+++ b/language/move-lang/src/cfgir/borrows/mod.rs
@@ -25,7 +25,7 @@ struct BorrowSafety {
 impl BorrowSafety {
     fn new<T>(local_types: &UniqueMap<Var, T>) -> Self {
         let mut local_numbers = UniqueMap::new();
-        for (idx, (v, _)) in local_types.iter().enumerate() {
+        for (idx, (v, _)) in local_types.key_cloned_iter().enumerate() {
             local_numbers.add(v, idx).unwrap();
         }
         Self { local_numbers }

--- a/language/move-lang/src/cfgir/borrows/state.rs
+++ b/language/move-lang/src/cfgir/borrows/state.rs
@@ -672,7 +672,7 @@ impl BorrowState {
 
         self.locals
             .iter_mut()
-            .for_each(|(_, v)| v.remap_refs(&id_map));
+            .for_each(|(_, _, v)| v.remap_refs(&id_map));
         self.borrows.remap_refs(&id_map);
         self.next_id = self.locals.len() + 1;
     }

--- a/language/move-lang/src/cfgir/locals/state.rs
+++ b/language/move-lang/src/cfgir/locals/state.rs
@@ -41,7 +41,7 @@ impl LocalStates {
         let mut states = LocalStates {
             local_states: UniqueMap::new(),
         };
-        for (var, _) in local_types.iter() {
+        for (var, _) in local_types.key_cloned_iter() {
             let local_state = LocalState::Unavailable(var.loc());
             states.set_state(var.clone(), local_state)
         }
@@ -64,7 +64,7 @@ impl LocalStates {
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (Var, &LocalState)> {
-        self.local_states.iter()
+        self.local_states.key_cloned_iter()
     }
 
     #[allow(dead_code)]
@@ -85,7 +85,7 @@ impl AbstractDomain for LocalStates {
     fn join(&mut self, other: &Self) -> JoinResult {
         use LocalState as L;
         let mut result = JoinResult::Unchanged;
-        for (local, other_state) in other.local_states.iter() {
+        for (local, other_state) in other.local_states.key_cloned_iter() {
             match (self.get_state(&local), other_state) {
                 // equal so nothing to do
                 (L::Unavailable(_), L::Unavailable(_))
@@ -98,7 +98,7 @@ impl AbstractDomain for LocalStates {
                 (_, L::MaybeUnavailable { .. }) => {
                     result = JoinResult::Changed;
                     let state = other_state.clone();
-                    self.set_state(local.clone(), state)
+                    self.set_state(local, state)
                 }
 
                 // Available in one but not the other, so maybe unavailable
@@ -112,7 +112,7 @@ impl AbstractDomain for LocalStates {
                         unavailable,
                     };
 
-                    self.set_state(local.clone(), state)
+                    self.set_state(local, state)
                 }
             }
         }

--- a/language/move-lang/src/compiled_unit.rs
+++ b/language/move-lang/src/compiled_unit.rs
@@ -56,7 +56,7 @@ pub enum CompiledUnit {
 impl CompiledUnit {
     pub fn name(&self) -> String {
         match self {
-            CompiledUnit::Module { ident, .. } => format!("{}", &ident.0.value.name),
+            CompiledUnit::Module { ident, .. } => ident.value.1.to_owned(),
             CompiledUnit::Script { key, .. } => key.to_owned(),
         }
     }

--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -377,7 +377,7 @@ impl fmt::Display for SpecId {
 impl AstDebug for Program {
     fn ast_debug(&self, w: &mut AstWriter) {
         let Program { modules, scripts } = self;
-        for (m, mdef) in modules {
+        for (m, mdef) in modules.key_cloned_iter() {
             w.write(&format!("module {}", m));
             w.block(|w| mdef.ast_debug(w));
             w.new_line();
@@ -400,7 +400,7 @@ impl AstDebug for Script {
             function,
             specs,
         } = self;
-        for cdef in constants {
+        for cdef in constants.key_cloned_iter() {
             cdef.ast_debug(w);
             w.new_line();
         }
@@ -427,15 +427,15 @@ impl AstDebug for ModuleDefinition {
         } else {
             "library module"
         });
-        for sdef in structs {
+        for sdef in structs.key_cloned_iter() {
             sdef.ast_debug(w);
             w.new_line();
         }
-        for cdef in constants {
+        for cdef in constants.key_cloned_iter() {
             cdef.ast_debug(w);
             w.new_line();
         }
-        for fdef in functions {
+        for fdef in functions.key_cloned_iter() {
             fdef.ast_debug(w);
             w.new_line();
         }
@@ -467,7 +467,7 @@ impl AstDebug for (StructName, &StructDefinition) {
         type_parameters.ast_debug(w);
         if let StructFields::Defined(fields) = fields {
             w.block(|w| {
-                w.list(fields, ",", |w, (f, idx_st)| {
+                w.list(fields, ",", |w, (_, f, idx_st)| {
                     let (idx, st) = idx_st;
                     w.write(&format!("{}#{}: ", idx, f));
                     st.ast_debug(w);
@@ -788,7 +788,7 @@ impl AstDebug for Exp_ {
                     w.write(">");
                 }
                 w.write("{");
-                w.comma(fields, |w, (f, idx_e)| {
+                w.comma(fields, |w, (_, f, idx_e)| {
                     let (idx, e) = idx_e;
                     w.write(&format!("{}#{}: ", idx, f));
                     e.ast_debug(w);
@@ -968,7 +968,7 @@ impl AstDebug for LValue_ {
                     w.write(">");
                 }
                 w.write("{");
-                w.comma(fields, |w, (f, idx_b)| {
+                w.comma(fields, |w, (_, f, idx_b)| {
                     let (idx, b) = idx_b;
                     w.write(&format!("{}#{}: ", idx, f));
                     b.ast_debug(w);

--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -193,7 +193,7 @@ fn module(
     assert!(context.address == None);
     set_sender_address(context, module_def.loc, address);
     let (mident, mod_) = module_(context, module_def);
-    if let Err((old_loc, _)) = module_map.add(mident.clone(), mod_) {
+    if let Err((mident, (old_loc, _))) = module_map.add(mident, mod_) {
         let mmsg = format!("Duplicate definition for module '{}'", mident);
         context.error(vec![
             (mident.loc(), mmsg),
@@ -645,7 +645,7 @@ fn struct_fields(
     let mut field_map = UniqueMap::new();
     for (idx, (field, pt)) in pfields_vec.into_iter().enumerate() {
         let t = type_(context, pt);
-        if let Err(old_loc) = field_map.add(field.clone(), (idx, t)) {
+        if let Err((field, old_loc)) = field_map.add(field, (idx, t)) {
             context.error(vec![
                 (
                     field.loc(),
@@ -1354,7 +1354,7 @@ fn fields<T>(
 ) -> Fields<T> {
     let mut fmap = UniqueMap::new();
     for (idx, (field, x)) in xs.into_iter().enumerate() {
-        if let Err(old_loc) = fmap.add(field.clone(), (idx, x)) {
+        if let Err((field, old_loc)) = fmap.add(field, (idx, x)) {
             context.error(vec![
                 (loc, format!("Invalid {}", case)),
                 (

--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -1582,7 +1582,7 @@ fn unbound_names_exp(unbound: &mut BTreeSet<Name>, sp!(_, e_): &E::Exp) {
             unbound.insert(n.clone());
         }
         EE::Call(_, _, sp!(_, es_)) => unbound_names_exps(unbound, es_),
-        EE::Pack(_, _, es) => unbound_names_exps(unbound, es.iter().map(|(_, (_, e))| e)),
+        EE::Pack(_, _, es) => unbound_names_exps(unbound, es.iter().map(|(_, _, (_, e))| e)),
         EE::IfElse(econd, et, ef) => {
             unbound_names_exp(unbound, ef);
             unbound_names_exp(unbound, et);
@@ -1692,7 +1692,7 @@ fn unbound_names_bind(unbound: &mut BTreeSet<Name>, sp!(_, l_): &E::LValue) {
         }
         EL::Unpack(_, _, efields) => efields
             .iter()
-            .for_each(|(_, (_, l))| unbound_names_bind(unbound, l)),
+            .for_each(|(_, _, (_, l))| unbound_names_bind(unbound, l)),
     }
 }
 
@@ -1713,7 +1713,7 @@ fn unbound_names_assign(unbound: &mut BTreeSet<Name>, sp!(_, l_): &E::LValue) {
         }
         EL::Unpack(_, _, efields) => efields
             .iter()
-            .for_each(|(_, (_, l))| unbound_names_assign(unbound, l)),
+            .for_each(|(_, _, (_, l))| unbound_names_assign(unbound, l)),
     }
 }
 

--- a/language/move-lang/src/hlir/ast.rs
+++ b/language/move-lang/src/hlir/ast.rs
@@ -537,7 +537,7 @@ impl std::fmt::Display for Label {
 impl AstDebug for Program {
     fn ast_debug(&self, w: &mut AstWriter) {
         let Program { modules, scripts } = self;
-        for (m, mdef) in modules {
+        for (m, mdef) in modules.key_cloned_iter() {
             w.write(&format!("module {}", m));
             w.block(|w| mdef.ast_debug(w));
             w.new_line();
@@ -559,7 +559,7 @@ impl AstDebug for Script {
             function_name,
             function,
         } = self;
-        for cdef in constants {
+        for cdef in constants.key_cloned_iter() {
             cdef.ast_debug(w);
             w.new_line();
         }
@@ -582,15 +582,15 @@ impl AstDebug for ModuleDefinition {
             w.writeln("source module")
         }
         w.writeln(&format!("dependency order #{}", dependency_order));
-        for sdef in structs {
+        for sdef in structs.key_cloned_iter() {
             sdef.ast_debug(w);
             w.new_line();
         }
-        for cdef in constants {
+        for cdef in constants.key_cloned_iter() {
             cdef.ast_debug(w);
             w.new_line();
         }
-        for fdef in functions {
+        for fdef in functions.key_cloned_iter() {
             fdef.ast_debug(w);
             w.new_line();
         }
@@ -668,7 +668,7 @@ impl AstDebug for (&UniqueMap<Var, SingleType>, &Block) {
         let (locals, body) = self;
         w.write("locals:");
         w.indent(4, |w| {
-            w.list(*locals, ",", |w, (v, st)| {
+            w.list(*locals, ",", |w, (_, v, st)| {
                 w.write(&format!("{}: ", v));
                 st.ast_debug(w);
                 true

--- a/language/move-lang/src/hlir/translate.rs
+++ b/language/move-lang/src/hlir/translate.rs
@@ -127,7 +127,7 @@ impl Context {
 
     pub fn add_struct_fields(&mut self, structs: &UniqueMap<StructName, H::StructDefinition>) {
         assert!(self.structs.is_empty());
-        for (sname, sdef) in structs.iter() {
+        for (sname, sdef) in structs.key_cloned_iter() {
             let mut fields = UniqueMap::new();
             let field_map = match &sdef.fields {
                 H::StructFields::Native(_) => continue,
@@ -591,7 +591,7 @@ fn declare_bind(context: &mut Context, sp!(_, bind_): &T::LValue) {
         }
         L::Unpack(_, _, _, fields) | L::BorrowUnpack(_, _, _, _, fields) => fields
             .iter()
-            .for_each(|(_, (_, (_, b)))| declare_bind(context, b)),
+            .for_each(|(_, _, (_, (_, b)))| declare_bind(context, b)),
     }
 }
 
@@ -1762,7 +1762,7 @@ fn check_unused_locals(
     let mut errors = Vec::new();
     // report unused locals
     for (v, _) in locals
-        .iter()
+        .key_cloned_iter()
         .filter(|(v, _)| !used.contains(v) && !v.starts_with_underscore())
     {
         let vstr = match display_var(v.value()) {

--- a/language/move-lang/src/naming/ast.rs
+++ b/language/move-lang/src/naming/ast.rs
@@ -512,7 +512,7 @@ impl fmt::Display for TypeName_ {
 impl AstDebug for Program {
     fn ast_debug(&self, w: &mut AstWriter) {
         let Program { modules, scripts } = self;
-        for (m, mdef) in modules {
+        for (m, mdef) in modules.key_cloned_iter() {
             w.write(&format!("module {}", m));
             w.block(|w| mdef.ast_debug(w));
             w.new_line();
@@ -534,7 +534,7 @@ impl AstDebug for Script {
             function_name,
             function,
         } = self;
-        for cdef in constants {
+        for cdef in constants.key_cloned_iter() {
             cdef.ast_debug(w);
             w.new_line();
         }
@@ -557,15 +557,15 @@ impl AstDebug for ModuleDefinition {
             w.writeln("source module")
         }
         w.writeln(&format!("dependency order #{}", dependency_order));
-        for sdef in structs {
+        for sdef in structs.key_cloned_iter() {
             sdef.ast_debug(w);
             w.new_line();
         }
-        for cdef in constants {
+        for cdef in constants.key_cloned_iter() {
             cdef.ast_debug(w);
             w.new_line();
         }
-        for fdef in functions {
+        for fdef in functions.key_cloned_iter() {
             fdef.ast_debug(w);
             w.new_line();
         }
@@ -592,7 +592,7 @@ impl AstDebug for (StructName, &StructDefinition) {
         type_parameters.ast_debug(w);
         if let StructFields::Defined(fields) = fields {
             w.block(|w| {
-                w.list(fields, ",", |w, (f, idx_st)| {
+                w.list(fields, ",", |w, (_, f, idx_st)| {
                     let (idx, st) = idx_st;
                     w.write(&format!("{}#{}: ", idx, f));
                     st.ast_debug(w);
@@ -829,7 +829,7 @@ impl AstDebug for Exp_ {
                     w.write(">");
                 }
                 w.write("{");
-                w.comma(fields, |w, (f, idx_e)| {
+                w.comma(fields, |w, (_, f, idx_e)| {
                     let (idx, e) = idx_e;
                     w.write(&format!("{}#{}: ", idx, f));
                     e.ast_debug(w);
@@ -1003,7 +1003,7 @@ impl AstDebug for LValue_ {
                     w.write(">");
                 }
                 w.write("{");
-                w.comma(fields, |w, (f, idx_b)| {
+                w.comma(fields, |w, (_, f, idx_b)| {
                     let (idx, b) = idx_b;
                     w.write(&format!("{}#{}: ", idx, f));
                     b.ast_debug(w);

--- a/language/move-lang/src/naming/translate.rs
+++ b/language/move-lang/src/naming/translate.rs
@@ -613,7 +613,7 @@ fn type_parameters(context: &mut Context, type_parameters: Vec<(Name, Kind)>) ->
                 name.value.to_string(),
                 ResolvedType::TParam(loc, tp.clone()),
             );
-            if let Err(old_loc) = unique_tparams.add(name.clone(), ()) {
+            if let Err((name, old_loc)) = unique_tparams.add(name, ()) {
                 let msg = format!("Duplicate type parameter declared with name '{}'", name);
                 context.error(vec![
                     (loc, msg),

--- a/language/move-lang/src/naming/uses.rs
+++ b/language/move-lang/src/naming/uses.rs
@@ -115,7 +115,7 @@ fn best_cycle_loc<'a>(
 
 fn module_defs(context: &mut Context, modules: &UniqueMap<ModuleIdent, N::ModuleDefinition>) {
     modules
-        .iter()
+        .key_cloned_iter()
         .for_each(|(mident, mdef)| module(context, mident, mdef))
 }
 
@@ -123,15 +123,15 @@ fn module(context: &mut Context, mident: ModuleIdent, mdef: &N::ModuleDefinition
     context.current_module = Some(mident);
     mdef.structs
         .iter()
-        .for_each(|(_, sdef)| struct_def(context, sdef));
+        .for_each(|(_, _, sdef)| struct_def(context, sdef));
     mdef.functions
         .iter()
-        .for_each(|(_, fdef)| function(context, fdef));
+        .for_each(|(_, _, fdef)| function(context, fdef));
 }
 
 fn struct_def(context: &mut Context, sdef: &N::StructDefinition) {
     if let N::StructFields::Defined(fields) = &sdef.fields {
-        fields.iter().for_each(|(_, (_, bt))| type_(context, bt));
+        fields.iter().for_each(|(_, _, (_, bt))| type_(context, bt));
     }
 }
 
@@ -215,7 +215,7 @@ fn lvalue(context: &mut Context, sp!(loc, a_): &N::LValue) {
     if let L::Unpack(m, _, bs_opt, f) = a_ {
         context.add_usage(m, *loc);
         types_opt(context, bs_opt);
-        lvalues(context, f.iter().map(|(_, (_, b))| b));
+        lvalues(context, f.iter().map(|(_, _, (_, b))| b));
     }
 }
 
@@ -273,7 +273,7 @@ fn exp(context: &mut Context, sp!(loc, e_): &N::Exp) {
         E::Pack(m, _, bs_opt, fes) => {
             context.add_usage(m, *loc);
             types_opt(context, bs_opt);
-            fes.iter().for_each(|(_, (_, e))| exp(context, e))
+            fes.iter().for_each(|(_, _, (_, e))| exp(context, e))
         }
 
         E::ExpList(es) => es.iter().for_each(|e| exp(context, e)),

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -578,15 +578,18 @@ pub type SequenceItem = Spanned<SequenceItem_>;
 impl TName for ModuleIdent {
     type Key = (Address, String);
     type Loc = (Loc, Loc);
+
     fn drop_loc(self) -> ((Loc, Loc), (Address, String)) {
         let inner = self.0.value;
         let (nloc, name_) = inner.name.drop_loc();
         ((self.0.loc, nloc), (inner.address, name_))
     }
+
     fn clone_drop_loc(&self) -> ((Loc, Loc), (Address, String)) {
         let (nloc, name_) = self.0.value.name.clone_drop_loc();
         ((self.0.loc, nloc), (self.0.value.address, name_))
     }
+
     fn add_loc(locs: (Loc, Loc), key: (Address, String)) -> ModuleIdent {
         let (iloc, nloc) = locs;
         let (address, name_str) = key;

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -18,12 +18,12 @@ macro_rules! new_name {
                 (self.0.loc, self.0.value)
             }
 
-            fn clone_drop_loc(&self) -> (Loc, String) {
-                (self.0.loc, self.0.value.clone())
-            }
-
             fn add_loc(loc: Loc, key: String) -> Self {
                 $n(sp(loc, key))
+            }
+
+            fn borrow(&self) -> (&Loc, &String) {
+                (&self.0.loc, &self.0.value)
             }
         }
 
@@ -584,12 +584,12 @@ impl TName for ModuleIdent {
         (self.locs, self.value)
     }
 
-    fn clone_drop_loc(&self) -> ((Loc, Loc), (Address, String)) {
-        (self.locs, self.value.clone())
-    }
-
     fn add_loc(locs: (Loc, Loc), value: (Address, String)) -> ModuleIdent {
         ModuleIdent { locs, value }
+    }
+
+    fn borrow(&self) -> (&(Loc, Loc), &(Address, String)) {
+        (&self.locs, &self.value)
     }
 }
 

--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -256,15 +256,13 @@ fn parse_module_ident(tokens: &mut Lexer<'_>) -> Result<ModuleIdent, Error> {
     let start_loc = tokens.start_loc();
     let address = parse_address(tokens)?;
     consume_token(tokens, Tok::ColonColon)?;
-    let name = parse_module_name(tokens)?;
+    let name = parse_module_name(tokens)?.0;
     let end_loc = tokens.previous_end_loc();
-    let m = ModuleIdent_ { address, name };
-    Ok(ModuleIdent(spanned(
-        tokens.file_name(),
-        start_loc,
-        end_loc,
-        m,
-    )))
+    let loc = make_loc(tokens.file_name(), start_loc, end_loc);
+    Ok(ModuleIdent {
+        locs: (loc, name.loc),
+        value: (address, name.value),
+    })
 }
 
 // Parse a module access (a variable, struct type, or function):

--- a/language/move-lang/src/shared/mod.rs
+++ b/language/move-lang/src/shared/mod.rs
@@ -14,6 +14,7 @@ use std::{
 pub mod ast_debug;
 pub mod remembering_unique_map;
 pub mod unique_map;
+pub mod unique_set;
 
 //**************************************************************************************************
 // Address

--- a/language/move-lang/src/shared/mod.rs
+++ b/language/move-lang/src/shared/mod.rs
@@ -134,8 +134,8 @@ pub trait TName: Eq + Ord + Clone {
     type Key: Ord + Clone;
     type Loc: Copy;
     fn drop_loc(self) -> (Self::Loc, Self::Key);
-    fn clone_drop_loc(&self) -> (Self::Loc, Self::Key);
     fn add_loc(loc: Self::Loc, key: Self::Key) -> Self;
+    fn borrow(&self) -> (&Self::Loc, &Self::Key);
 }
 
 pub trait Identifier {
@@ -154,12 +154,12 @@ impl TName for Name {
         (self.loc, self.value)
     }
 
-    fn clone_drop_loc(&self) -> (Loc, String) {
-        (self.loc, self.value.clone())
-    }
-
     fn add_loc(loc: Loc, key: String) -> Self {
         sp(loc, key)
+    }
+
+    fn borrow(&self) -> (&Loc, &String) {
+        (&self.loc, &self.value)
     }
 }
 

--- a/language/move-lang/src/shared/remembering_unique_map.rs
+++ b/language/move-lang/src/shared/remembering_unique_map.rs
@@ -32,7 +32,7 @@ impl<K: TName, V> RememberingUniqueMap<K, V> {
         self.map.len()
     }
 
-    pub fn add(&mut self, key: K, value: V) -> Result<(), K::Loc> {
+    pub fn add(&mut self, key: K, value: V) -> Result<(), (K, K::Loc)> {
         self.map.add(key, value)
     }
 

--- a/language/move-lang/src/shared/remembering_unique_map.rs
+++ b/language/move-lang/src/shared/remembering_unique_map.rs
@@ -199,7 +199,7 @@ impl<K: TName, V> IntoIterator for RememberingUniqueMap<K, V> {
 pub struct Iter<'a, K: TName, V>(unique_map::Iter<'a, K, V>);
 
 impl<'a, K: TName, V> Iterator for Iter<'a, K, V> {
-    type Item = (K, &'a V);
+    type Item = (K::Loc, &'a K::Key, &'a V);
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
@@ -211,7 +211,7 @@ impl<'a, K: TName, V> Iterator for Iter<'a, K, V> {
 }
 
 impl<'a, K: TName, V> IntoIterator for &'a RememberingUniqueMap<K, V> {
-    type Item = (K, &'a V);
+    type Item = (K::Loc, &'a K::Key, &'a V);
     type IntoIter = Iter<'a, K, V>;
 
     fn into_iter(self) -> Self::IntoIter {

--- a/language/move-lang/src/shared/remembering_unique_map.rs
+++ b/language/move-lang/src/shared/remembering_unique_map.rs
@@ -227,7 +227,7 @@ impl<'a, K: TName, V> IntoIterator for &'a RememberingUniqueMap<K, V> {
 pub struct IterMut<'a, K: TName, V>(unique_map::IterMut<'a, K, V>);
 
 impl<'a, K: TName, V> Iterator for IterMut<'a, K, V> {
-    type Item = (K, &'a mut V);
+    type Item = (K::Loc, &'a K::Key, &'a mut V);
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
@@ -239,7 +239,7 @@ impl<'a, K: TName, V> Iterator for IterMut<'a, K, V> {
 }
 
 impl<'a, K: TName, V> IntoIterator for &'a mut RememberingUniqueMap<K, V> {
-    type Item = (K, &'a mut V);
+    type Item = (K::Loc, &'a K::Key, &'a mut V);
     type IntoIter = IterMut<'a, K, V>;
 
     fn into_iter(self) -> Self::IntoIter {

--- a/language/move-lang/src/shared/unique_map.rs
+++ b/language/move-lang/src/shared/unique_map.rs
@@ -10,7 +10,7 @@ use std::{collections::BTreeMap, fmt::Debug, iter::IntoIterator};
 
 /// Unique wrapper around `BTreeMap` that throws on duplicate inserts
 #[derive(Default, Clone, Debug)]
-pub struct UniqueMap<K: TName, V>(BTreeMap<K::Key, (K::Loc, V)>);
+pub struct UniqueMap<K: TName, V>(pub(crate) BTreeMap<K::Key, (K::Loc, V)>);
 
 impl<K: TName, V> UniqueMap<K, V> {
     pub fn new() -> Self {

--- a/language/move-lang/src/shared/unique_map.rs
+++ b/language/move-lang/src/shared/unique_map.rs
@@ -269,13 +269,13 @@ impl<'a, K: TName, V> IntoIterator for &'a UniqueMap<K, V> {
 pub struct IterMut<'a, K: TName, V>(
     std::iter::Map<
         std::collections::btree_map::IterMut<'a, K::Key, (K::Loc, V)>,
-        fn((&'a K::Key, &'a mut (K::Loc, V))) -> (K, &'a mut V),
+        fn((&'a K::Key, &'a mut (K::Loc, V))) -> (K::Loc, &'a K::Key, &'a mut V),
     >,
     usize,
 );
 
 impl<'a, K: TName, V> Iterator for IterMut<'a, K, V> {
-    type Item = (K, &'a mut V);
+    type Item = (K::Loc, &'a K::Key, &'a mut V);
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.1 > 0 {
@@ -286,17 +286,17 @@ impl<'a, K: TName, V> Iterator for IterMut<'a, K, V> {
 }
 
 impl<'a, K: TName, V> IntoIterator for &'a mut UniqueMap<K, V> {
-    type Item = (K, &'a mut V);
+    type Item = (K::Loc, &'a K::Key, &'a mut V);
     type IntoIter = IterMut<'a, K, V>;
 
     fn into_iter(self) -> Self::IntoIter {
         let len = self.len();
-        let fix = |(k_, loc_v): (&'a K::Key, &'a mut (K::Loc, V))| -> (K, &'a mut V) {
-            let loc = loc_v.0;
-            let v = &mut loc_v.1;
-            let k = K::add_loc(loc, k_.clone());
-            (k, v)
-        };
+        let fix =
+            |(k_, loc_v): (&'a K::Key, &'a mut (K::Loc, V))| -> (K::Loc, &'a K::Key, &'a mut V) {
+                let loc = loc_v.0;
+                let v = &mut loc_v.1;
+                (loc, k_, v)
+            };
         IterMut(self.0.iter_mut().map(fix), len)
     }
 }

--- a/language/move-lang/src/shared/unique_set.rs
+++ b/language/move-lang/src/shared/unique_set.rs
@@ -1,0 +1,207 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{unique_map::UniqueMap, *};
+use std::{cmp::Ordering, fmt::Debug, iter::IntoIterator};
+
+/// Unique set wrapper around `UniqueMap` where the value of the map is not needed
+#[derive(Clone)]
+pub struct UniqueSet<T: TName>(UniqueMap<T, ()>);
+
+impl<T: TName> UniqueSet<T> {
+    pub fn new() -> Self {
+        Self(UniqueMap::new())
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn add(&mut self, x: T) -> Result<(), T::Loc> {
+        self.0.add(x, ())
+    }
+
+    pub fn contains(&self, x: &T) -> bool {
+        self.0.contains_key(x)
+    }
+
+    pub fn contains_(&self, x_: &T::Key) -> bool {
+        self.0.contains_key_(&x_)
+    }
+
+    // interesection of two sets. Keeps the loc of the first set
+    pub fn intersect(&self, other: &Self) -> Self {
+        let mut intersection = Self::new();
+        for x in self {
+            if !other.contains(&x) {
+                continue;
+            }
+            assert!(intersection.add(x).is_ok());
+        }
+        intersection
+    }
+
+    // union of two sets. Prefers the loc of the first set
+    pub fn union(&self, other: &Self) -> Self {
+        let mut joined = Self::new();
+        for x in self {
+            assert!(joined.add(x).is_ok());
+        }
+        for x in other {
+            if joined.contains(&x) {
+                continue;
+            }
+            assert!(joined.add(x).is_ok())
+        }
+        joined
+    }
+
+    pub fn is_subset(&self, other: &Self) -> bool {
+        self.iter().all(|x| other.contains(&x))
+    }
+
+    pub fn iter(&self) -> Iter<T> {
+        self.into_iter()
+    }
+
+    pub fn from_elements(
+        iter: impl IntoIterator<Item = T>,
+    ) -> Result<Self, (T::Key, T::Loc, T::Loc)> {
+        Ok(Self(UniqueMap::maybe_from_iter(
+            iter.into_iter().map(|x| (x, ())),
+        )?))
+    }
+
+    pub fn from_elements_(
+        loc: T::Loc,
+        iter: impl IntoIterator<Item = T::Key>,
+    ) -> Result<Self, (T::Key, T::Loc, T::Loc)> {
+        Ok(Self(UniqueMap::maybe_from_iter(
+            iter.into_iter().map(|x_| (T::add_loc(loc, x_), ())),
+        )?))
+    }
+}
+
+impl<T: TName> PartialEq for UniqueSet<T> {
+    fn eq(&self, other: &UniqueSet<T>) -> bool {
+        self.0 == other.0
+    }
+}
+impl<T: TName> Eq for UniqueSet<T> {}
+
+impl<T: TName> PartialOrd for UniqueSet<T> {
+    fn partial_cmp(&self, other: &UniqueSet<T>) -> Option<Ordering> {
+        (self.0).0.keys().partial_cmp((other.0).0.keys())
+    }
+}
+
+impl<T: TName> Ord for UniqueSet<T> {
+    fn cmp(&self, other: &UniqueSet<T>) -> Ordering {
+        (self.0).0.keys().cmp((other.0).0.keys())
+    }
+}
+
+impl<T: TName + Debug> Debug for UniqueSet<T>
+where
+    T::Key: Debug,
+    T::Loc: Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<T: TName> Hash for UniqueSet<T>
+where
+    T::Key: Hash,
+{
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        for k in (self.0).0.keys() {
+            k.hash(state);
+        }
+    }
+}
+
+//**************************************************************************************************
+// IntoIter
+//**************************************************************************************************
+
+pub struct IntoIter<T: TName>(
+    std::iter::Map<unique_map::IntoIter<T, ()>, fn((T, ())) -> T>,
+    usize,
+);
+
+impl<T: TName> Iterator for IntoIter<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.1 > 0 {
+            self.1 -= 1;
+        }
+        self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.1, Some(self.1))
+    }
+}
+
+impl<T: TName> IntoIterator for UniqueSet<T> {
+    type Item = T;
+    type IntoIter = IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        let len = self.len();
+        IntoIter(
+            self.0.into_iter().map(|ab_v| {
+                let (ab, ()) = ab_v;
+                ab
+            }),
+            len,
+        )
+    }
+}
+
+//**************************************************************************************************
+// Iter
+//**************************************************************************************************
+
+pub struct Iter<'a, T: TName>(
+    std::iter::Map<unique_map::Iter<'a, T, ()>, fn((T, &())) -> T>,
+    usize,
+);
+
+impl<'a, T: TName> Iterator for Iter<'a, T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.1 > 0 {
+            self.1 -= 1;
+        }
+        self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.1, Some(self.1))
+    }
+}
+
+impl<'a, T: TName> IntoIterator for &'a UniqueSet<T> {
+    type Item = T;
+    type IntoIter = Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        let len = self.len();
+        Iter(
+            self.0.iter().map(|ab_v| {
+                let (ab, ()) = ab_v;
+                ab
+            }),
+            len,
+        )
+    }
+}

--- a/language/move-lang/src/shared/unique_set.rs
+++ b/language/move-lang/src/shared/unique_set.rs
@@ -21,7 +21,7 @@ impl<T: TName> UniqueSet<T> {
         self.0.len()
     }
 
-    pub fn add(&mut self, x: T) -> Result<(), T::Loc> {
+    pub fn add(&mut self, x: T) -> Result<(), (T, T::Loc)> {
         self.0.add(x, ())
     }
 

--- a/language/move-lang/src/to_bytecode/context.rs
+++ b/language/move-lang/src/to_bytecode/context.rs
@@ -4,9 +4,7 @@
 use crate::{
     expansion::ast::SpecId,
     hlir::ast as H,
-    parser::ast::{
-        ConstantName, FunctionName, ModuleIdent, ModuleIdent_, ModuleName, StructName, Var,
-    },
+    parser::ast::{ConstantName, FunctionName, ModuleIdent, StructName, Var},
 };
 use diem_types::account_address::AccountAddress as DiemAddress;
 use move_ir_types::ast as IR;
@@ -206,21 +204,21 @@ impl<'a> Context<'a> {
     //**********************************************************************************************
 
     fn ir_module_alias(ident: &ModuleIdent) -> IR::ModuleName {
-        let ModuleIdent_ { address, name } = &ident.0.value;
+        let (address, name) = &ident.value;
         IR::ModuleName::new(format!("{}::{}", address, name))
     }
 
     fn translate_module_ident(ident: ModuleIdent) -> IR::ModuleIdent {
-        let ModuleIdent_ { address, name } = ident.0.value;
-        let name = Self::translate_module_name(name);
+        let (address, name) = ident.value;
+        let name = Self::translate_module_name_(name);
         IR::ModuleIdent::Qualified(IR::QualifiedModuleIdent::new(
             name,
             DiemAddress::new(address.to_u8()),
         ))
     }
 
-    fn translate_module_name(n: ModuleName) -> IR::ModuleName {
-        IR::ModuleName::new(n.0.value)
+    fn translate_module_name_(s: String) -> IR::ModuleName {
+        IR::ModuleName::new(s)
     }
 
     fn translate_struct_name(n: StructName) -> IR::StructName {

--- a/language/move-lang/src/to_bytecode/translate.rs
+++ b/language/move-lang/src/to_bytecode/translate.rs
@@ -39,14 +39,14 @@ pub fn program(prog: G::Program) -> Result<Vec<CompiledUnit>, Errors> {
     let mut errors = vec![];
     let orderings = prog
         .modules
-        .iter()
+        .key_cloned_iter()
         .map(|(m, mdef)| (m, mdef.dependency_order))
         .collect();
     let sdecls = prog
         .modules
-        .iter()
+        .key_cloned_iter()
         .flat_map(|(m, mdef)| {
-            mdef.structs.iter().map(move |(s, sdef)| {
+            mdef.structs.key_cloned_iter().map(move |(s, sdef)| {
                 let key = (m.clone(), s);
                 let is_nominal_resource = sdef.resource_opt.is_some();
                 let kinds = type_parameters(sdef.type_parameters.clone());
@@ -56,9 +56,9 @@ pub fn program(prog: G::Program) -> Result<Vec<CompiledUnit>, Errors> {
         .collect();
     let fdecls = prog
         .modules
-        .iter()
+        .key_cloned_iter()
         .flat_map(|(m, mdef)| {
-            mdef.functions.iter().map(move |(f, fdef)| {
+            mdef.functions.key_cloned_iter().map(move |(f, fdef)| {
                 let key = (m.clone(), f);
                 let seen = seen_structs(&fdef.signature);
                 let sig = function_signature(&mut Context::new(None), fdef.signature.clone());

--- a/language/move-lang/src/to_bytecode/translate.rs
+++ b/language/move-lang/src/to_bytecode/translate.rs
@@ -136,15 +136,15 @@ fn module(
         })
         .collect();
 
-    let addr = DiemAddress::new(ident.0.value.address.to_u8());
-    let mname = ident.0.value.name.clone();
+    let addr = DiemAddress::new(ident.value.0.to_u8());
+    let mname = ident.value.1.clone();
     let (imports, explicit_dependency_declarations) = context.materialize(
         dependency_orderings,
         struct_declarations,
         function_declarations,
     );
     let ir_module = IR::ModuleDefinition {
-        name: IR::ModuleName::new(mname.0.value),
+        name: IR::ModuleName::new(mname),
         // TODO: add friends here
         friends: vec![],
         imports,

--- a/language/move-lang/src/typing/ast.rs
+++ b/language/move-lang/src/typing/ast.rs
@@ -244,7 +244,7 @@ impl fmt::Display for BuiltinFunction_ {
 impl AstDebug for Program {
     fn ast_debug(&self, w: &mut AstWriter) {
         let Program { modules, scripts } = self;
-        for (m, mdef) in modules {
+        for (m, mdef) in modules.key_cloned_iter() {
             w.write(&format!("module {}", m));
             w.block(|w| mdef.ast_debug(w));
             w.new_line();
@@ -266,7 +266,7 @@ impl AstDebug for Script {
             function_name,
             function,
         } = self;
-        for cdef in constants {
+        for cdef in constants.key_cloned_iter() {
             cdef.ast_debug(w);
             w.new_line();
         }
@@ -289,15 +289,15 @@ impl AstDebug for ModuleDefinition {
             w.writeln("source module")
         }
         w.writeln(&format!("dependency order #{}", dependency_order));
-        for sdef in structs {
+        for sdef in structs.key_cloned_iter() {
             sdef.ast_debug(w);
             w.new_line();
         }
-        for cdef in constants {
+        for cdef in constants.key_cloned_iter() {
             cdef.ast_debug(w);
             w.new_line();
         }
-        for fdef in functions {
+        for fdef in functions.key_cloned_iter() {
             fdef.ast_debug(w);
             w.new_line();
         }
@@ -423,7 +423,7 @@ impl AstDebug for UnannotatedExp_ {
                 tys.ast_debug(w);
                 w.write(">");
                 w.write("{");
-                w.comma(fields, |w, (f, idx_bt_e)| {
+                w.comma(fields, |w, (_, f, idx_bt_e)| {
                     let (idx, (bt, e)) = idx_bt_e;
                     w.write(&format!("({}#{}:", idx, f));
                     bt.ast_debug(w);
@@ -666,7 +666,7 @@ impl AstDebug for LValue_ {
                 tys.ast_debug(w);
                 w.write(">");
                 w.write("{");
-                w.comma(fields, |w, (f, idx_bt_a)| {
+                w.comma(fields, |w, (_, f, idx_bt_a)| {
                     let (idx, (bt, a)) = idx_bt_a;
                     w.annotate(|w| w.write(&format!("{}#{}", idx, f)), bt);
                     w.write(": ");
@@ -684,7 +684,7 @@ impl AstDebug for LValue_ {
                 tys.ast_debug(w);
                 w.write(">");
                 w.write("{");
-                w.comma(fields, |w, (f, idx_bt_a)| {
+                w.comma(fields, |w, (_, f, idx_bt_a)| {
                     let (idx, (bt, a)) = idx_bt_a;
                     w.annotate(|w| w.write(&format!("{}#{}", idx, f)), bt);
                     w.write(": ");

--- a/language/move-lang/src/typing/core.rs
+++ b/language/move-lang/src/typing/core.rs
@@ -239,8 +239,11 @@ impl Context {
         declared: UniqueMap<Var, ()>,
     ) {
         // remove new locals from inner scope
-        for (new_local, _) in declared.iter().filter(|(v, _)| !old_locals.contains_key(v)) {
-            self.locals.remove(&new_local);
+        for (_, new_local, _) in declared
+            .iter()
+            .filter(|(_, v, _)| !old_locals.contains_key_(v))
+        {
+            self.locals.remove_(&new_local);
         }
 
         // return old type

--- a/language/move-lang/src/typing/expand.rs
+++ b/language/move-lang/src/typing/expand.rs
@@ -261,7 +261,7 @@ pub fn exp(context: &mut Context, e: &mut T::Exp) {
 
         E::Pack(_, _, bs, fields) => {
             types(context, bs);
-            for (_, (_, (bt, fe))) in fields.iter_mut() {
+            for (_, _, (_, (bt, fe))) in fields.iter_mut() {
                 type_(context, bt);
                 exp(context, fe)
             }
@@ -289,7 +289,7 @@ fn lvalue(context: &mut Context, b: &mut T::LValue) {
         }
         L::BorrowUnpack(_, _, _, bts, fields) | L::Unpack(_, _, bts, fields) => {
             types(context, bts);
-            for (_, (_, (bt, innerb))) in fields.iter_mut() {
+            for (_, _, (_, (bt, innerb))) in fields.iter_mut() {
                 type_(context, bt);
                 lvalue(context, innerb)
             }

--- a/language/move-lang/src/typing/globals.rs
+++ b/language/move-lang/src/typing/globals.rs
@@ -144,7 +144,7 @@ fn exp(
         }
 
         E::Pack(_, _, _, fields) => {
-            for (_, (_, (_, fe))) in fields.iter() {
+            for (_, _, (_, (_, fe))) in fields {
                 exp(context, annotated_acquires, seen, fe)
             }
         }

--- a/language/move-lang/src/typing/infinite_instantiations.rs
+++ b/language/move-lang/src/typing/infinite_instantiations.rs
@@ -128,18 +128,18 @@ impl<'a> Context<'a> {
 
 pub fn modules(errors: &mut Errors, modules: &UniqueMap<ModuleIdent, T::ModuleDefinition>) {
     let tparams = modules
-        .iter()
+        .key_cloned_iter()
         .map(|(mname, mdef)| {
             let tparams = mdef
                 .functions
-                .iter()
+                .key_cloned_iter()
                 .map(|(fname, fdef)| (fname, &fdef.signature.type_parameters))
                 .collect();
             (mname, tparams)
         })
         .collect();
     modules
-        .iter()
+        .key_cloned_iter()
         .for_each(|(mname, m)| module(errors, &tparams, mname, m))
 }
 
@@ -163,7 +163,7 @@ fn module<'a>(
     let context = &mut Context::new(tparams, mname);
     module
         .functions
-        .iter()
+        .key_cloned_iter()
         .for_each(|(_fname, fdef)| function_body(context, &fdef.body));
     let graph = context.instantiation_graph();
     // - get the strongly connected components
@@ -249,7 +249,7 @@ fn exp(context: &mut Context, e: &T::Exp) {
         }
 
         E::Pack(_, _, _, fields) => {
-            for (_, (_, (_, fe))) in fields.iter() {
+            for (_, _, (_, (_, fe))) in fields.iter() {
                 exp(context, fe)
             }
         }

--- a/language/move-lang/src/typing/recursive_structs.rs
+++ b/language/move-lang/src/typing/recursive_structs.rs
@@ -52,7 +52,7 @@ impl Context {
 
 pub fn modules(errors: &mut Errors, modules: &UniqueMap<ModuleIdent, T::ModuleDefinition>) {
     modules
-        .iter()
+        .key_cloned_iter()
         .for_each(|(mname, m)| module(errors, mname, m))
 }
 
@@ -60,7 +60,7 @@ fn module(errors: &mut Errors, mname: ModuleIdent, module: &T::ModuleDefinition)
     let context = &mut Context::new(mname);
     module
         .structs
-        .iter()
+        .key_cloned_iter()
         .for_each(|(sname, sdef)| struct_def(context, sname, sdef));
     let graph = context.struct_graph();
     // - get the strongly connected components
@@ -78,7 +78,7 @@ fn struct_def(context: &mut Context, sname: StructName, sdef: &N::StructDefiniti
     match &sdef.fields {
         N::StructFields::Native(_) => (),
         N::StructFields::Defined(fields) => {
-            fields.iter().for_each(|(_, (_, ty))| type_(context, ty))
+            fields.iter().for_each(|(_, _, (_, ty))| type_(context, ty))
         }
     };
     context.current_struct = None;

--- a/language/move-lang/src/typing/translate.rs
+++ b/language/move-lang/src/typing/translate.rs
@@ -447,7 +447,7 @@ mod check_valid_constant {
                 REFERENCE_CASE
             }
             E::Pack(_, _, _, fields) => {
-                for (_, (_, (_, fe))) in fields {
+                for (_, _, (_, (_, fe))) in fields {
                     exp(context, fe)
                 }
                 "Structs are"
@@ -522,7 +522,7 @@ fn struct_def(context: &mut Context, _name: StructName, s: &mut N::StructDefinit
         N::StructFields::Defined(m) => m,
     };
 
-    for (_field, idx_ty) in field_map.iter() {
+    for (_field_loc, _field, idx_ty) in field_map.iter() {
         let inst_ty = core::instantiate(context, idx_ty.1.clone());
         context.add_base_type_constraint(inst_ty.loc, "Invalid field type", inst_ty);
     }
@@ -1560,11 +1560,11 @@ fn add_field_types<T>(
             return fields.map(|f, (idx, x)| (idx, (context.error_type(f.loc()), x)));
         }
     };
-    for (f, _) in fields_ty.iter() {
-        if fields.get(&f).is_none() {
+    for (_, f_, _) in &fields_ty {
+        if fields.get_(&f_).is_none() {
             context.error(vec![(
                 loc,
-                format!("Missing {} for field '{}' in '{}::{}'", verb, f, m, n),
+                format!("Missing {} for field '{}' in '{}::{}'", verb, f_, m, n),
             )])
         }
     }

--- a/language/move-lang/src/typing/translate.rs
+++ b/language/move-lang/src/typing/translate.rs
@@ -208,7 +208,7 @@ fn function_signature(context: &mut Context, sig: &N::FunctionSignature) {
             "Invalid parameter type",
             param_ty.clone(),
         );
-        if let Err(prev_loc) = declared.add(param.clone(), ()) {
+        if let Err((param, prev_loc)) = declared.add(param.clone(), ()) {
             context.error(vec![
                 (
                     param.loc(),
@@ -1389,7 +1389,7 @@ fn lvalue(
                     var_ty
                 }
             };
-            if let Err(prev_loc) = seen_locals.add(var.clone(), ()) {
+            if let Err((var, prev_loc)) = seen_locals.add(var.clone(), ()) {
                 let error = match case {
                     C::Bind => {
                         let msg = format!(

--- a/language/move-lang/src/typing/translate.rs
+++ b/language/move-lang/src/typing/translate.rs
@@ -57,7 +57,7 @@ fn module(
     } = mdef;
     structs
         .iter_mut()
-        .for_each(|(name, s)| struct_def(context, name, s));
+        .for_each(|(_, _, s)| struct_def(context, s));
     let constants = nconstants.map(|name, c| constant(context, name, c));
     let functions = n_functions.map(|name, f| function(context, name, f, false));
     assert!(context.constraints.is_empty());
@@ -513,7 +513,7 @@ mod check_valid_constant {
 // Structs
 //**************************************************************************************************
 
-fn struct_def(context: &mut Context, _name: StructName, s: &mut N::StructDefinition) {
+fn struct_def(context: &mut Context, s: &mut N::StructDefinition) {
     assert!(context.constraints.is_empty());
     context.reset_for_module_item();
 
@@ -528,7 +528,7 @@ fn struct_def(context: &mut Context, _name: StructName, s: &mut N::StructDefinit
     }
     core::solve_constraints(context);
 
-    for (_field, idx_ty) in field_map.iter_mut() {
+    for (_field_loc, _field_, idx_ty) in field_map.iter_mut() {
         expand::type_(context, &mut idx_ty.1);
     }
 }

--- a/language/move-lang/tests/move_check/naming/duplicate_type_parameter_function.exp
+++ b/language/move-lang/tests/move_check/naming/duplicate_type_parameter_function.exp
@@ -28,6 +28,6 @@ error:
    │                                        ^ Duplicate type parameter declared with name 'T'
    ·
  3 │     fun foo2<T: copyable, T: resource, T>() {}
-   │                           - Previously defined here
+   │              - Previously defined here
    │
 

--- a/language/move-lang/tests/move_check/naming/duplicate_type_parameter_struct.exp
+++ b/language/move-lang/tests/move_check/naming/duplicate_type_parameter_struct.exp
@@ -28,7 +28,7 @@ error:
    │                                         ^ Duplicate type parameter declared with name 'T'
    ·
  3 │     struct S2<T: copyable, T: resource, T> {}
-   │                            - Previously defined here
+   │               - Previously defined here
    │
 
 error: 
@@ -61,6 +61,6 @@ error:
    │                                         ^ Duplicate type parameter declared with name 'T'
    ·
  5 │     struct R2<T: copyable, T: resource, T> {}
-   │                            - Previously defined here
+   │               - Previously defined here
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/generics/instantiation_loops/recursive_struct.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/generics/instantiation_loops/recursive_struct.exp
@@ -33,13 +33,13 @@ error:
 
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/move/generics/instantiation_loops/recursive_struct.move:45:8 ───
+    ┌── tests/move_check/translated_ir_tests/move/generics/instantiation_loops/recursive_struct.move:41:29 ───
     │
- 45 │ module M3 {
-    │        ^^ Duplicate definition for module '0x42::M3'
+ 41 │     struct Foo { f: M1::Cup<Foo> }
+    │                             ^^^ Invalid field containing 'Foo' in struct 'Foo'.
     ·
- 38 │ module M3 {
-    │        -- Previously defined here
+ 41 │     struct Foo { f: M1::Cup<Foo> }
+    │                             --- Using this struct creates a cycle: 'Foo' contains 'Foo'
     │
 
 error: 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/generics/instantiation_loops/recursive_struct.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/generics/instantiation_loops/recursive_struct.move
@@ -42,7 +42,7 @@ module M3 {
 
 }
 
-module M3 {
+module M4 {
     use 0x42::M1;
 
     struct A { b: B }

--- a/language/move-lang/tests/move_check/typing/assign_duplicate_assigning.exp
+++ b/language/move-lang/tests/move_check/typing/assign_duplicate_assigning.exp
@@ -28,6 +28,6 @@ error:
    │                   ^ Duplicate usage of local 'f' in a given assignment
    ·
  8 │         (f, R{f}, f) = (0, R { f: 0 }, 0);
-   │               - Previously assigned here
+   │          - Previously assigned here
    │
 

--- a/language/move-lang/tests/move_check/typing/bind_duplicate_binding.exp
+++ b/language/move-lang/tests/move_check/typing/bind_duplicate_binding.exp
@@ -28,6 +28,6 @@ error:
    │                       ^ Duplicate declaration for local 'f' in a given 'let'
    ·
  6 │         let (f, R{f}, f) = (0, R { f: 0 }, 0);
-   │                   - Previously declared here
+   │              - Previously declared here
    │
 

--- a/language/move-lang/tests/move_check/typing/declare_duplicate_binding.exp
+++ b/language/move-lang/tests/move_check/typing/declare_duplicate_binding.exp
@@ -44,6 +44,6 @@ error:
    │                       ^ Duplicate declaration for local 'f' in a given 'let'
    ·
  6 │         let (f, R{f}, f);
-   │                   - Previously declared here
+   │              - Previously declared here
    │
 

--- a/language/move-model/src/builder/exp_translator.rs
+++ b/language/move-model/src/builder/exp_translator.rs
@@ -516,8 +516,8 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                     },
                     ModuleType(m, n) => {
                         let module_name = ModuleName::from_str(
-                            &m.0.value.address.to_string(),
-                            self.symbol_pool().make(m.0.value.name.0.value.as_str()),
+                            &m.value.0.to_string(),
+                            self.symbol_pool().make(m.value.1.as_str()),
                         );
                         let symbol = self.symbol_pool().make(n.0.value.as_str());
                         let qsym = QualifiedSymbol {

--- a/language/move-model/src/builder/exp_translator.rs
+++ b/language/move-model/src/builder/exp_translator.rs
@@ -1679,15 +1679,15 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                 let mut fields_not_convered: BTreeSet<Symbol> = BTreeSet::new();
                 fields_not_convered.extend(field_decls.keys());
                 let mut args = BTreeMap::new();
-                for (ref name, (_, exp)) in fields.iter() {
-                    let field_name = self.symbol_pool().make(&name.0.value);
+                for (name_loc, name_, (_, exp)) in fields.iter() {
+                    let field_name = self.symbol_pool().make(&name_);
                     if let Some((idx, field_ty)) = field_decls.get(&field_name) {
                         let exp = self.translate_exp(exp, &field_ty.instantiate(&instantiation));
                         fields_not_convered.remove(&field_name);
                         args.insert(idx, exp);
                     } else {
                         self.error(
-                            &self.to_loc(&name.0.loc),
+                            &self.to_loc(&name_loc),
                             &format!(
                                 "field `{}` not declared in struct `{}`",
                                 field_name.display(self.symbol_pool()),

--- a/language/move-model/src/builder/module_builder.rs
+++ b/language/move-model/src/builder/module_builder.rs
@@ -184,8 +184,8 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
             EA::ModuleAccess_::Name(n) => (None, self.symbol_pool().make(n.value.as_str())),
             EA::ModuleAccess_::ModuleAccess(m, n) => {
                 let module_name = ModuleName::from_str(
-                    &m.0.value.address.to_string(),
-                    self.symbol_pool().make(m.0.value.name.0.value.as_str()),
+                    &m.value.0.to_string(),
+                    self.symbol_pool().make(m.value.1.as_str()),
                 );
                 (Some(module_name), self.symbol_pool().make(n.value.as_str()))
             }

--- a/language/tools/move-cli/src/package.rs
+++ b/language/tools/move-cli/src/package.rs
@@ -178,7 +178,7 @@ impl MovePackage {
                         let mut data = vec![];
                         module.serialize(&mut data)?;
                         let file_path = pkg_bin_path
-                            .join(ident.0.value.name.0.value)
+                            .join(ident.value.1)
                             .with_extension(COMPILED_EXTENSION);
                         let mut fp = File::create(file_path)?;
                         fp.write_all(&data)?;


### PR DESCRIPTION
- Added UniqueSet
- Cleaned up a lot of unnecessary clones in UniqueMap by reworking ModuleIdent and TName
- This also changed the API for iteration a bit, but a legacy cloning one was added for the cases that needed to clone anyway

## Motivation

- Some code cleanliness and reducing number of copies

## Test Plan

- cargo test