### PR TITLE
[scratchpad] fix clowntown

### DIFF
--- a/storage/scratchpad/src/sparse_merkle/mod.rs
+++ b/storage/scratchpad/src/sparse_merkle/mod.rs
@@ -74,8 +74,7 @@ mod node;
 #[cfg(test)]
 mod sparse_merkle_test;
 
-use self::node::LeafValue;
-use crate::sparse_merkle::node::{Node, SubTree};
+use crate::sparse_merkle::node::{LeafValue, Node, SubTree};
 use arc_swap::{ArcSwap, ArcSwapOption};
 use diem_crypto::{
     hash::{CryptoHash, HashValueBitIterator, SPARSE_MERKLE_PLACEHOLDER_HASH},
@@ -124,7 +123,7 @@ impl<V: CryptoHash> Inner<V> {
         // Replace the link to the root node with a weak reference, so all nodes created by this
         // version can be dropped. A weak link is still maintained so that if it's cached somehow,
         // we still have access to it without resorting to the DB.
-        self.root.store(Arc::new(self.root.load().as_ref().weak()));
+        self.root.store(Arc::new(self.root.load().weak()));
         // Disconnect the base tree, so that nodes created by previous versions can be dropped.
         self.base.store(None);
     }

--- a/storage/scratchpad/src/sparse_merkle/node.rs
+++ b/storage/scratchpad/src/sparse_merkle/node.rs
@@ -220,8 +220,8 @@ pub enum LeafValue<V> {
 impl<V: CryptoHash> LeafValue<V> {
     pub fn calc_hash(&self) -> HashValue {
         match self {
-            LeafValue::Value(ref val) => val.hash(),
-            LeafValue::ValueHash(ref val_hash) => *val_hash,
+            LeafValue::Value(val) => val.hash(),
+            LeafValue::ValueHash(val_hash) => *val_hash,
         }
     }
 }


### PR DESCRIPTION



## Motivation
1. replace IDE generated `use self::xx` with `use crate::`
2. remove unnecessary `ref` in a match clause.
3. remove unnecessary `as_ref()` on a ArcSwap load guard.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
Y

## Test Plan
existing coverage

## Related PRs
introduced by #7957