### PR TITLE
[sdk] Add client support for get_account_by_version

### DIFF
--- a/sdk/client/src/blocking.rs
+++ b/sdk/client/src/blocking.rs
@@ -138,6 +138,14 @@ impl BlockingClient {
         self.send(MethodRequest::get_account(address))
     }
 
+    pub fn get_account_by_version(
+        &self,
+        address: AccountAddress,
+        version: u64,
+    ) -> Result<Response<Option<AccountView>>> {
+        self.send(MethodRequest::get_account_by_version(address, version))
+    }
+
     pub fn get_transactions(
         &self,
         start_seq: u64,

--- a/sdk/client/src/client.rs
+++ b/sdk/client/src/client.rs
@@ -149,6 +149,15 @@ impl Client {
         self.send(MethodRequest::get_account(address)).await
     }
 
+    pub async fn get_account_by_version(
+        &self,
+        address: AccountAddress,
+        version: u64,
+    ) -> Result<Response<Option<AccountView>>> {
+        self.send(MethodRequest::get_account_by_version(address, version))
+            .await
+    }
+
     pub async fn get_transactions(
         &self,
         start_seq: u64,

--- a/sdk/client/src/request.rs
+++ b/sdk/client/src/request.rs
@@ -12,7 +12,7 @@ use std::sync::atomic::AtomicU64;
 pub enum MethodRequest {
     Submit((String,)),
     GetMetadata((Option<u64>,)),
-    GetAccount((AccountAddress,)),
+    GetAccount(AccountAddress, Option<u64>),
     GetTransactions(u64, u64, bool),
     GetAccountTransaction(AccountAddress, u64, bool),
     GetAccountTransactions(AccountAddress, u64, u64, bool),
@@ -43,8 +43,12 @@ impl MethodRequest {
         Self::GetMetadata((None,))
     }
 
+    pub fn get_account_by_version(address: AccountAddress, version: u64) -> Self {
+        Self::GetAccount(address, Some(version))
+    }
+
     pub fn get_account(address: AccountAddress) -> Self {
-        Self::GetAccount((address,))
+        Self::GetAccount(address, None)
     }
 
     pub fn get_transactions(start_seq: u64, limit: u64, include_events: bool) -> Self {
@@ -89,10 +93,10 @@ impl MethodRequest {
     }
     pub fn get_account_state_with_proof(
         address: AccountAddress,
-        from_version: Option<u64>,
-        to_version: Option<u64>,
+        version: Option<u64>,
+        ledger_version: Option<u64>,
     ) -> Self {
-        Self::GetAccountStateWithProof(address, from_version, to_version)
+        Self::GetAccountStateWithProof(address, version, ledger_version)
     }
 
     pub fn get_transactions_with_proofs(start_version: u64, limit: u64) -> Self {
@@ -107,7 +111,7 @@ impl MethodRequest {
         match self {
             MethodRequest::Submit(_) => Method::Submit,
             MethodRequest::GetMetadata(_) => Method::GetMetadata,
-            MethodRequest::GetAccount(_) => Method::GetAccount,
+            MethodRequest::GetAccount(_, _) => Method::GetAccount,
             MethodRequest::GetTransactions(_, _, _) => Method::GetTransactions,
             MethodRequest::GetAccountTransaction(_, _, _) => Method::GetAccountTransaction,
             MethodRequest::GetAccountTransactions(_, _, _, _) => Method::GetAccountTransactions,


### PR DESCRIPTION
We previously added support for getting an account at a historical version at the json-rpc server layer here: https://github.com/diem/diem/pull/7983

This PR finally adds support to the client. Here, we add a new method `get_account_by_version` for convenience, while the actual `MethodRequest::GetAccount` enum just gets an extra `Option<u64>` version parameter.