### PR TITLE
[test-infra][e2e] make the replayer a standalone diem-tool with version selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1607,6 +1607,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "diem-e2e-tests-replay"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bcs",
+ "bytecode-interpreter",
+ "diem-framework",
+ "diem-types",
+ "diem-vm",
+ "diem-workspace-hack",
+ "language-e2e-tests",
+ "move-binary-format",
+ "move-core-types",
+ "move-model",
+ "move-vm-runtime",
+ "move-vm-types",
+ "structopt 0.3.21",
+ "walkdir",
+]
+
+[[package]]
 name = "diem-events-fetcher"
 version = "0.1.0"
 dependencies = [
@@ -4154,11 +4175,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
- "bytecode-interpreter",
  "compiler",
  "diem-config",
  "diem-crypto",
- "diem-framework",
  "diem-framework-releases",
  "diem-proptest-helpers",
  "diem-state-view",
@@ -4171,7 +4190,6 @@ dependencies = [
  "hex",
  "move-binary-format",
  "move-core-types",
- "move-model",
  "move-vm-runtime",
  "move-vm-types",
  "once_cell",
@@ -4179,9 +4197,7 @@ dependencies = [
  "proptest-derive",
  "rand 0.8.3",
  "serde",
- "structopt 0.3.21",
  "vm-genesis",
- "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ members = [
     "language/diem-tools/diem-events-fetcher",
     "language/diem-tools/diem-read-write-set",
     "language/diem-tools/diem-validator-interface",
+    "language/diem-tools/e2e-tests-replay",
     "language/diem-tools/oncall-trainer",
     "language/diem-tools/transaction-replay",
     "language/diem-tools/writeset-transaction-generator",

--- a/language/diem-tools/e2e-tests-replay/Cargo.toml
+++ b/language/diem-tools/e2e-tests-replay/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "diem-e2e-tests-replay"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+description = "A tool that reconstructs and replays test cases from the trace dump of E2E tests"
+license = "Apache-2.0"
+edition = "2018"
+publish = false
+
+[dependencies]
+anyhow = "1.0.38"
+bcs = "0.1.2"
+structopt = "0.3.21"
+walkdir = "2.3.1"
+
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
+bytecode-interpreter = { path = "../../move-prover/interpreter" }
+diem-types = { path = "../../../types", features = ["fuzzing"] }
+diem-framework = { path = "../../diem-framework" }
+diem-vm = { path = "../../diem-vm" }
+language-e2e-tests = { path = "../../testing-infra/e2e-tests" }
+move-binary-format = { path = "../../move-binary-format" }
+move-core-types = { path = "../../move-core/types" }
+move-model = { path = "../../move-model" }
+move-vm-runtime = { path = "../../move-vm/runtime", features = ["testing"] }
+move-vm-types = { path = "../../move-vm/types" }

--- a/language/diem-tools/e2e-tests-replay/src/main.rs
+++ b/language/diem-tools/e2e-tests-replay/src/main.rs
@@ -1,0 +1,83 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, Result};
+use std::collections::{BTreeMap, BTreeSet};
+use structopt::StructOpt;
+
+use bytecode_interpreter::{concrete::settings::InterpreterSettings, StacklessBytecodeInterpreter};
+use diem_framework::diem_stdlib_files;
+use move_model::run_model_builder;
+
+use diem_e2e_tests_replay::{self, ReplayFlags};
+
+#[derive(StructOpt)]
+struct ReplayArgs {
+    /// Trace files
+    #[structopt(short = "t", long = "trace")]
+    trace_files: Vec<String>,
+
+    /// Trace filters, if specified, only replay traces that passes the filter
+    #[structopt(short = "f", long = "filter")]
+    filters: Vec<String>,
+
+    /// Maximum number of steps per trace to replay
+    #[structopt(short = "l", long = "limit")]
+    step_limit: Option<usize>,
+
+    /// Cross check the stackless VM against the Move VM
+    #[structopt(short = "x", long = "xrun")]
+    xrun: bool,
+
+    /// Verbose mode
+    #[structopt(short = "v", long = "verbose")]
+    verbose: Option<u64>,
+
+    /// Warning mode
+    #[structopt(short = "w", long = "warning")]
+    warning: Option<u64>,
+}
+
+pub fn main() -> Result<()> {
+    let args = ReplayArgs::from_args();
+    let mut filters = BTreeMap::new();
+    for item in args.filters {
+        let tokens: Vec<&str> = item.split("::").collect();
+        if tokens.len() == 1 {
+            filters
+                .entry(tokens[0].to_string())
+                .or_insert_with(BTreeSet::new);
+        } else if tokens.len() == 2 {
+            let step: usize = tokens[1].parse()?;
+            filters
+                .entry(tokens[0].to_string())
+                .or_insert_with(BTreeSet::new)
+                .insert(step);
+        } else {
+            bail!("Invalid filter: {}", item);
+        }
+    }
+
+    let flags = ReplayFlags {
+        filters,
+        step_limit: args.step_limit.unwrap_or(usize::MAX),
+        xrun: args.xrun,
+        verbose_trace_meta: args.verbose.map_or(false, |level| level > 0),
+        verbose_trace_step: args.verbose.map_or(false, |level| level > 1),
+        verbose_trace_xrun: args.verbose.map_or(false, |level| level > 2),
+        verbose_vm: args.verbose.map_or(false, |level| level > 3),
+        warning: args.warning.map_or(false, |level| level > 0),
+    };
+
+    let settings = if flags.verbose_vm {
+        InterpreterSettings::verbose_default()
+    } else {
+        InterpreterSettings::default()
+    };
+    let env = run_model_builder(&diem_stdlib_files(), &[])?;
+    let interpreter = StacklessBytecodeInterpreter::new(&env, None, settings);
+    for trace in args.trace_files {
+        diem_e2e_tests_replay::replay(trace, &interpreter, &flags)?;
+    }
+    Ok(())
+}

--- a/language/diem-tools/e2e-tests-replay/src/main.rs
+++ b/language/diem-tools/e2e-tests-replay/src/main.rs
@@ -7,6 +7,7 @@ use structopt::StructOpt;
 
 use bytecode_interpreter::{concrete::settings::InterpreterSettings, StacklessBytecodeInterpreter};
 use diem_framework::diem_stdlib_files;
+use diem_types::on_chain_config::{DiemVersion, DIEM_MAX_KNOWN_VERSION};
 use move_model::run_model_builder;
 
 use diem_e2e_tests_replay::{self, ReplayFlags};
@@ -16,6 +17,10 @@ struct ReplayArgs {
     /// Trace files
     #[structopt(short = "t", long = "trace")]
     trace_files: Vec<String>,
+
+    /// Diem selector, if set, replay traces executed in that version instead of the latest version
+    #[structopt(short = "d", long = "diem")]
+    diem_version: Option<u64>,
 
     /// Trace filters, if specified, only replay traces that passes the filter
     #[structopt(short = "f", long = "filter")]
@@ -59,6 +64,9 @@ pub fn main() -> Result<()> {
     }
 
     let flags = ReplayFlags {
+        diem_version: args
+            .diem_version
+            .map_or(DIEM_MAX_KNOWN_VERSION, |v| DiemVersion { major: v }),
         filters,
         step_limit: args.step_limit.unwrap_or(usize::MAX),
         xrun: args.xrun,

--- a/language/testing-infra/e2e-tests/Cargo.toml
+++ b/language/testing-infra/e2e-tests/Cargo.toml
@@ -31,12 +31,7 @@ proptest = "1.0.0"
 proptest-derive = "0.3.0"
 diem-proptest-helpers = { path = "../../../common/proptest-helpers" }
 diem-config = { path = "../../../config" }
-diem-framework = { path = "../../diem-framework" }
 diem-framework-releases = { path = "../../diem-framework/releases" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 diem-transaction-builder = { path = "../../../sdk/transaction-builder" }
 hex = "0.4.3"
-structopt = "0.3.21"
-walkdir = "2.3.1"
-bytecode-interpreter = { path = "../../move-prover/interpreter" }
-move-model = { path = "../../move-model" }

--- a/language/testing-infra/e2e-tests/src/executor.rs
+++ b/language/testing-infra/e2e-tests/src/executor.rs
@@ -26,9 +26,7 @@ use diem_types::{
     access_path::AccessPath,
     account_config::{AccountResource, BalanceResource, CORE_CODE_ADDRESS},
     block_metadata::{new_block_event_key, BlockMetadata, NewBlockEvent},
-    on_chain_config::{
-        DiemVersion, OnChainConfig, VMPublishingOption, ValidatorSet, DIEM_MAX_KNOWN_VERSION,
-    },
+    on_chain_config::{DiemVersion, OnChainConfig, VMPublishingOption, ValidatorSet},
     transaction::{
         ChangeSet, SignedTransaction, Transaction, TransactionOutput, TransactionStatus,
         VMValidatorResult,
@@ -148,35 +146,33 @@ impl FakeExecutor {
         self.executed_output = Some(GoldenOutputs::new(&file_name));
 
         // NOTE: tracing is only available when
-        //  - the e2e test outputs a golden file,
-        //  - the environment variable is properly set, and
-        //  - the diem version is at the latest version
+        //  - the e2e test outputs a golden file, and
+        //  - the environment variable is properly set
         if let Some(env_trace_dir) = env::var_os(ENV_TRACE_DIR) {
-            let diem_version = DiemVersion::fetch_config(&self.data_store);
-            if diem_version.map_or(false, |version| version == DIEM_MAX_KNOWN_VERSION) {
-                let trace_dir = Path::new(&env_trace_dir).join(file_name);
-                if trace_dir.exists() {
-                    fs::remove_dir_all(&trace_dir).expect("Failed to clean up the trace directory");
-                }
-                fs::create_dir_all(&trace_dir).expect("Failed to create the trace directory");
-                let mut name_file = OpenOptions::new()
-                    .write(true)
-                    .create_new(true)
-                    .open(trace_dir.join(TRACE_FILE_NAME))
-                    .unwrap();
-                name_file.write_all(test_name.as_bytes()).unwrap();
-                for sub_dir in &[
-                    TRACE_DIR_META,
-                    TRACE_DIR_DATA,
-                    TRACE_DIR_INPUT,
-                    TRACE_DIR_OUTPUT,
-                ] {
-                    fs::create_dir(trace_dir.join(sub_dir)).unwrap_or_else(|err| {
-                        panic!("Failed to create <trace>/{} directory: {}", sub_dir, err)
-                    });
-                }
-                self.trace_dir = Some(trace_dir);
+            let diem_version = DiemVersion::fetch_config(&self.data_store).map_or(0, |v| v.major);
+
+            let trace_dir = Path::new(&env_trace_dir).join(file_name);
+            if trace_dir.exists() {
+                fs::remove_dir_all(&trace_dir).expect("Failed to clean up the trace directory");
             }
+            fs::create_dir_all(&trace_dir).expect("Failed to create the trace directory");
+            let mut name_file = OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(trace_dir.join(TRACE_FILE_NAME))
+                .unwrap();
+            write!(name_file, "{}::{}", test_name, diem_version).unwrap();
+            for sub_dir in &[
+                TRACE_DIR_META,
+                TRACE_DIR_DATA,
+                TRACE_DIR_INPUT,
+                TRACE_DIR_OUTPUT,
+            ] {
+                fs::create_dir(trace_dir.join(sub_dir)).unwrap_or_else(|err| {
+                    panic!("Failed to create <trace>/{} directory: {}", sub_dir, err)
+                });
+            }
+            self.trace_dir = Some(trace_dir);
         }
     }
 

--- a/x.toml
+++ b/x.toml
@@ -166,6 +166,7 @@ members = [
     "cli",
     "cluster-test",
     "diem-documentation-tool",
+    "diem-e2e-tests-replay",
     "diem-fuzz",
     "diem-fuzzer",
     "diem-json-rpc-client",
@@ -212,6 +213,7 @@ members = [
 
 [workspace.move-to-diem-deps]
 diem_crates_in_language = [
+    "diem-e2e-tests-replay",
     "diem-framework",
     "diem-framework-releases",
     "diem-events-fetcher",


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

As promised in #8354, we want to make the e2e replayer a standalone tool in the diem-tool suite instead of polluting the `e2e-tests` lib crate with a `main.rs`. The first commit did that.

The second commit forces a trace dump when the e2e tests with Genesis of all DIem Framework versions and allow the replayer to select which version of trace to replay.

To run the replayer:

First, collect execution traces from the language e2e test suite:
```
cd language/e2e-testsuite
TRACE=<path-to-trace-dir> cargo test
```

Then, replay the trace with cross comparison between the Move VM and stackless VM
```
cd language/diem-tools/e2e-tests-replay
cargo run -- -t <path-to-trace-dir> -x -d 2 -v 1
```

To replay without the stackless VM, remove the `-x`:
```
cargo run -- -t <path-to-trace-dir> -d 2 -v 1
```

Run the following command to get help message on how to use the replayer
```
cd language/diem-tools/e2e-tests-replay
cargo run -- --help
```

## Motivation

Better code organization

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI
