### PR TITLE
[network] Always enable connectivity manager

### DIFF
--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -210,36 +210,19 @@ impl NetworkBuilder {
             config.ping_failures_tolerated,
         );
 
-        // Don't turn on connectivity manager if we're a public-facing server,
-        // for example.
-        //
-        // Cases that require connectivity manager:
-        //
-        // 1) mutual authentication networks currently require connmgr to set the
-        //    trusted peers set.
-        // 2) networks with a discovery protocol need connmgr to connect to newly
-        //    discovered peers.
-        // 3) if we have seed peers, then we need connmgr to connect to them.
-        // TODO(philiphayes): could probably use a better way to specify these cases
-        // TODO:  Why not add ConnectivityManager always?
-        if config.mutual_authentication
-            || config.discovery_method != DiscoveryMethod::None
-            || !config.seed_addrs.is_empty()
-            || !config.seeds.is_empty()
-        {
-            let seeds = merge_seeds(config);
+        // Always add a connectivity manager to keep track of known peers
+        let seeds = merge_seeds(config);
 
-            network_builder.add_connectivity_manager(
-                seeds,
-                trusted_peers,
-                config.max_outbound_connections,
-                config.connection_backoff_base,
-                config.max_connection_delay_ms,
-                config.connectivity_check_interval_ms,
-                config.network_channel_size,
-                config.mutual_authentication,
-            );
-        }
+        network_builder.add_connectivity_manager(
+            seeds,
+            trusted_peers,
+            config.max_outbound_connections,
+            config.connection_backoff_base,
+            config.max_connection_delay_ms,
+            config.connectivity_check_interval_ms,
+            config.network_channel_size,
+            config.mutual_authentication,
+        );
 
         match &config.discovery_method {
             DiscoveryMethod::Onchain => {


### PR DESCRIPTION
## Motivation

Connectivity Manager is necessary for keeping track of known peers, and really the networking stacks don't work without it.  The only way it could be used is to only allow anonymous connections, and be the root of an entire tree (which doesn't make sense in the network).  Doesn't seem to make the build break, so I'm going forward with enabling it to simplify everything.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

E2E tests.  It's already enabled on every node
