### PR TITLE
[network] Connectivity Manager updates to support Client Server model

### DIFF
--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -131,6 +131,8 @@ impl NetworkBuilder {
         listen_address: NetworkAddress,
         authentication_mode: AuthenticationMode,
     ) -> NetworkBuilder {
+        let mutual_authentication = matches!(authentication_mode, AuthenticationMode::Mutual(_));
+
         let mut builder = NetworkBuilder::new(
             chain_id,
             trusted_peers.clone(),
@@ -155,6 +157,7 @@ impl NetworkBuilder {
             MAX_CONNECTION_DELAY_MS,
             CONNECTIVITY_CHECK_INTERVAL_MS,
             NETWORK_CHANNEL_SIZE,
+            mutual_authentication,
         );
 
         builder
@@ -250,6 +253,7 @@ impl NetworkBuilder {
                 config.max_connection_delay_ms,
                 config.connectivity_check_interval_ms,
                 config.network_channel_size,
+                config.mutual_authentication,
             );
         }
 
@@ -337,6 +341,7 @@ impl NetworkBuilder {
         max_connection_delay_ms: u64,
         connectivity_check_interval_ms: u64,
         channel_size: usize,
+        mutual_authentication: bool,
     ) -> &mut Self {
         let pm_conn_mgr_notifs_rx = self.add_connection_event_listener();
         let outbound_connection_limit = if !self.network_context.network_id().is_validator_network()
@@ -373,6 +378,7 @@ impl NetworkBuilder {
             ConnectionRequestSender::new(self.peer_manager_builder.connection_reqs_tx()),
             pm_conn_mgr_notifs_rx,
             outbound_connection_limit,
+            mutual_authentication,
         ));
         self
     }

--- a/network/src/connectivity_manager/builder.rs
+++ b/network/src/connectivity_manager/builder.rs
@@ -28,6 +28,7 @@ struct ConnectivityManagerBuilderConfig {
     connection_notifs_rx: conn_notifs_channel::Receiver,
     requests_rx: channel::Receiver<ConnectivityRequest>,
     outbound_connection_limit: Option<usize>,
+    mutual_authentication: bool,
 }
 
 #[derive(Debug, PartialEq, PartialOrd)]
@@ -57,6 +58,7 @@ impl ConnectivityManagerBuilder {
         connection_reqs_tx: ConnectionRequestSender,
         connection_notifs_rx: conn_notifs_channel::Receiver,
         outbound_connection_limit: Option<usize>,
+        mutual_authentication: bool,
     ) -> Self {
         let (conn_mgr_reqs_tx, conn_mgr_reqs_rx) = channel::new(
             channel_size,
@@ -75,6 +77,7 @@ impl ConnectivityManagerBuilder {
                 connection_notifs_rx,
                 requests_rx: conn_mgr_reqs_rx,
                 outbound_connection_limit,
+                mutual_authentication,
             }),
             connectivity_manager: None,
             conn_mgr_reqs_tx,
@@ -108,6 +111,7 @@ impl ConnectivityManagerBuilder {
                 ExponentialBackoff::from_millis(config.backoff_base).factor(1000),
                 Duration::from_millis(config.max_connection_delay_ms),
                 config.outbound_connection_limit,
+                config.mutual_authentication,
             )
         });
     }

--- a/network/src/connectivity_manager/test.rs
+++ b/network/src/connectivity_manager/test.rs
@@ -102,6 +102,7 @@ impl TestHarness {
             FixedInterval::new(CONNECTION_DELAY),
             MAX_CONNECTION_DELAY,
             Some(MAX_TEST_CONNECTIONS),
+            true, /* mutual_authentication */
         );
         let mock = Self {
             trusted_peers,

--- a/network/src/connectivity_manager/test.rs
+++ b/network/src/connectivity_manager/test.rs
@@ -155,7 +155,11 @@ impl TestHarness {
             "Sending NewPeer notification for peer: {}",
             peer_id.short_str()
         );
-        let mut metadata = ConnectionMetadata::mock(notif_peer_id);
+        let mut metadata = ConnectionMetadata::mock_with_role_and_origin(
+            notif_peer_id,
+            PeerRole::Unknown,
+            ConnectionOrigin::Outbound,
+        );
         metadata.addr = address;
         let notif = peer_manager::ConnectionNotification::NewPeer(metadata, NetworkContext::mock());
         self.send_notification_await_delivery(peer_id, notif).await;
@@ -166,7 +170,11 @@ impl TestHarness {
             "Sending LostPeer notification for peer: {}",
             peer_id.short_str()
         );
-        let mut metadata = ConnectionMetadata::mock(peer_id);
+        let mut metadata = ConnectionMetadata::mock_with_role_and_origin(
+            peer_id,
+            PeerRole::Unknown,
+            ConnectionOrigin::Outbound,
+        );
         metadata.addr = address;
         let notif = peer_manager::ConnectionNotification::LostPeer(
             metadata,


### PR DESCRIPTION
## Motivation

Connectivity manager is being added to public interfaces in a `maybe_mutual` mode.  This allows known peers on a public interface that also allows unknown peers.  This provides the ability to use the discovery functionality without constantly kicking out unknown peers (normal clients).  

Additionally, this adds a fix to the way that outbound connection limits are enforced.  The outbound connection limit currently doesn't conflict because we use a second public network interface for outbound connections in VFNs, and the connection limits are per network interface.