### PR TITLE
[smt] batch update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6350,10 +6350,14 @@ dependencies = [
  "arc-swap",
  "diem-crypto",
  "diem-infallible",
+ "diem-temppath",
  "diem-types",
  "diem-workspace-hack",
+ "diemdb",
  "itertools 0.10.0",
  "proptest",
+ "rand 0.8.3",
+ "storage-interface",
 ]
 
 [[package]]

--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -204,6 +204,14 @@ impl HashValue {
         hash
     }
 
+    /// Returns the `index`-th bit in the bytes.
+    pub fn bit(&self, index: usize) -> bool {
+        assume!(index < Self::LENGTH_IN_BITS); // assumed precondition
+        let pos = index / 8;
+        let bit = 7 - index % 8;
+        (self.hash[pos] >> bit) & 1 != 0
+    }
+
     /// Returns a `HashValueBitIterator` over all the bits that represent this `HashValue`.
     pub fn iter_bits(&self) -> HashValueBitIterator<'_> {
         HashValueBitIterator::new(self)

--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -292,7 +292,7 @@ where
 
         let (txn_state_roots, current_state_tree) = parent_trees
             .state_tree()
-            .batch_update(
+            .serial_update(
                 txn_blobs
                     .iter()
                     .map(|m| {

--- a/json-rpc/src/tests/genesis.rs
+++ b/json-rpc/src/tests/genesis.rs
@@ -29,7 +29,7 @@ pub fn generate_genesis_state() -> (
         tree.update(
             blobs
                 .iter()
-                .map(|(addr, value)| (addr.hash(), value.clone()))
+                .map(|(addr, value)| (addr.hash(), value))
                 .collect(),
             &proof_reader,
         )

--- a/storage/scratchpad/Cargo.toml
+++ b/storage/scratchpad/Cargo.toml
@@ -19,8 +19,12 @@ diem-types = { path = "../../types" }
 diem-workspace-hack = { path = "../../common/workspace-hack" }
 
 [dev-dependencies]
+rand = "0.8.3"
 proptest = "1.0.0"
 
+diemdb = { path = "../diemdb", features = ["fuzzing"]}
+diem-temppath = { path = "../../common/temppath" }
+storage-interface = { path = "../storage-interface" }
+
 [features]
-default = []
-fuzzing = ["diem-types/fuzzing"]
+fuzzing = ["diemdb/fuzzing", "diem-types/fuzzing"]

--- a/storage/scratchpad/src/sparse_merkle/sparse_merkle_test.rs
+++ b/storage/scratchpad/src/sparse_merkle/sparse_merkle_test.rs
@@ -1,16 +1,28 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{AccountStatus, ProofRead};
+use super::*;
 use diem_crypto::{
     hash::{CryptoHash, TestOnlyHash, SPARSE_MERKLE_PLACEHOLDER_HASH},
     HashValue,
 };
+use diem_temppath::TempPath;
 use diem_types::{
+    account_address::HashAccountAddress,
     account_state_blob::AccountStateBlob,
     proof::{SparseMerkleLeafNode, SparseMerkleProof},
 };
+use diemdb::{test_helper::arb_blocks_to_commit, DiemDB};
+use proptest::prelude::*;
+use rand::{rngs::StdRng, SeedableRng};
 use std::collections::HashMap;
+use storage_interface::{DbReader, DbWriter};
+
+fn update_byte(original_key: &HashValue, n: usize, byte: u8) -> HashValue {
+    let mut key = original_key.to_vec();
+    key[n] = byte;
+    HashValue::from_slice(&key).unwrap()
+}
 
 fn hash_internal(left_child: HashValue, right_child: HashValue) -> HashValue {
     diem_types::proof::SparseMerkleInternalNode::new(left_child, right_child).hash()
@@ -99,7 +111,7 @@ fn test_construct_subtree_with_new_leaf_override_existing_leaf() {
     let subtree = SparseMerkleTree::construct_subtree_with_new_leaf(
         key,
         new_blob.clone(),
-        existing_leaf,
+        existing_leaf.clone(),
         key,
         /* distance_from_root_to_existing_leaf = */ 3,
     );
@@ -107,6 +119,16 @@ fn test_construct_subtree_with_new_leaf_override_existing_leaf() {
     let new_blob_hash = new_blob.hash();
     let root_hash = hash_leaf(key, new_blob_hash);
     assert_eq!(subtree.hash(), root_hash);
+
+    // batch version api
+    let subtree_batch = SparseMerkleTree::batch_construct_subtree_with_existing_leaf(
+        vec![(key, &new_blob)].as_slice(),
+        existing_leaf,
+        key,
+        /* depth = */ 3,
+    );
+
+    assert_eq!(subtree_batch.hash(), root_hash);
 }
 
 #[test]
@@ -132,21 +154,30 @@ fn test_construct_subtree_with_new_leaf_create_extension() {
 
     let existing_leaf = SubTree::new_leaf_with_value_hash(existing_key, existing_blob.hash());
 
-    let subtree = SparseMerkleTree::construct_subtree_with_new_leaf(
-        new_key,
-        new_blob.clone(),
-        existing_leaf,
-        existing_key,
-        /* distance_from_root_to_existing_leaf = */ 2,
-    );
-
     let new_blob_hash = new_blob.hash();
     let existing_leaf_hash = hash_leaf(existing_key, existing_blob_hash);
     let new_leaf_hash = hash_leaf(new_key, new_blob_hash);
     let x_hash = hash_internal(existing_leaf_hash, new_leaf_hash);
     let y_hash = hash_internal(x_hash, *SPARSE_MERKLE_PLACEHOLDER_HASH);
     let root_hash = hash_internal(y_hash, *SPARSE_MERKLE_PLACEHOLDER_HASH);
+
+    let subtree = SparseMerkleTree::construct_subtree_with_new_leaf(
+        new_key,
+        new_blob.clone(),
+        existing_leaf.clone(),
+        existing_key,
+        /* distance_from_root_to_existing_leaf = */ 2,
+    );
     assert_eq!(subtree.hash(), root_hash);
+
+    // batch version api
+    let subtree_batch = SparseMerkleTree::batch_construct_subtree_with_existing_leaf(
+        vec![(new_key, &new_blob)].as_slice(),
+        existing_leaf,
+        existing_key,
+        /* depth = */ 2,
+    );
+    assert_eq!(subtree_batch.hash(), root_hash);
 }
 
 #[test]
@@ -204,30 +235,30 @@ fn test_construct_subtree_at_bottom_found_leaf_node() {
     let proof = SparseMerkleProof::new(leaf, siblings);
     let proof_reader = ProofReader::new(vec![(new_key, proof)]);
 
-    let subtree = SparseMerkleTree::construct_subtree_at_bottom(
-        &current,
-        new_key,
-        new_blob.clone(),
-        remaining_bits,
-        &proof_reader,
-    )
-    .unwrap();
-
     let existing_leaf_hash = hash_leaf(existing_key, existing_blob_hash);
     let new_blob_hash = new_blob.hash();
     let new_leaf_hash = hash_leaf(new_key, new_blob_hash);
     let x_hash = hash_internal(existing_leaf_hash, new_leaf_hash);
     let y_hash = hash_internal(x_hash, *SPARSE_MERKLE_PLACEHOLDER_HASH);
     let root_hash = hash_internal(y_hash, *SPARSE_MERKLE_PLACEHOLDER_HASH);
+
+    let subtree = SparseMerkleTree::construct_subtree_at_bottom(
+        &current,
+        new_key,
+        new_blob,
+        remaining_bits,
+        &proof_reader,
+    )
+    .unwrap();
     assert_eq!(subtree.hash(), root_hash);
 }
 
 #[test]
 fn test_construct_subtree_at_bottom_found_empty_node() {
-    //        root                  root
-    //       /    \                /    \
-    //      o      o              o      o
-    //     / \                   / \
+    //        root                      root
+    //       /    \                    /    \
+    //      o      o                  o      o
+    //     / \                       / \
     //    o   placeholder    =>     o   new_key
     let new_key = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".test_only_hash();
     let new_blob = AccountStateBlob::from(b"new_blob!!!!!".to_vec());
@@ -243,17 +274,17 @@ fn test_construct_subtree_at_bottom_found_empty_node() {
     };
     let proof_reader = ProofReader::default();
 
+    let new_blob_hash = new_blob.hash();
+    let new_leaf_hash = hash_leaf(new_key, new_blob_hash);
+
     let subtree = SparseMerkleTree::construct_subtree_at_bottom(
         &current,
         new_key,
-        new_blob.clone(),
+        new_blob,
         remaining_bits,
         &proof_reader,
     )
     .unwrap();
-
-    let new_blob_hash = new_blob.hash();
-    let new_leaf_hash = hash_leaf(new_key, new_blob_hash);
     assert_eq!(subtree.hash(), new_leaf_hash);
 }
 
@@ -288,19 +319,19 @@ fn test_construct_subtree_at_bottom_found_subtree_node() {
     let proof = SparseMerkleProof::new(leaf, siblings);
     let proof_reader = ProofReader::new(vec![(new_key, proof)]);
 
-    let subtree = SparseMerkleTree::construct_subtree_at_bottom(
-        &current,
-        new_key,
-        new_blob.clone(),
-        remaining_bits,
-        &proof_reader,
-    )
-    .unwrap();
-
     let new_blob_hash = new_blob.hash();
     let new_leaf_hash = hash_leaf(new_key, new_blob_hash);
     let x_hash = hash_internal(HashValue::new([6; HashValue::LENGTH]), new_leaf_hash);
     let new_subtree_hash = hash_internal(x_hash, HashValue::new([5; HashValue::LENGTH]));
+
+    let subtree = SparseMerkleTree::construct_subtree_at_bottom(
+        &current,
+        new_key,
+        new_blob,
+        remaining_bits,
+        &proof_reader,
+    )
+    .unwrap();
     assert_eq!(subtree.hash(), new_subtree_hash);
 }
 
@@ -352,9 +383,7 @@ fn test_update_256_siblings_in_proof() {
     let new_blob1 = AccountStateBlob::from(b"value1111111111111".to_vec());
     let proof_reader = ProofReader::new(vec![(key1, proof_of_key1)]);
     let smt = SparseMerkleTree::new(old_root_hash);
-    let new_smt = smt
-        .update(vec![(key1, new_blob1.clone())], &proof_reader)
-        .unwrap();
+    let new_smt = smt.update(vec![(key1, &new_blob1)], &proof_reader).unwrap();
 
     let new_blob1_hash = new_blob1.hash();
     let new_leaf1_hash = hash_leaf(key1, new_blob1_hash);
@@ -427,7 +456,7 @@ fn test_update() {
     let proof_reader = ProofReader::new(vec![(key4, proof)]);
     let old_smt = SparseMerkleTree::new(old_root_hash);
     let smt1 = old_smt
-        .update(vec![(key4, value4.clone())], &proof_reader)
+        .update(vec![(key4, &value4)], &proof_reader)
         .unwrap();
 
     // Now smt1 should look like this:
@@ -464,9 +493,7 @@ fn test_update() {
 
     let value1 = AccountStateBlob::from(b"value11111".to_vec());
     let proof_reader = ProofReader::new(vec![(key1, proof)]);
-    let smt2 = smt1
-        .update(vec![(key1, value1.clone())], &proof_reader)
-        .unwrap();
+    let smt2 = smt1.update(vec![(key1, &value1)], &proof_reader).unwrap();
 
     // Now the tree looks like:
     //              root
@@ -496,9 +523,7 @@ fn test_update() {
     let value4 = AccountStateBlob::from(b"new value 4444444444".to_vec());
     // key4 already exists in the tree.
     let proof_reader = ProofReader::default();
-    let smt22 = smt1
-        .update(vec![(key4, value4.clone())], &proof_reader)
-        .unwrap();
+    let smt22 = smt1.update(vec![(key4, &value4)], &proof_reader).unwrap();
 
     // smt22 is like:
     // Now smt1 should look like this:
@@ -540,7 +565,7 @@ fn test_drop() {
     for _ in 0..100000 {
         smt = smt
             .update(
-                vec![(HashValue::zero(), AccountStateBlob::from(b"zero".to_vec()))],
+                vec![(HashValue::zero(), &AccountStateBlob::from(b"zero".to_vec()))],
                 &proof_reader,
             )
             .unwrap()
@@ -548,4 +573,219 @@ fn test_drop() {
 
     // smt with a lot of ancestors being dropped here. It's a stack overflow if a manual iterative
     // `Drop` implementation is not in place.
+}
+
+#[test]
+fn test_batch_update_construct_subtree_from_proofs() {
+    // Before the update, the tree was:
+    //             root
+    //            /    \
+    //           y      key3
+    //          / \
+    //         x   placeholder
+    //        / \
+    //    key1   key2
+    let key1 = HashValue::new([0x00u8; HashValue::LENGTH]);
+    let value1 = AccountStateBlob::from(b"value1".to_vec());
+
+    let key2 = update_byte(&key1, 0, 0b0010_0100);
+    let value2 = AccountStateBlob::from(b"value2".to_vec());
+
+    let key3 = update_byte(&key1, 0, 0b1110_0111);
+    let value3 = AccountStateBlob::from(b"value3".to_vec());
+    let new_value3 = AccountStateBlob::from(b"new_value3".to_vec());
+
+    let value1_hash = value1.hash();
+    let value2_hash = value2.hash();
+    let value3_hash = value3.hash();
+
+    // A new key at the "placeholder" position.
+    let key4 = update_byte(&key1, 0, 0b0100_1100);
+    let value4 = AccountStateBlob::from(b"value4".to_vec());
+
+    // A new key that shares path with key1.
+    let key5 = update_byte(&key1, 0, 0b0001_0000);
+    let value5 = AccountStateBlob::from(b"value5".to_vec());
+
+    // Two new keys that shares path with key2.
+    let key6 = update_byte(&key1, 0, 0b0010_0000);
+    let value6 = AccountStateBlob::from(b"value6".to_vec());
+    let key7 = update_byte(&key1, 0, 0b0011_0000);
+    let value7 = AccountStateBlob::from(b"value7".to_vec());
+
+    // Create a proof for this new key.
+    let leaf1 = SparseMerkleLeafNode::new(key1, value1_hash);
+    let leaf2 = SparseMerkleLeafNode::new(key2, value2_hash);
+    let leaf3 = SparseMerkleLeafNode::new(key3, value3_hash);
+    let leaf1_hash = leaf1.hash();
+    let leaf2_hash = leaf2.hash();
+    let leaf3_hash = leaf3.hash();
+    let x_hash = hash_internal(leaf1_hash, leaf2_hash);
+    let y_hash = hash_internal(x_hash, *SPARSE_MERKLE_PLACEHOLDER_HASH);
+    let old_root_hash = hash_internal(y_hash, leaf3_hash);
+
+    let proof3 = SparseMerkleProof::new(Some(leaf3), vec![y_hash]);
+    assert!(proof3.verify(old_root_hash, key3, Some(&value3)).is_ok());
+    let proof4 = SparseMerkleProof::new(None, vec![x_hash, leaf3_hash]);
+    assert!(proof4.verify(old_root_hash, key4, None).is_ok());
+    let proof5 = SparseMerkleProof::new(
+        Some(leaf1),
+        vec![leaf2_hash, *SPARSE_MERKLE_PLACEHOLDER_HASH, leaf3_hash],
+    );
+    assert!(proof5.verify(old_root_hash, key5, None).is_ok());
+
+    let proof67 = SparseMerkleProof::new(
+        Some(leaf2),
+        vec![leaf1_hash, *SPARSE_MERKLE_PLACEHOLDER_HASH, leaf3_hash],
+    );
+    assert!(proof67.verify(old_root_hash, key6, None).is_ok());
+    assert!(proof67.verify(old_root_hash, key7, None).is_ok());
+
+    // Create the old tree and update the tree with new value and proof.
+    let proof_reader = ProofReader::new(vec![
+        (key3, proof3),
+        (key4, proof4),
+        (key5, proof5),
+        (key6, proof67.clone()),
+        (key7, proof67),
+    ]);
+
+    let smt_serial = SparseMerkleTree::new(*SPARSE_MERKLE_PLACEHOLDER_HASH)
+        .serial_update(
+            vec![vec![
+                (key3, &new_value3),
+                (key4, &value4),
+                (key5, &value5),
+                (key6, &value6),
+                (key7, &value7),
+            ]],
+            &proof_reader,
+        )
+        .unwrap()
+        .1;
+
+    let smt_batch = SparseMerkleTree::new(*SPARSE_MERKLE_PLACEHOLDER_HASH)
+        .batch_update(
+            vec![
+                (key3, &new_value3),
+                (key4, &value4),
+                (key5, &value5),
+                (key6, &value6),
+                (key7, &value7),
+            ],
+            &proof_reader,
+        )
+        .unwrap();
+
+    assert_eq!(smt_serial.root_hash(), smt_batch.root_hash());
+}
+
+#[test]
+fn test_update_consistency() {
+    let seed: &[_] = &[1, 2, 3, 4];
+    let mut actual_seed = [0u8; 32];
+    actual_seed[..seed.len()].copy_from_slice(&seed);
+    let mut rng: StdRng = StdRng::from_seed(actual_seed);
+
+    let mut kvs = vec![];
+    let smt = SparseMerkleTree::new(*SPARSE_MERKLE_PLACEHOLDER_HASH);
+    let proof_reader = ProofReader::default();
+    let mut smt_serial;
+    let mut smt_batch;
+    for i in 1..=5 {
+        for _ in 0..1000 {
+            let key = HashValue::random_with_rng(&mut rng);
+            let value = AccountStateBlob::from(HashValue::random_with_rng(&mut rng).to_vec());
+            kvs.push((key, value));
+        }
+        let batch = kvs.iter().map(|(k, v)| (*k, v)).collect::<Vec<_>>();
+        let start = std::time::Instant::now();
+        smt_serial = smt
+            .serial_update(vec![batch.clone()], &proof_reader)
+            .unwrap()
+            .1;
+        println!("serial {}-th run: {}ms", i, start.elapsed().as_millis());
+
+        let start = std::time::Instant::now();
+        smt_batch = smt.batch_update(batch.clone(), &proof_reader).unwrap();
+        println!("batch {}-th run: {}ms", i, start.elapsed().as_millis());
+        kvs.clear();
+        assert_eq!(smt_serial.root_hash(), smt_batch.root_hash());
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+    #[test]
+    fn test_read_partial_tree_from_storage(input in arb_blocks_to_commit().no_shrink()) {
+        let tmp_dir = TempPath::new();
+        let db = DiemDB::new_for_test(&tmp_dir);
+        // Insert a transaction to ensure a non-empty ledger;
+
+        let tree_state = db.get_latest_tree_state().unwrap();
+        let initial_state_root = tree_state.account_state_root_hash;
+        let mut cur_ver = -1i64;
+
+        prop_assert_eq!(initial_state_root, *SPARSE_MERKLE_PLACEHOLDER_HASH);
+        let mut serial_updated_tree = SparseMerkleTree::new(initial_state_root);
+        let mut batch_updated_tree = SparseMerkleTree::new(initial_state_root);
+
+        for (txns_to_commit, ledger_info_with_sigs) in input.iter() {
+            let updates = txns_to_commit.iter()
+                .map(|txn_to_commit| txn_to_commit
+                     .account_states()
+                     .iter()
+                     .map(|(a, b)|(a.hash(), b))
+                     .collect::<Vec<_>>())
+                .collect::<Vec<_>>();
+            let account_state_proofs = txns_to_commit.iter()
+                .map(|txn_to_commit| txn_to_commit
+                     .account_states()
+                     .iter()
+                     .collect::<Vec<_>>())
+                .flatten()
+                .map(|(k, _)| {
+                    if cur_ver == -1 {
+                        SparseMerkleProof::<AccountStateBlob>::new(None, vec![])
+                    } else {
+                        db.get_account_state_with_proof(*k, cur_ver as u64, cur_ver as u64)
+                            .map(|p| p.proof.transaction_info_to_account_proof().clone())
+                            .unwrap()
+                    }
+                });
+
+            let proof_reader = ProofReader::new(
+                itertools::zip_eq(
+                    updates.iter().flatten().map(|(k, _)| *k),
+                    account_state_proofs,
+                ).collect::<Vec<_>>(),
+            );
+
+            db.save_transactions(
+                &txns_to_commit,
+                (cur_ver + 1) as u64, /* first_version */
+                Some(ledger_info_with_sigs),
+            )
+                .unwrap();
+
+            let tree_state = db.get_latest_tree_state().unwrap();
+            let root_in_db = tree_state.account_state_root_hash;
+            cur_ver = tree_state.num_transactions as i64 - 1;
+
+            batch_updated_tree = batch_updated_tree.batch_update(updates
+                                                                 .iter()
+                                                                 .flatten()
+                                                                 .map(|(k, v)| (*k, *v))
+                                                                 .collect::<Vec<_>>(),
+                                                                 &proof_reader)
+                .unwrap();
+            serial_updated_tree = serial_updated_tree
+                .serial_update(updates, &proof_reader)
+                .unwrap().1;
+            prop_assert_eq!(batch_updated_tree.root_hash(), serial_updated_tree.root_hash());
+            prop_assert_eq!(batch_updated_tree.root_hash(), root_in_db);
+            batch_updated_tree.prune();
+            serial_updated_tree.prune();
+        }
+    }
 }


### PR DESCRIPTION
## Motivation

This PR implements the batch update api for in-memory sparse merkle tree in a recursive way.

serial 1-th run: 143ms
batch 1-th run: 37ms
serial 2-th run: 143ms
batch 2-th run: 37ms
serial 3-th run: 147ms
batch 3-th run: 37ms
serial 4-th run: 140ms
batch 4-th run: 39ms
serial 5-th run: 142ms
batch 5-th run: 37ms

~4x speedup

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Test added
