### PR TITLE
[language][binary-format] remove diem-dependency: num-variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4445,12 +4445,12 @@ dependencies = [
  "diem-workspace-hack",
  "mirai-annotations",
  "move-core-types",
- "num-variants",
  "once_cell",
  "proptest",
  "proptest-derive",
  "ref-cast",
  "serde_json",
+ "variant_count",
 ]
 
 [[package]]
@@ -8184,6 +8184,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "variant_count"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae2faf80ac463422992abf4de234731279c058aaf33171ca70277c98406b124"
+dependencies = [
+ "quote 1.0.9",
+ "syn 1.0.72",
 ]
 
 [[package]]

--- a/language/move-binary-format/Cargo.toml
+++ b/language/move-binary-format/Cargo.toml
@@ -16,9 +16,9 @@ mirai-annotations = "1.10.1"
 proptest = { version = "1.0.0", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 ref-cast = "1.0.6"
+variant_count = "1.1.0"
 diem-workspace-hack = { path = "../../common/workspace-hack" }
 move-core-types = { path = "../move-core/types" }
-num-variants = { path = "../../common/num-variants" }
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/language/move-binary-format/src/file_format.rs
+++ b/language/move-binary-format/src/file_format.rs
@@ -41,13 +41,13 @@ use move_core_types::{
     language_storage::ModuleId,
     vm_status::StatusCode,
 };
-use num_variants::NumVariants;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest::{collection::vec, prelude::*, strategy::BoxedStrategy};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use ref_cast::RefCast;
 use std::ops::BitOr;
+use variant_count::VariantCount;
 
 /// Generic index into one of the tables in the binary format.
 pub type TableIndex = u16;
@@ -1051,10 +1051,9 @@ pub struct CodeUnit {
 ///
 /// Bytecodes operate on a stack machine and each bytecode has side effect on the stack and the
 /// instruction stream.
-#[derive(Clone, Hash, Eq, NumVariants, PartialEq)]
+#[derive(Clone, Hash, Eq, VariantCount, PartialEq)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
-#[num_variants = "NUM_INSTRUCTIONS"]
 pub enum Bytecode {
     /// Pop and discard the value at the top of the stack.
     /// The value on the stack must be an copyable type.

--- a/language/move-vm/types/src/gas_schedule.rs
+++ b/language/move-vm/types/src/gas_schedule.rs
@@ -147,7 +147,7 @@ pub fn new_from_instructions(
             }
         }
         debug_assert!(
-            instructions_covered == Bytecode::NUM_INSTRUCTIONS,
+            instructions_covered == Bytecode::VARIANT_COUNT,
             "all instructions must be in the cost table"
         );
     }

--- a/x.toml
+++ b/x.toml
@@ -252,7 +252,6 @@ existing_deps = [
     ["move-cli", "diem-types"],                               # `ContractEvent`
     ["move-cli", "diem-framework"],
     ["move-cli", "diem-framework-releases"],
-    ["move-binary-format", "num-variants"],                   # counting the number of bytecodes
     ["move-stdlib", "diem-crypto"],
 
     # Tier 1 - crates that can wait a little bit longer?


### PR DESCRIPTION
This replaces crate `num-variants` (a diem dependency) with `variant_count`, which has the same functionality.
