### PR TITLE
[executor-benchmark] Executor benchmark criterion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2900,6 +2900,7 @@ dependencies = [
 name = "executor-benchmark"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "diem-config",
  "diem-crypto",
  "diem-genesis-tool",

--- a/execution/executor-benchmark/Cargo.toml
+++ b/execution/executor-benchmark/Cargo.toml
@@ -14,6 +14,7 @@ itertools = { version = "0.10.0", default-features = false }
 rand = "0.8.3"
 rayon = "1.5.0"
 structopt = "0.3.21"
+criterion = "0.3.4"
 
 executor = { path = "../executor" }
 executor-types = { path = "../executor-types" }
@@ -34,3 +35,7 @@ diem-transaction-builder = { path = "../../sdk/transaction-builder" }
 [features]
 default = []
 fuzzing = ["diem-config/fuzzing", "diem-crypto/fuzzing", "diem-types/fuzzing"]
+
+[[bench]]
+name = "executor_benchmark"
+harness = false

--- a/execution/executor-benchmark/benches/executor_benchmark.rs
+++ b/execution/executor-benchmark/benches/executor_benchmark.rs
@@ -1,0 +1,68 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use criterion::{criterion_group, criterion_main, measurement::Measurement, BatchSize, Criterion};
+use executor_benchmark::{
+    create_storage_service_and_executor, TransactionExecutor, TransactionGenerator,
+};
+
+pub const NUM_ACCOUNTS: usize = 1000;
+pub const SMALL_BLOCK_SIZE: usize = 500;
+pub const MEDIUM_BLOCK_SIZE: usize = 1000;
+pub const LARGE_BLOCK_SIZE: usize = 1000;
+pub const INITIAL_BALANCE: u64 = 1000000;
+
+//
+// Transaction benchmarks
+//
+
+fn executor_benchmark<M: Measurement + 'static>(c: &mut Criterion<M>) {
+    let (config, genesis_key) = diem_genesis_tool::test_config();
+
+    let (_db, executor) = create_storage_service_and_executor(&config);
+    let parent_block_id = executor.committed_block_id();
+
+    let mut generator = TransactionGenerator::new(genesis_key, NUM_ACCOUNTS);
+
+    let mut executor = TransactionExecutor::new(executor, parent_block_id);
+    let txns = generator.gen_account_creations(SMALL_BLOCK_SIZE);
+    for txn_block in txns {
+        executor.execute_block(txn_block);
+    }
+    let txns = generator.gen_mint_transactions(INITIAL_BALANCE, SMALL_BLOCK_SIZE);
+    for txn_block in txns {
+        executor.execute_block(txn_block);
+    }
+
+    c.bench_function("bench_p2p_small", |bencher| {
+        bencher.iter_batched(
+            || generator.gen_transfer_transactions(SMALL_BLOCK_SIZE, 1),
+            |mut txn_block| executor.execute_block(txn_block.pop().unwrap()),
+            BatchSize::LargeInput,
+        )
+    });
+
+    c.bench_function("bench_p2p_medium", |bencher| {
+        bencher.iter_batched(
+            || generator.gen_transfer_transactions(MEDIUM_BLOCK_SIZE, 1),
+            |mut txn_block| executor.execute_block(txn_block.pop().unwrap()),
+            BatchSize::LargeInput,
+        )
+    });
+
+    c.bench_function("bench_p2p_large", |bencher| {
+        bencher.iter_batched(
+            || generator.gen_transfer_transactions(LARGE_BLOCK_SIZE, 1),
+            |mut txn_block| executor.execute_block(txn_block.pop().unwrap()),
+            BatchSize::LargeInput,
+        )
+    });
+}
+
+criterion_group!(
+    name = txn_benches;
+    config = Criterion::default().sample_size(10);
+    targets = executor_benchmark
+);
+
+criterion_main!(txn_benches);


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Implement a criterion bencher for transaction execution and commit pipeline so that we can better collect perf signals for execution pipeline.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

`cargo bench` under `executor_benchmark` yields following output:

```
Benchmarking bench_p2p: Warming up for 3.0000 s
Warning: Unable to complete 20 samples in 5.0s. You may wish to increase target time to 10.6s, or reduce sample count to 10.
bench_p2p               time:   [464.14 ms 479.71 ms 497.26 ms]                    
                        change: [-2.6016% +0.5619% +4.5145%] (p = 0.72 > 0.05)
                        No change in performance detected.
Found 3 outliers among 20 measurements (15.00%)
  3 (15.00%) high severe
```
The current experiment is measuring the e2e time of executing and committing a transaction block consisted of 500, 1000 and 2000 p2p transactions.
