### PR TITLE
[x] update nextest runner 

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -12,7 +12,7 @@ defaults:
 
 env:
   max_threads: 16
-  nextest_tries: 3
+  nextest_profile: ci-test
   pre_command: cd /opt/git/diem/
 
 jobs:
@@ -518,7 +518,7 @@ jobs:
           restore-keys: "crates-${{ runner.os }}"
       - name: run unit tests
         run: |
-          $pre_command && mkdir -p target/junit-reports && cargo nextest --jobs ${max_threads} --tries ${nextest_tries} --unit --failure-output=immediate-final --changed-since "origin/$TARGET_BRANCH" --junit target/junit-reports/unit-test.xml
+          $pre_command && cargo nextest --jobs ${max_threads} --test-profile ${nextest_profile} --unit --changed-since "origin/$TARGET_BRANCH"
           sccache -s
         env:
           TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
@@ -533,7 +533,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: unit-test-results
-          path: target/junit-reports/unit-test.xml
+          path: target/nextest-reports/nextest-junit.xml
       - uses: ./.github/actions/build-teardown
 
   unit-test-sccache:
@@ -560,7 +560,7 @@ jobs:
           restore-keys: "crates-${{ runner.os }}"
       - name: run unit tests
         run: |
-          $pre_command && mkdir -p target/junit-reports && cargo nextest --jobs ${max_threads} --tries ${nextest_tries} --unit --failure-output=immediate-final --changed-since "origin/$TARGET_BRANCH" --junit target/junit-reports/unit-test.xml
+          $pre_command && cargo nextest --jobs ${max_threads} --test-profile ${nextest_profile} --unit --changed-since "origin/$TARGET_BRANCH"
           sccache -s
         env:
           TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
@@ -579,7 +579,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: unit-test-results
-          path: target/junit-reports/unit-test.xml
+          path: target/nextest-reports/nextest-junit.xml
       - uses: ./.github/actions/build-teardown
 
   codegen-unit-test:
@@ -603,7 +603,7 @@ jobs:
           key: crates-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: "crates-${{ runner.os }}"
       - name: run codegen unit tests
-        run: $pre_command && mkdir -p target/junit-reports && cargo nextest --jobs ${max_threads} --tries ${nextest_tries} --failure-output=immediate-final -p transaction-builder-generator --unit --changed-since "origin/$TARGET_BRANCH" --run-ignored=ignored-only --junit target/junit-reports/codegen-unit-test.xml
+        run: $pre_command && cargo nextest --jobs ${max_threads} --test-profile ${nextest_profile} -p transaction-builder-generator --unit --changed-since "origin/$TARGET_BRANCH" --run-ignored=ignored-only
         env:
           TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
       - name: upload codegen test results
@@ -611,7 +611,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: codegen-unit-test-results
-          path: target/junit-reports/codegen-unit-test.xml
+          path: target/nextest-reports/nextest-junit.xml
       - uses: ./.github/actions/build-teardown
 
   codegen-unit-test-sccache:
@@ -636,7 +636,7 @@ jobs:
           key: crates-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: "crates-${{ runner.os }}"
       - name: run codegen unit tests
-        run: $pre_command && mkdir -p target/junit-reports && cargo nextest --jobs ${max_threads} --tries ${nextest_tries} --failure-output=immediate-final -p transaction-builder-generator --unit --changed-since "origin/$TARGET_BRANCH" --run-ignored=ignored-only --junit target/junit-reports/codegen-unit-test.xml
+        run: $pre_command && cargo nextest --jobs ${max_threads} --test-profile ${nextest_profile} -p transaction-builder-generator --unit --changed-since "origin/$TARGET_BRANCH" --run-ignored=ignored-only
         env:
           TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
           SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.ENV_DIEM_S3_AWS_ACCESS_KEY_ID }}
@@ -646,7 +646,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: codegen-unit-test-results
-          path: target/junit-reports/codegen-unit-test.xml
+          path: target/nextest-reports/nextest-junit.xml
       - uses: ./.github/actions/build-teardown
 
   e2e-test:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4830,9 +4830,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "nextest-config"
+version = "0.1.0"
+source = "git+https://github.com/diem/diem-devtools?rev=135c929f93723467534387c6e0372908f863fad6#135c929f93723467534387c6e0372908f863fad6"
+dependencies = [
+ "anyhow",
+ "camino",
+ "serde",
+ "toml",
+]
+
+[[package]]
 name = "nextest-runner"
 version = "0.1.0"
-source = "git+https://github.com/diem/diem-devtools?rev=1b61853016059b2dca577cefafff2825b49494a0#1b61853016059b2dca577cefafff2825b49494a0"
+source = "git+https://github.com/diem/diem-devtools?rev=135c929f93723467534387c6e0372908f863fad6#135c929f93723467534387c6e0372908f863fad6"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -4841,6 +4852,7 @@ dependencies = [
  "chrono",
  "crossbeam-channel",
  "duct",
+ "nextest-config",
  "num_cpus",
  "once_cell",
  "quick-junit",
@@ -4850,6 +4862,7 @@ dependencies = [
  "signal-hook",
  "structopt 0.3.21",
  "termcolor",
+ "twox-hash",
 ]
 
 [[package]]
@@ -5686,7 +5699,7 @@ checksum = "3ac73b1112776fc109b2e61909bc46c7e1bf0d7f690ffb1676553acce16d5cda"
 [[package]]
 name = "quick-junit"
 version = "0.1.0"
-source = "git+https://github.com/diem/diem-devtools?rev=1b61853016059b2dca577cefafff2825b49494a0#1b61853016059b2dca577cefafff2825b49494a0"
+source = "git+https://github.com/diem/diem-devtools?rev=135c929f93723467534387c6e0372908f863fad6#135c929f93723467534387c6e0372908f863fad6"
 dependencies = [
  "chrono",
  "indexmap",

--- a/Nextest.toml
+++ b/Nextest.toml
@@ -1,0 +1,20 @@
+# This is configuration for `cargo nextest`.
+
+default-profile = "diem"
+
+[profiles.diem]
+name = "diem-run"
+failure-output = "immediate"
+
+# Profile used in CI tests.
+[profiles.ci-test]
+name = "diem-ci-test-run"
+retries = 2
+# Output failures at the end of the run to make it easier to scan logs.
+failure-output = "immediate-final"
+metadata-key = "diem-junit"
+
+# Metadata config used in CI tests.
+[metadata.diem-junit]
+dir = "target/nextest"
+junit = "../nextest-reports/nextest-junit.xml"

--- a/devtools/x-core/src/errors.rs
+++ b/devtools/x-core/src/errors.rs
@@ -1,17 +1,11 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use camino::{Utf8Path, Utf8PathBuf};
 use guppy::TargetSpecError;
 use hex::FromHexError;
 use serde::{de, ser};
-use std::{
-    borrow::Cow,
-    error, fmt, io,
-    path::{Path, PathBuf},
-    process::ExitStatus,
-    result,
-    str::Utf8Error,
-};
+use std::{borrow::Cow, error, fmt, io, process::ExitStatus, result, str::Utf8Error};
 
 /// Type alias for the return type for `run` methods.
 pub type Result<T, E = SystemError> = result::Result<T, E>;
@@ -21,8 +15,8 @@ pub type Result<T, E = SystemError> = result::Result<T, E>;
 #[non_exhaustive]
 pub enum SystemError {
     CwdNotInProjectRoot {
-        current_dir: PathBuf,
-        project_root: &'static Path,
+        current_dir: Utf8PathBuf,
+        project_root: &'static Utf8Path,
     },
     Exec {
         cmd: &'static str,
@@ -146,8 +140,7 @@ impl fmt::Display for SystemError {
             } => write!(
                 f,
                 "current dir {} not in project root {}",
-                current_dir.display(),
-                project_root.display(),
+                current_dir, project_root,
             ),
             SystemError::Exec { cmd, status } => match status.code() {
                 Some(code) => write!(f, "'{}' failed with exit code {}", cmd, code),

--- a/devtools/x-core/src/lib.rs
+++ b/devtools/x-core/src/lib.rs
@@ -4,9 +4,12 @@
 #[macro_use]
 extern crate rental;
 
+use crate::{core_config::XCoreConfig, git::GitCli};
+use camino::{Utf8Path, Utf8PathBuf};
+use graph::PackageGraphPlus;
 use guppy::graph::PackageGraph;
+use hakari::{HakariBuilder, TomlOptions};
 use once_cell::sync::OnceCell;
-use std::path::{Path, PathBuf};
 
 pub mod core_config;
 mod debug_ignore;
@@ -15,20 +18,17 @@ pub mod git;
 mod graph;
 mod workspace_subset;
 
-use crate::{core_config::XCoreConfig, git::GitCli};
 pub use debug_ignore::*;
 pub use errors::*;
-use graph::PackageGraphPlus;
-use hakari::{HakariBuilder, TomlOptions};
 pub use workspace_subset::*;
 
 /// Core context shared across all of x.
 #[derive(Debug)]
 pub struct XCoreContext {
-    project_root: &'static Path,
+    project_root: &'static Utf8Path,
     config: XCoreConfig,
-    current_dir: PathBuf,
-    current_rel_dir: PathBuf,
+    current_dir: Utf8PathBuf,
+    current_rel_dir: Utf8PathBuf,
     git_cli: OnceCell<GitCli>,
     package_graph_plus: DebugIgnore<OnceCell<PackageGraphPlus>>,
 }
@@ -36,8 +36,8 @@ pub struct XCoreContext {
 impl XCoreContext {
     /// Creates a new XCoreContext.
     pub fn new(
-        project_root: &'static Path,
-        current_dir: PathBuf,
+        project_root: &'static Utf8Path,
+        current_dir: Utf8PathBuf,
         config: XCoreConfig,
     ) -> Result<Self> {
         let current_rel_dir = match current_dir.strip_prefix(project_root) {
@@ -62,7 +62,7 @@ impl XCoreContext {
     }
 
     /// Returns the project root for this workspace.
-    pub fn project_root(&self) -> &'static Path {
+    pub fn project_root(&self) -> &'static Utf8Path {
         self.project_root
     }
 
@@ -72,18 +72,18 @@ impl XCoreContext {
     }
 
     /// Returns the current working directory for this process.
-    pub fn current_dir(&self) -> &Path {
+    pub fn current_dir(&self) -> &Utf8Path {
         &self.current_dir
     }
 
     /// Returns the current working directory for this process, relative to the project root.
-    pub fn current_rel_dir(&self) -> &Path {
+    pub fn current_rel_dir(&self) -> &Utf8Path {
         &self.current_rel_dir
     }
 
     /// Returns true if x has been run from the project root.
     pub fn current_dir_is_root(&self) -> bool {
-        self.current_rel_dir == Path::new("")
+        self.current_rel_dir == ""
     }
 
     /// Returns the Git CLI for this workspace.

--- a/devtools/x-core/src/workspace_subset.rs
+++ b/devtools/x-core/src/workspace_subset.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{core_config::SubsetConfig, Result, SystemError};
-use camino::Utf8PathBuf;
+use camino::{Utf8Path, Utf8PathBuf};
 use guppy::{
     graph::{
         cargo::{CargoOptions, CargoResolverVersion, CargoSet},
@@ -12,7 +12,7 @@ use guppy::{
     PackageId,
 };
 use serde::Deserialize;
-use std::{collections::BTreeMap, fs, path::Path};
+use std::{collections::BTreeMap, fs};
 use toml::de;
 
 /// Contains information about all the subsets specified in this workspace.
@@ -32,7 +32,7 @@ impl<'g> WorkspaceSubsets<'g> {
     /// * no dev dependencies
     pub fn new(
         graph: &'g PackageGraph,
-        project_root: &Path,
+        project_root: &Utf8Path,
         config: &BTreeMap<String, SubsetConfig>,
     ) -> Result<Self> {
         let mut cargo_opts = CargoOptions::new();
@@ -91,7 +91,7 @@ impl<'g> WorkspaceSubsets<'g> {
     // Helper methods
     // ---
 
-    fn read_default_members(project_root: &Path) -> Result<Vec<Utf8PathBuf>> {
+    fn read_default_members(project_root: &Utf8Path) -> Result<Vec<Utf8PathBuf>> {
         #[derive(Deserialize)]
         struct RootToml {
             workspace: Workspace,

--- a/devtools/x-lint/src/file_path.rs
+++ b/devtools/x-lint/src/file_path.rs
@@ -3,7 +3,7 @@
 
 use crate::{prelude::*, LintContext};
 use camino::Utf8Path;
-use std::{fs, io, path::Path};
+use std::{fs, io};
 
 /// Represents a linter that runs once per file path.
 pub trait FilePathLinter: Linter {
@@ -54,7 +54,7 @@ impl<'l> FilePathContext<'l> {
     pub(super) fn load(self) -> Result<Option<ContentContext<'l>>> {
         let full_path = self.project_ctx.full_path(self.file_path);
         let contents_opt = read_file(&full_path)
-            .map_err(|err| SystemError::io(format!("loading {}", full_path.display()), err))?;
+            .map_err(|err| SystemError::io(format!("loading {}", full_path), err))?;
         Ok(contents_opt.map(|content| ContentContext::new(self, content)))
     }
 }
@@ -65,7 +65,7 @@ impl<'l> LintContext<'l> for FilePathContext<'l> {
     }
 }
 
-fn read_file(full_path: &Path) -> io::Result<Option<Vec<u8>>> {
+fn read_file(full_path: &Utf8Path) -> io::Result<Option<Vec<u8>>> {
     match fs::read(full_path) {
         Ok(bytes) => Ok(Some(bytes)),
         Err(err) => {

--- a/devtools/x-lint/src/project.rs
+++ b/devtools/x-lint/src/project.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{prelude::*, LintContext};
+use camino::{Utf8Path, Utf8PathBuf};
 use guppy::graph::PackageGraph;
 use hakari::Hakari;
-use std::path::{Path, PathBuf};
 use x_core::{WorkspaceSubset, XCoreContext};
 
 /// Represents a linter that checks some property for the overall project.
@@ -39,7 +39,7 @@ impl<'l> ProjectContext<'l> {
     }
 
     /// Returns the project root.
-    pub fn project_root(&self) -> &'l Path {
+    pub fn project_root(&self) -> &'l Utf8Path {
         self.core.project_root()
     }
 
@@ -49,7 +49,7 @@ impl<'l> ProjectContext<'l> {
     }
 
     /// Returns the absolute path from the project root.
-    pub fn full_path(&self, path: impl AsRef<Path>) -> PathBuf {
+    pub fn full_path(&self, path: impl AsRef<Utf8Path>) -> Utf8PathBuf {
         self.core.project_root().join(path.as_ref())
     }
 

--- a/devtools/x/Cargo.toml
+++ b/devtools/x/Cargo.toml
@@ -26,7 +26,7 @@ chrono = "0.4.19"
 globset = "0.4.6"
 regex = "1.4.3"
 rayon = "1.5.0"
-nextest-runner = { git = "https://github.com/diem/diem-devtools", rev = "1b61853016059b2dca577cefafff2825b49494a0" }
+nextest-runner = { git = "https://github.com/diem/diem-devtools", rev = "135c929f93723467534387c6e0372908f863fad6" }
 indexmap = "1.6.2"
 x-core = { path = "../x-core" }
 x-lint = { path = "../x-lint" }

--- a/devtools/x/src/context.rs
+++ b/devtools/x/src/context.rs
@@ -8,6 +8,8 @@ use crate::{
     Result,
 };
 use anyhow::Context;
+use camino::Utf8PathBuf;
+use std::convert::TryInto;
 use x_core::XCoreContext;
 
 /// Global context shared across x commands.
@@ -25,8 +27,10 @@ impl XContext {
 
     /// Creates a new `GlobalContext` based on the given config.
     pub fn with_config(x_config: XConfig) -> Result<Self> {
-        let current_dir =
-            std::env::current_dir().with_context(|| "error while fetching current dir")?;
+        let current_dir: Utf8PathBuf = std::env::current_dir()
+            .with_context(|| "error while fetching current dir")?
+            .try_into()
+            .with_context(|| "current dir is not valid UTF-8")?;
         let XConfig { core, config } = x_config;
         Ok(Self {
             core: XCoreContext::new(project_root(), current_dir, core)?,

--- a/devtools/x/src/generate_summaries.rs
+++ b/devtools/x/src/generate_summaries.rs
@@ -3,14 +3,12 @@
 
 use crate::context::XContext;
 use anyhow::Context;
+use camino::{Utf8Path, Utf8PathBuf};
 use guppy::graph::{
     cargo::CargoOptions,
     feature::{FeatureSet, StandardFeatures},
 };
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use std::fs;
 use structopt::{clap::arg_enum, StructOpt};
 
 arg_enum! {
@@ -25,7 +23,7 @@ arg_enum! {
 pub struct Args {
     #[structopt(name = "OUT_DIR")]
     /// Directory to output summaries to (default: target/summaries)
-    out_dir: Option<PathBuf>,
+    out_dir: Option<Utf8PathBuf>,
     #[structopt(name = "OUTPUT_FORMAT", default_value = "Toml")]
     /// Output in text, toml or json
     output_format: OutputFormat,
@@ -86,7 +84,7 @@ pub fn run(args: Args, xctx: XContext) -> crate::Result<()> {
 
     summary_count += 1;
 
-    println!("wrote {} summaries to {}", summary_count, out_dir.display());
+    println!("wrote {} summaries to {}", summary_count, out_dir);
 
     Ok(())
 }
@@ -95,7 +93,7 @@ fn write_summary(
     name: &str,
     initials: FeatureSet<'_>,
     cargo_opts: &CargoOptions<'_>,
-    out_dir: &Path,
+    out_dir: &Utf8Path,
     output_format: OutputFormat,
 ) -> crate::Result<()> {
     let build_set = initials.into_cargo_set(cargo_opts)?;
@@ -123,6 +121,5 @@ fn write_summary(
         }
     };
 
-    fs::write(&path, &out)
-        .with_context(|| format!("error while writing summary file {}", path.display()))
+    fs::write(&path, &out).with_context(|| format!("error while writing summary file {}", path))
 }

--- a/devtools/x/src/utils.rs
+++ b/devtools/x/src/utils.rs
@@ -3,15 +3,16 @@
 
 use crate::{config::CargoConfig, installer::install_if_needed, Result};
 use anyhow::anyhow;
+use camino::Utf8Path;
 use log::{info, warn};
-use std::{env::var_os, path::Path, process::Command};
+use std::{env::var_os, process::Command};
 
 /// The number of directories between the project root and the root of this crate.
 pub const X_DEPTH: usize = 2;
 
 /// Returns the project root. TODO: switch uses to XCoreContext::project_root instead)
-pub fn project_root() -> &'static Path {
-    Path::new(&env!("CARGO_MANIFEST_DIR"))
+pub fn project_root() -> &'static Utf8Path {
+    Utf8Path::new(&env!("CARGO_MANIFEST_DIR"))
         .ancestors()
         .nth(X_DEPTH)
         .unwrap()
@@ -42,7 +43,7 @@ pub fn apply_sccache_if_possible(
                 .to_str()
                 .unwrap_or_default()
                 == sccache_config.required_cargo_home
-                && sccache_config.required_git_home == project_root().to_str().unwrap_or_default();
+                && sccache_config.required_git_home == project_root();
             if !correct_location {
                 warn!("You will not benefit from sccache in this build!!!");
                 warn!(
@@ -51,7 +52,7 @@ pub fn apply_sccache_if_possible(
                 );
                 warn!(
                     "Current diem root is '{}',  and current CARGO_HOME is '{}'",
-                    project_root().to_str().unwrap_or_default(),
+                    project_root(),
                     var_os("CARGO_HOME").unwrap_or_default().to_string_lossy()
                 );
             } else {


### PR DESCRIPTION
The new test runner comes with several new features, including a
configuration file format (so a simpler CLI) and support for
partitioning tests. Going to start using the partitioning logic for
smoke tests in an upcoming PR.

Tested the new `--partition` feature through:

`cargo nextest --unit --partition count:1/2`