### PR TITLE
[move-prover] prepare the loop analysis pass for loop-to-dag transformation

### DIFF
--- a/language/move-model/src/ast.rs
+++ b/language/move-model/src/ast.rs
@@ -129,7 +129,7 @@ impl ConditionKind {
     /// Returns true if this condition is allowed in a function body.
     pub fn allowed_on_fun_impl(&self) -> bool {
         use ConditionKind::*;
-        matches!(self, Assert | Assume | Decreases)
+        matches!(self, Assert | Assume | Decreases | Invariant)
     }
 
     /// Returns true if this condition is allowed on a struct.

--- a/language/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/language/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -548,6 +548,10 @@ impl<'env> ModuleTranslator<'env> {
                     self.spec_translator.translate_unboxed(&exp.call_args()[0]);
                     emitln!(self.writer, ");");
                 }
+                PropKind::Invariant => panic!(
+                    "propositions of the invariant kind should have been eliminated by the \
+                    loop analysis pass"
+                ),
             },
             Label(_, label) => {
                 self.writer.unindent();

--- a/language/move-prover/bytecode/src/stackless_bytecode.rs
+++ b/language/move-prover/bytecode/src/stackless_bytecode.rs
@@ -255,6 +255,7 @@ pub enum BorrowEdge {
 pub enum PropKind {
     Assert,
     Assume,
+    Invariant,
     Modifies,
 }
 
@@ -661,6 +662,7 @@ impl<'env> fmt::Display for BytecodeDisplay<'env> {
                 match kind {
                     PropKind::Assume => write!(f, "assume {}", exp_display)?,
                     PropKind::Assert => write!(f, "assert {}", exp_display)?,
+                    PropKind::Invariant => write!(f, "invariant {}", exp_display)?,
                     PropKind::Modifies => write!(f, "modifies {}", exp_display)?,
                 }
             }

--- a/language/move-prover/bytecode/src/stackless_bytecode_generator.rs
+++ b/language/move-prover/bytecode/src/stackless_bytecode_generator.rs
@@ -151,6 +151,7 @@ impl<'a> StacklessBytecodeGenerator<'a> {
                 let kind = match cond.kind {
                     ConditionKind::Assert => PropKind::Assert,
                     ConditionKind::Assume => PropKind::Assume,
+                    ConditionKind::Invariant => PropKind::Invariant,
                     _ => panic!("unsupported spec condition in code"),
                 };
                 self.code

--- a/language/move-prover/tests/sources/functional/loops.move
+++ b/language/move-prover/tests/sources/functional/loops.move
@@ -32,7 +32,7 @@ module VerifyLoops {
     public fun iter10_no_abort() {
         let i = 0;
         while ({
-            spec { assert i <= 11; };
+            spec { invariant i <= 11; };
             (i <= 10)
         }) {
             if (i > 10) abort 10;
@@ -47,7 +47,7 @@ module VerifyLoops {
     public fun iter10_no_abort_incorrect() {
         let i = 0;
         while ({
-            spec { assert i <= 11; };
+            spec { invariant i <= 11; };
             (i <= 10)
         }) {
             if (i > 10) abort 10;
@@ -61,7 +61,7 @@ module VerifyLoops {
     public fun iter10_abort() {
         let i = 0;
         while ({
-            spec { assert i <= 7; };
+            spec { invariant i <= 7; };
             (i <= 10)
         }) {
             if (i == 7) abort 7;
@@ -76,7 +76,7 @@ module VerifyLoops {
     public fun iter10_abort_incorrect() {
         let i = 0;
         while ({
-            spec { assert i <= 7; };
+            spec { invariant i <= 7; };
             (i <= 10)
         }) {
             if (i == 7) abort 7;


### PR DESCRIPTION
This is a preparation PR that makes the loop-to-DAG transformation easier. It does two things (in two separate commits)

1. encapsulate loop info in a `NaturalLoop` struct with loop header, latch, and body information.
  - This is mostly a clean-up commit. The `compute_reducible()` function now returns a vector of `NaturalLoop` which encapsulates the information on `loop_header`, `loop_body`, and the `loop_latch` (latch -> header is the backedge).
  - It also brings the following checks explicit (i.e., the prover panics)
    - if the control-flow graph is not reducible
    - if the loop header block is a dummy block or the first bytecode in the header block is not a label
    - if two loops share the same header

2. use `invariant` instead of `assert` to mark loop invariant in spec block

- We need a special mark for loop invariant propositions because those will be translated to both `asserts` and `assume`s (under the loop-to-DAG pass). To prepare for this transition, this commit additionally allows `invariant <exp>` to be specified in a spec block in function code but transforms the `invariant <exp>` into an `assert <exp>` in the loop analysis pass.

## Motivation

Prepare for the loop-to-DAG pass

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

`cargo xtest`

