### PR TITLE
[specifications] update the move_adapter spec with script function info

### DIFF
--- a/specifications/move_adapter/README.md
+++ b/specifications/move_adapter/README.md
@@ -138,6 +138,8 @@ pub enum TransactionPayload {
     Script(Script),
     /// A transaction that publishes code.
     Module(Module),
+    /// A transaction that executes an existing script function published on-chain.
+    ScriptFunction(ScriptFunction),
 }
 
 /// Two different kinds of WriteSet transactions.
@@ -166,6 +168,14 @@ pub struct Script {
     args: Vec<TransactionArgument>,
 }
 
+/// Call a Move script function.
+pub struct ScriptFunction {
+    module: ModuleId,
+    function: Identifier,
+    ty_args: Vec<TypeTag>,
+    args: Vec<Vec<u8>>,
+}
+
 /// A module publishing transaction contains the code to be published.
 pub struct Module {
     code: Vec<u8>,
@@ -173,7 +183,8 @@ pub struct Module {
 ```
 
 There are several different kinds of transactions that can be stored in the
-transaction payload: executing a script, publishing a module, and applying a
+transaction payload: executing a script or script function,
+publishing a module, and applying a
 WriteSet for system maintenance or updates. The payload is stored inside a
 `RawTransaction` structure that includes the various fields that are common to
 all of these transactions, and the `RawTransaction` is signed and wrapped
@@ -198,6 +209,11 @@ public key and the `RawTransaction` content. If not, this check fails with an
 key against the sender account's authorization key is done separately in Move
 code.
 
+* Load the `RoleId` resource from the sender's account. If the validation is
+successful, this value is returned as the `governance_role` field of the
+`VMValidatorResult` so that the client can choose to prioritize governance
+transactions.
+
 * Check that the `gas_currency_code` in the `RawTransaction` is a name composed
 of uppercase ASCII alphanumeric characters where the first character is a letter. If
 not, validation will fail with an `INVALID_GAS_SPECIFIER` status code. Note
@@ -212,15 +228,15 @@ prioritizing the transaction. The normalization is calculated using the
 gas currency. This can fail with a status code of
 `CURRENCY_INFO_DOES_NOT_EXIST` if the exchange rate cannot be retrieved.
 
-* Load the `RoleId` resource from the sender's account. If the validation is
-successful, this value is returned as the `governance_role` field of the
-`VMValidatorResult` so that the client can choose to prioritize governance
-transactions.
+* If the transaction payload is a `ScriptFunction`, check if the on-chain
+Diem Version number is 2 or later. For version 1, validation will fail with
+a `FEATURE_UNDER_GATING` status code.
 
 ### Gas and Size Checks
 
 Next, there are a series of checks related to the transaction size and gas
-parameters. These checks are performed for `Script` and `Module` payloads, but
+parameters. These checks are performed for `Script`, `ScriptFunction`,
+and `Module` payloads, but
 not for `WriteSet` transactions. The constraints for these checks are defined
 by the `GasConstants` structure in the `DiemVMConfig` module.
 
@@ -260,10 +276,15 @@ Move VM with gas metering disabled. Each kind of transaction payload has a
 corresponding prologue function that is used for validation. These prologue
 functions are defined in the `DiemAccount` module of the Diem Framework:
 
-* `Script`: The prologue function is `script_prologue`. In addition to the
-common checks listed below, it also calls the `is_script_allowed` function in
-the `DiemTransactionPublishingOption` module with the hash of the script
-bytecode to check if it is on the list of allowed scripts. If not, validation
+* `ScriptFunction` and `Script`: The prologue function is `script_prologue`.
+In addition to the common checks listed below, it also calls the `is_script_allowed`
+function in the `DiemTransactionPublishingOption` module to determine if the script
+should be allowed. A script sent by an account with `has_diem_root_role` is always
+allowed. Otherwise, a `Script` payload is allowed if the hash of the
+script bytecode is on the list of allowed scripts published at
+`0x1::DiemTransactionPublishingOption::DiemTransactionPublishingOption.script_allowlist`.
+`ScriptFunction` payloads, for which the adapter uses an empty vector in place
+of the script hash, are always allowed. If the script is not allowed, validation
 fails with an `UNKNOWN_SCRIPT` status code.
 
 * `Module`: The prologue function is `module_prologue`. In addition to the
@@ -388,6 +409,7 @@ the entire system.
 ### Monitoring and Logging
 
 * Monitoring:
+
     - `diem_vm_transactions_validated`: Number of transactions processed by
       the validator, with either "success" or "failure" labels
     - `diem_vm_txn_validation_seconds`: Histogram of validation time (in
@@ -620,8 +642,22 @@ input transactions are executed.
 ### Script and Module Transactions
 
 After re-validating a user transaction, the adapter processes the payload,
-depending on its contents. In the common case, the payload is either a script
-or a module:
+depending on its contents.
+
+Diem version 1 had a fixed set of script transactions for general user
+transactions, with the script hash values stored in the on-chain allowlist,
+that are now implemented as script functions in Diem version 2 and later.
+If the on-chain Diem Version number is 2 or later, the adapter first checks
+if the script is one of those special scripts, and if so, remaps it to the
+corresponding script function. Because this remapping is fixed to Diem
+version 1 and is never expected to change, the remapping to script functions
+is hardcoded in the adapter.
+
+In the common case, the payload is either a script
+function, script, or a module:
+
+* `ScriptFunction`: The Move VM is used to [execute](#Script-Function-Execution)
+the script function with the types and arguments specified in the transaction.
 
 * `Script`: The Move VM is used to [execute](#Script-Execution) the script with
 the types and arguments specified in the transaction.
@@ -761,180 +797,14 @@ implementation for a data cache that relieves the Diem client from an
 important responsibility (data cache consistency). That abstraction is behind
 a `Session` which is the only way to talk to the runtime.
 
-```rust
-// A trait build on a data view (`StateView`) which offers an API suitable to the VM.
-pub trait RemoteCache {
-    // Get a binary (`Vec<u8>`) given a `ModuleId`. Return `None` if no binary was
-    // published for that `ModuleId`
-    fn get_module(&self, module_id: &ModuleId) -> VMResult<Option<Vec<u8>>>;
-
-    // Get a resource in its serialized form given an `AccountAddress` where the resource
-    // is published and a resource type
-    fn get_resource(
-        &self,
-        address: &AccountAddress,
-        tag: &TypeTag,
-    ) -> PartialVMResult<Option<Vec<u8>>>;
-}
-
-// A client interaction with a VM that collects side effects across multiple invocation.
-pub struct Session<'r, 'l, R>;
-
-// A `MoveVM`
-impl MoveVM {
-    // Get a `Session` given a `RemoteCache`
-    pub fn new_session<'r, R: RemoteCache>(&self, remote: &'r R) -> Session<'r, '_, R>;
-}
-
-impl<'r, 'l, R: RemoteCache> Session<'r, 'l, R> {
-    // Execute a function. The function identity is the `ModuleId` and the function name.
-    pub fn execute_function(
-        &mut self,
-        // instantiated function
-        module: &ModuleId,
-        function_name: &IdentStr,
-        ty_args: Vec<TypeTag>,
-        // arguments
-        args: Vec<Value>,
-        // sender
-        sender: AccountAddress,
-        // amount of computation allowed
-        cost_strategy: &mut CostStrategy,
-        log_context: &impl LogContext,
-    ) -> VMResult<()>;
-
-    // Execute a client script.
-    pub fn execute_script(
-        &mut self,
-        // instantiated script entry point
-        script: Vec<u8>,
-        ty_args: Vec<TypeTag>,
-        // arguments
-        args: Vec<Value>,
-        // senders
-        senders: Vec<AccountAddress>,
-        // amount of computation allowed
-        cost_strategy: &mut CostStrategy,
-        log_context: &impl LogContext,
-    ) -> VMResult<()>;
-
-    // Publish a Module.
-    pub fn publish_module(
-        &mut self,
-        // module to publish in its serialized form
-        module: Vec<u8>,
-        // publisher
-        sender: AccountAddress,
-        // amount of computation allowed
-        cost_strategy: &mut CostStrategy,
-        log_context: &impl LogContext,
-    ) -> VMResult<()>;
-
-    pub fn finish(self) -> VMResult<(ChangeSet, Vec<Event>)>;
-}
-
-/// A collection of changes to a Move state.
-/// Note: This is different than the ChangeSet used in Diem transactions.
-pub struct ChangeSet {
-    pub accounts: BTreeMap<AccountAddress, AccountChangeSet>,
-}
-
-/// A collection of changes to modules and resources under a Move account.
-pub struct AccountChangeSet {
-    pub modules: BTreeMap<Identifier, Option<Vec<u8>>>,
-    pub resources: BTreeMap<StructTag, Option<Vec<u8>>>,
-}
-
-/// Event tuple: event key, sequence number, type tag, and event data
-pub type Event = (Vec<u8>, u64, TypeTag, Vec<u8>);
-```
-
 The objective of a `Session` is to create and manage the data cache for a set
 of invocations into the VM. It is also intended to return side effects in a
 format that is suitable to the adapter, and in line with Diem and the
 generation of a `WriteSet`.
-
 A `Session` forwards calls to the `Runtime` which is where the logic and
-implementation of the VM lives and starts. A Runtime offers 3 entry points
-that are one-to-one with the `Session` API:
+implementation of the VM lives and starts.
 
-```rust
-impl Runtime {
-    // Publish a Module.
-    pub fn publish_module(
-        &self,
-        // module to publish in its serialized form
-        module: Vec<u8>,
-        // publisher
-        sender: AccountAddress,
-        // data store
-        data_store: &mut dyn DataStore,
-        // amount of computation allowed
-        cost_strategy: &mut CostStrategy,
-        log_context: &impl LogContext,
-    ) -> VMResult<()>;
-
-    // Execute a function. The function identity is the `ModuleId` and the function name.
-    pub fn execute_function(
-        &self,
-        // instantiated function
-        module: &ModuleId,
-        function_name: &IdentStr,
-        ty_args: Vec<TypeTag>,
-        // arguments
-        args: Vec<Value>,
-        // sender
-        sender: AccountAddress,
-        // data store
-        data_store: &mut dyn DataStore,
-        // amount of computation allowed
-        cost_strategy: &mut CostStrategy,
-        log_context: &impl LogContext,
-    ) -> VMResult<()>;
-
-    // Execute a client script.
-    pub fn execute_script(
-        &self,
-        // instantiated script entry point
-        script: Vec<u8>,
-        ty_args: Vec<TypeTag>,
-        // arguments
-        args: Vec<Value>,
-        // sender
-        sender: AccountAddress,
-        // data store
-        data_store: &mut dyn DataStore,
-        // amount of computation allowed
-        cost_strategy: &mut CostStrategy,
-        log_context: &impl LogContext,
-    ) -> VMResult<()>;
-}
-```
-
-All entry points take the following arguments:
-
-* `sender: AccountAddress`: This is the address that originated the call. In a
-sense the address that takes responsibility of the call. The `sender` is a
-special address in the Adapter as it represents either VM authority (for
-special calls) or the [signer of the transaction](#Script-Execution).
-
-* `data_store: &mut dyn DataStore`: The `DataStore` is the read/write API over the
-data for the VM. Remember that an adapter takes a `StateView` which is a read
-only view of the data. The Adapter is expected to wrap that view and provide
-the VM with a read/write API. The adapter uses that cache to track side
-effects and write set, and it forwards request to the `StateView` for loading
-data that is not in the cache yet.
-
-* `cost_strategy: &mut CostStrategy`: `CostStrategy` is a protocol to meter the
-VM. Metering allows a client to limit the amount of computation a call into
-the VM can perform. It is also the mechanism by which a transaction is
-charged. At the end of execution, `CostStrategy` will carry the transaction
-charges.
-
-* `log_context: &impl LogContext`: This is a trait used by the VM to trigger alerts
-for critical errors.
-
-#### Code Cache
+### Code Cache
 
 When loading a Module for the first time, the VM queries the data store for
 the Module. That binary is deserialized, verified, loaded and cached by the
@@ -967,128 +837,128 @@ the code cache.
 
 ### Publishing
 
-Clients may publish modules in the system by calling
+Clients may publish modules in the system by calling:
 
 ```rust
-// Publish a Module if passes verification and would be loadable by the VM.
 pub fn publish_module(
-    &self,
-    // module to publish
+    &mut self,
     module: Vec<u8>,
-    // publisher
     sender: AccountAddress,
-    // data store
-    data_store: &mut dyn DataStore,
-    // amount of computation allowed
     cost_strategy: &mut CostStrategy,
+    log_context: &impl LogContext,
 ) -> VMResult<()>;
 ```
 
-the module is in a [serialized form](#Binary-Format) and the VM performs the
+The `module` is in a [serialized form](#Binary-Format) and the VM performs the
 following steps:
 
-* **Deserialize the module**. If the module does not deserialize, an error is
+* Deserialize the module: If the module does not deserialize, an error is
 returned with a proper `StatusCode`.
 
-* **Check that the module address and the `sender` address are the same**. This
+* Check that the module address and the `sender` address are the same: This
 check verifies that the publisher is the account that will eventually [hold
-the module](#References-to-Data-and-Code). If the 2 addresses do not match, an
+the module](#References-to-Data-and-Code). If the two addresses do not match, an
 error with `StatusCode::MODULE_ADDRESS_DOES_NOT_MATCH_SENDER` is returned.
 
-* **Check that the module is not alredy published**. Code is immutable in
+* Check that the module is not already published: Code is immutable in
 Move. An attempt to overwrite an exiting module results in an error with
 `StatusCode::DUPLICATE_MODULE_NAME`.
 
-* **Verify loading**. The VM performs [verification](#Verification) of the
+* Verify loading: The VM performs [verification](#Verification) of the
 module to prove correctness. However, neither the module nor any of its
-dependencies are actually saved in the cached. The VM ensures that the module
+dependencies are actually saved in the cache. The VM ensures that the module
 will be loadable when a reference will be found. If a module would fail to
 load an error with proper `StatusCode` is returned.
 
-* **Publish**. The VM writes the module (as the original `module: Vec<u8>`),
-with the [proper key](#References-to-Data-and-Code) to the
-`DataStore`. `Ok(())` is returned. After this step any reference to the
+* Publish: The VM writes the serialized bytes of the module
+with the [proper key](#References-to-Data-and-Code) to the storage.
+After this step any reference to the
 module is valid.
-
-### Tests
-
-### Threats
-
-### Monitoring and Logging
-
-### Runbook
 
 ## Script Execution
 
-The VM allows the execution of [scripts](#Binary-Format). A script is an entry
-point (equivalent to a `main(...)`) that executes Move code. A script performs
-calls into the Diem Framework (_reference to specification?_) to accomplish a
-logical transaction. A script is not saved on storage, like modules are, and
-a script cannot be invoked by other scripts or modules. A script is
-"temporary" code intended to move the state using calls into the Diem
-Framework.
+The VM allows the execution of [scripts](#Binary-Format). A script is a
+Move function declared in a `script` block that performs
+calls into the Diem Framework to accomplish a
+logical transaction. A script is not saved in storage and
+it cannot be invoked by other scripts or modules.
 
 ```rust
-// Execute a user script
 pub fn execute_script(
-    &self,
-    // script entry point instantiated
+    &mut self,
     script: Vec<u8>,
     ty_args: Vec<TypeTag>,
-    // arguments
-    args: Vec<Value>,
-    // sender
-    sender: AccountAddress,
-    // data store
-    data_store: &mut dyn DataStore,
-    // amount of computation allowed
+    args: Vec<Vec<u8>>,
+    senders: Vec<AccountAddress>,
     cost_strategy: &mut CostStrategy,
+    log_context: &impl LogContext,
 ) -> VMResult<()>;
 ```
 
-a script is in a [serialized form](#Binary-Format) (`script: Vec<u8>`), and an
-instantiation (`ty_args: Vec<TypeTag>`) is provided if the script entry point
-is generic (`main()` vs `main<T: copyable>()`). If the entry point takes
-arguments (`main(v: u64)`) those are provided in `args: Vec<Value>`. The VM
+The `script` is specified in a [serialized form](#Binary-Format).
+If the script is generic, the `ty_args` vector contains the `TypeTag`
+values for the type arguments. The `signer` account addresses for the
+script are specified in the `senders` vector. Any additional arguments
+are provided in the `args` vector, where each argument is a BCS-serialized
+vector of bytes. The VM
 performs the following steps:
 
-* **Load the Script and the main function**
-    - The hash value of the script binary (`script: Vec<u8>`) is computed
-      (`HashValue::sha3_256_of`)
+* Load the Script and the main function:
+
+    - The `sha3_256` hash value of the `script` binary is computed.
     - The hash is used to access the script cache to see if the script was
       loaded. The hash is used for script identity.
     - If not in the cache the script is [loaded](#Loading). If loading fails,
       execution stops and an error with a proper `StatusCode` is returned.
     - The script main function is [checked against the
-      instantiation](#Verification) (`ty_args: Vec<TypeTag>`) and if there are
+      type argument instantiation](#Verification) and if there are
       errors, execution stops and the error returned.
 
-* **Build the argument list**. If the first parameter of the script main
-signature is `&Signer` the VM prepends the argument list in input with an
-instance of a `Signer` whose address is the `sender: AccountAddress`. The
-list is then checked against a whitelisted set of permitted types (_specify
-which types_). The VM returns an error with `StatusCode::TYPE_MISMATCH` if
+* Build the argument list: The first arguments are `Signer` values created by
+the VM for the account addresses in the `senders` vector. Any other arguments
+from the `args` vector are then checked against a whitelisted set of permitted
+types and added to the arguments for the script.
+The VM returns an error with `StatusCode::TYPE_MISMATCH` if
 any of the types is not permitted.
 
-* **Execute the script**. The VM invokes the interpreter to [execute the
+* Execute the script: The VM invokes the interpreter to [execute the
 script](#Interpreter). Any error during execution is returned, and the
 transaction aborted. The VM returns whether execution succeeded or
-failed. Clients track side effects through the `DataStore` instance.
+failed.
 
-### Tests
+## Script Function Execution
 
-### Threats
+Script functions (in version 2 and later of the Move VM) are similar to scripts
+except that the Move bytecode comes from a Move function with `script` visibility
+in an on-chain module. The script function is specified by the module and function
+name:
 
-### Monitoring and Logging
+```rust
+pub fn execute_script_function(
+    &mut self,
+    module: &ModuleId,
+    function_name: &IdentStr,
+    ty_args: Vec<TypeTag>,
+    args: Vec<Vec<u8>>,
+    senders: Vec<AccountAddress>,
+    cost_strategy: &mut CostStrategy,
+    log_context: &impl LogContext,
+) -> VMResult<()>;
+```
 
-### Runbook
+Execution of script functions is similar to scripts. Instead of using the Move bytecodes
+from a script, the script function is loaded from the on-chain module, and the Move VM
+checks that it has `script` visibility. The rest of the script function execution is
+the same as for scripts. If the function does not exist, execution fails with a
+`FUNCTION_RESOLUTION_FAILURE` status code. If the function does not have `script` visibility,
+it will fail with the `EXECUTE_SCRIPT_FUNCTION_CALLED_ON_NON_SCRIPT_VISIBLE` status code.
 
 ## Function Execution
 
-The VM allows the execution of [any function in a Module](#Binary-Format)
+The VM allows the execution of [any function in a module](#Binary-Format)
 through a `ModuleId` and a function name. Function names are unique within a
-Module (no overloading), so the signature of the function is not
-required. Arguments check is done by the [interpreter](#Interpreter).
+module (no overloading), so the signature of the function is not
+required. Argument checking is done by the [interpreter](#Interpreter).
 
 The adapter uses this entry point to run specific system functions as
 described in [validation](#Validation) and [execution](#Execution). This is a
@@ -1097,52 +967,39 @@ checks. Clients would likely use this entry point internally (e.g., for
 constructing a genesis state), or wrap and expose it with restrictions.
 
 ```rust
-// Execute a function. The function identity is the `ModuleId` and the function name.
 pub fn execute_function(
-    &self,
-    // function signature instantiated
+    &mut self,
     module: &ModuleId,
     function_name: &IdentStr,
     ty_args: Vec<TypeTag>,
-    // arguments
-    args: Vec<Value>,
-    // sender
-    sender: AccountAddress,
-    // data store
-    data_store: &mut dyn DataStore,
-    // amount of computation allowed
+    args: Vec<Vec<u8>>,
     cost_strategy: &mut CostStrategy,
+    log_context: &impl LogContext,
 ) -> VMResult<()>;
 ```
 
-* **Load Function**.
+The VM performs the following steps:
 
-    - The Module identified by `module: &ModuleId` is [loaded](#Loading).
-      An error in loading halts execution, and returns the error with a proper
+* Load the function:
+
+    - The specified `module` is first [loaded](#Loading).
+      An error in loading halts execution and returns the error with a proper
       `StatusCode`.
     - The VM looks up the function in the module. Failure to resolve the
       function returns an error with a proper `StatusCode`.
-    - Every type in `ty_args: Vec<TypeTag>` is [loaded](#Loading). An error
-      in loading halts execution, and returns the error with a proper `StatusCode`.
+    - Every type in the `ty_args` vector is [loaded](#Loading). An error
+      in loading halts execution and returns the error with a proper `StatusCode`.
       Type arguments are checked against type parameters and an error returned
-      if there is a mismatch (argument inconsistent with generic declaration)
+      if there is a mismatch (i.e., argument inconsistent with generic declaration).
 
-* **Build the argument list**. Arguments are checked against a whitelisted set
+* Build the argument list: Arguments are checked against a whitelisted set
 of permitted types (_specify which types_). The VM returns an error with
 `StatusCode::TYPE_MISMATCH` if any of the types is not permitted.
 
-* **Execute the function**. The VM invokes the interpreter to [execute the
+* Execute the function: The VM invokes the interpreter to [execute the
 function](#Interpreter). Any error during execution aborts the interpreter
 and returns the error. The VM returns whether execution succeeded or
-failed. Clients track side effects through the `DataStore` instance.
-
-### Tests
-
-### Threats
-
-### Monitoring and Logging
-
-### Runbook
+failed.
 
 ## Binary Format
 
@@ -1167,220 +1024,239 @@ an important saving. Integers, when used with no compression are in
 Vectors are serialized with the size first, in ULEB128 form, followed by the
 elements contiguously.
 
-##### Binary Header
+### Binary Header
 
 Every binary starts with a header that has the following format:
 
-* **Magic**: 4 bytes - constant 0xA11CEB0B (aka AliceBob)
-* **Version**: U32, 4 bytes, in little-endian form
-* **Table count**: number of tables in ULEB128 form. The current maximum number
+* `Magic`: 4 bytes 0xA1, 0x1C, 0xEB, 0x0B (aka "A11CEB0B" or "AliceBob")
+* `Version`: 4 byte little-endian unsigned integer
+* `Table count`: number of tables in ULEB128 form. The current maximum number
 of tables is contained in 1 byte, so this is effectively the count of tables in
 one byte. Not all tables need to be present. Each kind of table can only be
-present once, table repetitions are not allowed. Tables can be serialized in any
+present once; table repetitions are not allowed. Tables can be serialized in any
 order.
 
-##### Table Headers
+### Table Headers
 
 Following the binary header are the table headers. There are as many tables as
-defined in "table count". Each table header is a tuple of 3 elements and it
+defined in "table count". Each table header
 has the following format:
 
-* **Table Kind**: 1 byte - the [kind of table](#Tables) that is serialized at
+* `Table Kind`: 1 byte for the [kind of table](#Tables) that is serialized at
 the location defined by the next 2 entries
-* **Table Offset**: ULEB128 - offset from the end of the table headers where the
+* `Table Offset`: ULEB128 offset from the end of the table headers where the
 table content starts
-* **Table Length**: ULEB128 - byte count of the table content
+* `Table Length`: ULEB128 byte count of the table content
 
 Tables must be contiguous to each other, starting from the end of the table
 headers. There must not be any gap between the content of the tables. Table
 content must not overlap.
 
-##### Tables
+### Tables
 
-A **Table Kind** is 1 byte, and it is one of:
+A `Table Kind` is 1 byte, and it is one of:
 
-* `0x1`: MODULE\_HANDLES - for both Modules and Scripts
-* `0x2`: STRUCT\_HANDLES - for both Modules and Scripts
-* `0x3`: FUNCTION\_HANDLES - for both Modules and Scriptss
-* `0x4`: FUNCTION\_INSTANTIATIONS - for both Modules and Scripts
-* `0x5`: SIGNATURES - for both Modules and Scripts
-* `0x6`: CONSTANT\_POOL - for both Modules and Scripts
-* `0x7`: IDENTIFIERS - for both Modules and Scripts
-* `0x8`: ADDRESS\_IDENTIFIERS - for both Modules and Scripts
-* `0x9`: STRUCT\_DEFINITIONS - only for Modules
-* `0xA`: STRUCT\_DEF\_INSTANTIATIONS - only for Modules
-* `0xB`: FUNCTION\_DEFINITIONS - only for Modules
-* `0xC`: FIELD\_HANDLES - only for Modules
-* `0xD`: FIELD\_INSTANTIATIONS - only for Modules
+* `0x1`: `MODULE_HANDLES` - for both Modules and Scripts
+* `0x2`: `STRUCT_HANDLES` - for both Modules and Scripts
+* `0x3`: `FUNCTION_HANDLES` - for both Modules and Scriptss
+* `0x4`: `FUNCTION_INSTANTIATIONS` - for both Modules and Scripts
+* `0x5`: `SIGNATURES` - for both Modules and Scripts
+* `0x6`: `CONSTANT_POOL` - for both Modules and Scripts
+* `0x7`: `IDENTIFIERS` - for both Modules and Scripts
+* `0x8`: `ADDRESS_IDENTIFIERS` - for both Modules and Scripts
+* `0xA`: `STRUCT_DEFINITIONS` - only for Modules
+* `0xB`: `STRUCT_DEF_INSTANTIATIONS` - only for Modules
+* `0xC`: `FUNCTION_DEFINITIONS` - only for Modules
+* `0xD`: `FIELD_HANDLES` - only for Modules
+* `0xE`: `FIELD_INSTANTIATIONS` - only for Modules
+* `0xF`: `FRIEND_DECLS` - only for Modules, version 2 and later
 
-following is the format of each table:
+The formats of the tables are:
 
-* **_MODULE\_HANDLES_** - A Module Handle is a pair of indices that identify
-the location of a module
+* `MODULE_HANDLES`: A `Module Handle` is a pair of indices that identify
+the location of a module:
 
-    * **_address_**: ULEB128 - index into the ADDRESS\_IDENTIFIERS table of
+    * `address`: ULEB128 index into the `ADDRESS_IDENTIFIERS` table of
     the account under which the module is published
-    * **_name_**: ULEB128 - index into the IDENTIFIERS table of the name of the module
+    * `name`: ULEB128 index into the `IDENTIFIERS` table of the name of the module
 
-* **_STRUCT\_HANDLES_** - A Struct Handle contains all the information to
-uniquely identify a user type
+* `STRUCT_HANDLES`: A `Struct Handle` contains all the information to
+uniquely identify a user type:
 
-    * **_module_**: ULEB128 - index in the MODULE\_HANDLES table of the module
+    * `module`: ULEB128 index in the `MODULE_HANDLES` table of the module
     where the struct is defined
-    * **_name_**: ULEB128 - index into the IDENTIFIERS table of the name of the struct
-    * **_nominal resource_**: U8 - a bool (0: false, 1: true) defining whether the
+    * `name`: ULEB128 index into the `IDENTIFIERS` table of the name of the struct
+    * `nominal resource`: U8 bool defining whether the
     struct is a resource (true/1) or not (false/0)
-    * **_type parameters_**: vector of [type parameter kinds](#Kinds) if the
+    * `type parameters`: vector of [type parameter kinds](#Kinds) if the
     struct is generic, an empty vector otherwise:
-        * **_length_**: ULEB128 - length of the vector, effectively the number of type
+        * `length`: ULEB128 length of the vector, effectively the number of type
         parameters for the generic struct
-        * **_kinds_**: kind (U8) * length - contiguous kinds, not present if length is 0
+        * `kinds`: array of `length` U8 kind values; not present if length is 0
 
-* **_FUNCTION\_HANDLES_** - A Function Handle contains all the information to uniquely
-identify a function
+* `FUNCTION_HANDLES`: A `Function Handle` contains all the information to uniquely
+identify a function:
 
-    * **_module_**: ULEB128 - index in the MODULE\_HANDLES table of the module where
+    * `module`: ULEB128 index in the `MODULE_HANDLES` table of the module where
     the function is defined
-    * **_name_**: ULEB128 - index into the IDENTIFIERS table of the name of the function
-    * **_parameters_**: ULEB128 - index into the SIGNATURES table for the argument types
+    * `name`: ULEB128 index into the `IDENTIFIERS` table of the name of the function
+    * `parameters`: ULEB128 index into the `SIGNATURES` table for the argument types
     of the function
-    * **_return_**: ULEB128 - index into the SIGNATURES table for the return types of the function
-    * **_type parameters_**: vector of [type parameter kinds](#Kinds) if the function
+    * `return`: ULEB128 index into the `SIGNATURES` table for the return types of the function
+    * `type parameters`: vector of [type parameter kinds](#Kinds) if the function
     is generic, an empty vector otherwise:
-        * **_length_**: ULEB128 - length of the vector, effectively the number of type
+        * `length`: ULEB128 length of the vector, effectively the number of type
         parameters for the generic function
-        * **_kinds_**: kind (U8) * length - contiguous kinds, not present if length is 0
+        * `kinds`: array of `length` U8 kind values; not present if length is 0
 
-* **_FUNCTION\_INSTANTIATIONS_** - A Function Instantiation describes the
+* `FUNCTION_INSTANTIATIONS`: A `Function Instantiation` describes the
 instantation of a generic function. Function Instantiation can be full or
-partial. E.g. given a generic function `f<K, V>()` a full instantiation would
+partial. E.g., given a generic function `f<K, V>()` a full instantiation would
 be `f<U8, Bool>()` whereas a partial instantiation would be `f<U8, Z>()` where
 `Z` is a type parameter in a given context (typically another function
-`g<Z>()`)
+`g<Z>()`).
 
-    * **_function handle_**: ULEB128 - index into the FUNCTION\_HANDLES table of the
-    generic function for this instantiation (e.g. `f<K, W>()`)
-    * **_instantiation_**: ULEB128 - index into the SIGNATURES table for the
+    * `function handle`: ULEB128 index into the `FUNCTION_HANDLES` table of the
+    generic function for this instantiation (e.g., `f<K, W>()`)
+    * `instantiation`: ULEB128 index into the `SIGNATURES` table for the
     instantiation of the function
 
-* **_SIGNATURES_** - The set of signatures in this binary. A signature is a
+* `SIGNATURES`: The set of signatures in this binary. A signature is a
 vector of [Signature Tokens](#SignatureTokens), so every signature will carry
-the length (in ULEB128 form) followed by the Signature Tokens
+the length (in ULEB128 form) followed by the Signature Tokens.
 
-* **_CONSTANT\_POOL_** - The set of constants in the binary. A constant is a
+* `CONSTANT_POOL`: The set of constants in the binary. A constant is a
 copyable primitive value or a vector of vectors of primitives. Constants
 cannot be user types. Constants are serialized according to the rule defined
 in [Move Values](#Move-Values) and stored in the table in serialized form. A
 constant in the constant pool has the following entries:
 
-    * **_type_**: the [Signature Token](#SignatureTokens) (type) of the value that follows
-    * **_length_**: the length of the serialized value in bytes
-    * **_value_**: the serialized value
+    * `type`: the [Signature Token](#SignatureTokens) (type) of the value that follows
+    * `length`: the length of the serialized value in bytes
+    * `value`: the serialized value
 
-* **_IDENTIFIERS_** - The set of identifiers in this binary. Identifiers are
+* `IDENTIFIERS`: The set of identifiers in this binary. Identifiers are
 vectors of chars. Their format is the length of the vector in ULEB128 form
 followed by the chars. An identifier can only have characters in the ASCII set
 and specifically: must start with a letter or '\_', followed by a letter, '\_'
 or digit
 
-* **_ADDRESS\_IDENTIFIERS_** - The set of addresses used in ModuleHandles.
+* `ADDRESS_IDENTIFIERS`: The set of addresses used in ModuleHandles.
 Addresses are fixed size so they are stored contiguously in this table.
 
-* **_STRUCT\_DEFINITIONS_** - The structs or user types defined in the binary. A
+* `STRUCT_DEFINITIONS`: The structs or user types defined in the binary. A
 struct definition contains the following fields:
 
-    * **_struct\_handle_**: ULEB128 - index in the STRUCT\_HANDLES table for the
+    * `struct_handle`: ULEB128 index in the `STRUCT_HANDLES` table for the
     handle of this definition
-    * **_field\_information_**: Field Information provides information about the
+    * `field_information`: Field Information provides information about the
     fields of the struct or whether the struct is native
 
-        * **_tag_**: 1 byte - `0x1` if the struct is native, `0x2` if the struct
-        contains fields, in which case it is followed by
-        * **_field count_**: ULEB128 - number of fields for this struct
-        * **_fields_**: a field count of
-            * **_name_**: ULEB128 - index in the IDENTIFIERS table containing the
+        * `tag`: 1 byte, either `0x1` if the struct is native, or `0x2` if the struct
+        contains fields, in which case it is followed by:
+        * `field count`: ULEB128 number of fields for this struct
+        * `fields`: a field count of
+
+            * `name`: ULEB128 index in the `IDENTIFIERS` table containing the
             name of the field
-            * **_field type_**: [SignatureToken](#SignatureTokens) - the type of
+            * `field type`: [SignatureToken](#SignatureTokens) - the type of
             the field
 
-* **_STRUCT\_DEF\_INSTANTIATIONS_** - the set of instantiation for any given
+* `STRUCT_DEF_INSTANTIATIONS`: the set of instantiation for any given
 generic struct. It contains the following fields:
 
-    * **_struct handle_**: ULEB128 - index into the STRUCT\_HANDLES table of the
-    generic struct for this instantiation (e.g. `struct X<T>`)
-    * **_instantiation_**: ULEB128 - index into the SIGNATURES table for the
+    * `struct handle`: ULEB128 index into the `STRUCT_HANDLES` table of the
+    generic struct for this instantiation (e.g., `struct X<T>`)
+    * `instantiation`: ULEB128 index into the `SIGNATURES` table for the
     instantiation of the struct. The instantiation can be either partial or complete
-    (e.g. `X<U64>` or `X<Z>` when inside another generic function or generic struct
+    (e.g., `X<U64>` or `X<Z>` when inside another generic function or generic struct
     with type parameter `Z`)
 
-* **_FUNCTION\_DEFINITIONS_** - the set of functions defined in this binary. A
+* `FUNCTION_DEFINITIONS`: the set of functions defined in this binary. A
 function definition contains the following fields:
 
-    * **_function\_handle_**: ULEB128 - index in the FUNCTION\_HANDLES table for
+    * `function_handle`: ULEB128 index in the `FUNCTION_HANDLES` table for
     the handle of this definition
-    * **_flags_**: 1 byte -
+    * `visibility`: 1 byte for the function visibility (only used in version 2 and later)
+
         * `0x0` if the function is private to the Module
         * `0x1` if the function is public and thus visible outside this module
+        * `0x2` for a `script` function
+        * `0x3` if the function is private but also visible to `friend` modules
+
+    * `flags`: 1 byte:
+
+        * `0x0` if the function is private to the Module (version 1 only)
+        * `0x1` if the function is public and thus visible outside this module (version 1 only)
         * `0x2` if the function is native, not implemented in Move
 
-    * **_acquires\_global\_resources_**: resources accessed by this function
-        * **_length_**: ULEB128 - length of the vector, number of resources
+    * `acquires_global_resources`: resources accessed by this function
+
+        * `length`: ULEB128 length of the vector, number of resources
         acquired by this function
-        * **_resources_**: ULEB128 * length indices into the STRUCT\_DEFS table,
+        * `resources`: array of `length` ULEB128 indices into the `STRUCT_DEFS` table,
         for the resources acquired by this function
 
-    * **_code\_unit_**: if the function is not native, the code unit follows:
-        * **_locals_**: ULEB128 - index into the SIGNATURES table for the types
-        of the locals of the function
-        * **_code_**: vector of [Bytecodes](#Bytecodes), the body of this function
-            * **_length_**: the count of bytecodes the follows
-            * **_bytecodes_**: Bytecodes, they are variable size
+    * `code_unit`: if the function is not native, the code unit follows:
 
-* **_FIELD\_HANDLES_** - the set of fields accessed in code. A field handle is
+        * `locals`: ULEB128 index into the `SIGNATURES` table for the types
+        of the locals of the function
+        * `code`: vector of [Bytecodes](#Bytecodes), the body of this function
+
+            * `length`: the count of bytecodes the follows
+            * `bytecodes`: Bytecodes, they are variable size
+
+* `FIELD_HANDLES`: the set of fields accessed in code. A field handle is
 composed by the following fields:
 
-    * owner: ULEB128 - an index into the STRUCT\_DEFS table of the type that owns the field
-    * index: ULEB128 - the position of the field in the vector of fields of the "owner"
+    * `owner`: ULEB128 index into the `STRUCT_DEFS` table of the type that owns the field
+    * `index`: ULEB128 position of the field in the vector of fields of the `owner`
 
-* **_FIELD\_INSTANTIATIONS_** - the set of generic fields accessed in code. A
+* `FIELD_INSTANTIATIONS`: the set of generic fields accessed in code. A
 field instantiation is a pair of indices:
 
-    * field handle: ULEB128 - an index into the FIELD\_HANDLES table for the generic field
-    * instantiation: ULEB128 - index into the SIGNATURES table for the instantiation of
+    * `field_handle`: ULEB128 index into the `FIELD_HANDLES` table for the generic field
+    * `instantiation`: ULEB128 index into the `SIGNATURES` table for the instantiation of
     the type that owns the field
 
-##### Kinds
+* `FRIEND_DECLS`: the set of declared friend modules with the following for each one:
 
-A "Type Parameter Kind" is 1 byte, and it is one of:
+    * `address`: ULEB128 index into the `ADDRESS_IDENTIFIERS` table of
+    the account under which the module is published
+    * `name`: ULEB128 index into the `IDENTIFIERS` table of the name of the module
 
-* `0x1`: **ALL** - the type parameter can be substituted by either a resource, or a copyable type
-* `0x2`: **COPYABLE** - the type parameter must be substituted by a copyable type
-* `0x3`: **RESOURCE** - the type parameter must be substituted by a resource type
+### Kinds
 
-##### SignatureTokens
+A `Type Parameter Kind` is 1 byte, and it is one of:
 
-A SignatureToken is 1 byte, and it is one of:
+* `0x1`: `ALL` - the type parameter can be substituted by either a resource, or a copyable type
+* `0x2`: `COPYABLE` - the type parameter must be substituted by a copyable type
+* `0x3`: `RESOURCE` - the type parameter must be substituted by a resource type
 
-* `0x1`: **BOOL** - a boolean
-* `0x2`: **U8** - a U8 (byte)
-* `0x3`: **U64** - a 64-bit unsigned integer
-* `0x4`: **U128** - a 128-bit unsigned integer
-* `0x5`: **ADDRESS** - an `AccountAddress` in Diem, which is a 128-bit unsigned integer
-* `0x6`: **REFERENCE** - a reference; must be followed by another SignatureToken
+### SignatureTokens
+
+A `SignatureToken` is 1 byte, and it is one of:
+
+* `0x1`: `BOOL` - a boolean
+* `0x2`: `U8` - a U8 (byte)
+* `0x3`: `U64` - a 64-bit unsigned integer
+* `0x4`: `U128` - a 128-bit unsigned integer
+* `0x5`: `ADDRESS` - an `AccountAddress` in Diem, which is a 128-bit unsigned integer
+* `0x6`: `REFERENCE` - a reference; must be followed by another SignatureToken
 representing the type referenced
-* `0x7`: **MUTABLE\_REFERENCE** - a mutable reference; must be followed by another
+* `0x7`: `MUTABLE_REFERENCE` - a mutable reference; must be followed by another
 SignatureToken representing the type referenced
-* `0x8`: **STRUCT** - a structure; must be followed by the index into the
-STRUCT\_HANDLES table describing the type. That index is in ULEB128 form
-* `0x9`: **TYPE\_PARAMETER** - a type parameter of a generic struct or a generic
+* `0x8`: `STRUCT` - a structure; must be followed by the index into the
+`STRUCT_HANDLES` table describing the type. That index is in ULEB128 form
+* `0x9`: `TYPE_PARAMETER` - a type parameter of a generic struct or a generic
 function; must be followed by the index into the type parameters vector of its container.
 The index is in ULEB128 form
-* `0xA`: **VECTOR** - a vector - must be followed by another SignatureToken
+* `0xA`: `VECTOR` - a vector - must be followed by another SignatureToken
 representing the type of the vector
-* `0xB`: **STRUCT\_INST** - a struct instantiation; must be followed by an index
-into the STRUCT\_HANDLES table for the generic type of the instantiation, and a
+* `0xB`: `STRUCT_INST` - a struct instantiation; must be followed by an index
+into the `STRUCT_HANDLES` table for the generic type of the instantiation, and a
 vector describing the substitution types, that is, a vector of SignatureTokens
-* `0xC`: **SIGNER** - a signer type, which is a special type for the VM
+* `0xC`: `SIGNER` - a signer type, which is a special type for the VM
 representing the "entity" that signed the transaction. Signer is a resource type
 
 Signature tokens examples:
@@ -1388,214 +1264,156 @@ Signature tokens examples:
 * `u8, u128` -> `0x2 0x2 0x4` - size(`0x2`), U8(`0x2`), u128(`0x4`)
 * `u8, u128, A` where A is a struct -> `0x3 0x2 0x4 0x8 0x10` - size(`0x3`),
 U8(`0x2`), u128(`0x4`), Struct::A
-(`0x8 0x10` assuming the struct is in the STRUCT\_HANDLES table at position `0x10`)
+(`0x8 0x10` assuming the struct is in the `STRUCT_HANDLES` table at position `0x10`)
 * `vector<address>, &A` where A is a struct -> `0x2 0xA 0x5 0x8 0x10` - size(`0x2`),
 vector<address>(`0xA 0x5`), &Struct::A
-(`0x6 0x8 0x10` assuming the struct is in the STRUCT\_HANDLES table at position `0x10`)
+(`0x6 0x8 0x10` assuming the struct is in the `STRUCT_HANDLES` table at position `0x10`)
 * `vector<A>, &A<B>` where A and B are a struct ->
 `0x2 0xA 0x8 0x10 0x6 0xB 0x10 0x1 0x8 0x11` -
 size(`0x2`), vector\<A\>(`0xA 0x8 0x10`),
 &Struct::A\<Struct::B\> (`0x6` &, `0xB 0x10` A<\_>, `0x1 0x8 0x11` B type
-instantiation; assuming the struct are in the STRUCT\_HANDLES table at position
+instantiation; assuming the struct are in the `STRUCT_HANDLES` table at position
 `0x10` and `0x11` respectively)
 
-##### Bytecodes
+### Bytecodes
 
 Bytecodes are variable size instructions for the Move VM. Bytecodes are
 composed by opcodes (1 byte) followed by a possible payload which depends on
 the specific opcode and specified in "()" below:
 
-* `0x01`: **POP**
-* `0x02`: **RET**
-* `0x03`: **BR\_TRUE(offset)** - offset is in ULEB128 form, and it is the target
+* `0x01`: `POP`
+* `0x02`: `RET`
+* `0x03`: `BR_TRUE(offset)` - offset is in ULEB128 form, and it is the target
 offset in the code stream from the beginning of the code stream
-* `0x04`: **BR\_FALSE(offset)** - offset is in ULEB128 form, and it is the
+* `0x04`: `BR_FALSE(offset)` - offset is in ULEB128 form, and it is the
 target offset in the code stream from the beginning of the code stream
-* `0x05`: **BRANCH(offset)** - offset is in ULEB128 form, and it is the target
+* `0x05`: `BRANCH(offset)` - offset is in ULEB128 form, and it is the target
 offset in the code stream from the beginning of the code stream
-* `0x06`: **LD\_U64(value)** - value is a U64 in little-endian form
-* `0x07`: **LD\_CONST(index)** - index is in ULEB128 form, and it is an index
-in the CONSTANT\_POOL table
-* `0x08`: **LD\_TRUE**
-* `0x09`: **LD\_FALSE**
-* `0x0A`: **COPY\_LOC(index)** - index is in ULEB128 form, and it is an index
+* `0x06`: `LD_U64(value)` - value is a U64 in little-endian form
+* `0x07`: `LD_CONST(index)` - index is in ULEB128 form, and it is an index
+in the `CONSTANT_POOL` table
+* `0x08`: `LD_TRUE`
+* `0x09`: `LD_FALSE`
+* `0x0A`: `COPY_LOC(index)` - index is in ULEB128 form, and it is an index
 referring to either an argument or a local of the function. From a bytecode
 perspective arguments and locals lengths are added and the index must be in that
 range. If index is less than the length of arguments it refers to one of the
 arguments otherwise it refers to one of the locals
-* `0x0B`: **MOVE\_LOC(index)** - index is in ULEB128 form, and it is an index
+* `0x0B`: `MOVE_LOC(index)` - index is in ULEB128 form, and it is an index
 referring to either an argument or a local of the function. From a bytecode
 perspective arguments and locals lengths are added and the index must be in that
 range. If index is less than the length of arguments it refers to one of the
 arguments otherwise it refers to one of the locals
-* `0x0C`: **ST\_LOC(index)** - index is in ULEB128 form, and it is an index
+* `0x0C`: `ST_LOC(index)` - index is in ULEB128 form, and it is an index
 referring to either an argument or a local of the function. From a bytecode
 perspective arguments and locals lengths are added and the index must be in that
 range. If index is less than the length of arguments it refers to one of the
 arguments otherwise it refers to one of the locals
-* `0x0D`: **MUT\_BORROW\_LOC(index)** - index is in ULEB128 form, and it is an
+* `0x0D`: `MUT_BORROW_LOC(index)` - index is in ULEB128 form, and it is an
 index referring to either an argument or a local of the function. From a
 bytecode perspective arguments and locals lengths are added and the index must
 be in that range. If index is less than the length of arguments it refers to one
 of the arguments otherwise it refers to one of the locals
-* `0x0E`: **IMM\_BORROW\_LOC(index)** - index is in ULEB128 form, and it is an
+* `0x0E`: `IMM_BORROW_LOC(index)` - index is in ULEB128 form, and it is an
 index referring to either an argument or a local of the function. From a
 bytecode perspective arguments and locals lengths are added and the index must
 be in that range. If index is less than the length of arguments it refers to one
 of the arguments otherwise it refers to one of the locals
-* `0x0F`: **MUT\_BORROW\_FIELD(index)** - index is in ULEB128 form, and it is an
-index in the FIELD\_HANDLES table
-* `0x10`: **IMM\_BORROW\_FIELD(index)** - index is in ULEB128 form, and it is an
-index in the FIELD\_HANDLES table
-* `0x11`: **CALL(index)** - index is in ULEB128 form, and it is an index in the
-FUNCTION\_HANDLES table
-* `0x12`: **PACK(index)** - index is in ULEB128 form, and it is an index in the
-STRUCT\_DEFINITIONS table
-* `0x13`: **UNPACK(index)** - index is in ULEB128 form, and it is an index in
-the STRUCT\_DEFINITIONS table
-* `0x14`: **READ\_REF**
-* `0x15`: **WRITE\_REF**
-* `0x16`: **ADD**
-* `0x17`: **SUB**
-* `0x18`: **MUL**
-* `0x19`: **MOD**
-* `0x1A`: **DIV**
-* `0x1B`: **BIT\_OR**
-* `0x1C`: **BIT\_AND**
-* `0x1D`: **XOR**
-* `0x1E`: **OR**
-* `0x1F`: **AND**
-* `0x20`: **NOT**
-* `0x21`: **EQ**
-* `0x22`: **NEQ**
-* `0x23`: **LT**
-* `0x24`: **GT**
-* `0x25`: **LE**
-* `0x26`: **GE**
-* `0x27`: **ABORT**
-* `0x28`: **NOP**
-* `0x29`: **EXISTS(index)** - index is in ULEB128 form, and it is an index in
-the STRUCT\_DEFINITIONS table
-* `0x2A`: **MUT\_BORROW\_GLOBAL(index)** - index is in ULEB128 form, and it is
-an index in the STRUCT\_DEFINITIONS table
-* `0x2B`: **IMM\_BORROW\_GLOBAL(index)** - index is in ULEB128 form, and it is
-an index in the STRUCT\_DEFINITIONS table
-* `0x2C`: **MOVE\_FROM(index)** - index is in ULEB128 form, and it is an index
-in the STRUCT\_DEFINITIONS table
-* `0x2D`: **MOVE\_TO(index)** - index is in ULEB128 form, and it is an index
-in the STRUCT\_DEFINITIONS table
-* `0x2E`: **FREEZE\_REF**
-* `0x2F`: **SHL**
-* `0x30`: **SHR**
-* `0x31`: **LD\_U8(value)** - value is a U8
-* `0x32`: **LD\_U128(value)** - value is a U128 in little-endian form
-* `0x33`: **CAST\_U8**
-* `0x34`: **CAST\_U64**
-* `0x35`: **CAST\_U128**
-* `0x36`: **MUT\_BORROW\_FIELD\_GENERIC(index)** - index is in ULEB128 form,
-and it is an index in the FIELD\_INSTANTIATIONS table
-* `0x37`: **IMM\_BORROW\_FIELD\_GENERIC(index)** - index is in ULEB128 form,
-and it is an index in the FIELD\_INSTANTIATIONS table
-* `0x38`: **CALL\_GENERIC(index)** - index is in ULEB128 form, and it is an
-index in the FUNCTION\_INSTANTIATIONS table
-* `0x39`: **PACK\_GENERIC(index)** - index is in ULEB128 form, and it is an
-index in the STRUCT\_DEF\_INSTANTIATIONS table
-* `0x3A`: **UNPACK\_GENERIC(index)** - index is in ULEB128 form, and it is an
-index in the STRUCT\_DEF\_INSTANTIATIONS table
-* `0x3B`: **EXISTS\_GENERIC(index)** - index is in ULEB128 form, and it is an
-index in the STRUCT\_DEF\_INSTANTIATIONS table
-* `0x3C`: **MUT\_BORROW\_GLOBAL\_GENERIC(index)** - index is in ULEB128 form,
-and it is an index in the STRUCT\_DEF\_INSTANTIATIONS table
-* `0x3D`: **IMM\_BORROW\_GLOBAL\_GENERIC(index)** - index is in ULEB128 form,
-and it is an index in the STRUCT\_DEF\_INSTANTIATIONS table
-* `0x3E`: **MOVE\_FROM\_GENERIC(index)** - index is in ULEB128 form, and it
-is an index in the STRUCT\_DEF\_INSTANTIATIONS table
-* `0x3F`: **MOVE\_TO\_GENERIC(index)** - index is in ULEB128 form, and it is
-an index in the STRUCT\_DEF\_INSTANTIATIONS table
+* `0x0F`: `MUT_BORROW_FIELD(index)` - index is in ULEB128 form, and it is an
+index in the `FIELD_HANDLES` table
+* `0x10`: `IMM_BORROW_FIELD(index)` - index is in ULEB128 form, and it is an
+index in the `FIELD_HANDLES` table
+* `0x11`: `CALL(index)` - index is in ULEB128 form, and it is an index in the
+`FUNCTION_HANDLES` table
+* `0x12`: `PACK(index)` - index is in ULEB128 form, and it is an index in the
+`STRUCT_DEFINITIONS` table
+* `0x13`: `UNPACK(index)` - index is in ULEB128 form, and it is an index in
+the `STRUCT_DEFINITIONS` table
+* `0x14`: `READ_REF`
+* `0x15`: `WRITE_REF`
+* `0x16`: `ADD`
+* `0x17`: `SUB`
+* `0x18`: `MUL`
+* `0x19`: `MOD`
+* `0x1A`: `DIV`
+* `0x1B`: `BIT_OR`
+* `0x1C`: `BIT_AND`
+* `0x1D`: `XOR`
+* `0x1E`: `OR`
+* `0x1F`: `AND`
+* `0x20`: `NOT`
+* `0x21`: `EQ`
+* `0x22`: `NEQ`
+* `0x23`: `LT`
+* `0x24`: `GT`
+* `0x25`: `LE`
+* `0x26`: `GE`
+* `0x27`: `ABORT`
+* `0x28`: `NOP`
+* `0x29`: `EXISTS(index)` - index is in ULEB128 form, and it is an index in
+the `STRUCT_DEFINITIONS` table
+* `0x2A`: `MUT_BORROW_GLOBAL(index)` - index is in ULEB128 form, and it is
+an index in the `STRUCT_DEFINITIONS` table
+* `0x2B`: `IMM_BORROW_GLOBAL(index)` - index is in ULEB128 form, and it is
+an index in the `STRUCT_DEFINITIONS` table
+* `0x2C`: `MOVE_FROM(index)` - index is in ULEB128 form, and it is an index
+in the `STRUCT_DEFINITIONS` table
+* `0x2D`: `MOVE_TO(index)` - index is in ULEB128 form, and it is an index
+in the `STRUCT_DEFINITIONS` table
+* `0x2E`: `FREEZE_REF`
+* `0x2F`: `SHL`
+* `0x30`: `SHR`
+* `0x31`: `LD_U8(value)` - value is a U8
+* `0x32`: `LD_U128(value)` - value is a U128 in little-endian form
+* `0x33`: `CAST_U8`
+* `0x34`: `CAST_U64`
+* `0x35`: `CAST_U128`
+* `0x36`: `MUT_BORROW_FIELD_GENERIC(index)` - index is in ULEB128 form,
+and it is an index in the `FIELD_INSTANTIATIONS` table
+* `0x37`: `IMM_BORROW_FIELD_GENERIC(index)` - index is in ULEB128 form,
+and it is an index in the `FIELD_INSTANTIATIONS` table
+* `0x38`: `CALL_GENERIC(index)` - index is in ULEB128 form, and it is an
+index in the `FUNCTION_INSTANTIATIONS` table
+* `0x39`: `PACK_GENERIC(index)` - index is in ULEB128 form, and it is an
+index in the `STRUCT_DEF_INSTANTIATIONS` table
+* `0x3A`: `UNPACK_GENERIC(index)` - index is in ULEB128 form, and it is an
+index in the `STRUCT_DEF_INSTANTIATIONS` table
+* `0x3B`: `EXISTS_GENERIC(index)` - index is in ULEB128 form, and it is an
+index in the `STRUCT_DEF_INSTANTIATIONS` table
+* `0x3C`: `MUT_BORROW_GLOBAL_GENERIC(index)` - index is in ULEB128 form,
+and it is an index in the `STRUCT_DEF_INSTANTIATIONS` table
+* `0x3D`: `IMM_BORROW_GLOBAL_GENERIC(index)` - index is in ULEB128 form,
+and it is an index in the `STRUCT_DEF_INSTANTIATIONS` table
+* `0x3E`: `MOVE_FROM_GENERIC(index)` - index is in ULEB128 form, and it
+is an index in the `STRUCT_DEF_INSTANTIATIONS` table
+* `0x3F`: `MOVE_TO_GENERIC(index)` - index is in ULEB128 form, and it is
+an index in the `STRUCT_DEF_INSTANTIATIONS` table
 
-##### Module Specific Data
+### Module Specific Data
 
 A binary for a Module contains an index in ULEB128 form as its last
 entry. That is after all tables. That index points to the ModuleHandle table
 and it is the self module. It is where the module is stored, and a
-specification of which one of the Modules in the MODULE\_HANDLES tables is the
+specification of which one of the Modules in the `MODULE_HANDLES` tables is the
 self one.
 
-##### Script Specific Data
+### Script Specific Data
 
-A Script does not have a FUNCTION\_DEFINITIONS table, and the entry point is
-explicitly described in the following 3 entries, at the end of a Script
+A Script does not have a `FUNCTION_DEFINITIONS` table, and the entry point is
+explicitly described in the following entries, at the end of a Script
 Binary, in the order below:
 
-* **_type parameters_**: if the script entry point is generic, the number and
+* `type parameters`: if the script entry point is generic, the number and
 kind of the type parameters is in this vector.
 
-    * **_length_**: ULEB128 - length of the vector, effectively the number of
+    * `length`: ULEB128 length of the vector, effectively the number of
     type parameters for the generic entry point. 0 if the script is not generic
-    * **_kinds_**: [Kind](#Kinds) (U8) * length - contiguous kinds, not present
+    * `kinds`: array of `length` U8 [kind](#Kinds) values, not present
     if length is 0
 
-* **_parameters_**: ULEB128 - index into the SIGNATURES table for the argument
+* `parameters`: ULEB128 index into the `SIGNATURES` table for the argument
 types of the entry point
 
-* **_code_**: vector of [Bytecodes](#Bytecodes), the body of this function
-    * **_length_**: the count of bytecodes
-    * **_bytecodes_**: Bytecodes contiguously serialized, they are variable size
-
-### Tests
-
-### Threats
-
-### Monitoring and Logging
-
-### Runbook
-
-## Loading
-
-### Tests
-
-### Threats
-
-### Monitoring and Logging
-
-### Runbook
-
-## Verification
-
-### Tests
-
-### Threats
-
-### Monitoring and Logging
-
-### Runbook
-
-## Interpreter
-
-### Tests
-
-### Threats
-
-### Monitoring and Logging
-
-### Runbook
-
-## References to Data and Code
-
-### Tests
-
-### Threats
-
-### Monitoring and Logging
-
-### Runbook
-
-## Move Values
-
-### Tests
-
-### Threats
-
-### Monitoring and Logging
-
-### Runbook
+* `code`: vector of [Bytecodes](#Bytecodes), the body of this function
+    * `length`: the count of bytecodes
+    * `bytecodes`: Bytecodes contiguously serialized, they are variable size


### PR DESCRIPTION
This updates the Move Adapter specification for the addition of script
functions in the version 1.2 release.

I also made a pass over the VM sections which haven't been as well
maintained as other parts of the document:

- To simplify things and make it easier to keep updated, I removed the
internal APIs for the VM Runtime and moved the Session APIs to the
sections that describe those functions.

- Reformatted to use less bold and underline text.

- Added some updates for Version 2 of the binary file format, specifically
for function visibility and friend decls. Fixed incorrect values for Table
Kind IDs. Still missing ability sets...

## Motivation

Keeping docs up to date!

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Viewed changes in a Markdown editor to make sure they are formatted as expected