### PR TITLE
[move-lang] propogate friend list to bytecode

### DIFF
--- a/language/move-lang/src/cfgir/ast.rs
+++ b/language/move-lang/src/cfgir/ast.rs
@@ -45,6 +45,7 @@ pub struct ModuleDefinition {
     pub is_source_module: bool,
     /// `dependency_order` is the topological order/rank in the dependency graph.
     pub dependency_order: usize,
+    pub friends: UniqueMap<ModuleIdent, Loc>,
     pub structs: UniqueMap<StructName, StructDefinition>,
     pub constants: UniqueMap<ConstantName, Constant>,
     pub functions: UniqueMap<FunctionName, Function>,
@@ -200,6 +201,7 @@ impl AstDebug for ModuleDefinition {
         let ModuleDefinition {
             is_source_module,
             dependency_order,
+            friends,
             structs,
             constants,
             functions,
@@ -210,6 +212,10 @@ impl AstDebug for ModuleDefinition {
             w.writeln("source module")
         }
         w.writeln(&format!("dependency order #{}", dependency_order));
+        for (mident, _loc) in friends.key_cloned_iter() {
+            w.write(&format!("friend {};", mident));
+            w.new_line();
+        }
         for sdef in structs.key_cloned_iter() {
             sdef.ast_debug(w);
             w.new_line();

--- a/language/move-lang/src/cfgir/translate.rs
+++ b/language/move-lang/src/cfgir/translate.rs
@@ -156,16 +156,23 @@ fn module(
     module_ident: ModuleIdent,
     mdef: H::ModuleDefinition,
 ) -> (ModuleIdent, G::ModuleDefinition) {
-    let is_source_module = mdef.is_source_module;
-    let dependency_order = mdef.dependency_order;
-    let structs = mdef.structs;
-    let constants = mdef.constants.map(|name, c| constant(context, name, c));
-    let functions = mdef.functions.map(|name, f| function(context, name, f));
+    let H::ModuleDefinition {
+        is_source_module,
+        dependency_order,
+        friends,
+        structs,
+        functions: hfunctions,
+        constants: hconstants,
+    } = mdef;
+
+    let constants = hconstants.map(|name, c| constant(context, name, c));
+    let functions = hfunctions.map(|name, f| function(context, name, f));
     (
         module_ident,
         G::ModuleDefinition {
             is_source_module,
             dependency_order,
+            friends,
             structs,
             constants,
             functions,

--- a/language/move-lang/src/hlir/ast.rs
+++ b/language/move-lang/src/hlir/ast.rs
@@ -46,6 +46,7 @@ pub struct ModuleDefinition {
     pub is_source_module: bool,
     /// `dependency_order` is the topological order/rank in the dependency graph.
     pub dependency_order: usize,
+    pub friends: UniqueMap<ModuleIdent, Loc>,
     pub structs: UniqueMap<StructName, StructDefinition>,
     pub constants: UniqueMap<ConstantName, Constant>,
     pub functions: UniqueMap<FunctionName, Function>,
@@ -576,6 +577,7 @@ impl AstDebug for ModuleDefinition {
         let ModuleDefinition {
             is_source_module,
             dependency_order,
+            friends,
             structs,
             constants,
             functions,
@@ -586,6 +588,10 @@ impl AstDebug for ModuleDefinition {
             w.writeln("source module")
         }
         w.writeln(&format!("dependency order #{}", dependency_order));
+        for (mident, _loc) in friends.key_cloned_iter() {
+            w.write(&format!("friend {};", mident));
+            w.new_line();
+        }
         for sdef in structs.key_cloned_iter() {
             sdef.ast_debug(w);
             w.new_line();

--- a/language/move-lang/src/hlir/translate.rs
+++ b/language/move-lang/src/hlir/translate.rs
@@ -172,14 +172,20 @@ fn module(
     module_ident: ModuleIdent,
     mdef: T::ModuleDefinition,
 ) -> (ModuleIdent, H::ModuleDefinition) {
-    let is_source_module = mdef.is_source_module;
-    let dependency_order = mdef.dependency_order;
+    let T::ModuleDefinition {
+        is_source_module,
+        dependency_order,
+        friends,
+        structs: tstructs,
+        functions: tfunctions,
+        constants: tconstants,
+    } = mdef;
 
-    let structs = mdef.structs.map(|name, s| struct_def(context, name, s));
+    let structs = tstructs.map(|name, s| struct_def(context, name, s));
     context.add_struct_fields(&structs);
 
-    let constants = mdef.constants.map(|name, c| constant(context, name, c));
-    let functions = mdef.functions.map(|name, f| function(context, name, f));
+    let constants = tconstants.map(|name, c| constant(context, name, c));
+    let functions = tfunctions.map(|name, f| function(context, name, f));
 
     context.structs = UniqueMap::new();
     (
@@ -187,6 +193,7 @@ fn module(
         H::ModuleDefinition {
             is_source_module,
             dependency_order,
+            friends,
             structs,
             constants,
             functions,

--- a/language/move-lang/src/to_bytecode/context.rs
+++ b/language/move-lang/src/to_bytecode/context.rs
@@ -212,7 +212,7 @@ impl<'a> Context<'a> {
         IR::ModuleName::new(format!("{}::{}", address, name))
     }
 
-    fn translate_module_ident(ident: ModuleIdent) -> IR::ModuleIdent {
+    pub fn translate_module_ident(ident: ModuleIdent) -> IR::ModuleIdent {
         let (address, name) = ident.value;
         let name = Self::translate_module_name_(name);
         IR::ModuleIdent::Qualified(IR::QualifiedModuleIdent::new(

--- a/language/move-lang/src/to_bytecode/translate.rs
+++ b/language/move-lang/src/to_bytecode/translate.rs
@@ -144,15 +144,20 @@ fn module(
 
     let addr = DiemAddress::new(ident.value.0.to_u8());
     let mname = ident.value.1.clone();
+    let friends = mdef
+        .friends
+        .into_iter()
+        .map(|(mident, _loc)| Context::translate_module_ident(mident))
+        .collect();
     let (imports, explicit_dependency_declarations) = context.materialize(
         dependency_orderings,
         struct_declarations,
         function_declarations,
     );
+
     let ir_module = IR::ModuleDefinition {
         name: IR::ModuleName::new(mname),
-        // TODO: add friends here
-        friends: vec![],
+        friends,
         imports,
         explicit_dependency_declarations,
         structs,

--- a/language/move-lang/src/typing/translate.rs
+++ b/language/move-lang/src/typing/translate.rs
@@ -56,7 +56,6 @@ fn module(
         functions: n_functions,
         constants: nconstants,
     } = mdef;
-    // TODO: translate friends
     structs
         .iter_mut()
         .for_each(|(_, _, s)| struct_def(context, s));


### PR DESCRIPTION
The last piece of friend visibility in the source compiler.

Since friend list info is not used in hlir, cfgir, etc, most of the
translation is simply unpacking and repacking.

## Motivation

This completes the implementation of friend visibility.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo xtest

