### PR TITLE
[read/write set analysis] Remove Borrow access type

### DIFF
--- a/language/move-prover/bytecode/tests/read_write_set/borrow.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/borrow.exp
@@ -1,0 +1,55 @@
+============ initial translation from Move ================
+
+[variant baseline]
+fun Borrow::borrow_s($t0|a: address) {
+     var $t1: address
+     var $t2: &Borrow::S
+  0: $t1 := copy($t0)
+  1: $t2 := borrow_global<Borrow::S>($t1)
+  2: destroy($t2)
+  3: return ()
+}
+
+
+[variant baseline]
+fun Borrow::borrow_s_mut($t0|a: address) {
+     var $t1: address
+     var $t2: &mut Borrow::S
+  0: $t1 := copy($t0)
+  1: $t2 := borrow_global<Borrow::S>($t1)
+  2: destroy($t2)
+  3: return ()
+}
+
+============ after pipeline `read_write_set` ================
+
+[variant baseline]
+fun Borrow::borrow_s($t0|a: address) {
+     var $t1: address
+     var $t2: &Borrow::S
+     # Accesses:
+     #
+     # Locals:
+     # Loc(0): Loc(0)
+     #
+  0: $t1 := copy($t0)
+  1: $t2 := borrow_global<Borrow::S>($t1)
+  2: destroy($t2)
+  3: return ()
+}
+
+
+[variant baseline]
+fun Borrow::borrow_s_mut($t0|a: address) {
+     var $t1: address
+     var $t2: &mut Borrow::S
+     # Accesses:
+     #
+     # Locals:
+     # Loc(0): Loc(0)
+     #
+  0: $t1 := copy($t0)
+  1: $t2 := borrow_global<Borrow::S>($t1)
+  2: destroy($t2)
+  3: return ()
+}

--- a/language/move-prover/bytecode/tests/read_write_set/borrow.move
+++ b/language/move-prover/bytecode/tests/read_write_set/borrow.move
@@ -1,0 +1,30 @@
+address 0x1 {
+module Borrow {
+    // TODO: figure out how to allow this dependency
+    // ensure that borrows get counted as reads when appropriate
+    //use 0x1::Vector;
+
+    struct S has key { }
+
+    // expected: read a/S
+    fun borrow_s(a: address) acquires S {
+        _ = borrow_global<S>(a)
+    }
+
+    // expected: read a/S
+    fun borrow_s_mut(a: address) acquires S {
+        _ = borrow_global_mut<S>(a)
+    }
+
+    /*// expected: read v/size
+    fun borrow_vec(v: &vector<u64>) {
+        let _ = Vector::borrow(v, 7);
+    }
+
+    // expected: read v/size
+    fun borrow_vec_mut(v: &vector<u64>) {
+        let _ = Vector::borrow_mut(v, 7);
+    }*/
+
+}
+}

--- a/language/move-prover/bytecode/tests/read_write_set/counter.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/counter.exp
@@ -66,7 +66,7 @@ fun Counter::call_increment1($t0|s: &mut Counter::S) {
      var $t1: &mut Counter::S
      var $t2: &mut u64
      # Accesses:
-     # Loc(0)/f: ReadWriteBorrow
+     # Loc(0)/f: ReadWrite
      #
      # Locals:
      # Loc(0): Loc(0)
@@ -84,8 +84,7 @@ fun Counter::call_increment2($t0|a: address) {
      var $t1: address
      var $t2: &mut Counter::S
      # Accesses:
-     # Loc(0)/0x1::Counter::S: Borrow
-     # Loc(0)/0x1::Counter::S/f: ReadWriteBorrow
+     # Loc(0)/0x1::Counter::S/f: ReadWrite
      #
      # Locals:
      # Loc(0): Loc(0)
@@ -105,7 +104,7 @@ fun Counter::increment1($t0|i: &mut u64) {
      var $t4: u64
      var $t5: &mut u64
      # Accesses:
-     # Loc(0): ReadWriteBorrow
+     # Loc(0): ReadWrite
      #
      # Locals:
      #
@@ -129,7 +128,7 @@ fun Counter::increment2($t0|s: &mut Counter::S) {
      var $t6: &mut Counter::S
      var $t7: &mut u64
      # Accesses:
-     # Loc(0)/f: ReadWriteBorrow
+     # Loc(0)/f: ReadWrite
      #
      # Locals:
      # Loc(0): Loc(0)

--- a/language/move-prover/bytecode/tests/read_write_set/functions.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/functions.exp
@@ -90,7 +90,6 @@ public fun Funtions::call_write_vec($t0|a: address, $t1|v: vector<u8>) {
      var $t3: &mut Funtions::R
      var $t4: vector<u8>
      # Accesses:
-     # Loc(0)/0x1::Funtions::R: Borrow
      # Loc(0)/0x1::Funtions::R/v: Write
      #
      # Locals:

--- a/language/move-prover/bytecode/tests/read_write_set/summary.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/summary.exp
@@ -51,8 +51,6 @@ public fun Summary::write_caller2($t0|a: address) {
 public fun Summary::write_addr() {
      var $t0: address
      # Accesses:
-     # 0x777/0x2::Summary::S1: Borrow
-     # 0x777/0x2::Summary::S1/s2: Borrow
      # 0x777/0x2::Summary::S1/s2/f: Write
      #
      # Locals:
@@ -88,7 +86,6 @@ public fun Summary::write_caller1($t0|a: address) {
      var $t1: address
      var $t2: &mut Summary::S2
      # Accesses:
-     # Loc(0)/0x2::Summary::S2: Borrow
      # Loc(0)/0x2::Summary::S2/f: Write
      #
      # Locals:
@@ -107,8 +104,6 @@ public fun Summary::write_caller2($t0|a: address) {
      var $t2: &mut Summary::S1
      var $t3: &mut Summary::S2
      # Accesses:
-     # Loc(0)/0x2::Summary::S1: Borrow
-     # Loc(0)/0x2::Summary::S1/s2: Borrow
      # Loc(0)/0x2::Summary::S1/s2/f: Write
      #
      # Locals:


### PR DESCRIPTION
This access type was useful for sanity checks when building/debugging the initial analysis. But it is not needed by clients and just takes up space in the abstract state.