### PR TITLE
[language][vm] remove diem dependency: diem-crypto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2529,6 +2529,7 @@ dependencies = [
  "Inflector",
  "anyhow",
  "backtrace",
+ "block-buffer 0.9.0",
  "bstr",
  "byteorder",
  "bytes",
@@ -4808,7 +4809,6 @@ dependencies = [
  "anyhow",
  "bytecode-verifier",
  "compiler",
- "diem-crypto",
  "diem-logger",
  "diem-workspace-hack",
  "fail",
@@ -4821,6 +4821,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "proptest",
+ "sha3",
 ]
 
 [[package]]

--- a/common/workspace-hack/Cargo.toml
+++ b/common/workspace-hack/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 Inflector = { version = "0.11.4", features = ["default", "heavyweight", "lazy_static", "regex"] }
 anyhow = { version = "1.0.40", features = ["backtrace", "default", "std"] }
 backtrace = { version = "0.3.56", features = ["addr2line", "default", "gimli-symbolize", "miniz_oxide", "object", "serde", "std"] }
+block-buffer = { version = "0.9.0", default-features = false, features = ["block-padding"] }
 bstr = { version = "0.2.15", features = ["default", "lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
 byteorder = { version = "1.4.3", features = ["default", "i128", "std"] }
 bytes = { version = "1.0.1", features = ["default", "serde", "std"] }
@@ -68,6 +69,7 @@ zeroize = { version = "1.2.0", features = ["alloc", "default", "zeroize_derive"]
 Inflector = { version = "0.11.4", features = ["default", "heavyweight", "lazy_static", "regex"] }
 anyhow = { version = "1.0.40", features = ["backtrace", "default", "std"] }
 backtrace = { version = "0.3.56", features = ["addr2line", "default", "gimli-symbolize", "miniz_oxide", "object", "serde", "std"] }
+block-buffer = { version = "0.9.0", default-features = false, features = ["block-padding"] }
 bstr = { version = "0.2.15", features = ["default", "lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
 byteorder = { version = "1.4.3", features = ["default", "i128", "std"] }
 bytes = { version = "1.0.1", features = ["default", "serde", "std"] }
@@ -127,6 +129,7 @@ zeroize = { version = "1.2.0", features = ["alloc", "default", "zeroize_derive"]
 Inflector = { version = "0.11.4", features = ["default", "heavyweight", "lazy_static", "regex"] }
 anyhow = { version = "1.0.40", features = ["backtrace", "default", "std"] }
 backtrace = { version = "0.3.56", features = ["addr2line", "default", "gimli-symbolize", "miniz_oxide", "object", "serde", "std"] }
+block-buffer = { version = "0.9.0", default-features = false, features = ["block-padding"] }
 bstr = { version = "0.2.15", features = ["default", "lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
 byteorder = { version = "1.4.3", features = ["default", "i128", "std"] }
 bytes = { version = "1.0.1", features = ["default", "serde", "std"] }
@@ -181,6 +184,7 @@ zeroize = { version = "1.2.0", features = ["alloc", "default", "zeroize_derive"]
 Inflector = { version = "0.11.4", features = ["default", "heavyweight", "lazy_static", "regex"] }
 anyhow = { version = "1.0.40", features = ["backtrace", "default", "std"] }
 backtrace = { version = "0.3.56", features = ["addr2line", "default", "gimli-symbolize", "miniz_oxide", "object", "serde", "std"] }
+block-buffer = { version = "0.9.0", default-features = false, features = ["block-padding"] }
 bstr = { version = "0.2.15", features = ["default", "lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
 byteorder = { version = "1.4.3", features = ["default", "i128", "std"] }
 bytes = { version = "1.0.1", features = ["default", "serde", "std"] }

--- a/language/move-vm/runtime/Cargo.toml
+++ b/language/move-vm/runtime/Cargo.toml
@@ -16,9 +16,9 @@ fail = "0.4.0"
 mirai-annotations = "1.10.1"
 once_cell = "1.7.2"
 parking_lot = "0.11.1"
+sha3 = "0.9.1"
 
 bytecode-verifier = { path = "../../bytecode-verifier" }
-diem-crypto = { path = "../../../crypto/crypto" }
 diem-logger = { path = "../../../common/logger" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = { path = "../../move-core/types" }

--- a/x.toml
+++ b/x.toml
@@ -246,7 +246,6 @@ existing_deps = [
     ["bytecode-interpreter", "diem-crypto"],                  # implementation of native functions
     ["compiler", "diem-framework-releases"],
     ["move-vm-runtime", "diem-logger"],
-    ["move-vm-runtime", "diem-crypto"],                       # using `HashValue` as keys in the script cache
     ["move-cli", "vm-genesis"],
     ["move-cli", "diem-vm"],
     ["move-cli", "diem-types"],                               # `ContractEvent`


### PR DESCRIPTION
The Move VM uses the diem-crypto crate to compute the script hashes. This gets it replaced with the sha3 crate, removing the dependency on diem. The same algorithm (sha3) is used.