### PR TITLE
[mempool] Decrease VFN broadcasts to secondaries

### DIFF
--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -6,7 +6,7 @@
 use crate::{
     core_mempool::{
         index::TxnPointer,
-        transaction::{MempoolTransaction, TimelineState},
+        transaction::{MempoolTransaction, TimelineState, TransmissionState},
         transaction_store::TransactionStore,
         ttl_cache::TtlCache,
     },
@@ -110,6 +110,7 @@ impl Mempool {
         db_sequence_number: u64,
         timeline_state: TimelineState,
         governance_role: GovernanceRole,
+        transmission_state: TransmissionState,
     ) -> MempoolStatus {
         trace_event!("mempool::add_txn", {"txn", txn.sender(), txn.sequence_number()});
         trace!(
@@ -146,6 +147,7 @@ impl Mempool {
             ranking_score,
             timeline_state,
             governance_role,
+            transmission_state,
         );
 
         self.transactions.insert(txn_info, sequence_number)

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -264,8 +264,14 @@ impl Mempool {
     }
 
     /// Read transactions from timeline from `start_id` (exclusive) to `end_id` (inclusive).
-    pub(crate) fn timeline_range(&mut self, start_id: u64, end_id: u64) -> Vec<SignedTransaction> {
-        self.transactions.timeline_range(start_id, end_id)
+    pub(crate) fn timeline_range(
+        &mut self,
+        start_id: u64,
+        end_id: u64,
+        transmission_filter: Option<TransmissionState>,
+    ) -> Vec<SignedTransaction> {
+        self.transactions
+            .timeline_range(start_id, end_id, transmission_filter)
     }
 
     pub fn gen_snapshot(&self) -> TxnsLog {

--- a/mempool/src/core_mempool/mod.rs
+++ b/mempool/src/core_mempool/mod.rs
@@ -9,4 +9,8 @@ mod ttl_cache;
 
 #[cfg(test)]
 pub use self::ttl_cache::TtlCache;
-pub use self::{index::TxnPointer, mempool::Mempool as CoreMempool, transaction::TimelineState};
+pub use self::{
+    index::TxnPointer,
+    mempool::Mempool as CoreMempool,
+    transaction::{TimelineState, TransmissionState},
+};

--- a/mempool/src/core_mempool/transaction.rs
+++ b/mempool/src/core_mempool/transaction.rs
@@ -63,7 +63,7 @@ pub enum TimelineState {
     NonQualified,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct TransmissionState {
     pub from_vfn: bool,
 }

--- a/mempool/src/core_mempool/transaction.rs
+++ b/mempool/src/core_mempool/transaction.rs
@@ -17,6 +17,7 @@ pub struct MempoolTransaction {
     pub ranking_score: u64,
     pub timeline_state: TimelineState,
     pub governance_role: GovernanceRole,
+    pub transmission_state: TransmissionState,
 }
 
 impl MempoolTransaction {
@@ -27,6 +28,7 @@ impl MempoolTransaction {
         ranking_score: u64,
         timeline_state: TimelineState,
         governance_role: GovernanceRole,
+        transmission_state: TransmissionState,
     ) -> Self {
         Self {
             txn,
@@ -35,6 +37,7 @@ impl MempoolTransaction {
             expiration_time,
             timeline_state,
             governance_role,
+            transmission_state,
         }
     }
     pub(crate) fn get_sequence_number(&self) -> u64 {
@@ -58,4 +61,19 @@ pub enum TimelineState {
     // Transaction will never be qualified for broadcasting.
     // Currently we don't broadcast transactions originated on other peers.
     NonQualified,
+}
+
+#[derive(Clone)]
+pub struct TransmissionState {
+    pub from_vfn: bool,
+}
+
+impl TransmissionState {
+    pub fn new(from_vfn: bool) -> Self {
+        TransmissionState { from_vfn }
+    }
+
+    pub fn mock() -> Self {
+        Self::new(false)
+    }
 }

--- a/mempool/src/core_mempool/transaction.rs
+++ b/mempool/src/core_mempool/transaction.rs
@@ -65,12 +65,12 @@ pub enum TimelineState {
 
 #[derive(Clone, Eq, PartialEq)]
 pub struct TransmissionState {
-    pub from_vfn: bool,
+    pub from_same_level: bool,
 }
 
 impl TransmissionState {
-    pub fn new(from_vfn: bool) -> Self {
-        TransmissionState { from_vfn }
+    pub fn new(from_same_level: bool) -> Self {
+        TransmissionState { from_same_level }
     }
 
     pub fn mock() -> Self {

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -218,7 +218,7 @@ async fn handle_event<V>(
                     );
 
                     let transmission_state =
-                        TransmissionState::new(smp_clone.peer_manager.is_vfn(&peer));
+                        TransmissionState::new(smp_clone.peer_manager.is_same_level(&peer));
 
                     bounded_executor
                         .spawn(tasks::process_transaction_broadcast(

--- a/mempool/src/shared_mempool/peer_manager.rs
+++ b/mempool/src/shared_mempool/peer_manager.rs
@@ -464,6 +464,12 @@ impl PeerManager {
             self.peer_states.lock().contains_key(peer)
         }
     }
+
+    pub fn is_vfn(&self, peer: &PeerNetworkId) -> bool {
+        self.peer_states.lock().get(peer).map_or(false, |state| {
+            state.metadata.role == PeerRole::ValidatorFullNode
+        })
+    }
 }
 
 /// Provides ordering for prioritized peers

--- a/mempool/src/tests/common.rs
+++ b/mempool/src/tests/common.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::core_mempool::{CoreMempool, TimelineState, TxnPointer};
+use crate::core_mempool::{CoreMempool, TimelineState, TransmissionState, TxnPointer};
 use anyhow::{format_err, Result};
 use diem_config::config::NodeConfig;
 use diem_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
@@ -112,6 +112,7 @@ pub(crate) fn add_txns_to_mempool(
             0,
             TimelineState::NotReady,
             transaction.governance_role,
+            TransmissionState::mock(),
         );
         transactions.push(txn);
     }
@@ -131,6 +132,7 @@ pub(crate) fn add_signed_txn(pool: &mut CoreMempool, transaction: SignedTransact
             0,
             TimelineState::NotReady,
             GovernanceRole::NonGovernanceRole,
+            TransmissionState::mock(),
         )
         .code
     {

--- a/mempool/src/tests/core_mempool_test.rs
+++ b/mempool/src/tests/core_mempool_test.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    core_mempool::{CoreMempool, TimelineState, TtlCache},
+    core_mempool::{CoreMempool, TimelineState, TransmissionState, TtlCache},
     tests::common::{
         add_signed_txn, add_txn, add_txns_to_mempool, exist_in_metrics_cache, setup_mempool,
         TestTransaction,
@@ -411,6 +411,7 @@ fn test_gc_ready_transaction() {
         0,
         TimelineState::NotReady,
         GovernanceRole::NonGovernanceRole,
+        TransmissionState::mock(),
     );
 
     // Insert few transactions after it.
@@ -450,6 +451,7 @@ fn test_clean_stuck_transactions() {
         db_sequence_number,
         TimelineState::NotReady,
         GovernanceRole::NonGovernanceRole,
+        TransmissionState::mock(),
     );
     let block = pool.get_block(10, HashSet::new());
     assert_eq!(block.len(), 1);

--- a/mempool/src/tests/fuzzing.rs
+++ b/mempool/src/tests/fuzzing.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    core_mempool::{CoreMempool, TimelineState},
+    core_mempool::{CoreMempool, TimelineState, TransmissionState},
     shared_mempool::{peer_manager::PeerManager, tasks, types::SharedMempool},
 };
 use diem_config::config::NodeConfig;
@@ -44,8 +44,9 @@ pub fn test_mempool_process_incoming_transactions_impl(
         peer_manager: Arc::new(PeerManager::new(config.base.role, config.mempool)),
         subscribers: vec![],
     };
+    let transmission_state = TransmissionState::mock();
 
-    let _ = tasks::process_incoming_transactions(&smp, txns, timeline_state);
+    let _ = tasks::process_incoming_transactions(&smp, txns, timeline_state, transmission_state);
 }
 
 proptest! {

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    core_mempool::{CoreMempool, TimelineState},
+    core_mempool::{CoreMempool, TimelineState, TransmissionState},
     network::{MempoolNetworkEvents, MempoolNetworkSender},
     shared_mempool::start_shared_mempool,
     CommitNotification, ConsensusRequest, SubmissionStatus,
@@ -113,6 +113,7 @@ impl MockSharedMempool {
                         0,
                         TimelineState::NotReady,
                         GovernanceRole::NonGovernanceRole,
+                        TransmissionState::mock(),
                     )
                     .code
                     != MempoolStatusCode::Accepted

--- a/mempool/src/tests/node.rs
+++ b/mempool/src/tests/node.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    core_mempool::{CoreMempool, TimelineState},
+    core_mempool::{CoreMempool, TimelineState, TransmissionState},
     network::{MempoolNetworkEvents, MempoolSyncMsg},
     shared_mempool::{
         network::MempoolNetworkSender, start_shared_mempool, types::SharedMempoolNotification,
@@ -371,6 +371,7 @@ impl Node {
                 0,
                 TimelineState::NotReady,
                 GovernanceRole::NonGovernanceRole,
+                TransmissionState::mock(),
             );
         }
     }

--- a/testsuite/cluster-test/src/cluster_swarm/configs/fullnode.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/configs/fullnode.yaml
@@ -35,6 +35,9 @@ full_node_networks:
 - network_id: "public"
   discovery_method: "onchain"
 
+mempool:
+  default_failovers: 1
+
 metrics:
   enabled: false
 

--- a/testsuite/cluster-test/src/cluster_swarm/configs/fullnode.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/configs/fullnode.yaml
@@ -35,9 +35,6 @@ full_node_networks:
 - network_id: "public"
   discovery_method: "onchain"
 
-mempool:
-  default_failovers: 0
-
 metrics:
   enabled: false
 


### PR DESCRIPTION
This should make Cluster test closer to reality, by solving one of the main performance problems.  When mempool broadcasts to secondaries, that node then broadcasts to its secondaries.  In the VFN case, this leads to exponential work even in cases where secondaries aren't needed.

Now, VFNs do not broadcast transactions to secondaries, if the request came from a VFN.  It's a bit of a hack, but a simple one to lower the overhead on the VFNs as a result of rebroadcasting.