### PR TITLE
Use latest 'changes' action to support dependabot

### DIFF
--- a/.github/workflows/ci-publish-base-image.yml
+++ b/.github/workflows/ci-publish-base-image.yml
@@ -34,7 +34,7 @@ jobs:
         run: ./scripts/git-checks.sh
       - id: changes
         name: determine changes
-        uses: diem/actions/changes@78f868bd1170a959f0a9864e33df725690b45b9a
+        uses: diem/actions/changes@266156eaff7ba6e1253cf7019506c7b3702f73de
         with:
           workflow-file: ci-publish-base-image.yml
       - name: build image

--- a/.github/workflows/ci-test-complete.yml
+++ b/.github/workflows/ci-test-complete.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
       - name: Download artifacts
-        uses: diem/actions/get-artifacts@a5fa31ff2b54a544cd88ac912cda469742592e6c
+        uses: diem/actions/get-artifacts@266156eaff7ba6e1253cf7019506c7b3702f73de
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           workflow_run_id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -45,12 +45,12 @@ jobs:
         run: ./scripts/git-checks.sh
       - id: changes
         name: determine changes
-        uses: diem/actions/changes@78f868bd1170a959f0a9864e33df725690b45b9a
+        uses: diem/actions/changes@266156eaff7ba6e1253cf7019506c7b3702f73de
         with:
           workflow-file: ci-test.yml
       - id: need-build-images
         name: find changes need image build.
-        uses: diem/actions/matches@78f868bd1170a959f0a9864e33df725690b45b9a
+        uses: diem/actions/matches@266156eaff7ba6e1253cf7019506c7b3702f73de
         with:
           pattern: '^documentation\|^developers.diem.com'
           invert: "true"
@@ -92,39 +92,39 @@ jobs:
           echo "::set-output name=name::$(echo $output)";
       - id: rust-changes
         name: find rust/cargo changes.
-        uses: diem/actions/matches@78f868bd1170a959f0a9864e33df725690b45b9a
+        uses: diem/actions/matches@266156eaff7ba6e1253cf7019506c7b3702f73de
         with:
           pattern: '^documentation\|^docker\|^scripts\|^developers.diem.com'
           invert: "true"
       - id: non-rust-lint-changes
         name: find shell/dockerfile changes
-        uses: diem/actions/matches@78f868bd1170a959f0a9864e33df725690b45b9a
+        uses: diem/actions/matches@266156eaff7ba6e1253cf7019506c7b3702f73de
         with:
           pattern: 'Dockerfile$\|.*.sh$|^developers.diem.com'
       - id: helm-changes
         name: find helm changes
-        uses: diem/actions/matches@78f868bd1170a959f0a9864e33df725690b45b9a
+        uses: diem/actions/matches@266156eaff7ba6e1253cf7019506c7b3702f73de
         with:
           pattern: '^.github\|^helm\|^developers.diem.com'
       - id: dev-setup-sh-changes
         name: find dev-setup.sh/base docker image changes
-        uses: diem/actions/matches@78f868bd1170a959f0a9864e33df725690b45b9a
+        uses: diem/actions/matches@266156eaff7ba6e1253cf7019506c7b3702f73de
         with:
           pattern: 'docker/ci\|scripts/dev_setup.sh'
       - id: docker-compose-changes
         name: find changes that should trigger docker compose testing.
-        uses: diem/actions/matches@78f868bd1170a959f0a9864e33df725690b45b9a
+        uses: diem/actions/matches@266156eaff7ba6e1253cf7019506c7b3702f73de
         with:
           pattern: "^documentation"
           invert: "true"
       - id: website-changes
         name: find website changes.
-        uses: diem/actions/matches@78f868bd1170a959f0a9864e33df725690b45b9a
+        uses: diem/actions/matches@266156eaff7ba6e1253cf7019506c7b3702f73de
         with:
           pattern: "^documentation|^developers.diem.com"
       - id: test-coverage
         name: check if we should see if code coverage still works.
-        uses: diem/actions/matches@78f868bd1170a959f0a9864e33df725690b45b9a
+        uses: diem/actions/matches@266156eaff7ba6e1253cf7019506c7b3702f73de
         with:
           pattern: '^rust.toolchain\|^x.toml\|^devtools\|^.github\|common/logger'
 
@@ -162,7 +162,7 @@ jobs:
           fetch-depth: 0 #get all the history!!!
       - id: changes
         name: determine changes
-        uses: diem/actions/changes@78f868bd1170a959f0a9864e33df725690b45b9a
+        uses: diem/actions/changes@266156eaff7ba6e1253cf7019506c7b3702f73de
         with:
           workflow-file: docker-publish.yml
       - name: setup_aws_ecr_login

--- a/.github/workflows/ci-update-sccache.yml
+++ b/.github/workflows/ci-update-sccache.yml
@@ -28,12 +28,12 @@ jobs:
           fetch-depth: 0 #get all the history!!!
       - id: changes
         name: determine changes
-        uses: diem/actions/changes@78f868bd1170a959f0a9864e33df725690b45b9a
+        uses: diem/actions/changes@266156eaff7ba6e1253cf7019506c7b3702f73de
         with:
           workflow-file: ci-update-sccache.yml
       - id: rust-changes
         name: find rust/cargo changes.
-        uses: diem/actions/matches@78f868bd1170a959f0a9864e33df725690b45b9a
+        uses: diem/actions/matches@266156eaff7ba6e1253cf7019506c7b3702f73de
         with:
           pattern: '^documentation\|^docker\|^scripts'
           invert: "true"
@@ -77,7 +77,7 @@ jobs:
       - uses: ./.github/actions/build-setup
         # build setup is called to ensure the latest docker image tooling is in place and the ~/.profile is called.
       - name: Publish unit test results
-        uses: diem/actions/process-test-results@78f868bd1170a959f0a9864e33df725690b45b9a
+        uses: diem/actions/process-test-results@266156eaff7ba6e1253cf7019506c7b3702f73de
         with:
           #used to read artifacts, annoying to need one.
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0 #get all the history!!!
       - id: changes
         name: determine changes
-        uses: diem/actions/changes@78f868bd1170a959f0a9864e33df725690b45b9a
+        uses: diem/actions/changes@266156eaff7ba6e1253cf7019506c7b3702f73de
         with:
           workflow-file: docker-publish.yml
       - name: setup_aws_ecr_login


### PR DESCRIPTION
## Motivation

The latest changes action supports the messages created by bors for dependabot prs.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

land a dependabot pr after this lands.   Local testing of changes to shell script.

## Related PRs

https://github.com/diem/actions/pull/22

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
