### PR TITLE
[language] add Move language documentation as an mdBook

### DIFF
--- a/language/documentation/book/src/SUMMARY.md
+++ b/language/documentation/book/src/SUMMARY.md
@@ -1,0 +1,41 @@
+# The Move Programming Language
+
+[Introduction](introduction.md)
+
+## Getting Started
+
+- [Modules and Scripts](modules-and-scripts.md)
+- [First Tutorial: Creating Coins](creating-coins.md)
+
+## Primitive Types
+
+- [Integers](integers.md)
+- [Bool](bool.md)
+- [Address](address.md)
+- [Vector](vector.md)
+- [Signer](signer.md)
+- [References](references.md)
+- [Tuples and Unit](tuples.md)
+
+## Basic Concepts
+
+- [Local Variables and Scopes](variables.md)
+- [Abort and Assert](abort-and-assert.md)
+- [Conditionals](conditionals.md)
+- [While and Loop](loops.md)
+- [Functions](functions.md)
+- [Structs and Resources](structs-and-resources.md)
+- [Constants](constants.md)
+- [Generics](generics.md)
+- [Equality](equality.md)
+- [Uses and Aliases](uses.md)
+
+## Global Storage
+
+- [Global Storage Structure](global-storage-structure.md)
+- [Global Storage Operators](global-storage-operators.md)
+
+## Reference
+
+- [Standard Library](standard-library.md)
+- [Coding Conventions](coding-conventions.md)

--- a/language/documentation/book/src/abort-and-assert.md
+++ b/language/documentation/book/src/abort-and-assert.md
@@ -1,0 +1,163 @@
+---
+id: move-abort-and-assert
+title: Abort and Assert
+sidebar_label: Abort and Assert
+---
+
+[`return`](./functions.md) and `abort` are two control flow constructs that end execution, one for the current function and one for the entire transaction.
+
+More information on [`return` can be found in the linked section](./functions.md)
+
+
+## `abort`
+
+`abort` is an expression that takes one argument: an **abort code** of type `u64`. For example:
+```rust
+abort 42
+```
+The `abort` expression halts execution the current function and reverts all changes made to global state by the current transaction. There is no mechanism for "catching" or otherwise handling an `abort`.
+
+Luckily, in Move transactions are all or nothing, meaning any changes to global storage are made all at once only if the transaction succeeds. Because of this transactional commitment of changes, after an abort there is no need to worry about backing out changes. While this approach is lacking in flexibility, it is incredibly simple and predictable.
+
+Similar to [`return`](./functions.md), `abort` is useful for exiting control flow when some condition cannot be met.
+
+In this example, the function will pop two items off of the vector, but will abort early if the vector does not have two items
+```rust=
+use 0x1::Vector;
+fun pop_twice<T>(v: &mut vector<T>): (T, T) {
+    if (Vector::length(v) < 2) abort 42;
+
+    (Vector::pop_back(v), Vector::pop_back(v))
+}
+```
+
+This is even more useful deep inside a control-flow construct. For example, this function checks that all numbers in the vector are less than the specified `bound`. And aborts otherwise
+```rust=
+use 0x1::Vector;
+fun check_vec(v: &vector<u64>, bound: u64) {
+    let i = 0;
+    let n = Vector::length(v);
+    while (i < n) {
+        let cur = *Vector::borrow(v, i);
+        if (cur > bound) abort 42;
+        i = i + 1;
+    }
+}
+```
+
+### `assert`
+
+`assert` is a builtin, macro-like operation provided by the Move compiler. It takes two arguments, a condition of type `bool` and a code of type `u64`
+```rust
+assert(condition: bool, code: u64)
+```
+The operation does not exist at the bytecode level, and is replaced inside the compiler with
+```rust
+if (condition) () else abort code
+```
+The `abort` examples above can be rewritten using `assert`
+
+```rust=
+use 0x1::Vector;
+fun pop_twice<T>(v: &mut vector<T>): (T, T) {
+    assert(Vector::length(v) >= 2, 42); // Now uses 'assert'
+
+    (Vector::pop_back(v), Vector::pop_back(v))
+}
+```
+and
+```rust=
+use 0x1::Vector;
+fun check_vec(v: &vector<u64>, bound: u64) {
+    let i = 0;
+    let n = Vector::length(v);
+    while (i < n) {
+        let cur = *Vector::borrow(v, i);
+        assert(cur <= bound, 42); // Now uses 'assert'
+        i = i + 1;
+    }
+}
+```
+
+### Abort codes in the Move VM
+
+When using `abort`, it is important to understand how the `u64` code will be used by the VM.
+
+Normally, after successful execution, the Move VM produces a change-set for the changes made to global storage (added/removed resources, updates to existing resources, etc).
+
+If an `abort` is reached, the VM will instead indicate an error. Included in that error will be two pieces of information
+- The module that produced the abort (address and name)
+- The abort code.
+
+For example
+```rust=
+address 0x2 {
+module Example {
+    public fun aborts() {
+        abort 42
+    }
+}
+}
+
+script {
+    fun always_aborts() {
+        0x2::Example::aborts()
+    }
+}
+```
+If a transaction, such as the script `always_aborts` above, calls `0x2::Example::aborts`, the VM would produce an error that indicated the module `0x2::Example` and the code `42`.
+
+This can be useful for having multiple aborts being grouped together inside a module.
+
+In this example, the module has two separate error codes used in multiple functions
+```rust=
+address 0x42 {
+module Example {
+
+    use 0x1::Vector;
+
+    const EMPTY_VECTOR: u64 = 0;
+    const INDEX_OUT_OF_BOUNDS: u64 = 1;
+
+    // move i to j, move j to k, move k to i
+    public fun rotate_three<T>(v: &mut vector<T>, i: u64, j: u64, k: u64) {
+        let n = Vector::length(v);
+        assert(n > 0, EMPTY_VECTOR);
+        assert(i < n, INDEX_OUT_OF_BOUNDS);
+        assert(j < n, INDEX_OUT_OF_BOUNDS);
+        assert(k < n, INDEX_OUT_OF_BOUNDS);
+
+        Vector::swap(v, i, k);
+        Vector::swap(v, j, k);
+    }
+
+    public fun remove_twice<T>(v: &mut vector<T>, i: u64, j: u64): (T, T) {
+        let n = Vector::length(v);
+        assert(n > 0, EMPTY_VECTOR);
+        assert(i < n, INDEX_OUT_OF_BOUNDS);
+        assert(j < n, INDEX_OUT_OF_BOUNDS);
+        assert(i > j, INDEX_OUT_OF_BOUNDS);
+
+        (Vector::remove<T>(v, i), Vector::remove<T>(v, j))
+    }
+}
+}
+```
+
+## The type of `abort`
+
+The `abort i` expression can have any type! This is because both constructs break from the normal control flow, so they never need to evaluate to the value of that type.
+
+The following are not useful, but they will type check
+```rust
+let y: address = abort 0;
+```
+
+This behavior can be helpful in situations where you have a branching instruction that produces a value on some branches, but not all. For example:
+```rust
+let b =
+    if (x == 0) false
+    else if (x == 1) true
+    else abort 42;
+//       ^^^^^^^^ `abort 42` has type `bool`
+```

--- a/language/documentation/book/src/abort-and-assert.md
+++ b/language/documentation/book/src/abort-and-assert.md
@@ -1,13 +1,8 @@
----
-id: move-abort-and-assert
-title: Abort and Assert
-sidebar_label: Abort and Assert
----
+# Abort and Assert
 
 [`return`](./functions.md) and `abort` are two control flow constructs that end execution, one for the current function and one for the entire transaction.
 
 More information on [`return` can be found in the linked section](./functions.md)
-
 
 ## `abort`
 
@@ -73,6 +68,7 @@ fun pop_twice<T>(v: &mut vector<T>): (T, T) {
     (Vector::pop_back(v), Vector::pop_back(v))
 }
 ```
+
 and
 
 ```rust=
@@ -94,7 +90,8 @@ When using `abort`, it is important to understand how the `u64` code will be use
 
 Normally, after successful execution, the Move VM produces a change-set for the changes made to global storage (added/removed resources, updates to existing resources, etc).
 
-If an `abort` is reached, the VM will instead indicate an error. Included in that error will be two pieces of information
+If an `abort` is reached, the VM will instead indicate an error. Included in that error will be two pieces of information:
+
 - The module that produced the abort (address and name)
 - The abort code.
 

--- a/language/documentation/book/src/abort-and-assert.md
+++ b/language/documentation/book/src/abort-and-assert.md
@@ -12,9 +12,11 @@ More information on [`return` can be found in the linked section](./functions.md
 ## `abort`
 
 `abort` is an expression that takes one argument: an **abort code** of type `u64`. For example:
+
 ```rust
 abort 42
 ```
+
 The `abort` expression halts execution the current function and reverts all changes made to global state by the current transaction. There is no mechanism for "catching" or otherwise handling an `abort`.
 
 Luckily, in Move transactions are all or nothing, meaning any changes to global storage are made all at once only if the transaction succeeds. Because of this transactional commitment of changes, after an abort there is no need to worry about backing out changes. While this approach is lacking in flexibility, it is incredibly simple and predictable.
@@ -22,6 +24,7 @@ Luckily, in Move transactions are all or nothing, meaning any changes to global 
 Similar to [`return`](./functions.md), `abort` is useful for exiting control flow when some condition cannot be met.
 
 In this example, the function will pop two items off of the vector, but will abort early if the vector does not have two items
+
 ```rust=
 use 0x1::Vector;
 fun pop_twice<T>(v: &mut vector<T>): (T, T) {
@@ -32,6 +35,7 @@ fun pop_twice<T>(v: &mut vector<T>): (T, T) {
 ```
 
 This is even more useful deep inside a control-flow construct. For example, this function checks that all numbers in the vector are less than the specified `bound`. And aborts otherwise
+
 ```rust=
 use 0x1::Vector;
 fun check_vec(v: &vector<u64>, bound: u64) {
@@ -48,13 +52,17 @@ fun check_vec(v: &vector<u64>, bound: u64) {
 ### `assert`
 
 `assert` is a builtin, macro-like operation provided by the Move compiler. It takes two arguments, a condition of type `bool` and a code of type `u64`
+
 ```rust
 assert(condition: bool, code: u64)
 ```
+
 The operation does not exist at the bytecode level, and is replaced inside the compiler with
+
 ```rust
 if (condition) () else abort code
 ```
+
 The `abort` examples above can be rewritten using `assert`
 
 ```rust=
@@ -66,6 +74,7 @@ fun pop_twice<T>(v: &mut vector<T>): (T, T) {
 }
 ```
 and
+
 ```rust=
 use 0x1::Vector;
 fun check_vec(v: &vector<u64>, bound: u64) {
@@ -90,6 +99,7 @@ If an `abort` is reached, the VM will instead indicate an error. Included in tha
 - The abort code.
 
 For example
+
 ```rust=
 address 0x2 {
 module Example {
@@ -105,11 +115,13 @@ script {
     }
 }
 ```
+
 If a transaction, such as the script `always_aborts` above, calls `0x2::Example::aborts`, the VM would produce an error that indicated the module `0x2::Example` and the code `42`.
 
 This can be useful for having multiple aborts being grouped together inside a module.
 
 In this example, the module has two separate error codes used in multiple functions
+
 ```rust=
 address 0x42 {
 module Example {
@@ -149,11 +161,13 @@ module Example {
 The `abort i` expression can have any type! This is because both constructs break from the normal control flow, so they never need to evaluate to the value of that type.
 
 The following are not useful, but they will type check
+
 ```rust
 let y: address = abort 0;
 ```
 
 This behavior can be helpful in situations where you have a branching instruction that produces a value on some branches, but not all. For example:
+
 ```rust
 let b =
     if (x == 0) false

--- a/language/documentation/book/src/address.md
+++ b/language/documentation/book/src/address.md
@@ -1,0 +1,36 @@
+---
+id: move-address
+title: Address
+sidebar_label: Address
+---
+
+`address` is a built-in type in Move that is used to represent locations (sometimes called accounts) in global storage. An `address` value is a 128-bit (16 byte) identifier. At a given address, two things can be stored: [Modules](./modules-and-scripts.md) and [Resources](./structs-and-resources.md).
+
+Although an `address` is a 128 bit integer under the hood, Move addresses are intentionally opaque---they cannot be created from integers, they do not support arithmetic operations, and they cannot be modified. Even though there might be interesting programs that would use such a feature (e.g., pointer arithmetic in C fills a similar niche), Move does not allow this dynamic behavior because it has been designed from the ground up to support static verification.
+
+You can use runtime address values (values of type `address`) to access resources at that address. You *cannot* access modules at runtime via address values.
+
+## Literals
+
+`address` literals are 16-byte hex literals, i.e. `0x<hex encoded value>`. For convenience, leading `0`s are added for literals that are too short.
+
+### Examples
+
+```rust
+let a1: address = 0x1; // shorthand for 0x00000000000000000000000000000001
+let a2: address = 0x42; // shorthand for 0x00000000000000000000000000000042
+let a3: address = 0xDEADBEEF; // // shorthand for 0x000000000000000000000000DEADBEEF
+let a4: address = 0x0000000000000000000000000000000A;
+```
+
+## Global Storage Operations
+
+The primary purpose of `address` values are to interact with the global storage operations.
+
+`address` values are used with the `exists`, `borrow_global`, `borrow_global_mut`, and `move_from` [operations](./global-storage-operators.md).
+
+The only global storage operation that *does not* use `address` is `move_to`, which uses [`signer`](./signer.md).
+
+## Ownership
+
+As with the other scalar values built-in to the language, `address` values are implicitly copyable, meaning they can be copied without an explicit instruction such as [`copy`](./equality.md).

--- a/language/documentation/book/src/address.md
+++ b/language/documentation/book/src/address.md
@@ -1,8 +1,4 @@
----
-id: move-address
-title: Address
-sidebar_label: Address
----
+# Address
 
 `address` is a built-in type in Move that is used to represent locations (sometimes called accounts) in global storage. An `address` value is a 128-bit (16 byte) identifier. At a given address, two things can be stored: [Modules](./modules-and-scripts.md) and [Resources](./structs-and-resources.md).
 

--- a/language/documentation/book/src/bool.md
+++ b/language/documentation/book/src/bool.md
@@ -1,0 +1,32 @@
+---
+id: move-bool
+title: Bool
+sidebar_label: Bool
+---
+
+`bool` is Move's primitive type for boolean `true` and `false` values.
+
+## Literals
+
+Literals for `bool` are either `true` or `false`.
+
+## Operations
+
+### Logical
+
+`bool` supports three logical operations:
+
+
+| Syntax   | Description | Equivalent Expression |
+| -------- | ----------- | --------------------- |
+| `&&` | short-circuiting logical and | `p && q` is equivalent to `if (p) q else false` |
+| <code>&#124;</code> | short-circuiting logical or |`p <code>&#124;</code> q` is equivalent to `if (p) true else q` |
+| `!`  | logical negation | `!p` is equivalent to `if (p) false else true` |
+
+### Control Flow
+
+`bool` values are used in several of Move's control-flow constructs:
+
+- [`if (bool) { ... } `](./conditionals.md)
+- [`while(bool) { .. }`](./loops.md)
+- [`assert(bool, u64)`](./abort-and-assert.md)

--- a/language/documentation/book/src/bool.md
+++ b/language/documentation/book/src/bool.md
@@ -1,8 +1,4 @@
----
-id: move-bool
-title: Bool
-sidebar_label: Bool
----
+# Bool
 
 `bool` is Move's primitive type for boolean `true` and `false` values.
 

--- a/language/documentation/book/src/coding-conventions.md
+++ b/language/documentation/book/src/coding-conventions.md
@@ -1,0 +1,78 @@
+---
+id: move-coding-conventions
+title: Move Coding Conventions
+sidebar_label: Coding Conventions
+---
+
+This section lays out some basic coding conventions for Move that the Move team has found helpful. These are only recommendations, and you should feel free to use other formatting guidelines and conventions if you have a preference for them.
+
+## Naming
+- **Module names**: should be camel case, e.g., `FixedPoint32`, `Vector`
+- **Type names**: should be camel case if they are not a native type, e.g., `Coin`, `RoleId`
+- **Function names**: should be lower snake case, e.g., `destroy_empty`
+- **Constant names**: should be upper snake case, e.g., `REQUIRES_CAPABILITY`
+- Generic types should be descriptive, or anti-descriptive where appropriate, e.g., `T` or `Element` for the Vector generic type parameter. Most of the time the "main" type in a module should be the same name as the module e.g., `Option::Option`, `FixedPoint32::FixedPoint32`.
+- **Module file names**: should be the same as the module name e.g., `Option.move`
+- **Script file names**: should be lower snake case and should match the name of the “main” function in the script.
+- **Mixed file names**: If the file contains multiple modules and/or scripts, the file name should be lower_snake_case, where the name does not match any particular module/script inside.
+
+## Imports
+- All module `use` statements should be at the top of the module.
+- Functions should be imported and used fully qualified from the module in which they are declared, and not imported at the top level.
+- Types should be imported at the top-level. Where there are name clashes, `as` should be used to rename the type locally as appropriate.
+
+For example, if there is a module
+```rust=
+module Foo {
+    resource struct Foo { }
+    const CONST_FOO: u64 = 0;
+    public fun do_foo(): Foo { Foo{} }
+    ...
+}
+```
+
+this would be imported and used as:
+
+```rust=
+module Bar {
+    use 0x1::Foo::{Self, Foo};
+
+    public fun do_bar(x: u64): Foo {
+        if (x == 10) {
+            Foo::do_foo()
+        } else {
+            abort 0
+        }
+    }
+    ...
+}
+```
+
+And, if there is a local name-clash when importing two modules:
+
+```rust=
+module OtherFoo {
+    resource struct Foo {}
+    ...
+}
+
+module Importer {
+    use 0x1::OtherFoo::Foo as OtherFoo;
+    use 0x1::Foo::Foo;
+....
+}
+```
+
+
+## Comments
+
+- Each module, struct, resource, and public function declaration should be commented
+- Move has both doc comments `///`, regular single-line comments `//`, and block comments `/* */`
+
+
+## Formatting
+The Move team plans to write an autoformatter to enforce formatting conventions. However, in the meantime:
+
+- Four space indentation should be used except for `script` and `address` blocks whose contents should not be indented
+- Lines should be broken if they are longer than 100 characters
+- Resources, structs, and constants should be declared before all functions in a module

--- a/language/documentation/book/src/coding-conventions.md
+++ b/language/documentation/book/src/coding-conventions.md
@@ -1,12 +1,9 @@
----
-id: move-coding-conventions
-title: Move Coding Conventions
-sidebar_label: Coding Conventions
----
+# Move Coding Conventions
 
 This section lays out some basic coding conventions for Move that the Move team has found helpful. These are only recommendations, and you should feel free to use other formatting guidelines and conventions if you have a preference for them.
 
 ## Naming
+
 - **Module names**: should be camel case, e.g., `FixedPoint32`, `Vector`
 - **Type names**: should be camel case if they are not a native type, e.g., `Coin`, `RoleId`
 - **Function names**: should be lower snake case, e.g., `destroy_empty`
@@ -17,6 +14,7 @@ This section lays out some basic coding conventions for Move that the Move team 
 - **Mixed file names**: If the file contains multiple modules and/or scripts, the file name should be lower_snake_case, where the name does not match any particular module/script inside.
 
 ## Imports
+
 - All module `use` statements should be at the top of the module.
 - Functions should be imported and used fully qualified from the module in which they are declared, and not imported at the top level.
 - Types should be imported at the top-level. Where there are name clashes, `as` should be used to rename the type locally as appropriate.
@@ -69,8 +67,8 @@ module Importer {
 - Each module, struct, resource, and public function declaration should be commented
 - Move has both doc comments `///`, regular single-line comments `//`, and block comments `/* */`
 
-
 ## Formatting
+
 The Move team plans to write an autoformatter to enforce formatting conventions. However, in the meantime:
 
 - Four space indentation should be used except for `script` and `address` blocks whose contents should not be indented

--- a/language/documentation/book/src/coding-conventions.md
+++ b/language/documentation/book/src/coding-conventions.md
@@ -22,6 +22,7 @@ This section lays out some basic coding conventions for Move that the Move team 
 - Types should be imported at the top-level. Where there are name clashes, `as` should be used to rename the type locally as appropriate.
 
 For example, if there is a module
+
 ```rust=
 module Foo {
     resource struct Foo { }
@@ -62,7 +63,6 @@ module Importer {
 ....
 }
 ```
-
 
 ## Comments
 

--- a/language/documentation/book/src/conditionals.md
+++ b/language/documentation/book/src/conditionals.md
@@ -1,0 +1,65 @@
+---
+id: move-conditionals
+title: Conditionals
+sidebar_label: Conditionals
+---
+
+An `if` expression specifies that some code should only be evaluated if a certain condition is true. For example:
+
+```rust
+if (x > 5) x = x - 5
+```
+
+The condition must be an expression of type `bool`.
+
+An `if` expression can optionally include an `else` clause to specify another expression to evaluate when the condition is false.
+
+```rust
+if (y <= 10) y = y + 1 else y = 10
+```
+
+Either the "true" branch or the "false" branch will be evaluated, but not both. Either branch can be a single expression or an expression block.
+
+The conditional expressions may produce values so that the `if` expression has a result.
+
+```rust
+let z = if (x < 100) x else 100;
+```
+
+The expressions in the true and false branches must have compatible types. For example:
+
+```rust=
+// x and y must be u64 integers
+let maximum: u64 = if (x > y) x else y;
+
+// ERROR! branches different types
+let z = if (maximum < 10) 10u8 else 100u64;
+
+// ERROR! branches different types, as default false-branch is () not u64
+if (maximum >= 10) maximum;
+```
+
+If the `else` clause is not specified, the false branch defaults to the unit value. The following are equivalent:
+
+```rust
+if (condition) true_branch // implied default: else ()
+if (condition) true_branch else ()
+```
+
+
+Commonly, [`if` expressions](./conditionals.md) are used in conjunction with expression blocks.
+```rust
+let maximum = if (x > y) x else y;
+if (maximum < 10) {
+    x = x + 10;
+    y = y + 10;
+} else if (x >= 10 && y >= 10) {
+    x = x - 10;
+    y = y - 10;
+}
+```
+
+## Grammar for Conditionals
+
+> *if-expression* → **(** *expression* **)** *expression* *else-clause*<sub>*opt*</sub>
+> *else-clause* → **else** *expression*

--- a/language/documentation/book/src/conditionals.md
+++ b/language/documentation/book/src/conditionals.md
@@ -48,6 +48,7 @@ if (condition) true_branch else ()
 
 
 Commonly, [`if` expressions](./conditionals.md) are used in conjunction with expression blocks.
+
 ```rust
 let maximum = if (x > y) x else y;
 if (maximum < 10) {

--- a/language/documentation/book/src/conditionals.md
+++ b/language/documentation/book/src/conditionals.md
@@ -1,8 +1,4 @@
----
-id: move-conditionals
-title: Conditionals
-sidebar_label: Conditionals
----
+# Conditionals
 
 An `if` expression specifies that some code should only be evaluated if a certain condition is true. For example:
 
@@ -45,7 +41,6 @@ If the `else` clause is not specified, the false branch defaults to the unit val
 if (condition) true_branch // implied default: else ()
 if (condition) true_branch else ()
 ```
-
 
 Commonly, [`if` expressions](./conditionals.md) are used in conjunction with expression blocks.
 

--- a/language/documentation/book/src/constants.md
+++ b/language/documentation/book/src/constants.md
@@ -1,0 +1,97 @@
+---
+id: move-constants
+title: Constants
+sidebar_label: Constants
+---
+
+Constants are a way of giving a name to shared, static values inside of a `module` or `script`.
+
+The constant's must be known at compilation. The constant's value is stored in the compiled module or script. And each time the constant is used, a new copy of that value is made.
+
+## Declaration
+
+Constant declarations begin with the `const` keyword, followed by a name, a type, and a value. They can exist in either a script or module
+```
+const <name>: <type> = <expression>;
+```
+For example
+```rust=
+script {
+
+    const MY_ERROR_CODE: u64 = 0;
+
+    fun main(input: u64) {
+        assert(input > 0, MY_ERROR_CODE);
+    }
+
+}
+
+address 0x42 {
+module Example {
+
+    const MY_ADDRESS: address = 0x42;
+
+    public fun permissioned(s: &signer) {
+        assert(0x1::Signer::address_of(s) == MY_ADDRESS, 0);
+    }
+
+}
+}
+```
+
+## Naming
+
+Constants must start with a capital letter `A` to `Z`. After the first letter, constant names can contain underscores `_`, letters `a` to `z`, letters `A` to `Z`, or digits `0` to `9`.
+```rust
+const FLAG: bool = false;
+const MY_ERROR_CODE: u64 = 0;
+const ADDRESS_42: address = 0x42;
+```
+Even though you can use letters `a` to `z` in a constant. The  [general style guidelines](/GSiO5fHXTlK7E8kBZf50IQ) are to use just uppercase letters `A` to `Z`, with underscores `_` between each word.
+
+
+This naming restriction of starting with `A` to `Z` is in place to give room for future language features. It may or may not be removed later.
+
+
+## Visibility
+
+`public` constants are not currently supported. `const` values can be used only in the declaring module.
+
+
+## Valid Expressions
+
+Currently, constants are limited to the primitive types `bool`, `u8`, `u64`, `u128`, `address`, and `vector<u8>`. Future support for other `vector` values (besides the "string"-style literals) will come later.
+
+### Values
+
+Commonly, `const`s are assigned a simple value, or literal, of their type.
+For example
+```rust
+const MY_BOOL: bool = false;
+const MY_ADDRESS: address = 0x70DD;
+const BYTES: vector<u8> = b"hello world";
+const HEX_BYTES: vector<u8> = x"DEADBEEF";
+```
+
+### Complex Expressions
+
+In addition to literals, constants can include more complex expressions, as long as the compiler is able to reduce the expression to a value at compile time.
+
+Currently, equality operations, all boolean operations, all bitwise operations, and all arithmetic operations can be used.
+```rust
+const RULE: bool = true && false;
+const CAP: u64 = 10 * 100 + 1;
+const SHIFTY: u8 = {
+  (1 << 1) * (1 << 2) * (1 << 3) * (1 << 4)
+};
+const HALF_MAX: u128 = 340282366920938463463374607431768211455 / 2;
+const EQUAL: bool = 1 == 1;
+```
+If the operation would result in a runtime exception, the compiler will give an error that it is unable to generate the constant's value
+```rust
+const DIV_BY_ZERO: u64 = 1 / 0; // error!
+const SHIFT_BY_A_LOT: u64 = 1 << 100; // error!
+const NEGATIVE_U64: u64 = 0 - 1; // error!
+```
+
+Note that constants cannot currently refer to other constants. This feature, along with support for other expressions, will be added in the future.

--- a/language/documentation/book/src/constants.md
+++ b/language/documentation/book/src/constants.md
@@ -47,7 +47,7 @@ const FLAG: bool = false;
 const MY_ERROR_CODE: u64 = 0;
 const ADDRESS_42: address = 0x42;
 ```
-Even though you can use letters `a` to `z` in a constant. The  [general style guidelines](/GSiO5fHXTlK7E8kBZf50IQ) are to use just uppercase letters `A` to `Z`, with underscores `_` between each word.
+Even though you can use letters `a` to `z` in a constant. The  [general style guidelines](./coding-conventions.md) are to use just uppercase letters `A` to `Z`, with underscores `_` between each word.
 
 
 This naming restriction of starting with `A` to `Z` is in place to give room for future language features. It may or may not be removed later.

--- a/language/documentation/book/src/constants.md
+++ b/language/documentation/book/src/constants.md
@@ -1,8 +1,4 @@
----
-id: move-constants
-title: Constants
-sidebar_label: Constants
----
+# Constants
 
 Constants are a way of giving a name to shared, static values inside of a `module` or `script`.
 
@@ -54,14 +50,11 @@ const ADDRESS_42: address = 0x42;
 
 Even though you can use letters `a` to `z` in a constant. The  [general style guidelines](./coding-conventions.md) are to use just uppercase letters `A` to `Z`, with underscores `_` between each word.
 
-
 This naming restriction of starting with `A` to `Z` is in place to give room for future language features. It may or may not be removed later.
-
 
 ## Visibility
 
 `public` constants are not currently supported. `const` values can be used only in the declaring module.
-
 
 ## Valid Expressions
 

--- a/language/documentation/book/src/constants.md
+++ b/language/documentation/book/src/constants.md
@@ -11,10 +11,13 @@ The constant's must be known at compilation. The constant's value is stored in t
 ## Declaration
 
 Constant declarations begin with the `const` keyword, followed by a name, a type, and a value. They can exist in either a script or module
+
 ```
 const <name>: <type> = <expression>;
 ```
+
 For example
+
 ```rust=
 script {
 
@@ -42,11 +45,13 @@ module Example {
 ## Naming
 
 Constants must start with a capital letter `A` to `Z`. After the first letter, constant names can contain underscores `_`, letters `a` to `z`, letters `A` to `Z`, or digits `0` to `9`.
+
 ```rust
 const FLAG: bool = false;
 const MY_ERROR_CODE: u64 = 0;
 const ADDRESS_42: address = 0x42;
 ```
+
 Even though you can use letters `a` to `z` in a constant. The  [general style guidelines](./coding-conventions.md) are to use just uppercase letters `A` to `Z`, with underscores `_` between each word.
 
 
@@ -66,6 +71,7 @@ Currently, constants are limited to the primitive types `bool`, `u8`, `u64`, `u1
 
 Commonly, `const`s are assigned a simple value, or literal, of their type.
 For example
+
 ```rust
 const MY_BOOL: bool = false;
 const MY_ADDRESS: address = 0x70DD;
@@ -78,6 +84,7 @@ const HEX_BYTES: vector<u8> = x"DEADBEEF";
 In addition to literals, constants can include more complex expressions, as long as the compiler is able to reduce the expression to a value at compile time.
 
 Currently, equality operations, all boolean operations, all bitwise operations, and all arithmetic operations can be used.
+
 ```rust
 const RULE: bool = true && false;
 const CAP: u64 = 10 * 100 + 1;
@@ -87,7 +94,9 @@ const SHIFTY: u8 = {
 const HALF_MAX: u128 = 340282366920938463463374607431768211455 / 2;
 const EQUAL: bool = 1 == 1;
 ```
+
 If the operation would result in a runtime exception, the compiler will give an error that it is unable to generate the constant's value
+
 ```rust
 const DIV_BY_ZERO: u64 = 1 / 0; // error!
 const SHIFT_BY_A_LOT: u64 = 1 << 100; // error!

--- a/language/documentation/book/src/creating-coins.md
+++ b/language/documentation/book/src/creating-coins.md
@@ -1,8 +1,4 @@
----
-id: move-tutorial-creating-coins
-title: Tutorial - Creating Coins
-sidebar_label: Creating Coins
----
+# Tutorial - Creating Coins
 
 Move is a language about resources. Resources are special types of values that cannot be copied or forgotten about; they must always be moved from one place to another.
 
@@ -127,7 +123,6 @@ We'll have to add a constructor to our module to do this.
 
 Let's create a function in `Coin.move` to create coins. We'll call our function `mint`.
 
-
 ```=
 address 0x2 {
     module Coin {
@@ -151,7 +146,6 @@ Our function takes a `u64` value and returns the constructed `Coin`.
 Remember to always re-publish your module after making changes, otherwise our script won't be able to catch those changes.
 
 With this change, we should be able to update our script `test-coin.move` to call our new constructor:
-
 
 ```=
 script {
@@ -183,7 +177,6 @@ Move is designed around the concept of resources. Resources behave like money or
 
 We can convert our `Coin` into a resource just by adding the `resource` keyword to our type definition in `Coin.move`:
 
-
 ```=
         resource struct Coin {
             value: u64,
@@ -213,13 +206,12 @@ error:
     │
  ```
 
- Now we have a different error! The Move compiler is telling us that it is invalid to ignore a resource value. If ignored, the value would just disappear, but since it is a resource type, we must do something with it. We must move it somewhere.
+Now we have a different error! The Move compiler is telling us that it is invalid to ignore a resource value. If ignored, the value would just disappear, but since it is a resource type, we must do something with it. We must move it somewhere.
 
- Let's create a a `burn` function that will destroy coins as well as a function to retrieve the value of a coin. Add the following functions to `Coin.move`:
+Let's create a a `burn` function that will destroy coins as well as a function to retrieve the value of a coin. Add the following functions to `Coin.move`:
 
-
- ```=
-         public fun value(coin: &Coin): u64 {
+```=
+        public fun value(coin: &Coin): u64 {
             coin.value
         }
 
@@ -227,7 +219,6 @@ error:
             let Coin { value: value } = coin;
             value
         }
-
 ```
 
 These are both declared public so they can be used by scripts and other modules.
@@ -242,7 +233,6 @@ Now we can write a slightly more complicated script that tests our `Coin` module
 
 ```=
 script {
-
     use 0x1::Debug;
     use 0x2::Coin;
 
@@ -253,7 +243,6 @@ script {
 
         Coin::burn(coin);
     }
-
 }
 ```
 
@@ -268,8 +257,7 @@ The only new thing in our script is the use of the standard library function `De
 
 Note that we pass references using `&` to `Debug::print` and `Coin::value`. Also, since we move `coin` into the `burn` function, it no longer exists in our script's scope and because our script compiles we can be sure that we didn't accidentally lose some money. The only way to get rid of a coin we create is to move it somewhere else.
 
-
-# Wrap Up
+## Wrap Up
 
 In this tutorial, we learned how to get the Move CLI and how to use it to publish and run Move code.
 

--- a/language/documentation/book/src/creating-coins.md
+++ b/language/documentation/book/src/creating-coins.md
@@ -1,0 +1,280 @@
+---
+id: move-tutorial-creating-coins
+title: Tutorial - Creating Coins
+sidebar_label: Creating Coins
+---
+
+Move is a language about resources. Resources are special types of values that cannot be copied or forgotten about; they must always be moved from one place to another.
+
+Resources are a valuable tool for representing things that should be scarce like assets. For a cryptocurrency, the value of a coin that can be copied is nothing, and you'd like to know that smart contracts you write don't accidentally lose resources. Move makes resources a first class primitive in the language, and enforces many invariants useful for scarce values.
+
+In this first tutorial, we'll implement a simple coin and show off some of the ways that Move helps write correct code when creating, manipulating, and destroying coins.
+
+Let's get started!
+
+## Modules and Scripts
+
+Move code can exist in two forms, as modules or as transaction scripts.
+
+Move modules contain type definitions and code and expose these through a set of public functions that operate on those types. Modules are published at specific address, and that address is part of the fully qualified module name. Most Move code you will write will be in the form of modules.
+
+Transaction scripts are functions that can take any number of arguments and return nothing. These can call any published module's public functions attempt to achieve a specific change in the global state. Scripts only change global state if they are successful; if they abort any changes they have previously made will be discarded.
+
+To make this concrete, we're going to create a module `0x2::Coin` which defines a simple digital coin and some public functions for managing coins. After publishing this module, we'll use transaction scripts to interact with it.
+
+## Move CLI and Project Structure
+
+Before we jump into the code, let's install the Move CLI and talk briefly about project structure.
+
+To install the Move CLI just use `cargo install`. If you don't already have a Rust toolchain installed, you should install [Rustup](https://rustup.rs/) which will install the latest stable toolchain.
+
+```shell
+$ cargo install --git https://github.com/diem/diem move-cli
+```
+
+This will install the `move` binary in your Cargo binary directory. On macOS and Linux this is usually `~/.cargo/bin`. You'll want to make sure this location is in your `PATH` environment variable.
+
+Now you should be able to run the Move CLI:
+
+```shell
+$ move
+Move 0.1.0
+CLI frontend for Move compiler and VM
+
+USAGE:
+    move [FLAGS] [OPTIONS] <SUBCOMMAND>
+  ...
+```
+
+Let's create a directory for our new Move project:
+
+```shell
+$ mkdir toycoin
+$ cd toycoin
+$ mkdir -p src/modules
+$ mkdir -p src/scripts
+```
+
+We've created a directory called `toycoin` which has a subdirectory `src` for the modules we'll create as well as the transaction scripts. Now we can write some code!
+
+## Creating Our Coin
+
+We'll call our module `Coin`, and we'll publish it at address `0x2`. By convention, the Move standard library is published at address `0x1`, and for simplicity we'll use `0x2` for our tutorial code. Any address will work, as long as the address the modules are published to and the address the modules are accessed from is the same.
+
+In our module we'll define a new type `Coin`, which will be a structure with a single field `value`, containing the number of coins. The type of the `value` field is `u64`, which is, as you might have guessed, an unsigned 64-bit integer.
+
+Our module `Coin`, and our type `Coin` both share the same name, and this is another convention used by Move programmers to name the main type in a module the same as the module itself. This doesn't cause a problem as in the Move language as the context of where `Coin` appears will always make the name unambiguous.
+
+Here's a first draft of our `Coin` module, which we'll define in `src/modules/Coin.move`:
+
+```=
+address 0x2 {
+    module Coin {
+
+        struct Coin {
+            value: u64,
+        }
+
+    }
+}
+```
+
+In order to publish our module, we use the Move CLI:
+
+```shell
+$ move publish src/modules
+```
+
+To test our `Coin` module we'll createa small script that creates a value of our `Coin` type. The following code should go into `src/scripts/test-coin.move`:
+
+```=
+script {
+
+    use 0x2::Coin::Coin;
+
+    fun main() {
+        let _coin = Coin { value: 100 };
+    }
+
+}
+```
+
+First, on line 3, we must import the type. Note that the full location and name of the type includes the address and the module. After this `use` statement, we may refer to the type by its short name `Coin`.
+
+Scripts contain a single function definition that has no return value. The function can take any number of arguments and type arguments, but for our purposes we don't need any arguments at all.
+
+On line 6, we use `let` to bind the variable `_coin` to a constructed value of 100 coin. Note that we prefix the variable name with an underscore to signal to the compiler that we don't intend to use this variable. In a real program, we'd remove the underscore and the variable would get used later in the program.
+
+Let's run our scripts `test-coin.move` with the Move CLI:
+
+```shell
+$ move run src/scripts/test-coin.move
+error:
+
+   ┌── scripts/test-coin.move:6:20 ───
+   │
+ 6 │         let coin = Coin::Coin { value: 100 };
+   │                    ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid instantiation of '0x1::Coin::Coin'.
+All structs can only be constructed in the module in which they are declared
+   │
+```
+
+Uh oh! Something went wrong! The error message tells us that we can't construct values of this type in scripts. Only the module itself may construct a `Coin`.
+
+We'll have to add a constructor to our module to do this.
+
+### Minting
+
+Let's create a function in `Coin.move` to create coins. We'll call our function `mint`.
+
+
+```=
+address 0x2 {
+    module Coin {
+
+        struct Coin {
+            value: u64,
+        }
+
+        public fun mint(value: u64): Coin {
+            Coin { value }
+        }
+
+    }
+}
+```
+
+We declare the function public to indicate that other modules and scripts are allowed to call it. Functions that are not public can only be called from within the same module.
+
+Our function takes a `u64` value and returns the constructed `Coin`.
+
+Remember to always re-publish your module after making changes, otherwise our script won't be able to catch those changes.
+
+With this change, we should be able to update our script `test-coin.move` to call our new constructor:
+
+
+```=
+script {
+
+    use 0x2::Coin;
+
+    fun main() {
+        let _coin = Coin::mint(100);
+    }
+
+}
+```
+
+Let's run our script:
+
+```shell
+$ move run src/scripts/test-coin.move
+```
+
+The script didn't fail this time. There's no output since we didn't generate any. However, there is another problem you may have noticed.
+
+### Disappearing Coins
+
+After we minted a coin, where did it go?
+
+The answer is that it just disappeared into the ether. The local variable that held the coin went out of scope at the end of our script, and the coin ceased to exist. If coin had real value, this would be very bad, as it means if you weren't very careful about making sure you used the coin somehow, it might disappear and the value it represented would be lost forever.
+
+Move is designed around the concept of resources. Resources behave like money or an asset in that they can only be moved around, never copied. In addition, while we've seen that Move already restricts the construction of types, resources must have controlled destruction as well. Only the module that defines a resource type is able to destroy that type.
+
+We can convert our `Coin` into a resource just by adding the `resource` keyword to our type definition in `Coin.move`:
+
+
+```=
+        resource struct Coin {
+            value: u64,
+        }
+```
+
+Let's publish our `Coin` module again and re-run our script:
+
+```shell
+$ move publish src/modules
+$ move run src/scripts/test-coin.move
+error:
+
+   ┌── scripts/test-coin.move:6:13 ───
+   │
+ 6 │         let _coin = Coin::mint(100);
+   │             ^^^^^ Cannot ignore resource values. The value must be used
+   │
+
+    ┌── move_build_output/mv_interfaces/00000000000000000000000000000001/Coin.move:6:5 ───
+    │
+ 11 │     native public fun mint(a0: u64): Coin::Coin;
+    │                                      ---------- The type: '0x1::Coin::Coin'
+    ·
+  6 │     resource struct Coin {
+    │     -------- Is found to be a non-copyable type here
+    │
+ ```
+
+ Now we have a different error! The Move compiler is telling us that it is invalid to ignore a resource value. If ignored, the value would just disappear, but since it is a resource type, we must do something with it. We must move it somewhere.
+
+ Let's create a a `burn` function that will destroy coins as well as a function to retrieve the value of a coin. Add the following functions to `Coin.move`:
+
+
+ ```=
+         public fun value(coin: &Coin): u64 {
+            coin.value
+        }
+
+        public fun burn(coin: Coin): u64 {
+            let Coin { value: value } = coin;
+            value
+        }
+
+```
+
+These are both declared public so they can be used by scripts and other modules.
+
+Notice that `value` takes a reference to a `Coin`. This is a read-only value, but more critically, when passing a reference to a function the value is not moved. Compare this to `burn` which takes an actual `Coin` value. Calling this function with a coin will move the coin into the function and out of the caller's scope.
+
+The `value` function simply returns the internal `u64` value. Scripts and other modules can't directly access the interior fields of a module's types, so we need public accessor functions if that data should be available outside the module.
+
+The `burn` function uses pattern matching to unpack the `Coin` into just its internal value. This essentially destroys the resource and returns a normal `u64` value. We return the value of the coin to let the caller know how much money just disappeared. (see [Structs and Resources](./structs-and-resources.md#destroying-structs-via-pattern-matching))
+
+Now we can write a slightly more complicated script that tests our `Coin` module. We'll mint a coin, display its value, and then burn it. Add this code to `src/scripts/test-burn.move`:
+
+```=
+script {
+
+    use 0x1::Debug;
+    use 0x2::Coin;
+
+    fun main() {
+        let coin = Coin::mint(100);
+
+        Debug::print(&Coin::value(&coin));
+
+        Coin::burn(coin);
+    }
+
+}
+```
+
+Give it a try with `move run`:
+
+```shell
+$ move run src/scripts/test-burn.move
+[debug] 100
+```
+
+The only new thing in our script is the use of the standard library function `Debug::print` which takes a reference to a type and prints a human readable string respresentation of it.
+
+Note that we pass references using `&` to `Debug::print` and `Coin::value`. Also, since we move `coin` into the `burn` function, it no longer exists in our script's scope and because our script compiles we can be sure that we didn't accidentally lose some money. The only way to get rid of a coin we create is to move it somewhere else.
+
+
+# Wrap Up
+
+In this tutorial, we learned how to get the Move CLI and how to use it to publish and run Move code.
+
+Move code is made of up modules, which are published at specific addresses in global storage, and transaction scripts which can call public module functions and cause changes to global storage. These scripts either complete successfully or abort making no changes to global storage.
+
+As we created our first coin, we learned the difference between normal types and resource types, and how the Move compiler and virtual machine enforce invariants about which code can construct types, access fields, and whether values can be copied and destroyed.
+
+In the next tutorial, we'll build on our coin to implement accounts with balances.

--- a/language/documentation/book/src/equality.md
+++ b/language/documentation/book/src/equality.md
@@ -1,0 +1,140 @@
+---
+id: move-equality
+title: Equality
+sidebar_label: Equality
+---
+
+Move supports two equality operations `==` and `!=`
+
+## Operations
+
+| Syntax   | Operation | Description
+| -------- | ----------|------------
+| `==`     | equal     | Returns `true` if the two operands have the same value, `false` otherwise
+| `!=`     | not equal | Returns `true` if the two operands have different values, `false` otherwise
+
+### Typing
+Both the equal (`==`) and not-equal (`!=`) operations only work if both operands are the same type
+```rust
+0 == 0; // `true`
+1u128 == 2u128; // `false`
+b"hello" != x"00"; // `true`
+```
+Equality and non-equality also work over user defined types!
+```rust=
+address 0x42 {
+module Example {
+    struct S { f: u64, s: vector<u8> }
+
+    fun always_true(): bool {
+        let s = S { f: 0, s: b"" };
+        // parens are not needed but added for clarity in this example
+        (copy s) == s
+    }
+
+    fun always_false(): bool {
+        let s = S { f: 0, s: b"" };
+        // parens are not needed but added for clarity in this example
+        (copy s) != s
+    }
+}
+}
+```
+
+If the operands have different types, there is a type checking error
+```rust
+1u8 == 1u128; // ERROR!
+//     ^^^^^ expected an argument of type 'u8'
+b"" != 0; // ERROR!
+//     ^ expected an argument of type 'vector<u8>'
+```
+### Typing with references
+When comparing [references](./references.md), the type of the reference does not matter. This means that you can compare an immutable `&` reference with a mutable one `&mut` of the same type.
+```rust
+let i = &0;
+let m = &mut 1;
+
+i == m; // `false`
+m == i; // `false`
+m == m; // `true`
+i == i; // `true`
+```
+The above is equivalent to applying an explicit freeze to each mutable reference where needed
+```rust
+let i = &0;
+let m = &mut 1;
+
+i == freeze(m); // `false`
+freeze(m) == i; // `false`
+m == m; // `true`
+i == i; // `true`
+```
+But similar to non-reference types, the underlying type must be the same type
+```rust
+let i = &0;
+let s = &b"";
+
+i == s; // ERROR!
+//   ^ expected an argument of type '&u64'
+```
+
+## Restrictions
+
+Both `==` and `!=` consume the value when comparing them. As a result, the type system enforces that the type must be `copyable`, that is that it is not a `resource` value. Recall that resources cannot be copied, ownership must be transferred by the end of the function, and they can only be explicitly destroyed within their declaring module. If resources were used directly with either equality `==` or non-equality `!=`, the value would be destroyed which would break resource safety!
+```rust=
+address 0x42 {
+module Example {
+    resource struct Coin { value: u64 }
+    fun invalid(c1: Coin, c2: Coin) {
+        c1 == c2 // ERROR!
+//      ^^    ^^ These resources would be destroyed!
+    }
+}
+}
+```
+
+But, a programmer can *always* borrow the value first--to make it a `copyable` type--instead of directly comparing the resource. For example
+```rust=
+address 0x42 {
+module Example {
+    resource struct Coin { value: u64 }
+    fun swap_if_equal(c1: Coin, c2: Coin): (Coin, Coin) {
+        let are_equal = &c1 == &c2; // valid
+        if (are_equal) (c2, c1) else (c1, c2)
+    }
+}
+}
+```
+## Avoid Extra Copies
+
+While a programmer *can* compare any `copyable` value, a programmer should often compare by reference to avoid expensive copies.
+```rust=
+let v1: vector<u8> = function_that_returns_vector();
+let v2: vector<u8> = function_that_returns_vector();
+assert(copy v1 == copy v2, 42);
+//     ^^^^       ^^^^
+use_two_vectors(v1, v2);
+
+let s1: Foo = function_that_returns_large_struct();
+let s2: Foo = function_that_returns_large_struct();
+assert(copy s1 == copy s2, 42);
+//     ^^^^       ^^^^
+use_two_foos(s1, s2);
+```
+This code is perfectly acceptable, just not efficient. The highlighted copies can be removed and replaced with borrows
+```rust=
+let v1: vector<u8> = function_that_returns_vector();
+let v2: vector<u8> = function_that_returns_vector();
+assert(&v1 == &v2, 42);
+//     ^      ^
+use_two_vectors(v1, v2);
+
+let s1: Foo = function_that_returns_large_struct();
+let s2: Foo = function_that_returns_large_struct();
+assert(&s1 == &s2, 42);
+//     ^      ^
+use_two_foos(s1, s2);
+```
+The efficiency of the `==` itself remains the same, but the `copy`s are removed and thus the program is more efficient.
+
+###### tags: `basics` `Reviewed by Legal`

--- a/language/documentation/book/src/equality.md
+++ b/language/documentation/book/src/equality.md
@@ -14,13 +14,17 @@ Move supports two equality operations `==` and `!=`
 | `!=`     | not equal | Returns `true` if the two operands have different values, `false` otherwise
 
 ### Typing
+
 Both the equal (`==`) and not-equal (`!=`) operations only work if both operands are the same type
+
 ```rust
 0 == 0; // `true`
 1u128 == 2u128; // `false`
 b"hello" != x"00"; // `true`
 ```
+
 Equality and non-equality also work over user defined types!
+
 ```rust=
 address 0x42 {
 module Example {
@@ -42,14 +46,18 @@ module Example {
 ```
 
 If the operands have different types, there is a type checking error
+
 ```rust
 1u8 == 1u128; // ERROR!
 //     ^^^^^ expected an argument of type 'u8'
 b"" != 0; // ERROR!
 //     ^ expected an argument of type 'vector<u8>'
 ```
+
 ### Typing with references
+
 When comparing [references](./references.md), the type of the reference does not matter. This means that you can compare an immutable `&` reference with a mutable one `&mut` of the same type.
+
 ```rust
 let i = &0;
 let m = &mut 1;
@@ -59,7 +67,9 @@ m == i; // `false`
 m == m; // `true`
 i == i; // `true`
 ```
+
 The above is equivalent to applying an explicit freeze to each mutable reference where needed
+
 ```rust
 let i = &0;
 let m = &mut 1;
@@ -69,7 +79,9 @@ freeze(m) == i; // `false`
 m == m; // `true`
 i == i; // `true`
 ```
+
 But similar to non-reference types, the underlying type must be the same type
+
 ```rust
 let i = &0;
 let s = &b"";
@@ -81,6 +93,7 @@ i == s; // ERROR!
 ## Restrictions
 
 Both `==` and `!=` consume the value when comparing them. As a result, the type system enforces that the type must be `copyable`, that is that it is not a `resource` value. Recall that resources cannot be copied, ownership must be transferred by the end of the function, and they can only be explicitly destroyed within their declaring module. If resources were used directly with either equality `==` or non-equality `!=`, the value would be destroyed which would break resource safety!
+
 ```rust=
 address 0x42 {
 module Example {
@@ -94,6 +107,7 @@ module Example {
 ```
 
 But, a programmer can *always* borrow the value first--to make it a `copyable` type--instead of directly comparing the resource. For example
+
 ```rust=
 address 0x42 {
 module Example {
@@ -105,9 +119,11 @@ module Example {
 }
 }
 ```
+
 ## Avoid Extra Copies
 
 While a programmer *can* compare any `copyable` value, a programmer should often compare by reference to avoid expensive copies.
+
 ```rust=
 let v1: vector<u8> = function_that_returns_vector();
 let v2: vector<u8> = function_that_returns_vector();
@@ -121,7 +137,9 @@ assert(copy s1 == copy s2, 42);
 //     ^^^^       ^^^^
 use_two_foos(s1, s2);
 ```
+
 This code is perfectly acceptable, just not efficient. The highlighted copies can be removed and replaced with borrows
+
 ```rust=
 let v1: vector<u8> = function_that_returns_vector();
 let v2: vector<u8> = function_that_returns_vector();
@@ -135,6 +153,7 @@ assert(&s1 == &s2, 42);
 //     ^      ^
 use_two_foos(s1, s2);
 ```
+
 The efficiency of the `==` itself remains the same, but the `copy`s are removed and thus the program is more efficient.
 
 ###### tags: `basics` `Reviewed by Legal`

--- a/language/documentation/book/src/equality.md
+++ b/language/documentation/book/src/equality.md
@@ -1,8 +1,4 @@
----
-id: move-equality
-title: Equality
-sidebar_label: Equality
----
+# Equality
 
 Move supports two equality operations `==` and `!=`
 
@@ -155,5 +151,3 @@ use_two_foos(s1, s2);
 ```
 
 The efficiency of the `==` itself remains the same, but the `copy`s are removed and thus the program is more efficient.
-
-###### tags: `basics` `Reviewed by Legal`

--- a/language/documentation/book/src/functions.md
+++ b/language/documentation/book/src/functions.md
@@ -1,0 +1,370 @@
+---
+id: move-functions
+title: Functions
+sidebar_label: Functions
+---
+
+Function syntax in Move is shared between module functions and script functions. Functions inside of modules are reusable, whereas script functions are only used once to invoke a transaction.
+
+## Declaration
+
+Functions are declared with the `fun` keyword followed by the function name, type parameters, parameters, a return type, acquires annotations, and finally the function body.
+```
+fun <identifier><[type_parameters: constraint],*>([identifier: type],*): <return_type> <acquires [identifier],*> <function_body>
+```
+For example
+```rust
+fun foo<T1, T2>(x: u64, y: T1, z: T2): (T2, T1, u64) { (z, y, x) }
+```
+
+### Visibility
+
+Module functions, by default, can only be called within the same module. These internal (sometimes called private) functions cannot be called from other modules or from scripts.
+```rust=
+address 0x42 {
+module M {
+    fun foo(): u64 { 0 }
+    fun calls_foo(): u64 { foo() } // valid
+}
+
+module other {
+    fun calls_M_foo(): u64 {
+        0x42::M::foo() // ERROR!
+//      ^^^^^^^^^^^^ 'foo' is internal to '0x42::M'
+    }
+}
+}
+
+script {
+    fun calls_M_foo(): u64 {
+        0x42::M::foo() // ERROR!
+//      ^^^^^^^^^^^^ 'foo' is internal to '0x42::M'
+    }
+}
+```
+To allow access from other modules or from scripts, the function must be declared `public`
+```rust=
+address 0x42 {
+module M {
+    public fun foo(): u64 { 0 }
+    fun calls_foo(): u64 { foo() } // valid
+}
+
+module other {
+    fun calls_M_foo(): u64 {
+        0x42::M::foo() // valid
+    }
+}
+}
+
+script {
+    fun calls_M_foo(): u64 {
+        0x42::M::foo() // valid
+    }
+}
+```
+
+### Name
+
+Function names can start with letters `a` to `z` or letters `A` to `Z`. After the first character, function names can contain underscores `_`, letters `a` to `z`, letters `A` to `Z`, or digits `0` to `9`.
+```rust
+fun FOO() {}
+fun bar_42() {}
+fun _bAZ19() {}
+```
+
+### Type Parameters
+
+After the name, functions can have type parameters
+```rust
+fun id<T>(x: T): T { x }
+fun example<T1: copyable, T2>(x: T1, y: T2): (T1, T1, T2) { (copy x, x, y) }
+```
+For more details, see [Move generics](./generics.md).
+
+### Parameters
+
+Functions parameters are declared with a local variable name followed by a type annotation
+```rust
+fun add(x: u64, y: u64): u64 { x + y }
+```
+We read this as `x` has type `u64`
+
+A function does not have to have any parameters at all.
+```rust
+fun useless() { }
+```
+This is very common for functions that create new or empty data structures
+```rust=
+address 0x42 {
+module Example {
+  struct Counter { count: u64 }
+
+  fun new_counter(): Counter {
+      Counter { count: 0 }
+  }
+
+}
+}
+```
+
+### Acquires
+
+When a function accesses a resource using `move_from`, `borrow_global`, or `borrow_global_mut`, the function must indicate that it `acquires` that resource. This is then used by Move's type system to ensure the references into global storage are safe, specifically that there are no dangling references into global storage.
+```rust=
+address 0x42 {
+module Example {
+
+    resource struct Balance { value: u64 }
+
+    public fun add_balance(s: &signer, value: u64) {
+        move_to(s, Balance { value })
+    }
+
+    public fun extract_balance(addr: address): u64 acquires Balance {
+        let Balance { value } = move_from(addr); // acquires needed
+        value
+    }
+
+}
+}
+```
+`acquires` annotations must also be added for transitive calls within the module. Calls to these functions from another module do not need to annotated with these acquires because one module cannot access resources declared in another module--so the annotation is not needed to ensure reference safety.
+
+```rust=
+address 0x42 {
+module Example {
+
+    resource struct Balance { value: u64 }
+
+    public fun add_balance(s: &signer, value: u64) {
+        move_to(s, Balance { value })
+    }
+
+    public fun extract_balance(addr: address): u64 acquires Balance {
+        let Balance { value } = move_from(addr); // acquires needed
+        value
+    }
+
+    public fun extract_and_add(sender: address, receiver: &signer) acquires Balance {
+        let value = extract_balance(sender); // acquires needed here
+        add_balance(receiver, value)
+    }
+
+}
+}
+
+address 0x42 {
+module Other {
+    fun extract_balance(addr: address): u64 {
+        0x42::Example::extract_balance(addr) // no acquires needed
+    }
+}
+}
+```
+
+A function can `acquire` as many resources as it needs to
+```rust=
+address 0x42 {
+module Example {
+
+    use 0x1::Vector;
+
+    resource struct Balance { value: u64 }
+    resource struct Box<T> { items: vector<T> }
+
+    public fun store_two<Item1, Item2>(
+        addr: address,
+        item1: Item1,
+        item2: Item2,
+    ) acquires Balance, Box {
+        let balance = borrow_global_mut<Balance>(addr); // acquires needed
+        balance.value = balance.value - 2;
+        let box1 = borrow_global_mut<Box<Item1>>(addr); // acquires needed
+        Vector::push_back(&mut box1.items, item1);
+        let box2 = borrow_global_mut<Box<Item2>>(addr); // acquires needed
+        Vector::push_back(&mut box2.items, item2);
+    }
+}
+}
+```
+### Return type
+
+After the parameters, a function specifies its return type.
+```rust
+fun zero(): u64 { 0 }
+```
+Here `: u64` indicates that the function's return type is `u64`.
+
+Using tuples, a function can return multiple values
+
+```rust
+fun one_two_three(): (u64, u64, u64) { (0, 1, 2) }
+```
+
+If no return type is specified, the function has an implicit return type of unit `()`. These functions are equivalent
+```rust
+fun just_unit(): () { () }
+fun just_unit() { () }
+fun just_unit() { }
+```
+`script` functions must have a return type of unit `()`
+```rust=
+script {
+    fun do_nothing() {
+    }
+}
+```
+
+As mentioned in the [tuples section](./tuples.md), these tuple "values" are virtual and do not exist at runtime. So for a function that returns unit `()`, it will not be returning any value at all during execution.
+
+### Function body
+
+A function's body is an expression block. The return value of the function is the last value in the sequence
+```rust=
+fun example(): u64 {
+    let x = 0;
+    x = x + 1;
+    x // returns 'x'
+}
+```
+
+See [the section below for more information on returns](#returning-values)
+
+For more information on expression blocks, see [Move variables](./variables.md).
+
+### Native Functions
+
+Some functions do not have a body specified, and instead have the body provided by the VM. These functions are marked `native`.
+
+Without modifying the VM source code, a programmer cannot add new native functions. Furthermore, it is the intent that `native` functions are used for either standard library code or for functionality needed for the given Move environment.
+
+Most `native` functions you will likely see are in standard library code such as `Vector`
+```rust=
+address 0x1 {
+module Vector {
+    native public fun empty<Element>(): vector<Element>;
+    ...
+}
+}
+```
+
+## Calling
+
+When calling a function, the name can be specified either through an alias or fully qualified
+```rust=
+address 0x42 {
+module Example {
+    public fun zero(): u64 { 0 }
+}
+}
+
+script {
+    use 0x42::Example::{Self, zero};
+    fun call_zero() {
+        // With the `use` above all of these calls are equivalent
+        0x42::Example::zero();
+        Example::zero();
+        zero();
+    }
+}
+```
+
+When calling a function, an argument must be given for every parameter.
+```rust=
+address 0x42 {
+module Example {
+    public fun takes_none(): u64 { 0 }
+    public fun takes_one(x: u64): u64 { x }
+    public fun takes_two(x: u64, y: u64): u64 { x + y }
+    public fun takes_three(x: u64, y: u64, z: u64): u64 { x + y + z }
+}
+}
+
+script {
+    use 0x42::Example;
+    fun call_all() {
+        Example::takes_none();
+        Example::takes_one(0);
+        Example::takes_two(0, 1);
+        Example::takes_three(0, 1, 2);
+    }
+}
+```
+
+Type arguments can be either specified or inferred. Both calls are equivalent.
+```rust=
+address 0x42 {
+module Example {
+    public fun id<T>(x: T): T { x }
+}
+}
+
+script {
+    use 0x42::Example;
+    fun call_all() {
+        Example::id(0);
+        Example::id<u64>(0);
+    }
+}
+```
+For more details, see [Move generics](./generics.md).
+
+
+## Returning values
+
+The result of a function, it's "return value", is the final value of it's function body. For example
+```rust=
+fun add(x: u64, y: u64): u64 {
+    x + y
+}
+```
+[As mentioned above](#function-body), the function's body is an [expression block](./variables.md). The expression block can sequence various statements, and the final expression in the block will be be the value of that block
+```rust=
+fun double_and_add(x: u64, y: u64): u64 {
+    let double_x = x * 2;
+    let double_y = y * 2;
+    double_x + double_y
+}
+```
+The return value here is `double_x + double_y`
+
+
+### `return` expression
+
+A function implicitly returns the value that its body evaluates to. However, functions can also use the explicit `return` expression:
+
+```rust
+fun f1(): u64 { return 0 }
+fun f2(): u64 { 0 }
+```
+These two functions are equivalent. In this slightly more involved example, the function subtracts two `u64` values, but returns early with `0` if the second value is too large:
+```rust=
+fun safe_sub(x: u64, y: u64): u64 {
+    if (y > x) return 0;
+    x - y
+}
+```
+Note that the body of this function could also have been written as `if (y > x) 0 else x - y`.
+
+However `return` really shines is in exiting deep within other control flow constructs. In this example, the function iterates through a vector to find the index of a given value:
+```rust=
+use 0x1::Vector;
+use 0x1::Option::{Self, Option};
+fun index_of<T>(v: &vector<T>, target: &T): Option<u64> {
+    let i = 0;
+    let n = Vector::length(v);
+    while (i < n) {
+        if (Vector::borrow(v, i) == target) return Option::some(i);
+        i = i + 1
+    };
+
+    Option::none()
+}
+```
+
+Using `return` without an argument is shorthand for `return ()`. That is, the following two functions are equivalent:
+```rust
+fun foo() { return }
+fun foo() { return () }
+```

--- a/language/documentation/book/src/functions.md
+++ b/language/documentation/book/src/functions.md
@@ -9,10 +9,13 @@ Function syntax in Move is shared between module functions and script functions.
 ## Declaration
 
 Functions are declared with the `fun` keyword followed by the function name, type parameters, parameters, a return type, acquires annotations, and finally the function body.
+
 ```
 fun <identifier><[type_parameters: constraint],*>([identifier: type],*): <return_type> <acquires [identifier],*> <function_body>
 ```
+
 For example
+
 ```rust
 fun foo<T1, T2>(x: u64, y: T1, z: T2): (T2, T1, u64) { (z, y, x) }
 ```
@@ -20,6 +23,7 @@ fun foo<T1, T2>(x: u64, y: T1, z: T2): (T2, T1, u64) { (z, y, x) }
 ### Visibility
 
 Module functions, by default, can only be called within the same module. These internal (sometimes called private) functions cannot be called from other modules or from scripts.
+
 ```rust=
 address 0x42 {
 module M {
@@ -42,7 +46,9 @@ script {
     }
 }
 ```
+
 To allow access from other modules or from scripts, the function must be declared `public`
+
 ```rust=
 address 0x42 {
 module M {
@@ -67,6 +73,7 @@ script {
 ### Name
 
 Function names can start with letters `a` to `z` or letters `A` to `Z`. After the first character, function names can contain underscores `_`, letters `a` to `z`, letters `A` to `Z`, or digits `0` to `9`.
+
 ```rust
 fun FOO() {}
 fun bar_42() {}
@@ -76,25 +83,32 @@ fun _bAZ19() {}
 ### Type Parameters
 
 After the name, functions can have type parameters
+
 ```rust
 fun id<T>(x: T): T { x }
 fun example<T1: copyable, T2>(x: T1, y: T2): (T1, T1, T2) { (copy x, x, y) }
 ```
+
 For more details, see [Move generics](./generics.md).
 
 ### Parameters
 
 Functions parameters are declared with a local variable name followed by a type annotation
+
 ```rust
 fun add(x: u64, y: u64): u64 { x + y }
 ```
+
 We read this as `x` has type `u64`
 
 A function does not have to have any parameters at all.
+
 ```rust
 fun useless() { }
 ```
+
 This is very common for functions that create new or empty data structures
+
 ```rust=
 address 0x42 {
 module Example {
@@ -111,6 +125,7 @@ module Example {
 ### Acquires
 
 When a function accesses a resource using `move_from`, `borrow_global`, or `borrow_global_mut`, the function must indicate that it `acquires` that resource. This is then used by Move's type system to ensure the references into global storage are safe, specifically that there are no dangling references into global storage.
+
 ```rust=
 address 0x42 {
 module Example {
@@ -129,6 +144,7 @@ module Example {
 }
 }
 ```
+
 `acquires` annotations must also be added for transitive calls within the module. Calls to these functions from another module do not need to annotated with these acquires because one module cannot access resources declared in another module--so the annotation is not needed to ensure reference safety.
 
 ```rust=
@@ -164,6 +180,7 @@ module Other {
 ```
 
 A function can `acquire` as many resources as it needs to
+
 ```rust=
 address 0x42 {
 module Example {
@@ -188,12 +205,15 @@ module Example {
 }
 }
 ```
+
 ### Return type
 
 After the parameters, a function specifies its return type.
+
 ```rust
 fun zero(): u64 { 0 }
 ```
+
 Here `: u64` indicates that the function's return type is `u64`.
 
 Using tuples, a function can return multiple values
@@ -203,12 +223,15 @@ fun one_two_three(): (u64, u64, u64) { (0, 1, 2) }
 ```
 
 If no return type is specified, the function has an implicit return type of unit `()`. These functions are equivalent
+
 ```rust
 fun just_unit(): () { () }
 fun just_unit() { () }
 fun just_unit() { }
 ```
+
 `script` functions must have a return type of unit `()`
+
 ```rust=
 script {
     fun do_nothing() {
@@ -221,6 +244,7 @@ As mentioned in the [tuples section](./tuples.md), these tuple "values" are virt
 ### Function body
 
 A function's body is an expression block. The return value of the function is the last value in the sequence
+
 ```rust=
 fun example(): u64 {
     let x = 0;
@@ -240,6 +264,7 @@ Some functions do not have a body specified, and instead have the body provided 
 Without modifying the VM source code, a programmer cannot add new native functions. Furthermore, it is the intent that `native` functions are used for either standard library code or for functionality needed for the given Move environment.
 
 Most `native` functions you will likely see are in standard library code such as `Vector`
+
 ```rust=
 address 0x1 {
 module Vector {
@@ -252,6 +277,7 @@ module Vector {
 ## Calling
 
 When calling a function, the name can be specified either through an alias or fully qualified
+
 ```rust=
 address 0x42 {
 module Example {
@@ -271,6 +297,7 @@ script {
 ```
 
 When calling a function, an argument must be given for every parameter.
+
 ```rust=
 address 0x42 {
 module Example {
@@ -293,6 +320,7 @@ script {
 ```
 
 Type arguments can be either specified or inferred. Both calls are equivalent.
+
 ```rust=
 address 0x42 {
 module Example {
@@ -308,18 +336,22 @@ script {
     }
 }
 ```
+
 For more details, see [Move generics](./generics.md).
 
 
 ## Returning values
 
 The result of a function, its "return value", is the final value of its function body. For example
+
 ```rust=
 fun add(x: u64, y: u64): u64 {
     x + y
 }
 ```
+
 [As mentioned above](#function-body), the function's body is an [expression block](./variables.md). The expression block can sequence various statements, and the final expression in the block will be be the value of that block
+
 ```rust=
 fun double_and_add(x: u64, y: u64): u64 {
     let double_x = x * 2;
@@ -327,6 +359,7 @@ fun double_and_add(x: u64, y: u64): u64 {
     double_x + double_y
 }
 ```
+
 The return value here is `double_x + double_y`
 
 
@@ -338,16 +371,20 @@ A function implicitly returns the value that its body evaluates to. However, fun
 fun f1(): u64 { return 0 }
 fun f2(): u64 { 0 }
 ```
+
 These two functions are equivalent. In this slightly more involved example, the function subtracts two `u64` values, but returns early with `0` if the second value is too large:
+
 ```rust=
 fun safe_sub(x: u64, y: u64): u64 {
     if (y > x) return 0;
     x - y
 }
 ```
+
 Note that the body of this function could also have been written as `if (y > x) 0 else x - y`.
 
 However `return` really shines is in exiting deep within other control flow constructs. In this example, the function iterates through a vector to find the index of a given value:
+
 ```rust=
 use 0x1::Vector;
 use 0x1::Option::{Self, Option};
@@ -364,6 +401,7 @@ fun index_of<T>(v: &vector<T>, target: &T): Option<u64> {
 ```
 
 Using `return` without an argument is shorthand for `return ()`. That is, the following two functions are equivalent:
+
 ```rust
 fun foo() { return }
 fun foo() { return () }

--- a/language/documentation/book/src/functions.md
+++ b/language/documentation/book/src/functions.md
@@ -313,7 +313,7 @@ For more details, see [Move generics](./generics.md).
 
 ## Returning values
 
-The result of a function, it's "return value", is the final value of it's function body. For example
+The result of a function, its "return value", is the final value of its function body. For example
 ```rust=
 fun add(x: u64, y: u64): u64 {
     x + y

--- a/language/documentation/book/src/functions.md
+++ b/language/documentation/book/src/functions.md
@@ -1,8 +1,4 @@
----
-id: move-functions
-title: Functions
-sidebar_label: Functions
----
+# Functions
 
 Function syntax in Move is shared between module functions and script functions. Functions inside of modules are reusable, whereas script functions are only used once to invoke a transaction.
 
@@ -140,7 +136,6 @@ module Example {
         let Balance { value } = move_from(addr); // acquires needed
         value
     }
-
 }
 }
 ```
@@ -166,7 +161,6 @@ module Example {
         let value = extract_balance(sender); // acquires needed here
         add_balance(receiver, value)
     }
-
 }
 }
 
@@ -184,7 +178,6 @@ A function can `acquire` as many resources as it needs to
 ```rust=
 address 0x42 {
 module Example {
-
     use 0x1::Vector;
 
     resource struct Balance { value: u64 }
@@ -361,7 +354,6 @@ fun double_and_add(x: u64, y: u64): u64 {
 ```
 
 The return value here is `double_x + double_y`
-
 
 ### `return` expression
 

--- a/language/documentation/book/src/generics.md
+++ b/language/documentation/book/src/generics.md
@@ -1,0 +1,354 @@
+---
+id: move-generics
+title: Generics
+sidebar_label: Generics
+---
+
+Generics can be used to define functions and structs over different input data types. This language feature is sometimes referred to as *parametric polymorphism*. In Move, we will often use the term generics interchangeably with type parameters and type arguments.
+
+Generics are commonly used in library code, such as in Vector, to declare code that works over any possible instantiation (that satisfies the specified constraints). In other frameworks, generic code can sometimes be used to interact with global storage many different ways that all still share the same implementation.
+
+## Declaring Type Parameters
+
+Both functions and structs can take a list of type parameters in their signatures, enclosed by a pair of angle brackets `<...>`.
+
+### Generic Functions
+Type parameters for functions are placed after the function name and before the (value) parameter list. The following code defines a generic identity function that takes a value of any type and returns that value unchanged.
+```rust
+fun id<T>(x: T): T {
+    // this type annotation is unnecessary but valid
+    (x: T)
+}
+```
+Once defined, the type parameter `T` can be used in parameter types, return types, and inside the function body.
+
+### Generic Structs
+
+Type parameters for structs are placed after the struct name, and can be used to name the types of the fields.
+
+```rust
+struct Foo<T> { x: T }
+
+struct Bar<T1, T2> {
+    x: T1,
+    y: vector<T2>,
+}
+```
+
+[Note that type parameters do not have to be used](#unused-type-parameters)
+
+
+## Type Arguments
+
+### Calling Generic Functions
+
+When calling a generic function, one can specify the type arguments for the function's type parameters in a list enclosed by a pair of angle brackets.
+
+```rust=
+fun foo() {
+    let x = id<bool>(true);
+}
+```
+
+If you do not specify the type arguments, Move's [type inference](#type-inference) will supply them for you.
+
+### Using Generic Structs
+
+Similarly, one can attach a list of type arguments for the struct's type parameters when constructing or destructing values of generic types.
+
+```rust=
+fun foo() {
+    let foo = Foo<bool> { x: true };
+    let Foo<bool> { x } = foo;
+}
+```
+If you do not specify the type arguments, Move's [type inference](#type-inference) will supply them for you.
+
+### Type Argument Mismatch
+
+If you specify the type arguments and they conflict with the actual values supplied, an error will be given
+```rust=
+fun foo() {
+    let x = id<u64>(true); // error! true is not a u64
+}
+```
+and similarly
+```rust=
+fun foo() {
+    let foo = Foo<bool> { x: 0 }; // error! 0 is not a bool
+    let Foo<address> { x } = foo; // error! bool is incompatible with address
+}
+```
+
+## Type Inference
+
+In most cases, the Move compiler will be able to infer the type arguments so you don't have to write them down explicitly. Here's what the examples above would look like if we omit the type arguments.
+
+```rust=
+fun foo() {
+    let x = id(true);
+    //        ^ <bool> is inferred
+
+    let foo = Foo { x: true };
+    //           ^ <bool> is inferred
+
+    let Foo { x } = foo;
+    //     ^ <bool> is inferred
+}
+```
+Note: when the compiler is unable to infer the types, you'll need annotate them manually. A common scenario is to call a function with type parameters appearing only at return positions.
+```rust=
+address 0x2 {
+module M {
+    using 0x1::Vector;
+
+    fun foo() {
+        // let v = Vector::new();
+        //                    ^ The compiler cannot figure out the element type.
+
+        let v = Vector::new<u64>();
+        //                 ^~~~~ Must annotate manually.
+    }
+}
+}
+```
+However, the compiler will be able to infer the type if that return value is used later in that function
+```rust=
+address 0x2 {
+module M {
+    using 0x1::Vector;
+
+    fun foo() {
+        let v = Vector::new();
+        //                 ^ <u64> is inferred
+        Vector::push_back(&mut v, 42);
+    }
+}
+}
+```
+
+## Unused Type Parameters
+Move allows unused type parameters so the following struct definition is valid:
+```rust=
+struct Foo<T> {
+    foo: u64
+}
+```
+This can be convenient when modeling certain concepts. Here is an example:
+```rust=
+address 0x2 {
+module M {
+    // Currency Specifiers
+    struct Currency1 {}
+    struct Currency2 {}
+
+    // A generic coin type that can be instantiated using a currency
+    // specifier type.
+    //   e.g. Coin<Currency1>, Coin<Currency2> etc.
+    resource struct Coin<Currency> {
+        value: u64
+    }
+}
+}
+```
+
+## Constraints
+
+In the examples above, we have demonstrated how one can use type parameters to define "unkonwn" types that can be plugged in by callers at a later time. This however means the type system has little information about the type and has to perform checks in a very conservative way. In some sense, the type system must assume the worst case scenario for an unconstrained generic. If for instance you were to `copy` an unconstrained generic, you could break resource safety if that type was instantiated with a resource!
+
+This is where constraints come into play: they offer a way to specify what properties these unknown types have so the type system can allow operations that would otherwise be unsafe.
+
+### Declaring Constraints
+Constraints can be imposed on type parameters using the following syntax.
+```rust=
+// T is the name of the type parameter
+T: resource
+// or
+T: copyable
+```
+- `resource` means values of the type cannot be copied and cannot be dropped
+- `copyable` means values of the type can be copied and can be dropped
+
+These two constraint are mutually exclusive so you can't have both applied to a type parameter at the same time.
+### Verifying Constraints
+Constraints are checked at call sites so the following code won't compile.
+```rust=
+struct Foo<T: resource> { x: T }
+
+struct Bar { x: Foo<u8> }
+//                  ^ error! u8 is not resource
+
+struct Baz<T> { x: Foo<T> }
+//                     ^ error! T isn't necessarily resource
+```
+
+```rust=
+resource struct R {}
+
+fun unsafe_consume<T>(x: T) {
+    // error! x might be an unused resource
+}
+
+fun consume<T: copyable>(x: T) {
+    // valid!
+    // x will be dropped automatically
+}
+
+fun foo() {
+    let r = R {};
+    consume<R>(r);
+    //      ^ error! R is not copyable
+}
+```
+
+```rust=
+resource struct R {}
+
+fun unsafe_double<T>(x: T) {
+    (copy x, x)
+    // error! cannot copy x as it might be a resource
+}
+
+fun double<T: copyable>(x: T) {
+    (copy x, x)
+}
+
+fun foo(): (R, R) {
+    let r = R{};
+    double<R>(r)
+    //     ^ error! R is not copyable
+}
+```
+
+### How to tell if a struct type is resource or copyable
+Recall that a non-generic struct type is considered resource if and only if it is explicitly marked so.
+```rust=
+resource struct Foo {} // Foo is resource
+struct Bar {}          // Bar is copyable
+```
+However for a generic struct type, whether it is considered resource depends on the specific type arguments used to instantiate it, unless there's an explicit `resource` marker in the struct definition.
+```rust=
+struct Foo<T> {}
+resource struct Bar<T> {}
+resource struct R {}
+
+// R is a resource type by definition
+
+// Foo<u64> is a copyable type since u64 is a copyable type
+
+// Foo<vector<Foo<u64>>> is a copyable type since
+//   vector<Foo<u64>> is a copyable type since
+//     Foo<u64> is a copyable type since u64 is a copyable type
+
+// Foo<R> is a resource type since R is a resource type
+// However, Foo<R> cannot be used with global storage operations
+
+// Bar<u64> is a resource type by definition
+
+// vector<Foo<Bar<u64>>> is a resource type since
+//   Foo<Bar<u64>> is a resource type since
+//     Bar<u64> is a resource type by definition
+```
+
+## Limitations on Recursions
+
+### Recursive Structs
+
+Generic structs can not contain fields of the same type, either directly or indirectly, even with different type arguments. All of the following struct definitions are invalid:
+
+```rust=
+struct Foo<T> {
+    x: Foo<u64> // error! 'Foo' containing 'Foo'
+}
+
+struct Bar<T> {
+    x: Bar<T> // error! 'Bar' containing 'Bar'
+}
+
+// error! 'A' and 'B' forming a cycle, which is not allowed either.
+struct A<T> {
+    x: B<T, u64>
+}
+
+struct B<T1, T2> {
+    x: A<T1>
+    y: A<T2>
+}
+```
+
+### Advanced Topic: Type-level Recursions
+
+Move allows generic functions to be called recursively. However, when used in combination with generic structs, this could create an infinite number of types in certain cases, and allowing this means adding unnecessary complexity to the compiler, vm and other language components. Therefore, such recursions are forbidden.
+
+Allowed:
+```rust=
+address 0x2 {
+module M {
+    resource struct A<T> {}
+
+    // Finitely many types -- allowed.
+    // foo<T> -> foo<T> -> foo<T> -> ... is valid
+    fun foo<T>() {
+        foo<T>();
+    }
+
+    // Finitely many types -- allowed.
+    // foo<T> -> foo<A<u64>> -> foo<A<u64>> -> ... is valid
+    fun foo<T>() {
+        foo<A<u64>>();
+    }
+}
+}
+```
+
+Not allowed:
+```rust=
+address 0x2 {
+module M {
+    resource struct A<T> {}
+
+    // Infinitely many types -- NOT allowed.
+    // error!
+    // foo<T> -> foo<A<T>> -> foo<A<A<T>>> -> ...
+    fun foo<T>() {
+        foo<Foo<T>>();
+    }
+}
+}
+```
+```rust=
+address 0x2 {
+module N {
+    resource struct A<T> {}
+
+    // Infinitely many types -- NOT allowed.
+    // error!
+    // foo<T1, T2> -> bar<T2, T1> -> foo<T2, A<T1>>
+    //   -> bar<A<T1>, T2> -> foo<A<T1>, A<T2>>
+    //   -> bar<A<T2>, A<T1>> -> foo<A<T2>, A<A<T1>>>
+    //   -> ...
+    fun foo<T1, T2>() {
+        bar<T2, T1>();
+    }
+
+    fun bar<T1, T2> {
+        foo<T1, A<T2>>();
+    }
+}
+}
+```
+Note, the check for type level recursions is based on a conservative analysis on the call sites and does NOT take control flow or runtime values into account.
+```rust=
+address 0x2 {
+module M {
+    resource struct A<T> {}
+
+    fun foo<T>(n: u64) {
+        if (n > 0) {
+            foo<A<T>>(n - 1);
+        };
+    }
+}
+}
+```
+The function in the example above will technically terminate for any given input and therefore only creating finitely many types, but it is still considered invalid by Move's type system.

--- a/language/documentation/book/src/generics.md
+++ b/language/documentation/book/src/generics.md
@@ -1,8 +1,4 @@
----
-id: move-generics
-title: Generics
-sidebar_label: Generics
----
+# Generics
 
 Generics can be used to define functions and structs over different input data types. This language feature is sometimes referred to as *parametric polymorphism*. In Move, we will often use the term generics interchangeably with type parameters and type arguments.
 
@@ -39,7 +35,6 @@ struct Bar<T1, T2> {
 ```
 
 [Note that type parameters do not have to be used](#unused-type-parameters)
-
 
 ## Type Arguments
 

--- a/language/documentation/book/src/generics.md
+++ b/language/documentation/book/src/generics.md
@@ -13,13 +13,16 @@ Generics are commonly used in library code, such as in Vector, to declare code t
 Both functions and structs can take a list of type parameters in their signatures, enclosed by a pair of angle brackets `<...>`.
 
 ### Generic Functions
+
 Type parameters for functions are placed after the function name and before the (value) parameter list. The following code defines a generic identity function that takes a value of any type and returns that value unchanged.
+
 ```rust
 fun id<T>(x: T): T {
     // this type annotation is unnecessary but valid
     (x: T)
 }
 ```
+
 Once defined, the type parameter `T` can be used in parameter types, return types, and inside the function body.
 
 ### Generic Structs
@@ -62,17 +65,21 @@ fun foo() {
     let Foo<bool> { x } = foo;
 }
 ```
+
 If you do not specify the type arguments, Move's [type inference](#type-inference) will supply them for you.
 
 ### Type Argument Mismatch
 
 If you specify the type arguments and they conflict with the actual values supplied, an error will be given
+
 ```rust=
 fun foo() {
     let x = id<u64>(true); // error! true is not a u64
 }
 ```
+
 and similarly
+
 ```rust=
 fun foo() {
     let foo = Foo<bool> { x: 0 }; // error! 0 is not a bool
@@ -96,7 +103,9 @@ fun foo() {
     //     ^ <bool> is inferred
 }
 ```
+
 Note: when the compiler is unable to infer the types, you'll need annotate them manually. A common scenario is to call a function with type parameters appearing only at return positions.
+
 ```rust=
 address 0x2 {
 module M {
@@ -112,7 +121,9 @@ module M {
 }
 }
 ```
+
 However, the compiler will be able to infer the type if that return value is used later in that function
+
 ```rust=
 address 0x2 {
 module M {
@@ -128,13 +139,17 @@ module M {
 ```
 
 ## Unused Type Parameters
+
 Move allows unused type parameters so the following struct definition is valid:
+
 ```rust=
 struct Foo<T> {
     foo: u64
 }
 ```
+
 This can be convenient when modeling certain concepts. Here is an example:
+
 ```rust=
 address 0x2 {
 module M {
@@ -159,19 +174,25 @@ In the examples above, we have demonstrated how one can use type parameters to d
 This is where constraints come into play: they offer a way to specify what properties these unknown types have so the type system can allow operations that would otherwise be unsafe.
 
 ### Declaring Constraints
+
 Constraints can be imposed on type parameters using the following syntax.
+
 ```rust=
 // T is the name of the type parameter
 T: resource
 // or
 T: copyable
 ```
+
 - `resource` means values of the type cannot be copied and cannot be dropped
 - `copyable` means values of the type can be copied and can be dropped
 
 These two constraint are mutually exclusive so you can't have both applied to a type parameter at the same time.
+
 ### Verifying Constraints
+
 Constraints are checked at call sites so the following code won't compile.
+
 ```rust=
 struct Foo<T: resource> { x: T }
 
@@ -221,12 +242,16 @@ fun foo(): (R, R) {
 ```
 
 ### How to tell if a struct type is resource or copyable
+
 Recall that a non-generic struct type is considered resource if and only if it is explicitly marked so.
+
 ```rust=
 resource struct Foo {} // Foo is resource
 struct Bar {}          // Bar is copyable
 ```
+
 However for a generic struct type, whether it is considered resource depends on the specific type arguments used to instantiate it, unless there's an explicit `resource` marker in the struct definition.
+
 ```rust=
 struct Foo<T> {}
 resource struct Bar<T> {}
@@ -281,6 +306,7 @@ struct B<T1, T2> {
 Move allows generic functions to be called recursively. However, when used in combination with generic structs, this could create an infinite number of types in certain cases, and allowing this means adding unnecessary complexity to the compiler, vm and other language components. Therefore, such recursions are forbidden.
 
 Allowed:
+
 ```rust=
 address 0x2 {
 module M {
@@ -302,6 +328,7 @@ module M {
 ```
 
 Not allowed:
+
 ```rust=
 address 0x2 {
 module M {
@@ -316,6 +343,7 @@ module M {
 }
 }
 ```
+
 ```rust=
 address 0x2 {
 module N {
@@ -337,7 +365,9 @@ module N {
 }
 }
 ```
+
 Note, the check for type level recursions is based on a conservative analysis on the call sites and does NOT take control flow or runtime values into account.
+
 ```rust=
 address 0x2 {
 module M {
@@ -351,4 +381,5 @@ module M {
 }
 }
 ```
+
 The function in the example above will technically terminate for any given input and therefore only creating finitely many types, but it is still considered invalid by Move's type system.

--- a/language/documentation/book/src/global-storage-operators.md
+++ b/language/documentation/book/src/global-storage-operators.md
@@ -1,0 +1,247 @@
+---
+id: move-global-storage-operators
+title: Global Storage - Operators
+sidebar_label: Global Storage Operators
+---
+
+Move programs can create, delete, and update [resources](./structs-and-resources.md) in global storage using the following five instructions:
+
+| Operation                                   | Description                                                        | Aborts?                                  |
+----------------------------------------------|--------------------------------------------------------------------|-------------------------------------------
+|`move_to<T>(&signer,T)`                      | Publish `T` under `signer.address`                                 | If `signer.address` already holds a `T` |
+|`move_from<T>(address): T`                   | Remove `T` from `address` and return it                            | If `address` does not hold a `T`         |
+|`borrow_global_mut<T>(address): &mut T`      | Return a mutable reference to the `T` stored under `address`       | If `address` does not hold a `T`         |
+|`borrow_global<T>(address): &T`	             | Return an immutable reference to the `T` stored under `address`    | If `address` does not hold a `T`         |
+|`exists<T>(address): bool`                   | Return `true` if a `T` is stored under `address`                   |  Never                                      |
+
+Each of these instructions is parameterized by a resource type `T` declared *in the current module*. This ensures that a resource can only be manipulated via the API exposed by its defining module. The instructions also take either an [`address`](./address.md) or [`&signer`](./signer.md) representing the account address where the resource of type `T` is stored.
+
+### References to resources
+References to global resources returned by `borrow_global` or `borrow_global_mut` mostly behave like references to local storage: they can be extended, read, and written using ordinary [reference operators](./references.md) and passed as arguments to other function. However, there is one important difference between local and global references: **a function cannot return a reference that points into global storage**. For example, these two functions will each fail to compile:
+
+```rust
+resource struct R { f: u64 }
+// will not compile
+fun ret_direct_resource_ref_bad(a: address): &R {
+    borrow_global<R>(a) // error!
+}
+// also will not compile
+fun ret_resource_field_ref_bad(a: address): &u64 {
+    &borrow_global<R>(a).f // error!
+}
+```
+
+Move must enforce this restriction to guarantee absence of dangling references to global storage. [This](#reference-safety-for-global-resources) section contains much more detail for the interested reader.
+
+### Global storage operators with generics
+
+Global storage operations can be applied to generic resources with both instantiated and uninstantiated generic type parameters:
+
+```rust
+resource struct Container<T> { t: T }
+
+// Publish a Container storing a type T of the caller's choosing
+fun publish_generic_container<T>(account: &signer, t: T) {
+    move_to<Container<T>>(account, Container { t })
+}
+
+/// Publish a container storing a u64
+fun publish_instantiated_generic_container(account: &signer, t: u64) {
+    move_to<Container<u64>>(account, Container { t })
+}
+```
+
+The ability to index into global storage via a type parameter chosen at runtime is a powerful Move feature known as *storage polymorphism*. For more on the design patterns enabled by this feature, see [Move generics](./generics.md).
+
+## Example: `Counter`
+
+The simple `Counter` module below exercises each of the five global storage operators. The API exposed by this module allows:
+
+- Anyone to publish a `Counter` resource under their account
+- Anyone to check if a `Counter` exists under any address
+- Anyone to read or increment the value of a `Counter` resource under any address
+- An account that stores a `Counter` resource to reset it to zero
+- An account that stores a `Counter` resource to remove and delete it
+
+
+```rust
+address 0x42 {
+module Counter {
+    use 0x1::Signer;
+
+    /// Resource that wraps an integer counter
+    resource struct Counter { i: u64 }
+
+    /// Publish a `Counter` resource with value `i` under the given `account`
+    public fun publish(account: &signer, i: u64) {
+      // "Pack" (create) a Counter resource. This is a privileged operation that
+      // can only be done inside the module that declares the `Counter` resource
+      move_to(account, Counter { i })
+    }
+
+    /// Read the value in the `Counter` resource stored at `addr`
+    public fun get_count(addr: address): u64 acquires Counter {
+        borrow_global<Counter>(addr).i
+    }
+
+    /// Increment the value of `addr`'s `Counter` resource
+    public fun increment(addr: address) acquires Counter {
+        let c_ref = &mut borrow_global_mut<Counter>(addr).i;
+        *c_ref = *c_ref + 1
+    }
+
+    /// Reset the value of `account`'s `Counter` to 0
+    public fun reset(account: &signer) acquires Counter {
+        let c_ref = &mut borrow_global_mut<Counter>(Signer::address_of(account)).i;
+        *c_ref = 0
+    }
+
+    /// Delete the `Counter` resource under `account` and return its value
+    public fun delete(account: &Signer): u64 acquires Counter {
+        // remove the Counter resource
+        let c = move_from<Counter>(Signer::address_of(account));
+        // "Unpack" the `Counter` resource into its fields. This is a
+        // privileged operation that can only be done inside the module
+        // that declares the `Counter` resource
+        let Counter { i } = c;
+        i
+    }
+
+    /// Return `true` if `addr` contains a `Counter` resource
+    public fun exists(addr: address): bool {
+        exists<Counter>(addr)
+    }
+}
+}
+```
+
+## Annotating functions with `acquires`
+
+In the `Counter` example, you might have noticed that the`get_count`, `increment`, `reset`, and `delete` functions are annotated with `acquires Counter`. A Move function `M::f` must be annotated with `acquires T` if and only if:
+- The body of `M::f` contains a `move_from<T>`, `borrow_global_mut<T>`, or `borrow_global<T>` instruction, or
+- The body of `M::f` invokes a function `M::g` declared in the same module that is annotated with `acquires`
+
+For example, the following function inside `Counter` would need an `acquires` annotation:
+
+```rust
+// Needs `acquires` because `increment` is annotated with `acquires`
+fun call_increment(addr: address): u64 acquires Counter {
+    Counter::increment(addr)
+}
+```
+
+However, the same function *outside* `Counter` would not need an annotation:
+```rust
+address 0x43 {
+module M {
+   use 0x42::Counter;
+
+   // Ok. Only need annotation when resource acquired by callee is declared
+   // in the same module
+   fun call_increment(addr: address): u64 {
+       Counter::increment(addr)
+   }
+}
+}
+```
+
+If a function touches multiple resources, it needs multiple `acquires`:
+
+```rust=
+address 0x42 {
+module TwoResources {
+    resource struct R1 { f: u64 }
+    resource struct R2 { g: u64 }
+
+    fun double_acquires(a: address): u64 acquires R1, R2 {
+        borrow_global<R1>(a).f + borrow_global<R2>.g
+    }
+}
+}
+```
+
+The `acquires` annotation does not take generic type parameters into account:
+
+```rust=
+address 0x42 {
+module M {
+    resource struct R<T> { t: T }
+
+    // `acquires R`, not `acquires R<T>`
+    fun acquire_generic_resource(a: addr) acquires R {
+        let _ = borrow_global<R<T>>(a);
+    }
+
+    // `acquires R`, not `acquires R<u64>
+    fun acquire_instantiated_generic_resource(a: addr) acquires R {
+        let _ = borrow_global<R<u64>>(a);
+    }
+}
+}
+```
+
+Finally: redundant `acquires` are not allowed. Adding this function inside `Counter` will result in a compilation error:
+```rust
+// This code will not compile because the body of the function does not use a global
+// storage instruction or invoke a function with `acquires`
+fun redundant_acquires_bad() acquires Counter {}
+```
+
+For more information on `acquires`, see [Move functions](./functions.md).
+
+## Reference Safety For Global Resources
+
+Move prohibits returning global references and requires the `acquires` annotation to prevent dangling references. This allows Move to live up to its promise of static reference safety (i.e., no dangling references, no `null` or `nil` dereferences) for all [reference](./references.md) types.
+
+This example illustrates how the Move type system uses `acquires` to prevent a dangling reference:
+```rust=
+address 0x42 {
+module Dangling {
+    resource struct T { f: u64 }
+
+    fun borrow_then_remove_bad(a: address) acquires T {
+        let t_ref: &mut T = borrow_global_mut<T>(a);
+        let t = remove_t(a); // type system complains here
+        // t_ref now dangling!
+        let uh_oh = *&t_ref.f
+    }
+
+    fun remove_t(a: address): T acquires T {
+        move_from<T>(a)
+    }
+
+}
+}
+```
+In this code, line 6 acquires a reference to the `T` stored at address `a` in global storage. The callee `remove_t` then removes the value, which makes `t_ref` a dangling reference.
+
+Fortunately, this cannot happen because the type system will reject this program. The `acquires` annotation on `remove_t` lets the type system know that line 7 is dangerous, without having to recheck or introspect the body of `remove_t` separately!
+
+The restriction on returning global references prevents a similar, but even more insidious problem:
+
+```rust=
+address 0x42 {
+module M1 {
+    resource struct T {}
+
+    public fun ret_t_ref(a: address): &T acquires T {
+        borrow_global<T>(a) // error! type system complains here
+    }
+
+    public fun remove_t(a: address) acquires T {
+        let T {} = move_from<T>(a);
+    }
+}
+
+module M2 {
+    fun borrow_then_remove_bad(a: address) {
+        let t_ref = M1::ret_t_ref(a);
+        let t = M1::remove_t(a); // t_ref now dangling!
+    }
+}
+}
+```
+
+Line 16 acquires a reference to a global resource `M1::T`, then line 17 removes that same resource, which makes `t_ref` dangle. In this case, `acquires` annotations do not help us because the `borrow_then_remove_bad` function is outside of the `M1` module that declares `T` (recall that `acquires` annotations can only be used for resources declared in the current module). Instead, the type system avoids this problem by preventing the return of a global reference at line 6.
+
+Fancier type systems that would allow returning global references without sacrificing reference safety are possible, and we may consider them in future iterations of Move. We chose the current design because it strikes a good balance between expressivity, annotation burden, and type system complexity.

--- a/language/documentation/book/src/global-storage-operators.md
+++ b/language/documentation/book/src/global-storage-operators.md
@@ -1,8 +1,4 @@
----
-id: move-global-storage-operators
-title: Global Storage - Operators
-sidebar_label: Global Storage Operators
----
+# Global Storage - Operators
 
 Move programs can create, delete, and update [resources](./structs-and-resources.md) in global storage using the following five instructions:
 

--- a/language/documentation/book/src/global-storage-operators.md
+++ b/language/documentation/book/src/global-storage-operators.md
@@ -17,6 +17,7 @@ Move programs can create, delete, and update [resources](./structs-and-resources
 Each of these instructions is parameterized by a resource type `T` declared *in the current module*. This ensures that a resource can only be manipulated via the API exposed by its defining module. The instructions also take either an [`address`](./address.md) or [`&signer`](./signer.md) representing the account address where the resource of type `T` is stored.
 
 ### References to resources
+
 References to global resources returned by `borrow_global` or `borrow_global_mut` mostly behave like references to local storage: they can be extended, read, and written using ordinary [reference operators](./references.md) and passed as arguments to other function. However, there is one important difference between local and global references: **a function cannot return a reference that points into global storage**. For example, these two functions will each fail to compile:
 
 ```rust
@@ -131,6 +132,7 @@ fun call_increment(addr: address): u64 acquires Counter {
 ```
 
 However, the same function *outside* `Counter` would not need an annotation:
+
 ```rust
 address 0x43 {
 module M {
@@ -181,6 +183,7 @@ module M {
 ```
 
 Finally: redundant `acquires` are not allowed. Adding this function inside `Counter` will result in a compilation error:
+
 ```rust
 // This code will not compile because the body of the function does not use a global
 // storage instruction or invoke a function with `acquires`
@@ -194,6 +197,7 @@ For more information on `acquires`, see [Move functions](./functions.md).
 Move prohibits returning global references and requires the `acquires` annotation to prevent dangling references. This allows Move to live up to its promise of static reference safety (i.e., no dangling references, no `null` or `nil` dereferences) for all [reference](./references.md) types.
 
 This example illustrates how the Move type system uses `acquires` to prevent a dangling reference:
+
 ```rust=
 address 0x42 {
 module Dangling {
@@ -213,6 +217,7 @@ module Dangling {
 }
 }
 ```
+
 In this code, line 6 acquires a reference to the `T` stored at address `a` in global storage. The callee `remove_t` then removes the value, which makes `t_ref` a dangling reference.
 
 Fortunately, this cannot happen because the type system will reject this program. The `acquires` annotation on `remove_t` lets the type system know that line 7 is dangerous, without having to recheck or introspect the body of `remove_t` separately!

--- a/language/documentation/book/src/global-storage-structure.md
+++ b/language/documentation/book/src/global-storage-structure.md
@@ -1,8 +1,4 @@
----
-id: move-global-storage-structure
-title: Global Storage - Structure
-sidebar_label: Global Storage Structure
----
+# Global Storage - Structure
 
 The purpose of Move programs is to [read from and write to](./global-storage-operators.md) tree-shaped persistent global storage. Programs cannot access the filesystem, network, or any other data outside of this tree.
 

--- a/language/documentation/book/src/global-storage-structure.md
+++ b/language/documentation/book/src/global-storage-structure.md
@@ -1,0 +1,18 @@
+---
+id: move-global-storage-structure
+title: Global Storage - Structure
+sidebar_label: Global Storage Structure
+---
+
+The purpose of Move programs is to [read from and write to](./global-storage-operators.md) tree-shaped persistent global storage. Programs cannot access the filesystem, network, or any other data outside of this tree.
+
+In pseudocode, the global storage looks something like
+
+```rust
+struct GlobalStorage {
+  resources: Map<(address, ResourceType), ResourceValue>
+  modules: Map<(address, ModuleName), ModuleBytecode>
+}
+```
+
+Structurally, global storage is a [forest](https://en.wikipedia.org/wiki/Tree_(graph_theory)) consisting of trees rooted at an account [`address`](./address.md). Each address can store both [resource](./structs-and-resources.md) data values and [module](./modules-and-scripts.md) code values. As the pseudocode above indicates, each `address` can store at most one resource value of a given type and at most one module with a given name.

--- a/language/documentation/book/src/integers.md
+++ b/language/documentation/book/src/integers.md
@@ -1,0 +1,137 @@
+---
+id: move-integers
+title: Integers
+sidebar_label: Integers
+---
+
+Move supports three unsigned integer types: `u8`, `u64`, and `u128`. Values of these types range from 0 to a maximum that depends on the size of the type.
+
+| Type                             | Value Range              |
+| -------------------------------- | ------------------------ |
+| Unsigned 8-bit integer, `u8`     | 0 to 2<sup>8</sup> - 1   |
+| Unsigned 64-bit integer, `u64`   | 0 to 2<sup>64</sup> - 1  |
+| Unsigned 128-bit integer, `u128` | 0 to 2<sup>128</sup> - 1 |
+
+## Literals
+
+Literal values for these types are specified as a sequence of digits, e.g.,`112`. The type of the literal can optionally be added as a suffix, e.g., `112u8`. If the type is not specified, the compiler will try to infer the type from the context where the literal is used. If the type cannot be inferred, it is assumed to be `u64`.
+
+If a literal is too large for its specified (or inferred) size range, an error is reported.
+
+### Examples
+
+```rust
+// literals with explicit annotations;
+let explicit_u8 = 1u8;
+let explicit_u64 = 2u64;
+let explicit_u128 = 3u128;
+
+// literals with simple inference
+let simple_u8: u8 = 1;
+let simple_u64: u64 = 2;
+let simple_u128: u128 = 3;
+
+// literals with more complex inference
+let complex_u8 = 1; // inferred: u8
+// right hand argument to shift must be u8
+let _unused = 10 << complex_u8;
+
+let x: u8 = 0;
+let complex_u8 = 2; // inferred: u8
+// arguments to `+` must have the same type
+let _unused = x + complex_u8;
+
+let complex_u128 = 3; // inferred: u128
+// inferred from function argument type
+function_that_takes_u128(complex_u128);
+```
+
+## Operations
+
+### Arithmetic
+
+Each of these types supports the same set of checked arithmetic operations. For all of these operations, both arguments (the left and right side operands) *must* be of the same type. If you need to operate over values of different types, you will need to first perform a [cast](#casting). Similarly, if you expect the result of the operation to be too large for the integer type, perform a [cast](#casting) to a larger size before performing the operation.
+
+All arithmetic operations abort instead of behaving in a way that mathematical integers would not (e.g., overflow, underflow, divide-by-zero).
+
+| Syntax | Operation | Aborts If
+|--------|-----------|-------------------------------------
+| `+` |addition | Result is too large for the integer type
+| `-` | subtraction | Result is less than zero
+| `*` | multiplication | Result is too large for the integer type
+| `%` | modular division | The divisor is `0`
+| `/` | truncating division | The divisor is `0`
+
+
+### Bitwise
+
+The integer types support the following bitwise operations that treat each number as a series of individual bits, either 0 or 1, instead of as numerical integer values.
+
+Bitwise operations do not abort.
+
+
+| Syntax | Operation  | Description
+|--------|------------|------------
+| `&`    | bitwise and| Performs a boolean and for each bit pairwise
+| `|`   | bitwise or | Performs a boolean or for each bit pairwise
+| `^`    | bitwise xor| Performs a boolean exclusive or for each bit pairwise
+
+### Bit Shifts
+
+Similar to the bitwise operations, each integer type supports bit shifts. But unlike the other operations, the righthand side operand (how many bits to shift by) must *always* be a `u8` and need not match the left side operand (the number you are shifting).
+
+Bit shifts can abort if the number of bits to shift by is greater than or equal to `8`, `64`, or `128` for `u8`, `u64`, and `u128` respectively.
+
+| Syntax | Operation  | Aborts if
+|--------|------------|----------
+|`<<`    | shift left | Number of bits to shift by is greater than the size of the integer type
+|`>>`    | shift right| Number of bits to shift by is greater than the size of the integer type
+
+### Comparisons
+
+Integer types are the *only* types in Move that can use the comparison operators. Both arguments need to be of the same type. If you need to compare integers of different types, you will need to [cast](#casting) one of them first.
+
+Comparison operations do not abort.
+
+| Syntax | Operation
+|--------|-----------
+| `<`    | less than
+| `>`    | greater than
+| `<=`   | less than or equal to
+| `>=`   | greater than or equal to
+
+
+### Equality
+
+Like all [copyable](./equality.md) types in Move, all integer types support the "equal" and "not equal" operations. Both arguments need to be of the same type. If you need to compare integers of different types, you will need to [cast](#casting) one of them first.
+
+Equality operations do not abort.
+
+| Syntax | Operation
+|--------|----------
+| `==`   | equal
+| `!=`   | not equal
+
+## Casting
+
+Integer types of one size can be cast to integer types of another size. Integers are the only types in Move that support casting.
+
+Casts *do not* truncate. Casting will abort if the result is too large for the specified type
+
+
+| Syntax     | Operation                                                                       | Aborts if
+|------------|---------------------------------------------------------------------------------|---------------------------------------
+| `(e as T)`| Cast integer expression `e` into an integer type `T` | `e` is too large to represent as a `T`
+
+Here, the type of `e` must be `u8`, `u64`, or `u128` and `T` must be `u8`, `u64`, or `u128`.
+
+For example:
+
+- `(x as u8)`
+- `(2u8 as u64)`
+- `(1 + 3 as u128)`
+
+
+## Ownership
+
+As with the other builtin scalar types, integer values are implicitly copyable, meaning they can be copied without an explicit instruction such as [`copy`](./equality.md).

--- a/language/documentation/book/src/integers.md
+++ b/language/documentation/book/src/integers.md
@@ -1,8 +1,4 @@
----
-id: move-integers
-title: Integers
-sidebar_label: Integers
----
+# Integers
 
 Move supports three unsigned integer types: `u8`, `u64`, and `u128`. Values of these types range from 0 to a maximum that depends on the size of the type.
 
@@ -69,7 +65,6 @@ The integer types support the following bitwise operations that treat each numbe
 
 Bitwise operations do not abort.
 
-
 | Syntax | Operation  | Description
 |--------|------------|------------
 | `&`    | bitwise and| Performs a boolean and for each bit pairwise
@@ -100,7 +95,6 @@ Comparison operations do not abort.
 | `<=`   | less than or equal to
 | `>=`   | greater than or equal to
 
-
 ### Equality
 
 Like all [copyable](./equality.md) types in Move, all integer types support the "equal" and "not equal" operations. Both arguments need to be of the same type. If you need to compare integers of different types, you will need to [cast](#casting) one of them first.
@@ -118,7 +112,6 @@ Integer types of one size can be cast to integer types of another size. Integers
 
 Casts *do not* truncate. Casting will abort if the result is too large for the specified type
 
-
 | Syntax     | Operation                                                                       | Aborts if
 |------------|---------------------------------------------------------------------------------|---------------------------------------
 | `(e as T)`| Cast integer expression `e` into an integer type `T` | `e` is too large to represent as a `T`
@@ -130,7 +123,6 @@ For example:
 - `(x as u8)`
 - `(2u8 as u64)`
 - `(1 + 3 as u128)`
-
 
 ## Ownership
 

--- a/language/documentation/book/src/introduction.md
+++ b/language/documentation/book/src/introduction.md
@@ -10,9 +10,6 @@ Welcome to Move, a next generation language for secure, sandboxed, and formally 
 
 Move takes its cue from [Rust](https://www.rust-lang.org/) by using resource types with move (hence the name) semantics as an explicit representation of digital assets, such as currency.
 
-![Figure 1.1 Move Methods](/img/docs/move-methods.svg)
-<small className="figure">Figure 1.1 Move Methods</small>
-
 ## Who is Move for?
 
 Move was designed and created as a secure, verified, yet flexible programming language. The first use of Move is for the implementation of the Diem blockchain. That said, the language is still evolving. Move has the potential to be a language for other blockchains, and even non-blockchain use cases as well.
@@ -32,13 +29,6 @@ Beyond a hobbyist wanting to stay ahead of the curve for the core programming la
 ### Who Move is currently not targeting
 
 Currently, Move is not targeting developers who wish to create custom modules and contracts for use on the Diem Payment Network. We are also not targeting novice developers who expect a completely polished developer experience even in testing the language.
-
-## Move Architecture
-
-Move has all of the syntax and semantics you would expect from a first-class programming language. However, there is an entire architecture dedicated to creating, using, and executing code based on Move. The diagram below shows the architecture of Move as it pertains to the Diem Payment Network, from using the source language to script execution. Click on a specific topic of the diagram to be taken to more information about that specific area.
-
-<MoveArchitecture alt="Figure 1.2 Move Architecture" />
-<small className="figure">Figure 1.2 Move Architecture</small>
 
 ## Where Do I Start?
 

--- a/language/documentation/book/src/introduction.md
+++ b/language/documentation/book/src/introduction.md
@@ -1,10 +1,4 @@
----
-id: move-introduction
-title: Move Introduction
-sidebar_label: Introduction
----
-
-import MoveArchitecture from 'img/docs/move-architecture.svg';
+# Introduction
 
 Welcome to Move, a next generation language for secure, sandboxed, and formally verified programming. Its first use case is for the Diem blockchain, where Move provides the foundation for its implementation. Move allows developers to write programs that flexibly manage and transfer assets, while providing the security and protections against attacks on those assets. However, Move has been developed with use cases in mind outside a blockchain context as well.
 
@@ -32,4 +26,4 @@ Currently, Move is not targeting developers who wish to create custom modules an
 
 ## Where Do I Start?
 
-Begin with understanding [modules and scripts](./modules-and-scripts.md) and then work through the [first tutorial on creating coins](./creating-coins.md). And then use the sidebar to walkthrough even more details about the language.
+Begin with understanding [modules and scripts](./modules-and-scripts.md) and then work through the [first tutorial on creating coins](./creating-coins.md).

--- a/language/documentation/book/src/introduction.md
+++ b/language/documentation/book/src/introduction.md
@@ -1,0 +1,45 @@
+---
+id: move-introduction
+title: Move Introduction
+sidebar_label: Introduction
+---
+
+import MoveArchitecture from 'img/docs/move-architecture.svg';
+
+Welcome to Move, a next generation language for secure, sandboxed, and formally verified programming. Its first use case is for the Diem blockchain, where Move provides the foundation for its implementation. Move allows developers to write programs that flexibly manage and transfer assets, while providing the security and protections against attacks on those assets. However, Move has been developed with use cases in mind outside a blockchain context as well.
+
+Move takes its cue from [Rust](https://www.rust-lang.org/) by using resource types with move (hence the name) semantics as an explicit representation of digital assets, such as currency.
+
+![Figure 1.1 Move Methods](/img/docs/move-methods.svg)
+<small className="figure">Figure 1.1 Move Methods</small>
+
+## Who is Move for?
+
+Move was designed and created as a secure, verified, yet flexible programming language. The first use of Move is for the implementation of the Diem blockchain. That said, the language is still evolving. Move has the potential to be a language for other blockchains, and even non-blockchain use cases as well.
+
+Given custom Move modules will not be supported at the [launch](https://diem.com/white-paper/#whats-next) of the Diem Payment Network (DPN), we are targeting an early Move Developer persona.
+
+The early Move Developer is one with some programming experience, who wants to begin understanding the core programming language and see examples of its usage.
+
+### Hobbyists
+
+Understanding that the capability to create custom modules on the Diem Payment Network will not be available at launch, the hobbyist Move Developer is interested in learning the intricacies of the language. She will understand the basic syntax, the standard libraries available, and write example code that can be executed using the Move CLI. The Move Developer may even want to dig into understanding how the Move Virtual Machine executes the code she writes.
+
+### Core Contributor
+
+Beyond a hobbyist wanting to stay ahead of the curve for the core programming language is someone who may want to [contribute](https://diem.com/en-US/cla-sign/) directly to Move. Whether this includes submitting language improvements or even, in the future, adding core modules available on the Diem Payment Network, the core contributor will understand Move at a deep level. Once familiar with Move, the core contributor may want to submit a request to the Diem Association to add new transaction or module types, via the [Diem Improvement Protocol (DIP) process](https://dip.diem.com/).
+
+### Who Move is currently not targeting
+
+Currently, Move is not targeting developers who wish to create custom modules and contracts for use on the Diem Payment Network. We are also not targeting novice developers who expect a completely polished developer experience even in testing the language.
+
+## Move Architecture
+
+Move has all of the syntax and semantics you would expect from a first-class programming language. However, there is an entire architecture dedicated to creating, using, and executing code based on Move. The diagram below shows the architecture of Move as it pertains to the Diem Payment Network, from using the source language to script execution. Click on a specific topic of the diagram to be taken to more information about that specific area.
+
+<MoveArchitecture alt="Figure 1.2 Move Architecture" />
+<small className="figure">Figure 1.2 Move Architecture</small>
+
+## Where Do I Start?
+
+Begin with understanding [modules and scripts](./modules-and-scripts.md) and then work through the [first tutorial on creating coins](./creating-coins.md). And then use the sidebar to walkthrough even more details about the language.

--- a/language/documentation/book/src/loops.md
+++ b/language/documentation/book/src/loops.md
@@ -1,0 +1,173 @@
+---
+id: move-while-and-loop
+title: While and Loop
+sidebar_label: While and Loop
+---
+
+Move offers two constructs for looping: `while` and `loop`.
+
+## `while` loops
+The `while` construct repeats the body (an expression of type unit) until the condition (an expression of type `bool`) evaluates to `false`.
+
+Here is an example of simple `while` loop that computes the sum of the numbers from `1` to `n`:
+```rust=
+fun sum(n: u64): u64 {
+    let sum = 0;
+    let i = 1;
+    while (i <= n) {
+        sum = sum + i;
+        i = i + 1
+    };
+
+    sum
+}
+```
+Infinite loops are allowed:
+```rust=
+fun foo() {
+    while (true) { }
+}
+```
+
+### `break`
+
+The `break` expression can be used to exit a loop before the condition evaluates to `false`. For example, this loop uses `break` to find the smallest factor of `n` that's greater than 1:
+```rust=
+fun upper_bound_sqrt(n: u64): u64 {
+    // assuming the input is not 0 or 1
+    let i = 2;
+    while (i <= n) {
+        if (n % i == 0) break;
+        i = i + 1
+    };
+
+    i
+}
+```
+
+The `break` expression cannot be used outside of a loop.
+
+### `continue`
+The `continue` expression skips the rest of the loop and continuess to the next iteration. This loop uses `continue` to compute the sum of `1, 2, ..., n`, except when the number is divisible by 10:
+```rust=
+fun sum_intermediate(n: u64): u64 {
+    let sum = 0;
+    let i = 1;
+    while (i <= n) {
+        if (i % 10 == 0) continue;
+        sum = sum + i;
+        i = i + 1
+    };
+
+    sum
+}
+```
+
+The `continue` expression cannot be used outside of a loop.
+
+### The type of `break` and `continue`
+
+`break` and `continue`, much like `return` and `abort`, can have any type. The following examples illustrate where this flexible typing can be helpful:
+
+```rust=
+fun pop_smallest_while_not_equal(
+    v1: vector<u64>,
+    v2: vector<u64>,
+): vector<u64> {
+    let result = Vector::empty();
+    while (!Vector::is_empty(&v1) && !Vector::is_empty(&v2)) {
+        let u1 = *Vector::borrow(&v1, Vector::length(&v1) - 1);
+        let u2 = *Vector::borrow(&v1, Vector::length(&v1) - 1);
+        let popped =
+            if (u1 < u2) Vector::pop_back(&mut v1)
+            else if (u2 < u1) Vector::pop_back(&mut v2)
+            else break; // Here, `break` has type `u64`
+        Vector::push_back(&mut result, popped);
+    };
+
+    result
+}
+```
+```rust=
+fun pick(
+    indexes: vector<u64>,
+    v1: &vector<address>,
+    v2: &vector<address>
+): vector<address> {
+    let len1 = Vector::length(v1);
+    let len2 = Vector::length(v2);
+    let result = Vector::empty();
+    while (!Vector::is_empty(&indexes)) {
+        let index = Vector::pop_back(&mut indexes);
+        let chosen_vector =
+            if (index < len1) v1
+            else if (index < len2) v2
+            else continue; // Here, `continue` has type `&vector<address>`
+        Vector::push_back(&mut result, *Vector::borrow(chosen_vector, index))
+    };
+
+    result
+}
+```
+
+## The `loop` expression
+The `loop` expression repeats the loop body (an expression with type `()`) until it hits a `break`
+
+Without a `break`, the loop will continue forever
+```rust=
+fun foo() {
+    let i = 0;
+    loop { i = i + 1 }
+}
+```
+
+Here is an example that uses `loop` to write the `sum` function:
+```rust=
+fun sum(n: u64): u64 {
+    let sum = 0;
+    let i = 0;
+    loop {
+        i = i + 1;
+        if (i > n) break;
+        sum = sum + i
+    };
+
+    sum
+}
+```
+As you might expect, `continue` can also be used inside a `loop`. Here is `sum_intermediate` from above rewritten using `loop` instead of `while`
+```rust=
+fun sum_intermediate(n: u64): u64 {
+    let sum = 0;
+    let i = 0;
+    loop {
+        if (i % 10 == 0) continue;
+        i = i + 1;
+        if (i > n) break;
+        sum = sum + i
+    };
+
+    sum
+}
+```
+
+## The type of `while` and `loop`
+
+Move loops are typed expressions. A `while` expression always has type `()`.
+```rust
+let () = while (i < 10) { i = i + 1 };
+```
+
+If a `loop` contains a `break`, the expression has type unit `()`
+
+```rust
+(loop { if (i < 10) i = i + 1 else break }: ());
+let () = loop { if (i < 10) i = i + 1 else break };
+```
+
+If `loop` does not have a `break`, `loop` can have any type much like `return`, `abort`, `break`, and `continue`.
+```rust
+(loop (): u64);
+(loop (): address);
+(loop (): &vector<vector<u8>>);
+```

--- a/language/documentation/book/src/loops.md
+++ b/language/documentation/book/src/loops.md
@@ -1,8 +1,4 @@
----
-id: move-while-and-loop
-title: While and Loop
-sidebar_label: While and Loop
----
+# While and Loop
 
 Move offers two constructs for looping: `while` and `loop`.
 

--- a/language/documentation/book/src/loops.md
+++ b/language/documentation/book/src/loops.md
@@ -7,9 +7,11 @@ sidebar_label: While and Loop
 Move offers two constructs for looping: `while` and `loop`.
 
 ## `while` loops
+
 The `while` construct repeats the body (an expression of type unit) until the condition (an expression of type `bool`) evaluates to `false`.
 
 Here is an example of simple `while` loop that computes the sum of the numbers from `1` to `n`:
+
 ```rust=
 fun sum(n: u64): u64 {
     let sum = 0;
@@ -22,7 +24,9 @@ fun sum(n: u64): u64 {
     sum
 }
 ```
+
 Infinite loops are allowed:
+
 ```rust=
 fun foo() {
     while (true) { }
@@ -32,6 +36,7 @@ fun foo() {
 ### `break`
 
 The `break` expression can be used to exit a loop before the condition evaluates to `false`. For example, this loop uses `break` to find the smallest factor of `n` that's greater than 1:
+
 ```rust=
 fun upper_bound_sqrt(n: u64): u64 {
     // assuming the input is not 0 or 1
@@ -48,7 +53,9 @@ fun upper_bound_sqrt(n: u64): u64 {
 The `break` expression cannot be used outside of a loop.
 
 ### `continue`
+
 The `continue` expression skips the rest of the loop and continuess to the next iteration. This loop uses `continue` to compute the sum of `1, 2, ..., n`, except when the number is divisible by 10:
+
 ```rust=
 fun sum_intermediate(n: u64): u64 {
     let sum = 0;
@@ -88,6 +95,7 @@ fun pop_smallest_while_not_equal(
     result
 }
 ```
+
 ```rust=
 fun pick(
     indexes: vector<u64>,
@@ -111,9 +119,11 @@ fun pick(
 ```
 
 ## The `loop` expression
+
 The `loop` expression repeats the loop body (an expression with type `()`) until it hits a `break`
 
 Without a `break`, the loop will continue forever
+
 ```rust=
 fun foo() {
     let i = 0;
@@ -122,6 +132,7 @@ fun foo() {
 ```
 
 Here is an example that uses `loop` to write the `sum` function:
+
 ```rust=
 fun sum(n: u64): u64 {
     let sum = 0;
@@ -135,7 +146,9 @@ fun sum(n: u64): u64 {
     sum
 }
 ```
+
 As you might expect, `continue` can also be used inside a `loop`. Here is `sum_intermediate` from above rewritten using `loop` instead of `while`
+
 ```rust=
 fun sum_intermediate(n: u64): u64 {
     let sum = 0;
@@ -154,6 +167,7 @@ fun sum_intermediate(n: u64): u64 {
 ## The type of `while` and `loop`
 
 Move loops are typed expressions. A `while` expression always has type `()`.
+
 ```rust
 let () = while (i < 10) { i = i + 1 };
 ```
@@ -166,6 +180,7 @@ let () = loop { if (i < 10) i = i + 1 else break };
 ```
 
 If `loop` does not have a `break`, `loop` can have any type much like `return`, `abort`, `break`, and `continue`.
+
 ```rust
 (loop (): u64);
 (loop (): address);

--- a/language/documentation/book/src/modules-and-scripts.md
+++ b/language/documentation/book/src/modules-and-scripts.md
@@ -1,0 +1,95 @@
+---
+id: move-modules-and-scripts
+title: Modules and Scripts
+sidebar_label: Modules and Scripts
+---
+
+Move has two different types of programs: ***Modules*** and ***Scripts***. Modules are libraries that define struct types along with functions that operate on these types. Struct types define the schema of Move's [global storage](./global-storage-structure.md), and module functions define the rules for updating storage. Modules themselves are also stored in global storage. Scripts are executable entrypoints similar to a `main` function in a conventional language. A script typically calls functions of a published module that perform updates to global storage. Scripts are ephemeral code snippets that are not published in global storage.
+
+A Move source file (or **compilation unit**) may contain multiple modules and scripts. However, publishing a module or executing a script are separate VM operations.
+
+## Syntax
+
+### Scripts
+
+A script has the following structure:
+```
+script {
+    <use>*
+    <constants>*
+    fun <identifier><[type parameters: constraint]*>([identifier: type]*) <function_body>
+}
+```
+A `script` block must start with all of its [use](./uses.md) declarations, followed by any [constants](./constants.md) and (finally) the main
+[function](./functions.md) declaration.
+The main function can have any name (i.e., it need not be called `main`), is the only function in a script block, can have any number of
+arguments, and must not return a value. Here is an example with each of these components:
+```rust
+script {
+    // Import the Debug module published at account address 0x1.
+    // 0x1 is shorthand for the fully qualified address
+    // 0x00000000000000000000000000000001.
+    use 0x1::Debug;
+
+    const ONE: u64 = 1;
+
+    fun main(x: u64) {
+        let sum = x + ONE;
+        Debug::print(&sum)
+    }
+}
+```
+
+Scripts have very limited power--they cannot declare struct types or access global storage. Their primary purpose is invoke module functions.
+
+### Modules
+
+A Module has the following syntax:
+```
+address <address_const> {
+module <identifier> {
+    (<use> | <type> | <function> | <constant>)*
+}
+}
+```
+
+For example:
+```rust
+address 0x42 {
+module Test {
+    resource struct Example { i: u64 }
+
+    use 0x1::Debug;
+
+    const ONE: u64 = 1;
+
+    public fun print(x: u64) {
+        let sum = x + ONE;
+        let example = Example { i: sum };
+        Debug::print(&sum)
+    }
+}
+}
+```
+
+The `address 0x42` part specifies that the module will be published under the [account address](./address.md) 0x42 in [global storage](./global-storage-structure.md).
+
+Multiple modules can be declared in a single `address` block:
+
+```rust
+address 0x42 {
+module M { ... }
+module N { ... }
+}
+```
+Module names can start with letters `a` to `z` or letters `A` to `Z`. After the first character, module names can contain underscores `_`, letters `a` to `z`, letters `A` to `Z`, or digits `0` to `9`.
+```rust
+module my_module {}
+module FooBar42 {}
+```
+Typically, module names start with an uppercase letter. A module named `MyModule` should be stored in a source file named `MyModule.move`.
+
+
+All elements inside a `module` block can appear in any order.
+Fundamentally, a module is a collection of [`types`](./structs-and-resources.md) and
+[`functions`](./functions.md). [Uses](./uses.md) import types from other modules. [Constants](./constants.md) define private constants that can be used in the functions of a module.

--- a/language/documentation/book/src/modules-and-scripts.md
+++ b/language/documentation/book/src/modules-and-scripts.md
@@ -13,6 +13,7 @@ A Move source file (or **compilation unit**) may contain multiple modules and sc
 ### Scripts
 
 A script has the following structure:
+
 ```
 script {
     <use>*
@@ -20,10 +21,12 @@ script {
     fun <identifier><[type parameters: constraint]*>([identifier: type]*) <function_body>
 }
 ```
+
 A `script` block must start with all of its [use](./uses.md) declarations, followed by any [constants](./constants.md) and (finally) the main
 [function](./functions.md) declaration.
 The main function can have any name (i.e., it need not be called `main`), is the only function in a script block, can have any number of
 arguments, and must not return a value. Here is an example with each of these components:
+
 ```rust
 script {
     // Import the Debug module published at account address 0x1.
@@ -45,6 +48,7 @@ Scripts have very limited power--they cannot declare struct types or access glob
 ### Modules
 
 A Module has the following syntax:
+
 ```
 address <address_const> {
 module <identifier> {
@@ -54,6 +58,7 @@ module <identifier> {
 ```
 
 For example:
+
 ```rust
 address 0x42 {
 module Test {
@@ -82,11 +87,14 @@ module M { ... }
 module N { ... }
 }
 ```
+
 Module names can start with letters `a` to `z` or letters `A` to `Z`. After the first character, module names can contain underscores `_`, letters `a` to `z`, letters `A` to `Z`, or digits `0` to `9`.
+
 ```rust
 module my_module {}
 module FooBar42 {}
 ```
+
 Typically, module names start with an uppercase letter. A module named `MyModule` should be stored in a source file named `MyModule.move`.
 
 

--- a/language/documentation/book/src/modules-and-scripts.md
+++ b/language/documentation/book/src/modules-and-scripts.md
@@ -1,8 +1,4 @@
----
-id: move-modules-and-scripts
-title: Modules and Scripts
-sidebar_label: Modules and Scripts
----
+# Modules and Scripts
 
 Move has two different types of programs: ***Modules*** and ***Scripts***. Modules are libraries that define struct types along with functions that operate on these types. Struct types define the schema of Move's [global storage](./global-storage-structure.md), and module functions define the rules for updating storage. Modules themselves are also stored in global storage. Scripts are executable entrypoints similar to a `main` function in a conventional language. A script typically calls functions of a published module that perform updates to global storage. Scripts are ephemeral code snippets that are not published in global storage.
 
@@ -96,7 +92,6 @@ module FooBar42 {}
 ```
 
 Typically, module names start with an uppercase letter. A module named `MyModule` should be stored in a source file named `MyModule.move`.
-
 
 All elements inside a `module` block can appear in any order.
 Fundamentally, a module is a collection of [`types`](./structs-and-resources.md) and

--- a/language/documentation/book/src/overview.md
+++ b/language/documentation/book/src/overview.md
@@ -1,0 +1,200 @@
+---
+id: overview
+title: Overview
+sidebar_label: Move
+---
+
+Move is a next generation language for secure, sandboxed, and formally verified programming. Its first use case is for the Diem blockchain, where Move provides the foundation for its implementation. However, Move has been developed with use cases in mind outside a blockchain context as well.
+
+### Start Here
+
+<CardsWrapper>
+  <SimpleTextCard
+    icon="img/introduction-to-move.svg"
+    iconDark="img/introduction-to-move-dark.svg"
+    overlay="Understand Move’s background, current status and architecture"
+    title="Introduction"
+    to="/docs/move/move-introduction"
+  />
+  <SimpleTextCard
+    icon="img/modules-and-scripts.svg"
+    iconDark="img/modules-and-scripts-dark.svg"
+    overlay="Understand Move’s two different types of programs: Modules and Scripts"
+    title="Modules and Scripts"
+    to="/docs/move/move-modules-and-scripts"
+  />
+  <SimpleTextCard
+    icon="img/placeholder.svg"
+    iconDark="img/placeholder-dark.svg"
+    overlay="Play with Move directly as you create coins with the language"
+    title="First Tutorial: Creating Coins"
+    to="/docs/move/move-tutorial-creating-coins"
+  />
+</CardsWrapper>
+
+### Primitive Types
+
+<CardsWrapper>
+  <SimpleTextCard
+    icon="img/integers-bool.svg"
+    iconDark="img/integers-bool-dark.svg"
+    overlay="Move supports three unsigned integer types: u8, u64, and u128"
+    title="Integers"
+    to="/docs/move/move-integers"
+  />
+  <SimpleTextCard
+    icon="img/integers-bool.svg"
+    iconDark="img/integers-bool-dark.svg"
+    overlay="bool is Move's primitive type for boolean true and false values."
+    title="Bool"
+    to="/docs/move/move-bool"
+  />
+  <SimpleTextCard
+    icon="img/address.svg"
+    iconDark="img/address-dark.svg"
+    overlay="address is a built-in type in Move that is used to represent locations in global storage"
+    title="Address"
+    to="/docs/move/move-address"
+  />
+  <SimpleTextCard
+    icon="img/vector.svg"
+    iconDark="img/vector-dark.svg"
+    overlay="vector<T> is the only primitive collection type provided by Move"
+    title="Vector"
+    to="/docs/move/move-vector"
+  />
+  <SimpleTextCard
+    icon="img/signer.svg"
+    iconDark="img/signer-dark.svg"
+    overlay="signer is a built-in Move resource type. A signer is a capability that allows the holder to act on behalf of a particular address"
+    title="Signer"
+    to="/docs/move/move-signer"
+  />
+  <SimpleTextCard
+    icon="img/move-references.svg"
+    iconDark="img/move-references-dark.svg"
+    overlay="Move has two types of references: immutable & and mutable &mut"
+    title="References"
+    to="/docs/move/move-references"
+  />
+  <SimpleTextCard
+    icon="img/tuples.svg"
+    iconDark="img/tuples-dark.svg"
+    overlay="In order to support multiple return values, Move has tuple-like expressions. We can consider unit() to be an empty tuple"
+    title="Tuples and Unit"
+    to="/docs/move/move-tuples-and-unit"
+  />
+</CardsWrapper>
+
+### Basic Concepts
+
+<CardsWrapper>
+  <SimpleTextCard
+    icon="img/local-variables-and-scopes.svg"
+    iconDark="img/local-variables-and-scopes-dark.svg"
+    overlay="Local variables in Move are lexically (statically) scoped"
+    title="Local Variables and Scopes"
+    to="/docs/move/move-variables"
+  />
+  <SimpleTextCard
+    icon="img/abort-and-return.svg"
+    iconDark="img/abort-and-return-dark.svg"
+    overlay="return and abort are two control flow constructs that end execution, one for the current function and one for the entire transaction"
+    title="Abort & Assert"
+    to="/docs/move/move-abort-and-assert"
+  />
+  <SimpleTextCard
+    icon="img/conditionals.svg"
+    iconDark="img/conditionals-dark.svg"
+    overlay="An if expression specifies that some code should only be evaluated if a certain condition is true"
+    title="Conditionals"
+    to="/docs/move/move-conditionals"
+  />
+  <SimpleTextCard
+    icon="img/loops.svg"
+    iconDark="img/loops-dark.svg"
+    overlay="Move offers two constructs for looping: while and loop"
+    title="While and Loop"
+    to="/docs/move/move-while-and-loop"
+  />
+  <SimpleTextCard
+    icon="img/functions.svg"
+    iconDark="img/functions-dark.svg"
+    overlay="Function syntax in Move is shared between module functions and script functions"
+    title="Functions"
+    to="/docs/move/move-functions"
+  />
+  <SimpleTextCard
+    icon="img/structs-and-resources.svg"
+    iconDark="img/structs-and-resources-dark.svg"
+    overlay="A struct is a user-defined data structure containing typed fields. A resource is a kind of struct that cannot be copied and cannot be dropped"
+    title="Structs and Resources"
+    to="/docs/move/move-structs-and-resources"
+  />
+  <SimpleTextCard
+    icon="img/constants.svg"
+    iconDark="img/constants-dark.svg"
+    overlay="Constants are a way of giving a name to shared, static values inside of a module or script"
+    title="Constants"
+    to="/docs/move/move-constants"
+  />
+  <SimpleTextCard
+    icon="img/generics.svg"
+    iconDark="img/generics-dark.svg"
+    overlay="Generics can be used to define functions and structs over different input data types"
+    title="Generics"
+    to="/docs/move/move-generics"
+  />
+  <SimpleTextCard
+    icon="img/equality.svg"
+    iconDark="img/equality-dark.svg"
+    overlay="Move supports two equality operations == and !="
+    title="Equality"
+    to="/docs/move/move-equality"
+  />
+  <SimpleTextCard
+    icon="img/uses-and-aliases.svg"
+    iconDark="img/uses-and-aliases-dark.svg"
+    overlay="The use syntax can be used to create aliases to members in other modules"
+    title="Uses & Aliases"
+    to="/docs/move/move-uses-and-aliases"
+  />
+</CardsWrapper>
+
+### Global Storage
+
+<CardsWrapper>
+  <SimpleTextCard
+    icon="img/intro-to-global-storage.svg"
+    iconDark="img/intro-to-global-storage-dark.svg"
+    overlay="The purpose of Move programs is to read from and write to persistent global storage"
+    title="Global Storage Structure"
+    to="/docs/move/move-global-storage-structure"
+  />
+  <SimpleTextCard
+    icon="img/intro-to-global-storage.svg"
+    iconDark="img/intro-to-global-storage-dark.svg"
+    overlay="Move programs can create, delete, and update resources in global storage using five instructions"
+    title="Global Storage Operators"
+    to="/docs/move/move-global-storage-operators"
+  />
+</CardsWrapper>
+
+### Reference
+
+<CardsWrapper>
+  <SimpleTextCard
+    icon="img/standard-library.svg"
+    iconDark="img/standard-library-dark.svg"
+    overlay="The Move standard library exposes interfaces that implement functionality on vectors, option types, error codes and fixed-point numbers"
+    title="Standard Library"
+    to="/docs/move/move-standard-library"
+  />
+  <SimpleTextCard
+    icon="img/coding-conventions.svg"
+    iconDark="img/coding-conventions-dark.svg"
+    overlay="There are basic coding conventions when writing Move code"
+    title="Coding Conventions"
+    to="/docs/move/move-coding-conventions"
+  />
+</CardsWrapper>

--- a/language/documentation/book/src/references.md
+++ b/language/documentation/book/src/references.md
@@ -1,0 +1,197 @@
+---
+id: move-references
+title: References
+sidebar_label: References
+---
+
+Move has two types of references: immutable `&` and mutable `&mut`. Immutable references are read only, and cannot modify the underlying value (or any of its fields). Mutable references allow for modifications via a write through that reference. Move's type system enforces an ownership discipline that prevents reference errors.
+
+For more details on the rules of references, see [Structs and Resources](./structs-and-resources.md)
+
+## Reference Operators
+
+Move provides operators for creating and extending references as well as converting a mutable reference to an immutable one. Here and elsewhere, we use the notation `e: T` for "expression `e` has type `T`".
+
+| Syntax | Type | Description
+| ---------- | ---------- | ----------
+| `&e`       | `&T` where `e: T` and `T` is a non-reference type | Create an immutable reference to `e`
+| `&mut e`   | `&mut T` where `e: T` and `T` is a non-reference type | Create a mutable reference to `e`.
+| `&e.f`  | `&t` where `e.f: T` | Create an immutable reference to field `f` of struct `e`.
+| `&mut e.f`  | `&mut T` where `e.f: T` | Create a mutable reference to field `f` of struct`e`.
+| `freeze(e)` | `&T` where `e: &mut T` | Convert the mutable reference `e` into an immutable reference.
+
+The `&e.f` and `&mut e.f` operators can be used both to create a new reference into a struct or to extend an existing reference:
+
+```rust
+let s = S { f: 10 };
+let f_ref1: &u64 = &s.f; // works
+let s_ref: &S = &s;
+let f_ref2: &u64 = &s_ref.f // also works
+```
+
+A reference expression with multiple fields works as long as both structs are in the same module:
+
+```rust
+struct A { b: B }
+struct B { c : u64 }
+fun f(a: &A): &u64 {
+  &a.b.c
+}
+```
+
+Finally, note that references to references are not allowed:
+```rust
+let x = 7;
+let y: &u64 = &x;
+let z: &&u64 = &y; // will not compile
+```
+
+
+## Reading and Writing Through References
+
+Both mutable and immutable references can be read to produce a copy of the referenced value.
+
+Only mutable references can be written. A write `*x = v` discards the value previously stored in `x` and updates it with `v`.
+
+
+Both operations use the C-like `*` syntax. However, note that a read is an expression, whereas a write is a mutation that must occur on the left hand side of an equals.
+
+| Syntax | Type | Description
+| ---------- | ---------- | ----------
+| `*e` | `T` where `e` is `&T` or `&mut T` | Read the value pointed to by `e`
+| `*e1 = e2` | `()` where `e1: &mut T` and `e2: T` | Update the value in `e1` with `e2`.
+
+References to resources cannot be read or written. Reading a reference to a resource would duplicate the resource value:
+
+```rust=
+fun copy_resource_via_ref_bad(c: Coin) {
+    let c_ref = &c;
+    let counterfeit: Coin = *c_ref; // not allowed!
+    pay(c);
+    pay(counterfeit);
+}
+```
+Dually, writing via a resource reference is not allowed because it would destroy a resource value:
+```rust=
+fun destroy_resource_via_ref_bad(ten_coins: Coin, c: Coin) {
+    let ref = &mut ten_coins;
+    *ref = c; // not allowed--would destroy 10 coins!
+}
+```
+
+## `freeze` inference
+
+A mutable reference can be used in a context where an immutable reference is expected:
+
+```rust
+let x = 7;
+let y: &mut u64 = &mut x;
+```
+This works because the under the hood, the compiler inserts `freeze` instructions where they are needed. Here are a few more examples of `freeze` inference in action:
+
+```rust=
+fun takes_immut_returns_immut(x: &u64): &u64 { x }
+
+// freeze inference on return value
+fun takes_mut_returns_immut(x: &mut u64): &u64 { x }
+
+fun expression_examples() {
+    let x = 0;
+    let y = 0;
+    takes_immut_returns_immut(&x); // no inference
+    takes_immut_returns_immut(&mut x); // inferred freeze(&mut x)
+    takes_mut_returns_immut(&mut x); // no inference
+
+    assert(&x == &mut y, 42); // inferred freeze(&mut y)
+}
+
+fun assignment_examples() {
+    let x = 0;
+    let y = 0;
+    let imm_ref: &u64 = &x;
+
+    imm_ref = &x; // no inference
+    imm_ref = &mut y; // inferred freeze(&mut y)
+}
+````
+
+### Subtyping
+
+With this `freeze` inference, the Move type checker can view `&mut T` as a subtype of `&T`. As shown above, this means that anywhere for any expression where a `&T` value is used, an `&mut T` value. This terminology is used in error messages to concisely indicate that a `&mut T` was needed where a `&T` was supplied. For example
+```rust=
+address 0x42 {
+module Example {
+    fun read_and_assign(store: &mut u64, new_value: &u64) {
+        *store = *new_value
+    }
+
+    fun subtype_examples() {
+        let x: &u64 = &0;
+        let y: &mut u64 = &mut 1;
+
+        x = &mut 1; // valid
+        y = &2; // invalid!
+
+        read_and_assign(y, x); // valid
+        read_and_assign(x, y); // invalid!
+    }
+}
+}
+```
+will yield the following error messages
+```
+error:
+
+    ┌── example.move:12:9 ───
+    │
+ 12 │         y = &2; // invalid!
+    │         ^ Invalid assignment to local 'y'
+    ·
+ 12 │         y = &2; // invalid!
+    │             -- The type: '&{integer}'
+    ·
+  9 │         let y: &mut u64 = &mut 1;
+    │                -------- Is not a subtype of: '&mut u64'
+    │
+
+error:
+
+    ┌── example.move:15:9 ───
+    │
+ 15 │         read_and_assign(x, y); // invalid!
+    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x42::Example::read_and_assign'. Invalid argument for parameter 'store'
+    ·
+  8 │         let x: &u64 = &0;
+    │                ---- The type: '&u64'
+    ·
+  3 │     fun read_and_assign(store: &mut u64, new_value: &u64) {
+    │                                -------- Is not a subtype of: '&mut u64'
+    │
+```
+
+The only other types currently that has subtyping are [tuples](./tuples.md)
+
+## Ownership
+
+Both mutable and immutable references can always be copied and extended *even if there are existing copies or extensions of the same reference*:
+
+```rust
+fun reference_copies(s: &mut S) {
+  let s_copy1 = s; // ok
+  let s_extension = &mut s.f; // also ok
+  let s_copy2 = s; // still ok
+  ...
+}
+```
+
+This might be surprising for programmers familiar with Rust's ownership system, which would reject the code above. Move's type system is more permissive in its treatment of [copies](./equality.md), but equally strict in ensuring unique ownership of mutable references before writes.
+
+### References Cannot Be Stored
+
+References and tuples are the *only* types that cannot be stored inside of structs and resources, which also means that they cannot exist in global storage. All references created during program execution will be destroyed when a Move program terminates; they are entirely ephemeral.
+
+This is another difference between Move and Rust, which allows references to be stored inside of structs.
+
+Currently, Move cannot support this because references cannot be [serialized](https://en.wikipedia.org/wiki/Serialization), but *every Move value must be serializable*. This requirement comes from Move's [persistent global storage](./global-storage-structure.md), which needs to serialize values to persist them across program executions. Structs can be written to global storage, and thus they must be serializable.
+
+One could imagine a fancier, more expressive, type system that would allow references to be stored in structs *and* ban those structs from existing in global storage. Currently, we do not have the ability to discern between types that can and cannot exist in global storage, and are stuck with this ban. That being said even with such a discernation, Move has a fairly complex system for tracking static reference safety, and this aspect of the type system would also have to be extended to support storing references inside of structs. In summary, many aspects of Move's type system would have to expand to support stored references. But it is something we are keeping an eye on as the language evolves.

--- a/language/documentation/book/src/references.md
+++ b/language/documentation/book/src/references.md
@@ -1,8 +1,4 @@
----
-id: move-references
-title: References
-sidebar_label: References
----
+# References
 
 Move has two types of references: immutable `&` and mutable `&mut`. Immutable references are read only, and cannot modify the underlying value (or any of its fields). Mutable references allow for modifications via a write through that reference. Move's type system enforces an ownership discipline that prevents reference errors.
 
@@ -47,13 +43,11 @@ let y: &u64 = &x;
 let z: &&u64 = &y; // will not compile
 ```
 
-
 ## Reading and Writing Through References
 
 Both mutable and immutable references can be read to produce a copy of the referenced value.
 
 Only mutable references can be written. A write `*x = v` discards the value previously stored in `x` and updates it with `v`.
-
 
 Both operations use the C-like `*` syntax. However, note that a read is an expression, whereas a write is a mutation that must occur on the left hand side of an equals.
 

--- a/language/documentation/book/src/references.md
+++ b/language/documentation/book/src/references.md
@@ -40,6 +40,7 @@ fun f(a: &A): &u64 {
 ```
 
 Finally, note that references to references are not allowed:
+
 ```rust
 let x = 7;
 let y: &u64 = &x;
@@ -71,7 +72,9 @@ fun copy_resource_via_ref_bad(c: Coin) {
     pay(counterfeit);
 }
 ```
+
 Dually, writing via a resource reference is not allowed because it would destroy a resource value:
+
 ```rust=
 fun destroy_resource_via_ref_bad(ten_coins: Coin, c: Coin) {
     let ref = &mut ten_coins;
@@ -87,6 +90,7 @@ A mutable reference can be used in a context where an immutable reference is exp
 let x = 7;
 let y: &mut u64 = &mut x;
 ```
+
 This works because the under the hood, the compiler inserts `freeze` instructions where they are needed. Here are a few more examples of `freeze` inference in action:
 
 ```rust=
@@ -113,11 +117,12 @@ fun assignment_examples() {
     imm_ref = &x; // no inference
     imm_ref = &mut y; // inferred freeze(&mut y)
 }
-````
+```
 
 ### Subtyping
 
 With this `freeze` inference, the Move type checker can view `&mut T` as a subtype of `&T`. As shown above, this means that anywhere for any expression where a `&T` value is used, an `&mut T` value. This terminology is used in error messages to concisely indicate that a `&mut T` was needed where a `&T` was supplied. For example
+
 ```rust=
 address 0x42 {
 module Example {
@@ -138,7 +143,9 @@ module Example {
 }
 }
 ```
+
 will yield the following error messages
+
 ```
 error:
 

--- a/language/documentation/book/src/signer.md
+++ b/language/documentation/book/src/signer.md
@@ -1,0 +1,62 @@
+---
+id: move-signer
+title: Signer
+sidebar_label: Signer
+---
+
+`signer` is a built-in Move resource type. A `signer` is a [capability](https://en.wikipedia.org/wiki/Object-capability_model) that allows the holder to act on behalf of a particular `address`. You can think of the native implementation as being:
+
+```rust
+resource struct signer { a: address }
+```
+
+A `signer` is somewhat similar to a Unix [UID](https://en.wikipedia.org/wiki/User_identifier) in that it represents a user authenticated by code *outside* of Move (e.g., by checking a cryptographic signature or password).
+
+## Comparison to `address`
+
+A Move program can create any `address` value without special permission using address literals:
+
+```rust
+let a1 = 0x1;
+let a2 = 0x2;
+// ... and so on for every other possible address
+```
+
+However, `signer` values are special because they cannot be created via literals or instructions--only by the Move VM. Before the VM runs a script with parameters of type `signer`, it will automatically create `signer` values and pass them into the script:
+
+```rust=
+script {
+    use 0x1::Signer;
+    fun main(s: signer) {
+        assert(Signer::address_of(&s) == 0x42, 0);
+    }
+}
+```
+
+This script will abort with code `0` if the script is sent from any address other than `0x42`.
+
+A transaction script can have an arbitrary number of `signer`s as long as the signers are a prefix to any other arguments. In other words, all of the signer arguments must come first:
+
+```rust=
+script {
+    use 0x1::Signer;
+    fun main(s1: signer, s2: signer, x: u64, y: u8) {
+        // ...
+    }
+}
+```
+
+This is useful for implementing *multi-signer scripts* that atomically act with the authority of multiple parties. For example, an extension of the script above could perform an atomic currency swap between `s1` and `s2`.
+
+
+## `signer` Operators
+
+The `0x1::Signer` standard library module provides two utility functions over `signer` values:
+
+| Function | Description
+| ---------- | ----------
+| `Signer::address_of(&signer): address` | Return the `address` wrapped by this `&signer`.
+| `Signer::borrow_address(&signer): &address` | Return a reference to the `address` wrapped by this `&signer`
+
+
+In addition, the `move_to<T>(&signer, T)` [global storage operator](./global-storage-operators.md) requires a `&signer` argument to publish a resource `T` under `signer.address`'s account. This ensures that only an authenticated user can elect to publish a resource under their `address`.

--- a/language/documentation/book/src/signer.md
+++ b/language/documentation/book/src/signer.md
@@ -22,7 +22,7 @@ let a2 = 0x2;
 // ... and so on for every other possible address
 ```
 
-However, `signer` values are special because they cannot be created via literals or instructions--only by the Move VM. Before the VM runs a script with parameters of type `signer`, it will automatically create `signer` values and pass them into the script:
+However, `signer` values are special because they cannot be created via literals or instructions--only by the Move VM. Before the VM runs a script with parameters of type `&signer`, it will automatically create `signer` values and pass them into the script:
 
 ```rust=
 script {

--- a/language/documentation/book/src/signer.md
+++ b/language/documentation/book/src/signer.md
@@ -1,8 +1,4 @@
----
-id: move-signer
-title: Signer
-sidebar_label: Signer
----
+# Signer
 
 `signer` is a built-in Move resource type. A `signer` is a [capability](https://en.wikipedia.org/wiki/Object-capability_model) that allows the holder to act on behalf of a particular `address`. You can think of the native implementation as being:
 
@@ -48,7 +44,6 @@ script {
 
 This is useful for implementing *multi-signer scripts* that atomically act with the authority of multiple parties. For example, an extension of the script above could perform an atomic currency swap between `s1` and `s2`.
 
-
 ## `signer` Operators
 
 The `0x1::Signer` standard library module provides two utility functions over `signer` values:
@@ -57,6 +52,5 @@ The `0x1::Signer` standard library module provides two utility functions over `s
 | ---------- | ----------
 | `Signer::address_of(&signer): address` | Return the `address` wrapped by this `&signer`.
 | `Signer::borrow_address(&signer): &address` | Return a reference to the `address` wrapped by this `&signer`
-
 
 In addition, the `move_to<T>(&signer, T)` [global storage operator](./global-storage-operators.md) requires a `&signer` argument to publish a resource `T` under `signer.address`'s account. This ensures that only an authenticated user can elect to publish a resource under their `address`.

--- a/language/documentation/book/src/standard-library.md
+++ b/language/documentation/book/src/standard-library.md
@@ -1,0 +1,457 @@
+---
+id: move-standard-library
+title: Standard Library
+sidebar_label: Standard Library
+---
+
+The Move standard library exposes interfaces that implement the following functionality:
+* [Basic operations on vectors](#vector).
+* [Option types and operations on`Option` types](#option).
+* [A common error encoding code interface for abort codes](#errors).
+* [32-bit precision fixed-point numbers](#fixedpoint32).
+
+## <a href="vector">Vector</a>
+
+The `Vector` module defines a number of operations over the primitive
+[`vector`](./vector.md) type. The module is published under the
+core code address at `0x1` and consists of a number of native functions, as
+well as functions defined in Move. The API for this module is as follows.
+
+### Functions
+
+---------------------------------------------------------------------------
+
+Create an empty [`vector`](./vector.md).
+The `Element` type can be both a `resource` or `copyable` type.
+```rust
+    native public fun empty<Element>(): vector<Element>;
+```
+---------------------------------------------------------------------------
+
+Create a vector of length `1` containing the passed in `element`.
+```rust
+    public fun singleton<Element>(e: Element): vector<Element>;
+```
+---------------------------------------------------------------------------
+
+Destroy (deallocate) the vector `v`. Will abort if `v` is non-empty.
+*Note*: The emptiness restriction is due to the fact that `Element` can be a
+resource type, and destruction of a non-empty vector would violate
+[resource conservation](./structs-and-resources.md).
+```rust
+    native public fun destroy_empty<Element>(v: vector<Element>);
+```
+---------------------------------------------------------------------------
+
+Acquire an [immutable reference](./references.md) to the `i`th element of the vector `v`.  Will abort if
+the index `i` is out of bounds for the vector `v`.
+```rust
+    native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
+```
+---------------------------------------------------------------------------
+
+Acquire a [mutable reference](./references.md)
+to the `i`th element of the vector `v`.  Will abort if
+the index `i` is out of bounds for the vector `v`.
+```rust
+    native public fun borrow_mut<Element>(v: &mut vector<Element>, i: u64): &mut Element;
+```
+---------------------------------------------------------------------------
+
+Empty and destroy the `other` vector, and push each of the elements in
+the `other` vector onto the `lhs` vector in the same order as they occurred in `other`.
+```rust
+    public fun append<Element>(lhs: &mut vector<Element>, other: vector<Element>);
+```
+---------------------------------------------------------------------------
+
+Push an element `e` of type `Element` onto the end of the vector `v`. May
+trigger a resizing of the underlying vector's memory.
+```rust
+    native public fun push_back<Element>(v: &mut vector<Element>, e: Element);
+```
+---------------------------------------------------------------------------
+
+Pop an element from the end of the vector `v` in-place and return the owned
+value. Will abort if `v` is empty.
+```rust
+    native public fun pop_back<Element>(v: &mut vector<Element>): Element;
+```
+---------------------------------------------------------------------------
+
+Remove the element at index `i` in the vector `v` and return the owned value
+that was previously stored at `i` in `v`. All elements occurring at indices
+greater than `i` will be shifted down by 1. Will abort if `i` is out of bounds
+for `v`.
+```rust
+    public fun remove<Element>(v: &mut vector<Element>, i: u64): Element;
+```
+---------------------------------------------------------------------------
+
+Swap the `i`th element of the vector `v` with the last element and then pop
+this element off of the back of the vector and return the owned value that
+was previously stored at index `i`.
+This operation is O(1), but does not preserve ordering of elements in the vector.
+Aborts if the index `i` is out of bounds for the vector `v`.
+```rust
+    public fun swap_remove<Element>(v: &mut vector<Element>, i: u64): Element;
+```
+---------------------------------------------------------------------------
+
+Swap the elements at the `i`'th and `j`'th indices in the vector `v`. Will
+abort if either of `i` or `j` are out of bounds for `v`.
+```rust
+    native public fun swap<Element>(v: &mut vector<Element>, i: u64, j: u64);
+```
+---------------------------------------------------------------------------
+
+Reverse the order of the elements in the vector `v` in-place.
+```rust
+    public fun reverse<Element>(v: &mut vector<Element>);
+```
+---------------------------------------------------------------------------
+
+Return the index of the first occurrence of an element in `v` that is
+equal to `e`. Returns `(true, index)` if such an element was found, and
+`(false, 0)` otherwise.
+```rust
+    public fun index_of<Element>(v: &vector<Element>, e: &Element): (bool, u64);
+```
+---------------------------------------------------------------------------
+
+Return if an element equal to `e` exists in the vector `v`.
+```rust
+    public fun contains<Element>(v: &vector<Element>, e: &Element): bool;
+```
+---------------------------------------------------------------------------
+
+Return the length of a `vector`.
+```rust
+    native public fun length<Element>(v: &vector<Element>): u64;
+```
+---------------------------------------------------------------------------
+
+Return whether the vector `v` is empty.
+```rust
+    public fun is_empty<Element>(v: &vector<Element>): bool;
+```
+---------------------------------------------------------------------------
+
+## <a href="option">Option</a>
+
+The `Option` module defines a generic option type `Option<T>` that represents a
+value of type `T` that may, or may not, be present. It is published under the core code address at `0x1`.
+
+The Move option type is internally represented as a singleton vector, and may
+contain a value of `resource` or `copyable` kind.  If you are familiar with option
+types in other languages, the Move `Option` behaves similarly to those with a
+couple notable exceptions since the option can contain a value of kind `resource`.
+Particularly, certain operations such as `get_with_default` and
+`destroy_with_default` require that the element type `T` be of `copyable` kind.
+
+The API for the `Option` module is as as follows
+
+### Types
+
+Generic type abstraction of a value that may, or may not, be present. Can contain
+a value of either `resource` or `copyable` kind.
+```rust
+    struct Option<T>;
+```
+
+### Functions
+
+Create an empty `Option` of that can contain a value of `Element` type.
+```rust
+    public fun none<Element>(): Option<Element>;
+```
+---------------------------------------------------------------------------
+
+Create a non-empty `Option` type containing a value `e` of type `Element`.
+```rust
+    public fun some<Element>(e: T): Option<Element>;
+```
+---------------------------------------------------------------------------
+
+Return an immutable reference to the value inside the option `opt_elem`
+Will abort if `opt_elem` does not contain a value.
+```rust
+    public fun borrow<Element>(opt_elem: &Option<Element>): &Element;
+```
+---------------------------------------------------------------------------
+
+Return a reference to the value inside `opt_elem` if it contains one. If
+`opt_elem` does not contain a value the passed in `default_ref` reference will be returned.
+Does not abort.
+```rust
+    public fun borrow_with_default<Element>(opt_elem: &Option<Element>, default_ref: &Element): &Element;
+```
+---------------------------------------------------------------------------
+
+Return a mutable reference to the value inside `opt_elem`. Will abort if
+`opt_elem` does not contain a value.
+```rust
+    public fun borrow_mut<Element>(opt_elem: &mut Option<Element>): &mut Element;
+```
+---------------------------------------------------------------------------
+
+Convert an option value that contains a value to one that is empty in-place by
+removing and returning the value stored inside `opt_elem`.
+Will abort if `opt_elem` does not contain a value.
+```rust
+    public fun extract<Element>(opt_elem: &mut Option<Element>): Element;
+```
+---------------------------------------------------------------------------
+
+Return the value contained inside the option `opt_elem` if it contains one.
+Will return the passed in `default` value if `opt_elem` does not contain a
+value. The `Element` type that the `Option` type is instantiated with must be
+of `copyable` kind in order for this function to be callable.
+```rust
+    public fun get_with_default<Element: copyable>(opt_elem: &Option<Element>, default: Element): Element;
+```
+---------------------------------------------------------------------------
+
+Convert an empty option `opt_elem` to an option value that contains the value `e`.
+Will abort if `opt_elem` already contains a value.
+```rust
+    public fun fill<Element>(opt_elem: &mut Option<Element>, e: Element);
+```
+---------------------------------------------------------------------------
+
+Swap the value currently contained in `opt_elem` with `new_elem` and return the
+previously contained value. Will abort if `opt_elem` does not contain a value.
+```rust
+    public fun swap<Element>(opt_elem: &mut Option<Element>, e: Element): Element;
+```
+---------------------------------------------------------------------------
+
+Return true if `opt_elem` contains a value equal to the value of `e_ref`.
+Otherwise, `false` will be returned.
+```rust
+    public fun contains<Element>(opt_elem: &Option<Element>, e_ref: &Element): bool;
+```
+---------------------------------------------------------------------------
+
+Return `true` if `opt_elem` does not contain a value.
+```rust
+    public fun is_none<Element>(opt_elem: &Option<Element>): bool;
+```
+---------------------------------------------------------------------------
+
+Return `true` if `opt_elem` contains a value.
+```rust
+    public fun is_some<Element>(opt_elem: &Option<Element>): bool;
+```
+
+---------------------------------------------------------------------------
+
+Unpack `opt_elem` and return the value that it contained.
+Will abort if `opt_elem` does not contain a value.
+```rust
+    public fun destroy_some<Element>(opt_elem: Option<Element>): Element;
+```
+---------------------------------------------------------------------------
+
+Destroys the `opt_elem` value passed in. If `opt_elem` contained a value it
+will be returned otherwise, the passed in `default` value will be returned.
+```rust
+    public fun destroy_with_default<Element: copyable>(opt_elem: Option<Element>, default: Element): Element;
+```
+---------------------------------------------------------------------------
+
+Destroys the `opt_elem` value passed in, `opt_elem` must be empty and not
+contain a value. Will abort if `opt_elem` contains a value.
+```rust
+    public fun destroy_none<Element>(opt_elem: Option<Element>);
+```
+
+## Errors
+
+Recall that each abort code in Move is represented as an unsigned 64-bit integer. The `Errors` module defines a common interface that can be used to "tag" each of these abort codes so that they can represent both the error **category** along with an error **reason**.
+
+Error categories are declared as constants in the `Errors` module and are globally unique with respect to this module. Error reasons on the other hand are module-specific error codes, and can provide greater detail (perhaps, even a particular _reason_) about the specific error condition. This representation of a category and reason for each error code is done by dividing the abort code into two sections.
+
+The lower 8 bits of the abort code hold the *error category*. The remaining 56 bits of the abort code hold the *error reason*.
+The reason should be a unique number relative to the module which raised the error and can be used to obtain more information about the error at hand. It should mostly be used for diagnostic purposes as error reasons may change over time if the module is updated.
+
+![Error bits](/img/docs/standard-library-error-bits.png)
+
+Since error categories are globally stable, these present the most stable API and should in general be what is used by clients to determine the messages they may present to users (whereas the reason is useful for diagnostic purposes). There are public functions in the `Errors` module for creating an abort code of each error category with a specific `reason` number (represented as a `u64`).
+
+### Constants
+
+
+The system is in a state where the performed operation is not allowed.
+```rust
+    const INVALID_STATE: u8 = 1;
+```
+
+---------------------------------------------------------------------------
+A specific account address was required to perform an operation, but a different address from what was expected was encounterd.
+```rust
+    const REQUIRES_ADDRESS: u8 = 2;
+```
+
+---------------------------------------------------------------------------
+An account did not have the expected  role for this operation. Useful for Role Based Access Control (RBAC) error conditions.
+```rust
+    const REQUIRES_ROLE: u8 = 3;
+```
+
+---------------------------------------------------------------------------
+An account did not not have a required capability. Useful for RBAC error conditions.
+```rust
+    const REQUIRES_CAPABILITY: u8 = 4;
+```
+
+---------------------------------------------------------------------------
+A resource was expected, but did not exist under an address.
+```rust
+    const NOT_PUBLISHED: u8 = 5;
+```
+
+---------------------------------------------------------------------------
+Attempted to publish a resource under an address where one was already published.
+```rust
+    const ALREADY_PUBLISHED: u8 = 6;
+```
+
+---------------------------------------------------------------------------
+An argument provided for an operation was invalid.
+```rust
+    const INVALID_ARGUMENT: u8 = 7;
+```
+
+---------------------------------------------------------------------------
+A limit on a value was exceeded.
+```rust
+    const LIMIT_EXCEEDED: u8 = 8;
+```
+
+---------------------------------------------------------------------------
+An internal error (bug) has occurred.
+```rust
+    const INTERNAL: u8 = 10;
+```
+
+---------------------------------------------------------------------------
+A custom error category for extension points.
+```rust
+    const CUSTOM: u8 = 255;
+```
+---------------------------------------------------------------------------
+
+### Functions
+
+ Should be used in the case where invalid (global) state is encountered. Constructs an abort code with specified `reason` and category `INVALID_STATE`. Will abort if `reason` does not fit in 56 bits.
+```rust
+    public fun invalid_state(reason: u64): u64;
+```
+
+---------------------------------------------------------------------------
+Should be used if an account's address does not match a specific address. Constructs an abort code with specified `reason` and category `REQUIRES_ADDRESS`. Will abort if `reason` does not fit in 56 bits.
+```rust
+    public fun requires_address(reason: u64): u64;
+```
+
+---------------------------------------------------------------------------
+Should be used if a role did not match a required role when using RBAC. Constructs an abort code with specified `reason` and category `REQUIRES_ROLE`. Will abort if `reason` does not fit in 56 bits.
+```rust
+    public fun requires_role(reason: u64): u64;
+```
+
+---------------------------------------------------------------------------
+Should be used if an account did not have a required capability when using RBAC. Constructs an abort code with specified `reason` and category `REQUIRES_CAPABILITY`. Should be Will abort if `reason` does not fit in 56 bits.
+```rust
+    public fun requires_capability(reason: u64): u64;
+```
+
+---------------------------------------------------------------------------
+Should be used if a resource did not exist where one was expected. Constructs an abort code with specified `reason` and category `NOT_PUBLISHED`. Will abort if `reason` does not fit in 56 bits.
+```rust
+    public fun not_published(reason: u64): u64;
+```
+
+---------------------------------------------------------------------------
+Should be used if a resource already existed where one was about to be published. Constructs an abort code with specified `reason` and category `ALREADY_PUBLISHED`. Will abort if `reason` does not fit in 56 bits.
+```rust
+    public fun already_published(reason: u64): u64;
+```
+
+---------------------------------------------------------------------------
+Should be used if an invalid argument was passed to a function/operation. Constructs an abort code with specified `reason` and category `INVALID_ARGUMENT`. Will abort if `reason` does not fit in 56 bits.
+```rust
+    public fun invalid_argument(reason: u64): u64;
+```
+
+---------------------------------------------------------------------------
+Should be used if a limit on a specific value is reached, e.g., subtracting 1 from a value of 0. Constructs an abort code with specified `reason` and category `LIMIT_EXCEEDED`. Will abort if `reason` does not fit in 56 bits.
+```rust
+    public fun limit_exceeded(reason: u64): u64;
+```
+
+---------------------------------------------------------------------------
+Should be used if an internal error or bug was encountered. Constructs an abort code with specified `reason` and category `INTERNAL`. Will abort if `reason` does not fit in 56 bits.
+```rust
+    public fun internal(reason: u64): u64;
+```
+
+---------------------------------------------------------------------------
+Used for extension points, should be not used under most circumstances. Constructs an abort code with specified `reason` and category `CUSTOM`. Will abort if `reason` does not fit in 56 bits.
+```rust
+    public fun custom(reason: u64): u64;
+```
+
+---------------------------------------------------------------------------
+
+## <a href="fixedpoint32">FixedPoint32</a>
+
+
+The `FixedPoint32` module defines a fixed-point numeric type with 32 integer bits and 32 fractional bits. Internally, this is represented as a `u64` integer wrapped in a struct to make a unique `FixedPoint32` type. Since the numeric representation is a binary one, some decimal values may not be exactly representable, but it provides more than 9 decimal digits of precision both before and after the decimal point (18 digits total). For comparison, double precision floating-point has less than 16 decimal digits of precision, so you should be careful about using floating-point to convert these values to decimal.
+
+### Types
+
+
+Represents a fixed-point numeric number with 32 fractional bits.
+```rust
+    struct FixedPoint32;
+```
+
+### Functions
+
+Multiply a u64 integer by a fixed-point number, truncating any fractional part of the product. This will abort if the product overflows.
+```rust
+    public fun multiply_u64(val: u64, multiplier: FixedPoint32): u64;
+```
+
+---------------------------------------------------------------------------
+Divide a u64 integer by a fixed-point number, truncating any fractional part of the quotient. This will abort if the divisor is zero or if the quotient overflows.
+```rust
+    public fun divide_u64(val: u64, divisor: FixedPoint32): u64;
+```
+
+---------------------------------------------------------------------------
+Create a fixed-point value from a rational number specified by its numerator and denominator. Calling this function should be preferred for using `FixedPoint32::create_from_raw_value` which is also available. This will abort if the denominator is zero. It will also abort if the numerator is nonzero and the ratio is not in the range $2^{-32}\ldots2^{32}-1$. When specifying decimal fractions, be careful about rounding errors: if you round to display $N$ digits after the decimal point, you can use a denominator of $10^N$ to avoid numbers where the very small imprecision in the binary representation could change the rounding, e.g., 0.0125 will round down to 0.012 instead of up to 0.013.
+```rust
+    public fun create_from_rational(numerator: u64, denominator: u64): FixedPoint32;
+```
+
+---------------------------------------------------------------------------
+Create a fixedpoint value from a raw `u64` value.
+```rust
+    public fun create_from_raw_value(value: u64): FixedPoint32;
+```
+
+---------------------------------------------------------------------------
+Returns `true` if the decimal value of `num` is equal to zero.
+```rust
+    public fun is_zero(num: FixedPoint32): bool;
+```
+
+---------------------------------------------------------------------------
+Accessor for the raw `u64` value. Other less common operations, such as adding or subtracting `FixedPoint32` values, can be done using the raw values directly.
+```rust
+    public fun get_raw_value(num: FixedPoint32): u64;
+```
+---------------------------------------------------------------------------

--- a/language/documentation/book/src/standard-library.md
+++ b/language/documentation/book/src/standard-library.md
@@ -1,8 +1,4 @@
----
-id: move-standard-library
-title: Standard Library
-sidebar_label: Standard Library
----
+# Standard Library
 
 The Move standard library exposes interfaces that implement the following functionality:
 * [Basic operations on vectors](#vector).

--- a/language/documentation/book/src/standard-library.md
+++ b/language/documentation/book/src/standard-library.md
@@ -23,69 +23,87 @@ well as functions defined in Move. The API for this module is as follows.
 
 Create an empty [`vector`](./vector.md).
 The `Element` type can be both a `resource` or `copyable` type.
+
 ```rust
     native public fun empty<Element>(): vector<Element>;
 ```
+
 ---------------------------------------------------------------------------
 
 Create a vector of length `1` containing the passed in `element`.
+
 ```rust
     public fun singleton<Element>(e: Element): vector<Element>;
 ```
+
 ---------------------------------------------------------------------------
 
 Destroy (deallocate) the vector `v`. Will abort if `v` is non-empty.
 *Note*: The emptiness restriction is due to the fact that `Element` can be a
 resource type, and destruction of a non-empty vector would violate
 [resource conservation](./structs-and-resources.md).
+
 ```rust
     native public fun destroy_empty<Element>(v: vector<Element>);
 ```
+
 ---------------------------------------------------------------------------
 
 Acquire an [immutable reference](./references.md) to the `i`th element of the vector `v`.  Will abort if
 the index `i` is out of bounds for the vector `v`.
+
 ```rust
     native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
 ```
+
 ---------------------------------------------------------------------------
 
 Acquire a [mutable reference](./references.md)
 to the `i`th element of the vector `v`.  Will abort if
 the index `i` is out of bounds for the vector `v`.
+
 ```rust
     native public fun borrow_mut<Element>(v: &mut vector<Element>, i: u64): &mut Element;
 ```
+
 ---------------------------------------------------------------------------
 
 Empty and destroy the `other` vector, and push each of the elements in
 the `other` vector onto the `lhs` vector in the same order as they occurred in `other`.
+
 ```rust
     public fun append<Element>(lhs: &mut vector<Element>, other: vector<Element>);
 ```
+
 ---------------------------------------------------------------------------
 
 Push an element `e` of type `Element` onto the end of the vector `v`. May
 trigger a resizing of the underlying vector's memory.
+
 ```rust
     native public fun push_back<Element>(v: &mut vector<Element>, e: Element);
 ```
+
 ---------------------------------------------------------------------------
 
 Pop an element from the end of the vector `v` in-place and return the owned
 value. Will abort if `v` is empty.
+
 ```rust
     native public fun pop_back<Element>(v: &mut vector<Element>): Element;
 ```
+
 ---------------------------------------------------------------------------
 
 Remove the element at index `i` in the vector `v` and return the owned value
 that was previously stored at `i` in `v`. All elements occurring at indices
 greater than `i` will be shifted down by 1. Will abort if `i` is out of bounds
 for `v`.
+
 ```rust
     public fun remove<Element>(v: &mut vector<Element>, i: u64): Element;
 ```
+
 ---------------------------------------------------------------------------
 
 Swap the `i`th element of the vector `v` with the last element and then pop
@@ -93,48 +111,62 @@ this element off of the back of the vector and return the owned value that
 was previously stored at index `i`.
 This operation is O(1), but does not preserve ordering of elements in the vector.
 Aborts if the index `i` is out of bounds for the vector `v`.
+
 ```rust
     public fun swap_remove<Element>(v: &mut vector<Element>, i: u64): Element;
 ```
+
 ---------------------------------------------------------------------------
 
 Swap the elements at the `i`'th and `j`'th indices in the vector `v`. Will
 abort if either of `i` or `j` are out of bounds for `v`.
+
 ```rust
     native public fun swap<Element>(v: &mut vector<Element>, i: u64, j: u64);
 ```
+
 ---------------------------------------------------------------------------
 
 Reverse the order of the elements in the vector `v` in-place.
+
 ```rust
     public fun reverse<Element>(v: &mut vector<Element>);
 ```
+
 ---------------------------------------------------------------------------
 
 Return the index of the first occurrence of an element in `v` that is
 equal to `e`. Returns `(true, index)` if such an element was found, and
 `(false, 0)` otherwise.
+
 ```rust
     public fun index_of<Element>(v: &vector<Element>, e: &Element): (bool, u64);
 ```
+
 ---------------------------------------------------------------------------
 
 Return if an element equal to `e` exists in the vector `v`.
+
 ```rust
     public fun contains<Element>(v: &vector<Element>, e: &Element): bool;
 ```
+
 ---------------------------------------------------------------------------
 
 Return the length of a `vector`.
+
 ```rust
     native public fun length<Element>(v: &vector<Element>): u64;
 ```
+
 ---------------------------------------------------------------------------
 
 Return whether the vector `v` is empty.
+
 ```rust
     public fun is_empty<Element>(v: &vector<Element>): bool;
 ```
+
 ---------------------------------------------------------------------------
 
 ## Option
@@ -155,6 +187,7 @@ The API for the `Option` module is as as follows
 
 Generic type abstraction of a value that may, or may not, be present. Can contain
 a value of either `resource` or `copyable` kind.
+
 ```rust
     struct Option<T>;
 ```
@@ -162,84 +195,107 @@ a value of either `resource` or `copyable` kind.
 ### Functions
 
 Create an empty `Option` of that can contain a value of `Element` type.
+
 ```rust
     public fun none<Element>(): Option<Element>;
 ```
+
 ---------------------------------------------------------------------------
 
 Create a non-empty `Option` type containing a value `e` of type `Element`.
+
 ```rust
     public fun some<Element>(e: T): Option<Element>;
 ```
+
 ---------------------------------------------------------------------------
 
 Return an immutable reference to the value inside the option `opt_elem`
 Will abort if `opt_elem` does not contain a value.
+
 ```rust
     public fun borrow<Element>(opt_elem: &Option<Element>): &Element;
 ```
+
 ---------------------------------------------------------------------------
 
 Return a reference to the value inside `opt_elem` if it contains one. If
 `opt_elem` does not contain a value the passed in `default_ref` reference will be returned.
 Does not abort.
+
 ```rust
     public fun borrow_with_default<Element>(opt_elem: &Option<Element>, default_ref: &Element): &Element;
 ```
+
 ---------------------------------------------------------------------------
 
 Return a mutable reference to the value inside `opt_elem`. Will abort if
 `opt_elem` does not contain a value.
+
 ```rust
     public fun borrow_mut<Element>(opt_elem: &mut Option<Element>): &mut Element;
 ```
+
 ---------------------------------------------------------------------------
 
 Convert an option value that contains a value to one that is empty in-place by
 removing and returning the value stored inside `opt_elem`.
 Will abort if `opt_elem` does not contain a value.
+
 ```rust
     public fun extract<Element>(opt_elem: &mut Option<Element>): Element;
 ```
+
 ---------------------------------------------------------------------------
 
 Return the value contained inside the option `opt_elem` if it contains one.
 Will return the passed in `default` value if `opt_elem` does not contain a
 value. The `Element` type that the `Option` type is instantiated with must be
 of `copyable` kind in order for this function to be callable.
+
 ```rust
     public fun get_with_default<Element: copyable>(opt_elem: &Option<Element>, default: Element): Element;
 ```
+
 ---------------------------------------------------------------------------
 
 Convert an empty option `opt_elem` to an option value that contains the value `e`.
 Will abort if `opt_elem` already contains a value.
+
 ```rust
     public fun fill<Element>(opt_elem: &mut Option<Element>, e: Element);
 ```
+
 ---------------------------------------------------------------------------
 
 Swap the value currently contained in `opt_elem` with `new_elem` and return the
 previously contained value. Will abort if `opt_elem` does not contain a value.
+
 ```rust
     public fun swap<Element>(opt_elem: &mut Option<Element>, e: Element): Element;
 ```
+
 ---------------------------------------------------------------------------
 
 Return true if `opt_elem` contains a value equal to the value of `e_ref`.
 Otherwise, `false` will be returned.
+
 ```rust
     public fun contains<Element>(opt_elem: &Option<Element>, e_ref: &Element): bool;
 ```
+
 ---------------------------------------------------------------------------
 
 Return `true` if `opt_elem` does not contain a value.
+
 ```rust
     public fun is_none<Element>(opt_elem: &Option<Element>): bool;
 ```
+
 ---------------------------------------------------------------------------
 
 Return `true` if `opt_elem` contains a value.
+
 ```rust
     public fun is_some<Element>(opt_elem: &Option<Element>): bool;
 ```
@@ -248,20 +304,25 @@ Return `true` if `opt_elem` contains a value.
 
 Unpack `opt_elem` and return the value that it contained.
 Will abort if `opt_elem` does not contain a value.
+
 ```rust
     public fun destroy_some<Element>(opt_elem: Option<Element>): Element;
 ```
+
 ---------------------------------------------------------------------------
 
 Destroys the `opt_elem` value passed in. If `opt_elem` contained a value it
 will be returned otherwise, the passed in `default` value will be returned.
+
 ```rust
     public fun destroy_with_default<Element: copyable>(opt_elem: Option<Element>, default: Element): Element;
 ```
+
 ---------------------------------------------------------------------------
 
 Destroys the `opt_elem` value passed in, `opt_elem` must be empty and not
 contain a value. Will abort if `opt_elem` contains a value.
+
 ```rust
     public fun destroy_none<Element>(opt_elem: Option<Element>);
 ```
@@ -283,124 +344,144 @@ Since error categories are globally stable, these present the most stable API an
 
 ### Constants
 
-
 The system is in a state where the performed operation is not allowed.
+
 ```rust
     const INVALID_STATE: u8 = 1;
 ```
 
 ---------------------------------------------------------------------------
 A specific account address was required to perform an operation, but a different address from what was expected was encounterd.
+
 ```rust
     const REQUIRES_ADDRESS: u8 = 2;
 ```
 
 ---------------------------------------------------------------------------
 An account did not have the expected  role for this operation. Useful for Role Based Access Control (RBAC) error conditions.
+
 ```rust
     const REQUIRES_ROLE: u8 = 3;
 ```
 
 ---------------------------------------------------------------------------
 An account did not not have a required capability. Useful for RBAC error conditions.
+
 ```rust
     const REQUIRES_CAPABILITY: u8 = 4;
 ```
 
 ---------------------------------------------------------------------------
 A resource was expected, but did not exist under an address.
+
 ```rust
     const NOT_PUBLISHED: u8 = 5;
 ```
 
 ---------------------------------------------------------------------------
 Attempted to publish a resource under an address where one was already published.
+
 ```rust
     const ALREADY_PUBLISHED: u8 = 6;
 ```
 
 ---------------------------------------------------------------------------
 An argument provided for an operation was invalid.
+
 ```rust
     const INVALID_ARGUMENT: u8 = 7;
 ```
 
 ---------------------------------------------------------------------------
 A limit on a value was exceeded.
+
 ```rust
     const LIMIT_EXCEEDED: u8 = 8;
 ```
 
 ---------------------------------------------------------------------------
 An internal error (bug) has occurred.
+
 ```rust
     const INTERNAL: u8 = 10;
 ```
 
 ---------------------------------------------------------------------------
 A custom error category for extension points.
+
 ```rust
     const CUSTOM: u8 = 255;
 ```
+
 ---------------------------------------------------------------------------
 
 ### Functions
 
  Should be used in the case where invalid (global) state is encountered. Constructs an abort code with specified `reason` and category `INVALID_STATE`. Will abort if `reason` does not fit in 56 bits.
+
 ```rust
     public fun invalid_state(reason: u64): u64;
 ```
 
 ---------------------------------------------------------------------------
 Should be used if an account's address does not match a specific address. Constructs an abort code with specified `reason` and category `REQUIRES_ADDRESS`. Will abort if `reason` does not fit in 56 bits.
+
 ```rust
     public fun requires_address(reason: u64): u64;
 ```
 
 ---------------------------------------------------------------------------
 Should be used if a role did not match a required role when using RBAC. Constructs an abort code with specified `reason` and category `REQUIRES_ROLE`. Will abort if `reason` does not fit in 56 bits.
+
 ```rust
     public fun requires_role(reason: u64): u64;
 ```
 
 ---------------------------------------------------------------------------
 Should be used if an account did not have a required capability when using RBAC. Constructs an abort code with specified `reason` and category `REQUIRES_CAPABILITY`. Should be Will abort if `reason` does not fit in 56 bits.
+
 ```rust
     public fun requires_capability(reason: u64): u64;
 ```
 
 ---------------------------------------------------------------------------
 Should be used if a resource did not exist where one was expected. Constructs an abort code with specified `reason` and category `NOT_PUBLISHED`. Will abort if `reason` does not fit in 56 bits.
+
 ```rust
     public fun not_published(reason: u64): u64;
 ```
 
 ---------------------------------------------------------------------------
 Should be used if a resource already existed where one was about to be published. Constructs an abort code with specified `reason` and category `ALREADY_PUBLISHED`. Will abort if `reason` does not fit in 56 bits.
+
 ```rust
     public fun already_published(reason: u64): u64;
 ```
 
 ---------------------------------------------------------------------------
 Should be used if an invalid argument was passed to a function/operation. Constructs an abort code with specified `reason` and category `INVALID_ARGUMENT`. Will abort if `reason` does not fit in 56 bits.
+
 ```rust
     public fun invalid_argument(reason: u64): u64;
 ```
 
 ---------------------------------------------------------------------------
 Should be used if a limit on a specific value is reached, e.g., subtracting 1 from a value of 0. Constructs an abort code with specified `reason` and category `LIMIT_EXCEEDED`. Will abort if `reason` does not fit in 56 bits.
+
 ```rust
     public fun limit_exceeded(reason: u64): u64;
 ```
 
 ---------------------------------------------------------------------------
 Should be used if an internal error or bug was encountered. Constructs an abort code with specified `reason` and category `INTERNAL`. Will abort if `reason` does not fit in 56 bits.
+
 ```rust
     public fun internal(reason: u64): u64;
 ```
 
 ---------------------------------------------------------------------------
 Used for extension points, should be not used under most circumstances. Constructs an abort code with specified `reason` and category `CUSTOM`. Will abort if `reason` does not fit in 56 bits.
+
 ```rust
     public fun custom(reason: u64): u64;
 ```
@@ -416,6 +497,7 @@ The `FixedPoint32` module defines a fixed-point numeric type with 32 integer bit
 
 
 Represents a fixed-point numeric number with 32 fractional bits.
+
 ```rust
     struct FixedPoint32;
 ```
@@ -423,37 +505,44 @@ Represents a fixed-point numeric number with 32 fractional bits.
 ### Functions
 
 Multiply a u64 integer by a fixed-point number, truncating any fractional part of the product. This will abort if the product overflows.
+
 ```rust
     public fun multiply_u64(val: u64, multiplier: FixedPoint32): u64;
 ```
 
 ---------------------------------------------------------------------------
 Divide a u64 integer by a fixed-point number, truncating any fractional part of the quotient. This will abort if the divisor is zero or if the quotient overflows.
+
 ```rust
     public fun divide_u64(val: u64, divisor: FixedPoint32): u64;
 ```
 
 ---------------------------------------------------------------------------
 Create a fixed-point value from a rational number specified by its numerator and denominator. Calling this function should be preferred for using `FixedPoint32::create_from_raw_value` which is also available. This will abort if the denominator is zero. It will also abort if the numerator is nonzero and the ratio is not in the range $2^{-32}\ldots2^{32}-1$. When specifying decimal fractions, be careful about rounding errors: if you round to display $N$ digits after the decimal point, you can use a denominator of $10^N$ to avoid numbers where the very small imprecision in the binary representation could change the rounding, e.g., 0.0125 will round down to 0.012 instead of up to 0.013.
+
 ```rust
     public fun create_from_rational(numerator: u64, denominator: u64): FixedPoint32;
 ```
 
 ---------------------------------------------------------------------------
 Create a fixedpoint value from a raw `u64` value.
+
 ```rust
     public fun create_from_raw_value(value: u64): FixedPoint32;
 ```
 
 ---------------------------------------------------------------------------
 Returns `true` if the decimal value of `num` is equal to zero.
+
 ```rust
     public fun is_zero(num: FixedPoint32): bool;
 ```
 
 ---------------------------------------------------------------------------
 Accessor for the raw `u64` value. Other less common operations, such as adding or subtracting `FixedPoint32` values, can be done using the raw values directly.
+
 ```rust
     public fun get_raw_value(num: FixedPoint32): u64;
 ```
+
 ---------------------------------------------------------------------------

--- a/language/documentation/book/src/standard-library.md
+++ b/language/documentation/book/src/standard-library.md
@@ -10,7 +10,7 @@ The Move standard library exposes interfaces that implement the following functi
 * [A common error encoding code interface for abort codes](#errors).
 * [32-bit precision fixed-point numbers](#fixedpoint32).
 
-## <a href="vector">Vector</a>
+## Vector
 
 The `Vector` module defines a number of operations over the primitive
 [`vector`](./vector.md) type. The module is published under the
@@ -137,7 +137,7 @@ Return whether the vector `v` is empty.
 ```
 ---------------------------------------------------------------------------
 
-## <a href="option">Option</a>
+## Option
 
 The `Option` module defines a generic option type `Option<T>` that represents a
 value of type `T` that may, or may not, be present. It is published under the core code address at `0x1`.
@@ -275,7 +275,9 @@ Error categories are declared as constants in the `Errors` module and are global
 The lower 8 bits of the abort code hold the *error category*. The remaining 56 bits of the abort code hold the *error reason*.
 The reason should be a unique number relative to the module which raised the error and can be used to obtain more information about the error at hand. It should mostly be used for diagnostic purposes as error reasons may change over time if the module is updated.
 
-![Error bits](/img/docs/standard-library-error-bits.png)
+| Category | Reason |
+|----------|--------|
+| 8 bits   | 56 bits|
 
 Since error categories are globally stable, these present the most stable API and should in general be what is used by clients to determine the messages they may present to users (whereas the reason is useful for diagnostic purposes). There are public functions in the `Errors` module for creating an abort code of each error category with a specific `reason` number (represented as a `u64`).
 
@@ -405,7 +407,7 @@ Used for extension points, should be not used under most circumstances. Construc
 
 ---------------------------------------------------------------------------
 
-## <a href="fixedpoint32">FixedPoint32</a>
+## FixedPoint32
 
 
 The `FixedPoint32` module defines a fixed-point numeric type with 32 integer bits and 32 fractional bits. Internally, this is represented as a `u64` integer wrapped in a struct to make a unique `FixedPoint32` type. Since the numeric representation is a binary one, some decimal values may not be exactly representable, but it provides more than 9 decimal digits of precision both before and after the decimal point (18 digits total). For comparison, double precision floating-point has less than 16 decimal digits of precision, so you should be careful about using floating-point to convert these values to decimal.

--- a/language/documentation/book/src/structs-and-resources.md
+++ b/language/documentation/book/src/structs-and-resources.md
@@ -1,0 +1,453 @@
+---
+id: move-structs-and-resources
+title: Structs and Resources
+sidebar_label: Structs and Resources
+---
+
+A *struct* is a user-defined data structure containing typed fields. Structs can store any non-reference type, including other structs.
+
+A *resource* is a kind of struct that cannot be copied and cannot be dropped. All resource values must have ownership transferred by the end of the function. Resources are used to define global storage schemas, and Only resource structs can be saved directly into global storage.
+
+## Defining Structs
+
+Structs must be defined inside a module:
+```rust
+address 0x2 {
+module M {
+    struct Foo { x: u64, y: bool }
+    struct Bar {}
+    struct Baz { foo: Foo, }
+    //                   ^ note: it is fine to have a trailing comma
+}
+}
+```
+Structs cannot be recursive, so the following definition is invalid:
+```rust=
+struct Foo { x: Foo }
+//              ^ error! Foo cannot contain Foo
+```
+Struct definitions can be annotated with the `resource` modifier, which imposes a few additional constraints on the type, but also enables it to be used in global storage. We will cover the details later in this tutorial.
+```rust=
+address 0x2 {
+module M {
+    resource struct Foo { x: u64, y: bool }
+}
+}
+```
+Note: the term `resource struct` is a little bit cumbersome so in many places we just call it `resource`.
+
+### Naming
+
+Structs must start with a capital letter `A` to `Z`. After the first letter, constant names can contain underscores `_`, letters `a` to `z`, letters `A` to `Z`, or digits `0` to `9`.
+```rust
+struct Foo {}
+struct BAR {}
+struct B_a_z_4_2 {}
+```
+
+This naming restriction of starting with `A` to `Z` is in place to give room for future language features. It may or may not be removed later.
+
+
+## Using Structs
+
+### Creating Structs
+
+Values of a struct type can be created (or "packed") by indicating the struct name, followed by value for each field:
+
+```rust=
+address 0x2 {
+module M {
+    struct Foo { x: u64, y: bool }
+    struct Baz { foo: Foo }
+
+    fun example() {
+        let foo = Foo { x: 0, y: false };
+        let baz = Baz { foo: foo };
+    }
+}
+}
+```
+
+If you initialize a struct field with a local variable whose name is the same as the field, you can use the following shorthand:
+```rust
+let baz = Baz { foo: foo };
+// is equivalent to
+let baz = Baz { foo };
+```
+
+This is called sometimes called "field name punning".
+
+### Destroying Structs via Pattern Matching
+
+Struct values can be destroyed by binding or assigning them patterns.
+```rust=
+address 0x2 {
+module M {
+    struct Foo { x: u64, y: bool }
+    struct Bar { foo: Foo }
+    struct Baz {}
+
+    fun example_destroy_foo() {
+        let foo = Foo { x: 3, y: false };
+        let Foo { x, y: foo_y } = foo;
+        //        ^ shorthand for `x: x`
+
+        // two new bindings
+        //   x: u64 = 3
+        //   foo_y: bool = false
+    }
+
+    fun example_destroy_foo_wildcard() {
+        let foo = Foo { x: 3, y: false };
+        let Foo { x, y: _ } = foo;
+        // only one new binding since y was bound to a wildcard
+        //   x: u64 = 3
+    }
+
+    fun example_destroy_foo_assignment() {
+        let x: u64;
+        let y: bool;
+        Foo { x, y } = Foo { x: 3, y: false };
+        // mutating existing variables x & y
+        //   x = 3, y = false
+    }
+
+    fun example_foo_ref() {
+        let foo = Foo { x: 3, y: false };
+        let Foo { x, y } = &foo;
+        // two new bindings
+        //   x: &u64
+        //   y: &bool
+    }
+
+    fun example_foo_ref_mut() {
+        let foo = Foo { x: 3, y: false };
+        let Foo { x, y } = &mut foo;
+        // two new bindings
+        //   x: &mut u64
+        //   y: &mut bool
+    }
+
+    fun example_destroy_bar() {
+        let bar = Bar { foo: Foo { x: 3, y: false } };
+        let Bar { foo: Foo { x, y } } = bar;
+        //             ^ nested pattern
+        // two new bindings
+        //   x: u64 = 3
+        //   foo_y: bool = false
+    }
+
+    fun example_destroy_baz() {
+        let baz = Baz {};
+        let Baz {} = baz;
+    }
+}
+}
+```
+
+### Borrowing Structs and Fields
+
+The `&` and `&mut` operator can be used to create references to structs or fields. These examples include some optional type annotations (e.g., `:& Foo`) to demonstrate the type of operations.
+```rust=
+let foo = Foo { x: 3, y: true };
+let foo_ref: &Foo = &foo;
+let y: bool = foo_ref.y;          // reading a field via a reference to the struct
+let x_ref: &u64 = &foo.x;
+
+let x_ref_mut: &mut u64 = &mut foo.x;
+*x_ref_mut = 42;            // modifying a field via a mutable reference
+```
+It is possible to borrow inner fields of nested structs.
+```rust=
+let foo = Foo { x: 3, y: true };
+let bar = Bar { foo };
+
+let x_ref = &bar.foo.x;
+```
+You can also borrow a field via a reference to a struct.
+```rust=
+let foo = Foo { x: 3, y: true };
+let foo_ref = &foo;
+let x_ref = &foo_ref.x;
+// this has the same effect as let x_ref = &foo.x
+```
+
+### Reading and Writing Fields
+
+If you need to read and copy a field's value, you can then dereference the borrowed field
+```rust=
+let foo = Foo { x: 3, y: true };
+let bar = Bar { foo: copy foo };
+let x: u64 = *&foo.x;
+let y: bool = *&foo.y;
+let foo2: Foo = *&foo.bar;
+```
+
+If the field is an implicitly copyable, the dot operator can be used to read fields of a struct without any borrowing.
+```rust=
+let foo = Foo { x: 3, y: true };
+let x = foo.x;  // x == 3
+let y = foo.y;  // y == true
+```
+Dot operators can be chained to access nested fields.
+```rust=
+let baz = Baz { foo: Foo { x: 3, y: true } };
+let x = baz.foo.x; // x = 3;
+```
+
+However, this is not permitted for fields that contain non-primitive types, such a vector or another struct
+```rust=
+let foo = Foo { x: 3, y: true };
+let bar = Bar { foo };
+let foo2: Foo = *&foo.bar;
+let foo3: Foo = foo.bar; // error! add an explicit copy with *&
+```
+The reason behind this design decision is that copying a vector or another struct might be an expensive operation. It is important for a programmer to be aware of this copy and make others aware with the explicit syntax `*&`
+
+In addition reading from fields, the dot syntax can be used to modify fields, regardless of the field being a primitive type or some other struct
+```rust=
+let foo = Foo { x: 3, y: true };
+foo.x = 42;     // foo = Foo { x: 42, y: true }
+foo.y = !foo.y; // foo = Foo { x: 42, y: false }
+let bar = Bar { foo };            // bar = Bar { foo: Foo { x: 42, y: false } }
+bar.foo.x = 52;                   // bar = Bar { foo: Foo { x: 52, y: false } }
+bar.foo = Foo { x: 62, y: true }; // bar = Bar { foo: Foo { x: 62, y: true } }
+```
+
+The dot syntax also works via a reference to a struct
+```rust=
+let foo = Foo { x: 3, y: true };
+let foo_ref = &mut foo;
+foo.x = foo.x + 1;
+```
+
+## Privileged Struct Operations
+
+Most struct operations on a struct type `T` can only be performed inside the module that declares `T`:
+
+- Struct types can only be created ("packed"), destroyed ("unpacked") inside the module that defines the struct.
+- The fields of a struct are only accessible inside the module that defines the struct.
+
+Following these rules, if you want to modify your struct outside the module, you will need to provide publis APIs for them. The end of the chapter contains some examples of this.
+
+However, struct *types* are always visible to another module or script:
+```rust=
+// M.move
+address 0x2 {
+module M {
+    struct Foo { x: u64 }
+
+    public fun new_foo(): Foo {
+        Foo { x: 42 }
+    }
+}
+}
+```
+```rust=
+// N.move
+address 0x2 {
+module N {
+    use 0x2::M;
+
+    struct Wrapper {
+        foo: M::Foo
+    }
+
+    fun f1(foo: M::Foo) {
+        let x = foo.x;
+        //      ^ error! cannot access fields of `foo` here
+    }
+
+    fun f2() {
+        let foo_wrapper = Wrapper { foo: M::new_foo() };
+    }
+}
+}
+```
+
+Note that structs do not have visibility modifiers (e.g., `public` or `private`).
+
+## Ownership
+By default, structs can be freely copied and silently dropped.
+```rust=
+address 0x2 {
+module M {
+    struct Foo { x: u64 }
+
+    public fun run() {
+        let foo = Foo { x: 100 };
+        let foo_copy = copy foo;
+        // ^ this code copies foo, whereas `let x = foo` or
+        // `let x = move foo` both move foo
+
+        let x = foo.x;            // x = 100
+        let x_copy = foo_copy.x;  // x = 100
+
+        // both foo and foo_copy are implicitly discarded when the function returns
+    }
+}
+}
+```
+Resource structs on the other hand, cannot be copied or dropped silently. This property can be very useful when modeling
+real world resources like money, as you do not want money to be duplicated or get lost
+in circulation.
+```rust=
+address 0x2 {
+module M {
+    resource struct Foo { x: u64 }
+
+    public fun copying_resource() {
+        let foo = Foo { x: 100 };
+        let foo_copy = copy foo; // error! resources cannot be copied
+        let foo_ref = &foo;
+        let another_copy = *foo_ref // error! resources cannot be copied
+    }
+
+    public fun destroying resource1() {
+        let foo = Foo { x: 100 };
+
+        // error! when the function returns, foo still contains a resource
+    }
+
+    public fun destroying resource2(f: &mut Foo) {
+        *f = Foo { x: 100 } // error! destroying resource
+    }
+}
+}
+```
+To fix the second example (`fun dropping_resource`), you will need to manually "unpack" the resource:
+```rust=
+address 0x2 {
+module M {
+    resource struct Foo { x: u64 }
+
+    public fun destroying_resource() {
+        let foo = Foo { x: 100 };
+        let Foo { x } = foo;
+    }
+}
+}
+```
+In addition, in order to enforce the said ownership rules at all times, it is required that normal structs do NOT have contain fields of resource types.
+```rust=
+address 0x2 {
+module M {
+    resource struct R {}
+
+    struct Foo { x: R }
+    //           ^~~~ error! Foo is not a resource so
+    //                it cannot contain R
+
+    resource struct Bar { x: R }
+    // good
+}
+}
+```
+
+Recall that you are only able to deconstruct a resource within the module in which it is defined. This can be leveraged to enforce certain invariants in a system, for example, conservation of money.
+
+## Storing Resources in Global Storage
+
+Only resource structs can be saved directly in [persistent global storage](./global-storage-operators.md). See the [global storage](./global-storage-operators.md) chapter for more detail.
+
+
+## Example 1: Coin
+```rust=
+address 0x2 {
+module M {
+    resource struct Coin {
+        value: u64,
+    }
+
+    public fun zero(): Coin {
+        Coin { value: 0 }
+    }
+
+    public fun withdraw(coin: &mut Coin, amount: u64): Coin {
+        assert(coin.balance >= amount, 1000);
+        coin.value = coin.value - amount;
+        Coin { value: amount }
+    }
+
+    public fun deposit(coin: &mut Coin, other: Coin) {
+        let Coin { value } = other;
+        coin.value = coin.value + value;
+    }
+
+    public fun split(coin: Coin, amount: u64): (Coin, Coin) {
+        let other = withdraw(&mut coin, amount);
+        (coin, other)
+    }
+
+    public fun merge(coin1: Coin, coin2: Coin): Coin {
+        deposit(&mut coin1, coin2);
+        coin1
+    }
+}
+}
+```
+
+## Example 2: Geometry
+```rust=
+address 0x2 {
+module Point {
+    struct Point {
+        x: u64,
+        y: u64,
+    }
+
+    public fun new(x: u64, y: u64): Point {
+        Point {
+            x, y
+        }
+    }
+
+    public fun x(p: &Point): u64 {
+        p.x
+    }
+
+    public fun y(p: &Point): u64 {
+        p.y
+    }
+
+    fun abs_sub(a: u64, b: u64): u64 {
+        if (a < b) {
+            b - a
+        }
+        else {
+            a - b
+        }
+    }
+
+    public fun dist_squared(p1: &Point, p2: &Point): u64 {
+        let dx = abs_sub(p1.x, p2.x);
+        let dy = abs_sub(p1.y, p2.y);
+        dx*dx + dy*dy
+    }
+}
+}
+```
+
+```rust=
+address 0x2 {
+module Circle {
+    use 0x2::Point::{Self, Point};
+
+    struct Circle {
+        center: Point,
+        radius: u64,
+    }
+
+    public fun new(center: Point, radius: u64): Circle {
+        Circle { center, radius }
+    }
+
+    public fun overlaps(c1: &Circle, c2: &Circle): bool {
+        let d = Point::dist_squared(&c1.center, &c2.center);
+        let r1 = c1.radius;
+        let r2 = c2.radius;
+        d*d <= r1*r1 + 2*r1*r2 + r2*r2
+    }
+}
+}
+```

--- a/language/documentation/book/src/structs-and-resources.md
+++ b/language/documentation/book/src/structs-and-resources.md
@@ -1,8 +1,4 @@
----
-id: move-structs-and-resources
-title: Structs and Resources
-sidebar_label: Structs and Resources
----
+# Structs and Resources
 
 A *struct* is a user-defined data structure containing typed fields. Structs can store any non-reference type, including other structs.
 
@@ -53,7 +49,6 @@ struct B_a_z_4_2 {}
 ```
 
 This naming restriction of starting with `A` to `Z` is in place to give room for future language features. It may or may not be removed later.
-
 
 ## Using Structs
 
@@ -381,7 +376,6 @@ Recall that you are only able to deconstruct a resource within the module in whi
 ## Storing Resources in Global Storage
 
 Only resource structs can be saved directly in [persistent global storage](./global-storage-operators.md). See the [global storage](./global-storage-operators.md) chapter for more detail.
-
 
 ## Example 1: Coin
 

--- a/language/documentation/book/src/tuples.md
+++ b/language/documentation/book/src/tuples.md
@@ -1,0 +1,117 @@
+---
+id: move-tuples-and-unit
+title: Tuples and Unit
+sidebar_label: Tuples and Unit
+---
+
+Move does not fully support tuples as one might expect coming from another language with them as a first-class value. However, in order to support multiple return values, Move has tuple-like expressions. These expressions do not result in a concrete value at runtime (there are no tuples in the bytecode), and as a result they are very limited: they can only appear in expressions (usually in the return position for a function); they cannot be bound to local variables; they cannot be stored in structs; and tuple types cannot be used to instantiate generics.
+
+Similarly, unit `()` is a type created by the Move source language in order to be expression based. The unit value `()` does not result in any runtime value. We can consider unit`()` to be an empty tuple, and any restrictions that apply to tuples also apply to unit.
+
+It might feel weird to have tuples in the language at all given these restrictions. But one of the most common use cases for tuples in other languages is for functions to allow functions to return multiple values. Some languages work around this by forcing the users to write structs that contain the multiple return values. However in Move, you cannot put references inside of [structs](./structs-and-resources.md). This required Move to support multiple return values. These multiple return values are all pushed on the stack at the bytecode level. At the source level, these multiple return values are represented using tuples.
+
+## Literals
+
+Tuples are created by a comma separated list of expressions inside of parentheses
+
+|Syntax | Type | Description |
+| -------- | -------- | -------- |
+| `()`     | `(): ()` | Unit, the empty tuple, or the tuple of arity 0
+| `(e0, ..., en)` |`(e0, ..., en): (T0, ..., Tn)` where `e_i: Ti` s.t. `0 <= i <= n` and `n > 0` | A `n`-tuple, a tuple of arity `n`, a tuple with `n` elements
+
+Note that `(e)` does not have type `(e): (t)`, in other words there is no tuple with one element. If there is only a single element inside of the parentheses, the parentheses are only used for disambiguation and do not carry any other special meaning.
+
+Sometimes, tuples with two elements are called "pairs" and tuples with three elements are called "triples."
+
+### Examples
+
+```rust=
+address 0x42 {
+module Example {
+    // all 3 of these functions are equivalent
+
+    // when no return type is provided, it is assumed to be `()`
+    fun returs_unit_1() { }
+
+    // there is an implicit () value in empty expression blocks
+    fun returs_unit_2(): () { }
+
+    // explicit version of `returs_unit_1` and `returs_unit_2`
+    fun returs_unit_3(): () { () }
+
+
+    fun returns_3_values(): (u64, bool, address) {
+        (0, false, 0x42)
+    }
+    fun returns_4_values(x: &u64): (&u64, u8, u128, vector<u8>) {
+        (x, 0, 1, b"foobar")
+    }
+}
+}
+```
+
+## Operations
+
+The only operation that can be done on tuples currently is destructuring.
+
+### Destructuring
+
+For tuples of any size, they can be destructured in either a `let` binding or in an assignment.
+
+For example:
+```rust=
+address 0x42 {
+module Example {
+    // all 3 of these functions are equivalent
+    fun returns_unit() {}
+    fun returns_2_values(): (bool, bool) { (true, false) }
+    fun returns_4_values(x: &u64): (&u64, u8, u128, vector<u8>) { (x, 0, 1, b"foobar") }
+
+    fun examples(cond: bool) {
+        let () = ();
+        let (x, y): (u8, u64) = (0, 1);
+        let (a, b, c, d) = (0x0, 0, false, b"");
+
+        () = ();
+        (x, y) = if (cond) (1, 2) else (3, 4);
+        (a, b, c, d) = (0x1, 1, true, b"1");
+    }
+
+    fun examples_with_function_calls() {
+        let () = returns_unit();
+        let (x, y): (bool, bool) = returns_2_values();
+        let (a, b, c, d) = returns_4_values(&0);
+
+        () = returns_unit();
+        (x, y) = returns_2_values();
+        (a, b, c, d) = returns_4_values(&1);
+    }
+}
+}
+```
+
+For more details, see [Move Variables](./variables.md).
+
+## Subtyping
+
+Along with references, tuples are the only types that have subtyping in Move. Tuples do have subtyping only in the sense that subtype with references (in a covariant way).
+
+For example
+```rust=
+let x: &u64 = &0;
+let y: &mut u64 = &mut 1;
+
+// (&u64, &mut u64) is a subtype of (&u64, &u64)
+//   since &mut u64 is a subtype of &u64
+let (a, b): (&u64, &u64) = (x, y);
+// (&mut u64, &mut u64) is a subtype of (&u64, &u64)
+//   since &mut u64 is a subtype of &u64
+let (c, d): (&u64, &u64) = (y, y);
+// error! (&mut u64, &mut u64) is NOT a subtype of (&u64, &mut u64)
+//   since &u64 is NOT a subtype of &mut u64
+let (e, f): (&mut u64, &mut u64) = (x, y);
+```
+
+## Ownership
+
+As mentioned above, tuple values don't really exist at runtime. And currently they cannot be stored into local variables because of this (but it is likely that this feature will come soon). As such, tuples can only be moved currently, as copying them would require putting them into a local variable first.

--- a/language/documentation/book/src/tuples.md
+++ b/language/documentation/book/src/tuples.md
@@ -1,8 +1,4 @@
----
-id: move-tuples-and-unit
-title: Tuples and Unit
-sidebar_label: Tuples and Unit
----
+# Tuples and Unit
 
 Move does not fully support tuples as one might expect coming from another language with them as a first-class value. However, in order to support multiple return values, Move has tuple-like expressions. These expressions do not result in a concrete value at runtime (there are no tuples in the bytecode), and as a result they are very limited: they can only appear in expressions (usually in the return position for a function); they cannot be bound to local variables; they cannot be stored in structs; and tuple types cannot be used to instantiate generics.
 

--- a/language/documentation/book/src/tuples.md
+++ b/language/documentation/book/src/tuples.md
@@ -59,6 +59,7 @@ The only operation that can be done on tuples currently is destructuring.
 For tuples of any size, they can be destructured in either a `let` binding or in an assignment.
 
 For example:
+
 ```rust=
 address 0x42 {
 module Example {
@@ -97,6 +98,7 @@ For more details, see [Move Variables](./variables.md).
 Along with references, tuples are the only types that have subtyping in Move. Tuples do have subtyping only in the sense that subtype with references (in a covariant way).
 
 For example
+
 ```rust=
 let x: &u64 = &0;
 let y: &mut u64 = &mut 1;

--- a/language/documentation/book/src/uses.md
+++ b/language/documentation/book/src/uses.md
@@ -1,0 +1,325 @@
+---
+id: move-uses-and-aliases
+title: Uses and Aliases
+sidebar_label: Uses and Aliases
+---
+
+The `use` syntax can be used to create aliases to members in other modules. `use` can be used to create aliases that last either for the entire module, or for a given expression block scope.
+
+## Syntax
+
+There are several different syntax cases for `use`. Starting with the most simple, we have the following for creating aliases to other modules
+```rust
+use <address>::<module name>;
+use <address>::<module name> as <module alias name>;
+```
+For example
+```rust
+use 0x1::Vector;
+use 0x1::Vector as V;
+```
+`use 0x1::Vector;` introduces an alias `Vector` for `0x1::Vector`. This means that anywhere you would want to use the module name `0x1::Vector` (assuming this `use` is in scope), you could use `Vector` instead. `use 0x1::Vector;`  is equivalent to `use 0x1::Vector as Vector;`
+
+Similarly `use 0x1::Vector as V;` would let you use `V` instead of `0x1::Vector`
+```rust=
+use 0x1::Vector;
+use 0x1::Vector as V;
+
+fun new_vecs(): (vector<u8>, vector<u8>, vector<u8>) {
+    let v1 = 0x1::Vector::empty();
+    let v2 = Vector::empty();
+    let v3 = V::empty();
+    (v1, v2, v3)
+}
+```
+
+If you want to import a specific module member (such as a function, struct, or constant). You can use the following syntax.
+
+```rust
+use <address>::<module name>::<module member>;
+use <address>::<module name>::<module member> as <member alias>;
+```
+For example
+```rust
+use 0x1::Vector::empty;
+use 0x1::Vector::empty as empty_vec;
+```
+This would let you use the function `0x1::Vector::empty` without full qualification. Instead you could use `empty` and `empty_vec` respectively. Again, `use 0x1::Vector::empty;` is equivalent to `use 0x1::Vector::empty as empty;`
+
+```rust=
+use 0x1::Vector::empty;
+use 0x1::Vector::empty as empty_vec;
+
+fun new_vecs(): (vector<u8>, vector<u8>, vector<u8>) {
+    let v1 = 0x1::Vector::empty();
+    let v2 = empty();
+    let v3 = empty_vec();
+    (v1, v2, v3)
+}
+```
+
+If you want to add aliases for multiple module members at once, you can do so with the following syntax
+```rust
+use <address>::<module name>::{<module member>, <module member> as <member alias> ... };
+```
+For example
+```rust=
+use 0x1::Vector::{push_back, length as len, pop_back};
+
+fun swap_last_two<T>(v: &mut vector<T>) {
+    assert(len(v) >= 2, 42);
+    let last = pop_back(v);
+    let second_to_last = pop_back(v);
+    push_back(v, last);
+    push_back(v, second_to_last)
+}
+
+```
+
+If you need to add an alias to the Module itself in addition to module members, you can do that in a single `use` using `Self`. `Self` is a member of sorts that refers to the module.
+```rust
+use 0x1::Vector::{Self, empty};
+```
+
+For clarity, all of the following are equivalent:
+```rust
+use 0x1::Vector;
+use 0x1::Vector as Vector;
+use 0x1::Vector::Self;
+use 0x1::Vector::Self as Vector;
+use 0x1::Vector::{Self};
+use 0x1::Vector::{Self as Vector};
+```
+
+If needed, you can have as many aliases for any item as you like
+```rust=
+use 0x1::Vector::{
+    Self,
+    Self as V,
+    length,
+    length as len,
+};
+
+fun pop_twice<T>(v: &mut vector<T>): (T, T) {
+    // all options available given the `use` above
+    assert(Vector::length(v) > 1, 42);
+    assert(V::length(v) > 1, 42);
+    assert(length(v) > 1, 42);
+    assert(len(v) > 1, 42);
+
+    (Vector::pop_back(v), Vector::pop_back(v))
+}
+```
+
+## Inside a `module`
+
+Inside of a `module` all `use` declarations are usable regardless of the order of declaration.
+
+```rust=
+address 0x42 {
+module Example {
+    use 0x1::Vector;
+
+    fun example(): vector<u8> {
+        let v = empty();
+        Vector::push_back(&mut v, 0);
+        Vector::push_back(&mut v, 10);
+        v
+    }
+
+    use 0x1::Vector::empty;
+}
+}
+```
+The aliases declared by `use` in the module usable within that module.
+
+Additionally, the aliases introduced cannot conflict with other module members. See [Uniqueness](#uniqueness) for more details
+
+## Inside an expression
+
+You can add `use` declarations to the beginning of any expression block
+```rust=
+address 0x42 {
+module Example {
+
+    fun example(): vector<u8> {
+        use 0x1::Vector::{empty, push_back};
+
+        let v = empty();
+        push_back(&mut v, 0);
+        push_back(&mut v, 10);
+        v
+    }
+}
+}
+```
+As with `let`, the aliases introduced by `use` in an expression block are removed at the end of that block.
+```rust=
+address 0x42 {
+module Example {
+
+    fun example(): vector<u8> {
+        let result = {
+            use 0x1::Vector::{empty, push_back};
+            let v = empty();
+            push_back(&mut v, 0);
+            push_back(&mut v, 10);
+            v
+        };
+        result
+    }
+
+}
+}
+```
+Attempting to use the alias after the block ends will result in an error
+```rust=
+fun example(): vector<u8> {
+    let result = {
+        use 0x1::Vector::{empty, push_back};
+        let v = empty();
+        push_back(&mut v, 0);
+        push_back(&mut v, 10);
+        v
+    };
+    let v2 = empty(); // ERROR!
+//           ^^^^^ unbound function 'empty'
+    result
+}
+```
+
+Any `use` must be the first item in the block. If the `use` comes after any expression or `let`, it will result in a parsing error
+```rust=
+{
+    let x = 0;
+    use 0x1::Vector; // ERROR!
+    let v = Vector::empty();
+}
+```
+
+## Naming rules
+
+Aliases must follow the same rules as other module members. This means that aliases to structs or constants must start with `A` to `Z`
+
+```rust=
+address 0x42 {
+module Data {
+    struct S {}
+    const FLAG: bool = false;
+    fun foo() {}
+}
+module Example {
+    use 0x42::Data::{
+        S as s, // ERROR!
+        FLAG as fLAG, // ERROR!
+        foo as FOO,  // valid
+        foo as bar, // valid
+    };
+}
+}
+```
+
+## Uniqueness
+
+Inside a given scope, all aliases introduced by `use` declarations must be unique.
+
+For a module, this means aliases introduced by `use` cannot overla
+```rust=
+address 0x42 {
+module Example {
+
+    use 0x1::Vector::{empty as foo, length as foo}; // ERROR!
+    //                                        ^^^ duplicate 'foo'
+
+    use 0x1::Vector::empty as bar;
+
+    use 0x1::Vector::length as bar; // ERROR!
+    //                         ^^^ duplicate 'bar'
+
+}
+}
+```
+
+And, they cannot overlap with any of the module's other members
+```rust=
+address 0x42 {
+module Data {
+    struct S {}
+}
+module Example {
+    use 0x42::Data::S;
+
+    struct S { value: u64 } // ERROR!
+    //     ^ conflicts with alias 'S' above
+}
+}
+```
+
+Inside of an expression block, they cannot overlap with each other, but they can [shadow](#shadowing) other aliases or names from an outer scope
+
+## Shadowing
+
+`use` aliases inside of an expression block can shadow names (module members or aliases) from the outer scope. As with shadowing of locals, the shadowing ends at the end of the expression block;
+
+```rust=
+address 0x42 {
+module Example {
+
+    struct WrappedVector { vec: vector<u64> }
+
+    fun empty(): WrappedVector {
+        WrappedVector { vec: 0x1::Vector::empty() }
+    }
+
+    fun example1(): (WrappedVector, WrappedVector) {
+        let vec = {
+            use 0x1::Vector::{empty, push_back};
+            // 'empty' now refers to 0x1::Vector::empty
+
+            let v = empty();
+            push_back(&mut v, 0);
+            push_back(&mut v, 1);
+            push_back(&mut v, 10);
+            v
+        };
+        // 'empty' now refers to Self::empty
+
+        (empty(), WrappedVector { vec })
+    }
+
+    fun example2(): (WrappedVector, WrappedVector) {
+        use 0x1::Vector::{empty, push_back};
+        let w: WrappedVector = {
+            use 0x42::Example::empty;
+            empty()
+        };
+        push_back(&mut w.vec, 0);
+        push_back(&mut w.vec, 1);
+        push_back(&mut w.vec, 10);
+
+        let vec = empty();
+        push_back(&mut vec, 0);
+        push_back(&mut vec, 1);
+        push_back(&mut vec, 10);
+
+        (w, WrappedVector { vec })
+    }
+}
+}
+```
+
+## Unused Use or Alias
+
+An unused `use` will result in an error
+```rust=
+address 0x42 {
+module Example {
+    use 0x1::Vector::{empty, push_back}; // ERROR!
+    //                       ^^^^^^^^^ unused alias 'push_back'
+
+    fun example(): vector<u8> {
+        empty()
+    }
+}
+}
+```

--- a/language/documentation/book/src/uses.md
+++ b/language/documentation/book/src/uses.md
@@ -1,8 +1,4 @@
----
-id: move-uses-and-aliases
-title: Uses and Aliases
-sidebar_label: Uses and Aliases
----
+# Uses and Aliases
 
 The `use` syntax can be used to create aliases to members in other modules. `use` can be used to create aliases that last either for the entire module, or for a given expression block scope.
 

--- a/language/documentation/book/src/uses.md
+++ b/language/documentation/book/src/uses.md
@@ -9,18 +9,23 @@ The `use` syntax can be used to create aliases to members in other modules. `use
 ## Syntax
 
 There are several different syntax cases for `use`. Starting with the most simple, we have the following for creating aliases to other modules
+
 ```rust
 use <address>::<module name>;
 use <address>::<module name> as <module alias name>;
 ```
+
 For example
+
 ```rust
 use 0x1::Vector;
 use 0x1::Vector as V;
 ```
+
 `use 0x1::Vector;` introduces an alias `Vector` for `0x1::Vector`. This means that anywhere you would want to use the module name `0x1::Vector` (assuming this `use` is in scope), you could use `Vector` instead. `use 0x1::Vector;`  is equivalent to `use 0x1::Vector as Vector;`
 
 Similarly `use 0x1::Vector as V;` would let you use `V` instead of `0x1::Vector`
+
 ```rust=
 use 0x1::Vector;
 use 0x1::Vector as V;
@@ -39,11 +44,14 @@ If you want to import a specific module member (such as a function, struct, or c
 use <address>::<module name>::<module member>;
 use <address>::<module name>::<module member> as <member alias>;
 ```
+
 For example
+
 ```rust
 use 0x1::Vector::empty;
 use 0x1::Vector::empty as empty_vec;
 ```
+
 This would let you use the function `0x1::Vector::empty` without full qualification. Instead you could use `empty` and `empty_vec` respectively. Again, `use 0x1::Vector::empty;` is equivalent to `use 0x1::Vector::empty as empty;`
 
 ```rust=
@@ -59,10 +67,13 @@ fun new_vecs(): (vector<u8>, vector<u8>, vector<u8>) {
 ```
 
 If you want to add aliases for multiple module members at once, you can do so with the following syntax
+
 ```rust
 use <address>::<module name>::{<module member>, <module member> as <member alias> ... };
 ```
+
 For example
+
 ```rust=
 use 0x1::Vector::{push_back, length as len, pop_back};
 
@@ -73,15 +84,16 @@ fun swap_last_two<T>(v: &mut vector<T>) {
     push_back(v, last);
     push_back(v, second_to_last)
 }
-
 ```
 
 If you need to add an alias to the Module itself in addition to module members, you can do that in a single `use` using `Self`. `Self` is a member of sorts that refers to the module.
+
 ```rust
 use 0x1::Vector::{Self, empty};
 ```
 
 For clarity, all of the following are equivalent:
+
 ```rust
 use 0x1::Vector;
 use 0x1::Vector as Vector;
@@ -92,6 +104,7 @@ use 0x1::Vector::{Self as Vector};
 ```
 
 If needed, you can have as many aliases for any item as you like
+
 ```rust=
 use 0x1::Vector::{
     Self,
@@ -131,6 +144,7 @@ module Example {
 }
 }
 ```
+
 The aliases declared by `use` in the module usable within that module.
 
 Additionally, the aliases introduced cannot conflict with other module members. See [Uniqueness](#uniqueness) for more details
@@ -138,6 +152,7 @@ Additionally, the aliases introduced cannot conflict with other module members. 
 ## Inside an expression
 
 You can add `use` declarations to the beginning of any expression block
+
 ```rust=
 address 0x42 {
 module Example {
@@ -153,7 +168,9 @@ module Example {
 }
 }
 ```
+
 As with `let`, the aliases introduced by `use` in an expression block are removed at the end of that block.
+
 ```rust=
 address 0x42 {
 module Example {
@@ -172,7 +189,9 @@ module Example {
 }
 }
 ```
+
 Attempting to use the alias after the block ends will result in an error
+
 ```rust=
 fun example(): vector<u8> {
     let result = {
@@ -189,6 +208,7 @@ fun example(): vector<u8> {
 ```
 
 Any `use` must be the first item in the block. If the `use` comes after any expression or `let`, it will result in a parsing error
+
 ```rust=
 {
     let x = 0;
@@ -224,6 +244,7 @@ module Example {
 Inside a given scope, all aliases introduced by `use` declarations must be unique.
 
 For a module, this means aliases introduced by `use` cannot overla
+
 ```rust=
 address 0x42 {
 module Example {
@@ -241,6 +262,7 @@ module Example {
 ```
 
 And, they cannot overlap with any of the module's other members
+
 ```rust=
 address 0x42 {
 module Data {
@@ -311,6 +333,7 @@ module Example {
 ## Unused Use or Alias
 
 An unused `use` will result in an error
+
 ```rust=
 address 0x42 {
 module Example {

--- a/language/documentation/book/src/variables.md
+++ b/language/documentation/book/src/variables.md
@@ -1,0 +1,623 @@
+---
+id: move-variables
+title: Local Variables and Scope
+sidebar_label: Variables
+---
+
+Local variables in Move are lexically (statically) scoped. New variables are introduced with the keyword `let`, which will shadow any previous local with the same name. Locals are mutable and can be updated both directly and via a mutable reference.
+
+## Declaring Local Variables
+
+### `let` bindings
+
+Move programs use `let` to bind variable names to values:
+```rust
+let x = 1;
+let y = x + x:
+```
+
+`let` can also be used without binding a value to the local.
+
+```rust
+let x;
+```
+The local can then be assigned a value later.
+```rust
+let x;
+if (cond) {
+  x = 1
+} else {
+  x = 0
+}
+```
+This can be very helpful when trying to extract a value from a loop when a default value cannot be provided.
+```rust
+let x;
+let cond = true;
+let i = 0;
+loop {
+    (x, cond) = foo(i);
+    if (!cond) break;
+    i = i + 1;
+}
+```
+
+### Variables must be assigned before use
+
+Move's type system prevents a local variable from being used before it has been assigned.
+```rust
+let x;
+x + x // ERROR!
+```
+```rust
+let x;
+if (cond) x = 0;
+x + x // ERROR!
+```
+```rust
+let x;
+while (cond) x = 0;
+x + x // ERROR!
+```
+
+### Valid variable names
+
+Variable names can contain underscores `_`, letters `a` to `z`, letters `A` to `Z`, and digits `0` to `9`. Variable names must start with either an underscore `_` or a letter `a` through `z`. They *cannot* start with uppercase letters.
+
+```rust
+// all valid
+let x = e;
+let _x = e;
+let _A = e;
+let x0 = e;
+let xA = e;
+let foobar_123 = e;
+
+// all invalid
+let X = e; // ERROR!
+let Foo = e; // ERROR!
+```
+
+### Type annotations
+
+The type of a local variable can almost always be inferred by Move's type system.  However, Move allows explicit type annotations that can be useful for readability, clarity, or debuggability. The syntax for adding a type annotation is:
+```rust
+let x: T = e; // "Variable x of type T is initialized to expression e"
+```
+Some examples of explicit type annotations:
+```rust=
+address 0x42 {
+module Example {
+
+    struct S { f: u64, g: u64 }
+
+    fun annotated() {
+        let u: u8 = 0;
+        let b: vector<u8> = b"hello";
+        let a: address = 0x0;
+        let (x, y): (&u64, &mut u64) = (&0, &mut 1);
+        let S { f, g: f2 }: S = S { f: 0, g: 1 };
+    }
+}
+}
+```
+Note that the type annotations must always be to the right of the pattern:
+```rust
+let (x: &u64, y: &mut u64) = (&0, &mut 1); // ERROR! should be let (x, y): ... =
+```
+
+### When annotations are necessary
+
+In some cases, a local type annotation is required if the type system cannot infer the type. This commonly occurs when the type argument for a generic type cannot be inferred. For example:
+```rust
+let _v1 = Vector::empty(); // ERROR!
+//        ^^^^^^^^^^^^^^^ Could not infer this type. Try adding an annotation
+let v2: vector<u64> = Vector::empty(); // no error
+```
+
+
+In a rarer case, the type system might not be able to infer a type for divergent code (where all the following code is unreachable). Both `return` and [`abort`](./abort-and-assert.md) are expressions and can have any type. A [`loop`](./loops.md) has type `()` if it has a `break`, but if there is no break out of the `loop`, it could have any type.
+If these types cannot be inferred, a type annotation is required. For example, this code:
+```rust
+let a: u8 = return ();
+let b: bool = abort 0;
+let c: signer = loop ();
+
+let x = return (); // ERROR!
+//  ^ Could not infer this type. Try adding an annotation
+let y = abort 0; // ERROR!
+//  ^ Could not infer this type. Try adding an annotation
+let z = loop (); // ERROR!
+//  ^ Could not infer this type. Try adding an annotation
+```
+
+Adding type annotations to this code will expose other errors about dead code or unused local variables, but the example is still helpful for understanding this problem.
+
+### Multiple declarations with tuples
+
+`let` can introduce more than one local at a time using tuples. The locals declared inside the parenthesis are initialized to the corresponding values from the tuple.
+```rust
+let () = ();
+let (x0, x1) = (0, 1);
+let (y0, y1, y2) = (0, 1, 2);
+let (z0, z1, z2, z3) = (0, 1, 2, 3);
+```
+The type of the expression must match the arity of the tuple pattern exactly.
+
+```rust
+let (x, y) = (0, 1, 2); // ERROR!
+let (x, y, z, q) = (0, 1, 2); // ERROR!
+```
+
+You cannot declare more than one local with the same name in a single `let`.
+```rust
+let (x, x) = 0; // ERROR!
+```
+
+### Multiple declarations with structs
+
+`let` can also introduce more than one local at a time when destructuring (or matching against) a struct. In this form, the `let` creates a set of local variables that are initialized to the values of the fields from a struct. The syntax looks like this:
+```rust
+struct T { f1: u64, f2: u64 }
+```
+```rust
+let T { f1: local1, f2: local2 } = T { f1: 1, f2: 2 };
+// local1: u64
+// local2: u64
+```
+
+Here is a more complicated example:
+```rust
+address 0x42 {
+module Example {
+    struct X { f: u64 }
+    struct Y { x1: X, x2: X }
+
+    fun new_x(): X {
+        X { f: 1 }
+    }
+
+    fun example() {
+        let Y { x1: X { f }, x2 } = Y { x1: new_x(), x2: new_x() };
+        assert(f + x2.f == 2, 42);
+
+        let Y { x1: X { f: f1 }, x2: X { f: f2 } } = Y { x1: new_x(), x2: new_x() };
+        assert(f1 + f2 == 2, 42);
+    }
+}
+}
+```
+Fields of structs can serve double duty, identifying the field to bind *and* the name of the variable. This is sometimes referred to as punning.
+```rust
+let X { f } = e;
+```
+is equivalent to:
+```rust
+let X { f: f } = e;
+```
+
+As shown with tuples, you cannot declare more than one local with the same name in a single `let`.
+
+```rust
+let Y { x1: x, x2: x } = e; // ERROR!
+```
+
+### Destructuring against references
+
+In the examples above for structs, the bound value in the let was moved, destroying the struct value and binding its fields.
+```rust
+struct T { f1: u64, f2: u64 }
+```
+```rust
+let T { f1: local1, f2: local2 } = T { f1: 1, f2: 2 };
+// local1: u64
+// local2: u64
+```
+In this scenario the struct value `T { f1: 1, f2: 2 }` no longer exists after the `let`.
+
+If you wish instead to not move and destroy the struct value, you can borrow each of its fields.
+For example:
+```rust
+let t = T { f1: 1, f2: 2 };
+let T { f1: local1, f2: local2 } = &t;
+// local1: &u64
+// local2: &u64
+```
+And similarly with mutable references:
+```rust
+let t = T { f1: 1, f2: 2 };
+let T { f1: local1, f2: local2 } = &mut t;
+// local1: &mut u64
+// local2: &mut u64
+```
+
+This behavior can also work recursively.
+```rust
+address 0x42 {
+module Example {
+    struct X { f: u64 }
+    struct Y { x1: X, x2: X }
+
+    fun new_x(): X {
+        X { f: 1 }
+    }
+
+    fun example() {
+        let y = Y { x1: new_x(), x2: new_x() };
+
+        let Y { x1: X { f }, x2 } = &y;
+        assert(*f + x2.f == 2, 42);
+
+        let Y { x1: X { f: f1 }, x2: X { f: f2 } } = &mut y;
+        *f1 = *f1 + 1;
+        *f2 = *f2 + 1;
+        assert(*f1 + *f2 == 4, 42);
+    }
+}
+}
+```
+
+### Ignoring Values
+
+In `let` bindings, it is often helpful to ignore some values. Local variables that start with `_` will be ignored and not introduce a new variable
+
+```rust
+fun three(): (u64, u64, u64) {
+    (0, 1, 2)
+}
+```
+```rust
+let (x1, _, z1) = three();
+let (x2, _y, z2) = three();
+assert(x1 + z1 == x2 + z2)
+```
+This can be necessary at times as the compiler will error on unused local variables
+```rust
+let (x1, y, z1) = three(); // ERROR!
+//       ^ unused local 'y'
+```
+
+### General `let` grammar
+
+All of the different structures in `let` can be combined! With that we arrive at this general grammar for `let` statements:
+
+> *let-binding* → **let** *pattern-or-list* *type-annotation*<sub>*opt*</sub> *initializer*<sub>*opt*</sub>
+> *pattern-or-list* → *pattern* | **(** *pattern-list* **)**
+> *pattern-list* → *pattern* **,**<sub>*opt*</sub> | *pattern* **,** *pattern-list*
+> *type-annotation* → **:** *type*
+>  *initializer* → **=** *expression*
+
+The general term for the item that introduces the bindings is a *pattern*. The pattern serves to both destructure data (possibly recursively) and introduce the bindings. The pattern grammar is as follows:
+
+> *pattern* → *local-variable* | *struct-type* **{** *field-binding-list* **}**
+> *field-binding-list* → *field-binding* **,**<sub>*opt*</sub> | *field-binding* **,** *field-binding-list*
+> *field-binding* → *field* | *field* **:** *pattern*
+
+A few concrete examples with this grammar applied:
+```rust
+    let (x, y): (u64, u64) = (0, 1);
+//       ^                           local-variable
+//       ^                           pattern
+//          ^                        local-variable
+//          ^                        pattern
+//          ^                        pattern-list
+//       ^^^^                        pattern-list
+//      ^^^^^^                       pattern-or-list
+//            ^^^^^^^^^^^^           type-annotation
+//                         ^^^^^^^^  initializer
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ let-binding
+
+    let Foo { f, g: x } = Foo { f: 0, g: 1 };
+//      ^^^                                    struct-type
+//            ^                                field
+//            ^                                field-binding
+//               ^                             field
+//                  ^                          local-variable
+//                  ^                          pattern
+//               ^^^^                          field-binding
+//            ^^^^^^^                          field-binding-list
+//      ^^^^^^^^^^^^^^^                        pattern
+//      ^^^^^^^^^^^^^^^                        pattern-or-list
+//                      ^^^^^^^^^^^^^^^^^^^^   initializer
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ let-binding
+```
+## Mutations
+
+### Assignments
+
+After the local is introduced (either by `let` or as a function parameter), the local can be modified via an assignment:
+```rust
+x = e
+```
+
+Unlike `let` bindings, assignments are expressions. In some languages, assignments return the value that was assigned, but in Move, the type of any assignment is always `()`.
+```rust
+(x = e: ())
+```
+Practically, assignments being expressions means that they can be used without adding a new expression block with braces (`{`...`}`).
+```rust
+let x = 0;
+if (cond) x = 1 else x = 2;
+```
+
+The assignment uses the same pattern syntax scheme as `let` bindings:
+```rust=
+address 0x42 {
+module Example {
+    struct X { f: u64 }
+
+    fun new_x(): X {
+        X { f: 1 }
+    }
+
+    // This example will complain about unused variables and assignments.
+    fun example() {
+       let (x, _, z) = (0, 1, 3);
+       let (x, y, f, g);
+
+       (X { f }, X { f: x }) = (new_x(), new_x());
+       assert(f + x == 2, 42);
+
+       (x, y, z, f, _, g) = (0, 0, 0, 0, 0, 0);
+    }
+}
+}
+```
+Note that a local variable can only have one type, so the type of the local cannot change between assignments.
+```rust
+let x;
+x = 0;
+x = false; // ERROR!
+```
+
+### Mutating through a reference
+
+In addition to directly modifying a local with assignment, a local can be modified via a mutable reference `&mut`.
+
+```rust
+let x = 0;
+let r = &mut x;
+*r = 1;
+assert(x == 1, 42)
+}
+```
+This is particularly useful if either:
+
+(1) You want to modify different variables depending on some condition.
+```rust
+let x = 0;
+let y = 1;
+let r = if (cond) &mut x else &mut y;
+*r = *r + 1;
+```
+
+(2) You want another function to modify your local value.
+```rust
+let x = 0;
+modify_ref(&mut x);
+```
+This sort of modification is how you modify structs and vectors!
+```rust
+let v = Vector::empty();
+Vector::push_back(&mut v, 100);
+assert(*Vector::borrow(&v, 0) == 100, 42)
+```
+
+For more details, see [Move references](./references.md).
+
+## Scopes
+
+Any local declared with `let` is available for any subsequent expression, *within that scope*. Scopes are declared with expression blocks, `{`...`}`.
+
+Locals cannot be used outside of the declared scope.
+```rust
+let x = 0;
+{
+    let y = 1;
+};
+x + y // ERROR!
+//  ^ unbound local 'y'
+```
+
+But, locals from an outer scope *can* be used in a nested scope.
+```rust
+{
+    let x = 0;
+    {
+        let y = x + 1; // valid
+    }
+}
+```
+
+Locals can be mutated in any scope where they are accessible. That mutation survives with the local, regardless of the scope that performed the mutation.
+
+```rust
+let x = 0;
+x = x + 1;
+assert(x == 1, 42);
+{
+    x = x + 1;
+    assert(x == 2, 42);
+};
+assert(x == 2, 42);
+```
+
+### Expression Blocks
+
+An expression block is a series of statements separated by semicolons (`;`). The resulting value of an expression block is the value of the last expression in the block.
+```rust
+{ let x = 1; let y = 1; x + y }
+```
+In this example, the result of the block is `x + y`.
+
+A statement can be either a `let` declaration or an expression. Remember that assignments (`x = e`) are expressions of type `()`.
+```rust
+{ let x; let y = 1; x = 1; x + y }
+```
+
+Function calls are another common expression of type `()`. Function calls that modify data are commonly used as statements.
+```rust
+{ let v = Vector::empty(); Vector::push_back(&mut v, 1); v }
+```
+
+This is not just limited to `()` types---any expression can be used as a statement in a sequence!
+```rust
+{
+    let x = 0;
+    x + 1; // value is discarded
+    x + 2; // value is discarded
+    b"hello"; // value is discarded
+}
+```
+But! If the expression contains a resource, you will get an error. This is because Move's type system guarantees that no resource is dropped. (Ownership must be transferred or the resource must be explicitly destroyed within its declaring module.)
+```rust
+{
+    let x = 0;
+    Coin { value: x }; // ERROR!
+//  ^^^^^^^^^^^^^^^^^ unused resource
+    x
+}
+```
+
+If a final expression is not present in a block---that is, if there is a trailing semicolon `;`, there is an implicit unit `()` value. Similarly, if the expression block is empty, there is an implicit unit `()` value.
+```rust
+// Both are equivalent
+{ x = x + 1; 1 / x; }
+{ x = x + 1; 1 / x; () }
+```
+
+```rust
+// Both are equivalent
+{ }
+{ () }
+```
+
+An expression block is itself an expression and can be used anyplace an expression is used. (Note: The body of a function is also an expression block, but the function body cannot be replaced by another expression.)
+```rust
+let my_vector: vector<vector<u8>> = {
+    let v = Vector::empty();
+    Vector::push_back(&mut v, b"hello");
+    Vector::push_back(&mut v, b"goodbye");
+    v
+};
+```
+(The type annotation is not needed in this example and only added for clarity.)
+
+### Shadowing
+
+If a `let` introduces a local variable with a name already in scope, that previous variable can no longer be accessed for the rest of this scope. This is called *shadowing*.
+
+```rust
+let x = 0;
+assert(x == 0, 42);
+
+let x = 1; // x is shadowed
+assert(x == 1, 42);
+```
+When a local is shadowed, it does not need to retain the same type as before.
+```rust
+let x = 0;
+assert(x == 0, 42);
+
+let x = b"hello"; // x is shadowed
+assert(x == b"hello", 42);
+```
+After a local is shadowed, the value stored in the local still exists, but will no longer be accessible. This is important to keep in mind with resources, as ownership of the value must be transferred by the end of the function.
+```rust
+address 0x42 {
+    module Example {
+        resource struct Coin { value: u64 }
+
+        fun unused_resource(): Coin {
+            let x = Coin { value: 0 }; // ERROR!
+//              ^ This local still contains a resource
+            x.value = 1;
+            let x = Coin { value: 10 };
+            x
+//          ^ Invalid return
+        }
+    }
+}
+```
+
+When a local is shadowed inside a scope, the shadowing only remains for that scope. The shadowing is gone once that scope ends.
+```rust
+let x = 0;
+{
+    let x = 1;
+    assert(x == 1, 42);
+};
+assert(x == 0, 42);
+```
+
+Remember, locals can change type when they are shadowed.
+```rust
+let x = 0;
+{
+    let x = b"hello";
+    assert(x = b"hello", 42);
+};
+assert(x == 0, 42);
+```
+
+## Move and Copy
+
+All local variables in Move can be used in two ways, either by `move` or `copy`. If one or the other is not specified, the Move compiler is able to infer whether a `copy` or a `move` should be used. This means that in all of the examples above, a `move` or a `copy` would be inserted by the compiler. A local variable cannot be used without the use of `move` or `copy`.
+
+`copy` will likely feel the most familiar coming from other programming languages, as it creates a new copy of the value inside of the variable to use in that expression. With `copy`, the local variable can be used more than once.
+```rust
+let x = 0;
+let y = copy x + 1;
+let z = copy x + 2;
+```
+All non-resource values can be copied using `copy`.
+
+`move` takes the value out of the local variable *without* copying the data. After a `move` occurs, the local variable is unavailable.
+```rust
+let x = 1;
+let y = move x + 1;
+//      ------ Local was moved here
+let z = move x + 2; // Error!
+//      ^^^^^^ Invalid usage of local 'x'
+y + z
+```
+
+### Safety
+
+Move's type system will prevent a value from being used after it is moved. This is the same safety check described in [`let` declaration](#let-bindings) that prevents local variables from being used before it is assigned a value.
+
+For more information, see [Move equality](./equality.md).
+
+### Inference
+
+As mentioned above, the Move compiler will infer a `copy` or `move` if one is not indicated. The algorithm for doing so is quite simple:
+
+- Any copyable, scalar value is given a `copy`.
+- Any reference (both mutable `&mut` and immutable `&`) is given a `copy`.
+    - Except under special circumstances where it is made a `move` for predictable borrow checker errors.
+- Any other value is given a `move`.
+    - This means that even though other values might be copyable, it must be done *explicitly* by the programmer.
+    - This is to prevent accidental copies of large data structures.
+
+For example:
+```rust
+let s = b"hello";
+let foo = Foo { f: 0 };
+let coin = Coin { value: 0 };
+
+let s2 = s; // move
+let foo2 = foo; // move
+let coin2 = coin; // move
+
+let x = 0;
+let b = false;
+let addr = 0x42;
+let x_ref = &x;
+let coin_ref = &mut coin2;
+
+let x2 = x; // copy
+let b2 = b; // copy
+let addr2 = 0x42; // copy
+let x_ref2 = x_ref; // copy
+let coin_ref2 = coin_ref; // copy
+```

--- a/language/documentation/book/src/variables.md
+++ b/language/documentation/book/src/variables.md
@@ -11,6 +11,7 @@ Local variables in Move are lexically (statically) scoped. New variables are int
 ### `let` bindings
 
 Move programs use `let` to bind variable names to values:
+
 ```rust
 let x = 1;
 let y = x + x:
@@ -21,7 +22,9 @@ let y = x + x:
 ```rust
 let x;
 ```
+
 The local can then be assigned a value later.
+
 ```rust
 let x;
 if (cond) {
@@ -30,7 +33,9 @@ if (cond) {
   x = 0
 }
 ```
+
 This can be very helpful when trying to extract a value from a loop when a default value cannot be provided.
+
 ```rust
 let x;
 let cond = true;
@@ -45,15 +50,18 @@ loop {
 ### Variables must be assigned before use
 
 Move's type system prevents a local variable from being used before it has been assigned.
+
 ```rust
 let x;
 x + x // ERROR!
 ```
+
 ```rust
 let x;
 if (cond) x = 0;
 x + x // ERROR!
 ```
+
 ```rust
 let x;
 while (cond) x = 0;
@@ -81,10 +89,13 @@ let Foo = e; // ERROR!
 ### Type annotations
 
 The type of a local variable can almost always be inferred by Move's type system.  However, Move allows explicit type annotations that can be useful for readability, clarity, or debuggability. The syntax for adding a type annotation is:
+
 ```rust
 let x: T = e; // "Variable x of type T is initialized to expression e"
 ```
+
 Some examples of explicit type annotations:
+
 ```rust=
 address 0x42 {
 module Example {
@@ -101,7 +112,9 @@ module Example {
 }
 }
 ```
+
 Note that the type annotations must always be to the right of the pattern:
+
 ```rust
 let (x: &u64, y: &mut u64) = (&0, &mut 1); // ERROR! should be let (x, y): ... =
 ```
@@ -109,6 +122,7 @@ let (x: &u64, y: &mut u64) = (&0, &mut 1); // ERROR! should be let (x, y): ... =
 ### When annotations are necessary
 
 In some cases, a local type annotation is required if the type system cannot infer the type. This commonly occurs when the type argument for a generic type cannot be inferred. For example:
+
 ```rust
 let _v1 = Vector::empty(); // ERROR!
 //        ^^^^^^^^^^^^^^^ Could not infer this type. Try adding an annotation
@@ -118,6 +132,7 @@ let v2: vector<u64> = Vector::empty(); // no error
 
 In a rarer case, the type system might not be able to infer a type for divergent code (where all the following code is unreachable). Both `return` and [`abort`](./abort-and-assert.md) are expressions and can have any type. A [`loop`](./loops.md) has type `()` if it has a `break`, but if there is no break out of the `loop`, it could have any type.
 If these types cannot be inferred, a type annotation is required. For example, this code:
+
 ```rust
 let a: u8 = return ();
 let b: bool = abort 0;
@@ -136,12 +151,14 @@ Adding type annotations to this code will expose other errors about dead code or
 ### Multiple declarations with tuples
 
 `let` can introduce more than one local at a time using tuples. The locals declared inside the parenthesis are initialized to the corresponding values from the tuple.
+
 ```rust
 let () = ();
 let (x0, x1) = (0, 1);
 let (y0, y1, y2) = (0, 1, 2);
 let (z0, z1, z2, z3) = (0, 1, 2, 3);
 ```
+
 The type of the expression must match the arity of the tuple pattern exactly.
 
 ```rust
@@ -150,6 +167,7 @@ let (x, y, z, q) = (0, 1, 2); // ERROR!
 ```
 
 You cannot declare more than one local with the same name in a single `let`.
+
 ```rust
 let (x, x) = 0; // ERROR!
 ```
@@ -157,9 +175,11 @@ let (x, x) = 0; // ERROR!
 ### Multiple declarations with structs
 
 `let` can also introduce more than one local at a time when destructuring (or matching against) a struct. In this form, the `let` creates a set of local variables that are initialized to the values of the fields from a struct. The syntax looks like this:
+
 ```rust
 struct T { f1: u64, f2: u64 }
 ```
+
 ```rust
 let T { f1: local1, f2: local2 } = T { f1: 1, f2: 2 };
 // local1: u64
@@ -167,6 +187,7 @@ let T { f1: local1, f2: local2 } = T { f1: 1, f2: 2 };
 ```
 
 Here is a more complicated example:
+
 ```rust
 address 0x42 {
 module Example {
@@ -187,11 +208,15 @@ module Example {
 }
 }
 ```
+
 Fields of structs can serve double duty, identifying the field to bind *and* the name of the variable. This is sometimes referred to as punning.
+
 ```rust
 let X { f } = e;
 ```
+
 is equivalent to:
+
 ```rust
 let X { f: f } = e;
 ```
@@ -205,25 +230,31 @@ let Y { x1: x, x2: x } = e; // ERROR!
 ### Destructuring against references
 
 In the examples above for structs, the bound value in the let was moved, destroying the struct value and binding its fields.
+
 ```rust
 struct T { f1: u64, f2: u64 }
 ```
+
 ```rust
 let T { f1: local1, f2: local2 } = T { f1: 1, f2: 2 };
 // local1: u64
 // local2: u64
 ```
+
 In this scenario the struct value `T { f1: 1, f2: 2 }` no longer exists after the `let`.
 
 If you wish instead to not move and destroy the struct value, you can borrow each of its fields.
 For example:
+
 ```rust
 let t = T { f1: 1, f2: 2 };
 let T { f1: local1, f2: local2 } = &t;
 // local1: &u64
 // local2: &u64
 ```
+
 And similarly with mutable references:
+
 ```rust
 let t = T { f1: 1, f2: 2 };
 let T { f1: local1, f2: local2 } = &mut t;
@@ -232,6 +263,7 @@ let T { f1: local1, f2: local2 } = &mut t;
 ```
 
 This behavior can also work recursively.
+
 ```rust
 address 0x42 {
 module Example {
@@ -266,12 +298,15 @@ fun three(): (u64, u64, u64) {
     (0, 1, 2)
 }
 ```
+
 ```rust
 let (x1, _, z1) = three();
 let (x2, _y, z2) = three();
 assert(x1 + z1 == x2 + z2)
 ```
+
 This can be necessary at times as the compiler will error on unused local variables
+
 ```rust
 let (x1, y, z1) = three(); // ERROR!
 //       ^ unused local 'y'
@@ -294,6 +329,7 @@ The general term for the item that introduces the bindings is a *pattern*. The p
 > *field-binding* → *field* | *field* **:** *pattern*
 
 A few concrete examples with this grammar applied:
+
 ```rust
     let (x, y): (u64, u64) = (0, 1);
 //       ^                           local-variable
@@ -321,26 +357,32 @@ A few concrete examples with this grammar applied:
 //                      ^^^^^^^^^^^^^^^^^^^^   initializer
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ let-binding
 ```
+
 ## Mutations
 
 ### Assignments
 
 After the local is introduced (either by `let` or as a function parameter), the local can be modified via an assignment:
+
 ```rust
 x = e
 ```
 
 Unlike `let` bindings, assignments are expressions. In some languages, assignments return the value that was assigned, but in Move, the type of any assignment is always `()`.
+
 ```rust
 (x = e: ())
 ```
+
 Practically, assignments being expressions means that they can be used without adding a new expression block with braces (`{`...`}`).
+
 ```rust
 let x = 0;
 if (cond) x = 1 else x = 2;
 ```
 
 The assignment uses the same pattern syntax scheme as `let` bindings:
+
 ```rust=
 address 0x42 {
 module Example {
@@ -363,7 +405,9 @@ module Example {
 }
 }
 ```
+
 Note that a local variable can only have one type, so the type of the local cannot change between assignments.
+
 ```rust
 let x;
 x = 0;
@@ -381,9 +425,11 @@ let r = &mut x;
 assert(x == 1, 42)
 }
 ```
+
 This is particularly useful if either:
 
 (1) You want to modify different variables depending on some condition.
+
 ```rust
 let x = 0;
 let y = 1;
@@ -392,11 +438,14 @@ let r = if (cond) &mut x else &mut y;
 ```
 
 (2) You want another function to modify your local value.
+
 ```rust
 let x = 0;
 modify_ref(&mut x);
 ```
+
 This sort of modification is how you modify structs and vectors!
+
 ```rust
 let v = Vector::empty();
 Vector::push_back(&mut v, 100);
@@ -410,6 +459,7 @@ For more details, see [Move references](./references.md).
 Any local declared with `let` is available for any subsequent expression, *within that scope*. Scopes are declared with expression blocks, `{`...`}`.
 
 Locals cannot be used outside of the declared scope.
+
 ```rust
 let x = 0;
 {
@@ -420,6 +470,7 @@ x + y // ERROR!
 ```
 
 But, locals from an outer scope *can* be used in a nested scope.
+
 ```rust
 {
     let x = 0;
@@ -445,22 +496,27 @@ assert(x == 2, 42);
 ### Expression Blocks
 
 An expression block is a series of statements separated by semicolons (`;`). The resulting value of an expression block is the value of the last expression in the block.
+
 ```rust
 { let x = 1; let y = 1; x + y }
 ```
+
 In this example, the result of the block is `x + y`.
 
 A statement can be either a `let` declaration or an expression. Remember that assignments (`x = e`) are expressions of type `()`.
+
 ```rust
 { let x; let y = 1; x = 1; x + y }
 ```
 
 Function calls are another common expression of type `()`. Function calls that modify data are commonly used as statements.
+
 ```rust
 { let v = Vector::empty(); Vector::push_back(&mut v, 1); v }
 ```
 
 This is not just limited to `()` types---any expression can be used as a statement in a sequence!
+
 ```rust
 {
     let x = 0;
@@ -469,7 +525,9 @@ This is not just limited to `()` types---any expression can be used as a stateme
     b"hello"; // value is discarded
 }
 ```
+
 But! If the expression contains a resource, you will get an error. This is because Move's type system guarantees that no resource is dropped. (Ownership must be transferred or the resource must be explicitly destroyed within its declaring module.)
+
 ```rust
 {
     let x = 0;
@@ -480,6 +538,7 @@ But! If the expression contains a resource, you will get an error. This is becau
 ```
 
 If a final expression is not present in a block---that is, if there is a trailing semicolon `;`, there is an implicit unit `()` value. Similarly, if the expression block is empty, there is an implicit unit `()` value.
+
 ```rust
 // Both are equivalent
 { x = x + 1; 1 / x; }
@@ -493,6 +552,7 @@ If a final expression is not present in a block---that is, if there is a trailin
 ```
 
 An expression block is itself an expression and can be used anyplace an expression is used. (Note: The body of a function is also an expression block, but the function body cannot be replaced by another expression.)
+
 ```rust
 let my_vector: vector<vector<u8>> = {
     let v = Vector::empty();
@@ -501,6 +561,7 @@ let my_vector: vector<vector<u8>> = {
     v
 };
 ```
+
 (The type annotation is not needed in this example and only added for clarity.)
 
 ### Shadowing
@@ -514,7 +575,9 @@ assert(x == 0, 42);
 let x = 1; // x is shadowed
 assert(x == 1, 42);
 ```
+
 When a local is shadowed, it does not need to retain the same type as before.
+
 ```rust
 let x = 0;
 assert(x == 0, 42);
@@ -522,7 +585,9 @@ assert(x == 0, 42);
 let x = b"hello"; // x is shadowed
 assert(x == b"hello", 42);
 ```
+
 After a local is shadowed, the value stored in the local still exists, but will no longer be accessible. This is important to keep in mind with resources, as ownership of the value must be transferred by the end of the function.
+
 ```rust
 address 0x42 {
     module Example {
@@ -541,6 +606,7 @@ address 0x42 {
 ```
 
 When a local is shadowed inside a scope, the shadowing only remains for that scope. The shadowing is gone once that scope ends.
+
 ```rust
 let x = 0;
 {
@@ -551,6 +617,7 @@ assert(x == 0, 42);
 ```
 
 Remember, locals can change type when they are shadowed.
+
 ```rust
 let x = 0;
 {
@@ -565,14 +632,17 @@ assert(x == 0, 42);
 All local variables in Move can be used in two ways, either by `move` or `copy`. If one or the other is not specified, the Move compiler is able to infer whether a `copy` or a `move` should be used. This means that in all of the examples above, a `move` or a `copy` would be inserted by the compiler. A local variable cannot be used without the use of `move` or `copy`.
 
 `copy` will likely feel the most familiar coming from other programming languages, as it creates a new copy of the value inside of the variable to use in that expression. With `copy`, the local variable can be used more than once.
+
 ```rust
 let x = 0;
 let y = copy x + 1;
 let z = copy x + 2;
 ```
+
 All non-resource values can be copied using `copy`.
 
 `move` takes the value out of the local variable *without* copying the data. After a `move` occurs, the local variable is unavailable.
+
 ```rust
 let x = 1;
 let y = move x + 1;
@@ -600,6 +670,7 @@ As mentioned above, the Move compiler will infer a `copy` or `move` if one is no
     - This is to prevent accidental copies of large data structures.
 
 For example:
+
 ```rust
 let s = b"hello";
 let foo = Foo { f: 0 };

--- a/language/documentation/book/src/variables.md
+++ b/language/documentation/book/src/variables.md
@@ -1,8 +1,4 @@
----
-id: move-variables
-title: Local Variables and Scope
-sidebar_label: Variables
----
+# Local Variables and Scope
 
 Local variables in Move are lexically (statically) scoped. New variables are introduced with the keyword `let`, which will shadow any previous local with the same name. Locals are mutable and can be updated both directly and via a mutable reference.
 
@@ -128,7 +124,6 @@ let _v1 = Vector::empty(); // ERROR!
 //        ^^^^^^^^^^^^^^^ Could not infer this type. Try adding an annotation
 let v2: vector<u64> = Vector::empty(); // no error
 ```
-
 
 In a rarer case, the type system might not be able to infer a type for divergent code (where all the following code is unreachable). Both `return` and [`abort`](./abort-and-assert.md) are expressions and can have any type. A [`loop`](./loops.md) has type `()` if it has a `break`, but if there is no break out of the `loop`, it could have any type.
 If these types cannot be inferred, a type annotation is required. For example, this code:

--- a/language/documentation/book/src/vector.md
+++ b/language/documentation/book/src/vector.md
@@ -1,0 +1,126 @@
+---
+id: move-vector
+title: Vector
+sidebar_label: Vector
+---
+
+`vector<T>` is the only primitive collection type provided by Move. A `vector<T>` is a homogenous collection of `T`'s that can grow or shrink by pushing/popping values off the "end".
+
+A `vector<T>` can be instantiated with any type `T`, including resource types and other vectors. For example, `vector<u64>`, `vector<address>`, `vector<0x42::MyModule::MyResource>`, and `vector<vector<u8>>` are all valid vector types.
+
+## Operations
+
+`vector` supports the following operations via the `0x1::Vector` module in the Move standard library:
+
+| Function | Description | Aborts?
+| ---------- | ----------|----------
+| `Vector::empty<T>(): vector<T>` | Create an empty vector that can store values of type `T` | Never
+| `Vector::singleton<T>(t: T): vector<T>` | Create a vector of size 1 containing `t` | Never
+| `Vector::push_back<T>(v: &mut T, t: T)` | Add `t` to the end of `v` | Never
+| `Vector::pop_back<T>(v: &mut T): T` | Remove and return the last element in `v` | If `v` is empty
+| `Vector::borrow<T>(v: &vector<T>, i: u64): &T` | Return an immutable reference to the `T` at index `i` | If `i` is not in bounds
+| `Vector::borrow_mut<T>(v: &mut vector<T>, i: u64): &mut T` | Return an mutable reference to the `T` at index `i` | If `i` is not in bounds
+| `Vector::destroy_empty<T>(v: vector<T>)` | Delete `v` | If `v` is not empty
+| `Vector::append<T>(v1: &mut vector<T>, v2: vector<T>)` | Add the elements in `v2` to the end of `v1` | If `i` is not in bounds
+
+More operations may be added overtime
+
+## Example
+
+```rust
+use 0x1::Vector;
+
+let v = Vector::empty<u64>();
+Vector::push_back(&mut v, 5);
+Vector::push_back(&mut v, 6);
+
+assert(*Vector::borrow(&v, 0) == 5, 42);
+assert(*Vector::borrow(&v, 1) == 6, 42);
+assert(Vector::pop_back(&mut v) == 6, 42);
+assert(Vector::pop_back(&mut v) == 5, 42);
+```
+
+## Destroying and copying `vector`s
+
+Some behaviors of `vector<T>` depend on whether `T` is a resource type. For example, vectors containing resources cannot be implictly discarded like `v` in the example above--they must be explicitly destroyed with `Vector::destroy_empty`.
+
+Note that `Vector::destroy_empty` will abort at runtime unless `vec` contains zero elements.
+
+```rust
+fun destroy_resource_vector<T: resource>(vec: vector<T>) {
+    Vector::destroy_empty(vec) // deleting this line will cause a compiler error
+}
+```
+This error would also happen for an unconstrained `T` as the type *might* be a resource.
+```rust
+fun destroy_vector<T>(vec: vector<T>) {
+    Vector::destroy_empty(vec) // deleting this line will cause a compiler error
+}
+```
+But no error would occur for dropping a vector that contains `copyable` elements
+```rust
+fun destroy_copyable_vector<T: copyable>(vec: vector<T>) {
+    // valid!
+    // nothing needs to be done explicitly to destroy the vector
+}
+```
+
+Similarly, resource vectors cannot be copied. A `vector<T>` is copyable if and only if `T` is copyable. However, even copyable vectors are never implicitly copied:
+
+```rust
+let x = Vector::singleton<u64>(10);
+let y = copy x; // compiler error without the copy!
+```
+
+Copies of large vectors can be expensive, so the compiler requires explicit `copy`'s to make it easier to see where they are happening.
+
+## Literals
+
+### `vector<u8>` literals
+
+A common use-case for vectors in Move is to represent "byte arrays", which are represented with `vector<u8>`. These values are often used for cryptographic purposes, such as a public key or a hash result.
+
+There are currently two supported types of `vector<u8>` literals, byte strings and hex strings.
+
+#### Byte Strings
+
+Byte strings are quoted string literals prefixed by a `b`, e.g. `b"Hello!\n"`.
+
+These are ASCII encoded strings that allow for escape sequences. Currently, the supported escape sequences are
+
+| Escape Sequence | Description
+| -------- | --------
+| `\n` | New line (or Line feed)
+| `\r` | Carriage return
+| `\t` | Tab
+| `\\` | Backslash
+| `\0` | Null
+| `\"` | Quote
+| `\xHH` | Hex escape, inserts the hex byte sequence `HH`
+
+#### Hex Strings
+
+Hex strings are quoted string literals prefixed by a `x`, e.g. `x"48656C6C6F210A"`
+
+Each byte pair, ranging from `00` to `FF`, is interpreted as hex encoded `u8` value. So each byte pair corresponds to a single entry in the resulting `vector<u8>`
+
+#### Examples
+
+```rust
+script {
+fun byte_and_hex_strings() {
+    assert(b"" == x"", 0);
+    assert(b"Hello!\n" == x"48656C6C6F210A", 1);
+    assert(b"\x48\x65\x6C\x6C\x6F\x21\x0A" == x"48656C6C6F210A", 2);
+    assert(
+        b"\"Hello\tworld!\"\n \r \\Null=\0" ==
+            x"2248656C6C6F09776F726C6421220A200D205C4E756C6C3D00",
+        3
+    );
+}
+}
+```
+
+### Other `vector` literals
+
+Currently, there is no support for general `vector<T>` literals in Move where `T` is not a `u8`. However, Move bytecode supports `vector<T>` constants for any primitive type `T`. We plan to add `vector<T>` literals to the source language that can compile to bytecode constants.

--- a/language/documentation/book/src/vector.md
+++ b/language/documentation/book/src/vector.md
@@ -1,8 +1,4 @@
----
-id: move-vector
-title: Vector
-sidebar_label: Vector
----
+# Vector
 
 `vector<T>` is the only primitive collection type provided by Move. A `vector<T>` is a homogenous collection of `T`'s that can grow or shrink by pushing/popping values off the "end".
 

--- a/language/documentation/book/src/vector.md
+++ b/language/documentation/book/src/vector.md
@@ -51,13 +51,17 @@ fun destroy_resource_vector<T: resource>(vec: vector<T>) {
     Vector::destroy_empty(vec) // deleting this line will cause a compiler error
 }
 ```
+
 This error would also happen for an unconstrained `T` as the type *might* be a resource.
+
 ```rust
 fun destroy_vector<T>(vec: vector<T>) {
     Vector::destroy_empty(vec) // deleting this line will cause a compiler error
 }
 ```
+
 But no error would occur for dropping a vector that contains `copyable` elements
+
 ```rust
 fun destroy_copyable_vector<T: copyable>(vec: vector<T>) {
     // valid!


### PR DESCRIPTION
This adds a preliminary version of the Move language documentation as an mdBook, keeping the same content that is currently published on the Diem developer documentation website. It has not yet been updated to reflect changes in version 1.2. Further changes in the formatting are probably also needed to organize the book into larger chapters, e.g., "Primitive Types", instead of just a list of small sections as independent chapters. And, we will need to figure out how and when to build the html content.

## Motivation

We have decided to go back to keeping the Move language documentation in GitHub, but will now use mdBook to format the document.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Ran `mdbook build` and sanity checked the generated content