### PR TITLE
Add sdk versions to prometheus

### DIFF
--- a/json-rpc/src/counters.rs
+++ b/json-rpc/src/counters.rs
@@ -29,9 +29,10 @@ pub static REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
         "diem_client_service_requests_count",
         "Cumulative number of requests that JSON RPC client service receives",
         &[
-            "type",   // batch / single
+            "type",     // batch / single
             "method", // method of request, matches JSON RPC method name (e.g. "submit", "get_account")
             "result", // result of request: "success", "fail"
+            "sdk_lang", // the language of the SDK: "java", "python", etc
         ]
     )
     .unwrap()
@@ -46,6 +47,7 @@ pub static INVALID_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
             "type",      // batch / single
             "method", // method of request, matches JSON RPC method name (e.g. "submit", "get_account")
             "errortype", // categories of invalid requests: "invalid_format", "invalid_params", "invalid_method", "method_not_found"
+            "sdk_lang",  // the language of the SDK: "java", "python", etc
         ]
     )
     .unwrap()
@@ -60,6 +62,7 @@ pub static INTERNAL_ERRORS: Lazy<IntCounterVec> = Lazy::new(|| {
             "type",      // batch / single
             "method", // method of request, matches JSON RPC method name (e.g. "submit", "get_account")
             "errorcode", // error code
+            "sdk_lang", // the language of the SDK: "java", "python", etc
         ]
     )
     .unwrap()

--- a/json-rpc/src/fuzzing.rs
+++ b/json-rpc/src/fuzzing.rs
@@ -139,7 +139,7 @@ pub fn request_fuzzer(json_request: serde_json::Value) {
         }
     });
     let body = rt.block_on(async {
-        let reply = runtime::rpc_endpoint(json_request, service, registry)
+        let reply = runtime::rpc_endpoint(json_request, service, registry, None)
             .await
             .unwrap();
 

--- a/json-rpc/src/util.rs
+++ b/json-rpc/src/util.rs
@@ -54,6 +54,50 @@ macro_rules! register_rpc_method {
     };
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SdkLang {
+    Rust,
+    Java,
+    Python,
+    Typescript,
+    Go,
+    CSharp,
+    Cpp,
+    Unknown,
+}
+
+impl SdkLang {
+    pub fn from_user_agent(user_agent: &str) -> SdkLang {
+        // parse our sdk user agent strings, i.e `diem-client-sdk-python / 0.1.12`
+        if let Some(sdk_lang_part) = user_agent.to_lowercase().split('/').next() {
+            return match str::trim(sdk_lang_part) {
+                "diem-client-sdk-rust" => SdkLang::Rust,
+                "diem-client-sdk-java" => SdkLang::Java,
+                "diem-client-sdk-python" => SdkLang::Python,
+                "diem-client-sdk-typescript" => SdkLang::Typescript,
+                "diem-client-sdk-golang" => SdkLang::Go,
+                "diem-client-sdk-csharp" => SdkLang::CSharp,
+                "diem-client-sdk-cpp" => SdkLang::Cpp,
+                _ => SdkLang::Unknown,
+            };
+        }
+        SdkLang::Unknown
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SdkLang::Rust => "rust",
+            SdkLang::Java => "java",
+            SdkLang::Python => "python",
+            SdkLang::Typescript => "typescript",
+            SdkLang::Go => "golang",
+            SdkLang::CSharp => "csharp",
+            SdkLang::Cpp => "cpp",
+            SdkLang::Unknown => "unknown",
+        }
+    }
+}
+
 pub fn vm_status_view_from_kept_vm_status(status: &KeptVMStatus) -> VMStatusView {
     match status {
         KeptVMStatus::Executed => VMStatusView::Executed,
@@ -205,5 +249,12 @@ pub fn script_view_from_script_function(script: &ScriptFunction) -> ScriptView {
         ),
         type_arguments: Some(ty_args),
         ..Default::default()
+    }
+}
+
+pub fn sdk_language_from_user_agent(user_agent: Option<&str>) -> SdkLang {
+    match user_agent {
+        Some(user_agent) => SdkLang::from_user_agent(user_agent),
+        None => SdkLang::Unknown,
     }
 }


### PR DESCRIPTION
## Motivation
When the association scrapes fullnode /metrics endpoints, we would also like to get the sdk language being used for the jsonRPC requests

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
yes

## Test Plan
unit tests


## If targeting a release branch, please fill the below out as well
Affects jsonRPC endpoints. No breaking changes- just prometheus metrics changes
We would like to have this in for the launch so that the ecosystem team can understand what SDKs people are using for development, and guide our resource allocation accordingly.