### PR TITLE
[cherry-pick][network] Fix rate limit metrics

### DIFF
--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -477,9 +477,9 @@ pub static PENDING_PEER_NETWORK_NOTIFICATIONS: Lazy<IntGauge> = Lazy::new(|| {
 
 pub static NETWORK_RATE_LIMIT_METRICS: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
-        "diem_network_rate_limit_test",
+        "diem_network_rate_limit",
         "Network Rate Limiting Metrics",
-        &["direction", "key", "metric"]
+        &["direction", "metric"]
     )
     .unwrap()
 });


### PR DESCRIPTION
At one point the rate limiter gave per key metrics, but that became too
expensive, so it aggregates on direction.

## Motivation

Prevents metrics mismatch if rate limiter is turned on

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Testnet

## Related PRs

Original PR: https://github.com/diem/diem/pull/8142

## If targeting a release branch, please fill the below out as well

### Justification
* Rate limiting doesn't work without this change because it crashes due to a cardinality mismatch on the metrics
* Only affects nodes using rate limiting


### Why have the change?
* Without it, when rate limiting is turned on it crashes.

### Workarounds / alternatives
* Don't use rate limiting
