### PR TITLE
[move-prover] Enable some cvc4 functional tests.

### DIFF
--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -44,8 +44,10 @@ runs:
         # prepare move lang prover tooling.
         # By setting these values the dev-setup.sh script can detect already installed executables (and check versions).
         echo 'Z3_EXE='${HOME}/bin/z3 | tee -a $GITHUB_ENV
+        echo 'CVC4_EXE='${HOME}/bin/cvc4 | tee -a $GITHUB_ENV
         echo 'DOTNET_ROOT='${HOME}/.dotnet/ | tee -a $GITHUB_ENV
         echo 'BOOGIE_EXE='${HOME}/.dotnet/tools/boogie | tee -a $GITHUB_ENV
+        echo 'MVP_TEST_ON_CI'='1' | tee -a $GITHUB_ENV
         echo "$HOME/bin" | tee -a $GITHUB_PATH
         echo "$HOME/.dotnet" | tee -a $GITHUB_PATH
         echo "/opt/cargo/bin" | tee -a $GITHUB_PATH

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4443,6 +4443,7 @@ dependencies = [
  "tokio",
  "toml",
  "vm",
+ "walkdir",
 ]
 
 [[package]]

--- a/docker/ci/github/Dockerfile
+++ b/docker/ci/github/Dockerfile
@@ -20,6 +20,7 @@ RUN mkdir -p /github/home \
 ENV PATH "/opt/cargo/bin:/usr/lib/golang/bin:/github/home/bin:$PATH"
 ENV DOTNET_ROOT "/github/home/.dotnet"
 ENV Z3_EXE "/github/home/bin/z3"
+ENV CVC4_EXE "/github/home/bin/cvc4"
 ENV BOOGIE_EXE "/github/home/.dotnet/tools/boogie"
 
 FROM setup_ci as tested_ci

--- a/language/move-prover/Cargo.toml
+++ b/language/move-prover/Cargo.toml
@@ -45,6 +45,7 @@ toml = "0.5.8"
 datatest-stable = { path = "../../common/datatest-stable" }
 move-prover-test-utils = { path = "test-utils" }
 shell-words = "1.0.0"
+walkdir = "2.3.1"
 
 [[test]]
 name = "testsuite"

--- a/language/move-prover/src/lib.rs
+++ b/language/move-prover/src/lib.rs
@@ -81,6 +81,9 @@ pub fn run_move_prover<W: WriteColor>(
         return Ok(run_read_write_set(&env, &options, now));
     }
 
+    // Check correct backend versions.
+    options.backend.check_tool_versions()?;
+
     // Create and process bytecode
     let now = Instant::now();
     let targets = create_and_process_bytecode(&options, &env);

--- a/language/move-prover/tests/README.md
+++ b/language/move-prover/tests/README.md
@@ -1,54 +1,77 @@
-# Tests for Move Prover
+# Tests for the Move Prover
 
-This directory contains the tests for Move Prover. The tests are defined by the `.move` files in this tree,
-as well as all the `.move` files in the [Diem framework](../../diem-framework).
+This directory contains the tests for the Move Prover. The tests are defined by the `.move` files in
+this tree, as well as all the `.move` files in the [Diem framework](../../diem-framework) and the
+[Move stdlib](../../move-stdlib).
 
-*Note*: in order to run these tests locally, you must have installed tools and setup a few environment variables.
-See [`../doc/user/install.md`](../doc/user/install.md) for details. If the environment variables for
-configuring the prover are not set as described there, all tests and this directory will trivially pass.
+*Note*: in order to run these tests locally, you must have installed tools and setup a few
+environment variables. See [`../doc/user/install.md`](../doc/user/install.md) for details. If the
+environment variables for configuring the prover are not set as described there, all tests and this
+directory will trivially pass.
 
-*Note*: these are baseline tests, with expectations of prover output stored in files ending in `.exp`. To update
-those files, use `UPBL=1 cargo test`. To update or test a single file, you can also provide a fragment of the move
-source path.
+*Note*: these are baseline tests, with expectations of prover output stored in files ending in
+`.exp`. To update those files, use `UPBL=1 cargo test`. To update or test a single file, you can
+also provide a fragment of the Move source path.
 
-*Note*: there are three sets of tests here. The basic ones are those in `./sources`, in `../../diem-framework`, and in
-`../../move-stdlib`. Those are run by default and are merge blockers for submitting changes. An extended set of tests is
-found `./xsources`. Those are only run if the environment variable `MVP_TEST_X=1` is set.
+## Quick Guide
 
-There is a convention for test cases under this directory. In general, there are two kinds of test cases, which can be
-mixed in a file. The first type of test cases are "correct" Move functions which are expected to be proven so.
-Another type of test cases are incorrect Move functions which are expected to be disproven, with the created errors
-stored in so-called 'expectation baseline files' (`.exp`). The incorrect functions have suffix `_incorrect` in
-their names, by convention. It is expected that only errors for functions with this suffix appear in `.exp` files.
+- In order to regenerate baseline files, use `UPBL=1 cargo test <optional test filter>`
+- In order to narrow tests to a particular feature, use `MVP_TEST_FEATURE=<feature> cargo test`. If
+  not set, all features will be tested for each test they are enabled for. (See discussion below
+  about feature enabling).
+- In order to run tests with consistency checking enabled, use `MVP_TEST_INCONSISTENCY=1 cargo test`
+  .
+- In order to run tests with a specific flag combination, use `MVP_TEST_FLAGS=<flags> cargo test`.
+- In order to run the tests in the `tests/xsources` tree instead of the default locations, use
+  `MVP_TEST_X=1 cargo test`.
 
-`cargo test` will automatically detect all `.move` files under this directory and its sub-directories and let the Prover
-attempt to prove each function in the file. Unlike `cargo run`, `cargo test` can detect various directives
-in comments in the Move source:
+Certain comments in the test sources are interpreted by the test driver as test directives. A
+directive is a single line comment in the source of the form `// <directive>: <value>`. Directives
+can be repeated. The following directives are supported:
 
-- The line `// flag: <flag>` provides a flag to the Prover (see `cargo run -- --help` for  available flags). For
-  example, use  `// flag: --verify=public` to restrict verification to public functions (by default, tests use
-  `--verify=all`).
-- You can also pass flags to test using the env variable `MVP_TEST_FLAGS`. This is a string as provided on
-  the command line to the Move prover which can contain multiple flgs.
-- The line `// no-boogie-test` instructs the test driver to not attempt to run boogie at all. This is to support
-  negative tests where translation to boogie actually fails.
+- `// flag: <flags>` to run the test with the given flags in addition to the default flags.
+- `// no_ci:` exclude this test from running in CI.
+- `// exclude_for: <feature>` to exclude a test for a feature configured as "inclusive" (see below).
+- `// also_include_for: <feature>` to include a test for a feature configured as
+  "exclusive".
+
+Features can be either inclusive or exclusive. For an inclusive feature all tests are run unless
+explicitly excluded with `// exclude_for`. For an exclusive feature only those tests are run which
+have the directive `// also_include_for`.
+
+Currently the following features are available:
+
+- `default`: runs tests with all default flags. This feature is inclusive.
+- `cvc4`: runs tests configured to use the CVC4 solver as a backend. This feature is exclusive.
+
+## Conventions
+
+There is a convention for test cases under this directory. In general, there are two kinds of test
+cases, which can be mixed in a file. The first type of test cases are "correct" Move functions which
+are expected to be proven so. Another type of test cases are incorrect Move functions which are
+expected to be disproven, with the created errors stored in so-called 'expectation baseline
+files' (`.exp`). The incorrect functions have suffix `_incorrect` in their names, by convention. It
+is expected that only errors for functions with this suffix appear in `.exp` files.
 
 
 ## Debugging Long Running Tests
 
-By default, the prover uses a timeout of 40 seconds, which can be changed by the `-T=<seconds>` flag. Healthy tests
-should never take that long to finish. To avoid flakes in continuous integration, you should test your tests to
-be able to pass at least with `-T=20`. To do so use
+By default, the prover uses a timeout of 40 seconds, which can be changed by the `-T=<seconds>`
+flag. Healthy tests should never take that long to finish. To avoid flakes in continuous
+integration, you should test your tests to be able to pass at least with `-T=20`. To do so use
 
 ```shell script
 MVP_TEST_FLAGS="-T=20" cargo test -p move-prover
 ```
 
 ## Inconsistency Check
-If the flag `--check-inconsistency` is given, the prover not only verifies a target, but also checks if there is any
-inconsistent assumption in the verification. If the environment variable `MVP_TEST_INCONSISTENCY=1` is set, `cargo test`
-will perform the inconsistency check while running the tests in `../../diem-framework` and `../../move-stdlib` (i.e.,
-the prover will run those tests with the flag `--check-inconsistency`).
+
+If the flag `--check-inconsistency` is given, the prover not only verifies a target, but also checks
+if there is any inconsistent assumption in the verification. If the environment
+variable `MVP_TEST_INCONSISTENCY=1` is set, `cargo test`
+will perform the inconsistency check while running the tests in `../../diem-framework`
+and `../../move-stdlib` (i.e., the prover will run those tests with the
+flag `--check-inconsistency`).
 
 ```shell script
 MVP_TEST_INCONSISTENCY=1 cargo test -p move-prover
@@ -56,15 +79,19 @@ MVP_TEST_INCONSISTENCY=1 cargo test -p move-prover
 
 ## Code coverage
 
-Analyzing the test coverage of the diem repo is regularly done in CI, and the result updates the online report at
+Analyzing the test coverage of the diem repo is regularly done in CI, and the result updates the
+online report at
+
 * https://ci-artifacts.diem.com/coverage/unit-coverage/latest/index.html
-* https://codecov.io/gh/diem/diem (reports significantly less coverage due to panic unwinding being considered a branch)
+* https://codecov.io/gh/diem/diem (reports significantly less coverage due to panic unwinding being
+  considered a branch)
 
-Note that this report is based on the the coverage test when the environment variable `BOOGIE_EXE` is not set.
-So, the coverage result may not be as accurate as expected because all verifications with Boogie/Z3 are skipped
-during the test.
+Note that this report is based on the the coverage test when the environment variable `BOOGIE_EXE`
+is not set. So, the coverage result may not be as accurate as expected because all verifications
+with Boogie/Z3 are skipped during the test.
 
-To run the coverage test locally, one can use `cargo xtest html-cov-dir="/some/dir"`.   Keep in mind what is compiled and run when
-targeting a single crate is not the same as is run/built with multiple crates due to cargo's feature unification.
+To run the coverage test locally, one can use `cargo xtest html-cov-dir="/some/dir"`. Keep in mind
+what is compiled and run when targeting a single crate is not the same as is run/built with multiple
+crates due to cargo's feature unification.
 
 For any questions regarding code coverage, please use the Cadiem slack channel "#code_coverage".

--- a/language/move-prover/tests/sources/functional/aborts_if.cvc4_exp
+++ b/language/move-prover/tests/sources/functional/aborts_if.cvc4_exp
@@ -1,0 +1,181 @@
+Move prover returns: exiting with boogie verification errors
+error: unexpected boogie output: `Prover error: Unexpected prover response getting model: (() (define-fu ..`
+
+   ┌── <unknown>:1:1 ───
+   │
+ 1 │ <unknown>
+   │ ^^^^^^^^^
+   │
+
+error: function does not abort under this condition
+
+    ┌── tests/sources/functional/aborts_if.move:35:9 ───
+    │
+ 35 │         aborts_if _x <= _y;
+    │         ^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/aborts_if.move:32: abort2_incorrect
+    =     at tests/sources/functional/aborts_if.move:33: abort2_incorrect
+    =     at tests/sources/functional/aborts_if.move:35
+
+error: verification inconclusive
+
+    ┌── tests/sources/functional/aborts_if.move:39:5 ───
+    │
+ 39 │ ╭     fun abort3(_x: u64, _y: u64) {
+ 40 │ │         abort 1
+ 41 │ │     }
+    │ ╰─────^
+    │
+
+error: verification inconclusive
+
+    ┌── tests/sources/functional/aborts_if.move:47:5 ───
+    │
+ 47 │ ╭     fun abort4_incorrect(x: u64, y: u64) {
+ 48 │ │         if (x > y) abort 1
+ 49 │ │     }
+    │ ╰─────^
+    │
+
+error: verification inconclusive
+
+    ┌── tests/sources/functional/aborts_if.move:56:5 ───
+    │
+ 56 │ ╭     fun abort5_incorrect(x: u64, y: u64) {
+ 57 │ │         if (x <= y) abort 1
+ 58 │ │     }
+    │ ╰─────^
+    │
+
+error: verification inconclusive
+
+    ┌── tests/sources/functional/aborts_if.move:64:5 ───
+    │
+ 64 │ ╭     fun abort6_incorrect(x: u64, y: u64) {
+ 65 │ │         if (x < y) abort 1
+ 66 │ │     }
+    │ ╰─────^
+    │
+
+error: verification inconclusive
+
+     ┌── tests/sources/functional/aborts_if.move:162:5 ───
+     │
+ 162 │ ╭     fun abort_1() {
+ 163 │ │         abort 1
+ 164 │ │     }
+     │ ╰─────^
+     │
+
+error: verification inconclusive
+
+     ┌── tests/sources/functional/aborts_if.move:127:5 ───
+     │
+ 127 │ ╭     fun abort_at_2_or_3(x: u64) {
+ 128 │ │         if (x == 2 || x == 3) abort 1;
+ 129 │ │     }
+     │ ╰─────^
+     │
+
+error: verification inconclusive
+
+     ┌── tests/sources/functional/aborts_if.move:145:5 ───
+     │
+ 145 │ ╭     fun abort_at_2_or_3_spec_incorrect(x: u64) {
+ 146 │ │         if (x == 2 || x == 3) abort 1;
+ 147 │ │     }
+     │ ╰─────^
+     │
+
+error: verification inconclusive
+
+     ┌── tests/sources/functional/aborts_if.move:154:5 ───
+     │
+ 154 │ ╭     fun abort_at_2_or_3_strict_incorrect(x: u64) {
+ 155 │ │         if (x == 2 || x == 3) abort 1;
+ 156 │ │     }
+     │ ╰─────^
+     │
+
+error: verification inconclusive
+
+     ┌── tests/sources/functional/aborts_if.move:136:5 ───
+     │
+ 136 │ ╭     fun abort_at_2_or_3_total_incorrect(x: u64) {
+ 137 │ │         if (x == 2 || x == 3) abort 1;
+ 138 │ │     }
+     │ ╰─────^
+     │
+
+error: verification inconclusive
+
+     ┌── tests/sources/functional/aborts_if.move:170:5 ───
+     │
+ 170 │ ╭     fun aborts_if_with_code(x: u64) {
+ 171 │ │         if (x == 2 || x == 3) abort_1();
+ 172 │ │     }
+     │ ╰─────^
+     │
+
+error: verification inconclusive
+
+    ┌── tests/sources/functional/aborts_if.move:77:5 ───
+    │
+ 77 │ ╭     fun multi_abort1(x: u64, y: u64) {
+ 78 │ │         if (x <= y) abort 1
+ 79 │ │     }
+    │ ╰─────^
+    │
+
+error: verification inconclusive
+
+    ┌── tests/sources/functional/aborts_if.move:86:5 ───
+    │
+ 86 │ ╭     fun multi_abort2_incorrect(x: u64, y: u64) {
+ 87 │ │         if (x < y) abort 1
+ 88 │ │     }
+    │ ╰─────^
+    │
+
+error: verification inconclusive
+
+    ┌── tests/sources/functional/aborts_if.move:95:5 ───
+    │
+ 95 │ ╭     fun multi_abort3_incorrect(_x: u64, _y: u64) {
+ 96 │ │         abort 1
+ 97 │ │     }
+    │ ╰─────^
+    │
+
+error: verification inconclusive
+
+     ┌── tests/sources/functional/aborts_if.move:104:5 ───
+     │
+ 104 │ ╭     fun multi_abort4(_x: u64, _y: u64) {
+ 105 │ │         abort 1
+ 106 │ │     }
+     │ ╰─────^
+     │
+
+error: verification inconclusive
+
+     ┌── tests/sources/functional/aborts_if.move:113:5 ───
+     │
+ 113 │ ╭     fun multi_abort5_incorrect(x: u64) {
+ 114 │ │         if (x == 0) {
+ 115 │ │             abort 1
+ 116 │ │         };
+ 117 │ │     }
+     │ ╰─────^
+     │
+
+error: verification inconclusive
+
+    ┌── tests/sources/functional/aborts_if.move:12:5 ───
+    │
+ 12 │ ╭     fun no_aborts_if(_x: u64, _y: u64) {
+ 13 │ │         abort 1
+ 14 │ │     }
+    │ ╰─────^
+    │

--- a/language/move-prover/tests/sources/functional/aborts_if.move
+++ b/language/move-prover/tests/sources/functional/aborts_if.move
@@ -1,5 +1,5 @@
+// also_include_for: cvc4
 module 0x42::TestAbortsIf {
-
     spec module {
         pragma verify = true;
     }

--- a/language/move-prover/tests/sources/functional/aborts_if_with_code.cvc4_exp
+++ b/language/move-prover/tests/sources/functional/aborts_if_with_code.cvc4_exp
@@ -1,0 +1,129 @@
+Move prover returns: exiting with boogie verification errors
+error: unexpected boogie output: `Prover error: Unexpected prover response getting model: (() (define-fu ..`
+
+   ┌── <unknown>:1:1 ───
+   │
+ 1 │ <unknown>
+   │ ^^^^^^^^^
+   │
+
+error: abort code not covered by any of the `aborts_if` or `aborts_with` clauses
+
+    ┌── tests/sources/functional/aborts_if_with_code.move:77:5 ───
+    │
+ 77 │ ╭     spec fun aborts_if_with_code_mixed_invalid {
+ 78 │ │         aborts_if x == 1;
+ 79 │ │         aborts_if x == 2 with 1;
+ 80 │ │     }
+    │ ╰─────^
+    ·
+ 74 │             abort(2)
+    │             -------- abort happened here with code 0x2
+    │
+    =     at tests/sources/functional/aborts_if_with_code.move:69: aborts_if_with_code_mixed_invalid
+    =     at tests/sources/functional/aborts_if_with_code.move:70: aborts_if_with_code_mixed_invalid
+    =     at tests/sources/functional/aborts_if_with_code.move:74: aborts_if_with_code_mixed_invalid
+    =         ABORTED
+
+error: verification inconclusive
+
+    ┌── tests/sources/functional/aborts_if_with_code.move:85:5 ───
+    │
+ 85 │ ╭     fun aborts_with(x: u64) {
+ 86 │ │         if (x == 1) {
+ 87 │ │             abort(1)
+ 88 │ │         };
+ 89 │ │         if (x == 2) {
+ 90 │ │             abort(2)
+ 91 │ │         };
+ 92 │ │     }
+    │ ╰─────^
+    │
+
+error: verification inconclusive
+
+     ┌── tests/sources/functional/aborts_if_with_code.move:97:5 ───
+     │
+  97 │ ╭     fun aborts_with_invalid(x: u64) {
+  98 │ │         if (x == 1) {
+  99 │ │             abort(1)
+ 100 │ │         };
+ 101 │ │         if (x == 2) {
+ 102 │ │             abort(2)
+ 103 │ │         };
+ 104 │ │     }
+     │ ╰─────^
+     │
+
+error: verification inconclusive
+
+     ┌── tests/sources/functional/aborts_if_with_code.move:109:5 ───
+     │
+ 109 │ ╭     fun aborts_with_mixed(x: u64) {
+ 110 │ │         if (x == 1) {
+ 111 │ │             abort(1)
+ 112 │ │         };
+ 113 │ │         if (x == 2) {
+ 114 │ │             abort(2)
+ 115 │ │         };
+ 116 │ │     }
+     │ ╰─────^
+     │
+
+error: verification inconclusive
+
+     ┌── tests/sources/functional/aborts_if_with_code.move:123:5 ───
+     │
+ 123 │ ╭     fun aborts_with_mixed_invalid(x: u64) {
+ 124 │ │         if (x == 1) {
+ 125 │ │             abort(1)
+ 126 │ │         };
+ 127 │ │         if (x == 2) {
+ 128 │ │             abort(1)
+ 129 │ │         };
+ 130 │ │     }
+     │ ╰─────^
+     │
+
+error: verification inconclusive
+
+    ┌── tests/sources/functional/aborts_if_with_code.move:11:5 ───
+    │
+ 11 │ ╭     fun conditional_abort(x: u64, y: u64): u64 {
+ 12 │ │         if (x == 1) {
+ 13 │ │             abort 2
+ 14 │ │         };
+ 15 │ │         if (y == 2) {
+ 16 │ │             abort 3
+ 17 │ │         };
+ 18 │ │         // This one can also abort on overflow, with execution failure (code = -1).
+ 19 │ │         x + y
+ 20 │ │     }
+    │ ╰─────^
+    │
+
+error: verification inconclusive
+
+    ┌── tests/sources/functional/aborts_if_with_code.move:29:5 ───
+    │
+ 29 │ ╭     fun conditional_abort_invalid(x: u64, y: u64): u64 {
+ 30 │ │         if (x == 1) {
+ 31 │ │             abort 2
+ 32 │ │         };
+ 33 │ │         if (y == 2) {
+ 34 │ │             abort 3
+ 35 │ │         };
+ 36 │ │         x
+ 37 │ │     }
+    │ ╰─────^
+    │
+
+error: verification inconclusive
+
+    ┌── tests/sources/functional/aborts_if_with_code.move:45:5 ───
+    │
+ 45 │ ╭     fun exec_failure_invalid(x: u64): u64 {
+ 46 │ │         10 / x
+ 47 │ │     }
+    │ ╰─────^
+    │

--- a/language/move-prover/tests/sources/functional/aborts_if_with_code.move
+++ b/language/move-prover/tests/sources/functional/aborts_if_with_code.move
@@ -1,5 +1,5 @@
+// also_include_for: cvc4
 module 0x42::TestAbortsIfWithCode {
-
     spec module {
         pragma verify = true;
     }

--- a/language/move-prover/tests/sources/functional/address_quant.cvc4_exp
+++ b/language/move-prover/tests/sources/functional/address_quant.cvc4_exp
@@ -1,0 +1,23 @@
+Move prover returns: exiting with boogie verification errors
+error: unexpected boogie output: `Prover error: Unexpected prover response getting model: (() (define-fu ..`
+
+   ┌── <unknown>:1:1 ───
+   │
+ 1 │ <unknown>
+   │ ^^^^^^^^^
+   │
+
+error: post-condition does not hold
+
+    ┌── tests/sources/functional/address_quant.move:53:10 ───
+    │
+ 53 │          invariant atMostOne();
+    │          ^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/address_quant.move:46: multiple_copy_incorrect
+    =     at tests/sources/functional/address_quant.move:53
+    =     at tests/sources/functional/address_quant.move:54
+    =     at tests/sources/functional/address_quant.move:46: multiple_copy_incorrect
+    =     at tests/sources/functional/address_quant.move:47: multiple_copy_incorrect
+    =     at tests/sources/functional/address_quant.move:48: multiple_copy_incorrect
+    =     at tests/sources/functional/address_quant.move:53

--- a/language/move-prover/tests/sources/functional/address_quant.move
+++ b/language/move-prover/tests/sources/functional/address_quant.move
@@ -1,7 +1,7 @@
+// also_include_for: cvc4
 // Tests of quantification over addresses.
 module 0x42::AddressQuant {
     use 0x1::Signer;
-
     struct R has key {
         x: u64
     }

--- a/language/move-prover/tests/sources/functional/arithm.cvc4_exp
+++ b/language/move-prover/tests/sources/functional/arithm.cvc4_exp
@@ -1,0 +1,200 @@
+Move prover returns: exiting with boogie verification errors
+error: unexpected boogie output: `Prover error: Unexpected prover response getting model: (() (define-fu ..`
+
+   ┌── <unknown>:1:1 ───
+   │
+ 1 │ <unknown>
+   │ ^^^^^^^^^
+   │
+
+error: abort not covered by any of the `aborts_if` clauses
+
+     ┌── tests/sources/functional/arithm.move:128:5 ───
+     │
+ 128 │ ╭     spec fun div_by_zero_u64_incorrect {
+ 129 │ │         aborts_if false;
+ 130 │ │     }
+     │ ╰─────^
+     ·
+ 126 │         x / y
+     │           - abort happened here
+     │
+     =     at tests/sources/functional/arithm.move:125: div_by_zero_u64_incorrect
+     =     at tests/sources/functional/arithm.move:126: div_by_zero_u64_incorrect
+     =         ABORTED
+
+error: verification inconclusive
+
+    ┌── tests/sources/functional/arithm.move:69:5 ───
+    │
+ 69 │ ╭     fun f(x: u64) : u64 {
+ 70 │ │         x+1
+ 71 │ │     }
+    │ ╰─────^
+    │
+
+error: verification inconclusive
+
+    ┌── tests/sources/functional/arithm.move:77:5 ───
+    │
+ 77 │ ╭     fun g(x: u64) : u64 {
+ 78 │ │         x+2
+ 79 │ │     }
+    │ ╰─────^
+    │
+
+error: verification inconclusive
+
+    ┌── tests/sources/functional/arithm.move:85:5 ───
+    │
+ 85 │ ╭     fun h(b: bool): u64 {
+ 86 │ │         let x: u64 = 3;
+ 87 │ │         let y: u64;
+ 88 │ │         if (b) y=f(x) else y=g(x);
+ 89 │ │         if (b && y != 4) abort 4;
+ 90 │ │         if (!b && y != 5) abort 5;
+ 91 │ │         y
+ 92 │ │     }
+    │ ╰─────^
+    │
+
+error: verification inconclusive
+
+    ┌── tests/sources/functional/arithm.move:36:2 ───
+    │
+ 36 │ ╭     fun multiple_ops(x: u64, y: u64, z: u64): u64 {
+ 37 │ │ 		x + y * z
+ 38 │ │     }
+    │ ╰─────^
+    │
+
+error: verification inconclusive
+
+     ┌── tests/sources/functional/arithm.move:185:5 ───
+     │
+ 185 │ ╭     fun overflow_u128_add(x: u128, y: u128): u128 {
+ 186 │ │         x + y
+ 187 │ │     }
+     │ ╰─────^
+     │
+
+error: verification inconclusive
+
+     ┌── tests/sources/functional/arithm.move:177:5 ───
+     │
+ 177 │ ╭     fun overflow_u128_add_incorrect(x: u128, y: u128): u128 {
+ 178 │ │         x + y
+ 179 │ │     }
+     │ ╰─────^
+     │
+
+error: verification inconclusive
+
+     ┌── tests/sources/functional/arithm.move:236:5 ───
+     │
+ 236 │ ╭     fun overflow_u128_mul(x: u128, y: u128): u128 {
+ 237 │ │         x * y
+ 238 │ │     }
+     │ ╰─────^
+     │
+
+error: verification inconclusive
+
+     ┌── tests/sources/functional/arithm.move:229:5 ───
+     │
+ 229 │ ╭     fun overflow_u128_mul_incorrect(x: u128, y: u128): u128 {
+ 230 │ │         x * y
+ 231 │ │     }
+     │ ╰─────^
+     │
+
+error: verification inconclusive
+
+     ┌── tests/sources/functional/arithm.move:169:5 ───
+     │
+ 169 │ ╭     fun overflow_u64_add(x: u64, y: u64): u64 {
+ 170 │ │         x + y
+ 171 │ │     }
+     │ ╰─────^
+     │
+
+error: verification inconclusive
+
+     ┌── tests/sources/functional/arithm.move:161:5 ───
+     │
+ 161 │ ╭     fun overflow_u64_add_incorrect(x: u64, y: u64): u64 {
+ 162 │ │         x + y
+ 163 │ │     }
+     │ ╰─────^
+     │
+
+error: verification inconclusive
+
+     ┌── tests/sources/functional/arithm.move:221:5 ───
+     │
+ 221 │ ╭     fun overflow_u64_mul(x: u64, y: u64): u64 {
+ 222 │ │         x * y
+ 223 │ │     }
+     │ ╰─────^
+     │
+
+error: verification inconclusive
+
+     ┌── tests/sources/functional/arithm.move:214:5 ───
+     │
+ 214 │ ╭     fun overflow_u64_mul_incorrect(x: u64, y: u64): u64 {
+ 215 │ │         x * y
+ 216 │ │     }
+     │ ╰─────^
+     │
+
+error: verification inconclusive
+
+     ┌── tests/sources/functional/arithm.move:153:5 ───
+     │
+ 153 │ ╭     fun overflow_u8_add(x: u8, y: u8): u8 {
+ 154 │ │         x + y
+ 155 │ │     }
+     │ ╰─────^
+     │
+
+error: verification inconclusive
+
+     ┌── tests/sources/functional/arithm.move:145:5 ───
+     │
+ 145 │ ╭     fun overflow_u8_add_incorrect(x: u8, y: u8): u8 {
+ 146 │ │         x + y
+ 147 │ │     }
+     │ ╰─────^
+     │
+
+error: verification inconclusive
+
+     ┌── tests/sources/functional/arithm.move:206:5 ───
+     │
+ 206 │ ╭     fun overflow_u8_mul(x: u8, y: u8): u8 {
+ 207 │ │         x * y
+ 208 │ │     }
+     │ ╰─────^
+     │
+
+error: verification inconclusive
+
+     ┌── tests/sources/functional/arithm.move:198:5 ───
+     │
+ 198 │ ╭     fun overflow_u8_mul_incorrect(x: u8, y: u8): u8 {
+ 199 │ │         x * y
+ 200 │ │     }
+     │ ╰─────^
+     │
+
+error: verification inconclusive
+
+     ┌── tests/sources/functional/arithm.move:103:5 ───
+     │
+ 103 │ ╭     fun underflow(): u64 {
+ 104 │ │         let x = 0;
+ 105 │ │         x - 1
+ 106 │ │     }
+     │ ╰─────^
+     │

--- a/language/move-prover/tests/sources/functional/arithm.move
+++ b/language/move-prover/tests/sources/functional/arithm.move
@@ -1,9 +1,9 @@
-// Test works with v2:
+// also_include_for: cvc4
 module 0x42::TestArithmetic {
-
     spec module {
         pragma verify = true;
     }
+
     // --------------------------
     // Basic arithmetic operation
     // --------------------------

--- a/language/move-prover/tests/sources/functional/cast.cvc4_exp
+++ b/language/move-prover/tests/sources/functional/cast.cvc4_exp
@@ -1,0 +1,64 @@
+Move prover returns: exiting with boogie verification errors
+error: unexpected boogie output: `Prover error: Unexpected prover response getting model: (() (define-fu ..`
+
+   ┌── <unknown>:1:1 ───
+   │
+ 1 │ <unknown>
+   │ ^^^^^^^^^
+   │
+
+error: abort not covered by any of the `aborts_if` clauses
+
+    ┌── tests/sources/functional/cast.move:47:5 ───
+    │
+ 47 │ ╭     spec fun aborting_u64_cast_incorrect {
+ 48 │ │         aborts_if false;
+ 49 │ │     }
+    │ ╰─────^
+    ·
+ 45 │         (x as u64)
+    │         ---------- abort happened here
+    │
+    =     at tests/sources/functional/cast.move:44: aborting_u64_cast_incorrect
+    =     at tests/sources/functional/cast.move:45: aborting_u64_cast_incorrect
+    =         ABORTED
+
+error: verification inconclusive
+
+    ┌── tests/sources/functional/cast.move:37:5 ───
+    │
+ 37 │ ╭     fun aborting_u8_cast(x: u64): u8 {
+ 38 │ │         (x as u8)
+ 39 │ │     }
+    │ ╰─────^
+    │
+
+error: verification inconclusive
+
+    ┌── tests/sources/functional/cast.move:30:5 ───
+    │
+ 30 │ ╭     fun aborting_u8_cast_incorrect(x: u64): u8 {
+ 31 │ │         (x as u8)
+ 32 │ │     }
+    │ ╰─────^
+    │
+
+error: verification inconclusive
+
+    ┌── tests/sources/functional/cast.move:18:5 ───
+    │
+ 18 │ ╭     fun u64_cast(x: u64): u128 {
+ 19 │ │         (x as u128)
+ 20 │ │     }
+    │ ╰─────^
+    │
+
+error: verification inconclusive
+
+    ┌── tests/sources/functional/cast.move:11:5 ───
+    │
+ 11 │ ╭     fun u8_cast_incorrect(x: u8): u64 {
+ 12 │ │         (x as u64)
+ 13 │ │     }
+    │ ╰─────^
+    │

--- a/language/move-prover/tests/sources/functional/cast.move
+++ b/language/move-prover/tests/sources/functional/cast.move
@@ -1,5 +1,5 @@
+// also_include_for: cvc4
 module 0x42::TestCast {
-
     spec module {
         pragma verify = true;
     }

--- a/language/move-prover/tests/testsuite.rs
+++ b/language/move-prover/tests/testsuite.rs
@@ -17,10 +17,12 @@ use datatest_stable::Requirements;
 #[allow(unused_imports)]
 use log::{debug, info, warn};
 use std::sync::atomic::{AtomicBool, Ordering};
+use walkdir::WalkDir;
 
 const ENV_FLAGS: &str = "MVP_TEST_FLAGS";
 const ENV_TEST_EXTENDED: &str = "MVP_TEST_X";
-const MVP_TEST_INCONSISTENCY: &str = "MVP_TEST_INCONSISTENCY";
+const ENV_TEST_INCONSISTENCY: &str = "MVP_TEST_INCONSISTENCY";
+const ENV_TEST_FEATURE: &str = "MVP_TEST_FEATURE";
 const INCONSISTENCY_TEST_FLAGS: &[&str] = &[
     "--dependency=../move-stdlib/modules",
     "--dependency=../diem-framework/modules",
@@ -33,32 +35,41 @@ const REGULAR_TEST_FLAGS: &[&str] = &[
 
 static NOT_CONFIGURED_WARNED: AtomicBool = AtomicBool::new(false);
 
-/// A list of different feature variants to test. Each test will be executed for each variant,
-/// unless it (a) contains a line comment of the form `// exclude_for: <feature1> <feature2> ...` (b)
-/// its path is in the blacklisted paths specified.
-/// TODO: currently only default is active, as vnext is too unstable for release via sporadic
-///   timeouts.
-const TESTED_FEATURES: &[&str] = &["default" /*, "vnext"*/];
-const DENYLISTED_PATHS: &[(&str, &str)] = &[];
+/// A list of different features to test.
+const TESTED_FEATURES: &[(&str, InclusionMode, bool /*whether to enable in CI*/)] = &[
+    (DEFAULT_FEATURE, InclusionMode::Implicit, true),
+    ("cvc4", InclusionMode::Explicit, true),
+];
+const DEFAULT_FEATURE: &str = "default";
+
+/// An inclusion mode. A feature may be run in one of these modes.
+#[derive(Clone, Copy)]
+enum InclusionMode {
+    /// Only a test which has the comment `// also_include_for: <feature>` will be included.
+    Explicit,
+    /// Every test will be included unless it has the comment `// exclude_for: <feature>`.
+    Implicit,
+}
 
 /// Determines the runner based on feature name. Because the datatest framework requires a
 /// function pointer (not a closure) to set up a test, we need to have a specific static function
-/// for each feature.
+/// for each feature and implement our own dispatcher based on feature.
 fn get_runner(feature: &str) -> fn(&Path) -> datatest_stable::Result<()> {
     fn runner_default(p: &Path) -> datatest_stable::Result<()> {
-        test_runner_variant(p, "default", "")
+        test_runner_for_feature(p, "default", "")
     }
-    fn runner_vnext(p: &Path) -> datatest_stable::Result<()> {
-        test_runner_variant(p, "vnext", "--vnext")
+    fn runner_cvc4(p: &Path) -> datatest_stable::Result<()> {
+        test_runner_for_feature(p, "cvc4", "--use-cvc4")
     }
     match feature {
         "default" => runner_default,
-        "vnext" => runner_vnext,
+        "cvc4" => runner_cvc4,
         _ => panic!("unknown feature"),
     }
 }
 
-fn test_runner_variant(
+/// Test runner for a given feature.
+fn test_runner_for_feature(
     path: &Path,
     feature: &str,
     feature_flags: &str,
@@ -66,18 +77,6 @@ fn test_runner_variant(
     // Use the below + `cargo test -- --test-threads=1` to identify a long running test
     //println!(">>> testing {}", path.to_string_lossy().to_string());
 
-    // Determine whether the test is excluded for the given feature.
-    let feature_exclusion = extract_test_directives(path, "// exclude_for: ")?;
-    if feature_exclusion.contains(&feature.to_string()) {
-        info!("skipping {} for feature `{}`", path.display(), feature);
-        return Ok(());
-    }
-    for (feature_name, path_frag) in DENYLISTED_PATHS {
-        if feature == *feature_name && path.to_string_lossy().to_string().contains(path_frag) {
-            info!("skipping {} for feature `{}`", path.display(), feature);
-            return Ok(());
-        }
-    }
     info!(
         "testing {} with feature `{}` (flags = `{}`)",
         path.display(),
@@ -85,13 +84,9 @@ fn test_runner_variant(
         feature_flags
     );
 
-    let no_boogie = read_env_var("BOOGIE_EXE").is_empty() || read_env_var("Z3_EXE").is_empty();
-    let baseline_valid =
-        !no_boogie || !extract_test_directives(path, "// no-boogie-test")?.is_empty();
-
     let temp_dir = TempPath::new();
     std::fs::create_dir_all(temp_dir.path())?;
-    let (flags, baseline_path) = get_flags(temp_dir.path(), path)?;
+    let (flags, baseline_path) = get_path_dependent_flags(temp_dir.path(), path, feature)?;
 
     let mut args = vec!["mvp_test".to_string()];
     args.extend(flags);
@@ -107,7 +102,13 @@ fn test_runner_variant(
 
     let mut options = Options::create_from_args(&args)?;
     options.setup_logging_for_test();
-    if no_boogie {
+    let no_tools = read_env_var("BOOGIE_EXE").is_empty()
+        || !options.backend.use_cvc4 && read_env_var("Z3_EXE").is_empty()
+        || options.backend.use_cvc4 && read_env_var("CVC4_EXE").is_empty();
+    let baseline_valid =
+        !no_tools || !extract_test_directives(path, "// no-boogie-test")?.is_empty();
+
+    if no_tools {
         options.prover.generate_only = true;
         if NOT_CONFIGURED_WARNED
             .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
@@ -120,6 +121,7 @@ fn test_runner_variant(
             );
         }
     }
+    options.backend.check_tool_versions()?;
     options.prover.stable_test_output = true;
     options.backend.stable_test_output = true;
 
@@ -145,11 +147,15 @@ fn test_runner_variant(
     Ok(())
 }
 
-fn get_flags(temp_dir: &Path, path: &Path) -> anyhow::Result<(Vec<String>, Option<PathBuf>)> {
+fn get_path_dependent_flags(
+    temp_dir: &Path,
+    path: &Path,
+    feature: &str,
+) -> anyhow::Result<(Vec<String>, Option<PathBuf>)> {
     // Determine the way how to configure tests based on directory of the path.
     let path_str = path.to_string_lossy();
 
-    let stdlib_test_flags = if read_env_var(MVP_TEST_INCONSISTENCY).is_empty() {
+    let stdlib_test_flags = if read_env_var(ENV_TEST_INCONSISTENCY).is_empty() {
         REGULAR_TEST_FLAGS
     } else {
         INCONSISTENCY_TEST_FLAGS
@@ -161,7 +167,11 @@ fn get_flags(temp_dir: &Path, path: &Path) -> anyhow::Result<(Vec<String>, Optio
         } else {
             (
                 REGULAR_TEST_FLAGS,
-                Some(path.with_extension("exp")),
+                Some(path.with_extension(if feature == DEFAULT_FEATURE {
+                    "exp".to_string()
+                } else {
+                    format!("{}_exp", feature)
+                })),
                 "prover_",
             )
         };
@@ -182,37 +192,100 @@ fn get_flags(temp_dir: &Path, path: &Path) -> anyhow::Result<(Vec<String>, Optio
     Ok((flags, baseline_path))
 }
 
+/// Collects the enabled tests, accumulating them as datatest requirements.
+/// We collect the test data sources ourselves instead of letting datatest
+/// do it because we want to select them based on enabled feature as indicated
+/// in the source. We still use datatest to finally run the tests to utilize its
+/// execution engine.
+fn collect_enabled_tests(
+    reqs: &mut Vec<Requirements>,
+    group: &str,
+    feature: &str,
+    inclusion_mode: InclusionMode,
+    in_ci: bool,
+    path: &str,
+) {
+    let mut p = PathBuf::new(); // PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push(path);
+    for e in WalkDir::new(p).min_depth(1).into_iter() {
+        if let Ok(entry) = e {
+            if !entry.file_name().to_string_lossy().ends_with(".move") {
+                continue;
+            }
+            let path = entry.path();
+            let mut included = match inclusion_mode {
+                InclusionMode::Implicit => !extract_test_directives(path, "// exclude_for: ")
+                    .unwrap_or_default()
+                    .iter()
+                    .any(|s| s.as_str() == feature),
+                InclusionMode::Explicit => extract_test_directives(path, "// also_include_for: ")
+                    .unwrap_or_default()
+                    .iter()
+                    .any(|s| s.as_str() == feature),
+            };
+            if included && read_env_var("MVP_TEST_ON_CI") == "1" {
+                included = in_ci
+                    && extract_test_directives(path, "// no_ci:")
+                        .unwrap_or_default()
+                        .is_empty();
+            }
+            if included {
+                let runner = get_runner(feature);
+                reqs.push(Requirements::new(
+                    runner,
+                    format!("prover {}[{}]", group, feature),
+                    path.parent().unwrap().to_string_lossy().to_string(),
+                    path.file_name().unwrap().to_string_lossy().to_string(),
+                ));
+            }
+        }
+    }
+}
+
 // Test entry point based on datatest runner.
 fn main() {
     let mut reqs = vec![];
-    for feature in TESTED_FEATURES {
-        let runner = get_runner(*feature);
+    for (feature, inclusion_mode, in_ci) in TESTED_FEATURES {
+        // Evaluate whether the user narrowed which feature to test.
+        let feature_narrow = read_env_var(ENV_TEST_FEATURE);
+        if !feature_narrow.is_empty() && feature != &feature_narrow {
+            continue;
+        }
+        // Check whether we are running extended tests
         if read_env_var(ENV_TEST_EXTENDED) == "1" {
-            reqs.push(Requirements::new(
-                runner,
-                format!("extended[{}]", feature),
-                "tests/xsources".to_string(),
-                r".*\.move$".to_string(),
-            ));
+            collect_enabled_tests(
+                &mut reqs,
+                "extended",
+                feature,
+                *inclusion_mode,
+                *in_ci,
+                "tests/xsources",
+            );
         } else {
-            reqs.push(Requirements::new(
-                runner,
-                format!("unit[{}]", feature),
-                "tests/sources".to_string(),
-                r".*\.move$".to_string(),
-            ));
-            reqs.push(Requirements::new(
-                runner,
-                format!("stdlib[{}]", feature),
-                "../move-stdlib".to_string(),
-                r".*\.move$".to_string(),
-            ));
-            reqs.push(Requirements::new(
-                runner,
-                format!("diem[{}]", feature),
-                "../diem-framework".to_string(),
-                r".*\.move$".to_string(),
-            ));
+            collect_enabled_tests(
+                &mut reqs,
+                "unit",
+                feature,
+                *inclusion_mode,
+                *in_ci,
+                "tests/sources",
+            );
+            collect_enabled_tests(
+                &mut reqs,
+                "stdlib",
+                feature,
+                *inclusion_mode,
+                *in_ci,
+                "../move-stdlib",
+            );
+            collect_enabled_tests(
+                &mut reqs,
+                "diem",
+                feature,
+                *inclusion_mode,
+                *in_ci,
+                "../diem-framework",
+            );
         }
     }
     datatest_stable::runner(&reqs);


### PR DESCRIPTION
This PR refines the test driver to deal better with "features". A feature is a special setting of flags for the prover. The first feature we enable is to test with `--use-cvc4`.

A feature can be either exclusive or inclusive:

- A feature which is inclusive includes all tests until explicitly excluded by a `// exclude_for: <feature>` comment in the source. This is currently used for the `default` feature configuration of the prover.
- A feature which is exclusive must be enabled by a comment `// also_include_for: <feature>` in the test source. This is currenly used for the `cvc4` feature configuration.

Some cvc4 tests in `sources/functional` have been enabled this way. They create a different baseline file than the default.

There seem to be some basic issue with cvc4 and boogie which can be seen in most of the new `<file>.cvc4_exp` baselines. Some command send by Boogie to cvc4 seems to be not handled as expected by Boogie. Once this is fixed, further tests for cvc4 can be enabled.

When using `cargo test` all features for all enabled tests are run. One can use `MVP_TEST_FEATURE=<feature> cargo test` to narrow this down to specific features.

This PR also fixes some issues encountered on the way, specifically reporting unexpected output from boogie instead of silently ignoring it.

@barrettcw 


## Motivation

Better integration of cvc4.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests

## Related PRs

NA