### PR TITLE
[move-model] expose friend info to move model

### DIFF
--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -785,6 +785,7 @@ impl GlobalEnv {
             loc,
             spec_block_infos,
             used_modules: Default::default(),
+            friend_modules: Default::default(),
         });
     }
 
@@ -1188,6 +1189,9 @@ pub struct ModuleData {
 
     /// A cache for the modules used by this one.
     used_modules: RefCell<BTreeMap<bool, BTreeSet<ModuleId>>>,
+
+    /// A cache for the modules declared as friends by this one.
+    friend_modules: RefCell<Option<BTreeSet<ModuleId>>>,
 }
 
 impl ModuleData {
@@ -1209,6 +1213,7 @@ impl ModuleData {
             loc: Loc::default(),
             spec_block_infos: vec![],
             used_modules: Default::default(),
+            friend_modules: Default::default(),
         }
     }
 }
@@ -1266,9 +1271,14 @@ impl<'env> ModuleEnv<'env> {
     /// (including itself), friend modules are excluded from the return result.
     pub fn get_dependencies(&self) -> Vec<language_storage::ModuleId> {
         let compiled_module = &self.data.module;
-        let mut deps = self.data.module.immediate_dependencies();
+        let mut deps = compiled_module.immediate_dependencies();
         deps.push(compiled_module.self_id());
         deps
+    }
+
+    /// Return the set of language storage ModuleId's that this module declares as friends
+    pub fn get_friends(&self) -> Vec<language_storage::ModuleId> {
+        self.data.module.immediate_friends()
     }
 
     /// Returns the set of modules that use this one.
@@ -1336,6 +1346,23 @@ impl<'env> ModuleEnv<'env> {
             .borrow_mut()
             .insert(include_specs, usage.clone());
         usage
+    }
+
+    /// Returns the set of modules this one declares as friends.
+    pub fn get_friend_modules(&self) -> BTreeSet<ModuleId> {
+        self.data
+            .friend_modules
+            .borrow_mut()
+            .get_or_insert_with(|| {
+                // Determine modules used in bytecode from the compiled module.
+                self.get_friends()
+                    .into_iter()
+                    .map(|storage_id| self.env.to_module_name(&storage_id))
+                    .filter_map(|name| self.env.find_module(&name))
+                    .map(|env| env.get_id())
+                    .collect()
+            })
+            .clone()
     }
 
     /// Returns true if the given module is a transitive dependency of this one. The

--- a/language/move-prover/bytecode/src/function_target.rs
+++ b/language/move-prover/bytecode/src/function_target.rs
@@ -158,9 +158,9 @@ impl<'env> FunctionTarget<'env> {
         self.func_env.is_opaque()
     }
 
-    /// Returns true if this function is public.
-    pub fn is_public(&self) -> bool {
-        self.func_env.is_public()
+    /// Returns true if this function has public, friend, or script visibility.
+    pub fn is_exposed(&self) -> bool {
+        self.func_env.is_exposed()
     }
 
     /// Returns the visibility of this function.

--- a/language/move-prover/bytecode/src/memory_instrumentation.rs
+++ b/language/move-prover/bytecode/src/memory_instrumentation.rs
@@ -118,7 +118,9 @@ impl<'a> Instrumenter<'a> {
                 .env
                 .get_module(*mid)
                 .into_function(*fid);
-            if callee_env.is_public() {
+            // TODO: this will instrument not only `public` functions, but also `public(script)`
+            // and `public(friend)` as well.
+            if callee_env.is_exposed() {
                 let pack_refs: Vec<&TempIndex> = srcs
                     .iter()
                     .filter(|idx| self.is_pack_ref_ty(self.func_target.get_local_type(**idx)))

--- a/language/move-prover/docgen/Cargo.toml
+++ b/language/move-prover/docgen/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 [dependencies]
 # diem dependencies
 move-model = { path = "../../move-model" }
-bytecode = { path = "../bytecode"}
+bytecode = { path = "../bytecode" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 
 # external dependencies


### PR DESCRIPTION
## Motivation

As title suggests. This PR also changes the `is_public()` API to `is_exposed()` which encapsulates not only `public` functions but also `public(script)` and `public(friend)`. Several TODO marks are added too to signal more changes.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests should not fail
