### PR TITLE
[ci] start consuming JUnit report from nextest

### DIFF
--- a/.github/workflows/ci-test-complete.yml
+++ b/.github/workflows/ci-test-complete.yml
@@ -1,0 +1,45 @@
+# This workflow is run after CI tests are completed. This has to be done as a separate workflow because forks
+# don't have the right permissions.
+#
+# For this and other workflow_run scripts, the main branch's copy of the action is *always* used, even on release
+# branches. Changes to this action cannot be tested until it is updated on main.
+
+name: ci-test-complete
+
+on:
+  workflow_run:
+    workflows: ["ci-test"]
+    types:
+      - completed
+
+jobs:
+  unit-test-results:
+    name: Unit test results
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion != 'skipped' }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download artifacts
+        uses: diem/actions/download-artifacts@a5fa31ff2b54a544cd88ac912cda469742592e6c
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          pattern: '^.*-test-results$'
+          extract: true
+      - name: Publish unit test results
+        uses: diem/publish-unit-test-result-action@07dbf21c1095745d5149a54007f28231936c9da4
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          check_name: Test results
+          files: "artifacts/*/**/*.xml"
+          # Don't comment on PRs at the moment: might be too noisy and the test deltas are incorrect:
+          # https://github.com/EnricoMi/publish-unit-test-result-action/issues/115
+          comment_on_pr: false
+          # Disable comparisons because determinator means not all tests are run on all commits yet.
+          compare_to_earlier_commit: false
+          # The individual artifacts are for different sets of tests, so report them separately.
+          report_individual_runs: true
+          # These annotations are used for comparisons, but that model won't work for Diem because
+          # of the determinator -- so disable them
+          check_run_annotations: "none"
+          pull_request_build: "commit"

--- a/.github/workflows/dep-summaries.yml
+++ b/.github/workflows/dep-summaries.yml
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: fetch base ref
         id: fetch-base-ref
-        uses: diem/actions/pr-base-ref@26629aba5897746c40697c786d71635767f87cda
+        uses: diem/actions/pr-base-ref@a5fa31ff2b54a544cd88ac912cda469742592e6c
         if: ${{ startsWith(github.event_name, 'pull_request') }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -107,7 +107,7 @@ jobs:
   #   steps:
   #     - name: require dep-audit review if TCB deps changed
   #       if: ${{ needs.calc-summaries.outputs.lsr-summary-diff || needs.calc-summaries.lec-summary-diff }}
-  #       uses: diem/actions/require-review@26629aba5897746c40697c786d71635767f87cda
+  #       uses: diem/actions/require-review@a5fa31ff2b54a544cd88ac912cda469742592e6c
   #       with:
   #         github-token: ${{ secrets.GITHUB_TOKEN }}
   #         users: ${{ needs.calc-summaries.outputs.dep-auditors-list }}
@@ -120,7 +120,7 @@ jobs:
     steps:
       - name: annotate PR with LSR diff
         if: ${{ needs.calc-summaries.outputs.lsr-summary-diff }}
-        uses: diem/actions/comment@26629aba5897746c40697c786d71635767f87cda
+        uses: diem/actions/comment@a5fa31ff2b54a544cd88ac912cda469742592e6c
         with:
           comment: |
             **LSR dependency change summary**:
@@ -131,7 +131,7 @@ jobs:
           delete-older: true
       - name: annotate PR with LEC diff
         if: ${{ needs.calc-summaries.outputs.lec-summary-diff }}
-        uses: diem/actions/comment@26629aba5897746c40697c786d71635767f87cda
+        uses: diem/actions/comment@a5fa31ff2b54a544cd88ac912cda469742592e6c
         with:
           comment: |
             **LEC dependency change summary**:
@@ -142,7 +142,7 @@ jobs:
           delete-older: true
       - name: annotate PR with release diff
         if: ${{ needs.calc-summaries.outputs.release-summary-diff }}
-        uses: diem/actions/comment@26629aba5897746c40697c786d71635767f87cda
+        uses: diem/actions/comment@a5fa31ff2b54a544cd88ac912cda469742592e6c
         with:
           comment: |
             **release binaries dependency change summary**:
@@ -153,26 +153,26 @@ jobs:
           delete-older: true
       - name: label PR if TCB changed
         if: ${{ needs.calc-summaries.outputs.lsr-summary-diff || needs.calc-summaries.outputs.lec-summary-diff }}
-        uses: diem/actions/labels@26629aba5897746c40697c786d71635767f87cda
+        uses: diem/actions/labels@a5fa31ff2b54a544cd88ac912cda469742592e6c
         with:
           add: tcb-deps-changed
       - name: label PR if tracked deps changed
         if: ${{ needs.calc-summaries.outputs.lsr-summary-diff || needs.calc-summaries.outputs.lec-summary-diff || needs.calc-summaries.outputs.release-summary-diff }}
-        uses: diem/actions/labels@26629aba5897746c40697c786d71635767f87cda
+        uses: diem/actions/labels@a5fa31ff2b54a544cd88ac912cda469742592e6c
         with:
           add: deps-changed
       - name: unlabel PR if TCB changed
         if: ${{ !needs.calc-summaries.outputs.lsr-summary-diff && !needs.calc-summaries.outputs.lec-summary-diff }}
-        uses: diem/actions/labels@26629aba5897746c40697c786d71635767f87cda
+        uses: diem/actions/labels@a5fa31ff2b54a544cd88ac912cda469742592e6c
         with:
           remove: tcb-deps-changed
       - name: unlabel PR if tracked deps changed
         if: ${{ !needs.calc-summaries.outputs.lsr-summary-diff && !needs.calc-summaries.outputs.lec-summary-diff && !needs.calc-summaries.outputs.release-summary-diff }}
-        uses: diem/actions/labels@26629aba5897746c40697c786d71635767f87cda
+        uses: diem/actions/labels@a5fa31ff2b54a544cd88ac912cda469742592e6c
         with:
           remove: deps-changed
       - name: request dep-audit review if TCB deps changed
-        uses: diem/actions/request-review@26629aba5897746c40697c786d71635767f87cda
+        uses: diem/actions/request-review@a5fa31ff2b54a544cd88ac912cda469742592e6c
         if: ${{ needs.calc-summaries.outputs.lsr-summary-diff || needs.calc-summaries.outputs.lec-summary-diff }}
         with:
           users: ${{ needs.calc-summaries.outputs.dep-auditors-list }}

--- a/.github/workflows/hyperjump-comment.yml
+++ b/.github/workflows/hyperjump-comment.yml
@@ -12,7 +12,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: comment
-        uses: diem/actions/hyperjump-comment@26629aba5897746c40697c786d71635767f87cda
+        uses: diem/actions/hyperjump-comment@a5fa31ff2b54a544cd88ac912cda469742592e6c
         with:
           github-token: ${{ secrets.HYPERJUMP_TOKEN }}
           number: ${{ github.event.client_payload.number }}

--- a/.github/workflows/hyperjump-labels.yml
+++ b/.github/workflows/hyperjump-labels.yml
@@ -12,7 +12,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: labels
-        uses: diem/actions/hyperjump-labels@26629aba5897746c40697c786d71635767f87cda
+        uses: diem/actions/hyperjump-labels@a5fa31ff2b54a544cd88ac912cda469742592e6c
         with:
           github-token: ${{ secrets.HYPERJUMP_TOKEN }}
           number: ${{ github.event.client_payload.number }}

--- a/.github/workflows/hyperjump-request-review.yml
+++ b/.github/workflows/hyperjump-request-review.yml
@@ -12,7 +12,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: request review
-        uses: diem/actions/hyperjump-request-review@26629aba5897746c40697c786d71635767f87cda
+        uses: diem/actions/hyperjump-request-review@a5fa31ff2b54a544cd88ac912cda469742592e6c
         with:
           github-token: ${{ secrets.HYPERJUMP_TOKEN }}
           number: ${{ github.event.client_payload.number }}

--- a/.github/workflows/jsonrpc-compat.yml
+++ b/.github/workflows/jsonrpc-compat.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: comment
-        uses: diem/actions/comment@26629aba5897746c40697c786d71635767f87cda
+        uses: diem/actions/comment@a5fa31ff2b54a544cd88ac912cda469742592e6c
         with:
           comment: |
             **This PR may have modified JSON-RPC server code.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5564,7 +5564,7 @@ checksum = "3ac73b1112776fc109b2e61909bc46c7e1bf0d7f690ffb1676553acce16d5cda"
 [[package]]
 name = "quick-junit"
 version = "0.1.0"
-source = "git+https://github.com/diem/diem-devtools?branch=main#2e349d96e88b662fab9dfe45222e1486513615e1"
+source = "git+https://github.com/diem/diem-devtools?branch=main#bb4bc9d7d9ce6308c2571bf7e0ffaf662d5d2992"
 dependencies = [
  "chrono",
  "indexmap",
@@ -6759,9 +6759,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aa894ef3fade0ee7243422f4fbbd6c2b48e6de767e621d37ef65f2310f53cea"
+checksum = "ef33d6d0cd06e0840fba9985aab098c147e67e05cee14d412d3345ed14ff30ac"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -7336,7 +7336,7 @@ dependencies = [
 [[package]]
 name = "testrunner"
 version = "0.1.0"
-source = "git+https://github.com/diem/diem-devtools?branch=main#2e349d96e88b662fab9dfe45222e1486513615e1"
+source = "git+https://github.com/diem/diem-devtools?branch=main#bb4bc9d7d9ce6308c2571bf7e0ffaf662d5d2992"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/devtools/x/src/nextest.rs
+++ b/devtools/x/src/nextest.rs
@@ -97,18 +97,17 @@ pub fn run(args: Args, xctx: XContext) -> Result<()> {
                         ),
                     );
 
-                    // Construct the friendly name from the package and build target.
-                    let mut friendly_name = package.name().to_owned();
+                    // Construct the binary ID from the package and build target.
+                    let mut binary_id = package.name().to_owned();
                     if artifact.target.name != package.name() {
-                        friendly_name.push_str("::");
-                        friendly_name.push_str(&artifact.target.name);
+                        binary_id.push_str("::");
+                        binary_id.push_str(&artifact.target.name);
                     }
-                    let friendly_name = Some(friendly_name);
 
                     executables.push(TestBinary {
                         binary,
+                        binary_id,
                         cwd,
-                        friendly_name,
                     });
                 }
             }


### PR DESCRIPTION
This PR starts making the JUnit output generated in `nextest` available for developer consumption. This initial effort just implements a summary, but I hope to add more reporting soon.

This has to be implemented as a separate action because forks don't have the right permissions. Unfortunately, it also means that we can't test it until it lands on `main`. [This blog post](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/) covers the `workflow_run` action.

I've had to fork the action to add a `test_case_annotations` feature (which we may want to use to disable test annotations if they prove to be too noisy). We may have to keep iterating on this and/or use it more significantly so I expect we'll maintain a copy of the action in the `diem` org at some point.