### PR TITLE
[backup] metadata cache defaults to temp dir

### DIFF
--- a/storage/backup/backup-cli/Cargo.toml
+++ b/storage/backup/backup-cli/Cargo.toml
@@ -40,6 +40,7 @@ diem-crypto = { path = "../../../crypto/crypto" }
 diem-infallible = { path = "../../../common/infallible" }
 diem-logger = { path = "../../../common/logger" }
 diem-secure-push-metrics = { path = "../../../secure/push-metrics" }
+diem-temppath = { path = "../../../common/temppath" }
 diem-types = { path = "../../../types" }
 diem-vm = { path = "../../../language/diem-vm" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
@@ -55,7 +56,6 @@ executor-test-helpers = { path = "../../../execution/executor-test-helpers" }
 diemdb = { path = "../../diemdb", features = ["fuzzing"] }
 diem-config = { path = "../../../config" }
 diem-proptest-helpers = { path = "../../../common/proptest-helpers" }
-diem-temppath = { path = "../../../common/temppath" }
 storage-interface = { path = "../../storage-interface" }
 
 [features]


### PR DESCRIPTION
## Motivation

When not specified explicitly, it's probably people playing around on their own machine, and the cache conflicts with different backups, which confuses people.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
Y
## Test Plan

locally.

