### PR TITLE
[gha] split docker build in to a matrix build, should cut time in half.

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -145,6 +145,10 @@ jobs:
       head-tag: ${{ steps.push-to-novi-ecr.outputs.head-tag }}
     environment:
       name: Docker
+    strategy:
+      matrix:
+        target_images:
+          [client faucet cluster-test, init tools validator validator-tcb]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -177,16 +181,14 @@ jobs:
       - name: pre-release docker images
         run: |
           BRANCH="$CHANGES_TARGET_BRANCH"
+          echo Target Images: ${{ matrix.target_images }}
+          IFS=' ' read -ra TARGET_IMAGES <<< "${{ matrix.target_images }}"
           success=0
           tmpfile=$(mktemp)
           echo "Failed to push:" > "${tmpfile}"
-          docker/build_push.sh -u -p -b ${BRANCH} -n client || success=$(echo "client" >> "${tmpfile}"; echo 1)
-          docker/build_push.sh -u -p -b ${BRANCH} -n init || success=$(echo "init" >> "${tmpfile}"; echo 1)
-          docker/build_push.sh -u -p -b ${BRANCH} -n faucet || success=$(echo "faucet" >> "${tmpfile}"; echo 1)
-          docker/build_push.sh -u -p -b ${BRANCH} -n tools || success=$(echo "tools" >> "${tmpfile}"; echo 1)
-          docker/build_push.sh -u -p -b ${BRANCH} -n validator || success=$(echo "validator" >> "${tmpfile}"; echo 1)
-          docker/build_push.sh -u -p -b ${BRANCH} -n validator-tcb || success=$(echo "validator-tcb" >> "${tmpfile}"; echo 1)
-          docker/build_push.sh -u -p -b ${BRANCH} -n cluster-test || success=$(echo "cluster-test" >> "${tmpfile}"; echo 1)
+          for image in "${TARGET_IMAGES[@]}"; do
+            docker/build_push.sh -u -p -b ${BRANCH} -n "$image" || success=$(echo "$image" >> "${tmpfile}"; echo 1)
+          done
           if [[ "$success" == "1" ]]; then
             cat "${tmpfile}"
           fi
@@ -202,13 +204,14 @@ jobs:
           echo "::set-output name=head-tag::land_$GIT_REV";
           aws ecr get-login-password --region ${{ secrets.ENV_NOVI_ECR_AWS_REGION }} | \
           docker login --username AWS --password-stdin "${AWS_ECR_ACCOUNT_URL}"
-          docker/docker_republish.sh -t pre_${BRANCH}_${GIT_REV} -o land_${GIT_REV} -r ${AWS_ECR_ACCOUNT_URL} -d
+          docker/docker_republish.sh -t pre_${BRANCH}_${GIT_REV} -o land_${GIT_REV} -r ${AWS_ECR_ACCOUNT_URL} -d -i "${{ matrix.target_images }}"
 
   need-base-images:
     runs-on: self-hosted
     needs: prepare
     if: ${{ github.event_name == 'push' && needs.prepare.outputs.build-images == 'true' && needs.prepare.outputs.need-base-images == 'true' }}
     outputs:
+      # The last matrix build to succeed will set the output.   Hilarious.
       prev-tag: ${{ steps.build-extra-images.outputs.prev-tag }}
     steps:
       - uses: actions/checkout@v2

--- a/docker/build-common.sh
+++ b/docker/build-common.sh
@@ -3,6 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 set -e
 
+#either release or test
+if [ -z "$IMAGE_TARGETS" ]; then
+  IMAGE_TARGETS="all"
+fi
+
 # This is a common compilation scripts across different docker file
 # It unifies RUSFLAGS, compilation flags (like --release) and set of binary crates to compile in common docker layer
 
@@ -17,31 +22,36 @@ export CARGO_PROFILE_RELEASE_LTO=thin # override lto setting to turn on thin-LTO
 # TODO: consider using ${CARGO} once upstream issues are fixed.
 cargo x generate-workspace-hack --mode disable
 
-# Build release binaries (TODO: use x to run this?)
-cargo build --release \
-         -p diem-genesis-tool \
-         -p diem-operational-tool \
-         -p diem-node \
-         -p diem-key-manager \
-         -p safety-rules \
-         -p db-bootstrapper \
-         -p backup-cli \
-         -p diem-transaction-replay \
-         -p diem-writeset-generator \
-         "$@"
+if [ "$IMAGE_TARGETS" = "release" ] || [ "$IMAGE_TARGETS" = "all" ]; then
+  # Build release binaries (TODO: use x to run this?)
+  cargo build --release \
+          -p diem-genesis-tool \
+          -p diem-operational-tool \
+          -p diem-node \
+          -p diem-key-manager \
+          -p safety-rules \
+          -p db-bootstrapper \
+          -p backup-cli \
+          -p diem-transaction-replay \
+          -p diem-writeset-generator \
+          "$@"
 
-# Build and overwrite the diem-node binary with feature failpoints if $ENABLE_FAILPOINTS is configured
-if [ "$ENABLE_FAILPOINTS" = "1" ]; then
-  echo "Building diem-node with failpoints feature"
-  (cd diem-node && cargo build --release --features failpoints "$@")
+  # Build and overwrite the diem-node binary with feature failpoints if $ENABLE_FAILPOINTS is configured
+  if [ "$ENABLE_FAILPOINTS" = "1" ]; then
+    echo "Building diem-node with failpoints feature"
+    (cd diem-node && cargo build --release --features failpoints "$@")
+  fi
 fi
 
-# These non-release binaries are built separately to avoid feature unification issues
-cargo build --release \
-         -p cluster-test \
-         -p cli \
-         -p diem-faucet \
-         "$@"
+
+if [ "$IMAGE_TARGETS" = "test" ] || [ "$IMAGE_TARGETS" = "all"  ]; then
+  # These non-release binaries are built separately to avoid feature unification issues
+  cargo build --release \
+          -p cluster-test \
+          -p cli \
+          -p diem-faucet \
+          "$@"
+fi
 
 rm -rf target/release/{build,deps,incremental}
 

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -17,7 +17,7 @@ FROM toolchain AS builder
 ARG ENABLE_FAILPOINTS
 COPY . /diem
 
-RUN ./docker/build-common.sh
+RUN IMAGE_TARGETS="test" ./docker/build-common.sh
 
 ### Pre-Production Image ###
 FROM debian:buster-20210408@sha256:ba4a437377a0c450ac9bb634c3754a17b1f814ce6fa3157c0dc9eef431b29d1f AS pre-prod

--- a/docker/cluster-test/Dockerfile
+++ b/docker/cluster-test/Dockerfile
@@ -17,7 +17,7 @@ FROM toolchain AS builder
 ARG ENABLE_FAILPOINTS
 COPY . /diem
 
-RUN ./docker/build-common.sh
+RUN IMAGE_TARGETS="test" ./docker/build-common.sh
 
 FROM debian:buster-20210408@sha256:ba4a437377a0c450ac9bb634c3754a17b1f814ce6fa3157c0dc9eef431b29d1f
 

--- a/docker/diem-build.sh
+++ b/docker/diem-build.sh
@@ -60,7 +60,7 @@ if [ "$1" = "--incremental" ]; then
     echo "${BLUE}Tip:${RESTORE}: If you see unexpected failure, try docker rm -f $CONTAINER"
   fi
   CONTAINER_TARGET=/target
-  docker exec -e "STRIP_DIR=$CONTAINER_TARGET" -e "ENABLE_FAILPOINTS=$ENABLE_FAILPOINTS" -i -t "$CONTAINER" ./docker/build-common.sh --target-dir "$CONTAINER_TARGET"
+  docker exec -e "STRIP_DIR=$CONTAINER_TARGET" -e "ENABLE_FAILPOINTS=$ENABLE_FAILPOINTS" -i -t "$CONTAINER" "./docker/build-common.sh" --target-dir "$CONTAINER_TARGET"
   echo "${BLUE}Build is done, copying over artifacts${RESTORE}"
   docker exec -i -t "$CONTAINER" sh -c 'find /target/release -maxdepth 1 -executable -type f | xargs -I F cp F /out-target'
   TMP_DOCKERFILE="$DOCKERFILE.tmp"

--- a/docker/docker_republish.sh
+++ b/docker/docker_republish.sh
@@ -22,27 +22,31 @@ function usage {
 
 DOCKERHUB_TAG=;
 OUTPUT_TAG=;
-TARGET_REPO=docker.io
-TARGET_ORG=diem
-DISABLE_TRUST=false
+TARGET_REPO="docker.io"
+TARGET_ORG="diem"
+DISABLE_TRUST="false"
+IMAGES="init faucet tools validator validator_tcb cluster_test client"
 
 #parse args
-while getopts "t:o:r:g:dh" arg; do
+while getopts "t:o:r:g:i:dh" arg; do
   case $arg in
     t)
-      DOCKERHUB_TAG=$OPTARG
+      DOCKERHUB_TAG="$OPTARG"
       ;;
     o)
-      OUTPUT_TAG=$OPTARG
+      OUTPUT_TAG="$OPTARG"
       ;;
     r)
-      TARGET_REPO=$OPTARG
+      TARGET_REPO="$OPTARG"
       ;;
     g)
-      TARGET_ORG=$OPTARG
+      TARGET_ORG="$OPTARG"
       ;;
     d)
       DISABLE_TRUST=true
+      ;;
+    i)
+      IMAGES="$OPTARG"
       ;;
     *)
       usage;
@@ -59,38 +63,34 @@ fi
 
 set -x
 
-#Pull the latest docker hub images so we can push them to ECR
-docker pull --disable-content-trust=false docker.io/diem/init:"$DOCKERHUB_TAG"
-docker pull --disable-content-trust=false docker.io/diem/faucet:"$DOCKERHUB_TAG"
-docker pull --disable-content-trust=false docker.io/diem/tools:"$DOCKERHUB_TAG"
-docker pull --disable-content-trust=false docker.io/diem/validator:"$DOCKERHUB_TAG"
-docker pull --disable-content-trust=false docker.io/diem/validator_tcb:"$DOCKERHUB_TAG"
-docker pull --disable-content-trust=false docker.io/diem/cluster_test:"$DOCKERHUB_TAG"
-docker pull --disable-content-trust=false docker.io/diem/client:"$DOCKERHUB_TAG"
+IFS=' ' read -ra TARGET_IMAGES <<< "$IMAGES"
+
+for image in "${TARGET_IMAGES[@]}"; do
+  renamed_image="${image//-/_}"
+  docker pull --disable-content-trust=false docker.io/diem/"$renamed_image":"$DOCKERHUB_TAG"
+done
 
 if [[ $DISABLE_TRUST == "true" ]]; then
   export DOCKER_CONTENT_TRUST=0
 fi
 
+# retag images for new location
+for image in "${TARGET_IMAGES[@]}"; do
+  renamed_image="${image//-/_}"
+  docker tag diem/"$renamed_image":"$DOCKERHUB_TAG" "$TARGET_REPO"/"$TARGET_ORG"/"$renamed_image":"$OUTPUT_TAG"
+done
+
 #Push the proper locations to novi ecr.
-docker tag diem/init:"$DOCKERHUB_TAG" "$TARGET_REPO"/"$TARGET_ORG"/init:"$OUTPUT_TAG"
-docker tag diem/faucet:"$DOCKERHUB_TAG" "$TARGET_REPO"/"$TARGET_ORG"/faucet:"$OUTPUT_TAG"
-docker tag diem/tools:"$DOCKERHUB_TAG" "$TARGET_REPO"/"$TARGET_ORG"/tools:"$OUTPUT_TAG"
-docker tag diem/validator:"$DOCKERHUB_TAG" "$TARGET_REPO"/"$TARGET_ORG"/validator:"$OUTPUT_TAG"
-docker tag diem/validator_tcb:"$DOCKERHUB_TAG" "$TARGET_REPO"/"$TARGET_ORG"/validator_tcb:"$OUTPUT_TAG"
-docker tag diem/cluster_test:"$DOCKERHUB_TAG" "$TARGET_REPO"/"$TARGET_ORG"/cluster_test:"$OUTPUT_TAG"
-docker tag diem/client:"$DOCKERHUB_TAG" "$TARGET_REPO"/"$TARGET_ORG"/client:"$OUTPUT_TAG"
+
+
 
 tmpfile=$(mktemp)
 success=0;
 echo "Failed to republish" >> "${tmpfile}"
-docker push --disable-content-trust="$DISABLE_TRUST" "$TARGET_REPO"/"$TARGET_ORG"/init:"$OUTPUT_TAG" || success=$(echo "init" >> "${tmpfile}"; echo 1)
-docker push --disable-content-trust="$DISABLE_TRUST" "$TARGET_REPO"/"$TARGET_ORG"/faucet:"$OUTPUT_TAG" || success=$(echo "faucet" >> "${tmpfile}"; echo 1)
-docker push --disable-content-trust="$DISABLE_TRUST" "$TARGET_REPO"/"$TARGET_ORG"/tools:"$OUTPUT_TAG" || success=$(echo "tools" >> "${tmpfile}"; echo 1)
-docker push --disable-content-trust="$DISABLE_TRUST" "$TARGET_REPO"/"$TARGET_ORG"/validator:"$OUTPUT_TAG" || success=$(echo "validator" >> "${tmpfile}"; echo 1)
-docker push --disable-content-trust="$DISABLE_TRUST" "$TARGET_REPO"/"$TARGET_ORG"/validator_tcb:"$OUTPUT_TAG" || success=$(echo "validator_tcb" >> "${tmpfile}"; echo 1)
-docker push --disable-content-trust="$DISABLE_TRUST" "$TARGET_REPO"/"$TARGET_ORG"/cluster_test:"$OUTPUT_TAG" || success=$(echo "cluster_test" >> "${tmpfile}"; echo 1)
-docker push --disable-content-trust="$DISABLE_TRUST" "$TARGET_REPO"/"$TARGET_ORG"/client:"$OUTPUT_TAG" || success=$(echo "client" >> "${tmpfile}"; echo 1)
+for image in "${TARGET_IMAGES[@]}"; do
+  renamed_image="${image//-/_}"
+  docker push --disable-content-trust="$DISABLE_TRUST" "$TARGET_REPO"/"$TARGET_ORG"/"$renamed_image":"$OUTPUT_TAG" || success=$(echo "$renamed_image" >> "${tmpfile}"; echo 1)
+done
 
 if [[ "$success" == "1" ]]; then
   cat "${tmpfile}"

--- a/docker/faucet/Dockerfile
+++ b/docker/faucet/Dockerfile
@@ -19,7 +19,7 @@ FROM toolchain AS builder
 ARG ENABLE_FAILPOINTS
 COPY . /diem
 
-RUN ./docker/build-common.sh
+RUN IMAGE_TARGETS="test" ./docker/build-common.sh
 
 ### Production Image ###
 FROM debian-base AS pre-test

--- a/docker/init/Dockerfile
+++ b/docker/init/Dockerfile
@@ -17,7 +17,7 @@ FROM toolchain AS builder
 ARG ENABLE_FAILPOINTS
 COPY . /diem
 
-RUN ./docker/build-common.sh
+RUN IMAGE_TARGETS="release" ./docker/build-common.sh
 
 ### Production Image ###
 FROM debian:buster-20210408@sha256:ba4a437377a0c450ac9bb634c3754a17b1f814ce6fa3157c0dc9eef431b29d1f  AS pre-prod

--- a/docker/safety-rules/Dockerfile
+++ b/docker/safety-rules/Dockerfile
@@ -17,7 +17,7 @@ FROM toolchain AS builder
 ARG ENABLE_FAILPOINTS
 COPY . /diem
 
-RUN ./docker/build-common.sh
+RUN IMAGE_TARGETS="release" ./docker/build-common.sh
 
 ### Production Image ###
 FROM debian:buster-20210408@sha256:ba4a437377a0c450ac9bb634c3754a17b1f814ce6fa3157c0dc9eef431b29d1f AS prod

--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -17,7 +17,7 @@ FROM toolchain AS builder
 ARG ENABLE_FAILPOINTS
 COPY . /diem
 
-RUN ./docker/build-common.sh
+RUN IMAGE_TARGETS="release" ./docker/build-common.sh
 
 ### Production Image ###
 FROM debian:buster-20210408@sha256:ba4a437377a0c450ac9bb634c3754a17b1f814ce6fa3157c0dc9eef431b29d1f AS prod

--- a/docker/validator/Dockerfile
+++ b/docker/validator/Dockerfile
@@ -17,7 +17,7 @@ FROM toolchain AS builder
 ARG ENABLE_FAILPOINTS
 COPY . /diem
 
-RUN ./docker/build-common.sh
+RUN IMAGE_TARGETS="release" ./docker/build-common.sh
 
 ### Production Image ###
 FROM debian:buster-20210408@sha256:ba4a437377a0c450ac9bb634c3754a17b1f814ce6fa3157c0dc9eef431b29d1f AS prod


### PR DESCRIPTION
## Motivation

Attempt to split docker builds/build time in half.

Canaryed here:
https://github.com/diem/diem/runs/2453772955
15.75 minutes for non test docker images (init tools validator validator-tcb) 
11.5 minutes for test docker images (client faucet cluster-test)

We could enable sccache to cut these builds in half, but I'd want to overly secure the aws sccache creds first.

Should cut our total /land time from 50 minutes to 40.  Cluster test is still the long pole.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

Ci, Canary

## Related PRs

None.

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
