### PR TITLE
[language][bootcamp] Replace instance of unsafe arithmetic with checked alternative

### DIFF
--- a/language/move-core/types/src/parser.rs
+++ b/language/move-core/types/src/parser.rs
@@ -7,7 +7,7 @@ use crate::{
     language_storage::{StructTag, TypeTag},
     transaction_argument::TransactionArgument,
 };
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
 use std::iter::Peekable;
 
 #[derive(Eq, PartialEq, Debug)]
@@ -134,7 +134,10 @@ fn next_token(s: &str) -> Result<Option<(Token, usize)>> {
                         _ => bail!("unrecognized token"),
                     }
                 }
-                let len = r.len() + 3;
+                let len = r
+                    .len()
+                    .checked_add(3)
+                    .ok_or_else(|| anyhow!("Addition resulted in overflow"))?;
                 (Token::Bytes(hex::encode(r)), len)
             }
             'x' if it.peek() == Some(&'"') => {


### PR DESCRIPTION
## Motivation

We are creating bootcamp tasks to address all the instances of unsafe arithmetic (+,-,*,/,etc) in the diem core code base. 

This is an example fix we expect which we are using to test the end-to-end process these bootcampers will go through.

The Instructions will be available in a future wiki. Ping me directly if you would like access to the draft.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo x lint && cargo xfmt && cargo xclippy --all-targets
cargo xtest
