### PR TITLE
[sdk] experimental APIs for fetching deserialized Move events, resour…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1437,6 +1437,7 @@ dependencies = [
  "diem-workspace-hack",
  "hex",
  "ipnet",
+ "move-core-types",
  "reqwest",
  "serde",
  "serde_json",

--- a/language/vm/src/errors.rs
+++ b/language/vm/src/errors.rs
@@ -402,3 +402,9 @@ pub fn bounds_error(
 pub fn verification_error(status: StatusCode, kind: IndexKind, idx: TableIndex) -> PartialVMError {
     PartialVMError::new(status).at_index(kind, idx)
 }
+
+impl std::error::Error for PartialVMError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
+}

--- a/sdk/client/Cargo.toml
+++ b/sdk/client/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = "1.0.64"
 
 diem-crypto = { path = "../../crypto/crypto", version = "0.0.1" }
 diem-json-rpc-types  = { path = "../../json-rpc/types", version = "0.0.1" }
+move-core-types = { path = "../../language/move-core/types", version = "0.0.1" }
 diem-types = { path = "../../types", version = "0.0.1" }
 
 # Optional Dependencies

--- a/sdk/client/src/client.rs
+++ b/sdk/client/src/client.rs
@@ -9,6 +9,7 @@ use super::{
 };
 use crate::{
     error::WaitForTransactionError,
+    move_deserialize::{self, Event},
     views::{
         AccountStateWithProofView, AccountView, CurrencyInfoView, EventView, EventWithProofView,
         MetadataView, StateProofView, TransactionView, TransactionsWithProofsView,
@@ -18,8 +19,10 @@ use crate::{
 use diem_crypto::{hash::CryptoHash, HashValue};
 use diem_types::{
     account_address::AccountAddress,
+    event::EventKey,
     transaction::{SignedTransaction, Transaction},
 };
+use move_core_types::move_resource::MoveResource;
 use reqwest::Client as ReqwestClient;
 use serde::{de::DeserializeOwned, Serialize};
 use std::time::Duration;
@@ -251,6 +254,42 @@ impl Client {
     ) -> Result<Response<Vec<EventWithProofView>>> {
         self.send(MethodRequest::get_events_with_proofs(key, start_seq, limit))
             .await
+    }
+
+    /// Return the events of type `T` that have been emitted to `event_key` since `start_seq`, with a max of `limit`
+    /// results
+    /// Returns an empty vector if there are no such events
+    /// The type `T` must match the event types associated with `event_key`
+    pub async fn get_deserialized_events<T: MoveResource + DeserializeOwned>(
+        &self,
+        event_key: &EventKey,
+        start_seq: u64,
+        limit: u64,
+    ) -> Result<Response<Vec<Event<T>>>> {
+        let (events, state) = self
+            .get_events_with_proofs(&hex::encode(event_key.as_bytes()), start_seq, limit)
+            .await?
+            .into_parts();
+        Ok(Response::new(
+            move_deserialize::get_events::<T>(events)?,
+            state,
+        ))
+    }
+
+    /// Deserialize and return the resource value of type `T` stored under `address`
+    /// Returns None if there is no such value
+    pub async fn get_deserialized_resource<T: MoveResource + DeserializeOwned>(
+        &self,
+        address: AccountAddress,
+    ) -> Result<Response<Option<T>>> {
+        let (account, state) = self
+            .get_account_state_with_proof(address, None, None)
+            .await?
+            .into_parts();
+        Ok(Response::new(
+            move_deserialize::get_resource(account)?,
+            state,
+        ))
     }
 
     //

--- a/sdk/client/src/lib.rs
+++ b/sdk/client/src/lib.rs
@@ -28,6 +28,11 @@ pub use request::{JsonRpcRequest, MethodRequest};
 mod response;
 pub use response::{MethodResponse, Response};
 
+cfg_async_or_blocking! {
+    mod move_deserialize;
+    pub use move_deserialize::Event;
+}
+
 mod state;
 pub use state::State;
 

--- a/sdk/client/src/move_deserialize.rs
+++ b/sdk/client/src/move_deserialize.rs
@@ -1,0 +1,88 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{Error, Result};
+use diem_json_rpc_types::views::{AccountStateWithProofView, EventWithProofView};
+use diem_types::{
+    account_state::AccountState,
+    account_state_blob::AccountStateBlob,
+    contract_event::{ContractEvent, EventWithProof},
+};
+use move_core_types::{language_storage::TypeTag, move_resource::MoveResource};
+use serde::de::DeserializeOwned;
+use std::convert::TryFrom;
+
+/// Wrapper for a deserialized Move event and its containing `ContractEvent`
+#[derive(Debug, Clone)]
+pub struct Event<T: MoveResource + DeserializeOwned> {
+    /// The deserialized event type
+    data: T,
+    event: ContractEvent,
+}
+
+impl<T: MoveResource + DeserializeOwned> Event<T> {
+    pub fn data(&self) -> &T {
+        &self.data
+    }
+
+    pub fn event(&self) -> &ContractEvent {
+        &self.event
+    }
+}
+
+/// Deserialize and return the Move events of type `T` in `events`
+/// The type `T` must match the specified event types in `events`
+pub fn get_events<T: MoveResource + DeserializeOwned>(
+    events: Vec<EventWithProofView>,
+) -> Result<Vec<Event<T>>> {
+    let events_with_proof: Vec<EventWithProof> = events
+        .into_iter()
+        .map(|e| {
+            bcs::from_bytes::<EventWithProof>(e.event_with_proof.inner()).map_err(Error::decode)
+        })
+        .collect::<Result<Vec<EventWithProof>>>()?;
+    let event_type_tag = TypeTag::Struct(T::struct_tag());
+    events_with_proof
+        .into_iter()
+        .map(|e| {
+            // Check that `T` matches the type specified in `e`
+            if &event_type_tag != e.event.type_tag() {
+                Err(Error::decode(format!(
+                    "Type tag of events in stream {:?} does not match type tag of generic type T {:?}", event_type_tag, e.event.type_tag()),
+                ))
+            } else {
+                bcs::from_bytes::<T>(e.event.event_data())
+                    .map(|data| Event {
+                        data,
+                        event: e.event,
+                    })
+                    .map_err(Error::decode)
+            }
+        })
+        .collect::<Result<Vec<Event<T>>>>()
+}
+
+fn get_account_state(
+    account_state_with_proof: AccountStateWithProofView,
+) -> Result<Option<AccountState>> {
+    let account_opt = account_state_with_proof.blob;
+    if let Some(account) = account_opt {
+        let account_state_blob: AccountStateBlob =
+            bcs::from_bytes(account.inner()).map_err(Error::decode)?;
+        return Ok(Some(
+            AccountState::try_from(&account_state_blob).map_err(Error::decode)?,
+        ));
+    }
+    Ok(None)
+}
+
+/// Deserialize and return the Move value of type `T` in `account_state_with_proof`
+/// Returns None if no resource of type `T` exists under `address`
+pub fn get_resource<T: MoveResource + DeserializeOwned>(
+    account_state_with_proof: AccountStateWithProofView,
+) -> Result<Option<T>> {
+    if let Some(account_state) = get_account_state(account_state_with_proof)? {
+        return account_state.get_resource::<T>().map_err(Error::decode);
+    }
+    Ok(None)
+}


### PR DESCRIPTION
…ces, and modules

Add generic wrappers of `get_event_with_proof` and `get_account_state_with_proof` that deserialize the result into a specific Move event or resource type. Similarly, we add a wrapper that returns all the modules under a given address. These new APIs make it easier to interact with structured Move data from Rust.
