### PR TITLE
[move-prover] Corrects the default "--cores" value displayed in the help message

### DIFF
--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -229,7 +229,7 @@ impl Options {
                     .validator(is_number)
                     .help("sets the number of cores to use. \
                      NOTE: multiple cores may currently lead to scrambled model \
-                     output from boogie (default 1)")
+                     output from boogie (default 4)")
             )
             .arg(
                 Arg::with_name("timeout")


### PR DESCRIPTION
- Prover actually uses 4 cores by default. The information in the Prover's "--help" message was not right.

## Motivation

To correct some information in the help message

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test

