### PR TITLE
[move-unit-test] Add location reporting for non-abort errors

### DIFF
--- a/language/tools/move-unit-test/src/test_reporter.rs
+++ b/language/tools/move-unit-test/src/test_reporter.rs
@@ -144,11 +144,11 @@ impl TestFailure {
                     "{}. Expected test to abort with {} but instead it aborted with {} here",
                     message, expected_code, other_code,
                 );
-                Self::report_abort(test_plan, base_message, &self.vm_error)
+                Self::report_error_with_location(test_plan, base_message, &self.vm_error)
             }
             FailureReason::Aborted(message, code) => {
                 let base_message = format!("{} but it aborted with {} here", message, code);
-                Self::report_abort(test_plan, base_message, &self.vm_error)
+                Self::report_error_with_location(test_plan, base_message, &self.vm_error)
             }
             FailureReason::Mismatch {
                 move_vm_return_values,
@@ -172,12 +172,17 @@ impl TestFailure {
             FailureReason::Property(message) => message.clone(),
             FailureReason::Unknown(message) => {
                 format!(
-                    "{}. VMError (if there is one) is: {}",
+                    "{} Location: {}\nVMError (if there is one): {}",
                     message,
+                    TestFailure::report_error_with_location(
+                        test_plan,
+                        "".to_string(),
+                        &self.vm_error
+                    ),
                     self.vm_error
                         .as_ref()
                         .map(|err| format!("{:#?}", err))
-                        .unwrap_or_else(|| "".to_string())
+                        .unwrap_or_else(|| "".to_string()),
                 )
             }
         };
@@ -198,7 +203,7 @@ impl TestFailure {
         }
     }
 
-    fn report_abort(
+    fn report_error_with_location(
         test_plan: &TestPlan,
         base_message: String,
         vm_error: &Option<VMError>,

--- a/language/tools/move-unit-test/tests/test_sources/missing_data.exp
+++ b/language/tools/move-unit-test/tests/test_sources/missing_data.exp
@@ -1,0 +1,43 @@
+Running Move unit tests
+[ FAIL    ] 0x1::MissingData::missing_data
+
+Test failures:
+
+Failures in 0x1::MissingData:
+
+┌── missing_data ──────
+│ ITE: An unknown error was reported. Location: error: 
+│ 
+│    ┌── tests/test_sources/missing_data.move:6:9 ───
+│    │
+│  6 │         borrow_global<Missing>(@0x0);
+│    │         ^^^^^^^^^^^^^
+│    ·
+│  5 │     fun missing_data() acquires Missing {
+│    │         ------------ In this function in 0x1::MissingData
+│    │
+│ 
+│ 
+│ VMError (if there is one): VMError {
+│     major_status: MISSING_DATA,
+│     sub_status: None,
+│     message: None,
+│     location: Module(
+│         ModuleId {
+│             address: 00000000000000000000000000000001,
+│             name: Identifier(
+│                 "MissingData",
+│             ),
+│         },
+│     ),
+│     indices: [],
+│     offsets: [
+│         (
+│             FunctionDefinitionIndex(0),
+│             1,
+│         ),
+│     ],
+│ }
+└──────────────────
+
+Test result: FAILED. Total tests: 1; passed: 0; failed: 1

--- a/language/tools/move-unit-test/tests/test_sources/missing_data.move
+++ b/language/tools/move-unit-test/tests/test_sources/missing_data.move
@@ -1,0 +1,8 @@
+module 0x1::MissingData {
+    struct Missing has key { }
+
+    #[test]
+    fun missing_data() acquires Missing {
+        borrow_global<Missing>(@0x0);
+    }
+}


### PR DESCRIPTION
Previously if a non-abort error was encountered we'd display the VM error, but would not try to provide the source location of where that error occurred.

This PR adds support to report the location of non-abort errors in tests. You can see an example of this in the new test case added. 