### PR TITLE
[x] Improve code coverage generation (turn off sccache in code coverage by default, better warnings/logging, refactor)

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -33,6 +33,7 @@ jobs:
       test-website-build: ${{ steps.website-changes.outputs.changes-found }}
       test-non-rust-lint: ${{ steps.non-rust-lint-changes.outputs.changes-found }}
       test-docker-compose: ${{ steps.docker-compose-changes.outputs.changes-found }}
+      test-test-coverage: ${{ steps.test-coverage.outputs.changes-found }}
     steps:
       - uses: actions/checkout@v2.3.4
         with:
@@ -121,6 +122,11 @@ jobs:
         uses: diem/actions/matches@78f868bd1170a959f0a9864e33df725690b45b9a
         with:
           pattern: "^documentation|^developers.diem.com"
+      - id: test-coverage
+        name: check if we should see if code coverage still works.
+        uses: diem/actions/matches@78f868bd1170a959f0a9864e33df725690b45b9a
+        with:
+          pattern: '^rust.toolchain\|^x.toml\|^devtools\|^.github\'
 
   dev-setup-sh-test:
     runs-on: ubuntu-latest-xl
@@ -789,6 +795,36 @@ jobs:
           cd /opt/git/diem/crypto/crypto
           cargo test --features='u64' --no-default-features
           cargo test --features='u32' --no-default-features
+      - uses: ./.github/actions/build-teardown
+
+  coverage-unit-test:
+    runs-on: ubuntu-latest-xl
+    timeout-minutes: 10
+    needs: prepare
+    if: ${{ needs.prepare.outputs.test-test-coverage == 'true' }}
+    container:
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      volumes:
+        - "/home/runner/work/diem/diem:/opt/git/diem"
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: ./.github/actions/build-setup
+      - uses: actions/cache@v2.1.6
+        with:
+          path: "/opt/cargo/git\n/opt/cargo/registry\n/opt/cargo/.package-cache"
+          key: crates-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: "crates-${{ runner.os }}"
+      - name: run coverage tests and verify coverage is calculated.
+        run: |
+          cargo xtest --html-cov-dir=/tmp/results/ -p diem-logger
+          export line_coverage=$( cat /tmp/results/index.html | grep '<abbr' | head -1 | sed 's/<[^>]*>//g' |  sed 's/\..*//g' | sed 's/[[:blank:]]//g' )
+          echo Line Coverage: $line_coverage
+          if (( line_coverage < 80 )); then
+            echo Coverage appears to be broken, diem/logger should report more than 80% line coverage.
+            exit 1;
+          fi
       - uses: ./.github/actions/build-teardown
 
   helm-test:

--- a/devtools/x/src/build.rs
+++ b/devtools/x/src/build.rs
@@ -47,6 +47,7 @@ pub fn run(args: Box<Args>, xctx: XContext) -> Result<()> {
         direct_args: direct_args.as_slice(),
         args: &[],
         env: &[],
+        skip_sccache: false,
     };
 
     let packages = args.package_args.to_selected_packages(&xctx)?;

--- a/devtools/x/src/context.rs
+++ b/devtools/x/src/context.rs
@@ -30,7 +30,11 @@ impl XContext {
         let XConfig { core, config } = x_config;
         Ok(Self {
             core: XCoreContext::new(project_root(), current_dir, core)?,
-            installer: Installer::new(config.cargo_config().clone(), config.tools()),
+            installer: Installer::new(
+                config.cargo_config().clone(),
+                config.tools(),
+                vec!["llvm-tools-preview".to_string()],
+            ),
             config,
         })
     }

--- a/devtools/x/src/fmt.rs
+++ b/devtools/x/src/fmt.rs
@@ -32,7 +32,7 @@ pub fn run(args: Args, xctx: XContext) -> Result<()> {
 
     pass_through_args.extend(args.args);
 
-    let mut cmd = Cargo::new(xctx.config().cargo_config(), "fmt", false);
+    let mut cmd = Cargo::new(xctx.config().cargo_config(), "fmt", true);
 
     if args.workspace {
         // cargo fmt doesn't have a --workspace flag, instead it uses the

--- a/devtools/x/src/generate_workspace_hack.rs
+++ b/devtools/x/src/generate_workspace_hack.rs
@@ -106,7 +106,7 @@ pub fn run(args: Args, xctx: XContext) -> Result<()> {
     // Update Cargo.lock if the file on disk changed.
     if update_cargo_lock {
         info!("Workspace hack contents changed, updating Cargo.lock");
-        let mut cmd = Cargo::new(xctx.config().cargo_config(), "update", false);
+        let mut cmd = Cargo::new(xctx.config().cargo_config(), "update", true);
         cmd.args(&["--package", hakari_package.name()]);
         cmd.run()?;
     }

--- a/devtools/x/src/nextest.rs
+++ b/devtools/x/src/nextest.rs
@@ -68,6 +68,7 @@ pub fn run(args: Args, xctx: XContext) -> Result<()> {
         // Don't pass in the args (test name) -- they're for use by the test runner.
         args: &[],
         env: &[],
+        skip_sccache: false,
     };
 
     let messages = cmd.run_capture_messages(&packages)?;

--- a/devtools/x/src/test.rs
+++ b/devtools/x/src/test.rs
@@ -60,30 +60,55 @@ pub fn run(mut args: Args, xctx: XContext) -> Result<()> {
 
     let generate_coverage = args.html_cov_dir.is_some() || args.html_lcov_dir.is_some();
 
-    let env_vars: &[(&str, Option<&str>)] = if generate_coverage {
-        if !xctx.installer().install_if_needed("grcov") {
+    let llvm_profile_key = "LLVM_PROFILE_FILE";
+    let llvm_profile_path: &str = "target/debug/xtest-%p-%m.profraw";
+    let llvm_profile_path_ignored = "target/debug/ignored-%p-%m.profraw";
+
+    let env_vars = if generate_coverage {
+        if !xctx
+            .installer()
+            .install_via_rustup_if_needed("llvm-tools-preview")
+        {
+            return Err(anyhow!("Could not install llvm-tools-preview"));
+        }
+        if !xctx.installer().install_via_cargo_if_needed("grcov") {
             return Err(anyhow!("Could not install grcov"));
         }
-        info!("Running \"cargo clean\" before collecting coverage");
-        let mut clean_cmd = Command::new("cargo");
-        clean_cmd.arg("clean");
-        clean_cmd.output()?;
-        &[
-            // A way to use -Z (unstable) flags with the stable compiler. See below.
+
+        let shared_envionment = vec![
             ("RUSTC_BOOTSTRAP", Some("1")),
-            // Recommend setting for grcov, avoids using the cargo cache.
-            ("CARGO_INCREMENTAL", Some("0")),
-            // language/ir-testsuite's tests will stack overflow without this setting.
-            ("RUST_MIN_STACK", Some("8388608")),
             // Recommend flags for use with grcov, with these flags removed: -Copt-level=0, -Clink-dead-code.
             // for more info see:  https://github.com/mozilla/grcov#example-how-to-generate-gcda-fiels-for-a-rust-project
-            (
-                "RUSTFLAGS",
-                Some("-Zprofile -Ccodegen-units=1 -Coverflow-checks=off"),
-            ),
-        ]
+            ("RUSTFLAGS", Some("-Zinstrument-coverage")),
+            ("RUST_MIN_STACK", Some("8388608")),
+        ];
+
+        let mut build_env_vars = shared_envionment.clone();
+        build_env_vars.push((llvm_profile_key, Some(llvm_profile_path_ignored)));
+
+        info!("Performing a seperate \"cargo build\" before running tests and collecting coverage");
+
+        let mut direct_args = Vec::new();
+        args.build_args.add_args(&mut direct_args);
+        //direct_args.push(OsString::from("--no-run"));
+        let build = CargoCommand::Build {
+            cargo_config: xctx.config().cargo_config(),
+            direct_args: direct_args.as_slice(),
+            args: &args.args,
+            env: build_env_vars.as_slice(),
+            skip_sccache: true,
+        };
+        let build_result = build.run_on_packages(&packages);
+
+        if !args.no_fail_fast && build_result.is_err() {
+            return build_result;
+        }
+
+        let mut output = shared_envionment.clone();
+        output.push((llvm_profile_key, Some(llvm_profile_path)));
+        output
     } else {
-        &[]
+        vec![]
     };
 
     let mut direct_args = Vec::new();
@@ -103,6 +128,7 @@ pub fn run(mut args: Args, xctx: XContext) -> Result<()> {
         direct_args: direct_args.as_slice(),
         args: &args.args,
         env: &env_vars,
+        skip_sccache: generate_coverage,
     };
 
     let cmd_result = cmd.run_on_packages(&packages);
@@ -115,13 +141,13 @@ pub fn run(mut args: Args, xctx: XContext) -> Result<()> {
         create_dir_all(&html_cov_dir)?;
         let html_cov_path = &html_cov_dir.canonicalize()?;
         info!("created {}", &html_cov_path.to_string_lossy());
-        exec_grcov(&html_cov_path)?;
+        exec_grcov(&html_cov_path, llvm_profile_path)?;
     }
     if let Some(html_lcov_dir) = &args.html_lcov_dir {
         create_dir_all(&html_lcov_dir)?;
         let html_lcov_path = &html_lcov_dir.canonicalize()?;
         info!("created {}", &html_lcov_path.to_string_lossy());
-        exec_lcov(&html_lcov_path)?;
+        exec_lcov(&html_lcov_path, llvm_profile_path)?;
         exec_lcov_genhtml(&html_lcov_path)?;
     }
     cmd_result
@@ -154,7 +180,7 @@ fn exec_lcov_genhtml(html_lcov_path: &Path) -> Result<()> {
     }
 }
 
-fn exec_lcov(html_lcov_path: &Path) -> Result<()> {
+fn exec_lcov(html_lcov_path: &Path, llvm_profile_path: &str) -> Result<()> {
     let debug_dir = project_root().join("target/debug/");
     let mut lcov_file_path = PathBuf::new();
     lcov_file_path.push(html_lcov_path);
@@ -163,6 +189,8 @@ fn exec_lcov(html_lcov_path: &Path) -> Result<()> {
     lcov_file
         .current_dir(project_root())
         //output file from coverage: gcda files
+        .arg(debug_dir.as_os_str())
+        .arg("--binary-path")
         .arg(debug_dir.as_os_str())
         //source code location
         .arg("-s")
@@ -184,6 +212,8 @@ fn exec_lcov(html_lcov_path: &Path) -> Result<()> {
         .arg(lcov_file_path);
     info!("Converting lcov.info file to html");
     info!("{:?}", lcov_file);
+    lcov_file.env("RUSTFLAGS", "-Zinstrument-coverage");
+    lcov_file.env("LLVM_PROFILE_FILE", llvm_profile_path);
     lcov_file.stdout(Stdio::inherit()).stderr(Stdio::inherit());
     if let Some(err) = lcov_file.output().err() {
         Err(Error::new(err).context("Failed to generate lcov.info with grcov"))
@@ -192,12 +222,15 @@ fn exec_lcov(html_lcov_path: &Path) -> Result<()> {
     }
 }
 
-fn exec_grcov(html_cov_path: &Path) -> Result<()> {
+fn exec_grcov(html_cov_path: &Path, llvm_profile_path: &str) -> Result<()> {
     let debug_dir = project_root().join("target/debug/");
     let mut grcov_html = Command::new("grcov");
+    //grcov . --binary-path ./target/debug/ -s . -t html --branch --ignore-not-existing --ignore "/*" -o $HOME/output/
     grcov_html
         .current_dir(project_root())
         //output file from coverage: gcda files
+        .arg(project_root().as_os_str())
+        .arg("--binary-path")
         .arg(debug_dir.as_os_str())
         //source code location
         .arg("-s")
@@ -205,7 +238,6 @@ fn exec_grcov(html_cov_path: &Path) -> Result<()> {
         //html output
         .arg("-t")
         .arg("html")
-        .arg("--llvm")
         .arg("--branch")
         .arg("--ignore")
         .arg("/*")
@@ -218,6 +250,8 @@ fn exec_grcov(html_cov_path: &Path) -> Result<()> {
         .arg(html_cov_path);
     info!("Build grcov Html Coverage Report");
     info!("{:?}", grcov_html);
+    grcov_html.env("LLVM_PROFILE_FILE", llvm_profile_path);
+    grcov_html.env("RUSTFLAGS", "-Zinstrument-coverage");
     grcov_html.stdout(Stdio::inherit()).stderr(Stdio::inherit());
     if let Some(err) = grcov_html.output().err() {
         Err(Error::new(err).context("Failed to generate html output with grcov"))

--- a/devtools/x/src/utils.rs
+++ b/devtools/x/src/utils.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{config::CargoConfig, installer::install_if_needed, Result};
+use crate::{config::CargoConfig, installer::install_cargo_component_if_needed, Result};
 use anyhow::anyhow;
 use log::{info, warn};
 use std::{
@@ -95,7 +95,11 @@ pub fn apply_sccache_if_possible(
 
     if sccache_should_run(cargo_config, true) {
         if let Some(sccache_config) = &cargo_config.sccache {
-            if !install_if_needed(cargo_config, "sccache", &sccache_config.installer) {
+            if !install_cargo_component_if_needed(
+                cargo_config,
+                "sccache",
+                &sccache_config.installer,
+            ) {
                 return Err(anyhow!("Failed to install sccache, bailing"));
             }
             stop_sccache_server();

--- a/x.toml
+++ b/x.toml
@@ -1,5 +1,5 @@
 [grcov.installer]
-version = "0.6.1"
+version = "0.8.0"
 
 [system-tests]
 smoke-test = { path = "smoke-test" }


### PR DESCRIPTION
## Motivation

Fix code coverage since the last rust update broke it.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

Run by pushing code to gha-test-1 branch, results:
Runs:

https://github.com/diem/diem/runs/2814501836?check_suite_focus=true

Results:
https://ci-artifacts.diem.com/coverage/unit-coverage/2021-06-13-7ba68db8/index.html


## Related PRs

None

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
