### PR TITLE
[GHA] extend LBT time duration to avoid test failed

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -243,7 +243,7 @@ jobs:
     runs-on: self-hosted
     needs: [prepare, build-images, need-base-images]
     if: ${{ always() && needs.build-images.result=='success' }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Launch cluster test
         # NOTE Remember to update PR comment payload if cti cmd is updated.


### PR DESCRIPTION
a full LBT run with comp suite need around 25mins, sometimes if there has no cluster available to run, the waiting time also be counted in test duration which only has 30mins, extend to 45 mins to avoid test failed 
## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
