### PR TITLE
[language] remove unused diem-types dependency from disassembler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2676,7 +2676,6 @@ dependencies = [
  "bytecode-source-map",
  "bytecode-verifier",
  "colored",
- "diem-types",
  "diem-workspace-hack",
  "move-core-types",
  "move-coverage",

--- a/language/tools/disassembler/Cargo.toml
+++ b/language/tools/disassembler/Cargo.toml
@@ -12,7 +12,6 @@ colored = "2.0.0"
 
 bytecode-verifier = { path = "../../bytecode-verifier" }
 bytecode-source-map = { path = "../../compiler/bytecode-source-map" }
-diem-types = { path = "../../../types" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
 move-ir-types = { path = "../../move-ir/types" }

--- a/x.toml
+++ b/x.toml
@@ -265,7 +265,6 @@ existing_deps = [
     ["test-generation", "diem-state-view"],
     ["test-generation", "diem-logger"],
     ["test-generation", "diem-config"],
-    ["disassembler", "diem-types"],
     ["move-cli", "vm-genesis"],
     ["move-cli", "diem-vm"],
     ["move-cli", "diem-types"],


### PR DESCRIPTION
This removes the (unused) diem-types dependency from crate disassembler.