### PR TITLE
[move-prover] Refactor semantics of `let` in spec blocks.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4507,6 +4507,7 @@ dependencies = [
  "abigen",
  "anyhow",
  "async-trait",
+ "atty",
  "boogie-backend",
  "bytecode",
  "clap",

--- a/language/diem-framework/modules/AccountAdministrationScripts.move
+++ b/language/diem-framework/modules/AccountAdministrationScripts.move
@@ -122,7 +122,7 @@ module AccountAdministrationScripts {
         };
 
         ensures RecoveryAddress::spec_get_rotation_caps(recovery_address)[
-            len(RecoveryAddress::spec_get_rotation_caps(recovery_address)) - 1] == old(rotation_cap);
+            len(RecoveryAddress::spec_get_rotation_caps(recovery_address)) - 1] == rotation_cap;
 
         aborts_with [check]
             Errors::INVALID_STATE,
@@ -586,7 +586,7 @@ module AccountAdministrationScripts {
 
         ensures RecoveryAddress::spec_is_recovery_address(account_addr);
         ensures len(RecoveryAddress::spec_get_rotation_caps(account_addr)) == 1;
-        ensures RecoveryAddress::spec_get_rotation_caps(account_addr)[0] == old(rotation_cap);
+        ensures RecoveryAddress::spec_get_rotation_caps(account_addr)[0] == rotation_cap;
 
         aborts_with [check]
             Errors::INVALID_STATE,

--- a/language/diem-framework/modules/DesignatedDealer.move
+++ b/language/diem-framework/modules/DesignatedDealer.move
@@ -168,8 +168,9 @@ module DesignatedDealer {
         modifies global<TierInfo<CoinType>>(dd_addr);
         ensures !exists<TierInfo<CoinType>>(dd_addr);
         let currency_info = global<Diem::CurrencyInfo<CoinType>>(CoreAddresses::CURRENCY_INFO_ADDRESS());
+        let post post_currency_info = global<Diem::CurrencyInfo<CoinType>>(CoreAddresses::CURRENCY_INFO_ADDRESS());
         ensures result.value == amount;
-        ensures currency_info == update_field(old(currency_info), total_value, old(currency_info.total_value) + amount);
+        ensures post_currency_info == update_field(currency_info, total_value, currency_info.total_value + amount);
     }
     spec schema TieredMintAbortsIf<CoinType> {
         tc_account: signer;

--- a/language/diem-framework/modules/DiemAccount.move
+++ b/language/diem-framework/modules/DiemAccount.move
@@ -454,11 +454,13 @@ module DiemAccount {
         designated_dealer_address: address;
         mint_amount: u64;
         let dealer_balance = global<Balance<Token>>(designated_dealer_address).coin.value;
+        let post post_dealer_balance = global<Balance<Token>>(designated_dealer_address).coin.value;
         let currency_info = global<Diem::CurrencyInfo<Token>>(CoreAddresses::CURRENCY_INFO_ADDRESS());
+        let post post_currency_info = global<Diem::CurrencyInfo<Token>>(CoreAddresses::CURRENCY_INFO_ADDRESS());
         /// Total value of the currency increases by `amount`.
-        ensures currency_info == update_field(old(currency_info), total_value, old(currency_info.total_value) + mint_amount);
+        ensures post_currency_info == update_field(currency_info, total_value, currency_info.total_value + mint_amount);
         /// The balance of designated dealer increases by `amount`.
-        ensures dealer_balance == old(dealer_balance) + mint_amount;
+        ensures post_dealer_balance == dealer_balance + mint_amount;
     }
     spec schema TieredMintEmits<Token> {
         tc_account: signer;
@@ -697,8 +699,9 @@ module DiemAccount {
         amount: u64;
         modifies global<Balance<Token>>(payer);
         let payer_balance = global<Balance<Token>>(payer).coin.value;
+        let post post_payer_balance = global<Balance<Token>>(payer).coin.value;
         /// The balance of payer decreases by `amount`.
-        ensures payer_balance == old(payer_balance) - amount;
+        ensures post_payer_balance == payer_balance - amount;
         /// The value of preburn at `dd_addr` increases by `amount`;
         include Diem::PreburnToEnsures<Token>{amount, account: dd};
     }
@@ -1064,7 +1067,8 @@ module DiemAccount {
         ensures exists_at(new_account_addr);
         ensures AccountFreezing::spec_account_is_not_frozen(new_account_addr);
         let account_ops_cap = global<AccountOperationsCapability>(CoreAddresses::DIEM_ROOT_ADDRESS());
-        ensures account_ops_cap == update_field(old(account_ops_cap), creation_events, account_ops_cap.creation_events);
+        let post post_account_ops_cap = global<AccountOperationsCapability>(CoreAddresses::DIEM_ROOT_ADDRESS());
+        ensures post_account_ops_cap == update_field(account_ops_cap, creation_events, account_ops_cap.creation_events);
         ensures spec_holds_own_key_rotation_cap(new_account_addr);
         ensures spec_holds_own_withdraw_cap(new_account_addr);
         include MakeAccountEmits{new_account_address: Signer::spec_address_of(new_account)};
@@ -1086,8 +1090,8 @@ module DiemAccount {
     }
     spec schema MakeAccountEmits {
         new_account_address: address;
-        let handle = global<AccountOperationsCapability>(CoreAddresses::DIEM_ROOT_ADDRESS()).creation_events;
-        let msg = CreateAccountEvent {
+        let post handle = global<AccountOperationsCapability>(CoreAddresses::DIEM_ROOT_ADDRESS()).creation_events;
+        let post msg = CreateAccountEvent {
             created: new_account_address,
             role_id: Roles::spec_get_role_id(new_account_address)
         };
@@ -1233,7 +1237,8 @@ module DiemAccount {
         include MakeAccountAbortsIf{addr: CoreAddresses::TREASURY_COMPLIANCE_ADDRESS()};
         include CreateTreasuryComplianceAccountEnsures;
         let account_ops_cap = global<AccountOperationsCapability>(CoreAddresses::DIEM_ROOT_ADDRESS());
-        ensures account_ops_cap == update_field(old(account_ops_cap), creation_events, account_ops_cap.creation_events);
+        let post post_account_ops_cap = global<AccountOperationsCapability>(CoreAddresses::DIEM_ROOT_ADDRESS());
+        ensures post_account_ops_cap == update_field(account_ops_cap, creation_events, account_ops_cap.creation_events);
         include MakeAccountEmits{new_account_address: CoreAddresses::TREASURY_COMPLIANCE_ADDRESS()};
     }
     spec schema CreateTreasuryComplianceAccountModifies {

--- a/language/diem-framework/modules/DiemTimestamp.move
+++ b/language/diem-framework/modules/DiemTimestamp.move
@@ -78,16 +78,17 @@ module DiemTimestamp {
         modifies global<CurrentTimeMicroseconds>(CoreAddresses::DIEM_ROOT_ADDRESS());
 
         let now = spec_now_microseconds();
+        let post post_now = spec_now_microseconds();
 
         /// Conditions unique for abstract and concrete version of this function.
         include AbortsIfNotOperating;
         include CoreAddresses::AbortsIfNotVM;
-        ensures now == timestamp; // refers to the `now` in the post state
+        ensures post_now == timestamp;
 
         /// Conditions we only check for the implementation, but do not pass to the caller.
         aborts_if [concrete]
             (if (proposer == CoreAddresses::VM_RESERVED_ADDRESS()) {
-                now != timestamp // Refers to the now in the pre state
+                now != timestamp
              } else  {
                 now >= timestamp
              }

--- a/language/diem-framework/modules/DiemVMConfig.move
+++ b/language/diem-framework/modules/DiemVMConfig.move
@@ -191,8 +191,8 @@ module DiemVMConfig {
         ensures DiemConfig::spec_is_published<DiemVMConfig>();
         ensures DiemConfig::get<DiemVMConfig>() == DiemVMConfig {
             gas_schedule: GasSchedule {
-                instruction_schedule: old(config).gas_schedule.instruction_schedule,
-                native_schedule: old(config).gas_schedule.native_schedule,
+                instruction_schedule: config.gas_schedule.instruction_schedule,
+                native_schedule: config.gas_schedule.native_schedule,
                 gas_constants: GasConstants {
                         global_memory_per_byte_cost,
                         global_memory_per_byte_write_cost,

--- a/language/diem-framework/modules/RecoveryAddress.move
+++ b/language/diem-framework/modules/RecoveryAddress.move
@@ -187,7 +187,7 @@ module RecoveryAddress {
     spec schema AddRotationCapabilityEnsures {
         to_recover: KeyRotationCapability;
         recovery_address: address;
-        let num_rotation_caps = len(spec_get_rotation_caps(recovery_address));
+        let post num_rotation_caps = len(spec_get_rotation_caps(recovery_address));
         ensures spec_get_rotation_caps(recovery_address)[num_rotation_caps - 1] == to_recover;
     }
 

--- a/language/diem-framework/modules/TransactionFee.move
+++ b/language/diem-framework/modules/TransactionFee.move
@@ -85,8 +85,9 @@ module TransactionFee {
         include DiemTimestamp::AbortsIfNotOperating;
         aborts_if !is_coin_initialized<CoinType>() with Errors::NOT_PUBLISHED;
         let fees = spec_transaction_fee<CoinType>().balance;
+        let post post_fees = spec_transaction_fee<CoinType>().balance;
         include Diem::DepositAbortsIf<CoinType>{coin: fees, check: coin};
-        ensures fees.value == old(fees.value) + coin.value;
+        ensures post_fees.value == fees.value + coin.value;
     }
 
     /// Preburns the transaction fees collected in the `CoinType` currency.

--- a/language/diem-framework/modules/TreasuryComplianceScripts.move
+++ b/language/diem-framework/modules/TreasuryComplianceScripts.move
@@ -81,13 +81,18 @@ module TreasuryComplianceScripts {
         let total_preburn_value = global<Diem::CurrencyInfo<Token>>(
             CoreAddresses::CURRENCY_INFO_ADDRESS()
         ).preburn_value;
+        let post post_total_preburn_value = global<Diem::CurrencyInfo<Token>>(
+            CoreAddresses::CURRENCY_INFO_ADDRESS()
+        ).preburn_value;
+
         let balance_at_addr = DiemAccount::balance<Token>(preburn_address);
+        let post post_balance_at_addr = DiemAccount::balance<Token>(preburn_address);
 
         /// The total value of preburn for `Token` should decrease by the preburned amount.
-        ensures total_preburn_value == old(total_preburn_value) - amount;
+        ensures post_total_preburn_value == total_preburn_value - amount;
 
         /// The balance of `Token` at `preburn_address` should increase by the preburned amount.
-        ensures balance_at_addr == old(balance_at_addr) + amount;
+        ensures post_balance_at_addr == balance_at_addr + amount;
 
         include Diem::CancelBurnWithCapEmits<Token>;
         include DiemAccount::DepositEmits<Token>{

--- a/language/diem-framework/modules/doc/AccountAdministrationScripts.md
+++ b/language/diem-framework/modules/doc/AccountAdministrationScripts.md
@@ -272,15 +272,13 @@ resource stored under the account at <code>recovery_address</code>.
 <pre><code><b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: to_recover_account};
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityAbortsIf">DiemAccount::ExtractKeyRotationCapabilityAbortsIf</a>{account: to_recover_account};
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityEnsures">DiemAccount::ExtractKeyRotationCapabilityEnsures</a>{account: to_recover_account};
-<a name="0x1_AccountAdministrationScripts_addr$10"></a>
 <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(to_recover_account);
-<a name="0x1_AccountAdministrationScripts_rotation_cap$11"></a>
 <b>let</b> rotation_cap = <a href="DiemAccount.md#0x1_DiemAccount_spec_get_key_rotation_cap">DiemAccount::spec_get_key_rotation_cap</a>(addr);
 <b>include</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_AddRotationCapabilityAbortsIf">RecoveryAddress::AddRotationCapabilityAbortsIf</a>{
     to_recover: rotation_cap
 };
 <b>ensures</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">RecoveryAddress::spec_get_rotation_caps</a>(recovery_address)[
-    len(<a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">RecoveryAddress::spec_get_rotation_caps</a>(recovery_address)) - 1] == <b>old</b>(rotation_cap);
+    len(<a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">RecoveryAddress::spec_get_rotation_caps</a>(recovery_address)) - 1] == rotation_cap;
 <b>aborts_with</b> [check]
     <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>,
     <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>,
@@ -458,10 +456,8 @@ and <code>account</code> must not have previously delegated its <code><a href="D
 
 
 <pre><code><b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: account};
-<a name="0x1_AccountAdministrationScripts_account_addr$12"></a>
 <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityAbortsIf">DiemAccount::ExtractKeyRotationCapabilityAbortsIf</a>;
-<a name="0x1_AccountAdministrationScripts_key_rotation_capability$13"></a>
 <b>let</b> key_rotation_capability = <a href="DiemAccount.md#0x1_DiemAccount_spec_get_key_rotation_cap">DiemAccount::spec_get_key_rotation_cap</a>(account_addr);
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_RotateAuthenticationKeyAbortsIf">DiemAccount::RotateAuthenticationKeyAbortsIf</a>{cap: key_rotation_capability, new_authentication_key: new_key};
 </code></pre>
@@ -574,11 +570,9 @@ and <code>account</code> must not have previously delegated its <code><a href="D
 
 
 <pre><code><b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: account};
-<a name="0x1_AccountAdministrationScripts_account_addr$14"></a>
 <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 <b>include</b> <a href="SlidingNonce.md#0x1_SlidingNonce_RecordNonceAbortsIf">SlidingNonce::RecordNonceAbortsIf</a>{ seq_nonce: sliding_nonce };
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityAbortsIf">DiemAccount::ExtractKeyRotationCapabilityAbortsIf</a>;
-<a name="0x1_AccountAdministrationScripts_key_rotation_capability$15"></a>
 <b>let</b> key_rotation_capability = <a href="DiemAccount.md#0x1_DiemAccount_spec_get_key_rotation_cap">DiemAccount::spec_get_key_rotation_cap</a>(account_addr);
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_RotateAuthenticationKeyAbortsIf">DiemAccount::RotateAuthenticationKeyAbortsIf</a>{cap: key_rotation_capability, new_authentication_key: new_key};
 </code></pre>
@@ -692,11 +686,9 @@ and <code>account</code> must not have previously delegated its <code><a href="D
 
 
 <pre><code><b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: account};
-<a name="0x1_AccountAdministrationScripts_account_addr$16"></a>
 <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 <b>include</b> <a href="SlidingNonce.md#0x1_SlidingNonce_RecordNonceAbortsIf">SlidingNonce::RecordNonceAbortsIf</a>{ account: dr_account, seq_nonce: sliding_nonce };
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityAbortsIf">DiemAccount::ExtractKeyRotationCapabilityAbortsIf</a>;
-<a name="0x1_AccountAdministrationScripts_key_rotation_capability$17"></a>
 <b>let</b> key_rotation_capability = <a href="DiemAccount.md#0x1_DiemAccount_spec_get_key_rotation_cap">DiemAccount::spec_get_key_rotation_cap</a>(account_addr);
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_RotateAuthenticationKeyAbortsIf">DiemAccount::RotateAuthenticationKeyAbortsIf</a>{cap: key_rotation_capability, new_authentication_key: new_key};
 </code></pre>
@@ -833,9 +825,6 @@ This transaction can be sent either by the <code>to_recover</code> account, or b
 The delegatee at the recovery address has to hold the key rotation capability for
 the address to recover. The address of the transaction signer has to be either
 the delegatee's address or the address to recover [[H18]][PERMISSION][[J18]][PERMISSION].
-
-
-<a name="0x1_AccountAdministrationScripts_account_addr$18"></a>
 
 
 <pre><code><b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
@@ -1131,9 +1120,7 @@ may be used as a recovery account for those accounts.
 <pre><code><b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: account};
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityAbortsIf">DiemAccount::ExtractKeyRotationCapabilityAbortsIf</a>;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityEnsures">DiemAccount::ExtractKeyRotationCapabilityEnsures</a>;
-<a name="0x1_AccountAdministrationScripts_account_addr$19"></a>
 <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
-<a name="0x1_AccountAdministrationScripts_rotation_cap$20"></a>
 <b>let</b> rotation_cap = <a href="DiemAccount.md#0x1_DiemAccount_spec_get_key_rotation_cap">DiemAccount::spec_get_key_rotation_cap</a>(account_addr);
 <b>include</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_PublishAbortsIf">RecoveryAddress::PublishAbortsIf</a>{
     recovery_account: account,
@@ -1141,7 +1128,7 @@ may be used as a recovery account for those accounts.
 };
 <b>ensures</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_is_recovery_address">RecoveryAddress::spec_is_recovery_address</a>(account_addr);
 <b>ensures</b> len(<a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">RecoveryAddress::spec_get_rotation_caps</a>(account_addr)) == 1;
-<b>ensures</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">RecoveryAddress::spec_get_rotation_caps</a>(account_addr)[0] == <b>old</b>(rotation_cap);
+<b>ensures</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">RecoveryAddress::spec_get_rotation_caps</a>(account_addr)[0] == rotation_cap;
 <b>aborts_with</b> [check]
     <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>,
     <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>,

--- a/language/diem-framework/modules/doc/AccountCreationScripts.md
+++ b/language/diem-framework/modules/doc/AccountCreationScripts.md
@@ -179,9 +179,7 @@ This is emitted on the new Child VASPS's <code><a href="DiemAccount.md#0x1_DiemA
 
 
 <pre><code><b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: parent_vasp};
-<a name="0x1_AccountCreationScripts_parent_addr$5"></a>
 <b>let</b> parent_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(parent_vasp);
-<a name="0x1_AccountCreationScripts_parent_cap$6"></a>
 <b>let</b> parent_cap = <a href="DiemAccount.md#0x1_DiemAccount_spec_get_withdraw_cap">DiemAccount::spec_get_withdraw_cap</a>(parent_addr);
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateChildVASPAccountAbortsIf">DiemAccount::CreateChildVASPAccountAbortsIf</a>&lt;CoinType&gt;{
     parent: parent_vasp, new_account_address: child_address};

--- a/language/diem-framework/modules/doc/AccountFreezing.md
+++ b/language/diem-framework/modules/doc/AccountFreezing.md
@@ -256,7 +256,6 @@ The <code><a href="AccountFreezing.md#0x1_AccountFreezing_FreezingBit">FreezingB
 
 <pre><code><b>include</b> <a href="DiemTimestamp.md#0x1_DiemTimestamp_AbortsIfNotGenesis">DiemTimestamp::AbortsIfNotGenesis</a>;
 <b>include</b> <a href="CoreAddresses.md#0x1_CoreAddresses_AbortsIfNotDiemRoot">CoreAddresses::AbortsIfNotDiemRoot</a>{account: dr_account};
-<a name="0x1_AccountFreezing_addr$12"></a>
 <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(dr_account);
 <b>aborts_if</b> <b>exists</b>&lt;<a href="AccountFreezing.md#0x1_AccountFreezing_FreezeEventsHolder">FreezeEventsHolder</a>&gt;(addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>;
 <b>ensures</b> <b>exists</b>&lt;<a href="AccountFreezing.md#0x1_AccountFreezing_FreezeEventsHolder">FreezeEventsHolder</a>&gt;(addr);
@@ -295,9 +294,6 @@ The <code><a href="AccountFreezing.md#0x1_AccountFreezing_FreezingBit">FreezingB
 <details>
 <summary>Specification</summary>
 
-
-
-<a name="0x1_AccountFreezing_addr$13"></a>
 
 
 <pre><code><b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
@@ -376,9 +372,7 @@ Freeze the account at <code>addr</code>.
 <pre><code><b>schema</b> <a href="AccountFreezing.md#0x1_AccountFreezing_FreezeAccountEmits">FreezeAccountEmits</a> {
     account: &signer;
     frozen_address: address;
-    <a name="0x1_AccountFreezing_handle$8"></a>
     <b>let</b> handle = <b>global</b>&lt;<a href="AccountFreezing.md#0x1_AccountFreezing_FreezeEventsHolder">FreezeEventsHolder</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>()).freeze_event_handle;
-    <a name="0x1_AccountFreezing_msg$9"></a>
     <b>let</b> msg = <a href="AccountFreezing.md#0x1_AccountFreezing_FreezeAccountEvent">FreezeAccountEvent</a> {
         initiator_address: <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account),
         frozen_address
@@ -452,9 +446,7 @@ Unfreeze the account at <code>addr</code>.
 <pre><code><b>schema</b> <a href="AccountFreezing.md#0x1_AccountFreezing_UnfreezeAccountEmits">UnfreezeAccountEmits</a> {
     account: &signer;
     unfrozen_address: address;
-    <a name="0x1_AccountFreezing_handle$10"></a>
     <b>let</b> handle = <b>global</b>&lt;<a href="AccountFreezing.md#0x1_AccountFreezing_FreezeEventsHolder">FreezeEventsHolder</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>()).unfreeze_event_handle;
-    <a name="0x1_AccountFreezing_msg$11"></a>
     <b>let</b> msg = <a href="AccountFreezing.md#0x1_AccountFreezing_UnfreezeAccountEvent">UnfreezeAccountEvent</a> {
         initiator_address: <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account),
         unfrozen_address

--- a/language/diem-framework/modules/doc/ChainId.md
+++ b/language/diem-framework/modules/doc/ChainId.md
@@ -101,7 +101,6 @@ Publish the chain ID <code>id</code> of this Diem instance under the DiemRoot ac
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_ChainId_dr_addr$3"></a>
 <b>let</b> dr_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_address_of">Signer::address_of</a>(dr_account);
 <b>modifies</b> <b>global</b>&lt;<a href="ChainId.md#0x1_ChainId">ChainId</a>&gt;(dr_addr);
 <b>include</b> <a href="DiemTimestamp.md#0x1_DiemTimestamp_AbortsIfNotGenesis">DiemTimestamp::AbortsIfNotGenesis</a>;

--- a/language/diem-framework/modules/doc/DesignatedDealer.md
+++ b/language/diem-framework/modules/doc/DesignatedDealer.md
@@ -209,7 +209,6 @@ for each known currency at launch.
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_DesignatedDealer_dd_addr$4"></a>
 <b>let</b> dd_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(dd);
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotTreasuryCompliance">Roles::AbortsIfNotTreasuryCompliance</a>{account: tc_account};
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotDesignatedDealer">Roles::AbortsIfNotDesignatedDealer</a>{account: dd};
@@ -263,7 +262,6 @@ multi-signer transactions in order to add a new currency to an existing DD.
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_DesignatedDealer_dd_addr$5"></a>
 <b>let</b> dd_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(dd);
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotTreasuryCompliance">Roles::AbortsIfNotTreasuryCompliance</a>{account: tc_account};
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotDesignatedDealer">Roles::AbortsIfNotDesignatedDealer</a>{account: dd};
@@ -353,10 +351,10 @@ multi-signer transactions in order to add a new currency to an existing DD.
 <b>ensures</b> <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">Diem::CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
 <b>modifies</b> <b>global</b>&lt;<a href="DesignatedDealer.md#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr);
 <b>ensures</b> !<b>exists</b>&lt;<a href="DesignatedDealer.md#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr);
-<a name="0x1_DesignatedDealer_currency_info$6"></a>
 <b>let</b> currency_info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">Diem::CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
+<b>let</b> post post_currency_info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">Diem::CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
 <b>ensures</b> result.value == amount;
-<b>ensures</b> currency_info == update_field(<b>old</b>(currency_info), total_value, <b>old</b>(currency_info.total_value) + amount);
+<b>ensures</b> post_currency_info == update_field(currency_info, total_value, currency_info.total_value + amount);
 </code></pre>
 
 

--- a/language/diem-framework/modules/doc/Diem.md
+++ b/language/diem-framework/modules/doc/Diem.md
@@ -1160,10 +1160,8 @@ a value equal to <code>amount</code>.
 
 
 
-<a name="0x1_Diem_currency_info$97"></a>
-
-
 <pre><code><b>let</b> currency_info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
+<b>let</b> post post_currency_info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
 <b>modifies</b> <b>global</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(preburn_address);
 <b>modifies</b> <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
 <b>include</b> <a href="Diem.md#0x1_Diem_CancelBurnAbortsIf">CancelBurnAbortsIf</a>&lt;CoinType&gt;;
@@ -1171,10 +1169,10 @@ a value equal to <code>amount</code>.
 <b>include</b> <a href="Diem.md#0x1_Diem_CancelBurnWithCapEmits">CancelBurnWithCapEmits</a>&lt;CoinType&gt;;
 <b>ensures</b> <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
 <b>ensures</b> <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(preburn_address);
-<b>ensures</b> currency_info == update_field(
-    <b>old</b>(currency_info),
+<b>ensures</b> post_currency_info == update_field(
+    currency_info,
     preburn_value,
-    currency_info.preburn_value
+    post_currency_info.preburn_value
 );
 <b>ensures</b> result.value == amount;
 <b>ensures</b> result.value &gt; 0;
@@ -1293,10 +1291,10 @@ reference.
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_MintEnsures">MintEnsures</a>&lt;CoinType&gt; {
     value: u64;
     result: <a href="Diem.md#0x1_Diem">Diem</a>&lt;CoinType&gt;;
-    <a name="0x1_Diem_currency_info$61"></a>
     <b>let</b> currency_info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
+    <b>let</b> post post_currency_info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
     <b>ensures</b> <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
-    <b>ensures</b> currency_info == update_field(<b>old</b>(currency_info), total_value, <b>old</b>(currency_info.total_value) + value);
+    <b>ensures</b> post_currency_info == update_field(currency_info, total_value, currency_info.total_value + value);
     <b>ensures</b> result.value == value;
 }
 </code></pre>
@@ -1309,11 +1307,8 @@ reference.
 
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_MintEmits">MintEmits</a>&lt;CoinType&gt; {
     value: u64;
-    <a name="0x1_Diem_currency_info$62"></a>
     <b>let</b> currency_info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
-    <a name="0x1_Diem_handle$63"></a>
     <b>let</b> handle = currency_info.mint_events;
-    <a name="0x1_Diem_msg$64"></a>
     <b>let</b> msg = <a href="Diem.md#0x1_Diem_MintEvent">MintEvent</a>{
         amount: value,
         currency_code: currency_info.currency_code,
@@ -1430,9 +1425,9 @@ being preburned is a synthetic currency (<code>is_synthetic = <b>true</b></code>
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_PreburnEnsures">PreburnEnsures</a>&lt;CoinType&gt; {
     amount: u64;
     preburn: <a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;;
-    <a name="0x1_Diem_info$65"></a>
     <b>let</b> info = <a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;();
-    <b>ensures</b> info == update_field(<b>old</b>(info), preburn_value, <b>old</b>(info.preburn_value) + amount);
+    <b>let</b> post post_info = <a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;();
+    <b>ensures</b> post_info == update_field(info, preburn_value, info.preburn_value + amount);
 }
 </code></pre>
 
@@ -1445,13 +1440,9 @@ being preburned is a synthetic currency (<code>is_synthetic = <b>true</b></code>
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_PreburnWithResourceEmits">PreburnWithResourceEmits</a>&lt;CoinType&gt; {
     amount: u64;
     preburn_address: address;
-    <a name="0x1_Diem_info$66"></a>
     <b>let</b> info = <a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;();
-    <a name="0x1_Diem_currency_code$67"></a>
     <b>let</b> currency_code = <a href="Diem.md#0x1_Diem_spec_currency_code">spec_currency_code</a>&lt;CoinType&gt;();
-    <a name="0x1_Diem_handle$68"></a>
     <b>let</b> handle = info.preburn_events;
-    <a name="0x1_Diem_msg$69"></a>
     <b>let</b> msg = <a href="Diem.md#0x1_Diem_PreburnEvent">PreburnEvent</a> {
         amount,
         currency_code,
@@ -1568,7 +1559,6 @@ dealer account <code>account</code>.
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_Diem_account_addr$98"></a>
 <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 <b>modifies</b> <b>global</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr);
 <b>aborts_if</b> <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>;
@@ -1598,14 +1588,10 @@ dealer account <code>account</code>.
 
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_PublishPreburnQueueEnsures">PublishPreburnQueueEnsures</a>&lt;CoinType&gt; {
     account: signer;
-    <a name="0x1_Diem_account_addr$70"></a>
     <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
-    <a name="0x1_Diem_exists_preburn_queue$71"></a>
-    <b>let</b> exists_preburn_queue = <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr);
-    <b>ensures</b> exists_preburn_queue;
+    <b>ensures</b> <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr);
     <b>ensures</b> !<b>exists</b>&lt;<a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(account_addr);
     <b>ensures</b> <a href="../../../../../../move-stdlib/docs/Vector.md#0x1_Vector_length">Vector::length</a>(<b>global</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr).preburns) == 0;
-    <b>ensures</b> <b>old</b>(exists_preburn_queue) ==&gt; exists_preburn_queue;
 }
 </code></pre>
 
@@ -1653,7 +1639,6 @@ this resource for the designated dealer <code>account</code>.
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_Diem_account_addr$99"></a>
 <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 <b>modifies</b> <b>global</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr);
 </code></pre>
@@ -1736,9 +1721,6 @@ requests can be outstanding in the same currency for a designated dealer.
 
 
 
-<a name="0x1_Diem_account_addr$100"></a>
-
-
 <pre><code><b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 <b>modifies</b> <b>global</b>&lt;<a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(account_addr);
 <b>modifies</b> <b>global</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr);
@@ -1754,14 +1736,8 @@ requests can be outstanding in the same currency for a designated dealer.
 
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_UpgradePreburnAbortsIf">UpgradePreburnAbortsIf</a>&lt;CoinType&gt; {
     account: signer;
-    <a name="0x1_Diem_account_addr$72"></a>
     <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
-    <a name="0x1_Diem_preburn$73"></a>
-    <b>let</b> preburn = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(account_addr);
-    <a name="0x1_Diem_preburn_exists$74"></a>
-    <b>let</b> preburn_exists = <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(account_addr);
-    <a name="0x1_Diem_preburn_queue_exists$75"></a>
-    <b>let</b> preburn_queue_exists = <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr);
+    <b>let</b> upgrade = <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(account_addr) && !<b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr);
 }
 </code></pre>
 
@@ -1771,8 +1747,8 @@ Must abort if the account doesn't have the <code><a href="Diem.md#0x1_Diem_Prebu
 
 
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_UpgradePreburnAbortsIf">UpgradePreburnAbortsIf</a>&lt;CoinType&gt; {
+    <b>include</b> upgrade ==&gt; <a href="Diem.md#0x1_Diem_PublishPreburnQueueAbortsIf">PublishPreburnQueueAbortsIf</a>&lt;CoinType&gt;;
     <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotDesignatedDealer">Roles::AbortsIfNotDesignatedDealer</a>;
-    <b>include</b> (preburn_exists && !preburn_queue_exists) ==&gt; <a href="Diem.md#0x1_Diem_PublishPreburnQueueAbortsIf">PublishPreburnQueueAbortsIf</a>&lt;CoinType&gt;;
 }
 </code></pre>
 
@@ -1784,45 +1760,16 @@ Must abort if the account doesn't have the <code><a href="Diem.md#0x1_Diem_Prebu
 
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_UpgradePreburnEnsures">UpgradePreburnEnsures</a>&lt;CoinType&gt; {
     account: signer;
-    <a name="0x1_Diem_account_addr$76"></a>
     <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
-    <a name="0x1_Diem_preburn_exists$77"></a>
-    <b>let</b> preburn_exists = <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(account_addr);
-    <a name="0x1_Diem_preburn_queue_exists$78"></a>
-    <b>let</b> preburn_queue_exists = <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr);
-    <a name="0x1_Diem_preburn$79"></a>
+    <b>let</b> upgrade = <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(account_addr) && !<b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr);
     <b>let</b> preburn = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(account_addr);
-    <a name="0x1_Diem_preburn_queue$80"></a>
-    <b>let</b> preburn_queue = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr);
-    <a name="0x1_Diem_preburn_state_empty$81"></a>
-    <b>let</b> preburn_state_empty = preburn_exists && !preburn_queue_exists && preburn.to_burn.value == 0;
-    <a name="0x1_Diem_preburn_state_full$82"></a>
-    <b>let</b> preburn_state_full = preburn_exists && !preburn_queue_exists && preburn.to_burn.value &gt; 0;
-    <b>include</b> preburn_state_empty ==&gt; <a href="Diem.md#0x1_Diem_PublishPreburnQueueEnsures">PublishPreburnQueueEnsures</a>&lt;CoinType&gt;;
-    <b>include</b> preburn_state_full ==&gt; <a href="Diem.md#0x1_Diem_UpgradePreburnEnsuresFullState">UpgradePreburnEnsuresFullState</a>&lt;CoinType&gt; {
-        preburn_queue_exists: preburn_queue_exists,
-        account_addr: account_addr,
-        preburn_queue: preburn_queue,
-        preburn: <a href="Diem.md#0x1_Diem_PreburnWithMetadata">PreburnWithMetadata</a> { preburn, metadata: x"" },
-    };
-}
-</code></pre>
-
-
-
-
-<a name="0x1_Diem_UpgradePreburnEnsuresFullState"></a>
-
-
-<pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_UpgradePreburnEnsuresFullState">UpgradePreburnEnsuresFullState</a>&lt;CoinType&gt; {
-    preburn_queue_exists: bool;
-    account_addr: address;
-    preburn_queue: <a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;;
-    preburn: <a href="Diem.md#0x1_Diem_PreburnWithMetadata">PreburnWithMetadata</a>&lt;CoinType&gt;;
-    <b>ensures</b> preburn_queue_exists;
-    <b>ensures</b> !<b>exists</b>&lt;<a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(account_addr);
-    <b>ensures</b> <a href="../../../../../../move-stdlib/docs/Vector.md#0x1_Vector_length">Vector::length</a>(preburn_queue.preburns) == 1;
-    <b>ensures</b> <a href="../../../../../../move-stdlib/docs/Vector.md#0x1_Vector_eq_push_back">Vector::eq_push_back</a>(preburn_queue.preburns, <b>old</b>(preburn_queue).preburns, <b>old</b>(preburn));
+    <b>ensures</b> upgrade ==&gt;
+        !<b>exists</b>&lt;<a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(account_addr) && <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr);
+    <b>ensures</b> upgrade && preburn.to_burn.value &gt; 0 ==&gt;
+        <b>global</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr).preburns ==
+            vec(<a href="Diem.md#0x1_Diem_PreburnWithMetadata">PreburnWithMetadata</a> { preburn, metadata: x"" });
+    <b>ensures</b> upgrade && preburn.to_burn.value == 0 ==&gt;
+        <b>global</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr).preburns == vec();
 }
 </code></pre>
 
@@ -1871,15 +1818,14 @@ number of preburn requests does not exceed <code><a href="Diem.md#0x1_Diem_MAX_O
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_Diem_account_addr$101"></a>
 <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
-<a name="0x1_Diem_preburns$102"></a>
 <b>let</b> preburns = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr).preburns;
+<b>let</b> post post_preburns = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr).preburns;
 <b>modifies</b> <b>global</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr);
 <b>aborts_if</b> !<b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>;
 <b>include</b> <a href="Diem.md#0x1_Diem_AddPreburnToQueueAbortsIf">AddPreburnToQueueAbortsIf</a>&lt;CoinType&gt;;
 <b>ensures</b> <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr);
-<b>ensures</b> <a href="../../../../../../move-stdlib/docs/Vector.md#0x1_Vector_eq_push_back">Vector::eq_push_back</a>(preburns, <b>old</b>(preburns), preburn);
+<b>ensures</b> <a href="../../../../../../move-stdlib/docs/Vector.md#0x1_Vector_eq_push_back">Vector::eq_push_back</a>(post_preburns, preburns, preburn);
 </code></pre>
 
 
@@ -1891,7 +1837,6 @@ number of preburn requests does not exceed <code><a href="Diem.md#0x1_Diem_MAX_O
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_AddPreburnToQueueAbortsIf">AddPreburnToQueueAbortsIf</a>&lt;CoinType&gt; {
     account: signer;
     preburn: <a href="Diem.md#0x1_Diem_PreburnWithMetadata">PreburnWithMetadata</a>&lt;CoinType&gt;;
-    <a name="0x1_Diem_account_addr$83"></a>
     <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>aborts_if</b> preburn.preburn.to_burn.value == 0 <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
     <b>aborts_if</b> <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr) &&
@@ -1959,7 +1904,6 @@ Calls to this function will fail if:
 <pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Diem.md#0x1_Diem_PreburnToAbortsIf">PreburnToAbortsIf</a>&lt;CoinType&gt;{amount: coin.value};
 <b>include</b> <a href="Diem.md#0x1_Diem_PreburnToEnsures">PreburnToEnsures</a>&lt;CoinType&gt;{amount: coin.value};
-<a name="0x1_Diem_account_addr$103"></a>
 <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 <b>include</b> <a href="Diem.md#0x1_Diem_PreburnWithResourceEmits">PreburnWithResourceEmits</a>&lt;CoinType&gt;{amount: coin.value, preburn_address: account_addr};
 </code></pre>
@@ -1973,7 +1917,6 @@ Calls to this function will fail if:
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_PreburnToAbortsIf">PreburnToAbortsIf</a>&lt;CoinType&gt; {
     account: signer;
     amount: u64;
-    <a name="0x1_Diem_account_addr$84"></a>
     <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 }
 </code></pre>
@@ -2001,7 +1944,6 @@ the correct role [[H4]][PERMISSION].
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_PreburnToEnsures">PreburnToEnsures</a>&lt;CoinType&gt; {
     account: signer;
     amount: u64;
-    <a name="0x1_Diem_account_addr$85"></a>
     <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 }
 </code></pre>
@@ -2110,7 +2052,6 @@ Calls to this function will fail if:
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_RemovePreburnFromQueueAbortsIf">RemovePreburnFromQueueAbortsIf</a>&lt;CoinType&gt; {
     preburn_address: address;
     amount: u64;
-    <a name="0x1_Diem_preburn_queue$54"></a>
     <b>let</b> preburn_queue = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(preburn_address).preburns;
     <b>aborts_if</b> !<b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(preburn_address) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
     <b>aborts_if</b> <b>forall</b> i in 0..len(preburn_queue): preburn_queue[i].preburn.to_burn.value != amount <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>;
@@ -2128,9 +2069,7 @@ Calls to this function will fail if:
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_RemovePreburnFromQueueEnsures">RemovePreburnFromQueueEnsures</a>&lt;CoinType&gt; {
     preburn_address: address;
     amount: u64;
-    <a name="0x1_Diem_exists_preburn_queue$58"></a>
-    <b>let</b> exists_preburn_queue = <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(preburn_address);
-    <b>ensures</b> <b>old</b>(exists_preburn_queue) ==&gt; exists_preburn_queue;
+    <b>ensures</b> <b>old</b>(<b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(preburn_address)) ==&gt; <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(preburn_address);
 }
 </code></pre>
 
@@ -2200,8 +2139,7 @@ the preburn queue with a <code>to_burn</code> amount equal to <code>amount</code
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_BurnWithCapabilityAbortsIf">BurnWithCapabilityAbortsIf</a>&lt;CoinType&gt; {
     preburn_address: address;
     amount: u64;
-    <a name="0x1_Diem_preburn$57"></a>
-    <b>let</b> preburn = <a href="Diem.md#0x1_Diem_spec_make_preburn">spec_make_preburn</a>(amount);
+    <b>let</b> preburn = <a href="Diem.md#0x1_Diem_spec_make_preburn">spec_make_preburn</a>&lt;CoinType&gt;(amount);
     <b>include</b> <a href="Diem.md#0x1_Diem_AbortsIfNoPreburnQueue">AbortsIfNoPreburnQueue</a>&lt;CoinType&gt;;
     <b>include</b> <a href="Diem.md#0x1_Diem_RemovePreburnFromQueueAbortsIf">RemovePreburnFromQueueAbortsIf</a>&lt;CoinType&gt;;
     <b>include</b> <a href="Diem.md#0x1_Diem_BurnWithResourceCapAbortsIf">BurnWithResourceCapAbortsIf</a>&lt;CoinType&gt;{preburn: preburn};
@@ -2217,8 +2155,7 @@ the preburn queue with a <code>to_burn</code> amount equal to <code>amount</code
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_BurnWithCapabilityEnsures">BurnWithCapabilityEnsures</a>&lt;CoinType&gt; {
     preburn_address: address;
     amount: u64;
-    <a name="0x1_Diem_preburn$59"></a>
-    <b>let</b> preburn = <a href="Diem.md#0x1_Diem_spec_make_preburn">spec_make_preburn</a>(amount);
+    <b>let</b> preburn = <a href="Diem.md#0x1_Diem_spec_make_preburn">spec_make_preburn</a>&lt;CoinType&gt;(amount);
     <b>include</b> <a href="Diem.md#0x1_Diem_BurnWithResourceCapEnsures">BurnWithResourceCapEnsures</a>&lt;CoinType&gt;{preburn: preburn};
     <b>include</b> <a href="Diem.md#0x1_Diem_RemovePreburnFromQueueEnsures">RemovePreburnFromQueueEnsures</a>&lt;CoinType&gt;;
 }
@@ -2288,9 +2225,10 @@ Calls to this function will fail if the preburn <code>to_burn</code> area for <c
 
 
 
-<pre><code><b>include</b> <a href="Diem.md#0x1_Diem_BurnWithResourceCapAbortsIf">BurnWithResourceCapAbortsIf</a>&lt;CoinType&gt;;
-<b>include</b> <a href="Diem.md#0x1_Diem_BurnWithResourceCapEnsures">BurnWithResourceCapEnsures</a>&lt;CoinType&gt;;
-<b>include</b> <a href="Diem.md#0x1_Diem_BurnWithResourceCapEmits">BurnWithResourceCapEmits</a>&lt;CoinType&gt;;
+<pre><code><b>let</b> pre_preburn = preburn;
+<b>include</b> <a href="Diem.md#0x1_Diem_BurnWithResourceCapAbortsIf">BurnWithResourceCapAbortsIf</a>&lt;CoinType&gt;{preburn: pre_preburn};
+<b>include</b> <a href="Diem.md#0x1_Diem_BurnWithResourceCapEnsures">BurnWithResourceCapEnsures</a>&lt;CoinType&gt;{preburn: pre_preburn};
+<b>include</b> <a href="Diem.md#0x1_Diem_BurnWithResourceCapEmits">BurnWithResourceCapEmits</a>&lt;CoinType&gt;{preburn: pre_preburn};
 </code></pre>
 
 
@@ -2302,9 +2240,7 @@ Calls to this function will fail if the preburn <code>to_burn</code> area for <c
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_BurnWithResourceCapAbortsIf">BurnWithResourceCapAbortsIf</a>&lt;CoinType&gt; {
     preburn: <a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;;
     <b>include</b> <a href="Diem.md#0x1_Diem_AbortsIfNoCurrency">AbortsIfNoCurrency</a>&lt;CoinType&gt;;
-    <a name="0x1_Diem_to_burn$55"></a>
     <b>let</b> to_burn = preburn.to_burn.value;
-    <a name="0x1_Diem_info$56"></a>
     <b>let</b> info = <a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;();
     <b>aborts_if</b> to_burn == 0 <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>;
     <b>aborts_if</b> info.total_value &lt; to_burn <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_LIMIT_EXCEEDED">Errors::LIMIT_EXCEEDED</a>;
@@ -2321,9 +2257,9 @@ Calls to this function will fail if the preburn <code>to_burn</code> area for <c
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_BurnWithResourceCapEnsures">BurnWithResourceCapEnsures</a>&lt;CoinType&gt; {
     preburn: <a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;;
     <b>ensures</b> <a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;().total_value
-            == <b>old</b>(<a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;().total_value) - <b>old</b>(preburn.to_burn.value);
+            == <b>old</b>(<a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;().total_value) - preburn.to_burn.value;
     <b>ensures</b> <a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;().preburn_value
-            == <b>old</b>(<a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;().preburn_value) - <b>old</b>(preburn.to_burn.value);
+            == <b>old</b>(<a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;().preburn_value) - preburn.to_burn.value;
 }
 </code></pre>
 
@@ -2336,14 +2272,11 @@ Calls to this function will fail if the preburn <code>to_burn</code> area for <c
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_BurnWithResourceCapEmits">BurnWithResourceCapEmits</a>&lt;CoinType&gt; {
     preburn: <a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;;
     preburn_address: address;
-    <a name="0x1_Diem_info$86"></a>
     <b>let</b> info = <a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;();
-    <a name="0x1_Diem_currency_code$87"></a>
     <b>let</b> currency_code = <a href="Diem.md#0x1_Diem_spec_currency_code">spec_currency_code</a>&lt;CoinType&gt;();
-    <a name="0x1_Diem_handle$88"></a>
     <b>let</b> handle = info.burn_events;
     emits <a href="Diem.md#0x1_Diem_BurnEvent">BurnEvent</a> {
-            amount: <b>old</b>(preburn.to_burn.value),
+            amount: preburn.to_burn.value,
             currency_code,
             preburn_address,
         }
@@ -2434,7 +2367,6 @@ at <code>preburn_address</code> does not contain a preburn request of the right 
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_CancelBurnWithCapAbortsIf">CancelBurnWithCapAbortsIf</a>&lt;CoinType&gt; {
     preburn_address: address;
     amount: u64;
-    <a name="0x1_Diem_info$60"></a>
     <b>let</b> info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
     <b>include</b> <a href="Diem.md#0x1_Diem_AbortsIfNoCurrency">AbortsIfNoCurrency</a>&lt;CoinType&gt;;
     <b>include</b> <a href="Diem.md#0x1_Diem_RemovePreburnFromQueueAbortsIf">RemovePreburnFromQueueAbortsIf</a>&lt;CoinType&gt;;
@@ -2452,9 +2384,9 @@ at <code>preburn_address</code> does not contain a preburn request of the right 
     preburn_address: address;
     amount: u64;
     <b>include</b> <a href="Diem.md#0x1_Diem_RemovePreburnFromQueueEnsures">RemovePreburnFromQueueEnsures</a>&lt;CoinType&gt;;
-    <a name="0x1_Diem_info$89"></a>
     <b>let</b> info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
-    <b>ensures</b> info == update_field(<b>old</b>(info), preburn_value, <b>old</b>(info.preburn_value) - amount);
+    <b>let</b> post post_info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
+    <b>ensures</b> post_info == update_field(info, preburn_value, info.preburn_value - amount);
 }
 </code></pre>
 
@@ -2467,11 +2399,8 @@ at <code>preburn_address</code> does not contain a preburn request of the right 
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_CancelBurnWithCapEmits">CancelBurnWithCapEmits</a>&lt;CoinType&gt; {
     preburn_address: address;
     amount: u64;
-    <a name="0x1_Diem_info$90"></a>
     <b>let</b> info = <a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;();
-    <a name="0x1_Diem_currency_code$91"></a>
     <b>let</b> currency_code = <a href="Diem.md#0x1_Diem_spec_currency_code">spec_currency_code</a>&lt;CoinType&gt;();
-    <a name="0x1_Diem_handle$92"></a>
     <b>let</b> handle = info.cancel_burn_events;
     emits <a href="Diem.md#0x1_Diem_CancelBurnEvent">CancelBurnEvent</a> {
            amount,
@@ -2525,12 +2454,12 @@ used for administrative burns, like unpacking an XDX coin or charging fees.
 
 
 <pre><code><b>include</b> <a href="Diem.md#0x1_Diem_BurnNowAbortsIf">BurnNowAbortsIf</a>&lt;CoinType&gt;;
-<a name="0x1_Diem_info$104"></a>
 <b>let</b> info = <a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;();
+<b>let</b> post post_info = <a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;();
 <b>include</b> <a href="Diem.md#0x1_Diem_PreburnWithResourceEmits">PreburnWithResourceEmits</a>&lt;CoinType&gt;{amount: coin.value, preburn_address: preburn_address};
 <b>include</b> <a href="Diem.md#0x1_Diem_BurnWithResourceCapEmits">BurnWithResourceCapEmits</a>&lt;CoinType&gt;{preburn: <a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;{to_burn: coin}};
 <b>ensures</b> preburn.to_burn.value == 0;
-<b>ensures</b> info == update_field(<b>old</b>(info), total_value, <b>old</b>(info.total_value) - coin.value);
+<b>ensures</b> post_info == update_field(info, total_value, info.total_value - coin.value);
 </code></pre>
 
 
@@ -2544,7 +2473,6 @@ used for administrative burns, like unpacking an XDX coin or charging fees.
     preburn: <a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;;
     <b>aborts_if</b> coin.value == 0 <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
     <b>include</b> <a href="Diem.md#0x1_Diem_PreburnWithResourceAbortsIf">PreburnWithResourceAbortsIf</a>&lt;CoinType&gt;{amount: coin.value};
-    <a name="0x1_Diem_info$93"></a>
     <b>let</b> info = <a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;();
     <b>aborts_if</b> info.total_value &lt; coin.value <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_LIMIT_EXCEEDED">Errors::LIMIT_EXCEEDED</a>;
 }
@@ -3275,7 +3203,6 @@ rate is needed.
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_ApproxXdmForValueAbortsIf">ApproxXdmForValueAbortsIf</a>&lt;CoinType&gt; {
     from_value: num;
     <b>include</b> <a href="Diem.md#0x1_Diem_AbortsIfNoCurrency">AbortsIfNoCurrency</a>&lt;CoinType&gt;;
-    <a name="0x1_Diem_xdx_exchange_rate$94"></a>
     <b>let</b> xdx_exchange_rate = <a href="Diem.md#0x1_Diem_spec_xdx_exchange_rate">spec_xdx_exchange_rate</a>&lt;CoinType&gt;();
     <b>include</b> <a href="../../../../../../move-stdlib/docs/FixedPoint32.md#0x1_FixedPoint32_MultiplyAbortsIf">FixedPoint32::MultiplyAbortsIf</a>{val: from_value, multiplier: xdx_exchange_rate};
 }
@@ -3593,9 +3520,7 @@ Must abort if the account does not have the TreasuryCompliance Role [[H5]][PERMI
 
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_UpdateXDXExchangeRateEmits">UpdateXDXExchangeRateEmits</a>&lt;FromCoinType&gt; {
     xdx_exchange_rate: <a href="../../../../../../move-stdlib/docs/FixedPoint32.md#0x1_FixedPoint32">FixedPoint32</a>;
-    <a name="0x1_Diem_handle$95"></a>
     <b>let</b> handle = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;FromCoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>()).exchange_rate_update_events;
-    <a name="0x1_Diem_msg$96"></a>
     <b>let</b> msg = <a href="Diem.md#0x1_Diem_ToXDXExchangeRateUpdateEvent">ToXDXExchangeRateUpdateEvent</a> {
         currency_code: <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;FromCoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>()).currency_code,
         new_to_xdx_exchange_rate: <a href="../../../../../../move-stdlib/docs/FixedPoint32.md#0x1_FixedPoint32_get_raw_value">FixedPoint32::get_raw_value</a>(xdx_exchange_rate)
@@ -3642,7 +3567,6 @@ Returns the (rough) exchange rate between <code>CoinType</code> and <code><a hre
 
 <pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Diem.md#0x1_Diem_AbortsIfNoCurrency">AbortsIfNoCurrency</a>&lt;CoinType&gt;;
-<a name="0x1_Diem_info$105"></a>
 <b>let</b> info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
 <b>ensures</b> result == info.to_xdx_exchange_rate;
 </code></pre>

--- a/language/diem-framework/modules/doc/DiemAccount.md
+++ b/language/diem-framework/modules/doc/DiemAccount.md
@@ -1070,7 +1070,6 @@ Record a payment of <code>to_deposit</code> from <code>payer</code> to <code>pay
                             <b>old</b>(<b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payee).sent_events));
 <b>ensures</b> <a href="../../../../../../move-stdlib/docs/Event.md#0x1_Event_spec_guid_eq">Event::spec_guid_eq</a>(<b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payee).received_events,
                             <b>old</b>(<b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payee).received_events));
-<a name="0x1_DiemAccount_amount$85"></a>
 <b>let</b> amount = to_deposit.value;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_DepositAbortsIf">DepositAbortsIf</a>&lt;Token&gt;{amount: amount};
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_DepositOverflowAbortsIf">DepositOverflowAbortsIf</a>&lt;Token&gt;{amount: amount};
@@ -1162,9 +1161,7 @@ Record a payment of <code>to_deposit</code> from <code>payer</code> to <code>pay
     payee: address;
     amount: u64;
     metadata: vector&lt;u8&gt;;
-    <a name="0x1_DiemAccount_handle$61"></a>
     <b>let</b> handle = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payee).received_events;
-    <a name="0x1_DiemAccount_msg$62"></a>
     <b>let</b> msg = <a href="DiemAccount.md#0x1_DiemAccount_ReceivedPaymentEvent">ReceivedPaymentEvent</a> {
         amount,
         currency_code: <a href="Diem.md#0x1_Diem_spec_currency_code">Diem::spec_currency_code</a>&lt;Token&gt;(),
@@ -1260,10 +1257,10 @@ Sender should be treasury compliance account and receiver authorized DD.
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_TieredMintEnsures">TieredMintEnsures</a>&lt;Token&gt; {
     designated_dealer_address: address;
     mint_amount: u64;
-    <a name="0x1_DiemAccount_dealer_balance$63"></a>
     <b>let</b> dealer_balance = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_Balance">Balance</a>&lt;Token&gt;&gt;(designated_dealer_address).coin.value;
-    <a name="0x1_DiemAccount_currency_info$64"></a>
+    <b>let</b> post post_dealer_balance = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_Balance">Balance</a>&lt;Token&gt;&gt;(designated_dealer_address).coin.value;
     <b>let</b> currency_info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">Diem::CurrencyInfo</a>&lt;Token&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
+    <b>let</b> post post_currency_info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">Diem::CurrencyInfo</a>&lt;Token&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
 }
 </code></pre>
 
@@ -1272,7 +1269,7 @@ Total value of the currency increases by <code>amount</code>.
 
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_TieredMintEnsures">TieredMintEnsures</a>&lt;Token&gt; {
-    <b>ensures</b> currency_info == update_field(<b>old</b>(currency_info), total_value, <b>old</b>(currency_info.total_value) + mint_amount);
+    <b>ensures</b> post_currency_info == update_field(currency_info, total_value, currency_info.total_value + mint_amount);
 }
 </code></pre>
 
@@ -1281,7 +1278,7 @@ The balance of designated dealer increases by <code>amount</code>.
 
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_TieredMintEnsures">TieredMintEnsures</a>&lt;Token&gt; {
-    <b>ensures</b> dealer_balance == <b>old</b>(dealer_balance) + mint_amount;
+    <b>ensures</b> post_dealer_balance == dealer_balance + mint_amount;
 }
 </code></pre>
 
@@ -1551,9 +1548,6 @@ Withdraw <code>amount</code> <code><a href="Diem.md#0x1_Diem">Diem</a>&lt;Token&
 
 
 
-<a name="0x1_DiemAccount_payer$86"></a>
-
-
 <pre><code><b>let</b> payer = cap.account_address;
 <b>modifies</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_Balance">Balance</a>&lt;Token&gt;&gt;(payer);
 <b>modifies</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payer);
@@ -1581,7 +1575,6 @@ Withdraw <code>amount</code> <code><a href="Diem.md#0x1_Diem">Diem</a>&lt;Token&
     cap: <a href="DiemAccount.md#0x1_DiemAccount_WithdrawCapability">WithdrawCapability</a>;
     payee: address;
     amount: u64;
-    <a name="0x1_DiemAccount_payer$59"></a>
     <b>let</b> payer = cap.account_address;
     <b>include</b> <a href="DiemTimestamp.md#0x1_DiemTimestamp_AbortsIfNotOperating">DiemTimestamp::AbortsIfNotOperating</a>;
     <b>include</b> <a href="Diem.md#0x1_Diem_AbortsIfNoCurrency">Diem::AbortsIfNoCurrency</a>&lt;Token&gt;;
@@ -1628,11 +1621,8 @@ Can only withdraw from the balances of cap.account_address [[H19]][PERMISSION].
     payee: address;
     amount: u64;
     metadata: vector&lt;u8&gt;;
-    <a name="0x1_DiemAccount_payer$65"></a>
     <b>let</b> payer = cap.account_address;
-    <a name="0x1_DiemAccount_handle$66"></a>
     <b>let</b> handle = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payer).sent_events;
-    <a name="0x1_DiemAccount_msg$67"></a>
     <b>let</b> msg = <a href="DiemAccount.md#0x1_DiemAccount_SentPaymentEvent">SentPaymentEvent</a> {
         amount,
         currency_code: <a href="Diem.md#0x1_Diem_spec_currency_code">Diem::spec_currency_code</a>&lt;Token&gt;(),
@@ -1684,9 +1674,7 @@ resource under <code>dd</code>.
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_DiemAccount_dd_addr$87"></a>
 <b>let</b> dd_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(dd);
-<a name="0x1_DiemAccount_payer$88"></a>
 <b>let</b> payer = cap.account_address;
 <b>modifies</b> <b>global</b>&lt;<a href="AccountLimits.md#0x1_AccountLimits_Window">AccountLimits::Window</a>&lt;Token&gt;&gt;(<a href="VASP.md#0x1_VASP_spec_parent_address">VASP::spec_parent_address</a>(payer));
 <b>modifies</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payer);
@@ -1733,8 +1721,8 @@ resource under <code>dd</code>.
     payer: address;
     amount: u64;
     <b>modifies</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_Balance">Balance</a>&lt;Token&gt;&gt;(payer);
-    <a name="0x1_DiemAccount_payer_balance$60"></a>
     <b>let</b> payer_balance = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_Balance">Balance</a>&lt;Token&gt;&gt;(payer).coin.value;
+    <b>let</b> post post_payer_balance = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_Balance">Balance</a>&lt;Token&gt;&gt;(payer).coin.value;
 }
 </code></pre>
 
@@ -1743,7 +1731,7 @@ The balance of payer decreases by <code>amount</code>.
 
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_PreburnEnsures">PreburnEnsures</a>&lt;Token&gt; {
-    <b>ensures</b> payer_balance == <b>old</b>(payer_balance) - amount;
+    <b>ensures</b> post_payer_balance == payer_balance - amount;
 }
 </code></pre>
 
@@ -1766,7 +1754,6 @@ The value of preburn at <code>dd_addr</code> increases by <code>amount</code>;
     dd: signer;
     cap: <a href="DiemAccount.md#0x1_DiemAccount_WithdrawCapability">WithdrawCapability</a>;
     amount: u64;
-    <a name="0x1_DiemAccount_dd_addr$68"></a>
     <b>let</b> dd_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(dd);
     <b>include</b> <a href="Diem.md#0x1_Diem_PreburnWithResourceEmits">Diem::PreburnWithResourceEmits</a>&lt;Token&gt;{preburn_address: dd_addr};
     <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_WithdrawFromEmits">WithdrawFromEmits</a>&lt;Token&gt;{payee: dd_addr, metadata: x""};
@@ -1818,7 +1805,6 @@ Return a unique capability granting permission to withdraw from the sender's acc
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_DiemAccount_sender_addr$89"></a>
 <b>let</b> sender_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
 <b>modifies</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(sender_addr);
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ExtractWithdrawCapAbortsIf">ExtractWithdrawCapAbortsIf</a>{sender_addr};
@@ -1886,7 +1872,6 @@ Return the withdraw capability to the account it originally came from
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_DiemAccount_cap_addr$90"></a>
 <b>let</b> cap_addr = cap.account_address;
 <b>modifies</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(cap_addr);
 <b>ensures</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(cap_addr) == update_field(<b>old</b>(<b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(cap_addr)),
@@ -1947,7 +1932,6 @@ attestation protocol
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_DiemAccount_payer$91"></a>
 <b>let</b> payer = cap.account_address;
 <b>modifies</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payer);
 <b>modifies</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payee);
@@ -2004,7 +1988,6 @@ attestation protocol
     amount: u64;
     metadata: vector&lt;u8&gt;;
     metadata_signature: vector&lt;u8&gt; ;
-    <a name="0x1_DiemAccount_payer$69"></a>
     <b>let</b> payer = cap.account_address;
     <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_DepositAbortsIfRestricted">DepositAbortsIfRestricted</a>&lt;Token&gt;{payer: cap.account_address};
     <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_WithdrawFromBalanceNoLimitsAbortsIf">WithdrawFromBalanceNoLimitsAbortsIf</a>&lt;Token&gt;{payer, balance: <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_Balance">Balance</a>&lt;Token&gt;&gt;(payer)};
@@ -2039,7 +2022,6 @@ attestation protocol
     payee: address;
     amount: u64;
     metadata: vector&lt;u8&gt;;
-    <a name="0x1_DiemAccount_payer$70"></a>
     <b>let</b> payer = cap.account_address;
     <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_DepositEmits">DepositEmits</a>&lt;Token&gt;{payer: payer};
     <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_WithdrawFromEmits">WithdrawFromEmits</a>&lt;Token&gt;;
@@ -2203,7 +2185,6 @@ Return a unique capability granting permission to rotate the sender's authentica
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityAbortsIf">ExtractKeyRotationCapabilityAbortsIf</a> {
     account: signer;
-    <a name="0x1_DiemAccount_account_addr$71"></a>
     <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>aborts_if</b> !<a href="DiemAccount.md#0x1_DiemAccount_exists_at">exists_at</a>(account_addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
     <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_AbortsIfDelegatedKeyRotationCapability">AbortsIfDelegatedKeyRotationCapability</a>;
@@ -2347,9 +2328,6 @@ then add for both token types.
 
 
 
-<a name="0x1_DiemAccount_new_account_addr$92"></a>
-
-
 <pre><code><b>let</b> new_account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(new_account);
 <b>aborts_if</b> !<a href="Roles.md#0x1_Roles_spec_can_hold_balance_addr">Roles::spec_can_hold_balance_addr</a>(new_account_addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_AddCurrencyForAccountAbortsIf">AddCurrencyForAccountAbortsIf</a>&lt;Token&gt;{addr: new_account_addr};
@@ -2478,7 +2456,6 @@ Creating an account at address 0x0 will abort as it is a reserved address for th
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_DiemAccount_new_account_addr$93"></a>
 <b>let</b> new_account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_address_of">Signer::address_of</a>(new_account);
 <b>modifies</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(new_account_addr);
 <b>modifies</b> <b>global</b>&lt;<a href="../../../../../../move-stdlib/docs/Event.md#0x1_Event_EventHandleGenerator">Event::EventHandleGenerator</a>&gt;(new_account_addr);
@@ -2489,9 +2466,9 @@ Creating an account at address 0x0 will abort as it is a reserved address for th
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_MakeAccountAbortsIf">MakeAccountAbortsIf</a>{addr: new_account_addr};
 <b>ensures</b> <a href="DiemAccount.md#0x1_DiemAccount_exists_at">exists_at</a>(new_account_addr);
 <b>ensures</b> <a href="AccountFreezing.md#0x1_AccountFreezing_spec_account_is_not_frozen">AccountFreezing::spec_account_is_not_frozen</a>(new_account_addr);
-<a name="0x1_DiemAccount_account_ops_cap$94"></a>
 <b>let</b> account_ops_cap = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_AccountOperationsCapability">AccountOperationsCapability</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>());
-<b>ensures</b> account_ops_cap == update_field(<b>old</b>(account_ops_cap), creation_events, account_ops_cap.creation_events);
+<b>let</b> post post_account_ops_cap = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_AccountOperationsCapability">AccountOperationsCapability</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>());
+<b>ensures</b> post_account_ops_cap == update_field(account_ops_cap, creation_events, account_ops_cap.creation_events);
 <b>ensures</b> <a href="DiemAccount.md#0x1_DiemAccount_spec_holds_own_key_rotation_cap">spec_holds_own_key_rotation_cap</a>(new_account_addr);
 <b>ensures</b> <a href="DiemAccount.md#0x1_DiemAccount_spec_holds_own_withdraw_cap">spec_holds_own_withdraw_cap</a>(new_account_addr);
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_MakeAccountEmits">MakeAccountEmits</a>{new_account_address: <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(new_account)};
@@ -2524,10 +2501,8 @@ Creating an account at address 0x0 will abort as it is a reserved address for th
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_MakeAccountEmits">MakeAccountEmits</a> {
     new_account_address: address;
-    <a name="0x1_DiemAccount_handle$72"></a>
-    <b>let</b> handle = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_AccountOperationsCapability">AccountOperationsCapability</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>()).creation_events;
-    <a name="0x1_DiemAccount_msg$73"></a>
-    <b>let</b> msg = <a href="DiemAccount.md#0x1_DiemAccount_CreateAccountEvent">CreateAccountEvent</a> {
+    <b>let</b> post handle = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_AccountOperationsCapability">AccountOperationsCapability</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>()).creation_events;
+    <b>let</b> post msg = <a href="DiemAccount.md#0x1_DiemAccount_CreateAccountEvent">CreateAccountEvent</a> {
         created: new_account_address,
         role_id: <a href="Roles.md#0x1_Roles_spec_get_role_id">Roles::spec_get_role_id</a>(new_account_address)
     };
@@ -2691,9 +2666,6 @@ AccountOperationsCapability, WriteSetManager, and finally makes the account.
 <a name="0x1_DiemAccount_CreateDiemRootAccountModifies"></a>
 
 
-<a name="0x1_DiemAccount_dr_addr$74"></a>
-
-
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateDiemRootAccountModifies">CreateDiemRootAccountModifies</a> {
     <b>let</b> dr_addr = <a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>();
     <b>modifies</b> <b>global</b>&lt;<a href="../../../../../../move-stdlib/docs/Event.md#0x1_Event_EventHandleGenerator">Event::EventHandleGenerator</a>&gt;(dr_addr);
@@ -2732,9 +2704,6 @@ AccountOperationsCapability, WriteSetManager, and finally makes the account.
 
 
 <a name="0x1_DiemAccount_CreateDiemRootAccountEnsures"></a>
-
-
-<a name="0x1_DiemAccount_dr_addr$75"></a>
 
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateDiemRootAccountEnsures">CreateDiemRootAccountEnsures</a> {
@@ -2798,16 +2767,15 @@ event handle generator, then makes the account.
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_DiemAccount_tc_addr$95"></a>
 <b>let</b> tc_addr = <a href="CoreAddresses.md#0x1_CoreAddresses_TREASURY_COMPLIANCE_ADDRESS">CoreAddresses::TREASURY_COMPLIANCE_ADDRESS</a>();
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateTreasuryComplianceAccountModifies">CreateTreasuryComplianceAccountModifies</a>;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateTreasuryComplianceAccountAbortsIf">CreateTreasuryComplianceAccountAbortsIf</a>;
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotDiemRoot">Roles::AbortsIfNotDiemRoot</a>{account: dr_account};
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_MakeAccountAbortsIf">MakeAccountAbortsIf</a>{addr: <a href="CoreAddresses.md#0x1_CoreAddresses_TREASURY_COMPLIANCE_ADDRESS">CoreAddresses::TREASURY_COMPLIANCE_ADDRESS</a>()};
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateTreasuryComplianceAccountEnsures">CreateTreasuryComplianceAccountEnsures</a>;
-<a name="0x1_DiemAccount_account_ops_cap$96"></a>
 <b>let</b> account_ops_cap = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_AccountOperationsCapability">AccountOperationsCapability</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>());
-<b>ensures</b> account_ops_cap == update_field(<b>old</b>(account_ops_cap), creation_events, account_ops_cap.creation_events);
+<b>let</b> post post_account_ops_cap = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_AccountOperationsCapability">AccountOperationsCapability</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>());
+<b>ensures</b> post_account_ops_cap == update_field(account_ops_cap, creation_events, account_ops_cap.creation_events);
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_MakeAccountEmits">MakeAccountEmits</a>{new_account_address: <a href="CoreAddresses.md#0x1_CoreAddresses_TREASURY_COMPLIANCE_ADDRESS">CoreAddresses::TREASURY_COMPLIANCE_ADDRESS</a>()};
 </code></pre>
 
@@ -2815,9 +2783,6 @@ event handle generator, then makes the account.
 
 
 <a name="0x1_DiemAccount_CreateTreasuryComplianceAccountModifies"></a>
-
-
-<a name="0x1_DiemAccount_tc_addr$76"></a>
 
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateTreasuryComplianceAccountModifies">CreateTreasuryComplianceAccountModifies</a> {
@@ -2852,9 +2817,6 @@ event handle generator, then makes the account.
 
 
 <a name="0x1_DiemAccount_CreateTreasuryComplianceAccountEnsures"></a>
-
-
-<a name="0x1_DiemAccount_tc_addr$77"></a>
 
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateTreasuryComplianceAccountEnsures">CreateTreasuryComplianceAccountEnsures</a> {
@@ -3645,11 +3607,7 @@ The prologue for module transaction
 
 
 
-<a name="0x1_DiemAccount_transaction_sender$97"></a>
-
-
 <pre><code><b>let</b> transaction_sender = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
-<a name="0x1_DiemAccount_max_transaction_fee$98"></a>
 <b>let</b> max_transaction_fee = txn_gas_price * txn_max_gas_units;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ModulePrologueAbortsIf">ModulePrologueAbortsIf</a>&lt;Token&gt; {
     max_transaction_fee,
@@ -3671,7 +3629,6 @@ The prologue for module transaction
     chain_id: u8;
     max_transaction_fee: u128;
     txn_expiration_time_seconds: u64;
-    <a name="0x1_DiemAccount_transaction_sender$78"></a>
     <b>let</b> transaction_sender = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
     <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_PrologueCommonAbortsIf">PrologueCommonAbortsIf</a>&lt;Token&gt; {
         transaction_sender,
@@ -3758,11 +3715,7 @@ The prologue for script transaction
 
 
 
-<a name="0x1_DiemAccount_transaction_sender$99"></a>
-
-
 <pre><code><b>let</b> transaction_sender = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
-<a name="0x1_DiemAccount_max_transaction_fee$100"></a>
 <b>let</b> max_transaction_fee = txn_gas_price * txn_max_gas_units;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ScriptPrologueAbortsIf">ScriptPrologueAbortsIf</a>&lt;Token&gt;{
     max_transaction_fee,
@@ -3785,7 +3738,6 @@ The prologue for script transaction
     max_transaction_fee: u128;
     txn_expiration_time_seconds: u64;
     script_hash: vector&lt;u8&gt;;
-    <a name="0x1_DiemAccount_transaction_sender$79"></a>
     <b>let</b> transaction_sender = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
     <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_PrologueCommonAbortsIf">PrologueCommonAbortsIf</a>&lt;Token&gt; {transaction_sender};
 }
@@ -3881,7 +3833,6 @@ The prologue for WriteSet transaction
     txn_public_key: vector&lt;u8&gt;;
     txn_expiration_time_seconds: u64;
     chain_id: u8;
-    <a name="0x1_DiemAccount_transaction_sender$80"></a>
     <b>let</b> transaction_sender = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
 }
 </code></pre>
@@ -4031,11 +3982,7 @@ The main properties that it verifies:
 
 
 
-<a name="0x1_DiemAccount_transaction_sender$101"></a>
-
-
 <pre><code><b>let</b> transaction_sender = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
-<a name="0x1_DiemAccount_max_transaction_fee$102"></a>
 <b>let</b> max_transaction_fee = txn_gas_price * txn_max_gas_units;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_PrologueCommonAbortsIf">PrologueCommonAbortsIf</a>&lt;Token&gt; {
     transaction_sender,
@@ -4361,12 +4308,8 @@ Epilogue for WriteSet trasnaction
 <a name="0x1_DiemAccount_WritesetEpiloguEmits"></a>
 
 
-<a name="0x1_DiemAccount_handle$81"></a>
-
-
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_WritesetEpiloguEmits">WritesetEpiloguEmits</a> {
     <b>let</b> handle = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_DiemWriteSetManager">DiemWriteSetManager</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>()).upgrade_events;
-    <a name="0x1_DiemAccount_msg$82"></a>
     <b>let</b> msg = <a href="DiemAccount.md#0x1_DiemAccount_AdminTransactionEvent">AdminTransactionEvent</a> {
         committed_timestamp_secs: <a href="DiemTimestamp.md#0x1_DiemTimestamp_spec_now_seconds">DiemTimestamp::spec_now_seconds</a>()
     };
@@ -4597,7 +4540,6 @@ or the key rotation capability for addr itself [[H18]][PERMISSION].
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_EnsuresHasKeyRotationCap">EnsuresHasKeyRotationCap</a> {
     account: signer;
-    <a name="0x1_DiemAccount_addr$83"></a>
     <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>ensures</b> <a href="DiemAccount.md#0x1_DiemAccount_spec_holds_own_key_rotation_cap">spec_holds_own_key_rotation_cap</a>(addr);
 }
@@ -4659,7 +4601,6 @@ or the withdraw capability for addr itself [[H19]][PERMISSION].
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_EnsuresWithdrawCap">EnsuresWithdrawCap</a> {
     account: signer;
-    <a name="0x1_DiemAccount_addr$84"></a>
     <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>ensures</b> <a href="DiemAccount.md#0x1_DiemAccount_spec_holds_own_withdraw_cap">spec_holds_own_withdraw_cap</a>(addr);
 }

--- a/language/diem-framework/modules/doc/DiemBlock.md
+++ b/language/diem-framework/modules/doc/DiemBlock.md
@@ -286,9 +286,7 @@ The runtime always runs this before executing the transactions in a block.
     timestamp: u64;
     previous_block_votes: vector&lt;address&gt;;
     proposer: address;
-    <a name="0x1_DiemBlock_handle$4"></a>
     <b>let</b> handle = <b>global</b>&lt;<a href="DiemBlock.md#0x1_DiemBlock_BlockMetadata">BlockMetadata</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>()).new_block_events;
-    <a name="0x1_DiemBlock_msg$5"></a>
     <b>let</b> msg = <a href="DiemBlock.md#0x1_DiemBlock_NewBlockEvent">NewBlockEvent</a> {
         round,
         proposer,

--- a/language/diem-framework/modules/doc/DiemSystem.md
+++ b/language/diem-framework/modules/doc/DiemSystem.md
@@ -341,7 +341,6 @@ Must be invoked by the Diem root a single time in Genesis.
 <pre><code><b>modifies</b> <b>global</b>&lt;<a href="DiemConfig.md#0x1_DiemConfig_DiemConfig">DiemConfig::DiemConfig</a>&lt;<a href="DiemSystem.md#0x1_DiemSystem">DiemSystem</a>&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>());
 <b>include</b> <a href="DiemTimestamp.md#0x1_DiemTimestamp_AbortsIfNotGenesis">DiemTimestamp::AbortsIfNotGenesis</a>;
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotDiemRoot">Roles::AbortsIfNotDiemRoot</a>{account: dr_account};
-<a name="0x1_DiemSystem_dr_addr$20"></a>
 <b>let</b> dr_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(dr_account);
 <b>aborts_if</b> <a href="DiemConfig.md#0x1_DiemConfig_spec_is_published">DiemConfig::spec_is_published</a>&lt;<a href="DiemSystem.md#0x1_DiemSystem">DiemSystem</a>&gt;() <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>;
 <b>aborts_if</b> <b>exists</b>&lt;<a href="DiemSystem.md#0x1_DiemSystem_CapabilityHolder">CapabilityHolder</a>&gt;(dr_addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>;
@@ -521,10 +520,10 @@ a ValidatorRole
     <b>ensures</b> <a href="Roles.md#0x1_Roles_spec_has_validator_role_addr">Roles::spec_has_validator_role_addr</a>(validator_addr);
     <b>ensures</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_is_valid">ValidatorConfig::is_valid</a>(validator_addr);
     <b>ensures</b> <a href="DiemSystem.md#0x1_DiemSystem_spec_is_validator">spec_is_validator</a>(validator_addr);
-    <a name="0x1_DiemSystem_vs$15"></a>
     <b>let</b> vs = <a href="DiemSystem.md#0x1_DiemSystem_spec_get_validators">spec_get_validators</a>();
-    <b>ensures</b> <a href="../../../../../../move-stdlib/docs/Vector.md#0x1_Vector_eq_push_back">Vector::eq_push_back</a>(vs,
-                                 <b>old</b>(vs),
+    <b>let</b> post post_vs = <a href="DiemSystem.md#0x1_DiemSystem_spec_get_validators">spec_get_validators</a>();
+    <b>ensures</b> <a href="../../../../../../move-stdlib/docs/Vector.md#0x1_Vector_eq_push_back">Vector::eq_push_back</a>(post_vs,
+                                 vs,
                                  <a href="DiemSystem.md#0x1_DiemSystem_ValidatorInfo">ValidatorInfo</a> {
                                      addr: validator_addr,
                                      config: <a href="ValidatorConfig.md#0x1_ValidatorConfig_spec_get_config">ValidatorConfig::spec_get_config</a>(validator_addr),
@@ -612,9 +611,9 @@ Removes a validator, aborts unless called by diem root account
 
 <pre><code><b>schema</b> <a href="DiemSystem.md#0x1_DiemSystem_RemoveValidatorEnsures">RemoveValidatorEnsures</a> {
     validator_addr: address;
-    <a name="0x1_DiemSystem_vs$16"></a>
     <b>let</b> vs = <a href="DiemSystem.md#0x1_DiemSystem_spec_get_validators">spec_get_validators</a>();
-    <b>ensures</b> <b>forall</b> vi in vs <b>where</b> vi.addr != validator_addr: <b>exists</b> ovi in <b>old</b>(vs): vi == ovi;
+    <b>let</b> post post_vs = <a href="DiemSystem.md#0x1_DiemSystem_spec_get_validators">spec_get_validators</a>();
+    <b>ensures</b> <b>forall</b> vi in post_vs <b>where</b> vi.addr != validator_addr: <b>exists</b> ovi in vs: vi == ovi;
 }
 </code></pre>
 
@@ -693,7 +692,6 @@ and emits a reconfigurationevent.
 <b>include</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_AbortsIfGetOperator">ValidatorConfig::AbortsIfGetOperator</a>{addr: validator_addr};
 <b>include</b> <a href="DiemSystem.md#0x1_DiemSystem_UpdateConfigAndReconfigureAbortsIf">UpdateConfigAndReconfigureAbortsIf</a>;
 <b>include</b> <a href="DiemSystem.md#0x1_DiemSystem_UpdateConfigAndReconfigureEnsures">UpdateConfigAndReconfigureEnsures</a>;
-<a name="0x1_DiemSystem_is_validator_info_updated$21"></a>
 <b>let</b> is_validator_info_updated =
     <a href="ValidatorConfig.md#0x1_ValidatorConfig_is_valid">ValidatorConfig::is_valid</a>(validator_addr) &&
     (<b>exists</b> v_info in <a href="DiemSystem.md#0x1_DiemSystem_spec_get_validators">spec_get_validators</a>():
@@ -712,7 +710,6 @@ and emits a reconfigurationevent.
 <pre><code><b>schema</b> <a href="DiemSystem.md#0x1_DiemSystem_UpdateConfigAndReconfigureAbortsIf">UpdateConfigAndReconfigureAbortsIf</a> {
     validator_addr: address;
     validator_operator_account: signer;
-    <a name="0x1_DiemSystem_validator_operator_addr$17"></a>
     <b>let</b> validator_operator_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_address_of">Signer::address_of</a>(validator_operator_account);
     <b>include</b> <a href="DiemTimestamp.md#0x1_DiemTimestamp_AbortsIfNotOperating">DiemTimestamp::AbortsIfNotOperating</a>;
 }
@@ -741,9 +738,9 @@ for validator_addr, and doesn't change any addresses.
 
 <pre><code><b>schema</b> <a href="DiemSystem.md#0x1_DiemSystem_UpdateConfigAndReconfigureEnsures">UpdateConfigAndReconfigureEnsures</a> {
     validator_addr: address;
-    <a name="0x1_DiemSystem_vs$18"></a>
     <b>let</b> vs = <a href="DiemSystem.md#0x1_DiemSystem_spec_get_validators">spec_get_validators</a>();
-    <b>ensures</b> len(vs) == len(<b>old</b>(vs));
+    <b>let</b> post post_vs = <a href="DiemSystem.md#0x1_DiemSystem_spec_get_validators">spec_get_validators</a>();
+    <b>ensures</b> len(post_vs) == len(vs);
 }
 </code></pre>
 
@@ -752,7 +749,7 @@ No addresses change in the validator set
 
 
 <pre><code><b>schema</b> <a href="DiemSystem.md#0x1_DiemSystem_UpdateConfigAndReconfigureEnsures">UpdateConfigAndReconfigureEnsures</a> {
-    <b>ensures</b> <b>forall</b> i in 0..len(vs): vs[i].addr == <b>old</b>(vs)[i].addr;
+    <b>ensures</b> <b>forall</b> i in 0..len(vs): post_vs[i].addr == vs[i].addr;
 }
 </code></pre>
 
@@ -761,8 +758,8 @@ If the <code><a href="DiemSystem.md#0x1_DiemSystem_ValidatorInfo">ValidatorInfo<
 
 
 <pre><code><b>schema</b> <a href="DiemSystem.md#0x1_DiemSystem_UpdateConfigAndReconfigureEnsures">UpdateConfigAndReconfigureEnsures</a> {
-    <b>ensures</b> <b>forall</b> i in 0..len(vs) <b>where</b> <b>old</b>(vs)[i].addr != validator_addr:
-                     vs[i] == <b>old</b>(vs)[i];
+    <b>ensures</b> <b>forall</b> i in 0..len(vs) <b>where</b> vs[i].addr != validator_addr:
+                     post_vs[i] == vs[i];
 }
 </code></pre>
 
@@ -771,9 +768,9 @@ It updates the correct entry in the correct way
 
 
 <pre><code><b>schema</b> <a href="DiemSystem.md#0x1_DiemSystem_UpdateConfigAndReconfigureEnsures">UpdateConfigAndReconfigureEnsures</a> {
-    <b>ensures</b> <b>forall</b> i in 0..len(vs): vs[i].config == <b>old</b>(vs[i].config) ||
-                (<b>old</b>(vs)[i].addr == validator_addr &&
-                vs[i].config == <a href="ValidatorConfig.md#0x1_ValidatorConfig_get_config">ValidatorConfig::get_config</a>(validator_addr));
+    <b>ensures</b> <b>forall</b> i in 0..len(vs): post_vs[i].config == vs[i].config ||
+                (vs[i].addr == validator_addr &&
+                 post_vs[i].config == <a href="ValidatorConfig.md#0x1_ValidatorConfig_get_config">ValidatorConfig::get_config</a>(validator_addr));
 }
 </code></pre>
 
@@ -794,7 +791,6 @@ DIP-6 property
 
 <pre><code><b>schema</b> <a href="DiemSystem.md#0x1_DiemSystem_UpdateConfigAndReconfigureEmits">UpdateConfigAndReconfigureEmits</a> {
     validator_addr: address;
-    <a name="0x1_DiemSystem_is_validator_info_updated$19"></a>
     <b>let</b> is_validator_info_updated =
         <a href="ValidatorConfig.md#0x1_ValidatorConfig_is_valid">ValidatorConfig::is_valid</a>(validator_addr) &&
         (<b>exists</b> v_info in <a href="DiemSystem.md#0x1_DiemSystem_spec_get_validators">spec_get_validators</a>():
@@ -1078,7 +1074,6 @@ It has a loop, so there are spec blocks in the code to assert loop invariants.
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
-<a name="0x1_DiemSystem_size$22"></a>
 <b>let</b> size = len(validators);
 </code></pre>
 
@@ -1160,7 +1155,6 @@ This function never aborts.
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
-<a name="0x1_DiemSystem_new_validator_config$23"></a>
 <b>let</b> new_validator_config = <a href="ValidatorConfig.md#0x1_ValidatorConfig_spec_get_config">ValidatorConfig::spec_get_config</a>(validators[i].addr);
 </code></pre>
 

--- a/language/diem-framework/modules/doc/DiemTimestamp.md
+++ b/language/diem-framework/modules/doc/DiemTimestamp.md
@@ -209,8 +209,8 @@ Updates the wall clock time by consensus. Requires VM privilege and will be invo
 
 <pre><code><b>pragma</b> opaque;
 <b>modifies</b> <b>global</b>&lt;<a href="DiemTimestamp.md#0x1_DiemTimestamp_CurrentTimeMicroseconds">CurrentTimeMicroseconds</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>());
-<a name="0x1_DiemTimestamp_now$10"></a>
 <b>let</b> now = <a href="DiemTimestamp.md#0x1_DiemTimestamp_spec_now_microseconds">spec_now_microseconds</a>();
+<b>let</b> post post_now = <a href="DiemTimestamp.md#0x1_DiemTimestamp_spec_now_microseconds">spec_now_microseconds</a>();
 </code></pre>
 
 
@@ -219,7 +219,7 @@ Conditions unique for abstract and concrete version of this function.
 
 <pre><code><b>include</b> <a href="DiemTimestamp.md#0x1_DiemTimestamp_AbortsIfNotOperating">AbortsIfNotOperating</a>;
 <b>include</b> <a href="CoreAddresses.md#0x1_CoreAddresses_AbortsIfNotVM">CoreAddresses::AbortsIfNotVM</a>;
-<b>ensures</b> now == timestamp;
+<b>ensures</b> post_now == timestamp;
 </code></pre>
 
 
@@ -228,7 +228,7 @@ Conditions we only check for the implementation, but do not pass to the caller.
 
 <pre><code><b>aborts_if</b> [concrete]
     (<b>if</b> (proposer == <a href="CoreAddresses.md#0x1_CoreAddresses_VM_RESERVED_ADDRESS">CoreAddresses::VM_RESERVED_ADDRESS</a>()) {
-        now != timestamp // Refers <b>to</b> the now in the pre state
+        now != timestamp
      } <b>else</b>  {
         now &gt;= timestamp
      }

--- a/language/diem-framework/modules/doc/DiemVMConfig.md
+++ b/language/diem-framework/modules/doc/DiemVMConfig.md
@@ -275,9 +275,6 @@ Initialize the table under the diem root account
 
 
 
-<a name="0x1_DiemVMConfig_gas_constants$2"></a>
-
-
 <pre><code><b>let</b> gas_constants = <a href="DiemVMConfig.md#0x1_DiemVMConfig_GasConstants">GasConstants</a> {
     global_memory_per_byte_cost: 4,
     global_memory_per_byte_write_cost: 9,
@@ -393,13 +390,12 @@ No one can update DiemVMConfig except for the Diem Root account [[H11]][PERMISSI
 <b>include</b> <a href="DiemConfig.md#0x1_DiemConfig_SetAbortsIf">DiemConfig::SetAbortsIf</a>&lt;<a href="DiemVMConfig.md#0x1_DiemVMConfig">DiemVMConfig</a>&gt;{account: dr_account };
 <b>aborts_if</b> min_price_per_gas_unit &gt; max_price_per_gas_unit <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
 <b>aborts_if</b> min_transaction_gas_units &gt; maximum_number_of_gas_units <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
-<a name="0x1_DiemVMConfig_config$3"></a>
 <b>let</b> config = <a href="DiemConfig.md#0x1_DiemConfig_spec_get_config">DiemConfig::spec_get_config</a>&lt;<a href="DiemVMConfig.md#0x1_DiemVMConfig">DiemVMConfig</a>&gt;();
 <b>ensures</b> <a href="DiemConfig.md#0x1_DiemConfig_spec_is_published">DiemConfig::spec_is_published</a>&lt;<a href="DiemVMConfig.md#0x1_DiemVMConfig">DiemVMConfig</a>&gt;();
 <b>ensures</b> <a href="DiemConfig.md#0x1_DiemConfig_get">DiemConfig::get</a>&lt;<a href="DiemVMConfig.md#0x1_DiemVMConfig">DiemVMConfig</a>&gt;() == <a href="DiemVMConfig.md#0x1_DiemVMConfig">DiemVMConfig</a> {
     gas_schedule: <a href="DiemVMConfig.md#0x1_DiemVMConfig_GasSchedule">GasSchedule</a> {
-        instruction_schedule: <b>old</b>(config).gas_schedule.instruction_schedule,
-        native_schedule: <b>old</b>(config).gas_schedule.native_schedule,
+        instruction_schedule: config.gas_schedule.instruction_schedule,
+        native_schedule: config.gas_schedule.native_schedule,
         gas_constants: <a href="DiemVMConfig.md#0x1_DiemVMConfig_GasConstants">GasConstants</a> {
                 global_memory_per_byte_cost,
                 global_memory_per_byte_write_cost,

--- a/language/diem-framework/modules/doc/DualAttestation.md
+++ b/language/diem-framework/modules/doc/DualAttestation.md
@@ -458,7 +458,6 @@ Rotate the base URL for <code>account</code> to <code>new_url</code>
 
 <pre><code><b>schema</b> <a href="DualAttestation.md#0x1_DualAttestation_RotateBaseUrlAbortsIf">RotateBaseUrlAbortsIf</a> {
     account: signer;
-    <a name="0x1_DualAttestation_sender$25"></a>
     <b>let</b> sender = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 }
 </code></pre>
@@ -494,7 +493,6 @@ Must abort if the account does not have the resource Credential [[H17]][PERMISSI
 <pre><code><b>schema</b> <a href="DualAttestation.md#0x1_DualAttestation_RotateBaseUrlEnsures">RotateBaseUrlEnsures</a> {
     account: signer;
     new_url: vector&lt;u8&gt;;
-    <a name="0x1_DualAttestation_sender$26"></a>
     <b>let</b> sender = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>ensures</b> <b>global</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(sender).base_url == new_url;
 }
@@ -519,11 +517,8 @@ The sender can only rotate its own base url [[H17]][PERMISSION].
 <pre><code><b>schema</b> <a href="DualAttestation.md#0x1_DualAttestation_RotateBaseUrlEmits">RotateBaseUrlEmits</a> {
     account: signer;
     new_url: vector&lt;u8&gt;;
-    <a name="0x1_DualAttestation_sender$27"></a>
     <b>let</b> sender = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
-    <a name="0x1_DualAttestation_handle$28"></a>
     <b>let</b> handle = <b>global</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(sender).base_url_rotation_events;
-    <a name="0x1_DualAttestation_msg$29"></a>
     <b>let</b> msg = <a href="DualAttestation.md#0x1_DualAttestation_BaseUrlRotationEvent">BaseUrlRotationEvent</a> {
         new_base_url: new_url,
         time_rotated_seconds: <a href="DiemTimestamp.md#0x1_DiemTimestamp_spec_now_seconds">DiemTimestamp::spec_now_seconds</a>(),
@@ -592,7 +587,6 @@ Rotate the compliance public key for <code>account</code> to <code>new_key</code
 <pre><code><b>schema</b> <a href="DualAttestation.md#0x1_DualAttestation_RotateCompliancePublicKeyAbortsIf">RotateCompliancePublicKeyAbortsIf</a> {
     account: signer;
     new_key: vector&lt;u8&gt;;
-    <a name="0x1_DualAttestation_sender$30"></a>
     <b>let</b> sender = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 }
 </code></pre>
@@ -617,7 +611,6 @@ Must abort if the account does not have the resource Credential [[H17]][PERMISSI
 <pre><code><b>schema</b> <a href="DualAttestation.md#0x1_DualAttestation_RotateCompliancePublicKeyEnsures">RotateCompliancePublicKeyEnsures</a> {
     account: signer;
     new_key: vector&lt;u8&gt;;
-    <a name="0x1_DualAttestation_sender$31"></a>
     <b>let</b> sender = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>ensures</b> <b>global</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(sender).compliance_public_key == new_key;
 }
@@ -642,11 +635,8 @@ The sender only rotates its own compliance_public_key [[H17]][PERMISSION].
 <pre><code><b>schema</b> <a href="DualAttestation.md#0x1_DualAttestation_RotateCompliancePublicKeyEmits">RotateCompliancePublicKeyEmits</a> {
     account: signer;
     new_key: vector&lt;u8&gt;;
-    <a name="0x1_DualAttestation_sender$32"></a>
     <b>let</b> sender = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
-    <a name="0x1_DualAttestation_handle$33"></a>
     <b>let</b> handle = <b>global</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(sender).compliance_key_rotation_events;
-    <a name="0x1_DualAttestation_msg$34"></a>
     <b>let</b> msg = <a href="DualAttestation.md#0x1_DualAttestation_ComplianceKeyRotationEvent">ComplianceKeyRotationEvent</a> {
         new_compliance_public_key: new_key,
         time_rotated_seconds: <a href="DiemTimestamp.md#0x1_DiemTimestamp_spec_now_seconds">DiemTimestamp::spec_now_seconds</a>(),
@@ -1287,7 +1277,6 @@ Travel rule limit set during genesis
 <pre><code><b>include</b> <a href="DiemTimestamp.md#0x1_DiemTimestamp_AbortsIfNotGenesis">DiemTimestamp::AbortsIfNotGenesis</a>;
 <b>include</b> <a href="CoreAddresses.md#0x1_CoreAddresses_AbortsIfNotDiemRoot">CoreAddresses::AbortsIfNotDiemRoot</a>{account: dr_account};
 <b>aborts_if</b> <b>exists</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Limit">Limit</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>()) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>;
-<a name="0x1_DualAttestation_initial_limit$35"></a>
 <b>let</b> initial_limit = <a href="DualAttestation.md#0x1_DualAttestation_INITIAL_DUAL_ATTESTATION_LIMIT">INITIAL_DUAL_ATTESTATION_LIMIT</a> * <a href="Diem.md#0x1_Diem_spec_scaling_factor">Diem::spec_scaling_factor</a>&lt;<a href="XDX.md#0x1_XDX">XDX</a>&gt;();
 <b>aborts_if</b> initial_limit &gt; <a href="DualAttestation.md#0x1_DualAttestation_MAX_U64">MAX_U64</a> <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_LIMIT_EXCEEDED">Errors::LIMIT_EXCEEDED</a>;
 <b>include</b> <a href="Diem.md#0x1_Diem_AbortsIfNoCurrency">Diem::AbortsIfNoCurrency</a>&lt;<a href="XDX.md#0x1_XDX">XDX</a>&gt;;

--- a/language/diem-framework/modules/doc/PaymentScripts.md
+++ b/language/diem-framework/modules/doc/PaymentScripts.md
@@ -139,9 +139,7 @@ Successful execution of this script emits two events:
 
 
 <pre><code><b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: payer};
-<a name="0x1_PaymentScripts_payer_addr$1"></a>
 <b>let</b> payer_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer);
-<a name="0x1_PaymentScripts_cap$2"></a>
 <b>let</b> cap = <a href="DiemAccount.md#0x1_DiemAccount_spec_get_withdraw_cap">DiemAccount::spec_get_withdraw_cap</a>(payer_addr);
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ExtractWithdrawCapAbortsIf">DiemAccount::ExtractWithdrawCapAbortsIf</a>{sender_addr: payer_addr};
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_PayFromAbortsIf">DiemAccount::PayFromAbortsIf</a>&lt;Currency&gt;{cap: cap};

--- a/language/diem-framework/modules/doc/RecoveryAddress.md
+++ b/language/diem-framework/modules/doc/RecoveryAddress.md
@@ -210,7 +210,6 @@ Aborts if <code>recovery_account</code> has delegated its <code>KeyRotationCapab
 <pre><code><b>schema</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_PublishAbortsIf">PublishAbortsIf</a> {
     recovery_account: signer;
     rotation_cap: KeyRotationCapability;
-    <a name="0x1_RecoveryAddress_addr$6"></a>
     <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(recovery_account);
     <b>aborts_if</b> !<a href="VASP.md#0x1_VASP_is_vasp">VASP::is_vasp</a>(addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
     <b>aborts_if</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>;
@@ -228,7 +227,6 @@ Aborts if <code>recovery_account</code> has delegated its <code>KeyRotationCapab
 <pre><code><b>schema</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_PublishEnsures">PublishEnsures</a> {
     recovery_account: signer;
     rotation_cap: KeyRotationCapability;
-    <a name="0x1_RecoveryAddress_addr$7"></a>
     <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(recovery_account);
     <b>ensures</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(addr);
     <b>ensures</b> len(<a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">spec_get_rotation_caps</a>(addr)) == 1;
@@ -415,7 +413,6 @@ Aborts if <code>to_recover.address</code> and <code>recovery_address</code> belo
     recovery_address: address;
     <b>aborts_if</b> !<a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(recovery_address) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
     <b>aborts_if</b> len(<b>global</b>&lt;<a href="RecoveryAddress.md#0x1_RecoveryAddress">RecoveryAddress</a>&gt;(recovery_address).rotation_caps) &gt;= <a href="RecoveryAddress.md#0x1_RecoveryAddress_MAX_REGISTERED_KEYS">MAX_REGISTERED_KEYS</a> <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_LIMIT_EXCEEDED">Errors::LIMIT_EXCEEDED</a>;
-    <a name="0x1_RecoveryAddress_to_recover_address$8"></a>
     <b>let</b> to_recover_address = <a href="DiemAccount.md#0x1_DiemAccount_key_rotation_capability_address">DiemAccount::key_rotation_capability_address</a>(to_recover);
     <b>aborts_if</b> !<a href="VASP.md#0x1_VASP_spec_is_same_vasp">VASP::spec_is_same_vasp</a>(recovery_address, to_recover_address) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
 }
@@ -430,8 +427,7 @@ Aborts if <code>to_recover.address</code> and <code>recovery_address</code> belo
 <pre><code><b>schema</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_AddRotationCapabilityEnsures">AddRotationCapabilityEnsures</a> {
     to_recover: KeyRotationCapability;
     recovery_address: address;
-    <a name="0x1_RecoveryAddress_num_rotation_caps$9"></a>
-    <b>let</b> num_rotation_caps = len(<a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">spec_get_rotation_caps</a>(recovery_address));
+    <b>let</b> post num_rotation_caps = len(<a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">spec_get_rotation_caps</a>(recovery_address));
     <b>ensures</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">spec_get_rotation_caps</a>(recovery_address)[num_rotation_caps - 1] == to_recover;
 }
 </code></pre>

--- a/language/diem-framework/modules/doc/Roles.md
+++ b/language/diem-framework/modules/doc/Roles.md
@@ -593,7 +593,6 @@ Helper function to grant a role.
 
 <pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Roles.md#0x1_Roles_GrantRole">GrantRole</a>{addr: <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_address_of">Signer::address_of</a>(account)};
-<a name="0x1_Roles_addr$45"></a>
 <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 <b>requires</b> role_id == <a href="Roles.md#0x1_Roles_DIEM_ROOT_ROLE_ID">DIEM_ROOT_ROLE_ID</a> ==&gt; addr == <a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>();
 <b>requires</b> role_id == <a href="Roles.md#0x1_Roles_TREASURY_COMPLIANCE_ROLE_ID">TREASURY_COMPLIANCE_ROLE_ID</a> ==&gt; addr == <a href="CoreAddresses.md#0x1_CoreAddresses_TREASURY_COMPLIANCE_ADDRESS">CoreAddresses::TREASURY_COMPLIANCE_ADDRESS</a>();
@@ -1506,7 +1505,6 @@ ChildVASP have balances [[D7]][ROLE].
 <pre><code><b>schema</b> <a href="Roles.md#0x1_Roles_AbortsIfNotDiemRoot">AbortsIfNotDiemRoot</a> {
     account: signer;
     <b>include</b> <a href="CoreAddresses.md#0x1_CoreAddresses_AbortsIfNotDiemRoot">CoreAddresses::AbortsIfNotDiemRoot</a>;
-    <a name="0x1_Roles_addr$37"></a>
     <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>aborts_if</b> !<b>exists</b>&lt;<a href="Roles.md#0x1_Roles_RoleId">RoleId</a>&gt;(addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
     <b>aborts_if</b> <b>global</b>&lt;<a href="Roles.md#0x1_Roles_RoleId">RoleId</a>&gt;(addr).role_id != <a href="Roles.md#0x1_Roles_DIEM_ROOT_ROLE_ID">DIEM_ROOT_ROLE_ID</a> <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>;
@@ -1522,7 +1520,6 @@ ChildVASP have balances [[D7]][ROLE].
 <pre><code><b>schema</b> <a href="Roles.md#0x1_Roles_AbortsIfNotTreasuryCompliance">AbortsIfNotTreasuryCompliance</a> {
     account: signer;
     <b>include</b> <a href="CoreAddresses.md#0x1_CoreAddresses_AbortsIfNotTreasuryCompliance">CoreAddresses::AbortsIfNotTreasuryCompliance</a>;
-    <a name="0x1_Roles_addr$38"></a>
     <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>aborts_if</b> !<b>exists</b>&lt;<a href="Roles.md#0x1_Roles_RoleId">RoleId</a>&gt;(addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
     <b>aborts_if</b> <b>global</b>&lt;<a href="Roles.md#0x1_Roles_RoleId">RoleId</a>&gt;(addr).role_id != <a href="Roles.md#0x1_Roles_TREASURY_COMPLIANCE_ROLE_ID">TREASURY_COMPLIANCE_ROLE_ID</a> <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>;
@@ -1537,7 +1534,6 @@ ChildVASP have balances [[D7]][ROLE].
 
 <pre><code><b>schema</b> <a href="Roles.md#0x1_Roles_AbortsIfNotParentVasp">AbortsIfNotParentVasp</a> {
     account: signer;
-    <a name="0x1_Roles_addr$39"></a>
     <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>aborts_if</b> !<b>exists</b>&lt;<a href="Roles.md#0x1_Roles_RoleId">RoleId</a>&gt;(addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
     <b>aborts_if</b> <b>global</b>&lt;<a href="Roles.md#0x1_Roles_RoleId">RoleId</a>&gt;(addr).role_id != <a href="Roles.md#0x1_Roles_PARENT_VASP_ROLE_ID">PARENT_VASP_ROLE_ID</a> <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>;
@@ -1565,7 +1561,6 @@ ChildVASP have balances [[D7]][ROLE].
 
 <pre><code><b>schema</b> <a href="Roles.md#0x1_Roles_AbortsIfNotDesignatedDealer">AbortsIfNotDesignatedDealer</a> {
     account: signer;
-    <a name="0x1_Roles_addr$40"></a>
     <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>aborts_if</b> !<b>exists</b>&lt;<a href="Roles.md#0x1_Roles_RoleId">RoleId</a>&gt;(addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
     <b>aborts_if</b> <b>global</b>&lt;<a href="Roles.md#0x1_Roles_RoleId">RoleId</a>&gt;(addr).role_id != <a href="Roles.md#0x1_Roles_DESIGNATED_DEALER_ROLE_ID">DESIGNATED_DEALER_ROLE_ID</a> <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>;
@@ -1580,10 +1575,8 @@ ChildVASP have balances [[D7]][ROLE].
 
 <pre><code><b>schema</b> <a href="Roles.md#0x1_Roles_AbortsIfNotParentVaspOrDesignatedDealer">AbortsIfNotParentVaspOrDesignatedDealer</a> {
     account: signer;
-    <a name="0x1_Roles_addr$41"></a>
     <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>aborts_if</b> !<b>exists</b>&lt;<a href="Roles.md#0x1_Roles_RoleId">RoleId</a>&gt;(addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
-    <a name="0x1_Roles_role_id$42"></a>
     <b>let</b> role_id = <b>global</b>&lt;<a href="Roles.md#0x1_Roles_RoleId">RoleId</a>&gt;(addr).role_id;
     <b>aborts_if</b> role_id != <a href="Roles.md#0x1_Roles_PARENT_VASP_ROLE_ID">PARENT_VASP_ROLE_ID</a> && role_id != <a href="Roles.md#0x1_Roles_DESIGNATED_DEALER_ROLE_ID">DESIGNATED_DEALER_ROLE_ID</a>
         <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>;
@@ -1598,10 +1591,8 @@ ChildVASP have balances [[D7]][ROLE].
 
 <pre><code><b>schema</b> <a href="Roles.md#0x1_Roles_AbortsIfNotParentVaspOrChildVasp">AbortsIfNotParentVaspOrChildVasp</a> {
     account: signer;
-    <a name="0x1_Roles_addr$43"></a>
     <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>aborts_if</b> !<b>exists</b>&lt;<a href="Roles.md#0x1_Roles_RoleId">RoleId</a>&gt;(addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
-    <a name="0x1_Roles_role_id$44"></a>
     <b>let</b> role_id = <b>global</b>&lt;<a href="Roles.md#0x1_Roles_RoleId">RoleId</a>&gt;(addr).role_id;
     <b>aborts_if</b> role_id != <a href="Roles.md#0x1_Roles_PARENT_VASP_ROLE_ID">PARENT_VASP_ROLE_ID</a> && role_id != <a href="Roles.md#0x1_Roles_CHILD_VASP_ROLE_ID">CHILD_VASP_ROLE_ID</a>
         <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>;

--- a/language/diem-framework/modules/doc/SharedEd25519PublicKey.md
+++ b/language/diem-framework/modules/doc/SharedEd25519PublicKey.md
@@ -141,7 +141,6 @@ Aborts if the length of <code>new_public_key</code> is not 32.
 <pre><code><b>schema</b> <a href="SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey_PublishAbortsIf">PublishAbortsIf</a> {
     account: signer;
     key: vector&lt;u8&gt;;
-    <a name="0x1_SharedEd25519PublicKey_addr$5"></a>
     <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityAbortsIf">DiemAccount::ExtractKeyRotationCapabilityAbortsIf</a>;
     <b>include</b> <a href="SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey_RotateKey_AbortsIf">RotateKey_AbortsIf</a> {
@@ -164,7 +163,6 @@ Aborts if the length of <code>new_public_key</code> is not 32.
 <pre><code><b>schema</b> <a href="SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey_PublishEnsures">PublishEnsures</a> {
     account: signer;
     key: vector&lt;u8&gt;;
-    <a name="0x1_SharedEd25519PublicKey_addr$6"></a>
     <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>ensures</b> <a href="SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey_exists_at">exists_at</a>(addr);
     <b>include</b> <a href="SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey_RotateKey_Ensures">RotateKey_Ensures</a> { shared_key: <b>global</b>&lt;<a href="SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey">SharedEd25519PublicKey</a>&gt;(addr), new_public_key: key};
@@ -301,7 +299,6 @@ Aborts if the length of <code>new_public_key</code> is not 32.
 <pre><code><b>schema</b> <a href="SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey_RotateKeyAbortsIf">RotateKeyAbortsIf</a> {
     account: signer;
     new_public_key: vector&lt;u8&gt;;
-    <a name="0x1_SharedEd25519PublicKey_addr$7"></a>
     <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>aborts_if</b> !<a href="SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey_exists_at">exists_at</a>(addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
     <b>include</b> <a href="SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey_RotateKey_AbortsIf">RotateKey_AbortsIf</a> {shared_key: <b>global</b>&lt;<a href="SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey">SharedEd25519PublicKey</a>&gt;(addr)};
@@ -317,7 +314,6 @@ Aborts if the length of <code>new_public_key</code> is not 32.
 <pre><code><b>schema</b> <a href="SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey_RotateKeyEnsures">RotateKeyEnsures</a> {
     account: signer;
     new_public_key: vector&lt;u8&gt;;
-    <a name="0x1_SharedEd25519PublicKey_addr$8"></a>
     <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>include</b> <a href="SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey_RotateKey_Ensures">RotateKey_Ensures</a> {shared_key: <b>global</b>&lt;<a href="SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey">SharedEd25519PublicKey</a>&gt;(addr)};
 }

--- a/language/diem-framework/modules/doc/TransactionFee.md
+++ b/language/diem-framework/modules/doc/TransactionFee.md
@@ -265,10 +265,10 @@ Deposit <code>coin</code> into the transaction fees bucket
 
 <pre><code><b>include</b> <a href="DiemTimestamp.md#0x1_DiemTimestamp_AbortsIfNotOperating">DiemTimestamp::AbortsIfNotOperating</a>;
 <b>aborts_if</b> !<a href="TransactionFee.md#0x1_TransactionFee_is_coin_initialized">is_coin_initialized</a>&lt;CoinType&gt;() <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
-<a name="0x1_TransactionFee_fees$8"></a>
 <b>let</b> fees = <a href="TransactionFee.md#0x1_TransactionFee_spec_transaction_fee">spec_transaction_fee</a>&lt;CoinType&gt;().balance;
+<b>let</b> post post_fees = <a href="TransactionFee.md#0x1_TransactionFee_spec_transaction_fee">spec_transaction_fee</a>&lt;CoinType&gt;().balance;
 <b>include</b> <a href="Diem.md#0x1_Diem_DepositAbortsIf">Diem::DepositAbortsIf</a>&lt;CoinType&gt;{coin: fees, check: coin};
-<b>ensures</b> fees.value == <b>old</b>(fees.value) + coin.value;
+<b>ensures</b> post_fees.value == fees.value + coin.value;
 </code></pre>
 
 
@@ -394,7 +394,6 @@ Must abort if the account does not have BurnCapability [[H3]][PERMISSION].
 
 <pre><code><b>schema</b> <a href="TransactionFee.md#0x1_TransactionFee_BurnFeesNotXDX">BurnFeesNotXDX</a>&lt;CoinType&gt; {
     <b>include</b> <a href="Diem.md#0x1_Diem_AbortsIfNoBurnCapability">Diem::AbortsIfNoBurnCapability</a>&lt;CoinType&gt;{account: tc_account};
-    <a name="0x1_TransactionFee_fees$7"></a>
     <b>let</b> fees = <a href="TransactionFee.md#0x1_TransactionFee_spec_transaction_fee">spec_transaction_fee</a>&lt;CoinType&gt;();
     <b>include</b> <a href="Diem.md#0x1_Diem_BurnNowAbortsIf">Diem::BurnNowAbortsIf</a>&lt;CoinType&gt;{coin: fees.balance, preburn: fees.preburn};
 }

--- a/language/diem-framework/modules/doc/TreasuryComplianceScripts.md
+++ b/language/diem-framework/modules/doc/TreasuryComplianceScripts.md
@@ -197,26 +197,28 @@ being <code>preburn_address</code>.
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_CancelBurnAbortsIf">DiemAccount::CancelBurnAbortsIf</a>&lt;Token&gt;;
 <b>include</b> <a href="Diem.md#0x1_Diem_CancelBurnWithCapEnsures">Diem::CancelBurnWithCapEnsures</a>&lt;Token&gt;;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_DepositEnsures">DiemAccount::DepositEnsures</a>&lt;Token&gt;{payee: preburn_address};
-<a name="0x1_TreasuryComplianceScripts_total_preburn_value$10"></a>
 <b>let</b> total_preburn_value = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">Diem::CurrencyInfo</a>&lt;Token&gt;&gt;(
     <a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>()
 ).preburn_value;
-<a name="0x1_TreasuryComplianceScripts_balance_at_addr$11"></a>
+<b>let</b> post post_total_preburn_value = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">Diem::CurrencyInfo</a>&lt;Token&gt;&gt;(
+    <a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>()
+).preburn_value;
 <b>let</b> balance_at_addr = <a href="DiemAccount.md#0x1_DiemAccount_balance">DiemAccount::balance</a>&lt;Token&gt;(preburn_address);
+<b>let</b> post post_balance_at_addr = <a href="DiemAccount.md#0x1_DiemAccount_balance">DiemAccount::balance</a>&lt;Token&gt;(preburn_address);
 </code></pre>
 
 
 The total value of preburn for <code>Token</code> should decrease by the preburned amount.
 
 
-<pre><code><b>ensures</b> total_preburn_value == <b>old</b>(total_preburn_value) - amount;
+<pre><code><b>ensures</b> post_total_preburn_value == total_preburn_value - amount;
 </code></pre>
 
 
 The balance of <code>Token</code> at <code>preburn_address</code> should increase by the preburned amount.
 
 
-<pre><code><b>ensures</b> balance_at_addr == <b>old</b>(balance_at_addr) + amount;
+<pre><code><b>ensures</b> post_balance_at_addr == balance_at_addr + amount;
 <b>include</b> <a href="Diem.md#0x1_Diem_CancelBurnWithCapEmits">Diem::CancelBurnWithCapEmits</a>&lt;Token&gt;;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_DepositEmits">DiemAccount::DepositEmits</a>&lt;Token&gt;{
     payer: preburn_address,
@@ -475,9 +477,7 @@ handle with the <code>payee</code> and <code>payer</code> fields being <code>acc
 
 
 <pre><code><b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: account};
-<a name="0x1_TreasuryComplianceScripts_account_addr$12"></a>
 <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
-<a name="0x1_TreasuryComplianceScripts_cap$13"></a>
 <b>let</b> cap = <a href="DiemAccount.md#0x1_DiemAccount_spec_get_withdraw_cap">DiemAccount::spec_get_withdraw_cap</a>(account_addr);
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ExtractWithdrawCapAbortsIf">DiemAccount::ExtractWithdrawCapAbortsIf</a>{sender_addr: account_addr};
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_PreburnAbortsIf">DiemAccount::PreburnAbortsIf</a>&lt;Token&gt;{dd: account, cap: cap};
@@ -1084,7 +1084,6 @@ is given by <code>new_exchange_rate_numerator/new_exchange_rate_denominator</cod
        numerator: new_exchange_rate_numerator,
        denominator: new_exchange_rate_denominator
 };
-<a name="0x1_TreasuryComplianceScripts_rate$14"></a>
 <b>let</b> rate = <a href="../../../../../../move-stdlib/docs/FixedPoint32.md#0x1_FixedPoint32_spec_create_from_rational">FixedPoint32::spec_create_from_rational</a>(
         new_exchange_rate_numerator,
         new_exchange_rate_denominator

--- a/language/diem-framework/modules/doc/VASP.md
+++ b/language/diem-framework/modules/doc/VASP.md
@@ -189,7 +189,6 @@ or if there is already a VASP (child or parent) at this account.
 <pre><code><b>include</b> <a href="DiemTimestamp.md#0x1_DiemTimestamp_AbortsIfNotOperating">DiemTimestamp::AbortsIfNotOperating</a>;
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotTreasuryCompliance">Roles::AbortsIfNotTreasuryCompliance</a>{account: tc_account};
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotParentVasp">Roles::AbortsIfNotParentVasp</a>{account: vasp};
-<a name="0x1_VASP_vasp_addr$14"></a>
 <b>let</b> vasp_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(vasp);
 <b>aborts_if</b> <a href="VASP.md#0x1_VASP_is_vasp">is_vasp</a>(vasp_addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>;
 <b>include</b> <a href="VASP.md#0x1_VASP_PublishParentVASPEnsures">PublishParentVASPEnsures</a>{vasp_addr: vasp_addr};
@@ -256,9 +255,6 @@ Aborts if <code>parent</code> is not a ParentVASP
 
 
 
-<a name="0x1_VASP_child_addr$15"></a>
-
-
 <pre><code><b>let</b> child_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(child);
 <b>include</b> <a href="VASP.md#0x1_VASP_PublishChildVASPAbortsIf">PublishChildVASPAbortsIf</a>{child_addr};
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotChildVasp">Roles::AbortsIfNotChildVasp</a>{account: child_addr};
@@ -274,7 +270,6 @@ Aborts if <code>parent</code> is not a ParentVASP
 <pre><code><b>schema</b> <a href="VASP.md#0x1_VASP_PublishChildVASPAbortsIf">PublishChildVASPAbortsIf</a> {
     parent: signer;
     child_addr: address;
-    <a name="0x1_VASP_parent_addr$13"></a>
     <b>let</b> parent_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(parent);
     <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotParentVasp">Roles::AbortsIfNotParentVasp</a>{account: parent};
     <b>aborts_if</b> <a href="VASP.md#0x1_VASP_is_vasp">is_vasp</a>(child_addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>;

--- a/language/diem-framework/modules/doc/ValidatorAdministrationScripts.md
+++ b/language/diem-framework/modules/doc/ValidatorAdministrationScripts.md
@@ -562,7 +562,6 @@ on-chain with the updated <code><a href="ValidatorConfig.md#0x1_ValidatorConfig_
 };
 <b>include</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_SetConfigAbortsIf">ValidatorConfig::SetConfigAbortsIf</a>{validator_addr: validator_account};
 <b>include</b> <a href="DiemSystem.md#0x1_DiemSystem_UpdateConfigAndReconfigureAbortsIf">DiemSystem::UpdateConfigAndReconfigureAbortsIf</a>{validator_addr: validator_account};
-<a name="0x1_ValidatorAdministrationScripts_is_validator_info_updated$6"></a>
 <b>let</b> is_validator_info_updated =
     (<b>exists</b> v_info in <a href="DiemSystem.md#0x1_DiemSystem_spec_get_validators">DiemSystem::spec_get_validators</a>():
         v_info.addr == validator_account
@@ -693,9 +692,6 @@ resource published under it. The sending <code>account</code> must be a Validato
 <details>
 <summary>Specification</summary>
 
-
-
-<a name="0x1_ValidatorAdministrationScripts_account_addr$7"></a>
 
 
 <pre><code><b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_address_of">Signer::address_of</a>(account);
@@ -830,9 +826,6 @@ the system is initiated by this script.
 <details>
 <summary>Specification</summary>
 
-
-
-<a name="0x1_ValidatorAdministrationScripts_account_addr$8"></a>
 
 
 <pre><code><b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_address_of">Signer::address_of</a>(account);

--- a/language/diem-framework/modules/doc/ValidatorConfig.md
+++ b/language/diem-framework/modules/doc/ValidatorConfig.md
@@ -304,9 +304,6 @@ Note: Access control.  No one but the owner of the account may change .operator_
 Must abort if the signer does not have the Validator role [[H16]][PERMISSION].
 
 
-<a name="0x1_ValidatorConfig_sender$15"></a>
-
-
 <pre><code><b>let</b> sender = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(validator_account);
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotValidator">Roles::AbortsIfNotValidator</a>{validator_addr: sender};
 <b>include</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_SetOperatorAbortsIf">SetOperatorAbortsIf</a>;
@@ -324,7 +321,6 @@ Must abort if the signer does not have the Validator role [B24].
 <pre><code><b>schema</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_SetOperatorAbortsIf">SetOperatorAbortsIf</a> {
     validator_account: signer;
     operator_addr: address;
-    <a name="0x1_ValidatorConfig_validator_addr$13"></a>
     <b>let</b> validator_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(validator_account);
     <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotValidator">Roles::AbortsIfNotValidator</a>{validator_addr: validator_addr};
     <b>aborts_if</b> !<a href="ValidatorOperatorConfig.md#0x1_ValidatorOperatorConfig_has_validator_operator_config">ValidatorOperatorConfig::has_validator_operator_config</a>(operator_addr)
@@ -343,7 +339,6 @@ Must abort if the signer does not have the Validator role [B24].
 <pre><code><b>schema</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_SetOperatorEnsures">SetOperatorEnsures</a> {
     validator_account: signer;
     operator_addr: address;
-    <a name="0x1_ValidatorConfig_validator_addr$14"></a>
     <b>let</b> validator_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(validator_account);
     <b>ensures</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_spec_has_operator">spec_has_operator</a>(validator_addr);
     <b>ensures</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_get_operator">get_operator</a>(validator_addr) == operator_addr;
@@ -399,9 +394,6 @@ The old config is preserved.
 
 
 Must abort if the signer does not have the Validator role [[H16]][PERMISSION].
-
-
-<a name="0x1_ValidatorConfig_sender$16"></a>
 
 
 <pre><code><b>let</b> sender = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(validator_account);

--- a/language/diem-framework/releases/artifacts/current/docs/modules/AccountAdministrationScripts.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/AccountAdministrationScripts.md
@@ -272,15 +272,13 @@ resource stored under the account at <code>recovery_address</code>.
 <pre><code><b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: to_recover_account};
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityAbortsIf">DiemAccount::ExtractKeyRotationCapabilityAbortsIf</a>{account: to_recover_account};
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityEnsures">DiemAccount::ExtractKeyRotationCapabilityEnsures</a>{account: to_recover_account};
-<a name="0x1_AccountAdministrationScripts_addr$10"></a>
 <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(to_recover_account);
-<a name="0x1_AccountAdministrationScripts_rotation_cap$11"></a>
 <b>let</b> rotation_cap = <a href="DiemAccount.md#0x1_DiemAccount_spec_get_key_rotation_cap">DiemAccount::spec_get_key_rotation_cap</a>(addr);
 <b>include</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_AddRotationCapabilityAbortsIf">RecoveryAddress::AddRotationCapabilityAbortsIf</a>{
     to_recover: rotation_cap
 };
 <b>ensures</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">RecoveryAddress::spec_get_rotation_caps</a>(recovery_address)[
-    len(<a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">RecoveryAddress::spec_get_rotation_caps</a>(recovery_address)) - 1] == <b>old</b>(rotation_cap);
+    len(<a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">RecoveryAddress::spec_get_rotation_caps</a>(recovery_address)) - 1] == rotation_cap;
 <b>aborts_with</b> [check]
     <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>,
     <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>,
@@ -458,10 +456,8 @@ and <code>account</code> must not have previously delegated its <code><a href="D
 
 
 <pre><code><b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: account};
-<a name="0x1_AccountAdministrationScripts_account_addr$12"></a>
 <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityAbortsIf">DiemAccount::ExtractKeyRotationCapabilityAbortsIf</a>;
-<a name="0x1_AccountAdministrationScripts_key_rotation_capability$13"></a>
 <b>let</b> key_rotation_capability = <a href="DiemAccount.md#0x1_DiemAccount_spec_get_key_rotation_cap">DiemAccount::spec_get_key_rotation_cap</a>(account_addr);
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_RotateAuthenticationKeyAbortsIf">DiemAccount::RotateAuthenticationKeyAbortsIf</a>{cap: key_rotation_capability, new_authentication_key: new_key};
 </code></pre>
@@ -574,11 +570,9 @@ and <code>account</code> must not have previously delegated its <code><a href="D
 
 
 <pre><code><b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: account};
-<a name="0x1_AccountAdministrationScripts_account_addr$14"></a>
 <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 <b>include</b> <a href="SlidingNonce.md#0x1_SlidingNonce_RecordNonceAbortsIf">SlidingNonce::RecordNonceAbortsIf</a>{ seq_nonce: sliding_nonce };
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityAbortsIf">DiemAccount::ExtractKeyRotationCapabilityAbortsIf</a>;
-<a name="0x1_AccountAdministrationScripts_key_rotation_capability$15"></a>
 <b>let</b> key_rotation_capability = <a href="DiemAccount.md#0x1_DiemAccount_spec_get_key_rotation_cap">DiemAccount::spec_get_key_rotation_cap</a>(account_addr);
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_RotateAuthenticationKeyAbortsIf">DiemAccount::RotateAuthenticationKeyAbortsIf</a>{cap: key_rotation_capability, new_authentication_key: new_key};
 </code></pre>
@@ -692,11 +686,9 @@ and <code>account</code> must not have previously delegated its <code><a href="D
 
 
 <pre><code><b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: account};
-<a name="0x1_AccountAdministrationScripts_account_addr$16"></a>
 <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 <b>include</b> <a href="SlidingNonce.md#0x1_SlidingNonce_RecordNonceAbortsIf">SlidingNonce::RecordNonceAbortsIf</a>{ account: dr_account, seq_nonce: sliding_nonce };
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityAbortsIf">DiemAccount::ExtractKeyRotationCapabilityAbortsIf</a>;
-<a name="0x1_AccountAdministrationScripts_key_rotation_capability$17"></a>
 <b>let</b> key_rotation_capability = <a href="DiemAccount.md#0x1_DiemAccount_spec_get_key_rotation_cap">DiemAccount::spec_get_key_rotation_cap</a>(account_addr);
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_RotateAuthenticationKeyAbortsIf">DiemAccount::RotateAuthenticationKeyAbortsIf</a>{cap: key_rotation_capability, new_authentication_key: new_key};
 </code></pre>
@@ -833,9 +825,6 @@ This transaction can be sent either by the <code>to_recover</code> account, or b
 The delegatee at the recovery address has to hold the key rotation capability for
 the address to recover. The address of the transaction signer has to be either
 the delegatee's address or the address to recover [[H18]][PERMISSION][[J18]][PERMISSION].
-
-
-<a name="0x1_AccountAdministrationScripts_account_addr$18"></a>
 
 
 <pre><code><b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
@@ -1131,9 +1120,7 @@ may be used as a recovery account for those accounts.
 <pre><code><b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: account};
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityAbortsIf">DiemAccount::ExtractKeyRotationCapabilityAbortsIf</a>;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityEnsures">DiemAccount::ExtractKeyRotationCapabilityEnsures</a>;
-<a name="0x1_AccountAdministrationScripts_account_addr$19"></a>
 <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
-<a name="0x1_AccountAdministrationScripts_rotation_cap$20"></a>
 <b>let</b> rotation_cap = <a href="DiemAccount.md#0x1_DiemAccount_spec_get_key_rotation_cap">DiemAccount::spec_get_key_rotation_cap</a>(account_addr);
 <b>include</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_PublishAbortsIf">RecoveryAddress::PublishAbortsIf</a>{
     recovery_account: account,
@@ -1141,7 +1128,7 @@ may be used as a recovery account for those accounts.
 };
 <b>ensures</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_is_recovery_address">RecoveryAddress::spec_is_recovery_address</a>(account_addr);
 <b>ensures</b> len(<a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">RecoveryAddress::spec_get_rotation_caps</a>(account_addr)) == 1;
-<b>ensures</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">RecoveryAddress::spec_get_rotation_caps</a>(account_addr)[0] == <b>old</b>(rotation_cap);
+<b>ensures</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">RecoveryAddress::spec_get_rotation_caps</a>(account_addr)[0] == rotation_cap;
 <b>aborts_with</b> [check]
     <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>,
     <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>,

--- a/language/diem-framework/releases/artifacts/current/docs/modules/AccountCreationScripts.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/AccountCreationScripts.md
@@ -179,9 +179,7 @@ This is emitted on the new Child VASPS's <code><a href="DiemAccount.md#0x1_DiemA
 
 
 <pre><code><b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: parent_vasp};
-<a name="0x1_AccountCreationScripts_parent_addr$5"></a>
 <b>let</b> parent_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(parent_vasp);
-<a name="0x1_AccountCreationScripts_parent_cap$6"></a>
 <b>let</b> parent_cap = <a href="DiemAccount.md#0x1_DiemAccount_spec_get_withdraw_cap">DiemAccount::spec_get_withdraw_cap</a>(parent_addr);
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateChildVASPAccountAbortsIf">DiemAccount::CreateChildVASPAccountAbortsIf</a>&lt;CoinType&gt;{
     parent: parent_vasp, new_account_address: child_address};

--- a/language/diem-framework/releases/artifacts/current/docs/modules/AccountFreezing.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/AccountFreezing.md
@@ -256,7 +256,6 @@ The <code><a href="AccountFreezing.md#0x1_AccountFreezing_FreezingBit">FreezingB
 
 <pre><code><b>include</b> <a href="DiemTimestamp.md#0x1_DiemTimestamp_AbortsIfNotGenesis">DiemTimestamp::AbortsIfNotGenesis</a>;
 <b>include</b> <a href="CoreAddresses.md#0x1_CoreAddresses_AbortsIfNotDiemRoot">CoreAddresses::AbortsIfNotDiemRoot</a>{account: dr_account};
-<a name="0x1_AccountFreezing_addr$12"></a>
 <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(dr_account);
 <b>aborts_if</b> <b>exists</b>&lt;<a href="AccountFreezing.md#0x1_AccountFreezing_FreezeEventsHolder">FreezeEventsHolder</a>&gt;(addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>;
 <b>ensures</b> <b>exists</b>&lt;<a href="AccountFreezing.md#0x1_AccountFreezing_FreezeEventsHolder">FreezeEventsHolder</a>&gt;(addr);
@@ -295,9 +294,6 @@ The <code><a href="AccountFreezing.md#0x1_AccountFreezing_FreezingBit">FreezingB
 <details>
 <summary>Specification</summary>
 
-
-
-<a name="0x1_AccountFreezing_addr$13"></a>
 
 
 <pre><code><b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
@@ -376,9 +372,7 @@ Freeze the account at <code>addr</code>.
 <pre><code><b>schema</b> <a href="AccountFreezing.md#0x1_AccountFreezing_FreezeAccountEmits">FreezeAccountEmits</a> {
     account: &signer;
     frozen_address: address;
-    <a name="0x1_AccountFreezing_handle$8"></a>
     <b>let</b> handle = <b>global</b>&lt;<a href="AccountFreezing.md#0x1_AccountFreezing_FreezeEventsHolder">FreezeEventsHolder</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>()).freeze_event_handle;
-    <a name="0x1_AccountFreezing_msg$9"></a>
     <b>let</b> msg = <a href="AccountFreezing.md#0x1_AccountFreezing_FreezeAccountEvent">FreezeAccountEvent</a> {
         initiator_address: <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account),
         frozen_address
@@ -452,9 +446,7 @@ Unfreeze the account at <code>addr</code>.
 <pre><code><b>schema</b> <a href="AccountFreezing.md#0x1_AccountFreezing_UnfreezeAccountEmits">UnfreezeAccountEmits</a> {
     account: &signer;
     unfrozen_address: address;
-    <a name="0x1_AccountFreezing_handle$10"></a>
     <b>let</b> handle = <b>global</b>&lt;<a href="AccountFreezing.md#0x1_AccountFreezing_FreezeEventsHolder">FreezeEventsHolder</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>()).unfreeze_event_handle;
-    <a name="0x1_AccountFreezing_msg$11"></a>
     <b>let</b> msg = <a href="AccountFreezing.md#0x1_AccountFreezing_UnfreezeAccountEvent">UnfreezeAccountEvent</a> {
         initiator_address: <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account),
         unfrozen_address

--- a/language/diem-framework/releases/artifacts/current/docs/modules/ChainId.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/ChainId.md
@@ -101,7 +101,6 @@ Publish the chain ID <code>id</code> of this Diem instance under the DiemRoot ac
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_ChainId_dr_addr$3"></a>
 <b>let</b> dr_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_address_of">Signer::address_of</a>(dr_account);
 <b>modifies</b> <b>global</b>&lt;<a href="ChainId.md#0x1_ChainId">ChainId</a>&gt;(dr_addr);
 <b>include</b> <a href="DiemTimestamp.md#0x1_DiemTimestamp_AbortsIfNotGenesis">DiemTimestamp::AbortsIfNotGenesis</a>;

--- a/language/diem-framework/releases/artifacts/current/docs/modules/DesignatedDealer.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/DesignatedDealer.md
@@ -209,7 +209,6 @@ for each known currency at launch.
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_DesignatedDealer_dd_addr$4"></a>
 <b>let</b> dd_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(dd);
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotTreasuryCompliance">Roles::AbortsIfNotTreasuryCompliance</a>{account: tc_account};
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotDesignatedDealer">Roles::AbortsIfNotDesignatedDealer</a>{account: dd};
@@ -263,7 +262,6 @@ multi-signer transactions in order to add a new currency to an existing DD.
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_DesignatedDealer_dd_addr$5"></a>
 <b>let</b> dd_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(dd);
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotTreasuryCompliance">Roles::AbortsIfNotTreasuryCompliance</a>{account: tc_account};
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotDesignatedDealer">Roles::AbortsIfNotDesignatedDealer</a>{account: dd};
@@ -353,10 +351,10 @@ multi-signer transactions in order to add a new currency to an existing DD.
 <b>ensures</b> <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">Diem::CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
 <b>modifies</b> <b>global</b>&lt;<a href="DesignatedDealer.md#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr);
 <b>ensures</b> !<b>exists</b>&lt;<a href="DesignatedDealer.md#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr);
-<a name="0x1_DesignatedDealer_currency_info$6"></a>
 <b>let</b> currency_info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">Diem::CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
+<b>let</b> post post_currency_info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">Diem::CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
 <b>ensures</b> result.value == amount;
-<b>ensures</b> currency_info == update_field(<b>old</b>(currency_info), total_value, <b>old</b>(currency_info.total_value) + amount);
+<b>ensures</b> post_currency_info == update_field(currency_info, total_value, currency_info.total_value + amount);
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/Diem.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/Diem.md
@@ -1160,10 +1160,8 @@ a value equal to <code>amount</code>.
 
 
 
-<a name="0x1_Diem_currency_info$97"></a>
-
-
 <pre><code><b>let</b> currency_info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
+<b>let</b> post post_currency_info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
 <b>modifies</b> <b>global</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(preburn_address);
 <b>modifies</b> <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
 <b>include</b> <a href="Diem.md#0x1_Diem_CancelBurnAbortsIf">CancelBurnAbortsIf</a>&lt;CoinType&gt;;
@@ -1171,10 +1169,10 @@ a value equal to <code>amount</code>.
 <b>include</b> <a href="Diem.md#0x1_Diem_CancelBurnWithCapEmits">CancelBurnWithCapEmits</a>&lt;CoinType&gt;;
 <b>ensures</b> <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
 <b>ensures</b> <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(preburn_address);
-<b>ensures</b> currency_info == update_field(
-    <b>old</b>(currency_info),
+<b>ensures</b> post_currency_info == update_field(
+    currency_info,
     preburn_value,
-    currency_info.preburn_value
+    post_currency_info.preburn_value
 );
 <b>ensures</b> result.value == amount;
 <b>ensures</b> result.value &gt; 0;
@@ -1293,10 +1291,10 @@ reference.
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_MintEnsures">MintEnsures</a>&lt;CoinType&gt; {
     value: u64;
     result: <a href="Diem.md#0x1_Diem">Diem</a>&lt;CoinType&gt;;
-    <a name="0x1_Diem_currency_info$61"></a>
     <b>let</b> currency_info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
+    <b>let</b> post post_currency_info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
     <b>ensures</b> <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
-    <b>ensures</b> currency_info == update_field(<b>old</b>(currency_info), total_value, <b>old</b>(currency_info.total_value) + value);
+    <b>ensures</b> post_currency_info == update_field(currency_info, total_value, currency_info.total_value + value);
     <b>ensures</b> result.value == value;
 }
 </code></pre>
@@ -1309,11 +1307,8 @@ reference.
 
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_MintEmits">MintEmits</a>&lt;CoinType&gt; {
     value: u64;
-    <a name="0x1_Diem_currency_info$62"></a>
     <b>let</b> currency_info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
-    <a name="0x1_Diem_handle$63"></a>
     <b>let</b> handle = currency_info.mint_events;
-    <a name="0x1_Diem_msg$64"></a>
     <b>let</b> msg = <a href="Diem.md#0x1_Diem_MintEvent">MintEvent</a>{
         amount: value,
         currency_code: currency_info.currency_code,
@@ -1430,9 +1425,9 @@ being preburned is a synthetic currency (<code>is_synthetic = <b>true</b></code>
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_PreburnEnsures">PreburnEnsures</a>&lt;CoinType&gt; {
     amount: u64;
     preburn: <a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;;
-    <a name="0x1_Diem_info$65"></a>
     <b>let</b> info = <a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;();
-    <b>ensures</b> info == update_field(<b>old</b>(info), preburn_value, <b>old</b>(info.preburn_value) + amount);
+    <b>let</b> post post_info = <a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;();
+    <b>ensures</b> post_info == update_field(info, preburn_value, info.preburn_value + amount);
 }
 </code></pre>
 
@@ -1445,13 +1440,9 @@ being preburned is a synthetic currency (<code>is_synthetic = <b>true</b></code>
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_PreburnWithResourceEmits">PreburnWithResourceEmits</a>&lt;CoinType&gt; {
     amount: u64;
     preburn_address: address;
-    <a name="0x1_Diem_info$66"></a>
     <b>let</b> info = <a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;();
-    <a name="0x1_Diem_currency_code$67"></a>
     <b>let</b> currency_code = <a href="Diem.md#0x1_Diem_spec_currency_code">spec_currency_code</a>&lt;CoinType&gt;();
-    <a name="0x1_Diem_handle$68"></a>
     <b>let</b> handle = info.preburn_events;
-    <a name="0x1_Diem_msg$69"></a>
     <b>let</b> msg = <a href="Diem.md#0x1_Diem_PreburnEvent">PreburnEvent</a> {
         amount,
         currency_code,
@@ -1568,7 +1559,6 @@ dealer account <code>account</code>.
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_Diem_account_addr$98"></a>
 <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 <b>modifies</b> <b>global</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr);
 <b>aborts_if</b> <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>;
@@ -1598,14 +1588,10 @@ dealer account <code>account</code>.
 
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_PublishPreburnQueueEnsures">PublishPreburnQueueEnsures</a>&lt;CoinType&gt; {
     account: signer;
-    <a name="0x1_Diem_account_addr$70"></a>
     <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
-    <a name="0x1_Diem_exists_preburn_queue$71"></a>
-    <b>let</b> exists_preburn_queue = <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr);
-    <b>ensures</b> exists_preburn_queue;
+    <b>ensures</b> <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr);
     <b>ensures</b> !<b>exists</b>&lt;<a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(account_addr);
     <b>ensures</b> <a href="../../../../../../move-stdlib/docs/Vector.md#0x1_Vector_length">Vector::length</a>(<b>global</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr).preburns) == 0;
-    <b>ensures</b> <b>old</b>(exists_preburn_queue) ==&gt; exists_preburn_queue;
 }
 </code></pre>
 
@@ -1653,7 +1639,6 @@ this resource for the designated dealer <code>account</code>.
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_Diem_account_addr$99"></a>
 <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 <b>modifies</b> <b>global</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr);
 </code></pre>
@@ -1736,9 +1721,6 @@ requests can be outstanding in the same currency for a designated dealer.
 
 
 
-<a name="0x1_Diem_account_addr$100"></a>
-
-
 <pre><code><b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 <b>modifies</b> <b>global</b>&lt;<a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(account_addr);
 <b>modifies</b> <b>global</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr);
@@ -1754,14 +1736,8 @@ requests can be outstanding in the same currency for a designated dealer.
 
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_UpgradePreburnAbortsIf">UpgradePreburnAbortsIf</a>&lt;CoinType&gt; {
     account: signer;
-    <a name="0x1_Diem_account_addr$72"></a>
     <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
-    <a name="0x1_Diem_preburn$73"></a>
-    <b>let</b> preburn = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(account_addr);
-    <a name="0x1_Diem_preburn_exists$74"></a>
-    <b>let</b> preburn_exists = <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(account_addr);
-    <a name="0x1_Diem_preburn_queue_exists$75"></a>
-    <b>let</b> preburn_queue_exists = <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr);
+    <b>let</b> upgrade = <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(account_addr) && !<b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr);
 }
 </code></pre>
 
@@ -1771,8 +1747,8 @@ Must abort if the account doesn't have the <code><a href="Diem.md#0x1_Diem_Prebu
 
 
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_UpgradePreburnAbortsIf">UpgradePreburnAbortsIf</a>&lt;CoinType&gt; {
+    <b>include</b> upgrade ==&gt; <a href="Diem.md#0x1_Diem_PublishPreburnQueueAbortsIf">PublishPreburnQueueAbortsIf</a>&lt;CoinType&gt;;
     <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotDesignatedDealer">Roles::AbortsIfNotDesignatedDealer</a>;
-    <b>include</b> (preburn_exists && !preburn_queue_exists) ==&gt; <a href="Diem.md#0x1_Diem_PublishPreburnQueueAbortsIf">PublishPreburnQueueAbortsIf</a>&lt;CoinType&gt;;
 }
 </code></pre>
 
@@ -1784,45 +1760,16 @@ Must abort if the account doesn't have the <code><a href="Diem.md#0x1_Diem_Prebu
 
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_UpgradePreburnEnsures">UpgradePreburnEnsures</a>&lt;CoinType&gt; {
     account: signer;
-    <a name="0x1_Diem_account_addr$76"></a>
     <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
-    <a name="0x1_Diem_preburn_exists$77"></a>
-    <b>let</b> preburn_exists = <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(account_addr);
-    <a name="0x1_Diem_preburn_queue_exists$78"></a>
-    <b>let</b> preburn_queue_exists = <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr);
-    <a name="0x1_Diem_preburn$79"></a>
+    <b>let</b> upgrade = <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(account_addr) && !<b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr);
     <b>let</b> preburn = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(account_addr);
-    <a name="0x1_Diem_preburn_queue$80"></a>
-    <b>let</b> preburn_queue = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr);
-    <a name="0x1_Diem_preburn_state_empty$81"></a>
-    <b>let</b> preburn_state_empty = preburn_exists && !preburn_queue_exists && preburn.to_burn.value == 0;
-    <a name="0x1_Diem_preburn_state_full$82"></a>
-    <b>let</b> preburn_state_full = preburn_exists && !preburn_queue_exists && preburn.to_burn.value &gt; 0;
-    <b>include</b> preburn_state_empty ==&gt; <a href="Diem.md#0x1_Diem_PublishPreburnQueueEnsures">PublishPreburnQueueEnsures</a>&lt;CoinType&gt;;
-    <b>include</b> preburn_state_full ==&gt; <a href="Diem.md#0x1_Diem_UpgradePreburnEnsuresFullState">UpgradePreburnEnsuresFullState</a>&lt;CoinType&gt; {
-        preburn_queue_exists: preburn_queue_exists,
-        account_addr: account_addr,
-        preburn_queue: preburn_queue,
-        preburn: <a href="Diem.md#0x1_Diem_PreburnWithMetadata">PreburnWithMetadata</a> { preburn, metadata: x"" },
-    };
-}
-</code></pre>
-
-
-
-
-<a name="0x1_Diem_UpgradePreburnEnsuresFullState"></a>
-
-
-<pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_UpgradePreburnEnsuresFullState">UpgradePreburnEnsuresFullState</a>&lt;CoinType&gt; {
-    preburn_queue_exists: bool;
-    account_addr: address;
-    preburn_queue: <a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;;
-    preburn: <a href="Diem.md#0x1_Diem_PreburnWithMetadata">PreburnWithMetadata</a>&lt;CoinType&gt;;
-    <b>ensures</b> preburn_queue_exists;
-    <b>ensures</b> !<b>exists</b>&lt;<a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(account_addr);
-    <b>ensures</b> <a href="../../../../../../move-stdlib/docs/Vector.md#0x1_Vector_length">Vector::length</a>(preburn_queue.preburns) == 1;
-    <b>ensures</b> <a href="../../../../../../move-stdlib/docs/Vector.md#0x1_Vector_eq_push_back">Vector::eq_push_back</a>(preburn_queue.preburns, <b>old</b>(preburn_queue).preburns, <b>old</b>(preburn));
+    <b>ensures</b> upgrade ==&gt;
+        !<b>exists</b>&lt;<a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(account_addr) && <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr);
+    <b>ensures</b> upgrade && preburn.to_burn.value &gt; 0 ==&gt;
+        <b>global</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr).preburns ==
+            vec(<a href="Diem.md#0x1_Diem_PreburnWithMetadata">PreburnWithMetadata</a> { preburn, metadata: x"" });
+    <b>ensures</b> upgrade && preburn.to_burn.value == 0 ==&gt;
+        <b>global</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr).preburns == vec();
 }
 </code></pre>
 
@@ -1871,15 +1818,14 @@ number of preburn requests does not exceed <code><a href="Diem.md#0x1_Diem_MAX_O
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_Diem_account_addr$101"></a>
 <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
-<a name="0x1_Diem_preburns$102"></a>
 <b>let</b> preburns = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr).preburns;
+<b>let</b> post post_preburns = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr).preburns;
 <b>modifies</b> <b>global</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr);
 <b>aborts_if</b> !<b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>;
 <b>include</b> <a href="Diem.md#0x1_Diem_AddPreburnToQueueAbortsIf">AddPreburnToQueueAbortsIf</a>&lt;CoinType&gt;;
 <b>ensures</b> <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr);
-<b>ensures</b> <a href="../../../../../../move-stdlib/docs/Vector.md#0x1_Vector_eq_push_back">Vector::eq_push_back</a>(preburns, <b>old</b>(preburns), preburn);
+<b>ensures</b> <a href="../../../../../../move-stdlib/docs/Vector.md#0x1_Vector_eq_push_back">Vector::eq_push_back</a>(post_preburns, preburns, preburn);
 </code></pre>
 
 
@@ -1891,7 +1837,6 @@ number of preburn requests does not exceed <code><a href="Diem.md#0x1_Diem_MAX_O
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_AddPreburnToQueueAbortsIf">AddPreburnToQueueAbortsIf</a>&lt;CoinType&gt; {
     account: signer;
     preburn: <a href="Diem.md#0x1_Diem_PreburnWithMetadata">PreburnWithMetadata</a>&lt;CoinType&gt;;
-    <a name="0x1_Diem_account_addr$83"></a>
     <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>aborts_if</b> preburn.preburn.to_burn.value == 0 <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
     <b>aborts_if</b> <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(account_addr) &&
@@ -1959,7 +1904,6 @@ Calls to this function will fail if:
 <pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Diem.md#0x1_Diem_PreburnToAbortsIf">PreburnToAbortsIf</a>&lt;CoinType&gt;{amount: coin.value};
 <b>include</b> <a href="Diem.md#0x1_Diem_PreburnToEnsures">PreburnToEnsures</a>&lt;CoinType&gt;{amount: coin.value};
-<a name="0x1_Diem_account_addr$103"></a>
 <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 <b>include</b> <a href="Diem.md#0x1_Diem_PreburnWithResourceEmits">PreburnWithResourceEmits</a>&lt;CoinType&gt;{amount: coin.value, preburn_address: account_addr};
 </code></pre>
@@ -1973,7 +1917,6 @@ Calls to this function will fail if:
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_PreburnToAbortsIf">PreburnToAbortsIf</a>&lt;CoinType&gt; {
     account: signer;
     amount: u64;
-    <a name="0x1_Diem_account_addr$84"></a>
     <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 }
 </code></pre>
@@ -2001,7 +1944,6 @@ the correct role [[H4]][PERMISSION].
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_PreburnToEnsures">PreburnToEnsures</a>&lt;CoinType&gt; {
     account: signer;
     amount: u64;
-    <a name="0x1_Diem_account_addr$85"></a>
     <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 }
 </code></pre>
@@ -2110,7 +2052,6 @@ Calls to this function will fail if:
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_RemovePreburnFromQueueAbortsIf">RemovePreburnFromQueueAbortsIf</a>&lt;CoinType&gt; {
     preburn_address: address;
     amount: u64;
-    <a name="0x1_Diem_preburn_queue$54"></a>
     <b>let</b> preburn_queue = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(preburn_address).preburns;
     <b>aborts_if</b> !<b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(preburn_address) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
     <b>aborts_if</b> <b>forall</b> i in 0..len(preburn_queue): preburn_queue[i].preburn.to_burn.value != amount <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>;
@@ -2128,9 +2069,7 @@ Calls to this function will fail if:
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_RemovePreburnFromQueueEnsures">RemovePreburnFromQueueEnsures</a>&lt;CoinType&gt; {
     preburn_address: address;
     amount: u64;
-    <a name="0x1_Diem_exists_preburn_queue$58"></a>
-    <b>let</b> exists_preburn_queue = <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(preburn_address);
-    <b>ensures</b> <b>old</b>(exists_preburn_queue) ==&gt; exists_preburn_queue;
+    <b>ensures</b> <b>old</b>(<b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(preburn_address)) ==&gt; <b>exists</b>&lt;<a href="Diem.md#0x1_Diem_PreburnQueue">PreburnQueue</a>&lt;CoinType&gt;&gt;(preburn_address);
 }
 </code></pre>
 
@@ -2200,8 +2139,7 @@ the preburn queue with a <code>to_burn</code> amount equal to <code>amount</code
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_BurnWithCapabilityAbortsIf">BurnWithCapabilityAbortsIf</a>&lt;CoinType&gt; {
     preburn_address: address;
     amount: u64;
-    <a name="0x1_Diem_preburn$57"></a>
-    <b>let</b> preburn = <a href="Diem.md#0x1_Diem_spec_make_preburn">spec_make_preburn</a>(amount);
+    <b>let</b> preburn = <a href="Diem.md#0x1_Diem_spec_make_preburn">spec_make_preburn</a>&lt;CoinType&gt;(amount);
     <b>include</b> <a href="Diem.md#0x1_Diem_AbortsIfNoPreburnQueue">AbortsIfNoPreburnQueue</a>&lt;CoinType&gt;;
     <b>include</b> <a href="Diem.md#0x1_Diem_RemovePreburnFromQueueAbortsIf">RemovePreburnFromQueueAbortsIf</a>&lt;CoinType&gt;;
     <b>include</b> <a href="Diem.md#0x1_Diem_BurnWithResourceCapAbortsIf">BurnWithResourceCapAbortsIf</a>&lt;CoinType&gt;{preburn: preburn};
@@ -2217,8 +2155,7 @@ the preburn queue with a <code>to_burn</code> amount equal to <code>amount</code
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_BurnWithCapabilityEnsures">BurnWithCapabilityEnsures</a>&lt;CoinType&gt; {
     preburn_address: address;
     amount: u64;
-    <a name="0x1_Diem_preburn$59"></a>
-    <b>let</b> preburn = <a href="Diem.md#0x1_Diem_spec_make_preburn">spec_make_preburn</a>(amount);
+    <b>let</b> preburn = <a href="Diem.md#0x1_Diem_spec_make_preburn">spec_make_preburn</a>&lt;CoinType&gt;(amount);
     <b>include</b> <a href="Diem.md#0x1_Diem_BurnWithResourceCapEnsures">BurnWithResourceCapEnsures</a>&lt;CoinType&gt;{preburn: preburn};
     <b>include</b> <a href="Diem.md#0x1_Diem_RemovePreburnFromQueueEnsures">RemovePreburnFromQueueEnsures</a>&lt;CoinType&gt;;
 }
@@ -2288,9 +2225,10 @@ Calls to this function will fail if the preburn <code>to_burn</code> area for <c
 
 
 
-<pre><code><b>include</b> <a href="Diem.md#0x1_Diem_BurnWithResourceCapAbortsIf">BurnWithResourceCapAbortsIf</a>&lt;CoinType&gt;;
-<b>include</b> <a href="Diem.md#0x1_Diem_BurnWithResourceCapEnsures">BurnWithResourceCapEnsures</a>&lt;CoinType&gt;;
-<b>include</b> <a href="Diem.md#0x1_Diem_BurnWithResourceCapEmits">BurnWithResourceCapEmits</a>&lt;CoinType&gt;;
+<pre><code><b>let</b> pre_preburn = preburn;
+<b>include</b> <a href="Diem.md#0x1_Diem_BurnWithResourceCapAbortsIf">BurnWithResourceCapAbortsIf</a>&lt;CoinType&gt;{preburn: pre_preburn};
+<b>include</b> <a href="Diem.md#0x1_Diem_BurnWithResourceCapEnsures">BurnWithResourceCapEnsures</a>&lt;CoinType&gt;{preburn: pre_preburn};
+<b>include</b> <a href="Diem.md#0x1_Diem_BurnWithResourceCapEmits">BurnWithResourceCapEmits</a>&lt;CoinType&gt;{preburn: pre_preburn};
 </code></pre>
 
 
@@ -2302,9 +2240,7 @@ Calls to this function will fail if the preburn <code>to_burn</code> area for <c
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_BurnWithResourceCapAbortsIf">BurnWithResourceCapAbortsIf</a>&lt;CoinType&gt; {
     preburn: <a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;;
     <b>include</b> <a href="Diem.md#0x1_Diem_AbortsIfNoCurrency">AbortsIfNoCurrency</a>&lt;CoinType&gt;;
-    <a name="0x1_Diem_to_burn$55"></a>
     <b>let</b> to_burn = preburn.to_burn.value;
-    <a name="0x1_Diem_info$56"></a>
     <b>let</b> info = <a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;();
     <b>aborts_if</b> to_burn == 0 <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>;
     <b>aborts_if</b> info.total_value &lt; to_burn <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_LIMIT_EXCEEDED">Errors::LIMIT_EXCEEDED</a>;
@@ -2321,9 +2257,9 @@ Calls to this function will fail if the preburn <code>to_burn</code> area for <c
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_BurnWithResourceCapEnsures">BurnWithResourceCapEnsures</a>&lt;CoinType&gt; {
     preburn: <a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;;
     <b>ensures</b> <a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;().total_value
-            == <b>old</b>(<a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;().total_value) - <b>old</b>(preburn.to_burn.value);
+            == <b>old</b>(<a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;().total_value) - preburn.to_burn.value;
     <b>ensures</b> <a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;().preburn_value
-            == <b>old</b>(<a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;().preburn_value) - <b>old</b>(preburn.to_burn.value);
+            == <b>old</b>(<a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;().preburn_value) - preburn.to_burn.value;
 }
 </code></pre>
 
@@ -2336,14 +2272,11 @@ Calls to this function will fail if the preburn <code>to_burn</code> area for <c
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_BurnWithResourceCapEmits">BurnWithResourceCapEmits</a>&lt;CoinType&gt; {
     preburn: <a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;;
     preburn_address: address;
-    <a name="0x1_Diem_info$86"></a>
     <b>let</b> info = <a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;();
-    <a name="0x1_Diem_currency_code$87"></a>
     <b>let</b> currency_code = <a href="Diem.md#0x1_Diem_spec_currency_code">spec_currency_code</a>&lt;CoinType&gt;();
-    <a name="0x1_Diem_handle$88"></a>
     <b>let</b> handle = info.burn_events;
     emits <a href="Diem.md#0x1_Diem_BurnEvent">BurnEvent</a> {
-            amount: <b>old</b>(preburn.to_burn.value),
+            amount: preburn.to_burn.value,
             currency_code,
             preburn_address,
         }
@@ -2434,7 +2367,6 @@ at <code>preburn_address</code> does not contain a preburn request of the right 
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_CancelBurnWithCapAbortsIf">CancelBurnWithCapAbortsIf</a>&lt;CoinType&gt; {
     preburn_address: address;
     amount: u64;
-    <a name="0x1_Diem_info$60"></a>
     <b>let</b> info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
     <b>include</b> <a href="Diem.md#0x1_Diem_AbortsIfNoCurrency">AbortsIfNoCurrency</a>&lt;CoinType&gt;;
     <b>include</b> <a href="Diem.md#0x1_Diem_RemovePreburnFromQueueAbortsIf">RemovePreburnFromQueueAbortsIf</a>&lt;CoinType&gt;;
@@ -2452,9 +2384,9 @@ at <code>preburn_address</code> does not contain a preburn request of the right 
     preburn_address: address;
     amount: u64;
     <b>include</b> <a href="Diem.md#0x1_Diem_RemovePreburnFromQueueEnsures">RemovePreburnFromQueueEnsures</a>&lt;CoinType&gt;;
-    <a name="0x1_Diem_info$89"></a>
     <b>let</b> info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
-    <b>ensures</b> info == update_field(<b>old</b>(info), preburn_value, <b>old</b>(info.preburn_value) - amount);
+    <b>let</b> post post_info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
+    <b>ensures</b> post_info == update_field(info, preburn_value, info.preburn_value - amount);
 }
 </code></pre>
 
@@ -2467,11 +2399,8 @@ at <code>preburn_address</code> does not contain a preburn request of the right 
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_CancelBurnWithCapEmits">CancelBurnWithCapEmits</a>&lt;CoinType&gt; {
     preburn_address: address;
     amount: u64;
-    <a name="0x1_Diem_info$90"></a>
     <b>let</b> info = <a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;();
-    <a name="0x1_Diem_currency_code$91"></a>
     <b>let</b> currency_code = <a href="Diem.md#0x1_Diem_spec_currency_code">spec_currency_code</a>&lt;CoinType&gt;();
-    <a name="0x1_Diem_handle$92"></a>
     <b>let</b> handle = info.cancel_burn_events;
     emits <a href="Diem.md#0x1_Diem_CancelBurnEvent">CancelBurnEvent</a> {
            amount,
@@ -2525,12 +2454,12 @@ used for administrative burns, like unpacking an XDX coin or charging fees.
 
 
 <pre><code><b>include</b> <a href="Diem.md#0x1_Diem_BurnNowAbortsIf">BurnNowAbortsIf</a>&lt;CoinType&gt;;
-<a name="0x1_Diem_info$104"></a>
 <b>let</b> info = <a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;();
+<b>let</b> post post_info = <a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;();
 <b>include</b> <a href="Diem.md#0x1_Diem_PreburnWithResourceEmits">PreburnWithResourceEmits</a>&lt;CoinType&gt;{amount: coin.value, preburn_address: preburn_address};
 <b>include</b> <a href="Diem.md#0x1_Diem_BurnWithResourceCapEmits">BurnWithResourceCapEmits</a>&lt;CoinType&gt;{preburn: <a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;{to_burn: coin}};
 <b>ensures</b> preburn.to_burn.value == 0;
-<b>ensures</b> info == update_field(<b>old</b>(info), total_value, <b>old</b>(info.total_value) - coin.value);
+<b>ensures</b> post_info == update_field(info, total_value, info.total_value - coin.value);
 </code></pre>
 
 
@@ -2544,7 +2473,6 @@ used for administrative burns, like unpacking an XDX coin or charging fees.
     preburn: <a href="Diem.md#0x1_Diem_Preburn">Preburn</a>&lt;CoinType&gt;;
     <b>aborts_if</b> coin.value == 0 <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
     <b>include</b> <a href="Diem.md#0x1_Diem_PreburnWithResourceAbortsIf">PreburnWithResourceAbortsIf</a>&lt;CoinType&gt;{amount: coin.value};
-    <a name="0x1_Diem_info$93"></a>
     <b>let</b> info = <a href="Diem.md#0x1_Diem_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;();
     <b>aborts_if</b> info.total_value &lt; coin.value <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_LIMIT_EXCEEDED">Errors::LIMIT_EXCEEDED</a>;
 }
@@ -3275,7 +3203,6 @@ rate is needed.
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_ApproxXdmForValueAbortsIf">ApproxXdmForValueAbortsIf</a>&lt;CoinType&gt; {
     from_value: num;
     <b>include</b> <a href="Diem.md#0x1_Diem_AbortsIfNoCurrency">AbortsIfNoCurrency</a>&lt;CoinType&gt;;
-    <a name="0x1_Diem_xdx_exchange_rate$94"></a>
     <b>let</b> xdx_exchange_rate = <a href="Diem.md#0x1_Diem_spec_xdx_exchange_rate">spec_xdx_exchange_rate</a>&lt;CoinType&gt;();
     <b>include</b> <a href="../../../../../../move-stdlib/docs/FixedPoint32.md#0x1_FixedPoint32_MultiplyAbortsIf">FixedPoint32::MultiplyAbortsIf</a>{val: from_value, multiplier: xdx_exchange_rate};
 }
@@ -3593,9 +3520,7 @@ Must abort if the account does not have the TreasuryCompliance Role [[H5]][PERMI
 
 <pre><code><b>schema</b> <a href="Diem.md#0x1_Diem_UpdateXDXExchangeRateEmits">UpdateXDXExchangeRateEmits</a>&lt;FromCoinType&gt; {
     xdx_exchange_rate: <a href="../../../../../../move-stdlib/docs/FixedPoint32.md#0x1_FixedPoint32">FixedPoint32</a>;
-    <a name="0x1_Diem_handle$95"></a>
     <b>let</b> handle = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;FromCoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>()).exchange_rate_update_events;
-    <a name="0x1_Diem_msg$96"></a>
     <b>let</b> msg = <a href="Diem.md#0x1_Diem_ToXDXExchangeRateUpdateEvent">ToXDXExchangeRateUpdateEvent</a> {
         currency_code: <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;FromCoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>()).currency_code,
         new_to_xdx_exchange_rate: <a href="../../../../../../move-stdlib/docs/FixedPoint32.md#0x1_FixedPoint32_get_raw_value">FixedPoint32::get_raw_value</a>(xdx_exchange_rate)
@@ -3642,7 +3567,6 @@ Returns the (rough) exchange rate between <code>CoinType</code> and <code><a hre
 
 <pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Diem.md#0x1_Diem_AbortsIfNoCurrency">AbortsIfNoCurrency</a>&lt;CoinType&gt;;
-<a name="0x1_Diem_info$105"></a>
 <b>let</b> info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
 <b>ensures</b> result == info.to_xdx_exchange_rate;
 </code></pre>

--- a/language/diem-framework/releases/artifacts/current/docs/modules/DiemAccount.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/DiemAccount.md
@@ -1070,7 +1070,6 @@ Record a payment of <code>to_deposit</code> from <code>payer</code> to <code>pay
                             <b>old</b>(<b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payee).sent_events));
 <b>ensures</b> <a href="../../../../../../move-stdlib/docs/Event.md#0x1_Event_spec_guid_eq">Event::spec_guid_eq</a>(<b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payee).received_events,
                             <b>old</b>(<b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payee).received_events));
-<a name="0x1_DiemAccount_amount$85"></a>
 <b>let</b> amount = to_deposit.value;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_DepositAbortsIf">DepositAbortsIf</a>&lt;Token&gt;{amount: amount};
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_DepositOverflowAbortsIf">DepositOverflowAbortsIf</a>&lt;Token&gt;{amount: amount};
@@ -1162,9 +1161,7 @@ Record a payment of <code>to_deposit</code> from <code>payer</code> to <code>pay
     payee: address;
     amount: u64;
     metadata: vector&lt;u8&gt;;
-    <a name="0x1_DiemAccount_handle$61"></a>
     <b>let</b> handle = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payee).received_events;
-    <a name="0x1_DiemAccount_msg$62"></a>
     <b>let</b> msg = <a href="DiemAccount.md#0x1_DiemAccount_ReceivedPaymentEvent">ReceivedPaymentEvent</a> {
         amount,
         currency_code: <a href="Diem.md#0x1_Diem_spec_currency_code">Diem::spec_currency_code</a>&lt;Token&gt;(),
@@ -1260,10 +1257,10 @@ Sender should be treasury compliance account and receiver authorized DD.
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_TieredMintEnsures">TieredMintEnsures</a>&lt;Token&gt; {
     designated_dealer_address: address;
     mint_amount: u64;
-    <a name="0x1_DiemAccount_dealer_balance$63"></a>
     <b>let</b> dealer_balance = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_Balance">Balance</a>&lt;Token&gt;&gt;(designated_dealer_address).coin.value;
-    <a name="0x1_DiemAccount_currency_info$64"></a>
+    <b>let</b> post post_dealer_balance = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_Balance">Balance</a>&lt;Token&gt;&gt;(designated_dealer_address).coin.value;
     <b>let</b> currency_info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">Diem::CurrencyInfo</a>&lt;Token&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
+    <b>let</b> post post_currency_info = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">Diem::CurrencyInfo</a>&lt;Token&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
 }
 </code></pre>
 
@@ -1272,7 +1269,7 @@ Total value of the currency increases by <code>amount</code>.
 
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_TieredMintEnsures">TieredMintEnsures</a>&lt;Token&gt; {
-    <b>ensures</b> currency_info == update_field(<b>old</b>(currency_info), total_value, <b>old</b>(currency_info.total_value) + mint_amount);
+    <b>ensures</b> post_currency_info == update_field(currency_info, total_value, currency_info.total_value + mint_amount);
 }
 </code></pre>
 
@@ -1281,7 +1278,7 @@ The balance of designated dealer increases by <code>amount</code>.
 
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_TieredMintEnsures">TieredMintEnsures</a>&lt;Token&gt; {
-    <b>ensures</b> dealer_balance == <b>old</b>(dealer_balance) + mint_amount;
+    <b>ensures</b> post_dealer_balance == dealer_balance + mint_amount;
 }
 </code></pre>
 
@@ -1551,9 +1548,6 @@ Withdraw <code>amount</code> <code><a href="Diem.md#0x1_Diem">Diem</a>&lt;Token&
 
 
 
-<a name="0x1_DiemAccount_payer$86"></a>
-
-
 <pre><code><b>let</b> payer = cap.account_address;
 <b>modifies</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_Balance">Balance</a>&lt;Token&gt;&gt;(payer);
 <b>modifies</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payer);
@@ -1581,7 +1575,6 @@ Withdraw <code>amount</code> <code><a href="Diem.md#0x1_Diem">Diem</a>&lt;Token&
     cap: <a href="DiemAccount.md#0x1_DiemAccount_WithdrawCapability">WithdrawCapability</a>;
     payee: address;
     amount: u64;
-    <a name="0x1_DiemAccount_payer$59"></a>
     <b>let</b> payer = cap.account_address;
     <b>include</b> <a href="DiemTimestamp.md#0x1_DiemTimestamp_AbortsIfNotOperating">DiemTimestamp::AbortsIfNotOperating</a>;
     <b>include</b> <a href="Diem.md#0x1_Diem_AbortsIfNoCurrency">Diem::AbortsIfNoCurrency</a>&lt;Token&gt;;
@@ -1628,11 +1621,8 @@ Can only withdraw from the balances of cap.account_address [[H19]][PERMISSION].
     payee: address;
     amount: u64;
     metadata: vector&lt;u8&gt;;
-    <a name="0x1_DiemAccount_payer$65"></a>
     <b>let</b> payer = cap.account_address;
-    <a name="0x1_DiemAccount_handle$66"></a>
     <b>let</b> handle = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payer).sent_events;
-    <a name="0x1_DiemAccount_msg$67"></a>
     <b>let</b> msg = <a href="DiemAccount.md#0x1_DiemAccount_SentPaymentEvent">SentPaymentEvent</a> {
         amount,
         currency_code: <a href="Diem.md#0x1_Diem_spec_currency_code">Diem::spec_currency_code</a>&lt;Token&gt;(),
@@ -1684,9 +1674,7 @@ resource under <code>dd</code>.
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_DiemAccount_dd_addr$87"></a>
 <b>let</b> dd_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(dd);
-<a name="0x1_DiemAccount_payer$88"></a>
 <b>let</b> payer = cap.account_address;
 <b>modifies</b> <b>global</b>&lt;<a href="AccountLimits.md#0x1_AccountLimits_Window">AccountLimits::Window</a>&lt;Token&gt;&gt;(<a href="VASP.md#0x1_VASP_spec_parent_address">VASP::spec_parent_address</a>(payer));
 <b>modifies</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payer);
@@ -1733,8 +1721,8 @@ resource under <code>dd</code>.
     payer: address;
     amount: u64;
     <b>modifies</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_Balance">Balance</a>&lt;Token&gt;&gt;(payer);
-    <a name="0x1_DiemAccount_payer_balance$60"></a>
     <b>let</b> payer_balance = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_Balance">Balance</a>&lt;Token&gt;&gt;(payer).coin.value;
+    <b>let</b> post post_payer_balance = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_Balance">Balance</a>&lt;Token&gt;&gt;(payer).coin.value;
 }
 </code></pre>
 
@@ -1743,7 +1731,7 @@ The balance of payer decreases by <code>amount</code>.
 
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_PreburnEnsures">PreburnEnsures</a>&lt;Token&gt; {
-    <b>ensures</b> payer_balance == <b>old</b>(payer_balance) - amount;
+    <b>ensures</b> post_payer_balance == payer_balance - amount;
 }
 </code></pre>
 
@@ -1766,7 +1754,6 @@ The value of preburn at <code>dd_addr</code> increases by <code>amount</code>;
     dd: signer;
     cap: <a href="DiemAccount.md#0x1_DiemAccount_WithdrawCapability">WithdrawCapability</a>;
     amount: u64;
-    <a name="0x1_DiemAccount_dd_addr$68"></a>
     <b>let</b> dd_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(dd);
     <b>include</b> <a href="Diem.md#0x1_Diem_PreburnWithResourceEmits">Diem::PreburnWithResourceEmits</a>&lt;Token&gt;{preburn_address: dd_addr};
     <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_WithdrawFromEmits">WithdrawFromEmits</a>&lt;Token&gt;{payee: dd_addr, metadata: x""};
@@ -1818,7 +1805,6 @@ Return a unique capability granting permission to withdraw from the sender's acc
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_DiemAccount_sender_addr$89"></a>
 <b>let</b> sender_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
 <b>modifies</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(sender_addr);
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ExtractWithdrawCapAbortsIf">ExtractWithdrawCapAbortsIf</a>{sender_addr};
@@ -1886,7 +1872,6 @@ Return the withdraw capability to the account it originally came from
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_DiemAccount_cap_addr$90"></a>
 <b>let</b> cap_addr = cap.account_address;
 <b>modifies</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(cap_addr);
 <b>ensures</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(cap_addr) == update_field(<b>old</b>(<b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(cap_addr)),
@@ -1947,7 +1932,6 @@ attestation protocol
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_DiemAccount_payer$91"></a>
 <b>let</b> payer = cap.account_address;
 <b>modifies</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payer);
 <b>modifies</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(payee);
@@ -2004,7 +1988,6 @@ attestation protocol
     amount: u64;
     metadata: vector&lt;u8&gt;;
     metadata_signature: vector&lt;u8&gt; ;
-    <a name="0x1_DiemAccount_payer$69"></a>
     <b>let</b> payer = cap.account_address;
     <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_DepositAbortsIfRestricted">DepositAbortsIfRestricted</a>&lt;Token&gt;{payer: cap.account_address};
     <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_WithdrawFromBalanceNoLimitsAbortsIf">WithdrawFromBalanceNoLimitsAbortsIf</a>&lt;Token&gt;{payer, balance: <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_Balance">Balance</a>&lt;Token&gt;&gt;(payer)};
@@ -2039,7 +2022,6 @@ attestation protocol
     payee: address;
     amount: u64;
     metadata: vector&lt;u8&gt;;
-    <a name="0x1_DiemAccount_payer$70"></a>
     <b>let</b> payer = cap.account_address;
     <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_DepositEmits">DepositEmits</a>&lt;Token&gt;{payer: payer};
     <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_WithdrawFromEmits">WithdrawFromEmits</a>&lt;Token&gt;;
@@ -2203,7 +2185,6 @@ Return a unique capability granting permission to rotate the sender's authentica
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityAbortsIf">ExtractKeyRotationCapabilityAbortsIf</a> {
     account: signer;
-    <a name="0x1_DiemAccount_account_addr$71"></a>
     <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>aborts_if</b> !<a href="DiemAccount.md#0x1_DiemAccount_exists_at">exists_at</a>(account_addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
     <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_AbortsIfDelegatedKeyRotationCapability">AbortsIfDelegatedKeyRotationCapability</a>;
@@ -2347,9 +2328,6 @@ then add for both token types.
 
 
 
-<a name="0x1_DiemAccount_new_account_addr$92"></a>
-
-
 <pre><code><b>let</b> new_account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(new_account);
 <b>aborts_if</b> !<a href="Roles.md#0x1_Roles_spec_can_hold_balance_addr">Roles::spec_can_hold_balance_addr</a>(new_account_addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_AddCurrencyForAccountAbortsIf">AddCurrencyForAccountAbortsIf</a>&lt;Token&gt;{addr: new_account_addr};
@@ -2478,7 +2456,6 @@ Creating an account at address 0x0 will abort as it is a reserved address for th
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_DiemAccount_new_account_addr$93"></a>
 <b>let</b> new_account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_address_of">Signer::address_of</a>(new_account);
 <b>modifies</b> <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount">DiemAccount</a>&gt;(new_account_addr);
 <b>modifies</b> <b>global</b>&lt;<a href="../../../../../../move-stdlib/docs/Event.md#0x1_Event_EventHandleGenerator">Event::EventHandleGenerator</a>&gt;(new_account_addr);
@@ -2489,9 +2466,9 @@ Creating an account at address 0x0 will abort as it is a reserved address for th
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_MakeAccountAbortsIf">MakeAccountAbortsIf</a>{addr: new_account_addr};
 <b>ensures</b> <a href="DiemAccount.md#0x1_DiemAccount_exists_at">exists_at</a>(new_account_addr);
 <b>ensures</b> <a href="AccountFreezing.md#0x1_AccountFreezing_spec_account_is_not_frozen">AccountFreezing::spec_account_is_not_frozen</a>(new_account_addr);
-<a name="0x1_DiemAccount_account_ops_cap$94"></a>
 <b>let</b> account_ops_cap = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_AccountOperationsCapability">AccountOperationsCapability</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>());
-<b>ensures</b> account_ops_cap == update_field(<b>old</b>(account_ops_cap), creation_events, account_ops_cap.creation_events);
+<b>let</b> post post_account_ops_cap = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_AccountOperationsCapability">AccountOperationsCapability</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>());
+<b>ensures</b> post_account_ops_cap == update_field(account_ops_cap, creation_events, account_ops_cap.creation_events);
 <b>ensures</b> <a href="DiemAccount.md#0x1_DiemAccount_spec_holds_own_key_rotation_cap">spec_holds_own_key_rotation_cap</a>(new_account_addr);
 <b>ensures</b> <a href="DiemAccount.md#0x1_DiemAccount_spec_holds_own_withdraw_cap">spec_holds_own_withdraw_cap</a>(new_account_addr);
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_MakeAccountEmits">MakeAccountEmits</a>{new_account_address: <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(new_account)};
@@ -2524,10 +2501,8 @@ Creating an account at address 0x0 will abort as it is a reserved address for th
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_MakeAccountEmits">MakeAccountEmits</a> {
     new_account_address: address;
-    <a name="0x1_DiemAccount_handle$72"></a>
-    <b>let</b> handle = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_AccountOperationsCapability">AccountOperationsCapability</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>()).creation_events;
-    <a name="0x1_DiemAccount_msg$73"></a>
-    <b>let</b> msg = <a href="DiemAccount.md#0x1_DiemAccount_CreateAccountEvent">CreateAccountEvent</a> {
+    <b>let</b> post handle = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_AccountOperationsCapability">AccountOperationsCapability</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>()).creation_events;
+    <b>let</b> post msg = <a href="DiemAccount.md#0x1_DiemAccount_CreateAccountEvent">CreateAccountEvent</a> {
         created: new_account_address,
         role_id: <a href="Roles.md#0x1_Roles_spec_get_role_id">Roles::spec_get_role_id</a>(new_account_address)
     };
@@ -2691,9 +2666,6 @@ AccountOperationsCapability, WriteSetManager, and finally makes the account.
 <a name="0x1_DiemAccount_CreateDiemRootAccountModifies"></a>
 
 
-<a name="0x1_DiemAccount_dr_addr$74"></a>
-
-
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateDiemRootAccountModifies">CreateDiemRootAccountModifies</a> {
     <b>let</b> dr_addr = <a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>();
     <b>modifies</b> <b>global</b>&lt;<a href="../../../../../../move-stdlib/docs/Event.md#0x1_Event_EventHandleGenerator">Event::EventHandleGenerator</a>&gt;(dr_addr);
@@ -2732,9 +2704,6 @@ AccountOperationsCapability, WriteSetManager, and finally makes the account.
 
 
 <a name="0x1_DiemAccount_CreateDiemRootAccountEnsures"></a>
-
-
-<a name="0x1_DiemAccount_dr_addr$75"></a>
 
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateDiemRootAccountEnsures">CreateDiemRootAccountEnsures</a> {
@@ -2798,16 +2767,15 @@ event handle generator, then makes the account.
 
 
 <pre><code><b>pragma</b> opaque;
-<a name="0x1_DiemAccount_tc_addr$95"></a>
 <b>let</b> tc_addr = <a href="CoreAddresses.md#0x1_CoreAddresses_TREASURY_COMPLIANCE_ADDRESS">CoreAddresses::TREASURY_COMPLIANCE_ADDRESS</a>();
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateTreasuryComplianceAccountModifies">CreateTreasuryComplianceAccountModifies</a>;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateTreasuryComplianceAccountAbortsIf">CreateTreasuryComplianceAccountAbortsIf</a>;
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotDiemRoot">Roles::AbortsIfNotDiemRoot</a>{account: dr_account};
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_MakeAccountAbortsIf">MakeAccountAbortsIf</a>{addr: <a href="CoreAddresses.md#0x1_CoreAddresses_TREASURY_COMPLIANCE_ADDRESS">CoreAddresses::TREASURY_COMPLIANCE_ADDRESS</a>()};
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateTreasuryComplianceAccountEnsures">CreateTreasuryComplianceAccountEnsures</a>;
-<a name="0x1_DiemAccount_account_ops_cap$96"></a>
 <b>let</b> account_ops_cap = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_AccountOperationsCapability">AccountOperationsCapability</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>());
-<b>ensures</b> account_ops_cap == update_field(<b>old</b>(account_ops_cap), creation_events, account_ops_cap.creation_events);
+<b>let</b> post post_account_ops_cap = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_AccountOperationsCapability">AccountOperationsCapability</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>());
+<b>ensures</b> post_account_ops_cap == update_field(account_ops_cap, creation_events, account_ops_cap.creation_events);
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_MakeAccountEmits">MakeAccountEmits</a>{new_account_address: <a href="CoreAddresses.md#0x1_CoreAddresses_TREASURY_COMPLIANCE_ADDRESS">CoreAddresses::TREASURY_COMPLIANCE_ADDRESS</a>()};
 </code></pre>
 
@@ -2815,9 +2783,6 @@ event handle generator, then makes the account.
 
 
 <a name="0x1_DiemAccount_CreateTreasuryComplianceAccountModifies"></a>
-
-
-<a name="0x1_DiemAccount_tc_addr$76"></a>
 
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateTreasuryComplianceAccountModifies">CreateTreasuryComplianceAccountModifies</a> {
@@ -2852,9 +2817,6 @@ event handle generator, then makes the account.
 
 
 <a name="0x1_DiemAccount_CreateTreasuryComplianceAccountEnsures"></a>
-
-
-<a name="0x1_DiemAccount_tc_addr$77"></a>
 
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_CreateTreasuryComplianceAccountEnsures">CreateTreasuryComplianceAccountEnsures</a> {
@@ -3645,11 +3607,7 @@ The prologue for module transaction
 
 
 
-<a name="0x1_DiemAccount_transaction_sender$97"></a>
-
-
 <pre><code><b>let</b> transaction_sender = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
-<a name="0x1_DiemAccount_max_transaction_fee$98"></a>
 <b>let</b> max_transaction_fee = txn_gas_price * txn_max_gas_units;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ModulePrologueAbortsIf">ModulePrologueAbortsIf</a>&lt;Token&gt; {
     max_transaction_fee,
@@ -3671,7 +3629,6 @@ The prologue for module transaction
     chain_id: u8;
     max_transaction_fee: u128;
     txn_expiration_time_seconds: u64;
-    <a name="0x1_DiemAccount_transaction_sender$78"></a>
     <b>let</b> transaction_sender = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
     <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_PrologueCommonAbortsIf">PrologueCommonAbortsIf</a>&lt;Token&gt; {
         transaction_sender,
@@ -3758,11 +3715,7 @@ The prologue for script transaction
 
 
 
-<a name="0x1_DiemAccount_transaction_sender$99"></a>
-
-
 <pre><code><b>let</b> transaction_sender = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
-<a name="0x1_DiemAccount_max_transaction_fee$100"></a>
 <b>let</b> max_transaction_fee = txn_gas_price * txn_max_gas_units;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ScriptPrologueAbortsIf">ScriptPrologueAbortsIf</a>&lt;Token&gt;{
     max_transaction_fee,
@@ -3785,7 +3738,6 @@ The prologue for script transaction
     max_transaction_fee: u128;
     txn_expiration_time_seconds: u64;
     script_hash: vector&lt;u8&gt;;
-    <a name="0x1_DiemAccount_transaction_sender$79"></a>
     <b>let</b> transaction_sender = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
     <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_PrologueCommonAbortsIf">PrologueCommonAbortsIf</a>&lt;Token&gt; {transaction_sender};
 }
@@ -3881,7 +3833,6 @@ The prologue for WriteSet transaction
     txn_public_key: vector&lt;u8&gt;;
     txn_expiration_time_seconds: u64;
     chain_id: u8;
-    <a name="0x1_DiemAccount_transaction_sender$80"></a>
     <b>let</b> transaction_sender = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
 }
 </code></pre>
@@ -4031,11 +3982,7 @@ The main properties that it verifies:
 
 
 
-<a name="0x1_DiemAccount_transaction_sender$101"></a>
-
-
 <pre><code><b>let</b> transaction_sender = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
-<a name="0x1_DiemAccount_max_transaction_fee$102"></a>
 <b>let</b> max_transaction_fee = txn_gas_price * txn_max_gas_units;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_PrologueCommonAbortsIf">PrologueCommonAbortsIf</a>&lt;Token&gt; {
     transaction_sender,
@@ -4361,12 +4308,8 @@ Epilogue for WriteSet trasnaction
 <a name="0x1_DiemAccount_WritesetEpiloguEmits"></a>
 
 
-<a name="0x1_DiemAccount_handle$81"></a>
-
-
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_WritesetEpiloguEmits">WritesetEpiloguEmits</a> {
     <b>let</b> handle = <b>global</b>&lt;<a href="DiemAccount.md#0x1_DiemAccount_DiemWriteSetManager">DiemWriteSetManager</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>()).upgrade_events;
-    <a name="0x1_DiemAccount_msg$82"></a>
     <b>let</b> msg = <a href="DiemAccount.md#0x1_DiemAccount_AdminTransactionEvent">AdminTransactionEvent</a> {
         committed_timestamp_secs: <a href="DiemTimestamp.md#0x1_DiemTimestamp_spec_now_seconds">DiemTimestamp::spec_now_seconds</a>()
     };
@@ -4597,7 +4540,6 @@ or the key rotation capability for addr itself [[H18]][PERMISSION].
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_EnsuresHasKeyRotationCap">EnsuresHasKeyRotationCap</a> {
     account: signer;
-    <a name="0x1_DiemAccount_addr$83"></a>
     <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>ensures</b> <a href="DiemAccount.md#0x1_DiemAccount_spec_holds_own_key_rotation_cap">spec_holds_own_key_rotation_cap</a>(addr);
 }
@@ -4659,7 +4601,6 @@ or the withdraw capability for addr itself [[H19]][PERMISSION].
 
 <pre><code><b>schema</b> <a href="DiemAccount.md#0x1_DiemAccount_EnsuresWithdrawCap">EnsuresWithdrawCap</a> {
     account: signer;
-    <a name="0x1_DiemAccount_addr$84"></a>
     <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>ensures</b> <a href="DiemAccount.md#0x1_DiemAccount_spec_holds_own_withdraw_cap">spec_holds_own_withdraw_cap</a>(addr);
 }

--- a/language/diem-framework/releases/artifacts/current/docs/modules/DiemBlock.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/DiemBlock.md
@@ -286,9 +286,7 @@ The runtime always runs this before executing the transactions in a block.
     timestamp: u64;
     previous_block_votes: vector&lt;address&gt;;
     proposer: address;
-    <a name="0x1_DiemBlock_handle$4"></a>
     <b>let</b> handle = <b>global</b>&lt;<a href="DiemBlock.md#0x1_DiemBlock_BlockMetadata">BlockMetadata</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>()).new_block_events;
-    <a name="0x1_DiemBlock_msg$5"></a>
     <b>let</b> msg = <a href="DiemBlock.md#0x1_DiemBlock_NewBlockEvent">NewBlockEvent</a> {
         round,
         proposer,

--- a/language/diem-framework/releases/artifacts/current/docs/modules/DiemSystem.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/DiemSystem.md
@@ -341,7 +341,6 @@ Must be invoked by the Diem root a single time in Genesis.
 <pre><code><b>modifies</b> <b>global</b>&lt;<a href="DiemConfig.md#0x1_DiemConfig_DiemConfig">DiemConfig::DiemConfig</a>&lt;<a href="DiemSystem.md#0x1_DiemSystem">DiemSystem</a>&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>());
 <b>include</b> <a href="DiemTimestamp.md#0x1_DiemTimestamp_AbortsIfNotGenesis">DiemTimestamp::AbortsIfNotGenesis</a>;
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotDiemRoot">Roles::AbortsIfNotDiemRoot</a>{account: dr_account};
-<a name="0x1_DiemSystem_dr_addr$20"></a>
 <b>let</b> dr_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(dr_account);
 <b>aborts_if</b> <a href="DiemConfig.md#0x1_DiemConfig_spec_is_published">DiemConfig::spec_is_published</a>&lt;<a href="DiemSystem.md#0x1_DiemSystem">DiemSystem</a>&gt;() <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>;
 <b>aborts_if</b> <b>exists</b>&lt;<a href="DiemSystem.md#0x1_DiemSystem_CapabilityHolder">CapabilityHolder</a>&gt;(dr_addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>;
@@ -521,10 +520,10 @@ a ValidatorRole
     <b>ensures</b> <a href="Roles.md#0x1_Roles_spec_has_validator_role_addr">Roles::spec_has_validator_role_addr</a>(validator_addr);
     <b>ensures</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_is_valid">ValidatorConfig::is_valid</a>(validator_addr);
     <b>ensures</b> <a href="DiemSystem.md#0x1_DiemSystem_spec_is_validator">spec_is_validator</a>(validator_addr);
-    <a name="0x1_DiemSystem_vs$15"></a>
     <b>let</b> vs = <a href="DiemSystem.md#0x1_DiemSystem_spec_get_validators">spec_get_validators</a>();
-    <b>ensures</b> <a href="../../../../../../move-stdlib/docs/Vector.md#0x1_Vector_eq_push_back">Vector::eq_push_back</a>(vs,
-                                 <b>old</b>(vs),
+    <b>let</b> post post_vs = <a href="DiemSystem.md#0x1_DiemSystem_spec_get_validators">spec_get_validators</a>();
+    <b>ensures</b> <a href="../../../../../../move-stdlib/docs/Vector.md#0x1_Vector_eq_push_back">Vector::eq_push_back</a>(post_vs,
+                                 vs,
                                  <a href="DiemSystem.md#0x1_DiemSystem_ValidatorInfo">ValidatorInfo</a> {
                                      addr: validator_addr,
                                      config: <a href="ValidatorConfig.md#0x1_ValidatorConfig_spec_get_config">ValidatorConfig::spec_get_config</a>(validator_addr),
@@ -612,9 +611,9 @@ Removes a validator, aborts unless called by diem root account
 
 <pre><code><b>schema</b> <a href="DiemSystem.md#0x1_DiemSystem_RemoveValidatorEnsures">RemoveValidatorEnsures</a> {
     validator_addr: address;
-    <a name="0x1_DiemSystem_vs$16"></a>
     <b>let</b> vs = <a href="DiemSystem.md#0x1_DiemSystem_spec_get_validators">spec_get_validators</a>();
-    <b>ensures</b> <b>forall</b> vi in vs <b>where</b> vi.addr != validator_addr: <b>exists</b> ovi in <b>old</b>(vs): vi == ovi;
+    <b>let</b> post post_vs = <a href="DiemSystem.md#0x1_DiemSystem_spec_get_validators">spec_get_validators</a>();
+    <b>ensures</b> <b>forall</b> vi in post_vs <b>where</b> vi.addr != validator_addr: <b>exists</b> ovi in vs: vi == ovi;
 }
 </code></pre>
 
@@ -693,7 +692,6 @@ and emits a reconfigurationevent.
 <b>include</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_AbortsIfGetOperator">ValidatorConfig::AbortsIfGetOperator</a>{addr: validator_addr};
 <b>include</b> <a href="DiemSystem.md#0x1_DiemSystem_UpdateConfigAndReconfigureAbortsIf">UpdateConfigAndReconfigureAbortsIf</a>;
 <b>include</b> <a href="DiemSystem.md#0x1_DiemSystem_UpdateConfigAndReconfigureEnsures">UpdateConfigAndReconfigureEnsures</a>;
-<a name="0x1_DiemSystem_is_validator_info_updated$21"></a>
 <b>let</b> is_validator_info_updated =
     <a href="ValidatorConfig.md#0x1_ValidatorConfig_is_valid">ValidatorConfig::is_valid</a>(validator_addr) &&
     (<b>exists</b> v_info in <a href="DiemSystem.md#0x1_DiemSystem_spec_get_validators">spec_get_validators</a>():
@@ -712,7 +710,6 @@ and emits a reconfigurationevent.
 <pre><code><b>schema</b> <a href="DiemSystem.md#0x1_DiemSystem_UpdateConfigAndReconfigureAbortsIf">UpdateConfigAndReconfigureAbortsIf</a> {
     validator_addr: address;
     validator_operator_account: signer;
-    <a name="0x1_DiemSystem_validator_operator_addr$17"></a>
     <b>let</b> validator_operator_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_address_of">Signer::address_of</a>(validator_operator_account);
     <b>include</b> <a href="DiemTimestamp.md#0x1_DiemTimestamp_AbortsIfNotOperating">DiemTimestamp::AbortsIfNotOperating</a>;
 }
@@ -741,9 +738,9 @@ for validator_addr, and doesn't change any addresses.
 
 <pre><code><b>schema</b> <a href="DiemSystem.md#0x1_DiemSystem_UpdateConfigAndReconfigureEnsures">UpdateConfigAndReconfigureEnsures</a> {
     validator_addr: address;
-    <a name="0x1_DiemSystem_vs$18"></a>
     <b>let</b> vs = <a href="DiemSystem.md#0x1_DiemSystem_spec_get_validators">spec_get_validators</a>();
-    <b>ensures</b> len(vs) == len(<b>old</b>(vs));
+    <b>let</b> post post_vs = <a href="DiemSystem.md#0x1_DiemSystem_spec_get_validators">spec_get_validators</a>();
+    <b>ensures</b> len(post_vs) == len(vs);
 }
 </code></pre>
 
@@ -752,7 +749,7 @@ No addresses change in the validator set
 
 
 <pre><code><b>schema</b> <a href="DiemSystem.md#0x1_DiemSystem_UpdateConfigAndReconfigureEnsures">UpdateConfigAndReconfigureEnsures</a> {
-    <b>ensures</b> <b>forall</b> i in 0..len(vs): vs[i].addr == <b>old</b>(vs)[i].addr;
+    <b>ensures</b> <b>forall</b> i in 0..len(vs): post_vs[i].addr == vs[i].addr;
 }
 </code></pre>
 
@@ -761,8 +758,8 @@ If the <code><a href="DiemSystem.md#0x1_DiemSystem_ValidatorInfo">ValidatorInfo<
 
 
 <pre><code><b>schema</b> <a href="DiemSystem.md#0x1_DiemSystem_UpdateConfigAndReconfigureEnsures">UpdateConfigAndReconfigureEnsures</a> {
-    <b>ensures</b> <b>forall</b> i in 0..len(vs) <b>where</b> <b>old</b>(vs)[i].addr != validator_addr:
-                     vs[i] == <b>old</b>(vs)[i];
+    <b>ensures</b> <b>forall</b> i in 0..len(vs) <b>where</b> vs[i].addr != validator_addr:
+                     post_vs[i] == vs[i];
 }
 </code></pre>
 
@@ -771,9 +768,9 @@ It updates the correct entry in the correct way
 
 
 <pre><code><b>schema</b> <a href="DiemSystem.md#0x1_DiemSystem_UpdateConfigAndReconfigureEnsures">UpdateConfigAndReconfigureEnsures</a> {
-    <b>ensures</b> <b>forall</b> i in 0..len(vs): vs[i].config == <b>old</b>(vs[i].config) ||
-                (<b>old</b>(vs)[i].addr == validator_addr &&
-                vs[i].config == <a href="ValidatorConfig.md#0x1_ValidatorConfig_get_config">ValidatorConfig::get_config</a>(validator_addr));
+    <b>ensures</b> <b>forall</b> i in 0..len(vs): post_vs[i].config == vs[i].config ||
+                (vs[i].addr == validator_addr &&
+                 post_vs[i].config == <a href="ValidatorConfig.md#0x1_ValidatorConfig_get_config">ValidatorConfig::get_config</a>(validator_addr));
 }
 </code></pre>
 
@@ -794,7 +791,6 @@ DIP-6 property
 
 <pre><code><b>schema</b> <a href="DiemSystem.md#0x1_DiemSystem_UpdateConfigAndReconfigureEmits">UpdateConfigAndReconfigureEmits</a> {
     validator_addr: address;
-    <a name="0x1_DiemSystem_is_validator_info_updated$19"></a>
     <b>let</b> is_validator_info_updated =
         <a href="ValidatorConfig.md#0x1_ValidatorConfig_is_valid">ValidatorConfig::is_valid</a>(validator_addr) &&
         (<b>exists</b> v_info in <a href="DiemSystem.md#0x1_DiemSystem_spec_get_validators">spec_get_validators</a>():
@@ -1078,7 +1074,6 @@ It has a loop, so there are spec blocks in the code to assert loop invariants.
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
-<a name="0x1_DiemSystem_size$22"></a>
 <b>let</b> size = len(validators);
 </code></pre>
 
@@ -1160,7 +1155,6 @@ This function never aborts.
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
-<a name="0x1_DiemSystem_new_validator_config$23"></a>
 <b>let</b> new_validator_config = <a href="ValidatorConfig.md#0x1_ValidatorConfig_spec_get_config">ValidatorConfig::spec_get_config</a>(validators[i].addr);
 </code></pre>
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/DiemTimestamp.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/DiemTimestamp.md
@@ -209,8 +209,8 @@ Updates the wall clock time by consensus. Requires VM privilege and will be invo
 
 <pre><code><b>pragma</b> opaque;
 <b>modifies</b> <b>global</b>&lt;<a href="DiemTimestamp.md#0x1_DiemTimestamp_CurrentTimeMicroseconds">CurrentTimeMicroseconds</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>());
-<a name="0x1_DiemTimestamp_now$10"></a>
 <b>let</b> now = <a href="DiemTimestamp.md#0x1_DiemTimestamp_spec_now_microseconds">spec_now_microseconds</a>();
+<b>let</b> post post_now = <a href="DiemTimestamp.md#0x1_DiemTimestamp_spec_now_microseconds">spec_now_microseconds</a>();
 </code></pre>
 
 
@@ -219,7 +219,7 @@ Conditions unique for abstract and concrete version of this function.
 
 <pre><code><b>include</b> <a href="DiemTimestamp.md#0x1_DiemTimestamp_AbortsIfNotOperating">AbortsIfNotOperating</a>;
 <b>include</b> <a href="CoreAddresses.md#0x1_CoreAddresses_AbortsIfNotVM">CoreAddresses::AbortsIfNotVM</a>;
-<b>ensures</b> now == timestamp;
+<b>ensures</b> post_now == timestamp;
 </code></pre>
 
 
@@ -228,7 +228,7 @@ Conditions we only check for the implementation, but do not pass to the caller.
 
 <pre><code><b>aborts_if</b> [concrete]
     (<b>if</b> (proposer == <a href="CoreAddresses.md#0x1_CoreAddresses_VM_RESERVED_ADDRESS">CoreAddresses::VM_RESERVED_ADDRESS</a>()) {
-        now != timestamp // Refers <b>to</b> the now in the pre state
+        now != timestamp
      } <b>else</b>  {
         now &gt;= timestamp
      }

--- a/language/diem-framework/releases/artifacts/current/docs/modules/DiemVMConfig.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/DiemVMConfig.md
@@ -275,9 +275,6 @@ Initialize the table under the diem root account
 
 
 
-<a name="0x1_DiemVMConfig_gas_constants$2"></a>
-
-
 <pre><code><b>let</b> gas_constants = <a href="DiemVMConfig.md#0x1_DiemVMConfig_GasConstants">GasConstants</a> {
     global_memory_per_byte_cost: 4,
     global_memory_per_byte_write_cost: 9,
@@ -393,13 +390,12 @@ No one can update DiemVMConfig except for the Diem Root account [[H11]][PERMISSI
 <b>include</b> <a href="DiemConfig.md#0x1_DiemConfig_SetAbortsIf">DiemConfig::SetAbortsIf</a>&lt;<a href="DiemVMConfig.md#0x1_DiemVMConfig">DiemVMConfig</a>&gt;{account: dr_account };
 <b>aborts_if</b> min_price_per_gas_unit &gt; max_price_per_gas_unit <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
 <b>aborts_if</b> min_transaction_gas_units &gt; maximum_number_of_gas_units <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
-<a name="0x1_DiemVMConfig_config$3"></a>
 <b>let</b> config = <a href="DiemConfig.md#0x1_DiemConfig_spec_get_config">DiemConfig::spec_get_config</a>&lt;<a href="DiemVMConfig.md#0x1_DiemVMConfig">DiemVMConfig</a>&gt;();
 <b>ensures</b> <a href="DiemConfig.md#0x1_DiemConfig_spec_is_published">DiemConfig::spec_is_published</a>&lt;<a href="DiemVMConfig.md#0x1_DiemVMConfig">DiemVMConfig</a>&gt;();
 <b>ensures</b> <a href="DiemConfig.md#0x1_DiemConfig_get">DiemConfig::get</a>&lt;<a href="DiemVMConfig.md#0x1_DiemVMConfig">DiemVMConfig</a>&gt;() == <a href="DiemVMConfig.md#0x1_DiemVMConfig">DiemVMConfig</a> {
     gas_schedule: <a href="DiemVMConfig.md#0x1_DiemVMConfig_GasSchedule">GasSchedule</a> {
-        instruction_schedule: <b>old</b>(config).gas_schedule.instruction_schedule,
-        native_schedule: <b>old</b>(config).gas_schedule.native_schedule,
+        instruction_schedule: config.gas_schedule.instruction_schedule,
+        native_schedule: config.gas_schedule.native_schedule,
         gas_constants: <a href="DiemVMConfig.md#0x1_DiemVMConfig_GasConstants">GasConstants</a> {
                 global_memory_per_byte_cost,
                 global_memory_per_byte_write_cost,

--- a/language/diem-framework/releases/artifacts/current/docs/modules/DualAttestation.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/DualAttestation.md
@@ -458,7 +458,6 @@ Rotate the base URL for <code>account</code> to <code>new_url</code>
 
 <pre><code><b>schema</b> <a href="DualAttestation.md#0x1_DualAttestation_RotateBaseUrlAbortsIf">RotateBaseUrlAbortsIf</a> {
     account: signer;
-    <a name="0x1_DualAttestation_sender$25"></a>
     <b>let</b> sender = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 }
 </code></pre>
@@ -494,7 +493,6 @@ Must abort if the account does not have the resource Credential [[H17]][PERMISSI
 <pre><code><b>schema</b> <a href="DualAttestation.md#0x1_DualAttestation_RotateBaseUrlEnsures">RotateBaseUrlEnsures</a> {
     account: signer;
     new_url: vector&lt;u8&gt;;
-    <a name="0x1_DualAttestation_sender$26"></a>
     <b>let</b> sender = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>ensures</b> <b>global</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(sender).base_url == new_url;
 }
@@ -519,11 +517,8 @@ The sender can only rotate its own base url [[H17]][PERMISSION].
 <pre><code><b>schema</b> <a href="DualAttestation.md#0x1_DualAttestation_RotateBaseUrlEmits">RotateBaseUrlEmits</a> {
     account: signer;
     new_url: vector&lt;u8&gt;;
-    <a name="0x1_DualAttestation_sender$27"></a>
     <b>let</b> sender = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
-    <a name="0x1_DualAttestation_handle$28"></a>
     <b>let</b> handle = <b>global</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(sender).base_url_rotation_events;
-    <a name="0x1_DualAttestation_msg$29"></a>
     <b>let</b> msg = <a href="DualAttestation.md#0x1_DualAttestation_BaseUrlRotationEvent">BaseUrlRotationEvent</a> {
         new_base_url: new_url,
         time_rotated_seconds: <a href="DiemTimestamp.md#0x1_DiemTimestamp_spec_now_seconds">DiemTimestamp::spec_now_seconds</a>(),
@@ -592,7 +587,6 @@ Rotate the compliance public key for <code>account</code> to <code>new_key</code
 <pre><code><b>schema</b> <a href="DualAttestation.md#0x1_DualAttestation_RotateCompliancePublicKeyAbortsIf">RotateCompliancePublicKeyAbortsIf</a> {
     account: signer;
     new_key: vector&lt;u8&gt;;
-    <a name="0x1_DualAttestation_sender$30"></a>
     <b>let</b> sender = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 }
 </code></pre>
@@ -617,7 +611,6 @@ Must abort if the account does not have the resource Credential [[H17]][PERMISSI
 <pre><code><b>schema</b> <a href="DualAttestation.md#0x1_DualAttestation_RotateCompliancePublicKeyEnsures">RotateCompliancePublicKeyEnsures</a> {
     account: signer;
     new_key: vector&lt;u8&gt;;
-    <a name="0x1_DualAttestation_sender$31"></a>
     <b>let</b> sender = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>ensures</b> <b>global</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(sender).compliance_public_key == new_key;
 }
@@ -642,11 +635,8 @@ The sender only rotates its own compliance_public_key [[H17]][PERMISSION].
 <pre><code><b>schema</b> <a href="DualAttestation.md#0x1_DualAttestation_RotateCompliancePublicKeyEmits">RotateCompliancePublicKeyEmits</a> {
     account: signer;
     new_key: vector&lt;u8&gt;;
-    <a name="0x1_DualAttestation_sender$32"></a>
     <b>let</b> sender = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
-    <a name="0x1_DualAttestation_handle$33"></a>
     <b>let</b> handle = <b>global</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(sender).compliance_key_rotation_events;
-    <a name="0x1_DualAttestation_msg$34"></a>
     <b>let</b> msg = <a href="DualAttestation.md#0x1_DualAttestation_ComplianceKeyRotationEvent">ComplianceKeyRotationEvent</a> {
         new_compliance_public_key: new_key,
         time_rotated_seconds: <a href="DiemTimestamp.md#0x1_DiemTimestamp_spec_now_seconds">DiemTimestamp::spec_now_seconds</a>(),
@@ -1287,7 +1277,6 @@ Travel rule limit set during genesis
 <pre><code><b>include</b> <a href="DiemTimestamp.md#0x1_DiemTimestamp_AbortsIfNotGenesis">DiemTimestamp::AbortsIfNotGenesis</a>;
 <b>include</b> <a href="CoreAddresses.md#0x1_CoreAddresses_AbortsIfNotDiemRoot">CoreAddresses::AbortsIfNotDiemRoot</a>{account: dr_account};
 <b>aborts_if</b> <b>exists</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Limit">Limit</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>()) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>;
-<a name="0x1_DualAttestation_initial_limit$35"></a>
 <b>let</b> initial_limit = <a href="DualAttestation.md#0x1_DualAttestation_INITIAL_DUAL_ATTESTATION_LIMIT">INITIAL_DUAL_ATTESTATION_LIMIT</a> * <a href="Diem.md#0x1_Diem_spec_scaling_factor">Diem::spec_scaling_factor</a>&lt;<a href="XDX.md#0x1_XDX">XDX</a>&gt;();
 <b>aborts_if</b> initial_limit &gt; <a href="DualAttestation.md#0x1_DualAttestation_MAX_U64">MAX_U64</a> <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_LIMIT_EXCEEDED">Errors::LIMIT_EXCEEDED</a>;
 <b>include</b> <a href="Diem.md#0x1_Diem_AbortsIfNoCurrency">Diem::AbortsIfNoCurrency</a>&lt;<a href="XDX.md#0x1_XDX">XDX</a>&gt;;

--- a/language/diem-framework/releases/artifacts/current/docs/modules/PaymentScripts.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/PaymentScripts.md
@@ -139,9 +139,7 @@ Successful execution of this script emits two events:
 
 
 <pre><code><b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: payer};
-<a name="0x1_PaymentScripts_payer_addr$1"></a>
 <b>let</b> payer_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer);
-<a name="0x1_PaymentScripts_cap$2"></a>
 <b>let</b> cap = <a href="DiemAccount.md#0x1_DiemAccount_spec_get_withdraw_cap">DiemAccount::spec_get_withdraw_cap</a>(payer_addr);
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ExtractWithdrawCapAbortsIf">DiemAccount::ExtractWithdrawCapAbortsIf</a>{sender_addr: payer_addr};
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_PayFromAbortsIf">DiemAccount::PayFromAbortsIf</a>&lt;Currency&gt;{cap: cap};

--- a/language/diem-framework/releases/artifacts/current/docs/modules/RecoveryAddress.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/RecoveryAddress.md
@@ -210,7 +210,6 @@ Aborts if <code>recovery_account</code> has delegated its <code>KeyRotationCapab
 <pre><code><b>schema</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_PublishAbortsIf">PublishAbortsIf</a> {
     recovery_account: signer;
     rotation_cap: KeyRotationCapability;
-    <a name="0x1_RecoveryAddress_addr$6"></a>
     <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(recovery_account);
     <b>aborts_if</b> !<a href="VASP.md#0x1_VASP_is_vasp">VASP::is_vasp</a>(addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
     <b>aborts_if</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>;
@@ -228,7 +227,6 @@ Aborts if <code>recovery_account</code> has delegated its <code>KeyRotationCapab
 <pre><code><b>schema</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_PublishEnsures">PublishEnsures</a> {
     recovery_account: signer;
     rotation_cap: KeyRotationCapability;
-    <a name="0x1_RecoveryAddress_addr$7"></a>
     <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(recovery_account);
     <b>ensures</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(addr);
     <b>ensures</b> len(<a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">spec_get_rotation_caps</a>(addr)) == 1;
@@ -415,7 +413,6 @@ Aborts if <code>to_recover.address</code> and <code>recovery_address</code> belo
     recovery_address: address;
     <b>aborts_if</b> !<a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(recovery_address) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
     <b>aborts_if</b> len(<b>global</b>&lt;<a href="RecoveryAddress.md#0x1_RecoveryAddress">RecoveryAddress</a>&gt;(recovery_address).rotation_caps) &gt;= <a href="RecoveryAddress.md#0x1_RecoveryAddress_MAX_REGISTERED_KEYS">MAX_REGISTERED_KEYS</a> <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_LIMIT_EXCEEDED">Errors::LIMIT_EXCEEDED</a>;
-    <a name="0x1_RecoveryAddress_to_recover_address$8"></a>
     <b>let</b> to_recover_address = <a href="DiemAccount.md#0x1_DiemAccount_key_rotation_capability_address">DiemAccount::key_rotation_capability_address</a>(to_recover);
     <b>aborts_if</b> !<a href="VASP.md#0x1_VASP_spec_is_same_vasp">VASP::spec_is_same_vasp</a>(recovery_address, to_recover_address) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
 }
@@ -430,8 +427,7 @@ Aborts if <code>to_recover.address</code> and <code>recovery_address</code> belo
 <pre><code><b>schema</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_AddRotationCapabilityEnsures">AddRotationCapabilityEnsures</a> {
     to_recover: KeyRotationCapability;
     recovery_address: address;
-    <a name="0x1_RecoveryAddress_num_rotation_caps$9"></a>
-    <b>let</b> num_rotation_caps = len(<a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">spec_get_rotation_caps</a>(recovery_address));
+    <b>let</b> post num_rotation_caps = len(<a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">spec_get_rotation_caps</a>(recovery_address));
     <b>ensures</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">spec_get_rotation_caps</a>(recovery_address)[num_rotation_caps - 1] == to_recover;
 }
 </code></pre>

--- a/language/diem-framework/releases/artifacts/current/docs/modules/Roles.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/Roles.md
@@ -593,7 +593,6 @@ Helper function to grant a role.
 
 <pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Roles.md#0x1_Roles_GrantRole">GrantRole</a>{addr: <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_address_of">Signer::address_of</a>(account)};
-<a name="0x1_Roles_addr$45"></a>
 <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 <b>requires</b> role_id == <a href="Roles.md#0x1_Roles_DIEM_ROOT_ROLE_ID">DIEM_ROOT_ROLE_ID</a> ==&gt; addr == <a href="CoreAddresses.md#0x1_CoreAddresses_DIEM_ROOT_ADDRESS">CoreAddresses::DIEM_ROOT_ADDRESS</a>();
 <b>requires</b> role_id == <a href="Roles.md#0x1_Roles_TREASURY_COMPLIANCE_ROLE_ID">TREASURY_COMPLIANCE_ROLE_ID</a> ==&gt; addr == <a href="CoreAddresses.md#0x1_CoreAddresses_TREASURY_COMPLIANCE_ADDRESS">CoreAddresses::TREASURY_COMPLIANCE_ADDRESS</a>();
@@ -1506,7 +1505,6 @@ ChildVASP have balances [[D7]][ROLE].
 <pre><code><b>schema</b> <a href="Roles.md#0x1_Roles_AbortsIfNotDiemRoot">AbortsIfNotDiemRoot</a> {
     account: signer;
     <b>include</b> <a href="CoreAddresses.md#0x1_CoreAddresses_AbortsIfNotDiemRoot">CoreAddresses::AbortsIfNotDiemRoot</a>;
-    <a name="0x1_Roles_addr$37"></a>
     <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>aborts_if</b> !<b>exists</b>&lt;<a href="Roles.md#0x1_Roles_RoleId">RoleId</a>&gt;(addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
     <b>aborts_if</b> <b>global</b>&lt;<a href="Roles.md#0x1_Roles_RoleId">RoleId</a>&gt;(addr).role_id != <a href="Roles.md#0x1_Roles_DIEM_ROOT_ROLE_ID">DIEM_ROOT_ROLE_ID</a> <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>;
@@ -1522,7 +1520,6 @@ ChildVASP have balances [[D7]][ROLE].
 <pre><code><b>schema</b> <a href="Roles.md#0x1_Roles_AbortsIfNotTreasuryCompliance">AbortsIfNotTreasuryCompliance</a> {
     account: signer;
     <b>include</b> <a href="CoreAddresses.md#0x1_CoreAddresses_AbortsIfNotTreasuryCompliance">CoreAddresses::AbortsIfNotTreasuryCompliance</a>;
-    <a name="0x1_Roles_addr$38"></a>
     <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>aborts_if</b> !<b>exists</b>&lt;<a href="Roles.md#0x1_Roles_RoleId">RoleId</a>&gt;(addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
     <b>aborts_if</b> <b>global</b>&lt;<a href="Roles.md#0x1_Roles_RoleId">RoleId</a>&gt;(addr).role_id != <a href="Roles.md#0x1_Roles_TREASURY_COMPLIANCE_ROLE_ID">TREASURY_COMPLIANCE_ROLE_ID</a> <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>;
@@ -1537,7 +1534,6 @@ ChildVASP have balances [[D7]][ROLE].
 
 <pre><code><b>schema</b> <a href="Roles.md#0x1_Roles_AbortsIfNotParentVasp">AbortsIfNotParentVasp</a> {
     account: signer;
-    <a name="0x1_Roles_addr$39"></a>
     <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>aborts_if</b> !<b>exists</b>&lt;<a href="Roles.md#0x1_Roles_RoleId">RoleId</a>&gt;(addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
     <b>aborts_if</b> <b>global</b>&lt;<a href="Roles.md#0x1_Roles_RoleId">RoleId</a>&gt;(addr).role_id != <a href="Roles.md#0x1_Roles_PARENT_VASP_ROLE_ID">PARENT_VASP_ROLE_ID</a> <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>;
@@ -1565,7 +1561,6 @@ ChildVASP have balances [[D7]][ROLE].
 
 <pre><code><b>schema</b> <a href="Roles.md#0x1_Roles_AbortsIfNotDesignatedDealer">AbortsIfNotDesignatedDealer</a> {
     account: signer;
-    <a name="0x1_Roles_addr$40"></a>
     <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>aborts_if</b> !<b>exists</b>&lt;<a href="Roles.md#0x1_Roles_RoleId">RoleId</a>&gt;(addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
     <b>aborts_if</b> <b>global</b>&lt;<a href="Roles.md#0x1_Roles_RoleId">RoleId</a>&gt;(addr).role_id != <a href="Roles.md#0x1_Roles_DESIGNATED_DEALER_ROLE_ID">DESIGNATED_DEALER_ROLE_ID</a> <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>;
@@ -1580,10 +1575,8 @@ ChildVASP have balances [[D7]][ROLE].
 
 <pre><code><b>schema</b> <a href="Roles.md#0x1_Roles_AbortsIfNotParentVaspOrDesignatedDealer">AbortsIfNotParentVaspOrDesignatedDealer</a> {
     account: signer;
-    <a name="0x1_Roles_addr$41"></a>
     <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>aborts_if</b> !<b>exists</b>&lt;<a href="Roles.md#0x1_Roles_RoleId">RoleId</a>&gt;(addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
-    <a name="0x1_Roles_role_id$42"></a>
     <b>let</b> role_id = <b>global</b>&lt;<a href="Roles.md#0x1_Roles_RoleId">RoleId</a>&gt;(addr).role_id;
     <b>aborts_if</b> role_id != <a href="Roles.md#0x1_Roles_PARENT_VASP_ROLE_ID">PARENT_VASP_ROLE_ID</a> && role_id != <a href="Roles.md#0x1_Roles_DESIGNATED_DEALER_ROLE_ID">DESIGNATED_DEALER_ROLE_ID</a>
         <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>;
@@ -1598,10 +1591,8 @@ ChildVASP have balances [[D7]][ROLE].
 
 <pre><code><b>schema</b> <a href="Roles.md#0x1_Roles_AbortsIfNotParentVaspOrChildVasp">AbortsIfNotParentVaspOrChildVasp</a> {
     account: signer;
-    <a name="0x1_Roles_addr$43"></a>
     <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>aborts_if</b> !<b>exists</b>&lt;<a href="Roles.md#0x1_Roles_RoleId">RoleId</a>&gt;(addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
-    <a name="0x1_Roles_role_id$44"></a>
     <b>let</b> role_id = <b>global</b>&lt;<a href="Roles.md#0x1_Roles_RoleId">RoleId</a>&gt;(addr).role_id;
     <b>aborts_if</b> role_id != <a href="Roles.md#0x1_Roles_PARENT_VASP_ROLE_ID">PARENT_VASP_ROLE_ID</a> && role_id != <a href="Roles.md#0x1_Roles_CHILD_VASP_ROLE_ID">CHILD_VASP_ROLE_ID</a>
         <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>;

--- a/language/diem-framework/releases/artifacts/current/docs/modules/SharedEd25519PublicKey.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/SharedEd25519PublicKey.md
@@ -141,7 +141,6 @@ Aborts if the length of <code>new_public_key</code> is not 32.
 <pre><code><b>schema</b> <a href="SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey_PublishAbortsIf">PublishAbortsIf</a> {
     account: signer;
     key: vector&lt;u8&gt;;
-    <a name="0x1_SharedEd25519PublicKey_addr$5"></a>
     <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityAbortsIf">DiemAccount::ExtractKeyRotationCapabilityAbortsIf</a>;
     <b>include</b> <a href="SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey_RotateKey_AbortsIf">RotateKey_AbortsIf</a> {
@@ -164,7 +163,6 @@ Aborts if the length of <code>new_public_key</code> is not 32.
 <pre><code><b>schema</b> <a href="SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey_PublishEnsures">PublishEnsures</a> {
     account: signer;
     key: vector&lt;u8&gt;;
-    <a name="0x1_SharedEd25519PublicKey_addr$6"></a>
     <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>ensures</b> <a href="SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey_exists_at">exists_at</a>(addr);
     <b>include</b> <a href="SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey_RotateKey_Ensures">RotateKey_Ensures</a> { shared_key: <b>global</b>&lt;<a href="SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey">SharedEd25519PublicKey</a>&gt;(addr), new_public_key: key};
@@ -301,7 +299,6 @@ Aborts if the length of <code>new_public_key</code> is not 32.
 <pre><code><b>schema</b> <a href="SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey_RotateKeyAbortsIf">RotateKeyAbortsIf</a> {
     account: signer;
     new_public_key: vector&lt;u8&gt;;
-    <a name="0x1_SharedEd25519PublicKey_addr$7"></a>
     <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>aborts_if</b> !<a href="SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey_exists_at">exists_at</a>(addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
     <b>include</b> <a href="SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey_RotateKey_AbortsIf">RotateKey_AbortsIf</a> {shared_key: <b>global</b>&lt;<a href="SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey">SharedEd25519PublicKey</a>&gt;(addr)};
@@ -317,7 +314,6 @@ Aborts if the length of <code>new_public_key</code> is not 32.
 <pre><code><b>schema</b> <a href="SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey_RotateKeyEnsures">RotateKeyEnsures</a> {
     account: signer;
     new_public_key: vector&lt;u8&gt;;
-    <a name="0x1_SharedEd25519PublicKey_addr$8"></a>
     <b>let</b> addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>include</b> <a href="SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey_RotateKey_Ensures">RotateKey_Ensures</a> {shared_key: <b>global</b>&lt;<a href="SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey">SharedEd25519PublicKey</a>&gt;(addr)};
 }

--- a/language/diem-framework/releases/artifacts/current/docs/modules/TransactionFee.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/TransactionFee.md
@@ -265,10 +265,10 @@ Deposit <code>coin</code> into the transaction fees bucket
 
 <pre><code><b>include</b> <a href="DiemTimestamp.md#0x1_DiemTimestamp_AbortsIfNotOperating">DiemTimestamp::AbortsIfNotOperating</a>;
 <b>aborts_if</b> !<a href="TransactionFee.md#0x1_TransactionFee_is_coin_initialized">is_coin_initialized</a>&lt;CoinType&gt;() <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
-<a name="0x1_TransactionFee_fees$8"></a>
 <b>let</b> fees = <a href="TransactionFee.md#0x1_TransactionFee_spec_transaction_fee">spec_transaction_fee</a>&lt;CoinType&gt;().balance;
+<b>let</b> post post_fees = <a href="TransactionFee.md#0x1_TransactionFee_spec_transaction_fee">spec_transaction_fee</a>&lt;CoinType&gt;().balance;
 <b>include</b> <a href="Diem.md#0x1_Diem_DepositAbortsIf">Diem::DepositAbortsIf</a>&lt;CoinType&gt;{coin: fees, check: coin};
-<b>ensures</b> fees.value == <b>old</b>(fees.value) + coin.value;
+<b>ensures</b> post_fees.value == fees.value + coin.value;
 </code></pre>
 
 
@@ -394,7 +394,6 @@ Must abort if the account does not have BurnCapability [[H3]][PERMISSION].
 
 <pre><code><b>schema</b> <a href="TransactionFee.md#0x1_TransactionFee_BurnFeesNotXDX">BurnFeesNotXDX</a>&lt;CoinType&gt; {
     <b>include</b> <a href="Diem.md#0x1_Diem_AbortsIfNoBurnCapability">Diem::AbortsIfNoBurnCapability</a>&lt;CoinType&gt;{account: tc_account};
-    <a name="0x1_TransactionFee_fees$7"></a>
     <b>let</b> fees = <a href="TransactionFee.md#0x1_TransactionFee_spec_transaction_fee">spec_transaction_fee</a>&lt;CoinType&gt;();
     <b>include</b> <a href="Diem.md#0x1_Diem_BurnNowAbortsIf">Diem::BurnNowAbortsIf</a>&lt;CoinType&gt;{coin: fees.balance, preburn: fees.preburn};
 }

--- a/language/diem-framework/releases/artifacts/current/docs/modules/TreasuryComplianceScripts.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/TreasuryComplianceScripts.md
@@ -197,26 +197,28 @@ being <code>preburn_address</code>.
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_CancelBurnAbortsIf">DiemAccount::CancelBurnAbortsIf</a>&lt;Token&gt;;
 <b>include</b> <a href="Diem.md#0x1_Diem_CancelBurnWithCapEnsures">Diem::CancelBurnWithCapEnsures</a>&lt;Token&gt;;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_DepositEnsures">DiemAccount::DepositEnsures</a>&lt;Token&gt;{payee: preburn_address};
-<a name="0x1_TreasuryComplianceScripts_total_preburn_value$10"></a>
 <b>let</b> total_preburn_value = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">Diem::CurrencyInfo</a>&lt;Token&gt;&gt;(
     <a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>()
 ).preburn_value;
-<a name="0x1_TreasuryComplianceScripts_balance_at_addr$11"></a>
+<b>let</b> post post_total_preburn_value = <b>global</b>&lt;<a href="Diem.md#0x1_Diem_CurrencyInfo">Diem::CurrencyInfo</a>&lt;Token&gt;&gt;(
+    <a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>()
+).preburn_value;
 <b>let</b> balance_at_addr = <a href="DiemAccount.md#0x1_DiemAccount_balance">DiemAccount::balance</a>&lt;Token&gt;(preburn_address);
+<b>let</b> post post_balance_at_addr = <a href="DiemAccount.md#0x1_DiemAccount_balance">DiemAccount::balance</a>&lt;Token&gt;(preburn_address);
 </code></pre>
 
 
 The total value of preburn for <code>Token</code> should decrease by the preburned amount.
 
 
-<pre><code><b>ensures</b> total_preburn_value == <b>old</b>(total_preburn_value) - amount;
+<pre><code><b>ensures</b> post_total_preburn_value == total_preburn_value - amount;
 </code></pre>
 
 
 The balance of <code>Token</code> at <code>preburn_address</code> should increase by the preburned amount.
 
 
-<pre><code><b>ensures</b> balance_at_addr == <b>old</b>(balance_at_addr) + amount;
+<pre><code><b>ensures</b> post_balance_at_addr == balance_at_addr + amount;
 <b>include</b> <a href="Diem.md#0x1_Diem_CancelBurnWithCapEmits">Diem::CancelBurnWithCapEmits</a>&lt;Token&gt;;
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_DepositEmits">DiemAccount::DepositEmits</a>&lt;Token&gt;{
     payer: preburn_address,
@@ -475,9 +477,7 @@ handle with the <code>payee</code> and <code>payer</code> fields being <code>acc
 
 
 <pre><code><b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: account};
-<a name="0x1_TreasuryComplianceScripts_account_addr$12"></a>
 <b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
-<a name="0x1_TreasuryComplianceScripts_cap$13"></a>
 <b>let</b> cap = <a href="DiemAccount.md#0x1_DiemAccount_spec_get_withdraw_cap">DiemAccount::spec_get_withdraw_cap</a>(account_addr);
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ExtractWithdrawCapAbortsIf">DiemAccount::ExtractWithdrawCapAbortsIf</a>{sender_addr: account_addr};
 <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_PreburnAbortsIf">DiemAccount::PreburnAbortsIf</a>&lt;Token&gt;{dd: account, cap: cap};
@@ -1084,7 +1084,6 @@ is given by <code>new_exchange_rate_numerator/new_exchange_rate_denominator</cod
        numerator: new_exchange_rate_numerator,
        denominator: new_exchange_rate_denominator
 };
-<a name="0x1_TreasuryComplianceScripts_rate$14"></a>
 <b>let</b> rate = <a href="../../../../../../move-stdlib/docs/FixedPoint32.md#0x1_FixedPoint32_spec_create_from_rational">FixedPoint32::spec_create_from_rational</a>(
         new_exchange_rate_numerator,
         new_exchange_rate_denominator

--- a/language/diem-framework/releases/artifacts/current/docs/modules/VASP.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/VASP.md
@@ -189,7 +189,6 @@ or if there is already a VASP (child or parent) at this account.
 <pre><code><b>include</b> <a href="DiemTimestamp.md#0x1_DiemTimestamp_AbortsIfNotOperating">DiemTimestamp::AbortsIfNotOperating</a>;
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotTreasuryCompliance">Roles::AbortsIfNotTreasuryCompliance</a>{account: tc_account};
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotParentVasp">Roles::AbortsIfNotParentVasp</a>{account: vasp};
-<a name="0x1_VASP_vasp_addr$14"></a>
 <b>let</b> vasp_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(vasp);
 <b>aborts_if</b> <a href="VASP.md#0x1_VASP_is_vasp">is_vasp</a>(vasp_addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>;
 <b>include</b> <a href="VASP.md#0x1_VASP_PublishParentVASPEnsures">PublishParentVASPEnsures</a>{vasp_addr: vasp_addr};
@@ -256,9 +255,6 @@ Aborts if <code>parent</code> is not a ParentVASP
 
 
 
-<a name="0x1_VASP_child_addr$15"></a>
-
-
 <pre><code><b>let</b> child_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(child);
 <b>include</b> <a href="VASP.md#0x1_VASP_PublishChildVASPAbortsIf">PublishChildVASPAbortsIf</a>{child_addr};
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotChildVasp">Roles::AbortsIfNotChildVasp</a>{account: child_addr};
@@ -274,7 +270,6 @@ Aborts if <code>parent</code> is not a ParentVASP
 <pre><code><b>schema</b> <a href="VASP.md#0x1_VASP_PublishChildVASPAbortsIf">PublishChildVASPAbortsIf</a> {
     parent: signer;
     child_addr: address;
-    <a name="0x1_VASP_parent_addr$13"></a>
     <b>let</b> parent_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(parent);
     <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotParentVasp">Roles::AbortsIfNotParentVasp</a>{account: parent};
     <b>aborts_if</b> <a href="VASP.md#0x1_VASP_is_vasp">is_vasp</a>(child_addr) <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>;

--- a/language/diem-framework/releases/artifacts/current/docs/modules/ValidatorAdministrationScripts.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/ValidatorAdministrationScripts.md
@@ -562,7 +562,6 @@ on-chain with the updated <code><a href="ValidatorConfig.md#0x1_ValidatorConfig_
 };
 <b>include</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_SetConfigAbortsIf">ValidatorConfig::SetConfigAbortsIf</a>{validator_addr: validator_account};
 <b>include</b> <a href="DiemSystem.md#0x1_DiemSystem_UpdateConfigAndReconfigureAbortsIf">DiemSystem::UpdateConfigAndReconfigureAbortsIf</a>{validator_addr: validator_account};
-<a name="0x1_ValidatorAdministrationScripts_is_validator_info_updated$6"></a>
 <b>let</b> is_validator_info_updated =
     (<b>exists</b> v_info in <a href="DiemSystem.md#0x1_DiemSystem_spec_get_validators">DiemSystem::spec_get_validators</a>():
         v_info.addr == validator_account
@@ -693,9 +692,6 @@ resource published under it. The sending <code>account</code> must be a Validato
 <details>
 <summary>Specification</summary>
 
-
-
-<a name="0x1_ValidatorAdministrationScripts_account_addr$7"></a>
 
 
 <pre><code><b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_address_of">Signer::address_of</a>(account);
@@ -830,9 +826,6 @@ the system is initiated by this script.
 <details>
 <summary>Specification</summary>
 
-
-
-<a name="0x1_ValidatorAdministrationScripts_account_addr$8"></a>
 
 
 <pre><code><b>let</b> account_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_address_of">Signer::address_of</a>(account);

--- a/language/diem-framework/releases/artifacts/current/docs/modules/ValidatorConfig.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/ValidatorConfig.md
@@ -304,9 +304,6 @@ Note: Access control.  No one but the owner of the account may change .operator_
 Must abort if the signer does not have the Validator role [[H16]][PERMISSION].
 
 
-<a name="0x1_ValidatorConfig_sender$15"></a>
-
-
 <pre><code><b>let</b> sender = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(validator_account);
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotValidator">Roles::AbortsIfNotValidator</a>{validator_addr: sender};
 <b>include</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_SetOperatorAbortsIf">SetOperatorAbortsIf</a>;
@@ -324,7 +321,6 @@ Must abort if the signer does not have the Validator role [B24].
 <pre><code><b>schema</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_SetOperatorAbortsIf">SetOperatorAbortsIf</a> {
     validator_account: signer;
     operator_addr: address;
-    <a name="0x1_ValidatorConfig_validator_addr$13"></a>
     <b>let</b> validator_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(validator_account);
     <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotValidator">Roles::AbortsIfNotValidator</a>{validator_addr: validator_addr};
     <b>aborts_if</b> !<a href="ValidatorOperatorConfig.md#0x1_ValidatorOperatorConfig_has_validator_operator_config">ValidatorOperatorConfig::has_validator_operator_config</a>(operator_addr)
@@ -343,7 +339,6 @@ Must abort if the signer does not have the Validator role [B24].
 <pre><code><b>schema</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_SetOperatorEnsures">SetOperatorEnsures</a> {
     validator_account: signer;
     operator_addr: address;
-    <a name="0x1_ValidatorConfig_validator_addr$14"></a>
     <b>let</b> validator_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(validator_account);
     <b>ensures</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_spec_has_operator">spec_has_operator</a>(validator_addr);
     <b>ensures</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_get_operator">get_operator</a>(validator_addr) == operator_addr;
@@ -399,9 +394,6 @@ The old config is preserved.
 
 
 Must abort if the signer does not have the Validator role [[H16]][PERMISSION].
-
-
-<a name="0x1_ValidatorConfig_sender$16"></a>
 
 
 <pre><code><b>let</b> sender = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(validator_account);

--- a/language/diem-framework/releases/artifacts/current/docs/scripts/script_documentation.md
+++ b/language/diem-framework/releases/artifacts/current/docs/scripts/script_documentation.md
@@ -837,9 +837,7 @@ This is emitted on the new Child VASPS's <code><a href="../../../../../releases/
 
 
 <pre><code><b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: parent_vasp};
-<a name="0x1_AccountCreationScripts_parent_addr$5"></a>
 <b>let</b> parent_addr = <a href="_spec_address_of">Signer::spec_address_of</a>(parent_vasp);
-<a name="0x1_AccountCreationScripts_parent_cap$6"></a>
 <b>let</b> parent_cap = <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_spec_get_withdraw_cap">DiemAccount::spec_get_withdraw_cap</a>(parent_addr);
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_CreateChildVASPAccountAbortsIf">DiemAccount::CreateChildVASPAccountAbortsIf</a>&lt;CoinType&gt;{
     parent: parent_vasp, new_account_address: child_address};
@@ -1688,15 +1686,13 @@ resource stored under the account at <code>recovery_address</code>.
 <pre><code><b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: to_recover_account};
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityAbortsIf">DiemAccount::ExtractKeyRotationCapabilityAbortsIf</a>{account: to_recover_account};
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityEnsures">DiemAccount::ExtractKeyRotationCapabilityEnsures</a>{account: to_recover_account};
-<a name="0x1_AccountAdministrationScripts_addr$10"></a>
 <b>let</b> addr = <a href="_spec_address_of">Signer::spec_address_of</a>(to_recover_account);
-<a name="0x1_AccountAdministrationScripts_rotation_cap$11"></a>
 <b>let</b> rotation_cap = <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_spec_get_key_rotation_cap">DiemAccount::spec_get_key_rotation_cap</a>(addr);
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/RecoveryAddress.md#0x1_RecoveryAddress_AddRotationCapabilityAbortsIf">RecoveryAddress::AddRotationCapabilityAbortsIf</a>{
     to_recover: rotation_cap
 };
 <b>ensures</b> <a href="../../../../../releases/artifacts/current/docs/modules/RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">RecoveryAddress::spec_get_rotation_caps</a>(recovery_address)[
-    len(<a href="../../../../../releases/artifacts/current/docs/modules/RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">RecoveryAddress::spec_get_rotation_caps</a>(recovery_address)) - 1] == <b>old</b>(rotation_cap);
+    len(<a href="../../../../../releases/artifacts/current/docs/modules/RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">RecoveryAddress::spec_get_rotation_caps</a>(recovery_address)) - 1] == rotation_cap;
 <b>aborts_with</b> [check]
     <a href="_INVALID_STATE">Errors::INVALID_STATE</a>,
     <a href="_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>,
@@ -1874,10 +1870,8 @@ and <code>account</code> must not have previously delegated its <code><a href=".
 
 
 <pre><code><b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: account};
-<a name="0x1_AccountAdministrationScripts_account_addr$12"></a>
 <b>let</b> account_addr = <a href="_spec_address_of">Signer::spec_address_of</a>(account);
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityAbortsIf">DiemAccount::ExtractKeyRotationCapabilityAbortsIf</a>;
-<a name="0x1_AccountAdministrationScripts_key_rotation_capability$13"></a>
 <b>let</b> key_rotation_capability = <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_spec_get_key_rotation_cap">DiemAccount::spec_get_key_rotation_cap</a>(account_addr);
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_RotateAuthenticationKeyAbortsIf">DiemAccount::RotateAuthenticationKeyAbortsIf</a>{cap: key_rotation_capability, new_authentication_key: new_key};
 </code></pre>
@@ -1990,11 +1984,9 @@ and <code>account</code> must not have previously delegated its <code><a href=".
 
 
 <pre><code><b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: account};
-<a name="0x1_AccountAdministrationScripts_account_addr$14"></a>
 <b>let</b> account_addr = <a href="_spec_address_of">Signer::spec_address_of</a>(account);
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/SlidingNonce.md#0x1_SlidingNonce_RecordNonceAbortsIf">SlidingNonce::RecordNonceAbortsIf</a>{ seq_nonce: sliding_nonce };
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityAbortsIf">DiemAccount::ExtractKeyRotationCapabilityAbortsIf</a>;
-<a name="0x1_AccountAdministrationScripts_key_rotation_capability$15"></a>
 <b>let</b> key_rotation_capability = <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_spec_get_key_rotation_cap">DiemAccount::spec_get_key_rotation_cap</a>(account_addr);
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_RotateAuthenticationKeyAbortsIf">DiemAccount::RotateAuthenticationKeyAbortsIf</a>{cap: key_rotation_capability, new_authentication_key: new_key};
 </code></pre>
@@ -2108,11 +2100,9 @@ and <code>account</code> must not have previously delegated its <code><a href=".
 
 
 <pre><code><b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: account};
-<a name="0x1_AccountAdministrationScripts_account_addr$16"></a>
 <b>let</b> account_addr = <a href="_spec_address_of">Signer::spec_address_of</a>(account);
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/SlidingNonce.md#0x1_SlidingNonce_RecordNonceAbortsIf">SlidingNonce::RecordNonceAbortsIf</a>{ account: dr_account, seq_nonce: sliding_nonce };
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityAbortsIf">DiemAccount::ExtractKeyRotationCapabilityAbortsIf</a>;
-<a name="0x1_AccountAdministrationScripts_key_rotation_capability$17"></a>
 <b>let</b> key_rotation_capability = <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_spec_get_key_rotation_cap">DiemAccount::spec_get_key_rotation_cap</a>(account_addr);
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_RotateAuthenticationKeyAbortsIf">DiemAccount::RotateAuthenticationKeyAbortsIf</a>{cap: key_rotation_capability, new_authentication_key: new_key};
 </code></pre>
@@ -2249,9 +2239,6 @@ This transaction can be sent either by the <code>to_recover</code> account, or b
 The delegatee at the recovery address has to hold the key rotation capability for
 the address to recover. The address of the transaction signer has to be either
 the delegatee's address or the address to recover [[H18]][PERMISSION][[J18]][PERMISSION].
-
-
-<a name="0x1_AccountAdministrationScripts_account_addr$18"></a>
 
 
 <pre><code><b>let</b> account_addr = <a href="_spec_address_of">Signer::spec_address_of</a>(account);
@@ -2547,9 +2534,7 @@ may be used as a recovery account for those accounts.
 <pre><code><b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: account};
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityAbortsIf">DiemAccount::ExtractKeyRotationCapabilityAbortsIf</a>;
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityEnsures">DiemAccount::ExtractKeyRotationCapabilityEnsures</a>;
-<a name="0x1_AccountAdministrationScripts_account_addr$19"></a>
 <b>let</b> account_addr = <a href="_spec_address_of">Signer::spec_address_of</a>(account);
-<a name="0x1_AccountAdministrationScripts_rotation_cap$20"></a>
 <b>let</b> rotation_cap = <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_spec_get_key_rotation_cap">DiemAccount::spec_get_key_rotation_cap</a>(account_addr);
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/RecoveryAddress.md#0x1_RecoveryAddress_PublishAbortsIf">RecoveryAddress::PublishAbortsIf</a>{
     recovery_account: account,
@@ -2557,7 +2542,7 @@ may be used as a recovery account for those accounts.
 };
 <b>ensures</b> <a href="../../../../../releases/artifacts/current/docs/modules/RecoveryAddress.md#0x1_RecoveryAddress_spec_is_recovery_address">RecoveryAddress::spec_is_recovery_address</a>(account_addr);
 <b>ensures</b> len(<a href="../../../../../releases/artifacts/current/docs/modules/RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">RecoveryAddress::spec_get_rotation_caps</a>(account_addr)) == 1;
-<b>ensures</b> <a href="../../../../../releases/artifacts/current/docs/modules/RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">RecoveryAddress::spec_get_rotation_caps</a>(account_addr)[0] == <b>old</b>(rotation_cap);
+<b>ensures</b> <a href="../../../../../releases/artifacts/current/docs/modules/RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">RecoveryAddress::spec_get_rotation_caps</a>(account_addr)[0] == rotation_cap;
 <b>aborts_with</b> [check]
     <a href="_INVALID_STATE">Errors::INVALID_STATE</a>,
     <a href="_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>,
@@ -2708,9 +2693,7 @@ Successful execution of this script emits two events:
 
 
 <pre><code><b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: payer};
-<a name="0x1_PaymentScripts_payer_addr$1"></a>
 <b>let</b> payer_addr = <a href="_spec_address_of">Signer::spec_address_of</a>(payer);
-<a name="0x1_PaymentScripts_cap$2"></a>
 <b>let</b> cap = <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_spec_get_withdraw_cap">DiemAccount::spec_get_withdraw_cap</a>(payer_addr);
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_ExtractWithdrawCapAbortsIf">DiemAccount::ExtractWithdrawCapAbortsIf</a>{sender_addr: payer_addr};
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_PayFromAbortsIf">DiemAccount::PayFromAbortsIf</a>&lt;Currency&gt;{cap: cap};
@@ -3292,7 +3275,6 @@ on-chain with the updated <code><a href="../../../../../releases/artifacts/curre
 };
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/ValidatorConfig.md#0x1_ValidatorConfig_SetConfigAbortsIf">ValidatorConfig::SetConfigAbortsIf</a>{validator_addr: validator_account};
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemSystem.md#0x1_DiemSystem_UpdateConfigAndReconfigureAbortsIf">DiemSystem::UpdateConfigAndReconfigureAbortsIf</a>{validator_addr: validator_account};
-<a name="0x1_ValidatorAdministrationScripts_is_validator_info_updated$6"></a>
 <b>let</b> is_validator_info_updated =
     (<b>exists</b> v_info in <a href="../../../../../releases/artifacts/current/docs/modules/DiemSystem.md#0x1_DiemSystem_spec_get_validators">DiemSystem::spec_get_validators</a>():
         v_info.addr == validator_account
@@ -3423,9 +3405,6 @@ resource published under it. The sending <code>account</code> must be a Validato
 <details>
 <summary>Specification</summary>
 
-
-
-<a name="0x1_ValidatorAdministrationScripts_account_addr$7"></a>
 
 
 <pre><code><b>let</b> account_addr = <a href="_address_of">Signer::address_of</a>(account);
@@ -3560,9 +3539,6 @@ the system is initiated by this script.
 <details>
 <summary>Specification</summary>
 
-
-
-<a name="0x1_ValidatorAdministrationScripts_account_addr$8"></a>
 
 
 <pre><code><b>let</b> account_addr = <a href="_address_of">Signer::address_of</a>(account);
@@ -3737,26 +3713,28 @@ being <code>preburn_address</code>.
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_CancelBurnAbortsIf">DiemAccount::CancelBurnAbortsIf</a>&lt;Token&gt;;
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/Diem.md#0x1_Diem_CancelBurnWithCapEnsures">Diem::CancelBurnWithCapEnsures</a>&lt;Token&gt;;
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_DepositEnsures">DiemAccount::DepositEnsures</a>&lt;Token&gt;{payee: preburn_address};
-<a name="0x1_TreasuryComplianceScripts_total_preburn_value$10"></a>
 <b>let</b> total_preburn_value = <b>global</b>&lt;<a href="../../../../../releases/artifacts/current/docs/modules/Diem.md#0x1_Diem_CurrencyInfo">Diem::CurrencyInfo</a>&lt;Token&gt;&gt;(
     <a href="../../../../../releases/artifacts/current/docs/modules/CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>()
 ).preburn_value;
-<a name="0x1_TreasuryComplianceScripts_balance_at_addr$11"></a>
+<b>let</b> post post_total_preburn_value = <b>global</b>&lt;<a href="../../../../../releases/artifacts/current/docs/modules/Diem.md#0x1_Diem_CurrencyInfo">Diem::CurrencyInfo</a>&lt;Token&gt;&gt;(
+    <a href="../../../../../releases/artifacts/current/docs/modules/CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>()
+).preburn_value;
 <b>let</b> balance_at_addr = <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_balance">DiemAccount::balance</a>&lt;Token&gt;(preburn_address);
+<b>let</b> post post_balance_at_addr = <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_balance">DiemAccount::balance</a>&lt;Token&gt;(preburn_address);
 </code></pre>
 
 
 The total value of preburn for <code>Token</code> should decrease by the preburned amount.
 
 
-<pre><code><b>ensures</b> total_preburn_value == <b>old</b>(total_preburn_value) - amount;
+<pre><code><b>ensures</b> post_total_preburn_value == total_preburn_value - amount;
 </code></pre>
 
 
 The balance of <code>Token</code> at <code>preburn_address</code> should increase by the preburned amount.
 
 
-<pre><code><b>ensures</b> balance_at_addr == <b>old</b>(balance_at_addr) + amount;
+<pre><code><b>ensures</b> post_balance_at_addr == balance_at_addr + amount;
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/Diem.md#0x1_Diem_CancelBurnWithCapEmits">Diem::CancelBurnWithCapEmits</a>&lt;Token&gt;;
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_DepositEmits">DiemAccount::DepositEmits</a>&lt;Token&gt;{
     payer: preburn_address,
@@ -4015,9 +3993,7 @@ handle with the <code>payee</code> and <code>payer</code> fields being <code>acc
 
 
 <pre><code><b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: account};
-<a name="0x1_TreasuryComplianceScripts_account_addr$12"></a>
 <b>let</b> account_addr = <a href="_spec_address_of">Signer::spec_address_of</a>(account);
-<a name="0x1_TreasuryComplianceScripts_cap$13"></a>
 <b>let</b> cap = <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_spec_get_withdraw_cap">DiemAccount::spec_get_withdraw_cap</a>(account_addr);
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_ExtractWithdrawCapAbortsIf">DiemAccount::ExtractWithdrawCapAbortsIf</a>{sender_addr: account_addr};
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_PreburnAbortsIf">DiemAccount::PreburnAbortsIf</a>&lt;Token&gt;{dd: account, cap: cap};
@@ -4624,7 +4600,6 @@ is given by <code>new_exchange_rate_numerator/new_exchange_rate_denominator</cod
        numerator: new_exchange_rate_numerator,
        denominator: new_exchange_rate_denominator
 };
-<a name="0x1_TreasuryComplianceScripts_rate$14"></a>
 <b>let</b> rate = <a href="_spec_create_from_rational">FixedPoint32::spec_create_from_rational</a>(
         new_exchange_rate_numerator,
         new_exchange_rate_denominator

--- a/language/diem-framework/script_documentation/script_documentation.md
+++ b/language/diem-framework/script_documentation/script_documentation.md
@@ -837,9 +837,7 @@ This is emitted on the new Child VASPS's <code><a href="../../../../../releases/
 
 
 <pre><code><b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: parent_vasp};
-<a name="0x1_AccountCreationScripts_parent_addr$5"></a>
 <b>let</b> parent_addr = <a href="_spec_address_of">Signer::spec_address_of</a>(parent_vasp);
-<a name="0x1_AccountCreationScripts_parent_cap$6"></a>
 <b>let</b> parent_cap = <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_spec_get_withdraw_cap">DiemAccount::spec_get_withdraw_cap</a>(parent_addr);
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_CreateChildVASPAccountAbortsIf">DiemAccount::CreateChildVASPAccountAbortsIf</a>&lt;CoinType&gt;{
     parent: parent_vasp, new_account_address: child_address};
@@ -1688,15 +1686,13 @@ resource stored under the account at <code>recovery_address</code>.
 <pre><code><b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: to_recover_account};
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityAbortsIf">DiemAccount::ExtractKeyRotationCapabilityAbortsIf</a>{account: to_recover_account};
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityEnsures">DiemAccount::ExtractKeyRotationCapabilityEnsures</a>{account: to_recover_account};
-<a name="0x1_AccountAdministrationScripts_addr$10"></a>
 <b>let</b> addr = <a href="_spec_address_of">Signer::spec_address_of</a>(to_recover_account);
-<a name="0x1_AccountAdministrationScripts_rotation_cap$11"></a>
 <b>let</b> rotation_cap = <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_spec_get_key_rotation_cap">DiemAccount::spec_get_key_rotation_cap</a>(addr);
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/RecoveryAddress.md#0x1_RecoveryAddress_AddRotationCapabilityAbortsIf">RecoveryAddress::AddRotationCapabilityAbortsIf</a>{
     to_recover: rotation_cap
 };
 <b>ensures</b> <a href="../../../../../releases/artifacts/current/docs/modules/RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">RecoveryAddress::spec_get_rotation_caps</a>(recovery_address)[
-    len(<a href="../../../../../releases/artifacts/current/docs/modules/RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">RecoveryAddress::spec_get_rotation_caps</a>(recovery_address)) - 1] == <b>old</b>(rotation_cap);
+    len(<a href="../../../../../releases/artifacts/current/docs/modules/RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">RecoveryAddress::spec_get_rotation_caps</a>(recovery_address)) - 1] == rotation_cap;
 <b>aborts_with</b> [check]
     <a href="_INVALID_STATE">Errors::INVALID_STATE</a>,
     <a href="_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>,
@@ -1874,10 +1870,8 @@ and <code>account</code> must not have previously delegated its <code><a href=".
 
 
 <pre><code><b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: account};
-<a name="0x1_AccountAdministrationScripts_account_addr$12"></a>
 <b>let</b> account_addr = <a href="_spec_address_of">Signer::spec_address_of</a>(account);
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityAbortsIf">DiemAccount::ExtractKeyRotationCapabilityAbortsIf</a>;
-<a name="0x1_AccountAdministrationScripts_key_rotation_capability$13"></a>
 <b>let</b> key_rotation_capability = <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_spec_get_key_rotation_cap">DiemAccount::spec_get_key_rotation_cap</a>(account_addr);
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_RotateAuthenticationKeyAbortsIf">DiemAccount::RotateAuthenticationKeyAbortsIf</a>{cap: key_rotation_capability, new_authentication_key: new_key};
 </code></pre>
@@ -1990,11 +1984,9 @@ and <code>account</code> must not have previously delegated its <code><a href=".
 
 
 <pre><code><b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: account};
-<a name="0x1_AccountAdministrationScripts_account_addr$14"></a>
 <b>let</b> account_addr = <a href="_spec_address_of">Signer::spec_address_of</a>(account);
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/SlidingNonce.md#0x1_SlidingNonce_RecordNonceAbortsIf">SlidingNonce::RecordNonceAbortsIf</a>{ seq_nonce: sliding_nonce };
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityAbortsIf">DiemAccount::ExtractKeyRotationCapabilityAbortsIf</a>;
-<a name="0x1_AccountAdministrationScripts_key_rotation_capability$15"></a>
 <b>let</b> key_rotation_capability = <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_spec_get_key_rotation_cap">DiemAccount::spec_get_key_rotation_cap</a>(account_addr);
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_RotateAuthenticationKeyAbortsIf">DiemAccount::RotateAuthenticationKeyAbortsIf</a>{cap: key_rotation_capability, new_authentication_key: new_key};
 </code></pre>
@@ -2108,11 +2100,9 @@ and <code>account</code> must not have previously delegated its <code><a href=".
 
 
 <pre><code><b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: account};
-<a name="0x1_AccountAdministrationScripts_account_addr$16"></a>
 <b>let</b> account_addr = <a href="_spec_address_of">Signer::spec_address_of</a>(account);
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/SlidingNonce.md#0x1_SlidingNonce_RecordNonceAbortsIf">SlidingNonce::RecordNonceAbortsIf</a>{ account: dr_account, seq_nonce: sliding_nonce };
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityAbortsIf">DiemAccount::ExtractKeyRotationCapabilityAbortsIf</a>;
-<a name="0x1_AccountAdministrationScripts_key_rotation_capability$17"></a>
 <b>let</b> key_rotation_capability = <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_spec_get_key_rotation_cap">DiemAccount::spec_get_key_rotation_cap</a>(account_addr);
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_RotateAuthenticationKeyAbortsIf">DiemAccount::RotateAuthenticationKeyAbortsIf</a>{cap: key_rotation_capability, new_authentication_key: new_key};
 </code></pre>
@@ -2249,9 +2239,6 @@ This transaction can be sent either by the <code>to_recover</code> account, or b
 The delegatee at the recovery address has to hold the key rotation capability for
 the address to recover. The address of the transaction signer has to be either
 the delegatee's address or the address to recover [[H18]][PERMISSION][[J18]][PERMISSION].
-
-
-<a name="0x1_AccountAdministrationScripts_account_addr$18"></a>
 
 
 <pre><code><b>let</b> account_addr = <a href="_spec_address_of">Signer::spec_address_of</a>(account);
@@ -2547,9 +2534,7 @@ may be used as a recovery account for those accounts.
 <pre><code><b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: account};
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityAbortsIf">DiemAccount::ExtractKeyRotationCapabilityAbortsIf</a>;
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_ExtractKeyRotationCapabilityEnsures">DiemAccount::ExtractKeyRotationCapabilityEnsures</a>;
-<a name="0x1_AccountAdministrationScripts_account_addr$19"></a>
 <b>let</b> account_addr = <a href="_spec_address_of">Signer::spec_address_of</a>(account);
-<a name="0x1_AccountAdministrationScripts_rotation_cap$20"></a>
 <b>let</b> rotation_cap = <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_spec_get_key_rotation_cap">DiemAccount::spec_get_key_rotation_cap</a>(account_addr);
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/RecoveryAddress.md#0x1_RecoveryAddress_PublishAbortsIf">RecoveryAddress::PublishAbortsIf</a>{
     recovery_account: account,
@@ -2557,7 +2542,7 @@ may be used as a recovery account for those accounts.
 };
 <b>ensures</b> <a href="../../../../../releases/artifacts/current/docs/modules/RecoveryAddress.md#0x1_RecoveryAddress_spec_is_recovery_address">RecoveryAddress::spec_is_recovery_address</a>(account_addr);
 <b>ensures</b> len(<a href="../../../../../releases/artifacts/current/docs/modules/RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">RecoveryAddress::spec_get_rotation_caps</a>(account_addr)) == 1;
-<b>ensures</b> <a href="../../../../../releases/artifacts/current/docs/modules/RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">RecoveryAddress::spec_get_rotation_caps</a>(account_addr)[0] == <b>old</b>(rotation_cap);
+<b>ensures</b> <a href="../../../../../releases/artifacts/current/docs/modules/RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">RecoveryAddress::spec_get_rotation_caps</a>(account_addr)[0] == rotation_cap;
 <b>aborts_with</b> [check]
     <a href="_INVALID_STATE">Errors::INVALID_STATE</a>,
     <a href="_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>,
@@ -2708,9 +2693,7 @@ Successful execution of this script emits two events:
 
 
 <pre><code><b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: payer};
-<a name="0x1_PaymentScripts_payer_addr$1"></a>
 <b>let</b> payer_addr = <a href="_spec_address_of">Signer::spec_address_of</a>(payer);
-<a name="0x1_PaymentScripts_cap$2"></a>
 <b>let</b> cap = <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_spec_get_withdraw_cap">DiemAccount::spec_get_withdraw_cap</a>(payer_addr);
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_ExtractWithdrawCapAbortsIf">DiemAccount::ExtractWithdrawCapAbortsIf</a>{sender_addr: payer_addr};
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_PayFromAbortsIf">DiemAccount::PayFromAbortsIf</a>&lt;Currency&gt;{cap: cap};
@@ -3292,7 +3275,6 @@ on-chain with the updated <code><a href="../../../../../releases/artifacts/curre
 };
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/ValidatorConfig.md#0x1_ValidatorConfig_SetConfigAbortsIf">ValidatorConfig::SetConfigAbortsIf</a>{validator_addr: validator_account};
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemSystem.md#0x1_DiemSystem_UpdateConfigAndReconfigureAbortsIf">DiemSystem::UpdateConfigAndReconfigureAbortsIf</a>{validator_addr: validator_account};
-<a name="0x1_ValidatorAdministrationScripts_is_validator_info_updated$6"></a>
 <b>let</b> is_validator_info_updated =
     (<b>exists</b> v_info in <a href="../../../../../releases/artifacts/current/docs/modules/DiemSystem.md#0x1_DiemSystem_spec_get_validators">DiemSystem::spec_get_validators</a>():
         v_info.addr == validator_account
@@ -3423,9 +3405,6 @@ resource published under it. The sending <code>account</code> must be a Validato
 <details>
 <summary>Specification</summary>
 
-
-
-<a name="0x1_ValidatorAdministrationScripts_account_addr$7"></a>
 
 
 <pre><code><b>let</b> account_addr = <a href="_address_of">Signer::address_of</a>(account);
@@ -3560,9 +3539,6 @@ the system is initiated by this script.
 <details>
 <summary>Specification</summary>
 
-
-
-<a name="0x1_ValidatorAdministrationScripts_account_addr$8"></a>
 
 
 <pre><code><b>let</b> account_addr = <a href="_address_of">Signer::address_of</a>(account);
@@ -3737,26 +3713,28 @@ being <code>preburn_address</code>.
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_CancelBurnAbortsIf">DiemAccount::CancelBurnAbortsIf</a>&lt;Token&gt;;
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/Diem.md#0x1_Diem_CancelBurnWithCapEnsures">Diem::CancelBurnWithCapEnsures</a>&lt;Token&gt;;
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_DepositEnsures">DiemAccount::DepositEnsures</a>&lt;Token&gt;{payee: preburn_address};
-<a name="0x1_TreasuryComplianceScripts_total_preburn_value$10"></a>
 <b>let</b> total_preburn_value = <b>global</b>&lt;<a href="../../../../../releases/artifacts/current/docs/modules/Diem.md#0x1_Diem_CurrencyInfo">Diem::CurrencyInfo</a>&lt;Token&gt;&gt;(
     <a href="../../../../../releases/artifacts/current/docs/modules/CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>()
 ).preburn_value;
-<a name="0x1_TreasuryComplianceScripts_balance_at_addr$11"></a>
+<b>let</b> post post_total_preburn_value = <b>global</b>&lt;<a href="../../../../../releases/artifacts/current/docs/modules/Diem.md#0x1_Diem_CurrencyInfo">Diem::CurrencyInfo</a>&lt;Token&gt;&gt;(
+    <a href="../../../../../releases/artifacts/current/docs/modules/CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>()
+).preburn_value;
 <b>let</b> balance_at_addr = <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_balance">DiemAccount::balance</a>&lt;Token&gt;(preburn_address);
+<b>let</b> post post_balance_at_addr = <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_balance">DiemAccount::balance</a>&lt;Token&gt;(preburn_address);
 </code></pre>
 
 
 The total value of preburn for <code>Token</code> should decrease by the preburned amount.
 
 
-<pre><code><b>ensures</b> total_preburn_value == <b>old</b>(total_preburn_value) - amount;
+<pre><code><b>ensures</b> post_total_preburn_value == total_preburn_value - amount;
 </code></pre>
 
 
 The balance of <code>Token</code> at <code>preburn_address</code> should increase by the preburned amount.
 
 
-<pre><code><b>ensures</b> balance_at_addr == <b>old</b>(balance_at_addr) + amount;
+<pre><code><b>ensures</b> post_balance_at_addr == balance_at_addr + amount;
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/Diem.md#0x1_Diem_CancelBurnWithCapEmits">Diem::CancelBurnWithCapEmits</a>&lt;Token&gt;;
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_DepositEmits">DiemAccount::DepositEmits</a>&lt;Token&gt;{
     payer: preburn_address,
@@ -4015,9 +3993,7 @@ handle with the <code>payee</code> and <code>payer</code> fields being <code>acc
 
 
 <pre><code><b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: account};
-<a name="0x1_TreasuryComplianceScripts_account_addr$12"></a>
 <b>let</b> account_addr = <a href="_spec_address_of">Signer::spec_address_of</a>(account);
-<a name="0x1_TreasuryComplianceScripts_cap$13"></a>
 <b>let</b> cap = <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_spec_get_withdraw_cap">DiemAccount::spec_get_withdraw_cap</a>(account_addr);
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_ExtractWithdrawCapAbortsIf">DiemAccount::ExtractWithdrawCapAbortsIf</a>{sender_addr: account_addr};
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_PreburnAbortsIf">DiemAccount::PreburnAbortsIf</a>&lt;Token&gt;{dd: account, cap: cap};
@@ -4624,7 +4600,6 @@ is given by <code>new_exchange_rate_numerator/new_exchange_rate_denominator</cod
        numerator: new_exchange_rate_numerator,
        denominator: new_exchange_rate_denominator
 };
-<a name="0x1_TreasuryComplianceScripts_rate$14"></a>
 <b>let</b> rate = <a href="_spec_create_from_rational">FixedPoint32::spec_create_from_rational</a>(
         new_exchange_rate_numerator,
         new_exchange_rate_denominator

--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -204,6 +204,7 @@ pub enum SpecBlockMember_ {
     },
     Let {
         name: Name,
+        post_state: bool,
         def: Exp,
     },
     Include {
@@ -838,8 +839,16 @@ impl AstDebug for SpecBlockMember_ {
                 w.write(": ");
                 type_.ast_debug(w);
             }
-            SpecBlockMember_::Let { name, def } => {
-                w.write(&format!("let {} = ", name));
+            SpecBlockMember_::Let {
+                name,
+                post_state,
+                def,
+            } => {
+                w.write(&format!(
+                    "let {}{} = ",
+                    if *post_state { "post " } else { "" },
+                    name
+                ));
                 def.ast_debug(w);
             }
             SpecBlockMember_::Include { properties: _, exp } => {

--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -1070,9 +1070,17 @@ fn spec_member(context: &mut Context, sp!(loc, pm): P::SpecBlockMember) -> E::Sp
                 type_: t,
             }
         }
-        PM::Let { name, def: pdef } => {
+        PM::Let {
+            name,
+            post_state: old,
+            def: pdef,
+        } => {
             let def = exp_(context, pdef);
-            EM::Let { name, def }
+            EM::Let {
+                name,
+                post_state: old,
+                def,
+            }
         }
         PM::Include {
             properties: pproperties,

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -331,6 +331,7 @@ pub enum SpecBlockMember_ {
     },
     Let {
         name: Name,
+        post_state: bool,
         def: Exp,
     },
     Include {
@@ -1289,8 +1290,16 @@ impl AstDebug for SpecBlockMember_ {
                 w.write(": ");
                 type_.ast_debug(w);
             }
-            SpecBlockMember_::Let { name, def } => {
-                w.write(&format!("let {} = ", name));
+            SpecBlockMember_::Let {
+                name,
+                post_state,
+                def,
+            } => {
+                w.write(&format!(
+                    "let {}{} = ",
+                    if *post_state { "post " } else { "" },
+                    name
+                ));
                 def.ast_debug(w);
             }
             SpecBlockMember_::Include { properties: _, exp } => {

--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -2390,10 +2390,16 @@ fn parse_spec_variable(tokens: &mut Lexer) -> Result<SpecBlockMember, Error> {
 }
 
 // Parse a specification let.
-//     SpecLet =  "let" <Identifier> "=" <Exp> ";"
+//     SpecLet =  "let" [ "post" ] <Identifier> "=" <Exp> ";"
 fn parse_spec_let(tokens: &mut Lexer) -> Result<SpecBlockMember, Error> {
     let start_loc = tokens.start_loc();
     tokens.advance()?;
+    let post_state = if tokens.peek() == Tok::IdentifierValue && tokens.content() == "post" {
+        tokens.advance()?;
+        true
+    } else {
+        false
+    };
     let name = parse_identifier(tokens)?;
     consume_token(tokens, Tok::Equal)?;
     let def = parse_exp(tokens)?;
@@ -2402,7 +2408,11 @@ fn parse_spec_let(tokens: &mut Lexer) -> Result<SpecBlockMember, Error> {
         tokens.file_name(),
         start_loc,
         tokens.previous_end_loc(),
-        SpecBlockMember_::Let { name, def },
+        SpecBlockMember_::Let {
+            name,
+            post_state,
+            def,
+        },
     ))
 }
 

--- a/language/move-model/src/builder/model_builder.rs
+++ b/language/move-model/src/builder/model_builder.rs
@@ -390,8 +390,8 @@ impl<'env> ModelBuilder<'env> {
 pub(crate) struct LocalVarEntry {
     pub loc: Loc,
     pub type_: Type,
-    // If this local is associated with an operation, this is set.
+    /// If this local is associated with an operation, this is set.
     pub operation: Option<Operation>,
-    // If this a temporary from Move code, this is it's index.
+    /// If this a temporary from Move code, this is it's index.
     pub temp_index: Option<usize>,
 }

--- a/language/move-model/src/lib.rs
+++ b/language/move-model/src/lib.rs
@@ -81,6 +81,7 @@ pub fn run_model_builder(
         let fsrc = &files[fname];
         env.add_source(fname, fsrc, dep_sources.contains(fname));
     }
+
     // Add any documentation comments found by the Move compiler to the env.
     for (fname, documentation) in comment_map {
         let file_id = env.get_file_id(fname).expect("file name defined");

--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -378,7 +378,13 @@ impl<Id: Clone> QualifiedInstId<Id> {
 
     pub fn to_qualified_id(&self) -> QualifiedId<Id> {
         let Self { module_id, id, .. } = self;
-        module_id.qualified(id.clone())
+        module_id.qualified(id.to_owned())
+    }
+}
+
+impl QualifiedInstId<StructId> {
+    pub fn to_type(&self) -> Type {
+        Type::Struct(self.module_id, self.id, self.inst.to_owned())
     }
 }
 
@@ -489,8 +495,8 @@ pub struct GlobalEnv {
 
 /// Struct a helper type for implementing fmt::Display depending on GlobalEnv
 pub struct EnvDisplay<'a, T> {
-    env: &'a GlobalEnv,
-    val: &'a T,
+    pub env: &'a GlobalEnv,
+    pub val: &'a T,
 }
 
 impl GlobalEnv {
@@ -660,6 +666,23 @@ impl GlobalEnv {
         self.add_diag(diag);
     }
 
+    /// Adds a diagnostic of given severity to this environment, with secondary labels.
+    pub fn diag_with_labels(
+        &self,
+        severity: Severity,
+        loc: &Loc,
+        msg: &str,
+        labels: Vec<(Loc, String)>,
+    ) {
+        let mut diag = Diagnostic::new(severity, msg, Label::new(loc.file_id, loc.span, ""));
+        let labels = labels
+            .into_iter()
+            .map(|(l, m)| Label::new(l.file_id, l.span, m))
+            .collect_vec();
+        diag.secondary_labels = labels;
+        self.add_diag(diag);
+    }
+
     /// Checks whether any of the diagnostics contains string.
     pub fn has_diag(&self, pattern: &str) -> bool {
         self.diags
@@ -799,6 +822,7 @@ impl GlobalEnv {
 
     /// Writes accumulated diagnostics of given or higher severity.
     pub fn report_diag<W: WriteColor>(&self, writer: &mut W, severity: Severity) {
+        let mut shown = BTreeSet::new();
         for (diag, reported) in self
             .diags
             .borrow_mut()
@@ -806,8 +830,12 @@ impl GlobalEnv {
             .filter(|(d, _)| d.severity >= severity)
         {
             if !*reported {
-                emit(writer, &Config::default(), &self.source_files, diag)
-                    .expect("emit must not fail");
+                // Avoid showing the same message twice. This can happen e.g. because of
+                // duplication of expressions via schema inclusion.
+                if shown.insert(format!("{:?}", diag)) {
+                    emit(writer, &Config::default(), &self.source_files, diag)
+                        .expect("emit must not fail");
+                }
                 *reported = true;
             }
         }

--- a/language/move-model/src/ty.rs
+++ b/language/move-model/src/ty.rs
@@ -721,9 +721,10 @@ impl Substitution {
             } else {
                 // It is not clear to me whether this can ever occur given we do no global
                 // unification with recursion, but to be on the save side, we have it.
-                Err(TypeError::new(
-                    "[internal] type unification cycle check failed. Try to annotate types.",
-                ))
+                Err(TypeError::new(&format!(
+                    "[internal] type unification cycle check failed ({:?} =?= {:?})",
+                    t1, t2
+                )))
             }
         } else {
             Ok(None)

--- a/language/move-model/tests/sources/invariants_err.exp
+++ b/language/move-model/tests/sources/invariants_err.exp
@@ -14,6 +14,20 @@ error: `old(..)` expression not allowed in this context
     │               ^^^^^^
     │
 
+error: invalid reference to post state
+
+    ┌── tests/sources/invariants_err.move:11:5 ───
+    │
+ 11 │     invariant old(x) > 0;
+    │     ^^^^^^^^^^^^^^^^^^^^^
+    ·
+ 11 │     invariant old(x) > 0;
+    │     --------------------- not allowed to refer to post state
+    ·
+ 11 │     invariant old(x) > 0;
+    │               ------ expression referring to post state
+    │
+
 error: data invariants cannot depend on global state (directly or indirectly uses a global spec var or resource storage).
 
     ┌── tests/sources/invariants_err.move:13:5 ───

--- a/language/move-model/tests/sources/lets_err.exp
+++ b/language/move-model/tests/sources/lets_err.exp
@@ -1,0 +1,49 @@
+error: undeclared `M::one`
+
+   ┌── tests/sources/lets_err.move:6:16 ───
+   │
+ 6 │     let zero = one;
+   │                ^^^
+   │
+
+error: let bound `new_a` propagated via schema inclusion is referring to post state
+
+    ┌── tests/sources/lets_err.move:22:5 ───
+    │
+ 22 │     include Ensures{actual: a, expected: new_a + sum - sum};
+    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ·
+ 28 │     let a = expected;
+    │     ----------------- not allowed to use post state
+    ·
+ 21 │     let post new_a = old(a) / sum;
+    │                      ------------ let defined here
+    │
+
+error: invalid reference to post state
+
+    ┌── tests/sources/lets_err.move:43:5 ───
+    │
+ 43 │     include Requires{a: result};
+    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ·
+ 48 │     requires a != 0;
+    │     ---------------- not allowed to refer to post state
+    ·
+ 43 │     include Requires{a: result};
+    │                         ------ expression referring to post state
+    │
+
+error: invalid reference to post state
+
+    ┌── tests/sources/lets_err.move:44:5 ───
+    │
+ 44 │     include Requires{a: old(x)};
+    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ·
+ 48 │     requires a != 0;
+    │     ---------------- not allowed to refer to post state
+    ·
+ 44 │     include Requires{a: old(x)};
+    │                         ------ expression referring to post state
+    │

--- a/language/move-model/tests/sources/lets_err.move
+++ b/language/move-model/tests/sources/lets_err.move
@@ -1,0 +1,50 @@
+module 0x42::M {
+
+  fun foo(x: &mut u64): u64 { *x = *x + 1; *x }
+
+  spec fun foo {
+    let zero = one;
+    ensures result == old(x) + 1;
+  }
+
+  fun spec_let_with_schema(a: &mut u64, b: &mut u64) {
+    let saved_a = *a;
+    *a = *a / (*a + *b);
+    *b = saved_a * *b;
+  }
+  spec fun spec_let_with_schema {
+    let sum = a + b;
+    let product = a * b;
+    aborts_if sum == 0;
+    aborts_if sum > MAX_U64;
+    aborts_if product > MAX_U64;
+    let post new_a = old(a) / sum;
+    include Ensures{actual: a, expected: new_a + sum - sum};
+    include Ensures{actual: b, expected: product};
+  }
+  spec schema Ensures {
+    actual: u64;
+    expected: u64;
+    let a = expected;
+    let b = actual;
+    include Ensures2{a: a, b: b};
+  }
+  spec schema Ensures2 {
+    a: u64;
+    b: u64;
+    ensures a == b;
+  }
+
+  fun result_with_schema(x: &mut u64): u64 {
+    *x = 2;
+    *x
+  }
+  spec fun result_with_schema {
+    include Requires{a: result};
+    include Requires{a: old(x)};
+  }
+  spec schema Requires {
+    a: u64;
+    requires a != 0;
+  }
+}

--- a/language/move-model/tests/sources/lets_ok.exp
+++ b/language/move-model/tests/sources/lets_ok.exp
@@ -1,0 +1,1 @@
+All good, no errors!

--- a/language/move-model/tests/sources/lets_ok.move
+++ b/language/move-model/tests/sources/lets_ok.move
@@ -1,0 +1,10 @@
+module 0x42::M {
+
+  fun foo(x: &mut u64): u64 { *x = *x + 1; *x }
+
+  spec fun foo {
+    let zero = 0;
+    let one = zero + 1;
+    ensures result == old(x) + one;
+  }
+}

--- a/language/move-prover/Cargo.toml
+++ b/language/move-prover/Cargo.toml
@@ -22,6 +22,7 @@ move-ir-types = { path = "../move-ir/types" }
 # external dependencies
 async-trait = "0.1.42"
 anyhow = "1.0.38"
+atty = "0.2.14"
 clap = "2.33.3"
 codespan = "0.8.0"
 codespan-reporting = "0.8.0"

--- a/language/move-prover/boogie-backend/src/boogie_helpers.rs
+++ b/language/move-prover/boogie-backend/src/boogie_helpers.rs
@@ -175,7 +175,7 @@ pub fn boogie_temp(env: &GlobalEnv, ty: &Type, instance: usize) -> String {
 }
 
 pub fn boogie_temp_from_suffix(_env: &GlobalEnv, suffix: &str, instance: usize) -> String {
-    format!("$temp_{}{}", instance, suffix)
+    format!("$temp_{}'{}'", instance, suffix)
 }
 
 /// Returns the suffix to specialize a name for the given type instance.

--- a/language/move-prover/boogie-backend/src/spec_translator.rs
+++ b/language/move-prover/boogie-backend/src/spec_translator.rs
@@ -1269,7 +1269,10 @@ impl<'env> SpecTranslator<'env> {
         // a more efficient representation of equality between $Mutation objects. Otherwise
         // we translate it the default way with automatic reference removal.
         match (&args[0], &args[1]) {
-            (Temporary(_, idx1), Temporary(_, idx2)) => {
+            (Temporary(id1, idx1), Temporary(id2, idx2))
+                if self.get_node_type(*id1).is_reference()
+                    && self.get_node_type(*id2).is_reference() =>
+            {
                 emit!(self.writer, "$t{} == $t{}", idx1, idx2);
             }
             _ => self.translate_rel_op("==", args),

--- a/language/move-prover/bytecode/src/global_invariant_instrumentation.rs
+++ b/language/move-prover/bytecode/src/global_invariant_instrumentation.rs
@@ -82,7 +82,7 @@ impl FunctionTargetProcessor for GlobalInvariantInstrumentationProcessor {
 }
 
 struct Instrumenter<'a> {
-    _options: &'a ProverOptions,
+    options: &'a ProverOptions,
     builder: FunctionDataBuilder<'a>,
 }
 
@@ -93,10 +93,7 @@ impl<'a> Instrumenter<'a> {
         data: FunctionData,
     ) -> FunctionData {
         let builder = FunctionDataBuilder::new(fun_env, data);
-        let mut instrumenter = Instrumenter {
-            _options: options,
-            builder,
-        };
+        let mut instrumenter = Instrumenter { options, builder };
         instrumenter.instrument();
         instrumenter.builder.data
     }
@@ -141,6 +138,7 @@ impl<'a> Instrumenter<'a> {
         let mut assumed_at_update = BTreeSet::new();
         let module_env = &self.builder.fun_env.module_env;
         let mut translated = SpecTranslator::translate_invariants(
+            self.options.auto_trace_level.invariants(),
             &mut self.builder,
             invariants.iter().filter_map(|id| {
                 env.get_global_invariant(*id).filter(|inv| {
@@ -208,8 +206,11 @@ impl<'a> Instrumenter<'a> {
         // Translate the invariants, computing any state to be saved as well. State saves are
         // necessary for update invariants which contain the `old(..)` expressions.
         let invariants = self.get_verified_invariants_for_mem(mem);
-        let mut translated =
-            SpecTranslator::translate_invariants(&mut self.builder, invariants.iter().cloned());
+        let mut translated = SpecTranslator::translate_invariants(
+            self.options.auto_trace_level.invariants(),
+            &mut self.builder,
+            invariants.iter().cloned(),
+        );
 
         // Emit all necessary state saves for 'update' invariants.
         self.builder

--- a/language/move-prover/bytecode/src/options.rs
+++ b/language/move-prover/bytecode/src/options.rs
@@ -6,6 +6,28 @@ use move_model::model::{GlobalEnv, VerificationScope};
 use serde::{Deserialize, Serialize};
 use std::rc::Rc;
 
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+pub enum AutoTraceLevel {
+    Off,
+    VerifiedFunction,
+    AllFunctions,
+}
+
+impl AutoTraceLevel {
+    pub fn verified_functions(self) -> bool {
+        use AutoTraceLevel::*;
+        matches!(self, VerifiedFunction | AllFunctions)
+    }
+    pub fn functions(self) -> bool {
+        use AutoTraceLevel::*;
+        matches!(self, AllFunctions)
+    }
+    pub fn invariants(self) -> bool {
+        use AutoTraceLevel::*;
+        matches!(self, VerifiedFunction | AllFunctions)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct ProverOptions {
@@ -33,8 +55,8 @@ pub struct ProverOptions {
     pub assume_invariant_on_access: bool,
     /// Whether pack/unpack should recurse over the structure.
     pub deep_pack_unpack: bool,
-    /// Whether to automatically debug trace values of specification expression leafs.
-    pub debug_trace: bool,
+    /// Auto trace level.
+    pub auto_trace_level: AutoTraceLevel,
     /// Minimal severity level for diagnostics to be reported.
     pub report_severity: Severity,
     /// Whether to dump the transformed stackless bytecode to a file
@@ -67,8 +89,8 @@ impl Default for ProverOptions {
             resource_wellformed_axiom: false,
             assume_wellformed_on_access: false,
             deep_pack_unpack: false,
-            debug_trace: false,
-            report_severity: Severity::Error,
+            auto_trace_level: AutoTraceLevel::Off,
+            report_severity: Severity::Warning,
             assume_invariant_on_access: false,
             dump_bytecode: false,
             dump_cfg: false,

--- a/language/move-prover/bytecode/tests/spec_instrumentation/fun_spec.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/fun_spec.exp
@@ -345,40 +345,139 @@ fun Test::resource_with_old($t0|val: u64) {
   0: assume WellFormed($t0)
   1: assume forall $rsc: ResourceDomain<Test::R>(): WellFormed($rsc)
   2: assume Gt($t0, 0)
-  3: @0 := save_mem(Test::R)
-  4: $t2 := 0x0
-  5: $t3 := exists<Test::R>($t2)
-  6: $t4 := !($t3)
-  7: if ($t4) goto 10 else goto 8
-  8: label L1
-  9: goto 14
- 10: label L0
- 11: $t5 := 33
- 12: $t6 := move($t5)
- 13: goto 29
- 14: label L2
- 15: $t7 := 0x0
+  3: assume CanModify<Test::R>(0)
+  4: @0 := save_mem(Test::R)
+  5: $t2 := 0x0
+  6: $t3 := exists<Test::R>($t2)
+  7: $t4 := !($t3)
+  8: if ($t4) goto 11 else goto 9
+  9: label L1
+ 10: goto 15
+ 11: label L0
+ 12: $t5 := 33
+ 13: $t6 := move($t5)
+ 14: goto 30
+ 15: label L2
+ 16: $t7 := 0x0
      # VC: caller does not have permission to modify `Test::R` at given address at tests/spec_instrumentation/fun_spec.move:36:14+17
- 16: assert CanModify<Test::R>($t7)
- 17: $t8 := borrow_global<Test::R>($t7) on_abort goto 29 with $t6
- 18: $t9 := get_field<Test::R>.v($t8)
- 19: $t10 := +($t9, $t0) on_abort goto 29 with $t6
- 20: $t11 := borrow_field<Test::R>.v($t8)
- 21: write_ref($t11, $t10)
- 22: write_back[Reference($t8).0]($t11)
- 23: write_back[Test::R.D]($t8)
- 24: label L3
+ 17: assert CanModify<Test::R>($t7)
+ 18: $t8 := borrow_global<Test::R>($t7) on_abort goto 30 with $t6
+ 19: $t9 := get_field<Test::R>.v($t8)
+ 20: $t10 := +($t9, $t0) on_abort goto 30 with $t6
+ 21: $t11 := borrow_field<Test::R>.v($t8)
+ 22: write_ref($t11, $t10)
+ 23: write_back[Reference($t8).0]($t11)
+ 24: write_back[Test::R.D]($t8)
+ 25: label L3
      # VC: function does not abort under this condition at tests/spec_instrumentation/fun_spec.move:41:6+35
- 25: assert Not(Not(exists[@0]<Test::R>(0)))
+ 26: assert Not(Not(exists[@0]<Test::R>(0)))
      # VC: function does not abort under this condition at tests/spec_instrumentation/fun_spec.move:42:6+58
- 26: assert Not(Ge(Add(select Test::R.v(global[@0]<Test::R>(0)), $t0), 18446744073709551615))
+ 27: assert Not(Ge(Add(select Test::R.v(global[@0]<Test::R>(0)), $t0), 18446744073709551615))
      # VC: post-condition does not hold at tests/spec_instrumentation/fun_spec.move:43:6+58
- 27: assert Eq<u64>(select Test::R.v(global<Test::R>(0)), Add(select Test::R.v(global[@0]<Test::R>(0)), $t0))
- 28: return ()
- 29: label L4
+ 28: assert Eq<u64>(select Test::R.v(global<Test::R>(0)), Add(select Test::R.v(global[@0]<Test::R>(0)), $t0))
+ 29: return ()
+ 30: label L4
      # VC: abort not covered by any of the `aborts_if` clauses at tests/spec_instrumentation/fun_spec.move:39:2+254
- 30: assert Or(Not(exists[@0]<Test::R>(0)), Ge(Add(select Test::R.v(global[@0]<Test::R>(0)), $t0), 18446744073709551615))
+ 31: assert Or(Not(exists[@0]<Test::R>(0)), Ge(Add(select Test::R.v(global[@0]<Test::R>(0)), $t0), 18446744073709551615))
      # VC: abort code not covered by any of the `aborts_if` or `aborts_with` clauses at tests/spec_instrumentation/fun_spec.move:39:2+254
- 31: assert Or(And(Not(exists[@0]<Test::R>(0)), Eq(33, $t6)), Ge(Add(select Test::R.v(global[@0]<Test::R>(0)), $t0), 18446744073709551615))
- 32: abort($t6)
+ 32: assert Or(And(Not(exists[@0]<Test::R>(0)), Eq(33, $t6)), Ge(Add(select Test::R.v(global[@0]<Test::R>(0)), $t0), 18446744073709551615))
+ 33: abort($t6)
+}
+
+
+
+==== spec-instrumenter input specs ====
+
+fun Test::branching_result[baseline[
+spec {
+  aborts_if And($t0, Eq<u64>($t2, 0));
+  ensures Implies($t0, Eq<u64>(result0(), Div($t1, $t2)));
+  ensures Implies(Not($t0), Eq<u64>(result0(), Mul($t1, $t2)));
+}
+
+fun Test::branching_result[verification[
+spec {
+  aborts_if And($t0, Eq<u64>($t2, 0));
+  ensures Implies($t0, Eq<u64>(result0(), Div($t1, $t2)));
+  ensures Implies(Not($t0), Eq<u64>(result0(), Mul($t1, $t2)));
+}
+
+fun Test::implicit_and_explicit_abort[baseline[
+spec {
+  aborts_if Eq<u64>($t1, 0);
+  aborts_if Eq<u64>($t0, 0);
+  ensures Eq<u64>(result0(), Div($t0, $t1));
+}
+
+fun Test::implicit_and_explicit_abort[verification[
+spec {
+  aborts_if Eq<u64>($t1, 0);
+  aborts_if Eq<u64>($t0, 0);
+  ensures Eq<u64>(result0(), Div($t0, $t1));
+}
+
+fun Test::multiple_results[baseline[
+spec {
+  aborts_if Eq<u64>($t1, 0);
+  ensures Eq<u64>(result0(), Div($t0, $t1));
+  ensures Eq<u64>(result1(), Mod($t0, $t1));
+}
+
+fun Test::multiple_results[verification[
+spec {
+  aborts_if Eq<u64>($t1, 0);
+  ensures Eq<u64>(result0(), Div($t0, $t1));
+  ensures Eq<u64>(result1(), Mod($t0, $t1));
+}
+
+fun Test::mut_ref_param[baseline[
+spec {
+  aborts_if Eq<u64>(select Test::R.v($t0), 0);
+  ensures Eq<u64>(result0(), Old<u64>(select Test::R.v($t0)));
+  ensures Eq<u64>(select Test::R.v($t0), Add(Old<u64>(select Test::R.v($t0)), 1));
+}
+
+fun Test::mut_ref_param[verification[
+spec {
+  aborts_if Eq<u64>(select Test::R.v($t0), 0);
+  ensures Eq<u64>(result0(), Old<u64>(select Test::R.v($t0)));
+  ensures Eq<u64>(select Test::R.v($t0), Add(Old<u64>(select Test::R.v($t0)), 1));
+}
+
+fun Test::ref_param[baseline[
+spec {
+  ensures Eq<u64>(result0(), select Test::R.v($t0));
+}
+
+fun Test::ref_param[verification[
+spec {
+  ensures Eq<u64>(result0(), select Test::R.v($t0));
+}
+
+fun Test::ref_param_return_ref[baseline[
+spec {
+  ensures Eq<u64>(result0(), select Test::R.v($t0));
+}
+
+fun Test::ref_param_return_ref[verification[
+spec {
+  ensures Eq<u64>(result0(), select Test::R.v($t0));
+}
+
+fun Test::resource_with_old[baseline[
+spec {
+  requires Gt($t0, 0);
+  aborts_if Not(exists<Test::R>(0));
+  aborts_if Ge(Add(select Test::R.v(global<Test::R>(0)), $t0), 18446744073709551615);
+  ensures Eq<u64>(select Test::R.v(global<Test::R>(0)), Add(select Test::R.v(Old<Test::R>(global<Test::R>(0))), $t0));
+  modifies global<Test::R>(0);
+}
+
+fun Test::resource_with_old[verification[
+spec {
+  requires Gt($t0, 0);
+  aborts_if Not(exists<Test::R>(0));
+  aborts_if Ge(Add(select Test::R.v(global<Test::R>(0)), $t0), 18446744073709551615);
+  ensures Eq<u64>(select Test::R.v(global<Test::R>(0)), Add(select Test::R.v(Old<Test::R>(global<Test::R>(0))), $t0));
+  modifies global<Test::R>(0);
 }

--- a/language/move-prover/bytecode/tests/spec_instrumentation/generics.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/generics.exp
@@ -27,15 +27,16 @@ fun Generics::remove<$tv0>($t0|a: address): Generics::R<#0> {
      var $t2: num
   0: assume WellFormed($t0)
   1: assume forall $rsc: ResourceDomain<Generics::R<#0>>(): WellFormed($rsc)
+  2: assume CanModify<Generics::R<#0>>($t0)
      # VC: caller does not have permission to modify `Generics::R<#0>` at given address at tests/spec_instrumentation/generics.move:11:9+9
-  2: assert CanModify<Generics::R<#0>>($t0)
-  3: $t1 := move_from<Generics::R<#0>>($t0) on_abort goto 7 with $t2
-  4: label L1
+  3: assert CanModify<Generics::R<#0>>($t0)
+  4: $t1 := move_from<Generics::R<#0>>($t0) on_abort goto 8 with $t2
+  5: label L1
      # VC: post-condition does not hold at tests/spec_instrumentation/generics.move:20:9+25
-  5: assert Not(exists<Generics::R<#0>>($t0))
-  6: return $t1
-  7: label L2
-  8: abort($t2)
+  6: assert Not(exists<Generics::R<#0>>($t0))
+  7: return $t1
+  8: label L2
+  9: abort($t2)
 }
 
 
@@ -46,25 +47,54 @@ fun Generics::remove_u64($t0|a: address): Generics::R<u64> {
      var $t3: Generics::R<u64>
   0: assume WellFormed($t0)
   1: assume forall $rsc: ResourceDomain<Generics::R<u64>>(): WellFormed($rsc)
+  2: assume CanModify<Generics::R<u64>>($t0)
      # >> opaque call: $t1 := Generics::remove<u64>($t0)
-  2: nop
+  3: nop
      # VC: caller does not have permission to modify `Generics::R<u64>` at given address at tests/spec_instrumentation/generics.move:24:9+14
-  3: assert CanModify<Generics::R<u64>>($t0)
-  4: havoc[val]($t1)
-  5: if ($t1) goto 6 else goto 9
-  6: label L4
-  7: trace_abort($t2)
-  8: goto 17
-  9: label L3
- 10: modifies global<Generics::R<u64>>($t0)
- 11: assume WellFormed($t3)
- 12: assume Not(exists<Generics::R<u64>>($t0))
+  4: assert CanModify<Generics::R<u64>>($t0)
+  5: havoc[val]($t1)
+  6: if ($t1) goto 7 else goto 10
+  7: label L4
+  8: trace_abort($t2)
+  9: goto 18
+ 10: label L3
+ 11: modifies global<Generics::R<u64>>($t0)
+ 12: assume WellFormed($t3)
+ 13: assume Not(exists<Generics::R<u64>>($t0))
      # << opaque call: $t1 := Generics::remove<u64>($t0)
- 13: nop
- 14: label L1
+ 14: nop
+ 15: label L1
      # VC: post-condition does not hold at tests/spec_instrumentation/generics.move:20:9+25
- 15: assert Not(exists<Generics::R<u64>>($t0))
- 16: return $t3
- 17: label L2
- 18: abort($t2)
+ 16: assert Not(exists<Generics::R<u64>>($t0))
+ 17: return $t3
+ 18: label L2
+ 19: abort($t2)
+}
+
+
+
+==== spec-instrumenter input specs ====
+
+fun Generics::remove[baseline[
+spec {
+  modifies global<Generics::R<#0>>($t0);
+  ensures Not(exists<Generics::R<#0>>($t0));
+}
+
+fun Generics::remove[verification[
+spec {
+  modifies global<Generics::R<#0>>($t0);
+  ensures Not(exists<Generics::R<#0>>($t0));
+}
+
+fun Generics::remove_u64[baseline[
+spec {
+  modifies global<Generics::R<u64>>($t0);
+  ensures Not(exists<Generics::R<u64>>($t0));
+}
+
+fun Generics::remove_u64[verification[
+spec {
+  modifies global<Generics::R<u64>>($t0);
+  ensures Not(exists<Generics::R<u64>>($t0));
 }

--- a/language/move-prover/bytecode/tests/spec_instrumentation/modifies.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/modifies.exp
@@ -176,25 +176,26 @@ public fun A::mutate_at($t0|addr: address) {
      var $t5: &mut u64
   0: assume WellFormed($t0)
   1: assume forall $rsc: ResourceDomain<A::S>(): WellFormed($rsc)
-  2: @1 := save_mem(A::S)
+  2: assume CanModify<A::S>($t0)
+  3: @1 := save_mem(A::S)
      # VC: caller does not have permission to modify `A::S` at given address at tests/spec_instrumentation/modifies.move:18:17+17
-  3: assert CanModify<A::S>($t0)
-  4: $t2 := borrow_global<A::S>($t0) on_abort goto 14 with $t3
-  5: $t4 := 2
-  6: $t5 := borrow_field<A::S>.x($t2)
-  7: write_ref($t5, $t4)
-  8: write_back[Reference($t2).0]($t5)
-  9: write_back[A::S.D]($t2)
- 10: label L1
+  4: assert CanModify<A::S>($t0)
+  5: $t2 := borrow_global<A::S>($t0) on_abort goto 15 with $t3
+  6: $t4 := 2
+  7: $t5 := borrow_field<A::S>.x($t2)
+  8: write_ref($t5, $t4)
+  9: write_back[Reference($t2).0]($t5)
+ 10: write_back[A::S.D]($t2)
+ 11: label L1
      # VC: function does not abort under this condition at tests/spec_instrumentation/modifies.move:24:9+27
- 11: assert Not(Not(exists[@1]<A::S>($t0)))
+ 12: assert Not(Not(exists[@1]<A::S>($t0)))
      # VC: post-condition does not hold at tests/spec_instrumentation/modifies.move:23:9+31
- 12: assert Eq<u64>(select A::S.x(global<A::S>($t0)), 2)
- 13: return ()
- 14: label L2
+ 13: assert Eq<u64>(select A::S.x(global<A::S>($t0)), 2)
+ 14: return ()
+ 15: label L2
      # VC: abort not covered by any of the `aborts_if` clauses at tests/spec_instrumentation/modifies.move:21:5+166
- 15: assert Not(exists[@1]<A::S>($t0))
- 16: abort($t3)
+ 16: assert Not(exists[@1]<A::S>($t0))
+ 17: abort($t3)
 }
 
 
@@ -237,38 +238,39 @@ public fun B::move_from_test_incorrect($t0|addr1: address, $t1|addr2: address): 
   1: assume WellFormed($t1)
   2: assume forall $rsc: ResourceDomain<A::S>(): WellFormed($rsc)
   3: assume forall $rsc: ResourceDomain<B::T>(): WellFormed($rsc)
+  4: assume CanModify<B::T>($t1)
      # >> opaque call: $t5 := A::read_at($t1)
-  4: nop
-  5: assume Identical($t5, Not(exists<A::S>($t1)))
-  6: if ($t5) goto 7 else goto 10
-  7: label L4
-  8: trace_abort($t6)
-  9: goto 29
- 10: label L3
- 11: assume WellFormed($t7)
- 12: assume Eq<u64>($t7, select A::S.x(global<A::S>($t1)))
+  5: nop
+  6: assume Identical($t5, Not(exists<A::S>($t1)))
+  7: if ($t5) goto 8 else goto 11
+  8: label L4
+  9: trace_abort($t6)
+ 10: goto 30
+ 11: label L3
+ 12: assume WellFormed($t7)
+ 13: assume Eq<u64>($t7, select A::S.x(global<A::S>($t1)))
      # << opaque call: $t5 := A::read_at($t1)
- 13: nop
+ 14: nop
      # VC: caller does not have permission to modify `B::T` at given address at tests/spec_instrumentation/modifies.move:65:17+9
- 14: assert CanModify<B::T>($t0)
- 15: $t8 := move_from<B::T>($t0) on_abort goto 29 with $t6
+ 15: assert CanModify<B::T>($t0)
+ 16: $t8 := move_from<B::T>($t0) on_abort goto 30 with $t6
      # >> opaque call: $t7 := A::read_at($t1)
- 16: nop
- 17: assume Identical($t9, Not(exists<A::S>($t1)))
- 18: if ($t9) goto 19 else goto 22
- 19: label L6
- 20: trace_abort($t6)
- 21: goto 29
- 22: label L5
- 23: assume WellFormed($t10)
- 24: assume Eq<u64>($t10, select A::S.x(global<A::S>($t1)))
+ 17: nop
+ 18: assume Identical($t9, Not(exists<A::S>($t1)))
+ 19: if ($t9) goto 20 else goto 23
+ 20: label L6
+ 21: trace_abort($t6)
+ 22: goto 30
+ 23: label L5
+ 24: assume WellFormed($t10)
+ 25: assume Eq<u64>($t10, select A::S.x(global<A::S>($t1)))
      # << opaque call: $t7 := A::read_at($t1)
- 25: nop
- 26: assert Eq<u64>($t7, $t10)
- 27: label L1
- 28: return $t8
- 29: label L2
- 30: abort($t6)
+ 26: nop
+ 27: assert Eq<u64>($t7, $t10)
+ 28: label L1
+ 29: return $t8
+ 30: label L2
+ 31: abort($t6)
 }
 
 
@@ -287,40 +289,41 @@ public fun B::move_to_test_incorrect($t0|account: signer, $t1|addr2: address) {
   1: assume WellFormed($t1)
   2: assume forall $rsc: ResourceDomain<A::S>(): WellFormed($rsc)
   3: assume forall $rsc: ResourceDomain<B::T>(): WellFormed($rsc)
+  4: assume CanModify<B::T>($t1)
      # >> opaque call: $t4 := A::read_at($t1)
-  4: nop
-  5: assume Identical($t4, Not(exists<A::S>($t1)))
-  6: if ($t4) goto 7 else goto 10
-  7: label L4
-  8: trace_abort($t5)
-  9: goto 31
- 10: label L3
- 11: assume WellFormed($t6)
- 12: assume Eq<u64>($t6, select A::S.x(global<A::S>($t1)))
+  5: nop
+  6: assume Identical($t4, Not(exists<A::S>($t1)))
+  7: if ($t4) goto 8 else goto 11
+  8: label L4
+  9: trace_abort($t5)
+ 10: goto 32
+ 11: label L3
+ 12: assume WellFormed($t6)
+ 13: assume Eq<u64>($t6, select A::S.x(global<A::S>($t1)))
      # << opaque call: $t4 := A::read_at($t1)
- 13: nop
- 14: $t7 := 2
- 15: $t8 := pack B::T($t7)
+ 14: nop
+ 15: $t7 := 2
+ 16: $t8 := pack B::T($t7)
      # VC: caller does not have permission to modify `B::T` at given address at tests/spec_instrumentation/modifies.move:52:9+7
- 16: assert CanModify<B::T>($t0)
- 17: move_to<B::T>($t8, $t0) on_abort goto 31 with $t5
+ 17: assert CanModify<B::T>($t0)
+ 18: move_to<B::T>($t8, $t0) on_abort goto 32 with $t5
      # >> opaque call: $t7 := A::read_at($t1)
- 18: nop
- 19: assume Identical($t9, Not(exists<A::S>($t1)))
- 20: if ($t9) goto 21 else goto 24
- 21: label L6
- 22: trace_abort($t5)
- 23: goto 31
- 24: label L5
- 25: assume WellFormed($t10)
- 26: assume Eq<u64>($t10, select A::S.x(global<A::S>($t1)))
+ 19: nop
+ 20: assume Identical($t9, Not(exists<A::S>($t1)))
+ 21: if ($t9) goto 22 else goto 25
+ 22: label L6
+ 23: trace_abort($t5)
+ 24: goto 32
+ 25: label L5
+ 26: assume WellFormed($t10)
+ 27: assume Eq<u64>($t10, select A::S.x(global<A::S>($t1)))
      # << opaque call: $t7 := A::read_at($t1)
- 27: nop
- 28: assert Eq<u64>($t6, $t10)
- 29: label L1
- 30: return ()
- 31: label L2
- 32: abort($t5)
+ 28: nop
+ 29: assert Eq<u64>($t6, $t10)
+ 30: label L1
+ 31: return ()
+ 32: label L2
+ 33: abort($t5)
 }
 
 
@@ -338,49 +341,50 @@ public fun B::mutate_S_test1_incorrect($t0|addr1: address, $t1|addr2: address) {
   1: assume WellFormed($t1)
   2: assume forall $rsc: ResourceDomain<A::S>(): WellFormed($rsc)
   3: assume Neq<address>($t0, $t1)
+  4: assume CanModify<A::S>($t1)
      # >> opaque call: $t4 := A::read_at($t1)
-  4: nop
-  5: assume Identical($t4, Not(exists<A::S>($t1)))
-  6: if ($t4) goto 7 else goto 10
-  7: label L4
-  8: trace_abort($t5)
-  9: goto 38
- 10: label L3
- 11: assume WellFormed($t6)
- 12: assume Eq<u64>($t6, select A::S.x(global<A::S>($t1)))
+  5: nop
+  6: assume Identical($t4, Not(exists<A::S>($t1)))
+  7: if ($t4) goto 8 else goto 11
+  8: label L4
+  9: trace_abort($t5)
+ 10: goto 39
+ 11: label L3
+ 12: assume WellFormed($t6)
+ 13: assume Eq<u64>($t6, select A::S.x(global<A::S>($t1)))
      # << opaque call: $t4 := A::read_at($t1)
- 13: nop
-     # >> opaque call: A::mutate_at($t0)
  14: nop
+     # >> opaque call: A::mutate_at($t0)
+ 15: nop
      # VC: caller does not have permission to modify `A::S` at given address at tests/spec_instrumentation/modifies.move:79:9+19
- 15: assert CanModify<A::S>($t0)
- 16: assume Identical($t7, Not(exists<A::S>($t0)))
- 17: if ($t7) goto 18 else goto 21
- 18: label L6
- 19: trace_abort($t5)
- 20: goto 38
- 21: label L5
- 22: modifies global<A::S>($t0)
- 23: assume Eq<u64>(select A::S.x(global<A::S>($t0)), 2)
+ 16: assert CanModify<A::S>($t0)
+ 17: assume Identical($t7, Not(exists<A::S>($t0)))
+ 18: if ($t7) goto 19 else goto 22
+ 19: label L6
+ 20: trace_abort($t5)
+ 21: goto 39
+ 22: label L5
+ 23: modifies global<A::S>($t0)
+ 24: assume Eq<u64>(select A::S.x(global<A::S>($t0)), 2)
      # << opaque call: A::mutate_at($t0)
- 24: nop
-     # >> opaque call: $t5 := A::read_at($t1)
  25: nop
- 26: assume Identical($t8, Not(exists<A::S>($t1)))
- 27: if ($t8) goto 28 else goto 31
- 28: label L8
- 29: trace_abort($t5)
- 30: goto 38
- 31: label L7
- 32: assume WellFormed($t9)
- 33: assume Eq<u64>($t9, select A::S.x(global<A::S>($t1)))
+     # >> opaque call: $t5 := A::read_at($t1)
+ 26: nop
+ 27: assume Identical($t8, Not(exists<A::S>($t1)))
+ 28: if ($t8) goto 29 else goto 32
+ 29: label L8
+ 30: trace_abort($t5)
+ 31: goto 39
+ 32: label L7
+ 33: assume WellFormed($t9)
+ 34: assume Eq<u64>($t9, select A::S.x(global<A::S>($t1)))
      # << opaque call: $t5 := A::read_at($t1)
- 34: nop
- 35: assert Eq<u64>($t6, $t9)
- 36: label L1
- 37: return ()
- 38: label L2
- 39: abort($t5)
+ 35: nop
+ 36: assert Eq<u64>($t6, $t9)
+ 37: label L1
+ 38: return ()
+ 39: label L2
+ 40: abort($t5)
 }
 
 
@@ -396,49 +400,50 @@ public fun B::mutate_S_test2_incorrect($t0|addr: address) {
      var $t8: u64
   0: assume WellFormed($t0)
   1: assume forall $rsc: ResourceDomain<A::S>(): WellFormed($rsc)
+  2: assume CanModify<A::S>($t0)
      # >> opaque call: $t3 := A::read_at($t0)
-  2: nop
-  3: assume Identical($t3, Not(exists<A::S>($t0)))
-  4: if ($t3) goto 5 else goto 8
-  5: label L4
-  6: trace_abort($t4)
-  7: goto 36
-  8: label L3
-  9: assume WellFormed($t5)
- 10: assume Eq<u64>($t5, select A::S.x(global<A::S>($t0)))
+  3: nop
+  4: assume Identical($t3, Not(exists<A::S>($t0)))
+  5: if ($t3) goto 6 else goto 9
+  6: label L4
+  7: trace_abort($t4)
+  8: goto 37
+  9: label L3
+ 10: assume WellFormed($t5)
+ 11: assume Eq<u64>($t5, select A::S.x(global<A::S>($t0)))
      # << opaque call: $t3 := A::read_at($t0)
- 11: nop
-     # >> opaque call: A::mutate_at($t0)
  12: nop
+     # >> opaque call: A::mutate_at($t0)
+ 13: nop
      # VC: caller does not have permission to modify `A::S` at given address at tests/spec_instrumentation/modifies.move:92:9+18
- 13: assert CanModify<A::S>($t0)
- 14: assume Identical($t6, Not(exists<A::S>($t0)))
- 15: if ($t6) goto 16 else goto 19
- 16: label L6
- 17: trace_abort($t4)
- 18: goto 36
- 19: label L5
- 20: modifies global<A::S>($t0)
- 21: assume Eq<u64>(select A::S.x(global<A::S>($t0)), 2)
+ 14: assert CanModify<A::S>($t0)
+ 15: assume Identical($t6, Not(exists<A::S>($t0)))
+ 16: if ($t6) goto 17 else goto 20
+ 17: label L6
+ 18: trace_abort($t4)
+ 19: goto 37
+ 20: label L5
+ 21: modifies global<A::S>($t0)
+ 22: assume Eq<u64>(select A::S.x(global<A::S>($t0)), 2)
      # << opaque call: A::mutate_at($t0)
- 22: nop
-     # >> opaque call: $t4 := A::read_at($t0)
  23: nop
- 24: assume Identical($t7, Not(exists<A::S>($t0)))
- 25: if ($t7) goto 26 else goto 29
- 26: label L8
- 27: trace_abort($t4)
- 28: goto 36
- 29: label L7
- 30: assume WellFormed($t8)
- 31: assume Eq<u64>($t8, select A::S.x(global<A::S>($t0)))
+     # >> opaque call: $t4 := A::read_at($t0)
+ 24: nop
+ 25: assume Identical($t7, Not(exists<A::S>($t0)))
+ 26: if ($t7) goto 27 else goto 30
+ 27: label L8
+ 28: trace_abort($t4)
+ 29: goto 37
+ 30: label L7
+ 31: assume WellFormed($t8)
+ 32: assume Eq<u64>($t8, select A::S.x(global<A::S>($t0)))
      # << opaque call: $t4 := A::read_at($t0)
- 32: nop
- 33: assert Eq<u64>($t5, $t8)
- 34: label L1
- 35: return ()
- 36: label L2
- 37: abort($t4)
+ 33: nop
+ 34: assert Eq<u64>($t5, $t8)
+ 35: label L1
+ 36: return ()
+ 37: label L2
+ 38: abort($t4)
 }
 
 
@@ -459,41 +464,124 @@ public fun B::mutate_at_test_incorrect($t0|addr1: address, $t1|addr2: address) {
   1: assume WellFormed($t1)
   2: assume forall $rsc: ResourceDomain<A::S>(): WellFormed($rsc)
   3: assume forall $rsc: ResourceDomain<B::T>(): WellFormed($rsc)
+  4: assume CanModify<B::T>($t1)
      # >> opaque call: $t5 := A::read_at($t1)
-  4: nop
-  5: assume Identical($t5, Not(exists<A::S>($t1)))
-  6: if ($t5) goto 7 else goto 10
-  7: label L4
-  8: trace_abort($t6)
-  9: goto 34
- 10: label L3
- 11: assume WellFormed($t7)
- 12: assume Eq<u64>($t7, select A::S.x(global<A::S>($t1)))
+  5: nop
+  6: assume Identical($t5, Not(exists<A::S>($t1)))
+  7: if ($t5) goto 8 else goto 11
+  8: label L4
+  9: trace_abort($t6)
+ 10: goto 35
+ 11: label L3
+ 12: assume WellFormed($t7)
+ 13: assume Eq<u64>($t7, select A::S.x(global<A::S>($t1)))
      # << opaque call: $t5 := A::read_at($t1)
- 13: nop
+ 14: nop
      # VC: caller does not have permission to modify `B::T` at given address at tests/spec_instrumentation/modifies.move:38:17+17
- 14: assert CanModify<B::T>($t0)
- 15: $t8 := borrow_global<B::T>($t0) on_abort goto 34 with $t6
- 16: $t9 := 2
- 17: $t10 := borrow_field<B::T>.x($t8)
- 18: write_ref($t10, $t9)
- 19: write_back[Reference($t8).0]($t10)
- 20: write_back[B::T.D]($t8)
+ 15: assert CanModify<B::T>($t0)
+ 16: $t8 := borrow_global<B::T>($t0) on_abort goto 35 with $t6
+ 17: $t9 := 2
+ 18: $t10 := borrow_field<B::T>.x($t8)
+ 19: write_ref($t10, $t9)
+ 20: write_back[Reference($t8).0]($t10)
+ 21: write_back[B::T.D]($t8)
      # >> opaque call: $t9 := A::read_at($t1)
- 21: nop
- 22: assume Identical($t11, Not(exists<A::S>($t1)))
- 23: if ($t11) goto 24 else goto 27
- 24: label L6
- 25: trace_abort($t6)
- 26: goto 34
- 27: label L5
- 28: assume WellFormed($t12)
- 29: assume Eq<u64>($t12, select A::S.x(global<A::S>($t1)))
+ 22: nop
+ 23: assume Identical($t11, Not(exists<A::S>($t1)))
+ 24: if ($t11) goto 25 else goto 28
+ 25: label L6
+ 26: trace_abort($t6)
+ 27: goto 35
+ 28: label L5
+ 29: assume WellFormed($t12)
+ 30: assume Eq<u64>($t12, select A::S.x(global<A::S>($t1)))
      # << opaque call: $t9 := A::read_at($t1)
- 30: nop
- 31: assert Eq<u64>($t7, $t12)
- 32: label L1
- 33: return ()
- 34: label L2
- 35: abort($t6)
+ 31: nop
+ 32: assert Eq<u64>($t7, $t12)
+ 33: label L1
+ 34: return ()
+ 35: label L2
+ 36: abort($t6)
+}
+
+
+
+==== spec-instrumenter input specs ====
+
+fun A::mutate_at[baseline[
+spec {
+  ensures Eq<u64>(select A::S.x(global<A::S>($t0)), 2);
+  aborts_if Not(exists<A::S>($t0));
+  modifies global<A::S>($t0);
+}
+
+fun A::mutate_at[verification[
+spec {
+  ensures Eq<u64>(select A::S.x(global<A::S>($t0)), 2);
+  aborts_if Not(exists<A::S>($t0));
+  modifies global<A::S>($t0);
+}
+
+fun A::read_at[baseline[
+spec {
+  aborts_if Not(exists<A::S>($t0));
+  ensures Eq<u64>(result0(), select A::S.x(global<A::S>($t0)));
+}
+
+fun A::read_at[verification[
+spec {
+  aborts_if Not(exists<A::S>($t0));
+  ensures Eq<u64>(result0(), select A::S.x(global<A::S>($t0)));
+}
+
+fun B::move_from_test_incorrect[baseline[
+spec {
+  modifies global<B::T>($t1);
+}
+
+fun B::move_from_test_incorrect[verification[
+spec {
+  modifies global<B::T>($t1);
+}
+
+fun B::move_to_test_incorrect[baseline[
+spec {
+  modifies global<B::T>($t1);
+}
+
+fun B::move_to_test_incorrect[verification[
+spec {
+  modifies global<B::T>($t1);
+}
+
+fun B::mutate_S_test1_incorrect[baseline[
+spec {
+  requires Neq<address>($t0, $t1);
+  modifies global<A::S>($t1);
+}
+
+fun B::mutate_S_test1_incorrect[verification[
+spec {
+  requires Neq<address>($t0, $t1);
+  modifies global<A::S>($t1);
+}
+
+fun B::mutate_S_test2_incorrect[baseline[
+spec {
+  modifies global<A::S>($t0);
+}
+
+fun B::mutate_S_test2_incorrect[verification[
+spec {
+  modifies global<A::S>($t0);
+}
+
+fun B::mutate_at_test_incorrect[baseline[
+spec {
+  modifies global<B::T>($t1);
+}
+
+fun B::mutate_at_test_incorrect[verification[
+spec {
+  modifies global<B::T>($t1);
 }

--- a/language/move-prover/bytecode/tests/spec_instrumentation/opaque_call.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/opaque_call.exp
@@ -85,44 +85,45 @@ fun Test::get_and_incr($t0|addr: address): u64 {
   0: assume WellFormed($t0)
   1: assume forall $rsc: ResourceDomain<Test::R>(): WellFormed($rsc)
   2: assume Neq<address>($t0, 0)
-  3: @0 := save_mem(Test::R)
-  4: $t3 := exists<Test::R>($t0)
-  5: $t4 := !($t3)
-  6: if ($t4) goto 9 else goto 7
-  7: label L1
-  8: goto 13
-  9: label L0
- 10: $t5 := 33
- 11: $t6 := move($t5)
- 12: goto 30
- 13: label L2
+  3: assume CanModify<Test::R>($t0)
+  4: @0 := save_mem(Test::R)
+  5: $t3 := exists<Test::R>($t0)
+  6: $t4 := !($t3)
+  7: if ($t4) goto 10 else goto 8
+  8: label L1
+  9: goto 14
+ 10: label L0
+ 11: $t5 := 33
+ 12: $t6 := move($t5)
+ 13: goto 31
+ 14: label L2
      # VC: caller does not have permission to modify `Test::R` at given address at tests/spec_instrumentation/opaque_call.move:8:14+17
- 14: assert CanModify<Test::R>($t0)
- 15: $t7 := borrow_global<Test::R>($t0) on_abort goto 30 with $t6
- 16: $t8 := get_field<Test::R>.v($t7)
- 17: $t9 := get_field<Test::R>.v($t7)
- 18: $t10 := 1
- 19: $t11 := +($t9, $t10) on_abort goto 30 with $t6
- 20: $t12 := borrow_field<Test::R>.v($t7)
- 21: write_ref($t12, $t11)
- 22: write_back[Reference($t7).0]($t12)
- 23: write_back[Test::R.D]($t7)
- 24: label L3
+ 15: assert CanModify<Test::R>($t0)
+ 16: $t7 := borrow_global<Test::R>($t0) on_abort goto 31 with $t6
+ 17: $t8 := get_field<Test::R>.v($t7)
+ 18: $t9 := get_field<Test::R>.v($t7)
+ 19: $t10 := 1
+ 20: $t11 := +($t9, $t10) on_abort goto 31 with $t6
+ 21: $t12 := borrow_field<Test::R>.v($t7)
+ 22: write_ref($t12, $t11)
+ 23: write_back[Reference($t7).0]($t12)
+ 24: write_back[Test::R.D]($t7)
+ 25: label L3
      # VC: function does not abort under this condition at tests/spec_instrumentation/opaque_call.move:16:6+35
- 25: assert Not(Not(exists[@0]<Test::R>($t0)))
+ 26: assert Not(Not(exists[@0]<Test::R>($t0)))
      # VC: function does not abort under this condition at tests/spec_instrumentation/opaque_call.move:17:6+56
- 26: assert Not(Ge(Add(select Test::R.v(global[@0]<Test::R>($t0)), 1), 18446744073709551615))
+ 27: assert Not(Ge(Add(select Test::R.v(global[@0]<Test::R>($t0)), 1), 18446744073709551615))
      # VC: post-condition does not hold at tests/spec_instrumentation/opaque_call.move:19:6+56
- 27: assert Eq<u64>(select Test::R.v(global<Test::R>($t0)), Add(select Test::R.v(global[@0]<Test::R>($t0)), 1))
+ 28: assert Eq<u64>(select Test::R.v(global<Test::R>($t0)), Add(select Test::R.v(global[@0]<Test::R>($t0)), 1))
      # VC: post-condition does not hold at tests/spec_instrumentation/opaque_call.move:20:6+36
- 28: assert Eq<u64>($t8, select Test::R.v(global<Test::R>($t0)))
- 29: return $t8
- 30: label L4
+ 29: assert Eq<u64>($t8, select Test::R.v(global<Test::R>($t0)))
+ 30: return $t8
+ 31: label L4
      # VC: abort not covered by any of the `aborts_if` clauses at tests/spec_instrumentation/opaque_call.move:13:2+312
- 31: assert Or(Not(exists[@0]<Test::R>($t0)), Ge(Add(select Test::R.v(global[@0]<Test::R>($t0)), 1), 18446744073709551615))
+ 32: assert Or(Not(exists[@0]<Test::R>($t0)), Ge(Add(select Test::R.v(global[@0]<Test::R>($t0)), 1), 18446744073709551615))
      # VC: abort code not covered by any of the `aborts_if` or `aborts_with` clauses at tests/spec_instrumentation/opaque_call.move:13:2+312
- 32: assert Or(And(Not(exists[@0]<Test::R>($t0)), Eq(33, $t6)), Ge(Add(select Test::R.v(global[@0]<Test::R>($t0)), 1), 18446744073709551615))
- 33: abort($t6)
+ 33: assert Or(And(Not(exists[@0]<Test::R>($t0)), Eq(33, $t6)), Ge(Add(select Test::R.v(global[@0]<Test::R>($t0)), 1), 18446744073709551615))
+ 34: abort($t6)
 }
 
 
@@ -189,4 +190,40 @@ fun Test::incr_twice() {
      # VC: abort code not covered by any of the `aborts_if` or `aborts_with` clauses at tests/spec_instrumentation/opaque_call.move:27:2+127
  42: assert And(Not(exists[@1]<Test::R>(1)), Eq(33, $t2))
  43: abort($t2)
+}
+
+
+
+==== spec-instrumenter input specs ====
+
+fun Test::get_and_incr[baseline[
+spec {
+  requires Neq<address>($t0, 0);
+  aborts_if Not(exists<Test::R>($t0));
+  aborts_if Ge(Add(select Test::R.v(global<Test::R>($t0)), 1), 18446744073709551615);
+  modifies global<Test::R>($t0);
+  ensures Eq<u64>(select Test::R.v(global<Test::R>($t0)), Add(select Test::R.v(Old<Test::R>(global<Test::R>($t0))), 1));
+  ensures Eq<u64>(result0(), select Test::R.v(global<Test::R>($t0)));
+}
+
+fun Test::get_and_incr[verification[
+spec {
+  requires Neq<address>($t0, 0);
+  aborts_if Not(exists<Test::R>($t0));
+  aborts_if Ge(Add(select Test::R.v(global<Test::R>($t0)), 1), 18446744073709551615);
+  modifies global<Test::R>($t0);
+  ensures Eq<u64>(select Test::R.v(global<Test::R>($t0)), Add(select Test::R.v(Old<Test::R>(global<Test::R>($t0))), 1));
+  ensures Eq<u64>(result0(), select Test::R.v(global<Test::R>($t0)));
+}
+
+fun Test::incr_twice[baseline[
+spec {
+  aborts_if Not(exists<Test::R>(1));
+  ensures Eq<u64>(select Test::R.v(global<Test::R>(1)), Add(select Test::R.v(Old<Test::R>(global<Test::R>(1))), 2));
+}
+
+fun Test::incr_twice[verification[
+spec {
+  aborts_if Not(exists<Test::R>(1));
+  ensures Eq<u64>(select Test::R.v(global<Test::R>(1)), Add(select Test::R.v(Old<Test::R>(global<Test::R>(1))), 2));
 }

--- a/language/move-prover/src/main.rs
+++ b/language/move-prover/src/main.rs
@@ -23,7 +23,12 @@ fn main() {
 fn run() -> anyhow::Result<()> {
     let args: Vec<String> = env::args().collect();
     let options = Options::create_from_args(&args)?;
+    let color = if atty::is(atty::Stream::Stderr) && atty::is(atty::Stream::Stdout) {
+        ColorChoice::Auto
+    } else {
+        ColorChoice::Never
+    };
     options.setup_logging();
-    let mut error_writer = StandardStream::stderr(ColorChoice::Auto);
+    let mut error_writer = StandardStream::stderr(color);
     run_move_prover(&mut error_writer, options)
 }

--- a/language/move-prover/tests/sources/functional/ModifiesErrorTest.exp
+++ b/language/move-prover/tests/sources/functional/ModifiesErrorTest.exp
@@ -7,6 +7,8 @@ error: caller does not have permission to modify `B::T` at given address
     │                 ^^^^^^^^^
     │
     =     at tests/sources/functional/ModifiesErrorTest.move:63: move_from_test_incorrect
+    =     at tests/sources/functional/ModifiesErrorTest.move:74
+    =     at tests/sources/functional/ModifiesErrorTest.move:63: move_from_test_incorrect
     =         addr1 = <redacted>
     =         addr2 = <redacted>
     =     at tests/sources/functional/ModifiesErrorTest.move:64: move_from_test_incorrect
@@ -20,6 +22,8 @@ error: caller does not have permission to modify `B::T` at given address
  52 │         move_to<T>(account, T{x: 2});
     │         ^^^^^^^
     │
+    =     at tests/sources/functional/ModifiesErrorTest.move:50: move_to_test_incorrect
+    =     at tests/sources/functional/ModifiesErrorTest.move:60
     =     at tests/sources/functional/ModifiesErrorTest.move:50: move_to_test_incorrect
     =         account = <redacted>
     =         addr2 = <redacted>
@@ -36,6 +40,7 @@ error: caller does not have permission to modify `A::S` at given address
     │
     =     at tests/sources/functional/ModifiesErrorTest.move:77: mutate_S_test1_incorrect
     =     at tests/sources/functional/ModifiesErrorTest.move:86
+    =     at tests/sources/functional/ModifiesErrorTest.move:87
     =     at tests/sources/functional/ModifiesErrorTest.move:77: mutate_S_test1_incorrect
     =         addr1 = <redacted>
     =         addr2 = <redacted>
@@ -50,6 +55,8 @@ error: unknown assertion failed
  95 │             assert x0 == x1;
     │             ^^^^^^^^^^^^^^^^
     │
+    =     at tests/sources/functional/ModifiesErrorTest.move:90: mutate_S_test2_incorrect
+    =     at tests/sources/functional/ModifiesErrorTest.move:99
     =     at tests/sources/functional/ModifiesErrorTest.move:90: mutate_S_test2_incorrect
     =         addr = <redacted>
     =     at tests/sources/functional/ModifiesErrorTest.move:91: mutate_S_test2_incorrect
@@ -66,6 +73,8 @@ error: caller does not have permission to modify `B::T` at given address
  38 │         let t = borrow_global_mut<T>(addr1);
     │                 ^^^^^^^^^^^^^^^^^
     │
+    =     at tests/sources/functional/ModifiesErrorTest.move:36: mutate_at_test_incorrect
+    =     at tests/sources/functional/ModifiesErrorTest.move:47
     =     at tests/sources/functional/ModifiesErrorTest.move:36: mutate_at_test_incorrect
     =         addr1 = <redacted>
     =         addr2 = <redacted>

--- a/language/move-prover/tests/sources/functional/ModifiesSchemaTest.exp
+++ b/language/move-prover/tests/sources/functional/ModifiesSchemaTest.exp
@@ -7,6 +7,8 @@ error: caller does not have permission to modify `A::S` at given address
     │         ^^^^^^^^^^^^^^^^
     │
     =     at tests/sources/functional/ModifiesSchemaTest.move:29: mutate_at_wrapper2
+    =     at tests/sources/functional/ModifiesSchemaTest.move:9
+    =     at tests/sources/functional/ModifiesSchemaTest.move:29: mutate_at_wrapper2
     =         addr1 = <redacted>
     =         addr2 = <redacted>
     =     at tests/sources/functional/ModifiesSchemaTest.move:30: mutate_at_wrapper2

--- a/language/move-prover/tests/sources/functional/aborts_if_with_code.exp
+++ b/language/move-prover/tests/sources/functional/aborts_if_with_code.exp
@@ -89,10 +89,11 @@ error: abort code not covered by any of the `aborts_if` or `aborts_with` clauses
     │ ╰─────^
     ·
  46 │         10 / x
-    │         -- abort happened here with execution failure
+    │            - abort happened here with execution failure
     │
     =     at tests/sources/functional/aborts_if_with_code.move:50
     =     at tests/sources/functional/aborts_if_with_code.move:45: exec_failure_invalid
     =         x = <redacted>
+    =     at tests/sources/functional/aborts_if_with_code.move:46: exec_failure_invalid
     =     at tests/sources/functional/aborts_if_with_code.move:46: exec_failure_invalid
     =         ABORTED

--- a/language/move-prover/tests/sources/functional/address_serialization_constant_size.exp
+++ b/language/move-prover/tests/sources/functional/address_serialization_constant_size.exp
@@ -11,8 +11,6 @@ error: post-condition does not hold
     =         mv1 = <redacted>
     =         mv2 = <redacted>
     =     at tests/sources/functional/address_serialization_constant_size.move:16: serialized_move_values_diff_len_incorrect
-    =     at tests/sources/functional/address_serialization_constant_size.move:16: serialized_move_values_diff_len_incorrect
-    =     at tests/sources/functional/address_serialization_constant_size.move:16: serialized_move_values_diff_len_incorrect
     =         result_1 = <redacted>
     =         result_2 = <redacted>
     =     at tests/sources/functional/address_serialization_constant_size.move:17: serialized_move_values_diff_len_incorrect

--- a/language/move-prover/tests/sources/functional/choice.exp
+++ b/language/move-prover/tests/sources/functional/choice.exp
@@ -1,6 +1,26 @@
 Move prover returns: exiting with boogie verification errors
 error: post-condition does not hold
 
+    ┌── tests/sources/functional/choice.move:54:9 ───
+    │
+ 54 │         ensures choice == Signer::spec_address_of(s2);
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/choice.move:44: populate_R
+    =     at tests/sources/functional/choice.move:49
+    =     at tests/sources/functional/choice.move:50
+    =     at tests/sources/functional/choice.move:53
+    =     at tests/sources/functional/choice.move:52
+    =     at tests/sources/functional/choice.move:44: populate_R
+    =         s1 = <redacted>
+    =         s2 = <redacted>
+    =     at tests/sources/functional/choice.move:45: populate_R
+    =     at tests/sources/functional/choice.move:46: populate_R
+    =     at tests/sources/functional/choice.move:47: populate_R
+    =     at tests/sources/functional/choice.move:54
+
+error: post-condition does not hold
+
     ┌── tests/sources/functional/choice.move:21:9 ───
     │
  21 │         ensures result == TRACE(choose x: u64 where x >= 4 && x <= 5);
@@ -13,8 +33,8 @@ error: post-condition does not hold
     =         <redacted> = <redacted>
     =         result = <redacted>
     =     at tests/sources/functional/choice.move:17: simple_incorrect
-    =         `choose x: u64 where x >= 4 && x <= 5` = <redacted>
     =     at tests/sources/functional/choice.move:21
+    =         `TRACE(choose x: u64 where x >= 4 && x <= 5)` = <redacted>
 
 error: post-condition does not hold
 
@@ -24,7 +44,6 @@ error: post-condition does not hold
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
     =     at tests/sources/functional/choice.move:74: test_not_using_min_incorrect
-    =     at tests/sources/functional/choice.move:74: test_not_using_min_incorrect
     =         v = <redacted>
     =     at tests/sources/functional/choice.move:75: test_not_using_min_incorrect
     =         v_ref = <redacted>
@@ -33,9 +52,8 @@ error: post-condition does not hold
     =     at tests/sources/functional/choice.move:78: test_not_using_min_incorrect
     =     at tests/sources/functional/choice.move:79: test_not_using_min_incorrect
     =     at tests/sources/functional/choice.move:80: test_not_using_min_incorrect
-    =     at tests/sources/functional/choice.move:80: test_not_using_min_incorrect
     =     at tests/sources/functional/choice.move:81: test_not_using_min_incorrect
     =         result = <redacted>
     =     at tests/sources/functional/choice.move:82: test_not_using_min_incorrect
-    =         `choose i in 0..len(result) where result[i] == 2` = <redacted>
     =     at tests/sources/functional/choice.move:85
+    =         `TRACE(choose i in 0..len(result) where result[i] == 2)` = <redacted>

--- a/language/move-prover/tests/sources/functional/emits.exp
+++ b/language/move-prover/tests/sources/functional/emits.exp
@@ -78,7 +78,6 @@ error: function does not emit the expected event
     =         handle = <redacted>
     =     at tests/sources/functional/emits.move:48: multiple_incorrect
     =     at tests/sources/functional/emits.move:49: multiple_incorrect
-    =     at tests/sources/functional/emits.move:49: multiple_incorrect
     =         handle = <redacted>
     =     at tests/sources/functional/emits.move:50: multiple_incorrect
     =     at tests/sources/functional/emits.move:52
@@ -94,7 +93,6 @@ error: function does not emit the expected event
     │
     =     at tests/sources/functional/emits.move:66: multiple_same_incorrect
     =         handle = <redacted>
-    =     at tests/sources/functional/emits.move:67: multiple_same_incorrect
     =     at tests/sources/functional/emits.move:67: multiple_same_incorrect
     =         handle = <redacted>
     =     at tests/sources/functional/emits.move:68: multiple_same_incorrect
@@ -117,7 +115,6 @@ error: emitted event not covered by any of the `emits` clauses
      =     at tests/sources/functional/emits.move:310: opaque_completeness_incorrect
      =     at tests/sources/functional/emits.move:311: opaque_completeness_incorrect
      =     at tests/sources/functional/emits.move:312: opaque_completeness_incorrect
-     =     at tests/sources/functional/emits.move:312: opaque_completeness_incorrect
      =         handle = <redacted>
      =     at tests/sources/functional/emits.move:313: opaque_completeness_incorrect
      =     at tests/sources/functional/emits.move:315
@@ -136,7 +133,6 @@ error: function does not emit the expected event
      =         handle = <redacted>
      =     at tests/sources/functional/emits.move:287: opaque_incorrect
      =     at tests/sources/functional/emits.move:288: opaque_incorrect
-     =     at tests/sources/functional/emits.move:289: opaque_incorrect
      =     at tests/sources/functional/emits.move:289: opaque_incorrect
      =         handle = <redacted>
      =     at tests/sources/functional/emits.move:290: opaque_incorrect
@@ -164,7 +160,6 @@ error: emitted event not covered by any of the `emits` clauses
      =     at tests/sources/functional/emits.move:351: opaque_partial_incorrect
      =     at tests/sources/functional/emits.move:352: opaque_partial_incorrect
      =     at tests/sources/functional/emits.move:353: opaque_partial_incorrect
-     =     at tests/sources/functional/emits.move:353: opaque_partial_incorrect
      =         handle = <redacted>
      =     at tests/sources/functional/emits.move:354: opaque_partial_incorrect
      =     at tests/sources/functional/emits.move:356
@@ -186,7 +181,6 @@ error: emitted event not covered by any of the `emits` clauses
      =         handle = <redacted>
      =     at tests/sources/functional/emits.move:232: partial_incorrect
      =     at tests/sources/functional/emits.move:233: partial_incorrect
-     =     at tests/sources/functional/emits.move:233: partial_incorrect
      =         handle = <redacted>
      =     at tests/sources/functional/emits.move:234: partial_incorrect
      =     at tests/sources/functional/emits.move:236
@@ -203,7 +197,6 @@ error: function does not emit the expected event
     =         handle = <redacted>
     =         _handle2 = <redacted>
     =     at tests/sources/functional/emits.move:27: simple_wrong_handle_incorrect
-    =     at tests/sources/functional/emits.move:27: simple_wrong_handle_incorrect
     =         handle = <redacted>
     =         _handle2 = <redacted>
     =     at tests/sources/functional/emits.move:28: simple_wrong_handle_incorrect
@@ -218,7 +211,6 @@ error: function does not emit the expected event
     │
     =     at tests/sources/functional/emits.move:19: simple_wrong_msg_incorrect
     =         handle = <redacted>
-    =     at tests/sources/functional/emits.move:20: simple_wrong_msg_incorrect
     =     at tests/sources/functional/emits.move:20: simple_wrong_msg_incorrect
     =         handle = <redacted>
     =     at tests/sources/functional/emits.move:21: simple_wrong_msg_incorrect
@@ -236,7 +228,6 @@ error: emitted event not covered by any of the `emits` clauses
      =     at tests/sources/functional/emits.move:251: strict_incorrect
      =         handle = <redacted>
      =     at tests/sources/functional/emits.move:252: strict_incorrect
-     =     at tests/sources/functional/emits.move:253: strict_incorrect
      =     at tests/sources/functional/emits.move:253: strict_incorrect
      =         handle = <redacted>
      =     at tests/sources/functional/emits.move:254: strict_incorrect

--- a/language/move-prover/tests/sources/functional/exists_in_vector.move
+++ b/language/move-prover/tests/sources/functional/exists_in_vector.move
@@ -19,18 +19,17 @@ module 0x42::VectorExists {
     spec fun do_nothing_ref {
         aborts_if false;
 
-        ensures old(_v) == _v;
-        ensures exists l: u64: l == len(old(_v));
+        ensures _v == _v;
         ensures exists l: u64: l == len(_v);
-        ensures exists l: u64 where l == len(old(_v)): l == len(_v);
+        ensures exists l: u64 where l == len(_v): l == len(_v);
 
-        ensures old(e_in_v_vec(0, _v)) ==> e_in_v_vec(0, _v);
-        ensures old(e_in_v_range(0, _v)) ==> e_in_v_range(0, _v);
-        ensures old(e_in_v_u64(0, _v)) ==> e_in_v_u64(0, _v);
+        ensures e_in_v_vec(0, _v) ==> e_in_v_vec(0, _v);
+        ensures e_in_v_range(0, _v) ==> e_in_v_range(0, _v);
+        ensures e_in_v_u64(0, _v) ==> e_in_v_u64(0, _v);
 
-        ensures forall e: u64: (old(e_in_v_vec(e, _v)) ==> e_in_v_vec(e, _v));
-        ensures forall e: u64: (old(e_in_v_range(e, _v)) ==> e_in_v_range(e, _v));
-        ensures forall e: u64: (old(e_in_v_u64(e, _v)) ==> e_in_v_u64(e, _v));
+        ensures forall e: u64: (e_in_v_vec(e, _v) ==> e_in_v_vec(e, _v));
+        ensures forall e: u64: (e_in_v_range(e, _v) ==> e_in_v_range(e, _v));
+        ensures forall e: u64: (e_in_v_u64(e, _v) ==> e_in_v_u64(e, _v));
     }
 
     public fun do_nothing_ref_mut(_v: &mut vector<u64>) {

--- a/language/move-prover/tests/sources/functional/hash_model.exp
+++ b/language/move-prover/tests/sources/functional/hash_model.exp
@@ -11,9 +11,7 @@ error: post-condition does not hold
     =         v1 = <redacted>
     =         v2 = <redacted>
     =     at tests/sources/functional/hash_model.move:41: hash_test1_incorrect
-    =     at tests/sources/functional/hash_model.move:41: hash_test1_incorrect
     =         h1 = <redacted>
-    =     at tests/sources/functional/hash_model.move:42: hash_test1_incorrect
     =     at tests/sources/functional/hash_model.move:42: hash_test1_incorrect
     =         h2 = <redacted>
     =     at tests/sources/functional/hash_model.move:43: hash_test1_incorrect
@@ -35,9 +33,7 @@ error: post-condition does not hold
     =         v1 = <redacted>
     =         v2 = <redacted>
     =     at tests/sources/functional/hash_model.move:84: hash_test2_incorrect
-    =     at tests/sources/functional/hash_model.move:84: hash_test2_incorrect
     =         h1 = <redacted>
-    =     at tests/sources/functional/hash_model.move:85: hash_test2_incorrect
     =     at tests/sources/functional/hash_model.move:85: hash_test2_incorrect
     =         h2 = <redacted>
     =     at tests/sources/functional/hash_model.move:86: hash_test2_incorrect

--- a/language/move-prover/tests/sources/functional/hash_model_invalid.exp
+++ b/language/move-prover/tests/sources/functional/hash_model_invalid.exp
@@ -11,9 +11,7 @@ error: post-condition does not hold
     =         v1 = <redacted>
     =         v2 = <redacted>
     =     at tests/sources/functional/hash_model_invalid.move:13: hash_test1
-    =     at tests/sources/functional/hash_model_invalid.move:13: hash_test1
     =         h1 = <redacted>
-    =     at tests/sources/functional/hash_model_invalid.move:14: hash_test1
     =     at tests/sources/functional/hash_model_invalid.move:14: hash_test1
     =         h2 = <redacted>
     =     at tests/sources/functional/hash_model_invalid.move:15: hash_test1
@@ -35,9 +33,7 @@ error: post-condition does not hold
     =         v1 = <redacted>
     =         v2 = <redacted>
     =     at tests/sources/functional/hash_model_invalid.move:28: hash_test2
-    =     at tests/sources/functional/hash_model_invalid.move:28: hash_test2
     =         h1 = <redacted>
-    =     at tests/sources/functional/hash_model_invalid.move:29: hash_test2
     =     at tests/sources/functional/hash_model_invalid.move:29: hash_test2
     =         h2 = <redacted>
     =     at tests/sources/functional/hash_model_invalid.move:30: hash_test2

--- a/language/move-prover/tests/sources/functional/inconsistency.exp
+++ b/language/move-prover/tests/sources/functional/inconsistency.exp
@@ -1,5 +1,5 @@
 Move prover returns: exiting with boogie verification errors
-error: there is an inconsistent assumption in the function, which may allow any post-condition (including false) to be proved
+error: there is an inconsistent assumption in the function, which may allow any post-condition (including false) to be proven
 
     ┌── tests/sources/functional/inconsistency.move:48:5 ───
     │
@@ -9,7 +9,7 @@ error: there is an inconsistent assumption in the function, which may allow any 
     │ ╰─────^
     │
 
-error: there is an inconsistent assumption in the function, which may allow any post-condition (including false) to be proved
+error: there is an inconsistent assumption in the function, which may allow any post-condition (including false) to be proven
 
     ┌── tests/sources/functional/inconsistency.move:16:5 ───
     │
@@ -22,7 +22,7 @@ error: there is an inconsistent assumption in the function, which may allow any 
     │ ╰─────^
     │
 
-error: there is an inconsistent assumption in the function, which may allow any post-condition (including false) to be proved
+error: there is an inconsistent assumption in the function, which may allow any post-condition (including false) to be proven
 
     ┌── tests/sources/functional/inconsistency.move:39:5 ───
     │

--- a/language/move-prover/tests/sources/functional/let.exp
+++ b/language/move-prover/tests/sources/functional/let.exp
@@ -1,0 +1,66 @@
+Move prover returns: exiting with boogie verification errors
+error: function does not abort under this condition
+
+    ┌── tests/sources/functional/let.move:76:9 ───
+    │
+ 76 │         aborts_if sum != 0;
+    │         ^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/let.move:68: spec_let_with_abort_incorrect
+    =     at tests/sources/functional/let.move:74
+    =         `let sum = a + b;` = <redacted>
+    =     at tests/sources/functional/let.move:75
+    =         `let product = a * b;` = <redacted>
+    =     at tests/sources/functional/let.move:68: spec_let_with_abort_incorrect
+    =         a = <redacted>
+    =         b = <redacted>
+    =     at tests/sources/functional/let.move:69: spec_let_with_abort_incorrect
+    =         saved_a = <redacted>
+    =     at tests/sources/functional/let.move:70: spec_let_with_abort_incorrect
+    =     at tests/sources/functional/let.move:71: spec_let_with_abort_incorrect
+    =         a = <redacted>
+    =         b = <redacted>
+    =     at tests/sources/functional/let.move:72: spec_let_with_abort_incorrect
+    =     at tests/sources/functional/let.move:79
+    =         `let post new_a = old(a) / sum;` = <redacted>
+    =     at tests/sources/functional/let.move:76
+    =         `aborts_if sum != 0;` = <redacted>
+
+error: abort not covered by any of the `aborts_if` clauses
+
+    ┌── tests/sources/functional/let.move:73:5 ───
+    │
+ 73 │ ╭     spec fun spec_let_with_abort_incorrect {
+ 74 │ │         let sum = a + b;
+ 75 │ │         let product = a * b;
+ 76 │ │         aborts_if sum != 0;
+ 77 │ │         aborts_if sum >= MAX_U64;
+ 78 │ │         aborts_if product >= MAX_U64;
+ 79 │ │         let post new_a = old(a) / sum;
+ 80 │ │         ensures a == new_a;
+ 81 │ │         ensures b == product;
+ 82 │ │     }
+    │ ╰─────^
+    ·
+ 70 │         *a = *a / (*a + *b);
+    │                 - abort happened here with execution failure
+    │
+    =     at tests/sources/functional/let.move:68: spec_let_with_abort_incorrect
+    =     at tests/sources/functional/let.move:74
+    =         `let sum = a + b;` = <redacted>
+    =     at tests/sources/functional/let.move:75
+    =         `let product = a * b;` = <redacted>
+    =     at tests/sources/functional/let.move:68: spec_let_with_abort_incorrect
+    =         a = <redacted>
+    =         b = <redacted>
+    =     at tests/sources/functional/let.move:69: spec_let_with_abort_incorrect
+    =         saved_a = <redacted>
+    =     at tests/sources/functional/let.move:70: spec_let_with_abort_incorrect
+    =     at tests/sources/functional/let.move:70: spec_let_with_abort_incorrect
+    =         ABORTED
+    =     at tests/sources/functional/let.move:76
+    =         `aborts_if sum != 0;` = <redacted>
+    =     at tests/sources/functional/let.move:77
+    =         `aborts_if sum >= MAX_U64;` = <redacted>
+    =     at tests/sources/functional/let.move:78
+    =         `aborts_if product >= MAX_U64;` = <redacted>

--- a/language/move-prover/tests/sources/functional/let.move
+++ b/language/move-prover/tests/sources/functional/let.move
@@ -1,3 +1,4 @@
+// flag: --trace
 module 0x42::TestLet {
 
     spec module {
@@ -22,36 +23,91 @@ module 0x42::TestLet {
     }
 
     fun spec_let_with_old(a: &mut u64, b: &mut u64) {
-        let saved_a = *a;
         *a = *a + 1 + *b;
-        *b = saved_a + *b;
+        *b = *a + *b;
     }
     spec fun spec_let_with_old {
-       let x = a + 1;
-       let y = x + b;
-       let r2 = a - 1;
-       ensures a == old(y); // y in the context of old accesses old a and b.
-       ensures b == r2;
+       let post new_a = old(a) + 1 + old(b);
+       let post new_b = a + old(b);
+       ensures a == new_a;
+       ensures b == new_b;
     }
 
-    fun spec_let_with_lambda(a: u64, b: u64): (u64, u64) {
-        (a + 1 + b, a + b)
+    fun spec_let_with_abort(a: &mut u64, b: &mut u64) {
+        let saved_a = *a;
+        *a = *a / (*a + *b);
+        *b = saved_a * *b;
     }
-    spec fun spec_let_with_lambda {
-        let add_to_a = |n| a + n;
-        let add_to_b = |n| b + n;
-        ensures result_1 == add_to_b(add_to_a(1));
-        ensures result_2 == result_1 - 1;
+    spec fun spec_let_with_abort {
+        pragma opaque;
+        let sum = a + b;
+        let product = a * b;
+        aborts_if sum == 0;
+        aborts_if sum > MAX_U64;
+        aborts_if product > MAX_U64;
+        let post new_a = old(a) / sum;
+        ensures a == new_a + sum - sum;
+        ensures b == product;
     }
 
-    fun spec_let_with_generic<T:copy + drop>(x: T, y: T): bool {
-        x == y
+    fun spec_let_with_abort_opaque_caller(a: &mut u64, b: &mut u64) {
+        spec_let_with_abort(a, b)
     }
-    spec fun spec_let_with_generic {
-        let equals_to_x = |z| x == z;
-        ensures result == equals_to_x(y);
+    spec fun spec_let_with_abort_opaque_caller {
+        // Same as the callee
+        let sum = a + b;
+        let product = a * b;
+        aborts_if sum == 0;
+        aborts_if sum > MAX_U64;
+        aborts_if product > MAX_U64;
+        let post new_a = old(a) / sum;
+        ensures a == new_a + sum - sum;
+        ensures b == product;
     }
 
+    fun spec_let_with_abort_incorrect(a: &mut u64, b: &mut u64) {
+        let saved_a = *a;
+        *a = *a / (*a + *b);
+        *b = saved_a * *b;
+    }
+    spec fun spec_let_with_abort_incorrect {
+        let sum = a + b;
+        let product = a * b;
+        aborts_if sum != 0;
+        aborts_if sum >= MAX_U64;
+        aborts_if product >= MAX_U64;
+        let post new_a = old(a) / sum;
+        ensures a == new_a;
+        ensures b == product;
+    }
+
+    fun spec_let_with_schema(a: &mut u64, b: &mut u64) {
+        let saved_a = *a;
+        *a = *a / (*a + *b);
+        *b = saved_a * *b;
+    }
+    spec fun spec_let_with_schema {
+        let sum = a + b;
+        let product = a * b;
+        aborts_if sum == 0;
+        aborts_if sum > MAX_U64;
+        aborts_if product > MAX_U64;
+        let post new_a = old(a) / sum;
+        include Ensures{actual: a, expected: new_a + sum - sum};
+        include Ensures{actual: b, expected: product};
+    }
+    spec schema Ensures {
+        actual: u64;
+        expected: u64;
+        let post a = expected;
+        let post b = actual;
+        include Ensures2{a: a, b: b};
+    }
+    spec schema Ensures2 {
+        a: u64;
+        b: u64;
+        ensures a == b;
+    }
 
     // Local Let
     // =========

--- a/language/move-prover/tests/sources/functional/loops_with_memory_ops.exp
+++ b/language/move-prover/tests/sources/functional/loops_with_memory_ops.exp
@@ -10,16 +10,13 @@ error: unknown assertion failed
     =         a = <redacted>
     =         b = <redacted>
     =     at tests/sources/functional/loops_with_memory_ops.move:57: nested_loop2
-    =     at tests/sources/functional/loops_with_memory_ops.move:57: nested_loop2
     =         length = <redacted>
     =     at tests/sources/functional/loops_with_memory_ops.move:59: nested_loop2
     =     at tests/sources/functional/loops_with_memory_ops.move:60: nested_loop2
     =     at tests/sources/functional/loops_with_memory_ops.move:62: nested_loop2
     =         i = <redacted>
     =     at tests/sources/functional/loops_with_memory_ops.move:63: nested_loop2
-    =     at tests/sources/functional/loops_with_memory_ops.move:63: nested_loop2
     =         x = <redacted>
-    =     at tests/sources/functional/loops_with_memory_ops.move:64: nested_loop2
     =     at tests/sources/functional/loops_with_memory_ops.move:64: nested_loop2
     =         y = <redacted>
     =     at tests/sources/functional/loops_with_memory_ops.move:66: nested_loop2
@@ -49,16 +46,13 @@ error: induction case of the loop invariant does not hold
     =         a = <redacted>
     =         b = <redacted>
     =     at tests/sources/functional/loops_with_memory_ops.move:57: nested_loop2
-    =     at tests/sources/functional/loops_with_memory_ops.move:57: nested_loop2
     =         length = <redacted>
     =     at tests/sources/functional/loops_with_memory_ops.move:59: nested_loop2
     =     at tests/sources/functional/loops_with_memory_ops.move:60: nested_loop2
     =     at tests/sources/functional/loops_with_memory_ops.move:62: nested_loop2
     =         i = <redacted>
     =     at tests/sources/functional/loops_with_memory_ops.move:63: nested_loop2
-    =     at tests/sources/functional/loops_with_memory_ops.move:63: nested_loop2
     =         x = <redacted>
-    =     at tests/sources/functional/loops_with_memory_ops.move:64: nested_loop2
     =     at tests/sources/functional/loops_with_memory_ops.move:64: nested_loop2
     =         y = <redacted>
     =     at tests/sources/functional/loops_with_memory_ops.move:66: nested_loop2
@@ -75,9 +69,7 @@ error: induction case of the loop invariant does not hold
     =     at tests/sources/functional/loops_with_memory_ops.move:85: nested_loop2
     =         i = <redacted>
     =     at tests/sources/functional/loops_with_memory_ops.move:86: nested_loop2
-    =     at tests/sources/functional/loops_with_memory_ops.move:89: nested_loop2
     =         x = <redacted>
-    =     at tests/sources/functional/loops_with_memory_ops.move:90: nested_loop2
     =     at tests/sources/functional/loops_with_memory_ops.move:90: nested_loop2
     =         y = <redacted>
     =     at tests/sources/functional/loops_with_memory_ops.move:67: nested_loop2

--- a/language/move-prover/tests/sources/functional/mono.exp
+++ b/language/move-prover/tests/sources/functional/mono.exp
@@ -9,7 +9,6 @@ error: post-condition does not hold
     =     at tests/sources/functional/mono.move:71
     =     at tests/sources/functional/mono.move:70: vec_addr
     =         x = <redacted>
-    =     at tests/sources/functional/mono.move:70: vec_addr
     =         result = <redacted>
     =     at tests/sources/functional/mono.move:71
 
@@ -23,7 +22,6 @@ error: post-condition does not hold
     =     at tests/sources/functional/mono.move:73
     =     at tests/sources/functional/mono.move:72: vec_bool
     =         x = <redacted>
-    =     at tests/sources/functional/mono.move:72: vec_bool
     =         result = <redacted>
     =     at tests/sources/functional/mono.move:73
 
@@ -37,7 +35,6 @@ error: post-condition does not hold
     =     at tests/sources/functional/mono.move:69
     =     at tests/sources/functional/mono.move:68: vec_int
     =         x = <redacted>
-    =     at tests/sources/functional/mono.move:68: vec_int
     =         result = <redacted>
     =     at tests/sources/functional/mono.move:69
 
@@ -51,7 +48,6 @@ error: post-condition does not hold
     =     at tests/sources/functional/mono.move:77
     =     at tests/sources/functional/mono.move:76: vec_struct_addr
     =         x = <redacted>
-    =     at tests/sources/functional/mono.move:76: vec_struct_addr
     =         result = <redacted>
     =     at tests/sources/functional/mono.move:77
 
@@ -65,7 +61,6 @@ error: post-condition does not hold
     =     at tests/sources/functional/mono.move:75
     =     at tests/sources/functional/mono.move:74: vec_struct_int
     =         x = <redacted>
-    =     at tests/sources/functional/mono.move:74: vec_struct_int
     =         result = <redacted>
     =     at tests/sources/functional/mono.move:75
 
@@ -79,8 +74,6 @@ error: post-condition does not hold
     =     at tests/sources/functional/mono.move:82
     =     at tests/sources/functional/mono.move:79: vec_vec
     =         x = <redacted>
-    =     at tests/sources/functional/mono.move:80: vec_vec
-    =     at tests/sources/functional/mono.move:80: vec_vec
     =     at tests/sources/functional/mono.move:80: vec_vec
     =         result = <redacted>
     =     at tests/sources/functional/mono.move:81: vec_vec

--- a/language/move-prover/tests/sources/functional/return_values.exp
+++ b/language/move-prover/tests/sources/functional/return_values.exp
@@ -11,7 +11,6 @@ error: post-condition does not hold
     =         result_1 = <redacted>
     =         result_2 = <redacted>
     =     at tests/sources/functional/return_values.move:5: one_two
-    =     at tests/sources/functional/return_values.move:31: one_two_wrapper_incorrect
     =         result_1 = <redacted>
     =         result_2 = <redacted>
     =     at tests/sources/functional/return_values.move:32: one_two_wrapper_incorrect
@@ -31,7 +30,6 @@ error: post-condition does not hold
     =         result_1 = <redacted>
     =         result_2 = <redacted>
     =     at tests/sources/functional/return_values.move:41: true_one
-    =     at tests/sources/functional/return_values.move:57: true_one_wrapper_incorrect
     =         result_1 = <redacted>
     =         result_2 = <redacted>
     =     at tests/sources/functional/return_values.move:58: true_one_wrapper_incorrect

--- a/language/move-prover/tests/sources/functional/serialize_model.exp
+++ b/language/move-prover/tests/sources/functional/serialize_model.exp
@@ -11,9 +11,7 @@ error: post-condition does not hold
     =         v1 = <redacted>
     =         v2 = <redacted>
     =     at tests/sources/functional/serialize_model.move:28: bcs_test1_incorrect
-    =     at tests/sources/functional/serialize_model.move:28: bcs_test1_incorrect
     =         s1 = <redacted>
-    =     at tests/sources/functional/serialize_model.move:29: bcs_test1_incorrect
     =     at tests/sources/functional/serialize_model.move:29: bcs_test1_incorrect
     =         s2 = <redacted>
     =     at tests/sources/functional/serialize_model.move:30: bcs_test1_incorrect

--- a/language/move-prover/tests/sources/functional/simple_vector_client.move
+++ b/language/move-prover/tests/sources/functional/simple_vector_client.move
@@ -18,9 +18,7 @@ module 0x42::TestVector {
     spec fun test_vector_equal {
         aborts_if false;
         ensures _v == _v;
-        ensures old(_v) == old(_v);
         ensures _v == _v[0..len(_v)];
-        ensures old(_v) == old(_v[0..len(_v)]);
         ensures _w == _w;
         ensures old(_w) == old(_w);
         ensures _w == _w[0..len(_w)];

--- a/language/move-prover/tests/sources/functional/strong_edges.exp
+++ b/language/move-prover/tests/sources/functional/strong_edges.exp
@@ -7,6 +7,8 @@ error: post-condition does not hold
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
     =     at tests/sources/functional/strong_edges.move:47: glob_and_field_edges_incorrect
+    =     at tests/sources/functional/strong_edges.move:56
+    =     at tests/sources/functional/strong_edges.move:47: glob_and_field_edges_incorrect
     =         addr = <redacted>
     =     at tests/sources/functional/strong_edges.move:48: glob_and_field_edges_incorrect
     =         s = <redacted>

--- a/language/move-prover/tests/sources/functional/verify_vector.move
+++ b/language/move-prover/tests/sources/functional/verify_vector.move
@@ -185,7 +185,7 @@ module 0x42::VerifyVector {
     spec fun verify_model_append {
         ensures len(lhs) == old(len(lhs) + len(other));
         ensures lhs[0..len(old(lhs))] == old(lhs);
-        ensures lhs[len(old(lhs))..len(lhs)] == old(other);
+        ensures lhs[len(old(lhs))..len(lhs)] == other;
     }
 
     // Return true if the vector has no elements

--- a/language/move-stdlib/docs/FixedPoint32.md
+++ b/language/move-stdlib/docs/FixedPoint32.md
@@ -432,11 +432,8 @@ rounding, e.g., 0.0125 will round down to 0.012 instead of up to 0.013.
 <pre><code><b>schema</b> <a href="FixedPoint32.md#0x1_FixedPoint32_ConcreteCreateFromRationalAbortsIf">ConcreteCreateFromRationalAbortsIf</a> {
     numerator: u64;
     denominator: u64;
-    <a name="0x1_FixedPoint32_scaled_numerator$12"></a>
     <b>let</b> scaled_numerator = numerator &lt;&lt; 64;
-    <a name="0x1_FixedPoint32_scaled_denominator$13"></a>
     <b>let</b> scaled_denominator = denominator &lt;&lt; 32;
-    <a name="0x1_FixedPoint32_quotient$14"></a>
     <b>let</b> quotient = scaled_numerator / scaled_denominator;
     <b>aborts_if</b> scaled_denominator == 0 <b>with</b> <a href="Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
     <b>aborts_if</b> quotient == 0 && scaled_numerator != 0 <b>with</b> <a href="Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;

--- a/language/move-stdlib/docs/Option.md
+++ b/language/move-stdlib/docs/Option.md
@@ -667,7 +667,7 @@ Destroys <code>t.</code> If <code>t</code> holds a value, return it. Returns <co
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
-<b>ensures</b> result == (<b>if</b> (<a href="Option.md#0x1_Option_is_some">is_some</a>(<b>old</b>(t))) <a href="Option.md#0x1_Option_borrow">borrow</a>(<b>old</b>(t)) <b>else</b> default);
+<b>ensures</b> result == (<b>if</b> (<a href="Option.md#0x1_Option_is_some">is_some</a>(t)) <a href="Option.md#0x1_Option_borrow">borrow</a>(t) <b>else</b> default);
 </code></pre>
 
 
@@ -711,7 +711,7 @@ Aborts if <code>t</code> does not hold a value
 
 <pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Option.md#0x1_Option_AbortsIfNone">AbortsIfNone</a>&lt;Element&gt;;
-<b>ensures</b> result == <a href="Option.md#0x1_Option_borrow">borrow</a>(<b>old</b>(t));
+<b>ensures</b> result == <a href="Option.md#0x1_Option_borrow">borrow</a>(t);
 </code></pre>
 
 

--- a/language/move-stdlib/modules/Option.move
+++ b/language/move-stdlib/modules/Option.move
@@ -189,7 +189,7 @@ module Option {
     spec fun destroy_with_default {
         pragma opaque;
         aborts_if false;
-        ensures result == (if (is_some(old(t))) borrow(old(t)) else default);
+        ensures result == (if (is_some(t)) borrow(t) else default);
     }
 
     /// Unpack `t` and return its contents
@@ -204,7 +204,7 @@ module Option {
     spec fun destroy_some {
         pragma opaque;
         include AbortsIfNone<Element>;
-        ensures result == borrow(old(t));
+        ensures result == borrow(t);
     }
 
     /// Unpack `t`


### PR DESCRIPTION
The semantics of `let` bindings in spec blocks has been a continued source of confusion. In the old world, for `let x = E`, the name `x` was differently interpreted depending on the context it is used in (pre or post state). Also, because of this, `old(..)` could not be used in let bindings.

This PR changes lets to make them more like folks expect: the value of `let` once evaluated is always the same. There are now two lets: `let x = E` is evaluated in the pre-state, and `let post x = E` in the post state, where `E` can use the `old` expression. Moreover, `old(..)` can now be freely used for schema parameters and schema inclusion conditions.

As this change required a lot of changes in the framework specs, this PR also enhances debugging capabilites via the `--trace` flag. Now each member in a spec block is traced, specifically the value of `let` bindings.

The PR also adds additional consistency checks for the correct usage of `old(..)`. This was needed for easier upgrade of the framework to the new let-style. Now applying `old` to an invariant expression creates a type check error, including if this expression is imported into a schema via schema expansion.


## Motivation

More intuitive specs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

New tests

## Related PRs

NA