### PR TITLE
[read/write set analysis] Use FunctionEnv instead of FunctionTarget i…

### DIFF
--- a/language/move-prover/bytecode/src/access_path_trie.rs
+++ b/language/move-prover/bytecode/src/access_path_trie.rs
@@ -9,9 +9,8 @@
 use crate::{
     access_path::{AbsAddr, AccessPath, AccessPathMap, FootprintDomain, Offset, Root},
     dataflow_analysis::{AbstractDomain, JoinResult, MapDomain},
-    function_target::FunctionTarget,
 };
-use move_model::{ast::TempIndex, ty::Type};
+use move_model::{ast::TempIndex, model::FunctionEnv, ty::Type};
 use std::{
     collections::btree_map::Entry,
     fmt,
@@ -373,7 +372,7 @@ impl<T: FootprintDomain> AccessPathTrie<T> {
     }
 
     /// Return a wrapper that of `self` that implements `Display` using `env`
-    pub fn display<'a>(&'a self, env: &'a FunctionTarget) -> AccessPathTrieDisplay<'a, T> {
+    pub fn display<'a>(&'a self, env: &'a FunctionEnv) -> AccessPathTrieDisplay<'a, T> {
         AccessPathTrieDisplay { t: self, env }
     }
 }
@@ -412,7 +411,7 @@ impl<T: FootprintDomain> DerefMut for AccessPathTrie<T> {
 
 pub struct AccessPathTrieDisplay<'a, T: FootprintDomain> {
     t: &'a AccessPathTrie<T>,
-    env: &'a FunctionTarget<'a>,
+    env: &'a FunctionEnv<'a>,
 }
 
 impl<'a, T: FootprintDomain> fmt::Display for AccessPathTrieDisplay<'a, T> {

--- a/language/move-prover/bytecode/src/read_write_set_analysis.rs
+++ b/language/move-prover/bytecode/src/read_write_set_analysis.rs
@@ -243,7 +243,7 @@ impl ReadWriteSetState {
     }
 
     /// Return a wrapper of `self` that implements `Display` using `env`
-    pub fn display<'a>(&'a self, env: &'a FunctionTarget) -> ReadWriteSetStateDisplay<'a> {
+    pub fn display<'a>(&'a self, env: &'a FunctionEnv) -> ReadWriteSetStateDisplay<'a> {
         ReadWriteSetStateDisplay { state: self, env }
     }
 }
@@ -593,7 +593,7 @@ pub fn get_read_write_set(env: &GlobalEnv, targets: &FunctionTargetsHolder) {
                 "Invariant violation: read/write set analysis should be run before calling this",
             );
             println!("{}::{}", module_name, func_env.get_identifier());
-            println!("{}", annotation.display(&fun_target))
+            println!("{}", annotation.display(fun_target.func_env))
         }
     }
 }
@@ -614,7 +614,7 @@ pub fn format_read_write_set_annotation(
         return None;
     }
     if let Some(a) = target.get_annotations().get::<ReadWriteSetState>() {
-        Some(format!("{}", a.display(target)))
+        Some(format!("{}", a.display(target.func_env)))
     } else {
         None
     }
@@ -622,7 +622,7 @@ pub fn format_read_write_set_annotation(
 
 struct ReadWriteSetStateDisplay<'a> {
     state: &'a ReadWriteSetState,
-    env: &'a FunctionTarget<'a>,
+    env: &'a FunctionEnv<'a>,
 }
 
 impl<'a> fmt::Display for ReadWriteSetStateDisplay<'a> {


### PR DESCRIPTION
…n display

Printing a summary or analysis state in human-readable form currently requires a `FunctionTarget`. These are hard to get a hold of outside of the analysis + often introduce lifetime issues if you do manage to acquire one. Use `FunctionEnv` instead to facilitate printing/debugging.
