### PR TITLE
[ci] add RUSTSEC-2020-0146 to nightly ignore list

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -30,8 +30,9 @@ jobs:
       - name: audit crates
         # List of ignored RUSTSEC
         # 1. RUSTSEC-2021-0020 - Not impacted, see #7723
+        # 2. RUSTSEC-2020-0146 - Not impacted, see #7826
         run: |
-          $CARGO $CARGOFLAGS audit --ignore RUSTSEC-2021-0020 >> $MESSAGE_PAYLOAD_FILE
+          $CARGO $CARGOFLAGS audit --ignore RUSTSEC-2021-0020 --ignore RUSTSEC-2020-0146 >> $MESSAGE_PAYLOAD_FILE
       - uses: ./.github/actions/slack-file
         with:
           webhook: ${{ secrets.WEBHOOK_AUDIT }}


### PR DESCRIPTION
## Motivation
The vulnerable version of generic-array is a transitive dep. Adding it to the nightly ignore list to keep the audit actionable. 

## Test Plan
CI + cargo audit