### PR TITLE
[Move read/write set analysis] create standalone crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4285,6 +4285,8 @@ dependencies = [
  "move-vm-runtime",
  "move-vm-types",
  "once_cell",
+ "petgraph",
+ "read-write-set",
  "resource-viewer",
  "structopt 0.3.21",
  "vm-genesis",
@@ -5858,6 +5860,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 dependencies = [
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "read-write-set"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytecode",
+ "diem-workspace-hack",
+ "move-binary-format",
+ "move-core-types",
+ "move-model",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,7 @@ members = [
     "language/tools/move-cli",
     "language/tools/move-coverage",
     "language/tools/move-explain",
+    "language/tools/read-write-set",
     "language/tools/resource-viewer",
     "language/tools/vm-genesis",
     "language/transaction-builder/generator",

--- a/language/move-prover/bytecode/src/read_write_set_analysis.rs
+++ b/language/move-prover/bytecode/src/read_write_set_analysis.rs
@@ -31,7 +31,7 @@ use std::{cmp::Ordering, fmt, fmt::Formatter};
 
 /// An access to local or global state
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
-enum Access {
+pub enum Access {
     /// Not read or written; only accessed via a field borrow &, Vector::borrow, or borrow_global
     /// E.g., in *&x.f.g = 7, f is Borrow, g is Write
     Borrow,
@@ -46,7 +46,7 @@ enum Access {
 /// A record of the glocals and locals accessed by the current procedure + the address values stored
 /// by locals or globals
 #[derive(Debug, Clone, Eq, PartialOrd, PartialEq)]
-struct ReadWriteSetState {
+pub struct ReadWriteSetState {
     /// memory accessed so far
     accesses: AccessPathTrie<Access>,
     /// mapping from locals to formal or global roots
@@ -622,7 +622,7 @@ pub fn format_read_write_set_annotation(
     }
 }
 
-struct ReadWriteSetStateDisplay<'a> {
+pub struct ReadWriteSetStateDisplay<'a> {
     state: &'a ReadWriteSetState,
     env: &'a FunctionEnv<'a>,
 }
@@ -630,10 +630,10 @@ struct ReadWriteSetStateDisplay<'a> {
 impl<'a> fmt::Display for ReadWriteSetStateDisplay<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.write_str("Accesses:\n")?;
-        writeln!(f, "{}", self.state.accesses.display(self.env))?;
+        writeln!(f, "{}", self.state.accesses.display(&self.env))?;
         f.write_str("Locals:\n")?;
         self.state.locals.iter_paths(|path, v| {
-            writeln!(f, "{}: {}", path.display(self.env), v.display(self.env)).unwrap();
+            writeln!(f, "{}: {}", path.display(&self.env), v.display(&self.env)).unwrap();
         });
         Ok(())
     }

--- a/language/tools/move-cli/Cargo.toml
+++ b/language/tools/move-cli/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0.38"
 difference = "2.0.0"
 include_dir = { version = "0.6.0", features = ["search"] }
 once_cell = "1.7.2"
+petgraph = "0.5.1"
 structopt = "0.3.21"
 
 bcs = "0.1.2"
@@ -28,6 +29,7 @@ move-core-types = { path = "../../move-core/types" }
 move-lang = { path = "../../move-lang" }
 move-vm-types = { path = "../../move-vm/types" }
 move-vm-runtime = { path = "../../move-vm/runtime", features = ["debug_module"] }
+read-write-set = { path = "../read-write-set" }
 resource-viewer = { path = "../resource-viewer" }
 move-binary-format = { path = "../../move-binary-format" }
 vm-genesis = { path = "../vm-genesis" }

--- a/language/tools/move-cli/tests/testsuite/read_write_set/args.exp
+++ b/language/tools/move-cli/tests/testsuite/read_write_set/args.exp
@@ -1,0 +1,20 @@
+Command `publish --mode bare`:
+Command `analyze read-write-set storage/0x00000000000000000000000000000001/modules/RWSet.mv read_f --mode bare -v`:
+Inferring read/write set for 1 module(s)
+Accesses:
+Loc(0)/f: Read
+
+Locals:
+Loc(0): Loc(0)
+Loc(0)/f: Loc(0)/f
+Ret(0): Loc(0)/f
+
+Command `analyze read-write-set storage/0x00000000000000000000000000000001/modules/RWSet.mv write_f --mode bare -v`:
+Inferring read/write set for 1 module(s)
+Accesses:
+Loc(0)/f: Write
+
+Locals:
+Loc(0): Loc(0)
+Loc(0)/f: Loc(0)/f
+

--- a/language/tools/move-cli/tests/testsuite/read_write_set/args.txt
+++ b/language/tools/move-cli/tests/testsuite/read_write_set/args.txt
@@ -1,0 +1,3 @@
+publish --mode bare
+analyze read-write-set storage/0x00000000000000000000000000000001/modules/RWSet.mv read_f --mode bare -v
+analyze read-write-set storage/0x00000000000000000000000000000001/modules/RWSet.mv write_f --mode bare -v

--- a/language/tools/move-cli/tests/testsuite/read_write_set/src/modules/RWSet.move
+++ b/language/tools/move-cli/tests/testsuite/read_write_set/src/modules/RWSet.move
@@ -1,0 +1,13 @@
+address 0x1 {
+module RWSet {
+    struct S { f: u64 }
+
+    public fun read_f(s: &S): u64 {
+        s.f
+    }
+
+    public fun write_f(s: &mut S) {
+        s.f = 7;
+    }
+}
+}

--- a/language/tools/read-write-set/Cargo.toml
+++ b/language/tools/read-write-set/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "read-write-set"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+description = "Read/write set inference for Move bytecode programs"
+repository = "https://github.com/diem/diem"
+homepage = "https://diem.com"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0.38"
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
+move-core-types = { path = "../../move-core/types" }
+move-model = { path = "../../move-model" }
+prover_bytecode = { path = "../../move-prover/bytecode", package="bytecode" }
+move-binary-format = { path = "../../move-binary-format" }

--- a/language/tools/read-write-set/src/lib.rs
+++ b/language/tools/read-write-set/src/lib.rs
@@ -1,0 +1,58 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use move_binary_format::file_format::CompiledModule;
+use move_core_types::{identifier::Identifier, language_storage::ModuleId};
+use move_model::model::{FunctionEnv, GlobalEnv};
+use prover_bytecode::{
+    function_target_pipeline::{FunctionTargetPipeline, FunctionTargetsHolder, FunctionVariant},
+    read_write_set_analysis::{ReadWriteSetProcessor, ReadWriteSetState},
+};
+
+pub struct ReadWriteSet {
+    targets: FunctionTargetsHolder,
+    env: GlobalEnv,
+}
+
+/// Infer read/write set results for `modules`.
+/// The `modules` list must be topologically sorted by the dependency relation
+/// (i.e., a child node in the dependency graph should appear earlier in the
+/// vector than its parents), and all dependencies of each module must be
+/// included.
+pub fn analyze<'a>(modules: impl IntoIterator<Item = &'a CompiledModule>) -> Result<ReadWriteSet> {
+    let env = move_model::run_bytecode_model_builder(modules)?;
+    let mut pipeline = FunctionTargetPipeline::default();
+    pipeline.add_processor(ReadWriteSetProcessor::new());
+    let mut targets = FunctionTargetsHolder::default();
+    for module_env in env.get_modules() {
+        for func_env in module_env.get_functions() {
+            targets.add_target(&func_env)
+        }
+    }
+    pipeline.run(&env, &mut targets);
+
+    Ok(ReadWriteSet { targets, env })
+}
+
+impl ReadWriteSet {
+    /// Return the read/write set for `module`::`fun`.
+    /// Returns `None` if the read/write set does not exist.
+    pub fn get(&self, module: &ModuleId, fun: &Identifier) -> Option<&ReadWriteSetState> {
+        self.get_function_env(module, fun)
+            .map(|fenv| {
+                self.targets
+                    .get_data(&fenv.get_qualified_id(), &FunctionVariant::Baseline)
+                    .map(|data| data.annotations.get::<ReadWriteSetState>())
+                    .flatten()
+            })
+            .flatten()
+    }
+
+    /// Returns the FunctionEnv for `module`::`fun`
+    /// Returns `None` if this function does not exist
+    pub fn get_function_env(&self, module: &ModuleId, fun: &Identifier) -> Option<FunctionEnv> {
+        self.env
+            .find_function_by_language_storage_id_name(module, fun)
+    }
+}


### PR DESCRIPTION
To incorporate the read/write set analysis into the upcoming parallel execution scheme, it will be convenient to depend directly on the analysis + some related utilities instead of the prover's `bytecode` crate. This PR takes one step toward creating a standalone create for parallel execution and other clients of the read/write set analysis to depend on:

- Create tools/read-write-set crate
- Integrate this crate into the Move CLI via the new `analyze read-write-set <module> <script>` command. This will make it easy to experiment with the read-write set on local files + to write tests.
- To make this work, I had to add logic for topologically sorting CompiledModule's by the dependency relation (see changes in on_disk_state_view). Eventually, it might make sense to move these CodeCache and dependency types outside of the CLI, as they'd surely be useful elsewhere.
- Added CLI tests to show that this flow works