### PR TITLE
[language-benchmark] Use wall time as default measurement.

### DIFF
--- a/language/benchmarks/benches/transaction_benches.rs
+++ b/language/benchmarks/benches/transaction_benches.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use criterion::{criterion_group, criterion_main, measurement::Measurement, Criterion};
-use language_benchmarks::{measurement::cpu_time_measurement, transactions::TransactionBencher};
+use language_benchmarks::{measurement::wall_time_measurement, transactions::TransactionBencher};
 use language_e2e_tests::account_universe::P2PTransferGen;
 use proptest::prelude::*;
 
@@ -19,7 +19,7 @@ fn peer_to_peer<M: Measurement + 'static>(c: &mut Criterion<M>) {
 
 criterion_group!(
     name = txn_benches;
-    config = cpu_time_measurement();
+    config = wall_time_measurement();
     targets = peer_to_peer
 );
 

--- a/language/benchmarks/benches/vm_benches.rs
+++ b/language/benchmarks/benches/vm_benches.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use criterion::{criterion_group, criterion_main, measurement::Measurement, Criterion};
-use language_benchmarks::{measurement::cpu_time_measurement, move_vm::bench};
+use language_benchmarks::{measurement::wall_time_measurement, move_vm::bench};
 
 //
 // MoveVM benchmarks
@@ -22,7 +22,7 @@ fn natives<M: Measurement + 'static>(c: &mut Criterion<M>) {
 
 criterion_group!(
     name = vm_benches;
-    config = cpu_time_measurement();
+    config = wall_time_measurement();
     targets = arith,
     call,
     natives


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
Use wall clock time as default benchmark method.

According to my local experiments, wall clock time measurement is much stable than CPU measurement when the CPU is mostily idle. Using wall clock measurement will offer us more stable perf numbers.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I ran the benchmarks in different times of day on my local laptop with all CPU consuming applications closed, the readings become much stable comparing to using CPU clock measuring.
