### PR TITLE
[stackless-vm] re-enable the emit test case and minor clean-up

### DIFF
--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/event.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/event.exp
@@ -1,2 +1,3 @@
 Running Move unit tests
-Test result: OK. Total tests: 0; passed: 0; failed: 0
+[ PASS    ] 0x2::A::emit
+Test result: OK. Total tests: 1; passed: 1; failed: 0

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/event.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/event.move
@@ -9,8 +9,7 @@ module 0x2::A {
         Event::destroy_handle(handle);
     }
 
-// TODO: Meng, this test started failing when I made invariant_v2 the default.
-//#    #[test(a=@0x2)]
+    #[test(a=@0x2)]
     public fun emit(a: &signer) {
         Event::publish_generator(a);
         do_emit<u64>(a);

--- a/language/move-prover/interpreter/src/lib.rs
+++ b/language/move-prover/interpreter/src/lib.rs
@@ -183,10 +183,11 @@ impl<'env> StacklessBytecodeInterpreter<'env> {
         args: &[MoveValue],
         global_state: &GlobalState,
     ) -> (VMResult<Vec<Vec<u8>>>, ChangeSet, GlobalState) {
+        let mut new_global_state = global_state.clone();
+
         // execute and convert results
-        let vm = Runtime::new(self.env, &self.targets);
-        let (vm_result, new_global_state) =
-            vm.execute(fun_env, ty_args, args, global_state.clone());
+        let vm = Runtime::new(&self.targets);
+        let vm_result = vm.execute(fun_env, ty_args, args, &mut new_global_state);
         let serialized_vm_result = vm_result.map(|rets| {
             rets.into_iter()
                 .map(|v| {

--- a/language/tools/move-unit-test/src/test_runner.rs
+++ b/language/tools/move-unit-test/src/test_runner.rs
@@ -208,17 +208,23 @@ impl SharedTestingConfig {
     ) -> (VMResult<ChangeSet>, VMResult<Vec<Vec<u8>>>, TestRunInfo) {
         let now = Instant::now();
 
+        let settings = if self.verbose {
+            InterpreterSettings::verbose_default()
+        } else {
+            InterpreterSettings::default()
+        };
+        let interpreter = StacklessBytecodeInterpreter::new(env, None, settings);
+
         // NOTE: as of now, `self.starting_storage_state` contains modules only and no resources.
         // The modules are captured by `env: &GlobalEnv` and the default GlobalState captures the
         // empty-resource state.
-        let interpreter =
-            StacklessBytecodeInterpreter::new(env, None, InterpreterSettings::default());
+        let global_state = GlobalState::default();
         let (return_result, change_set, _) = interpreter.interpret(
             &test_plan.module_id,
             &IdentStr::new(function_name).unwrap(),
             &[], // no ty args, at least for now
             &test_info.arguments,
-            &GlobalState::default(),
+            &global_state,
         );
 
         let test_run_info = TestRunInfo::new(


### PR DESCRIPTION
The emit-event test case is turned off when the global invariant processing is set to v2 by default. But it seems to be passing now. So let's re-enable it.

This PR also has two additional cleanups that
- re-stored verbose debug printing when running the stackless bytecode interpreter in the move unit test framework (I accidentally removed the setting in a prior commit)
- simplified the APIs for the entrypoint of the stackless bytecode interpreter a bit. The inner runtime does not need to take a whole GlobalState, instead, a `&mut` is enough.

## Motivation

testing and cleaning-up

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI
