### PR TITLE
forge: new validator config builder

### DIFF
--- a/config/management/genesis/src/config_builder.rs
+++ b/config/management/genesis/src/config_builder.rs
@@ -1,246 +1,16 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{layout::Layout, storage_helper::StorageHelper, swarm_config::BuildSwarm};
+use crate::{swarm_config::BuildSwarm, validator_builder::ValidatorBuilder};
 use diem_config::{
-    config::{
-        Identity, NodeConfig, OnDiskStorageConfig, PeerRole, SafetyRulesService, SecureBackend,
-        WaypointConfig,
-    },
+    config::{NodeConfig, PeerRole},
     generator::build_seed_for_network,
     network_id::NetworkId,
 };
 use diem_crypto::ed25519::Ed25519PrivateKey;
-use diem_management::constants::{COMMON_NS, LAYOUT};
 use diem_secure_storage::{CryptoStorage, KVStorage, Storage};
 use diem_temppath::TempPath;
-use diem_types::{chain_id::ChainId, waypoint::Waypoint};
-use std::path::{Path, PathBuf};
-
-const DIEM_ROOT_NS: &str = "diem_root";
-const DIEM_ROOT_SHARED_NS: &str = "diem_root_shared";
-const OPERATOR_NS: &str = "_operator";
-const OPERATOR_SHARED_NS: &str = "_operator_shared";
-const OWNER_NS: &str = "_owner";
-const OWNER_SHARED_NS: &str = "_owner_shared";
-
-pub struct ValidatorBuilder<T: AsRef<Path>> {
-    storage_helper: StorageHelper,
-    num_validators: usize,
-    randomize_first_validator_ports: bool,
-    swarm_path: T,
-    template: NodeConfig,
-}
-
-impl<T: AsRef<Path>> ValidatorBuilder<T> {
-    pub fn new(num_validators: usize, template: NodeConfig, swarm_path: T) -> Self {
-        Self {
-            storage_helper: StorageHelper::new(),
-            num_validators,
-            randomize_first_validator_ports: true,
-            swarm_path,
-            template,
-        }
-    }
-
-    pub fn randomize_first_validator_ports(mut self, value: bool) -> Self {
-        self.randomize_first_validator_ports = value;
-        self
-    }
-
-    fn secure_backend(&self, ns: &str, usage: &str) -> SecureBackend {
-        let original = self.storage_helper.path();
-        let dst_base = self.swarm_path.as_ref();
-        let mut dst = dst_base.to_path_buf();
-        dst.push(format!("{}_{}", usage, ns));
-        std::fs::copy(original, &dst).unwrap();
-
-        let mut storage_config = OnDiskStorageConfig::default();
-        storage_config.path = dst;
-        storage_config.set_data_dir(PathBuf::from(""));
-        storage_config.namespace = Some(ns.into());
-        SecureBackend::OnDiskStorage(storage_config)
-    }
-
-    /// Association uploads the validator layout to shared storage.
-    fn create_layout(&self) {
-        let layout = Layout {
-            owners: (0..self.num_validators)
-                .map(|i| (i.to_string() + OWNER_SHARED_NS))
-                .collect(),
-            operators: (0..self.num_validators)
-                .map(|i| (i.to_string() + OPERATOR_SHARED_NS))
-                .collect(),
-            diem_root: DIEM_ROOT_SHARED_NS.into(),
-            treasury_compliance: DIEM_ROOT_SHARED_NS.into(),
-        };
-
-        let mut common_storage = self.storage_helper.storage(COMMON_NS.into());
-        let layout_value = layout.to_toml().unwrap();
-        common_storage.set(LAYOUT, layout_value).unwrap();
-    }
-
-    /// Root initializes diem root and treasury root keys.
-    fn create_root(&self) {
-        self.storage_helper
-            .initialize_by_idx(DIEM_ROOT_NS.into(), 0);
-        self.storage_helper
-            .diem_root_key(DIEM_ROOT_NS, DIEM_ROOT_SHARED_NS)
-            .unwrap();
-        self.storage_helper
-            .treasury_compliance_key(DIEM_ROOT_NS, DIEM_ROOT_SHARED_NS)
-            .unwrap();
-    }
-
-    /// Generate owner key locally and upload to shared storage.
-    fn initialize_validator_owner(&self, index: usize) {
-        let local_ns = index.to_string() + OWNER_NS;
-        let remote_ns = index.to_string() + OWNER_SHARED_NS;
-
-        self.storage_helper
-            .initialize_by_idx(local_ns.clone(), 1 + index);
-        let _ = self
-            .storage_helper
-            .owner_key(&local_ns, &remote_ns)
-            .unwrap();
-    }
-
-    /// Generate operator key locally and upload to shared storage.
-    fn initialize_validator_operator(&self, index: usize) {
-        let local_ns = index.to_string() + OPERATOR_NS;
-        let remote_ns = index.to_string() + OPERATOR_SHARED_NS;
-
-        self.storage_helper
-            .initialize_by_idx(local_ns.clone(), self.num_validators + 1 + index);
-        let _ = self
-            .storage_helper
-            .operator_key(&local_ns, &remote_ns)
-            .unwrap();
-    }
-
-    /// Sets the operator for the owner by uploading a set-operator transaction to shared storage.
-    /// Note, we assume that owner i chooses operator i to operate the validator.
-    fn set_validator_operator(&self, index: usize) {
-        let remote_ns = index.to_string() + OWNER_SHARED_NS;
-
-        let operator_name = index.to_string() + OPERATOR_SHARED_NS;
-        let _ = self.storage_helper.set_operator(&operator_name, &remote_ns);
-    }
-
-    /// Operators upload their validator_config to shared storage.
-    fn initialize_validator_config(&self, index: usize) -> NodeConfig {
-        let local_ns = index.to_string() + OPERATOR_NS;
-        let remote_ns = index.to_string() + OPERATOR_SHARED_NS;
-
-        let mut config = self.template.clone();
-        if index > 0 || self.randomize_first_validator_ports {
-            config.randomize_ports();
-        }
-
-        let validator_network = config.validator_network.as_mut().unwrap();
-        let validator_network_address = validator_network.listen_address.clone();
-        let fullnode_network = &mut config.full_node_networks[0];
-        let fullnode_network_address = fullnode_network.listen_address.clone();
-
-        self.storage_helper
-            .validator_config(
-                &(index.to_string() + OWNER_SHARED_NS),
-                validator_network_address,
-                fullnode_network_address,
-                ChainId::test(),
-                &local_ns,
-                &remote_ns,
-            )
-            .unwrap();
-
-        let validator_identity = validator_network.identity_from_storage();
-        validator_network.identity = Identity::from_storage(
-            validator_identity.key_name,
-            validator_identity.peer_id_name,
-            self.secure_backend(&local_ns, "validator"),
-        );
-        validator_network.network_address_key_backend =
-            Some(self.secure_backend(&local_ns, "validator"));
-
-        let fullnode_identity = fullnode_network.identity_from_storage();
-        fullnode_network.identity = Identity::from_storage(
-            fullnode_identity.key_name,
-            fullnode_identity.peer_id_name,
-            self.secure_backend(&local_ns, "full_node"),
-        );
-
-        config
-    }
-
-    /// Operators generate genesis from shared storage and verify against waypoint.
-    /// Insert the genesis/waypoint into local config.
-    fn finish_validator_config(&self, index: usize, config: &mut NodeConfig, waypoint: Waypoint) {
-        let local_ns = index.to_string() + OPERATOR_NS;
-
-        let genesis_path = TempPath::new();
-        genesis_path.create_as_file().unwrap();
-        let genesis = self
-            .storage_helper
-            .genesis(ChainId::test(), genesis_path.path())
-            .unwrap();
-
-        self.storage_helper
-            .insert_waypoint(&local_ns, waypoint)
-            .unwrap();
-
-        let output = self
-            .storage_helper
-            .verify_genesis(&local_ns, genesis_path.path())
-            .unwrap();
-        assert_eq!(output.split("match").count(), 5, "Failed to verify genesis");
-
-        config.consensus.safety_rules.service = SafetyRulesService::Thread;
-        config.consensus.safety_rules.backend = self.secure_backend(&local_ns, "safety-rules");
-        config.execution.backend = self.secure_backend(&local_ns, "execution");
-
-        let backend = self.secure_backend(&local_ns, "safety-rules");
-        config.base.waypoint = WaypointConfig::FromStorage(backend);
-        config.execution.genesis = Some(genesis);
-        config.execution.genesis_file_location = PathBuf::from("");
-    }
-}
-
-impl<T: AsRef<Path>> BuildSwarm for ValidatorBuilder<T> {
-    fn build_swarm(&self) -> anyhow::Result<(Vec<NodeConfig>, Ed25519PrivateKey)> {
-        self.create_layout();
-        self.create_root();
-        let diem_root_key = self
-            .storage_helper
-            .storage(DIEM_ROOT_NS.into())
-            .export_private_key(diem_global_constants::DIEM_ROOT_KEY)
-            .unwrap();
-
-        // Upload both owner and operator keys to shared storage
-        for index in 0..self.num_validators {
-            self.initialize_validator_owner(index);
-            self.initialize_validator_operator(index);
-        }
-
-        // Set the operator for each owner and the validator config for each operator
-        let mut configs = vec![];
-        for index in 0..self.num_validators {
-            let _ = self.set_validator_operator(index);
-            let config = self.initialize_validator_config(index);
-            configs.push(config);
-        }
-
-        let waypoint = self
-            .storage_helper
-            .create_waypoint(ChainId::test())
-            .unwrap();
-        // Create genesis and waypoint
-        for (i, config) in configs.iter_mut().enumerate() {
-            self.finish_validator_config(i, config, waypoint);
-        }
-
-        Ok((configs, diem_root_key))
-    }
-}
+use std::path::PathBuf;
 
 #[derive(Debug, Copy, Clone)]
 pub enum FullnodeType {
@@ -351,7 +121,9 @@ impl BuildSwarm for FullnodeBuilder {
 pub fn test_config() -> (NodeConfig, Ed25519PrivateKey) {
     let path = TempPath::new();
     path.create_as_dir().unwrap();
-    let builder = ValidatorBuilder::new(1, NodeConfig::default_for_validator(), path.path());
+    let builder = ValidatorBuilder::new(path.path())
+        .num_validators(1)
+        .template(NodeConfig::default_for_validator());
     let (mut configs, key) = builder.build_swarm().unwrap();
 
     let mut config = configs.swap_remove(0);

--- a/config/management/genesis/src/lib.rs
+++ b/config/management/genesis/src/lib.rs
@@ -16,7 +16,7 @@ mod waypoint;
 
 #[cfg(any(test, feature = "testing"))]
 pub mod config_builder;
-#[cfg(any(test, feature = "testing"))]
+#[cfg(test)]
 mod storage_helper;
 #[cfg(any(test, feature = "testing"))]
 pub mod swarm_config;

--- a/config/management/genesis/src/lib.rs
+++ b/config/management/genesis/src/lib.rs
@@ -8,6 +8,7 @@ pub mod command;
 mod genesis;
 mod key;
 pub mod layout;
+pub mod validator_builder;
 mod validator_config;
 mod validator_operator;
 mod verify;

--- a/config/management/genesis/src/storage_helper.rs
+++ b/config/management/genesis/src/storage_helper.rs
@@ -41,10 +41,6 @@ impl StorageHelper {
         Storage::from(Namespaced::new(namespace, Box::new(Storage::from(storage))))
     }
 
-    pub fn path(&self) -> &Path {
-        self.temppath.path()
-    }
-
     pub fn path_string(&self) -> &str {
         self.temppath.path().to_str().unwrap()
     }

--- a/config/management/genesis/src/swarm_config.rs
+++ b/config/management/genesis/src/swarm_config.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::validator_builder::ValidatorBuilder;
 use anyhow::Result;
 use diem_config::config::{NodeConfig, OnDiskStorageConfig};
 use diem_crypto::ed25519::Ed25519PrivateKey;
@@ -58,5 +59,16 @@ impl SwarmConfig {
             root_storage: root_storage_config,
             waypoint: configs[0].base.waypoint.waypoint(),
         })
+    }
+}
+
+impl BuildSwarm for ValidatorBuilder {
+    fn build_swarm(&self) -> Result<(Vec<NodeConfig>, Ed25519PrivateKey)> {
+        let (root_keys, validators) = self.clone().build()?;
+
+        Ok((
+            validators.into_iter().map(|v| v.config).collect(),
+            root_keys.root_key,
+        ))
     }
 }

--- a/config/management/genesis/src/validator_builder.rs
+++ b/config/management/genesis/src/validator_builder.rs
@@ -1,0 +1,400 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    builder::GenesisBuilder, layout::Layout, verify::verify_genesis,
+    waypoint::create_genesis_waypoint,
+};
+use anyhow::Result;
+use consensus_types::safety_data::SafetyData;
+use diem_config::config::{
+    Identity, NodeConfig, OnDiskStorageConfig, SafetyRulesService, SecureBackend, WaypointConfig,
+};
+use diem_crypto::{
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
+    Uniform,
+};
+use diem_global_constants::{
+    CONSENSUS_KEY, EXECUTION_KEY, FULLNODE_NETWORK_KEY, GENESIS_WAYPOINT, OPERATOR_ACCOUNT,
+    OPERATOR_KEY, OWNER_ACCOUNT, OWNER_KEY, SAFETY_DATA, VALIDATOR_NETWORK_KEY, WAYPOINT,
+};
+use diem_management::{
+    storage::StorageWrapper, validator_config::build_validator_config_transaction,
+};
+use diem_secure_storage::{CryptoStorage, KVStorage, OnDiskStorage, Storage};
+use diem_types::{
+    chain_id::ChainId,
+    network_address::encrypted::{
+        Key as NetworkAddressEncryptionKey, KeyVersion as NetworkAddressEncryptionKeyVersion,
+    },
+    transaction::{authenticator::AuthenticationKey, Transaction},
+    waypoint::Waypoint,
+};
+use std::{
+    convert::TryFrom,
+    fs::File,
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+const DIEM_ROOT_NS: &str = "diem_root";
+const OPERATOR_NS: &str = "_operator";
+const OWNER_NS: &str = "_owner";
+
+pub struct ValidatorConfig {
+    pub name: String,
+    pub storage_config: OnDiskStorageConfig,
+    pub config: NodeConfig,
+    pub directory: PathBuf,
+}
+
+impl ValidatorConfig {
+    fn new(
+        name: String,
+        storage_config: OnDiskStorageConfig,
+        directory: PathBuf,
+        config: NodeConfig,
+    ) -> Self {
+        Self {
+            name,
+            storage_config,
+            config,
+            directory,
+        }
+    }
+
+    fn owner(&self) -> String {
+        format!("{}{}", self.name, OWNER_NS)
+    }
+
+    fn operator(&self) -> String {
+        format!("{}{}", self.name, OPERATOR_NS)
+    }
+
+    fn storage(&self) -> OnDiskStorage {
+        OnDiskStorage::new(self.storage_config.path())
+    }
+
+    fn owner_key(&self) -> Result<Ed25519PublicKey> {
+        self.storage()
+            .get_public_key(OWNER_KEY)
+            .map(|r| r.public_key)
+            .map_err(Into::into)
+    }
+
+    fn operator_key(&self) -> Result<Ed25519PublicKey> {
+        self.storage()
+            .get_public_key(OPERATOR_KEY)
+            .map(|r| r.public_key)
+            .map_err(Into::into)
+    }
+
+    fn insert_waypoint(&mut self, waypoint: &Waypoint) -> Result<()> {
+        // set waypoint in storage
+        let mut storage = self.storage();
+        storage.set(WAYPOINT, waypoint)?;
+        storage.set(GENESIS_WAYPOINT, waypoint)?;
+
+        self.config.base.waypoint =
+            WaypointConfig::FromStorage(SecureBackend::OnDiskStorage(self.storage_config.clone()));
+
+        Ok(())
+    }
+
+    fn insert_genesis(&mut self, genesis: &Transaction) -> Result<()> {
+        // Save genesis file in this validator's config directory
+        let genesis_file_location = self.directory.join("genesis.blob");
+        File::create(&genesis_file_location)?.write_all(&bcs::to_bytes(&genesis)?)?;
+
+        self.config.execution.genesis = Some(genesis.clone());
+        self.config.execution.genesis_file_location = genesis_file_location;
+
+        Ok(())
+    }
+}
+
+pub struct RootKeys {
+    pub root_key: Ed25519PrivateKey,
+    pub treasury_compliance_key: Ed25519PrivateKey,
+    pub validator_network_address_encryption_key: NetworkAddressEncryptionKey,
+    pub validator_network_address_encryption_key_version: NetworkAddressEncryptionKeyVersion,
+}
+
+impl RootKeys {
+    pub fn generate<R>(rng: &mut R) -> Self
+    where
+        R: ::rand::RngCore + ::rand::CryptoRng,
+    {
+        // TODO use distinct keys for diem root and treasury
+        // let root_key = Ed25519PrivateKey::generate(rng);
+        // let treasury_compliance_key = Ed25519PrivateKey::generate(rng);
+        let key = Ed25519PrivateKey::generate(rng).to_bytes();
+        let root_key = Ed25519PrivateKey::try_from(key.as_ref()).unwrap();
+        let treasury_compliance_key = Ed25519PrivateKey::try_from(key.as_ref()).unwrap();
+
+        let mut validator_network_address_encryption_key = NetworkAddressEncryptionKey::default();
+        rng.fill_bytes(&mut validator_network_address_encryption_key);
+
+        Self {
+            root_key,
+            treasury_compliance_key,
+            validator_network_address_encryption_key,
+            validator_network_address_encryption_key_version: 0,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct ValidatorBuilder {
+    config_directory: PathBuf,
+    num_validators: usize,
+    randomize_first_validator_ports: bool,
+    template: NodeConfig,
+}
+
+impl ValidatorBuilder {
+    pub fn new<T: Into<PathBuf>>(config_directory: T) -> Self {
+        Self {
+            config_directory: config_directory.into(),
+            num_validators: 1,
+            randomize_first_validator_ports: true,
+            template: NodeConfig::default_for_validator(),
+        }
+    }
+
+    pub fn randomize_first_validator_ports(mut self, value: bool) -> Self {
+        self.randomize_first_validator_ports = value;
+        self
+    }
+
+    pub fn num_validators(mut self, num_validators: usize) -> Self {
+        self.num_validators = num_validators;
+        self
+    }
+
+    pub fn template(mut self, template: NodeConfig) -> Self {
+        self.template = template;
+        self
+    }
+
+    pub fn build(mut self) -> Result<(RootKeys, Vec<ValidatorConfig>)> {
+        // TODO Pass this in
+        let mut rng = rand::rngs::OsRng;
+
+        // Canonicalize the config directory path
+        self.config_directory = self.config_directory.canonicalize()?;
+
+        // Generate chain root keys
+        let root_keys = RootKeys::generate(&mut rng);
+
+        // Generate and initialize Validator configs
+        let mut validators = (0..self.num_validators)
+            .map(|i| {
+                self.initialize_validator_config(
+                    i,
+                    &mut rng,
+                    root_keys.validator_network_address_encryption_key,
+                    root_keys.validator_network_address_encryption_key_version,
+                )
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        // Build genesis
+        let mut genesis_storage =
+            OnDiskStorage::new(self.config_directory.join("genesis-storage.json"));
+        let (genesis, waypoint) =
+            Self::genesis_ceremony(&mut genesis_storage, &root_keys, &validators)?;
+
+        // Insert Genesis and Waypoint into each validator
+        for validator in &mut validators {
+            validator.insert_genesis(&genesis)?;
+            validator.insert_waypoint(&waypoint)?;
+
+            // verify genesis
+            let validator_storage = Storage::from(validator.storage());
+            let output = verify_genesis(
+                StorageWrapper::new("validator", validator_storage),
+                Some(validator.config.execution.genesis_file_location.as_path()),
+            )?;
+
+            anyhow::ensure!(
+                output.split("match").count() == 5,
+                "Failed to verify genesis"
+            );
+        }
+
+        Ok((root_keys, validators))
+    }
+
+    //
+    // Build helpers
+    //
+
+    fn initialize_validator_config<R>(
+        &self,
+        index: usize,
+        rng: &mut R,
+        validator_network_address_encryption_key: NetworkAddressEncryptionKey,
+        validator_network_address_encryption_key_version: NetworkAddressEncryptionKeyVersion,
+    ) -> Result<ValidatorConfig>
+    where
+        R: ::rand::RngCore + ::rand::CryptoRng,
+    {
+        let name = index.to_string();
+        let directory = self.config_directory.join(&name);
+        std::fs::create_dir_all(&directory)?;
+
+        let storage_config = Self::storage_config(&directory);
+
+        let mut validator =
+            ValidatorConfig::new(name, storage_config, directory, self.template.clone());
+        Self::initialize_validator_storage(
+            &validator,
+            rng,
+            validator_network_address_encryption_key,
+            validator_network_address_encryption_key_version,
+        )?;
+
+        let mut config = &mut validator.config;
+        if index > 0 || self.randomize_first_validator_ports {
+            config.randomize_ports();
+        }
+
+        // Setup the network configs
+        let validator_network = config.validator_network.as_mut().unwrap();
+        let fullnode_network = &mut config.full_node_networks[0];
+
+        let validator_identity = validator_network.identity_from_storage();
+        validator_network.identity = Identity::from_storage(
+            validator_identity.key_name,
+            validator_identity.peer_id_name,
+            SecureBackend::OnDiskStorage(validator.storage_config.clone()),
+        );
+        validator_network.network_address_key_backend = Some(SecureBackend::OnDiskStorage(
+            validator.storage_config.clone(),
+        ));
+
+        let fullnode_identity = fullnode_network.identity_from_storage();
+        fullnode_network.identity = Identity::from_storage(
+            fullnode_identity.key_name,
+            fullnode_identity.peer_id_name,
+            SecureBackend::OnDiskStorage(validator.storage_config.clone()),
+        );
+
+        // Setup consensus and execution configs
+        config.consensus.safety_rules.service = SafetyRulesService::Thread;
+        config.consensus.safety_rules.backend =
+            SecureBackend::OnDiskStorage(validator.storage_config.clone());
+        config.execution.backend = SecureBackend::OnDiskStorage(validator.storage_config.clone());
+
+        Ok(validator)
+    }
+
+    fn storage_config(directory: &Path) -> OnDiskStorageConfig {
+        let mut storage_config = OnDiskStorageConfig::default();
+        storage_config.path = directory.join("secure-storage.json");
+        storage_config.set_data_dir(directory.into());
+        storage_config
+    }
+
+    fn initialize_validator_storage<R>(
+        validator: &ValidatorConfig,
+        rng: &mut R,
+        validator_network_address_encryption_key: NetworkAddressEncryptionKey,
+        validator_network_address_encryption_key_version: NetworkAddressEncryptionKeyVersion,
+    ) -> Result<()>
+    where
+        R: ::rand::RngCore + ::rand::CryptoRng,
+    {
+        let mut storage = validator.storage();
+
+        // Set owner key and account address
+        storage.import_private_key(OWNER_KEY, Ed25519PrivateKey::generate(rng))?;
+        let owner_address =
+            diem_config::utils::validator_owner_account_from_name(validator.owner().as_bytes());
+        storage.set(OWNER_ACCOUNT, owner_address)?;
+
+        // Set operator key and account address
+        let operator_key = Ed25519PrivateKey::generate(rng);
+        let operator_address =
+            AuthenticationKey::ed25519(&Ed25519PublicKey::from(&operator_key)).derived_address();
+        storage.set(OPERATOR_ACCOUNT, operator_address)?;
+        storage.import_private_key(OPERATOR_KEY, operator_key)?;
+
+        storage.import_private_key(CONSENSUS_KEY, Ed25519PrivateKey::generate(rng))?;
+        storage.import_private_key(EXECUTION_KEY, Ed25519PrivateKey::generate(rng))?;
+        storage.import_private_key(FULLNODE_NETWORK_KEY, Ed25519PrivateKey::generate(rng))?;
+        storage.import_private_key(VALIDATOR_NETWORK_KEY, Ed25519PrivateKey::generate(rng))?;
+
+        // Initialize all other data in storage
+        storage.set(SAFETY_DATA, SafetyData::new(0, 0, 0, None))?;
+        storage.set(WAYPOINT, Waypoint::default())?;
+
+        let mut encryptor = diem_network_address_encryption::Encryptor::new(storage);
+        encryptor.initialize()?;
+        encryptor.add_key(
+            validator_network_address_encryption_key_version,
+            validator_network_address_encryption_key,
+        )?;
+
+        Ok(())
+    }
+
+    fn genesis_ceremony(
+        genesis_storage: &mut OnDiskStorage,
+        root_keys: &RootKeys,
+        validators: &[ValidatorConfig],
+    ) -> Result<(Transaction, Waypoint)> {
+        let mut genesis_builder = GenesisBuilder::new(genesis_storage);
+
+        // Set the Layout
+        let layout = Layout {
+            owners: validators.iter().map(|v| v.owner()).collect(),
+            operators: validators.iter().map(|v| v.operator()).collect(),
+            diem_root: DIEM_ROOT_NS.into(),
+            treasury_compliance: DIEM_ROOT_NS.into(),
+        };
+        genesis_builder.set_layout(&layout)?;
+
+        // Set Root and Treasury public keys
+        genesis_builder.set_root_key(Ed25519PublicKey::from(&root_keys.root_key))?;
+        genesis_builder.set_treasury_compliance_key(Ed25519PublicKey::from(
+            &root_keys.treasury_compliance_key,
+        ))?;
+
+        // Set Validator specific information
+        for validator in validators {
+            // Upload validator owner info
+            genesis_builder.set_owner_key(&validator.owner(), validator.owner_key()?)?;
+
+            // Upload validator operator info
+            genesis_builder.set_operator(&validator.owner(), &validator.operator())?;
+            genesis_builder.set_operator_key(&validator.operator(), validator.operator_key()?)?;
+
+            // Create and upload the onchain validator config
+            let validator_config = build_validator_config_transaction(
+                validator.storage(),
+                ChainId::test(),
+                0, // sequence_number
+                validator.config.full_node_networks[0]
+                    .listen_address
+                    .clone(),
+                validator
+                    .config
+                    .validator_network
+                    .as_ref()
+                    .map(|a| a.listen_address.clone())
+                    .unwrap(),
+                false, // This isn't a reconfiguration
+                false, // Don't disable address validation
+            )?;
+            genesis_builder.set_validator_config(&validator.operator(), &validator_config)?;
+        }
+
+        // Create Genesis and Genesis Waypoint
+        let genesis = genesis_builder.build(ChainId::test())?;
+        let waypoint = create_genesis_waypoint(&genesis)?;
+
+        Ok((genesis, waypoint))
+    }
+}

--- a/config/management/genesis/src/verify.rs
+++ b/config/management/genesis/src/verify.rs
@@ -52,36 +52,44 @@ impl Verify {
             .load()?
             .override_validator_backend(&self.backend.validator_backend)?;
         let validator_storage = config.validator_backend();
-        let mut buffer = String::new();
 
-        writeln!(buffer, "Data stored in SecureStorage:").unwrap();
-        write_break(&mut buffer);
-        writeln!(buffer, "Keys").unwrap();
-        write_break(&mut buffer);
-
-        write_ed25519_key(&validator_storage, &mut buffer, CONSENSUS_KEY);
-        write_x25519_key(&validator_storage, &mut buffer, FULLNODE_NETWORK_KEY);
-        write_ed25519_key(&validator_storage, &mut buffer, OWNER_KEY);
-        write_ed25519_key(&validator_storage, &mut buffer, OPERATOR_KEY);
-        write_ed25519_key(&validator_storage, &mut buffer, VALIDATOR_NETWORK_KEY);
-
-        write_break(&mut buffer);
-        writeln!(buffer, "Data").unwrap();
-        write_break(&mut buffer);
-
-        write_string(&validator_storage, &mut buffer, OPERATOR_ACCOUNT);
-        write_string(&validator_storage, &mut buffer, OWNER_ACCOUNT);
-        write_safety_data(&validator_storage, &mut buffer, SAFETY_DATA);
-        write_waypoint(&validator_storage, &mut buffer, WAYPOINT);
-
-        write_break(&mut buffer);
-
-        if let Some(genesis_path) = self.genesis_path.as_ref() {
-            compare_genesis(validator_storage, &mut buffer, genesis_path)?;
-        }
-
-        Ok(buffer)
+        verify_genesis(validator_storage, self.genesis_path.as_deref())
     }
+}
+
+pub fn verify_genesis(
+    validator_storage: Storage,
+    genesis_path: Option<&Path>,
+) -> Result<String, Error> {
+    let mut buffer = String::new();
+
+    writeln!(buffer, "Data stored in SecureStorage:").unwrap();
+    write_break(&mut buffer);
+    writeln!(buffer, "Keys").unwrap();
+    write_break(&mut buffer);
+
+    write_ed25519_key(&validator_storage, &mut buffer, CONSENSUS_KEY);
+    write_x25519_key(&validator_storage, &mut buffer, FULLNODE_NETWORK_KEY);
+    write_ed25519_key(&validator_storage, &mut buffer, OWNER_KEY);
+    write_ed25519_key(&validator_storage, &mut buffer, OPERATOR_KEY);
+    write_ed25519_key(&validator_storage, &mut buffer, VALIDATOR_NETWORK_KEY);
+
+    write_break(&mut buffer);
+    writeln!(buffer, "Data").unwrap();
+    write_break(&mut buffer);
+
+    write_string(&validator_storage, &mut buffer, OPERATOR_ACCOUNT);
+    write_string(&validator_storage, &mut buffer, OWNER_ACCOUNT);
+    write_safety_data(&validator_storage, &mut buffer, SAFETY_DATA);
+    write_waypoint(&validator_storage, &mut buffer, WAYPOINT);
+
+    write_break(&mut buffer);
+
+    if let Some(genesis_path) = genesis_path {
+        compare_genesis(validator_storage, &mut buffer, genesis_path)?;
+    }
+
+    Ok(buffer)
 }
 
 fn write_assert(buffer: &mut String, name: &str, value: bool) {

--- a/config/management/genesis/src/waypoint.rs
+++ b/config/management/genesis/src/waypoint.rs
@@ -4,7 +4,7 @@
 use diem_config::config::RocksdbConfig;
 use diem_management::{config::ConfigPath, error::Error, secure_backend::SharedBackend};
 use diem_temppath::TempPath;
-use diem_types::{chain_id::ChainId, waypoint::Waypoint};
+use diem_types::{chain_id::ChainId, transaction::Transaction, waypoint::Waypoint};
 use diem_vm::DiemVM;
 use diemdb::DiemDB;
 use executor::db_bootstrapper;
@@ -34,12 +34,16 @@ impl CreateWaypoint {
 
         let genesis = genesis_helper.execute()?;
 
-        let path = TempPath::new();
-        let diemdb = DiemDB::open(&path, false, None, RocksdbConfig::default())
-            .map_err(|e| Error::UnexpectedError(e.to_string()))?;
-        let db_rw = DbReaderWriter::new(diemdb);
-
-        db_bootstrapper::generate_waypoint::<DiemVM>(&db_rw, &genesis)
-            .map_err(|e| Error::UnexpectedError(e.to_string()))
+        create_genesis_waypoint(&genesis)
     }
+}
+
+pub fn create_genesis_waypoint(genesis: &Transaction) -> Result<Waypoint, Error> {
+    let path = TempPath::new();
+    let diemdb = DiemDB::open(&path, false, None, RocksdbConfig::default())
+        .map_err(|e| Error::UnexpectedError(e.to_string()))?;
+    let db_rw = DbReaderWriter::new(diemdb);
+
+    db_bootstrapper::generate_waypoint::<DiemVM>(&db_rw, &genesis)
+        .map_err(|e| Error::UnexpectedError(e.to_string()))
 }

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -713,14 +713,19 @@ fn optional_flag(flag: &'static str, enable_flag: bool) -> String {
 /// TODO: Support other types of storage
 fn backend_args(backend: &config::SecureBackend) -> Result<String, Error> {
     match backend {
-        config::SecureBackend::OnDiskStorage(config) => Ok(format!(
-            "backend={backend};\
-            path={path};\
-            namespace={namespace}",
-            backend = DISK,
-            namespace = config.namespace.clone().unwrap(),
-            path = config.path.to_str().unwrap(),
-        )),
+        config::SecureBackend::OnDiskStorage(config) => {
+            let mut s = format!(
+                "backend={backend};\
+                 path={path}",
+                backend = DISK,
+                path = config.path.to_str().unwrap(),
+            );
+            if let Some(namespace) = config.namespace.as_ref() {
+                s.push_str(&format!(";namespace={}", namespace));
+            }
+
+            Ok(s)
+        }
         _ => Err(Error::UnexpectedError("Storage isn't on disk".to_string())),
     }
 }

--- a/config/management/src/storage.rs
+++ b/config/management/src/storage.rs
@@ -22,6 +22,13 @@ pub struct StorageWrapper {
 }
 
 impl StorageWrapper {
+    pub fn new(storage_name: &'static str, storage: Storage) -> Self {
+        Self {
+            storage_name,
+            storage,
+        }
+    }
+
     pub fn encryptor(self) -> Encryptor<Storage> {
         Encryptor::new(self.storage)
     }

--- a/diem-node/src/lib.rs
+++ b/diem-node/src/lib.rs
@@ -126,9 +126,10 @@ pub fn load_test_environment(config_path: Option<PathBuf>, random_ports: bool) {
     maybe_config.push("validator_node_template.yaml");
     let template = NodeConfig::load_config(maybe_config)
         .unwrap_or_else(|_| NodeConfig::default_for_validator());
-    let builder =
-        diem_genesis_tool::config_builder::ValidatorBuilder::new(1, template, &config_path)
-            .randomize_first_validator_ports(random_ports);
+    let builder = diem_genesis_tool::validator_builder::ValidatorBuilder::new(&config_path)
+        .num_validators(1)
+        .template(template)
+        .randomize_first_validator_ports(random_ports);
     let test_config =
         diem_genesis_tool::swarm_config::SwarmConfig::build(&builder, &config_path).unwrap();
 
@@ -137,7 +138,7 @@ pub fn load_test_environment(config_path: Option<PathBuf>, random_ports: bool) {
     log_file.push("validator.log");
 
     // Build a waypoint file so that clients / docker can grab it easily
-    let mut waypoint_file_path = config_path.clone();
+    let mut waypoint_file_path = config_path;
     waypoint_file_path.push("waypoint.txt");
     std::io::Write::write_all(
         &mut std::fs::File::create(&waypoint_file_path).unwrap(),

--- a/json-rpc/tests/integration_test.rs
+++ b/json-rpc/tests/integration_test.rs
@@ -1039,7 +1039,7 @@ fn create_test_cases() -> Vec<Test> {
                         },
                         {
                             "data":{
-                                "created_address":"b5b333aabbf92e78524e2129b722eaca",
+                                "created_address": "652f27413456938eaa059f65231647cc",
                                 "role_id":3,
                                 "type":"createaccount"
                             },

--- a/json-rpc/tests/node.rs
+++ b/json-rpc/tests/node.rs
@@ -3,7 +3,7 @@
 
 use anyhow::Result;
 use diem_config::config::NodeConfig;
-use diem_genesis_tool::{config_builder::ValidatorBuilder, swarm_config::BuildSwarm};
+use diem_genesis_tool::{swarm_config::BuildSwarm, validator_builder::ValidatorBuilder};
 use diem_logger::prelude::FileWriter;
 
 pub struct Node {
@@ -24,7 +24,9 @@ impl Node {
 
         let config_path = node_dir.join("node.yaml");
 
-        let builder = ValidatorBuilder::new(1, NodeConfig::default_for_validator(), node_dir);
+        let builder = ValidatorBuilder::new(node_dir)
+            .num_validators(1)
+            .template(NodeConfig::default_for_validator());
         let (mut configs, root_key) = builder.build_swarm()?;
         let mut config = configs.pop().unwrap();
         config.set_data_dir(node_dir.to_path_buf());

--- a/language/diem-tools/oncall-trainer/src/init.rs
+++ b/language/diem-tools/oncall-trainer/src/init.rs
@@ -58,13 +58,14 @@ impl NodeInfo {
 
         // Build a single validator network
         let template = NodeConfig::default_for_validator();
-        let builder =
-            diem_genesis_tool::config_builder::ValidatorBuilder::new(1, template, &config_path)
-                .randomize_first_validator_ports(true);
+        let builder = diem_genesis_tool::validator_builder::ValidatorBuilder::new(&config_path)
+            .num_validators(1)
+            .template(template)
+            .randomize_first_validator_ports(true);
         let test_config =
             diem_genesis_tool::swarm_config::SwarmConfig::build(&builder, &config_path).unwrap();
 
-        let mut log_file = config_path.clone();
+        let mut log_file = config_path;
         log_file.push("validator.log");
         let log = File::create(log_file.as_path()).unwrap();
 

--- a/testsuite/diem-swarm/src/swarm.rs
+++ b/testsuite/diem-swarm/src/swarm.rs
@@ -5,8 +5,9 @@ use anyhow::{Context, Result};
 use debug_interface::NodeDebugClient;
 use diem_config::{config::NodeConfig, network_id::NetworkId};
 use diem_genesis_tool::{
-    config_builder::{FullnodeBuilder, FullnodeType, ValidatorBuilder},
+    config_builder::{FullnodeBuilder, FullnodeType},
     swarm_config::SwarmConfig,
+    validator_builder::ValidatorBuilder,
 };
 use diem_logger::prelude::*;
 use diem_temppath::TempPath;
@@ -488,7 +489,9 @@ impl DiemSwarm {
         let node_config = template.unwrap_or_else(NodeConfig::default_for_validator);
 
         let config_path = &swarm_config_dir.as_ref().to_path_buf();
-        let builder = ValidatorBuilder::new(num_nodes, node_config, &swarm_config_dir);
+        let builder = ValidatorBuilder::new(&config_path)
+            .num_validators(num_nodes)
+            .template(node_config);
         let config = SwarmConfig::build(&builder, config_path)?;
 
         Ok(Self {

--- a/testsuite/smoke-test/src/operational_tooling.rs
+++ b/testsuite/smoke-test/src/operational_tooling.rs
@@ -414,7 +414,6 @@ fn test_insert_waypoint() {
 
     // Get the current waypoint from storage
     let current_waypoint: Waypoint = storage.get(WAYPOINT).unwrap().value;
-    storage.get::<Waypoint>(GENESIS_WAYPOINT).unwrap_err();
 
     // Insert a new waypoint and genesis waypoint into storage
     let inserted_waypoint =

--- a/testsuite/smoke-test/src/test_utils.rs
+++ b/testsuite/smoke-test/src/test_utils.rs
@@ -171,9 +171,8 @@ pub mod diem_swarm_utils {
     }
 
     /// Loads the diem root's storage backend identified by the node index in the given swarm.
-    pub fn load_diem_root_storage(swarm: &DiemSwarm, node_index: usize) -> SecureBackend {
-        let (node_config, _) = load_node_config(swarm, node_index);
-        fetch_backend_storage(&node_config, Some("diem_root".to_string()))
+    pub fn load_diem_root_storage(swarm: &DiemSwarm, _node_index: usize) -> SecureBackend {
+        SecureBackend::OnDiskStorage(swarm.config.root_storage.clone())
     }
 
     /// Loads the node config for the validator at the specified index. Also returns the node


### PR DESCRIPTION
This PR introduces a new and improved ValidatorBuilder. The intent of this new builder is to improve the clarity of what happens during genesis as well as ensuring each validator's environment is a bit cleaner (e.g. the root key should not be present in each validator's secure-store).