### PR TITLE
[helm] update default image tag to devnet

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -77,7 +77,7 @@ jobs:
         name: find helm changes
         uses: ./.github/actions/matches
         with:
-          pattern: '^.github\|^helm|^developers.diem.com'
+          pattern: '^.github\|^helm\|^developers.diem.com'
       - id: dev-setup-sh-changes
         name: find dev-setup.sh/base docker image changes
         uses: ./.github/actions/matches

--- a/helm/fullnode/files/fullnode.yaml
+++ b/helm/fullnode/files/fullnode.yaml
@@ -9,8 +9,8 @@ execution:
 full_node_networks:
 - network_id: "public"
   discovery_method: "onchain"
-  seed_addrs:
-    {{- (get .Values.diem_chains .Values.chain.name).seed_addrs | default dict | toYaml | nindent 6 }}
+  seeds:
+    {{- (get .Values.diem_chains .Values.chain.name).seeds | default dict | toYaml | nindent 6 }}
 
 upstream:
   networks:

--- a/helm/fullnode/values.yaml
+++ b/helm/fullnode/values.yaml
@@ -7,16 +7,18 @@ diem_chains:
   testnet:
     id: TESTNET
     waypoint: 0:3139c30efe6dbde4228efb9df32c137dc3a2490b97ab6a086897be1d0cb336f0
-    seed_addrs:
+    seeds:
       4223dd0eeb0b0d78720a8990700955e1:
-      - "/dns4/fn.testnet.diem.com/tcp/6182/ln-noise-ik/d29d01bed8ab6c30921b327823f7e92c63f8371456fb110256e8c0e8911f4938/ln-handshake/0"
+        addresses:
+        - "/dns4/fn.testnet.diem.com/tcp/6182/ln-noise-ik/d29d01bed8ab6c30921b327823f7e92c63f8371456fb110256e8c0e8911f4938/ln-handshake/0"
+        keys:
+        - "d29d01bed8ab6c30921b327823f7e92c63f8371456fb110256e8c0e8911f4938"
+        role: "Upstream"
 
 rust_log: info
 
 image:
   repo: diem/validator
-  # "devnet" tag is updated daily
-  # additional image tags can be found on DockerHub: https://hub.docker.com/r/diem/validator/tags
   tag: devnet
   pullPolicy: IfNotPresent
 
@@ -58,7 +60,7 @@ logging:
 backup:
   image:
     repo: diem/tools
-    tag: release-1.1_a1abfc34
+    tag: devnet
     pullPolicy: IfNotPresent
   resources:
     limits:
@@ -100,7 +102,7 @@ backup_verify:
 restore:
   image:
     repo: diem/tools
-    tag: release-1.1_a1abfc34
+    tag: devnet
     pullPolicy: IfNotPresent
   resources:
     limits:

--- a/helm/fullnode/values.yaml
+++ b/helm/fullnode/values.yaml
@@ -15,7 +15,9 @@ rust_log: info
 
 image:
   repo: diem/validator
-  tag: release-1.1_a1abfc34
+  # "devnet" tag is updated daily
+  # additional image tags can be found on DockerHub: https://hub.docker.com/r/diem/validator/tags
+  tag: devnet
   pullPolicy: IfNotPresent
 
 resources:


### PR DESCRIPTION
Original image tag was hard coded to previous release. This makes it
easier to maintain, and also adds an additional check for backwards
compat.

Also update the GHA trigger since helm-test since there was previously a typo

Edit: also fix the seed peers config for PFN chart