### PR TITLE
[crypto] ECDSA secp256r1 in diem-crypto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,6 +1126,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c32f031ea41b4291d695026c023b95d59db2d8a2c7640800ed56bc8f510f22"
+
+[[package]]
 name = "const-random"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,10 +1335,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "281d926f72b42bf3ba840b88cd53e39f36be9f66e34c8df3fb336372b3753d41"
+dependencies = [
+ "generic-array 0.14.4",
+ "subtle",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
+dependencies = [
+ "generic-array 0.14.4",
+ "subtle",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
 dependencies = [
  "generic-array 0.14.4",
  "subtle",
@@ -1446,6 +1472,15 @@ dependencies = [
  "reqwest",
  "tokio",
  "warp",
+]
+
+[[package]]
+name = "der"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f215f706081a44cb702c71c39a52c05da637822e9c1645a50b7202689e982d"
+dependencies = [
+ "const-oid",
 ]
 
 [[package]]
@@ -1564,6 +1599,7 @@ dependencies = [
  "hkdf",
  "mirai-annotations",
  "once_cell",
+ "p256",
  "proptest",
  "proptest-derive",
  "rand 0.8.3",
@@ -2502,7 +2538,7 @@ dependencies = [
  "diem-workspace-hack",
  "ed25519-dalek-fiat",
  "hex",
- "hmac",
+ "hmac 0.10.1",
  "mirai-annotations",
  "pbkdf2",
  "rand 0.8.3",
@@ -2818,6 +2854,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecdsa"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05cb0ed2d2ce37766ac86c05f66973ace8c51f7f1533bedce8fb79e2b54b3f14"
+dependencies = [
+ "der",
+ "elliptic-curve",
+ "hmac 0.11.0",
+ "signature",
+]
+
+[[package]]
 name = "ed25519"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2847,6 +2895,22 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59029dd05f60215bbe37eda4b32ba1a142abc8b01a938955b20b92ff0d713e8e"
+dependencies = [
+ "crypto-bigint",
+ "ff",
+ "generic-array 0.14.4",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.2",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -3087,6 +3151,16 @@ version = "0.1.0"
 dependencies = [
  "diem-workspace-hack",
  "thiserror",
+]
+
+[[package]]
+name = "ff"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63eec06c61e487eecf0f7e6e6372e596a81922c28d33e645d6983ca6493a1af0"
+dependencies = [
+ "rand_core 0.6.2",
+ "subtle",
 ]
 
 [[package]]
@@ -3505,6 +3579,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
+dependencies = [
+ "ff",
+ "rand_core 0.6.2",
+ "subtle",
+]
+
+[[package]]
 name = "guppy"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3664,7 +3749,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51ab2f639c231793c5f6114bdb9bbe50a7dbbfcd7c7c6bd8475dec2d991e964f"
 dependencies = [
  "digest 0.9.0",
- "hmac",
+ "hmac 0.10.1",
 ]
 
 [[package]]
@@ -3673,7 +3758,17 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
- "crypto-mac",
+ "crypto-mac 0.10.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+dependencies = [
+ "crypto-mac 0.11.0",
  "digest 0.9.0",
 ]
 
@@ -5365,6 +5460,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d053368e1bae4c8a672953397bd1bd7183dde1c72b0b7612a15719173148d186"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "sha2",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5421,8 +5527,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "309c95c5f738c85920eb7062a2de29f3840d4f96974453fc9ac1ba078da9c627"
 dependencies = [
  "base64ct",
- "crypto-mac",
- "hmac",
+ "crypto-mac 0.10.0",
+ "hmac 0.10.1",
  "password-hash",
  "sha2",
 ]
@@ -5534,6 +5640,16 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d156817ae0125e8aa5067710b0db24f0984830614f99875a70aa5e3b74db69"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -6323,7 +6439,7 @@ dependencies = [
  "bytes",
  "futures",
  "hex",
- "hmac",
+ "hmac 0.10.1",
  "http",
  "hyper",
  "log",
@@ -6976,6 +7092,10 @@ name = "signature"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f0242b8e50dd9accdd56170e94ca1ebd223b098eb9c83539a6e367d0f36ae68"
+dependencies = [
+ "digest 0.9.0",
+ "rand_core 0.6.2",
+]
 
 [[package]]
 name = "simplelog"
@@ -7122,6 +7242,15 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spki"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "987637c5ae6b3121aba9d513f869bd2bff11c4cc086c22473befd6649c0bd521"
+dependencies = [
+ "der",
+]
 
 [[package]]
 name = "stable_deref_trait"

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -34,6 +34,7 @@ x25519-dalek = { version = "0.1.0", package = "x25519-dalek-fiat", default-featu
 aes-gcm = "0.8.0"
 diem-crypto-derive = { path = "../crypto-derive", version = "0.0.2" }
 bcs = "0.1.2"
+p256 = "0.9.0"
 
 [dev-dependencies]
 bitvec = "0.19.4"
@@ -49,7 +50,7 @@ trybuild = "1.0.41"
 diem-workspace-hack = { path = "../../common/workspace-hack" }
 
 [features]
-default = ["fiat"]
+default = ["fiat", "p256/ecdsa"]
 assert-private-keys-not-cloneable = []
 cloneable-private-keys = []
 fuzzing = ["proptest", "proptest-derive", "cloneable-private-keys"]

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -57,6 +57,7 @@ fuzzing = ["proptest", "proptest-derive", "cloneable-private-keys"]
 fiat = ["curve25519-dalek/fiat_u64_backend", "ed25519-dalek/fiat_u64_backend", "x25519-dalek/fiat_u64_backend"]
 u64 = ["curve25519-dalek/u64_backend", "ed25519-dalek/u64_backend", "x25519-dalek/u64_backend"]
 u32 = ["curve25519-dalek/u32_backend", "ed25519-dalek/u32_backend", "x25519-dalek/u32_backend"]
+# crypto-experimental = ["p256/ecdsa"]
 
 [[bench]]
 name = "noise"

--- a/crypto/crypto/src/ecdsa_secp256r1.rs
+++ b/crypto/crypto/src/ecdsa_secp256r1.rs
@@ -1,0 +1,415 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module provides an API for the ECDSA signature scheme over the secp256r1 twisted curve as
+//! as specified in [FIPS 186-4](https://csrc.nist.gov/publications/detail/fips/186/4/final) (Digital Signature Standard).
+//!
+//!
+//! # Examples
+#![allow(clippy::integer_arithmetic)]
+
+use crate::{
+    hash::{CryptoHash, CryptoHasher},
+    traits::*,
+};
+use anyhow::{anyhow, Result};
+use std::convert::{TryFrom, TryInto};
+use diem_crypto_derive::{DeserializeKey, SerializeKey, SilentDebug, SilentDisplay};
+use mirai_annotations::*;
+use p256::{
+    ecdsa::{SigningKey as P256SigningKey, Signature as P256Signature, signature::Signer, VerifyingKey as P256VerifyingKey, signature::Verifier}
+};
+use serde::Serialize;
+use std::{cmp::Ordering, fmt};
+
+/// The length of the EcdsaPublicKey
+pub const ECDSA_SECP256R1_PRIVATE_KEY_LENGTH: usize = 32;
+/// The length of the EcdsaPublicKey
+pub const ECDSA_SECP256R1_PUBLIC_KEY_LENGTH: usize = 33;
+/// The length of the EcdsaSignature
+pub const ECDSA_SECP256R1_SIGNATURE_LENGTH: usize = 64;
+
+/// An ECDSA secp256r1 private key
+#[derive(DeserializeKey, SerializeKey, SilentDebug, SilentDisplay)]
+pub struct EcdsaPrivateKey(Vec<u8>);
+
+#[cfg(feature = "assert-private-keys-not-cloneable")]
+static_assertions::assert_not_impl_any!(EcdsaPrivateKey: Clone);
+
+#[cfg(any(test, feature = "cloneable-private-keys"))]
+impl Clone for EcdsaPrivateKey {
+    fn clone(&self) -> Self {
+        EcdsaPrivateKey(self.0.clone())
+    }
+}
+
+/// An ECDSA secp256r1 public key
+#[derive(DeserializeKey, Clone, SerializeKey)]
+pub struct EcdsaPublicKey(Vec<u8>);
+
+#[cfg(mirai)]
+use crate::tags::ValidatedPublicKeyTag;
+#[cfg(not(mirai))]
+struct ValidatedPublicKeyTag {}
+
+/// An ECDSA secp256r1 signature
+#[derive(DeserializeKey, Clone, SerializeKey)]
+pub struct EcdsaSignature(Vec<u8>);
+
+impl EcdsaPrivateKey {
+    /// The length of the EcdsaPrivateKey
+    pub const LENGTH: usize = ECDSA_SECP256R1_PRIVATE_KEY_LENGTH;
+
+    /// Serialize an EcdsaPrivateKey.
+    pub fn to_bytes(&self) -> [u8; EcdsaPrivateKey::LENGTH] {
+        // Converting from Vec to array will not normally fail, and if it does it's better to panic.
+        self.0.clone().try_into().unwrap()
+    }
+
+    /// Deserialize an EcdsaPrivateKey without any validation checks apart from expected key size.
+    fn from_bytes_unchecked(
+        bytes: &[u8],
+    ) -> std::result::Result<EcdsaPrivateKey, CryptoMaterialError> {
+        if bytes.len() != ECDSA_SECP256R1_PRIVATE_KEY_LENGTH {
+            Err(CryptoMaterialError::DeserializationError)
+        } else {
+            Ok(EcdsaPrivateKey(bytes.to_vec()))
+        }
+    }
+
+    /// Private function aimed at minimizing code duplication between sign
+    /// methods of the SigningKey implementation. This should remain private.
+    fn sign_arbitrary_message(&self, message: &[u8]) -> EcdsaSignature {
+        let signing_key = P256SigningKey::from_bytes(&self.0).unwrap();
+        let signature: P256Signature = signing_key.sign(message);
+        EcdsaSignature(to_compressed_signature_bytes(&signature))
+    }
+}
+
+impl EcdsaPublicKey {
+    /// Serialize an EcdsaPublicKey.
+    pub fn to_bytes(&self) -> [u8; ECDSA_SECP256R1_PUBLIC_KEY_LENGTH] { self.0.clone().try_into().unwrap() }
+
+    /// Deserialize an EcdsaPublicKey without any validation checks apart from expected key size.
+    pub(crate) fn from_bytes_unchecked(
+        bytes: &[u8],
+    ) -> std::result::Result<EcdsaPublicKey, CryptoMaterialError> {
+        if bytes.len() != ECDSA_SECP256R1_PUBLIC_KEY_LENGTH {
+            return Err(CryptoMaterialError::WrongLengthError)
+        }
+        Ok(EcdsaPublicKey(bytes.to_vec()))
+    }
+}
+
+impl EcdsaSignature {
+    /// The length of the EcdsaSignature
+    pub const LENGTH: usize = ECDSA_SECP256R1_SIGNATURE_LENGTH;
+
+    /// Serialize an EcdsaSignature.
+    pub fn to_bytes(&self) -> [u8; ECDSA_SECP256R1_SIGNATURE_LENGTH] {
+        self.0.clone().try_into().unwrap()
+    }
+
+    /// Deserialize an EcdsaSignature without any validation checks
+    /// apart from expected key size.
+    pub(crate) fn from_bytes_unchecked(
+        bytes: &[u8],
+    ) -> std::result::Result<EcdsaSignature, CryptoMaterialError> {
+        if bytes.len() != ECDSA_SECP256R1_SIGNATURE_LENGTH {
+            return Err(CryptoMaterialError::WrongLengthError)
+        }
+        Ok(EcdsaSignature(bytes.to_vec()))
+    }
+
+    /// return an all-zero signature (for test only)
+    #[cfg(any(test, feature = "fuzzing"))]
+    pub fn dummy_signature() -> Self {
+        Self::from_bytes_unchecked(&[0u8; Self::LENGTH]).unwrap()
+    }
+}
+
+///////////////////////
+// PrivateKey Traits //
+///////////////////////
+
+impl PrivateKey for EcdsaPrivateKey {
+    type PublicKeyMaterial = EcdsaPublicKey;
+}
+
+impl SigningKey for EcdsaPrivateKey {
+    type VerifyingKeyMaterial = EcdsaPublicKey;
+    type SignatureMaterial = EcdsaSignature;
+
+    fn sign<T: CryptoHash + Serialize>(&self, message: &T) -> EcdsaSignature {
+        let mut bytes = <T::Hasher as CryptoHasher>::seed().to_vec();
+        bcs::serialize_into(&mut bytes, &message)
+            .map_err(|_| CryptoMaterialError::SerializationError)
+            .expect("Serialization of signable material should not fail.");
+        EcdsaPrivateKey::sign_arbitrary_message(&self, bytes.as_ref())
+    }
+
+    #[cfg(any(test, feature = "fuzzing"))]
+    fn sign_arbitrary_message(&self, message: &[u8]) -> EcdsaSignature {
+        EcdsaPrivateKey::sign_arbitrary_message(self, message)
+    }
+}
+
+impl Uniform for EcdsaPrivateKey {
+    fn generate<R>(rng: &mut R) -> Self
+        where
+            R: ::rand::RngCore + ::rand::CryptoRng,
+    {
+        let signing_key = P256SigningKey::random(rng);
+        EcdsaPrivateKey(signing_key.to_bytes().to_vec())
+    }
+}
+
+impl PartialEq<Self> for EcdsaPrivateKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.to_bytes() == other.to_bytes()
+    }
+}
+
+impl Eq for EcdsaPrivateKey {}
+
+// We could have a distinct kind of validation for the PrivateKey, for
+// ex. checking the derived PublicKey is valid?
+impl TryFrom<&[u8]> for EcdsaPrivateKey {
+    type Error = CryptoMaterialError;
+
+    /// Deserialize an Ed25519PrivateKey. This method will also check for key validity.
+    fn try_from(bytes: &[u8]) -> std::result::Result<EcdsaPrivateKey, CryptoMaterialError> {
+        if bytes.len() != EcdsaPrivateKey::LENGTH {
+            return Err(CryptoMaterialError::WrongLengthError)
+        }
+        Ok(EcdsaPrivateKey(bytes.to_vec()))
+    }
+}
+
+impl Length for EcdsaPrivateKey {
+    fn length(&self) -> usize {
+        Self::LENGTH
+    }
+}
+
+impl ValidCryptoMaterial for EcdsaPrivateKey {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.to_bytes().to_vec()
+    }
+}
+
+impl Genesis for EcdsaPrivateKey {
+    fn genesis() -> Self {
+        let mut buf = [0u8; EcdsaPrivateKey::LENGTH];
+        buf[EcdsaPrivateKey::LENGTH - 1] = 1;
+        Self::try_from(buf.as_ref()).unwrap()
+    }
+}
+
+//////////////////////
+// PublicKey Traits //
+//////////////////////
+
+// Implementing From<&PrivateKey<...>> allows to derive a public key in a more elegant fashion
+impl From<&EcdsaPrivateKey> for EcdsaPublicKey {
+    fn from(private_key: &EcdsaPrivateKey) -> Self {
+        let signing_key = P256SigningKey::from_bytes(&private_key.0).unwrap();
+        let verifying_key = P256VerifyingKey::from(&signing_key);
+        EcdsaPublicKey(verifying_key.to_encoded_point(true).to_bytes().to_vec())
+    }
+}
+
+// We deduce PublicKey from this
+impl PublicKey for EcdsaPublicKey {
+    type PrivateKeyMaterial = EcdsaPrivateKey;
+}
+
+impl std::hash::Hash for EcdsaPublicKey {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        let encoded_pubkey = self.to_bytes();
+        state.write(&encoded_pubkey);
+    }
+}
+
+// Those are required by the implementation of hash above
+impl PartialEq for EcdsaPublicKey {
+    fn eq(&self, other: &EcdsaPublicKey) -> bool {
+        self.to_bytes() == other.to_bytes()
+    }
+}
+
+impl Eq for EcdsaPublicKey {}
+
+// We deduce VerifyingKey from pointing to the signature material
+// we get the ability to do `pubkey.validate(msg, signature)`
+impl VerifyingKey for EcdsaPublicKey {
+    type SigningKeyMaterial = EcdsaPrivateKey;
+    type SignatureMaterial = EcdsaSignature;
+}
+
+impl fmt::Display for EcdsaPublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(&self.0))
+    }
+}
+
+impl fmt::Debug for EcdsaPublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "EcdsaPublicKey({})", self)
+    }
+}
+
+impl TryFrom<&[u8]> for EcdsaPublicKey {
+    type Error = CryptoMaterialError;
+
+    /// Deserialize an Ed25519PublicKey. This method will also check for key validity, for instance
+    ///  it will only deserialize keys that are safe against small subgroup attacks.
+    fn try_from(bytes: &[u8]) -> std::result::Result<EcdsaPublicKey, CryptoMaterialError> {
+        let public_key = EcdsaPublicKey::from_bytes_unchecked(bytes)?;
+        add_tag!(&public_key, ValidatedPublicKeyTag); // This key has gone through validity checks.
+        Ok(public_key)
+    }
+}
+
+impl Length for EcdsaPublicKey {
+    fn length(&self) -> usize {
+        ECDSA_SECP256R1_PUBLIC_KEY_LENGTH
+    }
+}
+
+impl ValidCryptoMaterial for EcdsaPublicKey {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.0.clone()
+    }
+}
+
+//////////////////////
+// Signature Traits //
+//////////////////////
+
+impl Signature for EcdsaSignature {
+    type VerifyingKeyMaterial = EcdsaPublicKey;
+    type SigningKeyMaterial = EcdsaPrivateKey;
+
+    /// Verifies that the provided signature is valid for the provided
+    /// message, according to the RFC8032 algorithm. This strict verification performs the
+    /// recommended check of 5.1.7 §3, on top of the required RFC8032 verifications.
+    fn verify<T: CryptoHash + Serialize>(
+        &self,
+        message: &T,
+        public_key: &EcdsaPublicKey,
+    ) -> Result<()> {
+        let mut bytes = <T::Hasher as CryptoHasher>::seed().to_vec();
+        bcs::serialize_into(&mut bytes, &message)
+            .map_err(|_| CryptoMaterialError::SerializationError)?;
+        Self::verify_arbitrary_msg(self, &bytes, public_key)
+    }
+
+    /// Checks that `self` is valid for an arbitrary &[u8] `message` using `public_key`.
+    /// Outside of this crate, this particular function should only be used for native signature
+    /// verification in move
+    fn verify_arbitrary_msg(&self, message: &[u8], public_key: &EcdsaPublicKey) -> Result<()> {
+        let verifying_key = P256VerifyingKey::from_sec1_bytes(&public_key.0).unwrap();
+        let signature = P256Signature::try_from((&self.0).as_slice()).unwrap();
+        verifying_key.verify(message, &signature)
+            .map_err(|e| anyhow!("{}", e))
+            .and(Ok(()))
+    }
+
+    fn to_bytes(&self) -> Vec<u8> {
+        self.0.clone()
+    }
+}
+
+impl Length for EcdsaSignature {
+    fn length(&self) -> usize {
+        ECDSA_SECP256R1_SIGNATURE_LENGTH
+    }
+}
+
+impl ValidCryptoMaterial for EcdsaSignature {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.to_bytes().to_vec()
+    }
+}
+
+impl std::hash::Hash for EcdsaSignature {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        let encoded_signature = self.to_bytes();
+        state.write(&encoded_signature);
+    }
+}
+
+impl TryFrom<&[u8]> for EcdsaSignature {
+    type Error = CryptoMaterialError;
+
+    fn try_from(bytes: &[u8]) -> std::result::Result<EcdsaSignature, CryptoMaterialError> {
+        EcdsaSignature::from_bytes_unchecked(bytes)
+    }
+}
+
+// Those are required by the implementation of hash above
+impl PartialEq for EcdsaSignature {
+    fn eq(&self, other: &EcdsaSignature) -> bool {
+        self.to_bytes()[..] == other.to_bytes()[..]
+    }
+}
+
+impl Eq for EcdsaSignature {}
+
+impl fmt::Display for EcdsaSignature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(&self.0))
+    }
+}
+
+impl fmt::Debug for EcdsaSignature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "EcdsaSignature({})", self)
+    }
+}
+
+// --- Utilities ---
+fn to_compressed_signature_bytes(signature: &P256Signature) -> Vec<u8>{
+    let mut sig_bytes = [0u8; 64];
+    sig_bytes[..32].copy_from_slice(&signature.r().to_bytes());
+    sig_bytes[32..].copy_from_slice(&signature.s().to_bytes());
+    sig_bytes.to_vec()
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+use crate::test_utils::{self, KeyPair};
+
+/// Produces a uniformly random ecdsa keypair from a seed
+#[cfg(any(test, feature = "fuzzing"))]
+pub fn keypair_strategy() -> impl Strategy<Value = KeyPair<EcdsaPrivateKey, EcdsaPublicKey>> {
+    test_utils::uniform_keypair_strategy::<EcdsaPrivateKey, EcdsaPublicKey>()
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+use proptest::prelude::*;
+use rand_core::OsRng;
+
+#[cfg(any(test, feature = "fuzzing"))]
+impl proptest::arbitrary::Arbitrary for EcdsaPublicKey {
+    type Parameters = ();
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        crate::test_utils::uniform_keypair_strategy::<EcdsaPrivateKey, EcdsaPublicKey>()
+            .prop_map(|v| v.public_key)
+            .boxed()
+    }
+
+    type Strategy = BoxedStrategy<Self>;
+}
+
+#[test]
+fn sign_verify() {
+    let message = b"Hello world";
+    let message2 = b"Hello world2";
+    let key_bytes = b"12345678901234567890123456789012";
+    let private_key = EcdsaPrivateKey::from_bytes_unchecked(&key_bytes.to_vec().as_slice()).unwrap();
+    let public_key = EcdsaPublicKey::from(&private_key);
+    let signature = private_key.sign_arbitrary_message(&message.to_vec().as_slice());
+    assert!(signature.verify_arbitrary_msg(&message.to_vec().as_slice(), &public_key).is_ok());
+    assert!(signature.verify_arbitrary_msg(&message2.to_vec().as_slice(), &public_key).is_err());
+}

--- a/crypto/crypto/src/ed25519.rs
+++ b/crypto/crypto/src/ed25519.rs
@@ -87,7 +87,7 @@ pub struct Ed25519Signature(ed25519_dalek::Signature);
 
 impl Ed25519PrivateKey {
     /// The length of the Ed25519PrivateKey
-    pub const LENGTH: usize = ed25519_dalek::SECRET_KEY_LENGTH;
+    pub const LENGTH: usize = ED25519_PRIVATE_KEY_LENGTH;
 
     /// Serialize an Ed25519PrivateKey.
     pub fn to_bytes(&self) -> [u8; ED25519_PRIVATE_KEY_LENGTH] {
@@ -170,7 +170,7 @@ impl Ed25519PublicKey {
 
 impl Ed25519Signature {
     /// The length of the Ed25519Signature
-    pub const LENGTH: usize = ed25519_dalek::SIGNATURE_LENGTH;
+    pub const LENGTH: usize = ED25519_SIGNATURE_LENGTH;
 
     /// Serialize an Ed25519Signature.
     pub fn to_bytes(&self) -> [u8; ED25519_SIGNATURE_LENGTH] {
@@ -551,11 +551,11 @@ use proptest::prelude::*;
 #[cfg(any(test, feature = "fuzzing"))]
 impl proptest::arbitrary::Arbitrary for Ed25519PublicKey {
     type Parameters = ();
-    type Strategy = BoxedStrategy<Self>;
-
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
         crate::test_utils::uniform_keypair_strategy::<Ed25519PrivateKey, Ed25519PublicKey>()
             .prop_map(|v| v.public_key)
             .boxed()
     }
+
+    type Strategy = BoxedStrategy<Self>;
 }

--- a/crypto/crypto/src/lib.rs
+++ b/crypto/crypto/src/lib.rs
@@ -23,6 +23,7 @@ mod unit_tests;
 
 #[cfg(mirai)]
 mod tags;
+mod ecdsa_secp256r1;
 
 pub use self::traits::*;
 pub use hash::HashValue;

--- a/crypto/crypto/src/lib.rs
+++ b/crypto/crypto/src/lib.rs
@@ -18,12 +18,14 @@ pub mod test_utils;
 pub mod traits;
 pub mod x25519;
 
+// #[cfg(feature = "crypto-experimental")]
+mod ecdsa_secp256r1;
+
 #[cfg(test)]
 mod unit_tests;
 
 #[cfg(mirai)]
 mod tags;
-mod ecdsa_secp256r1;
 
 pub use self::traits::*;
 pub use hash::HashValue;

--- a/crypto/crypto/src/traits.rs
+++ b/crypto/crypto/src/traits.rs
@@ -298,7 +298,10 @@ pub(crate) mod private {
     impl Sealed for crate::multi_ed25519::MultiEd25519PublicKey {}
     impl Sealed for crate::multi_ed25519::MultiEd25519Signature {}
 
+    // #[cfg(feature = "crypto-experimental")]
     impl Sealed for crate::ecdsa_secp256r1::EcdsaPrivateKey {}
+    // #[cfg(feature = "crypto-experimental")]
     impl Sealed for crate::ecdsa_secp256r1::EcdsaPublicKey {}
+    // #[cfg(feature = "crypto-experimental")]
     impl Sealed for crate::ecdsa_secp256r1::EcdsaSignature {}
 }

--- a/crypto/crypto/src/traits.rs
+++ b/crypto/crypto/src/traits.rs
@@ -297,4 +297,8 @@ pub(crate) mod private {
     impl Sealed for crate::multi_ed25519::MultiEd25519PrivateKey {}
     impl Sealed for crate::multi_ed25519::MultiEd25519PublicKey {}
     impl Sealed for crate::multi_ed25519::MultiEd25519Signature {}
+
+    impl Sealed for crate::ecdsa_secp256r1::EcdsaPrivateKey {}
+    impl Sealed for crate::ecdsa_secp256r1::EcdsaPublicKey {}
+    impl Sealed for crate::ecdsa_secp256r1::EcdsaSignature {}
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Supporting ECDSA with secp256r1 curve (known as NIST P-256 as well) in `diem-crypto` crate.
This algorithm might boost Diem's adoption due to being compatible with all major HSM devices (even old ones) and mobile secure enclaves. The latter can also allow for mobile-phone hardware wallets which might help on ceremonies, unhosted wallets etc.

This PR is only adding signature operations via the RustCrypto p256 crate (+ some reasonable compatibility modifications), and at the moment **it is not introducing a new blockchain Authenticator**, which means it won't affect any of the blockchain operations. This is on purpose, so we can properly review the algorithm first and keep the related PRs (i.e., extensive tests) as manageable as possible, as we're not targeting V1. **Ideally, we could add it under a "crypto-experimental' feature.**

Note that this work required significant effort by evaluating various implementations, to ensure compatibility with iPhone and Android native signatures + unlike Bitcoin's variable 70-72byte signature, we use a 64byte fixed compressed signature size.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

YES

## Test Plan

`sign_verify` and `serialization_full_cycle`
