### PR TITLE
[move-model] relocate model building logic fully to move model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4411,7 +4411,6 @@ dependencies = [
  "once_cell",
  "pretty",
  "rand 0.8.3",
- "regex",
  "serde",
  "serde_json",
  "shell-words",

--- a/language/move-model/tests/testsuite.rs
+++ b/language/move-model/tests/testsuite.rs
@@ -10,9 +10,7 @@ use move_prover_test_utils::baseline_test::verify_or_update_baseline;
 
 fn test_runner(path: &Path) -> datatest_stable::Result<()> {
     let targets = vec![path.to_str().unwrap().to_string()];
-    let deps = vec![];
-
-    let env = run_model_builder(targets, deps)?;
+    let env = run_model_builder(&targets, &[])?;
     let diags = if env.has_errors() {
         let mut writer = Buffer::no_color();
         env.report_errors(&mut writer);

--- a/language/move-prover/Cargo.toml
+++ b/language/move-prover/Cargo.toml
@@ -33,7 +33,6 @@ log = { version = "0.4.14", features = ["serde"] }
 num = "0.4.0"
 pretty = "0.10.0"
 rand = "0.8.3"
-regex = "1.4.3"
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
 simplelog = "0.9.0"

--- a/language/move-prover/bytecode/tests/testsuite.rs
+++ b/language/move-prover/bytecode/tests/testsuite.rs
@@ -159,7 +159,7 @@ fn get_tested_transformation_pipeline(
 fn test_runner(path: &Path) -> datatest_stable::Result<()> {
     let mut sources = extract_test_directives(path, "// dep:")?;
     sources.push(path.to_string_lossy().to_string());
-    let env: GlobalEnv = run_model_builder(sources, vec![])?;
+    let env: GlobalEnv = run_model_builder(&sources, &[])?;
     let out = if env.has_errors() {
         let mut error_writer = Buffer::no_color();
         env.report_errors(&mut error_writer);

--- a/language/move-prover/lab/src/benchmark.rs
+++ b/language/move-prover/lab/src/benchmark.rs
@@ -10,10 +10,12 @@ use clap::{App, Arg};
 use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
 use itertools::Itertools;
 use log::LevelFilter;
-use move_model::model::{FunctionEnv, GlobalEnv, ModuleEnv, VerificationScope};
+use move_model::{
+    model::{FunctionEnv, GlobalEnv, ModuleEnv, VerificationScope},
+    run_model_builder,
+};
 use move_prover::{
-    build_move_model, check_errors, cli::Options, create_and_process_bytecode, generate_boogie,
-    verify_boogie,
+    check_errors, cli::Options, create_and_process_bytecode, generate_boogie, verify_boogie,
 };
 use plotters::{
     coord::types::RangedCoordu32,
@@ -129,7 +131,7 @@ fn run_benchmark(
     per_function: bool,
 ) -> anyhow::Result<()> {
     println!("building model");
-    let env = build_move_model(modules, dep_dirs, false)?;
+    let env = run_model_builder(modules, dep_dirs)?;
     let mut error_writer = StandardStream::stderr(ColorChoice::Auto);
     check_errors(&env, &mut error_writer, "unexpected build errors")?;
     let mut options = if let Some(config_file) = config_file_opt {


### PR DESCRIPTION
Removed the `build_move_model` and the associated regex-matching logic
from move-prover to move-model. The regex-matching logic is also removed
in favor of using `move_parse` to find the dependencies.

NOTE: the first commit is the same as #8180, only the second commit needs to be reviewed.

## Motivation

I'll be needing this as well for spec instrumentation.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI
