### PR TITLE
 [move-lang] Move dependency ordering to expansion. Added specs to dependency ordering calculation

### DIFF
--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -46,6 +46,9 @@ pub struct Script {
 pub struct ModuleDefinition {
     pub loc: Loc,
     pub is_source_module: bool,
+    /// `dependency_order` is the topological order/rank in the dependency graph.
+    /// `dependency_order` is initialized at `0` and set in the uses pass
+    pub dependency_order: usize,
     pub friends: UniqueMap<ModuleIdent, Loc>,
     pub structs: UniqueMap<StructName, StructDefinition>,
     pub functions: UniqueMap<FunctionName, Function>,
@@ -563,6 +566,7 @@ impl AstDebug for ModuleDefinition {
         let ModuleDefinition {
             loc: _loc,
             is_source_module,
+            dependency_order,
             friends,
             structs,
             functions,
@@ -574,6 +578,7 @@ impl AstDebug for ModuleDefinition {
         } else {
             "library module"
         });
+        w.writeln(&format!("dependency order #{}", dependency_order));
         for (mident, _loc) in friends.key_cloned_iter() {
             w.write(&format!("friend {};", mident));
             w.new_line();

--- a/language/move-lang/src/expansion/mod.rs
+++ b/language/move-lang/src/expansion/mod.rs
@@ -4,5 +4,6 @@
 mod aliases;
 pub mod ast;
 mod byte_string;
+mod dependency_ordering;
 mod hex_string;
 pub(crate) mod translate;

--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -206,6 +206,8 @@ pub fn program(
         }
         keyed
     };
+
+    super::dependency_ordering::verify(&mut context.errors, &mut module_map);
     let prog = E::Program {
         modules: module_map,
         scripts,
@@ -303,6 +305,7 @@ fn module_(context: &mut Context, mdef: P::ModuleDefinition) -> (ModuleIdent, E:
     let def = E::ModuleDefinition {
         loc,
         is_source_module: context.is_source_module,
+        dependency_order: 0,
         friends,
         structs,
         constants,

--- a/language/move-lang/src/naming/mod.rs
+++ b/language/move-lang/src/naming/mod.rs
@@ -3,4 +3,3 @@
 
 pub mod ast;
 pub(crate) mod translate;
-mod uses;

--- a/language/move-lang/src/naming/translate.rs
+++ b/language/move-lang/src/naming/translate.rs
@@ -339,9 +339,8 @@ pub fn program(
         modules: emodules,
         scripts: escripts,
     } = prog;
-    let mut modules = modules(&mut context, emodules);
+    let modules = modules(&mut context, emodules);
     let scripts = scripts(&mut context, escripts);
-    super::uses::verify(&mut context.errors, &mut modules);
     (N::Program { modules, scripts }, context.get_errors())
 }
 
@@ -378,7 +377,7 @@ fn module(
     context.restore_unscoped(unscoped);
     N::ModuleDefinition {
         is_source_module,
-        dependency_order: 0,
+        dependency_order: mdef.dependency_order,
         friends,
         structs,
         functions,

--- a/language/move-lang/tests/move_check/dependencies/use_cycle_2.exp
+++ b/language/move-lang/tests/move_check/dependencies/use_cycle_2.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/dependencies/use_cycle_2.move:5:9 ───
    │
  5 │         0x2::B::foo()
-   │         ^^^^^^^^^^^^^ Invalid use of module '0x2::B' in module '0x2::A'.
+   │         ^^^^^^^^^^^ Invalid use of module '0x2::B' in module '0x2::A'.
    ·
  5 │         0x2::B::foo()
-   │         ------------- Using this module creates a dependency cycle: '0x2::B' uses '0x2::A' uses '0x2::B'
+   │         ----------- Using this module creates a dependency cycle: '0x2::B' uses '0x2::A' uses '0x2::B'
    │
 

--- a/language/move-lang/tests/move_check/dependencies/use_friend_direct.exp
+++ b/language/move-lang/tests/move_check/dependencies/use_friend_direct.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/dependencies/use_friend_direct.move:8:9 ───
    │
  8 │         B::b()
-   │         ^^^^^^ Invalid use of module '0x2::B' in module '0x2::A'.
+   │         ^^^^ Invalid use of module '0x2::B' in module '0x2::A'.
    ·
  8 │         B::b()
-   │         ------ Using this module creates a dependency cycle: '0x2::B' is a friend of '0x2::A' uses '0x2::B'
+   │         ---- Using this module creates a dependency cycle: '0x2::B' is a friend of '0x2::A' uses '0x2::B'
    │
 

--- a/language/move-lang/tests/move_check/dependencies/use_friend_transitive_by_use.exp
+++ b/language/move-lang/tests/move_check/dependencies/use_friend_transitive_by_use.exp
@@ -3,9 +3,9 @@ error:
     ┌── tests/move_check/dependencies/use_friend_transitive_by_use.move:16:9 ───
     │
  16 │         C::c()
-    │         ^^^^^^ Invalid use of module '0x2::C' in module '0x2::B'.
+    │         ^^^^ Invalid use of module '0x2::C' in module '0x2::B'.
     ·
  16 │         C::c()
-    │         ------ Using this module creates a dependency cycle: '0x2::C' is a friend of '0x2::A' uses '0x2::B' uses '0x2::C'
+    │         ---- Using this module creates a dependency cycle: '0x2::C' is a friend of '0x2::A' uses '0x2::B' uses '0x2::C'
     │
 

--- a/language/move-model/src/lib.rs
+++ b/language/move-model/src/lib.rs
@@ -237,6 +237,7 @@ fn run_spec_checker(env: &mut GlobalEnv, mut units: Vec<CompiledUnit>, mut eprog
                     functions.add(function_name, function).unwrap();
                     let expanded_module = ModuleDefinition {
                         loc,
+                        dependency_order: usize::MAX,
                         is_source_module: true,
                         friends: UniqueMap::new(),
                         structs: UniqueMap::new(),


### PR DESCRIPTION
- This pass was in Naming due to old algorithms before module member 'uses'
- Moving to expansion allowed for the inclusion of specs and spec blocks in dep ordering

## Motivation

- Missing functionality needed for the Move prover

## Test Plan

- Ran existing tests
- Punted on new tests to unblock prover quickly
