### PR TITLE
[workspace-hack] exclude the fail crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2413,7 +2413,6 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "either",
- "fail",
  "futures",
  "futures-channel",
  "futures-core",

--- a/common/workspace-hack/Cargo.toml
+++ b/common/workspace-hack/Cargo.toml
@@ -23,7 +23,6 @@ crossbeam-channel = { version = "0.5.1", features = ["crossbeam-utils", "default
 crossbeam-deque = { version = "0.8.0", features = ["crossbeam-epoch", "crossbeam-utils", "default", "std"] }
 crossbeam-utils = { version = "0.8.3", features = ["default", "lazy_static", "std"] }
 either = { version = "1.6.1", features = ["default", "use_std"] }
-fail = { version = "0.4.0", default-features = false, features = ["failpoints"] }
 futures = { version = "0.3.12", features = ["alloc", "async-await", "default", "executor", "futures-executor", "std"] }
 futures-channel = { version = "0.3.13", features = ["alloc", "default", "futures-sink", "sink", "std"] }
 futures-core = { version = "0.3.13", features = ["alloc", "default", "std"] }
@@ -73,7 +72,6 @@ crossbeam-channel = { version = "0.5.1", features = ["crossbeam-utils", "default
 crossbeam-deque = { version = "0.8.0", features = ["crossbeam-epoch", "crossbeam-utils", "default", "std"] }
 crossbeam-utils = { version = "0.8.3", features = ["default", "lazy_static", "std"] }
 either = { version = "1.6.1", features = ["default", "use_std"] }
-fail = { version = "0.4.0", default-features = false, features = ["failpoints"] }
 futures = { version = "0.3.12", features = ["alloc", "async-await", "default", "executor", "futures-executor", "std"] }
 futures-channel = { version = "0.3.13", features = ["alloc", "default", "futures-sink", "sink", "std"] }
 futures-core = { version = "0.3.13", features = ["alloc", "default", "std"] }
@@ -126,7 +124,6 @@ crossbeam-channel = { version = "0.5.1", features = ["crossbeam-utils", "default
 crossbeam-deque = { version = "0.8.0", features = ["crossbeam-epoch", "crossbeam-utils", "default", "std"] }
 crossbeam-utils = { version = "0.8.3", features = ["default", "lazy_static", "std"] }
 either = { version = "1.6.1", features = ["default", "use_std"] }
-fail = { version = "0.4.0", default-features = false, features = ["failpoints"] }
 futures = { version = "0.3.12", features = ["alloc", "async-await", "default", "executor", "futures-executor", "std"] }
 futures-channel = { version = "0.3.13", features = ["alloc", "default", "futures-sink", "sink", "std"] }
 futures-core = { version = "0.3.13", features = ["alloc", "default", "std"] }
@@ -176,7 +173,6 @@ crossbeam-channel = { version = "0.5.1", features = ["crossbeam-utils", "default
 crossbeam-deque = { version = "0.8.0", features = ["crossbeam-epoch", "crossbeam-utils", "default", "std"] }
 crossbeam-utils = { version = "0.8.3", features = ["default", "lazy_static", "std"] }
 either = { version = "1.6.1", features = ["default", "use_std"] }
-fail = { version = "0.4.0", default-features = false, features = ["failpoints"] }
 futures = { version = "0.3.12", features = ["alloc", "async-await", "default", "executor", "futures-executor", "std"] }
 futures-channel = { version = "0.3.13", features = ["alloc", "default", "futures-sink", "sink", "std"] }
 futures-core = { version = "0.3.13", features = ["alloc", "default", "std"] }

--- a/x.toml
+++ b/x.toml
@@ -88,6 +88,13 @@ name = "x-lint"
 version = "0.1.0"
 workspace-path = "devtools/x-lint"
 
+# Exclude the fail crate because the failpoints feature should only be enabled
+# for certain builds.
+[[hakari.omitted-packages]]
+name = "fail"
+version = "0.4.0"
+crates-io = true
+
 # This follows the same syntax as CargoOptionsSummary in guppy.
 [summaries.default]
 version = "v2"


### PR DESCRIPTION
This crate has features that should only be enabled for certain builds.

Requested by @zekun000.