### PR TITLE
[gha] consolidate artifact downloaders in prep to delete dupe in diem/actions

### DIFF
--- a/.github/workflows/ci-test-complete.yml
+++ b/.github/workflows/ci-test-complete.yml
@@ -20,18 +20,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
       - name: Download artifacts
-        uses: diem/actions/download-artifacts@a5fa31ff2b54a544cd88ac912cda469742592e6c
+        uses: diem/actions/get-artifacts@a5fa31ff2b54a544cd88ac912cda469742592e6c
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
-          pattern: "^.*-test-results$"
-          extract: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          workflow_run_id: ${{ github.event.workflow_run.id }}
+          artifacts: "unit-test-results codegen-unit-test-results"
+          target_dir: ${{ github.workspace }}/downloads
+          decompress: true
       - name: Publish unit test results
         uses: diem/publish-unit-test-result-action@07dbf21c1095745d5149a54007f28231936c9da4
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           check_name: Test results
-          files: "artifacts/*/**/*.xml"
+          files: "${{ github.workspace }}/downloads/*/**/*.xml"
           # Don't comment on PRs at the moment: might be too noisy and the test deltas are incorrect:
           # https://github.com/EnricoMi/publish-unit-test-result-action/issues/115
           comment_on_pr: false


### PR DESCRIPTION
## Motivation

Right now we've two actions in diem/actions that can download and unzip artifacts.  This is prep to consolidate on one which is written in shell - shell one also can work across jobs - rather than the javascript coupled to gha.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

CI, this run will spark execution of changes after running in ci-test-complete.yml

## Related PRs

None yet (will open one to remove old action).

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
