### PR TITLE
[docker] Add writeset tools into docker image

### DIFF
--- a/docker/build-common.sh
+++ b/docker/build-common.sh
@@ -29,6 +29,8 @@ ${CARGO} ${CARGOFLAGS} build --release \
          -p safety-rules \
          -p db-bootstrapper \
          -p backup-cli \
+         -p diem-transaction-replay \
+         -p diem-writeset-generator \
          "$@"
 
 # Build and overwrite the diem-node binary with feature failpoints if $ENABLE_FAILPOINTS is configured

--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -45,6 +45,8 @@ COPY --from=builder /diem/target/release/db-bootstrapper /usr/local/bin
 COPY --from=builder /diem/target/release/db-backup /usr/local/bin
 COPY --from=builder /diem/target/release/db-backup-verify /usr/local/bin
 COPY --from=builder /diem/target/release/db-restore /usr/local/bin
+COPY --from=builder /diem/target/release/diem-transaction-replay /usr/local/bin
+COPY --from=builder /diem/target/release/diem-writeset-generator /usr/local/bin
 
 ARG BUILD_DATE
 ARG GIT_REV


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Add writeset tools into the tools docker image, to make it easy for oncall to use. During incident, this would save us some time on building binaries locally.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- submit remote build to aws ecr.
- pull image locally 853397791086.dkr.ecr.us-west-2.amazonaws.com/diem/tools:dev_f825c1a1
- check if the writeset tool is working.
```
+ docker run -v /Users/sherryxiao/mainnet/tmp:/cwd --network=host -i 853397791086.dkr.ecr.us-west-2.amazonaws.com/diem/tools:dev_f825c1a1 sh -x
+ diem-transaction-replay
+ socat TCP-LISTEN:,bind=localhost,fork TCP:host.docker.internal:
2021/03/06 02:12:04 socat[7] E empty port/service
diem-transaction-replay 0.1.0

USAGE:
    diem-transaction-replay [FLAGS] [OPTIONS] <SUBCOMMAND>

FLAGS:
    -h, --help       Prints help information
    -s               If true, persist the effects of replaying transactions via `cmd` to disk in a format understood by
                     the Move CLI
    -V, --version    Prints version information

OPTIONS:
        --db <db>      Path to the local DiemDB file
    -u, --url <url>    Full URL address to connect to - should include port number, if applicable

SUBCOMMANDS:
    annotate-account
    annotate-key-accounts
    bisect-transaction
    diff-account
    get-modules                              Get the bytecode for all Diem Framework modules at `version`
    help                                     Prints this message or the help of the given subcommand(s)
    replay-recent-transactions
    replay-transaction-by-sequence-number
    replay-transactions
    replay-writeset
            Execute a writeset as if it is signed by the Diem Root and print the result
```


