### PR TITLE
Cherry-pick PR #7819 into release-1.1: [dep] bump generic-array to 0.12.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
  "block-padding 0.1.5",
  "byte-tools",
  "byteorder",
- "generic-array 0.12.3",
+ "generic-array 0.12.4",
 ]
 
 [[package]]
@@ -2399,7 +2399,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
- "generic-array 0.12.3",
+ "generic-array 0.12.4",
 ]
 
 [[package]]
@@ -3046,9 +3046,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
 dependencies = [
  "typenum",
 ]


### PR DESCRIPTION
This cherry-pick was triggerd by a request on #7819
Please review the diff to ensure there are not any unexpected changes.


- Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
This is not a breaking change. 
generic-array v0.12.3 is one of the transitive deps and is flagged in https://rustsec.org/advisories/RUSTSEC-2020-0146.html.  The fix is back ported to v0.12.4.  List of crates are affected: diem-writeset-generator, backup-service, debug-interface, json-rpc, faucet.

- Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
Tests include cargo audit + CI.

- Why we must have it for V1 launch.
Two reasons. One is to address the RUSTSEC.  The other is to maintain the SNR of the audit alerts so that they are actionable.

- What workarounds and alternative we have if we do not push the PR.
If we don't update this transitive dep, the alternative would be to update the indirect deps or wait for their fixes; they include: headers, pest_meta.

