### PR TITLE
[language][resource-viewer] remove diem dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,6 +903,7 @@ dependencies = [
  "diem-infallible",
  "diem-logger",
  "diem-metrics",
+ "diem-resource-viewer",
  "diem-temppath",
  "diem-transaction-builder",
  "diem-types",
@@ -910,11 +911,11 @@ dependencies = [
  "diem-workspace-hack",
  "generate-key",
  "hex",
+ "move-vm-test-utils",
  "num-traits",
  "once_cell",
  "proptest",
  "reqwest",
- "resource-viewer",
  "rust_decimal",
  "rustyline",
  "serde",
@@ -2251,6 +2252,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "diem-resource-viewer"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "diem-types",
+ "diem-workspace-hack",
+ "move-binary-format",
+ "move-core-types",
+ "move-vm-runtime",
+ "resource-viewer",
+]
+
+[[package]]
 name = "diem-retrier"
 version = "0.1.0"
 dependencies = [
@@ -2432,6 +2446,7 @@ dependencies = [
  "bcs",
  "diem-framework",
  "diem-framework-releases",
+ "diem-resource-viewer",
  "diem-state-view",
  "diem-types",
  "diem-validator-interface",
@@ -2447,7 +2462,6 @@ dependencies = [
  "move-vm-runtime",
  "move-vm-test-utils",
  "move-vm-types",
- "resource-viewer",
  "structopt 0.3.21",
  "vm-genesis",
 ]
@@ -3455,10 +3469,12 @@ version = "0.1.0"
 dependencies = [
  "bcs",
  "diem-framework-releases",
+ "diem-resource-viewer",
  "diem-types",
  "diem-workspace-hack",
  "move-binary-format",
- "resource-viewer",
+ "move-vm-runtime",
+ "move-vm-test-utils",
  "structopt 0.3.21",
  "vm-genesis",
 ]
@@ -6244,9 +6260,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
- "diem-framework-releases",
- "diem-state-view",
- "diem-types",
  "diem-workspace-hack",
  "hex",
  "move-binary-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,7 @@ members = [
     "language/testing-infra/functional-tests",
     "language/testing-infra/module-generation",
     "language/testing-infra/test-generation",
+    "language/tools/diem-resource-viewer",
     "language/tools/disassembler",
     "language/tools/genesis-viewer",
     "language/tools/move-bytecode-utils",

--- a/language/diem-tools/transaction-replay/Cargo.toml
+++ b/language/diem-tools/transaction-replay/Cargo.toml
@@ -25,7 +25,7 @@ move-vm-types = { path = "../../move-vm/types" }
 move-core-types = { path = "../../move-core/types" }
 move-vm-runtime = { path = "../../move-vm/runtime" }
 move-vm-test-utils = { path = "../../move-vm/test-utils" }
-resource-viewer = { path = "../../tools/resource-viewer" }
+diem-resource-viewer = { path = "../../tools/diem-resource-viewer" }
 diem-framework = { path = "../../diem-framework" }
 move-lang = { path = "../../move-lang" }
 bcs = "0.1.2"

--- a/language/diem-tools/transaction-replay/src/lib.rs
+++ b/language/diem-tools/transaction-replay/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{anyhow, bail, format_err, Result};
+use diem_resource_viewer::{AnnotatedAccountStateBlob, AnnotatedMoveStruct, DiemValueAnnotator};
 use diem_state_view::StateView;
 use diem_types::{
     access_path,
@@ -27,7 +28,6 @@ use move_lang::{compiled_unit::CompiledUnit, Compiler, Flags};
 use move_vm_runtime::{move_vm::MoveVM, session::Session};
 use move_vm_test_utils::DeltaStorage;
 use move_vm_types::gas_schedule::GasStatus;
-use resource_viewer::{AnnotatedAccountStateBlob, AnnotatedMoveStruct, MoveValueAnnotator};
 use std::path::{Path, PathBuf};
 
 #[cfg(test)]
@@ -236,7 +236,7 @@ impl DiemDebugger {
         let version = self.debugger.get_latest_version()?;
         let state_view = DebuggerStateView::new(&*self.debugger, version);
         let remote_storage = RemoteStorage::new(&state_view);
-        let annotator = MoveValueAnnotator::new(&remote_storage);
+        let annotator = DiemValueAnnotator::new(&remote_storage);
         let mut events_data = vec![];
         for event in events {
             match &event.event {
@@ -259,7 +259,7 @@ impl DiemDebugger {
     ) -> Result<Option<AnnotatedAccountStateBlob>> {
         let state_view = DebuggerStateView::new(&*self.debugger, version);
         let remote_storage = RemoteStorage::new(&state_view);
-        let annotator = MoveValueAnnotator::new(&remote_storage);
+        let annotator = DiemValueAnnotator::new(&remote_storage);
         Ok(
             match self
                 .debugger
@@ -284,7 +284,7 @@ impl DiemDebugger {
         let accounts = self.debugger.get_admin_accounts(version)?;
         let state_view = DebuggerStateView::new(&*self.debugger, version);
         let remote_storage = RemoteStorage::new(&state_view);
-        let annotator = MoveValueAnnotator::new(&remote_storage);
+        let annotator = DiemValueAnnotator::new(&remote_storage);
 
         let mut result = vec![];
         for (addr, state) in accounts.into_iter() {

--- a/language/tools/diem-resource-viewer/Cargo.toml
+++ b/language/tools/diem-resource-viewer/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "resource-viewer"
+name = "diem-resource-viewer"
 version = "0.1.0"
 authors = ["Diem Association <opensource@diem.com>"]
-description = "Diem genesis viewer"
+description = "Diem resource viewer"
 repository = "https://github.com/diem/diem"
 homepage = "https://diem.com"
 license = "Apache-2.0"
@@ -10,15 +10,11 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bcs = "0.1.2"
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
+resource-viewer = { path = "../resource-viewer" }
+diem-types = { path = "../../../types"  }
 move-core-types = { path = "../../move-core/types" }
 move-vm-runtime = { path = "../../move-vm/runtime" }
-move-vm-types = { path = "../../move-vm/types" }
 move-binary-format = { path = "../../move-binary-format" }
-serde_json = "1.0.64"
-serde = { version = "1.0.124", features = ["derive", "rc"] }
 
 anyhow = "1.0.38"
-once_cell = "1.7.2"
-hex = "0.4.3"

--- a/language/tools/diem-resource-viewer/src/lib.rs
+++ b/language/tools/diem-resource-viewer/src/lib.rs
@@ -1,0 +1,75 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, Result};
+use diem_types::{
+    access_path::AccessPath, account_address::AccountAddress, account_state::AccountState,
+    contract_event::ContractEvent,
+};
+use move_core_types::language_storage::StructTag;
+use move_vm_runtime::data_cache::MoveStorage;
+use resource_viewer::MoveValueAnnotator;
+use std::{
+    collections::BTreeMap,
+    fmt::{Display, Formatter},
+};
+
+pub use resource_viewer::{AnnotatedMoveStruct, AnnotatedMoveValue};
+
+pub struct DiemValueAnnotator<'a>(MoveValueAnnotator<'a>);
+
+/// A wrapper around `MoveValueAnnotator` that adds a few diem-specific funtionalities.
+#[derive(Debug)]
+pub struct AnnotatedAccountStateBlob(BTreeMap<StructTag, AnnotatedMoveStruct>);
+
+impl<'a> DiemValueAnnotator<'a> {
+    pub fn new(storage: &'a dyn MoveStorage) -> Self {
+        Self(MoveValueAnnotator::new(storage))
+    }
+
+    pub fn view_resource(&self, tag: &StructTag, blob: &[u8]) -> Result<AnnotatedMoveStruct> {
+        self.0.view_resource(tag, blob)
+    }
+
+    pub fn view_access_path(
+        &self,
+        access_path: AccessPath,
+        blob: &[u8],
+    ) -> Result<AnnotatedMoveStruct> {
+        match access_path.get_struct_tag() {
+            Some(tag) => self.view_resource(&tag, blob),
+            None => bail!("Bad resource access path"),
+        }
+    }
+
+    pub fn view_contract_event(&self, event: &ContractEvent) -> Result<AnnotatedMoveValue> {
+        self.0.view_value(event.type_tag(), event.event_data())
+    }
+
+    pub fn view_account_state(&self, state: &AccountState) -> Result<AnnotatedAccountStateBlob> {
+        let mut output = BTreeMap::new();
+        for (k, v) in state.iter() {
+            let tag = match AccessPath::new(AccountAddress::random(), k.to_vec()).get_struct_tag() {
+                Some(t) => t,
+                None => {
+                    println!("Uncached AccessPath: {:?}", k);
+                    continue;
+                }
+            };
+            let value = self.view_resource(&tag, v)?;
+            output.insert(tag, value);
+        }
+        Ok(AnnotatedAccountStateBlob(output))
+    }
+}
+
+impl Display for AnnotatedAccountStateBlob {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        writeln!(f, "{{")?;
+        for v in self.0.values() {
+            write!(f, "{}", v)?;
+            writeln!(f, ",")?;
+        }
+        writeln!(f, "}}")
+    }
+}

--- a/language/tools/genesis-viewer/Cargo.toml
+++ b/language/tools/genesis-viewer/Cargo.toml
@@ -14,8 +14,10 @@ bcs = "0.1.2"
 diem-types = { path = "../../../types" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-binary-format = { path = "../../move-binary-format" }
-resource-viewer = { path = "../resource-viewer"}
+diem-resource-viewer = { path = "../diem-resource-viewer"}
 vm-genesis = { path = "../vm-genesis" }
 diem-framework-releases = { path = "../../diem-framework/releases" }
+move-vm-runtime = { path = "../../move-vm/runtime" }
+move-vm-test-utils = { path = "../../move-vm/test-utils" }
 
 structopt = "0.3.21"

--- a/language/tools/genesis-viewer/src/main.rs
+++ b/language/tools/genesis-viewer/src/main.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use diem_resource_viewer::DiemValueAnnotator;
 use diem_types::{
     access_path::AccessPath,
     account_address::AccountAddress,
@@ -9,7 +10,8 @@ use diem_types::{
     write_set::{WriteOp, WriteSet},
 };
 use move_binary_format::CompiledModule;
-use resource_viewer::{MoveValueAnnotator, NullStateView};
+use move_vm_runtime::data_cache::MoveStorage;
+use move_vm_test_utils::InMemoryStorage;
 use std::collections::{BTreeMap, BTreeSet};
 use structopt::StructOpt;
 
@@ -74,8 +76,14 @@ pub fn main() {
     let args = Args::from_args();
     let ws =
         vm_genesis::generate_genesis_change_set_for_testing(vm_genesis::GenesisOptions::Compiled);
+
+    let mut storage = InMemoryStorage::new();
+    for (blob, module) in diem_framework_releases::current_modules_with_blobs() {
+        storage.publish_or_overwrite_module(module.self_id(), blob.clone())
+    }
+
     if args.all || arg_count == 3 {
-        print_all(&ws);
+        print_all(&storage, &ws);
     } else {
         if args.event_raw {
             print_events_raw(ws.events());
@@ -84,19 +92,19 @@ pub fn main() {
             print_events_key(ws.events());
         }
         if args.type_events {
-            print_events(ws.events());
+            print_events(&storage, ws.events());
         }
         if args.type_modules {
             print_modules(ws.write_set());
         }
         if args.type_resources {
-            print_resources(ws.write_set());
+            print_resources(&storage, ws.write_set());
         }
         if args.write_set {
             print_write_set_raw(ws.write_set());
         }
         if args.ws_by_type {
-            print_write_set_by_type(ws.write_set());
+            print_write_set_by_type(&storage, ws.write_set());
         }
         if args.ws_keys {
             print_keys(ws.write_set());
@@ -105,15 +113,15 @@ pub fn main() {
             print_keys_sorted(ws.write_set());
         }
         if args.print_account_states {
-            print_account_states(ws.write_set());
+            print_account_states(&storage, ws.write_set());
         }
     }
 }
 
-fn print_all(cs: &ChangeSet) {
-    print_write_set_by_type(cs.write_set());
+fn print_all(storage: &impl MoveStorage, cs: &ChangeSet) {
+    print_write_set_by_type(storage, cs.write_set());
     println!("* Events:");
-    print_events(cs.events());
+    print_events(storage, cs.events());
 }
 
 fn print_events_raw(events: &[ContractEvent]) {
@@ -146,16 +154,15 @@ fn print_events_key(events: &[ContractEvent]) {
     }
 }
 
-fn print_write_set_by_type(ws: &WriteSet) {
+fn print_write_set_by_type(storage: &impl MoveStorage, ws: &WriteSet) {
     println!("* Modules:");
     print_modules(ws);
     println!("* Resources:");
-    print_resources(ws);
+    print_resources(storage, ws);
 }
 
-fn print_events(events: &[ContractEvent]) {
-    let view = NullStateView::default();
-    let annotator = MoveValueAnnotator::new(&view);
+fn print_events(storage: &impl MoveStorage, events: &[ContractEvent]) {
+    let annotator = DiemValueAnnotator::new(storage);
 
     for event in events {
         println!("+ {:?}", event.key());
@@ -190,7 +197,7 @@ fn print_modules(ws: &WriteSet) {
     }
 }
 
-fn print_resources(ws: &WriteSet) {
+fn print_resources(storage: &impl MoveStorage, ws: &WriteSet) {
     let mut resources: BTreeMap<AccessPath, Vec<u8>> = BTreeMap::new();
     for (k, v) in ws {
         match v {
@@ -203,8 +210,7 @@ fn print_resources(ws: &WriteSet) {
             }
         }
     }
-    let view = NullStateView::default();
-    let annotator = MoveValueAnnotator::new(&view);
+    let annotator = DiemValueAnnotator::new(storage);
     for (k, v) in &resources {
         println!("AccessPath: {:?}", k);
         match annotator.view_access_path(k.clone(), v.as_ref()) {
@@ -215,7 +221,7 @@ fn print_resources(ws: &WriteSet) {
     }
 }
 
-fn print_account_states(ws: &WriteSet) {
+fn print_account_states(storage: &impl MoveStorage, ws: &WriteSet) {
     let mut accounts: BTreeMap<AccountAddress, Vec<(AccessPath, Vec<u8>)>> = BTreeMap::new();
     for (k, v) in ws {
         match v {
@@ -231,8 +237,7 @@ fn print_account_states(ws: &WriteSet) {
             }
         }
     }
-    let view = NullStateView::default();
-    let annotator = MoveValueAnnotator::new(&view);
+    let annotator = DiemValueAnnotator::new(storage);
     for (k, v) in &accounts {
         println!("Address: {}", k);
         for (ap, resource) in v {

--- a/language/tools/move-cli/src/sandbox/utils/mod.rs
+++ b/language/tools/move-cli/src/sandbox/utils/mod.rs
@@ -146,12 +146,12 @@ pub(crate) fn explain_execution_effects(
                         let resource_data = state
                             .get_resource_bytes(*addr, struct_tag.clone())?
                             .unwrap();
-                        let resource_old = MoveValueAnnotator::new_no_stdlib(state)
+                        let resource_old = MoveValueAnnotator::new(state)
                             .view_resource(&struct_tag, &resource_data)?;
                         println!("      Previous:");
                         print_struct_with_indent(&resource_old, 8);
-                        let resource_new = MoveValueAnnotator::new_no_stdlib(state)
-                            .view_resource(&struct_tag, &blob)?;
+                        let resource_new =
+                            MoveValueAnnotator::new(state).view_resource(&struct_tag, &blob)?;
                         println!("      New:");
                         print_struct_with_indent(&resource_new, 8)
                     } else {
@@ -160,8 +160,8 @@ pub(crate) fn explain_execution_effects(
                             struct_tag, blob, bytes_to_write
                         );
                         // Print new resource
-                        let resource = MoveValueAnnotator::new_no_stdlib(state)
-                            .view_resource(&struct_tag, &blob)?;
+                        let resource =
+                            MoveValueAnnotator::new(state).view_resource(&struct_tag, &blob)?;
                         print_struct_with_indent(&resource, 6)
                     }
                 }
@@ -174,7 +174,7 @@ pub(crate) fn explain_execution_effects(
                     let resource_data = state
                         .get_resource_bytes(*addr, struct_tag.clone())?
                         .unwrap();
-                    let resource_old = MoveValueAnnotator::new_no_stdlib(state)
+                    let resource_old = MoveValueAnnotator::new(state)
                         .view_resource(&struct_tag, &resource_data)?;
                     print_struct_with_indent(&resource_old, 6);
                 }

--- a/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
+++ b/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
@@ -190,10 +190,9 @@ impl OnDiskStateView {
                     t => bail!("Expected to parse struct tag, but got {}", t),
                 };
                 match Self::get_bytes(resource_path)? {
-                    Some(resource_data) => Some(
-                        MoveValueAnnotator::new_no_stdlib(self)
-                            .view_resource(&id, &resource_data)?,
-                    ),
+                    Some(resource_data) => {
+                        Some(MoveValueAnnotator::new(self).view_resource(&id, &resource_data)?)
+                    }
                     None => None,
                 }
             }),
@@ -212,10 +211,10 @@ impl OnDiskStateView {
     }
 
     pub fn view_events(&self, events_path: &Path) -> Result<Vec<AnnotatedMoveValue>> {
-        let annotator = MoveValueAnnotator::new_no_stdlib(self);
+        let annotator = MoveValueAnnotator::new(self);
         self.get_events(events_path)?
             .iter()
-            .map(|event| annotator.view_contract_event(event))
+            .map(|event| annotator.view_value(event.type_tag(), event.event_data()))
             .collect()
     }
 

--- a/language/tools/read-write-set/src/dynamic_analysis.rs
+++ b/language/tools/read-write-set/src/dynamic_analysis.rs
@@ -84,7 +84,7 @@ impl ConcretizedFormals {
         env: &GlobalEnv,
     ) -> ConcretizedSecondaryIndexes {
         // TODO: check if there are no secondary indexes and return accesses if so
-        let annotator = MoveValueAnnotator::new_no_stdlib(blockchain_view);
+        let annotator = MoveValueAnnotator::new(blockchain_view);
         let mut acc = AccessPathTrie::default();
         // TODO: do not unwrap here. iter_paths doesn't support Result, so need to create an Iter instead
         // of iter_paths or return a bool inside resolve_secondary instead of using ?

--- a/language/tools/resource-viewer/src/fat_type.rs
+++ b/language/tools/resource-viewer/src/fat_type.rs
@@ -2,15 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Loaded representation for runtime types.
 
-use diem_types::{account_address::AccountAddress, vm_status::StatusCode};
 use move_binary_format::{
     errors::{PartialVMError, PartialVMResult},
     file_format::AbilitySet,
 };
 use move_core_types::{
+    account_address::AccountAddress,
     identifier::Identifier,
     language_storage::{StructTag, TypeTag},
     value::{MoveStructLayout, MoveTypeLayout},
+    vm_status::StatusCode,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::convert::TryInto;

--- a/language/tools/resource-viewer/src/resolver.rs
+++ b/language/tools/resource-viewer/src/resolver.rs
@@ -6,7 +6,6 @@ use crate::{
     module_cache::ModuleCache,
 };
 use anyhow::{anyhow, Result};
-use diem_types::account_address::AccountAddress;
 use move_binary_format::{
     access::ModuleAccess,
     errors::PartialVMError,
@@ -16,6 +15,7 @@ use move_binary_format::{
     CompiledModule,
 };
 use move_core_types::{
+    account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, StructTag, TypeTag},
 };
@@ -28,15 +28,11 @@ pub(crate) struct Resolver<'a> {
 }
 
 impl<'a> Resolver<'a> {
-    pub fn new(state: &'a dyn MoveStorage, use_stdlib: bool) -> Self {
-        let cache = ModuleCache::new();
-        if use_stdlib {
-            let modules = diem_framework_releases::current_modules();
-            for module in modules {
-                cache.insert(module.self_id(), module.clone());
-            }
+    pub fn new(state: &'a dyn MoveStorage) -> Self {
+        Resolver {
+            state,
+            cache: ModuleCache::new(),
         }
-        Resolver { state, cache }
     }
 
     fn get_module(&self, address: &AccountAddress, name: &IdentStr) -> Result<Rc<CompiledModule>> {

--- a/testsuite/cli/Cargo.toml
+++ b/testsuite/cli/Cargo.toml
@@ -37,10 +37,11 @@ diem-metrics = { path = "../../common/metrics" }
 diem-types = { path = "../../types" }
 diem-temppath = { path = "../../common/temppath/" }
 diem-workspace-hack = { path = "../../common/workspace-hack" }
-resource-viewer = { path = "../../language/tools/resource-viewer" }
+diem-resource-viewer = { path = "../../language/tools/diem-resource-viewer" }
 diem-framework = { path = "../../language/diem-framework" }
 diem-framework-releases = { path = "../../language/diem-framework/releases" }
 diem-transaction-builder = { path = "../../sdk/transaction-builder" }
+move-vm-test-utils = { path = "../../language/move-vm/test-utils" }
 compiler = { path = "../../language/compiler" }
 
 [dev-dependencies]

--- a/x.toml
+++ b/x.toml
@@ -245,6 +245,7 @@ diem_crates_in_language = [
     "transaction-builder",
     "transaction-builder-generator",
     "move-lang-functional-tests",
+    "diem-resource-viewer",
 ]
 exclude = [
     "diem-workspace-hack",
@@ -269,9 +270,6 @@ existing_deps = [
     ["test-generation", "diem-state-view"],
     ["test-generation", "diem-logger"],
     ["test-generation", "diem-config"],
-    ["resource-viewer", "diem-framework-releases"],
-    ["resource-viewer", "diem-types"],
-    ["resource-viewer", "diem-state-view"],
 ]
 
 # Interesting subsets of the workspace, These are used for generating and


### PR DESCRIPTION
This removes all diem dependencies from the resource-viewer by refactoring its core APIs and splitting out the Diem APIs into a separate crate.
