### PR TITLE
Cherry-pick PR #8319 into release-1.2: [json-rpc]: remove the json field metadata if the value is null

### DIFF
--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -194,6 +194,7 @@ pub struct PreburnQueueView {
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct PreburnWithMetadataView {
     pub preburn: AmountView,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<BytesView>,
 }
 
@@ -855,5 +856,38 @@ impl TryFrom<AccountStateProof> for AccountStateProofView {
                 account_state_proof.transaction_info_to_account_proof(),
             )?),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        proto::types as jsonrpc,
+        views::{AmountView, PreburnWithMetadataView},
+    };
+    use serde_json::json;
+
+    #[test]
+    fn test_serialize_preburn_with_metadata_view() {
+        let view = PreburnWithMetadataView {
+            preburn: AmountView {
+                amount: 1,
+                currency: "XUS".to_string(),
+            },
+            metadata: None,
+        };
+        let value = serde_json::to_value(&view).unwrap();
+        assert_eq!(
+            value,
+            json!({
+                "preburn": {
+                    "amount": 1,
+                    "currency": "XUS"
+                }
+            })
+        );
+
+        let preburn: jsonrpc::PreburnWithMetadata = serde_json::from_value(value).unwrap();
+        assert_eq!(preburn.metadata, "");
     }
 }


### PR DESCRIPTION
## Motivation

1. To keep consistent behavior when output null value field.
2. Current Rust jsonrpc types generated from protobuf definition does not accept field value == null case for a string type; this change avoids the problem for the client.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Unit Test

## If targeting a release branch, please fill the below out as well

> * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)

Not a breaking change

> * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.

Unit test confirms a server side rendered JSON can be deserialized by protobuf generated client data structure.

> * Why we must have it for V1 launch.

AOS is depending on client data structure in the release branch, we have new client developed, but it is too risky for AOS to switch at current time. The plan is:
1. make server side response compatible with client data structure to mitigate issue.
2. AOS will work on migrating to new sdk client, so that similar problem won't affect AOS.

> * What workarounds and alternative we have if we do not push the PR.

As the data structure is generated from a protobuf file, the bug is from the code generation tool we use, we have 2 options:
1. Port the fix for the code generation tool, they have a fix in master but no release yet.
2. AOS migrates to use new sdk client which uses different data models code.

