### PR TITLE
[move-prover] record the loop header label in stop operation

### DIFF
--- a/language/move-prover/boogie-backend-exp/src/bytecode_translator.rs
+++ b/language/move-prover/boogie-backend-exp/src/bytecode_translator.rs
@@ -1223,7 +1223,7 @@ impl<'env> FunctionTranslator<'env> {
                             emitln!(writer, &check);
                         }
                     }
-                    Stop => {
+                    Stop(_) => {
                         // the two statements combined terminate any execution trace that reaches it
                         emitln!(writer, "assume false;");
                         emitln!(writer, "return;");

--- a/language/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/language/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -1081,7 +1081,7 @@ impl<'env> ModuleTranslator<'env> {
                             emitln!(self.writer, &check);
                         }
                     }
-                    Stop => {
+                    Stop(_) => {
                         // the two statements combined terminate any execution trace that reaches it
                         emitln!(self.writer, "assume false;");
                         emitln!(self.writer, "return;");

--- a/language/move-prover/bytecode/src/loop_analysis.rs
+++ b/language/move-prover/bytecode/src/loop_analysis.rs
@@ -222,7 +222,7 @@ impl LoopAnalysisProcessor {
 
             // stop the checking
             builder.emit_with(|attr_id| {
-                Bytecode::Call(attr_id, vec![], Operation::Stop, vec![], None)
+                Bytecode::Call(attr_id, vec![], Operation::Stop(*label), vec![], None)
             });
         }
 


### PR DESCRIPTION
## Motivation

The `Stop` operation was originally designed to halt the execution in Boogie and hence, does not need to know where the backedge originally goes into. However, for stackless bytecode execution, having a `Stop` will confuse the executor because in concrete execution, it should go back to the loop header.

This PR allows the `Stop` instruction to carry the label of the loop header where the backedge supposes to go into.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI
