### PR TITLE
[tests][move-lang] Reduce move_check_testsuite time by 97%

### DIFF
--- a/language/move-lang/test-utils/src/lib.rs
+++ b/language/move-lang/test-utils/src/lib.rs
@@ -30,6 +30,16 @@ pub const COMPLETED_DIRECTORIES: &[&str; 5] = &[
     "move/operators",
 ];
 
+pub fn minimal_stdlib_files() -> Vec<String> {
+    vec![
+        format!("{}/Errors.move", STD_LIB_DIR),
+        format!("{}/Hash.move", STD_LIB_DIR),
+        format!("{}/Option.move", STD_LIB_DIR),
+        format!("{}/Signer.move", STD_LIB_DIR),
+        format!("{}/Vector.move", STD_LIB_DIR),
+    ]
+}
+
 impl std::fmt::Display for StringError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", &self.0)

--- a/language/move-lang/tests/move_check/typing/global_builtins_script.exp
+++ b/language/move-lang/tests/move_check/typing/global_builtins_script.exp
@@ -1,16 +1,16 @@
 error: 
 
-   ┌── tests/move_check/typing/global_builtins_script.move:6:5 ───
-   │
- 6 │     borrow_global<DiemAccount::DiemAccount>(0x1);
-   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Global storage operator cannot be used from a 'script' function
-   │
+    ┌── tests/move_check/typing/global_builtins_script.move:16:5 ───
+    │
+ 16 │     borrow_global<M::R>(0x1);
+    │     ^^^^^^^^^^^^^^^^^^^^^^^^ Global storage operator cannot be used from a 'script' function
+    │
 
 error: 
 
-   ┌── tests/move_check/typing/global_builtins_script.move:7:5 ───
-   │
- 7 │     move_to(account, withdraw_cap);
-   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Global storage operator cannot be used from a 'script' function
-   │
+    ┌── tests/move_check/typing/global_builtins_script.move:17:5 ───
+    │
+ 17 │     move_to(account, r);
+    │     ^^^^^^^^^^^^^^^^^^^ Global storage operator cannot be used from a 'script' function
+    │
 

--- a/language/move-lang/tests/move_check/typing/global_builtins_script.move
+++ b/language/move-lang/tests/move_check/typing/global_builtins_script.move
@@ -1,9 +1,19 @@
+address 0x42 {
+module M {
+    resource struct R {}
+    public fun new(): R {
+        R {}
+    }
+}
+}
+
+
 script {
-use 0x1::DiemAccount;
+use 0x42::M;
 
 fun test<Token>(account: &signer) {
-    let withdraw_cap = DiemAccount::extract_withdraw_capability(account);
-    borrow_global<DiemAccount::DiemAccount>(0x1);
-    move_to(account, withdraw_cap);
+    let r = M::new();
+    borrow_global<M::R>(0x1);
+    move_to(account, r);
 }
 }

--- a/language/move-lang/tests/move_check_testsuite.rs
+++ b/language/move-lang/tests/move_check_testsuite.rs
@@ -45,7 +45,7 @@ fn format_diff(expected: String, actual: String) -> String {
 // Runs all tests under the test/testsuite directory.
 fn move_check_testsuite(path: &Path) -> datatest_stable::Result<()> {
     let targets: Vec<String> = vec![path.to_str().unwrap().to_owned()];
-    let deps = vec![STD_LIB_DIR.to_string()];
+    let deps = minimal_stdlib_files();
     let sender = Some(Address::parse_str(SENDER).unwrap());
 
     let exp_path = path.with_extension(EXP_EXT);


### PR DESCRIPTION
- Restricted stdlib usage in move_check tests to reduce overhead

## Motivation

- For simplicity/convenience, the stdlib was included with each move_check test. 
- By removing the diem-framework and restricting it to a set of core modules, it removes most of the work for each of the 721 tests

## Test Plan

- ran them
- fixed the one test that used the diem framework