### PR TITLE
[storage] make fuzzer JellyfishGetRangeProof faster

### DIFF
--- a/testsuite/diem-fuzzer/src/fuzz_targets/storage.rs
+++ b/testsuite/diem-fuzzer/src/fuzz_targets/storage.rs
@@ -115,12 +115,12 @@ impl FuzzTargetImpl for JellyfishGetRangeProof {
 
     fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
         Some(corpus_from_strategy(
-            arb_tree_with_index::<AccountStateBlob>(1000),
+            arb_tree_with_index::<AccountStateBlob>(100),
         ))
     }
 
     fn fuzz(&self, data: &[u8]) {
-        let input = fuzz_data_to_value(data, arb_tree_with_index::<AccountStateBlob>(1000));
+        let input = fuzz_data_to_value(data, arb_tree_with_index::<AccountStateBlob>(100));
         test_get_range_proof(input);
     }
 }


### PR DESCRIPTION


## Motivation

By limiting input size.

This is quite a heavy test (specifically, involving building a in-mem JellyFish DB on a version-by-version basis). I think it makes sense that it gets slower over time.

 We can improve the speed after it's possible to do all the updates in one single version (and without needing to calculate intermediate hashes).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Y
## Test Plan
