### PR TITLE
Refactor network builders

### DIFF
--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -265,7 +265,7 @@ impl NetworkBuilder {
 
         match &config.discovery_method {
             DiscoveryMethod::Onchain => {
-                network_builder.add_configuration_change_listener(pubkey, config.encryptor());
+                network_builder.add_validator_set_listener(pubkey, config.encryptor());
             }
             DiscoveryMethod::None => {}
         }
@@ -279,7 +279,6 @@ impl NetworkBuilder {
         self.state = State::BUILT;
         self.executor = Some(executor);
         self.build_peer_manager()
-            .build_configuration_change_listener()
             .build_connectivity_manager()
             .build_connection_monitoring()
     }
@@ -291,7 +290,7 @@ impl NetworkBuilder {
         self.start_peer_manager()
             .start_connectivity_manager()
             .start_connection_monitoring()
-            .start_configuration_change_listener()
+            .start_validator_set_listener()
     }
 
     pub fn reconfig_subscriptions(&mut self) -> &mut Vec<ReconfigSubscription> {
@@ -402,7 +401,7 @@ impl NetworkBuilder {
         self
     }
 
-    fn add_configuration_change_listener(
+    fn add_validator_set_listener(
         &mut self,
         pubkey: PublicKey,
         encryptor: Encryptor,
@@ -426,16 +425,7 @@ impl NetworkBuilder {
         self
     }
 
-    fn build_configuration_change_listener(&mut self) -> &mut Self {
-        if let Some(configuration_change_listener) =
-            self.configuration_change_listener_builder.as_mut()
-        {
-            configuration_change_listener.build();
-        }
-        self
-    }
-
-    fn start_configuration_change_listener(&mut self) -> &mut Self {
+    fn start_validator_set_listener(&mut self) -> &mut Self {
         if let Some(configuration_change_listener) =
             self.configuration_change_listener_builder.as_mut()
         {

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -256,7 +256,7 @@ impl NetworkBuilder {
         assert_eq!(self.state, State::CREATED);
         self.state = State::BUILT;
         self.executor = Some(executor);
-        self.build_peer_manager().build_connectivity_manager()
+        self.build_peer_manager()
     }
 
     /// Start the built Networking components.
@@ -348,13 +348,6 @@ impl NetworkBuilder {
         self
     }
 
-    fn build_connectivity_manager(&mut self) -> &mut Self {
-        if let Some(builder) = self.connectivity_manager_builder.as_mut() {
-            builder.build(self.executor.as_mut().expect("Executor must exist"));
-        }
-        self
-    }
-
     fn start_connectivity_manager(&mut self) -> &mut Self {
         if let Some(builder) = self.connectivity_manager_builder.as_mut() {
             builder.start(self.executor.as_mut().expect("Executor must exist"));
@@ -362,11 +355,7 @@ impl NetworkBuilder {
         self
     }
 
-    fn add_validator_set_listener(
-        &mut self,
-        pubkey: PublicKey,
-        encryptor: Encryptor,
-    ) -> &mut Self {
+    fn add_validator_set_listener(&mut self, pubkey: PublicKey, encryptor: Encryptor) -> &mut Self {
         let conn_mgr_reqs_tx = self
             .conn_mgr_reqs_tx()
             .expect("ConnectivityManager must be installed for validator");

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -177,7 +177,7 @@ impl NetworkBuilder {
         let authentication_mode = if config.mutual_authentication {
             AuthenticationMode::Mutual(identity_key)
         } else {
-            AuthenticationMode::ServerOnly(identity_key)
+            AuthenticationMode::MaybeMutual(identity_key)
         };
 
         let network_context = Arc::new(NetworkContext::new(

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -256,9 +256,7 @@ impl NetworkBuilder {
         assert_eq!(self.state, State::CREATED);
         self.state = State::BUILT;
         self.executor = Some(executor);
-        self.build_peer_manager()
-            .build_connectivity_manager()
-            .build_connection_monitoring()
+        self.build_peer_manager().build_connectivity_manager()
     }
 
     /// Start the built Networking components.
@@ -409,7 +407,7 @@ impl NetworkBuilder {
         let (hc_network_tx, hc_network_rx) =
             self.add_protocol_handler(health_checker::network_endpoint_config());
 
-        self.health_checker_builder = Some(HealthCheckerBuilder::create(
+        self.health_checker_builder = Some(HealthCheckerBuilder::new(
             self.network_context(),
             self.time_service.clone(),
             ping_interval_ms,
@@ -422,18 +420,6 @@ impl NetworkBuilder {
             NetworkSchema::new(&self.network_context),
             "{} Created health checker", self.network_context
         );
-        self
-    }
-
-    /// Build the HealthChecker, if it has been added.
-    fn build_connection_monitoring(&mut self) -> &mut Self {
-        if let Some(health_checker) = self.health_checker_builder.as_mut() {
-            health_checker.build(self.executor.as_mut().expect("Executor must exist"));
-            debug!(
-                NetworkSchema::new(&self.network_context),
-                "{} Built health checker", self.network_context
-            );
-        };
         self
     }
 

--- a/network/builder/src/dummy.rs
+++ b/network/builder/src/dummy.rs
@@ -147,7 +147,7 @@ pub fn setup_network() -> DummyNetwork {
     ));
     let mut network_builder = NetworkBuilder::new_for_test(
         chain_id,
-        &seeds,
+        seeds.clone(),
         trusted_peers,
         network_context,
         TimeService::real(),
@@ -175,7 +175,7 @@ pub fn setup_network() -> DummyNetwork {
 
     let mut network_builder = NetworkBuilder::new_for_test(
         chain_id,
-        &seeds,
+        seeds,
         trusted_peers,
         network_context,
         TimeService::real(),

--- a/network/src/connectivity_manager/builder.rs
+++ b/network/src/connectivity_manager/builder.rs
@@ -15,34 +15,9 @@ use tokio_retry::strategy::ExponentialBackoff;
 
 pub type ConnectivityManagerService = ConnectivityManager<ExponentialBackoff>;
 
-/// The configuration fields for ConnectivityManager
-struct ConnectivityManagerBuilderConfig {
-    network_context: Arc<NetworkContext>,
-    time_service: TimeService,
-    eligible: Arc<RwLock<PeerSet>>,
-    seeds: PeerSet,
-    connectivity_check_interval_ms: u64,
-    backoff_base: u64,
-    max_connection_delay_ms: u64,
-    connection_reqs_tx: ConnectionRequestSender,
-    connection_notifs_rx: conn_notifs_channel::Receiver,
-    requests_rx: channel::Receiver<ConnectivityRequest>,
-    outbound_connection_limit: Option<usize>,
-    mutual_authentication: bool,
-}
-
-#[derive(Debug, PartialEq, PartialOrd)]
-enum State {
-    CREATED,
-    BUILT,
-    STARTED,
-}
-
 pub struct ConnectivityManagerBuilder {
-    config: Option<ConnectivityManagerBuilderConfig>,
     connectivity_manager: Option<ConnectivityManagerService>,
     conn_mgr_reqs_tx: channel::Sender<ConnectivityRequest>,
-    state: State,
 }
 
 impl ConnectivityManagerBuilder {
@@ -64,24 +39,23 @@ impl ConnectivityManagerBuilder {
             channel_size,
             &counters::PENDING_CONNECTIVITY_MANAGER_REQUESTS,
         );
+
         Self {
-            config: Some(ConnectivityManagerBuilderConfig {
+            conn_mgr_reqs_tx,
+            connectivity_manager: Some(ConnectivityManager::new(
                 network_context,
                 time_service,
                 eligible,
                 seeds,
-                connectivity_check_interval_ms,
-                backoff_base,
-                max_connection_delay_ms,
                 connection_reqs_tx,
                 connection_notifs_rx,
-                requests_rx: conn_mgr_reqs_rx,
+                conn_mgr_reqs_rx,
+                Duration::from_millis(connectivity_check_interval_ms),
+                ExponentialBackoff::from_millis(backoff_base).factor(1000),
+                Duration::from_millis(max_connection_delay_ms),
                 outbound_connection_limit,
                 mutual_authentication,
-            }),
-            connectivity_manager: None,
-            conn_mgr_reqs_tx,
-            state: State::CREATED,
+            )),
         }
     }
 
@@ -89,36 +63,7 @@ impl ConnectivityManagerBuilder {
         self.conn_mgr_reqs_tx.clone()
     }
 
-    pub fn build(&mut self, executor: &Handle) {
-        assert_eq!(self.state, State::CREATED);
-        self.state = State::BUILT;
-        let config = self
-            .config
-            .take()
-            .expect("Config must exist in order to build");
-
-        let _guard = executor.enter();
-        self.connectivity_manager = Some({
-            ConnectivityManager::new(
-                config.network_context,
-                config.time_service,
-                config.eligible,
-                &config.seeds,
-                config.connection_reqs_tx,
-                config.connection_notifs_rx,
-                config.requests_rx,
-                Duration::from_millis(config.connectivity_check_interval_ms),
-                ExponentialBackoff::from_millis(config.backoff_base).factor(1000),
-                Duration::from_millis(config.max_connection_delay_ms),
-                config.outbound_connection_limit,
-                config.mutual_authentication,
-            )
-        });
-    }
-
     pub fn start(&mut self, executor: &Handle) {
-        assert_eq!(self.state, State::BUILT);
-        self.state = State::STARTED;
         let conn_mgr = self
             .connectivity_manager
             .take()

--- a/network/src/connectivity_manager/mod.rs
+++ b/network/src/connectivity_manager/mod.rs
@@ -252,7 +252,7 @@ where
         network_context: Arc<NetworkContext>,
         time_service: TimeService,
         eligible: Arc<RwLock<PeerSet>>,
-        seeds: &PeerSet,
+        seeds: PeerSet,
         connection_reqs_tx: ConnectionRequestSender,
         connection_notifs_rx: conn_notifs_channel::Receiver,
         requests_rx: channel::Receiver<ConnectivityRequest>,
@@ -294,7 +294,7 @@ where
         };
 
         // set the initial config addresses and pubkeys
-        connmgr.handle_update_discovered_peers(DiscoverySource::Config, seeds.clone());
+        connmgr.handle_update_discovered_peers(DiscoverySource::Config, seeds);
         connmgr
     }
 

--- a/network/src/connectivity_manager/test.rs
+++ b/network/src/connectivity_manager/test.rs
@@ -94,7 +94,7 @@ impl TestHarness {
             network_context,
             time_service.clone(),
             trusted_peers.clone(),
-            &seeds,
+            seeds,
             ConnectionRequestSender::new(connection_reqs_tx),
             connection_notifs_rx,
             conn_mgr_reqs_rx,

--- a/network/src/peer_manager/builder.rs
+++ b/network/src/peer_manager/builder.rs
@@ -265,13 +265,6 @@ impl PeerManagerBuilder {
             .clone()
     }
 
-    pub fn add_connection_event_listener(&mut self) -> conn_notifs_channel::Receiver {
-        self.peer_manager_context
-            .as_mut()
-            .expect("Cannot add an event listener if PeerManager has already been built.")
-            .add_connection_event_listener()
-    }
-
     /// Create the configured transport and start PeerManager.
     /// Return the actual NetworkAddress over which this peer is listening.
     pub fn build(&mut self, executor: &Handle) -> &mut Self {
@@ -414,6 +407,13 @@ impl PeerManagerBuilder {
             TransportPeerManager::Memory(pm) => self.start_peer_manager(pm, executor),
             TransportPeerManager::Tcp(pm) => self.start_peer_manager(pm, executor),
         }
+    }
+
+    pub fn add_connection_event_listener(&mut self) -> conn_notifs_channel::Receiver {
+        self.peer_manager_context
+            .as_mut()
+            .expect("Cannot add an event listener if PeerManager has already been built.")
+            .add_connection_event_listener()
     }
 
     /// Add a handler for given protocols using raw bytes.

--- a/network/src/protocols/health_checker/builder.rs
+++ b/network/src/protocols/health_checker/builder.rs
@@ -9,35 +9,12 @@ use diem_time_service::TimeService;
 use std::{sync::Arc, time::Duration};
 use tokio::runtime::Handle;
 
-/// Configuration for a HealthCheckerBuilder.
-struct HealthCheckerBuilderConfig {
-    network_context: Arc<NetworkContext>,
-    time_service: TimeService,
-    ping_interval_ms: u64,
-    ping_timeout_ms: u64,
-    ping_failures_tolerated: u64,
-    network_tx: HealthCheckerNetworkSender,
-    network_rx: HealthCheckerNetworkEvents,
-}
-
 pub struct HealthCheckerBuilder {
-    config: Option<HealthCheckerBuilderConfig>,
     service: Option<HealthChecker>,
-    built: bool,
-    started: bool,
 }
 
 impl HealthCheckerBuilder {
-    fn new(config: HealthCheckerBuilderConfig) -> Self {
-        Self {
-            config: Some(config),
-            service: None,
-            built: false,
-            started: false,
-        }
-    }
-
-    pub fn create(
+    pub fn new(
         network_context: Arc<NetworkContext>,
         time_service: TimeService,
         ping_interval_ms: u64,
@@ -46,44 +23,21 @@ impl HealthCheckerBuilder {
         network_tx: HealthCheckerNetworkSender,
         network_rx: HealthCheckerNetworkEvents,
     ) -> Self {
-        HealthCheckerBuilder::new(HealthCheckerBuilderConfig {
+        let service = HealthChecker::new(
             network_context,
             time_service,
-            ping_interval_ms,
-            ping_timeout_ms,
-            ping_failures_tolerated,
             network_tx,
             network_rx,
-        })
-    }
-
-    pub fn build(&mut self, executor: &Handle) -> &mut Self {
-        // Can only build once;  must build before starting.
-        assert!(!self.built);
-        assert!(!self.started);
-        self.built = true;
-        if let Some(config) = self.config.take() {
-            let _guard = executor.enter();
-            let service = HealthChecker::new(
-                config.network_context,
-                config.time_service,
-                config.network_tx,
-                config.network_rx,
-                Duration::from_millis(config.ping_interval_ms),
-                Duration::from_millis(config.ping_timeout_ms),
-                config.ping_failures_tolerated,
-            );
-            self.service = Some(service);
+            Duration::from_millis(ping_interval_ms),
+            Duration::from_millis(ping_timeout_ms),
+            ping_failures_tolerated,
+        );
+        Self {
+            service: Some(service),
         }
-        self
     }
 
     pub fn start(&mut self, executor: &Handle) {
-        // Must be built to start.
-        assert!(self.built);
-        // Can only start once.
-        assert!(!self.started);
-        self.started = true;
         if let Some(service) = self.service.take() {
             executor.spawn(service.start());
         }

--- a/state-sync/tests/test_harness.rs
+++ b/state-sync/tests/test_harness.rs
@@ -388,7 +388,7 @@ impl StateSyncEnvironment {
 
             let mut network_builder = NetworkBuilder::new_for_test(
                 ChainId::default(),
-                &seeds,
+                seeds,
                 trusted_peers,
                 network_context,
                 TimeService::real(),


### PR DESCRIPTION
## Motivation

As part of working through adding more types of network discovery, the builders were unwieldy and overcomplicated.  

This attempts to go upon the following ideas:
1. If a function is a one liner, used once, and does not expose internal pieces externally, inline it
2. Rename anything that is confusing or mismatching
3. Fix a few comments that don't match reality
4. If there's a big blob of code that performs a purpose and could stand on it's own, put it in a function
5. If there are structs for the purpose of fitting a pattern, but don't have an implementation, remove them.
6. If there are functions for the purpose of fitting a pattern that isn't consistent or has very little value add, remove them.
7. Try to pass in cloned objects, rather than reference them, and then clone them internally
8. Ensure that if there are structs that are used for certain purposes, that they hold the values that are related to their use

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

### Future followups
* There are tests that don't create health checkers, and they should