### PR TITLE
[backup] limit concurrent downloads by default

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -120,7 +120,7 @@ jobs:
           rm -rf downloadazcopy-v10-linux azcopy_linux_amd64_*
       - name: replay transactions
         run: |
-          cargo run --release --bin db-restore -- --target-db-dir /var/tmp/dbrestore/ auto --replay-all command-adapter --config "$CONFIG"
+          cargo run --release --bin db-restore -- --concurrent-downloads 2 --target-db-dir /var/tmp/dbrestore/ auto --replay-all command-adapter --config "$CONFIG"
       - uses: ./.github/actions/build-teardown
 
   json-rpc-backward-compat-test:

--- a/helm/fullnode/templates/restore.yaml
+++ b/helm/fullnode/templates/restore.yaml
@@ -35,7 +35,7 @@ spec:
               echo "$CONTROLLER_UID" > /opt/diem/data/restore-uid
           fi
           # start restore process
-          /usr/local/bin/db-restore{{ range .config.trusted_waypoints }} --trust-waypoint {{ . }}{{ end }} --target-db-dir /opt/diem/data/db auto --metadata-cache-dir /tmp/diem-restore-metadata command-adapter --config /opt/diem/etc/{{ .config.location }}.toml
+          /usr/local/bin/db-restore --concurrent-downloads {{ .config.concurrent_downloads }}{{ range .config.trusted_waypoints }} --trust-waypoint {{ . }}{{ end }} --target-db-dir /opt/diem/data/db auto --metadata-cache-dir /tmp/diem-restore-metadata command-adapter --config /opt/diem/etc/{{ .config.location }}.toml
         env:
         - name: RUST_LOG
           value: "debug"

--- a/helm/fullnode/values.yaml
+++ b/helm/fullnode/values.yaml
@@ -125,3 +125,4 @@ restore:
       container:
       sas:
     trusted_waypoints: []
+    concurrent_downloads: 2


### PR DESCRIPTION

## Motivation
Buffered transaction batches squeezing fs cache out with default setting in testnets (num_cpu(), which is 4).

Matching what we do on `partners` repo side. https://github.com/diem/partners/pull/879
 
### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Y
## Test Plan

professional eyes
## Related PRs
https://github.com/diem/partners/pull/879