### PR TITLE
[scratchpad] iterative drop

### DIFF
--- a/storage/scratchpad/src/sparse_merkle/sparse_merkle_test.rs
+++ b/storage/scratchpad/src/sparse_merkle/sparse_merkle_test.rs
@@ -532,3 +532,20 @@ fn test_update() {
     assert_eq!(smt22.get(key3), AccountStatus::Unknown);
     assert_eq!(smt22.get(key4), AccountStatus::ExistsInScratchPad(value4));
 }
+
+#[test]
+fn test_drop() {
+    let mut smt = SparseMerkleTree::new(*SPARSE_MERKLE_PLACEHOLDER_HASH);
+    let proof_reader = ProofReader::default();
+    for _ in 0..100000 {
+        smt = smt
+            .update(
+                vec![(HashValue::zero(), AccountStateBlob::from(b"zero".to_vec()))],
+                &proof_reader,
+            )
+            .unwrap()
+    }
+
+    // smt with a lot of ancestors being dropped here. It's a stack overflow if a manual iterative
+    // `Drop` implementation is not in place.
+}


### PR DESCRIPTION

## Motivation
The SMTs are chained to its bases between prunes, which might trigger a stack overflow due to default recursive drop implementation, if the block is large (more than a few thousands of transactions.)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
Y
## Test Plan
unit test added.
## Related PRs
introduced in #7857

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)
