### PR TITLE
[gha] e2e tests should have messages pushed on e2e test failures

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -274,6 +274,7 @@ jobs:
           exit $num_fails
       - name: "Send Message"
         uses: ./.github/actions/slack-file
+        if: ${{ always() }}
         with:
           payload-file: ${{ env.MESSAGE_PAYLOAD_FILE }}
           webhook: ${{ secrets.WEBHOOK_FLAKY_TESTS }}


### PR DESCRIPTION
## Motivation

E2e test failure messages should be pushed to slack.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

CI + time + eyeballs.

## Related PRs

None

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
