### PR TITLE
[move-prover] Enable setting of environment extensions with an immutable reference 

### DIFF
--- a/language/move-prover/bytecode/src/data_invariant_instrumentation.rs
+++ b/language/move-prover/bytecode/src/data_invariant_instrumentation.rs
@@ -14,7 +14,7 @@ use crate::{
     function_data_builder::FunctionDataBuilder,
     function_target::FunctionData,
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant},
-    options::{ProverOptions, PROVER_DEFAULT_OPTIONS},
+    options::ProverOptions,
     stackless_bytecode::{Bytecode, Operation, PropKind},
 };
 
@@ -47,12 +47,8 @@ impl FunctionTargetProcessor for DataInvariantInstrumentationProcessor {
             // Nothing to do.
             return data;
         }
-        let options = fun_env
-            .module_env
-            .env
-            .get_extension::<ProverOptions>()
-            .unwrap_or_else(|| &*PROVER_DEFAULT_OPTIONS);
-        Instrumenter::run(options, targets, fun_env, data)
+        let options = ProverOptions::get(fun_env.module_env.env);
+        Instrumenter::run(&*options, targets, fun_env, data)
     }
 
     fn name(&self) -> String {

--- a/language/move-prover/bytecode/src/global_invariant_instrumentation.rs
+++ b/language/move-prover/bytecode/src/global_invariant_instrumentation.rs
@@ -10,7 +10,7 @@ use crate::{
     function_data_builder::FunctionDataBuilder,
     function_target::FunctionData,
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant},
-    options::{ProverOptions, PROVER_DEFAULT_OPTIONS},
+    options::ProverOptions,
     stackless_bytecode::{BorrowNode, Bytecode, Operation, PropKind},
     usage_analysis,
 };
@@ -51,13 +51,8 @@ impl FunctionTargetProcessor for GlobalInvariantInstrumentationProcessor {
             return data;
         }
 
-        let options = fun_env
-            .module_env
-            .env
-            .get_extension::<ProverOptions>()
-            .unwrap_or_else(|| &*PROVER_DEFAULT_OPTIONS);
-
-        Instrumenter::run(options, fun_env, data)
+        let options = ProverOptions::get(fun_env.module_env.env);
+        Instrumenter::run(&*options, fun_env, data)
     }
 
     fn name(&self) -> String {

--- a/language/move-prover/bytecode/src/global_invariant_instrumentation_v2.rs
+++ b/language/move-prover/bytecode/src/global_invariant_instrumentation_v2.rs
@@ -10,7 +10,7 @@ use crate::{
     function_data_builder::FunctionDataBuilder,
     function_target::FunctionData,
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant},
-    options::{ProverOptions, PROVER_DEFAULT_OPTIONS},
+    options::ProverOptions,
     stackless_bytecode::{BorrowNode, Bytecode, Operation, PropKind},
     usage_analysis,
 };
@@ -51,13 +51,8 @@ impl FunctionTargetProcessor for GlobalInvariantInstrumentationProcessorV2 {
             return data;
         }
 
-        let options = fun_env
-            .module_env
-            .env
-            .get_extension::<ProverOptions>()
-            .unwrap_or_else(|| &*PROVER_DEFAULT_OPTIONS);
-
-        Instrumenter::run(options, fun_env, data)
+        let options = ProverOptions::get(fun_env.module_env.env);
+        Instrumenter::run(&*options, fun_env, data)
     }
 
     fn name(&self) -> String {

--- a/language/move-prover/bytecode/src/options.rs
+++ b/language/move-prover/bytecode/src/options.rs
@@ -1,9 +1,9 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_model::model::VerificationScope;
-use once_cell::sync::Lazy;
+use move_model::model::{GlobalEnv, VerificationScope};
 use serde::{Deserialize, Serialize};
+use std::rc::Rc;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
@@ -67,4 +67,11 @@ impl Default for ProverOptions {
     }
 }
 
-pub static PROVER_DEFAULT_OPTIONS: Lazy<ProverOptions> = Lazy::new(ProverOptions::default);
+impl ProverOptions {
+    pub fn get(env: &GlobalEnv) -> Rc<ProverOptions> {
+        if !env.has_extension::<ProverOptions>() {
+            env.set_extension(ProverOptions::default())
+        }
+        env.get_extension::<ProverOptions>().unwrap()
+    }
+}

--- a/language/move-prover/bytecode/src/spec_instrumentation.rs
+++ b/language/move-prover/bytecode/src/spec_instrumentation.rs
@@ -18,7 +18,7 @@ use crate::{
     function_target::{FunctionData, FunctionTarget},
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant},
     livevar_analysis::LiveVarAnalysisProcessor,
-    options::{ProverOptions, PROVER_DEFAULT_OPTIONS},
+    options::ProverOptions,
     reaching_def_analysis::ReachingDefProcessor,
     spec_translator::{SpecTranslator, TranslatedSpec},
     stackless_bytecode::{AbortAction, AssignKind, AttrId, Bytecode, Label, Operation, PropKind},
@@ -96,11 +96,7 @@ impl FunctionTargetProcessor for SpecInstrumentationProcessor {
             return data;
         }
 
-        let options = fun_env
-            .module_env
-            .env
-            .get_extension::<ProverOptions>()
-            .unwrap_or_else(|| &*PROVER_DEFAULT_OPTIONS);
+        let options = ProverOptions::get(fun_env.module_env.env);
         let verification_info =
             verification_analysis::get_info(&FunctionTarget::new(fun_env, &data));
 
@@ -114,7 +110,7 @@ impl FunctionTargetProcessor for SpecInstrumentationProcessor {
             let mut verification_data = data.fork(FunctionVariant::Verification);
             verification_data.annotations = annotations;
             verification_data = Instrumenter::run(
-                options,
+                &*options,
                 targets,
                 fun_env,
                 FunctionVariant::Verification,
@@ -129,7 +125,7 @@ impl FunctionTargetProcessor for SpecInstrumentationProcessor {
 
         // Instrument baseline variant only if it is inlined.
         if verification_info.inlined {
-            Instrumenter::run(options, targets, fun_env, FunctionVariant::Baseline, data)
+            Instrumenter::run(&*options, targets, fun_env, FunctionVariant::Baseline, data)
         } else {
             // Clear code but keep function data stub.
             // TODO(refactoring): the stub is currently still needed because boogie_wrapper

--- a/language/move-prover/bytecode/src/verification_analysis.rs
+++ b/language/move-prover/bytecode/src/verification_analysis.rs
@@ -6,7 +6,7 @@
 use crate::{
     function_target::{FunctionData, FunctionTarget},
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant},
-    options::{ProverOptions, PROVER_DEFAULT_OPTIONS},
+    options::ProverOptions,
     usage_analysis,
 };
 use move_model::model::{FunctionEnv, GlobalEnv, QualifiedId, StructId};
@@ -56,11 +56,7 @@ impl FunctionTargetProcessor for VerificationAnalysisProcessor {
         // Check the friend relation.
         check_friend_relation(fun_env);
 
-        let options = fun_env
-            .module_env
-            .env
-            .get_extension::<ProverOptions>()
-            .unwrap_or_else(|| &*PROVER_DEFAULT_OPTIONS);
+        let options = ProverOptions::get(fun_env.module_env.env);
         let is_verified =
             if fun_env.module_env.is_target() && fun_env.should_verify(options.verify_scope) {
                 // This function needs to be verified because it is a user provided verification

--- a/language/move-prover/bytecode/tests/testsuite.rs
+++ b/language/move-prover/bytecode/tests/testsuite.rs
@@ -150,7 +150,7 @@ fn get_tested_transformation_pipeline(
 fn test_runner(path: &Path) -> datatest_stable::Result<()> {
     let mut sources = extract_test_directives(path, "// dep:")?;
     sources.push(path.to_string_lossy().to_string());
-    let mut env: GlobalEnv = run_model_builder(sources, vec![], Some("0x2345467"))?;
+    let env: GlobalEnv = run_model_builder(sources, vec![], Some("0x2345467"))?;
     let out = if env.has_errors() {
         let mut error_writer = Buffer::no_color();
         env.report_errors(&mut error_writer);


### PR DESCRIPTION
This PR removes the need to have a `&mut GlobalEnv` to set extension data in the environment by making the extension storage a `RefCell`. Since with `RefCell` we cannot export references to the interior data, this PR makes `get_extension::<T>()` return an `Rc<T>`, avoiding the alternative of cloning T. The caller can then easily turn this `r: Rc<T>` into a `&T` by `&*r` if he needs to.

This also changes the way how processors retrieve the active ProverOptions, using the new mechanism.

## Motivation

Feature.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests

## Related PRs

NA

## If targeting a release branch, please fill the below out as well

 NA