### PR TITLE
[network] Rename ConfigurationChangeListener to ValidatorSetChangeListener

### DIFF
--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -40,7 +40,7 @@ use network::{
     ProtocolId,
 };
 use network_simple_onchain_discovery::{
-    builder::ConfigurationChangeListenerBuilder, gen_simple_discovery_reconfig_subscription,
+    builder::ValidatorSetChangeListenerBuilder, gen_simple_discovery_reconfig_subscription,
 };
 use std::{clone::Clone, collections::HashMap, sync::Arc};
 use subscription_service::ReconfigSubscription;
@@ -64,7 +64,7 @@ pub struct NetworkBuilder {
     time_service: TimeService,
     network_context: Arc<NetworkContext>,
 
-    configuration_change_listener_builder: Option<ConfigurationChangeListenerBuilder>,
+    configuration_change_listener_builder: Option<ValidatorSetChangeListenerBuilder>,
     connectivity_manager_builder: Option<ConnectivityManagerBuilder>,
     health_checker_builder: Option<HealthCheckerBuilder>,
     peer_manager_builder: PeerManagerBuilder,
@@ -416,7 +416,7 @@ impl NetworkBuilder {
             .push(simple_discovery_reconfig_subscription);
 
         self.configuration_change_listener_builder =
-            Some(ConfigurationChangeListenerBuilder::create(
+            Some(ValidatorSetChangeListenerBuilder::create(
                 self.network_context.clone(),
                 pubkey,
                 encryptor,

--- a/network/simple-onchain-discovery/src/builder.rs
+++ b/network/simple-onchain-discovery/src/builder.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::ConfigurationChangeListener;
+use crate::ValidatorSetChangeListener;
 use channel::diem_channel;
 use diem_config::network_id::NetworkContext;
 use diem_crypto::x25519::PublicKey;
@@ -11,7 +11,7 @@ use network::connectivity_manager::ConnectivityRequest;
 use std::sync::Arc;
 use tokio::runtime::Handle;
 
-struct ConfigurationChangeListenerConfig {
+struct ValidatorSetListenerConfig {
     network_context: Arc<NetworkContext>,
     expected_pubkey: PublicKey,
     encryptor: Encryptor,
@@ -19,7 +19,7 @@ struct ConfigurationChangeListenerConfig {
     reconfig_events: diem_channel::Receiver<(), OnChainConfigPayload>,
 }
 
-impl ConfigurationChangeListenerConfig {
+impl ValidatorSetListenerConfig {
     fn new(
         network_context: Arc<NetworkContext>,
         expected_pubkey: PublicKey,
@@ -44,22 +44,22 @@ enum State {
     STARTED,
 }
 
-pub struct ConfigurationChangeListenerBuilder {
-    config: Option<ConfigurationChangeListenerConfig>,
-    listener: Option<ConfigurationChangeListener>,
+pub struct ValidatorSetChangeListenerBuilder {
+    config: Option<ValidatorSetListenerConfig>,
+    listener: Option<ValidatorSetChangeListener>,
     state: State,
 }
 
-impl ConfigurationChangeListenerBuilder {
+impl ValidatorSetChangeListenerBuilder {
     pub fn create(
         network_context: Arc<NetworkContext>,
         expected_pubkey: PublicKey,
         encryptor: Encryptor,
         conn_mgr_reqs_tx: channel::Sender<ConnectivityRequest>,
         reconfig_events: diem_channel::Receiver<(), OnChainConfigPayload>,
-    ) -> ConfigurationChangeListenerBuilder {
+    ) -> ValidatorSetChangeListenerBuilder {
         Self {
-            config: Some(ConfigurationChangeListenerConfig::new(
+            config: Some(ValidatorSetListenerConfig::new(
                 network_context,
                 expected_pubkey,
                 encryptor,
@@ -75,7 +75,7 @@ impl ConfigurationChangeListenerBuilder {
         assert_eq!(self.state, State::CREATED);
         self.state = State::BUILT;
         let config = self.config.take().expect("Listener must be configured");
-        self.listener = Some(ConfigurationChangeListener::new(
+        self.listener = Some(ValidatorSetChangeListener::new(
             config.network_context,
             config.expected_pubkey,
             config.encryptor,

--- a/network/src/connectivity_manager/mod.rs
+++ b/network/src/connectivity_manager/mod.rs
@@ -120,7 +120,7 @@ pub struct ConnectivityManager<TBackoff> {
 #[repr(u8)]
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, NumVariants, Serialize)]
 pub enum DiscoverySource {
-    OnChain,
+    OnChainValidatorSet,
     Config,
 }
 
@@ -136,7 +136,7 @@ impl fmt::Display for DiscoverySource {
             f,
             "{}",
             match self {
-                DiscoverySource::OnChain => "OnChain",
+                DiscoverySource::OnChainValidatorSet => "OnChainValidatorSet",
                 DiscoverySource::Config => "Config",
             }
         )

--- a/network/src/connectivity_manager/test.rs
+++ b/network/src/connectivity_manager/test.rs
@@ -325,7 +325,7 @@ fn connect_to_seeds_on_startup() {
 
         // Sending an UpdateDiscoveredPeers with the same seed address should not
         // trigger any dials.
-        mock.send_update_discovered_peers(DiscoverySource::OnChain, seeds)
+        mock.send_update_discovered_peers(DiscoverySource::OnChainValidatorSet, seeds)
             .await;
         mock.trigger_connectivity_check().await;
         assert_eq!(0, mock.get_dial_queue_size().await);
@@ -334,7 +334,7 @@ fn connect_to_seeds_on_startup() {
         let (new_seed, new_seed_addr) =
             update_peer_with_address(seed_peer, "/ip4/127.0.1.1/tcp/8080");
         let update = hashmap! {seed_peer_id => new_seed};
-        mock.send_update_discovered_peers(DiscoverySource::OnChain, update)
+        mock.send_update_discovered_peers(DiscoverySource::OnChainValidatorSet, update)
             .await;
 
         // We expect the peer which changed its address to also disconnect.
@@ -362,7 +362,7 @@ fn addr_change() {
     let test = async move {
         // Sending address of other peer
         let update = hashmap! {other_peer_id => other_peer.clone()};
-        mock.send_update_discovered_peers(DiscoverySource::OnChain, update.clone())
+        mock.send_update_discovered_peers(DiscoverySource::OnChainValidatorSet, update.clone())
             .await;
 
         // Peer manager receives a request to connect to the other peer.
@@ -373,7 +373,7 @@ fn addr_change() {
 
         // Send request to connect to other peer at old address. ConnectivityManager should not
         // dial, since we are already connected at the new address.
-        mock.send_update_discovered_peers(DiscoverySource::OnChain, update)
+        mock.send_update_discovered_peers(DiscoverySource::OnChainValidatorSet, update)
             .await;
         mock.trigger_connectivity_check().await;
         assert_eq!(0, mock.get_dial_queue_size().await);
@@ -382,7 +382,7 @@ fn addr_change() {
         let (other_peer_new, other_addr_new) =
             update_peer_with_address(other_peer, "/ip4/127.0.1.1/tcp/8080");
         let update = hashmap! {other_peer_id => other_peer_new};
-        mock.send_update_discovered_peers(DiscoverySource::OnChain, update)
+        mock.send_update_discovered_peers(DiscoverySource::OnChainValidatorSet, update)
             .await;
         mock.trigger_connectivity_check().await;
         assert_eq!(1, mock.get_connected_size().await);
@@ -409,7 +409,7 @@ fn lost_connection() {
     let test = async move {
         // Sending address of other peer
         let update = hashmap! {other_peer_id => other_peer};
-        mock.send_update_discovered_peers(DiscoverySource::OnChain, update)
+        mock.send_update_discovered_peers(DiscoverySource::OnChainValidatorSet, update)
             .await;
 
         // Peer manager receives a request to connect to the other peer.
@@ -440,7 +440,7 @@ fn disconnect() {
     let test = async move {
         // Sending pubkey & address of other peer
         let peers = hashmap! {other_peer_id => other_peer.clone()};
-        mock.send_update_discovered_peers(DiscoverySource::OnChain, peers)
+        mock.send_update_discovered_peers(DiscoverySource::OnChainValidatorSet, peers)
             .await;
 
         // Waiting to receive dial request
@@ -455,7 +455,7 @@ fn disconnect() {
         peer.addresses = vec![network_address(DEFAULT_BASE_ADDR)];
 
         let peers = hashmap! {other_peer_id => peer};
-        mock.send_update_discovered_peers(DiscoverySource::OnChain, peers)
+        mock.send_update_discovered_peers(DiscoverySource::OnChainValidatorSet, peers)
             .await;
 
         // Peer is now ineligible, we should disconnect from them
@@ -475,7 +475,7 @@ fn retry_on_failure() {
     let test = async move {
         // Sending pubkey set and addr of other peer
         let peers = hashmap! {other_peer_id => peer.clone()};
-        mock.send_update_discovered_peers(DiscoverySource::OnChain, peers)
+        mock.send_update_discovered_peers(DiscoverySource::OnChainValidatorSet, peers)
             .await;
 
         // First dial attempt fails
@@ -495,7 +495,7 @@ fn retry_on_failure() {
         peer.keys = HashSet::new();
         peer.addresses = vec![network_address(DEFAULT_BASE_ADDR)];
         let peers = hashmap! {other_peer_id => peer};
-        mock.send_update_discovered_peers(DiscoverySource::OnChain, peers)
+        mock.send_update_discovered_peers(DiscoverySource::OnChainValidatorSet, peers)
             .await;
 
         // Peer manager receives a request to disconnect from the other peer, which fails.
@@ -522,7 +522,7 @@ fn no_op_requests() {
     let test = async move {
         // Sending pubkey set and addr of other peer
         let peers = hashmap! {other_peer_id => peer.clone()};
-        mock.send_update_discovered_peers(DiscoverySource::OnChain, peers)
+        mock.send_update_discovered_peers(DiscoverySource::OnChainValidatorSet, peers)
             .await;
 
         // Peer manager receives a request to connect to the other peer.
@@ -541,7 +541,7 @@ fn no_op_requests() {
         peer.keys = HashSet::new();
         peer.addresses = vec![network_address(DEFAULT_BASE_ADDR)];
         let peers = hashmap! {other_peer_id => peer};
-        mock.send_update_discovered_peers(DiscoverySource::OnChain, peers)
+        mock.send_update_discovered_peers(DiscoverySource::OnChainValidatorSet, peers)
             .await;
 
         // Peer manager receives a request to disconnect from the other peer, which fails.
@@ -573,7 +573,7 @@ fn backoff_on_failure() {
 
         // Sending pubkey set and addr of peers
         let peers = hashmap! {peer_id_a => peer_a, peer_id_b => peer_b};
-        mock.send_update_discovered_peers(DiscoverySource::OnChain, peers)
+        mock.send_update_discovered_peers(DiscoverySource::OnChainValidatorSet, peers)
             .await;
 
         // Send NewPeer notification for peer_b.
@@ -613,7 +613,7 @@ fn multiple_addrs_basic() {
 
         // Sending address of other peer
         let update = hashmap! {other_peer_id => peer};
-        mock.send_update_discovered_peers(DiscoverySource::OnChain, update)
+        mock.send_update_discovered_peers(DiscoverySource::OnChainValidatorSet, update)
             .await;
 
         // Assume that the first listen addr fails to connect.
@@ -646,7 +646,7 @@ fn multiple_addrs_wrapping() {
 
         // Sending address of other peer
         let update = hashmap! {other_peer_id => peer};
-        mock.send_update_discovered_peers(DiscoverySource::OnChain, update)
+        mock.send_update_discovered_peers(DiscoverySource::OnChainValidatorSet, update)
             .await;
 
         // Assume that the first listen addr fails to connect.
@@ -684,7 +684,7 @@ fn multiple_addrs_shrinking() {
 
         // Sending address of other peer
         let update = hashmap! {other_peer_id => peer.clone()};
-        mock.send_update_discovered_peers(DiscoverySource::OnChain, update)
+        mock.send_update_discovered_peers(DiscoverySource::OnChainValidatorSet, update)
             .await;
 
         // Assume that the first listen addr fails to connect.
@@ -698,7 +698,7 @@ fn multiple_addrs_shrinking() {
 
         // The peer issues a new, smaller set of listen addrs.
         let update = hashmap! {other_peer_id => peer};
-        mock.send_update_discovered_peers(DiscoverySource::OnChain, update)
+        mock.send_update_discovered_peers(DiscoverySource::OnChainValidatorSet, update)
             .await;
 
         // After updating the addresses, we should dial the first new address,
@@ -767,25 +767,27 @@ fn basic_update_discovered_peers() {
     let peers_1_2 = hashmap! {peer_id_a => peer_a_1_2, peer_id_b => peer_b1};
 
     // basic one peer one discovery source
-    conn_mgr.handle_update_discovered_peers(DiscoverySource::OnChain, peers_1.clone());
+    conn_mgr.handle_update_discovered_peers(DiscoverySource::OnChainValidatorSet, peers_1.clone());
     assert_eq!(*trusted_peers.read(), peers_1);
 
     // same update does nothing
-    conn_mgr.handle_update_discovered_peers(DiscoverySource::OnChain, peers_1.clone());
+    conn_mgr.handle_update_discovered_peers(DiscoverySource::OnChainValidatorSet, peers_1.clone());
     assert_eq!(*trusted_peers.read(), peers_1);
 
     // reset
-    conn_mgr.handle_update_discovered_peers(DiscoverySource::OnChain, peers_empty.clone());
+    conn_mgr
+        .handle_update_discovered_peers(DiscoverySource::OnChainValidatorSet, peers_empty.clone());
     assert_eq!(*trusted_peers.read(), peers_empty);
 
     // basic union across multiple sources
-    conn_mgr.handle_update_discovered_peers(DiscoverySource::OnChain, peers_1.clone());
+    conn_mgr.handle_update_discovered_peers(DiscoverySource::OnChainValidatorSet, peers_1.clone());
     assert_eq!(*trusted_peers.read(), peers_1);
     conn_mgr.handle_update_discovered_peers(DiscoverySource::Config, peers_2);
     assert_eq!(*trusted_peers.read(), peers_1_2);
 
     // does nothing even if another source has same set
-    conn_mgr.handle_update_discovered_peers(DiscoverySource::OnChain, peers_1_2.clone());
+    conn_mgr
+        .handle_update_discovered_peers(DiscoverySource::OnChainValidatorSet, peers_1_2.clone());
     assert_eq!(*trusted_peers.read(), peers_1_2);
     conn_mgr.handle_update_discovered_peers(DiscoverySource::Config, peers_1_2.clone());
     assert_eq!(*trusted_peers.read(), peers_1_2);
@@ -795,7 +797,8 @@ fn basic_update_discovered_peers() {
     assert_eq!(*trusted_peers.read(), peers_1_2);
 
     // reset
-    conn_mgr.handle_update_discovered_peers(DiscoverySource::OnChain, peers_empty.clone());
+    conn_mgr
+        .handle_update_discovered_peers(DiscoverySource::OnChainValidatorSet, peers_empty.clone());
     assert_eq!(*trusted_peers.read(), peers_empty);
 
     // empty update again does nothing

--- a/testsuite/cluster-test/src/experiments/load_test.rs
+++ b/testsuite/cluster-test/src/experiments/load_test.rs
@@ -296,7 +296,7 @@ impl StubbedNode {
 
         conn_req_tx
             .send(ConnectivityRequest::UpdateDiscoveredPeers(
-                DiscoverySource::OnChain,
+                DiscoverySource::OnChainValidatorSet,
                 seed_peers,
             ))
             .await


### PR DESCRIPTION
## Motivation

ConfigurationChangeListener is very generic, and the changes that it
listens to are not generic.  This is renaming it appropriately and all subsequent pieces that refer to `OnChain`
to keep it specific to `ValidatorSet` changes.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

None, rename so tests should handle it.

## Related PRs

N/A
