### PR TITLE
[forge] added dockerhub secrets for forge codebuild

### DIFF
--- a/docker/forge/buildspec.yaml
+++ b/docker/forge/buildspec.yaml
@@ -1,14 +1,19 @@
 # This buildspec is for AWS Codebuild
 version: 0.2
 
+env:
+  secrets-manager:
+    DOCKERHUB_USERNAME: dockerhub_ro_username
+    DOCKERHUB_PASSWORD: dockerhub_ro_password
+
 phases:
   install:
     runtime-versions:
       docker: 18
   pre_build:
     commands:
-      - echo Logging in to Amazon ECR...
-      - $(aws ecr get-login --no-include-email --region us-west-2)
+      - echo logging in to dockerhub.
+      - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
   build:
     commands:
       - echo Build started on `date`
@@ -18,4 +23,6 @@ phases:
     commands:
       - echo Build completed on `date`
       # Tag and push the docker images
+      - echo Logging in to Amazon ECR...
+      - $(aws ecr get-login --no-include-email --region us-west-2)
       - SOURCE=diem/forge:latest TARGET_REPO=$DIEM_FORGE_REPO TARGET_TAGS="${TAGS}:dev_$(git rev-parse --short=8  HEAD)" docker/tag-and-push.sh


### PR DESCRIPTION
Add dockerhub account secrets to forge codebuild to avoid pull rate limit

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

./docker/build-aws.sh --build-forge --version pull/8571

## Related PRs

(If this PR adds or changes functionality, please take some time to update or suggest changes to the docs at https://developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
