### PR TITLE
[RPC][Metrics] Add SDK language + version to prometheus metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1786,6 +1786,7 @@ dependencies = [
  "once_cell",
  "proptest",
  "rand 0.8.3",
+ "regex",
  "reqwest",
  "scratchpad",
  "serde",

--- a/json-rpc/Cargo.toml
+++ b/json-rpc/Cargo.toml
@@ -23,6 +23,7 @@ tokio = { version = "1.3.0", features = ["full"] }
 warp = { version = "0.3.0", features = ["tls"] }
 reqwest = { version = "0.11.2", features = ["blocking", "json"], default_features = false, optional = true }
 proptest = { version = "1.0.0", optional = true }
+regex = { version = "1.4.3", default-features = false, features = ["std", "perf"] }
 
 bcs = "0.1.2"
 compiled-stdlib = { path = "../language/diem-framework/compiled" }

--- a/json-rpc/src/counters.rs
+++ b/json-rpc/src/counters.rs
@@ -33,6 +33,7 @@ pub static REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
             "method", // method of request, matches JSON RPC method name (e.g. "submit", "get_account")
             "result", // result of request: "success", "fail"
             "sdk_lang", // the language of the SDK: "java", "python", etc
+            "sdk_ver", // the version of the SDK: "0.0.11", "1.45.31", etc
         ]
     )
     .unwrap()
@@ -48,6 +49,7 @@ pub static INVALID_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
             "method", // method of request, matches JSON RPC method name (e.g. "submit", "get_account")
             "errortype", // categories of invalid requests: "invalid_format", "invalid_params", "invalid_method", "method_not_found"
             "sdk_lang",  // the language of the SDK: "java", "python", etc
+            "sdk_ver",   // the version of the SDK: "0.0.11", "1.45.31", etc
         ]
     )
     .unwrap()
@@ -63,6 +65,7 @@ pub static INTERNAL_ERRORS: Lazy<IntCounterVec> = Lazy::new(|| {
             "method", // method of request, matches JSON RPC method name (e.g. "submit", "get_account")
             "errorcode", // error code
             "sdk_lang", // the language of the SDK: "java", "python", etc
+            "sdk_ver", // the version of the SDK: "0.0.11", "1.45.31", etc
         ]
     )
     .unwrap()

--- a/json-rpc/src/util.rs
+++ b/json-rpc/src/util.rs
@@ -11,7 +11,9 @@ use diem_types::{
     vm_status::{AbortLocation, KeptVMStatus},
 };
 use move_core_types::language_storage::{StructTag, TypeTag};
-use std::convert::TryFrom;
+use once_cell::sync::Lazy;
+use regex::Regex;
+use std::{convert::TryFrom, fmt, str::FromStr};
 
 /// Helper macros. Used to simplify adding new RpcHandler to Registry
 /// `registry` - name of local registry variable
@@ -66,22 +68,24 @@ pub enum SdkLang {
     Unknown,
 }
 
-impl SdkLang {
-    pub fn from_user_agent(user_agent: &str) -> SdkLang {
-        // parse our sdk user agent strings, i.e `diem-client-sdk-python / 0.1.12`
-        if let Some(sdk_lang_part) = user_agent.to_lowercase().split('/').next() {
-            return match str::trim(sdk_lang_part) {
-                "diem-client-sdk-rust" => SdkLang::Rust,
-                "diem-client-sdk-java" => SdkLang::Java,
-                "diem-client-sdk-python" => SdkLang::Python,
-                "diem-client-sdk-typescript" => SdkLang::Typescript,
-                "diem-client-sdk-golang" => SdkLang::Go,
-                "diem-client-sdk-csharp" => SdkLang::CSharp,
-                "diem-client-sdk-cpp" => SdkLang::Cpp,
-                _ => SdkLang::Unknown,
-            };
-        }
+impl Default for SdkLang {
+    fn default() -> Self {
         SdkLang::Unknown
+    }
+}
+
+impl SdkLang {
+    pub fn from_str(user_agent_part: &str) -> SdkLang {
+        match str::trim(user_agent_part) {
+            "diem-client-sdk-rust" => SdkLang::Rust,
+            "diem-client-sdk-java" => SdkLang::Java,
+            "diem-client-sdk-python" => SdkLang::Python,
+            "diem-client-sdk-typescript" => SdkLang::Typescript,
+            "diem-client-sdk-golang" => SdkLang::Go,
+            "diem-client-sdk-csharp" => SdkLang::CSharp,
+            "diem-client-sdk-cpp" => SdkLang::Cpp,
+            _ => SdkLang::Unknown,
+        }
     }
 
     pub fn as_str(self) -> &'static str {
@@ -95,6 +99,65 @@ impl SdkLang {
             SdkLang::Cpp => "cpp",
             SdkLang::Unknown => "unknown",
         }
+    }
+}
+
+static SDK_VERSION_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"\b([0-3])\.(\d{1,2})\.(\d{1,2})\b").unwrap());
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct SdkVersion {
+    pub major: u16,
+    pub minor: u16,
+    pub patch: u16,
+}
+
+impl SdkVersion {
+    pub fn from_str(user_agent_part: &str) -> SdkVersion {
+        if let Some(captures) = SDK_VERSION_REGEX.captures(user_agent_part) {
+            if captures.len() == 4 {
+                if let (Ok(major), Ok(minor), Ok(patch)) = (
+                    u16::from_str(&captures[1]),
+                    u16::from_str(&captures[2]),
+                    u16::from_str(&captures[3]),
+                ) {
+                    return SdkVersion {
+                        major,
+                        minor,
+                        patch,
+                    };
+                }
+            }
+        }
+        SdkVersion::default()
+    }
+}
+
+impl fmt::Display for SdkVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+#[derive(Clone, Copy, Default, Debug, Eq, PartialEq)]
+pub struct SdkInfo {
+    pub language: SdkLang,
+    pub version: SdkVersion,
+}
+
+impl SdkInfo {
+    pub fn from_user_agent(user_agent: &str) -> SdkInfo {
+        // parse our sdk user agent strings, i.e `diem-client-sdk-python / 0.1.12`
+        let lowercase_user_agent = user_agent.to_lowercase();
+        let user_agent_parts: Vec<&str> = lowercase_user_agent.split('/').collect();
+        if user_agent_parts.len() == 2 {
+            let language = SdkLang::from_str(&user_agent_parts[0]);
+            let version = SdkVersion::from_str(&user_agent_parts[1]);
+            if language != SdkLang::Unknown && version != SdkVersion::default() {
+                return SdkInfo { language, version };
+            }
+        }
+        SdkInfo::default()
     }
 }
 
@@ -252,9 +315,9 @@ pub fn script_view_from_script_function(script: &ScriptFunction) -> ScriptView {
     }
 }
 
-pub fn sdk_language_from_user_agent(user_agent: Option<&str>) -> SdkLang {
+pub fn sdk_info_from_user_agent(user_agent: Option<&str>) -> SdkInfo {
     match user_agent {
-        Some(user_agent) => SdkLang::from_user_agent(user_agent),
-        None => SdkLang::Unknown,
+        Some(user_agent) => SdkInfo::from_user_agent(user_agent),
+        None => SdkInfo::default(),
     }
 }


### PR DESCRIPTION
## Motivation
Add the versions to existing languages that SDK metrics are publishing now


### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
yes

## Test Plan
Unit tests


## Related PRs
PR #8007

## If targeting a release branch, please fill the below out as well
Affects jsonRPC endpoints. No breaking changes- just prometheus metrics changes
We would like to have this in for the launch so that the ecosystem team can understand what SDKs people are using for development, and guide our resource allocation accordingly.