### PR TITLE
[dev-infra] Removing pre-command from install_pkg invocation

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -736,7 +736,7 @@ if [[ "$PACKAGE_MANAGER" == "apt-get" ]]; then
   if [[ "$BATCH_MODE" == "false" ]]; then
    echo "Installing ca-certificates......"
   fi
-	"${PRE_COMMAND[@]}" install_pkg ca-certificates "$PACKAGE_MANAGER"
+	install_pkg ca-certificates "$PACKAGE_MANAGER"
 fi
 
 if [[ "$INSTALL_PROFILE" == "true" ]]; then


### PR DESCRIPTION
install_pkg is a shell function, and if the pre-command e.g. expands to `sudo` like in my ubuntu system, this leads to failure.

## Motivation

devsetup fails on my Ubuntu/PopOS box.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Manual
