### PR TITLE
[read-write-set] Standalone type definition for read-write-set analysis

### DIFF
--- a/language/diem-tools/df-cli/tests/testsuite/concretize_read_write_set_smoke/args.exp
+++ b/language/diem-tools/df-cli/tests/testsuite/concretize_read_write_set_smoke/args.exp
@@ -6,56 +6,58 @@ Command `sandbox run storage/0x00000000000000000000000000000001/modules/Treasury
 Command `sandbox run storage/0x00000000000000000000000000000001/modules/PaymentScripts.mv peer_to_peer_with_metadata --mode diem --type-args 0x1::XUS::XUS --signers 0xDD --args 0xA 700 x"" x""`:
 Command `experimental read-write-set storage/0x00000000000000000000000000000001/modules/PaymentScripts.mv peer_to_peer_with_metadata --mode diem --concretize paths --type-args 0x1::XUS::XUS --signers 0xA --args 0xB 500 x"" x""`:
 0xa/0x1::AccountFreezing::FreezingBit: Read
-0xa/0x1::AccountFreezing::FreezingBit/is_frozen: Read
-0xa/0x1::VASP::ParentVASP: Read
-0xa/0x1::DiemAccount::DiemAccount: Read
-0xa/0x1::DiemAccount::DiemAccount/withdraw_capability: Read
-0xa/0x1::DiemAccount::DiemAccount/withdraw_capability/vec: Read
-0xa/0x1::DiemAccount::DiemAccount/withdraw_capability/vec/[_]: ReadWrite
-0xa/0x1::DiemAccount::DiemAccount/withdraw_capability/vec/[_]/account_address: Read
-0xa/0x1::DiemAccount::DiemAccount/sent_events: Read
-0xa/0x1::DiemAccount::DiemAccount/sent_events/counter: ReadWrite
-0xa/0x1::DiemAccount::DiemAccount/sent_events/guid: Read
+0xa/0x1::AccountFreezing::FreezingBit/0: Read
 0xa/0x1::DiemAccount::Balance<0x1::XUS::XUS>: Read
-0xa/0x1::DiemAccount::Balance<0x1::XUS::XUS>/coin: Read
-0xa/0x1::DiemAccount::Balance<0x1::XUS::XUS>/coin/value: ReadWrite
+0xa/0x1::DiemAccount::Balance<0x1::XUS::XUS>/0: Read
+0xa/0x1::DiemAccount::Balance<0x1::XUS::XUS>/0/0: ReadWrite
+0xa/0x1::DiemAccount::DiemAccount: Read
+0xa/0x1::DiemAccount::DiemAccount/1: Read
+0xa/0x1::DiemAccount::DiemAccount/1/0: Read
+0xa/0x1::DiemAccount::DiemAccount/1/0/[_]: ReadWrite
+0xa/0x1::DiemAccount::DiemAccount/1/0/[_]/0: Read
+0xa/0x1::DiemAccount::DiemAccount/4: Read
+0xa/0x1::DiemAccount::DiemAccount/4/0: ReadWrite
+0xa/0x1::DiemAccount::DiemAccount/4/1: Read
+0xa/0x1::VASP::ParentVASP: Read
 0xb/0x1::AccountFreezing::FreezingBit: Read
-0xb/0x1::AccountFreezing::FreezingBit/is_frozen: Read
-0xb/0x1::VASP::ParentVASP: Read
-0xb/0x1::DualAttestation::Credential: Read
-0xb/0x1::DualAttestation::Credential/base_url: Read
-0xb/0x1::DualAttestation::Credential/compliance_public_key: Read
-0xb/0x1::DiemAccount::DiemAccount: Read
-0xb/0x1::DiemAccount::DiemAccount/received_events: Read
-0xb/0x1::DiemAccount::DiemAccount/received_events/counter: ReadWrite
-0xb/0x1::DiemAccount::DiemAccount/received_events/guid: Read
+0xb/0x1::AccountFreezing::FreezingBit/0: Read
 0xb/0x1::DiemAccount::Balance<0x1::XUS::XUS>: Read
-0xb/0x1::DiemAccount::Balance<0x1::XUS::XUS>/coin: Read
-0xb/0x1::DiemAccount::Balance<0x1::XUS::XUS>/coin/value: ReadWrite
-0xa550c18/0x1::DiemTimestamp::CurrentTimeMicroseconds: Read
-0xa550c18/0x1::DiemTimestamp::CurrentTimeMicroseconds/microseconds: Read
+0xb/0x1::DiemAccount::Balance<0x1::XUS::XUS>/0: Read
+0xb/0x1::DiemAccount::Balance<0x1::XUS::XUS>/0/0: ReadWrite
+0xb/0x1::DiemAccount::DiemAccount: Read
+0xb/0x1::DiemAccount::DiemAccount/3: Read
+0xb/0x1::DiemAccount::DiemAccount/3/0: ReadWrite
+0xb/0x1::DiemAccount::DiemAccount/3/1: Read
+0xb/0x1::DualAttestation::Credential: Read
+0xb/0x1::DualAttestation::Credential/1: Read
+0xb/0x1::DualAttestation::Credential/2: Read
+0xb/0x1::VASP::ParentVASP: Read
 0xa550c18/0x1::Diem::CurrencyInfo<0x1::XUS::XUS>: Read
-0xa550c18/0x1::Diem::CurrencyInfo<0x1::XUS::XUS>/to_xdx_exchange_rate: Read
-0xa550c18/0x1::Diem::CurrencyInfo<0x1::XUS::XUS>/to_xdx_exchange_rate/value: Read
-0xa550c18/0x1::Diem::CurrencyInfo<0x1::XUS::XUS>/currency_code: Read
+0xa550c18/0x1::Diem::CurrencyInfo<0x1::XUS::XUS>/2: Read
+0xa550c18/0x1::Diem::CurrencyInfo<0x1::XUS::XUS>/2/0: Read
+0xa550c18/0x1::Diem::CurrencyInfo<0x1::XUS::XUS>/6: Read
+0xa550c18/0x1::DiemTimestamp::CurrentTimeMicroseconds: Read
+0xa550c18/0x1::DiemTimestamp::CurrentTimeMicroseconds/0: Read
 0xa550c18/0x1::DualAttestation::Limit: Read
-0xa550c18/0x1::DualAttestation::Limit/micro_xdx_limit: Read
+0xa550c18/0x1::DualAttestation::Limit/0: Read
+
+
 
 Command `experimental read-write-set storage/0x00000000000000000000000000000001/modules/PaymentScripts.mv peer_to_peer_with_metadata --mode diem --concretize reads --type-args 0x1::XUS::XUS --signers 0xA --args 0xB 500 x"" x""`:
 0xa/0x1::AccountFreezing::FreezingBit
-0xa/0x1::VASP::ParentVASP
-0xa/0x1::DiemAccount::DiemAccount
 0xa/0x1::DiemAccount::Balance<0x1::XUS::XUS>
+0xa/0x1::DiemAccount::DiemAccount
+0xa/0x1::VASP::ParentVASP
 0xb/0x1::AccountFreezing::FreezingBit
-0xb/0x1::VASP::ParentVASP
-0xb/0x1::DualAttestation::Credential
-0xb/0x1::DiemAccount::DiemAccount
 0xb/0x1::DiemAccount::Balance<0x1::XUS::XUS>
-0xa550c18/0x1::DiemTimestamp::CurrentTimeMicroseconds
+0xb/0x1::DiemAccount::DiemAccount
+0xb/0x1::DualAttestation::Credential
+0xb/0x1::VASP::ParentVASP
 0xa550c18/0x1::Diem::CurrencyInfo<0x1::XUS::XUS>
+0xa550c18/0x1::DiemTimestamp::CurrentTimeMicroseconds
 0xa550c18/0x1::DualAttestation::Limit
 Command `experimental read-write-set storage/0x00000000000000000000000000000001/modules/PaymentScripts.mv peer_to_peer_with_metadata --mode diem --concretize writes --type-args 0x1::XUS::XUS --signers 0xA --args 0xB 500 x"" x""`:
-0xa/0x1::DiemAccount::DiemAccount
 0xa/0x1::DiemAccount::Balance<0x1::XUS::XUS>
-0xb/0x1::DiemAccount::DiemAccount
+0xa/0x1::DiemAccount::DiemAccount
 0xb/0x1::DiemAccount::Balance<0x1::XUS::XUS>
+0xb/0x1::DiemAccount::DiemAccount

--- a/language/move-prover/bytecode/src/read_write_set_analysis.rs
+++ b/language/move-prover/bytecode/src/read_write_set_analysis.rs
@@ -28,6 +28,7 @@ use move_model::{
 };
 use read_write_set_types::{
     Access, AccessPath as RWAccessPath, Offset as RWOffset, ReadWriteSet, Root as RWRoot,
+    RootAddress as RWRootAddress,
 };
 use std::{fmt, fmt::Formatter};
 
@@ -833,7 +834,6 @@ impl Offset {
 }
 
 impl AccessPath {
-    // `normalize` will return None when there's a malformed access path.
     pub fn normalize(&self, env: &GlobalEnv) -> Vec<RWAccessPath> {
         let mut normalized_offset = self
             .offsets()
@@ -841,24 +841,35 @@ impl AccessPath {
             .map(|offset| offset.normalize(env))
             .collect::<Vec<_>>();
 
-        let (roots, offsets) = match self.root() {
-            Root::Formal(idx) => (vec![RWRoot::Formal(*idx)], normalized_offset),
+        let roots = match self.root() {
+            Root::Formal(idx) => {
+                if normalized_offset.is_empty() {
+                    return vec![];
+                }
+                let access_type = if let RWOffset::Global(ty) = normalized_offset.remove(0) {
+                    ty
+                } else {
+                    return vec![];
+                };
+                vec![RWRoot {
+                    root: RWRootAddress::Formal(*idx),
+                    type_: access_type,
+                }]
+            }
             Root::Global(key) => {
-                let first_offset = RWOffset::Global(
-                    key.struct_type()
-                        .get_type()
-                        .into_struct_type(env)
-                        .expect("None struct type found in global key"),
-                );
-                normalized_offset.insert(0, first_offset);
-                (
-                    key.address()
-                        .get_concrete_addresses()
-                        .into_iter()
-                        .map(RWRoot::Const)
-                        .collect(),
-                    normalized_offset,
-                )
+                let access_type = key
+                    .struct_type()
+                    .get_type()
+                    .into_struct_type(env)
+                    .expect("None struct type found in global key");
+                key.address()
+                    .get_concrete_addresses()
+                    .into_iter()
+                    .map(|addr| RWRoot {
+                        root: RWRootAddress::Const(addr),
+                        type_: access_type.clone(),
+                    })
+                    .collect()
             }
             Root::Local(_) | Root::Return(_) => panic!("Malformed root"),
         };
@@ -867,7 +878,7 @@ impl AccessPath {
             .into_iter()
             .map(|root| RWAccessPath {
                 root,
-                offsets: offsets.clone(),
+                offsets: normalized_offset.clone(),
             })
             .collect()
     }

--- a/language/tools/move-cli/src/experimental/commands/read_writeset_analysis.rs
+++ b/language/tools/move-cli/src/experimental/commands/read_writeset_analysis.rs
@@ -40,63 +40,67 @@ pub fn analyze_read_write_set(
     }
     let modules = dep_graph.compute_topological_order()?;
     let rw = read_write_set::analyze(modules)?;
-    if let Some(fenv) = rw.get_function_env(&module_id, &fun_id) {
-        let signer_addresses = signers
-            .iter()
-            .map(|s| AccountAddress::from_hex_literal(s))
-            .collect::<Result<Vec<AccountAddress>, _>>()?;
-        // TODO: parse Value's directly instead of going through the indirection of TransactionArgument?
-        let script_args: Vec<Vec<u8>> = convert_txn_args(txn_args);
-        // substitute given script arguments + blockchain state into abstract r/w set
-        match concretize {
-            ConcretizeMode::Paths => {
-                let results = rw.get_concretized_summary(
-                    &module_id,
-                    &fun_id,
-                    &signer_addresses,
-                    &script_args,
-                    type_args,
-                    state,
-                )?;
-                println!("{}", results.display(&fenv))
-            }
-            ConcretizeMode::Reads => {
-                let results = rw.get_keys_read(
-                    &module_id,
-                    &fun_id,
-                    &signer_addresses,
-                    &script_args,
-                    type_args,
-                    state,
-                )?;
-                for key in results {
-                    println!("{}", key)
-                }
-            }
-            ConcretizeMode::Writes => {
-                let results = rw.get_keys_written(
-                    &module_id,
-                    &fun_id,
-                    &signer_addresses,
-                    &script_args,
-                    type_args,
-                    state,
-                )?;
-                for key in results {
-                    println!("{}", key)
-                }
-            }
-            ConcretizeMode::Dont => {
-                // don't try try to concretize; just print the R/W set
-                // safe to unwrap here because every function must be analyzed
-                let results = rw.get_summary(&module_id, &fun_id).expect(
-                    "Invariant violation: couldn't resolve R/W set summary for defined function",
-                );
-                println!("{}", results.display(&fenv))
+    let normalized_rw = rw.normalize_all_scripts(vec![]);
+
+    let signer_addresses = signers
+        .iter()
+        .map(|s| AccountAddress::from_hex_literal(s))
+        .collect::<Result<Vec<AccountAddress>, _>>()?;
+    // TODO: parse Value's directly instead of going through the indirection of TransactionArgument?
+    let script_args: Vec<Vec<u8>> = convert_txn_args(txn_args);
+    // substitute given script arguments + blockchain state into abstract r/w set
+    match concretize {
+        ConcretizeMode::Paths => {
+            let results = normalized_rw.get_concretized_summary(
+                &module_id,
+                &fun_id,
+                &signer_addresses,
+                &script_args,
+                type_args,
+                state,
+            )?;
+            println!("{}", results)
+        }
+        ConcretizeMode::Reads => {
+            let results = normalized_rw.get_keys_read(
+                &module_id,
+                &fun_id,
+                &signer_addresses,
+                &script_args,
+                type_args,
+                state,
+            )?;
+            for key in results {
+                println!("{}", key)
             }
         }
-    } else {
-        println!("Function {} not found in {:?}", function, module_file)
+        ConcretizeMode::Writes => {
+            let results = normalized_rw.get_keys_written(
+                &module_id,
+                &fun_id,
+                &signer_addresses,
+                &script_args,
+                type_args,
+                state,
+            )?;
+            for key in results {
+                println!("{}", key)
+            }
+        }
+        ConcretizeMode::Dont => {
+            // don't try try to concretize; just print the R/W set
+            // safe to unwrap here because every function must be analyzed
+            let results = rw.get_summary(&module_id, &fun_id).expect(
+                "Invariant violation: couldn't resolve R/W set summary for defined function",
+            );
+            println!(
+                "{}",
+                results.display(
+                    &rw.get_function_env(&module_id, &fun_id)
+                        .expect("Invariant violation: couldn't find the env for defined function")
+                )
+            )
+        }
     }
     Ok(())
 }

--- a/language/tools/move-cli/tests/testsuite/concretize_read_write_set/args.exp
+++ b/language/tools/move-cli/tests/testsuite/concretize_read_write_set/args.exp
@@ -10,18 +10,26 @@ Ret(0): Formal(0)/0x1::ConcretizeSecondaryIndexes::Addr/a/0x1::ConcretizeSeconda
 
 Command `experimental read-write-set storage/0x00000000000000000000000000000001/modules/ConcretizeSecondaryIndexes.mv read_indirect --concretize paths --args 0xA`:
 
+
+
 Command `sandbox run storage/0x00000000000000000000000000000001/modules/ConcretizeSecondaryIndexes.mv publish_addr --signers 0xA --args 0xB`:
 Command `experimental read-write-set storage/0x00000000000000000000000000000001/modules/ConcretizeSecondaryIndexes.mv read_indirect --concretize paths --args 0xA`:
-0xa/0x1::ConcretizeSecondaryIndexes::Addr/a: Read
+0xa/0x1::ConcretizeSecondaryIndexes::Addr/0: Read
+
+
 
 Command `sandbox run storage/0x00000000000000000000000000000001/modules/ConcretizeSecondaryIndexes.mv publish --signers 0xB`:
 Command `experimental read-write-set storage/0x00000000000000000000000000000001/modules/ConcretizeSecondaryIndexes.mv read_indirect --concretize paths --args 0xA`:
-0xa/0x1::ConcretizeSecondaryIndexes::Addr/a: Read
-0xb/0x1::ConcretizeSecondaryIndexes::S/f: Read
+0xa/0x1::ConcretizeSecondaryIndexes::Addr/0: Read
+0xb/0x1::ConcretizeSecondaryIndexes::S/0: Read
+
+
 
 Command `experimental read-write-set storage/0x00000000000000000000000000000001/modules/ConcretizeSecondaryIndexes.mv multi_arg --concretize paths --signers 0x1 --args 0xA 2`:
-0xa/0x1::ConcretizeSecondaryIndexes::Addr/a: Read
-0xb/0x1::ConcretizeSecondaryIndexes::S/f: Read
+0xa/0x1::ConcretizeSecondaryIndexes::Addr/0: Read
+0xb/0x1::ConcretizeSecondaryIndexes::S/0: Read
+
+
 
 Command `experimental read-write-set storage/0x00000000000000000000000000000001/modules/ConcretizeVector.mv read_vec`:
 Accesses:
@@ -35,16 +43,22 @@ Ret(0): Formal(0)/0x1::ConcretizeVector::S/v/[_]/0x1::ConcretizeVector::T/f
 
 Command `experimental read-write-set storage/0x00000000000000000000000000000001/modules/ConcretizeVector.mv read_vec --concretize paths --args 0x1`:
 
+
+
 Command `sandbox run storage/0x00000000000000000000000000000001/modules/ConcretizeVector.mv publish --signers 0x1 0x2`:
 Command `experimental read-write-set storage/0x00000000000000000000000000000001/modules/ConcretizeVector.mv read_vec --concretize paths --args 0x1`:
-0x1/0x1::ConcretizeVector::S/v: Read
-0x1/0x1::ConcretizeVector::S/v/[_]: Read
-0x1/0x1::ConcretizeVector::T/f: Read
-0x2/0x1::ConcretizeVector::T/f: Read
+0x1/0x1::ConcretizeVector::S/0: Read
+0x1/0x1::ConcretizeVector::S/0/[_]: Read
+0x1/0x1::ConcretizeVector::T/0: Read
+0x2/0x1::ConcretizeVector::T/0: Read
+
+
 
 Command `experimental read-write-set storage/0x00000000000000000000000000000001/modules/ConcretizeVector.mv write_vec --concretize paths --args 0x1 2`:
-0x1/0x1::ConcretizeVector::S/v: Read
-0x1/0x1::ConcretizeVector::S/v/[_]: Read
-0x1/0x1::ConcretizeVector::T/f: Write
-0x2/0x1::ConcretizeVector::T/f: Write
+0x1/0x1::ConcretizeVector::S/0: Read
+0x1/0x1::ConcretizeVector::S/0/[_]: Read
+0x1/0x1::ConcretizeVector::T/0: Write
+0x2/0x1::ConcretizeVector::T/0: Write
+
+
 

--- a/language/tools/read-write-set/src/dynamic_analysis.rs
+++ b/language/tools/read-write-set/src/dynamic_analysis.rs
@@ -1,122 +1,78 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
+use anyhow::{anyhow, bail, Result};
+use move_binary_format::{
+    layout::{ModuleCache, TypeLayoutBuilder},
+    normalized::{Module, Type},
+    CompiledModule,
+};
 use move_core_types::{
     account_address::AccountAddress,
-    language_storage::{ResourceKey, TypeTag},
+    identifier::IdentStr,
+    language_storage::{ModuleId, ResourceKey, TypeTag},
     resolver::MoveResolver,
+    value::MoveValue,
 };
-use move_model::{
-    model::{FunctionEnv, GlobalEnv},
-    ty::Type,
+use read_write_set_types::{Access, AccessPath, Offset, ReadWriteSet, RootAddress};
+use std::{
+    fmt::{self, Formatter},
+    ops::Deref,
 };
-use prover_bytecode::{
-    access_path::{AbsAddr, AccessPath, Offset, Root},
-    access_path_trie::AccessPathTrie,
-    read_write_set_analysis::ReadWriteSetState,
-};
-use read_write_set_types::Access;
-use resource_viewer::{AnnotatedMoveValue, MoveValueAnnotator};
-use std::ops::Deref;
 
 /// A read/write set state with no unbound formals or type variables
 #[derive(Debug)]
-pub struct ConcretizedFormals(AccessPathTrie<Access>);
+pub struct ConcretizedFormals(ReadWriteSet);
 
 /// A read/write set state with no secondary indexes and no unbound formals or type variables
 #[derive(Debug)]
 pub struct ConcretizedSecondaryIndexes(ConcretizedFormals);
 
 impl ConcretizedFormals {
-    /// Return the `ResourceKey`'s that may be accessed by `self`. If `is_write` is true, return the
-    /// keys that may be written; otherwise, return the keys that may be read.
+    /// Return the `ResourceKey`'s that may be written by `self`.
     /// For example: if `self` is 0x7/0x1::AModule::AResource/f/g -> ReadWrite, this will return
     /// 0x7/0x1::AModule.
-    pub fn get_keys_(&self, is_write: bool, env: &GlobalEnv) -> Vec<ResourceKey> {
-        self.0
-            .iter()
-            .flat_map(|(r, node)| {
-                let keep = node.get_child_data().map_or(false, |d| {
-                    if is_write {
-                        d.is_write()
-                    } else {
-                        d.is_read()
-                    }
-                });
-                if keep {
-                    match r {
-                        Root::Global(g) => {
-                            let type_ = g.struct_type().normalize(env).expect(
-                                "Getting type tag should never fail for ConcretizedFormals",
-                            );
-                            g.address()
-                                .get_concrete_addresses()
-                                .iter()
-                                .map(|a| ResourceKey::new(*a, type_.clone()))
-                                .collect()
-                        }
-                        _ => panic!("Unexpected root type {:?} for ConcretizedFormals", r),
-                    }
-                } else {
-                    vec![]
-                }
-            })
-            .collect()
-    }
-
-    /// Return the `ResourceKey`'s written by `self`.
-    pub fn get_keys_written(&self, env: &GlobalEnv) -> Vec<ResourceKey> {
-        self.get_keys_(true, env)
+    pub fn get_keys_written(&self) -> Option<Vec<ResourceKey>> {
+        self.0.get_keys_written()
     }
 
     /// Return the `ResourceKey`'s read by `self`.
-    pub fn get_keys_read(&self, env: &GlobalEnv) -> Vec<ResourceKey> {
-        self.get_keys_(false, env)
+    pub fn get_keys_read(&self) -> Option<Vec<ResourceKey>> {
+        self.0.get_keys_read()
     }
 
     /// Concretize all secondary indexes in `self` using `blockchain_view` and return the result. For
     /// example: if `self` is 0x7/0x1::AModule::AResource/addr_field/0x2::M2::R/f -> Write and the
     /// value of 0x7/0x1::AModule::AResource/addr_field is 0xA in `blockchain_view`, this will
     /// return { 0x7/0x1::AModule::AResource/addr_field -> Read, 0xA/0x2::M2::R/f -> Write }
-    fn concretize_secondary_indexes(
+    fn concretize_secondary_indexes<R: MoveResolver>(
         self,
-        blockchain_view: &impl MoveResolver,
-        env: &GlobalEnv,
-    ) -> ConcretizedSecondaryIndexes {
+        blockchain_view: &R,
+    ) -> Option<ConcretizedSecondaryIndexes> {
         // TODO: check if there are no secondary indexes and return accesses if so
-        let annotator = MoveValueAnnotator::new(blockchain_view);
-        let mut acc = AccessPathTrie::default();
-        // TODO: do not unwrap here. iter_paths doesn't support Result, so need to create an Iter instead
-        // of iter_paths or return a bool inside resolve_secondary instead of using ?
+        let mut acc = ReadWriteSet::new();
+        let module_cache = ModuleCache::new(blockchain_view);
         self.0.iter_paths(|access_path, access| {
-            Self::concretize_secondary_indexes_(&annotator, access_path, access, env, &mut acc)
-                .unwrap();
-        });
-        ConcretizedSecondaryIndexes(ConcretizedFormals(acc))
+            Self::concretize_secondary_indexes_(
+                &module_cache,
+                blockchain_view,
+                access_path,
+                access,
+                &mut acc,
+            )
+            .ok()
+        })?;
+        Some(ConcretizedSecondaryIndexes(ConcretizedFormals(acc)))
     }
 
     /// Construct a `ConcretizedFormals` from `accesses` by binding the formals and type variables in
     /// `accesses` to `actuals` and `type_actuals`.
     fn from_args_(
-        accesses: AccessPathTrie<Access>,
-        actuals: &[AbsAddr],
-        type_actuals: &[Type],
-        fun_env: &FunctionEnv,
+        read_write_set: &ReadWriteSet,
+        actuals: &[Option<AccountAddress>],
+        type_actuals: &[TypeTag],
     ) -> ConcretizedFormals {
-        let mut sub_map = AccessPathTrie::default();
-        let mut actual_indices = vec![];
-        for (i, actual) in actuals.iter().enumerate() {
-            sub_map.bind_local(i, actual.clone(), fun_env);
-            actual_indices.push(i);
-        }
-        ConcretizedFormals(ReadWriteSetState::sub_actuals(
-            accesses,
-            &actual_indices,
-            type_actuals,
-            fun_env,
-            &sub_map,
-        ))
+        ConcretizedFormals(read_write_set.sub_actuals(actuals, type_actuals))
     }
 
     /// Construct a `ConcretizedFormals` from `accesses` by binding the formals and type variables in
@@ -124,90 +80,80 @@ impl ConcretizedFormals {
     /// For example: if `accesses` is Formal(0)/0x1::M::S<TypeVar(0)>/f -> Read, `signers` is 0xA
     /// and type_actuals is 0x2::M2::S2, this will return  0xA/0x1::M::S<0x2::M2::S@>/f -> Read
     pub fn from_args(
-        accesses: AccessPathTrie<Access>,
+        read_write_set: &ReadWriteSet,
         signers: &[AccountAddress],
         actuals: &[Vec<u8>],
+        formal_types: &[TypeTag],
         type_actuals: &[TypeTag],
-        fun_env: &FunctionEnv,
     ) -> Result<ConcretizedFormals> {
-        let mut new_actuals = signers.iter().map(AbsAddr::from).collect::<Vec<AbsAddr>>();
-        let formal_types = fun_env.get_parameter_types();
+        let mut new_actuals = signers
+            .iter()
+            .map(|addr| Some(*addr))
+            .collect::<Vec<Option<_>>>();
         assert_eq!(
             formal_types.len(),
             actuals.len() + signers.len(),
             "Formal/actual arity mismatch"
         );
-        assert_eq!(
-            fun_env.get_type_parameter_count(),
-            type_actuals.len(),
-            "Type formal/type actual arity mismatch"
-        );
-        // The analysis abstracts addresses. Deserialize the address actuals, use an empty AbsAddr for
-        // the rest
+        // Deserialize the address actuals, use an None for the rest
         let num_signers = signers.len();
         // formal_types includes all formal types (including signers), but actuals is only
         // the non-signer actuals.
         for (actual_index, ty) in formal_types[num_signers..].iter().enumerate() {
-            let actual = if ty.is_address() {
-                AbsAddr::from(&AccountAddress::from_bytes(&actuals[actual_index])?)
+            let actual = if let TypeTag::Address = ty {
+                Some(AccountAddress::from_bytes(&actuals[actual_index])?)
             } else {
-                AbsAddr::default()
+                None
             };
             new_actuals.push(actual);
         }
-
-        let env = fun_env.module_env.env;
-        let new_type_actuals = type_actuals
-            .iter()
-            .map(|t| Type::from_type_tag(t, env))
-            .collect::<Vec<Type>>();
         Ok(Self::from_args_(
-            accesses,
-            &new_actuals,
-            &new_type_actuals,
-            fun_env,
+            read_write_set,
+            new_actuals.as_slice(),
+            type_actuals,
         ))
     }
 
     /// Concretize the secondary in `offsets` -> `access` using `annotator` and add the results to
     /// `acc`.
-    fn concretize_offsets<T: MoveResolver>(
-        annotator: &MoveValueAnnotator<T>,
+    fn concretize_offsets<R: MoveResolver>(
+        module_cache: &ModuleCache<&R>,
+        blockchain_view: &R,
         access_path: AccessPath,
-        mut next_value: AnnotatedMoveValue,
+        mut next_value: MoveValue,
         next_offset_index: usize,
         access: &Access,
-        env: &GlobalEnv,
-        acc: &mut AccessPathTrie<Access>,
+        acc: &mut ReadWriteSet,
     ) -> Result<()> {
-        let offsets = access_path.offsets();
+        let offsets = access_path.offset();
         for next_offset_index in next_offset_index..offsets.len() {
             let next_offset = &offsets[next_offset_index];
             match next_offset {
                 Offset::Field(index) => {
-                    if let AnnotatedMoveValue::Struct(s) = next_value {
-                        let fields = s.value;
-                        next_value = fields[*index].1.clone();
+                    if let MoveValue::Struct(s) = next_value {
+                        let fields = s.fields();
+                        next_value = fields[*index].clone();
                     } else {
-                        panic!("Malformed access path {:?}; expected struct value as prefix to field offset {:?}, but got {:?}",
+                        bail!("Malformed access path {:?}; expected struct value as prefix to field offset {:?}, but got {:?}",
                                access_path, next_offset, next_value)
                     }
                 }
                 Offset::Global(g_offset) => {
                     // secondary index. previous offset should have been an address value
-                    if let AnnotatedMoveValue::Address(a) = next_value {
-                        let mut new_ap = AccessPath::new_global_constant(
-                            move_model::addr_to_big_uint(&a),
-                            g_offset.clone(),
-                        );
+                    if let MoveValue::Address(a) = next_value {
+                        let mut new_ap = AccessPath::new_global_constant(a, g_offset.clone());
                         for o in offsets[next_offset_index + 1..].iter() {
                             new_ap.add_offset(o.clone())
                         }
                         return Self::concretize_secondary_indexes_(
-                            annotator, &new_ap, access, env, acc,
+                            module_cache,
+                            blockchain_view,
+                            &new_ap,
+                            access,
+                            acc,
                         );
                     } else {
-                        panic!(
+                        bail!(
                             "Malformed access path {:?}: expected address value before Global offset, but found {:?}",
                             access_path,
                             next_value
@@ -215,22 +161,22 @@ impl ConcretizedFormals {
                     }
                 }
                 Offset::VectorIndex => {
-                    if let AnnotatedMoveValue::Vector(_v_type, v_contents) = &next_value {
+                    if let MoveValue::Vector(v_contents) = &next_value {
                         // concretize offsets for each element in the vector
                         for val in v_contents {
                             Self::concretize_offsets(
-                                annotator,
+                                module_cache,
+                                blockchain_view,
                                 access_path.clone(),
                                 val.clone(),
                                 next_offset_index + 1,
                                 access,
-                                env,
                                 acc,
                             )?;
                         }
                         return Ok(());
                     } else {
-                        panic!(
+                        bail!(
                             "Malformed access path {:?}: expected vector value before VectorIndex offset, but found {:?}",
                             access_path,
                             next_value
@@ -239,61 +185,53 @@ impl ConcretizedFormals {
                 }
             }
         }
-        assert!(
-            access_path.all_addresses_types_bound(),
-            "Failed to concretize secondary indexes in ap {:?}",
-            access_path
-        );
         // Got to the end of the concrete access path. Add it to the accumulator
-        acc.update_access_path_weak(access_path, Some(*access));
+        acc.add_access_path(access_path, *access);
 
         Ok(())
     }
 
     /// Concretize the secondary indexes in `access_path` and add the result to `acc`. For example
-    fn concretize_secondary_indexes_<T: MoveResolver>(
-        annotator: &MoveValueAnnotator<T>,
+    fn concretize_secondary_indexes_<R: MoveResolver>(
+        module_cache: &ModuleCache<&R>,
+        blockchain_view: &R,
         access_path: &AccessPath,
         access: &Access,
-        env: &GlobalEnv,
-        acc: &mut AccessPathTrie<Access>,
+        acc: &mut ReadWriteSet,
     ) -> Result<()> {
-        if let Root::Global(g) = access_path.root() {
-            assert!(
-                g.is_statically_known(),
-                "Attempting to extract concrete addresses from unknown global {:?}",
-                g
-            );
-            let addrs = g.address().get_concrete_addresses();
-            assert!(!addrs.is_empty()); // TODO: enforce this in AbsAddr constructor instead
-            let tag = g.struct_type().get_type_tag(env).unwrap(); // safe because we checked g.is_statically_known
-            for addr in &addrs {
-                if let Some(resource_bytes) = annotator.get_resource_bytes(addr, &tag) {
-                    let mut ap = AccessPath::new_global_constant(
-                        move_model::addr_to_big_uint(addr),
-                        g.struct_type().clone(),
-                    );
-                    for o in access_path.offsets() {
-                        ap.add_offset(o.clone())
-                    }
-                    let resource = annotator.view_resource(&tag, &resource_bytes)?;
-                    Self::concretize_offsets(
-                        annotator,
-                        ap,
-                        AnnotatedMoveValue::Struct(resource),
-                        0,
-                        access,
-                        env,
-                        acc,
-                    )?;
-                } // else, resource not present. this can happen/is expected because the R/W set is overapproximate
-            }
-        } else {
-            panic!(
-                "Malformed access path {:?}: Bad root type {:?}. This root cannot be concretized by reading global state",
-                access_path,
-                access_path.root()
-            )
+        if let RootAddress::Const(g) = &access_path.root.root {
+            let tag = access_path
+                .root
+                .type_
+                .clone()
+                .into_struct_tag()
+                .ok_or_else(|| {
+                    anyhow!("Unbound type variable found: {:?}", access_path.root.type_)
+                })?;
+            if let Some(resource_bytes) = blockchain_view
+                .get_resource(g, &tag)
+                .map_err(|_| anyhow!("Failed to get resource for {:?}::{:?}", g, tag))?
+            {
+                let layout = TypeLayoutBuilder::build_runtime(&TypeTag::Struct(tag), module_cache)
+                    .map_err(|_| anyhow!("Failed to resolve type: {:?}", access_path.root.type_))?;
+
+                let resource =
+                    MoveValue::simple_deserialize(&resource_bytes, &layout).map_err(|_| {
+                        anyhow!(
+                            "Failed to deserialize move value of type: {:?}",
+                            access_path.root.type_
+                        )
+                    })?;
+                Self::concretize_offsets(
+                    module_cache,
+                    blockchain_view,
+                    access_path.clone(),
+                    resource,
+                    0,
+                    access,
+                    acc,
+                )?;
+            } // else, resource not present. this can happen/is expected because the R/W set is overapproximate
         }
         Ok(())
     }
@@ -303,20 +241,51 @@ impl ConcretizedFormals {
 /// `type_actuals`. In addition, concretize all secondary indexes in `accesses` against the state in
 /// `blockchain_view`.
 pub fn concretize(
-    accesses: AccessPathTrie<Access>,
+    accesses: &ReadWriteSet,
+    module: &ModuleId,
+    fun: &IdentStr,
     signers: &[AccountAddress],
     actuals: &[Vec<u8>],
     type_actuals: &[TypeTag],
-    fun_env: &FunctionEnv,
     blockchain_view: &impl MoveResolver,
 ) -> Result<ConcretizedSecondaryIndexes> {
-    let concretized_formals =
-        ConcretizedFormals::from_args(accesses, signers, actuals, type_actuals, fun_env)?;
-    Ok(concretized_formals.concretize_secondary_indexes(blockchain_view, fun_env.module_env.env))
+    let subst_map = type_actuals
+        .iter()
+        .map(|ty| Type::from(ty.clone()))
+        .collect::<Vec<_>>();
+
+    let compiled_module = CompiledModule::deserialize(
+        &blockchain_view
+            .get_module(module)
+            .map_err(|_| anyhow!("Failed to get module from storage"))?
+            .ok_or_else(|| anyhow!("Failed to get module"))?,
+    )
+    .map_err(|_| anyhow!("Failed to deserialize module"))?;
+
+    let module = Module::new(&compiled_module);
+    let func_type = module
+        .exposed_functions
+        .get(fun)
+        .ok_or_else(|| anyhow!("Failed to find function"))?
+        .parameters
+        .iter()
+        .map(|ty| ty.subst(&subst_map).into_type_tag())
+        .collect::<Option<Vec<_>>>()
+        .ok_or_else(|| anyhow!("Failed to substitute types"))?;
+    let concretized_formals = ConcretizedFormals::from_args(
+        accesses,
+        signers,
+        actuals,
+        func_type.as_slice(),
+        type_actuals,
+    )?;
+    concretized_formals
+        .concretize_secondary_indexes(blockchain_view)
+        .ok_or_else(|| anyhow!("Failed to concretize secondary index"))
 }
 
 impl Deref for ConcretizedFormals {
-    type Target = AccessPathTrie<Access>;
+    type Target = ReadWriteSet;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -328,5 +297,17 @@ impl Deref for ConcretizedSecondaryIndexes {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl fmt::Display for ConcretizedFormals {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        writeln!(f, "{}", self.0)
+    }
+}
+
+impl fmt::Display for ConcretizedSecondaryIndexes {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        writeln!(f, "{}", self.0)
     }
 }

--- a/language/tools/read-write-set/src/lib.rs
+++ b/language/tools/read-write-set/src/lib.rs
@@ -2,23 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod dynamic_analysis;
+pub mod normalize;
 
-use crate::dynamic_analysis::ConcretizedSecondaryIndexes;
-use anyhow::{bail, Result};
+use crate::normalize::NormalizedReadWriteSetAnalysis;
+use anyhow::Result;
 use move_binary_format::file_format::CompiledModule;
 use move_bytecode_utils::Modules;
 use move_core_types::{
-    account_address::AccountAddress,
-    identifier::IdentStr,
-    language_storage::{ModuleId, ResourceKey, TypeTag},
-    resolver::MoveResolver,
+    identifier::{IdentStr, Identifier},
+    language_storage::ModuleId,
 };
 use move_model::model::{FunctionEnv, GlobalEnv};
 use prover_bytecode::{
-    access_path::Offset,
     function_target_pipeline::{FunctionTargetPipeline, FunctionTargetsHolder, FunctionVariant},
     read_write_set_analysis::{ReadWriteSetProcessor, ReadWriteSetState},
 };
+use read_write_set_types::ReadWriteSet;
+use std::collections::BTreeMap;
 
 pub struct ReadWriteSetAnalysis {
     targets: FunctionTargetsHolder,
@@ -71,136 +71,40 @@ impl ReadWriteSetAnalysis {
             .flatten()
     }
 
-    fn get_summary_(&self, module: &ModuleId, fun: &IdentStr) -> Result<&ReadWriteSetState> {
-        if let Some(state) = self.get_summary(module, fun) {
-            Ok(state)
-        } else {
-            bail!("Couldn't resolve function {:?}::{:?}", module, fun)
-        }
-    }
-
-    /// Returns an overapproximation of the access paths in global storage that will be read/written
-    /// by `module::fun` if called with arguments `signers`, `actuals`, `type_actuals` in state
-    /// `blockchain_view`.
-    pub fn get_concretized_summary(
-        &self,
-        module: &ModuleId,
-        fun: &IdentStr,
-        signers: &[AccountAddress],
-        actuals: &[Vec<u8>],
-        type_actuals: &[TypeTag],
-        blockchain_view: &impl MoveResolver,
-    ) -> Result<ConcretizedSecondaryIndexes> {
-        let state = self.get_summary_(module, fun)?;
-        dynamic_analysis::concretize(
-            state.accesses().clone(),
-            signers,
-            actuals,
-            type_actuals,
-            &self.get_function_env(module, fun).unwrap(),
-            blockchain_view,
-        )
-    }
-
-    /// Return `true` if `module`::`fun` may read an address from the blockchain state and
-    /// subsequently read/write a resource stored at that address. Return `false` if the function
-    /// will not do this in any possible concrete execution. Return an error if `module`::`fun` does
-    /// not exist.
-    pub fn may_have_secondary_indexes(&self, module: &ModuleId, fun: &IdentStr) -> Result<bool> {
-        let state = self.get_summary_(module, fun)?;
-        let mut has_secondary_index = false;
-        state.accesses().iter_offsets(|offset| {
-            if matches!(offset, Offset::Global(_)) {
-                has_secondary_index = true
-            }
-        });
-        Ok(has_secondary_index)
-    }
-
-    /// Returns an overapproximation of the `ResourceKey`'s in global storage that will be written
-    /// by `module::fun` if called with arguments `signers`, `actuals`, `type_actuals` in state
-    /// `blockchain_view`.
-    pub fn get_keys_written(
-        &self,
-        module: &ModuleId,
-        fun: &IdentStr,
-        signers: &[AccountAddress],
-        actuals: &[Vec<u8>],
-        type_actuals: &[TypeTag],
-        blockchain_view: &impl MoveResolver,
-    ) -> Result<Vec<ResourceKey>> {
-        self.get_concretized_keys(
-            module,
-            fun,
-            signers,
-            actuals,
-            type_actuals,
-            blockchain_view,
-            true,
-        )
-    }
-
-    /// Returns an overapproximation of the `ResourceKey`'s in global storage that will be read by
-    /// `module::fun` if called with arguments `signers`, `actuals`, `type_actuals` in state
-    /// `blockchain_view`.
-    pub fn get_keys_read(
-        &self,
-        module: &ModuleId,
-        fun: &IdentStr,
-        signers: &[AccountAddress],
-        actuals: &[Vec<u8>],
-        type_actuals: &[TypeTag],
-        blockchain_view: &impl MoveResolver,
-    ) -> Result<Vec<ResourceKey>> {
-        self.get_concretized_keys(
-            module,
-            fun,
-            signers,
-            actuals,
-            type_actuals,
-            blockchain_view,
-            false,
-        )
-    }
-
-    /// Returns an overapproximation of the `ResourceKey`'s in global storage that will be accesses
-    /// by module::fun` if called with arguments `signers`, `actuals`, `type_actuals` in state
-    /// `blockchain_view`.
-    /// If `is_write` is true, only ResourceKey's written will be returned; otherwise, only
-    /// ResourceKey's read will be returned.
-    pub fn get_concretized_keys(
-        &self,
-        module: &ModuleId,
-        fun: &IdentStr,
-        signers: &[AccountAddress],
-        actuals: &[Vec<u8>],
-        type_actuals: &[TypeTag],
-        blockchain_view: &impl MoveResolver,
-        is_write: bool,
-    ) -> Result<Vec<ResourceKey>> {
-        if let Some(state) = self.get_summary(module, fun) {
-            let results = dynamic_analysis::concretize(
-                state.accesses().clone(),
-                signers,
-                actuals,
-                type_actuals,
-                &self.get_function_env(module, fun).unwrap(),
-                blockchain_view,
-            )?;
-            Ok(if is_write {
-                results.get_keys_written(&self.env)
-            } else {
-                results.get_keys_read(&self.env)
-            })
-        } else {
-            bail!("Couldn't resolve function {:?}::{:?}", module, fun)
-        }
-    }
-
     /// Returns the FunctionEnv for `module`::`fun`
     /// Returns `None` if this function does not exist
     pub fn get_function_env(&self, module: &ModuleId, fun: &IdentStr) -> Option<FunctionEnv> {
         self.env
             .find_function_by_language_storage_id_name(module, &fun.to_owned())
+    }
+
+    /// Normalize the analysis result computed from the move-prover pipeline.
+    ///
+    /// This will include all the script functions and the list function names provided in `add_ons`
+    /// that are required by the adapter, such as prologues, epilogues, etc.
+    pub fn normalize_all_scripts(
+        &self,
+        add_ons: Vec<(ModuleId, Identifier)>,
+    ) -> NormalizedReadWriteSetAnalysis {
+        let mut result: BTreeMap<ModuleId, BTreeMap<Identifier, ReadWriteSet>> = BTreeMap::new();
+        for module in self.env.get_modules() {
+            let module_id = module.get_verified_module().self_id();
+            let module_entry = result.entry(module_id.clone()).or_default();
+            for func in module.get_functions() {
+                let func_name = func.get_identifier();
+                if func.is_script() || add_ons.contains(&(module_id.clone(), func_name.clone())) {
+                    module_entry.insert(
+                        func.get_identifier(),
+                        self.targets
+                            .get_data(&func.get_qualified_id(), &FunctionVariant::Baseline)
+                            .map(|data| data.annotations.get::<ReadWriteSetState>())
+                            .flatten()
+                            .unwrap()
+                            .normalize(&self.env),
+                    );
+                }
+            }
+        }
+        NormalizedReadWriteSetAnalysis::new(result)
     }
 }

--- a/language/tools/read-write-set/src/normalize.rs
+++ b/language/tools/read-write-set/src/normalize.rs
@@ -1,0 +1,158 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::dynamic_analysis::{concretize, ConcretizedSecondaryIndexes};
+use anyhow::{anyhow, bail, Result};
+use move_core_types::{
+    account_address::AccountAddress,
+    identifier::{IdentStr, Identifier},
+    language_storage::{ModuleId, ResourceKey, TypeTag},
+    resolver::MoveResolver,
+};
+use read_write_set_types::ReadWriteSet;
+use std::collections::BTreeMap;
+
+pub struct NormalizedReadWriteSetAnalysis(BTreeMap<ModuleId, BTreeMap<Identifier, ReadWriteSet>>);
+
+impl NormalizedReadWriteSetAnalysis {
+    pub fn new(inner: BTreeMap<ModuleId, BTreeMap<Identifier, ReadWriteSet>>) -> Self {
+        Self(inner)
+    }
+
+    fn get_summary(&self, module: &ModuleId, fun: &IdentStr) -> Option<&ReadWriteSet> {
+        self.0.get(module)?.get(fun)
+    }
+
+    /// Returns an overapproximation of the `ResourceKey`'s in global storage that will be written
+    /// by `module::fun` if called with arguments `signers`, `actuals`, `type_actuals` in state
+    /// `blockchain_view`.
+    pub fn get_keys_written(
+        &self,
+        module: &ModuleId,
+        fun: &IdentStr,
+        signers: &[AccountAddress],
+        actuals: &[Vec<u8>],
+        type_actuals: &[TypeTag],
+        blockchain_view: &impl MoveResolver,
+    ) -> Result<Vec<ResourceKey>> {
+        self.get_concretized_keys(
+            module,
+            fun,
+            signers,
+            actuals,
+            type_actuals,
+            blockchain_view,
+            true,
+        )
+    }
+
+    /// Returns an overapproximation of the `ResourceKey`'s in global storage that will be read by
+    /// `module::fun` if called with arguments `signers`, `actuals`, `type_actuals` in state
+    /// `blockchain_view`.
+    pub fn get_keys_read(
+        &self,
+        module: &ModuleId,
+        fun: &IdentStr,
+        signers: &[AccountAddress],
+        actuals: &[Vec<u8>],
+        type_actuals: &[TypeTag],
+        blockchain_view: &impl MoveResolver,
+    ) -> Result<Vec<ResourceKey>> {
+        self.get_concretized_keys(
+            module,
+            fun,
+            signers,
+            actuals,
+            type_actuals,
+            blockchain_view,
+            false,
+        )
+    }
+
+    /// Returns an overapproximation of the `ResourceKey`'s in global storage that will be accesses
+    /// by module::fun` if called with arguments `signers`, `actuals`, `type_actuals` in state
+    /// `blockchain_view`.
+    /// If `is_write` is true, only ResourceKey's written will be returned; otherwise, only
+    /// ResourceKey's read will be returned.
+    pub fn get_concretized_keys(
+        &self,
+        module: &ModuleId,
+        fun: &IdentStr,
+        signers: &[AccountAddress],
+        actuals: &[Vec<u8>],
+        type_actuals: &[TypeTag],
+        blockchain_view: &impl MoveResolver,
+        is_write: bool,
+    ) -> Result<Vec<ResourceKey>> {
+        if let Some(state) = self.get_summary(module, fun) {
+            let results = concretize(
+                state,
+                module,
+                fun,
+                signers,
+                actuals,
+                type_actuals,
+                blockchain_view,
+            )?;
+            Ok(if is_write {
+                results
+                    .get_keys_written()
+                    .ok_or_else(|| anyhow!("Failed to get keys written"))?
+            } else {
+                results
+                    .get_keys_read()
+                    .ok_or_else(|| anyhow!("Failed to get keys read"))?
+            })
+        } else {
+            bail!("Couldn't resolve function {:?}::{:?}", module, fun)
+        }
+    }
+
+    /// Returns an overapproximation of the access paths in global storage that will be read/written
+    /// by `module::fun` if called with arguments `signers`, `actuals`, `type_actuals` in state
+    /// `blockchain_view`.
+    pub fn get_concretized_summary(
+        &self,
+        module: &ModuleId,
+        fun: &IdentStr,
+        signers: &[AccountAddress],
+        actuals: &[Vec<u8>],
+        type_actuals: &[TypeTag],
+        blockchain_view: &impl MoveResolver,
+    ) -> Result<ConcretizedSecondaryIndexes> {
+        let state = self
+            .get_summary(module, fun)
+            .ok_or_else(|| anyhow!("Function {}::{} to found", module, fun))?;
+        concretize(
+            state,
+            module,
+            fun,
+            signers,
+            actuals,
+            type_actuals,
+            blockchain_view,
+        )
+    }
+
+    pub fn get_canonical_summary(&self, module: &ModuleId, fun: &IdentStr) -> Option<ReadWriteSet> {
+        self.get_summary(module, fun).cloned()
+    }
+
+    /// Return `true` if `module`::`fun` may read an address from the blockchain state and
+    /// subsequently read/write a resource stored at that address. Return `false` if the function
+    /// will not do this in any possible concrete execution. Return an error if `module`::`fun` does
+    /// not exist.
+    pub fn may_have_secondary_indexes(&self, module: &ModuleId, fun: &IdentStr) -> Result<bool> {
+        let state = self
+            .get_summary(module, fun)
+            .ok_or_else(|| anyhow!("Function {}::{} to found", module, fun))?;
+        let mut has_secondary_index = false;
+        state.iter_paths(|offset, _| {
+            if offset.has_secondary_index() {
+                has_secondary_index = true;
+            }
+            Some(())
+        });
+        Ok(has_secondary_index)
+    }
+}


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Create a standalone type defintion for read-writeset analysis as the first step to separating the analysis path out from the move-model framework. The PR has two commits:
1. Create a type definition in move-core-types for types with free variables and the conversion function from move-model internal types to this definition.
2. Create a type definition crate in `language/tools/read-write-set/types` for the standalone type definition of the inferred result for read-writeset.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Updated existing tests.
