### PR TITLE
[mempool] Give ordering to upstream peers

### DIFF
--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -367,7 +367,7 @@ pub type PeerSet = HashMap<PeerId, Peer>;
 /// Downstream -> Downstream, defining a controlled downstream that I always want to connect
 /// Known -> A known peer, but it has no particular role assigned to it
 /// Unknown -> Undiscovered peer, likely due to a non-mutually authenticated connection always downstream
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum PeerRole {
     Validator = 0,
     PreferredUpstream,

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -170,10 +170,9 @@ async fn handle_event<V>(
     match event {
         Event::NewPeer(metadata) => {
             counters::shared_mempool_event_inc("new_peer");
-            let origin = metadata.origin;
             let peer = PeerNetworkId(network_id, metadata.remote_peer_id);
-            let is_new_peer = smp.peer_manager.add_peer(peer.clone(), metadata);
-            let is_upstream_peer = smp.peer_manager.is_upstream_peer(&peer, Some(origin));
+            let is_new_peer = smp.peer_manager.add_peer(peer.clone(), metadata.clone());
+            let is_upstream_peer = smp.peer_manager.is_upstream_peer(&peer, Some(&metadata));
             debug!(LogSchema::new(LogEntry::NewPeer)
                 .peer(&peer)
                 .is_upstream_peer(is_upstream_peer));
@@ -187,10 +186,7 @@ async fn handle_event<V>(
             let peer = PeerNetworkId(network_id, metadata.remote_peer_id);
             debug!(LogSchema::new(LogEntry::LostPeer)
                 .peer(&peer)
-                .is_upstream_peer(
-                    smp.peer_manager
-                        .is_upstream_peer(&peer, Some(metadata.origin))
-                ));
+                .is_upstream_peer(smp.peer_manager.is_upstream_peer(&peer, Some(&metadata))));
             smp.peer_manager.disable_peer(peer);
             notify_subscribers(SharedMempoolNotification::PeerStateChange, &smp.subscribers);
         }

--- a/mempool/src/shared_mempool/runtime.rs
+++ b/mempool/src/shared_mempool/runtime.rs
@@ -47,8 +47,7 @@ pub(crate) fn start_shared_mempool<V>(
 ) where
     V: TransactionValidation + 'static,
 {
-    let upstream_config = config.upstream.clone();
-    let peer_manager = Arc::new(PeerManager::new(config.mempool.clone(), upstream_config));
+    let peer_manager = Arc::new(PeerManager::new(config.mempool.clone()));
 
     let mut all_network_events = vec![];
     let mut network_senders = HashMap::new();

--- a/mempool/src/tests/fuzzing.rs
+++ b/mempool/src/tests/fuzzing.rs
@@ -41,7 +41,7 @@ pub fn test_mempool_process_incoming_transactions_impl(
         network_senders: HashMap::new(),
         db: Arc::new(mock_db),
         validator: vm_validator,
-        peer_manager: Arc::new(PeerManager::new(config.mempool, config.upstream)),
+        peer_manager: Arc::new(PeerManager::new(config.mempool)),
         subscribers: vec![],
     };
 


### PR DESCRIPTION
In order to better utilize upstream peers, we now provide a priority
order between all upstream peers.  This will allow us to simply choose
which peers to send txns to.  Additionally, removed some extra logic
around upstream configs since now there's no need for determining which
networks are for upstream.
