### PR TITLE
[cluster-test] Added perf measurement test

### DIFF
--- a/testsuite/cluster-test/src/experiments/accurate_measurment.rs
+++ b/testsuite/cluster-test/src/experiments/accurate_measurment.rs
@@ -1,0 +1,106 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    cluster::Cluster,
+    experiments::{Context, Experiment, ExperimentParam},
+    instance::Instance,
+    tx_emitter::EmitJobRequest,
+};
+use anyhow::Result;
+use async_trait::async_trait;
+use core::fmt;
+use futures::FutureExt;
+use std::{collections::HashSet, time::Duration};
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+pub struct AccurateMeasurementParams {
+    #[structopt(
+    long,
+    default_value = Box::leak(format!("{}", DEFAULT_BENCH_DURATION).into_boxed_str()),
+    help = "Duration of an experiment in seconds"
+    )]
+    pub duration: u64,
+    #[structopt(long, help = "Set fixed tps as the base tps number of experiment")]
+    pub base_tps: u64,
+    #[structopt(long, help = "Step numbers to change tps")]
+    pub step_num: u64,
+    #[structopt(long, help = "How may tps change for each step")]
+    pub step_length: u64,
+}
+
+pub struct AccurateMeasurement {
+    validators: Vec<Instance>,
+    fullnodes: Vec<Instance>,
+    duration: Duration,
+    base_tps: u64,
+    step_num: u64,
+    step_length: u64,
+}
+
+pub const DEFAULT_BENCH_DURATION: u64 = 600;
+
+impl ExperimentParam for AccurateMeasurementParams {
+    type E = AccurateMeasurement;
+    fn build(self, cluster: &Cluster) -> Self::E {
+        let validators = cluster.validator_instances().to_vec();
+        let fullnodes = cluster.fullnode_instances().to_vec();
+        Self::E {
+            validators,
+            fullnodes,
+            duration: Duration::from_secs(self.duration),
+            base_tps: self.base_tps,
+            step_num: self.step_num,
+            step_length: self.step_length,
+        }
+    }
+}
+
+#[async_trait]
+impl Experiment for AccurateMeasurement {
+    fn affected_validators(&self) -> HashSet<String> {
+        HashSet::new()
+    }
+
+    async fn run(&mut self, context: &mut Context<'_>) -> Result<()> {
+        let instances = if context.emit_to_validator {
+            self.validators.clone()
+        } else {
+            self.fullnodes.clone()
+        };
+        for i in 0..self.step_num {
+            let tps = self.base_tps + self.step_length * i;
+            let window = self.duration / self.step_num as u32;
+            let emit_job_request = EmitJobRequest::fixed_tps(instances.clone(), tps, 0, 0);
+            let emit_txn = context
+                .tx_emitter
+                .emit_txn_for(window, emit_job_request)
+                .boxed();
+            let stats = emit_txn.await?;
+            // Report
+            let test_step = format!("Step {}", i);
+            context
+                .report
+                .report_txn_stats(test_step, stats, window, "");
+        }
+
+        Ok(())
+    }
+
+    fn deadline(&self) -> Duration {
+        let buffer = Duration::from_secs(60);
+        self.duration + buffer
+    }
+}
+
+impl fmt::Display for AccurateMeasurement {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "Perf Measurement: start tps {}, steps number {}, step length = {}",
+            self.base_tps, self.step_num, self.step_length
+        )?;
+        Ok(())
+    }
+}

--- a/testsuite/cluster-test/src/experiments/mod.rs
+++ b/testsuite/cluster-test/src/experiments/mod.rs
@@ -3,6 +3,7 @@
 
 #![forbid(unsafe_code)]
 
+mod accurate_measurment;
 mod compatibility_test;
 mod cpu_flamegraph;
 mod load_test;
@@ -48,7 +49,10 @@ use crate::{
     tx_emitter::{EmitJobRequest, TxEmitter},
 };
 
-use crate::cluster_swarm::{cluster_swarm_kube::ClusterSwarmKube, ClusterSwarm};
+use crate::{
+    cluster_swarm::{cluster_swarm_kube::ClusterSwarmKube, ClusterSwarm},
+    experiments::accurate_measurment::AccurateMeasurementParams,
+};
 use async_trait::async_trait;
 pub use cpu_flamegraph::{CpuFlamegraph, CpuFlamegraphParams};
 use structopt::{clap::AppSettings, StructOpt};
@@ -153,6 +157,7 @@ pub fn get_experiment(name: &str, args: &[String], cluster: &Cluster) -> Box<dyn
     known_experiments.insert("reconfiguration", f::<ReconfigurationParams>());
     known_experiments.insert("load_test", f::<LoadTestParams>());
     known_experiments.insert("state_sync_performance", f::<StateSyncPerformanceParams>());
+    known_experiments.insert("measure", f::<AccurateMeasurementParams>());
 
     let builder = known_experiments.get(name).expect("Experiment not found");
     builder(args, cluster)


### PR DESCRIPTION
As a start point of "better performance measurement" https://github.com/diem/diem/issues/8023. This test can make perf test push work load stage by stage.

arguments introduced:
--base-tps: start workload for a fixed tps number
--step-length: incremental number of workload for each step
--step-num: step numbers for whole perf test

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

./scripts/cti --pr 8292 --run measure -- --base-tps 500 --step-length 100 --step-num 3

```
Starting experiment Perf Measurement: start tps 500, steps number 3, step length = 100
Experiment Result: Test runner setup time spent 249 secs
Step 0 : 385 TPS, 1338 ms latency, 1500 ms p99 latency, no expired txns
Step 1 : 429 TPS, 1488 ms latency, 1600 ms p99 latency, no expired txns
Step 2 : 462 TPS, 1577 ms latency, 1800 ms p99 latency, no expired txns
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update or suggest changes to the docs at https://developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
