### PR TITLE
[writeset-generator] Fix a few minor issues for writeset generator tool

### DIFF
--- a/language/diem-tools/writeset-transaction-generator/src/release_flow/artifacts.rs
+++ b/language/diem-tools/writeset-transaction-generator/src/release_flow/artifacts.rs
@@ -57,7 +57,7 @@ impl ReleaseArtifacts {
         existing_artifacts.0.push(artifact);
         std::fs::write(
             artifact_path().as_path(),
-            serde_json::to_vec_pretty(&existing_artifacts)?.as_slice(),
+            format!("{}\n", serde_json::to_string_pretty(&existing_artifacts)?),
         )
         .map_err(|err| format_err!("Unable to write to path: {:?}", err))
     }

--- a/testsuite/smoke-test/src/release_flow.rs
+++ b/testsuite/smoke-test/src/release_flow.rs
@@ -37,9 +37,9 @@ fn test_move_release_flow() {
     let payload_1 =
         create_release(chain_id, url.clone(), 1, true, &release_modules, None, "").unwrap();
     // Verifying the generated payload against release modules should pass.
-    verify_release(chain_id, url.clone(), &payload_1, &release_modules).unwrap();
+    verify_release(chain_id, url.clone(), &payload_1, &release_modules, false).unwrap();
     // Verifying the generated payload against older modules should pass due to hash mismatch.
-    assert!(verify_release(chain_id, url.clone(), &payload_1, &old_modules).is_err());
+    assert!(verify_release(chain_id, url.clone(), &payload_1, &old_modules, false).is_err());
 
     // Commit the release
     client
@@ -82,10 +82,10 @@ fn test_move_release_flow() {
     )
     .unwrap();
     // Verifying the generated payload against release modules should pass.
-    verify_release(chain_id, url.clone(), &payload_2, &old_modules).unwrap();
+    verify_release(chain_id, url.clone(), &payload_2, &old_modules, false).unwrap();
     // Verifying the old payload would fail.
-    assert!(verify_release(chain_id, url.clone(), &payload_1, &old_modules).is_err());
-    assert!(verify_release(chain_id, url.clone(), &payload_1, &release_modules).is_err());
+    assert!(verify_release(chain_id, url.clone(), &payload_1, &old_modules, false).is_err());
+    assert!(verify_release(chain_id, url.clone(), &payload_1, &release_modules, false).is_err());
 
     // Cannot create a release with an older version.
     assert!(create_release(


### PR DESCRIPTION
…ier.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Fixes a number of minor issues in WriteSet generator tool:

1. Fix the deserialization for verification pass: The creation path emits a serialized `TransactionPayload` whereas the verification path emits a `WritesetPayload`
2. Automatically inserts a newline at the end of the artifact file so that linter won't complain.
3. Add a `use_latest_version` option for `verify-release` command to fetch the latest diem-framework modules instead of the diem framework modules at the version when the payload gets created. This will help verify the payload when the writeset is created a while ago and the state is already pruned by the database.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan

Manually created the writeset and verify that 1 and 2 are fixed. It is hard to test 3 tho cuz this option would only matter when the states are already pruned by the system..
