### PR TITLE
[network] Remove rate-limit key from metrics

### DIFF
--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -477,9 +477,9 @@ pub static PENDING_PEER_NETWORK_NOTIFICATIONS: Lazy<IntGauge> = Lazy::new(|| {
 
 pub static NETWORK_RATE_LIMIT_METRICS: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
-        "diem_network_rate_limit_test",
+        "diem_network_rate_limit",
         "Network Rate Limiting Metrics",
-        &["direction", "key", "metric"]
+        &["direction", "metric"]
     )
     .unwrap()
 });


### PR DESCRIPTION
At one point the rate limiter gave per key metrics, but that became too
expensive, so it aggregates on direction.

I must have missed removing key in the first place when I removed it from the emitter https://github.com/diem/diem/blob/main/common/rate-limiter/src/rate_limit.rs#L274-L281