### PR TITLE
[move-lang][move-model] selective compilation for move-model building

### DIFF
--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -172,7 +172,7 @@ pub fn program(
         }
     }
 
-    let scripts = {
+    let mut scripts = {
         let mut collected: BTreeMap<String, Vec<E::Script>> = BTreeMap::new();
         for s in scripts {
             collected
@@ -199,7 +199,7 @@ pub fn program(
         keyed
     };
 
-    super::dependency_ordering::verify(context.env, &mut module_map);
+    super::dependency_ordering::verify(context.env, &mut module_map, &mut scripts);
     E::Program {
         modules: module_map,
         scripts,
@@ -331,6 +331,7 @@ fn module_(context: &mut Context, mdef: P::ModuleDefinition) -> (ModuleIdent, E:
         loc,
         is_source_module: context.is_source_module,
         dependency_order: 0,
+        dependency_summary: BTreeSet::new(),
         friends,
         structs,
         constants,
@@ -405,6 +406,7 @@ fn script_(context: &mut Context, pscript: P::Script) -> E::Script {
     E::Script {
         attributes,
         loc,
+        dependency_summary: BTreeSet::new(),
         constants,
         function_name,
         function,

--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -331,7 +331,7 @@ fn module_(context: &mut Context, mdef: P::ModuleDefinition) -> (ModuleIdent, E:
         loc,
         is_source_module: context.is_source_module,
         dependency_order: 0,
-        dependency_summary: BTreeSet::new(),
+        immediate_neighbors: BTreeSet::new(),
         friends,
         structs,
         constants,
@@ -406,7 +406,7 @@ fn script_(context: &mut Context, pscript: P::Script) -> E::Script {
     E::Script {
         attributes,
         loc,
-        dependency_summary: BTreeSet::new(),
+        immediate_neighbors: BTreeSet::new(),
         constants,
         function_name,
         function,

--- a/language/move-lang/src/naming/translate.rs
+++ b/language/move-lang/src/naming/translate.rs
@@ -353,6 +353,7 @@ fn module(
         loc: _loc,
         is_source_module,
         dependency_order,
+        dependency_summary: _,
         friends: efriends,
         structs: estructs,
         functions: efunctions,
@@ -399,6 +400,7 @@ fn script(context: &mut Context, escript: E::Script) -> N::Script {
     let E::Script {
         attributes,
         loc,
+        dependency_summary: _,
         constants: econstants,
         function_name,
         function: efunction,

--- a/language/move-lang/src/naming/translate.rs
+++ b/language/move-lang/src/naming/translate.rs
@@ -353,7 +353,7 @@ fn module(
         loc: _loc,
         is_source_module,
         dependency_order,
-        dependency_summary: _,
+        immediate_neighbors: _,
         friends: efriends,
         structs: estructs,
         functions: efunctions,
@@ -400,7 +400,7 @@ fn script(context: &mut Context, escript: E::Script) -> N::Script {
     let E::Script {
         attributes,
         loc,
-        dependency_summary: _,
+        immediate_neighbors: _,
         constants: econstants,
         function_name,
         function: efunction,

--- a/language/move-model/src/lib.rs
+++ b/language/move-model/src/lib.rs
@@ -235,6 +235,7 @@ fn run_spec_checker(env: &mut GlobalEnv, units: Vec<CompiledUnit>, mut eprog: Pr
                     let move_lang::expansion::ast::Script {
                         attributes,
                         loc,
+                        dependency_summary,
                         function_name,
                         constants,
                         function,
@@ -265,6 +266,7 @@ fn run_spec_checker(env: &mut GlobalEnv, units: Vec<CompiledUnit>, mut eprog: Pr
                         attributes,
                         loc,
                         dependency_order: usize::MAX,
+                        dependency_summary,
                         is_source_module: true,
                         friends: UniqueMap::new(),
                         structs: UniqueMap::new(),


### PR DESCRIPTION
This PR contains two commits that changes move source compiler and move model builder respectively:

The first commit: *[move-lang] summarize module dependencies after expansion*, provides enough information for the model builder to selectively compile (and build model for) modules in later compilation phases. This also collects friendships declared via the `pragma friend = ...` statement. Although the only use case is `pragma friend = 0x1::Genesis;` in the `DiemTimestamp`, it is important to have `Genesis` in the `dependency_summary` in order for the model builder to pick it up for compilation later. Otherwise, verification verification of many Move modules will fail if `Genesis.move` is not compiled. One example is `DiemSystem.move`:


```
error: global memory invariant does not hold

     ┌── DiemSystem.move:559:9 ───
     │
 559 │ ╭         invariant [global] DiemTimestamp::is_operating() ==>
 560 │ │             DiemConfig::spec_is_published<DiemSystem>() &&
 561 │ │             exists<CapabilityHolder>(CoreAddresses::DIEM_ROOT_ADDRESS());
     │ ╰─────────────────────────────────────────────────────────────────────────^
```

The same behavior can be observed with the `--inv_v2` flag in the original regex-based file filtering.

The second commit: *[move-model] compile only related modules in the last phase of module building*, do the selective compilation via three steps.

## Motivation

After #8179, for move model builder, all modules in the **deps** are now **always** included in any compilation whether they are used or not. This leads to both slowness in the overall `mvp` process as well as a mess up with the new `--bexp` backend. The conflict with `--bexp` is solved in #8208, but the first issue remains.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI
