### PR TITLE
[move-prover] Using immutable collections for SetDomain and MapDomain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,6 +436,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "bitvec"
 version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,6 +593,7 @@ dependencies = [
  "codespan-reporting",
  "datatest-stable",
  "diem-workspace-hack",
+ "im",
  "ir-to-bytecode",
  "itertools 0.10.0",
  "log",
@@ -2506,6 +2516,7 @@ dependencies = [
  "prost",
  "quote 0.6.13",
  "rand 0.8.3",
+ "rand_core 0.5.1",
  "regex",
  "regex-syntax",
  "reqwest",
@@ -3773,6 +3784,20 @@ dependencies = [
  "thread_local",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "im"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "111c1983f3c5bb72732df25cddacee9b546d08325fb584b5ebd38148be7b0246"
+dependencies = [
+ "bitmaps",
+ "rand_core 0.5.1",
+ "rand_xoshiro",
+ "sized-chunks",
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -5876,6 +5901,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004"
+dependencies = [
+ "rand_core 0.5.1",
+]
+
+[[package]]
 name = "rayon"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6862,6 +6896,16 @@ dependencies = [
  "chrono",
  "log",
  "termcolor",
+]
+
+[[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps",
+ "typenum",
 ]
 
 [[package]]

--- a/common/workspace-hack/Cargo.toml
+++ b/common/workspace-hack/Cargo.toml
@@ -45,6 +45,7 @@ petgraph = { version = "0.5.1", features = ["default", "graphmap", "matrix_graph
 plotters = { version = "0.3.0", default-features = false, features = ["area_series", "evcxr", "histogram", "line_series", "plotters-svg", "svg_backend"] }
 prost = { version = "0.7.0", features = ["default", "prost-derive", "std"] }
 rand = { version = "0.8.3", features = ["alloc", "default", "getrandom", "libc", "rand_chacha", "rand_hc", "small_rng", "std", "std_rng"] }
+rand_core = { version = "0.5.1", default-features = false, features = ["alloc", "getrandom", "std"] }
 regex = { version = "1.4.3", features = ["aho-corasick", "default", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 regex-syntax = { version = "0.6.23", features = ["default", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 reqwest = { version = "0.11.2", features = ["__tls", "blocking", "default", "default-tls", "hyper-tls", "json", "native-tls", "native-tls-crate", "serde_json", "stream", "tokio-native-tls"] }
@@ -99,6 +100,7 @@ proc-macro2 = { version = "0.4.30", features = ["default", "proc-macro"] }
 prost = { version = "0.7.0", features = ["default", "prost-derive", "std"] }
 quote = { version = "0.6.13", features = ["default", "proc-macro"] }
 rand = { version = "0.8.3", features = ["alloc", "default", "getrandom", "libc", "rand_chacha", "rand_hc", "small_rng", "std", "std_rng"] }
+rand_core = { version = "0.5.1", default-features = false, features = ["alloc", "getrandom", "std"] }
 regex = { version = "1.4.3", features = ["aho-corasick", "default", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 regex-syntax = { version = "0.6.23", features = ["default", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 reqwest = { version = "0.11.2", features = ["__tls", "blocking", "default", "default-tls", "hyper-tls", "json", "native-tls", "native-tls-crate", "serde_json", "stream", "tokio-native-tls"] }
@@ -152,6 +154,7 @@ petgraph = { version = "0.5.1", features = ["default", "graphmap", "matrix_graph
 plotters = { version = "0.3.0", default-features = false, features = ["area_series", "evcxr", "histogram", "line_series", "plotters-svg", "svg_backend"] }
 prost = { version = "0.7.0", features = ["default", "prost-derive", "std"] }
 rand = { version = "0.8.3", features = ["alloc", "default", "getrandom", "libc", "rand_chacha", "rand_hc", "small_rng", "std", "std_rng"] }
+rand_core = { version = "0.5.1", default-features = false, features = ["alloc", "getrandom", "std"] }
 regex = { version = "1.4.3", features = ["aho-corasick", "default", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 regex-syntax = { version = "0.6.23", features = ["default", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 reqwest = { version = "0.11.2", features = ["__tls", "blocking", "default", "default-tls", "hyper-tls", "json", "native-tls", "native-tls-crate", "serde_json", "stream", "tokio-native-tls"] }
@@ -206,6 +209,7 @@ proc-macro2 = { version = "0.4.30", features = ["default", "proc-macro"] }
 prost = { version = "0.7.0", features = ["default", "prost-derive", "std"] }
 quote = { version = "0.6.13", features = ["default", "proc-macro"] }
 rand = { version = "0.8.3", features = ["alloc", "default", "getrandom", "libc", "rand_chacha", "rand_hc", "small_rng", "std", "std_rng"] }
+rand_core = { version = "0.5.1", default-features = false, features = ["alloc", "getrandom", "std"] }
 regex = { version = "1.4.3", features = ["aho-corasick", "default", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 regex-syntax = { version = "0.6.23", features = ["default", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 reqwest = { version = "0.11.2", features = ["__tls", "blocking", "default", "default-tls", "hyper-tls", "json", "native-tls", "native-tls-crate", "serde_json", "stream", "tokio-native-tls"] }

--- a/language/move-model/src/ast.rs
+++ b/language/move-model/src/ast.rs
@@ -327,7 +327,7 @@ pub struct GlobalInvariant {
 /// A type alias for temporaries. Those are locals used in bytecode.
 pub type TempIndex = usize;
 
-/// The type of expressions.
+/// The type of expression data.
 ///
 /// Expression layout follows the following design principles:
 ///
@@ -337,8 +337,6 @@ pub type TempIndex = usize;
 /// - Each expression has a unique node id assigned. This id allows to build attribute tables
 ///   for additional information, like expression type and source location. The id is globally
 ///   unique.
-/// - Sub-expressions are reference counted. This makes cloning of expressions on a shallow
-///   level cheaper which is important for the efficiency of expression rewriting.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ExpData {
     /// Represents an invalid expression. This is used as a stub for algorithms which

--- a/language/move-prover/bytecode/Cargo.toml
+++ b/language/move-prover/bytecode/Cargo.toml
@@ -21,6 +21,7 @@ move-core-types = { path = "../../move-core/types" }
 codespan = "0.8.0"
 codespan-reporting = { version = "0.8.0", features = ["serde", "serialization"] }
 num = "0.4.0"
+im = "15.0.0"
 itertools = "0.10.0"
 log = "0.4.14"
 serde = { version = "1.0.124", features = ["derive"] }

--- a/language/move-prover/bytecode/src/clean_and_optimize.rs
+++ b/language/move-prover/bytecode/src/clean_and_optimize.rs
@@ -4,7 +4,7 @@
 // Final phase of cleanup and optimization.
 
 use crate::{
-    dataflow_analysis::{AbstractDomain, DataflowAnalysis, JoinResult, TransferFunctions},
+    dataflow_analysis::{DataflowAnalysis, TransferFunctions},
     function_target::{FunctionData, FunctionTarget},
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
     stackless_bytecode::{BorrowNode, Bytecode, Operation},
@@ -16,6 +16,7 @@ use move_model::{
     native::{EVENT_EMIT_EVENT, VECTOR_BORROW_MUT},
 };
 
+use crate::dataflow_domains::{AbstractDomain, JoinResult};
 use std::collections::BTreeSet;
 
 pub struct CleanAndOptimizeProcessor();

--- a/language/move-prover/bytecode/src/compositional_analysis.rs
+++ b/language/move-prover/bytecode/src/compositional_analysis.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    dataflow_analysis::{AbstractDomain, DataflowAnalysis},
+    dataflow_analysis::DataflowAnalysis,
+    dataflow_domains::AbstractDomain,
     function_target::FunctionTarget,
     function_target_pipeline::{FunctionTargetsHolder, FunctionVariant},
     stackless_control_flow_graph::StacklessControlFlowGraph,

--- a/language/move-prover/bytecode/src/dataflow_analysis.rs
+++ b/language/move-prover/bytecode/src/dataflow_analysis.rs
@@ -5,154 +5,15 @@
 //! framework for stackless bytecode.
 
 use crate::{
+    dataflow_domains::{AbstractDomain, JoinResult},
     stackless_bytecode::Bytecode,
     stackless_control_flow_graph::{BlockId, StacklessControlFlowGraph},
 };
 use move_binary_format::file_format::CodeOffset;
 use std::{
-    collections::{BTreeMap, BTreeSet, VecDeque},
+    collections::{BTreeMap, VecDeque},
     fmt::Debug,
-    ops::{Deref, DerefMut},
 };
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum JoinResult {
-    Unchanged,
-    Changed,
-}
-
-impl JoinResult {
-    pub fn combine(self, other: JoinResult) -> JoinResult {
-        use JoinResult::*;
-        match (self, other) {
-            (Unchanged, Unchanged) => Unchanged,
-            _ => Changed,
-        }
-    }
-}
-
-pub trait AbstractDomain: Clone + Sized + Eq + PartialOrd + PartialEq + Debug {
-    fn join(&mut self, other: &Self) -> JoinResult;
-}
-
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct SetDomain<Elem: Clone + Ord + Sized>(pub BTreeSet<Elem>);
-
-impl<E: Clone + Ord + Sized> Default for SetDomain<E> {
-    fn default() -> Self {
-        Self(BTreeSet::new())
-    }
-}
-
-impl<E: Clone + Ord + Sized> Deref for SetDomain<E> {
-    type Target = BTreeSet<E>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<E: Clone + Ord + Sized> DerefMut for SetDomain<E> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl<E: Clone + Ord + Sized + Debug> AbstractDomain for SetDomain<E> {
-    fn join(&mut self, other: &Self) -> JoinResult {
-        if self == other {
-            JoinResult::Unchanged
-        } else {
-            for e in other.iter() {
-                self.insert(e.clone());
-            }
-            JoinResult::Changed
-        }
-    }
-}
-
-impl<E: Clone + Ord> std::iter::FromIterator<E> for SetDomain<E> {
-    fn from_iter<I: IntoIterator<Item = E>>(iter: I) -> Self {
-        let mut s = SetDomain::default();
-        for e in iter {
-            s.insert(e);
-        }
-        s
-    }
-}
-
-impl<E: Clone + Ord> std::iter::IntoIterator for SetDomain<E> {
-    type Item = E;
-    type IntoIter = std::collections::btree_set::IntoIter<E>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
-    }
-}
-
-impl<E: Clone + Ord + Sized> SetDomain<E> {
-    pub fn singleton(e: E) -> Self {
-        let mut s = SetDomain::default();
-        s.insert(e);
-        s
-    }
-
-    pub fn of_set(s: BTreeSet<E>) -> Self {
-        Self(s)
-    }
-}
-
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct MapDomain<K: Ord, V: AbstractDomain>(pub BTreeMap<K, V>);
-
-impl<K: Ord, V: AbstractDomain> MapDomain<K, V> {
-    /// join `v` with self[k] if `k` is bound, insert `v` otherwise
-    pub fn insert_join(&mut self, k: K, v: V) {
-        self.0
-            .entry(k)
-            .and_modify(|old_v| {
-                old_v.join(&v);
-            })
-            .or_insert(v);
-    }
-}
-
-impl<K: Ord, V: AbstractDomain> Default for MapDomain<K, V> {
-    fn default() -> Self {
-        Self(BTreeMap::new())
-    }
-}
-
-impl<K: Clone + Sized + Eq + Ord + Debug, V: AbstractDomain> AbstractDomain for MapDomain<K, V> {
-    fn join(&mut self, other: &Self) -> JoinResult {
-        if self == other {
-            JoinResult::Unchanged
-        } else {
-            for (k, v1) in other.iter() {
-                self.entry(k.clone())
-                    .and_modify(|v2| {
-                        v2.join(&v1);
-                    })
-                    .or_insert_with(|| v1.clone());
-            }
-            JoinResult::Changed
-        }
-    }
-}
-
-impl<K: Clone + Sized + Eq + Ord, V: AbstractDomain> Deref for MapDomain<K, V> {
-    type Target = BTreeMap<K, V>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<K: Clone + Sized + Eq + Ord, V: AbstractDomain> DerefMut for MapDomain<K, V> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct BlockState<State: Clone> {

--- a/language/move-prover/bytecode/src/dataflow_domains.rs
+++ b/language/move-prover/bytecode/src/dataflow_domains.rs
@@ -1,0 +1,285 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module defines traits and representations of domains used in dataflow analysis.
+
+use im::{ordmap, ordset, OrdMap, OrdSet};
+use itertools::Itertools;
+use std::{
+    borrow::Borrow,
+    collections::{BTreeMap, BTreeSet},
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+};
+
+// ================================================================================================
+// Abstract Domains
+
+/// Represents the abstract outcome of a join.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JoinResult {
+    /// The left operand subsumes the right operand: L union R == L.
+    Unchanged,
+    /// The left operand does not subsume the right one and was changed as part of the join.
+    Changed,
+}
+
+impl JoinResult {
+    /// Build the least upper bound of two join results, where `Unchanged` is bottom element of the
+    /// semilattice.
+    pub fn combine(self, other: JoinResult) -> JoinResult {
+        use JoinResult::*;
+        match (self, other) {
+            (Unchanged, Unchanged) => Unchanged,
+            _ => Changed,
+        }
+    }
+}
+
+/// A trait to be implemented by domains which support a join.
+pub trait AbstractDomain {
+    fn join(&mut self, other: &Self) -> JoinResult;
+}
+
+// ================================================================================================
+// Predefined Domain Types
+
+// As the underlying implementation of the below types we use the collections from the `im`(mutable)
+// crate (`im::OrdSet` and `im::OrdMap`), a representation which supports structure sharing.
+// This is important because in data flow analysis we often refine a set or map
+// value in each step of the analysis, e.g. adding a single element to a larger collection, while
+// the original collection still need to be available at the previous program point.
+
+// ------------------------------------------------------------------------------------------------
+// Set Type
+
+/// Implements a set domain.
+#[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
+pub struct SetDomain<E: Ord + Clone>(OrdSet<E>);
+
+impl<E: Ord + Clone> Default for SetDomain<E> {
+    fn default() -> Self {
+        Self(OrdSet::default())
+    }
+}
+
+impl<E: Ord + Clone> From<OrdSet<E>> for SetDomain<E> {
+    fn from(ord_set: OrdSet<E>) -> Self {
+        Self(ord_set)
+    }
+}
+
+impl<E: Ord + Clone> AsRef<OrdSet<E>> for SetDomain<E> {
+    fn as_ref(&self) -> &OrdSet<E> {
+        &self.0
+    }
+}
+
+impl<E: Ord + Clone> Borrow<OrdSet<E>> for SetDomain<E> {
+    fn borrow(&self) -> &OrdSet<E> {
+        self.as_ref()
+    }
+}
+
+impl<E: Ord + Clone> Deref for SetDomain<E> {
+    type Target = OrdSet<E>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<E: Ord + Clone> DerefMut for SetDomain<E> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<E: Ord + Clone + Debug> Debug for SetDomain<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
+
+impl<E: Ord + Clone> std::iter::FromIterator<E> for SetDomain<E> {
+    fn from_iter<I: IntoIterator<Item = E>>(iter: I) -> Self {
+        let mut s = SetDomain::default();
+        for e in iter {
+            s.insert(e);
+        }
+        s
+    }
+}
+
+impl<E: Ord + Clone> std::iter::IntoIterator for SetDomain<E> {
+    type Item = E;
+    type IntoIter = im::ordset::ConsumingIter<E>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<E: Ord + Clone> AbstractDomain for SetDomain<E> {
+    fn join(&mut self, other: &Self) -> JoinResult {
+        let mut change = JoinResult::Unchanged;
+        for e in other.iter() {
+            if self.insert(e.clone()).is_none() {
+                change = JoinResult::Changed;
+            }
+        }
+        change
+    }
+}
+
+impl<E: Ord + Clone> From<BTreeSet<E>> for SetDomain<E> {
+    fn from(s: BTreeSet<E>) -> Self {
+        s.into_iter().collect()
+    }
+}
+
+impl<E: Ord + Clone> SetDomain<E> {
+    pub fn singleton(e: E) -> Self {
+        ordset!(e).into()
+    }
+
+    /// Implements set difference, which is not following standard APIs for rust sets in OrdSet
+    pub fn difference<'a>(&'a self, other: &'a Self) -> impl Iterator<Item = &'a E> {
+        self.iter().filter(move |e| !other.contains(e))
+    }
+
+    /// Implements is_disjoint which is not available in OrdSet
+    pub fn is_disjoint(&self, other: &Self) -> bool {
+        self.iter().all(move |e| !other.contains(e))
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// Map Type
+
+#[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
+pub struct MapDomain<K: Ord, V: AbstractDomain>(OrdMap<K, V>);
+
+impl<K: Ord + Clone, V: AbstractDomain + Clone> Default for MapDomain<K, V> {
+    fn default() -> Self {
+        Self(OrdMap::default())
+    }
+}
+
+impl<K: Ord + Clone, V: AbstractDomain + Clone> From<OrdMap<K, V>> for MapDomain<K, V> {
+    fn from(ord_map: OrdMap<K, V>) -> Self {
+        Self(ord_map)
+    }
+}
+
+impl<K: Ord + Clone, V: AbstractDomain + Clone> AsRef<OrdMap<K, V>> for MapDomain<K, V> {
+    fn as_ref(&self) -> &OrdMap<K, V> {
+        &self.0
+    }
+}
+
+impl<K: Ord + Clone, V: AbstractDomain + Clone> Borrow<OrdMap<K, V>> for MapDomain<K, V> {
+    fn borrow(&self) -> &OrdMap<K, V> {
+        self.as_ref()
+    }
+}
+
+impl<K: Ord + Clone, V: AbstractDomain + Clone> Deref for MapDomain<K, V> {
+    type Target = OrdMap<K, V>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<K: Ord + Clone, V: AbstractDomain + Clone> DerefMut for MapDomain<K, V> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<K: Ord + Clone + Debug, V: AbstractDomain + Clone + Debug> Debug for MapDomain<K, V> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
+
+impl<K: Ord + Clone, V: AbstractDomain + Clone> std::iter::FromIterator<(K, V)>
+    for MapDomain<K, V>
+{
+    fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
+        let mut s = MapDomain::default();
+        for (k, v) in iter {
+            s.insert(k, v);
+        }
+        s
+    }
+}
+
+impl<K: Ord + Clone, V: AbstractDomain + Clone> std::iter::IntoIterator for MapDomain<K, V> {
+    type Item = (K, V);
+    type IntoIter = im::ordmap::ConsumingIter<(K, V)>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<K: Ord + Clone, V: AbstractDomain + Clone> AbstractDomain for MapDomain<K, V> {
+    fn join(&mut self, other: &Self) -> JoinResult {
+        let mut change = JoinResult::Unchanged;
+        for (k, v) in other.iter() {
+            change = change.combine(self.insert_join(k.clone(), v.clone()));
+        }
+        change
+    }
+}
+
+impl<K: Ord + Clone, V: AbstractDomain + Clone> From<BTreeMap<K, V>> for MapDomain<K, V> {
+    fn from(m: BTreeMap<K, V>) -> Self {
+        m.into_iter().collect()
+    }
+}
+
+impl<K: Ord + Clone, V: AbstractDomain + Clone> MapDomain<K, V> {
+    /// Construct a singleton map.
+    pub fn singleton(k: K, v: V) -> MapDomain<K, V> {
+        (ordmap! {k => v}).into()
+    }
+
+    /// Join `v` with self[k] if `k` is bound, insert `v` otherwise
+    pub fn insert_join(&mut self, k: K, v: V) -> JoinResult {
+        let mut change = JoinResult::Unchanged;
+        self.0
+            .entry(k)
+            .and_modify(|old_v| {
+                change = old_v.join(&v);
+            })
+            .or_insert_with(|| {
+                change = JoinResult::Changed;
+                v
+            });
+        change
+    }
+}
+
+impl<K: Ord + Clone, V: AbstractDomain + Clone + PartialEq> MapDomain<K, V> {
+    /// Updates the values in the range of the map using the given function. Notice
+    /// that with other kind of map representations we would use `iter_mut` for this,
+    /// but this is not available in OrdMap for obvious reasons (because entries are shared),
+    /// so we need to use this pattern here instead.
+    pub fn update_values(&mut self, mut f: impl FnMut(&mut V)) {
+        // Commpute the key-values which actually changed. If the change is small, we preserve
+        // structure sharing.
+        let new_values = self
+            .iter()
+            .filter_map(|(k, v)| {
+                let mut v_new = v.clone();
+                f(&mut v_new);
+                if v != &v_new {
+                    Some((k.clone(), v_new))
+                } else {
+                    None
+                }
+            })
+            .collect_vec();
+        self.extend(new_values.into_iter());
+    }
+}

--- a/language/move-prover/bytecode/src/global_invariant_instrumentation.rs
+++ b/language/move-prover/bytecode/src/global_invariant_instrumentation.rs
@@ -128,10 +128,10 @@ impl<'a> Instrumenter<'a> {
         let env = self.builder.global_env();
         let mut invariants = BTreeSet::new();
         let mut invariants_for_modified_memory = BTreeSet::new();
-        for mem in usage_analysis::get_used_memory_inst(&self.builder.get_target()) {
+        for mem in usage_analysis::get_used_memory_inst(&self.builder.get_target()).iter() {
             invariants.extend(env.get_global_invariants_for_memory(mem));
         }
-        for mem in usage_analysis::get_modified_memory_inst(&self.builder.get_target()) {
+        for mem in usage_analysis::get_modified_memory_inst(&self.builder.get_target()).iter() {
             invariants_for_modified_memory.extend(env.get_global_invariants_for_memory(mem));
         }
 

--- a/language/move-prover/bytecode/src/global_invariant_instrumentation_v2.rs
+++ b/language/move-prover/bytecode/src/global_invariant_instrumentation_v2.rs
@@ -166,12 +166,12 @@ impl<'a> Instrumenter<'a> {
         let mut invariants_for_modified_memory = BTreeSet::new();
         // get memory (list of structs) read or written by the function target, then find all invariants in loaded
         // modules that refer to that memory.
-        for mem in usage_analysis::get_used_memory_inst(&self.builder.get_target()) {
+        for mem in usage_analysis::get_used_memory_inst(&self.builder.get_target()).iter() {
             invariants_for_used_memory.extend(env.get_global_invariants_for_memory(mem));
         }
         // get memory (list of structs) written by function, find the invariants referring to that memory.
         // Also called "invariants updated by the function"
-        for mem in usage_analysis::get_modified_memory_inst(&self.builder.get_target()) {
+        for mem in usage_analysis::get_modified_memory_inst(&self.builder.get_target()).iter() {
             invariants_for_modified_memory.extend(env.get_global_invariants_for_memory(mem));
         }
         let module_env = &self.builder.fun_env.module_env;

--- a/language/move-prover/bytecode/src/lib.rs
+++ b/language/move-prover/bytecode/src/lib.rs
@@ -14,6 +14,7 @@ pub mod clean_and_optimize;
 pub mod compositional_analysis;
 pub mod data_invariant_instrumentation;
 pub mod dataflow_analysis;
+pub mod dataflow_domains;
 pub mod debug_instrumentation;
 pub mod eliminate_imm_refs;
 pub mod function_data_builder;

--- a/language/move-prover/bytecode/src/livevar_analysis.rs
+++ b/language/move-prover/bytecode/src/livevar_analysis.rs
@@ -5,7 +5,8 @@
 // computation of new Destroy instructions.
 
 use crate::{
-    dataflow_analysis::{AbstractDomain, DataflowAnalysis, JoinResult, TransferFunctions},
+    dataflow_analysis::{DataflowAnalysis, TransferFunctions},
+    dataflow_domains::{AbstractDomain, JoinResult},
     function_target::{FunctionData, FunctionTarget},
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
     stackless_bytecode::{AbortAction, AttrId, Bytecode, Label, Operation},

--- a/language/move-prover/bytecode/src/reaching_def_analysis.rs
+++ b/language/move-prover/bytecode/src/reaching_def_analysis.rs
@@ -7,7 +7,8 @@
 // in the code. The subsequent livevar_analysis takes care of removing those.
 
 use crate::{
-    dataflow_analysis::{AbstractDomain, DataflowAnalysis, JoinResult, TransferFunctions},
+    dataflow_analysis::{DataflowAnalysis, TransferFunctions},
+    dataflow_domains::{AbstractDomain, JoinResult},
     function_target::{FunctionData, FunctionTarget},
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
     stackless_bytecode::{AbortAction, BorrowNode, Bytecode, Operation},

--- a/language/move-prover/bytecode/src/read_write_set_analysis.rs
+++ b/language/move-prover/bytecode/src/read_write_set_analysis.rs
@@ -13,7 +13,8 @@ use crate::{
     access_path::{AbsAddr, AccessPath, Addr, FootprintDomain, Offset, Root},
     access_path_trie::AccessPathTrie,
     compositional_analysis::{CompositionalAnalysis, SummaryCache},
-    dataflow_analysis::{AbstractDomain, DataflowAnalysis, JoinResult, TransferFunctions},
+    dataflow_analysis::{DataflowAnalysis, TransferFunctions},
+    dataflow_domains::{AbstractDomain, JoinResult},
     function_target::{FunctionData, FunctionTarget},
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant},
     stackless_bytecode::{Bytecode, Constant, Operation},
@@ -98,7 +99,7 @@ impl ReadWriteSetState {
                 formal_i.is_formal(),
                 "Arity mistmatch between caller and callee"
             );
-            if let Some(node) = new_callee_accesses.0.remove(&formal_i) {
+            if let Some(node) = new_callee_accesses.remove(&formal_i) {
                 let formal_ap = AccessPath::new(formal_i, vec![]);
                 for v in formal_ap.prepend_addrs(actual_v).iter() {
                     match v {
@@ -126,7 +127,7 @@ impl ReadWriteSetState {
         // (4) bind return values in caller locals
         for (i, ret) in returns.iter().enumerate() {
             let retvar_i = Root::Return(i);
-            if let Some(node) = new_callee_locals.0.remove(&retvar_i) {
+            if let Some(node) = new_callee_locals.remove(&retvar_i) {
                 self.locals.bind_local_node(*ret, node, caller_fun_env)
             }
         }

--- a/language/move-prover/bytecode/src/spec_instrumentation.rs
+++ b/language/move-prover/bytecode/src/spec_instrumentation.rs
@@ -1072,7 +1072,7 @@ fn check_opaque_modifies_completeness(
     // a modifies clause. Otherwise we could introduce unsoundness.
     // TODO: we currently except Event::EventHandle from this, because this is treated as
     //   an immutable reference. We should find a better way how to deal with event handles.
-    for mem in usage_analysis::get_modified_memory_inst(&target) {
+    for mem in usage_analysis::get_modified_memory_inst(&target).iter() {
         if env.is_wellknown_event_handle_type(&Type::Struct(mem.module_id, mem.id, vec![])) {
             continue;
         }

--- a/language/move-prover/bytecode/src/usage_analysis.rs
+++ b/language/move-prover/bytecode/src/usage_analysis.rs
@@ -3,9 +3,8 @@
 
 use crate::{
     compositional_analysis::{CompositionalAnalysis, SummaryCache},
-    dataflow_analysis::{
-        AbstractDomain, DataflowAnalysis, JoinResult, SetDomain, TransferFunctions,
-    },
+    dataflow_analysis::{DataflowAnalysis, TransferFunctions},
+    dataflow_domains::{AbstractDomain, JoinResult, SetDomain},
     function_target::{FunctionData, FunctionTarget},
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant},
     stackless_bytecode::{Bytecode, Operation},
@@ -40,7 +39,7 @@ pub fn get_directly_modified_memory(target: &FunctionTarget) -> BTreeSet<Qualifi
 
 pub fn get_used_memory_inst<'env>(
     target: &'env FunctionTarget,
-) -> &'env BTreeSet<QualifiedInstId<StructId>> {
+) -> &'env SetDomain<QualifiedInstId<StructId>> {
     &target
         .get_annotations()
         .get::<UsageState>()
@@ -50,7 +49,7 @@ pub fn get_used_memory_inst<'env>(
 
 pub fn get_modified_memory_inst<'env>(
     target: &'env FunctionTarget,
-) -> &'env BTreeSet<QualifiedInstId<StructId>> {
+) -> &'env SetDomain<QualifiedInstId<StructId>> {
     &target
         .get_annotations()
         .get::<UsageState>()
@@ -60,7 +59,7 @@ pub fn get_modified_memory_inst<'env>(
 
 pub fn get_directly_modified_memory_inst<'env>(
     target: &'env FunctionTarget,
-) -> &'env BTreeSet<QualifiedInstId<StructId>> {
+) -> &'env SetDomain<QualifiedInstId<StructId>> {
     &target
         .get_annotations()
         .get::<UsageState>()
@@ -206,14 +205,12 @@ impl<'a> TransferFunctions for MemoryUsageAnalysis<'a> {
                         state.modified_memory.extend(
                             summary
                                 .modified_memory
-                                .0
                                 .iter()
                                 .map(|qid| qid.instantiate_ref(inst)),
                         );
                         state.used_memory.extend(
                             summary
                                 .used_memory
-                                .0
                                 .iter()
                                 .map(|qid| qid.instantiate_ref(inst)),
                         );

--- a/language/move-prover/bytecode/src/verification_analysis.rs
+++ b/language/move-prover/bytecode/src/verification_analysis.rs
@@ -4,6 +4,7 @@
 //! Analysis which computes an annotation for each function whether it is verified or inlined.
 
 use crate::{
+    dataflow_domains::SetDomain,
     function_target::{FunctionData, FunctionTarget},
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant},
     options::ProverOptions,
@@ -157,12 +158,12 @@ fn check_friend_relation(fun_env: &FunctionEnv<'_>) {
 
 /// Compute the set of resources which are used in invariants which are target of
 /// verification.
-fn get_target_invariant_memory(env: &GlobalEnv) -> BTreeSet<QualifiedInstId<StructId>> {
-    let mut target_resources = BTreeSet::new();
+fn get_target_invariant_memory(env: &GlobalEnv) -> SetDomain<QualifiedInstId<StructId>> {
+    let mut target_resources = SetDomain::default();
     for module_env in env.get_modules() {
         if module_env.is_target() {
             let module_id = module_env.get_id();
-            let mentioned_resources: BTreeSet<QualifiedInstId<StructId>> = env
+            let mentioned_resources: SetDomain<QualifiedInstId<StructId>> = env
                 .get_global_invariants_by_module(module_id)
                 .iter()
                 .flat_map(|id| env.get_global_invariant(*id).unwrap().mem_usage.clone())

--- a/language/move-prover/bytecode/src/verification_analysis_v2.rs
+++ b/language/move-prover/bytecode/src/verification_analysis_v2.rs
@@ -4,6 +4,7 @@
 //! Analysis which computes an annotation for each function whether
 
 use crate::{
+    dataflow_domains::SetDomain,
     function_target::{FunctionData, FunctionTarget},
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant},
     options::ProverOptions,
@@ -192,11 +193,13 @@ fn compute_funs_that_modify_inv(
     let mut funs_that_modify_some_inv: BTreeSet<QualifiedId<FunId>> = BTreeSet::new();
     for inv_id in target_invariants {
         // Collect the global state used by inv_id (this is computed in usage_analysis.rs)
-        let inv_mem_use = global_env
+        let inv_mem_use: SetDomain<_> = global_env
             .get_global_invariant(*inv_id)
             .unwrap()
             .mem_usage
-            .clone();
+            .iter()
+            .cloned()
+            .collect();
         // set of functions that modify state in inv_id that we are building
         let mut fun_id_set: BTreeSet<QualifiedId<FunId>> = BTreeSet::new();
         // Iterate over all functions in the module cluster

--- a/language/move-prover/tests/sources/functional/disable_inv.exp
+++ b/language/move-prover/tests/sources/functional/disable_inv.exp
@@ -1,24 +1,24 @@
 Move prover returns: exiting with boogie verification errors
 error: global memory invariant does not hold
 
-    ┌── tests/sources/functional/disable_inv.move:60:9 ───
+    ┌── tests/sources/functional/disable_inv.move:61:9 ───
     │
- 60 │         invariant [global] forall a: address where exists<R1>(a): exists<R2>(a);
+ 61 │         invariant [global] forall a: address where exists<R1>(a): exists<R2>(a);
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/disable_inv.move:11: f1_incorrect
-    =         s = <redacted>
     =     at tests/sources/functional/disable_inv.move:12: f1_incorrect
-    =     at tests/sources/functional/disable_inv.move:60
+    =         s = <redacted>
+    =     at tests/sources/functional/disable_inv.move:13: f1_incorrect
+    =     at tests/sources/functional/disable_inv.move:61
 
 error: global memory invariant does not hold
 
-    ┌── tests/sources/functional/disable_inv.move:60:9 ───
+    ┌── tests/sources/functional/disable_inv.move:61:9 ───
     │
- 60 │         invariant [global] forall a: address where exists<R1>(a): exists<R2>(a);
+ 61 │         invariant [global] forall a: address where exists<R1>(a): exists<R2>(a);
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/disable_inv.move:31: f3_incorrect
-    =         s = <redacted>
     =     at tests/sources/functional/disable_inv.move:32: f3_incorrect
-    =     at tests/sources/functional/disable_inv.move:60
+    =         s = <redacted>
+    =     at tests/sources/functional/disable_inv.move:33: f3_incorrect
+    =     at tests/sources/functional/disable_inv.move:61

--- a/language/move-prover/tests/sources/functional/disable_inv.inv_v2_exp
+++ b/language/move-prover/tests/sources/functional/disable_inv.inv_v2_exp
@@ -1,0 +1,31 @@
+Move prover returns: exiting with bytecode transformation errors
+error: Public or script functions must not be called when invariants are disabled in a transitive caller or there is a pragma delegate_invariants_to_caller
+
+    ┌── tests/sources/functional/disable_inv.move:12:5 ───
+    │
+ 12 │ ╭     public fun f1_incorrect(s: &signer) {
+ 13 │ │         move_to(s, R1 {});
+ 14 │ │         move_to(s, R2 {});
+ 15 │ │     }
+    │ ╰─────^
+    │
+
+error: Functions must not have a disable invariant pragma when invariants are disabled in a transitive caller or there is a pragma delegate_invariants_to_caller
+
+    ┌── tests/sources/functional/disable_inv.move:32:5 ───
+    │
+ 32 │ ╭     fun f3_incorrect(s: &signer) {
+ 33 │ │         move_to(s, R1 {});
+ 34 │ │     }
+    │ ╰─────^
+    │
+
+error: Functions must not have a disable invariant pragma when invariants are disabled in a transitive caller or there is a pragma delegate_invariants_to_caller
+
+    ┌── tests/sources/functional/disable_inv.move:47:5 ───
+    │
+ 47 │ ╭     fun f5_incorrect(s: &signer) {
+ 48 │ │         move_to(s, R2 {});
+ 49 │ │     }
+    │ ╰─────^
+    │

--- a/language/move-prover/tests/sources/functional/disable_inv.move
+++ b/language/move-prover/tests/sources/functional/disable_inv.move
@@ -1,3 +1,4 @@
+// separate_baseline: inv_v2
 module 0x1::DisableInv {
 
     struct R1 has key { }


### PR DESCRIPTION
This reimplements the collection types for DFA using base types from the [`im` crate](https://docs.rs/im/15.0.0/im/).

In DFA, we often have types like maps or sets which are copied and refined with each basic block. Traditional Rust collections are not well suited for this, because for each instruction we need to make a deep clone of the input domains. The `im` types are designed with structure sharing in mind. Clone is O(1), and subsequent write leads only to a delta with a reference to the original value.

The API of those collections is slightly different which lead to some adoptions in our code. The PR also attempts to complete the wrapping traits for SetDomain and MapDomain such that they (mostly) behave as the underlying representation.

## Motivation

Make the DFA framework more sensible.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests.

This PR also fixes a test failure which exists in main and breaks the new `disable_inv.move` test for invariants v2. This test needs it's separate baseline, since the other features produce different errors.

## Related PRs

NA
