### PR TITLE
[mempool] Mempool Peer ordering optimization

### DIFF
--- a/mempool/src/shared_mempool/runtime.rs
+++ b/mempool/src/shared_mempool/runtime.rs
@@ -47,7 +47,7 @@ pub(crate) fn start_shared_mempool<V>(
 ) where
     V: TransactionValidation + 'static,
 {
-    let peer_manager = Arc::new(PeerManager::new(config.mempool.clone()));
+    let peer_manager = Arc::new(PeerManager::new(config.base.role, config.mempool.clone()));
 
     let mut all_network_events = vec![];
     let mut network_senders = HashMap::new();

--- a/mempool/src/tests/fuzzing.rs
+++ b/mempool/src/tests/fuzzing.rs
@@ -41,7 +41,7 @@ pub fn test_mempool_process_incoming_transactions_impl(
         network_senders: HashMap::new(),
         db: Arc::new(mock_db),
         validator: vm_validator,
-        peer_manager: Arc::new(PeerManager::new(config.mempool)),
+        peer_manager: Arc::new(PeerManager::new(config.base.role, config.mempool)),
         subscribers: vec![],
     };
 


### PR DESCRIPTION
* Uses prioritized peers to choose which upstreams to use
* Changes back to using `default_failovers` as the configuration for how many failovers to use
* Fixes performance loss in Cluster test testing (more to follow up about that later)