### PR TITLE
[vm][bytecode-verifier] Improve compatibility checks around abilities

### DIFF
--- a/language/bytecode-verifier/src/dependencies.rs
+++ b/language/bytecode-verifier/src/dependencies.rs
@@ -9,7 +9,7 @@ use vm::{
     access::{ModuleAccess, ScriptAccess},
     errors::{verification_error, Location, PartialVMError, PartialVMResult, VMResult},
     file_format::{
-        Bytecode, CodeOffset, CompiledModule, CompiledScript, FunctionDefinitionIndex,
+        AbilitySet, Bytecode, CodeOffset, CompiledModule, CompiledScript, FunctionDefinitionIndex,
         FunctionHandleIndex, ModuleHandleIndex, SignatureToken, StructHandleIndex, TableIndex,
         Visibility,
     },
@@ -209,8 +209,11 @@ fn verify_imported_structs(context: &Context) -> PartialVMResult<()> {
         {
             Some(def_idx) => {
                 let def_handle = owner_module.struct_handle_at(*def_idx);
-                if struct_handle.abilities != def_handle.abilities
-                    || struct_handle.type_parameters != def_handle.type_parameters
+                if !compatible_struct_abilities(struct_handle.abilities, def_handle.abilities)
+                    || !compatible_type_parameters(
+                        &struct_handle.type_parameters,
+                        &def_handle.type_parameters,
+                    )
                 {
                     return Err(verification_error(
                         StatusCode::TYPE_MISMATCH,
@@ -249,8 +252,11 @@ fn verify_imported_functions(context: &Context) -> PartialVMResult<()> {
         {
             Some(def_idx) => {
                 let def_handle = owner_module.function_handle_at(*def_idx);
-                // same type parameter constraints
-                if function_handle.type_parameters != def_handle.type_parameters {
+                // compatible type parameter constraints
+                if !compatible_type_parameters(
+                    &function_handle.type_parameters,
+                    &def_handle.type_parameters,
+                ) {
                     return Err(verification_error(
                         StatusCode::TYPE_MISMATCH,
                         IndexKind::FunctionHandle,
@@ -309,6 +315,41 @@ fn verify_imported_functions(context: &Context) -> PartialVMResult<()> {
         }
     }
     Ok(())
+}
+
+// The local view must be a subset of (or equal to) the defined set of abilities. Conceptually, the
+// local view can be more constrained than the defined one. Removing abilities locally does nothing
+// but limit the local usage.
+// (Note this works because there are no negative constraints, i.e. you cannot constrain a type
+// parameter with the absence of an ability)
+fn compatible_struct_abilities(
+    local_struct_abilities_declaration: AbilitySet,
+    defined_struct_abilities: AbilitySet,
+) -> bool {
+    local_struct_abilities_declaration.is_subset(defined_struct_abilities)
+}
+
+// - The number of type parameters must be the same
+// - For each type parameter, the local view must be a superset of (or equal to) the defined
+//   constraints. Conceptually, the local view can be more constrained than the defined one as the
+//   local context is only limiting usage, and cannot take advantage of the additional constraints.
+fn compatible_type_parameters(
+    local_type_parameters_declaration: &[AbilitySet],
+    defined_type_parameters: &[AbilitySet],
+) -> bool {
+    local_type_parameters_declaration.len() == defined_type_parameters.len()
+        && local_type_parameters_declaration
+            .iter()
+            .zip(defined_type_parameters)
+            .all(
+                |(
+                    local_type_parameter_constraints_declaration,
+                    defined_type_parameter_constraints,
+                )| {
+                    (*defined_type_parameter_constraints)
+                        .is_subset(*local_type_parameter_constraints_declaration)
+                },
+            )
 }
 
 fn compare_cross_module_signatures(

--- a/language/vm/src/compatibility.rs
+++ b/language/vm/src/compatibility.rs
@@ -1,7 +1,10 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{file_format::Visibility, normalized::Module};
+use crate::{
+    file_format::{AbilitySet, Visibility},
+    normalized::Module,
+};
 use std::collections::BTreeSet;
 
 /// The result of a linking and layout compatibility check. Here is what the different combinations
@@ -35,41 +38,9 @@ impl Compatibility {
         }
 
         // old module's structs are a subset of the new module's structs
-        for old_struct in &old_module.structs {
-            match new_module
-                .structs
-                .iter()
-                .find(|s| s.name == old_struct.name)
-            {
-                Some(new_struct) => {
-                    if new_struct.abilities != old_struct.abilities
-                        || new_struct.type_parameters != old_struct.type_parameters
-                    {
-                        // Declared kind and/or type parameters changed. Existing modules that depend on this struct will fail to link with the new version of the module
-                        struct_and_function_linking = false;
-                        // This does not change the struct layout, but it may leave some published
-                        // values "orphaned". For example: if
-                        // `resource struct S<T: copyable> { t : T }` is changed to
-                        // `resource struct S<T: resource> { t : T}`, code can no longer access
-                        // published values of type (e.g.) `S<u64>`.
-                    }
-                    if new_struct.fields != old_struct.fields {
-                        // Fields changed. Code in this module will fail at runtime if it tries to
-                        // read a previously published struct value
-                        // TODO: this is a stricter definition than required. We could in principle
-                        // choose to label the following as compatible
-                        // (1) changing the name (but not position or type) of a field. The VM does
-                        //     not care about the name of a field (it's purely informational), but
-                        //     clients presumably do.
-                        // (2) changing the type of a field to a different, but layout and kind
-                        //     compatible type. E.g. `struct S { b: bool }` to `struct S { b: B }`
-                        // where
-                        //     B is struct B { some_name: bool }. TODO: does this affect clients? I
-                        //     think not--the serialization of the same data with these two types
-                        //     will be the same.
-                        struct_layout = false
-                    }
-                }
+        for (name, old_struct) in &old_module.structs {
+            let new_struct = match new_module.structs.get(name) {
+                Some(new_struct) => new_struct,
                 None => {
                     // Struct not present in new . Existing modules that depend on this struct will fail to link with the new version of the module.
                     struct_and_function_linking = false;
@@ -83,7 +54,33 @@ impl Compatibility {
                     // in module `Child` will continue to run without error. But values of type
                     // `Parent::T` in `Child` are now "orphaned" in the sense that `Parent` no
                     // longer exposes any API for reading/writing them.
+                    continue;
                 }
+            };
+
+            if !struct_abilities_compatibile(old_struct.abilities, new_struct.abilities)
+                || !type_parameters_compatibile(
+                    &old_struct.type_parameters,
+                    &new_struct.type_parameters,
+                )
+            {
+                struct_and_function_linking = false;
+            }
+            if new_struct.fields != old_struct.fields {
+                // Fields changed. Code in this module will fail at runtime if it tries to
+                // read a previously published struct value
+                // TODO: this is a stricter definition than required. We could in principle
+                // choose to label the following as compatible
+                // (1) changing the name (but not position or type) of a field. The VM does
+                //     not care about the name of a field (it's purely informational), but
+                //     clients presumably do.
+                // (2) changing the type of a field to a different, but layout and kind
+                //     compatible type. E.g. `struct S { b: bool }` to `struct S { b: B }`
+                // where
+                //     B is struct B { some_name: bool }. TODO: does this affect clients? I
+                //     think not--the serialization of the same data with these two types
+                //     will be the same.
+                struct_layout = false
             }
         }
 
@@ -101,19 +98,32 @@ impl Compatibility {
         // we can remove/change a friend function if the function is not used by any module in the
         // friend list. But for simplicity, we decided to go to the more restrictive form now and
         // we may revisit this in the future.
-        for (func_sig, old_vis) in &old_module.exposed_functions {
-            let new_vis_opt = new_module.exposed_functions.get(func_sig);
-            let is_compatible = match (old_vis, new_vis_opt) {
-                (Visibility::Public, Some(Visibility::Public)) => true,
+        for (name, old_func) in &old_module.exposed_functions {
+            let new_func = match new_module.exposed_functions.get(name) {
+                Some(new_func) => new_func,
+                None => {
+                    struct_and_function_linking = false;
+                    continue;
+                }
+            };
+            let is_vis_compatible = match (old_func.visibility, new_func.visibility) {
+                (Visibility::Public, Visibility::Public) => true,
                 (Visibility::Public, _) => false,
-                (Visibility::Script, Some(Visibility::Script)) => true,
+                (Visibility::Script, Visibility::Script) => true,
                 (Visibility::Script, _) => false,
-                (Visibility::Friend, Some(Visibility::Public)) => true,
-                (Visibility::Friend, Some(Visibility::Friend)) => true,
+                (Visibility::Friend, Visibility::Public)
+                | (Visibility::Friend, Visibility::Friend) => true,
                 (Visibility::Friend, _) => false,
                 (Visibility::Private, _) => unreachable!("A private function can never be exposed"),
             };
-            if !is_compatible {
+            if !is_vis_compatible
+                || old_func.parameters != new_func.parameters
+                || old_func.return_ != new_func.return_
+                || !type_parameters_compatibile(
+                    &old_func.type_parameters,
+                    &new_func.type_parameters,
+                )
+            {
                 struct_and_function_linking = false;
             }
         }
@@ -137,4 +147,36 @@ impl Compatibility {
             struct_layout,
         }
     }
+}
+
+// When upgrading, the new abilities must be a superset of the old abilities.
+// Adding an ability is fine, but removing an ability could cause existing usages to fail.
+fn struct_abilities_compatibile(old_abilities: AbilitySet, new_abilities: AbilitySet) -> bool {
+    old_abilities.is_subset(new_abilities)
+}
+
+// When upgrading, the new type parameters must be the same length, and the new type parameter
+// constraints must be compatible
+fn type_parameters_compatibile(
+    old_type_parameters: &[AbilitySet],
+    new_type_parameters: &[AbilitySet],
+) -> bool {
+    old_type_parameters.len() == new_type_parameters.len()
+        && old_type_parameters.iter().zip(new_type_parameters).all(
+            |(old_type_parameter_constraint, new_type_parameter_constraint)| {
+                type_parameter_constraints_compatibile(
+                    *old_type_parameter_constraint,
+                    *new_type_parameter_constraint,
+                )
+            },
+        )
+}
+
+// When upgrading, the new constraints must be a subset of (or equal to) the old constraints.
+// Removing an ability is fine, but adding an ability could cause existing callsites to fail
+fn type_parameter_constraints_compatibile(
+    old_type_constraints: AbilitySet,
+    new_type_constraints: AbilitySet,
+) -> bool {
+    new_type_constraints.is_subset(old_type_constraints)
 }

--- a/language/vm/src/file_format.rs
+++ b/language/vm/src/file_format.rs
@@ -382,7 +382,7 @@ pub struct FieldDefinition {
 
 /// `Visibility` restricts the accessibility of the associated entity.
 /// - For function visibility, it restricts who may call into the associated function.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
 #[repr(u8)]


### PR DESCRIPTION
- Improve compatibility checks in upgrades for abilities
    - New struct abilities must be a superset of the old
    - New type parameter constraints must be a subset of the old
- Improve dependency/linking check to allow for these upgrades
    - Local view of struct abilities must be a subset of the defined
    - Local view of type parameter constraints must be a superset of the defined
    
## Motivation

- Necessary to support abilities properly after the release 

## Test Plan

- We can't really test linking easily at the moment
- @mengxu-fb, anything to do for compatibility/upgrade tests?