### PR TITLE
[cluster-test] Fix invalid dashboard link

### DIFF
--- a/testsuite/cluster-test/src/prometheus.rs
+++ b/testsuite/cluster-test/src/prometheus.rs
@@ -41,7 +41,7 @@ impl Prometheus {
 
     pub fn link_to_dashboard(&self, start: Duration, end: Duration) -> String {
         format!(
-            "{}d/overview10/overview?orgId=1&from={}&to={}",
+            "{}d/performance/performance?orgId=1&from={}&to={}",
             self.grafana_base_url,
             start.as_millis(),
             end.as_millis()


### PR DESCRIPTION
Link doesn't point anywhere, so I'm pointing it to somewhere that exists