### PR TITLE
[move-cli] Print resource changes after verbose execution

### DIFF
--- a/language/tools/move-cli/README.md
+++ b/language/tools/move-cli/README.md
@@ -258,6 +258,9 @@ Changed resource(s) under 1 address(es):
   Changed 1 resource(s) under address 0000000000000000000000000000000F:
     Added type 0x2::Test::Resource: [10, 0, 0, 0, 0, 0, 0, 0] (wrote 40 bytes)
 Wrote 40 bytes of resource ID's and data
+      key 0x2::Test::Resource {
+           i: 10
+      }
 Discarding changes; re-run without --dry-run if you would like to keep them.
 ```
 
@@ -271,9 +274,14 @@ Changed resource(s) under 1 address(es):
   Changed 1 resource(s) under address 0000000000000000000000000000000F:
     Added type 0x2::Test::Resource: [10, 0, 0, 0, 0, 0, 0, 0] (wrote 40 bytes)
 Wrote 40 bytes of resource ID's and data
+      key 0x2::Test::Resource {
+            i: 10
+      }
 ```
 
-We can now inspect this newly published resource using `move sandbox view` since
+While the verbose flag used above (`-v`) shows resource changes, it is also
+possible to view them manually.
+We can inspect the newly published resource using `move sandbox view` since
 the change has been committed:
 
 ```shell

--- a/language/tools/move-cli/tests/testsuite/diem_smoke/args.exp
+++ b/language/tools/move-cli/tests/testsuite/diem_smoke/args.exp
@@ -6,43 +6,348 @@ Emitted [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 30, 85, 237, 1, 0, 0, 0, 0, 0, 
 Changed resource(s) under 2 address(es):
   Changed 28 resource(s) under address 0000000000000000000000000A550C18:
     Added type 0x1::AccountFreezing::FreezeEventsHolder: [0, 0, 0, 0, 0, 0, 0, 0, 24, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 119 bytes)
+      key 0x1::AccountFreezing::FreezeEventsHolder {
+          freeze_event_handle: store 0x1::Event::EventHandle<0x1::AccountFreezing::FreezeAccountEvent> {
+              counter: 0
+              guid: 0f000000000000000000000000000000000000000a550c18
+          }
+          unfreeze_event_handle: store 0x1::Event::EventHandle<0x1::AccountFreezing::UnfreezeAccountEvent> {
+              counter: 0
+              guid: 10000000000000000000000000000000000000000a550c18
+          }
+      }
     Added type 0x1::AccountFreezing::FreezingBit: [0] (wrote 47 bytes)
+      key 0x1::AccountFreezing::FreezingBit {
+          is_frozen: false
+      }
     Added type 0x1::AccountLimits::LimitsDefinition<0x1::XDX::XDX>: [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 96, 215, 29, 20, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255] (wrote 107 bytes)
+      key 0x1::AccountLimits::LimitsDefinition<0x1::XDX::XDX> {
+          max_inflow: 18446744073709551615
+          max_outflow: 18446744073709551615
+          time_period: 86400000000
+          max_holding: 18446744073709551615
+      }
     Added type 0x1::AccountLimits::LimitsDefinition<0x1::XUS::XUS>: [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 96, 215, 29, 20, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255] (wrote 107 bytes)
+      key 0x1::AccountLimits::LimitsDefinition<0x1::XUS::XUS> {
+          max_inflow: 18446744073709551615
+          max_outflow: 18446744073709551615
+          time_period: 86400000000
+          max_holding: 18446744073709551615
+      }
     Added type 0x1::ChainId::ChainId: [0] (wrote 35 bytes)
+      key 0x1::ChainId::ChainId {
+          id: 0u8
+      }
     Added type 0x1::Diem::CurrencyInfo<0x1::XDX::XDX>: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 64, 66, 15, 0, 0, 0, 0, 0, 232, 3, 0, 0, 0, 0, 0, 0, 3, 88, 68, 88, 0, 0, 0, 0, 0, 0, 0, 0, 0, 24, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 281 bytes)
+      key 0x1::Diem::CurrencyInfo<0x1::XDX::XDX> {
+          total_value: 0u128
+          preburn_value: 0
+          to_xdx_exchange_rate: copy drop store 0x1::FixedPoint32::FixedPoint32 {
+              value: 4294967296
+          }
+          is_synthetic: true
+          scaling_factor: 1000000
+          fractional_part: 1000
+          currency_code: 584458
+          can_mint: false
+          mint_events: store 0x1::Event::EventHandle<0x1::Diem::MintEvent> {
+              counter: 0
+              guid: 0a000000000000000000000000000000000000000a550c18
+          }
+          burn_events: store 0x1::Event::EventHandle<0x1::Diem::BurnEvent> {
+              counter: 0
+              guid: 0b000000000000000000000000000000000000000a550c18
+          }
+          preburn_events: store 0x1::Event::EventHandle<0x1::Diem::PreburnEvent> {
+              counter: 0
+              guid: 0c000000000000000000000000000000000000000a550c18
+          }
+          cancel_burn_events: store 0x1::Event::EventHandle<0x1::Diem::CancelBurnEvent> {
+              counter: 0
+              guid: 0d000000000000000000000000000000000000000a550c18
+          }
+          exchange_rate_update_events: store 0x1::Event::EventHandle<0x1::Diem::ToXDXExchangeRateUpdateEvent> {
+              counter: 0
+              guid: 0e000000000000000000000000000000000000000a550c18
+          }
+      }
     Added type 0x1::Diem::CurrencyInfo<0x1::XUS::XUS>: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 64, 66, 15, 0, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 3, 88, 85, 83, 1, 0, 0, 0, 0, 0, 0, 0, 0, 24, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 281 bytes)
+      key 0x1::Diem::CurrencyInfo<0x1::XUS::XUS> {
+          total_value: 0u128
+          preburn_value: 0
+          to_xdx_exchange_rate: copy drop store 0x1::FixedPoint32::FixedPoint32 {
+              value: 4294967296
+          }
+          is_synthetic: false
+          scaling_factor: 1000000
+          fractional_part: 100
+          currency_code: 585553
+          can_mint: true
+          mint_events: store 0x1::Event::EventHandle<0x1::Diem::MintEvent> {
+              counter: 0
+              guid: 05000000000000000000000000000000000000000a550c18
+          }
+          burn_events: store 0x1::Event::EventHandle<0x1::Diem::BurnEvent> {
+              counter: 0
+              guid: 06000000000000000000000000000000000000000a550c18
+          }
+          preburn_events: store 0x1::Event::EventHandle<0x1::Diem::PreburnEvent> {
+              counter: 0
+              guid: 07000000000000000000000000000000000000000a550c18
+          }
+          cancel_burn_events: store 0x1::Event::EventHandle<0x1::Diem::CancelBurnEvent> {
+              counter: 0
+              guid: 08000000000000000000000000000000000000000a550c18
+          }
+          exchange_rate_update_events: store 0x1::Event::EventHandle<0x1::Diem::ToXDXExchangeRateUpdateEvent> {
+              counter: 0
+              guid: 09000000000000000000000000000000000000000a550c18
+          }
+      }
     Added type 0x1::DiemAccount::AccountOperationsCapability: [0, 2, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 92 bytes)
+      key 0x1::DiemAccount::AccountOperationsCapability {
+          limits_cap: store 0x1::AccountLimits::AccountLimitMutationCapability {
+              dummy_field: false
+          }
+          creation_events: store 0x1::Event::EventHandle<0x1::DiemAccount::CreateAccountEvent> {
+              counter: 2
+              guid: 00000000000000000000000000000000000000000a550c18
+          }
+      }
     Added type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
+      key 0x1::DiemAccount::DiemAccount {
+          authentication_key: 0000000000000000000000000000000000000000000000000000000000000000
+          withdraw_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::WithdrawCapability> {
+              vec: [
+                  store 0x1::DiemAccount::WithdrawCapability {
+                      account_address: a550c18
+                  },
+              ]
+          }
+          key_rotation_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::KeyRotationCapability> {
+              vec: [
+                  store 0x1::DiemAccount::KeyRotationCapability {
+                      account_address: a550c18
+                  },
+              ]
+          }
+          received_events: store 0x1::Event::EventHandle<0x1::DiemAccount::ReceivedPaymentEvent> {
+              counter: 0
+              guid: 02000000000000000000000000000000000000000a550c18
+          }
+          sent_events: store 0x1::Event::EventHandle<0x1::DiemAccount::SentPaymentEvent> {
+              counter: 0
+              guid: 03000000000000000000000000000000000000000a550c18
+          }
+          sequence_number: 0
+      }
     Added type 0x1::DiemAccount::DiemWriteSetManager: [0, 0, 0, 0, 0, 0, 0, 0, 24, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 83 bytes)
+      key 0x1::DiemAccount::DiemWriteSetManager {
+          upgrade_events: store 0x1::Event::EventHandle<0x1::DiemAccount::AdminTransactionEvent> {
+              counter: 0
+              guid: 01000000000000000000000000000000000000000a550c18
+          }
+      }
     Added type 0x1::DiemBlock::BlockMetadata: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 24, 17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 83 bytes)
+      key 0x1::DiemBlock::BlockMetadata {
+          height: 0
+          new_block_events: store 0x1::Event::EventHandle<0x1::DiemBlock::NewBlockEvent> {
+              counter: 0
+              guid: 11000000000000000000000000000000000000000a550c18
+          }
+      }
     Added type 0x1::DiemConfig::Configuration: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 24, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 92 bytes)
+      key 0x1::DiemConfig::Configuration {
+          epoch: 0
+          last_reconfiguration_time: 0
+          events: store 0x1::Event::EventHandle<0x1::DiemConfig::NewEpochEvent> {
+              counter: 0
+              guid: 04000000000000000000000000000000000000000a550c18
+          }
+      }
     Added type 0x1::DiemConfig::DiemConfig<0x1::DiemSystem::DiemSystem>: [0, 0] (wrote 82 bytes)
+      store key 0x1::DiemConfig::DiemConfig<0x1::DiemSystem::DiemSystem> {
+          payload: copy drop store 0x1::DiemSystem::DiemSystem {
+              scheme: 0u8
+              validators: [
+              ]
+          }
+      }
     Added type 0x1::DiemConfig::DiemConfig<0x1::DiemTransactionPublishingOption::DiemTransactionPublishingOption>: [0, 1] (wrote 124 bytes)
+      store key 0x1::DiemConfig::DiemConfig<0x1::DiemTransactionPublishingOption::DiemTransactionPublishingOption> {
+          payload: copy drop store 0x1::DiemTransactionPublishingOption::DiemTransactionPublishingOption {
+              script_allow_list: [
+              ]
+              module_publishing_allowed: true
+          }
+      }
     Added type 0x1::DiemConfig::DiemConfig<0x1::DiemVMConfig::DiemVMConfig>: [0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0, 88, 2, 0, 0, 0, 0, 0, 0, 88, 2, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 9, 61, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16, 39, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 232, 3, 0, 0, 0, 0, 0, 0, 32, 3, 0, 0, 0, 0, 0, 0] (wrote 174 bytes)
+      store key 0x1::DiemConfig::DiemConfig<0x1::DiemVMConfig::DiemVMConfig> {
+          payload: copy drop store 0x1::DiemVMConfig::DiemVMConfig {
+              gas_schedule: copy drop store 0x1::DiemVMConfig::GasSchedule {
+                  instruction_schedule: 
+                  native_schedule: 
+                  gas_constants: copy drop store 0x1::DiemVMConfig::GasConstants {
+                      global_memory_per_byte_cost: 4
+                      global_memory_per_byte_write_cost: 9
+                      min_transaction_gas_units: 600
+                      large_transaction_cutoff: 600
+                      intrinsic_gas_per_byte: 8
+                      maximum_number_of_gas_units: 4000000
+                      min_price_per_gas_unit: 0
+                      max_price_per_gas_unit: 10000
+                      max_transaction_size_in_bytes: 4096
+                      gas_unit_scaling_factor: 1000
+                      default_account_size: 800
+                  }
+              }
+          }
+      }
     Added type 0x1::DiemConfig::DiemConfig<0x1::DiemVersion::DiemVersion>: [1, 0, 0, 0, 0, 0, 0, 0] (wrote 90 bytes)
+      store key 0x1::DiemConfig::DiemConfig<0x1::DiemVersion::DiemVersion> {
+          payload: copy drop store 0x1::DiemVersion::DiemVersion {
+              major: 1
+          }
+      }
     Added type 0x1::DiemConfig::DiemConfig<0x1::RegisteredCurrencies::RegisteredCurrencies>: [2, 3, 88, 85, 83, 3, 88, 68, 88] (wrote 109 bytes)
+      store key 0x1::DiemConfig::DiemConfig<0x1::RegisteredCurrencies::RegisteredCurrencies> {
+          payload: copy drop store 0x1::RegisteredCurrencies::RegisteredCurrencies {
+              currency_codes: [
+                  585553,
+                  584458,
+              ]
+          }
+      }
     Added type 0x1::DiemConfig::ModifyConfigCapability<0x1::DiemTransactionPublishingOption::DiemTransactionPublishingOption>: [0] (wrote 135 bytes)
+      store key 0x1::DiemConfig::ModifyConfigCapability<0x1::DiemTransactionPublishingOption::DiemTransactionPublishingOption> {
+          dummy_field: false
+      }
     Added type 0x1::DiemConfig::ModifyConfigCapability<0x1::DiemVMConfig::DiemVMConfig>: [0] (wrote 97 bytes)
+      store key 0x1::DiemConfig::ModifyConfigCapability<0x1::DiemVMConfig::DiemVMConfig> {
+          dummy_field: false
+      }
     Added type 0x1::DiemConfig::ModifyConfigCapability<0x1::DiemVersion::DiemVersion>: [0] (wrote 95 bytes)
+      store key 0x1::DiemConfig::ModifyConfigCapability<0x1::DiemVersion::DiemVersion> {
+          dummy_field: false
+      }
     Added type 0x1::DiemConfig::ModifyConfigCapability<0x1::RegisteredCurrencies::RegisteredCurrencies>: [0] (wrote 113 bytes)
+      store key 0x1::DiemConfig::ModifyConfigCapability<0x1::RegisteredCurrencies::RegisteredCurrencies> {
+          dummy_field: false
+      }
     Added type 0x1::DiemSystem::CapabilityHolder: [0] (wrote 47 bytes)
+      key 0x1::DiemSystem::CapabilityHolder {
+          cap: store key 0x1::DiemConfig::ModifyConfigCapability<0x1::DiemSystem::DiemSystem> {
+              dummy_field: false
+          }
+      }
     Added type 0x1::DiemTimestamp::CurrentTimeMicroseconds: [0, 0, 0, 0, 0, 0, 0, 0] (wrote 64 bytes)
+      key 0x1::DiemTimestamp::CurrentTimeMicroseconds {
+          microseconds: 0
+      }
     Added type 0x1::DualAttestation::Limit: [0, 202, 154, 59, 0, 0, 0, 0] (wrote 48 bytes)
+      key 0x1::DualAttestation::Limit {
+          micro_xdx_limit: 1000000000
+      }
     Added type 0x1::Event::EventHandleGenerator: [18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 69 bytes)
+      key 0x1::Event::EventHandleGenerator {
+          counter: 18
+          addr: a550c18
+      }
     Added type 0x1::Roles::RoleId: [0, 0, 0, 0, 0, 0, 0, 0] (wrote 39 bytes)
+      key 0x1::Roles::RoleId {
+          role_id: 0
+      }
     Added type 0x1::SlidingNonce::SlidingNonce: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 68 bytes)
+      key 0x1::SlidingNonce::SlidingNonce {
+          min_nonce: 0
+          nonce_mask: 0u128
+      }
     Added type 0x1::XDX::Reserve: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 40 bytes)
+      key 0x1::XDX::Reserve {
+          mint_cap: store key 0x1::Diem::MintCapability<0x1::XDX::XDX> {
+              dummy_field: false
+          }
+          burn_cap: store key 0x1::Diem::BurnCapability<0x1::XDX::XDX> {
+              dummy_field: false
+          }
+          preburn_cap: store key 0x1::Diem::Preburn<0x1::XDX::XDX> {
+              to_burn: store 0x1::Diem::Diem<0x1::XDX::XDX> {
+                  value: 0
+              }
+          }
+      }
   Changed 9 resource(s) under address 0000000000000000000000000B1E55ED:
     Added type 0x1::AccountFreezing::FreezingBit: [0] (wrote 47 bytes)
+      key 0x1::AccountFreezing::FreezingBit {
+          is_frozen: false
+      }
     Added type 0x1::Diem::BurnCapability<0x1::XUS::XUS>: [0] (wrote 65 bytes)
+      store key 0x1::Diem::BurnCapability<0x1::XUS::XUS> {
+          dummy_field: false
+      }
     Added type 0x1::Diem::MintCapability<0x1::XUS::XUS>: [0] (wrote 65 bytes)
+      store key 0x1::Diem::MintCapability<0x1::XUS::XUS> {
+          dummy_field: false
+      }
     Added type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 30, 85, 237, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 30, 85, 237, 0, 0, 0, 0, 0, 0, 0, 0, 24, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 30, 85, 237, 0, 0, 0, 0, 0, 0, 0, 0, 24, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 30, 85, 237, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
+      key 0x1::DiemAccount::DiemAccount {
+          authentication_key: 0000000000000000000000000000000000000000000000000000000000000000
+          withdraw_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::WithdrawCapability> {
+              vec: [
+                  store 0x1::DiemAccount::WithdrawCapability {
+                      account_address: b1e55ed
+                  },
+              ]
+          }
+          key_rotation_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::KeyRotationCapability> {
+              vec: [
+                  store 0x1::DiemAccount::KeyRotationCapability {
+                      account_address: b1e55ed
+                  },
+              ]
+          }
+          received_events: store 0x1::Event::EventHandle<0x1::DiemAccount::ReceivedPaymentEvent> {
+              counter: 0
+              guid: 01000000000000000000000000000000000000000b1e55ed
+          }
+          sent_events: store 0x1::Event::EventHandle<0x1::DiemAccount::SentPaymentEvent> {
+              counter: 0
+              guid: 02000000000000000000000000000000000000000b1e55ed
+          }
+          sequence_number: 0
+      }
     Added type 0x1::DiemId::DiemIdDomainManager: [0, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 30, 85, 237] (wrote 78 bytes)
+      key 0x1::DiemId::DiemIdDomainManager {
+          diem_id_domain_events: store 0x1::Event::EventHandle<0x1::DiemId::DiemIdDomainEvent> {
+              counter: 0
+              guid: 00000000000000000000000000000000000000000b1e55ed
+          }
+      }
     Added type 0x1::Event::EventHandleGenerator: [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 30, 85, 237] (wrote 69 bytes)
+      key 0x1::Event::EventHandleGenerator {
+          counter: 3
+          addr: b1e55ed
+      }
     Added type 0x1::Roles::RoleId: [1, 0, 0, 0, 0, 0, 0, 0] (wrote 39 bytes)
+      key 0x1::Roles::RoleId {
+          role_id: 1
+      }
     Added type 0x1::SlidingNonce::SlidingNonce: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 68 bytes)
+      key 0x1::SlidingNonce::SlidingNonce {
+          min_nonce: 0
+          nonce_mask: 0u128
+      }
     Added type 0x1::TransactionFee::TransactionFee<0x1::XUS::XUS>: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 90 bytes)
+      key 0x1::TransactionFee::TransactionFee<0x1::XUS::XUS> {
+          balance: store 0x1::Diem::Diem<0x1::XUS::XUS> {
+              value: 0
+          }
+          preburn: store key 0x1::Diem::Preburn<0x1::XUS::XUS> {
+              to_burn: store 0x1::Diem::Diem<0x1::XUS::XUS> {
+                  value: 0
+              }
+          }
+      }
 Wrote 3608 bytes of resource ID's and data
 Command `sandbox run scripts/create_designated_dealer.move --mode diem --type-args 0x1::XDX::XDX --signers 0xB1E55ED --args 0 0xDD x"00000000000000000000000000000000" b"DD" true -v`:
 Compiling transaction script...
@@ -51,16 +356,106 @@ Emitted [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 2, 0, 0, 0, 0, 0, 0, 
 Changed resource(s) under 2 address(es):
   Changed 9 resource(s) under address 000000000000000000000000000000DD:
     Added type 0x1::AccountFreezing::FreezingBit: [0] (wrote 47 bytes)
+      key 0x1::AccountFreezing::FreezingBit {
+          is_frozen: false
+      }
     Added type 0x1::DesignatedDealer::Dealer: [0, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221] (wrote 75 bytes)
+      key 0x1::DesignatedDealer::Dealer {
+          mint_event_handle: store 0x1::Event::EventHandle<0x1::DesignatedDealer::ReceivedMintEvent> {
+              counter: 0
+              guid: 0000000000000000000000000000000000000000000000dd
+          }
+      }
     Added type 0x1::Diem::PreburnQueue<0x1::XUS::XUS>: [0] (wrote 63 bytes)
+      key 0x1::Diem::PreburnQueue<0x1::XUS::XUS> {
+          preburns: [
+          ]
+      }
     Added type 0x1::DiemAccount::Balance<0x1::XDX::XDX>: [0, 0, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+      key 0x1::DiemAccount::Balance<0x1::XDX::XDX> {
+          coin: store 0x1::Diem::Diem<0x1::XDX::XDX> {
+              value: 0
+          }
+      }
     Added type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [0, 0, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+      key 0x1::DiemAccount::Balance<0x1::XUS::XUS> {
+          coin: store 0x1::Diem::Diem<0x1::XUS::XUS> {
+              value: 0
+          }
+      }
     Added type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 0, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 0, 0, 0, 0, 0, 0, 0, 0, 24, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
+      key 0x1::DiemAccount::DiemAccount {
+          authentication_key: 00000000000000000000000000000000000000000000000000000000000000dd
+          withdraw_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::WithdrawCapability> {
+              vec: [
+                  store 0x1::DiemAccount::WithdrawCapability {
+                      account_address: dd
+                  },
+              ]
+          }
+          key_rotation_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::KeyRotationCapability> {
+              vec: [
+                  store 0x1::DiemAccount::KeyRotationCapability {
+                      account_address: dd
+                  },
+              ]
+          }
+          received_events: store 0x1::Event::EventHandle<0x1::DiemAccount::ReceivedPaymentEvent> {
+              counter: 0
+              guid: 0300000000000000000000000000000000000000000000dd
+          }
+          sent_events: store 0x1::Event::EventHandle<0x1::DiemAccount::SentPaymentEvent> {
+              counter: 0
+              guid: 0400000000000000000000000000000000000000000000dd
+          }
+          sequence_number: 0
+      }
     Added type 0x1::DualAttestation::Credential: [2, 68, 68, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 24, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 0, 0, 0, 0, 0, 0, 0, 0, 24, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221] (wrote 124 bytes)
+      key 0x1::DualAttestation::Credential {
+          human_name: 4444
+          base_url: 
+          compliance_public_key: 
+          expiration_date: 18446744073709551615
+          compliance_key_rotation_events: store 0x1::Event::EventHandle<0x1::DualAttestation::ComplianceKeyRotationEvent> {
+              counter: 0
+              guid: 0100000000000000000000000000000000000000000000dd
+          }
+          base_url_rotation_events: store 0x1::Event::EventHandle<0x1::DualAttestation::BaseUrlRotationEvent> {
+              counter: 0
+              guid: 0200000000000000000000000000000000000000000000dd
+          }
+      }
     Added type 0x1::Event::EventHandleGenerator: [5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221] (wrote 69 bytes)
+      key 0x1::Event::EventHandleGenerator {
+          counter: 5
+          addr: dd
+      }
     Added type 0x1::Roles::RoleId: [2, 0, 0, 0, 0, 0, 0, 0] (wrote 39 bytes)
+      key 0x1::Roles::RoleId {
+          role_id: 2
+      }
   Changed 1 resource(s) under address 0000000000000000000000000A550C18:
     Changed type 0x1::DiemAccount::AccountOperationsCapability: [0, 3, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 92 bytes)
+      Previous:
+        key 0x1::DiemAccount::AccountOperationsCapability {
+            limits_cap: store 0x1::AccountLimits::AccountLimitMutationCapability {
+                dummy_field: false
+            }
+            creation_events: store 0x1::Event::EventHandle<0x1::DiemAccount::CreateAccountEvent> {
+                counter: 2
+                guid: 00000000000000000000000000000000000000000a550c18
+            }
+        }
+      New:
+        key 0x1::DiemAccount::AccountOperationsCapability {
+            limits_cap: store 0x1::AccountLimits::AccountLimitMutationCapability {
+                dummy_field: false
+            }
+            creation_events: store 0x1::Event::EventHandle<0x1::DiemAccount::CreateAccountEvent> {
+                counter: 3
+                guid: 00000000000000000000000000000000000000000a550c18
+            }
+        }
 Wrote 836 bytes of resource ID's and data
 Command `sandbox run scripts/create_parent_vasp_account.move --mode diem --type-args 0x1::XDX::XDX --signers 0xB1E55ED --args 0 0xA x"00000000000000000000000000000000" b"VASP_A" true -v`:
 Compiling transaction script...
@@ -69,16 +464,103 @@ Emitted [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 5, 0, 0, 0, 0, 0, 0, 0
 Changed resource(s) under 2 address(es):
   Changed 9 resource(s) under address 0000000000000000000000000000000A:
     Added type 0x1::AccountFreezing::FreezingBit: [0] (wrote 47 bytes)
+      key 0x1::AccountFreezing::FreezingBit {
+          is_frozen: false
+      }
     Added type 0x1::DiemAccount::Balance<0x1::XDX::XDX>: [0, 0, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+      key 0x1::DiemAccount::Balance<0x1::XDX::XDX> {
+          coin: store 0x1::Diem::Diem<0x1::XDX::XDX> {
+              value: 0
+          }
+      }
     Added type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [0, 0, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+      key 0x1::DiemAccount::Balance<0x1::XUS::XUS> {
+          coin: store 0x1::Diem::Diem<0x1::XUS::XUS> {
+              value: 0
+          }
+      }
     Added type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 24, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
+      key 0x1::DiemAccount::DiemAccount {
+          authentication_key: 000000000000000000000000000000000000000000000000000000000000000a
+          withdraw_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::WithdrawCapability> {
+              vec: [
+                  store 0x1::DiemAccount::WithdrawCapability {
+                      account_address: a
+                  },
+              ]
+          }
+          key_rotation_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::KeyRotationCapability> {
+              vec: [
+                  store 0x1::DiemAccount::KeyRotationCapability {
+                      account_address: a
+                  },
+              ]
+          }
+          received_events: store 0x1::Event::EventHandle<0x1::DiemAccount::ReceivedPaymentEvent> {
+              counter: 0
+              guid: 02000000000000000000000000000000000000000000000a
+          }
+          sent_events: store 0x1::Event::EventHandle<0x1::DiemAccount::SentPaymentEvent> {
+              counter: 0
+              guid: 03000000000000000000000000000000000000000000000a
+          }
+          sequence_number: 0
+      }
     Added type 0x1::DiemId::DiemIdDomains: [0] (wrote 40 bytes)
+      key 0x1::DiemId::DiemIdDomains {
+          domains: [
+          ]
+      }
     Added type 0x1::DualAttestation::Credential: [6, 86, 65, 83, 80, 95, 65, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 24, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10] (wrote 128 bytes)
+      key 0x1::DualAttestation::Credential {
+          human_name: 564153505f41
+          base_url: 
+          compliance_public_key: 
+          expiration_date: 18446744073709551615
+          compliance_key_rotation_events: store 0x1::Event::EventHandle<0x1::DualAttestation::ComplianceKeyRotationEvent> {
+              counter: 0
+              guid: 00000000000000000000000000000000000000000000000a
+          }
+          base_url_rotation_events: store 0x1::Event::EventHandle<0x1::DualAttestation::BaseUrlRotationEvent> {
+              counter: 0
+              guid: 01000000000000000000000000000000000000000000000a
+          }
+      }
     Added type 0x1::Event::EventHandleGenerator: [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10] (wrote 69 bytes)
+      key 0x1::Event::EventHandleGenerator {
+          counter: 4
+          addr: a
+      }
     Added type 0x1::Roles::RoleId: [5, 0, 0, 0, 0, 0, 0, 0] (wrote 39 bytes)
+      key 0x1::Roles::RoleId {
+          role_id: 5
+      }
     Added type 0x1::VASP::ParentVASP: [0, 0, 0, 0, 0, 0, 0, 0] (wrote 42 bytes)
+      key 0x1::VASP::ParentVASP {
+          num_children: 0
+      }
   Changed 1 resource(s) under address 0000000000000000000000000A550C18:
     Changed type 0x1::DiemAccount::AccountOperationsCapability: [0, 4, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 92 bytes)
+      Previous:
+        key 0x1::DiemAccount::AccountOperationsCapability {
+            limits_cap: store 0x1::AccountLimits::AccountLimitMutationCapability {
+                dummy_field: false
+            }
+            creation_events: store 0x1::Event::EventHandle<0x1::DiemAccount::CreateAccountEvent> {
+                counter: 3
+                guid: 00000000000000000000000000000000000000000a550c18
+            }
+        }
+      New:
+        key 0x1::DiemAccount::AccountOperationsCapability {
+            limits_cap: store 0x1::AccountLimits::AccountLimitMutationCapability {
+                dummy_field: false
+            }
+            creation_events: store 0x1::Event::EventHandle<0x1::DiemAccount::CreateAccountEvent> {
+                counter: 4
+                guid: 00000000000000000000000000000000000000000a550c18
+            }
+        }
 Wrote 784 bytes of resource ID's and data
 Command `sandbox run scripts/create_parent_vasp_account.move --mode diem --type-args 0x1::XDX::XDX --signers 0xB1E55ED --args 0 0xB x"00000000000000000000000000000000" b"VASP_B" true -v`:
 Compiling transaction script...
@@ -87,16 +569,103 @@ Emitted [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 5, 0, 0, 0, 0, 0, 0, 0
 Changed resource(s) under 2 address(es):
   Changed 9 resource(s) under address 0000000000000000000000000000000B:
     Added type 0x1::AccountFreezing::FreezingBit: [0] (wrote 47 bytes)
+      key 0x1::AccountFreezing::FreezingBit {
+          is_frozen: false
+      }
     Added type 0x1::DiemAccount::Balance<0x1::XDX::XDX>: [0, 0, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+      key 0x1::DiemAccount::Balance<0x1::XDX::XDX> {
+          coin: store 0x1::Diem::Diem<0x1::XDX::XDX> {
+              value: 0
+          }
+      }
     Added type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [0, 0, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+      key 0x1::DiemAccount::Balance<0x1::XUS::XUS> {
+          coin: store 0x1::Diem::Diem<0x1::XUS::XUS> {
+              value: 0
+          }
+      }
     Added type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 24, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
+      key 0x1::DiemAccount::DiemAccount {
+          authentication_key: 000000000000000000000000000000000000000000000000000000000000000b
+          withdraw_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::WithdrawCapability> {
+              vec: [
+                  store 0x1::DiemAccount::WithdrawCapability {
+                      account_address: b
+                  },
+              ]
+          }
+          key_rotation_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::KeyRotationCapability> {
+              vec: [
+                  store 0x1::DiemAccount::KeyRotationCapability {
+                      account_address: b
+                  },
+              ]
+          }
+          received_events: store 0x1::Event::EventHandle<0x1::DiemAccount::ReceivedPaymentEvent> {
+              counter: 0
+              guid: 02000000000000000000000000000000000000000000000b
+          }
+          sent_events: store 0x1::Event::EventHandle<0x1::DiemAccount::SentPaymentEvent> {
+              counter: 0
+              guid: 03000000000000000000000000000000000000000000000b
+          }
+          sequence_number: 0
+      }
     Added type 0x1::DiemId::DiemIdDomains: [0] (wrote 40 bytes)
+      key 0x1::DiemId::DiemIdDomains {
+          domains: [
+          ]
+      }
     Added type 0x1::DualAttestation::Credential: [6, 86, 65, 83, 80, 95, 66, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 24, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11] (wrote 128 bytes)
+      key 0x1::DualAttestation::Credential {
+          human_name: 564153505f42
+          base_url: 
+          compliance_public_key: 
+          expiration_date: 18446744073709551615
+          compliance_key_rotation_events: store 0x1::Event::EventHandle<0x1::DualAttestation::ComplianceKeyRotationEvent> {
+              counter: 0
+              guid: 00000000000000000000000000000000000000000000000b
+          }
+          base_url_rotation_events: store 0x1::Event::EventHandle<0x1::DualAttestation::BaseUrlRotationEvent> {
+              counter: 0
+              guid: 01000000000000000000000000000000000000000000000b
+          }
+      }
     Added type 0x1::Event::EventHandleGenerator: [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11] (wrote 69 bytes)
+      key 0x1::Event::EventHandleGenerator {
+          counter: 4
+          addr: b
+      }
     Added type 0x1::Roles::RoleId: [5, 0, 0, 0, 0, 0, 0, 0] (wrote 39 bytes)
+      key 0x1::Roles::RoleId {
+          role_id: 5
+      }
     Added type 0x1::VASP::ParentVASP: [0, 0, 0, 0, 0, 0, 0, 0] (wrote 42 bytes)
+      key 0x1::VASP::ParentVASP {
+          num_children: 0
+      }
   Changed 1 resource(s) under address 0000000000000000000000000A550C18:
     Changed type 0x1::DiemAccount::AccountOperationsCapability: [0, 5, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 92 bytes)
+      Previous:
+        key 0x1::DiemAccount::AccountOperationsCapability {
+            limits_cap: store 0x1::AccountLimits::AccountLimitMutationCapability {
+                dummy_field: false
+            }
+            creation_events: store 0x1::Event::EventHandle<0x1::DiemAccount::CreateAccountEvent> {
+                counter: 4
+                guid: 00000000000000000000000000000000000000000a550c18
+            }
+        }
+      New:
+        key 0x1::DiemAccount::AccountOperationsCapability {
+            limits_cap: store 0x1::AccountLimits::AccountLimitMutationCapability {
+                dummy_field: false
+            }
+            creation_events: store 0x1::Event::EventHandle<0x1::DiemAccount::CreateAccountEvent> {
+                counter: 5
+                guid: 00000000000000000000000000000000000000000a550c18
+            }
+        }
 Wrote 784 bytes of resource ID's and data
 Command `sandbox run scripts/tiered_mint.move --mode diem --type-args 0x1::XUS::XUS --signers 0xB1E55ED --args 0 0xDD 1000 0 -v`:
 Compiling transaction script...
@@ -107,10 +676,156 @@ Emitted [232, 3, 0, 0, 0, 0, 0, 0, 3, 88, 85, 83, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
 Changed resource(s) under 2 address(es):
   Changed 3 resource(s) under address 000000000000000000000000000000DD:
     Changed type 0x1::DesignatedDealer::Dealer: [1, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221] (wrote 75 bytes)
+      Previous:
+        key 0x1::DesignatedDealer::Dealer {
+            mint_event_handle: store 0x1::Event::EventHandle<0x1::DesignatedDealer::ReceivedMintEvent> {
+                counter: 0
+                guid: 0000000000000000000000000000000000000000000000dd
+            }
+        }
+      New:
+        key 0x1::DesignatedDealer::Dealer {
+            mint_event_handle: store 0x1::Event::EventHandle<0x1::DesignatedDealer::ReceivedMintEvent> {
+                counter: 1
+                guid: 0000000000000000000000000000000000000000000000dd
+            }
+        }
     Changed type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [232, 3, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+      Previous:
+        key 0x1::DiemAccount::Balance<0x1::XUS::XUS> {
+            coin: store 0x1::Diem::Diem<0x1::XUS::XUS> {
+                value: 0
+            }
+        }
+      New:
+        key 0x1::DiemAccount::Balance<0x1::XUS::XUS> {
+            coin: store 0x1::Diem::Diem<0x1::XUS::XUS> {
+                value: 1000
+            }
+        }
     Changed type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 0, 0, 0, 0, 0, 0, 0, 0, 24, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
+      Previous:
+        key 0x1::DiemAccount::DiemAccount {
+            authentication_key: 00000000000000000000000000000000000000000000000000000000000000dd
+            withdraw_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::WithdrawCapability> {
+                vec: [
+                    store 0x1::DiemAccount::WithdrawCapability {
+                        account_address: dd
+                    },
+                ]
+            }
+            key_rotation_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::KeyRotationCapability> {
+                vec: [
+                    store 0x1::DiemAccount::KeyRotationCapability {
+                        account_address: dd
+                    },
+                ]
+            }
+            received_events: store 0x1::Event::EventHandle<0x1::DiemAccount::ReceivedPaymentEvent> {
+                counter: 0
+                guid: 0300000000000000000000000000000000000000000000dd
+            }
+            sent_events: store 0x1::Event::EventHandle<0x1::DiemAccount::SentPaymentEvent> {
+                counter: 0
+                guid: 0400000000000000000000000000000000000000000000dd
+            }
+            sequence_number: 0
+        }
+      New:
+        key 0x1::DiemAccount::DiemAccount {
+            authentication_key: 00000000000000000000000000000000000000000000000000000000000000dd
+            withdraw_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::WithdrawCapability> {
+                vec: [
+                    store 0x1::DiemAccount::WithdrawCapability {
+                        account_address: dd
+                    },
+                ]
+            }
+            key_rotation_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::KeyRotationCapability> {
+                vec: [
+                    store 0x1::DiemAccount::KeyRotationCapability {
+                        account_address: dd
+                    },
+                ]
+            }
+            received_events: store 0x1::Event::EventHandle<0x1::DiemAccount::ReceivedPaymentEvent> {
+                counter: 1
+                guid: 0300000000000000000000000000000000000000000000dd
+            }
+            sent_events: store 0x1::Event::EventHandle<0x1::DiemAccount::SentPaymentEvent> {
+                counter: 0
+                guid: 0400000000000000000000000000000000000000000000dd
+            }
+            sequence_number: 0
+        }
   Changed 1 resource(s) under address 0000000000000000000000000A550C18:
     Changed type 0x1::Diem::CurrencyInfo<0x1::XUS::XUS>: [232, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 64, 66, 15, 0, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 3, 88, 85, 83, 1, 1, 0, 0, 0, 0, 0, 0, 0, 24, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24, 0, 0, 0, 0, 0, 0, 0, 0, 24, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 281 bytes)
+      Previous:
+        key 0x1::Diem::CurrencyInfo<0x1::XUS::XUS> {
+            total_value: 0u128
+            preburn_value: 0
+            to_xdx_exchange_rate: copy drop store 0x1::FixedPoint32::FixedPoint32 {
+                value: 4294967296
+            }
+            is_synthetic: false
+            scaling_factor: 1000000
+            fractional_part: 100
+            currency_code: 585553
+            can_mint: true
+            mint_events: store 0x1::Event::EventHandle<0x1::Diem::MintEvent> {
+                counter: 0
+                guid: 05000000000000000000000000000000000000000a550c18
+            }
+            burn_events: store 0x1::Event::EventHandle<0x1::Diem::BurnEvent> {
+                counter: 0
+                guid: 06000000000000000000000000000000000000000a550c18
+            }
+            preburn_events: store 0x1::Event::EventHandle<0x1::Diem::PreburnEvent> {
+                counter: 0
+                guid: 07000000000000000000000000000000000000000a550c18
+            }
+            cancel_burn_events: store 0x1::Event::EventHandle<0x1::Diem::CancelBurnEvent> {
+                counter: 0
+                guid: 08000000000000000000000000000000000000000a550c18
+            }
+            exchange_rate_update_events: store 0x1::Event::EventHandle<0x1::Diem::ToXDXExchangeRateUpdateEvent> {
+                counter: 0
+                guid: 09000000000000000000000000000000000000000a550c18
+            }
+        }
+      New:
+        key 0x1::Diem::CurrencyInfo<0x1::XUS::XUS> {
+            total_value: 1000u128
+            preburn_value: 0
+            to_xdx_exchange_rate: copy drop store 0x1::FixedPoint32::FixedPoint32 {
+                value: 4294967296
+            }
+            is_synthetic: false
+            scaling_factor: 1000000
+            fractional_part: 100
+            currency_code: 585553
+            can_mint: true
+            mint_events: store 0x1::Event::EventHandle<0x1::Diem::MintEvent> {
+                counter: 1
+                guid: 05000000000000000000000000000000000000000a550c18
+            }
+            burn_events: store 0x1::Event::EventHandle<0x1::Diem::BurnEvent> {
+                counter: 0
+                guid: 06000000000000000000000000000000000000000a550c18
+            }
+            preburn_events: store 0x1::Event::EventHandle<0x1::Diem::PreburnEvent> {
+                counter: 0
+                guid: 07000000000000000000000000000000000000000a550c18
+            }
+            cancel_burn_events: store 0x1::Event::EventHandle<0x1::Diem::CancelBurnEvent> {
+                counter: 0
+                guid: 08000000000000000000000000000000000000000a550c18
+            }
+            exchange_rate_update_events: store 0x1::Event::EventHandle<0x1::Diem::ToXDXExchangeRateUpdateEvent> {
+                counter: 0
+                guid: 09000000000000000000000000000000000000000a550c18
+            }
+        }
 Wrote 611 bytes of resource ID's and data
 Command `sandbox run scripts/peer_to_peer_with_metadata.move --mode diem --type-args 0x1::XUS::XUS --signers 0xDD --args 0xA 700 x"" x"" -v`:
 Compiling transaction script...
@@ -120,10 +835,142 @@ Emitted [188, 2, 0, 0, 0, 0, 0, 0, 3, 88, 85, 83, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
 Changed resource(s) under 2 address(es):
   Changed 2 resource(s) under address 0000000000000000000000000000000A:
     Changed type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [188, 2, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+      Previous:
+        key 0x1::DiemAccount::Balance<0x1::XUS::XUS> {
+            coin: store 0x1::Diem::Diem<0x1::XUS::XUS> {
+                value: 0
+            }
+        }
+      New:
+        key 0x1::DiemAccount::Balance<0x1::XUS::XUS> {
+            coin: store 0x1::Diem::Diem<0x1::XUS::XUS> {
+                value: 700
+            }
+        }
     Changed type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 24, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
+      Previous:
+        key 0x1::DiemAccount::DiemAccount {
+            authentication_key: 000000000000000000000000000000000000000000000000000000000000000a
+            withdraw_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::WithdrawCapability> {
+                vec: [
+                    store 0x1::DiemAccount::WithdrawCapability {
+                        account_address: a
+                    },
+                ]
+            }
+            key_rotation_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::KeyRotationCapability> {
+                vec: [
+                    store 0x1::DiemAccount::KeyRotationCapability {
+                        account_address: a
+                    },
+                ]
+            }
+            received_events: store 0x1::Event::EventHandle<0x1::DiemAccount::ReceivedPaymentEvent> {
+                counter: 0
+                guid: 02000000000000000000000000000000000000000000000a
+            }
+            sent_events: store 0x1::Event::EventHandle<0x1::DiemAccount::SentPaymentEvent> {
+                counter: 0
+                guid: 03000000000000000000000000000000000000000000000a
+            }
+            sequence_number: 0
+        }
+      New:
+        key 0x1::DiemAccount::DiemAccount {
+            authentication_key: 000000000000000000000000000000000000000000000000000000000000000a
+            withdraw_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::WithdrawCapability> {
+                vec: [
+                    store 0x1::DiemAccount::WithdrawCapability {
+                        account_address: a
+                    },
+                ]
+            }
+            key_rotation_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::KeyRotationCapability> {
+                vec: [
+                    store 0x1::DiemAccount::KeyRotationCapability {
+                        account_address: a
+                    },
+                ]
+            }
+            received_events: store 0x1::Event::EventHandle<0x1::DiemAccount::ReceivedPaymentEvent> {
+                counter: 1
+                guid: 02000000000000000000000000000000000000000000000a
+            }
+            sent_events: store 0x1::Event::EventHandle<0x1::DiemAccount::SentPaymentEvent> {
+                counter: 0
+                guid: 03000000000000000000000000000000000000000000000a
+            }
+            sequence_number: 0
+        }
   Changed 2 resource(s) under address 000000000000000000000000000000DD:
     Changed type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [44, 1, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+      Previous:
+        key 0x1::DiemAccount::Balance<0x1::XUS::XUS> {
+            coin: store 0x1::Diem::Diem<0x1::XUS::XUS> {
+                value: 1000
+            }
+        }
+      New:
+        key 0x1::DiemAccount::Balance<0x1::XUS::XUS> {
+            coin: store 0x1::Diem::Diem<0x1::XUS::XUS> {
+                value: 300
+            }
+        }
     Changed type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 1, 0, 0, 0, 0, 0, 0, 0, 24, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
+      Previous:
+        key 0x1::DiemAccount::DiemAccount {
+            authentication_key: 00000000000000000000000000000000000000000000000000000000000000dd
+            withdraw_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::WithdrawCapability> {
+                vec: [
+                    store 0x1::DiemAccount::WithdrawCapability {
+                        account_address: dd
+                    },
+                ]
+            }
+            key_rotation_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::KeyRotationCapability> {
+                vec: [
+                    store 0x1::DiemAccount::KeyRotationCapability {
+                        account_address: dd
+                    },
+                ]
+            }
+            received_events: store 0x1::Event::EventHandle<0x1::DiemAccount::ReceivedPaymentEvent> {
+                counter: 1
+                guid: 0300000000000000000000000000000000000000000000dd
+            }
+            sent_events: store 0x1::Event::EventHandle<0x1::DiemAccount::SentPaymentEvent> {
+                counter: 0
+                guid: 0400000000000000000000000000000000000000000000dd
+            }
+            sequence_number: 0
+        }
+      New:
+        key 0x1::DiemAccount::DiemAccount {
+            authentication_key: 00000000000000000000000000000000000000000000000000000000000000dd
+            withdraw_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::WithdrawCapability> {
+                vec: [
+                    store 0x1::DiemAccount::WithdrawCapability {
+                        account_address: dd
+                    },
+                ]
+            }
+            key_rotation_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::KeyRotationCapability> {
+                vec: [
+                    store 0x1::DiemAccount::KeyRotationCapability {
+                        account_address: dd
+                    },
+                ]
+            }
+            received_events: store 0x1::Event::EventHandle<0x1::DiemAccount::ReceivedPaymentEvent> {
+                counter: 1
+                guid: 0300000000000000000000000000000000000000000000dd
+            }
+            sent_events: store 0x1::Event::EventHandle<0x1::DiemAccount::SentPaymentEvent> {
+                counter: 1
+                guid: 0400000000000000000000000000000000000000000000dd
+            }
+            sequence_number: 0
+        }
 Wrote 510 bytes of resource ID's and data
 Command `sandbox run scripts/peer_to_peer_with_metadata.move --mode diem --type-args 0x1::XUS::XUS --signers 0xA --args 0xB 500 x"" x"" -v`:
 Compiling transaction script...
@@ -133,10 +980,142 @@ Emitted [244, 1, 0, 0, 0, 0, 0, 0, 3, 88, 85, 83, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
 Changed resource(s) under 2 address(es):
   Changed 2 resource(s) under address 0000000000000000000000000000000A:
     Changed type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [200, 0, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+      Previous:
+        key 0x1::DiemAccount::Balance<0x1::XUS::XUS> {
+            coin: store 0x1::Diem::Diem<0x1::XUS::XUS> {
+                value: 700
+            }
+        }
+      New:
+        key 0x1::DiemAccount::Balance<0x1::XUS::XUS> {
+            coin: store 0x1::Diem::Diem<0x1::XUS::XUS> {
+                value: 200
+            }
+        }
     Changed type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 24, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
+      Previous:
+        key 0x1::DiemAccount::DiemAccount {
+            authentication_key: 000000000000000000000000000000000000000000000000000000000000000a
+            withdraw_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::WithdrawCapability> {
+                vec: [
+                    store 0x1::DiemAccount::WithdrawCapability {
+                        account_address: a
+                    },
+                ]
+            }
+            key_rotation_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::KeyRotationCapability> {
+                vec: [
+                    store 0x1::DiemAccount::KeyRotationCapability {
+                        account_address: a
+                    },
+                ]
+            }
+            received_events: store 0x1::Event::EventHandle<0x1::DiemAccount::ReceivedPaymentEvent> {
+                counter: 1
+                guid: 02000000000000000000000000000000000000000000000a
+            }
+            sent_events: store 0x1::Event::EventHandle<0x1::DiemAccount::SentPaymentEvent> {
+                counter: 0
+                guid: 03000000000000000000000000000000000000000000000a
+            }
+            sequence_number: 0
+        }
+      New:
+        key 0x1::DiemAccount::DiemAccount {
+            authentication_key: 000000000000000000000000000000000000000000000000000000000000000a
+            withdraw_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::WithdrawCapability> {
+                vec: [
+                    store 0x1::DiemAccount::WithdrawCapability {
+                        account_address: a
+                    },
+                ]
+            }
+            key_rotation_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::KeyRotationCapability> {
+                vec: [
+                    store 0x1::DiemAccount::KeyRotationCapability {
+                        account_address: a
+                    },
+                ]
+            }
+            received_events: store 0x1::Event::EventHandle<0x1::DiemAccount::ReceivedPaymentEvent> {
+                counter: 1
+                guid: 02000000000000000000000000000000000000000000000a
+            }
+            sent_events: store 0x1::Event::EventHandle<0x1::DiemAccount::SentPaymentEvent> {
+                counter: 1
+                guid: 03000000000000000000000000000000000000000000000a
+            }
+            sequence_number: 0
+        }
   Changed 2 resource(s) under address 0000000000000000000000000000000B:
     Changed type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [244, 1, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+      Previous:
+        key 0x1::DiemAccount::Balance<0x1::XUS::XUS> {
+            coin: store 0x1::Diem::Diem<0x1::XUS::XUS> {
+                value: 0
+            }
+        }
+      New:
+        key 0x1::DiemAccount::Balance<0x1::XUS::XUS> {
+            coin: store 0x1::Diem::Diem<0x1::XUS::XUS> {
+                value: 500
+            }
+        }
     Changed type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 1, 0, 0, 0, 0, 0, 0, 0, 24, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
+      Previous:
+        key 0x1::DiemAccount::DiemAccount {
+            authentication_key: 000000000000000000000000000000000000000000000000000000000000000b
+            withdraw_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::WithdrawCapability> {
+                vec: [
+                    store 0x1::DiemAccount::WithdrawCapability {
+                        account_address: b
+                    },
+                ]
+            }
+            key_rotation_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::KeyRotationCapability> {
+                vec: [
+                    store 0x1::DiemAccount::KeyRotationCapability {
+                        account_address: b
+                    },
+                ]
+            }
+            received_events: store 0x1::Event::EventHandle<0x1::DiemAccount::ReceivedPaymentEvent> {
+                counter: 0
+                guid: 02000000000000000000000000000000000000000000000b
+            }
+            sent_events: store 0x1::Event::EventHandle<0x1::DiemAccount::SentPaymentEvent> {
+                counter: 0
+                guid: 03000000000000000000000000000000000000000000000b
+            }
+            sequence_number: 0
+        }
+      New:
+        key 0x1::DiemAccount::DiemAccount {
+            authentication_key: 000000000000000000000000000000000000000000000000000000000000000b
+            withdraw_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::WithdrawCapability> {
+                vec: [
+                    store 0x1::DiemAccount::WithdrawCapability {
+                        account_address: b
+                    },
+                ]
+            }
+            key_rotation_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::KeyRotationCapability> {
+                vec: [
+                    store 0x1::DiemAccount::KeyRotationCapability {
+                        account_address: b
+                    },
+                ]
+            }
+            received_events: store 0x1::Event::EventHandle<0x1::DiemAccount::ReceivedPaymentEvent> {
+                counter: 1
+                guid: 02000000000000000000000000000000000000000000000b
+            }
+            sent_events: store 0x1::Event::EventHandle<0x1::DiemAccount::SentPaymentEvent> {
+                counter: 0
+                guid: 03000000000000000000000000000000000000000000000b
+            }
+            sequence_number: 0
+        }
 Wrote 510 bytes of resource ID's and data
 Command `sandbox run scripts/create_child_vasp_account.move --mode diem --type-args 0x1::XUS::XUS --signers 0xA --args 0xAA x"00000000000000000000000000000000" false 100 -v`:
 Compiling transaction script...
@@ -147,17 +1126,155 @@ Emitted [100, 0, 0, 0, 0, 0, 0, 0, 3, 88, 85, 83, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
 Changed resource(s) under 3 address(es):
   Changed 3 resource(s) under address 0000000000000000000000000000000A:
     Changed type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [100, 0, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+      Previous:
+        key 0x1::DiemAccount::Balance<0x1::XUS::XUS> {
+            coin: store 0x1::Diem::Diem<0x1::XUS::XUS> {
+                value: 200
+            }
+        }
+      New:
+        key 0x1::DiemAccount::Balance<0x1::XUS::XUS> {
+            coin: store 0x1::Diem::Diem<0x1::XUS::XUS> {
+                value: 100
+            }
+        }
     Changed type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0, 0, 24, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 2, 0, 0, 0, 0, 0, 0, 0, 24, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
+      Previous:
+        key 0x1::DiemAccount::DiemAccount {
+            authentication_key: 000000000000000000000000000000000000000000000000000000000000000a
+            withdraw_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::WithdrawCapability> {
+                vec: [
+                    store 0x1::DiemAccount::WithdrawCapability {
+                        account_address: a
+                    },
+                ]
+            }
+            key_rotation_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::KeyRotationCapability> {
+                vec: [
+                    store 0x1::DiemAccount::KeyRotationCapability {
+                        account_address: a
+                    },
+                ]
+            }
+            received_events: store 0x1::Event::EventHandle<0x1::DiemAccount::ReceivedPaymentEvent> {
+                counter: 1
+                guid: 02000000000000000000000000000000000000000000000a
+            }
+            sent_events: store 0x1::Event::EventHandle<0x1::DiemAccount::SentPaymentEvent> {
+                counter: 1
+                guid: 03000000000000000000000000000000000000000000000a
+            }
+            sequence_number: 0
+        }
+      New:
+        key 0x1::DiemAccount::DiemAccount {
+            authentication_key: 000000000000000000000000000000000000000000000000000000000000000a
+            withdraw_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::WithdrawCapability> {
+                vec: [
+                    store 0x1::DiemAccount::WithdrawCapability {
+                        account_address: a
+                    },
+                ]
+            }
+            key_rotation_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::KeyRotationCapability> {
+                vec: [
+                    store 0x1::DiemAccount::KeyRotationCapability {
+                        account_address: a
+                    },
+                ]
+            }
+            received_events: store 0x1::Event::EventHandle<0x1::DiemAccount::ReceivedPaymentEvent> {
+                counter: 1
+                guid: 02000000000000000000000000000000000000000000000a
+            }
+            sent_events: store 0x1::Event::EventHandle<0x1::DiemAccount::SentPaymentEvent> {
+                counter: 2
+                guid: 03000000000000000000000000000000000000000000000a
+            }
+            sequence_number: 0
+        }
     Changed type 0x1::VASP::ParentVASP: [1, 0, 0, 0, 0, 0, 0, 0] (wrote 42 bytes)
+      Previous:
+        key 0x1::VASP::ParentVASP {
+            num_children: 0
+        }
+      New:
+        key 0x1::VASP::ParentVASP {
+            num_children: 1
+        }
   Changed 6 resource(s) under address 000000000000000000000000000000AA:
     Added type 0x1::AccountFreezing::FreezingBit: [0] (wrote 47 bytes)
+      key 0x1::AccountFreezing::FreezingBit {
+          is_frozen: false
+      }
     Added type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [100, 0, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+      key 0x1::DiemAccount::Balance<0x1::XUS::XUS> {
+          coin: store 0x1::Diem::Diem<0x1::XUS::XUS> {
+              value: 100
+          }
+      }
     Added type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170, 1, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170, 0, 0, 0, 0, 0, 0, 0, 0, 24, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
+      key 0x1::DiemAccount::DiemAccount {
+          authentication_key: 00000000000000000000000000000000000000000000000000000000000000aa
+          withdraw_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::WithdrawCapability> {
+              vec: [
+                  store 0x1::DiemAccount::WithdrawCapability {
+                      account_address: aa
+                  },
+              ]
+          }
+          key_rotation_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::KeyRotationCapability> {
+              vec: [
+                  store 0x1::DiemAccount::KeyRotationCapability {
+                      account_address: aa
+                  },
+              ]
+          }
+          received_events: store 0x1::Event::EventHandle<0x1::DiemAccount::ReceivedPaymentEvent> {
+              counter: 1
+              guid: 0000000000000000000000000000000000000000000000aa
+          }
+          sent_events: store 0x1::Event::EventHandle<0x1::DiemAccount::SentPaymentEvent> {
+              counter: 0
+              guid: 0100000000000000000000000000000000000000000000aa
+          }
+          sequence_number: 0
+      }
     Added type 0x1::Event::EventHandleGenerator: [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170] (wrote 69 bytes)
+      key 0x1::Event::EventHandleGenerator {
+          counter: 2
+          addr: aa
+      }
     Added type 0x1::Roles::RoleId: [6, 0, 0, 0, 0, 0, 0, 0] (wrote 39 bytes)
+      key 0x1::Roles::RoleId {
+          role_id: 6
+      }
     Added type 0x1::VASP::ChildVASP: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10] (wrote 49 bytes)
+      key 0x1::VASP::ChildVASP {
+          parent_vasp_addr: a
+      }
   Changed 1 resource(s) under address 0000000000000000000000000A550C18:
     Changed type 0x1::DiemAccount::AccountOperationsCapability: [0, 6, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 92 bytes)
+      Previous:
+        key 0x1::DiemAccount::AccountOperationsCapability {
+            limits_cap: store 0x1::AccountLimits::AccountLimitMutationCapability {
+                dummy_field: false
+            }
+            creation_events: store 0x1::Event::EventHandle<0x1::DiemAccount::CreateAccountEvent> {
+                counter: 5
+                guid: 00000000000000000000000000000000000000000a550c18
+            }
+        }
+      New:
+        key 0x1::DiemAccount::AccountOperationsCapability {
+            limits_cap: store 0x1::AccountLimits::AccountLimitMutationCapability {
+                dummy_field: false
+            }
+            creation_events: store 0x1::Event::EventHandle<0x1::DiemAccount::CreateAccountEvent> {
+                counter: 6
+                guid: 00000000000000000000000000000000000000000a550c18
+            }
+        }
 Wrote 848 bytes of resource ID's and data
 Command `sandbox run scripts/create_child_vasp_account.move --mode diem --type-args 0x1::XUS::XUS --signers 0xB --args 0xBB x"00000000000000000000000000000000" false 0 -v`:
 Compiling transaction script...
@@ -166,15 +1283,87 @@ Emitted [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187, 6, 0, 0, 0, 0, 0, 0, 
 Changed resource(s) under 3 address(es):
   Changed 1 resource(s) under address 0000000000000000000000000000000B:
     Changed type 0x1::VASP::ParentVASP: [1, 0, 0, 0, 0, 0, 0, 0] (wrote 42 bytes)
+      Previous:
+        key 0x1::VASP::ParentVASP {
+            num_children: 0
+        }
+      New:
+        key 0x1::VASP::ParentVASP {
+            num_children: 1
+        }
   Changed 6 resource(s) under address 000000000000000000000000000000BB:
     Added type 0x1::AccountFreezing::FreezingBit: [0] (wrote 47 bytes)
+      key 0x1::AccountFreezing::FreezingBit {
+          is_frozen: false
+      }
     Added type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [0, 0, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+      key 0x1::DiemAccount::Balance<0x1::XUS::XUS> {
+          coin: store 0x1::Diem::Diem<0x1::XUS::XUS> {
+              value: 0
+          }
+      }
     Added type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187, 0, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187, 0, 0, 0, 0, 0, 0, 0, 0, 24, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
+      key 0x1::DiemAccount::DiemAccount {
+          authentication_key: 00000000000000000000000000000000000000000000000000000000000000bb
+          withdraw_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::WithdrawCapability> {
+              vec: [
+                  store 0x1::DiemAccount::WithdrawCapability {
+                      account_address: bb
+                  },
+              ]
+          }
+          key_rotation_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::KeyRotationCapability> {
+              vec: [
+                  store 0x1::DiemAccount::KeyRotationCapability {
+                      account_address: bb
+                  },
+              ]
+          }
+          received_events: store 0x1::Event::EventHandle<0x1::DiemAccount::ReceivedPaymentEvent> {
+              counter: 0
+              guid: 0000000000000000000000000000000000000000000000bb
+          }
+          sent_events: store 0x1::Event::EventHandle<0x1::DiemAccount::SentPaymentEvent> {
+              counter: 0
+              guid: 0100000000000000000000000000000000000000000000bb
+          }
+          sequence_number: 0
+      }
     Added type 0x1::Event::EventHandleGenerator: [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187] (wrote 69 bytes)
+      key 0x1::Event::EventHandleGenerator {
+          counter: 2
+          addr: bb
+      }
     Added type 0x1::Roles::RoleId: [6, 0, 0, 0, 0, 0, 0, 0] (wrote 39 bytes)
+      key 0x1::Roles::RoleId {
+          role_id: 6
+      }
     Added type 0x1::VASP::ChildVASP: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11] (wrote 49 bytes)
+      key 0x1::VASP::ChildVASP {
+          parent_vasp_addr: b
+      }
   Changed 1 resource(s) under address 0000000000000000000000000A550C18:
     Changed type 0x1::DiemAccount::AccountOperationsCapability: [0, 7, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24] (wrote 92 bytes)
+      Previous:
+        key 0x1::DiemAccount::AccountOperationsCapability {
+            limits_cap: store 0x1::AccountLimits::AccountLimitMutationCapability {
+                dummy_field: false
+            }
+            creation_events: store 0x1::Event::EventHandle<0x1::DiemAccount::CreateAccountEvent> {
+                counter: 6
+                guid: 00000000000000000000000000000000000000000a550c18
+            }
+        }
+      New:
+        key 0x1::DiemAccount::AccountOperationsCapability {
+            limits_cap: store 0x1::AccountLimits::AccountLimitMutationCapability {
+                dummy_field: false
+            }
+            creation_events: store 0x1::Event::EventHandle<0x1::DiemAccount::CreateAccountEvent> {
+                counter: 7
+                guid: 00000000000000000000000000000000000000000a550c18
+            }
+        }
 Wrote 593 bytes of resource ID's and data
 Command `sandbox run scripts/peer_to_peer_with_metadata.move --mode diem --type-args 0x1::XUS::XUS --signers 0xAA --args 0xBB 100 x"" x"" -v`:
 Compiling transaction script...
@@ -184,9 +1373,141 @@ Emitted [100, 0, 0, 0, 0, 0, 0, 0, 3, 88, 85, 83, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
 Changed resource(s) under 2 address(es):
   Changed 2 resource(s) under address 000000000000000000000000000000AA:
     Changed type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [0, 0, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+      Previous:
+        key 0x1::DiemAccount::Balance<0x1::XUS::XUS> {
+            coin: store 0x1::Diem::Diem<0x1::XUS::XUS> {
+                value: 100
+            }
+        }
+      New:
+        key 0x1::DiemAccount::Balance<0x1::XUS::XUS> {
+            coin: store 0x1::Diem::Diem<0x1::XUS::XUS> {
+                value: 0
+            }
+        }
     Changed type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170, 1, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170, 1, 0, 0, 0, 0, 0, 0, 0, 24, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 170, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
+      Previous:
+        key 0x1::DiemAccount::DiemAccount {
+            authentication_key: 00000000000000000000000000000000000000000000000000000000000000aa
+            withdraw_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::WithdrawCapability> {
+                vec: [
+                    store 0x1::DiemAccount::WithdrawCapability {
+                        account_address: aa
+                    },
+                ]
+            }
+            key_rotation_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::KeyRotationCapability> {
+                vec: [
+                    store 0x1::DiemAccount::KeyRotationCapability {
+                        account_address: aa
+                    },
+                ]
+            }
+            received_events: store 0x1::Event::EventHandle<0x1::DiemAccount::ReceivedPaymentEvent> {
+                counter: 1
+                guid: 0000000000000000000000000000000000000000000000aa
+            }
+            sent_events: store 0x1::Event::EventHandle<0x1::DiemAccount::SentPaymentEvent> {
+                counter: 0
+                guid: 0100000000000000000000000000000000000000000000aa
+            }
+            sequence_number: 0
+        }
+      New:
+        key 0x1::DiemAccount::DiemAccount {
+            authentication_key: 00000000000000000000000000000000000000000000000000000000000000aa
+            withdraw_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::WithdrawCapability> {
+                vec: [
+                    store 0x1::DiemAccount::WithdrawCapability {
+                        account_address: aa
+                    },
+                ]
+            }
+            key_rotation_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::KeyRotationCapability> {
+                vec: [
+                    store 0x1::DiemAccount::KeyRotationCapability {
+                        account_address: aa
+                    },
+                ]
+            }
+            received_events: store 0x1::Event::EventHandle<0x1::DiemAccount::ReceivedPaymentEvent> {
+                counter: 1
+                guid: 0000000000000000000000000000000000000000000000aa
+            }
+            sent_events: store 0x1::Event::EventHandle<0x1::DiemAccount::SentPaymentEvent> {
+                counter: 1
+                guid: 0100000000000000000000000000000000000000000000aa
+            }
+            sequence_number: 0
+        }
   Changed 2 resource(s) under address 000000000000000000000000000000BB:
     Changed type 0x1::DiemAccount::Balance<0x1::XUS::XUS>: [100, 0, 0, 0, 0, 0, 0, 0] (wrote 72 bytes)
+      Previous:
+        key 0x1::DiemAccount::Balance<0x1::XUS::XUS> {
+            coin: store 0x1::Diem::Diem<0x1::XUS::XUS> {
+                value: 0
+            }
+        }
+      New:
+        key 0x1::DiemAccount::Balance<0x1::XUS::XUS> {
+            coin: store 0x1::Diem::Diem<0x1::XUS::XUS> {
+                value: 100
+            }
+        }
     Changed type 0x1::DiemAccount::DiemAccount: [32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187, 1, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187, 0, 0, 0, 0, 0, 0, 0, 0, 24, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 187, 0, 0, 0, 0, 0, 0, 0, 0] (wrote 183 bytes)
+      Previous:
+        key 0x1::DiemAccount::DiemAccount {
+            authentication_key: 00000000000000000000000000000000000000000000000000000000000000bb
+            withdraw_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::WithdrawCapability> {
+                vec: [
+                    store 0x1::DiemAccount::WithdrawCapability {
+                        account_address: bb
+                    },
+                ]
+            }
+            key_rotation_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::KeyRotationCapability> {
+                vec: [
+                    store 0x1::DiemAccount::KeyRotationCapability {
+                        account_address: bb
+                    },
+                ]
+            }
+            received_events: store 0x1::Event::EventHandle<0x1::DiemAccount::ReceivedPaymentEvent> {
+                counter: 0
+                guid: 0000000000000000000000000000000000000000000000bb
+            }
+            sent_events: store 0x1::Event::EventHandle<0x1::DiemAccount::SentPaymentEvent> {
+                counter: 0
+                guid: 0100000000000000000000000000000000000000000000bb
+            }
+            sequence_number: 0
+        }
+      New:
+        key 0x1::DiemAccount::DiemAccount {
+            authentication_key: 00000000000000000000000000000000000000000000000000000000000000bb
+            withdraw_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::WithdrawCapability> {
+                vec: [
+                    store 0x1::DiemAccount::WithdrawCapability {
+                        account_address: bb
+                    },
+                ]
+            }
+            key_rotation_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::KeyRotationCapability> {
+                vec: [
+                    store 0x1::DiemAccount::KeyRotationCapability {
+                        account_address: bb
+                    },
+                ]
+            }
+            received_events: store 0x1::Event::EventHandle<0x1::DiemAccount::ReceivedPaymentEvent> {
+                counter: 1
+                guid: 0000000000000000000000000000000000000000000000bb
+            }
+            sent_events: store 0x1::Event::EventHandle<0x1::DiemAccount::SentPaymentEvent> {
+                counter: 0
+                guid: 0100000000000000000000000000000000000000000000bb
+            }
+            sequence_number: 0
+        }
 Wrote 510 bytes of resource ID's and data
 Command `sandbox doctor`:

--- a/language/tools/move-cli/tests/testsuite/events_emit_view/args.exp
+++ b/language/tools/move-cli/tests/testsuite/events_emit_view/args.exp
@@ -10,7 +10,17 @@ Emitted [5, 0, 0, 0, 0, 0, 0, 0] as the 0th event to stream [0, 0, 0, 0, 0, 0, 0
 Changed resource(s) under 1 address(es):
   Changed 2 resource(s) under address 0000000000000000000000000000000A:
     Added type 0x1::Event::EventHandleGenerator: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10] (wrote 69 bytes)
+      key 0x1::Event::EventHandleGenerator {
+          counter: 1
+          addr: a
+      }
     Added type 0x2::Events::Handle: [1, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10] (wrote 65 bytes)
+      key 0x2::Events::Handle {
+          h: store 0x1::Event::EventHandle<0x2::Events::AnEvent> {
+              counter: 1
+              guid: 00000000000000000000000000000000000000000000000a
+          }
+      }
 Wrote 134 bytes of resource ID's and data
 Command `sandbox view storage/0x0000000000000000000000000000000A/events/0.bcs`:
 copy drop store 0x2::Events::AnEvent {
@@ -23,6 +33,20 @@ Emitted [6, 0, 0, 0, 0, 0, 0, 0] as the 1th event to stream [0, 0, 0, 0, 0, 0, 0
 Changed resource(s) under 1 address(es):
   Changed 1 resource(s) under address 0000000000000000000000000000000A:
     Changed type 0x2::Events::Handle: [2, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10] (wrote 65 bytes)
+      Previous:
+        key 0x2::Events::Handle {
+            h: store 0x1::Event::EventHandle<0x2::Events::AnEvent> {
+                counter: 1
+                guid: 00000000000000000000000000000000000000000000000a
+            }
+        }
+      New:
+        key 0x2::Events::Handle {
+            h: store 0x1::Event::EventHandle<0x2::Events::AnEvent> {
+                counter: 2
+                guid: 00000000000000000000000000000000000000000000000a
+            }
+        }
 Wrote 65 bytes of resource ID's and data
 Command `sandbox view storage/0x0000000000000000000000000000000A/events/0.bcs`:
 copy drop store 0x2::Events::AnEvent {


### PR DESCRIPTION
## Motivation

This is in response to issue #8515. The goal is to print resource changes on execution Move sandbox commands with the verbose flag active. This removes a step where resource changes must be manually inspected with the `sandbox view` command. 

See below of example output for the three possible resource changes (`+` indicates diff, not part of actual output).

Addition now shows the resource that was added:
```diff
 Changed resource(s) under 1 address(es):
   Changed 1 resource(s) under address 0000000000000000000000000000000F:
     Added type 0x2::Test::Resource: [10, 0, 0, 0, 0, 0, 0, 0] (wrote 40 bytes)
+      key 0x2::Test::Resource {
+           i: 10
+      }
```

Modification now shows the previous and new states of the resource:
```diff
 Changed resource(s) under 1 address(es):
   Changed 1 resource(s) under address 0000000000000000000000000000000F:
     Changed type 0x2::Test::Resource: [20, 0, 0, 0, 0, 0, 0, 0] (wrote 40 bytes)
+      Previous:
+        key 0x2::Test::Resource {
+            i: 10
+        }
+      New:
+        key 0x2::Test::Resource {
+            i: 20
+        }
```

Deletion now shows the resource that was removed:
```diff
 Changed resource(s) under 1 address(es):
   Changed 1 resource(s) under address 0000000000000000000000000000000F:
     Deleted type 0x2::Test::Resource (wrote 32 bytes)
+      key 0x2::Test::Resource {
+          i: 10
+      }
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

This is covered via `cargo test`. To account for the output changes, the `diem_smoke` and `events_emit_view` tests' expected output have been updated.

## Related PRs

N/A

## If targeting a release branch, please fill the below out as well

N/A
