### PR TITLE
Add custom error type for infallible::checked and remove clippy annotations

### DIFF
--- a/common/infallible/src/lib.rs
+++ b/common/infallible/src/lib.rs
@@ -7,6 +7,7 @@ mod nonzero;
 mod rwlock;
 mod time;
 
+pub use math::ArithmeticError;
 pub use mutex::{Mutex, MutexGuard};
 pub use rwlock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 pub use time::duration_since_epoch;

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -33,6 +33,7 @@ use consensus_types::{
     vote::Vote,
     vote_msg::VoteMsg,
 };
+use diem_infallible::checked;
 use diem_logger::prelude::*;
 use diem_trace::prelude::*;
 use diem_types::{epoch_state::EpochState, validator_verifier::ValidatorVerifier};
@@ -411,9 +412,14 @@ impl RoundManager {
             "{}", sync_info
         );
         // To avoid a ping-pong cycle between two peers that move forward together.
-        self.ensure_round_and_sync_up(sync_info.highest_round() + 1, &sync_info, peer, false)
-            .await
-            .context("[RoundManager] Failed to process sync info msg")?;
+        self.ensure_round_and_sync_up(
+            checked!((sync_info.highest_round()) + 1)?,
+            &sync_info,
+            peer,
+            false,
+        )
+        .await
+        .context("[RoundManager] Failed to process sync info msg")?;
         Ok(())
     }
 


### PR DESCRIPTION
## Motivation

Change the error type returned by `checked` from `String` to a custom type that implements `Error`. 
This also removes the unnecessary annotations to ignore clippy arithmetic errors, they are not needed and were causing errors when using the macro.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Manually tested by creating dummy code and running `cargo clippy -- -W clippy::integer_arithmetic`

## Related PRs
https://github.com/diem/diem/pull/7423#pullrequestreview-583585006
