### PR TITLE
[move-prover] Implemented the feature of automatic inconsistency checking

### DIFF
--- a/language/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/language/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -233,18 +233,27 @@ impl<'env> ModuleTranslator<'env> {
                 let timeout = fun_target
                     .func_env
                     .get_num_pragma(TIMEOUT_PRAGMA, || self.options.vc_timeout);
-                let attribs = if fun_target.func_env.is_num_pragma_set(SEED_PRAGMA) {
+
+                let mut attribs = vec![format!("{{:timeLimit {}}} ", timeout)];
+
+                if fun_target.func_env.is_num_pragma_set(SEED_PRAGMA) {
                     let seed = fun_target
                         .func_env
                         .get_num_pragma(SEED_PRAGMA, || self.options.random_seed);
-                    format!("{{:timeLimit {}}} {{:random_seed {}}} ", timeout, seed)
-                } else {
-                    format!("{{:timeLimit {}}} ", timeout)
+                    attribs.push(format!("{{:random_seed {}}} ", seed));
                 };
+
+                if flavor == "inconsistency" {
+                    attribs.push(format!(
+                        "{{:msg_if_verifies \"inconsistency_detected{}\"}} ",
+                        self.loc_str(&fun_target.get_loc())
+                    ));
+                }
+
                 if flavor.is_empty() {
-                    ("$verify".to_string(), attribs)
+                    ("$verify".to_string(), attribs.join(""))
                 } else {
-                    (format!("$verify_{}", flavor), attribs)
+                    (format!("$verify_{}", flavor), attribs.join(""))
                 }
             }
         };

--- a/language/move-prover/bytecode/src/function_target_pipeline.rs
+++ b/language/move-prover/bytecode/src/function_target_pipeline.rs
@@ -39,6 +39,7 @@ impl FunctionVariant {
 
 /// The variant for regular verification.
 pub const REGULAR_VERIFICATION_VARIANT: &str = "";
+pub const INCONSISTENCY_CHECK_VARIANT: &str = "inconsistency";
 
 impl std::fmt::Display for FunctionVariant {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {

--- a/language/move-prover/bytecode/src/options.rs
+++ b/language/move-prover/bytecode/src/options.rs
@@ -45,6 +45,8 @@ pub struct ProverOptions {
     pub num_instances: usize,
     /// Whether to run Boogie instances sequentially.
     pub sequential_task: bool,
+    /// Whether to check the inconsistency
+    pub check_inconsistency: bool,
 }
 
 impl Default for ProverOptions {
@@ -66,6 +68,7 @@ impl Default for ProverOptions {
             dump_cfg: false,
             num_instances: 1,
             sequential_task: false,
+            check_inconsistency: false,
         }
     }
 }

--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -75,7 +75,7 @@ pub struct Options {
     pub errmapgen: ErrmapOptions,
     /// Whether to run experimental pipeline
     pub experimental_pipeline: bool,
-    /// Whether to use strong edges in borrow analtsis
+    /// Whether to use strong edges in borrow analysis
     pub strong_edges: bool,
 }
 
@@ -150,7 +150,7 @@ impl Options {
                     .multiple(true)
                     .number_of_values(1)
                     .value_name("TOML_STRING")
-                    .help("inline configuration string in toml syntax. Can be repeated. \
+                    .help("inlines configuration string in toml syntax. Can be repeated. \
                      Use as in `-C=prover.opt=value -C=backend.opt=value`"),
             )
             .arg(
@@ -178,7 +178,7 @@ impl Options {
                 Arg::with_name("generate-only")
                     .long("generate-only")
                     .short("g")
-                    .help("only generate boogie file but do not call boogie"),
+                    .help("only generates boogie file but does not call boogie"),
             )
             .arg(
                 Arg::with_name("warn")
@@ -196,7 +196,7 @@ impl Options {
                 Arg::with_name("keep")
                     .long("keep")
                     .short("k")
-                    .help("keep intermediate artifacts of the backend around")
+                    .help("keeps intermediate artifacts of the backend around")
             )
             .arg(
                 Arg::with_name("trans_v1")
@@ -211,7 +211,7 @@ impl Options {
             .arg(
                 Arg::with_name("negative")
                     .long("negative")
-                    .help("run negative verification checks")
+                    .help("runs negative verification checks")
             ).arg(
                 Arg::with_name("seed")
                     .long("seed")
@@ -244,7 +244,7 @@ impl Options {
             .arg(
                 Arg::with_name("docgen")
                     .long("docgen")
-                    .help("run the documentation generator instead of the prover. \
+                    .help("runs the documentation generator instead of the prover. \
                     Generated docs will be written into the directory `./doc` unless configured otherwise via toml"),
             )
             .arg(
@@ -257,24 +257,24 @@ impl Options {
             .arg(
                 Arg::with_name("abigen")
                     .long("abigen")
-                    .help("run the ABI generator instead of the prover. \
+                    .help("runs the ABI generator instead of the prover. \
                     Generated ABIs will be written into the directory `./abi` unless configured otherwise via toml"),
             )
             .arg(
                 Arg::with_name("errmapgen")
                     .long("errmapgen")
-                    .help("run the error map generator instead of the prover. \
+                    .help("runs the error map generator instead of the prover. \
                     The generated error map will be written to `errmap` unless configured otherwise"),
             )
             .arg(
                 Arg::with_name("packedtypesgen")
                     .long("packedtypesgen")
-                    .help("run the packed types generator instead of the prover.")
+                    .help("runs the packed types generator instead of the prover.")
             )
             .arg(
                 Arg::with_name("read-write-set")
                     .long("read-write-set")
-                    .help("run the read/write set analysis instead of the prover.")
+                    .help("runs the read/write set analysis instead of the prover.")
             )
             .arg(
                 Arg::with_name("verify")
@@ -363,22 +363,29 @@ impl Options {
             .arg(
                 Arg::with_name("use-cvc4")
                     .long("use-cvc4")
-                    .help("use cvc4 solver instead of z3")
-            ).arg(
-            Arg::with_name("experimental_pipeline")
-                .long("experimental_pipeline")
-                .short("e")
-                .help("whether to run experimental pipeline")
-            ).arg(
-            Arg::with_name("strong_edges")
-            .long("strong_edges")
-            .help("whether to use strong edges in borrow analysis")
+                    .help("uses cvc4 solver instead of z3")
+            )
+            .arg(
+                Arg::with_name("experimental_pipeline")
+                    .long("experimental_pipeline")
+                    .short("e")
+                    .help("whether to run experimental pipeline")
+            )
+            .arg(
+                Arg::with_name("strong_edges")
+                    .long("strong_edges")
+                    .help("whether to use strong edges in borrow analysis")
             )
             .arg(
                 Arg::with_name("exp_mut_param")
                     .long("exp-mut-param")
                     .help("exp_mut_param experiment")
-        )
+            )
+            .arg(
+                Arg::with_name("check-inconsistency")
+                    .long("check-inconsistency")
+                    .help("checks whether there is any inconsistency")
+            )
             .after_help("More options available via `--config file` or `--config-str str`. \
             Use `--print-config` to see format and current values. \
             See `move-prover/src/cli.rs::Option` for documentation.");
@@ -525,6 +532,9 @@ impl Options {
         }
         if matches.is_present("use-cvc4") {
             options.backend.use_cvc4 = true;
+        }
+        if matches.is_present("check-inconsistency") {
+            options.prover.check_inconsistency = true;
         }
         if matches.is_present("print-config") {
             println!("{}", toml::to_string(&options).unwrap());

--- a/language/move-prover/tests/sources/functional/inconsistency.exp
+++ b/language/move-prover/tests/sources/functional/inconsistency.exp
@@ -1,0 +1,33 @@
+Move prover returns: exiting with boogie verification errors
+error: there is an inconsistent assumption in the function, which may allow any post-condition (including false) to be proved
+
+    ┌── tests/sources/functional/inconsistency.move:48:5 ───
+    │
+ 48 │ ╭     fun always_abort() {
+ 49 │ │         abort 0
+ 50 │ │     }
+    │ ╰─────^
+    │
+
+error: there is an inconsistent assumption in the function, which may allow any post-condition (including false) to be proved
+
+    ┌── tests/sources/functional/inconsistency.move:16:5 ───
+    │
+ 16 │ ╭     fun assume_false(x: u64): u64 {
+ 17 │ │         spec {
+ 18 │ │             assume false;
+ 19 │ │         };
+ 20 │ │         dec(x)
+ 21 │ │     }
+    │ ╰─────^
+    │
+
+error: there is an inconsistent assumption in the function, which may allow any post-condition (including false) to be proved
+
+    ┌── tests/sources/functional/inconsistency.move:39:5 ───
+    │
+ 39 │ ╭     fun call_inconsistent_opaque() {
+ 40 │ │         inconsistent_opaque();
+ 41 │ │     }
+    │ ╰─────^
+    │

--- a/language/move-prover/tests/sources/functional/inconsistency.move
+++ b/language/move-prover/tests/sources/functional/inconsistency.move
@@ -1,0 +1,55 @@
+// flag: --check-inconsistency
+
+module Inconsistency {
+
+    // There is no inconsistency in this function.
+    fun dec(x: u64): u64 {
+        x - 1
+    }
+    spec fun dec {
+        aborts_if x == 0;
+        ensures result == x - 1;
+    }
+
+    // There is an inconsistent assumption in the verification of this function
+    // because it assumes false.
+    fun assume_false(x: u64): u64 {
+        spec {
+            assume false;
+        };
+        dec(x)
+    }
+    spec fun assume_false {
+        aborts_if x == 0;
+        ensures result == x - 1;
+        ensures false;
+    }
+
+    // This opaque function has the false post-condition, so introduces an inconsistency.
+    fun inconsistent_opaque() {
+    }
+    spec fun inconsistent_opaque {
+        pragma verify=false;
+        pragma opaque;
+        ensures false;
+    }
+
+    // There is an inconsistent assumption in the verification of this function
+    // because it calls an inconsistent opaque function.
+    fun call_inconsistent_opaque() {
+        inconsistent_opaque();
+    }
+    spec fun call_inconsistent_opaque {
+        ensures false;
+    }
+
+    // There is an inconsistent assumption in the verification of this function
+    // because it always aborts.
+    fun always_abort() {
+        abort 0
+    }
+    spec fun always_abort {
+        ensures false;
+    }
+
+}

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -23,7 +23,7 @@ VAULT_VERSION=1.5.0
 Z3_VERSION=4.8.9
 CVC4_VERSION=aac53f51
 DOTNET_VERSION=3.1
-BOOGIE_VERSION=2.8.25
+BOOGIE_VERSION=2.8.27
 
 SCRIPT_PATH="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
 cd "$SCRIPT_PATH/.." || exit


### PR DESCRIPTION
- Added "--check-inconsistency" flag into the Prover CLI
- With the flag above, Prover performs the inconsistency checking in  addition to the regular verification
- In order to perform the inconsistency checking, Prover creates another function variant as a target, and `assert false;` is inserted at the end of the "return" block of the new function variant
- If the assertion above passes, then Prover reports it as an inconsistency error
  - (Prover masks the expected errors (e.g., the "assert false" failures and the timeouts) from the negative test for the inconsistency checking, and does not report them to the users.)
- Some examples are in `.../functional/inconsistency.move`.

## Motivation

The presence of inconsistency is a serious issue. If there is an inconsistency in the verification assumption (perhaps due to a specification mistake or a Prover bug), any false post-condition can be proved vacuously. This PR adds to the Prover a new feature to automatically check the inconsistency and to ensure the absence of it.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

cargo test


