### PR TITLE
[language][move-stdlib] remove diem dependency: diem-crypto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4744,7 +4744,6 @@ dependencies = [
 name = "move-stdlib"
 version = "0.1.0"
 dependencies = [
- "diem-crypto",
  "diem-workspace-hack",
  "dir-diff",
  "docgen",
@@ -4756,6 +4755,7 @@ dependencies = [
  "move-vm-runtime",
  "move-vm-types",
  "sha2",
+ "sha3",
  "smallvec",
  "tempfile",
  "walkdir",

--- a/language/move-stdlib/Cargo.toml
+++ b/language/move-stdlib/Cargo.toml
@@ -18,13 +18,13 @@ diem-workspace-hack = { path = "../../common/workspace-hack" }
 move-vm-types = { path = "../move-vm/types" }
 move-binary-format = { path = "../move-binary-format" }
 move-core-types = { path = "../move-core/types" }
-diem-crypto = { path = "../../crypto/crypto" }
 move-vm-runtime = { path = "../move-vm/runtime" }
 
 log = "0.4.14"
 walkdir = "2.3.1"
 smallvec = "1.6.1"
 sha2 = "0.9.3"
+sha3 = "0.9.1"
 
 [dev-dependencies]
 move-unit-test = { path = "../tools/move-unit-test" }

--- a/language/move-stdlib/src/natives/hash.rs
+++ b/language/move-stdlib/src/natives/hash.rs
@@ -1,7 +1,6 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use diem_crypto::HashValue;
 use move_binary_format::errors::PartialVMResult;
 use move_vm_runtime::native_functions::NativeContext;
 use move_vm_types::{
@@ -12,6 +11,7 @@ use move_vm_types::{
     values::Value,
 };
 use sha2::{Digest, Sha256};
+use sha3::Sha3_256;
 use smallvec::smallvec;
 use std::collections::VecDeque;
 
@@ -54,7 +54,7 @@ pub fn native_sha3_256(
         hash_arg.len(),
     );
 
-    let hash_vec = HashValue::sha3_256_of(hash_arg.as_slice()).to_vec();
+    let hash_vec = Sha3_256::digest(hash_arg.as_slice()).to_vec();
     Ok(NativeResult::ok(
         cost,
         smallvec![Value::vector_u8(hash_vec)],

--- a/x.toml
+++ b/x.toml
@@ -251,7 +251,6 @@ existing_deps = [
     ["move-cli", "diem-types"],                               # `ContractEvent`
     ["move-cli", "diem-framework"],
     ["move-cli", "diem-framework-releases"],
-    ["move-stdlib", "diem-crypto"],
 
     # Tier 1 - crates that can wait a little bit longer?
     ["language-benchmarks", "language-e2e-tests"],


### PR DESCRIPTION
The `diem-crypto` crate is used to implement the sha3_256 native function. This replaces it with the implementation from crate `sha3` instead, removing the diem dependency.
