### PR TITLE
[forge] k8s backend implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3212,6 +3212,7 @@ name = "forge"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "base64",
  "debug-interface",
  "diem-config",
  "diem-genesis-tool",
@@ -3221,6 +3222,8 @@ dependencies = [
  "diem-workspace-hack",
  "futures",
  "itertools 0.10.0",
+ "k8s-openapi",
+ "kube",
  "rand 0.8.3",
  "rand_core 0.6.2",
  "reqwest",

--- a/scripts/fgi
+++ b/scripts/fgi
@@ -9,13 +9,14 @@ PR=""
 WORKSPACE=""
 ENV=""
 LOCAL_BUILD=""
+LOCAL_SWARM=""
 EXIT_CODE=0
 # Default timeout is 45 mins
 TIMEOUT_SECS=2700
 
 AWS_ACCOUNT=${AWS_ACCOUNT:-$(aws sts get-caller-identity --query Account --output text)}
 
-FORGE_K8S_CLUSTERS=(rustietest)
+FORGE_K8S_CLUSTERS=(forge-1)
 K8S_CONTEXT_PATTERN="arn:aws:eks:us-west-2:${AWS_ACCOUNT}:cluster/libra-CLUSTERNAME"
 HELM_CHARTS_URL_PATTERN="s3://diem-testnet-CLUSTERNAME-helm/charts"
 GRAFANA_URL_PATTERN="http://mon.CLUSTERNAME.aws.hlw3truzy4ls.com"
@@ -30,7 +31,7 @@ join_args() {
   retval_join_args=""
   for var in "$@"
   do
-    retval_join_args="${retval_join_args}, \"${var}\""
+    retval_join_args="${retval_join_args} \"${var}\""
   done
 }
 
@@ -150,6 +151,10 @@ while (( "$#" )); do
       TIMEOUT_SECS=$2
       shift 2
       ;;
+    --local-swarm)
+      LOCAL_SWARM="yes"
+      shift 1
+      ;;
     -T|--tag)
       TAG=$2
       shift 2
@@ -167,6 +172,11 @@ while (( "$#" )); do
       ;;
   esac
 done
+
+if [ -n "$LOCAL_SWARM" ]; then
+  cargo run -p forge -- --local-swarm
+  exit $EXIT_CODE
+fi
 
 if ! which kubectl &>/dev/null; then
   echo "kubectl is not installed. Please install kubectl. On mac, you can use: brew install kubectl"

--- a/testsuite/forge/Cargo.toml
+++ b/testsuite/forge/Cargo.toml
@@ -30,3 +30,6 @@ diem-config = { path = "../../config" }
 diem-workspace-hack = { path = "../../common/workspace-hack" }
 diem-genesis-tool = { path = "../../config/management/genesis" }
 diem-retrier = { path = "../../common/retrier" }
+base64 = "0.13.0"
+kube = "0.51.0"
+k8s-openapi = { version = "0.11.0", default-features = false, features = ["v1_15"] }

--- a/testsuite/forge/src/backend/k8s.rs
+++ b/testsuite/forge/src/backend/k8s.rs
@@ -1,4 +1,0 @@
-// Copyright (c) The Diem Core Contributors
-// SPDX-License-Identifier: Apache-2.0
-
-// Placeholder file for k8s backend

--- a/testsuite/forge/src/backend/k8s/mod.rs
+++ b/testsuite/forge/src/backend/k8s/mod.rs
@@ -1,0 +1,37 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{Factory, Swarm};
+use tokio::runtime::Runtime;
+
+mod node;
+mod swarm;
+pub use node::K8sNode;
+pub use swarm::*;
+
+pub struct K8sFactory {
+    root_key: String,
+    treasury_compliance_key: String,
+}
+
+impl K8sFactory {
+    pub fn new(root_key: String, treasury_compliance_key: String) -> Self {
+        Self {
+            root_key,
+            treasury_compliance_key,
+        }
+    }
+}
+
+impl Factory for K8sFactory {
+    fn launch_swarm(&self, _node_num: usize) -> Box<dyn Swarm> {
+        let rt = Runtime::new().unwrap();
+        let swarm = rt
+            .block_on(K8sSwarm::new(
+                self.root_key.clone(),
+                self.treasury_compliance_key.clone(),
+            ))
+            .unwrap();
+        Box::new(swarm)
+    }
+}

--- a/testsuite/forge/src/backend/k8s/node.rs
+++ b/testsuite/forge/src/backend/k8s/node.rs
@@ -1,0 +1,94 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{FullNode, HealthCheckError, Node, Result, Validator};
+use anyhow::format_err;
+use diem_config::config::NodeConfig;
+use diem_sdk::{client::Client as JsonRpcClient, types::PeerId};
+use reqwest::Url;
+use std::str::FromStr;
+use tokio::runtime::Runtime;
+
+pub struct K8sNode {
+    pub(crate) name: String,
+    pub(crate) peer_id: PeerId,
+    pub(crate) node_id: usize,
+    pub(crate) dns: String,
+    pub(crate) ip: String,
+    pub(crate) port: u32,
+    pub(crate) runtime: Runtime,
+}
+
+impl K8sNode {
+    fn port(&self) -> u32 {
+        self.port
+    }
+
+    #[allow(dead_code)]
+    fn dns(&self) -> String {
+        self.dns.clone()
+    }
+
+    fn ip(&self) -> String {
+        self.ip.clone()
+    }
+
+    #[allow(dead_code)]
+    fn node_id(&self) -> usize {
+        self.node_id
+    }
+
+    pub(crate) fn json_rpc_client(&self) -> JsonRpcClient {
+        JsonRpcClient::new(self.json_rpc_endpoint().to_string())
+    }
+}
+
+impl Node for K8sNode {
+    fn peer_id(&self) -> PeerId {
+        self.peer_id
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn json_rpc_endpoint(&self) -> Url {
+        Url::from_str(&format!("http://{}:{}/v1", self.ip(), self.port())).expect("Invalid URL.")
+    }
+
+    fn debug_endpoint(&self) -> Url {
+        Url::parse(&format!("http://{}:{}", self.ip(), self.port())).unwrap()
+    }
+
+    fn config(&self) -> &NodeConfig {
+        todo!()
+    }
+
+    fn start(&mut self) -> Result<()> {
+        todo!()
+    }
+
+    fn stop(&mut self) -> Result<()> {
+        todo!()
+    }
+
+    fn clear_storage(&mut self) -> Result<()> {
+        todo!()
+    }
+
+    fn health_check(&mut self) -> Result<(), HealthCheckError> {
+        let results = self
+            .runtime
+            .block_on(self.json_rpc_client().batch(Vec::new()))
+            .unwrap();
+        if results.iter().all(Result::is_ok) {
+            return Err(HealthCheckError::RpcFailure(format_err!("")));
+        }
+
+        Ok(())
+    }
+}
+
+impl Validator for K8sNode {}
+
+impl FullNode for K8sNode {}

--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -1,0 +1,284 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    backend::k8s::node::K8sNode, query_sequence_numbers, ChainInfo, FullNode, Node, Result, Swarm,
+    Validator,
+};
+use anyhow::format_err;
+use diem_logger::*;
+use diem_sdk::{
+    crypto::ed25519::{Ed25519PrivateKey, ED25519_PRIVATE_KEY_LENGTH},
+    types::{
+        chain_id::{ChainId, NamedChain},
+        AccountKey, LocalAccount, PeerId,
+    },
+};
+use k8s_openapi::api::core::v1::Service;
+use kube::{
+    api::{Api, ListParams},
+    client::Client as K8sClient,
+    Config,
+};
+use std::{collections::HashMap, convert::TryFrom, process::Command};
+use tokio::{runtime::Runtime, time::Duration};
+
+const HEALTH_CHECK_URL: &str = "http://127.0.0.1:8001";
+const KUBECTL_BIN: &str = "/root/bin/kubectl";
+const JSON_RPC_PORT: u32 = 80;
+const VALIDATOR_LB: &str = "validator-fullnode-lb";
+
+pub struct K8sSwarm {
+    validators: HashMap<PeerId, K8sNode>,
+    fullnodes: HashMap<PeerId, K8sNode>,
+    root_account: LocalAccount,
+    treasury_compliance_account: LocalAccount,
+    designated_dealer_account: LocalAccount,
+    kube_client: K8sClient,
+    runtime: Runtime,
+    pub chain_id: ChainId,
+}
+
+impl K8sSwarm {
+    pub async fn new(root_key: String, treasury_compliance_key: String) -> Result<Self> {
+        Command::new(KUBECTL_BIN).arg("proxy").spawn()?;
+        diem_retrier::retry_async(k8s_retry_strategy(), || {
+            Box::pin(async move {
+                debug!("Running local kube pod healthcheck on {}", HEALTH_CHECK_URL);
+                reqwest::get(HEALTH_CHECK_URL).await?.text().await?;
+                println!("Local kube pod healthcheck passed");
+                Ok::<(), reqwest::Error>(())
+            })
+        })
+        .await?;
+        let config = Config::new(
+            reqwest::Url::parse(HEALTH_CHECK_URL).expect("Failed to parse kubernetes endpoint url"),
+        );
+        let kube_client = K8sClient::try_from(config)?;
+        let fullnodes = HashMap::new();
+        let services = list_services(kube_client.clone()).await?;
+        let validators = services
+            .into_iter()
+            .filter(|s| s.name.contains(VALIDATOR_LB))
+            .map(|s| {
+                let node_id = parse_node_id(&s.name).expect("error to parse node id");
+                let node = K8sNode {
+                    name: format!("val-{}", node_id),
+                    peer_id: PeerId::random(),
+                    node_id,
+                    ip: s.host_ip.clone(),
+                    port: JSON_RPC_PORT,
+                    dns: s.name,
+                    runtime: Runtime::new().unwrap(),
+                };
+                Ok((node.peer_id(), node))
+            })
+            .collect::<Result<HashMap<_, _>>>()?;
+
+        let client = validators.values().next().unwrap().json_rpc_client();
+        let key = load_root_key(&root_key);
+        let account_key = AccountKey::from_private_key(key);
+        let address = diem_sdk::types::account_config::diem_root_address();
+        let sequence_number = query_sequence_numbers(&client, &[address])
+            .await
+            .map_err(|e| {
+                format_err!(
+                    "query_sequence_numbers on {:?} for dd account failed: {}",
+                    client,
+                    e
+                )
+            })?[0];
+        let root_account = LocalAccount::new(address, account_key, sequence_number);
+
+        let key = load_tc_key(&treasury_compliance_key);
+        let account_key = AccountKey::from_private_key(key);
+        let address = diem_sdk::types::account_config::treasury_compliance_account_address();
+        let sequence_number = query_sequence_numbers(&client, &[address])
+            .await
+            .map_err(|e| {
+                format_err!(
+                    "query_sequence_numbers on {:?} for dd account failed: {}",
+                    client,
+                    e
+                )
+            })?[0];
+        let treasury_compliance_account = LocalAccount::new(address, account_key, sequence_number);
+
+        let key = load_tc_key(&treasury_compliance_key);
+        let account_key = AccountKey::from_private_key(key);
+        let address = diem_sdk::types::account_config::testnet_dd_account_address();
+        let sequence_number = query_sequence_numbers(&client, &[address])
+            .await
+            .map_err(|e| {
+                format_err!(
+                    "query_sequence_numbers on {:?} for dd account failed: {}",
+                    client,
+                    e
+                )
+            })?[0];
+        let designated_dealer_account = LocalAccount::new(address, account_key, sequence_number);
+
+        Ok(Self {
+            validators,
+            fullnodes,
+            root_account,
+            treasury_compliance_account,
+            designated_dealer_account,
+            kube_client,
+            runtime: Runtime::new().unwrap(),
+            chain_id: ChainId::new(NamedChain::DEVNET.id()),
+        })
+    }
+
+    fn get_url(&self) -> String {
+        self.validators
+            .values()
+            .next()
+            .unwrap()
+            .json_rpc_endpoint()
+            .to_string()
+    }
+
+    #[allow(dead_code)]
+    fn get_kube_client(&self) -> K8sClient {
+        self.kube_client.clone()
+    }
+}
+
+impl Swarm for K8sSwarm {
+    fn health_check(&mut self) -> Result<()> {
+        self.runtime.block_on(async {
+            Command::new(KUBECTL_BIN).arg("proxy").spawn()?;
+            diem_retrier::retry_async(k8s_retry_strategy(), || {
+                Box::pin(async move {
+                    debug!("Running local kube pod healthcheck on {}", HEALTH_CHECK_URL);
+                    let _res = reqwest::get(HEALTH_CHECK_URL).await.unwrap().text().await;
+                    info!("Local kube pod healthcheck passed");
+                    Ok(())
+                })
+            })
+            .await
+        })
+    }
+
+    fn validators<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a dyn Validator> + 'a> {
+        Box::new(self.validators.values().map(|v| v as &'a dyn Validator))
+    }
+
+    fn validators_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut dyn Validator> + 'a> {
+        Box::new(
+            self.validators
+                .values_mut()
+                .map(|v| v as &'a mut dyn Validator),
+        )
+    }
+
+    fn validator(&self, id: PeerId) -> Option<&dyn Validator> {
+        self.validators.get(&id).map(|v| v as &dyn Validator)
+    }
+
+    fn validator_mut(&mut self, id: PeerId) -> Option<&mut dyn Validator> {
+        self.validators
+            .get_mut(&id)
+            .map(|v| v as &mut dyn Validator)
+    }
+
+    fn full_nodes<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a dyn FullNode> + 'a> {
+        Box::new(self.fullnodes.values().map(|v| v as &'a dyn FullNode))
+    }
+
+    fn full_nodes_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut dyn FullNode> + 'a> {
+        Box::new(
+            self.fullnodes
+                .values_mut()
+                .map(|v| v as &'a mut dyn FullNode),
+        )
+    }
+
+    fn full_node(&self, id: PeerId) -> Option<&dyn FullNode> {
+        self.fullnodes.get(&id).map(|v| v as &dyn FullNode)
+    }
+
+    fn full_node_mut(&mut self, id: PeerId) -> Option<&mut dyn FullNode> {
+        self.fullnodes.get_mut(&id).map(|v| v as &mut dyn FullNode)
+    }
+
+    fn add_validator(&mut self, _id: PeerId) -> Result<PeerId> {
+        todo!()
+    }
+
+    fn remove_validator(&mut self, _id: PeerId) -> Result<()> {
+        todo!()
+    }
+
+    fn add_full_node(&mut self, _id: PeerId) -> Result<()> {
+        todo!()
+    }
+
+    fn remove_full_node(&mut self, _id: PeerId) -> Result<()> {
+        todo!()
+    }
+
+    fn chain_info(&mut self) -> ChainInfo<'_> {
+        let url = self.get_url();
+        ChainInfo::new(
+            &mut self.root_account,
+            &mut self.treasury_compliance_account,
+            &mut self.designated_dealer_account,
+            url,
+            self.chain_id,
+        )
+    }
+}
+
+fn k8s_retry_strategy() -> impl Iterator<Item = Duration> {
+    diem_retrier::exp_retry_strategy(1000, 5000, 30)
+}
+
+#[derive(Clone, Debug)]
+pub struct KubeService {
+    pub name: String,
+    pub host_ip: String,
+}
+
+impl TryFrom<Service> for KubeService {
+    type Error = anyhow::Error;
+
+    fn try_from(service: Service) -> Result<Self, Self::Error> {
+        let metadata = service.metadata;
+        let name = metadata
+            .name
+            .ok_or_else(|| format_err!("node name not found"))?;
+        let spec = service
+            .spec
+            .ok_or_else(|| format_err!("spec not found for node"))?;
+        let host_ip = spec.cluster_ip.unwrap_or_default();
+        Ok(Self { name, host_ip })
+    }
+}
+
+pub async fn list_services(client: K8sClient) -> Result<Vec<KubeService>> {
+    let node_api: Api<Service> = Api::all(client);
+    let lp = ListParams::default();
+    let services = node_api.list(&lp).await?.items;
+    services.into_iter().map(KubeService::try_from).collect()
+}
+
+fn parse_node_id(s: &str) -> Result<usize> {
+    let v = s.split('-').collect::<Vec<&str>>();
+    if v.len() < 5 {
+        return Err(format_err!("Failed to parse {:?} node id format", s));
+    }
+    let idx: usize = v[0][3..].parse().unwrap();
+    Ok(idx)
+}
+
+fn load_root_key(root_key: &str) -> Ed25519PrivateKey {
+    let composite_key = base64::decode(root_key).unwrap();
+    Ed25519PrivateKey::try_from(composite_key.get(0..ED25519_PRIVATE_KEY_LENGTH).unwrap()).unwrap()
+}
+
+fn load_tc_key(tc_key: &str) -> Ed25519PrivateKey {
+    let composite_key = base64::decode(tc_key).unwrap();
+    Ed25519PrivateKey::try_from(composite_key.get(0..ED25519_PRIVATE_KEY_LENGTH).unwrap()).unwrap()
+}

--- a/testsuite/forge/src/backend/local/mod.rs
+++ b/testsuite/forge/src/backend/local/mod.rs
@@ -3,8 +3,9 @@
 
 use crate::{Factory, Swarm};
 
-pub mod node;
-pub mod swarm;
+mod node;
+mod swarm;
+pub use node::LocalNode;
 pub use swarm::{LocalSwarm, LocalSwarmBuilder};
 
 pub struct LocalFactory {

--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{node::LocalNode, ChainInfo, FullNode, HealthCheckError, Node, Swarm, Validator};
+use crate::{ChainInfo, FullNode, HealthCheckError, LocalNode, Node, Swarm, Validator};
 use anyhow::{anyhow, Result};
 use diem_config::config::NodeConfig;
 use diem_genesis_tool::validator_builder::ValidatorBuilder;
@@ -24,6 +24,7 @@ pub enum SwarmDirectory {
 }
 
 impl SwarmDirectory {
+    #[allow(dead_code)]
     pub fn persist(&mut self) {
         match self {
             SwarmDirectory::Persistent(_) => {}
@@ -35,6 +36,7 @@ impl SwarmDirectory {
         }
     }
 
+    #[allow(dead_code)]
     pub fn into_persistent(self) -> Self {
         match self {
             SwarmDirectory::Temporary(tempdir) => SwarmDirectory::Persistent(tempdir.into_path()),

--- a/testsuite/forge/src/backend/mod.rs
+++ b/testsuite/forge/src/backend/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod local;
-pub use local::*;
+pub use local::{LocalNode, *};
 
 mod k8s;
-pub use k8s::*;
+pub use k8s::{K8sNode, *};

--- a/testsuite/forge/src/interface/network.rs
+++ b/testsuite/forge/src/interface/network.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::Test;
-use crate::{CoreContext, Result, Swarm};
+use crate::{CoreContext, Result, Swarm, TestReport};
 
 /// The testing interface which defines a test written with full control over an existing network.
 /// Tests written against this interface will have access to both the Root account as well as the
@@ -15,11 +15,16 @@ pub trait NetworkTest: Test {
 pub struct NetworkContext<'t> {
     core: CoreContext,
     swarm: &'t mut dyn Swarm,
+    pub report: TestReport,
 }
 
 impl<'t> NetworkContext<'t> {
-    pub fn new(core: CoreContext, swarm: &'t mut dyn Swarm) -> Self {
-        Self { core, swarm }
+    pub fn new(core: CoreContext, swarm: &'t mut dyn Swarm, report: TestReport) -> Self {
+        Self {
+            core,
+            swarm,
+            report,
+        }
     }
 
     pub fn swarm(&mut self) -> &mut dyn Swarm {

--- a/testsuite/forge/src/lib.rs
+++ b/testsuite/forge/src/lib.rs
@@ -16,3 +16,6 @@ pub use backend::*;
 
 mod txn_emitter;
 pub use txn_emitter::*;
+
+mod report;
+pub use report::*;

--- a/testsuite/forge/src/report.rs
+++ b/testsuite/forge/src/report.rs
@@ -1,0 +1,75 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::TxnStats;
+use std::{fmt, time::Duration};
+
+#[derive(Default, Debug)]
+pub struct TestReport {
+    metrics: Vec<ReportedMetric>,
+    text: String,
+}
+
+#[derive(Debug)]
+pub struct ReportedMetric {
+    pub test_name: String,
+    pub metric: String,
+    pub value: f64,
+}
+
+impl TestReport {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn report_metric<E: ToString, M: ToString>(&mut self, test: E, metric: M, value: f64) {
+        self.metrics.push(ReportedMetric {
+            test_name: test.to_string(),
+            metric: metric.to_string(),
+            value,
+        });
+    }
+
+    pub fn report_text(&mut self, text: String) {
+        if !self.text.is_empty() {
+            self.text.push('\n');
+        }
+        self.text.push_str(&text);
+    }
+
+    pub fn report_txn_stats(&mut self, test_name: String, stats: TxnStats, window: Duration) {
+        let submitted_txn = stats.submitted;
+        let expired_txn = stats.expired;
+        let avg_tps = stats.committed / window.as_secs();
+        let avg_latency_client = if stats.committed == 0 {
+            0u64
+        } else {
+            stats.latency / stats.committed
+        };
+        let p99_latency = stats.latency_buckets.percentile(99, 100);
+        self.report_metric(test_name.clone(), "submitted_txn", submitted_txn as f64);
+        self.report_metric(test_name.clone(), "expired_txn", expired_txn as f64);
+        self.report_metric(test_name.clone(), "avg_tps", avg_tps as f64);
+        self.report_metric(test_name.clone(), "avg_latency", avg_latency_client as f64);
+        self.report_metric(test_name.clone(), "p99_latency", p99_latency as f64);
+        let expired_text = if expired_txn == 0 {
+            "no expired txns".to_string()
+        } else {
+            format!("(!) expired {} out of {} txns", expired_txn, submitted_txn)
+        };
+        self.report_text(format!(
+            "{} : {:.0} TPS, {:.1} ms latency, {:.1} ms p99 latency,{}",
+            test_name, avg_tps, avg_latency_client, p99_latency, expired_text
+        ));
+    }
+
+    pub fn print_report(&self) {
+        println!("Test Statistics: {}", self,);
+    }
+}
+
+impl fmt::Display for TestReport {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.text)
+    }
+}

--- a/testsuite/forge/src/txn_emitter/mod.rs
+++ b/testsuite/forge/src/txn_emitter/mod.rs
@@ -578,7 +578,7 @@ fn is_sequence_equal(accounts: &[LocalAccount], sequence_numbers: &[u64]) -> boo
     true
 }
 
-async fn query_sequence_numbers(
+pub async fn query_sequence_numbers(
     client: &JsonRpcClient,
     addresses: &[AccountAddress],
 ) -> Result<Vec<u64>> {


### PR DESCRIPTION
This is the last piece of forge framework MVP, it introduces the ability for Forge to build up swarm on k8s cluster which is deployed by standard testnet deployment.

This PR includes the work:
- fgi script for end user to interactive with forge test framework, dispatching between different swarm types
- new forge pod template (The first two items are split to https://github.com/diem/diem/pull/8603 for more modifications by @rustielin, this pr rebased on latest changes)
- rust side k8s backend implementation
- test statistics report

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

**Test whole Forge by both swarm types (local, k8s)**
Local swarm test by passing --local-swarm arg
```
./scripts/fgi --local-swarm 

running 4 tests
Wait for startup attempt: 0 of 10
rpc error: error sending request for url (http://localhost:56656/metrics): error trying to connect: tcp connect error: Connection refused (os error 61)
Wait for startup attempt: 1 of 10
Wait for connectivity attempt: 0
test fund_account ... ok
test transfer_coins ... ok
test get_metadata ... ok
Will use 10 workers per endpoint with total 10 endpoint clients
Will create 15 accounts_per_client with total 150 accounts
Creating and minting faucet account
DD account current balances are 9223372036854773807, requested 150000000 coins
Completed minting seed accounts
Minting additional 150 accounts
Mint is done
starting emitting txns for 10 secs
Test Result: emit_transaction : 15 TPS, 11418 ms latency, 11400 ms p99 latency,no expired txns
test emit_transaction ... ok

test result: ok. 4 passed; 0 failed; 0 filtered out
```

k8s swarm test
```
czh@czh-mbp libra % ./scripts/fgi --pr 8583 --root-key=<testnet_root_key> --treasury-compliance-key=<testnet_tc_key>                                 
Building with SOURCE_VERSION=refs/pull/8583/head TAGS=dev_czh_pull_8583
Started build for project diem-forge with ID diem-forge:c509ed38-ca4f-4763-9142-f85e167dbcbc. Link to the build https://us-west-2.console.aws.amazon.com/codesuite/codebuild/projects/diem-forge/build/diem-forge:c509ed38-ca4f-4763-9142-f85e167dbcbc/
diem-forge current phase: QUEUED
diem-forge current phase: QUEUED
diem-forge current phase: QUEUED
diem-forge current phase: PROVISIONING
diem-forge current phase: PROVISIONING
diem-forge current phase: PROVISIONING
diem-forge current phase: BUILD
diem-forge current phase: BUILD
diem-forge current phase: BUILD
diem-forge current phase: BUILD
diem-forge current phase: BUILD
diem-forge current phase: BUILD
diem-forge current phase: BUILD
diem-forge current phase: BUILD
diem-forge current phase: BUILD
diem-forge current phase: BUILD
diem-forge current phase: BUILD
diem-forge current phase: BUILD
diem-forge current phase: COMPLETED
All builds completed successfully
**TIP Use fgi -T dev_czh_pull_8583 <...> to restart this run with same tag without rebuilding it
Running forge on Kubernetes
Attempting to reach Kubernetes...
Updated context arn:aws:eks:us-west-2:853397791086:cluster/libra-rustietest in /Users/czh/.kube/config
Grabbing a Kubernetes cluster...

Pod spec: /var/folders/qd/tg50mr0d7k75qvztr_8yk2km0000gn/T/tmp.FXvpit25

Using cluster: rustietest
Context: arn:aws:eks:us-west-2:853397791086:cluster/libra-rustietest
Creating pod: forge-czh-1624467946
pod/forge-czh-1624467946 created
Waiting for forge-czh-1624467946 to be scheduled. Current phase: Pending
forge-czh-1624467946 reached phase: Running

**********
Auto refresh Dashboard: http://mon.rustietest.aws.hlw3truzy4ls.com/d/overview/overview?from=1624467960000&to=now&refresh=10s&orgId=1
**********

==========begin-pod-logs==========
+ helm plugin install https://github.com/hypnoglow/helm-s3.git
Downloading and installing helm-s3 v0.10.0 ...
Checksum is valid.
Installed plugin: s3
+ helm repo add testnet-internal s3://diem-testnet-rustietest-helm/charts
"testnet-internal" has been added to your repositories
+ helm search repo testnet-internal --versions
NAME                           	CHART VERSION	APP VERSION	DESCRIPTION                                       
testnet-internal/diem-fullnode 	1.3.0        	1.3.0      	                                                  
testnet-internal/diem-validator	1.3.0        	1.3.0      	Diem blockchain validator                         
testnet-internal/testnet       	0.1          	           	Additional components for a multi-validator tes...
+ timeout 2700 forge

running 4 tests
Starting to serve on 127.0.0.1:8001
Local kube pod healthcheck passed
test fund_account ... ok
test transfer_coins ... ok
test get_metadata ... ok
Will use 10 workers per endpoint with total 300 endpoint clients
Will create 15 accounts_per_client with total 4500 accounts
Creating and minting faucet account
DD account current balances are 9223372000854757807, requested 4500000000 coins
Completed minting seed accounts
Minting additional 4500 accounts
Mint is done
starting emitting txns for 10 secs
Test Statistics: emit_transaction : 3420 TPS, 1209 ms latency, 1650 ms p99 latency,no expired txns
test emit_transaction ... ok

test result: ok. 4 passed; 0 failed; 0 filtered out

==========end-pod-logs==========

**********
Dashboard snapshot: http://mon.rustietest.aws.hlw3truzy4ls.com/d/overview/overview?from=1624467960000&to=1624468255000&orgId=1
**********
```
## Related PRs

(If this PR adds or changes functionality, please take some time to update or suggest changes to the docs at https://developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
