### PR TITLE
Make JsonRpc Requesttypes generic

### DIFF
--- a/json-rpc/src/lib.rs
+++ b/json-rpc/src/lib.rs
@@ -14,12 +14,12 @@
 //! ├── tests.rs          # tests
 
 #[macro_use]
-mod util;
+pub mod util;
 
 mod counters;
 pub mod data;
 mod methods;
-mod runtime;
+pub mod runtime;
 
 pub use diem_json_rpc_types::{errors, response, views};
 

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -1215,9 +1215,9 @@ fn test_limit_batch_size() {
 
     let ret = client.batch(batch).unwrap_err();
 
-    let error = ret.json_rpc_error().unwrap();
-    let expected = "JsonRpcError { code: -32600, message: \"Invalid Request: batch size = 21, exceed limit 20\", data: None }";
-    assert_eq!(format!("{:?}", error), expected)
+    let error = serde_json::to_string(ret.json_rpc_error().unwrap()).unwrap();
+    let expected = serde_json::json!({ "code": -32600, "message": "Invalid Request: batch size = 21, exceed limit 20", "data": null }).to_string();
+    assert_eq!(error, expected)
 }
 
 #[test]
@@ -1228,9 +1228,9 @@ fn test_get_events_page_limit() {
         .get_events("13000000000000000000000000000000000000000a550c18", 0, 1001)
         .unwrap_err();
 
-    let error = ret.json_rpc_error().unwrap();
-    let expected = "JsonRpcError { code: -32600, message: \"Invalid Request: page size = 1001, exceed limit 1000\", data: None }";
-    assert_eq!(format!("{:?}", error), expected)
+    let error = serde_json::to_string(ret.json_rpc_error().unwrap()).unwrap();
+    let expected = serde_json::json!({ "code": -32600, "message": "Invalid Request: page size = 1001, exceed limit 1000", "data": null }).to_string();
+    assert_eq!(error, expected)
 }
 
 #[test]
@@ -1238,9 +1238,9 @@ fn test_get_transactions_page_limit() {
     let (_, client, _runtime) = create_database_client_and_runtime();
 
     let ret = client.get_transactions(0, 1001, false).unwrap_err();
-    let error = ret.json_rpc_error().unwrap();
-    let expected = "JsonRpcError { code: -32600, message: \"Invalid Request: page size = 1001, exceed limit 1000\", data: None }";
-    assert_eq!(format!("{:?}", error), expected)
+    let error = serde_json::to_string(ret.json_rpc_error().unwrap()).unwrap();
+    let expected = serde_json::json!({ "code": -32600, "message": "Invalid Request: page size = 1001, exceed limit 1000", "data": null }).to_string();
+    assert_eq!(error, expected)
 }
 
 #[test]

--- a/json-rpc/types/src/errors.rs
+++ b/json-rpc/types/src/errors.rs
@@ -9,8 +9,6 @@ use diem_types::{
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::Method;
-
 /// list of server internal errors
 pub static INTERNAL_ERRORS: &[i16; 7] = &[
     ServerCode::DefaultServerError as i16,
@@ -55,6 +53,7 @@ pub enum ServerCode {
 
 /// JSON RPC server error codes for invalid request
 pub enum InvalidRequestCode {
+    ParseError = -32700,
     InvalidRequest = -32600,
     MethodNotFound = -32601,
     InvalidParams = -32602,
@@ -133,10 +132,10 @@ impl JsonRpcError {
         }
     }
 
-    pub fn invalid_params(method: Method) -> Self {
+    pub fn invalid_params(method_name: &str) -> Self {
         Self {
             code: InvalidRequestCode::InvalidParams as i16,
-            message: format!("Invalid params for method '{}'", method.as_str()),
+            message: format!("Invalid params for method '{}'", method_name),
             data: None,
         }
     }
@@ -153,14 +152,6 @@ impl JsonRpcError {
         Self {
             code: InvalidRequestCode::InvalidParams as i16,
             message: format!("Invalid param {}", msg),
-            data: None,
-        }
-    }
-
-    pub fn invalid_params_from_method(method: Method) -> Self {
-        Self {
-            code: InvalidRequestCode::InvalidParams as i16,
-            message: format!("Invalid params for method '{}'", method.as_str()),
             data: None,
         }
     }

--- a/json-rpc/types/src/lib.rs
+++ b/json-rpc/types/src/lib.rs
@@ -12,7 +12,7 @@ pub mod proto;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-enum JsonRpcVersion {
+pub enum JsonRpcVersion {
     #[serde(rename = "2.0")]
     V2,
 }
@@ -25,6 +25,15 @@ pub enum Id {
     Number(u64),
     /// String id
     String(Box<str>),
+}
+
+impl std::fmt::Display for Id {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Id::Number(ref v) => std::fmt::Debug::fmt(v, f),
+            Id::String(ref v) => std::fmt::Debug::fmt(v, f),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Deserialize, Serialize)]
@@ -50,7 +59,7 @@ pub enum Method {
 }
 
 impl Method {
-    pub fn as_str(&self) -> &str {
+    pub fn as_str(&self) -> &'static str {
         match self {
             Method::Submit => "submit",
             Method::GetMetadata => "get_metadata",


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
In building the stream RPC there was a need to have similar types, but without being tied to the implementation specific details. This breaks out a piece of #8307 to make reviewing more palatable.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
yes

## Test Plan
All existing tests should function: this is a generic-ization that should maintain 1:1 functionality with existing implementation


## Related PRs
https://github.com/diem/diem/pull/8307

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.