### PR TITLE
[gha] use canonical volume mount point

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -48,6 +48,7 @@ jobs:
         uses: diem/actions/changes@266156eaff7ba6e1253cf7019506c7b3702f73de
         with:
           workflow-file: ci-test.yml
+          github-token: ${{secrets.GITHUB_TOKEN}}
       - id: need-build-images
         name: find changes need image build.
         uses: diem/actions/matches@266156eaff7ba6e1253cf7019506c7b3702f73de

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -483,7 +483,7 @@ jobs:
     container:
       image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
-        - "/home/runner/work/diem/diem:/opt/git/diem"
+        - "${{github.workspace}}:/opt/git/diem"
     steps:
       - uses: actions/checkout@v2.3.4
         with:
@@ -512,7 +512,7 @@ jobs:
     container:
       image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
-        - "/home/runner/work/diem/diem:/opt/git/diem"
+        - "${{github.workspace}}:/opt/git/diem"
     steps:
       - uses: actions/checkout@v2.3.4
         with:
@@ -552,7 +552,7 @@ jobs:
     container:
       image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
-        - "/home/runner/work/diem/diem:/opt/git/diem"
+        - "${{github.workspace}}:/opt/git/diem"
     steps:
       - uses: actions/checkout@v2.3.4
         with:
@@ -594,7 +594,7 @@ jobs:
     container:
       image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
-        - "/home/runner/work/diem/diem:/opt/git/diem"
+        - "${{github.workspace}}:/opt/git/diem"
     steps:
       - uses: actions/checkout@v2.3.4
         with:
@@ -627,7 +627,7 @@ jobs:
     container:
       image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
-        - "/home/runner/work/diem/diem:/opt/git/diem"
+        - "${{github.workspace}}:/opt/git/diem"
     steps:
       - uses: actions/checkout@v2.3.4
         with:
@@ -661,7 +661,7 @@ jobs:
     container:
       image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
-        - "/home/runner/work/diem/diem:/opt/git/diem"
+        - "${{github.workspace}}:/opt/git/diem"
     strategy:
       fail-fast: false
       matrix:
@@ -779,7 +779,7 @@ jobs:
     container:
       image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
-        - "/home/runner/work/diem/diem:/opt/git/diem"
+        - "${{github.workspace}}:/opt/git/diem"
     steps:
       - uses: actions/checkout@v2.3.4
         with:
@@ -805,7 +805,7 @@ jobs:
     container:
       image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
-        - "/home/runner/work/diem/diem:/opt/git/diem"
+        - "${{github.workspace}}:/opt/git/diem"
     steps:
       - uses: actions/checkout@v2.3.4
         with:
@@ -905,7 +905,7 @@ jobs:
     container:
       image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
-        - "/home/runner/work/diem/diem:/opt/git/diem"
+        - "${{github.workspace}}:/opt/git/diem"
     steps:
       - uses: actions/checkout@v2.3.4
         with:
@@ -928,7 +928,7 @@ jobs:
     container:
       image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
-        - "/home/runner/work/diem/diem:/opt/git/diem"
+        - "${{github.workspace}}:/opt/git/diem"
     steps:
       - uses: actions/checkout@v2.3.4
         with:

--- a/.github/workflows/ci-update-sccache.yml
+++ b/.github/workflows/ci-update-sccache.yml
@@ -66,7 +66,7 @@ jobs:
     container:
       image: diem/build_environment:main
       volumes:
-        - "/home/runner/work/diem/diem:/opt/git/diem"
+        - "${{github.workspace}}:/opt/git/diem"
     steps:
       - uses: actions/checkout@v2.3.4
         with:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: diem/build_environment:main
+      volumes:
+        - "${{github.workspace}}:/opt/git/diem"
     strategy:
       fail-fast: false
       matrix:
@@ -58,6 +60,8 @@ jobs:
     runs-on: ubuntu-latest-xl
     container:
       image: diem/build_environment:main
+      volumes:
+        - "${{github.workspace}}:/opt/git/diem"
     environment:
       name: Sccache
     env:
@@ -101,6 +105,8 @@ jobs:
     runs-on: ubuntu-latest-xl
     container:
       image: diem/build_environment:main
+      volumes:
+        - "${{github.workspace}}:/opt/git/diem"
     env:
       MESSAGE_PAYLOAD_FILE: /tmp/message
       ACCOUNT: ${{ secrets.TRANSACTION_REPLAY_ACCOUNT }}
@@ -142,6 +148,8 @@ jobs:
     runs-on: ubuntu-latest-xl
     container:
       image: diem/build_environment:main
+      volumes:
+        - "${{github.workspace}}:/opt/git/diem"
     env:
       DEVNET_MINT_TEST_KEY: ${{ secrets.DEVNET_MINT_TEST_KEY }}
       DEVNET_ENDPOINT: dev.testnet.diem.com
@@ -174,7 +182,7 @@ jobs:
     container:
       image: diem/build_environment:${{ matrix.target-branch }}
       volumes:
-        - "/home/runner/work/diem/diem:/opt/git/diem"
+        - "${{github.workspace}}:/opt/git/diem"
     env:
       MESSAGE_PAYLOAD_FILE: /tmp/message
     strategy:


### PR DESCRIPTION
## Motivation
Change GHA setup to work in private clones.
- The gh token is used to process PR info in private clone
- Switched the container to use canonical mount point

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan
Test 1 - canary in private clone
Before - https://github.com/diem/diem-private/runs/2861637839
After - https://github.com/diem/diem-private/actions/runs/958391093

Test 2 - canary in this repo
daily - https://github.com/diem/diem/actions/runs/958531037
sccache - https://github.com/diem/diem/actions/runs/958531030