### PR TITLE
[diem-framework] Updated the emits spec in the Diem Framework

### DIFF
--- a/language/diem-framework/modules/Diem.move
+++ b/language/diem-framework/modules/Diem.move
@@ -745,6 +745,8 @@ module Diem {
         pragma opaque;
         include PreburnToAbortsIf<CoinType>{amount: coin.value};
         include PreburnToEnsures<CoinType>{amount: coin.value};
+        let account_addr = Signer::spec_address_of(account);
+        include PreburnWithResourceEmits<CoinType>{amount: coin.value, preburn_address: account_addr};
     }
     spec schema PreburnToAbortsIf<CoinType> {
         account: signer;
@@ -770,7 +772,6 @@ module Diem {
         // The preburn amount in the currency info can be updated.
         modifies global<CurrencyInfo<CoinType>>(CoreAddresses::CURRENCY_INFO_ADDRESS());
         include PreburnEnsures<CoinType>{preburn: spec_make_preburn(amount)};
-        include PreburnWithResourceEmits<CoinType>{preburn_address: account_addr};
     }
 
     /// Remove the oldest preburn request in the `PreburnQueue<CoinType>`

--- a/language/diem-framework/modules/DiemAccount.move
+++ b/language/diem-framework/modules/DiemAccount.move
@@ -639,9 +639,6 @@ module DiemAccount {
         Diem::preburn_to<Token>(dd, withdraw_from(cap, Signer::address_of(dd), amount, x""))
     }
     spec fun preburn {
-        // TODO(timeout): started timing out after recent refactoring, investigate. (Likely due to
-        //   underspecified opaque functions).
-        pragma verify = false;
         pragma opaque;
         let dd_addr = Signer::spec_address_of(dd);
         let payer = cap.account_address;
@@ -651,7 +648,6 @@ module DiemAccount {
                 == old(global<DiemAccount>(payer).withdraw_capability);
         include PreburnAbortsIf<Token>;
         include PreburnEnsures<Token>{dd, payer};
-        include PreburnEmits<Token>{dd_addr};
     }
     spec schema PreburnAbortsIf<Token> {
         dd: signer;
@@ -670,12 +666,6 @@ module DiemAccount {
         ensures payer_balance == old(payer_balance) - amount;
         /// The value of preburn at `dd_addr` increases by `amount`;
         include Diem::PreburnToEnsures<Token>{amount, account: dd};
-    }
-    spec schema PreburnEmits<Token> {
-        dd_addr: address;
-        amount: u64;
-        let preburn = global<Diem::Preburn<Token>>(dd_addr);
-        include Diem::PreburnWithResourceEmits<Token>{preburn_address: dd_addr};
     }
 
     /// Return a unique capability granting permission to withdraw from the sender's account balance.

--- a/language/diem-framework/modules/doc/Diem.md
+++ b/language/diem-framework/modules/doc/Diem.md
@@ -1881,6 +1881,9 @@ Calls to this function will fail if:
 <pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Diem.md#0x1_Diem_PreburnToAbortsIf">PreburnToAbortsIf</a>&lt;CoinType&gt;{amount: coin.value};
 <b>include</b> <a href="Diem.md#0x1_Diem_PreburnToEnsures">PreburnToEnsures</a>&lt;CoinType&gt;{amount: coin.value};
+<a name="0x1_Diem_account_addr$99"></a>
+<b>let</b> account_addr = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
+<b>include</b> <a href="Diem.md#0x1_Diem_PreburnWithResourceEmits">PreburnWithResourceEmits</a>&lt;CoinType&gt;{amount: coin.value, preburn_address: account_addr};
 </code></pre>
 
 
@@ -1943,7 +1946,6 @@ Publishes if it doesn't exists. Updates its state either way.
     <b>ensures</b> <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr);
     <b>modifies</b> <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
     <b>include</b> <a href="Diem.md#0x1_Diem_PreburnEnsures">PreburnEnsures</a>&lt;CoinType&gt;{preburn: <a href="Diem.md#0x1_Diem_spec_make_preburn">spec_make_preburn</a>(amount)};
-    <b>include</b> <a href="Diem.md#0x1_Diem_PreburnWithResourceEmits">PreburnWithResourceEmits</a>&lt;CoinType&gt;{preburn_address: account_addr};
 }
 </code></pre>
 
@@ -2448,7 +2450,7 @@ used for administrative burns, like unpacking an XDX coin or charging fees.
 
 
 <pre><code><b>include</b> <a href="Diem.md#0x1_Diem_BurnNowAbortsIf">BurnNowAbortsIf</a>&lt;CoinType&gt;;
-<a name="0x1_Diem_info$99"></a>
+<a name="0x1_Diem_info$100"></a>
 <b>let</b> info = <a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;();
 <b>include</b> <a href="Diem.md#0x1_Diem_PreburnWithResourceEmits">PreburnWithResourceEmits</a>&lt;CoinType&gt;{amount: coin.value, preburn_address: preburn_address};
 <b>include</b> <a href="Diem.md#0x1_Diem_BurnWithResourceCapEmits">BurnWithResourceCapEmits</a>&lt;CoinType&gt;{preburn: <a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;{to_burn: coin}};
@@ -3565,7 +3567,7 @@ Returns the (rough) exchange rate between <code>CoinType</code> and <code><a hre
 
 <pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Diem.md#0x1_Diem_AbortsIfNoCurrency">AbortsIfNoCurrency</a>&lt;CoinType&gt;;
-<a name="0x1_Diem_info$100"></a>
+<a name="0x1_Diem_info$101"></a>
 <b>let</b> info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
 <b>ensures</b> result == info.to_xdx_exchange_rate;
 </code></pre>

--- a/language/diem-framework/modules/doc/DiemAccount.md
+++ b/language/diem-framework/modules/doc/DiemAccount.md
@@ -1066,7 +1066,7 @@ Record a payment of <code>to_deposit</code> from <code>payer</code> to <code>pay
     == <b>old</b>(<b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payee).withdraw_capability);
 <b>ensures</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payee).authentication_key
     == <b>old</b>(<b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payee).authentication_key);
-<a name="0x1_DiemAccount_amount$84"></a>
+<a name="0x1_DiemAccount_amount$83"></a>
 <b>let</b> amount = to_deposit.value;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_DepositAbortsIf">DepositAbortsIf</a>&lt;Token&gt;{amount: amount};
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_DepositOverflowAbortsIf">DepositOverflowAbortsIf</a>&lt;Token&gt;{amount: amount};
@@ -1522,7 +1522,7 @@ Withdraw <code>amount</code> <code><a href="Diem.md#0x1_Diem">Diem</a>&lt;Token&
 
 
 
-<a name="0x1_DiemAccount_payer$85"></a>
+<a name="0x1_DiemAccount_payer$84"></a>
 
 
 <pre><code><b>let</b> payer = cap.account_address;
@@ -1649,11 +1649,10 @@ resource under <code>dd</code>.
 
 
 
-<pre><code><b>pragma</b> verify = <b>false</b>;
-<b>pragma</b> opaque;
-<a name="0x1_DiemAccount_dd_addr$86"></a>
+<pre><code><b>pragma</b> opaque;
+<a name="0x1_DiemAccount_dd_addr$85"></a>
 <b>let</b> dd_addr = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(dd);
-<a name="0x1_DiemAccount_payer$87"></a>
+<a name="0x1_DiemAccount_payer$86"></a>
 <b>let</b> payer = cap.account_address;
 <b>modifies</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payer);
 <b>ensures</b> <b>exists</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payer);
@@ -1661,7 +1660,6 @@ resource under <code>dd</code>.
         == <b>old</b>(<b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payer).withdraw_capability);
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_PreburnAbortsIf">PreburnAbortsIf</a>&lt;Token&gt;;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_PreburnEnsures">PreburnEnsures</a>&lt;Token&gt;{dd, payer};
-<b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_PreburnEmits">PreburnEmits</a>&lt;Token&gt;{dd_addr};
 </code></pre>
 
 
@@ -1715,21 +1713,6 @@ The value of preburn at <code>dd_addr</code> increases by <code>amount</code>;
 
 
 
-
-<a name="0x1_DiemAccount_PreburnEmits"></a>
-
-
-<pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_PreburnEmits">PreburnEmits</a>&lt;Token&gt; {
-    dd_addr: address;
-    amount: u64;
-    <a name="0x1_DiemAccount_preburn$68"></a>
-    <b>let</b> preburn = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_Preburn">Diem::Preburn</a>&lt;Token&gt;&gt;(dd_addr);
-    <b>include</b> <a href="Diem.md#0x1_Diem_PreburnWithResourceEmits">Diem::PreburnWithResourceEmits</a>&lt;Token&gt;{preburn_address: dd_addr};
-}
-</code></pre>
-
-
-
 </details>
 
 <a name="0x1_DiemAccount_extract_withdraw_capability"></a>
@@ -1773,7 +1756,7 @@ Return a unique capability granting permission to withdraw from the sender's acc
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_DiemAccount_sender_addr$88"></a>
+<a name="0x1_DiemAccount_sender_addr$87"></a>
 <b>let</b> sender_addr = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
 <b>modifies</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(sender_addr);
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ExtractWithdrawCapAbortsIf">ExtractWithdrawCapAbortsIf</a>{sender_addr};
@@ -1841,7 +1824,7 @@ Return the withdraw capability to the account it originally came from
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_DiemAccount_cap_addr$89"></a>
+<a name="0x1_DiemAccount_cap_addr$88"></a>
 <b>let</b> cap_addr = cap.account_address;
 <b>modifies</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(cap_addr);
 <b>aborts_if</b> !<a href="DiemAccount.md#0x1_DiemAccount_exists_at">exists_at</a>(cap_addr) <b>with</b> <a href="Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
@@ -1900,7 +1883,7 @@ attestation protocol
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_DiemAccount_payer$90"></a>
+<a name="0x1_DiemAccount_payer$89"></a>
 <b>let</b> payer = cap.account_address;
 <b>modifies</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payer);
 <b>modifies</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payee);
@@ -1946,7 +1929,7 @@ attestation protocol
     amount: u64;
     metadata: vector&lt;u8&gt;;
     metadata_signature: vector&lt;u8&gt; ;
-    <a name="0x1_DiemAccount_payer$69"></a>
+    <a name="0x1_DiemAccount_payer$68"></a>
     <b>let</b> payer = cap.account_address;
     <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_DepositAbortsIfRestricted">DepositAbortsIfRestricted</a>&lt;Token&gt;{payer: cap.account_address};
     <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_WithdrawFromBalanceNoLimitsAbortsIf">WithdrawFromBalanceNoLimitsAbortsIf</a>&lt;Token&gt;{payer, balance: <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_Balance">Balance</a>&lt;Token&gt;&gt;(payer)};
@@ -2127,7 +2110,7 @@ Return a unique capability granting permission to rotate the sender's authentica
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityAbortsIf">ExtractKeyRotationCapabilityAbortsIf</a> {
     account: signer;
-    <a name="0x1_DiemAccount_account_addr$70"></a>
+    <a name="0x1_DiemAccount_account_addr$69"></a>
     <b>let</b> account_addr = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>aborts_if</b> !<a href="DiemAccount.md#0x1_DiemAccount_exists_at">exists_at</a>(account_addr) <b>with</b> <a href="Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
     <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_AbortsIfDelegatedKeyRotationCapability">AbortsIfDelegatedKeyRotationCapability</a>;
@@ -2271,7 +2254,7 @@ then add for both token types.
 
 
 
-<a name="0x1_DiemAccount_new_account_addr$91"></a>
+<a name="0x1_DiemAccount_new_account_addr$90"></a>
 
 
 <pre><code><b>let</b> new_account_addr = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(new_account);
@@ -2403,7 +2386,7 @@ Creating an account at address 0x0 will abort as it is a reserved address for th
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_DiemAccount_new_account_addr$92"></a>
+<a name="0x1_DiemAccount_new_account_addr$91"></a>
 <b>let</b> new_account_addr = <a href="Signer.md#0x1_Signer_address_of">Signer::address_of</a>(new_account);
 <b>modifies</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(new_account_addr);
 <b>modifies</b> <b>global</b>&lt;<a href="AccountFreezing.md#0x1_AccountFreezing_FreezingBit">AccountFreezing::FreezingBit</a>&gt;(new_account_addr);
@@ -2413,7 +2396,7 @@ Creating an account at address 0x0 will abort as it is a reserved address for th
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_MakeAccountAbortsIf">MakeAccountAbortsIf</a>{addr: new_account_addr};
 <b>ensures</b> <a href="DiemAccount.md#0x1_DiemAccount_exists_at">exists_at</a>(new_account_addr);
 <b>ensures</b> <a href="AccountFreezing.md#0x1_AccountFreezing_spec_account_is_not_frozen">AccountFreezing::spec_account_is_not_frozen</a>(new_account_addr);
-<a name="0x1_DiemAccount_account_ops_cap$93"></a>
+<a name="0x1_DiemAccount_account_ops_cap$92"></a>
 <b>let</b> account_ops_cap = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_AccountOperationsCapability">AccountOperationsCapability</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>());
 <b>ensures</b> account_ops_cap == update_field(<b>old</b>(account_ops_cap), creation_events, account_ops_cap.creation_events);
 <b>ensures</b> <a href="DiemAccount.md#0x1_DiemAccount_spec_holds_own_key_rotation_cap">spec_holds_own_key_rotation_cap</a>(new_account_addr);
@@ -2448,9 +2431,9 @@ Creating an account at address 0x0 will abort as it is a reserved address for th
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_MakeAccountEmits">MakeAccountEmits</a> {
     new_account_address: address;
-    <a name="0x1_DiemAccount_handle$71"></a>
+    <a name="0x1_DiemAccount_handle$70"></a>
     <b>let</b> handle = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_AccountOperationsCapability">AccountOperationsCapability</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>()).creation_events;
-    <a name="0x1_DiemAccount_msg$72"></a>
+    <a name="0x1_DiemAccount_msg$71"></a>
     <b>let</b> msg = <a href="DiemAccount.md#0x1_DiemAccount_CreateAccountEvent">CreateAccountEvent</a> {
         created: new_account_address,
         role_id: <a href="Roles.md#0x1_Roles_spec_get_role_id">Roles::spec_get_role_id</a>(new_account_address)
@@ -2615,7 +2598,7 @@ AccountOperationsCapability, WriteSetManager, and finally makes the account.
 <a name="0x1_DiemAccount_CreateDiemRootAccountModifies"></a>
 
 
-<a name="0x1_DiemAccount_dr_addr$73"></a>
+<a name="0x1_DiemAccount_dr_addr$72"></a>
 
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateDiemRootAccountModifies">CreateDiemRootAccountModifies</a> {
@@ -2657,7 +2640,7 @@ AccountOperationsCapability, WriteSetManager, and finally makes the account.
 <a name="0x1_DiemAccount_CreateDiemRootAccountEnsures"></a>
 
 
-<a name="0x1_DiemAccount_dr_addr$74"></a>
+<a name="0x1_DiemAccount_dr_addr$73"></a>
 
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateDiemRootAccountEnsures">CreateDiemRootAccountEnsures</a> {
@@ -2721,14 +2704,14 @@ event handle generator, then makes the account.
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_DiemAccount_tc_addr$94"></a>
+<a name="0x1_DiemAccount_tc_addr$93"></a>
 <b>let</b> tc_addr = <a href="CoreAddresses.md#0x1_CoreAddresses_TREASURY_COMPLIANCE_ADDRESS">CoreAddresses::TREASURY_COMPLIANCE_ADDRESS</a>();
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateTreasuryComplianceAccountModifies">CreateTreasuryComplianceAccountModifies</a>;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateTreasuryComplianceAccountAbortsIf">CreateTreasuryComplianceAccountAbortsIf</a>;
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotDiemRoot">Roles::AbortsIfNotDiemRoot</a>{account: dr_account};
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_MakeAccountAbortsIf">MakeAccountAbortsIf</a>{addr: <a href="CoreAddresses.md#0x1_CoreAddresses_TREASURY_COMPLIANCE_ADDRESS">CoreAddresses::TREASURY_COMPLIANCE_ADDRESS</a>()};
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateTreasuryComplianceAccountEnsures">CreateTreasuryComplianceAccountEnsures</a>;
-<a name="0x1_DiemAccount_account_ops_cap$95"></a>
+<a name="0x1_DiemAccount_account_ops_cap$94"></a>
 <b>let</b> account_ops_cap = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_AccountOperationsCapability">AccountOperationsCapability</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>());
 <b>ensures</b> account_ops_cap == update_field(<b>old</b>(account_ops_cap), creation_events, account_ops_cap.creation_events);
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_MakeAccountEmits">MakeAccountEmits</a>{new_account_address: <a href="CoreAddresses.md#0x1_CoreAddresses_TREASURY_COMPLIANCE_ADDRESS">CoreAddresses::TREASURY_COMPLIANCE_ADDRESS</a>()};
@@ -2740,7 +2723,7 @@ event handle generator, then makes the account.
 <a name="0x1_DiemAccount_CreateTreasuryComplianceAccountModifies"></a>
 
 
-<a name="0x1_DiemAccount_tc_addr$75"></a>
+<a name="0x1_DiemAccount_tc_addr$74"></a>
 
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateTreasuryComplianceAccountModifies">CreateTreasuryComplianceAccountModifies</a> {
@@ -2776,7 +2759,7 @@ event handle generator, then makes the account.
 <a name="0x1_DiemAccount_CreateTreasuryComplianceAccountEnsures"></a>
 
 
-<a name="0x1_DiemAccount_tc_addr$76"></a>
+<a name="0x1_DiemAccount_tc_addr$75"></a>
 
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateTreasuryComplianceAccountEnsures">CreateTreasuryComplianceAccountEnsures</a> {
@@ -3590,11 +3573,11 @@ The prologue for module transaction
 
 
 
-<a name="0x1_DiemAccount_transaction_sender$96"></a>
+<a name="0x1_DiemAccount_transaction_sender$95"></a>
 
 
 <pre><code><b>let</b> transaction_sender = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
-<a name="0x1_DiemAccount_max_transaction_fee$97"></a>
+<a name="0x1_DiemAccount_max_transaction_fee$96"></a>
 <b>let</b> max_transaction_fee = txn_gas_price * txn_max_gas_units;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ModulePrologueAbortsIf">ModulePrologueAbortsIf</a>&lt;Token&gt; {
     max_transaction_fee,
@@ -3616,7 +3599,7 @@ The prologue for module transaction
     chain_id: u8;
     max_transaction_fee: u128;
     txn_expiration_time_seconds: u64;
-    <a name="0x1_DiemAccount_transaction_sender$77"></a>
+    <a name="0x1_DiemAccount_transaction_sender$76"></a>
     <b>let</b> transaction_sender = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
     <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_PrologueCommonAbortsIf">PrologueCommonAbortsIf</a>&lt;Token&gt; {
         transaction_sender,
@@ -3703,11 +3686,11 @@ The prologue for script transaction
 
 
 
-<a name="0x1_DiemAccount_transaction_sender$98"></a>
+<a name="0x1_DiemAccount_transaction_sender$97"></a>
 
 
 <pre><code><b>let</b> transaction_sender = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
-<a name="0x1_DiemAccount_max_transaction_fee$99"></a>
+<a name="0x1_DiemAccount_max_transaction_fee$98"></a>
 <b>let</b> max_transaction_fee = txn_gas_price * txn_max_gas_units;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ScriptPrologueAbortsIf">ScriptPrologueAbortsIf</a>&lt;Token&gt;{
     max_transaction_fee,
@@ -3730,7 +3713,7 @@ The prologue for script transaction
     max_transaction_fee: u128;
     txn_expiration_time_seconds: u64;
     script_hash: vector&lt;u8&gt;;
-    <a name="0x1_DiemAccount_transaction_sender$78"></a>
+    <a name="0x1_DiemAccount_transaction_sender$77"></a>
     <b>let</b> transaction_sender = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
     <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_PrologueCommonAbortsIf">PrologueCommonAbortsIf</a>&lt;Token&gt; {transaction_sender};
 }
@@ -3826,7 +3809,7 @@ The prologue for WriteSet transaction
     txn_public_key: vector&lt;u8&gt;;
     txn_expiration_time_seconds: u64;
     chain_id: u8;
-    <a name="0x1_DiemAccount_transaction_sender$79"></a>
+    <a name="0x1_DiemAccount_transaction_sender$78"></a>
     <b>let</b> transaction_sender = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
 }
 </code></pre>
@@ -3976,11 +3959,11 @@ The main properties that it verifies:
 
 
 
-<a name="0x1_DiemAccount_transaction_sender$100"></a>
+<a name="0x1_DiemAccount_transaction_sender$99"></a>
 
 
 <pre><code><b>let</b> transaction_sender = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
-<a name="0x1_DiemAccount_max_transaction_fee$101"></a>
+<a name="0x1_DiemAccount_max_transaction_fee$100"></a>
 <b>let</b> max_transaction_fee = txn_gas_price * txn_max_gas_units;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_PrologueCommonAbortsIf">PrologueCommonAbortsIf</a>&lt;Token&gt; {
     transaction_sender,
@@ -4269,12 +4252,12 @@ Epilogue for WriteSet trasnaction
 <a name="0x1_DiemAccount_WritesetEpiloguEmits"></a>
 
 
-<a name="0x1_DiemAccount_handle$80"></a>
+<a name="0x1_DiemAccount_handle$79"></a>
 
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_WritesetEpiloguEmits">WritesetEpiloguEmits</a> {
     <b>let</b> handle = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_DiemWriteSetManager">DiemWriteSetManager</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>()).upgrade_events;
-    <a name="0x1_DiemAccount_msg$81"></a>
+    <a name="0x1_DiemAccount_msg$80"></a>
     <b>let</b> msg = <a href="DiemAccount.md#0x1_DiemAccount_AdminTransactionEvent">AdminTransactionEvent</a> {
         committed_timestamp_secs: <a href="DiemTimestamp.md#0x1_DiemTimestamp_spec_now_seconds">DiemTimestamp::spec_now_seconds</a>()
     };
@@ -4504,7 +4487,7 @@ or the key rotation capability for addr itself [[H17]][PERMISSION].
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_EnsuresHasKeyRotationCap">EnsuresHasKeyRotationCap</a> {
     account: signer;
-    <a name="0x1_DiemAccount_addr$82"></a>
+    <a name="0x1_DiemAccount_addr$81"></a>
     <b>let</b> addr = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>ensures</b> <a href="DiemAccount.md#0x1_DiemAccount_spec_holds_own_key_rotation_cap">spec_holds_own_key_rotation_cap</a>(addr);
 }
@@ -4566,7 +4549,7 @@ or the withdraw capability for addr itself [[H18]][PERMISSION].
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_EnsuresWithdrawCap">EnsuresWithdrawCap</a> {
     account: signer;
-    <a name="0x1_DiemAccount_addr$83"></a>
+    <a name="0x1_DiemAccount_addr$82"></a>
     <b>let</b> addr = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>ensures</b> <a href="DiemAccount.md#0x1_DiemAccount_spec_holds_own_withdraw_cap">spec_holds_own_withdraw_cap</a>(addr);
 }

--- a/language/move-prover/tests/sources/functional/emits.exp
+++ b/language/move-prover/tests/sources/functional/emits.exp
@@ -1,71 +1,71 @@
 Move prover returns: exiting with boogie verification errors
 error: function does not emit the expected event
 
-     ┌── tests/sources/functional/emits.move:112:9 ───
+     ┌── tests/sources/functional/emits.move:120:9 ───
      │
- 112 │         emits DummyEvent{msg: 0} to handle;
+ 120 │         emits DummyEvent{msg: 0} to handle;
      │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      │
-     =     at tests/sources/functional/emits.move:106: conditional_missing_condition_incorrect
+     =     at tests/sources/functional/emits.move:114: conditional_missing_condition_incorrect
      =         x = <redacted>
      =         handle = <redacted>
-     =     at tests/sources/functional/emits.move:107: conditional_missing_condition_incorrect
+     =     at tests/sources/functional/emits.move:115: conditional_missing_condition_incorrect
      =         handle = <redacted>
-     =     at tests/sources/functional/emits.move:110: conditional_missing_condition_incorrect
-     =     at tests/sources/functional/emits.move:112
+     =     at tests/sources/functional/emits.move:118: conditional_missing_condition_incorrect
+     =     at tests/sources/functional/emits.move:120
 
 error: function does not emit the expected event
 
-     ┌── tests/sources/functional/emits.move:151:9 ───
+     ┌── tests/sources/functional/emits.move:159:9 ───
      │
- 151 │         emits DummyEvent{msg: 2} to handle;
+ 159 │         emits DummyEvent{msg: 2} to handle;
      │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      │
-     =     at tests/sources/functional/emits.move:141: conditional_multiple_incorrect
+     =     at tests/sources/functional/emits.move:149: conditional_multiple_incorrect
      =         b = <redacted>
      =         handle = <redacted>
-     =     at tests/sources/functional/emits.move:142: conditional_multiple_incorrect
-     =     at tests/sources/functional/emits.move:143: conditional_multiple_incorrect
-     =     at tests/sources/functional/emits.move:144: conditional_multiple_incorrect
+     =     at tests/sources/functional/emits.move:150: conditional_multiple_incorrect
+     =     at tests/sources/functional/emits.move:151: conditional_multiple_incorrect
+     =     at tests/sources/functional/emits.move:152: conditional_multiple_incorrect
      =         handle = <redacted>
-     =     at tests/sources/functional/emits.move:147: conditional_multiple_incorrect
-     =     at tests/sources/functional/emits.move:149
-     =     at tests/sources/functional/emits.move:150
-     =     at tests/sources/functional/emits.move:151
+     =     at tests/sources/functional/emits.move:155: conditional_multiple_incorrect
+     =     at tests/sources/functional/emits.move:157
+     =     at tests/sources/functional/emits.move:158
+     =     at tests/sources/functional/emits.move:159
 
 error: function does not emit the expected event
 
-     ┌── tests/sources/functional/emits.move:181:9 ───
+     ┌── tests/sources/functional/emits.move:189:9 ───
      │
- 181 │         emits DummyEvent{msg: 0} to handle;
+ 189 │         emits DummyEvent{msg: 0} to handle;
      │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      │
-     =     at tests/sources/functional/emits.move:171: conditional_multiple_same_incorrect
+     =     at tests/sources/functional/emits.move:179: conditional_multiple_same_incorrect
      =         b = <redacted>
      =         handle = <redacted>
-     =     at tests/sources/functional/emits.move:172: conditional_multiple_same_incorrect
-     =     at tests/sources/functional/emits.move:173: conditional_multiple_same_incorrect
-     =     at tests/sources/functional/emits.move:174: conditional_multiple_same_incorrect
+     =     at tests/sources/functional/emits.move:180: conditional_multiple_same_incorrect
+     =     at tests/sources/functional/emits.move:181: conditional_multiple_same_incorrect
+     =     at tests/sources/functional/emits.move:182: conditional_multiple_same_incorrect
      =         handle = <redacted>
-     =     at tests/sources/functional/emits.move:177: conditional_multiple_same_incorrect
-     =     at tests/sources/functional/emits.move:179
-     =     at tests/sources/functional/emits.move:180
-     =     at tests/sources/functional/emits.move:181
+     =     at tests/sources/functional/emits.move:185: conditional_multiple_same_incorrect
+     =     at tests/sources/functional/emits.move:187
+     =     at tests/sources/functional/emits.move:188
+     =     at tests/sources/functional/emits.move:189
 
 error: function does not emit the expected event
 
-     ┌── tests/sources/functional/emits.move:103:9 ───
+     ┌── tests/sources/functional/emits.move:111:9 ───
      │
- 103 │         emits DummyEvent{msg: 0} to handle if x > 0;
+ 111 │         emits DummyEvent{msg: 0} to handle if x > 0;
      │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      │
-     =     at tests/sources/functional/emits.move:97: conditional_wrong_condition_incorrect
+     =     at tests/sources/functional/emits.move:105: conditional_wrong_condition_incorrect
      =         x = <redacted>
      =         handle = <redacted>
-     =     at tests/sources/functional/emits.move:98: conditional_wrong_condition_incorrect
+     =     at tests/sources/functional/emits.move:106: conditional_wrong_condition_incorrect
      =         handle = <redacted>
-     =     at tests/sources/functional/emits.move:101: conditional_wrong_condition_incorrect
-     =     at tests/sources/functional/emits.move:103
+     =     at tests/sources/functional/emits.move:109: conditional_wrong_condition_incorrect
+     =     at tests/sources/functional/emits.move:111
 
 error: function does not emit the expected event
 
@@ -103,94 +103,94 @@ error: function does not emit the expected event
 
 error: emitted event not covered by any of the `emits` clauses
 
-     ┌── tests/sources/functional/emits.move:296:5 ───
+     ┌── tests/sources/functional/emits.move:314:5 ───
      │
- 296 │ ╭     spec fun opaque_completeness_incorrect {
- 297 │ │         emits DummyEvent{msg: 0} to handle;
- 298 │ │         emits DummyEvent{msg: 7} to handle;
- 299 │ │         emits DummyEvent{msg: 1} to handle;
- 300 │ │     }
+ 314 │ ╭     spec fun opaque_completeness_incorrect {
+ 315 │ │         emits DummyEvent{msg: 0} to handle;
+ 316 │ │         emits DummyEvent{msg: 7} to handle;
+ 317 │ │         emits DummyEvent{msg: 1} to handle;
+ 318 │ │     }
      │ ╰─────^
      │
-     =     at tests/sources/functional/emits.move:291: opaque_completeness_incorrect
+     =     at tests/sources/functional/emits.move:309: opaque_completeness_incorrect
      =         handle = <redacted>
-     =     at tests/sources/functional/emits.move:292: opaque_completeness_incorrect
-     =     at tests/sources/functional/emits.move:293: opaque_completeness_incorrect
-     =     at tests/sources/functional/emits.move:294: opaque_completeness_incorrect
-     =     at tests/sources/functional/emits.move:294: opaque_completeness_incorrect
+     =     at tests/sources/functional/emits.move:310: opaque_completeness_incorrect
+     =     at tests/sources/functional/emits.move:311: opaque_completeness_incorrect
+     =     at tests/sources/functional/emits.move:312: opaque_completeness_incorrect
+     =     at tests/sources/functional/emits.move:312: opaque_completeness_incorrect
      =         handle = <redacted>
-     =     at tests/sources/functional/emits.move:295: opaque_completeness_incorrect
-     =     at tests/sources/functional/emits.move:297
-     =     at tests/sources/functional/emits.move:298
-     =     at tests/sources/functional/emits.move:299
-     =     at tests/sources/functional/emits.move:296
+     =     at tests/sources/functional/emits.move:313: opaque_completeness_incorrect
+     =     at tests/sources/functional/emits.move:315
+     =     at tests/sources/functional/emits.move:316
+     =     at tests/sources/functional/emits.move:317
+     =     at tests/sources/functional/emits.move:314
 
 error: function does not emit the expected event
 
-     ┌── tests/sources/functional/emits.move:288:9 ───
+     ┌── tests/sources/functional/emits.move:296:9 ───
      │
- 288 │         emits DummyEvent{msg: 2} to handle;
+ 296 │         emits DummyEvent{msg: 2} to handle;
      │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      │
-     =     at tests/sources/functional/emits.move:278: opaque_incorrect
+     =     at tests/sources/functional/emits.move:286: opaque_incorrect
      =         handle = <redacted>
-     =     at tests/sources/functional/emits.move:279: opaque_incorrect
-     =     at tests/sources/functional/emits.move:280: opaque_incorrect
-     =     at tests/sources/functional/emits.move:281: opaque_incorrect
-     =     at tests/sources/functional/emits.move:281: opaque_incorrect
+     =     at tests/sources/functional/emits.move:287: opaque_incorrect
+     =     at tests/sources/functional/emits.move:288: opaque_incorrect
+     =     at tests/sources/functional/emits.move:289: opaque_incorrect
+     =     at tests/sources/functional/emits.move:289: opaque_incorrect
      =         handle = <redacted>
-     =     at tests/sources/functional/emits.move:282: opaque_incorrect
-     =     at tests/sources/functional/emits.move:284
-     =     at tests/sources/functional/emits.move:285
-     =     at tests/sources/functional/emits.move:286
-     =     at tests/sources/functional/emits.move:287
-     =     at tests/sources/functional/emits.move:288
+     =     at tests/sources/functional/emits.move:290: opaque_incorrect
+     =     at tests/sources/functional/emits.move:292
+     =     at tests/sources/functional/emits.move:293
+     =     at tests/sources/functional/emits.move:294
+     =     at tests/sources/functional/emits.move:295
+     =     at tests/sources/functional/emits.move:296
 
 error: emitted event not covered by any of the `emits` clauses
 
-     ┌── tests/sources/functional/emits.move:337:5 ───
+     ┌── tests/sources/functional/emits.move:355:5 ───
      │
- 337 │ ╭     spec fun opaque_partial_incorrect {
- 338 │ │         emits DummyEvent{msg: 0} to handle;
- 339 │ │         emits DummyEvent{msg: 7} to handle;
- 340 │ │         emits DummyEvent{msg: 77} to handle;
- 341 │ │         emits DummyEvent{msg: 1} to handle;
- 342 │ │         // The completeness check of the `emits` spec of this function should fail.
- 343 │ │     }
+ 355 │ ╭     spec fun opaque_partial_incorrect {
+ 356 │ │         emits DummyEvent{msg: 0} to handle;
+ 357 │ │         emits DummyEvent{msg: 7} to handle;
+ 358 │ │         emits DummyEvent{msg: 77} to handle;
+ 359 │ │         emits DummyEvent{msg: 1} to handle;
+ 360 │ │         // The completeness check of the `emits` spec of this function should fail.
+ 361 │ │     }
      │ ╰─────^
      │
-     =     at tests/sources/functional/emits.move:332: opaque_partial_incorrect
+     =     at tests/sources/functional/emits.move:350: opaque_partial_incorrect
      =         handle = <redacted>
-     =     at tests/sources/functional/emits.move:333: opaque_partial_incorrect
-     =     at tests/sources/functional/emits.move:334: opaque_partial_incorrect
-     =     at tests/sources/functional/emits.move:335: opaque_partial_incorrect
-     =     at tests/sources/functional/emits.move:335: opaque_partial_incorrect
+     =     at tests/sources/functional/emits.move:351: opaque_partial_incorrect
+     =     at tests/sources/functional/emits.move:352: opaque_partial_incorrect
+     =     at tests/sources/functional/emits.move:353: opaque_partial_incorrect
+     =     at tests/sources/functional/emits.move:353: opaque_partial_incorrect
      =         handle = <redacted>
-     =     at tests/sources/functional/emits.move:336: opaque_partial_incorrect
-     =     at tests/sources/functional/emits.move:338
-     =     at tests/sources/functional/emits.move:339
-     =     at tests/sources/functional/emits.move:340
-     =     at tests/sources/functional/emits.move:341
-     =     at tests/sources/functional/emits.move:337
+     =     at tests/sources/functional/emits.move:354: opaque_partial_incorrect
+     =     at tests/sources/functional/emits.move:356
+     =     at tests/sources/functional/emits.move:357
+     =     at tests/sources/functional/emits.move:358
+     =     at tests/sources/functional/emits.move:359
+     =     at tests/sources/functional/emits.move:355
 
 error: emitted event not covered by any of the `emits` clauses
 
-     ┌── tests/sources/functional/emits.move:227:5 ───
+     ┌── tests/sources/functional/emits.move:235:5 ───
      │
- 227 │ ╭     spec fun partial_incorrect {
- 228 │ │         emits DummyEvent{msg: 0} to handle;
- 229 │ │     }
+ 235 │ ╭     spec fun partial_incorrect {
+ 236 │ │         emits DummyEvent{msg: 0} to handle;
+ 237 │ │     }
      │ ╰─────^
      │
-     =     at tests/sources/functional/emits.move:223: partial_incorrect
+     =     at tests/sources/functional/emits.move:231: partial_incorrect
      =         handle = <redacted>
-     =     at tests/sources/functional/emits.move:224: partial_incorrect
-     =     at tests/sources/functional/emits.move:225: partial_incorrect
-     =     at tests/sources/functional/emits.move:225: partial_incorrect
+     =     at tests/sources/functional/emits.move:232: partial_incorrect
+     =     at tests/sources/functional/emits.move:233: partial_incorrect
+     =     at tests/sources/functional/emits.move:233: partial_incorrect
      =         handle = <redacted>
-     =     at tests/sources/functional/emits.move:226: partial_incorrect
-     =     at tests/sources/functional/emits.move:228
-     =     at tests/sources/functional/emits.move:227
+     =     at tests/sources/functional/emits.move:234: partial_incorrect
+     =     at tests/sources/functional/emits.move:236
+     =     at tests/sources/functional/emits.move:235
 
 error: function does not emit the expected event
 
@@ -226,18 +226,18 @@ error: function does not emit the expected event
 
 error: emitted event not covered by any of the `emits` clauses
 
-     ┌── tests/sources/functional/emits.move:247:5 ───
+     ┌── tests/sources/functional/emits.move:255:5 ───
      │
- 247 │ ╭     spec fun strict_incorrect {
- 248 │ │         pragma emits_is_strict;
- 249 │ │     }
+ 255 │ ╭     spec fun strict_incorrect {
+ 256 │ │         pragma emits_is_strict;
+ 257 │ │     }
      │ ╰─────^
      │
-     =     at tests/sources/functional/emits.move:243: strict_incorrect
+     =     at tests/sources/functional/emits.move:251: strict_incorrect
      =         handle = <redacted>
-     =     at tests/sources/functional/emits.move:244: strict_incorrect
-     =     at tests/sources/functional/emits.move:245: strict_incorrect
-     =     at tests/sources/functional/emits.move:245: strict_incorrect
+     =     at tests/sources/functional/emits.move:252: strict_incorrect
+     =     at tests/sources/functional/emits.move:253: strict_incorrect
+     =     at tests/sources/functional/emits.move:253: strict_incorrect
      =         handle = <redacted>
-     =     at tests/sources/functional/emits.move:246: strict_incorrect
-     =     at tests/sources/functional/emits.move:247
+     =     at tests/sources/functional/emits.move:254: strict_incorrect
+     =     at tests/sources/functional/emits.move:255

--- a/language/move-prover/tests/sources/functional/emits.move
+++ b/language/move-prover/tests/sources/functional/emits.move
@@ -73,11 +73,19 @@ module TestEmits {
 
     public fun multiple_different_handle(handle: &mut EventHandle<DummyEvent>, handle2: &mut EventHandle<DummyEvent>) {
         Event::emit_event(handle, DummyEvent{msg: 0});
+        Event::emit_event(handle, DummyEvent{msg: 0});
+        Event::emit_event(handle, DummyEvent{msg: 1});
         Event::emit_event(handle2, DummyEvent{msg: 0});
+        Event::emit_event(handle2, DummyEvent{msg: 0});
+        Event::emit_event(handle2, DummyEvent{msg: 1});
     }
     spec fun multiple_different_handle {
         emits DummyEvent{msg: 0} to handle;
+        emits DummyEvent{msg: 0} to handle;
+        emits DummyEvent{msg: 1} to handle;
         emits DummyEvent{msg: 0} to handle2;
+        emits DummyEvent{msg: 0} to handle2;
+        emits DummyEvent{msg: 1} to handle2;
     }
 
 
@@ -286,6 +294,16 @@ module TestEmits {
         emits DummyEvent{msg: 77} to handle;
         emits DummyEvent{msg: 1} to handle;
         emits DummyEvent{msg: 2} to handle;
+    }
+
+    public fun opaque_in_call_chain(handle: &mut EventHandle<DummyEvent>) {
+        opaque(handle);
+    }
+    spec fun opaque_in_call_chain {
+        emits DummyEvent{msg: 0} to handle;
+        emits DummyEvent{msg: 7} to handle;
+        emits DummyEvent{msg: 77} to handle;
+        emits DummyEvent{msg: 1} to handle;
     }
 
     public fun opaque_completeness_incorrect(handle: &mut EventHandle<DummyEvent>) {


### PR DESCRIPTION
- Removed the emits spec of `DiemAccount::preburn` which was incorrect,
  so causing the timeout

- Corrected the mislocated emits spec in `Diem::preburn_to`

- Added some more test cases for the emits verification

## Motivation

To fix the emits spec in the Diem Framework

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test
