### PR TITLE
[language] remove diem-types dependencies from move-lang

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4287,7 +4287,6 @@ dependencies = [
  "codespan-reporting",
  "datatest-stable",
  "diem-framework",
- "diem-types",
  "diem-workspace-hack",
  "difference",
  "fallible",

--- a/language/move-lang/Cargo.toml
+++ b/language/move-lang/Cargo.toml
@@ -23,7 +23,6 @@ fallible = { path = "../../common/fallible" }
 move-vm = { path = "../vm", package = "vm" }
 move-core-types = { path = "../move-core/types" }
 move-bytecode-verifier = { path = "../bytecode-verifier", package = "bytecode-verifier" }
-diem-types = { path = "../../types" }
 diem-workspace-hack = { path = "../../common/workspace-hack" }
 move-ir-types = {path = "../move-ir/types" }
 ir-to-bytecode = {path = "../compiler/ir-to-bytecode" }

--- a/language/move-lang/src/cfgir/translate.rs
+++ b/language/move-lang/src/cfgir/translate.rs
@@ -14,8 +14,7 @@ use crate::{
     shared::unique_map::UniqueMap,
     FullyCompiledProgram,
 };
-use diem_types::account_address::AccountAddress as DiemAddress;
-use move_core_types::value::MoveValue;
+use move_core_types::{account_address::AccountAddress as MoveAddress, value::MoveValue};
 use move_ir_types::location::*;
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -340,7 +339,7 @@ fn move_value_from_value(sp!(_, v_): Value) -> MoveValue {
     use MoveValue as MV;
     use Value_ as V;
     match v_ {
-        V::Address(a) => MV::Address(DiemAddress::new(a.to_u8())),
+        V::Address(a) => MV::Address(MoveAddress::new(a.to_u8())),
         V::U8(u) => MV::U8(u),
         V::U64(u) => MV::U64(u),
         V::U128(u) => MV::U128(u),

--- a/language/move-lang/src/to_bytecode/context.rs
+++ b/language/move-lang/src/to_bytecode/context.rs
@@ -6,7 +6,7 @@ use crate::{
     hlir::ast as H,
     parser::ast::{ConstantName, FunctionName, ModuleIdent, StructName, Var},
 };
-use diem_types::account_address::AccountAddress as DiemAddress;
+use move_core_types::account_address::AccountAddress as MoveAddress;
 use move_ir_types::ast as IR;
 use std::{
     clone::Clone,
@@ -217,7 +217,7 @@ impl<'a> Context<'a> {
         let name = Self::translate_module_name_(name);
         IR::ModuleIdent::Qualified(IR::QualifiedModuleIdent::new(
             name,
-            DiemAddress::new(address.to_u8()),
+            MoveAddress::new(address.to_u8()),
         ))
     }
 

--- a/language/move-lang/src/to_bytecode/translate.rs
+++ b/language/move-lang/src/to_bytecode/translate.rs
@@ -20,7 +20,7 @@ use crate::{
     FullyCompiledProgram,
 };
 use bytecode_source_map::source_map::SourceMap;
-use diem_types::account_address::AccountAddress as DiemAddress;
+use move_core_types::account_address::AccountAddress as MoveAddress;
 use move_ir_types::{ast as IR, location::*};
 use move_vm::file_format as F;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -187,7 +187,7 @@ fn module(
         })
         .collect();
 
-    let addr = DiemAddress::new(ident.value.0.to_u8());
+    let addr = MoveAddress::new(ident.value.0.to_u8());
     let mname = ident.value.1.clone();
     let friends = mdef
         .friends
@@ -860,7 +860,7 @@ fn exp_(context: &mut Context, code: &mut IR::BytecodeBlock, e: H::Exp) {
             code.push(sp(
                 loc,
                 match v.value {
-                    V::Address(a) => B::LdAddr(DiemAddress::new(a.to_u8())),
+                    V::Address(a) => B::LdAddr(MoveAddress::new(a.to_u8())),
                     V::Bytearray(bytes) => B::LdByteArray(bytes),
                     V::U8(u) => B::LdU8(u),
                     V::U64(u) => B::LdU64(u),

--- a/x.toml
+++ b/x.toml
@@ -235,7 +235,6 @@ existing_deps = [
     ["compiled-stdlib", "diem-crypto"],
     ["move-lang", "fallible"],
     ["move-lang", "diem-framework"],
-    ["move-lang", "diem-types"],
     ["move-lang", "datatest-stable"],
     ["move-lang-test-utils", "datatest-stable"],
     ["move-model", "diem-types"],


### PR DESCRIPTION
This removes the dependency on `diem-types` from `move-lang`.