### PR TITLE
[move-model] fix source collection bug

### DIFF
--- a/language/move-model/src/lib.rs
+++ b/language/move-model/src/lib.rs
@@ -61,6 +61,11 @@ pub fn run_model_builder(
     )?;
     let (comment_map, parsed_prog) = match pprog_and_comments_res {
         Err(errors) => {
+            // Add source files so that the env knows how to translate locations of parse errors
+            for fname in files.keys().sorted() {
+                let fsrc = &files[fname];
+                env.add_source(fname, fsrc, /* is_dep */ false);
+            }
             add_move_lang_errors(&mut env, errors);
             return Ok(env);
         }

--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -660,13 +660,15 @@ impl GlobalEnv {
     /// TODO: move-lang should use FileId as well so we don't need this here. There is already
     /// a todo in their code to remove the current use of `&'static str` for file names in Loc.
     pub fn to_loc(&self, loc: &MoveIrLoc) -> Loc {
-        if let Some(file_id) = self.get_file_id(loc.file()) {
-            Loc {
-                file_id,
-                span: loc.span(),
-            }
-        } else {
-            self.unknown_loc.clone()
+        let file_id = self.get_file_id(loc.file()).unwrap_or_else(|| {
+            panic!(
+                "Unable to find source file '{}' in the environment",
+                loc.file()
+            )
+        });
+        Loc {
+            file_id,
+            span: loc.span(),
         }
     }
 

--- a/language/move-prover/tests/sources/functional/parse_error.exp
+++ b/language/move-prover/tests/sources/functional/parse_error.exp
@@ -1,11 +1,11 @@
 Move prover returns: exiting with model building errors
 error:
 
-   ┌── <unknown>:1:1 ───
+   ┌── tests/sources/functional/parse_error.move:3:25 ───
    │
- 1 │ <unknown>
-   │ ^^^^^^^^^ Unexpected ')'
+ 3 │     fun foo(x: u64) { 1 )
+   │                         ^ Unexpected ')'
    ·
- 1 │ <unknown>
-   │ --------- Expected ';'
+ 3 │     fun foo(x: u64) { 1 )
+   │                         - Expected ';'
    │


### PR DESCRIPTION
As title, fix the issue in #8222.

Add all sources to `GlobalEnv` even when `move_parse` failed. This allows the env to translate the locations of parse errors.
