### PR TITLE
[move-lang] make sources_shadow_deps part of parsing

### DIFF
--- a/language/move-lang/functional-tests/tests/functional_testsuite.rs
+++ b/language/move-lang/functional-tests/tests/functional_testsuite.rs
@@ -44,7 +44,9 @@ impl<'a> MoveSourceCompiler<'a> {
         errors::FilesSourceText,
         Result<Vec<CompiledUnit>, errors::Errors>,
     )> {
-        let (files, pprog_and_comments_res) = move_lang::move_parse(targets, &self.deps, None)?;
+        let (files, pprog_and_comments_res) = move_lang::move_parse(
+            targets, &self.deps, None, /* sources_shadow_deps */ false,
+        )?;
         let (_comments, pprog) = match pprog_and_comments_res {
             Err(errors) => return Ok((files, Err(errors))),
             Ok(res) => res,

--- a/language/move-model/src/lib.rs
+++ b/language/move-model/src/lib.rs
@@ -52,7 +52,12 @@ pub fn run_model_builder(
     all_sources.extend(other_sources.clone());
     let mut env = GlobalEnv::new();
     // Parse the program
-    let (files, pprog_and_comments_res) = move_parse(&all_sources, &[], None)?;
+    let (files, pprog_and_comments_res) = move_parse(
+        &all_sources,
+        &[],
+        None,
+        /* sources_shadow_deps */ false,
+    )?;
     for fname in files.keys().sorted() {
         let fsrc = &files[fname];
         env.add_source(fname, fsrc, other_sources.contains(&fname.to_string()));


### PR DESCRIPTION
`sources_shadow_deps` allows a module definition found in source file
shadow the same module definition found in dependency files. It is an
argument in `move_check`, `move_compile`, and
`move_construct_pre_compiled_lib` and in all these files, we can see the
following common code snippet:

```rust
let pprog = if sources_shadow_deps {
    shadow_lib_module_definitions(pprog)
} else {
    pprog
};
```

Perhaps a better place for this flag is `move_parse`, and more
specifically, its worker function, `parse_program`. And logically it
makes sense as well since the shadowing should be a parser concept.

A second change in this commit is that the meaning of
`sources_shadow_deps` is extended. In `move_parse`, there is a check,
`check_targets_deps_dont_intersect` (the same says all). However, it
creates a bit of inconvenience when compiling a module in a dir with
dependencies within the same dir. E.g., compile Diem.move by giving
`diem-framework/modules` as dependencies. A common usage pattern is from
the move prover: `mvp Diem.move --dependency=diem-framework/modules`.

The proposed change is to change `check_targets_deps_dont_intersect`
such that when `sources_shadow_deps` is True, do not return an error,
instead, remove the intersection of sources and deps from the deps.
Correspondingly, the name of this function is changed to
`ensure_targets_deps_dont_intersect` to better capture the change.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Needed by #8179 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI
