### PR TITLE
[gha] open issue when db-restore fails in CI

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -121,6 +121,16 @@ jobs:
       - name: replay transactions
         run: |
           cargo run --release --bin db-restore -- --concurrent-downloads 2 --target-db-dir /var/tmp/dbrestore/ auto --replay-all command-adapter --config "$CONFIG"
+      - uses: diem/actions/create-issue@04f4286ca22e4b9efbc5eb49a20e2e5389c5318b
+        if: ${{ failure() }}
+        env:
+          JOB_URL: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          title: "DB restore in transaction replay failed"
+          body: "Found db-restore failure in job ${{ env.JOB_URL }}"
+          assignees: "msmouse"
+          labels: "storage"
       - uses: ./.github/actions/build-teardown
 
   json-rpc-backward-compat-test:


### PR DESCRIPTION
## Motivation
Create a GH issue or update an existing one when db-restore fails the transaction-replay job in nightly.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan
canary in https://github.com/sausagee/libra/runs/2520895957?check_suite_focus=true which created issue https://github.com/sausagee/libra/issues/160