### PR TITLE
[move-prover] Add a wellformed-check after havoc of &mut parameters.

### DIFF
--- a/language/move-prover/bytecode/tests/spec_instrumentation/generics.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/generics.exp
@@ -57,8 +57,8 @@ fun Generics::remove_u64($t0|a: address): Generics::R<u64> {
   8: goto 17
   9: label L3
  10: modifies global<Generics::R<u64>>($t0)
- 11: assume Not(exists<Generics::R<u64>>($t0))
- 12: assume WellFormed($t3)
+ 11: assume WellFormed($t3)
+ 12: assume Not(exists<Generics::R<u64>>($t0))
      # << opaque call: $t1 := Generics::remove<u64>($t0)
  13: nop
  14: label L1

--- a/language/move-prover/bytecode/tests/spec_instrumentation/modifies.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/modifies.exp
@@ -245,8 +245,8 @@ pub fun B::move_from_test_incorrect($t0|addr1: address, $t1|addr2: address): B::
   8: trace_abort($t6)
   9: goto 29
  10: label L3
- 11: assume Eq<u64>($t7, select A::S.x(global<A::S>($t1)))
- 12: assume WellFormed($t7)
+ 11: assume WellFormed($t7)
+ 12: assume Eq<u64>($t7, select A::S.x(global<A::S>($t1)))
      # << opaque call: $t5 := A::read_at($t1)
  13: nop
      # VC: caller does not have permission to modify `B::T` at given address at tests/spec_instrumentation/modifies.move:65:17+9
@@ -260,8 +260,8 @@ pub fun B::move_from_test_incorrect($t0|addr1: address, $t1|addr2: address): B::
  20: trace_abort($t6)
  21: goto 29
  22: label L5
- 23: assume Eq<u64>($t10, select A::S.x(global<A::S>($t1)))
- 24: assume WellFormed($t10)
+ 23: assume WellFormed($t10)
+ 24: assume Eq<u64>($t10, select A::S.x(global<A::S>($t1)))
      # << opaque call: $t7 := A::read_at($t1)
  25: nop
  26: assert Eq<u64>($t7, $t10)
@@ -295,8 +295,8 @@ pub fun B::move_to_test_incorrect($t0|account: signer, $t1|addr2: address) {
   8: trace_abort($t5)
   9: goto 31
  10: label L3
- 11: assume Eq<u64>($t6, select A::S.x(global<A::S>($t1)))
- 12: assume WellFormed($t6)
+ 11: assume WellFormed($t6)
+ 12: assume Eq<u64>($t6, select A::S.x(global<A::S>($t1)))
      # << opaque call: $t4 := A::read_at($t1)
  13: nop
  14: $t7 := 2
@@ -312,8 +312,8 @@ pub fun B::move_to_test_incorrect($t0|account: signer, $t1|addr2: address) {
  22: trace_abort($t5)
  23: goto 31
  24: label L5
- 25: assume Eq<u64>($t10, select A::S.x(global<A::S>($t1)))
- 26: assume WellFormed($t10)
+ 25: assume WellFormed($t10)
+ 26: assume Eq<u64>($t10, select A::S.x(global<A::S>($t1)))
      # << opaque call: $t7 := A::read_at($t1)
  27: nop
  28: assert Eq<u64>($t6, $t10)
@@ -346,8 +346,8 @@ pub fun B::mutate_S_test1_incorrect($t0|addr1: address, $t1|addr2: address) {
   8: trace_abort($t5)
   9: goto 38
  10: label L3
- 11: assume Eq<u64>($t6, select A::S.x(global<A::S>($t1)))
- 12: assume WellFormed($t6)
+ 11: assume WellFormed($t6)
+ 12: assume Eq<u64>($t6, select A::S.x(global<A::S>($t1)))
      # << opaque call: $t4 := A::read_at($t1)
  13: nop
      # >> opaque call: A::mutate_at($t0)
@@ -372,8 +372,8 @@ pub fun B::mutate_S_test1_incorrect($t0|addr1: address, $t1|addr2: address) {
  29: trace_abort($t5)
  30: goto 38
  31: label L7
- 32: assume Eq<u64>($t9, select A::S.x(global<A::S>($t1)))
- 33: assume WellFormed($t9)
+ 32: assume WellFormed($t9)
+ 33: assume Eq<u64>($t9, select A::S.x(global<A::S>($t1)))
      # << opaque call: $t5 := A::read_at($t1)
  34: nop
  35: assert Eq<u64>($t6, $t9)
@@ -404,8 +404,8 @@ pub fun B::mutate_S_test2_incorrect($t0|addr: address) {
   6: trace_abort($t4)
   7: goto 36
   8: label L3
-  9: assume Eq<u64>($t5, select A::S.x(global<A::S>($t0)))
- 10: assume WellFormed($t5)
+  9: assume WellFormed($t5)
+ 10: assume Eq<u64>($t5, select A::S.x(global<A::S>($t0)))
      # << opaque call: $t3 := A::read_at($t0)
  11: nop
      # >> opaque call: A::mutate_at($t0)
@@ -430,8 +430,8 @@ pub fun B::mutate_S_test2_incorrect($t0|addr: address) {
  27: trace_abort($t4)
  28: goto 36
  29: label L7
- 30: assume Eq<u64>($t8, select A::S.x(global<A::S>($t0)))
- 31: assume WellFormed($t8)
+ 30: assume WellFormed($t8)
+ 31: assume Eq<u64>($t8, select A::S.x(global<A::S>($t0)))
      # << opaque call: $t4 := A::read_at($t0)
  32: nop
  33: assert Eq<u64>($t5, $t8)
@@ -467,8 +467,8 @@ pub fun B::mutate_at_test_incorrect($t0|addr1: address, $t1|addr2: address) {
   8: trace_abort($t6)
   9: goto 34
  10: label L3
- 11: assume Eq<u64>($t7, select A::S.x(global<A::S>($t1)))
- 12: assume WellFormed($t7)
+ 11: assume WellFormed($t7)
+ 12: assume Eq<u64>($t7, select A::S.x(global<A::S>($t1)))
      # << opaque call: $t5 := A::read_at($t1)
  13: nop
      # VC: caller does not have permission to modify `B::T` at given address at tests/spec_instrumentation/modifies.move:38:17+17
@@ -487,8 +487,8 @@ pub fun B::mutate_at_test_incorrect($t0|addr1: address, $t1|addr2: address) {
  25: trace_abort($t6)
  26: goto 34
  27: label L5
- 28: assume Eq<u64>($t12, select A::S.x(global<A::S>($t1)))
- 29: assume WellFormed($t12)
+ 28: assume WellFormed($t12)
+ 29: assume Eq<u64>($t12, select A::S.x(global<A::S>($t1)))
      # << opaque call: $t9 := A::read_at($t1)
  30: nop
  31: assert Eq<u64>($t7, $t12)

--- a/language/move-prover/bytecode/tests/spec_instrumentation/opaque_call.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/opaque_call.exp
@@ -151,9 +151,9 @@ fun Test::incr_twice() {
  11: label L3
  12: @2 := save_mem(Test::R)
  13: modifies global<Test::R>($t0)
- 14: assume Eq<u64>(select Test::R.v(global<Test::R>($t0)), Add(select Test::R.v(global[@2]<Test::R>($t0)), 1))
- 15: assume Eq<u64>($t3, select Test::R.v(global<Test::R>($t0)))
- 16: assume WellFormed($t3)
+ 14: assume WellFormed($t3)
+ 15: assume Eq<u64>(select Test::R.v(global<Test::R>($t0)), Add(select Test::R.v(global[@2]<Test::R>($t0)), 1))
+ 16: assume Eq<u64>($t3, select Test::R.v(global<Test::R>($t0)))
      # << opaque call: $t1 := Test::get_and_incr($t0)
  17: nop
  18: destroy($t3)
@@ -171,9 +171,9 @@ fun Test::incr_twice() {
  28: label L5
  29: @3 := save_mem(Test::R)
  30: modifies global<Test::R>($t4)
- 31: assume Eq<u64>(select Test::R.v(global<Test::R>($t4)), Add(select Test::R.v(global[@3]<Test::R>($t4)), 1))
- 32: assume Eq<u64>($t6, select Test::R.v(global<Test::R>($t4)))
- 33: assume WellFormed($t6)
+ 31: assume WellFormed($t6)
+ 32: assume Eq<u64>(select Test::R.v(global<Test::R>($t4)), Add(select Test::R.v(global[@3]<Test::R>($t4)), 1))
+ 33: assume Eq<u64>($t6, select Test::R.v(global<Test::R>($t4)))
      # << opaque call: $t3 := Test::get_and_incr($t2)
  34: nop
  35: destroy($t6)


### PR DESCRIPTION
This adds a wellformed assumption after havoc of &mut parameters, following up on a suspicion that new timeouts might be caused by this missing. It appears it did not fix the timeouts, but is needed anyway.

## Motivation

Chasing possible bugs in v2 prover.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests.

## Related PRs

#7818

## If targeting a release branch, please fill the below out as well

NA
