### PR TITLE
[Cluster Test] Update the state sync benchmark to format the throughput displayed.

### DIFF
--- a/testsuite/cluster-test/src/experiments/state_sync_performance.rs
+++ b/testsuite/cluster-test/src/experiments/state_sync_performance.rs
@@ -121,12 +121,9 @@ impl Experiment for StateSyncPerformance {
 
         // Calculate the state sync throughput
         let time_to_state_sync = start_instant.elapsed();
-        let state_sync_throughput =
-            (validator_synced_version * 1000.0) / time_to_state_sync.as_millis() as f64;
-        let state_sync_throughput_message = format!(
-            "State sync throughput : {:?} txn/sec",
-            state_sync_throughput,
-        );
+        let state_sync_throughput = validator_synced_version as u64 / time_to_state_sync.as_secs();
+        let state_sync_throughput_message =
+            format!("State sync throughput : {} txn/sec", state_sync_throughput,);
         info!("Time to state sync {:?}", time_to_state_sync);
 
         // Display the state sync throughput and report the results


### PR DESCRIPTION
## Motivation

This PR formats the throughput number reported by the state sync benchmark in cluster test to display only 2 decimal places (e.g., `1755.24`), as opposed to displaying the entire float (e.g., `1755.235294117647`).

Note: given that Duration::as_millis(..) returns the whole number of seconds as milliseconds (as opposed to the counted milliseconds [1]), this PR also updates the calculation to just use seconds. We shouldn't lose anything here.

[1] https://doc.rust-lang.org/std/time/struct.Duration.html#method.as_millis

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Running this produces the following test output for the state sync performance benchmark (this is the same output that will be displayed on continuous runs):

```
2021-04-14T21:21:52.997028Z [main] INFO testsuite/cluster-test/src/experiments/state_sync_performance.rs:133 State sync throughput : 1755.24 txn/sec
```

## Related PRs

None.
