### PR TITLE
[move prover] CompositionalAnalysis::summarize returns a Summary

### DIFF
--- a/language/move-prover/bytecode/src/packed_types_analysis.rs
+++ b/language/move-prover/bytecode/src/packed_types_analysis.rs
@@ -173,12 +173,15 @@ impl FunctionTargetProcessor for PackedTypesProcessor {
         &self,
         targets: &mut FunctionTargetsHolder,
         func_env: &FunctionEnv<'_>,
-        data: FunctionData,
+        mut data: FunctionData,
     ) -> FunctionData {
         let initial_state = PackedTypesState::default();
+        let fun_target = FunctionTarget::new(func_env, &data);
         let cache = SummaryCache::new(targets, func_env.module_env.env);
         let analysis = PackedTypesAnalysis { cache };
-        analysis.summarize(func_env, initial_state, data)
+        let summary = analysis.summarize(&fun_target, initial_state);
+        data.annotations.set(summary);
+        data
     }
 
     fn name(&self) -> String {

--- a/language/move-prover/bytecode/src/read_write_set_analysis.rs
+++ b/language/move-prover/bytecode/src/read_write_set_analysis.rs
@@ -558,7 +558,7 @@ impl FunctionTargetProcessor for ReadWriteSetProcessor {
         &self,
         targets: &mut FunctionTargetsHolder,
         func_env: &FunctionEnv<'_>,
-        data: FunctionData,
+        mut data: FunctionData,
     ) -> FunctionData {
         let fun_target = FunctionTarget::new(func_env, &data);
         let mut initial_state = ReadWriteSetState::default();
@@ -570,7 +570,9 @@ impl FunctionTargetProcessor for ReadWriteSetProcessor {
         }
         let cache = SummaryCache::new(targets, func_env.module_env.env);
         let analysis = ReadWriteSetAnalysis { cache };
-        analysis.summarize(func_env, initial_state, data)
+        let summary = analysis.summarize(&fun_target, initial_state);
+        data.annotations.set(summary);
+        data
     }
 
     fn name(&self) -> String {

--- a/language/move-prover/bytecode/src/usage_analysis.rs
+++ b/language/move-prover/bytecode/src/usage_analysis.rs
@@ -118,7 +118,7 @@ impl FunctionTargetProcessor for UsageProcessor {
         &self,
         targets: &mut FunctionTargetsHolder,
         func_env: &FunctionEnv<'_>,
-        data: FunctionData,
+        mut data: FunctionData,
     ) -> FunctionData {
         let mut initial_state = UsageState::default();
         let func_target = FunctionTarget::new(func_env, &data);
@@ -128,7 +128,9 @@ impl FunctionTargetProcessor for UsageProcessor {
 
         let cache = SummaryCache::new(targets, func_env.module_env.env);
         let analysis = MemoryUsageAnalysis { cache };
-        analysis.summarize(func_env, initial_state, data)
+        let summary = analysis.summarize(&func_target, initial_state);
+        data.annotations.set(summary);
+        data
     }
 
     fn name(&self) -> String {


### PR DESCRIPTION
Previously, this function took ownership of a `FunctionData`, mutated its `annotations` to add the summary, then handed it back. This is convenient because the caller doesn't have to remember to update the annotations, but it creates ownership problems in the case that the caller analysis wants to store a `FunctionTarget` or `FunctionEnv` as part of its analysis state (which is useful if, e.g., you want to know if a variable is a formal parameter of the current function or a local). This was creating problems for some upcoming changes to the read/write set analysis that require a `FunctionEnv` in the analysis state.