### PR TITLE
Cherry-pick PR #8247 into release-1.2: ci: pin the azcopy version used for the transaction reply job

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -4,8 +4,8 @@ on:
   schedule:
     - cron: "14 14 * * *"
   # Uncomment below to test.
-  #push:
-  #  branches: [gha-test-*, canary, auto]
+  # push:
+  #   branches: [gha-test-*, canary, auto]
 
 jobs:
   audit:
@@ -98,7 +98,7 @@ jobs:
       - name: install azcopy
         run: |
           # Download AzCopy
-          curl -sL -o downloadazcopy-v10-linux "https://aka.ms/downloadazcopy-v10-linux"
+          curl -sL -o downloadazcopy-v10-linux "https://azcopyvnext.azureedge.net/release20210226/azcopy_linux_amd64_10.9.0.tar.gz"
           # Expand Archive
           tar -xvf downloadazcopy-v10-linux
           # Move AzCopy to the destination you want to store it

--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update && \
 RUN ln -s /usr/bin/python3 /usr/local/bin/python
 COPY docker/tools/boto.cfg /etc
 
-RUN cd /usr/local/bin && wget https://aka.ms/downloadazcopy-v10-linux -O- | tar --gzip --wildcards --extract '*/azcopy' --strip-components=1 --no-same-owner && chmod +x azcopy
+RUN cd /usr/local/bin && wget https://azcopyvnext.azureedge.net/release20210226/azcopy_linux_amd64_10.9.0.tar.gz -O- | tar --gzip --wildcards --extract '*/azcopy' --strip-components=1 --no-same-owner && chmod +x azcopy
 RUN wget https://storage.googleapis.com/pub/gsutil.tar.gz -O- | tar --gzip --directory /opt --extract && ln -s /opt/gsutil/gsutil /usr/local/bin
 
 COPY --from=builder /diem/target/release/diem-genesis-tool /usr/local/bin


### PR DESCRIPTION
This cherry-pick was triggerd by a request on #8247
Please review the diff to ensure there are not any unexpected changes.


            
cc @sausagee