### PR TITLE
[cargo] include missing dev-dep

### DIFF
--- a/state-sync/Cargo.toml
+++ b/state-sync/Cargo.toml
@@ -64,6 +64,7 @@ storage-service = { path = "../storage/storage-service" }
 subscription-service = { path = "../common/subscription-service" }
 transaction-builder = { path = "../language/transaction-builder" }
 diem-time-service = { path = "../common/time-service", features = ["testing"] }
+vm-genesis = { path = "../language/tools/vm-genesis", features = ["fuzzing"] }
 
 [features]
 default = []


### PR DESCRIPTION
## Motivation

Let @davidiw's code land.   Also correctly define the dev-deps of state sync.   Or at least improve it's definition.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

Throw the kitchen sync at the problem and double check all our feature resolver behavior, and then realize the simple definition error.   Fix that error.   Compile.   Get a sliver of the day back.

## Related PRs

https://github.com/diem/diem/pull/8055

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
