### PR TITLE
[move-prover] Add a test for checking parse errors.

### DIFF
--- a/language/move-prover/tests/sources/functional/parse_error.exp
+++ b/language/move-prover/tests/sources/functional/parse_error.exp
@@ -1,0 +1,11 @@
+Move prover returns: exiting with model building errors
+error:
+
+   ┌── <unknown>:1:1 ───
+   │
+ 1 │ <unknown>
+   │ ^^^^^^^^^ Unexpected ')'
+   ·
+ 1 │ <unknown>
+   │ --------- Expected ';'
+   │

--- a/language/move-prover/tests/sources/functional/parse_error.move
+++ b/language/move-prover/tests/sources/functional/parse_error.move
@@ -1,0 +1,4 @@
+module 0x42::Test {
+
+    fun foo(x: u64) { 1 )
+}


### PR DESCRIPTION
This seems to have regressed. As you can see in the current baseline, position information is not available. This is because in GlobalEnv::to_loc, no file is defined when the error comes from Move parsing. (Before, to_loc crashed in this case, but this was changed in a previous PR to unblock this use case. Perhaps after fixing, we may want to crash again.)

## Motivation

Repro for bug and future regression test.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added test

## Related PRs

NA