### PR TITLE
[Cluster Test] Add state sync performance test to new_pre_release suite

### DIFF
--- a/testsuite/cluster-test/src/suite.rs
+++ b/testsuite/cluster-test/src/suite.rs
@@ -59,6 +59,7 @@ impl ExperimentSuite {
                 .enable_db_backup()
                 .build(cluster),
         ));
+        experiments.push(Box::new(StateSyncPerformanceParams::new(60).build(cluster)));
         experiments.push(Box::new(TwinValidatorsParams { pair: 1 }.build(cluster)));
         // This can't be run before any experiment that requires clean_data.
         experiments.push(Box::new(


### PR DESCRIPTION
## Motivation

This PR adds the state sync performance test to the `new_pre_release` test suite. This allows us to run the performance benchmark on all continuous pushes to keep better track of state sync performance (e.g., these numbers will automatically be posted in the #changelog channel).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

I've run the state sync test suite manually using the cluster test tool.

## Related PRs

None.
