### PR TITLE
[language] remove diem-types as a dependency from module-generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4219,7 +4219,6 @@ name = "module-generation"
 version = "0.1.0"
 dependencies = [
  "bytecode-verifier",
- "diem-types",
  "diem-workspace-hack",
  "ir-to-bytecode",
  "move-core-types",

--- a/language/testing-infra/module-generation/Cargo.toml
+++ b/language/testing-infra/module-generation/Cargo.toml
@@ -16,7 +16,6 @@ bytecode-verifier = { path = "../../bytecode-verifier" }
 ir-to-bytecode = { path = "../../compiler/ir-to-bytecode" }
 move-core-types = { path = "../../move-core/types" }
 move-ir-types = { path = "../../move-ir/types" }
-diem-types = { path = "../../../types" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 vm = { path = "../../vm" }
 

--- a/language/testing-infra/module-generation/src/generator.rs
+++ b/language/testing-infra/module-generation/src/generator.rs
@@ -3,8 +3,8 @@
 
 use crate::{options::ModuleGeneratorOptions, padding::Pad, utils::random_string};
 use bytecode_verifier::verify_module;
-use diem_types::account_address::AccountAddress;
 use ir_to_bytecode::compiler::compile_module;
+use move_core_types::account_address::AccountAddress;
 use move_ir_types::{ast::*, location::*};
 use rand::{rngs::StdRng, Rng};
 use std::{

--- a/language/testing-infra/module-generation/src/padding.rs
+++ b/language/testing-infra/module-generation/src/padding.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{options::ModuleGeneratorOptions, utils::random_string};
-use diem_types::account_address::AccountAddress;
-use move_core_types::identifier::Identifier;
+use move_core_types::{account_address::AccountAddress, identifier::Identifier};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use vm::file_format::{Bytecode, CompiledModuleMut, Signature};
 

--- a/x.toml
+++ b/x.toml
@@ -259,7 +259,6 @@ existing_deps = [
     ["move-vm-runtime", "diem-infallible"],
     ["move-vm-runtime", "diem-crypto"],
     ["move-vm-types", "diem-crypto"],
-    ["module-generation", "diem-types"],
     ["test-generation", "language-e2e-tests"],
     ["test-generation", "diem-vm"],
     ["test-generation", "diem-types"],


### PR DESCRIPTION
This removes diem-types as a dependency from module-generation.