### PR TITLE
[move-lang] use destruction pattern consistently for ModuleDefinition

### DIFF
--- a/language/move-lang/src/naming/translate.rs
+++ b/language/move-lang/src/naming/translate.rs
@@ -357,27 +357,34 @@ fn module(
     mdef: E::ModuleDefinition,
 ) -> N::ModuleDefinition {
     context.current_module = Some(ident);
-    let is_source_module = mdef.is_source_module;
-    let friends = mdef
-        .friends
-        .filter_map(|mident, f| friend(context, mident, f));
+    let E::ModuleDefinition {
+        loc: _loc,
+        is_source_module,
+        dependency_order,
+        friends: efriends,
+        structs: estructs,
+        functions: efunctions,
+        constants: econstants,
+        specs: _specs,
+    } = mdef;
+    let friends = efriends.filter_map(|mident, f| friend(context, mident, f));
     let unscoped = context.save_unscoped();
-    let structs = mdef.structs.map(|name, s| {
+    let structs = estructs.map(|name, s| {
         context.restore_unscoped(unscoped.clone());
         struct_def(context, name, s)
     });
-    let functions = mdef.functions.map(|name, f| {
+    let functions = efunctions.map(|name, f| {
         context.restore_unscoped(unscoped.clone());
         function(context, name, f)
     });
-    let constants = mdef.constants.map(|name, c| {
+    let constants = econstants.map(|name, c| {
         context.restore_unscoped(unscoped.clone());
         constant(context, name, c)
     });
     context.restore_unscoped(unscoped);
     N::ModuleDefinition {
         is_source_module,
-        dependency_order: mdef.dependency_order,
+        dependency_order,
         friends,
         structs,
         functions,

--- a/language/move-lang/src/typing/translate.rs
+++ b/language/move-lang/src/typing/translate.rs
@@ -62,14 +62,14 @@ fn module(
         dependency_order,
         friends,
         mut structs,
-        functions: n_functions,
+        functions: nfunctions,
         constants: nconstants,
     } = mdef;
     structs
         .iter_mut()
         .for_each(|(_, _, s)| struct_def(context, s));
     let constants = nconstants.map(|name, c| constant(context, name, c));
-    let functions = n_functions.map(|name, f| function(context, name, f, false));
+    let functions = nfunctions.map(|name, f| function(context, name, f, false));
     assert!(context.constraints.is_empty());
     T::ModuleDefinition {
         is_source_module,


### PR DESCRIPTION
## Motivation

Coding style consistency, as `ModuleDefinition` is destructed in all other source compiler passes.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI