### PR TITLE
[language] remove diem-types dependency from move-coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4305,7 +4305,6 @@ dependencies = [
  "bytecode-verifier",
  "codespan",
  "colored",
- "diem-types",
  "diem-workspace-hack",
  "move-core-types",
  "move-ir-types",

--- a/language/tools/move-coverage/Cargo.toml
+++ b/language/tools/move-coverage/Cargo.toml
@@ -19,7 +19,6 @@ codespan = { version = "0.8.0", features = ["serialization"] }
 colored = "2.0.0"
 
 bcs = "0.1.2"
-diem-types = { path = "../../../types" }
 move-core-types = { path = "../../move-core/types" }
 move-ir-types = { path = "../../move-ir/types" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
@@ -29,4 +28,3 @@ bytecode-verifier = { path = "../../bytecode-verifier" }
 
 [features]
 default = []
-fuzzing = ["diem-types/fuzzing"]

--- a/language/tools/move-coverage/src/coverage_map.rs
+++ b/language/tools/move-coverage/src/coverage_map.rs
@@ -4,8 +4,10 @@
 #![forbid(unsafe_code)]
 
 use anyhow::{format_err, Result};
-use diem_types::account_address::AccountAddress;
-use move_core_types::identifier::{IdentStr, Identifier};
+use move_core_types::{
+    account_address::AccountAddress,
+    identifier::{IdentStr, Identifier},
+};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::BTreeMap,

--- a/x.toml
+++ b/x.toml
@@ -273,7 +273,6 @@ existing_deps = [
     ["move-cli", "diem-framework"],
     ["move-cli", "diem-framework-releases"],
     ["move-cli", "datatest-stable"],
-    ["move-coverage", "diem-types"],
     ["resource-viewer", "diem-framework-releases"],
     ["resource-viewer", "diem-types"],
     ["resource-viewer", "diem-state-view"],


### PR DESCRIPTION
This removes the diem-types dependency from move-coverage.