### PR TITLE
[move-vm] `execute_script_function` should have no return values

### DIFF
--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -89,7 +89,7 @@ impl<'r, 'l, R: RemoteCache> Session<'r, 'l, R> {
         senders: Vec<AccountAddress>,
         cost_strategy: &mut CostStrategy,
         log_context: &impl LogContext,
-    ) -> VMResult<Vec<Vec<u8>>> {
+    ) -> VMResult<()> {
         self.runtime.execute_script_function(
             module,
             function_name,


### PR DESCRIPTION
There are two types of public(script) functions:
- those that serve as execution entry points and can be directly
  invoked via the ScriptFunction payload
- those that are only indirectly called by other public(script)
  functions.

The script functions in first category should have no return values,
and this is dynamically checked by the loader when the function is
loaded up for execution. Hence, the return value of
execute_script_function should return nothing, to bring it in line with
the execute_script function.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

For detailed discussion, refer to https://github.com/diem/diem/pull/7580#discussion_r583262845 in #7580.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests should all pass
