### PR TITLE
[move-prover] replace diem-temppath with tempfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,6 @@ dependencies = [
  "bytecode-verifier",
  "codespan-reporting",
  "datatest-stable",
- "diem-temppath",
  "diem-types",
  "diem-workspace-hack",
  "heck",
@@ -29,6 +28,7 @@ dependencies = [
  "move-prover",
  "move-prover-test-utils",
  "serde",
+ "tempfile",
 ]
 
 [[package]]
@@ -602,7 +602,6 @@ dependencies = [
  "codespan",
  "codespan-reporting",
  "datatest-stable",
- "diem-temppath",
  "diem-workspace-hack",
  "ir-to-bytecode",
  "itertools 0.10.0",
@@ -2699,7 +2698,6 @@ dependencies = [
  "codespan",
  "codespan-reporting",
  "datatest-stable",
- "diem-temppath",
  "diem-workspace-hack",
  "itertools 0.10.0",
  "log",
@@ -2710,6 +2708,7 @@ dependencies = [
  "once_cell",
  "regex",
  "serde",
+ "tempfile",
 ]
 
 [[package]]
@@ -4549,7 +4548,6 @@ dependencies = [
  "codespan",
  "codespan-reporting",
  "datatest-stable",
- "diem-temppath",
  "diem-workspace-hack",
  "docgen",
  "errmapgen",
@@ -4570,6 +4568,7 @@ dependencies = [
  "serde_json",
  "shell-words",
  "simplelog",
+ "tempfile",
  "tokio",
  "toml",
  "walkdir",

--- a/language/move-prover/Cargo.toml
+++ b/language/move-prover/Cargo.toml
@@ -17,7 +17,6 @@ abigen = { path = "abigen" }
 errmapgen = { path = "errmapgen" }
 bytecode = { path = "bytecode" }
 move-binary-format = { path = "../move-binary-format" }
-diem-temppath = { path = "../../common/temppath" }
 diem-workspace-hack = { path = "../../common/workspace-hack" }
 move-ir-types = { path = "../move-ir/types" }
 
@@ -46,6 +45,7 @@ datatest-stable = "0.1.1"
 move-prover-test-utils = { path = "test-utils" }
 shell-words = "1.0.0"
 walkdir = "2.3.1"
+tempfile = "3.2.0"
 
 [[test]]
 name = "testsuite"

--- a/language/move-prover/abigen/Cargo.toml
+++ b/language/move-prover/abigen/Cargo.toml
@@ -25,8 +25,8 @@ serde = { version = "1.0.124", features = ["derive"] }
 codespan-reporting = "0.8.0"
 move-prover = { path = ".." }
 datatest-stable = "0.1.1"
+tempfile = "3.2.0"
 move-prover-test-utils = { path = "../test-utils" }
-diem-temppath = { path = "../../../common/temppath" }
 
 [[test]]
 name = "testsuite"

--- a/language/move-prover/abigen/tests/testsuite.rs
+++ b/language/move-prover/abigen/tests/testsuite.rs
@@ -4,10 +4,10 @@
 use std::{ffi::OsStr, path::Path};
 
 use codespan_reporting::term::termcolor::Buffer;
-use diem_temppath::TempPath;
 use move_prover::{cli::Options, run_move_prover};
 use move_prover_test_utils::baseline_test::verify_or_update_baseline;
 use std::path::PathBuf;
+use tempfile::TempDir;
 
 #[allow(unused_imports)]
 use log::debug;
@@ -49,7 +49,7 @@ fn get_generated_abis(dir: &Path) -> std::io::Result<Vec<String>> {
 }
 
 fn test_abigen(path: &Path, mut options: Options, suffix: &str) -> anyhow::Result<()> {
-    let temp_path = PathBuf::from(TempPath::new().path());
+    let temp_path = PathBuf::from(TempDir::new()?.path());
     options.abigen.output_directory = temp_path.to_string_lossy().to_string();
 
     let mut error_writer = Buffer::no_color();

--- a/language/move-prover/bytecode/Cargo.toml
+++ b/language/move-prover/bytecode/Cargo.toml
@@ -33,7 +33,6 @@ datatest-stable = "0.1.1"
 move-prover-test-utils = { path = "../test-utils" }
 codespan = "0.8.0"
 codespan-reporting = "0.8.0"
-diem-temppath = { path = "../../../common/temppath" }
 anyhow = "1.0.38"
 
 [[test]]

--- a/language/move-prover/docgen/Cargo.toml
+++ b/language/move-prover/docgen/Cargo.toml
@@ -26,8 +26,8 @@ once_cell = "1.7.2"
 [dev-dependencies]
 move-prover = { path = ".." }
 datatest-stable = "0.1.1"
+tempfile = "3.2.0"
 move-prover-test-utils = { path = "../test-utils" }
-diem-temppath = { path = "../../../common/temppath" }
 
 [[test]]
 name = "testsuite"

--- a/language/move-prover/docgen/tests/testsuite.rs
+++ b/language/move-prover/docgen/tests/testsuite.rs
@@ -5,10 +5,10 @@ use std::path::Path;
 
 use codespan_reporting::term::termcolor::Buffer;
 
-use diem_temppath::TempPath;
 use move_prover::{cli::Options, run_move_prover};
 use move_prover_test_utils::baseline_test::verify_or_update_baseline;
 use std::path::PathBuf;
+use tempfile::TempDir;
 
 use itertools::Itertools;
 #[allow(unused_imports)]
@@ -72,7 +72,7 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
 }
 
 fn test_docgen(path: &Path, mut options: Options, suffix: &str) -> anyhow::Result<()> {
-    let mut temp_path = PathBuf::from(TempPath::new().path());
+    let mut temp_path = PathBuf::from(TempDir::new()?.path());
     options.docgen.output_directory = temp_path.to_string_lossy().to_string();
     let base_name = format!(
         "{}.md",

--- a/language/move-prover/tests/testsuite.rs
+++ b/language/move-prover/tests/testsuite.rs
@@ -6,12 +6,12 @@ use std::path::{Path, PathBuf};
 use codespan_reporting::term::termcolor::Buffer;
 
 use anyhow::anyhow;
-use diem_temppath::TempPath;
 use itertools::Itertools;
 use move_prover::{cli::Options, run_move_prover};
 use move_prover_test_utils::{
     baseline_test::verify_or_update_baseline, extract_test_directives, read_env_var,
 };
+use tempfile::TempDir;
 
 use datatest_stable::Requirements;
 #[allow(unused_imports)]
@@ -110,7 +110,7 @@ fn test_runner_for_feature(path: &Path, feature: &Feature) -> datatest_stable::R
         feature.flags.iter().map(|s| s.to_string()).join(" ")
     );
 
-    let temp_dir = TempPath::new();
+    let temp_dir = TempDir::new()?;
     std::fs::create_dir_all(temp_dir.path())?;
     let (mut args, baseline_path) = get_flags_and_baseline(temp_dir.path(), path, feature)?;
 

--- a/x.toml
+++ b/x.toml
@@ -236,15 +236,11 @@ existing_deps = [
     ["invalid-mutations", "diem-proptest-helpers"],           # pick_slice_idxs
     ["bytecode-verifier-tests", "diem-framework-releases"],
     ["compiler", "diem-framework-releases"],
-    ["move-prover", "diem-temppath"],
-    ["bytecode", "diem-temppath"],
-    ["docgen", "diem-temppath"],
     ["move-vm-natives", "diem-crypto"],
     ["move-vm-runtime", "diem-logger"],
     ["move-vm-runtime", "diem-infallible"],                   # `Mutex`
     ["move-vm-runtime", "diem-crypto"],                       # using `HashValue` as keys in the script cache
     ["abigen", "diem-types"],                                 # ABI types
-    ["abigen", "diem-temppath"],
     ["move-cli", "vm-genesis"],
     ["move-cli", "diem-vm"],
     ["move-cli", "diem-types"],                               # `ContractEvent`


### PR DESCRIPTION
This replaces a few usages of `diem-temppath` in the prover with `tempfile`, thus getting rid of the dependencies on the said Diem crate.