### PR TITLE
[x] render diagnostics during initial nextest build

### DIFF
--- a/devtools/x/src/cargo.rs
+++ b/devtools/x/src/cargo.rs
@@ -304,7 +304,7 @@ impl<'a> CargoCommand<'a> {
             vec![]
         } else {
             let mut cargo = self.prepare_cargo(packages);
-            cargo.args(&["--message-format", "json"]);
+            cargo.args(&["--message-format", "json-render-diagnostics"]);
             cargo.run_with_output()?
         };
 


### PR DESCRIPTION
I thought I'd have to implement this through providing some sort of
streaming interface at first, but turns out cargo has built-in support
for rendering diagnostics while producing JSON messages.

Tested by adding a couple garbage lines to `types/src/lib.rs`, then running `cargo nextest -p diem-types`. The output was:

```
   Compiling x v0.1.0 (/opt/git/diem/devtools/x)
    Finished dev [unoptimized + debuginfo] target(s) in 4.85s
     Running `target/debug/x nextest -p diem-types`
        INFO [16:27:33.741] - sccache of version 0.2.14-alpha.0 is installed
        INFO [16:27:33.743] - Stopped already running sccache.
        INFO [16:27:33.743] - export "RUSTC_WRAPPER"="sccache"
        INFO [16:27:33.743] - export "CARGO_INCREMENTAL"="false"
        INFO [16:27:33.743] - export "SCCACHE_BUCKET"="ci-artifacts.diem.com"
        INFO [16:27:33.743] - export "SCCACHE_ENDPOINT"="https://s3-us-west-2.amazonaws.com"
        INFO [16:27:33.743] - export "SCCACHE_REGION"="us-west-2"
        INFO [16:27:33.743] - export "SCCACHE_S3_KEY_PREFIX"="sccache/diem/"
        INFO [16:27:33.743] - export "SCCACHE_S3_PUBLIC"="true"
        INFO [16:27:33.743] - unset "AWS_ACCESS_KEY_ID"
        INFO [16:27:33.743] - unset "AWS_SECRET_ACCESS_KEY"
        INFO [16:27:33.743] - Executing: "cargo" "test" "--no-run" "--package" "diem-types" "--message-format" "json-render-diagnostics"
   Compiling diem-types v0.0.1 (/opt/git/diem/types)
error: expected one of `!` or `::`, found `;`
  --> types/src/lib.rs:45:4
   |
45 | aaa;
   |    ^ expected one of `!` or `::`

error: aborting due to previous error

error: could not compile `diem-types`

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error: expected one of `!` or `::`, found `;`
  --> types/src/lib.rs:45:4
   |
45 | aaa;
   |    ^ expected one of `!` or `::`

error: aborting due to previous error

error: build failed
        WARN [16:27:34.389] - Failed in 645ms: "cargo" "test" "--no-run" "--package" "diem-types" "--message-format" "json-render-diagnostics"
Error: failed to run cargo command

```
