### PR TITLE
client: symlink proxy module

### DIFF
--- a/sdk/client/src/blocking.rs
+++ b/sdk/client/src/blocking.rs
@@ -24,8 +24,9 @@ use serde::{de::DeserializeOwned, Serialize};
 use std::time::Duration;
 
 // In order to avoid needing to publish the proxy crate to crates.io we simply include the small
-// library in inline by making it a module instead of a dependency.
-#[path = "../../../common/proxy/src/lib.rs"]
+// library in inline by making it a module instead of a dependency. 'src/proxy.rs' is a symlink to
+// '../../../common/proxy/src/lib.rs'
+#[path = "proxy.rs"]
 mod proxy;
 
 const REQUEST_TIMEOUT: u64 = 10_000;

--- a/sdk/client/src/proxy.rs
+++ b/sdk/client/src/proxy.rs
@@ -1,0 +1,1 @@
+../../../common/proxy/src/lib.rs


### PR DESCRIPTION
It turns out that `cargo publish` requires that all source files live
under 'src/' so using the trick to include the proxy crate as a module
didn't work. Instead use a symlink.
