### PR TITLE
Add support for Iff Operator

### DIFF
--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -495,6 +495,8 @@ pub enum BinOp_ {
     // Bool ops
     // ==>
     Implies, // spec only
+    // <==>
+    Iff,
     // &&
     And,
     // ||
@@ -783,6 +785,7 @@ impl BinOp_ {
     pub const LE: &'static str = "<=";
     pub const GE: &'static str = ">=";
     pub const IMPLIES: &'static str = "==>";
+    pub const IFF: &'static str = "<==>";
     pub const RANGE: &'static str = "..";
 
     pub fn symbol(&self) -> &'static str {
@@ -807,6 +810,7 @@ impl BinOp_ {
             B::Le => B::LE,
             B::Ge => B::GE,
             B::Implies => B::IMPLIES,
+            B::Iff => B::IFF,
             B::Range => B::RANGE,
         }
     }
@@ -827,13 +831,14 @@ impl BinOp_ {
             | B::Le
             | B::Ge
             | B::Range
-            | B::Implies => true,
+            | B::Implies
+            | B::Iff => true,
         }
     }
 
     pub fn is_spec_only(&self) -> bool {
         use BinOp_ as B;
-        matches!(self, B::Range | B::Implies)
+        matches!(self, B::Range | B::Implies | B::Iff)
     }
 }
 

--- a/language/move-lang/src/parser/lexer.rs
+++ b/language/move-lang/src/parser/lexer.rs
@@ -39,6 +39,7 @@ pub enum Tok {
     Equal,
     EqualEqual,
     EqualEqualGreater,
+    LessEqualEqualGreater,
     Greater,
     GreaterEqual,
     GreaterGreater,
@@ -112,6 +113,7 @@ impl fmt::Display for Tok {
             Equal => "=",
             EqualEqual => "==",
             EqualEqualGreater => "==>",
+            LessEqualEqualGreater => "<==>",
             Greater => ">",
             GreaterEqual => ">=",
             GreaterGreater => ">>",
@@ -362,7 +364,9 @@ fn find_token(file: &'static str, text: &str, start_offset: usize) -> Result<(To
             }
         }
         '<' => {
-            if text.starts_with("<=") {
+            if text.starts_with("<==>") {
+                (Tok::LessEqualEqualGreater, 4)
+            } else if text.starts_with("<=") {
                 (Tok::LessEqual, 2)
             } else if text.starts_with("<<") {
                 (Tok::LessLess, 2)

--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -1038,6 +1038,7 @@ fn get_precedence(token: Tok) -> u32 {
     match token {
         // Reserved minimum precedence value is 1
         Tok::EqualEqualGreater => 2,
+        Tok::LessEqualEqualGreater => 2,
         Tok::PipePipe => 3,
         Tok::AmpAmp => 4,
         Tok::EqualEqual => 5,
@@ -1124,6 +1125,7 @@ fn parse_binop_exp(tokens: &mut Lexer, lhs: Exp, min_prec: u32) -> Result<Exp, E
             Tok::Percent => BinOp_::Mod,
             Tok::PeriodPeriod => BinOp_::Range,
             Tok::EqualEqualGreater => BinOp_::Implies,
+            Tok::LessEqualEqualGreater => BinOp_::Iff,
             _ => panic!("Unexpected token that is not a binary operator"),
         };
         let sp_op = spanned(tokens.file_name(), op_start_loc, op_end_loc, op);

--- a/language/move-lang/src/to_bytecode/translate.rs
+++ b/language/move-lang/src/to_bytecode/translate.rs
@@ -1123,7 +1123,7 @@ fn binary_op(code: &mut IR::BytecodeBlock, sp!(loc, op_): BinOp) {
             O::Le => B::Le,
             O::Ge => B::Ge,
 
-            O::Range | O::Implies => panic!("specification operator unexpected"),
+            O::Range | O::Implies | O::Iff => panic!("specification operator unexpected"),
         },
     ));
 }

--- a/language/move-lang/src/typing/translate.rs
+++ b/language/move-lang/src/typing/translate.rs
@@ -935,7 +935,7 @@ fn exp_(context: &mut Context, initial_ne: N::Exp) -> T::Exp {
                             (Type_::bool(loc), Type_::bool(loc))
                         }
 
-                        Range | Implies => panic!("specification operator unexpected"),
+                        Range | Implies | Iff => panic!("specification operator unexpected"),
                     };
                     let binop =
                         T::exp(ty, sp(loc, TE::BinopExp(el, bop, Box::new(operand_ty), er)));

--- a/language/move-model/src/ast.rs
+++ b/language/move-model/src/ast.rs
@@ -740,6 +740,7 @@ pub enum Operation {
     Shl,
     Shr,
     Implies,
+    Iff,
     And,
     Or,
     Eq,

--- a/language/move-model/src/builder/spec_builtins.rs
+++ b/language/move-model/src/builder/spec_builtins.rs
@@ -75,6 +75,7 @@ pub(crate) fn declare_spec_builtins(trans: &mut ModelBuilder<'_>) {
         declare_bin(Range, Operation::Range, num_t, range_t);
 
         declare_bin(Implies, Operation::Implies, bool_t, bool_t);
+        declare_bin(Iff, Operation::Iff, bool_t, bool_t);
         declare_bin(And, Operation::And, bool_t, bool_t);
         declare_bin(Or, Operation::Or, bool_t, bool_t);
 

--- a/language/move-model/src/exp_generator.rs
+++ b/language/move-model/src/exp_generator.rs
@@ -127,6 +127,11 @@ pub trait ExpGenerator<'env> {
         self.mk_bool_call(Operation::Implies, vec![arg1, arg2])
     }
 
+    /// Make an iff expression.
+    fn mk_iff(&self, arg1: Exp, arg2: Exp) -> Exp {
+        self.mk_bool_call(Operation::Iff, vec![arg1, arg2])
+    }
+
     /// Make a numerical expression for some of the builtin constants.
     fn mk_builtin_num_const(&self, oper: Operation) -> Exp {
         assert!(matches!(

--- a/language/move-prover/boogie-backend/src/spec_translator.rs
+++ b/language/move-prover/boogie-backend/src/spec_translator.rs
@@ -696,6 +696,7 @@ impl<'env> SpecTranslator<'env> {
             Operation::Shl => self.translate_primitive_call("$shl", args),
             Operation::Shr => self.translate_primitive_call("$shr", args),
             Operation::Implies => self.translate_logical_op("==>", args),
+            Operation::Iff => self.translate_logical_op("<==>", args),
             Operation::And => self.translate_logical_op("&&", args),
             Operation::Or => self.translate_logical_op("||", args),
             Operation::Lt => self.translate_rel_op("<", args),

--- a/language/move-prover/tests/sources/functional/arithm.move
+++ b/language/move-prover/tests/sources/functional/arithm.move
@@ -50,8 +50,8 @@ module 0x42::TestArithmetic {
         (c, d)
     }
     spec bool_ops {
-        ensures result_1 == (a > b && a >= b);
-        ensures result_2 == (a < b || a <= b);
+        ensures result_1 <==> (a > b && a >= b);
+        ensures result_2 <==> (a < b || a <= b);
     }
 
     // succeeds.


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Introduces the Iff operator and closes #4977.  The goal of this introduction is to add a minor feature as well as to help me work through the codebase and PR system.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

My tests are fairly minimal, just updating the existing arithm file with two instances of the iff operator.  I argue this is sufficient for a simple operator due to the relative lack of complexity of changes made; additionally, I minimize adding additional test cases to avoid excessive testing for a simple feature.  It is worth noting that I manually tested the operator with negative testing to ensure that it works with exactly booleans, which seems to be the case; I'm not sure if such negative tests should also be included.
