### PR TITLE
[move-prover] support old(..) in inlined spec blocks

### DIFF
--- a/language/move-model/src/ast.rs
+++ b/language/move-model/src/ast.rs
@@ -82,7 +82,10 @@ impl ConditionKind {
     /// Returns true of this condition allows the `old(..)` expression.
     pub fn allows_old(&self) -> bool {
         use ConditionKind::*;
-        matches!(self, Emits | Ensures | InvariantUpdate | LetPost(..))
+        matches!(
+            self,
+            Assert | Assume | Emits | Ensures | InvariantUpdate | LetPost(..)
+        )
     }
 
     /// Returns true if this condition is allowed on a public function declaration.

--- a/language/move-model/tests/sources/inline_spec_err.exp
+++ b/language/move-model/tests/sources/inline_spec_err.exp
@@ -1,0 +1,41 @@
+error: invalid old(..) expression in inline spec block
+
+   ┌── tests/sources/inline_spec_err.move:9:7 ───
+   │
+ 9 │       assert old(a) == y;
+   │       ^^^^^^^^^^^^^^^^^^^
+   ·
+ 9 │       assert old(a) == y;
+   │       ------------------- only a function parameter is allowed in old(..) expressions in inline spec block
+   ·
+ 9 │       assert old(a) == y;
+   │                  - this expression is not a function parameter
+   │
+
+error: invalid old(..) expression in inline spec block
+
+    ┌── tests/sources/inline_spec_err.move:10:7 ───
+    │
+ 10 │       assert old(b) == 0;
+    │       ^^^^^^^^^^^^^^^^^^^
+    ·
+ 10 │       assert old(b) == 0;
+    │       ------------------- only a function parameter is allowed in old(..) expressions in inline spec block
+    ·
+ 10 │       assert old(b) == 0;
+    │                  - this expression is not a function parameter
+    │
+
+error: invalid old(..) expression in inline spec block
+
+    ┌── tests/sources/inline_spec_err.move:11:7 ───
+    │
+ 11 │       assert old(x != y);
+    │       ^^^^^^^^^^^^^^^^^^^
+    ·
+ 11 │       assert old(x != y);
+    │       ------------------- only a function parameter is allowed in old(..) expressions in inline spec block
+    ·
+ 11 │       assert old(x != y);
+    │                  ------ this expression is not a function parameter
+    │

--- a/language/move-model/tests/sources/inline_spec_err.move
+++ b/language/move-model/tests/sources/inline_spec_err.move
@@ -1,0 +1,14 @@
+module 0x42::M {
+
+  fun invalid_old_exp(x: &mut u64, y: u64) {
+    let a = x;
+    let b = &mut y;
+    *a = *b;
+    *b = 0;
+    spec {
+      assert old(a) == y;
+      assert old(b) == 0;
+      assert old(x != y);
+    }
+  }
+}

--- a/language/move-prover/bytecode/src/spec_instrumentation.rs
+++ b/language/move-prover/bytecode/src/spec_instrumentation.rs
@@ -220,6 +220,17 @@ impl<'a> Instrumenter<'a> {
         fun_env: &FunctionEnv<'a>,
         data: FunctionData,
     ) -> FunctionData {
+        // Pre-collect properties in the original function data
+        let props: Vec<_> = data
+            .code
+            .iter()
+            .filter_map(|bc| match bc {
+                Bytecode::Prop(id, PropKind::Assume, exp)
+                | Bytecode::Prop(id, PropKind::Assert, exp) => Some((*id, exp.clone())),
+                _ => None,
+            })
+            .collect();
+
         let mut builder = FunctionDataBuilder::new(fun_env, data);
 
         // Create label and locals for unified return exit point. We translate each `Ret(t..)`
@@ -253,6 +264,18 @@ impl<'a> Instrumenter<'a> {
             &ret_locals,
         );
 
+        // Translate inlined properties. This deals with elimination of `old(..)` expressions in
+        // inlined spec blocks
+        let inlined_props: BTreeMap<_, _> = props
+            .into_iter()
+            .map(|(id, prop)| {
+                (
+                    id,
+                    SpecTranslator::translate_inline_property(&mut builder, &prop),
+                )
+            })
+            .collect();
+
         // Create and run the instrumenter.
         let mut instrumenter = Instrumenter {
             options,
@@ -264,7 +287,7 @@ impl<'a> Instrumenter<'a> {
             abort_label,
             can_abort: false,
         };
-        instrumenter.instrument(&spec);
+        instrumenter.instrument(&spec, &inlined_props);
 
         // Run copy propagation (reaching definitions) and then assignment
         // elimination (live vars). This cleans up some redundancy created by
@@ -280,7 +303,11 @@ impl<'a> Instrumenter<'a> {
         self.builder.data.variant.is_verified()
     }
 
-    fn instrument(&mut self, spec: &TranslatedSpec) {
+    fn instrument(
+        &mut self,
+        spec: &TranslatedSpec,
+        inlined_props: &BTreeMap<AttrId, (TranslatedSpec, Exp)>,
+    ) {
         use Bytecode::*;
         use PropKind::*;
 
@@ -351,23 +378,27 @@ impl<'a> Instrumenter<'a> {
 
             // For the verification variant, we generate post-conditions. Inject any state
             // save instructions needed for this.
-            for (mem, label) in &spec.saved_memory {
-                let mem = mem.clone();
-                self.builder
-                    .emit_with(|attr_id| SaveMem(attr_id, *label, mem));
+            for translated_spec in
+                std::iter::once(spec).chain(inlined_props.values().map(|(s, _)| s))
+            {
+                for (mem, label) in &translated_spec.saved_memory {
+                    let mem = mem.clone();
+                    self.builder
+                        .emit_with(|attr_id| SaveMem(attr_id, *label, mem));
+                }
+                for (spec_var, label) in &translated_spec.saved_spec_vars {
+                    let spec_var = spec_var.clone();
+                    self.builder
+                        .emit_with(|attr_id| SaveSpecVar(attr_id, *label, spec_var));
+                }
+                let saved_params = translated_spec.saved_params.clone();
+                self.emit_save_for_old(&saved_params);
             }
-            for (spec_var, label) in &spec.saved_spec_vars {
-                let spec_var = spec_var.clone();
-                self.builder
-                    .emit_with(|attr_id| SaveSpecVar(attr_id, *label, spec_var));
-            }
-            let saved_params = spec.saved_params.clone();
-            self.emit_save_for_old(&saved_params);
         }
 
         // Instrument and generate new code
         for bc in old_code {
-            self.instrument_bytecode(spec, bc);
+            self.instrument_bytecode(spec, inlined_props, bc);
         }
 
         // Generate return and abort blocks
@@ -379,7 +410,12 @@ impl<'a> Instrumenter<'a> {
         }
     }
 
-    fn instrument_bytecode(&mut self, spec: &TranslatedSpec, bc: Bytecode) {
+    fn instrument_bytecode(
+        &mut self,
+        spec: &TranslatedSpec,
+        inlined_props: &BTreeMap<AttrId, (TranslatedSpec, Exp)>,
+        bc: Bytecode,
+    ) {
         use Bytecode::*;
         use Operation::*;
 
@@ -448,6 +484,13 @@ impl<'a> Instrumenter<'a> {
                     Some(AbortAction(self.abort_label, self.abort_local)),
                 ));
                 self.can_abort = true;
+            }
+            Prop(id, kind @ PropKind::Assume, prop) | Prop(id, kind @ PropKind::Assert, prop) => {
+                let prop = match inlined_props.get(&id) {
+                    None => prop,
+                    Some((_, exp)) => exp.clone(),
+                };
+                self.builder.emit(Prop(id, kind, prop));
             }
             _ => self.builder.emit(bc),
         }

--- a/language/move-prover/tests/sources/functional/specs_in_fun_ref.move
+++ b/language/move-prover/tests/sources/functional/specs_in_fun_ref.move
@@ -99,4 +99,25 @@ module 0x42::TestAssertWithReferences {
     spec simple6 {
         ensures result == n;
     }
+
+    // This function verifies.
+    fun simple7(x: &mut u64, y: u64): u64 {
+        let a = x;
+        let b = y;
+        let c = &mut b;
+        *c = *a;
+        *a = y;
+        spec {
+            assert a == y;
+            assert x == y;
+            assert c == old(x);
+            // NOTE: cannot verify the following, write-back not propagated yet
+            // assert b == old(x);
+        };
+        let _ = c;
+        b
+    }
+    spec simple7 {
+        ensures x == y && result == old(x);
+    }
 }

--- a/language/move-prover/tests/sources/functional/verify_vector.cvc4_exp
+++ b/language/move-prover/tests/sources/functional/verify_vector.cvc4_exp
@@ -1,135 +1,521 @@
 Move prover returns: exiting with boogie verification errors
+error: induction case of the loop invariant does not hold
+
+     ┌── tests/sources/functional/verify_vector.move:143:17 ───
+     │
+ 143 │                 assert forall k in 0..len(old(v)): v[k] == old(v)[k];
+     │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     │
+     =     at tests/sources/functional/verify_vector.move:135: verify_append
+     =         v = <redacted>
+     =         other = <redacted>
+     =     at tests/sources/functional/verify_vector.move:136: verify_append
+     =         o = <redacted>
+     =     at tests/sources/functional/verify_vector.move:137: verify_append
+     =     at tests/sources/functional/verify_vector.move:139: verify_append
+     =     at tests/sources/functional/verify_vector.move:140: verify_append
+     =     at tests/sources/functional/verify_vector.move:141: verify_append
+     =     at tests/sources/functional/verify_vector.move:142: verify_append
+     =     at tests/sources/functional/verify_vector.move:143: verify_append
+     =     at tests/sources/functional/verify_vector.move:144: verify_append
+     =     at tests/sources/functional/verify_vector.move:145: verify_append
+     =     at tests/sources/functional/verify_vector.move:140: verify_append
+     =     at tests/sources/functional/verify_vector.move:141: verify_append
+     =     at tests/sources/functional/verify_vector.move:142: verify_append
+     =     at tests/sources/functional/verify_vector.move:143: verify_append
+     =     at tests/sources/functional/verify_vector.move:144: verify_append
+     =     at tests/sources/functional/verify_vector.move:145: verify_append
+     =     at tests/sources/functional/verify_vector.move:147: verify_append
+     =     at tests/sources/functional/verify_vector.move:138: verify_append
+     =     at tests/sources/functional/verify_vector.move:140: verify_append
+     =     at tests/sources/functional/verify_vector.move:141: verify_append
+     =     at tests/sources/functional/verify_vector.move:142: verify_append
+     =     at tests/sources/functional/verify_vector.move:143: verify_append
+
+error: induction case of the loop invariant does not hold
+
+     ┌── tests/sources/functional/verify_vector.move:144:17 ───
+     │
+ 144 │                 assert forall k in 0..len(o): o[k] == other[len(other)-1-k];
+     │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     │
+     =     at tests/sources/functional/verify_vector.move:135: verify_append
+     =         v = <redacted>
+     =         other = <redacted>
+     =     at tests/sources/functional/verify_vector.move:136: verify_append
+     =         o = <redacted>
+     =     at tests/sources/functional/verify_vector.move:137: verify_append
+     =     at tests/sources/functional/verify_vector.move:139: verify_append
+     =     at tests/sources/functional/verify_vector.move:140: verify_append
+     =     at tests/sources/functional/verify_vector.move:141: verify_append
+     =     at tests/sources/functional/verify_vector.move:142: verify_append
+     =     at tests/sources/functional/verify_vector.move:143: verify_append
+     =     at tests/sources/functional/verify_vector.move:144: verify_append
+     =     at tests/sources/functional/verify_vector.move:145: verify_append
+     =     at tests/sources/functional/verify_vector.move:140: verify_append
+     =     at tests/sources/functional/verify_vector.move:141: verify_append
+     =     at tests/sources/functional/verify_vector.move:142: verify_append
+     =     at tests/sources/functional/verify_vector.move:143: verify_append
+     =     at tests/sources/functional/verify_vector.move:144: verify_append
+     =     at tests/sources/functional/verify_vector.move:145: verify_append
+     =     at tests/sources/functional/verify_vector.move:147: verify_append
+     =     at tests/sources/functional/verify_vector.move:138: verify_append
+     =     at tests/sources/functional/verify_vector.move:140: verify_append
+     =     at tests/sources/functional/verify_vector.move:141: verify_append
+     =     at tests/sources/functional/verify_vector.move:142: verify_append
+     =     at tests/sources/functional/verify_vector.move:143: verify_append
+     =     at tests/sources/functional/verify_vector.move:144: verify_append
+
+error: induction case of the loop invariant does not hold
+
+     ┌── tests/sources/functional/verify_vector.move:145:17 ───
+     │
+ 145 │                 assert forall k in len(old(v))..len(v): v[k] == other[k-len(old(v))];
+     │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     │
+     =     at tests/sources/functional/verify_vector.move:135: verify_append
+     =         v = <redacted>
+     =         other = <redacted>
+     =     at tests/sources/functional/verify_vector.move:136: verify_append
+     =         o = <redacted>
+     =     at tests/sources/functional/verify_vector.move:137: verify_append
+     =     at tests/sources/functional/verify_vector.move:139: verify_append
+     =     at tests/sources/functional/verify_vector.move:140: verify_append
+     =     at tests/sources/functional/verify_vector.move:141: verify_append
+     =     at tests/sources/functional/verify_vector.move:142: verify_append
+     =     at tests/sources/functional/verify_vector.move:143: verify_append
+     =     at tests/sources/functional/verify_vector.move:144: verify_append
+     =     at tests/sources/functional/verify_vector.move:145: verify_append
+     =     at tests/sources/functional/verify_vector.move:140: verify_append
+     =     at tests/sources/functional/verify_vector.move:141: verify_append
+     =     at tests/sources/functional/verify_vector.move:142: verify_append
+     =     at tests/sources/functional/verify_vector.move:143: verify_append
+     =     at tests/sources/functional/verify_vector.move:144: verify_append
+     =     at tests/sources/functional/verify_vector.move:145: verify_append
+     =     at tests/sources/functional/verify_vector.move:147: verify_append
+     =     at tests/sources/functional/verify_vector.move:138: verify_append
+     =     at tests/sources/functional/verify_vector.move:140: verify_append
+     =     at tests/sources/functional/verify_vector.move:141: verify_append
+     =     at tests/sources/functional/verify_vector.move:142: verify_append
+     =     at tests/sources/functional/verify_vector.move:143: verify_append
+     =     at tests/sources/functional/verify_vector.move:144: verify_append
+     =     at tests/sources/functional/verify_vector.move:145: verify_append
+
+error: post-condition does not hold
+
+     ┌── tests/sources/functional/verify_vector.move:155:9 ───
+     │
+ 155 │         ensures v[0..len(old(v))] == old(v);
+     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     │
+     =     at tests/sources/functional/verify_vector.move:135: verify_append
+     =         v = <redacted>
+     =         other = <redacted>
+     =     at tests/sources/functional/verify_vector.move:136: verify_append
+     =         o = <redacted>
+     =     at tests/sources/functional/verify_vector.move:137: verify_append
+     =     at tests/sources/functional/verify_vector.move:139: verify_append
+     =     at tests/sources/functional/verify_vector.move:140: verify_append
+     =     at tests/sources/functional/verify_vector.move:141: verify_append
+     =     at tests/sources/functional/verify_vector.move:142: verify_append
+     =     at tests/sources/functional/verify_vector.move:143: verify_append
+     =     at tests/sources/functional/verify_vector.move:144: verify_append
+     =     at tests/sources/functional/verify_vector.move:145: verify_append
+     =     at tests/sources/functional/verify_vector.move:140: verify_append
+     =     at tests/sources/functional/verify_vector.move:141: verify_append
+     =     at tests/sources/functional/verify_vector.move:142: verify_append
+     =     at tests/sources/functional/verify_vector.move:143: verify_append
+     =     at tests/sources/functional/verify_vector.move:144: verify_append
+     =     at tests/sources/functional/verify_vector.move:145: verify_append
+     =     at tests/sources/functional/verify_vector.move:147: verify_append
+     =     at tests/sources/functional/verify_vector.move:138: verify_append
+     =         v = <redacted>
+     =     at tests/sources/functional/verify_vector.move:154
+     =     at tests/sources/functional/verify_vector.move:155
+
+error: post-condition does not hold
+
+     ┌── tests/sources/functional/verify_vector.move:156:9 ───
+     │
+ 156 │         ensures v[len(old(v))..len(v)] == other;
+     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     │
+     =     at tests/sources/functional/verify_vector.move:135: verify_append
+     =         v = <redacted>
+     =         other = <redacted>
+     =     at tests/sources/functional/verify_vector.move:136: verify_append
+     =         o = <redacted>
+     =     at tests/sources/functional/verify_vector.move:137: verify_append
+     =     at tests/sources/functional/verify_vector.move:139: verify_append
+     =     at tests/sources/functional/verify_vector.move:140: verify_append
+     =     at tests/sources/functional/verify_vector.move:141: verify_append
+     =     at tests/sources/functional/verify_vector.move:142: verify_append
+     =     at tests/sources/functional/verify_vector.move:143: verify_append
+     =     at tests/sources/functional/verify_vector.move:144: verify_append
+     =     at tests/sources/functional/verify_vector.move:145: verify_append
+     =     at tests/sources/functional/verify_vector.move:140: verify_append
+     =     at tests/sources/functional/verify_vector.move:141: verify_append
+     =     at tests/sources/functional/verify_vector.move:142: verify_append
+     =     at tests/sources/functional/verify_vector.move:143: verify_append
+     =     at tests/sources/functional/verify_vector.move:144: verify_append
+     =     at tests/sources/functional/verify_vector.move:145: verify_append
+     =     at tests/sources/functional/verify_vector.move:147: verify_append
+     =     at tests/sources/functional/verify_vector.move:138: verify_append
+     =         v = <redacted>
+     =     at tests/sources/functional/verify_vector.move:154
+     =     at tests/sources/functional/verify_vector.move:155
+     =     at tests/sources/functional/verify_vector.move:156
+
 error: unknown assertion failed
 
-     ┌── tests/sources/functional/verify_vector.move:255:12 ───
+     ┌── tests/sources/functional/verify_vector.move:234:12 ───
      │
- 255 │            assert !(exists x in v: x==e);
+ 234 │            assert !(exists x in v: x==e);
      │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      │
-     =     at tests/sources/functional/verify_vector.move:261
-     =     at tests/sources/functional/verify_vector.move:242: verify_contains
+     =     at tests/sources/functional/verify_vector.move:240
+     =     at tests/sources/functional/verify_vector.move:221: verify_contains
      =         v = <redacted>
      =         e = <redacted>
-     =     at tests/sources/functional/verify_vector.move:243: verify_contains
+     =     at tests/sources/functional/verify_vector.move:222: verify_contains
      =         i = <redacted>
-     =     at tests/sources/functional/verify_vector.move:244: verify_contains
+     =     at tests/sources/functional/verify_vector.move:223: verify_contains
      =         len = <redacted>
-     =     at tests/sources/functional/verify_vector.move:246: verify_contains
-     =     at tests/sources/functional/verify_vector.move:247: verify_contains
-     =     at tests/sources/functional/verify_vector.move:249: verify_contains
-     =     at tests/sources/functional/verify_vector.move:245: verify_contains
-     =     at tests/sources/functional/verify_vector.move:255: verify_contains
+     =     at tests/sources/functional/verify_vector.move:225: verify_contains
+     =     at tests/sources/functional/verify_vector.move:226: verify_contains
+     =     at tests/sources/functional/verify_vector.move:228: verify_contains
+     =     at tests/sources/functional/verify_vector.move:224: verify_contains
+     =     at tests/sources/functional/verify_vector.move:234: verify_contains
 
 error: induction case of the loop invariant does not hold
 
-     ┌── tests/sources/functional/verify_vector.move:247:16 ───
+     ┌── tests/sources/functional/verify_vector.move:226:16 ───
      │
- 247 │                assert !(exists j in 0..i: v[j]==e);
+ 226 │                assert !(exists j in 0..i: v[j]==e);
      │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      │
-     =     at tests/sources/functional/verify_vector.move:261
-     =     at tests/sources/functional/verify_vector.move:242: verify_contains
+     =     at tests/sources/functional/verify_vector.move:240
+     =     at tests/sources/functional/verify_vector.move:221: verify_contains
      =         v = <redacted>
      =         e = <redacted>
-     =     at tests/sources/functional/verify_vector.move:243: verify_contains
+     =     at tests/sources/functional/verify_vector.move:222: verify_contains
      =         i = <redacted>
-     =     at tests/sources/functional/verify_vector.move:244: verify_contains
+     =     at tests/sources/functional/verify_vector.move:223: verify_contains
      =         len = <redacted>
-     =     at tests/sources/functional/verify_vector.move:246: verify_contains
-     =     at tests/sources/functional/verify_vector.move:247: verify_contains
-     =     at tests/sources/functional/verify_vector.move:249: verify_contains
-     =     at tests/sources/functional/verify_vector.move:245: verify_contains
+     =     at tests/sources/functional/verify_vector.move:225: verify_contains
+     =     at tests/sources/functional/verify_vector.move:226: verify_contains
+     =     at tests/sources/functional/verify_vector.move:228: verify_contains
+     =     at tests/sources/functional/verify_vector.move:224: verify_contains
      =         i = <redacted>
-     =     at tests/sources/functional/verify_vector.move:247: verify_contains
+     =     at tests/sources/functional/verify_vector.move:226: verify_contains
 
 error: induction case of the loop invariant does not hold
 
-     ┌── tests/sources/functional/verify_vector.move:213:17 ───
+     ┌── tests/sources/functional/verify_vector.move:192:17 ───
      │
- 213 │                 assert !(exists j in 0..i: v[j]==e);
+ 192 │                 assert !(exists j in 0..i: v[j]==e);
      │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      │
-     =     at tests/sources/functional/verify_vector.move:227
-     =     at tests/sources/functional/verify_vector.move:208: verify_index_of
+     =     at tests/sources/functional/verify_vector.move:206
+     =     at tests/sources/functional/verify_vector.move:187: verify_index_of
      =         v = <redacted>
      =         e = <redacted>
-     =     at tests/sources/functional/verify_vector.move:209: verify_index_of
+     =     at tests/sources/functional/verify_vector.move:188: verify_index_of
      =         i = <redacted>
-     =     at tests/sources/functional/verify_vector.move:210: verify_index_of
+     =     at tests/sources/functional/verify_vector.move:189: verify_index_of
      =         len = <redacted>
-     =     at tests/sources/functional/verify_vector.move:212: verify_index_of
-     =     at tests/sources/functional/verify_vector.move:213: verify_index_of
-     =     at tests/sources/functional/verify_vector.move:215: verify_index_of
-     =     at tests/sources/functional/verify_vector.move:211: verify_index_of
+     =     at tests/sources/functional/verify_vector.move:191: verify_index_of
+     =     at tests/sources/functional/verify_vector.move:192: verify_index_of
+     =     at tests/sources/functional/verify_vector.move:194: verify_index_of
+     =     at tests/sources/functional/verify_vector.move:190: verify_index_of
      =         i = <redacted>
-     =     at tests/sources/functional/verify_vector.move:213: verify_index_of
+     =     at tests/sources/functional/verify_vector.move:192: verify_index_of
 
 error: post-condition does not hold
 
-     ┌── tests/sources/functional/verify_vector.move:224:9 ───
+     ┌── tests/sources/functional/verify_vector.move:203:9 ───
      │
- 224 │         ensures result_1 == (exists x in v: x==e); // whether v contains e or not
+ 203 │         ensures result_1 == (exists x in v: x==e); // whether v contains e or not
      │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      │
-     =     at tests/sources/functional/verify_vector.move:227
-     =     at tests/sources/functional/verify_vector.move:208: verify_index_of
+     =     at tests/sources/functional/verify_vector.move:206
+     =     at tests/sources/functional/verify_vector.move:187: verify_index_of
      =         v = <redacted>
      =         e = <redacted>
-     =     at tests/sources/functional/verify_vector.move:209: verify_index_of
+     =     at tests/sources/functional/verify_vector.move:188: verify_index_of
      =         i = <redacted>
-     =     at tests/sources/functional/verify_vector.move:210: verify_index_of
+     =     at tests/sources/functional/verify_vector.move:189: verify_index_of
      =         len = <redacted>
-     =     at tests/sources/functional/verify_vector.move:212: verify_index_of
-     =     at tests/sources/functional/verify_vector.move:213: verify_index_of
-     =     at tests/sources/functional/verify_vector.move:215: verify_index_of
-     =     at tests/sources/functional/verify_vector.move:211: verify_index_of
+     =     at tests/sources/functional/verify_vector.move:191: verify_index_of
+     =     at tests/sources/functional/verify_vector.move:192: verify_index_of
+     =     at tests/sources/functional/verify_vector.move:194: verify_index_of
+     =     at tests/sources/functional/verify_vector.move:190: verify_index_of
      =         result_1 = <redacted>
      =         result_2 = <redacted>
-     =     at tests/sources/functional/verify_vector.move:223
-     =     at tests/sources/functional/verify_vector.move:224
+     =     at tests/sources/functional/verify_vector.move:202
+     =     at tests/sources/functional/verify_vector.move:203
 
 error: post-condition does not hold
 
-     ┌── tests/sources/functional/verify_vector.move:226:9 ───
+     ┌── tests/sources/functional/verify_vector.move:205:9 ───
      │
- 226 │         ensures result_1 ==> (forall i in 0..result_2: v[i]!=e); // ensure the smallest index
+ 205 │         ensures result_1 ==> (forall i in 0..result_2: v[i]!=e); // ensure the smallest index
      │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      │
-     =     at tests/sources/functional/verify_vector.move:227
-     =     at tests/sources/functional/verify_vector.move:208: verify_index_of
+     =     at tests/sources/functional/verify_vector.move:206
+     =     at tests/sources/functional/verify_vector.move:187: verify_index_of
      =         v = <redacted>
      =         e = <redacted>
-     =     at tests/sources/functional/verify_vector.move:209: verify_index_of
+     =     at tests/sources/functional/verify_vector.move:188: verify_index_of
      =         i = <redacted>
-     =     at tests/sources/functional/verify_vector.move:210: verify_index_of
+     =     at tests/sources/functional/verify_vector.move:189: verify_index_of
      =         len = <redacted>
-     =     at tests/sources/functional/verify_vector.move:212: verify_index_of
-     =     at tests/sources/functional/verify_vector.move:213: verify_index_of
-     =     at tests/sources/functional/verify_vector.move:215: verify_index_of
-     =     at tests/sources/functional/verify_vector.move:211: verify_index_of
+     =     at tests/sources/functional/verify_vector.move:191: verify_index_of
+     =     at tests/sources/functional/verify_vector.move:192: verify_index_of
+     =     at tests/sources/functional/verify_vector.move:194: verify_index_of
+     =     at tests/sources/functional/verify_vector.move:190: verify_index_of
      =         result_1 = <redacted>
      =         result_2 = <redacted>
-     =     at tests/sources/functional/verify_vector.move:223
-     =     at tests/sources/functional/verify_vector.move:224
-     =     at tests/sources/functional/verify_vector.move:225
-     =     at tests/sources/functional/verify_vector.move:226
+     =     at tests/sources/functional/verify_vector.move:202
+     =     at tests/sources/functional/verify_vector.move:203
+     =     at tests/sources/functional/verify_vector.move:204
+     =     at tests/sources/functional/verify_vector.move:205
 
 error: post-condition does not hold
 
-     ┌── tests/sources/functional/verify_vector.move:237:9 ───
+     ┌── tests/sources/functional/verify_vector.move:216:9 ───
      │
- 237 │         ensures result_1 ==> (forall i in 0..result_2: v[i]!=e); // ensure the smallest index
+ 216 │         ensures result_1 ==> (forall i in 0..result_2: v[i]!=e); // ensure the smallest index
      │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      │
-     =     at tests/sources/functional/verify_vector.move:238
-     =     at tests/sources/functional/verify_vector.move:230: verify_model_index_of
+     =     at tests/sources/functional/verify_vector.move:217
+     =     at tests/sources/functional/verify_vector.move:209: verify_model_index_of
      =         v = <redacted>
      =         e = <redacted>
-     =     at tests/sources/functional/verify_vector.move:231: verify_model_index_of
+     =     at tests/sources/functional/verify_vector.move:210: verify_model_index_of
      =         result_1 = <redacted>
      =         result_2 = <redacted>
-     =     at tests/sources/functional/verify_vector.move:232: verify_model_index_of
-     =     at tests/sources/functional/verify_vector.move:234
-     =     at tests/sources/functional/verify_vector.move:235
-     =     at tests/sources/functional/verify_vector.move:236
-     =     at tests/sources/functional/verify_vector.move:237
+     =     at tests/sources/functional/verify_vector.move:211: verify_model_index_of
+     =     at tests/sources/functional/verify_vector.move:213
+     =     at tests/sources/functional/verify_vector.move:214
+     =     at tests/sources/functional/verify_vector.move:215
+     =     at tests/sources/functional/verify_vector.move:216
+
+error: induction case of the loop invariant does not hold
+
+     ┌── tests/sources/functional/verify_vector.move:266:17 ───
+     │
+ 266 │                 assert forall k in j..i: v[k] == old(v)[k+1];
+     │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     │
+     =     at tests/sources/functional/verify_vector.move:282
+     =     at tests/sources/functional/verify_vector.move:254: verify_remove
+     =         v = <redacted>
+     =         j = <redacted>
+     =     at tests/sources/functional/verify_vector.move:255: verify_remove
+     =         vlen = <redacted>
+     =     at tests/sources/functional/verify_vector.move:256: verify_remove
+     =         i = <redacted>
+     =     at tests/sources/functional/verify_vector.move:258: verify_remove
+     =         vlen = <redacted>
+     =     at tests/sources/functional/verify_vector.move:262: verify_remove
+     =     at tests/sources/functional/verify_vector.move:263: verify_remove
+     =     at tests/sources/functional/verify_vector.move:264: verify_remove
+     =     at tests/sources/functional/verify_vector.move:265: verify_remove
+     =     at tests/sources/functional/verify_vector.move:266: verify_remove
+     =     at tests/sources/functional/verify_vector.move:267: verify_remove
+     =     at tests/sources/functional/verify_vector.move:268: verify_remove
+     =     at tests/sources/functional/verify_vector.move:263: verify_remove
+     =     at tests/sources/functional/verify_vector.move:264: verify_remove
+     =     at tests/sources/functional/verify_vector.move:265: verify_remove
+     =     at tests/sources/functional/verify_vector.move:266: verify_remove
+     =     at tests/sources/functional/verify_vector.move:267: verify_remove
+     =     at tests/sources/functional/verify_vector.move:268: verify_remove
+     =     at tests/sources/functional/verify_vector.move:270: verify_remove
+     =     at tests/sources/functional/verify_vector.move:261: verify_remove
+     =     at tests/sources/functional/verify_vector.move:273: verify_remove
+     =         i = <redacted>
+     =     at tests/sources/functional/verify_vector.move:263: verify_remove
+     =     at tests/sources/functional/verify_vector.move:264: verify_remove
+     =     at tests/sources/functional/verify_vector.move:265: verify_remove
+     =     at tests/sources/functional/verify_vector.move:266: verify_remove
+
+error: induction case of the loop invariant does not hold
+
+     ┌── tests/sources/functional/verify_vector.move:267:17 ───
+     │
+ 267 │                 assert forall k in i+1..len(v): v[k] == old(v)[k];
+     │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     │
+     =     at tests/sources/functional/verify_vector.move:282
+     =     at tests/sources/functional/verify_vector.move:254: verify_remove
+     =         v = <redacted>
+     =         j = <redacted>
+     =     at tests/sources/functional/verify_vector.move:255: verify_remove
+     =         vlen = <redacted>
+     =     at tests/sources/functional/verify_vector.move:256: verify_remove
+     =         i = <redacted>
+     =     at tests/sources/functional/verify_vector.move:258: verify_remove
+     =         vlen = <redacted>
+     =     at tests/sources/functional/verify_vector.move:262: verify_remove
+     =     at tests/sources/functional/verify_vector.move:263: verify_remove
+     =     at tests/sources/functional/verify_vector.move:264: verify_remove
+     =     at tests/sources/functional/verify_vector.move:265: verify_remove
+     =     at tests/sources/functional/verify_vector.move:266: verify_remove
+     =     at tests/sources/functional/verify_vector.move:267: verify_remove
+     =     at tests/sources/functional/verify_vector.move:268: verify_remove
+     =     at tests/sources/functional/verify_vector.move:263: verify_remove
+     =     at tests/sources/functional/verify_vector.move:264: verify_remove
+     =     at tests/sources/functional/verify_vector.move:265: verify_remove
+     =     at tests/sources/functional/verify_vector.move:266: verify_remove
+     =     at tests/sources/functional/verify_vector.move:267: verify_remove
+     =     at tests/sources/functional/verify_vector.move:268: verify_remove
+     =     at tests/sources/functional/verify_vector.move:270: verify_remove
+     =     at tests/sources/functional/verify_vector.move:261: verify_remove
+     =     at tests/sources/functional/verify_vector.move:273: verify_remove
+     =         i = <redacted>
+     =     at tests/sources/functional/verify_vector.move:263: verify_remove
+     =     at tests/sources/functional/verify_vector.move:264: verify_remove
+     =     at tests/sources/functional/verify_vector.move:265: verify_remove
+     =     at tests/sources/functional/verify_vector.move:266: verify_remove
+     =     at tests/sources/functional/verify_vector.move:267: verify_remove
+
+error: induction case of the loop invariant does not hold
+
+     ┌── tests/sources/functional/verify_vector.move:108:17 ───
+     │
+ 108 │                 assert forall i in 0..front_index: v[i] == old(v)[vlen-1-i];
+     │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     │
+     =     at tests/sources/functional/verify_vector.move:99: verify_reverse
+     =         v = <redacted>
+     =     at tests/sources/functional/verify_vector.move:100: verify_reverse
+     =         vlen = <redacted>
+     =     at tests/sources/functional/verify_vector.move:101: verify_reverse
+     =         front_index = <redacted>
+     =     at tests/sources/functional/verify_vector.move:104: verify_reverse
+     =         back_index = <redacted>
+     =     at tests/sources/functional/verify_vector.move:106: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:107: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:108: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:109: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:110: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:111: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:107: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:108: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:109: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:110: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:111: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:113: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:105: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:116: verify_reverse
+     =         front_index = <redacted>
+     =     at tests/sources/functional/verify_vector.move:117: verify_reverse
+     =         back_index = <redacted>
+     =     at tests/sources/functional/verify_vector.move:107: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:108: verify_reverse
+
+error: induction case of the loop invariant does not hold
+
+     ┌── tests/sources/functional/verify_vector.move:109:17 ───
+     │
+ 109 │                 assert forall i in 0..front_index: v[vlen-1-i] == old(v)[i];
+     │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     │
+     =     at tests/sources/functional/verify_vector.move:99: verify_reverse
+     =         v = <redacted>
+     =     at tests/sources/functional/verify_vector.move:100: verify_reverse
+     =         vlen = <redacted>
+     =     at tests/sources/functional/verify_vector.move:101: verify_reverse
+     =         front_index = <redacted>
+     =     at tests/sources/functional/verify_vector.move:104: verify_reverse
+     =         back_index = <redacted>
+     =     at tests/sources/functional/verify_vector.move:106: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:107: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:108: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:109: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:110: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:111: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:107: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:108: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:109: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:110: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:111: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:113: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:105: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:116: verify_reverse
+     =         front_index = <redacted>
+     =     at tests/sources/functional/verify_vector.move:117: verify_reverse
+     =         back_index = <redacted>
+     =     at tests/sources/functional/verify_vector.move:107: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:108: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:109: verify_reverse
+
+error: induction case of the loop invariant does not hold
+
+     ┌── tests/sources/functional/verify_vector.move:110:17 ───
+     │
+ 110 │                 assert forall j in front_index..back_index+1: v[j] == old(v)[j];
+     │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     │
+     =     at tests/sources/functional/verify_vector.move:99: verify_reverse
+     =         v = <redacted>
+     =     at tests/sources/functional/verify_vector.move:100: verify_reverse
+     =         vlen = <redacted>
+     =     at tests/sources/functional/verify_vector.move:101: verify_reverse
+     =         front_index = <redacted>
+     =     at tests/sources/functional/verify_vector.move:104: verify_reverse
+     =         back_index = <redacted>
+     =     at tests/sources/functional/verify_vector.move:106: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:107: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:108: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:109: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:110: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:111: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:107: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:108: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:109: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:110: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:111: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:113: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:105: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:116: verify_reverse
+     =         front_index = <redacted>
+     =     at tests/sources/functional/verify_vector.move:117: verify_reverse
+     =         back_index = <redacted>
+     =     at tests/sources/functional/verify_vector.move:107: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:108: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:109: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:110: verify_reverse
+
+error: post-condition does not hold
+
+     ┌── tests/sources/functional/verify_vector.move:122:9 ───
+     │
+ 122 │         ensures forall i in 0..len(v): v[i] == old(v)[len(v)-1-i];
+     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     │
+     =     at tests/sources/functional/verify_vector.move:99: verify_reverse
+     =         v = <redacted>
+     =     at tests/sources/functional/verify_vector.move:100: verify_reverse
+     =         vlen = <redacted>
+     =     at tests/sources/functional/verify_vector.move:101: verify_reverse
+     =         front_index = <redacted>
+     =     at tests/sources/functional/verify_vector.move:104: verify_reverse
+     =         back_index = <redacted>
+     =     at tests/sources/functional/verify_vector.move:106: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:107: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:108: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:109: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:110: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:111: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:107: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:108: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:109: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:110: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:111: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:113: verify_reverse
+     =     at tests/sources/functional/verify_vector.move:105: verify_reverse
+     =         v = <redacted>
+     =     at tests/sources/functional/verify_vector.move:121
+     =     at tests/sources/functional/verify_vector.move:122


### PR DESCRIPTION
In addition to post states, old(..) is now allowed in `assert` and
`assume` statements in inlined spec blocks. The primary use case is to
support loop invariants: as showcased in the `verify_vector.move` test.

Note that the old(..) expressions in inline spec block is restricted to
take a single expression that is a function parameter only. No other
cases are currently allowed. Should we want to relax this constraint in
the future, the `ModuleBuilder::check_condition_is_valid` function needs
to be updated and the test case `inline_spec_err.move` in `move-model`
needs to be updated as well.

## Motivation

Complete the loop invariant story.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- CI
- `inline_spec_err.move` is added to test that only a single function parameter expression is allowed in `old(..)` in inline spec
- `specs_in_fun_ref.move` is updated to test that we can reason about local mut refs.
- `verify_vector.move` is updated to use the `old(..)` expressions to complete the specification and verification of loop invariants. The default flow verifies successfully but the cvc4 version failed. Please refer to the `.cvc4_exp` file for details.

## Related PRs

(I think the spec-lang doc should be updated as well, I'll link that once updated)

