### PR TITLE
[stackless-vm] update the interpreter with the new memory model

### DIFF
--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/function_call.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/function_call.exp
@@ -1,5 +1,6 @@
 Running Move unit tests
 [ PASS    ] 0x2::A::call_imm_ref
 [ PASS    ] 0x2::A::call_mut_ref
+[ PASS    ] 0x2::A::call_return_mut_ref
 [ PASS    ] 0x2::A::call_val
-Test result: OK. Total tests: 3; passed: 3; failed: 0
+Test result: OK. Total tests: 4; passed: 4; failed: 0

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/function_call.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/function_call.move
@@ -36,7 +36,7 @@ module 0x2::A {
         a
     }
 
-    // TODO (mengxu): this creates a Weak edge in the borrow graph
+    #[test]
     public fun call_return_mut_ref(): u64 {
         let a = 0;
         let b = &mut a;

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/return_mut_ref.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/return_mut_ref.exp
@@ -1,0 +1,4 @@
+Running Move unit tests
+[ PASS    ] 0x2::A::return_ref_path
+[ PASS    ] 0x2::A::return_ref_root
+Test result: OK. Total tests: 2; passed: 2; failed: 0

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/return_mut_ref.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/return_mut_ref.move
@@ -1,0 +1,64 @@
+module 0x2::A {
+    use 0x1::Vector;
+
+    struct X has copy, drop { value: u64 }
+    struct Y has copy, drop { value: u64 }
+    struct Z has copy, drop { value: u64, x: X }
+    struct V has copy, drop { is: vector<u64>, ts: vector<X> }
+
+    // Return reference with different root
+    fun return_ref_different_root(cond: bool, x: &mut X, y: &mut Y): &mut u64 {
+        if (cond) &mut x.value else &mut y.value
+    }
+
+    #[test]
+    public fun return_ref_root(): (X, Y) {
+        let x = X { value: 1 };
+        let y = Y { value: 2 };
+        let p = return_ref_different_root(true, &mut x, &mut y);
+        *p = 5;
+        let q = return_ref_different_root(false, &mut x, &mut y);
+        *q = 6;
+        (x, y)
+    }
+
+    // Return reference with different path
+    fun return_ref_different_path(cond: bool, z: &mut Z): &mut u64 {
+        if (cond) &mut z.value else &mut z.x.value
+    }
+
+    #[test]
+    public fun return_ref_path(): (Z, Z) {
+        let z1 = Z { value: 1, x: X { value: 2 } };
+        let p = return_ref_different_path(true, &mut z1);
+        *p = 5;
+        let z2 = Z { value: 1, x: X { value: 2 } };
+        let q = return_ref_different_path(false, &mut z2);
+        *q = 6;
+        (z1, z2)
+    }
+
+    // Return reference with different path in vec
+    fun return_ref_different_path_vec(cond: bool, v: &mut V, i1: u64, i2: u64): &mut u64 {
+        if (cond) {
+            Vector::borrow_mut(&mut v.is, i1)
+        } else {
+            Vector::borrow_mut(&mut v.is, i2)
+        }
+    }
+
+    // TODO there is a bug in spec_instrumenter that produces wrong goto labels:
+    // #[test]
+    public fun return_ref_path_vec_1(): V {
+        let is = Vector::empty();
+        let ts = Vector::empty();
+        Vector::push_back(&mut is, 1);
+        Vector::push_back(&mut is, 2);
+        let v = V { is, ts };
+        let p = return_ref_different_path_vec(true, &mut v, 0, 1);
+        *p = 5;
+        let q = return_ref_different_path_vec(false, &mut v, 0, 1);
+        *q = 6;
+        v
+    }
+}

--- a/language/move-prover/interpreter/src/concrete/local_state.rs
+++ b/language/move-prover/interpreter/src/concrete/local_state.rs
@@ -12,7 +12,7 @@ use move_model::ast::TempIndex;
 
 use crate::concrete::{
     ty::Type,
-    value::{LocalSlot, TypedValue},
+    value::{LocalSlot, Pointer, TypedValue},
 };
 
 #[derive(Clone, Debug)]
@@ -141,6 +141,15 @@ impl LocalState {
         } else {
             self.pc += 1;
         }
+    }
+
+    /// Collect the pointers of the underlying values in the local slots
+    pub fn collect_pointers(&self) -> BTreeMap<TempIndex, &Pointer> {
+        self.slots
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, slot)| slot.get_content().map(|(_, ptr)| (idx, ptr)))
+            .collect()
     }
 
     /// Mark that an abort is raised and we will be executing the abort action next

--- a/language/move-prover/interpreter/src/concrete/local_state.rs
+++ b/language/move-prover/interpreter/src/concrete/local_state.rs
@@ -3,15 +3,12 @@
 
 use std::collections::BTreeMap;
 
-use move_binary_format::{
-    errors::{Location, PartialVMError, VMError},
-    file_format::CodeOffset,
-};
+use move_binary_format::errors::{Location, PartialVMError, VMError};
 use move_core_types::vm_status::StatusCode;
 use move_model::ast::TempIndex;
 
 use crate::concrete::{
-    ty::Type,
+    ty::{CodeOffset, Type},
     value::{LocalSlot, Pointer, TypedValue},
 };
 

--- a/language/move-prover/interpreter/src/concrete/player.rs
+++ b/language/move-prover/interpreter/src/concrete/player.rs
@@ -31,8 +31,8 @@ use crate::{
         local_state::{AbortInfo, LocalState, TerminationStatus},
         settings::InterpreterSettings,
         ty::{
-            convert_model_base_type, convert_model_local_type, convert_model_struct_type, BaseType,
-            Type,
+            convert_model_base_type, convert_model_local_type, convert_model_partial_struct_type,
+            convert_model_struct_type, BaseType, Type,
         },
         value::{EvalState, GlobalState, LocalSlot, Pointer, TypedValue},
     },
@@ -1853,7 +1853,7 @@ impl<'env> FunctionContext<'env> {
         eval_state: &mut EvalState,
     ) {
         let env = self.target.global_env();
-        let inst = convert_model_struct_type(env, module_id, struct_id, ty_args, &self.ty_args);
+        let inst = convert_model_partial_struct_type(env, module_id, struct_id, ty_args);
         eval_state.save_memory(mem_label, inst, global_state);
     }
 

--- a/language/move-prover/interpreter/src/concrete/player.rs
+++ b/language/move-prover/interpreter/src/concrete/player.rs
@@ -15,7 +15,7 @@ use bytecode::{
         Operation,
     },
 };
-use move_binary_format::{errors::Location, file_format::CodeOffset};
+use move_binary_format::errors::Location;
 use move_core_types::{
     account_address::AccountAddress,
     vm_status::{sub_status, StatusCode},
@@ -32,7 +32,7 @@ use crate::{
         settings::InterpreterSettings,
         ty::{
             convert_model_base_type, convert_model_local_type, convert_model_partial_struct_type,
-            convert_model_struct_type, BaseType, Type,
+            convert_model_struct_type, BaseType, CodeOffset, Type,
         },
         value::{EvalState, GlobalState, LocalSlot, Pointer, TypedValue},
     },

--- a/language/move-prover/interpreter/src/concrete/ty.rs
+++ b/language/move-prover/interpreter/src/concrete/ty.rs
@@ -1,6 +1,18 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//! The type system in move-model is a fat type system that is designed to cover all cases that can
+//! possibly appear in the whole bytecode transformation pipeline. Natually, this means that some
+//! types are no longer applicable when the Move program reaches the end of the transformation.
+//!
+//! The type system for the interpreter is a strict subset of what is offered in the move-model.
+//! In other word, it is slimmed down version of the type system in move-model and a very restricted
+//! set of types that are only applicable to the interpreter. Doing so enables us to write code in a
+//! more precise way. For example, a type argument can only be a `BaseType` and never a reference.
+//! Therefore, `BaseType` is preferred over `Type` for if a struct field/function argument holds
+//! a type argument (e.g., `struct FunctionContext {ty_args: Vec<BaseType>, ...}` is preferred over
+//! `ty_args: Vec<Type>`, as the former is more descriptive and less error prone).
+
 use std::fmt;
 
 use bytecode::stackless_bytecode::Constant;

--- a/language/move-prover/interpreter/src/concrete/ty.rs
+++ b/language/move-prover/interpreter/src/concrete/ty.rs
@@ -4,7 +4,6 @@
 use std::fmt;
 
 use bytecode::stackless_bytecode::Constant;
-use move_binary_format::file_format::TypeParameterIndex;
 use move_core_types::{
     identifier::Identifier,
     language_storage::{StructTag, TypeTag},
@@ -16,6 +15,10 @@ use move_model::{
 };
 
 use crate::shared::ident::StructIdent;
+
+// avoid dependency to `move_binary_format::file_format`
+pub type TypeParameterIndex = u16;
+pub type CodeOffset = u16;
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub enum IntType {


### PR DESCRIPTION
[This PR is self-contained within the stackless bytecode interpreter]

PR #8357 refactored the borrow analysis and memory instrumentation
to use inter-procedural analysis to determine borrow behavior of called
functions. This PR has several implictions to the interpreter:
- elimination of weak edges in the memory model,
- addition of hyper edges in complex cases of `&mut` return values
  across function calls
- refactored the approach on how and when to check whether a
  `write_back` is active or not (via the new `IsParent` operation)

This PR incorporates these new changes and adds support (as well
as type checking) to the new `Hyper` type in `BorrowEdge` and the
`IsParent` operation.

However, currently, there is an issue in the live variable analysis pass
that makes a mutable reference to be destroyed before it is even
defined. An example to trigger the issue is shown in test case
`return_ref_path_vec_1` in
`move-prover/interpreter-testsuite/tests/concrete_check/return_mut_ref.move`
(marked with TODO). This issue never appears in the Diem framework
and does not affect the prover. But it violates certain assumptions
made in the interpreter and it is good to have the issue fixed instead
of finding workarounds. A follow-up #8430 is drafted to address this issue.
However, this PR is independent of #8430 and can be landed separately.

Additionally, the other two commits in PR allow the handling of
`SaveMem` in a separate `EvalState` that is dedicated for
expression evaluation. The original plan is to record saved memory
in `GlobalState`. However, that will break the mental match that
the `GlobalState` corresponds to the Move global storage.
As a result, we created an `EvalState` to track and record information
is produced for and will be produced in the expression evaluation
(while the `GlobalState` tracks information produced in `bytecode`
interpretation)

## Motivation

more progress on the stackless bytecode interpreter

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1) CI, with new test cases

2) replay the E2E test cases

```
// record
cd language/e2e-testsuite
TRACE=<path-to-trace-dir> cargo test

// replay
cd language/testing-infra/e2e-tests
cargo run -- -t <path-to-trace-dir> -x -v 1
```

