### PR TITLE
[x] use diem/sccache rusoto branch for build, rather than rexhoffman/sccache

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -519,13 +519,11 @@ jobs:
       - name: run unit tests
         run: |
           $pre_command && mkdir -p target/junit-reports && cargo nextest --jobs ${max_threads} --tries ${nextest_tries} --unit --failure-output=immediate-final --changed-since "origin/$TARGET_BRANCH" --junit target/junit-reports/unit-test.xml
-          sccache -s
         env:
           TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
       - name: run doctests
         run: |
           $pre_command && cargo xtest --doc --jobs ${max_threads} --unit --changed-since "origin/$TARGET_BRANCH"
-          sccache -s
         env:
           TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
       - name: upload unit test results
@@ -561,7 +559,6 @@ jobs:
       - name: run unit tests
         run: |
           $pre_command && mkdir -p target/junit-reports && cargo nextest --jobs ${max_threads} --tries ${nextest_tries} --unit --failure-output=immediate-final --changed-since "origin/$TARGET_BRANCH" --junit target/junit-reports/unit-test.xml
-          sccache -s
         env:
           TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
           SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.ENV_DIEM_S3_AWS_ACCESS_KEY_ID }}
@@ -569,7 +566,6 @@ jobs:
       - name: run doctests
         run: |
           $pre_command && cargo xtest --doc --jobs ${max_threads} --unit --changed-since "origin/$TARGET_BRANCH"
-          sccache -s
         env:
           TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
           SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.ENV_DIEM_S3_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/ci-update-sccache.yml
+++ b/.github/workflows/ci-update-sccache.yml
@@ -49,8 +49,6 @@ jobs:
         if: ${{ steps.rust-changes.outputs.changes-found == 'true' }}
         run: |
           $pre_command && cargo x test --no-run --jobs ${max_threads} --unit
-          echo stats:
-          sccache -s
         env:
           SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.ENV_DIEM_S3_AWS_ACCESS_KEY_ID }}
           SCCACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.ENV_DIEM_S3_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -184,7 +184,6 @@ jobs:
           cd /opt/git/diem/
           MVP_TEST_INCONSISTENCY=1 cargo test -p move-prover --release >> $MESSAGE_PAYLOAD_FILE
           MVP_TEST_FEATURE=cvc4 cargo test -p move-prover --release >> $MESSAGE_PAYLOAD_FILE
-          sccache -s
       - uses: ./.github/actions/slack-file
         with:
           webhook: ${{ secrets.WEBHOOK_MOVE_PROVER }}

--- a/devtools/x/src/utils.rs
+++ b/devtools/x/src/utils.rs
@@ -70,10 +70,21 @@ pub fn log_sccache_stats() {
 pub fn stop_sccache_server() {
     let mut sccache = Command::new("sccache");
     sccache.arg("--stop-server");
+    sccache.stdout(Stdio::piped()).stderr(Stdio::piped());
     let result = sccache.output();
-    if let Ok(output) = result {
-        if output.status.success() {
-            info!("Stopped already running sccache.");
+    match sccache.output() {
+        Ok(output) => {
+            if output.status.success() {
+                info!("Stopped already running sccache.");
+            } else {
+                info!("Failed to stopped already running sccache.");
+                warn!("status: {}", output.status);
+                warn!("stdout: {}", String::from_utf8_lossy(&output.stdout));
+                warn!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+            }
+        }
+        Err(error) => {
+            warn!("Failed to stop running sccache: {}", error)
         }
     }
 }

--- a/devtools/x/src/utils.rs
+++ b/devtools/x/src/utils.rs
@@ -71,7 +71,6 @@ pub fn stop_sccache_server() {
     let mut sccache = Command::new("sccache");
     sccache.arg("--stop-server");
     sccache.stdout(Stdio::piped()).stderr(Stdio::piped());
-    let result = sccache.output();
     match sccache.output() {
         Ok(output) => {
             if output.status.success() {

--- a/devtools/x/src/utils.rs
+++ b/devtools/x/src/utils.rs
@@ -4,7 +4,11 @@
 use crate::{config::CargoConfig, installer::install_if_needed, Result};
 use anyhow::anyhow;
 use log::{info, warn};
-use std::{env::var_os, path::Path, process::Command};
+use std::{
+    env::var_os,
+    path::Path,
+    process::{Command, Stdio},
+};
 
 /// The number of directories between the project root and the root of this crate.
 pub const X_DEPTH: usize = 2;
@@ -17,13 +21,69 @@ pub fn project_root() -> &'static Path {
         .unwrap()
 }
 
-fn stop_sccache_server() {
+/// Is the project configured to use sccache, and are the CARGO_HOME and project root in the correct location.
+/// If the warn_if_not parameter is set to true warnings will be logged if the project is configured for sccache
+/// but the CARGO_HOME or project root are not in the right locations.
+fn sccache_correct_locations(cargo_config: &CargoConfig, warn_if_not: bool) -> bool {
+    if let Some(sccache_config) = &cargo_config.sccache {
+        // Are we work on items in the right location:
+        // See: https://github.com/mozilla/sccache#known-caveats
+        let correct_location = var_os("CARGO_HOME")
+            .unwrap_or_default()
+            .to_str()
+            .unwrap_or_default()
+            == sccache_config.required_cargo_home
+            && sccache_config.required_git_home == project_root().to_str().unwrap_or_default();
+        if !correct_location && warn_if_not {
+            warn!("You will not benefit from sccache in this build!!!");
+            warn!(
+                "To get the best experience, please move your diem source code to {} and your set your CARGO_HOME to be {}, simply export it in your .profile or .bash_rc",
+                &sccache_config.required_git_home, &sccache_config.required_cargo_home
+            );
+            warn!(
+                "Current diem root is '{}',  and current CARGO_HOME is '{}'",
+                project_root().to_str().unwrap_or_default(),
+                var_os("CARGO_HOME").unwrap_or_default().to_string_lossy()
+            );
+        }
+        correct_location
+    } else {
+        false
+    }
+}
+
+/// If the project is configured for sccache, and the env variable SKIP_SCCACHE is unset then
+/// this function will return true.
+fn sccache_should_skip(cargo_config: &CargoConfig) -> bool {
+    var_os("SKIP_SCCACHE").is_some() || cargo_config.sccache.is_none()
+}
+
+fn print_sccache_stats() {
     let mut sccache = Command::new("sccache");
-    sccache.arg("--stop-server");
-    let result = sccache.output();
-    if let Ok(output) = result {
-        if output.status.success() {
-            info!("Stopped already running sccache.");
+    sccache.arg("--show-stats");
+    sccache.stdout(Stdio::inherit()).stderr(Stdio::inherit());
+    if let Err(error) = sccache.output() {
+        warn!("Could not log sccache status: {}", error);
+    }
+}
+
+pub fn sccache_log_stats(cargo_config: &CargoConfig) -> fn() {
+    if !sccache_should_skip(cargo_config) && sccache_correct_locations(cargo_config, false) {
+        print_sccache_stats
+    } else {
+        || ()
+    }
+}
+
+fn stop_sccache_server_if_needed(cargo_config: &CargoConfig) {
+    if !sccache_should_skip(cargo_config) && sccache_correct_locations(cargo_config, false) {
+        let mut sccache = Command::new("sccache");
+        sccache.arg("--stop-server");
+        let result = sccache.output();
+        if let Ok(output) = result {
+            if output.status.success() {
+                info!("Stopped already running sccache.");
+            }
         }
     }
 }
@@ -33,85 +93,64 @@ pub fn apply_sccache_if_possible(
 ) -> Result<Vec<(&str, Option<String>)>> {
     let mut envs = vec![];
 
-    if var_os("SKIP_SCCACHE").is_none() && cargo_config.sccache.is_some() {
+    if !sccache_should_skip(cargo_config) && sccache_correct_locations(cargo_config, true) {
         if let Some(sccache_config) = &cargo_config.sccache {
-            // Are we work on items in the right location:
-            // See: https://github.com/mozilla/sccache#known-caveats
-            let correct_location = var_os("CARGO_HOME")
-                .unwrap_or_default()
-                .to_str()
-                .unwrap_or_default()
-                == sccache_config.required_cargo_home
-                && sccache_config.required_git_home == project_root().to_str().unwrap_or_default();
-            if !correct_location {
-                warn!("You will not benefit from sccache in this build!!!");
-                warn!(
-                    "To get the best experience, please move your diem source code to {} and your set your CARGO_HOME to be {}, simply export it in your .profile or .bash_rc",
-                    &sccache_config.required_git_home, &sccache_config.required_cargo_home
-                );
-                warn!(
-                    "Current diem root is '{}',  and current CARGO_HOME is '{}'",
-                    project_root().to_str().unwrap_or_default(),
-                    var_os("CARGO_HOME").unwrap_or_default().to_string_lossy()
-                );
-            } else {
-                if !install_if_needed(cargo_config, "sccache", &sccache_config.installer) {
-                    return Err(anyhow!("Failed to install sccache, bailing"));
-                }
-                stop_sccache_server();
-                envs.push(("RUSTC_WRAPPER", Some("sccache".to_owned())));
-                envs.push(("CARGO_INCREMENTAL", Some("false".to_owned())));
-                envs.push(("SCCACHE_BUCKET", Some(sccache_config.bucket.to_owned())));
-                if let Some(ssl) = &sccache_config.ssl {
-                    envs.push((
-                        "SCCACHE_S3_USE_SSL",
-                        if *ssl {
-                            Some("true".to_owned())
-                        } else {
-                            Some("false".to_owned())
-                        },
-                    ));
-                }
-
-                if let Some(url) = &sccache_config.endpoint {
-                    envs.push(("SCCACHE_ENDPOINT", Some(url.to_owned())));
-                }
-
-                if let Some(extra_envs) = &sccache_config.envs {
-                    for (key, value) in extra_envs {
-                        envs.push((key, Some(value.to_owned())));
-                    }
-                }
-
-                if let Some(region) = &sccache_config.region {
-                    envs.push(("SCCACHE_REGION", Some(region.to_owned())));
-                }
-
-                if let Some(prefix) = &sccache_config.prefix {
-                    envs.push(("SCCACHE_S3_KEY_PREFIX", Some(prefix.to_owned())));
-                }
-                let access_key_id = if let Some(val) = var_os("SCCACHE_AWS_ACCESS_KEY_ID") {
-                    Some(val.to_string_lossy().to_string())
-                } else {
-                    None
-                };
-                let access_key_secret = if let Some(val) = var_os("SCCACHE_AWS_SECRET_ACCESS_KEY") {
-                    Some(val.to_string_lossy().to_string())
-                } else {
-                    None
-                };
-                // if either the access or secret key is not set, attempt to perform a public read.
-                // do not set this flag if attempting to write, as it will prevent the use of the aws creds.
-                if (access_key_id.is_none() || access_key_secret.is_none())
-                    && sccache_config.public.unwrap_or(true)
-                {
-                    envs.push(("SCCACHE_S3_PUBLIC", Some("true".to_owned())));
-                }
-
-                //Note: that this is also used to _unset_ AWS_ACCESS_KEY_ID & AWS_SECRET_ACCESS_KEY
-                envs.push(("AWS_ACCESS_KEY_ID", access_key_id));
-                envs.push(("AWS_SECRET_ACCESS_KEY", access_key_secret));
+            if !install_if_needed(cargo_config, "sccache", &sccache_config.installer) {
+                return Err(anyhow!("Failed to install sccache, bailing"));
             }
+            stop_sccache_server_if_needed(cargo_config);
+            envs.push(("RUSTC_WRAPPER", Some("sccache".to_owned())));
+            envs.push(("CARGO_INCREMENTAL", Some("false".to_owned())));
+            envs.push(("SCCACHE_BUCKET", Some(sccache_config.bucket.to_owned())));
+            if let Some(ssl) = &sccache_config.ssl {
+                envs.push((
+                    "SCCACHE_S3_USE_SSL",
+                    if *ssl {
+                        Some("true".to_owned())
+                    } else {
+                        Some("false".to_owned())
+                    },
+                ));
+            }
+
+            if let Some(url) = &sccache_config.endpoint {
+                envs.push(("SCCACHE_ENDPOINT", Some(url.to_owned())));
+            }
+
+            if let Some(extra_envs) = &sccache_config.envs {
+                for (key, value) in extra_envs {
+                    envs.push((key, Some(value.to_owned())));
+                }
+            }
+
+            if let Some(region) = &sccache_config.region {
+                envs.push(("SCCACHE_REGION", Some(region.to_owned())));
+            }
+
+            if let Some(prefix) = &sccache_config.prefix {
+                envs.push(("SCCACHE_S3_KEY_PREFIX", Some(prefix.to_owned())));
+            }
+            let access_key_id = if let Some(val) = var_os("SCCACHE_AWS_ACCESS_KEY_ID") {
+                Some(val.to_string_lossy().to_string())
+            } else {
+                None
+            };
+            let access_key_secret = if let Some(val) = var_os("SCCACHE_AWS_SECRET_ACCESS_KEY") {
+                Some(val.to_string_lossy().to_string())
+            } else {
+                None
+            };
+            // if either the access or secret key is not set, attempt to perform a public read.
+            // do not set this flag if attempting to write, as it will prevent the use of the aws creds.
+            if (access_key_id.is_none() || access_key_secret.is_none())
+                && sccache_config.public.unwrap_or(true)
+            {
+                envs.push(("SCCACHE_S3_PUBLIC", Some("true".to_owned())));
+            }
+
+            //Note: that this is also used to _unset_ AWS_ACCESS_KEY_ID & AWS_SECRET_ACCESS_KEY
+            envs.push(("AWS_ACCESS_KEY_ID", access_key_id));
+            envs.push(("AWS_SECRET_ACCESS_KEY", access_key_secret));
         }
     }
     Ok(envs)

--- a/docker/ci/alpine/README.md
+++ b/docker/ci/alpine/README.md
@@ -1,4 +1,0 @@
-# Status
-
-Everything compiles and installs correctly.
-sccache fails to execute when run - even though it's an executable on the path.

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -13,9 +13,9 @@
 
 SHELLCHECK_VERSION=0.7.1
 HADOLINT_VERSION=1.17.4
-SCCACHE_VERSION=0.2.14-alpha.0
+SCCACHE_VERSION=0.2.16-alpha.0
 #If installing sccache from a git repp set url@revision.
-SCCACHE_GIT='https://github.com/rexhoffman/sccache.git@549babdd3866aa60dae01668c42ee00bf1e8c763'
+SCCACHE_GIT='https://github.com/diem/sccache.git@ef50d87a58260c30767520045e242ccdbdb965af'
 KUBECTL_VERSION=1.18.6
 TERRAFORM_VERSION=0.12.26
 HELM_VERSION=3.2.4

--- a/x.toml
+++ b/x.toml
@@ -19,9 +19,9 @@ envs = [
 ]
 
 [cargo.sccache.installer]
-version = "0.2.14-alpha.0"
-git = "https://github.com/rexhoffman/sccache.git"
-git-rev = "549babdd3866aa60dae01668c42ee00bf1e8c763"
+version = "0.2.16-alpha.0"
+git = "https://github.com/diem/sccache.git"
+git-rev = "859b52d2dfa0f632f032a1faf43356e96000e01b"
 features = [ "s3" ]
 
 

--- a/x.toml
+++ b/x.toml
@@ -21,7 +21,7 @@ envs = [
 [cargo.sccache.installer]
 version = "0.2.16-alpha.0"
 git = "https://github.com/diem/sccache.git"
-git-rev = "859b52d2dfa0f632f032a1faf43356e96000e01b"
+git-rev = "ef50d87a58260c30767520045e242ccdbdb965af"
 features = [ "s3" ]
 
 


### PR DESCRIPTION
## Motivation

Move to a sccache fork/pr maintained in diem/sccache, which has it's changes rebased to the lastest master version of mozilla/sccache.   Also improves the printing out of sccache statistics.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

Local build, and inspect sccache status with ```sccache -s```.
/canary.

Logs here:
https://github.com/diem/diem/runs/2506354859#step:6:785

## Related PRs

None, aside from https://github.com/mozilla/sccache/pull/869, which will be brought up to speed with diem/sccache rusoto branch once this succeeds.

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
