### PR TITLE
[dkr] restore script needed in buildspec

### DIFF
--- a/docker/tag-and-push.sh
+++ b/docker/tag-and-push.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright (c) The Diem Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+# tag-and-push.sh is used tag an image with multiple tags and push them to the target repo. Use ":" as the separator
+# between multiple tags
+# Example:
+# SOURCE=diem_validator:latest TARGET_REPO=1234567890.dkr.ecr.us-west-2.amazonaws.com/diem_cluster_test TARGET_TAGS=master:master_39cnja0 tag-and-push.sh
+
+set -e
+
+TARGET_TAGS_ARR=(${TARGET_TAGS//:/ })
+for TAG in "${TARGET_TAGS_ARR[@]}"
+do
+  TARGET=${TARGET_REPO}:${TAG}
+  echo "Tagging ${SOURCE} to ${TARGET}"
+  docker tag ${SOURCE} ${TARGET}
+  echo "Pushing ${SOURCE} to ${TARGET}"
+  docker push ${TARGET}
+done


### PR DESCRIPTION
## Motivation
This partially reverts 9ed22830.  The buildspec in Codebuild still needs tag-and-push script. 

## Test Plan
CI