### PR TITLE
[scratchpad] NaiveSmt to test against

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6417,6 +6417,7 @@ name = "scratchpad"
 version = "0.1.0"
 dependencies = [
  "arc-swap",
+ "bitvec",
  "criterion",
  "diem-crypto",
  "diem-infallible",

--- a/storage/scratchpad/Cargo.toml
+++ b/storage/scratchpad/Cargo.toml
@@ -20,6 +20,7 @@ diem-types = { path = "../../types" }
 diem-workspace-hack = { path = "../../common/workspace-hack" }
 
 [dev-dependencies]
+bitvec = "0.19.4"
 criterion = "0.3.4"
 rand = "0.8.3"
 proptest = "1.0.0"

--- a/storage/scratchpad/src/sparse_merkle/mod.rs
+++ b/storage/scratchpad/src/sparse_merkle/mod.rs
@@ -74,6 +74,8 @@ mod utils;
 
 #[cfg(test)]
 mod sparse_merkle_test;
+#[cfg(test)]
+mod test_utils;
 
 use crate::sparse_merkle::{
     node::{LeafValue, Node, SubTree},

--- a/storage/scratchpad/src/sparse_merkle/test_utils.rs
+++ b/storage/scratchpad/src/sparse_merkle/test_utils.rs
@@ -1,0 +1,145 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::sparse_merkle::utils::partition;
+use bitvec::prelude::*;
+use diem_crypto::{
+    hash::{CryptoHash, SPARSE_MERKLE_PLACEHOLDER_HASH},
+    HashValue,
+};
+use diem_types::proof::{SparseMerkleInternalNode, SparseMerkleLeafNode, SparseMerkleProof};
+use std::collections::{BTreeMap, HashMap};
+
+type Cache = HashMap<BitVec<Msb0, u8>, HashValue>;
+
+struct NaiveSubTree<'a> {
+    leaves: &'a [(HashValue, HashValue)],
+    depth: usize,
+}
+
+impl<'a> NaiveSubTree<'a> {
+    fn get_proof(
+        &'a self,
+        key: &HashValue,
+        mut cache: &mut Cache,
+    ) -> (Option<SparseMerkleLeafNode>, Vec<HashValue>) {
+        if self.is_empty() {
+            (None, Vec::new())
+        } else if self.leaves.len() == 1 {
+            let only_leaf = self.leaves[0];
+            (
+                Some(SparseMerkleLeafNode::new(only_leaf.0, only_leaf.1)),
+                Vec::new(),
+            )
+        } else {
+            let (left, right) = self.children();
+            if key.bit(self.depth) {
+                let (ret_leaf, mut ret_siblings) = right.get_proof(key, &mut cache);
+                ret_siblings.push(left.get_hash(&mut cache));
+                (ret_leaf, ret_siblings)
+            } else {
+                let (ret_leaf, mut ret_siblings) = left.get_proof(key, &mut cache);
+                ret_siblings.push(right.get_hash(&mut cache));
+                (ret_leaf, ret_siblings)
+            }
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.leaves.is_empty()
+    }
+
+    fn get_hash(&self, mut cache: &mut Cache) -> HashValue {
+        if self.leaves.is_empty() {
+            return *SPARSE_MERKLE_PLACEHOLDER_HASH;
+        }
+
+        let position = self.leaves[0]
+            .0
+            .view_bits()
+            .split_at(self.depth)
+            .0
+            .to_bitvec();
+
+        match cache.get(&position) {
+            Some(hash) => *hash,
+            None => {
+                let hash = self.get_hash_uncached(&mut cache);
+                cache.insert(position, hash);
+                hash
+            }
+        }
+    }
+
+    fn get_hash_uncached(&self, mut cache: &mut Cache) -> HashValue {
+        assert!(!self.leaves.is_empty());
+        if self.leaves.len() == 1 {
+            let only_leaf = self.leaves[0];
+            SparseMerkleLeafNode::new(only_leaf.0, only_leaf.1).hash()
+        } else {
+            let (left, right) = self.children();
+            SparseMerkleInternalNode::new(left.get_hash(&mut cache), right.get_hash(&mut cache))
+                .hash()
+        }
+    }
+
+    fn children(&self) -> (Self, Self) {
+        let pivot = partition(self.leaves, self.depth);
+        let (left, right) = self.leaves.split_at(pivot);
+        (
+            Self {
+                leaves: left,
+                depth: self.depth + 1,
+            },
+            Self {
+                leaves: right,
+                depth: self.depth + 1,
+            },
+        )
+    }
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct NaiveSmt {
+    leaves: Vec<(HashValue, HashValue)>,
+    cache: Cache,
+}
+
+impl NaiveSmt {
+    pub fn new<V: CryptoHash>(leaves: &[(HashValue, &V)]) -> Self {
+        Self::default().update(leaves)
+    }
+
+    pub fn update<V: CryptoHash>(self, updates: &[(HashValue, &V)]) -> Self {
+        let mut leaves = self.leaves.into_iter().collect::<BTreeMap<_, _>>();
+        let mut new_leaves = updates
+            .iter()
+            .map(|(address, value)| (*address, value.hash()))
+            .collect::<BTreeMap<_, _>>();
+        leaves.append(&mut new_leaves);
+
+        Self {
+            leaves: leaves.into_iter().collect::<Vec<_>>(),
+            cache: Cache::new(),
+        }
+    }
+
+    pub fn get_proof<V: CryptoHash>(&mut self, key: &HashValue) -> SparseMerkleProof<V> {
+        let root = NaiveSubTree {
+            leaves: &self.leaves,
+            depth: 0,
+        };
+
+        let (leaf, siblings) = root.get_proof(key, &mut self.cache);
+        SparseMerkleProof::new(leaf, siblings)
+    }
+
+    pub fn get_root_hash(&mut self) -> HashValue {
+        let root = NaiveSubTree {
+            leaves: &self.leaves,
+            depth: 0,
+        };
+
+        root.get_hash(&mut self.cache)
+    }
+}

--- a/storage/scratchpad/src/sparse_merkle/utils.rs
+++ b/storage/scratchpad/src/sparse_merkle/utils.rs
@@ -1,0 +1,31 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use diem_crypto::HashValue;
+
+/// Swap template-type values if 'cond'=true - useful to determine left/right parameters.
+pub(crate) fn swap_if<T>(first: T, second: T, cond: bool) -> (T, T) {
+    if cond {
+        (second, first)
+    } else {
+        (first, second)
+    }
+}
+
+/// Return the index of the first bit that is 1 at the given depth when updates are
+/// lexicographically sorted.
+pub(crate) fn partition<T>(updates: &[(HashValue, T)], depth: usize) -> usize {
+    // Binary search for the cut-off point where the bit at this depth turns from 0 to 1.
+    // TODO: with stable partition_point: updates.partition_point(|&u| !u.0.bit(depth));
+    let (mut i, mut j) = (0, updates.len());
+    // Find the first index that starts with bit 1.
+    while i < j {
+        let mid = i + (j - i) / 2;
+        if updates[mid].0.bit(depth) {
+            j = mid;
+        } else {
+            i = mid + 1;
+        }
+    }
+    i
+}


### PR DESCRIPTION
## Motivation


Check generate root hash and proofs with this so that we don't need to rely on the DB (the JellyFish indeed) in tests and benchmarks. The update interface of the JellyFish might change and depend on the scratchpad instead.

(Will clean up the DB usage separately, later.)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Tests updated
