### PR TITLE
[move-prover] turning strong edges on by default in borrow analysis

### DIFF
--- a/language/move-prover/bytecode/src/borrow_analysis.rs
+++ b/language/move-prover/bytecode/src/borrow_analysis.rs
@@ -313,12 +313,12 @@ impl BorrowAnnotation {
 
 /// Borrow analysis processor.
 pub struct BorrowAnalysisProcessor {
-    strong_edges: bool,
+    weak_edges: bool,
 }
 
 impl BorrowAnalysisProcessor {
-    pub fn new(strong_edges: bool) -> Box<Self> {
-        Box::new(BorrowAnalysisProcessor { strong_edges })
+    pub fn new(weak_edges: bool) -> Box<Self> {
+        Box::new(BorrowAnalysisProcessor { weak_edges })
     }
 }
 
@@ -334,7 +334,7 @@ impl FunctionTargetProcessor for BorrowAnalysisProcessor {
             BorrowAnnotation(BTreeMap::new())
         } else {
             let func_target = FunctionTarget::new(func_env, &data);
-            let analyzer = BorrowAnalysis::new(&func_target, self.strong_edges);
+            let analyzer = BorrowAnalysis::new(&func_target, self.weak_edges);
             let result = analyzer.analyze(&data.code);
             let propagator = PropagateSplicedAnalysis::new(result);
             BorrowAnnotation(propagator.run(&data.code))
@@ -376,11 +376,11 @@ impl FunctionTargetProcessor for BorrowAnalysisProcessor {
 struct BorrowAnalysis<'a> {
     func_target: &'a FunctionTarget<'a>,
     livevar_annotation: &'a LiveVarAnnotation,
-    strong_edges: bool,
+    weak_edges: bool,
 }
 
 impl<'a> BorrowAnalysis<'a> {
-    fn new(func_target: &'a FunctionTarget<'a>, strong_edges: bool) -> Self {
+    fn new(func_target: &'a FunctionTarget<'a>, weak_edges: bool) -> Self {
         let livevar_annotation = func_target
             .get_annotations()
             .get::<LiveVarAnnotation>()
@@ -389,7 +389,7 @@ impl<'a> BorrowAnalysis<'a> {
         Self {
             func_target,
             livevar_annotation,
-            strong_edges,
+            weak_edges,
         }
     }
 
@@ -476,7 +476,7 @@ impl<'a> TransferFunctions for BorrowAnalysis<'a> {
                     }
                     AssignKind::Copy => {
                         state.add_node(dest_node.clone());
-                        if self.strong_edges {
+                        if !self.weak_edges {
                             state.add_edge(
                                 src_node,
                                 dest_node,
@@ -499,7 +499,7 @@ impl<'a> TransferFunctions for BorrowAnalysis<'a> {
                         let dest_node = self.borrow_node(dests[0]);
                         let src_node = self.borrow_node(srcs[0]);
                         state.add_node(dest_node.clone());
-                        if self.strong_edges {
+                        if !self.weak_edges {
                             state.add_edge(
                                 src_node,
                                 dest_node,
@@ -518,7 +518,7 @@ impl<'a> TransferFunctions for BorrowAnalysis<'a> {
                             id: *sid,
                         });
                         state.add_node(dest_node.clone());
-                        if self.strong_edges {
+                        if !self.weak_edges {
                             state.add_edge(
                                 src_node,
                                 dest_node,
@@ -534,7 +534,7 @@ impl<'a> TransferFunctions for BorrowAnalysis<'a> {
                         let dest_node = self.borrow_node(dests[0]);
                         let src_node = self.borrow_node(srcs[0]);
                         state.add_node(dest_node.clone());
-                        if self.strong_edges {
+                        if !self.weak_edges {
                             state.add_edge(
                                 src_node,
                                 dest_node,
@@ -592,7 +592,7 @@ impl<'a> TransferFunctions for BorrowAnalysis<'a> {
                                         .global_env()
                                         .get_extension::<VecBorMutInfo>()
                                         .unwrap();
-                                    if self.strong_edges
+                                    if !self.weak_edges
                                         && vec_bor_mut_info.0.is_some()
                                         && mid == &vec_bor_mut_info.0.unwrap().0
                                         && fid == &vec_bor_mut_info.0.unwrap().1

--- a/language/move-prover/bytecode/tests/testsuite.rs
+++ b/language/move-prover/bytecode/tests/testsuite.rs
@@ -64,7 +64,7 @@ fn get_tested_transformation_pipeline(
             pipeline.add_processor(MutRefInstrumenter::new());
             pipeline.add_processor(ReachingDefProcessor::new());
             pipeline.add_processor(LiveVarAnalysisProcessor::new());
-            pipeline.add_processor(BorrowAnalysisProcessor::new(false));
+            pipeline.add_processor(BorrowAnalysisProcessor::new(true));
             Ok(Some(pipeline))
         }
         "borrow_strong" => {
@@ -73,7 +73,7 @@ fn get_tested_transformation_pipeline(
             pipeline.add_processor(MutRefInstrumenter::new());
             pipeline.add_processor(ReachingDefProcessor::new());
             pipeline.add_processor(LiveVarAnalysisProcessor::new());
-            pipeline.add_processor(BorrowAnalysisProcessor::new(true));
+            pipeline.add_processor(BorrowAnalysisProcessor::new(false));
             Ok(Some(pipeline))
         }
         "memory_instr" => {

--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -75,10 +75,10 @@ pub struct Options {
     pub errmapgen: ErrmapOptions,
     /// Whether to run experimental pipeline
     pub experimental_pipeline: bool,
-    /// Whether to use strong edges in borrow analysis
-    pub strong_edges: bool,
     /// Whether to use the next major version instead of the current one
     pub vnext: bool,
+    /// Whether to use exclusively weak edges in borrow analysis
+    pub weak_edges: bool,
 }
 
 impl Default for Options {
@@ -101,8 +101,8 @@ impl Default for Options {
             abigen: AbigenOptions::default(),
             errmapgen: ErrmapOptions::default(),
             experimental_pipeline: false,
-            strong_edges: false,
             vnext: false,
+            weak_edges: false,
         }
     }
 }
@@ -375,9 +375,9 @@ impl Options {
                     .help("whether to run experimental pipeline")
             )
             .arg(
-                Arg::with_name("strong_edges")
-                    .long("strong_edges")
-                    .help("whether to use strong edges in borrow analysis")
+                Arg::with_name("weak-edges")
+                    .long("weak-edges")
+                    .help("whether to use exclusively weak edges in borrow analysis")
             )
             .arg(
                 Arg::with_name("exp_mut_param")
@@ -515,8 +515,8 @@ impl Options {
         if matches.is_present("experimental_pipeline") {
             options.experimental_pipeline = true;
         }
-        if matches.is_present("strong_edges") {
-            options.strong_edges = true;
+        if matches.is_present("weak-edges") {
+            options.weak_edges = true;
         }
         if matches.is_present("timeout") {
             options.backend.vc_timeout = matches.value_of("timeout").unwrap().parse::<usize>()?;

--- a/language/move-prover/src/pipelines.rs
+++ b/language/move-prover/src/pipelines.rs
@@ -21,7 +21,7 @@ pub fn pipelines(options: &Options) -> Vec<Box<dyn FunctionTargetProcessor>> {
             MutRefInstrumenter::new(),
             ReachingDefProcessor::new(),
             LiveVarAnalysisProcessor::new(),
-            BorrowAnalysisProcessor::new(options.strong_edges),
+            BorrowAnalysisProcessor::new(options.weak_edges),
             MemoryInstrumentationProcessor::new(),
             CleanAndOptimizeProcessor::new(),
             UsageProcessor::new(),


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Strong edge borrow analysis should have better verification time than weak edge borrow analysis. Strong edges are currently off by default and this commit will turn them on by default.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests.