### PR TITLE
Ignore the C# txn gen test by default. Still runs in CI

### DIFF
--- a/language/transaction-builder/generator/tests/generation.rs
+++ b/language/transaction-builder/generator/tests/generation.rs
@@ -299,6 +299,7 @@ fn test_that_java_code_compiles_and_demo_runs() {
 }
 
 #[test]
+#[ignore]
 fn test_that_csharp_code_compiles_and_demo_runs() {
     let registry = get_diem_registry();
     let abis = get_stdlib_script_abis();


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Ignore the C# transaction generation test by default. Like the other languages did. I just forgot to re-add it back after local testing.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI

## Related PRs

#7784 