### PR TITLE
Rust Offchain API: Add Diem Intent Identifier and accompanying fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,9 +222,9 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3548b8efc9f8e8a5a0a2808c5bd8451a9031b9e5b879a79590304ae928b0a70"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -233,9 +233,9 @@ version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36ea56748e10732c49404c153638a15ec3d6211ec5ff35d9bb20e13b93576adf"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -381,6 +381,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bech32"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c7f7096bc256f5e5cb960f60dfc4f4ef979ca65abe7fb9d5a4f77150d3783d4"
+
+[[package]]
 name = "bincode"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,7 +412,7 @@ dependencies = [
  "lazycell",
  "log",
  "peeking_take_while",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
  "regex",
  "rustc-hash",
@@ -749,7 +755,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -1578,9 +1584,9 @@ version = "0.0.2"
 dependencies = [
  "anyhow",
  "diem-workspace-hack",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -1933,9 +1939,9 @@ name = "diem-log-derive"
 version = "0.1.0"
 dependencies = [
  "diem-workspace-hack",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -2255,7 +2261,7 @@ name = "diem-smoke-test-attribute"
 version = "0.1.0"
 dependencies = [
  "diem-workspace-hack",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
 ]
 
@@ -2533,7 +2539,7 @@ dependencies = [
  "standback",
  "subtle",
  "syn 0.15.44",
- "syn 1.0.64",
+ "syn 1.0.72",
  "tiny-keccak",
  "tokio",
  "tokio-util",
@@ -2846,9 +2852,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8946e241a7774d5327d92749c50806f275f57d031d2229ecbfd65469a8ad338e"
 dependencies = [
  "once_cell",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -3256,9 +3262,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -3826,9 +3832,9 @@ checksum = "327869970574819d24d1dca25c891856144d29159ab797fa9dc725c5c3f57215"
 dependencies = [
  "anyhow",
  "proc-macro-hack",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -5114,9 +5120,9 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -5178,9 +5184,9 @@ name = "num-variants"
 version = "0.1.0"
 dependencies = [
  "diem-workspace-hack",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -5216,13 +5222,18 @@ name = "offchain"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "bech32",
  "diem-sdk",
  "diem-workspace-hack",
  "hex",
+ "rand 0.8.3",
  "rand_core 0.6.2",
+ "rstest",
  "serde",
  "serde_json",
  "serde_repr",
+ "thiserror",
+ "url",
  "uuid",
 ]
 
@@ -5320,9 +5331,9 @@ checksum = "41db02c8f8731cdd7a72b433c7900cce4bf245465b452c364bfd21f4566ab055"
 dependencies = [
  "Inflector",
  "proc-macro-error",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -5438,9 +5449,9 @@ checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -5479,9 +5490,9 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758669ae3558c6f74bd2a18b41f7ac0b5a195aea6639d6a9b5e5d1ad5ba24c0b"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -5556,9 +5567,9 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597c3287a549da151aca6ada2795ecde089c7527bd5093114e8e0e1c3f0e52b1"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -5609,9 +5620,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
  "version_check",
 ]
 
@@ -5621,7 +5632,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
  "version_check",
 ]
@@ -5649,9 +5660,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid 0.2.1",
 ]
@@ -5737,9 +5748,9 @@ checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
 dependencies = [
  "anyhow",
  "itertools 0.9.0",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -5841,7 +5852,7 @@ version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
 ]
 
 [[package]]
@@ -6058,9 +6069,9 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c38e3aecd2b21cb3959637b883bb3714bc7e43f0268b9a29d3743ee3e55cdd2"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -6191,6 +6202,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "041bb0202c14f6a158bbbf086afb03d0c6e975c2dec7d4912f8061ed44f290af"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "rustc_version 0.3.3",
+ "syn 1.0.72",
+]
+
+[[package]]
 name = "rusoto_autoscaling"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6222,7 +6246,7 @@ dependencies = [
  "log",
  "rusoto_credential",
  "rusoto_signature",
- "rustc_version",
+ "rustc_version 0.2.3",
  "serde",
  "serde_json",
  "tokio",
@@ -6278,7 +6302,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rusoto_credential",
- "rustc_version",
+ "rustc_version 0.2.3",
  "serde",
  "sha2",
  "time 0.2.25",
@@ -6342,6 +6366,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
 ]
 
 [[package]]
@@ -6703,9 +6736,9 @@ version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -6726,9 +6759,9 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dc6b7951b17b051f3210b063f12cc17320e2fe30ae05b0fe2a3abb068551c76"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -6784,9 +6817,9 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -7141,7 +7174,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
 dependencies = [
  "discard",
- "rustc_version",
+ "rustc_version 0.2.3",
  "stdweb-derive",
  "stdweb-internal-macros",
  "stdweb-internal-runtime",
@@ -7154,11 +7187,11 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
  "serde",
  "serde_derive",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -7168,13 +7201,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
  "base-x",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
  "serde",
  "serde_derive",
  "serde_json",
  "sha1",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -7289,9 +7322,9 @@ checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -7346,11 +7379,11 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.64"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd9d1e9976102a03c542daa2eff1b43f9d72306342f3f8b3ed5fb8908195d6f"
+checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
  "unicode-xid 0.2.1",
 ]
@@ -7361,9 +7394,9 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
  "unicode-xid 0.2.1",
 ]
 
@@ -7532,9 +7565,9 @@ version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -7589,10 +7622,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
  "standback",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -7665,9 +7698,9 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -7810,9 +7843,9 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8a9bd1db7706f2373a190b0d067146caa39350c486f3d455b0e33b431f94c07"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -8085,9 +8118,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -8279,9 +8312,9 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
  "wasm-bindgen-shared",
 ]
 
@@ -8313,9 +8346,9 @@ version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8527,8 +8560,8 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
  "synstructure",
 ]

--- a/common/workspace-hack/Cargo.toml
+++ b/common/workspace-hack/Cargo.toml
@@ -112,7 +112,7 @@ serde_json = { version = "1.0.64", features = ["default", "indexmap", "preserve_
 standback = { version = "0.2.15", default-features = false, features = ["std"] }
 subtle = { version = "2.4.0", default-features = false, features = ["std"] }
 syn-3575ec1268b04181 = { package = "syn", version = "0.15.44", features = ["clone-impls", "default", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
-syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.64", features = ["clone-impls", "default", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
+syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.72", features = ["clone-impls", "default", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
 tiny-keccak = { version = "2.0.2", features = ["default", "sha3"] }
 tokio = { version = "1.3.0", features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "test-util", "time", "tokio-macros", "winapi"] }
 tokio-util = { version = "0.6.4", features = ["codec", "compat", "default", "futures-io", "io"] }
@@ -223,7 +223,7 @@ serde_json = { version = "1.0.64", features = ["default", "indexmap", "preserve_
 standback = { version = "0.2.15", default-features = false, features = ["std"] }
 subtle = { version = "2.4.0", default-features = false, features = ["std"] }
 syn-3575ec1268b04181 = { package = "syn", version = "0.15.44", features = ["clone-impls", "default", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
-syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.64", features = ["clone-impls", "default", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
+syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.72", features = ["clone-impls", "default", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
 tiny-keccak = { version = "2.0.2", features = ["default", "sha3"] }
 tokio = { version = "1.3.0", features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "test-util", "time", "tokio-macros", "winapi"] }
 tokio-util = { version = "0.6.4", features = ["codec", "compat", "default", "futures-io", "io"] }

--- a/sdk/offchain/Cargo.toml
+++ b/sdk/offchain/Cargo.toml
@@ -11,15 +11,21 @@ edition = "2018"
 
 [dependencies]
 base64 = "0.13"
+bech32 = "0.8.0"
+hex = "0.4.3"
+rand = "0.8.3"
+rand_core = "0.6"
 serde = { version = "1.0.123", features = ["derive"] }
 serde_json = "1.0.61"
 serde_repr = "0.1"
+thiserror = "1.0.24"
+url = "2.2.2"
 uuid = { version = "0.8.2", features = ["serde"] }
 
 diem-sdk = { path = ".." }
 
 [dev-dependencies]
-hex = "0.4.2"
 rand_core = "0.6"
+rstest = "0.10.0"
 
 diem-workspace-hack = { path = "../../common/workspace-hack" }

--- a/sdk/offchain/src/identifier.rs
+++ b/sdk/offchain/src/identifier.rs
@@ -1,0 +1,428 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(clippy::clippy::upper_case_acronyms)]
+
+use crate::subaddress::{Subaddress, SubaddressParseError};
+use bech32::{self, u5, FromBase32, ToBase32};
+use diem_sdk::{
+    move_types::account_address::AccountAddressParseError,
+    transaction_builder::Currency,
+    types::{
+        account_address::AccountAddress,
+        account_config::{allowed_currency_code_string, XDX_NAME, XUS_NAME},
+    },
+};
+use std::{collections::HashMap, str::FromStr};
+use thiserror::Error;
+use url::Url;
+
+const DIEM_BECH32_VERSION_LENGTH: usize = 1;
+const DIEM_BECH32_VERSION: u8 = 1;
+
+/// Intent is a struct holdind data decoded from Diem Intent Identifier string
+/// https://dip.diem.com/dip-5/#format
+#[derive(Ord, PartialOrd, Eq, PartialEq, Hash, Clone)]
+pub struct Intent {
+    account_address: AccountAddress,
+    subaddress: Subaddress,
+    currency: Option<Currency>,
+    amount: Option<u64>,
+    hrp: HumanReadablePrefix,
+}
+
+impl Intent {
+    /// Encode Intent as a Diem intent identifier (https://dip.diem.com/dip-5/).
+    ///
+    /// ## Example
+    /// ```
+    /// use offchain::identifier::Intent;
+    /// use std::str::FromStr;
+    /// let identifier = "diem://dm1p7ujcndcl7nudzwt8fglhx6wxn08kgs5tm6mz4us2vfufk?c=XUS&am=4500";
+    /// let intent = Intent::from_str(identifier).unwrap();
+    /// assert_eq!(intent.to_encoded_string().unwrap(), identifier);
+    /// ```
+    pub fn to_encoded_string(&self) -> Result<String, IntentIdentifierError> {
+        let encoded_account = match encode_account(self.hrp, self.account_address, self.subaddress)
+        {
+            Ok(encoded_account) => encoded_account,
+            Err(error) => return Err(IntentIdentifierError::Bech32(error)),
+        };
+        Ok(encode_intent(&encoded_account, self.currency, self.amount))
+    }
+
+    pub fn account_address(&self) -> &AccountAddress {
+        &self.account_address
+    }
+
+    pub fn subaddress(&self) -> &Subaddress {
+        &self.subaddress
+    }
+
+    pub fn currency(&self) -> Option<Currency> {
+        self.currency
+    }
+
+    pub fn amount(&self) -> Option<u64> {
+        self.amount
+    }
+
+    pub fn hrp(&self) -> &HumanReadablePrefix {
+        &self.hrp
+    }
+}
+
+impl FromStr for Intent {
+    type Err = IntentIdentifierError;
+
+    /// Decode Diem intent identifier (https://dip.diem.com/dip-5/) int 3 parts:
+    /// 1. account identifier: account address & sub-address
+    /// 2. currency
+    /// 3. amount
+    ///
+    /// ## Example
+    /// ```
+    /// use offchain::identifier::HumanReadablePrefix;
+    /// use offchain::identifier::Intent;
+    /// use std::str::FromStr;
+    /// let identifier = "diem://dm1p7ujcndcl7nudzwt8fglhx6wxn08kgs5tm6mz4us2vfufk?c=XUS&am=4500";
+    /// let intent = Intent::from_str(identifier).unwrap();
+    /// assert_eq!(intent.hrp(), &HumanReadablePrefix::DM);
+    /// assert_eq!(intent.amount(), Some(4500));
+    /// ```
+    fn from_str(encoded_intent_identifier: &str) -> Result<Intent, IntentIdentifierError> {
+        let result: Url = Url::parse(encoded_intent_identifier)?;
+        if result.scheme() != "diem" {
+            return Err(IntentIdentifierError::Parse(format!(
+                "Unknown intent identifier scheme {}",
+                result.scheme()
+            )));
+        }
+
+        if result.host_str().is_none() {
+            return Err(IntentIdentifierError::Parse(
+                "No host string in encoded identifier".to_string(),
+            ));
+        }
+        let (hrp, account_address, subaddress) = decode_account(result.host_str().unwrap())?;
+        let params: HashMap<String, String> = result.query_pairs().into_owned().collect();
+        let amount = normalize_amount(params.get("am"))?;
+        let currency = normalize_currency(params.get("c"))?;
+
+        Ok(Self {
+            account_address,
+            subaddress,
+            currency,
+            amount,
+            hrp,
+        })
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum IntentIdentifierError {
+    #[error(transparent)]
+    AccountAddress(#[from] AccountAddressParseError),
+    #[error(transparent)]
+    Bech32(#[from] bech32::Error),
+    #[error("{0}")]
+    Parse(String),
+    #[error(transparent)]
+    Subaddress(#[from] SubaddressParseError),
+    #[error(transparent)]
+    Url(#[from] url::ParseError),
+}
+
+/// Defines the available HRPs (human readable prefix) as defined in
+/// https://dip.diem.com/dip-5/#format
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
+pub enum HumanReadablePrefix {
+    DM,
+    PDM,
+    TDM,
+}
+
+impl std::fmt::Display for HumanReadablePrefix {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl FromStr for HumanReadablePrefix {
+    type Err = IntentIdentifierError;
+
+    fn from_str(s: &str) -> Result<Self, IntentIdentifierError> {
+        match s.to_lowercase().as_str() {
+            "dm" => Ok(HumanReadablePrefix::DM),
+            "tdm" => Ok(HumanReadablePrefix::TDM),
+            "pdm" => Ok(HumanReadablePrefix::PDM),
+            _ => Err(IntentIdentifierError::Parse(format!("Unknown HRP {}", s))),
+        }
+    }
+}
+
+impl HumanReadablePrefix {
+    pub fn as_str(&self) -> &str {
+        match self {
+            HumanReadablePrefix::DM => "dm",
+            HumanReadablePrefix::PDM => "pdm",
+            HumanReadablePrefix::TDM => "tdm",
+        }
+    }
+}
+
+/// Encode onchain address and subaddress with human readable prefix (hrp) into bech32 format.
+fn encode_account(
+    hrp: HumanReadablePrefix,
+    account_address: AccountAddress,
+    subaddress: Subaddress,
+) -> Result<String, bech32::Error> {
+    let five_bit_data = [account_address.to_vec(), subaddress.to_vec()]
+        .concat()
+        .to_base32();
+    let diem_encoding_version = vec![u5::try_from_u8(DIEM_BECH32_VERSION)?];
+    let bytes = [diem_encoding_version, five_bit_data].concat();
+    bech32::encode(hrp.as_str(), bytes, bech32::Variant::Bech32)
+}
+
+/// Decodes an encoded address using bech32, ensuring a matching hrp (human readable prefix).
+fn decode_account(
+    encoded_address: &str,
+) -> Result<(HumanReadablePrefix, AccountAddress, Subaddress), IntentIdentifierError> {
+    let (hrp_str, data, _variant) = bech32::decode(encoded_address)?;
+    if data.len() < DIEM_BECH32_VERSION_LENGTH + AccountAddress::LENGTH + Subaddress::LENGTH {
+        return Err(IntentIdentifierError::Parse(format!(
+            "Unexpected encoded address length of {}",
+            data.len(),
+        )));
+    }
+
+    let diem_address_version = data[0].to_u8();
+    if diem_address_version != DIEM_BECH32_VERSION {
+        return Err(IntentIdentifierError::Parse(format!(
+            "Unsupported Diem Bech32 Version {}, expected {}",
+            diem_address_version, DIEM_BECH32_VERSION,
+        )));
+    }
+
+    let hrp = HumanReadablePrefix::from_str(hrp_str.as_str())?;
+    let payload = Vec::<u8>::from_base32(&data[1..])?;
+    let account_address = AccountAddress::from_bytes(&payload[..AccountAddress::LENGTH])?;
+    let subaddress = Subaddress::from_bytes(
+        &payload[AccountAddress::LENGTH..AccountAddress::LENGTH + Subaddress::LENGTH],
+    )?;
+    Ok((hrp, account_address, subaddress))
+}
+
+/// Encode account identifier string(encoded), currency and amount into
+/// Diem intent identifier (https://dip.diem.com/dip-5/)
+fn encode_intent(
+    encoded_account_identifier: &str,
+    currency: Option<Currency>,
+    amount: Option<u64>,
+) -> String {
+    let mut params = Vec::new();
+    if let Some(c) = currency {
+        params.push(format!("c={}", c));
+    }
+    if let Some(am) = amount {
+        params.push(format!("am={}", am));
+    }
+    if !params.is_empty() {
+        return format!("diem://{}?{}", encoded_account_identifier, params.join("&"));
+    }
+
+    return format!("diem://{}", encoded_account_identifier);
+}
+
+fn normalize_amount(input: Option<&String>) -> Result<Option<u64>, IntentIdentifierError> {
+    if let Some(amount) = input {
+        if let Ok(parsed_amount) = amount.parse::<u64>() {
+            return Ok(Some(parsed_amount));
+        } else {
+            return Err(IntentIdentifierError::Parse(
+                "Amount is invalid".to_string(),
+            ));
+        }
+    }
+    Ok(None)
+}
+
+fn normalize_currency(input: Option<&String>) -> Result<Option<Currency>, IntentIdentifierError> {
+    if let Some(currency) = input {
+        if allowed_currency_code_string(currency) {
+            return Ok(Some(currency_from_str(currency)?));
+        } else {
+            return Err(IntentIdentifierError::Parse(format!(
+                "currency {} is invalid",
+                currency
+            )));
+        }
+    }
+    Ok(None)
+}
+
+fn currency_from_str(currency: &str) -> Result<Currency, IntentIdentifierError> {
+    match currency {
+        XUS_NAME => Ok(Currency::XUS),
+        XDX_NAME => Ok(Currency::XDX),
+        _ => Err(IntentIdentifierError::Parse(format!(
+            "Unable to parse currency {}",
+            currency,
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bech32::{self, FromBase32, ToBase32};
+    use diem_sdk::types::account_address::AccountAddress;
+    use rstest::rstest;
+
+    const ACCOUNT_ADDRESS: &str = "f72589b71ff4f8d139674a3f7369c69b";
+    const SUBADDRESS: &str = "cf64428bdeb62af2";
+    const ZERO_SUBADDRESS: &str = "0000000000000000";
+
+    #[test]
+    fn test_encode_intent_parameterless() {
+        let intent_id = encode_intent("an_account_identifier", None, None);
+        assert_eq!(intent_id, "diem://an_account_identifier");
+    }
+
+    #[test]
+    fn test_encode_intent_parameters() {
+        let intent_id = encode_intent("an_account_identifier", Some(Currency::XUS), Some(45_00));
+        assert_eq!(intent_id, "diem://an_account_identifier?c=XUS&am=4500");
+    }
+
+    #[test]
+    fn test_encode_account() {
+        let vasp_address =
+            AccountAddress::from_hex_literal("0xd738a0b9851305dfe1d17707f0841dbc").unwrap();
+        let user_subaddress = Subaddress::from_hex("9072d012034a880f").unwrap();
+
+        let encoded_account =
+            encode_account(HumanReadablePrefix::TDM, vasp_address, user_subaddress).unwrap();
+
+        let expectation = "tdm1p6uu2pwv9zvzalcw3wurlppqahjg895qjqd9gsrcr9dqh8";
+        assert_eq!(encoded_account, expectation);
+    }
+
+    #[rstest]
+    #[case(
+        "dm1p7ujcndcl7nudzwt8fglhx6wxn08kgs5tm6mz4us2vfufk",
+        HumanReadablePrefix::DM,
+        ACCOUNT_ADDRESS,
+        SUBADDRESS
+    )]
+    #[case(
+        "dm1p7ujcndcl7nudzwt8fglhx6wxnvqqqqqqqqqqqqqd8p9cq",
+        HumanReadablePrefix::DM,
+        ACCOUNT_ADDRESS,
+        ZERO_SUBADDRESS
+    )]
+    #[case(
+        "tdm1p7ujcndcl7nudzwt8fglhx6wxn08kgs5tm6mz4ustv0tyx",
+        HumanReadablePrefix::TDM,
+        ACCOUNT_ADDRESS,
+        SUBADDRESS
+    )]
+    #[case(
+        "tdm1p7ujcndcl7nudzwt8fglhx6wxnvqqqqqqqqqqqqqv88j4s",
+        HumanReadablePrefix::TDM,
+        ACCOUNT_ADDRESS,
+        ZERO_SUBADDRESS
+    )]
+    fn test_decode_account(
+        #[case] encoded_account: &str,
+        #[case] expected_hrp: HumanReadablePrefix,
+        #[case] expected_account_address: &str,
+        #[case] expected_subaddress: &str,
+    ) {
+        let (hrp, account_address, subaddress) = decode_account(encoded_account).unwrap();
+        assert_eq!(hrp, expected_hrp);
+        assert_eq!(account_address.to_hex(), expected_account_address);
+        assert_eq!(subaddress.to_hex(), expected_subaddress);
+    }
+
+    #[rstest]
+    #[case(
+        "diem://dm1p7ujcndcl7nudzwt8fglhx6wxn08kgs5tm6mz4us2vfufk?c=XUS&am=4500",
+        HumanReadablePrefix::DM,
+        ACCOUNT_ADDRESS,
+        SUBADDRESS,
+        Some(Currency::XUS),
+        Some(4500)
+    )]
+    #[case(
+        "diem://tdm1p7ujcndcl7nudzwt8fglhx6wxnvqqqqqqqqqqqqqv88j4s",
+        HumanReadablePrefix::TDM,
+        ACCOUNT_ADDRESS,
+        ZERO_SUBADDRESS,
+        None,
+        None
+    )]
+    fn test_intent_from_str(
+        #[case] encoded_intent_identifier: &str,
+        #[case] expected_hrp: HumanReadablePrefix,
+        #[case] expected_account_address: &str,
+        #[case] expected_subaddress: &str,
+        #[case] expected_currency: Option<Currency>,
+        #[case] expected_amount: Option<u64>,
+    ) {
+        let intent = Intent::from_str(encoded_intent_identifier).unwrap();
+        assert_eq!(intent.hrp, expected_hrp);
+        assert_eq!(intent.account_address.to_hex(), expected_account_address);
+        assert_eq!(intent.subaddress.to_hex(), expected_subaddress);
+        match intent.currency {
+            Some(currency) => assert_eq!(currency, expected_currency.unwrap()),
+            None => assert_eq!(None, expected_currency),
+        }
+        assert_eq!(intent.amount, expected_amount);
+    }
+
+    #[test]
+    fn test_intent_to_and_from_reversible() {
+        let mut hex_address = String::from("0x");
+        hex_address.push_str(ACCOUNT_ADDRESS);
+
+        let intent = Intent {
+            account_address: AccountAddress::from_hex_literal(&hex_address).unwrap(),
+            subaddress: Subaddress::from_hex(SUBADDRESS).unwrap(),
+            currency: Some(Currency::XUS),
+            amount: Some(4500),
+            hrp: HumanReadablePrefix::DM,
+        };
+
+        let encoded_intent = intent.to_encoded_string().unwrap();
+        let decoded_intent = Intent::from_str(&encoded_intent).unwrap();
+
+        assert_eq!(
+            decoded_intent.account_address.to_hex(),
+            intent.account_address.to_hex()
+        );
+        assert_eq!(
+            decoded_intent.subaddress.to_hex(),
+            intent.subaddress.to_hex()
+        );
+        assert_eq!(decoded_intent.currency, intent.currency);
+        assert_eq!(decoded_intent.amount, intent.amount);
+        assert_eq!(decoded_intent.hrp, intent.hrp);
+    }
+
+    #[test]
+    fn test_bech32_reversibility() {
+        let hrp = "dm";
+        let address_str = "deadbeef";
+        let data = hex::decode(address_str).unwrap().to_base32();
+        let encoded = bech32::encode(hrp, data, bech32::Variant::Bech32).unwrap();
+        assert_eq!(encoded, "dm1m6kmamc4w6d7n");
+
+        let (decoded_hrp, decoded_data, _variant) = bech32::decode(encoded.as_str()).unwrap();
+        assert_eq!(hrp, decoded_hrp);
+
+        let decoded_address = Vec::<u8>::from_base32(&decoded_data).unwrap();
+        assert_eq!(hex::encode(decoded_address), address_str);
+    }
+}

--- a/sdk/offchain/src/lib.rs
+++ b/sdk/offchain/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod identifier;
 pub mod jws;
 pub mod payment_command;
+pub mod subaddress;
 pub mod types;

--- a/sdk/offchain/src/subaddress.rs
+++ b/sdk/offchain/src/subaddress.rs
@@ -1,0 +1,114 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use hex::FromHex;
+use std::{convert::TryFrom, fmt};
+
+#[derive(Ord, PartialOrd, Eq, PartialEq, Hash, Clone, Copy)]
+pub struct Subaddress([u8; Subaddress::LENGTH]);
+
+// Implementation is inspired by AccountAddress.
+impl Subaddress {
+    pub const fn new(address: [u8; Self::LENGTH]) -> Self {
+        Self(address)
+    }
+
+    /// The number of bytes in an address.
+    pub const LENGTH: usize = 8;
+
+    /// Hex address: 0x0
+    pub const ZERO: Self = Self([0u8; Self::LENGTH]);
+
+    pub fn generate<R>(rng: &mut R) -> Self
+    where
+        R: ::rand_core::RngCore + ::rand_core::CryptoRng,
+    {
+        let mut buf = [0u8; Self::LENGTH];
+        rng.fill_bytes(&mut buf);
+        Self(buf)
+    }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.0.to_vec()
+    }
+
+    pub fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, SubaddressParseError> {
+        <[u8; Self::LENGTH]>::from_hex(hex)
+            .map_err(|_| SubaddressParseError)
+            .map(Self)
+    }
+
+    pub fn to_hex(&self) -> String {
+        format!("{:x}", self)
+    }
+
+    pub fn from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, SubaddressParseError> {
+        <[u8; Self::LENGTH]>::try_from(bytes.as_ref())
+            .map_err(|_| SubaddressParseError)
+            .map(Self)
+    }
+}
+
+impl fmt::Display for Subaddress {
+    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:x}", self)
+    }
+}
+
+impl fmt::Debug for Subaddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:x}", self)
+    }
+}
+
+impl fmt::LowerHex for Subaddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+
+        for byte in &self.0 {
+            write!(f, "{:02x}", byte)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl fmt::UpperHex for Subaddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+
+        for byte in &self.0 {
+            write!(f, "{:02X}", byte)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct SubaddressParseError;
+
+impl fmt::Display for SubaddressParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
+        write!(f, "unable to parse Subaddress")
+    }
+}
+
+impl std::error::Error for SubaddressParseError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_subaddress_random() {
+        let mut rng = ::rand::thread_rng();
+        let subaddr = Subaddress::generate(&mut rng);
+        let zeroaddr = Subaddress::ZERO;
+        assert_ne!(subaddr, zeroaddr);
+    }
+}

--- a/sdk/src/transaction_builder.rs
+++ b/sdk/src/transaction_builder.rs
@@ -538,7 +538,7 @@ impl DualAttestationMessage {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum Currency {
     XDX,

--- a/testsuite/cluster-test/src/experiments/reconfiguration_test.rs
+++ b/testsuite/cluster-test/src/experiments/reconfiguration_test.rs
@@ -44,7 +44,7 @@ impl ExperimentParam for ReconfigurationParams {
     type E = Reconfiguration;
     fn build(self, cluster: &Cluster) -> Self::E {
         let full_node = cluster.random_fullnode_instance();
-        let client = JsonRpcClientWrapper::new(full_node.json_rpc_url().into_string());
+        let client = JsonRpcClientWrapper::new(full_node.json_rpc_url().into());
         let validator_info = client
             .validator_set(None)
             .expect("Unable to fetch validator set");


### PR DESCRIPTION
## Motivation

The Diem Offchain API largely resides in python (https://github.com/diem/client-sdk-python). This PR continues the transition to the rust offchain API by adding the Diem Intent Identifier functionality as described in DIP 5: https://dip.diem.com/dip-5/#format.

This PR converts the python SDK identifier implementation for rust: https://github.com/diem/client-sdk-python/blob/master/src/diem/identifier/__init__.py.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

```
$ cd sdk/offchain
$ cargo test
```
