### PR TITLE
[gha] allow go to force link on mac managed by github, should be safe locally as well.

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -502,7 +502,10 @@ function install_golang {
     elif [[ "$PACKAGE_MANAGER" == "apk" ]]; then
       apk --update add --no-cache git make musl-dev go
     elif [[ "$PACKAGE_MANAGER" == "brew" ]]; then
-      brew install go
+      failed=$(brew install go || echo "failed")
+      if [[ "$failed" == "failed" ]]; then
+        brew link --overwrite go
+      fi
     else
       install_pkg golang "$PACKAGE_MANAGER"
     fi


### PR DESCRIPTION
## Motivation

This will allow the github actions workflow ci-update-sccache.yml to complete when it had been failing to link the go lang.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

Ran the action and saw it work: https://github.com/diem/diem/actions/runs/941095055

## Related PRs

None

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
