### PR TITLE
[move-lang] Fix interface generator for 'friend'

### DIFF
--- a/language/move-lang/src/interface_generator.rs
+++ b/language/move-lang/src/interface_generator.rs
@@ -141,7 +141,7 @@ const DISCLAIMER: &str =
 
 fn write_friend_decl(ctx: &mut Context, fdecl: &ModuleHandle) -> String {
     format!(
-        "friend {}::{}",
+        "    friend {}::{};",
         ctx.module
             .address_identifier_at(fdecl.address)
             .short_str_lossless(),


### PR DESCRIPTION
- Fixed syntax for friends in interface generation

## Motivation

- Fix for #8403

## Test Plan

- Verified fix works
- It will be run on every test after #8403 lands, but we should think about a dedicated test 