### PR TITLE
[network] Remove diem_network_peers metric

### DIFF
--- a/common/metrics/src/public_metrics.rs
+++ b/common/metrics/src/public_metrics.rs
@@ -2,4 +2,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // A list of metrics which will be made public to all the partners
-pub const PUBLIC_METRICS: &[&str] = &["diem_network_peers", "revision"];
+pub const PUBLIC_METRICS: &[&str] = &["diem_connections", "revision"];

--- a/json-rpc/src/data.rs
+++ b/json-rpc/src/data.rs
@@ -23,7 +23,6 @@ use diem_types::{
     event::EventKey,
     ledger_info::LedgerInfoWithSignatures,
 };
-use network::counters;
 use std::{
     cmp::min,
     convert::{TryFrom, TryInto},
@@ -368,11 +367,9 @@ pub fn get_currencies(
 }
 
 /// Returns the number of peers this node is connected to
-pub fn get_network_status(role: &str) -> Result<u64, JsonRpcError> {
-    let peers = counters::DIEM_NETWORK_PEERS
-        .get_metric_with_label_values(&[role, "connected"])
-        .map_err(|e| JsonRpcError::internal_error(e.to_string()))?;
-    Ok(peers.get() as u64)
+pub fn get_network_status(_role: &str) -> Result<u64, JsonRpcError> {
+    // TODO: The underlying metric is deprecated, and we need a different way of communicating this number that doesn't need the peer Id
+    Ok(0)
 }
 
 /// Returns proof of new state relative to version known to client

--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -24,15 +24,6 @@ pub const SENT_LABEL: &str = "sent";
 pub const SUCCEEDED_LABEL: &str = "succeeded";
 pub const FAILED_LABEL: &str = "failed";
 
-pub static DIEM_NETWORK_PEERS: Lazy<IntGaugeVec> = Lazy::new(|| {
-    register_int_gauge_vec!(
-        "diem_network_peers",
-        "Number of peers, and their associated state",
-        &["role_type", "state"]
-    )
-    .unwrap()
-});
-
 pub static DIEM_CONNECTIONS: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         "diem_connections",

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -380,11 +380,6 @@ where
             .count();
         let outbound = total.saturating_sub(inbound);
 
-        // TODO: Work with PEs to update this to be a `NetworkId` rather than `RoleType`
-        counters::DIEM_NETWORK_PEERS
-            .with_label_values(&[self.network_context.role().as_str(), "connected"])
-            .set(total as i64);
-
         counters::connections(&self.network_context, ConnectionOrigin::Inbound).set(inbound as i64);
         counters::connections(&self.network_context, ConnectionOrigin::Outbound)
             .set(outbound as i64);


### PR DESCRIPTION
This metric is not consistent now, and it's been replaced with `diem_connections`.  Additionally, the `get_network_status` is not used, but we'll figure out how to deprecate it in the future.