### PR TITLE
[bytecode-verifier-tests] remove unused diem dependency: diem-framework-releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,7 +682,6 @@ name = "bytecode-verifier-tests"
 version = "0.1.0"
 dependencies = [
  "bytecode-verifier",
- "diem-framework-releases",
  "diem-workspace-hack",
  "invalid-mutations",
  "move-binary-format",

--- a/language/bytecode-verifier/bytecode-verifier-tests/Cargo.toml
+++ b/language/bytecode-verifier/bytecode-verifier-tests/Cargo.toml
@@ -17,7 +17,6 @@ bytecode-verifier = { path = "../" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 invalid-mutations = { path = "../invalid-mutations" }
 move-core-types = { path = "../../move-core/types" }
-diem-framework-releases = { path = "../../diem-framework/releases" }
 move-binary-format = { path = "../../move-binary-format", features = ["fuzzing"] }
 
 [features]

--- a/x.toml
+++ b/x.toml
@@ -242,7 +242,6 @@ existing_deps = [
     # Tier 0 - essential components that must be included in the first batch of crates getting
     #          moved to the new repo
     ["move-lang", "diem-framework"],                          # sanity check to ensure that the diem-framework compiles
-    ["bytecode-verifier-tests", "diem-framework-releases"],
     ["bytecode-interpreter", "diem-crypto"],                  # implementation of native functions
     ["compiler", "diem-framework-releases"],
     ["move-vm-runtime", "diem-logger"],


### PR DESCRIPTION
This removes diem-framework-releases as a dependency from the crate, which is unused anyway.