### PR TITLE
[x] add determinator rules for move-prover

### DIFF
--- a/x.toml
+++ b/x.toml
@@ -356,6 +356,11 @@ globs = ["language/diem-framework/compiled/transaction_scripts/abi/**/*"]
 mark-changed = ["transaction-builder-generator"]
 post-rule = "skip-rules"
 
+[[determinator.path-rule]]
+# On changes of diem-framework or move-stdlib, rerun the tests in move-prover.
+globs = ["language/diem-framework/**/*", "language/move-stdlib/**/*"]
+mark-changed = ["move-prover"]
+
 [[determinator.package-rule]]
 # x controls the build process, so if it changes, build everything.
 on-affected = ["x"]


### PR DESCRIPTION
Whenever changes in diem-framework or move-stdlib are found, rerun the
tests in the move-prover.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

`testsuite.rs` under the `move-prover` crate grabs files outside its crate for datatests AND `move-prover` do not depends on those crates. This commit ensures that whenever the files it grabs changes, the tests are run.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI
