### PR TITLE
[move-vm] allow multi-module publication

### DIFF
--- a/language/move-core/types/src/vm_status.rs
+++ b/language/move-core/types/src/vm_status.rs
@@ -552,8 +552,7 @@ pub enum StatusCode {
     GENERIC_MEMBER_OPCODE_MISMATCH = 1090,
     FUNCTION_RESOLUTION_FAILURE = 1091,
     INVALID_OPERATION_IN_SCRIPT = 1094,
-    // The sender is trying to publish a module named `M`, but the sender's account already
-    // contains a module with this name.
+    // The sender is trying to publish two modules with the same name in one transaction
     DUPLICATE_MODULE_NAME = 1095,
     // The sender is trying to publish a module that breaks the compatibility checks
     BACKWARD_INCOMPATIBLE_MODULE_UPDATE = 1096,

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -25,6 +25,7 @@ use move_core_types::{
 use move_vm_types::{
     data_store::DataStore, gas_schedule::GasStatus, loaded_data::runtime_types::Type, values::Value,
 };
+use std::collections::BTreeSet;
 use tracing::warn;
 
 /// An instantiation of the MoveVM.
@@ -57,64 +58,134 @@ impl VMRuntime {
         }
     }
 
-    // See Session::publish_module for what contracts to follow.
-    pub(crate) fn publish_module(
+    pub(crate) fn publish_module_bundle(
         &self,
-        module: Vec<u8>,
+        modules: Vec<Vec<u8>>,
         sender: AccountAddress,
         data_store: &mut impl DataStore,
         _gas_status: &mut GasStatus,
     ) -> VMResult<()> {
-        // deserialize the module. Perform bounds check. After this indexes can be
+        // deserialize the modules. Perform bounds check. After this indexes can be
         // used with the `[]` operator
-        let compiled_module = match CompiledModule::deserialize(&module) {
-            Ok(module) => module,
+        let compiled_modules = match modules
+            .iter()
+            .map(|blob| CompiledModule::deserialize(blob))
+            .collect::<PartialVMResult<Vec<_>>>()
+        {
+            Ok(modules) => modules,
             Err(err) => {
                 warn!("[VM] module deserialization failed {:?}", err);
                 return Err(err.finish(Location::Undefined));
             }
         };
 
-        // Make sure the module's self address matches the transaction sender. The self address is
+        // Make sure all modules' self addresses matches the transaction sender. The self address is
         // where the module will actually be published. If we did not check this, the sender could
         // publish a module under anyone's account.
-        if compiled_module.address() != &sender {
-            return Err(verification_error(
-                StatusCode::MODULE_ADDRESS_DOES_NOT_MATCH_SENDER,
-                IndexKind::AddressIdentifier,
-                compiled_module.self_handle_idx().0,
-            )
-            .finish(Location::Undefined));
+        for module in &compiled_modules {
+            if module.address() != &sender {
+                return Err(verification_error(
+                    StatusCode::MODULE_ADDRESS_DOES_NOT_MATCH_SENDER,
+                    IndexKind::AddressIdentifier,
+                    module.self_handle_idx().0,
+                )
+                .finish(Location::Undefined));
+            }
         }
 
-        let module_id = compiled_module.self_id();
+        // Collect ids for modules that are published together
+        let mut bundle_unverified = BTreeSet::new();
 
         // For now, we assume that all modules can be republished, as long as the new module is
         // backward compatible with the old module.
         //
         // TODO: in the future, we may want to add restrictions on module republishing, possibly by
         // changing the bytecode format to include an `is_upgradable` flag in the CompiledModule.
-        if data_store.exists_module(&module_id)? {
-            let old_module_ref = self
-                .loader
-                .load_module_expect_not_missing(&module_id, data_store)?;
-            let old_module = old_module_ref.module();
-            let old_m = normalized::Module::new(old_module);
-            let new_m = normalized::Module::new(&compiled_module);
-            let compat = Compatibility::check(&old_m, &new_m);
-            if !compat.is_fully_compatible() {
-                return Err(
-                    PartialVMError::new(StatusCode::BACKWARD_INCOMPATIBLE_MODULE_UPDATE)
-                        .finish(Location::Undefined),
-                );
+        for module in &compiled_modules {
+            let module_id = module.self_id();
+            if data_store.exists_module(&module_id)? {
+                let old_module_ref = self
+                    .loader
+                    .load_module_expect_not_missing(&module_id, data_store)?;
+                let old_module = old_module_ref.module();
+                let old_m = normalized::Module::new(old_module);
+                let new_m = normalized::Module::new(&module);
+                let compat = Compatibility::check(&old_m, &new_m);
+                if !compat.is_fully_compatible() {
+                    return Err(PartialVMError::new(
+                        StatusCode::BACKWARD_INCOMPATIBLE_MODULE_UPDATE,
+                    )
+                    .finish(Location::Undefined));
+                }
+            }
+            if !bundle_unverified.insert(module_id) {
+                return Err(PartialVMError::new(StatusCode::DUPLICATE_MODULE_NAME)
+                    .finish(Location::Undefined));
             }
         }
 
-        // perform bytecode and loading verification
+        // Perform bytecode and loading verification. Modules must be sorted in topological order.
         self.loader
-            .verify_module_for_publication(&compiled_module, data_store)?;
+            .verify_module_bundle_for_publication(&compiled_modules, data_store)?;
 
-        data_store.publish_module(&module_id, module)
+        // NOTE: we want to (informally) argue that all modules pass the linking check before being
+        // published to the data store.
+        //
+        // The linking check consists of two checks actually
+        // - dependencies::verify_module(module, all_imm_deps)
+        // - cyclic_dependencies::verify_module(module, fn_imm_deps, fn_imm_friends)
+        //
+        // [Claim 1]
+        // We show that the `dependencies::verify_module` check is always satisfied whenever a
+        // module M is published or updated and the `all_imm_deps` contains the actual modules
+        // required by M.
+        //
+        // Suppose M depends on D, and we now consider the following scenarios:
+        // 1) D does not appear in the bundle together with M
+        // -- In this case, D must be either in the code cache or in the data store which can be
+        //    loaded into the code cache (and pass all checks on D).
+        //    - If D is missing, the linking will fail and return an error.
+        //    - If D exists, D will be added to the `all_imm_deps` arg when checking M.
+        //
+        // 2) D appears in the bundle *before* M
+        // -- In this case, regardless of whether D is in code cache or not, D will be put into the
+        //    `bundle_verified` argument and modules in `bundle_verified` will be prioritized before
+        //    returning a module in code cache.
+        //
+        // 3) D appears in the bundle *after* M
+        // -- This technically should be discouraged but this is user input so we cannot have this
+        //    assumption here. But nevertheless, we can still make the claim 1 even in this case.
+        //    When M is verified, flow 1) is effectively activated, which means:
+        //    - If the code cache or the data store does not contain a D' which has the same name
+        //      with D, then the linking will fail and return an error.
+        //    - If D' exists, and M links against D', then when verifying D in a later time point,
+        //      a compatibility check will be invoked to ensure that D is compatible with D',
+        //      meaning, whichever module that links against D' will have to link against D as well.
+        //
+        // [Claim 2]
+        // We show that the `cyclic_dependencies::verify_module` check is always satisfied whenever
+        // a module M is published or updated and the dep/friend modules returned by the transitive
+        // dependency closure functions are valid.
+        //
+        // Currently, the code is written in a way that, from the view point of the
+        // `cyclic_dependencies::verify_module` check, modules checked prior to module M in the same
+        // bundle looks as if they have already been published and loaded to the code cache.
+        //
+        // Therefore, if M forms a cyclic dependency with module A in the same bundle that is
+        // checked prior to M, such an error will be detected. However, if M forms a cyclic
+        // dependency with a module X that appears in the same bundle *after* M. The cyclic
+        // dependency can only be caught when X is verified.
+        //
+        // In summary: the code is written in a way that, certain checks are skipped while checking
+        // each individual module in the bundle in order. But if every module in the bundle pass
+        // all the checks, then the whole bundle can be published/upgraded together. Otherwise,
+        // none of the module can be published/updated.
+
+        // All modules verified, publish them to data cache
+        for (module, blob) in compiled_modules.into_iter().zip(modules.into_iter()) {
+            data_store.publish_module(&module.self_id(), blob)?;
+        }
+        Ok(())
     }
 
     fn deserialize_args(

--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -133,7 +133,7 @@ impl<'r, 'l, S: MoveStorage> Session<'r, 'l, S> {
 
     /// Publish the given module.
     ///
-    /// The Move VM MUST return a user error (in other words, an error that's not an invariant violation) if
+    /// The Move VM MUST return a user error, i.e., an error that's not an invariant violation, if
     ///   - The module fails to deserialize or verify.
     ///   - The sender address does not match that of the module.
     ///   - (Republishing-only) the module to be updated is not backward compatible with the old module.
@@ -142,16 +142,37 @@ impl<'r, 'l, S: MoveStorage> Session<'r, 'l, S> {
     /// The Move VM should not be able to produce other user errors.
     /// Besides, no user input should cause the Move VM to return an invariant violation.
     ///
-    /// In case an invariant violation occurs, the whole Session should be considered corrupted and one shall
-    /// not proceed with effect generation.
+    /// In case an invariant violation occurs, the whole Session should be considered corrupted and
+    /// one shall not proceed with effect generation.
     pub fn publish_module(
         &mut self,
         module: Vec<u8>,
         sender: AccountAddress,
         gas_status: &mut GasStatus,
     ) -> VMResult<()> {
+        self.publish_module_bundle(vec![module], sender, gas_status)
+    }
+
+    /// Publish a series of modules.
+    ///
+    /// The Move VM MUST return a user error, i.e., an error that's not an invariant violation, if
+    /// any module fails to deserialize or verify (see the full list of  failing conditions in the
+    /// `publish_module` API). The publishing of the module series is an all-or-nothing action:
+    /// either all modules are published to the data store or none is.
+    ///
+    /// Similar to the `publish_module` API, the Move VM should not be able to produce other user
+    /// errors. Besides, no user input should cause the Move VM to return an invariant violation.
+    ///
+    /// In case an invariant violation occurs, the whole Session should be considered corrupted and
+    /// one shall not proceed with effect generation.
+    pub fn publish_module_bundle(
+        &mut self,
+        modules: Vec<Vec<u8>>,
+        sender: AccountAddress,
+        gas_status: &mut GasStatus,
+    ) -> VMResult<()> {
         self.runtime
-            .publish_module(module, sender, &mut self.data_cache, gas_status)
+            .publish_module_bundle(modules, sender, &mut self.data_cache, gas_status)
     }
 
     pub fn num_mutated_accounts(&self, sender: &AccountAddress) -> u64 {

--- a/language/tools/move-cli/src/lib.rs
+++ b/language/tools/move-cli/src/lib.rs
@@ -115,6 +115,9 @@ pub enum SandboxCommand {
         /// Set this flag to ignore breaking changes checks and publish anyway
         #[structopt(long = "ignore-breaking-changes")]
         ignore_breaking_changes: bool,
+        /// fix publishing order
+        #[structopt(short = "m", long = "override-ordering")]
+        override_ordering: Option<Vec<String>>,
     },
     /// Compile/run a Move script that reads/writes resources stored on disk in `storage`.
     /// This command compiles the script first before running it.
@@ -265,6 +268,7 @@ fn handle_sandbox_commands(
             source_files,
             no_republish,
             ignore_breaking_changes,
+            override_ordering,
         } => {
             let state = mode.prepare_state(&move_args.build_dir, &move_args.storage_dir)?;
             sandbox::commands::publish(
@@ -273,6 +277,7 @@ fn handle_sandbox_commands(
                 source_files,
                 !*no_republish,
                 *ignore_breaking_changes,
+                override_ordering.as_ref().map(|o| o.as_slice()),
                 move_args.verbose,
             )
         }

--- a/language/tools/move-cli/tests/testsuite/multi_module_publish/args.exp
+++ b/language/tools/move-cli/tests/testsuite/multi_module_publish/args.exp
@@ -1,0 +1,47 @@
+Command `sandbox publish src/GoodFriends.move -m A -v`:
+Compiling Move modules...
+Found and compiled 2 modules
+Invalid multi-module publishing: VMError with status LINKER_ERROR at location UNDEFINED and message Cannot find ModuleId { address: 00000000000000000000000000000002, name: Identifier("B") } in data cache
+Command `sandbox publish src/GoodFriends.move -m B -v`:
+Compiling Move modules...
+Found and compiled 2 modules
+Invalid multi-module publishing: VMError with status LINKER_ERROR at location UNDEFINED and message Cannot find ModuleId { address: 00000000000000000000000000000002, name: Identifier("A") } in data cache
+Command `sandbox publish src/GoodFriends.move -m B -m A -v`:
+Compiling Move modules...
+Found and compiled 2 modules
+Invalid multi-module publishing: VMError with status LINKER_ERROR at location UNDEFINED and message Cannot find ModuleId { address: 00000000000000000000000000000002, name: Identifier("A") } in data cache
+Command `sandbox publish src/GoodFriends.move -m A -m B -v`:
+Compiling Move modules...
+Found and compiled 2 modules
+Publishing a new module 00000000000000000000000000000002::A (wrote 89 bytes)
+Publishing a new module 00000000000000000000000000000002::B (wrote 97 bytes)
+Wrote 186 bytes of module ID's and code
+Command `sandbox view storage/0x00000000000000000000000000000002/modules/A.mv`:
+// Move bytecode v3
+module 2.A {
+
+
+public(friend) foo() {
+	0: Ret
+}
+}
+Command `sandbox view storage/0x00000000000000000000000000000002/modules/B.mv`:
+// Move bytecode v3
+module 2.B {
+
+
+bar() {
+	0: Call[1](foo())
+	1: Ret
+}
+}
+Command `sandbox publish src/CyclicFriendsPart1.move -m A -m B -v`:
+Compiling Move modules...
+Found and compiled 2 modules
+Publishing a new module 00000000000000000000000000000003::A (wrote 82 bytes)
+Publishing a new module 00000000000000000000000000000003::B (wrote 93 bytes)
+Wrote 175 bytes of module ID's and code
+Command `sandbox publish src/CyclicFriendsPart2.move -m A -m C -v`:
+Compiling Move modules...
+Found and compiled 2 modules
+Invalid multi-module publishing: VMError with status INVALID_FRIEND_DECL_WITH_MODULES_IN_DEPENDENCIES at location Module ModuleId { address: 00000000000000000000000000000003, name: Identifier("C") } and message At least one module, 00000000000000000000000000000003::A, appears in both the dependency set and the friend set

--- a/language/tools/move-cli/tests/testsuite/multi_module_publish/args.txt
+++ b/language/tools/move-cli/tests/testsuite/multi_module_publish/args.txt
@@ -1,0 +1,22 @@
+# expect failure as A friends B and B is missing in the bundle
+sandbox publish src/GoodFriends.move -m A -v
+
+# expect failure as B depends on A and A is missing in the bundle
+sandbox publish src/GoodFriends.move -m B -v
+
+# expect failure as B depends on A but A appears after B in the bundle
+sandbox publish src/GoodFriends.move -m B -m A -v
+
+# expect success: this is the correct order of publishing A and B
+# with friend relationship
+sandbox publish src/GoodFriends.move -m A -m B -v
+sandbox view storage/0x00000000000000000000000000000002/modules/A.mv
+sandbox view storage/0x00000000000000000000000000000002/modules/B.mv
+
+# expect success in first step and failure in the sescond step
+# After step 1: A, B are published and B depends on A
+# After step 2:
+#  A is updated to A', B depends on A', C depends on B, C friends A'
+#  A cyclic dependency is found in A' <- B <- C <- A'
+sandbox publish src/CyclicFriendsPart1.move -m A -m B -v
+sandbox publish src/CyclicFriendsPart2.move -m A -m C -v

--- a/language/tools/move-cli/tests/testsuite/multi_module_publish/src/CyclicFriendsPart1.move
+++ b/language/tools/move-cli/tests/testsuite/multi_module_publish/src/CyclicFriendsPart1.move
@@ -1,0 +1,7 @@
+module 0x3::A {
+    public fun foo() {}
+}
+
+module 0x3::B {
+    public fun foo() { 0x3::A::foo() }
+}

--- a/language/tools/move-cli/tests/testsuite/multi_module_publish/src/CyclicFriendsPart2.move
+++ b/language/tools/move-cli/tests/testsuite/multi_module_publish/src/CyclicFriendsPart2.move
@@ -1,0 +1,9 @@
+module 0x3::A {
+    public fun foo() {}
+    public fun bar() {}
+}
+
+module 0x3::C {
+    friend 0x3::A;
+    public fun foo() { 0x3::B::foo() }
+}

--- a/language/tools/move-cli/tests/testsuite/multi_module_publish/src/GoodFriends.move
+++ b/language/tools/move-cli/tests/testsuite/multi_module_publish/src/GoodFriends.move
@@ -1,0 +1,8 @@
+module 0x2::A {
+    friend 0x2::B;
+    public(friend) fun foo() {}
+}
+
+module 0x2::B {
+    fun bar() { 0x2::A::foo() }
+}


### PR DESCRIPTION
**The first commit updates the Move VM API**
This commit allows the Move VM to take a vector of modules (for lacking
of a better name, this vector of modules is called a bundle for now) and
publish them together.

Modules in the bundle vector must follow a topological order, i.e., if
there is a dependency relation (usage or friend) between two modules
A and B, via either 1) B uses A or 2) A declares B as a friend. Then,
A must appear before B in the bundle vector in order to be published
together. Putting B in front of A in this case will lead to a
MISSING_DEPENDENCY error or other linker errors.

All modules in the bundle will have to pass the bytecode verifier and
will be linker-checked with existing modules and all other modules in
the same bundle. Either all modules in the bundle are published/updated
or none is published/updated. Publication of the whole bundle fails as
long as one module in the bundle fail the bytecode verifier or the
linker checks (i.e., dependency and cyclic dependency check).

There is also a very informal argument in the code comments on why
the current implementation might seem plausible. Please check that
as well. I am hoping to come up with a much stronger argument (or
even paper proof) why this is correct, but I haven't reached there yet.

**The second commit adds support for multi-module publishing the Move CLI**
The `move-cli sandbox publish` command now accepts a new optional
command line argument -m/--override-ordering that allows manual
specification of which compiled modules to be published and in what
order.

Specifying any of the `-m/--override-ordering` flag will invoke the
multi-module publishing flow in the Move VM (compared with the
traditional one-module-at-a-time flow).

For example: `sandbox publish -m A -m B` will prepare a module vector
[A, B] to be sent for publication while `-m B -m A` will create a vector
[B, A]. And depending on the relationship between module A and B, it is
possible that only one particular ordering can be allowed. For more
detailed use cases, see the test case `multi_module_publish`.

It is possible to request publication of a subset of the compiled modules. For
example, if three modules A, B, C are compiled and only `-m A -m B` is
specified, then only A and B will be sent to Move VM for publication.

It is also possible to specify one module multiple times, e.g.,
`-m A -m A`. The Move CLI will not complain about it but the Move VM
will as it checks for no duplication in the vector of modules.

It is, however, not possible to specify a non-compiled module (e.g.,
module D which is not compiled) for publication. An error will be raised
in this case.

## Motivation

Partially address #8512 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI for existing code
new test cases being added to Move CLI, under `multi_module_publish` dir.
