### PR TITLE
[transaction-replay] Implement an api for fetching annotated event data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2272,6 +2272,7 @@ dependencies = [
  "diem-workspace-hack",
  "diemdb",
  "difference",
+ "hex",
  "move-binary-format",
  "move-cli",
  "move-core-types",

--- a/language/diem-tools/diem-validator-interface/src/json_rpc_interface.rs
+++ b/language/diem-tools/diem-validator-interface/src/json_rpc_interface.rs
@@ -8,6 +8,8 @@ use diem_types::{
     account_address::AccountAddress,
     account_state::AccountState,
     account_state_blob::AccountStateBlob,
+    contract_event::EventWithProof,
+    event::EventKey,
     transaction::{Transaction, Version},
 };
 use std::convert::TryFrom;
@@ -42,6 +44,23 @@ impl DiemValidatorInterface for JsonRpcDebuggerInterface {
             }
             None => None,
         })
+    }
+
+    fn get_events(
+        &self,
+        key: &EventKey,
+        start_seq: u64,
+        limit: u64,
+    ) -> Result<Vec<EventWithProof>> {
+        let events = self
+            .client
+            .get_events_with_proofs(key.to_string().as_str(), start_seq, limit)?
+            .into_inner();
+        let mut result = vec![];
+        for event in events {
+            result.push(bcs::from_bytes(event.event_with_proof.inner())?);
+        }
+        Ok(result)
     }
 
     fn get_committed_transactions(&self, start: Version, limit: u64) -> Result<Vec<Transaction>> {

--- a/language/diem-tools/diem-validator-interface/src/lib.rs
+++ b/language/diem-tools/diem-validator-interface/src/lib.rs
@@ -14,6 +14,8 @@ use diem_types::{
     account_address::AccountAddress,
     account_config,
     account_state::AccountState,
+    contract_event::EventWithProof,
+    event::EventKey,
     on_chain_config::ValidatorSet,
     transaction::{Transaction, Version},
 };
@@ -25,6 +27,8 @@ pub trait DiemValidatorInterface: Sync {
         account: AccountAddress,
         version: Version,
     ) -> Result<Option<AccountState>>;
+    fn get_events(&self, key: &EventKey, start_seq: u64, limit: u64)
+        -> Result<Vec<EventWithProof>>;
     fn get_committed_transactions(&self, start: Version, limit: u64) -> Result<Vec<Transaction>>;
     fn get_latest_version(&self) -> Result<Version>;
     fn get_version_by_account_sequence(

--- a/language/diem-tools/diem-validator-interface/src/storage_interface.rs
+++ b/language/diem-tools/diem-validator-interface/src/storage_interface.rs
@@ -7,11 +7,13 @@ use diem_config::config::RocksdbConfig;
 use diem_types::{
     account_address::AccountAddress,
     account_state::AccountState,
+    contract_event::EventWithProof,
+    event::EventKey,
     transaction::{Transaction, Version},
 };
 use diemdb::DiemDB;
 use std::{convert::TryFrom, path::Path, sync::Arc};
-use storage_interface::DbReader;
+use storage_interface::{DbReader, Order};
 
 pub struct DBDebuggerInterface(Arc<dyn DbReader>);
 
@@ -39,6 +41,15 @@ impl DiemValidatorInterface for DBDebuggerInterface {
             .transpose()
     }
 
+    fn get_events(
+        &self,
+        key: &EventKey,
+        start_seq: u64,
+        limit: u64,
+    ) -> Result<Vec<EventWithProof>> {
+        self.0
+            .get_events_with_proofs(key, start_seq, Order::Ascending, limit, None)
+    }
     fn get_committed_transactions(&self, start: Version, limit: u64) -> Result<Vec<Transaction>> {
         Ok(self
             .0

--- a/language/diem-tools/transaction-replay/Cargo.toml
+++ b/language/diem-tools/transaction-replay/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.38"
 structopt = "0.3.21"
+hex = "0.4.3"
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 diem-types = { path = "../../../types" }
 diem-state-view = { path = "../../../storage/state-view" }

--- a/language/diem-tools/transaction-replay/src/main.rs
+++ b/language/diem-tools/transaction-replay/src/main.rs
@@ -5,6 +5,7 @@ use anyhow::{bail, Result};
 use diem_transaction_replay::DiemDebugger;
 use diem_types::{
     account_address::AccountAddress,
+    event::EventKey,
     transaction::{TransactionPayload, Version},
 };
 use difference::Changeset;
@@ -29,10 +30,13 @@ struct Opt {
 
 #[derive(Debug, StructOpt)]
 enum Command {
+    /// Replay transactions starting from version `start` to `start + limit`.
     #[structopt(name = "replay-transactions")]
     ReplayTransactions { start: Version, limit: u64 },
+    /// Replay the last `txns` committed transactions.
     #[structopt(name = "replay-recent-transactions")]
     ReplayRecentTransactions { txns: u64 },
+    /// Replay the `seq`th transaction committed by `account`
     #[structopt(name = "replay-transaction-by-sequence-number")]
     ReplayTransactionBySequence {
         #[structopt(parse(try_from_str))]
@@ -47,14 +51,20 @@ enum Command {
         write_set_blob_path: PathBuf,
         version: u64,
     },
+    /// Annotate the resources stored under `account` at `version`.
     #[structopt(name = "annotate-account")]
     AnnotateAccount {
         #[structopt(parse(try_from_str))]
         account: AccountAddress,
-        version: Version,
+        version: Option<Version>,
     },
+    /// Annotate the resources stored under `diem_root`, `treasury_compliance` and all validator addresses.
     #[structopt(name = "annotate-key-accounts")]
     AnnotateKeyAccounts { version: Version },
+    /// Annotate the events stored under `key` with range `start` to `start+limit`.
+    #[structopt(name = "annotate-events")]
+    AnnotateEvents { key: String, start: u64, limit: u64 },
+    /// Diff between the resources stored under two versions of the same `account`
     #[structopt(name = "diff-account")]
     DiffAccount {
         #[structopt(parse(try_from_str))]
@@ -140,12 +150,28 @@ fn main() -> Result<()> {
                 )?
             );
         }
-        Command::AnnotateAccount { account, version } => println!(
-            "{}",
-            debugger
-                .annotate_account_state_at_version(account, version, opt.save_write_sets)?
-                .expect("Account not found")
-        ),
+        Command::AnnotateAccount {
+            account,
+            version: version_opt,
+        } => {
+            let version = match version_opt {
+                Some(v) => v,
+                None => debugger.get_latest_version()?,
+            };
+            println!(
+                "{}",
+                debugger
+                    .annotate_account_state_at_version(account, version, opt.save_write_sets)?
+                    .expect("Account not found")
+            )
+        }
+        Command::AnnotateEvents { key, start, limit } => {
+            debugger.pretty_print_events(
+                &EventKey::from_bytes(hex::decode(key.as_str())?)?,
+                start,
+                limit,
+            )?;
+        }
         Command::AnnotateKeyAccounts { version } => {
             for (addr, state) in
                 debugger.annotate_key_accounts_at_version(version, opt.save_write_sets)?

--- a/language/diem-tools/transaction-replay/src/unit_tests/mod.rs
+++ b/language/diem-tools/transaction-replay/src/unit_tests/mod.rs
@@ -9,6 +9,8 @@ use diem_types::{
     account_address::AccountAddress,
     account_state::AccountState,
     account_state_blob::AccountStateBlob,
+    contract_event::EventWithProof,
+    event::EventKey,
     transaction::{Transaction, Version, WriteSetPayload},
     write_set::WriteOp,
 };
@@ -93,6 +95,15 @@ impl DiemValidatorInterface for TestInterface {
 
     fn get_latest_version(&self) -> Result<Version> {
         Ok(self.latest_version)
+    }
+
+    fn get_events(
+        &self,
+        _key: &EventKey,
+        _start_seq: u64,
+        _limit: u64,
+    ) -> Result<Vec<EventWithProof>> {
+        unimplemented!()
     }
 
     fn get_version_by_account_sequence(


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Added a command to fetch events stored on chain and annotate them with `transaction-replay`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Spawned a local network and did following command:
```
cargo run --bin diem-transaction-replay -- --url http://localhost:54278 annotate-events 01000000000000000000000000000000000000000a550c18 0 1 
```

The result look like following:
```
Transaction Version: 4
Event index: 0
Event payload: drop store 0x1::DiemAccount::AdminTransactionEvent {
    committed_timestamp_secs: 1619474369
}
```