### PR TITLE
[diem-vm] Implement a prefetching logic for diem-vm

### DIFF
--- a/language/diem-vm/src/diem_transaction_executor.rs
+++ b/language/diem-vm/src/diem_transaction_executor.rs
@@ -19,12 +19,13 @@ use crate::{
 use diem_logger::prelude::*;
 use diem_state_view::StateView;
 use diem_types::{
+    access_path::AccessPath,
     account_config,
     block_metadata::BlockMetadata,
     on_chain_config::DIEM_VERSION_3,
     transaction::{
-        ChangeSet, Module, SignatureCheckedTransaction, Transaction, TransactionOutput,
-        TransactionPayload, TransactionStatus, WriteSetPayload,
+        ChangeSet, Module, SignatureCheckedTransaction, Transaction, TransactionArgument,
+        TransactionOutput, TransactionPayload, TransactionStatus, WriteSetPayload,
     },
     vm_status::{KeptVMStatus, StatusCode, VMStatus},
     write_set::{WriteSet, WriteSetMut},
@@ -650,6 +651,34 @@ impl DiemVM {
         ))
     }
 
+    fn preload_cache(
+        signature_verified_block: &[PreprocessedTransaction],
+        data_view: &impl StateView,
+    ) {
+        // generate a collection of addresses
+        let mut addresses_to_preload = HashSet::new();
+        for txn in signature_verified_block {
+            if let PreprocessedTransaction::UserTransaction(txn) = txn {
+                if let TransactionPayload::Script(script) = txn.payload() {
+                    addresses_to_preload.insert(txn.sender());
+
+                    for arg in script.args() {
+                        if let TransactionArgument::Address(address) = arg {
+                            addresses_to_preload.insert(*address);
+                        }
+                    }
+                }
+            }
+        }
+
+        // This will launch a number of threads to preload the account blobs in parallel. We may
+        // want to fine tune the number of threads launched here in the future.
+        addresses_to_preload
+            .into_par_iter()
+            .map(|addr| data_view.get(&AccessPath::new(addr, Vec::new())).ok()?)
+            .collect::<Vec<Option<Vec<u8>>>>();
+    }
+
     pub(crate) fn execute_block_impl(
         &self,
         transactions: Vec<Transaction>,
@@ -675,6 +704,12 @@ impl DiemVM {
                 .map(preprocess_transaction)
                 .collect();
         }
+
+        rayon::scope(|scope| {
+            scope.spawn(|_| {
+                DiemVM::preload_cache(&signature_verified_block, data_cache);
+            });
+        });
 
         for (idx, txn) in signature_verified_block.into_iter().enumerate() {
             let log_context = AdapterLogSchema::new(data_cache.id(), idx);

--- a/storage/storage-interface/src/state_view.rs
+++ b/storage/storage-interface/src/state_view.rs
@@ -168,11 +168,13 @@ impl<'a> StateView for VerifiedStateView<'a> {
                             err
                         )
                     })?;
-                assert!(self
-                    .account_to_proof_cache
+
+                // multiple threads may enter this code, and another thread might add
+                // an address before this one. Thus the insertion might return a None here.
+                self.account_to_proof_cache
                     .write()
-                    .insert(address_hash, proof)
-                    .is_none());
+                    .insert(address_hash, proof);
+
                 blob
             }
         };


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This is the revised version of #7338. The logic here is to prefetch the account blobs into the cache of the state view so that we can have account blob deserialization done in background.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan

Copied from #7338:

1. Launching one thread to prefetch accounts:
```
bench_p2p_small         time:   [410.93 ms 416.28 ms 421.76 ms]
                        change: [-6.6657% -4.3640% -2.2150%] (p = 0.00 < 0.05)
                        Performance has improved.

bench_p2p_medium        time:   [769.03 ms 775.82 ms 783.25 ms]
                        change: [-4.9727% -3.8442% -2.7737%] (p = 0.00 < 0.05)
                        Performance has improved.

bench_p2p_large         time:   [771.35 ms 786.97 ms 803.10 ms]
                        change: [-6.2914% -2.7613% +0.2655%] (p = 0.14 > 0.05)
                        No change in performance detected.
```
I've been observing a constant perf increase on medium case with 1000 txns in a block. The perf number for small and large has been pretty fluctuated but mostly on the improvement side.

2. Launching multiple threads to prefetch accounts:
```
bench_p2p_small         time:   [408.61 ms 411.82 ms 414.91 ms]
                        change: [-7.4353% -5.3868% -3.6983%] (p = 0.00 < 0.05)
                        Performance has improved.

bench_p2p_medium        time:   [761.75 ms 772.99 ms 783.74 ms]
                        change: [-5.6370% -4.1952% -2.7912%] (p = 0.00 < 0.05)
                        Performance has improved.

bench_p2p_large         time:   [736.94 ms 744.87 ms 753.19 ms]
                        change: [-10.851% -7.9634% -5.7760%] (p = 0.00 < 0.05)
                        Performance has improved.
```
This version is performing constantly better then the first version, especially on the p2p_large case. I would assume it's because we have more threads prefetching the values.

With this benchmark result, I would suggest land the version with multiple prefetching threads and fine tune the number of threads in the future.