### PR TITLE
[move-unit-test] Add ability to hook move unit tests into cargo test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4688,6 +4688,7 @@ dependencies = [
  "docgen",
  "log",
  "move-prover",
+ "move-unit-test",
  "tempfile",
  "walkdir",
 ]
@@ -4712,6 +4713,7 @@ dependencies = [
  "move-vm-test-utils",
  "move-vm-types",
  "rayon",
+ "regex",
  "resource-viewer",
  "structopt 0.3.21",
 ]

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/arithmetics.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/arithmetics.exp
@@ -1,4 +1,4 @@
-Running tests
+Running Move unit tests
 [ PASS    ] 0x2::A::add_ok
 [ PASS    ] 0x2::A::add_overflow
 [ PASS    ] 0x2::A::div_by_zero

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/bcs.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/bcs.exp
@@ -1,3 +1,3 @@
-Running tests
+Running Move unit tests
 [ PASS    ] 0x2::A::bcs_ops
 Test result: OK. Total tests: 1; passed: 1; failed: 0

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/bitwise.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/bitwise.exp
@@ -1,4 +1,4 @@
-Running tests
+Running Move unit tests
 [ PASS    ] 0x2::A::bitand
 [ PASS    ] 0x2::A::bitor
 [ PASS    ] 0x2::A::bitxor

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/comparison.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/comparison.exp
@@ -1,3 +1,3 @@
-Running tests
+Running Move unit tests
 [ PASS    ] 0x2::A::compare
 Test result: OK. Total tests: 1; passed: 1; failed: 0

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/empty.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/empty.exp
@@ -1,3 +1,3 @@
-Running tests
+Running Move unit tests
 [ PASS    ] 0x2::A::do_nothing
 Test result: OK. Total tests: 1; passed: 1; failed: 0

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/event.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/event.exp
@@ -1,3 +1,3 @@
-Running tests
+Running Move unit tests
 [ PASS    ] 0x2::A::emit
 Test result: OK. Total tests: 1; passed: 1; failed: 0

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/function_call.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/function_call.exp
@@ -1,4 +1,4 @@
-Running tests
+Running Move unit tests
 [ PASS    ] 0x2::A::call_imm_ref
 [ PASS    ] 0x2::A::call_mut_ref
 [ PASS    ] 0x2::A::call_val

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/global_basics.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/global_basics.exp
@@ -1,4 +1,4 @@
-Running tests
+Running Move unit tests
 [ PASS    ] 0x2::A::borrow_imm_err
 [ PASS    ] 0x2::A::borrow_imm_ok
 [ PASS    ] 0x2::A::borrow_mut_err

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/if_else.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/if_else.exp
@@ -1,3 +1,3 @@
-Running tests
+Running Move unit tests
 [ PASS    ] 0x2::A::if_else
 Test result: OK. Total tests: 1; passed: 1; failed: 0

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/load_constant.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/load_constant.exp
@@ -1,3 +1,3 @@
-Running tests
+Running Move unit tests
 [ PASS    ] 0x2::A::load_constant
 Test result: OK. Total tests: 1; passed: 1; failed: 0

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/local_ref.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/local_ref.exp
@@ -1,4 +1,4 @@
-Running tests
+Running Move unit tests
 [ PASS    ] 0x2::A::local_imm_ref
 [ PASS    ] 0x2::A::local_mut_ref
 Test result: OK. Total tests: 2; passed: 2; failed: 0

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/loop.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/loop.exp
@@ -1,4 +1,4 @@
-Running tests
+Running Move unit tests
 [ PASS    ] 0x2::A::loop_ind_ref
 [ PASS    ] 0x2::A::loop_ind_var
 Test result: OK. Total tests: 2; passed: 2; failed: 0

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/pack_unpack.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/pack_unpack.exp
@@ -1,4 +1,4 @@
-Running tests
+Running Move unit tests
 [ PASS    ] 0x2::A::pack
 [ PASS    ] 0x2::A::unpack
 Test result: OK. Total tests: 2; passed: 2; failed: 0

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/vector.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/vector.exp
@@ -1,3 +1,3 @@
-Running tests
+Running Move unit tests
 [ PASS    ] 0x2::A::vector_ops
 Test result: OK. Total tests: 1; passed: 1; failed: 0

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check_testsuite.rs
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check_testsuite.rs
@@ -22,6 +22,7 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
         check_stackless_vm: true,
         report_storage_on_error: false,
         report_statistics: false,
+        list: false,
         verbose: read_bool_env_var("VERBOSE"),
     };
 

--- a/language/move-stdlib/Cargo.toml
+++ b/language/move-stdlib/Cargo.toml
@@ -20,5 +20,6 @@ log = "0.4.14"
 walkdir = "2.3.1"
 
 [dev-dependencies]
+move-unit-test = { path = "../tools/move-unit-test" }
 tempfile = "3.2.0"
 dir-diff = "0.3.2"

--- a/language/move-stdlib/tests/move_unit_test.rs
+++ b/language/move-stdlib/tests/move_unit_test.rs
@@ -1,0 +1,10 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use move_unit_test::UnitTestingConfig;
+
+move_unit_test::register_move_unit_tests!(
+    UnitTestingConfig::default_with_bound(Some(100_000)),
+    ".",
+    r".*\.move$"
+);

--- a/language/tools/move-unit-test/Cargo.toml
+++ b/language/tools/move-unit-test/Cargo.toml
@@ -15,6 +15,9 @@ structopt = "0.3.21"
 colored = "2.0.0"
 rayon = "1.5.0"
 
+regex = "1.1.9"
+
+move-stdlib = { path = "../../move-stdlib" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
 move-lang = { path = "../../move-lang" }
@@ -29,7 +32,6 @@ bytecode-interpreter = { path = "../../move-prover/interpreter" }
 [dev-dependencies]
 datatest-stable = "0.1.1"
 difference = "2.0.0"
-move-stdlib = { path = "../../move-stdlib" }
 move-lang-test-utils = { path = "../../move-lang/test-utils" }
 
 [[bin]]

--- a/language/tools/move-unit-test/src/cargo_runner.rs
+++ b/language/tools/move-unit-test/src/cargo_runner.rs
@@ -1,0 +1,47 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::UnitTestingConfig;
+
+pub fn run_tests_with_config_and_filter(
+    mut config: UnitTestingConfig,
+    root_path: &str,
+    pattern: &str,
+) {
+    let re = regex::Regex::new(pattern)
+        .unwrap_or_else(|_| panic!("Invalid regular expression: '{}'", pattern));
+    let sources = move_stdlib::utils::iterate_directory(&std::path::Path::new(root_path))
+        .filter_map(|path| {
+            let name = path.to_string_lossy();
+            if re.is_match(&name) {
+                Some(name.to_string())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    config.source_files = sources;
+    let test_plan = config.build_test_plan().expect("Unable to build test plan");
+
+    let (_, all_tests_passed) = config
+        .run_and_report_unit_tests(test_plan, std::io::stdout())
+        .expect("Failed to execute tests");
+
+    // If all tests passed, exit with 0 otherwise with a non-zero exit code.
+    if all_tests_passed {
+        std::process::exit(0)
+    } else {
+        std::process::exit(1)
+    }
+}
+
+#[macro_export]
+macro_rules! register_move_unit_tests {
+    ($config:expr, $root:expr, $pattern:expr) => {
+        #[test]
+        fn move_unit_tests() {
+            $crate::cargo_runner::run_tests_with_config_and_filter($config, $root, $pattern)
+        }
+    };
+}

--- a/language/tools/move-unit-test/src/test_reporter.rs
+++ b/language/tools/move-unit-test/src/test_reporter.rs
@@ -368,7 +368,8 @@ impl TestResults {
         writeln!(writer.lock().unwrap())
     }
 
-    pub fn summarize<W: Write>(self, writer: &Mutex<W>) -> Result<()> {
+    /// Returns `true` if all tests passed, `false` if there was a test failure/timeout
+    pub fn summarize<W: Write>(self, writer: &Mutex<W>) -> Result<bool> {
         let num_failed_tests = self
             .final_statistics
             .failed
@@ -417,6 +418,6 @@ impl TestResults {
             num_passed_tests,
             num_failed_tests
         )?;
-        Ok(())
+        Ok(num_failed_tests == 0)
     }
 }

--- a/language/tools/move-unit-test/tests/move_unit_test_testsuite.rs
+++ b/language/tools/move-unit-test/tests/move_unit_test_testsuite.rs
@@ -58,7 +58,7 @@ pub fn modify(mut base_config: UnitTestingConfig, modifier_str: &str) -> Option<
 fn run_test_with_modifiers(
     unit_test_config: UnitTestingConfig,
     path: &Path,
-) -> datatest_stable::Result<Vec<(Vec<u8>, PathBuf)>> {
+) -> datatest_stable::Result<Vec<((Vec<u8>, bool), PathBuf)>> {
     let mut results = Vec::new();
 
     for modifier in TEST_MODIFIER_STRS.iter() {
@@ -113,9 +113,10 @@ fn run_test(path: &Path) -> datatest_stable::Result<()> {
         verbose: false,
         report_statistics: false,
         report_storage_on_error: false,
+        list: false,
     };
 
-    for (buffer, exp_path) in run_test_with_modifiers(unit_test_config, path)? {
+    for ((buffer, _), exp_path) in run_test_with_modifiers(unit_test_config, path)? {
         if update_baseline {
             fs::write(&exp_path, &buffer)?
         }

--- a/language/tools/move-unit-test/tests/test_sources/construct_data.exp
+++ b/language/tools/move-unit-test/tests/test_sources/construct_data.exp
@@ -1,4 +1,4 @@
-Running tests
+Running Move unit tests
 [ PASS    ] 0x1::M::make_sure_not_other_number
 [ PASS    ] 0x1::M::make_sure_number_matches
 Test result: OK. Total tests: 2; passed: 2; failed: 0

--- a/language/tools/move-unit-test/tests/test_sources/cross_module_aborts.exp
+++ b/language/tools/move-unit-test/tests/test_sources/cross_module_aborts.exp
@@ -1,4 +1,4 @@
-Running tests
+Running Move unit tests
 [ FAIL    ] 0x1::B::failing_test
 [ PASS    ] 0x1::M::dummy_test
 

--- a/language/tools/move-unit-test/tests/test_sources/expected_abort_no_abort.exp
+++ b/language/tools/move-unit-test/tests/test_sources/expected_abort_no_abort.exp
@@ -1,4 +1,4 @@
-Running tests
+Running Move unit tests
 [ FAIL    ] 0x1::M::fail
 [ FAIL    ] 0x1::M::fail_with_code
 

--- a/language/tools/move-unit-test/tests/test_sources/proposal_test.exp
+++ b/language/tools/move-unit-test/tests/test_sources/proposal_test.exp
@@ -1,4 +1,4 @@
-Running tests
+Running Move unit tests
 [ PASS    ] 0x1::Module::other_module_aborts
 [ PASS    ] 0x1::Module::tests_a
 [ PASS    ] 0x1::Module::tests_aborts

--- a/language/tools/move-unit-test/tests/test_sources/proposal_test.storage.exp
+++ b/language/tools/move-unit-test/tests/test_sources/proposal_test.storage.exp
@@ -1,4 +1,4 @@
-Running tests
+Running Move unit tests
 [ PASS    ] 0x1::Module::other_module_aborts
 [ PASS    ] 0x1::Module::tests_a
 [ PASS    ] 0x1::Module::tests_aborts

--- a/language/tools/move-unit-test/tests/test_sources/signer_args.exp
+++ b/language/tools/move-unit-test/tests/test_sources/signer_args.exp
@@ -1,4 +1,4 @@
-Running tests
+Running Move unit tests
 [ FAIL    ] 0x1::M::multi_signer_fail
 [ PASS    ] 0x1::M::multi_signer_pass
 [ PASS    ] 0x1::M::multi_signer_pass_expected_failure

--- a/language/tools/move-unit-test/tests/test_sources/storage_on_error_empty_and_non_empty.exp
+++ b/language/tools/move-unit-test/tests/test_sources/storage_on_error_empty_and_non_empty.exp
@@ -1,4 +1,4 @@
-Running tests
+Running Move unit tests
 [ PASS    ] 0x1::A::a
 [ PASS    ] 0x1::A::b
 [ PASS    ] 0x1::A::c

--- a/language/tools/move-unit-test/tests/test_sources/storage_on_error_empty_and_non_empty.storage.exp
+++ b/language/tools/move-unit-test/tests/test_sources/storage_on_error_empty_and_non_empty.storage.exp
@@ -1,4 +1,4 @@
-Running tests
+Running Move unit tests
 [ PASS    ] 0x1::A::a
 [ PASS    ] 0x1::A::b
 [ PASS    ] 0x1::A::c

--- a/language/tools/move-unit-test/tests/test_sources/storage_test.exp
+++ b/language/tools/move-unit-test/tests/test_sources/storage_test.exp
@@ -1,4 +1,4 @@
-Running tests
+Running Move unit tests
 [ PASS    ] 0x1::B::tests_a
 [ PASS    ] 0x1::B::tests_b
 Test result: OK. Total tests: 2; passed: 2; failed: 0

--- a/language/tools/move-unit-test/tests/test_sources/storage_test.storage.exp
+++ b/language/tools/move-unit-test/tests/test_sources/storage_test.storage.exp
@@ -1,4 +1,4 @@
-Running tests
+Running Move unit tests
 [ PASS    ] 0x1::B::tests_a
 [ PASS    ] 0x1::B::tests_b
 Test result: OK. Total tests: 2; passed: 2; failed: 0

--- a/language/tools/move-unit-test/tests/test_sources/timeout.exp
+++ b/language/tools/move-unit-test/tests/test_sources/timeout.exp
@@ -1,4 +1,4 @@
-Running tests
+Running Move unit tests
 [ PASS    ] 0x1::M::no_timeout
 [ FAIL    ] 0x1::M::no_timeout_fail
 [ PASS    ] 0x1::M::no_timeout_while_loop

--- a/language/tools/move-unit-test/tests/test_sources/unexpected_abort.exp
+++ b/language/tools/move-unit-test/tests/test_sources/unexpected_abort.exp
@@ -1,4 +1,4 @@
-Running tests
+Running Move unit tests
 [ PASS    ] 0x1::M::correct_abort_code
 [ PASS    ] 0x1::M::just_test_failure
 [ FAIL    ] 0x1::M::unexpected_abort


### PR DESCRIPTION
This adds a simple macro to the `move-unit-test` crate to allow Rust crates to add Move unit tests to its tests in a similar manner to `datatest_stable::harness`. This way Move unit tests will be run in CI.

I've  used this new feature in the `move-stdlib` crate as an example of how this would look (and since there is already Move code in there using unit tests that we want checked in CI).

Note that the features exposed through `cargo test` are fairly basic (no filtering etc.). If a user wants to run the Move unit tests and pass filters, num_threads, etc. they will need to use the move-unit-test binary itself (and later on the move cli).

