### PR TITLE
[x] don't log failing sccache stops if the client failed due to a non-running server

### DIFF
--- a/devtools/x/src/utils.rs
+++ b/devtools/x/src/utils.rs
@@ -76,10 +76,14 @@ pub fn stop_sccache_server() {
             if output.status.success() {
                 info!("Stopped already running sccache.");
             } else {
-                info!("Failed to stopped already running sccache.");
-                warn!("status: {}", output.status);
-                warn!("stdout: {}", String::from_utf8_lossy(&output.stdout));
-                warn!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+                let std_err = String::from_utf8_lossy(&output.stderr);
+                //sccache will fail
+                if !std_err.contains("couldn't connect to server") {
+                    warn!("Failed to stopped already running sccache.");
+                    warn!("status: {}", output.status);
+                    warn!("stdout: {}", String::from_utf8_lossy(&output.stdout));
+                    warn!("stderr: {}", std_err);
+                }
             }
         }
         Err(error) => {


### PR DESCRIPTION
## Motivation

Following up on: https://github.com/diem/diem/issues/8427

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

Local builds showing lack of logging with no running sccache servers.

## Related PRs

None

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
