### PR TITLE
[Operational Tool] Make backend arguments optional for non-required commands

### DIFF
--- a/config/management/genesis/src/key.rs
+++ b/config/management/genesis/src/key.rs
@@ -7,7 +7,7 @@ use diem_management::{
     error::Error,
     secure_backend::{SecureBackend, SharedBackend},
 };
-use std::path::PathBuf;
+use std::{convert::TryFrom, path::PathBuf, str::FromStr};
 use structopt::StructOpt;
 
 diem_management::secure_backend!(

--- a/config/management/network-address-encryption/src/lib.rs
+++ b/config/management/network-address-encryption/src/lib.rs
@@ -50,11 +50,17 @@ impl Encryptor {
         }
     }
 
-    /// This generates an Encryptor for use in default / testing scenarios where (proper)
-    /// encryption is not necessary.
-    pub fn for_testing() -> Self {
+    /// This generates an empty encryptor for use in scenarios where encryption is not necessary.
+    /// Any encryption operations (e.g., encrypt / decrypt) will return errors.
+    pub fn empty() -> Self {
         let storage = Storage::InMemoryStorage(diem_secure_storage::InMemoryStorage::new());
-        let mut encryptor = Encryptor::new(storage);
+        Encryptor::new(storage)
+    }
+
+    /// This generates an encryptor for use in testing scenarios. The encryptor is
+    /// initialized with a test network encryption key.
+    pub fn for_testing() -> Self {
+        let mut encryptor = Self::empty();
         encryptor.initialize_for_testing().unwrap();
         encryptor
     }

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -457,19 +457,25 @@ impl OperationalTool {
     pub fn validator_config(
         &self,
         account_address: AccountAddress,
-        backend: &config::SecureBackend,
+        backend: Option<&config::SecureBackend>,
     ) -> Result<DecryptedValidatorConfig, Error> {
+        let validator_backend = if let Some(backend) = backend {
+            Some(backend_args(backend)?)
+        } else {
+            None
+        };
+
         let args = format!(
             "
                 {command}
                 --json-server {json_server}
                 --account-address {account_address}
-                --validator-backend {backend_args}
+                {validator_backend}
             ",
             command = command(TOOL_NAME, CommandName::ValidatorConfig),
             json_server = self.host,
             account_address = account_address,
-            backend_args = backend_args(backend)?,
+            validator_backend = optional_arg("validator-backend", validator_backend),
         );
 
         let command = Command::from_iter(args.split_whitespace());
@@ -479,19 +485,25 @@ impl OperationalTool {
     pub fn validator_set(
         &self,
         account_address: Option<AccountAddress>,
-        backend: &config::SecureBackend,
+        backend: Option<&config::SecureBackend>,
     ) -> Result<Vec<DecryptedValidatorInfo>, Error> {
+        let validator_backend = if let Some(backend) = backend {
+            Some(backend_args(backend)?)
+        } else {
+            None
+        };
+
         let args = format!(
             "
                 {command}
                 {account_address}
                 --json-server {json_server}
-                --validator-backend {backend_args}
+                {validator_backend}
             ",
             command = command(TOOL_NAME, CommandName::ValidatorSet),
             json_server = self.host,
             account_address = optional_arg("account-address", account_address),
-            backend_args = backend_args(backend)?,
+            validator_backend = optional_arg("validator-backend", validator_backend),
         );
 
         let command = Command::from_iter(args.split_whitespace());

--- a/config/management/src/secure_backend.rs
+++ b/config/management/src/secure_backend.rs
@@ -163,6 +163,18 @@ pair: "k0=v0;k1=v1;...".  The current supported formats are:
             )]
             pub $field_name: Option<SecureBackend>,
         }
+
+        impl FromStr for $struct_name {
+            type Err = Error;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                let secure_backend = SecureBackend::try_from(s)?;
+                let $field_name = $struct_name {
+                    $field_name: Some(secure_backend),
+                };
+                Ok($field_name)
+            }
+        }
     };
 }
 

--- a/testsuite/smoke-test/src/consensus.rs
+++ b/testsuite/smoke-test/src/consensus.rs
@@ -121,7 +121,7 @@ fn rotate_operator_and_consensus_key(env: SmokeTestEnvironment, num_nodes: usize
     // Verify that the config has been updated correctly with the new consensus key
     let validator_account = storage.get::<AccountAddress>(OWNER_ACCOUNT).unwrap().value;
     let config_consensus_key = op_tool
-        .validator_config(validator_account, &backend)
+        .validator_config(validator_account, Some(&backend))
         .unwrap()
         .consensus_public_key;
     assert_eq!(new_consensus_key, config_consensus_key);

--- a/testsuite/smoke-test/src/genesis.rs
+++ b/testsuite/smoke-test/src/genesis.rs
@@ -98,7 +98,7 @@ fn test_genesis_transaction_flow() {
     let op_tool = get_op_tool(&env.validator_swarm, 0);
     let diem_root = load_diem_root_storage(&env.validator_swarm, 0);
     let config = op_tool
-        .validator_config(validator_address, &diem_root)
+        .validator_config(validator_address, Some(&diem_root))
         .unwrap();
     let name = config.name.as_bytes().to_vec();
 


### PR DESCRIPTION
## Motivation

This PR updates the operational tool to allow backends to be made optional for two commands: `validator-set` and `validator-config`. Both of these commands use a backend to fetch the network encryption keys to decrypt the on-chain validator addresses before printing the data to the command line. However, decryption is not always required by users (e.g., if someone just wants to view a validator config on-chain without having access to the network key). With this PR, the backend need not be specified in these cases.

The PR offers two commits to achieve this:
1. First, we add an empty encryptor to the Encryption struct. This allows us to run the commands with a dummy encryptor, so that not much internal code needs to change.
2. Second, we update the commands to support optional backends and update the smoke tests to verify this behaviour.

Note: This PR is in response to the feature request: https://github.com/diem/diem/issues/8291

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

I've updated the smoke test to check that the command works without specifying a backend. Moreover, running the tool manually shows us that the argument is no longer required, but optional:

```
% ./diem-operational-tool validator-config --json-server https://premainnet.libra.org --account-address 88C5DB7AD36F7A66A8FB2789FBDB30CC
Unable to decode network address for account 88C5DB7AD36F7A66A8FB2789FBDB30CC: Failed reading validator_network_address_keys from storage. Using a dummy validator network address!
{
  "Result": {
    "name": "a16z",
    "consensus_public_key": "decd03c332598fc9a19df70502d3ce53f14bf944d4250c01cfaa07fdfa98f412",
    "validator_network_address": "/dns4/could-not-decrypt",
    "fullnode_network_address": "/dns4/a1ef5c88a600111eb81de0a895a70996-8c2df3c37a850a49.elb.ap-northeast-1.amazonaws.com/tcp/6182/ln-noise-ik/39ef4d3505639d2f1142300fbc708cdbe102ec4bc6b6dbf74b938185962d0c48/ln-handshake/0"
  }
}
```

```
% ./diem-operational-tool validator-config --json-server https://premainnet.libra.org --account-address 88C5DB7AD36F7A66A8FB2789FBDB30CC --validator-backend backend=memory
Unable to decode network address for account 88C5DB7AD36F7A66A8FB2789FBDB30CC: Failed reading validator_network_address_keys from storage. Using a dummy validator network address!
{
  "Result": {
    "name": "a16z",
    "consensus_public_key": "decd03c332598fc9a19df70502d3ce53f14bf944d4250c01cfaa07fdfa98f412",
    "validator_network_address": "/dns4/could-not-decrypt",
    "fullnode_network_address": "/dns4/a1ef5c88a600111eb81de0a895a70996-8c2df3c37a850a49.elb.ap-northeast-1.amazonaws.com/tcp/6182/ln-noise-ik/39ef4d3505639d2f1142300fbc708cdbe102ec4bc6b6dbf74b938185962d0c48/ln-handshake/0"
  }
}
```

```
% ./diem-operational-tool validator-set --json-server https://premainnet.libra.org                                                                                   
Unable to decode network address for account 88C5DB7AD36F7A66A8FB2789FBDB30CC: Failed reading validator_network_address_keys from storage. Using a dummy validator network address!
...
{
  "Result": [
    {
      "name": "a16z",
      "account_address": "88c5db7ad36f7a66a8fb2789fbdb30cc",
      "consensus_public_key": "decd03c332598fc9a19df70502d3ce53f14bf944d4250c01cfaa07fdfa98f412",
      "fullnode_network_address": "/dns4/a1ef5c88a600111eb81de0a895a70996-8c2df3c37a850a49.elb.ap-northeast-1.amazonaws.com/tcp/6182/ln-noise-ik/39ef4d3505639d2f1142300fbc708cdbe102ec4bc6b6dbf74b938185962d0c48/ln-handshake/0",
      "validator_network_address": "/dns4/could-not-decrypt"
    },
   ...
}
```

```
% ./diem-operational-tool validator-set --json-server https://premainnet.libra.org --validator-backend backend=memory
                                                                                   
Unable to decode network address for account 88C5DB7AD36F7A66A8FB2789FBDB30CC: Failed reading validator_network_address_keys from storage. Using a dummy validator network address!
...
{
  "Result": [
    {
      "name": "a16z",
      "account_address": "88c5db7ad36f7a66a8fb2789fbdb30cc",
      "consensus_public_key": "decd03c332598fc9a19df70502d3ce53f14bf944d4250c01cfaa07fdfa98f412",
      "fullnode_network_address": "/dns4/a1ef5c88a600111eb81de0a895a70996-8c2df3c37a850a49.elb.ap-northeast-1.amazonaws.com/tcp/6182/ln-noise-ik/39ef4d3505639d2f1142300fbc708cdbe102ec4bc6b6dbf74b938185962d0c48/ln-handshake/0",
      "validator_network_address": "/dns4/could-not-decrypt"
    },
   ...
}
```

## Related PRs

None. But this relates to: https://github.com/diem/diem/issues/8291
