### PR TITLE
[x] Workaround x context to let us build and run xtest without a git repo

### DIFF
--- a/devtools/x-lint/src/runner.rs
+++ b/devtools/x-lint/src/runner.rs
@@ -239,7 +239,8 @@ impl<'cfg> LintEngine<'cfg> {
     // ---
 
     fn file_list(&self) -> Result<impl Iterator<Item = &'cfg Utf8Path> + 'cfg> {
-        let tracked_files = self.config.core.git_cli().tracked_files()?;
+        let git_cli = self.config.core.git_cli()?;
+        let tracked_files = git_cli.tracked_files()?;
         // TODO: make global exclusions configurable
         Ok(tracked_files
             .iter()


### PR DESCRIPTION
## Motivation

Workaround x context git dep to allow unzipped code to benefit from x (namely fuzzing done by fb's in house fuzzer, lionhead).

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

CI/local unzipped diem repo.

Local Downloaded Artifact:

```
rexhoffman@rexhoffman-mbp diem-main % cargo x changed-since ghjkl67890-
    Finished dev [unoptimized + debuginfo] target(s) in 0.37s
     Running `target/debug/x changed-since ghjkl67890-`
fatal: not a git repository (or any of the parent directories): .git
Error: git root error: unable to find a git repo at /Users/rexhoffman/Downloads/diem-main
(hint: did you download an archive from GitHub? x requires a git clone)
```

```
rexhoffman@rexhoffman-mbp diem-main % cargo xtest --changed-since 3456789o0p-
    Finished dev [unoptimized + debuginfo] target(s) in 0.39s
     Running `target/debug/x test --changed-since 3456789o0p-`
fatal: not a git repository (or any of the parent directories): .git
Error: May only use --changes-since if working in a local git repository.
```

With latest changes:

```
    Finished dev [unoptimized + debuginfo] target(s) in 12.17s
     Running `target/debug/x changed-since ghjkl67890-`
fatal: not a git repository (or any of the parent directories): .git
Error: `x changed-since` must be run within a project cloned from a git repo.

Caused by:
    git root error: unable to find a git repo at /Users/rexhoffman/Downloads/diem-main
    (hint: did you download an archive from GitHub? x requires a git clone)
```    
    
```
rexhoffman@rexhoffman-mbp diem-main % cargo xtest --changed-since 3456789o0p- 
    Finished dev [unoptimized + debuginfo] target(s) in 0.66s
     Running `target/debug/x test --changed-since 3456789o0p-`
fatal: not a git repository (or any of the parent directories): .git
Error: May only use --changes-since if working in a local git repository.

Caused by:
    git root error: unable to find a git repo at /Users/rexhoffman/Downloads/diem-main
    (hint: did you download an archive from GitHub? x requires a git clone)
```
And xclippy:
```
rexhoffman@rexhoffman-mbp diem-main % cargo xclippy --changed-since 4567890-
    Finished dev [unoptimized + debuginfo] target(s) in 0.37s
     Running `target/debug/x clippy --changed-since 4567890-`
fatal: not a git repository (or any of the parent directories): .git
Error: May only use --changes-since if working in a local git repository.

Caused by:
    git root error: unable to find a git repo at /Users/rexhoffman/Downloads/diem-main
    (hint: did you download an archive from GitHub? x requires a git clone)
```
Otherwise builds successfully.

## Related PRs

None

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
