### PR TITLE
[json-rpc] Avoid extra get_currencies lookup for get_account

### DIFF
--- a/client/assets-proof/src/lib.rs
+++ b/client/assets-proof/src/lib.rs
@@ -612,7 +612,7 @@ impl Client for diem_client::BlockingClient {
 fn make_account_view(
     address: AccountAddress,
     account_state: AccountState,
-    currency_ids: &[Identifier],
+    _currency_ids: &[Identifier],
     version: Version,
 ) -> Result<AccountView> {
     let account_resource = account_state
@@ -622,9 +622,9 @@ fn make_account_view(
         .get_freezing_bit()?
         .ok_or_else(|| format_err!("invalid account data: no freezing bit"))?;
     let account_role = account_state
-        .get_account_role(currency_ids)?
+        .get_account_role()?
         .ok_or_else(|| format_err!("invalid account data: no account role"))?;
-    let balances = account_state.get_balance_resources(currency_ids)?;
+    let balances = account_state.get_balance_resources()?;
 
     Ok(AccountView::new(
         address,

--- a/execution/executor-test-helpers/src/integration_test_impl.rs
+++ b/execution/executor-test-helpers/src/integration_test_impl.rs
@@ -527,7 +527,7 @@ where
 {
     let balance = if let Some(blob) = &account_state_with_proof.blob {
         AccountState::try_from(blob)?
-            .get_balance_resources(&[from_currency_code_string(XUS_NAME).unwrap()])?
+            .get_balance_resources()?
             .get(&from_currency_code_string(XUS_NAME).unwrap())
             .map(|b| b.coin())
             .unwrap_or(0)

--- a/execution/executor/tests/db_bootstrapper_test.rs
+++ b/execution/executor/tests/db_bootstrapper_test.rs
@@ -192,7 +192,7 @@ fn get_balance(account: &AccountAddress, db: &DbReaderWriter) -> u64 {
         .unwrap();
     let account_state = AccountState::try_from(&account_state_blob).unwrap();
     account_state
-        .get_balance_resources(&[from_currency_code_string(XUS_NAME).unwrap()])
+        .get_balance_resources()
         .unwrap()
         .get(&from_currency_code_string(XUS_NAME).unwrap())
         .unwrap()

--- a/json-rpc/src/data.rs
+++ b/json-rpc/src/data.rs
@@ -14,10 +14,7 @@ use anyhow::{format_err, Result};
 use diem_crypto::{hash::CryptoHash, HashValue};
 use diem_types::{
     account_address::AccountAddress,
-    account_config::{
-        diem_root_address, from_currency_code_string, resources::dual_attestation::Limit,
-        AccountResource,
-    },
+    account_config::{diem_root_address, resources::dual_attestation::Limit, AccountResource},
     account_state::AccountState,
     chain_id::ChainId,
     event::EventKey,
@@ -87,7 +84,6 @@ pub fn get_metadata(
 /// Returns account state (AccountView) by given address
 pub fn get_account(
     db: &dyn DbReader,
-    ledger_version: u64,
     account_address: AccountAddress,
     version: u64,
 ) -> Result<Option<AccountView>, JsonRpcError> {
@@ -96,16 +92,9 @@ pub fn get_account(
         None => return Ok(None),
     };
 
-    let currencies = get_currencies(db, ledger_version)?;
-    let currency_codes: Vec<_> = currencies
-        .into_iter()
-        .map(|info| from_currency_code_string(&info.code))
-        .collect::<Result<_, _>>()?;
-
     Ok(Some(AccountView::try_from_account_state(
         account_address,
         account_state,
-        &currency_codes,
         version,
     )?))
 }

--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -210,12 +210,7 @@ impl<'a> Handler<'a> {
     ) -> Result<Option<AccountView>, JsonRpcError> {
         let account_address = params.account;
         let version = self.version_param(params.version, "version")?;
-        data::get_account(
-            self.service.db.borrow(),
-            self.version(),
-            account_address,
-            version,
-        )
+        data::get_account(self.service.db.borrow(), account_address, version)
     }
 
     /// Returns transactions by range

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -20,7 +20,7 @@ use diem_metrics::get_all_metrics;
 use diem_proptest_helpers::ValueGenerator;
 use diem_types::{
     account_address::AccountAddress,
-    account_config::{from_currency_code_string, AccountResource, FreezingBit, XUS_NAME},
+    account_config::{AccountResource, FreezingBit},
     account_state::AccountState,
     account_state_blob::{AccountStateBlob, AccountStateWithProof},
     chain_id::ChainId,
@@ -1131,7 +1131,7 @@ fn test_get_account() {
         .unwrap();
     let account_balances: Vec<_> = account.balances.iter().map(|bal| bal.amount).collect();
     let expected_resource_balances: Vec<_> = expected_resource
-        .get_balance_resources(&[from_currency_code_string(XUS_NAME).unwrap()])
+        .get_balance_resources()
         .unwrap()
         .iter()
         .map(|(_, bal_resource)| bal_resource.coin())
@@ -1166,7 +1166,7 @@ fn test_get_account() {
         let account = response.unwrap().into_inner().unwrap_get_account().unwrap();
         let account_balances: Vec<_> = account.balances.iter().map(|bal| bal.amount).collect();
         let expected_resource_balances: Vec<_> = states[idx]
-            .get_balance_resources(&[from_currency_code_string(XUS_NAME).unwrap()])
+            .get_balance_resources()
             .unwrap()
             .iter()
             .map(|(_, bal_resource)| bal_resource.coin())

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -192,7 +192,7 @@ impl AccountView {
     pub fn try_from_account_state(
         address: AccountAddress,
         account_state: AccountState,
-        currency_codes: &[Identifier],
+        _currency_codes: &[Identifier],
         version: u64,
     ) -> Result<Self> {
         let account_resource = account_state
@@ -202,9 +202,9 @@ impl AccountView {
             .get_freezing_bit()?
             .ok_or_else(|| format_err!("invalid account state: no freezing bit"))?;
         let account_role = account_state
-            .get_account_role(currency_codes)?
+            .get_account_role()?
             .ok_or_else(|| format_err!("invalid account state: no account role"))?;
-        let balances = account_state.get_balance_resources(currency_codes)?;
+        let balances = account_state.get_balance_resources()?;
 
         Ok(AccountView::new(
             address,

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -192,7 +192,6 @@ impl AccountView {
     pub fn try_from_account_state(
         address: AccountAddress,
         account_state: AccountState,
-        _currency_codes: &[Identifier],
         version: u64,
     ) -> Result<Self> {
         let account_resource = account_state

--- a/types/src/account_state.rs
+++ b/types/src/account_state.rs
@@ -5,9 +5,9 @@ use crate::{
     access_path::Path,
     account_address::AccountAddress,
     account_config::{
-        type_tag_for_currency_code, AccountResource, AccountRole, BalanceResource, ChainIdResource,
-        ChildVASP, Credential, CurrencyInfoResource, DesignatedDealer, DesignatedDealerPreburns,
-        FreezingBit, ParentVASP, PreburnQueueResource, PreburnResource,
+        currency_code_from_type_tag, AccountResource, AccountRole, BalanceResource,
+        ChainIdResource, ChildVASP, Credential, CurrencyInfoResource, DesignatedDealer,
+        DesignatedDealerPreburns, FreezingBit, ParentVASP, PreburnQueueResource, PreburnResource,
     },
     block_metadata::DiemBlockResource,
     diem_timestamp::DiemTimestampResource,
@@ -18,7 +18,11 @@ use crate::{
     validator_config::{ValidatorConfigResource, ValidatorOperatorConfigResource},
 };
 use anyhow::{format_err, Error, Result};
-use move_core_types::{identifier::Identifier, move_resource::MoveResource};
+use move_core_types::{
+    identifier::Identifier,
+    language_storage::{StructTag, CORE_CODE_ADDRESS},
+    move_resource::MoveResource,
+};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{collections::btree_map::BTreeMap, convert::TryFrom, fmt};
 
@@ -36,53 +40,38 @@ impl AccountState {
         self.get_resource::<AccountResource>()
     }
 
-    pub fn get_balance_resources(
-        &self,
-        currency_codes: &[Identifier],
-    ) -> Result<BTreeMap<Identifier, BalanceResource>> {
-        currency_codes
-            .iter()
-            .filter_map(|currency_code| {
-                let currency_type_tag = type_tag_for_currency_code(currency_code.to_owned());
-                // TODO: update this to use BalanceResource::resource_path once that takes type
-                // parameters
-                self.get_resource_impl(&BalanceResource::access_path_for(currency_type_tag))
-                    .transpose()
-                    .map(|balance| balance.map(|b| (currency_code.to_owned(), b)))
+    pub fn get_balance_resources(&self) -> Result<BTreeMap<Identifier, BalanceResource>> {
+        self.get_resources_with_type::<BalanceResource>()
+            .map(|maybe_resource| {
+                let (struct_tag, resource) = maybe_resource?;
+                let currency_code = collect_exactly_one(struct_tag.type_params.into_iter())
+                    .ok_or_else(|| format_err!("expected one currency_code type tag"))
+                    .and_then(currency_code_from_type_tag)?;
+                Ok((currency_code, resource))
             })
             .collect()
     }
 
-    pub fn get_preburn_balances(
-        &self,
-        currency_codes: &[Identifier],
-    ) -> Result<BTreeMap<Identifier, PreburnResource>> {
-        currency_codes
-            .iter()
-            .filter_map(|currency_code| {
-                let currency_type_tag = type_tag_for_currency_code(currency_code.to_owned());
-                // TODO: update this to use PreburnResource::resource_path once that takes type
-                // parameters
-                self.get_resource_impl(&PreburnResource::access_path_for(currency_type_tag))
-                    .transpose()
-                    .map(|preburn_balance| preburn_balance.map(|b| (currency_code.to_owned(), b)))
+    pub fn get_preburn_balances(&self) -> Result<BTreeMap<Identifier, PreburnResource>> {
+        self.get_resources_with_type::<PreburnResource>()
+            .map(|maybe_resource| {
+                let (struct_tag, resource) = maybe_resource?;
+                let currency_code = collect_exactly_one(struct_tag.type_params.into_iter())
+                    .ok_or_else(|| format_err!("expected one currency_code type tag"))
+                    .and_then(currency_code_from_type_tag)?;
+                Ok((currency_code, resource))
             })
             .collect()
     }
 
-    pub fn get_preburn_queue_balances(
-        &self,
-        currency_codes: &[Identifier],
-    ) -> Result<BTreeMap<Identifier, PreburnQueueResource>> {
-        currency_codes
-            .iter()
-            .filter_map(|currency_code| {
-                let currency_type_tag = type_tag_for_currency_code(currency_code.to_owned());
-                // TODO: update this to use PreburnQueueResource::resource_path once that takes type
-                // parameters
-                self.get_resource_impl(&PreburnQueueResource::access_path_for(currency_type_tag))
-                    .transpose()
-                    .map(|preburn_balance| preburn_balance.map(|b| (currency_code.to_owned(), b)))
+    pub fn get_preburn_queue_balances(&self) -> Result<BTreeMap<Identifier, PreburnQueueResource>> {
+        self.get_resources_with_type::<PreburnQueueResource>()
+            .map(|maybe_resource| {
+                let (struct_tag, resource) = maybe_resource?;
+                let currency_code = collect_exactly_one(struct_tag.type_params.into_iter())
+                    .ok_or_else(|| format_err!("expected one currency_code type tag"))
+                    .and_then(currency_code_from_type_tag)?;
+                Ok((currency_code, resource))
             })
             .collect()
     }
@@ -113,7 +102,7 @@ impl AccountState {
         self.get_resource::<FreezingBit>()
     }
 
-    pub fn get_account_role(&self, currency_codes: &[Identifier]) -> Result<Option<AccountRole>> {
+    pub fn get_account_role(&self) -> Result<Option<AccountRole>> {
         if self.0.contains_key(&ParentVASP::resource_path()) {
             match (
                 self.get_resource::<ParentVASP>(),
@@ -130,8 +119,8 @@ impl AccountState {
         } else if self.0.contains_key(&DesignatedDealer::resource_path()) {
             match (
                 self.get_resource::<Credential>(),
-                self.get_preburn_balances(&currency_codes),
-                self.get_preburn_queue_balances(&currency_codes),
+                self.get_preburn_balances(),
+                self.get_preburn_queue_balances(),
                 self.get_resource::<DesignatedDealer>(),
             ) {
                 (
@@ -242,6 +231,41 @@ impl AccountState {
             },
         )
     }
+
+    /// Return an iterator over all resources stored under this account.
+    ///
+    /// Note that resource access [`Path`]s that fail to deserialize will be
+    /// silently ignored.
+    pub fn get_resources(&self) -> impl Iterator<Item = (StructTag, &[u8])> {
+        self.0.iter().filter_map(|(k, v)| match Path::try_from(k) {
+            Ok(Path::Resource(struct_tag)) => Some((struct_tag, v.as_ref())),
+            Ok(Path::Code(_)) | Err(_) => None,
+        })
+    }
+
+    /// Given a particular `MoveResource`, return an iterator with all instances
+    /// of that resource (there may be multiple with different generic type parameters).
+    pub fn get_resources_with_type<T: MoveResource>(
+        &self,
+    ) -> impl Iterator<Item = Result<(StructTag, T)>> + '_ {
+        self.get_resources().filter_map(|(struct_tag, bytes)| {
+            let matches_resource = struct_tag.address == CORE_CODE_ADDRESS
+                && struct_tag.module.as_ref() == T::MODULE_NAME
+                && struct_tag.name.as_ref() == T::STRUCT_NAME;
+            if matches_resource {
+                match bcs::from_bytes::<T>(bytes) {
+                    Ok(resource) => Some(Ok((struct_tag, resource))),
+                    Err(err) => Some(Err(format_err!(
+                        "failed to deserialize resource: '{}', error: {:?}",
+                        struct_tag,
+                        err
+                    ))),
+                }
+            } else {
+                None
+            }
+        })
+    }
 }
 
 impl fmt::Debug for AccountState {
@@ -297,5 +321,15 @@ impl TryFrom<(&AccountResource, &BalanceResource)> for AccountState {
         );
 
         Ok(Self(btree_map))
+    }
+}
+
+/// If an iterator contains exactly one item, then return it. Otherwise return
+/// `None` if there are no items or more than one items.
+fn collect_exactly_one<T>(iter: impl Iterator<Item = T>) -> Option<T> {
+    let mut iter = iter.fuse();
+    match (iter.next(), iter.next()) {
+        (Some(item), None) => Some(item),
+        _ => None,
     }
 }


### PR DESCRIPTION
## Overview

**Problem:** In order to project an `AccountState` into a json-rpc `AccountView`, we need to pull out the balance resources from the `AccountState`, which currently requires a list of currency code `Identifiers` (e.g. "XUS" or "XDX") to build the access `Path` needed to lookup the resource bytes from the state. To get the list of currency codes, we first need to lookup the global `RegisteredCurrencies` set, which requires an extra request for the verifying client's `get_account` implementation and doubles the read-amplification for normal `get_account` requests.

**Solution:** Instead of indexing by currency code to get the balance resources, this diff just reads all balance resources directly and extracts the currency code from the generic type parameter. That way, we don't need to first lookup the global supported currencies list. Likewise for preburn and preburn queue resources.

## Commits

###  [types] Get balances from an account state without indexing by currency

The previous version required callers to provide a list of currency codes in order to retrieve the `BalanceResource`s in an `AccountState`. With this change, we instead look up all `BalanceResource`s under an `AccountState` directly (there may be several with different generic coin type parameters).

Likewise, we simply list all `PreburnResource`s and `PreburnQueueResource`s instead of indexing by currency codes.

This change will allow us to avoid looking up the set of registered currencies from the `DiemRoot` account before we're able to deserialize account balances from an `AccountState`.

### [json-rpc] Avoid extra get_currencies lookup for get_account

Following the previous commit, we can avoid doing an extra `get_currencies` call in `get_account` since we no longer need the list of currencies to index into the current balance resources. The same is true for the verifying client's implementation of `get_account`. This halves the number of requests needed to support the verifying client's `get_account` call.

