### PR TITLE
[move cli] specify `main` branch in `cargo install --git` command

### DIFF
--- a/language/tools/move-cli/README.md
+++ b/language/tools/move-cli/README.md
@@ -10,7 +10,7 @@ $ cargo install --path diem/language/tools/move-cli
 ```
 or
 ```shell
-$ cargo install --git https://github.com/diem/diem move-cli
+$ cargo install --git https://github.com/diem/diem move-cli --branch main
 ```
 
 This will install the `move` binary in your Cargo binary directory. On


### PR DESCRIPTION
`cargo install --git` uses the `master` branch by default, but diem recently switched its primary branch name from `master` to `main`. Pointing at `main` will ensure that users get the latest copy of the CLI.