### PR TITLE
[move-lang] Improve constant sets with lazy. Restrict _ names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4288,6 +4288,7 @@ dependencies = [
  "move-core-types",
  "move-ir-types",
  "move-lang-test-utils",
+ "once_cell",
  "petgraph",
  "regex",
  "structopt 0.3.21",

--- a/language/move-lang/Cargo.toml
+++ b/language/move-lang/Cargo.toml
@@ -17,6 +17,7 @@ difference = "2.0.0"
 petgraph = "0.5.1"
 walkdir = "2.3.1"
 tempfile = "3.2.0"
+once_cell = "1.7.2"
 
 fallible = { path = "../../common/fallible" }
 move-vm = { path = "../vm", package = "vm" }

--- a/language/move-lang/src/naming/ast.rs
+++ b/language/move-lang/src/naming/ast.rs
@@ -13,6 +13,7 @@ use crate::{
     shared::{ast_debug::*, unique_map::UniqueMap, *},
 };
 use move_ir_types::location::*;
+use once_cell::sync::Lazy;
 use std::{
     collections::{BTreeMap, BTreeSet, VecDeque},
     fmt,
@@ -268,6 +269,38 @@ pub type SequenceItem = Spanned<SequenceItem_>;
 // impls
 //**************************************************************************************************
 
+static BUILTIN_TYPE_ALL_NAMES: Lazy<BTreeSet<&'static str>> = Lazy::new(|| {
+    [
+        BuiltinTypeName_::ADDRESS,
+        BuiltinTypeName_::SIGNER,
+        BuiltinTypeName_::U_8,
+        BuiltinTypeName_::U_64,
+        BuiltinTypeName_::U_128,
+        BuiltinTypeName_::BOOL,
+        BuiltinTypeName_::VECTOR,
+    ]
+    .iter()
+    .cloned()
+    .collect()
+});
+
+static BUILTIN_TYPE_NUMERIC: Lazy<BTreeSet<BuiltinTypeName_>> = Lazy::new(|| {
+    [
+        BuiltinTypeName_::U8,
+        BuiltinTypeName_::U64,
+        BuiltinTypeName_::U128,
+    ]
+    .iter()
+    .cloned()
+    .collect()
+});
+
+static BUILTIN_TYPE_BITS: Lazy<BTreeSet<BuiltinTypeName_>> =
+    Lazy::new(|| BUILTIN_TYPE_NUMERIC.clone());
+
+static BUILTIN_TYPE_ORDERED: Lazy<BTreeSet<BuiltinTypeName_>> =
+    Lazy::new(|| BUILTIN_TYPE_BITS.clone());
+
 impl BuiltinTypeName_ {
     pub const ADDRESS: &'static str = "address";
     pub const SIGNER: &'static str = "signer";
@@ -277,34 +310,20 @@ impl BuiltinTypeName_ {
     pub const BOOL: &'static str = "bool";
     pub const VECTOR: &'static str = "vector";
 
-    pub fn all_names() -> BTreeSet<&'static str> {
-        let mut s = BTreeSet::new();
-        s.insert(Self::ADDRESS);
-        s.insert(Self::SIGNER);
-        s.insert(Self::U_8);
-        s.insert(Self::U_64);
-        s.insert(Self::U_128);
-        s.insert(Self::BOOL);
-        s.insert(Self::VECTOR);
-        s
+    pub fn all_names() -> &'static BTreeSet<&'static str> {
+        &*BUILTIN_TYPE_ALL_NAMES
     }
 
-    pub fn numeric() -> BTreeSet<BuiltinTypeName_> {
-        use BuiltinTypeName_ as BT;
-        let mut s = BTreeSet::new();
-        s.insert(BT::U8);
-        s.insert(BT::U64);
-        s.insert(BT::U128);
-        s
+    pub fn numeric() -> &'static BTreeSet<BuiltinTypeName_> {
+        &*BUILTIN_TYPE_NUMERIC
     }
 
-    pub fn bits() -> BTreeSet<BuiltinTypeName_> {
-        use BuiltinTypeName_ as BT;
-        BT::numeric()
+    pub fn bits() -> &'static BTreeSet<BuiltinTypeName_> {
+        &*BUILTIN_TYPE_BITS
     }
 
-    pub fn ordered() -> BTreeSet<BuiltinTypeName_> {
-        Self::bits()
+    pub fn ordered() -> &'static BTreeSet<BuiltinTypeName_> {
+        &*BUILTIN_TYPE_ORDERED
     }
 
     pub fn is_numeric(&self) -> bool {
@@ -357,6 +376,18 @@ impl TVar {
     }
 }
 
+static BUILTIN_FUNCTION_ALL_NAMES: Lazy<BTreeSet<&'static str>> = Lazy::new(|| {
+    let mut s = BTreeSet::new();
+    s.insert(BuiltinFunction_::MOVE_TO);
+    s.insert(BuiltinFunction_::MOVE_FROM);
+    s.insert(BuiltinFunction_::BORROW_GLOBAL);
+    s.insert(BuiltinFunction_::BORROW_GLOBAL_MUT);
+    s.insert(BuiltinFunction_::EXISTS);
+    s.insert(BuiltinFunction_::FREEZE);
+    s.insert(BuiltinFunction_::ASSERT);
+    s
+});
+
 impl BuiltinFunction_ {
     pub const MOVE_TO: &'static str = "move_to";
     pub const MOVE_FROM: &'static str = "move_from";
@@ -366,16 +397,8 @@ impl BuiltinFunction_ {
     pub const FREEZE: &'static str = "freeze";
     pub const ASSERT: &'static str = "assert";
 
-    pub fn all_names() -> BTreeSet<&'static str> {
-        let mut s = BTreeSet::new();
-        s.insert(Self::MOVE_TO);
-        s.insert(Self::MOVE_FROM);
-        s.insert(Self::BORROW_GLOBAL);
-        s.insert(Self::BORROW_GLOBAL_MUT);
-        s.insert(Self::EXISTS);
-        s.insert(Self::FREEZE);
-        s.insert(Self::ASSERT);
-        s
+    pub fn all_names() -> &'static BTreeSet<&'static str> {
+        &*BUILTIN_FUNCTION_ALL_NAMES
     }
 
     pub fn resolve(name_str: &str, arg: Option<Type>) -> Option<Self> {

--- a/language/move-lang/src/naming/translate.rs
+++ b/language/move-lang/src/naming/translate.rs
@@ -91,7 +91,7 @@ impl Context {
             })
             .collect();
         let unscoped_types = N::BuiltinTypeName_::all_names()
-            .into_iter()
+            .iter()
             .map(|s| (s.to_string(), RT::BuiltinType))
             .collect();
         Self {

--- a/language/move-lang/src/typing/core.rs
+++ b/language/move-lang/src/typing/core.rs
@@ -1061,7 +1061,7 @@ fn solve_implicitly_copyable_constraint(
 
 fn solve_builtin_type_constraint(
     context: &mut Context,
-    builtin_set: BTreeSet<BuiltinTypeName_>,
+    builtin_set: &BTreeSet<BuiltinTypeName_>,
     loc: Loc,
     op: &'static str,
     ty: Type,

--- a/language/move-lang/tests/move_check/expansion/constant_invalid_alias_names.exp
+++ b/language/move-lang/tests/move_check/expansion/constant_invalid_alias_names.exp
@@ -19,6 +19,30 @@ error:
    ┌── tests/move_check/expansion/constant_invalid_alias_names.move:8:43 ───
    │
  8 │     use 0x42::N::{C as c1, C as _C1, C as Self};
-   │                                           ^^^^ Invalid module member name 'Self'. 'Self' is restricted and cannot be used to name a module member
+   │                                           ^^^^ Invalid constant alias name 'Self'. 'Self' is restricted and cannot be used to name a constant alias
    │
+
+error: 
+
+    ┌── tests/move_check/expansion/constant_invalid_alias_names.move:13:24 ───
+    │
+ 13 │     use 0x42::N::{C as c1, C as _C1, C as Self};
+    │                        ^^ Invalid constant alias name 'c1'. Constant alias names must start with 'A'..'Z'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/constant_invalid_alias_names.move:13:33 ───
+    │
+ 13 │     use 0x42::N::{C as c1, C as _C1, C as Self};
+    │                                 ^^^ Invalid constant alias name '_C1'. Constant alias names must start with 'A'..'Z'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/constant_invalid_alias_names.move:13:43 ───
+    │
+ 13 │     use 0x42::N::{C as c1, C as _C1, C as Self};
+    │                                           ^^^^ Invalid constant alias name 'Self'. 'Self' is restricted and cannot be used to name a constant alias
+    │
 

--- a/language/move-lang/tests/move_check/expansion/constant_invalid_alias_names.move
+++ b/language/move-lang/tests/move_check/expansion/constant_invalid_alias_names.move
@@ -8,3 +8,8 @@ module M {
     use 0x42::N::{C as c1, C as _C1, C as Self};
 }
 }
+
+script {
+    use 0x42::N::{C as c1, C as _C1, C as Self};
+    fun main() {}
+}

--- a/language/move-lang/tests/move_check/expansion/constant_invalid_names.exp
+++ b/language/move-lang/tests/move_check/expansion/constant_invalid_names.exp
@@ -19,6 +19,30 @@ error:
    ┌── tests/move_check/expansion/constant_invalid_names.move:5:11 ───
    │
  5 │     const Self: u64 = 0;
-   │           ^^^^ Invalid module member name 'Self'. 'Self' is restricted and cannot be used to name a module member
+   │           ^^^^ Invalid constant name 'Self'. 'Self' is restricted and cannot be used to name a constant
    │
+
+error: 
+
+    ┌── tests/move_check/expansion/constant_invalid_names.move:11:11 ───
+    │
+ 11 │     const c1: u64 = 0;
+    │           ^^ Invalid constant name 'c1'. Constant names must start with 'A'..'Z'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/constant_invalid_names.move:12:11 ───
+    │
+ 12 │     const _C1: u64 = 0;
+    │           ^^^ Invalid constant name '_C1'. Constant names must start with 'A'..'Z'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/constant_invalid_names.move:13:11 ───
+    │
+ 13 │     const Self: u64 = 0;
+    │           ^^^^ Invalid constant name 'Self'. 'Self' is restricted and cannot be used to name a constant
+    │
 

--- a/language/move-lang/tests/move_check/expansion/constant_invalid_names.move
+++ b/language/move-lang/tests/move_check/expansion/constant_invalid_names.move
@@ -5,3 +5,11 @@ module M {
     const Self: u64 = 0;
 }
 }
+
+
+script {
+    const c1: u64 = 0;
+    const _C1: u64 = 0;
+    const Self: u64 = 0;
+    fun main() {}
+}

--- a/language/move-lang/tests/move_check/expansion/function_invalid_names.exp
+++ b/language/move-lang/tests/move_check/expansion/function_invalid_names.exp
@@ -1,0 +1,48 @@
+error: 
+
+   ┌── tests/move_check/expansion/function_invalid_names.move:3:9 ───
+   │
+ 3 │     fun _foo() {}
+   │         ^^^^ Invalid function name '_foo'. Function names cannot start with '_'
+   │
+
+error: 
+
+   ┌── tests/move_check/expansion/function_invalid_names.move:4:9 ───
+   │
+ 4 │     fun _() {}
+   │         ^ Invalid function name '_'. Function names cannot start with '_'
+   │
+
+error: 
+
+   ┌── tests/move_check/expansion/function_invalid_names.move:5:9 ───
+   │
+ 5 │     fun ___() {}
+   │         ^^^ Invalid function name '___'. Function names cannot start with '_'
+   │
+
+error: 
+
+    ┌── tests/move_check/expansion/function_invalid_names.move:10:9 ───
+    │
+ 10 │     fun _foo() {}
+    │         ^^^^ Invalid function name '_foo'. Function names cannot start with '_'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/function_invalid_names.move:13:9 ───
+    │
+ 13 │     fun _() {}
+    │         ^ Invalid function name '_'. Function names cannot start with '_'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/function_invalid_names.move:16:9 ───
+    │
+ 16 │     fun ___() {}
+    │         ^^^ Invalid function name '___'. Function names cannot start with '_'
+    │
+

--- a/language/move-lang/tests/move_check/expansion/function_invalid_names.move
+++ b/language/move-lang/tests/move_check/expansion/function_invalid_names.move
@@ -1,0 +1,17 @@
+address 0x42 {
+module M {
+    fun _foo() {}
+    fun _() {}
+    fun ___() {}
+}
+}
+
+script {
+    fun _foo() {}
+}
+script {
+    fun _() {}
+}
+script {
+    fun ___() {}
+}

--- a/language/move-lang/tests/move_check/expansion/module_invalid_names.exp
+++ b/language/move-lang/tests/move_check/expansion/module_invalid_names.exp
@@ -1,0 +1,24 @@
+error: 
+
+   ┌── tests/move_check/expansion/module_invalid_names.move:2:8 ───
+   │
+ 2 │ module _m {
+   │        ^^ Invalid module name '_m'. Module names cannot start with '_'
+   │
+
+error: 
+
+   ┌── tests/move_check/expansion/module_invalid_names.move:4:8 ───
+   │
+ 4 │ module _ {
+   │        ^ Invalid module name '_'. Module names cannot start with '_'
+   │
+
+error: 
+
+   ┌── tests/move_check/expansion/module_invalid_names.move:6:8 ───
+   │
+ 6 │ module ___ {
+   │        ^^^ Invalid module name '___'. Module names cannot start with '_'
+   │
+

--- a/language/move-lang/tests/move_check/expansion/module_invalid_names.move
+++ b/language/move-lang/tests/move_check/expansion/module_invalid_names.move
@@ -1,0 +1,8 @@
+address 0x42 {
+module _m {
+}
+module _ {
+}
+module ___ {
+}
+}

--- a/language/move-lang/tests/move_check/expansion/restricted_alias_names.exp
+++ b/language/move-lang/tests/move_check/expansion/restricted_alias_names.exp
@@ -3,7 +3,7 @@ error:
    ┌── tests/move_check/expansion/restricted_alias_names.move:9:16 ───
    │
  9 │         foo as address,
-   │                ^^^^^^^ Invalid module member name 'address'. 'address' is restricted and cannot be used to name a module member
+   │                ^^^^^^^ Invalid function alias name 'address'. 'address' is restricted and cannot be used to name a function alias
    │
 
 error: 
@@ -11,7 +11,7 @@ error:
     ┌── tests/move_check/expansion/restricted_alias_names.move:10:16 ───
     │
  10 │         foo as signer,
-    │                ^^^^^^ Invalid module member name 'signer'. 'signer' is restricted and cannot be used to name a module member
+    │                ^^^^^^ Invalid function alias name 'signer'. 'signer' is restricted and cannot be used to name a function alias
     │
 
 error: 
@@ -19,7 +19,7 @@ error:
     ┌── tests/move_check/expansion/restricted_alias_names.move:11:16 ───
     │
  11 │         foo as u8,
-    │                ^^ Invalid module member name 'u8'. 'u8' is restricted and cannot be used to name a module member
+    │                ^^ Invalid function alias name 'u8'. 'u8' is restricted and cannot be used to name a function alias
     │
 
 error: 
@@ -27,7 +27,7 @@ error:
     ┌── tests/move_check/expansion/restricted_alias_names.move:12:16 ───
     │
  12 │         foo as u64,
-    │                ^^^ Invalid module member name 'u64'. 'u64' is restricted and cannot be used to name a module member
+    │                ^^^ Invalid function alias name 'u64'. 'u64' is restricted and cannot be used to name a function alias
     │
 
 error: 
@@ -35,7 +35,7 @@ error:
     ┌── tests/move_check/expansion/restricted_alias_names.move:13:16 ───
     │
  13 │         foo as u128,
-    │                ^^^^ Invalid module member name 'u128'. 'u128' is restricted and cannot be used to name a module member
+    │                ^^^^ Invalid function alias name 'u128'. 'u128' is restricted and cannot be used to name a function alias
     │
 
 error: 
@@ -43,7 +43,7 @@ error:
     ┌── tests/move_check/expansion/restricted_alias_names.move:14:16 ───
     │
  14 │         foo as vector,
-    │                ^^^^^^ Invalid module member name 'vector'. 'vector' is restricted and cannot be used to name a module member
+    │                ^^^^^^ Invalid function alias name 'vector'. 'vector' is restricted and cannot be used to name a function alias
     │
 
 error: 
@@ -51,7 +51,7 @@ error:
     ┌── tests/move_check/expansion/restricted_alias_names.move:15:16 ───
     │
  15 │         foo as move_to,
-    │                ^^^^^^^ Invalid module member name 'move_to'. 'move_to' is restricted and cannot be used to name a module member
+    │                ^^^^^^^ Invalid function alias name 'move_to'. 'move_to' is restricted and cannot be used to name a function alias
     │
 
 error: 
@@ -59,7 +59,7 @@ error:
     ┌── tests/move_check/expansion/restricted_alias_names.move:16:16 ───
     │
  16 │         foo as move_from,
-    │                ^^^^^^^^^ Invalid module member name 'move_from'. 'move_from' is restricted and cannot be used to name a module member
+    │                ^^^^^^^^^ Invalid function alias name 'move_from'. 'move_from' is restricted and cannot be used to name a function alias
     │
 
 error: 
@@ -67,7 +67,7 @@ error:
     ┌── tests/move_check/expansion/restricted_alias_names.move:17:16 ───
     │
  17 │         foo as borrow_global,
-    │                ^^^^^^^^^^^^^ Invalid module member name 'borrow_global'. 'borrow_global' is restricted and cannot be used to name a module member
+    │                ^^^^^^^^^^^^^ Invalid function alias name 'borrow_global'. 'borrow_global' is restricted and cannot be used to name a function alias
     │
 
 error: 
@@ -75,7 +75,7 @@ error:
     ┌── tests/move_check/expansion/restricted_alias_names.move:18:16 ───
     │
  18 │         foo as borrow_global_mut,
-    │                ^^^^^^^^^^^^^^^^^ Invalid module member name 'borrow_global_mut'. 'borrow_global_mut' is restricted and cannot be used to name a module member
+    │                ^^^^^^^^^^^^^^^^^ Invalid function alias name 'borrow_global_mut'. 'borrow_global_mut' is restricted and cannot be used to name a function alias
     │
 
 error: 
@@ -83,7 +83,7 @@ error:
     ┌── tests/move_check/expansion/restricted_alias_names.move:19:16 ───
     │
  19 │         foo as exists,
-    │                ^^^^^^ Invalid module member name 'exists'. 'exists' is restricted and cannot be used to name a module member
+    │                ^^^^^^ Invalid function alias name 'exists'. 'exists' is restricted and cannot be used to name a function alias
     │
 
 error: 
@@ -91,7 +91,7 @@ error:
     ┌── tests/move_check/expansion/restricted_alias_names.move:20:16 ───
     │
  20 │         foo as freeze,
-    │                ^^^^^^ Invalid module member name 'freeze'. 'freeze' is restricted and cannot be used to name a module member
+    │                ^^^^^^ Invalid function alias name 'freeze'. 'freeze' is restricted and cannot be used to name a function alias
     │
 
 error: 
@@ -99,7 +99,7 @@ error:
     ┌── tests/move_check/expansion/restricted_alias_names.move:21:16 ───
     │
  21 │         foo as assert,
-    │                ^^^^^^ Invalid module member name 'assert'. 'assert' is restricted and cannot be used to name a module member
+    │                ^^^^^^ Invalid function alias name 'assert'. 'assert' is restricted and cannot be used to name a function alias
     │
 
 error: 
@@ -107,6 +107,118 @@ error:
     ┌── tests/move_check/expansion/restricted_alias_names.move:22:16 ───
     │
  22 │         foo as Self,
-    │                ^^^^ Invalid module member name 'Self'. 'Self' is restricted and cannot be used to name a module member
+    │                ^^^^ Invalid function alias name 'Self'. 'Self' is restricted and cannot be used to name a function alias
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_alias_names.move:30:16 ───
+    │
+ 30 │         foo as address,
+    │                ^^^^^^^ Invalid function alias name 'address'. 'address' is restricted and cannot be used to name a function alias
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_alias_names.move:31:16 ───
+    │
+ 31 │         foo as signer,
+    │                ^^^^^^ Invalid function alias name 'signer'. 'signer' is restricted and cannot be used to name a function alias
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_alias_names.move:32:16 ───
+    │
+ 32 │         foo as u8,
+    │                ^^ Invalid function alias name 'u8'. 'u8' is restricted and cannot be used to name a function alias
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_alias_names.move:33:16 ───
+    │
+ 33 │         foo as u64,
+    │                ^^^ Invalid function alias name 'u64'. 'u64' is restricted and cannot be used to name a function alias
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_alias_names.move:34:16 ───
+    │
+ 34 │         foo as u128,
+    │                ^^^^ Invalid function alias name 'u128'. 'u128' is restricted and cannot be used to name a function alias
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_alias_names.move:35:16 ───
+    │
+ 35 │         foo as vector,
+    │                ^^^^^^ Invalid function alias name 'vector'. 'vector' is restricted and cannot be used to name a function alias
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_alias_names.move:36:16 ───
+    │
+ 36 │         foo as move_to,
+    │                ^^^^^^^ Invalid function alias name 'move_to'. 'move_to' is restricted and cannot be used to name a function alias
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_alias_names.move:37:16 ───
+    │
+ 37 │         foo as move_from,
+    │                ^^^^^^^^^ Invalid function alias name 'move_from'. 'move_from' is restricted and cannot be used to name a function alias
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_alias_names.move:38:16 ───
+    │
+ 38 │         foo as borrow_global,
+    │                ^^^^^^^^^^^^^ Invalid function alias name 'borrow_global'. 'borrow_global' is restricted and cannot be used to name a function alias
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_alias_names.move:39:16 ───
+    │
+ 39 │         foo as borrow_global_mut,
+    │                ^^^^^^^^^^^^^^^^^ Invalid function alias name 'borrow_global_mut'. 'borrow_global_mut' is restricted and cannot be used to name a function alias
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_alias_names.move:40:16 ───
+    │
+ 40 │         foo as exists,
+    │                ^^^^^^ Invalid function alias name 'exists'. 'exists' is restricted and cannot be used to name a function alias
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_alias_names.move:41:16 ───
+    │
+ 41 │         foo as freeze,
+    │                ^^^^^^ Invalid function alias name 'freeze'. 'freeze' is restricted and cannot be used to name a function alias
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_alias_names.move:42:16 ───
+    │
+ 42 │         foo as assert,
+    │                ^^^^^^ Invalid function alias name 'assert'. 'assert' is restricted and cannot be used to name a function alias
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_alias_names.move:43:16 ───
+    │
+ 43 │         foo as Self,
+    │                ^^^^ Invalid function alias name 'Self'. 'Self' is restricted and cannot be used to name a function alias
     │
 

--- a/language/move-lang/tests/move_check/expansion/restricted_alias_names.move
+++ b/language/move-lang/tests/move_check/expansion/restricted_alias_names.move
@@ -24,3 +24,23 @@ module M {
 }
 
 }
+
+script {
+    use 0x2::N::{
+        foo as address,
+        foo as signer,
+        foo as u8,
+        foo as u64,
+        foo as u128,
+        foo as vector,
+        foo as move_to,
+        foo as move_from,
+        foo as borrow_global,
+        foo as borrow_global_mut,
+        foo as exists,
+        foo as freeze,
+        foo as assert,
+        foo as Self,
+    };
+    fun main() {}
+}

--- a/language/move-lang/tests/move_check/expansion/restricted_constant_names.exp
+++ b/language/move-lang/tests/move_check/expansion/restricted_constant_names.exp
@@ -1,112 +1,224 @@
 error: 
 
-   ┌── tests/move_check/expansion/restricted_constant_names.move:4:11 ───
-   │
- 4 │     const address: u64 = 0;
-   │           ^^^^^^^ Invalid constant name 'address'. Constant names must start with 'A'..'Z'
-   │
-
-error: 
-
    ┌── tests/move_check/expansion/restricted_constant_names.move:5:11 ───
    │
- 5 │     const signer: u64 = 0;
-   │           ^^^^^^ Invalid constant name 'signer'. Constant names must start with 'A'..'Z'
+ 5 │     const address: u64 = 0;
+   │           ^^^^^^^ Invalid constant name 'address'. Constant names must start with 'A'..'Z'
    │
 
 error: 
 
    ┌── tests/move_check/expansion/restricted_constant_names.move:6:11 ───
    │
- 6 │     const u8: u64 = 0;
-   │           ^^ Invalid constant name 'u8'. Constant names must start with 'A'..'Z'
+ 6 │     const signer: u64 = 0;
+   │           ^^^^^^ Invalid constant name 'signer'. Constant names must start with 'A'..'Z'
    │
 
 error: 
 
    ┌── tests/move_check/expansion/restricted_constant_names.move:7:11 ───
    │
- 7 │     const u64: u64 = 0;
-   │           ^^^ Invalid constant name 'u64'. Constant names must start with 'A'..'Z'
+ 7 │     const u8: u64 = 0;
+   │           ^^ Invalid constant name 'u8'. Constant names must start with 'A'..'Z'
    │
 
 error: 
 
    ┌── tests/move_check/expansion/restricted_constant_names.move:8:11 ───
    │
- 8 │     const u128: u64 = 0;
-   │           ^^^^ Invalid constant name 'u128'. Constant names must start with 'A'..'Z'
+ 8 │     const u64: u64 = 0;
+   │           ^^^ Invalid constant name 'u64'. Constant names must start with 'A'..'Z'
    │
 
 error: 
 
    ┌── tests/move_check/expansion/restricted_constant_names.move:9:11 ───
    │
- 9 │     const vector: u64 = 0;
-   │           ^^^^^^ Invalid constant name 'vector'. Constant names must start with 'A'..'Z'
+ 9 │     const u128: u64 = 0;
+   │           ^^^^ Invalid constant name 'u128'. Constant names must start with 'A'..'Z'
    │
 
 error: 
 
     ┌── tests/move_check/expansion/restricted_constant_names.move:10:11 ───
     │
- 10 │     const move_to: u64 = 0;
-    │           ^^^^^^^ Invalid constant name 'move_to'. Constant names must start with 'A'..'Z'
+ 10 │     const vector: u64 = 0;
+    │           ^^^^^^ Invalid constant name 'vector'. Constant names must start with 'A'..'Z'
     │
 
 error: 
 
     ┌── tests/move_check/expansion/restricted_constant_names.move:11:11 ───
     │
- 11 │     const move_from: u64 = 0;
-    │           ^^^^^^^^^ Invalid constant name 'move_from'. Constant names must start with 'A'..'Z'
+ 11 │     const move_to: u64 = 0;
+    │           ^^^^^^^ Invalid constant name 'move_to'. Constant names must start with 'A'..'Z'
     │
 
 error: 
 
     ┌── tests/move_check/expansion/restricted_constant_names.move:12:11 ───
     │
- 12 │     const borrow_global: u64 = 0;
-    │           ^^^^^^^^^^^^^ Invalid constant name 'borrow_global'. Constant names must start with 'A'..'Z'
+ 12 │     const move_from: u64 = 0;
+    │           ^^^^^^^^^ Invalid constant name 'move_from'. Constant names must start with 'A'..'Z'
     │
 
 error: 
 
     ┌── tests/move_check/expansion/restricted_constant_names.move:13:11 ───
     │
- 13 │     const borrow_global_mut: u64 = 0;
-    │           ^^^^^^^^^^^^^^^^^ Invalid constant name 'borrow_global_mut'. Constant names must start with 'A'..'Z'
+ 13 │     const borrow_global: u64 = 0;
+    │           ^^^^^^^^^^^^^ Invalid constant name 'borrow_global'. Constant names must start with 'A'..'Z'
     │
 
 error: 
 
     ┌── tests/move_check/expansion/restricted_constant_names.move:14:11 ───
     │
- 14 │     const exists: u64 = 0;
-    │           ^^^^^^ Invalid constant name 'exists'. Constant names must start with 'A'..'Z'
+ 14 │     const borrow_global_mut: u64 = 0;
+    │           ^^^^^^^^^^^^^^^^^ Invalid constant name 'borrow_global_mut'. Constant names must start with 'A'..'Z'
     │
 
 error: 
 
     ┌── tests/move_check/expansion/restricted_constant_names.move:15:11 ───
     │
- 15 │     const freeze: u64 = 0;
-    │           ^^^^^^ Invalid constant name 'freeze'. Constant names must start with 'A'..'Z'
+ 15 │     const exists: u64 = 0;
+    │           ^^^^^^ Invalid constant name 'exists'. Constant names must start with 'A'..'Z'
     │
 
 error: 
 
     ┌── tests/move_check/expansion/restricted_constant_names.move:16:11 ───
     │
- 16 │     const assert: u64 = 0;
-    │           ^^^^^^ Invalid constant name 'assert'. Constant names must start with 'A'..'Z'
+ 16 │     const freeze: u64 = 0;
+    │           ^^^^^^ Invalid constant name 'freeze'. Constant names must start with 'A'..'Z'
     │
 
 error: 
 
     ┌── tests/move_check/expansion/restricted_constant_names.move:17:11 ───
     │
- 17 │     const Self: u64 = 0;
-    │           ^^^^ Invalid module member name 'Self'. 'Self' is restricted and cannot be used to name a module member
+ 17 │     const assert: u64 = 0;
+    │           ^^^^^^ Invalid constant name 'assert'. Constant names must start with 'A'..'Z'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_constant_names.move:19:11 ───
+    │
+ 19 │     const Self: u64 = 0;
+    │           ^^^^ Invalid constant name 'Self'. 'Self' is restricted and cannot be used to name a constant
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_constant_names.move:26:11 ───
+    │
+ 26 │     const address: u64 = 0;
+    │           ^^^^^^^ Invalid constant name 'address'. Constant names must start with 'A'..'Z'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_constant_names.move:27:11 ───
+    │
+ 27 │     const signer: u64 = 0;
+    │           ^^^^^^ Invalid constant name 'signer'. Constant names must start with 'A'..'Z'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_constant_names.move:28:11 ───
+    │
+ 28 │     const u8: u64 = 0;
+    │           ^^ Invalid constant name 'u8'. Constant names must start with 'A'..'Z'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_constant_names.move:29:11 ───
+    │
+ 29 │     const u64: u64 = 0;
+    │           ^^^ Invalid constant name 'u64'. Constant names must start with 'A'..'Z'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_constant_names.move:30:11 ───
+    │
+ 30 │     const u128: u64 = 0;
+    │           ^^^^ Invalid constant name 'u128'. Constant names must start with 'A'..'Z'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_constant_names.move:31:11 ───
+    │
+ 31 │     const vector: u64 = 0;
+    │           ^^^^^^ Invalid constant name 'vector'. Constant names must start with 'A'..'Z'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_constant_names.move:32:11 ───
+    │
+ 32 │     const move_to: u64 = 0;
+    │           ^^^^^^^ Invalid constant name 'move_to'. Constant names must start with 'A'..'Z'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_constant_names.move:33:11 ───
+    │
+ 33 │     const move_from: u64 = 0;
+    │           ^^^^^^^^^ Invalid constant name 'move_from'. Constant names must start with 'A'..'Z'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_constant_names.move:34:11 ───
+    │
+ 34 │     const borrow_global: u64 = 0;
+    │           ^^^^^^^^^^^^^ Invalid constant name 'borrow_global'. Constant names must start with 'A'..'Z'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_constant_names.move:35:11 ───
+    │
+ 35 │     const borrow_global_mut: u64 = 0;
+    │           ^^^^^^^^^^^^^^^^^ Invalid constant name 'borrow_global_mut'. Constant names must start with 'A'..'Z'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_constant_names.move:36:11 ───
+    │
+ 36 │     const exists: u64 = 0;
+    │           ^^^^^^ Invalid constant name 'exists'. Constant names must start with 'A'..'Z'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_constant_names.move:37:11 ───
+    │
+ 37 │     const freeze: u64 = 0;
+    │           ^^^^^^ Invalid constant name 'freeze'. Constant names must start with 'A'..'Z'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_constant_names.move:38:11 ───
+    │
+ 38 │     const assert: u64 = 0;
+    │           ^^^^^^ Invalid constant name 'assert'. Constant names must start with 'A'..'Z'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_constant_names.move:40:11 ───
+    │
+ 40 │     const Self: u64 = 0;
+    │           ^^^^ Invalid constant name 'Self'. 'Self' is restricted and cannot be used to name a constant
     │
 

--- a/language/move-lang/tests/move_check/expansion/restricted_constant_names.move
+++ b/language/move-lang/tests/move_check/expansion/restricted_constant_names.move
@@ -1,6 +1,7 @@
 address 0x2 {
 
 module M {
+    // restricted names are invalid due to not starting with A-Z
     const address: u64 = 0;
     const signer: u64 = 0;
     const u8: u64 = 0;
@@ -14,7 +15,28 @@ module M {
     const exists: u64 = 0;
     const freeze: u64 = 0;
     const assert: u64 = 0;
+    // restricted
     const Self: u64 = 0;
 }
 
+}
+
+script {
+    // restricted names are invalid due to not starting with A-Z
+    const address: u64 = 0;
+    const signer: u64 = 0;
+    const u8: u64 = 0;
+    const u64: u64 = 0;
+    const u128: u64 = 0;
+    const vector: u64 = 0;
+    const move_to: u64 = 0;
+    const move_from: u64 = 0;
+    const borrow_global: u64 = 0;
+    const borrow_global_mut: u64 = 0;
+    const exists: u64 = 0;
+    const freeze: u64 = 0;
+    const assert: u64 = 0;
+    // restricted
+    const Self: u64 = 0;
+    fun main() {}
 }

--- a/language/move-lang/tests/move_check/expansion/restricted_function_names.exp
+++ b/language/move-lang/tests/move_check/expansion/restricted_function_names.exp
@@ -3,7 +3,7 @@ error:
    ┌── tests/move_check/expansion/restricted_function_names.move:2:9 ───
    │
  2 │     fun address() { abort 0 }
-   │         ^^^^^^^ Invalid module member name 'address'. 'address' is restricted and cannot be used to name a module member
+   │         ^^^^^^^ Invalid function name 'address'. 'address' is restricted and cannot be used to name a function
    │
 
 error: 
@@ -11,7 +11,7 @@ error:
    ┌── tests/move_check/expansion/restricted_function_names.move:3:9 ───
    │
  3 │     fun signer() { abort 0 }
-   │         ^^^^^^ Invalid module member name 'signer'. 'signer' is restricted and cannot be used to name a module member
+   │         ^^^^^^ Invalid function name 'signer'. 'signer' is restricted and cannot be used to name a function
    │
 
 error: 
@@ -19,7 +19,7 @@ error:
    ┌── tests/move_check/expansion/restricted_function_names.move:4:9 ───
    │
  4 │     fun u8() { abort 0 }
-   │         ^^ Invalid module member name 'u8'. 'u8' is restricted and cannot be used to name a module member
+   │         ^^ Invalid function name 'u8'. 'u8' is restricted and cannot be used to name a function
    │
 
 error: 
@@ -27,7 +27,7 @@ error:
    ┌── tests/move_check/expansion/restricted_function_names.move:5:9 ───
    │
  5 │     fun u64() { abort 0 }
-   │         ^^^ Invalid module member name 'u64'. 'u64' is restricted and cannot be used to name a module member
+   │         ^^^ Invalid function name 'u64'. 'u64' is restricted and cannot be used to name a function
    │
 
 error: 
@@ -35,7 +35,7 @@ error:
    ┌── tests/move_check/expansion/restricted_function_names.move:6:9 ───
    │
  6 │     fun u128() { abort 0 }
-   │         ^^^^ Invalid module member name 'u128'. 'u128' is restricted and cannot be used to name a module member
+   │         ^^^^ Invalid function name 'u128'. 'u128' is restricted and cannot be used to name a function
    │
 
 error: 
@@ -43,7 +43,7 @@ error:
    ┌── tests/move_check/expansion/restricted_function_names.move:7:9 ───
    │
  7 │     fun vector<T>() { abort 0 }
-   │         ^^^^^^ Invalid module member name 'vector'. 'vector' is restricted and cannot be used to name a module member
+   │         ^^^^^^ Invalid function name 'vector'. 'vector' is restricted and cannot be used to name a function
    │
 
 error: 
@@ -51,7 +51,7 @@ error:
    ┌── tests/move_check/expansion/restricted_function_names.move:8:9 ───
    │
  8 │     fun move_to() { abort 0 }
-   │         ^^^^^^^ Invalid module member name 'move_to'. 'move_to' is restricted and cannot be used to name a module member
+   │         ^^^^^^^ Invalid function name 'move_to'. 'move_to' is restricted and cannot be used to name a function
    │
 
 error: 
@@ -59,7 +59,7 @@ error:
    ┌── tests/move_check/expansion/restricted_function_names.move:9:9 ───
    │
  9 │     fun move_from() { abort 0 }
-   │         ^^^^^^^^^ Invalid module member name 'move_from'. 'move_from' is restricted and cannot be used to name a module member
+   │         ^^^^^^^^^ Invalid function name 'move_from'. 'move_from' is restricted and cannot be used to name a function
    │
 
 error: 
@@ -67,7 +67,7 @@ error:
     ┌── tests/move_check/expansion/restricted_function_names.move:10:9 ───
     │
  10 │     fun borrow_global() { abort 0 }
-    │         ^^^^^^^^^^^^^ Invalid module member name 'borrow_global'. 'borrow_global' is restricted and cannot be used to name a module member
+    │         ^^^^^^^^^^^^^ Invalid function name 'borrow_global'. 'borrow_global' is restricted and cannot be used to name a function
     │
 
 error: 
@@ -75,7 +75,7 @@ error:
     ┌── tests/move_check/expansion/restricted_function_names.move:11:9 ───
     │
  11 │     fun borrow_global_mut() { abort 0 }
-    │         ^^^^^^^^^^^^^^^^^ Invalid module member name 'borrow_global_mut'. 'borrow_global_mut' is restricted and cannot be used to name a module member
+    │         ^^^^^^^^^^^^^^^^^ Invalid function name 'borrow_global_mut'. 'borrow_global_mut' is restricted and cannot be used to name a function
     │
 
 error: 
@@ -83,7 +83,7 @@ error:
     ┌── tests/move_check/expansion/restricted_function_names.move:12:9 ───
     │
  12 │     fun exists() { abort 0 }
-    │         ^^^^^^ Invalid module member name 'exists'. 'exists' is restricted and cannot be used to name a module member
+    │         ^^^^^^ Invalid function name 'exists'. 'exists' is restricted and cannot be used to name a function
     │
 
 error: 
@@ -91,7 +91,7 @@ error:
     ┌── tests/move_check/expansion/restricted_function_names.move:13:9 ───
     │
  13 │     fun freeze() { abort 0 }
-    │         ^^^^^^ Invalid module member name 'freeze'. 'freeze' is restricted and cannot be used to name a module member
+    │         ^^^^^^ Invalid function name 'freeze'. 'freeze' is restricted and cannot be used to name a function
     │
 
 error: 
@@ -99,7 +99,7 @@ error:
     ┌── tests/move_check/expansion/restricted_function_names.move:14:9 ───
     │
  14 │     fun assert() { abort 0 }
-    │         ^^^^^^ Invalid module member name 'assert'. 'assert' is restricted and cannot be used to name a module member
+    │         ^^^^^^ Invalid function name 'assert'. 'assert' is restricted and cannot be used to name a function
     │
 
 error: 
@@ -107,6 +107,118 @@ error:
     ┌── tests/move_check/expansion/restricted_function_names.move:15:9 ───
     │
  15 │     fun Self() { abort 0}
-    │         ^^^^ Invalid module member name 'Self'. 'Self' is restricted and cannot be used to name a module member
+    │         ^^^^ Invalid function name 'Self'. 'Self' is restricted and cannot be used to name a function
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_function_names.move:18:14 ───
+    │
+ 18 │ script { fun address() { abort 0 } }
+    │              ^^^^^^^ Invalid function name 'address'. 'address' is restricted and cannot be used to name a function
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_function_names.move:19:14 ───
+    │
+ 19 │ script { fun signer() { abort 0 } }
+    │              ^^^^^^ Invalid function name 'signer'. 'signer' is restricted and cannot be used to name a function
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_function_names.move:20:14 ───
+    │
+ 20 │ script { fun u8() { abort 0 } }
+    │              ^^ Invalid function name 'u8'. 'u8' is restricted and cannot be used to name a function
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_function_names.move:21:14 ───
+    │
+ 21 │ script { fun u64() { abort 0 } }
+    │              ^^^ Invalid function name 'u64'. 'u64' is restricted and cannot be used to name a function
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_function_names.move:22:14 ───
+    │
+ 22 │ script { fun u128() { abort 0 } }
+    │              ^^^^ Invalid function name 'u128'. 'u128' is restricted and cannot be used to name a function
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_function_names.move:23:14 ───
+    │
+ 23 │ script { fun vector<T>() { abort 0 } }
+    │              ^^^^^^ Invalid function name 'vector'. 'vector' is restricted and cannot be used to name a function
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_function_names.move:24:14 ───
+    │
+ 24 │ script { fun move_to() { abort 0 } }
+    │              ^^^^^^^ Invalid function name 'move_to'. 'move_to' is restricted and cannot be used to name a function
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_function_names.move:25:14 ───
+    │
+ 25 │ script { fun move_from() { abort 0 } }
+    │              ^^^^^^^^^ Invalid function name 'move_from'. 'move_from' is restricted and cannot be used to name a function
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_function_names.move:26:14 ───
+    │
+ 26 │ script { fun borrow_global() { abort 0 } }
+    │              ^^^^^^^^^^^^^ Invalid function name 'borrow_global'. 'borrow_global' is restricted and cannot be used to name a function
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_function_names.move:27:14 ───
+    │
+ 27 │ script { fun borrow_global_mut() { abort 0 } }
+    │              ^^^^^^^^^^^^^^^^^ Invalid function name 'borrow_global_mut'. 'borrow_global_mut' is restricted and cannot be used to name a function
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_function_names.move:28:14 ───
+    │
+ 28 │ script { fun exists() { abort 0 } }
+    │              ^^^^^^ Invalid function name 'exists'. 'exists' is restricted and cannot be used to name a function
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_function_names.move:29:14 ───
+    │
+ 29 │ script { fun freeze() { abort 0 } }
+    │              ^^^^^^ Invalid function name 'freeze'. 'freeze' is restricted and cannot be used to name a function
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_function_names.move:30:14 ───
+    │
+ 30 │ script { fun assert() { abort 0 } }
+    │              ^^^^^^ Invalid function name 'assert'. 'assert' is restricted and cannot be used to name a function
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_function_names.move:31:14 ───
+    │
+ 31 │ script { fun Self() { abort 0} }
+    │              ^^^^ Invalid function name 'Self'. 'Self' is restricted and cannot be used to name a function
     │
 

--- a/language/move-lang/tests/move_check/expansion/restricted_function_names.move
+++ b/language/move-lang/tests/move_check/expansion/restricted_function_names.move
@@ -14,3 +14,18 @@ module M {
     fun assert() { abort 0 }
     fun Self() { abort 0}
 }
+
+script { fun address() { abort 0 } }
+script { fun signer() { abort 0 } }
+script { fun u8() { abort 0 } }
+script { fun u64() { abort 0 } }
+script { fun u128() { abort 0 } }
+script { fun vector<T>() { abort 0 } }
+script { fun move_to() { abort 0 } }
+script { fun move_from() { abort 0 } }
+script { fun borrow_global() { abort 0 } }
+script { fun borrow_global_mut() { abort 0 } }
+script { fun exists() { abort 0 } }
+script { fun freeze() { abort 0 } }
+script { fun assert() { abort 0 } }
+script { fun Self() { abort 0} }

--- a/language/move-lang/tests/move_check/expansion/restricted_struct_names.exp
+++ b/language/move-lang/tests/move_check/expansion/restricted_struct_names.exp
@@ -99,6 +99,6 @@ error:
     ┌── tests/move_check/expansion/restricted_struct_names.move:15:12 ───
     │
  15 │     struct Self {}
-    │            ^^^^ Invalid module member name 'Self'. 'Self' is restricted and cannot be used to name a module member
+    │            ^^^^ Invalid struct name 'Self'. 'Self' is restricted and cannot be used to name a struct
     │
 


### PR DESCRIPTION
- Improve static sets by generating them only once with Lazy
- Module members and module names can no longer start with '_'

## Motivation

- Lazy usage is a conceptual perf win (unlikely to be noticeable) 
- Underscore rule fixes #7572

## Test Plan

- New test