### PR TITLE
[json-rpc] get_account by version

### DIFF
--- a/client/assets-proof/src/lib.rs
+++ b/client/assets-proof/src/lib.rs
@@ -602,7 +602,7 @@ impl Client for diem_client::BlockingClient {
 
         let account_state =
             AccountState::try_from(&account_blob).context("Failed to deserialize account state")?;
-        let account_view = make_account_view(address, account_state, currency_ids)
+        let account_view = make_account_view(address, account_state, currency_ids, version)
             .context("Failed to project account state into account view")?;
         Ok(Response::new(Some(account_view), response_state))
     }
@@ -613,6 +613,7 @@ fn make_account_view(
     address: AccountAddress,
     account_state: AccountState,
     currency_ids: &[Identifier],
+    version: Version,
 ) -> Result<AccountView> {
     let account_resource = account_state
         .get_account_resource()?
@@ -631,6 +632,7 @@ fn make_account_view(
         balances,
         account_role,
         freezing_bit,
+        version,
     ))
 }
 

--- a/json-rpc/API-CHANGELOG.md
+++ b/json-rpc/API-CHANGELOG.md
@@ -13,6 +13,11 @@ Please add the API change in the following format:
 
 ```
 
+## 2021-03-18 Add optional parameter `version` to `get_account` method
+
+- Get account data by version.
+- A new field `version` is added to [Account](docs/type_account.md) in the `get_account` method response.
+
 ## 2021-03-16 Add support for script functions in `TransactionDataView` and `ScriptView`
 
 Update `ScriptView` to support script functions. This adds three new nullable

--- a/json-rpc/docs/method_get_account.md
+++ b/json-rpc/docs/method_get_account.md
@@ -7,9 +7,12 @@ Get the latest account information for a given account address.
 
 ### Parameters
 
-| Name    | Type   | Description                 |
-|---------|--------|-----------------------------|
-| account | string | Hex-encoded account address |
+| Name    | Type           | Description                                                                                         |
+|---------|----------------|-----------------------------------------------------------------------------------------------------|
+| account | string         | Hex-encoded account address                                                                         |
+| version | unsigned int64 | The transaction version, this parameter is optional, default is server's latest transaction version |
+
+> Depending on server's configuration, querying too old version may get error indicating data is pruned.
 
 
 ### Returns

--- a/json-rpc/docs/type_account.md
+++ b/json-rpc/docs/type_account.md
@@ -7,22 +7,23 @@ A Diem account.
 
 ### Attributes
 
-| Name                              | Type                           | Description                                                                                 |
-|-----------------------------------|--------------------------------|---------------------------------------------------------------------------------------------|
-| address                           | string                         | the account address                                                                         |
-| sequence_number                   | unsigned int64                 | The next sequence number for the current account                                            |
-| authentication_key                | string                         | Hex-encoded authentication key for the account                                              |
-| delegated_key_rotation_capability | boolean                        | If true, another account has the ability to rotate the authentication key for this account. |
-| delegated_withdrawal_capability   | boolean                        | If true, another account has the ability to withdraw funds from this account.               |
-| balances                          | List<[Amount](type_amount.md)> | Balances of all the currencies associated with the account                                  |
-| sent_events_key                   | string                         | Unique key for the sent events stream of this account                                       |
-| received_events_key               | string                         | Unique key for the received events stream of this account                                   |
-| is_frozen                         | boolean                        | Whether this account is frozen or not                                                       |
-| role                              | object                         | One of the following type:                                                                |
-|                                   |                                |   - [UnknownRole](#type-unknownrole) |
-|                                   |                                |   - [ParentVASPRole](#type-parentvasprole) |
-|                                   |                                |   - [ChildVASPRole](#type-childvasprole) |
-|                                   |                                |   - [DesignatedDealerRole](#type-designateddealerrole) |
+| Name                                 | Type                           | Description                                                                                 |
+|--------------------------------------|--------------------------------|---------------------------------------------------------------------------------------------|
+| address                              | string                         | the account address                                                                         |
+| sequence\_number                     | unsigned int64                 | The next sequence number for the current account                                            |
+| authentication\_key                  | string                         | Hex-encoded authentication key for the account                                              |
+| delegated\_key\_rotation\_capability | boolean                        | If true, another account has the ability to rotate the authentication key for this account. |
+| delegated\_withdrawal\_capability    | boolean                        | If true, another account has the ability to withdraw funds from this account.               |
+| balances                             | List<[Amount](type_amount.md)> | Balances of all the currencies associated with the account                                  |
+| sent\_events\_key                    | string                         | Unique key for the sent events stream of this account                                       |
+| received\_events\_key                | string                         | Unique key for the received events stream of this account                                   |
+| is\_frozen                           | boolean                        | Whether this account is frozen or not                                                       |
+| version                              | unsigned int64                 | The transaction version of the account data.                                                |
+| role                                 | object                         | One of the following type:                                                                  |
+|                                      |                                | - [UnknownRole](#type-unknownrole)                                                          |
+|                                      |                                | - [ParentVASPRole](#type-parentvasprole)                                                    |
+|                                      |                                | - [ChildVASPRole](#type-childvasprole)                                                      |
+|                                      |                                | - [DesignatedDealerRole](#type-designateddealerrole)                                        |
 
 ---
 

--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -259,8 +259,9 @@ async fn get_account(
     request: JsonRpcRequest,
 ) -> Result<Option<AccountView>> {
     let account_address: AccountAddress = request.parse_account_address(0)?;
+    let version: u64 = request.parse_version_param(1, "version")?;
 
-    let account_state = match service.get_account_state(account_address, request.version())? {
+    let account_state = match service.get_account_state(account_address, version)? {
         Some(val) => val,
         None => return Ok(None),
     };
@@ -289,6 +290,7 @@ async fn get_account(
         balances,
         account_role,
         freezing_bit,
+        version,
     )))
 }
 
@@ -297,11 +299,7 @@ async fn get_account(
 /// Can be used to verify that target Full Node is up-to-date
 async fn get_metadata(service: JsonRpcService, request: JsonRpcRequest) -> Result<MetadataView> {
     let chain_id = service.chain_id().id();
-    let version = if !request.params.is_empty() {
-        request.parse_version_param(0, "version")?
-    } else {
-        request.version()
-    };
+    let version = request.parse_version_param(0, "version")?;
 
     let mut script_hash_allow_list: Option<Vec<HashValue>> = None;
     let mut module_publishing_allowed: Option<bool> = None;
@@ -678,7 +676,7 @@ pub(crate) fn build_registry() -> RpcRegistry {
     let mut registry = RpcRegistry::new();
     register_rpc_method!(registry, "submit", submit, 1, 0);
     register_rpc_method!(registry, "get_metadata", get_metadata, 0, 1);
-    register_rpc_method!(registry, "get_account", get_account, 1, 0);
+    register_rpc_method!(registry, "get_account", get_account, 1, 1);
     register_rpc_method!(registry, "get_transactions", get_transactions, 3, 0);
     register_rpc_method!(
         registry,

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -291,11 +291,11 @@ fn test_json_rpc_protocol_invalid_requests() {
         ),
         (
             "invalid arguments: too many arguments",
-            json!({"jsonrpc": "2.0", "method": "get_account", "params": [1, 2], "id": 1}),
+            json!({"jsonrpc": "2.0", "method": "get_currencies", "params": [1, 2], "id": 1}),
             json!({
                 "error": {
                     "code": -32602,
-                    "message": "Invalid params: wrong number of arguments (given 2, expected 1)",
+                    "message": "Invalid params: wrong number of arguments (given 2, expected 0)",
                     "data": null
                 },
                 "id": 1,
@@ -307,11 +307,11 @@ fn test_json_rpc_protocol_invalid_requests() {
         ),
         (
             "invalid arguments: not enough arguments",
-            json!({"jsonrpc": "2.0", "method": "get_account", "id": 1}),
+            json!({"jsonrpc": "2.0", "method": "get_events", "id": 1}),
             json!({
                 "error": {
                     "code": -32602,
-                    "message": "Invalid params: wrong number of arguments (given 0, expected 1)",
+                    "message": "Invalid params: wrong number of arguments (given 0, expected 3)",
                     "data": null
                 },
                 "id": 1,
@@ -376,6 +376,22 @@ fn test_json_rpc_protocol_invalid_requests() {
                 "error": {
                     "code": -32602,
                     "message": "Invalid param account address(params[0]): should be hex-encoded string",
+                    "data": null
+                },
+                "id": 1,
+                "jsonrpc": "2.0",
+                "diem_chain_id": ChainId::test().id(),
+                "diem_ledger_timestampusec": timestamp,
+                "diem_ledger_version": version
+            }),
+        ),
+        (
+            "get_account: invalid version param type",
+            json!({"jsonrpc": "2.0", "method": "get_account", "params": ["e1b3d22871989e9fd9dc6814b2f4fc41", true], "id": 1}),
+            json!({
+                "error": {
+                    "code": -32602,
+                    "message": "Invalid param version(params[1]): should be unsigned int64",
                     "data": null
                 },
                 "id": 1,

--- a/json-rpc/tests/integration_test.rs
+++ b/json-rpc/tests/integration_test.rs
@@ -163,7 +163,8 @@ fn create_test_cases() -> Vec<Test> {
                         "received_events_key": "02000000000000000000000000000000000000000a550c18",
                         "role": { "type": "unknown" },
                         "sent_events_key": "03000000000000000000000000000000000000000a550c18",
-                        "sequence_number": 1
+                        "sequence_number": 1,
+                        "version": resp.diem_ledger_version,
                     }),
                 );
             },
@@ -222,7 +223,8 @@ fn create_test_cases() -> Vec<Test> {
                             "base_url_rotation_events_key": "0200000000000000000000000000000000000000000000dd",
                         },
                         "sent_events_key": "0400000000000000000000000000000000000000000000dd",
-                        "sequence_number": 2
+                        "sequence_number": 2,
+                        "version": resp.diem_ledger_version,
                     }),
                 );
             },
@@ -301,7 +303,8 @@ fn create_test_cases() -> Vec<Test> {
                             "base_url_rotation_events_key": "0200000000000000000000000000000000000000000000dd",
                         },
                         "sent_events_key": "0400000000000000000000000000000000000000000000dd",
-                        "sequence_number": 5
+                        "sequence_number": 5,
+                        "version": resp.diem_ledger_version,
                     }),
                 );
             },
@@ -334,7 +337,48 @@ fn create_test_cases() -> Vec<Test> {
                             "type": "parent_vasp"
                         },
                         "sent_events_key": format!("0300000000000000{}", address),
-                        "sequence_number": 1
+                        "sequence_number": 1,
+                        "version": resp.diem_ledger_version,
+                    }),
+                );
+            },
+        },
+        Test {
+            name: "get account by version",
+            run: |env: &mut testing::Env| {
+                let account = &env.vasps[0];
+                let address = format!("{:x}", &account.address);
+                // The account txn is creating child VASP.
+                let account_sequence = 0;
+
+                let resp = env.send("get_account_transaction", json!([address, account_sequence, false]));
+                let result = resp.result.unwrap();
+                let prev_version: u64 = result["version"].as_u64().unwrap() - 1;
+                let resp = env.send("get_account", json!([address, prev_version]));
+                let result = resp.result.unwrap();
+                assert_eq!(
+                    result,
+                    json!({
+                        "address": address,
+                        "authentication_key": account.auth_key().to_string(),
+                        "balances": [{"amount": 1000000000000_u64, "currency": "XUS"}],
+                        "delegated_key_rotation_capability": false,
+                        "delegated_withdrawal_capability": false,
+                        "is_frozen": false,
+                        "received_events_key": format!("0200000000000000{}", address),
+                        "role": {
+                            "base_url": "",
+                            "base_url_rotation_events_key": format!("0100000000000000{}", address),
+                            "compliance_key": "",
+                            "compliance_key_rotation_events_key": format!("0000000000000000{}", address),
+                            "expiration_time": 18446744073709551615_u64,
+                            "human_name": "Novi 0",
+                            "num_children": 0,
+                            "type": "parent_vasp"
+                        },
+                        "sent_events_key": format!("0300000000000000{}", address),
+                        "sequence_number": 0,
+                        "version": prev_version,
                     }),
                 );
             },
@@ -362,7 +406,8 @@ fn create_test_cases() -> Vec<Test> {
                             "parent_vasp_address": format!("{:x}", &parent.address),
                         },
                         "sent_events_key": format!("0100000000000000{}", address),
-                        "sequence_number": 0
+                        "sequence_number": 0,
+                        "version": resp.diem_ledger_version,
                     }),
                 );
             },

--- a/json-rpc/types/src/proto/jsonrpc.proto
+++ b/json-rpc/types/src/proto/jsonrpc.proto
@@ -59,6 +59,8 @@ message Account {
   bool is_frozen = 9 [json_name="delegated_withdrawal_capability"];
 
   AccountRole role = 10;
+  // the transaction version of the account
+  uint64 version = 11;
 }
 
 message AccountRole {

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -140,6 +140,9 @@ pub struct AccountView {
     pub delegated_withdrawal_capability: bool,
     pub is_frozen: bool,
     pub role: AccountRoleView,
+    // the transaction version of the account data
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<u64>,
 }
 
 impl AccountView {
@@ -149,6 +152,7 @@ impl AccountView {
         balances: BTreeMap<Identifier, BalanceResource>,
         account_role: AccountRole,
         freezing_bit: FreezingBit,
+        version: u64,
     ) -> Self {
         Self {
             address,
@@ -166,6 +170,7 @@ impl AccountView {
             delegated_withdrawal_capability: account.has_delegated_withdrawal_capability(),
             is_frozen: freezing_bit.is_frozen(),
             role: AccountRoleView::from(account_role),
+            version: Some(version),
         }
     }
 }


### PR DESCRIPTION

## Motivation

There are use cases require getting account data at same version, e.g. sum of child VASPs account balances.
Batch request may not fit for the case because the number of child VASPs maybe exceed the batch size limit.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Integration test.


