### PR TITLE
sdk: use correct response types in experimental proof API's

### DIFF
--- a/client/json-rpc/src/broadcast_client.rs
+++ b/client/json-rpc/src/broadcast_client.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use diem_client::{
-    views::{AccountView, MetadataView, TransactionView},
+    views::{
+        AccountView, EventWithProofView, MetadataView, TransactionView, TransactionsWithProofsView,
+    },
     Client, MethodRequest, MethodResponse, Response, Result,
 };
 use diem_types::{account_address::AccountAddress, transaction::SignedTransaction};
@@ -186,7 +188,7 @@ impl BroadcastingClient {
         &self,
         start_version: u64,
         limit: u64,
-    ) -> Result<Response<()>> {
+    ) -> Result<Response<Option<TransactionsWithProofsView>>> {
         let futures = self
             .random_clients()
             .map(|client| client.get_transactions_with_proofs(start_version, limit));
@@ -199,7 +201,7 @@ impl BroadcastingClient {
         key: &str,
         start_seq: u64,
         limit: u64,
-    ) -> Result<Response<()>> {
+    ) -> Result<Response<Vec<EventWithProofView>>> {
         let futures = self
             .random_clients()
             .map(|client| client.get_events_with_proofs(key, start_seq, limit));

--- a/sdk/client/src/client.rs
+++ b/sdk/client/src/client.rs
@@ -10,8 +10,8 @@ use super::{
 use crate::{
     error::WaitForTransactionError,
     views::{
-        AccountStateWithProofView, AccountView, CurrencyInfoView, EventView, MetadataView,
-        StateProofView, TransactionView,
+        AccountStateWithProofView, AccountView, CurrencyInfoView, EventView, EventWithProofView,
+        MetadataView, StateProofView, TransactionView, TransactionsWithProofsView,
     },
     Error, Result, Retry, State,
 };
@@ -235,7 +235,7 @@ impl Client {
         &self,
         start_version: u64,
         limit: u64,
-    ) -> Result<Response<()>> {
+    ) -> Result<Response<Option<TransactionsWithProofsView>>> {
         self.send(MethodRequest::get_transactions_with_proofs(
             start_version,
             limit,
@@ -248,7 +248,7 @@ impl Client {
         key: &str,
         start_seq: u64,
         limit: u64,
-    ) -> Result<Response<()>> {
+    ) -> Result<Response<Vec<EventWithProofView>>> {
         self.send(MethodRequest::get_events_with_proofs(key, start_seq, limit))
             .await
     }


### PR DESCRIPTION
https://github.com/diem/diem/pull/8206 does this for the blocking client, so lets also make sure its fixed for the async client.