### PR TITLE
[move-lang] do not coalesce nested loops into a shared header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4387,6 +4387,7 @@ dependencies = [
  "datatest-stable",
  "diem-temppath",
  "diem-workspace-hack",
+ "disassembler",
  "docgen",
  "errmapgen",
  "futures",

--- a/language/move-lang/src/shared/graph.rs
+++ b/language/move-lang/src/shared/graph.rs
@@ -1,0 +1,360 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// This module implements a technique to compute the natural loops of a graph.
+// The implementation is based on the computation of the dominance relation
+// of a graph using the technique method in this paper:
+// Keith D. Cooper, Timothy J. Harvey, Ken Kennedy, "A Simple, Fast Dominance Algorithm ",
+// Software Practice and Experience, 2001.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::Debug,
+};
+
+pub struct NaturalLoop<T: Ord + Copy + Debug> {
+    pub loop_header: T,
+    pub loop_latch: T, // latch -> header is the back edge representing this loop
+    pub loop_body: BTreeSet<T>,
+}
+
+pub struct Graph<T: Ord + Copy + Debug> {
+    entry: T,
+    nodes: Vec<T>,
+    edges: Vec<(T, T)>,
+    predecessors: BTreeMap<T, BTreeSet<T>>,
+    successors: BTreeMap<T, BTreeSet<T>>,
+}
+
+impl<T: Ord + Copy + Debug> Graph<T> {
+    /// This function creates a graph from a set of nodes (with a unique entry node)
+    /// and a set of edges.
+    pub fn new(entry: T, nodes: Vec<T>, edges: Vec<(T, T)>) -> Self {
+        let mut predecessors: BTreeMap<T, BTreeSet<T>> =
+            nodes.iter().map(|x| (*x, BTreeSet::new())).collect();
+        let mut successors: BTreeMap<T, BTreeSet<T>> =
+            nodes.iter().map(|x| (*x, BTreeSet::new())).collect();
+        for edge in &edges {
+            successors.entry(edge.0).and_modify(|x| {
+                x.insert(edge.1);
+            });
+            predecessors.entry(edge.1).and_modify(|x| {
+                x.insert(edge.0);
+            });
+        }
+        Self {
+            entry,
+            nodes,
+            edges,
+            predecessors,
+            successors,
+        }
+    }
+
+    /// This function computes the loop headers and natural loops of a reducible graph.
+    /// If the graph is irreducible, None is returned.
+    pub fn compute_reducible(&self) -> Option<Vec<NaturalLoop<T>>> {
+        let dom_relation = DomRelation::new(self);
+        let mut loop_headers = BTreeSet::new();
+        let mut back_edges = vec![];
+        let mut non_back_edges = vec![];
+        for e in &self.edges {
+            if !dom_relation.is_reachable(e.0) {
+                continue;
+            }
+            if dom_relation.is_dominated_by(e.0, e.1) {
+                back_edges.push(*e);
+                loop_headers.insert(e.1);
+            } else {
+                non_back_edges.push(*e);
+            }
+        }
+        if Graph::new(self.entry, self.nodes.clone(), non_back_edges).is_acyclic() {
+            let natural_loops = back_edges
+                .into_iter()
+                .map(|edge| self.natural_loop(edge))
+                .collect();
+            Some(natural_loops)
+        } else {
+            None
+        }
+    }
+
+    fn is_acyclic(&self) -> bool {
+        let mut visited = BTreeMap::new();
+        let mut stack = vec![];
+        visited.insert(self.entry, false);
+        stack.push(self.entry);
+        while !stack.is_empty() {
+            let n = stack.pop().unwrap();
+            if visited[&n] {
+                visited.entry(n).and_modify(|x| {
+                    *x = false;
+                });
+                continue;
+            }
+            stack.push(n);
+            visited.entry(n).and_modify(|x| {
+                *x = true;
+            });
+            for s in &self.successors[&n] {
+                if visited.contains_key(s) {
+                    if visited[s] {
+                        return false;
+                    }
+                } else {
+                    visited.insert(*s, false);
+                    stack.push(*s);
+                }
+            }
+        }
+        true
+    }
+
+    fn natural_loop(&self, back_edge: (T, T)) -> NaturalLoop<T> {
+        let loop_latch = back_edge.0;
+        let loop_header = back_edge.1;
+        let mut stack = vec![];
+        let mut loop_body = BTreeSet::new();
+        loop_body.insert(loop_header);
+        if loop_latch != loop_header {
+            loop_body.insert(loop_latch);
+            stack.push(loop_latch);
+        }
+        while !stack.is_empty() {
+            let m = stack.pop().unwrap();
+            for p in &self.predecessors[&m] {
+                if !loop_body.contains(p) {
+                    loop_body.insert(*p);
+                    stack.push(*p);
+                }
+            }
+        }
+        NaturalLoop {
+            loop_header,
+            loop_latch,
+            loop_body,
+        }
+    }
+}
+
+struct DomRelation<T: Ord + Copy + Debug> {
+    node_to_postorder_num: BTreeMap<T, usize>,
+    postorder_num_to_node: Vec<T>,
+    idom_tree: BTreeMap<usize, usize>,
+}
+
+impl<T: Ord + Copy + Debug> DomRelation<T> {
+    /// This function computes the dominance relation on the subset of the graph
+    /// that is reachable from its entry node.
+    pub fn new(graph: &Graph<T>) -> Self {
+        let mut dom_relation = Self {
+            node_to_postorder_num: BTreeMap::new(),
+            postorder_num_to_node: vec![],
+            idom_tree: BTreeMap::new(),
+        };
+        dom_relation.postorder_visit(graph);
+        dom_relation.compute_dominators(graph);
+        dom_relation
+    }
+
+    /// This function returns true iff `x` is reachable from the entry node of the graph.
+    pub fn is_reachable(&self, x: T) -> bool {
+        self.node_to_postorder_num.contains_key(&x)
+    }
+
+    /// This function returns true iff `x` is dominated by `y`.
+    pub fn is_dominated_by(&self, x: T, y: T) -> bool {
+        let x_num = self.node_to_postorder_num[&x];
+        let y_num = self.node_to_postorder_num[&y];
+        let mut curr_num = x_num;
+        loop {
+            if curr_num == y_num {
+                return true;
+            }
+            if curr_num == self.entry_num() {
+                return false;
+            }
+            curr_num = self.idom_tree[&curr_num];
+        }
+    }
+
+    fn entry_num(&self) -> usize {
+        self.num_nodes() - 1
+    }
+
+    fn num_nodes(&self) -> usize {
+        self.node_to_postorder_num.len()
+    }
+
+    fn postorder_visit(&mut self, graph: &Graph<T>) {
+        let mut stack = vec![];
+        let mut visited = BTreeSet::new();
+        let mut grey = BTreeSet::new();
+        stack.push(graph.entry);
+        visited.insert(graph.entry);
+        while !stack.is_empty() {
+            let curr = stack.pop().unwrap();
+            if grey.contains(&curr) {
+                let curr_num = self.postorder_num_to_node.len();
+                self.postorder_num_to_node.push(curr);
+                self.node_to_postorder_num.insert(curr, curr_num);
+            } else {
+                grey.insert(curr);
+                stack.push(curr);
+                for child in &graph.successors[&curr] {
+                    if !visited.contains(child) {
+                        visited.insert(*child);
+                        stack.push(*child);
+                    }
+                }
+            }
+        }
+    }
+
+    fn compute_dominators(&mut self, graph: &Graph<T>) {
+        let entry_num = self.entry_num();
+        self.idom_tree.insert(entry_num, entry_num);
+        let mut changed = true;
+        while changed {
+            changed = false;
+            for node_num in (0..self.num_nodes() - 1).rev() {
+                let b = self.postorder_num_to_node[node_num];
+                let mut new_idom = self.num_nodes();
+                for p in &graph.predecessors[&b] {
+                    if !self.node_to_postorder_num.contains_key(p) {
+                        continue; // not all nodes are reachable
+                    }
+                    let pred_num = self.node_to_postorder_num[p];
+                    if self.idom_tree.contains_key(&pred_num) {
+                        if new_idom == self.num_nodes() {
+                            new_idom = pred_num;
+                        } else {
+                            new_idom = self.intersect(pred_num, new_idom);
+                        }
+                    }
+                }
+                assert!(new_idom != self.num_nodes());
+                if self.idom_tree.contains_key(&node_num) && self.idom_tree[&node_num] == new_idom {
+                    continue;
+                } else {
+                    self.idom_tree
+                        .entry(node_num)
+                        .and_modify(|x| {
+                            *x = new_idom;
+                        })
+                        .or_insert(new_idom);
+                    changed = true;
+                }
+            }
+        }
+    }
+
+    fn intersect(&self, x: usize, y: usize) -> usize {
+        let mut finger1 = x;
+        let mut finger2 = y;
+        while finger1 != finger2 {
+            while finger1 < finger2 {
+                finger1 = self.idom_tree[&finger1];
+            }
+            while finger2 < finger1 {
+                finger2 = self.idom_tree[&finger2];
+            }
+        }
+        finger1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test1() {
+        let nodes = vec![1, 2, 3, 4, 5];
+        let edges = vec![(1, 2), (2, 1), (4, 1), (3, 2), (5, 3), (5, 4)];
+        let source = 5;
+        let graph = Graph::new(source, nodes, edges);
+        assert!(graph.compute_reducible().is_none());
+    }
+
+    #[test]
+    fn test2() {
+        let nodes = vec![1, 2, 3, 4, 5, 6];
+        let edges = vec![
+            (1, 2),
+            (2, 1),
+            (2, 3),
+            (3, 2),
+            (4, 2),
+            (4, 3),
+            (5, 1),
+            (6, 5),
+            (6, 4),
+        ];
+        let source = 6;
+        let graph = Graph::new(source, nodes, edges);
+        assert!(graph.compute_reducible().is_none());
+    }
+
+    #[test]
+    fn test3() {
+        let nodes = vec![1, 2, 3, 4, 5, 6];
+        let edges = vec![(1, 2), (2, 3), (2, 4), (2, 6), (3, 5), (4, 5), (5, 2)];
+        let source = 1;
+        let graph = Graph::new(source, nodes, edges);
+        let natural_loops = graph.compute_reducible().unwrap();
+        assert_eq!(natural_loops.len(), 1);
+        let single_loop = &natural_loops[0];
+        assert_eq!(single_loop.loop_header, 2);
+        assert_eq!(single_loop.loop_latch, 5);
+        assert_eq!(
+            single_loop.loop_body,
+            vec![2, 3, 4, 5].into_iter().collect()
+        );
+    }
+
+    #[test]
+    fn test4() {
+        let nodes = vec![1, 2, 3, 4, 5, 6];
+        let edges = vec![(1, 2), (2, 3), (2, 4), (2, 6), (3, 5), (4, 5), (5, 2)];
+        let source = 6;
+        let graph = Graph::new(source, nodes, edges);
+        assert!(graph.compute_reducible().is_some());
+    }
+
+    #[test]
+    fn test5() {
+        // nested natural loops
+        let nodes = vec![1, 2, 3, 4, 5, 6];
+        let edges = vec![
+            (1, 2),
+            (2, 3),
+            (2, 4),
+            (2, 6),
+            (3, 5),
+            (4, 5),
+            (5, 2),
+            (3, 2),
+        ];
+        let source = 1;
+        let graph = Graph::new(source, nodes, edges);
+        let natural_loops = graph.compute_reducible().unwrap();
+
+        assert_eq!(natural_loops.len(), 2);
+        let (inner_loop, outer_loop) = if natural_loops[0].loop_latch == 3 {
+            assert_eq!(natural_loops[1].loop_latch, 5);
+            (&natural_loops[0], &natural_loops[1])
+        } else {
+            assert_eq!(natural_loops[0].loop_latch, 5);
+            assert_eq!(natural_loops[1].loop_latch, 3);
+            (&natural_loops[1], &natural_loops[0])
+        };
+
+        assert_eq!(inner_loop.loop_header, 2);
+        assert_eq!(inner_loop.loop_body, vec![2, 3].into_iter().collect());
+
+        assert_eq!(outer_loop.loop_header, 2);
+        assert_eq!(outer_loop.loop_body, vec![2, 3, 4, 5].into_iter().collect());
+    }
+}

--- a/language/move-lang/src/shared/mod.rs
+++ b/language/move-lang/src/shared/mod.rs
@@ -12,6 +12,7 @@ use std::{
 };
 
 pub mod ast_debug;
+pub mod graph;
 pub mod remembering_unique_map;
 pub mod unique_map;
 pub mod unique_set;

--- a/language/move-lang/src/to_bytecode/remove_fallthrough_jumps.rs
+++ b/language/move-lang/src/to_bytecode/remove_fallthrough_jumps.rs
@@ -1,12 +1,19 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::shared::graph::Graph;
 use move_ir_types::ast as IR;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
-// Removes any "fall through jumps", i.e. this a is a jump directly to the next instruction.
-// Iterates to find a fixpoint as it might create empty blocks which could create more jumps to
-// clean up
+// Removes any "fall through jumps", i.e. this is a direct jump to the next instruction. However,
+// if a fall-through jump is *the only instruction* in a loop header block, the jump is preserved.
+// This is essential for loop invariant instrumentation performed by the Move prover. Without this
+// preservation, nested loops might be coalesced to sharing a single loop header, e.g., in the case
+// of `loop { loop { loop { ... } ... } ... }`, but we need these loops to have different headers
+// such that we can instrument invariants for each loop respectively.
+//
+// The process of removing fall-through jumps and empty blocks repeats until a fixpoint is reached,
+// as removing jumps might create empty blocks which could create more jumps to be cleaned up.
 
 pub fn code(blocks: &mut IR::BytecodeBlocks) {
     let mut changed = true;
@@ -19,12 +26,18 @@ pub fn code(blocks: &mut IR::BytecodeBlocks) {
 
 fn remove_fall_through(blocks: &mut IR::BytecodeBlocks) -> bool {
     use IR::Bytecode_ as B;
+
+    let no_removals = collect_code_offsets_for_single_bytecode_loop_headers(blocks);
     let mut changed = false;
+    let mut code_offset = 0;
     for idx in 0..(blocks.len() - 1) {
         let next_block = blocks.get(idx + 1).unwrap().0.clone();
         let (_, block) = blocks.get_mut(idx).unwrap();
-        let remove_last =
-            matches!(&block.last().unwrap().value, B::Branch(lbl) if lbl == &next_block);
+        code_offset += block.len();
+        let remove_last = matches!(
+            &block.last().unwrap().value, B::Branch(lbl)
+            if lbl == &next_block && !no_removals.contains(&(code_offset - 1))
+        );
         if remove_last {
             changed = true;
             block.pop();
@@ -54,4 +67,117 @@ fn remove_empty_blocks(blocks: &mut IR::BytecodeBlocks) -> bool {
     }
 
     removed
+}
+
+// control-flow graph construction
+type CodeOffset = usize;
+
+struct BasicBlock {
+    entry: CodeOffset,
+    exit: CodeOffset,
+    successors: BTreeSet<CodeOffset>,
+}
+
+struct ControlFlowGraph {
+    graph: Graph<CodeOffset>,
+    blocks: BTreeMap<CodeOffset, BasicBlock>,
+}
+
+fn build_control_flow_graph(blocks: &[(IR::BlockLabel, IR::BytecodeBlock)]) -> ControlFlowGraph {
+    use IR::Bytecode_ as B;
+
+    // collect block ids
+    let code_length: usize = blocks.iter().map(|(_, block)| block.len()).sum();
+    let mut label_to_offset = BTreeMap::new();
+    let mut block_ids = BTreeSet::new();
+    let mut code_offset = 0;
+    for (label, block) in blocks {
+        label_to_offset.insert(label.clone(), code_offset);
+        block_ids.insert(code_offset);
+        for bytecode in block {
+            match bytecode.value {
+                B::Branch(_) | B::BrFalse(_) | B::BrTrue(_) | B::Ret | B::Abort => {
+                    let next_offset = code_offset + 1;
+                    if next_offset < code_length {
+                        block_ids.insert(next_offset);
+                    }
+                }
+                _ => {}
+            }
+            code_offset += 1;
+        }
+    }
+
+    // construct blocks
+    let mut cfg_blocks = BTreeMap::new();
+    code_offset = 0;
+    let mut entry = 0;
+    for (_, block) in blocks {
+        for bytecode in block {
+            let next_offset = code_offset + 1;
+            if next_offset == code_length || block_ids.contains(&next_offset) {
+                // this is the end of the block
+                let mut successors = BTreeSet::new();
+                match &bytecode.value {
+                    B::Ret | B::Abort => {
+                        // terminator block, no successors
+                    }
+                    B::Branch(br_label) => {
+                        // unconditional branch
+                        successors.insert(*label_to_offset.get(br_label).unwrap());
+                    }
+                    B::BrTrue(br_label) | B::BrFalse(br_label) => {
+                        // conditional branch, must have a fall through block
+                        successors.insert(*label_to_offset.get(br_label).unwrap());
+                        successors.insert(next_offset);
+                    }
+                    _ => {
+                        // fall-through
+                        successors.insert(next_offset);
+                    }
+                }
+                let bb = BasicBlock {
+                    entry,
+                    exit: code_offset,
+                    successors,
+                };
+                cfg_blocks.insert(entry, bb);
+                entry = next_offset;
+            }
+            code_offset += 1;
+        }
+    }
+
+    // construct the CFG
+    let nodes = cfg_blocks.keys().copied().collect();
+    let edges = cfg_blocks
+        .values()
+        .map(|bb| {
+            bb.successors
+                .iter()
+                .map(move |successor| (bb.entry, *successor))
+        })
+        .flatten()
+        .collect();
+
+    ControlFlowGraph {
+        graph: Graph::new(0, nodes, edges),
+        blocks: cfg_blocks,
+    }
+}
+
+fn collect_code_offsets_for_single_bytecode_loop_headers(
+    blocks: &[(IR::BlockLabel, IR::BytecodeBlock)],
+) -> BTreeSet<CodeOffset> {
+    let cfg = build_control_flow_graph(blocks);
+    let loops = cfg
+        .graph
+        .compute_reducible()
+        .expect("Well-formed Move control-flow graph should be reducible");
+    loops
+        .into_iter()
+        .map(|natural_loop| cfg.blocks.get(&natural_loop.loop_header).unwrap())
+        .filter(|bb| bb.entry == bb.exit)
+        .map(|bb| bb.entry)
+        .collect()
 }

--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -1401,6 +1401,11 @@ impl<'env> ModuleEnv<'env> {
         &self.data.module
     }
 
+    /// Gets the source map for the module
+    pub fn get_source_map(&'env self) -> &'env SourceMap<MoveIrLoc> {
+        &self.data.source_map
+    }
+
     /// Gets a `NamedConstantEnv` in this module by name
     pub fn find_named_constant(&'env self, name: Symbol) -> Option<NamedConstantEnv<'env>> {
         let id = NamedConstantId(name);

--- a/language/move-prover/Cargo.toml
+++ b/language/move-prover/Cargo.toml
@@ -20,6 +20,7 @@ diem-temppath = { path = "../../common/temppath" }
 diem-workspace-hack = { path = "../../common/workspace-hack" }
 bytecode-source-map = { path = "../compiler/bytecode-source-map" }
 move-ir-types = { path = "../move-ir/types" }
+disassembler = { path = "../tools/disassembler" }
 
 # external dependencies
 async-trait = "0.1.42"

--- a/language/move-prover/src/lib.rs
+++ b/language/move-prover/src/lib.rs
@@ -19,7 +19,9 @@ use bytecode::{
     read_write_set_analysis::{self, ReadWriteSetProcessor},
     spec_instrumentation::SpecInstrumentationProcessor,
 };
+use bytecode_source_map::mapping::SourceMapping;
 use codespan_reporting::term::termcolor::{ColorChoice, StandardStream, WriteColor};
+use disassembler::disassembler::{Disassembler, DisassemblerOptions};
 use docgen::Docgen;
 use errmapgen::ErrmapGen;
 use handlebars::Handlebars;
@@ -274,6 +276,30 @@ fn create_and_process_bytecode(options: &Options, env: &GlobalEnv) -> FunctionTa
 
     // Add function targets for all functions in the environment.
     for module_env in env.get_modules() {
+        if options.prover.dump_bytecode {
+            let disas = Disassembler::new(
+                SourceMapping::new(
+                    module_env.get_source_map().clone(),
+                    module_env.get_verified_module().clone(),
+                ),
+                DisassemblerOptions {
+                    only_externally_visible: false,
+                    print_code: true,
+                    print_basic_blocks: true,
+                    print_locals: true,
+                },
+            );
+            let content = disas
+                .disassemble()
+                .expect("Failed to disassemble a verified module");
+            let output_file = options
+                .move_sources
+                .get(0)
+                .cloned()
+                .unwrap_or_else(|| "bytecode".to_string())
+                .replace(".move", ".mv.disas");
+            fs::write(&output_file, &content).expect("dumping disassembled module");
+        }
         for func_env in module_env.get_functions() {
             targets.add_target(&func_env)
         }


### PR DESCRIPTION
In the source compiler, there is a simple optimization performed which removes any "fall through jumps" --- a direct jump to the next instruction.

However, if a fall-through jump is *the only instruction* in a loop header block, the jump should be preserved, because removing this jump means removing the header block as well, which essentially coalesced the outer loop to share the same header block with the inner loop. This is absolutely correct for program semantics, but creates a hard time for loop invariant instrumentation.

To illustrate, given a similar move program
```
// loop A
loop {
  // loop B
  loop {
    // loop C
    loop { 
      ... 
    } 
    ...
  }
...
}
```
where `loop` is the first statement in a loop body, then all loops will be coalesced to using the same header. In the above case, loop A, B, C will share the same header block in the control-flow graph.

But for the loop invariant instrumentation, we need these loops to have different headers such that we can instrument invariants for each loop respectively.

To illustrate this, here is the Move code

```
module VerifyLoopsWithMemoryOps {
    use 0x1::Vector;

    spec module {
        pragma verify=true;
    }

    public fun nested_loop(a: &mut vector<u64>, b: &mut vector<u64>) {
        let length = Vector::length(a);
        spec {
            assume length > 0;
            assume length == len(b);
        };
        let i = 0;
        let x = Vector::borrow_mut(a, i);
        let y = Vector::borrow_mut(b, i);
        loop {
            loop {
                loop {
                    spec {
                        assert x != y;
                    };
                    if (*x <= *y) {
                        break
                    };
                    *y = *y + 1;
                };

                if (*y <= *x) {
                    break
                };
                *x = *x + 1;
            };
            if (i == length) {
                break
            };
            i = i + 1;
            x = Vector::borrow_mut(a, i);
            y = Vector::borrow_mut(b, i);
        };
        spec {
            assert forall m in 0..len(a): a[m] == b[m];
        };
    }
    spec fun nested_loop {
        aborts_if false;
    }
}
```

Here is the
[disassembled bytecode w/o coalescing](https://github.com/diem/diem/files/6208349/loops-after.txt), and
[CFG w/o coalescing](https://github.com/diem/diem/files/6208356/cfg.pdf)
which can be compared with the coalesced version:
[disassembled bytecode w coalescing](https://github.com/diem/diem/files/6208467/loop.txt), and
[CFG w/ coalescing](https://github.com/diem/diem/files/6208446/cfg.pdf)
Pay attention to the loop header blocks that have only a single GOTO statement.

## Motivation

Make loop invariant instrumentation easier

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

This should not break anything, so the CI should all pass.

To reproduce the example:
`mvp --dependency <path-to-move-stdlib-modules>/Vector.move --dump-bytecode --dump-cfg loops.move`
`dot -Tpdf loops_10_verification_analysis_VerifyLoopsWithMemoryOps__nested_loop_baseline_cfg.dot -o cfg.pdf`
