### PR TITLE
[move-prover] add strong edges for vector writebacks

### DIFF
--- a/language/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/language/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -643,11 +643,11 @@ impl<'env> ModuleTranslator<'env> {
                                 );
                                 let func = match edge {
                                     BorrowEdge::Weak => "WritebackToGlobalWeak",
-                                    BorrowEdge::Strong(StrongEdge::Empty) => {
+                                    BorrowEdge::Strong(StrongEdge::Direct) => {
                                         "WritebackToGlobalStrong"
                                     }
-                                    BorrowEdge::Strong(StrongEdge::Offset(_)) => {
-                                        panic!("Strong global writeback has offset")
+                                    _ => {
+                                        panic!("Strong global writeback cannot have field")
                                     }
                                 };
                                 emitln!(
@@ -662,11 +662,11 @@ impl<'env> ModuleTranslator<'env> {
                             LocalRoot(idx) => {
                                 let func = match edge {
                                     BorrowEdge::Weak => "WritebackToValueWeak",
-                                    BorrowEdge::Strong(StrongEdge::Empty) => {
+                                    BorrowEdge::Strong(StrongEdge::Direct) => {
                                         "WritebackToValueStrong"
                                     }
-                                    BorrowEdge::Strong(StrongEdge::Offset(_)) => {
-                                        panic!("Strong local writeback has offset")
+                                    _ => {
+                                        panic!("Strong local writeback cannot have field")
                                     }
                                 };
                                 emitln!(
@@ -684,11 +684,14 @@ impl<'env> ModuleTranslator<'env> {
                                     BorrowEdge::Weak => {
                                         ("WritebackToReferenceWeak", "".to_string())
                                     }
-                                    BorrowEdge::Strong(StrongEdge::Empty) => {
-                                        ("WritebackToReferenceStrongEmp", "".to_string())
+                                    BorrowEdge::Strong(StrongEdge::Direct) => {
+                                        ("WritebackToReferenceStrongDirect", "".to_string())
                                     }
-                                    BorrowEdge::Strong(StrongEdge::Offset(offset)) => {
-                                        ("WritebackToReferenceStrongOff", format!(", {}", offset))
+                                    BorrowEdge::Strong(StrongEdge::Field(field)) => {
+                                        ("WritebackToReferenceStrongField", format!(", {}", field))
+                                    }
+                                    BorrowEdge::Strong(StrongEdge::FieldUnknown) => {
+                                        ("WritebackToVec", "".to_string())
                                     }
                                 };
                                 emitln!(

--- a/language/move-prover/bytecode/src/stackless_bytecode.rs
+++ b/language/move-prover/bytecode/src/stackless_bytecode.rs
@@ -232,11 +232,15 @@ impl BorrowNode {
     }
 }
 
-/// A borrow edge with a known offset -- used in memory operations
+/// A borrow with a path length of 0 or 1 -- used in memory operations
+/// A `Direct` edge is a borrow edge with length 0
+/// A `Field(usize)` edge has length 1 and the path in known
+/// A FieldUnknown has length 1 but the path is unknown
 #[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
 pub enum StrongEdge {
-    Empty,
-    Offset(usize),
+    Direct,
+    Field(usize),
+    FieldUnknown,
 }
 
 /// A borrow edge -- used in memory operations
@@ -551,8 +555,9 @@ impl std::fmt::Display for BorrowEdge {
 impl std::fmt::Display for StrongEdge {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            StrongEdge::Empty => write!(f, "E"),
-            StrongEdge::Offset(offset) => write!(f, "{}", offset),
+            StrongEdge::Field(field) => write!(f, "{}", field),
+            StrongEdge::FieldUnknown => write!(f, "U"),
+            StrongEdge::Direct => write!(f, "D"),
         }
     }
 }

--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -960,7 +960,7 @@ procedure {:inline 1} $WritebackToValueStrong(src: $Mutation, idx: int, vdst: $V
     }
 }
 
-procedure {:inline 1} $WritebackToReferenceStrongEmp(src: $Mutation, dst: $Mutation) returns (dst': $Mutation)
+procedure {:inline 1} $WritebackToReferenceStrongDirect(src: $Mutation, dst: $Mutation) returns (dst': $Mutation)
 {
     var srcPath, dstPath: $Path;
 
@@ -970,13 +970,13 @@ procedure {:inline 1} $WritebackToReferenceStrongEmp(src: $Mutation, dst: $Mutat
         dst' := $Mutation(
                     l#$Mutation(dst),
                     dstPath,
-                    v#$Mutation(dst));
+                    v#$Mutation(src));
     } else {
         dst' := dst;
     }
 }
 
-procedure {:inline 1} $WritebackToReferenceStrongOff(src: $Mutation, dst: $Mutation, edge: $FieldName)
+procedure {:inline 1} $WritebackToReferenceStrongField(src: $Mutation, dst: $Mutation, edge: $FieldName)
 returns (dst': $Mutation)
 {
     var srcPath, dstPath: $Path;
@@ -988,6 +988,26 @@ returns (dst': $Mutation)
                     l#$Mutation(dst),
                     dstPath,
                     $Vector($UpdateValueArray(v#$Vector(v#$Mutation(dst)), edge, v#$Mutation(src)))
+                    );
+    } else {
+        dst' := dst;
+    }
+}
+
+
+procedure {:inline 1} $WritebackToVec(src: $Mutation, dst: $Mutation)
+returns (dst': $Mutation)
+{
+    var srcPath, dstPath: $Path;
+
+    srcPath := p#$Mutation(src);
+    dstPath := p#$Mutation(dst);
+    if (l#$Mutation(dst) == l#$Mutation(src)) {
+        dst' := $Mutation(
+                    l#$Mutation(dst),
+                    dstPath,
+                    $Vector($UpdateValueArray(v#$Vector(v#$Mutation(dst)),
+                    $path_index_at(srcPath, size#$Path(srcPath) - 1), v#$Mutation(src)))
                     );
     } else {
         dst' := dst;


### PR DESCRIPTION
…

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Strong edges for vector writebacks should further improve verification runtime. This commit also fixes a bug in the previous version of strong direct reference writebacks.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Plan to add some unit tests in to the bytecode test suite in future commit. This was tested on all existing benchmarks. Also recall that strong writebacks are off by default when using the move-prover, so this won't affect any integration testing at this time.
