### PR TITLE
[vm] stronger invariants in ChangeSet

### DIFF
--- a/language/diem-vm/src/diem_vm.rs
+++ b/language/diem-vm/src/diem_vm.rs
@@ -481,8 +481,9 @@ pub fn convert_changeset_and_events_cached<C: AccessPathCache>(
     // TODO: Cache access path computations if necessary.
     let mut ops = vec![];
 
-    for (addr, account_changeset) in changeset.accounts {
-        for (struct_tag, blob_opt) in account_changeset.resources {
+    for (addr, account_changeset) in changeset.into_inner() {
+        let (modules, resources) = account_changeset.into_inner();
+        for (struct_tag, blob_opt) in resources {
             let ap = ap_cache.get_resource_path(addr, struct_tag);
             let op = match blob_opt {
                 None => WriteOp::Deletion,
@@ -491,7 +492,7 @@ pub fn convert_changeset_and_events_cached<C: AccessPathCache>(
             ops.push((ap, op))
         }
 
-        for (name, blob_opt) in account_changeset.modules {
+        for (name, blob_opt) in modules {
             let ap = ap_cache.get_module_path(ModuleId::new(addr, name));
             let op = match blob_opt {
                 None => WriteOp::Deletion,

--- a/language/move-core/types/src/effects.rs
+++ b/language/move-core/types/src/effects.rs
@@ -12,8 +12,8 @@ use std::collections::btree_map::{self, BTreeMap};
 /// A collection of changes to modules and resources under a Move account.
 #[derive(Debug, Clone)]
 pub struct AccountChangeSet {
-    pub modules: BTreeMap<Identifier, Option<Vec<u8>>>,
-    pub resources: BTreeMap<StructTag, Option<Vec<u8>>>,
+    modules: BTreeMap<Identifier, Option<Vec<u8>>>,
+    resources: BTreeMap<StructTag, Option<Vec<u8>>>,
 }
 
 fn publish_checked<K, V, F>(map: &mut BTreeMap<K, Option<V>>, k: K, v: V, make_err: F) -> Result<()>
@@ -57,11 +57,47 @@ where
 }
 
 impl AccountChangeSet {
+    pub fn from_modules_resources(
+        modules: BTreeMap<Identifier, Option<Vec<u8>>>,
+        resources: BTreeMap<StructTag, Option<Vec<u8>>>,
+    ) -> Self {
+        Self { modules, resources }
+    }
+
     pub fn new() -> Self {
         Self {
             modules: BTreeMap::new(),
             resources: BTreeMap::new(),
         }
+    }
+
+    pub fn into_inner(
+        self,
+    ) -> (
+        BTreeMap<Identifier, Option<Vec<u8>>>,
+        BTreeMap<StructTag, Option<Vec<u8>>>,
+    ) {
+        (self.modules, self.resources)
+    }
+
+    pub fn into_resources(self) -> BTreeMap<StructTag, Option<Vec<u8>>> {
+        self.resources
+    }
+
+    pub fn into_modules(self) -> BTreeMap<Identifier, Option<Vec<u8>>> {
+        self.modules
+    }
+
+    pub fn modules(&self) -> &BTreeMap<Identifier, Option<Vec<u8>>> {
+        &self.modules
+    }
+
+    pub fn resources(&self) -> &BTreeMap<StructTag, Option<Vec<u8>>> {
+        &self.resources
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.modules.is_empty() && self.resources.is_empty()
     }
 
     pub fn squash(&mut self, other: Self) -> Result<()> {
@@ -113,10 +149,11 @@ impl AccountChangeSet {
     }
 }
 
-/// A collection of changes to a Move state.
+/// A collection of changes to a Move state. Each AccountChangeSet in the domain of `accounts`
+/// is guaranteed to be nonempty
 #[derive(Debug, Clone)]
 pub struct ChangeSet {
-    pub accounts: BTreeMap<AccountAddress, AccountChangeSet>,
+    accounts: BTreeMap<AccountAddress, AccountChangeSet>,
 }
 
 impl ChangeSet {
@@ -126,10 +163,28 @@ impl ChangeSet {
         }
     }
 
+    pub fn accounts(&self) -> &BTreeMap<AccountAddress, AccountChangeSet> {
+        &self.accounts
+    }
+
+    pub fn into_inner(self) -> BTreeMap<AccountAddress, AccountChangeSet> {
+        self.accounts
+    }
+
     fn get_or_insert_account_changeset(&mut self, addr: AccountAddress) -> &mut AccountChangeSet {
         match self.accounts.entry(addr) {
             btree_map::Entry::Occupied(entry) => entry.into_mut(),
             btree_map::Entry::Vacant(entry) => entry.insert(AccountChangeSet::new()),
+        }
+    }
+
+    pub fn publish_or_overwrite_account_change_set(
+        &mut self,
+        addr: AccountAddress,
+        account_change_set: AccountChangeSet,
+    ) {
+        if !account_change_set.is_empty() {
+            self.accounts.insert(addr, account_change_set);
         }
     }
 

--- a/language/tools/move-cli/src/commands.rs
+++ b/language/tools/move-cli/src/commands.rs
@@ -358,25 +358,25 @@ fn explain_execution_effects(
             )
         }
     }
-    if !changeset.accounts.is_empty() {
+    if !changeset.accounts().is_empty() {
         println!(
             "Changed resource(s) under {:?} address(es):",
-            changeset.accounts.len()
+            changeset.accounts().len()
         );
     }
     // total bytes written across all accounts
     let mut total_bytes_written = 0;
-    for (addr, account) in &changeset.accounts {
+    for (addr, account) in changeset.accounts() {
         print!("  ");
-        if account.resources.is_empty() {
+        if account.resources().is_empty() {
             continue;
         }
         println!(
             "Changed {:?} resource(s) under address {:?}:",
-            account.resources.len(),
+            account.resources().len(),
             addr
         );
-        for (struct_tag, write_opt) in &account.resources {
+        for (struct_tag, write_opt) in account.resources() {
             print!("    ");
             let mut bytes_to_write = struct_tag.access_vector().len();
             match write_opt {
@@ -427,8 +427,8 @@ fn maybe_commit_effects(
     // similar to explain effects, all module publishing happens via save_modules(), so effects
     // shouldn't contain modules
     if commit {
-        for (addr, account) in changeset.accounts {
-            for (struct_tag, blob_opt) in account.resources {
+        for (addr, account) in changeset.into_inner() {
+            for (struct_tag, blob_opt) in account.into_resources() {
                 match blob_opt {
                     Some(blob) => state.save_resource(addr, struct_tag, &blob)?,
                     None => state.delete_resource(addr, struct_tag)?,

--- a/language/tools/move-cli/tests/testsuite/diem_smoke/args.exp
+++ b/language/tools/move-cli/tests/testsuite/diem_smoke/args.exp
@@ -47,7 +47,7 @@ Command `run scripts/create_designated_dealer.move --mode diem --type-args 0x1::
 Compiling transaction script...
 Emitted 1 events:
 Emitted [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 2, 0, 0, 0, 0, 0, 0, 0] as the 2th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
-Changed resource(s) under 3 address(es):
+Changed resource(s) under 2 address(es):
   Changed 9 resource(s) under address 000000000000000000000000000000DD:
     Added type 0x1::AccountFreezing::FreezingBit: [0] (wrote 47 bytes)
     Added type 0x1::DesignatedDealer::Dealer: [0, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221] (wrote 75 bytes)
@@ -60,12 +60,12 @@ Changed resource(s) under 3 address(es):
     Added type 0x1::Roles::RoleId: [2, 0, 0, 0, 0, 0, 0, 0] (wrote 39 bytes)
   Changed 1 resource(s) under address 0000000000000000000000000A550C18:
     Changed type 0x1::DiemAccount::AccountOperationsCapability: [0, 3, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 92 bytes)
-  Wrote 836 bytes of resource ID's and data
+Wrote 836 bytes of resource ID's and data
 Command `run scripts/create_parent_vasp_account.move --mode diem --type-args 0x1::XDX::XDX --signers 0xB1E55ED --args 0 0xA x"00000000000000000000000000000000" b"VASP_A" true -v`:
 Compiling transaction script...
 Emitted 1 events:
 Emitted [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 5, 0, 0, 0, 0, 0, 0, 0] as the 3th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
-Changed resource(s) under 3 address(es):
+Changed resource(s) under 2 address(es):
   Changed 8 resource(s) under address 0000000000000000000000000000000A:
     Added type 0x1::AccountFreezing::FreezingBit: [0] (wrote 47 bytes)
     Added type 0x1::DiemAccount::Balance<0x1::XDX::XDX>: [0, 0, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
@@ -77,12 +77,12 @@ Changed resource(s) under 3 address(es):
     Added type 0x1::VASP::ParentVASP: [0, 0, 0, 0, 0, 0, 0, 0] (wrote 42 bytes)
   Changed 1 resource(s) under address 0000000000000000000000000A550C18:
     Changed type 0x1::DiemAccount::AccountOperationsCapability: [0, 4, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 92 bytes)
-  Wrote 744 bytes of resource ID's and data
+Wrote 744 bytes of resource ID's and data
 Command `run scripts/create_parent_vasp_account.move --mode diem --type-args 0x1::XDX::XDX --signers 0xB1E55ED --args 0 0xB x"00000000000000000000000000000000" b"VASP_B" true -v`:
 Compiling transaction script...
 Emitted 1 events:
 Emitted [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 5, 0, 0, 0, 0, 0, 0, 0] as the 4th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
-Changed resource(s) under 3 address(es):
+Changed resource(s) under 2 address(es):
   Changed 8 resource(s) under address 0000000000000000000000000000000B:
     Added type 0x1::AccountFreezing::FreezingBit: [0] (wrote 47 bytes)
     Added type 0x1::DiemAccount::Balance<0x1::XDX::XDX>: [0, 0, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
@@ -94,47 +94,47 @@ Changed resource(s) under 3 address(es):
     Added type 0x1::VASP::ParentVASP: [0, 0, 0, 0, 0, 0, 0, 0] (wrote 42 bytes)
   Changed 1 resource(s) under address 0000000000000000000000000A550C18:
     Changed type 0x1::DiemAccount::AccountOperationsCapability: [0, 5, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 92 bytes)
-  Wrote 744 bytes of resource ID's and data
+Wrote 744 bytes of resource ID's and data
 Command `run scripts/tiered_mint.move --mode diem --type-args 0x1::XUS::XUS --signers 0xB1E55ED --args 0 0xDD 1000 0 -v`:
 Compiling transaction script...
 Emitted 3 events:
 Emitted [3, 88, 85, 83, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 232, 3, 0, 0, 0, 0, 0, 0] as the 0th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]
 Emitted [232, 3, 0, 0, 0, 0, 0, 0, 3, 88, 85, 83] as the 0th event to stream [5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
 Emitted [232, 3, 0, 0, 0, 0, 0, 0, 3, 88, 85, 83, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] as the 0th event to stream [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]
-Changed resource(s) under 3 address(es):
+Changed resource(s) under 2 address(es):
   Changed 3 resource(s) under address 000000000000000000000000000000DD:
     Changed type 0x1::DesignatedDealer::Dealer: [1, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221] (wrote 75 bytes)
     Changed type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [232, 3, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
     Changed type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 0, 0, 0, 0, 0, 0, 0, 0, 24, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
   Changed 1 resource(s) under address 0000000000000000000000000A550C18:
     Changed type 0x1::Diem::CurrencyInfo<0x1::XUS::XUS>: [232, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 64, 66, 15, 0, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 3, 88, 85, 83, 1, 1, 0, 0, 0, 0, 0, 0, 0, 24, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 281 bytes)
-  Wrote 611 bytes of resource ID's and data
+Wrote 611 bytes of resource ID's and data
 Command `run scripts/peer_to_peer_with_metadata.move --mode diem --type-args 0x1::XUS::XUS --signers 0xDD --args 0xA 700 x"" x"" -v`:
 Compiling transaction script...
 Emitted 2 events:
 Emitted [188, 2, 0, 0, 0, 0, 0, 0, 3, 88, 85, 83, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0] as the 0th event to stream [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]
 Emitted [188, 2, 0, 0, 0, 0, 0, 0, 3, 88, 85, 83, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 0] as the 0th event to stream [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
-Changed resource(s) under 3 address(es):
+Changed resource(s) under 2 address(es):
   Changed 2 resource(s) under address 0000000000000000000000000000000A:
     Changed type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [188, 2, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
     Changed type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 24, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
   Changed 2 resource(s) under address 000000000000000000000000000000DD:
     Changed type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [44, 1, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
     Changed type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 24, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
-  Wrote 510 bytes of resource ID's and data
+Wrote 510 bytes of resource ID's and data
 Command `run scripts/peer_to_peer_with_metadata.move --mode diem --type-args 0x1::XUS::XUS --signers 0xA --args 0xB 500 x"" x"" -v`:
 Compiling transaction script...
 Emitted 2 events:
 Emitted [244, 1, 0, 0, 0, 0, 0, 0, 3, 88, 85, 83, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0] as the 0th event to stream [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
 Emitted [244, 1, 0, 0, 0, 0, 0, 0, 3, 88, 85, 83, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0] as the 0th event to stream [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11]
-Changed resource(s) under 3 address(es):
+Changed resource(s) under 2 address(es):
   Changed 2 resource(s) under address 0000000000000000000000000000000A:
     Changed type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [200, 0, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
     Changed type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 24, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
   Changed 2 resource(s) under address 0000000000000000000000000000000B:
     Changed type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [244, 1, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
     Changed type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 1, 0, 0, 0, 0, 0, 0, 0, 24, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
-  Wrote 510 bytes of resource ID's and data
+Wrote 510 bytes of resource ID's and data
 Command `run scripts/create_child_vasp_account.move --mode diem --type-args 0x1::XUS::XUS --signers 0xA --args 0xAA x"00000000000000000000000000000000" false 100 -v`:
 Compiling transaction script...
 Emitted 3 events:
@@ -178,12 +178,12 @@ Compiling transaction script...
 Emitted 2 events:
 Emitted [100, 0, 0, 0, 0, 0, 0, 0, 3, 88, 85, 83, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187, 0] as the 0th event to stream [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170]
 Emitted [100, 0, 0, 0, 0, 0, 0, 0, 3, 88, 85, 83, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170, 0] as the 0th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187]
-Changed resource(s) under 5 address(es):
-      Changed 2 resource(s) under address 000000000000000000000000000000AA:
+Changed resource(s) under 2 address(es):
+  Changed 2 resource(s) under address 000000000000000000000000000000AA:
     Changed type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [0, 0, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
     Changed type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170, 1, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170, 1, 0, 0, 0, 0, 0, 0, 0, 24, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
   Changed 2 resource(s) under address 000000000000000000000000000000BB:
     Changed type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [100, 0, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
     Changed type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187, 1, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187, 0, 0, 0, 0, 0, 0, 0, 0, 24, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
-  Wrote 510 bytes of resource ID's and data
+Wrote 510 bytes of resource ID's and data
 Command `doctor`:


### PR DESCRIPTION
A `ChangeSet` is a map from address -> `AccountChangeSet`. Previously, a `ChangeSet` could contain an `AccountChangeSet` with no changes, which is potentially confusing for clients.
This PR encapsulates both `ChangeSet` and `AccountChangeSet` (which previously had public fields) and enforces a useful invariant for `ChangeSet`: every `AccountChangeSet` in the range of the backing map is non-empty.
