### PR TITLE
[move-prover] Internalization for expressions plus new rewriter design

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
+dependencies = [
+ "const-random",
+]
+
+[[package]]
+name = "ahash"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,6 +1104,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f590d95d011aa80b063ffe3253422ed5aa462af4e9867d43ce8337562bac77c4"
+dependencies = [
+ "const-random-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "615f6e27d000a2bffbc7f2f6a8669179378fa27ee4d0a509e985dfc0a7defb40"
+dependencies = [
+ "getrandom 0.2.2",
+ "lazy_static",
+ "proc-macro-hack",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "const_fn"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1332,6 +1369,17 @@ dependencies = [
  "rand_core 0.6.2",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "dashmap"
+version = "3.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f260e2fc850179ef410018660006951c1b55b79e8087e87111a2c388994b9b5"
+dependencies = [
+ "ahash 0.3.8",
+ "cfg-if 0.1.10",
+ "num_cpus",
 ]
 
 [[package]]
@@ -2436,6 +2484,8 @@ dependencies = [
  "futures-io",
  "futures-sink",
  "futures-util",
+ "getrandom 0.2.2",
+ "hashbrown",
  "hyper",
  "indexmap",
  "itertools 0.10.0",
@@ -2462,6 +2512,7 @@ dependencies = [
  "subtle",
  "syn 0.15.44",
  "syn 1.0.64",
+ "tiny-keccak",
  "tokio",
  "tokio-util",
  "toml",
@@ -3504,6 +3555,9 @@ name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+dependencies = [
+ "ahash 0.4.7",
+]
 
 [[package]]
 name = "headers"
@@ -3788,6 +3842,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "internment"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84361d019110e87ee0b527edae8cba07feb78a09c53d8579e5411005d0ad5065"
+dependencies = [
+ "dashmap",
+ "hashbrown",
+ "once_cell",
 ]
 
 [[package]]
@@ -4488,6 +4553,7 @@ dependencies = [
  "datatest-stable",
  "diem-workspace-hack",
  "disassembler",
+ "internment",
  "itertools 0.10.0",
  "log",
  "move-binary-format",

--- a/common/workspace-hack/Cargo.toml
+++ b/common/workspace-hack/Cargo.toml
@@ -29,6 +29,8 @@ futures-core = { version = "0.3.13", features = ["alloc", "default", "std"] }
 futures-io = { version = "0.3.13", features = ["default", "std"] }
 futures-sink = { version = "0.3.13", features = ["alloc", "default", "std"] }
 futures-util = { version = "0.3.12", features = ["alloc", "async-await", "async-await-macro", "channel", "default", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "proc-macro-hack", "proc-macro-nested", "sink", "slab", "std"] }
+getrandom = { version = "0.2.2", default-features = false, features = ["std"] }
+hashbrown = { version = "0.9.1", features = ["ahash", "default", "inline-more", "raw"] }
 hyper = { version = "0.14.4", features = ["client", "default", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
 indexmap = { version = "1.6.2", default-features = false, features = ["std"] }
 itertools = { version = "0.10.0", features = ["default", "use_alloc", "use_std"] }
@@ -51,6 +53,7 @@ serde = { version = "1.0.125", features = ["alloc", "default", "derive", "rc", "
 serde_json = { version = "1.0.64", features = ["default", "indexmap", "preserve_order", "std"] }
 standback = { version = "0.2.15", default-features = false, features = ["std"] }
 subtle = { version = "2.4.0", default-features = false, features = ["std"] }
+tiny-keccak = { version = "2.0.2", features = ["default", "sha3"] }
 tokio = { version = "1.3.0", features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "test-util", "time", "tokio-macros", "winapi"] }
 tokio-util = { version = "0.6.4", features = ["codec", "compat", "default", "futures-io", "io"] }
 toml = { version = "0.5.8", features = ["default"] }
@@ -78,6 +81,8 @@ futures-core = { version = "0.3.13", features = ["alloc", "default", "std"] }
 futures-io = { version = "0.3.13", features = ["default", "std"] }
 futures-sink = { version = "0.3.13", features = ["alloc", "default", "std"] }
 futures-util = { version = "0.3.12", features = ["alloc", "async-await", "async-await-macro", "channel", "default", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "proc-macro-hack", "proc-macro-nested", "sink", "slab", "std"] }
+getrandom = { version = "0.2.2", default-features = false, features = ["std"] }
+hashbrown = { version = "0.9.1", features = ["ahash", "default", "inline-more", "raw"] }
 hyper = { version = "0.14.4", features = ["client", "default", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
 indexmap = { version = "1.6.2", default-features = false, features = ["std"] }
 itertools = { version = "0.10.0", features = ["default", "use_alloc", "use_std"] }
@@ -104,6 +109,7 @@ standback = { version = "0.2.15", default-features = false, features = ["std"] }
 subtle = { version = "2.4.0", default-features = false, features = ["std"] }
 syn-3575ec1268b04181 = { package = "syn", version = "0.15.44", features = ["clone-impls", "default", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.64", features = ["clone-impls", "default", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
+tiny-keccak = { version = "2.0.2", features = ["default", "sha3"] }
 tokio = { version = "1.3.0", features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "test-util", "time", "tokio-macros", "winapi"] }
 tokio-util = { version = "0.6.4", features = ["codec", "compat", "default", "futures-io", "io"] }
 toml = { version = "0.5.8", features = ["default"] }
@@ -130,6 +136,8 @@ futures-core = { version = "0.3.13", features = ["alloc", "default", "std"] }
 futures-io = { version = "0.3.13", features = ["default", "std"] }
 futures-sink = { version = "0.3.13", features = ["alloc", "default", "std"] }
 futures-util = { version = "0.3.12", features = ["alloc", "async-await", "async-await-macro", "channel", "default", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "proc-macro-hack", "proc-macro-nested", "sink", "slab", "std"] }
+getrandom = { version = "0.2.2", default-features = false, features = ["std"] }
+hashbrown = { version = "0.9.1", features = ["ahash", "default", "inline-more", "raw"] }
 hyper = { version = "0.14.4", features = ["client", "default", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
 indexmap = { version = "1.6.2", default-features = false, features = ["std"] }
 itertools = { version = "0.10.0", features = ["default", "use_alloc", "use_std"] }
@@ -152,6 +160,7 @@ serde = { version = "1.0.125", features = ["alloc", "default", "derive", "rc", "
 serde_json = { version = "1.0.64", features = ["default", "indexmap", "preserve_order", "std"] }
 standback = { version = "0.2.15", default-features = false, features = ["std"] }
 subtle = { version = "2.4.0", default-features = false, features = ["std"] }
+tiny-keccak = { version = "2.0.2", features = ["default", "sha3"] }
 tokio = { version = "1.3.0", features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "test-util", "time", "tokio-macros", "winapi"] }
 tokio-util = { version = "0.6.4", features = ["codec", "compat", "default", "futures-io", "io"] }
 toml = { version = "0.5.8", features = ["default"] }
@@ -179,6 +188,8 @@ futures-core = { version = "0.3.13", features = ["alloc", "default", "std"] }
 futures-io = { version = "0.3.13", features = ["default", "std"] }
 futures-sink = { version = "0.3.13", features = ["alloc", "default", "std"] }
 futures-util = { version = "0.3.12", features = ["alloc", "async-await", "async-await-macro", "channel", "default", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "proc-macro-hack", "proc-macro-nested", "sink", "slab", "std"] }
+getrandom = { version = "0.2.2", default-features = false, features = ["std"] }
+hashbrown = { version = "0.9.1", features = ["ahash", "default", "inline-more", "raw"] }
 hyper = { version = "0.14.4", features = ["client", "default", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
 indexmap = { version = "1.6.2", default-features = false, features = ["std"] }
 itertools = { version = "0.10.0", features = ["default", "use_alloc", "use_std"] }
@@ -205,6 +216,7 @@ standback = { version = "0.2.15", default-features = false, features = ["std"] }
 subtle = { version = "2.4.0", default-features = false, features = ["std"] }
 syn-3575ec1268b04181 = { package = "syn", version = "0.15.44", features = ["clone-impls", "default", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.64", features = ["clone-impls", "default", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
+tiny-keccak = { version = "2.0.2", features = ["default", "sha3"] }
 tokio = { version = "1.3.0", features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "test-util", "time", "tokio-macros", "winapi"] }
 tokio-util = { version = "0.6.4", features = ["codec", "compat", "default", "futures-io", "io"] }
 toml = { version = "0.5.8", features = ["default"] }

--- a/language/move-model/Cargo.toml
+++ b/language/move-model/Cargo.toml
@@ -20,6 +20,7 @@ disassembler = { path = "../tools/disassembler" }
 # external dependencies
 codespan = "0.8.0"
 codespan-reporting = "0.8.0"
+internment = { version = "0.5.0", features = [ "arc"] }
 itertools = "0.10.0"
 log = "0.4.14"
 num = "0.4.0"

--- a/language/move-model/src/exp_rewriter.rs
+++ b/language/move-model/src/exp_rewriter.rs
@@ -4,8 +4,8 @@
 use std::collections::{BTreeSet, VecDeque};
 
 use crate::{
-    ast::{Exp, LocalVarDecl, TempIndex},
-    model::{GlobalEnv, NodeId},
+    ast::{Exp, ExpData, LocalVarDecl, MemoryLabel, Operation, TempIndex, Value},
+    model::{GlobalEnv, ModuleId, NodeId, SpecVarId},
     symbol::Symbol,
     ty::Type,
 };
@@ -49,143 +49,396 @@ impl<'env, 'rewriter> ExpRewriter<'env, 'rewriter> {
         self.type_args = type_args;
         self
     }
+}
 
-    /// Runs the rewriter.
-    pub fn rewrite(&mut self, exp: &Exp) -> Exp {
-        use crate::ast::Exp::*;
-        match exp {
-            LocalVar(id, sym) => self.replace_local(*id, *sym),
-            Temporary(id, idx) => self.replace_temporary(*id, *idx),
-            Call(id, oper, args) => Call(
-                self.rewrite_attrs(*id),
-                oper.clone(),
-                self.rewrite_vec(args),
-            ),
-            Invoke(id, target, args) => Invoke(
-                self.rewrite_attrs(*id),
-                Box::new(self.rewrite(target)),
-                self.rewrite_vec(args),
-            ),
-            Lambda(id, vars, body) => {
-                let vars = self.rewrite_decls(vars);
-                self.shadowed
-                    .push_front(vars.iter().map(|decl| decl.name).collect());
-                let res = Lambda(self.rewrite_attrs(*id), vars, Box::new(self.rewrite(body)));
-                self.shadowed.pop_front();
-                res
-            }
-            Quant(id, kind, ranges, triggers, condition, body) => {
-                let ranges = self.rewrite_quant_decls(ranges);
-                self.shadowed
-                    .push_front(ranges.iter().map(|(decl, _)| decl.name).collect());
-                let res = Quant(
-                    self.rewrite_attrs(*id),
-                    *kind,
-                    ranges,
-                    triggers
-                        .iter()
-                        .map(|trigger| trigger.iter().map(|exp| self.rewrite(&*exp)).collect())
-                        .collect(),
-                    condition.as_ref().map(|exp| Box::new(self.rewrite(&*exp))),
-                    Box::new(self.rewrite(body)),
-                );
-                self.shadowed.pop_front();
-                res
-            }
-            Block(id, vars, body) => {
-                let vars = self.rewrite_decls(vars);
-                self.shadowed
-                    .push_front(vars.iter().map(|decl| decl.name).collect());
-                let res = Block(self.rewrite_attrs(*id), vars, Box::new(self.rewrite(body)));
-                self.shadowed.pop_front();
-                res
-            }
-            IfElse(id, cond, then, else_) => IfElse(
-                self.rewrite_attrs(*id),
-                Box::new(self.rewrite(cond)),
-                Box::new(self.rewrite(then)),
-                Box::new(self.rewrite(else_)),
-            ),
-            Invalid(..) | Value(..) | SpecVar(..) => exp.clone(),
-        }
-    }
-
-    fn rewrite_decls(&mut self, decls: &[LocalVarDecl]) -> Vec<LocalVarDecl> {
-        decls
-            .iter()
-            .map(|d| LocalVarDecl {
-                id: self.rewrite_attrs(d.id),
-                name: d.name,
-                binding: d.binding.as_ref().map(|e| self.rewrite(e)),
-            })
-            .collect()
-    }
-
-    fn rewrite_quant_decls(&mut self, decls: &[(LocalVarDecl, Exp)]) -> Vec<(LocalVarDecl, Exp)> {
-        decls
-            .iter()
-            .map(|(d, e)| {
-                (
-                    LocalVarDecl {
-                        id: self.rewrite_attrs(d.id),
-                        name: d.name,
-                        binding: d.binding.as_ref().map(|e| self.rewrite(e)),
-                    },
-                    self.rewrite(e),
-                )
-            })
-            .collect()
-    }
-
-    fn replace_local(&mut self, node_id: NodeId, sym: Symbol) -> Exp {
+impl<'env, 'rewriter> ExpRewriterFunctions for ExpRewriter<'env, 'rewriter> {
+    fn rewrite_local_var(&mut self, id: NodeId, sym: Symbol) -> Option<Exp> {
         for vars in &self.shadowed {
             if vars.contains(&sym) {
-                let node_id = self.rewrite_attrs(node_id);
-                return Exp::LocalVar(node_id, sym);
+                return None;
             }
         }
-        if let Some(exp) = (*self.replacer)(node_id, RewriteTarget::LocalVar(sym)) {
-            exp
+        (*self.replacer)(id, RewriteTarget::LocalVar(sym))
+    }
+
+    fn rewrite_temporary(&mut self, id: NodeId, idx: TempIndex) -> Option<Exp> {
+        (*self.replacer)(id, RewriteTarget::Temporary(idx))
+    }
+
+    fn rewrite_node_id(&mut self, id: NodeId) -> Option<NodeId> {
+        ExpData::instantiate_node(self.env, id, self.type_args)
+    }
+}
+
+// ======================================================================================
+// Expression rewriting trait
+
+/// A general trait for expression rewriting.
+///
+/// This allows customization by re-implementing any of the `rewrite_local_var`,
+/// `rewrite_temporary`, etc. functions. Each expression node has an equivalent of such
+/// a function.
+///
+/// This rewriter takes care of preserving sharing between expressions: only expression trees
+/// which are actually modified are reconstructed.
+///
+/// For most rewriting problems, there are already specializations of this trait, like `ExpRewriter`
+/// in this module, and `Exp::rewrite` in the AST module.
+///
+/// When custom implementing this trait, consider the semantics of the generic logic used.
+/// When any of the `rewrite_<exp-variant>` functions is called, any arguments have been already
+/// recursively rewritten, inclusive of the passed node id. To implement a pre-descent
+/// transformation, you need to implement the `rewrite_exp` function and after pre-processing,
+/// continue (or not) descent with `rewrite_exp_descent` for sub-expressions.
+#[allow(unused)] // for trait default parameters
+pub trait ExpRewriterFunctions {
+    /// Top-level entry for rewriting an expression. Can be re-implemented to do some
+    /// pre/post processing embedding a call to `do_rewrite`.
+    fn rewrite_exp(&mut self, exp: Exp) -> Exp {
+        self.rewrite_exp_descent(exp)
+    }
+
+    fn rewrite_vec(&mut self, exps: &[Exp]) -> Vec<Exp> {
+        exps.iter().map(|e| self.rewrite_exp(e.clone())).collect()
+    }
+
+    // Functions to specialize for the rewriting problem
+    // --------------------------------------------------
+
+    fn rewrite_enter_scope<'a>(&mut self, decls: impl Iterator<Item = &'a LocalVarDecl>) {}
+    fn rewrite_exit_scope(&mut self) {}
+    fn rewrite_node_id(&mut self, id: NodeId) -> Option<NodeId> {
+        None
+    }
+    fn rewrite_local_var(&mut self, id: NodeId, sym: Symbol) -> Option<Exp> {
+        None
+    }
+    fn rewrite_temporary(&mut self, id: NodeId, idx: TempIndex) -> Option<Exp> {
+        None
+    }
+    fn rewrite_value(&mut self, id: NodeId, value: &Value) -> Option<Exp> {
+        None
+    }
+    fn rewrite_spec_var(
+        &mut self,
+        id: NodeId,
+        mid: ModuleId,
+        vid: SpecVarId,
+        label: &Option<MemoryLabel>,
+    ) -> Option<Exp> {
+        None
+    }
+    fn rewrite_call(&mut self, id: NodeId, oper: &Operation, args: &[Exp]) -> Option<Exp> {
+        None
+    }
+    fn rewrite_invoke(&mut self, id: NodeId, target: &Exp, args: &[Exp]) -> Option<Exp> {
+        None
+    }
+    fn rewrite_lambda(&mut self, id: NodeId, vars: &[LocalVarDecl], body: &Exp) -> Option<Exp> {
+        None
+    }
+    fn rewrite_block(&mut self, id: NodeId, vars: &[LocalVarDecl], body: &Exp) -> Option<Exp> {
+        None
+    }
+    fn rewrite_quant(
+        &mut self,
+        id: NodeId,
+        vars: &[(LocalVarDecl, Exp)],
+        triggers: &[Vec<Exp>],
+        cond: &Option<Exp>,
+        body: &Exp,
+    ) -> Option<Exp> {
+        None
+    }
+    fn rewrite_if_else(&mut self, id: NodeId, cond: &Exp, then: &Exp, else_: &Exp) -> Option<Exp> {
+        None
+    }
+
+    // Core traversal functions, not intended to be re-implemented
+    // -----------------------------------------------------------
+
+    fn rewrite_exp_descent(&mut self, exp: Exp) -> Exp {
+        use ExpData::*;
+        match exp.as_ref() {
+            Value(id, value) => {
+                let (id_changed, new_id) = self.internal_rewrite_id(id);
+                if let Some(new_exp) = self.rewrite_value(new_id, value) {
+                    new_exp
+                } else if id_changed {
+                    Value(new_id, value.clone()).into_exp()
+                } else {
+                    exp
+                }
+            }
+            LocalVar(id, sym) => {
+                let (id_changed, new_id) = self.internal_rewrite_id(id);
+                if let Some(new_exp) = self.rewrite_local_var(new_id, *sym) {
+                    new_exp
+                } else if id_changed {
+                    LocalVar(new_id, *sym).into_exp()
+                } else {
+                    exp
+                }
+            }
+            Temporary(id, idx) => {
+                let (id_changed, new_id) = self.internal_rewrite_id(id);
+                if let Some(new_exp) = self.rewrite_temporary(new_id, *idx) {
+                    new_exp
+                } else if id_changed {
+                    Temporary(new_id, *idx).into_exp()
+                } else {
+                    exp
+                }
+            }
+            SpecVar(id, mid, vid, label) => {
+                let (id_changed, new_id) = self.internal_rewrite_id(id);
+                if let Some(new_exp) = self.rewrite_spec_var(new_id, *mid, *vid, label) {
+                    new_exp
+                } else if id_changed {
+                    SpecVar(new_id, *mid, *vid, label.to_owned()).into_exp()
+                } else {
+                    exp
+                }
+            }
+            Call(id, oper, args) => {
+                let (id_changed, new_id) = self.internal_rewrite_id(id);
+                let new_args_opt = self.internal_rewrite_vec(args);
+                let args_ref = if let Some(new_args) = &new_args_opt {
+                    new_args.as_slice()
+                } else {
+                    args.as_slice()
+                };
+                if let Some(new_exp) = self.rewrite_call(new_id, oper, &args_ref) {
+                    new_exp
+                } else if new_args_opt.is_some() || id_changed {
+                    let args_owned = if let Some(new_args) = new_args_opt {
+                        new_args
+                    } else {
+                        args.to_owned()
+                    };
+                    Call(new_id, oper.clone(), args_owned).into_exp()
+                } else {
+                    exp
+                }
+            }
+            Invoke(id, target, args) => {
+                let (id_changed, new_id) = self.internal_rewrite_id(id);
+                let (target_changed, new_target) = self.internal_rewrite_exp(target);
+                let new_args_opt = self.internal_rewrite_vec(args);
+                let args_ref = if let Some(new_args) = &new_args_opt {
+                    new_args.as_slice()
+                } else {
+                    args.as_slice()
+                };
+                if let Some(new_exp) = self.rewrite_invoke(new_id, &new_target, args_ref) {
+                    new_exp
+                } else if id_changed || target_changed || new_args_opt.is_some() {
+                    let args_owned = if let Some(new_args) = new_args_opt {
+                        new_args
+                    } else {
+                        args.to_owned()
+                    };
+                    Invoke(new_id, new_target, args_owned).into_exp()
+                } else {
+                    exp
+                }
+            }
+            Lambda(id, vars, body) => {
+                let (id_changed, new_id) = self.internal_rewrite_id(id);
+                let (vars_changed, new_vars) = self.internal_rewrite_decls(vars);
+                self.rewrite_enter_scope(new_vars.iter());
+                let (body_changed, new_body) = self.internal_rewrite_exp(body);
+                self.rewrite_exit_scope();
+                if let Some(new_exp) = self.rewrite_lambda(new_id, &new_vars, &new_body) {
+                    new_exp
+                } else if id_changed || vars_changed || body_changed {
+                    Lambda(new_id, new_vars, new_body).into_exp()
+                } else {
+                    exp
+                }
+            }
+            Block(id, vars, body) => {
+                let (id_changed, new_id) = self.internal_rewrite_id(id);
+                let (vars_changed, new_vars) = self.internal_rewrite_decls(vars);
+                self.rewrite_enter_scope(new_vars.iter());
+                let (body_changed, new_body) = self.internal_rewrite_exp(body);
+                self.rewrite_exit_scope();
+                if let Some(new_exp) = self.rewrite_block(new_id, &new_vars, &new_body) {
+                    new_exp
+                } else if id_changed || vars_changed || body_changed {
+                    Block(new_id, new_vars, new_body).into_exp()
+                } else {
+                    exp
+                }
+            }
+            Quant(id, kind, ranges, triggers, cond, body) => {
+                let (id_changed, new_id) = self.internal_rewrite_id(id);
+                let (ranges_changed, new_ranges) = self.internal_rewrite_quant_decls(ranges);
+                self.rewrite_enter_scope(ranges.iter().map(|(decl, _)| decl));
+                let mut triggers_changed = false;
+                let new_triggers = triggers
+                    .iter()
+                    .map(|p| {
+                        let (c, new_p) = self
+                            .internal_rewrite_vec(p)
+                            .map(|pr| (true, pr))
+                            .unwrap_or_else(|| (false, p.clone()));
+                        triggers_changed = triggers_changed || c;
+                        new_p
+                    })
+                    .collect_vec();
+                let mut cond_changed = false;
+                let new_cond = cond.as_ref().map(|c| {
+                    let (c, new_c) = self.internal_rewrite_exp(c);
+                    cond_changed = c;
+                    new_c
+                });
+                let (body_changed, new_body) = self.internal_rewrite_exp(body);
+                self.rewrite_exit_scope();
+                if let Some(new_exp) =
+                    self.rewrite_quant(new_id, &new_ranges, &new_triggers, &new_cond, &new_body)
+                {
+                    new_exp
+                } else if id_changed
+                    || ranges_changed
+                    || triggers_changed
+                    || cond_changed
+                    || body_changed
+                {
+                    Quant(new_id, *kind, new_ranges, new_triggers, new_cond, new_body).into_exp()
+                } else {
+                    exp
+                }
+            }
+            IfElse(id, cond, then, else_) => {
+                let (id_changed, new_id) = self.internal_rewrite_id(id);
+                let (cond_changed, new_cond) = self.internal_rewrite_exp(cond);
+                let (then_changed, new_then) = self.internal_rewrite_exp(then);
+                let (else_changed, new_else) = self.internal_rewrite_exp(else_);
+                if let Some(new_exp) = self.rewrite_if_else(new_id, &new_cond, &new_then, &new_else)
+                {
+                    new_exp
+                } else if id_changed || cond_changed || then_changed || else_changed {
+                    IfElse(new_id, new_cond, new_then, new_else).into_exp()
+                } else {
+                    exp
+                }
+            }
+            Invalid(..) => unreachable!(),
+        }
+    }
+
+    fn internal_rewrite_id(&mut self, id: &NodeId) -> (bool, NodeId) {
+        if let Some(new_id) = self.rewrite_node_id(*id) {
+            (true, new_id)
         } else {
-            let node_id = self.rewrite_attrs(node_id);
-            Exp::LocalVar(node_id, sym)
+            (false, *id)
         }
     }
 
-    fn replace_temporary(&mut self, node_id: NodeId, idx: TempIndex) -> Exp {
-        if let Some(exp) = (*self.replacer)(node_id, RewriteTarget::Temporary(idx)) {
-            exp
-        } else {
-            let node_id = self.rewrite_attrs(node_id);
-            Exp::Temporary(node_id, idx)
+    fn internal_rewrite_exp(&mut self, exp: &Exp) -> (bool, Exp) {
+        let new_exp = self.rewrite_exp(exp.clone());
+        (!ExpData::ptr_eq(exp, &new_exp), new_exp)
+    }
+
+    fn internal_rewrite_vec(&mut self, exps: &[Exp]) -> Option<Vec<Exp>> {
+        // The vector rewrite works a bit different as we try to avoid constructing
+        // new vectors if nothing changed, and optimize common cases of 0-3 arguments.
+        match exps.len() {
+            0 => None,
+            1 => {
+                let (c, e) = self.internal_rewrite_exp(&exps[0]);
+                if c {
+                    Some(vec![e])
+                } else {
+                    None
+                }
+            }
+            2 => {
+                let (c1, e1) = self.internal_rewrite_exp(&exps[0]);
+                let (c2, e2) = self.internal_rewrite_exp(&exps[1]);
+                if c1 || c2 {
+                    Some(vec![e1, e2])
+                } else {
+                    None
+                }
+            }
+            3 => {
+                let (c1, e1) = self.internal_rewrite_exp(&exps[0]);
+                let (c2, e2) = self.internal_rewrite_exp(&exps[1]);
+                let (c3, e3) = self.internal_rewrite_exp(&exps[2]);
+                if c1 || c2 || c3 {
+                    Some(vec![e1, e2, e3])
+                } else {
+                    None
+                }
+            }
+            _ => {
+                // generic treatment
+                let mut change = false;
+                let mut res = vec![];
+                for exp in exps {
+                    let (c, new_exp) = self.internal_rewrite_exp(exp);
+                    change = change || c;
+                    res.push(new_exp)
+                }
+                if change {
+                    Some(res)
+                } else {
+                    None
+                }
+            }
         }
     }
 
-    pub fn rewrite_vec(&mut self, exps: &[Exp]) -> Vec<Exp> {
-        let mut res = vec![];
-        for exp in exps {
-            res.push(self.rewrite(exp));
-        }
-        res
+    fn internal_rewrite_decls(&mut self, decls: &[LocalVarDecl]) -> (bool, Vec<LocalVarDecl>) {
+        let mut change = false;
+        let new_decls = decls
+            .iter()
+            .map(|d| LocalVarDecl {
+                id: {
+                    let (c, id) = self.internal_rewrite_id(&d.id);
+                    change = change || c;
+                    id
+                },
+                name: d.name,
+                binding: d.binding.as_ref().map(|e| {
+                    let (c, new_e) = self.internal_rewrite_exp(e);
+                    change = change || c;
+                    new_e
+                }),
+            })
+            .collect();
+        (change, new_decls)
     }
 
-    fn rewrite_attrs(&mut self, node_id: NodeId) -> NodeId {
-        if self.type_args.is_empty() {
-            // Can reuse the node_id and attributes
-            return node_id;
-        }
-        // Need to create a new node id because of type instantiation in this rewrite.
-        let loc = self.env.get_node_loc(node_id);
-        let ty = self.env.get_node_type(node_id).instantiate(self.type_args);
-        let inst_opt = self.env.get_node_instantiation_opt(node_id).map(|tys| {
-            tys.into_iter()
-                .map(|ty| ty.instantiate(self.type_args))
-                .collect_vec()
-        });
-        let new_node_id = self.env.new_node(loc, ty);
-        if let Some(inst) = inst_opt {
-            self.env.set_node_instantiation(new_node_id, inst);
-        }
-        new_node_id
+    fn internal_rewrite_quant_decls(
+        &mut self,
+        decls: &[(LocalVarDecl, Exp)],
+    ) -> (bool, Vec<(LocalVarDecl, Exp)>) {
+        let mut change = false;
+        let new_decls = decls
+            .iter()
+            .map(|(d, e)| {
+                assert!(d.binding.is_none());
+                (
+                    LocalVarDecl {
+                        id: {
+                            let (c, id) = self.internal_rewrite_id(&d.id);
+                            change = change || c;
+                            id
+                        },
+                        name: d.name,
+                        binding: None,
+                    },
+                    {
+                        let (c, new_e) = self.internal_rewrite_exp(e);
+                        change = change || c;
+                        new_e
+                    },
+                )
+            })
+            .collect();
+        (change, new_decls)
     }
 }

--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -58,7 +58,7 @@ use move_core_types::{
 
 use crate::{
     ast::{
-        ConditionKind, Exp, GlobalInvariant, ModuleName, PropertyBag, PropertyValue, Spec,
+        ConditionKind, ExpData, GlobalInvariant, ModuleName, PropertyBag, PropertyValue, Spec,
         SpecBlockInfo, SpecFunDecl, SpecVarDecl, Value,
     },
     pragmas::{
@@ -70,6 +70,7 @@ use crate::{
 };
 
 // import and re-expose symbols
+use crate::ast::Exp;
 pub use move_binary_format::file_format::{AbilitySet, Visibility as FunctionVisibility};
 
 // =================================================================================================
@@ -1597,7 +1598,7 @@ impl<'env> ModuleEnv<'env> {
             .collect();
         if include_specs {
             // Add any usage in specs.
-            let add_usage_of_exp = |usage: &mut BTreeSet<ModuleId>, exp: &Exp| {
+            let add_usage_of_exp = |usage: &mut BTreeSet<ModuleId>, exp: &ExpData| {
                 exp.module_usage(usage);
                 for node_id in exp.node_ids() {
                     self.env.get_node_type(node_id).module_usage(usage);

--- a/language/move-prover/bytecode/src/function_target.rs
+++ b/language/move-prover/bytecode/src/function_target.rs
@@ -9,7 +9,7 @@ use crate::{
 use itertools::Itertools;
 use move_binary_format::file_format::CodeOffset;
 use move_model::{
-    ast::{Exp, Spec},
+    ast::Spec,
     model::{
         FunId, FunctionEnv, FunctionVisibility, GlobalEnv, Loc, ModuleEnv, QualifiedId, StructId,
         TypeParameter,
@@ -19,7 +19,10 @@ use move_model::{
 };
 
 use crate::function_target_pipeline::FunctionVariant;
-use move_model::{ast::TempIndex, model::QualifiedInstId};
+use move_model::{
+    ast::{Exp, TempIndex},
+    model::QualifiedInstId,
+};
 use std::{
     cell::RefCell,
     collections::{BTreeMap, BTreeSet},

--- a/language/move-prover/bytecode/src/stackless_bytecode.rs
+++ b/language/move-prover/bytecode/src/stackless_bytecode.rs
@@ -5,8 +5,8 @@ use crate::function_target::FunctionTarget;
 use itertools::Itertools;
 use move_binary_format::file_format::CodeOffset;
 use move_model::{
-    ast::{Exp, MemoryLabel, TempIndex},
-    exp_rewriter::{ExpRewriter, RewriteTarget},
+    ast::{Exp, ExpData, MemoryLabel, TempIndex},
+    exp_rewriter::{ExpRewriter, ExpRewriterFunctions, RewriteTarget},
     model::{FunId, GlobalEnv, ModuleId, NodeId, QualifiedInstId, SpecVarId, StructId},
     ty::{Type, TypeDisplayContext},
 };
@@ -514,12 +514,12 @@ impl Bytecode {
     {
         let mut replacer = |node_id: NodeId, target: RewriteTarget| {
             if let RewriteTarget::Temporary(idx) = target {
-                Some(Exp::Temporary(node_id, f(idx)))
+                Some(ExpData::Temporary(node_id, f(idx)).into_exp())
             } else {
                 None
             }
         };
-        ExpRewriter::new(func_target.global_env(), &mut replacer).rewrite(&exp)
+        ExpRewriter::new(func_target.global_env(), &mut replacer).rewrite_exp(exp)
     }
 
     /// Return the temporaries this instruction modifies and how the temporaries are modified.


### PR DESCRIPTION
This PR switch the `model::ast::Exp` representation to use internalization (aka "pointer equality ==> structural equality"). We use the awesome new [internment](https://crates.io/crates/internment) crate for this which provides a uniform API, behaving similar than Rc, with different underlying implementations (process global, thread local, or Arc ref counted). The current choice is to use thread local, but it can be easily changed at later points.

The PR also introduces a new trait-based expression rewriter abstraction which attempts to preserve sharing. This new rewriter replaces three different existing rewriter implementations, eliminating some technical debt.

Internalization is highly desirable to make specification inference and other techniques relying on term rewriting feasible.

## Motivation

Better representation of expressions.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests

## Related PRs

NA
