### PR TITLE
Add support for test-only natives

### DIFF
--- a/language/move-lang/src/unit_test/filter_test_members.rs
+++ b/language/move-lang/src/unit_test/filter_test_members.rs
@@ -3,9 +3,9 @@
 
 use crate::{
     parser::ast as P,
-    shared::{known_attributes, CompilationEnv},
+    shared::{known_attributes, AddressBytes, CompilationEnv},
 };
-use move_ir_types::location::Loc;
+use move_ir_types::location::{sp, Loc};
 
 struct Context<'env> {
     env: &'env mut CompilationEnv,
@@ -23,11 +23,21 @@ impl<'env> Context<'env> {
 // Filtering of test-annotated module members
 //***************************************************************************
 
+const UNIT_TEST_MODULE_NAME: &str = "UnitTest";
+// TODO: remove once named addresses have landed in the stdlib
+const STDLIB_ADDRESS: AddressBytes = AddressBytes::new([
+    0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8,
+]);
+
 // This filters out all test, and test-only annotated module member from `prog` if the `test` flag
 // in `compilation_env` is not set. If the test flag is set, no filtering is performed, and instead
 // a test plan is created for use by the testing framework.
 pub fn program(compilation_env: &mut CompilationEnv, prog: P::Program) -> P::Program {
     let mut context = Context::new(compilation_env);
+
+    if !check_has_unit_test_module(&mut context, &prog) {
+        return prog;
+    }
 
     let P::Program {
         source_definitions,
@@ -48,6 +58,46 @@ pub fn program(compilation_env: &mut CompilationEnv, prog: P::Program) -> P::Pro
         source_definitions,
         lib_definitions,
     }
+}
+
+fn check_has_unit_test_module(context: &mut Context, prog: &P::Program) -> bool {
+    let has_unit_test_module = prog
+        .lib_definitions
+        .iter()
+        .chain(prog.source_definitions.iter())
+        .any(|def| match def {
+            P::Definition::Module(mdef) => {
+                mdef.name.0.value == UNIT_TEST_MODULE_NAME
+                    && mdef.address.is_some()
+                    && match &mdef.address.as_ref().unwrap().value {
+                        // TODO: remove once named addresses have landed in the stdlib
+                        P::LeadingNameAccess_::AnonymousAddress(bytes) => bytes == &STDLIB_ADDRESS,
+                        P::LeadingNameAccess_::Name(name) => name.value == "Std",
+                    }
+            }
+            _ => false,
+        });
+
+    if !has_unit_test_module && context.env.flags().is_testing() {
+        if let Some(def) = prog
+            .source_definitions
+            .iter()
+            .chain(prog.lib_definitions.iter())
+            .next()
+        {
+            let loc = match def {
+                P::Definition::Module(P::ModuleDefinition { name, .. }) => name.0.loc,
+                P::Definition::Address(P::AddressDefinition { loc, .. })
+                | P::Definition::Script(P::Script { loc, .. }) => *loc,
+            };
+            context.env.add_error(vec![
+                    (loc, "Compilation in test mode requires passing the UnitTest module in the Move stdlib as a dependency")
+                ]);
+            return false;
+        }
+    }
+
+    true
 }
 
 fn filter_tests_from_definition(
@@ -138,10 +188,12 @@ fn filter_tests_from_module(
         members,
     } = module_def;
 
-    let new_members: Vec<_> = members
+    let mut new_members: Vec<_> = members
         .into_iter()
         .filter_map(|member| filter_tests_from_module_member(context, member))
         .collect();
+
+    insert_test_poison(context, loc, &mut new_members);
 
     Some(P::ModuleDefinition {
         attributes,
@@ -151,6 +203,78 @@ fn filter_tests_from_module(
         is_spec_module,
         members: new_members,
     })
+}
+
+/// If a module is being compiled in test mode, this inserts a function that calls a native
+/// function `0x1::UnitTest::create_signers_for_testing` that only exists if the VM is being run with the
+/// "unit_test" feature flag set. This will then cause the module to fail to link if an attempt is
+/// made to publish a module that has been compiled in test mode on a VM that is not running in
+/// test mode.
+fn insert_test_poison(context: &mut Context, mloc: Loc, members: &mut Vec<P::ModuleMember>) {
+    if !context.env.flags().is_testing() {
+        return;
+    }
+
+    let signature = P::FunctionSignature {
+        type_parameters: vec![],
+        parameters: vec![],
+        return_type: sp(mloc, P::Type_::Unit),
+    };
+
+    // TODO: Change this to a named "Std" address once named addresses in the stdlib have landed
+    //let leading_name_access =  sp(mloc, P::LeadingNameAccess_::Name(P::ModuleName(sp(mloc, "Std".to_string())),
+    let leading_name_access = sp(
+        mloc,
+        P::LeadingNameAccess_::AnonymousAddress(STDLIB_ADDRESS),
+    );
+
+    let nop_call = P::Exp_::Call(
+        sp(
+            mloc,
+            P::NameAccessChain_::Three(
+                sp(
+                    mloc,
+                    (
+                        leading_name_access,
+                        sp(mloc, UNIT_TEST_MODULE_NAME.to_string()),
+                    ),
+                ),
+                sp(mloc, "create_signers_for_testing".to_string()),
+            ),
+        ),
+        None,
+        sp(
+            mloc,
+            vec![sp(
+                mloc,
+                P::Exp_::Value(sp(mloc, P::Value_::Num("0".to_string()))),
+            )],
+        ),
+    );
+
+    // fun unit_test_poison() { 0x1::UnitTest::create_signers_for_testing(0); () }
+    let function = P::Function {
+        attributes: vec![],
+        loc: mloc,
+        visibility: P::Visibility::Internal,
+        acquires: vec![],
+        signature,
+        name: P::FunctionName(sp(mloc, "unit_test_poison".to_string())),
+        body: sp(
+            mloc,
+            P::FunctionBody_::Defined((
+                vec![],
+                vec![sp(
+                    mloc,
+                    P::SequenceItem_::Seq(Box::new(sp(mloc, nop_call))),
+                )],
+                None,
+                Box::new(Some(sp(mloc, P::Exp_::Unit))),
+            )),
+        ),
+    };
+
+    members.push(P::ModuleMember::Function(function));
 }
 
 fn filter_tests_from_module_member(

--- a/language/move-lang/tests/move_check_testsuite.rs
+++ b/language/move-lang/tests/move_check_testsuite.rs
@@ -84,7 +84,8 @@ fn run_test(
     flags: Flags,
 ) -> datatest_stable::Result<()> {
     let targets: Vec<String> = vec![path.to_str().unwrap().to_owned()];
-    let deps = move_stdlib::move_stdlib_files();
+    let mut deps = move_stdlib::move_stdlib_files();
+    deps.push(move_stdlib::unit_testing_module_file());
 
     let compilation_env = CompilationEnv::new(flags);
     let (files, pprog_and_comments_res) = move_parse(&compilation_env, &targets, &deps, None)?;

--- a/language/move-stdlib/nursery/Debug.move
+++ b/language/move-stdlib/nursery/Debug.move
@@ -6,5 +6,4 @@ module Debug {
 
     native public fun print_stack_trace();
 }
-
 }

--- a/language/move-stdlib/nursery/UnitTest.move
+++ b/language/move-stdlib/nursery/UnitTest.move
@@ -1,0 +1,12 @@
+#[test_only]
+/// Module providing testing functionality. Only included for tests.
+module 0x1::UnitTest {
+    /// Return a `num_signers` number of unique signer values. No ordering or
+    /// starting value guarantees are made, only that the order and values of
+    /// the signers in the returned vector is deterministic.
+    ///
+    /// This function is also used to poison modules compiled in `test` mode.
+    /// This will cause a linking failure if an attempt is made to publish a
+    /// test module in a VM that isn't in unit test mode.
+    native public fun create_signers_for_testing(num_signers: u64): vector<signer>;
+}

--- a/language/move-stdlib/src/lib.rs
+++ b/language/move-stdlib/src/lib.rs
@@ -42,6 +42,13 @@ pub fn filter_move_bytecode_files(
     })
 }
 
+pub fn unit_testing_module_file() -> String {
+    path_in_crate("nursery/UnitTest.move")
+        .into_os_string()
+        .into_string()
+        .unwrap()
+}
+
 pub fn path_in_crate<S>(relative: S) -> PathBuf
 where
     S: Into<String>,

--- a/language/move-vm/natives/Cargo.toml
+++ b/language/move-vm/natives/Cargo.toml
@@ -25,4 +25,4 @@ move-binary-format = { path = "../../move-binary-format" }
 
 [features]
 default = []
-debug_module = []
+testing = []

--- a/language/move-vm/natives/src/debug.rs
+++ b/language/move-vm/natives/src/debug.rs
@@ -24,7 +24,7 @@ pub fn native_print(
     debug_assert!(args.len() == 1);
 
     // No-op if the feature flag is not present.
-    #[cfg(feature = "debug_module")]
+    #[cfg(feature = "testing")]
     {
         let ty = ty_args.pop().unwrap();
         let r = pop_arg!(args, Reference);
@@ -46,7 +46,7 @@ pub fn native_print_stack_trace(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.is_empty());
 
-    #[cfg(feature = "debug_module")]
+    #[cfg(feature = "testing")]
     {
         let mut s = String::new();
         context.print_stack_trace(&mut s)?;

--- a/language/move-vm/natives/src/lib.rs
+++ b/language/move-vm/natives/src/lib.rs
@@ -11,4 +11,6 @@ pub mod event;
 pub mod hash;
 pub mod signature;
 pub mod signer;
+#[cfg(feature = "testing")]
+pub mod unit_test;
 pub mod vector;

--- a/language/move-vm/natives/src/unit_test.rs
+++ b/language/move-vm/natives/src/unit_test.rs
@@ -1,0 +1,33 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use move_binary_format::errors::PartialVMResult;
+use move_core_types::gas_schedule::ONE_GAS_UNIT;
+#[allow(unused_imports)]
+use move_vm_types::values::{values_impl::debug::print_reference, Reference};
+use move_vm_types::{
+    loaded_data::runtime_types::Type,
+    natives::function::{NativeContext, NativeResult},
+    values::Value,
+};
+use smallvec::smallvec;
+use std::collections::VecDeque;
+
+use move_core_types::account_address::AccountAddress;
+
+#[cfg(feature = "testing")]
+pub fn native_create_signers_for_testing(
+    _context: &mut impl NativeContext,
+    ty_args: Vec<Type>,
+    mut arguments: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(arguments.len() == 1);
+
+    let num_signers = pop_arg!(arguments, u64);
+    let signers = Value::vector_for_testing_only(
+        (0..num_signers).map(|i| Value::signer(AccountAddress::new((i as u128).to_le_bytes()))),
+    );
+
+    Ok(NativeResult::ok(ONE_GAS_UNIT, smallvec![signers]))
+}

--- a/language/move-vm/runtime/Cargo.toml
+++ b/language/move-vm/runtime/Cargo.toml
@@ -36,6 +36,6 @@ move-lang = { path = "../../move-lang" }
 
 [features]
 default = []
-debug_module = ["move-vm-natives/debug_module"]
+testing = ["move-vm-natives/testing"]
 fuzzing = ["move-vm-types/fuzzing"]
 failpoints = ["fail/failpoints"]

--- a/language/move-vm/types/src/values/values_impl.rs
+++ b/language/move-vm/types/src/values/values_impl.rs
@@ -110,21 +110,21 @@ enum ReferenceImpl {
 }
 
 // A reference to a signer. Clients can attempt a cast to this struct if they are
-// expecting a Signer on the stavk or as an argument.
+// expecting a Signer on the stack or as an argument.
 #[derive(Debug)]
 pub struct SignerRef(ContainerRef);
 
 // A reference to a vector. This is an alias for a ContainerRef for now but we may change
 // it once Containers are restructured.
 // It's used from vector native functions to get a reference to a vector and operate on that.
-// There is an impl for VecotrRef which implements the API private to this module.
+// There is an impl for VectorRef which implements the API private to this module.
 #[derive(Debug)]
 pub struct VectorRef(ContainerRef);
 
 // A vector. This is an alias for a Container for now but we may change
 // it once Containers are restructured.
 // It's used from vector native functions to get a vector and operate on that.
-// There is an impl for Vecotr which implements the API private to this module.
+// There is an impl for Vector which implements the API private to this module.
 #[derive(Debug)]
 pub struct Vector(Container);
 
@@ -139,7 +139,7 @@ pub struct Vector(Container);
  *
  *   They are opaque to an external caller by design -- no knowledge about the internal
  *   representation is given and they can only be manipulated via the public methods,
- *   which is to ensure no arbitratry invalid states can be created unless some crucial
+ *   which is to ensure no arbitrary invalid states can be created unless some crucial
  *   internal invariants are violated.
  *
  **************************************************************************************/
@@ -148,7 +148,7 @@ pub struct Vector(Container);
 #[derive(Debug)]
 pub struct StructRef(ContainerRef);
 
-/// A generic Move reference that offers two functinalities: read_ref & write_ref.
+/// A generic Move reference that offers two functionalities: read_ref & write_ref.
 #[derive(Debug)]
 pub struct Reference(ReferenceImpl);
 
@@ -1549,6 +1549,7 @@ fn check_elem_layout(
         (Type::Vector(_), Container::Vec(_)) => Ok(()),
 
         (Type::Struct(_), Container::Vec(_))
+        | (Type::Signer, Container::Vec(_))
         | (Type::StructInstantiation(_, _), Container::Vec(_)) => Ok(()),
 
         (Type::Reference(_), _) | (Type::MutableReference(_), _) | (Type::TyParam(_), _) => Err(

--- a/language/testing-infra/e2e-tests/Cargo.toml
+++ b/language/testing-infra/e2e-tests/Cargo.toml
@@ -22,7 +22,7 @@ diem-state-view = { path = "../../../storage/state-view" }
 diem-types = { path = "../../../types", features = ["fuzzing"] }
 diem-writeset-generator = { path = "../../diem-tools/writeset-transaction-generator" }
 move-core-types = { path = "../../move-core/types" }
-move-vm-runtime = { path = "../../move-vm/runtime", features = ["debug_module"] }
+move-vm-runtime = { path = "../../move-vm/runtime", features = ["testing"] }
 move-vm-types = { path = "../../move-vm/types" }
 move-binary-format = { path = "../../move-binary-format" }
 vm-genesis = { path = "../../tools/vm-genesis" }

--- a/language/tools/move-cli/Cargo.toml
+++ b/language/tools/move-cli/Cargo.toml
@@ -27,7 +27,7 @@ move-coverage = { path = "../move-coverage" }
 move-core-types = { path = "../../move-core/types" }
 move-lang = { path = "../../move-lang" }
 move-vm-types = { path = "../../move-vm/types" }
-move-vm-runtime = { path = "../../move-vm/runtime", features = ["debug_module"] }
+move-vm-runtime = { path = "../../move-vm/runtime", features = ["testing"] }
 read-write-set = { path = "../read-write-set" }
 resource-viewer = { path = "../resource-viewer" }
 move-binary-format = { path = "../../move-binary-format" }

--- a/language/tools/move-unit-test/Cargo.toml
+++ b/language/tools/move-unit-test/Cargo.toml
@@ -22,7 +22,7 @@ diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
 move-lang = { path = "../../move-lang" }
 move-vm-types = { path = "../../move-vm/types" }
-move-vm-runtime = { path = "../../move-vm/runtime", features = ["debug_module"] }
+move-vm-runtime = { path = "../../move-vm/runtime", features = ["testing"] }
 move-vm-test-utils = { path = "../../move-vm/test-utils" }
 resource-viewer = { path = "../resource-viewer" }
 move-binary-format = { path = "../../move-binary-format" }

--- a/language/tools/move-unit-test/src/lib.rs
+++ b/language/tools/move-unit-test/src/lib.rs
@@ -96,9 +96,20 @@ impl UnitTestingConfig {
 
     /// Build a test plan from a unit test config
     pub fn build_test_plan(&self) -> Option<TestPlan> {
+        let mut source_files = self.source_files.clone();
+
+        // We always need to have the unit testing module in otherwise the modules will fail to
+        // compile in test mode
+        if !source_files
+            .iter()
+            .any(|file_path| file_path.contains("UnitTest.move"))
+        {
+            source_files.push(move_stdlib::unit_testing_module_file());
+        }
+
         let mut compilation_env = CompilationEnv::new(Flags::testing());
         let (files, pprog_and_comments_res) =
-            move_lang::move_parse(&compilation_env, &self.source_files, &[], None).ok()?;
+            move_lang::move_parse(&compilation_env, &source_files, &[], None).ok()?;
         let (_, pprog) = move_lang::unwrap_or_report_errors!(files, pprog_and_comments_res);
         let cfgir_result = move_lang::move_continue_up_to(
             &mut compilation_env,

--- a/language/tools/move-unit-test/tests/test_sources/native_signer_creation.exp
+++ b/language/tools/move-unit-test/tests/test_sources/native_signer_creation.exp
@@ -1,0 +1,25 @@
+Running Move unit tests
+[ PASS    ] 0x1::M::test_determinisim
+[ FAIL    ] 0x1::M::test_doesnt_exist
+[ PASS    ] 0x1::M::test_exists
+
+Test failures:
+
+Failures in 0x1::M:
+
+┌── test_doesnt_exist ──────
+│ error: 
+│ 
+│     ┌── tests/test_sources/native_signer_creation.move:47:9 ───
+│     │
+│  47 │         abort 0
+│     │         ^^^^^^^ Test was not expected to abort but it aborted with 0 here
+│     ·
+│  36 │     fun test_doesnt_exist() {
+│     │         ----------------- In this function in 0x1::M
+│     │
+│ 
+│ 
+└──────────────────
+
+Test result: FAILED. Total tests: 3; passed: 2; failed: 1

--- a/language/tools/move-unit-test/tests/test_sources/native_signer_creation.move
+++ b/language/tools/move-unit-test/tests/test_sources/native_signer_creation.move
@@ -1,0 +1,67 @@
+module 0x1::M {
+    use 0x1::UnitTest;
+    use 0x1::Vector;
+    use 0x1::Signer;
+
+    struct A has key {}
+
+    fun has_a(a: address): bool {
+        exists<A>(a)
+    }
+
+    #[test_only]
+    fun setup_storage(sig: &signer) {
+        move_to(sig, A { })
+    }
+
+    #[test]
+    fun test_exists() {
+        let num_signers = 10;
+        let i = 0;
+
+        let signers = UnitTest::create_signers_for_testing(num_signers);
+        while (i < num_signers) {
+            setup_storage(Vector::borrow(&signers, i));
+            i = i + 1;
+        };
+
+        i = 0;
+        while (i < num_signers) {
+            assert(has_a(Signer::address_of(Vector::borrow(&signers, i))), 0);
+            i = i + 1;
+        }
+    }
+
+    #[test]
+    fun test_doesnt_exist() {
+        let num_signers = 10;
+        let i = 0;
+
+        let signers = UnitTest::create_signers_for_testing(num_signers);
+        while (i < num_signers) {
+            setup_storage(Vector::borrow(&signers, i));
+            i = i + 1;
+        };
+
+        // abort to trigger a dump of storage state to make sure this is getting populated correctly
+        abort 0
+
+    }
+
+    #[test]
+    fun test_determinisim() {
+        let num_signers = 10;
+        let i = 0;
+        let signers = UnitTest::create_signers_for_testing(num_signers);
+        let other_signers = UnitTest::create_signers_for_testing(num_signers);
+
+        while (i < num_signers) {
+            assert(
+                Signer::address_of(Vector::borrow(&signers, i)) ==
+                  Signer::address_of(Vector::borrow(&other_signers, i)),
+                i
+            );
+            i = i + 1;
+        };
+    }
+}

--- a/language/tools/move-unit-test/tests/test_sources/native_signer_creation.storage.exp
+++ b/language/tools/move-unit-test/tests/test_sources/native_signer_creation.storage.exp
@@ -1,0 +1,67 @@
+Running Move unit tests
+[ PASS    ] 0x1::M::test_determinisim
+[ FAIL    ] 0x1::M::test_doesnt_exist
+[ PASS    ] 0x1::M::test_exists
+
+Test failures:
+
+Failures in 0x1::M:
+
+┌── test_doesnt_exist ──────
+│ error: 
+│ 
+│     ┌── tests/test_sources/native_signer_creation.move:47:9 ───
+│     │
+│  47 │         abort 0
+│     │         ^^^^^^^ Test was not expected to abort but it aborted with 0 here
+│     ·
+│  36 │     fun test_doesnt_exist() {
+│     │         ----------------- In this function in 0x1::M
+│     │
+│ 
+│ 
+│ ────── Storage state at point of failure ──────
+│ 0x0:
+│ 	=> key 0x1::M::A {
+│ 	    dummy_field: false
+│ 	}
+│ 0x1000000000000000000000000000000:
+│ 	=> key 0x1::M::A {
+│ 	    dummy_field: false
+│ 	}
+│ 0x2000000000000000000000000000000:
+│ 	=> key 0x1::M::A {
+│ 	    dummy_field: false
+│ 	}
+│ 0x3000000000000000000000000000000:
+│ 	=> key 0x1::M::A {
+│ 	    dummy_field: false
+│ 	}
+│ 0x4000000000000000000000000000000:
+│ 	=> key 0x1::M::A {
+│ 	    dummy_field: false
+│ 	}
+│ 0x5000000000000000000000000000000:
+│ 	=> key 0x1::M::A {
+│ 	    dummy_field: false
+│ 	}
+│ 0x6000000000000000000000000000000:
+│ 	=> key 0x1::M::A {
+│ 	    dummy_field: false
+│ 	}
+│ 0x7000000000000000000000000000000:
+│ 	=> key 0x1::M::A {
+│ 	    dummy_field: false
+│ 	}
+│ 0x8000000000000000000000000000000:
+│ 	=> key 0x1::M::A {
+│ 	    dummy_field: false
+│ 	}
+│ 0x9000000000000000000000000000000:
+│ 	=> key 0x1::M::A {
+│ 	    dummy_field: false
+│ 	}
+│ 
+└──────────────────
+
+Test result: FAILED. Total tests: 3; passed: 2; failed: 1

--- a/language/tools/move-unit-test/tests/test_sources/use_unit_test_module.exp
+++ b/language/tools/move-unit-test/tests/test_sources/use_unit_test_module.exp
@@ -1,0 +1,3 @@
+Running Move unit tests
+[ PASS    ] 0x1::M::poison_call
+Test result: OK. Total tests: 1; passed: 1; failed: 0

--- a/language/tools/move-unit-test/tests/test_sources/use_unit_test_module.move
+++ b/language/tools/move-unit-test/tests/test_sources/use_unit_test_module.move
@@ -1,0 +1,8 @@
+module 0x1::M {
+    use 0x1::UnitTest;
+
+    #[test]
+    fun poison_call() {
+        UnitTest::create_signers_for_testing(0);
+    }
+}


### PR DESCRIPTION
This PR adds a new feature flag `"testing`" to the VM and rolls-in the "`debug_module`" feature flag functionality into this flag as well. Test-only natives are then conditionally compiled in the VM based on this flag. 


This PR then use this functionality to add a test-only neative `create_signers_for_testing` that given a number `n` returns a vector of unique signers of length `n`. No guarantees are made about the values, or ordering of the values inside of this returned vector other than that the values and ordering are deterministic. This new native function can then be used in unit tests to create an arbitrary number of signer values (see new unit-test tests). 

Additionally, whenever a module is compiled in `test` mode, we add a function with a call to `create_signers_for_testing`:
```
fun unit_test_poison() {
  0x1::UnitTest::create_signers_for_testing(0);
  ()
}
```
This way, if an attempt to publish a module compiled in test mode is made in a VM that hasn't been compiled with the "testing" feature set, a linker error will be raised at the time of publication (and not at runtime!). 
