### PR TITLE
[move-prover] Ensure that Signer and Vector are always processed first by ModelBuilder

### DIFF
--- a/language/move-model/src/lib.rs
+++ b/language/move-model/src/lib.rs
@@ -167,7 +167,14 @@ fn add_move_lang_errors(env: &mut GlobalEnv, errors: Errors) {
 }
 
 #[allow(deprecated)]
-fn run_spec_checker(env: &mut GlobalEnv, units: Vec<CompiledUnit>, mut eprog: Program) {
+fn run_spec_checker(env: &mut GlobalEnv, mut units: Vec<CompiledUnit>, mut eprog: Program) {
+    // Ensure that modules with builtin types are at front.
+    // TODO: this is a workaround for that the compiler does not longer ensures they are
+    //   dep-sorted if only the builtin types presented by those modules are used. We need
+    //   a full dep analysis instead which considers both spec and move lang constructs;
+    //   CompiledUnit is only sorted w.r.t. move-lang constructs.
+    move_to_front("00000000000000000000000000000001::Vector", &mut units);
+    move_to_front("00000000000000000000000000000001::Signer", &mut units);
     let mut builder = ModelBuilder::new(env);
     // Merge the compiled units with the expanded program, preserving the order of the compiled
     // units which is topological w.r.t. use relation.
@@ -263,6 +270,19 @@ fn run_spec_checker(env: &mut GlobalEnv, units: Vec<CompiledUnit>, mut eprog: Pr
     }
     // After all specs have been processed, warn about any unused schemas.
     builder.warn_unused_schemas();
+}
+
+fn move_to_front(name: &str, units: &mut Vec<CompiledUnit>) {
+    if let Some(i) = units.iter().position(|u| {
+        if let CompiledUnit::Module { module, .. } = u {
+            module.self_id().to_string().as_str() == name
+        } else {
+            false
+        }
+    }) {
+        let unit = units.remove(i);
+        units.insert(0, unit);
+    }
 }
 
 // =================================================================================================

--- a/language/move-prover/bytecode/tests/from_move/regression_generic_and_native_type.exp
+++ b/language/move-prover/bytecode/tests/from_move/regression_generic_and_native_type.exp
@@ -1,6 +1,18 @@
 ============ initial translation from Move ================
 
 [variant baseline]
+public fun Signer::address_of($t0|s: &signer): address {
+     var $t1: &signer
+     var $t2: &address
+     var $t3: address
+  0: $t1 := move($t0)
+  1: $t2 := Signer::borrow_address($t1)
+  2: $t3 := read_ref($t2)
+  3: return $t3
+}
+
+
+[variant baseline]
 public fun Vector::append<$tv0>($t0|lhs: &mut vector<#0>, $t1|other: vector<#0>) {
      var $t2: &mut vector<#0>
      var $t3: &vector<#0>
@@ -392,18 +404,6 @@ public fun Vector::swap_remove<$tv0>($t0|v: &mut vector<#0>, $t1|i: u64): #0 {
  10: $t11 := move($t0)
  11: $t12 := Vector::pop_back<#0>($t11)
  12: return $t12
-}
-
-
-[variant baseline]
-public fun Signer::address_of($t0|s: &signer): address {
-     var $t1: &signer
-     var $t2: &address
-     var $t3: address
-  0: $t1 := move($t0)
-  1: $t2 := Signer::borrow_address($t1)
-  2: $t3 := read_ref($t2)
-  3: return $t3
 }
 
 

--- a/language/move-prover/tests/testsuite.rs
+++ b/language/move-prover/tests/testsuite.rs
@@ -227,11 +227,12 @@ fn cvc4_deny_listed(path: &Path) -> bool {
 fn get_flags(temp_dir: &Path, path: &Path) -> anyhow::Result<(Vec<String>, Option<PathBuf>)> {
     // Determine the way how to configure tests based on directory of the path.
     let path_str = path.to_string_lossy();
-    let (base_flags, baseline_path, modifier) = if path_str.contains("diem-framework/") {
-        (STDLIB_FLAGS, None, "std_")
-    } else {
-        (STDLIB_FLAGS, Some(path.with_extension("exp")), "prover_")
-    };
+    let (base_flags, baseline_path, modifier) =
+        if path_str.contains("diem-framework/") || path_str.contains("move-stdlib/") {
+            (STDLIB_FLAGS, None, "std_")
+        } else {
+            (STDLIB_FLAGS, Some(path.with_extension("exp")), "prover_")
+        };
     let mut flags = base_flags.iter().map(|s| (*s).to_string()).collect_vec();
     // Add any flags specified in the source.
     flags.extend(extract_test_directives(path, "// flag:")?);
@@ -264,6 +265,12 @@ fn main() {
             test_runner,
             "functional".to_string(),
             "tests/sources".to_string(),
+            r".*\.move$".to_string(),
+        ));
+        reqs.push(Requirements::new(
+            test_runner,
+            "fx".to_string(),
+            "../move-stdlib".to_string(),
             r".*\.move$".to_string(),
         ));
         reqs.push(Requirements::new(


### PR DESCRIPTION
This is a workaround for addressing an issue with dependency sorting of modules. A better fix should be done later (see TODO).

The PR also re-activates verification tests for move-stdlib which had been dropped as those modules had been moved out of diem-framework.

## Motivation

Unblock work for release.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests.

## Related PRs

NA

## If targeting a release branch, please fill the below out as well

NA