### PR TITLE
[Secure Storage] Vault timeout workaround due to ureq bug.

### DIFF
--- a/secure/storage/vault/src/lib.rs
+++ b/secure/storage/vault/src/lib.rs
@@ -28,7 +28,12 @@ pub mod fuzzing;
 const MAX_NUM_KEY_VERSIONS: u32 = 4;
 
 /// Default request timeouts for vault operations.
-const DEFAULT_CONNECTION_TIMEOUT_MS: u64 = 100;
+/// Note: there is a bug in ureq v 1.5.4 where it's not currently possible to set
+/// different timeouts for connections and operations. The connection timeout
+/// will override any other timeouts (including reads and writes). This has been
+/// fixed in ureq 2. Once we upgrade, we'll be able to have separate timeouts.
+/// Until then, the connection timeout is used for all operations.
+const DEFAULT_CONNECTION_TIMEOUT_MS: u64 = 1_000;
 const DEFAULT_RESPONSE_TIMEOUT_MS: u64 = 1_000;
 
 #[derive(Debug, Error, PartialEq)]


### PR DESCRIPTION
## Motivation

This PR updates the connection timeout for vault from 100ms to 1 second. This is due to a bug/unclear documentation that currently exists in ureq 1.5.4, where the connection timeout overrides all other timeout values, including timeouts for reads and writes (https://github.com/algesten/ureq/blob/1.5.4/src/stream.rs#L459). Note: there's also another bug where the read timeout is reset instead of the write timeout, but that is unrelated (https://github.com/algesten/ureq/blob/1.5.4/src/stream.rs#L467).

This functionality has been fixed in version 2 of ureq (https://github.com/algesten/ureq/commit/a52c6021cfd01e2c3441ba0383b075ddfe7c7f1b#diff-aa0a8d713ea64389a4b4916384d286b01c0de291edf10fec2f213123419e2647R335), which means it's possible to set separate timeouts, but until we migrate to version 2 (which is unfortunately not trivial), we'll need to use this workaround and increase the connection timeout.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally.

## Related PRs

This relates to configurable timeouts and defaults that were recently updated: https://github.com/diem/diem/pull/7743
