### PR TITLE
[bytecode verifier][invalid mutations] remove diem-dependency: diem-proptest-helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3934,7 +3934,6 @@ dependencies = [
 name = "invalid-mutations"
 version = "0.1.0"
 dependencies = [
- "diem-proptest-helpers",
  "diem-workspace-hack",
  "move-binary-format",
  "move-core-types",

--- a/language/bytecode-verifier/invalid-mutations/Cargo.toml
+++ b/language/bytecode-verifier/invalid-mutations/Cargo.toml
@@ -13,7 +13,6 @@ publish = false
 move-core-types = { path = "../../move-core/types" }
 move-binary-format = { path = "../../move-binary-format" }
 proptest = "1.0.0"
-diem-proptest-helpers = { path = "../../../common/proptest-helpers" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 
 [features]

--- a/language/bytecode-verifier/invalid-mutations/src/bounds.rs
+++ b/language/bytecode-verifier/invalid-mutations/src/bounds.rs
@@ -1,7 +1,6 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use diem_proptest_helpers::pick_slice_idxs;
 use move_binary_format::{
     errors::{bounds_error, PartialVMError},
     file_format::{
@@ -220,7 +219,7 @@ impl ApplyOutOfBoundsContext {
         };
         // Any signature can be a destination, not just the ones that have structs in them.
         let dst_count = self.module.kind_count(dst_kind);
-        let to_mutate = pick_slice_idxs(src_count, &mutations);
+        let to_mutate = crate::helpers::pick_slice_idxs(src_count, &mutations);
 
         mutations
             .iter()

--- a/language/bytecode-verifier/invalid-mutations/src/bounds/code_unit.rs
+++ b/language/bytecode-verifier/invalid-mutations/src/bounds/code_unit.rs
@@ -1,7 +1,6 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use diem_proptest_helpers::pick_slice_idxs;
 use move_binary_format::{
     errors::{offset_out_of_bounds, PartialVMError},
     file_format::{
@@ -172,7 +171,7 @@ impl<'a> ApplyCodeUnitBoundsContext<'a> {
         let interesting_offsets: Vec<usize> = (0..code.len())
             .filter(|bytecode_idx| is_interesting(&code[*bytecode_idx]))
             .collect();
-        let to_mutate = pick_slice_idxs(interesting_offsets.len(), &mutations);
+        let to_mutate = crate::helpers::pick_slice_idxs(interesting_offsets.len(), &mutations);
 
         // These have to be computed upfront because self.module is being mutated below.
         let constant_pool_len = self.module.constant_pool.len();

--- a/language/bytecode-verifier/invalid-mutations/src/helpers.rs
+++ b/language/bytecode-verifier/invalid-mutations/src/helpers.rs
@@ -1,0 +1,49 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use proptest::sample::Index as PropIndex;
+use std::{collections::BTreeSet, ops::Index as OpsIndex};
+
+/// Given a maximum value `max` and a list of [`Index`](proptest::sample::Index) instances, picks
+/// integers in the range `[0, max)` uniformly randomly and without duplication.
+///
+/// If `indexes_len` is greater than `max`, all indexes will be returned.
+///
+/// This function implements [Robert Floyd's F2
+/// algorithm](https://blog.acolyer.org/2018/01/30/a-sample-of-brilliance/) for sampling without
+/// replacement.
+pub(crate) fn pick_idxs<T, P>(max: usize, indexes: &T, indexes_len: usize) -> Vec<usize>
+where
+    T: OpsIndex<usize, Output = P> + ?Sized,
+    P: AsRef<PropIndex>,
+{
+    // See https://blog.acolyer.org/2018/01/30/a-sample-of-brilliance/ (the F2 algorithm)
+    // for a longer explanation. This is a variant that works with zero-indexing.
+    let mut selected = BTreeSet::new();
+    let to_select = indexes_len.min(max);
+    for (iter_idx, choice) in ((max - to_select)..max).enumerate() {
+        // "RandInt(1, J)" in the original algorithm means a number between 1
+        // and choice, both inclusive. `PropIndex::index` picks a number between 0 and
+        // whatever's passed in, with the latter exclusive. Pass in "+1" to ensure the same
+        // range of values is picked from. (This also ensures that if choice is 0 then `index`
+        // doesn't panic.
+        let idx = indexes[iter_idx].as_ref().index(choice + 1);
+        if !selected.insert(idx) {
+            selected.insert(choice);
+        }
+    }
+    selected.into_iter().collect()
+}
+
+/// Given a maximum value `max` and a slice of [`Index`](proptest::sample::Index) instances, picks
+/// integers in the range `[0, max)` uniformly randomly and without duplication.
+///
+/// If the number of `Index` instances is greater than `max`, all indexes will be returned.
+///
+/// This function implements [Robert Floyd's F2
+/// algorithm](https://blog.acolyer.org/2018/01/30/a-sample-of-brilliance/) for sampling without
+/// replacement.
+#[inline]
+pub(crate) fn pick_slice_idxs(max: usize, indexes: &[impl AsRef<PropIndex>]) -> Vec<usize> {
+    pick_idxs(max, indexes, indexes.len())
+}

--- a/language/bytecode-verifier/invalid-mutations/src/lib.rs
+++ b/language/bytecode-verifier/invalid-mutations/src/lib.rs
@@ -4,4 +4,5 @@
 #![forbid(unsafe_code)]
 
 pub mod bounds;
+mod helpers;
 pub mod signature;

--- a/x.toml
+++ b/x.toml
@@ -242,7 +242,6 @@ existing_deps = [
     # Tier 0 - essential components that must be included in the first batch of crates getting
     #          moved to the new repo
     ["move-lang", "diem-framework"],                          # sanity check to ensure that the diem-framework compiles
-    ["invalid-mutations", "diem-proptest-helpers"],           # pick_slice_idxs
     ["bytecode-verifier-tests", "diem-framework-releases"],
     ["bytecode-interpreter", "diem-crypto"],                  # implementation of native functions
     ["compiler", "diem-framework-releases"],


### PR DESCRIPTION
This duplicates a simple helper function in the crate so it doesn't need to depend on diem-proptest-helpers, which is a diem dependency.