### PR TITLE
[account universe] Update keygen for invalid auth key txns

### DIFF
--- a/language/testing-infra/e2e-tests/src/account_universe/bad_transaction.rs
+++ b/language/testing-infra/e2e-tests/src/account_universe/bad_transaction.rs
@@ -7,7 +7,7 @@ use crate::{
     gas_costs,
 };
 use diem_crypto::{
-    ed25519::{self, Ed25519PrivateKey, Ed25519PublicKey},
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
     test_utils::KeyPair,
 };
 use diem_proptest_helpers::Index;
@@ -134,7 +134,9 @@ impl AUTransactionGen for InsufficientBalanceGen {
 #[proptest(no_params)]
 pub struct InvalidAuthkeyGen {
     sender: Index,
-    #[proptest(strategy = "ed25519::keypair_strategy()")]
+    #[proptest(
+        strategy = "diem_crypto::test_utils::uniform_keypair_strategy_with_perturbation(1)"
+    )]
     new_keypair: KeyPair<Ed25519PrivateKey, Ed25519PublicKey>,
 }
 

--- a/language/testing-infra/e2e-tests/src/account_universe/rotate_key.rs
+++ b/language/testing-infra/e2e-tests/src/account_universe/rotate_key.rs
@@ -7,7 +7,7 @@ use crate::{
     gas_costs,
 };
 use diem_crypto::{
-    ed25519::{self, Ed25519PrivateKey, Ed25519PublicKey},
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
     test_utils::KeyPair,
 };
 use diem_proptest_helpers::Index;
@@ -23,7 +23,9 @@ use proptest_derive::Arbitrary;
 #[proptest(no_params)]
 pub struct RotateKeyGen {
     sender: Index,
-    #[proptest(strategy = "ed25519::keypair_strategy()")]
+    #[proptest(
+        strategy = "diem_crypto::test_utils::uniform_keypair_strategy_with_perturbation(0)"
+    )]
     new_keypair: KeyPair<Ed25519PrivateKey, Ed25519PublicKey>,
 }
 

--- a/language/testing-infra/e2e-tests/src/common_transactions.rs
+++ b/language/testing-infra/e2e-tests/src/common_transactions.rs
@@ -57,7 +57,7 @@ pub static CREATE_ACCOUNT_SCRIPT: Lazy<Vec<u8>> = Lazy::new(|| {
 
 pub static EMPTY_SCRIPT: Lazy<Vec<u8>> = Lazy::new(|| {
     let code = "
-    main<Token>(account: signer) {
+    main(account: signer) {
       return;
     }
 ";


### PR DESCRIPTION
This updates the keygen generation for invalid auth key and key rotation transactions. Previously they would use the same deterministic seed which could lead to issues where in a previous transaction the account will have rotated to one key, and then the invalid auth key generation will generate that same key and assume that it is invalid.

This also fixes an issue where we weren't passing a type argument to the `EMPTY_SCRIPT` transaction even though it had a type argument. 

### Testing

Tested against failing fuzz result and all tests passed. 