### PR TITLE
[diem-vm] Adjust the internal api for diem-vm

### DIFF
--- a/language/diem-tools/writeset-transaction-generator/src/writeset_builder.rs
+++ b/language/diem-tools/writeset-transaction-generator/src/writeset_builder.rs
@@ -16,13 +16,13 @@ use move_core_types::{
     value::{serialize_values, MoveValue},
 };
 use move_vm_runtime::{
-    data_cache::RemoteCache, logging::NoContextLog, move_vm::MoveVM, session::Session,
+    data_cache::MoveStorage, logging::NoContextLog, move_vm::MoveVM, session::Session,
 };
 use move_vm_types::gas_schedule::GasStatus;
 
-pub struct GenesisSession<'r, 'l, R>(Session<'r, 'l, R>);
+pub struct GenesisSession<'r, 'l, S>(Session<'r, 'l, S>);
 
-impl<'r, 'l, R: RemoteCache> GenesisSession<'r, 'l, R> {
+impl<'r, 'l, S: MoveStorage> GenesisSession<'r, 'l, S> {
     pub fn exec_func(
         &mut self,
         module_name: &str,

--- a/language/diem-vm/src/data_cache.rs
+++ b/language/diem-vm/src/data_cache.rs
@@ -19,7 +19,7 @@ use move_core_types::{
     account_address::AccountAddress,
     language_storage::{ModuleId, StructTag},
 };
-use move_vm_runtime::data_cache::RemoteCache;
+use move_vm_runtime::data_cache::MoveStorage;
 use std::collections::btree_map::BTreeMap;
 
 /// A local cache for a given a `StateView`. The cache is private to the Diem layer
@@ -107,7 +107,7 @@ impl<'block> StateView for StateViewCache<'block> {
     }
 }
 
-impl<'block> RemoteCache for StateViewCache<'block> {
+impl<'block> MoveStorage for StateViewCache<'block> {
     fn get_module(&self, module_id: &ModuleId) -> VMResult<Option<Vec<u8>>> {
         RemoteStorage::new(self).get_module(module_id)
     }
@@ -142,7 +142,7 @@ impl<'a, S: StateView> RemoteStorage<'a, S> {
     }
 }
 
-impl<'a, S: StateView> RemoteCache for RemoteStorage<'a, S> {
+impl<'a, S: StateView> MoveStorage for RemoteStorage<'a, S> {
     fn get_module(&self, module_id: &ModuleId) -> VMResult<Option<Vec<u8>>> {
         // REVIEW: cache this?
         let ap = AccessPath::from(module_id);

--- a/language/diem-vm/src/diem_vm.rs
+++ b/language/diem-vm/src/diem_vm.rs
@@ -31,7 +31,7 @@ use move_core_types::{
     value::{serialize_values, MoveValue},
 };
 use move_vm_runtime::{
-    data_cache::RemoteCache,
+    data_cache::MoveStorage,
     logging::{expect_no_verification_errors, LogContext},
     move_vm::MoveVM,
     session::Session,
@@ -205,9 +205,9 @@ impl DiemVMImpl {
 
     /// Run the prologue of a transaction by calling into `SCRIPT_PROLOGUE_NAME` function stored
     /// in the `ACCOUNT_MODULE` on chain.
-    pub(crate) fn run_script_prologue<R: RemoteCache>(
+    pub(crate) fn run_script_prologue<S: MoveStorage>(
         &self,
-        session: &mut Session<R>,
+        session: &mut Session<S>,
         txn_data: &TransactionMetadata,
         account_currency_symbol: &IdentStr,
         log_context: &impl LogContext,
@@ -246,9 +246,9 @@ impl DiemVMImpl {
 
     /// Run the prologue of a transaction by calling into `MODULE_PROLOGUE_NAME` function stored
     /// in the `ACCOUNT_MODULE` on chain.
-    pub(crate) fn run_module_prologue<R: RemoteCache>(
+    pub(crate) fn run_module_prologue<S: MoveStorage>(
         &self,
-        session: &mut Session<R>,
+        session: &mut Session<S>,
         txn_data: &TransactionMetadata,
         account_currency_symbol: &IdentStr,
         log_context: &impl LogContext,
@@ -286,9 +286,9 @@ impl DiemVMImpl {
 
     /// Run the epilogue of a transaction by calling into `EPILOGUE_NAME` function stored
     /// in the `ACCOUNT_MODULE` on chain.
-    pub(crate) fn run_success_epilogue<R: RemoteCache>(
+    pub(crate) fn run_success_epilogue<S: MoveStorage>(
         &self,
-        session: &mut Session<R>,
+        session: &mut Session<S>,
         gas_status: &mut GasStatus,
         txn_data: &TransactionMetadata,
         account_currency_symbol: &IdentStr,
@@ -328,9 +328,9 @@ impl DiemVMImpl {
 
     /// Run the failure epilogue of a transaction by calling into `USER_EPILOGUE_NAME` function
     /// stored in the `ACCOUNT_MODULE` on chain.
-    pub(crate) fn run_failure_epilogue<R: RemoteCache>(
+    pub(crate) fn run_failure_epilogue<S: MoveStorage>(
         &self,
-        session: &mut Session<R>,
+        session: &mut Session<S>,
         gas_status: &mut GasStatus,
         txn_data: &TransactionMetadata,
         account_currency_symbol: &IdentStr,
@@ -366,9 +366,9 @@ impl DiemVMImpl {
 
     /// Run the prologue of a transaction by calling into `PROLOGUE_NAME` function stored
     /// in the `WRITESET_MODULE` on chain.
-    pub(crate) fn run_writeset_prologue<R: RemoteCache>(
+    pub(crate) fn run_writeset_prologue<S: MoveStorage>(
         &self,
-        session: &mut Session<R>,
+        session: &mut Session<S>,
         txn_data: &TransactionMetadata,
         log_context: &impl LogContext,
     ) -> Result<(), VMStatus> {
@@ -400,9 +400,9 @@ impl DiemVMImpl {
 
     /// Run the epilogue of a transaction by calling into `WRITESET_EPILOGUE_NAME` function stored
     /// in the `WRITESET_MODULE` on chain.
-    pub(crate) fn run_writeset_epilogue<R: RemoteCache>(
+    pub(crate) fn run_writeset_epilogue<S: MoveStorage>(
         &self,
-        session: &mut Session<R>,
+        session: &mut Session<S>,
         txn_data: &TransactionMetadata,
         should_trigger_reconfiguration: bool,
         log_context: &impl LogContext,
@@ -428,7 +428,7 @@ impl DiemVMImpl {
             })
     }
 
-    pub fn new_session<'r, R: RemoteCache>(&self, r: &'r R) -> Session<'r, '_, R> {
+    pub fn new_session<'r, R: MoveStorage>(&self, r: &'r R) -> Session<'r, '_, R> {
         self.move_vm.new_session(r)
     }
 }
@@ -526,7 +526,7 @@ pub fn convert_changeset_and_events(
     convert_changeset_and_events_cached(&mut (), changeset, events)
 }
 
-pub(crate) fn charge_global_write_gas_usage<R: RemoteCache>(
+pub(crate) fn charge_global_write_gas_usage<R: MoveStorage>(
     gas_status: &mut GasStatus,
     session: &Session<R>,
     sender: &AccountAddress,
@@ -543,9 +543,9 @@ pub(crate) fn charge_global_write_gas_usage<R: RemoteCache>(
         .map_err(|p_err| p_err.finish(Location::Undefined).into_vm_status())
 }
 
-pub(crate) fn get_transaction_output<A: AccessPathCache, R: RemoteCache>(
+pub(crate) fn get_transaction_output<A: AccessPathCache, S: MoveStorage>(
     ap_cache: &mut A,
-    session: Session<R>,
+    session: Session<S>,
     gas_left: GasUnits<GasCarrier>,
     txn_data: &TransactionMetadata,
     status: KeptVMStatus,

--- a/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
@@ -11,7 +11,7 @@ use move_core_types::{
     value::{serialize_values, MoveValue},
     vm_status::{StatusCode, StatusType},
 };
-use move_vm_runtime::{data_cache::RemoteCache, logging::NoContextLog, move_vm::MoveVM};
+use move_vm_runtime::{data_cache::MoveStorage, logging::NoContextLog, move_vm::MoveVM};
 use move_vm_test_utils::{DeltaStorage, InMemoryStorage};
 use move_vm_types::gas_schedule::GasStatus;
 
@@ -532,7 +532,7 @@ struct BogusStorage {
     bad_status_code: StatusCode,
 }
 
-impl RemoteCache for BogusStorage {
+impl MoveStorage for BogusStorage {
     fn get_module(&self, _module_id: &ModuleId) -> VMResult<Option<Vec<u8>>> {
         Err(PartialVMError::new(self.bad_status_code).finish(Location::Undefined))
     }

--- a/language/move-vm/runtime/src/move_vm.rs
+++ b/language/move-vm/runtime/src/move_vm.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{data_cache::RemoteCache, runtime::VMRuntime, session::Session};
+use crate::{data_cache::MoveStorage, runtime::VMRuntime, session::Session};
 
 pub struct MoveVM {
     runtime: VMRuntime,
@@ -28,7 +28,7 @@ impl MoveVM {
     ///     cases where this may not be necessary, with the most notable one being the common module
     ///     publishing flow: you can keep using the same Move VM if you publish some modules in a Session
     ///     and apply the effects to the storage when the Session ends.
-    pub fn new_session<'r, R: RemoteCache>(&self, remote: &'r R) -> Session<'r, '_, R> {
+    pub fn new_session<'r, S: MoveStorage>(&self, remote: &'r S) -> Session<'r, '_, S> {
         self.runtime.new_session(remote)
     }
 }

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    data_cache::{RemoteCache, TransactionDataCache},
+    data_cache::{MoveStorage, TransactionDataCache},
     interpreter::Interpreter,
     loader::Loader,
     logging::LogContext,
@@ -47,7 +47,7 @@ impl VMRuntime {
         }
     }
 
-    pub fn new_session<'r, R: RemoteCache>(&self, remote: &'r R) -> Session<'r, '_, R> {
+    pub fn new_session<'r, S: MoveStorage>(&self, remote: &'r S) -> Session<'r, '_, S> {
         Session {
             runtime: self,
             data_cache: TransactionDataCache::new(remote, &self.loader),

--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    data_cache::{RemoteCache, TransactionDataCache},
+    data_cache::{MoveStorage, TransactionDataCache},
     logging::LogContext,
     runtime::VMRuntime,
 };
@@ -15,12 +15,12 @@ use move_core_types::{
 };
 use move_vm_types::gas_schedule::GasStatus;
 
-pub struct Session<'r, 'l, R> {
+pub struct Session<'r, 'l, S> {
     pub(crate) runtime: &'l VMRuntime,
-    pub(crate) data_cache: TransactionDataCache<'r, 'l, R>,
+    pub(crate) data_cache: TransactionDataCache<'r, 'l, S>,
 }
 
-impl<'r, 'l, R: RemoteCache> Session<'r, 'l, R> {
+impl<'r, 'l, S: MoveStorage> Session<'r, 'l, S> {
     /// Execute a Move function with the given arguments. This is mainly designed for an external
     /// environment to invoke system logic written in Move.
     ///

--- a/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashMap;
 
-use crate::{data_cache::RemoteCache, logging::NoContextLog, move_vm::MoveVM};
+use crate::{data_cache::MoveStorage, logging::NoContextLog, move_vm::MoveVM};
 use move_binary_format::{
     errors::{PartialVMResult, VMResult},
     file_format::{
@@ -237,7 +237,7 @@ impl RemoteStore {
     }
 }
 
-impl RemoteCache for RemoteStore {
+impl MoveStorage for RemoteStore {
     fn get_module(&self, module_id: &ModuleId) -> VMResult<Option<Vec<u8>>> {
         Ok(self.modules.get(module_id).cloned())
     }

--- a/language/move-vm/test-utils/src/storage.rs
+++ b/language/move-vm/test-utils/src/storage.rs
@@ -8,7 +8,7 @@ use move_core_types::{
     identifier::Identifier,
     language_storage::{ModuleId, StructTag},
 };
-use move_vm_runtime::data_cache::RemoteCache;
+use move_vm_runtime::data_cache::MoveStorage;
 // use move_vm_txn_effect_converter::convert_txn_effects_to_move_changeset_and_events;
 use move_binary_format::errors::{PartialVMResult, VMResult};
 use std::collections::{btree_map, BTreeMap};
@@ -23,7 +23,7 @@ impl BlankStorage {
     }
 }
 
-impl RemoteCache for BlankStorage {
+impl MoveStorage for BlankStorage {
     fn get_module(&self, _module_id: &ModuleId) -> VMResult<Option<Vec<u8>>> {
         Ok(None)
     }
@@ -45,7 +45,7 @@ pub struct DeltaStorage<'a, 'b, S> {
     delta: &'b ChangeSet,
 }
 
-impl<'a, 'b, S: RemoteCache> RemoteCache for DeltaStorage<'a, 'b, S> {
+impl<'a, 'b, S: MoveStorage> MoveStorage for DeltaStorage<'a, 'b, S> {
     fn get_module(&self, module_id: &ModuleId) -> VMResult<Option<Vec<u8>>> {
         if let Some(account_storage) = self.delta.accounts().get(module_id.address()) {
             if let Some(blob_opt) = account_storage.modules().get(module_id.name()) {
@@ -71,7 +71,7 @@ impl<'a, 'b, S: RemoteCache> RemoteCache for DeltaStorage<'a, 'b, S> {
     }
 }
 
-impl<'a, 'b, S: RemoteCache> DeltaStorage<'a, 'b, S> {
+impl<'a, 'b, S: MoveStorage> DeltaStorage<'a, 'b, S> {
     pub fn new(base: &'a S, delta: &'b ChangeSet) -> Self {
         Self { base, delta }
     }
@@ -185,7 +185,7 @@ impl InMemoryStorage {
     }
 }
 
-impl RemoteCache for InMemoryStorage {
+impl MoveStorage for InMemoryStorage {
     fn get_module(&self, module_id: &ModuleId) -> VMResult<Option<Vec<u8>>> {
         if let Some(account_storage) = self.accounts.get(module_id.address()) {
             return Ok(account_storage.modules.get(module_id.name()).cloned());

--- a/language/testing-infra/e2e-tests/src/data_store.rs
+++ b/language/testing-infra/e2e-tests/src/data_store.rs
@@ -18,7 +18,7 @@ use move_core_types::{
     account_address::AccountAddress,
     language_storage::{ModuleId, StructTag},
 };
-use move_vm_runtime::data_cache::RemoteCache;
+use move_vm_runtime::data_cache::MoveStorage;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use vm_genesis::{generate_genesis_change_set_for_testing, GenesisOptions};
@@ -107,7 +107,7 @@ impl StateView for FakeDataStore {
     }
 }
 
-impl RemoteCache for FakeDataStore {
+impl MoveStorage for FakeDataStore {
     fn get_module(&self, module_id: &ModuleId) -> VMResult<Option<Vec<u8>>> {
         RemoteStorage::new(self).get_module(module_id)
     }

--- a/language/tools/move-cli/src/on_disk_state_view.rs
+++ b/language/tools/move-cli/src/on_disk_state_view.rs
@@ -18,7 +18,7 @@ use move_core_types::{
     vm_status::StatusCode,
 };
 use move_lang::{MOVE_COMPILED_EXTENSION, MOVE_COMPILED_INTERFACES_DIR};
-use move_vm_runtime::data_cache::RemoteCache;
+use move_vm_runtime::data_cache::MoveStorage;
 use petgraph::graphmap::DiGraphMap;
 use resource_viewer::{AnnotatedMoveStruct, AnnotatedMoveValue, MoveValueAnnotator};
 
@@ -412,7 +412,7 @@ impl OnDiskStateView {
     }
 }
 
-impl RemoteCache for OnDiskStateView {
+impl MoveStorage for OnDiskStateView {
     fn get_module(&self, module_id: &ModuleId) -> VMResult<Option<Vec<u8>>> {
         self.get_module_bytes(module_id)
             .map_err(|_| PartialVMError::new(StatusCode::STORAGE_ERROR).finish(Location::Undefined))

--- a/language/tools/resource-viewer/src/lib.rs
+++ b/language/tools/resource-viewer/src/lib.rs
@@ -20,7 +20,7 @@ use move_core_types::{
     language_storage::{ModuleId, StructTag, TypeTag},
     value::{MoveStruct, MoveValue},
 };
-use move_vm_runtime::data_cache::RemoteCache;
+use move_vm_runtime::data_cache::MoveStorage;
 use std::{
     collections::btree_map::BTreeMap,
     convert::TryInto,
@@ -59,18 +59,18 @@ pub enum AnnotatedMoveValue {
 
 pub struct MoveValueAnnotator<'a> {
     cache: Resolver<'a>,
-    _data_view: &'a dyn RemoteCache,
+    _data_view: &'a dyn MoveStorage,
 }
 
 impl<'a> MoveValueAnnotator<'a> {
-    pub fn new(view: &'a dyn RemoteCache) -> Self {
+    pub fn new(view: &'a dyn MoveStorage) -> Self {
         Self {
             cache: Resolver::new(view, true),
             _data_view: view,
         }
     }
 
-    pub fn new_no_stdlib(view: &'a dyn RemoteCache) -> Self {
+    pub fn new_no_stdlib(view: &'a dyn MoveStorage) -> Self {
         Self {
             cache: Resolver::new(view, false),
             _data_view: view,
@@ -291,7 +291,7 @@ impl StateView for NullStateView {
     }
 }
 
-impl RemoteCache for NullStateView {
+impl MoveStorage for NullStateView {
     fn get_module(&self, _module_id: &ModuleId) -> VMResult<Option<Vec<u8>>> {
         Ok(None)
     }

--- a/language/tools/resource-viewer/src/resolver.rs
+++ b/language/tools/resource-viewer/src/resolver.rs
@@ -19,16 +19,16 @@ use move_core_types::{
     identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, StructTag, TypeTag},
 };
-use move_vm_runtime::data_cache::RemoteCache;
+use move_vm_runtime::data_cache::MoveStorage;
 use std::rc::Rc;
 
 pub(crate) struct Resolver<'a> {
-    state: &'a dyn RemoteCache,
+    state: &'a dyn MoveStorage,
     cache: ModuleCache,
 }
 
 impl<'a> Resolver<'a> {
-    pub fn new(state: &'a dyn RemoteCache, use_stdlib: bool) -> Self {
+    pub fn new(state: &'a dyn MoveStorage, use_stdlib: bool) -> Self {
         let cache = ModuleCache::new();
         if use_stdlib {
             let modules = diem_framework_releases::current_modules();


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Adjust the internal api for DiemVM to allow for a more generic transaction scheduler. The main change is to replace `StateViewCache` with a trait so that it could be replaced with some other data structure in the future.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

`cargo test`
