### PR TITLE
[move stdlib] Capability-based secure storage

### DIFF
--- a/language/move-stdlib/nursery/Vault.move
+++ b/language/move-stdlib/nursery/Vault.move
@@ -1,0 +1,537 @@
+/// A module which implements secure memory (called a *vault*) of some content which can only be operated
+/// on if authorized by a signer. Authorization is managed by
+/// [*capabilities*](https://en.wikipedia.org/wiki/Capability-based_security). The vault supports delegation
+/// of capabilities to other signers (including revocation) as well as transfer of ownership.
+///
+/// # Overview
+///
+/// ## Capabilities
+///
+/// Capabilities are unforgeable tokens which represent the right to perform a particular
+/// operation on the vault. To acquire a capability instance, authentication via a signer is needed.
+/// This signer must either be the owner of the vault, or someone the capability has been delegated to.
+////
+/// Once acquired, a capability can be passed to other functions to perform the operation it enables.
+/// Specifically, those called functions do not need to have access to the original signer. This is a key
+/// property of capability based security as it prevents granting more rights to code than needed.
+///
+/// Capability instances are unforgeable because they are localized to transactions. They can only be
+/// created by functions of this module, and as they do not have the Move language `store` or `key` abilities,
+/// they cannot leak out of a transaction.
+///
+/// Example:
+///
+/// ```move
+/// struct Content has store { ssn: u64 }
+/// ...
+/// // Create new vault
+/// Vault::new(signer, b"My Vault", Content{ ssn: 525659745 });
+/// ...
+/// // Obtain a read capability
+/// let read_cap = Vault::acquire_read_cap<Content>(signer);
+/// process(&read_cap)
+/// ...
+/// fun process(cap: &Vault::ReadCap<Content>) {
+///     let accessor = Vault::read_accessor(cap);
+///     let content = Vault::borrow(accessor);
+///     << do something with `content: &Content` >>
+///     Vault::release_read_accessor(accessor);
+/// }
+/// ```
+///
+/// ## Delegation
+///
+/// Delegation provides the option to delegate the right to acquire a vault capability to other
+/// signers than the owner of the vault. Delegates still need to authenticate themselves using their
+/// signer, similar as the owner does. All security arguments for owners apply also to delegates.
+/// Delegation can be revoked removing previously granted rights from a delegate.
+///
+/// Delegation can be configured to be transitive by granting the right to acquire a delegation capability
+/// to delegates, which can then further delegate access rights.
+///
+/// By default, when a vault is created, it does not support delegation. The owner of the vault
+/// needs to explicitly enable delegation. This allows to create vaults which are not intended for delegation
+/// and one does not need to worry about its misuse.
+///
+/// Example:
+///
+/// ```move
+/// Vault::new(signer, b"My Vault", Content{ ssn: 525659745 });
+/// // Enable delegation for this vault. Only the owning signer can do this.
+/// Vault::enable_delegation<Content>(signer);
+/// ...
+/// // Delegate read capability to some other signer.
+/// let delegate_cap = Vault::acquire_delegate_cap<Content>(signer);
+/// Vault::delegate_read_cap(&delegate_cap, other_signer);
+/// ...
+/// // Other signer can now acquire read cap
+/// let read_cap = Vault::acquire_read_cap<Content>(other_signer);
+/// ...
+/// // The granted capability can be revoked. There is no need to have the other signer for this.
+/// Vault::revoke_read_cap(&delegate_cap, Signer::address_of(other_signer));
+/// ```
+///
+/// ## Abilities
+///
+/// Currently, we require that the `Content` type of a vault has the `drop` ability in order to instantiate
+/// a capability type like `ReadCap<Content>`. Without this, capabilities themselves would need to have an
+/// explicit release function, which makes little sense as they are pure values. We expect the Move
+/// language to have 'phantom type parameters' or similar features added, which will allows us to have
+/// `ReadCap<Content>` droppable and copyable without `Content` needing the same.
+module 0x1::Vault {
+
+    use 0x1::Errors;
+    use 0x1::Event;
+    use 0x1::Option;
+    use 0x1::Signer;
+    use 0x1::Vector;
+
+    // ================================================================================================================
+    // Error reasons
+
+    const EVAULT: u64 = 0;
+    const EDELEGATE: u64 = 1;
+    const EACCESSOR_IN_USE: u64 = 2;
+    const EACCESSOR_INCONSISTENCY: u64 = 3;
+    const EDELEGATE_TO_SELF: u64 = 4;
+    const EDELEGATION_NOT_ENABLED: u64 = 5;
+    const EEVENT: u64 = 6;
+
+
+    // ================================================================================================================
+    // Capabilities
+
+    /// A capability to read the content of the vault. Notice that the capability cannot be
+    /// stored but can be freely copied and dropped.
+    //
+    /// TODO: remove `drop` on `Content` here and elsewhere once we have phantom type parameters.
+    struct ReadCap<Content: store + drop> has copy, drop {
+        vault_address: address,
+        authority: address
+    }
+
+    /// A capability to modify the content of the vault.
+    struct ModifyCap<Content: store + drop> has copy, drop {
+        vault_address: address,
+        authority: address
+    }
+
+    /// A capability to delegate access to the vault.
+    struct DelegateCap<Content: store + drop> has copy, drop {
+        vault_address: address,
+        authority: address
+    }
+
+    /// A capability to transfer ownership of the vault.
+    struct TransferCap<Content: store + drop> has copy, drop {
+        vault_address: address,
+        authority: address
+    }
+
+    /// A type describing a capability. This is used for functions like `Self::delegate` where we need to
+    /// specify capability types.
+    struct CapType has copy, drop, store { code: u8 }
+
+    /// Creates a read capability type.
+    public fun read_cap_type(): CapType { CapType{ code : 0 } }
+
+    /// Creates a modify  capability type.
+    public fun modify_cap_type(): CapType { CapType{ code : 1 } }
+
+    /// Creates a delegate  capability type.
+    public fun delegate_cap_type(): CapType { CapType{ code : 2 } }
+
+    /// Creates a transfer  capability type.
+    public fun transfer_cap_type(): CapType { CapType{ code : 3 } }
+
+    // ================================================================================================================
+    // Events
+
+    /// An event which we generate on vault access delegation or revocation if event generation is enabled.
+    struct VaultDelegateEvent has store, drop {
+        metadata: vector<u8>,
+        vault_address: address,
+        authority: address,
+        delegate: address,
+        cap: CapType,
+        is_revoked: bool,
+    }
+
+    /// An event which we generate on vault transfer if event generation is enabled.
+    struct VaultTransferEvent has store, drop {
+        metadata: vector<u8>,
+        vault_address: address,
+        authority: address,
+        new_vault_address: address,
+    }
+
+    // ================================================================================================================
+    // Representation
+
+    /// Private. The vault representation.
+    struct Vault<Content: store> has key {
+        /// The content. If the option is empty, the content is currently moved into an
+        /// accessor in order to work with it.
+        content: Option::Option<Content>,
+    }
+
+    /// Private. If the vault supports delegation, information about the delegates.
+    struct VaultDelegates<Content: store> has key {
+         /// The currently authorized delegates.
+        delegates: vector<address>,
+    }
+
+    /// Private. If event generation is enabled, contains the event generators.
+    struct VaultEvents<Content: store> has key {
+        /// Metadata which identifies this vault. This information is used
+        /// in events generated by this module.
+        metadata: vector<u8>,
+        /// Event handle for vault delegation.
+        delegate_events: Event::EventHandle<VaultDelegateEvent>,
+        /// Event handle for vault transfer.
+        transfer_events: Event::EventHandle<VaultTransferEvent>,
+    }
+
+    /// Private. A value stored at a delegates address pointing to the owner of the vault. Also
+    /// describes the capabilities granted to this delegate.
+    struct VaultDelegate<Content: store> has key {
+        vault_address: address,
+        granted_caps: vector<CapType>,
+    }
+
+    // ================================================================================================================
+    // Vault Creation and Removal
+
+    /// Creates new vault for the given signer. The vault is populated with the `initial_content`.
+    public fun new<Content: store>(owner: &signer,  initial_content: Content) {
+        let addr = Signer::address_of(owner);
+        assert(!exists<Vault<Content>>(addr), Errors::already_published(EVAULT));
+        move_to<Vault<Content>>(
+            owner,
+            Vault{
+                content: Option::some(initial_content)
+            }
+        )
+    }
+
+    /// Enables delegation functionality for this vault. By default, vaults to not support delegation.
+    public fun enable_delegation<Content: store>(owner: &signer) {
+        let addr = Signer::address_of(owner);
+        assert(exists<Vault<Content>>(addr), Errors::not_published(EVAULT));
+        assert(!exists<VaultDelegates<Content>>(addr), Errors::already_published(EDELEGATE));
+        move_to<VaultDelegates<Content>>(owner, VaultDelegates{delegates: Vector::empty()})
+    }
+
+    /// Enables event generation for this vault. This passed metadata is used to identify
+    /// the vault in events.
+    public fun enable_events<Content: store>(owner: &signer, metadata: vector<u8>) {
+        let addr = Signer::address_of(owner);
+        assert(exists<Vault<Content>>(addr), Errors::not_published(EVAULT));
+        assert(!exists<VaultEvents<Content>>(addr), Errors::already_published(EEVENT));
+        move_to<VaultEvents<Content>>(
+            owner,
+            VaultEvents{
+                metadata,
+                delegate_events: Event::new_event_handle<VaultDelegateEvent>(owner),
+                transfer_events: Event::new_event_handle<VaultTransferEvent>(owner),
+            }
+        );
+    }
+
+    /// Removes a vault and all its associated data, returning the current content. In order for
+    /// this to succeed, there must be no active accessor for the vault.
+    public fun remove_vault<Content: store + drop>(owner: &signer): Content
+    acquires Vault, VaultDelegates, VaultDelegate, VaultEvents {
+        let addr = Signer::address_of(owner);
+        assert(exists<Vault<Content>>(addr), Errors::not_published(EVAULT));
+        let Vault{content} = move_from<Vault<Content>>(addr);
+        assert(Option::is_some(&content), Errors::invalid_state(EACCESSOR_IN_USE));
+
+        if (exists<VaultDelegates<Content>>(addr)) {
+            let delegate_cap = DelegateCap<Content>{vault_address: addr, authority: addr};
+            revoke_all(&delegate_cap);
+        };
+        if (exists<VaultEvents<Content>>(addr)) {
+            let VaultEvents{metadata: _metadata, delegate_events, transfer_events} =
+                move_from<VaultEvents<Content>>(addr);
+            Event::destroy_handle(delegate_events);
+            Event::destroy_handle(transfer_events);
+        };
+
+        Option::extract(&mut content)
+    }
+
+    // ================================================================================================================
+    // Acquiring Capabilities
+
+    /// Acquires the capability to read the vault. The passed signer must either be the owner
+    /// of the vault or a delegate with appropriate access.
+    public fun acquire_read_cap<Content: store + drop>(requester: &signer): ReadCap<Content>
+    acquires VaultDelegate {
+        let (vault_address, authority) = validate_cap<Content>(requester, read_cap_type());
+        ReadCap{ vault_address, authority }
+    }
+
+    /// Acquires the capability to modify the vault. The passed signer must either be the owner
+    /// of the vault or a delegate with appropriate access.
+    public fun acquire_modify_cap<Content: store + drop>(requester: &signer): ModifyCap<Content>
+    acquires VaultDelegate {
+        let (vault_address, authority) = validate_cap<Content>(requester, modify_cap_type());
+        ModifyCap{ vault_address, authority }
+    }
+
+    /// Acquires the capability to delegate access to the vault. The passed signer must either be the owner
+    /// of the vault or a delegate with appropriate access.
+    public fun acquire_delegate_cap<Content: store + drop>(requester: &signer): DelegateCap<Content>
+    acquires VaultDelegate {
+        let (vault_address, authority) = validate_cap<Content>(requester, delegate_cap_type());
+        DelegateCap{ vault_address, authority }
+    }
+
+    /// Acquires the capability to transfer the vault. The passed signer must either be the owner
+    /// of the vault or a delegate with appropriate access.
+    public fun acquire_transfer_cap<Content: store + drop>(requester: &signer): TransferCap<Content>
+    acquires VaultDelegate {
+        let (vault_address, authority) = validate_cap<Content>(requester, transfer_cap_type());
+        TransferCap{ vault_address, authority }
+    }
+
+    /// Private. Validates whether a capability can be acquired by the given signer. Returns the
+    /// pair of the vault address and the used authority.
+    fun validate_cap<Content: store + drop>(requester: &signer, cap: CapType): (address, address)
+    acquires VaultDelegate {
+        let addr = Signer::address_of(requester);
+        if (exists<VaultDelegate<Content>>(addr)) {
+            // The signer is a delegate. Check it's granted capabilities.
+            let delegate = borrow_global<VaultDelegate<Content>>(addr);
+            assert(Vector::contains(&delegate.granted_caps, &cap), Errors::requires_capability(EDELEGATE));
+            (delegate.vault_address, addr)
+        } else {
+            // If it is not a delegate, it must be the owner to succeed.
+            assert(exists<Vault<Content>>(addr), Errors::not_published(EVAULT));
+            (addr, addr)
+        }
+    }
+
+
+    // ================================================================================================================
+    // Read Accessor
+
+    /// A read accessor for the content of the vault.
+    struct ReadAccessor<Content: store + drop> {
+        content: Content,
+        vault_address: address,
+    }
+
+    /// Creates a read accessor for the content in the vault based on a read capability.
+    ///
+    /// Only one accessor (whether read or modify) for the same vault can exist at a time, and this
+    /// function will abort if one is in use. An accessor must be explicitly released using
+    /// `Self::release_read_accessor`.
+    public fun read_accessor<Content: store + drop>(cap: &ReadCap<Content>): ReadAccessor<Content>
+    acquires Vault {
+        let content = &mut borrow_global_mut<Vault<Content>>(cap.vault_address).content;
+        assert(Option::is_some(content), Errors::invalid_state(EACCESSOR_IN_USE));
+        ReadAccessor{ vault_address: cap.vault_address, content: Option::extract(content) }
+    }
+
+    /// Returns a reference to the content represented by a read accessor.
+    public fun borrow<Content: store + drop>(accessor: &ReadAccessor<Content>): &Content {
+        &accessor.content
+    }
+
+    /// Releases read accessor.
+    public fun release_read_accessor<Content: store + drop>(accessor: ReadAccessor<Content>)
+    acquires Vault {
+        let ReadAccessor{ content: new_content, vault_address } = accessor;
+        let content = &mut borrow_global_mut<Vault<Content>>(vault_address).content;
+        // We (should be/are) able to prove that the below cannot happen, but we leave the assertion
+        // here anyway for double safety.
+        assert(Option::is_none(content), Errors::internal(EACCESSOR_INCONSISTENCY));
+        Option::fill(content, new_content);
+    }
+
+    // ================================================================================================================
+    // Modify Accessor
+
+    /// A modify accessor for the content of the vault.
+    struct ModifyAccessor<Content: store + drop> {
+        content: Content,
+        vault_address: address,
+    }
+
+    /// Creates a modify accessor for the content in the vault based on a modify capability. This
+    /// is similar like `Self::read_accessor` but the returned accessor will allow to mutate
+    /// the content.
+    public fun modify_accessor<Content: store + drop>(cap: &ModifyCap<Content>): ModifyAccessor<Content>
+    acquires Vault {
+        let content = &mut borrow_global_mut<Vault<Content>>(cap.vault_address).content;
+        assert(Option::is_some(content), Errors::invalid_state(EACCESSOR_IN_USE));
+        ModifyAccessor{ vault_address: cap.vault_address, content: Option::extract(content) }
+    }
+
+    /// Returns a mutable reference to the content represented by a modify accessor.
+    public fun borrow_mut<Content: store + drop>(accessor: &mut ModifyAccessor<Content>): &mut Content {
+        &mut accessor.content
+    }
+
+    /// Releases a modify accessor. This will ensure that any modifications are written back
+    /// to the vault.
+    public fun release_modify_accessor<Content: store + drop>(accessor: ModifyAccessor<Content>)
+    acquires Vault {
+        let ModifyAccessor{ content: new_content, vault_address } = accessor;
+        let content = &mut borrow_global_mut<Vault<Content>>(vault_address).content;
+        // We (should be/are) able to prove that the below cannot happen, but we leave the assertion
+        // here anyway for double safety.
+        assert(Option::is_none(content), Errors::internal(EACCESSOR_INCONSISTENCY));
+        Option::fill(content, new_content);
+    }
+
+
+    // ================================================================================================================
+    // Delegation
+
+    /// Delegates the right to acquire a capability of the given type. Delegation must have been enabled
+    /// during vault creation for this to succeed.
+    public fun delegate<Content: store + drop>(cap: &DelegateCap<Content>, to_signer: &signer, cap_type: CapType)
+    acquires VaultDelegates, VaultDelegate, VaultEvents {
+        assert(
+            exists<VaultDelegates<Content>>(cap.vault_address),
+            Errors::invalid_state(EDELEGATION_NOT_ENABLED)
+        );
+
+        let addr = Signer::address_of(to_signer);
+        assert(addr != cap.vault_address, Errors::invalid_argument(EDELEGATE_TO_SELF));
+
+        if (!exists<VaultDelegate<Content>>(addr)) {
+            // Create VaultDelegate if it is not yet existing.
+            move_to<VaultDelegate<Content>>(
+                to_signer,
+                VaultDelegate{vault_address: cap.vault_address, granted_caps: Vector::empty()}
+            );
+            // Add the the delegate to VaultDelegates.
+            let vault_delegates = borrow_global_mut<VaultDelegates<Content>>(cap.vault_address);
+            add_element(&mut vault_delegates.delegates, addr);
+        };
+
+        // Grant the capability.
+        let delegate = borrow_global_mut<VaultDelegate<Content>>(addr);
+        add_element(&mut delegate.granted_caps, *&cap_type);
+
+        // Generate event
+        emit_delegate_event(cap, cap_type, addr, false);
+    }
+
+    /// Revokes the delegated right to acquire a capability of given type.
+    public fun revoke<Content: store + drop>(cap: &DelegateCap<Content>, addr: address, cap_type: CapType)
+    acquires VaultDelegates, VaultDelegate, VaultEvents {
+        assert(
+            exists<VaultDelegates<Content>>(cap.vault_address),
+            Errors::invalid_state(EDELEGATION_NOT_ENABLED)
+        );
+        assert(exists<VaultDelegate<Content>>(addr), Errors::not_published(EDELEGATE));
+
+        let delegate = borrow_global_mut<VaultDelegate<Content>>(addr);
+        remove_element(&mut delegate.granted_caps, &cap_type);
+
+        // If the granted caps of this delegate drop to zero, remove it.
+        if (Vector::is_empty(&delegate.granted_caps)) {
+            let VaultDelegate{ vault_address: _owner, granted_caps: _granted_caps} =
+                move_from<VaultDelegate<Content>>(addr);
+            let vault_delegates = borrow_global_mut<VaultDelegates<Content>>(cap.vault_address);
+            remove_element(&mut vault_delegates.delegates, &addr);
+        };
+
+        // Generate event.
+        emit_delegate_event(cap, cap_type, addr, true);
+    }
+
+    /// Revokes all delegate rights for this vault.
+    public fun revoke_all<Content: store + drop>(cap: &DelegateCap<Content>)
+    acquires VaultDelegates, VaultDelegate, VaultEvents {
+        assert(
+            exists<VaultDelegates<Content>>(cap.vault_address),
+            Errors::invalid_state(EDELEGATION_NOT_ENABLED)
+        );
+        let delegates = &mut borrow_global_mut<VaultDelegates<Content>>(cap.vault_address).delegates;
+        while (!Vector::is_empty(delegates)) {
+            let addr = Vector::pop_back(delegates);
+            let VaultDelegate{ vault_address: _vault_address, granted_caps} =
+                move_from<VaultDelegate<Content>>(cap.vault_address);
+            while (!Vector::is_empty(&granted_caps)) {
+                let cap_type = Vector::pop_back(&mut granted_caps);
+                emit_delegate_event(cap, cap_type, addr, true);
+            }
+        }
+    }
+
+    /// Helper to remove an element from a vector.
+    fun remove_element<E: drop>(v: &mut vector<E>, x: &E) {
+        let (found, index) = Vector::index_of(v, x);
+        if (found) {
+            Vector::remove(v, index);
+        }
+    }
+
+    /// Helper to add an element to a vector.
+    fun add_element<E: drop>(v: &mut vector<E>, x: E) {
+        if (!Vector::contains(v, &x)) {
+            Vector::push_back(v, x)
+        }
+    }
+
+    /// Emits a delegation or revocation event if event generation is enabled.
+    fun emit_delegate_event<Content: store + drop>(
+           cap: &DelegateCap<Content>,
+           cap_type: CapType,
+           delegate: address,
+           is_revoked: bool
+    ) acquires VaultEvents {
+        if (exists<VaultEvents<Content>>(cap.vault_address)) {
+            let event = VaultDelegateEvent{
+                metadata: *&borrow_global<VaultEvents<Content>>(cap.vault_address).metadata,
+                vault_address: cap.vault_address,
+                authority: cap.authority,
+                delegate,
+                cap: cap_type,
+                is_revoked
+            };
+            Event::emit_event(&mut borrow_global_mut<VaultEvents<Content>>(cap.vault_address).delegate_events, event);
+        }
+    }
+
+    // ================================================================================================================
+    // Transfer
+
+    /// Transfers ownership of the vault to a new signer. All delegations are revoked before transfer,
+    /// and the new owner must re-create delegates as needed.
+    public fun transfer<Content: store + drop>(cap: &TransferCap<Content>, to_owner: &signer)
+    acquires Vault, VaultEvents, VaultDelegate, VaultDelegates {
+        let new_addr = Signer::address_of(to_owner);
+        assert(!exists<Vault<Content>>(new_addr), Errors::already_published(EVAULT));
+        assert(
+            Option::is_some(&borrow_global<Vault<Content>>(cap.vault_address).content),
+            Errors::invalid_state(EACCESSOR_IN_USE)
+        );
+
+        // Revoke all delegates.
+        if (exists<VaultDelegates<Content>>(cap.vault_address)) {
+            let delegate_cap = DelegateCap<Content>{vault_address: cap.vault_address, authority: cap.authority };
+            revoke_all(&delegate_cap);
+        };
+
+        // Emit event if event generation is enabled. We emit the event on the old vault not the new one.
+        if (exists<VaultEvents<Content>>(cap.vault_address)) {
+            let event = VaultTransferEvent {
+                metadata: *&borrow_global<VaultEvents<Content>>(cap.vault_address).metadata,
+                vault_address: cap.vault_address,
+                authority: cap.authority,
+                new_vault_address: new_addr
+            };
+            Event::emit_event(&mut borrow_global_mut<VaultEvents<Content>>(cap.vault_address).transfer_events, event);
+        };
+
+        // Move the vault.
+        move_to<Vault<Content>>(to_owner, move_from<Vault<Content>>(cap.vault_address));
+    }
+}

--- a/language/move-stdlib/nursery/docs/BitVector.md
+++ b/language/move-stdlib/nursery/docs/BitVector.md
@@ -1,0 +1,273 @@
+
+<a name="0x1_BitVector"></a>
+
+# Module `0x1::BitVector`
+
+
+
+-  [Struct `BitVector`](#0x1_BitVector_BitVector)
+-  [Constants](#@Constants_0)
+-  [Function `new`](#0x1_BitVector_new)
+-  [Function `set`](#0x1_BitVector_set)
+-  [Function `unset`](#0x1_BitVector_unset)
+-  [Function `shift_left`](#0x1_BitVector_shift_left)
+-  [Function `is_index_set`](#0x1_BitVector_is_index_set)
+-  [Function `bit_index`](#0x1_BitVector_bit_index)
+-  [Module Specification](#@Module_Specification_1)
+
+
+<pre><code><b>use</b> <a href="">0x1::Vector</a>;
+</code></pre>
+
+
+
+<a name="0x1_BitVector_BitVector"></a>
+
+## Struct `BitVector`
+
+
+
+<pre><code><b>struct</b> <a href="BitVector.md#0x1_BitVector">BitVector</a> has <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>length: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>bit_field: vector&lt;u64&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x1_BitVector_EINDEX"></a>
+
+The provided index is out of bounds
+
+
+<pre><code><b>const</b> <a href="BitVector.md#0x1_BitVector_EINDEX">EINDEX</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_BitVector_WORD_SIZE"></a>
+
+
+
+<pre><code><b>const</b> <a href="BitVector.md#0x1_BitVector_WORD_SIZE">WORD_SIZE</a>: u64 = 64;
+</code></pre>
+
+
+
+<a name="0x1_BitVector_new"></a>
+
+## Function `new`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="BitVector.md#0x1_BitVector_new">new</a>(length: u64): <a href="BitVector.md#0x1_BitVector_BitVector">BitVector::BitVector</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="BitVector.md#0x1_BitVector_new">new</a>(length: u64): <a href="BitVector.md#0x1_BitVector">BitVector</a> {
+    <b>let</b> num_words = (length + (<a href="BitVector.md#0x1_BitVector_WORD_SIZE">WORD_SIZE</a> - 1)) /  <a href="BitVector.md#0x1_BitVector_WORD_SIZE">WORD_SIZE</a>;
+    <b>let</b> bit_field = <a href="_empty">Vector::empty</a>();
+    <b>while</b> (num_words &gt; 0) {
+        <a href="_push_back">Vector::push_back</a>(&<b>mut</b> bit_field, 0u64);
+        num_words = num_words - 1;
+    };
+
+    <a href="BitVector.md#0x1_BitVector">BitVector</a> {
+        length,
+        bit_field,
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_BitVector_set"></a>
+
+## Function `set`
+
+Set the bit at <code>bit_index</code> in the <code>bitvector</code> regardless of its previous state.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="BitVector.md#0x1_BitVector_set">set</a>(bitvector: &<b>mut</b> <a href="BitVector.md#0x1_BitVector_BitVector">BitVector::BitVector</a>, bit_index: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="BitVector.md#0x1_BitVector_set">set</a>(bitvector: &<b>mut</b> <a href="BitVector.md#0x1_BitVector">BitVector</a>, bit_index: u64) {
+    <b>assert</b>(<a href="BitVector.md#0x1_BitVector_bit_index">bit_index</a> &lt; bitvector.length, <a href="BitVector.md#0x1_BitVector_EINDEX">EINDEX</a>);
+    <b>let</b> (inner_index, inner) = <a href="BitVector.md#0x1_BitVector_bit_index">bit_index</a>(bitvector, bit_index);
+    *inner = *inner | 1u64 &lt;&lt; (inner_index <b>as</b> u8);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_BitVector_unset"></a>
+
+## Function `unset`
+
+Unset the bit at <code>bit_index</code> in the <code>bitvector</code> regardless of its previous state.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="BitVector.md#0x1_BitVector_unset">unset</a>(bitvector: &<b>mut</b> <a href="BitVector.md#0x1_BitVector_BitVector">BitVector::BitVector</a>, bit_index: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="BitVector.md#0x1_BitVector_unset">unset</a>(bitvector: &<b>mut</b> <a href="BitVector.md#0x1_BitVector">BitVector</a>, bit_index: u64) {
+    <b>assert</b>(<a href="BitVector.md#0x1_BitVector_bit_index">bit_index</a> &lt; bitvector.length, <a href="BitVector.md#0x1_BitVector_EINDEX">EINDEX</a>);
+    <b>let</b> (inner_index, inner) = <a href="BitVector.md#0x1_BitVector_bit_index">bit_index</a>(bitvector, bit_index);
+    // Having negation would be nice here...
+    *inner = *inner ^ (*inner & (1u64 &lt;&lt; (inner_index <b>as</b> u8)));
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_BitVector_shift_left"></a>
+
+## Function `shift_left`
+
+Shift the <code>bitvector</code> left by <code>amount</code>, <code>amount</code> must be less than the
+bitvector's length.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="BitVector.md#0x1_BitVector_shift_left">shift_left</a>(bitvector: &<b>mut</b> <a href="BitVector.md#0x1_BitVector_BitVector">BitVector::BitVector</a>, amount: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="BitVector.md#0x1_BitVector_shift_left">shift_left</a>(bitvector: &<b>mut</b> <a href="BitVector.md#0x1_BitVector">BitVector</a>, amount: u64) {
+    <b>assert</b>(amount &lt; bitvector.length, <a href="BitVector.md#0x1_BitVector_EINDEX">EINDEX</a>);
+    <b>let</b> i = amount;
+
+    <b>while</b> (i &lt; bitvector.length) {
+        <b>if</b> (<a href="BitVector.md#0x1_BitVector_is_index_set">is_index_set</a>(bitvector, i)) <a href="BitVector.md#0x1_BitVector_set">set</a>(bitvector, i - amount)
+        <b>else</b> <a href="BitVector.md#0x1_BitVector_unset">unset</a>(bitvector, i - amount);
+        i = i + 1;
+    };
+
+    i = bitvector.length - amount;
+
+    <b>while</b> (i &lt; bitvector.length) {
+        <a href="BitVector.md#0x1_BitVector_unset">unset</a>(bitvector, i);
+        i = i + 1;
+    };
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_BitVector_is_index_set"></a>
+
+## Function `is_index_set`
+
+Return the value of the bit at <code>bit_index</code> in the <code>bitvector</code>. <code><b>true</b></code>
+represents "1" and <code><b>false</b></code> represents a 0
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="BitVector.md#0x1_BitVector_is_index_set">is_index_set</a>(bitvector: &<a href="BitVector.md#0x1_BitVector_BitVector">BitVector::BitVector</a>, bit_index: u64): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="BitVector.md#0x1_BitVector_is_index_set">is_index_set</a>(bitvector: &<a href="BitVector.md#0x1_BitVector">BitVector</a>, bit_index: u64): bool {
+    <b>assert</b>(<a href="BitVector.md#0x1_BitVector_bit_index">bit_index</a> &lt; bitvector.length, <a href="BitVector.md#0x1_BitVector_EINDEX">EINDEX</a>);
+    <b>let</b> inner = <a href="_borrow">Vector::borrow</a>(&bitvector.bit_field, bit_index / <a href="BitVector.md#0x1_BitVector_WORD_SIZE">WORD_SIZE</a>);
+    <b>let</b> inner_index = bit_index % <a href="BitVector.md#0x1_BitVector_WORD_SIZE">WORD_SIZE</a>;
+    *inner & (1 &lt;&lt; (inner_index <b>as</b> u8)) != 0
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_BitVector_bit_index"></a>
+
+## Function `bit_index`
+
+Return the larger containing u64, and the bit index within that u64
+for <code>index</code> w.r.t. <code>bitvector</code>.
+
+
+<pre><code><b>fun</b> <a href="BitVector.md#0x1_BitVector_bit_index">bit_index</a>(bitvector: &<b>mut</b> <a href="BitVector.md#0x1_BitVector_BitVector">BitVector::BitVector</a>, index: u64): (u64, &<b>mut</b> u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="BitVector.md#0x1_BitVector_bit_index">bit_index</a>(bitvector: &<b>mut</b> <a href="BitVector.md#0x1_BitVector">BitVector</a>, index: u64): (u64, &<b>mut</b> u64) {
+    <b>assert</b>(index &lt; bitvector.length, <a href="BitVector.md#0x1_BitVector_EINDEX">EINDEX</a>);
+    (index % <a href="BitVector.md#0x1_BitVector_WORD_SIZE">WORD_SIZE</a>, <a href="_borrow_mut">Vector::borrow_mut</a>(&<b>mut</b> bitvector.bit_field, index / <a href="BitVector.md#0x1_BitVector_WORD_SIZE">WORD_SIZE</a>))
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="@Module_Specification_1"></a>
+
+## Module Specification
+
+
+
+<pre><code><b>pragma</b> verify = <b>false</b>;
+</code></pre>

--- a/language/move-stdlib/nursery/docs/Compare.md
+++ b/language/move-stdlib/nursery/docs/Compare.md
@@ -1,0 +1,172 @@
+
+<a name="0x1_Compare"></a>
+
+# Module `0x1::Compare`
+
+Utilities for comparing Move values based on their representation in BCS.
+
+
+-  [Constants](#@Constants_0)
+-  [Function `cmp_bcs_bytes`](#0x1_Compare_cmp_bcs_bytes)
+-  [Function `cmp_u8`](#0x1_Compare_cmp_u8)
+-  [Function `cmp_u64`](#0x1_Compare_cmp_u64)
+
+
+<pre><code><b>use</b> <a href="">0x1::Vector</a>;
+</code></pre>
+
+
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x1_Compare_EQUAL"></a>
+
+
+
+<pre><code><b>const</b> <a href="Compare.md#0x1_Compare_EQUAL">EQUAL</a>: u8 = 0;
+</code></pre>
+
+
+
+<a name="0x1_Compare_GREATER_THAN"></a>
+
+
+
+<pre><code><b>const</b> <a href="Compare.md#0x1_Compare_GREATER_THAN">GREATER_THAN</a>: u8 = 2;
+</code></pre>
+
+
+
+<a name="0x1_Compare_LESS_THAN"></a>
+
+
+
+<pre><code><b>const</b> <a href="Compare.md#0x1_Compare_LESS_THAN">LESS_THAN</a>: u8 = 1;
+</code></pre>
+
+
+
+<a name="0x1_Compare_cmp_bcs_bytes"></a>
+
+## Function `cmp_bcs_bytes`
+
+Compare vectors <code>v1</code> and <code>v2</code> using (1) vector contents from right to left and then
+(2) vector length to break ties.
+Returns either <code><a href="Compare.md#0x1_Compare_EQUAL">EQUAL</a></code> (0u8), <code><a href="Compare.md#0x1_Compare_LESS_THAN">LESS_THAN</a></code> (1u8), or <code><a href="Compare.md#0x1_Compare_GREATER_THAN">GREATER_THAN</a></code> (2u8).
+
+This function is designed to compare BCS (Binary Canonical Serialization)-encoded values
+(i.e., vectors produced by <code><a href="_to_bytes">BCS::to_bytes</a></code>). A typical client will call
+<code><a href="Compare.md#0x1_Compare_cmp_bcs_bytes">Compare::cmp_bcs_bytes</a>(<a href="_to_bytes">BCS::to_bytes</a>(&t1), <a href="_to_bytes">BCS::to_bytes</a>(&t2))</code>. The comparison provides the
+following guarantees w.r.t the original values t1 and t2:
+- <code><a href="Compare.md#0x1_Compare_cmp_bcs_bytes">cmp_bcs_bytes</a>(bcs(t1), bcs(t2)) == <a href="Compare.md#0x1_Compare_LESS_THAN">LESS_THAN</a></code> iff <code><a href="Compare.md#0x1_Compare_cmp_bcs_bytes">cmp_bcs_bytes</a>(t2, t1) == <a href="Compare.md#0x1_Compare_GREATER_THAN">GREATER_THAN</a></code>
+- <code>Compare::cmp&lt;T&gt;(t1, t2) == <a href="Compare.md#0x1_Compare_EQUAL">EQUAL</a></code> iff <code>t1 == t2</code> and (similarly)
+<code>Compare::cmp&lt;T&gt;(t1, t2) != <a href="Compare.md#0x1_Compare_EQUAL">EQUAL</a></code> iff <code>t1 != t2</code>, where <code>==</code> and <code>!=</code> denote the Move
+bytecode operations for polymorphic equality.
+- for all primitive types <code>T</code> with <code>&lt;</code> and <code>&gt;</code> comparison operators exposed in Move bytecode
+(<code>u8</code>, <code>u64</code>, <code>u128</code>), we have
+<code>compare_bcs_bytes(bcs(t1), bcs(t2)) == <a href="Compare.md#0x1_Compare_LESS_THAN">LESS_THAN</a></code> iff <code>t1 &lt; t2</code> and (similarly)
+<code>compare_bcs_bytes(bcs(t1), bcs(t2)) == <a href="Compare.md#0x1_Compare_LESS_THAN">LESS_THAN</a></code> iff <code>t1 &gt; t2</code>.
+
+For all other types, the order is whatever the BCS encoding of the type and the comparison
+strategy above gives you. One case where the order might be surprising is the <code>address</code>
+type.
+CoreAddresses are 16 byte hex values that BCS encodes with the identity function. The right
+to left, byte-by-byte comparison means that (for example)
+<code>compare_bcs_bytes(bcs(0x01), bcs(0x10)) == <a href="Compare.md#0x1_Compare_LESS_THAN">LESS_THAN</a></code> (as you'd expect), but
+<code>compare_bcs_bytes(bcs(0x100), bcs(0x001)) == <a href="Compare.md#0x1_Compare_LESS_THAN">LESS_THAN</a></code> (as you probably wouldn't expect).
+Keep this in mind when using this function to compare addresses.
+
+> TODO: there is currently no specification for this function, which causes no problem because it is not yet
+> used in the Diem framework. However, should this functionality be needed in specification, a customized
+> native abstraction is needed in the prover framework.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Compare.md#0x1_Compare_cmp_bcs_bytes">cmp_bcs_bytes</a>(v1: &vector&lt;u8&gt;, v2: &vector&lt;u8&gt;): u8
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Compare.md#0x1_Compare_cmp_bcs_bytes">cmp_bcs_bytes</a>(v1: &vector&lt;u8&gt;, v2: &vector&lt;u8&gt;): u8 {
+    <b>let</b> i1 = <a href="_length">Vector::length</a>(v1);
+    <b>let</b> i2 = <a href="_length">Vector::length</a>(v2);
+    <b>let</b> len_cmp = <a href="Compare.md#0x1_Compare_cmp_u64">cmp_u64</a>(i1, i2);
+
+    // <a href="">BCS</a> uses little endian encoding for all integer types, so we choose <b>to</b> compare from left
+    // <b>to</b> right. Going right <b>to</b> left would make the behavior of <a href="Compare.md#0x1_Compare">Compare</a>.cmp diverge from the
+    // bytecode operators &lt; and &gt; on integer values (which would be confusing).
+    <b>while</b> (i1 &gt; 0 && i2 &gt; 0) {
+        i1 = i1 - 1;
+        i2 = i2 - 1;
+        <b>let</b> elem_cmp = <a href="Compare.md#0x1_Compare_cmp_u8">cmp_u8</a>(*<a href="_borrow">Vector::borrow</a>(v1, i1), *<a href="_borrow">Vector::borrow</a>(v2, i2));
+        <b>if</b> (elem_cmp != 0) <b>return</b> elem_cmp
+        // <b>else</b>, compare next element
+    };
+    // all compared elements equal; <b>use</b> length comparion <b>to</b> <b>break</b> the tie
+    len_cmp
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Compare_cmp_u8"></a>
+
+## Function `cmp_u8`
+
+Compare two <code>u8</code>'s
+
+
+<pre><code><b>fun</b> <a href="Compare.md#0x1_Compare_cmp_u8">cmp_u8</a>(i1: u8, i2: u8): u8
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="Compare.md#0x1_Compare_cmp_u8">cmp_u8</a>(i1: u8, i2: u8): u8 {
+    <b>if</b> (i1 == i2) <a href="Compare.md#0x1_Compare_EQUAL">EQUAL</a>
+    <b>else</b> <b>if</b> (i1 &lt; i2) <a href="Compare.md#0x1_Compare_LESS_THAN">LESS_THAN</a>
+    <b>else</b> <a href="Compare.md#0x1_Compare_GREATER_THAN">GREATER_THAN</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Compare_cmp_u64"></a>
+
+## Function `cmp_u64`
+
+Compare two <code>u64</code>'s
+
+
+<pre><code><b>fun</b> <a href="Compare.md#0x1_Compare_cmp_u64">cmp_u64</a>(i1: u64, i2: u64): u8
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="Compare.md#0x1_Compare_cmp_u64">cmp_u64</a>(i1: u64, i2: u64): u8 {
+    <b>if</b> (i1 == i2) <a href="Compare.md#0x1_Compare_EQUAL">EQUAL</a>
+    <b>else</b> <b>if</b> (i1 &lt; i2) <a href="Compare.md#0x1_Compare_LESS_THAN">LESS_THAN</a>
+    <b>else</b> <a href="Compare.md#0x1_Compare_GREATER_THAN">GREATER_THAN</a>
+}
+</code></pre>
+
+
+
+</details>

--- a/language/move-stdlib/nursery/docs/Debug.md
+++ b/language/move-stdlib/nursery/docs/Debug.md
@@ -1,0 +1,59 @@
+
+<a name="0x1_Debug"></a>
+
+# Module `0x1::Debug`
+
+Module providing debug functionality.
+
+
+-  [Function `print`](#0x1_Debug_print)
+-  [Function `print_stack_trace`](#0x1_Debug_print_stack_trace)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="0x1_Debug_print"></a>
+
+## Function `print`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Debug.md#0x1_Debug_print">print</a>&lt;T&gt;(x: &T)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="Debug.md#0x1_Debug_print">print</a>&lt;T&gt;(x: &T);
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Debug_print_stack_trace"></a>
+
+## Function `print_stack_trace`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Debug.md#0x1_Debug_print_stack_trace">print_stack_trace</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="Debug.md#0x1_Debug_print_stack_trace">print_stack_trace</a>();
+</code></pre>
+
+
+
+</details>

--- a/language/move-stdlib/nursery/docs/Offer.md
+++ b/language/move-stdlib/nursery/docs/Offer.md
@@ -1,0 +1,374 @@
+
+<a name="0x1_Offer"></a>
+
+# Module `0x1::Offer`
+
+Provides a way to transfer structs from one account to another in two transactions.
+Unlike many languages, Move cannot move data from one account to another with
+single-signer transactions. As of this writing, ordinary transactions can only have
+a single signer, and Move code can only store to an address (via <code>move_to</code>) if it
+can supply a reference to a signer for the destination address (there are special case
+exceptions in Genesis and DiemAccount where there can temporarily be multiple signers).
+
+Offer solves this problem by providing an <code><a href="Offer.md#0x1_Offer">Offer</a></code> resource.  To move a struct <code>T</code> from
+account A to B, account A first publishes an <code><a href="Offer.md#0x1_Offer">Offer</a>&lt;T&gt;</code> resource at <code><a href="Offer.md#0x1_Offer_address_of">address_of</a>(A)</code>,
+using the <code><a href="Offer.md#0x1_Offer_create">Offer::create</a></code> function.
+Then account B, in a separate transaction, can move the struct <code>T</code> from the <code><a href="Offer.md#0x1_Offer">Offer</a></code> at
+A's address to the desired destination. B accesses the resource using the <code>redeem</code> function,
+which aborts unless the <code>for</code> field is B's address (preventing other addresses from
+accessing the <code>T</code> that is intended only for B). A can also redeem the <code>T</code> value if B hasn't
+redeemed it.
+
+
+-  [Resource `Offer`](#0x1_Offer_Offer)
+-  [Constants](#@Constants_0)
+-  [Function `create`](#0x1_Offer_create)
+-  [Function `redeem`](#0x1_Offer_redeem)
+-  [Function `exists_at`](#0x1_Offer_exists_at)
+-  [Function `address_of`](#0x1_Offer_address_of)
+-  [Module Specification](#@Module_Specification_1)
+    -  [Access Control](#@Access_Control_2)
+        -  [Creation of Offers](#@Creation_of_Offers_3)
+        -  [Removal of Offers](#@Removal_of_Offers_4)
+    -  [Helper Functions](#@Helper_Functions_5)
+
+
+<pre><code><b>use</b> <a href="">0x1::Errors</a>;
+<b>use</b> <a href="">0x1::Signer</a>;
+</code></pre>
+
+
+
+<a name="0x1_Offer_Offer"></a>
+
+## Resource `Offer`
+
+A wrapper around value <code>offered</code> that can be claimed by the address stored in <code>for</code>.
+
+
+<pre><code><b>struct</b> <a href="Offer.md#0x1_Offer">Offer</a>&lt;Offered&gt; has key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>offered: Offered</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>for: address</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x1_Offer_EOFFER_ALREADY_CREATED"></a>
+
+Address already has an offer of this type.
+
+
+<pre><code><b>const</b> <a href="Offer.md#0x1_Offer_EOFFER_ALREADY_CREATED">EOFFER_ALREADY_CREATED</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_Offer_EOFFER_DNE_FOR_ACCOUNT"></a>
+
+An offer of the specified type for the account does not exist
+
+
+<pre><code><b>const</b> <a href="Offer.md#0x1_Offer_EOFFER_DNE_FOR_ACCOUNT">EOFFER_DNE_FOR_ACCOUNT</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_Offer_EOFFER_DOES_NOT_EXIST"></a>
+
+Address does not have an offer of this type to redeem.
+
+
+<pre><code><b>const</b> <a href="Offer.md#0x1_Offer_EOFFER_DOES_NOT_EXIST">EOFFER_DOES_NOT_EXIST</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_Offer_create"></a>
+
+## Function `create`
+
+Publish a value of type <code>Offered</code> under the sender's account. The value can be claimed by
+either the <code>for</code> address or the transaction sender.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Offer.md#0x1_Offer_create">create</a>&lt;Offered: store&gt;(account: &signer, offered: Offered, for: address)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Offer.md#0x1_Offer_create">create</a>&lt;Offered: store&gt;(account: &signer, offered: Offered, for: address) {
+  <b>assert</b>(!<b>exists</b>&lt;<a href="Offer.md#0x1_Offer">Offer</a>&lt;Offered&gt;&gt;(<a href="_address_of">Signer::address_of</a>(account)), <a href="_already_published">Errors::already_published</a>(<a href="Offer.md#0x1_Offer_EOFFER_ALREADY_CREATED">EOFFER_ALREADY_CREATED</a>));
+  move_to(account, <a href="Offer.md#0x1_Offer">Offer</a>&lt;Offered&gt; { offered, for });
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+Offer a struct to the account under address <code>for</code> by
+placing the offer under the signer's address
+
+
+<pre><code><b>aborts_if</b> <b>exists</b>&lt;<a href="Offer.md#0x1_Offer">Offer</a>&lt;Offered&gt;&gt;(<a href="_spec_address_of">Signer::spec_address_of</a>(account))
+    <b>with</b> <a href="_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>;
+<b>ensures</b> <b>exists</b>&lt;<a href="Offer.md#0x1_Offer">Offer</a>&lt;Offered&gt;&gt;(<a href="_spec_address_of">Signer::spec_address_of</a>(account));
+<b>ensures</b> <b>global</b>&lt;<a href="Offer.md#0x1_Offer">Offer</a>&lt;Offered&gt;&gt;(<a href="_spec_address_of">Signer::spec_address_of</a>(account)) == <a href="Offer.md#0x1_Offer">Offer</a>&lt;Offered&gt; { offered: offered, for: for };
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Offer_redeem"></a>
+
+## Function `redeem`
+
+Claim the value of type <code>Offered</code> published at <code>offer_address</code>.
+Only succeeds if the sender is the intended recipient stored in <code>for</code> or the original
+publisher <code>offer_address</code>.
+Also fails if there is no <code><a href="Offer.md#0x1_Offer">Offer</a>&lt;Offered&gt;</code> published.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Offer.md#0x1_Offer_redeem">redeem</a>&lt;Offered: store&gt;(account: &signer, offer_address: address): Offered
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Offer.md#0x1_Offer_redeem">redeem</a>&lt;Offered: store&gt;(account: &signer, offer_address: address): Offered <b>acquires</b> <a href="Offer.md#0x1_Offer">Offer</a> {
+  <b>assert</b>(<b>exists</b>&lt;<a href="Offer.md#0x1_Offer">Offer</a>&lt;Offered&gt;&gt;(offer_address), <a href="_not_published">Errors::not_published</a>(<a href="Offer.md#0x1_Offer_EOFFER_DOES_NOT_EXIST">EOFFER_DOES_NOT_EXIST</a>));
+  <b>let</b> <a href="Offer.md#0x1_Offer">Offer</a>&lt;Offered&gt; { offered, for } = move_from&lt;<a href="Offer.md#0x1_Offer">Offer</a>&lt;Offered&gt;&gt;(offer_address);
+  <b>let</b> sender = <a href="_address_of">Signer::address_of</a>(account);
+  <b>assert</b>(sender == for || sender == offer_address, <a href="_invalid_argument">Errors::invalid_argument</a>(<a href="Offer.md#0x1_Offer_EOFFER_DNE_FOR_ACCOUNT">EOFFER_DNE_FOR_ACCOUNT</a>));
+  offered
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+Aborts if there is no offer under <code>offer_address</code> or if the account
+cannot redeem the offer.
+Ensures that the offered struct under <code>offer_address</code> is removed.
+
+
+<pre><code><b>aborts_if</b> !<b>exists</b>&lt;<a href="Offer.md#0x1_Offer">Offer</a>&lt;Offered&gt;&gt;(offer_address)
+    <b>with</b> <a href="_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
+<b>aborts_if</b> !<a href="Offer.md#0x1_Offer_is_allowed_recipient">is_allowed_recipient</a>&lt;Offered&gt;(offer_address, <a href="_spec_address_of">Signer::spec_address_of</a>(account))
+    <b>with</b> <a href="_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
+<b>ensures</b> !<b>exists</b>&lt;<a href="Offer.md#0x1_Offer">Offer</a>&lt;Offered&gt;&gt;(offer_address);
+<b>ensures</b> result == <b>old</b>(<b>global</b>&lt;<a href="Offer.md#0x1_Offer">Offer</a>&lt;Offered&gt;&gt;(offer_address).offered);
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Offer_exists_at"></a>
+
+## Function `exists_at`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Offer.md#0x1_Offer_exists_at">exists_at</a>&lt;Offered: store&gt;(offer_address: address): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Offer.md#0x1_Offer_exists_at">exists_at</a>&lt;Offered: store&gt;(offer_address: address): bool {
+  <b>exists</b>&lt;<a href="Offer.md#0x1_Offer">Offer</a>&lt;Offered&gt;&gt;(offer_address)
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>aborts_if</b> <b>false</b>;
+</code></pre>
+
+
+Returns whether or not an <code><a href="Offer.md#0x1_Offer">Offer</a></code> resource is under the given address <code>offer_address</code>.
+
+
+<pre><code><b>ensures</b> result == <b>exists</b>&lt;<a href="Offer.md#0x1_Offer">Offer</a>&lt;Offered&gt;&gt;(offer_address);
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Offer_address_of"></a>
+
+## Function `address_of`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Offer.md#0x1_Offer_address_of">address_of</a>&lt;Offered: store&gt;(offer_address: address): address
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Offer.md#0x1_Offer_address_of">address_of</a>&lt;Offered: store&gt;(offer_address: address): address <b>acquires</b> <a href="Offer.md#0x1_Offer">Offer</a> {
+  <b>assert</b>(<b>exists</b>&lt;<a href="Offer.md#0x1_Offer">Offer</a>&lt;Offered&gt;&gt;(offer_address), <a href="_not_published">Errors::not_published</a>(<a href="Offer.md#0x1_Offer_EOFFER_DOES_NOT_EXIST">EOFFER_DOES_NOT_EXIST</a>));
+  borrow_global&lt;<a href="Offer.md#0x1_Offer">Offer</a>&lt;Offered&gt;&gt;(offer_address).for
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+Aborts is there is no offer resource <code><a href="Offer.md#0x1_Offer">Offer</a></code> at the <code>offer_address</code>.
+Returns the address of the intended recipient of the Offer
+under the <code>offer_address</code>.
+
+
+<pre><code><b>aborts_if</b> !<b>exists</b>&lt;<a href="Offer.md#0x1_Offer">Offer</a>&lt;Offered&gt;&gt;(offer_address) <b>with</b> <a href="_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
+<b>ensures</b> result == <b>global</b>&lt;<a href="Offer.md#0x1_Offer">Offer</a>&lt;Offered&gt;&gt;(offer_address).for;
+</code></pre>
+
+
+
+</details>
+
+<a name="@Module_Specification_1"></a>
+
+## Module Specification
+
+
+
+<a name="@Access_Control_2"></a>
+
+### Access Control
+
+
+<a name="@Creation_of_Offers_3"></a>
+
+#### Creation of Offers
+
+
+
+<a name="0x1_Offer_NoOfferCreated"></a>
+
+Says no offer is created or any type or address. Later, it is applied to all functions
+except <code>create</code>
+
+
+<pre><code><b>schema</b> <a href="Offer.md#0x1_Offer_NoOfferCreated">NoOfferCreated</a> {
+    <b>ensures</b> <b>forall</b> ty: type, addr: address <b>where</b> !<b>old</b>(<b>exists</b>&lt;<a href="Offer.md#0x1_Offer">Offer</a>&lt;ty&gt;&gt;(addr)) : !<b>exists</b>&lt;<a href="Offer.md#0x1_Offer">Offer</a>&lt;ty&gt;&gt;(addr);
+}
+</code></pre>
+
+
+
+Apply OnlyCreateCanCreateOffer to every function except <code>create</code>
+
+
+<pre><code><b>apply</b> <a href="Offer.md#0x1_Offer_NoOfferCreated">NoOfferCreated</a> <b>to</b> *&lt;Offered&gt;, * <b>except</b> create;
+</code></pre>
+
+
+
+<a name="@Removal_of_Offers_4"></a>
+
+#### Removal of Offers
+
+
+
+<a name="0x1_Offer_NoOfferRemoved"></a>
+
+Says no offer is removed for any type or address. Applied below to everything except <code>redeem</code>
+
+
+<pre><code><b>schema</b> <a href="Offer.md#0x1_Offer_NoOfferRemoved">NoOfferRemoved</a> {
+    <b>ensures</b> <b>forall</b> ty: type, addr: address <b>where</b> <b>old</b>(<b>exists</b>&lt;<a href="Offer.md#0x1_Offer">Offer</a>&lt;ty&gt;&gt;(addr)) :
+              (<b>exists</b>&lt;<a href="Offer.md#0x1_Offer">Offer</a>&lt;ty&gt;&gt;(addr) && <b>global</b>&lt;<a href="Offer.md#0x1_Offer">Offer</a>&lt;ty&gt;&gt;(addr) == <b>old</b>(<b>global</b>&lt;<a href="Offer.md#0x1_Offer">Offer</a>&lt;ty&gt;&gt;(addr)));
+}
+</code></pre>
+
+
+
+Only <code>redeem</code> can remove an offer from the global store.
+
+
+<pre><code><b>apply</b> <a href="Offer.md#0x1_Offer_NoOfferRemoved">NoOfferRemoved</a> <b>to</b> *&lt;Offered&gt;, * <b>except</b> redeem;
+</code></pre>
+
+
+
+<a name="@Helper_Functions_5"></a>
+
+### Helper Functions
+
+
+Returns true if the recipient is allowed to redeem <code><a href="Offer.md#0x1_Offer">Offer</a>&lt;Offered&gt;</code> at <code>offer_address</code>
+and false otherwise.
+
+
+<a name="0x1_Offer_is_allowed_recipient"></a>
+
+
+<pre><code><b>fun</b> <a href="Offer.md#0x1_Offer_is_allowed_recipient">is_allowed_recipient</a>&lt;Offered&gt;(offer_addr: address, recipient: address): bool {
+  recipient == <b>global</b>&lt;<a href="Offer.md#0x1_Offer">Offer</a>&lt;Offered&gt;&gt;(offer_addr).for || recipient == offer_addr
+}
+</code></pre>

--- a/language/move-stdlib/nursery/docs/Vault.md
+++ b/language/move-stdlib/nursery/docs/Vault.md
@@ -1,0 +1,1532 @@
+
+<a name="0x1_Vault"></a>
+
+# Module `0x1::Vault`
+
+A module which implements secure memory (called a *vault*) of some content which can only be operated
+on if authorized by a signer. Authorization is managed by
+[*capabilities*](https://en.wikipedia.org/wiki/Capability-based_security). The vault supports delegation
+of capabilities to other signers (including revocation) as well as transfer of ownership.
+
+
+<a name="@Overview_0"></a>
+
+## Overview
+
+
+
+<a name="@Capabilities_1"></a>
+
+### Capabilities
+
+
+Capabilities are unforgeable tokens which represent the right to perform a particular
+operation on the vault. To acquire a capability instance, authentication via a signer is needed.
+This signer must either be the owner of the vault, or someone the capability has been delegated to.
+Once acquired, a capability can be passed to other functions to perform the operation it enables.
+Specifically, those called functions do not need to have access to the original signer. This is a key
+property of capability based security as it prevents granting more rights to code than needed.
+
+Capability instances are unforgeable because they are localized to transactions. They can only be
+created by functions of this module, and as they do not have the Move language <code>store</code> or <code>key</code> abilities,
+they cannot leak out of a transaction.
+
+Example:
+
+```move
+struct Content has store { ssn: u64 }
+...
+// Create new vault
+Vault::new(signer, b"My Vault", Content{ ssn: 525659745 });
+...
+// Obtain a read capability
+let read_cap = Vault::acquire_read_cap<Content>(signer);
+process(&read_cap)
+...
+fun process(cap: &Vault::ReadCap<Content>) {
+let accessor = Vault::read_accessor(cap);
+let content = Vault::borrow(accessor);
+<< do something with <code>content: &Content</code> >>
+Vault::release_read_accessor(accessor);
+}
+```
+
+
+<a name="@Delegation_2"></a>
+
+### Delegation
+
+
+Delegation provides the option to delegate the right to acquire a vault capability to other
+signers than the owner of the vault. Delegates still need to authenticate themselves using their
+signer, similar as the owner does. All security arguments for owners apply also to delegates.
+Delegation can be revoked removing previously granted rights from a delegate.
+
+Delegation can be configured to be transitive by granting the right to acquire a delegation capability
+to delegates, which can then further delegate access rights.
+
+By default, when a vault is created, it does not support delegation. The owner of the vault
+needs to explicitly enable delegation. This allows to create vaults which are not intended for delegation
+and one does not need to worry about its misuse.
+
+Example:
+
+```move
+Vault::new(signer, b"My Vault", Content{ ssn: 525659745 });
+// Enable delegation for this vault. Only the owning signer can do this.
+Vault::enable_delegation<Content>(signer);
+...
+// Delegate read capability to some other signer.
+let delegate_cap = Vault::acquire_delegate_cap<Content>(signer);
+Vault::delegate_read_cap(&delegate_cap, other_signer);
+...
+// Other signer can now acquire read cap
+let read_cap = Vault::acquire_read_cap<Content>(other_signer);
+...
+// The granted capability can be revoked. There is no need to have the other signer for this.
+Vault::revoke_read_cap(&delegate_cap, Signer::address_of(other_signer));
+```
+
+
+<a name="@Abilities_3"></a>
+
+### Abilities
+
+
+Currently, we require that the <code>Content</code> type of a vault has the <code>drop</code> ability in order to instantiate
+a capability type like <code><a href="Vault.md#0x1_Vault_ReadCap">ReadCap</a>&lt;Content&gt;</code>. Without this, capabilities themselves would need to have an
+explicit release function, which makes little sense as they are pure values. We expect the Move
+language to have 'phantom type parameters' or similar features added, which will allows us to have
+<code><a href="Vault.md#0x1_Vault_ReadCap">ReadCap</a>&lt;Content&gt;</code> droppable and copyable without <code>Content</code> needing the same.
+
+
+-  [Overview](#@Overview_0)
+    -  [Capabilities](#@Capabilities_1)
+    -  [Delegation](#@Delegation_2)
+    -  [Abilities](#@Abilities_3)
+-  [Struct `ReadCap`](#0x1_Vault_ReadCap)
+-  [Struct `ModifyCap`](#0x1_Vault_ModifyCap)
+-  [Struct `DelegateCap`](#0x1_Vault_DelegateCap)
+-  [Struct `TransferCap`](#0x1_Vault_TransferCap)
+-  [Struct `CapType`](#0x1_Vault_CapType)
+-  [Struct `VaultDelegateEvent`](#0x1_Vault_VaultDelegateEvent)
+-  [Struct `VaultTransferEvent`](#0x1_Vault_VaultTransferEvent)
+-  [Resource `Vault`](#0x1_Vault_Vault)
+-  [Resource `VaultDelegates`](#0x1_Vault_VaultDelegates)
+-  [Resource `VaultEvents`](#0x1_Vault_VaultEvents)
+-  [Resource `VaultDelegate`](#0x1_Vault_VaultDelegate)
+-  [Struct `ReadAccessor`](#0x1_Vault_ReadAccessor)
+-  [Struct `ModifyAccessor`](#0x1_Vault_ModifyAccessor)
+-  [Constants](#@Constants_4)
+-  [Function `read_cap_type`](#0x1_Vault_read_cap_type)
+-  [Function `modify_cap_type`](#0x1_Vault_modify_cap_type)
+-  [Function `delegate_cap_type`](#0x1_Vault_delegate_cap_type)
+-  [Function `transfer_cap_type`](#0x1_Vault_transfer_cap_type)
+-  [Function `new`](#0x1_Vault_new)
+-  [Function `enable_delegation`](#0x1_Vault_enable_delegation)
+-  [Function `enable_events`](#0x1_Vault_enable_events)
+-  [Function `remove_vault`](#0x1_Vault_remove_vault)
+-  [Function `acquire_read_cap`](#0x1_Vault_acquire_read_cap)
+-  [Function `acquire_modify_cap`](#0x1_Vault_acquire_modify_cap)
+-  [Function `acquire_delegate_cap`](#0x1_Vault_acquire_delegate_cap)
+-  [Function `acquire_transfer_cap`](#0x1_Vault_acquire_transfer_cap)
+-  [Function `validate_cap`](#0x1_Vault_validate_cap)
+-  [Function `read_accessor`](#0x1_Vault_read_accessor)
+-  [Function `borrow`](#0x1_Vault_borrow)
+-  [Function `release_read_accessor`](#0x1_Vault_release_read_accessor)
+-  [Function `modify_accessor`](#0x1_Vault_modify_accessor)
+-  [Function `borrow_mut`](#0x1_Vault_borrow_mut)
+-  [Function `release_modify_accessor`](#0x1_Vault_release_modify_accessor)
+-  [Function `delegate`](#0x1_Vault_delegate)
+-  [Function `revoke`](#0x1_Vault_revoke)
+-  [Function `revoke_all`](#0x1_Vault_revoke_all)
+-  [Function `remove_element`](#0x1_Vault_remove_element)
+-  [Function `add_element`](#0x1_Vault_add_element)
+-  [Function `emit_delegate_event`](#0x1_Vault_emit_delegate_event)
+-  [Function `transfer`](#0x1_Vault_transfer)
+
+
+<pre><code><b>use</b> <a href="">0x1::Errors</a>;
+<b>use</b> <a href="">0x1::Event</a>;
+<b>use</b> <a href="">0x1::Option</a>;
+<b>use</b> <a href="">0x1::Signer</a>;
+<b>use</b> <a href="">0x1::Vector</a>;
+</code></pre>
+
+
+
+<a name="0x1_Vault_ReadCap"></a>
+
+## Struct `ReadCap`
+
+A capability to read the content of the vault. Notice that the capability cannot be
+stored but can be freely copied and dropped.
+TODO: remove <code>drop</code> on <code>Content</code> here and elsewhere once we have phantom type parameters.
+
+
+<pre><code><b>struct</b> <a href="Vault.md#0x1_Vault_ReadCap">ReadCap</a>&lt;Content: drop, store&gt; has <b>copy</b>, drop
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>vault_address: address</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>authority: address</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x1_Vault_ModifyCap"></a>
+
+## Struct `ModifyCap`
+
+A capability to modify the content of the vault.
+
+
+<pre><code><b>struct</b> <a href="Vault.md#0x1_Vault_ModifyCap">ModifyCap</a>&lt;Content: drop, store&gt; has <b>copy</b>, drop
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>vault_address: address</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>authority: address</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x1_Vault_DelegateCap"></a>
+
+## Struct `DelegateCap`
+
+A capability to delegate access to the vault.
+
+
+<pre><code><b>struct</b> <a href="Vault.md#0x1_Vault_DelegateCap">DelegateCap</a>&lt;Content: drop, store&gt; has <b>copy</b>, drop
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>vault_address: address</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>authority: address</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x1_Vault_TransferCap"></a>
+
+## Struct `TransferCap`
+
+A capability to transfer ownership of the vault.
+
+
+<pre><code><b>struct</b> <a href="Vault.md#0x1_Vault_TransferCap">TransferCap</a>&lt;Content: drop, store&gt; has <b>copy</b>, drop
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>vault_address: address</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>authority: address</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x1_Vault_CapType"></a>
+
+## Struct `CapType`
+
+A type describing a capability. This is used for functions like <code><a href="Vault.md#0x1_Vault_delegate">Self::delegate</a></code> where we need to
+specify capability types.
+
+
+<pre><code><b>struct</b> <a href="Vault.md#0x1_Vault_CapType">CapType</a> has <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>code: u8</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x1_Vault_VaultDelegateEvent"></a>
+
+## Struct `VaultDelegateEvent`
+
+An event which we generate on vault access delegation or revocation if event generation is enabled.
+
+
+<pre><code><b>struct</b> <a href="Vault.md#0x1_Vault_VaultDelegateEvent">VaultDelegateEvent</a> has drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>metadata: vector&lt;u8&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>vault_address: address</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>authority: address</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>delegate: address</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>cap: <a href="Vault.md#0x1_Vault_CapType">Vault::CapType</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>is_revoked: bool</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x1_Vault_VaultTransferEvent"></a>
+
+## Struct `VaultTransferEvent`
+
+An event which we generate on vault transfer if event generation is enabled.
+
+
+<pre><code><b>struct</b> <a href="Vault.md#0x1_Vault_VaultTransferEvent">VaultTransferEvent</a> has drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>metadata: vector&lt;u8&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>vault_address: address</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>authority: address</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>new_vault_address: address</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x1_Vault_Vault"></a>
+
+## Resource `Vault`
+
+Private. The vault representation.
+
+
+<pre><code><b>struct</b> <a href="Vault.md#0x1_Vault">Vault</a>&lt;Content: store&gt; has key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>content: <a href="_Option">Option::Option</a>&lt;Content&gt;</code>
+</dt>
+<dd>
+ The content. If the option is empty, the content is currently moved into an
+ accessor in order to work with it.
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x1_Vault_VaultDelegates"></a>
+
+## Resource `VaultDelegates`
+
+Private. If the vault supports delegation, information about the delegates.
+
+
+<pre><code><b>struct</b> <a href="Vault.md#0x1_Vault_VaultDelegates">VaultDelegates</a>&lt;Content: store&gt; has key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>delegates: vector&lt;address&gt;</code>
+</dt>
+<dd>
+ The currently authorized delegates.
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x1_Vault_VaultEvents"></a>
+
+## Resource `VaultEvents`
+
+Private. If event generation is enabled, contains the event generators.
+
+
+<pre><code><b>struct</b> <a href="Vault.md#0x1_Vault_VaultEvents">VaultEvents</a>&lt;Content: store&gt; has key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>metadata: vector&lt;u8&gt;</code>
+</dt>
+<dd>
+ Metadata which identifies this vault. This information is used
+ in events generated by this module.
+</dd>
+<dt>
+<code>delegate_events: <a href="_EventHandle">Event::EventHandle</a>&lt;<a href="Vault.md#0x1_Vault_VaultDelegateEvent">Vault::VaultDelegateEvent</a>&gt;</code>
+</dt>
+<dd>
+ Event handle for vault delegation.
+</dd>
+<dt>
+<code>transfer_events: <a href="_EventHandle">Event::EventHandle</a>&lt;<a href="Vault.md#0x1_Vault_VaultTransferEvent">Vault::VaultTransferEvent</a>&gt;</code>
+</dt>
+<dd>
+ Event handle for vault transfer.
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x1_Vault_VaultDelegate"></a>
+
+## Resource `VaultDelegate`
+
+Private. A value stored at a delegates address pointing to the owner of the vault. Also
+describes the capabilities granted to this delegate.
+
+
+<pre><code><b>struct</b> <a href="Vault.md#0x1_Vault_VaultDelegate">VaultDelegate</a>&lt;Content: store&gt; has key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>vault_address: address</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>granted_caps: vector&lt;<a href="Vault.md#0x1_Vault_CapType">Vault::CapType</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x1_Vault_ReadAccessor"></a>
+
+## Struct `ReadAccessor`
+
+A read accessor for the content of the vault.
+
+
+<pre><code><b>struct</b> <a href="Vault.md#0x1_Vault_ReadAccessor">ReadAccessor</a>&lt;Content: drop, store&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>content: Content</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>vault_address: address</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x1_Vault_ModifyAccessor"></a>
+
+## Struct `ModifyAccessor`
+
+A modify accessor for the content of the vault.
+
+
+<pre><code><b>struct</b> <a href="Vault.md#0x1_Vault_ModifyAccessor">ModifyAccessor</a>&lt;Content: drop, store&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>content: Content</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>vault_address: address</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_4"></a>
+
+## Constants
+
+
+<a name="0x1_Vault_EACCESSOR_INCONSISTENCY"></a>
+
+
+
+<pre><code><b>const</b> <a href="Vault.md#0x1_Vault_EACCESSOR_INCONSISTENCY">EACCESSOR_INCONSISTENCY</a>: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x1_Vault_EACCESSOR_IN_USE"></a>
+
+
+
+<pre><code><b>const</b> <a href="Vault.md#0x1_Vault_EACCESSOR_IN_USE">EACCESSOR_IN_USE</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_Vault_EDELEGATE"></a>
+
+
+
+<pre><code><b>const</b> <a href="Vault.md#0x1_Vault_EDELEGATE">EDELEGATE</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_Vault_EDELEGATE_TO_SELF"></a>
+
+
+
+<pre><code><b>const</b> <a href="Vault.md#0x1_Vault_EDELEGATE_TO_SELF">EDELEGATE_TO_SELF</a>: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x1_Vault_EDELEGATION_NOT_ENABLED"></a>
+
+
+
+<pre><code><b>const</b> <a href="Vault.md#0x1_Vault_EDELEGATION_NOT_ENABLED">EDELEGATION_NOT_ENABLED</a>: u64 = 5;
+</code></pre>
+
+
+
+<a name="0x1_Vault_EEVENT"></a>
+
+
+
+<pre><code><b>const</b> <a href="Vault.md#0x1_Vault_EEVENT">EEVENT</a>: u64 = 6;
+</code></pre>
+
+
+
+<a name="0x1_Vault_EVAULT"></a>
+
+
+
+<pre><code><b>const</b> <a href="Vault.md#0x1_Vault_EVAULT">EVAULT</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_Vault_read_cap_type"></a>
+
+## Function `read_cap_type`
+
+Creates a read capability type.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_read_cap_type">read_cap_type</a>(): <a href="Vault.md#0x1_Vault_CapType">Vault::CapType</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_read_cap_type">read_cap_type</a>(): <a href="Vault.md#0x1_Vault_CapType">CapType</a> { <a href="Vault.md#0x1_Vault_CapType">CapType</a>{ code : 0 } }
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Vault_modify_cap_type"></a>
+
+## Function `modify_cap_type`
+
+Creates a modify  capability type.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_modify_cap_type">modify_cap_type</a>(): <a href="Vault.md#0x1_Vault_CapType">Vault::CapType</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_modify_cap_type">modify_cap_type</a>(): <a href="Vault.md#0x1_Vault_CapType">CapType</a> { <a href="Vault.md#0x1_Vault_CapType">CapType</a>{ code : 1 } }
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Vault_delegate_cap_type"></a>
+
+## Function `delegate_cap_type`
+
+Creates a delegate  capability type.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_delegate_cap_type">delegate_cap_type</a>(): <a href="Vault.md#0x1_Vault_CapType">Vault::CapType</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_delegate_cap_type">delegate_cap_type</a>(): <a href="Vault.md#0x1_Vault_CapType">CapType</a> { <a href="Vault.md#0x1_Vault_CapType">CapType</a>{ code : 2 } }
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Vault_transfer_cap_type"></a>
+
+## Function `transfer_cap_type`
+
+Creates a transfer  capability type.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_transfer_cap_type">transfer_cap_type</a>(): <a href="Vault.md#0x1_Vault_CapType">Vault::CapType</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_transfer_cap_type">transfer_cap_type</a>(): <a href="Vault.md#0x1_Vault_CapType">CapType</a> { <a href="Vault.md#0x1_Vault_CapType">CapType</a>{ code : 3 } }
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Vault_new"></a>
+
+## Function `new`
+
+Creates new vault for the given signer. The vault is populated with the <code>initial_content</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_new">new</a>&lt;Content: store&gt;(owner: &signer, initial_content: Content)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_new">new</a>&lt;Content: store&gt;(owner: &signer,  initial_content: Content) {
+    <b>let</b> addr = <a href="_address_of">Signer::address_of</a>(owner);
+    <b>assert</b>(!<b>exists</b>&lt;<a href="Vault.md#0x1_Vault">Vault</a>&lt;Content&gt;&gt;(addr), <a href="_already_published">Errors::already_published</a>(<a href="Vault.md#0x1_Vault_EVAULT">EVAULT</a>));
+    move_to&lt;<a href="Vault.md#0x1_Vault">Vault</a>&lt;Content&gt;&gt;(
+        owner,
+        <a href="Vault.md#0x1_Vault">Vault</a>{
+            content: <a href="_some">Option::some</a>(initial_content)
+        }
+    )
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Vault_enable_delegation"></a>
+
+## Function `enable_delegation`
+
+Enables delegation functionality for this vault. By default, vaults to not support delegation.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_enable_delegation">enable_delegation</a>&lt;Content: store&gt;(owner: &signer)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_enable_delegation">enable_delegation</a>&lt;Content: store&gt;(owner: &signer) {
+    <b>let</b> addr = <a href="_address_of">Signer::address_of</a>(owner);
+    <b>assert</b>(<b>exists</b>&lt;<a href="Vault.md#0x1_Vault">Vault</a>&lt;Content&gt;&gt;(addr), <a href="_not_published">Errors::not_published</a>(<a href="Vault.md#0x1_Vault_EVAULT">EVAULT</a>));
+    <b>assert</b>(!<b>exists</b>&lt;<a href="Vault.md#0x1_Vault_VaultDelegates">VaultDelegates</a>&lt;Content&gt;&gt;(addr), <a href="_already_published">Errors::already_published</a>(<a href="Vault.md#0x1_Vault_EDELEGATE">EDELEGATE</a>));
+    move_to&lt;<a href="Vault.md#0x1_Vault_VaultDelegates">VaultDelegates</a>&lt;Content&gt;&gt;(owner, <a href="Vault.md#0x1_Vault_VaultDelegates">VaultDelegates</a>{delegates: <a href="_empty">Vector::empty</a>()})
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Vault_enable_events"></a>
+
+## Function `enable_events`
+
+Enables event generation for this vault. This passed metadata is used to identify
+the vault in events.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_enable_events">enable_events</a>&lt;Content: store&gt;(owner: &signer, metadata: vector&lt;u8&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_enable_events">enable_events</a>&lt;Content: store&gt;(owner: &signer, metadata: vector&lt;u8&gt;) {
+    <b>let</b> addr = <a href="_address_of">Signer::address_of</a>(owner);
+    <b>assert</b>(<b>exists</b>&lt;<a href="Vault.md#0x1_Vault">Vault</a>&lt;Content&gt;&gt;(addr), <a href="_not_published">Errors::not_published</a>(<a href="Vault.md#0x1_Vault_EVAULT">EVAULT</a>));
+    <b>assert</b>(!<b>exists</b>&lt;<a href="Vault.md#0x1_Vault_VaultEvents">VaultEvents</a>&lt;Content&gt;&gt;(addr), <a href="_already_published">Errors::already_published</a>(<a href="Vault.md#0x1_Vault_EEVENT">EEVENT</a>));
+    move_to&lt;<a href="Vault.md#0x1_Vault_VaultEvents">VaultEvents</a>&lt;Content&gt;&gt;(
+        owner,
+        <a href="Vault.md#0x1_Vault_VaultEvents">VaultEvents</a>{
+            metadata,
+            delegate_events: <a href="_new_event_handle">Event::new_event_handle</a>&lt;<a href="Vault.md#0x1_Vault_VaultDelegateEvent">VaultDelegateEvent</a>&gt;(owner),
+            transfer_events: <a href="_new_event_handle">Event::new_event_handle</a>&lt;<a href="Vault.md#0x1_Vault_VaultTransferEvent">VaultTransferEvent</a>&gt;(owner),
+        }
+    );
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Vault_remove_vault"></a>
+
+## Function `remove_vault`
+
+Removes a vault and all its associated data, returning the current content. In order for
+this to succeed, there must be no active accessor for the vault.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_remove_vault">remove_vault</a>&lt;Content: drop, store&gt;(owner: &signer): Content
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_remove_vault">remove_vault</a>&lt;Content: store + drop&gt;(owner: &signer): Content
+<b>acquires</b> <a href="Vault.md#0x1_Vault">Vault</a>, <a href="Vault.md#0x1_Vault_VaultDelegates">VaultDelegates</a>, <a href="Vault.md#0x1_Vault_VaultDelegate">VaultDelegate</a>, <a href="Vault.md#0x1_Vault_VaultEvents">VaultEvents</a> {
+    <b>let</b> addr = <a href="_address_of">Signer::address_of</a>(owner);
+    <b>assert</b>(<b>exists</b>&lt;<a href="Vault.md#0x1_Vault">Vault</a>&lt;Content&gt;&gt;(addr), <a href="_not_published">Errors::not_published</a>(<a href="Vault.md#0x1_Vault_EVAULT">EVAULT</a>));
+    <b>let</b> <a href="Vault.md#0x1_Vault">Vault</a>{content} = move_from&lt;<a href="Vault.md#0x1_Vault">Vault</a>&lt;Content&gt;&gt;(addr);
+    <b>assert</b>(<a href="_is_some">Option::is_some</a>(&content), <a href="_invalid_state">Errors::invalid_state</a>(<a href="Vault.md#0x1_Vault_EACCESSOR_IN_USE">EACCESSOR_IN_USE</a>));
+
+    <b>if</b> (<b>exists</b>&lt;<a href="Vault.md#0x1_Vault_VaultDelegates">VaultDelegates</a>&lt;Content&gt;&gt;(addr)) {
+        <b>let</b> delegate_cap = <a href="Vault.md#0x1_Vault_DelegateCap">DelegateCap</a>&lt;Content&gt;{vault_address: addr, authority: addr};
+        <a href="Vault.md#0x1_Vault_revoke_all">revoke_all</a>(&delegate_cap);
+    };
+    <b>if</b> (<b>exists</b>&lt;<a href="Vault.md#0x1_Vault_VaultEvents">VaultEvents</a>&lt;Content&gt;&gt;(addr)) {
+        <b>let</b> <a href="Vault.md#0x1_Vault_VaultEvents">VaultEvents</a>{metadata: _metadata, delegate_events, transfer_events} =
+            move_from&lt;<a href="Vault.md#0x1_Vault_VaultEvents">VaultEvents</a>&lt;Content&gt;&gt;(addr);
+        <a href="_destroy_handle">Event::destroy_handle</a>(delegate_events);
+        <a href="_destroy_handle">Event::destroy_handle</a>(transfer_events);
+    };
+
+    <a href="_extract">Option::extract</a>(&<b>mut</b> content)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Vault_acquire_read_cap"></a>
+
+## Function `acquire_read_cap`
+
+Acquires the capability to read the vault. The passed signer must either be the owner
+of the vault or a delegate with appropriate access.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_acquire_read_cap">acquire_read_cap</a>&lt;Content: drop, store&gt;(requester: &signer): <a href="Vault.md#0x1_Vault_ReadCap">Vault::ReadCap</a>&lt;Content&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_acquire_read_cap">acquire_read_cap</a>&lt;Content: store + drop&gt;(requester: &signer): <a href="Vault.md#0x1_Vault_ReadCap">ReadCap</a>&lt;Content&gt;
+<b>acquires</b> <a href="Vault.md#0x1_Vault_VaultDelegate">VaultDelegate</a> {
+    <b>let</b> (vault_address, authority) = <a href="Vault.md#0x1_Vault_validate_cap">validate_cap</a>&lt;Content&gt;(requester, <a href="Vault.md#0x1_Vault_read_cap_type">read_cap_type</a>());
+    <a href="Vault.md#0x1_Vault_ReadCap">ReadCap</a>{ vault_address, authority }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Vault_acquire_modify_cap"></a>
+
+## Function `acquire_modify_cap`
+
+Acquires the capability to modify the vault. The passed signer must either be the owner
+of the vault or a delegate with appropriate access.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_acquire_modify_cap">acquire_modify_cap</a>&lt;Content: drop, store&gt;(requester: &signer): <a href="Vault.md#0x1_Vault_ModifyCap">Vault::ModifyCap</a>&lt;Content&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_acquire_modify_cap">acquire_modify_cap</a>&lt;Content: store + drop&gt;(requester: &signer): <a href="Vault.md#0x1_Vault_ModifyCap">ModifyCap</a>&lt;Content&gt;
+<b>acquires</b> <a href="Vault.md#0x1_Vault_VaultDelegate">VaultDelegate</a> {
+    <b>let</b> (vault_address, authority) = <a href="Vault.md#0x1_Vault_validate_cap">validate_cap</a>&lt;Content&gt;(requester, <a href="Vault.md#0x1_Vault_modify_cap_type">modify_cap_type</a>());
+    <a href="Vault.md#0x1_Vault_ModifyCap">ModifyCap</a>{ vault_address, authority }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Vault_acquire_delegate_cap"></a>
+
+## Function `acquire_delegate_cap`
+
+Acquires the capability to delegate access to the vault. The passed signer must either be the owner
+of the vault or a delegate with appropriate access.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_acquire_delegate_cap">acquire_delegate_cap</a>&lt;Content: drop, store&gt;(requester: &signer): <a href="Vault.md#0x1_Vault_DelegateCap">Vault::DelegateCap</a>&lt;Content&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_acquire_delegate_cap">acquire_delegate_cap</a>&lt;Content: store + drop&gt;(requester: &signer): <a href="Vault.md#0x1_Vault_DelegateCap">DelegateCap</a>&lt;Content&gt;
+<b>acquires</b> <a href="Vault.md#0x1_Vault_VaultDelegate">VaultDelegate</a> {
+    <b>let</b> (vault_address, authority) = <a href="Vault.md#0x1_Vault_validate_cap">validate_cap</a>&lt;Content&gt;(requester, <a href="Vault.md#0x1_Vault_delegate_cap_type">delegate_cap_type</a>());
+    <a href="Vault.md#0x1_Vault_DelegateCap">DelegateCap</a>{ vault_address, authority }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Vault_acquire_transfer_cap"></a>
+
+## Function `acquire_transfer_cap`
+
+Acquires the capability to transfer the vault. The passed signer must either be the owner
+of the vault or a delegate with appropriate access.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_acquire_transfer_cap">acquire_transfer_cap</a>&lt;Content: drop, store&gt;(requester: &signer): <a href="Vault.md#0x1_Vault_TransferCap">Vault::TransferCap</a>&lt;Content&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_acquire_transfer_cap">acquire_transfer_cap</a>&lt;Content: store + drop&gt;(requester: &signer): <a href="Vault.md#0x1_Vault_TransferCap">TransferCap</a>&lt;Content&gt;
+<b>acquires</b> <a href="Vault.md#0x1_Vault_VaultDelegate">VaultDelegate</a> {
+    <b>let</b> (vault_address, authority) = <a href="Vault.md#0x1_Vault_validate_cap">validate_cap</a>&lt;Content&gt;(requester, <a href="Vault.md#0x1_Vault_transfer_cap_type">transfer_cap_type</a>());
+    <a href="Vault.md#0x1_Vault_TransferCap">TransferCap</a>{ vault_address, authority }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Vault_validate_cap"></a>
+
+## Function `validate_cap`
+
+Private. Validates whether a capability can be acquired by the given signer. Returns the
+pair of the vault address and the used authority.
+
+
+<pre><code><b>fun</b> <a href="Vault.md#0x1_Vault_validate_cap">validate_cap</a>&lt;Content: drop, store&gt;(requester: &signer, cap: <a href="Vault.md#0x1_Vault_CapType">Vault::CapType</a>): (address, address)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="Vault.md#0x1_Vault_validate_cap">validate_cap</a>&lt;Content: store + drop&gt;(requester: &signer, cap: <a href="Vault.md#0x1_Vault_CapType">CapType</a>): (address, address)
+<b>acquires</b> <a href="Vault.md#0x1_Vault_VaultDelegate">VaultDelegate</a> {
+    <b>let</b> addr = <a href="_address_of">Signer::address_of</a>(requester);
+    <b>if</b> (<b>exists</b>&lt;<a href="Vault.md#0x1_Vault_VaultDelegate">VaultDelegate</a>&lt;Content&gt;&gt;(addr)) {
+        // The signer is a delegate. Check it's granted capabilities.
+        <b>let</b> delegate = borrow_global&lt;<a href="Vault.md#0x1_Vault_VaultDelegate">VaultDelegate</a>&lt;Content&gt;&gt;(addr);
+        <b>assert</b>(<a href="_contains">Vector::contains</a>(&delegate.granted_caps, &cap), <a href="_requires_capability">Errors::requires_capability</a>(<a href="Vault.md#0x1_Vault_EDELEGATE">EDELEGATE</a>));
+        (delegate.vault_address, addr)
+    } <b>else</b> {
+        // If it is not a delegate, it must be the owner <b>to</b> succeed.
+        <b>assert</b>(<b>exists</b>&lt;<a href="Vault.md#0x1_Vault">Vault</a>&lt;Content&gt;&gt;(addr), <a href="_not_published">Errors::not_published</a>(<a href="Vault.md#0x1_Vault_EVAULT">EVAULT</a>));
+        (addr, addr)
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Vault_read_accessor"></a>
+
+## Function `read_accessor`
+
+Creates a read accessor for the content in the vault based on a read capability.
+
+Only one accessor (whether read or modify) for the same vault can exist at a time, and this
+function will abort if one is in use. An accessor must be explicitly released using
+<code><a href="Vault.md#0x1_Vault_release_read_accessor">Self::release_read_accessor</a></code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_read_accessor">read_accessor</a>&lt;Content: drop, store&gt;(cap: &<a href="Vault.md#0x1_Vault_ReadCap">Vault::ReadCap</a>&lt;Content&gt;): <a href="Vault.md#0x1_Vault_ReadAccessor">Vault::ReadAccessor</a>&lt;Content&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_read_accessor">read_accessor</a>&lt;Content: store + drop&gt;(cap: &<a href="Vault.md#0x1_Vault_ReadCap">ReadCap</a>&lt;Content&gt;): <a href="Vault.md#0x1_Vault_ReadAccessor">ReadAccessor</a>&lt;Content&gt;
+<b>acquires</b> <a href="Vault.md#0x1_Vault">Vault</a> {
+    <b>let</b> content = &<b>mut</b> borrow_global_mut&lt;<a href="Vault.md#0x1_Vault">Vault</a>&lt;Content&gt;&gt;(cap.vault_address).content;
+    <b>assert</b>(<a href="_is_some">Option::is_some</a>(content), <a href="_invalid_state">Errors::invalid_state</a>(<a href="Vault.md#0x1_Vault_EACCESSOR_IN_USE">EACCESSOR_IN_USE</a>));
+    <a href="Vault.md#0x1_Vault_ReadAccessor">ReadAccessor</a>{ vault_address: cap.vault_address, content: <a href="_extract">Option::extract</a>(content) }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Vault_borrow"></a>
+
+## Function `borrow`
+
+Returns a reference to the content represented by a read accessor.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_borrow">borrow</a>&lt;Content: drop, store&gt;(accessor: &<a href="Vault.md#0x1_Vault_ReadAccessor">Vault::ReadAccessor</a>&lt;Content&gt;): &Content
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_borrow">borrow</a>&lt;Content: store + drop&gt;(accessor: &<a href="Vault.md#0x1_Vault_ReadAccessor">ReadAccessor</a>&lt;Content&gt;): &Content {
+    &accessor.content
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Vault_release_read_accessor"></a>
+
+## Function `release_read_accessor`
+
+Releases read accessor.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_release_read_accessor">release_read_accessor</a>&lt;Content: drop, store&gt;(accessor: <a href="Vault.md#0x1_Vault_ReadAccessor">Vault::ReadAccessor</a>&lt;Content&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_release_read_accessor">release_read_accessor</a>&lt;Content: store + drop&gt;(accessor: <a href="Vault.md#0x1_Vault_ReadAccessor">ReadAccessor</a>&lt;Content&gt;)
+<b>acquires</b> <a href="Vault.md#0x1_Vault">Vault</a> {
+    <b>let</b> <a href="Vault.md#0x1_Vault_ReadAccessor">ReadAccessor</a>{ content: new_content, vault_address } = accessor;
+    <b>let</b> content = &<b>mut</b> borrow_global_mut&lt;<a href="Vault.md#0x1_Vault">Vault</a>&lt;Content&gt;&gt;(vault_address).content;
+    // We (should be/are) able <b>to</b> prove that the below cannot happen, but we leave the assertion
+    // here anyway for double safety.
+    <b>assert</b>(<a href="_is_none">Option::is_none</a>(content), <a href="_internal">Errors::internal</a>(<a href="Vault.md#0x1_Vault_EACCESSOR_INCONSISTENCY">EACCESSOR_INCONSISTENCY</a>));
+    <a href="_fill">Option::fill</a>(content, new_content);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Vault_modify_accessor"></a>
+
+## Function `modify_accessor`
+
+Creates a modify accessor for the content in the vault based on a modify capability. This
+is similar like <code><a href="Vault.md#0x1_Vault_read_accessor">Self::read_accessor</a></code> but the returned accessor will allow to mutate
+the content.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_modify_accessor">modify_accessor</a>&lt;Content: drop, store&gt;(cap: &<a href="Vault.md#0x1_Vault_ModifyCap">Vault::ModifyCap</a>&lt;Content&gt;): <a href="Vault.md#0x1_Vault_ModifyAccessor">Vault::ModifyAccessor</a>&lt;Content&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_modify_accessor">modify_accessor</a>&lt;Content: store + drop&gt;(cap: &<a href="Vault.md#0x1_Vault_ModifyCap">ModifyCap</a>&lt;Content&gt;): <a href="Vault.md#0x1_Vault_ModifyAccessor">ModifyAccessor</a>&lt;Content&gt;
+<b>acquires</b> <a href="Vault.md#0x1_Vault">Vault</a> {
+    <b>let</b> content = &<b>mut</b> borrow_global_mut&lt;<a href="Vault.md#0x1_Vault">Vault</a>&lt;Content&gt;&gt;(cap.vault_address).content;
+    <b>assert</b>(<a href="_is_some">Option::is_some</a>(content), <a href="_invalid_state">Errors::invalid_state</a>(<a href="Vault.md#0x1_Vault_EACCESSOR_IN_USE">EACCESSOR_IN_USE</a>));
+    <a href="Vault.md#0x1_Vault_ModifyAccessor">ModifyAccessor</a>{ vault_address: cap.vault_address, content: <a href="_extract">Option::extract</a>(content) }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Vault_borrow_mut"></a>
+
+## Function `borrow_mut`
+
+Returns a mutable reference to the content represented by a modify accessor.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_borrow_mut">borrow_mut</a>&lt;Content: drop, store&gt;(accessor: &<b>mut</b> <a href="Vault.md#0x1_Vault_ModifyAccessor">Vault::ModifyAccessor</a>&lt;Content&gt;): &<b>mut</b> Content
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_borrow_mut">borrow_mut</a>&lt;Content: store + drop&gt;(accessor: &<b>mut</b> <a href="Vault.md#0x1_Vault_ModifyAccessor">ModifyAccessor</a>&lt;Content&gt;): &<b>mut</b> Content {
+    &<b>mut</b> accessor.content
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Vault_release_modify_accessor"></a>
+
+## Function `release_modify_accessor`
+
+Releases a modify accessor. This will ensure that any modifications are written back
+to the vault.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_release_modify_accessor">release_modify_accessor</a>&lt;Content: drop, store&gt;(accessor: <a href="Vault.md#0x1_Vault_ModifyAccessor">Vault::ModifyAccessor</a>&lt;Content&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_release_modify_accessor">release_modify_accessor</a>&lt;Content: store + drop&gt;(accessor: <a href="Vault.md#0x1_Vault_ModifyAccessor">ModifyAccessor</a>&lt;Content&gt;)
+<b>acquires</b> <a href="Vault.md#0x1_Vault">Vault</a> {
+    <b>let</b> <a href="Vault.md#0x1_Vault_ModifyAccessor">ModifyAccessor</a>{ content: new_content, vault_address } = accessor;
+    <b>let</b> content = &<b>mut</b> borrow_global_mut&lt;<a href="Vault.md#0x1_Vault">Vault</a>&lt;Content&gt;&gt;(vault_address).content;
+    // We (should be/are) able <b>to</b> prove that the below cannot happen, but we leave the assertion
+    // here anyway for double safety.
+    <b>assert</b>(<a href="_is_none">Option::is_none</a>(content), <a href="_internal">Errors::internal</a>(<a href="Vault.md#0x1_Vault_EACCESSOR_INCONSISTENCY">EACCESSOR_INCONSISTENCY</a>));
+    <a href="_fill">Option::fill</a>(content, new_content);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Vault_delegate"></a>
+
+## Function `delegate`
+
+Delegates the right to acquire a capability of the given type. Delegation must have been enabled
+during vault creation for this to succeed.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_delegate">delegate</a>&lt;Content: drop, store&gt;(cap: &<a href="Vault.md#0x1_Vault_DelegateCap">Vault::DelegateCap</a>&lt;Content&gt;, to_signer: &signer, cap_type: <a href="Vault.md#0x1_Vault_CapType">Vault::CapType</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_delegate">delegate</a>&lt;Content: store + drop&gt;(cap: &<a href="Vault.md#0x1_Vault_DelegateCap">DelegateCap</a>&lt;Content&gt;, to_signer: &signer, cap_type: <a href="Vault.md#0x1_Vault_CapType">CapType</a>)
+<b>acquires</b> <a href="Vault.md#0x1_Vault_VaultDelegates">VaultDelegates</a>, <a href="Vault.md#0x1_Vault_VaultDelegate">VaultDelegate</a>, <a href="Vault.md#0x1_Vault_VaultEvents">VaultEvents</a> {
+    <b>assert</b>(
+        <b>exists</b>&lt;<a href="Vault.md#0x1_Vault_VaultDelegates">VaultDelegates</a>&lt;Content&gt;&gt;(cap.vault_address),
+        <a href="_invalid_state">Errors::invalid_state</a>(<a href="Vault.md#0x1_Vault_EDELEGATION_NOT_ENABLED">EDELEGATION_NOT_ENABLED</a>)
+    );
+
+    <b>let</b> addr = <a href="_address_of">Signer::address_of</a>(to_signer);
+    <b>assert</b>(addr != cap.vault_address, <a href="_invalid_argument">Errors::invalid_argument</a>(<a href="Vault.md#0x1_Vault_EDELEGATE_TO_SELF">EDELEGATE_TO_SELF</a>));
+
+    <b>if</b> (!<b>exists</b>&lt;<a href="Vault.md#0x1_Vault_VaultDelegate">VaultDelegate</a>&lt;Content&gt;&gt;(addr)) {
+        // Create <a href="Vault.md#0x1_Vault_VaultDelegate">VaultDelegate</a> <b>if</b> it is not yet existing.
+        move_to&lt;<a href="Vault.md#0x1_Vault_VaultDelegate">VaultDelegate</a>&lt;Content&gt;&gt;(
+            to_signer,
+            <a href="Vault.md#0x1_Vault_VaultDelegate">VaultDelegate</a>{vault_address: cap.vault_address, granted_caps: <a href="_empty">Vector::empty</a>()}
+        );
+        // Add the the delegate <b>to</b> <a href="Vault.md#0x1_Vault_VaultDelegates">VaultDelegates</a>.
+        <b>let</b> vault_delegates = borrow_global_mut&lt;<a href="Vault.md#0x1_Vault_VaultDelegates">VaultDelegates</a>&lt;Content&gt;&gt;(cap.vault_address);
+        <a href="Vault.md#0x1_Vault_add_element">add_element</a>(&<b>mut</b> vault_delegates.delegates, addr);
+    };
+
+    // Grant the capability.
+    <b>let</b> delegate = borrow_global_mut&lt;<a href="Vault.md#0x1_Vault_VaultDelegate">VaultDelegate</a>&lt;Content&gt;&gt;(addr);
+    <a href="Vault.md#0x1_Vault_add_element">add_element</a>(&<b>mut</b> delegate.granted_caps, *&cap_type);
+
+    // Generate event
+    <a href="Vault.md#0x1_Vault_emit_delegate_event">emit_delegate_event</a>(cap, cap_type, addr, <b>false</b>);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Vault_revoke"></a>
+
+## Function `revoke`
+
+Revokes the delegated right to acquire a capability of given type.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_revoke">revoke</a>&lt;Content: drop, store&gt;(cap: &<a href="Vault.md#0x1_Vault_DelegateCap">Vault::DelegateCap</a>&lt;Content&gt;, addr: address, cap_type: <a href="Vault.md#0x1_Vault_CapType">Vault::CapType</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_revoke">revoke</a>&lt;Content: store + drop&gt;(cap: &<a href="Vault.md#0x1_Vault_DelegateCap">DelegateCap</a>&lt;Content&gt;, addr: address, cap_type: <a href="Vault.md#0x1_Vault_CapType">CapType</a>)
+<b>acquires</b> <a href="Vault.md#0x1_Vault_VaultDelegates">VaultDelegates</a>, <a href="Vault.md#0x1_Vault_VaultDelegate">VaultDelegate</a>, <a href="Vault.md#0x1_Vault_VaultEvents">VaultEvents</a> {
+    <b>assert</b>(
+        <b>exists</b>&lt;<a href="Vault.md#0x1_Vault_VaultDelegates">VaultDelegates</a>&lt;Content&gt;&gt;(cap.vault_address),
+        <a href="_invalid_state">Errors::invalid_state</a>(<a href="Vault.md#0x1_Vault_EDELEGATION_NOT_ENABLED">EDELEGATION_NOT_ENABLED</a>)
+    );
+    <b>assert</b>(<b>exists</b>&lt;<a href="Vault.md#0x1_Vault_VaultDelegate">VaultDelegate</a>&lt;Content&gt;&gt;(addr), <a href="_not_published">Errors::not_published</a>(<a href="Vault.md#0x1_Vault_EDELEGATE">EDELEGATE</a>));
+
+    <b>let</b> delegate = borrow_global_mut&lt;<a href="Vault.md#0x1_Vault_VaultDelegate">VaultDelegate</a>&lt;Content&gt;&gt;(addr);
+    <a href="Vault.md#0x1_Vault_remove_element">remove_element</a>(&<b>mut</b> delegate.granted_caps, &cap_type);
+
+    // If the granted caps of this delegate drop <b>to</b> zero, remove it.
+    <b>if</b> (<a href="_is_empty">Vector::is_empty</a>(&delegate.granted_caps)) {
+        <b>let</b> <a href="Vault.md#0x1_Vault_VaultDelegate">VaultDelegate</a>{ vault_address: _owner, granted_caps: _granted_caps} =
+            move_from&lt;<a href="Vault.md#0x1_Vault_VaultDelegate">VaultDelegate</a>&lt;Content&gt;&gt;(addr);
+        <b>let</b> vault_delegates = borrow_global_mut&lt;<a href="Vault.md#0x1_Vault_VaultDelegates">VaultDelegates</a>&lt;Content&gt;&gt;(cap.vault_address);
+        <a href="Vault.md#0x1_Vault_remove_element">remove_element</a>(&<b>mut</b> vault_delegates.delegates, &addr);
+    };
+
+    // Generate event.
+    <a href="Vault.md#0x1_Vault_emit_delegate_event">emit_delegate_event</a>(cap, cap_type, addr, <b>true</b>);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Vault_revoke_all"></a>
+
+## Function `revoke_all`
+
+Revokes all delegate rights for this vault.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_revoke_all">revoke_all</a>&lt;Content: drop, store&gt;(cap: &<a href="Vault.md#0x1_Vault_DelegateCap">Vault::DelegateCap</a>&lt;Content&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_revoke_all">revoke_all</a>&lt;Content: store + drop&gt;(cap: &<a href="Vault.md#0x1_Vault_DelegateCap">DelegateCap</a>&lt;Content&gt;)
+<b>acquires</b> <a href="Vault.md#0x1_Vault_VaultDelegates">VaultDelegates</a>, <a href="Vault.md#0x1_Vault_VaultDelegate">VaultDelegate</a>, <a href="Vault.md#0x1_Vault_VaultEvents">VaultEvents</a> {
+    <b>assert</b>(
+        <b>exists</b>&lt;<a href="Vault.md#0x1_Vault_VaultDelegates">VaultDelegates</a>&lt;Content&gt;&gt;(cap.vault_address),
+        <a href="_invalid_state">Errors::invalid_state</a>(<a href="Vault.md#0x1_Vault_EDELEGATION_NOT_ENABLED">EDELEGATION_NOT_ENABLED</a>)
+    );
+    <b>let</b> delegates = &<b>mut</b> borrow_global_mut&lt;<a href="Vault.md#0x1_Vault_VaultDelegates">VaultDelegates</a>&lt;Content&gt;&gt;(cap.vault_address).delegates;
+    <b>while</b> (!<a href="_is_empty">Vector::is_empty</a>(delegates)) {
+        <b>let</b> addr = <a href="_pop_back">Vector::pop_back</a>(delegates);
+        <b>let</b> <a href="Vault.md#0x1_Vault_VaultDelegate">VaultDelegate</a>{ vault_address: _vault_address, granted_caps} =
+            move_from&lt;<a href="Vault.md#0x1_Vault_VaultDelegate">VaultDelegate</a>&lt;Content&gt;&gt;(cap.vault_address);
+        <b>while</b> (!<a href="_is_empty">Vector::is_empty</a>(&granted_caps)) {
+            <b>let</b> cap_type = <a href="_pop_back">Vector::pop_back</a>(&<b>mut</b> granted_caps);
+            <a href="Vault.md#0x1_Vault_emit_delegate_event">emit_delegate_event</a>(cap, cap_type, addr, <b>true</b>);
+        }
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Vault_remove_element"></a>
+
+## Function `remove_element`
+
+Helper to remove an element from a vector.
+
+
+<pre><code><b>fun</b> <a href="Vault.md#0x1_Vault_remove_element">remove_element</a>&lt;E: drop&gt;(v: &<b>mut</b> vector&lt;E&gt;, x: &E)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="Vault.md#0x1_Vault_remove_element">remove_element</a>&lt;E: drop&gt;(v: &<b>mut</b> vector&lt;E&gt;, x: &E) {
+    <b>let</b> (found, index) = <a href="_index_of">Vector::index_of</a>(v, x);
+    <b>if</b> (found) {
+        <a href="_remove">Vector::remove</a>(v, index);
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Vault_add_element"></a>
+
+## Function `add_element`
+
+Helper to add an element to a vector.
+
+
+<pre><code><b>fun</b> <a href="Vault.md#0x1_Vault_add_element">add_element</a>&lt;E: drop&gt;(v: &<b>mut</b> vector&lt;E&gt;, x: E)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="Vault.md#0x1_Vault_add_element">add_element</a>&lt;E: drop&gt;(v: &<b>mut</b> vector&lt;E&gt;, x: E) {
+    <b>if</b> (!<a href="_contains">Vector::contains</a>(v, &x)) {
+        <a href="_push_back">Vector::push_back</a>(v, x)
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Vault_emit_delegate_event"></a>
+
+## Function `emit_delegate_event`
+
+Emits a delegation or revocation event if event generation is enabled.
+
+
+<pre><code><b>fun</b> <a href="Vault.md#0x1_Vault_emit_delegate_event">emit_delegate_event</a>&lt;Content: drop, store&gt;(cap: &<a href="Vault.md#0x1_Vault_DelegateCap">Vault::DelegateCap</a>&lt;Content&gt;, cap_type: <a href="Vault.md#0x1_Vault_CapType">Vault::CapType</a>, delegate: address, is_revoked: bool)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="Vault.md#0x1_Vault_emit_delegate_event">emit_delegate_event</a>&lt;Content: store + drop&gt;(
+       cap: &<a href="Vault.md#0x1_Vault_DelegateCap">DelegateCap</a>&lt;Content&gt;,
+       cap_type: <a href="Vault.md#0x1_Vault_CapType">CapType</a>,
+       delegate: address,
+       is_revoked: bool
+) <b>acquires</b> <a href="Vault.md#0x1_Vault_VaultEvents">VaultEvents</a> {
+    <b>if</b> (<b>exists</b>&lt;<a href="Vault.md#0x1_Vault_VaultEvents">VaultEvents</a>&lt;Content&gt;&gt;(cap.vault_address)) {
+        <b>let</b> event = <a href="Vault.md#0x1_Vault_VaultDelegateEvent">VaultDelegateEvent</a>{
+            metadata: *&borrow_global&lt;<a href="Vault.md#0x1_Vault_VaultEvents">VaultEvents</a>&lt;Content&gt;&gt;(cap.vault_address).metadata,
+            vault_address: cap.vault_address,
+            authority: cap.authority,
+            delegate,
+            cap: cap_type,
+            is_revoked
+        };
+        <a href="_emit_event">Event::emit_event</a>(&<b>mut</b> borrow_global_mut&lt;<a href="Vault.md#0x1_Vault_VaultEvents">VaultEvents</a>&lt;Content&gt;&gt;(cap.vault_address).delegate_events, event);
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Vault_transfer"></a>
+
+## Function `transfer`
+
+Transfers ownership of the vault to a new signer. All delegations are revoked before transfer,
+and the new owner must re-create delegates as needed.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_transfer">transfer</a>&lt;Content: drop, store&gt;(cap: &<a href="Vault.md#0x1_Vault_TransferCap">Vault::TransferCap</a>&lt;Content&gt;, to_owner: &signer)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Vault.md#0x1_Vault_transfer">transfer</a>&lt;Content: store + drop&gt;(cap: &<a href="Vault.md#0x1_Vault_TransferCap">TransferCap</a>&lt;Content&gt;, to_owner: &signer)
+<b>acquires</b> <a href="Vault.md#0x1_Vault">Vault</a>, <a href="Vault.md#0x1_Vault_VaultEvents">VaultEvents</a>, <a href="Vault.md#0x1_Vault_VaultDelegate">VaultDelegate</a>, <a href="Vault.md#0x1_Vault_VaultDelegates">VaultDelegates</a> {
+    <b>let</b> new_addr = <a href="_address_of">Signer::address_of</a>(to_owner);
+    <b>assert</b>(!<b>exists</b>&lt;<a href="Vault.md#0x1_Vault">Vault</a>&lt;Content&gt;&gt;(new_addr), <a href="_already_published">Errors::already_published</a>(<a href="Vault.md#0x1_Vault_EVAULT">EVAULT</a>));
+    <b>assert</b>(
+        <a href="_is_some">Option::is_some</a>(&borrow_global&lt;<a href="Vault.md#0x1_Vault">Vault</a>&lt;Content&gt;&gt;(cap.vault_address).content),
+        <a href="_invalid_state">Errors::invalid_state</a>(<a href="Vault.md#0x1_Vault_EACCESSOR_IN_USE">EACCESSOR_IN_USE</a>)
+    );
+
+    // Revoke all delegates.
+    <b>if</b> (<b>exists</b>&lt;<a href="Vault.md#0x1_Vault_VaultDelegates">VaultDelegates</a>&lt;Content&gt;&gt;(cap.vault_address)) {
+        <b>let</b> delegate_cap = <a href="Vault.md#0x1_Vault_DelegateCap">DelegateCap</a>&lt;Content&gt;{vault_address: cap.vault_address, authority: cap.authority };
+        <a href="Vault.md#0x1_Vault_revoke_all">revoke_all</a>(&delegate_cap);
+    };
+
+    // Emit event <b>if</b> event generation is enabled. We emit the event on the <b>old</b> vault not the new one.
+    <b>if</b> (<b>exists</b>&lt;<a href="Vault.md#0x1_Vault_VaultEvents">VaultEvents</a>&lt;Content&gt;&gt;(cap.vault_address)) {
+        <b>let</b> event = <a href="Vault.md#0x1_Vault_VaultTransferEvent">VaultTransferEvent</a> {
+            metadata: *&borrow_global&lt;<a href="Vault.md#0x1_Vault_VaultEvents">VaultEvents</a>&lt;Content&gt;&gt;(cap.vault_address).metadata,
+            vault_address: cap.vault_address,
+            authority: cap.authority,
+            new_vault_address: new_addr
+        };
+        <a href="_emit_event">Event::emit_event</a>(&<b>mut</b> borrow_global_mut&lt;<a href="Vault.md#0x1_Vault_VaultEvents">VaultEvents</a>&lt;Content&gt;&gt;(cap.vault_address).transfer_events, event);
+    };
+
+    // Move the vault.
+    move_to&lt;<a href="Vault.md#0x1_Vault">Vault</a>&lt;Content&gt;&gt;(to_owner, move_from&lt;<a href="Vault.md#0x1_Vault">Vault</a>&lt;Content&gt;&gt;(cap.vault_address));
+}
+</code></pre>
+
+
+
+</details>

--- a/language/move-stdlib/src/lib.rs
+++ b/language/move-stdlib/src/lib.rs
@@ -13,7 +13,9 @@ pub const COMPILED_EXTENSION: &str = "mv";
 pub const ERROR_DESC_EXTENSION: &str = "errmap";
 
 const MODULES_DIR: &str = "modules";
+const NURSERY_DIR: &str = "nursery";
 const DOCS_DIR: &str = "docs";
+const NURSERY_DOCS_DIR: &str = "nursery/docs";
 
 const REFERENCES_TEMPLATE: &str = "templates/references.md";
 const OVERVIEW_TEMPLATE: &str = "templates/overview.md";
@@ -57,8 +59,20 @@ pub fn move_stdlib_docs_full_path() -> String {
     format!("{}/{}", env!("CARGO_MANIFEST_DIR"), DOCS_DIR)
 }
 
+pub fn move_nursery_docs_full_path() -> String {
+    format!("{}/{}", env!("CARGO_MANIFEST_DIR"), NURSERY_DOCS_DIR)
+}
+
 pub fn move_stdlib_files() -> Vec<String> {
     let path = path_in_crate(MODULES_DIR);
+    let dirfiles = utils::iterate_directory(&path);
+    filter_move_files(dirfiles)
+        .flat_map(|path| path.into_os_string().into_string())
+        .collect()
+}
+
+pub fn move_nursery_files() -> Vec<String> {
+    let path = path_in_crate(NURSERY_DIR);
     let dirfiles = utils::iterate_directory(&path);
     filter_move_files(dirfiles)
         .flat_map(|path| path.into_os_string().into_string())
@@ -108,6 +122,18 @@ pub fn build_stdlib_doc(output_path: &str) {
         ),
         move_stdlib_files().as_slice(),
         vec![],
+        false,
+    )
+}
+
+pub fn build_nursery_doc(output_path: &str) {
+    build_doc(
+        output_path,
+        "",
+        vec![],
+        None,
+        move_nursery_files().as_slice(),
+        vec![move_stdlib_modules_full_path()],
         false,
     )
 }

--- a/language/move-stdlib/src/main.rs
+++ b/language/move-stdlib/src/main.rs
@@ -11,5 +11,10 @@ fn main() {
             //std::fs::create_dir_all(&move_stdlib::move_stdlib_docs_full_path()).unwrap();
             move_stdlib::build_stdlib_doc(&move_stdlib::move_stdlib_docs_full_path());
         });
+
+        time_it("Generating nursery documentation", || {
+            std::fs::remove_dir_all(&move_stdlib::move_nursery_docs_full_path()).unwrap_or(());
+            move_stdlib::build_nursery_doc(&move_stdlib::move_nursery_docs_full_path());
+        });
     }
 }

--- a/language/tools/move-cli/tests/testsuite/concretize_read_write_set_smoke/args.exp
+++ b/language/tools/move-cli/tests/testsuite/concretize_read_write_set_smoke/args.exp
@@ -5,7 +5,7 @@ Command `run  storage/0x00000000000000000000000000000001/modules/AccountCreation
 Command `run storage/0x00000000000000000000000000000001/modules/TreasuryComplianceScripts.mv tiered_mint --mode diem --type-args 0x1::XUS::XUS --signers 0xB1E55ED --args 0 0xDD 1000 0`:
 Command `run storage/0x00000000000000000000000000000001/modules/PaymentScripts.mv peer_to_peer_with_metadata --mode diem --type-args 0x1::XUS::XUS --signers 0xDD --args 0xA 700 x"" x""`:
 Command `analyze read-write-set storage/0x00000000000000000000000000000001/modules/PaymentScripts.mv peer_to_peer_with_metadata --mode diem --concretize --type-args 0x1::XUS::XUS --signers 0xA --args 0xB 500 x"" x"" -v`:
-Inferring read/write set for 49 module(s)
+Inferring read/write set for 50 module(s)
 0xa/0x1::AccountFreezing::FreezingBit: Read
 0xa/0x1::AccountFreezing::FreezingBit/is_frozen: Read
 0xa/0x1::VASP::ParentVASP: Read


### PR DESCRIPTION
This PR introduces a new module (in the nursery), called *Vault*, which implements a secure memory of some content which can only be operated on if authorized by a signer. 

Authorization is managed by [*capabilities*](https://en.wikipedia.org/wiki/Capability-based_security) in the proper sense as used in security engineering. Capabilities are unforgeable tokens which represent the successful authorization of access based on a signer, and which can be passed on to other functions which can perform the operations enabled by the capability, without the need to have access to the signer themselves.

The vault comes with 4 kinds of capabilities:

- Read: allows to read the content.
- Modify: allows to read and write the content.
- Delegate: allows to delegate access (of one or more capabilities) to another signer. Delegation can be revoked.
- Transfer: allows to transfer ownership of the vault to a new signer.

Reading and writing of the vault is enabled by using a wrapper object (called an accessor) which moves the value temporarily out of the vault and allows to created references to it. The accessor needs to be explicitly released. This is the current workaround for that we can't return references to global memory in Move.

This PR also enables documentation generation for modules in the nursery. The generated doc for the new module is [here](https://github.com/wrwg/diem/blob/cap/language/move-stdlib/nursery/docs/Vault.md).

There are currently no specs or tests, which need to be added in later PRs.

## Motivation

Unified access control.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

No tests yet

## Related PRs

NA
