### PR TITLE
[scratchpad] sophisticated Criterion benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6421,6 +6421,7 @@ name = "scratchpad"
 version = "0.1.0"
 dependencies = [
  "arc-swap",
+ "bitvec",
  "criterion",
  "diem-crypto",
  "diem-infallible",

--- a/storage/scratchpad/Cargo.toml
+++ b/storage/scratchpad/Cargo.toml
@@ -20,6 +20,7 @@ diem-types = { path = "../../types" }
 diem-workspace-hack = { path = "../../common/workspace-hack" }
 
 [dev-dependencies]
+bitvec = "0.19.4"
 criterion = "0.3.4"
 rand = "0.8.3"
 proptest = "1.0.0"

--- a/storage/scratchpad/Cargo.toml
+++ b/storage/scratchpad/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 arc-swap = "1.2.0"
+bitvec = {version = "0.19.4", optional = true}
 itertools = "0.10.0"
 rayon = "1.5.0"
 
@@ -32,7 +33,9 @@ storage-interface = { path = "../storage-interface" }
 
 [features]
 fuzzing = ["diemdb/fuzzing", "diem-types/fuzzing"]
+bench = ["bitvec"]
 
 [[bench]]
 name = "sparse_merkle"
 harness = false
+required-features = ["bench"]

--- a/storage/scratchpad/src/lib.rs
+++ b/storage/scratchpad/src/lib.rs
@@ -6,3 +6,6 @@
 mod sparse_merkle;
 
 pub use crate::sparse_merkle::{AccountStatus, ProofRead, SparseMerkleTree};
+
+#[cfg(any(test, feature = "bench"))]
+pub use crate::sparse_merkle::test_utils;

--- a/storage/scratchpad/src/sparse_merkle/mod.rs
+++ b/storage/scratchpad/src/sparse_merkle/mod.rs
@@ -74,6 +74,8 @@ mod utils;
 
 #[cfg(test)]
 mod sparse_merkle_test;
+#[cfg(test)]
+mod test_utils;
 
 use crate::sparse_merkle::{
     node::{LeafValue, Node, SubTree},

--- a/storage/scratchpad/src/sparse_merkle/mod.rs
+++ b/storage/scratchpad/src/sparse_merkle/mod.rs
@@ -74,8 +74,8 @@ mod utils;
 
 #[cfg(test)]
 mod sparse_merkle_test;
-#[cfg(test)]
-mod test_utils;
+#[cfg(any(test, feature = "bench"))]
+pub mod test_utils;
 
 use crate::sparse_merkle::{
     node::{LeafValue, Node, SubTree},

--- a/storage/scratchpad/src/sparse_merkle/test_utils.rs
+++ b/storage/scratchpad/src/sparse_merkle/test_utils.rs
@@ -100,7 +100,7 @@ impl<'a> NaiveSubTree<'a> {
 }
 
 #[derive(Clone, Default)]
-pub(crate) struct NaiveSmt {
+pub struct NaiveSmt {
     leaves: Vec<(HashValue, HashValue)>,
     cache: Cache,
 }

--- a/storage/scratchpad/src/sparse_merkle/test_utils.rs
+++ b/storage/scratchpad/src/sparse_merkle/test_utils.rs
@@ -1,0 +1,145 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::sparse_merkle::utils::partition;
+use bitvec::prelude::*;
+use diem_crypto::{
+    hash::{CryptoHash, SPARSE_MERKLE_PLACEHOLDER_HASH},
+    HashValue,
+};
+use diem_types::proof::{SparseMerkleInternalNode, SparseMerkleLeafNode, SparseMerkleProof};
+use std::collections::{BTreeMap, HashMap};
+
+type Cache = HashMap<BitVec<Msb0, u8>, HashValue>;
+
+struct NaiveSubTree<'a> {
+    leaves: &'a [(HashValue, HashValue)],
+    depth: usize,
+}
+
+impl<'a> NaiveSubTree<'a> {
+    fn get_proof(
+        &'a self,
+        key: &HashValue,
+        mut cache: &mut Cache,
+    ) -> (Option<SparseMerkleLeafNode>, Vec<HashValue>) {
+        if self.is_empty() {
+            (None, Vec::new())
+        } else if self.leaves.len() == 1 {
+            let only_leaf = self.leaves[0];
+            (
+                Some(SparseMerkleLeafNode::new(only_leaf.0, only_leaf.1)),
+                Vec::new(),
+            )
+        } else {
+            let (left, right) = self.children();
+            if key.bit(self.depth) {
+                let (ret_leaf, mut ret_siblings) = right.get_proof(key, &mut cache);
+                ret_siblings.push(left.get_hash(&mut cache));
+                (ret_leaf, ret_siblings)
+            } else {
+                let (ret_leaf, mut ret_siblings) = left.get_proof(key, &mut cache);
+                ret_siblings.push(right.get_hash(&mut cache));
+                (ret_leaf, ret_siblings)
+            }
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.leaves.is_empty()
+    }
+
+    fn get_hash(&self, mut cache: &mut Cache) -> HashValue {
+        if self.leaves.is_empty() {
+            return *SPARSE_MERKLE_PLACEHOLDER_HASH;
+        }
+
+        let position = self.leaves[0]
+            .0
+            .view_bits()
+            .split_at(self.depth)
+            .0
+            .to_bitvec();
+
+        match cache.get(&position) {
+            Some(hash) => *hash,
+            None => {
+                let hash = self.get_hash_uncached(&mut cache);
+                cache.insert(position, hash);
+                hash
+            }
+        }
+    }
+
+    fn get_hash_uncached(&self, mut cache: &mut Cache) -> HashValue {
+        assert!(!self.leaves.is_empty());
+        if self.leaves.len() == 1 {
+            let only_leaf = self.leaves[0];
+            SparseMerkleLeafNode::new(only_leaf.0, only_leaf.1).hash()
+        } else {
+            let (left, right) = self.children();
+            SparseMerkleInternalNode::new(left.get_hash(&mut cache), right.get_hash(&mut cache))
+                .hash()
+        }
+    }
+
+    fn children(&self) -> (Self, Self) {
+        let pivot = partition(self.leaves, self.depth);
+        let (left, right) = self.leaves.split_at(pivot);
+        (
+            Self {
+                leaves: left,
+                depth: self.depth + 1,
+            },
+            Self {
+                leaves: right,
+                depth: self.depth + 1,
+            },
+        )
+    }
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct NaiveSmt {
+    leaves: Vec<(HashValue, HashValue)>,
+    cache: Cache,
+}
+
+impl NaiveSmt {
+    pub fn new<V: CryptoHash>(leaves: &[(HashValue, &V)]) -> Self {
+        Self::default().update(leaves)
+    }
+
+    pub fn update<V: CryptoHash>(self, updates: &[(HashValue, &V)]) -> Self {
+        let mut leaves = self.leaves.into_iter().collect::<BTreeMap<_, _>>();
+        let mut new_leaves = updates
+            .iter()
+            .map(|(address, value)| (*address, value.hash()))
+            .collect::<BTreeMap<_, _>>();
+        leaves.append(&mut new_leaves);
+
+        Self {
+            leaves: leaves.into_iter().collect::<Vec<_>>(),
+            cache: Cache::new(),
+        }
+    }
+
+    pub fn get_proof<V: CryptoHash>(&mut self, key: &HashValue) -> SparseMerkleProof<V> {
+        let root = NaiveSubTree {
+            leaves: &self.leaves,
+            depth: 0,
+        };
+
+        let (leaf, siblings) = root.get_proof(key, &mut self.cache);
+        SparseMerkleProof::new(leaf, siblings)
+    }
+
+    pub fn get_root_hash(&mut self) -> HashValue {
+        let root = NaiveSubTree {
+            leaves: &self.leaves,
+            depth: 0,
+        };
+
+        root.get_hash(&mut self.cache)
+    }
+}

--- a/storage/scratchpad/src/sparse_merkle/utils.rs
+++ b/storage/scratchpad/src/sparse_merkle/utils.rs
@@ -1,0 +1,31 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use diem_crypto::HashValue;
+
+/// Swap template-type values if 'cond'=true - useful to determine left/right parameters.
+pub(crate) fn swap_if<T>(first: T, second: T, cond: bool) -> (T, T) {
+    if cond {
+        (second, first)
+    } else {
+        (first, second)
+    }
+}
+
+/// Return the index of the first bit that is 1 at the given depth when updates are
+/// lexicographically sorted.
+pub(crate) fn partition<T>(updates: &[(HashValue, T)], depth: usize) -> usize {
+    // Binary search for the cut-off point where the bit at this depth turns from 0 to 1.
+    // TODO: with stable partition_point: updates.partition_point(|&u| !u.0.bit(depth));
+    let (mut i, mut j) = (0, updates.len());
+    // Find the first index that starts with bit 1.
+    while i < j {
+        let mid = i + (j - i) / 2;
+        if updates[mid].0.bit(depth) {
+            j = mid;
+        } else {
+            i = mid + 1;
+        }
+    }
+    i
+}


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(This is on top of https://github.com/diem/diem/pull/8386, including its two commits before it got landed.)



Based on the NaiveSmt newly introduced, benchmark the updating time in these three cases: 1. inserting to an empty SMT; 2. inserting to an SMT with a committed base (root is "unknown" hence all information about the base tree must be known through the proof reader; 3. updating an SMT with some in mem nodes.

The `NaiveSmt` is under the feature "bench", and when running the bench "--features bench" needs to be in the command line, which is not ideal. Probably `NaiveSmt` needs to be split into its own crate.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
Y

## Test Plan

benchmark updated

 cargo bench -p scratchpad --features bench


```
    Finished bench [optimized + debuginfo] target(s) in 9.68s
     Running target/release/deps/scratchpad-7c837bd6e47fcdb2

running 18 tests
test sparse_merkle::sparse_merkle_test::test_batch_update_construct_subtree_from_proofs ... ignored
test sparse_merkle::sparse_merkle_test::test_construct_subtree_at_bottom_found_empty_node ... ignored
test sparse_merkle::sparse_merkle_test::test_construct_subtree_at_bottom_found_internal_node ... ignored
test sparse_merkle::sparse_merkle_test::test_construct_subtree_at_bottom_found_leaf_node ... ignored
test sparse_merkle::sparse_merkle_test::test_construct_subtree_at_bottom_found_subtree_node ... ignored
test sparse_merkle::sparse_merkle_test::test_construct_subtree_panic ... ignored
test sparse_merkle::sparse_merkle_test::test_construct_subtree_three_siblings ... ignored
test sparse_merkle::sparse_merkle_test::test_construct_subtree_with_new_leaf_create_extension ... ignored
test sparse_merkle::sparse_merkle_test::test_construct_subtree_with_new_leaf_override_existing_leaf ... ignored
test sparse_merkle::sparse_merkle_test::test_construct_subtree_zero_siblings ... ignored
test sparse_merkle::sparse_merkle_test::test_drop ... ignored
test sparse_merkle::sparse_merkle_test::test_new_empty ... ignored
test sparse_merkle::sparse_merkle_test::test_new_subtree ... ignored
test sparse_merkle::sparse_merkle_test::test_read_partial_tree_from_storage ... ignored
test sparse_merkle::sparse_merkle_test::test_update ... ignored
test sparse_merkle::sparse_merkle_test::test_update_256_siblings_in_proof ... ignored
test sparse_merkle::sparse_merkle_test::test_update_consistency ... ignored
test sparse_merkle::sparse_merkle_test::test_update_consistency_batches ... ignored

test result: ok. 0 passed; 0 failed; 18 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running target/release/deps/sparse_merkle-55c0c17a2ae2a8fb
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

insert to empty/serial_update/100
                        time:   [13.527 ms 14.292 ms 15.105 ms]
                        thrpt:  [6.6204 Kelem/s 6.9967 Kelem/s 7.3928 Kelem/s]
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe
Benchmarking insert to empty/batches_update/100: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.7s, enable flat sampling, or reduce sample count to 50.
insert to empty/batches_update/100
                        time:   [1.3015 ms 1.3039 ms 1.3064 ms]
                        thrpt:  [76.549 Kelem/s 76.695 Kelem/s 76.832 Kelem/s]
Found 13 outliers among 100 measurements (13.00%)
  6 (6.00%) high mild
  7 (7.00%) high severe
insert to empty/batch_update/100
                        time:   [714.19 us 717.26 us 720.35 us]
                        thrpt:  [138.82 Kelem/s 139.42 Kelem/s 140.02 Kelem/s]
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe
Benchmarking insert to empty/serial_update/1000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 14.9s, or reduce sample count to 30.
insert to empty/serial_update/1000
                        time:   [142.65 ms 143.26 ms 143.89 ms]
                        thrpt:  [6.9500 Kelem/s 6.9802 Kelem/s 7.0103 Kelem/s]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
insert to empty/batches_update/1000
                        time:   [16.868 ms 16.891 ms 16.918 ms]
                        thrpt:  [59.108 Kelem/s 59.203 Kelem/s 59.286 Kelem/s]
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) high mild
  7 (7.00%) high severe
insert to empty/batch_update/1000
                        time:   [2.6954 ms 2.7105 ms 2.7255 ms]
                        thrpt:  [366.91 Kelem/s 368.94 Kelem/s 371.00 Kelem/s]
Benchmarking insert to empty/serial_update/10000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 142.0s, or reduce sample count to 10.
insert to empty/serial_update/10000
                        time:   [1.4500 s 1.4596 s 1.4698 s]
                        thrpt:  [6.8036 Kelem/s 6.8513 Kelem/s 6.8967 Kelem/s]
Found 10 outliers among 100 measurements (10.00%)
  10 (10.00%) high mild
Benchmarking insert to empty/batches_update/10000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 21.1s, or reduce sample count to 20.
insert to empty/batches_update/10000
                        time:   [208.66 ms 208.80 ms 208.95 ms]
                        thrpt:  [47.858 Kelem/s 47.893 Kelem/s 47.926 Kelem/s]
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
insert to empty/batch_update/10000
                        time:   [16.936 ms 17.012 ms 17.087 ms]
                        thrpt:  [585.24 Kelem/s 587.82 Kelem/s 590.45 Kelem/s]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) low mild
  1 (1.00%) high mild

insert to committed base/serial_update/100
                        time:   [15.525 ms 15.672 ms 15.823 ms]
                        thrpt:  [6.3200 Kelem/s 6.3808 Kelem/s 6.4411 Kelem/s]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
insert to committed base/batches_update/100
                        time:   [5.1969 ms 5.2011 ms 5.2058 ms]
                        thrpt:  [19.209 Kelem/s 19.227 Kelem/s 19.242 Kelem/s]
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
insert to committed base/batch_update/100
                        time:   [2.3438 ms 2.3577 ms 2.3724 ms]
                        thrpt:  [42.151 Kelem/s 42.414 Kelem/s 42.665 Kelem/s]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
Benchmarking insert to committed base/serial_update/1000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 16.5s, or reduce sample count to 30.
insert to committed base/serial_update/1000
                        time:   [160.16 ms 161.07 ms 161.99 ms]
                        thrpt:  [6.1732 Kelem/s 6.2084 Kelem/s 6.2438 Kelem/s]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
insert to committed base/batches_update/1000
                        time:   [48.654 ms 48.798 ms 48.984 ms]
                        thrpt:  [20.415 Kelem/s 20.493 Kelem/s 20.553 Kelem/s]
Found 14 outliers among 100 measurements (14.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
  10 (10.00%) high severe
insert to committed base/batch_update/1000
                        time:   [10.939 ms 10.994 ms 11.051 ms]
                        thrpt:  [90.489 Kelem/s 90.959 Kelem/s 91.413 Kelem/s]
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high mild
Benchmarking insert to committed base/serial_update/10000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 157.4s, or reduce sample count to 10.
insert to committed base/serial_update/10000
                        time:   [1.6184 s 1.6249 s 1.6319 s]
                        thrpt:  [6.1280 Kelem/s 6.1541 Kelem/s 6.1790 Kelem/s]
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) low mild
  10 (10.00%) high mild
  1 (1.00%) high severe
Benchmarking insert to committed base/batches_update/10000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 43.6s, or reduce sample count to 10.
Benchmarking insert to committed base/batches_update/10000: Collecting 100 samples in estimated 43.649 s (100 iterations                                                                                                                        insert to committed base/batches_update/10000
                        time:   [432.45 ms 432.68 ms 432.92 ms]
                        thrpt:  [23.099 Kelem/s 23.112 Kelem/s 23.124 Kelem/s]
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
Benchmarking insert to committed base/batch_update/10000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.4s, or reduce sample count to 60.
insert to committed base/batch_update/10000
                        time:   [73.519 ms 73.856 ms 74.205 ms]
                        thrpt:  [134.76 Kelem/s 135.40 Kelem/s 136.02 Kelem/s]
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

insert to uncommitted base/serial_update/100
                        time:   [16.507 ms 16.651 ms 16.791 ms]
                        thrpt:  [5.9557 Kelem/s 6.0057 Kelem/s 6.0581 Kelem/s]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low mild
Benchmarking insert to uncommitted base/batches_update/100: Collecting 100 samples in estimated 5.2687 s (1000 iteration                                                                                                                        insert to uncommitted base/batches_update/100
                        time:   [5.2638 ms 5.2699 ms 5.2765 ms]
                        thrpt:  [18.952 Kelem/s 18.976 Kelem/s 18.998 Kelem/s]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
Benchmarking insert to uncommitted base/batch_update/100: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.7s, enable flat sampling, or reduce sample count to 50.
insert to uncommitted base/batch_update/100
                        time:   [1.5108 ms 1.5228 ms 1.5348 ms]
                        thrpt:  [65.155 Kelem/s 65.668 Kelem/s 66.190 Kelem/s]
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
Benchmarking insert to uncommitted base/serial_update/1000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 16.3s, or reduce sample count to 30.
Benchmarking insert to uncommitted base/serial_update/1000: Collecting 100 samples in estimated 16.289 s (100 iterations                                                                                                                        insert to uncommitted base/serial_update/1000
                        time:   [159.49 ms 160.18 ms 160.86 ms]
                        thrpt:  [6.2166 Kelem/s 6.2431 Kelem/s 6.2701 Kelem/s]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
Benchmarking insert to uncommitted base/batches_update/1000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.0s, or reduce sample count to 90.
Benchmarking insert to uncommitted base/batches_update/1000: Collecting 100 samples in estimated 5.0392 s (100 iteration                                                                                                                        insert to uncommitted base/batches_update/1000
                        time:   [50.327 ms 50.364 ms 50.400 ms]
                        thrpt:  [19.841 Kelem/s 19.855 Kelem/s 19.870 Kelem/s]
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) low severe
  6 (6.00%) low mild
  3 (3.00%) high mild
insert to uncommitted base/batch_update/1000
                        time:   [7.7170 ms 7.7643 ms 7.8120 ms]
                        thrpt:  [128.01 Kelem/s 128.79 Kelem/s 129.58 Kelem/s]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
Benchmarking insert to uncommitted base/serial_update/10000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 166.1s, or reduce sample count to 10.
Benchmarking insert to uncommitted base/serial_update/10000: Collecting 100 samples in estimated 166.09 s (100 iteration                                                                                                                        insert to uncommitted base/serial_update/10000
                        time:   [1.5330 s 1.5563 s 1.5776 s]
                        thrpt:  [6.3387 Kelem/s 6.4257 Kelem/s 6.5234 Kelem/s]
Found 16 outliers among 100 measurements (16.00%)
  13 (13.00%) low severe
  2 (2.00%) low mild
  1 (1.00%) high mild
Benchmarking insert to uncommitted base/batches_update/10000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 44.5s, or reduce sample count to 10.
Benchmarking insert to uncommitted base/batches_update/10000: Collecting 100 samples in estimated 44.509 s (100 iteratio                                                                                                                        insert to uncommitted base/batches_update/10000
                        time:   [440.94 ms 441.28 ms 441.63 ms]
                        thrpt:  [22.643 Kelem/s 22.661 Kelem/s 22.679 Kelem/s]
Benchmarking insert to uncommitted base/batch_update/10000: Collecting 100 samples in estimated 9.1737 s (200 iterations                                                                                                                        insert to uncommitted base/batch_update/10000
                        time:   [45.539 ms 45.720 ms 45.902 ms]
                        thrpt:  [217.85 Kelem/s 218.72 Kelem/s 219.59 Kelem/s]
```

## Related PRs
https://github.com/diem/diem/pull/8386