### PR TITLE
[language] remove diem-types dependencies from move-ir-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4270,7 +4270,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "codespan",
- "diem-types",
  "diem-workspace-hack",
  "hex",
  "move-core-types",

--- a/language/move-ir/types/Cargo.toml
+++ b/language/move-ir/types/Cargo.toml
@@ -18,6 +18,5 @@ serde = { version = "1.0.124", features = ["derive"] }
 hex = "0.4.3"
 once_cell = "1.7.2"
 
-diem-types = { path = "../../../types" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = { path = "../../move-core/types" }

--- a/language/move-ir/types/src/ast.rs
+++ b/language/move-ir/types/src/ast.rs
@@ -6,8 +6,10 @@ use crate::{
     spec_language_ast::{Condition, Invariant, SyntheticDefinition},
 };
 use anyhow::Result;
-use diem_types::account_address::AccountAddress;
-use move_core_types::{identifier::Identifier, language_storage::ModuleId, value::MoveValue};
+use move_core_types::{
+    account_address::AccountAddress, identifier::Identifier, language_storage::ModuleId,
+    value::MoveValue,
+};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::{

--- a/language/move-ir/types/src/spec_language_ast.rs
+++ b/language/move-ir/types/src/spec_language_ast.rs
@@ -5,8 +5,7 @@ use crate::{
     ast::{BinOp, CopyableVal_, Field_, QualifiedStructIdent, Type},
     location::*,
 };
-use diem_types::account_address::AccountAddress;
-use move_core_types::identifier::Identifier;
+use move_core_types::{account_address::AccountAddress, identifier::Identifier};
 
 /// AST for the Move Prover specification language.
 

--- a/x.toml
+++ b/x.toml
@@ -237,7 +237,6 @@ existing_deps = [
     ["compiled-stdlib", "diem-proptest-helpers"],
     ["compiled-stdlib", "diem-framework"],
     ["compiled-stdlib", "diem-crypto"],
-    ["move-ir-types", "diem-types"],
     ["move-lang", "fallible"],
     ["move-lang", "diem-framework"],
     ["move-lang", "diem-types"],


### PR DESCRIPTION
This removes the dependency from `move-ir-types` to `diem-types`.