### PR TITLE
[move-prover] Monomorphization analysis

### DIFF
--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -1004,6 +1004,11 @@ impl GlobalEnv {
         self.get_module(fun.module_id).into_function(fun.id)
     }
 
+    /// Return the `StructEnv` for `str`
+    pub fn get_struct(&self, str: QualifiedId<StructId>) -> StructEnv<'_> {
+        self.get_module(str.module_id).into_struct(str.id)
+    }
+
     // Gets the number of modules in this environment.
     pub fn get_module_count(&self) -> usize {
         self.module_data.len()
@@ -2516,6 +2521,10 @@ impl<'env> FunctionEnv<'env> {
     /// Returns true if this function has the pragma intrinsic set to true.
     pub fn is_intrinsic(&self) -> bool {
         self.is_pragma_true(INTRINSIC_PRAGMA, || false)
+    }
+
+    pub fn is_native_or_intrinsic(&self) -> bool {
+        self.is_native() || self.is_intrinsic()
     }
 
     /// Returns true if this function is opaque.

--- a/language/move-prover/boogie-backend-exp/src/boogie_wrapper.rs
+++ b/language/move-prover/boogie-backend-exp/src/boogie_wrapper.rs
@@ -208,8 +208,9 @@ impl<'env> BoogieWrapper<'env> {
                     }
                     Temporary(fun, idx, value) if error.model.is_some() => {
                         let fun_env = self.env.get_function(*fun);
-                        let fun_target =
-                            self.targets.get_target(&fun_env, FunctionVariant::Baseline);
+                        let fun_target = self
+                            .targets
+                            .get_target(&fun_env, &FunctionVariant::Baseline);
                         if *idx < fun_target.get_local_count() {
                             let var_name = fun_target
                                 .get_local_name(*idx)
@@ -235,8 +236,9 @@ impl<'env> BoogieWrapper<'env> {
                     }
                     Result(fun, idx, value) if error.model.is_some() => {
                         let fun_env = self.env.get_function(*fun);
-                        let fun_target =
-                            self.targets.get_target(&fun_env, FunctionVariant::Baseline);
+                        let fun_target = self
+                            .targets
+                            .get_target(&fun_env, &FunctionVariant::Baseline);
                         let n = fun_target.get_return_count();
                         if *idx < n {
                             let var_name = if n > 1 {

--- a/language/move-prover/boogie-backend/src/boogie_wrapper.rs
+++ b/language/move-prover/boogie-backend/src/boogie_wrapper.rs
@@ -226,8 +226,9 @@ impl<'env> BoogieWrapper<'env> {
                     }
                     Temporary(fun, idx, value) if error.model.is_some() => {
                         let fun_env = self.env.get_function(*fun);
-                        let fun_target =
-                            self.targets.get_target(&fun_env, FunctionVariant::Baseline);
+                        let fun_target = self
+                            .targets
+                            .get_target(&fun_env, &FunctionVariant::Baseline);
                         if *idx < fun_target.get_local_count() {
                             let var_name = fun_target
                                 .get_local_name(*idx)
@@ -253,8 +254,9 @@ impl<'env> BoogieWrapper<'env> {
                     }
                     Result(fun, idx, value) if error.model.is_some() => {
                         let fun_env = self.env.get_function(*fun);
-                        let fun_target =
-                            self.targets.get_target(&fun_env, FunctionVariant::Baseline);
+                        let fun_target = self
+                            .targets
+                            .get_target(&fun_env, &FunctionVariant::Baseline);
                         let n = fun_target.get_return_count();
                         if *idx < n {
                             let var_name = if n > 1 {

--- a/language/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/language/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -211,13 +211,16 @@ impl<'env> ModuleTranslator<'env> {
             let verification_info = verification_analysis::get_info(
                 &self
                     .targets
-                    .get_target(&func_env, FunctionVariant::Baseline),
+                    .get_target(&func_env, &FunctionVariant::Baseline),
             );
             for variant in self.targets.get_target_variants(&func_env) {
                 if verification_info.verified && variant.is_verified()
                     || verification_info.inlined && !variant.is_verified()
                 {
-                    self.translate_function(variant, &self.targets.get_target(&func_env, variant));
+                    self.translate_function(
+                        &variant,
+                        &self.targets.get_target(&func_env, &variant),
+                    );
                 }
             }
         }
@@ -226,7 +229,7 @@ impl<'env> ModuleTranslator<'env> {
 
 impl<'env> ModuleTranslator<'env> {
     /// Translates the given function.
-    fn translate_function(&self, variant: FunctionVariant, fun_target: &FunctionTarget<'_>) {
+    fn translate_function(&self, variant: &FunctionVariant, fun_target: &FunctionTarget<'_>) {
         self.generate_function_sig(variant, &fun_target);
         self.generate_function_body(variant, &fun_target);
         emitln!(self.writer);
@@ -234,7 +237,7 @@ impl<'env> ModuleTranslator<'env> {
 
     /// Return a string for a boogie procedure header. Use inline attribute and name
     /// suffix as indicated by `entry_point`.
-    fn generate_function_sig(&self, variant: FunctionVariant, fun_target: &FunctionTarget<'_>) {
+    fn generate_function_sig(&self, variant: &FunctionVariant, fun_target: &FunctionTarget<'_>) {
         let (args, rets) = self.generate_function_args_and_returns(fun_target);
 
         let (suffix, attribs) = match variant {
@@ -253,7 +256,7 @@ impl<'env> ModuleTranslator<'env> {
                     attribs.push(format!("{{:random_seed {}}} ", seed));
                 };
 
-                if flavor == "inconsistency" {
+                if *flavor == "inconsistency" {
                     attribs.push(format!(
                         "{{:msg_if_verifies \"inconsistency_detected{}\"}} ",
                         self.loc_str(&fun_target.get_loc())
@@ -321,7 +324,7 @@ impl<'env> ModuleTranslator<'env> {
     }
 
     /// Generates boogie implementation body.
-    fn generate_function_body(&self, variant: FunctionVariant, fun_target: &FunctionTarget<'_>) {
+    fn generate_function_body(&self, variant: &FunctionVariant, fun_target: &FunctionTarget<'_>) {
         // Be sure to set back location to the whole function definition as a default.
         self.writer.set_location(&fun_target.get_loc().at_start());
 
@@ -768,7 +771,7 @@ impl<'env> ModuleTranslator<'env> {
                         let callee_env = self.module_env.env.get_module(*mid).into_function(*fid);
                         let callee_target = self
                             .targets
-                            .get_target(&callee_env, FunctionVariant::Baseline);
+                            .get_target(&callee_env, &FunctionVariant::Baseline);
 
                         let args_str = std::iter::once(boogie_type_values(
                             fun_target.func_env.module_env.env,

--- a/language/move-prover/bytecode/src/lib.rs
+++ b/language/move-prover/bytecode/src/lib.rs
@@ -25,6 +25,7 @@ pub mod graph;
 pub mod livevar_analysis;
 pub mod loop_analysis;
 pub mod memory_instrumentation;
+pub mod mono_analysis;
 pub mod mut_ref_instrumentation;
 pub mod options;
 pub mod packed_types_analysis;

--- a/language/move-prover/bytecode/src/mono_analysis.rs
+++ b/language/move-prover/bytecode/src/mono_analysis.rs
@@ -1,0 +1,239 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Analysis which computes information needed in backends for monomorphization. This
+//! computes the distinct type instantiations in the model for structs and inlined functions.
+
+use crate::{
+    function_target::FunctionTarget,
+    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant},
+    stackless_bytecode::{Bytecode, Operation},
+    verification_analysis,
+};
+use itertools::Itertools;
+use move_model::{
+    model::{FunId, GlobalEnv, QualifiedId, StructEnv, StructId},
+    ty::{Type, TypeDisplayContext},
+};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+    rc::Rc,
+};
+
+/// The environment extension computed by this analysis.
+#[derive(Clone, Default, Debug, PartialEq, PartialOrd, Eq)]
+pub struct MonoInfo {
+    pub structs: BTreeMap<QualifiedId<StructId>, BTreeSet<Vec<Type>>>,
+    pub funs: BTreeMap<QualifiedId<FunId>, BTreeSet<Vec<Type>>>,
+}
+
+/// Get the information computed by this analysis.
+pub fn get_info(env: &GlobalEnv) -> Rc<MonoInfo> {
+    env.get_extension::<MonoInfo>()
+        .unwrap_or_else(|| Rc::new(MonoInfo::default()))
+}
+
+pub struct MonoAnalysisProcessor();
+
+impl MonoAnalysisProcessor {
+    pub fn new() -> Box<Self> {
+        Box::new(Self())
+    }
+}
+
+impl FunctionTargetProcessor for MonoAnalysisProcessor {
+    fn run(&self, env: &GlobalEnv, targets: &mut FunctionTargetsHolder) {
+        let mut analyzer = Analyzer {
+            env,
+            targets,
+            info: MonoInfo::default(),
+            todo_targets: vec![],
+            done_targets: BTreeSet::new(),
+            inst_opt: None,
+        };
+        analyzer.analyze();
+        let Analyzer { info, .. } = analyzer;
+        env.set_extension(info);
+    }
+
+    fn is_single_run(&self) -> bool {
+        true
+    }
+
+    fn name(&self) -> String {
+        "mono_analysis".to_owned()
+    }
+
+    fn dump_result(
+        &self,
+        f: &mut fmt::Formatter,
+        env: &GlobalEnv,
+        _targets: &FunctionTargetsHolder,
+    ) -> fmt::Result {
+        writeln!(f, "\n\n==== mono-analysis result ====\n")?;
+        let info = env
+            .get_extension::<MonoInfo>()
+            .expect("monomorphization analysis not run");
+        let tctx = TypeDisplayContext::WithEnv {
+            env,
+            type_param_names: None,
+        };
+        let display_inst = |tys: &[Type]| {
+            tys.iter()
+                .map(|ty| ty.display(&tctx).to_string())
+                .join(", ")
+        };
+        for (sid, insts) in &info.structs {
+            let sname = env.get_struct(*sid).get_full_name_str();
+            writeln!(f, "struct {} = {{", sname)?;
+            for inst in insts {
+                writeln!(f, "  <{}>", display_inst(inst))?;
+            }
+            writeln!(f, "}}")?;
+        }
+        for (fid, insts) in &info.funs {
+            let fname = env.get_function(*fid).get_full_name_str();
+            writeln!(f, "fun {} = {{", fname)?;
+            for inst in insts {
+                writeln!(f, "  <{}>", display_inst(inst))?;
+            }
+            writeln!(f, "}}")?;
+        }
+
+        Ok(())
+    }
+}
+
+struct Analyzer<'a> {
+    env: &'a GlobalEnv,
+    targets: &'a FunctionTargetsHolder,
+    info: MonoInfo,
+    todo_targets: Vec<(QualifiedId<FunId>, Vec<Type>)>,
+    done_targets: BTreeSet<(QualifiedId<FunId>, Vec<Type>)>,
+    inst_opt: Option<Vec<Type>>,
+}
+
+impl<'a> Analyzer<'a> {
+    fn analyze(&mut self) {
+        // Analyze top-level, verified functions. Any functions they call will be queued in
+        // self.todo_targets for later analysis. During this phase, self.inst_opt is None.
+        for module in self.env.get_modules() {
+            for fun in module.get_functions() {
+                for (_, target) in self.targets.get_targets(&fun) {
+                    let info = verification_analysis::get_info(&target);
+                    if info.verified {
+                        self.analyze_target(target);
+                    }
+                }
+            }
+        }
+        // Now incrementally work included targets until they are done, while self.inst_opt
+        // contains the specific instantiation.
+        while !self.todo_targets.is_empty() {
+            let (fun, inst) = self.todo_targets.pop().unwrap();
+            self.inst_opt = Some(inst);
+            self.analyze_target(
+                self.targets
+                    .get_target(&self.env.get_function(fun), &FunctionVariant::Baseline),
+            );
+            let inst = std::mem::take(&mut self.inst_opt).unwrap();
+            if !inst.is_empty() {
+                // Insert it into final analysis result if not trivial
+                self.info.funs.entry(fun).or_default().insert(inst.clone());
+            }
+            self.done_targets.insert((fun, inst));
+        }
+    }
+
+    fn analyze_target(&mut self, target: FunctionTarget<'_>) {
+        // Analyze function locals and return value types.
+        for idx in 0..target.get_local_count() {
+            self.add_type(target.get_local_type(idx));
+        }
+        for ty in target.get_return_types().iter() {
+            self.add_type(ty);
+        }
+        // Analyze code.
+        if !target.func_env.is_native_or_intrinsic() {
+            for bc in target.get_bytecode() {
+                self.analyze_bytecode(&target, bc);
+            }
+        }
+    }
+
+    fn analyze_bytecode(&mut self, target: &FunctionTarget<'_>, bc: &Bytecode) {
+        use Bytecode::*;
+        use Operation::*;
+        // We only need to analyze function calls, not `pack` or other instructions
+        // because the types those are using are reflected in locals which are analyzed
+        // elsewhere.
+        if let Call(_, _, Function(mid, fid, targs), ..) = bc {
+            if !target.is_opaque() {
+                // This call needs to be inlined, with targs instantiated by self.inst_opt.
+                // Schedule for later processing.
+                let actuals = if let Some(inst) = &self.inst_opt {
+                    targs.iter().map(|ty| ty.instantiate(inst)).collect_vec()
+                } else {
+                    targs.to_owned()
+                };
+                let fun = mid.qualified(*fid);
+                // Only if this call has not been processed yet, queue it for future processing.
+                if !self.done_targets.contains(&(fun, actuals.clone())) {
+                    self.todo_targets.push((mid.qualified(*fid), actuals));
+                }
+            }
+        }
+    }
+
+    // Type Analysis
+    // =============
+
+    fn add_type(&mut self, ty: &Type) {
+        if let Some(inst) = &self.inst_opt {
+            let ty = ty.instantiate(inst);
+            self.add_type_continue(&ty)
+        } else {
+            self.add_type_continue(ty)
+        }
+    }
+
+    fn add_type_continue(&mut self, ty: &Type) {
+        match ty {
+            Type::Primitive(_) => {}
+            Type::Tuple(tys) => self.add_types(tys),
+            Type::Vector(et) => self.add_type(&*et),
+            Type::Struct(mid, sid, targs) => {
+                self.add_struct(self.env.get_module(*mid).into_struct(*sid), targs)
+            }
+            Type::Reference(_, rt) => self.add_type(&*rt),
+            Type::Fun(args, res) => {
+                self.add_types(args);
+                self.add_type(&*res);
+            }
+            Type::TypeDomain(rd) => self.add_type(&*rd),
+            Type::ResourceDomain(_mid, _sid) => {
+                // TODO: ignored for now, since the constructor will need to be refined to
+                // have type arguments in a future PR.
+            }
+            _ => {}
+        }
+    }
+
+    fn add_types<'b, T: IntoIterator<Item = &'b Type>>(&mut self, tys: T) {
+        for ty in tys {
+            self.add_type(ty);
+        }
+    }
+
+    fn add_struct(&mut self, struct_: StructEnv<'_>, targs: &[Type]) {
+        if !targs.is_empty() {
+            self.info
+                .structs
+                .entry(struct_.get_qualified_id())
+                .or_default()
+                .insert(targs.to_owned());
+            self.add_types(targs);
+        }
+    }
+}

--- a/language/move-prover/bytecode/src/packed_types_analysis.rs
+++ b/language/move-prover/bytecode/src/packed_types_analysis.rs
@@ -37,7 +37,7 @@ pub fn get_packed_types(
         let is_script = module_env.is_script_module();
         if is_script || module_name == "Genesis" {
             for func_env in module_env.get_functions() {
-                let fun_target = targets.get_target(&func_env, FunctionVariant::Baseline);
+                let fun_target = targets.get_target(&func_env, &FunctionVariant::Baseline);
                 let annotation = fun_target
                     .get_annotations()
                     .get::<PackedTypesState>()
@@ -121,7 +121,10 @@ impl<'a> TransferFunctions for PackedTypesAnalysis<'a> {
                     }
                 }
                 Function(mid, fid, types) => {
-                    if let Some(summary) = self.cache.get::<PackedTypesState>(mid.qualified(*fid)) {
+                    if let Some(summary) = self
+                        .cache
+                        .get::<PackedTypesState>(mid.qualified(*fid), &FunctionVariant::Baseline)
+                    {
                         // add closed types
                         for ty in &summary.closed_types.0 {
                             state.closed_types.insert(ty.clone());

--- a/language/move-prover/bytecode/src/read_write_set_analysis.rs
+++ b/language/move-prover/bytecode/src/read_write_set_analysis.rs
@@ -385,7 +385,10 @@ impl<'a> TransferFunctions for ReadWriteSetAnalysis<'a> {
                     let fun_id = mid.qualified(*fid);
                     let global_env = self.cache.global_env();
                     let callee_fun_env = global_env.get_function(fun_id);
-                    if let Some(callee_summary) = self.cache.get::<ReadWriteSetState>(fun_id) {
+                    if let Some(callee_summary) = self
+                        .cache
+                        .get::<ReadWriteSetState>(fun_id, &FunctionVariant::Baseline)
+                    {
                         state.apply_summary(callee_summary, args, types, rets);
                     } else {
                         // native fun. use handwritten model
@@ -582,7 +585,7 @@ pub fn get_read_write_set(env: &GlobalEnv, targets: &FunctionTargetsHolder) {
     for module_env in env.get_modules() {
         let module_name = module_env.get_identifier().to_string();
         for func_env in module_env.get_functions() {
-            let fun_target = targets.get_target(&func_env, FunctionVariant::Baseline);
+            let fun_target = targets.get_target(&func_env, &FunctionVariant::Baseline);
             let annotation = fun_target
                 .get_annotations()
                 .get::<ReadWriteSetState>()

--- a/language/move-prover/bytecode/src/spec_instrumentation.rs
+++ b/language/move-prover/bytecode/src/spec_instrumentation.rs
@@ -118,7 +118,7 @@ impl FunctionTargetProcessor for SpecInstrumentationProcessor {
             verification_data = Instrumenter::run(&*options, targets, fun_env, verification_data);
             targets.insert_target_data(
                 &fun_env.get_qualified_id(),
-                verification_data.variant,
+                verification_data.variant.clone(),
                 verification_data,
             );
 
@@ -127,7 +127,11 @@ impl FunctionTargetProcessor for SpecInstrumentationProcessor {
                 let mut new_data =
                     data.fork(FunctionVariant::Verification(INCONSISTENCY_CHECK_VARIANT));
                 new_data = Instrumenter::run(&*options, targets, fun_env, new_data);
-                targets.insert_target_data(&fun_env.get_qualified_id(), new_data.variant, new_data);
+                targets.insert_target_data(
+                    &fun_env.get_qualified_id(),
+                    new_data.variant.clone(),
+                    new_data,
+                );
             }
         }
 
@@ -819,13 +823,13 @@ fn check_caller_callee_modifies_relation(
     if fun_env.is_native() || fun_env.is_intrinsic() {
         return;
     }
-    let caller_func_target = targets.get_target(&fun_env, FunctionVariant::Baseline);
+    let caller_func_target = targets.get_target(&fun_env, &FunctionVariant::Baseline);
     for callee in fun_env.get_called_functions() {
         let callee_fun_env = env.get_function(callee);
         if callee_fun_env.is_native() || callee_fun_env.is_intrinsic() {
             continue;
         }
-        let callee_func_target = targets.get_target(&callee_fun_env, FunctionVariant::Baseline);
+        let callee_func_target = targets.get_target(&callee_fun_env, &FunctionVariant::Baseline);
         let callee_modified_memory = usage_analysis::get_modified_memory(&callee_func_target);
         for target in caller_func_target.get_modify_targets().keys() {
             if callee_modified_memory.contains(target)
@@ -855,7 +859,7 @@ fn check_opaque_modifies_completeness(
     targets: &FunctionTargetsHolder,
     fun_env: &FunctionEnv,
 ) {
-    let target = targets.get_target(fun_env, FunctionVariant::Baseline);
+    let target = targets.get_target(fun_env, &FunctionVariant::Baseline);
     if !target.is_opaque() {
         return;
     }

--- a/language/move-prover/bytecode/src/usage_analysis.rs
+++ b/language/move-prover/bytecode/src/usage_analysis.rs
@@ -7,7 +7,7 @@ use crate::{
         AbstractDomain, DataflowAnalysis, JoinResult, SetDomain, TransferFunctions,
     },
     function_target::{FunctionData, FunctionTarget},
-    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
+    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant},
     stackless_bytecode::{Bytecode, Operation},
 };
 use move_model::model::{FunctionEnv, QualifiedId, StructId};
@@ -123,7 +123,10 @@ impl<'a> TransferFunctions for MemoryUsageAnalysis<'a> {
         if let Call(_, _, oper, _, _) = code {
             match oper {
                 Function(mid, fid, _) => {
-                    if let Some(summary) = self.cache.get::<UsageState>(mid.qualified(*fid)) {
+                    if let Some(summary) = self
+                        .cache
+                        .get::<UsageState>(mid.qualified(*fid), &FunctionVariant::Baseline)
+                    {
                         state.modified_memory.extend(&summary.modified_memory.0);
                         state.used_memory.extend(&summary.used_memory.0);
                     }

--- a/language/move-prover/bytecode/tests/mono_analysis/test.exp
+++ b/language/move-prover/bytecode/tests/mono_analysis/test.exp
@@ -1,0 +1,79 @@
+============ initial translation from Move ================
+
+[variant baseline]
+public fun Test::f1<$tv0>($t0|x1: #0): Test::A<#0, u64> {
+     var $t1: #0
+     var $t2: u64
+     var $t3: Test::A<#0, u64>
+  0: $t1 := move($t0)
+  1: $t2 := 10
+  2: $t3 := pack Test::A<#0, u64>($t1, $t2)
+  3: return $t3
+}
+
+
+[variant baseline]
+public fun Test::f2($t0|x: u8): Test::B<u8> {
+     var $t1: u8
+     var $t2: Test::A<u8, u64>
+     var $t3: Test::B<u8>
+  0: $t1 := copy($t0)
+  1: $t2 := Test::f1<u8>($t1)
+  2: $t3 := pack Test::B<u8>($t2)
+  3: return $t3
+}
+
+
+[variant baseline]
+public fun Test::f3<$tv0>($t0|x1: #0): Test::A<#0, u64> {
+     var $t1: #0
+     var $t2: u64
+     var $t3: Test::A<#0, u64>
+  0: $t1 := move($t0)
+  1: $t2 := 1
+  2: $t3 := pack Test::A<#0, u64>($t1, $t2)
+  3: return $t3
+}
+
+
+[variant baseline]
+public fun Test::f4<$tv0>($t0|x1: #0): Test::B<#0> {
+     var $t1: #0
+     var $t2: Test::A<#0, u64>
+     var $t3: Test::B<#0>
+  0: $t1 := move($t0)
+  1: $t2 := Test::f3<#0>($t1)
+  2: $t3 := pack Test::B<#0>($t2)
+  3: return $t3
+}
+
+
+[variant baseline]
+public fun Test::f5(): Test::B<u128> {
+     var $t0: u128
+     var $t1: Test::B<u128>
+  0: $t0 := 1
+  1: $t1 := Test::f4<u128>($t0)
+  2: return $t1
+}
+
+
+
+==== mono-analysis result ====
+
+struct Test::A = {
+  <u8, u64>
+  <u128, u64>
+  <#0, u64>
+}
+struct Test::B = {
+  <u8>
+  <u128>
+  <#0>
+}
+fun Test::f1 = {
+  <u8>
+}
+fun Test::f4 = {
+  <u128>
+}

--- a/language/move-prover/bytecode/tests/mono_analysis/test.move
+++ b/language/move-prover/bytecode/tests/mono_analysis/test.move
@@ -1,0 +1,37 @@
+address 0x123 {
+module Test {
+
+    struct A<T1, T2> {
+        x1: T1,
+        x2: T2,
+    }
+
+    struct B<T1> {
+        x1: A<T1, u64>,
+    }
+
+    public fun f1<T>(x1: T): A<T, u64> {
+        A{x1, x2: 10}
+    }
+
+    public fun f2(x: u8): B<u8> {
+        B{x1: f1(x)}
+    }
+
+    public fun f3<T>(x1: T): A<T, u64> {
+        A{x1, x2: 1}
+    }
+    spec fun f3 {
+        pragma opaque = true;
+    }
+
+    public fun f4<T>(x1: T): B<T> {
+        B{x1: f3(x1)}
+    }
+
+    public fun f5(): B<u128> {
+        f4(1)
+    }
+
+}
+}

--- a/language/move-prover/src/lib.rs
+++ b/language/move-prover/src/lib.rs
@@ -15,6 +15,7 @@ use bytecode::{
     function_target_pipeline::{FunctionTargetPipeline, FunctionTargetsHolder},
     global_invariant_instrumentation::GlobalInvariantInstrumentationProcessor,
     global_invariant_instrumentation_v2::GlobalInvariantInstrumentationProcessorV2,
+    mono_analysis::MonoAnalysisProcessor,
     read_write_set_analysis::{self, ReadWriteSetProcessor},
     spec_instrumentation::SpecInstrumentationProcessor,
 };
@@ -237,6 +238,7 @@ fn create_bytecode_processing_pipeline(options: &Options) -> FunctionTargetPipel
     } else {
         res.add_processor(GlobalInvariantInstrumentationProcessor::new());
     }
+    res.add_processor(MonoAnalysisProcessor::new());
     res
 }
 


### PR DESCRIPTION
This implements a new bytecode processor which performs monomorphization analysis. This analysis computes all type instantiations in a program for structs and functions which are inlined for verification.

The basic assumptions for monomorphization are the followings:

- We can verify top-level functions with generic parameters by fixing those to a "given" type. Those given types will later be introduced in the Boogie backend.
- For functions which are not opaque and therefore are inlined for verification, we need to transitively compute all instantiations (with concrete or formal given types from top-level functions).  For opaque functions, we expect that pre/post will be specialized by the backend at caller points, so we do not to compute their instantiations.
- All structs types used directly or indirectly need to have instantiations computed.
- For specification expressions and functions, we expect the backend to be able to represent them generically. (Boogie supports this and we do it already today.)

This PR also makes some some changes to the bytecode pipeline infra:

- As I first thought to use compositional analysis for this, I removed some restrictions there to work with function variants.
- However, I later decided to do this with a new style of processor, namely a "single run" processor. This type of processor does not visit function by function, but just performs one global analysis step.
- There is also now a facility for a processor to dump global (not per function) output.

The PR also fixes an issue with the new way how we collect sources and dependencies in move-lang. Specifically, we canonicalize file names such that `./foo.move` and `/<path/foo.move` are recognized as the same.

## Motivation

Monomorphization

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

New test

## Related PRs

NA
