### PR TITLE
[scratchpad] fix benchmark

### DIFF
--- a/storage/scratchpad/src/sparse_merkle/test_utils/mod.rs
+++ b/storage/scratchpad/src/sparse_merkle/test_utils/mod.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(any(test, feature = "bench", feature = "fuzzing"))]
-mod naive_smt;
+pub mod naive_smt;
 #[cfg(any(test, feature = "bench", feature = "fuzzing"))]
-pub(crate) mod proof_reader;
+pub mod proof_reader;
 #[cfg(any(test, feature = "fuzzing"))]
 pub mod proptest_helpers;

--- a/storage/scratchpad/src/sparse_merkle/test_utils/proof_reader.rs
+++ b/storage/scratchpad/src/sparse_merkle/test_utils/proof_reader.rs
@@ -6,10 +6,10 @@ use diem_crypto::HashValue;
 use diem_types::proof::SparseMerkleProof;
 use std::collections::HashMap;
 
-pub(crate) struct ProofReader<V>(HashMap<HashValue, SparseMerkleProof<V>>);
+pub struct ProofReader<V>(HashMap<HashValue, SparseMerkleProof<V>>);
 
 impl<V: Sync> ProofReader<V> {
-    pub(crate) fn new(key_with_proof: Vec<(HashValue, SparseMerkleProof<V>)>) -> Self {
+    pub fn new(key_with_proof: Vec<(HashValue, SparseMerkleProof<V>)>) -> Self {
         ProofReader(key_with_proof.into_iter().collect())
     }
 }

--- a/testsuite/diem-fuzzer/src/fuzz_targets.rs
+++ b/testsuite/diem-fuzzer/src/fuzz_targets.rs
@@ -95,6 +95,7 @@ static ALL_TARGETS: Lazy<BTreeMap<&'static str, Box<dyn FuzzTargetImpl>>> = Lazy
         Box::new(storage::AccumulatorRangeProof::default()),
         Box::new(storage::AccumulatorAppendMany::default()),
         Box::new(storage::AccumulatorAppendEmpty::default()),
+        Box::new(storage::SparseMerkleCorrectness::default()),
         // Transaction
         Box::new(transaction::LanguageTransactionExecution::default()),
         Box::new(transaction::SignedTransactionTarget::default()),


### PR DESCRIPTION


## Motivation

The Criterion benchmark was broken and normal build process was not able to detect it.

Also added the fuzz target to the list so it can actually be run.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan
`cargo bench -p scratchpad --features bench`

`cargo run -p diem-fuzzer --bin diem-fuzzer -- fuzz SparseMerkleCorrectness`
## Related PRs
#8388 