### PR TITLE
[language] remove unused dependency on diem-types from move-vm-runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4501,7 +4501,6 @@ dependencies = [
  "diem-crypto",
  "diem-infallible",
  "diem-logger",
- "diem-state-view",
  "diem-workspace-hack",
  "fail",
  "hex",

--- a/language/move-vm/runtime/Cargo.toml
+++ b/language/move-vm/runtime/Cargo.toml
@@ -32,7 +32,6 @@ hex = "0.4.3"
 proptest = "1.0.0"
 
 compiler = { path = "../../compiler" }
-diem-state-view = { path = "../../../storage/state-view" }
 move-lang = { path = "../../move-lang" }
 
 [features]


### PR DESCRIPTION
This removes the diem-types dependency from move-vm-runtime. This dependency is currently unused.