### PR TITLE
[Configs] Remove UpstreamConfig.

### DIFF
--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -81,8 +81,6 @@ pub struct NodeConfig {
     #[serde(default)]
     pub test: Option<TestConfig>,
     #[serde(default)]
-    pub upstream: UpstreamConfig,
-    #[serde(default)]
     pub validator_network: Option<NetworkConfig>,
     #[serde(default)]
     pub failpoints: Option<HashMap<String, String>>,

--- a/config/src/config/test_data/public_full_node.yaml
+++ b/config/src/config/test_data/public_full_node.yaml
@@ -24,9 +24,3 @@ json_rpc:
     # This specifies your JSON-RPC endpoint. This runs locally to prevent remote queries, setting
     # it to 0.0.0.0:8080 would open it to all remote connections that can connect to that computer.
     address: 127.0.0.1:8080
-
-# Do not modify this value as it dictates upstream peers, those which receive outgoing transactions
-# and funnel downward the latest blockchain state.
-upstream:
-    networks:
-      - public

--- a/config/src/config/test_data/validator_full_node.yaml
+++ b/config/src/config/test_data/validator_full_node.yaml
@@ -36,8 +36,3 @@ full_node_networks:
             - "/ip4/127.0.0.1/tcp/58259/ln-noise-ik/c998dcd54c3daf48e0ad516d94b7be0b0b7a27caa00541f2b2c14b13500df10b/ln-handshake/0"
           keys: ["c998dcd54c3daf48e0ad516d94b7be0b0b7a27caa00541f2b2c14b13500df10b"]
           role: "Validator"
-
-upstream:
-    networks:
-        - private: vfn
-        - public

--- a/config/src/config/upstream_config.rs
+++ b/config/src/config/upstream_config.rs
@@ -7,44 +7,6 @@ use serde::{Deserialize, Serialize};
 use short_hex_str::AsShortHexStr;
 use std::fmt;
 
-/// If a node considers a network 'upstream', the node will broadcast transactions (via mempool) to and
-/// send sync requests (via state sync) to all its peers in this network.
-/// For validators, it is unnecessary to declare their validator network as their upstream network in this config
-/// Otherwise, any non-validator network not declared here will be treated as a downstream
-/// network (i.e. transactions will not be broadcast to and sync requests will not be sent to such networks)
-#[derive(Clone, Default, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default, deny_unknown_fields)]
-pub struct UpstreamConfig {
-    // list of upstream networks for this node, ordered by preference
-    // A validator's primary upstream network is their validator network, and for a FN,
-    // it is the first network defined here. If the primary upstream network goes down, the node will fall back to the networks
-    // specified here, in this order
-    pub networks: Vec<NetworkId>,
-}
-
-impl UpstreamConfig {
-    /// Returns the upstream network preference of a network according to this config
-    /// if network is not an upstream network, returns `None`
-    /// else, returns `Some<ranking>`, where `ranking` is zero-indexed and zero represents the highest preference
-    pub fn get_upstream_preference(&self, network: NetworkId) -> Option<usize> {
-        if network == NetworkId::Validator {
-            // validator network is always highest priority
-            Some(0)
-        } else {
-            self.networks
-                .iter()
-                .position(|upstream_network| upstream_network == &network)
-        }
-    }
-
-    /// Returns the number of upstream networks possible for a node with this config
-    pub fn upstream_count(&self) -> usize {
-        // `self.networks.len()` is not enough because for validators, this is empty
-        // but their unspecified validator network is considered upstream by default
-        std::cmp::max(1, self.networks.len())
-    }
-}
-
 #[derive(Clone, Deserialize, Eq, Hash, PartialEq, Serialize)]
 /// Identifier of a node, represented as (network_id, peer_id)
 pub struct PeerNetworkId(pub NodeNetworkId, pub PeerId);

--- a/docker/compose/public_full_node/public_full_node.yaml
+++ b/docker/compose/public_full_node/public_full_node.yaml
@@ -29,9 +29,3 @@ full_node_networks:
 json_rpc:
     # This specifies your JSON-RPC endpoint. Intentionally on public so that Docker can export it.
     address: 0.0.0.0:8080
-
-# Do not modify this value as it dictates upstream peers, those which receive outgoing transactions
-# and funnel downward the latest blockchain state.
-upstream:
-    networks:
-        - public

--- a/helm/fullnode/files/fullnode.yaml
+++ b/helm/fullnode/files/fullnode.yaml
@@ -12,10 +12,6 @@ full_node_networks:
   seeds:
     {{- (get .Values.diem_chains .Values.chain.name).seeds | default dict | toYaml | nindent 6 }}
 
-upstream:
-  networks:
-  - public
-
 metrics:
   enabled: false
 

--- a/mempool/src/counters.rs
+++ b/mempool/src/counters.rs
@@ -412,8 +412,6 @@ pub static DB_ERROR: Lazy<IntCounter> = Lazy::new(|| {
 
 /// Gauge for the preference ranking of the current chosen upstream network
 /// to broadcast to
-/// See `UpstreamConfig::get_upstream_preference` for details on the numerical value of the preference
-/// ranking of a network
 static UPSTREAM_NETWORK: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
         "diem_mempool_upstream_network",

--- a/state-sync/tests/integration_tests.rs
+++ b/state-sync/tests/integration_tests.rs
@@ -53,14 +53,7 @@ fn test_flaky_peer_sync() {
             Ok(resp)
         }
     });
-    env.start_state_sync_peer(
-        1,
-        handler,
-        RoleType::Validator,
-        Waypoint::default(),
-        false,
-        None,
-    );
+    env.start_state_sync_peer(1, handler, RoleType::Validator, Waypoint::default(), false);
 
     let validator_0 = env.get_state_sync_peer(0);
     let validator_1 = env.get_state_sync_peer(1);
@@ -82,14 +75,7 @@ fn test_request_timeout() {
     let handler = Box::new(move |_| -> Result<TransactionListWithProof, Error> {
         Err(Error::UnexpectedError("Failed to fetch chunk!".into()))
     });
-    env.start_state_sync_peer(
-        0,
-        handler,
-        RoleType::Validator,
-        Waypoint::default(),
-        false,
-        None,
-    );
+    env.start_state_sync_peer(0, handler, RoleType::Validator, Waypoint::default(), false);
     env.setup_state_sync_peer(
         1,
         default_handler(),
@@ -98,7 +84,6 @@ fn test_request_timeout() {
         100,
         300,
         false,
-        None,
     );
 
     let validator_0 = env.get_state_sync_peer(0);
@@ -227,14 +212,7 @@ fn catch_up_with_waypoints() {
     let waypoint = Waypoint::new_epoch_boundary(waypoint_li.ledger_info()).unwrap();
     drop(validator_0);
 
-    env.start_state_sync_peer(
-        1,
-        default_handler(),
-        RoleType::FullNode,
-        waypoint,
-        false,
-        None,
-    );
+    env.start_state_sync_peer(1, default_handler(), RoleType::FullNode, waypoint, false);
     let fullnode = env.get_state_sync_peer(1);
     fullnode.wait_until_initialized();
     assert!(fullnode.latest_li().ledger_info().version() >= 3500);
@@ -267,7 +245,6 @@ fn test_lagging_upstream_long_poll() {
         10_000,
         1_000_000,
         true,
-        Some(vec![VFN_NETWORK.clone(), PFN_NETWORK.clone()]),
     );
     env.start_state_sync_peer(
         3,
@@ -275,7 +252,6 @@ fn test_lagging_upstream_long_poll() {
         RoleType::FullNode,
         Waypoint::default(),
         true,
-        Some(vec![VFN_NETWORK.clone()]),
     );
 
     let validator_0 = env.get_state_sync_peer(0);
@@ -498,7 +474,6 @@ fn test_fn_failover() {
         1_000,
         60_000,
         true,
-        Some(vec![VFN_NETWORK.clone(), PFN_NETWORK.clone()]),
     );
 
     // Start up 3 PFNs
@@ -729,11 +704,6 @@ fn test_multicast_failover() {
         1_000,
         multicast_timeout_ms,
         true,
-        Some(vec![
-            VFN_NETWORK.clone(),
-            VFN_NETWORK_2.clone(),
-            PFN_NETWORK.clone(),
-        ]),
     );
 
     // Start up 3 FNs

--- a/testsuite/cluster-test/src/cluster_swarm/configs/fullnode.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/configs/fullnode.yaml
@@ -35,11 +35,6 @@ full_node_networks:
 - network_id: "public"
   discovery_method: "onchain"
 
-upstream:
-  networks:
-  - private: "vfn"
-  - public
-
 mempool:
   default_failovers: 0
 


### PR DESCRIPTION
## Motivation

This PR removes the "UpstreamConfig" configuration struct from the codebase. The last dependency on this config was state sync, which now no longer needs this config to operate (https://github.com/diem/diem/pull/7902).

Note that:
- I've tried to remove all references of UpstreamConfig in the code. However, LBT is failing below (I suspect because there's an old config being pulled from somewhere else? e.g., the compatibility test?). @sausagee, any suggestions?
- We'll need to update the configs and templates in the partners repo. I'll submit a PR for that once we decide on landing this.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally.

## Related PRs

None.
