### PR TITLE
[stackless-vm] produce a changeset after execution

### DIFF
--- a/language/move-core/types/src/effects.rs
+++ b/language/move-core/types/src/effects.rs
@@ -10,7 +10,7 @@ use anyhow::{format_err, Error, Result};
 use std::collections::btree_map::{self, BTreeMap};
 
 /// A collection of changes to modules and resources under a Move account.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct AccountChangeSet {
     modules: BTreeMap<Identifier, Option<Vec<u8>>>,
     resources: BTreeMap<StructTag, Option<Vec<u8>>>,
@@ -151,7 +151,7 @@ impl AccountChangeSet {
 
 /// A collection of changes to a Move state. Each AccountChangeSet in the domain of `accounts`
 /// is guaranteed to be nonempty
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct ChangeSet {
     accounts: BTreeMap<AccountAddress, AccountChangeSet>,
 }

--- a/language/move-prover/interpreter/src/concrete/mod.rs
+++ b/language/move-prover/interpreter/src/concrete/mod.rs
@@ -1,8 +1,8 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-mod local_state;
-mod player;
+pub mod local_state;
+pub mod player;
 pub mod runtime;
 pub mod ty;
 pub mod value;


### PR DESCRIPTION
As title. The stackless bytecpde interpreter now also produces a changeset that captures changes of resources in the global storage.

The cross comparison also reveals a bug in the prior write-back implementation on vector and struct field updates. This is fixed now.

## Motivation

To bridge the gap between the two VMs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI, especially the tests on global ops and events.
