### PR TITLE
[diem-swarm] Add PrivateFullNode tests and Improve test framework for Full Node testing

### DIFF
--- a/config/management/genesis/src/config_builder.rs
+++ b/config/management/genesis/src/config_builder.rs
@@ -242,7 +242,7 @@ impl<T: AsRef<Path>> BuildSwarm for ValidatorBuilder<T> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub enum FullnodeType {
     ValidatorFullnode,
     PublicFullnode(usize),

--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -214,6 +214,11 @@ impl ClientProxy {
         })
     }
 
+    /// Gets account data for the indexed address
+    pub fn get_account(&self, address_num: usize) -> Option<&AccountData> {
+        self.accounts.get(address_num)
+    }
+
     fn get_account_data(&self, address: &AccountAddress) -> Result<(usize, &AccountData)> {
         for (index, acc) in self.accounts.iter().enumerate() {
             if &acc.address == address {

--- a/testsuite/diem-swarm/src/main.rs
+++ b/testsuite/diem-swarm/src/main.rs
@@ -63,6 +63,7 @@ fn main() {
     let mut full_node_swarm = if num_full_nodes > 0 {
         Some(
             DiemSwarm::configure_fn_swarm(
+                "ValidatorFullNode",
                 args.diem_node.as_ref(),
                 None, /* config dir */
                 None,

--- a/testsuite/diem-swarm/src/swarm.rs
+++ b/testsuite/diem-swarm/src/swarm.rs
@@ -444,7 +444,7 @@ impl DiemSwarm {
 
         // TODO: Maybe wait for mroe than one on full nodes
         let expected_peers = match self.node_type {
-            NodeType::Validator => self.nodes.len() - 1,
+            NodeType::Validator => self.nodes.len().saturating_sub(1),
             NodeType::ValidatorFullNode => 1,
             NodeType::PublicFullNode => 1,
         };

--- a/testsuite/diem-swarm/src/swarm.rs
+++ b/testsuite/diem-swarm/src/swarm.rs
@@ -117,6 +117,12 @@ impl DiemNode {
         self.config.json_rpc.address.port()
     }
 
+    pub fn debug_port(&self) -> u16 {
+        self.config
+            .debug_interface
+            .admission_control_node_debug_port
+    }
+
     pub fn config(&self) -> &NodeConfig {
         &self.config
     }
@@ -583,24 +589,7 @@ impl DiemSwarm {
         self.nodes.get(&node_id).map(|node| node.port()).unwrap()
     }
 
-    /// Vector with the peer ids of the validators in the swarm.
-    pub fn get_validators_ids(&self) -> Vec<String> {
-        self.nodes.keys().cloned().collect()
-    }
-
-    /// Vector with the debug ports of all the validators in the swarm.
-    pub fn get_validators_debug_ports(&self) -> Vec<u16> {
-        self.config
-            .config_files
-            .iter()
-            .map(|path| {
-                let config = NodeConfig::load(&path).unwrap();
-                config.debug_interface.admission_control_node_debug_port
-            })
-            .collect()
-    }
-
-    pub fn get_validator(&self, idx: usize) -> Option<&DiemNode> {
+    pub fn get_node(&self, idx: usize) -> Option<&DiemNode> {
         let node_id = format!("{}", idx);
         self.nodes.get(&node_id)
     }

--- a/testsuite/diem-swarm/src/swarm.rs
+++ b/testsuite/diem-swarm/src/swarm.rs
@@ -315,6 +315,7 @@ pub enum NodeType {
 
 /// Struct holding instances and information of Diem Swarm
 pub struct DiemSwarm {
+    label: &'static str,
     diem_node_bin_path: PathBuf,
     // Output log, DiemNodes' config file, diemdb etc, into this dir.
     pub dir: DiemSwarmDir,
@@ -362,6 +363,7 @@ impl DiemSwarm {
     }
 
     pub fn configure_fn_swarm(
+        label: &'static str,
         diem_node_bin_path: &Path,
         config_dir: Option<String>,
         template: Option<NodeConfig>,
@@ -389,6 +391,7 @@ impl DiemSwarm {
             FullnodeType::PublicFullnode(_) => NodeType::PublicFullNode,
         };
         Ok(Self {
+            label,
             diem_node_bin_path: diem_node_bin_path.to_path_buf(),
             dir: swarm_config_dir,
             nodes: HashMap::new(),
@@ -413,6 +416,7 @@ impl DiemSwarm {
         let config = SwarmConfig::build(&builder, config_path)?;
 
         Ok(Self {
+            label: "Validator",
             diem_node_bin_path: diem_node_bin_path.to_path_buf(),
             dir: swarm_config_dir,
             nodes: HashMap::new(),
@@ -474,7 +478,7 @@ impl DiemSwarm {
         let num_attempts = 60;
 
         for i in 0..num_attempts {
-            println!("Wait for connectivity attempt: {}", i);
+            println!("{:?} Wait for connectivity attempt: {}", self.node_type, i);
 
             if self
                 .nodes
@@ -483,7 +487,6 @@ impl DiemSwarm {
             {
                 return Ok(());
             }
-            // TODO check full node connectivity for full nodes
 
             ::std::thread::sleep(::std::time::Duration::from_millis(1000));
         }
@@ -652,7 +655,7 @@ impl Drop for DiemSwarm {
             if let DiemSwarmDir::Temporary(temp_dir) = &mut self.dir {
                 temp_dir.persist();
                 let log_path = temp_dir.path();
-                println!("logs located at {:?}", log_path);
+                println!("{:?} logs located at {:?}", self.label, log_path);
 
                 // Dump logs for each validator to stdout when `DIEM_DUMP_LOGS`
                 // environment variable is set

--- a/testsuite/diem-swarm/src/swarm.rs
+++ b/testsuite/diem-swarm/src/swarm.rs
@@ -610,7 +610,7 @@ impl DiemSwarm {
         self.nodes.remove(&node_id);
     }
 
-    pub fn add_node(&mut self, idx: usize) -> Result<(), SwarmLaunchFailure> {
+    pub fn start_node(&mut self, idx: usize) -> Result<(), SwarmLaunchFailure> {
         // First take the configs out to not keep immutable borrow on self when calling
         // `launch_node`.
         let path = self

--- a/testsuite/smoke-test/src/client.rs
+++ b/testsuite/smoke-test/src/client.rs
@@ -109,7 +109,7 @@ fn test_client_waypoints() {
     );
 
     // Start next epoch
-    let peer_id = env.validator_swarm.get_validator(0).unwrap().peer_id();
+    let peer_id = env.validator_swarm.get_node(0).unwrap().peer_id();
     let op_tool = get_op_tool(&env.validator_swarm, 1);
     let diem_root = load_diem_root_storage(&env.validator_swarm, 0);
     let _ = op_tool
@@ -183,7 +183,7 @@ fn test_concurrent_transfers_single_node() {
 fn test_trace() {
     let (env, mut client) = setup_swarm_and_client_proxy(1, 0);
 
-    let port = env.validator_swarm.get_validators_debug_ports()[0];
+    let port = env.validator_swarm.get_node(0).unwrap().debug_port();
     let mut debug_client = NodeDebugClient::new("localhost", port);
 
     client.create_next_account(false).unwrap();

--- a/testsuite/smoke-test/src/client.rs
+++ b/testsuite/smoke-test/src/client.rs
@@ -109,12 +109,7 @@ fn test_client_waypoints() {
     );
 
     // Start next epoch
-    let peer_id = env
-        .validator_swarm
-        .get_validator(0)
-        .unwrap()
-        .validator_peer_id()
-        .unwrap();
+    let peer_id = env.validator_swarm.get_validator(0).unwrap().peer_id();
     let op_tool = get_op_tool(&env.validator_swarm, 1);
     let diem_root = load_diem_root_storage(&env.validator_swarm, 0);
     let _ = op_tool

--- a/testsuite/smoke-test/src/client.rs
+++ b/testsuite/smoke-test/src/client.rs
@@ -63,7 +63,7 @@ fn test_basic_restartability() {
     let peer_to_restart = 0;
     env.validator_swarm.kill_node(peer_to_restart);
 
-    assert!(env.validator_swarm.add_node(peer_to_restart).is_ok());
+    assert!(env.validator_swarm.start_node(peer_to_restart).is_ok());
     assert!(compare_balances(
         vec![(90.0, "XUS".to_string())],
         client.get_balances(&["b", "0"]).unwrap(),

--- a/testsuite/smoke-test/src/full_nodes.rs
+++ b/testsuite/smoke-test/src/full_nodes.rs
@@ -340,7 +340,7 @@ fn test_private_full_node() {
     // Ensure that User node is connected to private node and only the private node
     {
         let mut user_swarm = user_swarm.lock();
-        let user_node = user_swarm.nodes.get_mut("0").unwrap();
+        let user_node = user_swarm.mut_node(0).unwrap();
         assert_eq!(
             1,
             user_node

--- a/testsuite/smoke-test/src/full_nodes.rs
+++ b/testsuite/smoke-test/src/full_nodes.rs
@@ -246,7 +246,7 @@ fn test_vfn_failover() {
     }
 
     // bring back one of the validators so consensus can resume
-    assert!(env.validator_swarm.add_node(0).is_ok());
+    assert!(env.validator_swarm.start_node(0).is_ok());
     // check all txns submitted so far (even those submitted during overlapping validator downtime) are committed
     let vfn_0_acct_0 = vfn_0_client.copy_all_accounts().get(0).unwrap().address;
     vfn_0_client.wait_for_transaction(vfn_0_acct_0, 13).unwrap();
@@ -266,7 +266,7 @@ fn test_vfn_failover() {
         .unwrap();
 
     // bring back all Vs back up
-    assert!(env.validator_swarm.add_node(1).is_ok());
+    assert!(env.validator_swarm.start_node(1).is_ok());
 
     // just for kicks: check regular minting still works with revived validators
     for _ in 0..5 {

--- a/testsuite/smoke-test/src/full_nodes.rs
+++ b/testsuite/smoke-test/src/full_nodes.rs
@@ -2,7 +2,80 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{smoke_test_environment::SmokeTestEnvironment, test_utils::compare_balances};
+use cli::client_proxy::{ClientProxy, IndexAndSequence};
+use diem_client::AccountAddress;
 use diem_types::account_config::{testnet_dd_account_address, treasury_compliance_account_address};
+
+// TODO: All of this convenience code below should be put in the client proxy directly, it's
+// very hard for users to know what the order of a bunch of random inputs should be
+fn get_and_reset_sequence_number(client: &mut ClientProxy, account: AccountAddress) -> u64 {
+    sequence_number_inner(client, account, true)
+}
+
+fn sequence_number_inner(
+    client: &mut ClientProxy,
+    account: AccountAddress,
+    reset_sequence_number: bool,
+) -> u64 {
+    let command_string = format!("sequence {} {}", account, reset_sequence_number);
+    let command: Vec<_> = command_string.split(' ').collect();
+    client.get_sequence_number(&command).unwrap()
+}
+
+fn mint_coins(
+    client: &mut ClientProxy,
+    account_num: usize,
+    amount: u64,
+    currency: &str,
+    is_blocking: bool,
+) {
+    client
+        .mint_coins(
+            &[
+                "mintb",
+                &account_num.to_string(),
+                &amount.to_string(),
+                currency,
+            ],
+            is_blocking,
+        )
+        .expect("Failed to mint coins!")
+}
+
+fn transfer_coins(
+    client: &mut ClientProxy,
+    sender_address_num: usize,
+    receiver_address_num: usize,
+    amount: u64,
+    currency: &str,
+    is_blocking: bool,
+) -> IndexAndSequence {
+    client
+        .transfer_coins(
+            &[
+                "tb",
+                &sender_address_num.to_string(),
+                &receiver_address_num.to_string(),
+                &amount.to_string(),
+                currency,
+            ],
+            is_blocking,
+        )
+        .expect("Failed to transfer coins!")
+}
+
+fn get_balances(client: &mut ClientProxy, account_num: usize) -> Vec<String> {
+    let account = account_num.to_string();
+    client.get_balances(&["b", &account]).unwrap()
+}
+
+fn wait_for_transaction(client: &mut ClientProxy, account: AccountAddress, seq_num: u64) {
+    client
+        .wait_for_transaction(account, seq_num)
+        .expect("Expected transaction")
+}
+
+const XUS: &str = "XUS";
 
 #[test]
 fn test_full_node_basic_flow() {
@@ -26,106 +99,71 @@ fn test_full_node_basic_flow() {
 
     let sender_account = testnet_dd_account_address();
     let creation_account = treasury_compliance_account_address();
-    let sequence_reset = format!("sequence {} true", sender_account);
-    let creation_sequence_reset = format!("sequence {} true", creation_account);
-    let sequence_reset_command: Vec<_> = sequence_reset.split(' ').collect();
-    let creation_sequence_reset_command: Vec<_> = creation_sequence_reset.split(' ').collect();
 
-    vfn_client
-        .get_sequence_number(&sequence_reset_command)
-        .unwrap();
-    vfn_client
-        .get_sequence_number(&creation_sequence_reset_command)
-        .unwrap();
-    vfn_client
-        .mint_coins(&["mintb", "0", "10", "XUS"], true)
-        .expect("Fail to mint!");
+    get_and_reset_sequence_number(&mut vfn_client, sender_account);
+    get_and_reset_sequence_number(&mut vfn_client, creation_account);
+    mint_coins(&mut vfn_client, 0, 10, XUS, true);
+
     assert!(compare_balances(
-        vec![(10.0, "XUS".to_string())],
-        vfn_client.get_balances(&["b", "0"]).unwrap(),
+        vec![(10.0, XUS.to_string())],
+        get_balances(&mut vfn_client, 0)
     ));
 
-    let sequence = vfn_client
-        .get_sequence_number(&sequence_reset_command)
-        .unwrap();
-    validator_client
-        .wait_for_transaction(sender_account, sequence - 1)
-        .unwrap();
+    let sequence = get_and_reset_sequence_number(&mut vfn_client, sender_account);
+    wait_for_transaction(&mut validator_client, sender_account, sequence - 1);
     assert!(compare_balances(
-        vec![(10.0, "XUS".to_string())],
-        validator_client.get_balances(&["b", "0"]).unwrap(),
+        vec![(10.0, XUS.to_string())],
+        get_balances(&mut validator_client, 0),
     ));
 
     // reset sequence number for sender account
-    validator_client
-        .get_sequence_number(&sequence_reset_command)
-        .unwrap();
-    vfn_client
-        .get_sequence_number(&sequence_reset_command)
-        .unwrap();
-    validator_client
-        .get_sequence_number(&creation_sequence_reset_command)
-        .unwrap();
-    vfn_client
-        .get_sequence_number(&creation_sequence_reset_command)
-        .unwrap();
+    get_and_reset_sequence_number(&mut validator_client, sender_account);
+    get_and_reset_sequence_number(&mut vfn_client, sender_account);
+    get_and_reset_sequence_number(&mut validator_client, creation_account);
+    get_and_reset_sequence_number(&mut vfn_client, creation_account);
 
     // mint from validator and check both nodes have correct balance
     validator_client.create_next_account(false).unwrap();
     vfn_client.create_next_account(false).unwrap();
     pfn_client.create_next_account(false).unwrap();
 
-    validator_client
-        .mint_coins(&["mintb", "1", "10", "XUS"], true)
-        .unwrap();
-    let sequence = validator_client
-        .get_sequence_number(&sequence_reset_command)
-        .unwrap();
-    vfn_client
-        .wait_for_transaction(sender_account, sequence - 1)
-        .unwrap();
+    mint_coins(&mut validator_client, 1, 10, XUS, true);
+    let sequence = get_and_reset_sequence_number(&mut validator_client, sender_account);
+    wait_for_transaction(&mut vfn_client, sender_account, sequence - 1);
 
     assert!(compare_balances(
-        vec![(10.0, "XUS".to_string())],
-        validator_client.get_balances(&["b", "1"]).unwrap(),
+        vec![(10.0, XUS.to_string())],
+        get_balances(&mut validator_client, 1)
     ));
     assert!(compare_balances(
-        vec![(10.0, "XUS".to_string())],
-        vfn_client.get_balances(&["b", "1"]).unwrap(),
+        vec![(10.0, XUS.to_string())],
+        get_balances(&mut vfn_client, 1)
     ));
 
     // minting again on validator doesn't cause error since client sequence has been updated
-    validator_client
-        .mint_coins(&["mintb", "1", "10", "XUS"], true)
-        .unwrap();
+    mint_coins(&mut validator_client, 1, 10, XUS, true);
 
     // test transferring balance from 0 to 1 through full node proxy
-    vfn_client
-        .transfer_coins(&["tb", "0", "1", "10", "XUS"], true)
-        .unwrap();
+    transfer_coins(&mut vfn_client, 0, 1, 10, XUS, true);
 
     assert!(compare_balances(
-        vec![(0.0, "XUS".to_string())],
-        vfn_client.get_balances(&["b", "0"]).unwrap(),
+        vec![(0.0, XUS.to_string())],
+        get_balances(&mut vfn_client, 0)
     ));
     assert!(compare_balances(
-        vec![(30.0, "XUS".to_string())],
-        validator_client.get_balances(&["b", "1"]).unwrap(),
+        vec![(30.0, XUS.to_string())],
+        get_balances(&mut validator_client, 1)
     ));
 
-    let sequence = validator_client
-        .get_sequence_number(&["sequence", &format!("{}", account), "true"])
-        .unwrap();
-    pfn_client
-        .wait_for_transaction(account, sequence - 1)
-        .unwrap();
+    let sequence = get_and_reset_sequence_number(&mut validator_client, account);
+    wait_for_transaction(&mut pfn_client, account, sequence - 1);
     assert!(compare_balances(
-        vec![(0.0, "XUS".to_string())],
-        pfn_client.get_balances(&["b", "0"]).unwrap(),
+        vec![(0.0, XUS.to_string())],
+        get_balances(&mut pfn_client, 0)
     ));
     assert!(compare_balances(
-        vec![(30.0, "XUS".to_string())],
-        pfn_client.get_balances(&["b", "1"]).unwrap(),
+        vec![(30.0, XUS.to_string())],
+        get_balances(&mut pfn_client, 1)
     ));
 }
 
@@ -147,10 +185,6 @@ fn test_vfn_failover() {
     // some helpers for creation/minting
     let sender_account = testnet_dd_account_address();
     let creation_account = treasury_compliance_account_address();
-    let sequence_reset = format!("sequence {} true", sender_account);
-    let creation_sequence_reset = format!("sequence {} true", creation_account);
-    let sequence_reset_command: Vec<_> = sequence_reset.split(' ').collect();
-    let creation_sequence_reset_command: Vec<_> = creation_sequence_reset.split(' ').collect();
 
     // Case 1:
     // submit client requests directly to VFN of dead V
@@ -158,66 +192,35 @@ fn test_vfn_failover() {
     for _ in 0..2 {
         vfn_0_client.create_next_account(false).unwrap();
     }
-    vfn_0_client
-        .mint_coins(&["mb", "0", "100", "XUS"], true)
-        .unwrap();
-    vfn_0_client
-        .mint_coins(&["mb", "1", "50", "XUS"], true)
-        .unwrap();
+
+    mint_coins(&mut vfn_0_client, 0, 100, XUS, true);
+    mint_coins(&mut vfn_0_client, 1, 50, XUS, true);
     for _ in 0..8 {
-        vfn_0_client
-            .transfer_coins(&["t", "0", "1", "1", "XUS"], false)
-            .unwrap();
+        transfer_coins(&mut vfn_0_client, 0, 1, 1, XUS, false);
     }
-    vfn_0_client
-        .transfer_coins(&["tb", "0", "1", "1", "XUS"], true)
-        .unwrap();
+    transfer_coins(&mut vfn_0_client, 0, 1, 1, XUS, true);
 
     // wait for VFN 1 to catch up with creation and sender account
-    vfn_1_client
-        .wait_for_transaction(creation_account, 0)
-        .unwrap();
-    vfn_1_client
-        .wait_for_transaction(sender_account, 1)
-        .unwrap();
-    vfn_1_client
-        .get_sequence_number(&sequence_reset_command)
-        .unwrap();
-    vfn_1_client
-        .get_sequence_number(&creation_sequence_reset_command)
-        .unwrap();
+    wait_for_transaction(&mut vfn_1_client, creation_account, 0);
+    wait_for_transaction(&mut vfn_1_client, sender_account, 1);
+    get_and_reset_sequence_number(&mut vfn_1_client, sender_account);
+    get_and_reset_sequence_number(&mut vfn_1_client, creation_account);
     for _ in 0..4 {
         vfn_1_client.create_next_account(false).unwrap();
     }
-    vfn_1_client
-        .mint_coins(&["mb", "2", "100", "XUS"], true)
-        .unwrap();
-    vfn_1_client
-        .mint_coins(&["mb", "3", "50", "XUS"], true)
-        .unwrap();
+    mint_coins(&mut vfn_1_client, 2, 100, XUS, true);
+    mint_coins(&mut vfn_1_client, 3, 50, XUS, true);
 
     for _ in 0..6 {
         pfn_0_client.create_next_account(false).unwrap();
     }
     // wait for PFN to catch up with creation and sender account
-    pfn_0_client
-        .wait_for_transaction(creation_account, 2)
-        .unwrap();
-    pfn_0_client
-        .wait_for_transaction(sender_account, 3)
-        .unwrap();
-    pfn_0_client
-        .get_sequence_number(&sequence_reset_command)
-        .unwrap();
-    pfn_0_client
-        .get_sequence_number(&creation_sequence_reset_command)
-        .unwrap();
-    pfn_0_client
-        .mint_coins(&["mb", "4", "100", "XUS"], true)
-        .unwrap();
-    pfn_0_client
-        .mint_coins(&["mb", "5", "50", "XUS"], true)
-        .unwrap();
+    wait_for_transaction(&mut pfn_0_client, creation_account, 2);
+    wait_for_transaction(&mut pfn_0_client, sender_account, 3);
+    get_and_reset_sequence_number(&mut pfn_0_client, sender_account);
+    get_and_reset_sequence_number(&mut pfn_0_client, creation_account);
+    mint_coins(&mut pfn_0_client, 4, 100, XUS, true);
+    mint_coins(&mut pfn_0_client, 5, 50, XUS, true);
 
     // bring down another V
     // Transition to unfortunate case where 2(>f) validators are down
@@ -225,56 +228,43 @@ fn test_vfn_failover() {
     env.validator_swarm.kill_node(1);
     // submit some non-blocking txns during this scenario when >f validators are down
     for _ in 0..10 {
-        vfn_1_client
-            .transfer_coins(&["t", "2", "3", "1", "XUS"], false)
-            .unwrap();
+        transfer_coins(&mut vfn_1_client, 2, 3, 1, XUS, false);
     }
 
     // submit txn for vfn_0 too
     for _ in 0..5 {
-        vfn_0_client
-            .transfer_coins(&["t", "0", "1", "1", "XUS"], false)
-            .unwrap();
+        transfer_coins(&mut vfn_0_client, 0, 1, 1, XUS, false);
     }
 
     // we don't know which exact VFNs each pfn client's PFN is connected to,
     // but by pigeonhole principle, we know the PFN is connected to max 2 live VFNs
     for _ in 0..7 {
-        pfn_0_client
-            .transfer_coins(&["t", "4", "5", "1", "XUS"], false)
-            .unwrap();
+        transfer_coins(&mut pfn_0_client, 4, 5, 1, XUS, false);
     }
 
     // bring back one of the validators so consensus can resume
     assert!(env.validator_swarm.start_node(0).is_ok());
     // check all txns submitted so far (even those submitted during overlapping validator downtime) are committed
-    let vfn_0_acct_0 = vfn_0_client.copy_all_accounts().get(0).unwrap().address;
-    vfn_0_client.wait_for_transaction(vfn_0_acct_0, 13).unwrap();
-    let vfn_1_acct_0 = vfn_1_client.copy_all_accounts().get(2).unwrap().address;
-    vfn_1_client.wait_for_transaction(vfn_1_acct_0, 9).unwrap();
-    let pfn_acct_0 = pfn_0_client.copy_all_accounts().get(4).unwrap().address;
-    pfn_0_client.wait_for_transaction(pfn_acct_0, 6).unwrap();
+
+    let vfn_0_acct_0 = vfn_0_client.get_account(0).unwrap().address;
+    wait_for_transaction(&mut vfn_0_client, vfn_0_acct_0, 13);
+    let vfn_1_acct_0 = vfn_1_client.get_account(2).unwrap().address;
+    wait_for_transaction(&mut vfn_1_client, vfn_1_acct_0, 9);
+    let pfn_acct_0 = pfn_0_client.get_account(4).unwrap().address;
+    wait_for_transaction(&mut pfn_0_client, pfn_acct_0, 6);
 
     // submit txns to vfn of dead V
     for _ in 0..5 {
-        vfn_1_client
-            .transfer_coins(&["t", "2", "3", "1", "XUS"], false)
-            .unwrap();
+        transfer_coins(&mut vfn_1_client, 2, 3, 1, XUS, false);
     }
-    vfn_1_client
-        .transfer_coins(&["tb", "2", "3", "1", "XUS"], true)
-        .unwrap();
+    transfer_coins(&mut vfn_1_client, 2, 3, 1, XUS, true);
 
     // bring back all Vs back up
     assert!(env.validator_swarm.start_node(1).is_ok());
 
     // just for kicks: check regular minting still works with revived validators
     for _ in 0..5 {
-        pfn_0_client
-            .transfer_coins(&["t", "4", "5", "1", "XUS"], false)
-            .unwrap();
+        transfer_coins(&mut pfn_0_client, 4, 5, 1, XUS, false);
     }
-    pfn_0_client
-        .transfer_coins(&["tb", "4", "5", "1", "XUS"], true)
-        .unwrap();
+    transfer_coins(&mut pfn_0_client, 4, 5, 1, XUS, true);
 }

--- a/testsuite/smoke-test/src/full_nodes.rs
+++ b/testsuite/smoke-test/src/full_nodes.rs
@@ -76,21 +76,22 @@ fn wait_for_transaction(client: &mut ClientProxy, account: AccountAddress, seq_n
 }
 
 const XUS: &str = "XUS";
+const PUBLIC: &str = "public";
 
 #[test]
 fn test_full_node_basic_flow() {
     let mut env = SmokeTestEnvironment::new(4);
     env.setup_vfn_swarm();
-    env.setup_pfn_swarm(2);
+    env.add_public_fn_swarm(PUBLIC, 2);
 
     env.validator_swarm.launch();
-    env.vfn_swarm.as_mut().unwrap().launch();
-    env.pfn_swarm.as_mut().unwrap().launch();
+    env.vfn_swarm().lock().launch();
+    env.public_swarm(PUBLIC).lock().launch();
 
     // read state from full node client
     let mut validator_client = env.get_validator_client(0, None);
     let mut vfn_client = env.get_vfn_client(1, None);
-    let mut pfn_client = env.get_pfn_client(0, None);
+    let mut pfn_client = env.get_pfn_client(PUBLIC, 0, None);
 
     // mint from full node and check both validator and full node have correct balance
     let account = validator_client.create_next_account(false).unwrap().address;
@@ -171,16 +172,16 @@ fn test_full_node_basic_flow() {
 fn test_vfn_failover() {
     let mut env = SmokeTestEnvironment::new(7);
     env.setup_vfn_swarm();
-    env.setup_pfn_swarm(1);
+    env.add_public_fn_swarm(PUBLIC, 1);
 
     env.validator_swarm.launch();
-    env.vfn_swarm.as_mut().unwrap().launch();
-    env.pfn_swarm.as_mut().unwrap().launch();
+    env.vfn_swarm().lock().launch();
+    env.public_swarm(PUBLIC).lock().launch();
 
     // set up clients
     let mut vfn_0_client = env.get_vfn_client(0, None);
     let mut vfn_1_client = env.get_vfn_client(1, None);
-    let mut pfn_0_client = env.get_pfn_client(0, None);
+    let mut pfn_0_client = env.get_pfn_client(PUBLIC, 0, None);
 
     // some helpers for creation/minting
     let sender_account = testnet_dd_account_address();

--- a/testsuite/smoke-test/src/genesis.rs
+++ b/testsuite/smoke-test/src/genesis.rs
@@ -71,7 +71,7 @@ fn test_genesis_transaction_flow() {
     let mut known_round = None;
     for i in 0..5 {
         let last_committed_round_str = "diem_consensus_last_committed_round{}";
-        for (index, node) in &mut env.validator_swarm.nodes {
+        for (index, node) in env.validator_swarm.nodes() {
             if let Some(round) = node.get_metric(last_committed_round_str) {
                 match known_round {
                     Some(r) if r != round => panic!(
@@ -102,7 +102,7 @@ fn test_genesis_transaction_flow() {
         .unwrap();
     let name = config.name.as_bytes().to_vec();
 
-    for index in 0..env.validator_swarm.nodes.len() {
+    for index in 0..env.validator_swarm.nodes().len() {
         env.validator_swarm.kill_node(index);
     }
     let genesis_transaction = Transaction::GenesisTransaction(WriteSetPayload::Script {

--- a/testsuite/smoke-test/src/genesis.rs
+++ b/testsuite/smoke-test/src/genesis.rs
@@ -58,13 +58,13 @@ fn test_genesis_transaction_flow() {
         node_config.consensus.sync_only = true;
         save_node_config(&mut node_config, &env.validator_swarm, i);
         env.validator_swarm.kill_node(i);
-        env.validator_swarm.add_node(i).unwrap();
+        env.validator_swarm.start_node(i).unwrap();
     }
 
     println!("3. delete one node's db and test they can still sync when sync_only is true for every nodes");
     env.validator_swarm.kill_node(0);
     fs::remove_dir_all(node_config.storage.dir()).unwrap();
-    env.validator_swarm.add_node(0).unwrap();
+    env.validator_swarm.start_node(0).unwrap();
 
     println!("4. verify all nodes are at the same round and no progress being made in 5 sec");
     env.validator_swarm.wait_for_all_nodes_to_catchup();
@@ -139,7 +139,7 @@ fn test_genesis_transaction_flow() {
     }
 
     for i in 1..4 {
-        env.validator_swarm.add_node(i).unwrap();
+        env.validator_swarm.start_node(i).unwrap();
     }
 
     println!("8. verify it's able to mint after the waypoint");
@@ -192,7 +192,7 @@ fn test_genesis_transaction_flow() {
     node_config.execution.genesis_file_location = PathBuf::from("");
     insert_waypoint(&mut node_config, waypoint);
     save_node_config(&mut node_config, &env.validator_swarm, 0);
-    env.validator_swarm.add_node(0).unwrap();
+    env.validator_swarm.start_node(0).unwrap();
     assert!(env.validator_swarm.wait_for_all_nodes_to_catchup());
     let mut client_proxy_0 = env.get_validator_client(0, Some(waypoint));
     client_proxy_0.set_accounts(client_proxy_1.copy_all_accounts());
@@ -205,7 +205,7 @@ fn test_genesis_transaction_flow() {
     let db_dir = node_config.storage.dir();
     fs::remove_dir_all(&db_dir).unwrap();
     db_restore(backup_path.path(), db_dir.as_path(), &[waypoint]);
-    env.validator_swarm.add_node(0).unwrap();
+    env.validator_swarm.start_node(0).unwrap();
     assert!(env.validator_swarm.wait_for_all_nodes_to_catchup());
 
     let mut client = env.get_validator_client(0, Some(waypoint));

--- a/testsuite/smoke-test/src/operational_tooling.rs
+++ b/testsuite/smoke-test/src/operational_tooling.rs
@@ -362,7 +362,7 @@ fn test_network_key_rotation() {
     // Restart validator
     // At this point, the `add_node` call ensures connectivity to all nodes
     env.validator_swarm.kill_node(0);
-    env.validator_swarm.add_node(0).unwrap();
+    env.validator_swarm.start_node(0).unwrap();
 }
 
 #[test]
@@ -406,7 +406,7 @@ fn test_network_key_rotation_recovery() {
     // Restart validator
     // At this point, the `add_node` call ensures connectivity to all nodes
     env.validator_swarm.kill_node(0);
-    env.validator_swarm.add_node(0).unwrap();
+    env.validator_swarm.start_node(0).unwrap();
 }
 
 #[test]

--- a/testsuite/smoke-test/src/state_sync.rs
+++ b/testsuite/smoke-test/src/state_sync.rs
@@ -64,7 +64,7 @@ fn test_basic_state_synchronization() {
         .unwrap();
 
     // Reconnect and synchronize the state
-    assert!(env.validator_swarm.add_node(node_to_restart).is_ok());
+    assert!(env.validator_swarm.start_node(node_to_restart).is_ok());
 
     // Wait for all the nodes to catch up
     assert!(env.validator_swarm.wait_for_all_nodes_to_catchup());
@@ -99,7 +99,7 @@ fn test_basic_state_synchronization() {
     }
 
     // Reconnect and synchronize the state
-    assert!(env.validator_swarm.add_node(node_to_restart).is_ok());
+    assert!(env.validator_swarm.start_node(node_to_restart).is_ok());
 
     // Wait for all the nodes to catch up
     assert!(env.validator_swarm.wait_for_all_nodes_to_catchup());
@@ -150,7 +150,7 @@ fn test_startup_sync_state() {
     // behind consensus db and forcing a state sync
     // during a node startup
     fs::remove_dir_all(state_db_path).unwrap();
-    assert!(env.validator_swarm.add_node(peer_to_stop).is_ok());
+    assert!(env.validator_swarm.start_node(peer_to_stop).is_ok());
     // create the client for the restarted node
     let accounts = client_1.copy_all_accounts();
     let mut client_0 = env.get_validator_client(0, None);
@@ -217,7 +217,7 @@ fn test_startup_sync_state_with_empty_consensus_db() {
     assert!(consensus_db_path.as_path().exists());
     // Delete the consensus db to simulate consensus db is nuked
     fs::remove_dir_all(consensus_db_path).unwrap();
-    assert!(env.validator_swarm.add_node(peer_to_stop).is_ok());
+    assert!(env.validator_swarm.start_node(peer_to_stop).is_ok());
     // create the client for the restarted node
     let accounts = client_1.copy_all_accounts();
     let mut client_0 = env.get_validator_client(0, None);
@@ -323,7 +323,7 @@ fn test_state_sync_multichunk_epoch() {
     node_config.execution.genesis_file_location = PathBuf::from("");
     insert_waypoint(&mut node_config, waypoint_epoch_2);
     save_node_config(&mut node_config, &env.validator_swarm, 3);
-    env.validator_swarm.add_node(3).unwrap();
+    env.validator_swarm.start_node(3).unwrap();
 
     assert!(env.validator_swarm.wait_for_all_nodes_to_catchup());
 }

--- a/testsuite/smoke-test/src/storage.rs
+++ b/testsuite/smoke-test/src/storage.rs
@@ -94,7 +94,7 @@ fn test_db_restore() {
 
     // start node 0 on top of restored db
     // (add_node() waits for it to connect to peers)
-    env.validator_swarm.add_node(0).unwrap();
+    env.validator_swarm.start_node(0).unwrap();
 
     // stop transferring
     transfer_quit.store(true, Ordering::Relaxed);


### PR DESCRIPTION
## Motivation
After spending many hours staring out the test framework, I found it was very `validator` centric, and hadn't been adjusted to a full node ecosystem.  Additionally, there were a lot of rough edges that make the average reader be confused, so hopefully that cleans up those.

Additionally, this makes a simple test to test out `PrivateFullNodes` and the ability to route traffic through `Upstream` nodes, and register `Downstream` nodes only to access them.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yeah

## Test Plan

See CI

## Related PRs

None
