### PR TITLE
[move-model] bytecode-agnostic exp generator and spec translator

### DIFF
--- a/language/move-model/src/exp_generator.rs
+++ b/language/move-model/src/exp_generator.rs
@@ -1,0 +1,279 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use itertools::Itertools;
+
+use crate::{
+    ast::{Exp, LocalVarDecl, Operation, QuantKind, TempIndex, Value},
+    model::{FieldEnv, FunctionEnv, GlobalEnv, Loc, NodeId, QualifiedId, StructId},
+    symbol::Symbol,
+    ty::{Type, BOOL_TYPE, NUM_TYPE},
+};
+
+/// A trait that defines a generator for `Exp`.
+pub trait ExpGenerator<'env> {
+    /// Get the functional environment
+    fn function_env(&self) -> &FunctionEnv<'env>;
+
+    /// Get the current location
+    fn get_current_loc(&self) -> Loc;
+
+    /// Set the current location
+    fn set_loc(&mut self, loc: Loc);
+
+    /// Add a local variable with given type, return the local index.
+    fn add_local(&mut self, ty: Type) -> TempIndex;
+
+    /// Get the type of a local given at `temp` index
+    fn get_local_type(&self, temp: TempIndex) -> Type;
+
+    /// Get the global environment
+    fn global_env(&self) -> &'env GlobalEnv {
+        self.function_env().module_env.env
+    }
+
+    /// Sets the default location from a node id.
+    fn set_loc_from_node(&mut self, node_id: NodeId) {
+        let loc = self.global_env().get_node_loc(node_id);
+        self.set_loc(loc);
+    }
+
+    /// Creates a new expression node id, using current default location, provided type,
+    /// and optional instantiation.
+    fn new_node(&self, ty: Type, inst_opt: Option<Vec<Type>>) -> NodeId {
+        let node_id = self.global_env().new_node(self.get_current_loc(), ty);
+        if let Some(inst) = inst_opt {
+            self.global_env().set_node_instantiation(node_id, inst);
+        }
+        node_id
+    }
+
+    /// Allocates a new temporary.
+    fn new_temp(&mut self, ty: Type) -> TempIndex {
+        self.add_local(ty)
+    }
+
+    /// Make a boolean constant expression.
+    fn mk_bool_const(&self, value: bool) -> Exp {
+        let node_id = self.new_node(BOOL_TYPE.clone(), None);
+        Exp::Value(node_id, Value::Bool(value))
+    }
+
+    /// Makes a Call expression.
+    fn mk_call(&self, ty: &Type, oper: Operation, args: Vec<Exp>) -> Exp {
+        let node_id = self.new_node(ty.clone(), None);
+        Exp::Call(node_id, oper, args)
+    }
+
+    /// Makes an if-then-else expression.
+    fn mk_ite(&self, cond: Exp, if_true: Exp, if_false: Exp) -> Exp {
+        let node_id = self.new_node(self.global_env().get_node_type(if_true.node_id()), None);
+        Exp::IfElse(
+            node_id,
+            Box::new(cond),
+            Box::new(if_true),
+            Box::new(if_false),
+        )
+    }
+
+    /// Makes a Call expression with boolean result type.
+    fn mk_bool_call(&self, oper: Operation, args: Vec<Exp>) -> Exp {
+        self.mk_call(&BOOL_TYPE, oper, args)
+    }
+
+    /// Make a boolean not expression.
+    fn mk_not(&self, arg: Exp) -> Exp {
+        self.mk_bool_call(Operation::Not, vec![arg])
+    }
+
+    /// Make an equality expression.
+    fn mk_eq(&self, arg1: Exp, arg2: Exp) -> Exp {
+        self.mk_bool_call(Operation::Eq, vec![arg1, arg2])
+    }
+
+    /// Make an identical equality expression. This is stronger than `make_equal` because
+    /// it requires the exact same representation, not only interpretation.
+    fn mk_identical(&self, arg1: Exp, arg2: Exp) -> Exp {
+        self.mk_bool_call(Operation::Identical, vec![arg1, arg2])
+    }
+
+    /// Make an and expression.
+    fn mk_and(&self, arg1: Exp, arg2: Exp) -> Exp {
+        self.mk_bool_call(Operation::And, vec![arg1, arg2])
+    }
+
+    /// Make an or expression.
+    fn mk_or(&self, arg1: Exp, arg2: Exp) -> Exp {
+        self.mk_bool_call(Operation::Or, vec![arg1, arg2])
+    }
+
+    /// Make an implies expression.
+    fn mk_implies(&self, arg1: Exp, arg2: Exp) -> Exp {
+        self.mk_bool_call(Operation::Implies, vec![arg1, arg2])
+    }
+
+    /// Make a numerical expression for some of the builtin constants.
+    fn mk_builtin_num_const(&self, oper: Operation) -> Exp {
+        assert!(matches!(
+            oper,
+            Operation::MaxU8 | Operation::MaxU64 | Operation::MaxU128
+        ));
+        self.mk_call(&NUM_TYPE, oper, vec![])
+    }
+
+    /// Join an iterator of boolean expressions with a boolean binary operator.
+    fn mk_join_bool(&self, oper: Operation, args: impl Iterator<Item = Exp>) -> Option<Exp> {
+        args.fold1(|a, b| self.mk_bool_call(oper.clone(), vec![a, b]))
+    }
+
+    /// Join two boolean optional expression with binary operator.
+    fn mk_join_opt_bool(
+        &self,
+        oper: Operation,
+        arg1: Option<Exp>,
+        arg2: Option<Exp>,
+    ) -> Option<Exp> {
+        match (arg1, arg2) {
+            (Some(a1), Some(a2)) => Some(self.mk_bool_call(oper, vec![a1, a2])),
+            (Some(a1), None) => Some(a1),
+            (None, Some(a2)) => Some(a2),
+            _ => None,
+        }
+    }
+
+    /// Creates a quantifier over the content of a vector. The passed function `f` receives
+    /// an expression representing an element of the vector and returns the quantifiers predicate;
+    /// if it returns None, this function will also return None, otherwise the quantifier will be
+    /// returned.
+    fn mk_vector_quant_opt<F>(
+        &self,
+        kind: QuantKind,
+        vector: Exp,
+        elem_ty: &Type,
+        f: &mut F,
+    ) -> Option<Exp>
+    where
+        F: FnMut(Exp) -> Option<Exp>,
+    {
+        let elem = self.mk_local("$elem", elem_ty.clone());
+        if let Some(body) = f(elem) {
+            let range_decl = self.mk_decl(self.mk_symbol("$elem"), elem_ty.clone(), None);
+            let node_id = self.new_node(BOOL_TYPE.clone(), None);
+            Some(Exp::Quant(
+                node_id,
+                kind,
+                vec![(range_decl, vector)],
+                vec![],
+                None,
+                Box::new(body),
+            ))
+        } else {
+            None
+        }
+    }
+
+    /// Creates a quantifier over the content of memory. The passed function `f` receives
+    //  an expression representing a value in memory and returns the quantifiers predicate;
+    //  if it returns None, this function will also return None.
+    fn mk_mem_quant_opt<F>(
+        &self,
+        kind: QuantKind,
+        mem: QualifiedId<StructId>,
+        f: &mut F,
+    ) -> Option<Exp>
+    where
+        F: FnMut(Exp) -> Option<Exp>,
+    {
+        // We generate `forall $val in resources<R>: INV[$val]`. The `resources<R>`
+        // quantifier domain is currently only available in the internal expression language,
+        // not on user level.
+        let struct_env = self
+            .global_env()
+            .get_module(mem.module_id)
+            .into_struct(mem.id);
+        let type_inst = (0..struct_env.get_type_parameters().len())
+            .map(|i| Type::TypeParameter(i as u16))
+            .collect_vec();
+        let struct_ty = Type::Struct(mem.module_id, mem.id, type_inst);
+        let value = self.mk_local("$rsc", struct_ty.clone());
+
+        if let Some(body) = f(value) {
+            let resource_domain_ty = Type::ResourceDomain(mem.module_id, mem.id);
+            let resource_domain_node_id =
+                self.new_node(resource_domain_ty, Some(vec![struct_ty.clone()]));
+            let resource_domain =
+                Exp::Call(resource_domain_node_id, Operation::ResourceDomain, vec![]);
+            let resource_decl = self.mk_decl(self.mk_symbol("$rsc"), struct_ty, None);
+            let quant_node_id = self.new_node(BOOL_TYPE.clone(), None);
+            Some(Exp::Quant(
+                quant_node_id,
+                kind,
+                vec![(resource_decl, resource_domain)],
+                vec![],
+                None,
+                Box::new(body),
+            ))
+        } else {
+            None
+        }
+    }
+
+    /// Makes a local variable declaration.
+    fn mk_decl(&self, name: Symbol, ty: Type, binding: Option<Exp>) -> LocalVarDecl {
+        let node_id = self.new_node(ty, None);
+        LocalVarDecl {
+            id: node_id,
+            name,
+            binding,
+        }
+    }
+
+    /// Makes a symbol from a string.
+    fn mk_symbol(&self, str: &str) -> Symbol {
+        self.global_env().symbol_pool().make(str)
+    }
+
+    /// Makes a type domain expression.
+    fn mk_type_domain(&self, ty: Type) -> Exp {
+        let domain_ty = Type::TypeDomain(Box::new(ty.clone()));
+        let node_id = self.new_node(domain_ty, Some(vec![ty]));
+        Exp::Call(node_id, Operation::TypeDomain, vec![])
+    }
+
+    /// Makes an expression which selects a field from a struct.
+    fn mk_field_select(&self, field_env: &FieldEnv<'_>, targs: &[Type], exp: Exp) -> Exp {
+        let ty = field_env.get_type().instantiate(targs);
+        let node_id = self.new_node(ty, None);
+        Exp::Call(
+            node_id,
+            Operation::Select(
+                field_env.struct_env.module_env.get_id(),
+                field_env.struct_env.get_id(),
+                field_env.get_id(),
+            ),
+            vec![exp],
+        )
+    }
+
+    /// Makes an expression for a temporary.
+    fn mk_temporary(&self, temp: TempIndex) -> Exp {
+        let ty = self.get_local_type(temp);
+        let node_id = self.new_node(ty, None);
+        Exp::Temporary(node_id, temp)
+    }
+
+    /// Makes an expression for a named local.
+    fn mk_local(&self, name: &str, ty: Type) -> Exp {
+        let node_id = self.new_node(ty, None);
+        let sym = self.mk_symbol(name);
+        Exp::LocalVar(node_id, sym)
+    }
+
+    /// Get's the memory associated with a Call(Global,..) or Call(Exists, ..) node. Crashes
+    /// if the the node is not typed as expected.
+    fn get_memory_of_node(&self, node_id: NodeId) -> QualifiedId<StructId> {
+        let rty = &self.global_env().get_node_instantiation(node_id)[0];
+        let (mid, sid, _) = rty.require_struct();
+        mid.qualified(sid)
+    }
+}

--- a/language/move-model/src/lib.rs
+++ b/language/move-model/src/lib.rs
@@ -32,9 +32,11 @@ use crate::{
 pub mod ast;
 mod builder;
 pub mod code_writer;
+pub mod exp_generator;
 pub mod exp_rewriter;
 pub mod model;
 pub mod pragmas;
+pub mod spec_translator;
 pub mod symbol;
 pub mod ty;
 

--- a/language/move-prover/bytecode/src/data_invariant_instrumentation.rs
+++ b/language/move-prover/bytecode/src/data_invariant_instrumentation.rs
@@ -21,6 +21,7 @@ use crate::{
 use move_model::{
     ast,
     ast::{ConditionKind, Exp, QuantKind, TempIndex},
+    exp_generator::ExpGenerator,
     exp_rewriter::ExpRewriter,
     model::{FunctionEnv, Loc, StructEnv},
     ty::Type,

--- a/language/move-prover/bytecode/src/debug_instrumentation.rs
+++ b/language/move-prover/bytecode/src/debug_instrumentation.rs
@@ -16,7 +16,7 @@ use crate::{
     stackless_bytecode::{Bytecode, Operation},
 };
 
-use move_model::model::FunctionEnv;
+use move_model::{exp_generator::ExpGenerator, model::FunctionEnv};
 use std::collections::BTreeSet;
 
 pub struct DebugInstrumenter {}

--- a/language/move-prover/bytecode/src/global_invariant_instrumentation_v2.rs
+++ b/language/move-prover/bytecode/src/global_invariant_instrumentation_v2.rs
@@ -15,12 +15,12 @@ use crate::{
     usage_analysis,
 };
 
-use crate::spec_translator::SpecTranslator;
-
 use move_model::{
     ast::{ConditionKind, GlobalInvariant},
+    exp_generator::ExpGenerator,
     model::{FunctionEnv, GlobalEnv, GlobalId, QualifiedId, StructId},
     pragmas::CONDITION_ISOLATED_PROP,
+    spec_translator::SpecTranslator,
 };
 use std::collections::BTreeSet;
 
@@ -82,7 +82,7 @@ impl FunctionTargetProcessor for GlobalInvariantInstrumentationProcessorV2 {
 }
 
 struct Instrumenter<'a> {
-    options: &'a ProverOptions,
+    _options: &'a ProverOptions,
     builder: FunctionDataBuilder<'a>,
 }
 
@@ -93,7 +93,10 @@ impl<'a> Instrumenter<'a> {
         data: FunctionData,
     ) -> FunctionData {
         let builder = FunctionDataBuilder::new(fun_env, data);
-        let mut instrumenter = Instrumenter { options, builder };
+        let mut instrumenter = Instrumenter {
+            _options: options,
+            builder,
+        };
         instrumenter.instrument();
         instrumenter.builder.data
     }
@@ -138,7 +141,6 @@ impl<'a> Instrumenter<'a> {
         let mut assumed_at_update = BTreeSet::new();
         let module_env = &self.builder.fun_env.module_env;
         let mut translated = SpecTranslator::translate_invariants(
-            self.options,
             &mut self.builder,
             invariants.iter().filter_map(|id| {
                 env.get_global_invariant(*id).filter(|inv| {
@@ -204,11 +206,8 @@ impl<'a> Instrumenter<'a> {
         // Translate the invariants, computing any state to be saved as well. State saves are
         // necessary for update invariants which contain the `old(..)` expressions.
         let invariants = self.get_verified_invariants_for_mem(mem);
-        let mut translated = SpecTranslator::translate_invariants(
-            self.options,
-            &mut self.builder,
-            invariants.iter().cloned(),
-        );
+        let mut translated =
+            SpecTranslator::translate_invariants(&mut self.builder, invariants.iter().cloned());
 
         // Emit all necessary state saves for 'update' invariants.
         self.builder

--- a/language/move-prover/bytecode/src/lib.rs
+++ b/language/move-prover/bytecode/src/lib.rs
@@ -31,7 +31,6 @@ pub mod packed_types_analysis;
 pub mod reaching_def_analysis;
 pub mod read_write_set_analysis;
 pub mod spec_instrumentation;
-mod spec_translator;
 pub mod stackless_bytecode;
 pub mod stackless_bytecode_generator;
 pub mod stackless_control_flow_graph;

--- a/language/move-prover/bytecode/src/loop_analysis.rs
+++ b/language/move-prover/bytecode/src/loop_analysis.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 use move_model::{
     ast::{self, TempIndex},
+    exp_generator::ExpGenerator,
     model::FunctionEnv,
 };
 use std::collections::{BTreeMap, BTreeSet};

--- a/language/move-prover/bytecode/src/spec_instrumentation.rs
+++ b/language/move-prover/bytecode/src/spec_instrumentation.rs
@@ -23,13 +23,16 @@ use crate::{
     livevar_analysis::LiveVarAnalysisProcessor,
     options::ProverOptions,
     reaching_def_analysis::ReachingDefProcessor,
-    spec_translator::{SpecTranslator, TranslatedSpec},
     stackless_bytecode::{
         AbortAction, AssignKind, AttrId, Bytecode, HavocKind, Label, Operation, PropKind,
     },
     usage_analysis, verification_analysis,
 };
-use move_model::ast::QuantKind;
+use move_model::{
+    ast::QuantKind,
+    exp_generator::ExpGenerator,
+    spec_translator::{SpecTranslator, TranslatedSpec},
+};
 use std::collections::{BTreeMap, BTreeSet};
 
 const REQUIRES_FAILS_MESSAGE: &str = "precondition does not hold at this call";
@@ -146,7 +149,7 @@ impl FunctionTargetProcessor for SpecInstrumentationProcessor {
 }
 
 struct Instrumenter<'a> {
-    options: &'a ProverOptions,
+    _options: &'a ProverOptions,
     builder: FunctionDataBuilder<'a>,
     spec: TranslatedSpec,
     ret_locals: Vec<TempIndex>,
@@ -187,7 +190,6 @@ impl<'a> Instrumenter<'a> {
         // Translate the specification. This deals with elimination of `old(..)` expressions,
         // as well as replaces `result_n` references with `ret_locals`.
         let spec = SpecTranslator::translate_fun_spec(
-            options,
             false,
             &mut builder,
             fun_env,
@@ -198,7 +200,7 @@ impl<'a> Instrumenter<'a> {
 
         // Create and run the instrumenter.
         let mut instrumenter = Instrumenter {
-            options,
+            _options: options,
             builder,
             spec,
             ret_locals,
@@ -386,7 +388,6 @@ impl<'a> Instrumenter<'a> {
         let callee_env = env.get_module(mid).into_function(fid);
         let callee_opaque = callee_env.is_opaque();
         let mut callee_spec = SpecTranslator::translate_fun_spec(
-            self.options,
             true,
             &mut self.builder,
             &callee_env,


### PR DESCRIPTION
Both components are moved from the crate move-prover/bytecode into
move-model.

- Exp generator originally locates in FunctionDataBuilder, now the exp
  generator is turned into a trait and FunctionDataBuilder implement
  this trait to produce move-model exps. This minimizes the code change.
  FunctionDataBuilder still remains but now only handles
  bytecode-related operations, such as `emit_*` or operations related to
  `AttrId` or `Label`, which are not known to move-model

- The SpecTranslator file is completely removed from bytecode and fully
  substituted by the version in move-model. Other necessary changes are
  made to hook-up with the new SpecTranslator. There are no logic
  changes to the translator. The main change is that functions that
  used to takes a `FunctionDataBuilder` now takes a `T: ExpGenerator`.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Part of the effort to abstract the common functionalities used by the spec instrumenter (in prover pipeline) and executable spec.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI

