### PR TITLE
[verifying-client] Verify consistency proofs

### DIFF
--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -253,6 +253,18 @@ impl HashValue {
             .map_err(|_| HashValueParseError)
             .map(Self::new)
     }
+
+    /// Create a hash value whose contents are just the given integer. Useful for
+    /// generating basic mock hash values.
+    ///
+    /// Ex: HashValue::from_u64(0x1234) => HashValue([0, .., 0, 0x12, 0x34])
+    #[cfg(any(test, feature = "fuzzing"))]
+    pub fn from_u64(v: u64) -> Self {
+        let mut hash = [0u8; Self::LENGTH];
+        let bytes = v.to_be_bytes();
+        hash[Self::LENGTH - bytes.len()..].copy_from_slice(&bytes[..]);
+        Self::new(hash)
+    }
 }
 
 impl ser::Serialize for HashValue {

--- a/execution/executor-test-helpers/src/integration_test_impl.rs
+++ b/execution/executor-test-helpers/src/integration_test_impl.rs
@@ -240,13 +240,18 @@ pub fn test_execution_with_storage_impl() -> Arc<DiemDB> {
         .commit_blocks(vec![block1_id], ledger_info_with_sigs)
         .unwrap();
 
-    let (li, epoch_change_proof, _accumulator_consistency_proof) =
-        db.reader.get_state_proof(0).unwrap();
-    let mut trusted_state = TrustedState::from(waypoint);
-    match trusted_state.verify_and_ratchet(&li, &epoch_change_proof) {
-        Ok(TrustedStateChange::Epoch { new_state, .. }) => trusted_state = new_state,
+    let initial_accumulator = db.reader.get_accumulator_summary(0).unwrap();
+    let (li, epoch_change_proof, consistency_proof) = db.reader.get_state_proof(0).unwrap();
+    let trusted_state = TrustedState::from_epoch_waypoint(waypoint);
+    let trusted_state = match trusted_state.verify_and_ratchet(
+        &li,
+        &epoch_change_proof,
+        &consistency_proof,
+        Some(&initial_accumulator),
+    ) {
+        Ok(TrustedStateChange::Epoch { new_state, .. }) => new_state,
         _ => panic!("unexpected state change"),
-    }
+    };
     let current_version = li.ledger_info().version();
     assert_eq!(trusted_state.version(), 9);
 
@@ -416,11 +421,15 @@ pub fn test_execution_with_storage_impl() -> Arc<DiemDB> {
         .commit_blocks(vec![block2_id], ledger_info_with_sigs)
         .unwrap();
 
-    let (li, epoch_change_proof, _accumulator_consistency_proof) =
+    let (li, epoch_change_proof, consistency_proof) =
         db.reader.get_state_proof(trusted_state.version()).unwrap();
-    trusted_state
-        .verify_and_ratchet(&li, &epoch_change_proof)
+    let trusted_state_change = trusted_state
+        .verify_and_ratchet(&li, &epoch_change_proof, &consistency_proof, None)
         .unwrap();
+    assert!(matches!(
+        trusted_state_change,
+        TrustedStateChange::Version { .. }
+    ));
     let current_version = li.ledger_info().version();
     assert_eq!(current_version, 23);
 

--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -152,7 +152,7 @@ impl DbReader for FakeDb {
     fn get_state_proof_with_ledger_info(
         &self,
         _known_version: u64,
-        _ledger_info: LedgerInfoWithSignatures,
+        _ledger_info: &LedgerInfoWithSignatures,
     ) -> Result<(EpochChangeProof, AccumulatorConsistencyProof)> {
         unimplemented!();
     }

--- a/json-rpc/API-CHANGELOG.md
+++ b/json-rpc/API-CHANGELOG.md
@@ -13,6 +13,11 @@ Please add the API change in the following format:
 
 ```
 
+## 2021-06-01 Add `get_accumulator_consistency_proof` API
+
+This API allows light clients to build their initial transaction accumulator summary
+and verifiably extend their accumulator summary to newer ledger states.
+
 ## 2021-05-25 Add `TreasuryComplianceRole`
 
 TreasuryComplianceRole has been created and has a field `diem_id_domain_events_key` that stores the event key of diem id domain events.

--- a/json-rpc/docs/method_get_accumulator_consistency_proof.md
+++ b/json-rpc/docs/method_get_accumulator_consistency_proof.md
@@ -1,0 +1,34 @@
+## Method get_accumulator_consistency_proof
+
+**Description**
+
+Gets an accumulator consistency proof starting from `client_known_version` (or pre-genesis if null or not present) until `ledger_version` (or the server's current version if null or not present).
+
+In other words, if the client has an accumulator summary for `client_known_version`, they can use the result from this API to efficiently extend their accumulator to `ledger_version` and prove that the new accumulator is consistent with their old accumulator. By consistent, we mean that by appending the actual `ledger_version - client_known_version` transactions to the old accumulator summary you get the new accumulator summary.
+
+If the client is starting up for the first time and has no accumulator summary yet, they can call this without `client_known_version`, i.e., pre-genesis, to get the complete accumulator summary up to `ledger_version`.
+
+### Parameters
+
+| Name                 | Type                   | Description                                                                                                                                                                                                     |
+|----------------------|------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| client_known_version | Option<unsigned int64> | The version of the client's current accumulator summary. This parameter is optional; if null or not present, the proof will start from pre-genesis, allowing the client to build an initial accumulator summary |
+| ledger_version       | Option<unsinged int64> | The target version of the consistency proof. The parameter is optional; if null or not present, the target version will be the server's current ledger version.                                                 |
+
+### Returns
+
+Returns an object with a field `ledger_consistency_proof`. The field is a hex-encoded string of the raw BCS bytes of the `AccumulatorConsistencyProof` type, spanning versions `client_known_version` to `ledger_version`.
+
+Example JSON-RPC response:
+```json
+{
+    "id": 1,
+    "jsonrpc": "2.0",
+    "diem_chain_id": 4,
+    "diem_ledger_timestampusec": 1621975989145066,
+    "diem_ledger_version": 148,
+    "result": {
+        "ledger_consistency_proof": "04207311cfe9202a5ece145829ef74dfe6f2bb835ce9f747a94437360bfb6d1d96e2200134b4b5f232395c5553af9b99558d33b11e338cc0d62606a0922fe1d2d0e0582061e9761b07c1223b11ac93a70c0a16833a80e8f6f2ae5d285cda6f592013712f20d7907576215fe0c824f92d03d12fda9a05069e8c7fdd1a6eaeb74922b2251f0d",
+    },
+}
+```

--- a/json-rpc/src/data.rs
+++ b/json-rpc/src/data.rs
@@ -267,7 +267,7 @@ pub fn get_state_proof(
     version: u64,
     ledger_info: &LedgerInfoWithSignatures,
 ) -> Result<StateProofView, JsonRpcError> {
-    let proofs = db.get_state_proof_with_ledger_info(version, ledger_info.clone())?;
+    let proofs = db.get_state_proof_with_ledger_info(version, &ledger_info)?;
     StateProofView::try_from((ledger_info.clone(), proofs.0, proofs.1)).map_err(Into::into)
 }
 

--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -6,18 +6,19 @@ use crate::{
     data,
     errors::JsonRpcError,
     views::{
-        AccountStateWithProofView, AccountView, CurrencyInfoView, EventView, EventWithProofView,
-        MetadataView, StateProofView, TransactionListView, TransactionView,
-        TransactionsWithProofsView,
+        AccountStateWithProofView, AccountView, AccumulatorConsistencyProofView, CurrencyInfoView,
+        EventView, EventWithProofView, MetadataView, StateProofView, TransactionListView,
+        TransactionView, TransactionsWithProofsView,
     },
 };
 use anyhow::Result;
 use diem_config::config::RoleType;
 use diem_json_rpc_types::request::{
     GetAccountParams, GetAccountStateWithProofParams, GetAccountTransactionParams,
-    GetAccountTransactionsParams, GetCurrenciesParams, GetEventsParams, GetEventsWithProofsParams,
-    GetMetadataParams, GetNetworkStatusParams, GetStateProofParams, GetTransactionsParams,
-    GetTransactionsWithProofsParams, MethodRequest, SubmitParams,
+    GetAccountTransactionsParams, GetAccumulatorConsistencyProofParams, GetCurrenciesParams,
+    GetEventsParams, GetEventsWithProofsParams, GetMetadataParams, GetNetworkStatusParams,
+    GetStateProofParams, GetTransactionsParams, GetTransactionsWithProofsParams, MethodRequest,
+    SubmitParams,
 };
 use diem_mempool::{MempoolClientSender, SubmissionStatus};
 use diem_types::{
@@ -169,6 +170,9 @@ impl<'a> Handler<'a> {
             }
             MethodRequest::GetStateProof(params) => {
                 serde_json::to_value(self.get_state_proof(params).await?)?
+            }
+            MethodRequest::GetAccumulatorConsistencyProof(params) => {
+                serde_json::to_value(self.get_accumulator_consistency_proof(params).await?)?
             }
             MethodRequest::GetAccountStateWithProof(params) => {
                 serde_json::to_value(self.get_account_state_with_proof(params).await?)?
@@ -341,6 +345,18 @@ impl<'a> Handler<'a> {
     ) -> Result<StateProofView, JsonRpcError> {
         let version = self.version_param(Some(params.version), "version")?;
         data::get_state_proof(self.service.db.borrow(), version, &self.ledger_info)
+    }
+
+    async fn get_accumulator_consistency_proof(
+        &self,
+        params: GetAccumulatorConsistencyProofParams,
+    ) -> Result<AccumulatorConsistencyProofView, JsonRpcError> {
+        let ledger_version = self.version_param(params.ledger_version, "ledger_version")?;
+        data::get_accumulator_consistency_proof(
+            self.service.db.borrow(),
+            params.client_known_version,
+            ledger_version,
+        )
     }
 
     /// Returns the account state to the client, alongside a proof relative to the version and

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -763,6 +763,38 @@ fn test_json_rpc_protocol_invalid_requests() {
             }),
         ),
         (
+            "get_accumulator_consistency_proof: ledger_version is too large",
+            json!({"jsonrpc": "2.0", "method": "get_accumulator_consistency_proof", "params": [5, version+1], "id": 1}),
+            json!({
+                "error": {
+                    "code": -32602,
+                    "message": format!("Invalid param ledger_version should be <= known latest version {}", version),
+                    "data": null
+                },
+                "id": 1,
+                "jsonrpc": "2.0",
+                "diem_chain_id": ChainId::test().id(),
+                "diem_ledger_timestampusec": timestamp,
+                "diem_ledger_version": version
+            }),
+        ),
+        (
+            "get_accumulator_consistency_proof: client_known_version is greater than ledger_version",
+            json!({"jsonrpc": "2.0", "method": "get_accumulator_consistency_proof", "params": [10, 5], "id": 1}),
+            json!({
+                "error": {
+                    "code": -32600,
+                    "message": "Invalid Request: client_known_version(10) should be <= ledger_version(5)".to_string(),
+                    "data": null
+                },
+                "id": 1,
+                "jsonrpc": "2.0",
+                "diem_chain_id": ChainId::test().id(),
+                "diem_ledger_timestampusec": timestamp,
+                "diem_ledger_version": version
+            }),
+        ),
+        (
             "get_account_state_with_proof: invalid account address",
             json!({"jsonrpc": "2.0", "method": "get_account_state_with_proof", "params": ["invalid", 1, 1], "id": 1}),
             json!({

--- a/json-rpc/src/tests/utils.rs
+++ b/json-rpc/src/tests/utils.rs
@@ -269,7 +269,7 @@ impl DbReader for MockDiemDB {
         AccumulatorConsistencyProof,
     )> {
         let li = self.get_latest_ledger_info()?;
-        let proofs = self.get_state_proof_with_ledger_info(known_version, li.clone())?;
+        let proofs = self.get_state_proof_with_ledger_info(known_version, &li)?;
         Ok((
             LedgerInfoWithSignatures::new(li.ledger_info().clone(), BTreeMap::new()),
             proofs.0,
@@ -280,7 +280,7 @@ impl DbReader for MockDiemDB {
     fn get_state_proof_with_ledger_info(
         &self,
         _known_version: u64,
-        _ledger_info: LedgerInfoWithSignatures,
+        _ledger_info: &LedgerInfoWithSignatures,
     ) -> Result<(EpochChangeProof, AccumulatorConsistencyProof)> {
         Ok((
             EpochChangeProof::new(vec![], false),

--- a/json-rpc/types/proto/src/jsonrpc.proto
+++ b/json-rpc/types/proto/src/jsonrpc.proto
@@ -420,3 +420,11 @@ message AccountStateProof {
   // hex-encoded bcs bytes
   string transaction_info_to_account_proof = 3 [json_name="transaction_info_to_account_proof"];
 }
+
+/**
+ * This is for the experimental API get_accumulator_consistency_proof response. It is unstable and likely to be changed.
+ */
+message AccumulatorConsistencyProof {
+  // hex-encoded bcs bytes
+  string ledger_consistency_proof = 1 [json_name="ledger_consistency_proof"];
+}

--- a/json-rpc/types/src/lib.rs
+++ b/json-rpc/types/src/lib.rs
@@ -41,6 +41,7 @@ pub enum Method {
     // Experimental APIs
     //
     GetStateProof,
+    GetAccumulatorConsistencyProof,
     GetAccountStateWithProof,
     GetTransactionsWithProofs,
     GetEventsWithProofs,
@@ -59,6 +60,7 @@ impl Method {
             Method::GetCurrencies => "get_currencies",
             Method::GetNetworkStatus => "get_network_status",
             Method::GetStateProof => "get_state_proof",
+            Method::GetAccumulatorConsistencyProof => "get_accumulator_consistency_proof",
             Method::GetAccountStateWithProof => "get_account_state_with_proof",
             Method::GetTransactionsWithProofs => "get_transactions_with_proofs",
             Method::GetEventsWithProofs => "get_events_with_proofs",

--- a/json-rpc/types/src/request.rs
+++ b/json-rpc/types/src/request.rs
@@ -77,6 +77,7 @@ pub enum MethodRequest {
     // Experimental APIs
     //
     GetStateProof(GetStateProofParams),
+    GetAccumulatorConsistencyProof(GetAccumulatorConsistencyProofParams),
     GetAccountStateWithProof(GetAccountStateWithProofParams),
     GetTransactionsWithProofs(GetTransactionsWithProofsParams),
     GetEventsWithProofs(GetEventsWithProofsParams),
@@ -103,6 +104,9 @@ impl MethodRequest {
                 MethodRequest::GetNetworkStatus(serde_json::from_value(value)?)
             }
             Method::GetStateProof => MethodRequest::GetStateProof(serde_json::from_value(value)?),
+            Method::GetAccumulatorConsistencyProof => {
+                MethodRequest::GetAccumulatorConsistencyProof(serde_json::from_value(value)?)
+            }
             Method::GetAccountStateWithProof => {
                 MethodRequest::GetAccountStateWithProof(serde_json::from_value(value)?)
             }
@@ -129,6 +133,9 @@ impl MethodRequest {
             MethodRequest::GetCurrencies(_) => Method::GetCurrencies,
             MethodRequest::GetNetworkStatus(_) => Method::GetNetworkStatus,
             MethodRequest::GetStateProof(_) => Method::GetStateProof,
+            MethodRequest::GetAccumulatorConsistencyProof(_) => {
+                Method::GetAccumulatorConsistencyProof
+            }
             MethodRequest::GetAccountStateWithProof(_) => Method::GetAccountStateWithProof,
             MethodRequest::GetTransactionsWithProofs(_) => Method::GetTransactionsWithProofs,
             MethodRequest::GetEventsWithProofs(_) => Method::GetEventsWithProofs,
@@ -304,6 +311,14 @@ impl<'de> de::Visitor<'de> for NoParamsVisitor {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct GetStateProofParams {
     pub version: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct GetAccumulatorConsistencyProofParams {
+    #[serde(default)]
+    pub client_known_version: Option<u64>,
+    #[serde(default)]
+    pub ledger_version: Option<u64>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -711,6 +726,64 @@ mod test {
             "foo": 11,
         });
         serde_json::from_value::<GetStateProofParams>(value).unwrap();
+    }
+
+    #[test]
+    fn get_accumulator_consistency_proof() {
+        // Array with all params
+        let value = serde_json::json!([11, 42]);
+        serde_json::from_value::<GetAccumulatorConsistencyProofParams>(value).unwrap();
+
+        // Array with too many params
+        let value = serde_json::json!([11, 42, 7]);
+        serde_json::from_value::<GetAccumulatorConsistencyProofParams>(value).unwrap_err();
+
+        // Array with no ledger version
+        let value = serde_json::json!([11]);
+        serde_json::from_value::<GetAccumulatorConsistencyProofParams>(value).unwrap();
+
+        // Array with no ledger version or client known version
+        let value = serde_json::json!([]);
+        serde_json::from_value::<GetAccumulatorConsistencyProofParams>(value).unwrap();
+
+        // Array with wrong first param
+        let value = serde_json::json!(["foo"]);
+        serde_json::from_value::<GetAccumulatorConsistencyProofParams>(value).unwrap_err();
+
+        // Array with wrong second param
+        let value = serde_json::json!([123, "bar"]);
+        serde_json::from_value::<GetAccumulatorConsistencyProofParams>(value).unwrap_err();
+
+        // Object with no ledger version or client known version
+        let value = serde_json::json!({});
+        serde_json::from_value::<GetAccumulatorConsistencyProofParams>(value).unwrap();
+
+        // Object with no ledger version
+        let value = serde_json::json!({
+            "client_known_version": 123,
+        });
+        serde_json::from_value::<GetAccumulatorConsistencyProofParams>(value).unwrap();
+
+        // Object with no client known version
+        let value = serde_json::json!({
+            "ledger_version": 123,
+        });
+        serde_json::from_value::<GetAccumulatorConsistencyProofParams>(value).unwrap();
+
+        // Object with all params
+        let value = serde_json::json!({
+            "client_known_version": 42,
+            "ledger_version": 123,
+        });
+        serde_json::from_value::<GetAccumulatorConsistencyProofParams>(value).unwrap();
+
+        // Object with extra params
+        let value = serde_json::json!({
+            "client_known_version": 42,
+            "ledger_version": 123,
+            "foo": "bar",
+        });
+        serde_json::from_value::<GetAccumulatorConsistencyProofParams>(value).unwrap();
     }
 
     #[test]

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -1292,6 +1292,29 @@ impl TryFrom<&StateProofView>
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct AccumulatorConsistencyProofView {
+    pub ledger_consistency_proof: BytesView,
+}
+
+impl TryFrom<&AccumulatorConsistencyProof> for AccumulatorConsistencyProofView {
+    type Error = Error;
+
+    fn try_from(proof: &AccumulatorConsistencyProof) -> Result<Self, Self::Error> {
+        Ok(Self {
+            ledger_consistency_proof: BytesView::new(bcs::to_bytes(proof)?),
+        })
+    }
+}
+
+impl TryFrom<&AccumulatorConsistencyProofView> for AccumulatorConsistencyProof {
+    type Error = Error;
+
+    fn try_from(view: &AccumulatorConsistencyProofView) -> Result<Self, Self::Error> {
+        Ok(bcs::from_bytes(view.ledger_consistency_proof.as_ref())?)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct AccountStateWithProofView {
     pub version: u64,
     pub blob: Option<BytesView>,

--- a/sdk/client/src/blocking.rs
+++ b/sdk/client/src/blocking.rs
@@ -11,8 +11,9 @@ use crate::{
     error::WaitForTransactionError,
     move_deserialize::{self, Event},
     views::{
-        AccountStateWithProofView, AccountView, CurrencyInfoView, EventView, EventWithProofView,
-        MetadataView, StateProofView, TransactionView, TransactionsWithProofsView,
+        AccountStateWithProofView, AccountView, AccumulatorConsistencyProofView, CurrencyInfoView,
+        EventView, EventWithProofView, MetadataView, StateProofView, TransactionView,
+        TransactionsWithProofsView,
     },
     Error, Result, Retry, State,
 };
@@ -216,6 +217,17 @@ impl BlockingClient {
 
     pub fn get_state_proof(&self, from_version: u64) -> Result<Response<StateProofView>> {
         self.send(MethodRequest::get_state_proof(from_version))
+    }
+
+    pub fn get_accumulator_consistency_proof(
+        &self,
+        client_known_version: Option<u64>,
+        ledger_version: Option<u64>,
+    ) -> Result<Response<AccumulatorConsistencyProofView>> {
+        self.send(MethodRequest::get_accumulator_consistency_proof(
+            client_known_version,
+            ledger_version,
+        ))
     }
 
     pub fn get_account_state_with_proof(

--- a/sdk/client/src/client.rs
+++ b/sdk/client/src/client.rs
@@ -11,8 +11,9 @@ use crate::{
     error::WaitForTransactionError,
     move_deserialize::{self, Event},
     views::{
-        AccountStateWithProofView, AccountView, CurrencyInfoView, EventView, EventWithProofView,
-        MetadataView, StateProofView, TransactionView, TransactionsWithProofsView,
+        AccountStateWithProofView, AccountView, AccumulatorConsistencyProofView, CurrencyInfoView,
+        EventView, EventWithProofView, MetadataView, StateProofView, TransactionView,
+        TransactionsWithProofsView,
     },
     Error, Result, Retry, State,
 };
@@ -233,6 +234,18 @@ impl Client {
     pub async fn get_state_proof(&self, from_version: u64) -> Result<Response<StateProofView>> {
         self.send(MethodRequest::get_state_proof(from_version))
             .await
+    }
+
+    pub async fn get_accumulator_consistency_proof(
+        &self,
+        client_known_version: Option<u64>,
+        ledger_version: Option<u64>,
+    ) -> Result<Response<AccumulatorConsistencyProofView>> {
+        self.send(MethodRequest::get_accumulator_consistency_proof(
+            client_known_version,
+            ledger_version,
+        ))
+        .await
     }
 
     pub async fn get_account_state_with_proof(

--- a/sdk/client/src/error.rs
+++ b/sdk/client/src/error.rs
@@ -121,11 +121,8 @@ impl Error {
         )
     }
 
-    pub(crate) fn stale(expected: &super::State, recieved: &super::State) -> Self {
-        Self::new(
-            Kind::StaleResponse,
-            Some(format!("expected: {:?} recieved: {:?}", expected, recieved)),
-        )
+    pub(crate) fn stale<E: Into<BoxError>>(e: E) -> Self {
+        Self::new(Kind::StaleResponse, Some(e))
     }
 
     cfg_async! {

--- a/sdk/client/src/lib.rs
+++ b/sdk/client/src/lib.rs
@@ -78,6 +78,7 @@ pub enum Method {
     // Experimental APIs
     //
     GetStateProof,
+    GetAccumulatorConsistencyProof,
     GetAccountStateWithProof,
     GetTransactionsWithProofs,
     GetEventsWithProofs,

--- a/sdk/client/src/lib.rs
+++ b/sdk/client/src/lib.rs
@@ -87,6 +87,7 @@ pub enum Method {
 cfg_async_or_blocking! {
     fn validate(
         state_manager: &state::StateManager,
+        req_state: Option<&State>,
         resp: &diem_json_rpc_types::response::JsonRpcResponse,
         ignore_stale: bool,
     ) -> Result<(u64, State, serde_json::Value)> {
@@ -102,28 +103,25 @@ cfg_async_or_blocking! {
             return Err(Error::json_rpc(err.clone()));
         }
 
-        let state = State::from_response(resp);
-        if let Err(e) = state_manager.update_state(&state) {
-            if !ignore_stale {
-                return Err(e);
-            }
-        }
+        let resp_state = State::from_response(resp);
+        state_manager.update_state(ignore_stale, req_state, &resp_state)?;
 
         // Result being empty is an acceptable response
         let result = resp.result.clone().unwrap_or(serde_json::Value::Null);
 
-        Ok((id, state, result))
+        Ok((id, resp_state, result))
     }
 
     fn validate_batch(
         state_manager: &state::StateManager,
+        req_state: Option<&State>,
         requests: &[JsonRpcRequest],
         raw_responses: Vec<diem_json_rpc_types::response::JsonRpcResponse>,
     ) -> Result<Vec<Result<Response<MethodResponse>>>> {
         let mut responses = std::collections::HashMap::new();
         for raw_response in &raw_responses {
             let id = get_id(&raw_response)?;
-            let response = validate(state_manager, &raw_response, false);
+            let response = validate(state_manager, req_state, &raw_response, false);
 
             responses.insert(id, response);
         }

--- a/sdk/client/src/request.rs
+++ b/sdk/client/src/request.rs
@@ -26,6 +26,7 @@ pub enum MethodRequest {
     // Experimental APIs
     //
     GetStateProof((u64,)),
+    GetAccumulatorConsistencyProof(Option<u64>, Option<u64>),
     GetAccountStateWithProof(AccountAddress, Option<u64>, Option<u64>),
     GetTransactionsWithProofs(u64, u64, bool),
     GetEventsWithProofs(EventKey, u64, u64),
@@ -93,6 +94,14 @@ impl MethodRequest {
     pub fn get_state_proof(from_version: u64) -> Self {
         Self::GetStateProof((from_version,))
     }
+
+    pub fn get_accumulator_consistency_proof(
+        client_known_version: Option<u64>,
+        ledger_version: Option<u64>,
+    ) -> Self {
+        Self::GetAccumulatorConsistencyProof(client_known_version, ledger_version)
+    }
+
     pub fn get_account_state_with_proof(
         address: AccountAddress,
         version: Option<u64>,
@@ -125,6 +134,9 @@ impl MethodRequest {
             MethodRequest::GetCurrencies(_) => Method::GetCurrencies,
             MethodRequest::GetNetworkStatus(_) => Method::GetNetworkStatus,
             MethodRequest::GetStateProof(_) => Method::GetStateProof,
+            MethodRequest::GetAccumulatorConsistencyProof(_, _) => {
+                Method::GetAccumulatorConsistencyProof
+            }
             MethodRequest::GetAccountStateWithProof(_, _, _) => Method::GetAccountStateWithProof,
             MethodRequest::GetTransactionsWithProofs(_, _, _) => Method::GetTransactionsWithProofs,
             MethodRequest::GetEventsWithProofs(_, _, _) => Method::GetEventsWithProofs,

--- a/sdk/client/src/response.rs
+++ b/sdk/client/src/response.rs
@@ -155,6 +155,18 @@ impl MethodResponse {
         }
     }
 
+    pub fn try_into_get_accumulator_consistency_proof(
+        self,
+    ) -> Result<AccumulatorConsistencyProofView, Error> {
+        match self {
+            MethodResponse::GetAccumulatorConsistencyProof(proof) => Ok(proof),
+            _ => Err(Error::rpc_response(format!(
+                "expected MethodResponse::GetAccumulatorConsistencyProof found MethodResponse::{:?}",
+                self.method()
+            ))),
+        }
+    }
+
     pub fn try_into_get_account(self) -> Result<Option<AccountView>, Error> {
         match self {
             MethodResponse::GetAccount(account_view) => Ok(account_view),

--- a/sdk/client/src/response.rs
+++ b/sdk/client/src/response.rs
@@ -4,12 +4,12 @@
 use super::Method;
 use crate::{
     views::{
-        AccountStateWithProofView, AccountView, CurrencyInfoView, EventView, MetadataView,
-        StateProofView, TransactionView,
+        AccountStateWithProofView, AccountView, AccumulatorConsistencyProofView, CurrencyInfoView,
+        EventView, EventWithProofView, MetadataView, StateProofView, TransactionView,
+        TransactionsWithProofsView,
     },
     Error, State,
 };
-use diem_json_rpc_types::views::{EventWithProofView, TransactionsWithProofsView};
 use serde_json::Value;
 
 #[derive(Debug)]
@@ -65,7 +65,11 @@ pub enum MethodResponse {
     GetCurrencies(Vec<CurrencyInfoView>),
     GetNetworkStatus(u64),
 
+    //
+    // Experimental APIs
+    //
     GetStateProof(StateProofView),
+    GetAccumulatorConsistencyProof(AccumulatorConsistencyProofView),
     GetAccountStateWithProof(AccountStateWithProofView),
     GetTransactionsWithProofs(Option<TransactionsWithProofsView>),
     GetEventsWithProofs(Vec<EventWithProofView>),
@@ -92,6 +96,9 @@ impl MethodResponse {
                 MethodResponse::GetNetworkStatus(serde_json::from_value(json)?)
             }
             Method::GetStateProof => MethodResponse::GetStateProof(serde_json::from_value(json)?),
+            Method::GetAccumulatorConsistencyProof => {
+                MethodResponse::GetAccumulatorConsistencyProof(serde_json::from_value(json)?)
+            }
             Method::GetAccountStateWithProof => {
                 MethodResponse::GetAccountStateWithProof(serde_json::from_value(json)?)
             }
@@ -118,6 +125,9 @@ impl MethodResponse {
             MethodResponse::GetCurrencies(_) => Method::GetCurrencies,
             MethodResponse::GetNetworkStatus(_) => Method::GetNetworkStatus,
             MethodResponse::GetStateProof(_) => Method::GetStateProof,
+            MethodResponse::GetAccumulatorConsistencyProof(_) => {
+                Method::GetAccumulatorConsistencyProof
+            }
             MethodResponse::GetAccountStateWithProof(_) => Method::GetAccountStateWithProof,
             MethodResponse::GetTransactionsWithProofs(_) => Method::GetTransactionsWithProofs,
             MethodResponse::GetEventsWithProofs(_) => Method::GetEventsWithProofs,

--- a/sdk/client/src/state.rs
+++ b/sdk/client/src/state.rs
@@ -58,7 +58,11 @@ cfg_async_or_blocking! {
                     return Err(Error::chain_id(state.chain_id, resp_state.chain_id));
                 }
                 if resp_state < state {
-                    return Err(Error::stale(state, resp_state));
+                    return Err(Error::stale(format!(
+                        "received response with stale metadata: {:?}, expected a response more recent than: {:?}",
+                        resp_state,
+                        state,
+                    )));
                 }
             }
             *state_writer = Some(resp_state.clone());

--- a/sdk/compatibility/src/lib.rs
+++ b/sdk/compatibility/src/lib.rs
@@ -7,14 +7,14 @@
 
 use anyhow::Result;
 use diem_sdk::{
-    crypto::hash::{HashValue, TransactionAccumulatorHasher},
+    crypto::HashValue,
     transaction_builder::{
         stdlib::{self, ScriptCall},
         Currency, DualAttestationMessage,
     },
     types::{
         account_address::AccountAddress,
-        proof::{accumulator::InMemoryAccumulator, AccumulatorConsistencyProof},
+        proof::{AccumulatorConsistencyProof, TransactionAccumulatorSummary},
         transaction::Script,
         AccountKey,
     },
@@ -76,9 +76,8 @@ fn get_accumulator_consistency_proof() -> Result<()> {
         .get_accumulator_consistency_proof(None, Some(metadata.version))?
         .into_inner();
     let proof = AccumulatorConsistencyProof::try_from(&proof_view)?;
-    let num_txns = metadata.version + 1;
     let accumulator =
-        InMemoryAccumulator::<TransactionAccumulatorHasher>::new(proof.into_subtrees(), num_txns)?;
+        TransactionAccumulatorSummary::try_from_genesis_proof(proof, metadata.version)?;
 
     // the root hashes should match up
     assert_eq!(metadata.accumulator_root_hash, accumulator.root_hash());

--- a/storage/diemdb/src/ledger_store/mod.rs
+++ b/storage/diemdb/src/ledger_store/mod.rs
@@ -314,12 +314,9 @@ impl LedgerStore {
         ledger_version: Version,
     ) -> Result<AccumulatorConsistencyProof> {
         let client_known_num_leaves = client_known_version
-            .map(|v| v.checked_add(1).ok_or_else(|| format_err!("overflow")))
-            .transpose()?
+            .map(|v| v.saturating_add(1))
             .unwrap_or(0);
-        let ledger_num_leaves = ledger_version
-            .checked_add(1)
-            .ok_or_else(|| format_err!("overflow"))?;
+        let ledger_num_leaves = ledger_version.saturating_add(1);
         Accumulator::get_consistency_proof(self, ledger_num_leaves, client_known_num_leaves)
     }
 

--- a/storage/diemdb/src/lib.rs
+++ b/storage/diemdb/src/lib.rs
@@ -774,7 +774,7 @@ impl DbReader for DiemDB {
 
             let ledger_consistency_proof = self
                 .ledger_store
-                .get_consistency_proof(known_version, ledger_info.version())?;
+                .get_consistency_proof(Some(known_version), ledger_info.version())?;
             Ok((epoch_change_proof, ledger_consistency_proof))
         })
     }
@@ -918,6 +918,17 @@ impl DbReader for DiemDB {
     fn get_accumulator_root_hash(&self, version: Version) -> Result<HashValue> {
         gauged_api("get_accumulator_root_hash", || {
             self.ledger_store.get_root_hash(version)
+        })
+    }
+
+    fn get_accumulator_consistency_proof(
+        &self,
+        client_known_version: Option<Version>,
+        ledger_version: Version,
+    ) -> Result<AccumulatorConsistencyProof> {
+        gauged_api("get_accumulator_consistency_proof", || {
+            self.ledger_store
+                .get_consistency_proof(client_known_version, ledger_version)
         })
     }
 }

--- a/storage/storage-client/src/lib.rs
+++ b/storage/storage-client/src/lib.rs
@@ -175,7 +175,7 @@ impl DbReader for StorageClient {
     fn get_state_proof_with_ledger_info(
         &self,
         _known_version: u64,
-        _ledger_info: LedgerInfoWithSignatures,
+        _ledger_info: &LedgerInfoWithSignatures,
     ) -> Result<(EpochChangeProof, AccumulatorConsistencyProof)> {
         unimplemented!()
     }

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -14,7 +14,10 @@ use diem_types::{
     event::EventKey,
     ledger_info::LedgerInfoWithSignatures,
     move_resource::MoveStorage,
-    proof::{definition::LeafCount, AccumulatorConsistencyProof, SparseMerkleProof},
+    proof::{
+        definition::LeafCount, AccumulatorConsistencyProof, SparseMerkleProof,
+        TransactionAccumulatorSummary,
+    },
     transaction::{
         TransactionInfo, TransactionListWithProof, TransactionToCommit, TransactionWithProof,
         Version,
@@ -347,6 +350,23 @@ pub trait DbReader: Send + Sync {
         _ledger_version: Version,
     ) -> Result<AccumulatorConsistencyProof> {
         unimplemented!()
+    }
+
+    /// A convenience function for building a [`TransactionAccumulatorSummary`]
+    /// at the given `ledger_version`.
+    ///
+    /// Note: this is roughly equivalent to calling
+    /// `DbReader::get_accumulator_consistency_proof(None, ledger_version)`.
+    fn get_accumulator_summary(
+        &self,
+        ledger_version: Version,
+    ) -> Result<TransactionAccumulatorSummary> {
+        let genesis_consistency_proof =
+            self.get_accumulator_consistency_proof(None, ledger_version)?;
+        TransactionAccumulatorSummary::try_from_genesis_proof(
+            genesis_consistency_proof,
+            ledger_version,
+        )
     }
 }
 

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -263,7 +263,7 @@ pub trait DbReader: Send + Sync {
     fn get_state_proof_with_ledger_info(
         &self,
         known_version: u64,
-        ledger_info: LedgerInfoWithSignatures,
+        ledger_info: &LedgerInfoWithSignatures,
     ) -> Result<(EpochChangeProof, AccumulatorConsistencyProof)>;
 
     /// Returns proof of new state relative to version known to client

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -327,6 +327,27 @@ pub trait DbReader: Send + Sync {
     fn get_accumulator_root_hash(&self, _version: Version) -> Result<HashValue> {
         unimplemented!()
     }
+
+    /// Gets an [`AccumulatorConsistencyProof`] starting from `client_known_version`
+    /// (or pre-genesis if `None`) until `ledger_version`.
+    ///
+    /// In other words, if the client has an accumulator summary for
+    /// `client_known_version`, they can use the result from this API to efficiently
+    /// extend their accumulator to `ledger_version` and prove that the new accumulator
+    /// is consistent with their old accumulator. By consistent, we mean that by
+    /// appending the actual `ledger_version - client_known_version` transactions
+    /// to the old accumulator summary you get the new accumulator summary.
+    ///
+    /// If the client is starting up for the first time and has no accumulator
+    /// summary yet, they can call this with `client_known_version=None`, i.e.,
+    /// pre-genesis, to get the complete accumulator summary up to `ledger_version`.
+    fn get_accumulator_consistency_proof(
+        &self,
+        _client_known_version: Option<Version>,
+        _ledger_version: Version,
+    ) -> Result<AccumulatorConsistencyProof> {
+        unimplemented!()
+    }
 }
 
 impl MoveStorage for &dyn DbReader {

--- a/storage/storage-interface/src/mock.rs
+++ b/storage/storage-interface/src/mock.rs
@@ -99,7 +99,7 @@ impl DbReader for MockDbReader {
     fn get_state_proof_with_ledger_info(
         &self,
         _known_version: u64,
-        _ledger_info: LedgerInfoWithSignatures,
+        _ledger_info: &LedgerInfoWithSignatures,
     ) -> Result<(EpochChangeProof, AccumulatorConsistencyProof)> {
         unimplemented!()
     }

--- a/testsuite/smoke-test/src/verifying_client.rs
+++ b/testsuite/smoke-test/src/verifying_client.rs
@@ -47,7 +47,7 @@ impl Environment {
         let client = Client::new(url);
 
         let genesis_waypoint = env.validator_swarm.config.waypoint;
-        let trusted_state = TrustedState::from(genesis_waypoint);
+        let trusted_state = TrustedState::from_epoch_waypoint(genesis_waypoint);
         let storage = InMemoryStorage::new();
         let verifying_client =
             VerifyingClient::new_with_state(client.clone(), trusted_state, storage);

--- a/types/src/proof/accumulator/mock.rs
+++ b/types/src/proof/accumulator/mock.rs
@@ -1,0 +1,307 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    proof::{AccumulatorConsistencyProof, MerkleTreeInternalNode, TransactionAccumulatorSummary},
+    transaction::Version,
+};
+use diem_crypto::hash::{
+    CryptoHash, HashValue, TransactionAccumulatorHasher, ACCUMULATOR_PLACEHOLDER_HASH,
+};
+use std::{cell::RefCell, collections::HashMap};
+
+type Children = (HashValue, Option<HashValue>);
+
+/// An immutable transaction accumulator (not a summary, since it stores all leaf
+/// nodes and caches internal nodes) that allows for easily computing root hashes,
+/// consistency proofs, etc... at any versions in the range `0..=self.version()`.
+///
+/// This implementation intentionally eschews the existing storage implementation
+/// and `Position` APIs to be as different as possible so we can better guarantee
+/// correctness across implementations. Here, we mostly use "naive" recursive
+/// algorithms (with internal caches).
+///
+/// Note: intended for test-only code; panics whenever something goes wrong.
+#[derive(Clone, Debug)]
+pub struct MockTransactionAccumulator {
+    /// The list of leaf nodes.
+    leaves: Vec<HashValue>,
+    /// Cache that maps child nodes to their parent node.
+    c2p: RefCell<HashMap<Children, HashValue>>,
+    /// Cache that maps from a parent node to its child nodes.
+    p2c: RefCell<HashMap<HashValue, Children>>,
+}
+
+impl MockTransactionAccumulator {
+    /// Create a full transaction accumulator from a list of leaf node hashes.
+    pub fn from_leaves(leaves: Vec<HashValue>) -> Self {
+        assert!(!leaves.is_empty());
+        Self {
+            leaves,
+            c2p: RefCell::new(HashMap::new()),
+            p2c: RefCell::new(HashMap::new()),
+        }
+    }
+
+    /// Create an accumulator with some mock leaf hash values at the given version.
+    pub fn with_version(version: Version) -> Self {
+        Self::from_leaves(mock_txn_hashes(version))
+    }
+
+    pub fn version(&self) -> Version {
+        self.leaves.len() as u64 - 1
+    }
+
+    fn hash_internal_inner(pair: Children) -> HashValue {
+        let (left, maybe_right) = pair;
+        let right = maybe_right.unwrap_or(*ACCUMULATOR_PLACEHOLDER_HASH);
+        MerkleTreeInternalNode::<TransactionAccumulatorHasher>::new(left, right).hash()
+    }
+
+    /// Compute the parent node hash from a pair of siblings while also updating
+    /// internal caches.
+    fn hash_internal(&self, pair: Children) -> HashValue {
+        let parent = *self
+            .c2p
+            .borrow_mut()
+            .entry(pair)
+            .or_insert_with(|| Self::hash_internal_inner(pair));
+        self.p2c.borrow_mut().insert(parent, pair);
+        parent
+    }
+
+    /// Get the accumulator root hash at a specific version. Note that this method
+    /// has the side effect of seeding the parent<->child caches.
+    pub fn get_root_hash(&self, version: Version) -> HashValue {
+        assert!(version <= self.version());
+        let leaves_view = &self.leaves[0..=version as usize];
+
+        let mut level = leaves_view.to_vec();
+        while level.len() != 1 {
+            let siblings_iter = level.chunks(2);
+            level = siblings_iter
+                .map(|pair| self.hash_internal((pair[0], pair.get(1).copied())))
+                .collect();
+        }
+
+        level.into_iter().next().unwrap()
+    }
+
+    fn children(&self, parent: HashValue) -> Option<Children> {
+        // precondition: parent in internal node set
+        self.p2c.borrow().get(&parent).copied()
+    }
+
+    fn height(&self, subtree_root: HashValue) -> u64 {
+        // precondition: subtree_root in internal node set
+        match self.children(subtree_root) {
+            // leaves have no children
+            None => 0,
+            Some((left, _)) => self.height(left) + 1,
+        }
+    }
+
+    /// A node is frozen if it is complete. A node is complete if it's a leaf node
+    /// or both of its children are complete. Note that a complete right child
+    /// also implies that the left child is complete (since this is an accumulator).
+    fn is_frozen(&self, subtree_root: HashValue) -> bool {
+        // precondition: subtree_root in internal node set
+        match self.children(subtree_root) {
+            // leaf node ==> frozen
+            None => true,
+            // right subtree complete ==> left subtree also complete ==> frozen
+            Some((_, Some(right))) => self.is_frozen(right),
+            // not complete ==> not frozen
+            Some((_, None)) => false,
+        }
+    }
+
+    /// f(n) := if n.is_frozen => [n]
+    ///         else           => f(n.left) || f(n.right)
+    fn frozen_subtrees(&self, subtree_root: HashValue) -> Vec<HashValue> {
+        // precondition: subtree_root in internal node set
+        if self.is_frozen(subtree_root) {
+            vec![subtree_root]
+        } else {
+            let (left, maybe_right) = self.children(subtree_root).unwrap();
+            let mut left_subtrees = self.frozen_subtrees(left);
+            let right_subtrees = maybe_right
+                .map(|right| self.frozen_subtrees(right))
+                .unwrap_or_else(Vec::new);
+            left_subtrees.extend(right_subtrees);
+            left_subtrees
+        }
+    }
+
+    pub fn get_accumulator_summary(&self, version: Version) -> TransactionAccumulatorSummary {
+        assert!(version <= self.version());
+
+        let genesis_consistency_proof = self.get_consistency_proof(None, version);
+        TransactionAccumulatorSummary::try_from_genesis_proof(genesis_consistency_proof, version)
+            .unwrap()
+    }
+
+    pub fn get_consistency_proof(
+        &self,
+        start_version: Option<Version>,
+        end_version: Version,
+    ) -> AccumulatorConsistencyProof {
+        assert!(start_version <= Some(end_version));
+        assert!(end_version <= self.version());
+
+        let maybe_old_root = start_version.map(|v| self.get_root_hash(v));
+        let new_root = self.get_root_hash(end_version);
+
+        let height_diff = maybe_old_root
+            .clone()
+            .map(|old_root| self.height(new_root) - self.height(old_root))
+            .unwrap_or(0);
+
+        let subtrees = self.frozen_subtree_diff(maybe_old_root, new_root, height_diff);
+        AccumulatorConsistencyProof::new(subtrees)
+    }
+
+    /// Given a subtree root at an older version and a subtree root at a newer
+    /// version, find the frozen subtree siblings needed to bring the frozen
+    /// subtrees at the old subtree to the frozen subtrees at the new subtree.
+    ///
+    /// This method is recursive, typically starting at the root hashes for the
+    /// old and new accumulators. Note that the new accumulator root can start at
+    /// a greater height. After recursing left `height_diff` times, the old and
+    /// new subtree roots will be tracking the same position. When old and new
+    /// subtrees are tracking the same position, `height_diff == 0`.
+    ///
+    /// The old subtree parameter is an Option; when None, it means there is no
+    /// subtree at this position in the old accumulator.
+    ///
+    /// ```not_rust
+    /// // base case:
+    /// // position does not exist in old subtree
+    /// f(None, new, _) := frozen_subtrees(new)
+    /// // node is frozen in both accumulators
+    /// f(Some(same), same, 0) := []
+    ///
+    /// // inductive step:
+    /// // same position
+    /// f(Some(old), new, 0)
+    ///     := f(Some(old.left), new.left, 0) || new.maybe_right.map(|new_right| f(old.maybe_right, new_right, 0))
+    /// // new.height > old.height ==> old is in new's left descendents
+    /// f(Some(old), new, dh > 0)
+    ///     := f(Some(old), new.left, dh - 1) || f(None, new.right, _)
+    /// ```
+    fn frozen_subtree_diff(
+        &self,
+        maybe_old_subtree: Option<HashValue>,
+        new_subtree: HashValue,
+        height_diff: u64,
+    ) -> Vec<HashValue> {
+        // precondition: Some(old_subtree) and new_subtree in internal node set
+
+        let old_subtree = match maybe_old_subtree {
+            Some(old_subtree) => old_subtree,
+            // When we are in a disjoint subtree from the old accumulator, we just
+            // need the frozen subtrees.
+            None => return self.frozen_subtrees(new_subtree),
+        };
+
+        if height_diff == 0 {
+            // the old subtree and new subtree are at the same position
+
+            if old_subtree == new_subtree {
+                // the same subtree is frozen in both accumulators, don't need
+                // anything here.
+                vec![]
+            } else {
+                // this subtree is different between the old and new accumulator
+
+                let (old_left, maybe_old_right) = self
+                    .children(old_subtree)
+                    .expect("cannot have two different leaf nodes");
+                let (new_left, maybe_new_right) = self
+                    .children(new_subtree)
+                    .expect("cannot have two different leaf nodes");
+
+                // recurse left and right
+                let mut left_subtrees = self.frozen_subtree_diff(Some(old_left), new_left, 0);
+                let right_subtrees = maybe_new_right
+                    .map(|new_right| self.frozen_subtree_diff(maybe_old_right, new_right, 0))
+                    .unwrap_or_else(Vec::new);
+                left_subtrees.extend(right_subtrees);
+                left_subtrees
+            }
+        } else {
+            // the new subtree is still above the old subtree (which is somewhere
+            // in the new subtree's left descendents).
+
+            let (left, maybe_right) = self
+                .children(new_subtree)
+                .expect("non-zero height_diff implies new_subtree is an internal node, which must have children");
+            let right = maybe_right
+                .expect("non-zero height_diff implies new subtree must have a right child");
+            // recurse to the left
+            let mut left_subtrees =
+                self.frozen_subtree_diff(Some(old_subtree), left, height_diff - 1);
+            // this is effectively just frozen_subtrees(new.right), since the right
+            // subtree will always be disjoint
+            let right_subtrees = self.frozen_subtree_diff(None, right, 0);
+            left_subtrees.extend(right_subtrees);
+            left_subtrees
+        }
+    }
+}
+
+fn mock_txn_hashes(version: Version) -> Vec<HashValue> {
+    (0..=version).map(HashValue::from_u64).collect::<Vec<_>>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{block_info::BlockInfo, ledger_info::LedgerInfo};
+    use proptest::prelude::*;
+
+    fn mock_ledger_info(version: Version, root_hash: HashValue) -> LedgerInfo {
+        LedgerInfo::new(
+            BlockInfo::new(0, 0, HashValue::zero(), root_hash, version, 0, None),
+            HashValue::zero(),
+        )
+    }
+
+    #[test]
+    fn test_mock_accumulator() {
+        let end = 255;
+
+        // A
+        let accumulator = MockTransactionAccumulator::with_version(end);
+        assert_eq!(accumulator.version(), end);
+
+        let end_li = mock_ledger_info(end, accumulator.get_root_hash(end));
+
+        // check for { m1, m2 : 0 <= m1 <= m2 <= end } that accumulators A and B have the same root hash
+        // |------------------------------------------->|        A: accumulator
+        // |--------------->|------------>|------------>|        B: B_{None,m1}.extend(B_{m1,m2}).extend(B_{m2,end})
+        // 0               m1            m2            end
+        //    B_{None,m1}      B_{m1,m2}     B_{m2,end}    B_{i,j}: accumulator.consistency_proof(i, j)
+        proptest!(|((m1, m2) in (0..=end).prop_flat_map(|m1| (Just(m1), m1..=end)))| {
+            // B_{None,m1}
+            let accumulator_summary = accumulator.get_accumulator_summary(m1);
+            assert_eq!(accumulator_summary.version(), m1);
+            assert_eq!(accumulator_summary.root_hash(), accumulator.get_root_hash(m1));
+
+            // B_{m1,m2}
+            let mid1_to_mid2 = accumulator.get_consistency_proof(Some(m1), m2);
+            let mid2_li = mock_ledger_info(m2, accumulator.get_root_hash(m2));
+
+            // B_{None,m1}.extend(B_{m1,m2})
+            let accumulator_summary = accumulator_summary
+                .try_extend_with_proof(&mid1_to_mid2, &mid2_li)
+                .unwrap();
+
+            // B_{m2,end}
+            let mid2_to_end = accumulator.get_consistency_proof(Some(m2), end);
+
+            // B_{None,m1}.extend(B_{m1,m2}).extend(B_{m2,end})
+            accumulator_summary.try_extend_with_proof(&mid2_to_end, &end_li).unwrap();
+        });
+    }
+}

--- a/types/src/proof/accumulator/mod.rs
+++ b/types/src/proof/accumulator/mod.rs
@@ -13,6 +13,9 @@
 #[cfg(test)]
 mod accumulator_test;
 
+#[cfg(any(test, feature = "fuzzing"))]
+pub mod mock;
+
 use super::MerkleTreeInternalNode;
 use crate::proof::definition::{LeafCount, MAX_ACCUMULATOR_LEAVES};
 use anyhow::{ensure, format_err, Result};

--- a/types/src/proof/accumulator/mod.rs
+++ b/types/src/proof/accumulator/mod.rs
@@ -20,9 +20,11 @@ use diem_crypto::{
     hash::{CryptoHash, CryptoHasher, ACCUMULATOR_PLACEHOLDER_HASH},
     HashValue,
 };
+use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 
 /// The Accumulator implementation.
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct InMemoryAccumulator<H> {
     /// Represents the roots of all the full subtrees from left to right in this accumulator. For
     /// example, if we have the following accumulator, this vector will have two hashes that
@@ -283,16 +285,20 @@ where
     pub fn num_leaves(&self) -> LeafCount {
         self.num_leaves
     }
+
+    /// Returns true if this accumulator is empty and has no leaves.
+    pub fn is_empty(&self) -> bool {
+        self.num_leaves == 0
+    }
 }
 
-// We manually implement Debug because H (CryptoHasher) does not implement Debug.
-impl<H> std::fmt::Debug for InMemoryAccumulator<H> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(
-            f,
-            "Accumulator {{ frozen_subtree_roots: {:?}, num_leaves: {:?} }}",
-            self.frozen_subtree_roots, self.num_leaves
-        )
+// #[derive(..)] doesn't seem to work b/c of the PhantomData :(
+impl<H> std::cmp::Eq for InMemoryAccumulator<H> {}
+impl<H> std::cmp::PartialEq for InMemoryAccumulator<H> {
+    fn eq(&self, other: &Self) -> bool {
+        self.num_leaves == other.num_leaves
+            && self.root_hash == other.root_hash
+            && self.frozen_subtree_roots == other.frozen_subtree_roots
     }
 }
 

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -290,6 +290,10 @@ impl AccumulatorConsistencyProof {
     pub fn subtrees(&self) -> &[HashValue] {
         &self.subtrees
     }
+
+    pub fn into_subtrees(self) -> Vec<HashValue> {
+        self.subtrees
+    }
 }
 
 /// A proof that is similar to `AccumulatorProof`, but can be used to authenticate a range of

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -375,6 +375,10 @@ impl AccumulatorConsistencyProof {
         Self { subtrees }
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.subtrees.is_empty()
+    }
+
     /// Returns the subtrees.
     pub fn subtrees(&self) -> &[HashValue] {
         &self.subtrees

--- a/types/src/proof/mod.rs
+++ b/types/src/proof/mod.rs
@@ -32,7 +32,7 @@ pub use self::definition::{
     AccountStateProof, AccumulatorConsistencyProof, AccumulatorExtensionProof, AccumulatorProof,
     AccumulatorRangeProof, EventAccumulatorProof, EventProof, SparseMerkleProof,
     SparseMerkleRangeProof, TransactionAccumulatorProof, TransactionAccumulatorRangeProof,
-    TransactionInfoWithProof, TransactionListProof,
+    TransactionAccumulatorSummary, TransactionInfoWithProof, TransactionListProof,
 };
 
 #[cfg(any(test, feature = "fuzzing"))]

--- a/types/src/proof/position/mod.rs
+++ b/types/src/proof/position/mod.rs
@@ -31,7 +31,7 @@ use std::fmt;
 #[cfg(test)]
 mod position_test;
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Position(u64);
 // invariant Position.0 < u64::max_value() - 1
 
@@ -48,7 +48,7 @@ impl Position {
         (!self.0).trailing_zeros()
     }
 
-    fn is_leaf(self) -> bool {
+    pub fn is_leaf(self) -> bool {
         self.0 & 1 == 0
     }
 


### PR DESCRIPTION
## Overview

This PR includes everything needed to support verifying consistency proofs in the verifying client, from exposing a get_accumulator_consistency_proof API in json-rpc and DbReader, to refactoring TrustedState so it can keep track of its trusted accumulator summary, to modifying the verifying client itself so that it can query an initial accumulator and verify consistency proofs when ratcheting state proofs.

## Commits

### [storage] Add get_accumulator_consistency_proof to DbReader

This diff allows DB clients to query a specific accumulator consistency proof for a given range, rather than via get_state_proof(start_version), which will only give a consistency proof to the latest li.

One notable change is that the starting version is an `Option<Version>`, where `None` denotes starting the proof from "pre-genesis".  This API change allows DB clients to not only get a range like `get_accumulator_consistency_proof(Some(100), 200)`, but also first initialize their accumulator summaries via `get_accumulator_consistency_proof(None, 100)`.  They can do this because a consistency proof from pre-genesis to a verseion is exactly the frozen subtrees in an accumulator summary valid at that version.


### [json-rpc] Add get_accumulator_consistency_proof API

Expose the new get_accumulator_consistency_proof API to json-rpc clients, which allows clients to initialize their in-memory accumulator summaries and query consistency proofs to extend their in-memory accumulator summaries to new versions.

The main use-case for this stack is enabling verifying clients to initialize their in-memory accumulator summary when first starting up.  Once initialized, they can then actually verify the accumulator consistency proofs from get_state_proof, which we are not currently verifying at all.

The second use-case, which will come in a separate PR, is supporting historical get_metadata(version) for verifying clients. We can use this API to request `get_accumulator_consistency_proof(None, version)` and `get_accumulator_consistency_proof(version, None)` to get a proof for the historical accumulator root hash.


### [sdk] Add get_accumulator_consistency_proof API to non-verifying client


### [storage] Return consistency proof only for client-verifiable range

When a verifying client is syncing via get_state_proof requests, they can't verify the accumulator consistency proof when there are more epoch changes needed to sync before entering the epoch of that latest li. The reason is that the current behaviour always returns a consistency proof to the latest li version, regardless of whether or not the client will actually be able to reach the latest li after applying the epoch changes.

This diff fixes the above issue by limiting the consistency proof to the last client-verifiable version. If the state proof manages to get the client to the latest li, then the consistency proof is as before.  Otherwise, if the client will need more epoch changes, then the consistency proof is only to the last epoch change li version.


### [types] Add TransactionAccumulatorSummary

Adds a small wrapper type around `InMemoryAccumulator<TransactionInfoHasher>` with methods for more easily handling the transaction accumulator use-case.


### [types] Add MockTransactionAccumulator

Adds a small in-memory transaction accumulator for testing. The main use-case here is to hold all leaf hashes and allow arbitrary historical root hash and consistency proof queries against the accumulator.


### [types] Verify accumulator consistency proofs in trusted state

This diff modifies the `TrustedState` to support verifying accumulator consistency proofs. Now when verifying state proofs, we will correctly verify the consistency proof up to the last verifiable ledger info.

In order to verify a consistency proof, the trusted state needs to keep track of a verified transaction accumulator summary; ratcheting a state proof will also move the accumulator summary forward to the newly trusted state.

When verifying from a waypoint, we haven't yet built an accumulator summary. `verify_and_ratchet` now also takes an optional, untrusted `initial_accumulator`, which the trusted state will verify and use when it does not yet have an accumulator summary built up.

One consequence of verifying the consistency proofs is that we can no longer verify a state proof with a newer latest li but a partially trusted/verified prefix of epoch changes, since consistency proofs can only be verified from the exact accumulator summary at their starting version. This means users like the verifying client must verify_and_ratchet from the trusted state they had at the start of their request rather than reading the current trusted state when they verify the response.

This diff also adds support for verifying the initializing the accumulator and verifying consistency proofs to the verifying client.


### [sdk] Less strict concurrency model for clients

Currently, issuing concurrent requests with either verifying or non-verifying clients is not super useful since the ordering requirement is too strict. Each concurrent request races to place its latest observed state into the state store / trusted state store; the losers are considered "stale" and must be retried.

This strategy means we're almost less efficient than issuing requests serially, since we have to keep retrying the losers and (worst case) only one request wins each round.

The benefit of this strategy is that we maintain a consistent and strictly increasing global ordering of responses, with the important caveat that this is only true as of the time we compare-and-exchange the response state into the respective store and the response is the winner. Of course, the client may actually observe a different ordering due to asynchrony between placing the response into the store and actually observing the response in the client application code, rendering the benefit less useful than initially expected.

With this change, we relax the ordering requirements. When issuing multiple concurrent requests we now guarantee:

1. Each response batch is fulfilled and verified at a ledger version that is greater than or equal to the current trusted version _at the time we made the request batch_, though not necessarily the globally most recent trusted ledger version.

2. Requests made serially within a single thread of execution appear strictly ordered, i.e., they were fulfilled and verified at monotonically increasing ledger versions (`v1 <= v2 <= ...`).

Consequently, without any other effort, multiple concurrent requests may have responses that appear inconsistent or out-of-order. For example, naively making concurrent `get_account(..)` requests will (most likely) show accounts at different ledger versions; even further, the first response you receive may show a more recent ledger version than the second response.

To avoid these issues, clients should pin a batch of concurrent requests to the same ledger version in order to avoid an inconsistent ledger view.
