### PR TITLE
[sdk] Add move error explanations to transaction builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,6 +2316,7 @@ dependencies = [
 name = "diem-transaction-builder"
 version = "0.0.2"
 dependencies = [
+ "anyhow",
  "bcs",
  "diem-types",
  "diem-workspace-hack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4433,7 +4433,6 @@ dependencies = [
  "diem-workspace-hack",
  "difference",
  "disassembler",
- "errmapgen",
  "include_dir",
  "move-binary-format",
  "move-core-types",
@@ -4497,7 +4496,6 @@ dependencies = [
  "bcs",
  "diem-framework-releases",
  "diem-workspace-hack",
- "errmapgen",
  "move-core-types",
  "structopt 0.3.21",
 ]

--- a/language/move-core/types/src/errmap.rs
+++ b/language/move-core/types/src/errmap.rs
@@ -1,0 +1,102 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::language_storage::ModuleId;
+use anyhow::{bail, Result};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::BTreeMap,
+    fs::File,
+    io::{Read, Write},
+    path::Path,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErrorDescription {
+    /// The constant name of error e.g., ECANT_PAY_DEPOSIT
+    pub code_name: String,
+    /// The code description. This is generated from the doc comments on the constant.
+    pub code_description: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErrorContext {
+    /// The error category e.g., INVALID_ARGUMENT
+    pub category: ErrorDescription,
+    /// The error reason e.g., ECANT_PAY_DEPOSIT
+    pub reason: ErrorDescription,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErrorMapping {
+    /// The set of error categories and their descriptions
+    pub error_categories: BTreeMap<u64, ErrorDescription>,
+    /// The set of modules, and the module-specific errors
+    pub module_error_maps: BTreeMap<ModuleId, BTreeMap<u64, ErrorDescription>>,
+}
+
+impl Default for ErrorMapping {
+    fn default() -> Self {
+        Self {
+            error_categories: BTreeMap::new(),
+            module_error_maps: BTreeMap::new(),
+        }
+    }
+}
+
+impl ErrorMapping {
+    pub fn add_error_category(
+        &mut self,
+        category_id: u64,
+        description: ErrorDescription,
+    ) -> Result<()> {
+        if let Some(previous_entry) = self.error_categories.insert(category_id, description) {
+            bail!(format!(
+                "Entry for category {} already taken by: {:#?}",
+                category_id, previous_entry
+            ))
+        }
+        Ok(())
+    }
+
+    pub fn add_module_error(
+        &mut self,
+        module_id: ModuleId,
+        abort_code: u64,
+        description: ErrorDescription,
+    ) -> Result<()> {
+        let module_error_map = self.module_error_maps.entry(module_id.clone()).or_default();
+        if let Some(previous_entry) = module_error_map.insert(abort_code, description) {
+            bail!(format!(
+                "Duplicate entry for abort code {} found in {}, previous entry: {:#?}",
+                abort_code, module_id, previous_entry
+            ))
+        }
+        Ok(())
+    }
+
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Self {
+        let mut bytes = Vec::new();
+        File::open(path).unwrap().read_to_end(&mut bytes).unwrap();
+        bcs::from_bytes(&bytes).unwrap()
+    }
+
+    pub fn to_file<P: AsRef<Path>>(&self, path: P) {
+        let bytes = bcs::to_bytes(self).unwrap();
+        let mut file = File::create(path).unwrap();
+        file.write_all(&bytes).unwrap();
+    }
+
+    pub fn get_explanation(&self, module: &ModuleId, output_code: u64) -> Option<ErrorContext> {
+        let category = output_code & 0xFFu64;
+        let reason_code = output_code >> 8;
+        self.error_categories.get(&category).and_then(|category| {
+            self.module_error_maps.get(module).and_then(|module_map| {
+                module_map.get(&reason_code).map(|reason| ErrorContext {
+                    category: category.clone(),
+                    reason: reason.clone(),
+                })
+            })
+        })
+    }
+}

--- a/language/move-core/types/src/lib.rs
+++ b/language/move-core/types/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod account_address;
 pub mod effects;
+pub mod errmap;
 pub mod gas_schedule;
 pub mod identifier;
 pub mod language_storage;

--- a/language/move-prover/errmapgen/src/errmapgen.rs
+++ b/language/move-prover/errmapgen/src/errmapgen.rs
@@ -1,11 +1,12 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use anyhow::{bail, Result};
 use move_core_types::{
-    account_address::AccountAddress, identifier::Identifier, language_storage::ModuleId,
+    account_address::AccountAddress,
+    errmap::{ErrorDescription, ErrorMapping},
+    identifier::Identifier,
+    language_storage::ModuleId,
 };
 use move_model::{
     ast::Value,
@@ -13,14 +14,7 @@ use move_model::{
     symbol::Symbol,
 };
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::BTreeMap,
-    convert::TryFrom,
-    fs::File,
-    io::{Read, Write},
-    path::Path,
-    rc::Rc,
-};
+use std::{convert::TryFrom, rc::Rc};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ErrmapOptions {
@@ -30,30 +24,6 @@ pub struct ErrmapOptions {
     pub error_category_module: ModuleId,
     /// In which file to store the output
     pub output_file: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ErrorDescription {
-    /// The constant name of error e.g., ECANT_PAY_DEPOSIT
-    pub code_name: String,
-    /// The code description. This is generated from the doc comments on the constant.
-    pub code_description: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ErrorContext {
-    /// The error category e.g., INVALID_ARGUMENT
-    pub category: ErrorDescription,
-    /// The error reason e.g., ECANT_PAY_DEPOSIT
-    pub reason: ErrorDescription,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ErrorMapping {
-    /// The set of error categories and their descriptions
-    pub error_categories: BTreeMap<u64, ErrorDescription>,
-    /// The set of modules, and the module-specific errors
-    pub module_error_maps: BTreeMap<ModuleId, BTreeMap<u64, ErrorDescription>>,
 }
 
 impl Default for ErrmapOptions {
@@ -66,72 +36,6 @@ impl Default for ErrmapOptions {
             ),
             output_file: "errmap".to_string(),
         }
-    }
-}
-
-impl Default for ErrorMapping {
-    fn default() -> Self {
-        Self {
-            error_categories: BTreeMap::new(),
-            module_error_maps: BTreeMap::new(),
-        }
-    }
-}
-
-impl ErrorMapping {
-    pub fn add_error_category(
-        &mut self,
-        category_id: u64,
-        description: ErrorDescription,
-    ) -> Result<()> {
-        if let Some(previous_entry) = self.error_categories.insert(category_id, description) {
-            bail!(format!(
-                "Entry for category {} already taken by: {:#?}",
-                category_id, previous_entry
-            ))
-        }
-        Ok(())
-    }
-
-    pub fn add_module_error(
-        &mut self,
-        module_id: ModuleId,
-        abort_code: u64,
-        description: ErrorDescription,
-    ) -> Result<()> {
-        let module_error_map = self.module_error_maps.entry(module_id.clone()).or_default();
-        if let Some(previous_entry) = module_error_map.insert(abort_code, description) {
-            bail!(format!(
-                "Duplicate entry for abort code {} found in {}, previous entry: {:#?}",
-                abort_code, module_id, previous_entry
-            ))
-        }
-        Ok(())
-    }
-
-    pub fn from_file<P: AsRef<Path>>(path: P) -> Self {
-        let mut bytes = Vec::new();
-        File::open(path).unwrap().read_to_end(&mut bytes).unwrap();
-        bcs::from_bytes(&bytes).unwrap()
-    }
-
-    pub fn to_file<P: AsRef<Path>>(&self, path: P) {
-        let bytes = bcs::to_bytes(self).unwrap();
-        let mut file = File::create(path).unwrap();
-        file.write_all(&bytes).unwrap();
-    }
-
-    pub fn get_explanation(&self, module: &ModuleId, output_code: u64) -> Option<ErrorContext> {
-        let category = output_code & 0xFFu64;
-        let reason_code = output_code >> 8;
-        self.error_categories.get(&category).and_then(|category| {
-            self.module_error_maps.get(module).and_then(|module_map| {
-                module_map.get(&reason_code).map(|reason| ErrorContext {
-                    category: category.clone(),
-                    reason: reason.clone(),
-                })
-            })
-        })
     }
 }
 

--- a/language/tools/move-cli/Cargo.toml
+++ b/language/tools/move-cli/Cargo.toml
@@ -21,7 +21,6 @@ bcs = "0.1.2"
 bytecode-verifier = { path = "../../bytecode-verifier" }
 diem-framework-releases = { path = "../../diem-framework/releases" }
 disassembler = { path = "../disassembler" }
-errmapgen = { path = "../../move-prover/errmapgen" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 diem-types = { path = "../../../types" }
 move-coverage = { path = "../move-coverage" }

--- a/language/tools/move-cli/src/commands.rs
+++ b/language/tools/move-cli/src/commands.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use errmapgen::ErrorMapping;
-
 use crate::on_disk_state_view::OnDiskStateView;
 use move_binary_format::{
     access::ModuleAccess,
@@ -14,6 +12,7 @@ use move_binary_format::{
 use move_core_types::{
     account_address::AccountAddress,
     effects::{ChangeSet, Event},
+    errmap::ErrorMapping,
     gas_schedule::{GasAlgebra, GasUnits},
     identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, TypeTag},

--- a/language/tools/move-explain/Cargo.toml
+++ b/language/tools/move-explain/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2018"
 structopt = "0.3.21"
 diem-framework-releases = { path = "../../diem-framework/releases" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
-errmapgen = { path = "../../move-prover/errmapgen" }
 move-core-types = { path = "../../move-core/types" }
 bcs = "0.1.2"
 

--- a/language/tools/move-explain/src/lib.rs
+++ b/language/tools/move-explain/src/lib.rs
@@ -1,8 +1,10 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use errmapgen::{ErrorContext, ErrorMapping};
-use move_core_types::language_storage::ModuleId;
+use move_core_types::{
+    errmap::{ErrorContext, ErrorMapping},
+    language_storage::ModuleId,
+};
 
 /// Given the module ID and the abort code raised from that module, returns the human-readable
 /// explanation of that abort if possible.

--- a/sdk/transaction-builder/Cargo.toml
+++ b/sdk/transaction-builder/Cargo.toml
@@ -10,6 +10,7 @@ publish = ["crates-io"]
 edition = "2018"
 
 [dependencies]
+anyhow = "1.0.38"
 bcs = "0.1.2"
 once_cell = "1.7.2"
 serde = { version = "1.0.124", features = ["derive"] }

--- a/sdk/transaction-builder/release_errmap/error_description.errmap
+++ b/sdk/transaction-builder/release_errmap/error_description.errmap
@@ -1,0 +1,1 @@
+../../../language/diem-framework/releases/artifacts/current/error_description/error_description.errmap

--- a/sdk/transaction-builder/src/error_explain.rs
+++ b/sdk/transaction-builder/src/error_explain.rs
@@ -1,0 +1,44 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! A module for looking up the human-readable explanation of a Diem Move
+//! transaction abort code.
+//!
+//! This module mostly exists as a temporary hack until we figure out a more
+//! sustainable approach towards publishing the Diem move framework release to
+//! crates.io.
+//!
+//! Note that the ~13 KiB error descriptions will be inlined into the final binary.
+
+use move_core_types::{
+    errmap::{ErrorContext, ErrorMapping},
+    language_storage::ModuleId,
+};
+use once_cell::sync::Lazy;
+
+static RELEASE_ERRMAP_BYTES: &[u8] = include_bytes!("../release_errmap/error_description.errmap");
+
+static RELEASE_ERRMAP: Lazy<ErrorMapping> = Lazy::new(|| {
+    bcs::from_bytes(&*RELEASE_ERRMAP_BYTES)
+        .expect("Failed to deserialize static error descriptions")
+});
+
+/// Given the module ID and the abort code raised from that module, returns the
+/// human-readable explanation of that abort if possible.
+pub fn get_explanation(module_id: &ModuleId, abort_code: u64) -> Option<ErrorContext> {
+    let errmap = &*RELEASE_ERRMAP;
+    errmap.get_explanation(module_id, abort_code)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use move_core_types::{account_address::AccountAddress, ident_str};
+
+    #[test]
+    fn test_get_explanation() {
+        let module_id = ModuleId::new(AccountAddress::ZERO, ident_str!("TESTTEST").to_owned());
+        // We don't care about the result, just that the errmap deserializes without panicking.
+        let _ = get_explanation(&module_id, 1234);
+    }
+}

--- a/sdk/transaction-builder/src/lib.rs
+++ b/sdk/transaction-builder/src/lib.rs
@@ -3,4 +3,5 @@
 
 #![forbid(unsafe_code)]
 
+pub mod error_explain;
 pub mod stdlib;


### PR DESCRIPTION
# Overview

In order to unblock a PR (#8398) which needs the ability to get Move error explanations from a _published_ crate, this PR adds a small sdk crate `diem-move-error-explain` (very creative name :)) with no unpublished dependencies (so it's easy to publish) and allows us to continue deferring on how we want to publish `diem-framework-release` (pending the Move separation).

### [errmapgen] Extract ErrorMapping definitions from the generation logic

We need to pull out the `ErrorMapping` definitions so they're separated from the generation logic, which depends on the internal, unpublished `move-model` crate. This separation will allow us to easily publish a small `diem-move-error-explain` crate without publishing any internal move modules.


### [sdk] Add diem-move-error-explain crate to published sdk

A crate for looking up the human-readable explanation of a Diem Move transaction abort code. This crate mostly exists as a temporary hack until we figure out a more sustainable approach towards publishing the Diem move framework release to crates.io.

cc @bmwill How do we publish this? : p