### PR TITLE
[sdk] Add json-rpc VerifyingClient

### DIFF
--- a/execution/executor-test-helpers/src/integration_test_impl.rs
+++ b/execution/executor-test-helpers/src/integration_test_impl.rs
@@ -252,7 +252,7 @@ pub fn test_execution_with_storage_impl() -> Arc<DiemDB> {
         _ => panic!("unexpected state change"),
     }
     let current_version = li.ledger_info().version();
-    assert_eq!(trusted_state.latest_version(), 9);
+    assert_eq!(trusted_state.version(), 9);
 
     let t1 = db
         .reader
@@ -420,10 +420,8 @@ pub fn test_execution_with_storage_impl() -> Arc<DiemDB> {
         .commit_blocks(vec![block2_id], ledger_info_with_sigs)
         .unwrap();
 
-    let (li, epoch_change_proof, _accumulator_consistency_proof) = db
-        .reader
-        .get_state_proof(trusted_state.latest_version())
-        .unwrap();
+    let (li, epoch_change_proof, _accumulator_consistency_proof) =
+        db.reader.get_state_proof(trusted_state.version()).unwrap();
     trusted_state
         .verify_and_ratchet(&li, &epoch_change_proof)
         .unwrap();

--- a/execution/executor/tests/db_bootstrapper_test.rs
+++ b/execution/executor/tests/db_bootstrapper_test.rs
@@ -376,10 +376,8 @@ fn test_new_genesis() {
 
     // Client bootable from waypoint.
     let trusted_state = TrustedState::from(waypoint);
-    let (li, epoch_change_proof, accumulator_consistency_proof) = db
-        .reader
-        .get_state_proof(trusted_state.latest_version())
-        .unwrap();
+    let (li, epoch_change_proof, accumulator_consistency_proof) =
+        db.reader.get_state_proof(trusted_state.version()).unwrap();
     assert_eq!(li.ledger_info().version(), 5);
     assert!(accumulator_consistency_proof.subtrees().is_empty());
     trusted_state

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -444,7 +444,7 @@ pub struct MetadataView {
     pub dual_attestation_limit: Option<u64>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct BytesView(Box<[u8]>);
 
 impl BytesView {
@@ -480,8 +480,13 @@ impl std::fmt::Display for BytesView {
         for byte in self.inner() {
             write!(f, "{:02x}", byte)?;
         }
-
         Ok(())
+    }
+}
+
+impl std::fmt::Debug for BytesView {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "BytesView(\"{}\")", self)
     }
 }
 

--- a/sdk/client/src/error.rs
+++ b/sdk/client/src/error.rs
@@ -34,6 +34,7 @@ enum Kind {
     StaleResponse,
     Batch,
     Decode,
+    InvalidProof,
     Unknown,
 }
 
@@ -53,6 +54,7 @@ impl Error {
             | Kind::ChainId
             | Kind::Batch
             | Kind::Decode
+            | Kind::InvalidProof
             | Kind::Unknown => false,
         }
     }
@@ -98,6 +100,10 @@ impl Error {
 
     pub(crate) fn decode<E: Into<BoxError>>(e: E) -> Self {
         Self::new(Kind::Decode, Some(e))
+    }
+
+    pub(crate) fn invalid_proof<E: Into<BoxError>>(e: E) -> Self {
+        Self::new(Kind::InvalidProof, Some(e))
     }
 
     pub(crate) fn unknown<E: Into<BoxError>>(e: E) -> Self {

--- a/sdk/client/src/lib.rs
+++ b/sdk/client/src/lib.rs
@@ -15,6 +15,9 @@ cfg_blocking! {
 cfg_async! {
     mod client;
     pub use client::Client;
+
+    mod verifying_client;
+    pub use verifying_client::{Storage, InMemoryStorage, VerifyingClient};
 }
 
 cfg_faucet! {

--- a/sdk/client/src/lib.rs
+++ b/sdk/client/src/lib.rs
@@ -17,6 +17,10 @@ cfg_async! {
     pub use client::Client;
 
     mod verifying_client;
+    // WARNING: the VerifyingClient is currently experimental; it's not recommended
+    // to use it until it stabilizes further
+    // TODO(philiphayes): make this pub once verifying_client is stable.
+    #[doc(hidden)]
     pub use verifying_client::{Storage, InMemoryStorage, VerifyingClient};
 }
 

--- a/sdk/client/src/response.rs
+++ b/sdk/client/src/response.rs
@@ -133,14 +133,20 @@ impl MethodResponse {
     pub fn try_into_get_state_proof(self) -> Result<StateProofView, Error> {
         match self {
             MethodResponse::GetStateProof(state_proof) => Ok(state_proof),
-            _ => Err(Error::rpc_response("unexpected response")),
+            _ => Err(Error::rpc_response(format!(
+                "expected MethodResponse::GetStateProof found MethodResponse::{:?}",
+                self.method()
+            ))),
         }
     }
 
     pub fn try_into_get_account(self) -> Result<Option<AccountView>, Error> {
         match self {
             MethodResponse::GetAccount(account_view) => Ok(account_view),
-            _ => Err(Error::rpc_response("unexpected response")),
+            _ => Err(Error::rpc_response(format!(
+                "expected MethodResponse::GetAccount found MethodResponse::{:?}",
+                self.method()
+            ))),
         }
     }
 }

--- a/sdk/client/src/verifying_client.rs
+++ b/sdk/client/src/verifying_client.rs
@@ -1,0 +1,516 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    client::Client,
+    request::MethodRequest,
+    response::{MethodResponse, Response},
+    state::State,
+};
+use anyhow::{bail, ensure, format_err, Result};
+use diem_json_rpc_types::views::AccountView;
+use diem_types::{
+    account_address::AccountAddress, account_config::diem_root_address,
+    account_state::AccountState, account_state_blob::AccountStateWithProof,
+    epoch_change::EpochChangeProof, ledger_info::LedgerInfoWithSignatures,
+    on_chain_config::RegisteredCurrencies, proof::AccumulatorConsistencyProof,
+    transaction::Version, trusted_state::TrustedState, waypoint::Waypoint,
+};
+use std::{
+    collections::HashMap,
+    convert::TryFrom,
+    fmt::Debug,
+    sync::{Arc, RwLock},
+};
+
+// TODO(philiphayes): figure out retry strategy
+// TODO(philiphayes): real on-disk waypoint persistence
+// TODO(philiphayes): fill out rest of the methods
+// TODO(philiphayes): use real error types
+// TODO(philiphayes): non-verifying vs verifying client equivalence testing
+// TODO(philiphayes): all clients should validate chain id (allow users to trust-on-first-use or pre-configure)
+// TODO(philiphayes): we could abstract the async client so VerifyingClient takes a dyn Trait?
+
+// TODO(philiphayes): we should really add a real StateProof type (not alias) that
+// collects these types together. StateProof isn't a very descriptive name though...
+
+type StateProof = (
+    LedgerInfoWithSignatures,
+    EpochChangeProof,
+    AccumulatorConsistencyProof,
+);
+
+#[derive(Clone, Debug)]
+pub struct VerifyingClient {
+    inner: Client,
+    trusted_state_store: Arc<RwLock<TrustedStateStore>>,
+}
+
+impl VerifyingClient {
+    // TODO(philiphayes): construct the client ourselves? we probably want to
+    // control the retries out here. For example, during sync, if we get a stale
+    // state proof the retry logic should include that and not just fail immediately.
+    pub fn new(inner: Client, storage: Box<dyn Storage>) -> Result<Self> {
+        let trusted_state_store = TrustedStateStore::new(storage)?;
+        Ok(Self {
+            inner,
+            trusted_state_store: Arc::new(RwLock::new(trusted_state_store)),
+        })
+    }
+
+    pub fn new_with_state(
+        inner: Client,
+        trusted_state: TrustedState,
+        storage: Box<dyn Storage>,
+    ) -> Self {
+        let trusted_state_store = TrustedStateStore::new_with_state(trusted_state, storage);
+        Self {
+            inner,
+            trusted_state_store: Arc::new(RwLock::new(trusted_state_store)),
+        }
+    }
+
+    /// Get a snapshot of our current trusted ledger [`Version`].
+    pub fn version(&self) -> Version {
+        self.trusted_state_store.read().unwrap().version()
+    }
+
+    /// Get a snapshot of our current trusted [`Waypoint`].
+    pub fn waypoint(&self) -> Waypoint {
+        self.trusted_state_store.read().unwrap().waypoint()
+    }
+
+    /// Get a snapshot of our current [`TrustedState`].
+    pub fn trusted_state(&self) -> TrustedState {
+        self.trusted_state_store
+            .read()
+            .unwrap()
+            .trusted_state()
+            .clone()
+    }
+
+    /// Issue `get_state_proof` requests until we successfully sync to the remote
+    /// node's current version (unless we experience a verification error or other
+    /// I/O error).
+    pub async fn sync(&self) -> Result<()> {
+        // TODO(philiphayes): retries
+        while self.sync_one_step().await? {}
+        Ok(())
+    }
+
+    /// Issue a single `get_state_proof` request and try to verify it. Returns
+    /// `Ok(true)` if, after verification, we still need to sync more. Returns
+    /// `Ok(false)` if we have finished syncing.
+    pub async fn sync_one_step(&self) -> Result<bool> {
+        let (state_proof_view, state) = self
+            .inner
+            .get_state_proof(self.version())
+            .await?
+            .into_parts();
+        let state_proof = StateProof::try_from(&state_proof_view)?;
+
+        let latest_li = state_proof.0.ledger_info();
+        ensure!(latest_li.version() == state.version);
+        ensure!(latest_li.timestamp_usecs() == state.timestamp_usecs);
+
+        self.verify_and_ratchet(&state_proof)?;
+
+        Ok(state_proof.1.more)
+    }
+
+    /// Verify and ratchet forward our trusted state using a state proof.
+    pub fn verify_and_ratchet(&self, state_proof: &StateProof) -> Result<()> {
+        let (latest_li, epoch_change_proof, _) = state_proof;
+
+        let trusted_state = self.trusted_state();
+        let change = trusted_state.verify_and_ratchet(latest_li, epoch_change_proof)?;
+
+        if let Some(new_state) = change.new_state() {
+            self.trusted_state_store
+                .write()
+                .unwrap()
+                .ratchet(new_state)?;
+        }
+
+        // TODO(philiphayes): verify the accumulator consistency proof; no-one
+        // seems to actually verify this anywhere?
+
+        Ok(())
+    }
+
+    pub async fn get_account(
+        &self,
+        address: AccountAddress,
+    ) -> Result<Response<Option<AccountView>>> {
+        Ok(self
+            .send_via_batch(MethodRequest::GetAccount((address,)))
+            .await?
+            .and_then(MethodResponse::try_into_get_account)?)
+    }
+
+    /// Send a single request via `VerifyingClient::batch`.
+    async fn send_via_batch(&self, request: MethodRequest) -> Result<Response<MethodResponse>> {
+        let mut responses = self.batch(vec![request]).await?.into_iter();
+        let response = match responses.next() {
+            Some(response) => response,
+            None => bail!("response batch is empty"),
+        };
+        ensure!(responses.next().is_none(), "too many responses");
+        response
+    }
+
+    pub async fn batch(
+        &self,
+        requests: Vec<MethodRequest>,
+    ) -> Result<Vec<Result<Response<MethodResponse>>>> {
+        // transform each request into verifying sub-request batches
+        let batch = VerifyingBatch::from_batch(requests);
+
+        // flatten and collect sub-request batches into flat list of requests
+        let mut requests = batch.collect_requests();
+        // append get_state_proof request
+        let start_version = self.version();
+        requests.push(MethodRequest::get_state_proof(start_version));
+
+        // actually send the batch
+        let responses = self.inner.batch(requests).await?;
+
+        // TODO(philiphayes): REMOVE. for now, just convert the errors until we
+        // use the real error type.
+        let mut responses = responses
+            .into_iter()
+            .map(|result| result.map_err(anyhow::Error::new))
+            .collect::<Vec<_>>();
+
+        // extract and verify the state proof
+        let (state_proof_response, state) = responses.pop().unwrap()?.into_parts();
+        let state_proof_view = state_proof_response.try_into_get_state_proof()?;
+        let state_proof = StateProof::try_from(&state_proof_view)?;
+
+        // check the response metadata matches the state proof
+        let latest_li = state_proof.0.ledger_info();
+        ensure!(state.version == latest_li.version());
+        ensure!(state.timestamp_usecs == latest_li.timestamp_usecs());
+
+        // try to ratchet our trusted state using the state proof
+        self.verify_and_ratchet(&state_proof)?;
+
+        // remote says we're too far behind and need to sync. we have to throw
+        // out the batch since we can't verify any proofs
+        if state_proof.1.more {
+            bail!("needs sync");
+        }
+
+        // unflatten subresponses, verify, and collect into one response per request
+        batch.validate_responses(start_version, &state, &state_proof, responses)
+    }
+}
+
+struct VerifyingBatch {
+    requests: Vec<VerifyingRequest>,
+}
+
+impl VerifyingBatch {
+    fn from_batch(requests: Vec<MethodRequest>) -> Self {
+        Self {
+            requests: requests.into_iter().map(VerifyingRequest::from).collect(),
+        }
+    }
+
+    fn num_subrequests(&self) -> usize {
+        self.requests
+            .iter()
+            .map(|request| request.subrequests.len())
+            .sum()
+    }
+
+    fn collect_requests(&self) -> Vec<MethodRequest> {
+        self.requests
+            .iter()
+            .flat_map(|request| request.subrequests.iter().cloned())
+            .collect()
+    }
+
+    fn validate_responses(
+        &self,
+        start_version: Version,
+        state: &State,
+        state_proof: &StateProof,
+        responses: Vec<Result<Response<MethodResponse>>>,
+    ) -> Result<Vec<Result<Response<MethodResponse>>>> {
+        ensure!(
+            self.num_subrequests() == responses.len(),
+            "unexpected number of responses"
+        );
+
+        for response in &responses {
+            if let Ok(response) = response {
+                ensure!(response.state() == state);
+            }
+        }
+
+        let mut responses_iter = responses.into_iter();
+
+        Ok(self
+            .requests
+            .iter()
+            .map(|request| {
+                let n = request.subrequests.len();
+                let subresponses = responses_iter.by_ref().take(n).collect();
+                request.validate_subresponses(start_version, state, state_proof, subresponses)
+            })
+            .collect())
+    }
+}
+
+struct RequestContext<'a> {
+    #[allow(dead_code)]
+    start_version: Version,
+
+    #[allow(dead_code)]
+    state: &'a State,
+
+    state_proof: &'a StateProof,
+
+    request: &'a MethodRequest,
+
+    #[allow(dead_code)]
+    subrequests: &'a [MethodRequest],
+}
+
+type RequestCallback = fn(RequestContext<'_>, &[MethodResponse]) -> Result<MethodResponse>;
+
+struct VerifyingRequest {
+    request: MethodRequest,
+    subrequests: Vec<MethodRequest>,
+    callback: RequestCallback,
+}
+
+impl VerifyingRequest {
+    fn new(
+        request: MethodRequest,
+        subrequests: Vec<MethodRequest>,
+        callback: RequestCallback,
+    ) -> Self {
+        Self {
+            request,
+            subrequests,
+            callback,
+        }
+    }
+
+    // TODO(philiphayes): this would be easier if the Error's were cloneable...
+
+    fn validate_subresponses(
+        &self,
+        start_version: Version,
+        state: &State,
+        state_proof: &StateProof,
+        subresponses: Vec<Result<Response<MethodResponse>>>,
+    ) -> Result<Response<MethodResponse>> {
+        ensure!(!subresponses.is_empty(), "no responses");
+        ensure!(
+            subresponses.len() == self.subrequests.len(),
+            "unexpected number of responses"
+        );
+
+        let ctxt = RequestContext {
+            start_version,
+            state,
+            state_proof,
+            request: &self.request,
+            subrequests: &self.subrequests.as_slice(),
+        };
+
+        // TODO(philiphayes): coalesce the Result's somehow so we don't lose error info.
+
+        let subresponses_only = subresponses
+            .into_iter()
+            .map(|result| result.map(Response::into_inner))
+            .collect::<Result<Vec<_>>>()?;
+
+        let response = (self.callback)(ctxt, subresponses_only.as_slice())?;
+        Ok(Response::new(response, state.clone()))
+    }
+}
+
+impl From<MethodRequest> for VerifyingRequest {
+    fn from(request: MethodRequest) -> Self {
+        match request {
+            MethodRequest::GetAccount((address,)) => verifying_get_account(address),
+            _ => todo!(),
+        }
+    }
+}
+
+// TODO(philiphayes): add separate type for each MethodRequest? like:
+//
+// ```
+// struct GetAccount((address,));
+//
+// enum MethodRequest {
+//     GetAccount(GetAccount),
+//     // ..
+// }
+// ```
+//
+// would allow the from(MethodRequest) above to call a method on the enum inner
+// instead of these ad-hoc methods i think
+
+fn verifying_get_account(address: AccountAddress) -> VerifyingRequest {
+    let request = MethodRequest::GetAccount((address,));
+    let subrequests = vec![
+        MethodRequest::GetAccountStateWithProof(diem_root_address(), None, None),
+        MethodRequest::GetAccountStateWithProof(address, None, None),
+    ];
+    let callback: RequestCallback = |ctxt, subresponses| match subresponses {
+        [MethodResponse::GetAccountStateWithProof(ref diem_root), MethodResponse::GetAccountStateWithProof(ref account)] =>
+        {
+            let diem_root_with_proof = AccountStateWithProof::try_from(diem_root)?;
+            let account_state_with_proof = AccountStateWithProof::try_from(account)?;
+
+            let latest_li = ctxt.state_proof.0.ledger_info();
+            let state_version = latest_li.version();
+
+            let address = match ctxt.request {
+                MethodRequest::GetAccount((address,)) => *address,
+                _ => panic!("should not happen"),
+            };
+
+            diem_root_with_proof.verify(latest_li, state_version, diem_root_address())?;
+            account_state_with_proof.verify(latest_li, state_version, address)?;
+
+            // TODO(philiphayes): it seems wasteful to lookup the whole diem_root
+            // account, verify the proofs, etc... just to get a list of supported
+            // currency codes. Would it make sense for the AccountView to just
+            // list _all_ BalanceResource's under balance? Then we could avoid
+            // this extra lookup. It's even more problematic when a batch
+            // includes many GetAccount requests, as this batch handling logic
+            // isn't (currently) smart enough to dedup the diem_root lookups.
+            let diem_root_blob = diem_root_with_proof
+                .blob
+                .ok_or_else(|| format_err!("missing diem_root accound somehow"))?;
+            let diem_root = AccountState::try_from(&diem_root_blob)?;
+            let currencies: Option<RegisteredCurrencies> = diem_root.get_config()?;
+            let currency_codes = currencies
+                .as_ref()
+                .map(RegisteredCurrencies::currency_codes)
+                .ok_or_else(|| format_err!("diem_root missing registered currencies"))?;
+
+            let maybe_account_view = account_state_with_proof
+                .blob
+                .map(|blob| {
+                    let account_state = AccountState::try_from(&blob)?;
+                    AccountView::try_from_account_state(
+                        address,
+                        account_state,
+                        &currency_codes,
+                        state_version,
+                    )
+                })
+                .transpose()?;
+
+            Ok(MethodResponse::GetAccount(maybe_account_view))
+        }
+        _ => bail!("invalid responses"),
+    };
+    VerifyingRequest::new(request, subrequests, callback)
+}
+
+// TODO(philiphayes): reuse secure/storage?
+
+pub trait Storage: Debug {
+    fn get(&self, key: &str) -> Result<Vec<u8>>;
+    fn set(&mut self, key: &str, value: Vec<u8>) -> Result<()>;
+}
+
+#[derive(Debug, Default)]
+pub struct InMemoryStorage {
+    data: HashMap<String, Vec<u8>>,
+}
+
+impl InMemoryStorage {
+    pub fn new() -> Self {
+        Self {
+            data: HashMap::new(),
+        }
+    }
+}
+
+impl Storage for InMemoryStorage {
+    fn get(&self, key: &str) -> Result<Vec<u8>> {
+        self.data
+            .get(key)
+            .map(Clone::clone)
+            .ok_or_else(|| format_err!("key not set"))
+    }
+
+    fn set(&mut self, key: &str, value: Vec<u8>) -> Result<()> {
+        self.data.insert(key.to_owned(), value);
+        Ok(())
+    }
+}
+
+pub const TRUSTED_STATE_KEY: &str = "trusted_state";
+
+#[derive(Debug)]
+struct TrustedStateStore {
+    trusted_state: TrustedState,
+    storage: Box<dyn Storage>,
+}
+
+impl TrustedStateStore {
+    fn new(storage: Box<dyn Storage>) -> Result<Self> {
+        let trusted_state = storage
+            .get(TRUSTED_STATE_KEY)
+            .and_then(|bytes| bcs::from_bytes(&bytes).map_err(Into::into))?;
+
+        Ok(Self {
+            trusted_state,
+            storage,
+        })
+    }
+
+    fn new_with_state(trusted_state: TrustedState, storage: Box<dyn Storage>) -> Self {
+        let maybe_stored_state: Result<TrustedState> = storage
+            .get(TRUSTED_STATE_KEY)
+            .and_then(|bytes| bcs::from_bytes(&bytes).map_err(Into::into));
+
+        let trusted_state = if let Ok(stored_state) = maybe_stored_state {
+            if trusted_state.version() > stored_state.version() {
+                trusted_state
+            } else {
+                stored_state
+            }
+        } else {
+            trusted_state
+        };
+
+        Self {
+            trusted_state,
+            storage,
+        }
+    }
+
+    fn version(&self) -> Version {
+        self.trusted_state.version()
+    }
+
+    fn waypoint(&self) -> Waypoint {
+        self.trusted_state.waypoint()
+    }
+
+    fn trusted_state(&self) -> &TrustedState {
+        &self.trusted_state
+    }
+
+    fn ratchet(&mut self, new_state: TrustedState) -> Result<()> {
+        if new_state.version() > self.trusted_state.version() {
+            self.trusted_state = new_state;
+            let trusted_state_bytes = bcs::to_bytes(&self.trusted_state)?;
+            self.storage.set(TRUSTED_STATE_KEY, trusted_state_bytes)?;
+        }
+
+        Ok(())
+    }
+}

--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -1024,7 +1024,7 @@ impl ClientProxy {
     /// Get the latest version
     pub fn get_latest_version(&mut self) -> Version {
         self.client.update_and_verify_state_proof().unwrap();
-        self.client.trusted_state().latest_version()
+        self.client.trusted_state().version()
     }
 
     /// Get the latest annotated account resources from validator.

--- a/testsuite/cli/src/diem_client.rs
+++ b/testsuite/cli/src/diem_client.rs
@@ -130,7 +130,7 @@ impl DiemClient {
     pub fn update_and_verify_state_proof(&mut self) -> Result<()> {
         let state_proof = self
             .client
-            .get_state_proof(self.trusted_state().latest_version())
+            .get_state_proof(self.trusted_state().version())
             .map(Response::into_inner)?;
 
         self.verify_state_proof(state_proof)
@@ -146,10 +146,10 @@ impl DiemClient {
 
         // check ledger info version
         ensure!(
-            li.ledger_info().version() >= state.latest_version(),
+            li.ledger_info().version() >= state.version(),
             "Got stale ledger_info with version {}, known version: {}",
             li.ledger_info().version(),
-            state.latest_version(),
+            state.version(),
         );
 
         // trusted_state_change
@@ -170,8 +170,8 @@ impl DiemClient {
                 self.update_latest_epoch_change_li(latest_epoch_change_li.clone());
             }
             TrustedStateChange::Version { new_state } => {
-                if state.latest_version() < new_state.latest_version() {
-                    info!("Verified version change to: {}", new_state.latest_version());
+                if state.version() < new_state.version() {
+                    info!("Verified version change to: {}", new_state.version());
                 }
                 self.update_trusted_state(new_state);
             }

--- a/types/src/trusted_state.rs
+++ b/types/src/trusted_state.rs
@@ -42,6 +42,10 @@ pub enum TrustedStateChange<'a> {
 }
 
 impl TrustedState {
+    pub fn version(&self) -> Version {
+        self.verified_state.version()
+    }
+
     /// Verify and ratchet forward our trusted state using a `EpochChangeProof`
     /// (that moves us into the latest epoch) and a `LedgerInfoWithSignatures`
     /// inside that epoch.
@@ -74,7 +78,7 @@ impl TrustedState {
     ) -> Result<TrustedStateChange<'a>> {
         let res_version = latest_li.ledger_info().version();
         ensure!(
-            res_version >= self.latest_version(),
+            res_version >= self.version(),
             "The target latest ledger info is stale and behind our current trusted version",
         );
 
@@ -142,10 +146,6 @@ impl TrustedState {
                 Ok(TrustedStateChange::Version { new_state })
             }
         }
-    }
-
-    pub fn latest_version(&self) -> Version {
-        self.verified_state.version()
     }
 }
 

--- a/types/src/unit_tests/trusted_state_test.rs
+++ b/types/src/unit_tests/trusted_state_test.rs
@@ -245,7 +245,7 @@ proptest! {
                 new_state,
                 latest_epoch_change_li,
             } => {
-                assert_eq!(new_state.latest_version(), expected_latest_version);
+                assert_eq!(new_state.version(), expected_latest_version);
                 assert_eq!(Some(latest_epoch_change_li), expected_latest_epoch_change_li.as_ref());
                 assert_eq!(latest_epoch_change_li.ledger_info().next_epoch_state(), expected_validator_set);
             }
@@ -280,9 +280,9 @@ proptest! {
             TrustedStateChange::Version {
                 new_state,
             } => {
-                assert_eq!(new_state.latest_version(), expected_latest_version);
+                assert_eq!(new_state.version(), expected_latest_version);
             }
-            TrustedStateChange::NoChange => assert_eq!(trusted_state.latest_version(), expected_latest_version),
+            TrustedStateChange::NoChange => assert_eq!(trusted_state.version(), expected_latest_version),
         };
     }
 
@@ -320,14 +320,14 @@ proptest! {
                 new_state,
                 latest_epoch_change_li,
             } => {
-                assert_eq!(new_state.latest_version(), expected_latest_version);
+                assert_eq!(new_state.version(), expected_latest_version);
                 assert_eq!(Some(latest_epoch_change_li), expected_latest_epoch_change_li.as_ref());
                 assert_eq!(latest_epoch_change_li.ledger_info().next_epoch_state(), expected_validator_set);
             }
             TrustedStateChange::Version {
                 new_state,
             } => {
-                assert_eq!(new_state.latest_version(), expected_latest_version);
+                assert_eq!(new_state.version(), expected_latest_version);
             }
             _ => (),
         };
@@ -400,7 +400,7 @@ proptest! {
                 new_state,
                 latest_epoch_change_li,
             } => {
-                assert_eq!(new_state.latest_version(), expected_latest_version);
+                assert_eq!(new_state.version(), expected_latest_version);
                 assert_eq!(Some(latest_epoch_change_li), expected_latest_epoch_change_li.as_ref());
                 assert_eq!(latest_epoch_change_li.ledger_info().next_epoch_state(), expected_validator_set);
             }
@@ -453,7 +453,7 @@ proptest! {
         let good_li = latest_li.ledger_info();
         let change_proof = EpochChangeProof::new(lis_with_sigs, false /* more */);
 
-        if good_li.version() == trusted_state.latest_version() {
+        if good_li.version() == trusted_state.version() {
             // Verifying a latest ledger info (inside the last epoch) with
             // invalid data should fail.
             let bad_li = LedgerInfoWithSignatures::new(

--- a/types/src/unit_tests/trusted_state_test.rs
+++ b/types/src/unit_tests/trusted_state_test.rs
@@ -13,6 +13,7 @@ use crate::{
     validator_verifier::{random_validator_verifier, ValidatorConsensusInfo, ValidatorVerifier},
     waypoint::Waypoint,
 };
+use bcs::test_helpers::assert_canonical_encode_decode;
 use diem_crypto::{ed25519::Ed25519Signature, hash::HashValue};
 use proptest::{
     collection::{size_range, vec, SizeRange},
@@ -213,6 +214,11 @@ fn arb_update_proof(
 
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn test_trusted_state_roundtrip_canonical_serialization(trusted_state in any::<TrustedState>()) {
+        assert_canonical_encode_decode(trusted_state);
+    }
 
     #[test]
     fn test_ratchet_from(

--- a/types/src/waypoint.rs
+++ b/types/src/waypoint.rs
@@ -10,6 +10,8 @@ use crate::{
 use anyhow::{ensure, format_err, Error, Result};
 use diem_crypto::hash::{CryptoHash, HashValue};
 use diem_crypto_derive::{BCSCryptoHash, CryptoHasher};
+#[cfg(any(test, feature = "fuzzing"))]
+use proptest_derive::Arbitrary;
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
 use std::{
     fmt::{Display, Formatter},
@@ -24,6 +26,7 @@ const WAYPOINT_DELIMITER: char = ':';
 /// At high level, a trusted waypoint verifies the LedgerInfo for a certain epoch change.
 /// For more information, please refer to the Waypoints documentation.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct Waypoint {
     /// The version of the reconfiguration transaction that is being approved by this waypoint.
     version: Version,


### PR DESCRIPTION
+ Note: this diff implements the bare minimum to get a single non-verifying API call working (`get_account`). Would like to get feedback on whether this looks like the right approach.

+ `VerifyingClient` wraps a base non-verifying json-rpc `Client` and converts normal non-verifying json-rpc calls, like `get_account(address)`, into a set of verifying calls `[get_account_with_proof(diem_root), get_account_with_proof(address)]`, issues the requests to the remote, untrusted json-rpc server, then verifies the proofs in the response, and finally presents the response as a normal `AccountView`.

+ I tested this implementation against testnet, and it seems to correctly sync and make a verifying `get_account` call. It seems like the sdk testing framework is still a bit of a moving target, so I've left that out for now.

+ For this first attempt, we just add an `InMemoryStorage` for storing the `TrustedState`. We already have a series of "Storage" traits/impls in `secure/storage`, which might be handy to reuse.

+ We could probably use a macro or something to make implementing the handlers easier.

+ See also this assorted list of TODO's:

```
// TODO(philiphayes): figure out retry strategy
// TODO(philiphayes): real on-disk waypoint persistence
// TODO(philiphayes): fill out rest of the methods
// TODO(philiphayes): use real error types
// TODO(philiphayes): non-verifying vs verifying client equivalence testing
// TODO(philiphayes): all clients should validate chain id (allow users to trust-on-first-use or pre-configure)
// TODO(philiphayes): we could abstract the async client so VerifyingClient takes a dyn Trait?
```
