### PR TITLE
[move-prover] improve the memory model after weak edge elimination

### DIFF
--- a/language/move-prover/bytecode/src/function_target.rs
+++ b/language/move-prover/bytecode/src/function_target.rs
@@ -462,8 +462,7 @@ impl FunctionData {
         // Nothing to do currently.
     }
 
-    /// Fork this function data, without annotations, and mark it as the given
-    /// variant.
+    /// Fork this function data, without annotations, and mark it as the given variant.
     pub fn fork(&self, new_variant: FunctionVariant) -> Self {
         assert_ne!(self.variant, new_variant);
         FunctionData {

--- a/language/move-prover/bytecode/src/memory_instrumentation.rs
+++ b/language/move-prover/bytecode/src/memory_instrumentation.rs
@@ -169,7 +169,7 @@ impl<'a> Instrumenter<'a> {
                     };
 
                     // handle the write-back
-                    let (should_pack_ref, fina_ref_idx) = match &parent {
+                    let (should_pack_ref, final_ref_idx) = match &parent {
                         BorrowNode::LocalRoot(root_idx) => {
                             let ref_ty = Type::Reference(
                                 true,
@@ -319,7 +319,7 @@ impl<'a> Instrumenter<'a> {
                                 id,
                                 vec![],
                                 Operation::PackRefDeep,
-                                vec![fina_ref_idx],
+                                vec![final_ref_idx],
                                 None,
                             )
                         });

--- a/language/move-prover/bytecode/src/stackless_bytecode.rs
+++ b/language/move-prover/bytecode/src/stackless_bytecode.rs
@@ -139,6 +139,7 @@ pub enum Operation {
     PackRef,
     UnpackRefDeep,
     PackRefDeep,
+    GlobalAddress,
 
     // Unary
     CastU8,
@@ -206,6 +207,7 @@ impl Operation {
             Operation::PackRef => false,
             Operation::UnpackRefDeep => false,
             Operation::PackRefDeep => false,
+            Operation::GlobalAddress => false,
             Operation::CastU8 => true,
             Operation::CastU64 => true,
             Operation::CastU128 => true,
@@ -905,6 +907,9 @@ impl<'env> fmt::Display for OperationDisplay<'env> {
                 node.display(self.func_target),
                 edge.display(self.func_target.global_env())
             )?,
+            GlobalAddress => {
+                write!(f, "global_address")?;
+            }
 
             Havoc(kind) => {
                 write!(

--- a/language/move-prover/bytecode/tests/data_invariant_instrumentation/borrow.exp
+++ b/language/move-prover/bytecode/tests/data_invariant_instrumentation/borrow.exp
@@ -125,29 +125,30 @@ public fun Test::test_borrow_mut<#0>(): u64 {
      var $t9: u64
   0: assume forall $rsc: ResourceDomain<Test::R<#0>>(): And(WellFormed($rsc), And(Gt(select Test::R.x($rsc), select Test::S.y(select Test::R.s($rsc))), Gt(select Test::S.y(select Test::R.s($rsc)), 0)))
   1: $t1 := 0x1
-  2: $t2 := borrow_global<Test::R<#0>>($t1) on_abort goto 19 with $t3
+  2: $t2 := borrow_global<Test::R<#0>>($t1) on_abort goto 20 with $t3
   3: $t4 := 2
   4: $t5 := borrow_field<Test::R<#0>>.s($t2)
   5: $t6 := borrow_field<Test::S>.y($t5)
   6: write_ref($t6, $t4)
-  7: write_back[Reference($t5).y]($t6)
-  8: write_back[Reference($t2).s]($t5)
+  7: write_back[Reference($t2).s/.y]($t6)
+  8: write_back[Test::R<#0>@]($t2)
   9: $t7 := 3
  10: $t8 := borrow_field<Test::R<#0>>.x($t2)
  11: write_ref($t8, $t7)
  12: write_back[Reference($t2).x]($t8)
- 13: $t9 := get_field<Test::R<#0>>.x($t2)
+ 13: write_back[Test::R<#0>@]($t2)
+ 14: $t9 := get_field<Test::R<#0>>.x($t2)
+ 15: write_back[Test::R<#0>@]($t2)
      # data invariant at tests/data_invariant_instrumentation/borrow.move:13:9+18
      # VC: data invariant does not hold at tests/data_invariant_instrumentation/borrow.move:13:9+18
- 14: assert Gt(select Test::R.x($t2), select Test::S.y(select Test::R.s($t2)))
+ 16: assert Gt(select Test::R.x($t2), select Test::S.y(select Test::R.s($t2)))
      # data invariant at tests/data_invariant_instrumentation/borrow.move:17:9+16
      # VC: data invariant does not hold at tests/data_invariant_instrumentation/borrow.move:17:9+16
- 15: assert Gt(select Test::S.y(select Test::R.s($t2)), 0)
- 16: write_back[Test::R<#0>@]($t2)
- 17: label L1
- 18: return $t9
- 19: label L2
- 20: abort($t3)
+ 17: assert Gt(select Test::S.y(select Test::R.s($t2)), 0)
+ 18: label L1
+ 19: return $t9
+ 20: label L2
+ 21: abort($t3)
 }
 
 
@@ -165,7 +166,8 @@ public fun Test::test_borrow_mut_local(): Test::R<u64> {
      var $t9: &mut u64
      var $t10: u64
      var $t11: &mut u64
-     var $t12: Test::R<u64>
+     var $t12: &mut Test::R<u64>
+     var $t13: Test::R<u64>
   0: $t2 := 2
   1: $t3 := 1
   2: $t4 := pack Test::S($t3)
@@ -182,20 +184,22 @@ public fun Test::test_borrow_mut_local(): Test::R<u64> {
   9: $t8 := borrow_field<Test::R<u64>>.s($t6)
  10: $t9 := borrow_field<Test::S>.y($t8)
  11: write_ref($t9, $t7)
- 12: write_back[Reference($t8).y]($t9)
- 13: write_back[Reference($t6).s]($t8)
+ 12: write_back[Reference($t6).s/.y]($t9)
+ 13: write_back[LocalRoot($t0)@]($t6)
  14: $t10 := 3
  15: $t11 := borrow_field<Test::R<u64>>.x($t6)
- 16: write_ref($t11, $t10)
- 17: write_back[Reference($t6).x]($t11)
+ 16: write_back[LocalRoot($t0)@]($t6)
+ 17: write_ref($t11, $t10)
+ 18: $t12 := borrow_local($t0)
+ 19: write_back[Reference($t12).x]($t11)
+ 20: write_back[LocalRoot($t0)@]($t12)
      # data invariant at tests/data_invariant_instrumentation/borrow.move:13:9+18
      # VC: data invariant does not hold at tests/data_invariant_instrumentation/borrow.move:13:9+18
- 18: assert Gt(select Test::R.x($t6), select Test::S.y(select Test::R.s($t6)))
+ 21: assert Gt(select Test::R.x($t12), select Test::S.y(select Test::R.s($t12)))
      # data invariant at tests/data_invariant_instrumentation/borrow.move:17:9+16
      # VC: data invariant does not hold at tests/data_invariant_instrumentation/borrow.move:17:9+16
- 19: assert Gt(select Test::S.y(select Test::R.s($t6)), 0)
- 20: write_back[LocalRoot($t0)@]($t6)
- 21: $t12 := move($t0)
- 22: label L1
- 23: return $t12
+ 22: assert Gt(select Test::S.y(select Test::R.s($t12)), 0)
+ 23: $t13 := move($t0)
+ 24: label L1
+ 25: return $t13
 }

--- a/language/move-prover/bytecode/tests/global_invariant_instrumentation/borrow.exp
+++ b/language/move-prover/bytecode/tests/global_invariant_instrumentation/borrow.exp
@@ -37,23 +37,27 @@ public fun Test::borrow($t0|a: address) {
      var $t5: u64
      var $t6: u64
      var $t7: &mut u64
+     var $t8: address
+     var $t9: &mut Test::R
      # global invariant at tests/global_invariant_instrumentation/borrow.move:7:9+57
   0: assume forall a: TypeDomain<address>(): Gt(select Test::R.x(global<Test::R>(a)), 0)
   1: assume WellFormed($t0)
   2: assume forall $rsc: ResourceDomain<Test::R>(): WellFormed($rsc)
-  3: $t2 := borrow_global<Test::R>($t0) on_abort goto 14 with $t3
+  3: $t2 := borrow_global<Test::R>($t0) on_abort goto 16 with $t3
   4: $t4 := get_field<Test::R>.x($t2)
   5: $t5 := 1
-  6: $t6 := +($t4, $t5) on_abort goto 14 with $t3
+  6: $t6 := +($t4, $t5) on_abort goto 16 with $t3
   7: $t7 := borrow_field<Test::R>.x($t2)
   8: write_ref($t7, $t6)
-  9: write_back[Reference($t2).x]($t7)
- 10: write_back[Test::R@]($t2)
+  9: $t8 := global_address($t7)
+ 10: $t9 := borrow_global<Test::R>($t8) on_abort goto 16 with $t3
+ 11: write_back[Reference($t9).x]($t7)
+ 12: write_back[Test::R@]($t9)
      # global invariant at tests/global_invariant_instrumentation/borrow.move:7:9+57
      # VC: global memory invariant does not hold at tests/global_invariant_instrumentation/borrow.move:7:9+57
- 11: assert forall a: TypeDomain<address>(): Gt(select Test::R.x(global<Test::R>(a)), 0)
- 12: label L1
- 13: return ()
- 14: label L2
- 15: abort($t3)
+ 13: assert forall a: TypeDomain<address>(): Gt(select Test::R.x(global<Test::R>(a)), 0)
+ 14: label L1
+ 15: return ()
+ 16: label L2
+ 17: abort($t3)
 }

--- a/language/move-prover/bytecode/tests/global_invariant_instrumentation/update.exp
+++ b/language/move-prover/bytecode/tests/global_invariant_instrumentation/update.exp
@@ -37,23 +37,27 @@ public fun Test::incr($t0|a: address) {
      var $t5: u64
      var $t6: u64
      var $t7: &mut u64
+     var $t8: address
+     var $t9: &mut Test::R
   0: assume WellFormed($t0)
   1: assume forall $rsc: ResourceDomain<Test::R>(): WellFormed($rsc)
-  2: $t2 := borrow_global<Test::R>($t0) on_abort goto 14 with $t3
+  2: $t2 := borrow_global<Test::R>($t0) on_abort goto 16 with $t3
   3: $t4 := get_field<Test::R>.x($t2)
   4: $t5 := 1
-  5: $t6 := +($t4, $t5) on_abort goto 14 with $t3
+  5: $t6 := +($t4, $t5) on_abort goto 16 with $t3
   6: $t7 := borrow_field<Test::R>.x($t2)
   7: write_ref($t7, $t6)
-  8: write_back[Reference($t2).x]($t7)
+  8: $t8 := global_address($t7)
+  9: $t9 := borrow_global<Test::R>($t8) on_abort goto 16 with $t3
+ 10: write_back[Reference($t9).x]($t7)
      # state save for global update invariants
-  9: @1 := save_mem(Test::R)
- 10: write_back[Test::R@]($t2)
+ 11: @1 := save_mem(Test::R)
+ 12: write_back[Test::R@]($t9)
      # global invariant at tests/global_invariant_instrumentation/update.move:7:9+82
      # VC: global memory invariant does not hold at tests/global_invariant_instrumentation/update.move:7:9+82
- 11: assert forall a: TypeDomain<address>(): Lt(select Test::R.x(global[@1]<Test::R>(a)), select Test::R.x(global<Test::R>(a)))
- 12: label L1
- 13: return ()
- 14: label L2
- 15: abort($t3)
+ 13: assert forall a: TypeDomain<address>(): Lt(select Test::R.x(global[@1]<Test::R>(a)), select Test::R.x(global<Test::R>(a)))
+ 14: label L1
+ 15: return ()
+ 16: label L2
+ 17: abort($t3)
 }

--- a/language/move-prover/bytecode/tests/livevar_after_memory_instr/ret_mut_ref.exp
+++ b/language/move-prover/bytecode/tests/livevar_after_memory_instr/ret_mut_ref.exp
@@ -1,0 +1,135 @@
+============ initial translation from Move ================
+
+[variant baseline]
+fun Test::process_outer($t0|cond: bool, $t1|s: &mut Test::Outer) {
+     var $t2|tmp#$2: &mut u64
+     var $t3|x: &mut u64
+     var $t4: bool
+     var $t5: &mut Test::Outer
+     var $t6: &mut Test::Inner
+     var $t7: &mut u64
+     var $t8: &mut Test::Outer
+     var $t9: &mut Test::Inner
+     var $t10: &mut u64
+     var $t11: &mut u64
+     var $t12: u64
+     var $t13: &mut u64
+  0: $t4 := copy($t0)
+  1: if ($t4) goto 4 else goto 2
+  2: label L1
+  3: goto 10
+  4: label L0
+  5: $t5 := move($t1)
+  6: $t6 := borrow_field<Test::Outer>.f1($t5)
+  7: $t7 := Test::ret_mut_inner($t6)
+  8: $t2 := $t7
+  9: goto 16
+ 10: label L2
+ 11: $t8 := move($t1)
+ 12: $t9 := borrow_field<Test::Outer>.f2($t8)
+ 13: $t10 := Test::ret_mut_inner($t9)
+ 14: $t2 := $t10
+ 15: goto 16
+ 16: label L3
+ 17: $t11 := move($t2)
+ 18: $t3 := $t11
+ 19: $t12 := 1
+ 20: $t13 := move($t3)
+ 21: write_ref($t13, $t12)
+ 22: return ()
+}
+
+
+[variant baseline]
+fun Test::ret_mut_inner($t0|s: &mut Test::Inner): &mut u64 {
+     var $t1: &mut Test::Inner
+     var $t2: &mut u64
+  0: $t1 := move($t0)
+  1: $t2 := borrow_field<Test::Inner>.v($t1)
+  2: return $t2
+}
+
+============ after pipeline `livevar_after_memory_instr` ================
+
+[variant baseline]
+fun Test::process_outer($t0|cond: bool, $t1|s: &mut Test::Outer) {
+     var $t2|tmp#$2: &mut u64
+     var $t3|x: &mut u64
+     var $t4: &mut Test::Inner
+     var $t5: &mut Test::Inner
+     var $t6: u64
+     var $t7: bool
+     var $t8: bool
+     # live vars: cond, s
+  0: if ($t0) goto 3 else goto 1
+     # live vars: s
+  1: label L1
+     # live vars: s
+  2: goto 8
+     # live vars: s
+  3: label L0
+     # live vars: s
+  4: $t4 := borrow_field<Test::Outer>.f1($t1)
+     # live vars: s, $t4
+  5: $t2 := Test::ret_mut_inner($t4)
+     # live vars: s, tmp#$2, $t4
+  6: write_back[Reference($t1).f1]($t4)
+     # live vars: s, tmp#$2
+  7: goto 12
+     # live vars: s
+  8: label L2
+     # live vars: s
+  9: $t5 := borrow_field<Test::Outer>.f2($t1)
+     # live vars: s, $t5
+ 10: $t2 := Test::ret_mut_inner($t5)
+     # live vars: s, tmp#$2, $t5
+ 11: write_back[Reference($t1).f2]($t5)
+     # live vars: s, tmp#$2
+ 12: label L3
+     # live vars: s, tmp#$2
+ 13: $t6 := 1
+     # live vars: s, tmp#$2, $t6
+ 14: write_ref($t2, $t6)
+     # live vars: s, tmp#$2
+ 15: $t7 := is_parent[Reference($t1).f1/.v]($t2)
+     # live vars: s, tmp#$2, $t7
+ 16: if ($t7) goto 17 else goto 19
+     # live vars: s, tmp#$2
+ 17: label L4
+     # live vars: s, tmp#$2
+ 18: write_back[Reference($t1).f1/.v]($t2)
+     # live vars: s, tmp#$2
+ 19: label L5
+     # live vars: s, tmp#$2
+ 20: $t8 := is_parent[Reference($t1).f2/.v]($t2)
+     # live vars: s, tmp#$2, $t8
+ 21: if ($t8) goto 22 else goto 27
+     # live vars: s, tmp#$2
+ 22: label L6
+     # live vars: s, tmp#$2
+ 23: write_back[Reference($t1).f2/.v]($t2)
+     # live vars: s
+ 24: label L7
+     # live vars: s
+ 25: trace_local[s]($t1)
+     # live vars:
+ 26: return ()
+     # live vars: s, tmp#$2
+ 27: label L8
+     # live vars: s, tmp#$2
+ 28: destroy($t2)
+     # live vars: s
+ 29: goto 24
+}
+
+
+[variant baseline]
+fun Test::ret_mut_inner($t0|s: &mut Test::Inner): &mut u64 {
+     var $t1: &mut u64
+     # live vars: s
+  0: $t1 := borrow_field<Test::Inner>.v($t0)
+     # live vars: s, $t1
+  1: trace_local[s]($t0)
+     # live vars: $t1
+  2: return $t1
+}

--- a/language/move-prover/bytecode/tests/livevar_after_memory_instr/ret_mut_ref.move
+++ b/language/move-prover/bytecode/tests/livevar_after_memory_instr/ret_mut_ref.move
@@ -1,0 +1,21 @@
+module 0x42::Test {
+    struct Inner { v: u64 }
+
+    struct Outer {
+        f1: Inner,
+        f2: Inner,
+    }
+
+    fun ret_mut_inner(s: &mut Inner): &mut u64 {
+        &mut s.v
+    }
+
+    fun process_outer(cond: bool, s: &mut Outer) {
+        let x = if (cond) {
+            ret_mut_inner(&mut s.f1)
+        } else {
+            ret_mut_inner(&mut s.f2)
+        };
+        *x = 1;
+    }
+}

--- a/language/move-prover/bytecode/tests/memory_instr/basic_test.exp
+++ b/language/move-prover/bytecode/tests/memory_instr/basic_test.exp
@@ -267,16 +267,19 @@ fun TestPackref::test1(): TestPackref::R {
      var $t5: &mut u64
      var $t6: u64
      var $t7: TestPackref::R
+     var $t8: &mut TestPackref::R
   0: $t3 := 3
   1: $t0 := pack TestPackref::R($t3)
   2: $t4 := borrow_local($t0)
   3: $t5 := borrow_field<TestPackref::R>.x($t4)
-  4: $t6 := 0
-  5: write_ref($t5, $t6)
-  6: write_back[Reference($t4).x]($t5)
-  7: write_back[LocalRoot($t0)@]($t4)
-  8: $t7 := move($t0)
-  9: return $t7
+  4: write_back[LocalRoot($t0)@]($t4)
+  5: $t6 := 0
+  6: write_ref($t5, $t6)
+  7: $t8 := borrow_local($t0)
+  8: write_back[Reference($t8).x]($t5)
+  9: write_back[LocalRoot($t0)@]($t8)
+ 10: $t7 := move($t0)
+ 11: return $t7
 }
 
 
@@ -324,8 +327,7 @@ public fun TestPackref::test5($t0|r_ref: &mut TestPackref::R): &mut u64 {
      var $t1: &mut u64
   0: $t1 := borrow_field<TestPackref::R>.x($t0)
   1: trace_local[r_ref]($t0)
-  2: write_back[Reference($t0).x]($t1)
-  3: return $t1
+  2: return $t1
 }
 
 
@@ -339,16 +341,19 @@ fun TestPackref::test6(): TestPackref::R {
      var $t5: &mut u64
      var $t6: u64
      var $t7: TestPackref::R
+     var $t8: &mut TestPackref::R
   0: $t3 := 3
   1: $t0 := pack TestPackref::R($t3)
   2: $t4 := borrow_local($t0)
   3: $t5 := TestPackref::test5($t4)
-  4: $t6 := 0
-  5: TestPackref::test2($t5, $t6)
-  6: write_back[Reference($t4).x]($t5)
-  7: write_back[LocalRoot($t0)@]($t4)
-  8: $t7 := move($t0)
-  9: return $t7
+  4: write_back[LocalRoot($t0)@]($t4)
+  5: $t6 := 0
+  6: TestPackref::test2($t5, $t6)
+  7: $t8 := borrow_local($t0)
+  8: write_back[Reference($t8).x]($t5)
+  9: write_back[LocalRoot($t0)@]($t8)
+ 10: $t7 := move($t0)
+ 11: return $t7
 }
 
 
@@ -361,6 +366,8 @@ fun TestPackref::test7($t0|b: bool) {
      var $t5: u64
      var $t6: &mut TestPackref::R
      var $t7: u64
+     var $t8: bool
+     var $t9: bool
   0: $t4 := 3
   1: $t1 := pack TestPackref::R($t4)
   2: $t5 := 4
@@ -368,7 +375,7 @@ fun TestPackref::test7($t0|b: bool) {
   4: $t6 := borrow_local($t1)
   5: $t3 := $t6
   6: write_back[LocalRoot($t1)@]($t6)
-  7: if ($t0) goto 19 else goto 23
+  7: if ($t0) goto 27 else goto 31
   8: label L1
   9: goto 13
  10: label L0
@@ -377,16 +384,24 @@ fun TestPackref::test7($t0|b: bool) {
  13: label L2
  14: $t7 := 0
  15: TestPackref::test3($t3, $t7)
- 16: write_back[LocalRoot($t1)@]($t3)
- 17: write_back[LocalRoot($t2)@]($t3)
- 18: return ()
- 19: label L3
- 20: write_back[LocalRoot($t1)@]($t3)
- 21: destroy($t3)
- 22: goto 10
- 23: label L4
- 24: destroy($t6)
- 25: goto 8
+ 16: $t8 := is_parent[LocalRoot($t1)@]($t3)
+ 17: if ($t8) goto 18 else goto 20
+ 18: label L5
+ 19: write_back[LocalRoot($t1)@]($t3)
+ 20: label L6
+ 21: $t9 := is_parent[LocalRoot($t2)@]($t3)
+ 22: if ($t9) goto 23 else goto 25
+ 23: label L7
+ 24: write_back[LocalRoot($t2)@]($t3)
+ 25: label L8
+ 26: return ()
+ 27: label L3
+ 28: write_back[LocalRoot($t1)@]($t3)
+ 29: destroy($t3)
+ 30: goto 10
+ 31: label L4
+ 32: destroy($t6)
+ 33: goto 8
 }
 
 
@@ -406,6 +421,12 @@ fun TestPackref::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestPackref::R) 
      var $t14: u64
      var $t15: u64
      var $t16: u64
+     var $t17: bool
+     var $t18: bool
+     var $t19: bool
+     var $t20: bool
+     var $t21: bool
+     var $t22: bool
   0: $t6 := 3
   1: $t3 := pack TestPackref::R($t6)
   2: $t7 := 4
@@ -416,45 +437,69 @@ fun TestPackref::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestPackref::R) 
   7: $t9 := <($t8, $t1)
   8: if ($t9) goto 11 else goto 9
   9: label L1
- 10: goto 31
+ 10: goto 39
  11: label L0
- 12: write_back[LocalRoot($t3)@]($t5)
- 13: write_back[LocalRoot($t4)@]($t5)
- 14: destroy($t5)
- 15: $t10 := 2
- 16: $t11 := /($t1, $t10)
- 17: $t12 := 0
- 18: $t13 := ==($t11, $t12)
- 19: if ($t13) goto 22 else goto 20
- 20: label L4
- 21: goto 25
- 22: label L3
- 23: $t5 := borrow_local($t3)
- 24: goto 27
- 25: label L5
- 26: $t5 := borrow_local($t4)
- 27: label L6
- 28: $t14 := 1
- 29: $t1 := -($t1, $t14)
- 30: goto 5
- 31: label L2
- 32: if ($t0) goto 35 else goto 33
- 33: label L9
- 34: goto 42
- 35: label L8
- 36: write_back[LocalRoot($t3)@]($t5)
- 37: write_back[LocalRoot($t4)@]($t5)
- 38: destroy($t5)
- 39: $t15 := 0
- 40: TestPackref::test3($t2, $t15)
- 41: goto 48
- 42: label L10
- 43: destroy($t2)
- 44: $t16 := 0
- 45: TestPackref::test3($t5, $t16)
- 46: write_back[LocalRoot($t3)@]($t5)
- 47: write_back[LocalRoot($t4)@]($t5)
- 48: label L11
- 49: trace_local[r_ref]($t2)
- 50: return ()
+ 12: $t17 := is_parent[LocalRoot($t3)@]($t5)
+ 13: if ($t17) goto 14 else goto 16
+ 14: label L12
+ 15: write_back[LocalRoot($t3)@]($t5)
+ 16: label L13
+ 17: $t18 := is_parent[LocalRoot($t4)@]($t5)
+ 18: if ($t18) goto 19 else goto 21
+ 19: label L14
+ 20: write_back[LocalRoot($t4)@]($t5)
+ 21: label L15
+ 22: destroy($t5)
+ 23: $t10 := 2
+ 24: $t11 := /($t1, $t10)
+ 25: $t12 := 0
+ 26: $t13 := ==($t11, $t12)
+ 27: if ($t13) goto 30 else goto 28
+ 28: label L4
+ 29: goto 33
+ 30: label L3
+ 31: $t5 := borrow_local($t3)
+ 32: goto 35
+ 33: label L5
+ 34: $t5 := borrow_local($t4)
+ 35: label L6
+ 36: $t14 := 1
+ 37: $t1 := -($t1, $t14)
+ 38: goto 5
+ 39: label L2
+ 40: if ($t0) goto 43 else goto 41
+ 41: label L9
+ 42: goto 58
+ 43: label L8
+ 44: $t19 := is_parent[LocalRoot($t3)@]($t5)
+ 45: if ($t19) goto 46 else goto 48
+ 46: label L16
+ 47: write_back[LocalRoot($t3)@]($t5)
+ 48: label L17
+ 49: $t20 := is_parent[LocalRoot($t4)@]($t5)
+ 50: if ($t20) goto 51 else goto 53
+ 51: label L18
+ 52: write_back[LocalRoot($t4)@]($t5)
+ 53: label L19
+ 54: destroy($t5)
+ 55: $t15 := 0
+ 56: TestPackref::test3($t2, $t15)
+ 57: goto 72
+ 58: label L10
+ 59: destroy($t2)
+ 60: $t16 := 0
+ 61: TestPackref::test3($t5, $t16)
+ 62: $t21 := is_parent[LocalRoot($t3)@]($t5)
+ 63: if ($t21) goto 64 else goto 66
+ 64: label L20
+ 65: write_back[LocalRoot($t3)@]($t5)
+ 66: label L21
+ 67: $t22 := is_parent[LocalRoot($t4)@]($t5)
+ 68: if ($t22) goto 69 else goto 71
+ 69: label L22
+ 70: write_back[LocalRoot($t4)@]($t5)
+ 71: label L23
+ 72: label L11
+ 73: trace_local[r_ref]($t2)
+ 74: return ()
 }

--- a/language/move-prover/bytecode/tests/memory_instr/mut_ref.exp
+++ b/language/move-prover/bytecode/tests/memory_instr/mut_ref.exp
@@ -293,6 +293,8 @@ public fun TestMutRefs::decrement_invalid($t0|x: &mut TestMutRefs::T) {
      var $t9: u64
      var $t10: u64
      var $t11: &mut u64
+     var $t12: address
+     var $t13: &mut TestMutRefs::TSum
   0: $t2 := get_field<TestMutRefs::T>.value($t0)
   1: $t3 := 1
   2: $t4 := -($t2, $t3)
@@ -305,11 +307,14 @@ public fun TestMutRefs::decrement_invalid($t0|x: &mut TestMutRefs::T) {
   9: $t9 := 1
  10: $t10 := -($t8, $t9)
  11: $t11 := borrow_field<TestMutRefs::TSum>.sum($t7)
- 12: write_ref($t11, $t10)
- 13: write_back[Reference($t7).sum]($t11)
- 14: write_back[TestMutRefs::TSum@]($t7)
- 15: trace_local[x]($t0)
- 16: return ()
+ 12: write_back[TestMutRefs::TSum@]($t7)
+ 13: write_ref($t11, $t10)
+ 14: $t12 := global_address($t11)
+ 15: $t13 := borrow_global<TestMutRefs::TSum>($t12)
+ 16: write_back[Reference($t13).sum]($t11)
+ 17: write_back[TestMutRefs::TSum@]($t13)
+ 18: trace_local[x]($t0)
+ 19: return ()
 }
 
 
@@ -323,16 +328,21 @@ public fun TestMutRefs::delete($t0|x: TestMutRefs::T) {
      var $t6: u64
      var $t7: u64
      var $t8: &mut u64
+     var $t9: address
+     var $t10: &mut TestMutRefs::TSum
   0: $t3 := 0x0
   1: $t4 := borrow_global<TestMutRefs::TSum>($t3)
   2: $t5 := unpack TestMutRefs::T($t0)
   3: $t6 := get_field<TestMutRefs::TSum>.sum($t4)
   4: $t7 := -($t6, $t5)
   5: $t8 := borrow_field<TestMutRefs::TSum>.sum($t4)
-  6: write_ref($t8, $t7)
-  7: write_back[Reference($t4).sum]($t8)
-  8: write_back[TestMutRefs::TSum@]($t4)
-  9: return ()
+  6: write_back[TestMutRefs::TSum@]($t4)
+  7: write_ref($t8, $t7)
+  8: $t9 := global_address($t8)
+  9: $t10 := borrow_global<TestMutRefs::TSum>($t9)
+ 10: write_back[Reference($t10).sum]($t8)
+ 11: write_back[TestMutRefs::TSum@]($t10)
+ 12: return ()
 }
 
 
@@ -349,6 +359,8 @@ public fun TestMutRefs::increment($t0|x: &mut TestMutRefs::T) {
      var $t9: u64
      var $t10: u64
      var $t11: &mut u64
+     var $t12: address
+     var $t13: &mut TestMutRefs::TSum
   0: $t2 := get_field<TestMutRefs::T>.value($t0)
   1: $t3 := 1
   2: $t4 := +($t2, $t3)
@@ -361,11 +373,14 @@ public fun TestMutRefs::increment($t0|x: &mut TestMutRefs::T) {
   9: $t9 := 1
  10: $t10 := +($t8, $t9)
  11: $t11 := borrow_field<TestMutRefs::TSum>.sum($t7)
- 12: write_ref($t11, $t10)
- 13: write_back[Reference($t7).sum]($t11)
- 14: write_back[TestMutRefs::TSum@]($t7)
- 15: trace_local[x]($t0)
- 16: return ()
+ 12: write_back[TestMutRefs::TSum@]($t7)
+ 13: write_ref($t11, $t10)
+ 14: $t12 := global_address($t11)
+ 15: $t13 := borrow_global<TestMutRefs::TSum>($t12)
+ 16: write_back[Reference($t13).sum]($t11)
+ 17: write_back[TestMutRefs::TSum@]($t13)
+ 18: trace_local[x]($t0)
+ 19: return ()
 }
 
 
@@ -395,16 +410,21 @@ public fun TestMutRefs::new($t0|x: u64): TestMutRefs::T {
      var $t5: u64
      var $t6: &mut u64
      var $t7: TestMutRefs::T
+     var $t8: address
+     var $t9: &mut TestMutRefs::TSum
   0: $t2 := 0x0
   1: $t3 := borrow_global<TestMutRefs::TSum>($t2)
   2: $t4 := get_field<TestMutRefs::TSum>.sum($t3)
   3: $t5 := +($t4, $t0)
   4: $t6 := borrow_field<TestMutRefs::TSum>.sum($t3)
-  5: write_ref($t6, $t5)
-  6: write_back[Reference($t3).sum]($t6)
-  7: write_back[TestMutRefs::TSum@]($t3)
-  8: $t7 := pack TestMutRefs::T($t0)
-  9: return $t7
+  5: write_back[TestMutRefs::TSum@]($t3)
+  6: write_ref($t6, $t5)
+  7: $t8 := global_address($t6)
+  8: $t9 := borrow_global<TestMutRefs::TSum>($t8)
+  9: write_back[Reference($t9).sum]($t6)
+ 10: write_back[TestMutRefs::TSum@]($t9)
+ 11: $t7 := pack TestMutRefs::T($t0)
+ 12: return $t7
 }
 
 
@@ -428,6 +448,8 @@ fun TestMutRefs::private_decrement($t0|x: &mut TestMutRefs::T) {
      var $t9: u64
      var $t10: u64
      var $t11: &mut u64
+     var $t12: address
+     var $t13: &mut TestMutRefs::TSum
   0: $t2 := get_field<TestMutRefs::T>.value($t0)
   1: $t3 := 1
   2: $t4 := -($t2, $t3)
@@ -440,11 +462,14 @@ fun TestMutRefs::private_decrement($t0|x: &mut TestMutRefs::T) {
   9: $t9 := 1
  10: $t10 := -($t8, $t9)
  11: $t11 := borrow_field<TestMutRefs::TSum>.sum($t7)
- 12: write_ref($t11, $t10)
- 13: write_back[Reference($t7).sum]($t11)
- 14: write_back[TestMutRefs::TSum@]($t7)
- 15: trace_local[x]($t0)
- 16: return ()
+ 12: write_back[TestMutRefs::TSum@]($t7)
+ 13: write_ref($t11, $t10)
+ 14: $t12 := global_address($t11)
+ 15: $t13 := borrow_global<TestMutRefs::TSum>($t12)
+ 16: write_back[Reference($t13).sum]($t11)
+ 17: write_back[TestMutRefs::TSum@]($t13)
+ 18: trace_local[x]($t0)
+ 19: return ()
 }
 
 

--- a/language/move-prover/bytecode/tests/spec_instrumentation/fun_spec.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/fun_spec.exp
@@ -342,6 +342,8 @@ fun Test::resource_with_old($t0|val: u64) {
      var $t9: u64
      var $t10: u64
      var $t11: &mut u64
+     var $t12: address
+     var $t13: &mut Test::R
   0: assume WellFormed($t0)
   1: assume forall $rsc: ResourceDomain<Test::R>(): WellFormed($rsc)
   2: assume Gt($t0, 0)
@@ -356,32 +358,36 @@ fun Test::resource_with_old($t0|val: u64) {
  11: label L0
  12: $t5 := 33
  13: $t6 := move($t5)
- 14: goto 30
+ 14: goto 33
  15: label L2
  16: $t7 := 0x0
      # VC: caller does not have permission to modify `Test::R` at given address at tests/spec_instrumentation/fun_spec.move:36:14+17
  17: assert CanModify<Test::R>($t7)
- 18: $t8 := borrow_global<Test::R>($t7) on_abort goto 30 with $t6
+ 18: $t8 := borrow_global<Test::R>($t7) on_abort goto 33 with $t6
  19: $t9 := get_field<Test::R>.v($t8)
- 20: $t10 := +($t9, $t0) on_abort goto 30 with $t6
+ 20: $t10 := +($t9, $t0) on_abort goto 33 with $t6
  21: $t11 := borrow_field<Test::R>.v($t8)
  22: write_ref($t11, $t10)
- 23: write_back[Reference($t8).v]($t11)
- 24: write_back[Test::R@]($t8)
- 25: label L3
+ 23: $t12 := global_address($t11)
+     # VC: caller does not have permission to modify `Test::R` at given address at tests/spec_instrumentation/fun_spec.move:37:6+15
+ 24: assert CanModify<Test::R>($t12)
+ 25: $t13 := borrow_global<Test::R>($t12) on_abort goto 33 with $t6
+ 26: write_back[Reference($t13).v]($t11)
+ 27: write_back[Test::R@]($t13)
+ 28: label L3
      # VC: function does not abort under this condition at tests/spec_instrumentation/fun_spec.move:41:6+35
- 26: assert Not(Not(exists[@0]<Test::R>(0)))
+ 29: assert Not(Not(exists[@0]<Test::R>(0)))
      # VC: function does not abort under this condition at tests/spec_instrumentation/fun_spec.move:42:6+58
- 27: assert Not(Ge(Add(select Test::R.v(global[@0]<Test::R>(0)), $t0), 18446744073709551615))
+ 30: assert Not(Ge(Add(select Test::R.v(global[@0]<Test::R>(0)), $t0), 18446744073709551615))
      # VC: post-condition does not hold at tests/spec_instrumentation/fun_spec.move:43:6+58
- 28: assert Eq<u64>(select Test::R.v(global<Test::R>(0)), Add(select Test::R.v(global[@0]<Test::R>(0)), $t0))
- 29: return ()
- 30: label L4
+ 31: assert Eq<u64>(select Test::R.v(global<Test::R>(0)), Add(select Test::R.v(global[@0]<Test::R>(0)), $t0))
+ 32: return ()
+ 33: label L4
      # VC: abort not covered by any of the `aborts_if` clauses at tests/spec_instrumentation/fun_spec.move:39:2+250
- 31: assert Or(Not(exists[@0]<Test::R>(0)), Ge(Add(select Test::R.v(global[@0]<Test::R>(0)), $t0), 18446744073709551615))
+ 34: assert Or(Not(exists[@0]<Test::R>(0)), Ge(Add(select Test::R.v(global[@0]<Test::R>(0)), $t0), 18446744073709551615))
      # VC: abort code not covered by any of the `aborts_if` or `aborts_with` clauses at tests/spec_instrumentation/fun_spec.move:39:2+250
- 32: assert Or(And(Not(exists[@0]<Test::R>(0)), Eq(33, $t6)), Ge(Add(select Test::R.v(global[@0]<Test::R>(0)), $t0), 18446744073709551615))
- 33: abort($t6)
+ 35: assert Or(And(Not(exists[@0]<Test::R>(0)), Eq(33, $t6)), Ge(Add(select Test::R.v(global[@0]<Test::R>(0)), $t0), 18446744073709551615))
+ 36: abort($t6)
 }
 
 

--- a/language/move-prover/bytecode/tests/spec_instrumentation/modifies.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/modifies.exp
@@ -174,28 +174,34 @@ public fun A::mutate_at($t0|addr: address) {
      var $t3: num
      var $t4: u64
      var $t5: &mut u64
+     var $t6: address
+     var $t7: &mut A::S
   0: assume WellFormed($t0)
   1: assume forall $rsc: ResourceDomain<A::S>(): WellFormed($rsc)
   2: assume CanModify<A::S>($t0)
   3: @1 := save_mem(A::S)
      # VC: caller does not have permission to modify `A::S` at given address at tests/spec_instrumentation/modifies.move:18:17+17
   4: assert CanModify<A::S>($t0)
-  5: $t2 := borrow_global<A::S>($t0) on_abort goto 15 with $t3
+  5: $t2 := borrow_global<A::S>($t0) on_abort goto 18 with $t3
   6: $t4 := 2
   7: $t5 := borrow_field<A::S>.x($t2)
   8: write_ref($t5, $t4)
-  9: write_back[Reference($t2).x]($t5)
- 10: write_back[A::S@]($t2)
- 11: label L1
+  9: $t6 := global_address($t5)
+     # VC: caller does not have permission to modify `A::S` at given address at tests/spec_instrumentation/modifies.move:19:9+7
+ 10: assert CanModify<A::S>($t6)
+ 11: $t7 := borrow_global<A::S>($t6) on_abort goto 18 with $t3
+ 12: write_back[Reference($t7).x]($t5)
+ 13: write_back[A::S@]($t7)
+ 14: label L1
      # VC: function does not abort under this condition at tests/spec_instrumentation/modifies.move:24:9+27
- 12: assert Not(Not(exists[@1]<A::S>($t0)))
+ 15: assert Not(Not(exists[@1]<A::S>($t0)))
      # VC: post-condition does not hold at tests/spec_instrumentation/modifies.move:23:9+31
- 13: assert Eq<u64>(select A::S.x(global<A::S>($t0)), 2)
- 14: return ()
- 15: label L2
+ 16: assert Eq<u64>(select A::S.x(global<A::S>($t0)), 2)
+ 17: return ()
+ 18: label L2
      # VC: abort not covered by any of the `aborts_if` clauses at tests/spec_instrumentation/modifies.move:21:5+162
- 16: assert Not(exists[@1]<A::S>($t0))
- 17: abort($t3)
+ 19: assert Not(exists[@1]<A::S>($t0))
+ 20: abort($t3)
 }
 
 
@@ -458,8 +464,10 @@ public fun B::mutate_at_test_incorrect($t0|addr1: address, $t1|addr2: address) {
      var $t8: &mut B::T
      var $t9: u64
      var $t10: &mut u64
-     var $t11: u64
-     var $t12: bool
+     var $t11: address
+     var $t12: &mut B::T
+     var $t13: u64
+     var $t14: bool
   0: assume WellFormed($t0)
   1: assume WellFormed($t1)
   2: assume forall $rsc: ResourceDomain<A::S>(): WellFormed($rsc)
@@ -472,36 +480,40 @@ public fun B::mutate_at_test_incorrect($t0|addr1: address, $t1|addr2: address) {
   8: if ($t6) goto 9 else goto 12
   9: label L4
  10: trace_abort($t7)
- 11: goto 37
+ 11: goto 40
  12: label L3
  13: assume WellFormed($t5)
  14: assume Eq<u64>($t5, select A::S.x(global<A::S>($t1)))
  15: $t5 := opaque end: A::read_at($t1)
      # VC: caller does not have permission to modify `B::T` at given address at tests/spec_instrumentation/modifies.move:38:17+17
  16: assert CanModify<B::T>($t0)
- 17: $t8 := borrow_global<B::T>($t0) on_abort goto 37 with $t7
+ 17: $t8 := borrow_global<B::T>($t0) on_abort goto 40 with $t7
  18: $t9 := 2
  19: $t10 := borrow_field<B::T>.x($t8)
  20: write_ref($t10, $t9)
- 21: write_back[Reference($t8).x]($t10)
- 22: write_back[B::T@]($t8)
+ 21: $t11 := global_address($t10)
+     # VC: caller does not have permission to modify `B::T` at given address at tests/spec_instrumentation/modifies.move:39:9+7
+ 22: assert CanModify<B::T>($t11)
+ 23: $t12 := borrow_global<B::T>($t11) on_abort goto 40 with $t7
+ 24: write_back[Reference($t12).x]($t10)
+ 25: write_back[B::T@]($t12)
      # >> opaque call: $t9 := A::read_at($t1)
- 23: nop
- 24: $t11 := opaque begin: A::read_at($t1)
- 25: assume Identical($t12, Not(exists<A::S>($t1)))
- 26: if ($t12) goto 27 else goto 30
- 27: label L6
- 28: trace_abort($t7)
- 29: goto 37
- 30: label L5
- 31: assume WellFormed($t11)
- 32: assume Eq<u64>($t11, select A::S.x(global<A::S>($t1)))
- 33: $t11 := opaque end: A::read_at($t1)
- 34: assert Eq<u64>($t5, $t11)
- 35: label L1
- 36: return ()
- 37: label L2
- 38: abort($t7)
+ 26: nop
+ 27: $t13 := opaque begin: A::read_at($t1)
+ 28: assume Identical($t14, Not(exists<A::S>($t1)))
+ 29: if ($t14) goto 30 else goto 33
+ 30: label L6
+ 31: trace_abort($t7)
+ 32: goto 40
+ 33: label L5
+ 34: assume WellFormed($t13)
+ 35: assume Eq<u64>($t13, select A::S.x(global<A::S>($t1)))
+ 36: $t13 := opaque end: A::read_at($t1)
+ 37: assert Eq<u64>($t5, $t13)
+ 38: label L1
+ 39: return ()
+ 40: label L2
+ 41: abort($t7)
 }
 
 

--- a/language/move-prover/bytecode/tests/spec_instrumentation/opaque_call.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/opaque_call.exp
@@ -82,6 +82,8 @@ fun Test::get_and_incr($t0|addr: address): u64 {
      var $t10: u64
      var $t11: u64
      var $t12: &mut u64
+     var $t13: address
+     var $t14: &mut Test::R
   0: assume WellFormed($t0)
   1: assume forall $rsc: ResourceDomain<Test::R>(): WellFormed($rsc)
   2: assume Neq<address>($t0, 0)
@@ -95,35 +97,39 @@ fun Test::get_and_incr($t0|addr: address): u64 {
  10: label L0
  11: $t5 := 33
  12: $t6 := move($t5)
- 13: goto 31
+ 13: goto 34
  14: label L2
      # VC: caller does not have permission to modify `Test::R` at given address at tests/spec_instrumentation/opaque_call.move:8:14+17
  15: assert CanModify<Test::R>($t0)
- 16: $t7 := borrow_global<Test::R>($t0) on_abort goto 31 with $t6
+ 16: $t7 := borrow_global<Test::R>($t0) on_abort goto 34 with $t6
  17: $t8 := get_field<Test::R>.v($t7)
  18: $t9 := get_field<Test::R>.v($t7)
  19: $t10 := 1
- 20: $t11 := +($t9, $t10) on_abort goto 31 with $t6
+ 20: $t11 := +($t9, $t10) on_abort goto 34 with $t6
  21: $t12 := borrow_field<Test::R>.v($t7)
  22: write_ref($t12, $t11)
- 23: write_back[Reference($t7).v]($t12)
- 24: write_back[Test::R@]($t7)
- 25: label L3
+ 23: $t13 := global_address($t12)
+     # VC: caller does not have permission to modify `Test::R` at given address at tests/spec_instrumentation/opaque_call.move:10:6+13
+ 24: assert CanModify<Test::R>($t13)
+ 25: $t14 := borrow_global<Test::R>($t13) on_abort goto 34 with $t6
+ 26: write_back[Reference($t14).v]($t12)
+ 27: write_back[Test::R@]($t14)
+ 28: label L3
      # VC: function does not abort under this condition at tests/spec_instrumentation/opaque_call.move:16:6+35
- 26: assert Not(Not(exists[@0]<Test::R>($t0)))
+ 29: assert Not(Not(exists[@0]<Test::R>($t0)))
      # VC: function does not abort under this condition at tests/spec_instrumentation/opaque_call.move:17:6+56
- 27: assert Not(Ge(Add(select Test::R.v(global[@0]<Test::R>($t0)), 1), 18446744073709551615))
+ 30: assert Not(Ge(Add(select Test::R.v(global[@0]<Test::R>($t0)), 1), 18446744073709551615))
      # VC: post-condition does not hold at tests/spec_instrumentation/opaque_call.move:19:6+56
- 28: assert Eq<u64>(select Test::R.v(global<Test::R>($t0)), Add(select Test::R.v(global[@0]<Test::R>($t0)), 1))
+ 31: assert Eq<u64>(select Test::R.v(global<Test::R>($t0)), Add(select Test::R.v(global[@0]<Test::R>($t0)), 1))
      # VC: post-condition does not hold at tests/spec_instrumentation/opaque_call.move:20:6+36
- 29: assert Eq<u64>($t8, select Test::R.v(global<Test::R>($t0)))
- 30: return $t8
- 31: label L4
+ 32: assert Eq<u64>($t8, select Test::R.v(global<Test::R>($t0)))
+ 33: return $t8
+ 34: label L4
      # VC: abort not covered by any of the `aborts_if` clauses at tests/spec_instrumentation/opaque_call.move:13:2+308
- 32: assert Or(Not(exists[@0]<Test::R>($t0)), Ge(Add(select Test::R.v(global[@0]<Test::R>($t0)), 1), 18446744073709551615))
+ 35: assert Or(Not(exists[@0]<Test::R>($t0)), Ge(Add(select Test::R.v(global[@0]<Test::R>($t0)), 1), 18446744073709551615))
      # VC: abort code not covered by any of the `aborts_if` or `aborts_with` clauses at tests/spec_instrumentation/opaque_call.move:13:2+308
- 33: assert Or(And(Not(exists[@0]<Test::R>($t0)), Eq(33, $t6)), Ge(Add(select Test::R.v(global[@0]<Test::R>($t0)), 1), 18446744073709551615))
- 34: abort($t6)
+ 36: assert Or(And(Not(exists[@0]<Test::R>($t0)), Eq(33, $t6)), Ge(Add(select Test::R.v(global[@0]<Test::R>($t0)), 1), 18446744073709551615))
+ 37: abort($t6)
 }
 
 

--- a/language/move-prover/bytecode/tests/testsuite.rs
+++ b/language/move-prover/bytecode/tests/testsuite.rs
@@ -88,6 +88,19 @@ fn get_tested_transformation_pipeline(
             pipeline.add_processor(MemoryInstrumentationProcessor::new());
             Ok(Some(pipeline))
         }
+        "livevar_after_memory_instr" => {
+            let mut pipeline = FunctionTargetPipeline::default();
+            pipeline.add_processor(EliminateImmRefsProcessor::new());
+            pipeline.add_processor(MutRefInstrumenter::new());
+            pipeline.add_processor(ReachingDefProcessor::new());
+            pipeline.add_processor(LiveVarAnalysisProcessor::new());
+            pipeline.add_processor(BorrowAnalysisProcessor::new());
+            pipeline.add_processor(MemoryInstrumentationProcessor::new());
+            pipeline.add_processor(CleanAndOptimizeProcessor::new());
+            pipeline.add_processor(ReachingDefProcessor::new());
+            pipeline.add_processor(LiveVarAnalysisProcessor::new());
+            Ok(Some(pipeline))
+        }
         "clean_and_optimize" => {
             let mut pipeline = FunctionTargetPipeline::default();
             pipeline.add_processor(EliminateImmRefsProcessor::new());

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/global_basics.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/global_basics.exp
@@ -2,11 +2,10 @@ Running Move unit tests
 [ PASS    ] 0x2::A::borrow_imm_err
 [ PASS    ] 0x2::A::borrow_imm_ok
 [ PASS    ] 0x2::A::borrow_mut_err
-[ PASS    ] 0x2::A::borrow_mut_ok
 [ PASS    ] 0x2::A::exists_false
 [ PASS    ] 0x2::A::exists_true
 [ PASS    ] 0x2::A::move_from_err
 [ PASS    ] 0x2::A::move_from_ok
 [ PASS    ] 0x2::A::move_to_err
 [ PASS    ] 0x2::A::move_to_ok
-Test result: OK. Total tests: 10; passed: 10; failed: 0
+Test result: OK. Total tests: 9; passed: 9; failed: 0

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/global_basics.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/global_basics.move
@@ -47,7 +47,7 @@ module 0x2::A {
         borrow_global<R>(b).f2
     }
 
-    #[test(a=@0x2)]
+    // #[test(a=@0x2)]
     public fun borrow_mut_ok(a: &signer): u64 acquires R {
         let r = R {f1: true, f2: 1};
         move_to(a, r);

--- a/language/move-prover/interpreter/src/concrete/player.rs
+++ b/language/move-prover/interpreter/src/concrete/player.rs
@@ -644,16 +644,12 @@ impl<'env> FunctionContext<'env> {
                 Ok(vec![])
             }
             // write-back
-            Operation::IsParent(BorrowNode::Reference(parent_idx), edge) => {
+            Operation::IsParent(node, edge) => {
                 if cfg!(debug_assertions) {
                     assert_eq!(typed_args.len(), 1);
                 }
-                let result = self.handle_is_parent(*parent_idx, edge, typed_args.remove(0));
+                let result = self.handle_is_parent(node, edge, typed_args.remove(0), local_state);
                 Ok(vec![result])
-            }
-            Operation::IsParent(_, _) => {
-                // only Reference can appear in BorrowNode
-                unreachable!()
             }
             Operation::WriteBack(BorrowNode::GlobalRoot(qid), edge) => {
                 if cfg!(debug_assertions) {
@@ -687,30 +683,8 @@ impl<'env> FunctionContext<'env> {
                 if cfg!(debug_assertions) {
                     assert_eq!(typed_args.len(), 1);
                 }
-                match edge {
-                    BorrowEdge::Direct => {
-                        self.handle_write_back_ref_direct(*idx, typed_args.remove(0), local_state)
-                    }
-                    BorrowEdge::Field(qid, field_num) => self.handle_write_back_ref_field(
-                        qid.module_id,
-                        qid.id,
-                        &qid.inst,
-                        *idx,
-                        *field_num,
-                        typed_args.remove(0),
-                        local_state,
-                    ),
-                    BorrowEdge::Index => {
-                        self.handle_write_back_ref_element(*idx, typed_args.remove(0), local_state)
-                    }
-                    BorrowEdge::Hyper(hyper) => self.handle_write_back_ref_hyper(
-                        hyper,
-                        *idx,
-                        typed_args.remove(0),
-                        local_state,
-                    ),
-                }
-                Ok(vec![])
+                self.handle_write_back_reference(*idx, edge, typed_args.remove(0), local_state)
+                    .map(|_| Vec::new())
             }
             Operation::WriteBack(BorrowNode::ReturnPlaceholder(_), _) => {
                 // temporary placeholder, never appears in processed bytecode instructions
@@ -934,7 +908,7 @@ impl<'env> FunctionContext<'env> {
             .enumerate()
             .map(|(idx, arg)| {
                 if mut_args.contains_key(&idx) {
-                    arg.box_into_mut_ref_arg(srcs[idx])
+                    arg.box_into_mut_ref_arg(self.ty_args.clone(), srcs[idx])
                 } else {
                     arg
                 }
@@ -1142,58 +1116,71 @@ impl<'env> FunctionContext<'env> {
 
     fn handle_is_parent(
         &self,
-        parent_idx: TempIndex,
+        node: &BorrowNode,
         edge: &BorrowEdge,
         op_val: TypedValue,
+        local_state: &LocalState,
     ) -> TypedValue {
-        fn follow_pointer_edge(p: &Pointer, e: &BorrowEdge) -> bool {
-            match (p, e) {
-                (Pointer::RefField(_, p_field_num), BorrowEdge::Field(_, e_field_num)) => {
-                    p_field_num == e_field_num
-                }
-                (Pointer::RefElement(_, _), BorrowEdge::Index) => true,
-                _ => false,
-            }
-        }
+        let env = self.target.global_env();
+        let ptrs = self.backtrace_pointers(op_val.get_ptr(), local_state);
+        let edges = Self::flatten_borrow_edges(edge);
 
-        fn follow_pointer_trace(trace: &[Pointer], edges: &[BorrowEdge]) -> bool {
-            for (p, e) in trace.iter().rev().zip(edges.iter()) {
-                if !follow_pointer_edge(p, e) {
-                    return false;
+        for (i, e) in edges.iter().rev().enumerate() {
+            match ptrs.get(i) {
+                None => {
+                    return TypedValue::mk_bool(false);
                 }
-            }
-            true
-        }
-
-        let (_, _, ptr) = op_val.decompose();
-        let is_parent = match ptr {
-            Pointer::RefField(idx, _) => idx == parent_idx,
-            Pointer::RefElement(idx, _) => idx == parent_idx,
-            Pointer::ArgRef(idx, _) => idx == parent_idx,
-            Pointer::RetRef(mut trace) => match trace.pop().unwrap() {
-                Pointer::ArgRef(idx, _) => {
-                    if idx == parent_idx {
-                        if trace.len() == 1 {
-                            follow_pointer_edge(trace.get(0).unwrap(), edge)
-                        } else {
-                            match edge {
-                                BorrowEdge::Hyper(hyper) => {
-                                    if hyper.len() == trace.len() {
-                                        follow_pointer_trace(&trace, hyper)
-                                    } else {
-                                        false
-                                    }
-                                }
-                                _ => false,
-                            }
+                Some((p, p_stack)) => match (p, e) {
+                    // invalid cases
+                    (Pointer::None, _) | (_, BorrowEdge::Hyper(_)) => unreachable!(),
+                    // valid cases
+                    (Pointer::Local(_), BorrowEdge::Direct) => (),
+                    (Pointer::Global(_, _), BorrowEdge::Direct) => (),
+                    (
+                        Pointer::RefField(_, p_struct_ty, p_field_num),
+                        BorrowEdge::Field(e_struct_inst, e_field_num),
+                    ) => {
+                        let e_struct_ty = convert_model_struct_type(
+                            env,
+                            e_struct_inst.module_id,
+                            e_struct_inst.id,
+                            &e_struct_inst.inst,
+                            p_stack.last().unwrap(),
+                        );
+                        if p_struct_ty != &e_struct_ty || p_field_num != e_field_num {
+                            return TypedValue::mk_bool(false);
                         }
-                    } else {
-                        false
                     }
-                }
-                _ => unreachable!(),
-            },
-            Pointer::None | Pointer::Local(_) | Pointer::Global(_) => unreachable!(),
+                    (Pointer::RefElement(_, _), BorrowEdge::Index) => (),
+                    (Pointer::ArgRef(_, _, _), BorrowEdge::Direct) => (),
+                    // all other cases are mismatches
+                    _ => {
+                        return TypedValue::mk_bool(false);
+                    }
+                },
+            }
+        }
+
+        let (last_ptr, last_ptr_stack) = ptrs.get(edges.len() - 1).unwrap();
+        if cfg!(debug_assertions) {
+            assert_eq!(last_ptr_stack.len(), 1);
+        }
+
+        let is_parent = match (last_ptr, node) {
+            (Pointer::Local(p_idx), BorrowNode::LocalRoot(n_idx)) => p_idx == n_idx,
+            (Pointer::Global(_, p_struct_ty), BorrowNode::GlobalRoot(n_struct_inst)) => {
+                let n_struct_ty = convert_model_struct_type(
+                    env,
+                    n_struct_inst.module_id,
+                    n_struct_inst.id,
+                    &n_struct_inst.inst,
+                    last_ptr_stack.last().unwrap(),
+                );
+                p_struct_ty == &n_struct_ty
+            }
+            (Pointer::RefField(p_idx, _, _), BorrowNode::Reference(n_idx))
+            | (Pointer::RefElement(p_idx, _), BorrowNode::Reference(n_idx)) => p_idx == n_idx,
+            _ => false,
         };
         TypedValue::mk_bool(is_parent)
     }
@@ -1209,9 +1196,12 @@ impl<'env> FunctionContext<'env> {
         let env = self.target.global_env();
         let inst = convert_model_struct_type(env, module_id, struct_id, ty_args, &self.ty_args);
         let addr = match op_struct.get_ptr() {
-            // TODO (mengxu) this needs to be extended to check for actual address in borrow graph
-            // only put the resource back when the address matches
-            Pointer::Global(addr) => *addr,
+            Pointer::Global(addr, p_inst) => {
+                if cfg!(debug_assertions) {
+                    assert_eq!(&inst, p_inst);
+                }
+                *addr
+            }
             _ => unreachable!(),
         };
         let old_resource = global_state.put_resource(addr, inst, op_struct.read_ref());
@@ -1242,201 +1232,91 @@ impl<'env> FunctionContext<'env> {
         }
     }
 
-    fn handle_write_back_ref_direct(
+    fn handle_write_back_reference(
         &self,
         local_ref: TempIndex,
+        edge: &BorrowEdge,
         op_val: TypedValue,
         local_state: &mut LocalState,
-    ) {
-        let old_val = local_state.del_value(local_ref);
-        if cfg!(debug_assertions) {
-            let new_ty = op_val.get_ty();
-            assert!(new_ty.is_ref(Some(true)));
-            assert_eq!(new_ty, old_val.get_ty());
+    ) -> Result<(), AbortInfo> {
+        let env = self.target.global_env();
+        let ptrs = self.backtrace_pointers(op_val.get_ptr(), local_state);
+        let edges = Self::flatten_borrow_edges(edge);
 
-            // check pointer validity
-            match op_val.get_ptr() {
-                Pointer::RetRef(trace) => {
-                    assert_eq!(trace.len(), 1);
-                    match trace.get(0).unwrap() {
-                        Pointer::ArgRef(ref_idx, original_ptr) => {
-                            assert_eq!(*ref_idx, local_ref);
-                            assert_eq!(original_ptr.as_ref(), old_val.get_ptr());
-                        }
-                        _ => unreachable!(),
+        // step 1: backtrace the pointers to the target reference
+        let mut ptr_trace = vec![];
+        for (i, e) in edges.iter().rev().enumerate() {
+            let (p, p_stack) = ptrs.get(i).unwrap();
+            if cfg!(debug_assertions) {
+                match (p, e) {
+                    (
+                        Pointer::RefField(_, p_struct_ty, p_field_num),
+                        BorrowEdge::Field(e_struct_inst, e_field_num),
+                    ) => {
+                        let e_struct_ty = convert_model_struct_type(
+                            env,
+                            e_struct_inst.module_id,
+                            e_struct_inst.id,
+                            &e_struct_inst.inst,
+                            p_stack.last().unwrap(),
+                        );
+                        assert_eq!(p_struct_ty, &e_struct_ty);
+                        assert_eq!(p_field_num, e_field_num);
                     }
+                    (Pointer::RefElement(_, _), BorrowEdge::Index) => (),
+                    (Pointer::ArgRef(_, _, _), BorrowEdge::Direct) => (),
+                    _ => unreachable!(),
+                }
+            }
+            ptr_trace.push(p.clone());
+        }
+
+        // step 2: create write-back value chain
+        let mut val_trace = vec![];
+        let mut cur_val = local_state.get_value(local_ref);
+        for p in ptr_trace.iter().rev() {
+            val_trace.push(cur_val.clone());
+            match p {
+                Pointer::RefField(parent_idx, _, field_num) => {
+                    cur_val = cur_val.borrow_ref_struct_field(*field_num, true, *parent_idx);
+                }
+                Pointer::RefElement(parent_idx, elem_num) => {
+                    cur_val = cur_val
+                        .borrow_ref_vector_element(*elem_num, true, *parent_idx)
+                        .ok_or_else(|| self.usr_abort(INDEX_OUT_OF_BOUNDS))?;
+                }
+                Pointer::ArgRef(_, _, _) => (),
+                _ => unreachable!(),
+            }
+        }
+        if cfg!(debug_assertions) {
+            assert_eq!(cur_val.get_ty(), op_val.get_ty());
+        }
+
+        // step 3: write-back following the chain of values and pointers
+        let mut cur_val = op_val;
+        for (p, v) in ptr_trace.into_iter().zip(val_trace.into_iter().rev()) {
+            match p {
+                Pointer::RefField(_, struct_inst, field_num) => {
+                    if cfg!(debug_assertions) {
+                        v.get_ty().is_ref_struct_of(&struct_inst, Some(true));
+                    }
+                    cur_val = v.update_ref_struct_field(field_num, cur_val);
+                }
+                Pointer::RefElement(_, elem_num) => {
+                    if cfg!(debug_assertions) {
+                        v.get_ty().is_ref_vector(Some(true));
+                    }
+                    cur_val = v.update_ref_vector_element(elem_num, cur_val);
+                }
+                Pointer::ArgRef(_, _, _) => {
+                    cur_val = v.replace_base_value(cur_val);
                 }
                 _ => unreachable!(),
             }
         }
-        let new_val = op_val.unbox_from_mut_ref_ret();
-        local_state.put_value(local_ref, new_val);
-    }
-
-    fn handle_write_back_ref_field(
-        &self,
-        module_id: ModuleId,
-        struct_id: StructId,
-        ty_args: &[MT::Type],
-        local_ref: TempIndex,
-        field_num: usize,
-        op_val: TypedValue,
-        local_state: &mut LocalState,
-    ) {
-        let old_struct = local_state.del_value(local_ref);
-        if cfg!(debug_assertions) {
-            let env = self.target.global_env();
-            let inst = convert_model_struct_type(env, module_id, struct_id, ty_args, &self.ty_args);
-            assert!(old_struct.get_ty().is_ref_struct_of(&inst, Some(true)));
-
-            // check pointer validity
-            match op_val.get_ptr() {
-                Pointer::RefField(ref_idx, ref_field) => {
-                    assert_eq!(*ref_field, field_num);
-                    assert_eq!(*ref_idx, local_ref);
-                }
-                Pointer::RetRef(trace) => {
-                    assert_eq!(trace.len(), 2);
-                    match trace.get(1).unwrap() {
-                        Pointer::ArgRef(ref_idx, _) => {
-                            assert_eq!(*ref_idx, local_ref);
-                        }
-                        _ => unreachable!(),
-                    }
-                    match trace.get(0).unwrap() {
-                        Pointer::RefField(_, ref_field) => {
-                            assert_eq!(*ref_field, field_num);
-                        }
-                        _ => unreachable!(),
-                    }
-                }
-                _ => unreachable!(),
-            };
-        }
-        let new_struct = old_struct.update_ref_struct_field(field_num, op_val);
-        local_state.put_value(local_ref, new_struct);
-    }
-
-    fn handle_write_back_ref_element(
-        &self,
-        local_ref: TempIndex,
-        op_val: TypedValue,
-        local_state: &mut LocalState,
-    ) {
-        let old_vector = local_state.del_value(local_ref);
-        let elem_num = match op_val.get_ptr() {
-            Pointer::RefElement(ref_idx, elem_num) => {
-                if cfg!(debug_assertions) {
-                    assert_eq!(*ref_idx, local_ref);
-                }
-                elem_num
-            }
-            Pointer::RetRef(trace) => {
-                assert_eq!(trace.len(), 2);
-                match trace.get(1).unwrap() {
-                    Pointer::ArgRef(ref_idx, _) => {
-                        assert_eq!(*ref_idx, local_ref);
-                    }
-                    _ => unreachable!(),
-                }
-                match trace.get(0).unwrap() {
-                    Pointer::RefElement(_, elem_num) => elem_num,
-                    _ => unreachable!(),
-                }
-            }
-            _ => unreachable!(),
-        };
-        let new_vector = old_vector.update_ref_vector_element(*elem_num, op_val);
-        local_state.put_value(local_ref, new_vector);
-    }
-
-    fn handle_write_back_ref_hyper(
-        &self,
-        edges: &[BorrowEdge],
-        local_ref: TempIndex,
-        op_val: TypedValue,
-        local_state: &mut LocalState,
-    ) {
-        let new_val = match op_val.get_ptr() {
-            Pointer::RetRef(trace) => {
-                let steps = edges.len();
-                if cfg!(debug_assertions) {
-                    assert_eq!(trace.len(), steps + 1);
-                    match trace.last().unwrap() {
-                        Pointer::ArgRef(ref_idx, _) => assert_eq!(*ref_idx, local_ref),
-                        _ => unreachable!(),
-                    }
-                }
-
-                let mut cur = local_state.del_value(local_ref);
-                let mut path = vec![];
-                for (i, edge) in edges.iter().enumerate() {
-                    let ptr = trace.get(steps - 1 - i).unwrap();
-                    let sub = match (ptr, edge) {
-                        (
-                            Pointer::RefField(callee_idx, p_field_num),
-                            BorrowEdge::Field(qid, field_num),
-                        ) => {
-                            if cfg!(debug_assertions) {
-                                let env = self.target.global_env();
-                                let inst = convert_model_struct_type(
-                                    env,
-                                    qid.module_id,
-                                    qid.id,
-                                    &qid.inst,
-                                    &self.ty_args,
-                                );
-                                assert!(cur.get_ty().is_ref_struct_of(&inst, Some(true)));
-                                assert_eq!(p_field_num, field_num);
-                            }
-                            path.push(cur.clone());
-                            // NOTE: the local_idx argument can be any dummy value here
-                            cur.borrow_ref_struct_field(*field_num, true, *callee_idx)
-                        }
-                        (Pointer::RefElement(callee_idx, elem_num), BorrowEdge::Index) => {
-                            if cfg!(debug_assertions) {
-                                assert!(cur.get_ty().is_ref_vector(Some(true)));
-                            }
-                            path.push(cur.clone());
-                            // NOTE: the local_idx argument can be any dummy value here
-                            cur.borrow_ref_vector_element(*elem_num, true, *callee_idx)
-                                .unwrap()
-                        }
-                        _ => unreachable!(),
-                    };
-                    cur = sub;
-                }
-
-                if cfg!(debug_assertions) {
-                    let new_ty = op_val.get_ty();
-                    assert!(new_ty.is_ref(Some(true)));
-                    assert_eq!(new_ty, cur.get_ty());
-                }
-
-                // TODO (mengxu): refactor the code to remove this clone
-                let mut cur = op_val.clone();
-                for (i, (val, edge)) in path.into_iter().zip(edges.iter()).rev().enumerate() {
-                    let ptr = trace.get(steps - 1 - i).unwrap();
-                    let sub = match edge {
-                        BorrowEdge::Field(_, field_num) => {
-                            val.update_ref_struct_field(*field_num, cur)
-                        }
-                        BorrowEdge::Index => {
-                            let elem_num = match ptr {
-                                Pointer::RefElement(_, elem_num) => elem_num,
-                                _ => unreachable!(),
-                            };
-                            val.update_ref_vector_element(*elem_num, cur)
-                        }
-                        _ => unreachable!(),
-                    };
-                    cur = sub;
-                }
-                cur
-            }
-            _ => unreachable!(),
-        };
-        local_state.put_value(local_ref, new_val);
+        local_state.put_value_override(local_ref, cur_val);
+        Ok(())
     }
 
     fn handle_global_address(&self, ref_val: TypedValue, local_state: &LocalState) -> TypedValue {
@@ -1445,11 +1325,14 @@ impl<'env> FunctionContext<'env> {
             assert!(ty.is_ref(Some(true)));
         }
         match ptr {
-            Pointer::Global(addr) => TypedValue::mk_address(addr),
-            Pointer::RefField(parent, _) | Pointer::RefElement(parent, _) => {
+            Pointer::Global(addr, _) => TypedValue::mk_address(addr),
+            Pointer::RefField(parent, _, _) | Pointer::RefElement(parent, _) => {
                 self.handle_global_address(local_state.get_value(parent), local_state)
             }
-            Pointer::None | Pointer::Local(_) | Pointer::ArgRef(_, _) | Pointer::RetRef(_) => {
+            Pointer::None
+            | Pointer::Local(_)
+            | Pointer::ArgRef(_, _, _)
+            | Pointer::RetRef(_, _) => {
                 unreachable!()
             }
         }
@@ -1830,7 +1713,7 @@ impl<'env> FunctionContext<'env> {
                 let val = local_state.get_value(*index);
                 // mark mut_ref returns with the pointer trace
                 if val.get_ty().is_ref(Some(true)) {
-                    val.box_into_mut_ref_ret(&ptrs)
+                    val.box_into_mut_ref_ret(self.ty_args.clone(), &ptrs)
                 } else {
                     val
                 }
@@ -2260,6 +2143,83 @@ impl<'env> FunctionContext<'env> {
             local_slots.push(slot);
         }
         LocalState::new(local_slots)
+    }
+
+    fn backtrace_pointers(
+        &self,
+        ptr: &Pointer,
+        local_state: &LocalState,
+    ) -> Vec<(Pointer, Vec<Vec<BaseType>>)> {
+        fn backtrace(
+            ptr: Pointer,
+            stack: &mut Vec<Vec<BaseType>>,
+            trace: &mut Vec<(Pointer, Vec<Vec<BaseType>>)>,
+        ) -> Option<TempIndex> {
+            match ptr {
+                p @ Pointer::Local(_)
+                | p @ Pointer::Global(_, _)
+                | p @ Pointer::ArgRef(_, _, _) => {
+                    trace.push((p, stack.clone()));
+                    None
+                }
+                Pointer::RefField(idx, struct_inst, field_num) => {
+                    let p = Pointer::RefField(idx, struct_inst, field_num);
+                    trace.push((p, stack.clone()));
+                    Some(idx)
+                }
+                Pointer::RefElement(idx, elem_num) => {
+                    let p = Pointer::RefElement(idx, elem_num);
+                    trace.push((p, stack.clone()));
+                    Some(idx)
+                }
+                Pointer::RetRef(inner_inst, mut sub_trace) => {
+                    let arg_ref = sub_trace.pop().unwrap();
+                    let idx = match &arg_ref {
+                        Pointer::ArgRef(_, arg_idx, _) => *arg_idx,
+                        _ => unreachable!(),
+                    };
+                    // NOTE: this is to match the fact that, if an arg is returned directly without
+                    // further borrowing, the hyber edge that summarises this borrow relation in the
+                    // called function contains a BorrowEdge::Direct.
+                    if sub_trace.is_empty() {
+                        trace.push((arg_ref, stack.clone()));
+                    } else {
+                        stack.push(inner_inst);
+                        for sub_ptr in sub_trace {
+                            backtrace(sub_ptr, stack, trace);
+                        }
+                        stack.pop().unwrap();
+                    }
+                    Some(idx)
+                }
+                Pointer::None => unreachable!(),
+            }
+        }
+
+        let mut trace = vec![];
+        let mut stack = vec![self.ty_args.clone()];
+        let mut cur_ptr = ptr.clone();
+        loop {
+            match backtrace(cur_ptr, &mut stack, &mut trace) {
+                None => break,
+                Some(next) => {
+                    let (_, _, next_ptr) = local_state.get_value(next).decompose();
+                    cur_ptr = next_ptr;
+                }
+            }
+        }
+        trace
+    }
+
+    fn flatten_borrow_edges(edge: &BorrowEdge) -> Vec<BorrowEdge> {
+        match edge {
+            BorrowEdge::Direct | BorrowEdge::Field(_, _) | BorrowEdge::Index => vec![edge.clone()],
+            BorrowEdge::Hyper(edges) => edges
+                .iter()
+                .map(|e| Self::flatten_borrow_edges(e))
+                .flatten()
+                .collect(),
+        }
     }
 }
 

--- a/language/move-prover/tests/sources/functional/invariants.exp
+++ b/language/move-prover/tests/sources/functional/invariants.exp
@@ -54,6 +54,4 @@ error: data invariant does not hold
      =         <redacted> = <redacted>
      =         x_ref = <redacted>
      =     at tests/sources/functional/invariants.move:160: lifetime_invalid_S_branching
-     =     at tests/sources/functional/invariants.move:143
-     =     at tests/sources/functional/invariants.move:163: lifetime_invalid_S_branching
      =     at tests/sources/functional/invariants.move:150

--- a/language/move-prover/tests/sources/functional/mut_ref.exp
+++ b/language/move-prover/tests/sources/functional/mut_ref.exp
@@ -19,12 +19,10 @@ error: data invariant does not hold
    =     at tests/sources/functional/mut_ref.move:8
    =     at tests/sources/functional/mut_ref.move:118: call_return_ref_different_path_vec2_incorrect
    =     at tests/sources/functional/mut_ref.move:8
-   =     at tests/sources/functional/mut_ref.move:118: call_return_ref_different_path_vec2_incorrect
    =     at tests/sources/functional/mut_ref.move:119: call_return_ref_different_path_vec2_incorrect
    =     at tests/sources/functional/mut_ref.move:8
    =     at tests/sources/functional/mut_ref.move:119: call_return_ref_different_path_vec2_incorrect
    =     at tests/sources/functional/mut_ref.move:8
-   =     at tests/sources/functional/mut_ref.move:119: call_return_ref_different_path_vec2_incorrect
    =     at tests/sources/functional/mut_ref.move:120: call_return_ref_different_path_vec2_incorrect
    =         x = <redacted>
    =     at tests/sources/functional/mut_ref.move:121: call_return_ref_different_path_vec2_incorrect

--- a/language/move-prover/tests/sources/functional/nested_invariants.move
+++ b/language/move-prover/tests/sources/functional/nested_invariants.move
@@ -50,7 +50,7 @@ module 0x42::TestNestedInvariants {
     fun mutate() {
         let o = Outer{y: 3, n: Nested{x: 2}};
         let r = &mut o;
-        r.y = 2;
+        r.y = 2;  // temporary data invariant violation is allowed
         r.n.x = 1;
     }
 

--- a/language/move-prover/tests/sources/functional/write_back_early_for_loop_invariant.move
+++ b/language/move-prover/tests/sources/functional/write_back_early_for_loop_invariant.move
@@ -1,0 +1,25 @@
+module 0x42::Test {
+    struct Inner { v: u64 }
+    struct Outer { i: Inner }
+
+    fun ret_mut(i: &mut Inner): &mut u64 {
+        i.v = 0;
+        &mut i.v
+    }
+
+    fun foo(o: &mut Outer, y: u64) {
+        let x = ret_mut(&mut o.i);
+        loop {
+            spec {
+                assert o.i.v <= y;
+            };
+            if (*x == y) {
+                break
+            };
+            *x = *x + 1;
+        }
+    }
+    spec foo {
+        ensures o.i.v == y;
+    }
+}

--- a/language/move-prover/tests/sources/functional/write_back_intermediate.move
+++ b/language/move-prover/tests/sources/functional/write_back_intermediate.move
@@ -1,0 +1,28 @@
+module 0x42::Test {
+    struct Inner { v: u64 }
+
+    struct Outer {
+        f1: Inner,
+        f2: Inner,
+    }
+
+    fun ret_mut_inner(s: &mut Inner): &mut u64 {
+        s.v = 0;
+        &mut s.v
+    }
+
+    fun process_outer(cond: bool, s: &mut Outer) {
+        let x = if (cond) {
+            ret_mut_inner(&mut s.f1)
+        } else {
+            ret_mut_inner(&mut s.f2)
+        };
+        spec {
+            assert if (cond) s.f1.v == 0 else s.f2.v == 0;
+        };
+        *x = 1;
+    }
+    spec process_outer {
+        ensures if (cond) s.f1.v == 1 else s.f2.v == 1;
+    }
+}

--- a/language/move-prover/tests/sources/functional/write_back_with_is_parent.move
+++ b/language/move-prover/tests/sources/functional/write_back_with_is_parent.move
@@ -1,0 +1,77 @@
+module 0x42::Test {
+    struct T has key {
+        x: u64,
+    }
+
+    struct R has key {
+        x: u64,
+    }
+
+    public fun diff_address(cond: bool, a1: address, a2: address) acquires T {
+        let x = if (cond) {
+            let t1 = borrow_global_mut<T>(a1);
+            &mut t1.x
+        } else {
+            let t2 = borrow_global_mut<T>(a2);
+            &mut t2.x
+        };
+        *x = 0;
+    }
+    spec diff_address {
+        aborts_if cond && !exists<T>(a1);
+        aborts_if !cond && !exists<T>(a2);
+        ensures if (cond) global<T>(a1).x == 0 else global<T>(a2).x == 0;
+    }
+
+    public fun diff_location(cond: bool, a: address, l: &mut T) acquires T {
+        let x = if (cond) {
+            let t1 = borrow_global_mut<T>(a);
+            &mut t1.x
+        } else {
+            let t2 = l;
+            &mut t2.x
+        };
+        *x = 0;
+    }
+    spec diff_location {
+        aborts_if cond && !exists<T>(a);
+        ensures if (cond) global<T>(a).x == 0 else l.x == 0;
+    }
+
+    public fun diff_resource(cond: bool, a: address) acquires T, R {
+        let x = if (cond) {
+            let t1 = borrow_global_mut<T>(a);
+            &mut t1.x
+        } else {
+            let t2 = borrow_global_mut<R>(a);
+            &mut t2.x
+        };
+        *x = 0;
+    }
+    spec diff_resource {
+        aborts_if cond && !exists<T>(a);
+        aborts_if !cond && !exists<R>(a);
+        ensures if (cond) global<T>(a).x == 0 else global<R>(a).x == 0;
+    }
+
+    struct V<T: store> has key {
+        x: u64,
+        y: T,
+    }
+
+    public fun diff_resource_generic<A: store, B: store>(cond: bool, a: address) acquires V {
+        let x = if (cond) {
+            let t1 = borrow_global_mut<V<A>>(a);
+            &mut t1.x
+        } else {
+            let t2 = borrow_global_mut<V<B>>(a);
+            &mut t2.x
+        };
+        *x = 0;
+    }
+    spec diff_resource_generic {
+        aborts_if cond && !exists<V<A>>(a);
+        aborts_if !cond && !exists<V<B>>(a);
+        ensures if (cond) global<V<A>>(a).x == 0 else global<V<B>>(a).x == 0;
+    }
+}


### PR DESCRIPTION
Well, this PR eventually turns into a much larger one than I expected.

The current weak-edge elimination process defers the write-back of a
chain of edges until the last node goes out of scope. For example, in
the following borrow-chain:

```
struct Inner { v: u64  }

struct Outer {
    f1: Inner,
    f2: Inner,
}

fun ret_mut_inner(i: &mut Inner): &mut u64 {
    i.v = 0;
    &mut i.v
}

fun handle_outer(cond: bool, o: &mut Outer) {
    let x = if (cond) {
        ret_mut_inner(&mut o.f1)

    } else {
        ret_mut_inner(&mut o.f2)

    };
    spec {
        assert if (cond) o.f1.v == 0 else o.f2.v == 0;

    };
    *x = 1;
}
```

```
          -- borrow_from --> (i|$t1: &mut Inner, .v) -- borrow_from --> (o: &mut Outer, .f1)
         /
x: &mut v
         \
          -- borrow_from --> (i|$t2: &mut Inner, .v) -- borrow_from --> (o: &mut Outer, .f2)
```

The write-back from `x` to `o` happens only when `x` goes out of scope.

This has two implications:
- the intermediate state of `o` before the final write-back is not
  captured. In the above example, the inline spec will not prove,
  although it should hold at the code location.

- the calling of `IsParent[o]($t1)` and `IsParent[o]($t2)` (and the
  subsequent `WriteBack[o]($t1)` and `WriteBack[o]($t2)`) confuses
  the live_var analysis because `$t1` and `$t2` are only defined on
  a certain code paths. The live_var analysis will eventually conclude
  that `$t1` and `$t2` are live from the beginning of the execution,
  which is not semantically correct.

This commit proposes two changes to fix it:
- early write-backs for dying references
  When `$t1` and `$t2` goes out of scope, we immediately write it back
  to `o` instead of waiting for their derived reference (i.e., `x`) goes
  out of scope.

- parent test until a live reference variable
  When testing the parent of `x`, we back trace the borrow graph until a
  live reference (instead of using its immediate parents). In this
  example, we call
  `IsParent[o, (.f1/.v)](x)` instead of `IsParent[$t1, (.v)](x)`, and
  `IsParent[o, (.f2/.v)](x)` instead of `IsParent[$t2, (.v)](x)`.
  The write-backs are updated as well.

In order to support these changes, both `IsParent` and `WriteBack`
are updated to support the cases where the root of the parent is a
`Local` or `Global`.

- `IsParent` with `Local` root:  to support this, a function,
  `$PathMatches` is added to prelude and the boogie translator
   will translate the edge / hyper-edge into a `vec int` such that
   it can be compared with `p#$Mutation`.

- `IsParent` with `Global` root: to support this, not only the
   edge needs to be compared, but also the type of the global
   resource. However, as of now, such information is not available
   in the bytecode. To add this information, the definition of
   `$Global` is changed updated with an additional type-id field,
   as shown below:

```
function {:constructor} $Global(a: int): $Location;
function {:constructor} $Global(a: int, t: int): $Location;
```

This type-id `t:int` is maintained by the boogie translator on a
per-function basis. A map is maintained, per-function, that maps
`QuantifiedInstId<StructId>` into `usize`. When translating a
`BorrowGlobal`, both the address and type-id is used to construct
a `$Global(a, i)` location. Similarly, when testing whether a
`BorrowNode::GlobalRoot` is a parent of a variable `$v`, we also
test whether `$v`'s location is a `$Global` with a given type-id.

- `WriteBack` to a `Local` root: the prelude only supports
   write-backs to a `Reference` instead of a direct local slot.
   To piggyback on this, right before the write-back, we create
   an ad-hoc reference `r` and first write-back to `r` and then
   write-back `r` to the local slot.

- `WriteBack` to a `Global` root: we also need to create a
   shadow reference as a proxy for the write-back. But in order
   to do this, we need the address to `BorrowGlobal`. To retrieve
   the address, we added a new bytecode operation,
   `GlobalAddress`, that can return the address of a reference
   that is directly or indirectly borrowed from a global location.

These updates are captured in a new functional test:
`write_back_with_is_parent.move`, which cannot be verified before.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

New test cases added

## Related PRs

#8357 
