### PR TITLE
[move-prover] generate dot graph for per-function CFG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,6 +586,7 @@ dependencies = [
  "move-prover-test-utils",
  "num 0.4.0",
  "once_cell",
+ "petgraph",
  "serde",
  "serde_json",
  "vm",

--- a/language/move-prover/Cargo.toml
+++ b/language/move-prover/Cargo.toml
@@ -14,7 +14,7 @@ move-model = { path = "../move-model" }
 docgen = { path = "docgen" }
 abigen = { path = "abigen" }
 errmapgen = { path = "errmapgen" }
-bytecode = { path = "bytecode"}
+bytecode = { path = "bytecode" }
 vm = { path = "../vm" }
 diem-types = { path = "../../types" }
 diem-temppath = { path = "../../common/temppath" }

--- a/language/move-prover/bytecode/Cargo.toml
+++ b/language/move-prover/bytecode/Cargo.toml
@@ -24,6 +24,7 @@ log = "0.4.14"
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
 once_cell = "1.7.2"
+petgraph = "0.5.1"
 
 [dev-dependencies]
 datatest-stable = { path = "../../../common/datatest-stable" }

--- a/language/move-prover/bytecode/src/options.rs
+++ b/language/move-prover/bytecode/src/options.rs
@@ -39,6 +39,8 @@ pub struct ProverOptions {
     pub report_warnings: bool,
     /// Whether to dump the transformed stackless bytecode to a file
     pub dump_bytecode: bool,
+    /// Whether to dump the control-flow graphs (in dot format) to files, one per each function
+    pub dump_cfg: bool,
     /// Number of Boogie instances to be run concurrently.
     pub num_instances: usize,
     /// Whether to run Boogie instances sequentially.
@@ -61,6 +63,7 @@ impl Default for ProverOptions {
             report_warnings: false,
             assume_invariant_on_access: false,
             dump_bytecode: false,
+            dump_cfg: false,
             num_instances: 1,
             sequential_task: false,
         }

--- a/language/move-prover/bytecode/tests/testsuite.rs
+++ b/language/move-prover/bytecode/tests/testsuite.rs
@@ -180,7 +180,7 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
 
         // Run pipeline if any
         if let Some(pipeline) = pipeline_opt {
-            pipeline.run(&env, &mut targets, None);
+            pipeline.run(&env, &mut targets, None, /* dump_cfg */ false);
             text +=
                 &print_targets_for_test(&env, &format!("after pipeline `{}`", dir_name), &targets);
         }

--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -335,6 +335,12 @@ impl Options {
                     .help("whether to dump the transformed bytecode to a file")
             )
             .arg(
+                Arg::with_name("dump-cfg")
+                    .long("dump-cfg")
+                    .requires("dump-bytecode")
+                    .help("whether to dump the per-function control-flow graphs (in dot format) to files")
+            )
+            .arg(
                 Arg::with_name("num-instances")
                     .long("num-instances")
                     .takes_value(true)
@@ -465,6 +471,9 @@ impl Options {
         }
         if matches.is_present("dump-bytecode") {
             options.prover.dump_bytecode = true;
+        }
+        if matches.is_present("dump-cfg") {
+            options.prover.dump_cfg = true;
         }
         if matches.is_present("num-instances") {
             let num_instances = matches

--- a/language/move-prover/src/lib.rs
+++ b/language/move-prover/src/lib.rs
@@ -238,7 +238,7 @@ fn run_read_write_set(env: &GlobalEnv, options: &Options, now: Instant) {
 
     let start = now.elapsed();
     info!("generating read/write set");
-    pipeline.run(env, &mut targets, None);
+    pipeline.run(env, &mut targets, None, /* dump_cfg */ false);
     read_write_set_analysis::get_read_write_set(env, &targets);
     println!("generated for {:?}", options.move_sources);
 
@@ -293,7 +293,7 @@ fn create_and_process_bytecode(options: &Options, env: &GlobalEnv) -> FunctionTa
     } else {
         None
     };
-    pipeline.run(env, &mut targets, dump_file);
+    pipeline.run(env, &mut targets, dump_file, options.prover.dump_cfg);
 
     targets
 }


### PR DESCRIPTION
This feature can be invoked with the `--dump-cfg` CLI flag, together
with `--dump-bytecode`:

`mvp --dump-bytecode --dump-cfg <path-to-file>.move`

The pass will save the CFG in dot format for *every* function after
*every* transformation step. So it may generate a lot of files.

The .dot files can be rendered with the Dot program, e.g.,
`dot -Tpdf <path-to-input>.dot -o <path-to-output>.pdf`

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Visualize the control-flow graphs after each transformation pass.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Use the `loop1.move` as the following

```
module Loops {
    public fun iter10_no_abort() {
        let i = 0;
        while ({
            spec { assert i <= 11; };
            (i <= 10)
        }) {
            if (i > 10) abort 10;
            i = i + 1;
        }
    }
    spec fun iter10_no_abort { // Verified. Abort cannot happen.
        pragma verify=true;
        aborts_if false;
    }
}
```

```
mvp --dump-bytecode --dump-cfg loop1.move
ls -all
```
Expect (at least) the following files in the directory

```
loop1.move
loop1_0_stackless.bytecode
loop1_0_stackless_Loops__iter10_no_abort_baseline_cfg.dot
loop1_10_verification_analysis.bytecode
loop1_10_verification_analysis_Loops__iter10_no_abort_baseline_cfg.dot
loop1_11_loop_analysis.bytecode
loop1_11_loop_analysis_Loops__iter10_no_abort_baseline_cfg.dot
loop1_12_spec_instrumenter.bytecode
loop1_12_spec_instrumenter_Loops__iter10_no_abort_verification_cfg.dot
loop1_13_data_invariant_instrumenter.bytecode
loop1_13_data_invariant_instrumenter_Loops__iter10_no_abort_verification_cfg.dot
loop1_14_global_invariant_instrumenter.bytecode
loop1_14_global_invariant_instrumenter_Loops__iter10_no_abort_verification_cfg.dot
loop1_1_debug_instrumenter.bytecode
loop1_1_debug_instrumenter_Loops__iter10_no_abort_baseline_cfg.dot
loop1_2_eliminate_imm_refs.bytecode
loop1_2_eliminate_imm_refs_Loops__iter10_no_abort_baseline_cfg.dot
loop1_3_mut_ref_instrumentation.bytecode
loop1_3_mut_ref_instrumentation_Loops__iter10_no_abort_baseline_cfg.dot
loop1_4_reaching_def_analysis.bytecode
loop1_4_reaching_def_analysis_Loops__iter10_no_abort_baseline_cfg.dot
loop1_5_livevar_analysis.bytecode
loop1_5_livevar_analysis_Loops__iter10_no_abort_baseline_cfg.dot
loop1_6_borrow_analysis.bytecode
loop1_6_borrow_analysis_Loops__iter10_no_abort_baseline_cfg.dot
loop1_7_memory_instr.bytecode
loop1_7_memory_instr_Loops__iter10_no_abort_baseline_cfg.dot
loop1_8_clean_and_optimize.bytecode
loop1_8_clean_and_optimize_Loops__iter10_no_abort_baseline_cfg.dot
loop1_9_usage_analysis.bytecode
loop1_9_usage_analysis_Loops__iter10_no_abort_baseline_cfg.dot

```

To render one dot file into pdf:
```
dot -Tpdf loop1_12_spec_instrumenter_Loops__iter10_no_abort_verification_cfg.dot -o cfg.pdf
```

The cfg.pdf looks like: [cfg.pdf](https://github.com/diem/diem/files/6132772/cfg.pdf)
