### PR TITLE
[State Sync Performance Test] Add additional checks for possible error cases.

### DIFF
--- a/testsuite/cluster-test/src/experiments/state_sync_performance.rs
+++ b/testsuite/cluster-test/src/experiments/state_sync_performance.rs
@@ -90,6 +90,11 @@ impl Experiment for StateSyncPerformance {
 
         // Read the validator synced version
         let validator_synced_version = self.read_validator_synced_version();
+        if validator_synced_version == 0.0 {
+            return Err(anyhow::format_err!(
+                "Validator synced zero transactions! Something has gone wrong!"
+            ));
+        }
         info!(
             "The validator is now synced at version: {}",
             validator_synced_version
@@ -120,8 +125,13 @@ impl Experiment for StateSyncPerformance {
         );
 
         // Calculate the state sync throughput
-        let time_to_state_sync = start_instant.elapsed();
-        let state_sync_throughput = validator_synced_version as u64 / time_to_state_sync.as_secs();
+        let time_to_state_sync = start_instant.elapsed().as_secs();
+        if time_to_state_sync == 0 {
+            return Err(anyhow::format_err!(
+                "The time taken to state sync was 0 seconds! Something has gone wrong!"
+            ));
+        }
+        let state_sync_throughput = validator_synced_version as u64 / time_to_state_sync;
         let state_sync_throughput_message =
             format!("State sync throughput : {} txn/sec", state_sync_throughput,);
         info!("Time to state sync {:?}", time_to_state_sync);


### PR DESCRIPTION
## Motivation

This PR adds two simple checks for possible error cases in the state sync performance test:
- Ensure that the validator syncs more than 0 transactions
- Ensure that the time taken to sync is more than 0 seconds (otherwise we get a division by zero error, as reported here: https://app.circleci.com/pipelines/github/novifinancial/libra-ops/4037/workflows/d047e444-98ed-4f6e-8cc6-4a7fab0f2969/jobs/15116)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Will run locally before landing to ensure it still works (however, I won't exercise these error paths manually).

## Related PRs

None.

