### PR TITLE
[State Sync] Audit state sync logs and remove use of the overloaded "upstream" term.

### DIFF
--- a/state-sync/src/chunk_request.rs
+++ b/state-sync/src/chunk_request.rs
@@ -16,13 +16,13 @@ pub enum TargetType {
     TargetLedgerInfo(LedgerInfoWithSignatures),
     /// The response is built relative to the highest available LedgerInfo (or end of epoch).
     /// The value specifies the timeout in ms to wait for an available response.
-    /// This "long poll" approach allows an upstream node to add the request to the list of its
+    /// This "long poll" approach allows a responding node to add the request to the list of its
     /// subscriptions for the duration of a timeout until some new information becomes available.
     ///
     /// `target_li`: While asking for the highest available ledger info, this request also provides
     /// the option to the sync requester to specify a target LI.
-    /// This is to support the scenario where the sync requester is lagging too much behind the upstream node
-    /// in the sync process. If the highest ledger info version keeps advancing on the upstream node,
+    /// This is to support the scenario where the sync requester is lagging too much behind the responding node
+    /// in the sync process. If the highest ledger info version keeps advancing on the responding node,
     /// even though the sync requester continues to receive and sync txns, those txns will never be backed an LI,
     /// since a LI can only be committed once all the transactions up to the LI's version has been received.
     /// (It is important for a transaction to be backed by an LI, because transactions need to be backed by an LI
@@ -33,7 +33,7 @@ pub enum TargetType {
     /// to build the requested transactions w.r.t.. With (1), the sync requester can store the LI later to target-sync
     /// once it is ready for that LI after syncing to an earlier target LI via (2).
     ///
-    /// If `target_li` is not specified, the upstream node will build the responses against its highest LI
+    /// If `target_li` is not specified, the responding node will build the responses against its highest LI
     HighestAvailable {
         target_li: Option<LedgerInfoWithSignatures>,
         timeout_ms: u64,

--- a/state-sync/src/coordinator.rs
+++ b/state-sync/src/coordinator.rs
@@ -358,7 +358,7 @@ impl<T: ExecutorProxyTrait> StateSyncCoordinator<T> {
 
         let local_li_version = self.local_state.committed_version();
         let target_version = request.target.ledger_info().version();
-        debug!(
+        info!(
             LogSchema::event_log(LogEntry::SyncRequest, LogEvent::Received)
                 .target_version(target_version)
                 .local_li_version(local_li_version)
@@ -514,7 +514,7 @@ impl<T: ExecutorProxyTrait> StateSyncCoordinator<T> {
                 ));
             }
             if synced_version == sync_target_version {
-                debug!(
+                info!(
                     LogSchema::event_log(LogEntry::SyncRequest, LogEvent::Complete)
                         .local_li_version(committed_version)
                         .local_synced_version(synced_version)

--- a/state-sync/src/error.rs
+++ b/state-sync/src/error.rs
@@ -19,6 +19,10 @@ pub enum Error {
     IntegerOverflow(String),
     #[error("Received an invalid chunk request: {0}")]
     InvalidChunkRequest(String),
+    #[error(
+        "Unable to add peer as they are not a valid state sync peer: {0}. Connection origin: {1}"
+    )]
+    InvalidStateSyncPeer(String, String),
     #[error("Encountered a network error: {0}")]
     NetworkError(String),
     #[error("No peers are currently available: {0}")]
@@ -29,8 +33,6 @@ pub enum Error {
     NoTransactionsCommitted,
     #[error("Received an old sync request for version {0}, but our known version is: {1}")]
     OldSyncRequestVersion(Version, Version),
-    #[error("Unable to add peer as they are not an upstream peer: {0}. Connection origin: {1}")]
-    PeerIsNotUpstream(String, String),
     #[error("Processed an invalid chunk! Failed to apply the chunk: {0}")]
     ProcessInvalidChunk(String),
     #[error(

--- a/state-sync/src/executor_proxy.rs
+++ b/state-sync/src/executor_proxy.rs
@@ -289,7 +289,7 @@ impl ExecutorProxyTrait for ExecutorProxy {
                         subscription.name
                     );
                 } else {
-                    debug!(
+                    info!(
                         LogSchema::event_log(LogEntry::Reconfig, LogEvent::Success)
                             .subscription_name(subscription.name.clone()),
                         "Successfully published reconfig notification to subscription {}",

--- a/state-sync/src/logging.rs
+++ b/state-sync/src/logging.rs
@@ -20,7 +20,7 @@ pub struct LogSchema<'a> {
     error: Option<&'a Error>,
     #[schema(display)]
     peer: Option<&'a PeerNetworkId>,
-    is_upstream_peer: Option<bool>,
+    is_valid_peer: Option<bool>,
     #[schema(display)]
     chunk_request: Option<GetChunkRequest>,
     version: Option<u64>,
@@ -60,7 +60,7 @@ impl<'a> LogSchema<'a> {
             name,
             event,
             peer: None,
-            is_upstream_peer: None,
+            is_valid_peer: None,
             error: None,
             chunk_request: None,
             chunk_response: None,

--- a/state-sync/src/request_manager.rs
+++ b/state-sync/src/request_manager.rs
@@ -130,7 +130,7 @@ impl RequestManager {
             ));
         }
 
-        debug!(LogSchema::new(LogEntry::NewPeer)
+        info!(LogSchema::new(LogEntry::NewPeer)
             .peer(&peer)
             .is_upstream_peer(true));
         counters::ACTIVE_UPSTREAM_PEERS
@@ -157,7 +157,7 @@ impl RequestManager {
         peer: &PeerNetworkId,
         origin: ConnectionOrigin,
     ) -> Result<(), Error> {
-        debug!(LogSchema::new(LogEntry::LostPeer)
+        info!(LogSchema::new(LogEntry::LostPeer)
             .peer(&peer)
             .is_upstream_peer(self.is_upstream_peer(&peer, origin)));
 


### PR DESCRIPTION
## Motivation

This PR makes 2 improvements to state sync from a debugging and code clarity perspective:
1. (Debugging) First, the PR changes several important `debug` level logs to `info` level logs. Given that these logs correspond to important (but infrequent) events, it makes sense to ensure they are visible at higher levels. This was especially true when having to debug a recent issue around networking.
2. (Code Clarity) Second, we remove the use of the term "upstream" in the state sync code. This term is heavily overloaded as an upstream node in the network is different to an upstream node in state sync. Instead, in state sync, an "upstream" node is simply a valid node that can be used to synchronize. This commit updates the terms.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass.

## Related PRs

This relates to: https://github.com/diem/diem/issues/6795