### PR TITLE
[move-vm][stackless-vm] fix warnings on unused items caused by conditional compilation in debug mode

### DIFF
--- a/language/move-prover/interpreter/src/concrete/runtime.rs
+++ b/language/move-prover/interpreter/src/concrete/runtime.rs
@@ -127,9 +127,7 @@ fn check_and_convert_type_args_and_args(
     let mut converted_args = vec![];
     for (i, (arg, param)) in args.iter().zip(params.into_iter()).enumerate() {
         let local_ty = fun_env.get_local_type(i);
-
-        #[cfg(debug_assertions)]
-        assert_eq!(local_ty, param.1);
+        debug_assert_eq!(local_ty, param.1);
 
         // NOTE: for historical reasons, we may receive `&signer` as arguments
         // TODO (mengxu): clean this up when we no longer accept `&signer` as valid arguments

--- a/language/move-vm/runtime/src/tracing.rs
+++ b/language/move-vm/runtime/src/tracing.rs
@@ -19,6 +19,7 @@ use ::{
     },
 };
 
+#[cfg(debug_assertions)]
 use crate::{
     interpreter::Interpreter,
     loader::{Function, Loader},


### PR DESCRIPTION
## Motivation

Fix the warning when compiling move prover in release mode.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Not sure why this is not caught in CI...

Manually do a `cargo build --release` in `move-prover` directory should yield no warnings.
