### PR TITLE
[cluster-test] Revert 7959

### DIFF
--- a/testsuite/cluster-test/src/experiments/compatibility_test.rs
+++ b/testsuite/cluster-test/src/experiments/compatibility_test.rs
@@ -196,7 +196,7 @@ impl Experiment for CompatibilityTest {
         info!("{}", msg);
         context.report.report_text(msg);
         let all_full_nodes_request = EmitJobRequest::for_instances(
-            context.cluster.validator_instances().to_vec(),
+            context.cluster.fullnode_instances().to_vec(),
             context.global_emit_job_request,
             0,
             0,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The first batch of transactions in the LBT are being sent to validator nodes now instead of the full nodes. This might result in the recent flaky LBT. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan

Manually ran the cluster test on a few previously failed LBR runs. Those runs passed.

## Related PRs
#7959 