### PR TITLE
[move] Update compiler README with required args

### DIFF
--- a/language/compiler/README.md
+++ b/language/compiler/README.md
@@ -31,23 +31,23 @@ automatically calls the bytecode verifier at the end of compilation.
 
 ```text
 USAGE:
-    compiler [FLAGS] [OPTIONS] <source_path>
+    compiler [FLAGS] [OPTIONS] <source-path> --address <address>
 
 FLAGS:
     -h, --help                 Prints help information
-    -l, --list_dependencies    Instead of compiling the source, emit a dependency list of the compiled source
+    -l, --list-dependencies    Instead of compiling the source, emit a dependency list of the compiled source
     -m, --module               Treat input file as a module (default is to treat file as a script)
         --no-stdlib            Do not automatically compile stdlib dependencies
         --no-verify            Do not automatically run the bytecode verifier
+        --src-map
     -V, --version              Prints version information
 
 OPTIONS:
-    -a, --address <address>       Account address used for publishing
-        --deps <deps_path>        Path to the list of modules that we want to link with
-    -o, --output <output_path>    Serialize and write the compiled output to this file
+    -a, --address <address>    Account address used for publishing
+        --deps <deps-path>     Path to the list of modules that we want to link with
 
 ARGS:
-    <source_path>    Path to the Move IR source to compile
+    <source-path>    Path to the Move IR source to compile
 ```
 
 ### Example Usage
@@ -59,10 +59,10 @@ ARGS:
 * Alternatively, the binary can be run directly with `cargo run -p compiler`.
 
 To compile and verify `foo.mvir`, which contains a Move IR module:
-> `compiler -m foo.mvir`
+> `compiler --address 0x42 --no-stdlib -m foo.mvir`
 
 To compile and verify `bar.mvir`, which contains a transaction script:
-> `compiler bar.mvir`
+> `compiler --address 0xca --no-stdlib bar.mvir`
 
 ## Folder Structure
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

I have a small change to the README for the `compiler` binary that would have helped me, a relatively new contributor to the project, get started debugging MVIR:

When attempting to use the compiler I found the documentation slightly out-of-date: running the listed commands to compile and verify modules and scripts resulted in an error:

```
compiler script.mvir
error: The following required arguments were not provided:
    --address <address>
```

I tried providing `--address` as instructed but encountered a different issue:

```
compiler --address 0x02 script.mvir
thread 'main' panicked at 'Failed to compile script: Duplicate dependency module for 00000000000000000000000000000001.AccountAdministrationScripts', language/compiler/src/main.rs:144:14
```

Update the documentation with a command that works out-of-the-box. In addition, update the output of the help text (although the `--src-map` argument is undocumented for now).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Because the only change here is to the README, my only test was to check that it rendered properly on GitHub at my fork.

## Related PRs

None.