### PR TITLE
Correct the Signer module documentation

### DIFF
--- a/language/move-stdlib/modules/Signer.move
+++ b/language/move-stdlib/modules/Signer.move
@@ -1,10 +1,10 @@
 address 0x1 {
 module Signer {
     // Borrows the address of the signer
-    // Conceptually, you can think of the `signer` as being a resource struct wrapper arround an
+    // Conceptually, you can think of the `signer` as being a struct wrapper arround an
     // address
     // ```
-    // struct Signer has key, store { addr: address }
+    // struct Signer has drop { addr: address }
     // ```
     // `borrow_address` borrows this inner field
     native public fun borrow_address(s: &signer): &address;


### PR DESCRIPTION
Conceptually, Signer is a droppable struct.

## Motivation

To correct the Signer module doc

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

cargo test