### PR TITLE
[x] generate JUnit reports and publish them as artifacts

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -499,7 +499,7 @@ jobs:
           restore-keys: "crates-${{ runner.os }}"
       - name: run unit tests
         run: |
-          $pre_command && cargo nextest --jobs ${max_threads} --unit --changed-since "origin/$TARGET_BRANCH"
+          $pre_command && mkdir -p target/junit-reports && cargo nextest --jobs ${max_threads} --unit --failure-output=immediate-final --changed-since "origin/$TARGET_BRANCH" --junit target/junit-reports/unit-test.xml
           sccache -s
         env:
           TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
@@ -513,6 +513,12 @@ jobs:
           TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
           SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
           SCCACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
+      - name: upload unit test results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: unit-test-results
+          path: target/junit-reports/unit-test.xml
       - uses: ./.github/actions/build-teardown
 
   codegen-unit-test:
@@ -539,11 +545,17 @@ jobs:
           key: crates-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: "crates-${{ runner.os }}"
       - name: run codegen unit tests
-        run: $pre_command && cargo nextest --jobs ${max_threads} -p transaction-builder-generator --unit --changed-since "origin/$TARGET_BRANCH" --run-ignored=ignored-only
+        run: $pre_command && mkdir -p target/junit-reports && cargo nextest --jobs ${max_threads} --failure-output=immediate-final -p transaction-builder-generator --unit --changed-since "origin/$TARGET_BRANCH" --run-ignored=ignored-only --junit target/junit-reports/codegen-unit-test.xml
         env:
           TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
           SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
           SCCACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
+      - name: upload codegen test results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: codegen-unit-test-results
+          path: target/junit-reports/codegen-unit-test.xml
       - uses: ./.github/actions/build-teardown
 
   e2e-test:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cddc5f91628367664cc7c69714ff08deee8a3efc54623011c772544d7b2767"
+checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
 name = "arbitrary"
@@ -5458,6 +5458,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ac73b1112776fc109b2e61909bc46c7e1bf0d7f690ffb1676553acce16d5cda"
 
 [[package]]
+name = "quick-junit"
+version = "0.1.0"
+source = "git+https://github.com/diem/diem-devtools?branch=main#2e349d96e88b662fab9dfe45222e1486513615e1"
+dependencies = [
+ "chrono",
+ "indexmap",
+ "quick-xml",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8533f14c8382aaad0d592c812ac3b826162128b65662331e1127b45c3d18536b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6338,9 +6357,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
+checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
 dependencies = [
  "serde_derive",
 ]
@@ -6415,9 +6434,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
+checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
@@ -7163,7 +7182,7 @@ dependencies = [
 [[package]]
 name = "testrunner"
 version = "0.1.0"
-source = "git+https://github.com/diem/diem-devtools?branch=main#3cc8015b05cf591a5a96801aee394f7df92d946c"
+source = "git+https://github.com/diem/diem-devtools?branch=main#2e349d96e88b662fab9dfe45222e1486513615e1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -7173,6 +7192,7 @@ dependencies = [
  "duct",
  "num_cpus",
  "once_cell",
+ "quick-junit",
  "rayon",
  "serde",
  "serde_json",

--- a/common/workspace-hack/Cargo.toml
+++ b/common/workspace-hack/Cargo.toml
@@ -43,7 +43,7 @@ regex = { version = "1.4.3", features = ["aho-corasick", "default", "memchr", "p
 regex-syntax = { version = "0.6.23", features = ["default", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 reqwest = { version = "0.11.2", features = ["__tls", "blocking", "default", "default-tls", "hyper-tls", "json", "native-tls", "native-tls-crate", "serde_json", "stream", "tokio-native-tls"] }
 rusty-fork = { version = "0.3.0", features = ["default", "timeout", "wait-timeout"] }
-serde = { version = "1.0.124", features = ["alloc", "default", "derive", "rc", "serde_derive", "std"] }
+serde = { version = "1.0.125", features = ["alloc", "default", "derive", "rc", "serde_derive", "std"] }
 serde_json = { version = "1.0.64", features = ["default", "indexmap", "preserve_order", "std"] }
 standback = { version = "0.2.15", default-features = false, features = ["std"] }
 subtle = { version = "2.4.0", default-features = false, features = ["std"] }
@@ -90,7 +90,7 @@ regex = { version = "1.4.3", features = ["aho-corasick", "default", "memchr", "p
 regex-syntax = { version = "0.6.23", features = ["default", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 reqwest = { version = "0.11.2", features = ["__tls", "blocking", "default", "default-tls", "hyper-tls", "json", "native-tls", "native-tls-crate", "serde_json", "stream", "tokio-native-tls"] }
 rusty-fork = { version = "0.3.0", features = ["default", "timeout", "wait-timeout"] }
-serde = { version = "1.0.124", features = ["alloc", "default", "derive", "rc", "serde_derive", "std"] }
+serde = { version = "1.0.125", features = ["alloc", "default", "derive", "rc", "serde_derive", "std"] }
 serde_json = { version = "1.0.64", features = ["default", "indexmap", "preserve_order", "std"] }
 standback = { version = "0.2.15", default-features = false, features = ["std"] }
 subtle = { version = "2.4.0", default-features = false, features = ["std"] }
@@ -136,7 +136,7 @@ regex = { version = "1.4.3", features = ["aho-corasick", "default", "memchr", "p
 regex-syntax = { version = "0.6.23", features = ["default", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 reqwest = { version = "0.11.2", features = ["__tls", "blocking", "default", "default-tls", "hyper-tls", "json", "native-tls", "native-tls-crate", "serde_json", "stream", "tokio-native-tls"] }
 rusty-fork = { version = "0.3.0", features = ["default", "timeout", "wait-timeout"] }
-serde = { version = "1.0.124", features = ["alloc", "default", "derive", "rc", "serde_derive", "std"] }
+serde = { version = "1.0.125", features = ["alloc", "default", "derive", "rc", "serde_derive", "std"] }
 serde_json = { version = "1.0.64", features = ["default", "indexmap", "preserve_order", "std"] }
 standback = { version = "0.2.15", default-features = false, features = ["std"] }
 subtle = { version = "2.4.0", default-features = false, features = ["std"] }
@@ -183,7 +183,7 @@ regex = { version = "1.4.3", features = ["aho-corasick", "default", "memchr", "p
 regex-syntax = { version = "0.6.23", features = ["default", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 reqwest = { version = "0.11.2", features = ["__tls", "blocking", "default", "default-tls", "hyper-tls", "json", "native-tls", "native-tls-crate", "serde_json", "stream", "tokio-native-tls"] }
 rusty-fork = { version = "0.3.0", features = ["default", "timeout", "wait-timeout"] }
-serde = { version = "1.0.124", features = ["alloc", "default", "derive", "rc", "serde_derive", "std"] }
+serde = { version = "1.0.125", features = ["alloc", "default", "derive", "rc", "serde_derive", "std"] }
 serde_json = { version = "1.0.64", features = ["default", "indexmap", "preserve_order", "std"] }
 standback = { version = "0.2.15", default-features = false, features = ["std"] }
 subtle = { version = "2.4.0", default-features = false, features = ["std"] }

--- a/devtools/x/src/nextest.rs
+++ b/devtools/x/src/nextest.rs
@@ -131,7 +131,7 @@ pub fn run(args: Args, xctx: XContext) -> Result<()> {
         Coloring::Always => Color::Always,
         Coloring::Never => Color::Never,
     };
-    let reporter = TestReporter::new(&test_list, color, args.reporter_opts);
+    let mut reporter = TestReporter::new(&test_list, color, args.reporter_opts);
 
     let run_stats = runner.try_execute(|event| reporter.report_event(event))?;
     if !run_stats.is_success() {


### PR DESCRIPTION
Adds a couple new features: JUnit reporting, and printing out failing test results at the end.

Once this lands, every `ci-test` run will have two new artifacts associated with it: `codegen-unit-test-results` and `unit-test-results`. These artifacts will contain JUnit XML files with the status of each test. They are not presented in a user-visible format yet -- solving that will require some work to handle GitHub's security model. See [this section](https://github.com/marketplace/actions/publish-unit-test-results#support-fork-repositories-and-dependabot-branches) for an example of some of the work that will need to be done.

![image](https://user-images.githubusercontent.com/180618/113449058-e2e3b380-93b1-11eb-8fe9-6b5b6b9330a9.png)
