### PR TITLE
[move-model] panic when including a schema with undeclared var

### DIFF
--- a/language/move-model/tests/sources/schemas_err.move
+++ b/language/move-model/tests/sources/schemas_err.move
@@ -85,4 +85,10 @@ module 0x42::M {
         include true ==> 23;
         include Condition || Condition;
     }
+
+    fun var_in_fun_not_schema(x: u64): u64 { x }
+    spec var_in_fun_not_schema {
+        // TODO uncomment the following line to see the panic
+        // include UndeclaredVar;
+    }
 }


### PR DESCRIPTION
A regression when a scheme with an undeclared var is included elsewhere, first observed in #8471 

## Motivation

Put up the test case to repro the issue

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI
