### PR TITLE
[stackless-vm] Expression evaluator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,6 +620,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytecode",
+ "codespan-reporting",
  "datatest-stable",
  "diem-crypto",
  "diem-workspace-hack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,6 +624,7 @@ dependencies = [
  "datatest-stable",
  "diem-crypto",
  "diem-workspace-hack",
+ "itertools 0.10.0",
  "move-binary-format",
  "move-core-types",
  "move-model",

--- a/language/diem-tools/e2e-tests-replay/src/main.rs
+++ b/language/diem-tools/e2e-tests-replay/src/main.rs
@@ -34,6 +34,10 @@ struct ReplayArgs {
     #[structopt(short = "x", long = "xrun")]
     xrun: bool,
 
+    /// Cross check the stackless VM against the Move VM without invoking the expression checker
+    #[structopt(short = "X", long = "xrun-shallow", conflicts_with = "xrun")]
+    xrun_shallow: bool,
+
     /// Verbose mode
     #[structopt(short = "v", long = "verbose")]
     verbose: Option<u64>,
@@ -77,11 +81,15 @@ pub fn main() -> Result<()> {
         warning: args.warning.map_or(false, |level| level > 0),
     };
 
-    let settings = if flags.verbose_vm {
+    let mut settings = if flags.verbose_vm {
         InterpreterSettings::verbose_default()
     } else {
         InterpreterSettings::default()
     };
+    if args.xrun_shallow {
+        settings.no_expr_check = true;
+    }
+
     let env = run_model_builder(&diem_stdlib_files(), &[])?;
     let interpreter = StacklessBytecodeInterpreter::new(&env, None, settings);
     for trace in args.trace_files {

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/destroy.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/destroy.exp
@@ -1,0 +1,2 @@
+Running Move unit tests
+Test result: OK. Total tests: 0; passed: 0; failed: 0

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/destroy.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/destroy.move
@@ -1,0 +1,19 @@
+module 0x2::A {
+    struct S {
+        f1: bool,
+        f2: u64,
+    }
+
+    fun foo(s: &S): u64 {
+        s.f2
+    }
+
+    // TODO (mengxu) there is a bug that tries to destroy a value instead of reference
+    // #[test]
+    public fun destroy(): S {
+        let s = S { f1: true, f2: 42 };
+        let p = &s;
+        let _ = p;
+        s
+    }
+}

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/function_call.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/function_call.move
@@ -17,20 +17,20 @@ module 0x2::A {
 
     #[test]
     public fun call_val(): u64 {
-        let a = 0;
+        let a = 0u64;
         handle_val(a)
     }
 
     #[test]
     public fun call_imm_ref(): u64 {
-        let a = 0;
+        let a = 0u64;
         let b = &a;
         handle_imm_ref(b)
     }
 
     #[test]
     public fun call_mut_ref(): u64 {
-        let a = 0;
+        let a = 0u64;
         let b = &mut a;
         handle_mut_ref(b);
         a
@@ -38,7 +38,7 @@ module 0x2::A {
 
     #[test]
     public fun call_return_mut_ref(): u64 {
-        let a = 0;
+        let a = 0u64;
         let b = &mut a;
         let c = return_mut_ref(b);
         handle_mut_ref(c);

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/arithmetics.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/arithmetics.exp
@@ -1,0 +1,35 @@
+Running Move unit tests
+[ FAIL    ] 0x2::A::check_arithmetics_div0
+[ FAIL    ] 0x2::A::check_arithmetics_mod0
+[ PASS    ] 0x2::A::check_arithmetics_ok
+
+Test failures:
+
+Failures in 0x2::A:
+
+┌── check_arithmetics_div0 ──────
+│ error: failed to evaluate expression
+│
+│     ┌── tests/concrete_check/property/arithmetics.move:17:20 ───
+│     │
+│  17 │             assert 5 / 0 == 1;
+│     │                    ^^^^^^^^^^
+│     │
+│
+│
+└──────────────────
+
+
+┌── check_arithmetics_mod0 ──────
+│ error: failed to evaluate expression
+│
+│     ┌── tests/concrete_check/property/arithmetics.move:24:20 ───
+│     │
+│  24 │             assert 5 % 0 == 1;
+│     │                    ^^^^^^^^^^
+│     │
+│
+│
+└──────────────────
+
+Test result: FAILED. Total tests: 3; passed: 1; failed: 2

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/arithmetics.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/arithmetics.move
@@ -1,0 +1,27 @@
+module 0x2::A {
+    #[test]
+    public fun check_arithmetics_ok() {
+        spec {
+            // there is no overflow/underflow in spec expressions
+            assert 255u8 + 1u64 == 256u128;
+            assert 1u8 - 2u64 < 0;
+            assert 255u8 * 255u8 == 255u128 * 255u128;
+            assert 5 / 2 == 2;
+            assert 5 % 2 == 1;
+        };
+    }
+
+    #[test]
+    public fun check_arithmetics_div0() {
+        spec {
+            assert 5 / 0 == 1;
+        };
+    }
+
+    #[test]
+    public fun check_arithmetics_mod0() {
+        spec {
+            assert 5 % 0 == 1;
+        };
+    }
+}

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/basics.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/basics.exp
@@ -1,0 +1,36 @@
+Running Move unit tests
+[ FAIL    ] 0x2::A::check_const_fail
+[ PASS    ] 0x2::A::check_const_pass
+[ FAIL    ] 0x2::A::check_local_fail
+[ PASS    ] 0x2::A::check_local_pass
+
+Test failures:
+
+Failures in 0x2::A:
+
+┌── check_const_fail ──────
+│ error: property does not hold
+│
+│     ┌── tests/concrete_check/property/basics.move:12:20 ───
+│     │
+│  12 │             assert false;
+│     │                    ^^^^^
+│     │
+│
+│
+└──────────────────
+
+
+┌── check_local_fail ──────
+│ error: property does not hold
+│
+│     ┌── tests/concrete_check/property/basics.move:29:20 ───
+│     │
+│  29 │             assert a;
+│     │                    ^
+│     │
+│
+│
+└──────────────────
+
+Test result: FAILED. Total tests: 4; passed: 2; failed: 2

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/basics.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/basics.move
@@ -1,0 +1,33 @@
+module 0x2::A {
+    #[test]
+    public fun check_const_pass() {
+        spec {
+            assert true;
+        };
+    }
+
+    #[test]
+    public fun check_const_fail() {
+        spec {
+            assert false;
+        };
+    }
+
+    #[test]
+    public fun check_local_pass(): bool {
+        let a = true;
+        spec {
+            assert a;
+        };
+        a
+    }
+
+    #[test]
+    public fun check_local_fail(): bool {
+        let a = false;
+        spec {
+            assert a;
+        };
+        a
+    }
+}

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/bitwise.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/bitwise.exp
@@ -1,0 +1,29 @@
+Running Move unit tests
+[ FAIL    ] 0x2::A::check_bitwise_fail
+[ PASS    ] 0x2::A::check_bitwise_ok
+
+Test failures:
+
+Failures in 0x2::A:
+
+┌── check_bitwise_fail ──────
+│ error: property does not hold
+│
+│     ┌── tests/concrete_check/property/bitwise.move:14:20 ───
+│     │
+│  14 │             assert 0x1u128 ^ 0x2 != 0x3u64;
+│     │                    ^^^^^^^^^^^^^^^^^^^^^^^
+│     │
+│
+│ error: property does not hold
+│
+│     ┌── tests/concrete_check/property/bitwise.move:15:20 ───
+│     │
+│  15 │             assert 0x100u64 >> 16 != 0;
+│     │                    ^^^^^^^^^^^^^^^^^^^
+│     │
+│
+│
+└──────────────────
+
+Test result: FAILED. Total tests: 2; passed: 1; failed: 1

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/bitwise.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/bitwise.move
@@ -1,0 +1,18 @@
+module 0x2::A {
+    #[test]
+    public fun check_bitwise_ok() {
+        spec {
+            assert 0x1u8 & 0x2u64 == 0u128;
+            assert 0x1u128 | 0x2u64 == 0x3u8;
+            assert 0x1u8 << 8 == 0x100;
+        };
+    }
+
+    #[test]
+    public fun check_bitwise_fail() {
+        spec {
+            assert 0x1u128 ^ 0x2 != 0x3u64;
+            assert 0x100u64 >> 16 != 0;
+        };
+    }
+}

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/boolean.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/boolean.exp
@@ -1,0 +1,21 @@
+Running Move unit tests
+[ FAIL    ] 0x2::A::check_boolean_fail
+[ PASS    ] 0x2::A::check_boolean_ok
+
+Test failures:
+
+Failures in 0x2::A:
+
+┌── check_boolean_fail ──────
+│ error: property does not hold
+│
+│     ┌── tests/concrete_check/property/boolean.move:13:20 ───
+│     │
+│  13 │             assert true ==> false;
+│     │                    ^^^^^^^^^^^^^^
+│     │
+│
+│
+└──────────────────
+
+Test result: FAILED. Total tests: 2; passed: 1; failed: 1

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/boolean.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/boolean.move
@@ -1,0 +1,16 @@
+module 0x2::A {
+    #[test]
+    public fun check_boolean_ok() {
+        spec {
+            assert true && false == false;
+            assert true || false == true;
+        };
+    }
+
+    #[test]
+    public fun check_boolean_fail() {
+        spec {
+            assert true ==> false;
+        };
+    }
+}

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/call_move.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/call_move.exp
@@ -1,0 +1,3 @@
+Running Move unit tests
+[ PASS    ] 0x2::A::check_call_move
+Test result: OK. Total tests: 1; passed: 1; failed: 0

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/call_move.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/call_move.move
@@ -1,0 +1,31 @@
+module 0x2::A {
+    struct S1 has copy, drop {
+        f1: bool,
+        f2: u64,
+    }
+
+    struct S2<T: copy> has copy, drop {
+        f1: bool,
+        f2: T,
+    }
+
+    fun move_plain(s: &S1): u64 {
+        s.f2
+    }
+
+    fun move_generic<T: copy>(s: &S2<T>): T {
+        *&s.f2
+    }
+
+    #[test]
+    public fun check_call_move() {
+        let s1 = S1 { f1: true, f2: 42 };
+        let s2 = S2 { f1: false, f2: s1 };
+        let p1 = &s2.f2;
+        let p2 = &s2;
+        spec {
+            assert move_plain(p1) == 42;
+            assert move_generic(p2) == s1;
+        };
+    }
+}

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/call_spec.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/call_spec.exp
@@ -1,0 +1,3 @@
+Running Move unit tests
+[ PASS    ] 0x2::A::check_call_spec
+Test result: OK. Total tests: 1; passed: 1; failed: 0

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/call_spec.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/call_spec.move
@@ -1,0 +1,31 @@
+module 0x2::A {
+    struct S1 has copy, drop {
+        f1: bool,
+        f2: u64,
+    }
+
+    struct S2<T: copy> has copy, drop {
+        f1: bool,
+        f2: T,
+    }
+
+    spec fun spec_plain(s: S1): u64 {
+        s.f2
+    }
+
+    spec fun spec_generic<T: copy>(s: S2<T>): T {
+        s.f2
+    }
+
+    #[test]
+    public fun check_call_spec() {
+        let s1 = S1 { f1: true, f2: 42 };
+        let s2 = S2 { f1: false, f2: s1 };
+        let p1 = &s2.f2;
+        let p2 = &s2;
+        spec {
+            assert spec_plain(p1) == 42;
+            assert spec_generic(p2) == s1;
+        };
+    }
+}

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/global_basics.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/global_basics.exp
@@ -1,0 +1,21 @@
+Running Move unit tests
+[ FAIL    ] 0x2::A::check_global_basics_fail
+[ PASS    ] 0x2::A::check_global_basics_ok
+
+Test failures:
+
+Failures in 0x2::A:
+
+┌── check_global_basics_fail ──────
+│ error: failed to evaluate expression
+│
+│     ┌── tests/concrete_check/property/global_basics.move:28:20 ───
+│     │
+│  28 │             assert global<R>(a).f2 == 42;
+│     │                    ^^^^^^^^^^^^^^^^^^^^^
+│     │
+│
+│
+└──────────────────
+
+Test result: FAILED. Total tests: 2; passed: 1; failed: 1

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/global_basics.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/global_basics.move
@@ -1,0 +1,31 @@
+module 0x2::A {
+    use 0x1::Signer;
+
+    struct R has key {
+        f1: bool,
+        f2: u64,
+    }
+
+    #[test(s=@0x2)]
+    public fun check_global_basics_ok(s: &signer) {
+        let a = Signer::address_of(s);
+        spec {
+            assert !exists<R>(a);
+        };
+        let r = R { f1: true, f2: 1 };
+        move_to(s, r);
+        spec {
+            assert exists<R>(a);
+            assert global<R>(a).f1;
+            assert global<R>(a) == R { f1: true, f2: 1 };
+        };
+    }
+
+    #[test(s=@0x2)]
+    public fun check_global_basics_fail(s: &signer) {
+        let a = Signer::address_of(s);
+        spec {
+            assert global<R>(a).f2 == 42;
+        };
+    }
+}

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/lambda.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/lambda.exp
@@ -1,0 +1,3 @@
+Running Move unit tests
+[ PASS    ] 0x2::A::check_lambda
+Test result: OK. Total tests: 1; passed: 1; failed: 0

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/lambda.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/lambda.move
@@ -1,0 +1,16 @@
+module 0x2::A {
+    #[test]
+    public fun check_lambda() {
+        spec {
+            assert f2() == 2;
+        };
+    }
+    spec module {
+        fun f1(f: |u64| u64): u64 {
+            f(1u64)
+        }
+        fun f2(): num {
+            f1(|x| x + 1)
+        }
+    }
+}

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/mem_label.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/mem_label.exp
@@ -1,0 +1,4 @@
+Running Move unit tests
+[ PASS    ] 0x2::A::check_mem_label_set
+[ PASS    ] 0x2::A::check_mem_label_swap
+Test result: OK. Total tests: 2; passed: 2; failed: 0

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/mem_label.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/mem_label.move
@@ -1,0 +1,54 @@
+module 0x2::A {
+    use 0x1::Signer;
+
+    struct R1<T: store> has key { f: T }
+
+    fun mutate_r1(addr: address) acquires R1 {
+        borrow_global_mut<R1<bool>>(addr).f = true;
+    }
+
+    spec mutate_r1 {
+        ensures global<R1<bool>>(addr) == update_field(old(global<R1<bool>>(addr)), f, true);
+    }
+
+    #[test(s=@0x2)]
+    public fun check_mem_label_set(s: &signer) acquires R1 {
+        let a = Signer::address_of(s);
+        let r = R1 { f: false };
+        move_to(s, r);
+        mutate_r1(a);
+        spec {
+            assert global<R1<bool>>(a).f;
+        };
+    }
+
+    struct R2<T: store> has key { f1: T, f2: T }
+
+    fun mutate_r2(addr: address) acquires R2 {
+        let r = borrow_global_mut<R2<bool>>(addr);
+        let f = r.f1;
+        r.f1 = r.f2;
+        r.f2 = f;
+    }
+
+    spec mutate_r2 {
+        ensures old(spec_get_r2<bool>(addr).f1) == spec_get_r2<bool>(addr).f2;
+        ensures old(spec_get_r2<bool>(addr).f2) == spec_get_r2<bool>(addr).f1;
+    }
+
+    spec fun spec_get_r2<T: store>(addr: address): R2<T> {
+        global<R2<T>>(addr)
+    }
+
+    #[test(s=@0x2)]
+    public fun check_mem_label_swap(s: &signer) acquires R2 {
+        let a = Signer::address_of(s);
+        let r = R2 { f1: true, f2: false };
+        move_to(s, r);
+        mutate_r2(a);
+        spec {
+            assert !global<R2<bool>>(a).f1;
+            assert global<R2<bool>>(a).f2;
+        };
+    }
+}

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/mono.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/mono.exp
@@ -1,0 +1,2 @@
+Running Move unit tests
+Test result: OK. Total tests: 0; passed: 0; failed: 0

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/mono.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/mono.move
@@ -1,0 +1,56 @@
+address 0x2 {
+module Base {
+    struct B has key {}
+
+    public fun BASE_ADDR(): address {
+        @0x1
+    }
+
+    public fun put_b(s: &signer) {
+        move_to(s, B {});
+    }
+
+    spec module {
+        fun has_b(): bool {
+            exists<B>(BASE_ADDR())
+        }
+    }
+}
+
+module Test {
+    use 0x2::Base;
+
+    struct R<T: store> has key {
+         f: T,
+    }
+
+    public fun put_r<T: store>(s: &signer, v: T) {
+        Base::put_b(s);
+        move_to(s, R { f: v });
+    }
+
+    // TODO (mengxu), after mono, the global invariant is changed to Base::has_b() ==> true...
+    // #[test(s=@0x2)]
+    public fun check_0x2_pass(s: &signer) {
+        put_r(s, true);
+    }
+
+    // TODO (mengxu), after mono, the global invariant is changed to Base::has_b() ==> true...
+    // #[test(s=@0x1)]
+    public fun check_0x1_fail(s: &signer) {
+        put_r(s, true);
+    }
+
+    spec module {
+        fun has_r<T>(): bool {
+            exists<R<T>>(Base::BASE_ADDR())
+        }
+    }
+
+    spec module {
+        invariant update
+            Base::has_b() ==>
+                (forall t: type where has_r<t>(): old(has_r<t>()));
+    }
+}
+}

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/spec_natives.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/spec_natives.exp
@@ -1,0 +1,3 @@
+Running Move unit tests
+[ PASS    ] 0x2::A::check_signer_spec_address_of
+Test result: OK. Total tests: 1; passed: 1; failed: 0

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/spec_natives.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/spec_natives.move
@@ -1,0 +1,12 @@
+module 0x2::A {
+    use 0x1::Signer;
+
+    #[test(s=@0x2)]
+    public fun check_signer_spec_address_of(s: &signer) {
+        let a = Signer::address_of(s);
+        spec {
+            assert a == Signer::spec_address_of(s);
+            assert a == Signer::address_of(s);
+        };
+    }
+}

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/struct.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/struct.exp
@@ -1,0 +1,3 @@
+Running Move unit tests
+[ PASS    ] 0x2::A::check_struct
+Test result: OK. Total tests: 1; passed: 1; failed: 0

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/struct.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/struct.move
@@ -1,0 +1,18 @@
+module 0x2::A {
+    struct S has drop {
+        f1: bool,
+        f2: u64,
+    }
+
+    #[test]
+    public fun check_struct() {
+        let a = S { f1: true, f2: 42 };
+        let b = S { f1: true, f2: 0 };
+        spec {
+            assert a != b;
+            assert a.f1 == b.f1;
+            assert a == update_field(b, f2, 42);
+            assert b != S { f1: false, f2: 0 };
+        };
+    }
+}

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/vector.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/vector.exp
@@ -1,0 +1,3 @@
+Running Move unit tests
+[ PASS    ] 0x2::A::check_vector
+Test result: OK. Total tests: 1; passed: 1; failed: 0

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/vector.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/vector.move
@@ -1,0 +1,27 @@
+module 0x2::A {
+    use 0x1::Vector;
+
+    #[test]
+    public fun check_vector() {
+        let a = Vector::empty();
+        let b = Vector::empty();
+        spec {
+            assert len(a) == 0;
+            assert a == vec();
+        };
+
+        Vector::push_back(&mut a, 42u128);
+        Vector::push_back(&mut b, 0u128);
+        spec {
+            assert len(a) == 1;
+            assert a == vec(42);
+            assert a[0] == 42;
+            assert contains(a, 42);
+            assert index_of(a, 42) == 0;
+            assert update(b, 0, 42) == a;
+            assert concat(a, b) == concat(vec(42), vec(0));
+            assert in_range(a, 0);
+            assert !in_range(b, 2);
+        };
+    }
+}

--- a/language/move-prover/interpreter/Cargo.toml
+++ b/language/move-prover/interpreter/Cargo.toml
@@ -18,6 +18,7 @@ move-vm-runtime = { path = "../../move-vm/runtime" }
 
 # external dependencies
 anyhow = "1.0.38"
+codespan-reporting = "0.8.0"
 num = "0.4.0"
 sha2 = "0.9.3"
 serde = { version = "1.0.124", features = ["derive"] }

--- a/language/move-prover/interpreter/Cargo.toml
+++ b/language/move-prover/interpreter/Cargo.toml
@@ -19,6 +19,7 @@ move-vm-runtime = { path = "../../move-vm/runtime" }
 # external dependencies
 anyhow = "1.0.38"
 codespan-reporting = "0.8.0"
+itertools = "0.10.0"
 num = "0.4.0"
 sha2 = "0.9.3"
 serde = { version = "1.0.124", features = ["derive"] }

--- a/language/move-prover/interpreter/src/concrete/evaluator.rs
+++ b/language/move-prover/interpreter/src/concrete/evaluator.rs
@@ -1,0 +1,1150 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use num::{BigInt, ToPrimitive, Zero};
+use std::{cell::Cell, collections::BTreeMap, rc::Rc};
+
+use bytecode::{function_target::FunctionTarget, function_target_pipeline::FunctionTargetsHolder};
+use move_core_types::account_address::AccountAddress;
+use move_model::{
+    ast::{Exp, ExpData, LocalVarDecl, MemoryLabel, Operation, SpecFunDecl, TempIndex, Value},
+    model::{FieldId, ModuleEnv, ModuleId, NodeId, SpecFunId, StructId},
+};
+
+use crate::{
+    concrete::{
+        local_state::LocalState,
+        player,
+        settings::InterpreterSettings,
+        ty::{convert_model_base_type, BaseType},
+        value::{BaseValue, EvalState, GlobalState, TypedValue},
+    },
+    shared::variant::choose_variant,
+};
+
+//**************************************************************************************************
+// Types
+//**************************************************************************************************
+
+pub type EvalResult<T> = ::std::result::Result<T, BigInt>;
+
+//**************************************************************************************************
+// Constants
+//**************************************************************************************************
+
+const DIEM_CORE_ADDR: AccountAddress =
+    AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+
+//**************************************************************************************************
+// Evaluation context
+//**************************************************************************************************
+
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+pub struct ExpState {
+    // bindings for the local variables
+    local_vars: BTreeMap<String, BaseValue>,
+    // bindings for lambda functions
+    local_lambdas: BTreeMap<String, (Vec<LocalVarDecl>, Exp)>,
+}
+
+impl ExpState {
+    pub fn add_var(&mut self, name: String, val: BaseValue) {
+        let exists = self.local_vars.insert(name, val);
+        if cfg!(debug_assertions) {
+            assert!(exists.is_none());
+        }
+    }
+
+    pub fn get_var(&self, name: &str) -> BaseValue {
+        self.local_vars.get(name).unwrap().clone()
+    }
+
+    pub fn add_lambda(&mut self, name: String, vars: Vec<LocalVarDecl>, stmt: Exp) {
+        let exists = self.local_lambdas.insert(name, (vars, stmt));
+        if cfg!(debug_assertions) {
+            assert!(exists.is_none());
+        }
+    }
+
+    pub fn get_lambda(&self, name: &str) -> &(Vec<LocalVarDecl>, Exp) {
+        self.local_lambdas.get(name).unwrap()
+    }
+}
+
+pub struct Evaluator<'env> {
+    // context
+    holder: &'env FunctionTargetsHolder,
+    target: &'env FunctionTarget<'env>,
+    ty_args: &'env [BaseType],
+    // debug
+    level: Cell<usize>,
+    // states
+    exp_state: ExpState,
+    eval_state: &'env EvalState,
+    local_state: &'env LocalState,
+    global_state: &'env GlobalState,
+}
+
+impl<'env> Evaluator<'env> {
+    pub fn new(
+        holder: &'env FunctionTargetsHolder,
+        target: &'env FunctionTarget<'env>,
+        ty_args: &'env [BaseType],
+        level: usize,
+        exp_state: ExpState,
+        eval_state: &'env EvalState,
+        local_state: &'env LocalState,
+        global_state: &'env GlobalState,
+    ) -> Self {
+        Self {
+            holder,
+            target,
+            ty_args,
+            level: Cell::new(level),
+            exp_state,
+            eval_state,
+            local_state,
+            global_state,
+        }
+    }
+
+    //
+    // entry points
+    //
+
+    pub fn check_assert(&self, exp: &Exp) {
+        match self.evaluate(exp) {
+            Ok(val) => {
+                if !val.into_bool() {
+                    self.record_checking_failure(exp);
+                }
+            }
+            Err(err) => {
+                // TODO (mengxu) this is just to keep tests happy, to be removed once completed
+                if err == BigInt::zero() {
+                    return;
+                }
+                self.record_evaluation_failure(exp, err);
+            }
+        }
+    }
+
+    pub fn check_assume(&self, exp: &Exp) -> Option<(TempIndex, TypedValue)> {
+        // NOTE: `let` bindings are translated to `Assume(Identical($t, <exp>));`. This should be
+        // treated as an assignment.
+        if let ExpData::Call(_, Operation::Identical, args) = exp.as_ref() {
+            if cfg!(debug_assertions) {
+                assert_eq!(args.len(), 2);
+            }
+            let env = self.target.global_env();
+            let (local_idx, local_ty) = match args[0].as_ref() {
+                ExpData::Temporary(node_id, idx) => {
+                    let node_ty = env.get_node_type(*node_id);
+                    let local_ty = convert_model_base_type(env, &node_ty, self.ty_args);
+                    (*idx, local_ty)
+                }
+                _ => unreachable!(),
+            };
+            if cfg!(debug_assertions) {
+                assert_eq!(
+                    &local_ty,
+                    self.local_state.get_type(local_idx).get_base_type()
+                );
+            }
+            let local_val = self.evaluate(&args[1]).unwrap();
+            Some((local_idx, TypedValue::fuse_base(local_ty, local_val)))
+        } else {
+            // for all other cases, treat with as an assertion
+            self.check_assert(exp);
+            None
+        }
+    }
+
+    //
+    // dispatcher
+    //
+
+    fn evaluate(&self, exp: &Exp) -> EvalResult<BaseValue> {
+        let exp_level = self.level.get();
+        self.level.set(exp_level + 1);
+
+        let debug_expression = self.get_settings().verbose_expression;
+        if debug_expression {
+            println!(
+                "{} {}[>]: {}",
+                "-".repeat(self.level.get()),
+                self.target.func_env.get_full_name_str(),
+                exp.display(self.target.global_env())
+            );
+        }
+
+        let result = match exp.as_ref() {
+            ExpData::Value(_, val) => self.evaluate_constant(val),
+            ExpData::Temporary(_, idx) => self.local_state.get_value(*idx).decompose().1,
+            ExpData::LocalVar(_, name) => {
+                let env = self.target.global_env();
+                self.exp_state
+                    .get_var(env.symbol_pool().string(*name).as_str())
+            }
+            ExpData::SpecVar(..) => {
+                // TODO (mengxu) handle spec var if they are still here
+                unreachable!()
+            }
+            ExpData::Call(node_id, op, args) => self.evaluate_operation(*node_id, op, args)?,
+            ExpData::IfElse(_, cond, t_exp, f_exp) => {
+                self.evaluate_if_then_else(cond, t_exp, f_exp)?
+            }
+            ExpData::Invoke(_, def, args) => self.evaluate_invocation(def, args)?,
+            ExpData::Quant(..) => {
+                // TODO (to avoid test case failure)
+                return Err(BigInt::zero());
+            }
+            ExpData::Invalid(_) => unreachable!(),
+            // should not appear in this context
+            ExpData::Lambda(..) | ExpData::Block(..) => unreachable!(),
+        };
+
+        if debug_expression {
+            println!(
+                "{} {}[<]: {}",
+                "-".repeat(self.level.get()),
+                self.target.func_env.get_full_name_str(),
+                exp.display(self.target.global_env())
+            );
+        }
+
+        self.level.set(exp_level);
+        Ok(result)
+    }
+
+    //
+    // concrete cases
+    //
+
+    fn evaluate_constant(&self, val: &Value) -> BaseValue {
+        match val {
+            Value::Address(v) => BaseValue::mk_address(
+                AccountAddress::from_hex_literal(&format!("{:#x}", v)).unwrap(),
+            ),
+            Value::Number(v) => BaseValue::mk_num(v.clone()),
+            Value::Bool(v) => BaseValue::mk_bool(*v),
+            Value::ByteArray(v) => {
+                BaseValue::mk_vector(v.iter().map(|e| BaseValue::mk_u8(*e)).collect())
+            }
+        }
+    }
+
+    fn evaluate_operation(
+        &self,
+        node_id: NodeId,
+        op: &Operation,
+        args: &[Exp],
+    ) -> EvalResult<BaseValue> {
+        let result = match op {
+            Operation::Slice => {
+                if cfg!(debug_assertions) {
+                    assert_eq!(args.len(), 2);
+                }
+                let arg_vec = self.evaluate(&args[0])?;
+                self.handle_vector_slice(arg_vec, &args[1])?
+            }
+            Operation::InRangeRange => {
+                if cfg!(debug_assertions) {
+                    assert_eq!(args.len(), 2);
+                }
+                let arg_idx = self.evaluate(&args[1])?;
+                self.handle_in_range(&args[0], arg_idx)?
+            }
+            Operation::Function(module_id, spec_fun_id, mem_labels_opt) => self.handle_call(
+                node_id,
+                *module_id,
+                *spec_fun_id,
+                mem_labels_opt.as_ref(),
+                args,
+            )?,
+            _ => self.evaluate_operation_with_values(node_id, op, args)?,
+        };
+        Ok(result)
+    }
+
+    fn evaluate_operation_with_values(
+        &self,
+        node_id: NodeId,
+        op: &Operation,
+        args: &[Exp],
+    ) -> EvalResult<BaseValue> {
+        let mut arg_vals = args
+            .iter()
+            .map(|arg_exp| self.evaluate(arg_exp))
+            .collect::<EvalResult<Vec<_>>>()?;
+        let result = match op {
+            // binary arithmetic
+            Operation::Add | Operation::Sub | Operation::Mul | Operation::Div | Operation::Mod => {
+                if cfg!(debug_assertions) {
+                    assert_eq!(arg_vals.len(), 2);
+                }
+                let rhs = arg_vals.remove(1);
+                let lhs = arg_vals.remove(0);
+                self.handle_binary_arithmetic(op, lhs, rhs)?
+            }
+            // binary bitwise
+            Operation::BitAnd | Operation::BitOr | Operation::Xor => {
+                if cfg!(debug_assertions) {
+                    assert_eq!(arg_vals.len(), 2);
+                }
+                let rhs = arg_vals.remove(1);
+                let lhs = arg_vals.remove(0);
+                self.handle_binary_bitwise(op, lhs, rhs)
+            }
+            // binary bitshift
+            Operation::Shl | Operation::Shr => {
+                if cfg!(debug_assertions) {
+                    assert_eq!(arg_vals.len(), 2);
+                }
+                let rhs = arg_vals.remove(1);
+                let lhs = arg_vals.remove(0);
+                self.handle_binary_bitshift(op, lhs, rhs)
+            }
+            // binary comparison
+            Operation::Lt | Operation::Le | Operation::Ge | Operation::Gt => {
+                if cfg!(debug_assertions) {
+                    assert_eq!(arg_vals.len(), 2);
+                }
+                let rhs = arg_vals.remove(1);
+                let lhs = arg_vals.remove(0);
+                self.handle_binary_comparison(op, lhs, rhs)
+            }
+            // binary equality
+            Operation::Eq | Operation::Neq => {
+                if cfg!(debug_assertions) {
+                    assert_eq!(arg_vals.len(), 2);
+                }
+                let rhs = arg_vals.remove(1);
+                let lhs = arg_vals.remove(0);
+                self.handle_binary_equality(op, lhs, rhs)
+            }
+            // unary boolean
+            Operation::Not => {
+                if cfg!(debug_assertions) {
+                    assert_eq!(arg_vals.len(), 1);
+                }
+                let opv = arg_vals.remove(0);
+                self.handle_unary_boolean(op, opv)
+            }
+            // binary boolean
+            Operation::And | Operation::Or | Operation::Implies | Operation::Iff => {
+                if cfg!(debug_assertions) {
+                    assert_eq!(arg_vals.len(), 2);
+                }
+                let rhs = arg_vals.remove(1);
+                let lhs = arg_vals.remove(0);
+                self.handle_binary_boolean(op, lhs, rhs)
+            }
+            // vector operation
+            Operation::Len => {
+                if cfg!(debug_assertions) {
+                    assert_eq!(arg_vals.len(), 1);
+                }
+                let opv = arg_vals.remove(0);
+                BaseValue::mk_num(BigInt::from(opv.into_vector().len()))
+            }
+            Operation::EmptyVec => {
+                if cfg!(debug_assertions) {
+                    assert!(arg_vals.is_empty());
+                }
+                BaseValue::mk_vector(vec![])
+            }
+            Operation::SingleVec => {
+                if cfg!(debug_assertions) {
+                    assert_eq!(arg_vals.len(), 1);
+                }
+                BaseValue::mk_vector(arg_vals)
+            }
+            Operation::Index => {
+                if cfg!(debug_assertions) {
+                    assert_eq!(arg_vals.len(), 2);
+                }
+                let idx = arg_vals.remove(1);
+                let vec = arg_vals.remove(0);
+                self.handle_vector_get(vec, idx)?
+            }
+            Operation::UpdateVec => {
+                if cfg!(debug_assertions) {
+                    assert_eq!(arg_vals.len(), 3);
+                }
+                let elem = arg_vals.remove(2);
+                let idx = arg_vals.remove(1);
+                let vec = arg_vals.remove(0);
+                self.handle_vector_update(vec, idx, elem)?
+            }
+            Operation::ConcatVec => {
+                if cfg!(debug_assertions) {
+                    assert_eq!(arg_vals.len(), 2);
+                }
+                let rhs = arg_vals.remove(1);
+                let lhs = arg_vals.remove(0);
+                self.handle_vector_concat(lhs, rhs)
+            }
+            Operation::IndexOfVec => {
+                if cfg!(debug_assertions) {
+                    assert_eq!(arg_vals.len(), 2);
+                }
+                let elem = arg_vals.remove(1);
+                let vec = arg_vals.remove(0);
+                self.handle_vector_index_of(vec, elem)
+            }
+            Operation::ContainsVec => {
+                if cfg!(debug_assertions) {
+                    assert_eq!(arg_vals.len(), 2);
+                }
+                let elem = arg_vals.remove(1);
+                let vec = arg_vals.remove(0);
+                self.handle_vector_contains(vec, elem)
+            }
+            Operation::InRangeVec => {
+                if cfg!(debug_assertions) {
+                    assert_eq!(args.len(), 2);
+                }
+                let idx = arg_vals.remove(1);
+                let vec = arg_vals.remove(0);
+                self.handle_vector_in_range(vec, idx)
+            }
+            // struct
+            Operation::Pack(module_id, struct_id) => {
+                self.handle_struct_pack(*module_id, *struct_id, arg_vals)
+            }
+            Operation::Select(module_id, struct_id, field_id) => {
+                if cfg!(debug_assertions) {
+                    assert_eq!(arg_vals.len(), 1);
+                }
+                let struct_val = arg_vals.remove(0);
+                self.handle_struct_get_field(*module_id, *struct_id, *field_id, struct_val)
+            }
+            Operation::UpdateField(module_id, struct_id, field_id) => {
+                if cfg!(debug_assertions) {
+                    assert_eq!(arg_vals.len(), 2);
+                }
+                let field_val = arg_vals.remove(1);
+                let struct_val = arg_vals.remove(0);
+                self.handle_struct_update_field(
+                    *module_id, *struct_id, *field_id, struct_val, field_val,
+                )
+            }
+            // globals
+            Operation::Exists(mem_opt) => {
+                if cfg!(debug_assertions) {
+                    assert_eq!(arg_vals.len(), 1);
+                }
+                let addr = arg_vals.remove(0);
+                self.handle_global_exists(node_id, mem_opt.as_ref().copied(), addr)
+            }
+            Operation::Global(mem_opt) => {
+                if cfg!(debug_assertions) {
+                    assert_eq!(arg_vals.len(), 1);
+                }
+                let addr = arg_vals.remove(0);
+                self.handle_global_get(node_id, mem_opt.as_ref().copied(), addr)?
+            }
+            // constant values
+            Operation::MaxU8 => {
+                if cfg!(debug_assertions) {
+                    assert!(arg_vals.is_empty());
+                }
+                BaseValue::mk_num(BigInt::from(u8::MAX))
+            }
+            Operation::MaxU64 => {
+                if cfg!(debug_assertions) {
+                    assert!(arg_vals.is_empty());
+                }
+                BaseValue::mk_num(BigInt::from(u64::MAX))
+            }
+            Operation::MaxU128 => {
+                if cfg!(debug_assertions) {
+                    assert!(arg_vals.is_empty());
+                }
+                BaseValue::mk_num(BigInt::from(u128::MAX))
+            }
+            Operation::AbortFlag => {
+                if cfg!(debug_assertions) {
+                    assert!(arg_vals.is_empty());
+                }
+                BaseValue::mk_bool(self.local_state.is_post_abort())
+            }
+            // type checking
+            Operation::WellFormed => {
+                if cfg!(debug_assertions) {
+                    assert_eq!(arg_vals.len(), 1);
+                }
+                // TODO (mengxu) implement the type checking logic
+                // if we don't, and the value is not actually well-formed, it should panic the
+                // stackless VM later in the execution.
+                BaseValue::mk_bool(true)
+            }
+            // TODO (mengxu) modifies check is not supported now
+            Operation::CanModify => {
+                // TODO (to avoid test case failure)
+                return Err(BigInt::zero());
+            }
+            // TODO (mengxu) events are not handled now
+            Operation::EmptyEventStore
+            | Operation::ExtendEventStore
+            | Operation::EventStoreIncludes
+            | Operation::EventStoreIncludedIn => {
+                // TODO (to avoid test case failure)
+                return Err(BigInt::zero());
+            }
+            // unexpected operations in this context
+            Operation::NoOp
+            | Operation::Identical
+            | Operation::Old
+            | Operation::Trace
+            | Operation::Tuple
+            | Operation::Result(_)
+            | Operation::AbortCode
+            | Operation::TypeValue
+            | Operation::TypeDomain
+            | Operation::ResourceDomain
+            | Operation::BoxValue
+            | Operation::UnboxValue => {
+                unreachable!()
+            }
+            // handled elsewhere, should not be here
+            Operation::Function(..)
+            | Operation::Slice
+            | Operation::Range
+            | Operation::RangeVec
+            | Operation::InRangeRange => {
+                unreachable!()
+            }
+        };
+        Ok(result)
+    }
+
+    fn evaluate_if_then_else(&self, cond: &Exp, t_exp: &Exp, f_exp: &Exp) -> EvalResult<BaseValue> {
+        let cond_val = self.evaluate(cond)?;
+        // NOTE: do not short-circuit the other path. For ITE expressions, we want to evaluate both
+        // expressions instead of short-circuiting the path that is not going to be taken.
+        let t_val = self.evaluate(t_exp)?;
+        let f_val = self.evaluate(f_exp)?;
+        let result = if cond_val.into_bool() { t_val } else { f_val };
+        Ok(result)
+    }
+
+    fn evaluate_invocation(&self, def: &Exp, args: &[Exp]) -> EvalResult<BaseValue> {
+        let env = self.target.global_env();
+
+        let (vars, stmt) = match def.as_ref() {
+            // TODO (mengxu): the assumption here is that the only way to invoke a lambda is to pass
+            // the lambda to a spec function as a function argument and then invoke the lambda
+            // within the spec function.
+            ExpData::LocalVar(_, symbol) => self
+                .exp_state
+                .get_lambda(env.symbol_pool().string(*symbol).as_str()),
+            _ => unreachable!(),
+        };
+
+        let arg_vals = args
+            .iter()
+            .map(|arg_exp| self.evaluate(arg_exp))
+            .collect::<EvalResult<Vec<_>>>()?;
+
+        let mut exp_state = ExpState::default();
+        for (var, val) in vars.iter().zip(arg_vals.into_iter()) {
+            if cfg!(debug_assertions) {
+                assert!(var.binding.is_none());
+            }
+            let name = env.symbol_pool().string(var.name).to_string();
+            exp_state.add_var(name, val);
+        }
+
+        let evaluator = Evaluator::new(
+            self.holder,
+            self.target,
+            self.ty_args,
+            self.level.get(),
+            exp_state,
+            self.eval_state,
+            self.local_state,
+            self.global_state,
+        );
+        evaluator.evaluate(stmt)
+    }
+
+    //
+    // handlers
+    //
+
+    fn handle_call(
+        &self,
+        node_id: NodeId,
+        module_id: ModuleId,
+        spec_fun_id: SpecFunId,
+        mem_labels_opt: Option<&Vec<MemoryLabel>>,
+        args: &[Exp],
+    ) -> EvalResult<BaseValue> {
+        let env = self.target.global_env();
+        let module_env = env.get_module(module_id);
+        let decl = module_env.get_spec_fun(spec_fun_id);
+        if cfg!(debug_assertions) {
+            assert_eq!(decl.params.len(), args.len());
+        }
+
+        let mut global_state = match mem_labels_opt {
+            None => self.global_state.clone(),
+            Some(labels) => {
+                let mut state = GlobalState::default();
+                for label in labels {
+                    self.eval_state.register_memory(label, &mut state);
+                }
+                state
+            }
+        };
+
+        let result = if decl.is_move_fun {
+            // TODO (mengxu) the decl for calling a move function might also have a body, maybe
+            // we could just interpret that?
+            self.handle_call_move_function(node_id, &module_env, decl, args, &mut global_state)?
+        } else if decl.body.is_none() {
+            self.handle_call_native_or_uninterpreted(&module_env, decl, args, &mut global_state)?
+        } else {
+            self.handle_call_spec_function(node_id, decl, args, &mut global_state)?
+        };
+        Ok(result)
+    }
+
+    fn handle_call_native_or_uninterpreted(
+        &self,
+        module_env: &ModuleEnv,
+        decl: &SpecFunDecl,
+        args: &[Exp],
+        _global_state: &mut GlobalState,
+    ) -> EvalResult<BaseValue> {
+        // convert args
+        let mut arg_vals = args
+            .iter()
+            .map(|arg_exp| self.evaluate(arg_exp))
+            .collect::<EvalResult<Vec<_>>>()?;
+
+        let env = self.target.global_env();
+        let addr = *module_env.self_address();
+        let module_name = env.symbol_pool().string(module_env.get_name().name());
+        let function_name = env.symbol_pool().string(decl.name);
+
+        // dispatch
+        let result = match (addr, module_name.as_str(), function_name.as_str()) {
+            (DIEM_CORE_ADDR, "Signer", "spec_address_of") => {
+                if cfg!(debug_assertions) {
+                    assert_eq!(arg_vals.len(), 1);
+                }
+                self.native_spec_signer_of(arg_vals.remove(0))
+            }
+            _ => unreachable!(),
+        };
+        Ok(result)
+    }
+
+    fn handle_call_spec_function(
+        &self,
+        node_id: NodeId,
+        decl: &SpecFunDecl,
+        args: &[Exp],
+        global_state: &mut GlobalState,
+    ) -> EvalResult<BaseValue> {
+        let env = self.target.global_env();
+
+        // convert type args
+        let callee_inst = env.get_node_instantiation(node_id);
+        if cfg!(debug_assertions) {
+            assert_eq!(decl.type_params.len(), callee_inst.len());
+        }
+        let ty_args: Vec<_> = callee_inst
+            .into_iter()
+            .map(|inst_ty| convert_model_base_type(env, &inst_ty, self.ty_args))
+            .collect();
+
+        // interpret
+        self.interpret_spec_function(decl, &ty_args, args, global_state)
+    }
+
+    fn handle_call_move_function(
+        &self,
+        node_id: NodeId,
+        module_env: &ModuleEnv,
+        decl: &SpecFunDecl,
+        args: &[Exp],
+        global_state: &mut GlobalState,
+    ) -> EvalResult<BaseValue> {
+        let env = self.target.global_env();
+        let decl_fun_name = env.symbol_pool().string(decl.name);
+        let fun_name_tokens: Vec<_> = decl_fun_name.split('$').collect();
+        if cfg!(debug_assertions) {
+            assert_eq!(fun_name_tokens.len(), 2);
+            assert_eq!(fun_name_tokens[0], "");
+        }
+        let fun_name = fun_name_tokens[1];
+
+        // find callee
+        let callee_env = module_env
+            .get_functions()
+            .find(|fun_env| env.symbol_pool().string(fun_env.get_name()).as_str() == fun_name)
+            .unwrap();
+        let callee_target = choose_variant(self.holder, &callee_env);
+
+        // convert type args
+        let callee_inst = env.get_node_instantiation(node_id);
+        if cfg!(debug_assertions) {
+            let callee_ty_params = callee_target.get_type_parameters();
+            assert_eq!(decl.type_params.len(), callee_ty_params.len());
+            assert_eq!(decl.type_params.len(), callee_inst.len());
+        }
+        let ty_args: Vec<_> = callee_inst
+            .into_iter()
+            .map(|inst_ty| convert_model_base_type(env, &inst_ty, self.ty_args))
+            .collect();
+
+        // convert args
+        if cfg!(debug_assertions) {
+            assert_eq!(decl.params.len(), callee_target.get_parameter_count());
+        }
+        let arg_vals = args
+            .iter()
+            .map(|arg_exp| self.evaluate(arg_exp))
+            .collect::<EvalResult<Vec<_>>>()?;
+
+        let typed_args = decl
+            .params
+            .iter()
+            .zip(arg_vals.into_iter())
+            .map(|((_, arg_ty), arg_val)| {
+                let converted = convert_model_base_type(env, arg_ty, &ty_args);
+                TypedValue::fuse_base(converted, arg_val)
+            })
+            .collect();
+
+        // execute the function
+        let callee_result = player::entrypoint(
+            self.holder,
+            callee_target,
+            &ty_args,
+            typed_args,
+            /* skip_specs */ true,
+            self.level.get(),
+            global_state,
+        );
+
+        // analyze the result
+        let return_val = match callee_result {
+            Ok(rets) => {
+                if cfg!(debug_assertions) {
+                    assert_eq!(rets.len(), 1);
+                }
+                rets.into_iter().next().unwrap().decompose().1
+            }
+            Err(_) => {
+                return Err(Self::eval_failure_code());
+            }
+        };
+        Ok(return_val)
+    }
+
+    fn handle_binary_arithmetic(
+        &self,
+        op: &Operation,
+        lhs: BaseValue,
+        rhs: BaseValue,
+    ) -> EvalResult<BaseValue> {
+        let lval = lhs.into_int();
+        let rval = rhs.into_int();
+        let result = match op {
+            Operation::Add => lval + rval,
+            Operation::Sub => lval - rval,
+            Operation::Mul => lval * rval,
+            Operation::Div => {
+                if rval.is_zero() {
+                    return Err(Self::eval_failure_code());
+                }
+                lval / rval
+            }
+            Operation::Mod => {
+                if rval.is_zero() {
+                    return Err(Self::eval_failure_code());
+                }
+                lval % rval
+            }
+            _ => unreachable!(),
+        };
+
+        Ok(BaseValue::mk_num(result))
+    }
+
+    fn handle_binary_bitwise(&self, op: &Operation, lhs: BaseValue, rhs: BaseValue) -> BaseValue {
+        let lval = lhs.into_int();
+        let rval = rhs.into_int();
+        let result = match op {
+            Operation::BitAnd => lval & rval,
+            Operation::BitOr => lval | rval,
+            Operation::Xor => lval ^ rval,
+            _ => unreachable!(),
+        };
+        BaseValue::mk_num(result)
+    }
+
+    fn handle_binary_bitshift(&self, op: &Operation, lhs: BaseValue, rhs: BaseValue) -> BaseValue {
+        let lval = lhs.into_int();
+        let rval = rhs.into_int();
+        let result = match op {
+            Operation::Shl => lval << rval.to_usize().unwrap(),
+            Operation::Shr => lval >> rval.to_usize().unwrap(),
+            _ => unreachable!(),
+        };
+        BaseValue::mk_num(result)
+    }
+
+    fn handle_binary_comparison(
+        &self,
+        op: &Operation,
+        lhs: BaseValue,
+        rhs: BaseValue,
+    ) -> BaseValue {
+        let lval = lhs.into_int();
+        let rval = rhs.into_int();
+        let result = match op {
+            Operation::Lt => lval < rval,
+            Operation::Le => lval <= rval,
+            Operation::Ge => lval >= rval,
+            Operation::Gt => lval > rval,
+            _ => unreachable!(),
+        };
+        BaseValue::mk_bool(result)
+    }
+
+    fn handle_binary_equality(&self, op: &Operation, lhs: BaseValue, rhs: BaseValue) -> BaseValue {
+        let result = match op {
+            Operation::Eq => lhs == rhs,
+            Operation::Neq => lhs != rhs,
+            _ => unreachable!(),
+        };
+        BaseValue::mk_bool(result)
+    }
+
+    fn handle_unary_boolean(&self, op: &Operation, opv: BaseValue) -> BaseValue {
+        let opval = opv.into_bool();
+        let result = match op {
+            Operation::Not => !opval,
+            _ => unreachable!(),
+        };
+        BaseValue::mk_bool(result)
+    }
+
+    fn handle_binary_boolean(&self, op: &Operation, lhs: BaseValue, rhs: BaseValue) -> BaseValue {
+        let lval = lhs.into_bool();
+        let rval = rhs.into_bool();
+        let result = match op {
+            Operation::And => lval && rval,
+            Operation::Or => lval || rval,
+            Operation::Implies => !lval || rval,
+            Operation::Iff => lval == rval,
+            _ => unreachable!(),
+        };
+        BaseValue::mk_bool(result)
+    }
+
+    fn handle_in_range(&self, range: &Exp, idx: BaseValue) -> EvalResult<BaseValue> {
+        let (lhs, rhs) = self.unroll_range(range)?;
+        let i = idx.into_int();
+        let r = i >= lhs && i < rhs;
+        Ok(BaseValue::mk_bool(r))
+    }
+
+    fn handle_vector_get(&self, vec: BaseValue, idx: BaseValue) -> EvalResult<BaseValue> {
+        let mut v = vec.into_vector();
+        let i = idx.into_int().to_usize().unwrap();
+        if i >= v.len() {
+            return Err(Self::eval_failure_code());
+        }
+        Ok(v.remove(i))
+    }
+
+    fn handle_vector_update(
+        &self,
+        vec: BaseValue,
+        idx: BaseValue,
+        elem: BaseValue,
+    ) -> EvalResult<BaseValue> {
+        let mut v = vec.into_vector();
+        let i = idx.into_int().to_usize().unwrap();
+        if i >= v.len() {
+            return Err(Self::eval_failure_code());
+        }
+        *v.get_mut(i).unwrap() = elem;
+        Ok(BaseValue::mk_vector(v))
+    }
+
+    fn handle_vector_slice(&self, vec: BaseValue, range: &Exp) -> EvalResult<BaseValue> {
+        let mut v = vec.into_vector();
+        let (lhs, rhs) = self.unroll_range(range)?;
+        if lhs > rhs || lhs < BigInt::zero() || rhs > BigInt::from(v.len()) {
+            return Err(Self::eval_failure_code());
+        }
+        let mut slice = v.split_off(lhs.to_usize().unwrap());
+        let _ = slice.split_off(rhs.to_usize().unwrap());
+        Ok(BaseValue::mk_vector(slice))
+    }
+
+    fn handle_vector_concat(&self, lhs: BaseValue, rhs: BaseValue) -> BaseValue {
+        let mut concat = lhs.into_vector();
+        concat.append(&mut rhs.into_vector());
+        BaseValue::mk_vector(concat)
+    }
+
+    fn handle_vector_index_of(&self, vec: BaseValue, elem: BaseValue) -> BaseValue {
+        let v = vec.into_vector();
+        let idx = match v.into_iter().position(|e| e == elem) {
+            None => BigInt::from(-1),
+            Some(i) => BigInt::from(i),
+        };
+        BaseValue::mk_num(idx)
+    }
+
+    fn handle_vector_contains(&self, vec: BaseValue, elem: BaseValue) -> BaseValue {
+        let v = vec.into_vector();
+        BaseValue::mk_bool(v.contains(&elem))
+    }
+
+    fn handle_vector_in_range(&self, vec: BaseValue, idx: BaseValue) -> BaseValue {
+        let v = vec.into_vector();
+        let i = idx.into_int();
+        let r = i >= BigInt::zero() && i < BigInt::from(v.len());
+        BaseValue::mk_bool(r)
+    }
+
+    fn handle_struct_pack(
+        &self,
+        module_id: ModuleId,
+        struct_id: StructId,
+        fields: Vec<BaseValue>,
+    ) -> BaseValue {
+        if cfg!(debug_assertions) {
+            let env = self.target.global_env();
+            let struct_env = env.get_struct(module_id.qualified(struct_id));
+            assert_eq!(struct_env.get_field_count(), fields.len());
+        }
+        BaseValue::mk_struct(fields)
+    }
+
+    fn handle_struct_get_field(
+        &self,
+        module_id: ModuleId,
+        struct_id: StructId,
+        field_id: FieldId,
+        struct_val: BaseValue,
+    ) -> BaseValue {
+        let mut fields = struct_val.into_struct();
+
+        let env = self.target.global_env();
+        let struct_env = env.get_struct(module_id.qualified(struct_id));
+        if cfg!(debug_assertions) {
+            assert_eq!(struct_env.get_field_count(), fields.len());
+        }
+
+        let offset = struct_env.get_field(field_id).get_offset();
+        fields.remove(offset)
+    }
+
+    fn handle_struct_update_field(
+        &self,
+        module_id: ModuleId,
+        struct_id: StructId,
+        field_id: FieldId,
+        struct_val: BaseValue,
+        field_val: BaseValue,
+    ) -> BaseValue {
+        let mut fields = struct_val.into_struct();
+
+        let env = self.target.global_env();
+        let struct_env = env.get_struct(module_id.qualified(struct_id));
+        if cfg!(debug_assertions) {
+            assert_eq!(struct_env.get_field_count(), fields.len());
+        }
+
+        let offset = struct_env.get_field(field_id).get_offset();
+        *fields.get_mut(offset).unwrap() = field_val;
+        BaseValue::mk_struct(fields)
+    }
+
+    fn handle_global_exists(
+        &self,
+        node_id: NodeId,
+        mem_opt: Option<MemoryLabel>,
+        addr_val: BaseValue,
+    ) -> BaseValue {
+        let env = self.target.global_env();
+        let node_ty = env
+            .get_node_instantiation(node_id)
+            .into_iter()
+            .next()
+            .unwrap();
+        let struct_ty = convert_model_base_type(env, &node_ty, self.ty_args);
+        let struct_inst = struct_ty.into_struct_inst();
+        let addr = addr_val.into_address();
+        let result = match mem_opt {
+            None => self.global_state.has_resource(&addr, &struct_inst),
+            Some(mem_label) => self
+                .eval_state
+                .load_memory(&mem_label, &struct_inst, &addr)
+                .is_some(),
+        };
+        BaseValue::mk_bool(result)
+    }
+
+    fn handle_global_get(
+        &self,
+        node_id: NodeId,
+        mem_opt: Option<MemoryLabel>,
+        addr_val: BaseValue,
+    ) -> EvalResult<BaseValue> {
+        let env = self.target.global_env();
+        let node_ty = env
+            .get_node_instantiation(node_id)
+            .into_iter()
+            .next()
+            .unwrap();
+        let struct_ty = convert_model_base_type(env, &node_ty, self.ty_args);
+        let struct_inst = struct_ty.into_struct_inst();
+        let addr = addr_val.into_address();
+        let resource = match mem_opt {
+            None => {
+                match self
+                    .global_state
+                    .get_resource(Some(true), addr, struct_inst)
+                {
+                    None => {
+                        return Err(Self::eval_failure_code());
+                    }
+                    Some(val) => val.decompose().1,
+                }
+            }
+            Some(mem_label) => match self.eval_state.load_memory(&mem_label, &struct_inst, &addr) {
+                None => {
+                    return Err(Self::eval_failure_code());
+                }
+                Some(val) => val,
+            },
+        };
+        Ok(resource)
+    }
+
+    //
+    // natives
+    //
+
+    fn native_spec_signer_of(&self, arg: BaseValue) -> BaseValue {
+        BaseValue::mk_address(arg.into_signer())
+    }
+
+    //
+    // spec function interpretation
+    //
+
+    fn interpret_spec_function(
+        &self,
+        decl: &SpecFunDecl,
+        ty_args: &[BaseType],
+        args: &[Exp],
+        global_state: &mut GlobalState,
+    ) -> EvalResult<BaseValue> {
+        let (vars, stmt) = match decl.body.as_ref().unwrap().as_ref() {
+            ExpData::Block(_, vars, stmt) => (vars, stmt),
+            _ => unreachable!(),
+        };
+
+        let env = self.target.global_env();
+        let mut exp_state = ExpState::default();
+        for ((param_name, _), arg_exp) in decl.params.iter().zip(args.iter()) {
+            let name = env.symbol_pool().string(*param_name).to_string();
+            match arg_exp.as_ref() {
+                ExpData::Lambda(_, vars, stmt) => {
+                    exp_state.add_lambda(name, vars.to_vec(), stmt.clone())
+                }
+                _ => {
+                    let arg_val = self.evaluate(arg_exp)?;
+                    exp_state.add_var(name, arg_val);
+                }
+            }
+        }
+        for var in vars {
+            let name = env.symbol_pool().string(var.name).to_string();
+            let val = self.evaluate(var.binding.as_ref().unwrap())?;
+            exp_state.add_var(name, val);
+        }
+
+        let evaluator = Evaluator::new(
+            self.holder,
+            self.target,
+            ty_args,
+            self.level.get(),
+            exp_state,
+            self.eval_state,
+            self.local_state,
+            global_state,
+        );
+        evaluator.evaluate(stmt)
+    }
+
+    //
+    // operators that gives other types
+    //
+
+    fn unroll_range(&self, exp: &Exp) -> EvalResult<(BigInt, BigInt)> {
+        let range = match exp.as_ref() {
+            ExpData::Call(_, Operation::Range, args) => {
+                if cfg!(debug_assertions) {
+                    assert_eq!(args.len(), 2);
+                }
+                let lhs = self.evaluate(&args[0])?.into_int();
+                let rhs = self.evaluate(&args[1])?.into_int();
+                (lhs, rhs)
+            }
+            ExpData::Call(_, Operation::RangeVec, args) => {
+                if cfg!(debug_assertions) {
+                    assert_eq!(args.len(), 1);
+                }
+                let opv = self.evaluate(&args[0])?.into_vector();
+                (BigInt::zero(), BigInt::from(opv.len()))
+            }
+            _ => unreachable!(),
+        };
+        Ok(range)
+    }
+
+    //
+    // utilities
+    //
+
+    fn record_evaluation_failure(&self, exp: &Exp, _err: BigInt) {
+        let env = self.target.global_env();
+        let loc = env.get_node_loc(exp.node_id());
+        env.error(&loc, "failed to evaluate expression");
+    }
+
+    fn record_checking_failure(&self, exp: &Exp) {
+        let env = self.target.global_env();
+        let loc = env.get_node_loc(exp.node_id());
+        env.error(&loc, "property does not hold");
+    }
+
+    fn eval_failure_code() -> BigInt {
+        BigInt::from(-1)
+    }
+
+    //
+    // settings
+    //
+
+    fn get_settings(&self) -> Rc<InterpreterSettings> {
+        self.target
+            .global_env()
+            .get_extension::<InterpreterSettings>()
+            .unwrap_or_default()
+    }
+}

--- a/language/move-prover/interpreter/src/concrete/local_state.rs
+++ b/language/move-prover/interpreter/src/concrete/local_state.rs
@@ -1,6 +1,9 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//! This file implements the information needed in the local interpretation context, i.e., the
+//! context created and updated when interpreting a single function.
+
 use std::collections::BTreeMap;
 
 use move_binary_format::errors::{Location, PartialVMError, VMError};
@@ -21,6 +24,7 @@ pub enum AbortInfo {
 }
 
 impl AbortInfo {
+    /// Convert the AbortInfo into a VMError
     pub fn into_err(self) -> VMError {
         match self {
             Self::User(status_code, location) => PartialVMError::new(StatusCode::ABORTED)
@@ -32,6 +36,7 @@ impl AbortInfo {
         }
     }
 
+    /// Retrieve the status code as a u64
     pub fn get_status_code(&self) -> u64 {
         match self {
             Self::User(status_code, _) => *status_code,

--- a/language/move-prover/interpreter/src/concrete/local_state.rs
+++ b/language/move-prover/interpreter/src/concrete/local_state.rs
@@ -163,6 +163,10 @@ impl LocalState {
             TerminationStatus::Return(_) | TerminationStatus::Abort(_)
         )
     }
+    /// Check whether we are executing in a post-abort status
+    pub fn is_post_abort(&self) -> bool {
+        matches!(self.termination, TerminationStatus::PostAbort(_))
+    }
     /// Mark that the current function terminated with an abort
     pub fn terminate_with_abort(&mut self, abort_info: AbortInfo) {
         if cfg!(debug_assertions) {

--- a/language/move-prover/interpreter/src/concrete/mod.rs
+++ b/language/move-prover/interpreter/src/concrete/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod evaluator;
 pub mod local_state;
 pub mod player;
 pub mod runtime;

--- a/language/move-prover/interpreter/src/concrete/player.rs
+++ b/language/move-prover/interpreter/src/concrete/player.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//! This file implements the statement interpretation part of the stackless bytecode interpreter.
+
 use num::{BigInt, ToPrimitive, Zero};
 use sha2::{Digest, Sha256};
 use std::{collections::BTreeMap, convert::TryFrom, rc::Rc};
@@ -96,6 +98,7 @@ impl<'env> FunctionContext<'env> {
     // settings
     //
 
+    /// Retrieve the `InterpreterSettings` from the global environment
     pub fn get_settings(&self) -> Rc<InterpreterSettings> {
         self.target
             .global_env()

--- a/language/move-prover/interpreter/src/concrete/runtime.rs
+++ b/language/move-prover/interpreter/src/concrete/runtime.rs
@@ -79,6 +79,8 @@ impl<'env> Runtime<'env> {
             fun_target,
             ty_args,
             args.to_vec(),
+            /* skip_specs */ false,
+            /* level */ 1,
             global_state,
         )
         .map_err(|abort_info| abort_info.into_err())

--- a/language/move-prover/interpreter/src/concrete/runtime.rs
+++ b/language/move-prover/interpreter/src/concrete/runtime.rs
@@ -1,6 +1,11 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//! This file implements the orchestration part of the stackless bytecode interpreter and also
+//! provides outside-facing interfaces for the clients of stackless bytecode interpreter. Clients
+//! of the interpreter should never directly interact with the statement player (in `player.rs`) nor
+//! the expression evaluator (in `evaluator.rs`).
+
 use bytecode::{function_target::FunctionTarget, function_target_pipeline::FunctionTargetsHolder};
 use move_binary_format::errors::{Location, PartialVMError, PartialVMResult, VMResult};
 use move_core_types::{

--- a/language/move-prover/interpreter/src/concrete/settings.rs
+++ b/language/move-prover/interpreter/src/concrete/settings.rs
@@ -7,6 +7,8 @@ pub struct InterpreterSettings {
     pub verbose_stepwise: bool,
     /// dump bytecode trace
     pub verbose_bytecode: bool,
+    /// dump expression trace
+    pub verbose_expression: bool,
 }
 
 impl InterpreterSettings {
@@ -14,6 +16,7 @@ impl InterpreterSettings {
         Self {
             verbose_stepwise: true,
             verbose_bytecode: true,
+            verbose_expression: true,
         }
     }
 }

--- a/language/move-prover/interpreter/src/concrete/settings.rs
+++ b/language/move-prover/interpreter/src/concrete/settings.rs
@@ -3,6 +3,8 @@
 
 #[derive(Default, Clone)]
 pub struct InterpreterSettings {
+    /// skip expression checking
+    pub no_expr_check: bool,
     /// dump stepwise bytecode
     pub verbose_stepwise: bool,
     /// dump bytecode trace
@@ -17,6 +19,7 @@ impl InterpreterSettings {
             verbose_stepwise: true,
             verbose_bytecode: true,
             verbose_expression: true,
+            ..Default::default()
         }
     }
 }

--- a/language/move-prover/interpreter/src/lib.rs
+++ b/language/move-prover/interpreter/src/lib.rs
@@ -56,6 +56,9 @@ pub struct InterpreterOptions {
     #[structopt(long = "ty-args", parse(try_from_str = parse_type_tag))]
     pub ty_args: Vec<TypeTag>,
 
+    /// Skip checking of expressions
+    #[structopt(long = "no-expr-check")]
+    pub no_expr_check: bool,
     /// Level of verbosity
     #[structopt(short = "v", long = "verbose")]
     pub verbose: Option<u64>,
@@ -107,6 +110,7 @@ pub fn interpret_with_options(
 
     // collect settings
     let settings = InterpreterSettings {
+        no_expr_check: options.no_expr_check,
         verbose_stepwise: options.verbose.map_or(false, |level| level > 0),
         verbose_bytecode: options.verbose.map_or(false, |level| level > 1),
         verbose_expression: options.verbose.map_or(false, |level| level > 2),
@@ -201,7 +205,7 @@ impl<'env> StacklessBytecodeInterpreter<'env> {
         let mut new_global_state = global_state.clone();
 
         // execute and convert results
-        let vm = Runtime::new(&self.targets);
+        let vm = Runtime::new(self.env, &self.targets);
         let vm_result = vm.execute(fun_env, ty_args, args, &mut new_global_state);
         let serialized_vm_result = vm_result.map(|rets| {
             rets.into_iter()

--- a/language/move-prover/interpreter/src/shared/ident.rs
+++ b/language/move-prover/interpreter/src/shared/ident.rs
@@ -5,7 +5,7 @@ use std::fmt;
 
 use bytecode::{function_target::FunctionTarget, function_target_pipeline::FunctionVariant};
 use move_core_types::account_address::AccountAddress;
-use move_model::model::StructEnv;
+use move_model::model::{ModuleEnv, StructEnv};
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct ModuleIdent {
@@ -52,21 +52,27 @@ impl fmt::Display for StructIdent {
 // Implementation
 //**************************************************************************************************
 
+impl ModuleIdent {
+    pub fn new(module_env: &ModuleEnv) -> Self {
+        let env = module_env.env;
+        Self {
+            address: *module_env.self_address(),
+            name: env
+                .symbol_pool()
+                .string(module_env.get_name().name())
+                .to_string(),
+        }
+    }
+}
+
 impl FunctionIdent {
     #[allow(dead_code)]
     pub fn new(target: &FunctionTarget) -> Self {
         let func_env = target.func_env;
         let module_env = &func_env.module_env;
         let env = module_env.env;
-        let module_ident = ModuleIdent {
-            address: *module_env.self_address(),
-            name: env
-                .symbol_pool()
-                .string(module_env.get_name().name())
-                .to_string(),
-        };
         FunctionIdent {
-            module: module_ident,
+            module: ModuleIdent::new(module_env),
             name: env.symbol_pool().string(target.get_name()).to_string(),
             variant: target.data.variant.clone(),
         }
@@ -77,15 +83,8 @@ impl StructIdent {
     pub fn new(struct_env: &StructEnv) -> Self {
         let module_env = &struct_env.module_env;
         let env = module_env.env;
-        let module_ident = ModuleIdent {
-            address: *module_env.self_address(),
-            name: env
-                .symbol_pool()
-                .string(module_env.get_name().name())
-                .to_string(),
-        };
         StructIdent {
-            module: module_ident,
+            module: ModuleIdent::new(module_env),
             name: env.symbol_pool().string(struct_env.get_name()).to_string(),
         }
     }

--- a/language/tools/move-unit-test/src/test_reporter.rs
+++ b/language/tools/move-unit-test/src/test_reporter.rs
@@ -33,6 +33,8 @@ pub enum FailureReason {
         stackless_vm_return_values: Box<VMResult<Vec<Vec<u8>>>>,
         stackless_vm_change_set: Box<VMResult<ChangeSet>>,
     },
+    // Property checking failed
+    Property(String),
     // The test failed for some unknown reason. This shouldn't be encountered
     Unknown(String),
 }
@@ -109,6 +111,10 @@ impl FailureReason {
         }
     }
 
+    pub fn property(details: String) -> Self {
+        FailureReason::Property(details)
+    }
+
     pub fn unknown() -> Self {
         FailureReason::Unknown("ITE: An unknown error was reported.".to_string())
     }
@@ -163,6 +169,7 @@ impl TestFailure {
                     stackless_vm_change_set
                 )
             }
+            FailureReason::Property(message) => message.clone(),
             FailureReason::Unknown(message) => {
                 format!(
                     "{}. VMError (if there is one) is: {}",


### PR DESCRIPTION
This PR contains the expression evaluation part of the stackless bytecode interpreter.

## Overview

The stackless bytecode interpreter consists of two major parts:
- A stackless statement interpreter, of which a majority of the code is in #8316, behaves mostly like the Move VM. It follows a statement-based semantics and treat each statement `s` in the function as a way to update local and global states, i.e., `interpret(s, local_state, global_state) -> (new_local_state, new_global_state)`. The interpreter itself should produce exactly the same results as the the Move VM.
- An expression evaluator (which is the focus of this PR), recursively evaluates the expressions in a bottom-up manner. The expression evaluator only takes information from local and global states but will never update them.

The entry point to the expression evaluator is via the handle of the `Prop` bytecode type in the statement interpreter, in particular, either via `PropKind::Assert` or `PropKind::Assume`. The statement interpreter will fork an expression evaluator whenever an assertion or assumption is checked. The expression evaluation will then evaluate the expression by traversing the expression tree in a bottom-up manner, i.e., in a sketch:

```
evaluate(expr) {
  // collect sub_expr_values bottom-up
  for each sub_expr of expr {
    evaluate(sub_expr);
  }
  // calculate the value of this expression
  calculate_expr_value(expr_operation, sub_expr_values);
}
```

Occasionally, the evaluator might also fork a statement interpreter for the handling of pure Move functions.

## Details on non-quantified expressions

Most expressions can be handled without special treatment, but the following exp types are handled specially:
- `ExpData::SpecVar `=> this is not supported
- `ExpData::Lambda` | `ExpData::Block` => these two are handled when we handle `ExpData::Invoke`, hence, they are never evaluated directly. (In fact, in the type system of the stackless VM, there is no type for a `Lambda`).
- `Operation::Range` | `Operation::RangeVec` => these two are handled when we handle the `ExpData::Quant` as well as `ExpData::InRangeRange` | `ExpData::InRangeVec`, hence, they are never evaluated directly. Similarly, we don't have a range type in the stackless VM's type system.
- `Operation::TypeDomain` | `Operation::ResourceDomain` => these are unrolled when when we handle quantified expression. In theory, they should only appear in the `Range` part of a quantified expression.

## Details on quantified expressions

The entry point to handling quantified expressions is `Evaluator::evaluate_quantifier`, and basically, for the `forall` and `exists` quantifiers, there are three components

- range: `v_1: range_1, v_2: range_2, ..., v_n: range_n,`
- constraint expression: `constraints(v_1, v_2, ..., v_n)`
- quantifier body: `boolean_predicate(v_1, v_2, ..., v_n)`

And reach `range_i` must be one of the following types:
- bounded integer range, created via `Operation::Range` and `Operation::RangeVec`
- type domain, which only the `Address` type is allowed. The evaluator will consult the global state to collect all addresses that is available in the state, at the time of evaluation.
- resource domain: The evaluator will consult the global state to collect all values that are of the resource type in the current global state.
- a vector expression: the type of the `range_i` expression is a vector. In this case, we can just unpack that vector.

The summary is: the range has to be bounded (such that we can enumerate in a reasonable amount of time). And these are all the cases that exist in the Diem framework specs, and I guess it is not unreasonable to believe that this will continue to exist in such a way.

The handling of a quantified expression is straightforward given the above restrictions:

```
let mut results = vec![];
for (v_1, v_2, ..., v_n) in cartesian_product(range_1, range_2, ..., range_n) {
  if constraints(v_1, v_2, ..., v_n) {
    let r = boolean_predicate(v_1, v_2, ..., v_n);
    results.push_back(r);
  }
}
```

Evaluating `forall` will be a `results.all()` and `exists` will be a `results.any()`.

## Integration with the Unit Testing Framework

The Move unit testing framework is updated with a new error type when a property in a spec does not hold. Following is an example on how it looks like:

Suppose that we have the following `test.move` file:
```
module 0x2::A {
    use 0x1::Signer;

    struct R has key {
        v: u64,
    }

    #[test(s=@0x2)]
    public fun check_global_ok(s: &signer) {
        let r = R { v: 1 };
        move_to(s, r);
    }
    spec check_global_ok {
        ensures global<R>(Signer::spec_address_of(s)) == R { v: 2 };
    }
}
```

Invoking the unit test on it will produce the following output:
```
Running Move unit tests
[ FAIL    ] 0x2::A::check_global_ok

Test failures:

Failures in 0x2::A:

┌── check_global_ok ──────
│ error: property does not hold
│
│     ┌── tests/concrete_check/property/test.move:14:17 ───
│     │
│  14 │         ensures global<R>(Signer::spec_address_of(s)) == R { v: 2 };
│     │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
│     │
│
│
└──────────────────

Test result: FAILED. Total tests: 1; passed: 0; failed: 1
```

## TODO items remaining
- More thorough unit tests for quantified expressions and other expressions (especially after the issue between global invariant and type-quantifier elimination is resolved)
- Update the handler of `IsParent` and `WriteBack` bytecode when the new memory model is finanlzed
- Support and test `Choose` | `ChooseMin` operators
- Support `Modify` properties
- Support properties over `Events`

But these should be relatively easy once this PR is landed.

## Motivation

This fills in the second major part of the stackless VM: evaluating expressions for assertions.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- CI + new unit tests
- successful replay of all language e2e test cases (without evaluation of quantified expressions)

A full replay of the language e2e test cases with full evaluation of quantified expressions will be attempted after the issue between global invariant and 
