### PR TITLE
[2chain] add 2-chain related Timeout structs and implement safety rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,6 +1135,7 @@ dependencies = [
  "mirai-annotations",
  "proptest",
  "serde",
+ "serde_json",
  "short-hex-str",
 ]
 

--- a/config/management/genesis/src/storage_helper.rs
+++ b/config/management/genesis/src/storage_helper.rs
@@ -87,7 +87,7 @@ impl StorageHelper {
 
         // Initialize all other data in storage
         storage
-            .set(SAFETY_DATA, SafetyData::new(0, 0, 0, None))
+            .set(SAFETY_DATA, SafetyData::new(0, 0, 0, 0, None))
             .unwrap();
         storage.set(WAYPOINT, Waypoint::default()).unwrap();
         let mut encryptor = diem_network_address_encryption::Encryptor::new(storage);

--- a/config/management/genesis/src/validator_builder.rs
+++ b/config/management/genesis/src/validator_builder.rs
@@ -341,7 +341,7 @@ impl ValidatorBuilder {
         storage.import_private_key(VALIDATOR_NETWORK_KEY, Ed25519PrivateKey::generate(rng))?;
 
         // Initialize all other data in storage
-        storage.set(SAFETY_DATA, SafetyData::new(0, 0, 0, None))?;
+        storage.set(SAFETY_DATA, SafetyData::new(0, 0, 0, 0, None))?;
         storage.set(WAYPOINT, Waypoint::default())?;
 
         let mut encryptor = diem_network_address_encryption::Encryptor::new(storage);

--- a/consensus/consensus-types/Cargo.toml
+++ b/consensus/consensus-types/Cargo.toml
@@ -25,6 +25,7 @@ short-hex-str = { path = "../../common/short-hex-str" }
 
 [dev-dependencies]
 proptest = "1.0.0"
+serde_json = "1.0.64"
 
 diem-types = { path = "../../types", features = ["fuzzing"] }
 

--- a/consensus/consensus-types/src/lib.rs
+++ b/consensus/consensus-types/src/lib.rs
@@ -14,6 +14,7 @@ pub mod quorum_cert;
 pub mod safety_data;
 pub mod sync_info;
 pub mod timeout;
+pub mod timeout_2chain;
 pub mod timeout_certificate;
 pub mod vote;
 pub mod vote_data;

--- a/consensus/consensus-types/src/safety_data.rs
+++ b/consensus/consensus-types/src/safety_data.rs
@@ -10,7 +10,11 @@ use std::fmt;
 pub struct SafetyData {
     pub epoch: u64,
     pub last_voted_round: u64,
+    // highest 2-chain round, used for 3-chain
     pub preferred_round: u64,
+    // highest 1-chain round, used for 2-chain
+    #[serde(default)]
+    pub one_chain_round: u64,
     pub last_vote: Option<Vote>,
 }
 
@@ -19,12 +23,14 @@ impl SafetyData {
         epoch: u64,
         last_voted_round: u64,
         preferred_round: u64,
+        one_chain_round: u64,
         last_vote: Option<Vote>,
     ) -> Self {
         Self {
             epoch,
             last_voted_round,
             preferred_round,
+            one_chain_round,
             last_vote,
         }
     }
@@ -34,8 +40,27 @@ impl fmt::Display for SafetyData {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
-            "SafetyData: [epoch: {}, last_voted_round: {}, preferred_round: {}]",
-            self.epoch, self.last_voted_round, self.preferred_round
+            "SafetyData: [epoch: {}, last_voted_round: {}, preferred_round: {}, one_chain_round: {}]",
+            self.epoch, self.last_voted_round, self.preferred_round, self.one_chain_round
         )
     }
+}
+
+#[test]
+fn test_safety_data_upgrade() {
+    #[derive(Debug, Deserialize, Eq, PartialEq, Serialize, Clone, Default)]
+    struct OldSafetyData {
+        pub epoch: u64,
+        pub last_voted_round: u64,
+        pub preferred_round: u64,
+        pub last_vote: Option<Vote>,
+    }
+    let old_data = OldSafetyData {
+        epoch: 1,
+        last_voted_round: 10,
+        preferred_round: 100,
+        last_vote: None,
+    };
+    let value = serde_json::to_value(&old_data).unwrap();
+    let _: SafetyData = serde_json::from_value(value).unwrap();
 }

--- a/consensus/consensus-types/src/timeout_2chain.rs
+++ b/consensus/consensus-types/src/timeout_2chain.rs
@@ -1,0 +1,244 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::common::Author;
+use crate::quorum_cert::QuorumCert;
+use anyhow::{ensure, Context};
+use diem_crypto::ed25519::Ed25519Signature;
+use diem_crypto_derive::{BCSCryptoHash, CryptoHasher};
+use diem_types::block_info::Round;
+use diem_types::validator_signer::ValidatorSigner;
+use diem_types::validator_verifier::ValidatorVerifier;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fmt::{Display, Formatter};
+
+/// This structure contains all the information necessary to construct a signature
+/// on the equivalent of a DiemBFT v4 timeout message.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct TwoChainTimeout {
+    /// Epoch number corresponds to the set of validators that are active for this round.
+    epoch: u64,
+    /// The consensus protocol executes proposals (blocks) in rounds, which monotonically increase per epoch.
+    round: Round,
+    /// THe highest quorum cert the node has seen.
+    quorum_cert: QuorumCert,
+}
+
+impl TwoChainTimeout {
+    pub fn new(epoch: u64, round: Round, quorum_cert: QuorumCert) -> Self {
+        Self {
+            epoch,
+            round,
+            quorum_cert,
+        }
+    }
+
+    pub fn epoch(&self) -> u64 {
+        self.epoch
+    }
+
+    pub fn round(&self) -> Round {
+        self.round
+    }
+
+    pub fn hqc_round(&self) -> Round {
+        self.quorum_cert.certified_block().round()
+    }
+
+    pub fn quorum_cert(&self) -> &QuorumCert {
+        &self.quorum_cert
+    }
+
+    pub fn sign(&self, signer: &ValidatorSigner) -> Ed25519Signature {
+        signer.sign(&TimeoutSigningRepr {
+            epoch: self.epoch(),
+            round: self.round(),
+            hqc_round: self.hqc_round(),
+        })
+    }
+}
+
+impl Display for TwoChainTimeout {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "Timeout: [epoch: {}, round: {}, hqc_round: {}]",
+            self.epoch,
+            self.round,
+            self.hqc_round(),
+        )
+    }
+}
+
+/// The form the node signs on, which abbreviates the quorum cert with the round number.
+#[derive(Serialize, Deserialize, CryptoHasher, BCSCryptoHash)]
+struct TimeoutSigningRepr {
+    pub epoch: u64,
+    pub round: Round,
+    pub hqc_round: Round,
+}
+
+/// TimeoutCertificate is a proof that 2f+1 participants in epoch i
+/// have voted in round r and we can now move to round r+1. DiemBFT v4 requires signature to sign on
+/// the TimeoutSigningRepr and carry the TimeoutWithHighestQC with highest quorum cert among 2f+1.
+#[derive(Clone)]
+pub struct TwoChainTimeoutCertificate {
+    timeout: TwoChainTimeout,
+    signatures: BTreeMap<Author, (Round, Ed25519Signature)>,
+}
+
+impl Display for TwoChainTimeoutCertificate {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "TimeoutCertificate[epoch: {}, round: {}, hqc_round: {}]",
+            self.timeout.epoch(),
+            self.timeout.round(),
+            self.timeout.hqc_round(),
+        )
+    }
+}
+
+impl TwoChainTimeoutCertificate {
+    /// Creates new TimeoutCertificate
+    pub fn new(timeout: TwoChainTimeout) -> Self {
+        Self {
+            timeout,
+            signatures: BTreeMap::new(),
+        }
+    }
+    /// Verifies the signatures for each validator, the signature is on the TimeoutSigningRepr where the
+    /// hqc_round is in the signature map.
+    /// We verify the following:
+    /// 1. the highest quorum cert is valid
+    /// 2. all signatures are properly formed (timeout.epoch, timeout.round, round)
+    /// 3. timeout.hqc_round == max(signed round)
+    pub fn verify(&self, validators: &ValidatorVerifier) -> anyhow::Result<()> {
+        // Verify the highest quorum cert validity.
+        let hqc_round = self.timeout.hqc_round();
+        ensure!(
+            hqc_round < self.timeout.round(),
+            "Timeout round should be larger than the QC round"
+        );
+        self.timeout.quorum_cert().verify(validators)?;
+        let mut signed_round = 0;
+        validators.check_voting_power(self.signatures.keys())?;
+        for (author, (qc_round, signature)) in &self.signatures {
+            let t = TimeoutSigningRepr {
+                epoch: self.timeout.epoch(),
+                round: self.timeout.round(),
+                hqc_round: *qc_round,
+            };
+            validators
+                .verify(*author, &t, signature)
+                .with_context(|| format!("Failed to verify {}'s TimeoutSigningRepr", *author))?;
+            signed_round = std::cmp::max(signed_round, *qc_round);
+        }
+        ensure!(
+            hqc_round == signed_round,
+            "Inconsistent hqc round, qc has round {}, highest signed round {}",
+            hqc_round,
+            signed_round
+        );
+        Ok(())
+    }
+
+    /// The highest hqc round of the 2f+1 participants
+    pub fn highest_hqc_round(&self) -> Round {
+        self.timeout.hqc_round()
+    }
+
+    /// Returns the signatures certifying the round
+    pub fn signers(&self) -> impl Iterator<Item = &Author> {
+        self.signatures.iter().map(|(k, _)| k)
+    }
+
+    /// Add a new timeout message from author, the timeout should already be verified in upper layer.
+    pub fn add(&mut self, author: Author, timeout: TwoChainTimeout, signature: Ed25519Signature) {
+        debug_assert_eq!(
+            self.timeout.epoch(),
+            timeout.epoch(),
+            "Timeout should have the same epoch as TimeoutCert"
+        );
+        debug_assert_eq!(
+            self.timeout.round(),
+            timeout.round(),
+            "Timeout should have the same round as TimeoutCert"
+        );
+        let hqc_round = timeout.hqc_round();
+        if timeout.hqc_round() > self.timeout.hqc_round() {
+            self.timeout = timeout;
+        }
+        self.signatures.insert(author, (hqc_round, signature));
+    }
+}
+
+#[test]
+fn test_2chain_timeout_certificate() {
+    use crate::vote_data::VoteData;
+    use diem_crypto::hash::CryptoHash;
+    use diem_types::block_info::BlockInfo;
+    use diem_types::ledger_info::{LedgerInfo, LedgerInfoWithSignatures};
+    use diem_types::validator_verifier::random_validator_verifier;
+
+    let num_nodes = 4;
+    let quorum_size = num_nodes * 2 / 3 + 1;
+    let (signers, validators) = random_validator_verifier(num_nodes, None, false);
+    let generate_quorum = |round, num_of_signature| {
+        let vote_data = VoteData::new(BlockInfo::random(round), BlockInfo::random(0));
+        let mut ledger_info = LedgerInfoWithSignatures::new(
+            LedgerInfo::new(BlockInfo::empty(), vote_data.hash()),
+            BTreeMap::new(),
+        );
+        for signer in &signers[0..num_of_signature] {
+            let signature = signer.sign(ledger_info.ledger_info());
+            ledger_info.add_signature(signer.author(), signature);
+        }
+        QuorumCert::new(vote_data, ledger_info)
+    };
+    let generate_timeout =
+        |round, qc_round| TwoChainTimeout::new(1, round, generate_quorum(qc_round, quorum_size));
+
+    let timeouts: Vec<_> = (1..=3)
+        .map(|qc_round| generate_timeout(4, qc_round))
+        .collect();
+    // timeout cert with (round, hqc round) = (4, 1), (4, 2), (4, 3)
+    let mut valid_timeout_cert = TwoChainTimeoutCertificate::new(timeouts[0].clone());
+    for (timeout, signer) in timeouts.iter().zip(&signers) {
+        valid_timeout_cert.add(signer.author(), timeout.clone(), timeout.sign(&signer));
+    }
+    valid_timeout_cert.verify(&validators).unwrap();
+
+    // timeout round < hqc round
+    let mut invalid_timeout_cert = valid_timeout_cert.clone();
+    invalid_timeout_cert.timeout.round = 1;
+    invalid_timeout_cert.verify(&validators).unwrap_err();
+
+    // invalid signature
+    let mut invalid_timeout_cert = valid_timeout_cert.clone();
+    invalid_timeout_cert
+        .signatures
+        .get_mut(&signers[0].author())
+        .unwrap()
+        .1 = Ed25519Signature::dummy_signature();
+    invalid_timeout_cert.verify(&validators).unwrap_err();
+
+    // not enough signature
+    let mut invalid_timeout_cert = valid_timeout_cert.clone();
+    invalid_timeout_cert
+        .signatures
+        .remove(&signers[0].author())
+        .unwrap();
+    invalid_timeout_cert.verify(&validators).unwrap_err();
+
+    // hqc round not match signed round
+    let mut invalid_timeout_cert = valid_timeout_cert.clone();
+    invalid_timeout_cert.timeout.quorum_cert = generate_quorum(2, quorum_size);
+    invalid_timeout_cert.verify(&validators).unwrap_err();
+
+    // invalid quorum cert
+    let mut invalid_timeout_cert = valid_timeout_cert;
+    invalid_timeout_cert.timeout.quorum_cert = generate_quorum(3, quorum_size - 1);
+    invalid_timeout_cert.verify(&validators).unwrap_err();
+}

--- a/consensus/safety-rules/src/consensus_state.rs
+++ b/consensus/safety-rules/src/consensus_state.rs
@@ -61,6 +61,11 @@ impl ConsensusState {
         self.safety_data.preferred_round
     }
 
+    /// The round of the highest QuorumCert.
+    pub fn one_chain_round(&self) -> Round {
+        self.safety_data.one_chain_round
+    }
+
     /// Last known checkpoint this should map to a LedgerInfo that contains a new ValidatorSet
     pub fn waypoint(&self) -> Waypoint {
         self.waypoint

--- a/consensus/safety-rules/src/error.rs
+++ b/consensus/safety-rules/src/error.rs
@@ -41,6 +41,12 @@ pub enum Error {
     ValidatorNotInSet(String),
     #[error("Vote proposal missing expected signature")]
     VoteProposalSignatureNotFound,
+    #[error("Does not satisfy 2-chain voting rule. Round {0}, Quorum round {1}, TC round {2},  HQC round in TC {3}")]
+    NotSafeToVote(u64, u64, u64, u64),
+    #[error("Does not satisfy 2-chain timeout rule. Round {0}, Quorum round {1}, TC round {2}, one-chain round {3}")]
+    NotSafeToTimeout(u64, u64, u64, u64),
+    #[error("Invalid TC: {0}")]
+    InvalidTimeoutCertificate(String),
 }
 
 impl From<bcs::Error> for Error {

--- a/consensus/safety-rules/src/lib.rs
+++ b/consensus/safety-rules/src/lib.rs
@@ -13,6 +13,7 @@ mod persistent_safety_storage;
 mod process;
 mod remote_service;
 mod safety_rules;
+mod safety_rules_2chain;
 mod safety_rules_manager;
 mod serializer;
 mod t_safety_rules;

--- a/consensus/safety-rules/src/local_client.rs
+++ b/consensus/safety-rules/src/local_client.rs
@@ -3,7 +3,11 @@
 
 use crate::{ConsensusState, Error, SafetyRules, TSafetyRules};
 use consensus_types::{
-    block::Block, block_data::BlockData, timeout::Timeout, vote::Vote,
+    block::Block,
+    block_data::BlockData,
+    timeout::Timeout,
+    timeout_2chain::{TwoChainTimeout, TwoChainTimeoutCertificate},
+    vote::Vote,
     vote_proposal::MaybeSignedVoteProposal,
 };
 use diem_crypto::ed25519::Ed25519Signature;
@@ -46,5 +50,25 @@ impl TSafetyRules for LocalClient {
 
     fn sign_timeout(&mut self, timeout: &Timeout) -> Result<Ed25519Signature, Error> {
         self.internal.write().sign_timeout(timeout)
+    }
+
+    fn sign_timeout_with_qc(
+        &mut self,
+        timeout: &TwoChainTimeout,
+        timeout_cert: Option<&TwoChainTimeoutCertificate>,
+    ) -> Result<Ed25519Signature, Error> {
+        self.internal
+            .write()
+            .sign_timeout_with_qc(timeout, timeout_cert)
+    }
+
+    fn construct_and_sign_vote_two_chain(
+        &mut self,
+        vote_proposal: &MaybeSignedVoteProposal,
+        timeout_cert: Option<&TwoChainTimeoutCertificate>,
+    ) -> Result<Vote, Error> {
+        self.internal
+            .write()
+            .construct_and_sign_vote_two_chain(vote_proposal, timeout_cert)
     }
 }

--- a/consensus/safety-rules/src/logging.rs
+++ b/consensus/safety-rules/src/logging.rs
@@ -42,13 +42,16 @@ impl<'a> SafetyLogSchema<'a> {
 pub enum LogEntry {
     ConsensusState,
     ConstructAndSignVote,
+    ConstructAndSignVoteTwoChain,
     Epoch,
     Initialize,
     KeyReconciliation,
     LastVotedRound,
+    OneChainRound,
     PreferredRound,
     SignProposal,
     SignTimeout,
+    SignTimeoutWithQC,
     State,
     Waypoint,
 }
@@ -58,13 +61,16 @@ impl LogEntry {
         match self {
             LogEntry::ConsensusState => "consensus_state",
             LogEntry::ConstructAndSignVote => "construct_and_sign_vote",
+            LogEntry::ConstructAndSignVoteTwoChain => "construct_and_sign_vote_2chain",
             LogEntry::Epoch => "epoch",
             LogEntry::Initialize => "initialize",
             LogEntry::LastVotedRound => "last_voted_round",
             LogEntry::KeyReconciliation => "key_reconciliation",
+            LogEntry::OneChainRound => "one_chain_round",
             LogEntry::PreferredRound => "preferred_round",
             LogEntry::SignProposal => "sign_proposal",
             LogEntry::SignTimeout => "sign_timeout",
+            LogEntry::SignTimeoutWithQC => "sign_timeout_with_qc",
             LogEntry::State => "state",
             LogEntry::Waypoint => "waypoint",
         }

--- a/consensus/safety-rules/src/persistent_safety_storage.rs
+++ b/consensus/safety-rules/src/persistent_safety_storage.rs
@@ -42,7 +42,7 @@ impl PersistentSafetyStorage {
         waypoint: Waypoint,
         enable_cached_safety_data: bool,
     ) -> Self {
-        let safety_data = SafetyData::new(1, 0, 0, None);
+        let safety_data = SafetyData::new(1, 0, 0, 0, None);
         Self::initialize_(
             &mut internal_store,
             safety_data.clone(),
@@ -209,7 +209,7 @@ mod tests {
         assert_eq!(safety_data.preferred_round, 0);
 
         safety_storage
-            .set_safety_data(SafetyData::new(9, 8, 1, None))
+            .set_safety_data(SafetyData::new(9, 8, 1, 0, None))
             .unwrap();
 
         let safety_data = safety_storage.safety_data().unwrap();

--- a/consensus/safety-rules/src/safety_rules.rs
+++ b/consensus/safety-rules/src/safety_rules.rs
@@ -17,6 +17,7 @@ use consensus_types::{
     quorum_cert::QuorumCert,
     safety_data::SafetyData,
     timeout::Timeout,
+    timeout_2chain::{TwoChainTimeout, TwoChainTimeoutCertificate},
     vote::Vote,
     vote_data::VoteData,
     vote_proposal::{MaybeSignedVoteProposal, VoteProposal},
@@ -32,15 +33,18 @@ use diem_types::{
     ledger_info::LedgerInfo, waypoint::Waypoint,
 };
 use serde::Serialize;
-use std::cmp::Ordering;
+
+pub(crate) fn next_round(round: Round) -> Result<Round, Error> {
+    u64::checked_add(round, 1).ok_or(Error::IncorrectRound(round))
+}
 
 /// @TODO consider a cache of verified QCs to cut down on verification costs
 pub struct SafetyRules {
-    persistent_storage: PersistentSafetyStorage,
-    execution_public_key: Option<Ed25519PublicKey>,
-    export_consensus_key: bool,
-    validator_signer: Option<ConfigurableValidatorSigner>,
-    epoch_state: Option<EpochState>,
+    pub(crate) persistent_storage: PersistentSafetyStorage,
+    pub(crate) execution_public_key: Option<Ed25519PublicKey>,
+    pub(crate) export_consensus_key: bool,
+    pub(crate) validator_signer: Option<ConfigurableValidatorSigner>,
+    pub(crate) epoch_state: Option<EpochState>,
 }
 
 impl SafetyRules {
@@ -69,21 +73,77 @@ impl SafetyRules {
         }
     }
 
-    fn sign<T: Serialize + CryptoHash>(&self, message: &T) -> Result<Ed25519Signature, Error> {
+    /// Validity checks
+    pub(crate) fn verify_proposal(
+        &mut self,
+        maybe_signed_vote_proposal: &MaybeSignedVoteProposal,
+    ) -> Result<VoteData, Error> {
+        let vote_proposal = &maybe_signed_vote_proposal.vote_proposal;
+        let execution_signature = maybe_signed_vote_proposal.signature.as_ref();
+
+        if let Some(public_key) = self.execution_public_key.as_ref() {
+            execution_signature
+                .ok_or(Error::VoteProposalSignatureNotFound)?
+                .verify(vote_proposal, public_key)
+                .map_err(|error| Error::InternalError(error.to_string()))?;
+        }
+
+        let proposed_block = vote_proposal.block();
+        let safety_data = self.persistent_storage.safety_data()?;
+
+        self.verify_epoch(proposed_block.epoch(), &safety_data)?;
+
+        self.verify_qc(proposed_block.quorum_cert())?;
+        proposed_block
+            .validate_signature(&self.epoch_state()?.verifier)
+            .map_err(|error| Error::InvalidProposal(error.to_string()))?;
+        proposed_block
+            .verify_well_formed()
+            .map_err(|error| Error::InvalidProposal(error.to_string()))?;
+        self.extension_check(vote_proposal)
+    }
+
+    pub(crate) fn sign<T: Serialize + CryptoHash>(
+        &self,
+        message: &T,
+    ) -> Result<Ed25519Signature, Error> {
         let signer = self.signer()?;
         signer.sign(message, &self.persistent_storage)
     }
 
-    fn signer(&self) -> Result<&ConfigurableValidatorSigner, Error> {
+    pub(crate) fn signer(&self) -> Result<&ConfigurableValidatorSigner, Error> {
         self.validator_signer
             .as_ref()
             .ok_or_else(|| Error::NotInitialized("validator_signer".into()))
     }
 
-    fn epoch_state(&self) -> Result<&EpochState, Error> {
+    pub(crate) fn epoch_state(&self) -> Result<&EpochState, Error> {
         self.epoch_state
             .as_ref()
             .ok_or_else(|| Error::NotInitialized("epoch_state".into()))
+    }
+
+    pub(crate) fn observe_qc(&self, qc: &QuorumCert, safety_data: &mut SafetyData) -> bool {
+        let mut updated = false;
+        let one_chain = qc.certified_block().round();
+        let two_chain = qc.parent_block().round();
+        if one_chain > safety_data.one_chain_round {
+            safety_data.one_chain_round = one_chain;
+            info!(
+                SafetyLogSchema::new(LogEntry::OneChainRound, LogEvent::Update)
+                    .preferred_round(safety_data.one_chain_round)
+            );
+            updated = true;
+        }
+        if two_chain > safety_data.preferred_round {
+            safety_data.preferred_round = two_chain;
+            info!(
+                SafetyLogSchema::new(LogEntry::PreferredRound, LogEvent::Update)
+                    .preferred_round(safety_data.preferred_round)
+            );
+            updated = true;
+        }
+        updated
     }
 
     /// Check if the executed result extends the parent result.
@@ -114,7 +174,7 @@ impl SafetyRules {
     /// 1) B0 <- B1 <- B2 <--
     /// 2) round(B0) + 1 = round(B1), and
     /// 3) round(B1) + 1 = round(B2).
-    pub fn construct_ledger_info(
+    fn construct_ledger_info(
         &self,
         proposed_block: &Block,
         consensus_data_hash: HashValue,
@@ -124,8 +184,6 @@ impl SafetyRules {
         let block0 = proposed_block.quorum_cert().parent_block().round();
 
         // verify 3-chain rule
-        let next_round =
-            |round: u64| u64::checked_add(round, 1).ok_or(Error::IncorrectRound(round));
         let commit = next_round(block0)? == block1 && next_round(block1)? == block2;
 
         // create a ledger info
@@ -146,7 +204,6 @@ impl SafetyRules {
     ) -> Result<bool, Error> {
         let preferred_round = safety_data.preferred_round;
         let one_chain_round = quorum_cert.certified_block().round();
-        let two_chain_round = quorum_cert.parent_block().round();
 
         if one_chain_round < preferred_round {
             return Err(Error::IncorrectPreferredRound(
@@ -154,26 +211,7 @@ impl SafetyRules {
                 preferred_round,
             ));
         }
-
-        let updated = match two_chain_round.cmp(&preferred_round) {
-            Ordering::Greater => {
-                safety_data.preferred_round = two_chain_round;
-                info!(
-                    SafetyLogSchema::new(LogEntry::PreferredRound, LogEvent::Update)
-                        .preferred_round(safety_data.preferred_round)
-                );
-                true
-            }
-            Ordering::Less => {
-                trace!(
-                "2-chain round {} is lower than preferred round {} but 1-chain round {} is higher.",
-                two_chain_round, preferred_round, one_chain_round
-            );
-                false
-            }
-            Ordering::Equal => false,
-        };
-        Ok(updated)
+        Ok(self.observe_qc(quorum_cert, safety_data))
     }
 
     /// This verifies whether the author of one proposal is the validator signer
@@ -190,7 +228,7 @@ impl SafetyRules {
     }
 
     /// This verifies the epoch given against storage for consistent verification
-    fn verify_epoch(&self, epoch: u64, safety_data: &SafetyData) -> Result<(), Error> {
+    pub(crate) fn verify_epoch(&self, epoch: u64, safety_data: &SafetyData) -> Result<(), Error> {
         if epoch != safety_data.epoch {
             return Err(Error::IncorrectEpoch(epoch, safety_data.epoch));
         }
@@ -199,7 +237,7 @@ impl SafetyRules {
     }
 
     /// First voting rule
-    fn verify_and_update_last_vote_round(
+    pub(crate) fn verify_and_update_last_vote_round(
         &self,
         round: Round,
         safety_data: &mut SafetyData,
@@ -221,7 +259,7 @@ impl SafetyRules {
     }
 
     /// This verifies a QC has valid signatures.
-    fn verify_qc(&self, qc: &QuorumCert) -> Result<(), Error> {
+    pub(crate) fn verify_qc(&self, qc: &QuorumCert) -> Result<(), Error> {
         let epoch_state = self.epoch_state()?;
 
         qc.verify(&epoch_state.verifier)
@@ -272,6 +310,7 @@ impl SafetyRules {
             self.persistent_storage.set_waypoint(waypoint)?;
             self.persistent_storage.set_safety_data(SafetyData::new(
                 epoch_state.epoch,
+                0,
                 0,
                 0,
                 None,
@@ -340,21 +379,10 @@ impl SafetyRules {
         // Exit early if we cannot sign
         self.signer()?;
 
-        let vote_proposal = &maybe_signed_vote_proposal.vote_proposal;
-        let execution_signature = maybe_signed_vote_proposal.signature.as_ref();
-
-        if let Some(public_key) = self.execution_public_key.as_ref() {
-            execution_signature
-                .ok_or(Error::VoteProposalSignatureNotFound)?
-                .verify(vote_proposal, public_key)
-                .map_err(|error| Error::InternalError(error.to_string()))?;
-        }
-
-        let proposed_block = vote_proposal.block();
+        let vote_data = self.verify_proposal(maybe_signed_vote_proposal)?;
         let mut safety_data = self.persistent_storage.safety_data()?;
 
-        self.verify_epoch(proposed_block.epoch(), &safety_data)?;
-
+        let proposed_block = maybe_signed_vote_proposal.vote_proposal.block();
         // if already voted on this round, send back the previous vote
         // note: this needs to happen after verifying the epoch as we just check the round here
         if let Some(vote) = safety_data.last_vote.clone() {
@@ -363,11 +391,7 @@ impl SafetyRules {
             }
         }
 
-        self.verify_qc(proposed_block.quorum_cert())?;
-        proposed_block
-            .validate_signature(&self.epoch_state()?.verifier)
-            .map_err(|error| Error::InternalError(error.to_string()))?;
-
+        // Two voting rules
         self.verify_and_update_preferred_round(proposed_block.quorum_cert(), &mut safety_data)?;
         self.verify_and_update_last_vote_round(
             proposed_block.block_data().round(),
@@ -375,7 +399,6 @@ impl SafetyRules {
         )?;
 
         // Construct and sign vote
-        let vote_data = self.extension_check(vote_proposal)?;
         let author = self.signer()?.author();
         let ledger_info = self.construct_ledger_info(proposed_block, vote_data.hash())?;
         let signature = self.sign(&ledger_info)?;
@@ -470,6 +493,35 @@ impl TSafetyRules for SafetyRules {
     fn sign_timeout(&mut self, timeout: &Timeout) -> Result<Ed25519Signature, Error> {
         let cb = || self.guarded_sign_timeout(timeout);
         run_and_log(cb, |log| log.round(timeout.round()), LogEntry::SignTimeout)
+    }
+
+    fn sign_timeout_with_qc(
+        &mut self,
+        timeout: &TwoChainTimeout,
+        timeout_cert: Option<&TwoChainTimeoutCertificate>,
+    ) -> Result<Ed25519Signature, Error> {
+        let cb = || self.guarded_sign_timeout_with_qc(timeout, timeout_cert);
+        run_and_log(
+            cb,
+            |log| log.round(timeout.round()),
+            LogEntry::SignTimeoutWithQC,
+        )
+    }
+
+    fn construct_and_sign_vote_two_chain(
+        &mut self,
+        maybe_signed_vote_proposal: &MaybeSignedVoteProposal,
+        timeout_cert: Option<&TwoChainTimeoutCertificate>,
+    ) -> Result<Vote, Error> {
+        let round = maybe_signed_vote_proposal.vote_proposal.block().round();
+        let cb = || {
+            self.guarded_construct_and_sign_vote_two_chain(maybe_signed_vote_proposal, timeout_cert)
+        };
+        run_and_log(
+            cb,
+            |log| log.round(round),
+            LogEntry::ConstructAndSignVoteTwoChain,
+        )
     }
 }
 

--- a/consensus/safety-rules/src/safety_rules_2chain.rs
+++ b/consensus/safety-rules/src/safety_rules_2chain.rs
@@ -1,0 +1,170 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{error::Error, safety_rules::next_round, SafetyRules};
+use consensus_types::{
+    block::Block,
+    safety_data::SafetyData,
+    timeout_2chain::{TwoChainTimeout, TwoChainTimeoutCertificate},
+    vote::Vote,
+    vote_proposal::MaybeSignedVoteProposal,
+};
+use diem_crypto::{ed25519::Ed25519Signature, hash::CryptoHash, HashValue};
+use diem_types::{block_info::BlockInfo, ledger_info::LedgerInfo};
+
+/// 2-chain safety rules implementation
+impl SafetyRules {
+    pub(crate) fn guarded_sign_timeout_with_qc(
+        &mut self,
+        timeout: &TwoChainTimeout,
+        timeout_cert: Option<&TwoChainTimeoutCertificate>,
+    ) -> Result<Ed25519Signature, Error> {
+        self.signer()?;
+        let mut safety_data = self.persistent_storage.safety_data()?;
+        self.verify_epoch(timeout.epoch(), &safety_data)?;
+        self.verify_qc(timeout.quorum_cert())?;
+        if let Some(tc) = timeout_cert {
+            self.verify_tc(tc)?;
+        }
+
+        self.safe_to_timeout(timeout, timeout_cert, &safety_data)?;
+        if timeout.round() < safety_data.last_voted_round {
+            return Err(Error::IncorrectLastVotedRound(
+                timeout.round(),
+                safety_data.last_voted_round,
+            ));
+        }
+        if timeout.round() > safety_data.last_voted_round {
+            self.verify_and_update_last_vote_round(timeout.round(), &mut safety_data)?;
+            self.persistent_storage.set_safety_data(safety_data)?;
+        }
+
+        let signature = self.sign(&timeout.signing_format())?;
+        Ok(signature)
+    }
+
+    pub(crate) fn guarded_construct_and_sign_vote_two_chain(
+        &mut self,
+        maybe_signed_vote_proposal: &MaybeSignedVoteProposal,
+        timeout_cert: Option<&TwoChainTimeoutCertificate>,
+    ) -> Result<Vote, Error> {
+        // Exit early if we cannot sign
+        self.signer()?;
+
+        let vote_data = self.verify_proposal(maybe_signed_vote_proposal)?;
+        if let Some(tc) = timeout_cert {
+            self.verify_tc(tc)?;
+        }
+        let proposed_block = maybe_signed_vote_proposal.vote_proposal.block();
+        let mut safety_data = self.persistent_storage.safety_data()?;
+
+        // if already voted on this round, send back the previous vote
+        // note: this needs to happen after verifying the epoch as we just check the round here
+        if let Some(vote) = safety_data.last_vote.clone() {
+            if vote.vote_data().proposed().round() == proposed_block.round() {
+                return Ok(vote);
+            }
+        }
+
+        // Two voting rules
+        self.verify_and_update_last_vote_round(
+            proposed_block.block_data().round(),
+            &mut safety_data,
+        )?;
+        self.safe_to_vote(proposed_block, timeout_cert)?;
+
+        // Record 1-chain data
+        self.observe_qc(proposed_block.quorum_cert(), &mut safety_data);
+        // Construct and sign vote
+        let author = self.signer()?.author();
+        let ledger_info = self.construct_ledger_info_2chain(proposed_block, vote_data.hash())?;
+        let signature = self.sign(&ledger_info)?;
+        let vote = Vote::new_with_signature(vote_data, author, ledger_info, signature);
+
+        safety_data.last_vote = Some(vote.clone());
+        self.persistent_storage.set_safety_data(safety_data)?;
+
+        Ok(vote)
+    }
+
+    /// Core safety timeout rule for 2-chain protocol. Return success if 1 and 2 are true
+    /// 1. round == timeout.qc.round + 1 || round == tc.round + 1
+    /// 2. timeout.qc.round >= one_chain_round
+    fn safe_to_timeout(
+        &self,
+        timeout: &TwoChainTimeout,
+        maybe_tc: Option<&TwoChainTimeoutCertificate>,
+        safety_data: &SafetyData,
+    ) -> Result<(), Error> {
+        let round = timeout.round();
+        let qc_round = timeout.hqc_round();
+        let tc_round = maybe_tc.map_or(0, |tc| tc.round());
+        if (round == next_round(qc_round)? || round == next_round(tc_round)?)
+            && qc_round >= safety_data.one_chain_round
+        {
+            Ok(())
+        } else {
+            Err(Error::NotSafeToTimeout(
+                round,
+                qc_round,
+                tc_round,
+                safety_data.one_chain_round,
+            ))
+        }
+    }
+
+    /// Core safety voting rule for 2-chain protocol. Return success if 1 or 2 is true
+    /// 1. block.round == block.qc.round + 1
+    /// 2. block.round == tc.round + 1 && block.qc.round >= tc.highest_hqc.round
+    fn safe_to_vote(
+        &self,
+        block: &Block,
+        maybe_tc: Option<&TwoChainTimeoutCertificate>,
+    ) -> Result<(), Error> {
+        let round = block.round();
+        let qc_round = block.quorum_cert().certified_block().round();
+        let tc_round = maybe_tc.map_or(0, |tc| tc.round());
+        let hqc_round = maybe_tc.map_or(0, |tc| tc.highest_hqc_round());
+        if round == next_round(qc_round)?
+            || (round == next_round(tc_round)? && qc_round >= hqc_round)
+        {
+            Ok(())
+        } else {
+            Err(Error::NotSafeToVote(round, qc_round, tc_round, hqc_round))
+        }
+    }
+
+    fn verify_tc(&self, tc: &TwoChainTimeoutCertificate) -> Result<(), Error> {
+        let epoch_state = self.epoch_state()?;
+
+        tc.verify(&epoch_state.verifier)
+            .map_err(|e| Error::InvalidTimeoutCertificate(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Produces a LedgerInfo that either commits a block based upon the 2-chain
+    /// commit rule or an empty LedgerInfo for no commit. The 2-chain commit rule is: B0 and its
+    /// prefixes can be committed if there exist certified block B1 that satisfy:
+    /// 1) B0 <- B1 <--
+    /// 2) round(B0) + 1 = round(B1)
+    fn construct_ledger_info_2chain(
+        &self,
+        proposed_block: &Block,
+        consensus_data_hash: HashValue,
+    ) -> Result<LedgerInfo, Error> {
+        let block1 = proposed_block.round();
+        let block0 = proposed_block.quorum_cert().certified_block().round();
+
+        // verify 2-chain rule
+        let commit = next_round(block0)? == block1;
+
+        // create a ledger info
+        let commit_info = if commit {
+            proposed_block.quorum_cert().certified_block().clone()
+        } else {
+            BlockInfo::empty()
+        };
+
+        Ok(LedgerInfo::new(commit_info, consensus_data_hash))
+    }
+}

--- a/consensus/safety-rules/src/t_safety_rules.rs
+++ b/consensus/safety-rules/src/t_safety_rules.rs
@@ -3,7 +3,11 @@
 
 use crate::{ConsensusState, Error};
 use consensus_types::{
-    block::Block, block_data::BlockData, timeout::Timeout, vote::Vote,
+    block::Block,
+    block_data::BlockData,
+    timeout::Timeout,
+    timeout_2chain::{TwoChainTimeout, TwoChainTimeoutCertificate},
+    vote::Vote,
     vote_proposal::MaybeSignedVoteProposal,
 };
 use diem_crypto::ed25519::Ed25519Signature;
@@ -34,4 +38,22 @@ pub trait TSafetyRules {
     /// As the holder of the private key, SafetyRules also signs what is effectively a
     /// timeout message. This returns the signature for that timeout message.
     fn sign_timeout(&mut self, timeout: &Timeout) -> Result<Ed25519Signature, Error>;
+
+    /// Sign the timeout together with highest qc for 2-chain protocol.
+    fn sign_timeout_with_qc(
+        &mut self,
+        _timeout: &TwoChainTimeout,
+        _timeout_cert: Option<&TwoChainTimeoutCertificate>,
+    ) -> Result<Ed25519Signature, Error> {
+        unimplemented!();
+    }
+
+    /// Sign the vote with 2-chain protocol.
+    fn construct_and_sign_vote_two_chain(
+        &mut self,
+        _vote_proposal: &MaybeSignedVoteProposal,
+        _timeout_cert: Option<&TwoChainTimeoutCertificate>,
+    ) -> Result<Vote, Error> {
+        unimplemented!();
+    }
 }

--- a/consensus/safety-rules/src/test_utils.rs
+++ b/consensus/safety-rules/src/test_utils.rs
@@ -10,6 +10,7 @@ use consensus_types::{
     common::{Payload, Round},
     quorum_cert::QuorumCert,
     timeout::Timeout,
+    timeout_2chain::{TwoChainTimeout, TwoChainTimeoutCertificate},
     vote::Vote,
     vote_data::VoteData,
     vote_proposal::{MaybeSignedVoteProposal, VoteProposal},
@@ -20,7 +21,6 @@ use diem_crypto::{
     traits::SigningKey,
     Uniform,
 };
-use diem_infallible::duration_since_epoch;
 use diem_secure_storage::{InMemoryStorage, Storage};
 use diem_types::{
     block_info::BlockInfo,
@@ -66,7 +66,7 @@ pub fn make_proposal_with_qc_and_proof(
         Block::new_proposal(
             payload,
             round,
-            duration_since_epoch().as_secs(),
+            qc.certified_block().timestamp_usecs() + 1,
             qc,
             validator_signer,
         ),
@@ -126,7 +126,7 @@ pub fn make_proposal_with_parent_and_overrides(
         parent.block().id(),
         parent_output.root_hash(),
         parent_output.version(),
-        parent.block().timestamp_usecs(),
+        parent.block().timestamp_usecs() + 1,
         None,
     );
 
@@ -196,6 +196,18 @@ pub fn make_proposal_with_parent(
         None,
         exec_key,
     )
+}
+
+pub fn make_timeout_cert(
+    round: Round,
+    hqc: &QuorumCert,
+    signer: &ValidatorSigner,
+) -> TwoChainTimeoutCertificate {
+    let timeout = TwoChainTimeout::new(1, round, hqc.clone());
+    let mut tc = TwoChainTimeoutCertificate::new(timeout.clone());
+    let signature = timeout.sign(&signer);
+    tc.add(signer.author(), timeout, signature);
+    tc
 }
 
 pub fn validator_signers_to_ledger_info(signers: &[&ValidatorSigner]) -> LedgerInfo {

--- a/testsuite/cluster-test/src/cluster_builder.rs
+++ b/testsuite/cluster-test/src/cluster_builder.rs
@@ -408,7 +408,7 @@ impl ClusterBuilder {
                     .map_err(|e| format_err!("Failed to create {}__{} : {}", pod_name, key, e))?;
             }
             vault_storage
-                .set(SAFETY_DATA, SafetyData::new(0, 0, 0, None))
+                .set(SAFETY_DATA, SafetyData::new(0, 0, 0, 0, None))
                 .map_err(|e| format_err!("Failed to create {}/{}: {}", pod_name, SAFETY_DATA, e))?;
             vault_storage
                 .set(WAYPOINT, Waypoint::default())


### PR DESCRIPTION
Add 2chain related Timeout structure which carries the highest quorum cert. Test added for verification.

Implement corresponding safety rules in safety_rules_2chain and add tests.

Remaining work:
- Add new Timeout in Vote
- Add new TimeoutCert in SyncInfo
- Add gated codepath for using 2-chain protocol
- Add on-chain config to switch the protocol

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Add 2chain related Timeout structure which carries the highest quorum cert. Test added for verification.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

Added tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update or suggest changes to the docs at https://developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
