### PR TITLE
[move-prover] Handle `&mut` parameter threading on boogie instead of bytecode level.

### DIFF
--- a/language/move-prover/bytecode/src/borrow_analysis.rs
+++ b/language/move-prover/bytecode/src/borrow_analysis.rs
@@ -407,37 +407,18 @@ impl<'a> TransferFunctions for BorrowAnalysis<'a> {
                         }
                     }
                     Function(mid, fid, ..) => {
-                        // Create a borrow edge for all &mut parameters to the
-                        // corresponding return value.
-                        let callee_env = self
-                            .func_target
-                            .global_env()
-                            .get_module(*mid)
-                            .into_function(*fid);
-                        let mut ret_idx = callee_env.get_return_count();
-                        for src in srcs.iter().filter(|idx| {
-                            self.func_target
-                                .get_local_type(**idx)
-                                .is_mutable_reference()
-                        }) {
-                            let dest = dests[ret_idx];
-                            ret_idx = usize::saturating_add(ret_idx, 1);
-                            if *src != dest {
-                                let src_node = self.borrow_node(*src);
-                                let dest_node = self.borrow_node(dest);
-                                if livevar_annotation_at.after.contains(&dest) {
-                                    state.add_node(dest_node.clone());
-                                }
-                                state.add_edge(src_node, dest_node);
-                            }
-                        }
-                        // For all proper &mut ref return values (that is those which are not
+                        // For all &mut ref return values (that is those which are not
                         // introduced for &mut parameters), create a borrow edge from all &mut
                         // parameters. This reflects the current borrow semantics of Move.
                         // We do not known from which input parameter the returned reference
                         // borrows, so we must assume it could be any of them.
                         // TODO: this is one place where we could do better via inter-procedural
                         //   analysis.
+                        let callee_env = self
+                            .func_target
+                            .global_env()
+                            .get_module(*mid)
+                            .into_function(*fid);
                         for ret_idx in (0..callee_env.get_return_count()).filter(|ret_idx| {
                             callee_env.get_return_type(*ret_idx).is_mutable_reference()
                         }) {

--- a/language/move-prover/bytecode/tests/borrow/basic_test.exp
+++ b/language/move-prover/bytecode/tests/borrow/basic_test.exp
@@ -293,18 +293,18 @@ fun TestBorrow::test1(): TestBorrow::R {
 
 
 [variant baseline]
-fun TestBorrow::test2($t0|x_ref: &mut u64, $t1|v: u64): &mut u64 {
+fun TestBorrow::test2($t0|x_ref: &mut u64, $t1|v: u64) {
      # live_nodes: LocalRoot($t1), Reference($t0)
   0: write_ref($t0, $t1)
      # live_nodes: LocalRoot($t1), Reference($t0)
   1: trace_local[x_ref]($t0)
-     # live_nodes: LocalRoot($t1), Reference($t0)
-  2: return $t0
+     # live_nodes: LocalRoot($t1)
+  2: return ()
 }
 
 
 [variant baseline]
-pub fun TestBorrow::test3($t0|r_ref: &mut TestBorrow::R, $t1|v: u64): &mut TestBorrow::R {
+pub fun TestBorrow::test3($t0|r_ref: &mut TestBorrow::R, $t1|v: u64) {
      var $t2|x_ref: &mut u64
      var $t3: &mut u64
      # live_nodes: LocalRoot($t1), Reference($t0)
@@ -312,15 +312,15 @@ pub fun TestBorrow::test3($t0|r_ref: &mut TestBorrow::R, $t1|v: u64): &mut TestB
      # live_nodes: LocalRoot($t1), Reference($t0), Reference($t3)
      # borrowed_by: Reference($t0) -> {Reference($t3)}
      # borrows_from: Reference($t3) -> {Reference($t0)}
-  1: $t3 := TestBorrow::test2($t3, $t1)
+  1: TestBorrow::test2($t3, $t1)
      # live_nodes: LocalRoot($t1), Reference($t0)
      # borrowed_by: Reference($t0) -> {Reference($t3)}
      # borrows_from: Reference($t3) -> {Reference($t0)}
   2: trace_local[r_ref]($t0)
-     # live_nodes: LocalRoot($t1), Reference($t0)
+     # live_nodes: LocalRoot($t1)
      # borrowed_by: Reference($t0) -> {Reference($t3)}
      # borrows_from: Reference($t3) -> {Reference($t0)}
-  3: return $t0
+  3: return ()
 }
 
 
@@ -342,7 +342,7 @@ fun TestBorrow::test4(): TestBorrow::R {
      # live_nodes: Reference($t3)
      # borrowed_by: LocalRoot($t0) -> {Reference($t3)}
      # borrows_from: Reference($t3) -> {LocalRoot($t0)}
-  4: $t3 := TestBorrow::test3($t3, $t4)
+  4: TestBorrow::test3($t3, $t4)
      # borrowed_by: LocalRoot($t0) -> {Reference($t3)}
      # borrows_from: Reference($t3) -> {LocalRoot($t0)}
   5: $t5 := move($t0)
@@ -354,7 +354,7 @@ fun TestBorrow::test4(): TestBorrow::R {
 
 
 [variant baseline]
-pub fun TestBorrow::test5($t0|r_ref: &mut TestBorrow::R): (&mut u64, &mut TestBorrow::R) {
+pub fun TestBorrow::test5($t0|r_ref: &mut TestBorrow::R): &mut u64 {
      var $t1: &mut u64
      # live_nodes: Reference($t0)
   0: $t1 := borrow_field<TestBorrow::R>.x($t0)
@@ -362,10 +362,10 @@ pub fun TestBorrow::test5($t0|r_ref: &mut TestBorrow::R): (&mut u64, &mut TestBo
      # borrowed_by: Reference($t0) -> {Reference($t1)}
      # borrows_from: Reference($t1) -> {Reference($t0)}
   1: trace_local[r_ref]($t0)
-     # live_nodes: Reference($t0), Reference($t1)
+     # live_nodes: Reference($t1)
      # borrowed_by: Reference($t0) -> {Reference($t1)}
      # borrows_from: Reference($t1) -> {Reference($t0)}
-  2: return ($t1, $t0)
+  2: return $t1
 }
 
 
@@ -385,7 +385,7 @@ fun TestBorrow::test6(): TestBorrow::R {
      # live_nodes: Reference($t4)
      # borrowed_by: LocalRoot($t0) -> {Reference($t4)}
      # borrows_from: Reference($t4) -> {LocalRoot($t0)}
-  3: ($t5, $t4) := TestBorrow::test5($t4)
+  3: $t5 := TestBorrow::test5($t4)
      # live_nodes: Reference($t5)
      # borrowed_by: LocalRoot($t0) -> {Reference($t4)}, Reference($t4) -> {Reference($t5)}
      # borrows_from: Reference($t4) -> {LocalRoot($t0)}, Reference($t5) -> {Reference($t4)}
@@ -393,7 +393,7 @@ fun TestBorrow::test6(): TestBorrow::R {
      # live_nodes: Reference($t5)
      # borrowed_by: LocalRoot($t0) -> {Reference($t4)}, Reference($t4) -> {Reference($t5)}
      # borrows_from: Reference($t4) -> {LocalRoot($t0)}, Reference($t5) -> {Reference($t4)}
-  5: $t5 := TestBorrow::test2($t5, $t6)
+  5: TestBorrow::test2($t5, $t6)
      # borrowed_by: LocalRoot($t0) -> {Reference($t4)}, Reference($t4) -> {Reference($t5)}
      # borrows_from: Reference($t4) -> {LocalRoot($t0)}, Reference($t5) -> {Reference($t4)}
   6: $t7 := move($t0)
@@ -471,7 +471,7 @@ fun TestBorrow::test7($t0|b: bool) {
      # moved_nodes: Reference($t6)
      # borrowed_by: LocalRoot($t1) -> {Reference($t3)}, LocalRoot($t2) -> {Reference($t3)}
      # borrows_from: Reference($t3) -> {LocalRoot($t1), LocalRoot($t2)}
- 14: $t3 := TestBorrow::test3($t3, $t7)
+ 14: TestBorrow::test3($t3, $t7)
      # live_nodes: LocalRoot($t0)
      # moved_nodes: Reference($t6)
      # borrowed_by: LocalRoot($t1) -> {Reference($t3)}, LocalRoot($t2) -> {Reference($t3)}
@@ -511,7 +511,7 @@ fun TestBorrow::test7($t0|b: bool) {
 
 
 [variant baseline]
-fun TestBorrow::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestBorrow::R): &mut TestBorrow::R {
+fun TestBorrow::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestBorrow::R) {
      var $t3|r1: TestBorrow::R
      var $t4|r2: TestBorrow::R
      var $t5|t_ref: &mut TestBorrow::R
@@ -663,7 +663,7 @@ fun TestBorrow::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestBorrow::R): &
      # live_nodes: LocalRoot($t0), LocalRoot($t1), Reference($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}
- 36: $t2 := TestBorrow::test3($t2, $t15)
+ 36: TestBorrow::test3($t2, $t15)
      # live_nodes: LocalRoot($t0), LocalRoot($t1), Reference($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}
@@ -683,7 +683,7 @@ fun TestBorrow::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestBorrow::R): &
      # live_nodes: LocalRoot($t0), LocalRoot($t1), Reference($t2), Reference($t5)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}
- 41: $t5 := TestBorrow::test3($t5, $t16)
+ 41: TestBorrow::test3($t5, $t16)
      # live_nodes: LocalRoot($t0), LocalRoot($t1), Reference($t2)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}
@@ -692,8 +692,8 @@ fun TestBorrow::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestBorrow::R): &
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}
  43: trace_local[r_ref]($t2)
-     # live_nodes: LocalRoot($t0), LocalRoot($t1), Reference($t2)
+     # live_nodes: LocalRoot($t0), LocalRoot($t1)
      # borrowed_by: LocalRoot($t3) -> {Reference($t5)}, LocalRoot($t4) -> {Reference($t5)}
      # borrows_from: Reference($t5) -> {LocalRoot($t3), LocalRoot($t4)}
- 44: return $t2
+ 44: return ()
 }

--- a/language/move-prover/bytecode/tests/borrow/pack_unpack.exp
+++ b/language/move-prover/bytecode/tests/borrow/pack_unpack.exp
@@ -434,7 +434,7 @@ pub fun TestPackUnpack::update_via_returned_ref_var_incorrect(): TestPackUnpack:
 ============ after pipeline `borrow` ================
 
 [variant baseline]
-pub fun TestPackUnpack::call_private_violating_invariant($t0|r: &mut TestPackUnpack::R): &mut TestPackUnpack::R {
+pub fun TestPackUnpack::call_private_violating_invariant($t0|r: &mut TestPackUnpack::R) {
      var $t1|s: &mut TestPackUnpack::S
      var $t2: &mut TestPackUnpack::S
      var $t3: u64
@@ -449,7 +449,7 @@ pub fun TestPackUnpack::call_private_violating_invariant($t0|r: &mut TestPackUnp
      # live_nodes: Reference($t0), Reference($t2)
      # borrowed_by: Reference($t0) -> {Reference($t2)}
      # borrows_from: Reference($t2) -> {Reference($t0)}
-  2: $t2 := TestPackUnpack::private_update_value($t2, $t3)
+  2: TestPackUnpack::private_update_value($t2, $t3)
      # live_nodes: Reference($t0), Reference($t2)
      # borrowed_by: Reference($t0) -> {Reference($t2)}
      # borrows_from: Reference($t2) -> {Reference($t0)}
@@ -466,15 +466,14 @@ pub fun TestPackUnpack::call_private_violating_invariant($t0|r: &mut TestPackUnp
      # borrowed_by: Reference($t0) -> {Reference($t2)}, Reference($t2) -> {Reference($t5)}
      # borrows_from: Reference($t2) -> {Reference($t0)}, Reference($t5) -> {Reference($t2)}
   6: trace_local[r]($t0)
-     # live_nodes: Reference($t0)
      # borrowed_by: Reference($t0) -> {Reference($t2)}, Reference($t2) -> {Reference($t5)}
      # borrows_from: Reference($t2) -> {Reference($t0)}, Reference($t5) -> {Reference($t2)}
-  7: return $t0
+  7: return ()
 }
 
 
 [variant baseline]
-pub fun TestPackUnpack::call_public_violating_invariant_incorrect($t0|r: &mut TestPackUnpack::R): &mut TestPackUnpack::R {
+pub fun TestPackUnpack::call_public_violating_invariant_incorrect($t0|r: &mut TestPackUnpack::R) {
      var $t1|s: &mut TestPackUnpack::S
      var $t2: &mut TestPackUnpack::S
      var $t3: u64
@@ -489,7 +488,7 @@ pub fun TestPackUnpack::call_public_violating_invariant_incorrect($t0|r: &mut Te
      # live_nodes: Reference($t0), Reference($t2)
      # borrowed_by: Reference($t0) -> {Reference($t2)}
      # borrows_from: Reference($t2) -> {Reference($t0)}
-  2: $t2 := TestPackUnpack::public_update_value($t2, $t3)
+  2: TestPackUnpack::public_update_value($t2, $t3)
      # live_nodes: Reference($t0), Reference($t2)
      # borrowed_by: Reference($t0) -> {Reference($t2)}
      # borrows_from: Reference($t2) -> {Reference($t0)}
@@ -506,10 +505,9 @@ pub fun TestPackUnpack::call_public_violating_invariant_incorrect($t0|r: &mut Te
      # borrowed_by: Reference($t0) -> {Reference($t2)}, Reference($t2) -> {Reference($t5)}
      # borrows_from: Reference($t2) -> {Reference($t0)}, Reference($t5) -> {Reference($t2)}
   6: trace_local[r]($t0)
-     # live_nodes: Reference($t0)
      # borrowed_by: Reference($t0) -> {Reference($t2)}, Reference($t2) -> {Reference($t5)}
      # borrows_from: Reference($t2) -> {Reference($t0)}, Reference($t5) -> {Reference($t2)}
-  7: return $t0
+  7: return ()
 }
 
 
@@ -591,7 +589,7 @@ pub fun TestPackUnpack::extract_and_update($t0|r: TestPackUnpack::R): TestPackUn
 
 
 [variant baseline]
-fun TestPackUnpack::get_value_ref($t0|r: &mut TestPackUnpack::R): (&mut u64, &mut TestPackUnpack::R) {
+fun TestPackUnpack::get_value_ref($t0|r: &mut TestPackUnpack::R): &mut u64 {
      var $t1: &mut TestPackUnpack::S
      var $t2: &mut u64
      # live_nodes: Reference($t0)
@@ -604,15 +602,15 @@ fun TestPackUnpack::get_value_ref($t0|r: &mut TestPackUnpack::R): (&mut u64, &mu
      # borrowed_by: Reference($t0) -> {Reference($t1)}, Reference($t1) -> {Reference($t2)}
      # borrows_from: Reference($t1) -> {Reference($t0)}, Reference($t2) -> {Reference($t1)}
   2: trace_local[r]($t0)
-     # live_nodes: Reference($t0), Reference($t2)
+     # live_nodes: Reference($t2)
      # borrowed_by: Reference($t0) -> {Reference($t1)}, Reference($t1) -> {Reference($t2)}
      # borrows_from: Reference($t1) -> {Reference($t0)}, Reference($t2) -> {Reference($t1)}
-  3: return ($t2, $t0)
+  3: return $t2
 }
 
 
 [variant baseline]
-pub fun TestPackUnpack::move_ref_unchanged($t0|r1: &mut TestPackUnpack::R, $t1|r2: &mut TestPackUnpack::R): (&mut TestPackUnpack::R, &mut TestPackUnpack::R) {
+pub fun TestPackUnpack::move_ref_unchanged($t0|r1: &mut TestPackUnpack::R, $t1|r2: &mut TestPackUnpack::R) {
      var $t2: TestPackUnpack::S
      var $t3: u64
      var $t4: TestPackUnpack::S
@@ -669,19 +667,18 @@ pub fun TestPackUnpack::move_ref_unchanged($t0|r1: &mut TestPackUnpack::R, $t1|r
      # borrowed_by: Reference($t0) -> {Reference($t12)}, Reference($t1) -> {Reference($t9)}, Reference($t9) -> {Reference($t10)}, Reference($t12) -> {Reference($t13)}
      # borrows_from: Reference($t9) -> {Reference($t1)}, Reference($t10) -> {Reference($t9)}, Reference($t12) -> {Reference($t0)}, Reference($t13) -> {Reference($t12)}
  14: trace_local[r1]($t0)
-     # live_nodes: Reference($t0), Reference($t1)
+     # live_nodes: Reference($t1)
      # borrowed_by: Reference($t0) -> {Reference($t12)}, Reference($t1) -> {Reference($t9)}, Reference($t9) -> {Reference($t10)}, Reference($t12) -> {Reference($t13)}
      # borrows_from: Reference($t9) -> {Reference($t1)}, Reference($t10) -> {Reference($t9)}, Reference($t12) -> {Reference($t0)}, Reference($t13) -> {Reference($t12)}
  15: trace_local[r2]($t1)
-     # live_nodes: Reference($t0), Reference($t1)
      # borrowed_by: Reference($t0) -> {Reference($t12)}, Reference($t1) -> {Reference($t9)}, Reference($t9) -> {Reference($t10)}, Reference($t12) -> {Reference($t13)}
      # borrows_from: Reference($t9) -> {Reference($t1)}, Reference($t10) -> {Reference($t9)}, Reference($t12) -> {Reference($t0)}, Reference($t13) -> {Reference($t12)}
- 16: return ($t0, $t1)
+ 16: return ()
 }
 
 
 [variant baseline]
-pub fun TestPackUnpack::move_ref_unchanged_invariant_incorrect($t0|r1: &mut TestPackUnpack::R, $t1|r2: &mut TestPackUnpack::R): (&mut TestPackUnpack::R, &mut TestPackUnpack::R) {
+pub fun TestPackUnpack::move_ref_unchanged_invariant_incorrect($t0|r1: &mut TestPackUnpack::R, $t1|r2: &mut TestPackUnpack::R) {
      var $t2: TestPackUnpack::S
      var $t3: u64
      var $t4: TestPackUnpack::S
@@ -732,19 +729,18 @@ pub fun TestPackUnpack::move_ref_unchanged_invariant_incorrect($t0|r1: &mut Test
      # borrowed_by: Reference($t0) -> {Reference($t10)}, Reference($t1) -> {Reference($t7)}, Reference($t7) -> {Reference($t8)}, Reference($t10) -> {Reference($t11)}
      # borrows_from: Reference($t7) -> {Reference($t1)}, Reference($t8) -> {Reference($t7)}, Reference($t10) -> {Reference($t0)}, Reference($t11) -> {Reference($t10)}
  12: trace_local[r1]($t0)
-     # live_nodes: Reference($t0), Reference($t1)
+     # live_nodes: Reference($t1)
      # borrowed_by: Reference($t0) -> {Reference($t10)}, Reference($t1) -> {Reference($t7)}, Reference($t7) -> {Reference($t8)}, Reference($t10) -> {Reference($t11)}
      # borrows_from: Reference($t7) -> {Reference($t1)}, Reference($t8) -> {Reference($t7)}, Reference($t10) -> {Reference($t0)}, Reference($t11) -> {Reference($t10)}
  13: trace_local[r2]($t1)
-     # live_nodes: Reference($t0), Reference($t1)
      # borrowed_by: Reference($t0) -> {Reference($t10)}, Reference($t1) -> {Reference($t7)}, Reference($t7) -> {Reference($t8)}, Reference($t10) -> {Reference($t11)}
      # borrows_from: Reference($t7) -> {Reference($t1)}, Reference($t8) -> {Reference($t7)}, Reference($t10) -> {Reference($t0)}, Reference($t11) -> {Reference($t10)}
- 14: return ($t0, $t1)
+ 14: return ()
 }
 
 
 [variant baseline]
-fun TestPackUnpack::private_pass_value_violating_invariant_incorrect($t0|s: &mut TestPackUnpack::S): (u64, &mut TestPackUnpack::S) {
+fun TestPackUnpack::private_pass_value_violating_invariant_incorrect($t0|s: &mut TestPackUnpack::S): u64 {
      var $t1: TestPackUnpack::S
      var $t2: u64
      # live_nodes: Reference($t0)
@@ -753,13 +749,12 @@ fun TestPackUnpack::private_pass_value_violating_invariant_incorrect($t0|s: &mut
   1: $t2 := TestPackUnpack::read_S_from_immutable($t1)
      # live_nodes: Reference($t0)
   2: trace_local[s]($t0)
-     # live_nodes: Reference($t0)
-  3: return ($t2, $t0)
+  3: return $t2
 }
 
 
 [variant baseline]
-fun TestPackUnpack::private_select_value_violating_invariant_incorrect($t0|r: &mut TestPackUnpack::R): (u64, &mut TestPackUnpack::R) {
+fun TestPackUnpack::private_select_value_violating_invariant_incorrect($t0|r: &mut TestPackUnpack::R): u64 {
      var $t1: TestPackUnpack::S
      var $t2: u64
      # live_nodes: Reference($t0)
@@ -768,13 +763,12 @@ fun TestPackUnpack::private_select_value_violating_invariant_incorrect($t0|r: &m
   1: $t2 := TestPackUnpack::read_S_from_immutable($t1)
      # live_nodes: Reference($t0)
   2: trace_local[r]($t0)
-     # live_nodes: Reference($t0)
-  3: return ($t2, $t0)
+  3: return $t2
 }
 
 
 [variant baseline]
-fun TestPackUnpack::private_update_value($t0|s: &mut TestPackUnpack::S, $t1|v: u64): &mut TestPackUnpack::S {
+fun TestPackUnpack::private_update_value($t0|s: &mut TestPackUnpack::S, $t1|v: u64) {
      var $t2: &mut u64
      # live_nodes: LocalRoot($t1), Reference($t0)
   0: $t2 := borrow_field<TestPackUnpack::S>.value($t0)
@@ -786,15 +780,15 @@ fun TestPackUnpack::private_update_value($t0|s: &mut TestPackUnpack::S, $t1|v: u
      # borrowed_by: Reference($t0) -> {Reference($t2)}
      # borrows_from: Reference($t2) -> {Reference($t0)}
   2: trace_local[s]($t0)
-     # live_nodes: LocalRoot($t1), Reference($t0)
+     # live_nodes: LocalRoot($t1)
      # borrowed_by: Reference($t0) -> {Reference($t2)}
      # borrows_from: Reference($t2) -> {Reference($t0)}
-  3: return $t0
+  3: return ()
 }
 
 
 [variant baseline]
-pub fun TestPackUnpack::public_update_value($t0|s: &mut TestPackUnpack::S, $t1|v: u64): &mut TestPackUnpack::S {
+pub fun TestPackUnpack::public_update_value($t0|s: &mut TestPackUnpack::S, $t1|v: u64) {
      var $t2: &mut u64
      # live_nodes: LocalRoot($t1), Reference($t0)
   0: $t2 := borrow_field<TestPackUnpack::S>.value($t0)
@@ -806,10 +800,10 @@ pub fun TestPackUnpack::public_update_value($t0|s: &mut TestPackUnpack::S, $t1|v
      # borrowed_by: Reference($t0) -> {Reference($t2)}
      # borrows_from: Reference($t2) -> {Reference($t0)}
   2: trace_local[s]($t0)
-     # live_nodes: LocalRoot($t1), Reference($t0)
+     # live_nodes: LocalRoot($t1)
      # borrowed_by: Reference($t0) -> {Reference($t2)}
      # borrows_from: Reference($t2) -> {Reference($t0)}
-  3: return $t0
+  3: return ()
 }
 
 
@@ -824,7 +818,7 @@ fun TestPackUnpack::read_S_from_immutable($t0|s: TestPackUnpack::S): u64 {
 
 
 [variant baseline]
-pub fun TestPackUnpack::read_ref_unchanged($t0|r: &mut TestPackUnpack::R): (u64, &mut TestPackUnpack::R) {
+pub fun TestPackUnpack::read_ref_unchanged($t0|r: &mut TestPackUnpack::R): u64 {
      var $t1|nested: &mut TestPackUnpack::S
      var $t2|tmp#$2: &mut TestPackUnpack::R
      var $t3: &mut TestPackUnpack::S
@@ -839,15 +833,14 @@ pub fun TestPackUnpack::read_ref_unchanged($t0|r: &mut TestPackUnpack::R): (u64,
      # borrowed_by: Reference($t0) -> {Reference($t3)}
      # borrows_from: Reference($t3) -> {Reference($t0)}
   2: trace_local[r]($t0)
-     # live_nodes: Reference($t0)
      # borrowed_by: Reference($t0) -> {Reference($t3)}
      # borrows_from: Reference($t3) -> {Reference($t0)}
-  3: return ($t4, $t0)
+  3: return $t4
 }
 
 
 [variant baseline]
-pub fun TestPackUnpack::select_value_violating_invariant_incorrect($t0|r: &mut TestPackUnpack::R): (u64, &mut TestPackUnpack::R) {
+pub fun TestPackUnpack::select_value_violating_invariant_incorrect($t0|r: &mut TestPackUnpack::R): u64 {
      var $t1|s: &mut TestPackUnpack::S
      var $t2: &mut TestPackUnpack::S
      var $t3: u64
@@ -880,15 +873,14 @@ pub fun TestPackUnpack::select_value_violating_invariant_incorrect($t0|r: &mut T
      # borrowed_by: Reference($t0) -> {Reference($t2)}, Reference($t2) -> {Reference($t4)}
      # borrows_from: Reference($t2) -> {Reference($t0)}, Reference($t4) -> {Reference($t2)}
   6: trace_local[r]($t0)
-     # live_nodes: Reference($t0)
      # borrowed_by: Reference($t0) -> {Reference($t2)}, Reference($t2) -> {Reference($t4)}
      # borrows_from: Reference($t2) -> {Reference($t0)}, Reference($t4) -> {Reference($t2)}
-  7: return ($t6, $t0)
+  7: return $t6
 }
 
 
 [variant baseline]
-pub fun TestPackUnpack::update_ref_changed($t0|r: &mut TestPackUnpack::R): (u64, &mut TestPackUnpack::R) {
+pub fun TestPackUnpack::update_ref_changed($t0|r: &mut TestPackUnpack::R): u64 {
      var $t1|nested: &mut TestPackUnpack::S
      var $t2|tmp#$2: &mut TestPackUnpack::R
      var $t3: &mut TestPackUnpack::S
@@ -927,10 +919,9 @@ pub fun TestPackUnpack::update_ref_changed($t0|r: &mut TestPackUnpack::R): (u64,
      # borrowed_by: Reference($t0) -> {Reference($t3)}, Reference($t3) -> {Reference($t7)}
      # borrows_from: Reference($t3) -> {Reference($t0)}, Reference($t7) -> {Reference($t3)}
   7: trace_local[r]($t0)
-     # live_nodes: Reference($t0)
      # borrowed_by: Reference($t0) -> {Reference($t3)}, Reference($t3) -> {Reference($t7)}
      # borrows_from: Reference($t3) -> {Reference($t0)}, Reference($t7) -> {Reference($t3)}
-  8: return ($t8, $t0)
+  8: return $t8
 }
 
 
@@ -951,7 +942,7 @@ pub fun TestPackUnpack::update_via_returned_ref(): TestPackUnpack::R {
      # live_nodes: Reference($t4)
      # borrowed_by: LocalRoot($t0) -> {Reference($t4)}
      # borrows_from: Reference($t4) -> {LocalRoot($t0)}
-  4: ($t5, $t4) := TestPackUnpack::get_value_ref($t4)
+  4: $t5 := TestPackUnpack::get_value_ref($t4)
      # live_nodes: Reference($t5)
      # borrowed_by: LocalRoot($t0) -> {Reference($t4)}, Reference($t4) -> {Reference($t5)}
      # borrows_from: Reference($t4) -> {LocalRoot($t0)}, Reference($t5) -> {Reference($t4)}
@@ -987,7 +978,7 @@ pub fun TestPackUnpack::update_via_returned_ref_invariant_incorrect(): TestPackU
      # live_nodes: Reference($t4)
      # borrowed_by: LocalRoot($t0) -> {Reference($t4)}
      # borrows_from: Reference($t4) -> {LocalRoot($t0)}
-  4: ($t5, $t4) := TestPackUnpack::get_value_ref($t4)
+  4: $t5 := TestPackUnpack::get_value_ref($t4)
      # live_nodes: Reference($t5)
      # borrowed_by: LocalRoot($t0) -> {Reference($t4)}, Reference($t4) -> {Reference($t5)}
      # borrows_from: Reference($t4) -> {LocalRoot($t0)}, Reference($t5) -> {Reference($t4)}
@@ -1023,7 +1014,7 @@ pub fun TestPackUnpack::update_via_returned_ref_var_incorrect(): TestPackUnpack:
      # live_nodes: Reference($t4)
      # borrowed_by: LocalRoot($t0) -> {Reference($t4)}
      # borrows_from: Reference($t4) -> {LocalRoot($t0)}
-  4: ($t5, $t4) := TestPackUnpack::get_value_ref($t4)
+  4: $t5 := TestPackUnpack::get_value_ref($t4)
      # live_nodes: Reference($t5)
      # borrowed_by: LocalRoot($t0) -> {Reference($t4)}, Reference($t4) -> {Reference($t5)}
      # borrows_from: Reference($t4) -> {LocalRoot($t0)}, Reference($t5) -> {Reference($t4)}

--- a/language/move-prover/bytecode/tests/clean_and_optimize/pack_unpack.exp
+++ b/language/move-prover/bytecode/tests/clean_and_optimize/pack_unpack.exp
@@ -434,7 +434,7 @@ pub fun TestPackUnpack::update_via_returned_ref_var_incorrect(): TestPackUnpack:
 ============ after pipeline `clean_and_optimize` ================
 
 [variant baseline]
-pub fun TestPackUnpack::call_private_violating_invariant($t0|r: &mut TestPackUnpack::R): &mut TestPackUnpack::R {
+pub fun TestPackUnpack::call_private_violating_invariant($t0|r: &mut TestPackUnpack::R) {
      var $t1|s: &mut TestPackUnpack::S
      var $t2: &mut TestPackUnpack::S
      var $t3: u64
@@ -443,7 +443,7 @@ pub fun TestPackUnpack::call_private_violating_invariant($t0|r: &mut TestPackUnp
   0: $t2 := borrow_field<TestPackUnpack::R>.nested($t0)
   1: unpack_ref($t2)
   2: $t3 := 0
-  3: $t2 := TestPackUnpack::private_update_value($t2, $t3)
+  3: TestPackUnpack::private_update_value($t2, $t3)
   4: $t4 := 1
   5: $t5 := borrow_field<TestPackUnpack::S>.value($t2)
   6: write_ref($t5, $t4)
@@ -452,12 +452,12 @@ pub fun TestPackUnpack::call_private_violating_invariant($t0|r: &mut TestPackUnp
   9: write_back[Reference($t0)]($t2)
  10: trace_local[r]($t0)
  11: pack_ref($t0)
- 12: return $t0
+ 12: return ()
 }
 
 
 [variant baseline]
-pub fun TestPackUnpack::call_public_violating_invariant_incorrect($t0|r: &mut TestPackUnpack::R): &mut TestPackUnpack::R {
+pub fun TestPackUnpack::call_public_violating_invariant_incorrect($t0|r: &mut TestPackUnpack::R) {
      var $t1|s: &mut TestPackUnpack::S
      var $t2: &mut TestPackUnpack::S
      var $t3: u64
@@ -467,7 +467,7 @@ pub fun TestPackUnpack::call_public_violating_invariant_incorrect($t0|r: &mut Te
   1: unpack_ref($t2)
   2: $t3 := 0
   3: pack_ref($t2)
-  4: $t2 := TestPackUnpack::public_update_value($t2, $t3)
+  4: TestPackUnpack::public_update_value($t2, $t3)
   5: unpack_ref($t2)
   6: $t4 := 1
   7: $t5 := borrow_field<TestPackUnpack::S>.value($t2)
@@ -477,7 +477,7 @@ pub fun TestPackUnpack::call_public_violating_invariant_incorrect($t0|r: &mut Te
  11: write_back[Reference($t0)]($t2)
  12: trace_local[r]($t0)
  13: pack_ref($t0)
- 14: return $t0
+ 14: return ()
 }
 
 
@@ -533,21 +533,21 @@ pub fun TestPackUnpack::extract_and_update($t0|r: TestPackUnpack::R): TestPackUn
 
 
 [variant baseline]
-fun TestPackUnpack::get_value_ref($t0|r: &mut TestPackUnpack::R): (&mut u64, &mut TestPackUnpack::R) {
+fun TestPackUnpack::get_value_ref($t0|r: &mut TestPackUnpack::R): &mut u64 {
      var $t1: &mut TestPackUnpack::S
      var $t2: &mut u64
   0: $t1 := borrow_field<TestPackUnpack::R>.nested($t0)
   1: unpack_ref($t1)
   2: $t2 := borrow_field<TestPackUnpack::S>.value($t1)
   3: trace_local[r]($t0)
-  4: pack_ref($t0)
-  5: pack_ref($t1)
-  6: return ($t2, $t0)
+  4: pack_ref($t1)
+  5: pack_ref($t0)
+  6: return $t2
 }
 
 
 [variant baseline]
-pub fun TestPackUnpack::move_ref_unchanged($t0|r1: &mut TestPackUnpack::R, $t1|r2: &mut TestPackUnpack::R): (&mut TestPackUnpack::R, &mut TestPackUnpack::R) {
+pub fun TestPackUnpack::move_ref_unchanged($t0|r1: &mut TestPackUnpack::R, $t1|r2: &mut TestPackUnpack::R) {
      var $t2: TestPackUnpack::S
      var $t3: u64
      var $t4: TestPackUnpack::S
@@ -583,15 +583,15 @@ pub fun TestPackUnpack::move_ref_unchanged($t0|r1: &mut TestPackUnpack::R, $t1|r
  20: pack_ref($t12)
  21: write_back[Reference($t0)]($t12)
  22: trace_local[r1]($t0)
- 23: trace_local[r2]($t1)
- 24: pack_ref($t0)
+ 23: pack_ref($t0)
+ 24: trace_local[r2]($t1)
  25: pack_ref($t1)
- 26: return ($t0, $t1)
+ 26: return ()
 }
 
 
 [variant baseline]
-pub fun TestPackUnpack::move_ref_unchanged_invariant_incorrect($t0|r1: &mut TestPackUnpack::R, $t1|r2: &mut TestPackUnpack::R): (&mut TestPackUnpack::R, &mut TestPackUnpack::R) {
+pub fun TestPackUnpack::move_ref_unchanged_invariant_incorrect($t0|r1: &mut TestPackUnpack::R, $t1|r2: &mut TestPackUnpack::R) {
      var $t2: TestPackUnpack::S
      var $t3: u64
      var $t4: TestPackUnpack::S
@@ -623,58 +623,58 @@ pub fun TestPackUnpack::move_ref_unchanged_invariant_incorrect($t0|r1: &mut Test
  18: pack_ref($t10)
  19: write_back[Reference($t0)]($t10)
  20: trace_local[r1]($t0)
- 21: trace_local[r2]($t1)
- 22: pack_ref($t0)
+ 21: pack_ref($t0)
+ 22: trace_local[r2]($t1)
  23: pack_ref($t1)
- 24: return ($t0, $t1)
+ 24: return ()
 }
 
 
 [variant baseline]
-fun TestPackUnpack::private_pass_value_violating_invariant_incorrect($t0|s: &mut TestPackUnpack::S): (u64, &mut TestPackUnpack::S) {
+fun TestPackUnpack::private_pass_value_violating_invariant_incorrect($t0|s: &mut TestPackUnpack::S): u64 {
      var $t1: TestPackUnpack::S
      var $t2: u64
   0: $t1 := read_ref($t0)
   1: $t2 := TestPackUnpack::read_S_from_immutable($t1)
   2: trace_local[s]($t0)
   3: pack_ref($t0)
-  4: return ($t2, $t0)
+  4: return $t2
 }
 
 
 [variant baseline]
-fun TestPackUnpack::private_select_value_violating_invariant_incorrect($t0|r: &mut TestPackUnpack::R): (u64, &mut TestPackUnpack::R) {
+fun TestPackUnpack::private_select_value_violating_invariant_incorrect($t0|r: &mut TestPackUnpack::R): u64 {
      var $t1: TestPackUnpack::S
      var $t2: u64
   0: $t1 := get_field<TestPackUnpack::R>.nested($t0)
   1: $t2 := TestPackUnpack::read_S_from_immutable($t1)
   2: trace_local[r]($t0)
   3: pack_ref($t0)
-  4: return ($t2, $t0)
+  4: return $t2
 }
 
 
 [variant baseline]
-fun TestPackUnpack::private_update_value($t0|s: &mut TestPackUnpack::S, $t1|v: u64): &mut TestPackUnpack::S {
+fun TestPackUnpack::private_update_value($t0|s: &mut TestPackUnpack::S, $t1|v: u64) {
      var $t2: &mut u64
   0: $t2 := borrow_field<TestPackUnpack::S>.value($t0)
   1: write_ref($t2, $t1)
   2: write_back[Reference($t0)]($t2)
   3: trace_local[s]($t0)
   4: pack_ref($t0)
-  5: return $t0
+  5: return ()
 }
 
 
 [variant baseline]
-pub fun TestPackUnpack::public_update_value($t0|s: &mut TestPackUnpack::S, $t1|v: u64): &mut TestPackUnpack::S {
+pub fun TestPackUnpack::public_update_value($t0|s: &mut TestPackUnpack::S, $t1|v: u64) {
      var $t2: &mut u64
   0: $t2 := borrow_field<TestPackUnpack::S>.value($t0)
   1: write_ref($t2, $t1)
   2: write_back[Reference($t0)]($t2)
   3: trace_local[s]($t0)
   4: pack_ref($t0)
-  5: return $t0
+  5: return ()
 }
 
 
@@ -687,7 +687,7 @@ fun TestPackUnpack::read_S_from_immutable($t0|s: TestPackUnpack::S): u64 {
 
 
 [variant baseline]
-pub fun TestPackUnpack::read_ref_unchanged($t0|r: &mut TestPackUnpack::R): (u64, &mut TestPackUnpack::R) {
+pub fun TestPackUnpack::read_ref_unchanged($t0|r: &mut TestPackUnpack::R): u64 {
      var $t1|nested: &mut TestPackUnpack::S
      var $t2|tmp#$2: &mut TestPackUnpack::R
      var $t3: &mut TestPackUnpack::S
@@ -698,12 +698,12 @@ pub fun TestPackUnpack::read_ref_unchanged($t0|r: &mut TestPackUnpack::R): (u64,
   3: pack_ref($t3)
   4: trace_local[r]($t0)
   5: pack_ref($t0)
-  6: return ($t4, $t0)
+  6: return $t4
 }
 
 
 [variant baseline]
-pub fun TestPackUnpack::select_value_violating_invariant_incorrect($t0|r: &mut TestPackUnpack::R): (u64, &mut TestPackUnpack::R) {
+pub fun TestPackUnpack::select_value_violating_invariant_incorrect($t0|r: &mut TestPackUnpack::R): u64 {
      var $t1|s: &mut TestPackUnpack::S
      var $t2: &mut TestPackUnpack::S
      var $t3: u64
@@ -722,12 +722,12 @@ pub fun TestPackUnpack::select_value_violating_invariant_incorrect($t0|r: &mut T
   9: $t6 := TestPackUnpack::read_S_from_immutable($t5)
  10: trace_local[r]($t0)
  11: pack_ref($t0)
- 12: return ($t6, $t0)
+ 12: return $t6
 }
 
 
 [variant baseline]
-pub fun TestPackUnpack::update_ref_changed($t0|r: &mut TestPackUnpack::R): (u64, &mut TestPackUnpack::R) {
+pub fun TestPackUnpack::update_ref_changed($t0|r: &mut TestPackUnpack::R): u64 {
      var $t1|nested: &mut TestPackUnpack::S
      var $t2|tmp#$2: &mut TestPackUnpack::R
      var $t3: &mut TestPackUnpack::S
@@ -749,7 +749,7 @@ pub fun TestPackUnpack::update_ref_changed($t0|r: &mut TestPackUnpack::R): (u64,
  10: write_back[Reference($t0)]($t3)
  11: trace_local[r]($t0)
  12: pack_ref($t0)
- 13: return ($t8, $t0)
+ 13: return $t8
 }
 
 
@@ -768,7 +768,7 @@ pub fun TestPackUnpack::update_via_returned_ref(): TestPackUnpack::R {
   2: $t0 := pack TestPackUnpack::R($t3)
   3: $t4 := borrow_local($t0)
   4: unpack_ref($t4)
-  5: ($t5, $t4) := TestPackUnpack::get_value_ref($t4)
+  5: $t5 := TestPackUnpack::get_value_ref($t4)
   6: $t6 := 2
   7: write_ref($t5, $t6)
   8: write_back[Reference($t4)]($t5)
@@ -794,7 +794,7 @@ pub fun TestPackUnpack::update_via_returned_ref_invariant_incorrect(): TestPackU
   2: $t0 := pack TestPackUnpack::R($t3)
   3: $t4 := borrow_local($t0)
   4: unpack_ref($t4)
-  5: ($t5, $t4) := TestPackUnpack::get_value_ref($t4)
+  5: $t5 := TestPackUnpack::get_value_ref($t4)
   6: $t6 := 0
   7: write_ref($t5, $t6)
   8: write_back[Reference($t4)]($t5)
@@ -820,7 +820,7 @@ pub fun TestPackUnpack::update_via_returned_ref_var_incorrect(): TestPackUnpack:
   2: $t0 := pack TestPackUnpack::R($t3)
   3: $t4 := borrow_local($t0)
   4: unpack_ref($t4)
-  5: ($t5, $t4) := TestPackUnpack::get_value_ref($t4)
+  5: $t5 := TestPackUnpack::get_value_ref($t4)
   6: $t6 := 1
   7: write_ref($t5, $t6)
   8: write_back[Reference($t4)]($t5)

--- a/language/move-prover/bytecode/tests/data_invariant_instrumentation/params.exp
+++ b/language/move-prover/bytecode/tests/data_invariant_instrumentation/params.exp
@@ -8,7 +8,7 @@ pub fun Test::test_param($t0|_simple_R: Test::R, $t1|_ref_R: &Test::R, $t2|_simp
 ============ after pipeline `data_invariant_instrumentation` ================
 
 [variant verification]
-pub fun Test::test_param($t0|_simple_R: Test::R, $t1|_ref_R: Test::R, $t2|_simple_S: Test::S, $t3|_mut_R: &mut Test::R): &mut Test::R {
+pub fun Test::test_param($t0|_simple_R: Test::R, $t1|_ref_R: Test::R, $t2|_simple_S: Test::S, $t3|_mut_R: &mut Test::R) {
   0: assume And(WellFormed($t0), And(Gt(select Test::R.x($t0), select Test::S.y(select Test::R.s($t0))), Gt(select Test::S.y(select Test::R.s($t0)), 0)))
   1: assume And(WellFormed($t1), And(Gt(select Test::R.x($t1), select Test::S.y(select Test::R.s($t1))), Gt(select Test::S.y(select Test::R.s($t1)), 0)))
   2: assume And(WellFormed($t2), Gt(select Test::S.y($t2), 0))
@@ -18,5 +18,5 @@ pub fun Test::test_param($t0|_simple_R: Test::R, $t1|_ref_R: Test::R, $t2|_simpl
      # VC: data invariant does not hold at tests/data_invariant_instrumentation/params.move:12:9+18
   5: assert Gt(select Test::R.x($t3), select Test::S.y(select Test::R.s($t3)))
   6: label L1
-  7: return $t3
+  7: return ()
 }

--- a/language/move-prover/bytecode/tests/livevar/mut_ref_unpack.exp
+++ b/language/move-prover/bytecode/tests/livevar/mut_ref_unpack.exp
@@ -55,7 +55,7 @@ pub fun TestMutRefs::unpack_incorrect($t0|r: &mut TestMutRefs::R): u64 {
 ============ after pipeline `livevar` ================
 
 [variant baseline]
-pub fun TestMutRefs::unpack($t0|r: &mut TestMutRefs::R): (u64, &mut TestMutRefs::R) {
+pub fun TestMutRefs::unpack($t0|r: &mut TestMutRefs::R): u64 {
      var $t1|result: u64
      var $t2|tmp#$2: &mut TestMutRefs::R
      var $t3|value: &mut u64
@@ -72,13 +72,13 @@ pub fun TestMutRefs::unpack($t0|r: &mut TestMutRefs::R): (u64, &mut TestMutRefs:
   3: write_ref($t4, $t6)
      # live vars: r, $t5
   4: trace_local[r]($t0)
-     # live vars: r, $t5
-  5: return ($t5, $t0)
+     # live vars: $t5
+  5: return $t5
 }
 
 
 [variant baseline]
-pub fun TestMutRefs::unpack_incorrect($t0|r: &mut TestMutRefs::R): (u64, &mut TestMutRefs::R) {
+pub fun TestMutRefs::unpack_incorrect($t0|r: &mut TestMutRefs::R): u64 {
      var $t1|result: u64
      var $t2|tmp#$2: &mut TestMutRefs::R
      var $t3|value: &mut u64
@@ -90,6 +90,6 @@ pub fun TestMutRefs::unpack_incorrect($t0|r: &mut TestMutRefs::R): (u64, &mut Te
   1: $t5 := read_ref($t4)
      # live vars: r, $t5
   2: trace_local[r]($t0)
-     # live vars: r, $t5
-  3: return ($t5, $t0)
+     # live vars: $t5
+  3: return $t5
 }

--- a/language/move-prover/bytecode/tests/memory_instr/basic_test.exp
+++ b/language/move-prover/bytecode/tests/memory_instr/basic_test.exp
@@ -281,22 +281,22 @@ fun TestPackref::test1(): TestPackref::R {
 
 
 [variant baseline]
-fun TestPackref::test2($t0|x_ref: &mut u64, $t1|v: u64): &mut u64 {
+fun TestPackref::test2($t0|x_ref: &mut u64, $t1|v: u64) {
   0: write_ref($t0, $t1)
   1: trace_local[x_ref]($t0)
-  2: return $t0
+  2: return ()
 }
 
 
 [variant baseline]
-pub fun TestPackref::test3($t0|r_ref: &mut TestPackref::R, $t1|v: u64): &mut TestPackref::R {
+pub fun TestPackref::test3($t0|r_ref: &mut TestPackref::R, $t1|v: u64) {
      var $t2|x_ref: &mut u64
      var $t3: &mut u64
   0: $t3 := borrow_field<TestPackref::R>.x($t0)
-  1: $t3 := TestPackref::test2($t3, $t1)
+  1: TestPackref::test2($t3, $t1)
   2: write_back[Reference($t0)]($t3)
   3: trace_local[r_ref]($t0)
-  4: return $t0
+  4: return ()
 }
 
 
@@ -312,7 +312,7 @@ fun TestPackref::test4(): TestPackref::R {
   1: $t0 := pack TestPackref::R($t2)
   2: $t3 := borrow_local($t0)
   3: $t4 := 0
-  4: $t3 := TestPackref::test3($t3, $t4)
+  4: TestPackref::test3($t3, $t4)
   5: write_back[LocalRoot($t0)]($t3)
   6: $t5 := move($t0)
   7: return $t5
@@ -320,12 +320,12 @@ fun TestPackref::test4(): TestPackref::R {
 
 
 [variant baseline]
-pub fun TestPackref::test5($t0|r_ref: &mut TestPackref::R): (&mut u64, &mut TestPackref::R) {
+pub fun TestPackref::test5($t0|r_ref: &mut TestPackref::R): &mut u64 {
      var $t1: &mut u64
   0: $t1 := borrow_field<TestPackref::R>.x($t0)
   1: trace_local[r_ref]($t0)
   2: write_back[Reference($t0)]($t1)
-  3: return ($t1, $t0)
+  3: return $t1
 }
 
 
@@ -342,9 +342,9 @@ fun TestPackref::test6(): TestPackref::R {
   0: $t3 := 3
   1: $t0 := pack TestPackref::R($t3)
   2: $t4 := borrow_local($t0)
-  3: ($t5, $t4) := TestPackref::test5($t4)
+  3: $t5 := TestPackref::test5($t4)
   4: $t6 := 0
-  5: $t5 := TestPackref::test2($t5, $t6)
+  5: TestPackref::test2($t5, $t6)
   6: write_back[Reference($t4)]($t5)
   7: write_back[LocalRoot($t0)]($t4)
   8: $t7 := move($t0)
@@ -376,7 +376,7 @@ fun TestPackref::test7($t0|b: bool) {
  12: $t3 := borrow_local($t2)
  13: label L2
  14: $t7 := 0
- 15: $t3 := TestPackref::test3($t3, $t7)
+ 15: TestPackref::test3($t3, $t7)
  16: write_back[LocalRoot($t1)]($t3)
  17: write_back[LocalRoot($t2)]($t3)
  18: return ()
@@ -391,7 +391,7 @@ fun TestPackref::test7($t0|b: bool) {
 
 
 [variant baseline]
-fun TestPackref::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestPackref::R): &mut TestPackref::R {
+fun TestPackref::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestPackref::R) {
      var $t3|r1: TestPackref::R
      var $t4|r2: TestPackref::R
      var $t5|t_ref: &mut TestPackref::R
@@ -446,15 +446,15 @@ fun TestPackref::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestPackref::R):
  37: write_back[LocalRoot($t3)]($t5)
  38: write_back[LocalRoot($t4)]($t5)
  39: $t15 := 0
- 40: $t2 := TestPackref::test3($t2, $t15)
+ 40: TestPackref::test3($t2, $t15)
  41: goto 48
  42: label L10
  43: destroy($t2)
  44: $t16 := 0
- 45: $t5 := TestPackref::test3($t5, $t16)
+ 45: TestPackref::test3($t5, $t16)
  46: write_back[LocalRoot($t3)]($t5)
  47: write_back[LocalRoot($t4)]($t5)
  48: label L11
  49: trace_local[r_ref]($t2)
- 50: return $t2
+ 50: return ()
 }

--- a/language/move-prover/bytecode/tests/memory_instr/mut_ref.exp
+++ b/language/move-prover/bytecode/tests/memory_instr/mut_ref.exp
@@ -274,14 +274,14 @@ pub fun TestMutRefsUser::valid() {
 ============ after pipeline `memory_instr` ================
 
 [variant baseline]
-pub fun TestMutRefs::data_invariant($t0|_x: &mut TestMutRefs::T): &mut TestMutRefs::T {
+pub fun TestMutRefs::data_invariant($t0|_x: &mut TestMutRefs::T) {
   0: trace_local[_x]($t0)
-  1: return $t0
+  1: return ()
 }
 
 
 [variant baseline]
-pub fun TestMutRefs::decrement_invalid($t0|x: &mut TestMutRefs::T): &mut TestMutRefs::T {
+pub fun TestMutRefs::decrement_invalid($t0|x: &mut TestMutRefs::T) {
      var $t1|r: &mut TestMutRefs::TSum
      var $t2: u64
      var $t3: u64
@@ -309,7 +309,7 @@ pub fun TestMutRefs::decrement_invalid($t0|x: &mut TestMutRefs::T): &mut TestMut
  13: write_back[Reference($t7)]($t11)
  14: write_back[TestMutRefs::TSum]($t7)
  15: trace_local[x]($t0)
- 16: return $t0
+ 16: return ()
 }
 
 
@@ -337,7 +337,7 @@ pub fun TestMutRefs::delete($t0|x: TestMutRefs::T) {
 
 
 [variant baseline]
-pub fun TestMutRefs::increment($t0|x: &mut TestMutRefs::T): &mut TestMutRefs::T {
+pub fun TestMutRefs::increment($t0|x: &mut TestMutRefs::T) {
      var $t1|r: &mut TestMutRefs::TSum
      var $t2: u64
      var $t3: u64
@@ -365,12 +365,12 @@ pub fun TestMutRefs::increment($t0|x: &mut TestMutRefs::T): &mut TestMutRefs::T 
  13: write_back[Reference($t7)]($t11)
  14: write_back[TestMutRefs::TSum]($t7)
  15: trace_local[x]($t0)
- 16: return $t0
+ 16: return ()
 }
 
 
 [variant baseline]
-pub fun TestMutRefs::increment_invalid($t0|x: &mut TestMutRefs::T): &mut TestMutRefs::T {
+pub fun TestMutRefs::increment_invalid($t0|x: &mut TestMutRefs::T) {
      var $t1: u64
      var $t2: u64
      var $t3: u64
@@ -382,7 +382,7 @@ pub fun TestMutRefs::increment_invalid($t0|x: &mut TestMutRefs::T): &mut TestMut
   4: write_ref($t4, $t3)
   5: write_back[Reference($t0)]($t4)
   6: trace_local[x]($t0)
-  7: return $t0
+  7: return ()
 }
 
 
@@ -409,14 +409,14 @@ pub fun TestMutRefs::new($t0|x: u64): TestMutRefs::T {
 
 
 [variant baseline]
-fun TestMutRefs::private_data_invariant_invalid($t0|_x: &mut TestMutRefs::T): &mut TestMutRefs::T {
+fun TestMutRefs::private_data_invariant_invalid($t0|_x: &mut TestMutRefs::T) {
   0: trace_local[_x]($t0)
-  1: return $t0
+  1: return ()
 }
 
 
 [variant baseline]
-fun TestMutRefs::private_decrement($t0|x: &mut TestMutRefs::T): &mut TestMutRefs::T {
+fun TestMutRefs::private_decrement($t0|x: &mut TestMutRefs::T) {
      var $t1|r: &mut TestMutRefs::TSum
      var $t2: u64
      var $t3: u64
@@ -444,15 +444,15 @@ fun TestMutRefs::private_decrement($t0|x: &mut TestMutRefs::T): &mut TestMutRefs
  13: write_back[Reference($t7)]($t11)
  14: write_back[TestMutRefs::TSum]($t7)
  15: trace_local[x]($t0)
- 16: return $t0
+ 16: return ()
 }
 
 
 [variant baseline]
-fun TestMutRefs::private_to_public_caller($t0|r: &mut TestMutRefs::T): &mut TestMutRefs::T {
-  0: $t0 := TestMutRefs::increment($t0)
+fun TestMutRefs::private_to_public_caller($t0|r: &mut TestMutRefs::T) {
+  0: TestMutRefs::increment($t0)
   1: trace_local[r]($t0)
-  2: return $t0
+  2: return ()
 }
 
 
@@ -465,8 +465,8 @@ fun TestMutRefs::private_to_public_caller_invalid_data_invariant() {
   0: $t2 := 1
   1: $t1 := TestMutRefs::new($t2)
   2: $t3 := borrow_local($t1)
-  3: $t3 := TestMutRefs::private_decrement($t3)
-  4: $t3 := TestMutRefs::increment($t3)
+  3: TestMutRefs::private_decrement($t3)
+  4: TestMutRefs::increment($t3)
   5: write_back[LocalRoot($t1)]($t3)
   6: return ()
 }
@@ -481,7 +481,7 @@ pub fun TestMutRefsUser::valid() {
   0: $t1 := 4
   1: $t0 := TestMutRefs::new($t1)
   2: $t2 := borrow_local($t0)
-  3: $t2 := TestMutRefs::increment($t2)
+  3: TestMutRefs::increment($t2)
   4: write_back[LocalRoot($t0)]($t2)
   5: $t3 := move($t0)
   6: TestMutRefs::delete($t3)

--- a/language/move-prover/bytecode/tests/mut_ref_instrumentation/basic_test.exp
+++ b/language/move-prover/bytecode/tests/mut_ref_instrumentation/basic_test.exp
@@ -287,19 +287,19 @@ fun TestEliminateMutRefs::test1(): TestEliminateMutRefs::R {
 
 
 [variant baseline]
-fun TestEliminateMutRefs::test2($t0|x_ref: &mut u64, $t1|v: u64): &mut u64 {
+fun TestEliminateMutRefs::test2($t0|x_ref: &mut u64, $t1|v: u64) {
      var $t2: u64
      var $t3: &mut u64
   0: $t2 := copy($t1)
   1: $t3 := copy($t0)
   2: write_ref($t3, $t2)
   3: trace_local[x_ref]($t0)
-  4: return $t0
+  4: return ()
 }
 
 
 [variant baseline]
-pub fun TestEliminateMutRefs::test3($t0|r_ref: &mut TestEliminateMutRefs::R, $t1|v: u64): &mut TestEliminateMutRefs::R {
+pub fun TestEliminateMutRefs::test3($t0|r_ref: &mut TestEliminateMutRefs::R, $t1|v: u64) {
      var $t2|x_ref: &mut u64
      var $t3: &mut TestEliminateMutRefs::R
      var $t4: &mut u64
@@ -310,9 +310,9 @@ pub fun TestEliminateMutRefs::test3($t0|r_ref: &mut TestEliminateMutRefs::R, $t1
   2: $t2 := $t4
   3: $t5 := move($t2)
   4: $t6 := copy($t1)
-  5: $t5 := TestEliminateMutRefs::test2($t5, $t6)
+  5: TestEliminateMutRefs::test2($t5, $t6)
   6: trace_local[r_ref]($t0)
-  7: return $t0
+  7: return ()
 }
 
 
@@ -333,20 +333,20 @@ fun TestEliminateMutRefs::test4(): TestEliminateMutRefs::R {
   4: $t1 := $t4
   5: $t5 := move($t1)
   6: $t6 := 0
-  7: $t5 := TestEliminateMutRefs::test3($t5, $t6)
+  7: TestEliminateMutRefs::test3($t5, $t6)
   8: $t7 := move($t0)
   9: return $t7
 }
 
 
 [variant baseline]
-pub fun TestEliminateMutRefs::test5($t0|r_ref: &mut TestEliminateMutRefs::R): (&mut u64, &mut TestEliminateMutRefs::R) {
+pub fun TestEliminateMutRefs::test5($t0|r_ref: &mut TestEliminateMutRefs::R): &mut u64 {
      var $t1: &mut TestEliminateMutRefs::R
      var $t2: &mut u64
   0: $t1 := copy($t0)
   1: $t2 := borrow_field<TestEliminateMutRefs::R>.x($t1)
   2: trace_local[r_ref]($t0)
-  3: return ($t2, $t0)
+  3: return $t2
 }
 
 
@@ -369,11 +369,11 @@ fun TestEliminateMutRefs::test6(): TestEliminateMutRefs::R {
   3: $t5 := borrow_local($t0)
   4: $t1 := $t5
   5: $t6 := move($t1)
-  6: ($t7, $t6) := TestEliminateMutRefs::test5($t6)
+  6: $t7 := TestEliminateMutRefs::test5($t6)
   7: $t2 := $t7
   8: $t8 := move($t2)
   9: $t9 := 0
- 10: $t8 := TestEliminateMutRefs::test2($t8, $t9)
+ 10: TestEliminateMutRefs::test2($t8, $t9)
  11: $t10 := move($t0)
  12: return $t10
 }
@@ -414,13 +414,13 @@ fun TestEliminateMutRefs::test7($t0|b: bool) {
  17: label L2
  18: $t12 := move($t3)
  19: $t13 := 0
- 20: $t12 := TestEliminateMutRefs::test3($t12, $t13)
+ 20: TestEliminateMutRefs::test3($t12, $t13)
  21: return ()
 }
 
 
 [variant baseline]
-fun TestEliminateMutRefs::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestEliminateMutRefs::R): &mut TestEliminateMutRefs::R {
+fun TestEliminateMutRefs::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestEliminateMutRefs::R) {
      var $t3|r1: TestEliminateMutRefs::R
      var $t4|r2: TestEliminateMutRefs::R
      var $t5|t_ref: &mut TestEliminateMutRefs::R
@@ -499,15 +499,15 @@ fun TestEliminateMutRefs::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestEli
  46: destroy($t26)
  47: $t27 := copy($t2)
  48: $t28 := 0
- 49: $t27 := TestEliminateMutRefs::test3($t27, $t28)
+ 49: TestEliminateMutRefs::test3($t27, $t28)
  50: goto 57
  51: label L10
  52: $t29 := copy($t2)
  53: destroy($t29)
  54: $t30 := move($t5)
  55: $t31 := 0
- 56: $t30 := TestEliminateMutRefs::test3($t30, $t31)
+ 56: TestEliminateMutRefs::test3($t30, $t31)
  57: label L11
  58: trace_local[r_ref]($t2)
- 59: return $t2
+ 59: return ()
 }

--- a/language/move-prover/bytecode/tests/reaching_def/mut_ref_unpack.exp
+++ b/language/move-prover/bytecode/tests/reaching_def/mut_ref_unpack.exp
@@ -55,7 +55,7 @@ pub fun TestMutRefs::unpack_incorrect($t0|r: &mut TestMutRefs::R): u64 {
 ============ after pipeline `reaching_def` ================
 
 [variant baseline]
-pub fun TestMutRefs::unpack($t0|r: &mut TestMutRefs::R): (u64, &mut TestMutRefs::R) {
+pub fun TestMutRefs::unpack($t0|r: &mut TestMutRefs::R): u64 {
      var $t1|result: u64
      var $t2|tmp#$2: &mut TestMutRefs::R
      var $t3|value: &mut u64
@@ -80,12 +80,12 @@ pub fun TestMutRefs::unpack($t0|r: &mut TestMutRefs::R): (u64, &mut TestMutRefs:
  10: write_ref($t6, $t9)
  11: $t11 := copy($t8)
  12: trace_local[r]($t0)
- 13: return ($t8, $t0)
+ 13: return $t8
 }
 
 
 [variant baseline]
-pub fun TestMutRefs::unpack_incorrect($t0|r: &mut TestMutRefs::R): (u64, &mut TestMutRefs::R) {
+pub fun TestMutRefs::unpack_incorrect($t0|r: &mut TestMutRefs::R): u64 {
      var $t1|result: u64
      var $t2|tmp#$2: &mut TestMutRefs::R
      var $t3|value: &mut u64
@@ -105,5 +105,5 @@ pub fun TestMutRefs::unpack_incorrect($t0|r: &mut TestMutRefs::R): (u64, &mut Te
   7: $t1 := $t8
   8: $t9 := copy($t8)
   9: trace_local[r]($t0)
- 10: return ($t8, $t0)
+ 10: return $t8
 }

--- a/language/move-prover/bytecode/tests/spec_instrumentation/fun_spec.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/fun_spec.exp
@@ -269,7 +269,7 @@ fun Test::multiple_results($t0|a: u64, $t1|b: u64): (u64, u64) {
 
 
 [variant verification]
-fun Test::mut_ref_param($t0|r: &mut Test::R): (u64, &mut Test::R) {
+fun Test::mut_ref_param($t0|r: &mut Test::R): u64 {
      var $t1|x: u64
      var $t2: Test::R
      var $t3: u64
@@ -278,32 +278,30 @@ fun Test::mut_ref_param($t0|r: &mut Test::R): (u64, &mut Test::R) {
      var $t6: u64
      var $t7: num
      var $t8: &mut u64
-     var $t9: &mut Test::R
   0: assume WellFormed($t0)
   1: $t2 := read_ref($t0)
   2: $t3 := get_field<Test::R>.v($t0)
   3: $t4 := get_field<Test::R>.v($t0)
   4: $t5 := 1
-  5: $t6 := -($t4, $t5) on_abort goto 16 with $t7
+  5: $t6 := -($t4, $t5) on_abort goto 15 with $t7
   6: $t8 := borrow_field<Test::R>.v($t0)
   7: write_ref($t8, $t6)
   8: write_back[Reference($t0)]($t8)
   9: trace_local[r]($t0)
- 10: $t9 := move($t0)
- 11: label L1
+ 10: label L1
      # VC: function does not abort under this condition at tests/spec_instrumentation/fun_spec.move:67:6+42
- 12: assert Not(Eq<u64>(select Test::R.v($t2), 0))
+ 11: assert Not(Eq<u64>(select Test::R.v($t2), 0))
      # VC: post-condition does not hold at tests/spec_instrumentation/fun_spec.move:68:6+27
- 13: assert Eq<u64>($t3, select Test::R.v($t2))
+ 12: assert Eq<u64>($t3, select Test::R.v($t2))
      # VC: post-condition does not hold at tests/spec_instrumentation/fun_spec.move:69:6+28
- 14: assert Eq<u64>(select Test::R.v($t0), Add(select Test::R.v($t2), 1))
- 15: return ($t3, $t9)
- 16: label L2
+ 13: assert Eq<u64>(select Test::R.v($t0), Add(select Test::R.v($t2), 1))
+ 14: return $t3
+ 15: label L2
      # VC: abort not covered by any of the `aborts_if` clauses at tests/spec_instrumentation/fun_spec.move:66:2+142
- 17: assert Eq<u64>(select Test::R.v($t2), 0)
+ 16: assert Eq<u64>(select Test::R.v($t2), 0)
      # VC: abort code not covered by any of the `aborts_if` or `aborts_with` clauses at tests/spec_instrumentation/fun_spec.move:66:2+142
- 18: assert And(Eq<u64>(select Test::R.v($t2), 0), Eq(-1, $t7))
- 19: abort($t7)
+ 17: assert And(Eq<u64>(select Test::R.v($t2), 0), Eq(-1, $t7))
+ 18: abort($t7)
 }
 
 


### PR DESCRIPTION
This change came out from a conversation with Shaz. Instead of transforming a function `f(&mut)` from `f(x)` to `x := f(x)` already on bytecode level, we defer this step until Boogie generation, and assume for the bytecode semantics that `&mut` parameter passing semantics is supported. This removes some irregularities in the borrow analysis and simplifies the memory instrumentation further.

## Motivation

Simplification.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests

## Related PRs

NA
