### PR TITLE
[Website] Adding warnings about using JSON-RPC

### DIFF
--- a/developers.diem.com/docs/core/my-first-client.md
+++ b/developers.diem.com/docs/core/my-first-client.md
@@ -13,7 +13,6 @@ const syntax = [
 
 _An introduction to client development on testnet using the official SDKs._
 
-
 ## Getting Started
 
 In this tutorial, we demonstrate the key elements of a basic client using the official SDKs to interact with the Blockchain. The code for the tutorial is available here: [my-first-client](https://github.com/diem/my-first-client). The code in this project can be run from the root of the project directory by issuing the `make` command.
@@ -22,21 +21,27 @@ The example code uses the official Client SDKs. Currently, Go, Java, and Python 
 
 To see advanced usage, refer to the Reference Wallet project.
 
+## Warning
+
+Notice that this guide is relying on the SDK who are assuming that you're connected to a trusted fullnode providing you with the required JSON-RPC interface. The JSON-RPC responses are not providing any proofs that would allow you to verify they contain data actually stored in the Diem ledger.
+
+If you are connecting to a public fullnode that you do not own, it is not providing you the same security guarantees as if you were running your own, allowing it to easily feed you with fake data.
+We strongly recommend running your own fullnode as soon as you depend on the JSON-RPC API or the SDKs for any critical operation.
 
 ## Setup
 
 All code examples are shared in the [my-first-client](https://github.com/diem/my-first-client) repo on GitHub.
 
-### Clone the repo:
+### Clone the repo
 
 _git clone [https://github.com/diem/my-first-client.git](https://github.com/diem/my-first-client.git)_
 
 Each SDK has the following system requirements:
 
-*   Java: Java 8+
-*   Python: Python v3.7+, pipenv
+* Java: Java 8+
+* Python: Python v3.7+, pipenv
 
-### Run the examples:
+### Run the examples
 
 `make`
 
@@ -63,6 +68,7 @@ client = testnet.create_client();
 ```java
 client = Testnet.createClient();
 ```
+
 </TabItem>
 </Tabs>
 
@@ -117,7 +123,6 @@ Testnet.mintCoins(client, 10000000, senderAuthKey.hex(), "XUS");
 </TabItem>
 </Tabs>
 
-
 ## Getting a balance
 
 In the previous step we requested 100 XUS from the faucet. We can verify that our test wallet now has the expected balance.
@@ -170,7 +175,6 @@ System.out.println(account);
 
 </TabItem>
 </Tabs>
-
 
 ## Sending Coins
 
@@ -309,9 +313,7 @@ System.out.println(transaction);
 </TabItem>
 </Tabs>
 
-
 We can verify that 10 XUS was sent by verifying the sender’s wallet balance is 90 and receiver’s balance is 10.
-
 
 ## Transaction Intent (DIP-5)
 
@@ -522,6 +524,7 @@ public class GetEventsExample {
    }
 }
 ```
+
 </TabItem>
 </Tabs>
 

--- a/developers.diem.com/docs/core/query-the-blockchain.md
+++ b/developers.diem.com/docs/core/query-the-blockchain.md
@@ -5,32 +5,77 @@ title: Query the Blockchain
 
 The JSON-RPC service provides APIs for clients to query the Diem Blockchain. This tutorial will guide you through the different methods you can use. You can test these on testnet.
 
-#### Assumptions
+### Assumptions
 
 All commands in this document assume that:
 
 * You are running on a Linux (Red Hat or Debian-based) or macOS system.
 * You have a stable connection to the internet.
 
-#### Prerequisites
+### Prerequisites
+
 * Complete the [My First Transaction](my-first-transaction.md) tutorial to understand how to create accounts and interact with testnet.
 
 If you have already completed the My First Transaction tutorial, you can use the following account information for Alice and Bob to get started:
+
 * [Account address: Hex-coded account address](my-first-transaction.md#step-4-optional-list-accounts)
 
+### Warning
+
+Notice that this guide is relying on the JSON-RPC service, which is assuming that you're connected to a trusted fullnode providing you with that API. The JSON-RPC responses are not providing any proofs that would allow you to verify they contain data actually stored in the Diem ledger.
+
+If you are connecting to a public fullnode that you do not own, it is not providing you the same security guarantees as if you were running your own, allowing it to easily feed you with fake data.
+We strongly recommend running your own fullnode as soon as you depend on the JSON-RPC API or the SDKs for any critical operation.
+
 ## Get account information
+
 To get information about Alice’s account, use [get_account](https://github.com/diem/diem/blob/main/json-rpc/docs/method_get_account.md). To run this method, you will need the hex-coded account address (see step 4 of My First Transaction).
 
 In the example below, we have a request sent using [get_account](https://github.com/diem/diem/blob/main/json-rpc/docs/method_get_account.md) to learn information about Alice’s account and the response received.
 
 ```
-// Request: fetches account for account address "5261f913eab22cfc448a815a0e672143"curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"get_account","params":["5261f913eab22cfc448a815a0e672143"],"id":1}' https://testnet.libra.org/v1
-  // Response{  "libra_chain_id":2,  "libra_ledger_version":3052934,  "libra_ledger_timestampusec":1603827580322991,  "jsonrpc":"2.0",  "id":1,  "result":  {    "address":"5261f913eab22cfc448a815a0e672143",    "authentication_key":"8013a28f82e5ab390ff0b75762bf3d8c5261f913eab22cfc448a815a0e672143",    "balances":[      {        "amount":100000000,        "currency":"Coin1"      }    ],    "delegated_key_rotation_capability":false,    "delegated_withdrawal_capability":false,    "is_frozen":false,    "received_events_key":"02000000000000005261f913eab22cfc448a815a0e672143",    "role":      {        "base_url":"",        "base_url_rotation_events_key":"01000000000000005261f913eab22cfc448a815a0e672143",        "compliance_key":"",        "compliance_key_rotation_events_key":"00000000000000005261f913eab22cfc448a815a0e672143",        "expiration_time":18446744073709551615,        "human_name":"No. 3597",        "num_children":0,        "type":"parent_vasp"      },    "sent_events_key":"03000000000000005261f913eab22cfc448a815a0e672143",    "sequence_number":1  }}%
+// Request: fetches account for account address "5261f913eab22cfc448a815a0e672143"
+curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"get_account","params":["5261f913eab22cfc448a815a0e672143"],"id":1}' https://testnet.libra.org/v1
+// Response in JSON
+{
+  "libra_chain_id": 2,
+  "libra_ledger_version": 3052934,
+  "libra_ledger_timestampusec": 1603827580322991,
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "address": "5261f913eab22cfc448a815a0e672143",
+    "authentication_key": "8013a28f82e5ab390ff0b75762bf3d8c5261f913eab22cfc448a815a0e672143",
+    "balances": [
+      {
+        "amount": 100000000,
+        "currency": "Coin1"
+      }
+    ],
+    "delegated_key_rotation_capability": false,
+    "delegated_withdrawal_capability": false,
+    "is_frozen": false,
+    "received_events_key": "02000000000000005261f913eab22cfc448a815a0e672143",
+    "role": {
+      "base_url": "",
+      "base_url_rotation_events_key": "01000000000000005261f913eab22cfc448a815a0e672143",
+      "compliance_key": "",
+      "compliance_key_rotation_events_key": "00000000000000005261f913eab22cfc448a815a0e672143",
+      "expiration_time": 18446744073709552000,
+      "human_name": "No. 3597",
+      "num_children": 0,
+      "type": "parent_vasp"
+    },
+    "sent_events_key": "03000000000000005261f913eab22cfc448a815a0e672143",
+    "sequence_number": 1
+  }
+}
 ```
 
-
 ## Get transactions for an account
+
 To see all the transactions sent by Alice’s account, you can use [get_account_transactions](https://github.com/diem/diem/blob/main/json-rpc/docs/method_get_account_transactions.md). You will need:
+
 * Alice’s hex-code account address
 * the starting sequence number
 * the maximum number of transactions you want returned for this method
@@ -38,32 +83,169 @@ To see all the transactions sent by Alice’s account, you can use [get_account_
 In the example below, we have a request sent using [get_account_transactions](https://github.com/diem/diem/blob/main/json-rpc/docs/method_get_account_transactions.md) to learn transaction information about Alice’s account and the response received.
 
 ```
-// Request: fetches account for account address "5261f913eab22cfc448a815a0e672143"curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"get_account_transactions","params":["5261f913eab22cfc448a815a0e672143", 0, 100, false],"id":1}' https://testnet.libra.org/v1
-//Response{  libra_chain_id":2,  "libra_ledger_version":3058809,  "libra_ledger_timestampusec":1603828579094476,  "jsonrpc":"2.0",  "id":1,  "result":[    {      "bytes":"005261f913eab22cfc448a815a0e672143000000000000000001e101a11ceb0b010000000701000202020403061004160205181d0735610896011000000001010000020001000003020301010004010300010501060c0108000506080005030a020a020005060c05030a020a020109000c4c696272614163636f756e741257697468647261774361706162696c6974791b657874726163745f77697468647261775f6361706162696c697479087061795f66726f6d1b726573746f72655f77697468647261775f6361706162696c69747900000000000000000000000000000001010104010c0b0011000c050e050a010a020b030b0438000b0511020201070000000000000000000000000000000105436f696e3105436f696e31000403701901dad4e06079cc701452ac48a99d0180969800000000000400040040420f0000000000000000000000000005436f696e319a75985f0000000002002043e9cc017c028e3a4537d7a434e10f4efe969e40b6874a9fded9a87fe8460cf8404b357285fcf6919188ada95517dfab76717faadc54aaef37e22c4bd0fbe4a450b7ba20e41e2629bb5754dd0a51af0a4360af8ac07d8f32419d197ff0401e830f","events":[],"gas_used":489,"hash":"40de7d62d0a7583e8670a2b2b872c63c51060cc2d86acdd191a739af77f239e6",      "transaction":      {        "chain_id":2,        "expiration_timestamp_secs":1603827098,        "gas_currency":"Coin1",        "gas_unit_price":0,        "max_gas_amount":1000000,        "public_key":"43e9cc017c028e3a4537d7a434e10f4efe969e40b6874a9fded9a87fe8460cf8",        "script":          {            "amount":10000000,            "arguments":[              "{ADDRESS: 701901DAD4E06079CC701452AC48A99D}",              "{U64: 10000000}",              "{U8Vector: 0x}",              "{U8Vector: 0x}"            ],            "code":"a11ceb0b010000000701000202020403061004160205181d0735610896011000000001010000020001000003020301010004010300010501060c0108000506080005030a020a020005060c05030a020a020109000c4c696272614163636f756e741257697468647261774361706162696c6974791b657874726163745f77697468647261775f6361706162696c697479087061795f66726f6d1b726573746f72655f77697468647261775f6361706162696c69747900000000000000000000000000000001010104010c0b0011000c050e050a010a020b030b0438000b05110202",            "currency":"Coin1",            "metadata":"",            "metadata_signature":"",            "receiver":"701901DAD4E06079CC701452AC48A99D",            "type":"peer_to_peer_with_metadata",            "type_arguments":["Coin1"]          },        "script_bytes":"e101a11ceb0b010000000701000202020403061004160205181d0735610896011000000001010000020001000003020301010004010300010501060c0108000506080005030a020a020005060c05030a020a020109000c4c696272614163636f756e741257697468647261774361706162696c6974791b657874726163745f77697468647261775f6361706162696c697479087061795f66726f6d1b726573746f72655f77697468647261775f6361706162696c69747900000000000000000000000000000001010104010c0b0011000c050e050a010a020b030b0438000b0511020201070000000000000000000000000000000105436f696e3105436f696e31000403701901dad4e06079cc701452ac48a99d01809698000000000004000400",        "script_hash":"61749d43d8f10940be6944df85ddf13f0f8fb830269c601f481cc5ee3de731c8",        "sender":"5261F913EAB22CFC448A815A0E672143",        "sequence_number":0,        "signature":"4b357285fcf6919188ada95517dfab76717faadc54aaef37e22c4bd0fbe4a450b7ba20e41e2629bb5754dd0a51af0a4360af8ac07d8f32419d197ff0401e830f",        "signature_scheme":"Scheme::Ed25519",        "type":"user"      },      "version":3049426,      "vm_status":{"type":"executed"}    }  ]}%
+// Request: fetches account for account address "5261f913eab22cfc448a815a0e672143"
+curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"get_account_transactions","params":["5261f913eab22cfc448a815a0e672143", 0, 100, false],"id":1}' https://testnet.libra.org/v1
+// Response in JSON:
+{
+  "libra_chain_id": 2,
+  "libra_ledger_version": 3058809,
+  "libra_ledger_timestampusec": 1603828579094476,
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": [
+    {
+      "bytes": "005261f913eab22cfc448a815a0e672143000000000000000001e101a11ceb0b010000000701000202020403061004160205181d0735610896011000000001010000020001000003020301010004010300010501060c0108000506080005030a020a020005060c05030a020a020109000c4c696272614163636f756e741257697468647261774361706162696c6974791b657874726163745f77697468647261775f6361706162696c697479087061795f66726f6d1b726573746f72655f77697468647261775f6361706162696c69747900000000000000000000000000000001010104010c0b0011000c050e050a010a020b030b0438000b0511020201070000000000000000000000000000000105436f696e3105436f696e31000403701901dad4e06079cc701452ac48a99d0180969800000000000400040040420f0000000000000000000000000005436f696e319a75985f0000000002002043e9cc017c028e3a4537d7a434e10f4efe969e40b6874a9fded9a87fe8460cf8404b357285fcf6919188ada95517dfab76717faadc54aaef37e22c4bd0fbe4a450b7ba20e41e2629bb5754dd0a51af0a4360af8ac07d8f32419d197ff0401e830f",
+      "events": [],
+      "gas_used": 489,
+      "hash": "40de7d62d0a7583e8670a2b2b872c63c51060cc2d86acdd191a739af77f239e6",
+      "transaction": {
+        "chain_id": 2,
+        "expiration_timestamp_secs": 1603827098,
+        "gas_currency": "Coin1",
+        "gas_unit_price": 0,
+        "max_gas_amount": 1000000,
+        "public_key": "43e9cc017c028e3a4537d7a434e10f4efe969e40b6874a9fded9a87fe8460cf8",
+        "script": {
+          "amount": 10000000,
+          "arguments": [
+            "{ADDRESS: 701901DAD4E06079CC701452AC48A99D}",
+            "{U64: 10000000}",
+            "{U8Vector: 0x}",
+            "{U8Vector: 0x}"
+          ],
+          "code": "a11ceb0b010000000701000202020403061004160205181d0735610896011000000001010000020001000003020301010004010300010501060c0108000506080005030a020a020005060c05030a020a020109000c4c696272614163636f756e741257697468647261774361706162696c6974791b657874726163745f77697468647261775f6361706162696c697479087061795f66726f6d1b726573746f72655f77697468647261775f6361706162696c69747900000000000000000000000000000001010104010c0b0011000c050e050a010a020b030b0438000b05110202",
+          "currency": "Coin1",
+          "metadata": "",
+          "metadata_signature": "",
+          "receiver": "701901DAD4E06079CC701452AC48A99D",
+          "type": "peer_to_peer_with_metadata",
+          "type_arguments": [
+            "Coin1"
+          ]
+        },
+        "script_bytes": "e101a11ceb0b010000000701000202020403061004160205181d0735610896011000000001010000020001000003020301010004010300010501060c0108000506080005030a020a020005060c05030a020a020109000c4c696272614163636f756e741257697468647261774361706162696c6974791b657874726163745f77697468647261775f6361706162696c697479087061795f66726f6d1b726573746f72655f77697468647261775f6361706162696c69747900000000000000000000000000000001010104010c0b0011000c050e050a010a020b030b0438000b0511020201070000000000000000000000000000000105436f696e3105436f696e31000403701901dad4e06079cc701452ac48a99d01809698000000000004000400",
+        "script_hash": "61749d43d8f10940be6944df85ddf13f0f8fb830269c601f481cc5ee3de731c8",
+        "sender": "5261F913EAB22CFC448A815A0E672143",
+        "sequence_number": 0,
+        "signature": "4b357285fcf6919188ada95517dfab76717faadc54aaef37e22c4bd0fbe4a450b7ba20e41e2629bb5754dd0a51af0a4360af8ac07d8f32419d197ff0401e830f",
+        "signature_scheme": "Scheme::Ed25519",
+        "type": "user"
+      },
+      "version": 3049426,
+      "vm_status": {
+        "type": "executed"
+      }
+    }
+  ]
+}
 ```
 
-
 ## Get the latest ledger state
+
 You can check the current state of the testnet using [get_metadata](https://github.com/diem/diem/blob/main/json-rpc/docs/method_get_metadata.md).
 
 The example below has the request and response received.
 
 ```
-// Request: fetches current block metadatacurl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"get_metadata","params":[],"id":1}' https://testnet.libra.org/v1
-//Response{  "libra_chain_id":2,  "libra_ledger_version":3063324,  "libra_ledger_timestampusec":1603829337973264,  "jsonrpc":"2.0",  "id":1,  "result":    {      "accumulator_root_hash":"a01b07539e4e6a303eeeefab2fe88be3671d4db80d6e4bd2cf19cef63e88b740",      "chain_id":2,      "libra_version":1,      "module_publishing_allowed":false,      "script_hash_allow_list":[        "6d9d309c5cc6df4c7082817eb657904781b06b2071552ae762806fce3b623463",        "570b8627a80ded5704775fc18060d58af396bb72565952fb0920221cc21ea9d1",        "19ea57b5051d34306353cc335baedbc022d28055cd6d76238a107ba433295930",        "a801d467df10ac00de027bc427637db66e8afc84a4bb94761b526016cb20a5ef",        "8f019b20740269011c05d8348cc7501bed64c7d56b8726eb8f4e21a01bd2eb4c",        "18da4e8c53fed321d58770e6c3f455848935cdc26153c3b41c166995787cff1d",        "5de6edd4b881622c4f7bc3bb9f2a1f98eeb8ca8483ad4e8dda3691c6bc5cbf32",        "bef38e6ed5ad51f0d060a4e194e4c8379cc6dfb60492c671a885f6752733866b",        "04ec5aec7f5cf5ea55e29cd65542134a7f4bb3c18421fecf00e5102dfe2d7efb",        "afabc7c4a2fd7b54734881f7e760e7d798cd93411839c20860a57e02eebd3893",        "ae693591b0d7169f4a68da27859fc055053b317c81836d6ef66a1418b1e9db5b",        "1a2c5cd660de7217f513bdfaa9c36bef8f384d018f128e7ddbb37dbb21f9b38f",        "387dce4a1f3421a369de8a48c070e7aa8e1e587ecadcf35fe254d3d8df0382b8",        "ff9e545db9c3546d892de6c6716d0a45929a721a14d478da3d689900eb16a394",        "61749d43d8f10940be6944df85ddf13f0f8fb830269c601f481cc5ee3de731c8",        "d01cd5656905ab073fefc899eb4af0c158ad3775d17f5d9731e5b5b040d52cfd",        "dfcfe1d8eb8e7a9dc1038b5d9d015c09c9e38ec6af310de7d5592de359092486",        "2b124c549e828df9bc38c6d45779d155f973116f077d8f0faa92c4d25389a4c1",        "c46e0e6d7579033024c73242b9a031d0d602f46222a79d1c86afcc07a1bbe59d",        "6aa259be3a3f160a5d0d089fdf14d70a3579d23b34bad2ae1dee50f52275ed9c",        "4820a09dae6cbfc9a77a060a919ad5913f91e6d52a75430c0672b44f241b70cc",        "8a1a527d4bf4b4993d525f1c1458235b47c26582762c6ac59cbc3162a0555499",        "157f747315d3cbf7695f6892b1aee3fb493d7fa231dd545fe5f173920b30e657",        "b4e23670c081e09e5da9f3c26aa31f84da8beab55ab299cfdddf64769551ed76",        "6adcf90ce474223545e2c204c1b48fab4ce28693a1d9bf51fb0f06d687d22a3f",        "ccf81752586ce59142e3625dd4aa7463f1e7167812f7de0ac82a924a0638284b",        "b33b71a6e98a50d8f41f00af92feec4fd77ede12d3ceb5052e53c6291920620d",        "7b7d7e02addc3dc14210d1db2baf17779b443b6dc9b70daf88cf4673d458f429",        "27d5e5756fd287f2c3e90bba57cfc82674b7d9890d9e65e4619b81fe6aa1d6c8",        "0e9dceaf3a66b076acb0ddd29041ddea4316716da26c88fdd55dad5fd862a3e3",        "b3a8003b1ebeafab289e75f8adec0f4fe80f7f220c01143173b0caf3b467fa6a",        "8e756eee24336712dcd5d03e20f2b97db7b1f74e26f077d41ba02175874dfd84",        "431c979535f701b76bfb0c4b51f35d4893dd30d4dd52bdf2f31c7002c0067369",        "ffbf8a2b64b711e61376c525a96b4206c791fc050e09a56c12d1ec187ad598ad"      ],      "timestamp":1603829337973264,      "version":3063324    }}%
+// Request: fetches current block metadata
+curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"get_metadata","params":[],"id":1}' https://testnet.libra.org/v1
+// Response in JSON:
+{
+  "libra_chain_id": 2,
+  "libra_ledger_version": 3063324,
+  "libra_ledger_timestampusec": 1603829337973264,
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "accumulator_root_hash": "a01b07539e4e6a303eeeefab2fe88be3671d4db80d6e4bd2cf19cef63e88b740",
+    "chain_id": 2,
+    "libra_version": 1,
+    "module_publishing_allowed": false,
+    "script_hash_allow_list": [
+      "6d9d309c5cc6df4c7082817eb657904781b06b2071552ae762806fce3b623463",
+      "570b8627a80ded5704775fc18060d58af396bb72565952fb0920221cc21ea9d1",
+      "19ea57b5051d34306353cc335baedbc022d28055cd6d76238a107ba433295930",
+      "a801d467df10ac00de027bc427637db66e8afc84a4bb94761b526016cb20a5ef",
+      "8f019b20740269011c05d8348cc7501bed64c7d56b8726eb8f4e21a01bd2eb4c",
+      "18da4e8c53fed321d58770e6c3f455848935cdc26153c3b41c166995787cff1d",
+      "5de6edd4b881622c4f7bc3bb9f2a1f98eeb8ca8483ad4e8dda3691c6bc5cbf32",
+      "bef38e6ed5ad51f0d060a4e194e4c8379cc6dfb60492c671a885f6752733866b",
+      "04ec5aec7f5cf5ea55e29cd65542134a7f4bb3c18421fecf00e5102dfe2d7efb",
+      "afabc7c4a2fd7b54734881f7e760e7d798cd93411839c20860a57e02eebd3893",
+      "ae693591b0d7169f4a68da27859fc055053b317c81836d6ef66a1418b1e9db5b",
+      "1a2c5cd660de7217f513bdfaa9c36bef8f384d018f128e7ddbb37dbb21f9b38f",
+      "387dce4a1f3421a369de8a48c070e7aa8e1e587ecadcf35fe254d3d8df0382b8",
+      "ff9e545db9c3546d892de6c6716d0a45929a721a14d478da3d689900eb16a394",
+      "61749d43d8f10940be6944df85ddf13f0f8fb830269c601f481cc5ee3de731c8",
+      "d01cd5656905ab073fefc899eb4af0c158ad3775d17f5d9731e5b5b040d52cfd",
+      "dfcfe1d8eb8e7a9dc1038b5d9d015c09c9e38ec6af310de7d5592de359092486",
+      "2b124c549e828df9bc38c6d45779d155f973116f077d8f0faa92c4d25389a4c1",
+      "c46e0e6d7579033024c73242b9a031d0d602f46222a79d1c86afcc07a1bbe59d",
+      "6aa259be3a3f160a5d0d089fdf14d70a3579d23b34bad2ae1dee50f52275ed9c",
+      "4820a09dae6cbfc9a77a060a919ad5913f91e6d52a75430c0672b44f241b70cc",
+      "8a1a527d4bf4b4993d525f1c1458235b47c26582762c6ac59cbc3162a0555499",
+      "157f747315d3cbf7695f6892b1aee3fb493d7fa231dd545fe5f173920b30e657",
+      "b4e23670c081e09e5da9f3c26aa31f84da8beab55ab299cfdddf64769551ed76",
+      "6adcf90ce474223545e2c204c1b48fab4ce28693a1d9bf51fb0f06d687d22a3f",
+      "ccf81752586ce59142e3625dd4aa7463f1e7167812f7de0ac82a924a0638284b",
+      "b33b71a6e98a50d8f41f00af92feec4fd77ede12d3ceb5052e53c6291920620d",
+      "7b7d7e02addc3dc14210d1db2baf17779b443b6dc9b70daf88cf4673d458f429",
+      "27d5e5756fd287f2c3e90bba57cfc82674b7d9890d9e65e4619b81fe6aa1d6c8",
+      "0e9dceaf3a66b076acb0ddd29041ddea4316716da26c88fdd55dad5fd862a3e3",
+      "b3a8003b1ebeafab289e75f8adec0f4fe80f7f220c01143173b0caf3b467fa6a",
+      "8e756eee24336712dcd5d03e20f2b97db7b1f74e26f077d41ba02175874dfd84",
+      "431c979535f701b76bfb0c4b51f35d4893dd30d4dd52bdf2f31c7002c0067369",
+      "ffbf8a2b64b711e61376c525a96b4206c791fc050e09a56c12d1ec187ad598ad"
+    ],
+    "timestamp": 1603829337973264,
+    "version": 3063324
+  }
+}
 ```
 
-
 ## Get currencies available
+
 Use [get_currencies](https://github.com/diem/diem/blob/main/json-rpc/docs/method_get_currencies.md) to query the types of currencies supported by the Diem Blockchain.
 
 ```
-// Request: fetches currencies supported by the systemcurl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"get_currencies","params":[],"id":1}' https://testnet.libra.org/v1
-// Response{  "libra_chain_id":2,  "libra_ledger_version":3068158,  "libra_ledger_timestampusec":1603830172248671,  "jsonrpc":"2.0",  "id":1,  "result":[    {      "burn_events_key":"06000000000000000000000000000000000000000a550c18",      "cancel_burn_events_key":"08000000000000000000000000000000000000000a550c18",      "code":"Coin1",      "exchange_rate_update_events_key":"09000000000000000000000000000000000000000a550c18",      "fractional_part":100,      "mint_events_key":"05000000000000000000000000000000000000000a550c18",      "preburn_events_key":"07000000000000000000000000000000000000000a550c18",      "scaling_factor":1000000,      "to_lbr_exchange_rate":1.0    },    {      "burn_events_key":"0b000000000000000000000000000000000000000a550c18",      "cancel_burn_events_key":"0d000000000000000000000000000000000000000a550c18",      "code":"LBR",      "exchange_rate_update_events_key":"0e000000000000000000000000000000000000000a550c18",      "fractional_part":1000,      "mint_events_key":"0a000000000000000000000000000000000000000a550c18",      "preburn_events_key":"0c000000000000000000000000000000000000000a550c18",      "scaling_factor":1000000,      "to_lbr_exchange_rate":1.0    }  ]}%
-
+// Request: fetches currencies supported by the system
+curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"get_currencies","params":[],"id":1}' https://testnet.libra.org/v1
+// Response in JSON:
+{
+  "libra_chain_id": 2,
+  "libra_ledger_version": 3068158,
+  "libra_ledger_timestampusec": 1603830172248671,
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": [
+    {
+      "burn_events_key": "06000000000000000000000000000000000000000a550c18",
+      "cancel_burn_events_key": "08000000000000000000000000000000000000000a550c18",
+      "code": "Coin1",
+      "exchange_rate_update_events_key": "09000000000000000000000000000000000000000a550c18",
+      "fractional_part": 100,
+      "mint_events_key": "05000000000000000000000000000000000000000a550c18",
+      "preburn_events_key": "07000000000000000000000000000000000000000a550c18",
+      "scaling_factor": 1000000,
+      "to_lbr_exchange_rate": 1
+    },
+    {
+      "burn_events_key": "0b000000000000000000000000000000000000000a550c18",
+      "cancel_burn_events_key": "0d000000000000000000000000000000000000000a550c18",
+      "code": "LBR",
+      "exchange_rate_update_events_key": "0e000000000000000000000000000000000000000a550c18",
+      "fractional_part": 1000,
+      "mint_events_key": "0a000000000000000000000000000000000000000a550c18",
+      "preburn_events_key": "0c000000000000000000000000000000000000000a550c18",
+      "scaling_factor": 1000000,
+      "to_lbr_exchange_rate": 1
+    }
+  ]
+}
 ```
 
 ## All methods
+
 You can use different methods to query the blockchain and get the information you’re looking for. We’ve included the complete list and their descriptions below.
 
 | Method                                                       | Description                                                  |
@@ -74,6 +256,5 @@ You can use different methods to query the blockchain and get the information yo
 | [get_metadata](https://github.com/diem/diem/blob/main/json-rpc/docs/method_get_metadata.md) | Get the blockchain metadata (for example, state as known to the current full node). |
 | [get_events](https://github.com/diem/diem/blob/main/json-rpc/docs/method_get_events.md) | Get the events for a given event stream key.                 |
 | [get_currencies](https://github.com/diem/diem/blob/main/json-rpc/docs/method_get_currencies.md) | Get information about all currencies supported by the Diem Blockchain. |
-
 
 ###### tags: `core`

--- a/developers.diem.com/docs/merchant/merchant-guide.md
+++ b/developers.diem.com/docs/merchant/merchant-guide.md
@@ -11,12 +11,9 @@ title: Integrate Your Merchant Store with DPN
 > **Note:** This guide is intended to provide a merchant-serving [Regulated Virtual Asset Service Provider (VASP)](reference/glossary.md#Regulated-VASP), with the necessary information needed to integrate a merchant store with the Diem Payment Network (DPN).  This guide assumes that you are a Regulated VASP, and that you have been permissioned by Diem Networks as a participant on DPN. This guide also assumes you have undergone and passed a Diem Networks security penetration test (PEN) to check for exploitable vulnerabilities.
 >
 
-
 ## Getting Started
 
 To start the integration process for DPN mainnet, you will need to [create your on-chain Regulated VASP account](#create-your-vasp-account). To create an account on testnet (Diem’s test network), you can follow the instructions [available here](core/my-first-transaction.md).
-
-
 
 Before you create your Regulated VASP account, you will need to become familiar with some account concepts.
 
@@ -24,7 +21,6 @@ DPN supports the following on-chain institutional accounts:
 
 * Regulated VASP Accounts: These accounts are reserved for [Regulated VASP](/reference/glossary.md#Regulated-VASP) that operate on the DPN usually on behalf of end users. These are of two types - [ParentVASP and ChildVASP accounts](#account-roles).
 * Designated Dealer Accounts: These accounts are reserved for designated dealers that have contracted with Diem Networks to mint and burn Diem Coins.
-
 
 #### Account roles
 
@@ -34,9 +30,9 @@ The **ParentVASP account** is your unique root account. You can have only one pa
 
 Diem Networks will create a ParentVASP account on your behalf with your authentication key. This parent account contains three key pieces of data:
 
-* its `human_name: `Your unique account name.
+* `human_name:` your unique account name.
 * `base_url:` a URL containing an endpoint to hit for off-chain APIs like exchanging information to comply with the Travel Rule. This will contain a dummy value when the ParentVASP account is created.
-* `compliance_public_key:` An ed5519 public key for authenticating signatures on Travel Rule payloads. This will contain a dummy value when the account is created.
+* `compliance_public_key:` an ed5519 public key for authenticating signatures on Travel Rule payloads. This will contain a dummy value when the account is created.
 
 >Note: Note: We recommend updating the dummy values for the base_url and compliance_public_key before sending any transactions. Though these can also be updated later before sending an off-chain transaction.
 
@@ -45,6 +41,7 @@ The **ChildVASP account** is the child of your ParentVASP account. You can have 
 Learn more about account concepts [here](core/accounts.md).
 
 ### Create Your VASP Account
+
 ![Figure 1.0 Steps to create your VASP account](https://lh3.googleusercontent.com/zugl1j3iyLgTL6U9hVQ8b1VAF5X3_zNiEezOzsgYj2sJ4-C_kPoiM9SM8BJtydfweZV1W1AuA6KlZx6R6qFqQPvyN4WCc1DBFqxOct9CXnsiL4lHQyQJBj8ZslJazNgMRKOkMZNo)
 
 1. **[Generate Keys](core/accounts.md#addresses-authentication-keys-and-cryptographic-keys)**: Generate an ed25519 keypair and associated authentication key for your on-chain Regulated VASP account.
@@ -57,11 +54,11 @@ Learn more about account concepts [here](core/accounts.md).
 5. **Create Child Account**: If you want to, you can create a new [ChildVASP account](#account-roles) from your ParentVASP account using this transaction [script](https://github.com/diem/diem/blob/main/language/diem-framework/transaction_scripts/doc/transaction_script_documentation.md#script-create_child_vasp_account). You can only create ChildVASP accounts using your ParentVASP account.
 6. **Start Transacting**: Once the previous steps have been completed, you can send transactions from your account on-chain using the keypair from step (1).
 
-
 #### Choose Currencies
+
 When you are creating your ParentVASP account, you will need to choose at least one Diem Coin currency. The Diem Coin currencies that are currently available on the DPN are:
 
-*   `XUS`(a USD stablecoin)
+* `XUS` (a USD stablecoin)
 
 At such time that more one Diem Coin currency is available, you can share with DPN which [Diem Coin currencies](core/accounts.md#currencies-and-balances]) you would like to associate with your account. You can also request DPN to choose all Diem Coin currencies available.
 
@@ -71,36 +68,37 @@ At such time that more one Diem Coin currency is available, you can share with D
 
 You can [add new Diem Coin currencies to an existing account](core/transaction-types.md#adding-a-currency-to-an-account) via the `add_currency_to_account` transaction [script](https://github.com/diem/diem/blob/main/language/diem-framework/transaction_scripts/doc/transaction_script_documentation.md#script-add_currency_to_account). You can add all currencies offered on DPN to your child VASP accounts by using the `add_all_currencies` flag in the account creation scripts.
 
-
 ## Submit a Transaction on the Network
+
 Once you have your own Regulated VASP account, you can start interacting with DPN. Before you submit your first transaction, you will need to:
 
 * [**Learn How to Interact with DPN**](#how-to-interact-with-the-dpn): Learn how you can interact with the DPN using private full nodes.
 * [**Set-up Off-chain APIs**](#how-and-when-to-use-off-chain-apis): Off-chain APIs to exchange data, where applicable..
 * [**Choose Gas Values**](#choose-gas-values): The gas values that determine the computational resources used and the fees you will incur for each transaction.
 
-
-#### Lifecycle of a Transaction
+### Lifecycle of a Transaction
 
 When you submit a transaction to the DPN, you are cryptographically signing a transaction script and then waiting (by listening to the event stream) for consensus from validators. The diagram below shows the flow of a transaction once it’s been submitted. Learn more about this flow [here](core/life-of-a-transaction.md).
 
 ![Figure 1.1 Lifecycle of a transaction](https://lh3.googleusercontent.com/Vp5Ko8_mIV5AIV6fPUZX361fCqqs1XJ44_q9Jhf6OaftznmyRplZAmczmnqjc8511ULBFKMQzzn_ZIliDK22oCQYN4gjO91JhByyHuZrQMpPUtXq1oCrSTXFDd0KwDYM3PFi6pSJ)
 
-#### How to Interact with the DPN
+### How to Interact with the DPN
+
 The first step to submitting transactions to the DPN is determining how to connect and interact with it. The guidance for this differs slightly based on if you are a validator node operator or not.
 
+#### For any DPN Participant
 
-##### For any DPN Participant
 If you are not a validator node operator, you can do one of the following:
 
 * Communicate with a validator operator or owner of a validator node to obtain dedicated access to the validator network, using either a full node or JSON-RPC as described above.
 * Leverage the public full node network, again, deploying your own full node with a JSON-RPC endpoint.
-* Access a public JSON-RPC endpoint.
+* Access a public JSON-RPC endpoint, fully trusting it. (⚠ This is not providing the same security guarantees as running your own full node, see below.)
 
 On JSON-RPC:
 
 * It is most likely that Regulated VASPs will leverage JSON-RPC to connect to the Diem Blockchain.
 * The development time of your merchant store integration with the Diem Blockchain may be faster when done using JSON-RPC.
+* Is the least secure way, as it requires you trusting a full node to provide you with the data. Shall that node go rogue, it could feed you fake data on its JSON-RPC interface without you detecting it, as the JSON-RPC responses are not (currently) providing any proofs of the validity of their data. This can be worked around by querying multiple public full nodes interfaces, or by running your own full node and connecting to its JSON-RPC endpoint.
 
 Additionally, you may also use your own private full node. It may:
 
@@ -108,10 +106,9 @@ Additionally, you may also use your own private full node. It may:
 * Give you the ability to leverage pub/sub solutions
 * Allow you to more closely monitor your submitted transaction
 * Provide additional redundancy -- when your private full node is unavailable you can easily fall back to the well-maintained public network
+* Provide all security guarantees that the Diem network can, including verification of the cryptographic proofs and validators' signatures provided by the network.
 
-
-
-##### How to Use Off-Chain APIs
+#### How to Use Off-Chain APIs
 
 Off-Chain protocols are APIs and payload specifications to support compliance and scalability on the DPN. It is executed between pairs of Regulated VASPs, such as wallets, exchanges, or designated dealers, and allows Regulated VASPs to privately exchange payment information before, while, or after settling it on the Diem Blockchain.
 
@@ -121,17 +118,18 @@ To use an off-chain API you will need to set  values for the base_url and compli
 
 You can read more about off-chain protocols [here](https://dip.diem.com/dip-1/).
 
-
 ### Choose Gas Values
+
 In the Diem Payment Network, **gas** is used to track and measure the network resources used while executing a transaction.
 
-##### Introduction to Gas
+#### Introduction to Gas
+
 Gas is a way for the Move virtual machine to track and account for the abstract representation of computational resources consumed during execution. In other words, gas is used to track and measure the network resources used during a transaction in the Diem Payment Network (DPN).
 
 Gas is used to ensure that all Move programs running on the Diem Blockchain terminate, so that the computational resources used are bounded. It also provides the ability to charge a transaction fee, partly based on consumed resources during a transaction.
 
+#### Using gas to specify a transaction fee
 
-##### Using gas to specify a transaction fee
 When an account submits a transaction for execution to the Diem Blockchain, it contains a specified:
 
 * `max_gas_amount`: This is the maximum amount of gas units that can be used to execute a transaction, and therefore bounds the amount of computational resources that can be consumed by a transaction.
@@ -140,19 +138,18 @@ When an account submits a transaction for execution to the Diem Blockchain, it c
 
 > **Note**: At launch, we anticipate these charges will be zero. But during high congestion, you can specify a gas fee.
 
-
-##### Choose Values
+#### Choose Values
 
 When an account submits a transaction for execution, **gas** is used to:
 
-*   Track and account the computational resources used.
-*   Limit the number of resources used during execution.
-*   Charge a transaction fee based on the amount of resources used for execution.
+* Track and account the computational resources used.
+* Limit the number of resources used during execution.
+* Charge a transaction fee based on the amount of resources used for execution.
 
 You can do these by setting the following parameters:
 
-
 When you submit a transaction for execution, you will use **gas** to:
+
 * Track and account the computational resources used.
 * Limit the number of resources used during execution.
 * Charge a transaction fee based on the amount of resources used for execution.
@@ -168,13 +165,14 @@ You can do these by setting the following parameters:
 You can learn more about gas and how it works [here](core/gas.md).
 
 ### What are Events?
+
 Each transaction is designed to emit any number of events as a list. An aborting transaction never emits events, so you can use events to confirm if a transaction has been successfully executed.
 
-For example, a peer-to-peer payment transaction emits a `SentPayment` event for the sender’s account and a `ReceivedPayment` event for the recipient account. The `SentPayment` event allows the sender to confirm that the payment was sent from their account, while a `ReceivedPayment `event allows the recipient to confirm that a payment was received in their account. Events are persisted on the Diem Blockchain and you (as a Regulated VASP) can use these events to answer your queries.
+For example, a peer-to-peer payment transaction emits a `SentPayment` event for the sender’s account and a `ReceivedPayment` event for the recipient account. The `SentPayment` event allows the sender to confirm that the payment was sent from their account, while a `ReceivedPayment`event allows the recipient to confirm that a payment was received in their account. Events are persisted on the Diem Blockchain and you (as a Regulated VASP) can use these events to answer your queries.
 
-##### Event Structure
+#### Event Structure
 
-There are a number of events that can be emitted from a transaction. The primary ones that you should be aware of are the `SentPayment`, and `ReceivedPayment` events.  A `ReceivedPayment` event contains the amount received and currency, the sending address, and a metadata field that contains any transaction specific information that the sender has added to the payment, subject to certain limitations specified in the Participation Agreement and DPN Rules. Likewise, a `SentPayment `event contains the amount sent and currency, the receiving account address, and any metadata that the sender has added to the payment.
+There are a number of events that can be emitted from a transaction. The primary ones that you should be aware of are the `SentPayment`, and `ReceivedPayment` events.  A `ReceivedPayment` event contains the amount received and currency, the sending address, and a metadata field that contains any transaction specific information that the sender has added to the payment, subject to certain limitations specified in the Participation Agreement and DPN Rules. Likewise, a `SentPayment`event contains the amount sent and currency, the receiving account address, and any metadata that the sender has added to the payment.
 
 The exact structures of these events are as follows:
 
@@ -205,7 +203,6 @@ where the amount structure is:
 | `amount` | u64 | Amount in base currency units (e.g. microdiem).|
 | `currency` | String | Currency code (e.g. `XUS`) |
 
-
 More information on event structures, and how they can be queried and the surrounding data in the JSON responses can be found [here](https://github.com/diem/diem/blob/main/json-rpc/json-rpc-spec.md).
 
 To check for new transactions posted to your account, you need to [query the blockchain](core/query-the-blockchain.md) using the JSON-RPC endpoints.
@@ -215,16 +212,16 @@ To check for new transactions posted to your account, you need to [query the blo
 
 ## Accepting Direct Payments
 
-#### Checkout Experience
+### Checkout Experience
 
 When the Diem Payment Network launches, we expect that wallets will support a basic set of payment flows that resemble peer-to-peer transactions. Accordingly, the initial range of merchant checkout options will be limited to direct payments: single point-in-time transactions with a known amount and currency type.
 
 To provide an interoperable checkout experience, a merchant service provider will need to share payment information with the end user. This can happen through a generated QR code, copy-pastable URI, or mobile deep link.
 
-
 ![Figure 2.0 How checkout works for direct payments](/img/docs/direct-payments.svg)
 
 This “payment context” includes:
+
 * Fully qualified address: stable on-chain address and unique, generated subaddress
 * Payment amount in microunits
 * Currency code
@@ -233,18 +230,18 @@ More information about payment request URI serialization can be found [here](htt
 
 After the RegulatedVASP providing the relevant consumer with a wallet receives the “payment context,” it can construct a pre-populated payment for the user to authorize.
 
-
 When the user authorizes their wallet to pay the merchant per the shared “payment context,” their wallet will go through a similar sender flow to a peer-to-peer payment. A transaction is committed directly on-chain as long as the amount doesn't exceed the Travel Rule threshold. If the Travel Rule goes into effect, the payment will first be preflighted through the off-chain protocol, before being committed on-chain.
 
 More information about the off-chain protocol can be found [here](https://dip.diem.com/dip-1/).
 
-#### Detecting Purchases
+### Detecting Purchases
+
 A merchant service provider can interface with a full node to track emitted events for their on-chain accounts. If they see that they have received funds, they can examine the accompanying subaddress to route the funds internally. Since the subaddress will be unique for each transaction, they can determine who the buyer was. In other words, the merchant service provider can connect the funds received to a checkout session and signal confirmation to the end user.
 
 More information about events can be found [here](/core/events.md).
 
+### Handling Refunds
 
-#### Handling Refunds
 In some cases, a merchant may want to issue a refund to a customer. For instance, if the merchant receives duplicate payments or a payment to an invalid subaddress. Additionally, merchants may want to refund a user upon a return or other customer support inquiry.
 
 Refunds on the DPN resemble any other peer-to-peer transaction. A merchant service provider would need to construct a transaction script on behalf of the merchant, and submit it to the original customer. These transactions are subject to the Travel Rule controls and will require off-chain preflighting if the amount exceeds the Travel Rule threshold.
@@ -252,6 +249,5 @@ Refunds on the DPN resemble any other peer-to-peer transaction. A merchant servi
 Unlike other transactions, refunds will contain a pointer to the original transaction that they correspond to. If the transaction exceeds the Travel Rule threshold, the `original event reference id` is included in the off-chain payload. Otherwise (ie. in the non-Travel Rule case), the `original event sequence number` is sent in the on-chain body of the refund transaction. Wallets that receive refunds can use the reference to the original transaction to provide additional context to the inbound funds.
 
 More information about refunds can be found [here](https://drive.google.com/file/d/1YUEtAqd0N5dl2vg5EgEQhrVQKNN0OhoI/view?usp=sharing). Additional information about transaction serialization can be found [here](https://dip.diem.com/dip-4/).
-
 
 ###### tags: `merchant`

--- a/developers.diem.com/docs/sdks/overview.md
+++ b/developers.diem.com/docs/sdks/overview.md
@@ -39,3 +39,10 @@ Select a language to access its approved Diem resource package on GitHub:
     to="https://diem.github.io/diem"
   />
 </CardsWrapper>
+
+## Warning
+
+Notice that the SDKs are assuming that you have a trusted fullnode providing you with the required JSON-RPC API. The JSON-RPC responses are not providing any proofs that would allow you to verify they contain data that can be trusted.
+
+If you are connecting to a public fullnode that you do not own, it is not providing you the same security guarantees as if you were running your own, allowing it to easily feed you with fake data.
+We strongly recommend running your own fullnode as soon as you depend on the JSON-RPC API or the SDKs for any critical operation.


### PR DESCRIPTION
and running some markdown linter on the modified files

## Motivation

Currently we recognize that relying on a JSON-RPC endpoint provided by a public fullnode might not be the best solution from a security point of view, since the JSON-RPC API isn't exposing crypto proofs for its data.

The best way to do it securely is to run our own fullnode, and then rely on its JSON-RPC API. (Which needs not be public then), but this was previously undocumented.

This PR attempts to add the proper warnings and information for people to know what they are exposing themselves to when relying on a public JSON-RPC endpoint.
