### PR TITLE
[docker compose] clean up libra names, and trigger on proper events.

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -26,6 +26,7 @@ jobs:
       test-dev-setup: ${{ steps.dev-setup-sh-changes.outputs.changes-found }}
       test-website-build: ${{ steps.website-changes.outputs.changes-found }}
       test-non-rust-lint: ${{ steps.non-rust-lint-changes.outputs.changes-found }}
+      test-docker-compose: ${{ steps.docker-compose-changes.outputs.changes-found }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -61,6 +62,12 @@ jobs:
         uses: ./.github/actions/matches
         with:
           pattern: '^.github\|docker/ci\|scripts/dev_setup.sh'
+      - id: docker-compose-changes
+        name: find changes that should trigger docker compose testing.
+        uses: ./.github/actions/matches
+        with:
+          pattern: '^documentation\|^.circleci'
+          invert: "true"
       - id: website-changes
         name: find website changes.
         uses: ./.github/actions/matches
@@ -330,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest-xl
     timeout-minutes: 30
     needs: prepare
-    #if: ${{ needs.prepare.outputs.test-rust == 'true' }}
+    if: ${{ needs.prepare.outputs.test-docker-compose == 'true' }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -343,14 +350,15 @@ jobs:
           sudo apt --assume-yes update
           sudo apt --assume-yes install expect
       - name: build validator docker image
-        run: docker/diem-build.sh docker/validator/Dockerfile libra/validator:test
+        run: docker/diem-build.sh docker/validator/Dockerfile diem/validator:test
       - name: build faucet image
-        run: docker/diem-build.sh docker/faucet/Dockerfile libra/faucet:test
+        run: docker/diem-build.sh docker/faucet/Dockerfile diem/faucet:test
       - name: build client image
-        run: docker/diem-build.sh docker/client/Dockerfile libra/client:test
+        run: docker/diem-build.sh docker/client/Dockerfile diem/client:test
       - name: run validator-client test
         run: docker/compose/test_docker_compose.sh
         env:
+          # this overrides the default docker tag of "testnet"
           IMAGE_TAG: "test"
 
   crypto-unit-test:

--- a/docker/compose/client-cli/docker-compose.yaml
+++ b/docker/compose/client-cli/docker-compose.yaml
@@ -3,9 +3,8 @@
 
 version: "3.8"
 services:
-
   client-cli:
-    image: "libra/client:${IMAGE_TAG:-devnet}"
+    image: "diem/client:${IMAGE_TAG:-devnet}"
     networks:
       shared:
     volumes:
@@ -14,25 +13,25 @@ services:
         target: /opt/diem/var
     entrypoint: /bin/bash
     command: >
-        -c '
-          for i in {1..10}
-          do
-              if [[ -s /opt/diem/var/waypoint.txt ]]
-              then
-                  echo "Waypoint: `cat /opt/diem/var/waypoint.txt`\n"
-                  /opt/diem/bin/diem_client \
-                      --url http://validator:8080/v1 \
-                      --faucet-url http://faucet:8000 \
-                      --chain-id TESTING \
-                      --waypoint `cat /opt/diem/var/waypoint.txt`
-                  exit $$?
-              else
-                  echo "Validator has not populated waypoint.txt yet. Is it running?"
-                  sleep 1
-              fi
-          done
-          exit 1
-        '
+      -c '
+        for i in {1..10}
+        do
+            if [[ -s /opt/diem/var/waypoint.txt ]]
+            then
+                echo "Waypoint: `cat /opt/diem/var/waypoint.txt`\n"
+                /opt/diem/bin/diem_client \
+                    --url http://validator:8080/v1 \
+                    --faucet-url http://faucet:8000 \
+                    --chain-id TESTING \
+                    --waypoint `cat /opt/diem/var/waypoint.txt`
+                exit $$?
+            else
+                echo "Validator has not populated waypoint.txt yet. Is it running?"
+                sleep 1
+            fi
+        done
+        exit 1
+      '
 networks:
   shared:
     name: "diem-docker-compose-shared"

--- a/docker/compose/public_full_node/docker-compose.yaml
+++ b/docker/compose/public_full_node/docker-compose.yaml
@@ -30,26 +30,26 @@
 #   * `du -csm /opt/diem/data``
 version: "3.8"
 services:
-    fullnode:
-        image: libra/validator:devnet
-        volumes:
-            - type: volume
-              source: db
-              target: /opt/diem/data
-            - type: bind
-              source: ./genesis.blob
-              target: /opt/diem/etc/genesis.blob
-              read_only: true
-            - type: bind
-              source: ./public_full_node.yaml
-              target: /opt/diem/etc/node.yaml
-              read_only: true
-            - type: bind
-              source: ./waypoint.txt
-              target: /opt/diem/etc/waypoint.txt
-              read_only: true
-        command: ["/opt/diem/bin/diem-node", "-f", "/opt/diem/etc/node.yaml"]
-        ports:
-            - "8080:8080"
+  fullnode:
+    image: diem/validator:devnet
+    volumes:
+      - type: volume
+        source: db
+        target: /opt/diem/data
+      - type: bind
+        source: ./genesis.blob
+        target: /opt/diem/etc/genesis.blob
+        read_only: true
+      - type: bind
+        source: ./public_full_node.yaml
+        target: /opt/diem/etc/node.yaml
+        read_only: true
+      - type: bind
+        source: ./waypoint.txt
+        target: /opt/diem/etc/waypoint.txt
+        read_only: true
+    command: ["/opt/diem/bin/diem-node", "-f", "/opt/diem/etc/node.yaml"]
+    ports:
+      - "8080:8080"
 volumes:
-    db:
+  db:

--- a/docker/compose/validator-testnet/docker-compose.yaml
+++ b/docker/compose/validator-testnet/docker-compose.yaml
@@ -9,15 +9,15 @@
 # * If you use this compose for different Diem Networks, you will need remove the db volume first.
 # * If you would like to use the current Diem version within this repository, execute the
 #     `build.sh` in `docker/validator` and change the image tag below to diem_e2e:latest
-# * Validator images can be found at https://hub.docker.com/r/libra/faucet/tags
-# * Faucet images can be found at https://hub.docker.com/r/libra/validator/tags
+# * Validator images can be found at https://hub.docker.com/r/devnet/validator/tags
+# * Faucet images can be found at https://hub.docker.com/r/devnet/faucet/tags
 
 version: "3.8"
 services:
   validator:
     # Note this image currently does not support this, will update to the appropriate minimum
     # version shortly
-    image: "libra/validator:${IMAGE_TAG:-devnet}"
+    image: "diem/validator:${IMAGE_TAG:-devnet}"
     networks:
       shared:
     volumes:
@@ -32,7 +32,7 @@ services:
       - "8080:8080"
 
   faucet:
-    image: "libra/faucet:${IMAGE_TAG:-devnet}"
+    image: "diem/faucet:${IMAGE_TAG:-devnet}"
     depends_on:
       - validator
     networks:
@@ -72,5 +72,5 @@ networks:
         - subnet: 172.16.1.0/24
 
 volumes:
-    diem-shared:
-        name: diem-shared
+  diem-shared:
+    name: diem-shared


### PR DESCRIPTION
## Motivation

Hackathon to clean up the names in diem (old libra).   Also makes sure the docker-compose job doesn't trigger on documentation changes, and a small comment on why the tag name "test" works.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

CI

## Related PRs

None

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
