### PR TITLE
[scratchpad] limit concurrency for the updater

### DIFF
--- a/storage/scratchpad/Cargo.toml
+++ b/storage/scratchpad/Cargo.toml
@@ -39,3 +39,8 @@ bench = ["bitvec", "proptest"]
 name = "sparse_merkle"
 harness = false
 required-features = ["bench"]
+
+[lib]
+# Allow Criterion benchmarks to take command line arguments
+# https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+bench = false

--- a/storage/scratchpad/benches/sparse_merkle.rs
+++ b/storage/scratchpad/benches/sparse_merkle.rs
@@ -252,7 +252,15 @@ impl Benches {
 }
 
 fn sparse_merkle_benches(c: &mut Criterion) {
-    Benches::gen(&[100, 1000, 10000]).run(c);
+    // Fix Rayon threadpool size to 8, which is realistic as in the current production setting
+    // and benchmarking result will be more stable across different machines.
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(8)
+        .thread_name(|index| format!("rayon-global-{}", index))
+        .build_global()
+        .expect("Failed to build rayon global thread pool.");
+
+    Benches::gen(&[2, 4, 8, 16, 32, 100, 1000, 10000]).run(c);
 }
 
 criterion_group!(benches, sparse_merkle_benches);


### PR DESCRIPTION
## Motivation
1. Don't split if depth is big -- limiting total tasks in parallel, also eliminate potential stack overflow in DEBUG mode due to how Rayon works.
1. Don't introduce Rayon overhead if work is small, makes `serial_update` (if call the updater, which it will in my follow up PR) as fast as no rayon is involved.

Performance improvement was observed.

```
insert to committed base/batch_update_by_updater/2
                        time:   [70.834 us 70.983 us 71.143 us]
                        thrpt:  [28.113 Kelem/s 28.176 Kelem/s 28.235 Kelem/s]
                 change:
                        time:   [-23.625% -22.946% -22.324%] (p = 0.00 < 0.05)
                        thrpt:  [+28.740% +29.779% +30.933%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe
insert to committed base/batch_update_by_updater/4
                        time:   [103.65 us 103.79 us 103.96 us]
                        thrpt:  [38.478 Kelem/s 38.538 Kelem/s 38.592 Kelem/s]
                 change:
                        time:   [-8.3787% -7.7923% -7.1521%] (p = 0.00 < 0.05)
                        thrpt:  [+7.7030% +8.4508% +9.1449%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
insert to committed base/batch_update_by_updater/8
                        time:   [142.73 us 143.08 us 143.47 us]
                        thrpt:  [55.760 Kelem/s 55.914 Kelem/s 56.048 Kelem/s]
                 change:
                        time:   [-1.5931% -1.1617% -0.7673%] (p = 0.00 < 0.05)
                        thrpt:  [+0.7732% +1.1754% +1.6189%]
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
insert to committed base/batch_update_by_updater/16
                        time:   [197.22 us 197.64 us 198.03 us]
                        thrpt:  [80.795 Kelem/s 80.957 Kelem/s 81.128 Kelem/s]
                 change:
                        time:   [-4.8270% -4.4163% -4.0153%] (p = 0.00 < 0.05)
                        thrpt:  [+4.1832% +4.6204% +5.0718%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
insert to committed base/batch_update_by_updater/32
                        time:   [334.51 us 335.08 us 335.67 us]
                        thrpt:  [95.332 Kelem/s 95.501 Kelem/s 95.664 Kelem/s]
                 change:
                        time:   [+3.6869% +4.0245% +4.3739%] (p = 0.00 < 0.05)
                        thrpt:  [-4.1906% -3.8688% -3.5558%]
                        Performance has regressed.
Found 13 outliers among 100 measurements (13.00%)
  1 (1.00%) low severe
  4 (4.00%) low mild
  5 (5.00%) high mild
  3 (3.00%) high severe
insert to committed base/batch_update_by_updater/100
                        time:   [715.89 us 716.73 us 717.62 us]
                        thrpt:  [139.35 Kelem/s 139.52 Kelem/s 139.69 Kelem/s]
                 change:
                        time:   [-3.6696% -3.3792% -3.0956%] (p = 0.00 < 0.05)
                        thrpt:  [+3.1945% +3.4974% +3.8094%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe
insert to committed base/batch_update_by_updater/1000
                        time:   [4.8992 ms 4.9045 ms 4.9100 ms]
                        thrpt:  [203.67 Kelem/s 203.89 Kelem/s 204.12 Kelem/s]
                 change:
                        time:   [-6.6152% -6.4565% -6.2835%] (p = 0.00 < 0.05)
                        thrpt:  [+6.7048% +6.9021% +7.0838%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
insert to committed base/batch_update_by_updater/10000
                        time:   [44.754 ms 44.852 ms 44.949 ms]
                        thrpt:  [222.47 Kelem/s 222.96 Kelem/s 223.44 Kelem/s]
                 change:
                        time:   [-4.6056% -4.2766% -3.9393%] (p = 0.00 < 0.05)
                        thrpt:  [+4.1008% +4.4676% +4.8279%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild

insert to uncommitted base/batch_update_by_updater/2
                        time:   [69.582 us 70.050 us 70.571 us]
                        thrpt:  [28.340 Kelem/s 28.551 Kelem/s 28.743 Kelem/s]
                 change:
                        time:   [-25.900% -25.592% -25.229%] (p = 0.00 < 0.05)
                        thrpt:  [+33.742% +34.395% +34.953%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe
insert to uncommitted base/batch_update_by_updater/4
                        time:   [93.830 us 94.037 us 94.233 us]
                        thrpt:  [42.448 Kelem/s 42.537 Kelem/s 42.630 Kelem/s]
                 change:
                        time:   [-14.439% -14.052% -13.645%] (p = 0.00 < 0.05)
                        thrpt:  [+15.801% +16.349% +16.875%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe
insert to uncommitted base/batch_update_by_updater/8
                        time:   [148.51 us 148.71 us 148.94 us]
                        thrpt:  [53.711 Kelem/s 53.795 Kelem/s 53.869 Kelem/s]
                 change:
                        time:   [+5.4972% +6.0204% +6.5593%] (p = 0.00 < 0.05)
                        thrpt:  [-6.1556% -5.6786% -5.2108%]
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high severe
insert to uncommitted base/batch_update_by_updater/16
                        time:   [206.29 us 206.72 us 207.20 us]
                        thrpt:  [77.219 Kelem/s 77.398 Kelem/s 77.561 Kelem/s]
                 change:
                        time:   [-1.6481% -1.3273% -1.0231%] (p = 0.00 < 0.05)
                        thrpt:  [+1.0337% +1.3452% +1.6758%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
insert to uncommitted base/batch_update_by_updater/32
                        time:   [332.97 us 333.51 us 334.08 us]
                        thrpt:  [95.785 Kelem/s 95.949 Kelem/s 96.105 Kelem/s]
                 change:
                        time:   [+2.0935% +2.4655% +2.8322%] (p = 0.00 < 0.05)
                        thrpt:  [-2.7542% -2.4061% -2.0506%]
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low severe
  7 (7.00%) high mild
insert to uncommitted base/batch_update_by_updater/100
                        time:   [732.79 us 734.22 us 735.84 us]
                        thrpt:  [135.90 Kelem/s 136.20 Kelem/s 136.46 Kelem/s]
                 change:
                        time:   [-4.9678% -4.6421% -4.3233%] (p = 0.00 < 0.05)
                        thrpt:  [+4.5186% +4.8681% +5.2275%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe
insert to uncommitted base/batch_update_by_updater/1000
                        time:   [4.9632 ms 4.9696 ms 4.9763 ms]
                        thrpt:  [200.95 Kelem/s 201.22 Kelem/s 201.48 Kelem/s]
                 change:
                        time:   [-7.1965% -7.0081% -6.8244%] (p = 0.00 < 0.05)
                        thrpt:  [+7.3242% +7.5362% +7.7545%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
insert to uncommitted base/batch_update_by_updater/10000
                        time:   [46.113 ms 46.248 ms 46.386 ms]
                        thrpt:  [215.58 Kelem/s 216.23 Kelem/s 216.86 Kelem/s]
                 change:
                        time:   [-7.9836% -7.4626% -6.9433%] (p = 0.00 < 0.05)
                        thrpt:  [+7.4613% +8.0644% +8.6763%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild

cargo bench --features bench -p scratchpad -- "updater" --load-baseline   mai  183.15s user 7.96s system 551% cpu 34.657 total

```
### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan
`cargo bench -p scratchpad --features bench`

## Related PRs


## If targeting a release branch, please fill the below out as well


