### PR TITLE
[HKDF] do not allow < 16 bytes seeds to prevent misuse.

### DIFF
--- a/crypto/crypto/src/hkdf.rs
+++ b/crypto/crypto/src/hkdf.rs
@@ -85,8 +85,14 @@ use generic_array::typenum::{IsGreaterOrEqual, True, U32};
 use std::marker::PhantomData;
 use thiserror::Error;
 
-/// Hash function are not supported if their output is less than 32 bits.
+/// Hash function is not supported if its output is less than 32 bits.
 type DMinimumSize = U32;
+
+/// Seed (ikm = initial key material) is not accepted if its size is less than 16 bytes. This is a
+/// precautionary measure to prevent HKDF misuse. 128 bits is the minimum accepted seed entropy
+/// length in the majority of today's applications to avoid brute forcing.
+/// Note that for Ed25519 keys, random seeds of at least 32 bytes are recommended.
+const MINIMUM_SEED_LENGTH: usize = 16;
 
 /// Structure representing the HKDF, capable of HKDF-Extract and HKDF-Expand operations, as defined
 /// in RFC 5869.
@@ -110,8 +116,15 @@ where
 {
     /// The RFC5869 HKDF-Extract operation.
     pub fn extract(salt: Option<&[u8]>, ikm: &[u8]) -> Result<Vec<u8>, HkdfError> {
+        if ikm.len() < MINIMUM_SEED_LENGTH {
+            return Err(HkdfError::InvalidSeedLengthError);
+        }
+        Ok(Hkdf::<D>::extract_no_ikm_check(salt, ikm))
+    }
+
+    fn extract_no_ikm_check(salt: Option<&[u8]>, ikm: &[u8]) -> Vec<u8> {
         let (arr, _hkdf) = hkdf::Hkdf::<D>::extract(salt, ikm);
-        Ok(arr.to_vec())
+        arr.to_vec()
     }
 
     /// The RFC5869 HKDF-Expand operation.
@@ -142,6 +155,22 @@ where
         let prk = Hkdf::<D>::extract(salt, ikm)?;
         Hkdf::<D>::expand(&prk, info, length)
     }
+
+    /// CAUTION: This is not recommended because it does not take an ikm (seed) as an input and
+    /// thus, it is not fully compliant with the HKDF RFC (which always expects a non-zero ikm).
+    /// Please use `extract_then_expand` instead, unless you know what you are doing.
+    ///
+    /// This api is currently required by the Noise protocol [HKDF specs](https://noiseprotocol.org/noise.html#hash-functions).
+    ///
+    /// HKDF Extract then Expand operation as a single step, but without an ikm input.
+    pub fn extract_then_expand_no_ikm(
+        salt: Option<&[u8]>,
+        info: Option<&[u8]>,
+        length: usize,
+    ) -> Result<Vec<u8>, HkdfError> {
+        let prk = Hkdf::<D>::extract_no_ikm_check(salt, &[]);
+        Hkdf::<D>::expand(&prk, info, length)
+    }
 }
 
 /// An error type for HKDF key derivation issues.
@@ -165,4 +194,7 @@ pub enum HkdfError {
     /// HMAC key related error; unlikely to happen because every key size is accepted in HMAC.
     #[error("HMAC key error")]
     MACKeyError,
+    /// HKDF extract input seed should not be less than the minimum accepted.
+    #[error("HKDF extract error - input seed is too small")]
+    InvalidSeedLengthError,
 }

--- a/crypto/crypto/src/noise.rs
+++ b/crypto/crypto/src/noise.rs
@@ -182,7 +182,11 @@ fn hash(data: &[u8]) -> Vec<u8> {
 
 fn hkdf(ck: &[u8], dh_output: Option<&[u8]>) -> Result<(Vec<u8>, Vec<u8>), NoiseError> {
     let dh_output = dh_output.unwrap_or_else(|| &[]);
-    let hkdf_output = Hkdf::<sha2::Sha256>::extract_then_expand(Some(ck), dh_output, None, 64);
+    let hkdf_output = if dh_output.is_empty() {
+        Hkdf::<sha2::Sha256>::extract_then_expand_no_ikm(Some(ck), None, 64)
+    } else {
+        Hkdf::<sha2::Sha256>::extract_then_expand(Some(ck), dh_output, None, 64)
+    };
 
     let hkdf_output = hkdf_output.map_err(|_| NoiseError::Hkdf)?;
     let (k1, k2) = hkdf_output.split_at(32);

--- a/types/src/network_address/encrypted.rs
+++ b/types/src/network_address/encrypted.rs
@@ -226,7 +226,7 @@ impl EncNetworkAddress {
         let nonce_slice = GenericArray::from_slice(nonce_slice);
 
         // the key_version is in-the-clear, so we include it in the integrity check
-        // using the "additonal data"
+        // using the "additional data"
         let ad_buf = key_version.to_be_bytes();
         let ad_slice = &ad_buf[..];
 


### PR DESCRIPTION
## Motivation

Extra precautionary measures to HKDF by not allowing < 16 bytes seeds. 
Unfortunately Noise is invoking (in some places) HKDF without setting ikm (initial key material) which is not recommended by the HKDF RFC, thus to accommodate this we're introducing an `extract_then_expand_no_ikm` public fun, but we specifically discourage any other uses of it, unless protocol designers know what they are doing.

Noise's HKDF use is [described here](https://noiseprotocol.org/noise.html#hash-functions); as you will read there: the _input_key_material (ikm) byte sequence with length either **zero bytes**, 32 bytes, or DHLEN bytes_. The **zero bytes** ikm is what makes Noise to in theory violate the HKDF rfc recommendation, although in practice we're not aware of any attack.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

YES

## Test Plan

test_ikm_size
