### PR TITLE
[move-unit-test] Add support for dependencies in Move unit test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4771,6 +4771,7 @@ dependencies = [
  "diem-workspace-hack",
  "difference",
  "move-binary-format",
+ "move-bytecode-utils",
  "move-core-types",
  "move-lang",
  "move-lang-test-utils",

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check_testsuite.rs
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check_testsuite.rs
@@ -12,13 +12,13 @@ const BASELINE_EXTENSION: &str = "exp";
 fn test_runner(path: &Path) -> datatest_stable::Result<()> {
     env::set_var("NO_COLOR", "1");
 
-    let mut targets = move_stdlib_files();
-    targets.push(path.to_str().unwrap().to_owned());
+    let source_files = vec![path.to_str().unwrap().to_owned()];
     let config = UnitTestingConfig {
         instruction_execution_bound: 5000,
         filter: None,
         num_threads: 1,
-        source_files: targets,
+        source_files,
+        dep_files: move_stdlib_files(),
         check_stackless_vm: true,
         report_storage_on_error: false,
         report_statistics: false,

--- a/language/tools/move-unit-test/Cargo.toml
+++ b/language/tools/move-unit-test/Cargo.toml
@@ -28,6 +28,7 @@ resource-viewer = { path = "../resource-viewer" }
 move-binary-format = { path = "../../move-binary-format" }
 move-model = { path = "../../move-model" }
 bytecode-interpreter = { path = "../../move-prover/interpreter" }
+move-bytecode-utils = { path = "../move-bytecode-utils" }
 
 [dev-dependencies]
 datatest-stable = "0.1.1"

--- a/language/tools/move-unit-test/src/test_runner.rs
+++ b/language/tools/move-unit-test/src/test_runner.rs
@@ -13,6 +13,7 @@ use bytecode_interpreter::{
 };
 use colored::*;
 use move_binary_format::{errors::VMResult, file_format::CompiledModule};
+use move_bytecode_utils::Modules;
 use move_core_types::{
     account_address::AccountAddress,
     effects::ChangeSet,
@@ -70,7 +71,11 @@ fn setup_test_storage<'a>(
     modules: impl Iterator<Item = &'a CompiledModule>,
 ) -> Result<InMemoryStorage> {
     let mut storage = InMemoryStorage::new();
-    for module in modules {
+    let modules = Modules::new(modules);
+    for module in modules
+        .compute_dependency_graph()
+        .compute_topological_order()?
+    {
         let module_id = module.self_id();
         let mut module_bytes = Vec::new();
         module.serialize(&mut module_bytes)?;

--- a/language/tools/move-unit-test/tests/move_unit_test_testsuite.rs
+++ b/language/tools/move-unit-test/tests/move_unit_test_testsuite.rs
@@ -102,13 +102,13 @@ fn run_test_with_modifiers(
 fn run_test(path: &Path) -> datatest_stable::Result<()> {
     std::env::set_var("NO_COLOR", "1");
     let update_baseline = read_bool_env_var(UPDATE_BASELINE) || read_bool_env_var(UPB);
-    let mut targets = move_stdlib::move_stdlib_files();
-    targets.push(path.to_str().unwrap().to_owned());
+    let source_files = vec![path.to_str().unwrap().to_owned()];
     let unit_test_config = UnitTestingConfig {
         num_threads: 1,
         instruction_execution_bound: 1000,
         filter: None,
-        source_files: targets,
+        source_files,
+        dep_files: move_stdlib::move_stdlib_files(),
         check_stackless_vm: false,
         verbose: false,
         report_statistics: false,

--- a/language/tools/move-unit-test/tests/sources/A.move
+++ b/language/tools/move-unit-test/tests/sources/A.move
@@ -1,0 +1,9 @@
+module 0x1::A {
+    #[test]
+    fun a() { }
+
+    #[test_only]
+    public fun a_call() {
+        abort 0
+    }
+}

--- a/language/tools/move-unit-test/tests/sources/B.move
+++ b/language/tools/move-unit-test/tests/sources/B.move
@@ -1,0 +1,24 @@
+module 0x1::B {
+    #[test_only]
+    use 0x1::A;
+
+    #[test]
+    fun b() { }
+
+    #[test]
+    public fun b_other() {
+        A::a_call()
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 0)]
+    public fun b_other0() {
+        A::a_call()
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 1)]
+    public fun b_other1() {
+        A::a_call()
+    }
+}

--- a/language/tools/move-unit-test/tests/test_deps.rs
+++ b/language/tools/move-unit-test/tests/test_deps.rs
@@ -1,0 +1,31 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use move_core_types::{
+    account_address::AccountAddress, identifier::Identifier, language_storage::ModuleId,
+};
+use move_unit_test::{self, UnitTestingConfig};
+use std::path::PathBuf;
+
+// Make sure the compiled bytecode for dependencies is included, but the tests in them are not run.
+#[test]
+fn test_deps_arent_tested() {
+    let mut testing_config = UnitTestingConfig::default_with_bound(None);
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let a_path = path.join("tests/sources/A.move");
+    let b_path = path.join("tests/sources/B.move");
+
+    testing_config.source_files = vec![b_path.to_str().unwrap().to_owned()];
+    testing_config.dep_files = vec![a_path.to_str().unwrap().to_owned()];
+
+    let test_plan = testing_config.build_test_plan().unwrap();
+
+    let mut iter = test_plan.module_tests.into_iter();
+    let (mod_id, _) = iter.next().unwrap();
+    let expected_mod_id = ModuleId::new(
+        AccountAddress::from_hex_literal("0x1").unwrap(),
+        Identifier::new("B").unwrap(),
+    );
+    assert!(mod_id == expected_mod_id);
+    assert!(iter.next().is_none());
+}


### PR DESCRIPTION
Adds support for dependencies in Move unit tests. This will compile the dependencies in the test mode, but will not include any of the tests from the dependencies in the test plan that is generated and run for the source modules.

### Testing

Added a test to make sure that unit test dependencies with tests in them are not included in the generated test plan. 