### PR TITLE
[move-compiler] remove dependency on fallible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4404,7 +4404,6 @@ dependencies = [
  "diem-framework",
  "diem-workspace-hack",
  "difference",
- "fallible",
  "hex",
  "ir-to-bytecode",
  "move-binary-format",

--- a/language/move-lang/Cargo.toml
+++ b/language/move-lang/Cargo.toml
@@ -19,7 +19,6 @@ walkdir = "2.3.1"
 tempfile = "3.2.0"
 once_cell = "1.7.2"
 
-fallible = { path = "../../common/fallible" }
 move-binary-format = { path = "../move-binary-format" }
 move-core-types = { path = "../move-core/types" }
 move-bytecode-verifier = { path = "../bytecode-verifier", package = "bytecode-verifier" }

--- a/language/move-lang/src/shared/mod.rs
+++ b/language/move-lang/src/shared/mod.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{command_line as cli, errors::Errors};
-use fallible::copy_from_slice::copy_slice_to_vec;
 use move_ir_types::location::*;
 use petgraph::{algo::astar as petgraph_astar, graphmap::DiGraphMap};
 use std::{
@@ -122,7 +121,7 @@ impl TryFrom<&[u8]> for Address {
             Err(format!("The Address {:?} is of invalid length", bytes))
         } else {
             let mut addr = [0u8; ADDRESS_LENGTH];
-            copy_slice_to_vec(bytes, &mut addr).map_err(|e| format!("{}", e))?;
+            addr.copy_from_slice(bytes);
             Ok(Address(addr))
         }
     }

--- a/x.toml
+++ b/x.toml
@@ -231,7 +231,6 @@ exclude = [
 existing_deps = [
     # Tier 0 - essential components that must be included in the first batch of crates getting
     #          moved to the new repo
-    ["move-lang", "fallible"],                                # copy_slice_to_vec
     ["move-lang", "diem-framework"],                          # sanity check to ensure that the diem-framework compiles
     ["invalid-mutations", "diem-proptest-helpers"],           # pick_slice_idxs
     ["bytecode-verifier-tests", "diem-framework-releases"],


### PR DESCRIPTION
This makes the move compiler no longer depend on `fallible`, which is a Diem crate.