### PR TITLE
[State Sync] Update state sync to prioritize preferred peers

### DIFF
--- a/config/src/network_id.rs
+++ b/config/src/network_id.rs
@@ -96,7 +96,9 @@ impl Ord for NetworkId {
 }
 
 impl PartialOrd for NetworkId {
-    /// Generalized ordering for determining which network is the most important
+    /// Generalized ordering for determining which network is the most important.
+    /// The lower the ordering, the higher the importance (i.e., the validator
+    /// network is less than all other networks because it has the highest priority).
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         // To simplify logic below, if it's the same it's equal
         Some(if self == other {

--- a/state-sync/src/coordinator.rs
+++ b/state-sync/src/coordinator.rs
@@ -118,7 +118,6 @@ impl<T: ExecutorProxyTrait> StateSyncCoordinator<T> {
             })?,
         };
         let request_manager = RequestManager::new(
-            node_config.upstream.clone(),
             Duration::from_millis(retry_timeout_val),
             Duration::from_millis(node_config.state_sync.multicast_timeout_ms),
             network_senders,

--- a/state-sync/src/logging.rs
+++ b/state-sync/src/logging.rs
@@ -5,7 +5,7 @@ use crate::{
     chunk_request::GetChunkRequest, chunk_response::GetChunkResponse, error::Error,
     request_manager::ChunkRequestInfo,
 };
-use diem_config::config::PeerNetworkId;
+use diem_config::{config::PeerNetworkId, network_id::NetworkId};
 use diem_logger::Schema;
 use diem_types::{
     contract_event::ContractEvent, ledger_info::LedgerInfoWithSignatures, waypoint::Waypoint,
@@ -40,8 +40,8 @@ pub struct LogSchema<'a> {
     new_epoch: Option<u64>,
     request_version: Option<u64>,
     target_version: Option<u64>,
-    old_multicast_level: Option<usize>,
-    new_multicast_level: Option<usize>,
+    old_multicast_level: Option<NetworkId>,
+    new_multicast_level: Option<NetworkId>,
     #[schema(debug)]
     chunk_req_info: Option<&'a ChunkRequestInfo>,
 }

--- a/state-sync/tests/integration_tests.rs
+++ b/state-sync/tests/integration_tests.rs
@@ -774,21 +774,25 @@ fn test_multicast_failover() {
         true,
     );
 
-    // Wait for fullnode 0's chunk request to time out
+    // Wait for fullnode 0's chunk request to time out before delivering the response
     std::thread::sleep(std::time::Duration::from_millis(multicast_timeout_ms));
+    env.deliver_msg(validator_peer_id);
 
-    // Verify that fullnode 0 broadcasts to the validator peer and the fallback peer
+    // Verify that fullnode 0 broadcasts to the validator peer and both fallback peers
     let _ = execute_commit_and_verify_chunk_requests(
         &mut env,
         2,
-        &[fn_0_vfn_2_peer_id, fn_0_vfn_peer_id],
-        &[validator_peer_id, fn_1_vfn_2_peer_id],
-        &[fn_0_pfn_peer_id],
+        &[fn_0_vfn_2_peer_id, fn_0_vfn_peer_id, fn_0_pfn_peer_id],
+        &[validator_peer_id, fn_1_vfn_2_peer_id, fn_2_pfn_peer_id],
+        &[],
         true,
     );
 
-    // Wait for fullnode 0's chunk request to time out again
+    // Wait for fullnode 0's chunk request to time out before delivering responses
     std::thread::sleep(std::time::Duration::from_millis(multicast_timeout_ms));
+    env.deliver_msg(validator_peer_id);
+    env.deliver_msg(fn_2_pfn_peer_id);
+    env.deliver_msg(fn_1_vfn_2_peer_id);
 
     // Verify that fullnode 0 broadcasts to the validator peer and both fallback peers
     let _ = execute_commit_and_verify_chunk_requests(
@@ -800,7 +804,7 @@ fn test_multicast_failover() {
         true,
     );
 
-    // Deliver chunks from the 3 nodes (VFN delivers before validator)
+    // Deliver chunks from the 3 nodes (PFN delivers before validator)
     env.deliver_msg(fn_2_pfn_peer_id);
     env.deliver_msg(fn_1_vfn_2_peer_id);
     env.deliver_msg(validator_peer_id);
@@ -856,7 +860,7 @@ fn test_multicast_failover() {
         &mut env,
         7,
         &[fn_0_vfn_peer_id],
-        &[validator_peer_id, fn_1_vfn_2_peer_id, fn_2_pfn_peer_id],
+        &[validator_peer_id],
         &[fn_0_vfn_2_peer_id, fn_0_pfn_peer_id],
         true,
     );


### PR DESCRIPTION
## Motivation

This PR updates state sync to make use of `PeerRole` information to prioritize sending chunk requests to preferred peers. This works by giving preferred upstream peers a higher internal weighting when compared to non-preferred nodes (thus making them more likely to be selected as the endpoint to send a chunk request).

The PR offers the following commits:
1. Remove reliance of state sync on UpstreamConfig and instead use NetworkId's directly. Note: we may need to think about the correct abstractions that NetworkId exposes in the future (as state is leaking into components). However, I've left this as a TODO.
2. Update state sync to give preferred upstream peers a higher likelihood of being selected when sending chunk requests. This commit also adds a unit test for this functionality.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally, including the newly added one.

## Related PRs

This PR moves state sync away from using UpstreamConfig, similar to a previous PR that did the same for mempool: https://github.com/diem/diem/pull/7809
