### PR TITLE
[move-model] replace TypeConstraint with AbilityConstraint

### DIFF
--- a/language/diem-framework/releases/artifacts/current/docs/modules/AccountAdministrationScripts.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/AccountAdministrationScripts.md
@@ -133,7 +133,7 @@ already have a <code><a href="DiemAccount.md#0x1_DiemAccount_Balance">DiemAccoun
 * <code><a href="PaymentScripts.md#0x1_PaymentScripts_peer_to_peer_with_metadata">PaymentScripts::peer_to_peer_with_metadata</a></code>
 
 
-<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="AccountAdministrationScripts.md#0x1_AccountAdministrationScripts_add_currency_to_account">add_currency_to_account</a>&lt;Currency&gt;(account: signer)
+<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="AccountAdministrationScripts.md#0x1_AccountAdministrationScripts_add_currency_to_account">add_currency_to_account</a>&lt;Currency: store&gt;(account: signer)
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/AccountCreationScripts.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/AccountCreationScripts.md
@@ -136,7 +136,7 @@ This is emitted on the new Child VASPS's <code><a href="DiemAccount.md#0x1_DiemA
 * <code><a href="AccountAdministrationScripts.md#0x1_AccountAdministrationScripts_create_recovery_address">AccountAdministrationScripts::create_recovery_address</a></code>
 
 
-<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="AccountCreationScripts.md#0x1_AccountCreationScripts_create_child_vasp_account">create_child_vasp_account</a>&lt;CoinType&gt;(parent_vasp: signer, child_address: address, auth_key_prefix: vector&lt;u8&gt;, add_all_currencies: bool, child_initial_balance: u64)
+<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="AccountCreationScripts.md#0x1_AccountCreationScripts_create_child_vasp_account">create_child_vasp_account</a>&lt;CoinType: store&gt;(parent_vasp: signer, child_address: address, auth_key_prefix: vector&lt;u8&gt;, add_all_currencies: bool, child_initial_balance: u64)
 </code></pre>
 
 
@@ -606,7 +606,7 @@ and the <code>rold_id</code> field being <code><a href="Roles.md#0x1_Roles_PAREN
 * <code><a href="AccountAdministrationScripts.md#0x1_AccountAdministrationScripts_rotate_dual_attestation_info">AccountAdministrationScripts::rotate_dual_attestation_info</a></code>
 
 
-<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="AccountCreationScripts.md#0x1_AccountCreationScripts_create_parent_vasp_account">create_parent_vasp_account</a>&lt;CoinType&gt;(tc_account: signer, sliding_nonce: u64, new_account_address: address, auth_key_prefix: vector&lt;u8&gt;, human_name: vector&lt;u8&gt;, add_all_currencies: bool)
+<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="AccountCreationScripts.md#0x1_AccountCreationScripts_create_parent_vasp_account">create_parent_vasp_account</a>&lt;CoinType: store&gt;(tc_account: signer, sliding_nonce: u64, new_account_address: address, auth_key_prefix: vector&lt;u8&gt;, human_name: vector&lt;u8&gt;, add_all_currencies: bool)
 </code></pre>
 
 
@@ -748,7 +748,7 @@ and the <code>rold_id</code> field being <code><a href="Roles.md#0x1_Roles_DESIG
 * <code><a href="AccountAdministrationScripts.md#0x1_AccountAdministrationScripts_rotate_dual_attestation_info">AccountAdministrationScripts::rotate_dual_attestation_info</a></code>
 
 
-<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="AccountCreationScripts.md#0x1_AccountCreationScripts_create_designated_dealer">create_designated_dealer</a>&lt;Currency&gt;(tc_account: signer, sliding_nonce: u64, addr: address, auth_key_prefix: vector&lt;u8&gt;, human_name: vector&lt;u8&gt;, add_all_currencies: bool)
+<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="AccountCreationScripts.md#0x1_AccountCreationScripts_create_designated_dealer">create_designated_dealer</a>&lt;Currency: store&gt;(tc_account: signer, sliding_nonce: u64, addr: address, auth_key_prefix: vector&lt;u8&gt;, human_name: vector&lt;u8&gt;, add_all_currencies: bool)
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/AccountLimits.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/AccountLimits.md
@@ -280,7 +280,7 @@ account at <code>addr</code> is amenable with their account limits.
 Returns false if this deposit violates the account limits.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="AccountLimits.md#0x1_AccountLimits_update_deposit_limits">update_deposit_limits</a>&lt;CoinType&gt;(amount: u64, addr: address, _cap: &<a href="AccountLimits.md#0x1_AccountLimits_AccountLimitMutationCapability">AccountLimits::AccountLimitMutationCapability</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="AccountLimits.md#0x1_AccountLimits_update_deposit_limits">update_deposit_limits</a>&lt;CoinType: store&gt;(amount: u64, addr: address, _cap: &<a href="AccountLimits.md#0x1_AccountLimits_AccountLimitMutationCapability">AccountLimits::AccountLimitMutationCapability</a>): bool
 </code></pre>
 
 
@@ -367,7 +367,7 @@ the account at <code>addr</code> would violate the account limits for that accou
 Returns <code><b>false</b></code> if this withdrawal violates account limits.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="AccountLimits.md#0x1_AccountLimits_update_withdrawal_limits">update_withdrawal_limits</a>&lt;CoinType&gt;(amount: u64, addr: address, _cap: &<a href="AccountLimits.md#0x1_AccountLimits_AccountLimitMutationCapability">AccountLimits::AccountLimitMutationCapability</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="AccountLimits.md#0x1_AccountLimits_update_withdrawal_limits">update_withdrawal_limits</a>&lt;CoinType: store&gt;(amount: u64, addr: address, _cap: &<a href="AccountLimits.md#0x1_AccountLimits_AccountLimitMutationCapability">AccountLimits::AccountLimitMutationCapability</a>): bool
 </code></pre>
 
 
@@ -443,7 +443,7 @@ Root accounts for multi-account entities will hold this resource at
 their root/parent account.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="AccountLimits.md#0x1_AccountLimits_publish_window">publish_window</a>&lt;CoinType&gt;(dr_account: &signer, to_limit: &signer, limit_address: address)
+<pre><code><b>public</b> <b>fun</b> <a href="AccountLimits.md#0x1_AccountLimits_publish_window">publish_window</a>&lt;CoinType: store&gt;(dr_account: &signer, to_limit: &signer, limit_address: address)
 </code></pre>
 
 
@@ -530,7 +530,7 @@ window to it. Additionally, the TC controls the values held within this
 resource once it's published.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="AccountLimits.md#0x1_AccountLimits_publish_unrestricted_limits">publish_unrestricted_limits</a>&lt;CoinType&gt;(publish_account: &signer)
+<pre><code><b>public</b> <b>fun</b> <a href="AccountLimits.md#0x1_AccountLimits_publish_unrestricted_limits">publish_unrestricted_limits</a>&lt;CoinType: store&gt;(publish_account: &signer)
 </code></pre>
 
 
@@ -613,7 +613,7 @@ If any of the field arguments is <code>0</code> the corresponding field is not u
 TODO: This should be specified.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="AccountLimits.md#0x1_AccountLimits_update_limits_definition">update_limits_definition</a>&lt;CoinType&gt;(tc_account: &signer, limit_address: address, new_max_inflow: u64, new_max_outflow: u64, new_max_holding_balance: u64, new_time_period: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="AccountLimits.md#0x1_AccountLimits_update_limits_definition">update_limits_definition</a>&lt;CoinType: store&gt;(tc_account: &signer, limit_address: address, new_max_inflow: u64, new_max_outflow: u64, new_max_holding_balance: u64, new_time_period: u64)
 </code></pre>
 
 
@@ -663,7 +663,7 @@ but the <code>limit_address</code> should remain the same, the current
 TODO(wrwg): specify
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="AccountLimits.md#0x1_AccountLimits_update_window_info">update_window_info</a>&lt;CoinType&gt;(tc_account: &signer, window_address: address, aggregate_balance: u64, new_limit_address: address)
+<pre><code><b>public</b> <b>fun</b> <a href="AccountLimits.md#0x1_AccountLimits_update_window_info">update_window_info</a>&lt;CoinType: store&gt;(tc_account: &signer, window_address: address, aggregate_balance: u64, new_limit_address: address)
 </code></pre>
 
 
@@ -699,7 +699,7 @@ If the time window starting at <code>window.window_start</code> and lasting for
 the inflow and outflow records.
 
 
-<pre><code><b>fun</b> <a href="AccountLimits.md#0x1_AccountLimits_reset_window">reset_window</a>&lt;CoinType&gt;(window: &<b>mut</b> <a href="AccountLimits.md#0x1_AccountLimits_Window">AccountLimits::Window</a>&lt;CoinType&gt;, limits_definition: &<a href="AccountLimits.md#0x1_AccountLimits_LimitsDefinition">AccountLimits::LimitsDefinition</a>&lt;CoinType&gt;)
+<pre><code><b>fun</b> <a href="AccountLimits.md#0x1_AccountLimits_reset_window">reset_window</a>&lt;CoinType: store&gt;(window: &<b>mut</b> <a href="AccountLimits.md#0x1_AccountLimits_Window">AccountLimits::Window</a>&lt;CoinType&gt;, limits_definition: &<a href="AccountLimits.md#0x1_AccountLimits_LimitsDefinition">AccountLimits::LimitsDefinition</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -806,7 +806,7 @@ If the receipt of <code>amount</code> doesn't violate the limits <code>amount</c
 <code>CoinType</code> is recorded as received in the given <code>receiving</code> window.
 
 
-<pre><code><b>fun</b> <a href="AccountLimits.md#0x1_AccountLimits_can_receive_and_update_window">can_receive_and_update_window</a>&lt;CoinType&gt;(amount: u64, receiving: &<b>mut</b> <a href="AccountLimits.md#0x1_AccountLimits_Window">AccountLimits::Window</a>&lt;CoinType&gt;): bool
+<pre><code><b>fun</b> <a href="AccountLimits.md#0x1_AccountLimits_can_receive_and_update_window">can_receive_and_update_window</a>&lt;CoinType: store&gt;(amount: u64, receiving: &<b>mut</b> <a href="AccountLimits.md#0x1_AccountLimits_Window">AccountLimits::Window</a>&lt;CoinType&gt;): bool
 </code></pre>
 
 
@@ -986,7 +986,7 @@ If the withdrawal of <code>amount</code> doesn't violate the limits <code>amount
 <code>CoinType</code> is recorded as withdrawn in the given <code>sending</code> window.
 
 
-<pre><code><b>fun</b> <a href="AccountLimits.md#0x1_AccountLimits_can_withdraw_and_update_window">can_withdraw_and_update_window</a>&lt;CoinType&gt;(amount: u64, sending: &<b>mut</b> <a href="AccountLimits.md#0x1_AccountLimits_Window">AccountLimits::Window</a>&lt;CoinType&gt;): bool
+<pre><code><b>fun</b> <a href="AccountLimits.md#0x1_AccountLimits_can_withdraw_and_update_window">can_withdraw_and_update_window</a>&lt;CoinType: store&gt;(amount: u64, sending: &<b>mut</b> <a href="AccountLimits.md#0x1_AccountLimits_Window">AccountLimits::Window</a>&lt;CoinType&gt;): bool
 </code></pre>
 
 
@@ -1121,7 +1121,7 @@ Update outflow.
 Determine whether the <code><a href="AccountLimits.md#0x1_AccountLimits_LimitsDefinition">LimitsDefinition</a></code> resource has no restrictions.
 
 
-<pre><code><b>fun</b> <a href="AccountLimits.md#0x1_AccountLimits_is_unrestricted">is_unrestricted</a>&lt;CoinType&gt;(limits_def: &<a href="AccountLimits.md#0x1_AccountLimits_LimitsDefinition">AccountLimits::LimitsDefinition</a>&lt;CoinType&gt;): bool
+<pre><code><b>fun</b> <a href="AccountLimits.md#0x1_AccountLimits_is_unrestricted">is_unrestricted</a>&lt;CoinType: store&gt;(limits_def: &<a href="AccountLimits.md#0x1_AccountLimits_LimitsDefinition">AccountLimits::LimitsDefinition</a>&lt;CoinType&gt;): bool
 </code></pre>
 
 
@@ -1178,7 +1178,7 @@ Checks whether the limits definition is unrestricted.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="AccountLimits.md#0x1_AccountLimits_limits_definition_address">limits_definition_address</a>&lt;CoinType&gt;(addr: address): address
+<pre><code><b>public</b> <b>fun</b> <a href="AccountLimits.md#0x1_AccountLimits_limits_definition_address">limits_definition_address</a>&lt;CoinType: store&gt;(addr: address): address
 </code></pre>
 
 
@@ -1202,7 +1202,7 @@ Checks whether the limits definition is unrestricted.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="AccountLimits.md#0x1_AccountLimits_has_limits_published">has_limits_published</a>&lt;CoinType&gt;(addr: address): bool
+<pre><code><b>public</b> <b>fun</b> <a href="AccountLimits.md#0x1_AccountLimits_has_limits_published">has_limits_published</a>&lt;CoinType: store&gt;(addr: address): bool
 </code></pre>
 
 
@@ -1226,7 +1226,7 @@ Checks whether the limits definition is unrestricted.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="AccountLimits.md#0x1_AccountLimits_has_window_published">has_window_published</a>&lt;CoinType&gt;(addr: address): bool
+<pre><code><b>public</b> <b>fun</b> <a href="AccountLimits.md#0x1_AccountLimits_has_window_published">has_window_published</a>&lt;CoinType: store&gt;(addr: address): bool
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/DesignatedDealer.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/DesignatedDealer.md
@@ -173,7 +173,7 @@ If <code>add_all_currencies = <b>true</b></code> this will add a <code>PreburnQu
 for each known currency at launch.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_publish_designated_dealer_credential">publish_designated_dealer_credential</a>&lt;CoinType&gt;(dd: &signer, tc_account: &signer, add_all_currencies: bool)
+<pre><code><b>public</b> <b>fun</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_publish_designated_dealer_credential">publish_designated_dealer_credential</a>&lt;CoinType: store&gt;(dd: &signer, tc_account: &signer, add_all_currencies: bool)
 </code></pre>
 
 
@@ -236,7 +236,7 @@ Public so that a currency can be added to a DD later on. Will require
 multi-signer transactions in order to add a new currency to an existing DD.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_add_currency">add_currency</a>&lt;CoinType&gt;(dd: &signer, tc_account: &signer)
+<pre><code><b>public</b> <b>fun</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_add_currency">add_currency</a>&lt;CoinType: store&gt;(dd: &signer, tc_account: &signer)
 </code></pre>
 
 
@@ -297,7 +297,7 @@ multi-signer transactions in order to add a new currency to an existing DD.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_tiered_mint">tiered_mint</a>&lt;CoinType&gt;(tc_account: &signer, amount: u64, dd_addr: address, _tier_index: u64): <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_tiered_mint">tiered_mint</a>&lt;CoinType: store&gt;(tc_account: &signer, amount: u64, dd_addr: address, _tier_index: u64): <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/Diem.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/Diem.md
@@ -885,7 +885,7 @@ Publishes the <code><a href="Diem.md#0x1_Diem_BurnCapability">BurnCapability</a>
 must be a registered currency type. The caller must pass a treasury compliance account.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_publish_burn_capability">publish_burn_capability</a>&lt;CoinType&gt;(tc_account: &signer, cap: <a href="Diem.md#0x1_Diem_BurnCapability">Diem::BurnCapability</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_publish_burn_capability">publish_burn_capability</a>&lt;CoinType: store&gt;(tc_account: &signer, cap: <a href="Diem.md#0x1_Diem_BurnCapability">Diem::BurnCapability</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -968,7 +968,7 @@ Mints <code>amount</code> of currency. The <code>account</code> must hold a
 to be successful.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_mint">mint</a>&lt;CoinType&gt;(account: &signer, value: u64): <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_mint">mint</a>&lt;CoinType: store&gt;(account: &signer, value: u64): <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -1026,7 +1026,7 @@ there is not a <code><a href="Diem.md#0x1_Diem_Preburn">Preburn</a></code> reque
 equal <code>amount</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_burn">burn</a>&lt;CoinType&gt;(account: &signer, preburn_address: address, amount: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_burn">burn</a>&lt;CoinType: store&gt;(account: &signer, preburn_address: address, amount: u64)
 </code></pre>
 
 
@@ -1127,7 +1127,7 @@ outstanding in the <code><a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a
 a value equal to <code>amount</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_cancel_burn">cancel_burn</a>&lt;CoinType&gt;(account: &signer, preburn_address: address, amount: u64): <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_cancel_burn">cancel_burn</a>&lt;CoinType: store&gt;(account: &signer, preburn_address: address, amount: u64): <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -1217,7 +1217,7 @@ the treasury compliance account or the <code><a href="XDX.md#0x1_XDX">0x1::XDX</
 reference.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_mint_with_capability">mint_with_capability</a>&lt;CoinType&gt;(value: u64, _capability: &<a href="Diem.md#0x1_Diem_MintCapability">Diem::MintCapability</a>&lt;CoinType&gt;): <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_mint_with_capability">mint_with_capability</a>&lt;CoinType: store&gt;(value: u64, _capability: &<a href="Diem.md#0x1_Diem_MintCapability">Diem::MintCapability</a>&lt;CoinType&gt;): <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -1339,7 +1339,7 @@ being preburned is a synthetic currency (<code>is_synthetic = <b>true</b></code>
 <code><a href="Diem.md#0x1_Diem_PreburnEvent">PreburnEvent</a></code> will be emitted.
 
 
-<pre><code><b>fun</b> <a href="Diem.md#0x1_Diem_preburn_with_resource">preburn_with_resource</a>&lt;CoinType&gt;(coin: <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;, preburn: &<b>mut</b> <a href="Diem.md#0x1_Diem_Preburn">Diem::Preburn</a>&lt;CoinType&gt;, preburn_address: address)
+<pre><code><b>fun</b> <a href="Diem.md#0x1_Diem_preburn_with_resource">preburn_with_resource</a>&lt;CoinType: store&gt;(coin: <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;, preburn: &<b>mut</b> <a href="Diem.md#0x1_Diem_Preburn">Diem::Preburn</a>&lt;CoinType&gt;, preburn_address: address)
 </code></pre>
 
 
@@ -1474,7 +1474,7 @@ This is useful for places where a module needs to be able to burn coins
 outside of a Designated Dealer, e.g., for transaction fees, or for the XDX reserve.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_create_preburn">create_preburn</a>&lt;CoinType&gt;(tc_account: &signer): <a href="Diem.md#0x1_Diem_Preburn">Diem::Preburn</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_create_preburn">create_preburn</a>&lt;CoinType: store&gt;(tc_account: &signer): <a href="Diem.md#0x1_Diem_Preburn">Diem::Preburn</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -1529,7 +1529,7 @@ Publish an empty <code><a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a><
 dealer account <code>account</code>.
 
 
-<pre><code><b>fun</b> <a href="Diem.md#0x1_Diem_publish_preburn_queue">publish_preburn_queue</a>&lt;CoinType&gt;(account: &signer)
+<pre><code><b>fun</b> <a href="Diem.md#0x1_Diem_publish_preburn_queue">publish_preburn_queue</a>&lt;CoinType: store&gt;(account: &signer)
 </code></pre>
 
 
@@ -1623,7 +1623,7 @@ time, and the association TC account <code>tc_account</code> (at <code><a href="
 this resource for the designated dealer <code>account</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_publish_preburn_queue_to_account">publish_preburn_queue_to_account</a>&lt;CoinType&gt;(account: &signer, tc_account: &signer)
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_publish_preburn_queue_to_account">publish_preburn_queue_to_account</a>&lt;CoinType: store&gt;(account: &signer, tc_account: &signer)
 </code></pre>
 
 
@@ -1693,7 +1693,7 @@ resource to using a <code><a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</
 requests can be outstanding in the same currency for a designated dealer.
 
 
-<pre><code><b>fun</b> <a href="Diem.md#0x1_Diem_upgrade_preburn">upgrade_preburn</a>&lt;CoinType&gt;(account: &signer)
+<pre><code><b>fun</b> <a href="Diem.md#0x1_Diem_upgrade_preburn">upgrade_preburn</a>&lt;CoinType: store&gt;(account: &signer)
 </code></pre>
 
 
@@ -1838,7 +1838,7 @@ Add the <code>preburn</code> request to the preburn queue of <code>account</code
 number of preburn requests does not exceed <code><a href="Diem.md#0x1_Diem_MAX_OUTSTANDING_PREBURNS">MAX_OUTSTANDING_PREBURNS</a></code>.
 
 
-<pre><code><b>fun</b> <a href="Diem.md#0x1_Diem_add_preburn_to_queue">add_preburn_to_queue</a>&lt;CoinType&gt;(account: &signer, preburn: <a href="Diem.md#0x1_Diem_PreburnWithMetadata">Diem::PreburnWithMetadata</a>&lt;CoinType&gt;)
+<pre><code><b>fun</b> <a href="Diem.md#0x1_Diem_add_preburn_to_queue">add_preburn_to_queue</a>&lt;CoinType: store&gt;(account: &signer, preburn: <a href="Diem.md#0x1_Diem_PreburnWithMetadata">Diem::PreburnWithMetadata</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -1916,7 +1916,7 @@ Calls to this function will fail if:
 * <code>coin</code> has a <code>value</code> field of zero.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_preburn_to">preburn_to</a>&lt;CoinType&gt;(account: &signer, coin: <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_preburn_to">preburn_to</a>&lt;CoinType: store&gt;(account: &signer, coin: <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -2042,7 +2042,7 @@ Calls to this function will fail if:
 * a preburn request with the correct value for <code>amount</code> cannot be found in the preburn queue for <code>preburn_address</code>;
 
 
-<pre><code><b>fun</b> <a href="Diem.md#0x1_Diem_remove_preburn_from_queue">remove_preburn_from_queue</a>&lt;CoinType&gt;(preburn_address: address, amount: u64): <a href="Diem.md#0x1_Diem_PreburnWithMetadata">Diem::PreburnWithMetadata</a>&lt;CoinType&gt;
+<pre><code><b>fun</b> <a href="Diem.md#0x1_Diem_remove_preburn_from_queue">remove_preburn_from_queue</a>&lt;CoinType: store&gt;(preburn_address: address, amount: u64): <a href="Diem.md#0x1_Diem_PreburnWithMetadata">Diem::PreburnWithMetadata</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -2151,7 +2151,7 @@ resource under <code>preburn_address</code>, or, if there is no preburn request 
 the preburn queue with a <code>to_burn</code> amount equal to <code>amount</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_burn_with_capability">burn_with_capability</a>&lt;CoinType&gt;(preburn_address: address, capability: &<a href="Diem.md#0x1_Diem_BurnCapability">Diem::BurnCapability</a>&lt;CoinType&gt;, amount: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_burn_with_capability">burn_with_capability</a>&lt;CoinType: store&gt;(preburn_address: address, capability: &<a href="Diem.md#0x1_Diem_BurnCapability">Diem::BurnCapability</a>&lt;CoinType&gt;, amount: u64)
 </code></pre>
 
 
@@ -2238,7 +2238,7 @@ This function can only be called by the holder of a <code><a href="Diem.md#0x1_D
 Calls to this function will fail if the preburn <code>to_burn</code> area for <code>CoinType</code> is empty.
 
 
-<pre><code><b>fun</b> <a href="Diem.md#0x1_Diem_burn_with_resource_cap">burn_with_resource_cap</a>&lt;CoinType&gt;(preburn: &<b>mut</b> <a href="Diem.md#0x1_Diem_Preburn">Diem::Preburn</a>&lt;CoinType&gt;, preburn_address: address, _capability: &<a href="Diem.md#0x1_Diem_BurnCapability">Diem::BurnCapability</a>&lt;CoinType&gt;)
+<pre><code><b>fun</b> <a href="Diem.md#0x1_Diem_burn_with_resource_cap">burn_with_resource_cap</a>&lt;CoinType: store&gt;(preburn: &<b>mut</b> <a href="Diem.md#0x1_Diem_Preburn">Diem::Preburn</a>&lt;CoinType&gt;, preburn_address: address, _capability: &<a href="Diem.md#0x1_Diem_BurnCapability">Diem::BurnCapability</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -2366,7 +2366,7 @@ This function can only be called by the holder of a
 at <code>preburn_address</code> does not contain a preburn request of the right amount.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_cancel_burn_with_capability">cancel_burn_with_capability</a>&lt;CoinType&gt;(preburn_address: address, _capability: &<a href="Diem.md#0x1_Diem_BurnCapability">Diem::BurnCapability</a>&lt;CoinType&gt;, amount: u64): <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_cancel_burn_with_capability">cancel_burn_with_capability</a>&lt;CoinType: store&gt;(preburn_address: address, _capability: &<a href="Diem.md#0x1_Diem_BurnCapability">Diem::BurnCapability</a>&lt;CoinType&gt;, amount: u64): <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -2494,7 +2494,7 @@ A shortcut for immediately burning a coin. This calls preburn followed by a subs
 used for administrative burns, like unpacking an XDX coin or charging fees.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_burn_now">burn_now</a>&lt;CoinType&gt;(coin: <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;, preburn: &<b>mut</b> <a href="Diem.md#0x1_Diem_Preburn">Diem::Preburn</a>&lt;CoinType&gt;, preburn_address: address, capability: &<a href="Diem.md#0x1_Diem_BurnCapability">Diem::BurnCapability</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_burn_now">burn_now</a>&lt;CoinType: store&gt;(coin: <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;, preburn: &<b>mut</b> <a href="Diem.md#0x1_Diem_Preburn">Diem::Preburn</a>&lt;CoinType&gt;, preburn_address: address, capability: &<a href="Diem.md#0x1_Diem_BurnCapability">Diem::BurnCapability</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -2563,7 +2563,7 @@ Calls to this function will fail if <code>account</code> does  not have a
 published <code><a href="Diem.md#0x1_Diem_BurnCapability">BurnCapability</a>&lt;CoinType&gt;</code> resource at the top-level.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_remove_burn_capability">remove_burn_capability</a>&lt;CoinType&gt;(account: &signer): <a href="Diem.md#0x1_Diem_BurnCapability">Diem::BurnCapability</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_remove_burn_capability">remove_burn_capability</a>&lt;CoinType: store&gt;(account: &signer): <a href="Diem.md#0x1_Diem_BurnCapability">Diem::BurnCapability</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -2618,7 +2618,7 @@ preburn requests across all preburn resources for the <code>CoinType</code>
 currency).
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_preburn_value">preburn_value</a>&lt;CoinType&gt;(): u64
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_preburn_value">preburn_value</a>&lt;CoinType: store&gt;(): u64
 </code></pre>
 
 
@@ -2645,7 +2645,7 @@ Create a new <code><a href="Diem.md#0x1_Diem">Diem</a>&lt;CoinType&gt;</code> wi
 this and it will be successful as long as <code>CoinType</code> is a registered currency.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_zero">zero</a>&lt;CoinType&gt;(): <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_zero">zero</a>&lt;CoinType: store&gt;(): <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -2673,7 +2673,7 @@ represented in the base units for the currency represented by
 <code>CoinType</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_value">value</a>&lt;CoinType&gt;(coin: &<a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;): u64
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_value">value</a>&lt;CoinType: store&gt;(coin: &<a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;): u64
 </code></pre>
 
 
@@ -2700,7 +2700,7 @@ remaining balance of the passed in <code>coin</code>, along with another coin
 with value equal to <code>amount</code>. Calls will fail if <code>amount &gt; <a href="Diem.md#0x1_Diem_value">Diem::value</a>(&coin)</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_split">split</a>&lt;CoinType&gt;(coin: <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;, amount: u64): (<a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;, <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_split">split</a>&lt;CoinType: store&gt;(coin: <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;, amount: u64): (<a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;, <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -2744,7 +2744,7 @@ Calls will abort if the passed-in <code>amount</code> is greater than the
 value of the passed-in <code>coin</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_withdraw">withdraw</a>&lt;CoinType&gt;(coin: &<b>mut</b> <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;, amount: u64): <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_withdraw">withdraw</a>&lt;CoinType: store&gt;(coin: &<b>mut</b> <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;, amount: u64): <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -2801,7 +2801,7 @@ Return a <code><a href="Diem.md#0x1_Diem">Diem</a>&lt;CoinType&gt;</code> worth 
 zero. Does not abort.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_withdraw_all">withdraw_all</a>&lt;CoinType&gt;(coin: &<b>mut</b> <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;): <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_withdraw_all">withdraw_all</a>&lt;CoinType: store&gt;(coin: &<b>mut</b> <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;): <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -2843,7 +2843,7 @@ Takes two coins as input, returns a single coin with the total value of both coi
 Destroys on of the input coins.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_join">join</a>&lt;CoinType&gt;(coin1: <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;, coin2: <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;): <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_join">join</a>&lt;CoinType: store&gt;(coin1: <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;, coin2: <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;): <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -2885,7 +2885,7 @@ The coin passed in by reference will have a value equal to the sum of the two co
 The <code>check</code> coin is consumed in the process
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_deposit">deposit</a>&lt;CoinType&gt;(coin: &<b>mut</b> <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;, check: <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_deposit">deposit</a>&lt;CoinType: store&gt;(coin: &<b>mut</b> <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;, check: <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -2941,7 +2941,7 @@ so it is impossible to "burn" any non-zero amount of <code><a href="Diem.md#0x1_
 a <code><a href="Diem.md#0x1_Diem_BurnCapability">BurnCapability</a></code> for the specific <code>CoinType</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_destroy_zero">destroy_zero</a>&lt;CoinType&gt;(coin: <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_destroy_zero">destroy_zero</a>&lt;CoinType: store&gt;(coin: <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -2990,7 +2990,7 @@ adds the currency to the set of <code><a href="RegisteredCurrencies.md#0x1_Regis
 <code><a href="Diem.md#0x1_Diem_MintCapability">MintCapability</a>&lt;CoinType&gt;</code> and <code><a href="Diem.md#0x1_Diem_BurnCapability">BurnCapability</a>&lt;CoinType&gt;</code> resources.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_register_currency">register_currency</a>&lt;CoinType&gt;(dr_account: &signer, to_xdx_exchange_rate: <a href="../../../../../../move-stdlib/docs/FixedPoint32.md#0x1_FixedPoint32_FixedPoint32">FixedPoint32::FixedPoint32</a>, is_synthetic: bool, scaling_factor: u64, fractional_part: u64, currency_code: vector&lt;u8&gt;): (<a href="Diem.md#0x1_Diem_MintCapability">Diem::MintCapability</a>&lt;CoinType&gt;, <a href="Diem.md#0x1_Diem_BurnCapability">Diem::BurnCapability</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_register_currency">register_currency</a>&lt;CoinType: store&gt;(dr_account: &signer, to_xdx_exchange_rate: <a href="../../../../../../move-stdlib/docs/FixedPoint32.md#0x1_FixedPoint32_FixedPoint32">FixedPoint32::FixedPoint32</a>, is_synthetic: bool, scaling_factor: u64, fractional_part: u64, currency_code: vector&lt;u8&gt;): (<a href="Diem.md#0x1_Diem_MintCapability">Diem::MintCapability</a>&lt;CoinType&gt;, <a href="Diem.md#0x1_Diem_BurnCapability">Diem::BurnCapability</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -3107,7 +3107,7 @@ This code allows different currencies to have different treasury compliance
 accounts.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_register_SCS_currency">register_SCS_currency</a>&lt;CoinType&gt;(dr_account: &signer, tc_account: &signer, to_xdx_exchange_rate: <a href="../../../../../../move-stdlib/docs/FixedPoint32.md#0x1_FixedPoint32_FixedPoint32">FixedPoint32::FixedPoint32</a>, scaling_factor: u64, fractional_part: u64, currency_code: vector&lt;u8&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_register_SCS_currency">register_SCS_currency</a>&lt;CoinType: store&gt;(dr_account: &signer, tc_account: &signer, to_xdx_exchange_rate: <a href="../../../../../../move-stdlib/docs/FixedPoint32.md#0x1_FixedPoint32_FixedPoint32">FixedPoint32::FixedPoint32</a>, scaling_factor: u64, fractional_part: u64, currency_code: vector&lt;u8&gt;)
 </code></pre>
 
 
@@ -3207,7 +3207,7 @@ Only a TreasuryCompliance account can have the BurnCapability [[H3]][PERMISSION]
 Returns the total amount of currency minted of type <code>CoinType</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_market_cap">market_cap</a>&lt;CoinType&gt;(): u128
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_market_cap">market_cap</a>&lt;CoinType: store&gt;(): u128
 </code></pre>
 
 
@@ -3236,7 +3236,7 @@ This should only be used where a _rough_ approximation of the exchange
 rate is needed.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_approx_xdx_for_value">approx_xdx_for_value</a>&lt;FromCoinType&gt;(from_value: u64): u64
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_approx_xdx_for_value">approx_xdx_for_value</a>&lt;FromCoinType: store&gt;(from_value: u64): u64
 </code></pre>
 
 
@@ -3294,7 +3294,7 @@ This should only be used where a rough approximation of the exchange
 rate is needed.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_approx_xdx_for_coin">approx_xdx_for_coin</a>&lt;FromCoinType&gt;(coin: &<a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;FromCoinType&gt;): u64
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_approx_xdx_for_coin">approx_xdx_for_coin</a>&lt;FromCoinType: store&gt;(coin: &<a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;FromCoinType&gt;): u64
 </code></pre>
 
 
@@ -3322,7 +3322,7 @@ Returns <code><b>true</b></code> if the type <code>CoinType</code> is a register
 Returns <code><b>false</b></code> otherwise.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_is_currency">is_currency</a>&lt;CoinType&gt;(): bool
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_is_currency">is_currency</a>&lt;CoinType: store&gt;(): bool
 </code></pre>
 
 
@@ -3346,7 +3346,7 @@ Returns <code><b>false</b></code> otherwise.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_is_SCS_currency">is_SCS_currency</a>&lt;CoinType&gt;(): bool
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_is_SCS_currency">is_SCS_currency</a>&lt;CoinType: store&gt;(): bool
 </code></pre>
 
 
@@ -3373,7 +3373,7 @@ Returns <code><b>true</b></code> if <code>CoinType</code> is a synthetic currenc
 its <code><a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a></code>. Returns <code><b>false</b></code> otherwise.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_is_synthetic_currency">is_synthetic_currency</a>&lt;CoinType&gt;(): bool
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_is_synthetic_currency">is_synthetic_currency</a>&lt;CoinType: store&gt;(): bool
 </code></pre>
 
 
@@ -3402,7 +3402,7 @@ Returns the scaling factor for the <code>CoinType</code> currency as defined
 in its <code><a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a></code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_scaling_factor">scaling_factor</a>&lt;CoinType&gt;(): u64
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_scaling_factor">scaling_factor</a>&lt;CoinType: store&gt;(): u64
 </code></pre>
 
 
@@ -3430,7 +3430,7 @@ Returns the representable (i.e. real-world) fractional part for the
 <code>CoinType</code> currency as defined in its <code><a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a></code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_fractional_part">fractional_part</a>&lt;CoinType&gt;(): u64
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_fractional_part">fractional_part</a>&lt;CoinType: store&gt;(): u64
 </code></pre>
 
 
@@ -3458,7 +3458,7 @@ Returns the currency code for the registered currency as defined in
 its <code><a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a></code> resource.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_currency_code">currency_code</a>&lt;CoinType&gt;(): vector&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_currency_code">currency_code</a>&lt;CoinType: store&gt;(): vector&lt;u8&gt;
 </code></pre>
 
 
@@ -3511,7 +3511,7 @@ Updates the <code>to_xdx_exchange_rate</code> held in the <code><a href="Diem.md
 <code>FromCoinType</code> to the new passed-in <code>xdx_exchange_rate</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_update_xdx_exchange_rate">update_xdx_exchange_rate</a>&lt;FromCoinType&gt;(tc_account: &signer, xdx_exchange_rate: <a href="../../../../../../move-stdlib/docs/FixedPoint32.md#0x1_FixedPoint32_FixedPoint32">FixedPoint32::FixedPoint32</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_update_xdx_exchange_rate">update_xdx_exchange_rate</a>&lt;FromCoinType: store&gt;(tc_account: &signer, xdx_exchange_rate: <a href="../../../../../../move-stdlib/docs/FixedPoint32.md#0x1_FixedPoint32_FixedPoint32">FixedPoint32::FixedPoint32</a>)
 </code></pre>
 
 
@@ -3615,7 +3615,7 @@ Must abort if the account does not have the TreasuryCompliance Role [[H5]][PERMI
 Returns the (rough) exchange rate between <code>CoinType</code> and <code><a href="XDX.md#0x1_XDX">XDX</a></code>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_xdx_exchange_rate">xdx_exchange_rate</a>&lt;CoinType&gt;(): <a href="../../../../../../move-stdlib/docs/FixedPoint32.md#0x1_FixedPoint32_FixedPoint32">FixedPoint32::FixedPoint32</a>
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_xdx_exchange_rate">xdx_exchange_rate</a>&lt;CoinType: store&gt;(): <a href="../../../../../../move-stdlib/docs/FixedPoint32.md#0x1_FixedPoint32_FixedPoint32">FixedPoint32::FixedPoint32</a>
 </code></pre>
 
 
@@ -3664,7 +3664,7 @@ disallowed until it is turned back on via this function. All coins
 start out in the default state of <code>can_mint = <b>true</b></code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_update_minting_ability">update_minting_ability</a>&lt;CoinType&gt;(tc_account: &signer, can_mint: bool)
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_update_minting_ability">update_minting_ability</a>&lt;CoinType: store&gt;(tc_account: &signer, can_mint: bool)
 </code></pre>
 
 
@@ -3743,7 +3743,7 @@ Only the TreasuryCompliance role can enable/disable minting [[H2]][PERMISSION].
 Asserts that <code>CoinType</code> is a registered currency.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_assert_is_currency">assert_is_currency</a>&lt;CoinType&gt;()
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_assert_is_currency">assert_is_currency</a>&lt;CoinType: store&gt;()
 </code></pre>
 
 
@@ -3791,7 +3791,7 @@ Asserts that <code>CoinType</code> is a registered currency.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_assert_is_SCS_currency">assert_is_SCS_currency</a>&lt;CoinType&gt;()
+<pre><code><b>public</b> <b>fun</b> <a href="Diem.md#0x1_Diem_assert_is_SCS_currency">assert_is_SCS_currency</a>&lt;CoinType: store&gt;()
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/DiemAccount.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/DiemAccount.md
@@ -882,7 +882,7 @@ Initialize this module. This is only callable from genesis.
 Return <code><b>true</b></code> if <code>addr</code> has already published account limits for <code>Token</code>
 
 
-<pre><code><b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_has_published_account_limits">has_published_account_limits</a>&lt;Token&gt;(addr: address): bool
+<pre><code><b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_has_published_account_limits">has_published_account_limits</a>&lt;Token: store&gt;(addr: address): bool
 </code></pre>
 
 
@@ -915,7 +915,7 @@ Depending on the <code>is_withdrawal</code> flag passed in we determine whether 
 <code>any-&gt;<a href="VASP.md#0x1_VASP">VASP</a></code> transfers are tracked in the VASP.
 
 
-<pre><code><b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_should_track_limits_for_account">should_track_limits_for_account</a>&lt;Token&gt;(payer: address, payee: address, is_withdrawal: bool): bool
+<pre><code><b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_should_track_limits_for_account">should_track_limits_for_account</a>&lt;Token: store&gt;(payer: address, payee: address, is_withdrawal: bool): bool
 </code></pre>
 
 
@@ -985,7 +985,7 @@ Depending on the <code>is_withdrawal</code> flag passed in we determine whether 
 Record a payment of <code>to_deposit</code> from <code>payer</code> to <code>payee</code> with the attached <code>metadata</code>
 
 
-<pre><code><b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_deposit">deposit</a>&lt;Token&gt;(payer: address, payee: address, to_deposit: <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;Token&gt;, metadata: vector&lt;u8&gt;, metadata_signature: vector&lt;u8&gt;)
+<pre><code><b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_deposit">deposit</a>&lt;Token: store&gt;(payer: address, payee: address, to_deposit: <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;Token&gt;, metadata: vector&lt;u8&gt;, metadata_signature: vector&lt;u8&gt;)
 </code></pre>
 
 
@@ -1189,7 +1189,7 @@ Max valid tier index is 3 since there are max 4 tiers per DD.
 Sender should be treasury compliance account and receiver authorized DD.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_tiered_mint">tiered_mint</a>&lt;Token&gt;(tc_account: &signer, designated_dealer_address: address, mint_amount: u64, tier_index: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_tiered_mint">tiered_mint</a>&lt;Token: store&gt;(tc_account: &signer, designated_dealer_address: address, mint_amount: u64, tier_index: u64)
 </code></pre>
 
 
@@ -1316,7 +1316,7 @@ The balance of designated dealer increases by <code>amount</code>.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_cancel_burn">cancel_burn</a>&lt;Token&gt;(account: &signer, preburn_address: address, amount: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_cancel_burn">cancel_burn</a>&lt;Token: store&gt;(account: &signer, preburn_address: address, amount: u64)
 </code></pre>
 
 
@@ -1391,7 +1391,7 @@ The balance of designated dealer increases by <code>amount</code>.
 Helper to withdraw <code>amount</code> from the given account balance and return the withdrawn Diem<Token>
 
 
-<pre><code><b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_withdraw_from_balance">withdraw_from_balance</a>&lt;Token&gt;(payer: address, payee: address, balance: &<b>mut</b> <a href="DiemAccount.md#0x1_DiemAccount_Balance">DiemAccount::Balance</a>&lt;Token&gt;, amount: u64): <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;Token&gt;
+<pre><code><b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_withdraw_from_balance">withdraw_from_balance</a>&lt;Token: store&gt;(payer: address, payee: address, balance: &<b>mut</b> <a href="DiemAccount.md#0x1_DiemAccount_Balance">DiemAccount::Balance</a>&lt;Token&gt;, amount: u64): <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;Token&gt;
 </code></pre>
 
 
@@ -1509,7 +1509,7 @@ Withdraw <code>amount</code> <code><a href="Diem.md#0x1_Diem">Diem</a>&lt;Token&
 <code>cap.account_address</code>
 
 
-<pre><code><b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_withdraw_from">withdraw_from</a>&lt;Token&gt;(cap: &<a href="DiemAccount.md#0x1_DiemAccount_WithdrawCapability">DiemAccount::WithdrawCapability</a>, payee: address, amount: u64, metadata: vector&lt;u8&gt;): <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;Token&gt;
+<pre><code><b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_withdraw_from">withdraw_from</a>&lt;Token: store&gt;(cap: &<a href="DiemAccount.md#0x1_DiemAccount_WithdrawCapability">DiemAccount::WithdrawCapability</a>, payee: address, amount: u64, metadata: vector&lt;u8&gt;): <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;Token&gt;
 </code></pre>
 
 
@@ -1656,7 +1656,7 @@ Withdraw <code>amount</code> <code><a href="Diem.md#0x1_Diem">Diem</a>&lt;Token&
 resource under <code>dd</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_preburn">preburn</a>&lt;Token&gt;(dd: &signer, cap: &<a href="DiemAccount.md#0x1_DiemAccount_WithdrawCapability">DiemAccount::WithdrawCapability</a>, amount: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_preburn">preburn</a>&lt;Token: store&gt;(dd: &signer, cap: &<a href="DiemAccount.md#0x1_DiemAccount_WithdrawCapability">DiemAccount::WithdrawCapability</a>, amount: u64)
 </code></pre>
 
 
@@ -1912,7 +1912,7 @@ The <code>metadata_signature</code> will only be checked if this payment is subj
 attestation protocol
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_pay_from">pay_from</a>&lt;Token&gt;(cap: &<a href="DiemAccount.md#0x1_DiemAccount_WithdrawCapability">DiemAccount::WithdrawCapability</a>, payee: address, amount: u64, metadata: vector&lt;u8&gt;, metadata_signature: vector&lt;u8&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_pay_from">pay_from</a>&lt;Token: store&gt;(cap: &<a href="DiemAccount.md#0x1_DiemAccount_WithdrawCapability">DiemAccount::WithdrawCapability</a>, payee: address, amount: u64, metadata: vector&lt;u8&gt;, metadata_signature: vector&lt;u8&gt;)
 </code></pre>
 
 
@@ -2313,7 +2313,7 @@ Add balances for <code>Token</code> to <code>new_account</code>.  If <code>add_a
 then add for both token types.
 
 
-<pre><code><b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_add_currencies_for_account">add_currencies_for_account</a>&lt;Token&gt;(new_account: &signer, add_all_currencies: bool)
+<pre><code><b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_add_currencies_for_account">add_currencies_for_account</a>&lt;Token: store&gt;(new_account: &signer, add_all_currencies: bool)
 </code></pre>
 
 
@@ -2883,7 +2883,7 @@ Create a designated dealer account at <code>new_account_address</code> with auth
 Creates Preburn resource under account 'new_account_address'
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_create_designated_dealer">create_designated_dealer</a>&lt;CoinType&gt;(creator_account: &signer, new_account_address: address, auth_key_prefix: vector&lt;u8&gt;, human_name: vector&lt;u8&gt;, add_all_currencies: bool)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_create_designated_dealer">create_designated_dealer</a>&lt;CoinType: store&gt;(creator_account: &signer, new_account_address: address, auth_key_prefix: vector&lt;u8&gt;, human_name: vector&lt;u8&gt;, add_all_currencies: bool)
 </code></pre>
 
 
@@ -2972,7 +2972,7 @@ Create an account with the ParentVASP role at <code>new_account_address</code> w
 all available currencies in the system will also be added.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_create_parent_vasp_account">create_parent_vasp_account</a>&lt;Token&gt;(creator_account: &signer, new_account_address: address, auth_key_prefix: vector&lt;u8&gt;, human_name: vector&lt;u8&gt;, add_all_currencies: bool)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_create_parent_vasp_account">create_parent_vasp_account</a>&lt;Token: store&gt;(creator_account: &signer, new_account_address: address, auth_key_prefix: vector&lt;u8&gt;, human_name: vector&lt;u8&gt;, add_all_currencies: bool)
 </code></pre>
 
 
@@ -3061,7 +3061,7 @@ Create an account with the ChildVASP role at <code>new_account_address</code> wi
 also be added. This account will be a child of <code>creator</code>, which must be a ParentVASP.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_create_child_vasp_account">create_child_vasp_account</a>&lt;Token&gt;(parent: &signer, new_account_address: address, auth_key_prefix: vector&lt;u8&gt;, add_all_currencies: bool)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_create_child_vasp_account">create_child_vasp_account</a>&lt;Token: store&gt;(parent: &signer, new_account_address: address, auth_key_prefix: vector&lt;u8&gt;, add_all_currencies: bool)
 </code></pre>
 
 
@@ -3196,7 +3196,7 @@ also be added. This account will be a child of <code>creator</code>, which must 
 Helper to return the u64 value of the <code>balance</code> for <code>account</code>
 
 
-<pre><code><b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_balance_for">balance_for</a>&lt;Token&gt;(balance: &<a href="DiemAccount.md#0x1_DiemAccount_Balance">DiemAccount::Balance</a>&lt;Token&gt;): u64
+<pre><code><b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_balance_for">balance_for</a>&lt;Token: store&gt;(balance: &<a href="DiemAccount.md#0x1_DiemAccount_Balance">DiemAccount::Balance</a>&lt;Token&gt;): u64
 </code></pre>
 
 
@@ -3221,7 +3221,7 @@ Helper to return the u64 value of the <code>balance</code> for <code>account</co
 Return the current balance of the account at <code>addr</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_balance">balance</a>&lt;Token&gt;(addr: address): u64
+<pre><code><b>public</b> <b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_balance">balance</a>&lt;Token: store&gt;(addr: address): u64
 </code></pre>
 
 
@@ -3259,7 +3259,7 @@ Return the current balance of the account at <code>addr</code>.
 Add a balance of <code>Token</code> type to the sending account
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_add_currency">add_currency</a>&lt;Token&gt;(account: &signer)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_add_currency">add_currency</a>&lt;Token: store&gt;(account: &signer)
 </code></pre>
 
 
@@ -3394,7 +3394,7 @@ This function must abort if the predicate <code>can_hold_balance</code> for <cod
 Return whether the account at <code>addr</code> accepts <code>Token</code> type coins
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_accepts_currency">accepts_currency</a>&lt;Token&gt;(addr: address): bool
+<pre><code><b>public</b> <b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_accepts_currency">accepts_currency</a>&lt;Token: store&gt;(addr: address): bool
 </code></pre>
 
 
@@ -3625,7 +3625,7 @@ Checks if an account exists at <code>check_addr</code>
 The prologue for module transaction
 
 
-<pre><code><b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_module_prologue">module_prologue</a>&lt;Token&gt;(sender: signer, txn_sequence_number: u64, txn_public_key: vector&lt;u8&gt;, txn_gas_price: u64, txn_max_gas_units: u64, txn_expiration_time: u64, chain_id: u8)
+<pre><code><b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_module_prologue">module_prologue</a>&lt;Token: store&gt;(sender: signer, txn_sequence_number: u64, txn_public_key: vector&lt;u8&gt;, txn_gas_price: u64, txn_max_gas_units: u64, txn_expiration_time: u64, chain_id: u8)
 </code></pre>
 
 
@@ -3737,7 +3737,7 @@ Covered: L75 (Match 9)
 The prologue for script transaction
 
 
-<pre><code><b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_script_prologue">script_prologue</a>&lt;Token&gt;(sender: signer, txn_sequence_number: u64, txn_public_key: vector&lt;u8&gt;, txn_gas_price: u64, txn_max_gas_units: u64, txn_expiration_time: u64, chain_id: u8, script_hash: vector&lt;u8&gt;)
+<pre><code><b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_script_prologue">script_prologue</a>&lt;Token: store&gt;(sender: signer, txn_sequence_number: u64, txn_public_key: vector&lt;u8&gt;, txn_gas_price: u64, txn_max_gas_units: u64, txn_expiration_time: u64, chain_id: u8, script_hash: vector&lt;u8&gt;)
 </code></pre>
 
 
@@ -3948,7 +3948,7 @@ The main properties that it verifies:
 - That the sequence number matches the transaction's sequence key
 
 
-<pre><code><b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_prologue_common">prologue_common</a>&lt;Token&gt;(sender: &signer, txn_sequence_number: u64, txn_public_key: vector&lt;u8&gt;, txn_gas_price: u64, txn_max_gas_units: u64, txn_expiration_time_seconds: u64, chain_id: u8)
+<pre><code><b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_prologue_common">prologue_common</a>&lt;Token: store&gt;(sender: &signer, txn_sequence_number: u64, txn_public_key: vector&lt;u8&gt;, txn_gas_price: u64, txn_max_gas_units: u64, txn_expiration_time_seconds: u64, chain_id: u8)
 </code></pre>
 
 
@@ -4214,7 +4214,7 @@ If the exection of the epilogue fails, it is re-invoked with different arguments
 based on the conditions checked in the prologue, should never fail.
 
 
-<pre><code><b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_epilogue">epilogue</a>&lt;Token&gt;(account: signer, txn_sequence_number: u64, txn_gas_price: u64, txn_max_gas_units: u64, gas_units_remaining: u64)
+<pre><code><b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_epilogue">epilogue</a>&lt;Token: store&gt;(account: signer, txn_sequence_number: u64, txn_gas_price: u64, txn_max_gas_units: u64, gas_units_remaining: u64)
 </code></pre>
 
 
@@ -4250,7 +4250,7 @@ based on the conditions checked in the prologue, should never fail.
 
 
 
-<pre><code><b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_epilogue_common">epilogue_common</a>&lt;Token&gt;(account: &signer, txn_sequence_number: u64, txn_gas_price: u64, txn_max_gas_units: u64, gas_units_remaining: u64)
+<pre><code><b>fun</b> <a href="DiemAccount.md#0x1_DiemAccount_epilogue_common">epilogue_common</a>&lt;Token: store&gt;(account: &signer, txn_sequence_number: u64, txn_gas_price: u64, txn_max_gas_units: u64, gas_units_remaining: u64)
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/DiemConfig.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/DiemConfig.md
@@ -48,7 +48,7 @@ to synchronize configuration changes for the validators.
 A generic singleton resource that holds a value of a specific type.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemConfig.md#0x1_DiemConfig">DiemConfig</a>&lt;Config: <b>copyable</b>&gt;
+<pre><code><b>resource</b> <b>struct</b> <a href="DiemConfig.md#0x1_DiemConfig">DiemConfig</a>&lt;Config: <b>copy</b>, drop, store&gt;
 </code></pre>
 
 
@@ -339,7 +339,7 @@ Publishes <code><a href="DiemConfig.md#0x1_DiemConfig_Configuration">Configurati
 Returns a copy of <code>Config</code> value stored under <code>addr</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemConfig.md#0x1_DiemConfig_get">get</a>&lt;Config: <b>copyable</b>&gt;(): Config
+<pre><code><b>public</b> <b>fun</b> <a href="DiemConfig.md#0x1_DiemConfig_get">get</a>&lt;Config: <b>copy</b>, drop, store&gt;(): Config
 </code></pre>
 
 
@@ -394,7 +394,7 @@ reconfiguration. This function requires that the signer have a <code><a href="Di
 resource published under it.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemConfig.md#0x1_DiemConfig_set">set</a>&lt;Config: <b>copyable</b>&gt;(account: &signer, payload: Config)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemConfig.md#0x1_DiemConfig_set">set</a>&lt;Config: <b>copy</b>, drop, store&gt;(account: &signer, payload: Config)
 </code></pre>
 
 
@@ -494,7 +494,7 @@ validator operators to change the validator set.  All other config changes requi
 a Diem root signer.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemConfig.md#0x1_DiemConfig_set_with_capability_and_reconfigure">set_with_capability_and_reconfigure</a>&lt;Config: <b>copyable</b>&gt;(_cap: &<a href="DiemConfig.md#0x1_DiemConfig_ModifyConfigCapability">DiemConfig::ModifyConfigCapability</a>&lt;Config&gt;, payload: Config)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemConfig.md#0x1_DiemConfig_set_with_capability_and_reconfigure">set_with_capability_and_reconfigure</a>&lt;Config: <b>copy</b>, drop, store&gt;(_cap: &<a href="DiemConfig.md#0x1_DiemConfig_ModifyConfigCapability">DiemConfig::ModifyConfigCapability</a>&lt;Config&gt;, payload: Config)
 </code></pre>
 
 
@@ -639,7 +639,7 @@ policy for who can modify the config.
 Does not trigger a reconfiguration.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemConfig.md#0x1_DiemConfig_publish_new_config_and_get_capability">publish_new_config_and_get_capability</a>&lt;Config: <b>copyable</b>&gt;(dr_account: &signer, payload: Config): <a href="DiemConfig.md#0x1_DiemConfig_ModifyConfigCapability">DiemConfig::ModifyConfigCapability</a>&lt;Config&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemConfig.md#0x1_DiemConfig_publish_new_config_and_get_capability">publish_new_config_and_get_capability</a>&lt;Config: <b>copy</b>, drop, store&gt;(dr_account: &signer, payload: Config): <a href="DiemConfig.md#0x1_DiemConfig_ModifyConfigCapability">DiemConfig::ModifyConfigCapability</a>&lt;Config&gt;
 </code></pre>
 
 
@@ -705,7 +705,7 @@ Publishes the capability to modify this config under the Diem root account.
 Does not trigger a reconfiguration.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemConfig.md#0x1_DiemConfig_publish_new_config">publish_new_config</a>&lt;Config: <b>copyable</b>&gt;(dr_account: &signer, payload: Config)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemConfig.md#0x1_DiemConfig_publish_new_config">publish_new_config</a>&lt;Config: <b>copy</b>, drop, store&gt;(dr_account: &signer, payload: Config)
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/DualAttestation.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/DualAttestation.md
@@ -908,7 +908,7 @@ Return the address where the credentials for <code>addr</code> are stored
 Helper which returns true if dual attestion is required for a deposit.
 
 
-<pre><code><b>fun</b> <a href="DualAttestation.md#0x1_DualAttestation_dual_attestation_required">dual_attestation_required</a>&lt;Token&gt;(payer: address, payee: address, deposit_value: u64): bool
+<pre><code><b>fun</b> <a href="DualAttestation.md#0x1_DualAttestation_dual_attestation_required">dual_attestation_required</a>&lt;Token: store&gt;(payer: address, payee: address, deposit_value: u64): bool
 </code></pre>
 
 
@@ -1185,7 +1185,7 @@ It aborts with an appropriate error code if dual attestation is required, but on
 the conditions in (2) is not met.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DualAttestation.md#0x1_DualAttestation_assert_payment_ok">assert_payment_ok</a>&lt;Currency&gt;(payer: address, payee: address, value: u64, metadata: vector&lt;u8&gt;, metadata_signature: vector&lt;u8&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="DualAttestation.md#0x1_DualAttestation_assert_payment_ok">assert_payment_ok</a>&lt;Currency: store&gt;(payer: address, payee: address, value: u64, metadata: vector&lt;u8&gt;, metadata_signature: vector&lt;u8&gt;)
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/PaymentScripts.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/PaymentScripts.md
@@ -105,7 +105,7 @@ Successful execution of this script emits two events:
 * <code><a href="AccountAdministrationScripts.md#0x1_AccountAdministrationScripts_add_currency_to_account">AccountAdministrationScripts::add_currency_to_account</a></code>
 
 
-<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="PaymentScripts.md#0x1_PaymentScripts_peer_to_peer_with_metadata">peer_to_peer_with_metadata</a>&lt;Currency&gt;(payer: signer, payee: address, amount: u64, metadata: vector&lt;u8&gt;, metadata_signature: vector&lt;u8&gt;)
+<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="PaymentScripts.md#0x1_PaymentScripts_peer_to_peer_with_metadata">peer_to_peer_with_metadata</a>&lt;Currency: store&gt;(payer: signer, payee: address, amount: u64, metadata: vector&lt;u8&gt;, metadata_signature: vector&lt;u8&gt;)
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/TransactionFee.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/TransactionFee.md
@@ -148,7 +148,7 @@ Called in genesis. Sets up the needed resources to collect transaction fees from
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="TransactionFee.md#0x1_TransactionFee_is_coin_initialized">is_coin_initialized</a>&lt;CoinType&gt;(): bool
+<pre><code><b>public</b> <b>fun</b> <a href="TransactionFee.md#0x1_TransactionFee_is_coin_initialized">is_coin_initialized</a>&lt;CoinType: store&gt;(): bool
 </code></pre>
 
 
@@ -199,7 +199,7 @@ Sets up the needed transaction fee state for a given <code>CoinType</code> curre
 (2) publishing a wrapper of the <code>Preburn&lt;CoinType&gt;</code> resource under <code>tc_account</code>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="TransactionFee.md#0x1_TransactionFee_add_txn_fee_currency">add_txn_fee_currency</a>&lt;CoinType&gt;(tc_account: &signer)
+<pre><code><b>public</b> <b>fun</b> <a href="TransactionFee.md#0x1_TransactionFee_add_txn_fee_currency">add_txn_fee_currency</a>&lt;CoinType: store&gt;(tc_account: &signer)
 </code></pre>
 
 
@@ -235,7 +235,7 @@ Sets up the needed transaction fee state for a given <code>CoinType</code> curre
 Deposit <code>coin</code> into the transaction fees bucket
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="TransactionFee.md#0x1_TransactionFee_pay_fee">pay_fee</a>&lt;CoinType&gt;(coin: <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="TransactionFee.md#0x1_TransactionFee_pay_fee">pay_fee</a>&lt;CoinType: store&gt;(coin: <a href="Diem.md#0x1_Diem_Diem">Diem::Diem</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -284,7 +284,7 @@ If the <code>CoinType</code> is XDX, it unpacks the coin and preburns the
 underlying fiat.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="TransactionFee.md#0x1_TransactionFee_burn_fees">burn_fees</a>&lt;CoinType&gt;(tc_account: &signer)
+<pre><code><b>public</b> <b>fun</b> <a href="TransactionFee.md#0x1_TransactionFee_burn_fees">burn_fees</a>&lt;CoinType: store&gt;(tc_account: &signer)
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/TreasuryComplianceScripts.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/TreasuryComplianceScripts.md
@@ -170,7 +170,7 @@ being <code>preburn_address</code>.
 * <code><a href="TreasuryComplianceScripts.md#0x1_TreasuryComplianceScripts_preburn">TreasuryComplianceScripts::preburn</a></code>
 
 
-<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="TreasuryComplianceScripts.md#0x1_TreasuryComplianceScripts_cancel_burn_with_amount">cancel_burn_with_amount</a>&lt;Token&gt;(account: signer, preburn_address: address, amount: u64)
+<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="TreasuryComplianceScripts.md#0x1_TreasuryComplianceScripts_cancel_burn_with_amount">cancel_burn_with_amount</a>&lt;Token: store&gt;(account: signer, preburn_address: address, amount: u64)
 </code></pre>
 
 
@@ -327,7 +327,7 @@ held in the <code><a href="Diem.md#0x1_Diem_CurrencyInfo">Diem::CurrencyInfo</a>
 * <code><a href="TreasuryComplianceScripts.md#0x1_TreasuryComplianceScripts_preburn">TreasuryComplianceScripts::preburn</a></code>
 
 
-<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="TreasuryComplianceScripts.md#0x1_TreasuryComplianceScripts_burn_with_amount">burn_with_amount</a>&lt;Token&gt;(account: signer, sliding_nonce: u64, preburn_address: address, amount: u64)
+<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="TreasuryComplianceScripts.md#0x1_TreasuryComplianceScripts_burn_with_amount">burn_with_amount</a>&lt;Token: store&gt;(account: signer, sliding_nonce: u64, preburn_address: address, amount: u64)
 </code></pre>
 
 
@@ -449,7 +449,7 @@ handle with the <code>payee</code> and <code>payer</code> fields being <code>acc
 * <code><a href="TreasuryComplianceScripts.md#0x1_TreasuryComplianceScripts_burn_txn_fees">TreasuryComplianceScripts::burn_txn_fees</a></code>
 
 
-<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="TreasuryComplianceScripts.md#0x1_TreasuryComplianceScripts_preburn">preburn</a>&lt;Token&gt;(account: signer, amount: u64)
+<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="TreasuryComplianceScripts.md#0x1_TreasuryComplianceScripts_preburn">preburn</a>&lt;Token: store&gt;(account: signer, amount: u64)
 </code></pre>
 
 
@@ -574,7 +574,7 @@ held in the <code><a href="Diem.md#0x1_Diem_CurrencyInfo">Diem::CurrencyInfo</a>
 * <code><a href="TreasuryComplianceScripts.md#0x1_TreasuryComplianceScripts_cancel_burn_with_amount">TreasuryComplianceScripts::cancel_burn_with_amount</a></code>
 
 
-<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="TreasuryComplianceScripts.md#0x1_TreasuryComplianceScripts_burn_txn_fees">burn_txn_fees</a>&lt;CoinType&gt;(tc_account: signer)
+<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="TreasuryComplianceScripts.md#0x1_TreasuryComplianceScripts_burn_txn_fees">burn_txn_fees</a>&lt;CoinType: store&gt;(tc_account: signer)
 </code></pre>
 
 
@@ -674,7 +674,7 @@ resource published under the <code>designated_dealer_address</code>.
 * <code><a href="AccountAdministrationScripts.md#0x1_AccountAdministrationScripts_rotate_dual_attestation_info">AccountAdministrationScripts::rotate_dual_attestation_info</a></code>
 
 
-<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="TreasuryComplianceScripts.md#0x1_TreasuryComplianceScripts_tiered_mint">tiered_mint</a>&lt;CoinType&gt;(tc_account: signer, sliding_nonce: u64, designated_dealer_address: address, mint_amount: u64, tier_index: u64)
+<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="TreasuryComplianceScripts.md#0x1_TreasuryComplianceScripts_tiered_mint">tiered_mint</a>&lt;CoinType: store&gt;(tc_account: signer, sliding_nonce: u64, designated_dealer_address: address, mint_amount: u64, tier_index: u64)
 </code></pre>
 
 
@@ -1045,7 +1045,7 @@ is given by <code>new_exchange_rate_numerator/new_exchange_rate_denominator</cod
 * <code><a href="TreasuryComplianceScripts.md#0x1_TreasuryComplianceScripts_update_minting_ability">TreasuryComplianceScripts::update_minting_ability</a></code>
 
 
-<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="TreasuryComplianceScripts.md#0x1_TreasuryComplianceScripts_update_exchange_rate">update_exchange_rate</a>&lt;Currency&gt;(tc_account: signer, sliding_nonce: u64, new_exchange_rate_numerator: u64, new_exchange_rate_denominator: u64)
+<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="TreasuryComplianceScripts.md#0x1_TreasuryComplianceScripts_update_exchange_rate">update_exchange_rate</a>&lt;Currency: store&gt;(tc_account: signer, sliding_nonce: u64, new_exchange_rate_numerator: u64, new_exchange_rate_denominator: u64)
 </code></pre>
 
 
@@ -1165,7 +1165,7 @@ This transaction needs to be sent by the Treasury Compliance account.
 * <code><a href="TreasuryComplianceScripts.md#0x1_TreasuryComplianceScripts_update_exchange_rate">TreasuryComplianceScripts::update_exchange_rate</a></code>
 
 
-<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="TreasuryComplianceScripts.md#0x1_TreasuryComplianceScripts_update_minting_ability">update_minting_ability</a>&lt;Currency&gt;(tc_account: signer, allow_minting: bool)
+<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="TreasuryComplianceScripts.md#0x1_TreasuryComplianceScripts_update_minting_ability">update_minting_ability</a>&lt;Currency: store&gt;(tc_account: signer, allow_minting: bool)
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/VASP.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/VASP.md
@@ -311,7 +311,7 @@ Return <code><b>true</b></code> if <code>addr</code> is a parent or child VASP w
 Aborts if <code>addr</code> is not a VASP
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="VASP.md#0x1_VASP_has_account_limits">has_account_limits</a>&lt;CoinType&gt;(addr: address): bool
+<pre><code><b>public</b> <b>fun</b> <a href="VASP.md#0x1_VASP_has_account_limits">has_account_limits</a>&lt;CoinType: store&gt;(addr: address): bool
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/XDX.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/XDX.md
@@ -223,7 +223,7 @@ Moreover, only the TreasuryCompliance role can create Preburn.
 Returns true if <code>CoinType</code> is <code><a href="XDX.md#0x1_XDX_XDX">XDX::XDX</a></code>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="XDX.md#0x1_XDX_is_xdx">is_xdx</a>&lt;CoinType&gt;(): bool
+<pre><code><b>public</b> <b>fun</b> <a href="XDX.md#0x1_XDX_is_xdx">is_xdx</a>&lt;CoinType: store&gt;(): bool
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/scripts/script_documentation.md
+++ b/language/diem-framework/releases/artifacts/current/docs/scripts/script_documentation.md
@@ -794,7 +794,7 @@ This is emitted on the new Child VASPS's <code><a href="../../../../../releases/
 * <code><a href="script_documentation.md#0x1_AccountAdministrationScripts_create_recovery_address">AccountAdministrationScripts::create_recovery_address</a></code>
 
 
-<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="script_documentation.md#0x1_AccountCreationScripts_create_child_vasp_account">create_child_vasp_account</a>&lt;CoinType&gt;(parent_vasp: signer, child_address: address, auth_key_prefix: vector&lt;u8&gt;, add_all_currencies: bool, child_initial_balance: u64)
+<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="script_documentation.md#0x1_AccountCreationScripts_create_child_vasp_account">create_child_vasp_account</a>&lt;CoinType: store&gt;(parent_vasp: signer, child_address: address, auth_key_prefix: vector&lt;u8&gt;, add_all_currencies: bool, child_initial_balance: u64)
 </code></pre>
 
 
@@ -1264,7 +1264,7 @@ and the <code>rold_id</code> field being <code><a href="../../../../../releases/
 * <code><a href="script_documentation.md#0x1_AccountAdministrationScripts_rotate_dual_attestation_info">AccountAdministrationScripts::rotate_dual_attestation_info</a></code>
 
 
-<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="script_documentation.md#0x1_AccountCreationScripts_create_parent_vasp_account">create_parent_vasp_account</a>&lt;CoinType&gt;(tc_account: signer, sliding_nonce: u64, new_account_address: address, auth_key_prefix: vector&lt;u8&gt;, human_name: vector&lt;u8&gt;, add_all_currencies: bool)
+<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="script_documentation.md#0x1_AccountCreationScripts_create_parent_vasp_account">create_parent_vasp_account</a>&lt;CoinType: store&gt;(tc_account: signer, sliding_nonce: u64, new_account_address: address, auth_key_prefix: vector&lt;u8&gt;, human_name: vector&lt;u8&gt;, add_all_currencies: bool)
 </code></pre>
 
 
@@ -1406,7 +1406,7 @@ and the <code>rold_id</code> field being <code><a href="../../../../../releases/
 * <code><a href="script_documentation.md#0x1_AccountAdministrationScripts_rotate_dual_attestation_info">AccountAdministrationScripts::rotate_dual_attestation_info</a></code>
 
 
-<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="script_documentation.md#0x1_AccountCreationScripts_create_designated_dealer">create_designated_dealer</a>&lt;Currency&gt;(tc_account: signer, sliding_nonce: u64, addr: address, auth_key_prefix: vector&lt;u8&gt;, human_name: vector&lt;u8&gt;, add_all_currencies: bool)
+<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="script_documentation.md#0x1_AccountCreationScripts_create_designated_dealer">create_designated_dealer</a>&lt;Currency: store&gt;(tc_account: signer, sliding_nonce: u64, addr: address, auth_key_prefix: vector&lt;u8&gt;, human_name: vector&lt;u8&gt;, add_all_currencies: bool)
 </code></pre>
 
 
@@ -1549,7 +1549,7 @@ already have a <code><a href="../../../../../releases/artifacts/current/docs/mod
 * <code><a href="script_documentation.md#0x1_PaymentScripts_peer_to_peer_with_metadata">PaymentScripts::peer_to_peer_with_metadata</a></code>
 
 
-<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="script_documentation.md#0x1_AccountAdministrationScripts_add_currency_to_account">add_currency_to_account</a>&lt;Currency&gt;(account: signer)
+<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="script_documentation.md#0x1_AccountAdministrationScripts_add_currency_to_account">add_currency_to_account</a>&lt;Currency: store&gt;(account: signer)
 </code></pre>
 
 
@@ -2674,7 +2674,7 @@ Successful execution of this script emits two events:
 * <code><a href="script_documentation.md#0x1_AccountAdministrationScripts_add_currency_to_account">AccountAdministrationScripts::add_currency_to_account</a></code>
 
 
-<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="script_documentation.md#0x1_PaymentScripts_peer_to_peer_with_metadata">peer_to_peer_with_metadata</a>&lt;Currency&gt;(payer: signer, payee: address, amount: u64, metadata: vector&lt;u8&gt;, metadata_signature: vector&lt;u8&gt;)
+<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="script_documentation.md#0x1_PaymentScripts_peer_to_peer_with_metadata">peer_to_peer_with_metadata</a>&lt;Currency: store&gt;(payer: signer, payee: address, amount: u64, metadata: vector&lt;u8&gt;, metadata_signature: vector&lt;u8&gt;)
 </code></pre>
 
 
@@ -3710,7 +3710,7 @@ being <code>preburn_address</code>.
 * <code><a href="script_documentation.md#0x1_TreasuryComplianceScripts_preburn">TreasuryComplianceScripts::preburn</a></code>
 
 
-<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="script_documentation.md#0x1_TreasuryComplianceScripts_cancel_burn_with_amount">cancel_burn_with_amount</a>&lt;Token&gt;(account: signer, preburn_address: address, amount: u64)
+<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="script_documentation.md#0x1_TreasuryComplianceScripts_cancel_burn_with_amount">cancel_burn_with_amount</a>&lt;Token: store&gt;(account: signer, preburn_address: address, amount: u64)
 </code></pre>
 
 
@@ -3867,7 +3867,7 @@ held in the <code><a href="../../../../../releases/artifacts/current/docs/module
 * <code><a href="script_documentation.md#0x1_TreasuryComplianceScripts_preburn">TreasuryComplianceScripts::preburn</a></code>
 
 
-<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="script_documentation.md#0x1_TreasuryComplianceScripts_burn_with_amount">burn_with_amount</a>&lt;Token&gt;(account: signer, sliding_nonce: u64, preburn_address: address, amount: u64)
+<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="script_documentation.md#0x1_TreasuryComplianceScripts_burn_with_amount">burn_with_amount</a>&lt;Token: store&gt;(account: signer, sliding_nonce: u64, preburn_address: address, amount: u64)
 </code></pre>
 
 
@@ -3989,7 +3989,7 @@ handle with the <code>payee</code> and <code>payer</code> fields being <code>acc
 * <code><a href="script_documentation.md#0x1_TreasuryComplianceScripts_burn_txn_fees">TreasuryComplianceScripts::burn_txn_fees</a></code>
 
 
-<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="script_documentation.md#0x1_TreasuryComplianceScripts_preburn">preburn</a>&lt;Token&gt;(account: signer, amount: u64)
+<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="script_documentation.md#0x1_TreasuryComplianceScripts_preburn">preburn</a>&lt;Token: store&gt;(account: signer, amount: u64)
 </code></pre>
 
 
@@ -4114,7 +4114,7 @@ held in the <code><a href="../../../../../releases/artifacts/current/docs/module
 * <code><a href="script_documentation.md#0x1_TreasuryComplianceScripts_cancel_burn_with_amount">TreasuryComplianceScripts::cancel_burn_with_amount</a></code>
 
 
-<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="script_documentation.md#0x1_TreasuryComplianceScripts_burn_txn_fees">burn_txn_fees</a>&lt;CoinType&gt;(tc_account: signer)
+<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="script_documentation.md#0x1_TreasuryComplianceScripts_burn_txn_fees">burn_txn_fees</a>&lt;CoinType: store&gt;(tc_account: signer)
 </code></pre>
 
 
@@ -4214,7 +4214,7 @@ resource published under the <code>designated_dealer_address</code>.
 * <code><a href="script_documentation.md#0x1_AccountAdministrationScripts_rotate_dual_attestation_info">AccountAdministrationScripts::rotate_dual_attestation_info</a></code>
 
 
-<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="script_documentation.md#0x1_TreasuryComplianceScripts_tiered_mint">tiered_mint</a>&lt;CoinType&gt;(tc_account: signer, sliding_nonce: u64, designated_dealer_address: address, mint_amount: u64, tier_index: u64)
+<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="script_documentation.md#0x1_TreasuryComplianceScripts_tiered_mint">tiered_mint</a>&lt;CoinType: store&gt;(tc_account: signer, sliding_nonce: u64, designated_dealer_address: address, mint_amount: u64, tier_index: u64)
 </code></pre>
 
 
@@ -4585,7 +4585,7 @@ is given by <code>new_exchange_rate_numerator/new_exchange_rate_denominator</cod
 * <code><a href="script_documentation.md#0x1_TreasuryComplianceScripts_update_minting_ability">TreasuryComplianceScripts::update_minting_ability</a></code>
 
 
-<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="script_documentation.md#0x1_TreasuryComplianceScripts_update_exchange_rate">update_exchange_rate</a>&lt;Currency&gt;(tc_account: signer, sliding_nonce: u64, new_exchange_rate_numerator: u64, new_exchange_rate_denominator: u64)
+<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="script_documentation.md#0x1_TreasuryComplianceScripts_update_exchange_rate">update_exchange_rate</a>&lt;Currency: store&gt;(tc_account: signer, sliding_nonce: u64, new_exchange_rate_numerator: u64, new_exchange_rate_denominator: u64)
 </code></pre>
 
 
@@ -4705,7 +4705,7 @@ This transaction needs to be sent by the Treasury Compliance account.
 * <code><a href="script_documentation.md#0x1_TreasuryComplianceScripts_update_exchange_rate">TreasuryComplianceScripts::update_exchange_rate</a></code>
 
 
-<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="script_documentation.md#0x1_TreasuryComplianceScripts_update_minting_ability">update_minting_ability</a>&lt;Currency&gt;(tc_account: signer, allow_minting: bool)
+<pre><code><b>public</b>(<b>script</b>) <b>fun</b> <a href="script_documentation.md#0x1_TreasuryComplianceScripts_update_minting_ability">update_minting_ability</a>&lt;Currency: store&gt;(tc_account: signer, allow_minting: bool)
 </code></pre>
 
 

--- a/language/move-model/src/builder/module_builder.rs
+++ b/language/move-model/src/builder/module_builder.rs
@@ -19,7 +19,7 @@ use move_lang::{
 };
 use vm::{
     access::ModuleAccess,
-    file_format::{Constant, FunctionDefinitionIndex, StructDefinitionIndex},
+    file_format::{AbilitySet, Constant, FunctionDefinitionIndex, StructDefinitionIndex},
     views::{FunctionHandleView, StructHandleView},
     CompiledModule,
 };
@@ -36,9 +36,9 @@ use crate::{
     },
     exp_rewriter::{ExpRewriter, RewriteTarget},
     model::{
-        FieldId, FunId, FunctionData, Loc, ModuleId, MoveIrLoc, NamedConstantData, NamedConstantId,
-        NodeId, QualifiedId, SchemaId, SpecFunId, SpecVarId, StructData, StructId, TypeConstraint,
-        TypeParameter, SCRIPT_BYTECODE_FUN_NAME,
+        AbilityConstraint, FieldId, FunId, FunctionData, Loc, ModuleId, MoveIrLoc,
+        NamedConstantData, NamedConstantId, NodeId, QualifiedId, SchemaId, SpecFunId, SpecVarId,
+        StructData, StructId, TypeParameter, SCRIPT_BYTECODE_FUN_NAME,
     },
     pragmas::{
         is_pragma_valid_for_block, is_property_valid_for_condition, CONDITION_DEACTIVATED_PROP,
@@ -2669,7 +2669,9 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                         entry
                             .type_params
                             .iter()
-                            .map(|(name, _)| TypeParameter(*name, TypeConstraint::None))
+                            .map(|(name, _)| {
+                                TypeParameter(*name, AbilityConstraint(AbilitySet::EMPTY))
+                            })
                             .collect_vec(),
                     )
                 }

--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -1982,7 +1982,7 @@ impl<'env> StructEnv<'env> {
             .map(|(i, k)| {
                 TypeParameter(
                     self.module_env.env.symbol_pool.make(&format!("$tv{}", i)),
-                    TypeConstraint::from(*k),
+                    AbilityConstraint(*k),
                 )
             })
             .collect_vec()
@@ -2009,7 +2009,7 @@ impl<'env> StructEnv<'env> {
                     .unwrap_or_else(|| format!("unknown#{}", i));
                 TypeParameter(
                     self.module_env.env.symbol_pool.make(&name),
-                    TypeConstraint::from(*k),
+                    AbilityConstraint(*k),
                 )
             })
             .collect_vec()
@@ -2177,27 +2177,10 @@ impl<'env> NamedConstantEnv<'env> {
 
 /// Represents a type parameter.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct TypeParameter(pub Symbol, pub TypeConstraint);
+pub struct TypeParameter(pub Symbol, pub AbilityConstraint);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum TypeConstraint {
-    None,
-    Copyable,
-    Resource,
-}
-
-impl TypeConstraint {
-    // TODO(tmn) migrate to abilities
-    fn from(abs: AbilitySet) -> Self {
-        if abs.has_key() {
-            TypeConstraint::Resource
-        } else if abs.has_copy() | abs.has_drop() {
-            TypeConstraint::Copyable
-        } else {
-            TypeConstraint::None
-        }
-    }
-}
+pub struct AbilityConstraint(pub AbilitySet);
 
 /// Represents a parameter.
 #[derive(Debug, Clone)]
@@ -2546,7 +2529,7 @@ impl<'env> FunctionEnv<'env> {
             .map(|(i, k)| {
                 TypeParameter(
                     self.module_env.env.symbol_pool.make(&format!("$tv{}", i)),
-                    TypeConstraint::from(*k),
+                    AbilityConstraint(*k),
                 )
             })
             .collect_vec()
@@ -2570,7 +2553,7 @@ impl<'env> FunctionEnv<'env> {
                     .unwrap_or_else(|| format!("unknown#{}", i));
                 TypeParameter(
                     self.module_env.env.symbol_pool.make(&name),
-                    TypeConstraint::from(*k),
+                    AbilityConstraint(*k),
                 )
             })
             .collect_vec()

--- a/language/move-prover/docgen/src/docgen.rs
+++ b/language/move-prover/docgen/src/docgen.rs
@@ -12,7 +12,7 @@ use move_model::{
     emit, emitln,
     model::{
         FunId, FunctionEnv, GlobalEnv, Loc, ModuleEnv, ModuleId, NamedConstantEnv, Parameter,
-        QualifiedId, StructEnv, TypeConstraint, TypeParameter,
+        QualifiedId, StructEnv, TypeParameter,
     },
     symbol::Symbol,
     ty::TypeDisplayContext,
@@ -1741,15 +1741,29 @@ impl<'env> Docgen<'env> {
 
     /// Display a type parameter.
     fn type_parameter_display(&self, tp: &TypeParameter) -> String {
-        format!(
-            "{}{}",
-            self.name_string(tp.0),
-            match tp.1 {
-                TypeConstraint::None => "",
-                TypeConstraint::Resource => ": resource",
-                TypeConstraint::Copyable => ": copyable",
-            }
-        )
+        let mut ability_constraints = vec![];
+        let ability_set = tp.1 .0;
+        if ability_set.has_copy() {
+            ability_constraints.push("copy");
+        }
+        if ability_set.has_drop() {
+            ability_constraints.push("drop");
+        }
+        if ability_set.has_store() {
+            ability_constraints.push("store");
+        }
+        if ability_set.has_key() {
+            ability_constraints.push("key");
+        }
+        if ability_constraints.is_empty() {
+            self.name_string(tp.0).to_string()
+        } else {
+            format!(
+                "{}: {}",
+                self.name_string(tp.0),
+                ability_constraints.join(", ")
+            )
+        }
     }
 
     /// Display a type parameter list.

--- a/language/move-prover/docgen/tests/sources/DiemTest.spec_inline.md
+++ b/language/move-prover/docgen/tests/sources/DiemTest.spec_inline.md
@@ -733,7 +733,7 @@ The caller must pass a <code>TreasuryComplianceRole</code> capability.
 TODO (dd): I think there is a multiple signer problem here.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_publish_burn_capability">publish_burn_capability</a>&lt;CoinType&gt;(account: &signer, cap: <a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;, tc_account: &signer)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_publish_burn_capability">publish_burn_capability</a>&lt;CoinType: store&gt;(account: &signer, cap: <a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;, tc_account: &signer)
 </code></pre>
 
 
@@ -766,7 +766,7 @@ Mints <code>amount</code> coins. The <code>account</code> must hold a
 to be successful, and will fail with <code>MISSING_DATA</code> otherwise.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_mint">mint</a>&lt;CoinType&gt;(account: &signer, value: u64): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_mint">mint</a>&lt;CoinType: store&gt;(account: &signer, value: u64): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -811,7 +811,7 @@ Calls to this functions will fail if the <code>account</code> does not have a
 published <code><a href="DiemTest.md#0x1_DiemTest_BurnCapability">BurnCapability</a></code> for the <code>CoinType</code> published under it.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_burn">burn</a>&lt;CoinType&gt;(account: &signer, preburn_address: address)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_burn">burn</a>&lt;CoinType: store&gt;(account: &signer, preburn_address: address)
 </code></pre>
 
 
@@ -859,7 +859,7 @@ Calls to this will fail if the sender does not have a published
 outstanding in the <code><a href="DiemTest.md#0x1_DiemTest_Preburn">Preburn</a></code> resource under <code>preburn_address</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_cancel_burn">cancel_burn</a>&lt;CoinType&gt;(account: &signer, preburn_address: address): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_cancel_burn">cancel_burn</a>&lt;CoinType: store&gt;(account: &signer, preburn_address: address): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -893,7 +893,7 @@ the treasury compliance account or the <code><a href="">0x1::XDX</a></code> modu
 reference.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_mint_with_capability">mint_with_capability</a>&lt;CoinType&gt;(value: u64, _capability: &<a href="DiemTest.md#0x1_DiemTest_MintCapability">DiemTest::MintCapability</a>&lt;CoinType&gt;): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_mint_with_capability">mint_with_capability</a>&lt;CoinType: store&gt;(value: u64, _capability: &<a href="DiemTest.md#0x1_DiemTest_MintCapability">DiemTest::MintCapability</a>&lt;CoinType&gt;): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -985,7 +985,7 @@ the <code>preburn_events</code> event stream in the <code><a href="DiemTest.md#0
 <code>synthetic</code> then no <code><a href="DiemTest.md#0x1_DiemTest_PreburnEvent">PreburnEvent</a></code> event will be emitted.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_preburn_with_resource">preburn_with_resource</a>&lt;CoinType&gt;(coin: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, preburn: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Preburn">DiemTest::Preburn</a>&lt;CoinType&gt;, preburn_address: address)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_preburn_with_resource">preburn_with_resource</a>&lt;CoinType: store&gt;(coin: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, preburn: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Preburn">DiemTest::Preburn</a>&lt;CoinType&gt;, preburn_address: address)
 </code></pre>
 
 
@@ -1073,7 +1073,7 @@ the <code>preburn_events</code> event stream in the <code><a href="DiemTest.md#0
 Create a <code><a href="DiemTest.md#0x1_DiemTest_Preburn">Preburn</a>&lt;CoinType&gt;</code> resource
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_create_preburn">create_preburn</a>&lt;CoinType&gt;(tc_account: &signer): <a href="DiemTest.md#0x1_DiemTest_Preburn">DiemTest::Preburn</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_create_preburn">create_preburn</a>&lt;CoinType: store&gt;(tc_account: &signer): <a href="DiemTest.md#0x1_DiemTest_Preburn">DiemTest::Preburn</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -1107,7 +1107,7 @@ time, and the association TC account <code>creator</code> (at <code><a href="_TR
 this resource for the designated dealer.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_publish_preburn_to_account">publish_preburn_to_account</a>&lt;CoinType&gt;(account: &signer, tc_account: &signer)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_publish_preburn_to_account">publish_preburn_to_account</a>&lt;CoinType: store&gt;(account: &signer, tc_account: &signer)
 </code></pre>
 
 
@@ -1139,7 +1139,7 @@ Calls to this function will fail if <code>account</code> does not have a
 <code><a href="DiemTest.md#0x1_DiemTest_Preburn">Preburn</a>&lt;CoinType&gt;</code> resource published under it.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_preburn_to">preburn_to</a>&lt;CoinType&gt;(account: &signer, coin: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_preburn_to">preburn_to</a>&lt;CoinType: store&gt;(account: &signer, coin: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -1186,7 +1186,7 @@ resource under <code>preburn_address</code>, or, if the preburn to_burn area for
 <code>CoinType</code> is empty (error code 7).
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_burn_with_capability">burn_with_capability</a>&lt;CoinType&gt;(preburn_address: address, capability: &<a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_burn_with_capability">burn_with_capability</a>&lt;CoinType: store&gt;(preburn_address: address, capability: &<a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -1238,7 +1238,7 @@ resource under <code>preburn_address</code>, or, if the preburn to_burn area for
 <code>CoinType</code> is empty (error code 7).
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_burn_with_resource_cap">burn_with_resource_cap</a>&lt;CoinType&gt;(preburn: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Preburn">DiemTest::Preburn</a>&lt;CoinType&gt;, preburn_address: address, _capability: &<a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_burn_with_resource_cap">burn_with_resource_cap</a>&lt;CoinType: store&gt;(preburn: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Preburn">DiemTest::Preburn</a>&lt;CoinType&gt;, preburn_address: address, _capability: &<a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -1333,7 +1333,7 @@ This function can only be called by the holder of a
 at <code>preburn_address</code> does not contain a pending burn request.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_cancel_burn_with_capability">cancel_burn_with_capability</a>&lt;CoinType&gt;(preburn_address: address, _capability: &<a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_cancel_burn_with_capability">cancel_burn_with_capability</a>&lt;CoinType: store&gt;(preburn_address: address, _capability: &<a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -1384,7 +1384,7 @@ Calls to this function will fail if <code>account</code> does  not have a
 published <code><a href="DiemTest.md#0x1_DiemTest_BurnCapability">BurnCapability</a>&lt;CoinType&gt;</code> resource at the top-level.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_remove_burn_capability">remove_burn_capability</a>&lt;CoinType&gt;(account: &signer): <a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_remove_burn_capability">remove_burn_capability</a>&lt;CoinType: store&gt;(account: &signer): <a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -1413,7 +1413,7 @@ preburn requests across all preburn resources for the <code>CoinType</code>
 currency).
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_preburn_value">preburn_value</a>&lt;CoinType&gt;(): u64
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_preburn_value">preburn_value</a>&lt;CoinType: store&gt;(): u64
 </code></pre>
 
 
@@ -1439,7 +1439,7 @@ Create a new <code><a href="">Diem</a>&lt;CoinType&gt;</code> with a value of <c
 this and it will be successful as long as <code>CoinType</code> is a registered currency.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_zero">zero</a>&lt;CoinType&gt;(): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_zero">zero</a>&lt;CoinType: store&gt;(): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -1467,7 +1467,7 @@ represented in the base units for the currency represented by
 <code>CoinType</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_value">value</a>&lt;CoinType&gt;(coin: &<a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;): u64
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_value">value</a>&lt;CoinType: store&gt;(coin: &<a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;): u64
 </code></pre>
 
 
@@ -1494,7 +1494,7 @@ remaining balance of the passed in <code>coin</code>, along with another coin
 with value equal to <code>amount</code>. Calls will fail if <code>amount &gt; <a href="_value">Diem::value</a>(&coin)</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_split">split</a>&lt;CoinType&gt;(coin: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, amount: u64): (<a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_split">split</a>&lt;CoinType: store&gt;(coin: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, amount: u64): (<a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -1538,7 +1538,7 @@ Calls will abort if the passed-in <code>amount</code> is greater than the
 value of the passed-in <code>coin</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_withdraw">withdraw</a>&lt;CoinType&gt;(coin: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, amount: u64): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_withdraw">withdraw</a>&lt;CoinType: store&gt;(coin: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, amount: u64): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -1581,7 +1581,7 @@ Return a <code><a href="">Diem</a>&lt;CoinType&gt;</code> worth <code>coin.value
 zero. Does not abort.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_withdraw_all">withdraw_all</a>&lt;CoinType&gt;(coin: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_withdraw_all">withdraw_all</a>&lt;CoinType: store&gt;(coin: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -1621,7 +1621,7 @@ zero. Does not abort.
 and returns a new coin whose value is equal to the sum of the two inputs.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_join">join</a>&lt;CoinType&gt;(xus: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, coin2: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_join">join</a>&lt;CoinType: store&gt;(xus: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, coin2: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -1662,7 +1662,7 @@ The coin passed in by reference will have a value equal to the sum of the two co
 The <code>check</code> coin is consumed in the process
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_deposit">deposit</a>&lt;CoinType&gt;(coin: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, check: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_deposit">deposit</a>&lt;CoinType: store&gt;(coin: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, check: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -1738,7 +1738,7 @@ adds the currency to the set of <code><a href="">RegisteredCurrencies</a></code>
 <code><a href="DiemTest.md#0x1_DiemTest_MintCapability">MintCapability</a>&lt;CoinType&gt;</code> and <code><a href="DiemTest.md#0x1_DiemTest_BurnCapability">BurnCapability</a>&lt;CoinType&gt;</code> resources.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_register_currency">register_currency</a>&lt;CoinType&gt;(dr_account: &signer, to_xdx_exchange_rate: <a href="_FixedPoint32">FixedPoint32::FixedPoint32</a>, is_synthetic: bool, scaling_factor: u64, fractional_part: u64, currency_code: vector&lt;u8&gt;): (<a href="DiemTest.md#0x1_DiemTest_MintCapability">DiemTest::MintCapability</a>&lt;CoinType&gt;, <a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_register_currency">register_currency</a>&lt;CoinType: store&gt;(dr_account: &signer, to_xdx_exchange_rate: <a href="_FixedPoint32">FixedPoint32::FixedPoint32</a>, is_synthetic: bool, scaling_factor: u64, fractional_part: u64, currency_code: vector&lt;u8&gt;): (<a href="DiemTest.md#0x1_DiemTest_MintCapability">DiemTest::MintCapability</a>&lt;CoinType&gt;, <a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -1818,7 +1818,7 @@ This code allows different currencies to have different treasury compliance
 accounts.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_register_SCS_currency">register_SCS_currency</a>&lt;CoinType&gt;(dr_account: &signer, tc_account: &signer, to_xdx_exchange_rate: <a href="_FixedPoint32">FixedPoint32::FixedPoint32</a>, scaling_factor: u64, fractional_part: u64, currency_code: vector&lt;u8&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_register_SCS_currency">register_SCS_currency</a>&lt;CoinType: store&gt;(dr_account: &signer, tc_account: &signer, to_xdx_exchange_rate: <a href="_FixedPoint32">FixedPoint32::FixedPoint32</a>, scaling_factor: u64, fractional_part: u64, currency_code: vector&lt;u8&gt;)
 </code></pre>
 
 
@@ -1876,7 +1876,7 @@ accounts.
 Returns the total amount of currency minted of type <code>CoinType</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_market_cap">market_cap</a>&lt;CoinType&gt;(): u128
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_market_cap">market_cap</a>&lt;CoinType: store&gt;(): u128
 </code></pre>
 
 
@@ -1904,7 +1904,7 @@ This should only be used where a _rough_ approximation of the exchange
 rate is needed.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_approx_xdx_for_value">approx_xdx_for_value</a>&lt;FromCoinType&gt;(from_value: u64): u64
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_approx_xdx_for_value">approx_xdx_for_value</a>&lt;FromCoinType: store&gt;(from_value: u64): u64
 </code></pre>
 
 
@@ -1933,7 +1933,7 @@ This should only be used where a rough approximation of the exchange
 rate is needed.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_approx_xdx_for_coin">approx_xdx_for_coin</a>&lt;FromCoinType&gt;(coin: &<a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;FromCoinType&gt;): u64
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_approx_xdx_for_coin">approx_xdx_for_coin</a>&lt;FromCoinType: store&gt;(coin: &<a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;FromCoinType&gt;): u64
 </code></pre>
 
 
@@ -1961,7 +1961,7 @@ Returns <code><b>true</b></code> if the type <code>CoinType</code> is a register
 Returns <code><b>false</b></code> otherwise.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_is_currency">is_currency</a>&lt;CoinType&gt;(): bool
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_is_currency">is_currency</a>&lt;CoinType: store&gt;(): bool
 </code></pre>
 
 
@@ -1985,7 +1985,7 @@ Returns <code><b>false</b></code> otherwise.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_is_SCS_currency">is_SCS_currency</a>&lt;CoinType&gt;(): bool
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_is_SCS_currency">is_SCS_currency</a>&lt;CoinType: store&gt;(): bool
 </code></pre>
 
 
@@ -2012,7 +2012,7 @@ Returns <code><b>true</b></code> if <code>CoinType</code> is a synthetic currenc
 its <code><a href="DiemTest.md#0x1_DiemTest_CurrencyInfo">CurrencyInfo</a></code>. Returns <code><b>false</b></code> otherwise.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_is_synthetic_currency">is_synthetic_currency</a>&lt;CoinType&gt;(): bool
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_is_synthetic_currency">is_synthetic_currency</a>&lt;CoinType: store&gt;(): bool
 </code></pre>
 
 
@@ -2041,7 +2041,7 @@ Returns the scaling factor for the <code>CoinType</code> currency as defined
 in its <code><a href="DiemTest.md#0x1_DiemTest_CurrencyInfo">CurrencyInfo</a></code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_scaling_factor">scaling_factor</a>&lt;CoinType&gt;(): u64
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_scaling_factor">scaling_factor</a>&lt;CoinType: store&gt;(): u64
 </code></pre>
 
 
@@ -2068,7 +2068,7 @@ Returns the representable (i.e. real-world) fractional part for the
 <code>CoinType</code> currency as defined in its <code><a href="DiemTest.md#0x1_DiemTest_CurrencyInfo">CurrencyInfo</a></code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_fractional_part">fractional_part</a>&lt;CoinType&gt;(): u64
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_fractional_part">fractional_part</a>&lt;CoinType: store&gt;(): u64
 </code></pre>
 
 
@@ -2095,7 +2095,7 @@ Returns the currency code for the registered currency as defined in
 its <code><a href="DiemTest.md#0x1_DiemTest_CurrencyInfo">CurrencyInfo</a></code> resource.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_currency_code">currency_code</a>&lt;CoinType&gt;(): vector&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_currency_code">currency_code</a>&lt;CoinType: store&gt;(): vector&lt;u8&gt;
 </code></pre>
 
 
@@ -2122,7 +2122,7 @@ Updates the <code>to_xdx_exchange_rate</code> held in the <code><a href="DiemTes
 <code>FromCoinType</code> to the new passed-in <code>xdx_exchange_rate</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_update_xdx_exchange_rate">update_xdx_exchange_rate</a>&lt;FromCoinType&gt;(tr_account: &signer, xdx_exchange_rate: <a href="_FixedPoint32">FixedPoint32::FixedPoint32</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_update_xdx_exchange_rate">update_xdx_exchange_rate</a>&lt;FromCoinType: store&gt;(tr_account: &signer, xdx_exchange_rate: <a href="_FixedPoint32">FixedPoint32::FixedPoint32</a>)
 </code></pre>
 
 
@@ -2161,7 +2161,7 @@ Updates the <code>to_xdx_exchange_rate</code> held in the <code><a href="DiemTes
 Returns the (rough) exchange rate between <code>CoinType</code> and <code><a href="">XDX</a></code>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_xdx_exchange_rate">xdx_exchange_rate</a>&lt;CoinType&gt;(): <a href="_FixedPoint32">FixedPoint32::FixedPoint32</a>
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_xdx_exchange_rate">xdx_exchange_rate</a>&lt;CoinType: store&gt;(): <a href="_FixedPoint32">FixedPoint32::FixedPoint32</a>
 </code></pre>
 
 
@@ -2193,7 +2193,7 @@ disallowed until it is turned back on via this function. All coins
 start out in the default state of <code>can_mint = <b>true</b></code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_update_minting_ability">update_minting_ability</a>&lt;CoinType&gt;(tr_account: &signer, can_mint: bool)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_update_minting_ability">update_minting_ability</a>&lt;CoinType: store&gt;(tr_account: &signer, can_mint: bool)
 </code></pre>
 
 
@@ -2225,7 +2225,7 @@ start out in the default state of <code>can_mint = <b>true</b></code>.
 Asserts that <code>CoinType</code> is a registered currency.
 
 
-<pre><code><b>fun</b> <a href="DiemTest.md#0x1_DiemTest_assert_is_currency">assert_is_currency</a>&lt;CoinType&gt;()
+<pre><code><b>fun</b> <a href="DiemTest.md#0x1_DiemTest_assert_is_currency">assert_is_currency</a>&lt;CoinType: store&gt;()
 </code></pre>
 
 
@@ -2249,7 +2249,7 @@ Asserts that <code>CoinType</code> is a registered currency.
 
 
 
-<pre><code><b>fun</b> <a href="DiemTest.md#0x1_DiemTest_assert_is_SCS_currency">assert_is_SCS_currency</a>&lt;CoinType&gt;()
+<pre><code><b>fun</b> <a href="DiemTest.md#0x1_DiemTest_assert_is_SCS_currency">assert_is_SCS_currency</a>&lt;CoinType: store&gt;()
 </code></pre>
 
 

--- a/language/move-prover/docgen/tests/sources/DiemTest.spec_inline_no_fold.md
+++ b/language/move-prover/docgen/tests/sources/DiemTest.spec_inline_no_fold.md
@@ -694,7 +694,7 @@ The caller must pass a <code>TreasuryComplianceRole</code> capability.
 TODO (dd): I think there is a multiple signer problem here.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_publish_burn_capability">publish_burn_capability</a>&lt;CoinType&gt;(account: &signer, cap: <a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;, tc_account: &signer)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_publish_burn_capability">publish_burn_capability</a>&lt;CoinType: store&gt;(account: &signer, cap: <a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;, tc_account: &signer)
 </code></pre>
 
 
@@ -724,7 +724,7 @@ Mints <code>amount</code> coins. The <code>account</code> must hold a
 to be successful, and will fail with <code>MISSING_DATA</code> otherwise.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_mint">mint</a>&lt;CoinType&gt;(account: &signer, value: u64): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_mint">mint</a>&lt;CoinType: store&gt;(account: &signer, value: u64): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -763,7 +763,7 @@ Calls to this functions will fail if the <code>account</code> does not have a
 published <code><a href="DiemTest.md#0x1_DiemTest_BurnCapability">BurnCapability</a></code> for the <code>CoinType</code> published under it.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_burn">burn</a>&lt;CoinType&gt;(account: &signer, preburn_address: address)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_burn">burn</a>&lt;CoinType: store&gt;(account: &signer, preburn_address: address)
 </code></pre>
 
 
@@ -805,7 +805,7 @@ Calls to this will fail if the sender does not have a published
 outstanding in the <code><a href="DiemTest.md#0x1_DiemTest_Preburn">Preburn</a></code> resource under <code>preburn_address</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_cancel_burn">cancel_burn</a>&lt;CoinType&gt;(account: &signer, preburn_address: address): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_cancel_burn">cancel_burn</a>&lt;CoinType: store&gt;(account: &signer, preburn_address: address): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -836,7 +836,7 @@ the treasury compliance account or the <code><a href="">0x1::XDX</a></code> modu
 reference.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_mint_with_capability">mint_with_capability</a>&lt;CoinType&gt;(value: u64, _capability: &<a href="DiemTest.md#0x1_DiemTest_MintCapability">DiemTest::MintCapability</a>&lt;CoinType&gt;): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_mint_with_capability">mint_with_capability</a>&lt;CoinType: store&gt;(value: u64, _capability: &<a href="DiemTest.md#0x1_DiemTest_MintCapability">DiemTest::MintCapability</a>&lt;CoinType&gt;): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -922,7 +922,7 @@ the <code>preburn_events</code> event stream in the <code><a href="DiemTest.md#0
 <code>synthetic</code> then no <code><a href="DiemTest.md#0x1_DiemTest_PreburnEvent">PreburnEvent</a></code> event will be emitted.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_preburn_with_resource">preburn_with_resource</a>&lt;CoinType&gt;(coin: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, preburn: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Preburn">DiemTest::Preburn</a>&lt;CoinType&gt;, preburn_address: address)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_preburn_with_resource">preburn_with_resource</a>&lt;CoinType: store&gt;(coin: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, preburn: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Preburn">DiemTest::Preburn</a>&lt;CoinType&gt;, preburn_address: address)
 </code></pre>
 
 
@@ -1004,7 +1004,7 @@ the <code>preburn_events</code> event stream in the <code><a href="DiemTest.md#0
 Create a <code><a href="DiemTest.md#0x1_DiemTest_Preburn">Preburn</a>&lt;CoinType&gt;</code> resource
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_create_preburn">create_preburn</a>&lt;CoinType&gt;(tc_account: &signer): <a href="DiemTest.md#0x1_DiemTest_Preburn">DiemTest::Preburn</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_create_preburn">create_preburn</a>&lt;CoinType: store&gt;(tc_account: &signer): <a href="DiemTest.md#0x1_DiemTest_Preburn">DiemTest::Preburn</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -1035,7 +1035,7 @@ time, and the association TC account <code>creator</code> (at <code><a href="_TR
 this resource for the designated dealer.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_publish_preburn_to_account">publish_preburn_to_account</a>&lt;CoinType&gt;(account: &signer, tc_account: &signer)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_publish_preburn_to_account">publish_preburn_to_account</a>&lt;CoinType: store&gt;(account: &signer, tc_account: &signer)
 </code></pre>
 
 
@@ -1064,7 +1064,7 @@ Calls to this function will fail if <code>account</code> does not have a
 <code><a href="DiemTest.md#0x1_DiemTest_Preburn">Preburn</a>&lt;CoinType&gt;</code> resource published under it.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_preburn_to">preburn_to</a>&lt;CoinType&gt;(account: &signer, coin: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_preburn_to">preburn_to</a>&lt;CoinType: store&gt;(account: &signer, coin: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -1105,7 +1105,7 @@ resource under <code>preburn_address</code>, or, if the preburn to_burn area for
 <code>CoinType</code> is empty (error code 7).
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_burn_with_capability">burn_with_capability</a>&lt;CoinType&gt;(preburn_address: address, capability: &<a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_burn_with_capability">burn_with_capability</a>&lt;CoinType: store&gt;(preburn_address: address, capability: &<a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -1151,7 +1151,7 @@ resource under <code>preburn_address</code>, or, if the preburn to_burn area for
 <code>CoinType</code> is empty (error code 7).
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_burn_with_resource_cap">burn_with_resource_cap</a>&lt;CoinType&gt;(preburn: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Preburn">DiemTest::Preburn</a>&lt;CoinType&gt;, preburn_address: address, _capability: &<a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_burn_with_resource_cap">burn_with_resource_cap</a>&lt;CoinType: store&gt;(preburn: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Preburn">DiemTest::Preburn</a>&lt;CoinType&gt;, preburn_address: address, _capability: &<a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -1240,7 +1240,7 @@ This function can only be called by the holder of a
 at <code>preburn_address</code> does not contain a pending burn request.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_cancel_burn_with_capability">cancel_burn_with_capability</a>&lt;CoinType&gt;(preburn_address: address, _capability: &<a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_cancel_burn_with_capability">cancel_burn_with_capability</a>&lt;CoinType: store&gt;(preburn_address: address, _capability: &<a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -1288,7 +1288,7 @@ Calls to this function will fail if <code>account</code> does  not have a
 published <code><a href="DiemTest.md#0x1_DiemTest_BurnCapability">BurnCapability</a>&lt;CoinType&gt;</code> resource at the top-level.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_remove_burn_capability">remove_burn_capability</a>&lt;CoinType&gt;(account: &signer): <a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_remove_burn_capability">remove_burn_capability</a>&lt;CoinType: store&gt;(account: &signer): <a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -1314,7 +1314,7 @@ preburn requests across all preburn resources for the <code>CoinType</code>
 currency).
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_preburn_value">preburn_value</a>&lt;CoinType&gt;(): u64
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_preburn_value">preburn_value</a>&lt;CoinType: store&gt;(): u64
 </code></pre>
 
 
@@ -1337,7 +1337,7 @@ Create a new <code><a href="">Diem</a>&lt;CoinType&gt;</code> with a value of <c
 this and it will be successful as long as <code>CoinType</code> is a registered currency.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_zero">zero</a>&lt;CoinType&gt;(): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_zero">zero</a>&lt;CoinType: store&gt;(): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -1362,7 +1362,7 @@ represented in the base units for the currency represented by
 <code>CoinType</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_value">value</a>&lt;CoinType&gt;(coin: &<a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;): u64
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_value">value</a>&lt;CoinType: store&gt;(coin: &<a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;): u64
 </code></pre>
 
 
@@ -1386,7 +1386,7 @@ remaining balance of the passed in <code>coin</code>, along with another coin
 with value equal to <code>amount</code>. Calls will fail if <code>amount &gt; <a href="_value">Diem::value</a>(&coin)</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_split">split</a>&lt;CoinType&gt;(coin: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, amount: u64): (<a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_split">split</a>&lt;CoinType: store&gt;(coin: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, amount: u64): (<a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -1424,7 +1424,7 @@ Calls will abort if the passed-in <code>amount</code> is greater than the
 value of the passed-in <code>coin</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_withdraw">withdraw</a>&lt;CoinType&gt;(coin: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, amount: u64): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_withdraw">withdraw</a>&lt;CoinType: store&gt;(coin: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, amount: u64): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -1461,7 +1461,7 @@ Return a <code><a href="">Diem</a>&lt;CoinType&gt;</code> worth <code>coin.value
 zero. Does not abort.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_withdraw_all">withdraw_all</a>&lt;CoinType&gt;(coin: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_withdraw_all">withdraw_all</a>&lt;CoinType: store&gt;(coin: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -1495,7 +1495,7 @@ zero. Does not abort.
 and returns a new coin whose value is equal to the sum of the two inputs.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_join">join</a>&lt;CoinType&gt;(xus: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, coin2: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_join">join</a>&lt;CoinType: store&gt;(xus: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, coin2: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -1530,7 +1530,7 @@ The coin passed in by reference will have a value equal to the sum of the two co
 The <code>check</code> coin is consumed in the process
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_deposit">deposit</a>&lt;CoinType&gt;(coin: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, check: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_deposit">deposit</a>&lt;CoinType: store&gt;(coin: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, check: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -1597,7 +1597,7 @@ adds the currency to the set of <code><a href="">RegisteredCurrencies</a></code>
 <code><a href="DiemTest.md#0x1_DiemTest_MintCapability">MintCapability</a>&lt;CoinType&gt;</code> and <code><a href="DiemTest.md#0x1_DiemTest_BurnCapability">BurnCapability</a>&lt;CoinType&gt;</code> resources.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_register_currency">register_currency</a>&lt;CoinType&gt;(dr_account: &signer, to_xdx_exchange_rate: <a href="_FixedPoint32">FixedPoint32::FixedPoint32</a>, is_synthetic: bool, scaling_factor: u64, fractional_part: u64, currency_code: vector&lt;u8&gt;): (<a href="DiemTest.md#0x1_DiemTest_MintCapability">DiemTest::MintCapability</a>&lt;CoinType&gt;, <a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_register_currency">register_currency</a>&lt;CoinType: store&gt;(dr_account: &signer, to_xdx_exchange_rate: <a href="_FixedPoint32">FixedPoint32::FixedPoint32</a>, is_synthetic: bool, scaling_factor: u64, fractional_part: u64, currency_code: vector&lt;u8&gt;): (<a href="DiemTest.md#0x1_DiemTest_MintCapability">DiemTest::MintCapability</a>&lt;CoinType&gt;, <a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -1671,7 +1671,7 @@ This code allows different currencies to have different treasury compliance
 accounts.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_register_SCS_currency">register_SCS_currency</a>&lt;CoinType&gt;(dr_account: &signer, tc_account: &signer, to_xdx_exchange_rate: <a href="_FixedPoint32">FixedPoint32::FixedPoint32</a>, scaling_factor: u64, fractional_part: u64, currency_code: vector&lt;u8&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_register_SCS_currency">register_SCS_currency</a>&lt;CoinType: store&gt;(dr_account: &signer, tc_account: &signer, to_xdx_exchange_rate: <a href="_FixedPoint32">FixedPoint32::FixedPoint32</a>, scaling_factor: u64, fractional_part: u64, currency_code: vector&lt;u8&gt;)
 </code></pre>
 
 
@@ -1723,7 +1723,7 @@ accounts.
 Returns the total amount of currency minted of type <code>CoinType</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_market_cap">market_cap</a>&lt;CoinType&gt;(): u128
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_market_cap">market_cap</a>&lt;CoinType: store&gt;(): u128
 </code></pre>
 
 
@@ -1748,7 +1748,7 @@ This should only be used where a _rough_ approximation of the exchange
 rate is needed.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_approx_xdx_for_value">approx_xdx_for_value</a>&lt;FromCoinType&gt;(from_value: u64): u64
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_approx_xdx_for_value">approx_xdx_for_value</a>&lt;FromCoinType: store&gt;(from_value: u64): u64
 </code></pre>
 
 
@@ -1774,7 +1774,7 @@ This should only be used where a rough approximation of the exchange
 rate is needed.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_approx_xdx_for_coin">approx_xdx_for_coin</a>&lt;FromCoinType&gt;(coin: &<a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;FromCoinType&gt;): u64
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_approx_xdx_for_coin">approx_xdx_for_coin</a>&lt;FromCoinType: store&gt;(coin: &<a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;FromCoinType&gt;): u64
 </code></pre>
 
 
@@ -1799,7 +1799,7 @@ Returns <code><b>true</b></code> if the type <code>CoinType</code> is a register
 Returns <code><b>false</b></code> otherwise.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_is_currency">is_currency</a>&lt;CoinType&gt;(): bool
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_is_currency">is_currency</a>&lt;CoinType: store&gt;(): bool
 </code></pre>
 
 
@@ -1820,7 +1820,7 @@ Returns <code><b>false</b></code> otherwise.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_is_SCS_currency">is_SCS_currency</a>&lt;CoinType&gt;(): bool
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_is_SCS_currency">is_SCS_currency</a>&lt;CoinType: store&gt;(): bool
 </code></pre>
 
 
@@ -1844,7 +1844,7 @@ Returns <code><b>true</b></code> if <code>CoinType</code> is a synthetic currenc
 its <code><a href="DiemTest.md#0x1_DiemTest_CurrencyInfo">CurrencyInfo</a></code>. Returns <code><b>false</b></code> otherwise.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_is_synthetic_currency">is_synthetic_currency</a>&lt;CoinType&gt;(): bool
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_is_synthetic_currency">is_synthetic_currency</a>&lt;CoinType: store&gt;(): bool
 </code></pre>
 
 
@@ -1870,7 +1870,7 @@ Returns the scaling factor for the <code>CoinType</code> currency as defined
 in its <code><a href="DiemTest.md#0x1_DiemTest_CurrencyInfo">CurrencyInfo</a></code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_scaling_factor">scaling_factor</a>&lt;CoinType&gt;(): u64
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_scaling_factor">scaling_factor</a>&lt;CoinType: store&gt;(): u64
 </code></pre>
 
 
@@ -1894,7 +1894,7 @@ Returns the representable (i.e. real-world) fractional part for the
 <code>CoinType</code> currency as defined in its <code><a href="DiemTest.md#0x1_DiemTest_CurrencyInfo">CurrencyInfo</a></code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_fractional_part">fractional_part</a>&lt;CoinType&gt;(): u64
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_fractional_part">fractional_part</a>&lt;CoinType: store&gt;(): u64
 </code></pre>
 
 
@@ -1918,7 +1918,7 @@ Returns the currency code for the registered currency as defined in
 its <code><a href="DiemTest.md#0x1_DiemTest_CurrencyInfo">CurrencyInfo</a></code> resource.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_currency_code">currency_code</a>&lt;CoinType&gt;(): vector&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_currency_code">currency_code</a>&lt;CoinType: store&gt;(): vector&lt;u8&gt;
 </code></pre>
 
 
@@ -1942,7 +1942,7 @@ Updates the <code>to_xdx_exchange_rate</code> held in the <code><a href="DiemTes
 <code>FromCoinType</code> to the new passed-in <code>xdx_exchange_rate</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_update_xdx_exchange_rate">update_xdx_exchange_rate</a>&lt;FromCoinType&gt;(tr_account: &signer, xdx_exchange_rate: <a href="_FixedPoint32">FixedPoint32::FixedPoint32</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_update_xdx_exchange_rate">update_xdx_exchange_rate</a>&lt;FromCoinType: store&gt;(tr_account: &signer, xdx_exchange_rate: <a href="_FixedPoint32">FixedPoint32::FixedPoint32</a>)
 </code></pre>
 
 
@@ -1978,7 +1978,7 @@ Updates the <code>to_xdx_exchange_rate</code> held in the <code><a href="DiemTes
 Returns the (rough) exchange rate between <code>CoinType</code> and <code><a href="">XDX</a></code>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_xdx_exchange_rate">xdx_exchange_rate</a>&lt;CoinType&gt;(): <a href="_FixedPoint32">FixedPoint32::FixedPoint32</a>
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_xdx_exchange_rate">xdx_exchange_rate</a>&lt;CoinType: store&gt;(): <a href="_FixedPoint32">FixedPoint32::FixedPoint32</a>
 </code></pre>
 
 
@@ -2007,7 +2007,7 @@ disallowed until it is turned back on via this function. All coins
 start out in the default state of <code>can_mint = <b>true</b></code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_update_minting_ability">update_minting_ability</a>&lt;CoinType&gt;(tr_account: &signer, can_mint: bool)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_update_minting_ability">update_minting_ability</a>&lt;CoinType: store&gt;(tr_account: &signer, can_mint: bool)
 </code></pre>
 
 
@@ -2036,7 +2036,7 @@ start out in the default state of <code>can_mint = <b>true</b></code>.
 Asserts that <code>CoinType</code> is a registered currency.
 
 
-<pre><code><b>fun</b> <a href="DiemTest.md#0x1_DiemTest_assert_is_currency">assert_is_currency</a>&lt;CoinType&gt;()
+<pre><code><b>fun</b> <a href="DiemTest.md#0x1_DiemTest_assert_is_currency">assert_is_currency</a>&lt;CoinType: store&gt;()
 </code></pre>
 
 
@@ -2057,7 +2057,7 @@ Asserts that <code>CoinType</code> is a registered currency.
 
 
 
-<pre><code><b>fun</b> <a href="DiemTest.md#0x1_DiemTest_assert_is_SCS_currency">assert_is_SCS_currency</a>&lt;CoinType&gt;()
+<pre><code><b>fun</b> <a href="DiemTest.md#0x1_DiemTest_assert_is_SCS_currency">assert_is_SCS_currency</a>&lt;CoinType: store&gt;()
 </code></pre>
 
 

--- a/language/move-prover/docgen/tests/sources/DiemTest.spec_separate.md
+++ b/language/move-prover/docgen/tests/sources/DiemTest.spec_separate.md
@@ -734,7 +734,7 @@ The caller must pass a <code>TreasuryComplianceRole</code> capability.
 TODO (dd): I think there is a multiple signer problem here.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_publish_burn_capability">publish_burn_capability</a>&lt;CoinType&gt;(account: &signer, cap: <a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;, tc_account: &signer)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_publish_burn_capability">publish_burn_capability</a>&lt;CoinType: store&gt;(account: &signer, cap: <a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;, tc_account: &signer)
 </code></pre>
 
 
@@ -767,7 +767,7 @@ Mints <code>amount</code> coins. The <code>account</code> must hold a
 to be successful, and will fail with <code>MISSING_DATA</code> otherwise.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_mint">mint</a>&lt;CoinType&gt;(account: &signer, value: u64): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_mint">mint</a>&lt;CoinType: store&gt;(account: &signer, value: u64): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -798,7 +798,7 @@ Calls to this functions will fail if the <code>account</code> does not have a
 published <code><a href="DiemTest.md#0x1_DiemTest_BurnCapability">BurnCapability</a></code> for the <code>CoinType</code> published under it.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_burn">burn</a>&lt;CoinType&gt;(account: &signer, preburn_address: address)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_burn">burn</a>&lt;CoinType: store&gt;(account: &signer, preburn_address: address)
 </code></pre>
 
 
@@ -833,7 +833,7 @@ Calls to this will fail if the sender does not have a published
 outstanding in the <code><a href="DiemTest.md#0x1_DiemTest_Preburn">Preburn</a></code> resource under <code>preburn_address</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_cancel_burn">cancel_burn</a>&lt;CoinType&gt;(account: &signer, preburn_address: address): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_cancel_burn">cancel_burn</a>&lt;CoinType: store&gt;(account: &signer, preburn_address: address): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -867,7 +867,7 @@ the treasury compliance account or the <code><a href="">0x1::XDX</a></code> modu
 reference.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_mint_with_capability">mint_with_capability</a>&lt;CoinType&gt;(value: u64, _capability: &<a href="DiemTest.md#0x1_DiemTest_MintCapability">DiemTest::MintCapability</a>&lt;CoinType&gt;): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_mint_with_capability">mint_with_capability</a>&lt;CoinType: store&gt;(value: u64, _capability: &<a href="DiemTest.md#0x1_DiemTest_MintCapability">DiemTest::MintCapability</a>&lt;CoinType&gt;): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -917,7 +917,7 @@ the <code>preburn_events</code> event stream in the <code><a href="DiemTest.md#0
 <code>synthetic</code> then no <code><a href="DiemTest.md#0x1_DiemTest_PreburnEvent">PreburnEvent</a></code> event will be emitted.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_preburn_with_resource">preburn_with_resource</a>&lt;CoinType&gt;(coin: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, preburn: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Preburn">DiemTest::Preburn</a>&lt;CoinType&gt;, preburn_address: address)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_preburn_with_resource">preburn_with_resource</a>&lt;CoinType: store&gt;(coin: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, preburn: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Preburn">DiemTest::Preburn</a>&lt;CoinType&gt;, preburn_address: address)
 </code></pre>
 
 
@@ -963,7 +963,7 @@ the <code>preburn_events</code> event stream in the <code><a href="DiemTest.md#0
 Create a <code><a href="DiemTest.md#0x1_DiemTest_Preburn">Preburn</a>&lt;CoinType&gt;</code> resource
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_create_preburn">create_preburn</a>&lt;CoinType&gt;(tc_account: &signer): <a href="DiemTest.md#0x1_DiemTest_Preburn">DiemTest::Preburn</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_create_preburn">create_preburn</a>&lt;CoinType: store&gt;(tc_account: &signer): <a href="DiemTest.md#0x1_DiemTest_Preburn">DiemTest::Preburn</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -997,7 +997,7 @@ time, and the association TC account <code>creator</code> (at <code><a href="_TR
 this resource for the designated dealer.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_publish_preburn_to_account">publish_preburn_to_account</a>&lt;CoinType&gt;(account: &signer, tc_account: &signer)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_publish_preburn_to_account">publish_preburn_to_account</a>&lt;CoinType: store&gt;(account: &signer, tc_account: &signer)
 </code></pre>
 
 
@@ -1029,7 +1029,7 @@ Calls to this function will fail if <code>account</code> does not have a
 <code><a href="DiemTest.md#0x1_DiemTest_Preburn">Preburn</a>&lt;CoinType&gt;</code> resource published under it.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_preburn_to">preburn_to</a>&lt;CoinType&gt;(account: &signer, coin: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_preburn_to">preburn_to</a>&lt;CoinType: store&gt;(account: &signer, coin: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -1061,7 +1061,7 @@ resource under <code>preburn_address</code>, or, if the preburn to_burn area for
 <code>CoinType</code> is empty (error code 7).
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_burn_with_capability">burn_with_capability</a>&lt;CoinType&gt;(preburn_address: address, capability: &<a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_burn_with_capability">burn_with_capability</a>&lt;CoinType: store&gt;(preburn_address: address, capability: &<a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -1099,7 +1099,7 @@ resource under <code>preburn_address</code>, or, if the preburn to_burn area for
 <code>CoinType</code> is empty (error code 7).
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_burn_with_resource_cap">burn_with_resource_cap</a>&lt;CoinType&gt;(preburn: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Preburn">DiemTest::Preburn</a>&lt;CoinType&gt;, preburn_address: address, _capability: &<a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_burn_with_resource_cap">burn_with_resource_cap</a>&lt;CoinType: store&gt;(preburn: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Preburn">DiemTest::Preburn</a>&lt;CoinType&gt;, preburn_address: address, _capability: &<a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -1151,7 +1151,7 @@ This function can only be called by the holder of a
 at <code>preburn_address</code> does not contain a pending burn request.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_cancel_burn_with_capability">cancel_burn_with_capability</a>&lt;CoinType&gt;(preburn_address: address, _capability: &<a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_cancel_burn_with_capability">cancel_burn_with_capability</a>&lt;CoinType: store&gt;(preburn_address: address, _capability: &<a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -1202,7 +1202,7 @@ Calls to this function will fail if <code>account</code> does  not have a
 published <code><a href="DiemTest.md#0x1_DiemTest_BurnCapability">BurnCapability</a>&lt;CoinType&gt;</code> resource at the top-level.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_remove_burn_capability">remove_burn_capability</a>&lt;CoinType&gt;(account: &signer): <a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_remove_burn_capability">remove_burn_capability</a>&lt;CoinType: store&gt;(account: &signer): <a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -1231,7 +1231,7 @@ preburn requests across all preburn resources for the <code>CoinType</code>
 currency).
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_preburn_value">preburn_value</a>&lt;CoinType&gt;(): u64
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_preburn_value">preburn_value</a>&lt;CoinType: store&gt;(): u64
 </code></pre>
 
 
@@ -1257,7 +1257,7 @@ Create a new <code><a href="">Diem</a>&lt;CoinType&gt;</code> with a value of <c
 this and it will be successful as long as <code>CoinType</code> is a registered currency.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_zero">zero</a>&lt;CoinType&gt;(): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_zero">zero</a>&lt;CoinType: store&gt;(): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -1285,7 +1285,7 @@ represented in the base units for the currency represented by
 <code>CoinType</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_value">value</a>&lt;CoinType&gt;(coin: &<a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;): u64
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_value">value</a>&lt;CoinType: store&gt;(coin: &<a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;): u64
 </code></pre>
 
 
@@ -1312,7 +1312,7 @@ remaining balance of the passed in <code>coin</code>, along with another coin
 with value equal to <code>amount</code>. Calls will fail if <code>amount &gt; <a href="_value">Diem::value</a>(&coin)</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_split">split</a>&lt;CoinType&gt;(coin: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, amount: u64): (<a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_split">split</a>&lt;CoinType: store&gt;(coin: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, amount: u64): (<a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -1342,7 +1342,7 @@ Calls will abort if the passed-in <code>amount</code> is greater than the
 value of the passed-in <code>coin</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_withdraw">withdraw</a>&lt;CoinType&gt;(coin: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, amount: u64): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_withdraw">withdraw</a>&lt;CoinType: store&gt;(coin: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, amount: u64): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -1371,7 +1371,7 @@ Return a <code><a href="">Diem</a>&lt;CoinType&gt;</code> worth <code>coin.value
 zero. Does not abort.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_withdraw_all">withdraw_all</a>&lt;CoinType&gt;(coin: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_withdraw_all">withdraw_all</a>&lt;CoinType: store&gt;(coin: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -1397,7 +1397,7 @@ zero. Does not abort.
 and returns a new coin whose value is equal to the sum of the two inputs.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_join">join</a>&lt;CoinType&gt;(xus: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, coin2: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_join">join</a>&lt;CoinType: store&gt;(xus: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, coin2: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -1425,7 +1425,7 @@ The coin passed in by reference will have a value equal to the sum of the two co
 The <code>check</code> coin is consumed in the process
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_deposit">deposit</a>&lt;CoinType&gt;(coin: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, check: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_deposit">deposit</a>&lt;CoinType: store&gt;(coin: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, check: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -1489,7 +1489,7 @@ adds the currency to the set of <code><a href="">RegisteredCurrencies</a></code>
 <code><a href="DiemTest.md#0x1_DiemTest_MintCapability">MintCapability</a>&lt;CoinType&gt;</code> and <code><a href="DiemTest.md#0x1_DiemTest_BurnCapability">BurnCapability</a>&lt;CoinType&gt;</code> resources.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_register_currency">register_currency</a>&lt;CoinType&gt;(dr_account: &signer, to_xdx_exchange_rate: <a href="_FixedPoint32">FixedPoint32::FixedPoint32</a>, is_synthetic: bool, scaling_factor: u64, fractional_part: u64, currency_code: vector&lt;u8&gt;): (<a href="DiemTest.md#0x1_DiemTest_MintCapability">DiemTest::MintCapability</a>&lt;CoinType&gt;, <a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_register_currency">register_currency</a>&lt;CoinType: store&gt;(dr_account: &signer, to_xdx_exchange_rate: <a href="_FixedPoint32">FixedPoint32::FixedPoint32</a>, is_synthetic: bool, scaling_factor: u64, fractional_part: u64, currency_code: vector&lt;u8&gt;): (<a href="DiemTest.md#0x1_DiemTest_MintCapability">DiemTest::MintCapability</a>&lt;CoinType&gt;, <a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -1553,7 +1553,7 @@ This code allows different currencies to have different treasury compliance
 accounts.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_register_SCS_currency">register_SCS_currency</a>&lt;CoinType&gt;(dr_account: &signer, tc_account: &signer, to_xdx_exchange_rate: <a href="_FixedPoint32">FixedPoint32::FixedPoint32</a>, scaling_factor: u64, fractional_part: u64, currency_code: vector&lt;u8&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_register_SCS_currency">register_SCS_currency</a>&lt;CoinType: store&gt;(dr_account: &signer, tc_account: &signer, to_xdx_exchange_rate: <a href="_FixedPoint32">FixedPoint32::FixedPoint32</a>, scaling_factor: u64, fractional_part: u64, currency_code: vector&lt;u8&gt;)
 </code></pre>
 
 
@@ -1598,7 +1598,7 @@ accounts.
 Returns the total amount of currency minted of type <code>CoinType</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_market_cap">market_cap</a>&lt;CoinType&gt;(): u128
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_market_cap">market_cap</a>&lt;CoinType: store&gt;(): u128
 </code></pre>
 
 
@@ -1626,7 +1626,7 @@ This should only be used where a _rough_ approximation of the exchange
 rate is needed.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_approx_xdx_for_value">approx_xdx_for_value</a>&lt;FromCoinType&gt;(from_value: u64): u64
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_approx_xdx_for_value">approx_xdx_for_value</a>&lt;FromCoinType: store&gt;(from_value: u64): u64
 </code></pre>
 
 
@@ -1655,7 +1655,7 @@ This should only be used where a rough approximation of the exchange
 rate is needed.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_approx_xdx_for_coin">approx_xdx_for_coin</a>&lt;FromCoinType&gt;(coin: &<a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;FromCoinType&gt;): u64
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_approx_xdx_for_coin">approx_xdx_for_coin</a>&lt;FromCoinType: store&gt;(coin: &<a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;FromCoinType&gt;): u64
 </code></pre>
 
 
@@ -1683,7 +1683,7 @@ Returns <code><b>true</b></code> if the type <code>CoinType</code> is a register
 Returns <code><b>false</b></code> otherwise.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_is_currency">is_currency</a>&lt;CoinType&gt;(): bool
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_is_currency">is_currency</a>&lt;CoinType: store&gt;(): bool
 </code></pre>
 
 
@@ -1707,7 +1707,7 @@ Returns <code><b>false</b></code> otherwise.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_is_SCS_currency">is_SCS_currency</a>&lt;CoinType&gt;(): bool
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_is_SCS_currency">is_SCS_currency</a>&lt;CoinType: store&gt;(): bool
 </code></pre>
 
 
@@ -1734,7 +1734,7 @@ Returns <code><b>true</b></code> if <code>CoinType</code> is a synthetic currenc
 its <code><a href="DiemTest.md#0x1_DiemTest_CurrencyInfo">CurrencyInfo</a></code>. Returns <code><b>false</b></code> otherwise.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_is_synthetic_currency">is_synthetic_currency</a>&lt;CoinType&gt;(): bool
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_is_synthetic_currency">is_synthetic_currency</a>&lt;CoinType: store&gt;(): bool
 </code></pre>
 
 
@@ -1763,7 +1763,7 @@ Returns the scaling factor for the <code>CoinType</code> currency as defined
 in its <code><a href="DiemTest.md#0x1_DiemTest_CurrencyInfo">CurrencyInfo</a></code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_scaling_factor">scaling_factor</a>&lt;CoinType&gt;(): u64
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_scaling_factor">scaling_factor</a>&lt;CoinType: store&gt;(): u64
 </code></pre>
 
 
@@ -1790,7 +1790,7 @@ Returns the representable (i.e. real-world) fractional part for the
 <code>CoinType</code> currency as defined in its <code><a href="DiemTest.md#0x1_DiemTest_CurrencyInfo">CurrencyInfo</a></code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_fractional_part">fractional_part</a>&lt;CoinType&gt;(): u64
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_fractional_part">fractional_part</a>&lt;CoinType: store&gt;(): u64
 </code></pre>
 
 
@@ -1817,7 +1817,7 @@ Returns the currency code for the registered currency as defined in
 its <code><a href="DiemTest.md#0x1_DiemTest_CurrencyInfo">CurrencyInfo</a></code> resource.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_currency_code">currency_code</a>&lt;CoinType&gt;(): vector&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_currency_code">currency_code</a>&lt;CoinType: store&gt;(): vector&lt;u8&gt;
 </code></pre>
 
 
@@ -1844,7 +1844,7 @@ Updates the <code>to_xdx_exchange_rate</code> held in the <code><a href="DiemTes
 <code>FromCoinType</code> to the new passed-in <code>xdx_exchange_rate</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_update_xdx_exchange_rate">update_xdx_exchange_rate</a>&lt;FromCoinType&gt;(tr_account: &signer, xdx_exchange_rate: <a href="_FixedPoint32">FixedPoint32::FixedPoint32</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_update_xdx_exchange_rate">update_xdx_exchange_rate</a>&lt;FromCoinType: store&gt;(tr_account: &signer, xdx_exchange_rate: <a href="_FixedPoint32">FixedPoint32::FixedPoint32</a>)
 </code></pre>
 
 
@@ -1883,7 +1883,7 @@ Updates the <code>to_xdx_exchange_rate</code> held in the <code><a href="DiemTes
 Returns the (rough) exchange rate between <code>CoinType</code> and <code><a href="">XDX</a></code>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_xdx_exchange_rate">xdx_exchange_rate</a>&lt;CoinType&gt;(): <a href="_FixedPoint32">FixedPoint32::FixedPoint32</a>
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_xdx_exchange_rate">xdx_exchange_rate</a>&lt;CoinType: store&gt;(): <a href="_FixedPoint32">FixedPoint32::FixedPoint32</a>
 </code></pre>
 
 
@@ -1915,7 +1915,7 @@ disallowed until it is turned back on via this function. All coins
 start out in the default state of <code>can_mint = <b>true</b></code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_update_minting_ability">update_minting_ability</a>&lt;CoinType&gt;(tr_account: &signer, can_mint: bool)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_update_minting_ability">update_minting_ability</a>&lt;CoinType: store&gt;(tr_account: &signer, can_mint: bool)
 </code></pre>
 
 
@@ -1947,7 +1947,7 @@ start out in the default state of <code>can_mint = <b>true</b></code>.
 Asserts that <code>CoinType</code> is a registered currency.
 
 
-<pre><code><b>fun</b> <a href="DiemTest.md#0x1_DiemTest_assert_is_currency">assert_is_currency</a>&lt;CoinType&gt;()
+<pre><code><b>fun</b> <a href="DiemTest.md#0x1_DiemTest_assert_is_currency">assert_is_currency</a>&lt;CoinType: store&gt;()
 </code></pre>
 
 
@@ -1971,7 +1971,7 @@ Asserts that <code>CoinType</code> is a registered currency.
 
 
 
-<pre><code><b>fun</b> <a href="DiemTest.md#0x1_DiemTest_assert_is_SCS_currency">assert_is_SCS_currency</a>&lt;CoinType&gt;()
+<pre><code><b>fun</b> <a href="DiemTest.md#0x1_DiemTest_assert_is_SCS_currency">assert_is_SCS_currency</a>&lt;CoinType: store&gt;()
 </code></pre>
 
 
@@ -2165,7 +2165,7 @@ Account for updating <code><a href="DiemTest.md#0x1_DiemTest_sum_of_coin_values"
 ### Function `mint`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_mint">mint</a>&lt;CoinType&gt;(account: &signer, value: u64): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_mint">mint</a>&lt;CoinType: store&gt;(account: &signer, value: u64): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -2183,7 +2183,7 @@ Account for updating <code><a href="DiemTest.md#0x1_DiemTest_sum_of_coin_values"
 ### Function `burn`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_burn">burn</a>&lt;CoinType&gt;(account: &signer, preburn_address: address)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_burn">burn</a>&lt;CoinType: store&gt;(account: &signer, preburn_address: address)
 </code></pre>
 
 
@@ -2200,7 +2200,7 @@ Account for updating <code><a href="DiemTest.md#0x1_DiemTest_sum_of_coin_values"
 ### Function `mint_with_capability`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_mint_with_capability">mint_with_capability</a>&lt;CoinType&gt;(value: u64, _capability: &<a href="DiemTest.md#0x1_DiemTest_MintCapability">DiemTest::MintCapability</a>&lt;CoinType&gt;): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_mint_with_capability">mint_with_capability</a>&lt;CoinType: store&gt;(value: u64, _capability: &<a href="DiemTest.md#0x1_DiemTest_MintCapability">DiemTest::MintCapability</a>&lt;CoinType&gt;): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -2246,7 +2246,7 @@ Account for updating <code><a href="DiemTest.md#0x1_DiemTest_sum_of_coin_values"
 ### Function `preburn_with_resource`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_preburn_with_resource">preburn_with_resource</a>&lt;CoinType&gt;(coin: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, preburn: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Preburn">DiemTest::Preburn</a>&lt;CoinType&gt;, preburn_address: address)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_preburn_with_resource">preburn_with_resource</a>&lt;CoinType: store&gt;(coin: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, preburn: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Preburn">DiemTest::Preburn</a>&lt;CoinType&gt;, preburn_address: address)
 </code></pre>
 
 
@@ -2292,7 +2292,7 @@ Account for updating <code><a href="DiemTest.md#0x1_DiemTest_sum_of_coin_values"
 ### Function `preburn_to`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_preburn_to">preburn_to</a>&lt;CoinType&gt;(account: &signer, coin: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_preburn_to">preburn_to</a>&lt;CoinType: store&gt;(account: &signer, coin: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -2311,7 +2311,7 @@ Account for updating <code><a href="DiemTest.md#0x1_DiemTest_sum_of_coin_values"
 ### Function `burn_with_capability`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_burn_with_capability">burn_with_capability</a>&lt;CoinType&gt;(preburn_address: address, capability: &<a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_burn_with_capability">burn_with_capability</a>&lt;CoinType: store&gt;(preburn_address: address, capability: &<a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -2329,7 +2329,7 @@ Account for updating <code><a href="DiemTest.md#0x1_DiemTest_sum_of_coin_values"
 ### Function `burn_with_resource_cap`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_burn_with_resource_cap">burn_with_resource_cap</a>&lt;CoinType&gt;(preburn: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Preburn">DiemTest::Preburn</a>&lt;CoinType&gt;, preburn_address: address, _capability: &<a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_burn_with_resource_cap">burn_with_resource_cap</a>&lt;CoinType: store&gt;(preburn: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Preburn">DiemTest::Preburn</a>&lt;CoinType&gt;, preburn_address: address, _capability: &<a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -2376,7 +2376,7 @@ Account for updating <code><a href="DiemTest.md#0x1_DiemTest_sum_of_coin_values"
 ### Function `split`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_split">split</a>&lt;CoinType&gt;(coin: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, amount: u64): (<a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_split">split</a>&lt;CoinType: store&gt;(coin: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, amount: u64): (<a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -2394,7 +2394,7 @@ Account for updating <code><a href="DiemTest.md#0x1_DiemTest_sum_of_coin_values"
 ### Function `withdraw`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_withdraw">withdraw</a>&lt;CoinType&gt;(coin: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, amount: u64): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_withdraw">withdraw</a>&lt;CoinType: store&gt;(coin: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, amount: u64): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -2412,7 +2412,7 @@ Account for updating <code><a href="DiemTest.md#0x1_DiemTest_sum_of_coin_values"
 ### Function `withdraw_all`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_withdraw_all">withdraw_all</a>&lt;CoinType&gt;(coin: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_withdraw_all">withdraw_all</a>&lt;CoinType: store&gt;(coin: &<b>mut</b> <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -2430,7 +2430,7 @@ Account for updating <code><a href="DiemTest.md#0x1_DiemTest_sum_of_coin_values"
 ### Function `join`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_join">join</a>&lt;CoinType&gt;(xus: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, coin2: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_join">join</a>&lt;CoinType: store&gt;(xus: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;, coin2: <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;): <a href="DiemTest.md#0x1_DiemTest_Diem">DiemTest::Diem</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -2463,7 +2463,7 @@ Account for updating <code><a href="DiemTest.md#0x1_DiemTest_sum_of_coin_values"
 ### Function `register_currency`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_register_currency">register_currency</a>&lt;CoinType&gt;(dr_account: &signer, to_xdx_exchange_rate: <a href="_FixedPoint32">FixedPoint32::FixedPoint32</a>, is_synthetic: bool, scaling_factor: u64, fractional_part: u64, currency_code: vector&lt;u8&gt;): (<a href="DiemTest.md#0x1_DiemTest_MintCapability">DiemTest::MintCapability</a>&lt;CoinType&gt;, <a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_register_currency">register_currency</a>&lt;CoinType: store&gt;(dr_account: &signer, to_xdx_exchange_rate: <a href="_FixedPoint32">FixedPoint32::FixedPoint32</a>, is_synthetic: bool, scaling_factor: u64, fractional_part: u64, currency_code: vector&lt;u8&gt;): (<a href="DiemTest.md#0x1_DiemTest_MintCapability">DiemTest::MintCapability</a>&lt;CoinType&gt;, <a href="DiemTest.md#0x1_DiemTest_BurnCapability">DiemTest::BurnCapability</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -2483,7 +2483,7 @@ Account for updating <code><a href="DiemTest.md#0x1_DiemTest_sum_of_coin_values"
 ### Function `register_SCS_currency`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_register_SCS_currency">register_SCS_currency</a>&lt;CoinType&gt;(dr_account: &signer, tc_account: &signer, to_xdx_exchange_rate: <a href="_FixedPoint32">FixedPoint32::FixedPoint32</a>, scaling_factor: u64, fractional_part: u64, currency_code: vector&lt;u8&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="DiemTest.md#0x1_DiemTest_register_SCS_currency">register_SCS_currency</a>&lt;CoinType: store&gt;(dr_account: &signer, tc_account: &signer, to_xdx_exchange_rate: <a href="_FixedPoint32">FixedPoint32::FixedPoint32</a>, scaling_factor: u64, fractional_part: u64, currency_code: vector&lt;u8&gt;)
 </code></pre>
 
 

--- a/language/move-stdlib/docs/Event.md
+++ b/language/move-stdlib/docs/Event.md
@@ -73,7 +73,7 @@ A handle for an event such that:
 2. Storage can use this handle to prove the total number of events that happened in the past.
 
 
-<pre><code><b>struct</b> <a href="Event.md#0x1_Event_EventHandle">EventHandle</a>&lt;T: <b>copyable</b>&gt;
+<pre><code><b>struct</b> <a href="Event.md#0x1_Event_EventHandle">EventHandle</a>&lt;T: drop, store&gt;
 </code></pre>
 
 
@@ -185,7 +185,7 @@ hash it with the sender's address, the result is guaranteed to be globally uniqu
 Use EventHandleGenerator to generate a unique event handle for <code>sig</code>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Event.md#0x1_Event_new_event_handle">new_event_handle</a>&lt;T: <b>copyable</b>&gt;(account: &signer): <a href="Event.md#0x1_Event_EventHandle">Event::EventHandle</a>&lt;T&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="Event.md#0x1_Event_new_event_handle">new_event_handle</a>&lt;T: drop, store&gt;(account: &signer): <a href="Event.md#0x1_Event_EventHandle">Event::EventHandle</a>&lt;T&gt;
 </code></pre>
 
 
@@ -216,7 +216,7 @@ Use EventHandleGenerator to generate a unique event handle for <code>sig</code>
 Emit an event with payload <code>msg</code> by using <code>handle_ref</code>'s key and counter.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Event.md#0x1_Event_emit_event">emit_event</a>&lt;T: <b>copyable</b>&gt;(handle_ref: &<b>mut</b> <a href="Event.md#0x1_Event_EventHandle">Event::EventHandle</a>&lt;T&gt;, msg: T)
+<pre><code><b>public</b> <b>fun</b> <a href="Event.md#0x1_Event_emit_event">emit_event</a>&lt;T: drop, store&gt;(handle_ref: &<b>mut</b> <a href="Event.md#0x1_Event_EventHandle">Event::EventHandle</a>&lt;T&gt;, msg: T)
 </code></pre>
 
 
@@ -245,7 +245,7 @@ Native procedure that writes to the actual event stream in Event store
 This will replace the "native" portion of EmitEvent bytecode
 
 
-<pre><code><b>fun</b> <a href="Event.md#0x1_Event_write_to_event_store">write_to_event_store</a>&lt;T: <b>copyable</b>&gt;(guid: vector&lt;u8&gt;, count: u64, msg: T)
+<pre><code><b>fun</b> <a href="Event.md#0x1_Event_write_to_event_store">write_to_event_store</a>&lt;T: drop, store&gt;(guid: vector&lt;u8&gt;, count: u64, msg: T)
 </code></pre>
 
 
@@ -268,7 +268,7 @@ This will replace the "native" portion of EmitEvent bytecode
 Destroy a unique handle.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Event.md#0x1_Event_destroy_handle">destroy_handle</a>&lt;T: <b>copyable</b>&gt;(handle: <a href="Event.md#0x1_Event_EventHandle">Event::EventHandle</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="Event.md#0x1_Event_destroy_handle">destroy_handle</a>&lt;T: drop, store&gt;(handle: <a href="Event.md#0x1_Event_EventHandle">Event::EventHandle</a>&lt;T&gt;)
 </code></pre>
 
 

--- a/language/move-stdlib/docs/Option.md
+++ b/language/move-stdlib/docs/Option.md
@@ -424,7 +424,7 @@ Return the value inside <code>t</code> if it holds one
 Return <code>default</code> if <code>t</code> does not hold a value
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Option.md#0x1_Option_get_with_default">get_with_default</a>&lt;Element: <b>copyable</b>&gt;(t: &<a href="Option.md#0x1_Option_Option">Option::Option</a>&lt;Element&gt;, default: Element): Element
+<pre><code><b>public</b> <b>fun</b> <a href="Option.md#0x1_Option_get_with_default">get_with_default</a>&lt;Element: <b>copy</b>, drop&gt;(t: &<a href="Option.md#0x1_Option_Option">Option::Option</a>&lt;Element&gt;, default: Element): Element
 </code></pre>
 
 
@@ -640,7 +640,7 @@ Aborts if <code>t</code> does not hold a value
 Destroys <code>t.</code> If <code>t</code> holds a value, return it. Returns <code>default</code> otherwise
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Option.md#0x1_Option_destroy_with_default">destroy_with_default</a>&lt;Element: <b>copyable</b>&gt;(t: <a href="Option.md#0x1_Option_Option">Option::Option</a>&lt;Element&gt;, default: Element): Element
+<pre><code><b>public</b> <b>fun</b> <a href="Option.md#0x1_Option_destroy_with_default">destroy_with_default</a>&lt;Element: drop&gt;(t: <a href="Option.md#0x1_Option_Option">Option::Option</a>&lt;Element&gt;, default: Element): Element
 </code></pre>
 
 


### PR DESCRIPTION
As title. TypeConstraint (i.e., copyable, resource) no longer exists, use the AbilityConstraint instead.

Only the first commit needs to be reviewed, the second one is doc update which is auto-generated.

## Motivation

Found this when converting Spec types into Move types.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI
