### PR TITLE
[move-core] Add ident_str! macro to create const IdentStr's

### DIFF
--- a/language/diem-framework/releases/artifacts/current/transaction_script_builder.rs
+++ b/language/diem-framework/releases/artifacts/current/transaction_script_builder.rs
@@ -17,7 +17,7 @@ use diem_types::{
     transaction::{Script, ScriptFunction, TransactionArgument, TransactionPayload},
 };
 use move_core_types::{
-    identifier::Identifier,
+    ident_str,
     language_storage::{ModuleId, TypeTag},
 };
 use std::collections::BTreeMap as Map;
@@ -3604,9 +3604,9 @@ pub fn encode_add_currency_to_account_script_function(currency: TypeTag) -> Tran
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("AccountAdministrationScripts").unwrap(),
+            ident_str!("AccountAdministrationScripts").to_owned(),
         ),
-        Identifier::new("add_currency_to_account").unwrap(),
+        ident_str!("add_currency_to_account").to_owned(),
         vec![currency],
         vec![],
     ))
@@ -3658,9 +3658,9 @@ pub fn encode_add_recovery_rotation_capability_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("AccountAdministrationScripts").unwrap(),
+            ident_str!("AccountAdministrationScripts").to_owned(),
         ),
-        Identifier::new("add_recovery_rotation_capability").unwrap(),
+        ident_str!("add_recovery_rotation_capability").to_owned(),
         vec![],
         vec![bcs::to_bytes(&recovery_address).unwrap()],
     ))
@@ -3720,9 +3720,9 @@ pub fn encode_add_validator_and_reconfigure_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("ValidatorAdministrationScripts").unwrap(),
+            ident_str!("ValidatorAdministrationScripts").to_owned(),
         ),
-        Identifier::new("add_validator_and_reconfigure").unwrap(),
+        ident_str!("add_validator_and_reconfigure").to_owned(),
         vec![],
         vec![
             bcs::to_bytes(&sliding_nonce).unwrap(),
@@ -3771,9 +3771,9 @@ pub fn encode_burn_txn_fees_script_function(coin_type: TypeTag) -> TransactionPa
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("TreasuryComplianceScripts").unwrap(),
+            ident_str!("TreasuryComplianceScripts").to_owned(),
         ),
-        Identifier::new("burn_txn_fees").unwrap(),
+        ident_str!("burn_txn_fees").to_owned(),
         vec![coin_type],
         vec![],
     ))
@@ -3841,9 +3841,9 @@ pub fn encode_burn_with_amount_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("TreasuryComplianceScripts").unwrap(),
+            ident_str!("TreasuryComplianceScripts").to_owned(),
         ),
-        Identifier::new("burn_with_amount").unwrap(),
+        ident_str!("burn_with_amount").to_owned(),
         vec![token],
         vec![
             bcs::to_bytes(&sliding_nonce).unwrap(),
@@ -3909,9 +3909,9 @@ pub fn encode_cancel_burn_with_amount_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("TreasuryComplianceScripts").unwrap(),
+            ident_str!("TreasuryComplianceScripts").to_owned(),
         ),
-        Identifier::new("cancel_burn_with_amount").unwrap(),
+        ident_str!("cancel_burn_with_amount").to_owned(),
         vec![token],
         vec![
             bcs::to_bytes(&preburn_address).unwrap(),
@@ -3988,9 +3988,9 @@ pub fn encode_create_child_vasp_account_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("AccountCreationScripts").unwrap(),
+            ident_str!("AccountCreationScripts").to_owned(),
         ),
-        Identifier::new("create_child_vasp_account").unwrap(),
+        ident_str!("create_child_vasp_account").to_owned(),
         vec![coin_type],
         vec![
             bcs::to_bytes(&child_address).unwrap(),
@@ -4062,9 +4062,9 @@ pub fn encode_create_designated_dealer_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("AccountCreationScripts").unwrap(),
+            ident_str!("AccountCreationScripts").to_owned(),
         ),
-        Identifier::new("create_designated_dealer").unwrap(),
+        ident_str!("create_designated_dealer").to_owned(),
         vec![currency],
         vec![
             bcs::to_bytes(&sliding_nonce).unwrap(),
@@ -4097,9 +4097,9 @@ pub fn encode_create_diem_id_domains_script_function() -> TransactionPayload {
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("AccountAdministrationScripts").unwrap(),
+            ident_str!("AccountAdministrationScripts").to_owned(),
         ),
-        Identifier::new("create_diem_id_domains").unwrap(),
+        ident_str!("create_diem_id_domains").to_owned(),
         vec![],
         vec![],
     ))
@@ -4164,9 +4164,9 @@ pub fn encode_create_parent_vasp_account_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("AccountCreationScripts").unwrap(),
+            ident_str!("AccountCreationScripts").to_owned(),
         ),
-        Identifier::new("create_parent_vasp_account").unwrap(),
+        ident_str!("create_parent_vasp_account").to_owned(),
         vec![coin_type],
         vec![
             bcs::to_bytes(&sliding_nonce).unwrap(),
@@ -4212,9 +4212,9 @@ pub fn encode_create_recovery_address_script_function() -> TransactionPayload {
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("AccountAdministrationScripts").unwrap(),
+            ident_str!("AccountAdministrationScripts").to_owned(),
         ),
-        Identifier::new("create_recovery_address").unwrap(),
+        ident_str!("create_recovery_address").to_owned(),
         vec![],
         vec![],
     ))
@@ -4278,9 +4278,9 @@ pub fn encode_create_validator_account_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("AccountCreationScripts").unwrap(),
+            ident_str!("AccountCreationScripts").to_owned(),
         ),
-        Identifier::new("create_validator_account").unwrap(),
+        ident_str!("create_validator_account").to_owned(),
         vec![],
         vec![
             bcs::to_bytes(&sliding_nonce).unwrap(),
@@ -4346,9 +4346,9 @@ pub fn encode_create_validator_operator_account_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("AccountCreationScripts").unwrap(),
+            ident_str!("AccountCreationScripts").to_owned(),
         ),
-        Identifier::new("create_validator_operator_account").unwrap(),
+        ident_str!("create_validator_operator_account").to_owned(),
         vec![],
         vec![
             bcs::to_bytes(&sliding_nonce).unwrap(),
@@ -4409,9 +4409,9 @@ pub fn encode_freeze_account_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("TreasuryComplianceScripts").unwrap(),
+            ident_str!("TreasuryComplianceScripts").to_owned(),
         ),
-        Identifier::new("freeze_account").unwrap(),
+        ident_str!("freeze_account").to_owned(),
         vec![],
         vec![
             bcs::to_bytes(&sliding_nonce).unwrap(),
@@ -4448,9 +4448,9 @@ pub fn encode_initialize_diem_consensus_config_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("SystemAdministrationScripts").unwrap(),
+            ident_str!("SystemAdministrationScripts").to_owned(),
         ),
-        Identifier::new("initialize_diem_consensus_config").unwrap(),
+        ident_str!("initialize_diem_consensus_config").to_owned(),
         vec![],
         vec![bcs::to_bytes(&sliding_nonce).unwrap()],
     ))
@@ -4520,9 +4520,9 @@ pub fn encode_peer_to_peer_with_metadata_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("PaymentScripts").unwrap(),
+            ident_str!("PaymentScripts").to_owned(),
         ),
-        Identifier::new("peer_to_peer_with_metadata").unwrap(),
+        ident_str!("peer_to_peer_with_metadata").to_owned(),
         vec![currency],
         vec![
             bcs::to_bytes(&payee).unwrap(),
@@ -4580,9 +4580,9 @@ pub fn encode_preburn_script_function(token: TypeTag, amount: u64) -> Transactio
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("TreasuryComplianceScripts").unwrap(),
+            ident_str!("TreasuryComplianceScripts").to_owned(),
         ),
-        Identifier::new("preburn").unwrap(),
+        ident_str!("preburn").to_owned(),
         vec![token],
         vec![bcs::to_bytes(&amount).unwrap()],
     ))
@@ -4621,9 +4621,9 @@ pub fn encode_publish_shared_ed25519_public_key_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("AccountAdministrationScripts").unwrap(),
+            ident_str!("AccountAdministrationScripts").to_owned(),
         ),
-        Identifier::new("publish_shared_ed25519_public_key").unwrap(),
+        ident_str!("publish_shared_ed25519_public_key").to_owned(),
         vec![],
         vec![bcs::to_bytes(&public_key).unwrap()],
     ))
@@ -4674,9 +4674,9 @@ pub fn encode_register_validator_config_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("ValidatorAdministrationScripts").unwrap(),
+            ident_str!("ValidatorAdministrationScripts").to_owned(),
         ),
-        Identifier::new("register_validator_config").unwrap(),
+        ident_str!("register_validator_config").to_owned(),
         vec![],
         vec![
             bcs::to_bytes(&validator_account).unwrap(),
@@ -4737,9 +4737,9 @@ pub fn encode_remove_validator_and_reconfigure_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("ValidatorAdministrationScripts").unwrap(),
+            ident_str!("ValidatorAdministrationScripts").to_owned(),
         ),
-        Identifier::new("remove_validator_and_reconfigure").unwrap(),
+        ident_str!("remove_validator_and_reconfigure").to_owned(),
         vec![],
         vec![
             bcs::to_bytes(&sliding_nonce).unwrap(),
@@ -4778,9 +4778,9 @@ pub fn encode_rotate_authentication_key_script_function(new_key: Vec<u8>) -> Tra
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("AccountAdministrationScripts").unwrap(),
+            ident_str!("AccountAdministrationScripts").to_owned(),
         ),
-        Identifier::new("rotate_authentication_key").unwrap(),
+        ident_str!("rotate_authentication_key").to_owned(),
         vec![],
         vec![bcs::to_bytes(&new_key).unwrap()],
     ))
@@ -4825,9 +4825,9 @@ pub fn encode_rotate_authentication_key_with_nonce_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("AccountAdministrationScripts").unwrap(),
+            ident_str!("AccountAdministrationScripts").to_owned(),
         ),
-        Identifier::new("rotate_authentication_key_with_nonce").unwrap(),
+        ident_str!("rotate_authentication_key_with_nonce").to_owned(),
         vec![],
         vec![
             bcs::to_bytes(&sliding_nonce).unwrap(),
@@ -4875,9 +4875,9 @@ pub fn encode_rotate_authentication_key_with_nonce_admin_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("AccountAdministrationScripts").unwrap(),
+            ident_str!("AccountAdministrationScripts").to_owned(),
         ),
-        Identifier::new("rotate_authentication_key_with_nonce_admin").unwrap(),
+        ident_str!("rotate_authentication_key_with_nonce_admin").to_owned(),
         vec![],
         vec![
             bcs::to_bytes(&sliding_nonce).unwrap(),
@@ -4927,9 +4927,9 @@ pub fn encode_rotate_authentication_key_with_recovery_address_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("AccountAdministrationScripts").unwrap(),
+            ident_str!("AccountAdministrationScripts").to_owned(),
         ),
-        Identifier::new("rotate_authentication_key_with_recovery_address").unwrap(),
+        ident_str!("rotate_authentication_key_with_recovery_address").to_owned(),
         vec![],
         vec![
             bcs::to_bytes(&recovery_address).unwrap(),
@@ -4982,9 +4982,9 @@ pub fn encode_rotate_dual_attestation_info_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("AccountAdministrationScripts").unwrap(),
+            ident_str!("AccountAdministrationScripts").to_owned(),
         ),
-        Identifier::new("rotate_dual_attestation_info").unwrap(),
+        ident_str!("rotate_dual_attestation_info").to_owned(),
         vec![],
         vec![
             bcs::to_bytes(&new_url).unwrap(),
@@ -5025,9 +5025,9 @@ pub fn encode_rotate_shared_ed25519_public_key_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("AccountAdministrationScripts").unwrap(),
+            ident_str!("AccountAdministrationScripts").to_owned(),
         ),
-        Identifier::new("rotate_shared_ed25519_public_key").unwrap(),
+        ident_str!("rotate_shared_ed25519_public_key").to_owned(),
         vec![],
         vec![bcs::to_bytes(&public_key).unwrap()],
     ))
@@ -5084,9 +5084,9 @@ pub fn encode_set_gas_constants_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("SystemAdministrationScripts").unwrap(),
+            ident_str!("SystemAdministrationScripts").to_owned(),
         ),
-        Identifier::new("set_gas_constants").unwrap(),
+        ident_str!("set_gas_constants").to_owned(),
         vec![],
         vec![
             bcs::to_bytes(&sliding_nonce).unwrap(),
@@ -5151,9 +5151,9 @@ pub fn encode_set_validator_config_and_reconfigure_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("ValidatorAdministrationScripts").unwrap(),
+            ident_str!("ValidatorAdministrationScripts").to_owned(),
         ),
-        Identifier::new("set_validator_config_and_reconfigure").unwrap(),
+        ident_str!("set_validator_config_and_reconfigure").to_owned(),
         vec![],
         vec![
             bcs::to_bytes(&validator_account).unwrap(),
@@ -5209,9 +5209,9 @@ pub fn encode_set_validator_operator_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("ValidatorAdministrationScripts").unwrap(),
+            ident_str!("ValidatorAdministrationScripts").to_owned(),
         ),
-        Identifier::new("set_validator_operator").unwrap(),
+        ident_str!("set_validator_operator").to_owned(),
         vec![],
         vec![
             bcs::to_bytes(&operator_name).unwrap(),
@@ -5273,9 +5273,9 @@ pub fn encode_set_validator_operator_with_nonce_admin_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("ValidatorAdministrationScripts").unwrap(),
+            ident_str!("ValidatorAdministrationScripts").to_owned(),
         ),
-        Identifier::new("set_validator_operator_with_nonce_admin").unwrap(),
+        ident_str!("set_validator_operator_with_nonce_admin").to_owned(),
         vec![],
         vec![
             bcs::to_bytes(&sliding_nonce).unwrap(),
@@ -5347,9 +5347,9 @@ pub fn encode_tiered_mint_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("TreasuryComplianceScripts").unwrap(),
+            ident_str!("TreasuryComplianceScripts").to_owned(),
         ),
-        Identifier::new("tiered_mint").unwrap(),
+        ident_str!("tiered_mint").to_owned(),
         vec![coin_type],
         vec![
             bcs::to_bytes(&sliding_nonce).unwrap(),
@@ -5400,9 +5400,9 @@ pub fn encode_unfreeze_account_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("TreasuryComplianceScripts").unwrap(),
+            ident_str!("TreasuryComplianceScripts").to_owned(),
         ),
-        Identifier::new("unfreeze_account").unwrap(),
+        ident_str!("unfreeze_account").to_owned(),
         vec![],
         vec![
             bcs::to_bytes(&sliding_nonce).unwrap(),
@@ -5441,9 +5441,9 @@ pub fn encode_update_diem_consensus_config_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("SystemAdministrationScripts").unwrap(),
+            ident_str!("SystemAdministrationScripts").to_owned(),
         ),
-        Identifier::new("update_diem_consensus_config").unwrap(),
+        ident_str!("update_diem_consensus_config").to_owned(),
         vec![],
         vec![
             bcs::to_bytes(&sliding_nonce).unwrap(),
@@ -5482,9 +5482,9 @@ pub fn encode_update_diem_id_domains_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("TreasuryComplianceScripts").unwrap(),
+            ident_str!("TreasuryComplianceScripts").to_owned(),
         ),
-        Identifier::new("update_diem_id_domains").unwrap(),
+        ident_str!("update_diem_id_domains").to_owned(),
         vec![],
         vec![
             bcs::to_bytes(&to_update_address).unwrap(),
@@ -5527,9 +5527,9 @@ pub fn encode_update_diem_version_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("SystemAdministrationScripts").unwrap(),
+            ident_str!("SystemAdministrationScripts").to_owned(),
         ),
-        Identifier::new("update_diem_version").unwrap(),
+        ident_str!("update_diem_version").to_owned(),
         vec![],
         vec![
             bcs::to_bytes(&sliding_nonce).unwrap(),
@@ -5573,9 +5573,9 @@ pub fn encode_update_dual_attestation_limit_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("TreasuryComplianceScripts").unwrap(),
+            ident_str!("TreasuryComplianceScripts").to_owned(),
         ),
-        Identifier::new("update_dual_attestation_limit").unwrap(),
+        ident_str!("update_dual_attestation_limit").to_owned(),
         vec![],
         vec![
             bcs::to_bytes(&sliding_nonce).unwrap(),
@@ -5628,9 +5628,9 @@ pub fn encode_update_exchange_rate_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("TreasuryComplianceScripts").unwrap(),
+            ident_str!("TreasuryComplianceScripts").to_owned(),
         ),
-        Identifier::new("update_exchange_rate").unwrap(),
+        ident_str!("update_exchange_rate").to_owned(),
         vec![currency],
         vec![
             bcs::to_bytes(&sliding_nonce).unwrap(),
@@ -5674,9 +5674,9 @@ pub fn encode_update_minting_ability_script_function(
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(
             AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
-            Identifier::new("TreasuryComplianceScripts").unwrap(),
+            ident_str!("TreasuryComplianceScripts").to_owned(),
         ),
-        Identifier::new("update_minting_ability").unwrap(),
+        ident_str!("update_minting_ability").to_owned(),
         vec![currency],
         vec![bcs::to_bytes(&allow_minting).unwrap()],
     ))

--- a/language/diem-vm/src/script_to_script_function.rs
+++ b/language/diem-vm/src/script_to_script_function.rs
@@ -5,10 +5,7 @@
 //! function
 
 use diem_types::account_config::CORE_CODE_ADDRESS;
-use move_core_types::{
-    identifier::{IdentStr, Identifier},
-    language_storage::ModuleId,
-};
+use move_core_types::{ident_str, identifier::IdentStr, language_storage::ModuleId};
 use once_cell::sync::Lazy;
 
 #[macro_export]
@@ -534,137 +531,128 @@ pub(crate) fn remapping(script_bytes: &[u8]) -> Option<(&'static ModuleId, &'sta
         // AccountAdministrationScripts
         ADD_CURRENCY_TO_ACCOUNT_BYTES!() => Some((
             &*ACCOUNT_ADMINISTRATION_SCRIPTS,
-            IdentStr::new("add_currency_to_account").unwrap(),
+            ident_str!("add_currency_to_account"),
         )),
         ADD_RECOVERY_ROTATION_CAPABILITY_BYTES!() => Some((
             &*ACCOUNT_ADMINISTRATION_SCRIPTS,
-            IdentStr::new("add_recovery_rotation_capability").unwrap(),
+            ident_str!("add_recovery_rotation_capability"),
         )),
         CREATE_RECOVERY_ADDRESS_BYTES!() => Some((
             &*ACCOUNT_ADMINISTRATION_SCRIPTS,
-            IdentStr::new("create_recovery_address").unwrap(),
+            ident_str!("create_recovery_address"),
         )),
         PUBLISH_SHARED_ED25519_PUBLIC_KEY_BYTES!() => Some((
             &*ACCOUNT_ADMINISTRATION_SCRIPTS,
-            IdentStr::new("publish_shared_ed25519_public_key").unwrap(),
+            ident_str!("publish_shared_ed25519_public_key"),
         )),
         ROTATE_AUTHENTICATION_KEY_BYTES!() => Some((
             &*ACCOUNT_ADMINISTRATION_SCRIPTS,
-            IdentStr::new("rotate_authentication_key").unwrap(),
+            ident_str!("rotate_authentication_key"),
         )),
         ROTATE_AUTHENTICATION_KEY_WITH_NONCE_BYTES!() => Some((
             &*ACCOUNT_ADMINISTRATION_SCRIPTS,
-            IdentStr::new("rotate_authentication_key_with_nonce").unwrap(),
+            ident_str!("rotate_authentication_key_with_nonce"),
         )),
         ROTATE_AUTHENTICATION_KEY_WITH_NONCE_ADMIN_BYTES!() => Some((
             &*ACCOUNT_ADMINISTRATION_SCRIPTS,
-            IdentStr::new("rotate_authentication_key_with_nonce_admin").unwrap(),
+            ident_str!("rotate_authentication_key_with_nonce_admin"),
         )),
         ROTATE_AUTHENTICATION_KEY_WITH_RECOVERY_ADDRESS_BYTES!() => Some((
             &*ACCOUNT_ADMINISTRATION_SCRIPTS,
-            IdentStr::new("rotate_authentication_key_with_recovery_address").unwrap(),
+            ident_str!("rotate_authentication_key_with_recovery_address"),
         )),
         ROTATE_DUAL_ATTESTATION_INFO_BYTES!() => Some((
             &*ACCOUNT_ADMINISTRATION_SCRIPTS,
-            IdentStr::new("rotate_dual_attestation_info").unwrap(),
+            ident_str!("rotate_dual_attestation_info"),
         )),
         ROTATE_SHARED_ED25519_PUBLIC_KEY_BYTES!() => Some((
             &*ACCOUNT_ADMINISTRATION_SCRIPTS,
-            IdentStr::new("rotate_shared_ed25519_public_key").unwrap(),
+            ident_str!("rotate_shared_ed25519_public_key"),
         )),
 
         // AccountCreationScripts
         CREATE_CHILD_VASP_ACCOUNT_BYTES!() => Some((
             &*ACCOUNT_CREATION_SCRIPTS,
-            IdentStr::new("create_child_vasp_account").unwrap(),
+            ident_str!("create_child_vasp_account"),
         )),
         CREATE_DESIGNATED_DEALER_BYTES!() => Some((
             &*ACCOUNT_CREATION_SCRIPTS,
-            IdentStr::new("create_designated_dealer").unwrap(),
+            ident_str!("create_designated_dealer"),
         )),
         CREATE_PARENT_VASP_ACCOUNT_BYTES!() => Some((
             &*ACCOUNT_CREATION_SCRIPTS,
-            IdentStr::new("create_parent_vasp_account").unwrap(),
+            ident_str!("create_parent_vasp_account"),
         )),
         CREATE_VALIDATOR_ACCOUNT_BYTES!() => Some((
             &*ACCOUNT_CREATION_SCRIPTS,
-            IdentStr::new("create_validator_account").unwrap(),
+            ident_str!("create_validator_account"),
         )),
         CREATE_VALIDATOR_OPERATOR_ACCOUNT_BYTES!() => Some((
             &*ACCOUNT_CREATION_SCRIPTS,
-            IdentStr::new("create_validator_operator_account").unwrap(),
+            ident_str!("create_validator_operator_account"),
         )),
 
         // PaymentScripts
-        PEER_TO_PEER_WITH_METADATA_BYTES!() => Some((
-            &*PAYMENT_SCRIPTS,
-            IdentStr::new("peer_to_peer_with_metadata").unwrap(),
-        )),
+        PEER_TO_PEER_WITH_METADATA_BYTES!() => {
+            Some((&*PAYMENT_SCRIPTS, ident_str!("peer_to_peer_with_metadata")))
+        }
 
         // SystemAdministrationScripts
         UPDATE_DIEM_VERSION_BYTES!() => Some((
             &*SYSTEM_ADMINISTRATION_SCRIPTS,
-            IdentStr::new("update_diem_version").unwrap(),
+            ident_str!("update_diem_version"),
         )),
 
         // TreasuryComplianceScripts
-        BURN_TXN_FEES_BYTES!() => Some((
-            &*TREASURY_COMPLIANCE_SCRIPTS,
-            IdentStr::new("burn_txn_fees").unwrap(),
-        )),
-        FREEZE_ACCOUNT_BYTES!() => Some((
-            &*TREASURY_COMPLIANCE_SCRIPTS,
-            IdentStr::new("freeze_account").unwrap(),
-        )),
-        PREBURN_BYTES!() => Some((
-            &*TREASURY_COMPLIANCE_SCRIPTS,
-            IdentStr::new("preburn").unwrap(),
-        )),
-        TIERED_MINT_BYTES!() => Some((
-            &*TREASURY_COMPLIANCE_SCRIPTS,
-            IdentStr::new("tiered_mint").unwrap(),
-        )),
+        BURN_TXN_FEES_BYTES!() => {
+            Some((&*TREASURY_COMPLIANCE_SCRIPTS, ident_str!("burn_txn_fees")))
+        }
+        FREEZE_ACCOUNT_BYTES!() => {
+            Some((&*TREASURY_COMPLIANCE_SCRIPTS, ident_str!("freeze_account")))
+        }
+        PREBURN_BYTES!() => Some((&*TREASURY_COMPLIANCE_SCRIPTS, ident_str!("preburn"))),
+        TIERED_MINT_BYTES!() => Some((&*TREASURY_COMPLIANCE_SCRIPTS, ident_str!("tiered_mint"))),
         UNFREEZE_ACCOUNT_BYTES!() => Some((
             &*TREASURY_COMPLIANCE_SCRIPTS,
-            IdentStr::new("unfreeze_account").unwrap(),
+            ident_str!("unfreeze_account"),
         )),
         UPDATE_EXCHANGE_RATE_BYTES!() => Some((
             &*TREASURY_COMPLIANCE_SCRIPTS,
-            IdentStr::new("update_exchange_rate").unwrap(),
+            ident_str!("update_exchange_rate"),
         )),
         UPDATE_MINTING_ABILITY_BYTES!() => Some((
             &*TREASURY_COMPLIANCE_SCRIPTS,
-            IdentStr::new("update_minting_ability").unwrap(),
+            ident_str!("update_minting_ability"),
         )),
         UPDATE_DUAL_ATTESTATION_LIMIT_BYTES!() => Some((
             &*TREASURY_COMPLIANCE_SCRIPTS,
-            IdentStr::new("update_dual_attestation_limit").unwrap(),
+            ident_str!("update_dual_attestation_limit"),
         )),
 
         // ValidatorAdministrationScripts
         ADD_VALIDATOR_AND_RECONFIGURE_BYTES!() => Some((
             &*VALIDATOR_ADMINISTRATION_SCRIPTS,
-            IdentStr::new("add_validator_and_reconfigure").unwrap(),
+            ident_str!("add_validator_and_reconfigure"),
         )),
         REGISTER_VALIDATOR_CONFIG_BYTES!() => Some((
             &*VALIDATOR_ADMINISTRATION_SCRIPTS,
-            IdentStr::new("register_validator_config").unwrap(),
+            ident_str!("register_validator_config"),
         )),
         REMOVE_VALIDATOR_AND_RECONFIGURE_BYTES!() => Some((
             &*VALIDATOR_ADMINISTRATION_SCRIPTS,
-            IdentStr::new("remove_validator_and_reconfigure").unwrap(),
+            ident_str!("remove_validator_and_reconfigure"),
         )),
         SET_VALIDATOR_CONFIG_AND_RECONFIGURE_BYTES!() => Some((
             &*VALIDATOR_ADMINISTRATION_SCRIPTS,
-            IdentStr::new("set_validator_config_and_reconfigure").unwrap(),
+            ident_str!("set_validator_config_and_reconfigure"),
         )),
         SET_VALIDATOR_OPERATOR_BYTES!() => Some((
             &*VALIDATOR_ADMINISTRATION_SCRIPTS,
-            IdentStr::new("set_validator_operator").unwrap(),
+            ident_str!("set_validator_operator"),
         )),
         SET_VALIDATOR_OPERATOR_WITH_NONCE_ADMIN_BYTES!() => Some((
             &*VALIDATOR_ADMINISTRATION_SCRIPTS,
-            IdentStr::new("set_validator_operator_with_nonce_admin").unwrap(),
+            ident_str!("set_validator_operator_with_nonce_admin"),
         )),
 
         // removed scripts
@@ -680,41 +668,37 @@ pub(crate) fn remapping(script_bytes: &[u8]) -> Option<(&'static ModuleId, &'sta
 static ACCOUNT_ADMINISTRATION_SCRIPTS: Lazy<ModuleId> = Lazy::new(|| {
     ModuleId::new(
         CORE_CODE_ADDRESS,
-        Identifier::new("AccountAdministrationScripts").unwrap(),
+        ident_str!("AccountAdministrationScripts").to_owned(),
     )
 });
 
 static ACCOUNT_CREATION_SCRIPTS: Lazy<ModuleId> = Lazy::new(|| {
     ModuleId::new(
         CORE_CODE_ADDRESS,
-        Identifier::new("AccountCreationScripts").unwrap(),
+        ident_str!("AccountCreationScripts").to_owned(),
     )
 });
 
-static PAYMENT_SCRIPTS: Lazy<ModuleId> = Lazy::new(|| {
-    ModuleId::new(
-        CORE_CODE_ADDRESS,
-        Identifier::new("PaymentScripts").unwrap(),
-    )
-});
+static PAYMENT_SCRIPTS: Lazy<ModuleId> =
+    Lazy::new(|| ModuleId::new(CORE_CODE_ADDRESS, ident_str!("PaymentScripts").to_owned()));
 
 static SYSTEM_ADMINISTRATION_SCRIPTS: Lazy<ModuleId> = Lazy::new(|| {
     ModuleId::new(
         CORE_CODE_ADDRESS,
-        Identifier::new("SystemAdministrationScripts").unwrap(),
+        ident_str!("SystemAdministrationScripts").to_owned(),
     )
 });
 
 static TREASURY_COMPLIANCE_SCRIPTS: Lazy<ModuleId> = Lazy::new(|| {
     ModuleId::new(
         CORE_CODE_ADDRESS,
-        Identifier::new("TreasuryComplianceScripts").unwrap(),
+        ident_str!("TreasuryComplianceScripts").to_owned(),
     )
 });
 
 static VALIDATOR_ADMINISTRATION_SCRIPTS: Lazy<ModuleId> = Lazy::new(|| {
     ModuleId::new(
         CORE_CODE_ADDRESS,
-        Identifier::new("ValidatorAdministrationScripts").unwrap(),
+        ident_str!("ValidatorAdministrationScripts").to_owned(),
     )
 });

--- a/language/diem-vm/src/system_module_names.rs
+++ b/language/diem-vm/src/system_module_names.rs
@@ -3,7 +3,7 @@
 //! Names of modules, functions, and types used by Diem System.
 
 use diem_types::account_config;
-use move_core_types::{identifier::Identifier, language_storage::ModuleId};
+use move_core_types::{ident_str, identifier::IdentStr, language_storage::ModuleId};
 use once_cell::sync::Lazy;
 
 // Data to resolve basic account and transaction flow functions and structs
@@ -12,20 +12,14 @@ use once_cell::sync::Lazy;
 pub static DIEM_BLOCK_MODULE: Lazy<ModuleId> = Lazy::new(|| {
     ModuleId::new(
         account_config::CORE_CODE_ADDRESS,
-        Identifier::new("DiemBlock").unwrap(),
+        ident_str!("DiemBlock").to_owned(),
     )
 });
 
 // Names for special functions and structs
-pub static SCRIPT_PROLOGUE_NAME: Lazy<Identifier> =
-    Lazy::new(|| Identifier::new("script_prologue").unwrap());
-pub static MODULE_PROLOGUE_NAME: Lazy<Identifier> =
-    Lazy::new(|| Identifier::new("module_prologue").unwrap());
-pub static WRITESET_PROLOGUE_NAME: Lazy<Identifier> =
-    Lazy::new(|| Identifier::new("writeset_prologue").unwrap());
-pub static WRITESET_EPILOGUE_NAME: Lazy<Identifier> =
-    Lazy::new(|| Identifier::new("writeset_epilogue").unwrap());
-pub static USER_EPILOGUE_NAME: Lazy<Identifier> =
-    Lazy::new(|| Identifier::new("epilogue").unwrap());
-pub static BLOCK_PROLOGUE: Lazy<Identifier> =
-    Lazy::new(|| Identifier::new("block_prologue").unwrap());
+pub const SCRIPT_PROLOGUE_NAME: &IdentStr = ident_str!("script_prologue");
+pub const MODULE_PROLOGUE_NAME: &IdentStr = ident_str!("module_prologue");
+pub const WRITESET_PROLOGUE_NAME: &IdentStr = ident_str!("writeset_prologue");
+pub const WRITESET_EPILOGUE_NAME: &IdentStr = ident_str!("writeset_epilogue");
+pub const USER_EPILOGUE_NAME: &IdentStr = ident_str!("epilogue");
+pub const BLOCK_PROLOGUE: &IdentStr = ident_str!("block_prologue");

--- a/language/move-core/types/src/move_resource.rs
+++ b/language/move-core/types/src/move_resource.rs
@@ -8,19 +8,15 @@ use crate::{
 use serde::de::DeserializeOwned;
 
 pub trait MoveStructType {
-    const MODULE_NAME: &'static str;
-    const STRUCT_NAME: &'static str;
+    const MODULE_NAME: &'static IdentStr;
+    const STRUCT_NAME: &'static IdentStr;
 
     fn module_identifier() -> Identifier {
-        IdentStr::new(Self::MODULE_NAME)
-            .expect("failed to get IdentStr for Move module")
-            .to_owned()
+        Self::MODULE_NAME.to_owned()
     }
 
     fn struct_identifier() -> Identifier {
-        IdentStr::new(Self::STRUCT_NAME)
-            .expect("failed to get IdentStr for Move struct")
-            .to_owned()
+        Self::STRUCT_NAME.to_owned()
     }
 
     fn type_params() -> Vec<TypeTag> {

--- a/language/move-core/types/src/unit_tests/identifier_test.rs
+++ b/language/move-core/types/src/unit_tests/identifier_test.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::identifier::{IdentStr, Identifier, ALLOWED_IDENTIFIERS};
+use crate::identifier::{IdentStr, Identifier, ALLOWED_IDENTIFIERS, ALLOWED_NO_SELF_IDENTIFIERS};
 use bcs::test_helpers::assert_canonical_encode_decode;
 use once_cell::sync::Lazy;
 use proptest::prelude::*;
@@ -66,6 +66,11 @@ proptest! {
         // will be rejected by the is_valid validator. Note that the converse is checked by the
         // Arbitrary impl for Identifier.
         prop_assert!(!Identifier::is_valid(&identifier));
+    }
+
+    #[test]
+    fn valid_identifiers_proptest(identifier in ALLOWED_NO_SELF_IDENTIFIERS) {
+        prop_assert!(Identifier::is_valid(&identifier));
     }
 
     #[test]

--- a/language/move-core/types/src/vm_status.rs
+++ b/language/move-core/types/src/vm_status.rs
@@ -311,47 +311,39 @@ impl std::error::Error for VMStatus {}
 
 pub mod known_locations {
     use crate::{
-        identifier::Identifier,
+        ident_str,
+        identifier::IdentStr,
         language_storage::{ModuleId, CORE_CODE_ADDRESS},
         vm_status::AbortLocation,
     };
     use once_cell::sync::Lazy;
 
-    /// The name of the Account module.
-    pub const ACCOUNT_MODULE_NAME: &str = "DiemAccount";
     /// The Identifier for the Account module.
-    pub static ACCOUNT_MODULE_IDENTIFIER: Lazy<Identifier> =
-        Lazy::new(|| Identifier::new(ACCOUNT_MODULE_NAME).unwrap());
+    pub const ACCOUNT_MODULE_IDENTIFIER: &IdentStr = ident_str!("DiemAccount");
     /// The ModuleId for the Account module.
     pub static ACCOUNT_MODULE: Lazy<ModuleId> =
-        Lazy::new(|| ModuleId::new(CORE_CODE_ADDRESS, ACCOUNT_MODULE_IDENTIFIER.clone()));
+        Lazy::new(|| ModuleId::new(CORE_CODE_ADDRESS, ACCOUNT_MODULE_IDENTIFIER.to_owned()));
     /// Location for an abort in the Account module
     pub fn account_module_abort() -> AbortLocation {
         AbortLocation::Module(ACCOUNT_MODULE.clone())
     }
 
-    /// The name of the Diem module.
-    pub const DIEM_MODULE_NAME: &str = "Diem";
     /// The Identifier for the Diem module.
-    pub static DIEM_MODULE_IDENTIFIER: Lazy<Identifier> =
-        Lazy::new(|| Identifier::new(DIEM_MODULE_NAME).unwrap());
+    pub const DIEM_MODULE_IDENTIFIER: &IdentStr = ident_str!("Diem");
     /// The ModuleId for the Diem module.
     pub static DIEM_MODULE: Lazy<ModuleId> =
-        Lazy::new(|| ModuleId::new(CORE_CODE_ADDRESS, DIEM_MODULE_IDENTIFIER.clone()));
+        Lazy::new(|| ModuleId::new(CORE_CODE_ADDRESS, DIEM_MODULE_IDENTIFIER.to_owned()));
     pub fn diem_module_abort() -> AbortLocation {
         AbortLocation::Module(DIEM_MODULE.clone())
     }
 
-    /// The name of the Designated Dealer module.
-    pub const DESIGNATED_DEALER_MODULE_NAME: &str = "DesignatedDealer";
     /// The Identifier for the Designated Dealer module.
-    pub static DESIGNATED_DEALER_MODULE_IDENTIFIER: Lazy<Identifier> =
-        Lazy::new(|| Identifier::new(DESIGNATED_DEALER_MODULE_NAME).unwrap());
+    pub const DESIGNATED_DEALER_MODULE_IDENTIFIER: &IdentStr = ident_str!("DesignatedDealer");
     /// The ModuleId for the Designated Dealer module.
     pub static DESIGNATED_DEALER_MODULE: Lazy<ModuleId> = Lazy::new(|| {
         ModuleId::new(
             CORE_CODE_ADDRESS,
-            DESIGNATED_DEALER_MODULE_IDENTIFIER.clone(),
+            DESIGNATED_DEALER_MODULE_IDENTIFIER.to_owned(),
         )
     });
     pub fn designated_dealer_module_abort() -> AbortLocation {

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -114,7 +114,7 @@ pub fn encode_genesis_change_set(
     let xdx_ty = TypeTag::Struct(StructTag {
         address: *account_config::XDX_MODULE.address(),
         module: account_config::XDX_MODULE.name().to_owned(),
-        name: account_config::XDX_STRUCT_NAME.to_owned(),
+        name: account_config::XDX_IDENTIFIER.to_owned(),
         type_params: vec![],
     });
 

--- a/language/transaction-builder/generator/src/rust.rs
+++ b/language/transaction-builder/generator/src/rust.rs
@@ -205,7 +205,7 @@ impl ScriptFunctionCall {
                     "move_core_types::language_storage",
                     vec!["TypeTag", "ModuleId"],
                 ),
-                ("move_core_types::identifier", vec!["Identifier"]),
+                ("move_core_types", vec!["ident_str"]),
                 (
                     "diem_types::transaction",
                     vec![
@@ -680,7 +680,7 @@ fn decode_{}_argument(arg: TransactionArgument) -> Option<{}> {{
 
     fn quote_identifier(&self, ident: &str) -> String {
         if self.local_types {
-            format!("Identifier::new(\"{}\").unwrap()", ident)
+            format!("ident_str!(\"{}\").to_owned()", ident)
         } else {
             format!("Identifier(\"{}\".to_string())", ident)
         }

--- a/types/src/account_config/constants/account.rs
+++ b/types/src/account_config/constants/account.rs
@@ -1,6 +1,4 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-pub use move_core_types::vm_status::known_locations::{
-    ACCOUNT_MODULE, ACCOUNT_MODULE_IDENTIFIER, ACCOUNT_MODULE_NAME,
-};
+pub use move_core_types::vm_status::known_locations::{ACCOUNT_MODULE, ACCOUNT_MODULE_IDENTIFIER};

--- a/types/src/account_config/constants/coins.rs
+++ b/types/src/account_config/constants/coins.rs
@@ -3,13 +3,16 @@
 
 use crate::account_config::constants::{from_currency_code_string, CORE_CODE_ADDRESS};
 use move_core_types::{
-    identifier::Identifier,
+    ident_str,
+    identifier::IdentStr,
     language_storage::{ModuleId, StructTag, TypeTag},
 };
 use once_cell::sync::Lazy;
 
 pub const XDX_NAME: &str = "XDX";
+pub const XDX_IDENTIFIER: &IdentStr = ident_str!(XDX_NAME);
 pub const XUS_NAME: &str = "XUS";
+pub const XUS_IDENTIFIER: &IdentStr = ident_str!(XUS_NAME);
 
 pub fn xus_tag() -> TypeTag {
     TypeTag::Struct(StructTag {
@@ -21,8 +24,7 @@ pub fn xus_tag() -> TypeTag {
 }
 
 pub static XDX_MODULE: Lazy<ModuleId> =
-    Lazy::new(|| ModuleId::new(CORE_CODE_ADDRESS, Identifier::new(XDX_NAME).unwrap()));
-pub static XDX_STRUCT_NAME: Lazy<Identifier> = Lazy::new(|| Identifier::new(XDX_NAME).unwrap());
+    Lazy::new(|| ModuleId::new(CORE_CODE_ADDRESS, XDX_IDENTIFIER.to_owned()));
 
 pub fn xdx_type_tag() -> TypeTag {
     TypeTag::Struct(StructTag {
@@ -58,9 +60,9 @@ pub fn coin_name(t: &TypeTag) -> Option<String> {
 fn coin_names() {
     assert!(coin_name(&xus_tag()).unwrap() == XUS_NAME);
     assert!(coin_name(&xdx_type_tag()).unwrap() == XDX_NAME);
-
     assert!(coin_name(&TypeTag::U64) == None);
-    let bad_name = Identifier::new("NotACoin").unwrap();
+
+    let bad_name = ident_str!("NotACoin").to_owned();
     let bad_coin = TypeTag::Struct(StructTag {
         address: CORE_CODE_ADDRESS,
         module: bad_name.clone(),

--- a/types/src/account_config/constants/designated_dealer.rs
+++ b/types/src/account_config/constants/designated_dealer.rs
@@ -1,0 +1,6 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub use move_core_types::vm_status::known_locations::{
+    DESIGNATED_DEALER_MODULE, DESIGNATED_DEALER_MODULE_IDENTIFIER,
+};

--- a/types/src/account_config/constants/diem.rs
+++ b/types/src/account_config/constants/diem.rs
@@ -4,15 +4,16 @@
 use crate::account_config::constants::CORE_CODE_ADDRESS;
 use anyhow::{bail, Result};
 use move_core_types::{
-    identifier::Identifier,
+    identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, StructTag, TypeTag},
 };
 use once_cell::sync::Lazy;
 
-pub const DIEM_MODULE_NAME: &str = "Diem";
-static COIN_MODULE_NAME: Lazy<Identifier> = Lazy::new(|| Identifier::new("Diem").unwrap());
+pub use move_core_types::vm_status::known_locations::{DIEM_MODULE, DIEM_MODULE_IDENTIFIER};
+
+const COIN_MODULE_IDENTIFIER: &IdentStr = DIEM_MODULE_IDENTIFIER;
 pub static COIN_MODULE: Lazy<ModuleId> =
-    Lazy::new(|| ModuleId::new(CORE_CODE_ADDRESS, COIN_MODULE_NAME.clone()));
+    Lazy::new(|| ModuleId::new(CORE_CODE_ADDRESS, COIN_MODULE_IDENTIFIER.to_owned()));
 
 // TODO: This imposes a few implied restrictions:
 //   1) The currency module must be published under the core code address.

--- a/types/src/account_config/constants/event.rs
+++ b/types/src/account_config/constants/event.rs
@@ -3,37 +3,23 @@
 
 use crate::account_config::constants::CORE_CODE_ADDRESS;
 use move_core_types::{
-    identifier::{IdentStr, Identifier},
+    ident_str,
+    identifier::IdentStr,
     language_storage::{ModuleId, StructTag},
 };
 use once_cell::sync::Lazy;
 
-static EVENT_MODULE_NAME: Lazy<Identifier> = Lazy::new(|| Identifier::new("Event").unwrap());
+pub const EVENT_MODULE_IDENTIFIER: &IdentStr = ident_str!("Event");
 pub static EVENT_MODULE: Lazy<ModuleId> =
-    Lazy::new(|| ModuleId::new(CORE_CODE_ADDRESS, EVENT_MODULE_NAME.clone()));
-
-static EVENT_HANDLE_STRUCT_NAME: Lazy<Identifier> =
-    Lazy::new(|| Identifier::new("EventHandle").unwrap());
-static EVENT_HANDLE_GENERATOR_STRUCT_NAME: Lazy<Identifier> =
-    Lazy::new(|| Identifier::new("EventHandleGenerator").unwrap());
-
-pub fn event_module_name() -> &'static IdentStr {
-    &*EVENT_MODULE_NAME
-}
-
-pub fn event_handle_generator_struct_name() -> &'static IdentStr {
-    &*EVENT_HANDLE_GENERATOR_STRUCT_NAME
-}
-
-pub fn event_handle_struct_name() -> &'static IdentStr {
-    &*EVENT_HANDLE_STRUCT_NAME
-}
+    Lazy::new(|| ModuleId::new(CORE_CODE_ADDRESS, EVENT_MODULE_IDENTIFIER.to_owned()));
+pub const EVENT_HANDLE_STRUCT_IDENTIFIER: &IdentStr = ident_str!("EventHandle");
+pub const EVENT_HANDLE_GENERATOR_STRUCT_IDENTIFIER: &IdentStr = ident_str!("EventHandleGenerator");
 
 pub fn event_handle_generator_struct_tag() -> StructTag {
     StructTag {
         address: CORE_CODE_ADDRESS,
-        module: event_module_name().to_owned(),
-        name: event_handle_generator_struct_name().to_owned(),
+        module: EVENT_MODULE_IDENTIFIER.to_owned(),
+        name: EVENT_HANDLE_GENERATOR_STRUCT_IDENTIFIER.to_owned(),
         type_params: vec![],
     }
 }

--- a/types/src/account_config/constants/mod.rs
+++ b/types/src/account_config/constants/mod.rs
@@ -4,11 +4,13 @@
 pub mod account;
 pub mod addresses;
 pub mod coins;
+pub mod designated_dealer;
 pub mod diem;
 pub mod event;
 
 pub use account::*;
 pub use addresses::*;
 pub use coins::*;
+pub use designated_dealer::*;
 pub use diem::*;
 pub use event::*;

--- a/types/src/account_config/events/admin_transaction.rs
+++ b/types/src/account_config/events/admin_transaction.rs
@@ -1,8 +1,9 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::account_config::ACCOUNT_MODULE_IDENTIFIER;
 use anyhow::Result;
-use move_core_types::move_resource::MoveStructType;
+use move_core_types::{ident_str, identifier::IdentStr, move_resource::MoveStructType};
 use serde::{Deserialize, Serialize};
 
 /// Struct that represents a AdminEvent.
@@ -23,6 +24,6 @@ impl AdminTransactionEvent {
 }
 
 impl MoveStructType for AdminTransactionEvent {
-    const MODULE_NAME: &'static str = "DiemAccount";
-    const STRUCT_NAME: &'static str = "AdminTransactionEvent";
+    const MODULE_NAME: &'static IdentStr = ACCOUNT_MODULE_IDENTIFIER;
+    const STRUCT_NAME: &'static IdentStr = ident_str!("AdminTransactionEvent");
 }

--- a/types/src/account_config/events/base_url_rotation.rs
+++ b/types/src/account_config/events/base_url_rotation.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use move_core_types::move_resource::MoveStructType;
+use move_core_types::{ident_str, identifier::IdentStr, move_resource::MoveStructType};
 use serde::{Deserialize, Serialize};
 
 /// Struct that represents a BaseUrlRotationEvent.
@@ -29,6 +29,6 @@ impl BaseUrlRotationEvent {
 }
 
 impl MoveStructType for BaseUrlRotationEvent {
-    const MODULE_NAME: &'static str = "DualAttestation";
-    const STRUCT_NAME: &'static str = "BaseUrlRotationEvent";
+    const MODULE_NAME: &'static IdentStr = ident_str!("DualAttestation");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("BaseUrlRotationEvent");
 }

--- a/types/src/account_config/events/burn.rs
+++ b/types/src/account_config/events/burn.rs
@@ -1,9 +1,10 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{account_address::AccountAddress, account_config::DIEM_MODULE_NAME};
+use crate::{account_address::AccountAddress, account_config::DIEM_MODULE_IDENTIFIER};
 use anyhow::Result;
 use move_core_types::{
+    ident_str,
     identifier::{IdentStr, Identifier},
     move_resource::MoveStructType,
 };
@@ -39,6 +40,6 @@ impl BurnEvent {
 }
 
 impl MoveStructType for BurnEvent {
-    const MODULE_NAME: &'static str = DIEM_MODULE_NAME;
-    const STRUCT_NAME: &'static str = "BurnEvent";
+    const MODULE_NAME: &'static IdentStr = DIEM_MODULE_IDENTIFIER;
+    const STRUCT_NAME: &'static IdentStr = ident_str!("BurnEvent");
 }

--- a/types/src/account_config/events/cancel_burn.rs
+++ b/types/src/account_config/events/cancel_burn.rs
@@ -1,9 +1,10 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{account_address::AccountAddress, account_config::DIEM_MODULE_NAME};
+use crate::{account_address::AccountAddress, account_config::DIEM_MODULE_IDENTIFIER};
 use anyhow::Result;
 use move_core_types::{
+    ident_str,
     identifier::{IdentStr, Identifier},
     move_resource::MoveStructType,
 };
@@ -39,6 +40,6 @@ impl CancelBurnEvent {
 }
 
 impl MoveStructType for CancelBurnEvent {
-    const MODULE_NAME: &'static str = DIEM_MODULE_NAME;
-    const STRUCT_NAME: &'static str = "CancelBurnEvent";
+    const MODULE_NAME: &'static IdentStr = DIEM_MODULE_IDENTIFIER;
+    const STRUCT_NAME: &'static IdentStr = ident_str!("CancelBurnEvent");
 }

--- a/types/src/account_config/events/compliance_key_rotation.rs
+++ b/types/src/account_config/events/compliance_key_rotation.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use move_core_types::move_resource::MoveStructType;
+use move_core_types::{ident_str, identifier::IdentStr, move_resource::MoveStructType};
 use serde::{Deserialize, Serialize};
 
 /// Struct that represents a ComplianceKeyRotationEvent.
@@ -29,6 +29,6 @@ impl ComplianceKeyRotationEvent {
 }
 
 impl MoveStructType for ComplianceKeyRotationEvent {
-    const MODULE_NAME: &'static str = "DualAttestation";
-    const STRUCT_NAME: &'static str = "ComplianceKeyRotationEvent";
+    const MODULE_NAME: &'static IdentStr = ident_str!("DualAttestation");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("ComplianceKeyRotationEvent");
 }

--- a/types/src/account_config/events/create_account.rs
+++ b/types/src/account_config/events/create_account.rs
@@ -1,9 +1,12 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{account_address::AccountAddress, account_config, event::EventKey};
+use crate::{
+    account_address::AccountAddress, account_config, account_config::ACCOUNT_MODULE_IDENTIFIER,
+    event::EventKey,
+};
 use anyhow::Result;
-use move_core_types::move_resource::MoveStructType;
+use move_core_types::{ident_str, identifier::IdentStr, move_resource::MoveStructType};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -31,6 +34,6 @@ impl CreateAccountEvent {
 }
 
 impl MoveStructType for CreateAccountEvent {
-    const MODULE_NAME: &'static str = "DiemAccount";
-    const STRUCT_NAME: &'static str = "CreateAccountEvent";
+    const MODULE_NAME: &'static IdentStr = ACCOUNT_MODULE_IDENTIFIER;
+    const STRUCT_NAME: &'static IdentStr = ident_str!("CreateAccountEvent");
 }

--- a/types/src/account_config/events/exchange_rate_update.rs
+++ b/types/src/account_config/events/exchange_rate_update.rs
@@ -1,9 +1,10 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::account_config::DIEM_MODULE_NAME;
+use crate::account_config::DIEM_MODULE_IDENTIFIER;
 use anyhow::Result;
 use move_core_types::{
+    ident_str,
     identifier::{IdentStr, Identifier},
     move_resource::MoveStructType,
 };
@@ -37,6 +38,6 @@ impl ToXDXExchangeRateUpdateEvent {
 }
 
 impl MoveStructType for ToXDXExchangeRateUpdateEvent {
-    const MODULE_NAME: &'static str = DIEM_MODULE_NAME;
-    const STRUCT_NAME: &'static str = "ToXDXExchangeRateUpdateEvent";
+    const MODULE_NAME: &'static IdentStr = DIEM_MODULE_IDENTIFIER;
+    const STRUCT_NAME: &'static IdentStr = ident_str!("ToXDXExchangeRateUpdateEvent");
 }

--- a/types/src/account_config/events/mint.rs
+++ b/types/src/account_config/events/mint.rs
@@ -1,9 +1,10 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::account_config::DIEM_MODULE_NAME;
+use crate::account_config::DIEM_MODULE_IDENTIFIER;
 use anyhow::Result;
 use move_core_types::{
+    ident_str,
     identifier::{IdentStr, Identifier},
     move_resource::MoveStructType,
 };
@@ -33,6 +34,6 @@ impl MintEvent {
 }
 
 impl MoveStructType for MintEvent {
-    const MODULE_NAME: &'static str = DIEM_MODULE_NAME;
-    const STRUCT_NAME: &'static str = "MintEvent";
+    const MODULE_NAME: &'static IdentStr = DIEM_MODULE_IDENTIFIER;
+    const STRUCT_NAME: &'static IdentStr = ident_str!("MintEvent");
 }

--- a/types/src/account_config/events/new_block.rs
+++ b/types/src/account_config/events/new_block.rs
@@ -3,7 +3,7 @@
 
 use crate::account_address::AccountAddress;
 use anyhow::Result;
-use move_core_types::move_resource::MoveStructType;
+use move_core_types::{ident_str, identifier::IdentStr, move_resource::MoveStructType};
 use serde::{Deserialize, Serialize};
 
 /// Struct that represents a NewBlockEvent.
@@ -49,6 +49,6 @@ impl NewBlockEvent {
 }
 
 impl MoveStructType for NewBlockEvent {
-    const MODULE_NAME: &'static str = "DiemBlock";
-    const STRUCT_NAME: &'static str = "NewBlockEvent";
+    const MODULE_NAME: &'static IdentStr = ident_str!("DiemBlock");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("NewBlockEvent");
 }

--- a/types/src/account_config/events/new_epoch.rs
+++ b/types/src/account_config/events/new_epoch.rs
@@ -3,7 +3,7 @@
 
 use crate::event::EventKey;
 use anyhow::Result;
-use move_core_types::move_resource::MoveStructType;
+use move_core_types::{ident_str, identifier::IdentStr, move_resource::MoveStructType};
 use serde::{Deserialize, Serialize};
 
 /// Struct that represents a NewEpochEvent.
@@ -27,6 +27,6 @@ impl NewEpochEvent {
 }
 
 impl MoveStructType for NewEpochEvent {
-    const MODULE_NAME: &'static str = "DiemConfig";
-    const STRUCT_NAME: &'static str = "NewEpochEvent";
+    const MODULE_NAME: &'static IdentStr = ident_str!("DiemConfig");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("NewEpochEvent");
 }

--- a/types/src/account_config/events/preburn.rs
+++ b/types/src/account_config/events/preburn.rs
@@ -1,9 +1,10 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{account_address::AccountAddress, account_config::DIEM_MODULE_NAME};
+use crate::{account_address::AccountAddress, account_config::DIEM_MODULE_IDENTIFIER};
 use anyhow::Result;
 use move_core_types::{
+    ident_str,
     identifier::{IdentStr, Identifier},
     move_resource::MoveStructType,
 };
@@ -39,6 +40,6 @@ impl PreburnEvent {
 }
 
 impl MoveStructType for PreburnEvent {
-    const MODULE_NAME: &'static str = DIEM_MODULE_NAME;
-    const STRUCT_NAME: &'static str = "PreburnEvent";
+    const MODULE_NAME: &'static IdentStr = DIEM_MODULE_IDENTIFIER;
+    const STRUCT_NAME: &'static IdentStr = ident_str!("PreburnEvent");
 }

--- a/types/src/account_config/events/received_mint.rs
+++ b/types/src/account_config/events/received_mint.rs
@@ -1,10 +1,10 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::account_address::AccountAddress;
-
+use crate::{account_address::AccountAddress, account_config::DESIGNATED_DEALER_MODULE_IDENTIFIER};
 use anyhow::Result;
 use move_core_types::{
+    ident_str,
     identifier::{IdentStr, Identifier},
     move_resource::MoveStructType,
 };
@@ -40,6 +40,6 @@ impl ReceivedMintEvent {
 }
 
 impl MoveStructType for ReceivedMintEvent {
-    const MODULE_NAME: &'static str = "DesignatedDealer";
-    const STRUCT_NAME: &'static str = "ReceivedMintEvent";
+    const MODULE_NAME: &'static IdentStr = DESIGNATED_DEALER_MODULE_IDENTIFIER;
+    const STRUCT_NAME: &'static IdentStr = ident_str!("ReceivedMintEvent");
 }

--- a/types/src/account_config/events/received_payment.rs
+++ b/types/src/account_config/events/received_payment.rs
@@ -1,9 +1,12 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{account_address::AccountAddress, account_config::constants::ACCOUNT_MODULE_NAME};
+use crate::{
+    account_address::AccountAddress, account_config::constants::ACCOUNT_MODULE_IDENTIFIER,
+};
 use anyhow::Result;
 use move_core_types::{
+    ident_str,
     identifier::{IdentStr, Identifier},
     move_resource::MoveStructType,
 };
@@ -45,6 +48,6 @@ impl ReceivedPaymentEvent {
 }
 
 impl MoveStructType for ReceivedPaymentEvent {
-    const MODULE_NAME: &'static str = ACCOUNT_MODULE_NAME;
-    const STRUCT_NAME: &'static str = "ReceivedPaymentEvent";
+    const MODULE_NAME: &'static IdentStr = ACCOUNT_MODULE_IDENTIFIER;
+    const STRUCT_NAME: &'static IdentStr = ident_str!("ReceivedPaymentEvent");
 }

--- a/types/src/account_config/events/sent_payment.rs
+++ b/types/src/account_config/events/sent_payment.rs
@@ -1,9 +1,12 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{account_address::AccountAddress, account_config::constants::ACCOUNT_MODULE_NAME};
+use crate::{
+    account_address::AccountAddress, account_config::constants::ACCOUNT_MODULE_IDENTIFIER,
+};
 use anyhow::Result;
 use move_core_types::{
+    ident_str,
     identifier::{IdentStr, Identifier},
     move_resource::MoveStructType,
 };
@@ -60,6 +63,6 @@ impl SentPaymentEvent {
 }
 
 impl MoveStructType for SentPaymentEvent {
-    const MODULE_NAME: &'static str = ACCOUNT_MODULE_NAME;
-    const STRUCT_NAME: &'static str = "SentPaymentEvent";
+    const MODULE_NAME: &'static IdentStr = ACCOUNT_MODULE_IDENTIFIER;
+    const STRUCT_NAME: &'static IdentStr = ident_str!("SentPaymentEvent");
 }

--- a/types/src/account_config/resources/account.rs
+++ b/types/src/account_config/resources/account.rs
@@ -3,11 +3,15 @@
 
 use crate::{
     account_config::{
-        constants::ACCOUNT_MODULE_NAME, KeyRotationCapabilityResource, WithdrawCapabilityResource,
+        constants::ACCOUNT_MODULE_IDENTIFIER, KeyRotationCapabilityResource,
+        WithdrawCapabilityResource,
     },
     event::EventHandle,
 };
-use move_core_types::move_resource::{MoveResource, MoveStructType};
+use move_core_types::{
+    identifier::IdentStr,
+    move_resource::{MoveResource, MoveStructType},
+};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -77,8 +81,8 @@ impl AccountResource {
 }
 
 impl MoveStructType for AccountResource {
-    const MODULE_NAME: &'static str = ACCOUNT_MODULE_NAME;
-    const STRUCT_NAME: &'static str = ACCOUNT_MODULE_NAME;
+    const MODULE_NAME: &'static IdentStr = ACCOUNT_MODULE_IDENTIFIER;
+    const STRUCT_NAME: &'static IdentStr = ACCOUNT_MODULE_IDENTIFIER;
 }
 
 impl MoveResource for AccountResource {}

--- a/types/src/account_config/resources/balance.rs
+++ b/types/src/account_config/resources/balance.rs
@@ -3,9 +3,11 @@
 
 use crate::{
     access_path::AccessPath,
-    account_config::constants::{xus_tag, ACCOUNT_MODULE_NAME, CORE_CODE_ADDRESS},
+    account_config::constants::{xus_tag, ACCOUNT_MODULE_IDENTIFIER, CORE_CODE_ADDRESS},
 };
 use move_core_types::{
+    ident_str,
+    identifier::IdentStr,
     language_storage::{StructTag, TypeTag},
     move_resource::{MoveResource, MoveStructType},
 };
@@ -46,8 +48,8 @@ impl BalanceResource {
 }
 
 impl MoveStructType for BalanceResource {
-    const MODULE_NAME: &'static str = ACCOUNT_MODULE_NAME;
-    const STRUCT_NAME: &'static str = "Balance";
+    const MODULE_NAME: &'static IdentStr = ACCOUNT_MODULE_IDENTIFIER;
+    const STRUCT_NAME: &'static IdentStr = ident_str!("Balance");
 
     fn type_params() -> Vec<TypeTag> {
         vec![xus_tag()]

--- a/types/src/account_config/resources/chain_id.rs
+++ b/types/src/account_config/resources/chain_id.rs
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::chain_id::ChainId;
-use move_core_types::move_resource::{MoveResource, MoveStructType};
+use move_core_types::{
+    ident_str,
+    identifier::IdentStr,
+    move_resource::{MoveResource, MoveStructType},
+};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -17,8 +21,8 @@ impl ChainIdResource {
 }
 
 impl MoveStructType for ChainIdResource {
-    const MODULE_NAME: &'static str = "ChainId";
-    const STRUCT_NAME: &'static str = "ChainId";
+    const MODULE_NAME: &'static IdentStr = ident_str!("ChainId");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("ChainId");
 }
 
 impl MoveResource for ChainIdResource {}

--- a/types/src/account_config/resources/currency_info.rs
+++ b/types/src/account_config/resources/currency_info.rs
@@ -3,11 +3,14 @@
 
 use crate::{
     access_path::AccessPath,
-    account_config::constants::{diem_root_address, type_tag_for_currency_code, CORE_CODE_ADDRESS},
+    account_config::constants::{
+        diem_root_address, type_tag_for_currency_code, CORE_CODE_ADDRESS, DIEM_MODULE_IDENTIFIER,
+    },
     event::EventHandle,
 };
 use anyhow::Result;
 use move_core_types::{
+    ident_str,
     identifier::{IdentStr, Identifier},
     language_storage::{ResourceKey, StructTag},
     move_resource::{MoveResource, MoveStructType},
@@ -33,8 +36,8 @@ pub struct CurrencyInfoResource {
 }
 
 impl MoveStructType for CurrencyInfoResource {
-    const MODULE_NAME: &'static str = "Diem";
-    const STRUCT_NAME: &'static str = "CurrencyInfo";
+    const MODULE_NAME: &'static IdentStr = DIEM_MODULE_IDENTIFIER;
+    const STRUCT_NAME: &'static IdentStr = ident_str!("CurrencyInfo");
 }
 
 impl MoveResource for CurrencyInfoResource {}

--- a/types/src/account_config/resources/designated_dealer.rs
+++ b/types/src/account_config/resources/designated_dealer.rs
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    account_config::{PreburnQueueResource, PreburnResource},
+    account_config::{PreburnQueueResource, PreburnResource, DESIGNATED_DEALER_MODULE_IDENTIFIER},
     event::EventHandle,
 };
 use move_core_types::{
-    identifier::Identifier,
+    ident_str,
+    identifier::{IdentStr, Identifier},
     move_resource::{MoveResource, MoveStructType},
 };
 use serde::{Deserialize, Serialize};
@@ -25,8 +26,8 @@ impl DesignatedDealer {
 }
 
 impl MoveStructType for DesignatedDealer {
-    const MODULE_NAME: &'static str = "DesignatedDealer";
-    const STRUCT_NAME: &'static str = "Dealer";
+    const MODULE_NAME: &'static IdentStr = DESIGNATED_DEALER_MODULE_IDENTIFIER;
+    const STRUCT_NAME: &'static IdentStr = ident_str!("Dealer");
 }
 
 impl MoveResource for DesignatedDealer {}

--- a/types/src/account_config/resources/dual_attestation.rs
+++ b/types/src/account_config/resources/dual_attestation.rs
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{event::EventHandle, on_chain_config::OnChainConfig};
-use move_core_types::move_resource::{MoveResource, MoveStructType};
+use move_core_types::{
+    ident_str,
+    identifier::IdentStr,
+    move_resource::{MoveResource, MoveStructType},
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -42,8 +46,8 @@ impl Credential {
 }
 
 impl MoveStructType for Credential {
-    const MODULE_NAME: &'static str = "DualAttestation";
-    const STRUCT_NAME: &'static str = "Credential";
+    const MODULE_NAME: &'static IdentStr = ident_str!("DualAttestation");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("Credential");
 }
 
 impl MoveResource for Credential {}
@@ -59,8 +63,8 @@ impl OnChainConfig for Limit {
 }
 
 impl MoveStructType for Limit {
-    const MODULE_NAME: &'static str = "DualAttestation";
-    const STRUCT_NAME: &'static str = "Limit";
+    const MODULE_NAME: &'static IdentStr = ident_str!("DualAttestation");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("Limit");
 }
 
 impl MoveResource for Limit {}

--- a/types/src/account_config/resources/freezing_bit.rs
+++ b/types/src/account_config/resources/freezing_bit.rs
@@ -1,7 +1,11 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_core_types::move_resource::{MoveResource, MoveStructType};
+use move_core_types::{
+    ident_str,
+    identifier::IdentStr,
+    move_resource::{MoveResource, MoveStructType},
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -16,8 +20,8 @@ impl FreezingBit {
 }
 
 impl MoveStructType for FreezingBit {
-    const MODULE_NAME: &'static str = "AccountFreezing";
-    const STRUCT_NAME: &'static str = "FreezingBit";
+    const MODULE_NAME: &'static IdentStr = ident_str!("AccountFreezing");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("FreezingBit");
 }
 
 impl MoveResource for FreezingBit {}

--- a/types/src/account_config/resources/key_rotation_capability.rs
+++ b/types/src/account_config/resources/key_rotation_capability.rs
@@ -1,8 +1,14 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{account_address::AccountAddress, account_config::constants::ACCOUNT_MODULE_NAME};
-use move_core_types::move_resource::{MoveResource, MoveStructType};
+use crate::{
+    account_address::AccountAddress, account_config::constants::ACCOUNT_MODULE_IDENTIFIER,
+};
+use move_core_types::{
+    ident_str,
+    identifier::IdentStr,
+    move_resource::{MoveResource, MoveStructType},
+};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -14,8 +20,8 @@ pub struct KeyRotationCapabilityResource {
 }
 
 impl MoveStructType for KeyRotationCapabilityResource {
-    const MODULE_NAME: &'static str = ACCOUNT_MODULE_NAME;
-    const STRUCT_NAME: &'static str = "KeyRotationCapability";
+    const MODULE_NAME: &'static IdentStr = ACCOUNT_MODULE_IDENTIFIER;
+    const STRUCT_NAME: &'static IdentStr = ident_str!("KeyRotationCapability");
 }
 
 impl MoveResource for KeyRotationCapabilityResource {}

--- a/types/src/account_config/resources/preburn_balance.rs
+++ b/types/src/account_config/resources/preburn_balance.rs
@@ -3,9 +3,11 @@
 
 use crate::{
     access_path::AccessPath,
-    account_config::constants::{xus_tag, CORE_CODE_ADDRESS, DIEM_MODULE_NAME},
+    account_config::constants::{xus_tag, CORE_CODE_ADDRESS, DIEM_MODULE_IDENTIFIER},
 };
 use move_core_types::{
+    ident_str,
+    identifier::IdentStr,
     language_storage::{StructTag, TypeTag},
     move_resource::{MoveResource, MoveStructType},
 };
@@ -46,8 +48,8 @@ impl PreburnResource {
 }
 
 impl MoveStructType for PreburnResource {
-    const MODULE_NAME: &'static str = DIEM_MODULE_NAME;
-    const STRUCT_NAME: &'static str = "Preburn";
+    const MODULE_NAME: &'static IdentStr = DIEM_MODULE_IDENTIFIER;
+    const STRUCT_NAME: &'static IdentStr = ident_str!("Preburn");
 
     fn type_params() -> Vec<TypeTag> {
         vec![xus_tag()]

--- a/types/src/account_config/resources/preburn_queue.rs
+++ b/types/src/account_config/resources/preburn_queue.rs
@@ -4,11 +4,13 @@
 use crate::{
     access_path::AccessPath,
     account_config::{
-        constants::{xus_tag, CORE_CODE_ADDRESS, DIEM_MODULE_NAME},
+        constants::{xus_tag, CORE_CODE_ADDRESS, DIEM_MODULE_IDENTIFIER},
         resources::PreburnWithMetadataResource,
     },
 };
 use move_core_types::{
+    ident_str,
+    identifier::IdentStr,
     language_storage::{StructTag, TypeTag},
     move_resource::{MoveResource, MoveStructType},
 };
@@ -47,8 +49,8 @@ impl PreburnQueueResource {
 }
 
 impl MoveStructType for PreburnQueueResource {
-    const MODULE_NAME: &'static str = DIEM_MODULE_NAME;
-    const STRUCT_NAME: &'static str = "PreburnQueue";
+    const MODULE_NAME: &'static IdentStr = DIEM_MODULE_IDENTIFIER;
+    const STRUCT_NAME: &'static IdentStr = ident_str!("PreburnQueue");
 
     fn type_params() -> Vec<TypeTag> {
         vec![xus_tag()]

--- a/types/src/account_config/resources/preburn_with_metadata.rs
+++ b/types/src/account_config/resources/preburn_with_metadata.rs
@@ -4,11 +4,13 @@
 use crate::{
     access_path::AccessPath,
     account_config::{
-        constants::{xus_tag, CORE_CODE_ADDRESS, DIEM_MODULE_NAME},
+        constants::{xus_tag, CORE_CODE_ADDRESS, DIEM_MODULE_IDENTIFIER},
         resources::PreburnResource,
     },
 };
 use move_core_types::{
+    ident_str,
+    identifier::IdentStr,
     language_storage::{StructTag, TypeTag},
     move_resource::{MoveResource, MoveStructType},
 };
@@ -56,8 +58,8 @@ impl PreburnWithMetadataResource {
 }
 
 impl MoveStructType for PreburnWithMetadataResource {
-    const MODULE_NAME: &'static str = DIEM_MODULE_NAME;
-    const STRUCT_NAME: &'static str = "PreburnWithMetadata";
+    const MODULE_NAME: &'static IdentStr = DIEM_MODULE_IDENTIFIER;
+    const STRUCT_NAME: &'static IdentStr = ident_str!("PreburnWithMetadata");
 
     fn type_params() -> Vec<TypeTag> {
         vec![xus_tag()]

--- a/types/src/account_config/resources/role_id.rs
+++ b/types/src/account_config/resources/role_id.rs
@@ -1,7 +1,11 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_core_types::move_resource::{MoveResource, MoveStructType};
+use move_core_types::{
+    ident_str,
+    identifier::IdentStr,
+    move_resource::{MoveResource, MoveStructType},
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -16,8 +20,8 @@ impl RoleId {
 }
 
 impl MoveStructType for RoleId {
-    const MODULE_NAME: &'static str = "Roles";
-    const STRUCT_NAME: &'static str = "RoleId";
+    const MODULE_NAME: &'static IdentStr = ident_str!("Roles");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("RoleId");
 }
 
 impl MoveResource for RoleId {}

--- a/types/src/account_config/resources/vasp.rs
+++ b/types/src/account_config/resources/vasp.rs
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::account_address::AccountAddress;
-use move_core_types::move_resource::{MoveResource, MoveStructType};
+use move_core_types::{
+    ident_str,
+    identifier::IdentStr,
+    move_resource::{MoveResource, MoveStructType},
+};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -31,13 +35,13 @@ impl ChildVASP {
 }
 
 impl MoveStructType for ParentVASP {
-    const MODULE_NAME: &'static str = "VASP";
-    const STRUCT_NAME: &'static str = "ParentVASP";
+    const MODULE_NAME: &'static IdentStr = ident_str!("VASP");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("ParentVASP");
 }
 
 impl MoveStructType for ChildVASP {
-    const MODULE_NAME: &'static str = "VASP";
-    const STRUCT_NAME: &'static str = "ChildVASP";
+    const MODULE_NAME: &'static IdentStr = ident_str!("VASP");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("ChildVASP");
 }
 
 impl MoveResource for ParentVASP {}

--- a/types/src/account_config/resources/withdraw_capability.rs
+++ b/types/src/account_config/resources/withdraw_capability.rs
@@ -1,8 +1,14 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{account_address::AccountAddress, account_config::constants::ACCOUNT_MODULE_NAME};
-use move_core_types::move_resource::{MoveResource, MoveStructType};
+use crate::{
+    account_address::AccountAddress, account_config::constants::ACCOUNT_MODULE_IDENTIFIER,
+};
+use move_core_types::{
+    ident_str,
+    identifier::IdentStr,
+    move_resource::{MoveResource, MoveStructType},
+};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -14,8 +20,8 @@ pub struct WithdrawCapabilityResource {
 }
 
 impl MoveStructType for WithdrawCapabilityResource {
-    const MODULE_NAME: &'static str = ACCOUNT_MODULE_NAME;
-    const STRUCT_NAME: &'static str = "WithdrawCapability";
+    const MODULE_NAME: &'static IdentStr = ACCOUNT_MODULE_IDENTIFIER;
+    const STRUCT_NAME: &'static IdentStr = ident_str!("WithdrawCapability");
 }
 
 impl MoveResource for WithdrawCapabilityResource {}

--- a/types/src/block_metadata.rs
+++ b/types/src/block_metadata.rs
@@ -7,7 +7,11 @@ use crate::{
     event::{EventHandle, EventKey},
 };
 use diem_crypto::HashValue;
-use move_core_types::move_resource::{MoveResource, MoveStructType};
+use move_core_types::{
+    ident_str,
+    identifier::IdentStr,
+    move_resource::{MoveResource, MoveStructType},
+};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 
@@ -96,8 +100,8 @@ impl DiemBlockResource {
 }
 
 impl MoveStructType for DiemBlockResource {
-    const MODULE_NAME: &'static str = "DiemBlock";
-    const STRUCT_NAME: &'static str = "BlockMetadata";
+    const MODULE_NAME: &'static IdentStr = ident_str!("DiemBlock");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("BlockMetadata");
 }
 
 impl MoveResource for DiemBlockResource {}

--- a/types/src/diem_timestamp.rs
+++ b/types/src/diem_timestamp.rs
@@ -1,7 +1,11 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_core_types::move_resource::{MoveResource, MoveStructType};
+use move_core_types::{
+    ident_str,
+    identifier::IdentStr,
+    move_resource::{MoveResource, MoveStructType},
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -10,8 +14,8 @@ pub struct DiemTimestampResource {
 }
 
 impl MoveStructType for DiemTimestampResource {
-    const MODULE_NAME: &'static str = "DiemTimestamp";
-    const STRUCT_NAME: &'static str = "CurrentTimeMicroseconds";
+    const MODULE_NAME: &'static IdentStr = ident_str!("DiemTimestamp");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("CurrentTimeMicroseconds");
 }
 
 impl MoveResource for DiemTimestampResource {}

--- a/types/src/on_chain_config/mod.rs
+++ b/types/src/on_chain_config/mod.rs
@@ -9,7 +9,8 @@ use crate::{
 };
 use anyhow::{format_err, Result};
 use move_core_types::{
-    identifier::Identifier,
+    ident_str,
+    identifier::{IdentStr, Identifier},
     language_storage::{StructTag, TypeTag},
     move_resource::{MoveResource, MoveStructType},
 };
@@ -165,8 +166,8 @@ pub fn access_path_for_config(address: AccountAddress, config_name: Identifier) 
         address,
         AccessPath::resource_access_vec(StructTag {
             address: CORE_CODE_ADDRESS,
-            module: Identifier::new("DiemConfig").unwrap(),
-            name: Identifier::new("DiemConfig").unwrap(),
+            module: ConfigurationResource::MODULE_NAME.to_owned(),
+            name: ConfigurationResource::MODULE_NAME.to_owned(),
             type_params: vec![TypeTag::Struct(StructTag {
                 address: CORE_CODE_ADDRESS,
                 module: config_name.clone(),
@@ -224,8 +225,8 @@ impl Default for ConfigurationResource {
 }
 
 impl MoveStructType for ConfigurationResource {
-    const MODULE_NAME: &'static str = "DiemConfig";
-    const STRUCT_NAME: &'static str = "Configuration";
+    const MODULE_NAME: &'static IdentStr = ident_str!("DiemConfig");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("Configuration");
 }
 
 impl MoveResource for ConfigurationResource {}

--- a/types/src/validator_config.rs
+++ b/types/src/validator_config.rs
@@ -6,7 +6,11 @@ use crate::{
     network_address::{encrypted::EncNetworkAddress, NetworkAddress},
 };
 use diem_crypto::ed25519::Ed25519PublicKey;
-use move_core_types::move_resource::{MoveResource, MoveStructType};
+use move_core_types::{
+    ident_str,
+    identifier::IdentStr,
+    move_resource::{MoveResource, MoveStructType},
+};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -19,8 +23,8 @@ pub struct ValidatorConfigResource {
 }
 
 impl MoveStructType for ValidatorConfigResource {
-    const MODULE_NAME: &'static str = "ValidatorConfig";
-    const STRUCT_NAME: &'static str = "ValidatorConfig";
+    const MODULE_NAME: &'static IdentStr = ident_str!("ValidatorConfig");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("ValidatorConfig");
 }
 
 impl MoveResource for ValidatorConfigResource {}
@@ -31,8 +35,8 @@ pub struct ValidatorOperatorConfigResource {
 }
 
 impl MoveStructType for ValidatorOperatorConfigResource {
-    const MODULE_NAME: &'static str = "ValidatorOperatorConfig";
-    const STRUCT_NAME: &'static str = "ValidatorOperatorConfig";
+    const MODULE_NAME: &'static IdentStr = ident_str!("ValidatorOperatorConfig");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("ValidatorOperatorConfig");
 }
 
 impl MoveResource for ValidatorOperatorConfigResource {}


### PR DESCRIPTION
## Overview

A PR for something that's been bothering me for a while; namely, storing `&'static str`s instead of `&'static IdentStr`s for `MoveResource::MODULE_NAME` and `MoveResource::STRUCT_NAME`, which means lots of `Lazy<Identifier>` and `unwrap`s everywhere in `diem-types`.

This diff adds a new macro `ident_str!` which lets us construct const `&'static IdentStr`s that are asserted valid at compile-time.

Note for reviewers: most of the diff is just swapping `Identifier::new("..")` and `IdentStr::new("..")` for `ident_str!`. The interesting parts to check out are the macro in `language/move-core/types/src/identifier.rs` and the consts in `MoveResource` changed to `&'static IdentStr`.

There's also an unsafe line in here:

```rust
macro_rules ident_str {
    ($ident:literal) => {{
        // ..

        // SAFETY: the following transmute is safe because
        // (1) it's equivalent to the unsafe-reborrow inside IdentStr::ref_cast()
        //     (which we can't use b/c it's not const).
        // (2) we've just asserted that IdentStr impls RefCast<From = str>, which
        //     already guarantees the transmute is safe (RefCast checks that
        //     IdentStr(str) is #[repr(transparent)]).
        // (3) both in and out lifetimes are 'static, so we're not widening the lifetime.
        // (4) we've just asserted that the IdentStr passes the is_valid check.
        //
        // Note: this lint is unjustified and no longer checked. See issue:
        // https://github.com/rust-lang/rust-clippy/issues/6372
        #[allow(clippy::transmute_ptr_to_ptr)]
        unsafe {
            ::std::mem::transmute::<&'static str, &'static $crate::identifier::IdentStr>(s)
        }
    }}
}
```

which is safe because we derive `RefCast` for `IdentStr`, which guarantees this kind of transmute is safe if the trait is derivable. Finally, the transmute is effectively the same as the unsafe pointer cast inside `RefCast::ref_cast(s)`, except we can actually use transmute in a const context (though not in a const fn for some reason, which is why this is implemented as a macro and not an `IdentStr` method).