### PR TITLE
[diem-framework] Fixed the inconsistency in the verification of `txn::burn_txn_fees` and `TransactionFee::burn_fees`

### DIFF
--- a/language/diem-framework/modules/XDX.move
+++ b/language/diem-framework/modules/XDX.move
@@ -98,13 +98,14 @@ module XDX {
         Diem::is_currency<CoinType>() &&
             Diem::currency_code<CoinType>() == Diem::currency_code<XDX>()
     }
-
     spec fun is_xdx {
-        pragma opaque, verify = false;
+        pragma opaque;
         include Diem::spec_is_currency<CoinType>() ==> Diem::AbortsIfNoCurrency<XDX>;
-        /// The following is correct because currency codes are unique; however, we
-        /// can currently not prove it, therefore verify is false.
-        ensures result == Diem::spec_is_currency<CoinType>() && spec_is_xdx<CoinType>();
+        ensures result == spec_is_xdx<CoinType>();
+    }
+    spec define spec_is_xdx<CoinType>(): bool {
+        Diem::spec_is_currency<CoinType>() && Diem::spec_is_currency<XDX>() &&
+            (Diem::spec_currency_code<CoinType>() == Diem::spec_currency_code<XDX>())
     }
 
     /// Return the account address where the globally unique XDX::Reserve resource is stored
@@ -132,11 +133,6 @@ module XDX {
         /// Checks whether the Reserve resource exists.
         define reserve_exists(): bool {
            exists<Reserve>(CoreAddresses::CURRENCY_INFO_ADDRESS())
-        }
-
-        /// Returns true if CoinType is XDX.
-        define spec_is_xdx<CoinType>(): bool {
-            type<CoinType>() == type<XDX>()
         }
 
         /// After genesis, `LimitsDefinition<XDX>` is published at Diem root. It's published by

--- a/language/diem-framework/modules/doc/XDX.md
+++ b/language/diem-framework/modules/doc/XDX.md
@@ -247,16 +247,21 @@ Returns true if <code>CoinType</code> is <code><a href="XDX.md#0x1_XDX_XDX">XDX:
 
 
 
-<pre><code><b>pragma</b> opaque, verify = <b>false</b>;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Diem.md#0x1_Diem_spec_is_currency">Diem::spec_is_currency</a>&lt;CoinType&gt;() ==&gt; <a href="Diem.md#0x1_Diem_AbortsIfNoCurrency">Diem::AbortsIfNoCurrency</a>&lt;<a href="XDX.md#0x1_XDX">XDX</a>&gt;;
+<b>ensures</b> result == <a href="XDX.md#0x1_XDX_spec_is_xdx">spec_is_xdx</a>&lt;CoinType&gt;();
 </code></pre>
 
 
-The following is correct because currency codes are unique; however, we
-can currently not prove it, therefore verify is false.
 
 
-<pre><code><b>ensures</b> result == <a href="Diem.md#0x1_Diem_spec_is_currency">Diem::spec_is_currency</a>&lt;CoinType&gt;() && <a href="XDX.md#0x1_XDX_spec_is_xdx">spec_is_xdx</a>&lt;CoinType&gt;();
+<a name="0x1_XDX_spec_is_xdx"></a>
+
+
+<pre><code><b>define</b> <a href="XDX.md#0x1_XDX_spec_is_xdx">spec_is_xdx</a>&lt;CoinType&gt;(): bool {
+   <a href="Diem.md#0x1_Diem_spec_is_currency">Diem::spec_is_currency</a>&lt;CoinType&gt;() && <a href="Diem.md#0x1_Diem_spec_is_currency">Diem::spec_is_currency</a>&lt;<a href="XDX.md#0x1_XDX">XDX</a>&gt;() &&
+       (<a href="Diem.md#0x1_Diem_spec_currency_code">Diem::spec_currency_code</a>&lt;CoinType&gt;() == <a href="Diem.md#0x1_Diem_spec_currency_code">Diem::spec_currency_code</a>&lt;<a href="XDX.md#0x1_XDX">XDX</a>&gt;())
+}
 </code></pre>
 
 
@@ -327,18 +332,6 @@ Checks whether the Reserve resource exists.
 
 <pre><code><b>define</b> <a href="XDX.md#0x1_XDX_reserve_exists">reserve_exists</a>(): bool {
    <b>exists</b>&lt;<a href="XDX.md#0x1_XDX_Reserve">Reserve</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>())
-}
-</code></pre>
-
-
-Returns true if CoinType is XDX.
-
-
-<a name="0x1_XDX_spec_is_xdx"></a>
-
-
-<pre><code><b>define</b> <a href="XDX.md#0x1_XDX_spec_is_xdx">spec_is_xdx</a>&lt;CoinType&gt;(): bool {
-    type&lt;CoinType&gt;() == type&lt;<a href="XDX.md#0x1_XDX">XDX</a>&gt;()
 }
 </code></pre>
 


### PR DESCRIPTION
- This PR fixed the inconsistency in the verification of `txn::burn_txn_fees` and `TransactionFee::burn_fees`

- The root cause is the specification mistake in the "unverified" opaque function `XDX::is_xdx`, which made those functions above always abort.

- The specification mistake is overlooking the fact that `==` has a higher precedence than `&&` in the following line of spec: `ensures result == Diem::spec_is_currency<CoinType>() && spec_is_xdx<CoinType>();`

- For `XDX::is_xdx`, the `verify` flag was set to be `false` because the its spec was not verifiable by Prover which asserted that the type values of CoinType and XDX are the same. This PR rewrites `spec_is_xdx` in a correct and straightforward way, so that `is_xdx` is verifiable by Prover (i.e., the `verify` flag is back on), and so the inconsistency problems are fixed.

## Motivation

Fix the inconsistency issue in the Diem Framework

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test
