### PR TITLE
[cluster-test] deprecate accountData in CT

### DIFF
--- a/sdk/src/transaction_builder.rs
+++ b/sdk/src/transaction_builder.rs
@@ -391,6 +391,43 @@ impl TransactionFactory {
         }
     }
 
+    pub fn update_diem_version(&self, sliding_nonce: u64, major: u64) -> TransactionBuilder {
+        if self.is_script_function_enabled() {
+            self.payload(stdlib::encode_update_diem_version_script_function(
+                sliding_nonce,
+                major,
+            ))
+        } else {
+            self.script(stdlib::encode_update_diem_version_script(
+                sliding_nonce,
+                major,
+            ))
+        }
+    }
+
+    pub fn remove_validator_and_reconfigure(
+        &self,
+        sliding_nonce: u64,
+        validator_name: Vec<u8>,
+        validator_address: AccountAddress,
+    ) -> TransactionBuilder {
+        if self.is_script_function_enabled() {
+            self.payload(
+                stdlib::encode_remove_validator_and_reconfigure_script_function(
+                    sliding_nonce,
+                    validator_name,
+                    validator_address,
+                ),
+            )
+        } else {
+            self.script(stdlib::encode_remove_validator_and_reconfigure_script(
+                sliding_nonce,
+                validator_name,
+                validator_address,
+            ))
+        }
+    }
+
     //
     // Internal Helpers
     //

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -24,11 +24,11 @@ pub struct LocalAccount {
 }
 
 impl LocalAccount {
-    pub fn new<T: Into<AccountKey>>(address: AccountAddress, key: T) -> Self {
+    pub fn new<T: Into<AccountKey>>(address: AccountAddress, key: T, sequence_number: u64) -> Self {
         Self {
             address,
             key: key.into(),
-            sequence_number: 0,
+            sequence_number,
         }
     }
 
@@ -39,7 +39,7 @@ impl LocalAccount {
         let key = AccountKey::generate(rng);
         let address = key.authentication_key().derived_address();
 
-        Self::new(address, key)
+        Self::new(address, key, 0)
     }
 
     pub fn sign_transaction(&self, txn: RawTransaction) -> SignedTransaction {

--- a/testsuite/cluster-test/src/experiments/load_test.rs
+++ b/testsuite/cluster-test/src/experiments/load_test.rs
@@ -13,6 +13,7 @@ use async_trait::async_trait;
 use diem_config::{config::NodeConfig, network_id::NetworkId};
 use diem_logger::*;
 use diem_mempool::network::{MempoolNetworkEvents, MempoolNetworkSender};
+use diem_sdk::transaction_builder::TransactionFactory;
 use diem_time_service::TimeService;
 use diem_types::{account_config::diem_root_address, chain_id::ChainId};
 use futures::{sink::SinkExt, StreamExt};
@@ -161,7 +162,8 @@ impl Experiment for LoadTest {
                 .load_diem_root_account(&full_node_client)
                 .await?;
             let receiver = diem_root_address();
-            let dummy_tx = gen_transfer_txn_request(&mut sender, &receiver, 0, ChainId::test(), 0);
+            let tx_factory = TransactionFactory::new(ChainId::test());
+            let dummy_tx = gen_transfer_txn_request(&mut sender, &receiver, 0, tx_factory);
             let total_byte = dummy_tx.raw_txn_bytes_len() as u64 * stats.submitted;
             info!("Total tx emitter stats: {}, bytes: {}", stats, total_byte);
             info!(

--- a/testsuite/cluster-test/src/experiments/reconfiguration_test.rs
+++ b/testsuite/cluster-test/src/experiments/reconfiguration_test.rs
@@ -7,20 +7,16 @@ use crate::{
     cluster::Cluster,
     experiments::{Context, Experiment, ExperimentParam},
     instance::Instance,
-    tx_emitter::{execute_and_wait_transactions, gen_submit_transaction_request, EmitJobRequest},
+    tx_emitter::{execute_and_wait_transactions, EmitJobRequest},
 };
 use anyhow::ensure;
 use async_trait::async_trait;
 use diem_client::Client;
 use diem_logger::prelude::*;
 use diem_operational_tool::json_rpc::JsonRpcClientWrapper;
-use diem_transaction_builder::stdlib::{
-    encode_add_validator_and_reconfigure_script, encode_remove_validator_and_reconfigure_script,
-    encode_update_diem_version_script,
-};
+use diem_sdk::transaction_builder::TransactionFactory;
 use diem_types::{
     account_address::AccountAddress, chain_id::ChainId, ledger_info::LedgerInfoWithSignatures,
-    transaction::TransactionPayload,
 };
 use std::{
     collections::HashSet,
@@ -96,6 +92,7 @@ impl Experiment for Reconfiguration {
 
     async fn run(&mut self, context: &mut Context<'_>) -> anyhow::Result<()> {
         let full_node = context.cluster.random_fullnode_instance();
+        let tx_factory = TransactionFactory::new(ChainId::test());
         let mut full_node_client = full_node.json_rpc_client();
         let mut diem_root_account = context
             .tx_emitter
@@ -134,15 +131,12 @@ impl Experiment for Reconfiguration {
         let validator_name = self.affected_pod_name.as_bytes().to_vec();
         let timer = Instant::now();
         for i in 0..self.count / 2 {
-            let remove_txn = gen_submit_transaction_request(
-                TransactionPayload::Script(encode_remove_validator_and_reconfigure_script(
+            let remove_txn = diem_root_account.sign_with_transaction_builder(
+                tx_factory.remove_validator_and_reconfigure(
                     allowed_nonce,
                     validator_name.clone(),
                     self.affected_peer_id,
-                )),
-                &mut diem_root_account,
-                ChainId::test(),
-                0,
+                ),
             );
             execute_and_wait_transactions(
                 &mut full_node_client,
@@ -151,15 +145,12 @@ impl Experiment for Reconfiguration {
             )
             .await?;
             version = expect_epoch(&full_node_client, version, (i + 1) * 2).await?;
-            let add_txn = gen_submit_transaction_request(
-                TransactionPayload::Script(encode_add_validator_and_reconfigure_script(
+            let add_txn = diem_root_account.sign_with_transaction_builder(
+                tx_factory.add_validator_and_reconfigure(
                     allowed_nonce,
                     validator_name.clone(),
                     self.affected_peer_id,
-                )),
-                &mut diem_root_account,
-                ChainId::test(),
-                0,
+                ),
             );
             execute_and_wait_transactions(
                 &mut full_node_client,
@@ -173,16 +164,10 @@ impl Experiment for Reconfiguration {
         if self.count % 2 == 1 {
             let magic_number = 42;
             info!("Bump DiemVersion to {}", magic_number);
-            let update_txn = gen_submit_transaction_request(
-                TransactionPayload::Script(encode_update_diem_version_script(
-                    allowed_nonce,
-                    magic_number,
-                )),
-                &mut diem_root_account,
-                ChainId::test(),
-                0,
+            let update_txn = diem_root_account.sign_with_transaction_builder(
+                TransactionFactory::new(ChainId::test())
+                    .update_diem_version(allowed_nonce, magic_number),
             );
-
             execute_and_wait_transactions(
                 &mut full_node_client,
                 &mut diem_root_account,

--- a/testsuite/forge/src/backend/local.rs
+++ b/testsuite/forge/src/backend/local.rs
@@ -69,18 +69,21 @@ impl Factory for LocalFactory {
         let root_account = LocalAccount::new(
             diem_sdk::types::account_config::diem_root_address(),
             account_key,
+            0,
         );
         let key = generate_key::load_key(&validator_swarm.config.diem_root_key_path);
         let account_key = AccountKey::from_private_key(key);
         let treasury_compliance_account = LocalAccount::new(
             diem_sdk::types::account_config::treasury_compliance_account_address(),
             account_key,
+            0,
         );
         let key = generate_key::load_key(&validator_swarm.config.diem_root_key_path);
         let account_key = AccountKey::from_private_key(key);
         let designated_dealer_account = LocalAccount::new(
             diem_sdk::types::account_config::testnet_dd_account_address(),
             account_key,
+            0,
         );
 
         validator_swarm.launch();


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan
test on local swarm with one validator node:
```cargo run -p cluster-test -- --mint-file "/private/var/folders/qd/tg50mr0d7k75qvztr_8yk2km0000gn/T/5b88e78fac18c65fbc2ab3908c86c5a5/mint.key" --swarm --peers "127.0.0.1:8080" --emit-tx --chain-id TESTING```

test with novi fnode with AOS DD and VASP accounts:
```
cargo run -p cluster-test \
  -- \
  --emit-tx \
  --swarm \
  --vasp \
  --peers premainnet.libra.novi.com:80 \
  --chain-id 21 \
  --accounts-per-client 4 \
  --workers-per-ac 4 \
  --duration 60
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
