### PR TITLE
[State Sync] Ignore flaky tests and add a warning.

### DIFF
--- a/state-sync/tests/integration_tests.rs
+++ b/state-sync/tests/integration_tests.rs
@@ -476,7 +476,13 @@ fn test_fullnode_catch_up_moving_target() {
     }
 }
 
+// Unfortunately, this test contains race conditions that are inherent to the way
+// the integration tests are built. While flakes don't seem to occur locally
+// (or often), we've hit them at least once in CI, so let's ignore this for now and
+// return to fix it once this is higher priority.
+// Note: this test is still useful for verifying state sync behaviour.
 #[test]
+#[ignore]
 fn test_fn_failover() {
     let mut env = StateSyncEnvironment::new(5);
 
@@ -700,7 +706,13 @@ fn execute_commit_and_verify_chunk_requests(
     panic!("Unexpected code path in test helper! No chunk responses were sent?");
 }
 
+// Unfortunately, this test contains race conditions that are inherent to the way
+// the integration tests are built. While flakes don't seem to occur locally
+// (or often), we've hit them at least once in CI, so let's ignore this for now and
+// return to fix it once this is higher priority.
+// Note: this test is still useful for verifying state sync behaviour.
 #[test]
+#[ignore]
 fn test_multicast_failover() {
     let mut env = StateSyncEnvironment::new(5);
 


### PR DESCRIPTION
## Motivation

This PR adds two integration tests (back) to the ignore list for state sync: 
(i) `test_fn_failover` (which has failed only once in CI up to now, but I've yet to see any failures locally)
(i) `test_multicast_failover` (which hasn't failed yet in CI, but I suspect it too will flake at some point given that it's built very similarly to `test_fn_failover`)

The PR also adds a warning comment to the files to emphasize that the tests are still useful for verifying behaviour, so they shouldn't be removed. Perhaps, in the future we can update the state sync test harness to be more deterministic. But, for now, it's not high priority.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All (non-ignored) tests still pass.

## Related PRs

None.