### PR TITLE
[diem genesis] some simplifications in Genesis module

### DIFF
--- a/config/management/genesis/src/command.rs
+++ b/config/management/genesis/src/command.rs
@@ -22,6 +22,8 @@ pub enum Command {
     OwnerKey(crate::key::OwnerKey),
     #[structopt(about = "Submits a Layout doc to a shared storage")]
     SetLayout(crate::layout::SetLayout),
+    #[structopt(about = "Submits the initial set of Move modules to be published in genesis")]
+    SetMoveModules(crate::move_modules::SetMoveModules),
     #[structopt(about = "Sets the validator operator chosen by the owner")]
     SetOperator(crate::validator_operator::ValidatorOperator),
     #[structopt(about = "Submits an Ed25519PublicKey for the treasury root")]
@@ -41,6 +43,7 @@ pub enum CommandName {
     OperatorKey,
     OwnerKey,
     SetLayout,
+    SetMoveModules,
     SetOperator,
     TreasuryComplianceKey,
     ValidatorConfig,
@@ -57,6 +60,7 @@ impl From<&Command> for CommandName {
             Command::OperatorKey(_) => CommandName::OperatorKey,
             Command::OwnerKey(_) => CommandName::OwnerKey,
             Command::SetLayout(_) => CommandName::SetLayout,
+            Command::SetMoveModules(_) => CommandName::SetMoveModules,
             Command::SetOperator(_) => CommandName::SetOperator,
             Command::TreasuryComplianceKey(_) => CommandName::TreasuryComplianceKey,
             Command::ValidatorConfig(_) => CommandName::ValidatorConfig,
@@ -75,6 +79,7 @@ impl std::fmt::Display for CommandName {
             CommandName::OperatorKey => "operator-key",
             CommandName::OwnerKey => "owner-key",
             CommandName::SetLayout => "set-layout",
+            CommandName::SetMoveModules => "set-move-modules",
             CommandName::SetOperator => "set-operator",
             CommandName::TreasuryComplianceKey => "treasury-compliance-key",
             CommandName::ValidatorConfig => "validator-config",
@@ -96,6 +101,7 @@ impl Command {
             Command::OperatorKey(_) => self.operator_key().map(|_| "Success!".to_string()),
             Command::OwnerKey(_) => self.owner_key().map(|_| "Success!".to_string()),
             Command::SetLayout(_) => self.set_layout().map(|_| "Success!".to_string()),
+            Command::SetMoveModules(_) => self.set_move_modules().map(|_| "Success!".to_string()),
             Command::SetOperator(_) => self.set_operator().map(|_| "Success!".to_string()),
             Command::TreasuryComplianceKey(_) => self
                 .treasury_compliance_key()
@@ -131,6 +137,10 @@ impl Command {
 
     pub fn set_layout(self) -> Result<crate::layout::Layout, Error> {
         execute_command!(self, Command::SetLayout, CommandName::SetLayout)
+    }
+
+    pub fn set_move_modules(self) -> Result<crate::move_modules::MoveModules, Error> {
+        execute_command!(self, Command::SetMoveModules, CommandName::SetMoveModules)
     }
 
     pub fn set_operator(self) -> Result<String, Error> {

--- a/config/management/genesis/src/genesis.rs
+++ b/config/management/genesis/src/genesis.rs
@@ -26,6 +26,8 @@ pub struct Genesis {
     #[structopt(flatten)]
     pub backend: SharedBackend,
     #[structopt(long)]
+    pub modules: Vec<PathBuf>,
+    #[structopt(long)]
     pub path: Option<PathBuf>,
 }
 

--- a/config/management/genesis/src/lib.rs
+++ b/config/management/genesis/src/lib.rs
@@ -7,6 +7,7 @@ pub mod command;
 mod genesis;
 mod key;
 pub mod layout;
+pub mod move_modules;
 mod validator_config;
 mod validator_operator;
 mod verify;

--- a/config/management/genesis/src/move_modules.rs
+++ b/config/management/genesis/src/move_modules.rs
@@ -1,0 +1,101 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::builder::GenesisBuilder;
+use diem_management::{config::ConfigPath, error::Error, secure_backend::SharedBackend};
+use diem_secure_storage::Storage;
+use serde::{Deserialize, Serialize};
+use std::{
+    fs::File,
+    io::Read,
+    path::{Path, PathBuf},
+};
+use structopt::StructOpt;
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct MoveModules {
+    pub modules: Vec<PathBuf>,
+}
+
+impl MoveModules {
+    /*pub fn from_disk<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
+        let mut file = File::open(&path).map_err(|e| Error::UnexpectedError(e.to_string()))?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)
+            .map_err(|e| Error::UnexpectedError(e.to_string()))?;
+        Self::parse(&contents)
+    }
+
+    pub fn parse(contents: &str) -> Result<Self, Error> {
+        toml::from_str(&contents).map_err(|e| Error::UnexpectedError(e.to_string()))
+    }
+
+    pub fn to_toml(&self) -> Result<String, Error> {
+        toml::to_string(&self).map_err(|e| Error::UnexpectedError(e.to_string()))
+    }*/
+}
+
+impl std::fmt::Display for MoveModules {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        //write!(f, "{}", toml::to_string(self).unwrap())
+        unimplemented!()
+    }
+}
+
+#[derive(Debug, StructOpt)]
+pub struct SetMoveModules {
+    #[structopt(flatten)]
+    config: ConfigPath,
+    #[structopt(long)]
+    path: PathBuf,
+    #[structopt(flatten)]
+    backend: SharedBackend,
+}
+
+impl SetMoveModules {
+    pub fn execute(self) -> Result<MoveModules, Error> {
+        /*let layout = Layout::from_disk(&self.path)?;
+
+        let config = self
+            .config
+            .load()?
+            .override_shared_backend(&self.backend.shared_backend)?;
+
+        // In order to not break cli compatibility we need to clear the namespace set via cli since
+        // it was previously ignored.
+        let mut shared_backend = config.shared_backend;
+        shared_backend.clear_namespace();
+
+        let storage = Storage::from(&shared_backend);
+        GenesisBuilder::new(storage)
+            .set_layout(&layout)
+            .map_err(|e| Error::StorageWriteError("shared", "layout", e.to_string()))?;
+
+        Ok(layout)*/
+        unimplemented!()
+    }
+}
+
+/*#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_layout() {
+        let contents = "\
+            operators = [\"alice\", \"bob\"]\n\
+            owners = [\"carol\"]\n\
+            diem_root = \"dave\"\n\
+            treasury_compliance = \"other_dave\"\n\
+        ";
+
+        let layout = Layout::parse(contents).unwrap();
+        assert_eq!(
+            layout.operators,
+            vec!["alice".to_string(), "bob".to_string()]
+        );
+        assert_eq!(layout.owners, vec!["carol".to_string()]);
+        assert_eq!(layout.diem_root, "dave");
+        assert_eq!(layout.treasury_compliance, "other_dave");
+    }
+}*/

--- a/config/management/genesis/src/waypoint.rs
+++ b/config/management/genesis/src/waypoint.rs
@@ -25,11 +25,12 @@ pub struct CreateWaypoint {
 
 impl CreateWaypoint {
     pub fn execute(self) -> Result<Waypoint, Error> {
+        let modules = unimplemented!("add modules");
         let genesis_helper = crate::genesis::Genesis {
             config: self.config,
             chain_id: self.chain_id,
             backend: self.shared_backend,
-            path: None,
+            modules,
         };
 
         let genesis = genesis_helper.execute()?;

--- a/config/src/config/execution_config.rs
+++ b/config/src/config/execution_config.rs
@@ -63,7 +63,9 @@ impl Default for ExecutionConfig {
 
 impl ExecutionConfig {
     pub fn load(&mut self, root_dir: &RootPath) -> Result<(), Error> {
+        println!("attempting to load genesis file");
         if !self.genesis_file_location.as_os_str().is_empty() {
+            println!("foud nonemtpy");
             let path = root_dir.full_path(&self.genesis_file_location);
             let mut file = File::open(&path).map_err(|e| Error::IO("genesis".into(), e))?;
             let mut buffer = vec![];


### PR DESCRIPTION
- DiemVersion::initialize takes the initial version number as input
- Set Diem version in Move code instead of Rust
