### PR TITLE
[move-prover] Add the `MVP_TEST_INCONSISTENCY` to `cargo test -p move-prover`

### DIFF
--- a/language/move-prover/tests/README.md
+++ b/language/move-prover/tests/README.md
@@ -11,9 +11,9 @@ configuring the prover are not set as described there, all tests and this direct
 those files, use `UPBL=1 cargo test`. To update or test a single file, you can also provide a fragment of the move
 source path.
 
-*Note*: there are two sets of tests here. The basic ones are those in `./sources` and in `../../diem-framework`. Those are run
-by default and are merge blockers for submitting changes. An extended set of tests is found `./xsources`. Those
-are only run if the environment variable `MVP_TEST_X=1` is set.
+*Note*: there are three sets of tests here. The basic ones are those in `./sources`, in `../../diem-framework`, and in
+`../../move-stdlib`. Those are run by default and are merge blockers for submitting changes. An extended set of tests is
+found `./xsources`. Those are only run if the environment variable `MVP_TEST_X=1` is set.
 
 There is a convention for test cases under this directory. In general, there are two kinds of test cases, which can be
 mixed in a file. The first type of test cases are "correct" Move functions which are expected to be proven so.
@@ -42,6 +42,16 @@ be able to pass at least with `-T=20`. To do so use
 
 ```shell script
 MVP_TEST_FLAGS="-T=20" cargo test -p move-prover
+```
+
+## Inconsistency Check
+If the flag `--check-inconsistency` is given, the prover not only verifies a target, but also checks if there is any
+inconsistent assumption in the verification. If the environment variable `MVP_TEST_INCONSISTENCY=1` is set, `cargo test`
+will perform the inconsistency check while running the tests in `../../diem-framework` and `../../move-stdlib` (i.e.,
+the prover will run those tests with the flag `--check-inconsistency`).
+
+```shell script
+MVP_TEST_INCONSISTENCY=1 cargo test -p move-prover
 ```
 
 ## Code coverage


### PR DESCRIPTION
-  This PR adds the `MVP_TEST_INCONSISTENCY` flag to the `cargo test` for Prover

- To check the inconsistency during the unit test for Prover, use the following command:
```
MVP_TEST_INCONSISTENCY=1 cargo test -p move-prover
```

Running time measured from a experiment on a local Macbook machine (using the default value of cores (i.e., 4))
- Without the "MVP_TEST_INCONSISTENCY flag
  -  53s when "T=20", "T=40" and "T=80"

- With the "MVP_TEST_INCONSISTENCY=1" flag
  -  4m 39s when "T=20"
  -  7m 10s when "T=40"
  -  12m 32s when "T=80"

## Motivation

Inconsistency check in CI

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test
MVP_TEST_INCONSISTENCY=1 cargo test

