### PR TITLE
[x] Add allowlist for direct dep duplicates

### DIFF
--- a/devtools/x/src/config.rs
+++ b/devtools/x/src/config.rs
@@ -121,6 +121,8 @@ pub struct WorkspaceConfig {
     pub enforced_attributes: EnforcedAttributesConfig,
     /// Banned dependencies
     pub banned_deps: BannedDepsConfig,
+    /// Direct dep duplicate lint config
+    pub direct_dep_dups: DirectDepDupsConfig,
     /// Overlay config in this workspace
     pub overlay: OverlayConfig,
     /// Test-only config in this workspace
@@ -147,6 +149,12 @@ pub struct BannedDepsConfig {
     pub direct: HashMap<String, String>,
     /// Banned dependencies in the default build set
     pub default_build: HashMap<String, String>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub struct DirectDepDupsConfig {
+    pub allow: Vec<String>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]

--- a/devtools/x/src/lint/mod.rs
+++ b/devtools/x/src/lint/mod.rs
@@ -27,7 +27,7 @@ pub fn run(args: Args, xctx: XContext) -> crate::Result<()> {
 
     let project_linters: &[&dyn ProjectLinter] = &[
         &guppy::BannedDeps::new(&workspace_config.banned_deps),
-        &guppy::DirectDepDups::new(&core_config.hakari)?,
+        &guppy::DirectDepDups::new(&workspace_config.direct_dep_dups, &core_config.hakari)?,
         &workspace_hack::GenerateWorkspaceHack,
     ];
 

--- a/x.toml
+++ b/x.toml
@@ -142,6 +142,9 @@ lazy_static = "use once_cell::sync::Lazy instead"
 criterion = "criterion is only for benchmarks"
 proptest = "proptest is only for testing and fuzzing"
 
+[workspace.direct-dep-dups]
+allow = []
+
 [workspace.overlay]
 features = ["fuzzing"]
 


### PR DESCRIPTION
Duplicates are occasionally desired when doing a long upgrade of a
dependency. When such upgrades land over multiple PRs, the dependency will be
temporarily duplicated.