### PR TITLE
[move-prover] changed name of join function of "joinresult"

### DIFF
--- a/language/move-prover/bytecode/src/borrow_analysis.rs
+++ b/language/move-prover/bytecode/src/borrow_analysis.rs
@@ -596,21 +596,21 @@ impl AbstractDomain for BorrowInfo {
         let mut borrowed_changed = JoinResult::Unchanged;
         for (src, dests) in other.borrowed_by.iter() {
             for (dest, edges) in dests {
-                let new_edges = self
+                let edges_changed = self
                     .borrowed_by
                     .entry(src.clone())
                     .or_default()
                     .entry(dest.clone())
                     .or_default()
                     .join(edges);
-                borrowed_changed = borrowed_changed.join(new_edges)
+                borrowed_changed = borrowed_changed.combine(edges_changed)
             }
         }
         borrowed_changed
-            .join(moved_changed)
-            .join(spliced_changed)
-            .join(unchecked_changed)
-            .join(live_changed)
+            .combine(moved_changed)
+            .combine(spliced_changed)
+            .combine(unchecked_changed)
+            .combine(live_changed)
     }
 }
 

--- a/language/move-prover/bytecode/src/dataflow_analysis.rs
+++ b/language/move-prover/bytecode/src/dataflow_analysis.rs
@@ -22,7 +22,7 @@ pub enum JoinResult {
 }
 
 impl JoinResult {
-    pub fn join(self, other: JoinResult) -> JoinResult {
+    pub fn combine(self, other: JoinResult) -> JoinResult {
         use JoinResult::*;
         match (self, other) {
             (Unchanged, Unchanged) => Unchanged,


### PR DESCRIPTION

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

changed name of join function of "joinresult" to make clear that this is not an abstract domain.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

existing tests are fine