### PR TITLE
[bytecode-verifier] bound check for self_module_handle_idx

### DIFF
--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/bounds_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/bounds_tests.rs
@@ -6,7 +6,8 @@ use invalid_mutations::bounds::{
     OutOfBoundsMutation,
 };
 use move_binary_format::{
-    check_bounds::BoundsChecker, file_format::*, proptest_types::CompiledModuleStrategyGen,
+    check_bounds::BoundsChecker, file_format::*, file_format_common,
+    proptest_types::CompiledModuleStrategyGen,
 };
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, vm_status::StatusCode,
@@ -16,6 +17,22 @@ use proptest::{collection::vec, prelude::*};
 #[test]
 fn empty_module_no_errors() {
     basic_test_module().freeze().unwrap();
+}
+
+#[test]
+fn invalid_default_module() {
+    let m = CompiledModuleMut {
+        version: file_format_common::VERSION_MAX,
+        ..Default::default()
+    };
+    m.freeze().unwrap_err();
+}
+
+#[test]
+fn invalid_self_module_handle_index() {
+    let mut m = basic_test_module();
+    m.self_module_handle_idx = ModuleHandleIndex(12);
+    m.freeze().unwrap_err();
 }
 
 #[test]

--- a/language/move-binary-format/src/check_bounds.rs
+++ b/language/move-binary-format/src/check_bounds.rs
@@ -74,12 +74,19 @@ impl<'a> BoundsChecker<'a> {
         {
             bounds_check.check_function_def(function_def_idx, function_def)?
         }
-        Ok(())
+        bounds_check.check_self_module_handle()
     }
 
     fn check_module_handle(&self, module_handle: &ModuleHandle) -> PartialVMResult<()> {
         check_bounds_impl(&self.module.address_identifiers, module_handle.address)?;
         check_bounds_impl(&self.module.identifiers, module_handle.name)
+    }
+
+    fn check_self_module_handle(&self) -> PartialVMResult<()> {
+        check_bounds_impl(
+            &self.module.module_handles,
+            self.module.self_module_handle_idx,
+        )
     }
 
     fn check_struct_handle(&self, struct_handle: &StructHandle) -> PartialVMResult<()> {


### PR DESCRIPTION
The `self_module_handle_idx` in not bound checked by the bytecode verifier. This PR (the first commit) fixes that.

This issue was originally reported in https://community.diem.com/t/is-this-a-vulnerability-to-move-vm/3571 and a repro example can be found in https://github.com/suirui17/input_samples.

Before the fix, the module deserializes fine and will trigger an out-of-bound access when `self_module_handle_idx` is used to dereference the handle. After the fix, the module no longer deserializes. To verify that, save the example in some test file `test.mv` and run `move-cli view test.mv`. Expect an error saying that the module does not deserialize.

While fixing the issue, we also found that the proptest hardcoded `self_module_handle_idx` to always be zero in the valid module generation strategy, which is not the invariant as of now. So we relaxed the restriction and now `self_module_handle_idx` can take any value in the range of `0..length_of_module_handles`.

## Motivation

Bug fix

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Save the [example](https://github.com/suirui17/input_samples) in some test file `test.mv` and run `move-cli view test.mv`. Expect deserialization failure.

