### PR TITLE
[move-vm] Use parking lot Rwlock for loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4747,7 +4747,6 @@ dependencies = [
  "bytecode-verifier",
  "compiler",
  "diem-crypto",
- "diem-infallible",
  "diem-logger",
  "diem-workspace-hack",
  "fail",
@@ -4759,6 +4758,7 @@ dependencies = [
  "move-vm-natives",
  "move-vm-types",
  "once_cell",
+ "parking_lot",
  "proptest",
 ]
 

--- a/language/move-vm/runtime/Cargo.toml
+++ b/language/move-vm/runtime/Cargo.toml
@@ -15,11 +15,11 @@ edition = "2018"
 fail = "0.4.0"
 mirai-annotations = "1.10.1"
 once_cell = "1.7.2"
+parking_lot = "0.11.1"
 
 bytecode-verifier = { path = "../../bytecode-verifier" }
 diem-crypto = { path = "../../../crypto/crypto" }
 diem-logger = { path = "../../../common/logger" }
-diem-infallible = { path = "../../../common/infallible" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
 move-vm-natives = { path = "../natives" }

--- a/language/move-vm/runtime/src/tracing.rs
+++ b/language/move-vm/runtime/src/tracing.rs
@@ -6,7 +6,6 @@ use crate::debug::DebugContext;
 
 #[cfg(debug_assertions)]
 use ::{
-    diem_infallible::Mutex,
     move_binary_format::file_format::Bytecode,
     move_vm_types::values::Locals,
     once_cell::sync::Lazy,
@@ -14,7 +13,9 @@ use ::{
         env,
         fs::{File, OpenOptions},
         io::Write,
-        process, thread,
+        process,
+        sync::Mutex,
+        thread,
     },
 };
 
@@ -68,7 +69,7 @@ pub(crate) fn trace<L: LogContext>(
     interp: &Interpreter<L>,
 ) {
     if *TRACING_ENABLED {
-        let f = &mut *LOGGING_FILE.lock();
+        let f = &mut *LOGGING_FILE.lock().unwrap();
         writeln!(
             f,
             "{}-{:?},{},{},{:?}",
@@ -83,6 +84,7 @@ pub(crate) fn trace<L: LogContext>(
     if *DEBUGGING_ENABLED {
         DEBUG_CONTEXT
             .lock()
+            .unwrap()
             .debug_loop(function_desc, locals, pc, instr, loader, interp);
     }
 }

--- a/x.toml
+++ b/x.toml
@@ -244,7 +244,6 @@ existing_deps = [
     ["compiler", "diem-framework-releases"],
     ["move-vm-natives", "diem-crypto"],
     ["move-vm-runtime", "diem-logger"],
-    ["move-vm-runtime", "diem-infallible"],                   # `Mutex`
     ["move-vm-runtime", "diem-crypto"],                       # using `HashValue` as keys in the script cache
     ["abigen", "diem-types"],                                 # ABI types
     ["move-cli", "vm-genesis"],


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Use `parking_lot::RwLock` instead of thr `Mutex` in MoveVM. There are two major reasons:
1. `parking_lot::RwLock` will have a better perf in a none contensious scenario, which would be our major use case given the single threaded nature of the current system. This would help parallel execution as well when each thread owns a dedicated instance of MoveVM.
2.  This would cut another Move to Diem dependency.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Perf for single threaded execution wasn't affected:
```
peer_to_peer            time:   [248.14 ms 250.13 ms 252.33 ms]
                        change: [-0.9126% +0.1851% +1.4207%] (p = 0.76 > 0.05)
                        No change in performance detected.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
```

Perf for parallel execution was improved:
```
peer_to_peer            time:   [644.71 ms 647.89 ms 651.62 ms]
                        change: [+1.3569% +2.3361% +3.3793%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) high mild
```
I ran the baseline on PR first.