### PR TITLE
[language][prover] remove diem-types as a dependency from stackless bytecode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -606,7 +606,6 @@ dependencies = [
  "codespan-reporting",
  "datatest-stable",
  "diem-temppath",
- "diem-types",
  "diem-workspace-hack",
  "ir-to-bytecode",
  "itertools 0.10.0",

--- a/language/move-prover/bytecode/Cargo.toml
+++ b/language/move-prover/bytecode/Cargo.toml
@@ -18,7 +18,6 @@ ir-to-bytecode = { path = "../../compiler/ir-to-bytecode" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 num = "0.4.0"
 itertools = "0.10.0"
-diem-types = { path = "../../../types" }
 move-core-types = { path = "../../move-core/types" }
 log = "0.4.14"
 serde = { version = "1.0.124", features = ["derive"] }

--- a/x.toml
+++ b/x.toml
@@ -247,7 +247,6 @@ existing_deps = [
     ["boogie-backend", "datatest-stable"],
     ["boogie-backend-v2", "diem-temppath"],
     ["boogie-backend-v2", "datatest-stable"],
-    ["bytecode", "diem-types"],
     ["bytecode", "diem-temppath"],
     ["bytecode", "datatest-stable"],
     ["bytecode-verifier-tests", "diem-framework-releases"],


### PR DESCRIPTION
This makes the stackless bytecode crate no longer depend on diem-types.