### PR TITLE
[language] remove diem-types dependency from bytecode-verifier-tests and invalid-mutations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,6 @@ version = "0.1.0"
 dependencies = [
  "bytecode-verifier",
  "compiled-stdlib",
- "diem-types",
  "diem-workspace-hack",
  "invalid-mutations",
  "move-core-types",
@@ -3674,8 +3673,8 @@ name = "invalid-mutations"
 version = "0.1.0"
 dependencies = [
  "diem-proptest-helpers",
- "diem-types",
  "diem-workspace-hack",
+ "move-core-types",
  "proptest",
  "vm",
 ]

--- a/language/bytecode-verifier/bytecode-verifier-tests/Cargo.toml
+++ b/language/bytecode-verifier/bytecode-verifier-tests/Cargo.toml
@@ -14,7 +14,6 @@ petgraph = "0.5.1"
 proptest = "1.0.0"
 
 bytecode-verifier = { path = "../" }
-diem-types = { path = "../../../types" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 invalid-mutations = { path = "../invalid-mutations" }
 move-core-types = { path = "../../move-core/types" }
@@ -22,4 +21,4 @@ compiled-stdlib = { path = "../../diem-framework/compiled" }
 vm = { path = "../../vm", features = ["fuzzing"] }
 
 [features]
-fuzzing = ["diem-types/fuzzing", "vm/fuzzing"]
+fuzzing = ["vm/fuzzing"]

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/bounds_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/bounds_tests.rs
@@ -1,12 +1,13 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use diem_types::{account_address::AccountAddress, vm_status::StatusCode};
 use invalid_mutations::bounds::{
     ApplyCodeUnitBoundsContext, ApplyOutOfBoundsContext, CodeUnitBoundsMutation,
     OutOfBoundsMutation,
 };
-use move_core_types::identifier::Identifier;
+use move_core_types::{
+    account_address::AccountAddress, identifier::Identifier, vm_status::StatusCode,
+};
 use proptest::{collection::vec, prelude::*};
 use vm::{check_bounds::BoundsChecker, file_format::*, proptest_types::CompiledModuleStrategyGen};
 

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/code_unit_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/code_unit_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use bytecode_verifier::CodeUnitVerifier;
-use diem_types::vm_status::StatusCode;
+use move_core_types::vm_status::StatusCode;
 use vm::file_format::{self, Bytecode};
 
 #[test]

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/constants_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/constants_tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 use bytecode_verifier::constants;
-use diem_types::vm_status::StatusCode;
+use move_core_types::vm_status::StatusCode;
 use proptest::prelude::*;
 use vm::file_format::{empty_module, CompiledModule, Constant, SignatureToken};
 

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/control_flow_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/control_flow_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use bytecode_verifier::control_flow;
-use diem_types::vm_status::StatusCode;
+use move_core_types::vm_status::StatusCode;
 use vm::{
     access::ModuleAccess,
     errors::PartialVMResult,

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/generic_ops_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/generic_ops_tests.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use bytecode_verifier::InstructionConsistency;
-use diem_types::vm_status::StatusCode;
-use move_core_types::{account_address::AccountAddress, identifier::Identifier};
+use move_core_types::{
+    account_address::AccountAddress, identifier::Identifier, vm_status::StatusCode,
+};
 use vm::file_format::*;
 
 // Make a Module with 2 structs and 2 resources with one field each, and 2 functions.

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/negative_stack_size_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/negative_stack_size_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use bytecode_verifier::CodeUnitVerifier;
-use diem_types::vm_status::StatusCode;
+use move_core_types::vm_status::StatusCode;
 use vm::file_format::{self, Bytecode};
 
 #[test]

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use bytecode_verifier::{verify_module, SignatureChecker};
-use diem_types::account_address::AccountAddress;
 use invalid_mutations::signature::{FieldRefMutation, SignatureRefMutation};
-use move_core_types::identifier::Identifier;
+use move_core_types::{account_address::AccountAddress, identifier::Identifier};
 use proptest::{collection::vec, prelude::*, sample::Index as PropIndex};
 use vm::file_format::{Bytecode::*, CompiledModule, SignatureToken::*, *};
 

--- a/language/bytecode-verifier/invalid-mutations/Cargo.toml
+++ b/language/bytecode-verifier/invalid-mutations/Cargo.toml
@@ -10,12 +10,11 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
+move-core-types = { path = "../../move-core/types" }
 vm = { path = "../../vm" }
-diem-types = { path = "../../../types" }
 proptest = "1.0.0"
 diem-proptest-helpers = { path = "../../../common/proptest-helpers" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 
 [features]
 default = []
-fuzzing = ["diem-types/fuzzing"]

--- a/language/bytecode-verifier/invalid-mutations/src/bounds.rs
+++ b/language/bytecode-verifier/invalid-mutations/src/bounds.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use diem_proptest_helpers::pick_slice_idxs;
-use diem_types::vm_status::StatusCode;
+use move_core_types::vm_status::StatusCode;
 use proptest::{
     prelude::*,
     sample::{self, Index as PropIndex},

--- a/language/bytecode-verifier/invalid-mutations/src/bounds/code_unit.rs
+++ b/language/bytecode-verifier/invalid-mutations/src/bounds/code_unit.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use diem_proptest_helpers::pick_slice_idxs;
-use diem_types::vm_status::StatusCode;
+use move_core_types::vm_status::StatusCode;
 use proptest::{prelude::*, sample::Index as PropIndex};
 use std::collections::BTreeMap;
 use vm::{

--- a/x.toml
+++ b/x.toml
@@ -228,8 +228,6 @@ existing_deps = [
     ["language-benchmarks", "diem-types"],
     ["language-benchmarks", "diem-state-view"],
     ["language-benchmarks", "diem-proptest-helpers"],
-    ["bytecode-verifier-tests", "diem-types"],
-    ["invalid-mutations", "diem-types"],
     ["invalid-mutations", "diem-proptest-helpers"],
     ["compiler", "diem-types"],
     ["bytecode-source-map", "diem-types"],


### PR DESCRIPTION
This removes the dependency on `diem-types` from `bytecode-verifier-tests` and `invalid-mutations`.