### PR TITLE
[benchmark] add cpu time measurement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,6 +1201,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion-cpu-time"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63aaaf47e457badbcb376c65a49d0f182c317ebd97dc6d1ced94c8e1d09c0f3a"
+dependencies = [
+ "criterion",
+ "libc",
+]
+
+[[package]]
 name = "criterion-plot"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3938,6 +3948,7 @@ dependencies = [
  "anyhow",
  "bytecode-verifier",
  "criterion",
+ "criterion-cpu-time",
  "diem-proptest-helpers",
  "diem-state-view",
  "diem-types",

--- a/language/benchmarks/Cargo.toml
+++ b/language/benchmarks/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0.38"
 criterion = "0.3.4"
 once_cell = "1.7.2"
 proptest = "1.0.0"
+criterion-cpu-time = "0.1.0"
 
 bytecode-verifier = { path = "../bytecode-verifier" }
 language-e2e-tests = { path = "../testing-infra/e2e-tests" }

--- a/language/benchmarks/benches/transaction_benches.rs
+++ b/language/benchmarks/benches/transaction_benches.rs
@@ -1,8 +1,8 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use criterion::{criterion_group, criterion_main, Criterion};
-use language_benchmarks::transactions::TransactionBencher;
+use criterion::{criterion_group, criterion_main, measurement::Measurement, Criterion};
+use language_benchmarks::{measurement::cpu_time_measurement, transactions::TransactionBencher};
 use language_e2e_tests::account_universe::P2PTransferGen;
 use proptest::prelude::*;
 
@@ -10,13 +10,17 @@ use proptest::prelude::*;
 // Transaction benchmarks
 //
 
-fn peer_to_peer(c: &mut Criterion) {
+fn peer_to_peer<M: Measurement + 'static>(c: &mut Criterion<M>) {
     c.bench_function("peer_to_peer", |b| {
         let bencher = TransactionBencher::new(any_with::<P2PTransferGen>((1_000, 1_000_000)));
         bencher.bench(b)
     });
 }
 
-criterion_group!(txn_benches, peer_to_peer);
+criterion_group!(
+    name = txn_benches;
+    config = cpu_time_measurement();
+    targets = peer_to_peer
+);
 
 criterion_main!(txn_benches);

--- a/language/benchmarks/benches/vm_benches.rs
+++ b/language/benchmarks/benches/vm_benches.rs
@@ -1,25 +1,31 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use criterion::{criterion_group, criterion_main, Criterion};
-use language_benchmarks::move_vm::bench;
+use criterion::{criterion_group, criterion_main, measurement::Measurement, Criterion};
+use language_benchmarks::{measurement::cpu_time_measurement, move_vm::bench};
 
 //
 // MoveVM benchmarks
 //
 
-fn arith(c: &mut Criterion) {
+fn arith<M: Measurement + 'static>(c: &mut Criterion<M>) {
     bench(c, "arith");
 }
 
-fn call(c: &mut Criterion) {
+fn call<M: Measurement + 'static>(c: &mut Criterion<M>) {
     bench(c, "call");
 }
 
-fn natives(c: &mut Criterion) {
+fn natives<M: Measurement + 'static>(c: &mut Criterion<M>) {
     bench(c, "natives");
 }
 
-criterion_group!(vm_benches, arith, call, natives);
+criterion_group!(
+    name = vm_benches;
+    config = cpu_time_measurement();
+    targets = arith,
+    call,
+    natives
+);
 
 criterion_main!(vm_benches);

--- a/language/benchmarks/src/lib.rs
+++ b/language/benchmarks/src/lib.rs
@@ -3,5 +3,6 @@
 
 #![forbid(unsafe_code)]
 
+pub mod measurement;
 pub mod move_vm;
 pub mod transactions;

--- a/language/benchmarks/src/measurement.rs
+++ b/language/benchmarks/src/measurement.rs
@@ -1,0 +1,13 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use criterion::Criterion;
+use criterion_cpu_time::PosixTime;
+
+pub fn cpu_time_measurement() -> Criterion<PosixTime> {
+    Criterion::default().with_measurement(PosixTime::UserAndSystemTime)
+}
+
+pub fn wall_time_measurement() -> Criterion {
+    Criterion::default()
+}

--- a/language/benchmarks/src/move_vm.rs
+++ b/language/benchmarks/src/move_vm.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use criterion::Criterion;
+use criterion::{measurement::Measurement, Criterion};
 use diem_state_view::StateView;
 use diem_types::{access_path::AccessPath, account_address::AccountAddress};
 use diem_vm::data_cache::StateViewCache;
@@ -34,7 +34,7 @@ static STDLIB_VECTOR_SRC_PATH: Lazy<PathBuf> = Lazy::new(|| {
 });
 
 /// Entry point for the bench, provide a function name to invoke in Module Bench in bench.move.
-pub fn bench(c: &mut Criterion, fun: &str) {
+pub fn bench<M: Measurement + 'static>(c: &mut Criterion<M>, fun: &str) {
     let modules = compile_modules();
     let move_vm = MoveVM::new();
     execute(c, &move_vm, modules, fun);
@@ -63,7 +63,12 @@ fn compile_modules() -> Vec<CompiledModule> {
 }
 
 // execute a given function in the Bench module
-fn execute(c: &mut Criterion, move_vm: &MoveVM, modules: Vec<CompiledModule>, fun: &str) {
+fn execute<M: Measurement + 'static>(
+    c: &mut Criterion<M>,
+    move_vm: &MoveVM,
+    modules: Vec<CompiledModule>,
+    fun: &str,
+) {
     // establish running context
     let sender = AccountAddress::new(Address::DIEM_CORE.to_u8());
     let state = EmptyStateView;

--- a/language/benchmarks/src/transactions.rs
+++ b/language/benchmarks/src/transactions.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use criterion::{BatchSize, Bencher};
+use criterion::{measurement::Measurement, BatchSize, Bencher};
 use diem_proptest_helpers::ValueGenerator;
 use diem_types::transaction::SignedTransaction;
 use language_e2e_tests::{
@@ -52,7 +52,7 @@ where
     }
 
     /// Runs the bencher.
-    pub fn bench(&self, b: &mut Bencher) {
+    pub fn bench<M: Measurement>(&self, b: &mut Bencher<M>) {
         b.iter_batched(
             || {
                 TransactionBenchState::with_size(


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

use cpu-time instead of wall-time, hopefully get more stable measurement.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

run bench

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
