### PR TITLE
[dependencies] disable rust dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
       - dependency-name: "codespan*"
       - dependency-name: "libfuzzer-sys"
       - dependency-name: "bindgen"
-    open-pull-requests-limit: 20
+    open-pull-requests-limit: 0
 
   # Dockerfiles.
 


### PR DESCRIPTION
## Motivation

Looks like there's plan to move off of dependabot, possible to whackadep.

Following documented disabling process here:  https://docs.github.com/en/github/administering-a-repository/enabling-and-disabling-version-updates#example-disabling-version-updates-for-some-dependencies

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

Time (no new rust dep prs will be opened).

## Related PRs

None.

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
