### PR TITLE
[move-lang] Starting migration to new codespan reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
  "anyhow",
  "bcs",
  "bytecode-verifier",
- "codespan-reporting",
+ "codespan-reporting 0.8.0",
  "datatest-stable",
  "diem-workspace-hack",
  "heck",
@@ -516,8 +516,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bytecode",
- "codespan",
- "codespan-reporting",
+ "codespan 0.8.0",
+ "codespan-reporting 0.8.0",
  "diem-workspace-hack",
  "futures",
  "itertools 0.10.0",
@@ -594,8 +594,8 @@ dependencies = [
  "anyhow",
  "borrow-graph",
  "bytecode-verifier",
- "codespan",
- "codespan-reporting",
+ "codespan 0.8.0",
+ "codespan-reporting 0.8.0",
  "datatest-stable",
  "diem-workspace-hack",
  "im",
@@ -620,7 +620,7 @@ dependencies = [
  "anyhow",
  "bytecode",
  "bytecode-interpreter-crypto",
- "codespan-reporting",
+ "codespan-reporting 0.8.0",
  "datatest-stable",
  "diem-workspace-hack",
  "itertools 0.10.0",
@@ -668,8 +668,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
- "codespan",
- "codespan-reporting",
+ "codespan 0.8.0",
+ "codespan-reporting 0.8.0",
  "diem-workspace-hack",
  "move-binary-format",
  "move-core-types",
@@ -999,13 +999,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "codespan"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3362992a0d9f1dd7c3d0e89e0ab2bb540b7a95fea8cd798090e758fda2899b5e"
+dependencies = [
+ "codespan-reporting 0.11.1",
+]
+
+[[package]]
 name = "codespan-reporting"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "600c3317d4705222ff820139aaa76a3a208024ffc41f894da565a4c3b949d4c9"
 dependencies = [
- "codespan",
+ "codespan 0.8.0",
  "serde",
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
  "termcolor",
  "unicode-width",
 ]
@@ -2550,7 +2569,7 @@ dependencies = [
  "cc",
  "chrono",
  "clap",
- "codespan-reporting",
+ "codespan-reporting 0.8.0",
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
@@ -2810,8 +2829,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytecode",
- "codespan",
- "codespan-reporting",
+ "codespan 0.8.0",
+ "codespan-reporting 0.8.0",
  "datatest-stable",
  "diem-workspace-hack",
  "itertools 0.10.0",
@@ -2949,7 +2968,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
- "codespan-reporting",
+ "codespan-reporting 0.8.0",
  "datatest-stable",
  "diem-workspace-hack",
  "log",
@@ -3984,8 +4003,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytecode-source-map",
- "codespan",
- "codespan-reporting",
+ "codespan 0.8.0",
+ "codespan-reporting 0.8.0",
  "diem-workspace-hack",
  "ir-to-bytecode-syntax",
  "log",
@@ -4001,7 +4020,7 @@ name = "ir-to-bytecode-syntax"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "codespan",
+ "codespan 0.8.0",
  "diem-workspace-hack",
  "hex",
  "move-core-types",
@@ -4485,7 +4504,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytecode-source-map",
- "codespan",
+ "codespan 0.8.0",
  "diem-workspace-hack",
  "disassembler",
  "move-binary-format",
@@ -4554,7 +4573,7 @@ dependencies = [
  "bcs",
  "bytecode-source-map",
  "bytecode-verifier",
- "codespan",
+ "codespan 0.8.0",
  "colored",
  "diem-workspace-hack",
  "move-binary-format",
@@ -4582,7 +4601,7 @@ name = "move-ir-types"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "codespan",
+ "codespan 0.8.0",
  "diem-workspace-hack",
  "hex",
  "move-core-types",
@@ -4599,8 +4618,10 @@ dependencies = [
  "borrow-graph",
  "bytecode-source-map",
  "bytecode-verifier",
- "codespan",
- "codespan-reporting",
+ "codespan 0.11.1",
+ "codespan 0.8.0",
+ "codespan-reporting 0.11.1",
+ "codespan-reporting 0.8.0",
  "datatest-stable",
  "diem-framework",
  "diem-workspace-hack",
@@ -4662,8 +4683,8 @@ dependencies = [
  "anyhow",
  "bytecode-source-map",
  "bytecode-verifier",
- "codespan",
- "codespan-reporting",
+ "codespan 0.8.0",
+ "codespan-reporting 0.8.0",
  "datatest-stable",
  "diem-workspace-hack",
  "disassembler",
@@ -4715,8 +4736,8 @@ dependencies = [
  "bytecode",
  "bytecode-interpreter",
  "clap",
- "codespan",
- "codespan-reporting",
+ "codespan 0.8.0",
+ "codespan-reporting 0.8.0",
  "datatest-stable",
  "diem-workspace-hack",
  "docgen",
@@ -5822,8 +5843,8 @@ dependencies = [
  "bytecode",
  "chrono",
  "clap",
- "codespan",
- "codespan-reporting",
+ "codespan 0.8.0",
+ "codespan-reporting 0.8.0",
  "datatest-stable",
  "diem-workspace-hack",
  "hex",

--- a/language/move-ir/types/src/location.rs
+++ b/language/move-ir/types/src/location.rs
@@ -13,7 +13,7 @@ use std::{
 // Loc
 //**************************************************************************************************
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct Loc {
     file: &'static str,
     span: Span,

--- a/language/move-lang/Cargo.toml
+++ b/language/move-lang/Cargo.toml
@@ -10,6 +10,8 @@ license = "Apache-2.0"
 anyhow = "1.0.38"
 codespan = "0.8.0"
 codespan-reporting = "0.8.0"
+codespan-new = { package = "codespan", version = "0.11.1" }
+codespan-reporting-new = { package = "codespan-reporting", version = "0.11.1" }
 hex = "0.4.3"
 regex = "1.4.3"
 structopt = "0.3.21"

--- a/language/move-lang/src/cfgir/absint.rs
+++ b/language/move-lang/src/cfgir/absint.rs
@@ -43,8 +43,8 @@ fn collect_states_and_errors<State>(map: InvariantMap<State>) -> (BTreeMap<Label
     let final_states = map
         .into_iter()
         .map(|(lbl, BlockInvariant { pre, post })| {
-            if let BlockPostcondition::Error(mut es) = post {
-                errors.append(&mut es)
+            if let BlockPostcondition::Error(es) = post {
+                errors.extend(es)
             }
             (lbl, pre)
         })
@@ -148,9 +148,9 @@ pub trait AbstractInterpreter: TransferFunctions {
         block_lbl: Label,
     ) -> (Self::State, Errors) {
         let mut state = pre_state.clone();
-        let mut errors = vec![];
+        let mut errors = Errors::new();
         for (idx, cmd) in cfg.commands(block_lbl) {
-            errors.append(&mut self.execute(&mut state, block_lbl, idx, cmd));
+            errors.extend(self.execute(&mut state, block_lbl, idx, cmd));
         }
         (state, errors)
     }

--- a/language/move-lang/src/cfgir/borrows/mod.rs
+++ b/language/move-lang/src/cfgir/borrows/mod.rs
@@ -44,7 +44,7 @@ impl<'a, 'b> Context<'a, 'b> {
         Self {
             local_numbers,
             borrow_state,
-            errors: vec![],
+            errors: Errors::new(),
         }
     }
 
@@ -52,8 +52,8 @@ impl<'a, 'b> Context<'a, 'b> {
         self.errors
     }
 
-    fn add_errors(&mut self, mut additional: Errors) {
-        self.errors.append(&mut additional);
+    fn add_errors(&mut self, additional: Errors) {
+        self.errors.extend(additional);
     }
 }
 

--- a/language/move-lang/src/cfgir/cfg.rs
+++ b/language/move-lang/src/cfgir/cfg.rs
@@ -181,9 +181,9 @@ const DEAD_ERR_EXP: &str = "Invalid use of a divergent expression. The code foll
 fn dead_code_error(errors: &mut Errors, block: &BasicBlock) {
     let first_command = block.front().unwrap();
     match unreachable_loc(first_command) {
-        Some(loc) => errors.push(vec![(loc, DEAD_ERR_EXP.into())]),
+        Some(loc) => errors.add_deprecated(vec![(loc, DEAD_ERR_EXP.into())]),
         None if is_implicit_control_flow(&block) => (),
-        None => errors.push(vec![(first_command.loc, DEAD_ERR_CMD.into())]),
+        None => errors.add_deprecated(vec![(first_command.loc, DEAD_ERR_CMD.into())]),
     }
 }
 

--- a/language/move-lang/src/cfgir/liveness/mod.rs
+++ b/language/move-lang/src/cfgir/liveness/mod.rs
@@ -300,7 +300,7 @@ mod last_usage {
                                      '_{}')",
                                     v_str, v_str
                                 );
-                                context.env.add_error(vec![(l.loc, msg)]);
+                                context.env.add_error_deprecated(vec![(l.loc, msg)]);
                             }
                             if context.has_drop(v) {
                                 l.value = L::Ignore

--- a/language/move-lang/src/cfgir/translate.rs
+++ b/language/move-lang/src/cfgir/translate.rs
@@ -313,7 +313,9 @@ fn constant_(
     cfgir::optimize(&fake_signature, &locals, &mut cfg);
 
     if blocks.len() != 1 {
-        context.env.add_error(vec![(full_loc, CANNOT_FOLD)]);
+        context
+            .env
+            .add_error_deprecated(vec![(full_loc, CANNOT_FOLD)]);
         return None;
     }
     let mut optimized_block = blocks.remove(&start).unwrap();
@@ -322,7 +324,7 @@ fn constant_(
         let e = match cmd_ {
             C::IgnoreAndPop { exp, .. } => exp,
             _ => {
-                context.env.add_error(vec![(*cloc, CANNOT_FOLD)]);
+                context.env.add_error_deprecated(vec![(*cloc, CANNOT_FOLD)]);
                 continue;
             }
         };
@@ -341,7 +343,9 @@ fn check_constant_value(context: &mut Context, e: &H::Exp) {
     use H::UnannotatedExp_ as E;
     match &e.exp.value {
         E::Value(_) => (),
-        _ => context.env.add_error(vec![(e.exp.loc, CANNOT_FOLD)]),
+        _ => context
+            .env
+            .add_error_deprecated(vec![(e.exp.loc, CANNOT_FOLD)]),
     }
 }
 
@@ -361,7 +365,7 @@ fn move_value_from_value(context: &mut Context, sp!(loc, v_): Value) -> Option<M
         V::Address(a) => match a.into_addr_bytes(&context.addresses, loc, "address value") {
             Ok(bytes) => MV::Address(MoveAddress::new(bytes.into_bytes())),
             Err(err) => {
-                context.env.add_error(err);
+                context.env.add_error_deprecated(err);
                 return None;
             }
         },
@@ -416,9 +420,7 @@ fn function_body(
 
             let (mut cfg, infinite_loop_starts, errors) =
                 BlockCFG::new(start, &mut blocks, &block_info);
-            for e in errors {
-                context.env.add_error(e);
-            }
+            context.env.add_errors(errors);
 
             cfgir::refine_inference_and_verify(
                 context.env,

--- a/language/move-lang/src/compiled_unit.rs
+++ b/language/move-lang/src/compiled_unit.rs
@@ -173,33 +173,33 @@ impl CompiledUnit {
 
 fn verify_module(loc: Loc, cm: F::CompiledModule) -> (F::CompiledModule, Errors) {
     match move_bytecode_verifier::verifier::verify_module(&cm) {
-        Ok(_) => (cm, vec![]),
+        Ok(_) => (cm, Errors::new()),
         Err(e) => (
             cm,
-            vec![vec![(
+            Errors::from(vec![vec![(
                 loc,
                 format!("ICE failed bytecode verifier: {:#?}", e),
-            )]],
+            )]]),
         ),
     }
 }
 
 fn verify_script(loc: Loc, cs: F::CompiledScript) -> (F::CompiledScript, Errors) {
     match move_bytecode_verifier::verifier::verify_script(&cs) {
-        Ok(_) => (cs, vec![]),
+        Ok(_) => (cs, Errors::new()),
         Err(e) => (
             cs,
-            vec![vec![(
+            Errors::from(vec![vec![(
                 loc,
                 format!("ICE failed bytecode verifier: {:#?}", e),
-            )]],
+            )]]),
         ),
     }
 }
 
 pub fn verify_units(units: Vec<CompiledUnit>) -> (Vec<CompiledUnit>, Errors) {
     let mut new_units = vec![];
-    let mut errors = vec![];
+    let mut errors = Errors::new();
     for unit in units {
         let (unit, es) = unit.verify();
         new_units.push(unit);

--- a/language/move-lang/src/errors/diagnostic_codes.rs
+++ b/language/move-lang/src/errors/diagnostic_codes.rs
@@ -1,0 +1,110 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use codespan_reporting_new::diagnostic::Severity;
+
+//**************************************************************************************************
+// Main types
+//**************************************************************************************************
+
+#[derive(PartialEq, Eq, Clone, Debug, Hash)]
+pub(crate) struct DiagnosticInfo {
+    pub(crate) severity: Severity,
+    category: Category,
+    code: u8,
+    message: &'static str,
+}
+
+pub(crate) trait DiagnosticCode: Copy {
+    const SEVERITY: Severity;
+    const CATEGORY: Category;
+
+    fn code_and_message(self) -> (u8, &'static str);
+
+    fn into_info(self) -> DiagnosticInfo {
+        let severity = Self::SEVERITY;
+        let category = Self::CATEGORY;
+        let (code, message) = self.code_and_message();
+        DiagnosticInfo {
+            severity,
+            category,
+            code,
+            message,
+        }
+    }
+}
+
+//**************************************************************************************************
+// Categories and Codes
+//**************************************************************************************************
+
+macro_rules! codes {
+    ($(severity:$sev:ident, category:$cat:ident=$cat_num:literal, name:$name:ident, codes:[
+        $($code:ident = $code_num:literal: $code_msg:literal),*
+
+    ]),*) => {
+        #[derive(PartialEq, Eq, Clone, Copy, Debug, Hash)]
+        #[repr(u8)]
+        pub enum Category {
+            $($cat = $cat_num,)*
+        }
+
+        $(
+            #[derive(PartialEq, Eq, Clone, Copy, Debug, Hash)]
+            #[repr(u8)]
+            pub enum $name {
+                $($code = $code_num,)*
+            }
+
+            impl DiagnosticCode for $name {
+                const SEVERITY: Severity = Severity::$sev;
+                const CATEGORY: Category = {
+                    // hacky check that $cat_num <= 99
+                    let cat_is_leq_99 = $cat_num <= 99;
+                    ["Diagnostic Category must be a u8 <= 99"][!cat_is_leq_99 as usize];
+                    Category::$cat
+                };
+
+                fn code_and_message(self) -> (u8, &'static str) {
+                    let code = self as u8;
+                    debug_assert!(code > 0);
+                    let message = match self {
+                        $(Self::$code => $code_msg,)*
+                    };
+                    (code, message)
+                }
+            }
+        )*
+
+    };
+}
+
+codes!(
+    severity: Error, category: NameResolution=2, name: NameResolutionError, codes: [
+        UnboundModule = 1:  "unbound module"
+    ]
+);
+
+//**************************************************************************************************
+// impls
+//**************************************************************************************************
+
+impl DiagnosticInfo {
+    pub fn render(self) -> (/* code */ String, /* message */ &'static str) {
+        let Self {
+            severity,
+            category,
+            code,
+            message,
+        } = self;
+        let sev_prefix = match severity {
+            Severity::Error => "E",
+            Severity::Warning => "W",
+            _ => unimplemented!(),
+        };
+        let cat_prefix: u8 = category as u8;
+        debug_assert!(cat_prefix <= 99);
+        let string_code = format!("{}{:02}{:03}", sev_prefix, cat_prefix, code);
+        (string_code, message)
+    }
+}

--- a/language/move-lang/src/errors/new.rs
+++ b/language/move-lang/src/errors/new.rs
@@ -1,0 +1,183 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::errors::diagnostic_codes::{DiagnosticCode, DiagnosticInfo};
+use codespan_reporting_new::{
+    self as csr,
+    files::SimpleFiles,
+    term::{emit, termcolor::WriteColor, Config},
+};
+use move_ir_types::location::*;
+use std::{
+    collections::{HashMap, HashSet},
+    iter::FromIterator,
+    ops::Range,
+};
+
+//**************************************************************************************************
+// Types
+//**************************************************************************************************
+
+pub type FileId = usize;
+
+pub type FilesSourceText = HashMap<&'static str, String>;
+type FileMapping = HashMap<&'static str, FileId>;
+
+#[derive(PartialEq, Eq, Clone, Debug, Hash)]
+pub struct Diagnostic {
+    pub(crate) info: DiagnosticInfo,
+    pub(crate) primary_label: (Loc, String),
+    pub(crate) secondary_labels: Vec<(Loc, String)>,
+}
+
+#[derive(PartialEq, Eq, Hash, Clone, Debug, Default)]
+pub struct Diagnostics(pub(crate) Vec<Diagnostic>);
+
+//**************************************************************************************************
+// Reporting
+//**************************************************************************************************
+
+pub(crate) fn output_diagnostics<W: WriteColor>(
+    writer: &mut W,
+    sources: &FilesSourceText,
+    diags: Diagnostics,
+) {
+    let mut files = SimpleFiles::new();
+    let mut file_mapping = HashMap::new();
+    for (fname, source) in sources {
+        let id = files.add(*fname, source.as_str());
+        file_mapping.insert(*fname, id);
+    }
+    render_diagnostics(writer, &files, &file_mapping, diags);
+}
+
+fn render_diagnostics(
+    writer: &mut dyn WriteColor,
+    files: &SimpleFiles<&'static str, &str>,
+    file_mapping: &FileMapping,
+    mut diags: Diagnostics,
+) {
+    diags.0.sort_by(|e1, e2| {
+        let loc1: &Loc = &e1.primary_label.0;
+        let loc2: &Loc = &e2.primary_label.0;
+        loc1.cmp(loc2)
+    });
+    let mut seen: HashSet<Diagnostic> = HashSet::new();
+    for diag in diags.0 {
+        if seen.contains(&diag) {
+            continue;
+        }
+        seen.insert(diag.clone());
+        let rendered = render_diagnostic(file_mapping, diag);
+        emit(writer, &Config::default(), files, &rendered).unwrap()
+    }
+}
+
+fn convert_loc(file_mapping: &FileMapping, loc: Loc) -> (FileId, Range<usize>) {
+    let fname = loc.file();
+    let id = *file_mapping.get(fname).unwrap();
+    let start = loc.span().start().to_usize();
+    let end = loc.span().end().to_usize();
+    (id, Range { start, end })
+}
+
+fn render_diagnostic(
+    file_mapping: &FileMapping,
+    diag: Diagnostic,
+) -> csr::diagnostic::Diagnostic<FileId> {
+    use csr::diagnostic::{Label, LabelStyle};
+    let mk_lbl = |style: LabelStyle, msg: (Loc, String)| -> Label<FileId> {
+        let (id, range) = convert_loc(file_mapping, msg.0);
+        csr::diagnostic::Label::new(style, id, range).with_message(msg.1)
+    };
+    let Diagnostic {
+        info,
+        primary_label,
+        secondary_labels,
+    } = diag;
+    let mut diag = csr::diagnostic::Diagnostic::new(info.severity);
+    let (code, message) = info.render();
+    diag = diag.with_code(code);
+    diag = diag.with_message(message);
+    diag = diag.with_labels(vec![mk_lbl(LabelStyle::Primary, primary_label)]);
+    diag = diag.with_labels(
+        secondary_labels
+            .into_iter()
+            .map(|msg| mk_lbl(LabelStyle::Secondary, msg))
+            .collect(),
+    );
+    diag
+}
+
+//**************************************************************************************************
+// impls
+//**************************************************************************************************
+
+impl Diagnostics {
+    pub fn new() -> Self {
+        Self(vec![])
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn add(&mut self, diag: Diagnostic) {
+        self.0.push(diag)
+    }
+
+    pub fn extend(&mut self, diags: Self) {
+        self.0.extend(diags.0)
+    }
+
+    pub fn into_vec(self) -> Vec<Diagnostic> {
+        self.0
+    }
+}
+
+impl Diagnostic {
+    pub(crate) fn new(
+        code: impl DiagnosticCode,
+        (loc, label): (Loc, impl ToString),
+        secondary_labels: impl IntoIterator<Item = (Loc, impl ToString)>,
+    ) -> Self {
+        Diagnostic {
+            info: code.into_info(),
+            primary_label: (loc, label.to_string()),
+            secondary_labels: secondary_labels
+                .into_iter()
+                .map(|(loc, msg)| (loc, msg.to_string()))
+                .collect(),
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! diag {
+    ($code: expr, $primary: expr $(,)?) => {{
+        crate::errors::new::Diagnostic::new($code, $primary, std::iter::empty::<(Loc, String)>())
+    }};
+    ($code: expr, $primary: expr, $($secondary: expr),+) => {{
+        crate::errors::new::Diagnostic::new($code, $primary, $(vec![$secondary, ])*)
+    }};
+}
+
+//**************************************************************************************************
+// traits
+//**************************************************************************************************
+
+impl FromIterator<Diagnostic> for Diagnostics {
+    fn from_iter<I: IntoIterator<Item = Diagnostic>>(iter: I) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl From<Vec<Diagnostic>> for Diagnostics {
+    fn from(v: Vec<Diagnostic>) -> Self {
+        Self(v)
+    }
+}

--- a/language/move-lang/src/expansion/address_map.rs
+++ b/language/move-lang/src/expansion/address_map.rs
@@ -86,7 +86,7 @@ fn definition(context: &mut Context, def: &P::Definition) {
 
             context
                 .env
-                .add_error(vec![(loc, msg), (prev_loc, prev_msg)]);
+                .add_error_deprecated(vec![(loc, msg), (prev_loc, prev_msg)]);
         }
     }
 }

--- a/language/move-lang/src/expansion/byte_string.rs
+++ b/language/move-lang/src/expansion/byte_string.rs
@@ -21,7 +21,7 @@ impl Context {
     }
 
     fn error(&mut self, start: usize, end: usize, err_text: String) {
-        self.errors.push(vec![(
+        self.errors.add_deprecated(vec![(
             make_loc(
                 self.filename,
                 self.start_offset + 2 + start, // add 2 for the beginning of the string

--- a/language/move-lang/src/expansion/dependency_ordering.rs
+++ b/language/move-lang/src/expansion/dependency_ordering.rs
@@ -34,7 +34,7 @@ pub fn verify(
         Err(cycle_node) => {
             let cycle_ident = cycle_node.node_id().clone();
             let error = cycle_error(&module_neighbors, cycle_ident);
-            compilation_env.add_error(error);
+            compilation_env.add_error_deprecated(error);
         }
         Ok(ordered_ids) => {
             for (order, mident) in ordered_ids.iter().rev().enumerate() {

--- a/language/move-lang/src/expansion/hex_string.rs
+++ b/language/move-lang/src/expansion/hex_string.rs
@@ -12,16 +12,16 @@ pub fn decode(loc: Loc, s: &str) -> Result<Vec<u8>, Errors> {
             let start_offset = loc.span().start().0 as usize;
             let offset = start_offset + 2 + index;
             let loc = make_loc(filename, offset, offset);
-            Err(vec![vec![(
+            Err(Errors::from(vec![vec![(
                 loc,
                 format!("Invalid hexadecimal character: '{}'", c),
-            )]])
+            )]]))
         }
-        Err(hex::FromHexError::OddLength) => Err(vec![vec![(
+        Err(hex::FromHexError::OddLength) => Err(Errors::from(vec![vec![(
             loc,
             "Odd number of characters in hex string. Expected 2 hexadecimal digits for each byte"
                 .to_string(),
-        )]]),
+        )]])),
         Err(_) => unreachable!("unexpected error parsing hex byte string value"),
     }
 }

--- a/language/move-lang/src/expansion/unique_modules_after_mapping.rs
+++ b/language/move-lang/src/expansion/unique_modules_after_mapping.rs
@@ -63,7 +63,7 @@ pub fn verify(
             };
             let msg = format!("Duplicate definition of {}", format_name(duplicate));
             let prev_msg = format!("Previously defined here as {}", format_name(orig));
-            compilation_env.add_error(vec![(duplicate.loc, msg), (orig.loc, prev_msg)]);
+            compilation_env.add_error_deprecated(vec![(duplicate.loc, msg), (orig.loc, prev_msg)]);
         }
     }
 }

--- a/language/move-lang/src/hlir/translate.rs
+++ b/language/move-lang/src/hlir/translate.rs
@@ -1676,7 +1676,7 @@ fn check_trailing_unit(context: &mut Context, block: &mut Block) {
             let unreachable_msg = "Any code after this expression will not be reached";
             let info_msg = "A trailing ';' in an expression block implicitly adds a '()' value \
                         after the semicolon. That '()' value will not be reachable";
-            $context.env.add_error(vec![
+            $context.env.add_error_deprecated(vec![
                 ($uloc, semi_msg),
                 ($loc, unreachable_msg),
                 ($uloc, info_msg),
@@ -1803,7 +1803,7 @@ fn check_unused_locals(
         errors.push((loc, msg));
     }
     for error in errors {
-        context.env.add_error(vec![error]);
+        context.env.add_error_deprecated(vec![error]);
     }
     for v in &unused {
         locals.remove(v);

--- a/language/move-lang/src/parser/comments.rs
+++ b/language/move-lang/src/parser/comments.rs
@@ -54,7 +54,7 @@ fn verify_string(fname: &'static str, string: &str) -> Result<(), Errors> {
                  tabs (\\t), and line endings (\\n) are permitted.",
                 chr
             );
-            Err(vec![vec![(loc, msg)]])
+            Err(Errors::from(vec![vec![(loc, msg)]]))
         }
     }
 }
@@ -212,7 +212,7 @@ fn strip_comments(fname: &'static str, input: &str) -> Result<(String, FileComme
                 // try to point to last real character
                 pos -= 1;
             }
-            return Err(vec![vec![
+            return Err(Errors::from(vec![vec![
                 (
                     Loc::new(fname, Span::new(pos, pos)),
                     "unclosed block comment".to_string(),
@@ -221,7 +221,7 @@ fn strip_comments(fname: &'static str, input: &str) -> Result<(String, FileComme
                     Loc::new(fname, Span::new(comment_start_pos, comment_start_pos + 2)),
                     "begin of unclosed block comment".to_string(),
                 ),
-            ]]);
+            ]]));
         }
         State::Source | State::String => {}
     }

--- a/language/move-lang/src/parser/merge_spec_modules.rs
+++ b/language/move-lang/src/parser/merge_spec_modules.rs
@@ -11,6 +11,7 @@
 //! are for specs or not, and allow the older to resolve only in spec contexts.
 
 use crate::{
+    errors::Errors,
     parser::ast::{Definition, LeadingNameAccess_, ModuleDefinition, ModuleMember, Program},
     shared::*,
 };
@@ -30,7 +31,7 @@ pub fn program(compilation_env: &mut CompilationEnv, prog: Program) -> Program {
 
     // Report errors for misplaced members
     for m in spec_modules.values() {
-        let errors: Vec<_> = m
+        let errors: Errors = m
             .members
             .iter()
             .filter_map(|m| match m {
@@ -60,7 +61,7 @@ pub fn program(compilation_env: &mut CompilationEnv, prog: Program) -> Program {
 
     // Remaining spec modules could not be merged, report errors.
     for (_, m) in spec_modules {
-        compilation_env.add_error(vec![(
+        compilation_env.add_error_deprecated(vec![(
             m.name.loc(),
             "Cannot associate specification with any target module in this compilation. \
                     A module specification cannot be compiled standalone."

--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -2774,11 +2774,11 @@ pub fn parse_file_string(
 ) -> Result<(Vec<Definition>, BTreeMap<ByteIndex, String>), Errors> {
     let mut tokens = Lexer::new(input, file, comment_map);
     match tokens.advance() {
-        Err(err) => Err(vec![err]),
+        Err(err) => Err(Errors::from(vec![err])),
         Ok(..) => Ok(()),
     }?;
     match parse_file(&mut tokens) {
-        Err(err) => Err(vec![err]),
+        Err(err) => Err(Errors::from(vec![err])),
         Ok(def) => {
             let doc_comments = tokens.check_and_get_doc_comments()?;
             Ok((def, doc_comments))

--- a/language/move-lang/src/shared/mod.rs
+++ b/language/move-lang/src/shared/mod.rs
@@ -1,7 +1,10 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{command_line as cli, errors::Errors};
+use crate::{
+    command_line as cli,
+    errors::{new::Diagnostic, Errors},
+};
 use move_ir_types::location::*;
 use petgraph::{algo::astar as petgraph_astar, graphmap::DiGraphMap};
 use std::{
@@ -235,13 +238,17 @@ impl CompilationEnv {
     pub fn new(flags: Flags) -> Self {
         Self {
             flags,
-            errors: Vec::new(),
+            errors: Errors::new(),
         }
     }
 
-    pub fn add_error(&mut self, e: Vec<(Loc, impl Into<String>)>) {
+    pub fn add_error_deprecated(&mut self, e: Vec<(Loc, impl Into<String>)>) {
         self.errors
-            .push(e.into_iter().map(|(loc, msg)| (loc, msg.into())).collect())
+            .add_deprecated(e.into_iter().map(|(loc, msg)| (loc, msg.into())).collect())
+    }
+
+    pub fn add_diag(&mut self, diag: Diagnostic) {
+        self.errors.add(diag)
     }
 
     pub fn add_errors(&mut self, es: Errors) {

--- a/language/move-lang/src/to_bytecode/context.rs
+++ b/language/move-lang/src/to_bytecode/context.rs
@@ -100,7 +100,7 @@ impl<'a> Context<'a> {
             let ir_ident = match Self::translate_module_ident_impl(addresses, module) {
                 Ok(ident) => ident,
                 Err(e) => {
-                    env.add_error(e);
+                    env.add_error_deprecated(e);
                     continue;
                 }
             };
@@ -230,7 +230,7 @@ impl<'a> Context<'a> {
         match addr.into_addr_bytes(self.addresses, loc, case) {
             Ok(addr) => Some(addr),
             Err(e) => {
-                self.env.add_error(e);
+                self.env.add_error_deprecated(e);
                 None
             }
         }
@@ -240,7 +240,7 @@ impl<'a> Context<'a> {
         match Self::translate_module_ident_impl(&self.addresses, ident) {
             Ok(ident) => Some(ident),
             Err(e) => {
-                self.env.add_error(e);
+                self.env.add_error_deprecated(e);
                 None
             }
         }

--- a/language/move-lang/src/to_bytecode/translate.rs
+++ b/language/move-lang/src/to_bytecode/translate.rs
@@ -241,7 +241,8 @@ fn module(
     {
         Ok(res) => res,
         Err(e) => {
-            compilation_env.add_error(vec![(ident_loc, format!("ICE. IR ERROR: {}", e))]);
+            compilation_env
+                .add_error_deprecated(vec![(ident_loc, format!("ICE. IR ERROR: {}", e))]);
             return None;
         }
     };
@@ -300,7 +301,7 @@ fn script(
     {
         Ok(res) => res,
         Err(e) => {
-            compilation_env.add_error(vec![(loc, format!("IR ERROR: {}", e))]);
+            compilation_env.add_error_deprecated(vec![(loc, format!("IR ERROR: {}", e))]);
             return None;
         }
     };

--- a/language/move-lang/src/typing/core.rs
+++ b/language/move-lang/src/typing/core.rs
@@ -245,7 +245,7 @@ impl<'env> Context<'env> {
     pub fn get_local(&mut self, loc: Loc, verb: &str, var: &Var) -> Type {
         match self.get_local_(var) {
             None => {
-                self.env.add_error(vec![(
+                self.env.add_error_deprecated(vec![(
                     loc,
                     format!("Invalid {}. Unbound local '{}'", verb, var),
                 )]);
@@ -692,7 +692,7 @@ pub fn make_field_type(
     let fields_map = match &sdef.fields {
         N::StructFields::Native(nloc) => {
             let nloc = *nloc;
-            context.env.add_error(vec![
+            context.env.add_error_deprecated(vec![
                 (
                     loc,
                     format!("Unbound field '{}' for native struct '{}::{}'", field, m, n),
@@ -705,7 +705,7 @@ pub fn make_field_type(
     };
     match fields_map.get(field).cloned() {
         None => {
-            context.env.add_error(vec![(
+            context.env.add_error_deprecated(vec![(
                 loc,
                 format!("Unbound field '{}' in '{}::{}'", field, m, n),
             )]);
@@ -746,7 +746,7 @@ pub fn make_constant_type(
                             outside of their module";
         context
             .env
-            .add_error(vec![(loc, msg), (defined_loc, internal_msg.into())]);
+            .add_error_deprecated(vec![(loc, msg), (defined_loc, internal_msg.into())]);
     }
 
     signature
@@ -823,7 +823,7 @@ pub fn make_function_type(
                 Visibility::SCRIPT,
                 Visibility::FRIEND
             );
-            context.env.add_error(vec![
+            context.env.add_error_deprecated(vec![
                 (loc, format!("Invalid call to '{}::{}'", m, f)),
                 (defined_loc, internal_msg),
             ])
@@ -835,7 +835,7 @@ pub fn make_function_type(
                  or a '{}' function",
                 Visibility::SCRIPT
             );
-            context.env.add_error(vec![
+            context.env.add_error_deprecated(vec![
                 (loc, format!("Invalid call to '{}::{}'", m, f)),
                 (vis_loc, internal_msg),
             ])
@@ -846,7 +846,7 @@ pub fn make_function_type(
                 "This function can only be called from a 'friend' of module '{}'",
                 m
             );
-            context.env.add_error(vec![
+            context.env.add_error_deprecated(vec![
                 (loc, format!("Invalid call to '{}::{}'", m, f)),
                 (vis_loc, internal_msg),
             ])
@@ -948,7 +948,7 @@ fn solve_ability_constraint(
                 format!("'{}' constraint declared here", constraint),
             ));
         }
-        context.env.add_error(error)
+        context.env.add_error_deprecated(error)
     }
 }
 
@@ -1046,7 +1046,7 @@ fn solve_implicitly_copyable_constraint(
     let tloc = ty.loc;
     if !is_implicitly_copyable(&context.subst, &ty) {
         let ty_str = error_format(&ty, &context.subst);
-        context.env.add_error(vec![
+        context.env.add_error_deprecated(vec![
             (loc, format!("{} {}", msg, fix)),
             (
                 tloc,
@@ -1101,7 +1101,7 @@ fn solve_builtin_type_constraint(
                 (loc, format!("Invalid argument to '{}'", op)),
                 (tloc, tmsg()),
             ];
-            context.env.add_error(error)
+            context.env.add_error_deprecated(error)
         }
     }
 }
@@ -1115,7 +1115,9 @@ fn solve_base_type_constraint(context: &mut Context, loc: Loc, msg: String, ty: 
         Unit | Ref(_, _) | Apply(_, sp!(_, Multiple(_)), _) => {
             let tystr = error_format(ty, &context.subst);
             let tmsg = format!("Expected a single non-reference type, but found: {}", tystr);
-            context.env.add_error(vec![(loc, msg), (tyloc, tmsg)])
+            context
+                .env
+                .add_error_deprecated(vec![(loc, msg), (tyloc, tmsg)])
         }
         UnresolvedError | Anything | Param(_) | Apply(_, _, _) => (),
     }
@@ -1133,7 +1135,9 @@ fn solve_single_type_constraint(context: &mut Context, loc: Loc, msg: String, ty
                 "Expected a single type, but found expression list type: {}",
                 tystr
             );
-            context.env.add_error(vec![(loc, msg), (tyloc, tmsg)])
+            context
+                .env
+                .add_error_deprecated(vec![(loc, msg), (tyloc, tmsg)])
         }
         UnresolvedError | Anything | Ref(_, _) | Param(_) | Apply(_, _, _) => (),
     }
@@ -1316,7 +1320,7 @@ fn check_type_argument_arity<F: FnOnce() -> String>(
     let args_len = ty_args.len();
     let arity = tparam_constraints.len();
     if args_len != arity {
-        context.env.add_error(vec![(
+        context.env.add_error_deprecated(vec![(
             loc,
             format!(
                 "Invalid instantiation of '{}'. Expected {} type argument(s) but got {}",

--- a/language/move-lang/src/typing/expand.rs
+++ b/language/move-lang/src/typing/expand.rs
@@ -55,7 +55,7 @@ pub fn type_(context: &mut Context, ty: &mut Type) {
             let replacement = match replacement {
                 sp!(_, Var(_)) => panic!("ICE unfold_type_base failed to expand"),
                 sp!(loc, Anything) => {
-                    context.env.add_error(vec![(
+                    context.env.add_error_deprecated(vec![(
                         ty.loc,
                         "Could not infer this type. Try adding an annotation",
                     )]);
@@ -178,7 +178,7 @@ pub fn exp(context: &mut Context, e: &mut T::Exp) {
                     value=v,
                     type=fix_bt,
                 );
-                context.env.add_error(vec![
+                context.env.add_error_deprecated(vec![
                     (e.exp.loc, "Invalid numerical literal".into()),
                     (e.ty.loc, msg),
                     (e.exp.loc, fix),

--- a/language/move-lang/src/typing/globals.rs
+++ b/language/move-lang/src/typing/globals.rs
@@ -38,7 +38,9 @@ pub fn function_body_(
                 N::BuiltinFunction_::BORROW_GLOBAL,
                 N::BuiltinFunction_::BORROW_GLOBAL_MUT
             );
-            context.env.add_error(vec![(*annotated_loc, msg)])
+            context
+                .env
+                .add_error_deprecated(vec![(*annotated_loc, msg)])
         }
     }
 }
@@ -228,7 +230,7 @@ fn check_acquire_listed<F>(
         );
         context
             .env
-            .add_error(vec![(loc, msg()), (global_type_loc, tmsg)]);
+            .add_error_deprecated(vec![(loc, msg()), (global_type_loc, tmsg)]);
     }
 }
 
@@ -281,7 +283,9 @@ where
                 ty_debug
             );
 
-            context.env.add_error(vec![(*loc, msg()), (*tloc, tmsg)]);
+            context
+                .env
+                .add_error_deprecated(vec![(*loc, msg()), (*tloc, tmsg)]);
             return None;
         }
 
@@ -296,11 +300,13 @@ where
                  internal to the module'",
                 ty_debug
             );
-            context.env.add_error(vec![(*loc, msg()), (*tloc, tmsg)]);
+            context
+                .env
+                .add_error_deprecated(vec![(*loc, msg()), (*tloc, tmsg)]);
             return None;
         }
         None => {
-            context.env.add_error(vec![(
+            context.env.add_error_deprecated(vec![(
                 *loc,
                 "Global storage operator cannot be used from a 'script' function",
             )]);

--- a/language/move-lang/src/typing/infinite_instantiations.rs
+++ b/language/move-lang/src/typing/infinite_instantiations.rs
@@ -176,7 +176,7 @@ fn module<'a>(
     petgraph_scc(&graph)
         .into_iter()
         .filter(|scc| scc_edges!(&graph, scc).any(|(_, e, _)| e == Edge::Nested))
-        .for_each(|scc| compilation_env.add_error(cycle_error(context, &graph, scc)))
+        .for_each(|scc| compilation_env.add_error_deprecated(cycle_error(context, &graph, scc)))
 }
 
 //**************************************************************************************************

--- a/language/move-lang/src/typing/recursive_structs.rs
+++ b/language/move-lang/src/typing/recursive_structs.rs
@@ -73,7 +73,7 @@ fn module(compilation_env: &mut CompilationEnv, mname: ModuleIdent, module: &T::
     petgraph_scc(&graph)
         .into_iter()
         .filter(|scc| scc.len() > 1 || graph.contains_edge(scc[0], scc[0]))
-        .for_each(|scc| compilation_env.add_error(cycle_error(context, &graph, scc[0])))
+        .for_each(|scc| compilation_env.add_error_deprecated(cycle_error(context, &graph, scc[0])))
 }
 
 fn struct_def(context: &mut Context, sname: StructName, sdef: &N::StructDefinition) {

--- a/language/move-lang/src/typing/translate.rs
+++ b/language/move-lang/src/typing/translate.rs
@@ -149,7 +149,9 @@ fn check_primitive_script_arg(
                  non-signer types",
                 core::error_format(&signer, &Subst::empty()),
             );
-            context.env.add_error(vec![(mloc, msg), (loc, tmsg)]);
+            context
+                .env
+                .add_error_deprecated(vec![(mloc, msg), (loc, tmsg)]);
             return;
         }
     } else {
@@ -227,7 +229,7 @@ fn function_signature(context: &mut Context, sig: &N::FunctionSignature) {
             param_ty.clone(),
         );
         if let Err((param, prev_loc)) = declared.add(param.clone(), ()) {
-            context.env.add_error(vec![
+            context.env.add_error_deprecated(vec![
                 (
                     param.loc(),
                     format!("Duplicate parameter with name '{}'", param),
@@ -379,7 +381,7 @@ mod check_valid_constant {
         );
         context
             .env
-            .add_error(vec![(sloc, fmsg().into()), (loc, tmsg)]);
+            .add_error_deprecated(vec![(sloc, fmsg().into()), (loc, tmsg)]);
     }
 
     pub fn exp(context: &mut Context, e: &T::Exp) {
@@ -480,7 +482,7 @@ mod check_valid_constant {
             }
             E::Constant(_, _) => "Other constants are",
         };
-        context.env.add_error(vec![(
+        context.env.add_error_deprecated(vec![(
             *loc,
             format!("{} not supported in constants", error_case),
         )])
@@ -524,7 +526,7 @@ mod check_valid_constant {
                 "'let' declarations"
             }
         };
-        context.env.add_error(vec![(
+        context.env.add_error_deprecated(vec![(
             *loc,
             format!("{} are not supported in constants", error_case),
         )])
@@ -624,7 +626,7 @@ fn typing_error<T: Into<String>, F: FnOnce() -> T>(
             ),
         ],
     };
-    context.env.add_error(error);
+    context.env.add_error_deprecated(error);
 }
 
 fn subtype_no_report(
@@ -1095,7 +1097,7 @@ fn exp_inner(context: &mut Context, sp!(eloc, ne_): N::Exp) -> T::Exp {
         }
         NE::Break => {
             if !context.in_loop() {
-                context.env.add_error(vec![(
+                context.env.add_error_deprecated(vec![(
                     eloc,
                     "Invalid usage of 'break'. 'break' can only be used inside a loop body",
                 )]);
@@ -1113,7 +1115,7 @@ fn exp_inner(context: &mut Context, sp!(eloc, ne_): N::Exp) -> T::Exp {
         }
         NE::Continue => {
             if !context.in_loop() {
-                context.env.add_error(vec![(
+                context.env.add_error_deprecated(vec![(
                     eloc,
                     "Invalid usage of 'continue'. 'continue' can only be used inside a loop body",
                 )]);
@@ -1202,7 +1204,7 @@ fn exp_inner(context: &mut Context, sp!(eloc, ne_): N::Exp) -> T::Exp {
                      the module in which they are declared",
                     &m, &n,
                 );
-                context.env.add_error(vec![(eloc, msg)])
+                context.env.add_error_deprecated(vec![(eloc, msg)])
             }
             (bt, TE::Pack(m, n, targs, tfields))
         }
@@ -1471,7 +1473,7 @@ fn lvalue(
                         ]
                     }
                 };
-                context.env.add_error(error)
+                context.env.add_error_deprecated(error)
             }
             TL::Var(var, Box::new(var_ty))
         }
@@ -1519,7 +1521,7 @@ fn lvalue(
                      deconstructed in the module in which they are declared",
                     verb, &m, &n,
                 );
-                context.env.add_error(vec![(loc, msg)])
+                context.env.add_error_deprecated(vec![(loc, msg)])
             }
             match ref_mut {
                 None => TL::Unpack(m, n, targs, tfields),
@@ -1570,7 +1572,7 @@ fn resolve_field(context: &mut Context, loc: Loc, ty: Type, field: &Field) -> Ty
     match core::unfold_type(&context.subst, ty) {
         sp!(_, UnresolvedError) => context.error_type(loc),
         sp!(tloc, Anything) => {
-            context.env.add_error(vec![
+            context.env.add_error_deprecated(vec![
                 (loc, msg()),
                 (tloc, "Could not infer the type. Try annotating here".into()),
             ]);
@@ -1583,12 +1585,12 @@ fn resolve_field(context: &mut Context, loc: Loc, ty: Type, field: &Field) -> Ty
                      the struct's module",
                     field, &m, &n
                 );
-                context.env.add_error(vec![(loc, msg)])
+                context.env.add_error_deprecated(vec![(loc, msg)])
             }
             core::make_field_type(context, loc, &m, &n, targs, field)
         }
         t => {
-            context.env.add_error(vec![
+            context.env.add_error_deprecated(vec![
                 (loc, msg()),
                 (
                     t.loc,
@@ -1623,13 +1625,13 @@ fn add_field_types<T>(
             );
             context
                 .env
-                .add_error(vec![(loc, msg), (nloc, "Declared 'native' here".into())]);
+                .add_error_deprecated(vec![(loc, msg), (nloc, "Declared 'native' here".into())]);
             return fields.map(|f, (idx, x)| (idx, (context.error_type(f.loc()), x)));
         }
     };
     for (_, f_, _) in &fields_ty {
         if fields.get_(&f_).is_none() {
-            context.env.add_error(vec![(
+            context.env.add_error_deprecated(vec![(
                 loc,
                 format!("Missing {} for field '{}' in '{}::{}'", verb, f_, m, n),
             )])
@@ -1638,7 +1640,7 @@ fn add_field_types<T>(
     fields.map(|f, (idx, x)| {
         let fty = match fields_ty.remove(&f) {
             None => {
-                context.env.add_error(vec![(
+                context.env.add_error_deprecated(vec![(
                     loc,
                     format!("Unbound field '{}' in '{}::{}'", &f, m, n),
                 )]);
@@ -1733,7 +1735,7 @@ fn exp_dotted_to_borrow(
             };
             // lhs is immutable and current borrow is mutable
             if !lhs_mut && mut_ {
-                context.env.add_error(vec![
+                context.env.add_error_deprecated(vec![
                     (loc, "Invalid mutable borrow from an immutable reference"),
                     (tyloc, "Immutable because of this position"),
                 ])
@@ -1976,7 +1978,7 @@ fn make_arg_types<S: std::fmt::Display, F: Fn() -> S>(
             arity,
             given_len
         );
-        context.env.add_error(vec![
+        context.env.add_error_deprecated(vec![
             (loc, cmsg),
             (argloc, format!("Found {} argument(s) here", given_len)),
         ])

--- a/language/move-lang/src/unit_test/filter_test_members.rs
+++ b/language/move-lang/src/unit_test/filter_test_members.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    errors::Errors,
     parser::ast as P,
     shared::{known_attributes, AddressBytes, CompilationEnv},
 };
@@ -90,7 +91,7 @@ fn check_has_unit_test_module(context: &mut Context, prog: &P::Program) -> bool 
                 P::Definition::Address(P::AddressDefinition { loc, .. })
                 | P::Definition::Script(P::Script { loc, .. }) => *loc,
             };
-            context.env.add_error(vec![
+            context.env.add_error_deprecated(vec![
                     (loc, "Compilation in test mode requires passing the UnitTest module in the Move stdlib as a dependency")
                 ]);
             return false;
@@ -147,7 +148,7 @@ fn filter_tests_from_definition(
                 .chain(function.attributes.iter())
                 .chain(specs.iter().flat_map(|spec| &spec.value.attributes));
 
-            let errors: Vec<_> = script_attributes
+            let errors: Errors = script_attributes
                 .map(|attr| {
                     test_attributes(attr).into_iter().map(|(loc, _)| {
                         let msg = "Testing attributes are not allowed in scripts.";

--- a/language/move-lang/src/unit_test/plan_builder.rs
+++ b/language/move-lang/src/unit_test/plan_builder.rs
@@ -38,7 +38,7 @@ impl<'env> Context<'env> {
         let resolved = addr.clone().into_addr_bytes_opt(self.addresses);
         if resolved.is_none() {
             let msg = format!("{}. No value specified for address '{}'", case(), addr);
-            self.env.add_error(vec![(loc, msg)]);
+            self.env.add_error_deprecated(vec![(loc, msg)]);
         }
         resolved
     }
@@ -124,7 +124,7 @@ fn build_test_info(
     if !abort_attributes.is_empty() && test_attributes.is_empty() {
         let fn_msg =  "Only functions defined as a test with #[test] can also have an #[expected_failure] attribute";
         let abort_msg = "Attributed as #[expected_failure] here";
-        context.env.add_error(vec![
+        context.env.add_error_deprecated(vec![
             (fn_loc, fn_msg),
             (abort_attributes.last().unwrap().loc, abort_msg),
         ])
@@ -137,7 +137,7 @@ fn build_test_info(
     // Check for duplicate #[test(...)] attributes
     if test_attributes.len() > 1 {
         let len = test_attributes.len();
-        context.env.add_error(vec![
+        context.env.add_error_deprecated(vec![
             (
                 test_attributes[len - 1].loc,
                 make_duplicate_msg(known_attributes::TestingAttributes::TEST),
@@ -153,7 +153,7 @@ fn build_test_info(
     // A #[test] function cannot also be annotated #[test_only]
     if !test_only_attributes.is_empty() {
         let msg = "Function annotated as both #[test(...)] and #[test_only]. You need to declare it as either one or the other";
-        context.env.add_error(vec![
+        context.env.add_error_deprecated(vec![
             (test_only_attributes.last().unwrap().loc, msg),
             (
                 test_attributes.last().unwrap().loc,
@@ -166,7 +166,7 @@ fn build_test_info(
     // Only one abort can be specified
     if abort_attributes.len() > 1 {
         let len = abort_attributes.len();
-        context.env.add_error(vec![
+        context.env.add_error_deprecated(vec![
             (
                 abort_attributes[len - 1].loc,
                 make_duplicate_msg(known_attributes::TestingAttributes::EXPECTED_FAILURE),
@@ -187,7 +187,7 @@ fn build_test_info(
             Some(value) => arguments.push(value.clone()),
             None => {
                 let missing_param_msg = "Missing test parameter assignment in test. Expected a parameter to be assigned in this attribute";
-                context.env.add_error(vec![
+                context.env.add_error_deprecated(vec![
                     (test_attribute.loc, missing_param_msg),
                     (var.loc(), "Corresponding to this parameter"),
                     (fn_loc, in_this_test_msg),
@@ -232,7 +232,7 @@ fn parse_test_attribute(
             let value = match convert_attribute_value_to_move_value(context, attr_value) {
                 Some(move_value) => move_value,
                 None => {
-                    context.env.add_error(vec![
+                    context.env.add_error_deprecated(vec![
                         (*assign_loc, "Unsupported attribute value"),
                         (*aloc, "Assigned in this attribute"),
                     ]);
@@ -277,7 +277,7 @@ fn parse_failure_attribute(
                 "Expect an #[expected_failure({}=...)] attribute for abort code assignment",
                 known_attributes::TestingAttributes::CODE_ASSIGNMENT_NAME
             );
-            context.env.add_error(vec![
+            context.env.add_error_deprecated(vec![
                 (assign_loc, invalid_assignment_msg.into()),
                 (*aloc, expected_msg),
             ]);
@@ -289,7 +289,9 @@ fn parse_failure_attribute(
                     "Invalid #[expected_failure(...)] attribute, expected 1 argument but found {}",
                     attrs.len()
                 );
-                context.env.add_error(vec![(*aloc, invalid_attr_msg)]);
+                context
+                    .env
+                    .add_error_deprecated(vec![(*aloc, invalid_attr_msg)]);
                 return None;
             }
             assert!(
@@ -311,7 +313,7 @@ fn parse_failure_attribute(
                         }
                         sp!(vloc, EAV::Value(sp!(_, EV::U8(_))))
                         | sp!(vloc, EAV::Value(sp!(_, EV::U128(_)))) => {
-                            context.env.add_error(vec![
+                            context.env.add_error_deprecated(vec![
                                 (
                                     *assign_loc,
                                     "Invalid value in expected failure code assignment",
@@ -321,7 +323,7 @@ fn parse_failure_attribute(
                             None
                         }
                         sp!(vloc, _) => {
-                            context.env.add_error(vec![
+                            context.env.add_error_deprecated(vec![
                                 (*vloc, "Invalid value in expected failure code assignment"),
                                 (*assign_loc, "In this assignment"),
                             ]);
@@ -334,7 +336,7 @@ fn parse_failure_attribute(
                                 "Invalid name in expected failure code assignment. Did you mean to use '{}'?",
                                 known_attributes::TestingAttributes::CODE_ASSIGNMENT_NAME
                             );
-                    context.env.add_error(vec![
+                    context.env.add_error_deprecated(vec![
                         (*nmloc, invalid_name_msg),
                         (*assign_loc, "In this assignment".into()),
                     ]);
@@ -344,7 +346,7 @@ fn parse_failure_attribute(
                     let msg = "Unsupported attribute value for expected failure attribute";
                     context
                         .env
-                        .add_error(vec![(*aloc, msg), (*loc, "In this assignment")]);
+                        .add_error_deprecated(vec![(*aloc, msg), (*loc, "In this assignment")]);
                     None
                 }
             }

--- a/language/move-lang/tests/move_check/naming/friend_decl_unbound_module.exp
+++ b/language/move-lang/tests/move_check/naming/friend_decl_unbound_module.exp
@@ -1,8 +1,6 @@
-error: 
-
-   ┌── tests/move_check/naming/friend_decl_unbound_module.move:3:12 ───
-   │
- 3 │     friend 0x42::Nonexistent;
-   │            ^^^^^^^^^^^^^^^^^ Unbound module '0x42::Nonexistent'
-   │
+error[E02001]: unbound module
+  ┌─ tests/move_check/naming/friend_decl_unbound_module.move:3:12
+  │
+3 │     friend 0x42::Nonexistent;
+  │            ^^^^^^^^^^^^^^^^^ Unbound module '0x42::Nonexistent'
 

--- a/language/move-model/src/lib.rs
+++ b/language/move-model/src/lib.rs
@@ -256,10 +256,11 @@ fn add_move_lang_errors(env: &mut GlobalEnv, errors: Errors) {
         let loc = env.to_loc(&err.0);
         Label::new(loc.file_id(), loc.span(), err.1)
     };
-    for mut error in errors {
-        let primary = error.remove(0);
+    #[allow(deprecated)]
+    for mut labels in errors.into_vec() {
+        let primary = labels.remove(0);
         let diag = Diagnostic::new_error("", mk_label(env, primary))
-            .with_secondary_labels(error.into_iter().map(|e| mk_label(env, e)));
+            .with_secondary_labels(labels.into_iter().map(|e| mk_label(env, e)));
         env.add_diag(diag);
     }
 }

--- a/language/tools/move-unit-test/src/test_reporter.rs
+++ b/language/tools/move-unit-test/src/test_reporter.rs
@@ -238,7 +238,7 @@ impl TestFailure {
                             (function_source_map.decl_location, msg),
                         ])
                     })
-                    .collect::<Vec<_>>();
+                    .collect();
 
                 String::from_utf8(report_error(test_plan.files.clone(), errors)).unwrap()
             }

--- a/x.toml
+++ b/x.toml
@@ -148,7 +148,10 @@ criterion = "criterion is only for benchmarks"
 proptest = "proptest is only for testing and fuzzing"
 
 [workspace.direct-dep-dups]
-allow = []
+allow = [
+    "codespan",
+    "codespan-reporting",
+]
 
 [workspace.overlay]
 features = ["fuzzing"]


### PR DESCRIPTION
- New codespan reporting sorts based on line numbers, not based on which label was added when
- As such, a lot of the error messages new to be reworded
- This begins the migration to the new version

## Motivation

- I'm setting up a new API here for errors so I can easily migrate to the new codespan reporting without having to do all of the migration at once

## Test Plan

- cargo check, new API is not yet in use