### PR TITLE
[read/writes set analysis] always use weak updates in access domain

### DIFF
--- a/language/move-prover/bytecode/src/read_write_set_analysis.rs
+++ b/language/move-prover/bytecode/src/read_write_set_analysis.rs
@@ -193,7 +193,8 @@ impl ReadWriteSetState {
             .iter()
         {
             if let Addr::Footprint(ap) = p {
-                self.accesses.update_access_path(ap.clone(), Some(access))
+                self.accesses
+                    .update_access_path_weak(ap.clone(), Some(access))
             }
         }
     }
@@ -204,7 +205,7 @@ impl ReadWriteSetState {
         let extended_aps = borrowed.add_offset(offset);
         for ap in extended_aps.footprint_paths() {
             self.accesses
-                .update_access_path(ap.clone(), Some(access_type))
+                .update_access_path_weak(ap.clone(), Some(access_type))
         }
     }
 
@@ -222,7 +223,7 @@ impl ReadWriteSetState {
             self.locals
                 .update_access_path(ap.clone(), Some(AbsAddr::footprint(ap.clone())));
             self.accesses
-                .update_access_path(ap.clone(), Some(access_type))
+                .update_access_path_weak(ap.clone(), Some(access_type))
         }
         self.locals.bind_local(ret, extended_aps)
     }
@@ -356,7 +357,7 @@ impl<'a> TransferFunctions for ReadWriteSetAnalysis<'a> {
                                 state.locals.update_access_path(extended_ap.clone(), None);
                                 state
                                     .accesses
-                                    .update_access_path(extended_ap, Some(Access::Borrow))
+                                    .update_access_path_weak(extended_ap, Some(Access::Borrow))
                             }
                             Addr::Constant(c) => {
                                 let extended_ap = AccessPath::new_address_constant(

--- a/language/move-prover/bytecode/tests/read_write_set/counter.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/counter.exp
@@ -1,0 +1,147 @@
+============ initial translation from Move ================
+
+[variant baseline]
+fun Counter::call_increment1($t0|s: &mut Counter::S) {
+     var $t1: &mut Counter::S
+     var $t2: &mut u64
+  0: $t1 := move($t0)
+  1: $t2 := borrow_field<Counter::S>.f($t1)
+  2: Counter::increment1($t2)
+  3: return ()
+}
+
+
+[variant baseline]
+fun Counter::call_increment2($t0|a: address) {
+     var $t1: address
+     var $t2: &mut Counter::S
+  0: $t1 := copy($t0)
+  1: $t2 := borrow_global<Counter::S>($t1)
+  2: Counter::increment2($t2)
+  3: return ()
+}
+
+
+[variant baseline]
+fun Counter::increment1($t0|i: &mut u64) {
+     var $t1: &mut u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: &mut u64
+  0: $t1 := copy($t0)
+  1: $t2 := read_ref($t1)
+  2: $t3 := 1
+  3: $t4 := +($t2, $t3)
+  4: $t5 := move($t0)
+  5: write_ref($t5, $t4)
+  6: return ()
+}
+
+
+[variant baseline]
+fun Counter::increment2($t0|s: &mut Counter::S) {
+     var $t1: &mut Counter::S
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: &mut Counter::S
+     var $t7: &mut u64
+  0: $t1 := copy($t0)
+  1: $t2 := borrow_field<Counter::S>.f($t1)
+  2: $t3 := read_ref($t2)
+  3: $t4 := 1
+  4: $t5 := +($t3, $t4)
+  5: $t6 := move($t0)
+  6: $t7 := borrow_field<Counter::S>.f($t6)
+  7: write_ref($t7, $t5)
+  8: return ()
+}
+
+============ after pipeline `read_write_set` ================
+
+[variant baseline]
+fun Counter::call_increment1($t0|s: &mut Counter::S) {
+     var $t1: &mut Counter::S
+     var $t2: &mut u64
+     # Accesses:
+     # Loc(0)/f: ReadWriteBorrow
+     #
+     # Locals:
+     # Loc(0): Loc(0)
+     # Loc(0)/f: Loc(0)/f
+     #
+  0: $t1 := move($t0)
+  1: $t2 := borrow_field<Counter::S>.f($t1)
+  2: Counter::increment1($t2)
+  3: return ()
+}
+
+
+[variant baseline]
+fun Counter::call_increment2($t0|a: address) {
+     var $t1: address
+     var $t2: &mut Counter::S
+     # Accesses:
+     # Loc(0)/0x1::Counter::S: Borrow
+     # Loc(0)/0x1::Counter::S/f: ReadWriteBorrow
+     #
+     # Locals:
+     # Loc(0): Loc(0)
+     #
+  0: $t1 := copy($t0)
+  1: $t2 := borrow_global<Counter::S>($t1)
+  2: Counter::increment2($t2)
+  3: return ()
+}
+
+
+[variant baseline]
+fun Counter::increment1($t0|i: &mut u64) {
+     var $t1: &mut u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: &mut u64
+     # Accesses:
+     # Loc(0): ReadWriteBorrow
+     #
+     # Locals:
+     #
+  0: $t1 := copy($t0)
+  1: $t2 := read_ref($t1)
+  2: $t3 := 1
+  3: $t4 := +($t2, $t3)
+  4: $t5 := move($t0)
+  5: write_ref($t5, $t4)
+  6: return ()
+}
+
+
+[variant baseline]
+fun Counter::increment2($t0|s: &mut Counter::S) {
+     var $t1: &mut Counter::S
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: &mut Counter::S
+     var $t7: &mut u64
+     # Accesses:
+     # Loc(0)/f: ReadWriteBorrow
+     #
+     # Locals:
+     # Loc(0): Loc(0)
+     # Loc(0)/f: Loc(0)/f
+     #
+  0: $t1 := copy($t0)
+  1: $t2 := borrow_field<Counter::S>.f($t1)
+  2: $t3 := read_ref($t2)
+  3: $t4 := 1
+  4: $t5 := +($t3, $t4)
+  5: $t6 := move($t0)
+  6: $t7 := borrow_field<Counter::S>.f($t6)
+  7: write_ref($t7, $t5)
+  8: return ()
+}

--- a/language/move-prover/bytecode/tests/read_write_set/counter.move
+++ b/language/move-prover/bytecode/tests/read_write_set/counter.move
@@ -1,0 +1,21 @@
+address 0x1 {
+module Counter {
+  struct S has key { f: u64 }
+
+  fun increment1(i: &mut u64) {
+      *i = *i + 1
+  }
+
+  fun increment2(s: &mut S) {
+      *&mut s.f = *&mut s.f + 1
+  }
+
+  fun call_increment1(s: &mut S) {
+      increment1(&mut s.f)
+  }
+
+  fun call_increment2(a: address) acquires S {
+      increment2(borrow_global_mut<S>(a))
+  }
+}
+}


### PR DESCRIPTION
The access domain is tracking which memory locations have been read/written, so it is never appropriate to perform a strong update.
Added a test where the analysis would previously perform an incorrect strong update, but now does the right thing.