### PR TITLE
[move-prover] Fixes a bug with empty struct pack in the spec language

### DIFF
--- a/language/move-prover/tests/sources/functional/resources.move
+++ b/language/move-prover/tests/sources/functional/resources.move
@@ -262,4 +262,18 @@ module 0x42::TestResources {
         ensures result == B{ a: A{ addr: Signer::spec_address_of(account), val: 7 }, val: 77 };
         ensures result == B{ a: A{ val: 7, addr: Signer::spec_address_of(account)}, val: 77 };
     }
+
+    // ------------
+    // Empty struct
+    // ------------
+
+    struct Empty {}
+
+    public fun create_empty(): Empty {
+        Empty{}
+    }
+    spec fun create_empty {
+        ensures result == Empty{};
+    }
+
 }


### PR DESCRIPTION
The spec language created an empty value on `S{}`, whereas the Move compiler inserts a dummy field by design with the value of false for empty structs. This lead to mismatch in intepretation of bytecode and spec language during verification.

## Motivation

User reported bug.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added new test.

## Related PRs

NA
