### PR TITLE
[move-prover] Fix the problem with the pragma "aborts_if_is_partial"

### DIFF
--- a/language/move-prover/tests/sources/functional/aborts_if.move
+++ b/language/move-prover/tests/sources/functional/aborts_if.move
@@ -158,4 +158,22 @@ module TestAbortsIf {
         // When the strict mode is enabled, no aborts_if clause means aborts_if false.
         pragma aborts_if_is_strict = true;
     }
+
+    fun abort_1() {
+        abort 1
+    }
+    spec fun abort_1 {
+        pragma opaque;
+        aborts_if true with 1;
+    }
+
+    fun aborts_if_with_code(x: u64) {
+        if (x == 2 || x == 3) abort_1();
+    }
+    spec fun aborts_if_with_code {
+        // It is ok to specify only one abort condition of we set partial to true.
+        pragma aborts_if_is_partial = true;
+        aborts_if x == 2 with 1;
+        aborts_with 1;
+    }
 }


### PR DESCRIPTION
In Prover, there was a problem with "aborts_if_is_partial":
- when a callee is opaque, Prover is supposed to check whether the callee has the "aborts_if_is_partial" flag. However, Prover was checking a wrong condition (it was checking whether the "caller" has such flag).

## Motivation

To fix a bug regarding "aborts_if_is_partial"

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test
