### PR TITLE
[move-lang-functional-tests] Reduce test time by 60%

### DIFF
--- a/language/move-lang/src/cfgir/ast.rs
+++ b/language/move-lang/src/cfgir/ast.rs
@@ -18,7 +18,7 @@ use std::collections::{BTreeMap, VecDeque};
 // Program
 //**************************************************************************************************
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Program {
     pub modules: UniqueMap<ModuleIdent, ModuleDefinition>,
     pub scripts: BTreeMap<String, Script>,
@@ -28,7 +28,7 @@ pub struct Program {
 // Scripts
 //**************************************************************************************************
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Script {
     pub loc: Loc,
     pub constants: UniqueMap<ConstantName, Constant>,
@@ -40,7 +40,7 @@ pub struct Script {
 // Modules
 //**************************************************************************************************
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ModuleDefinition {
     pub is_source_module: bool,
     /// `dependency_order` is the topological order/rank in the dependency graph.
@@ -55,7 +55,7 @@ pub struct ModuleDefinition {
 // Constants
 //**************************************************************************************************
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct Constant {
     pub loc: Loc,
     pub signature: BaseType,
@@ -66,7 +66,7 @@ pub struct Constant {
 // Functions
 //**************************************************************************************************
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum FunctionBody_ {
     Native,
     Defined {
@@ -77,7 +77,7 @@ pub enum FunctionBody_ {
 }
 pub type FunctionBody = Spanned<FunctionBody_>;
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct Function {
     pub visibility: FunctionVisibility,
     pub signature: FunctionSignature,

--- a/language/move-lang/src/compiled_unit.rs
+++ b/language/move-lang/src/compiled_unit.rs
@@ -17,26 +17,26 @@ use std::collections::BTreeMap;
 // Compiled Unit
 //**************************************************************************************************
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct VarInfo {
     pub type_: H::SingleType,
     pub index: F::LocalIndex,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SpecInfo {
     pub offset: F::CodeOffset,
     // Free locals that are used but not declared in the block
     pub used_locals: UniqueMap<Var, VarInfo>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FunctionInfo {
     pub spec_info: BTreeMap<SpecId, SpecInfo>,
     pub parameters: Vec<(Var, VarInfo)>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum CompiledUnit {
     Module {
         ident: ModuleIdent,

--- a/language/move-lang/src/hlir/ast.rs
+++ b/language/move-lang/src/hlir/ast.rs
@@ -19,7 +19,7 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 // Program
 //**************************************************************************************************
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Program {
     pub modules: UniqueMap<ModuleIdent, ModuleDefinition>,
     pub scripts: BTreeMap<String, Script>,
@@ -29,7 +29,7 @@ pub struct Program {
 // Scripts
 //**************************************************************************************************
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Script {
     pub loc: Loc,
     pub constants: UniqueMap<ConstantName, Constant>,
@@ -41,7 +41,7 @@ pub struct Script {
 // Modules
 //**************************************************************************************************
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ModuleDefinition {
     pub is_source_module: bool,
     /// `dependency_order` is the topological order/rank in the dependency graph.
@@ -73,7 +73,7 @@ pub enum StructFields {
 // Constants
 //**************************************************************************************************
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct Constant {
     pub loc: Loc,
     pub signature: BaseType,
@@ -91,7 +91,7 @@ pub struct FunctionSignature {
     pub return_type: Type,
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum FunctionBody_ {
     Native,
     Defined {
@@ -101,7 +101,7 @@ pub enum FunctionBody_ {
 }
 pub type FunctionBody = Spanned<FunctionBody_>;
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct Function {
     pub visibility: FunctionVisibility,
     pub signature: FunctionSignature,
@@ -150,7 +150,7 @@ pub type Type = Spanned<Type_>;
 // Statements
 //**************************************************************************************************
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum Statement_ {
     Command(Command),
@@ -183,7 +183,7 @@ pub struct Label(pub usize);
 // Commands
 //**************************************************************************************************
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum Command_ {
     Assign(Vec<LValue>, Box<Exp>),
@@ -211,7 +211,7 @@ pub enum Command_ {
 }
 pub type Command = Spanned<Command_>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum LValue_ {
     Ignore,
     Var(Var, Box<SingleType>),
@@ -230,7 +230,7 @@ pub enum UnitCase {
     FromUser,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct ModuleCall {
     pub module: ModuleIdent,
     pub name: FunctionName,
@@ -239,7 +239,7 @@ pub struct ModuleCall {
     pub acquires: BTreeMap<StructName, Loc>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum BuiltinFunction_ {
     MoveTo(BaseType),
     MoveFrom(BaseType),
@@ -248,7 +248,7 @@ pub enum BuiltinFunction_ {
 }
 pub type BuiltinFunction = Spanned<BuiltinFunction_>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum UnannotatedExp_ {
     Unit { case: UnitCase },
     Value(Value),
@@ -279,7 +279,7 @@ pub enum UnannotatedExp_ {
     UnresolvedError,
 }
 pub type UnannotatedExp = Spanned<UnannotatedExp_>;
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Exp {
     pub ty: Type,
     pub exp: UnannotatedExp,
@@ -288,7 +288,7 @@ pub fn exp(ty: Type, exp: UnannotatedExp) -> Exp {
     Exp { ty, exp }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum ExpListItem {
     Single(Exp, Box<SingleType>),
     Splat(Loc, Exp, Vec<SingleType>),

--- a/language/move-lang/src/hlir/translate.rs
+++ b/language/move-lang/src/hlir/translate.rs
@@ -9,6 +9,7 @@ use crate::{
     parser::ast::{BinOp_, ConstantName, Field, FunctionName, ModuleIdent, StructName, Var},
     shared::{unique_map::UniqueMap, *},
     typing::ast as T,
+    FullyCompiledProgram,
 };
 use move_ir_types::location::*;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
@@ -149,10 +150,17 @@ impl Context {
 // Entry
 //**************************************************************************************************
 
-pub fn program(prog: T::Program) -> (H::Program, Errors) {
+pub fn program(
+    _pre_compiled_lib: Option<&FullyCompiledProgram>,
+    prog: T::Program,
+) -> (H::Program, Errors) {
     let mut context = Context::new(vec![]);
-    let modules = modules(&mut context, prog.modules);
-    let scripts = scripts(&mut context, prog.scripts);
+    let T::Program {
+        modules: tmodules,
+        scripts: tscripts,
+    } = prog;
+    let modules = modules(&mut context, tmodules);
+    let scripts = scripts(&mut context, tscripts);
 
     (H::Program { modules, scripts }, context.get_errors())
 }

--- a/language/move-lang/src/naming/ast.rs
+++ b/language/move-lang/src/naming/ast.rs
@@ -23,7 +23,7 @@ use std::{
 // Program
 //**************************************************************************************************
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Program {
     pub modules: UniqueMap<ModuleIdent, ModuleDefinition>,
     pub scripts: BTreeMap<String, Script>,
@@ -33,7 +33,7 @@ pub struct Program {
 // Scripts
 //**************************************************************************************************
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Script {
     pub loc: Loc,
     pub constants: UniqueMap<ConstantName, Constant>,
@@ -45,7 +45,7 @@ pub struct Script {
 // Modules
 //**************************************************************************************************
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ModuleDefinition {
     pub is_source_module: bool,
     /// `dependency_order` is the topological order/rank in the dependency graph.
@@ -85,14 +85,14 @@ pub struct FunctionSignature {
     pub return_type: Type,
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum FunctionBody_ {
     Defined(Sequence),
     Native,
 }
 pub type FunctionBody = Spanned<FunctionBody_>;
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct Function {
     pub visibility: FunctionVisibility,
     pub signature: FunctionSignature,
@@ -104,7 +104,7 @@ pub struct Function {
 // Constants
 //**************************************************************************************************
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct Constant {
     pub loc: Loc,
     pub signature: Type,
@@ -173,7 +173,7 @@ pub type Type = Spanned<Type_>;
 // Expressions
 //**************************************************************************************************
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum LValue_ {
     Ignore,
     Var(Var),
@@ -183,14 +183,14 @@ pub type LValue = Spanned<LValue_>;
 pub type LValueList_ = Vec<LValue>;
 pub type LValueList = Spanned<LValueList_>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum ExpDotted_ {
     Exp(Box<Exp>),
     Dot(Box<ExpDotted>, Field),
 }
 pub type ExpDotted = Spanned<ExpDotted_>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum BuiltinFunction_ {
     MoveTo(Option<Type>),
@@ -202,7 +202,7 @@ pub enum BuiltinFunction_ {
 }
 pub type BuiltinFunction = Spanned<BuiltinFunction_>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum Exp_ {
     Value(Value),
@@ -257,7 +257,7 @@ pub enum Exp_ {
 pub type Exp = Spanned<Exp_>;
 
 pub type Sequence = VecDeque<SequenceItem>;
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum SequenceItem_ {
     Seq(Exp),
     Declare(LValueList, Option<Type>),

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -48,13 +48,13 @@ macro_rules! new_name {
 // Program
 //**************************************************************************************************
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Program {
     pub source_definitions: Vec<Definition>,
     pub lib_definitions: Vec<Definition>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum Definition {
     Module(ModuleDefinition),
@@ -62,7 +62,7 @@ pub enum Definition {
     Script(Script),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Script {
     pub loc: Loc,
     pub uses: Vec<Use>,
@@ -92,14 +92,14 @@ pub struct ModuleIdent {
     pub value: (Address, String),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ModuleDefinition {
     pub loc: Loc,
     pub name: ModuleName,
     pub members: Vec<ModuleMember>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ModuleMember {
     Function(Function),
     Struct(StructDefinition),
@@ -113,7 +113,7 @@ pub enum ModuleMember {
 // Friends
 //**************************************************************************************************
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Friend_ {
     Module(ModuleName),
     QualifiedModule(ModuleIdent),
@@ -130,7 +130,7 @@ new_name!(StructName);
 
 pub type ResourceLoc = Option<Loc>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct StructDefinition {
     pub loc: Loc,
     pub abilities: Vec<Ability>,
@@ -139,7 +139,7 @@ pub struct StructDefinition {
     pub fields: StructFields,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum StructFields {
     Defined(Vec<(Field, Type)>),
     Native(Loc),
@@ -173,7 +173,7 @@ pub enum FunctionBody_ {
 }
 pub type FunctionBody = Spanned<FunctionBody_>;
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 // (public?) foo<T1(: copyable?), ..., TN(: copyable?)>(x1: t1, ..., xn: tn): t1 * ... * tn {
 //    body
 //  }
@@ -193,7 +193,7 @@ pub struct Function {
 
 new_name!(ConstantName);
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct Constant {
     pub loc: Loc,
     pub signature: Type,

--- a/language/move-lang/src/typing/ast.rs
+++ b/language/move-lang/src/typing/ast.rs
@@ -20,7 +20,7 @@ use std::{
 // Program
 //**************************************************************************************************
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Program {
     pub modules: UniqueMap<ModuleIdent, ModuleDefinition>,
     pub scripts: BTreeMap<String, Script>,
@@ -30,7 +30,7 @@ pub struct Program {
 // Scripts
 //**************************************************************************************************
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Script {
     pub loc: Loc,
     pub constants: UniqueMap<ConstantName, Constant>,
@@ -42,7 +42,7 @@ pub struct Script {
 // Modules
 //**************************************************************************************************
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ModuleDefinition {
     pub is_source_module: bool,
     /// `dependency_order` is the topological order/rank in the dependency graph.
@@ -57,14 +57,14 @@ pub struct ModuleDefinition {
 // Functions
 //**************************************************************************************************
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum FunctionBody_ {
     Defined(Sequence),
     Native,
 }
 pub type FunctionBody = Spanned<FunctionBody_>;
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct Function {
     pub visibility: FunctionVisibility,
     pub signature: FunctionSignature,
@@ -76,7 +76,7 @@ pub struct Function {
 // Constants
 //**************************************************************************************************
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct Constant {
     pub loc: Loc,
     pub signature: Type,
@@ -87,7 +87,7 @@ pub struct Constant {
 // Expressions
 //**************************************************************************************************
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum LValue_ {
     Ignore,
@@ -105,7 +105,7 @@ pub type LValue = Spanned<LValue_>;
 pub type LValueList_ = Vec<LValue>;
 pub type LValueList = Spanned<LValueList_>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct ModuleCall {
     pub module: ModuleIdent,
     pub name: FunctionName,
@@ -115,7 +115,7 @@ pub struct ModuleCall {
     pub acquires: BTreeMap<StructName, Loc>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum BuiltinFunction_ {
     MoveTo(Type),
@@ -127,7 +127,7 @@ pub enum BuiltinFunction_ {
 }
 pub type BuiltinFunction = Spanned<BuiltinFunction_>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum UnannotatedExp_ {
     Unit { trailing: bool },
     Value(Value),
@@ -170,7 +170,7 @@ pub enum UnannotatedExp_ {
     UnresolvedError,
 }
 pub type UnannotatedExp = Spanned<UnannotatedExp_>;
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Exp {
     pub ty: Type,
     pub exp: UnannotatedExp,
@@ -180,7 +180,7 @@ pub fn exp(ty: Type, exp: UnannotatedExp) -> Exp {
 }
 
 pub type Sequence = VecDeque<SequenceItem>;
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum SequenceItem_ {
     Seq(Box<Exp>),
     Declare(LValueList),
@@ -188,7 +188,7 @@ pub enum SequenceItem_ {
 }
 pub type SequenceItem = Spanned<SequenceItem_>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum ExpListItem {
     Single(Exp, Box<Type>),
     Splat(Loc, Exp, Vec<Type>),

--- a/language/move-lang/src/typing/core.rs
+++ b/language/move-lang/src/typing/core.rs
@@ -13,6 +13,7 @@ use crate::{
         Var,
     },
     shared::{unique_map::UniqueMap, *},
+    FullyCompiledProgram,
 };
 use move_ir_types::location::*;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -88,8 +89,24 @@ pub struct Context {
 }
 
 impl Context {
-    pub fn new(prog: &N::Program, errors: Errors) -> Self {
-        let modules = prog.modules.ref_map(|_ident, mdef| {
+    pub fn new(
+        pre_compiled_lib: Option<&FullyCompiledProgram>,
+        prog: &N::Program,
+        errors: Errors,
+    ) -> Self {
+        let all_modules = prog.modules.key_cloned_iter().chain(
+            pre_compiled_lib
+                .iter()
+                .map(|pre_compiled| {
+                    pre_compiled
+                        .naming
+                        .modules
+                        .key_cloned_iter()
+                        .filter(|(mident, _m)| !prog.modules.contains_key(mident))
+                })
+                .flatten(),
+        );
+        let modules = UniqueMap::maybe_from_iter(all_modules.map(|(mident, mdef)| {
             let structs = mdef.structs.clone();
             let functions = mdef.functions.ref_map(|fname, fdef| FunctionInfo {
                 defined_loc: fname.loc(),
@@ -101,13 +118,15 @@ impl Context {
                 defined_loc: cname.loc(),
                 signature: cdef.signature.clone(),
             });
-            ModuleInfo {
+            let minfo = ModuleInfo {
                 friends: mdef.friends.clone(),
                 structs,
                 functions,
                 constants,
-            }
-        });
+            };
+            (mident, minfo)
+        }))
+        .unwrap();
         Context {
             subst: Subst::empty(),
             current_module: None,

--- a/language/move-lang/src/typing/translate.rs
+++ b/language/move-lang/src/typing/translate.rs
@@ -14,6 +14,7 @@ use crate::{
     },
     shared::{unique_map::UniqueMap, *},
     typing::ast as T,
+    FullyCompiledProgram,
 };
 use move_ir_types::location::*;
 use std::collections::{BTreeMap, VecDeque};
@@ -22,10 +23,18 @@ use std::collections::{BTreeMap, VecDeque};
 // Entry
 //**************************************************************************************************
 
-pub fn program(prog: N::Program, errors: Errors) -> (T::Program, Errors) {
-    let mut context = Context::new(&prog, errors);
-    let modules = modules(&mut context, prog.modules);
-    let scripts = scripts(&mut context, prog.scripts);
+pub fn program(
+    pre_compiled_lib: Option<&FullyCompiledProgram>,
+    prog: N::Program,
+    errors: Errors,
+) -> (T::Program, Errors) {
+    let mut context = Context::new(pre_compiled_lib, &prog, errors);
+    let N::Program {
+        modules: nmodules,
+        scripts: nscripts,
+    } = prog;
+    let modules = modules(&mut context, nmodules);
+    let scripts = scripts(&mut context, nscripts);
 
     assert!(context.constraints.is_empty());
     let mut errors = context.get_errors();

--- a/language/move-model/src/lib.rs
+++ b/language/move-model/src/lib.rs
@@ -75,6 +75,7 @@ pub fn run_model_builder(
     }
     // Run the compiler up to expansion and clone a copy of the expansion program ast
     let (expansion_ast, expansion_result) = match move_continue_up_to(
+        None,
         MovePassResult::Parser(addr_opt, parsed_prog),
         MovePass::Expansion,
     ) {
@@ -88,7 +89,7 @@ pub fn run_model_builder(
         Ok(_) => unreachable!(),
     };
     // Run the compiler fully to the compiled units
-    let units = match move_continue_up_to(expansion_result, MovePass::Compilation) {
+    let units = match move_continue_up_to(None, expansion_result, MovePass::Compilation) {
         Err(errors) => {
             add_move_lang_errors(&mut env, errors);
             return Ok(env);


### PR DESCRIPTION
- Added clone to ASTs
- Added move-lang endpoint to save ASTs from each pass for dependency/libraries
- Saved the compilation of the stdlib/diem framework for functional tests. Reducing test time by 60%

## Motivation

- Before the change, tests took about 354s on my machine. 
- After, it's down to about 135s

## Test Plan

- ran affected tests
