### PR TITLE
[testnet] support a template config for testnet

### DIFF
--- a/diem-node/src/lib.rs
+++ b/diem-node/src/lib.rs
@@ -5,7 +5,7 @@ use backup_service::start_backup_service;
 use consensus::{consensus_provider::start_consensus, gen_consensus_reconfig_subscription};
 use debug_interface::node_debug_service::NodeDebugService;
 use diem_config::{
-    config::{NetworkConfig, NodeConfig},
+    config::{NetworkConfig, NodeConfig, PersistableConfig},
     network_id::NodeNetworkId,
     utils::get_genesis_txn,
 };
@@ -122,7 +122,10 @@ pub fn load_test_environment(config_path: Option<PathBuf>, random_ports: bool) {
     let config_path = config_path.canonicalize().unwrap();
 
     // Build a single validator network
-    let template = NodeConfig::default_for_validator();
+    let mut maybe_config = PathBuf::from(&config_path);
+    maybe_config.push("validator_node_template.yaml");
+    let template = NodeConfig::load_config(maybe_config)
+        .unwrap_or_else(|_| NodeConfig::default_for_validator());
     let builder =
         diem_genesis_tool::config_builder::ValidatorBuilder::new(1, template, &config_path)
             .randomize_first_validator_ports(random_ports);

--- a/docker/compose/validator-testnet/docker-compose.yaml
+++ b/docker/compose/validator-testnet/docker-compose.yaml
@@ -24,6 +24,9 @@ services:
       - type: volume
         source: diem-shared
         target: /opt/diem/var
+      - type: bind
+        source: ./validator_node_template.yaml
+        target: /opt/diem/var/validator_node_template.yaml
     command: ["/opt/diem/bin/diem-node", "--test", "--config", "/opt/diem/var"]
     ports:
       - "8080:8080"

--- a/docker/compose/validator-testnet/docker-compose.yaml
+++ b/docker/compose/validator-testnet/docker-compose.yaml
@@ -14,61 +14,60 @@
 
 version: "3.8"
 services:
-    validator:
-        # Note this image currently does not support this, will update to the appropriate minimum
-        # version shortly
-        image: "libra/validator:${IMAGE_TAG:-devnet}"
-        networks:
-            shared:
-        volumes:
-            - type: volume
-              source: diem-shared
-              target: /opt/diem/var
-        command: ["/opt/diem/bin/diem-node", "--test", "--config", "/opt/diem/var"]
-        ports:
-            - "8080:8080"
+  validator:
+    # Note this image currently does not support this, will update to the appropriate minimum
+    # version shortly
+    image: "libra/validator:${IMAGE_TAG:-devnet}"
+    networks:
+      shared:
+    volumes:
+      - type: volume
+        source: diem-shared
+        target: /opt/diem/var
+    command: ["/opt/diem/bin/diem-node", "--test", "--config", "/opt/diem/var"]
+    ports:
+      - "8080:8080"
 
-    faucet:
-      image: "libra/faucet:${IMAGE_TAG:-devnet}"
-      depends_on:
-        - validator
-      networks:
-        shared:
-      volumes:
-        - type: volume
-          source: diem-shared
-          target: /opt/diem/var
-      command: >
-        /bin/bash -c "
-            for i in {1..10}
-            do
-                if [[ -s /opt/diem/var/mint.key ]]
-                then
-                    /opt/diem/bin/diem-faucet \
-                        --address 0.0.0.0 \
-                        --port 8000 \
-                        --chain-id TESTING \
-                        --mint-key-file-path /opt/diem/var/mint.key \
-                        --server-url http://validator:8080/v1
-                    exit $$?
-                else
-                    echo 'Validator has not populated mint.key yet. Is it running?'
-                    sleep 1
-                fi
-            done
-            exit 1
-          "
-      ports:
-        - "8000:8000"
-
+  faucet:
+    image: "libra/faucet:${IMAGE_TAG:-devnet}"
+    depends_on:
+      - validator
+    networks:
+      shared:
+    volumes:
+      - type: volume
+        source: diem-shared
+        target: /opt/diem/var
+    command: >
+      /bin/bash -c "
+        for i in {1..10}
+        do
+          if [[ -s /opt/diem/var/mint.key ]]
+          then
+            /opt/diem/bin/diem-faucet \
+              --address 0.0.0.0 \
+              --port 8000 \
+              --chain-id TESTING \
+              --mint-key-file-path /opt/diem/var/mint.key \
+              --server-url http://validator:8080/v1
+            exit $$?
+          else
+            echo 'Validator has not populated mint.key yet. Is it running?'
+            sleep 1
+          fi
+        done
+        exit 1
+      "
+    ports:
+      - "8000:8000"
 
 networks:
-    shared:
-        name: "diem-docker-compose-shared"
-        ipam:
-          config:
-            - subnet: 172.16.1.0/24
+  shared:
+    name: "diem-docker-compose-shared"
+    ipam:
+      config:
+        - subnet: 172.16.1.0/24
 
 volumes:
-  diem-shared:
-    name: diem-shared
+    diem-shared:
+        name: diem-shared

--- a/docker/compose/validator-testnet/validator_node_template.yaml
+++ b/docker/compose/validator-testnet/validator_node_template.yaml
@@ -1,0 +1,32 @@
+consensus:
+  # The following slow consensus down when there are no active transactions to process
+  round_initial_timeout_ms: 20000
+  mempool_poll_count: 333
+
+# The rest of this config is copy paste of config/src/config/test_data/validator.yaml
+validator_network:
+  listen_address: "/ip4/0.0.0.0/tcp/6180"
+  identity:
+    type: "from_storage"
+    key_name: "validator_network"
+    peer_id_name: "owner_account"
+    backend:
+      type: "vault"
+      server: "https://127.0.0.1:8200"
+      ca_certificate: "/full/path/to/certificate"
+      token:
+        from_disk: "/full/path/to/token"
+
+full_node_networks:
+  - listen_address: "/ip4/0.0.0.0/tcp/7180"
+    identity:
+      type: "from_storage"
+      key_name: "fullnode_network"
+        peer_id_name: "owner_account"
+        backend:
+          type: "vault"
+          server: "https://127.0.0.1:8200"
+          token:
+                from_disk: "/full/path/to/token"
+    network_id:
+      private: "vfn"


### PR DESCRIPTION
this is definitely a hack so that we can enable consensus slow down for docker(-compose)
