### PR TITLE
[move-prover] output disassembled move bytecode for debugging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4387,6 +4387,7 @@ dependencies = [
  "datatest-stable",
  "diem-temppath",
  "diem-workspace-hack",
+ "disassembler",
  "docgen",
  "errmapgen",
  "futures",

--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -1401,6 +1401,11 @@ impl<'env> ModuleEnv<'env> {
         &self.data.module
     }
 
+    /// Gets the source map for the module
+    pub fn get_source_map(&'env self) -> &'env SourceMap<MoveIrLoc> {
+        &self.data.source_map
+    }
+
     /// Gets a `NamedConstantEnv` in this module by name
     pub fn find_named_constant(&'env self, name: Symbol) -> Option<NamedConstantEnv<'env>> {
         let id = NamedConstantId(name);

--- a/language/move-prover/Cargo.toml
+++ b/language/move-prover/Cargo.toml
@@ -20,6 +20,7 @@ diem-temppath = { path = "../../common/temppath" }
 diem-workspace-hack = { path = "../../common/workspace-hack" }
 bytecode-source-map = { path = "../compiler/bytecode-source-map" }
 move-ir-types = { path = "../move-ir/types" }
+disassembler = { path = "../tools/disassembler" }
 
 # external dependencies
 async-trait = "0.1.42"

--- a/language/move-prover/src/lib.rs
+++ b/language/move-prover/src/lib.rs
@@ -19,7 +19,9 @@ use bytecode::{
     read_write_set_analysis::{self, ReadWriteSetProcessor},
     spec_instrumentation::SpecInstrumentationProcessor,
 };
+use bytecode_source_map::mapping::SourceMapping;
 use codespan_reporting::term::termcolor::{ColorChoice, StandardStream, WriteColor};
+use disassembler::disassembler::{Disassembler, DisassemblerOptions};
 use docgen::Docgen;
 use errmapgen::ErrmapGen;
 use handlebars::Handlebars;
@@ -274,6 +276,30 @@ fn create_and_process_bytecode(options: &Options, env: &GlobalEnv) -> FunctionTa
 
     // Add function targets for all functions in the environment.
     for module_env in env.get_modules() {
+        if options.prover.dump_bytecode {
+            let disas = Disassembler::new(
+                SourceMapping::new(
+                    module_env.get_source_map().clone(),
+                    module_env.get_verified_module().clone(),
+                ),
+                DisassemblerOptions {
+                    only_externally_visible: false,
+                    print_code: true,
+                    print_basic_blocks: true,
+                    print_locals: true,
+                },
+            );
+            let content = disas
+                .disassemble()
+                .expect("Failed to disassemble a verified module");
+            let output_file = options
+                .move_sources
+                .get(0)
+                .cloned()
+                .unwrap_or_else(|| "bytecode".to_string())
+                .replace(".move", ".mv.disas");
+            fs::write(&output_file, &content).expect("dumping disassembled module");
+        }
         for func_env in module_env.get_functions() {
             targets.add_target(&func_env)
         }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

By-product on the way of placing nested loops with different loop headers.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI

`mvp --dump-bytecode <path-to-file>.move`. There should be a `<path-to-file>.mv.disas` text file generated.
