### PR TITLE
Cherry-pick GHA changes into release-1.2

### DIFF
--- a/.github/workflows/ci-publish-base-image.yml
+++ b/.github/workflows/ci-publish-base-image.yml
@@ -18,6 +18,9 @@ jobs:
     continue-on-error: false
     env:
       DOCKERHUB_ORG: diem
+    environment:
+      name: Docker
+      url: https://hub.docker.com/u/diem
     steps:
       - uses: actions/checkout@v2
         with:
@@ -37,11 +40,11 @@ jobs:
       - name: Sign in to dockerhub, install image signing cert.
         uses: ./.github/actions/dockerhub_login
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          key_material: ${{ secrets.DOCKERHUB_KEY_MATERIAL }}
-          key_name: ${{ secrets.DOCKERHUB_KEY_NAME }}
-          key_password: ${{ secrets.DOCKERHUB_KEY_PASSWORD }}
+          username: ${{ secrets.ENV_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.ENV_DOCKERHUB_PASSWORD }}
+          key_material: ${{ secrets.ENV_DOCKERHUB_KEY_MATERIAL }}
+          key_name: ${{ secrets.ENV_DOCKERHUB_KEY_NAME }}
+          key_password: ${{ secrets.ENV_DOCKERHUB_KEY_PASSWORD }}
       - name: Push to dockerhub.
         run: |
           if [[ "$DOCKERHUB_LOGGED_IN" == true ]]; then
@@ -52,4 +55,4 @@ jobs:
             docker push --disable-content-trust=${disable_content_trust} ${{ env.DOCKERHUB_ORG }}/build_environment:${{ steps.changes.outputs.changes-target-branch }}
           fi
         env:
-          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKERHUB_KEY_PASSWORD }}
+          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.ENV_DOCKERHUB_KEY_PASSWORD }}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -24,6 +24,7 @@ jobs:
       changes-pull-request-number: ${{ steps.changes.outputs.changes-pull-request-number }}
       build-images: ${{ steps.need-build-images.outputs.changes-found }}
       need-base-images: ${{ steps.need-base-images.outputs.need-extra }}
+      test-land-blocking: ${{ steps.need-land-blocking-test.outputs.need-lbt }}
       test-rust-environment: ${{ steps.environment.outputs.name }}
       test-rust: ${{ steps.rust-changes.outputs.changes-found }}
       test-helm: ${{ steps.helm-changes.outputs.changes-found }}
@@ -51,12 +52,24 @@ jobs:
         with:
           pattern: '^documentation\|^developers.diem.com'
           invert: "true"
+      - id: need-land-blocking-test
+        name: check KS if LBT should be run
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          res=true
+          ks="${{ secrets.KILL_SWITCH_LAND_BLOCKING_TEST }}"
+          if ! [[ -z "${ks}" ]] && [[ "${ks}" =~ .*"${{ steps.changes.outputs.changes-target-branch }}".* ]]; then
+            echo "killswitch activated! Will skip land-blocking-test";
+            res=false
+          fi
+          echo "::set-output name=need-lbt::$(echo $res)";
       - id: need-base-images
         name: build extra images if it is needed by LBT
         if: ${{ github.event_name == 'push' }}
         run: |
           res=true
-          if ${{ secrets.KILL_SWITCH_LAND_BLOCKING_COMPAT }}; then
+          ks="${{ secrets.KILL_SWITCH_LAND_BLOCKING_COMPAT }}"
+          if ! [[ -z "${ks}" ]] && [[ "${ks}" =~ .*"${{ steps.changes.outputs.changes-target-branch }}".* ]] || ${{ steps.need-land-blocking-test.outputs.need-lbt != 'true' }}; then
             echo "Compat killswitch activated! Will run land_blocking suite";
             res=false
           else
@@ -255,7 +268,7 @@ jobs:
     name: Run land blocking test
     runs-on: self-hosted
     needs: [prepare, build-images, need-base-images]
-    if: ${{ always() && needs.build-images.result=='success' }}
+    if: ${{ always() && needs.build-images.result=='success' && needs.prepare.outputs.test-land-blocking == 'true' }}
     timeout-minutes: 45
     steps:
       - name: Launch cluster test

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -267,9 +267,9 @@ jobs:
           echo "CTI_OUTPUT_LOG=$CTI_OUTPUT_LOG" >> $GITHUB_ENV
           cmd=""
           if ${{ needs.need-base-images.result!='success' }}; then
-            cmd="./scripts/cti --tag ${{ needs.build-images.outputs.head-tag }} -E RUST_LOG=debug --report report.json --suite land_blocking"
+            cmd="./scripts/cti --tag ${{ needs.build-images.outputs.head-tag }} --report report.json --suite land_blocking"
           else
-            cmd="./scripts/cti --tag ${{ needs.need-base-images.outputs.prev-tag }} --cluster-test-tag ${{ needs.build-images.outputs.head-tag }} -E RUST_LOG=debug -E BATCH_SIZE=15 -E UPDATE_TO_TAG=${{ needs.build-images.outputs.head-tag }} --report report.json --suite land_blocking_compat"
+            cmd="./scripts/cti --tag ${{ needs.need-base-images.outputs.prev-tag }} --cluster-test-tag ${{ needs.build-images.outputs.head-tag }} -E BATCH_SIZE=15 -E UPDATE_TO_TAG=${{ needs.build-images.outputs.head-tag }} --report report.json --suite land_blocking_compat"
           fi
           eval $cmd
           ret=$?

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -57,23 +57,26 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         run: |
           res=true
-          ks="${{ secrets.KILL_SWITCH_LAND_BLOCKING_TEST }}"
-          if ! [[ -z "${ks}" ]] && [[ "${ks}" =~ .*"${{ steps.changes.outputs.changes-target-branch }}".* ]]; then
-            echo "killswitch activated! Will skip land-blocking-test";
+          branches="${{ secrets.BRANCHES_TO_ENABLE_LBT }}"
+          if ! [[ -z "${branches}" ]] && [[ "${branches}" =~ .*"${{ steps.changes.outputs.changes-target-branch }}".* ]]; then
+            echo "LBT is enabled for target branch. Will trigger it."
+          else
+            echo "LBT is NOT enabled for target branch. Will skip it."
             res=false
           fi
           echo "::set-output name=need-lbt::$(echo $res)";
       - id: need-base-images
         name: build extra images if it is needed by LBT
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && steps.need-land-blocking-test.outputs.need-lbt == 'true' }}
         run: |
           res=true
-          ks="${{ secrets.KILL_SWITCH_LAND_BLOCKING_COMPAT }}"
-          if ! [[ -z "${ks}" ]] && [[ "${ks}" =~ .*"${{ steps.changes.outputs.changes-target-branch }}".* ]] || ${{ steps.need-land-blocking-test.outputs.need-lbt != 'true' }}; then
-            echo "Compat killswitch activated! Will run land_blocking suite";
-            res=false
+          branches="${{ secrets.BRANCHES_TO_ENABLE_LBT_COMPAT_SUITE }}"
+          if ! [[ -z "${branches}" ]] && [[ "${branches}" =~ .*"${{ steps.changes.outputs.changes-target-branch }}".* ]];  then
+            echo "LBT compatibility suite is enabled. Will use land_blocking_compat suite."
+            echo "Will trigger base images build if they not found."
           else
-            echo "Will run land_blocking_compat suite"
+            echo "LBT compatibility sutie is NOT enabled. Will use land_blocking suite."
+            res=false
           fi
           echo "::set-output name=need-extra::$(echo $res)";
       - id: environment

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -119,6 +119,8 @@ jobs:
     if: ${{ github.event_name == 'push' && needs.prepare.outputs.build-images == 'true' }}
     outputs:
       head-tag: ${{ steps.push-to-novi-ecr.outputs.head-tag }}
+    environment:
+      name: Docker
     steps:
       - uses: actions/checkout@v2
         with:
@@ -130,24 +132,24 @@ jobs:
           workflow-file: docker-publish.yml
       - name: setup_aws_ecr_login
         run: |
-          echo 'AWS_ECR_ACCOUNT_URL=${{ secrets.AWS_ECR_ACCOUNT_NUM }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com' >> $GITHUB_ENV
+          echo 'AWS_ECR_ACCOUNT_URL=${{ secrets.ENV_NOVI_ECR_AWS_ACCOUNT_NUM }}.dkr.ecr.${{ secrets.ENV_NOVI_ECR_AWS_REGION }}.amazonaws.com' >> $GITHUB_ENV
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-access-key-id: ${{ secrets.ENV_NOVI_ECR_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ENV_NOVI_ECR_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.ENV_NOVI_ECR_AWS_REGION }}
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
       - name: Sign in to dockerhub, install image signing cert.
         uses: ./.github/actions/dockerhub_login
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          key_material: ${{ secrets.DOCKERHUB_KEY_MATERIAL }}
-          key_name: ${{ secrets.DOCKERHUB_KEY_NAME }}
-          key_password: ${{ secrets.DOCKERHUB_KEY_PASSWORD }}
+          username: ${{ secrets.ENV_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.ENV_DOCKERHUB_PASSWORD }}
+          key_material: ${{ secrets.ENV_DOCKERHUB_KEY_MATERIAL }}
+          key_name: ${{ secrets.ENV_DOCKERHUB_KEY_NAME }}
+          key_password: ${{ secrets.ENV_DOCKERHUB_KEY_PASSWORD }}
       - name: pre-release docker images
         run: |
           BRANCH="$CHANGES_TARGET_BRANCH"
@@ -166,7 +168,7 @@ jobs:
           fi
           exit $success
         env:
-          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKERHUB_KEY_PASSWORD }}
+          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.ENV_DOCKERHUB_KEY_PASSWORD }}
       - name: push to novi ecr
         id: push-to-novi-ecr
         run: |
@@ -174,7 +176,7 @@ jobs:
           BRANCH="$CHANGES_TARGET_BRANCH"
           GIT_REV=$(git rev-parse --short=8 HEAD)
           echo "::set-output name=head-tag::land_$GIT_REV";
-          aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | \
+          aws ecr get-login-password --region ${{ secrets.ENV_NOVI_ECR_AWS_REGION }} | \
           docker login --username AWS --password-stdin "${AWS_ECR_ACCOUNT_URL}"
           docker/docker_republish.sh -t pre_${BRANCH}_${GIT_REV} -o land_${GIT_REV} -r ${AWS_ECR_ACCOUNT_URL} -d
 

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -24,6 +24,7 @@ jobs:
       changes-pull-request-number: ${{ steps.changes.outputs.changes-pull-request-number }}
       build-images: ${{ steps.need-build-images.outputs.changes-found }}
       need-base-images: ${{ steps.need-base-images.outputs.need-extra }}
+      test-rust-environment: ${{ steps.environment.outputs.name }}
       test-rust: ${{ steps.rust-changes.outputs.changes-found }}
       test-helm: ${{ steps.helm-changes.outputs.changes-found }}
       test-dev-setup: ${{ steps.dev-setup-sh-changes.outputs.changes-found }}
@@ -62,6 +63,15 @@ jobs:
             echo "Will run land_blocking_compat suite"
           fi
           echo "::set-output name=need-extra::$(echo $res)";
+      - id: environment
+        name: Which environment should we use for secrets.
+        run: |
+          output=None
+          if ${{ github.event_name == 'push' }}; then
+            echo "will use sccache environment for rust builds";
+            output=Sccache
+          fi
+          echo "::set-output name=name::$(echo $output)";
       - id: rust-changes
         name: find rust/cargo changes.
         uses: ./.github/actions/matches
@@ -107,9 +117,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: ./.github/actions/check-machine
-        with:
-          webhook-gha-hardware: ${{ secrets.WEBHOOK_GHA_HARDWARE }}
       - name: build image with dev-setup.sh
         run: docker build -f docker/ci/${{ matrix.target_os }}/Dockerfile -t diem/build_environment:test .
 
@@ -431,9 +438,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: ./.github/actions/build-setup
-      - uses: ./.github/actions/check-machine
-        with:
-          webhook-gha-hardware: ${{ secrets.WEBHOOK_GHA_HARDWARE }}
       - name: shell lints
         run: |
           shellcheck scripts/dev_setup.sh && \
@@ -457,9 +461,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: ./.github/actions/check-machine
-        with:
-          webhook-gha-hardware: ${{ secrets.WEBHOOK_GHA_HARDWARE }}
       - uses: ./.github/actions/build-setup
       - uses: actions/cache@v2.1.4
         with:
@@ -480,7 +481,7 @@ jobs:
     runs-on: ubuntu-latest-xl
     timeout-minutes: 50
     needs: prepare
-    if: ${{ needs.prepare.outputs.test-rust == 'true' }}
+    if: ${{ needs.prepare.outputs.test-rust == 'true' && github.event_name == 'pull_request' }}
     container:
       image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
@@ -490,9 +491,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 #get all the history!!!
-      - uses: ./.github/actions/check-machine
-        with:
-          webhook-gha-hardware: ${{ secrets.WEBHOOK_GHA_HARDWARE }}
       - uses: ./.github/actions/build-setup
       - uses: actions/cache@v2.1.4
         with:
@@ -505,23 +503,21 @@ jobs:
           sccache -s
         env:
           TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
-          SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
-          SCCACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
       - name: run doctests
         run: |
           $pre_command && cargo xtest --doc --jobs ${max_threads} --unit --changed-since "origin/$TARGET_BRANCH"
           sccache -s
         env:
           TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
-          SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
-          SCCACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
       - uses: ./.github/actions/build-teardown
 
-  codegen-unit-test:
+  unit-test-sccache:
     runs-on: ubuntu-latest-xl
-    timeout-minutes: 60
+    timeout-minutes: 50
     needs: prepare
-    if: ${{ needs.prepare.outputs.test-rust == 'true' }}
+    if: ${{ needs.prepare.outputs.test-rust == 'true' && github.event_name == 'push' }}
+    environment:
+      name: Sccache
     container:
       image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
@@ -531,9 +527,44 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 #get all the history!!!
-      - uses: ./.github/actions/check-machine
+      - uses: ./.github/actions/build-setup
+      - uses: actions/cache@v2.1.4
         with:
-          webhook-gha-hardware: ${{ secrets.WEBHOOK_GHA_HARDWARE }}
+          path: "/opt/cargo/git\n/opt/cargo/registry\n/opt/cargo/.package-cache"
+          key: crates-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: "crates-${{ runner.os }}"
+      - name: run unit tests
+        run: |
+          $pre_command && cargo nextest --jobs ${max_threads} --unit --changed-since "origin/$TARGET_BRANCH"
+          sccache -s
+        env:
+          TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
+          SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.ENV_DIEM_S3_AWS_ACCESS_KEY_ID }}
+          SCCACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.ENV_DIEM_S3_AWS_SECRET_ACCESS_KEY }}
+      - name: run doctests
+        run: |
+          $pre_command && cargo xtest --doc --jobs ${max_threads} --unit --changed-since "origin/$TARGET_BRANCH"
+          sccache -s
+        env:
+          TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
+          SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.ENV_DIEM_S3_AWS_ACCESS_KEY_ID }}
+          SCCACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.ENV_DIEM_S3_AWS_SECRET_ACCESS_KEY }}
+      - uses: ./.github/actions/build-teardown
+
+  codegen-unit-test:
+    runs-on: ubuntu-latest-xl
+    timeout-minutes: 60
+    needs: prepare
+    if: ${{ needs.prepare.outputs.test-rust == 'true' && github.event_name == 'pull_request' }}
+    container:
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      volumes:
+        - "/home/runner/work/diem/diem:/opt/git/diem"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0 #get all the history!!!
       - uses: ./.github/actions/build-setup
       - uses: actions/cache@v2.1.4
         with:
@@ -544,8 +575,35 @@ jobs:
         run: $pre_command && cargo nextest --jobs ${max_threads} -p transaction-builder-generator --unit --changed-since "origin/$TARGET_BRANCH" --run-ignored=ignored-only
         env:
           TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
-          SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
-          SCCACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
+      - uses: ./.github/actions/build-teardown
+
+  codegen-unit-test-sccache:
+    runs-on: ubuntu-latest-xl
+    timeout-minutes: 60
+    needs: prepare
+    if: ${{ needs.prepare.outputs.test-rust == 'true' && github.event_name == 'push' }}
+    environment: Sccache
+    container:
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      volumes:
+        - "/home/runner/work/diem/diem:/opt/git/diem"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0 #get all the history!!!
+      - uses: ./.github/actions/build-setup
+      - uses: actions/cache@v2.1.4
+        with:
+          path: "/opt/cargo/git\n/opt/cargo/registry\n/opt/cargo/.package-cache"
+          key: crates-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: "crates-${{ runner.os }}"
+      - name: run codegen unit tests
+        run: $pre_command && cargo nextest --jobs ${max_threads} -p transaction-builder-generator --unit --changed-since "origin/$TARGET_BRANCH" --run-ignored=ignored-only
+        env:
+          TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
+          SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.ENV_DIEM_S3_AWS_ACCESS_KEY_ID }}
+          SCCACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.ENV_DIEM_S3_AWS_SECRET_ACCESS_KEY }}
       - uses: ./.github/actions/build-teardown
 
   e2e-test:
@@ -636,9 +694,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: ./.github/actions/check-machine
-        with:
-          webhook-gha-hardware: ${{ secrets.WEBHOOK_GHA_HARDWARE }}
       - name: install expect
         run: |
           sudo apt --assume-yes update
@@ -673,11 +728,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: ./.github/actions/check-machine
-        with:
-          min-cpu: 2
-          min-ram: 7
-          webhook-gha-hardware: ${{ secrets.WEBHOOK_GHA_HARDWARE }}
       - uses: ./.github/actions/build-setup
       - uses: actions/cache@v2.1.4
         with:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -927,7 +927,9 @@ jobs:
       - non-rust-lint
       - lint
       - unit-test
+      - unit-test-sccache
       - codegen-unit-test
+      - codegen-unit-test-sccache
       - e2e-test
       - docker-compose-test
       - crypto-unit-test
@@ -943,7 +945,9 @@ jobs:
           echo non-rust-lint: ${{ needs.non-rust-lint.result }}
           echo lint: ${{ needs.lint.result }}
           echo unit-test: ${{ needs.unit-test.result }}
+          echo unit-test-sccache: ${{ needs.unit-test-sccache.result }}
           echo codegen-unit-test: ${{ needs.codegen-unit-test.result }}
+          echo codegen-unit-test-sccache: ${{ needs.codegen-unit-test-sccache.result }}
           echo e2e-test: ${{ needs.e2e-test.result }}
           echo docker-compose-test: ${{ needs.docker-compose-test.result }}
           echo crypto-unit-test: ${{ needs.crypto-unit-test.result }}
@@ -958,7 +962,9 @@ jobs:
             && (needs.non-rust-lint.result=='success' || needs.non-rust-lint.result=='skipped')
             && (needs.lint.result=='success' || needs.lint.result=='skipped')
             && (needs.unit-test.result=='success' || needs.unit-test.result=='skipped')
+            && (needs.unit-test-sccache.result=='success' || needs.unit-test-sccache.result=='skipped')
             && (needs.codegen-unit-test.result=='success' || needs.codegen-unit-test.result=='skipped')
+            && (needs.codegen-unit-test-sccache.result=='success' || needs.codegen-unit-test-sccache.result=='skipped')
             && (needs.e2e-test.result=='success' || needs.e2e-test.result=='skipped')
             && (needs.docker-compose-test.result=='success' || needs.docker-compose-test.result=='skipped')
             && (needs.crypto-unit-test.result=='success' || needs.crypto-unit-test.result=='skipped')

--- a/.github/workflows/ci-update-sccache.yml
+++ b/.github/workflows/ci-update-sccache.yml
@@ -14,6 +14,8 @@ env:
 
 jobs:
   update-sccache-osx:
+    environment:
+      name: Sccache
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
@@ -48,7 +50,7 @@ jobs:
           echo stats:
           sccache -s
         env:
-          SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
-          SCCACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
+          SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.ENV_DIEM_S3_AWS_ACCESS_KEY_ID }}
+          SCCACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.ENV_DIEM_S3_AWS_SECRET_ACCESS_KEY }}
       - uses: ./.github/actions/build-teardown
         if: ${{ steps.rust-changes.outputs.changes-found == 'true' }}

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -123,7 +123,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release-branch: [release-1.1]
+        release-branch: [release-1.1, release-1.2]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -154,7 +154,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target-branch: [main, release-1.1]
+        target-branch: [main, release-1.1, release-1.2]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -170,9 +170,6 @@ jobs:
           cd /opt/git/diem/
           MVP_TEST_INCONSISTENCY=1 cargo test -p move-prover --release >> $MESSAGE_PAYLOAD_FILE
           sccache -s
-        env:
-          SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
-          SCCACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
       - uses: ./.github/actions/slack-file
         with:
           webhook: ${{ secrets.WEBHOOK_MOVE_PROVER }}

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         #this is a painful solution since it doesn't pick up new branches, other option is lotsa shell in one job....
         #to test in canary add in canary here.....
-        target-branch: [main, release-1.1]
+        target-branch: [main, release-1.1, release-1.2]
     env:
       MESSAGE_PAYLOAD_FILE: /tmp/message
     steps:
@@ -182,17 +182,20 @@ jobs:
 
   prune-docker-images:
     runs-on: ubuntu-latest
+    environment:
+      name: Docker
+      url: https://hub.docker.com/u/diem
     steps:
       - uses: actions/checkout@v2
       - name: sign in to DockerHub; install image signing cert
         uses: ./.github/actions/dockerhub_login
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          key_material: ${{ secrets.DOCKERHUB_KEY_MATERIAL }}
-          key_name: ${{ secrets.DOCKERHUB_KEY_NAME }}
-          key_password: ${{ secrets.DOCKERHUB_KEY_PASSWORD }}
+          username: ${{ secrets.ENV_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.ENV_DOCKERHUB_PASSWORD }}
+          key_material: ${{ secrets.ENV_DOCKERHUB_KEY_MATERIAL }}
+          key_name: ${{ secrets.ENV_DOCKERHUB_KEY_NAME }}
+          key_password: ${{ secrets.ENV_DOCKERHUB_KEY_PASSWORD }}
       - name: prune Docker image
         if: ${{ github.ref != 'refs/heads/auto' }}
         run: |
-          scripts/dockerhub_prune.sh -u "${{ secrets.DOCKERHUB_USERNAME }}" -p "${{ secrets.DOCKERHUB_PASSWORD }}" -x
+          scripts/dockerhub_prune.sh -u "${{ secrets.ENV_DOCKERHUB_USERNAME }}" -p "${{ secrets.ENV_DOCKERHUB_PASSWORD }}" -x

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,13 +24,13 @@ jobs:
           workflow-file: docker-publish.yml
       - name: setup_aws_ecr_login
         run: |
-          echo 'AWS_ECR_ACCOUNT_URL=${{ secrets.ENV_NOVI_ECR_AWS_ECR_ACCOUNT_NUM }}.dkr.ecr.${{ secrets.ENV_NOVI_ECR_AWS_REGION }}.amazonaws.com' >> $GITHUB_ENV
+          echo 'AWS_ECR_ACCOUNT_URL=${{ secrets.ENV_NOVI_ECR_AWS_ACCOUNT_NUM }}.dkr.ecr.${{ secrets.ENV_NOVI_ECR_AWS_REGION }}.amazonaws.com' >> $GITHUB_ENV
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.ENV_NOVI_ECR_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.ENV_NOVI_ECR_AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.ENV_NOVI_ECR_ECR_AWS_REGION }}
+          aws-region: ${{ secrets.ENV_NOVI_ECR_AWS_REGION }}
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,6 +10,9 @@ jobs:
     continue-on-error: false
     env:
       TAG: github-1
+    environment:
+      name: Docker
+      url: https://hub.docker.com/u/diem
     steps:
       - uses: actions/checkout@v2
         with:
@@ -21,24 +24,24 @@ jobs:
           workflow-file: docker-publish.yml
       - name: setup_aws_ecr_login
         run: |
-          echo 'AWS_ECR_ACCOUNT_URL=${{ secrets.AWS_ECR_ACCOUNT_NUM }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com' >> $GITHUB_ENV
+          echo 'AWS_ECR_ACCOUNT_URL=${{ secrets.ENV_NOVI_ECR_AWS_ECR_ACCOUNT_NUM }}.dkr.ecr.${{ secrets.ENV_NOVI_ECR_AWS_REGION }}.amazonaws.com' >> $GITHUB_ENV
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-access-key-id: ${{ secrets.ENV_NOVI_ECR_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ENV_NOVI_ECR_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.ENV_NOVI_ECR_ECR_AWS_REGION }}
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
       - name: Sign in to dockerhub, install image signing cert.
         uses: ./.github/actions/dockerhub_login
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          key_material: ${{ secrets.DOCKERHUB_KEY_MATERIAL }}
-          key_name: ${{ secrets.DOCKERHUB_KEY_NAME }}
-          key_password: ${{ secrets.DOCKERHUB_KEY_PASSWORD }}
+          username: ${{ secrets.ENV_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.ENV_DOCKERHUB_PASSWORD }}
+          key_material: ${{ secrets.ENV_DOCKERHUB_KEY_MATERIAL }}
+          key_name: ${{ secrets.ENV_DOCKERHUB_KEY_NAME }}
+          key_password: ${{ secrets.ENV_DOCKERHUB_KEY_PASSWORD }}
       - name: should pre build docker images (targeting a release branch)?
         if: ${{ github.ref == 'refs/heads/auto' }}
         run: |
@@ -64,7 +67,7 @@ jobs:
           fi
           exit $success
         env:
-          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKERHUB_KEY_PASSWORD }}
+          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.ENV_DOCKERHUB_KEY_PASSWORD }}
       - name: pull pre images (or build if not pullable) and push release docker images if not on auto branch.
         if: ${{ github.ref != 'refs/heads/auto' }}
         run: |
@@ -85,13 +88,13 @@ jobs:
           fi
           exit $success
         env:
-          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKERHUB_KEY_PASSWORD }}
+          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.ENV_DOCKERHUB_KEY_PASSWORD }}
       - name: push to novi ecr
         if: ${{ always() && github.ref != 'refs/heads/auto' }}
         run: |
           #push to novi ecr with standard names
           BRANCH=$(echo "$GITHUB_REF" | sed 's|.*/||' )
           GIT_REV=$(git rev-parse --short=8 HEAD)
-          aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | \
+          aws ecr get-login-password --region ${{ secrets.ENV_NOVI_ECR_AWS_REGION }} | \
           docker login --username AWS --password-stdin "${AWS_ECR_ACCOUNT_URL}"
           docker/docker_republish.sh -t ${BRANCH}_${GIT_REV} -r ${AWS_ECR_ACCOUNT_URL} -d


### PR DESCRIPTION
## Motivation
This pick includes the following 6 PRs on GHA workflows
- #8133: switch GHA to use env secrets
- #8153: fix typo in env secret
- #8171: disable debug log in LBT during PR landing
- #8168: add LBT kill switch
- #8190: rename LBT kill switch and rework its workflow
- #8199: failed CI workflow when sccache enabled unit test and codegen unit test fail 

## Test Plan
Canary + CI

## If targeting a release branch, please fill the below out as well

> * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)

This change affects GHA/CI workflow.  It does not affect mainnet or AOS.

> * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.

CI in-place + Canary (https://github.com/diem/diem/actions/runs/786131119)

> * Why we must have it for V1 launch.

This allows the oncalls to use one consistent CI workflow, secrets and runbook.  It also fixes the unintended ninja land.

> * What workarounds and alternative we have if we do not push the PR.

The alternative is to maintain the different sets of info above until the release-1.2 branch retires. 