### PR TITLE
[ci-test] enable nextest retries + flaky test detection

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -12,6 +12,7 @@ defaults:
 
 env:
   max_threads: 16
+  nextest_tries: 3
   pre_command: cd /opt/git/diem/
 
 jobs:
@@ -514,7 +515,7 @@ jobs:
           restore-keys: "crates-${{ runner.os }}"
       - name: run unit tests
         run: |
-          $pre_command && mkdir -p target/junit-reports && cargo nextest --jobs ${max_threads} --unit --failure-output=immediate-final --changed-since "origin/$TARGET_BRANCH" --junit target/junit-reports/unit-test.xml
+          $pre_command && mkdir -p target/junit-reports && cargo nextest --jobs ${max_threads} --tries ${nextest_tries} --unit --failure-output=immediate-final --changed-since "origin/$TARGET_BRANCH" --junit target/junit-reports/unit-test.xml
           sccache -s
         env:
           TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
@@ -556,7 +557,7 @@ jobs:
           restore-keys: "crates-${{ runner.os }}"
       - name: run unit tests
         run: |
-          $pre_command && mkdir -p target/junit-reports && cargo nextest --jobs ${max_threads} --unit --failure-output=immediate-final --changed-since "origin/$TARGET_BRANCH" --junit target/junit-reports/unit-test.xml
+          $pre_command && mkdir -p target/junit-reports && cargo nextest --jobs ${max_threads} --tries ${nextest_tries} --unit --failure-output=immediate-final --changed-since "origin/$TARGET_BRANCH" --junit target/junit-reports/unit-test.xml
           sccache -s
         env:
           TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
@@ -599,7 +600,7 @@ jobs:
           key: crates-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: "crates-${{ runner.os }}"
       - name: run codegen unit tests
-        run: $pre_command && mkdir -p target/junit-reports && cargo nextest --jobs ${max_threads} --failure-output=immediate-final -p transaction-builder-generator --unit --changed-since "origin/$TARGET_BRANCH" --run-ignored=ignored-only --junit target/junit-reports/codegen-unit-test.xml
+        run: $pre_command && mkdir -p target/junit-reports && cargo nextest --jobs ${max_threads} --tries ${nextest_tries} --failure-output=immediate-final -p transaction-builder-generator --unit --changed-since "origin/$TARGET_BRANCH" --run-ignored=ignored-only --junit target/junit-reports/codegen-unit-test.xml
         env:
           TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
       - name: upload codegen test results
@@ -632,7 +633,7 @@ jobs:
           key: crates-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: "crates-${{ runner.os }}"
       - name: run codegen unit tests
-        run: $pre_command && mkdir -p target/junit-reports && cargo nextest --jobs ${max_threads} --failure-output=immediate-final -p transaction-builder-generator --unit --changed-since "origin/$TARGET_BRANCH" --run-ignored=ignored-only --junit target/junit-reports/codegen-unit-test.xml
+        run: $pre_command && mkdir -p target/junit-reports && cargo nextest --jobs ${max_threads} --tries ${nextest_tries} --failure-output=immediate-final -p transaction-builder-generator --unit --changed-since "origin/$TARGET_BRANCH" --run-ignored=ignored-only --junit target/junit-reports/codegen-unit-test.xml
         env:
           TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
           SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.ENV_DIEM_S3_AWS_ACCESS_KEY_ID }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,9 +1211,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -4758,6 +4758,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "nextest-runner"
+version = "0.1.0"
+source = "git+https://github.com/diem/diem-devtools?rev=1b61853016059b2dca577cefafff2825b49494a0#1b61853016059b2dca577cefafff2825b49494a0"
+dependencies = [
+ "aho-corasick",
+ "anyhow",
+ "atty",
+ "camino",
+ "chrono",
+ "crossbeam-channel",
+ "duct",
+ "num_cpus",
+ "once_cell",
+ "quick-junit",
+ "rayon",
+ "serde",
+ "serde_json",
+ "signal-hook",
+ "structopt 0.3.21",
+ "termcolor",
+]
+
+[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5582,7 +5605,7 @@ checksum = "3ac73b1112776fc109b2e61909bc46c7e1bf0d7f690ffb1676553acce16d5cda"
 [[package]]
 name = "quick-junit"
 version = "0.1.0"
-source = "git+https://github.com/diem/diem-devtools?branch=main#bb4bc9d7d9ce6308c2571bf7e0ffaf662d5d2992"
+source = "git+https://github.com/diem/diem-devtools?rev=1b61853016059b2dca577cefafff2825b49494a0#1b61853016059b2dca577cefafff2825b49494a0"
 dependencies = [
  "chrono",
  "indexmap",
@@ -7364,28 +7387,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "testrunner"
-version = "0.1.0"
-source = "git+https://github.com/diem/diem-devtools?branch=main#bb4bc9d7d9ce6308c2571bf7e0ffaf662d5d2992"
-dependencies = [
- "aho-corasick",
- "anyhow",
- "atty",
- "camino",
- "crossbeam-channel",
- "duct",
- "num_cpus",
- "once_cell",
- "quick-junit",
- "rayon",
- "serde",
- "serde_json",
- "signal-hook",
- "structopt 0.3.21",
- "termcolor",
-]
-
-[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8271,12 +8272,12 @@ dependencies = [
  "indexmap",
  "indoc",
  "log",
+ "nextest-runner",
  "rayon",
  "regex",
  "serde",
  "serde_json",
  "structopt 0.3.21",
- "testrunner",
  "toml",
  "x-core",
  "x-lint",

--- a/common/workspace-hack/Cargo.toml
+++ b/common/workspace-hack/Cargo.toml
@@ -17,7 +17,7 @@ byteorder = { version = "1.4.3", features = ["default", "i128", "std"] }
 bytes = { version = "1.0.1", features = ["default", "serde", "std"] }
 chrono = { version = "0.4.19", features = ["clock", "default", "libc", "oldtime", "serde", "std", "time", "winapi"] }
 clap = { version = "2.33.3", features = ["ansi_term", "atty", "color", "default", "strsim", "suggestions", "vec_map"] }
-crossbeam-channel = { version = "0.5.0", features = ["crossbeam-utils", "default", "std"] }
+crossbeam-channel = { version = "0.5.1", features = ["crossbeam-utils", "default", "std"] }
 crossbeam-deque = { version = "0.8.0", features = ["crossbeam-epoch", "crossbeam-utils", "default", "std"] }
 crossbeam-utils = { version = "0.8.3", features = ["default", "lazy_static", "std"] }
 either = { version = "1.6.1", features = ["default", "use_std"] }
@@ -65,7 +65,7 @@ bytes = { version = "1.0.1", features = ["default", "serde", "std"] }
 cc = { version = "1.0.67", default-features = false, features = ["jobserver", "parallel"] }
 chrono = { version = "0.4.19", features = ["clock", "default", "libc", "oldtime", "serde", "std", "time", "winapi"] }
 clap = { version = "2.33.3", features = ["ansi_term", "atty", "color", "default", "strsim", "suggestions", "vec_map"] }
-crossbeam-channel = { version = "0.5.0", features = ["crossbeam-utils", "default", "std"] }
+crossbeam-channel = { version = "0.5.1", features = ["crossbeam-utils", "default", "std"] }
 crossbeam-deque = { version = "0.8.0", features = ["crossbeam-epoch", "crossbeam-utils", "default", "std"] }
 crossbeam-utils = { version = "0.8.3", features = ["default", "lazy_static", "std"] }
 either = { version = "1.6.1", features = ["default", "use_std"] }
@@ -116,7 +116,7 @@ byteorder = { version = "1.4.3", features = ["default", "i128", "std"] }
 bytes = { version = "1.0.1", features = ["default", "serde", "std"] }
 chrono = { version = "0.4.19", features = ["clock", "default", "libc", "oldtime", "serde", "std", "time", "winapi"] }
 clap = { version = "2.33.3", features = ["ansi_term", "atty", "color", "default", "strsim", "suggestions", "vec_map"] }
-crossbeam-channel = { version = "0.5.0", features = ["crossbeam-utils", "default", "std"] }
+crossbeam-channel = { version = "0.5.1", features = ["crossbeam-utils", "default", "std"] }
 crossbeam-deque = { version = "0.8.0", features = ["crossbeam-epoch", "crossbeam-utils", "default", "std"] }
 crossbeam-utils = { version = "0.8.3", features = ["default", "lazy_static", "std"] }
 either = { version = "1.6.1", features = ["default", "use_std"] }
@@ -164,7 +164,7 @@ bytes = { version = "1.0.1", features = ["default", "serde", "std"] }
 cc = { version = "1.0.67", default-features = false, features = ["jobserver", "parallel"] }
 chrono = { version = "0.4.19", features = ["clock", "default", "libc", "oldtime", "serde", "std", "time", "winapi"] }
 clap = { version = "2.33.3", features = ["ansi_term", "atty", "color", "default", "strsim", "suggestions", "vec_map"] }
-crossbeam-channel = { version = "0.5.0", features = ["crossbeam-utils", "default", "std"] }
+crossbeam-channel = { version = "0.5.1", features = ["crossbeam-utils", "default", "std"] }
 crossbeam-deque = { version = "0.8.0", features = ["crossbeam-epoch", "crossbeam-utils", "default", "std"] }
 crossbeam-utils = { version = "0.8.3", features = ["default", "lazy_static", "std"] }
 either = { version = "1.6.1", features = ["default", "use_std"] }

--- a/devtools/x/Cargo.toml
+++ b/devtools/x/Cargo.toml
@@ -26,7 +26,7 @@ chrono = "0.4.19"
 globset = "0.4.6"
 regex = "1.4.3"
 rayon = "1.5.0"
-testrunner = { git = "https://github.com/diem/diem-devtools", branch = "main" }
+nextest-runner = { git = "https://github.com/diem/diem-devtools", rev = "1b61853016059b2dca577cefafff2825b49494a0" }
 indexmap = "1.6.2"
 x-core = { path = "../x-core" }
 x-lint = { path = "../x-lint" }

--- a/devtools/x/src/cargo/build_args.rs
+++ b/devtools/x/src/cargo/build_args.rs
@@ -20,7 +20,7 @@ pub struct BuildArgs {
     /// No output printed to stdout
     pub(crate) quiet: bool,
     #[structopt(long, short)]
-    /// Number of parallel jobs, defaults to # of CPUs
+    /// Number of parallel build jobs, defaults to # of CPUs
     pub(crate) jobs: Option<u16>,
     #[structopt(long)]
     /// Only this package's library

--- a/devtools/x/src/nextest.rs
+++ b/devtools/x/src/nextest.rs
@@ -13,14 +13,14 @@ use crate::{
 use anyhow::bail;
 use cargo_metadata::Message;
 use guppy::PackageId;
-use std::ffi::OsString;
-use structopt::StructOpt;
-use testrunner::{
+use nextest_runner::{
     reporter::{Color, ReporterOpts, TestReporter},
     runner::TestRunnerOpts,
     test_filter::{RunIgnored, TestFilter},
     test_list::{TestBinary, TestList},
 };
+use std::ffi::OsString;
+use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 pub struct Args {
@@ -31,6 +31,8 @@ pub struct Args {
     unit: bool,
     #[structopt(flatten)]
     pub(crate) build_args: BuildArgs,
+    #[structopt(flatten)]
+    pub(crate) runner_opts: TestRunnerOpts,
     #[structopt(long)]
     /// Do not run tests, only compile the test executables
     no_run: bool,
@@ -120,10 +122,7 @@ pub fn run(args: Args, xctx: XContext) -> Result<()> {
     let test_filter = TestFilter::new(args.run_ignored, &args.filters);
     let test_list = TestList::new(executables, &test_filter)?;
 
-    let runner_opts = TestRunnerOpts {
-        jobs: args.build_args.jobs.map(|jobs| jobs as usize),
-    };
-    let runner = runner_opts.build(&test_list);
+    let runner = args.runner_opts.build(&test_list);
 
     let color = match args.build_args.color {
         Coloring::Auto => Color::Auto,


### PR DESCRIPTION
This will cause two things to happen:
* If a test fails, it will automatically be retried.
* If a test succeeds the second or further times, it will be marked as
  successful but flaky.

While we don't do anything with flaky test data at the moment, this
should improve land reliability because spurious test failures will be
retried. In the future, we plan to start filing GitHub issues for flaky
tests.

Also add timestamps to testcases.

Example output: https://gist.github.com/sunshowers/c2dc0989cda41c5b9646e52768cf6088
JUnit output: https://gist.github.com/sunshowers/74acf9d7b594698157157758dcfebff6