### PR TITLE
[State Sync] Merge flows, prevent empty message sending and improve incremental sync.

### DIFF
--- a/state-sync/src/chunk_request.rs
+++ b/state-sync/src/chunk_request.rs
@@ -10,6 +10,9 @@ use std::fmt;
 /// available on the requesting side.
 pub enum TargetType {
     /// The response is built relative to the target (or end of epoch).
+    /// **DEPRECATED**: `TargetLedgerInfo` is only required for backward compatibility. State sync
+    /// avoids sending these target types and instead uses `HighestAvailable` below. This message
+    /// will be removed on the next breaking release: https://github.com/diem/diem/issues/8013
     TargetLedgerInfo(LedgerInfoWithSignatures),
     /// The response is built relative to the highest available LedgerInfo (or end of epoch).
     /// The value specifies the timeout in ms to wait for an available response.

--- a/state-sync/src/chunk_response.rs
+++ b/state-sync/src/chunk_response.rs
@@ -15,6 +15,9 @@ use std::fmt;
 pub enum ResponseLedgerInfo {
     /// A typical response carries a LedgerInfo with signatures that should be verified using the
     /// local trusted validator set.
+    /// **DEPRECATED**: `VerifiableLedgerInfo` is only required for backward compatibility. State
+    /// sync avoids sending these response types and instead uses `ProgressiveLedgerInfo` below.
+    /// This message will be removed on the next breaking release: https://github.com/diem/diem/issues/8013
     VerifiableLedgerInfo(LedgerInfoWithSignatures),
     /// A response to `TargetType::HighestAvailable` chunk request type.
     ProgressiveLedgerInfo {

--- a/state-sync/src/coordinator.rs
+++ b/state-sync/src/coordinator.rs
@@ -2183,13 +2183,12 @@ mod tests {
         let (sync_request, _) = create_sync_request_at_version(10);
         let _ = validator_coordinator.process_sync_request(sync_request);
 
-        // Verify wrong chunk type for non-target messages
-        let mut chunk_responses = create_non_empty_chunk_responses(1);
-        let _ = chunk_responses.remove(1); // Ignore the target chunk response
+        // Verify wrong chunk type for waypoint message
+        let chunk_responses = create_non_empty_chunk_responses(1);
         verify_all_chunk_responses_are_the_wrong_type(
             &mut validator_coordinator,
             &peer_network_id,
-            &chunk_responses,
+            &chunk_responses[0..1], // Ignore the target and highest chunk responses
         );
 
         // Verify ledger info version doesn't exceed sync request version

--- a/state-sync/tests/integration_tests.rs
+++ b/state-sync/tests/integration_tests.rs
@@ -337,13 +337,13 @@ fn test_lagging_upstream_long_poll() {
 
     // Fullnode 1 sends long-poll subscription to fullnode 0
     let (_, message) = env.deliver_msg(fullnode_1_peer_id_pfn);
-    check_chunk_response(message, 600, 251, 250);
+    check_chunk_response(message, 400, 251, 150);
 
     // Fullnode 0 sends chunk request to fullnode 1 and commits to latest state
     let (_, message) = env.deliver_msg(fullnode_0_peer_id_pfn);
-    check_chunk_request(message, 500, None);
+    check_chunk_request(message, 400, None);
     let (_, message) = env.deliver_msg(fullnode_1_peer_id_pfn);
-    check_chunk_response(message, 600, 501, 100);
+    check_chunk_response(message, 600, 401, 200);
     env.get_state_sync_peer(2).wait_for_version(600, Some(600));
 }
 


### PR DESCRIPTION
## Motivation

This PR makes 3 improvements to state sync:
1. (Code Simplification) First, it merges the two state sync flows (i.e., syncing to a target for consensus and syncing to the highest available for fullnodes) into a single flow. To achieve this, the PR updates state sync to avoid sending `TargetLedgerInfo` requests and `VerifiableLedgerInfo` responses. These are replaced with `HighestAvailable` requests and `ProgressiveLedgerInfo` responses, respectively.
2. (Performance/Resource Usage) Second, by merging the flows as above, the PR updates syncing to a target for consensus to support long polling. Right now, when a node syncs to a target for consensus, it sends requests to other nodes for a specific target. However, if those nodes aren't up-to-date with the requestor, they will send *empty chunk* responses back, which are ultimately rejected 😞. This wastes resources (e.g., CPU and network bandwidth). Instead, nodes should support long polling, and thus only respond to the requestor if they can help.
3. (Incremental Sync) Third, it updates long polling to return chunk responses that: (i) sync the node to the given specified target (if any); and (ii) also return the highest known available ledger info by the sender. This allows fullnodes to incrementally sync more efficiently when receiving responses from long poll requests.

To achieve these improvements, the PR offers the following commits:
1. Merge the sync flows to use only `HighestAvailable` requests and `ProgressiveLedgerInfo` responses and add deprecated warnings to old message types.
2. Update long polling to sync to the specified target as well as return the highest available (to support incremental syncing for fullnodes).
3. Update the tests that depend on the modifications above.
4. Rename the unified syncing flow methods to be clearer in intent.


Note:
- Given that we want to be backward compatible with v1.1, this change doesn't remove support for processing the old message types (i.e., `TargetLedgerInfo` and `VerifiableLedgerInfo`). These messages are still supported when received from nodes running v1.1. Instead, this PR simply updates nodes not to send these messages. Moreover, given that nodes running v1.1 don't distinguish between `VerifiableLedgerInfo` and `ProgressLedgerInfo` response messages, this change should not cause any issues.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass.

## Related PRs

This relates to: https://github.com/diem/diem/issues/6795