### PR TITLE
[move-vm] use tracing for logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2022,6 +2022,8 @@ dependencies = [
  "prometheus",
  "serde",
  "serde_json",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2541,6 +2543,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]
@@ -2609,6 +2612,7 @@ dependencies = [
  "rand 0.8.3",
  "rand_core 0.5.1",
  "regex",
+ "regex-automata",
  "regex-syntax",
  "reqwest",
  "rusty-fork",
@@ -2624,6 +2628,7 @@ dependencies = [
  "tokio-util",
  "toml",
  "tracing",
+ "tracing-core",
  "warp",
  "zeroize",
 ]
@@ -4260,6 +4265,7 @@ dependencies = [
  "diem-crypto",
  "diem-framework-releases",
  "diem-logger",
+ "diem-state-view",
  "diem-transaction-builder",
  "diem-types",
  "diem-vm",
@@ -4370,6 +4376,15 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "matches"
@@ -4851,7 +4866,6 @@ dependencies = [
  "anyhow",
  "bytecode-verifier",
  "compiler",
- "diem-logger",
  "diem-workspace-hack",
  "fail",
  "hex",
@@ -4864,6 +4878,7 @@ dependencies = [
  "parking_lot",
  "proptest",
  "sha3",
+ "tracing",
 ]
 
 [[package]]
@@ -6172,6 +6187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
 dependencies = [
  "byteorder",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -6965,6 +6981,15 @@ dependencies = [
  "digest 0.9.0",
  "keccak",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -7906,9 +7931,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
+checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -7919,9 +7944,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a9bd1db7706f2373a190b0d067146caa39350c486f3d455b0e33b431f94c07"
+checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
@@ -7930,9 +7955,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
 dependencies = [
  "lazy_static",
 ]
@@ -7945,6 +7970,49 @@ checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
  "pin-project",
  "tracing",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa5553bf0883ba7c9cbe493b085c29926bd41b66afc31ff72cf17ff4fb60dcd5"
+dependencies = [
+ "ansi_term 0.12.1",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/common/logger/Cargo.toml
+++ b/common/logger/Cargo.toml
@@ -23,3 +23,5 @@ once_cell = "1.7.2"
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
 prometheus = { version = "0.12.0", default-features = false }
+tracing = "0.1.26"
+tracing-subscriber = "0.2.18"

--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -153,6 +153,7 @@ mod logger;
 mod macros;
 mod metadata;
 pub mod sample;
+pub mod tracing_adapter;
 
 mod security;
 mod struct_log;

--- a/common/logger/src/logger.rs
+++ b/common/logger/src/logger.rs
@@ -7,6 +7,7 @@ use crate::{counters::STRUCT_LOG_COUNT, Event, Metadata};
 
 use once_cell::sync::OnceCell;
 use std::sync::Arc;
+use tracing_subscriber::Layer;
 
 /// The global `Logger`
 static LOGGER: OnceCell<Arc<dyn Logger>> = OnceCell::new();
@@ -44,6 +45,10 @@ pub fn set_global_logger(logger: Arc<dyn Logger>) {
     if LOGGER.set(logger).is_err() {
         eprintln!("Global logger has already been set");
     }
+    let _ = tracing::subscriber::set_global_default(
+        crate::tracing_adapter::TracingToDiemLoggerLayer
+            .with_subscriber(tracing_subscriber::Registry::default()),
+    );
 }
 
 /// Flush the global `Logger`

--- a/common/logger/src/tracing_adapter.rs
+++ b/common/logger/src/tracing_adapter.rs
@@ -1,0 +1,84 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate as dl;
+use std::fmt;
+use tracing as tr;
+use tracing_subscriber::{layer::Context, Layer};
+
+/// A layer that translates tracing events into diem-logger events.
+pub struct TracingToDiemLoggerLayer;
+
+fn translate_level(level: &tr::Level) -> Option<dl::Level> {
+    if *level == tr::Level::ERROR {
+        return Some(dl::Level::Error);
+    }
+    if *level == tr::Level::INFO {
+        return Some(dl::Level::Info);
+    }
+    if *level == tr::Level::DEBUG {
+        return Some(dl::Level::Debug);
+    }
+    if *level == tr::Level::TRACE {
+        return Some(dl::Level::Trace);
+    }
+    if *level == tr::Level::WARN {
+        return Some(dl::Level::Warn);
+    }
+    None
+}
+
+fn translate_metadata(metadata: &tr::Metadata<'static>) -> Option<dl::Metadata> {
+    let level = translate_level(metadata.level())?;
+
+    Some(dl::Metadata::new(
+        level,
+        metadata.target(),
+        metadata.module_path().unwrap_or(""),
+        metadata.file().unwrap_or(""),
+        metadata.line().unwrap_or(0),
+        "",
+    ))
+}
+
+struct KeyValueVisitorAdapter<'a> {
+    visitor: &'a mut dyn dl::Visitor,
+}
+
+impl<'a> tr::field::Visit for KeyValueVisitorAdapter<'a> {
+    fn record_debug(&mut self, field: &tr::field::Field, value: &dyn fmt::Debug) {
+        self.visitor
+            .visit_pair(dl::Key::new(field.name()), dl::Value::Debug(value))
+    }
+}
+
+struct EventKeyValueAdapter<'a, 'b> {
+    event: &'a tr::Event<'b>,
+}
+
+impl<'a, 'b> dl::Schema for EventKeyValueAdapter<'a, 'b> {
+    fn visit(&self, visitor: &mut dyn dl::Visitor) {
+        self.event.record(&mut KeyValueVisitorAdapter { visitor })
+    }
+}
+
+impl<S: tr::Subscriber> Layer<S> for TracingToDiemLoggerLayer {
+    fn on_event(&self, event: &tr::Event, _ctx: Context<S>) {
+        let metadata = match translate_metadata(event.metadata()) {
+            Some(metadata) => metadata,
+            None => {
+                dl::warn!(
+                    "[tracing-to-diem-logger] failed to translate event due to unknown level {:?}",
+                    event.metadata().level()
+                );
+                return;
+            }
+        };
+
+        // `tracing::Event` contains an implicit field named "message".
+        // However I couldn't figure out a way to convert it to `fmt::Arguments` due to lifetime issues.
+        // Therefore I'm omitting message argument to `Event::dispatch`.
+        // This should generally be fine since the message will be translated as a normal record.
+        dl::Event::dispatch(&metadata, None, &[&EventKeyValueAdapter { event }]);
+    }
+}

--- a/common/logger/tests/tracing_translation_tests.rs
+++ b/common/logger/tests/tracing_translation_tests.rs
@@ -1,0 +1,47 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use diem_infallible::RwLock;
+use diem_logger::{DiemLogger, Writer};
+use std::sync::Arc;
+
+#[derive(Default)]
+struct VecWriter {
+    logs: Arc<RwLock<Vec<String>>>,
+}
+
+impl Writer for VecWriter {
+    fn write(&self, log: String) {
+        self.logs.write().push(log)
+    }
+}
+
+#[test]
+fn verify_tracing_kvs() {
+    // set up the diem logger
+    let writer = VecWriter::default();
+    let logs = writer.logs.clone();
+    DiemLogger::builder()
+        .is_async(false)
+        .printer(Box::new(writer))
+        .build();
+
+    assert_eq!(logs.read().len(), 0);
+
+    // log some messages
+    tracing::error!("hello world");
+    let s = logs.write().pop().unwrap();
+    assert!(s.contains("ERROR"));
+    assert!(s.contains("hello world"));
+
+    tracing::info!("foo {} bar", 42);
+    let s = logs.write().pop().unwrap();
+    assert!(s.contains("INFO"));
+    assert!(s.contains("foo 42 bar"));
+
+    tracing::warn!(a = true, b = false);
+    let s = logs.write().pop().unwrap();
+    assert!(s.contains("WARN"));
+    assert!(s.contains("true"));
+    assert!(s.contains("false"));
+}

--- a/common/workspace-hack/Cargo.toml
+++ b/common/workspace-hack/Cargo.toml
@@ -49,6 +49,7 @@ prost = { version = "0.7.0", features = ["default", "prost-derive", "std"] }
 rand = { version = "0.8.3", features = ["alloc", "default", "getrandom", "libc", "rand_chacha", "rand_hc", "small_rng", "std", "std_rng"] }
 rand_core = { version = "0.5.1", default-features = false, features = ["alloc", "getrandom", "std"] }
 regex = { version = "1.4.3", features = ["aho-corasick", "default", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+regex-automata = { version = "0.1.9", features = ["default", "regex-syntax", "std"] }
 regex-syntax = { version = "0.6.23", features = ["default", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 reqwest = { version = "0.11.2", features = ["__tls", "blocking", "default", "default-tls", "hyper-tls", "json", "native-tls-crate", "serde_json", "stream", "tokio-native-tls"] }
 rusty-fork = { version = "0.3.0", features = ["default", "timeout", "wait-timeout"] }
@@ -61,7 +62,8 @@ tokio = { version = "1.6.1", features = ["bytes", "default", "fs", "full", "io-s
 tokio-tungstenite = { version = "0.13.0", features = ["connect", "default", "stream"] }
 tokio-util = { version = "0.6.4", features = ["codec", "compat", "default", "futures-io", "io"] }
 toml = { version = "0.5.8", features = ["default"] }
-tracing = { version = "0.1.25", features = ["attributes", "default", "log", "std", "tracing-attributes"] }
+tracing = { version = "0.1.26", features = ["attributes", "default", "log", "std", "tracing-attributes"] }
+tracing-core = { version = "0.1.18", features = ["default", "lazy_static", "std"] }
 warp = { version = "0.3.0", features = ["default", "multipart", "tls", "tokio-rustls", "tokio-tungstenite", "websocket"] }
 zeroize = { version = "1.2.0", features = ["alloc", "default", "zeroize_derive"] }
 
@@ -107,6 +109,7 @@ quote = { version = "0.6.13", features = ["default", "proc-macro"] }
 rand = { version = "0.8.3", features = ["alloc", "default", "getrandom", "libc", "rand_chacha", "rand_hc", "small_rng", "std", "std_rng"] }
 rand_core = { version = "0.5.1", default-features = false, features = ["alloc", "getrandom", "std"] }
 regex = { version = "1.4.3", features = ["aho-corasick", "default", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+regex-automata = { version = "0.1.9", features = ["default", "regex-syntax", "std"] }
 regex-syntax = { version = "0.6.23", features = ["default", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 reqwest = { version = "0.11.2", features = ["__tls", "blocking", "default", "default-tls", "hyper-tls", "json", "native-tls-crate", "serde_json", "stream", "tokio-native-tls"] }
 rusty-fork = { version = "0.3.0", features = ["default", "timeout", "wait-timeout"] }
@@ -121,7 +124,8 @@ tokio = { version = "1.6.1", features = ["bytes", "default", "fs", "full", "io-s
 tokio-tungstenite = { version = "0.13.0", features = ["connect", "default", "stream"] }
 tokio-util = { version = "0.6.4", features = ["codec", "compat", "default", "futures-io", "io"] }
 toml = { version = "0.5.8", features = ["default"] }
-tracing = { version = "0.1.25", features = ["attributes", "default", "log", "std", "tracing-attributes"] }
+tracing = { version = "0.1.26", features = ["attributes", "default", "log", "std", "tracing-attributes"] }
+tracing-core = { version = "0.1.18", features = ["default", "lazy_static", "std"] }
 warp = { version = "0.3.0", features = ["default", "multipart", "tls", "tokio-rustls", "tokio-tungstenite", "websocket"] }
 zeroize = { version = "1.2.0", features = ["alloc", "default", "zeroize_derive"] }
 
@@ -164,6 +168,7 @@ prost = { version = "0.7.0", features = ["default", "prost-derive", "std"] }
 rand = { version = "0.8.3", features = ["alloc", "default", "getrandom", "libc", "rand_chacha", "rand_hc", "small_rng", "std", "std_rng"] }
 rand_core = { version = "0.5.1", default-features = false, features = ["alloc", "getrandom", "std"] }
 regex = { version = "1.4.3", features = ["aho-corasick", "default", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+regex-automata = { version = "0.1.9", features = ["default", "regex-syntax", "std"] }
 regex-syntax = { version = "0.6.23", features = ["default", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 reqwest = { version = "0.11.2", features = ["__tls", "blocking", "default", "default-tls", "hyper-tls", "json", "native-tls-crate", "serde_json", "stream", "tokio-native-tls"] }
 rusty-fork = { version = "0.3.0", features = ["default", "timeout", "wait-timeout"] }
@@ -176,7 +181,8 @@ tokio = { version = "1.6.1", features = ["bytes", "default", "fs", "full", "io-s
 tokio-tungstenite = { version = "0.13.0", features = ["connect", "default", "stream"] }
 tokio-util = { version = "0.6.4", features = ["codec", "compat", "default", "futures-io", "io"] }
 toml = { version = "0.5.8", features = ["default"] }
-tracing = { version = "0.1.25", features = ["attributes", "default", "log", "std", "tracing-attributes"] }
+tracing = { version = "0.1.26", features = ["attributes", "default", "log", "std", "tracing-attributes"] }
+tracing-core = { version = "0.1.18", features = ["default", "lazy_static", "std"] }
 warp = { version = "0.3.0", features = ["default", "multipart", "tls", "tokio-rustls", "tokio-tungstenite", "websocket"] }
 zeroize = { version = "1.2.0", features = ["alloc", "default", "zeroize_derive"] }
 
@@ -222,6 +228,7 @@ quote = { version = "0.6.13", features = ["default", "proc-macro"] }
 rand = { version = "0.8.3", features = ["alloc", "default", "getrandom", "libc", "rand_chacha", "rand_hc", "small_rng", "std", "std_rng"] }
 rand_core = { version = "0.5.1", default-features = false, features = ["alloc", "getrandom", "std"] }
 regex = { version = "1.4.3", features = ["aho-corasick", "default", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+regex-automata = { version = "0.1.9", features = ["default", "regex-syntax", "std"] }
 regex-syntax = { version = "0.6.23", features = ["default", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 reqwest = { version = "0.11.2", features = ["__tls", "blocking", "default", "default-tls", "hyper-tls", "json", "native-tls-crate", "serde_json", "stream", "tokio-native-tls"] }
 rusty-fork = { version = "0.3.0", features = ["default", "timeout", "wait-timeout"] }
@@ -236,7 +243,8 @@ tokio = { version = "1.6.1", features = ["bytes", "default", "fs", "full", "io-s
 tokio-tungstenite = { version = "0.13.0", features = ["connect", "default", "stream"] }
 tokio-util = { version = "0.6.4", features = ["codec", "compat", "default", "futures-io", "io"] }
 toml = { version = "0.5.8", features = ["default"] }
-tracing = { version = "0.1.25", features = ["attributes", "default", "log", "std", "tracing-attributes"] }
+tracing = { version = "0.1.26", features = ["attributes", "default", "log", "std", "tracing-attributes"] }
+tracing-core = { version = "0.1.18", features = ["default", "lazy_static", "std"] }
 warp = { version = "0.3.0", features = ["default", "multipart", "tls", "tokio-rustls", "tokio-tungstenite", "websocket"] }
 zeroize = { version = "1.2.0", features = ["alloc", "default", "zeroize_derive"] }
 

--- a/language/diem-tools/e2e-tests-replay/src/lib.rs
+++ b/language/diem-tools/e2e-tests-replay/src/lib.rs
@@ -57,7 +57,7 @@ use move_core_types::{
     value::MoveValue,
     vm_status::{KeptVMStatus, VMStatus},
 };
-use move_vm_runtime::{logging::NoContextLog, move_vm::MoveVM, session::Session};
+use move_vm_runtime::{move_vm::MoveVM, session::Session};
 use move_vm_types::gas_schedule::GasStatus;
 
 const MOVE_VM_TRACING_ENV_VAR_NAME: &str = "MOVE_VM_TRACE";
@@ -399,15 +399,7 @@ fn execute_function_via_session(
     args: Vec<Vec<u8>>,
 ) -> VMResult<Vec<Vec<u8>>> {
     let mut gas_status = GasStatus::new_unmetered();
-    let log_context = NoContextLog::new();
-    session.execute_function(
-        module_id,
-        function_name,
-        ty_args,
-        args,
-        &mut gas_status,
-        &log_context,
-    )
+    session.execute_function(module_id, function_name, ty_args, args, &mut gas_status)
 }
 
 fn execute_function_via_session_and_xrunner(
@@ -433,7 +425,6 @@ fn execute_script_function_via_session(
     senders: Vec<AccountAddress>,
 ) -> VMResult<()> {
     let mut gas_status = GasStatus::new_unmetered();
-    let log_context = NoContextLog::new();
     session.execute_script_function(
         module_id,
         function_name,
@@ -441,7 +432,6 @@ fn execute_script_function_via_session(
         args,
         senders,
         &mut gas_status,
-        &log_context,
     )
 }
 

--- a/language/diem-tools/writeset-transaction-generator/src/writeset_builder.rs
+++ b/language/diem-tools/writeset-transaction-generator/src/writeset_builder.rs
@@ -15,9 +15,7 @@ use move_core_types::{
     transaction_argument::convert_txn_args,
     value::{serialize_values, MoveValue},
 };
-use move_vm_runtime::{
-    data_cache::MoveStorage, logging::NoContextLog, move_vm::MoveVM, session::Session,
-};
+use move_vm_runtime::{data_cache::MoveStorage, move_vm::MoveVM, session::Session};
 use move_vm_types::gas_schedule::GasStatus;
 
 pub struct GenesisSession<'r, 'l, S>(Session<'r, 'l, S>);
@@ -40,7 +38,6 @@ impl<'r, 'l, S: MoveStorage> GenesisSession<'r, 'l, S> {
                 ty_args,
                 args,
                 &mut GasStatus::new_unmetered(),
-                &NoContextLog::new(),
             )
             .unwrap_or_else(|e| {
                 panic!(
@@ -60,7 +57,6 @@ impl<'r, 'l, S: MoveStorage> GenesisSession<'r, 'l, S> {
                 convert_txn_args(script.args()),
                 vec![sender],
                 &mut GasStatus::new_unmetered(),
-                &NoContextLog::new(),
             )
             .unwrap()
     }

--- a/language/diem-vm/Cargo.toml
+++ b/language/diem-vm/Cargo.toml
@@ -15,6 +15,7 @@ fail = "0.4.0"
 once_cell = "1.7.2"
 rayon = "1.5.0"
 mirai-annotations = "1.10.1"
+tracing = "0.1.16"
 
 bcs = "0.1.2"
 diem-crypto = { path = "../../crypto/crypto" }

--- a/language/diem-vm/src/diem_transaction_validator.rs
+++ b/language/diem-vm/src/diem_transaction_validator.rs
@@ -21,7 +21,7 @@ use move_core_types::{
     identifier::{IdentStr, Identifier},
     move_resource::MoveStructType,
 };
-use move_vm_runtime::{data_cache::MoveStorage, logging::LogContext, session::Session};
+use move_vm_runtime::{data_cache::MoveStorage, session::Session};
 
 use crate::logging::AdapterLogSchema;
 
@@ -124,7 +124,7 @@ pub(crate) fn validate_signature_checked_transaction<S: MoveStorage>(
     transaction: &SignatureCheckedTransaction,
     remote_cache: &S,
     allow_too_new: bool,
-    log_context: &impl LogContext,
+    log_context: &AdapterLogSchema,
 ) -> Result<(u64, Identifier), VMStatus> {
     if transaction.is_multi_agent() && vm.get_diem_version()? < DIEM_VERSION_3 {
         // Multi agent is not allowed under this version

--- a/language/diem-vm/src/errors.rs
+++ b/language/diem-vm/src/errors.rs
@@ -1,10 +1,10 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::logging::AdapterLogSchema;
 use diem_logger::prelude::*;
 use move_binary_format::errors::VMError;
 use move_core_types::vm_status::{known_locations, StatusCode, VMStatus};
-use move_vm_runtime::logging::LogContext;
 
 /// Error codes that can be emitted by the prologue. These have special significance to the VM when
 /// they are raised during the prologue.
@@ -41,7 +41,7 @@ fn error_split(code: u64) -> (u8, u64) {
 /// `UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION`
 pub fn convert_prologue_error(
     error: VMError,
-    log_context: &impl LogContext,
+    log_context: &AdapterLogSchema,
 ) -> Result<(), VMStatus> {
     let status = error.into_vm_status();
     Err(match status {
@@ -119,7 +119,7 @@ pub fn convert_prologue_error(
 /// `UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION`
 pub fn convert_epilogue_error(
     error: VMError,
-    log_context: &impl LogContext,
+    log_context: &AdapterLogSchema,
 ) -> Result<(), VMStatus> {
     let status = error.into_vm_status();
     Err(match status {
@@ -167,7 +167,7 @@ pub fn convert_epilogue_error(
 pub fn expect_only_successful_execution(
     error: VMError,
     function_name: &str,
-    log_context: &impl LogContext,
+    log_context: &AdapterLogSchema,
 ) -> Result<(), VMStatus> {
     let status = error.into_vm_status();
     Err(match status {

--- a/language/diem-vm/src/logging.rs
+++ b/language/diem-vm/src/logging.rs
@@ -6,7 +6,6 @@ use diem_crypto::HashValue;
 use diem_logger::Schema;
 use diem_state_view::StateViewId;
 use diem_types::transaction::Version;
-use move_vm_runtime::logging::LogContext;
 use serde::Serialize;
 
 #[derive(Schema, Clone)]
@@ -63,16 +62,10 @@ impl AdapterLogSchema {
             },
         }
     }
-}
 
-impl LogContext for AdapterLogSchema {
     // Increment the `CRITICAL_ERRORS` monitor event that will fire an alert
-    fn alert(&self) {
+    pub fn alert(&self) {
         CRITICAL_ERRORS.inc();
-    }
-
-    fn as_super(&self) -> &dyn Schema {
-        self
     }
 }
 

--- a/language/e2e-testsuite/Cargo.toml
+++ b/language/e2e-testsuite/Cargo.toml
@@ -28,6 +28,7 @@ diem-logger = { path = "../../common/logger" }
 diem-framework-releases = { path = "../diem-framework/releases" }
 diem-workspace-hack = { path = "../../common/workspace-hack" }
 diem-writeset-generator = { path = "../diem-tools/writeset-transaction-generator"}
+diem-state-view = { path = "../../storage/state-view" }
 
 [features]
 default = ["diem-transaction-builder/fuzzing"]

--- a/language/e2e-testsuite/src/tests/failed_transaction_tests.rs
+++ b/language/e2e-testsuite/src/tests/failed_transaction_tests.rs
@@ -1,14 +1,17 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use diem_state_view::StateView;
 use diem_types::vm_status::{KeptVMStatus, StatusCode, VMStatus};
-use diem_vm::{data_cache::StateViewCache, transaction_metadata::TransactionMetadata, DiemVM};
+use diem_vm::{
+    data_cache::StateViewCache, logging::AdapterLogSchema,
+    transaction_metadata::TransactionMetadata, DiemVM,
+};
 use language_e2e_tests::{
     account, common_transactions::peer_to_peer_txn, test_with_different_versions,
     versioning::CURRENT_RELEASE_VERSIONS,
 };
 use move_core_types::gas_schedule::{GasAlgebra, GasPrice, GasUnits};
-use move_vm_runtime::logging::NoContextLog;
 use move_vm_types::gas_schedule::{zero_cost_schedule, GasStatus};
 
 #[test]
@@ -18,7 +21,7 @@ fn failed_transaction_cleanup_test() {
         let sender = executor.create_raw_account_data(1_000_000, 10);
         executor.add_account_data(&sender);
 
-        let log_context = NoContextLog::new();
+        let log_context = AdapterLogSchema::new(executor.get_state_view().id(), 0);
         let diem_vm = DiemVM::new(executor.get_state_view());
         let data_cache = StateViewCache::new(executor.get_state_view());
 

--- a/language/move-vm/integration-tests/src/tests/bad_entry_point_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/bad_entry_point_tests.rs
@@ -9,7 +9,7 @@ use move_core_types::{
     value::{serialize_values, MoveValue},
     vm_status::StatusType,
 };
-use move_vm_runtime::{logging::NoContextLog, move_vm::MoveVM};
+use move_vm_runtime::move_vm::MoveVM;
 use move_vm_test_utils::{BlankStorage, InMemoryStorage};
 use move_vm_types::gas_schedule::GasStatus;
 
@@ -24,7 +24,6 @@ fn call_non_existent_module() {
     let module_id = ModuleId::new(TEST_ADDR, Identifier::new("M").unwrap());
     let fun_name = Identifier::new("foo").unwrap();
     let mut gas_status = GasStatus::new_unmetered();
-    let context = NoContextLog::new();
 
     let err = sess
         .execute_function(
@@ -33,7 +32,6 @@ fn call_non_existent_module() {
             vec![],
             serialize_values(&vec![MoveValue::Signer(TEST_ADDR)]),
             &mut gas_status,
-            &context,
         )
         .unwrap_err();
 
@@ -61,7 +59,6 @@ fn call_non_existent_function() {
 
     let fun_name = Identifier::new("foo").unwrap();
     let mut gas_status = GasStatus::new_unmetered();
-    let context = NoContextLog::new();
 
     let err = sess
         .execute_function(
@@ -70,7 +67,6 @@ fn call_non_existent_function() {
             vec![],
             serialize_values(&vec![MoveValue::Signer(TEST_ADDR)]),
             &mut gas_status,
-            &context,
         )
         .unwrap_err();
 

--- a/language/move-vm/integration-tests/src/tests/function_arg_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/function_arg_tests.rs
@@ -10,7 +10,7 @@ use move_core_types::{
     value::{MoveStruct, MoveValue},
     vm_status::StatusCode,
 };
-use move_vm_runtime::{logging::NoContextLog, move_vm::MoveVM};
+use move_vm_runtime::move_vm::MoveVM;
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::gas_schedule::GasStatus;
 
@@ -60,21 +60,13 @@ fn run(
 
     let fun_name = Identifier::new("foo").unwrap();
     let mut gas_status = GasStatus::new_unmetered();
-    let context = NoContextLog::new();
 
     let args: Vec<_> = args
         .into_iter()
         .map(|val| val.simple_serialize().unwrap())
         .collect();
 
-    sess.execute_function(
-        &module_id,
-        &fun_name,
-        ty_args,
-        args,
-        &mut gas_status,
-        &context,
-    )?;
+    sess.execute_function(&module_id, &fun_name, ty_args, args, &mut gas_status)?;
 
     Ok(())
 }

--- a/language/move-vm/integration-tests/src/tests/mutated_accounts_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/mutated_accounts_tests.rs
@@ -8,7 +8,7 @@ use move_core_types::{
     language_storage::ModuleId,
     value::{serialize_values, MoveValue},
 };
-use move_vm_runtime::{logging::NoContextLog, move_vm::MoveVM};
+use move_vm_runtime::move_vm::MoveVM;
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::gas_schedule::GasStatus;
 
@@ -46,7 +46,6 @@ fn mutated_accounts() {
     let mut sess = vm.new_session(&storage);
 
     let mut gas_status = GasStatus::new_unmetered();
-    let context = NoContextLog::new();
 
     let publish = Identifier::new("publish").unwrap();
     let flip = Identifier::new("flip").unwrap();
@@ -60,7 +59,6 @@ fn mutated_accounts() {
         vec![],
         serialize_values(&vec![MoveValue::Signer(account1)]),
         &mut gas_status,
-        &context,
     )
     .unwrap();
 
@@ -75,7 +73,6 @@ fn mutated_accounts() {
         vec![],
         serialize_values(&vec![MoveValue::Address(account1)]),
         &mut gas_status,
-        &context,
     )
     .unwrap();
 
@@ -87,7 +84,6 @@ fn mutated_accounts() {
         vec![],
         serialize_values(&vec![MoveValue::Address(account1)]),
         &mut gas_status,
-        &context,
     )
     .unwrap();
     assert_eq!(sess.num_mutated_accounts(&TEST_ADDR), 2);
@@ -102,7 +98,6 @@ fn mutated_accounts() {
         vec![],
         serialize_values(&vec![MoveValue::Address(account1)]),
         &mut gas_status,
-        &context,
     )
     .unwrap();
 

--- a/language/move-vm/integration-tests/src/tests/return_value_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/return_value_tests.rs
@@ -10,7 +10,7 @@ use move_core_types::{
     value::{MoveTypeLayout, MoveValue},
     vm_status::StatusCode,
 };
-use move_vm_runtime::{logging::NoContextLog, move_vm::MoveVM};
+use move_vm_runtime::move_vm::MoveVM;
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::gas_schedule::GasStatus;
 
@@ -52,21 +52,14 @@ fn run(
 
     let fun_name = Identifier::new("foo").unwrap();
     let mut gas_status = GasStatus::new_unmetered();
-    let context = NoContextLog::new();
 
     let args: Vec<_> = args
         .into_iter()
         .map(|val| val.simple_serialize().unwrap())
         .collect();
 
-    let return_vals = sess.execute_function(
-        &module_id,
-        &fun_name,
-        ty_args,
-        args,
-        &mut gas_status,
-        &context,
-    )?;
+    let return_vals =
+        sess.execute_function(&module_id, &fun_name, ty_args, args, &mut gas_status)?;
 
     Ok(return_vals)
 }

--- a/language/move-vm/runtime/Cargo.toml
+++ b/language/move-vm/runtime/Cargo.toml
@@ -17,9 +17,9 @@ mirai-annotations = "1.10.1"
 once_cell = "1.7.2"
 parking_lot = "0.11.1"
 sha3 = "0.9.1"
+tracing = "0.1.26"
 
 bytecode-verifier = { path = "../../bytecode-verifier" }
-diem-logger = { path = "../../../common/logger" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
 move-vm-types = { path = "../types" }
@@ -29,6 +29,7 @@ move-binary-format = { path = "../../move-binary-format" }
 anyhow = "1.0.38"
 hex = "0.4.3"
 proptest = "1.0.0"
+
 
 compiler = { path = "../../compiler" }
 move-lang = { path = "../../move-lang" }

--- a/language/move-vm/runtime/src/logging.rs
+++ b/language/move-vm/runtime/src/logging.rs
@@ -1,46 +1,14 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use diem_logger::{prelude::error, Schema};
 use move_binary_format::errors::{PartialVMError, VMError};
 use move_core_types::vm_status::{StatusCode, StatusType};
-
-// Trait used by the VM to log interesting data.
-// Clients are responsible for the implementation of alert.
-pub trait LogContext: Schema {
-    // Alert is called on critical errors
-    fn alert(&self);
-
-    fn as_super(&self) -> &dyn Schema;
-}
-
-// Helper `Logger` implementation that does nothing
-#[derive(Schema)]
-pub struct NoContextLog {
-    name: String,
-}
-
-impl NoContextLog {
-    pub fn new() -> Self {
-        Self {
-            name: "test".to_string(),
-        }
-    }
-}
-
-impl LogContext for NoContextLog {
-    fn alert(&self) {}
-
-    fn as_super(&self) -> &dyn Schema {
-        self
-    }
-}
-
+use tracing::error;
 //
 // Utility functions
 //
 
-pub fn expect_no_verification_errors(err: VMError, log_context: &impl LogContext) -> VMError {
+pub fn expect_no_verification_errors(err: VMError) -> VMError {
     match err.status_type() {
         status_type @ StatusType::Deserialization | status_type @ StatusType::Verification => {
             let message = format!(
@@ -56,8 +24,7 @@ pub fn expect_no_verification_errors(err: VMError, log_context: &impl LogContext
                 _ => unreachable!(),
             };
 
-            log_context.alert();
-            error!(*log_context, "[VM] {}", message);
+            error!("[VM] {}", message);
             PartialVMError::new(major_status)
                 .with_message(message)
                 .at_indices(indices)

--- a/language/move-vm/runtime/src/native_functions.rs
+++ b/language/move-vm/runtime/src/native_functions.rs
@@ -55,16 +55,16 @@ impl NativeFunctions {
     }
 }
 
-pub struct NativeContext<'a, 'b> {
-    interpreter: &'a mut Interpreter<'b>,
+pub struct NativeContext<'a> {
+    interpreter: &'a mut Interpreter,
     data_store: &'a mut dyn DataStore,
     gas_status: &'a GasStatus<'a>,
     resolver: &'a Resolver<'a>,
 }
 
-impl<'a, 'b> NativeContext<'a, 'b> {
+impl<'a, 'b> NativeContext<'a> {
     pub(crate) fn new(
-        interpreter: &'a mut Interpreter<'b>,
+        interpreter: &'a mut Interpreter,
         data_store: &'a mut dyn DataStore,
         gas_status: &'a mut GasStatus,
         resolver: &'a Resolver<'a>,
@@ -78,7 +78,7 @@ impl<'a, 'b> NativeContext<'a, 'b> {
     }
 }
 
-impl<'a, 'b> NativeContext<'a, 'b> {
+impl<'a> NativeContext<'a> {
     pub fn print_stack_trace<B: Write>(&self, buf: &mut B) -> PartialVMResult<()> {
         self.interpreter
             .debug_print_stack_trace(buf, self.resolver.loader())

--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -3,7 +3,6 @@
 
 use crate::{
     data_cache::{MoveStorage, TransactionDataCache},
-    logging::LogContext,
     runtime::VMRuntime,
 };
 use move_binary_format::errors::*;
@@ -43,7 +42,6 @@ impl<'r, 'l, S: MoveStorage> Session<'r, 'l, S> {
         ty_args: Vec<TypeTag>,
         args: Vec<Vec<u8>>,
         gas_status: &mut GasStatus,
-        log_context: &impl LogContext,
     ) -> VMResult<Vec<Vec<u8>>> {
         self.runtime.execute_function(
             module,
@@ -52,7 +50,6 @@ impl<'r, 'l, S: MoveStorage> Session<'r, 'l, S> {
             args,
             &mut self.data_cache,
             gas_status,
-            log_context,
         )
     }
 
@@ -88,7 +85,6 @@ impl<'r, 'l, S: MoveStorage> Session<'r, 'l, S> {
         args: Vec<Vec<u8>>,
         senders: Vec<AccountAddress>,
         gas_status: &mut GasStatus,
-        log_context: &impl LogContext,
     ) -> VMResult<()> {
         self.runtime.execute_script_function(
             module,
@@ -98,7 +94,6 @@ impl<'r, 'l, S: MoveStorage> Session<'r, 'l, S> {
             senders,
             &mut self.data_cache,
             gas_status,
-            log_context,
         )
     }
 
@@ -125,7 +120,6 @@ impl<'r, 'l, S: MoveStorage> Session<'r, 'l, S> {
         args: Vec<Vec<u8>>,
         senders: Vec<AccountAddress>,
         gas_status: &mut GasStatus,
-        log_context: &impl LogContext,
     ) -> VMResult<()> {
         self.runtime.execute_script(
             script,
@@ -134,7 +128,6 @@ impl<'r, 'l, S: MoveStorage> Session<'r, 'l, S> {
             senders,
             &mut self.data_cache,
             gas_status,
-            log_context,
         )
     }
 
@@ -156,15 +149,9 @@ impl<'r, 'l, S: MoveStorage> Session<'r, 'l, S> {
         module: Vec<u8>,
         sender: AccountAddress,
         gas_status: &mut GasStatus,
-        log_context: &impl LogContext,
     ) -> VMResult<()> {
-        self.runtime.publish_module(
-            module,
-            sender,
-            &mut self.data_cache,
-            gas_status,
-            log_context,
-        )
+        self.runtime
+            .publish_module(module, sender, &mut self.data_cache, gas_status)
     }
 
     pub fn num_mutated_accounts(&self, sender: &AccountAddress) -> u64 {

--- a/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashMap;
 
-use crate::{data_cache::MoveStorage, logging::NoContextLog, move_vm::MoveVM};
+use crate::{data_cache::MoveStorage, move_vm::MoveVM};
 use move_binary_format::{
     errors::{PartialVMResult, VMResult},
     file_format::{
@@ -259,17 +259,9 @@ fn call_script_with_args_ty_args_signers(
 ) -> VMResult<()> {
     let move_vm = MoveVM::new(vec![]).unwrap();
     let remote_view = RemoteStore::new();
-    let log_context = NoContextLog::new();
     let mut session = move_vm.new_session(&remote_view);
     let mut gas_status = GasStatus::new_unmetered();
-    session.execute_script(
-        script,
-        ty_args,
-        args,
-        signers,
-        &mut gas_status,
-        &log_context,
-    )
+    session.execute_script(script, ty_args, args, signers, &mut gas_status)
 }
 
 fn call_script(script: Vec<u8>, args: Vec<Vec<u8>>) -> VMResult<()> {
@@ -287,7 +279,6 @@ fn call_script_function_with_args_ty_args_signers(
     let mut remote_view = RemoteStore::new();
     let id = module.self_id();
     remote_view.add_module(module);
-    let log_context = NoContextLog::new();
     let mut session = move_vm.new_session(&remote_view);
     let mut gas_status = GasStatus::new_unmetered();
     session.execute_script_function(
@@ -297,7 +288,6 @@ fn call_script_function_with_args_ty_args_signers(
         args,
         signers,
         &mut gas_status,
-        &log_context,
     )?;
     Ok(())
 }
@@ -761,19 +751,10 @@ fn call_missing_item() {
     // mising module
     let move_vm = MoveVM::new(vec![]).unwrap();
     let mut remote_view = RemoteStore::new();
-    let log_context = NoContextLog::new();
     let mut session = move_vm.new_session(&remote_view);
     let mut gas_status = GasStatus::new_unmetered();
     let error = session
-        .execute_script_function(
-            id,
-            function_name,
-            vec![],
-            vec![],
-            vec![],
-            &mut gas_status,
-            &log_context,
-        )
+        .execute_script_function(id, function_name, vec![], vec![], vec![], &mut gas_status)
         .err()
         .unwrap();
     assert_eq!(error.major_status(), StatusCode::LINKER_ERROR);
@@ -783,15 +764,7 @@ fn call_missing_item() {
     remote_view.add_module(module);
     let mut session = move_vm.new_session(&remote_view);
     let error = session
-        .execute_script_function(
-            id,
-            function_name,
-            vec![],
-            vec![],
-            vec![],
-            &mut gas_status,
-            &log_context,
-        )
+        .execute_script_function(id, function_name, vec![], vec![], vec![], &mut gas_status)
         .err()
         .unwrap();
     assert_eq!(

--- a/language/testing-infra/e2e-tests/src/executor.rs
+++ b/language/testing-infra/e2e-tests/src/executor.rs
@@ -42,7 +42,7 @@ use move_core_types::{
     identifier::Identifier,
     language_storage::{ModuleId, TypeTag},
 };
-use move_vm_runtime::{logging::NoContextLog, move_vm::MoveVM};
+use move_vm_runtime::move_vm::MoveVM;
 use move_vm_types::gas_schedule::GasStatus;
 
 static RNG_SEED: [u8; 32] = [9u8; 32];
@@ -466,7 +466,6 @@ impl FakeExecutor {
             let vm = MoveVM::new(diem_vm::natives::diem_natives()).unwrap();
             let remote_view = RemoteStorage::new(&self.data_store);
             let mut session = vm.new_session(&remote_view);
-            let log_context = NoContextLog::new();
             session
                 .execute_function(
                     &Self::module(module_name),
@@ -474,7 +473,6 @@ impl FakeExecutor {
                     type_params,
                     args,
                     &mut gas_status,
-                    &log_context,
                 )
                 .unwrap_or_else(|e| {
                     panic!(
@@ -503,7 +501,6 @@ impl FakeExecutor {
         let vm = MoveVM::new(diem_vm::natives::diem_natives()).unwrap();
         let remote_view = RemoteStorage::new(&self.data_store);
         let mut session = vm.new_session(&remote_view);
-        let log_context = NoContextLog::new();
         session
             .execute_function(
                 &Self::module(module_name),
@@ -511,7 +508,6 @@ impl FakeExecutor {
                 type_params,
                 args,
                 &mut gas_status,
-                &log_context,
             )
             .map_err(|e| e.into_vm_status())?;
         let (changeset, events) = session.finish().expect("Failed to generate txn effects");

--- a/language/tools/move-cli/src/sandbox/commands/publish.rs
+++ b/language/tools/move-cli/src/sandbox/commands/publish.rs
@@ -6,7 +6,7 @@ use crate::sandbox::utils::{
     on_disk_state_view::OnDiskStateView,
 };
 use move_lang::{self, compiled_unit::CompiledUnit, Compiler, Flags};
-use move_vm_runtime::{logging::NoContextLog, move_vm::MoveVM};
+use move_vm_runtime::move_vm::MoveVM;
 
 use anyhow::Result;
 
@@ -53,7 +53,6 @@ pub fn publish(
     if !ignore_breaking_changes {
         let vm = MoveVM::new(diem_vm::natives::diem_natives()).unwrap();
         let mut gas_status = get_gas_status(None)?;
-        let log_context = NoContextLog::new();
         let mut session = vm.new_session(state);
 
         let mut has_error = false;
@@ -64,7 +63,7 @@ pub fn publish(
             let id = module.self_id();
             let sender = *id.address();
 
-            let res = session.publish_module(module_bytes, sender, &mut gas_status, &log_context);
+            let res = session.publish_module(module_bytes, sender, &mut gas_status);
             if let Err(err) = res {
                 explain_publish_error(err, &state, module)?;
                 has_error = true;

--- a/language/tools/move-cli/src/sandbox/commands/run.rs
+++ b/language/tools/move-cli/src/sandbox/commands/run.rs
@@ -13,7 +13,7 @@ use move_core_types::{
     transaction_argument::{convert_txn_args, TransactionArgument},
 };
 use move_lang::{self, compiled_unit::CompiledUnit, Compiler, Flags};
-use move_vm_runtime::{logging::NoContextLog, move_vm::MoveVM};
+use move_vm_runtime::move_vm::MoveVM;
 
 use anyhow::{anyhow, bail, Result};
 use std::{fs, path::Path};
@@ -100,7 +100,6 @@ move run` must be applied to a module inside `storage/`",
 
     let vm = MoveVM::new(diem_vm::natives::diem_natives()).unwrap();
     let mut gas_status = get_gas_status(gas_budget)?;
-    let log_context = NoContextLog::new();
     let mut session = vm.new_session(state);
 
     let script_type_parameters = vec![];
@@ -118,7 +117,6 @@ move run` must be applied to a module inside `storage/`",
                     vm_args,
                     signer_addresses.clone(),
                     &mut gas_status,
-                    &log_context,
                 )
                 .map(|_| ())
         }
@@ -128,7 +126,6 @@ move run` must be applied to a module inside `storage/`",
             vm_args,
             signer_addresses.clone(),
             &mut gas_status,
-            &log_context,
         ),
     };
 

--- a/language/tools/move-unit-test/src/test_runner.rs
+++ b/language/tools/move-unit-test/src/test_runner.rs
@@ -27,7 +27,7 @@ use move_lang::{
     unit_test::{ExpectedFailure, ModuleTestPlan, TestCase, TestPlan},
 };
 use move_model::{model::GlobalEnv, run_model_builder_with_compilation_flags};
-use move_vm_runtime::{logging::NoContextLog, move_vm::MoveVM};
+use move_vm_runtime::move_vm::MoveVM;
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::gas_schedule::{zero_cost_schedule, GasStatus};
 use rayon::prelude::*;
@@ -185,7 +185,6 @@ impl SharedTestingConfig {
         let mut session = move_vm.new_session(&self.starting_storage_state);
         let mut gas_meter = GasStatus::new(&self.cost_table, GasUnits::new(self.execution_bound));
         // TODO: collect VM logs if the verbose flag (i.e, `self.verbose`) is set
-        let log_context = NoContextLog::new();
 
         let now = Instant::now();
         let return_result = session.execute_function(
@@ -194,7 +193,6 @@ impl SharedTestingConfig {
             vec![], // no ty args, at least for now
             serialize_values(test_info.arguments.iter()),
             &mut gas_meter,
-            &log_context,
         );
         let test_run_info = TestRunInfo::new(
             function_name.to_string(),

--- a/specifications/move_adapter/README.md
+++ b/specifications/move_adapter/README.md
@@ -897,7 +897,6 @@ pub fn publish_module(
     module: Vec<u8>,
     sender: AccountAddress,
     gas_status: &mut GasStatus,
-    log_context: &impl LogContext,
 ) -> VMResult<()>;
 ```
 
@@ -943,7 +942,6 @@ pub fn execute_script(
     args: Vec<Vec<u8>>,
     senders: Vec<AccountAddress>,
     gas_status: &mut GasStatus,
-    log_context: &impl LogContext,
 ) -> VMResult<()>;
 ```
 
@@ -994,7 +992,6 @@ pub fn execute_script_function(
     args: Vec<Vec<u8>>,
     senders: Vec<AccountAddress>,
     gas_status: &mut GasStatus,
-    log_context: &impl LogContext,
 ) -> VMResult<()>;
 ```
 
@@ -1026,7 +1023,6 @@ pub fn execute_function(
     ty_args: Vec<TypeTag>,
     args: Vec<Vec<u8>>,
     gas_status: &mut GasStatus,
-    log_context: &impl LogContext,
 ) -> VMResult<()>;
 ```
 

--- a/x.toml
+++ b/x.toml
@@ -256,7 +256,6 @@ existing_deps = [
     #          moved to the new repo
     ["move-lang", "diem-framework"],                          # sanity check to ensure that the diem-framework compiles
     ["compiler", "diem-framework-releases"],
-    ["move-vm-runtime", "diem-logger"],
     ["move-cli", "vm-genesis"],
     ["move-cli", "diem-vm"],
     ["move-cli", "diem-types"],                               # `ContractEvent`


### PR DESCRIPTION
## Summary
This replaces the `diem-logger` macros from the Move VM with the ones from `tracing` crate. It also implements a tracing-to-diem-logger adapter.

## ~~Unanswered~~ Answered Questions
- How should errors/lack of info be handled in `tracing-to-diem-logger`?
  - Use default values like `0` or `""`
- How should the global subscriber for tracing be set?
  - The initialization should be part of the diem-logger initialization process.
- Is the counter layer in diem-vm modeled correctly?
  - We should not monitor errors in the Move VM and increment the counter accordingly. Instead, let those errors propagate to the adapter and capture them there.
- Do we need to care about spans for now? Is Registry necessary? Would a do-nothing subscriber with the translation layer and counter layer be sufficient?
  - Spans: not needed
  - We should still use registry for simplicity and future-proofing.