### PR TITLE
[move-lang] Clean up shadowing lib logic

### DIFF
--- a/language/benchmarks/src/move_vm.rs
+++ b/language/benchmarks/src/move_vm.rs
@@ -51,8 +51,7 @@ fn compile_modules() -> Vec<CompiledModule> {
         ],
         &[],
         None,
-        false,
-        Flags::empty(),
+        Flags::empty().set_sources_shadow_deps(false),
     )
     .expect("Error compiling...");
     compiled_units

--- a/language/diem-framework/src/lib.rs
+++ b/language/diem-framework/src/lib.rs
@@ -87,7 +87,7 @@ pub fn stdlib_bytecode_files() -> Vec<String> {
 
 pub(crate) fn build_stdlib() -> BTreeMap<String, CompiledModule> {
     let (_files, compiled_units) =
-        move_compile_and_report(&diem_stdlib_files(), &[], None, false, Flags::empty()).unwrap();
+        move_compile_and_report(&diem_stdlib_files(), &[], None, Flags::empty()).unwrap();
     let mut modules = BTreeMap::new();
     for (i, compiled_unit) in compiled_units.into_iter().enumerate() {
         let name = compiled_unit.name();

--- a/language/diem-tools/transaction-replay/src/lib.rs
+++ b/language/diem-tools/transaction-replay/src/lib.rs
@@ -399,8 +399,7 @@ fn compile_move_script(file_path: &str) -> Result<Vec<u8>> {
         targets,
         &diem_framework::diem_stdlib_files(),
         None,
-        false,
-        Flags::empty(),
+        Flags::empty().set_sources_shadow_deps(false),
     )?;
     let unit = match units_or_errors {
         Err(errors) => {

--- a/language/diem-tools/writeset-transaction-generator/src/admin_script_builder.rs
+++ b/language/diem-tools/writeset-transaction-generator/src/admin_script_builder.rs
@@ -21,8 +21,7 @@ pub fn compile_script(source_file_str: String) -> Vec<u8> {
         &[source_file_str],
         &diem_framework::diem_stdlib_files(),
         None,
-        false,
-        Flags::empty(),
+        Flags::empty().set_sources_shadow_deps(false),
     )
     .unwrap();
     let mut script_bytes = vec![];

--- a/language/move-lang/src/bin/move-build.rs
+++ b/language/move-lang/src/bin/move-build.rs
@@ -33,15 +33,6 @@ pub struct Options {
     )]
     pub out_dir: String,
 
-    /// If set, do not allow modules defined in source_files to shadow modules of the same id that
-    /// exist in dependencies. Compilation will fail in this case.
-    #[structopt(
-        name = "SOURCES_DO_NOT_SHADOW_DEPS",
-        short = cli::NO_SHADOW_SHORT,
-        long = cli::NO_SHADOW,
-    )]
-    pub no_shadow: bool,
-
     /// Save bytecode source map to disk
     #[structopt(
         name = "",
@@ -59,7 +50,6 @@ pub fn main() -> anyhow::Result<()> {
         source_files,
         dependencies,
         out_dir,
-        no_shadow,
         emit_source_map,
         flags,
     } = Options::from_args();
@@ -69,7 +59,6 @@ pub fn main() -> anyhow::Result<()> {
         &source_files,
         &dependencies,
         Some(interface_files_dir),
-        !no_shadow,
         flags,
     )?;
     move_lang::output_compiled_units(emit_source_map, files, compiled_units, &out_dir)

--- a/language/move-lang/src/bin/move-check.rs
+++ b/language/move-lang/src/bin/move-check.rs
@@ -36,15 +36,6 @@ pub struct Options {
     )]
     pub out_dir: Option<String>,
 
-    /// If set, do not allow modules defined in source_files to shadow modules of the same id that
-    /// exist in dependencies. Checking will fail in this case.
-    #[structopt(
-        name = "SOURCES_DO_NOT_SHADOW_DEPS",
-        short = cli::NO_SHADOW_SHORT,
-        long = cli::NO_SHADOW,
-    )]
-    pub no_shadow: bool,
-
     #[structopt(flatten)]
     pub flags: Flags,
 }
@@ -54,11 +45,9 @@ pub fn main() -> anyhow::Result<()> {
         source_files,
         dependencies,
         out_dir,
-        no_shadow,
         flags,
     } = Options::from_args();
 
-    let _files =
-        move_lang::move_check_and_report(&source_files, &dependencies, out_dir, !no_shadow, flags)?;
+    let _files = move_lang::move_check_and_report(&source_files, &dependencies, out_dir, flags)?;
     Ok(())
 }

--- a/language/move-lang/src/parser/mod.rs
+++ b/language/move-lang/src/parser/mod.rs
@@ -5,3 +5,4 @@ mod lexer;
 pub(crate) mod syntax;
 
 pub mod ast;
+pub(crate) mod sources_shadow_deps;

--- a/language/move-lang/src/parser/sources_shadow_deps.rs
+++ b/language/move-lang/src/parser/sources_shadow_deps.rs
@@ -1,0 +1,61 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    parser::ast::{Definition, Program},
+    shared::*,
+};
+use std::collections::BTreeSet;
+
+/// Given a parsed program, if a module id is found in both the source and lib definitions, filter
+/// out the lib definition and re-construct a new parsed program
+pub fn program(compilation_env: &CompilationEnv, prog: Program) -> Program {
+    if !compilation_env.flags().sources_shadow_deps() {
+        return prog;
+    }
+
+    let Program {
+        source_definitions,
+        lib_definitions,
+    } = prog;
+    let mut modules_defined_in_src = BTreeSet::new();
+    for def in &source_definitions {
+        match def {
+            Definition::Address(_, _, addr, modules) => {
+                for module in modules {
+                    modules_defined_in_src.insert((*addr, module.name.clone()));
+                }
+            }
+            Definition::Module(module) => {
+                modules_defined_in_src.insert((
+                    module.address.map(|a| a.value).unwrap_or_default(),
+                    module.name.clone(),
+                ));
+            }
+            Definition::Script(_) => (),
+        }
+    }
+
+    // Shadow (i.e., filter out) library definitions with the following criteria
+    //  1. this library definition is an Address space AST and any module in the address space is
+    //    already defined in the source.
+    //  2. this library definition is a Module AST and the module is already defined in the source.
+    let lib_definitions = lib_definitions
+        .into_iter()
+        .filter(|def| match def {
+            Definition::Address(_, _, addr, modules) => !modules
+                .iter()
+                .any(|module| modules_defined_in_src.contains(&(*addr, module.name.clone()))),
+            Definition::Module(module) => !modules_defined_in_src.contains(&(
+                module.address.map(|a| a.value).unwrap_or_default(),
+                module.name.clone(),
+            )),
+            Definition::Script(_) => false,
+        })
+        .collect();
+
+    Program {
+        source_definitions,
+        lib_definitions,
+    }
+}

--- a/language/move-lang/src/shared/mod.rs
+++ b/language/move-lang/src/shared/mod.rs
@@ -311,19 +311,45 @@ pub struct Flags {
         long = cli::TEST,
     )]
     test: bool,
+
+    /// If set, do not allow modules defined in source_files to shadow modules of the same id that
+    /// exist in dependencies. Checking will fail in this case.
+    #[structopt(
+        name = "SOURCES_DO_NOT_SHADOW_DEPS",
+        short = cli::NO_SHADOW_SHORT,
+        long = cli::NO_SHADOW,
+    )]
+    no_shadow: bool,
 }
 
 impl Flags {
     pub fn empty() -> Self {
-        Self { test: false }
+        Self {
+            test: false,
+            no_shadow: false,
+        }
     }
 
     pub fn testing() -> Self {
-        Self { test: true }
+        Self {
+            test: true,
+            no_shadow: false,
+        }
+    }
+
+    pub fn set_sources_shadow_deps(self, sources_shadow_deps: bool) -> Self {
+        Self {
+            no_shadow: !sources_shadow_deps,
+            ..self
+        }
     }
 
     pub fn is_testing(&self) -> bool {
         self.test
+    }
+
+    pub fn sources_shadow_deps(&self) -> bool {
+        !self.no_shadow
     }
 }
 

--- a/language/move-lang/tests/move_check_testsuite.rs
+++ b/language/move-lang/tests/move_check_testsuite.rs
@@ -86,8 +86,9 @@ fn run_test(
     let targets: Vec<String> = vec![path.to_str().unwrap().to_owned()];
     let deps = move_stdlib::move_stdlib_files();
 
-    let (files, pprog_and_comments_res) = move_parse(&targets, &deps, None, false)?;
-    let errors = match move_check_for_errors(pprog_and_comments_res, flags) {
+    let compilation_env = CompilationEnv::new(flags);
+    let (files, pprog_and_comments_res) = move_parse(&compilation_env, &targets, &deps, None)?;
+    let errors = match move_check_for_errors(compilation_env, pprog_and_comments_res) {
         Err(errors) | Ok(errors) => errors,
     };
 
@@ -146,10 +147,9 @@ fn run_test(
 }
 
 fn move_check_for_errors(
+    mut compilation_env: CompilationEnv,
     pprog_and_comments_res: Result<(CommentMap, parser::ast::Program), Errors>,
-    flags: Flags,
 ) -> Result<Errors, Errors> {
-    let mut compilation_env = CompilationEnv::new(flags);
     let (_, prog) = pprog_and_comments_res?;
     let cfgir = match move_continue_up_to(
         &mut compilation_env,

--- a/language/move-lang/tests/stdlib_sanity_check.rs
+++ b/language/move-lang/tests/stdlib_sanity_check.rs
@@ -4,8 +4,13 @@
 use move_lang::{move_compile, shared::Flags};
 
 fn sanity_check_testsuite_impl(targets: Vec<String>, deps: Vec<String>) {
-    let (files, units_or_errors) =
-        move_compile(&targets, &deps, None, false, Flags::empty()).unwrap();
+    let (files, units_or_errors) = move_compile(
+        &targets,
+        &deps,
+        None,
+        Flags::empty().set_sources_shadow_deps(false),
+    )
+    .unwrap();
     let errors = match units_or_errors {
         Err(errors) => errors,
         Ok(units) => move_lang::compiled_unit::verify_units(units).1,

--- a/language/move-vm/integration-tests/src/compiler.rs
+++ b/language/move-vm/integration-tests/src/compiler.rs
@@ -20,8 +20,7 @@ pub fn compile_units(s: &str) -> Result<Vec<CompiledUnit>> {
         &[file_path.to_str().unwrap().to_string()],
         &[],
         None,
-        false,
-        Flags::empty(),
+        Flags::empty().set_sources_shadow_deps(false),
     )?;
 
     dir.close()?;
@@ -43,8 +42,7 @@ pub fn compile_modules_in_file(path: &Path) -> Result<Vec<CompiledModule>> {
         &[path.to_str().unwrap().to_string()],
         &[],
         None,
-        false,
-        Flags::empty(),
+        Flags::empty().set_sources_shadow_deps(false),
     )?;
 
     expect_modules(units).collect()

--- a/language/tools/move-cli/src/commands.rs
+++ b/language/tools/move-cli/src/commands.rs
@@ -56,8 +56,7 @@ pub fn check(
         files,
         &[state.interface_files_dir()?],
         None,
-        republish,
-        Flags::empty(),
+        Flags::empty().set_sources_shadow_deps(republish),
     )?;
     Ok(())
 }
@@ -77,8 +76,7 @@ pub fn publish(
         files,
         &[state.interface_files_dir()?],
         None,
-        republish,
-        Flags::empty(),
+        Flags::empty().set_sources_shadow_deps(republish),
     )?;
 
     let num_modules = compiled_units
@@ -179,8 +177,7 @@ pub fn run(
             &[script_file.to_string()],
             &[state.interface_files_dir()?],
             None,
-            false,
-            Flags::empty(),
+            Flags::empty().set_sources_shadow_deps(false),
         )?;
 
         let mut script_opt = None;

--- a/language/tools/move-cli/src/package.rs
+++ b/language/tools/move-cli/src/package.rs
@@ -131,8 +131,7 @@ impl MovePackage {
                 &[path_to_string(&pkg_src_path)?],
                 &src_dirs,
                 None,
-                false,
-                Flags::empty(),
+                Flags::empty().set_sources_shadow_deps(false),
             )?;
 
             // save modules and ignore scripts

--- a/language/tools/move-unit-test/src/lib.rs
+++ b/language/tools/move-unit-test/src/lib.rs
@@ -70,7 +70,7 @@ impl UnitTestingConfig {
     pub fn build_test_plan(&self) -> Option<TestPlan> {
         let mut compilation_env = CompilationEnv::new(Flags::testing());
         let (files, pprog_and_comments_res) =
-            move_lang::move_parse(&self.source_files, &[], None, false).ok()?;
+            move_lang::move_parse(&compilation_env, &self.source_files, &[], None).ok()?;
         let (_, pprog) = move_lang::unwrap_or_report_errors!(files, pprog_and_comments_res);
         let cfgir_result = move_lang::move_continue_up_to(
             &mut compilation_env,


### PR DESCRIPTION
- Moved shadowing lib logic into expansion, as it needs to be there after named addresses
- Moved the no_shadow flag into the Flags struct

## Motivation

~~- Makes named address logic a lot easier~~
- Originally I thought I needed this for named addressing, but I don't. Regardless, I think moving this into flags is cleaner. 

## Test Plan

- Updated endpoints. Ran tests