### PR TITLE
[forge] Added first networking test in Forge

### DIFF
--- a/testsuite/diem-swarm/src/swarm.rs
+++ b/testsuite/diem-swarm/src/swarm.rs
@@ -321,7 +321,7 @@ impl DiemNode {
                 HealthStatus::Healthy
             }
             Err(e) => {
-                println!("Error querying metrics for node '{}'", self.node_id);
+                warn!("Error querying metrics for node '{}'", self.node_id);
                 HealthStatus::RpcFailure(e)
             }
         }

--- a/testsuite/forge/src/interface/network.rs
+++ b/testsuite/forge/src/interface/network.rs
@@ -15,15 +15,15 @@ pub trait NetworkTest: Test {
 pub struct NetworkContext<'t> {
     core: CoreContext,
 
-    swarm: &'t dyn Swarm,
+    swarm: &'t mut dyn Swarm,
 }
 
 impl<'t> NetworkContext<'t> {
-    pub fn new(core: CoreContext, swarm: &'t dyn Swarm) -> Self {
+    pub fn new(core: CoreContext, swarm: &'t mut dyn Swarm) -> Self {
         Self { core, swarm }
     }
 
-    pub fn swarm(&self) -> &dyn Swarm {
+    pub fn swarm(&mut self) -> &mut dyn Swarm {
         self.swarm
     }
 

--- a/testsuite/forge/src/interface/node.rs
+++ b/testsuite/forge/src/interface/node.rs
@@ -1,11 +1,10 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::Result;
+use crate::{HealthCheckError, Result};
 use debug_interface::NodeDebugClient;
 use diem_config::config::NodeConfig;
 use diem_sdk::types::PeerId;
-use diem_swarm::swarm::HealthStatus;
 
 /// A NodeId is intended to be a unique identifier of a Node in a Swarm. Due to VFNs sharing the
 /// same PeerId as their Validator, another identifier is needed in order to distinguish between
@@ -61,7 +60,7 @@ pub trait Node {
     fn clear_storage(&mut self) -> Result<()>;
 
     /// Performs a Health Check on the Node
-    fn health_check(&mut self) -> HealthStatus;
+    fn health_check(&mut self) -> Result<(), HealthCheckError>;
 }
 
 /// Trait used to represent a running Validator


### PR DESCRIPTION
First "Helloworld" test case for networking part in Forge, it approved we are on the right track

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan
```
/testsuite/forge/cargo run
```

```
test fund_account ... ok
test transfer_coins ... ok
test get_metadata ... ok
Health check on node '0'
Node '0' is healthy
Restarting node 0
Health check on node '0'
test restart_validator ... ok

test result: ok. 4 passed; 0 failed; 0 filtered out
```
(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update or suggest changes to the docs at https://developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
