### PR TITLE
[helm] bump era and use get_metadata for test

### DIFF
--- a/helm/fullnode/templates/tests/test-fullnode-connection.yaml
+++ b/helm/fullnode/templates/tests/test-fullnode-connection.yaml
@@ -14,18 +14,5 @@ spec:
         - -c
         - |-
           set -ex
-          metrics=http://{{ include "diem-fullnode.fullname" . }}:9101/metrics
-          sync1=$(curl -s $metrics  | grep 'diem_state_sync_version{type="synced"}' | awk '{ print $2 }')
-          echo "Synced version: $sync1"
-          echo "Sleeping 30s to wait for state sync..."
-          sleep 30
-          sync2=$(curl -s $metrics  | grep 'diem_state_sync_version{type="synced"}' | awk '{ print $2 }')
-          echo "Synced version: $sync2"
-          if [ "$sync2" -gt "$sync1" ]; then
-            echo "Success: state sync making progress"
-            exit 0
-          else
-            echo "Failed: state sync not making progress"
-            exit 1
-          fi
+          curl --fail -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0", "method":"get_metadata","params":[],"id":1}' http://{{ include "diem-fullnode.fullname" . }}-lb:80
   restartPolicy: Never

--- a/helm/fullnode/values.yaml
+++ b/helm/fullnode/values.yaml
@@ -1,5 +1,5 @@
 chain:
-  era: 24
+  era: 26
   name: testnet
   genesisConfigmap:
 


### PR DESCRIPTION
Testnet era increased during release-1.2
Also to separate helm test from metrics exposed, especially since there have been some state sync metrics changes. Just test via jsonrpc instead, and fail on HTTP error via curl flag.

Tested by deploying PFN locally via minikube, and running the helm test. Also CI passed :) [ci-test/helm-test](https://github.com/diem/diem/pull/8327/checks?check_run_id=2503063855)