### PR TITLE
[cluster-test] let CT has ability to support new feature of script fu…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,6 +877,7 @@ dependencies = [
  "diem-node",
  "diem-operational-tool",
  "diem-retrier",
+ "diem-sdk",
  "diem-secure-storage",
  "diem-swarm",
  "diem-time-service",

--- a/testsuite/cluster-test/Cargo.toml
+++ b/testsuite/cluster-test/Cargo.toml
@@ -60,6 +60,7 @@ network = { path = "../../network" }
 network-builder = { path = "../../network/builder" }
 seed-peer-generator = { path = "../../config/seed-peer-generator" }
 state-sync = { path = "../../state-sync" }
+diem-sdk = { path = "../../sdk" }
 diem-transaction-builder = { path = "../../sdk/transaction-builder" }
 
 futures = "0.3.12"

--- a/testsuite/cluster-test/src/experiments/reconfiguration_test.rs
+++ b/testsuite/cluster-test/src/experiments/reconfiguration_test.rs
@@ -20,6 +20,7 @@ use diem_transaction_builder::stdlib::{
 };
 use diem_types::{
     account_address::AccountAddress, chain_id::ChainId, ledger_info::LedgerInfoWithSignatures,
+    transaction::TransactionPayload,
 };
 use std::{
     collections::HashSet,
@@ -134,11 +135,11 @@ impl Experiment for Reconfiguration {
         let timer = Instant::now();
         for i in 0..self.count / 2 {
             let remove_txn = gen_submit_transaction_request(
-                encode_remove_validator_and_reconfigure_script(
+                TransactionPayload::Script(encode_remove_validator_and_reconfigure_script(
                     allowed_nonce,
                     validator_name.clone(),
                     self.affected_peer_id,
-                ),
+                )),
                 &mut diem_root_account,
                 ChainId::test(),
                 0,
@@ -151,11 +152,11 @@ impl Experiment for Reconfiguration {
             .await?;
             version = expect_epoch(&full_node_client, version, (i + 1) * 2).await?;
             let add_txn = gen_submit_transaction_request(
-                encode_add_validator_and_reconfigure_script(
+                TransactionPayload::Script(encode_add_validator_and_reconfigure_script(
                     allowed_nonce,
                     validator_name.clone(),
                     self.affected_peer_id,
-                ),
+                )),
                 &mut diem_root_account,
                 ChainId::test(),
                 0,
@@ -173,7 +174,10 @@ impl Experiment for Reconfiguration {
             let magic_number = 42;
             info!("Bump DiemVersion to {}", magic_number);
             let update_txn = gen_submit_transaction_request(
-                encode_update_diem_version_script(allowed_nonce, magic_number),
+                TransactionPayload::Script(encode_update_diem_version_script(
+                    allowed_nonce,
+                    magic_number,
+                )),
                 &mut diem_root_account,
                 ChainId::test(),
                 0,


### PR DESCRIPTION
…nction tx type

Changed cluster test runner has ability to emit the new ScriptFun transaction instead of the legacy Script transaction to better test the behavior of the network with the newer feature
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

SCRIPT_FN=true cargo run -p cluster-test -- --mint-file "/private/var/folders/qd/tg50mr0d7k75qvztr_8yk2km0000gn/T/266ed040e1915cf9e136274d8ed459ee/mint.key" --swarm --peers "127.0.0.1:8080" --emit-tx --chain-id TESTING

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
