### PR TITLE
[docs] change &signer to signer in script docs

### DIFF
--- a/developers.diem.com/docs/move/signer.md
+++ b/developers.diem.com/docs/move/signer.md
@@ -22,13 +22,13 @@ let a2 = 0x2;
 // ... and so on for every other possible address
 ```
 
-However, `signer` values are special because they cannot be created via literals or instructions--only by the Move VM. Before the VM runs a script with parameters of type `&signer`, it will automatically create `signer` values and pass references to these values into the script:
+However, `signer` values are special because they cannot be created via literals or instructions--only by the Move VM. Before the VM runs a script with parameters of type `signer`, it will automatically create `signer` values and them into the script:
 
 ```rust=
 script {
     use 0x1::Signer;
-    fun main(s: &signer) {
-        assert(Signer::address_of(s) == 0x42, 0);
+    fun main(s: signer) {
+        assert(Signer::address_of(&s) == 0x42, 0);
     }
 }
 ```
@@ -40,7 +40,7 @@ A transaction script can have an arbitrary number of `signer`s as long as the si
 ```rust=
 script {
     use 0x1::Signer;
-    fun main(s1: &signer, s2: &signer, x: u64, y: u8) {
+    fun main(s1: signer, s2: signer, x: u64, y: u8) {
         // ...
     }
 }

--- a/developers.diem.com/docs/move/signer.md
+++ b/developers.diem.com/docs/move/signer.md
@@ -22,7 +22,7 @@ let a2 = 0x2;
 // ... and so on for every other possible address
 ```
 
-However, `signer` values are special because they cannot be created via literals or instructions--only by the Move VM. Before the VM runs a script with parameters of type `signer`, it will automatically create `signer` values and them into the script:
+However, `signer` values are special because they cannot be created via literals or instructions--only by the Move VM. Before the VM runs a script with parameters of type `signer`, it will automatically create `signer` values and pass them into the script:
 
 ```rust=
 script {

--- a/language/tools/move-cli/README.md
+++ b/language/tools/move-cli/README.md
@@ -68,7 +68,7 @@ Let's first start out with a simple script that prints its `signer`:
 ```rust
 script {
 use 0x1::Debug;
-fun main(account: &signer) {
+fun main(account: signer) {
     Debug::print(account)
 }
 }
@@ -111,7 +111,7 @@ address 0x2 {
 module Test {
     use 0x1::Signer;
 
-    resource struct Resource { i: u64 }
+    struct Resource { i: u64 } has key
 
     public fun publish(account: &signer) {
         move_to(account, Resource { i: 10 })
@@ -201,8 +201,8 @@ Let's exercise our new `Test` module by running the following script:
 ```rust
 script {
 use 0x2::Test;
-fun main(account: &signer) {
-    Test::publish(account)
+fun main(account: signer) {
+    Test::publish(&account)
 }
 }
 ```
@@ -393,8 +393,8 @@ content:
 ```rust
 script {
 use 0x2::Test;
-fun main(account: &signer) {
-    Test::unpublish(account)
+fun main(account: signer) {
+    Test::unpublish(&account)
 }
 }
 ```
@@ -502,7 +502,7 @@ module:
 ```
 address 0x2 {
 module M {
-  resource struct S { f: u64, g: u64 }
+    struct S { f: u64, g: u64 } has key
 }
 }
 ```
@@ -512,7 +512,7 @@ and then wish to upgrade it to the following:
 ```
 address 0x2 {
 module M {
-  resource struct S { f: u64 }
+    struct S { f: u64 } has key
 }
 }
 ```


### PR DESCRIPTION
Reflecting recent Move changes in the documentation.