### PR TITLE
[gha] re-arrange docker prune to after ecr push

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -107,3 +107,22 @@ jobs:
         run: |
           cargo run --release --bin db-restore -- --target-db-dir /var/tmp/dbrestore/ auto --replay-all command-adapter --config "$CONFIG"
       - uses: ./.github/actions/build-teardown
+
+  prune-docker-images:
+    runs-on: ubuntu-latest
+    env:
+      TAG: github-1
+    steps:
+      - uses: actions/checkout@v2
+      - name: sign in to DockerHub; install image signing cert
+        uses: ./.github/actions/dockerhub_login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          key_material: ${{ secrets.DOCKERHUB_KEY_MATERIAL }}
+          key_name: ${{ secrets.DOCKERHUB_KEY_NAME }}
+          key_password: ${{ secrets.DOCKERHUB_KEY_PASSWORD }}
+      - name: prune Docker image
+        if: ${{ github.ref != 'refs/heads/auto' }}
+        run: |
+          scripts/dockerhub_prune.sh -u "${{ secrets.DOCKERHUB_USERNAME }}" -p "${{ secrets.DOCKERHUB_PASSWORD }}" -x

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -94,10 +94,6 @@ jobs:
           docker/docker_republish.sh -t ${BRANCH}_${GIT_REV} -g libra
         env:
           DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKERHUB_KEY_PASSWORD }}
-      - name: docker image pruning.
-        if: ${{ github.ref != 'refs/heads/auto' }}
-        run: |
-          scripts/dockerhub_prune.sh -u "${{ secrets.DOCKERHUB_USERNAME }}" -p "${{ secrets.DOCKERHUB_PASSWORD }}" -x
       - name: push to novi ecr
         if: ${{ always() && github.ref != 'refs/heads/auto' }}
         run: |


### PR DESCRIPTION
## Motivation
The docker build job in CI sometimes takes 30min prune old images in DH before pushing to ECR, ex https://github.com/diem/diem/runs/2068344850?check_suite_focus=true.  The extended delay like this causes the timeout in continuous push that depends on ECR.

## Test Plan
CI + canary (https://github.com/diem/diem/runs/2069999166?check_suite_focus=true)