### PR TITLE
[testsuite] Remove Flaky connection limit test

### DIFF
--- a/testsuite/smoke-test/src/full_nodes.rs
+++ b/testsuite/smoke-test/src/full_nodes.rs
@@ -8,7 +8,6 @@ use diem_config::{
     config::{DiscoveryMethod, NodeConfig, Peer, PeerRole, HANDSHAKE_VERSION},
     network_id::NetworkId,
 };
-use diem_operational_tool::test_helper::OperationalTool;
 use diem_types::{
     account_config::{testnet_dd_account_address, treasury_compliance_account_address},
     network_address::{NetworkAddress, Protocol},
@@ -378,14 +377,6 @@ fn test_private_full_node() {
         vec![(10.0, XUS.to_string())],
         get_balances(&mut validator_client, 0),
     ));
-
-    // Check that we can't connect, testing the connection limit
-    let op_tool = OperationalTool::test();
-    let mut private_swarm = private_swarm.lock();
-    let private_node = private_swarm.mut_node(0).unwrap();
-    op_tool
-        .check_endpoint(NetworkId::Public, private_node.public_address())
-        .expect_err("Shouldn't be able to connect to private node anonymously");
 }
 
 fn add_node_to_seeds(


### PR DESCRIPTION
I've manually tested that the connection limit works through logs.
However, the network checker establishes a connection, and doesn't
currently wait for being disconnected by the connection limit.  Sadly
since these are handled at different levels, ther 's a slight mismatch,
and some additional work will be needed to make this more test more
stable.

This is currently blocking my other PR https://github.com/diem/diem/pull/8458 but I wanted to call it out as a separate PR