### PR TITLE
[move-lang-functional-tests] Reduce test time by another 70%

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4323,6 +4323,7 @@ dependencies = [
  "diem-workspace-hack",
  "functional-tests",
  "move-lang",
+ "once_cell",
  "tempfile",
 ]
 

--- a/language/move-lang/functional-tests/Cargo.toml
+++ b/language/move-lang/functional-tests/Cargo.toml
@@ -14,6 +14,7 @@ diem-workspace-hack = { path = "../../../common/workspace-hack" }
 [dev-dependencies]
 anyhow = "1.0.38"
 tempfile = "3.2.0"
+once_cell = "1.7.2"
 
 datatest-stable = { path = "../../../common/datatest-stable" }
 functional-tests = { path = "../../testing-infra/functional-tests" }

--- a/language/move-lang/src/lib.rs
+++ b/language/move-lang/src/lib.rs
@@ -81,6 +81,7 @@ pub enum PassResult {
     Compilation(Vec<CompiledUnit>),
 }
 
+#[derive(Clone)]
 pub struct FullyCompiledProgram {
     pub parser: (Option<Address>, parser::ast::Program),
     pub expansion: expansion::ast::Program,


### PR DESCRIPTION
- Saved stdlib in a lazy-static as suggested by @vgao1996
- Total reduction is about 80 to 90% of the original test time.

## Motivation

- Faster tests are good

## Test Plan

- Ran em. Clocked em. 