### PR TITLE
[move-core] Refactored MoveResource trait

### DIFF
--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -26,7 +26,7 @@ use diem_types::{
 use hex::FromHex;
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, language_storage::TypeTag,
-    move_resource::MoveResource,
+    move_resource::MoveStructType,
 };
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
 use std::{

--- a/language/diem-tools/transaction-replay/src/unit_tests/bisection_tests.rs
+++ b/language/diem-tools/transaction-replay/src/unit_tests/bisection_tests.rs
@@ -8,7 +8,7 @@ use diem_types::{
     account_config::AccountResource,
     event::{EventHandle, EventKey},
 };
-use move_core_types::{effects::ChangeSet, move_resource::MoveResource};
+use move_core_types::{effects::ChangeSet, move_resource::MoveStructType};
 use std::path::PathBuf;
 
 #[test]

--- a/language/diem-vm/src/diem_transaction_validator.rs
+++ b/language/diem-vm/src/diem_transaction_validator.rs
@@ -19,7 +19,7 @@ use diem_types::{
 };
 use move_core_types::{
     identifier::{IdentStr, Identifier},
-    move_resource::MoveResource,
+    move_resource::MoveStructType,
 };
 use move_vm_runtime::{data_cache::MoveStorage, logging::LogContext, session::Session};
 

--- a/language/move-core/types/src/move_resource.rs
+++ b/language/move-core/types/src/move_resource.rs
@@ -5,8 +5,9 @@ use crate::{
     identifier::{IdentStr, Identifier},
     language_storage::{StructTag, TypeTag},
 };
+use serde::de::DeserializeOwned;
 
-pub trait MoveResource {
+pub trait MoveStructType {
     const MODULE_NAME: &'static str;
     const STRUCT_NAME: &'static str;
 
@@ -34,7 +35,9 @@ pub trait MoveResource {
             type_params: Self::type_params(),
         }
     }
+}
 
+pub trait MoveResource: MoveStructType + DeserializeOwned {
     fn resource_path() -> Vec<u8> {
         Self::struct_tag().access_vector()
     }

--- a/language/testing-infra/e2e-tests/src/account.rs
+++ b/language/testing-infra/e2e-tests/src/account.rs
@@ -24,7 +24,7 @@ use diem_types::{
 use move_core_types::{
     identifier::{IdentStr, Identifier},
     language_storage::{ResourceKey, StructTag},
-    move_resource::MoveResource,
+    move_resource::MoveStructType,
     value::{MoveStructLayout, MoveTypeLayout},
 };
 use move_vm_types::values::{Struct, Value};

--- a/sdk/client/src/blocking.rs
+++ b/sdk/client/src/blocking.rs
@@ -22,7 +22,7 @@ use diem_types::{
     event::EventKey,
     transaction::{SignedTransaction, Transaction},
 };
-use move_core_types::move_resource::MoveResource;
+use move_core_types::move_resource::{MoveResource, MoveStructType};
 use serde::{de::DeserializeOwned, Serialize};
 use std::time::Duration;
 
@@ -249,7 +249,7 @@ impl BlockingClient {
     /// results
     /// Returns an empty vector if there are no such event
     /// The type `T` must match the event types associated with `event_key`
-    pub fn get_deserialized_events<T: MoveResource + DeserializeOwned>(
+    pub fn get_deserialized_events<T: MoveStructType + DeserializeOwned>(
         &self,
         event_key: &EventKey,
         start_seq: u64,
@@ -266,7 +266,7 @@ impl BlockingClient {
 
     /// Deserialize and return the resource value of type `T` stored under `address`
     /// Returns None if there is no such value
-    pub fn get_deserialized_resource<T: MoveResource + DeserializeOwned>(
+    pub fn get_deserialized_resource<T: MoveResource>(
         &self,
         address: AccountAddress,
     ) -> Result<Response<Option<T>>> {

--- a/sdk/client/src/client.rs
+++ b/sdk/client/src/client.rs
@@ -22,7 +22,7 @@ use diem_types::{
     event::EventKey,
     transaction::{SignedTransaction, Transaction},
 };
-use move_core_types::move_resource::MoveResource;
+use move_core_types::move_resource::{MoveResource, MoveStructType};
 use reqwest::Client as ReqwestClient;
 use serde::{de::DeserializeOwned, Serialize};
 use std::time::Duration;
@@ -269,7 +269,7 @@ impl Client {
     /// results
     /// Returns an empty vector if there are no such events
     /// The type `T` must match the event types associated with `event_key`
-    pub async fn get_deserialized_events<T: MoveResource + DeserializeOwned>(
+    pub async fn get_deserialized_events<T: MoveStructType + DeserializeOwned>(
         &self,
         event_key: &EventKey,
         start_seq: u64,
@@ -287,7 +287,7 @@ impl Client {
 
     /// Deserialize and return the resource value of type `T` stored under `address`
     /// Returns None if there is no such value
-    pub async fn get_deserialized_resource<T: MoveResource + DeserializeOwned>(
+    pub async fn get_deserialized_resource<T: MoveResource>(
         &self,
         address: AccountAddress,
     ) -> Result<Response<Option<T>>> {

--- a/sdk/client/src/move_deserialize.rs
+++ b/sdk/client/src/move_deserialize.rs
@@ -8,19 +8,19 @@ use diem_types::{
     account_state_blob::AccountStateBlob,
     contract_event::{ContractEvent, EventWithProof},
 };
-use move_core_types::{language_storage::TypeTag, move_resource::MoveResource};
+use move_core_types::{language_storage::TypeTag, move_resource::{MoveResource, MoveStructType}};
 use serde::de::DeserializeOwned;
 use std::convert::TryFrom;
 
 /// Wrapper for a deserialized Move event and its containing `ContractEvent`
 #[derive(Debug, Clone)]
-pub struct Event<T: MoveResource + DeserializeOwned> {
+pub struct Event<T: MoveStructType + DeserializeOwned> {
     /// The deserialized event type
     data: T,
     event: ContractEvent,
 }
 
-impl<T: MoveResource + DeserializeOwned> Event<T> {
+impl<T: MoveStructType + DeserializeOwned> Event<T> {
     pub fn data(&self) -> &T {
         &self.data
     }
@@ -32,7 +32,7 @@ impl<T: MoveResource + DeserializeOwned> Event<T> {
 
 /// Deserialize and return the Move events of type `T` in `events`
 /// The type `T` must match the specified event types in `events`
-pub fn get_events<T: MoveResource + DeserializeOwned>(
+pub fn get_events<T: MoveStructType + DeserializeOwned>(
     events: Vec<EventWithProofView>,
 ) -> Result<Vec<Event<T>>> {
     let events_with_proof: Vec<EventWithProof> = events
@@ -78,7 +78,7 @@ fn get_account_state(
 
 /// Deserialize and return the Move value of type `T` in `account_state_with_proof`
 /// Returns None if no resource of type `T` exists under `address`
-pub fn get_resource<T: MoveResource + DeserializeOwned>(
+pub fn get_resource<T: MoveResource>(
     account_state_with_proof: AccountStateWithProofView,
 ) -> Result<Option<T>> {
     if let Some(account_state) = get_account_state(account_state_with_proof)? {

--- a/storage/diemdb/src/event_store/test.rs
+++ b/storage/diemdb/src/event_store/test.rs
@@ -13,7 +13,7 @@ use diem_types::{
     proptest_types::{AccountInfoUniverse, ContractEventGen},
 };
 use itertools::Itertools;
-use move_core_types::{language_storage::TypeTag, move_resource::MoveResource};
+use move_core_types::{language_storage::TypeTag, move_resource::MoveStructType};
 use proptest::{
     collection::{hash_set, vec},
     prelude::*,

--- a/testsuite/cli/src/diem_client.rs
+++ b/testsuite/cli/src/diem_client.rs
@@ -1,13 +1,11 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{bail, ensure, Result};
+use anyhow::{ensure, Result};
 use diem_client::{views, BlockingClient, Response, WaitForTransactionError};
 use diem_logger::prelude::info;
 use diem_types::{
-    access_path::AccessPath,
     account_address::AccountAddress,
-    account_config::{ACCOUNT_RECEIVED_EVENT_PATH, ACCOUNT_SENT_EVENT_PATH},
     account_state_blob::AccountStateBlob,
     epoch_change::EpochChangeProof,
     event::EventKey,
@@ -223,31 +221,5 @@ impl DiemClient {
             .get_transactions(start_version, limit, fetch_events)
             .map_err(Into::into)
             .map(Response::into_inner)
-    }
-
-    pub fn get_events_by_access_path(
-        &self,
-        access_path: AccessPath,
-        start_event_seq_num: u64,
-        limit: u64,
-    ) -> Result<(Vec<views::EventView>, views::AccountView)> {
-        // get event key from access_path
-        match self.get_account(&access_path.address)? {
-            None => bail!("No account found for address {:?}", access_path.address),
-            Some(account_view) => {
-                let path = access_path.path;
-                let event_key = if path == ACCOUNT_SENT_EVENT_PATH.to_vec() {
-                    &account_view.sent_events_key
-                } else if path == ACCOUNT_RECEIVED_EVENT_PATH.to_vec() {
-                    &account_view.received_events_key
-                } else {
-                    bail!("Unexpected event path found in access path");
-                };
-
-                // get_events
-                let events = self.get_events(*event_key, start_event_seq_num, limit)?;
-                Ok((events, account_view))
-            }
-        }
     }
 }

--- a/types/src/account_config/events/admin_transaction.rs
+++ b/types/src/account_config/events/admin_transaction.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use move_core_types::move_resource::MoveResource;
+use move_core_types::move_resource::MoveStructType;
 use serde::{Deserialize, Serialize};
 
 /// Struct that represents a AdminEvent.
@@ -22,7 +22,7 @@ impl AdminTransactionEvent {
     }
 }
 
-impl MoveResource for AdminTransactionEvent {
+impl MoveStructType for AdminTransactionEvent {
     const MODULE_NAME: &'static str = "DiemAccount";
     const STRUCT_NAME: &'static str = "AdminTransactionEvent";
 }

--- a/types/src/account_config/events/base_url_rotation.rs
+++ b/types/src/account_config/events/base_url_rotation.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use move_core_types::move_resource::MoveResource;
+use move_core_types::move_resource::MoveStructType;
 use serde::{Deserialize, Serialize};
 
 /// Struct that represents a BaseUrlRotationEvent.
@@ -28,7 +28,7 @@ impl BaseUrlRotationEvent {
     }
 }
 
-impl MoveResource for BaseUrlRotationEvent {
+impl MoveStructType for BaseUrlRotationEvent {
     const MODULE_NAME: &'static str = "DualAttestation";
     const STRUCT_NAME: &'static str = "BaseUrlRotationEvent";
 }

--- a/types/src/account_config/events/burn.rs
+++ b/types/src/account_config/events/burn.rs
@@ -5,7 +5,7 @@ use crate::{account_address::AccountAddress, account_config::DIEM_MODULE_NAME};
 use anyhow::Result;
 use move_core_types::{
     identifier::{IdentStr, Identifier},
-    move_resource::MoveResource,
+    move_resource::MoveStructType,
 };
 use serde::{Deserialize, Serialize};
 
@@ -38,7 +38,7 @@ impl BurnEvent {
     }
 }
 
-impl MoveResource for BurnEvent {
+impl MoveStructType for BurnEvent {
     const MODULE_NAME: &'static str = DIEM_MODULE_NAME;
     const STRUCT_NAME: &'static str = "BurnEvent";
 }

--- a/types/src/account_config/events/cancel_burn.rs
+++ b/types/src/account_config/events/cancel_burn.rs
@@ -5,7 +5,7 @@ use crate::{account_address::AccountAddress, account_config::DIEM_MODULE_NAME};
 use anyhow::Result;
 use move_core_types::{
     identifier::{IdentStr, Identifier},
-    move_resource::MoveResource,
+    move_resource::MoveStructType,
 };
 use serde::{Deserialize, Serialize};
 
@@ -38,7 +38,7 @@ impl CancelBurnEvent {
     }
 }
 
-impl MoveResource for CancelBurnEvent {
+impl MoveStructType for CancelBurnEvent {
     const MODULE_NAME: &'static str = DIEM_MODULE_NAME;
     const STRUCT_NAME: &'static str = "CancelBurnEvent";
 }

--- a/types/src/account_config/events/compliance_key_rotation.rs
+++ b/types/src/account_config/events/compliance_key_rotation.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use move_core_types::move_resource::MoveResource;
+use move_core_types::move_resource::MoveStructType;
 use serde::{Deserialize, Serialize};
 
 /// Struct that represents a ComplianceKeyRotationEvent.
@@ -28,7 +28,7 @@ impl ComplianceKeyRotationEvent {
     }
 }
 
-impl MoveResource for ComplianceKeyRotationEvent {
+impl MoveStructType for ComplianceKeyRotationEvent {
     const MODULE_NAME: &'static str = "DualAttestation";
     const STRUCT_NAME: &'static str = "ComplianceKeyRotationEvent";
 }

--- a/types/src/account_config/events/create_account.rs
+++ b/types/src/account_config/events/create_account.rs
@@ -3,7 +3,7 @@
 
 use crate::{account_address::AccountAddress, account_config, event::EventKey};
 use anyhow::Result;
-use move_core_types::move_resource::MoveResource;
+use move_core_types::move_resource::MoveStructType;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -30,7 +30,7 @@ impl CreateAccountEvent {
     }
 }
 
-impl MoveResource for CreateAccountEvent {
+impl MoveStructType for CreateAccountEvent {
     const MODULE_NAME: &'static str = "DiemAccount";
     const STRUCT_NAME: &'static str = "CreateAccountEvent";
 }

--- a/types/src/account_config/events/exchange_rate_update.rs
+++ b/types/src/account_config/events/exchange_rate_update.rs
@@ -5,7 +5,7 @@ use crate::account_config::DIEM_MODULE_NAME;
 use anyhow::Result;
 use move_core_types::{
     identifier::{IdentStr, Identifier},
-    move_resource::MoveResource,
+    move_resource::MoveStructType,
 };
 use serde::{Deserialize, Serialize};
 
@@ -36,7 +36,7 @@ impl ToXDXExchangeRateUpdateEvent {
     }
 }
 
-impl MoveResource for ToXDXExchangeRateUpdateEvent {
+impl MoveStructType for ToXDXExchangeRateUpdateEvent {
     const MODULE_NAME: &'static str = DIEM_MODULE_NAME;
     const STRUCT_NAME: &'static str = "ToXDXExchangeRateUpdateEvent";
 }

--- a/types/src/account_config/events/mint.rs
+++ b/types/src/account_config/events/mint.rs
@@ -5,7 +5,7 @@ use crate::account_config::DIEM_MODULE_NAME;
 use anyhow::Result;
 use move_core_types::{
     identifier::{IdentStr, Identifier},
-    move_resource::MoveResource,
+    move_resource::MoveStructType,
 };
 use serde::{Deserialize, Serialize};
 
@@ -32,7 +32,7 @@ impl MintEvent {
     }
 }
 
-impl MoveResource for MintEvent {
+impl MoveStructType for MintEvent {
     const MODULE_NAME: &'static str = DIEM_MODULE_NAME;
     const STRUCT_NAME: &'static str = "MintEvent";
 }

--- a/types/src/account_config/events/new_block.rs
+++ b/types/src/account_config/events/new_block.rs
@@ -3,7 +3,7 @@
 
 use crate::account_address::AccountAddress;
 use anyhow::Result;
-use move_core_types::move_resource::MoveResource;
+use move_core_types::move_resource::MoveStructType;
 use serde::{Deserialize, Serialize};
 
 /// Struct that represents a NewBlockEvent.
@@ -48,7 +48,7 @@ impl NewBlockEvent {
     }
 }
 
-impl MoveResource for NewBlockEvent {
+impl MoveStructType for NewBlockEvent {
     const MODULE_NAME: &'static str = "DiemBlock";
     const STRUCT_NAME: &'static str = "NewBlockEvent";
 }

--- a/types/src/account_config/events/new_epoch.rs
+++ b/types/src/account_config/events/new_epoch.rs
@@ -3,7 +3,7 @@
 
 use crate::event::EventKey;
 use anyhow::Result;
-use move_core_types::move_resource::MoveResource;
+use move_core_types::move_resource::MoveStructType;
 use serde::{Deserialize, Serialize};
 
 /// Struct that represents a NewEpochEvent.
@@ -26,7 +26,7 @@ impl NewEpochEvent {
     }
 }
 
-impl MoveResource for NewEpochEvent {
+impl MoveStructType for NewEpochEvent {
     const MODULE_NAME: &'static str = "DiemConfig";
     const STRUCT_NAME: &'static str = "NewEpochEvent";
 }

--- a/types/src/account_config/events/preburn.rs
+++ b/types/src/account_config/events/preburn.rs
@@ -5,7 +5,7 @@ use crate::{account_address::AccountAddress, account_config::DIEM_MODULE_NAME};
 use anyhow::Result;
 use move_core_types::{
     identifier::{IdentStr, Identifier},
-    move_resource::MoveResource,
+    move_resource::MoveStructType,
 };
 use serde::{Deserialize, Serialize};
 
@@ -38,7 +38,7 @@ impl PreburnEvent {
     }
 }
 
-impl MoveResource for PreburnEvent {
+impl MoveStructType for PreburnEvent {
     const MODULE_NAME: &'static str = DIEM_MODULE_NAME;
     const STRUCT_NAME: &'static str = "PreburnEvent";
 }

--- a/types/src/account_config/events/received_mint.rs
+++ b/types/src/account_config/events/received_mint.rs
@@ -6,7 +6,7 @@ use crate::account_address::AccountAddress;
 use anyhow::Result;
 use move_core_types::{
     identifier::{IdentStr, Identifier},
-    move_resource::MoveResource,
+    move_resource::MoveStructType,
 };
 use serde::{Deserialize, Serialize};
 
@@ -39,7 +39,7 @@ impl ReceivedMintEvent {
     }
 }
 
-impl MoveResource for ReceivedMintEvent {
+impl MoveStructType for ReceivedMintEvent {
     const MODULE_NAME: &'static str = "DesignatedDealer";
     const STRUCT_NAME: &'static str = "ReceivedMintEvent";
 }

--- a/types/src/account_config/events/received_payment.rs
+++ b/types/src/account_config/events/received_payment.rs
@@ -1,25 +1,13 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    account_address::AccountAddress,
-    account_config::{constants::ACCOUNT_MODULE_NAME, resources::AccountResource},
-};
+use crate::{account_address::AccountAddress, account_config::constants::ACCOUNT_MODULE_NAME};
 use anyhow::Result;
 use move_core_types::{
     identifier::{IdentStr, Identifier},
-    move_resource::MoveResource,
+    move_resource::MoveStructType,
 };
-use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
-
-/// Returns the path to the received event counter for an Account resource.
-/// It can be used to query the event DB for the given event.
-pub static ACCOUNT_RECEIVED_EVENT_PATH: Lazy<Vec<u8>> = Lazy::new(|| {
-    let mut path = AccountResource::resource_path();
-    path.extend_from_slice(b"/received_events_count/");
-    path
-});
 
 /// Struct that represents a ReceivedPaymentEvent.
 #[derive(Debug, Serialize, Deserialize)]
@@ -56,7 +44,7 @@ impl ReceivedPaymentEvent {
     }
 }
 
-impl MoveResource for ReceivedPaymentEvent {
+impl MoveStructType for ReceivedPaymentEvent {
     const MODULE_NAME: &'static str = ACCOUNT_MODULE_NAME;
     const STRUCT_NAME: &'static str = "ReceivedPaymentEvent";
 }

--- a/types/src/account_config/events/sent_payment.rs
+++ b/types/src/account_config/events/sent_payment.rs
@@ -1,25 +1,13 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    account_address::AccountAddress,
-    account_config::{constants::ACCOUNT_MODULE_NAME, resources::AccountResource},
-};
+use crate::{account_address::AccountAddress, account_config::constants::ACCOUNT_MODULE_NAME};
 use anyhow::Result;
 use move_core_types::{
     identifier::{IdentStr, Identifier},
-    move_resource::MoveResource,
+    move_resource::MoveStructType,
 };
-use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
-
-/// The path to the sent event counter for an Account resource.
-/// It can be used to query the event DB for the given event.
-pub static ACCOUNT_SENT_EVENT_PATH: Lazy<Vec<u8>> = Lazy::new(|| {
-    let mut path = AccountResource::resource_path();
-    path.extend_from_slice(b"/sent_events_count/");
-    path
-});
 
 /// Struct that represents a SentPaymentEvent.
 #[derive(Debug, Serialize, Deserialize)]
@@ -71,7 +59,7 @@ impl SentPaymentEvent {
     }
 }
 
-impl MoveResource for SentPaymentEvent {
+impl MoveStructType for SentPaymentEvent {
     const MODULE_NAME: &'static str = ACCOUNT_MODULE_NAME;
     const STRUCT_NAME: &'static str = "SentPaymentEvent";
 }

--- a/types/src/account_config/resources/account.rs
+++ b/types/src/account_config/resources/account.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     event::EventHandle,
 };
-use move_core_types::move_resource::MoveResource;
+use move_core_types::move_resource::{MoveResource, MoveStructType};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -76,7 +76,9 @@ impl AccountResource {
     }
 }
 
-impl MoveResource for AccountResource {
+impl MoveStructType for AccountResource {
     const MODULE_NAME: &'static str = ACCOUNT_MODULE_NAME;
     const STRUCT_NAME: &'static str = ACCOUNT_MODULE_NAME;
 }
+
+impl MoveResource for AccountResource {}

--- a/types/src/account_config/resources/balance.rs
+++ b/types/src/account_config/resources/balance.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use move_core_types::{
     language_storage::{StructTag, TypeTag},
-    move_resource::MoveResource,
+    move_resource::{MoveResource, MoveStructType},
 };
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
@@ -45,7 +45,7 @@ impl BalanceResource {
     }
 }
 
-impl MoveResource for BalanceResource {
+impl MoveStructType for BalanceResource {
     const MODULE_NAME: &'static str = ACCOUNT_MODULE_NAME;
     const STRUCT_NAME: &'static str = "Balance";
 
@@ -53,3 +53,5 @@ impl MoveResource for BalanceResource {
         vec![xus_tag()]
     }
 }
+
+impl MoveResource for BalanceResource {}

--- a/types/src/account_config/resources/chain_id.rs
+++ b/types/src/account_config/resources/chain_id.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::chain_id::ChainId;
-use move_core_types::move_resource::MoveResource;
+use move_core_types::move_resource::{MoveResource, MoveStructType};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -16,7 +16,9 @@ impl ChainIdResource {
     }
 }
 
-impl MoveResource for ChainIdResource {
+impl MoveStructType for ChainIdResource {
     const MODULE_NAME: &'static str = "ChainId";
     const STRUCT_NAME: &'static str = "ChainId";
 }
+
+impl MoveResource for ChainIdResource {}

--- a/types/src/account_config/resources/currency_info.rs
+++ b/types/src/account_config/resources/currency_info.rs
@@ -10,7 +10,7 @@ use anyhow::Result;
 use move_core_types::{
     identifier::{IdentStr, Identifier},
     language_storage::{ResourceKey, StructTag},
-    move_resource::MoveResource,
+    move_resource::{MoveResource, MoveStructType},
 };
 use serde::{Deserialize, Serialize};
 
@@ -32,10 +32,12 @@ pub struct CurrencyInfoResource {
     exchange_rate_update_events: EventHandle,
 }
 
-impl MoveResource for CurrencyInfoResource {
+impl MoveStructType for CurrencyInfoResource {
     const MODULE_NAME: &'static str = "Diem";
     const STRUCT_NAME: &'static str = "CurrencyInfo";
 }
+
+impl MoveResource for CurrencyInfoResource {}
 
 impl CurrencyInfoResource {
     pub fn new(

--- a/types/src/account_config/resources/designated_dealer.rs
+++ b/types/src/account_config/resources/designated_dealer.rs
@@ -5,7 +5,10 @@ use crate::{
     account_config::{PreburnQueueResource, PreburnResource},
     event::EventHandle,
 };
-use move_core_types::{identifier::Identifier, move_resource::MoveResource};
+use move_core_types::{
+    identifier::Identifier,
+    move_resource::{MoveResource, MoveStructType},
+};
 use serde::{Deserialize, Serialize};
 use std::collections::btree_map::BTreeMap;
 
@@ -21,10 +24,12 @@ impl DesignatedDealer {
     }
 }
 
-impl MoveResource for DesignatedDealer {
+impl MoveStructType for DesignatedDealer {
     const MODULE_NAME: &'static str = "DesignatedDealer";
     const STRUCT_NAME: &'static str = "Dealer";
 }
+
+impl MoveResource for DesignatedDealer {}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum DesignatedDealerPreburns {

--- a/types/src/account_config/resources/dual_attestation.rs
+++ b/types/src/account_config/resources/dual_attestation.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{event::EventHandle, on_chain_config::OnChainConfig};
-use move_core_types::move_resource::MoveResource;
+use move_core_types::move_resource::{MoveResource, MoveStructType};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -41,10 +41,12 @@ impl Credential {
     }
 }
 
-impl MoveResource for Credential {
+impl MoveStructType for Credential {
     const MODULE_NAME: &'static str = "DualAttestation";
     const STRUCT_NAME: &'static str = "Credential";
 }
+
+impl MoveResource for Credential {}
 
 /// Defines the dual attest limit in microDiem XDX
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -56,7 +58,9 @@ impl OnChainConfig for Limit {
     const IDENTIFIER: &'static str = "Limit";
 }
 
-impl MoveResource for Limit {
+impl MoveStructType for Limit {
     const MODULE_NAME: &'static str = "DualAttestation";
     const STRUCT_NAME: &'static str = "Limit";
 }
+
+impl MoveResource for Limit {}

--- a/types/src/account_config/resources/freezing_bit.rs
+++ b/types/src/account_config/resources/freezing_bit.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_core_types::move_resource::MoveResource;
+use move_core_types::move_resource::{MoveResource, MoveStructType};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -15,7 +15,9 @@ impl FreezingBit {
     }
 }
 
-impl MoveResource for FreezingBit {
+impl MoveStructType for FreezingBit {
     const MODULE_NAME: &'static str = "AccountFreezing";
     const STRUCT_NAME: &'static str = "FreezingBit";
 }
+
+impl MoveResource for FreezingBit {}

--- a/types/src/account_config/resources/key_rotation_capability.rs
+++ b/types/src/account_config/resources/key_rotation_capability.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{account_address::AccountAddress, account_config::constants::ACCOUNT_MODULE_NAME};
-use move_core_types::move_resource::MoveResource;
+use move_core_types::move_resource::{MoveResource, MoveStructType};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -13,7 +13,9 @@ pub struct KeyRotationCapabilityResource {
     account_address: AccountAddress,
 }
 
-impl MoveResource for KeyRotationCapabilityResource {
+impl MoveStructType for KeyRotationCapabilityResource {
     const MODULE_NAME: &'static str = ACCOUNT_MODULE_NAME;
     const STRUCT_NAME: &'static str = "KeyRotationCapability";
 }
+
+impl MoveResource for KeyRotationCapabilityResource {}

--- a/types/src/account_config/resources/preburn_balance.rs
+++ b/types/src/account_config/resources/preburn_balance.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use move_core_types::{
     language_storage::{StructTag, TypeTag},
-    move_resource::MoveResource,
+    move_resource::{MoveResource, MoveStructType},
 };
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
@@ -45,7 +45,7 @@ impl PreburnResource {
     }
 }
 
-impl MoveResource for PreburnResource {
+impl MoveStructType for PreburnResource {
     const MODULE_NAME: &'static str = DIEM_MODULE_NAME;
     const STRUCT_NAME: &'static str = "Preburn";
 
@@ -53,3 +53,5 @@ impl MoveResource for PreburnResource {
         vec![xus_tag()]
     }
 }
+
+impl MoveResource for PreburnResource {}

--- a/types/src/account_config/resources/preburn_queue.rs
+++ b/types/src/account_config/resources/preburn_queue.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use move_core_types::{
     language_storage::{StructTag, TypeTag},
-    move_resource::MoveResource,
+    move_resource::{MoveResource, MoveStructType},
 };
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
@@ -46,7 +46,7 @@ impl PreburnQueueResource {
     }
 }
 
-impl MoveResource for PreburnQueueResource {
+impl MoveStructType for PreburnQueueResource {
     const MODULE_NAME: &'static str = DIEM_MODULE_NAME;
     const STRUCT_NAME: &'static str = "PreburnQueue";
 
@@ -54,3 +54,5 @@ impl MoveResource for PreburnQueueResource {
         vec![xus_tag()]
     }
 }
+
+impl MoveResource for PreburnQueueResource {}

--- a/types/src/account_config/resources/preburn_with_metadata.rs
+++ b/types/src/account_config/resources/preburn_with_metadata.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use move_core_types::{
     language_storage::{StructTag, TypeTag},
-    move_resource::MoveResource,
+    move_resource::{MoveResource, MoveStructType},
 };
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
@@ -55,7 +55,7 @@ impl PreburnWithMetadataResource {
     }
 }
 
-impl MoveResource for PreburnWithMetadataResource {
+impl MoveStructType for PreburnWithMetadataResource {
     const MODULE_NAME: &'static str = DIEM_MODULE_NAME;
     const STRUCT_NAME: &'static str = "PreburnWithMetadata";
 
@@ -63,3 +63,5 @@ impl MoveResource for PreburnWithMetadataResource {
         vec![xus_tag()]
     }
 }
+
+impl MoveResource for PreburnWithMetadataResource {}

--- a/types/src/account_config/resources/role_id.rs
+++ b/types/src/account_config/resources/role_id.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_core_types::move_resource::MoveResource;
+use move_core_types::move_resource::{MoveResource, MoveStructType};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -15,7 +15,9 @@ impl RoleId {
     }
 }
 
-impl MoveResource for RoleId {
+impl MoveStructType for RoleId {
     const MODULE_NAME: &'static str = "Roles";
     const STRUCT_NAME: &'static str = "RoleId";
 }
+
+impl MoveResource for RoleId {}

--- a/types/src/account_config/resources/vasp.rs
+++ b/types/src/account_config/resources/vasp.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::account_address::AccountAddress;
-use move_core_types::move_resource::MoveResource;
+use move_core_types::move_resource::{MoveResource, MoveStructType};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -30,12 +30,15 @@ impl ChildVASP {
     }
 }
 
-impl MoveResource for ParentVASP {
+impl MoveStructType for ParentVASP {
     const MODULE_NAME: &'static str = "VASP";
     const STRUCT_NAME: &'static str = "ParentVASP";
 }
 
-impl MoveResource for ChildVASP {
+impl MoveStructType for ChildVASP {
     const MODULE_NAME: &'static str = "VASP";
     const STRUCT_NAME: &'static str = "ChildVASP";
 }
+
+impl MoveResource for ParentVASP {}
+impl MoveResource for ChildVASP {}

--- a/types/src/account_config/resources/withdraw_capability.rs
+++ b/types/src/account_config/resources/withdraw_capability.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{account_address::AccountAddress, account_config::constants::ACCOUNT_MODULE_NAME};
-use move_core_types::move_resource::MoveResource;
+use move_core_types::move_resource::{MoveResource, MoveStructType};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -13,7 +13,9 @@ pub struct WithdrawCapabilityResource {
     account_address: AccountAddress,
 }
 
-impl MoveResource for WithdrawCapabilityResource {
+impl MoveStructType for WithdrawCapabilityResource {
     const MODULE_NAME: &'static str = ACCOUNT_MODULE_NAME;
     const STRUCT_NAME: &'static str = "WithdrawCapability";
 }
+
+impl MoveResource for WithdrawCapabilityResource {}

--- a/types/src/account_state.rs
+++ b/types/src/account_state.rs
@@ -229,7 +229,7 @@ impl AccountState {
         self.get_resource_impl(&T::CONFIG_ID.access_path().path)
     }
 
-    pub fn get_resource<T: MoveResource + DeserializeOwned>(&self) -> Result<Option<T>> {
+    pub fn get_resource<T: MoveResource>(&self) -> Result<Option<T>> {
         self.get_resource_impl(&T::struct_tag().access_vector())
     }
 

--- a/types/src/block_metadata.rs
+++ b/types/src/block_metadata.rs
@@ -7,7 +7,7 @@ use crate::{
     event::{EventHandle, EventKey},
 };
 use diem_crypto::HashValue;
-use move_core_types::move_resource::MoveResource;
+use move_core_types::move_resource::{MoveResource, MoveStructType};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 
@@ -95,10 +95,12 @@ impl DiemBlockResource {
     }
 }
 
-impl MoveResource for DiemBlockResource {
+impl MoveStructType for DiemBlockResource {
     const MODULE_NAME: &'static str = "DiemBlock";
     const STRUCT_NAME: &'static str = "BlockMetadata";
 }
+
+impl MoveResource for DiemBlockResource {}
 
 #[derive(Clone, Deserialize, Serialize)]
 pub struct NewBlockEvent {

--- a/types/src/contract_event.rs
+++ b/types/src/contract_event.rs
@@ -16,7 +16,7 @@ use crate::{
 use anyhow::{ensure, Error, Result};
 use diem_crypto::hash::CryptoHash;
 use diem_crypto_derive::{BCSCryptoHash, CryptoHasher};
-use move_core_types::{language_storage::TypeTag, move_resource::MoveResource};
+use move_core_types::{language_storage::TypeTag, move_resource::MoveStructType};
 
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;

--- a/types/src/diem_timestamp.rs
+++ b/types/src/diem_timestamp.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_core_types::move_resource::MoveResource;
+use move_core_types::move_resource::{MoveResource, MoveStructType};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -9,10 +9,12 @@ pub struct DiemTimestampResource {
     pub diem_timestamp: DiemTimestamp,
 }
 
-impl MoveResource for DiemTimestampResource {
+impl MoveStructType for DiemTimestampResource {
     const MODULE_NAME: &'static str = "DiemTimestamp";
     const STRUCT_NAME: &'static str = "CurrentTimeMicroseconds";
 }
+
+impl MoveResource for DiemTimestampResource {}
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct DiemTimestamp {

--- a/types/src/on_chain_config/mod.rs
+++ b/types/src/on_chain_config/mod.rs
@@ -11,7 +11,7 @@ use anyhow::{format_err, Result};
 use move_core_types::{
     identifier::Identifier,
     language_storage::{StructTag, TypeTag},
-    move_resource::MoveResource,
+    move_resource::{MoveResource, MoveStructType},
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{collections::HashMap, fmt, sync::Arc};
@@ -223,7 +223,9 @@ impl Default for ConfigurationResource {
     }
 }
 
-impl MoveResource for ConfigurationResource {
+impl MoveStructType for ConfigurationResource {
     const MODULE_NAME: &'static str = "DiemConfig";
     const STRUCT_NAME: &'static str = "Configuration";
 }
+
+impl MoveResource for ConfigurationResource {}

--- a/types/src/validator_config.rs
+++ b/types/src/validator_config.rs
@@ -6,7 +6,7 @@ use crate::{
     network_address::{encrypted::EncNetworkAddress, NetworkAddress},
 };
 use diem_crypto::ed25519::Ed25519PublicKey;
-use move_core_types::move_resource::MoveResource;
+use move_core_types::move_resource::{MoveResource, MoveStructType};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -18,20 +18,24 @@ pub struct ValidatorConfigResource {
     pub human_name: Vec<u8>,
 }
 
-impl MoveResource for ValidatorConfigResource {
+impl MoveStructType for ValidatorConfigResource {
     const MODULE_NAME: &'static str = "ValidatorConfig";
     const STRUCT_NAME: &'static str = "ValidatorConfig";
 }
+
+impl MoveResource for ValidatorConfigResource {}
 
 #[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq, Default)]
 pub struct ValidatorOperatorConfigResource {
     pub human_name: Vec<u8>,
 }
 
-impl MoveResource for ValidatorOperatorConfigResource {
+impl MoveStructType for ValidatorOperatorConfigResource {
     const MODULE_NAME: &'static str = "ValidatorOperatorConfig";
     const STRUCT_NAME: &'static str = "ValidatorOperatorConfig";
 }
+
+impl MoveResource for ValidatorOperatorConfigResource {}
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Refactored `MoveResource` trait to better work our new Move type system:

1. `MoveStructType` to represent a rust struct that correspond to a Move struct
2. `MoveResource` to represent a rust struct that correspond to a top level Move Resource.

I intended to use `MoveResource` as a marker trait to distinguish between event payload and top level resources.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
`cargo check`