### PR TITLE
[network] Prioritize peer connections and Remove VFN 2nd public network interface

### DIFF
--- a/config/management/genesis/src/config_builder.rs
+++ b/config/management/genesis/src/config_builder.rs
@@ -4,8 +4,8 @@
 use crate::{layout::Layout, storage_helper::StorageHelper, swarm_config::BuildSwarm};
 use diem_config::{
     config::{
-        DiscoveryMethod, Identity, NodeConfig, OnDiskStorageConfig, PeerRole, SafetyRulesService,
-        SecureBackend, WaypointConfig,
+        Identity, NodeConfig, OnDiskStorageConfig, PeerRole, SafetyRulesService, SecureBackend,
+        WaypointConfig,
     },
     generator::build_seed_for_network,
     network_id::NetworkId,
@@ -280,9 +280,7 @@ impl FullnodeBuilder {
         let pfn = &mut full_node_config
             .full_node_networks
             .iter_mut()
-            .find(|n| {
-                n.network_id == NetworkId::Public && n.discovery_method != DiscoveryMethod::Onchain
-            })
+            .find(|n| n.network_id == NetworkId::Public)
             .expect("vfn missing external public network in config");
         let v_vfn = &mut validator_config.full_node_networks[0];
         pfn.identity = v_vfn.identity.clone();

--- a/config/management/genesis/src/config_builder.rs
+++ b/config/management/genesis/src/config_builder.rs
@@ -4,7 +4,7 @@
 use crate::{layout::Layout, storage_helper::StorageHelper, swarm_config::BuildSwarm};
 use diem_config::{
     config::{
-        DiscoveryMethod, Identity, NodeConfig, OnDiskStorageConfig, SafetyRulesService,
+        DiscoveryMethod, Identity, NodeConfig, OnDiskStorageConfig, PeerRole, SafetyRulesService,
         SecureBackend, WaypointConfig,
     },
     generator::build_seed_for_network,
@@ -292,7 +292,7 @@ impl FullnodeBuilder {
 
         // Now let's prepare the full nodes internal network to communicate with the validators
         // internal network
-        let seeds = build_seed_for_network(v_vfn);
+        let seeds = build_seed_for_network(v_vfn, PeerRole::Validator);
 
         let fn_vfn = &mut full_node_config
             .full_node_networks

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -371,8 +371,8 @@ pub type PeerSet = HashMap<PeerId, Peer>;
 pub enum PeerRole {
     Validator = 0,
     PreferredUpstream,
-    ValidatorFullNode,
     Upstream,
+    ValidatorFullNode,
     Downstream,
     Known,
     Unknown,

--- a/config/src/config/test_data/validator.yaml
+++ b/config/src/config/test_data/validator.yaml
@@ -20,6 +20,7 @@ execution:
 
 full_node_networks:
     - listen_address: "/ip4/0.0.0.0/tcp/7180"
+      max_outbound_connections: 0
       identity:
           type: "from_storage"
           key_name: "fullnode_network"

--- a/config/src/config/test_data/validator_full_node.yaml
+++ b/config/src/config/test_data/validator_full_node.yaml
@@ -14,6 +14,7 @@ execution:
 
 full_node_networks:
     - listen_address: "/ip4/0.0.0.0/tcp/6180"
+      discovery_method: "onchain"
       identity:
           type: "from_storage"
           key_name: "fullnode_network"
@@ -26,6 +27,7 @@ full_node_networks:
                   from_disk: "/full/path/to/token"
       network_id: "public"
     - listen_address: "/ip4/0.0.0.0/tcp/7180"
+      max_outbound_connections: 1
       network_id:
           private: "vfn"
       seeds:
@@ -34,9 +36,6 @@ full_node_networks:
             - "/ip4/127.0.0.1/tcp/58259/ln-noise-ik/c998dcd54c3daf48e0ad516d94b7be0b0b7a27caa00541f2b2c14b13500df10b/ln-handshake/0"
           keys: ["c998dcd54c3daf48e0ad516d94b7be0b0b7a27caa00541f2b2c14b13500df10b"]
           role: "Validator"
-    - discovery_method: "onchain"
-      listen_address: "/ip4/0.0.0.0/tcp/8180"
-      network_id: "public"
 
 upstream:
     networks:

--- a/config/src/generator.rs
+++ b/config/src/generator.rs
@@ -44,7 +44,7 @@ pub fn validator_swarm(
 
     // set the first validator as every validators' initial configured seed peer.
     let seed_config = &nodes[0].validator_network.as_ref().unwrap();
-    let seeds = build_seed_for_network(&seed_config);
+    let seeds = build_seed_for_network(&seed_config, PeerRole::Validator);
     for node in &mut nodes {
         let network = node.validator_network.as_mut().unwrap();
         network.seeds = seeds.clone();
@@ -64,18 +64,7 @@ pub fn validator_swarm_for_testing(nodes: usize) -> ValidatorSwarm {
 /// Convenience function that builds a `PeerSet` containing a single peer for testing
 /// with a fully formatted `NetworkAddress` containing its network identity pubkey
 /// and handshake protocol version.
-pub fn build_seed_for_network(seed_config: &NetworkConfig) -> PeerSet {
-    let seed_role = match &seed_config.network_id {
-        NetworkId::Validator => PeerRole::Validator,
-        network_id => {
-            if network_id.is_vfn_network() {
-                PeerRole::ValidatorFullNode
-            } else {
-                PeerRole::Upstream
-            }
-        }
-    };
-
+pub fn build_seed_for_network(seed_config: &NetworkConfig, seed_role: PeerRole) -> PeerSet {
     let seed_pubkey = diem_crypto::PrivateKey::public_key(&seed_config.identity_key());
     let seed_addr = seed_config
         .listen_address

--- a/config/src/network_id.rs
+++ b/config/src/network_id.rs
@@ -188,28 +188,10 @@ impl NetworkId {
         matches!(self, NetworkId::Validator)
     }
 
-    /// Roles for P2P relationships
-    pub fn p2p_roles(&self, role: &RoleType) -> &'static [PeerRole] {
-        match self {
-            NetworkId::Validator => &[PeerRole::Validator],
-            NetworkId::Public => &[],
-            NetworkId::Private(_) => {
-                if self.is_vfn_network() {
-                    match role {
-                        RoleType::Validator => &[],
-                        RoleType::FullNode => &[PeerRole::ValidatorFullNode],
-                    }
-                } else {
-                    &[]
-                }
-            }
-        }
-    }
-
     /// Roles for a prioritization of relative upstreams
     pub fn upstream_roles(&self, role: &RoleType) -> &'static [PeerRole] {
         match self {
-            NetworkId::Validator => &[],
+            NetworkId::Validator => &[PeerRole::Validator],
             NetworkId::Public => &[
                 PeerRole::PreferredUpstream,
                 PeerRole::Upstream,
@@ -219,7 +201,7 @@ impl NetworkId {
                 if self.is_vfn_network() {
                     match role {
                         RoleType::Validator => &[],
-                        RoleType::FullNode => &[PeerRole::Validator, PeerRole::ValidatorFullNode],
+                        RoleType::FullNode => &[PeerRole::Validator],
                     }
                 } else {
                     &[PeerRole::PreferredUpstream, PeerRole::Upstream]
@@ -231,11 +213,11 @@ impl NetworkId {
     /// Roles for a prioritization of relative downstreams
     pub fn downstream_roles(&self, role: &RoleType) -> &'static [PeerRole] {
         match self {
-            NetworkId::Validator => &[],
+            NetworkId::Validator => &[PeerRole::Validator],
             // In order to allow fallbacks, we must allow for nodes to accept ValidatorFullNodes
             NetworkId::Public => &[
-                PeerRole::Downstream,
                 PeerRole::ValidatorFullNode,
+                PeerRole::Downstream,
                 PeerRole::Known,
                 PeerRole::Unknown,
             ],
@@ -251,18 +233,6 @@ impl NetworkId {
                 }
             }
         }
-    }
-
-    pub fn is_p2p_role(&self, remote_peer_role: &PeerRole, role: &RoleType) -> bool {
-        self.p2p_roles(role).contains(remote_peer_role)
-    }
-
-    pub fn is_upstream_role(&self, remote_peer_role: &PeerRole, role: &RoleType) -> bool {
-        self.upstream_roles(role).contains(remote_peer_role)
-    }
-
-    pub fn is_downstream_role(&self, remote_peer_role: &PeerRole, role: &RoleType) -> bool {
-        self.downstream_roles(role).contains(remote_peer_role)
     }
 
     pub fn as_str(&self) -> &str {


### PR DESCRIPTION
## Motivation

Having a 2nd public network interfaces causes tons of confusion, as well as makes it hard to keep track of the number of connections to individual nodes.  This removes it, and allows us to run a single network interface for known and unknown connections and simplifies this confusion.

Additionally, this prioritizes connections to other peers, now that there is only one connectivity manager due to there only being one public interface.


Currently builds upon https://github.com/diem/diem/pull/7925