### PR TITLE
[move-prover] Add inv_v2 to cargo test, add error checking

### DIFF
--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -2740,6 +2740,15 @@ impl<'env> FunctionEnv<'env> {
             }
     }
 
+    /// Return whether this function is exposed outside of the module.
+    pub fn has_unknown_callers(&self) -> bool {
+        self.module_env.is_script_module()
+            || match self.definition_view().visibility() {
+                Visibility::Public | Visibility::Script => true,
+                Visibility::Private | Visibility::Friend => false,
+            }
+    }
+
     /// Returns true if the function is a script function
     pub fn is_script(&self) -> bool {
         // The main function of a scipt is a script function

--- a/language/move-prover/tests/sources/functional/ModifiesErrorTest.exp
+++ b/language/move-prover/tests/sources/functional/ModifiesErrorTest.exp
@@ -1,83 +1,83 @@
 Move prover returns: exiting with boogie verification errors
 error: caller does not have permission to modify `B::T` at given address
 
-    ┌── tests/sources/functional/ModifiesErrorTest.move:65:17 ───
+    ┌── tests/sources/functional/ModifiesErrorTest.move:66:17 ───
     │
- 65 │         let v = move_from<T>(addr1);
+ 66 │         let v = move_from<T>(addr1);
     │                 ^^^^^^^^^
     │
-    =     at tests/sources/functional/ModifiesErrorTest.move:63: move_from_test_incorrect
-    =     at tests/sources/functional/ModifiesErrorTest.move:74
-    =     at tests/sources/functional/ModifiesErrorTest.move:63: move_from_test_incorrect
+    =     at tests/sources/functional/ModifiesErrorTest.move:64: move_from_test_incorrect
+    =     at tests/sources/functional/ModifiesErrorTest.move:75
+    =     at tests/sources/functional/ModifiesErrorTest.move:64: move_from_test_incorrect
     =         addr1 = <redacted>
     =         addr2 = <redacted>
-    =     at tests/sources/functional/ModifiesErrorTest.move:64: move_from_test_incorrect
-    =         x0 = <redacted>
     =     at tests/sources/functional/ModifiesErrorTest.move:65: move_from_test_incorrect
+    =         x0 = <redacted>
+    =     at tests/sources/functional/ModifiesErrorTest.move:66: move_from_test_incorrect
 
 error: caller does not have permission to modify `B::T` at given address
 
-    ┌── tests/sources/functional/ModifiesErrorTest.move:52:9 ───
+    ┌── tests/sources/functional/ModifiesErrorTest.move:53:9 ───
     │
- 52 │         move_to<T>(account, T{x: 2});
+ 53 │         move_to<T>(account, T{x: 2});
     │         ^^^^^^^
     │
-    =     at tests/sources/functional/ModifiesErrorTest.move:50: move_to_test_incorrect
-    =     at tests/sources/functional/ModifiesErrorTest.move:60
-    =     at tests/sources/functional/ModifiesErrorTest.move:50: move_to_test_incorrect
+    =     at tests/sources/functional/ModifiesErrorTest.move:51: move_to_test_incorrect
+    =     at tests/sources/functional/ModifiesErrorTest.move:61
+    =     at tests/sources/functional/ModifiesErrorTest.move:51: move_to_test_incorrect
     =         account = <redacted>
     =         addr2 = <redacted>
-    =     at tests/sources/functional/ModifiesErrorTest.move:51: move_to_test_incorrect
-    =         x0 = <redacted>
     =     at tests/sources/functional/ModifiesErrorTest.move:52: move_to_test_incorrect
+    =         x0 = <redacted>
+    =     at tests/sources/functional/ModifiesErrorTest.move:53: move_to_test_incorrect
 
 error: caller does not have permission to modify `A::S` at given address
 
-    ┌── tests/sources/functional/ModifiesErrorTest.move:79:9 ───
+    ┌── tests/sources/functional/ModifiesErrorTest.move:80:9 ───
     │
- 79 │         A::mutate_at(addr1);
+ 80 │         A::mutate_at(addr1);
     │         ^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/ModifiesErrorTest.move:77: mutate_S_test1_incorrect
-    =     at tests/sources/functional/ModifiesErrorTest.move:86
+    =     at tests/sources/functional/ModifiesErrorTest.move:78: mutate_S_test1_incorrect
     =     at tests/sources/functional/ModifiesErrorTest.move:87
-    =     at tests/sources/functional/ModifiesErrorTest.move:77: mutate_S_test1_incorrect
+    =     at tests/sources/functional/ModifiesErrorTest.move:88
+    =     at tests/sources/functional/ModifiesErrorTest.move:78: mutate_S_test1_incorrect
     =         addr1 = <redacted>
     =         addr2 = <redacted>
-    =     at tests/sources/functional/ModifiesErrorTest.move:78: mutate_S_test1_incorrect
-    =         x0 = <redacted>
     =     at tests/sources/functional/ModifiesErrorTest.move:79: mutate_S_test1_incorrect
+    =         x0 = <redacted>
+    =     at tests/sources/functional/ModifiesErrorTest.move:80: mutate_S_test1_incorrect
 
 error: unknown assertion failed
 
-    ┌── tests/sources/functional/ModifiesErrorTest.move:95:13 ───
+    ┌── tests/sources/functional/ModifiesErrorTest.move:96:13 ───
     │
- 95 │             assert x0 == x1;
+ 96 │             assert x0 == x1;
     │             ^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/ModifiesErrorTest.move:90: mutate_S_test2_incorrect
-    =     at tests/sources/functional/ModifiesErrorTest.move:99
-    =     at tests/sources/functional/ModifiesErrorTest.move:90: mutate_S_test2_incorrect
-    =         addr = <redacted>
     =     at tests/sources/functional/ModifiesErrorTest.move:91: mutate_S_test2_incorrect
-    =         x0 = <redacted>
+    =     at tests/sources/functional/ModifiesErrorTest.move:100
+    =     at tests/sources/functional/ModifiesErrorTest.move:91: mutate_S_test2_incorrect
+    =         addr = <redacted>
     =     at tests/sources/functional/ModifiesErrorTest.move:92: mutate_S_test2_incorrect
+    =         x0 = <redacted>
     =     at tests/sources/functional/ModifiesErrorTest.move:93: mutate_S_test2_incorrect
+    =     at tests/sources/functional/ModifiesErrorTest.move:94: mutate_S_test2_incorrect
     =         x1 = <redacted>
-    =     at tests/sources/functional/ModifiesErrorTest.move:95: mutate_S_test2_incorrect
+    =     at tests/sources/functional/ModifiesErrorTest.move:96: mutate_S_test2_incorrect
 
 error: caller does not have permission to modify `B::T` at given address
 
-    ┌── tests/sources/functional/ModifiesErrorTest.move:38:17 ───
+    ┌── tests/sources/functional/ModifiesErrorTest.move:39:17 ───
     │
- 38 │         let t = borrow_global_mut<T>(addr1);
+ 39 │         let t = borrow_global_mut<T>(addr1);
     │                 ^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/ModifiesErrorTest.move:36: mutate_at_test_incorrect
-    =     at tests/sources/functional/ModifiesErrorTest.move:47
-    =     at tests/sources/functional/ModifiesErrorTest.move:36: mutate_at_test_incorrect
+    =     at tests/sources/functional/ModifiesErrorTest.move:37: mutate_at_test_incorrect
+    =     at tests/sources/functional/ModifiesErrorTest.move:48
+    =     at tests/sources/functional/ModifiesErrorTest.move:37: mutate_at_test_incorrect
     =         addr1 = <redacted>
     =         addr2 = <redacted>
-    =     at tests/sources/functional/ModifiesErrorTest.move:37: mutate_at_test_incorrect
-    =         x0 = <redacted>
     =     at tests/sources/functional/ModifiesErrorTest.move:38: mutate_at_test_incorrect
+    =         x0 = <redacted>
+    =     at tests/sources/functional/ModifiesErrorTest.move:39: mutate_at_test_incorrect

--- a/language/move-prover/tests/sources/functional/ModifiesErrorTest.move
+++ b/language/move-prover/tests/sources/functional/ModifiesErrorTest.move
@@ -1,3 +1,4 @@
+// exclude_for: inv_v2
 address 0x0 {
 module A {
 

--- a/language/move-prover/tests/sources/functional/disable_inv.exp
+++ b/language/move-prover/tests/sources/functional/disable_inv.exp
@@ -1,0 +1,24 @@
+Move prover returns: exiting with boogie verification errors
+error: global memory invariant does not hold
+
+    ┌── tests/sources/functional/disable_inv.move:60:9 ───
+    │
+ 60 │         invariant [global] forall a: address where exists<R1>(a): exists<R2>(a);
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/disable_inv.move:11: f1_incorrect
+    =         s = <redacted>
+    =     at tests/sources/functional/disable_inv.move:12: f1_incorrect
+    =     at tests/sources/functional/disable_inv.move:60
+
+error: global memory invariant does not hold
+
+    ┌── tests/sources/functional/disable_inv.move:60:9 ───
+    │
+ 60 │         invariant [global] forall a: address where exists<R1>(a): exists<R2>(a);
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/disable_inv.move:31: f3_incorrect
+    =         s = <redacted>
+    =     at tests/sources/functional/disable_inv.move:32: f3_incorrect
+    =     at tests/sources/functional/disable_inv.move:60

--- a/language/move-prover/tests/sources/functional/disable_inv.move
+++ b/language/move-prover/tests/sources/functional/disable_inv.move
@@ -1,0 +1,62 @@
+module 0x1::DisableInv {
+
+    struct R1 has key { }
+
+    struct R2 has key { }
+
+    struct R3 has key { }
+
+    // Error here because the function is public, it modifies the
+    // invariant, and has a pragma disable_invariants_in_body
+    public fun f1_incorrect(s: &signer) {
+        move_to(s, R1 {});
+        move_to(s, R2 {});
+    }
+
+    spec fun f1_incorrect {
+         pragma delegate_invariants_to_caller;
+    }
+
+    public fun f2(s: &signer) {
+        f3_incorrect(s);
+        f4(s);
+    }
+
+    spec fun f2 {
+        pragma disable_invariants_in_body;
+    }
+
+    // Error because it is called from a site (f2) where invariants
+    // are disabled, but it has a pragma to disable invariants directly.
+    fun f3_incorrect(s: &signer) {
+        move_to(s, R1 {});
+    }
+
+    spec fun f3_incorrect {
+        pragma disable_invariants_in_body;
+    }
+
+    fun f4(s: &signer) {
+        f5_incorrect(s);
+    }
+
+    // Error because it is called from a site (f2) where invariants
+    // are disabled, but it has a pragma to disable invariants directly.
+    // Different from f3 because it's called indirectly through f4.
+    fun f5_incorrect(s: &signer) {
+        move_to(s, R2 {});
+    }
+
+    spec fun f5_incorrect {
+        pragma disable_invariants_in_body;
+    }
+
+    // Lik f1_incorrect, but ok because it does not modify the invariant.
+    public fun f6(s: &signer) {
+        move_to(s, R3 {});
+    }
+
+    spec module {
+        invariant [global] forall a: address where exists<R1>(a): exists<R2>(a);
+    }
+}

--- a/language/move-prover/tests/sources/functional/friend_error.exp
+++ b/language/move-prover/tests/sources/functional/friend_error.exp
@@ -1,24 +1,24 @@
 Move prover returns: exiting with bytecode transformation errors
 error: function with a friend cannot be declared as opaque
 
-    ┌── tests/sources/functional/friend_error.move:13:5 ───
+    ┌── tests/sources/functional/friend_error.move:14:5 ───
     │
- 13 │     public fun g() {}
+ 14 │     public fun g() {}
     │     ^^^^^^^^^^^^^^^^^
     │
 
 error: function `TestFriendError::g` is called by other functions while it can only be called by its friend h
 
-    ┌── tests/sources/functional/friend_error.move:13:5 ───
+    ┌── tests/sources/functional/friend_error.move:14:5 ───
     │
- 13 │     public fun g() {}
+ 14 │     public fun g() {}
     │     ^^^^^^^^^^^^^^^^^
     │
 
 error: function `TestFriendError::f` is called by other functions while it can only be called by its friend M::some_other_fun
 
-   ┌── tests/sources/functional/friend_error.move:7:5 ───
+   ┌── tests/sources/functional/friend_error.move:8:5 ───
    │
- 7 │     public fun f() {}
+ 8 │     public fun f() {}
    │     ^^^^^^^^^^^^^^^^^
    │

--- a/language/move-prover/tests/sources/functional/friend_error.move
+++ b/language/move-prover/tests/sources/functional/friend_error.move
@@ -1,3 +1,4 @@
+// exclude_for: inv_v2
 module 0x42::TestFriendError {
 
     struct R {

--- a/language/move-prover/tests/testsuite.rs
+++ b/language/move-prover/tests/testsuite.rs
@@ -98,6 +98,17 @@ fn get_features() -> &'static [Feature] {
                 runner: |p| test_runner_for_feature(p, get_feature_by_name("cvc4")),
                 enabling_condition: |group, _| group == "unit",
             },
+            // Tests for new invariants
+            Feature {
+                name: "inv_v2",
+                flags: &["--inv_v2"],
+                inclusion_mode: InclusionMode::Implicit,
+                enable_in_ci: false, // Do not enable in CI until we have more data about stability
+                only_if_requested: false,
+                separate_baseline: false,
+                runner: |p| test_runner_for_feature(p, get_feature_by_name("inv_v2")),
+                enabling_condition: |_, _| true,
+            },
         ]
     })
 }


### PR DESCRIPTION
Modified testsuite.rs to run inv_v2 tests when "cargo test" is
executed in the move-prover directory.

Two functional tests are excluded (for inv_v2) because they don't work
yet for known reasons. It was necessary to add an "exclude_for" comment to each of
those files, and then to recompute the .exp files because the line
numbers changed, causing changes to show up in the diff.

Added error checking.  A "non-invariant function" is a function that
is called in a context where invariants are disabled.  It is illegal
to have a non-invariant function that is public or a script function
because there is no way to prove that the invariant holds outside of
the cluster of target modules, their dependencies, friends of
dependencies, and dependencies of friends, as is required for
soundness.
    
Similarly, it is illegal to have a non-invariant function that has a
"pragma disable_invariants_in_body", because that pragma says that the
invariant holds in the calling context but is disabled in the body.
    
There is a new functional test case, disable_inv.move, to test this error
reporting code.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update or suggest changes to the docs at https://developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
