### PR TITLE
[stackless-vm] remove dep on diem-crypto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,6 +639,7 @@ name = "bytecode-interpreter-crypto"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "curve25519-dalek-fiat",
  "diem-workspace-hack",
  "ed25519-dalek-fiat",
  "sha2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,9 +619,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytecode",
+ "bytecode-interpreter-crypto",
  "codespan-reporting",
  "datatest-stable",
- "diem-crypto",
  "diem-workspace-hack",
  "itertools 0.10.0",
  "move-binary-format",
@@ -631,8 +631,18 @@ dependencies = [
  "move-vm-runtime",
  "num 0.4.0",
  "serde",
- "sha2",
  "structopt 0.3.21",
+]
+
+[[package]]
+name = "bytecode-interpreter-crypto"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "diem-workspace-hack",
+ "ed25519-dalek-fiat",
+ "sha2",
+ "sha3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ members = [
     "language/move-prover/docgen",
     "language/move-prover/errmapgen",
     "language/move-prover/interpreter",
+    "language/move-prover/interpreter/crypto",
     "language/move-prover/interpreter-testsuite",
     "language/move-prover/lab",
     "language/move-prover/test-utils",

--- a/language/move-prover/interpreter/Cargo.toml
+++ b/language/move-prover/interpreter/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 [dependencies]
 # diem dependencies
 bytecode = { path = "../bytecode" }
-diem-crypto = { path = "../../../crypto/crypto" }
+bytecode-interpreter-crypto = { path = "crypto" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-binary-format = { path = "../../move-binary-format" }
 move-core-types = { path = "../../move-core/types" }
@@ -21,7 +21,6 @@ anyhow = "1.0.38"
 codespan-reporting = "0.8.0"
 itertools = "0.10.0"
 num = "0.4.0"
-sha2 = "0.9.3"
 serde = { version = "1.0.124", features = ["derive"] }
 structopt = "0.3.21"
 

--- a/language/move-prover/interpreter/crypto/Cargo.toml
+++ b/language/move-prover/interpreter/crypto/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "bytecode-interpreter-crypto"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+publish = false
+edition = "2018"
+license = "Apache-2.0"
+
+[dependencies]
+diem-workspace-hack = { path = "../../../../common/workspace-hack" }
+
+# external dependencies
+anyhow = "1.0.38"
+ed25519-dalek = { version = "0.1.0", package = "ed25519-dalek-fiat", default-features = false, features = ["std", "serde"] }
+sha2 = "0.9.3"
+sha3 = "0.9.1"

--- a/language/move-prover/interpreter/crypto/Cargo.toml
+++ b/language/move-prover/interpreter/crypto/Cargo.toml
@@ -11,6 +11,7 @@ diem-workspace-hack = { path = "../../../../common/workspace-hack" }
 
 # external dependencies
 anyhow = "1.0.38"
+curve25519-dalek = { version = "0.1.0", package = "curve25519-dalek-fiat", default-features = false, features = ["std"] }
 ed25519-dalek = { version = "0.1.0", package = "ed25519-dalek-fiat", default-features = false, features = ["std", "serde"] }
 sha2 = "0.9.3"
 sha3 = "0.9.1"

--- a/language/move-prover/interpreter/crypto/src/lib.rs
+++ b/language/move-prover/interpreter/crypto/src/lib.rs
@@ -1,0 +1,36 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use ed25519_dalek::{
+    ed25519::signature::Signature, PublicKey as Ed25519PublicKey, Signature as Ed25519Signature,
+};
+
+use sha2::{Digest, Sha256};
+use sha3::Sha3_256;
+
+// Hash functions
+pub fn sha2_256_of(bytes: &[u8]) -> Vec<u8> {
+    Sha256::digest(&bytes).to_vec()
+}
+
+pub fn sha3_256_of(bytes: &[u8]) -> Vec<u8> {
+    Sha3_256::digest(&bytes).to_vec()
+}
+
+// Ed25519
+pub fn ed25519_deserialize_public_key(bytes: &[u8]) -> Result<Ed25519PublicKey> {
+    Ok(Ed25519PublicKey::from_bytes(bytes)?)
+}
+
+pub fn ed25519_deserialize_signature(bytes: &[u8]) -> Result<Ed25519Signature> {
+    Ok(Ed25519Signature::from_bytes(bytes)?)
+}
+
+pub fn ed25519_verify_signature(
+    key: &Ed25519PublicKey,
+    sig: &Ed25519Signature,
+    msg: &[u8],
+) -> Result<()> {
+    Ok(key.verify_strict(msg, sig)?)
+}

--- a/language/move-prover/interpreter/crypto/src/lib.rs
+++ b/language/move-prover/interpreter/crypto/src/lib.rs
@@ -1,13 +1,30 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
+//! This file duplicates the code in the diem-crypto crate to support
+//! - native function implementation for the stackless bytecode interpreter, and
+//! - decoupling of Move crates from Diem crates.
+//!
+//! This is expected to be a temporary solution only. Once we properly
+//! restructure the stackless interpreter like what we did to the Move VM,
+//! native functions will likely be implemented in a Diem crate (most likely
+//! diem-framework) and be passed into the VM for execution. In this way we no
+//! longer need to worry about depending on diem-crypto.
+
+use anyhow::{bail, Result};
 use ed25519_dalek::{
     ed25519::signature::Signature, PublicKey as Ed25519PublicKey, Signature as Ed25519Signature,
+    PUBLIC_KEY_LENGTH as ED25519_PUBLIC_KEY_LENGTH, SIGNATURE_LENGTH as ED25519_SIGNATURE_LENGTH,
 };
-
 use sha2::{Digest, Sha256};
 use sha3::Sha3_256;
+use std::cmp::Ordering;
+
+/// The order of ed25519 as defined in [RFC8032](https://tools.ietf.org/html/rfc8032).
+const L: [u8; 32] = [
+    0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58, 0xd6, 0x9c, 0xf7, 0xa2, 0xde, 0xf9, 0xde, 0x14,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10,
+];
 
 // Hash functions
 pub fn sha2_256_of(bytes: &[u8]) -> Vec<u8> {
@@ -19,11 +36,53 @@ pub fn sha3_256_of(bytes: &[u8]) -> Vec<u8> {
 }
 
 // Ed25519
+fn validate_public_key(bytes: &[u8]) -> bool {
+    // We need to access the Edwards point which is not directly accessible from
+    // ed25519_dalek::PublicKey, so we need to do some custom deserialization.
+    if bytes.len() != ED25519_PUBLIC_KEY_LENGTH {
+        return false;
+    }
+
+    let mut bits = [0u8; ED25519_PUBLIC_KEY_LENGTH];
+    bits.copy_from_slice(&bytes[..ED25519_PUBLIC_KEY_LENGTH]);
+
+    let compressed = curve25519_dalek::edwards::CompressedEdwardsY(bits);
+    let point = match compressed.decompress() {
+        None => return false,
+        Some(point) => point,
+    };
+
+    // Check if the point lies on a small subgroup. This is required
+    // when using curves with a small cofactor (in ed25519, cofactor = 8).
+    !point.is_small_order()
+}
+
 pub fn ed25519_deserialize_public_key(bytes: &[u8]) -> Result<Ed25519PublicKey> {
+    if !validate_public_key(bytes) {
+        bail!("Invalid public key bytes");
+    }
     Ok(Ed25519PublicKey::from_bytes(bytes)?)
 }
 
+fn validate_signature(bytes: &[u8]) -> bool {
+    if bytes.len() != ED25519_SIGNATURE_LENGTH {
+        return false;
+    }
+    for i in (0..32).rev() {
+        match bytes[32 + i].cmp(&L[i]) {
+            Ordering::Less => return true,
+            Ordering::Greater => return false,
+            _ => (),
+        }
+    }
+    // As this stage S == L which implies a non canonical S.
+    false
+}
+
 pub fn ed25519_deserialize_signature(bytes: &[u8]) -> Result<Ed25519Signature> {
+    if !validate_signature(bytes) {
+        bail!("Invalid signature bytes");
+    }
     Ok(Ed25519Signature::from_bytes(bytes)?)
 }
 
@@ -32,5 +91,11 @@ pub fn ed25519_verify_signature(
     sig: &Ed25519Signature,
     msg: &[u8],
 ) -> Result<()> {
+    if !validate_public_key(&key.to_bytes()) {
+        bail!("Malleable public key");
+    }
+    if !validate_signature(&sig.to_bytes()) {
+        bail!("Malleable signature");
+    }
     Ok(key.verify_strict(msg, sig)?)
 }

--- a/x.toml
+++ b/x.toml
@@ -69,6 +69,11 @@ name = "diem-crypto-derive"
 version = "0.1.0"
 workspace-path = "crypto/crypto-derive"
 
+[[hakari.omitted-packages]]
+name = "bytecode-interpreter-crypto"
+version = "0.1.0"
+workspace-path = "language/move-prover/interpreter/crypto"
+
 # Also exclude the devtools packages since they get compiled with a different set of options.
 [[hakari.omitted-packages]]
 name = "x"
@@ -245,7 +250,6 @@ existing_deps = [
     # Tier 0 - essential components that must be included in the first batch of crates getting
     #          moved to the new repo
     ["move-lang", "diem-framework"],                          # sanity check to ensure that the diem-framework compiles
-    ["bytecode-interpreter", "diem-crypto"],                  # implementation of native functions
     ["compiler", "diem-framework-releases"],
     ["move-vm-runtime", "diem-logger"],
     ["move-cli", "vm-genesis"],


### PR DESCRIPTION
## Motivation

Cooperating as part of the effort of removing dependencies from
Move to Diem crates.

After discussion with @vgao1996, we believe that it is OK for now to
manually unroll the implementation of a few crypto native functions.
We need to come up with a better architecture on exposing
package-dependent native functions to the stackless VM (and in a
broader scope, to the Move prover) in the future.

Only the first commit requires a review, the content in the `fixup!`
commit is auto-generated with `cargo x generate-workspace-hack` 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- CI
- Diem framework e2e tests replay with the stackless VM
