### PR TITLE
[stackless-vm][crypto] fix missing feature section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,8 +642,11 @@ dependencies = [
  "curve25519-dalek-fiat",
  "diem-workspace-hack",
  "ed25519-dalek-fiat",
+ "proptest",
+ "proptest-derive",
  "sha2",
  "sha3",
+ "x25519-dalek-fiat",
 ]
 
 [[package]]

--- a/language/move-prover/interpreter/crypto/Cargo.toml
+++ b/language/move-prover/interpreter/crypto/Cargo.toml
@@ -13,5 +13,17 @@ diem-workspace-hack = { path = "../../../../common/workspace-hack" }
 anyhow = "1.0.38"
 curve25519-dalek = { version = "0.1.0", package = "curve25519-dalek-fiat", default-features = false, features = ["std"] }
 ed25519-dalek = { version = "0.1.0", package = "ed25519-dalek-fiat", default-features = false, features = ["std", "serde"] }
+proptest = { version = "1.0.0", optional = true }
+proptest-derive = { version = "0.3.0", optional = true }
 sha2 = "0.9.3"
 sha3 = "0.9.1"
+x25519-dalek = { version = "0.1.0", package = "x25519-dalek-fiat", default-features = false, features = ["std"] }
+
+[features]
+default = ["fiat"]
+assert-private-keys-not-cloneable = []
+cloneable-private-keys = []
+fuzzing = ["proptest", "proptest-derive", "cloneable-private-keys"]
+fiat = ["curve25519-dalek/fiat_u64_backend", "ed25519-dalek/fiat_u64_backend", "x25519-dalek/fiat_u64_backend"]
+u64 = ["curve25519-dalek/u64_backend", "ed25519-dalek/u64_backend", "x25519-dalek/u64_backend"]
+u32 = ["curve25519-dalek/u32_backend", "ed25519-dalek/u32_backend", "x25519-dalek/u32_backend"]


### PR DESCRIPTION
This fixes the `no curve25519-dalek backend cargo feature enabled!`
cargo build error.

Wondering why this is not caught by CI though as `cargo build` fails.
The original PR that introduces the crate is #8573
## Motivation

Fix `cargo build` failure.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

`cargo build`
