### PR TITLE
[language] remove dependency on diem-proptest-helpers from language-benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3988,7 +3988,6 @@ dependencies = [
  "bytecode-verifier",
  "criterion",
  "criterion-cpu-time",
- "diem-proptest-helpers",
  "diem-state-view",
  "diem-types",
  "diem-vm",

--- a/language/benchmarks/Cargo.toml
+++ b/language/benchmarks/Cargo.toml
@@ -18,7 +18,6 @@ criterion-cpu-time = "0.1.0"
 
 bytecode-verifier = { path = "../bytecode-verifier" }
 language-e2e-tests = { path = "../testing-infra/e2e-tests" }
-diem-proptest-helpers = { path = "../../common/proptest-helpers" }
 diem-state-view = { path = "../../storage/state-view" }
 diem-types = { path = "../../types", features = ["fuzzing"] }
 diem-workspace-hack = { path = "../../common/workspace-hack" }

--- a/x.toml
+++ b/x.toml
@@ -252,7 +252,6 @@ existing_deps = [
     ["language-benchmarks", "diem-vm"],
     ["language-benchmarks", "diem-types"],
     ["language-benchmarks", "diem-state-view"],
-    ["language-benchmarks", "diem-proptest-helpers"],
     ["test-generation", "language-e2e-tests"],
     ["test-generation", "diem-vm"],
     ["test-generation", "diem-types"],


### PR DESCRIPTION
This removes `diem-proptest-helpers` as a dependency from `language-benchmark`.