### PR TITLE
[gha] e2e should use the crates cache.

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -66,7 +66,7 @@ jobs:
         name: find changes that should trigger docker compose testing.
         uses: ./.github/actions/matches
         with:
-          pattern: '^documentation'
+          pattern: "^documentation"
           invert: "true"
       - id: website-changes
         name: find website changes.
@@ -277,6 +277,11 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: ./.github/actions/build-setup
+      - uses: actions/cache@v2.1.4
+        with:
+          path: "/opt/cargo/git\n/opt/cargo/registry\n/opt/cargo/.package-cache"
+          key: crates-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: "crates-${{ runner.os }}"
       - name: split tests
         run: |
           cd /opt/git/diem/


### PR DESCRIPTION
## Motivation

e2e should use the crates cache to prevent build problems and build more quickly

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

CI

## Related PRs

None

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
