### PR TITLE
[doc] fix broken link in execution_correctness spec

### DIFF
--- a/specifications/trusted_computing_base/execution_correctness/README.md
+++ b/specifications/trusted_computing_base/execution_correctness/README.md
@@ -5,8 +5,7 @@
 This specification outlines the design and implementation of Diem Execution Correctness (LEC): a secured service
 dedicated for executing transactions correctly (with the MOVE VM) and used by Consensus in the Diem payment network.
 
-For those
-unfamiliar with the execution flow of TCB, we recommend reading the architecture of [Trusted Computing Base (TCB)](../TCB.md).
+For those unfamiliar with the execution flow of TCB, we recommend reading the architecture of [Trusted Computing Base (TCB)](../README.md).
 
 ## Overview and Architecture
 


### PR DESCRIPTION
Link was pointing to TCB.md, when it should be pointing to the ../README.md file.



## Motivation

Improving the docs

(Write your answer here.)

## Test Plan

- view file using Github's markdown renderer via web browser

