### PR TITLE
[gha] in case diem/logger coverage drops this will alert the author who can lower coverage restrictions.

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -126,7 +126,7 @@ jobs:
         name: check if we should see if code coverage still works.
         uses: diem/actions/matches@78f868bd1170a959f0a9864e33df725690b45b9a
         with:
-          pattern: '^rust.toolchain\|^x.toml\|^devtools\|^.github\'
+          pattern: '^rust.toolchain\|^x.toml\|^devtools\|^.github\|common/logger'
 
   dev-setup-sh-test:
     runs-on: ubuntu-latest-xl


### PR DESCRIPTION
## Motivation

Ensure the canary to determine if coverage has broken is due to tooling changes or a legitimate drop in coverage in commons/logger so we'll always build for common/logger as well.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

CI

## Related PRs

None

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
