### PR TITLE
[test-infra][e2e] make sure to test until the latest DiemVersion

### DIFF
--- a/language/e2e-testsuite/src/tests/emergency_admin_script.rs
+++ b/language/e2e-testsuite/src/tests/emergency_admin_script.rs
@@ -4,7 +4,7 @@
 use diem_transaction_builder::stdlib::*;
 use diem_types::{
     account_config::diem_root_address,
-    on_chain_config::new_epoch_event_key,
+    on_chain_config::{new_epoch_event_key, DIEM_MAX_KNOWN_VERSION},
     transaction::{Transaction, TransactionStatus},
     vm_status::KeptVMStatus,
 };
@@ -222,7 +222,7 @@ fn validator_batch_remove() {
 fn halt_network() {
     // This can only run on versions >= 2 since
     // `DiemTransactionPublishingOption::halt_all_transactions` is not available in version 1.
-    test_with_different_versions! {&[2], |test_env| {
+    test_with_different_versions! {2..=DIEM_MAX_KNOWN_VERSION.major, |test_env| {
         let mut executor = test_env.executor;
         let diem_root_account = test_env.dr_account;
         let sender = executor.create_raw_account_data(1_000_000, 10);


### PR DESCRIPTION
The original e2e tests are hardcoded to test up to version 2 while the
latest DiemVersion is at 3. This commit ensures that the e2e tests will
at least attempt to test with whatever the latest DiemVersion is.

Unfortunately, there is no upgrade path to version 3 yet so this version
is actually ignored in e2e tests. Nevertheless, it might still be good
to have the code here and once we have the upgrade path to version 3,
the e2e test executor will automatically pick it up.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Ensure consistency between e2e tests versions and max diem version. Accidentally found this while investigating why my e2e tests replayer is not picking up the trace anymore.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI
