### PR TITLE
[Cluster Test] Add a performance test suite for state syncing fullnodes.

### DIFF
--- a/testsuite/cluster-test/src/experiments/mod.rs
+++ b/testsuite/cluster-test/src/experiments/mod.rs
@@ -13,6 +13,7 @@ mod reboot_cluster;
 mod reboot_random_validators;
 mod reconfiguration_test;
 mod recovery_time;
+mod state_sync_performance;
 mod twin_validator;
 mod versioning_test;
 
@@ -35,6 +36,7 @@ pub use reboot_cluster::{RebootCluster, RebootClusterParams};
 pub use reboot_random_validators::{RebootRandomValidators, RebootRandomValidatorsParams};
 pub use reconfiguration_test::{Reconfiguration, ReconfigurationParams};
 pub use recovery_time::{RecoveryTime, RecoveryTimeParams};
+pub use state_sync_performance::{StateSyncPerformance, StateSyncPerformanceParams};
 pub use twin_validator::{TwinValidators, TwinValidatorsParams};
 pub use versioning_test::{ValidatorVersioning, ValidatorVersioningParams};
 
@@ -156,6 +158,7 @@ pub fn get_experiment(name: &str, args: &[String], cluster: &Cluster) -> Box<dyn
     known_experiments.insert("reboot_cluster", f::<RebootClusterParams>());
     known_experiments.insert("reconfiguration", f::<ReconfigurationParams>());
     known_experiments.insert("load_test", f::<LoadTestParams>());
+    known_experiments.insert("state_sync_performance", f::<StateSyncPerformanceParams>());
 
     let builder = known_experiments.get(name).expect("Experiment not found");
     builder(args, cluster)

--- a/testsuite/cluster-test/src/experiments/state_sync_performance.rs
+++ b/testsuite/cluster-test/src/experiments/state_sync_performance.rs
@@ -1,0 +1,169 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use std::{collections::HashSet, fmt, time::Duration};
+
+use structopt::StructOpt;
+use tokio::time;
+
+use crate::{
+    cluster::Cluster,
+    experiments::{Context, Experiment, ExperimentParam},
+    instance::Instance,
+    tx_emitter::EmitJobRequest,
+};
+use async_trait::async_trait;
+use diem_logger::info;
+use std::time::Instant;
+
+const EXPERIMENT_DURATION_TIMEOUT_SECS: u64 = 600;
+const STATE_SYNC_COMMITTED_COUNTER_NAME: &str = "diem_state_sync_version.synced";
+
+#[derive(StructOpt, Debug)]
+pub struct StateSyncPerformanceParams {
+    emit_transactions_duration_secs: u64,
+}
+
+impl StateSyncPerformanceParams {
+    pub fn new(emit_transactions_duration_secs: u64) -> Self {
+        Self {
+            emit_transactions_duration_secs,
+        }
+    }
+}
+
+pub struct StateSyncPerformance {
+    params: StateSyncPerformanceParams,
+    fullnode_instance: Instance,
+    validator_instance: Instance,
+}
+
+impl ExperimentParam for StateSyncPerformanceParams {
+    type E = StateSyncPerformance;
+
+    fn build(self, cluster: &Cluster) -> Self::E {
+        let validator_instance = cluster.random_validator_instance();
+        let fullnode_instance = cluster.random_fullnode_instance();
+        Self::E {
+            params: self,
+            fullnode_instance,
+            validator_instance,
+        }
+    }
+}
+
+#[async_trait]
+impl Experiment for StateSyncPerformance {
+    fn affected_validators(&self) -> HashSet<String> {
+        let mut result = HashSet::new();
+        result.insert(self.validator_instance.peer_name().clone());
+        result
+    }
+
+    async fn run(&mut self, context: &mut Context<'_>) -> anyhow::Result<()> {
+        // Stop the fullnode and clear all data so that it falls behind
+        info!("Stopping the fullnode: {}", self.fullnode_instance);
+        self.fullnode_instance.stop().await?;
+        self.fullnode_instance.clean_data().await?;
+
+        // Execute and commit transactions on the validators for the specified duration
+        let emit_transactions_duration_secs = self.params.emit_transactions_duration_secs;
+        info!(
+            "Executing transactions for {} seconds",
+            emit_transactions_duration_secs
+        );
+        let emit_job_request = EmitJobRequest::for_instances(
+            context.cluster.validator_instances().to_vec(),
+            context.global_emit_job_request,
+            0,
+            0,
+        );
+        let _ = context
+            .tx_emitter
+            .emit_txn_for(
+                Duration::from_secs(emit_transactions_duration_secs),
+                emit_job_request,
+            )
+            .await?;
+
+        // Read the validator synced version
+        let validator_synced_version = self.read_validator_synced_version();
+        info!(
+            "The validator is now synced at version: {}",
+            validator_synced_version
+        );
+
+        // Restart the fullnode so that it starts state syncing to catch up
+        info!(
+            "Waiting for the fullnode to wake up: {}",
+            self.fullnode_instance
+        );
+        self.fullnode_instance.start().await?;
+        self.fullnode_instance
+            .wait_json_rpc(Instant::now() + Duration::from_secs(120))
+            .await?;
+
+        // Wait for the fullnode to catch up to the expected version
+        info!(
+            "The fullnode is now up. Waiting for it to state sync to the expected version: {}",
+            validator_synced_version
+        );
+        let start_instant = Instant::now();
+        while self.read_fullnode_synced_version() < validator_synced_version {
+            time::sleep(Duration::from_secs(1)).await;
+        }
+        info!(
+            "The fullnode has caught up to version: {}",
+            validator_synced_version
+        );
+
+        // Calculate the state sync throughput
+        let time_to_state_sync = start_instant.elapsed();
+        let state_sync_throughput =
+            (validator_synced_version * 1000.0) / time_to_state_sync.as_millis() as f64;
+        let state_sync_throughput_message = format!(
+            "State sync throughput : {:?} txn/sec",
+            state_sync_throughput,
+        );
+        info!("Time to state sync {:?}", time_to_state_sync);
+
+        // Display the state sync throughput and report the results
+        info!("{}", state_sync_throughput_message);
+        context.report.report_text(state_sync_throughput_message);
+        context
+            .report
+            .report_metric(self, "state_sync_throughput", state_sync_throughput as f64);
+
+        Ok(())
+    }
+
+    fn deadline(&self) -> Duration {
+        Duration::from_secs(EXPERIMENT_DURATION_TIMEOUT_SECS)
+    }
+}
+
+impl StateSyncPerformance {
+    fn read_fullnode_synced_version(&self) -> f64 {
+        Self::read_synced_counter(&self.fullnode_instance)
+    }
+
+    fn read_validator_synced_version(&self) -> f64 {
+        Self::read_synced_counter(&self.validator_instance)
+    }
+
+    // Reads the state sync "synced counter" for the given instance. If no
+    // counter is found, returns zero.
+    fn read_synced_counter(instance: &Instance) -> f64 {
+        instance
+            .counter(STATE_SYNC_COMMITTED_COUNTER_NAME)
+            .unwrap_or(0.0)
+    }
+}
+
+impl fmt::Display for StateSyncPerformance {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "StateSyncPerformance")
+    }
+}

--- a/testsuite/cluster-test/src/suite.rs
+++ b/testsuite/cluster-test/src/suite.rs
@@ -10,7 +10,7 @@ use crate::{
         CompatiblityTestParams, CpuFlamegraphParams, Experiment, ExperimentParam,
         PerformanceBenchmarkParams, PerformanceBenchmarkThreeRegionSimulationParams,
         RebootRandomValidatorsParams, ReconfigurationParams, RecoveryTimeParams,
-        TwinValidatorsParams, ValidatorVersioningParams,
+        StateSyncPerformanceParams, TwinValidatorsParams, ValidatorVersioningParams,
     },
 };
 use anyhow::{format_err, Result};
@@ -160,6 +160,12 @@ impl ExperimentSuite {
         Self { experiments }
     }
 
+    fn new_state_sync_suite(cluster: &Cluster) -> Self {
+        let mut experiments: Vec<Box<dyn Experiment>> = vec![];
+        experiments.push(Box::new(StateSyncPerformanceParams::new(60).build(cluster)));
+        Self { experiments }
+    }
+
     pub fn new_by_name(cluster: &Cluster, name: &str) -> Result<Self> {
         match name {
             "perf" => Ok(Self::new_perf_suite(cluster)),
@@ -169,6 +175,7 @@ impl ExperimentSuite {
             "land_blocking_compat" => Self::new_land_blocking_compat_suite(cluster),
             "versioning" => Self::new_versioning_suite(cluster),
             "invalid" => Ok(Self::new_invalid_tx_suite(cluster)),
+            "state_sync" => Ok(Self::new_state_sync_suite(cluster)),
             other => Err(format_err!("Unknown suite: {}", other)),
         }
     }


### PR DESCRIPTION
## Motivation

This PR adds a new state sync performance benchmark to cluster test (to measure the performance of state syncing fullnodes). For now, the benchmark is somewhat primitive (i.e., it simply measures how long a fullnode takes to synchronize state from version 0 to the expected version of the validators around it). Current results are showing around 1.7k tx/s in cluster test (see the benchmark output below).

Once this benchmark lands, I'll follow up by enabling the benchmark to run on all future PRs and display the results. This will allow us to keep a closer eye on state sync performance going forward.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

I've run this benchmark several times manually using `./scripts/cti ... --suite state_sync`. The output is as follows:

```
...
2021-04-07T21:16:51.355804Z [main] INFO testsuite/cluster-test/src/experiments/state_sync_performance.rs:93 The validator is now synced at version: 58806
2021-04-07T21:16:51.355817Z [main] INFO testsuite/cluster-test/src/experiments/state_sync_performance.rs:99 Waiting for the fullnode to wake up: fn-14-0(192.168.239.79)
2021-04-07T21:17:07.278455Z [main] INFO testsuite/cluster-test/src/experiments/state_sync_performance.rs:109 The fullnode is now up. Waiting for it to state sync to the expected version: 58806
2021-04-07T21:17:40.561229Z [main] INFO testsuite/cluster-test/src/experiments/state_sync_performance.rs:117 The fullnode has caught up to version: 58806
2021-04-07T21:17:40.561243Z [main] INFO testsuite/cluster-test/src/experiments/state_sync_performance.rs:130 Time to state sync 33.282774558s
2021-04-07T21:17:40.561245Z [main] INFO testsuite/cluster-test/src/experiments/state_sync_performance.rs:133 State sync throughput : 1766.9010275824771 txn/sec
2021-04-07T21:17:40.561266Z [main] INFO testsuite/cluster-test/src/main.rs:686 ^[[1mExperiment finished, waiting until all affected validators recover^[[m
2021-04-07T21:17:40.561268Z [main] INFO testsuite/cluster-test/src/main.rs:749 Waiting for all nodes to be healthy
2021-04-07T21:17:45.592993Z [main] INFO testsuite/cluster-test/src/main.rs:770 All nodes are now healthy. Checking json rpc endpoints of validators and full nodes
2021-04-07T21:17:45.956058Z [main] INFO testsuite/cluster-test/src/main.rs:795 All json rpc endpoints are healthy
2021-04-07T21:17:45.956072Z [main] INFO testsuite/cluster-test/src/main.rs:694 Experiment completed
2021-04-07T21:17:45.956239Z [main] INFO testsuite/cluster-test/src/main.rs:611 Suite completed in 153.545571596s
2021-04-07T21:17:45.956265Z [main] INFO testsuite/cluster-test/src/main.rs:622 
====json-report-begin===
{
  "metrics": [
    {
      "experiment": "StateSyncPerformance",
      "metric": "state_sync_throughput",
      "value": 1766.9010275824771
    }
  ],
  "text": "Test runner setup time spent 249 secs\nState sync throughput : 1766.9010275824771 txn/sec, time spent 153 secs"
}
```


## Related PRs

None.

## If targeting a release branch, please fill the below out as well

None.
