### PR TITLE
[json-rpc]: add raw BCS bytes to unknown event data

### DIFF
--- a/json-rpc/API-CHANGELOG.md
+++ b/json-rpc/API-CHANGELOG.md
@@ -13,6 +13,10 @@ Please add the API change in the following format:
 
 ```
 
+## 2021-04-21 Add `bytes` field to `unknown` event
+
+When the event data can't be parsed, we output `unknown` type event data with raw BCS event data bytes, so that client can unwrap event details by parsing the BCS bytes.
+
 ## 2021-03-25 Add `metadata` field to preburns in the `preburn_queues` for designated dealers
 
 This adds an additional `metadata` field coupled with each preburn request held

--- a/json-rpc/docs/type_event.md
+++ b/json-rpc/docs/type_event.md
@@ -158,8 +158,9 @@ Event emitted when a new account is created
 
 Represents events currently unsupported by JSON-RPC API.
 
-| Name    | Type   | Description                 |
-|---------|--------|-----------------------------|
-| type    | string | Constant string "unknown"   |
+| Name  | Type   | Description                             |
+|-------|--------|-----------------------------------------|
+| type  | string | Constant string "unknown"               |
+| bytes | string | Hex-encoded BCS bytes of the event data |
 
 [1]: https://docs.rs/bcs/ "BCS"

--- a/json-rpc/types/src/proto/jsonrpc.proto
+++ b/json-rpc/types/src/proto/jsonrpc.proto
@@ -167,6 +167,12 @@ message EventData {
    * It is created by validators.
    */
   uint64 committed_timestamp_secs = 20 [json_name="committed_timestamp_secs"];
+
+  /**
+   * unknown event field.
+   * Hex-encoded BCS bytes of the event data.
+   */
+  string bytes = 21;
 }
 
 message Metadata {


### PR DESCRIPTION

## Motivation

When we have a new event that is not deserialized by json-rpc Event view, exposing the raw BCS bytes of the event data helps client to decode the data before we update server view 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Unit test


