### PR TITLE
[executor] speculation cache doesn't remember committed txns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,6 +1100,7 @@ dependencies = [
  "diem-types",
  "diem-workspace-hack",
  "executor-types",
+ "itertools 0.10.0",
  "mirai-annotations",
  "proptest",
  "serde",

--- a/consensus/consensus-types/Cargo.toml
+++ b/consensus/consensus-types/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.38"
+itertools = "0.10.0"
 mirai-annotations = { version = "1.10.1", default-features = false }
 proptest = { version = "1.0.0", optional = true }
 serde = { version = "1.0.124", default-features = false }

--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -10,9 +10,14 @@ use anyhow::{bail, ensure, format_err};
 use diem_crypto::{ed25519::Ed25519Signature, hash::CryptoHash, HashValue};
 use diem_infallible::duration_since_epoch;
 use diem_types::{
-    account_address::AccountAddress, block_info::BlockInfo, block_metadata::BlockMetadata,
-    epoch_state::EpochState, ledger_info::LedgerInfo, transaction::Version,
-    validator_signer::ValidatorSigner, validator_verifier::ValidatorVerifier,
+    account_address::AccountAddress,
+    block_info::BlockInfo,
+    block_metadata::BlockMetadata,
+    epoch_state::EpochState,
+    ledger_info::LedgerInfo,
+    transaction::{Transaction, Version},
+    validator_signer::ValidatorSigner,
+    validator_verifier::ValidatorVerifier,
 };
 use mirai_annotations::debug_checked_verify_eq;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -281,6 +286,18 @@ impl Block {
             "Block id mismatch the hash"
         );
         Ok(())
+    }
+
+    pub fn transactions_to_execute(&self) -> Vec<Transaction> {
+        std::iter::once(Transaction::BlockMetadata(self.into()))
+            .chain(
+                self.payload()
+                    .unwrap_or(&Vec::new())
+                    .iter()
+                    .cloned()
+                    .map(Transaction::UserTransaction),
+            )
+            .collect()
     }
 }
 

--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -156,6 +156,7 @@ impl BlockStore {
             None,                     /* epoch_state */
             vec![],                   /* compute_status */
             vec![],                   /* txn_infos */
+            vec![],                   /* reconfig_events */
         );
 
         let executed_root_block = ExecutedBlock::new(
@@ -215,10 +216,7 @@ impl BlockStore {
             .unwrap_or_else(Vec::new);
 
         self.state_computer
-            .commit(
-                blocks_to_commit.iter().map(|b| b.id()).collect(),
-                finality_proof,
-            )
+            .commit(&blocks_to_commit, finality_proof)
             .await
             .expect("Failed to persist commit");
         update_counters_for_committed_blocks(&blocks_to_commit);

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -3,10 +3,11 @@
 
 use crate::error::{MempoolError, StateSyncError};
 use anyhow::Result;
-use consensus_types::{block::Block, common::Payload};
+use consensus_types::{block::Block, common::Payload, executed_block::ExecutedBlock};
 use diem_crypto::HashValue;
 use diem_types::ledger_info::LedgerInfoWithSignatures;
 use executor_types::{Error as ExecutionError, StateComputeResult};
+use std::sync::Arc;
 
 /// Retrieves and updates the status of transactions on demand (e.g., via talking with Mempool)
 #[async_trait::async_trait]
@@ -51,7 +52,7 @@ pub trait StateComputer: Send + Sync {
     /// Send a successful commit. A future is fulfilled when the state is finalized.
     async fn commit(
         &self,
-        block_ids: Vec<HashValue>,
+        blocks: &[Arc<ExecutedBlock>],
         finality_proof: LedgerInfoWithSignatures,
     ) -> Result<(), ExecutionError>;
 

--- a/consensus/src/test_utils/mock_txn_manager.rs
+++ b/consensus/src/test_utils/mock_txn_manager.rs
@@ -74,6 +74,7 @@ impl TxnManager for MockTransactionManager {
                 compute_results.epoch_state().clone(),
                 mock_transaction_status(block.payload().map_or(0, |txns| txns.len())),
                 compute_results.transaction_info_hashes().clone(),
+                compute_results.reconfig_events().to_vec(),
             );
             assert!(self
                 .mempool_proxy

--- a/execution/execution-correctness/src/execution_correctness.rs
+++ b/execution/execution-correctness/src/execution_correctness.rs
@@ -3,9 +3,7 @@
 
 use consensus_types::block::Block;
 use diem_crypto::HashValue;
-use diem_types::{
-    contract_event::ContractEvent, ledger_info::LedgerInfoWithSignatures, transaction::Transaction,
-};
+use diem_types::ledger_info::LedgerInfoWithSignatures;
 use executor_types::{Error, StateComputeResult};
 
 /// Interface for ExecutionCorrectness.
@@ -26,5 +24,5 @@ pub trait ExecutionCorrectness: Send {
         &mut self,
         block_ids: Vec<HashValue>,
         ledger_info_with_sigs: LedgerInfoWithSignatures,
-    ) -> Result<(Vec<Transaction>, Vec<ContractEvent>), Error>;
+    ) -> Result<(), Error>;
 }

--- a/execution/execution-correctness/src/lib.rs
+++ b/execution/execution-correctness/src/lib.rs
@@ -3,10 +3,6 @@
 
 #![forbid(unsafe_code)]
 
-use consensus_types::block::Block;
-use diem_crypto::HashValue;
-use diem_types::transaction::Transaction;
-
 mod execution_correctness;
 mod execution_correctness_manager;
 mod local;
@@ -22,16 +18,3 @@ pub use crate::{
 
 #[cfg(test)]
 mod tests;
-
-fn id_and_transactions_from_block(block: &Block) -> (HashValue, Vec<Transaction>) {
-    let id = block.id();
-    let mut transactions = vec![Transaction::BlockMetadata(block.into())];
-    transactions.extend(
-        block
-            .payload()
-            .unwrap_or(&vec![])
-            .iter()
-            .map(|txn| Transaction::UserTransaction(txn.clone())),
-    );
-    (id, transactions)
-}

--- a/execution/execution-correctness/src/local.rs
+++ b/execution/execution-correctness/src/local.rs
@@ -1,13 +1,11 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{execution_correctness::ExecutionCorrectness, id_and_transactions_from_block};
+use crate::execution_correctness::ExecutionCorrectness;
 use consensus_types::{block::Block, vote_proposal::VoteProposal};
 use diem_crypto::{ed25519::Ed25519PrivateKey, traits::SigningKey, HashValue};
 use diem_infallible::Mutex;
-use diem_types::{
-    contract_event::ContractEvent, ledger_info::LedgerInfoWithSignatures, transaction::Transaction,
-};
+use diem_types::ledger_info::LedgerInfoWithSignatures;
 use executor_types::{BlockExecutor, Error, StateComputeResult};
 use std::{boxed::Box, sync::Arc};
 
@@ -53,9 +51,10 @@ impl ExecutionCorrectness for LocalClient {
         parent_block_id: HashValue,
     ) -> Result<StateComputeResult, Error> {
         let mut local = self.internal.lock();
-        let mut result = local
-            .block_executor
-            .execute_block(id_and_transactions_from_block(&block), parent_block_id)?;
+        let mut result = local.block_executor.execute_block(
+            (block.id(), block.transactions_to_execute()),
+            parent_block_id,
+        )?;
         if let Some(prikey) = local.prikey.as_ref() {
             let vote_proposal = VoteProposal::new(
                 result.extension_proof(),
@@ -72,7 +71,7 @@ impl ExecutionCorrectness for LocalClient {
         &mut self,
         block_ids: Vec<HashValue>,
         ledger_info_with_sigs: LedgerInfoWithSignatures,
-    ) -> Result<(Vec<Transaction>, Vec<ContractEvent>), Error> {
+    ) -> Result<(), Error> {
         self.internal
             .lock()
             .block_executor

--- a/execution/execution-correctness/src/serializer.rs
+++ b/execution/execution-correctness/src/serializer.rs
@@ -1,13 +1,11 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{execution_correctness::ExecutionCorrectness, id_and_transactions_from_block};
+use crate::execution_correctness::ExecutionCorrectness;
 use consensus_types::{block::Block, vote_proposal::VoteProposal};
 use diem_crypto::{ed25519::Ed25519PrivateKey, traits::SigningKey, HashValue};
 use diem_infallible::Mutex;
-use diem_types::{
-    contract_event::ContractEvent, ledger_info::LedgerInfoWithSignatures, transaction::Transaction,
-};
+use diem_types::ledger_info::LedgerInfoWithSignatures;
 use executor_types::{BlockExecutor, Error, StateComputeResult};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -42,7 +40,10 @@ impl SerializerService {
                 &self
                     .internal
                     .execute_block(
-                        id_and_transactions_from_block(&block_with_parent_id.0),
+                        (
+                            block_with_parent_id.0.id(),
+                            block_with_parent_id.0.transactions_to_execute(),
+                        ),
                         block_with_parent_id.1,
                     )
                     .map(|mut result| {
@@ -114,7 +115,7 @@ impl ExecutionCorrectness for SerializerClient {
         &mut self,
         block_ids: Vec<HashValue>,
         ledger_info_with_sigs: LedgerInfoWithSignatures,
-    ) -> Result<(Vec<Transaction>, Vec<ContractEvent>), Error> {
+    ) -> Result<(), Error> {
         let response = self.request(ExecutionCorrectnessInput::CommitBlocks(Box::new((
             block_ids,
             ledger_info_with_sigs,

--- a/execution/execution-correctness/src/tests/suite.rs
+++ b/execution/execution-correctness/src/tests/suite.rs
@@ -30,7 +30,7 @@ pub fn run_test_suite(executor_pair: (Box<dyn ExecutionCorrectness>, Option<Ed25
     }
 
     let ledger_info_with_sigs = gen_ledger_info_with_sigs(1, &result, block_id, vec![&signer]);
-    let (_, _) = executor
+    executor
         .commit_blocks(vec![block_id], ledger_info_with_sigs)
         .unwrap();
 }

--- a/execution/execution-correctness/src/tests/suite.rs
+++ b/execution/execution-correctness/src/tests/suite.rs
@@ -29,7 +29,7 @@ pub fn run_test_suite(executor_pair: (Box<dyn ExecutionCorrectness>, Option<Ed25
             .unwrap();
     }
 
-    let ledger_info_with_sigs = gen_ledger_info_with_sigs(1, result, block_id, vec![&signer]);
+    let ledger_info_with_sigs = gen_ledger_info_with_sigs(1, &result, block_id, vec![&signer]);
     let (_, _) = executor
         .commit_blocks(vec![block_id], ledger_info_with_sigs)
         .unwrap();

--- a/execution/executor-test-helpers/src/integration_test_impl.rs
+++ b/execution/executor-test-helpers/src/integration_test_impl.rs
@@ -235,14 +235,10 @@ pub fn test_execution_with_storage_impl() -> Arc<DiemDB> {
     let output1 = executor
         .execute_block((block1_id, block1.clone()), parent_block_id)
         .unwrap();
-    let ledger_info_with_sigs = gen_ledger_info_with_sigs(1, output1, block1_id, vec![&signer]);
-    let (_, reconfig_events) = executor
+    let ledger_info_with_sigs = gen_ledger_info_with_sigs(1, &output1, block1_id, vec![&signer]);
+    executor
         .commit_blocks(vec![block1_id], ledger_info_with_sigs)
         .unwrap();
-    assert!(
-        reconfig_events.is_empty(),
-        "expected no reconfiguration event from executor commit"
-    );
 
     let (li, epoch_change_proof, _accumulator_consistency_proof) =
         db.reader.get_state_proof(0).unwrap();

--- a/execution/executor-test-helpers/src/integration_test_impl.rs
+++ b/execution/executor-test-helpers/src/integration_test_impl.rs
@@ -415,7 +415,7 @@ pub fn test_execution_with_storage_impl() -> Arc<DiemDB> {
     let output2 = executor
         .execute_block((block2_id, block2.clone()), block1_id)
         .unwrap();
-    let ledger_info_with_sigs = gen_ledger_info_with_sigs(1, output2, block2_id, vec![&signer]);
+    let ledger_info_with_sigs = gen_ledger_info_with_sigs(1, &output2, block2_id, vec![&signer]);
     executor
         .commit_blocks(vec![block2_id], ledger_info_with_sigs)
         .unwrap();

--- a/execution/executor-test-helpers/src/lib.rs
+++ b/execution/executor-test-helpers/src/lib.rs
@@ -56,7 +56,7 @@ pub fn gen_block_id(index: u8) -> HashValue {
 
 pub fn gen_ledger_info_with_sigs(
     epoch: u64,
-    output: StateComputeResult,
+    output: &StateComputeResult,
     commit_block_id: HashValue,
     signer: Vec<&ValidatorSigner>,
 ) -> LedgerInfoWithSignatures {

--- a/execution/executor/src/executor_test.rs
+++ b/execution/executor/src/executor_test.rs
@@ -212,14 +212,13 @@ fn test_executor_commit_twice() {
         .execute_block((block1_id, block1_txns), parent_block_id)
         .unwrap();
     let ledger_info = gen_ledger_info(5, output1.root_hash(), block1_id, 1);
-    let res = executor
+    executor
         .commit_blocks(vec![block1_id], ledger_info.clone())
         .unwrap();
     // commit with the same ledger info again.
-    let res_retry = executor
+    executor
         .commit_blocks(vec![block1_id], ledger_info)
         .unwrap();
-    assert_eq!(res, res_retry);
 }
 
 #[test]

--- a/execution/executor/src/speculation_cache/mod.rs
+++ b/execution/executor/src/speculation_cache/mod.rs
@@ -26,9 +26,7 @@ use consensus_types::block::Block;
 use diem_crypto::{hash::PRE_GENESIS_BLOCK_ID, HashValue};
 use diem_infallible::Mutex;
 use diem_logger::prelude::*;
-use diem_types::{
-    contract_event::ContractEvent, ledger_info::LedgerInfo, transaction::Transaction,
-};
+use diem_types::{ledger_info::LedgerInfo, transaction::Transaction};
 use executor_types::{Error, ExecutedTrees};
 use std::{
     collections::HashMap,
@@ -111,7 +109,6 @@ impl Drop for SpeculationBlock {
 pub(crate) struct SpeculationCache {
     synced_trees: ExecutedTrees,
     committed_trees: ExecutedTrees,
-    committed_txns_and_events: (Vec<Transaction>, Vec<ContractEvent>),
     // The id of root block.
     committed_block_id: HashValue,
     // The chidren of root block.
@@ -126,7 +123,6 @@ impl SpeculationCache {
         Self {
             synced_trees: ExecutedTrees::new_empty(),
             committed_trees: ExecutedTrees::new_empty(),
-            committed_txns_and_events: (vec![], vec![]),
             heads: vec![],
             block_map: Arc::new(Mutex::new(HashMap::new())),
             committed_block_id: *PRE_GENESIS_BLOCK_ID,
@@ -137,12 +133,7 @@ impl SpeculationCache {
         let mut cache = Self::new();
         let ledger_info = startup_info.latest_ledger_info.ledger_info();
         let committed_trees = ExecutedTrees::from(startup_info.committed_tree_state);
-        cache.update_block_tree_root(
-            committed_trees,
-            ledger_info,
-            vec![], /* lastest_committed_txns */
-            vec![], /* latest_reconfig_events */
-        );
+        cache.update_block_tree_root(committed_trees, ledger_info);
         if let Some(synced_tree_state) = startup_info.synced_tree_state {
             cache.update_synced_trees(ExecutedTrees::from(synced_tree_state));
         }
@@ -156,15 +147,10 @@ impl SpeculationCache {
         Self {
             synced_trees: executor_trees.clone(),
             committed_trees: executor_trees,
-            committed_txns_and_events: (vec![], vec![]),
             heads: vec![],
             block_map: Arc::new(Mutex::new(HashMap::new())),
             committed_block_id: *PRE_GENESIS_BLOCK_ID,
         }
-    }
-
-    pub fn committed_txns_and_events(&self) -> (Vec<Transaction>, Vec<ContractEvent>) {
-        self.committed_txns_and_events.clone()
     }
 
     pub fn committed_block_id(&self) -> HashValue {
@@ -183,8 +169,6 @@ impl SpeculationCache {
         &mut self,
         committed_trees: ExecutedTrees,
         committed_ledger_info: &LedgerInfo,
-        committed_txns: Vec<Transaction>,
-        reconfig_events: Vec<ContractEvent>,
     ) {
         let new_root_block_id = if committed_ledger_info.ends_epoch() {
             // Update the root block id with reconfig virtual block id, to be consistent
@@ -207,7 +191,6 @@ impl SpeculationCache {
         };
         self.committed_block_id = new_root_block_id;
         self.committed_trees = committed_trees.clone();
-        self.committed_txns_and_events = (committed_txns, reconfig_events);
         self.synced_trees = committed_trees;
     }
 
@@ -273,12 +256,7 @@ impl SpeculationCache {
         Ok(())
     }
 
-    pub fn prune(
-        &mut self,
-        committed_ledger_info: &LedgerInfo,
-        committed_txns: Vec<Transaction>,
-        reconfig_events: Vec<ContractEvent>,
-    ) -> Result<(), Error> {
+    pub fn prune(&mut self, committed_ledger_info: &LedgerInfo) -> Result<(), Error> {
         let arc_latest_committed_block =
             self.get_block(&committed_ledger_info.consensus_block_id())?;
         let latest_committed_block = arc_latest_committed_block.lock();
@@ -286,8 +264,6 @@ impl SpeculationCache {
         self.update_block_tree_root(
             latest_committed_block.output().executed_trees().clone(),
             committed_ledger_info,
-            committed_txns,
-            reconfig_events,
         );
         Ok(())
     }

--- a/execution/executor/src/speculation_cache/test.rs
+++ b/execution/executor/src/speculation_cache/test.rs
@@ -78,9 +78,7 @@ fn test_branch() {
     // if assertion fails.
     let mut num_blocks = cache.block_map.lock().len();
     assert_eq!(num_blocks, 11);
-    cache
-        .prune(&gen_ledger_info(id(9), false), vec![], vec![])
-        .unwrap();
+    cache.prune(&gen_ledger_info(id(9), false)).unwrap();
     num_blocks = cache.block_map.lock().len();
     assert_eq!(num_blocks, 2);
     assert_eq!(cache.committed_block_id, id(9));
@@ -89,9 +87,7 @@ fn test_branch() {
 #[test]
 fn test_reconfig_id_update() {
     let mut cache = create_cache();
-    cache
-        .prune(&gen_ledger_info(id(1), true), vec![], vec![])
-        .unwrap();
+    cache.prune(&gen_ledger_info(id(1), true)).unwrap();
     let num_blocks = cache.block_map.lock().len();
     assert_eq!(num_blocks, 4);
     assert_ne!(cache.committed_block_id, id(1));

--- a/execution/executor/tests/db_bootstrapper_test.rs
+++ b/execution/executor/tests/db_bootstrapper_test.rs
@@ -89,7 +89,7 @@ fn execute_and_commit(txns: Vec<Transaction>, db: &DbReaderWriter, signer: &Vali
         .execute_block((block_id, txns), executor.committed_block_id())
         .unwrap();
     assert_eq!(output.num_leaves(), target_version + 1);
-    let ledger_info_with_sigs = gen_ledger_info_with_sigs(epoch, output, block_id, vec![&signer]);
+    let ledger_info_with_sigs = gen_ledger_info_with_sigs(epoch, &output, block_id, vec![&signer]);
     executor
         .commit_blocks(vec![block_id], ledger_info_with_sigs)
         .unwrap();

--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -379,7 +379,7 @@ fn test_change_publishing_option_to_custom() {
         .execute_block((block2_id, block2.clone()), executor.committed_block_id())
         .unwrap();
 
-    let ledger_info_with_sigs = gen_ledger_info_with_sigs(2, output2, block2_id, vec![&signer]);
+    let ledger_info_with_sigs = gen_ledger_info_with_sigs(2, &output2, block2_id, vec![&signer]);
     let (_, reconfig_events) = executor
         .commit_blocks(vec![block2_id], ledger_info_with_sigs)
         .unwrap();

--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -146,14 +146,10 @@ fn test_reconfiguration() {
         vm_output.has_reconfiguration(),
         "StateComputeResult does not see a reconfiguration"
     );
-    let ledger_info_with_sigs = gen_ledger_info_with_sigs(1, vm_output, block_id, vec![&signer]);
-    let (_, reconfig_events) = executor
+    let ledger_info_with_sigs = gen_ledger_info_with_sigs(1, &vm_output, block_id, vec![&signer]);
+    executor
         .commit_blocks(vec![block_id], ledger_info_with_sigs)
         .unwrap();
-    assert!(
-        !reconfig_events.is_empty(),
-        "expected reconfiguration event"
-    );
 
     let (li, _epoch_change_proof, _accumulator_consistency_proof) =
         db.reader.get_state_proof(0).unwrap();
@@ -325,14 +321,10 @@ fn test_change_publishing_option_to_custom() {
         "StateComputeResult has a new validator set"
     );
 
-    let ledger_info_with_sigs = gen_ledger_info_with_sigs(1, output1, block1_id, vec![&signer]);
-    let (_, reconfig_events) = executor
+    let ledger_info_with_sigs = gen_ledger_info_with_sigs(1, &output1, block1_id, vec![&signer]);
+    executor
         .commit_blocks(vec![block1_id], ledger_info_with_sigs)
         .unwrap();
-    assert!(
-        !reconfig_events.is_empty(),
-        "executor commit should return reconfig events for reconfiguration"
-    );
 
     let (li, epoch_change_proof, _accumulator_consistency_proof) =
         db.reader.get_state_proof(0).unwrap();
@@ -380,13 +372,9 @@ fn test_change_publishing_option_to_custom() {
         .unwrap();
 
     let ledger_info_with_sigs = gen_ledger_info_with_sigs(2, &output2, block2_id, vec![&signer]);
-    let (_, reconfig_events) = executor
+    executor
         .commit_blocks(vec![block2_id], ledger_info_with_sigs)
         .unwrap();
-    assert!(
-        reconfig_events.is_empty(),
-        "expect executor to reutrn no reconfig events"
-    );
 
     let (li, epoch_change_proof, _accumulator_consistency_proof) =
         db.reader.get_state_proof(current_version).unwrap();

--- a/state-sync/src/executor_proxy.rs
+++ b/state-sync/src/executor_proxy.rs
@@ -741,7 +741,7 @@ mod tests {
 
         // Commit block
         let ledger_info_with_sigs =
-            gen_ledger_info_with_sigs(block_id.into(), output, block_hash, vec![]);
+            gen_ledger_info_with_sigs(block_id.into(), &output, block_hash, vec![]);
         let (_, reconfig_events) = block_executor
             .commit_blocks(vec![block_hash], ledger_info_with_sigs.clone())
             .unwrap();

--- a/state-sync/src/executor_proxy.rs
+++ b/state-sync/src/executor_proxy.rs
@@ -742,14 +742,10 @@ mod tests {
         // Commit block
         let ledger_info_with_sigs =
             gen_ledger_info_with_sigs(block_id.into(), &output, block_hash, vec![]);
-        let (_, reconfig_events) = block_executor
+        block_executor
             .commit_blocks(vec![block_hash], ledger_info_with_sigs.clone())
             .unwrap();
-        assert!(
-            !reconfig_events.is_empty(),
-            "Expected reconfig events from block commit!"
-        );
 
-        (reconfig_events, ledger_info_with_sigs)
+        (output.reconfig_events().to_vec(), ledger_info_with_sigs)
     }
 }


### PR DESCRIPTION
## Motivation

`Executor::commit()` returns those on a retry, even though the block has already been committed previously, which is why the information is cached.
In fact, the information is already part of the state compute result which the caller always have a hold of.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Y
## Test Plan

Existing coverage.

