### PR TITLE
[language] remove diem-types dependency from bytecode-verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "borrow-graph",
- "diem-types",
  "diem-workspace-hack",
  "invalid-mutations",
  "mirai-annotations",

--- a/language/bytecode-verifier/Cargo.toml
+++ b/language/bytecode-verifier/Cargo.toml
@@ -16,7 +16,6 @@ petgraph = "0.5.1"
 
 borrow-graph = { path = "../borrow-graph" }
 vm = { path = "../vm" }
-diem-types = { path = "../../types" }
 diem-workspace-hack = { path = "../../common/workspace-hack" }
 move-core-types = { path = "../move-core/types" }
 
@@ -25,4 +24,3 @@ invalid-mutations = { path = "invalid-mutations" }
 
 [features]
 default = []
-fuzzing = ["diem-types/fuzzing"]

--- a/language/bytecode-verifier/src/ability_field_requirements.rs
+++ b/language/bytecode-verifier/src/ability_field_requirements.rs
@@ -5,7 +5,7 @@
 //! abilities required by the struct's abilities
 use crate::binary_views;
 use binary_views::BinaryIndexedView;
-use diem_types::vm_status::StatusCode;
+use move_core_types::vm_status::StatusCode;
 use vm::{
     access::ModuleAccess,
     errors::{verification_error, Location, PartialVMResult, VMResult},

--- a/language/bytecode-verifier/src/acquires_list_verifier.rs
+++ b/language/bytecode-verifier/src/acquires_list_verifier.rs
@@ -10,7 +10,7 @@
 //! - No missing resources (any resource acquired must be present)
 //! - No additional resources (no extraneous resources not actually acquired)
 
-use diem_types::vm_status::StatusCode;
+use move_core_types::vm_status::StatusCode;
 use std::collections::{BTreeSet, HashMap};
 use vm::{
     access::ModuleAccess,

--- a/language/bytecode-verifier/src/binary_views.rs
+++ b/language/bytecode-verifier/src/binary_views.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::control_flow_graph::VMControlFlowGraph;
-use diem_types::vm_status::StatusCode;
 use move_core_types::{
     account_address::AccountAddress, identifier::IdentStr, language_storage::ModuleId,
+    vm_status::StatusCode,
 };
 use vm::{
     access::{ModuleAccess, ScriptAccess},

--- a/language/bytecode-verifier/src/check_duplication.rs
+++ b/language/bytecode-verifier/src/check_duplication.rs
@@ -8,8 +8,9 @@
 //! - struct and field definitions are consistent
 //! - the handles in struct and function definitions point to the self module index
 //! - all struct and function handles pointing to the self module index have a definition
-use diem_types::vm_status::StatusCode;
-use move_core_types::{account_address::AccountAddress, identifier::Identifier};
+use move_core_types::{
+    account_address::AccountAddress, identifier::Identifier, vm_status::StatusCode,
+};
 use std::{collections::HashSet, hash::Hash};
 use vm::{
     access::{ModuleAccess, ScriptAccess},

--- a/language/bytecode-verifier/src/constants.rs
+++ b/language/bytecode-verifier/src/constants.rs
@@ -4,7 +4,7 @@
 //! This module implements a checker for verifying that
 //! - a constant's type only refers to primitive types
 //! - a constant's data serializes correctly for that type
-use diem_types::vm_status::StatusCode;
+use move_core_types::vm_status::StatusCode;
 use vm::{
     access::ModuleAccess,
     errors::{verification_error, Location, PartialVMResult, VMResult},

--- a/language/bytecode-verifier/src/control_flow.rs
+++ b/language/bytecode-verifier/src/control_flow.rs
@@ -6,7 +6,7 @@
 //! - All forward jumps do not enter into the middle of a loop
 //! - All "breaks" (forward, loop-exiting jumps) go to the "end" of the loop
 //! - All "continues" (back jumps in a loop) are only to the current loop
-use diem_types::vm_status::StatusCode;
+use move_core_types::vm_status::StatusCode;
 use std::{collections::HashSet, convert::TryInto};
 use vm::{
     errors::{PartialVMError, PartialVMResult},

--- a/language/bytecode-verifier/src/cyclic_dependencies.rs
+++ b/language/bytecode-verifier/src/cyclic_dependencies.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module contains verification of usage of dependencies for modules
-use diem_types::vm_status::StatusCode;
-use move_core_types::language_storage::ModuleId;
+use move_core_types::{language_storage::ModuleId, vm_status::StatusCode};
 use std::collections::BTreeSet;
 use vm::{
     access::ModuleAccess,

--- a/language/bytecode-verifier/src/dependencies.rs
+++ b/language/bytecode-verifier/src/dependencies.rs
@@ -3,8 +3,7 @@
 
 //! This module contains verification of usage of dependencies for modules and scripts.
 use crate::binary_views::BinaryIndexedView;
-use diem_types::vm_status::StatusCode;
-use move_core_types::{identifier::Identifier, language_storage::ModuleId};
+use move_core_types::{identifier::Identifier, language_storage::ModuleId, vm_status::StatusCode};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use vm::{
     access::{ModuleAccess, ScriptAccess},

--- a/language/bytecode-verifier/src/friends.rs
+++ b/language/bytecode-verifier/src/friends.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module contains verification of usage of dependencies for modules
-use diem_types::vm_status::StatusCode;
+use move_core_types::vm_status::StatusCode;
 use vm::{
     access::ModuleAccess,
     errors::{Location, PartialVMError, PartialVMResult, VMResult},

--- a/language/bytecode-verifier/src/instantiation_loops.rs
+++ b/language/bytecode-verifier/src/instantiation_loops.rs
@@ -12,7 +12,7 @@
 //! instances. We do reject recursive functions that create a new type upon each call but do
 //! terminate eventually.
 
-use diem_types::vm_status::StatusCode;
+use move_core_types::vm_status::StatusCode;
 use petgraph::{
     algo::tarjan_scc,
     graph::{EdgeIndex, NodeIndex},

--- a/language/bytecode-verifier/src/instruction_consistency.rs
+++ b/language/bytecode-verifier/src/instruction_consistency.rs
@@ -5,7 +5,7 @@
 //! It does not utilize control flow, but does check each block independently
 
 use crate::binary_views::BinaryIndexedView;
-use diem_types::vm_status::StatusCode;
+use move_core_types::vm_status::StatusCode;
 use vm::{
     access::ModuleAccess,
     errors::{Location, PartialVMError, PartialVMResult, VMResult},

--- a/language/bytecode-verifier/src/locals_safety/mod.rs
+++ b/language/bytecode-verifier/src/locals_safety/mod.rs
@@ -13,8 +13,8 @@ use crate::{
     binary_views::{BinaryIndexedView, FunctionView},
 };
 use abstract_state::{AbstractState, LocalState};
-use diem_types::vm_status::StatusCode;
 use mirai_annotations::*;
+use move_core_types::vm_status::StatusCode;
 use vm::{
     errors::{PartialVMError, PartialVMResult},
     file_format::{Bytecode, CodeOffset},

--- a/language/bytecode-verifier/src/reference_safety/abstract_state.rs
+++ b/language/bytecode-verifier/src/reference_safety/abstract_state.rs
@@ -7,8 +7,8 @@ use crate::{
     binary_views::FunctionView,
 };
 use borrow_graph::references::RefID;
-use diem_types::vm_status::StatusCode;
 use mirai_annotations::{checked_postcondition, checked_precondition, checked_verify};
+use move_core_types::vm_status::StatusCode;
 use std::collections::{BTreeMap, BTreeSet};
 use vm::{
     errors::{PartialVMError, PartialVMResult},

--- a/language/bytecode-verifier/src/script_signature.rs
+++ b/language/bytecode-verifier/src/script_signature.rs
@@ -7,8 +7,7 @@
 //! - All types non-signer arguments have a type that is valid for constants
 //! - Has an empty return type
 use crate::binary_views::BinaryIndexedView;
-use diem_types::vm_status::StatusCode;
-use move_core_types::identifier::IdentStr;
+use move_core_types::{identifier::IdentStr, vm_status::StatusCode};
 use vm::{
     access::ModuleAccess,
     errors::{Location, PartialVMError, PartialVMResult, VMResult},

--- a/language/bytecode-verifier/src/signature.rs
+++ b/language/bytecode-verifier/src/signature.rs
@@ -5,7 +5,7 @@
 //! parameters, locals, and fields of structs are well-formed. References can only occur at the
 //! top-level in all tokens.  Additionally, references cannot occur at all in field types.
 use crate::binary_views::BinaryIndexedView;
-use diem_types::vm_status::StatusCode;
+use move_core_types::vm_status::StatusCode;
 use vm::{
     access::{ModuleAccess, ScriptAccess},
     errors::{Location, PartialVMError, PartialVMResult, VMResult},

--- a/language/bytecode-verifier/src/stack_usage_verifier.rs
+++ b/language/bytecode-verifier/src/stack_usage_verifier.rs
@@ -12,7 +12,7 @@ use crate::{
     binary_views::{BinaryIndexedView, FunctionView},
     control_flow_graph::{BlockId, ControlFlowGraph},
 };
-use diem_types::vm_status::StatusCode;
+use move_core_types::vm_status::StatusCode;
 use vm::{
     errors::{PartialVMError, PartialVMResult},
     file_format::{Bytecode, CodeUnit, FunctionDefinitionIndex, Signature, StructFieldInformation},

--- a/language/bytecode-verifier/src/struct_defs.rs
+++ b/language/bytecode-verifier/src/struct_defs.rs
@@ -4,7 +4,7 @@
 //! This module provides a checker for verifying that struct definitions in a module are not
 //! recursive. Since the module dependency graph is acylic by construction, applying this checker to
 //! each module in isolation guarantees that there is no structural recursion globally.
-use diem_types::vm_status::StatusCode;
+use move_core_types::vm_status::StatusCode;
 use petgraph::{algo::toposort, graphmap::DiGraphMap};
 use std::collections::{BTreeMap, BTreeSet};
 use vm::{

--- a/language/bytecode-verifier/src/type_safety.rs
+++ b/language/bytecode-verifier/src/type_safety.rs
@@ -8,8 +8,8 @@ use crate::{
     binary_views::{BinaryIndexedView, FunctionView},
     control_flow_graph::ControlFlowGraph,
 };
-use diem_types::vm_status::StatusCode;
 use mirai_annotations::*;
+use move_core_types::vm_status::StatusCode;
 use vm::{
     errors::{PartialVMError, PartialVMResult},
     file_format::{

--- a/x.toml
+++ b/x.toml
@@ -228,7 +228,6 @@ existing_deps = [
     ["language-benchmarks", "diem-types"],
     ["language-benchmarks", "diem-state-view"],
     ["language-benchmarks", "diem-proptest-helpers"],
-    ["bytecode-verifier", "diem-types"],
     ["bytecode-verifier-tests", "diem-types"],
     ["invalid-mutations", "diem-types"],
     ["invalid-mutations", "diem-proptest-helpers"],


### PR DESCRIPTION
This makes the bytecode-verifier no longer depend on diem-types.