### PR TITLE
[sdk] Add get_events to json-rpc verifying client

### DIFF
--- a/json-rpc/src/data.rs
+++ b/json-rpc/src/data.rs
@@ -336,18 +336,12 @@ pub fn get_events_with_proofs(
         Some(ledger_version),
     )?;
 
-    let mut results = vec![];
+    let views = events_with_proofs
+        .iter()
+        .map(EventWithProofView::try_from)
+        .collect::<Result<Vec<_>>>()?;
 
-    for event in events_with_proofs
-        .into_iter()
-        .filter(|e| e.transaction_version <= ledger_version)
-    {
-        results.push(EventWithProofView {
-            event_with_proof: bcs::to_bytes(&event)?.into(),
-        });
-    }
-
-    Ok(results)
+    Ok(views)
 }
 
 /// Returns meta information about supported currencies

--- a/sdk/client/src/response.rs
+++ b/sdk/client/src/response.rs
@@ -154,4 +154,14 @@ impl MethodResponse {
             ))),
         }
     }
+
+    pub fn try_into_get_events(self) -> Result<Vec<EventView>, Error> {
+        match self {
+            MethodResponse::GetEvents(events) => Ok(events),
+            _ => Err(Error::rpc_response(format!(
+                "expected MethodResponse::GetEvents found MethodResponse::{:?}",
+                self.method()
+            ))),
+        }
+    }
 }


### PR DESCRIPTION
This diff allows verifying clients to call `get_events` while still verifying all of the proofs.