### PR TITLE
[forge][aws][code-build] Enable ad-hoc code build for forge

### DIFF
--- a/docker/build-aws.sh
+++ b/docker/build-aws.sh
@@ -49,6 +49,9 @@ while [[ "$1" =~ ^- ]]; do case $1 in
   --build-tools )
     BUILD_PROJECTS=(diem-tools)
     ;;
+  --build-forge )
+    BUILD_PROJECTS=(diem-forge)
+    ;;
   --version )
     shift;
     if [[ "$1" =~ ^pull ]]; then

--- a/docker/build-common.sh
+++ b/docker/build-common.sh
@@ -50,6 +50,7 @@ if [ "$IMAGE_TARGETS" = "test" ] || [ "$IMAGE_TARGETS" = "all"  ]; then
           -p cluster-test \
           -p cli \
           -p diem-faucet \
+          -p forge \
           "$@"
 fi
 

--- a/docker/forge/Dockerfile
+++ b/docker/forge/Dockerfile
@@ -1,0 +1,35 @@
+FROM debian:buster-20210511@sha256:acf7795dc91df17e10effee064bd229580a9c34213b4dba578d64768af5d8c51 AS toolchain
+
+# To use http/https proxy while building, use:
+# docker build --build-arg https_proxy=http://fwdproxy:8080 --build-arg http_proxy=http://fwdproxy:8080
+
+RUN apt-get update && apt-get install -y cmake curl clang git pkg-config libssl-dev
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+ENV PATH "$PATH:/root/.cargo/bin"
+
+WORKDIR /diem
+COPY rust-toolchain /diem/rust-toolchain
+RUN rustup install $(cat rust-toolchain)
+
+FROM toolchain AS builder
+
+ARG ENABLE_FAILPOINTS
+COPY . /diem
+
+RUN IMAGE_TARGETS="test" ./docker/build-common.sh
+
+FROM debian:buster-20210511@sha256:acf7795dc91df17e10effee064bd229580a9c34213b4dba578d64768af5d8c51
+
+RUN apt-get update && apt-get install -y libssl1.1 openssh-client wget && apt-get clean && rm -r /var/lib/apt/lists/*
+RUN cd /usr/local/bin && wget "https://storage.googleapis.com/kubernetes-release/release/v1.17.0/bin/linux/amd64/kubectl" -O kubectl && chmod +x kubectl
+RUN mkdir /etc/forge
+WORKDIR /etc/forge
+COPY --from=builder /diem/target/release/forge /usr/local/bin/forge
+ENTRYPOINT ["forge"]
+ARG BUILD_DATE
+ARG GIT_REV
+ARG GIT_UPSTREAM
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.build-date=$BUILD_DATE
+LABEL org.label-schema.vcs-ref=$GIT_REV

--- a/docker/forge/build.sh
+++ b/docker/forge/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Copyright (c) The Diem Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+set -e
+
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+
+$DIR/../diem-build.sh $DIR/Dockerfile diem/forge:latest "$@"

--- a/docker/forge/buildspec.yaml
+++ b/docker/forge/buildspec.yaml
@@ -1,0 +1,21 @@
+# This buildspec is for AWS Codebuild
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      docker: 18
+  pre_build:
+    commands:
+      - echo Logging in to Amazon ECR...
+      - $(aws ecr get-login --no-include-email --region us-west-2)
+  build:
+    commands:
+      - echo Build started on `date`
+      - echo Building the Docker image...
+      - bash docker/forge/build.sh
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      # Tag and push the docker images
+      - SOURCE=diem/forge:latest TARGET_REPO=$DIEM_FORGE_REPO TARGET_TAGS="${TAGS}:dev_$(git rev-parse --short=8  HEAD)" docker/tag-and-push.sh


### PR DESCRIPTION
Add CodeBuild support for forge. As a temp solution to build forge image to unblock development which same as currently cluster test is using, it will be deprecated in near future by the same time with CT: https://github.com/diem/diem/issues/8444

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

./docker/build-aws.sh --build-forge --version pull/8439

## Related PRs

(If this PR adds or changes functionality, please take some time to update or suggest changes to the docs at https://developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
