### PR TITLE
[GHA] Added build-images step into ci-test workflow

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -85,6 +85,47 @@ jobs:
       - name: build image with dev-setup.sh
         run: docker build -f docker/ci/${{ matrix.target_os }}/Dockerfile -t diem/build_environment:test .
 
+  build-images:
+    runs-on: ubuntu-latest-xl
+    needs: prepare
+    if: ${{ github.event_name == 'push' && needs.prepare.outputs.test-rust == 'true' }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 #get all the history!!!
+      - id: changes
+        name: determine changes
+        uses: ./.github/actions/changes
+        with:
+          workflow-file: docker-publish.yml
+      - name: Sign in to dockerhub, install image signing cert.
+        uses: ./.github/actions/dockerhub_login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          key_material: ${{ secrets.DOCKERHUB_KEY_MATERIAL }}
+          key_name: ${{ secrets.DOCKERHUB_KEY_NAME }}
+          key_password: ${{ secrets.DOCKERHUB_KEY_PASSWORD }}
+      - name: pre-release docker images
+        run: |
+          BRANCH="$CHANGES_TARGET_BRANCH"
+          success=0
+          tmpfile=$(mktemp)
+          echo "Failed to push:" > "${tmpfile}"
+          docker/build_push.sh -u -p -b ${BRANCH} -n client || success=$(echo "client" >> "${tmpfile}"; echo 1)
+          docker/build_push.sh -u -p -b ${BRANCH} -n init || success=$(echo "init" >> "${tmpfile}"; echo 1)
+          docker/build_push.sh -u -p -b ${BRANCH} -n faucet || success=$(echo "faucet" >> "${tmpfile}"; echo 1)
+          docker/build_push.sh -u -p -b ${BRANCH} -n tools || success=$(echo "tools" >> "${tmpfile}"; echo 1)
+          docker/build_push.sh -u -p -b ${BRANCH} -n validator || success=$(echo "validator" >> "${tmpfile}"; echo 1)
+          docker/build_push.sh -u -p -b ${BRANCH} -n validator-tcb || success=$(echo "validator-tcb" >> "${tmpfile}"; echo 1)
+          docker/build_push.sh -u -p -b ${BRANCH} -n cluster-test || success=$(echo "cluster-test" >> "${tmpfile}"; echo 1)
+          if [[ "$success" == "1" ]]; then
+            cat "${tmpfile}"
+          fi
+          exit $success
+        env:
+          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKERHUB_KEY_PASSWORD }}
+
   non-rust-lint:
     runs-on: ubuntu-latest-xl
     timeout-minutes: 10

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: docker-publish.yml
 
 on:
   push:
-    branches: [auto, master, release-*]
+    branches: [master, release-*]
 
 jobs:
   build-images:
@@ -10,7 +10,6 @@ jobs:
     continue-on-error: false
     env:
       TAG: github-1
-      DOCKERHUB_ORG: libra
     steps:
       - uses: actions/checkout@v2
         with:
@@ -20,7 +19,7 @@ jobs:
         uses: ./.github/actions/changes
         with:
           workflow-file: docker-publish.yml
-      - name: setup_aws_erc_login
+      - name: setup_aws_ecr_login
         run: |
           echo 'AWS_ECR_ACCOUNT_URL=${{ secrets.AWS_ECR_ACCOUNT_NUM }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com' >> $GITHUB_ENV
       - name: Configure AWS credentials


### PR DESCRIPTION
split current docker publish workflow into 2 parts:

- Added new step build-images to ci-test workflow for further usage by LBT merging. It has condition by github.event_name == 'push' && needs.prepare.outputs.test-rust == 'true' and only push pre_build_image
- Removed auto branch task from docker-publish workflow, which ci-test workflow will be also triggered by auto branch

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

- tested new step will skip by pr pull
- tested with /canary, current ci-test passed and new build-images step pushed pre_master_018999af image succeeded 


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/master/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
