### PR TITLE
[move-lang] Attributes

### DIFF
--- a/language/move-lang/src/cfgir/translate.rs
+++ b/language/move-lang/src/cfgir/translate.rs
@@ -181,6 +181,7 @@ fn module(
     mdef: H::ModuleDefinition,
 ) -> (ModuleIdent, G::ModuleDefinition) {
     let H::ModuleDefinition {
+        attributes,
         is_source_module,
         dependency_order,
         friends,
@@ -194,6 +195,7 @@ fn module(
     (
         module_ident,
         G::ModuleDefinition {
+            attributes,
             is_source_module,
             dependency_order,
             friends,
@@ -216,6 +218,7 @@ fn scripts(
 
 fn script(context: &mut Context, hscript: H::Script) -> G::Script {
     let H::Script {
+        attributes,
         loc,
         constants: hconstants,
         function_name,
@@ -224,6 +227,7 @@ fn script(context: &mut Context, hscript: H::Script) -> G::Script {
     let constants = hconstants.map(|name, c| constant(context, name, c));
     let function = function(context, function_name.clone(), hfunction);
     G::Script {
+        attributes,
         loc,
         constants,
         function_name,
@@ -237,6 +241,7 @@ fn script(context: &mut Context, hscript: H::Script) -> G::Script {
 
 fn constant(context: &mut Context, _name: ConstantName, c: H::Constant) -> G::Constant {
     let H::Constant {
+        attributes,
         loc,
         signature,
         value: (locals, block),
@@ -246,6 +251,7 @@ fn constant(context: &mut Context, _name: ConstantName, c: H::Constant) -> G::Co
     let value = final_value.and_then(move_value_from_exp);
 
     G::Constant {
+        attributes,
         loc,
         signature,
         value,
@@ -355,11 +361,13 @@ fn move_value_from_value(sp!(_, v_): Value) -> MoveValue {
 //**************************************************************************************************
 
 fn function(context: &mut Context, _name: FunctionName, f: H::Function) -> G::Function {
+    let attributes = f.attributes;
     let visibility = f.visibility;
     let signature = f.signature;
     let acquires = f.acquires;
     let body = function_body(context, &signature, &acquires, f.body);
     G::Function {
+        attributes,
         visibility,
         signature,
         acquires,

--- a/language/move-lang/src/expansion/dependency_ordering.rs
+++ b/language/move-lang/src/expansion/dependency_ordering.rs
@@ -179,7 +179,7 @@ fn module(context: &mut Context, mident: ModuleIdent, mdef: &E::ModuleDefinition
     context.current_module = Some(mident);
     mdef.friends
         .key_cloned_iter()
-        .for_each(|(mident, loc)| context.add_friend(mident, *loc));
+        .for_each(|(mident, friend)| context.add_friend(mident, friend.loc));
     mdef.structs
         .iter()
         .for_each(|(_, _, sdef)| struct_def(context, sdef));

--- a/language/move-lang/src/hlir/ast.rs
+++ b/language/move-lang/src/hlir/ast.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    expansion::ast::{ability_modifiers_ast_debug, AbilitySet, SpecId, Value},
+    expansion::ast::{ability_modifiers_ast_debug, AbilitySet, Attribute, Friend, SpecId, Value},
     naming::ast::{BuiltinTypeName, BuiltinTypeName_, TParam},
     parser::ast::{
         BinOp, ConstantName, Field, FunctionName, ModuleIdent, StructName, UnaryOp, Var, Visibility,
@@ -30,6 +30,7 @@ pub struct Program {
 
 #[derive(Debug, Clone)]
 pub struct Script {
+    pub attributes: Vec<Attribute>,
     pub loc: Loc,
     pub constants: UniqueMap<ConstantName, Constant>,
     pub function_name: FunctionName,
@@ -42,10 +43,11 @@ pub struct Script {
 
 #[derive(Debug, Clone)]
 pub struct ModuleDefinition {
+    pub attributes: Vec<Attribute>,
     pub is_source_module: bool,
     /// `dependency_order` is the topological order/rank in the dependency graph.
     pub dependency_order: usize,
-    pub friends: UniqueMap<ModuleIdent, Loc>,
+    pub friends: UniqueMap<ModuleIdent, Friend>,
     pub structs: UniqueMap<StructName, StructDefinition>,
     pub constants: UniqueMap<ConstantName, Constant>,
     pub functions: UniqueMap<FunctionName, Function>,
@@ -57,6 +59,7 @@ pub struct ModuleDefinition {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct StructDefinition {
+    pub attributes: Vec<Attribute>,
     pub abilities: AbilitySet,
     pub type_parameters: Vec<TParam>,
     pub fields: StructFields,
@@ -74,6 +77,7 @@ pub enum StructFields {
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct Constant {
+    pub attributes: Vec<Attribute>,
     pub loc: Loc,
     pub signature: BaseType,
     pub value: (UniqueMap<Var, SingleType>, Block),
@@ -102,6 +106,7 @@ pub type FunctionBody = Spanned<FunctionBody_>;
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct Function {
+    pub attributes: Vec<Attribute>,
     pub visibility: Visibility,
     pub signature: FunctionSignature,
     pub acquires: BTreeMap<StructName, Loc>,
@@ -558,11 +563,13 @@ impl AstDebug for Program {
 impl AstDebug for Script {
     fn ast_debug(&self, w: &mut AstWriter) {
         let Script {
+            attributes,
             loc: _loc,
             constants,
             function_name,
             function,
         } = self;
+        attributes.ast_debug(w);
         for cdef in constants.key_cloned_iter() {
             cdef.ast_debug(w);
             w.new_line();
@@ -574,6 +581,7 @@ impl AstDebug for Script {
 impl AstDebug for ModuleDefinition {
     fn ast_debug(&self, w: &mut AstWriter) {
         let ModuleDefinition {
+            attributes,
             is_source_module,
             dependency_order,
             friends,
@@ -581,6 +589,7 @@ impl AstDebug for ModuleDefinition {
             constants,
             functions,
         } = self;
+        attributes.ast_debug(w);
         if *is_source_module {
             w.writeln("library module")
         } else {
@@ -611,11 +620,13 @@ impl AstDebug for (StructName, &StructDefinition) {
         let (
             name,
             StructDefinition {
+                attributes,
                 abilities,
                 type_parameters,
                 fields,
             },
         ) = self;
+        attributes.ast_debug(w);
         if let StructFields::Native(_) = fields {
             w.write("native ");
         }
@@ -640,12 +651,14 @@ impl AstDebug for (FunctionName, &Function) {
         let (
             name,
             Function {
+                attributes,
                 visibility,
                 signature,
                 acquires,
                 body,
             },
         ) = self;
+        attributes.ast_debug(w);
         visibility.ast_debug(w);
         if let FunctionBody_::Native = &body.value {
             w.write("native ");
@@ -710,11 +723,13 @@ impl AstDebug for (ConstantName, &Constant) {
         let (
             name,
             Constant {
+                attributes,
                 loc: _loc,
                 signature,
                 value,
             },
         ) = self;
+        attributes.ast_debug(w);
         w.write(&format!("const {}:", name));
         signature.ast_debug(w);
         w.write(" = ");

--- a/language/move-lang/src/hlir/translate.rs
+++ b/language/move-lang/src/hlir/translate.rs
@@ -168,6 +168,7 @@ fn module(
     mdef: T::ModuleDefinition,
 ) -> (ModuleIdent, H::ModuleDefinition) {
     let T::ModuleDefinition {
+        attributes,
         is_source_module,
         dependency_order,
         friends,
@@ -186,6 +187,7 @@ fn module(
     (
         module_ident,
         H::ModuleDefinition {
+            attributes,
             is_source_module,
             dependency_order,
             friends,
@@ -208,6 +210,7 @@ fn scripts(
 
 fn script(context: &mut Context, tscript: T::Script) -> H::Script {
     let T::Script {
+        attributes,
         loc,
         constants: tconstants,
         function_name,
@@ -216,6 +219,8 @@ fn script(context: &mut Context, tscript: T::Script) -> H::Script {
     let constants = tconstants.map(|name, c| constant(context, name, c));
     let function = function(context, function_name.clone(), tfunction);
     H::Script {
+        attributes,
+
         loc,
         constants,
         function_name,
@@ -229,11 +234,13 @@ fn script(context: &mut Context, tscript: T::Script) -> H::Script {
 
 fn function(context: &mut Context, _name: FunctionName, f: T::Function) -> H::Function {
     assert!(context.has_empty_locals());
+    let attributes = f.attributes;
     let visibility = f.visibility;
     let signature = function_signature(context, f.signature);
     let acquires = f.acquires;
     let body = function_body(context, &signature, f.body);
     H::Function {
+        attributes,
         visibility,
         signature,
         acquires,
@@ -318,6 +325,7 @@ fn function_body_defined(
 
 fn constant(context: &mut Context, _name: ConstantName, cdef: T::Constant) -> H::Constant {
     let T::Constant {
+        attributes,
         loc,
         signature: tsignature,
         value: tvalue,
@@ -336,6 +344,7 @@ fn constant(context: &mut Context, _name: ConstantName, cdef: T::Constant) -> H:
     };
     let (locals, body) = function_body_defined(context, &function_signature, eloc, tseq);
     H::Constant {
+        attributes,
         loc,
         signature,
         value: (locals, body),
@@ -351,10 +360,12 @@ fn struct_def(
     _name: StructName,
     sdef: N::StructDefinition,
 ) -> H::StructDefinition {
+    let attributes = sdef.attributes;
     let abilities = sdef.abilities;
     let type_parameters = sdef.type_parameters;
     let fields = struct_fields(context, sdef.fields);
     H::StructDefinition {
+        attributes,
         abilities,
         type_parameters,
         fields,

--- a/language/move-lang/src/lib.rs
+++ b/language/move-lang/src/lib.rs
@@ -495,7 +495,7 @@ fn shadow_lib_module_definitions(pprog: parser::ast::Program) -> parser::ast::Pr
     let mut modules_defined_in_src = BTreeSet::new();
     for def in &source_definitions {
         match def {
-            parser::ast::Definition::Address(_, addr, modules) => {
+            parser::ast::Definition::Address(_, _, addr, modules) => {
                 for module in modules {
                     modules_defined_in_src.insert((*addr, module.name.clone()));
                 }
@@ -517,7 +517,7 @@ fn shadow_lib_module_definitions(pprog: parser::ast::Program) -> parser::ast::Pr
     let lib_definitions = lib_definitions
         .into_iter()
         .filter(|def| match def {
-            parser::ast::Definition::Address(_, addr, modules) => !modules
+            parser::ast::Definition::Address(_, _, addr, modules) => !modules
                 .iter()
                 .any(|module| modules_defined_in_src.contains(&(*addr, module.name.clone()))),
             parser::ast::Definition::Module(module) => !modules_defined_in_src.contains(&(

--- a/language/move-lang/src/parser/lexer.rs
+++ b/language/move-lang/src/parser/lexer.rs
@@ -77,6 +77,7 @@ pub enum Tok {
     Script,
     Const,
     Friend,
+    NumSign,
 }
 
 impl fmt::Display for Tok {
@@ -152,6 +153,7 @@ impl fmt::Display for Tok {
             Script => "script",
             Const => "const",
             Friend => "friend",
+            NumSign => "#",
         };
         fmt::Display::fmt(s, formatter)
     }
@@ -411,6 +413,7 @@ fn find_token(file: &'static str, text: &str, start_offset: usize) -> Result<(To
         '^' => (Tok::Caret, 1),
         '{' => (Tok::LBrace, 1),
         '}' => (Tok::RBrace, 1),
+        '#' => (Tok::NumSign, 1),
         _ => {
             let loc = make_loc(file, start_offset, start_offset);
             return Err(vec![(loc, format!("Invalid character: '{}'", c))]);

--- a/language/move-lang/src/to_bytecode/translate.rs
+++ b/language/move-lang/src/to_bytecode/translate.rs
@@ -127,7 +127,8 @@ pub fn program(
     }
     for (key, s) in gscripts {
         let G::Script {
-            loc: _,
+            attributes: _attributes,
+            loc: _loc,
             constants,
             function_name,
             function,
@@ -396,6 +397,7 @@ fn struct_def(
     sdef: H::StructDefinition,
 ) -> IR::StructDefinition {
     let H::StructDefinition {
+        attributes: _attributes,
         abilities: abs,
         type_parameters: tys,
         fields,
@@ -475,6 +477,7 @@ fn function(
     fdef: G::Function,
 ) -> ((IR::FunctionName, IR::Function), CollectedInfo) {
     let G::Function {
+        attributes: _attributes,
         visibility: v,
         signature,
         acquires,

--- a/language/move-lang/src/typing/core.rs
+++ b/language/move-lang/src/typing/core.rs
@@ -117,7 +117,7 @@ impl<'env> Context<'env> {
                 signature: cdef.signature.clone(),
             });
             let minfo = ModuleInfo {
-                friends: mdef.friends.clone(),
+                friends: mdef.friends.ref_map(|_, friend| friend.loc),
                 structs,
                 functions,
                 constants,

--- a/language/move-lang/src/typing/translate.rs
+++ b/language/move-lang/src/typing/translate.rs
@@ -56,6 +56,7 @@ fn module(
     assert!(context.current_script_constants.is_none());
     context.current_module = Some(ident);
     let N::ModuleDefinition {
+        attributes,
         is_source_module,
         dependency_order,
         friends,
@@ -70,6 +71,7 @@ fn module(
     let functions = nfunctions.map(|name, f| function(context, name, f, false));
     assert!(context.constraints.is_empty());
     T::ModuleDefinition {
+        attributes,
         is_source_module,
         dependency_order,
         friends,
@@ -93,6 +95,7 @@ fn script(context: &mut Context, nscript: N::Script) -> T::Script {
     assert!(context.current_script_constants.is_none());
     context.current_module = None;
     let N::Script {
+        attributes,
         loc,
         constants: nconstants,
         function_name,
@@ -103,6 +106,7 @@ fn script(context: &mut Context, nscript: N::Script) -> T::Script {
     let function = function(context, function_name.clone(), nfunction, true);
     context.current_script_constants = None;
     T::Script {
+        attributes,
         loc,
         function_name,
         function,
@@ -164,6 +168,7 @@ fn function(
 ) -> T::Function {
     let loc = name.loc();
     let N::Function {
+        attributes,
         visibility,
         mut signature,
         body: n_body,
@@ -199,6 +204,7 @@ fn function(
     let body = function_body(context, &acquires, n_body);
     context.current_function = None;
     T::Function {
+        attributes,
         visibility,
         signature,
         acquires,
@@ -271,6 +277,7 @@ fn constant(context: &mut Context, _name: ConstantName, nconstant: N::Constant) 
     context.reset_for_module_item();
 
     let N::Constant {
+        attributes,
         loc,
         signature,
         value: nvalue,
@@ -303,6 +310,7 @@ fn constant(context: &mut Context, _name: ConstantName, nconstant: N::Constant) 
     check_valid_constant::exp(context, &value);
 
     T::Constant {
+        attributes,
         loc,
         signature,
         value,

--- a/language/move-lang/tests/move_check/expansion/friend_decl_aliased_duplicates.exp
+++ b/language/move-lang/tests/move_check/expansion/friend_decl_aliased_duplicates.exp
@@ -6,6 +6,6 @@ error:
    │     ^^^^^^^^^^^^^^^^ Duplicate friend declaration '0x42::A'. Friend declarations in a module must be unique
    ·
  6 │     friend 0x42::A;
-   │            ------- Previously declared here
+   │     --------------- Previously declared here
    │
 

--- a/language/move-lang/tests/move_check/expansion/friend_decl_imported_duplicates.exp
+++ b/language/move-lang/tests/move_check/expansion/friend_decl_imported_duplicates.exp
@@ -6,6 +6,6 @@ error:
    │     ^^^^^^^^^ Duplicate friend declaration '0x42::A'. Friend declarations in a module must be unique
    ·
  6 │     friend 0x42::A;
-   │            ------- Previously declared here
+   │     --------------- Previously declared here
    │
 

--- a/language/move-lang/tests/move_check/expansion/friend_decl_qualified_duplicates.exp
+++ b/language/move-lang/tests/move_check/expansion/friend_decl_qualified_duplicates.exp
@@ -6,6 +6,6 @@ error:
    │     ^^^^^^^^^^^^^^^ Duplicate friend declaration '0x42::A'. Friend declarations in a module must be unique
    ·
  5 │     friend 0x42::A;
-   │            ------- Previously declared here
+   │     --------------- Previously declared here
    │
 

--- a/language/move-lang/tests/move_check/parser/attribute_no_closing_bracket.exp
+++ b/language/move-lang/tests/move_check/parser/attribute_no_closing_bracket.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/parser/attribute_no_closing_bracket.move:4:5 ───
+   │
+ 4 │     fun foo() {}
+   │     ^ Expected ']'
+   ·
+ 3 │     #[attr = 0
+   │      - To match this '['
+   │
+

--- a/language/move-lang/tests/move_check/parser/attribute_no_closing_bracket.move
+++ b/language/move-lang/tests/move_check/parser/attribute_no_closing_bracket.move
@@ -1,0 +1,5 @@
+module 0x42::M {
+    // Errors expecting a ']'
+    #[attr = 0
+    fun foo() {}
+}

--- a/language/move-lang/tests/move_check/parser/attribute_num_sign_no_bracket.exp
+++ b/language/move-lang/tests/move_check/parser/attribute_num_sign_no_bracket.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/parser/attribute_num_sign_no_bracket.move:4:5 ───
+   │
+ 4 │     fun foo() {}
+   │     ^^^ Unexpected 'fun'
+   ·
+ 4 │     fun foo() {}
+   │     --- Expected '['
+   │
+

--- a/language/move-lang/tests/move_check/parser/attribute_num_sign_no_bracket.move
+++ b/language/move-lang/tests/move_check/parser/attribute_num_sign_no_bracket.move
@@ -1,0 +1,5 @@
+module 0x42::M {
+    // Errors expecting a '['
+    #
+    fun foo() {}
+}

--- a/language/move-lang/tests/move_check/parser/attribute_placement.move
+++ b/language/move-lang/tests/move_check/parser/attribute_placement.move
@@ -1,0 +1,46 @@
+#[attr]
+address 0x42 {
+#[attr]
+module M {
+    #[attr]
+    use 0x42::N;
+
+    #[attr]
+    struct S {}
+
+    #[attr]
+    const C: u64 = 0;
+
+    #[attr]
+    public fun foo() { N::bar() }
+
+    #[attr]
+    spec fun foo {}
+}
+}
+
+#[attr]
+module 0x42::N {
+    #[attr]
+    friend 0x42::M;
+
+    #[attr]
+    public fun bar() {}
+}
+
+#[attr]
+script {
+    #[attr]
+    use 0x42::M;
+
+    #[attr]
+    const C: u64 = 0;
+
+    #[attr]
+    fun main() {
+        M::foo();
+    }
+
+    #[attr]
+    spec fun main { }
+}

--- a/language/move-lang/tests/move_check/parser/attribute_variants.move
+++ b/language/move-lang/tests/move_check/parser/attribute_variants.move
@@ -1,0 +1,5 @@
+#[]
+#[attr, attr=0, attr1=b"hello", attr1=x"0f", attr2=0x42, attr2(attr, attr1, attr2(attr, attr1=0))]
+#[attr=false, attr1=0u8, attr2=0u64, attr=0u128]
+#[]
+module 0x42::M {}

--- a/language/move-model/src/lib.rs
+++ b/language/move-model/src/lib.rs
@@ -228,6 +228,7 @@ fn run_spec_checker(env: &mut GlobalEnv, units: Vec<CompiledUnit>, mut eprog: Pr
                     function_info,
                 } => {
                     let move_lang::expansion::ast::Script {
+                        attributes,
                         loc,
                         function_name,
                         constants,
@@ -256,6 +257,7 @@ fn run_spec_checker(env: &mut GlobalEnv, units: Vec<CompiledUnit>, mut eprog: Pr
                     let mut functions = UniqueMap::new();
                     functions.add(function_name, function).unwrap();
                     let expanded_module = ModuleDefinition {
+                        attributes,
                         loc,
                         dependency_order: usize::MAX,
                         is_source_module: true,


### PR DESCRIPTION
 - Added attributes to Move
 - Syntax is based on Rust attribute syntax, which is in turn based on the standards found in ECMA-334 and ECMA-335
 - Attributes can currently be added on address blocks, modules, scripts, and any module top level member. 
   - Eventually they should be able to be parsed on expression blocks, expression spec blocks, and expression use statements. 
   
- There is no sanity checking currently 
  - we probably eventually want some way for attributes to register with the compiler so they can be checked
  - We will likely hard code this temporarily for unit tests

## Motivation

- Blocking for unit test framework
- Should be helpful for other tools too, particularly the prover. 

## Test Plan

- Added a few tests 

## Related PRs

Built on top of #8143, so waiting for that to land