### PR TITLE
[move-prover] instrument write-backs before the Destroy operation

### DIFF
--- a/language/move-prover/bytecode/src/memory_instrumentation.rs
+++ b/language/move-prover/bytecode/src/memory_instrumentation.rs
@@ -92,10 +92,9 @@ impl<'a> Instrumenter<'a> {
     ) -> (Vec<Bytecode>, Vec<Bytecode>) {
         let (mut before, mut after) = self.public_function_instrumentation(code_offset, bytecode);
         let destroy_instr = self.ref_create_destroy_instrumentation(code_offset, bytecode);
-        if matches!(
-            bytecode,
-            Bytecode::Ret(..) | Bytecode::Branch(..) | Bytecode::Jump(..) | Bytecode::Abort(..)
-        ) {
+        if bytecode.is_branch()
+            || matches!(bytecode, Bytecode::Call(_, _, Operation::Destroy, _, _))
+        {
             // Add this to before instrumentation.
             before.extend(destroy_instr);
         } else {

--- a/language/move-prover/bytecode/tests/memory_instr/basic_test.exp
+++ b/language/move-prover/bytecode/tests/memory_instr/basic_test.exp
@@ -381,8 +381,8 @@ fun TestPackref::test7($t0|b: bool) {
  17: write_back[LocalRoot($t2).D]($t3)
  18: return ()
  19: label L3
- 20: destroy($t3)
- 21: write_back[LocalRoot($t1).D]($t3)
+ 20: write_back[LocalRoot($t1).D]($t3)
+ 21: destroy($t3)
  22: goto 10
  23: label L4
  24: destroy($t6)
@@ -418,9 +418,9 @@ fun TestPackref::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestPackref::R) 
   9: label L1
  10: goto 31
  11: label L0
- 12: destroy($t5)
- 13: write_back[LocalRoot($t3).D]($t5)
- 14: write_back[LocalRoot($t4).D]($t5)
+ 12: write_back[LocalRoot($t3).D]($t5)
+ 13: write_back[LocalRoot($t4).D]($t5)
+ 14: destroy($t5)
  15: $t10 := 2
  16: $t11 := /($t1, $t10)
  17: $t12 := 0
@@ -442,9 +442,9 @@ fun TestPackref::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestPackref::R) 
  33: label L9
  34: goto 42
  35: label L8
- 36: destroy($t5)
- 37: write_back[LocalRoot($t3).D]($t5)
- 38: write_back[LocalRoot($t4).D]($t5)
+ 36: write_back[LocalRoot($t3).D]($t5)
+ 37: write_back[LocalRoot($t4).D]($t5)
+ 38: destroy($t5)
  39: $t15 := 0
  40: TestPackref::test3($t2, $t15)
  41: goto 48

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/loop.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/loop.exp
@@ -1,3 +1,4 @@
 Running tests
+[ PASS    ] 0x2::A::loop_ind_ref
 [ PASS    ] 0x2::A::loop_ind_var
-Test result: OK. Total tests: 1; passed: 1; failed: 0
+Test result: OK. Total tests: 2; passed: 2; failed: 0

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/loop.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/loop.move
@@ -7,7 +7,7 @@ module 0x2::A {
         };
     }
 
-    // TODO (mengxu): there is an error in the transformation pipeline, a destroy($t) appears before the writeback($t).
+    #[test]
     public fun loop_ind_ref() {
         let i = 0;
         let p = &mut i;


### PR DESCRIPTION
Otherwise we see patterns like the following:

```
 26: destroy($t3)
 27: write_back[LocalRoot($t0).D]($t3)
```

It is not an issue with boogie translator because `destroy` will be
translated to a nop. But it will create a problem for the interpreter
(and possibly the write-set analysis too)

After this commit it will be like,
```
 26: write_back[LocalRoot($t0).D]($t3)
 27: destroy($t3)
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI
