### PR TITLE
Add Payment Metadata

### DIFF
--- a/specifications/transactions/onchain/README.md
+++ b/specifications/transactions/onchain/README.md
@@ -93,6 +93,7 @@ enum RefundReason {
   InvalidSubaddress = 1,
   UserInitiatedPartialRefund = 2,
   UserInitiatedFullRefund = 3,
+  InvalidReferenceId = 4,
 }
 ```
 

--- a/testsuite/generate-format/tests/staged/diem.yaml
+++ b/testsuite/generate-format/tests/staged/diem.yaml
@@ -101,6 +101,10 @@ Metadata:
       CoinTradeMetadata:
         NEWTYPE:
           TYPENAME: CoinTradeMetadata
+    6:
+      PaymentMetadata:
+        NEWTYPE:
+          TYPENAME: PaymentMetadata
 Module:
   STRUCT:
     - code: BYTES
@@ -114,6 +118,18 @@ MultiEd25519PublicKey:
   NEWTYPESTRUCT: BYTES
 MultiEd25519Signature:
   NEWTYPESTRUCT: BYTES
+PaymentMetadata:
+  ENUM:
+    0:
+      PaymentMetadataVersion0:
+        NEWTYPE:
+          TYPENAME: PaymentMetadataV0
+PaymentMetadataV0:
+  STRUCT:
+    - reference_id:
+        TUPLEARRAY:
+          CONTENT: U8
+          SIZE: 16
 RawTransaction:
   STRUCT:
     - sender:
@@ -148,6 +164,8 @@ RefundReason:
       UserInitiatedPartialRefund: UNIT
     3:
       UserInitiatedFullRefund: UNIT
+    4:
+      InvalidReferenceId: UNIT
 Script:
   STRUCT:
     - code: BYTES

--- a/types/src/transaction/metadata.rs
+++ b/types/src/transaction/metadata.rs
@@ -115,6 +115,7 @@ pub enum RefundReason {
     InvalidSubaddress,
     UserInitiatedPartialRefund,
     UserInitiatedFullRefund,
+    InvalidReferenceId,
 }
 
 /// List of supported transaction metadata format versions for coin trade transaction

--- a/types/src/transaction/metadata.rs
+++ b/types/src/transaction/metadata.rs
@@ -17,6 +17,7 @@ pub enum Metadata {
     UnstructuredBytesMetadata(UnstructuredBytesMetadata),
     RefundMetadata(RefundMetadata),
     CoinTradeMetadata(CoinTradeMetadata),
+    PaymentMetadata(PaymentMetadata),
 }
 
 /// List of supported transaction metadata format versions for regular
@@ -127,4 +128,17 @@ pub enum CoinTradeMetadata {
 pub struct CoinTradeMetadataV0 {
     /// A list of trade_ids this transaction wants to settle
     pub trade_ids: Vec<String>,
+}
+
+/// List of supported transaction metadata format versions for transactions for payments
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum PaymentMetadata {
+    PaymentMetadataVersion0(PaymentMetadataV0),
+}
+
+/// Transaction metadata format for transactions for payments
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PaymentMetadataV0 {
+    /// Reference ID needed for off-chain reference ID exchange.
+    reference_id: [u8; 16],
 }


### PR DESCRIPTION
## Motivation

Adding new metadata type PaymentMetadata as defined in DIP-10. Used for transactions that are specific to payments that can we looked up using a reference ID. 

## Test Plan

unit test suite