### PR TITLE
[language] clean up use of gas_schedule::CostStrategy

### DIFF
--- a/language/benchmarks/src/move_vm.rs
+++ b/language/benchmarks/src/move_vm.rs
@@ -12,7 +12,7 @@ use move_core_types::{
 };
 use move_lang::{compiled_unit::CompiledUnit, shared::Address};
 use move_vm_runtime::{logging::NoContextLog, move_vm::MoveVM};
-use move_vm_types::gas_schedule::CostStrategy;
+use move_vm_types::gas_schedule::GasStatus;
 use once_cell::sync::Lazy;
 use std::path::PathBuf;
 use vm::CompiledModule;
@@ -73,7 +73,7 @@ fn execute<M: Measurement + 'static>(
     let data_cache = StateViewCache::new(&state);
     let log_context = NoContextLog::new();
     let mut session = move_vm.new_session(&data_cache);
-    let mut cost_strategy = CostStrategy::system();
+    let mut gas_status = GasStatus::new_unmetered();
 
     for module in modules {
         let mut mod_blob = vec![];
@@ -81,7 +81,7 @@ fn execute<M: Measurement + 'static>(
             .serialize(&mut mod_blob)
             .expect("Module serialization error");
         session
-            .publish_module(mod_blob, sender, &mut cost_strategy, &log_context)
+            .publish_module(mod_blob, sender, &mut gas_status, &log_context)
             .expect("Module must load");
     }
 
@@ -98,7 +98,7 @@ fn execute<M: Measurement + 'static>(
                     &fun_name,
                     vec![],
                     vec![],
-                    &mut cost_strategy,
+                    &mut gas_status,
                     &log_context,
                 )
                 .unwrap_or_else(|err| {

--- a/language/benchmarks/src/move_vm.rs
+++ b/language/benchmarks/src/move_vm.rs
@@ -7,13 +7,12 @@ use diem_state_view::StateView;
 use diem_types::{access_path::AccessPath, account_address::AccountAddress};
 use diem_vm::data_cache::StateViewCache;
 use move_core_types::{
-    gas_schedule::{GasAlgebra, GasUnits},
     identifier::{IdentStr, Identifier},
     language_storage::ModuleId,
 };
 use move_lang::{compiled_unit::CompiledUnit, shared::Address};
 use move_vm_runtime::{logging::NoContextLog, move_vm::MoveVM};
-use move_vm_types::gas_schedule::{zero_cost_schedule, CostStrategy};
+use move_vm_types::gas_schedule::CostStrategy;
 use once_cell::sync::Lazy;
 use std::path::PathBuf;
 use vm::CompiledModule;
@@ -71,11 +70,10 @@ fn execute<M: Measurement + 'static>(
     // establish running context
     let sender = AccountAddress::new(Address::DIEM_CORE.to_u8());
     let state = EmptyStateView;
-    let gas_schedule = zero_cost_schedule();
     let data_cache = StateViewCache::new(&state);
     let log_context = NoContextLog::new();
     let mut session = move_vm.new_session(&data_cache);
-    let mut cost_strategy = CostStrategy::system(&gas_schedule, GasUnits::new(100_000_000));
+    let mut cost_strategy = CostStrategy::system();
 
     for module in modules {
         let mut mod_blob = vec![];

--- a/language/diem-tools/transaction-replay/src/lib.rs
+++ b/language/diem-tools/transaction-replay/src/lib.rs
@@ -19,7 +19,7 @@ use move_core_types::effects::ChangeSet as MoveChanges;
 use move_lang::{compiled_unit::CompiledUnit, move_compile};
 use move_vm_runtime::{logging::NoContextLog, move_vm::MoveVM, session::Session};
 use move_vm_test_utils::DeltaStorage;
-use move_vm_types::gas_schedule::CostStrategy;
+use move_vm_types::gas_schedule::GasStatus;
 use resource_viewer::{AnnotatedAccountStateBlob, MoveValueAnnotator};
 use std::path::{Path, PathBuf};
 use vm::{errors::VMResult, file_format::CompiledModule};
@@ -300,14 +300,14 @@ impl DiemDebugger {
         let predicate = compile_move_script(code_path)?;
         let is_version_ok = |version| {
             self.run_session_at_version(version, override_changeset.clone(), |session| {
-                let mut cost_strategy = CostStrategy::system();
+                let mut gas_status = GasStatus::new_unmetered();
                 let log_context = NoContextLog::new();
                 session.execute_script(
                     predicate.clone(),
                     vec![],
                     vec![],
                     vec![diem_root_address(), sender],
-                    &mut cost_strategy,
+                    &mut gas_status,
                     &log_context,
                 )
             })

--- a/language/diem-tools/transaction-replay/src/lib.rs
+++ b/language/diem-tools/transaction-replay/src/lib.rs
@@ -15,14 +15,11 @@ use diem_validator_interface::{
 };
 use diem_vm::{convert_changeset_and_events, data_cache::RemoteStorage, DiemVM, VMExecutor};
 use move_cli::OnDiskStateView;
-use move_core_types::{
-    effects::ChangeSet as MoveChanges,
-    gas_schedule::{GasAlgebra, GasUnits},
-};
+use move_core_types::effects::ChangeSet as MoveChanges;
 use move_lang::{compiled_unit::CompiledUnit, move_compile};
 use move_vm_runtime::{logging::NoContextLog, move_vm::MoveVM, session::Session};
 use move_vm_test_utils::DeltaStorage;
-use move_vm_types::gas_schedule::{zero_cost_schedule, CostStrategy};
+use move_vm_types::gas_schedule::CostStrategy;
 use resource_viewer::{AnnotatedAccountStateBlob, MoveValueAnnotator};
 use std::path::{Path, PathBuf};
 use vm::{errors::VMResult, file_format::CompiledModule};
@@ -301,10 +298,9 @@ impl DiemDebugger {
         // TODO: The code here is compiled against the local move stdlib instead of the one from on
         // chain storage.
         let predicate = compile_move_script(code_path)?;
-        let gas_table = zero_cost_schedule();
         let is_version_ok = |version| {
             self.run_session_at_version(version, override_changeset.clone(), |session| {
-                let mut cost_strategy = CostStrategy::system(&gas_table, GasUnits::new(0));
+                let mut cost_strategy = CostStrategy::system();
                 let log_context = NoContextLog::new();
                 session.execute_script(
                     predicate.clone(),

--- a/language/diem-tools/writeset-transaction-generator/src/writeset_builder.rs
+++ b/language/diem-tools/writeset-transaction-generator/src/writeset_builder.rs
@@ -18,7 +18,7 @@ use move_core_types::{
 use move_vm_runtime::{
     data_cache::RemoteCache, logging::NoContextLog, move_vm::MoveVM, session::Session,
 };
-use move_vm_types::gas_schedule::CostStrategy;
+use move_vm_types::gas_schedule::GasStatus;
 
 pub struct GenesisSession<'r, 'l, R>(Session<'r, 'l, R>);
 
@@ -39,7 +39,7 @@ impl<'r, 'l, R: RemoteCache> GenesisSession<'r, 'l, R> {
                 &Identifier::new(function_name).unwrap(),
                 ty_args,
                 args,
-                &mut CostStrategy::system(),
+                &mut GasStatus::new_unmetered(),
                 &NoContextLog::new(),
             )
             .unwrap_or_else(|e| {
@@ -59,7 +59,7 @@ impl<'r, 'l, R: RemoteCache> GenesisSession<'r, 'l, R> {
                 script.ty_args().to_vec(),
                 convert_txn_args(script.args()),
                 vec![sender],
-                &mut CostStrategy::system(),
+                &mut GasStatus::new_unmetered(),
                 &NoContextLog::new(),
             )
             .unwrap()

--- a/language/diem-tools/writeset-transaction-generator/src/writeset_builder.rs
+++ b/language/diem-tools/writeset-transaction-generator/src/writeset_builder.rs
@@ -10,7 +10,6 @@ use diem_types::{
 };
 use diem_vm::{convert_changeset_and_events, data_cache::RemoteStorage};
 use move_core_types::{
-    gas_schedule::{CostTable, GasAlgebra, GasUnits},
     identifier::Identifier,
     language_storage::{ModuleId, TypeTag},
     transaction_argument::convert_txn_args,
@@ -19,10 +18,7 @@ use move_core_types::{
 use move_vm_runtime::{
     data_cache::RemoteCache, logging::NoContextLog, move_vm::MoveVM, session::Session,
 };
-use move_vm_types::gas_schedule::{zero_cost_schedule, CostStrategy};
-use once_cell::sync::Lazy;
-
-pub static ZERO_COST_SCHEDULE: Lazy<CostTable> = Lazy::new(zero_cost_schedule);
+use move_vm_types::gas_schedule::CostStrategy;
 
 pub struct GenesisSession<'r, 'l, R>(Session<'r, 'l, R>);
 
@@ -43,7 +39,7 @@ impl<'r, 'l, R: RemoteCache> GenesisSession<'r, 'l, R> {
                 &Identifier::new(function_name).unwrap(),
                 ty_args,
                 args,
-                &mut CostStrategy::system(&ZERO_COST_SCHEDULE, GasUnits::new(100_000_000)),
+                &mut CostStrategy::system(),
                 &NoContextLog::new(),
             )
             .unwrap_or_else(|e| {
@@ -63,7 +59,7 @@ impl<'r, 'l, R: RemoteCache> GenesisSession<'r, 'l, R> {
                 script.ty_args().to_vec(),
                 convert_txn_args(script.args()),
                 vec![sender],
-                &mut CostStrategy::system(&ZERO_COST_SCHEDULE, GasUnits::new(100_000_000)),
+                &mut CostStrategy::system(),
                 &NoContextLog::new(),
             )
             .unwrap()

--- a/language/diem-vm/src/diem_transaction_executor.rs
+++ b/language/diem-vm/src/diem_transaction_executor.rs
@@ -32,13 +32,13 @@ use diem_types::{
 use fail::fail_point;
 use move_core_types::{
     account_address::AccountAddress,
-    gas_schedule::{CostTable, GasAlgebra, GasCarrier, GasUnits},
+    gas_schedule::GasAlgebra,
     identifier::IdentStr,
     transaction_argument::convert_txn_args,
     value::{serialize_values, MoveValue},
 };
 use move_vm_runtime::{data_cache::RemoteCache, logging::LogContext, session::Session};
-use move_vm_types::gas_schedule::{zero_cost_schedule, CostStrategy};
+use move_vm_types::gas_schedule::CostStrategy;
 use rayon::prelude::*;
 use std::{
     collections::HashSet,
@@ -61,8 +61,7 @@ impl DiemVM {
     pub fn failed_transaction_cleanup(
         &self,
         error_code: VMStatus,
-        gas_schedule: &CostTable,
-        gas_left: GasUnits<GasCarrier>,
+        cost_strategy: &mut CostStrategy,
         txn_data: &TransactionMetadata,
         remote_cache: &StateViewCache<'_>,
         account_currency_symbol: &IdentStr,
@@ -70,8 +69,7 @@ impl DiemVM {
     ) -> TransactionOutput {
         self.failed_transaction_cleanup_and_keep_vm_status(
             error_code,
-            gas_schedule,
-            gas_left,
+            cost_strategy,
             txn_data,
             remote_cache,
             account_currency_symbol,
@@ -83,14 +81,13 @@ impl DiemVM {
     fn failed_transaction_cleanup_and_keep_vm_status(
         &self,
         error_code: VMStatus,
-        gas_schedule: &CostTable,
-        gas_left: GasUnits<GasCarrier>,
+        cost_strategy: &mut CostStrategy,
         txn_data: &TransactionMetadata,
         remote_cache: &StateViewCache<'_>,
         account_currency_symbol: &IdentStr,
         log_context: &impl LogContext,
     ) -> (VMStatus, TransactionOutput) {
-        let mut cost_strategy = CostStrategy::system(gas_schedule, gas_left);
+        cost_strategy.disable_metering();
         let mut session = self.0.new_session(remote_cache);
         match TransactionStatus::from(error_code.clone()) {
             TransactionStatus::Keep(status) => {
@@ -102,16 +99,21 @@ impl DiemVM {
                 // discard the transaction.
                 if let Err(e) = self.0.run_failure_epilogue(
                     &mut session,
-                    &mut cost_strategy,
+                    cost_strategy,
                     txn_data,
                     account_currency_symbol,
                     log_context,
                 ) {
                     return discard_error_vm_status(e);
                 }
-                let txn_output =
-                    get_transaction_output(&mut (), session, &cost_strategy, txn_data, status)
-                        .unwrap_or_else(|e| discard_error_vm_status(e).1);
+                let txn_output = get_transaction_output(
+                    &mut (),
+                    session,
+                    cost_strategy.remaining_gas(),
+                    txn_data,
+                    status,
+                )
+                .unwrap_or_else(|e| discard_error_vm_status(e).1);
                 (error_code, txn_output)
             }
             TransactionStatus::Discard(status) => {
@@ -124,16 +126,15 @@ impl DiemVM {
     fn success_transaction_cleanup<R: RemoteCache>(
         &self,
         mut session: Session<R>,
-        gas_schedule: &CostTable,
-        gas_left: GasUnits<GasCarrier>,
+        cost_strategy: &mut CostStrategy,
         txn_data: &TransactionMetadata,
         account_currency_symbol: &IdentStr,
         log_context: &impl LogContext,
     ) -> Result<(VMStatus, TransactionOutput), VMStatus> {
-        let mut cost_strategy = CostStrategy::system(gas_schedule, gas_left);
+        cost_strategy.disable_metering();
         self.0.run_success_epilogue(
             &mut session,
-            &mut cost_strategy,
+            cost_strategy,
             txn_data,
             account_currency_symbol,
             log_context,
@@ -144,7 +145,7 @@ impl DiemVM {
             get_transaction_output(
                 &mut (),
                 session,
-                &cost_strategy,
+                cost_strategy.remaining_gas(),
                 txn_data,
                 KeptVMStatus::Executed,
             )?,
@@ -165,8 +166,6 @@ impl DiemVM {
                 StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
             ))
         });
-
-        let gas_schedule = self.0.get_gas_schedule(log_context)?;
 
         // Run the execution logic
         {
@@ -222,11 +221,9 @@ impl DiemVM {
 
             charge_global_write_gas_usage(cost_strategy, &session, &txn_data.sender())?;
 
-            cost_strategy.disable_metering();
             self.success_transaction_cleanup(
                 session,
-                gas_schedule,
-                cost_strategy.remaining_gas(),
+                cost_strategy,
                 txn_data,
                 account_currency_symbol,
                 log_context,
@@ -248,8 +245,6 @@ impl DiemVM {
                 StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
             ))
         });
-
-        let gas_schedule = self.0.get_gas_schedule(log_context)?;
 
         // Publish the module
         let module_address = if self.0.publishing_option(log_context)?.is_open_module() {
@@ -274,8 +269,7 @@ impl DiemVM {
 
         self.success_transaction_cleanup(
             session,
-            gas_schedule,
-            cost_strategy.remaining_gas(),
+            cost_strategy,
             txn_data,
             account_currency_symbol,
             log_context,
@@ -355,8 +349,7 @@ impl DiemVM {
                 } else {
                     self.failed_transaction_cleanup_and_keep_vm_status(
                         err,
-                        gas_schedule,
-                        cost_strategy.remaining_gas(),
+                        &mut cost_strategy,
                         &txn_data,
                         remote_cache,
                         &account_currency_symbol,
@@ -374,8 +367,7 @@ impl DiemVM {
         txn_sender: Option<AccountAddress>,
         log_context: &impl LogContext,
     ) -> Result<ChangeSet, Result<(VMStatus, TransactionOutput), VMStatus>> {
-        let gas_schedule = zero_cost_schedule();
-        let mut cost_strategy = CostStrategy::system(&gas_schedule, GasUnits::new(0));
+        let mut cost_strategy = CostStrategy::system();
 
         Ok(match writeset_payload {
             WriteSetPayload::Direct(change_set) => change_set.clone(),
@@ -462,8 +454,7 @@ impl DiemVM {
             sender: account_config::reserved_vm_address(),
             ..Default::default()
         };
-        let gas_schedule = zero_cost_schedule();
-        let mut cost_strategy = CostStrategy::system(&gas_schedule, GasUnits::new(0));
+        let mut cost_strategy = CostStrategy::system();
         let mut session = self.0.new_session(remote_cache);
 
         let (round, timestamp, previous_vote, proposer) = block_metadata.into_inner();
@@ -492,7 +483,7 @@ impl DiemVM {
         let output = get_transaction_output(
             &mut (),
             session,
-            &cost_strategy,
+            cost_strategy.remaining_gas(),
             &txn_data,
             KeptVMStatus::Executed,
         )?;

--- a/language/diem-vm/src/diem_vm.rs
+++ b/language/diem-vm/src/diem_vm.rs
@@ -24,7 +24,7 @@ use fail::fail_point;
 use move_core_types::{
     account_address::AccountAddress,
     effects::{ChangeSet as MoveChangeSet, Event as MoveEvent},
-    gas_schedule::{CostTable, GasAlgebra, GasUnits, InternalGasUnits},
+    gas_schedule::{CostTable, GasAlgebra, GasCarrier, GasUnits, InternalGasUnits},
     identifier::IdentStr,
     language_storage::ModuleId,
     value::{serialize_values, MoveValue},
@@ -35,7 +35,7 @@ use move_vm_runtime::{
     move_vm::MoveVM,
     session::Session,
 };
-use move_vm_types::gas_schedule::{calculate_intrinsic_gas, zero_cost_schedule, CostStrategy};
+use move_vm_types::gas_schedule::{calculate_intrinsic_gas, CostStrategy};
 use std::{convert::TryFrom, sync::Arc};
 use vm::errors::Location;
 
@@ -208,7 +208,6 @@ impl DiemVMImpl {
     pub(crate) fn run_script_prologue<R: RemoteCache>(
         &self,
         session: &mut Session<R>,
-        cost_strategy: &mut CostStrategy,
         txn_data: &TransactionMetadata,
         account_currency_symbol: &IdentStr,
         log_context: &impl LogContext,
@@ -221,6 +220,7 @@ impl DiemVMImpl {
         let txn_max_gas_units = txn_data.max_gas_amount().get();
         let txn_expiration_timestamp_secs = txn_data.expiration_timestamp_secs();
         let chain_id = txn_data.chain_id();
+        let mut cost_strategy = CostStrategy::system();
         session
             .execute_function(
                 &account_config::ACCOUNT_MODULE,
@@ -236,7 +236,7 @@ impl DiemVMImpl {
                     MoveValue::U8(chain_id.id()),
                     MoveValue::vector_u8(txn_data.script_hash.clone()),
                 ]),
-                cost_strategy,
+                &mut cost_strategy,
                 log_context,
             )
             .map(|_return_vals| ())
@@ -249,7 +249,6 @@ impl DiemVMImpl {
     pub(crate) fn run_module_prologue<R: RemoteCache>(
         &self,
         session: &mut Session<R>,
-        cost_strategy: &mut CostStrategy,
         txn_data: &TransactionMetadata,
         account_currency_symbol: &IdentStr,
         log_context: &impl LogContext,
@@ -262,6 +261,7 @@ impl DiemVMImpl {
         let txn_max_gas_units = txn_data.max_gas_amount().get();
         let txn_expiration_timestamp_secs = txn_data.expiration_timestamp_secs();
         let chain_id = txn_data.chain_id();
+        let mut cost_strategy = CostStrategy::system();
         session
             .execute_function(
                 &account_config::ACCOUNT_MODULE,
@@ -276,7 +276,7 @@ impl DiemVMImpl {
                     MoveValue::U64(txn_expiration_timestamp_secs),
                     MoveValue::U8(chain_id.id()),
                 ]),
-                cost_strategy,
+                &mut cost_strategy,
                 log_context,
             )
             .map(|_return_vals| ())
@@ -377,8 +377,7 @@ impl DiemVMImpl {
         let txn_expiration_timestamp_secs = txn_data.expiration_timestamp_secs();
         let chain_id = txn_data.chain_id();
 
-        let gas_schedule = zero_cost_schedule();
-        let mut cost_strategy = CostStrategy::system(&gas_schedule, GasUnits::new(0));
+        let mut cost_strategy = CostStrategy::system();
         session
             .execute_function(
                 &account_config::ACCOUNT_MODULE,
@@ -408,8 +407,7 @@ impl DiemVMImpl {
         should_trigger_reconfiguration: bool,
         log_context: &impl LogContext,
     ) -> Result<(), VMStatus> {
-        let gas_schedule = zero_cost_schedule();
-        let mut cost_strategy = CostStrategy::system(&gas_schedule, GasUnits::new(0));
+        let mut cost_strategy = CostStrategy::system();
         session
             .execute_function(
                 &account_config::ACCOUNT_MODULE,
@@ -552,14 +550,11 @@ pub(crate) fn charge_global_write_gas_usage<R: RemoteCache>(
 pub(crate) fn get_transaction_output<A: AccessPathCache, R: RemoteCache>(
     ap_cache: &mut A,
     session: Session<R>,
-    cost_strategy: &CostStrategy,
+    gas_left: GasUnits<GasCarrier>,
     txn_data: &TransactionMetadata,
     status: KeptVMStatus,
 ) -> Result<TransactionOutput, VMStatus> {
-    let gas_used: u64 = txn_data
-        .max_gas_amount()
-        .sub(cost_strategy.remaining_gas())
-        .get();
+    let gas_used: u64 = txn_data.max_gas_amount().sub(gas_left).get();
 
     let (changeset, events) = session.finish().map_err(|e| e.into_vm_status())?;
     let (write_set, events) = convert_changeset_and_events_cached(ap_cache, changeset, events)?;

--- a/language/e2e-testsuite/src/tests/failed_transaction_tests.rs
+++ b/language/e2e-testsuite/src/tests/failed_transaction_tests.rs
@@ -9,7 +9,7 @@ use language_e2e_tests::{
 };
 use move_core_types::gas_schedule::{GasAlgebra, GasPrice, GasUnits};
 use move_vm_runtime::logging::NoContextLog;
-use move_vm_types::gas_schedule::{zero_cost_schedule, CostStrategy};
+use move_vm_types::gas_schedule::{zero_cost_schedule, GasStatus};
 
 #[test]
 fn failed_transaction_cleanup_test() {
@@ -31,12 +31,12 @@ fn failed_transaction_cleanup_test() {
         };
 
         let gas_schedule = zero_cost_schedule();
-        let mut cost_strategy = CostStrategy::transaction(&gas_schedule, GasUnits::new(10_000));
+        let mut gas_status = GasStatus::new(&gas_schedule, GasUnits::new(10_000));
 
         // TYPE_MISMATCH should be kept and charged.
         let out1 = diem_vm.failed_transaction_cleanup(
             VMStatus::Error(StatusCode::TYPE_MISMATCH),
-            &mut cost_strategy,
+            &mut gas_status,
             &txn_data,
             &data_cache,
             &account::xus_currency_code(),
@@ -54,7 +54,7 @@ fn failed_transaction_cleanup_test() {
         // Invariant violations should be discarded and not charged.
         let out2 = diem_vm.failed_transaction_cleanup(
             VMStatus::Error(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR),
-            &mut cost_strategy,
+            &mut gas_status,
             &txn_data,
             &data_cache,
             &account::xus_currency_code(),

--- a/language/move-vm/integration-tests/src/tests/bad_entry_point_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/bad_entry_point_tests.rs
@@ -11,7 +11,7 @@ use move_core_types::{
 };
 use move_vm_runtime::{logging::NoContextLog, move_vm::MoveVM};
 use move_vm_test_utils::{BlankStorage, InMemoryStorage};
-use move_vm_types::gas_schedule::CostStrategy;
+use move_vm_types::gas_schedule::GasStatus;
 
 const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGTH]);
 
@@ -23,7 +23,7 @@ fn call_non_existent_module() {
     let mut sess = vm.new_session(&storage);
     let module_id = ModuleId::new(TEST_ADDR, Identifier::new("M").unwrap());
     let fun_name = Identifier::new("foo").unwrap();
-    let mut cost_strategy = CostStrategy::system();
+    let mut gas_status = GasStatus::new_unmetered();
     let context = NoContextLog::new();
 
     let err = sess
@@ -32,7 +32,7 @@ fn call_non_existent_module() {
             &fun_name,
             vec![],
             serialize_values(&vec![MoveValue::Signer(TEST_ADDR)]),
-            &mut cost_strategy,
+            &mut gas_status,
             &context,
         )
         .unwrap_err();
@@ -60,7 +60,7 @@ fn call_non_existent_function() {
     let mut sess = vm.new_session(&storage);
 
     let fun_name = Identifier::new("foo").unwrap();
-    let mut cost_strategy = CostStrategy::system();
+    let mut gas_status = GasStatus::new_unmetered();
     let context = NoContextLog::new();
 
     let err = sess
@@ -69,7 +69,7 @@ fn call_non_existent_function() {
             &fun_name,
             vec![],
             serialize_values(&vec![MoveValue::Signer(TEST_ADDR)]),
-            &mut cost_strategy,
+            &mut gas_status,
             &context,
         )
         .unwrap_err();

--- a/language/move-vm/integration-tests/src/tests/bad_entry_point_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/bad_entry_point_tests.rs
@@ -4,7 +4,6 @@
 use crate::compiler::{as_module, compile_units};
 use move_core_types::{
     account_address::AccountAddress,
-    gas_schedule::{GasAlgebra, GasUnits},
     identifier::Identifier,
     language_storage::ModuleId,
     value::{serialize_values, MoveValue},
@@ -12,7 +11,7 @@ use move_core_types::{
 };
 use move_vm_runtime::{logging::NoContextLog, move_vm::MoveVM};
 use move_vm_test_utils::{BlankStorage, InMemoryStorage};
-use move_vm_types::gas_schedule::{zero_cost_schedule, CostStrategy};
+use move_vm_types::gas_schedule::CostStrategy;
 
 const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGTH]);
 
@@ -24,8 +23,7 @@ fn call_non_existent_module() {
     let mut sess = vm.new_session(&storage);
     let module_id = ModuleId::new(TEST_ADDR, Identifier::new("M").unwrap());
     let fun_name = Identifier::new("foo").unwrap();
-    let cost_table = zero_cost_schedule();
-    let mut cost_strategy = CostStrategy::system(&cost_table, GasUnits::new(0));
+    let mut cost_strategy = CostStrategy::system();
     let context = NoContextLog::new();
 
     let err = sess
@@ -62,8 +60,7 @@ fn call_non_existent_function() {
     let mut sess = vm.new_session(&storage);
 
     let fun_name = Identifier::new("foo").unwrap();
-    let cost_table = zero_cost_schedule();
-    let mut cost_strategy = CostStrategy::system(&cost_table, GasUnits::new(0));
+    let mut cost_strategy = CostStrategy::system();
     let context = NoContextLog::new();
 
     let err = sess

--- a/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
@@ -5,7 +5,6 @@ use crate::compiler::{as_module, as_script, compile_units};
 use move_core_types::{
     account_address::AccountAddress,
     effects::ChangeSet,
-    gas_schedule::{GasAlgebra, GasUnits},
     identifier::Identifier,
     language_storage::{ModuleId, StructTag},
     value::{serialize_values, MoveValue},
@@ -13,7 +12,7 @@ use move_core_types::{
 };
 use move_vm_runtime::{data_cache::RemoteCache, logging::NoContextLog, move_vm::MoveVM};
 use move_vm_test_utils::{DeltaStorage, InMemoryStorage};
-use move_vm_types::gas_schedule::{zero_cost_schedule, CostStrategy};
+use move_vm_types::gas_schedule::CostStrategy;
 use vm::errors::{Location, PartialVMError, PartialVMResult, VMResult};
 
 const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGTH]);
@@ -86,8 +85,7 @@ fn test_malformed_resource() {
     let vm = MoveVM::new();
 
     let log_context = NoContextLog::new();
-    let cost_table = zero_cost_schedule();
-    let mut cost_strategy = CostStrategy::system(&cost_table, GasUnits::new(0));
+    let mut cost_strategy = CostStrategy::system();
 
     // Execute the first script to publish a resource Foo.
     let mut script_blob = vec![];
@@ -173,8 +171,7 @@ fn test_malformed_module() {
     let module_id = ModuleId::new(TEST_ADDR, Identifier::new("M").unwrap());
     let fun_name = Identifier::new("foo").unwrap();
     let log_context = NoContextLog::new();
-    let cost_table = zero_cost_schedule();
-    let mut cost_strategy = CostStrategy::system(&cost_table, GasUnits::new(0));
+    let mut cost_strategy = CostStrategy::system();
 
     // Publish M and call M::foo. No errors should be thrown.
     {
@@ -236,8 +233,7 @@ fn test_unverifiable_module() {
     let m = as_module(units.pop().unwrap());
 
     let log_context = NoContextLog::new();
-    let cost_table = zero_cost_schedule();
-    let mut cost_strategy = CostStrategy::system(&cost_table, GasUnits::new(0));
+    let mut cost_strategy = CostStrategy::system();
     let module_id = ModuleId::new(TEST_ADDR, Identifier::new("M").unwrap());
     let fun_name = Identifier::new("foo").unwrap();
 
@@ -318,8 +314,7 @@ fn test_missing_module_dependency() {
     n.serialize(&mut blob_n).unwrap();
 
     let log_context = NoContextLog::new();
-    let cost_table = zero_cost_schedule();
-    let mut cost_strategy = CostStrategy::system(&cost_table, GasUnits::new(0));
+    let mut cost_strategy = CostStrategy::system();
 
     let module_id = ModuleId::new(TEST_ADDR, Identifier::new("N").unwrap());
     let fun_name = Identifier::new("bar").unwrap();
@@ -394,8 +389,7 @@ fn test_malformed_module_denpency() {
     n.serialize(&mut blob_n).unwrap();
 
     let log_context = NoContextLog::new();
-    let cost_table = zero_cost_schedule();
-    let mut cost_strategy = CostStrategy::system(&cost_table, GasUnits::new(0));
+    let mut cost_strategy = CostStrategy::system();
 
     let module_id = ModuleId::new(TEST_ADDR, Identifier::new("N").unwrap());
     let fun_name = Identifier::new("bar").unwrap();
@@ -474,8 +468,7 @@ fn test_unverifiable_module_dependency() {
     n.serialize(&mut blob_n).unwrap();
 
     let log_context = NoContextLog::new();
-    let cost_table = zero_cost_schedule();
-    let mut cost_strategy = CostStrategy::system(&cost_table, GasUnits::new(0));
+    let mut cost_strategy = CostStrategy::system();
 
     let module_id = ModuleId::new(TEST_ADDR, Identifier::new("N").unwrap());
     let fun_name = Identifier::new("bar").unwrap();
@@ -566,8 +559,7 @@ const LIST_OF_ERROR_CODES: &[StatusCode] = &[
 #[test]
 fn test_storage_returns_bogus_error_when_loading_module() {
     let log_context = NoContextLog::new();
-    let cost_table = zero_cost_schedule();
-    let mut cost_strategy = CostStrategy::system(&cost_table, GasUnits::new(0));
+    let mut cost_strategy = CostStrategy::system();
     let module_id = ModuleId::new(TEST_ADDR, Identifier::new("N").unwrap());
     let fun_name = Identifier::new("bar").unwrap();
 
@@ -596,8 +588,7 @@ fn test_storage_returns_bogus_error_when_loading_module() {
 #[test]
 fn test_storage_returns_bogus_error_when_loading_resource() {
     let log_context = NoContextLog::new();
-    let cost_table = zero_cost_schedule();
-    let mut cost_strategy = CostStrategy::system(&cost_table, GasUnits::new(0));
+    let mut cost_strategy = CostStrategy::system();
 
     let code = r#"
         address 0x1 {

--- a/language/move-vm/integration-tests/src/tests/function_arg_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/function_arg_tests.rs
@@ -11,7 +11,7 @@ use move_core_types::{
 };
 use move_vm_runtime::{logging::NoContextLog, move_vm::MoveVM};
 use move_vm_test_utils::InMemoryStorage;
-use move_vm_types::gas_schedule::CostStrategy;
+use move_vm_types::gas_schedule::GasStatus;
 use vm::errors::VMResult;
 
 const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGTH]);
@@ -59,7 +59,7 @@ fn run(
     let mut sess = vm.new_session(&storage);
 
     let fun_name = Identifier::new("foo").unwrap();
-    let mut cost_strategy = CostStrategy::system();
+    let mut gas_status = GasStatus::new_unmetered();
     let context = NoContextLog::new();
 
     let args: Vec<_> = args
@@ -72,7 +72,7 @@ fn run(
         &fun_name,
         ty_args,
         args,
-        &mut cost_strategy,
+        &mut gas_status,
         &context,
     )?;
 

--- a/language/move-vm/integration-tests/src/tests/function_arg_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/function_arg_tests.rs
@@ -4,7 +4,6 @@
 use crate::compiler::{as_module, compile_units};
 use move_core_types::{
     account_address::AccountAddress,
-    gas_schedule::{GasAlgebra, GasUnits},
     identifier::Identifier,
     language_storage::{ModuleId, TypeTag},
     value::{MoveStruct, MoveValue},
@@ -12,7 +11,7 @@ use move_core_types::{
 };
 use move_vm_runtime::{logging::NoContextLog, move_vm::MoveVM};
 use move_vm_test_utils::InMemoryStorage;
-use move_vm_types::gas_schedule::{zero_cost_schedule, CostStrategy};
+use move_vm_types::gas_schedule::CostStrategy;
 use vm::errors::VMResult;
 
 const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGTH]);
@@ -60,8 +59,7 @@ fn run(
     let mut sess = vm.new_session(&storage);
 
     let fun_name = Identifier::new("foo").unwrap();
-    let cost_table = zero_cost_schedule();
-    let mut cost_strategy = CostStrategy::system(&cost_table, GasUnits::new(0));
+    let mut cost_strategy = CostStrategy::system();
     let context = NoContextLog::new();
 
     let args: Vec<_> = args

--- a/language/move-vm/integration-tests/src/tests/loader_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/loader_tests.rs
@@ -4,13 +4,12 @@
 use crate::compiler::compile_modules_in_file;
 use move_core_types::{
     account_address::AccountAddress,
-    gas_schedule::{GasAlgebra, GasUnits},
     identifier::{IdentStr, Identifier},
     language_storage::ModuleId,
 };
 use move_vm_runtime::{logging::NoContextLog, move_vm::MoveVM};
 use move_vm_test_utils::InMemoryStorage;
-use move_vm_types::gas_schedule::{zero_cost_schedule, CostStrategy};
+use move_vm_types::gas_schedule::CostStrategy;
 use std::{path::PathBuf, sync::Arc, thread};
 use vm::CompiledModule;
 
@@ -55,9 +54,8 @@ impl Adapter {
 
     fn publish_modules(&mut self, modules: Vec<CompiledModule>) {
         let mut session = self.vm.new_session(&self.store);
-        let cost_table = zero_cost_schedule();
         let log_context = NoContextLog::new();
-        let mut cost_strategy = CostStrategy::system(&cost_table, GasUnits::new(0));
+        let mut cost_strategy = CostStrategy::system();
         for module in modules {
             let mut binary = vec![];
             module
@@ -86,8 +84,7 @@ impl Adapter {
                 let vm = self.vm.clone();
                 let data_store = self.store.clone();
                 children.push(thread::spawn(move || {
-                    let cost_table = zero_cost_schedule();
-                    let mut cost_strategy = CostStrategy::system(&cost_table, GasUnits::new(0));
+                    let mut cost_strategy = CostStrategy::system();
                     let log_context = NoContextLog::new();
                     let mut session = vm.new_session(&data_store);
                     session
@@ -111,8 +108,7 @@ impl Adapter {
     }
 
     fn call_function(&self, module: &ModuleId, name: &IdentStr) {
-        let cost_table = zero_cost_schedule();
-        let mut cost_strategy = CostStrategy::system(&cost_table, GasUnits::new(0));
+        let mut cost_strategy = CostStrategy::system();
         let log_context = NoContextLog::new();
         let mut session = self.vm.new_session(&self.store);
         session

--- a/language/move-vm/integration-tests/src/tests/mutated_accounts_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/mutated_accounts_tests.rs
@@ -10,7 +10,7 @@ use move_core_types::{
 };
 use move_vm_runtime::{logging::NoContextLog, move_vm::MoveVM};
 use move_vm_test_utils::InMemoryStorage;
-use move_vm_types::gas_schedule::CostStrategy;
+use move_vm_types::gas_schedule::GasStatus;
 
 const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGTH]);
 
@@ -45,7 +45,7 @@ fn mutated_accounts() {
     let vm = MoveVM::new();
     let mut sess = vm.new_session(&storage);
 
-    let mut cost_strategy = CostStrategy::system();
+    let mut gas_status = GasStatus::new_unmetered();
     let context = NoContextLog::new();
 
     let publish = Identifier::new("publish").unwrap();
@@ -59,7 +59,7 @@ fn mutated_accounts() {
         &publish,
         vec![],
         serialize_values(&vec![MoveValue::Signer(account1)]),
-        &mut cost_strategy,
+        &mut gas_status,
         &context,
     )
     .unwrap();
@@ -74,7 +74,7 @@ fn mutated_accounts() {
         &get,
         vec![],
         serialize_values(&vec![MoveValue::Address(account1)]),
-        &mut cost_strategy,
+        &mut gas_status,
         &context,
     )
     .unwrap();
@@ -86,7 +86,7 @@ fn mutated_accounts() {
         &flip,
         vec![],
         serialize_values(&vec![MoveValue::Address(account1)]),
-        &mut cost_strategy,
+        &mut gas_status,
         &context,
     )
     .unwrap();
@@ -101,7 +101,7 @@ fn mutated_accounts() {
         &get,
         vec![],
         serialize_values(&vec![MoveValue::Address(account1)]),
-        &mut cost_strategy,
+        &mut gas_status,
         &context,
     )
     .unwrap();

--- a/language/move-vm/integration-tests/src/tests/mutated_accounts_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/mutated_accounts_tests.rs
@@ -4,14 +4,13 @@
 use crate::compiler::{as_module, compile_units};
 use move_core_types::{
     account_address::AccountAddress,
-    gas_schedule::{GasAlgebra, GasUnits},
     identifier::Identifier,
     language_storage::ModuleId,
     value::{serialize_values, MoveValue},
 };
 use move_vm_runtime::{logging::NoContextLog, move_vm::MoveVM};
 use move_vm_test_utils::InMemoryStorage;
-use move_vm_types::gas_schedule::{zero_cost_schedule, CostStrategy};
+use move_vm_types::gas_schedule::CostStrategy;
 
 const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGTH]);
 
@@ -46,8 +45,7 @@ fn mutated_accounts() {
     let vm = MoveVM::new();
     let mut sess = vm.new_session(&storage);
 
-    let cost_table = zero_cost_schedule();
-    let mut cost_strategy = CostStrategy::system(&cost_table, GasUnits::new(0));
+    let mut cost_strategy = CostStrategy::system();
     let context = NoContextLog::new();
 
     let publish = Identifier::new("publish").unwrap();

--- a/language/move-vm/integration-tests/src/tests/return_value_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/return_value_tests.rs
@@ -11,7 +11,7 @@ use move_core_types::{
 };
 use move_vm_runtime::{logging::NoContextLog, move_vm::MoveVM};
 use move_vm_test_utils::InMemoryStorage;
-use move_vm_types::gas_schedule::CostStrategy;
+use move_vm_types::gas_schedule::GasStatus;
 use vm::errors::VMResult;
 
 const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGTH]);
@@ -51,7 +51,7 @@ fn run(
     let mut sess = vm.new_session(&storage);
 
     let fun_name = Identifier::new("foo").unwrap();
-    let mut cost_strategy = CostStrategy::system();
+    let mut gas_status = GasStatus::new_unmetered();
     let context = NoContextLog::new();
 
     let args: Vec<_> = args
@@ -64,7 +64,7 @@ fn run(
         &fun_name,
         ty_args,
         args,
-        &mut cost_strategy,
+        &mut gas_status,
         &context,
     )?;
 

--- a/language/move-vm/integration-tests/src/tests/return_value_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/return_value_tests.rs
@@ -4,7 +4,6 @@
 use crate::compiler::{as_module, compile_units};
 use move_core_types::{
     account_address::AccountAddress,
-    gas_schedule::{GasAlgebra, GasUnits},
     identifier::Identifier,
     language_storage::{ModuleId, TypeTag},
     value::{MoveTypeLayout, MoveValue},
@@ -12,7 +11,7 @@ use move_core_types::{
 };
 use move_vm_runtime::{logging::NoContextLog, move_vm::MoveVM};
 use move_vm_test_utils::InMemoryStorage;
-use move_vm_types::gas_schedule::{zero_cost_schedule, CostStrategy};
+use move_vm_types::gas_schedule::CostStrategy;
 use vm::errors::VMResult;
 
 const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGTH]);
@@ -52,8 +51,7 @@ fn run(
     let mut sess = vm.new_session(&storage);
 
     let fun_name = Identifier::new("foo").unwrap();
-    let cost_table = zero_cost_schedule();
-    let mut cost_strategy = CostStrategy::system(&cost_table, GasUnits::new(0));
+    let mut cost_strategy = CostStrategy::system();
     let context = NoContextLog::new();
 
     let args: Vec<_> = args

--- a/language/move-vm/runtime/src/native_functions.rs
+++ b/language/move-vm/runtime/src/native_functions.rs
@@ -9,7 +9,7 @@ use move_core_types::{
 use move_vm_natives::{account, bcs, debug, event, hash, signature, signer, vector};
 use move_vm_types::{
     data_store::DataStore,
-    gas_schedule::CostStrategy,
+    gas_schedule::GasStatus,
     loaded_data::runtime_types::Type,
     natives::function::{NativeContext, NativeResult},
     values::Value,
@@ -119,7 +119,7 @@ impl NativeFunction {
 pub(crate) struct FunctionContext<'a, L: LogContext> {
     interpreter: &'a mut Interpreter<L>,
     data_store: &'a mut dyn DataStore,
-    cost_strategy: &'a CostStrategy<'a>,
+    gas_status: &'a GasStatus<'a>,
     resolver: &'a Resolver<'a>,
 }
 
@@ -127,13 +127,13 @@ impl<'a, L: LogContext> FunctionContext<'a, L> {
     pub(crate) fn new(
         interpreter: &'a mut Interpreter<L>,
         data_store: &'a mut dyn DataStore,
-        cost_strategy: &'a mut CostStrategy,
+        gas_status: &'a mut GasStatus,
         resolver: &'a Resolver<'a>,
     ) -> FunctionContext<'a, L> {
         FunctionContext {
             interpreter,
             data_store,
-            cost_strategy,
+            gas_status,
             resolver,
         }
     }
@@ -146,7 +146,7 @@ impl<'a, L: LogContext> NativeContext for FunctionContext<'a, L> {
     }
 
     fn cost_table(&self) -> &CostTable {
-        self.cost_strategy.cost_table()
+        self.gas_status.cost_table()
     }
 
     fn save_event(

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -17,8 +17,7 @@ use move_core_types::{
     vm_status::StatusCode,
 };
 use move_vm_types::{
-    data_store::DataStore, gas_schedule::CostStrategy, loaded_data::runtime_types::Type,
-    values::Value,
+    data_store::DataStore, gas_schedule::GasStatus, loaded_data::runtime_types::Type, values::Value,
 };
 use vm::{
     access::ModuleAccess,
@@ -61,7 +60,7 @@ impl VMRuntime {
         module: Vec<u8>,
         sender: AccountAddress,
         data_store: &mut impl DataStore,
-        _cost_strategy: &mut CostStrategy,
+        _gas_status: &mut GasStatus,
         log_context: &impl LogContext,
     ) -> VMResult<()> {
         // deserialize the module. Perform bounds check. After this indexes can be
@@ -237,7 +236,7 @@ impl VMRuntime {
         args: Vec<Vec<u8>>,
         senders: Vec<AccountAddress>,
         data_store: &mut impl DataStore,
-        cost_strategy: &mut CostStrategy,
+        gas_status: &mut GasStatus,
         log_context: &impl LogContext,
     ) -> VMResult<()> {
         // load the script, perform verification
@@ -254,7 +253,7 @@ impl VMRuntime {
             ty_args,
             signers_and_args,
             data_store,
-            cost_strategy,
+            gas_status,
             &self.loader,
             log_context,
         )?;
@@ -280,7 +279,7 @@ impl VMRuntime {
         make_args: F,
         is_script_execution: bool,
         data_store: &mut impl DataStore,
-        cost_strategy: &mut CostStrategy,
+        gas_status: &mut GasStatus,
         log_context: &impl LogContext,
     ) -> VMResult<Vec<Vec<u8>>>
     where
@@ -322,7 +321,7 @@ impl VMRuntime {
             ty_args,
             args,
             data_store,
-            cost_strategy,
+            gas_status,
             &self.loader,
             log_context,
         )?;
@@ -360,7 +359,7 @@ impl VMRuntime {
         args: Vec<Vec<u8>>,
         senders: Vec<AccountAddress>,
         data_store: &mut impl DataStore,
-        cost_strategy: &mut CostStrategy,
+        gas_status: &mut GasStatus,
         log_context: &impl LogContext,
     ) -> VMResult<()> {
         let return_vals = self.execute_function_impl(
@@ -372,7 +371,7 @@ impl VMRuntime {
             },
             true,
             data_store,
-            cost_strategy,
+            gas_status,
             log_context,
         )?;
 
@@ -402,7 +401,7 @@ impl VMRuntime {
         ty_args: Vec<TypeTag>,
         args: Vec<Vec<u8>>,
         data_store: &mut impl DataStore,
-        cost_strategy: &mut CostStrategy,
+        gas_status: &mut GasStatus,
         log_context: &impl LogContext,
     ) -> VMResult<Vec<Vec<u8>>> {
         self.execute_function_impl(
@@ -412,7 +411,7 @@ impl VMRuntime {
             move |runtime, version, params| runtime.deserialize_args(version, params, args),
             false,
             data_store,
-            cost_strategy,
+            gas_status,
             log_context,
         )
     }

--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -12,7 +12,7 @@ use move_core_types::{
     identifier::IdentStr,
     language_storage::{ModuleId, TypeTag},
 };
-use move_vm_types::gas_schedule::CostStrategy;
+use move_vm_types::gas_schedule::GasStatus;
 use vm::errors::*;
 
 pub struct Session<'r, 'l, R> {
@@ -42,7 +42,7 @@ impl<'r, 'l, R: RemoteCache> Session<'r, 'l, R> {
         function_name: &IdentStr,
         ty_args: Vec<TypeTag>,
         args: Vec<Vec<u8>>,
-        cost_strategy: &mut CostStrategy,
+        gas_status: &mut GasStatus,
         log_context: &impl LogContext,
     ) -> VMResult<Vec<Vec<u8>>> {
         self.runtime.execute_function(
@@ -51,7 +51,7 @@ impl<'r, 'l, R: RemoteCache> Session<'r, 'l, R> {
             ty_args,
             args,
             &mut self.data_cache,
-            cost_strategy,
+            gas_status,
             log_context,
         )
     }
@@ -87,7 +87,7 @@ impl<'r, 'l, R: RemoteCache> Session<'r, 'l, R> {
         ty_args: Vec<TypeTag>,
         args: Vec<Vec<u8>>,
         senders: Vec<AccountAddress>,
-        cost_strategy: &mut CostStrategy,
+        gas_status: &mut GasStatus,
         log_context: &impl LogContext,
     ) -> VMResult<()> {
         self.runtime.execute_script_function(
@@ -97,7 +97,7 @@ impl<'r, 'l, R: RemoteCache> Session<'r, 'l, R> {
             args,
             senders,
             &mut self.data_cache,
-            cost_strategy,
+            gas_status,
             log_context,
         )
     }
@@ -124,7 +124,7 @@ impl<'r, 'l, R: RemoteCache> Session<'r, 'l, R> {
         ty_args: Vec<TypeTag>,
         args: Vec<Vec<u8>>,
         senders: Vec<AccountAddress>,
-        cost_strategy: &mut CostStrategy,
+        gas_status: &mut GasStatus,
         log_context: &impl LogContext,
     ) -> VMResult<()> {
         self.runtime.execute_script(
@@ -133,7 +133,7 @@ impl<'r, 'l, R: RemoteCache> Session<'r, 'l, R> {
             args,
             senders,
             &mut self.data_cache,
-            cost_strategy,
+            gas_status,
             log_context,
         )
     }
@@ -155,14 +155,14 @@ impl<'r, 'l, R: RemoteCache> Session<'r, 'l, R> {
         &mut self,
         module: Vec<u8>,
         sender: AccountAddress,
-        cost_strategy: &mut CostStrategy,
+        gas_status: &mut GasStatus,
         log_context: &impl LogContext,
     ) -> VMResult<()> {
         self.runtime.publish_module(
             module,
             sender,
             &mut self.data_cache,
-            cost_strategy,
+            gas_status,
             log_context,
         )
     }

--- a/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
@@ -11,7 +11,7 @@ use move_core_types::{
     value::{serialize_values, MoveValue},
     vm_status::{StatusCode, StatusType},
 };
-use move_vm_types::gas_schedule::CostStrategy;
+use move_vm_types::gas_schedule::GasStatus;
 use vm::{
     errors::{PartialVMResult, VMResult},
     file_format::{
@@ -261,13 +261,13 @@ fn call_script_with_args_ty_args_signers(
     let remote_view = RemoteStore::new();
     let log_context = NoContextLog::new();
     let mut session = move_vm.new_session(&remote_view);
-    let mut cost_strategy = CostStrategy::system();
+    let mut gas_status = GasStatus::new_unmetered();
     session.execute_script(
         script,
         ty_args,
         args,
         signers,
-        &mut cost_strategy,
+        &mut gas_status,
         &log_context,
     )
 }
@@ -289,14 +289,14 @@ fn call_script_function_with_args_ty_args_signers(
     remote_view.add_module(module);
     let log_context = NoContextLog::new();
     let mut session = move_vm.new_session(&remote_view);
-    let mut cost_strategy = CostStrategy::system();
+    let mut gas_status = GasStatus::new_unmetered();
     session.execute_script_function(
         &id,
         function_name.as_ident_str(),
         ty_args,
         args,
         signers,
-        &mut cost_strategy,
+        &mut gas_status,
         &log_context,
     )?;
     Ok(())
@@ -763,7 +763,7 @@ fn call_missing_item() {
     let mut remote_view = RemoteStore::new();
     let log_context = NoContextLog::new();
     let mut session = move_vm.new_session(&remote_view);
-    let mut cost_strategy = CostStrategy::system();
+    let mut gas_status = GasStatus::new_unmetered();
     let error = session
         .execute_script_function(
             id,
@@ -771,7 +771,7 @@ fn call_missing_item() {
             vec![],
             vec![],
             vec![],
-            &mut cost_strategy,
+            &mut gas_status,
             &log_context,
         )
         .err()
@@ -789,7 +789,7 @@ fn call_missing_item() {
             vec![],
             vec![],
             vec![],
-            &mut cost_strategy,
+            &mut gas_status,
             &log_context,
         )
         .err()

--- a/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
@@ -6,13 +6,12 @@ use std::collections::HashMap;
 use crate::{data_cache::RemoteCache, logging::NoContextLog, move_vm::MoveVM};
 use move_core_types::{
     account_address::AccountAddress,
-    gas_schedule::{GasAlgebra, GasUnits},
     identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, StructTag, TypeTag},
     value::{serialize_values, MoveValue},
     vm_status::{StatusCode, StatusType},
 };
-use move_vm_types::gas_schedule::{zero_cost_schedule, CostStrategy};
+use move_vm_types::gas_schedule::CostStrategy;
 use vm::{
     errors::{PartialVMResult, VMResult},
     file_format::{
@@ -262,8 +261,7 @@ fn call_script_with_args_ty_args_signers(
     let remote_view = RemoteStore::new();
     let log_context = NoContextLog::new();
     let mut session = move_vm.new_session(&remote_view);
-    let cost_table = zero_cost_schedule();
-    let mut cost_strategy = CostStrategy::system(&cost_table, GasUnits::new(0));
+    let mut cost_strategy = CostStrategy::system();
     session.execute_script(
         script,
         ty_args,
@@ -291,8 +289,7 @@ fn call_script_function_with_args_ty_args_signers(
     remote_view.add_module(module);
     let log_context = NoContextLog::new();
     let mut session = move_vm.new_session(&remote_view);
-    let cost_table = zero_cost_schedule();
-    let mut cost_strategy = CostStrategy::system(&cost_table, GasUnits::new(0));
+    let mut cost_strategy = CostStrategy::system();
     session.execute_script_function(
         &id,
         function_name.as_ident_str(),
@@ -766,8 +763,7 @@ fn call_missing_item() {
     let mut remote_view = RemoteStore::new();
     let log_context = NoContextLog::new();
     let mut session = move_vm.new_session(&remote_view);
-    let cost_table = zero_cost_schedule();
-    let mut cost_strategy = CostStrategy::system(&cost_table, GasUnits::new(0));
+    let mut cost_strategy = CostStrategy::system();
     let error = session
         .execute_script_function(
             id,

--- a/language/testing-infra/e2e-tests/src/executor.rs
+++ b/language/testing-infra/e2e-tests/src/executor.rs
@@ -35,7 +35,7 @@ use move_core_types::{
     language_storage::{ModuleId, TypeTag},
 };
 use move_vm_runtime::{logging::NoContextLog, move_vm::MoveVM};
-use move_vm_types::gas_schedule::CostStrategy;
+use move_vm_types::gas_schedule::GasStatus;
 
 static RNG_SEED: [u8; 32] = [9u8; 32];
 
@@ -352,7 +352,7 @@ impl FakeExecutor {
         args: Vec<Vec<u8>>,
     ) {
         let write_set = {
-            let mut cost_strategy = CostStrategy::system();
+            let mut gas_status = GasStatus::new_unmetered();
             let vm = MoveVM::new();
             let remote_view = RemoteStorage::new(&self.data_store);
             let mut session = vm.new_session(&remote_view);
@@ -363,7 +363,7 @@ impl FakeExecutor {
                     &Self::name(function_name),
                     type_params,
                     args,
-                    &mut cost_strategy,
+                    &mut gas_status,
                     &log_context,
                 )
                 .unwrap_or_else(|e| {
@@ -389,7 +389,7 @@ impl FakeExecutor {
         type_params: Vec<TypeTag>,
         args: Vec<Vec<u8>>,
     ) -> Result<WriteSet, VMStatus> {
-        let mut cost_strategy = CostStrategy::system();
+        let mut gas_status = GasStatus::new_unmetered();
         let vm = MoveVM::new();
         let remote_view = RemoteStorage::new(&self.data_store);
         let mut session = vm.new_session(&remote_view);
@@ -400,7 +400,7 @@ impl FakeExecutor {
                 &Self::name(function_name),
                 type_params,
                 args,
-                &mut cost_strategy,
+                &mut gas_status,
                 &log_context,
             )
             .map_err(|e| e.into_vm_status())?;

--- a/language/testing-infra/e2e-tests/src/executor.rs
+++ b/language/testing-infra/e2e-tests/src/executor.rs
@@ -31,12 +31,11 @@ use diem_vm::{
     VMValidator,
 };
 use move_core_types::{
-    gas_schedule::{GasAlgebra, GasUnits},
     identifier::Identifier,
     language_storage::{ModuleId, TypeTag},
 };
 use move_vm_runtime::{logging::NoContextLog, move_vm::MoveVM};
-use move_vm_types::gas_schedule::{zero_cost_schedule, CostStrategy};
+use move_vm_types::gas_schedule::CostStrategy;
 
 static RNG_SEED: [u8; 32] = [9u8; 32];
 
@@ -353,8 +352,7 @@ impl FakeExecutor {
         args: Vec<Vec<u8>>,
     ) {
         let write_set = {
-            let cost_table = zero_cost_schedule();
-            let mut cost_strategy = CostStrategy::system(&cost_table, GasUnits::new(100_000_000));
+            let mut cost_strategy = CostStrategy::system();
             let vm = MoveVM::new();
             let remote_view = RemoteStorage::new(&self.data_store);
             let mut session = vm.new_session(&remote_view);
@@ -391,8 +389,7 @@ impl FakeExecutor {
         type_params: Vec<TypeTag>,
         args: Vec<Vec<u8>>,
     ) -> Result<WriteSet, VMStatus> {
-        let cost_table = zero_cost_schedule();
-        let mut cost_strategy = CostStrategy::system(&cost_table, GasUnits::new(100_000_000));
+        let mut cost_strategy = CostStrategy::system();
         let vm = MoveVM::new();
         let remote_view = RemoteStorage::new(&self.data_store);
         let mut session = vm.new_session(&remote_view);

--- a/language/testing-infra/test-generation/src/lib.rs
+++ b/language/testing-infra/test-generation/src/lib.rs
@@ -28,7 +28,7 @@ use language_e2e_tests::executor::FakeExecutor;
 use module_generation::generate_module;
 use move_core_types::{language_storage::TypeTag, value::MoveValue, vm_status::VMStatus};
 use move_vm_runtime::logging::NoContextLog;
-use move_vm_types::gas_schedule::CostStrategy;
+use move_vm_types::gas_schedule::GasStatus;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::{fs, io::Write, panic, thread};
 use vm::{
@@ -112,9 +112,9 @@ fn execute_function_in_module<S: StateView>(
             module
                 .serialize(&mut mod_blob)
                 .expect("Module serialization error");
-            let mut cost_strategy = CostStrategy::system();
+            let mut gas_status = GasStatus::new_unmetered();
             txn_context
-                .publish_module(mod_blob, sender, &mut cost_strategy, &log_context)
+                .publish_module(mod_blob, sender, &mut gas_status, &log_context)
                 .map_err(|e| e.into_vm_status())?;
             txn_context
                 .execute_function(
@@ -122,7 +122,7 @@ fn execute_function_in_module<S: StateView>(
                     &entry_name,
                     ty_args,
                     args,
-                    &mut cost_strategy,
+                    &mut gas_status,
                     &log_context,
                 )
                 .map_err(|e| e.into_vm_status())?;

--- a/language/testing-infra/test-generation/src/lib.rs
+++ b/language/testing-infra/test-generation/src/lib.rs
@@ -26,12 +26,7 @@ use diem_vm::DiemVM;
 use getrandom::getrandom;
 use language_e2e_tests::executor::FakeExecutor;
 use module_generation::generate_module;
-use move_core_types::{
-    gas_schedule::{GasAlgebra, GasUnits},
-    language_storage::TypeTag,
-    value::MoveValue,
-    vm_status::VMStatus,
-};
+use move_core_types::{language_storage::TypeTag, value::MoveValue, vm_status::VMStatus};
 use move_vm_runtime::logging::NoContextLog;
 use move_vm_types::gas_schedule::CostStrategy;
 use rand::{rngs::StdRng, Rng, SeedableRng};
@@ -111,14 +106,13 @@ fn execute_function_in_module<S: StateView>(
         let internals = diem_vm.internals();
 
         let log_context = NoContextLog::new();
-        let gas_schedule = internals.gas_schedule(&log_context)?;
         internals.with_txn_data_cache(state_view, |mut txn_context| {
             let sender = AccountAddress::random();
             let mut mod_blob = vec![];
             module
                 .serialize(&mut mod_blob)
                 .expect("Module serialization error");
-            let mut cost_strategy = CostStrategy::system(gas_schedule, GasUnits::new(0));
+            let mut cost_strategy = CostStrategy::system();
             txn_context
                 .publish_module(mod_blob, sender, &mut cost_strategy, &log_context)
                 .map_err(|e| e.into_vm_status())?;

--- a/language/tools/move-cli/src/main.rs
+++ b/language/tools/move-cli/src/main.rs
@@ -469,8 +469,8 @@ move run` must be applied to a module inside `storage/`",
 }
 
 fn get_cost_strategy(gas_budget: Option<u64>) -> Result<CostStrategy<'static>> {
-    let gas_schedule = &vm_genesis::genesis_gas_schedule::INITIAL_GAS_SCHEDULE;
     let cost_strategy = if let Some(gas_budget) = gas_budget {
+        let gas_schedule = &vm_genesis::genesis_gas_schedule::INITIAL_GAS_SCHEDULE;
         let max_gas_budget = u64::MAX
             .checked_div(gas_schedule.gas_constants.gas_unit_scaling_factor)
             .unwrap();
@@ -480,7 +480,7 @@ fn get_cost_strategy(gas_budget: Option<u64>) -> Result<CostStrategy<'static>> {
         CostStrategy::transaction(gas_schedule, GasUnits::new(gas_budget))
     } else {
         // no budget specified. use CostStrategy::system, which disables gas metering
-        CostStrategy::system(gas_schedule, GasUnits::new(0))
+        CostStrategy::system()
     };
     Ok(cost_strategy)
 }

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -40,7 +40,7 @@ use move_vm_runtime::{
     move_vm::MoveVM,
     session::Session,
 };
-use move_vm_types::gas_schedule::CostStrategy;
+use move_vm_types::gas_schedule::GasStatus;
 use once_cell::sync::Lazy;
 use rand::prelude::*;
 use transaction_builder::encode_create_designated_dealer_script_function;
@@ -178,7 +178,7 @@ fn exec_function(
             &Identifier::new(function_name).unwrap(),
             ty_args,
             args,
-            &mut CostStrategy::system(),
+            &mut GasStatus::new_unmetered(),
             log_context,
         )
         .unwrap_or_else(|e| {
@@ -204,7 +204,7 @@ fn exec_script_function(
             script_function.ty_args().to_vec(),
             script_function.args().to_vec(),
             vec![sender],
-            &mut CostStrategy::system(),
+            &mut GasStatus::new_unmetered(),
             log_context,
         )
         .unwrap()
@@ -464,7 +464,7 @@ fn publish_stdlib(
             .publish_module(
                 (*bytes).clone(),
                 *module_id.address(),
-                &mut CostStrategy::system(),
+                &mut GasStatus::new_unmetered(),
                 log_context,
             )
             .unwrap_or_else(|e| panic!("Failure publishing module {:?}, {:?}", module_id, e));

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -31,7 +31,6 @@ use diem_types::{
 use diem_vm::{convert_changeset_and_events, data_cache::StateViewCache};
 use move_core_types::{
     account_address::AccountAddress,
-    gas_schedule::{CostTable, GasAlgebra, GasUnits},
     identifier::Identifier,
     language_storage::{ModuleId, StructTag, TypeTag},
     value::{serialize_values, MoveValue},
@@ -41,7 +40,7 @@ use move_vm_runtime::{
     move_vm::MoveVM,
     session::Session,
 };
-use move_vm_types::gas_schedule::{zero_cost_schedule, CostStrategy};
+use move_vm_types::gas_schedule::CostStrategy;
 use once_cell::sync::Lazy;
 use rand::prelude::*;
 use transaction_builder::encode_create_designated_dealer_script_function;
@@ -59,8 +58,6 @@ pub static GENESIS_KEYPAIR: Lazy<(Ed25519PrivateKey, Ed25519PublicKey)> = Lazy::
     let public_key = private_key.public_key();
     (private_key, public_key)
 });
-
-pub static ZERO_COST_SCHEDULE: Lazy<CostTable> = Lazy::new(zero_cost_schedule);
 
 const ZERO_AUTH_KEY: [u8; 32] = [0; 32];
 
@@ -181,7 +178,7 @@ fn exec_function(
             &Identifier::new(function_name).unwrap(),
             ty_args,
             args,
-            &mut CostStrategy::system(&ZERO_COST_SCHEDULE, GasUnits::new(100_000_000)),
+            &mut CostStrategy::system(),
             log_context,
         )
         .unwrap_or_else(|e| {
@@ -207,7 +204,7 @@ fn exec_script_function(
             script_function.ty_args().to_vec(),
             script_function.args().to_vec(),
             vec![sender],
-            &mut CostStrategy::system(&ZERO_COST_SCHEDULE, GasUnits::new(100_000_000)),
+            &mut CostStrategy::system(),
             log_context,
         )
         .unwrap()
@@ -467,7 +464,7 @@ fn publish_stdlib(
             .publish_module(
                 (*bytes).clone(),
                 *module_id.address(),
-                &mut CostStrategy::system(&ZERO_COST_SCHEDULE, GasUnits::new(100_000_000)),
+                &mut CostStrategy::system(),
                 log_context,
             )
             .unwrap_or_else(|e| panic!("Failure publishing module {:?}, {:?}", module_id, e));

--- a/specifications/move_adapter/README.md
+++ b/specifications/move_adapter/README.md
@@ -844,7 +844,7 @@ pub fn publish_module(
     &mut self,
     module: Vec<u8>,
     sender: AccountAddress,
-    cost_strategy: &mut CostStrategy,
+    gas_status: &mut GasStatus,
     log_context: &impl LogContext,
 ) -> VMResult<()>;
 ```
@@ -890,7 +890,7 @@ pub fn execute_script(
     ty_args: Vec<TypeTag>,
     args: Vec<Vec<u8>>,
     senders: Vec<AccountAddress>,
-    cost_strategy: &mut CostStrategy,
+    gas_status: &mut GasStatus,
     log_context: &impl LogContext,
 ) -> VMResult<()>;
 ```
@@ -941,7 +941,7 @@ pub fn execute_script_function(
     ty_args: Vec<TypeTag>,
     args: Vec<Vec<u8>>,
     senders: Vec<AccountAddress>,
-    cost_strategy: &mut CostStrategy,
+    gas_status: &mut GasStatus,
     log_context: &impl LogContext,
 ) -> VMResult<()>;
 ```
@@ -973,7 +973,7 @@ pub fn execute_function(
     function_name: &IdentStr,
     ty_args: Vec<TypeTag>,
     args: Vec<Vec<u8>>,
-    cost_strategy: &mut CostStrategy,
+    gas_status: &mut GasStatus,
     log_context: &impl LogContext,
 ) -> VMResult<()>;
 ```


### PR DESCRIPTION
The diem-vm code has been inconsistent about how it uses CostStrategy values. In some cases where it wants to use the VM with metering disabled, it constructs a new `CostStrategy::system`, but in other cases, it disables metering in an existing CostStrategy. But, it’s more complicated than that -- sometimes when creating a new `system` CostStrategy, it passes the remaining gas balance from the previous CostStrategy into the new one, essentially using the CostStrategy as a way to pass the remaining gas balance. This code also pointlessly passes around `gas_schedule` arguments that are then used to create `system` CostStrategy values where the gas schedule is ignored.

We should be consistent about this: when we want to run an epilogue function with metering disabled, we should either consistently create a new `system` CostStrategy or disable metering on the previous CostStrategy. After trying it both ways, I think it works better to use one CostStrategy and disable metering for epilogue functions. This also works well as a way to track the remaining gas balance.

Also, because `CostStrategy::system` constructs a CostStrategy where metering is always disabled, there’s no need to specify a gas schedule and the amount of gas remaining. We can simplify all the places where this is used by removing those parameters.

## Motivation

Code cleanup

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo xtest