### PR TITLE
[cluster-test] extend newly added StateSyncPerformance test duration

### DIFF
--- a/testsuite/cluster-test/src/experiments/state_sync_performance.rs
+++ b/testsuite/cluster-test/src/experiments/state_sync_performance.rs
@@ -18,7 +18,7 @@ use async_trait::async_trait;
 use diem_logger::info;
 use std::time::Instant;
 
-const EXPERIMENT_DURATION_TIMEOUT_SECS: u64 = 600;
+const EXPERIMENT_DURATION_TIMEOUT_SECS: u64 = 1000;
 const STATE_SYNC_COMMITTED_COUNTER_NAME: &str = "diem_state_sync_version.synced";
 
 #[derive(StructOpt, Debug)]


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update or suggest changes to the docs at https://developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
