### PR TITLE
[move-model][docgen] drop the resource keyword, switch to abilities

### DIFF
--- a/language/diem-framework/modules/doc/AccountFreezing.md
+++ b/language/diem-framework/modules/doc/AccountFreezing.md
@@ -39,7 +39,7 @@ Module which manages freezing of accounts.
 
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="AccountFreezing.md#0x1_AccountFreezing_FreezingBit">FreezingBit</a>
+<pre><code><b>struct</b> <a href="AccountFreezing.md#0x1_AccountFreezing_FreezingBit">FreezingBit</a> has key
 </code></pre>
 
 
@@ -66,7 +66,7 @@ Module which manages freezing of accounts.
 
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="AccountFreezing.md#0x1_AccountFreezing_FreezeEventsHolder">FreezeEventsHolder</a>
+<pre><code><b>struct</b> <a href="AccountFreezing.md#0x1_AccountFreezing_FreezeEventsHolder">FreezeEventsHolder</a> has key
 </code></pre>
 
 
@@ -100,7 +100,7 @@ Module which manages freezing of accounts.
 Message for freeze account events
 
 
-<pre><code><b>struct</b> <a href="AccountFreezing.md#0x1_AccountFreezing_FreezeAccountEvent">FreezeAccountEvent</a>
+<pre><code><b>struct</b> <a href="AccountFreezing.md#0x1_AccountFreezing_FreezeAccountEvent">FreezeAccountEvent</a> has drop, store
 </code></pre>
 
 
@@ -134,7 +134,7 @@ Message for freeze account events
 Message for unfreeze account events
 
 
-<pre><code><b>struct</b> <a href="AccountFreezing.md#0x1_AccountFreezing_UnfreezeAccountEvent">UnfreezeAccountEvent</a>
+<pre><code><b>struct</b> <a href="AccountFreezing.md#0x1_AccountFreezing_UnfreezeAccountEvent">UnfreezeAccountEvent</a> has drop, store
 </code></pre>
 
 

--- a/language/diem-framework/modules/doc/AccountLimits.md
+++ b/language/diem-framework/modules/doc/AccountLimits.md
@@ -46,7 +46,7 @@ An operations capability that restricts callers of this module since
 the operations can mutate account states.
 
 
-<pre><code><b>struct</b> <a href="AccountLimits.md#0x1_AccountLimits_AccountLimitMutationCapability">AccountLimitMutationCapability</a>
+<pre><code><b>struct</b> <a href="AccountLimits.md#0x1_AccountLimits_AccountLimitMutationCapability">AccountLimitMutationCapability</a> has store
 </code></pre>
 
 
@@ -78,7 +78,7 @@ different account limit definitons. In such cases, they will have a
 <code><a href="AccountLimits.md#0x1_AccountLimits_LimitsDefinition">LimitsDefinition</a></code> published under their (root) account.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="AccountLimits.md#0x1_AccountLimits_LimitsDefinition">LimitsDefinition</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="AccountLimits.md#0x1_AccountLimits_LimitsDefinition">LimitsDefinition</a>&lt;CoinType&gt; has key
 </code></pre>
 
 
@@ -141,7 +141,7 @@ starting at <code>window_start</code> and lasting for the <code>time_period</cod
 in the limits definition at <code>limit_address</code>.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;CoinType&gt; has key
 </code></pre>
 
 

--- a/language/diem-framework/modules/doc/Authenticator.md
+++ b/language/diem-framework/modules/doc/Authenticator.md
@@ -31,7 +31,7 @@ and MultiEd25519 (K-of-N multisig).
 A multi-ed25519 public key
 
 
-<pre><code><b>struct</b> <a href="Authenticator.md#0x1_Authenticator_MultiEd25519PublicKey">MultiEd25519PublicKey</a>
+<pre><code><b>struct</b> <a href="Authenticator.md#0x1_Authenticator_MultiEd25519PublicKey">MultiEd25519PublicKey</a> has <b>copy</b>, drop, store
 </code></pre>
 
 

--- a/language/diem-framework/modules/doc/ChainId.md
+++ b/language/diem-framework/modules/doc/ChainId.md
@@ -31,7 +31,7 @@ This code provides a container for storing a chain id and functions to initializ
 
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="ChainId.md#0x1_ChainId">ChainId</a>
+<pre><code><b>struct</b> <a href="ChainId.md#0x1_ChainId">ChainId</a> has key
 </code></pre>
 
 

--- a/language/diem-framework/modules/doc/DesignatedDealer.md
+++ b/language/diem-framework/modules/doc/DesignatedDealer.md
@@ -36,7 +36,7 @@ currencies it can hold. All <code><a href="DesignatedDealer.md#0x1_DesignatedDea
 currencies will be emitted on <code>mint_event_handle</code>.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_Dealer">Dealer</a>
+<pre><code><b>struct</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_Dealer">Dealer</a> has key
 </code></pre>
 
 
@@ -66,7 +66,7 @@ tier a mint to a DD needs to be in.
 DEPRECATED: This resource is no longer used and will be removed from the system
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt; has key
 </code></pre>
 
 
@@ -106,7 +106,7 @@ DEPRECATED: This resource is no longer used and will be removed from the system
 Message for mint events
 
 
-<pre><code><b>struct</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_ReceivedMintEvent">ReceivedMintEvent</a>
+<pre><code><b>struct</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_ReceivedMintEvent">ReceivedMintEvent</a> has drop, store
 </code></pre>
 
 

--- a/language/diem-framework/modules/doc/Diem.md
+++ b/language/diem-framework/modules/doc/Diem.md
@@ -100,7 +100,7 @@ and specified in the <code><a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo<
 published under the <code><a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>()</code> account address).
 
 
-<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem">Diem</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem">Diem</a>&lt;CoinType&gt; has store
 </code></pre>
 
 
@@ -131,7 +131,7 @@ This capability is held only either by the <code><a href="CoreAddresses.md#0x1_C
 account or the <code><a href="XDX.md#0x1_XDX">0x1::XDX</a></code> module (and <code><a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>()</code> in testnet).
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="Diem.md#0x1_Diem_MintCapability">MintCapability</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_MintCapability">MintCapability</a>&lt;CoinType&gt; has store, key
 </code></pre>
 
 
@@ -160,7 +160,7 @@ The <code><a href="Diem.md#0x1_Diem_BurnCapability">BurnCapability</a></code> re
 of <code>CoinType</code> currency to be burned by the holder of it.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="Diem.md#0x1_Diem_BurnCapability">BurnCapability</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_BurnCapability">BurnCapability</a>&lt;CoinType&gt; has store, key
 </code></pre>
 
 
@@ -192,7 +192,7 @@ minted, and that is defined in the <code>currency_code</code> field of the
 <code><a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a></code> resource for the currency.
 
 
-<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_MintEvent">MintEvent</a>
+<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_MintEvent">MintEvent</a> has drop, store
 </code></pre>
 
 
@@ -232,7 +232,7 @@ It also contains the <code>preburn_address</code> from which the coin is
 extracted for burning.
 
 
-<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_BurnEvent">BurnEvent</a>
+<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_BurnEvent">BurnEvent</a> has drop, store
 </code></pre>
 
 
@@ -274,7 +274,7 @@ a coin type <code>currency_code</code> is enqueued in the <code><a href="Diem.md
 the account at the address <code>preburn_address</code>.
 
 
-<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_PreburnEvent">PreburnEvent</a>
+<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_PreburnEvent">PreburnEvent</a> has drop, store
 </code></pre>
 
 
@@ -317,7 +317,7 @@ preburn queue, but not burned). The currency of the funds is given by the
 <code>currency_code</code> as defined in the <code><a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a></code> for that currency.
 
 
-<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_CancelBurnEvent">CancelBurnEvent</a>
+<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_CancelBurnEvent">CancelBurnEvent</a> has drop, store
 </code></pre>
 
 
@@ -358,7 +358,7 @@ An <code><a href="Diem.md#0x1_Diem_ToXDXExchangeRateUpdateEvent">ToXDXExchangeRa
 rate for the currency given by <code>currency_code</code> is updated.
 
 
-<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_ToXDXExchangeRateUpdateEvent">ToXDXExchangeRateUpdateEvent</a>
+<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_ToXDXExchangeRateUpdateEvent">ToXDXExchangeRateUpdateEvent</a> has drop, store
 </code></pre>
 
 
@@ -401,7 +401,7 @@ the time of registration, the <code><a href="Diem.md#0x1_Diem_MintCapability">Mi
 Unless they are specified otherwise the fields in this resource are immutable.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt; has key
 </code></pre>
 
 
@@ -535,7 +535,7 @@ of a <code><a href="Diem.md#0x1_Diem_BurnCapability">BurnCapability</a></code> b
 the funds to the account that initiated the burn request.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt; has store, key
 </code></pre>
 
 
@@ -565,7 +565,7 @@ A preburn request, along with (an opaque to Move) metadata that is
 associated with the preburn request.
 
 
-<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_PreburnWithMetadata">PreburnWithMetadata</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_PreburnWithMetadata">PreburnWithMetadata</a>&lt;CoinType&gt; has store
 </code></pre>
 
 
@@ -609,7 +609,7 @@ account, or during the upgrade process, by a designated dealer with an
 existing <code><a href="Diem.md#0x1_Diem_Preburn">Preburn</a></code> resource in <code>CoinType</code>
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt; has key
 </code></pre>
 
 

--- a/language/diem-framework/modules/doc/DiemAccount.md
+++ b/language/diem-framework/modules/doc/DiemAccount.md
@@ -116,7 +116,7 @@ before and after every transaction.
 An <code>address</code> is a Diem Account iff it has a published DiemAccount resource.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>
+<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a> has key
 </code></pre>
 
 
@@ -188,7 +188,7 @@ A resource that holds the total value of currency of type <code>Token</code>
 currently held by the account.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_Balance">Balance</a>&lt;Token&gt;
+<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_Balance">Balance</a>&lt;Token&gt; has key
 </code></pre>
 
 
@@ -220,7 +220,7 @@ account_address/DiemAccount/balance.
 There is at most one WithdrawCapability in existence for a given address.
 
 
-<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_WithdrawCapability">WithdrawCapability</a>
+<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_WithdrawCapability">WithdrawCapability</a> has store
 </code></pre>
 
 
@@ -251,7 +251,7 @@ account_address (i.e., write to account_address/DiemAccount/authentication_key).
 There is at most one KeyRotationCapability in existence for a given address.
 
 
-<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_KeyRotationCapability">KeyRotationCapability</a>
+<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_KeyRotationCapability">KeyRotationCapability</a> has store
 </code></pre>
 
 
@@ -281,7 +281,7 @@ A wrapper around an <code>AccountLimitMutationCapability</code> which is used to
 and to record freeze/unfreeze events.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_AccountOperationsCapability">AccountOperationsCapability</a>
+<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_AccountOperationsCapability">AccountOperationsCapability</a> has key
 </code></pre>
 
 
@@ -315,7 +315,7 @@ and to record freeze/unfreeze events.
 A resource that holds the event handle for all the past WriteSet transactions that have been committed on chain.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_DiemWriteSetManager">DiemWriteSetManager</a>
+<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_DiemWriteSetManager">DiemWriteSetManager</a> has key
 </code></pre>
 
 
@@ -343,7 +343,7 @@ A resource that holds the event handle for all the past WriteSet transactions th
 Message for sent events
 
 
-<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_SentPaymentEvent">SentPaymentEvent</a>
+<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_SentPaymentEvent">SentPaymentEvent</a> has drop, store
 </code></pre>
 
 
@@ -389,7 +389,7 @@ Message for sent events
 Message for received events
 
 
-<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_ReceivedPaymentEvent">ReceivedPaymentEvent</a>
+<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_ReceivedPaymentEvent">ReceivedPaymentEvent</a> has drop, store
 </code></pre>
 
 
@@ -435,7 +435,7 @@ Message for received events
 Message for committed WriteSet transaction.
 
 
-<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_AdminTransactionEvent">AdminTransactionEvent</a>
+<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_AdminTransactionEvent">AdminTransactionEvent</a> has drop, store
 </code></pre>
 
 
@@ -463,7 +463,7 @@ Message for committed WriteSet transaction.
 Message for creation of a new account
 
 
-<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateAccountEvent">CreateAccountEvent</a>
+<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateAccountEvent">CreateAccountEvent</a> has drop, store
 </code></pre>
 
 

--- a/language/diem-framework/modules/doc/DiemBlock.md
+++ b/language/diem-framework/modules/doc/DiemBlock.md
@@ -32,7 +32,7 @@ This module defines a struct storing the metadata of the block and new block eve
 
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemBlock.md#0x1_DiemBlock_BlockMetadata">BlockMetadata</a>
+<pre><code><b>struct</b> <a href="DiemBlock.md#0x1_DiemBlock_BlockMetadata">BlockMetadata</a> has key
 </code></pre>
 
 
@@ -65,7 +65,7 @@ This module defines a struct storing the metadata of the block and new block eve
 
 
 
-<pre><code><b>struct</b> <a href="DiemBlock.md#0x1_DiemBlock_NewBlockEvent">NewBlockEvent</a>
+<pre><code><b>struct</b> <a href="DiemBlock.md#0x1_DiemBlock_NewBlockEvent">NewBlockEvent</a> has drop, store
 </code></pre>
 
 

--- a/language/diem-framework/modules/doc/DiemConfig.md
+++ b/language/diem-framework/modules/doc/DiemConfig.md
@@ -48,7 +48,7 @@ to synchronize configuration changes for the validators.
 A generic singleton resource that holds a value of a specific type.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemConfig.md#0x1_DiemConfig">DiemConfig</a>&lt;Config: <b>copy</b>, drop, store&gt;
+<pre><code><b>struct</b> <a href="DiemConfig.md#0x1_DiemConfig">DiemConfig</a>&lt;Config: <b>copy</b>, drop, store&gt; has store, key
 </code></pre>
 
 
@@ -78,7 +78,7 @@ with new configuration information. This is also called a
 "reconfiguration event"
 
 
-<pre><code><b>struct</b> <a href="DiemConfig.md#0x1_DiemConfig_NewEpochEvent">NewEpochEvent</a>
+<pre><code><b>struct</b> <a href="DiemConfig.md#0x1_DiemConfig_NewEpochEvent">NewEpochEvent</a> has drop, store
 </code></pre>
 
 
@@ -106,7 +106,7 @@ with new configuration information. This is also called a
 Holds information about state of reconfiguration
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemConfig.md#0x1_DiemConfig_Configuration">Configuration</a>
+<pre><code><b>struct</b> <a href="DiemConfig.md#0x1_DiemConfig_Configuration">Configuration</a> has key
 </code></pre>
 
 
@@ -146,7 +146,7 @@ Holds information about state of reconfiguration
 Accounts with this privilege can modify DiemConfig<TypeName> under Diem root address.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemConfig.md#0x1_DiemConfig_ModifyConfigCapability">ModifyConfigCapability</a>&lt;TypeName&gt;
+<pre><code><b>struct</b> <a href="DiemConfig.md#0x1_DiemConfig_ModifyConfigCapability">ModifyConfigCapability</a>&lt;TypeName&gt; has store, key
 </code></pre>
 
 
@@ -174,7 +174,7 @@ Accounts with this privilege can modify DiemConfig<TypeName> under Diem root add
 Reconfiguration disabled if this resource occurs under LibraRoot.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemConfig.md#0x1_DiemConfig_DisableReconfiguration">DisableReconfiguration</a>
+<pre><code><b>struct</b> <a href="DiemConfig.md#0x1_DiemConfig_DisableReconfiguration">DisableReconfiguration</a> has key
 </code></pre>
 
 

--- a/language/diem-framework/modules/doc/DiemConsensusConfig.md
+++ b/language/diem-framework/modules/doc/DiemConsensusConfig.md
@@ -28,7 +28,7 @@ DiemConfig, and may be updated by Diem root.
 
 
 
-<pre><code><b>struct</b> <a href="DiemConsensusConfig.md#0x1_DiemConsensusConfig">DiemConsensusConfig</a>
+<pre><code><b>struct</b> <a href="DiemConsensusConfig.md#0x1_DiemConsensusConfig">DiemConsensusConfig</a> has <b>copy</b>, drop, store
 </code></pre>
 
 

--- a/language/diem-framework/modules/doc/DiemSystem.md
+++ b/language/diem-framework/modules/doc/DiemSystem.md
@@ -54,7 +54,7 @@ and "configuration" are used for several distinct concepts.
 Information about a Validator Owner.
 
 
-<pre><code><b>struct</b> <a href="DiemSystem.md#0x1_DiemSystem_ValidatorInfo">ValidatorInfo</a>
+<pre><code><b>struct</b> <a href="DiemSystem.md#0x1_DiemSystem_ValidatorInfo">ValidatorInfo</a> has <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -109,7 +109,7 @@ Only Diem root can add or remove a validator from the validator set, so the
 capability is not needed for access control in those functions.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemSystem.md#0x1_DiemSystem_CapabilityHolder">CapabilityHolder</a>
+<pre><code><b>struct</b> <a href="DiemSystem.md#0x1_DiemSystem_CapabilityHolder">CapabilityHolder</a> has key
 </code></pre>
 
 
@@ -140,7 +140,7 @@ DiemConfig. The DiemSystem struct is stored by DiemConfig, which publishes a
 DiemConfig<DiemSystem> resource.
 
 
-<pre><code><b>struct</b> <a href="DiemSystem.md#0x1_DiemSystem">DiemSystem</a>
+<pre><code><b>struct</b> <a href="DiemSystem.md#0x1_DiemSystem">DiemSystem</a> has <b>copy</b>, drop, store
 </code></pre>
 
 

--- a/language/diem-framework/modules/doc/DiemTimestamp.md
+++ b/language/diem-framework/modules/doc/DiemTimestamp.md
@@ -44,7 +44,7 @@ which reflect that the system has been successfully initialized.
 A singleton resource holding the current Unix time in microseconds
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemTimestamp.md#0x1_DiemTimestamp_CurrentTimeMicroseconds">CurrentTimeMicroseconds</a>
+<pre><code><b>struct</b> <a href="DiemTimestamp.md#0x1_DiemTimestamp_CurrentTimeMicroseconds">CurrentTimeMicroseconds</a> has key
 </code></pre>
 
 

--- a/language/diem-framework/modules/doc/DiemTransactionPublishingOption.md
+++ b/language/diem-framework/modules/doc/DiemTransactionPublishingOption.md
@@ -45,7 +45,7 @@ Defines and holds the publishing policies for the VM. There are three possible c
 We represent these as the following resource.
 
 
-<pre><code><b>struct</b> <a href="DiemTransactionPublishingOption.md#0x1_DiemTransactionPublishingOption">DiemTransactionPublishingOption</a>
+<pre><code><b>struct</b> <a href="DiemTransactionPublishingOption.md#0x1_DiemTransactionPublishingOption">DiemTransactionPublishingOption</a> has <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -80,7 +80,7 @@ We represent these as the following resource.
 If published, halts transactions from all accounts except DiemRoot
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemTransactionPublishingOption.md#0x1_DiemTransactionPublishingOption_HaltAllTransactions">HaltAllTransactions</a>
+<pre><code><b>struct</b> <a href="DiemTransactionPublishingOption.md#0x1_DiemTransactionPublishingOption_HaltAllTransactions">HaltAllTransactions</a> has key
 </code></pre>
 
 

--- a/language/diem-framework/modules/doc/DiemVMConfig.md
+++ b/language/diem-framework/modules/doc/DiemVMConfig.md
@@ -33,7 +33,7 @@ including different costs of running the VM.
 The struct to hold config data needed to operate the DiemVM.
 
 
-<pre><code><b>struct</b> <a href="DiemVMConfig.md#0x1_DiemVMConfig">DiemVMConfig</a>
+<pre><code><b>struct</b> <a href="DiemVMConfig.md#0x1_DiemVMConfig">DiemVMConfig</a> has <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -71,7 +71,7 @@ address, and will preload the vector with the gas schedule for instructions. The
 load this into memory at the startup of each block.
 
 
-<pre><code><b>struct</b> <a href="DiemVMConfig.md#0x1_DiemVMConfig_GasSchedule">GasSchedule</a>
+<pre><code><b>struct</b> <a href="DiemVMConfig.md#0x1_DiemVMConfig_GasSchedule">GasSchedule</a> has <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -110,7 +110,7 @@ load this into memory at the startup of each block.
 
 
 
-<pre><code><b>struct</b> <a href="DiemVMConfig.md#0x1_DiemVMConfig_GasConstants">GasConstants</a>
+<pre><code><b>struct</b> <a href="DiemVMConfig.md#0x1_DiemVMConfig_GasConstants">GasConstants</a> has <b>copy</b>, drop, store
 </code></pre>
 
 

--- a/language/diem-framework/modules/doc/DiemVersion.md
+++ b/language/diem-framework/modules/doc/DiemVersion.md
@@ -31,7 +31,7 @@ DiemConfig, and may be updated by Diem root.
 
 
 
-<pre><code><b>struct</b> <a href="DiemVersion.md#0x1_DiemVersion">DiemVersion</a>
+<pre><code><b>struct</b> <a href="DiemVersion.md#0x1_DiemVersion">DiemVersion</a> has <b>copy</b>, drop, store
 </code></pre>
 
 

--- a/language/diem-framework/modules/doc/DualAttestation.md
+++ b/language/diem-framework/modules/doc/DualAttestation.md
@@ -56,7 +56,7 @@ This resource holds an entity's globally unique name and all of the metadata it 
 participate in off-chain protocols.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>
+<pre><code><b>struct</b> <a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a> has key
 </code></pre>
 
 
@@ -123,7 +123,7 @@ participate in off-chain protocols.
 Struct to store the limit on-chain
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DualAttestation.md#0x1_DualAttestation_Limit">Limit</a>
+<pre><code><b>struct</b> <a href="DualAttestation.md#0x1_DualAttestation_Limit">Limit</a> has key
 </code></pre>
 
 
@@ -151,7 +151,7 @@ Struct to store the limit on-chain
 The message sent whenever the compliance public key for a <code><a href="DualAttestation.md#0x1_DualAttestation">DualAttestation</a></code> resource is rotated.
 
 
-<pre><code><b>struct</b> <a href="DualAttestation.md#0x1_DualAttestation_ComplianceKeyRotationEvent">ComplianceKeyRotationEvent</a>
+<pre><code><b>struct</b> <a href="DualAttestation.md#0x1_DualAttestation_ComplianceKeyRotationEvent">ComplianceKeyRotationEvent</a> has drop, store
 </code></pre>
 
 
@@ -185,7 +185,7 @@ The message sent whenever the compliance public key for a <code><a href="DualAtt
 The message sent whenever the base url for a <code><a href="DualAttestation.md#0x1_DualAttestation">DualAttestation</a></code> resource is rotated.
 
 
-<pre><code><b>struct</b> <a href="DualAttestation.md#0x1_DualAttestation_BaseUrlRotationEvent">BaseUrlRotationEvent</a>
+<pre><code><b>struct</b> <a href="DualAttestation.md#0x1_DualAttestation_BaseUrlRotationEvent">BaseUrlRotationEvent</a> has drop, store
 </code></pre>
 
 

--- a/language/diem-framework/modules/doc/RecoveryAddress.md
+++ b/language/diem-framework/modules/doc/RecoveryAddress.md
@@ -42,7 +42,7 @@ The authentication key for A can be "buried in the mountain" and dug up only if 
 recover one of accounts in <code>rotation_caps</code> arises.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress">RecoveryAddress</a>
+<pre><code><b>struct</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress">RecoveryAddress</a> has key
 </code></pre>
 
 

--- a/language/diem-framework/modules/doc/RegisteredCurrencies.md
+++ b/language/diem-framework/modules/doc/RegisteredCurrencies.md
@@ -34,7 +34,7 @@ currencies. The inner vector<u8>'s are string representations of
 currency names.
 
 
-<pre><code><b>struct</b> <a href="RegisteredCurrencies.md#0x1_RegisteredCurrencies">RegisteredCurrencies</a>
+<pre><code><b>struct</b> <a href="RegisteredCurrencies.md#0x1_RegisteredCurrencies">RegisteredCurrencies</a> has <b>copy</b>, drop, store
 </code></pre>
 
 

--- a/language/diem-framework/modules/doc/Roles.md
+++ b/language/diem-framework/modules/doc/Roles.md
@@ -63,7 +63,7 @@ The roleId contains the role id for the account. This is only moved
 to an account as a top-level resource, and is otherwise immovable.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="Roles.md#0x1_Roles_RoleId">RoleId</a>
+<pre><code><b>struct</b> <a href="Roles.md#0x1_Roles_RoleId">RoleId</a> has key
 </code></pre>
 
 

--- a/language/diem-framework/modules/doc/SharedEd25519PublicKey.md
+++ b/language/diem-framework/modules/doc/SharedEd25519PublicKey.md
@@ -36,7 +36,7 @@ A resource that forces the account associated with <code>rotation_cap</code> to 
 authentication key derived from <code>key</code>
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey">SharedEd25519PublicKey</a>
+<pre><code><b>struct</b> <a href="SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey">SharedEd25519PublicKey</a> has key
 </code></pre>
 
 

--- a/language/diem-framework/modules/doc/SlidingNonce.md
+++ b/language/diem-framework/modules/doc/SlidingNonce.md
@@ -35,7 +35,7 @@ When nonce X is recorded, all transactions with nonces lower then X-128 will abo
 
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="SlidingNonce.md#0x1_SlidingNonce">SlidingNonce</a>
+<pre><code><b>struct</b> <a href="SlidingNonce.md#0x1_SlidingNonce">SlidingNonce</a> has key
 </code></pre>
 
 

--- a/language/diem-framework/modules/doc/TransactionFee.md
+++ b/language/diem-framework/modules/doc/TransactionFee.md
@@ -40,7 +40,7 @@ The <code><a href="TransactionFee.md#0x1_TransactionFee">TransactionFee</a></cod
 fiat <code>CoinType</code> that can be collected as a transaction fee.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="TransactionFee.md#0x1_TransactionFee">TransactionFee</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="TransactionFee.md#0x1_TransactionFee">TransactionFee</a>&lt;CoinType&gt; has key
 </code></pre>
 
 

--- a/language/diem-framework/modules/doc/VASP.md
+++ b/language/diem-framework/modules/doc/VASP.md
@@ -45,7 +45,7 @@ the VASP's globally unique name and all of the metadata that other VASPs need to
 off-chain protocols with this one.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="VASP.md#0x1_VASP_ParentVASP">ParentVASP</a>
+<pre><code><b>struct</b> <a href="VASP.md#0x1_VASP_ParentVASP">ParentVASP</a> has key
 </code></pre>
 
 
@@ -73,7 +73,7 @@ off-chain protocols with this one.
 A resource that represents a child account of the parent VASP account at <code>parent_vasp_addr</code>
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="VASP.md#0x1_VASP_ChildVASP">ChildVASP</a>
+<pre><code><b>struct</b> <a href="VASP.md#0x1_VASP_ChildVASP">ChildVASP</a> has key
 </code></pre>
 
 

--- a/language/diem-framework/modules/doc/ValidatorConfig.md
+++ b/language/diem-framework/modules/doc/ValidatorConfig.md
@@ -48,7 +48,7 @@ of the <code><a href="DiemSystem.md#0x1_DiemSystem_DiemSystem">DiemSystem::DiemS
 
 
 
-<pre><code><b>struct</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_Config">Config</a>
+<pre><code><b>struct</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_Config">Config</a> has <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -87,7 +87,7 @@ of the <code><a href="DiemSystem.md#0x1_DiemSystem_DiemSystem">DiemSystem::DiemS
 
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig">ValidatorConfig</a>
+<pre><code><b>struct</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig">ValidatorConfig</a> has key
 </code></pre>
 
 

--- a/language/diem-framework/modules/doc/ValidatorOperatorConfig.md
+++ b/language/diem-framework/modules/doc/ValidatorOperatorConfig.md
@@ -30,7 +30,7 @@ Stores the string name of a ValidatorOperator account.
 
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="ValidatorOperatorConfig.md#0x1_ValidatorOperatorConfig">ValidatorOperatorConfig</a>
+<pre><code><b>struct</b> <a href="ValidatorOperatorConfig.md#0x1_ValidatorOperatorConfig">ValidatorOperatorConfig</a> has key
 </code></pre>
 
 

--- a/language/diem-framework/modules/doc/XDX.md
+++ b/language/diem-framework/modules/doc/XDX.md
@@ -37,7 +37,7 @@ Once the component makeup of the XDX has been chosen the
 The type tag representing the <code><a href="XDX.md#0x1_XDX">XDX</a></code> currency on-chain.
 
 
-<pre><code><b>struct</b> <a href="XDX.md#0x1_XDX">XDX</a>
+<pre><code><b>struct</b> <a href="XDX.md#0x1_XDX">XDX</a> has store
 </code></pre>
 
 
@@ -71,7 +71,7 @@ coins, and also each reserve component that holds the backing for these coins on
 Currently this holds no coins since XDX is not able to be minted/created.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="XDX.md#0x1_XDX_Reserve">Reserve</a>
+<pre><code><b>struct</b> <a href="XDX.md#0x1_XDX_Reserve">Reserve</a> has key
 </code></pre>
 
 

--- a/language/diem-framework/modules/doc/XUS.md
+++ b/language/diem-framework/modules/doc/XUS.md
@@ -27,7 +27,7 @@ This module defines the coin type XUS and its initialization function.
 The type tag representing the <code><a href="XUS.md#0x1_XUS">XUS</a></code> currency on-chain.
 
 
-<pre><code><b>struct</b> <a href="XUS.md#0x1_XUS">XUS</a>
+<pre><code><b>struct</b> <a href="XUS.md#0x1_XUS">XUS</a> has store
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/AccountFreezing.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/AccountFreezing.md
@@ -39,7 +39,7 @@ Module which manages freezing of accounts.
 
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="AccountFreezing.md#0x1_AccountFreezing_FreezingBit">FreezingBit</a>
+<pre><code><b>struct</b> <a href="AccountFreezing.md#0x1_AccountFreezing_FreezingBit">FreezingBit</a> has key
 </code></pre>
 
 
@@ -66,7 +66,7 @@ Module which manages freezing of accounts.
 
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="AccountFreezing.md#0x1_AccountFreezing_FreezeEventsHolder">FreezeEventsHolder</a>
+<pre><code><b>struct</b> <a href="AccountFreezing.md#0x1_AccountFreezing_FreezeEventsHolder">FreezeEventsHolder</a> has key
 </code></pre>
 
 
@@ -100,7 +100,7 @@ Module which manages freezing of accounts.
 Message for freeze account events
 
 
-<pre><code><b>struct</b> <a href="AccountFreezing.md#0x1_AccountFreezing_FreezeAccountEvent">FreezeAccountEvent</a>
+<pre><code><b>struct</b> <a href="AccountFreezing.md#0x1_AccountFreezing_FreezeAccountEvent">FreezeAccountEvent</a> has drop, store
 </code></pre>
 
 
@@ -134,7 +134,7 @@ Message for freeze account events
 Message for unfreeze account events
 
 
-<pre><code><b>struct</b> <a href="AccountFreezing.md#0x1_AccountFreezing_UnfreezeAccountEvent">UnfreezeAccountEvent</a>
+<pre><code><b>struct</b> <a href="AccountFreezing.md#0x1_AccountFreezing_UnfreezeAccountEvent">UnfreezeAccountEvent</a> has drop, store
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/AccountLimits.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/AccountLimits.md
@@ -46,7 +46,7 @@ An operations capability that restricts callers of this module since
 the operations can mutate account states.
 
 
-<pre><code><b>struct</b> <a href="AccountLimits.md#0x1_AccountLimits_AccountLimitMutationCapability">AccountLimitMutationCapability</a>
+<pre><code><b>struct</b> <a href="AccountLimits.md#0x1_AccountLimits_AccountLimitMutationCapability">AccountLimitMutationCapability</a> has store
 </code></pre>
 
 
@@ -78,7 +78,7 @@ different account limit definitons. In such cases, they will have a
 <code><a href="AccountLimits.md#0x1_AccountLimits_LimitsDefinition">LimitsDefinition</a></code> published under their (root) account.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="AccountLimits.md#0x1_AccountLimits_LimitsDefinition">LimitsDefinition</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="AccountLimits.md#0x1_AccountLimits_LimitsDefinition">LimitsDefinition</a>&lt;CoinType&gt; has key
 </code></pre>
 
 
@@ -141,7 +141,7 @@ starting at <code>window_start</code> and lasting for the <code>time_period</cod
 in the limits definition at <code>limit_address</code>.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;CoinType&gt; has key
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/Authenticator.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/Authenticator.md
@@ -31,7 +31,7 @@ and MultiEd25519 (K-of-N multisig).
 A multi-ed25519 public key
 
 
-<pre><code><b>struct</b> <a href="Authenticator.md#0x1_Authenticator_MultiEd25519PublicKey">MultiEd25519PublicKey</a>
+<pre><code><b>struct</b> <a href="Authenticator.md#0x1_Authenticator_MultiEd25519PublicKey">MultiEd25519PublicKey</a> has <b>copy</b>, drop, store
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/ChainId.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/ChainId.md
@@ -31,7 +31,7 @@ This code provides a container for storing a chain id and functions to initializ
 
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="ChainId.md#0x1_ChainId">ChainId</a>
+<pre><code><b>struct</b> <a href="ChainId.md#0x1_ChainId">ChainId</a> has key
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/DesignatedDealer.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/DesignatedDealer.md
@@ -36,7 +36,7 @@ currencies it can hold. All <code><a href="DesignatedDealer.md#0x1_DesignatedDea
 currencies will be emitted on <code>mint_event_handle</code>.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_Dealer">Dealer</a>
+<pre><code><b>struct</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_Dealer">Dealer</a> has key
 </code></pre>
 
 
@@ -66,7 +66,7 @@ tier a mint to a DD needs to be in.
 DEPRECATED: This resource is no longer used and will be removed from the system
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt; has key
 </code></pre>
 
 
@@ -106,7 +106,7 @@ DEPRECATED: This resource is no longer used and will be removed from the system
 Message for mint events
 
 
-<pre><code><b>struct</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_ReceivedMintEvent">ReceivedMintEvent</a>
+<pre><code><b>struct</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_ReceivedMintEvent">ReceivedMintEvent</a> has drop, store
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/Diem.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/Diem.md
@@ -100,7 +100,7 @@ and specified in the <code><a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo<
 published under the <code><a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>()</code> account address).
 
 
-<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem">Diem</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem">Diem</a>&lt;CoinType&gt; has store
 </code></pre>
 
 
@@ -131,7 +131,7 @@ This capability is held only either by the <code><a href="CoreAddresses.md#0x1_C
 account or the <code><a href="XDX.md#0x1_XDX">0x1::XDX</a></code> module (and <code><a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>()</code> in testnet).
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="Diem.md#0x1_Diem_MintCapability">MintCapability</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_MintCapability">MintCapability</a>&lt;CoinType&gt; has store, key
 </code></pre>
 
 
@@ -160,7 +160,7 @@ The <code><a href="Diem.md#0x1_Diem_BurnCapability">BurnCapability</a></code> re
 of <code>CoinType</code> currency to be burned by the holder of it.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="Diem.md#0x1_Diem_BurnCapability">BurnCapability</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_BurnCapability">BurnCapability</a>&lt;CoinType&gt; has store, key
 </code></pre>
 
 
@@ -192,7 +192,7 @@ minted, and that is defined in the <code>currency_code</code> field of the
 <code><a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a></code> resource for the currency.
 
 
-<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_MintEvent">MintEvent</a>
+<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_MintEvent">MintEvent</a> has drop, store
 </code></pre>
 
 
@@ -232,7 +232,7 @@ It also contains the <code>preburn_address</code> from which the coin is
 extracted for burning.
 
 
-<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_BurnEvent">BurnEvent</a>
+<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_BurnEvent">BurnEvent</a> has drop, store
 </code></pre>
 
 
@@ -274,7 +274,7 @@ a coin type <code>currency_code</code> is enqueued in the <code><a href="Diem.md
 the account at the address <code>preburn_address</code>.
 
 
-<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_PreburnEvent">PreburnEvent</a>
+<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_PreburnEvent">PreburnEvent</a> has drop, store
 </code></pre>
 
 
@@ -317,7 +317,7 @@ preburn queue, but not burned). The currency of the funds is given by the
 <code>currency_code</code> as defined in the <code><a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a></code> for that currency.
 
 
-<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_CancelBurnEvent">CancelBurnEvent</a>
+<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_CancelBurnEvent">CancelBurnEvent</a> has drop, store
 </code></pre>
 
 
@@ -358,7 +358,7 @@ An <code><a href="Diem.md#0x1_Diem_ToXDXExchangeRateUpdateEvent">ToXDXExchangeRa
 rate for the currency given by <code>currency_code</code> is updated.
 
 
-<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_ToXDXExchangeRateUpdateEvent">ToXDXExchangeRateUpdateEvent</a>
+<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_ToXDXExchangeRateUpdateEvent">ToXDXExchangeRateUpdateEvent</a> has drop, store
 </code></pre>
 
 
@@ -401,7 +401,7 @@ the time of registration, the <code><a href="Diem.md#0x1_Diem_MintCapability">Mi
 Unless they are specified otherwise the fields in this resource are immutable.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt; has key
 </code></pre>
 
 
@@ -535,7 +535,7 @@ of a <code><a href="Diem.md#0x1_Diem_BurnCapability">BurnCapability</a></code> b
 the funds to the account that initiated the burn request.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt; has store, key
 </code></pre>
 
 
@@ -565,7 +565,7 @@ A preburn request, along with (an opaque to Move) metadata that is
 associated with the preburn request.
 
 
-<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_PreburnWithMetadata">PreburnWithMetadata</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_PreburnWithMetadata">PreburnWithMetadata</a>&lt;CoinType&gt; has store
 </code></pre>
 
 
@@ -609,7 +609,7 @@ account, or during the upgrade process, by a designated dealer with an
 existing <code><a href="Diem.md#0x1_Diem_Preburn">Preburn</a></code> resource in <code>CoinType</code>
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt; has key
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/DiemAccount.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/DiemAccount.md
@@ -116,7 +116,7 @@ before and after every transaction.
 An <code>address</code> is a Diem Account iff it has a published DiemAccount resource.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>
+<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a> has key
 </code></pre>
 
 
@@ -188,7 +188,7 @@ A resource that holds the total value of currency of type <code>Token</code>
 currently held by the account.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_Balance">Balance</a>&lt;Token&gt;
+<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_Balance">Balance</a>&lt;Token&gt; has key
 </code></pre>
 
 
@@ -220,7 +220,7 @@ account_address/DiemAccount/balance.
 There is at most one WithdrawCapability in existence for a given address.
 
 
-<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_WithdrawCapability">WithdrawCapability</a>
+<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_WithdrawCapability">WithdrawCapability</a> has store
 </code></pre>
 
 
@@ -251,7 +251,7 @@ account_address (i.e., write to account_address/DiemAccount/authentication_key).
 There is at most one KeyRotationCapability in existence for a given address.
 
 
-<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_KeyRotationCapability">KeyRotationCapability</a>
+<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_KeyRotationCapability">KeyRotationCapability</a> has store
 </code></pre>
 
 
@@ -281,7 +281,7 @@ A wrapper around an <code>AccountLimitMutationCapability</code> which is used to
 and to record freeze/unfreeze events.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_AccountOperationsCapability">AccountOperationsCapability</a>
+<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_AccountOperationsCapability">AccountOperationsCapability</a> has key
 </code></pre>
 
 
@@ -315,7 +315,7 @@ and to record freeze/unfreeze events.
 A resource that holds the event handle for all the past WriteSet transactions that have been committed on chain.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_DiemWriteSetManager">DiemWriteSetManager</a>
+<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_DiemWriteSetManager">DiemWriteSetManager</a> has key
 </code></pre>
 
 
@@ -343,7 +343,7 @@ A resource that holds the event handle for all the past WriteSet transactions th
 Message for sent events
 
 
-<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_SentPaymentEvent">SentPaymentEvent</a>
+<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_SentPaymentEvent">SentPaymentEvent</a> has drop, store
 </code></pre>
 
 
@@ -389,7 +389,7 @@ Message for sent events
 Message for received events
 
 
-<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_ReceivedPaymentEvent">ReceivedPaymentEvent</a>
+<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_ReceivedPaymentEvent">ReceivedPaymentEvent</a> has drop, store
 </code></pre>
 
 
@@ -435,7 +435,7 @@ Message for received events
 Message for committed WriteSet transaction.
 
 
-<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_AdminTransactionEvent">AdminTransactionEvent</a>
+<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_AdminTransactionEvent">AdminTransactionEvent</a> has drop, store
 </code></pre>
 
 
@@ -463,7 +463,7 @@ Message for committed WriteSet transaction.
 Message for creation of a new account
 
 
-<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateAccountEvent">CreateAccountEvent</a>
+<pre><code><b>struct</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateAccountEvent">CreateAccountEvent</a> has drop, store
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/DiemBlock.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/DiemBlock.md
@@ -32,7 +32,7 @@ This module defines a struct storing the metadata of the block and new block eve
 
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemBlock.md#0x1_DiemBlock_BlockMetadata">BlockMetadata</a>
+<pre><code><b>struct</b> <a href="DiemBlock.md#0x1_DiemBlock_BlockMetadata">BlockMetadata</a> has key
 </code></pre>
 
 
@@ -65,7 +65,7 @@ This module defines a struct storing the metadata of the block and new block eve
 
 
 
-<pre><code><b>struct</b> <a href="DiemBlock.md#0x1_DiemBlock_NewBlockEvent">NewBlockEvent</a>
+<pre><code><b>struct</b> <a href="DiemBlock.md#0x1_DiemBlock_NewBlockEvent">NewBlockEvent</a> has drop, store
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/DiemConfig.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/DiemConfig.md
@@ -48,7 +48,7 @@ to synchronize configuration changes for the validators.
 A generic singleton resource that holds a value of a specific type.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemConfig.md#0x1_DiemConfig">DiemConfig</a>&lt;Config: <b>copy</b>, drop, store&gt;
+<pre><code><b>struct</b> <a href="DiemConfig.md#0x1_DiemConfig">DiemConfig</a>&lt;Config: <b>copy</b>, drop, store&gt; has store, key
 </code></pre>
 
 
@@ -78,7 +78,7 @@ with new configuration information. This is also called a
 "reconfiguration event"
 
 
-<pre><code><b>struct</b> <a href="DiemConfig.md#0x1_DiemConfig_NewEpochEvent">NewEpochEvent</a>
+<pre><code><b>struct</b> <a href="DiemConfig.md#0x1_DiemConfig_NewEpochEvent">NewEpochEvent</a> has drop, store
 </code></pre>
 
 
@@ -106,7 +106,7 @@ with new configuration information. This is also called a
 Holds information about state of reconfiguration
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemConfig.md#0x1_DiemConfig_Configuration">Configuration</a>
+<pre><code><b>struct</b> <a href="DiemConfig.md#0x1_DiemConfig_Configuration">Configuration</a> has key
 </code></pre>
 
 
@@ -146,7 +146,7 @@ Holds information about state of reconfiguration
 Accounts with this privilege can modify DiemConfig<TypeName> under Diem root address.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemConfig.md#0x1_DiemConfig_ModifyConfigCapability">ModifyConfigCapability</a>&lt;TypeName&gt;
+<pre><code><b>struct</b> <a href="DiemConfig.md#0x1_DiemConfig_ModifyConfigCapability">ModifyConfigCapability</a>&lt;TypeName&gt; has store, key
 </code></pre>
 
 
@@ -174,7 +174,7 @@ Accounts with this privilege can modify DiemConfig<TypeName> under Diem root add
 Reconfiguration disabled if this resource occurs under LibraRoot.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemConfig.md#0x1_DiemConfig_DisableReconfiguration">DisableReconfiguration</a>
+<pre><code><b>struct</b> <a href="DiemConfig.md#0x1_DiemConfig_DisableReconfiguration">DisableReconfiguration</a> has key
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/DiemConsensusConfig.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/DiemConsensusConfig.md
@@ -28,7 +28,7 @@ DiemConfig, and may be updated by Diem root.
 
 
 
-<pre><code><b>struct</b> <a href="DiemConsensusConfig.md#0x1_DiemConsensusConfig">DiemConsensusConfig</a>
+<pre><code><b>struct</b> <a href="DiemConsensusConfig.md#0x1_DiemConsensusConfig">DiemConsensusConfig</a> has <b>copy</b>, drop, store
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/DiemSystem.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/DiemSystem.md
@@ -54,7 +54,7 @@ and "configuration" are used for several distinct concepts.
 Information about a Validator Owner.
 
 
-<pre><code><b>struct</b> <a href="DiemSystem.md#0x1_DiemSystem_ValidatorInfo">ValidatorInfo</a>
+<pre><code><b>struct</b> <a href="DiemSystem.md#0x1_DiemSystem_ValidatorInfo">ValidatorInfo</a> has <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -109,7 +109,7 @@ Only Diem root can add or remove a validator from the validator set, so the
 capability is not needed for access control in those functions.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemSystem.md#0x1_DiemSystem_CapabilityHolder">CapabilityHolder</a>
+<pre><code><b>struct</b> <a href="DiemSystem.md#0x1_DiemSystem_CapabilityHolder">CapabilityHolder</a> has key
 </code></pre>
 
 
@@ -140,7 +140,7 @@ DiemConfig. The DiemSystem struct is stored by DiemConfig, which publishes a
 DiemConfig<DiemSystem> resource.
 
 
-<pre><code><b>struct</b> <a href="DiemSystem.md#0x1_DiemSystem">DiemSystem</a>
+<pre><code><b>struct</b> <a href="DiemSystem.md#0x1_DiemSystem">DiemSystem</a> has <b>copy</b>, drop, store
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/DiemTimestamp.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/DiemTimestamp.md
@@ -44,7 +44,7 @@ which reflect that the system has been successfully initialized.
 A singleton resource holding the current Unix time in microseconds
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemTimestamp.md#0x1_DiemTimestamp_CurrentTimeMicroseconds">CurrentTimeMicroseconds</a>
+<pre><code><b>struct</b> <a href="DiemTimestamp.md#0x1_DiemTimestamp_CurrentTimeMicroseconds">CurrentTimeMicroseconds</a> has key
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/DiemTransactionPublishingOption.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/DiemTransactionPublishingOption.md
@@ -45,7 +45,7 @@ Defines and holds the publishing policies for the VM. There are three possible c
 We represent these as the following resource.
 
 
-<pre><code><b>struct</b> <a href="DiemTransactionPublishingOption.md#0x1_DiemTransactionPublishingOption">DiemTransactionPublishingOption</a>
+<pre><code><b>struct</b> <a href="DiemTransactionPublishingOption.md#0x1_DiemTransactionPublishingOption">DiemTransactionPublishingOption</a> has <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -80,7 +80,7 @@ We represent these as the following resource.
 If published, halts transactions from all accounts except DiemRoot
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemTransactionPublishingOption.md#0x1_DiemTransactionPublishingOption_HaltAllTransactions">HaltAllTransactions</a>
+<pre><code><b>struct</b> <a href="DiemTransactionPublishingOption.md#0x1_DiemTransactionPublishingOption_HaltAllTransactions">HaltAllTransactions</a> has key
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/DiemVMConfig.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/DiemVMConfig.md
@@ -33,7 +33,7 @@ including different costs of running the VM.
 The struct to hold config data needed to operate the DiemVM.
 
 
-<pre><code><b>struct</b> <a href="DiemVMConfig.md#0x1_DiemVMConfig">DiemVMConfig</a>
+<pre><code><b>struct</b> <a href="DiemVMConfig.md#0x1_DiemVMConfig">DiemVMConfig</a> has <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -71,7 +71,7 @@ address, and will preload the vector with the gas schedule for instructions. The
 load this into memory at the startup of each block.
 
 
-<pre><code><b>struct</b> <a href="DiemVMConfig.md#0x1_DiemVMConfig_GasSchedule">GasSchedule</a>
+<pre><code><b>struct</b> <a href="DiemVMConfig.md#0x1_DiemVMConfig_GasSchedule">GasSchedule</a> has <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -110,7 +110,7 @@ load this into memory at the startup of each block.
 
 
 
-<pre><code><b>struct</b> <a href="DiemVMConfig.md#0x1_DiemVMConfig_GasConstants">GasConstants</a>
+<pre><code><b>struct</b> <a href="DiemVMConfig.md#0x1_DiemVMConfig_GasConstants">GasConstants</a> has <b>copy</b>, drop, store
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/DiemVersion.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/DiemVersion.md
@@ -31,7 +31,7 @@ DiemConfig, and may be updated by Diem root.
 
 
 
-<pre><code><b>struct</b> <a href="DiemVersion.md#0x1_DiemVersion">DiemVersion</a>
+<pre><code><b>struct</b> <a href="DiemVersion.md#0x1_DiemVersion">DiemVersion</a> has <b>copy</b>, drop, store
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/DualAttestation.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/DualAttestation.md
@@ -56,7 +56,7 @@ This resource holds an entity's globally unique name and all of the metadata it 
 participate in off-chain protocols.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>
+<pre><code><b>struct</b> <a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a> has key
 </code></pre>
 
 
@@ -123,7 +123,7 @@ participate in off-chain protocols.
 Struct to store the limit on-chain
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DualAttestation.md#0x1_DualAttestation_Limit">Limit</a>
+<pre><code><b>struct</b> <a href="DualAttestation.md#0x1_DualAttestation_Limit">Limit</a> has key
 </code></pre>
 
 
@@ -151,7 +151,7 @@ Struct to store the limit on-chain
 The message sent whenever the compliance public key for a <code><a href="DualAttestation.md#0x1_DualAttestation">DualAttestation</a></code> resource is rotated.
 
 
-<pre><code><b>struct</b> <a href="DualAttestation.md#0x1_DualAttestation_ComplianceKeyRotationEvent">ComplianceKeyRotationEvent</a>
+<pre><code><b>struct</b> <a href="DualAttestation.md#0x1_DualAttestation_ComplianceKeyRotationEvent">ComplianceKeyRotationEvent</a> has drop, store
 </code></pre>
 
 
@@ -185,7 +185,7 @@ The message sent whenever the compliance public key for a <code><a href="DualAtt
 The message sent whenever the base url for a <code><a href="DualAttestation.md#0x1_DualAttestation">DualAttestation</a></code> resource is rotated.
 
 
-<pre><code><b>struct</b> <a href="DualAttestation.md#0x1_DualAttestation_BaseUrlRotationEvent">BaseUrlRotationEvent</a>
+<pre><code><b>struct</b> <a href="DualAttestation.md#0x1_DualAttestation_BaseUrlRotationEvent">BaseUrlRotationEvent</a> has drop, store
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/RecoveryAddress.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/RecoveryAddress.md
@@ -42,7 +42,7 @@ The authentication key for A can be "buried in the mountain" and dug up only if 
 recover one of accounts in <code>rotation_caps</code> arises.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress">RecoveryAddress</a>
+<pre><code><b>struct</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress">RecoveryAddress</a> has key
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/RegisteredCurrencies.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/RegisteredCurrencies.md
@@ -34,7 +34,7 @@ currencies. The inner vector<u8>'s are string representations of
 currency names.
 
 
-<pre><code><b>struct</b> <a href="RegisteredCurrencies.md#0x1_RegisteredCurrencies">RegisteredCurrencies</a>
+<pre><code><b>struct</b> <a href="RegisteredCurrencies.md#0x1_RegisteredCurrencies">RegisteredCurrencies</a> has <b>copy</b>, drop, store
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/Roles.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/Roles.md
@@ -63,7 +63,7 @@ The roleId contains the role id for the account. This is only moved
 to an account as a top-level resource, and is otherwise immovable.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="Roles.md#0x1_Roles_RoleId">RoleId</a>
+<pre><code><b>struct</b> <a href="Roles.md#0x1_Roles_RoleId">RoleId</a> has key
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/SharedEd25519PublicKey.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/SharedEd25519PublicKey.md
@@ -36,7 +36,7 @@ A resource that forces the account associated with <code>rotation_cap</code> to 
 authentication key derived from <code>key</code>
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey">SharedEd25519PublicKey</a>
+<pre><code><b>struct</b> <a href="SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey">SharedEd25519PublicKey</a> has key
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/SlidingNonce.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/SlidingNonce.md
@@ -35,7 +35,7 @@ When nonce X is recorded, all transactions with nonces lower then X-128 will abo
 
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="SlidingNonce.md#0x1_SlidingNonce">SlidingNonce</a>
+<pre><code><b>struct</b> <a href="SlidingNonce.md#0x1_SlidingNonce">SlidingNonce</a> has key
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/TransactionFee.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/TransactionFee.md
@@ -40,7 +40,7 @@ The <code><a href="TransactionFee.md#0x1_TransactionFee">TransactionFee</a></cod
 fiat <code>CoinType</code> that can be collected as a transaction fee.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="TransactionFee.md#0x1_TransactionFee">TransactionFee</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="TransactionFee.md#0x1_TransactionFee">TransactionFee</a>&lt;CoinType&gt; has key
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/VASP.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/VASP.md
@@ -45,7 +45,7 @@ the VASP's globally unique name and all of the metadata that other VASPs need to
 off-chain protocols with this one.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="VASP.md#0x1_VASP_ParentVASP">ParentVASP</a>
+<pre><code><b>struct</b> <a href="VASP.md#0x1_VASP_ParentVASP">ParentVASP</a> has key
 </code></pre>
 
 
@@ -73,7 +73,7 @@ off-chain protocols with this one.
 A resource that represents a child account of the parent VASP account at <code>parent_vasp_addr</code>
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="VASP.md#0x1_VASP_ChildVASP">ChildVASP</a>
+<pre><code><b>struct</b> <a href="VASP.md#0x1_VASP_ChildVASP">ChildVASP</a> has key
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/ValidatorConfig.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/ValidatorConfig.md
@@ -48,7 +48,7 @@ of the <code><a href="DiemSystem.md#0x1_DiemSystem_DiemSystem">DiemSystem::DiemS
 
 
 
-<pre><code><b>struct</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_Config">Config</a>
+<pre><code><b>struct</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_Config">Config</a> has <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -87,7 +87,7 @@ of the <code><a href="DiemSystem.md#0x1_DiemSystem_DiemSystem">DiemSystem::DiemS
 
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig">ValidatorConfig</a>
+<pre><code><b>struct</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig">ValidatorConfig</a> has key
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/ValidatorOperatorConfig.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/ValidatorOperatorConfig.md
@@ -30,7 +30,7 @@ Stores the string name of a ValidatorOperator account.
 
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="ValidatorOperatorConfig.md#0x1_ValidatorOperatorConfig">ValidatorOperatorConfig</a>
+<pre><code><b>struct</b> <a href="ValidatorOperatorConfig.md#0x1_ValidatorOperatorConfig">ValidatorOperatorConfig</a> has key
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/XDX.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/XDX.md
@@ -37,7 +37,7 @@ Once the component makeup of the XDX has been chosen the
 The type tag representing the <code><a href="XDX.md#0x1_XDX">XDX</a></code> currency on-chain.
 
 
-<pre><code><b>struct</b> <a href="XDX.md#0x1_XDX">XDX</a>
+<pre><code><b>struct</b> <a href="XDX.md#0x1_XDX">XDX</a> has store
 </code></pre>
 
 
@@ -71,7 +71,7 @@ coins, and also each reserve component that holds the backing for these coins on
 Currently this holds no coins since XDX is not able to be minted/created.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="XDX.md#0x1_XDX_Reserve">Reserve</a>
+<pre><code><b>struct</b> <a href="XDX.md#0x1_XDX_Reserve">Reserve</a> has key
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/XUS.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/XUS.md
@@ -27,7 +27,7 @@ This module defines the coin type XUS and its initialization function.
 The type tag representing the <code><a href="XUS.md#0x1_XUS">XUS</a></code> currency on-chain.
 
 
-<pre><code><b>struct</b> <a href="XUS.md#0x1_XUS">XUS</a>
+<pre><code><b>struct</b> <a href="XUS.md#0x1_XUS">XUS</a> has store
 </code></pre>
 
 

--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -2061,14 +2061,6 @@ impl<'env> StructEnv<'env> {
         name.as_ref() == "Vector" && addr == &BigUint::from(0_u64)
     }
 
-    // TODO(tmn) migrate to abilities
-    // NOTE(mengxu) there is still a use case of `is_resource` in the boogie translator, which
-    // makes it seemingly fine to keep it here as an abstraction to the boogie translator.
-    /// Determines whether this struct is a resource type.
-    pub fn is_resource(&self) -> bool {
-        self.get_abilities().has_key()
-    }
-
     /// Get the abilities of this struct.
     pub fn get_abilities(&self) -> AbilitySet {
         let def = self.module_env.data.module.struct_def_at(self.data.def_idx);
@@ -2078,6 +2070,11 @@ impl<'env> StructEnv<'env> {
             .module
             .struct_handle_at(def.struct_handle);
         handle.abilities
+    }
+
+    /// Determines whether memory-related operations needs to be declared for this struct.
+    pub fn has_memory(&self) -> bool {
+        self.get_abilities().has_key()
     }
 
     /// Get an iterator for the fields, ordered by offset.

--- a/language/move-prover/boogie-backend-exp/src/bytecode_translator.rs
+++ b/language/move-prover/boogie-backend-exp/src/bytecode_translator.rs
@@ -484,7 +484,7 @@ impl<'env> ModuleTranslator<'env> {
             );
         }
 
-        if struct_env.is_resource() {
+        if struct_env.has_memory() {
             // Emit memory variable.
             let memory_name =
                 boogie_resource_memory_name(env, struct_env.get_qualified_id(), &None);

--- a/language/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/language/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -178,7 +178,7 @@ impl<'env> ModuleTranslator<'env> {
         );
 
         // Emit memory variable.
-        if struct_env.is_resource() {
+        if struct_env.has_memory() {
             let memory_name = boogie_resource_memory_name(
                 struct_env.module_env.env,
                 struct_env.get_qualified_id(),

--- a/language/move-prover/docgen/src/docgen.rs
+++ b/language/move-prover/docgen/src/docgen.rs
@@ -985,7 +985,7 @@ impl<'env> Docgen<'env> {
         // with the `key` ability.
         format!(
             "{} `{}`",
-            if struct_env.is_resource() {
+            if struct_env.has_memory() {
                 "Resource"
             } else {
                 "Struct"

--- a/language/move-prover/docgen/tests/sources/DiemTest.spec_inline.md
+++ b/language/move-prover/docgen/tests/sources/DiemTest.spec_inline.md
@@ -83,7 +83,7 @@ minting and burning of coins.
 
 
 
-<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_RegisterNewCurrency">RegisterNewCurrency</a>
+<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_RegisterNewCurrency">RegisterNewCurrency</a> has store
 </code></pre>
 
 
@@ -116,7 +116,7 @@ and specified in the <code><a href="DiemTest.md#0x1_DiemTest_CurrencyInfo">Curre
 published under the <code><a href="_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>()</code> account address).
 
 
-<pre><code><b>struct</b> <a href="">Diem</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="">Diem</a>&lt;CoinType&gt; has store
 </code></pre>
 
 
@@ -161,7 +161,7 @@ This capability is held only either by the <code><a href="_TREASURY_COMPLIANCE_A
 account or the <code><a href="">0x1::XDX</a></code> module (and <code><a href="_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>()</code> in testnet).
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemTest.md#0x1_DiemTest_MintCapability">MintCapability</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_MintCapability">MintCapability</a>&lt;CoinType&gt; has key
 </code></pre>
 
 
@@ -191,7 +191,7 @@ of <code>CoinType</code> currency to be burned by the holder of the
 and the <code><a href="">0x1::XDX</a></code> module (and <code><a href="_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>()</code> in testnet).
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemTest.md#0x1_DiemTest_BurnCapability">BurnCapability</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_BurnCapability">BurnCapability</a>&lt;CoinType&gt; has key
 </code></pre>
 
 
@@ -227,7 +227,7 @@ minted, and that is defined in the <code>currency_code</code> field of the
 <code><a href="DiemTest.md#0x1_DiemTest_CurrencyInfo">CurrencyInfo</a></code> resource for the currency.
 
 
-<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_MintEvent">MintEvent</a>
+<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_MintEvent">MintEvent</a> has <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -268,7 +268,7 @@ extracted for burning.
 for that currency.
 
 
-<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_BurnEvent">BurnEvent</a>
+<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_BurnEvent">BurnEvent</a> has <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -310,7 +310,7 @@ a coin type <code>currency_code</code> are moved to a <code><a href="DiemTest.md
 the account at the address <code>preburn_address</code>.
 
 
-<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_PreburnEvent">PreburnEvent</a>
+<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_PreburnEvent">PreburnEvent</a> has <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -353,7 +353,7 @@ preburn, but not burned). The currency of the funds is given by the
 <code>currency_code</code> as defined in the <code><a href="DiemTest.md#0x1_DiemTest_CurrencyInfo">CurrencyInfo</a></code> for that currency.
 
 
-<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_CancelBurnEvent">CancelBurnEvent</a>
+<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_CancelBurnEvent">CancelBurnEvent</a> has <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -394,7 +394,7 @@ An <code><a href="DiemTest.md#0x1_DiemTest_ToXDXExchangeRateUpdateEvent">ToXDXEx
 rate for the currency given by <code>currency_code</code> is updated.
 
 
-<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_ToXDXExchangeRateUpdateEvent">ToXDXExchangeRateUpdateEvent</a>
+<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_ToXDXExchangeRateUpdateEvent">ToXDXExchangeRateUpdateEvent</a> has <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -437,7 +437,7 @@ the time of registration the <code><a href="DiemTest.md#0x1_DiemTest_MintCapabil
 Unless they are specified otherwise the fields in this resource are immutable.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemTest.md#0x1_DiemTest_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt; has key
 </code></pre>
 
 
@@ -557,7 +557,7 @@ returning the funds to the account that initiated the burn request.
 Concurrent preburn requests are not allowed, only one request (in to_burn) can be handled at any time.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemTest.md#0x1_DiemTest_Preburn">Preburn</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_Preburn">Preburn</a>&lt;CoinType&gt; has key
 </code></pre>
 
 

--- a/language/move-prover/docgen/tests/sources/DiemTest.spec_inline_no_fold.md
+++ b/language/move-prover/docgen/tests/sources/DiemTest.spec_inline_no_fold.md
@@ -83,7 +83,7 @@ minting and burning of coins.
 
 
 
-<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_RegisterNewCurrency">RegisterNewCurrency</a>
+<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_RegisterNewCurrency">RegisterNewCurrency</a> has store
 </code></pre>
 
 
@@ -113,7 +113,7 @@ and specified in the <code><a href="DiemTest.md#0x1_DiemTest_CurrencyInfo">Curre
 published under the <code><a href="_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>()</code> account address).
 
 
-<pre><code><b>struct</b> <a href="">Diem</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="">Diem</a>&lt;CoinType&gt; has store
 </code></pre>
 
 
@@ -152,7 +152,7 @@ This capability is held only either by the <code><a href="_TREASURY_COMPLIANCE_A
 account or the <code><a href="">0x1::XDX</a></code> module (and <code><a href="_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>()</code> in testnet).
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemTest.md#0x1_DiemTest_MintCapability">MintCapability</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_MintCapability">MintCapability</a>&lt;CoinType&gt; has key
 </code></pre>
 
 
@@ -179,7 +179,7 @@ of <code>CoinType</code> currency to be burned by the holder of the
 and the <code><a href="">0x1::XDX</a></code> module (and <code><a href="_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>()</code> in testnet).
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemTest.md#0x1_DiemTest_BurnCapability">BurnCapability</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_BurnCapability">BurnCapability</a>&lt;CoinType&gt; has key
 </code></pre>
 
 
@@ -212,7 +212,7 @@ minted, and that is defined in the <code>currency_code</code> field of the
 <code><a href="DiemTest.md#0x1_DiemTest_CurrencyInfo">CurrencyInfo</a></code> resource for the currency.
 
 
-<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_MintEvent">MintEvent</a>
+<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_MintEvent">MintEvent</a> has <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -250,7 +250,7 @@ extracted for burning.
 for that currency.
 
 
-<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_BurnEvent">BurnEvent</a>
+<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_BurnEvent">BurnEvent</a> has <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -289,7 +289,7 @@ a coin type <code>currency_code</code> are moved to a <code><a href="DiemTest.md
 the account at the address <code>preburn_address</code>.
 
 
-<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_PreburnEvent">PreburnEvent</a>
+<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_PreburnEvent">PreburnEvent</a> has <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -329,7 +329,7 @@ preburn, but not burned). The currency of the funds is given by the
 <code>currency_code</code> as defined in the <code><a href="DiemTest.md#0x1_DiemTest_CurrencyInfo">CurrencyInfo</a></code> for that currency.
 
 
-<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_CancelBurnEvent">CancelBurnEvent</a>
+<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_CancelBurnEvent">CancelBurnEvent</a> has <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -367,7 +367,7 @@ An <code><a href="DiemTest.md#0x1_DiemTest_ToXDXExchangeRateUpdateEvent">ToXDXEx
 rate for the currency given by <code>currency_code</code> is updated.
 
 
-<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_ToXDXExchangeRateUpdateEvent">ToXDXExchangeRateUpdateEvent</a>
+<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_ToXDXExchangeRateUpdateEvent">ToXDXExchangeRateUpdateEvent</a> has <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -407,7 +407,7 @@ the time of registration the <code><a href="DiemTest.md#0x1_DiemTest_MintCapabil
 Unless they are specified otherwise the fields in this resource are immutable.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemTest.md#0x1_DiemTest_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt; has key
 </code></pre>
 
 
@@ -524,7 +524,7 @@ returning the funds to the account that initiated the burn request.
 Concurrent preburn requests are not allowed, only one request (in to_burn) can be handled at any time.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemTest.md#0x1_DiemTest_Preburn">Preburn</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_Preburn">Preburn</a>&lt;CoinType&gt; has key
 </code></pre>
 
 

--- a/language/move-prover/docgen/tests/sources/DiemTest.spec_separate.md
+++ b/language/move-prover/docgen/tests/sources/DiemTest.spec_separate.md
@@ -98,7 +98,7 @@ minting and burning of coins.
 
 
 
-<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_RegisterNewCurrency">RegisterNewCurrency</a>
+<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_RegisterNewCurrency">RegisterNewCurrency</a> has store
 </code></pre>
 
 
@@ -131,7 +131,7 @@ and specified in the <code><a href="DiemTest.md#0x1_DiemTest_CurrencyInfo">Curre
 published under the <code><a href="_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>()</code> account address).
 
 
-<pre><code><b>struct</b> <a href="">Diem</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="">Diem</a>&lt;CoinType&gt; has store
 </code></pre>
 
 
@@ -162,7 +162,7 @@ This capability is held only either by the <code><a href="_TREASURY_COMPLIANCE_A
 account or the <code><a href="">0x1::XDX</a></code> module (and <code><a href="_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>()</code> in testnet).
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemTest.md#0x1_DiemTest_MintCapability">MintCapability</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_MintCapability">MintCapability</a>&lt;CoinType&gt; has key
 </code></pre>
 
 
@@ -192,7 +192,7 @@ of <code>CoinType</code> currency to be burned by the holder of the
 and the <code><a href="">0x1::XDX</a></code> module (and <code><a href="_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>()</code> in testnet).
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemTest.md#0x1_DiemTest_BurnCapability">BurnCapability</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_BurnCapability">BurnCapability</a>&lt;CoinType&gt; has key
 </code></pre>
 
 
@@ -228,7 +228,7 @@ minted, and that is defined in the <code>currency_code</code> field of the
 <code><a href="DiemTest.md#0x1_DiemTest_CurrencyInfo">CurrencyInfo</a></code> resource for the currency.
 
 
-<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_MintEvent">MintEvent</a>
+<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_MintEvent">MintEvent</a> has <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -269,7 +269,7 @@ extracted for burning.
 for that currency.
 
 
-<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_BurnEvent">BurnEvent</a>
+<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_BurnEvent">BurnEvent</a> has <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -311,7 +311,7 @@ a coin type <code>currency_code</code> are moved to a <code><a href="DiemTest.md
 the account at the address <code>preburn_address</code>.
 
 
-<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_PreburnEvent">PreburnEvent</a>
+<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_PreburnEvent">PreburnEvent</a> has <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -354,7 +354,7 @@ preburn, but not burned). The currency of the funds is given by the
 <code>currency_code</code> as defined in the <code><a href="DiemTest.md#0x1_DiemTest_CurrencyInfo">CurrencyInfo</a></code> for that currency.
 
 
-<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_CancelBurnEvent">CancelBurnEvent</a>
+<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_CancelBurnEvent">CancelBurnEvent</a> has <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -395,7 +395,7 @@ An <code><a href="DiemTest.md#0x1_DiemTest_ToXDXExchangeRateUpdateEvent">ToXDXEx
 rate for the currency given by <code>currency_code</code> is updated.
 
 
-<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_ToXDXExchangeRateUpdateEvent">ToXDXExchangeRateUpdateEvent</a>
+<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_ToXDXExchangeRateUpdateEvent">ToXDXExchangeRateUpdateEvent</a> has <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -438,7 +438,7 @@ the time of registration the <code><a href="DiemTest.md#0x1_DiemTest_MintCapabil
 Unless they are specified otherwise the fields in this resource are immutable.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemTest.md#0x1_DiemTest_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt; has key
 </code></pre>
 
 
@@ -558,7 +558,7 @@ returning the funds to the account that initiated the burn request.
 Concurrent preburn requests are not allowed, only one request (in to_burn) can be handled at any time.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="DiemTest.md#0x1_DiemTest_Preburn">Preburn</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="DiemTest.md#0x1_DiemTest_Preburn">Preburn</a>&lt;CoinType&gt; has key
 </code></pre>
 
 
@@ -2137,7 +2137,7 @@ all coins of a currency type.
 ### Struct `Diem`
 
 
-<pre><code><b>struct</b> <a href="">Diem</a>&lt;CoinType&gt;
+<pre><code><b>struct</b> <a href="">Diem</a>&lt;CoinType&gt; has store
 </code></pre>
 
 

--- a/language/move-stdlib/docs/Event.md
+++ b/language/move-stdlib/docs/Event.md
@@ -37,7 +37,7 @@ A resource representing the counter used to generate uniqueness under each accou
 this resource to guarantee the uniqueness of the generated handle.
 
 
-<pre><code><b>resource</b> <b>struct</b> <a href="Event.md#0x1_Event_EventHandleGenerator">EventHandleGenerator</a>
+<pre><code><b>struct</b> <a href="Event.md#0x1_Event_EventHandleGenerator">EventHandleGenerator</a> has key
 </code></pre>
 
 
@@ -73,7 +73,7 @@ A handle for an event such that:
 2. Storage can use this handle to prove the total number of events that happened in the past.
 
 
-<pre><code><b>struct</b> <a href="Event.md#0x1_Event_EventHandle">EventHandle</a>&lt;T: drop, store&gt;
+<pre><code><b>struct</b> <a href="Event.md#0x1_Event_EventHandle">EventHandle</a>&lt;T: drop, store&gt; has store
 </code></pre>
 
 

--- a/language/move-stdlib/docs/FixedPoint32.md
+++ b/language/move-stdlib/docs/FixedPoint32.md
@@ -41,7 +41,7 @@ be careful about using floating-point to convert these values to
 decimal.
 
 
-<pre><code><b>struct</b> <a href="FixedPoint32.md#0x1_FixedPoint32">FixedPoint32</a>
+<pre><code><b>struct</b> <a href="FixedPoint32.md#0x1_FixedPoint32">FixedPoint32</a> has <b>copy</b>, drop, store
 </code></pre>
 
 

--- a/language/move-stdlib/docs/Option.md
+++ b/language/move-stdlib/docs/Option.md
@@ -41,7 +41,7 @@ Abstraction of a value that may or may not be present. Implemented with a vector
 zero or one because Move bytecode does not have ADTs.
 
 
-<pre><code><b>struct</b> <a href="Option.md#0x1_Option">Option</a>&lt;Element&gt;
+<pre><code><b>struct</b> <a href="Option.md#0x1_Option">Option</a>&lt;Element&gt; has <b>copy</b>, drop, store
 </code></pre>
 
 


### PR DESCRIPTION
Expose abilities in `StructEnv` and update docgen accordingly. The `is_resource` is not fully deprecated because the boogie translator still relies on it.

Only the first commit needs to be reviewed, the second one is an update to the auto-generated docs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI
