### PR TITLE
[forge] init fgi

### DIFF
--- a/scripts/fgi
+++ b/scripts/fgi
@@ -1,0 +1,262 @@
+#!/bin/bash
+# Copyright (c) The Diem Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+set -e
+set -o pipefail
+
+TAG=""
+PR=""
+WORKSPACE=""
+ENV=""
+LOCAL_BUILD=""
+EXIT_CODE=0
+# Default timeout is 45 mins
+TIMEOUT_SECS=2700
+
+AWS_ACCOUNT=${AWS_ACCOUNT:-$(aws sts get-caller-identity --query Account --output text)}
+
+FORGE_K8S_CLUSTERS=(rustietest)
+K8S_CONTEXT_PATTERN="arn:aws:eks:us-west-2:${AWS_ACCOUNT}:cluster/libra-CLUSTERNAME"
+HELM_CHARTS_URL_PATTERN="s3://diem-testnet-CLUSTERNAME-helm/charts"
+GRAFANA_URL_PATTERN="http://mon.CLUSTERNAME.aws.hlw3truzy4ls.com"
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# Colorize Output
+RESTORE=$(echo -en '\001\033[0m\002')
+BLUE=$(echo -en '\001\033[01;34m\002')
+
+join_args() {
+  retval_join_args=""
+  for var in "$@"
+  do
+    retval_join_args="${retval_join_args}, \"${var}\""
+  done
+}
+
+join_env_vars() {
+  retval_join_env_vars=""
+  for var in "$@"
+  do
+    IFS='=' read -ra env_var <<< "$var"
+    retval_join_env_vars="{\"name\":\"${env_var[0]}\", \"value\":\"${env_var[1]}\"}, ${retval_join_env_vars}"
+  done
+}
+
+# https://stackoverflow.com/a/5533586
+# This function shuffles the elements of an array named "array" in-place using the Knuth-Fisher-Yates shuffle algorithm
+shuffle() {
+   local i tmp size max rand
+
+   # $RANDOM % (i+1) is biased because of the limited range of $RANDOM
+   # Compensate by using a range which is a multiple of the array size.
+   size=${#array[*]}
+   max=$(( 32768 / size * size ))
+
+   for ((i=size-1; i>0; i--)); do
+      while (( (rand=RANDOM) >= max )); do :; done
+      rand=$(( rand % (i+1) ))
+      tmp=${array[i]} array[i]=${array[rand]} array[rand]=$tmp
+   done
+}
+
+# init the kube context for each available cluster
+kube_init_context () {
+  aws eks --region us-west-2 describe-cluster --name "libra-${FORGE_K8S_CLUSTERS[0]}" &>/dev/null || (echo "Failed to access EKS, try awsmfa?"; exit 1)
+  for cluster in "${FORGE_K8S_CLUSTERS[@]}"; do
+    aws eks --region us-west-2 update-kubeconfig --name "libra-${cluster}"
+  done
+}
+
+# randomly select a cluster that is free
+kube_select_cluster () {
+  retval_kube_select_cluster=""
+  array=("${FORGE_K8S_CLUSTERS[@]}")
+  shuffle
+  local attempts
+  attempts=360
+  for attempt in $(seq 1 $attempts) ; do
+    for cluster in "${array[@]}"; do
+      local context running_pods pending_pods monitoring_healthy_containers
+      context=${K8S_CONTEXT_PATTERN/CLUSTERNAME/$cluster}
+      running_pods=$(kubectl --context="${context}" get pods -l app.kubernetes.io/name=forge --field-selector=status.phase==Running 2> /dev/null | grep -cv ^NAME || true)
+      pending_pods=$(kubectl --context="${context}" get pods -l app.kubernetes.io/name=forge --field-selector=status.phase==Pending 2> /dev/null | grep -cv ^NAME || true)
+      monitoring_healthy_containers=$(kubectl --context="${context}" get pod/diem-testnet-monitoring-0 | grep 'diem-testnet-monitoring-0' | awk '{print $2}')
+      if [[ "${pending_pods}" -gt 0 ]]; then
+        echo "${cluster} has ${pending_pods} pending pods. Skipping."
+      elif [[ ${monitoring_healthy_containers} != "3/3" ]]; then
+        echo "monitoring is not healthy for ${cluster}. Skipping."
+      elif [[ ${running_pods} -gt 0 ]]; then
+        echo "${cluster} has ${running_pods} running pods. Skipping."
+      else
+        retval_kube_select_cluster="${cluster}"
+        return
+      fi
+    done
+    echo "All clusters have jobs running on them. Retrying in 10 secs. ${attempt}/${attempts}"
+    sleep 10
+  done
+  echo "Failed to schedule job on a cluster as all are busy"
+  exit 1
+}
+
+# wait for the given pod to be scheduled
+kube_wait_pod () {
+  local pod_name context phase
+  pod_name="${1}"
+  context="${2}"
+  for i in {1..360} ; do
+    phase=$(kubectl --context="${context}" get pod "${pod_name}" -o jsonpath="{.status.phase}" || echo -n "kubectlfailed")
+    if [[ "${phase}" == "kubectlfailed" ]]; then
+        echo "kubectl get pod ${pod_name} failed. Retrying."
+        sleep 10
+        continue
+    fi
+
+    # pod is either Running, Succeeded, or Failed
+    # https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
+    if [[ $phase != "Pending" &&  $phase != "Unknown" ]]; then
+      echo "${pod_name} reached phase: ${phase}"
+      return
+    fi
+
+    # error pulling the image
+    if kubectl --context="${context}" get pod "${pod_name}" | grep -i -e ImagePullBackOff -e InvalidImageName -e ErrImagePull &>/dev/null; then
+      image_name=$(kubectl --context="${context}" get pod "${pod_name}" -o jsonpath="{.spec.containers[0].image}")
+      echo "${pod_name} name failed to be scheduled because there was an error pulling the image: ${image_name}"
+      # Delete the pod so that it doesn't block other pods from being scheduled on this
+      kubectl --context="${context}" delete pod "${pod_name}"
+      exit 1
+    fi
+
+    echo "Waiting for ${pod_name} to be scheduled. Current phase: ${phase}"
+    sleep 10
+  done
+  echo "Pod ${pod_name} failed to be scheduled"
+  exit 1
+}
+
+while (( "$#" )); do
+  case "$1" in
+    -p|--pr)
+      PR=$2
+      shift 2
+      ;;
+    -L|--local-build)
+      LOCAL_BUILD="yes"
+      shift 1
+      ;;
+    --timeout-secs)
+      TIMEOUT_SECS=$2
+      shift 2
+      ;;
+    -T|--tag)
+      TAG=$2
+      shift 2
+      ;;
+    -W|--workspace)
+      WORKSPACE=$2
+      shift 2
+      ;;
+    -E|--env)
+      ENV="$ENV $2"
+      shift 2
+      ;;
+    *) # end argument parsing
+      break
+      ;;
+  esac
+done
+
+if ! which kubectl &>/dev/null; then
+  echo "kubectl is not installed. Please install kubectl. On mac, you can use: brew install kubectl"
+  echo "scripts/dev_setup.sh -i kubectl"
+  exit 1
+fi
+
+# build and push the images to be used
+if [ -z "$TAG" ]; then
+  if [ -z "$LOCAL_BUILD" ]; then
+    aws codebuild list-projects >/dev/null || (echo "Failed to access codebuild, try awsmfa?"; exit 1)
+    ./docker/build-aws.sh --build-forge --version "pull/${PR}"
+    TAG="dev_${USER}_pull_${PR}"
+    echo "**TIP Use fgi -T $TAG <...> to restart this run with same tag without rebuilding it"
+  else
+    TAG="dev_$(whoami)_$(git rev-parse --short HEAD)"
+    TAG=$TAG ./docker/build-push-local.sh
+  fi
+fi
+
+FORGE_TAG=${FORGE_TAG:-${TAG}}
+VALIDATOR_TAG=${VALIDATOR_TAG:-${TAG}}
+OUTPUT_TEE=${FGI_OUTPUT_LOG:-$(mktemp)}
+
+# select the kubernetes cluster
+echo "Running forge on Kubernetes"
+echo "Attempting to reach Kubernetes..."
+kube_init_context
+echo "Grabbing a Kubernetes cluster..."
+if [[ -z "${WORKSPACE}" ]]; then
+  kube_select_cluster
+  WORKSPACE=${retval_kube_select_cluster}
+fi
+helm_charts_url=${HELM_CHARTS_URL_PATTERN/CLUSTERNAME/${WORKSPACE}}
+grafana_url=${GRAFANA_URL_PATTERN/CLUSTERNAME/${WORKSPACE}}
+echo
+
+# create the pod spec
+pod_name="forge-$(whoami)-$(date +%s)"
+pod_name=${pod_name/_/-} # underscore not allowed in pod name
+specfile=$(mktemp)
+echo "Pod spec: ${specfile}"
+# shellcheck disable=SC2068
+join_args $@ # pass the rest of the args into forge. this should remain unquoted
+run_id="${WORKSPACE}-${pod_name}"
+ENV="${ENV} AWS_ROLE_SESSION_NAME=AWS_ROLE_SESSION_NAME RUN_ID=${run_id}"
+# shellcheck disable=SC2068,SC2086
+join_env_vars $ENV # pass the environment variables into the pod. this should remain unquoted
+sed -e "s/{pod_name}/${pod_name}/g" \
+    -e "s/{aws_account}/${AWS_ACCOUNT}/g" \
+    -e "s/{timeout_secs}/${TIMEOUT_SECS}/g" \
+    -e "s/{forge_image_tag}/${FORGE_TAG}/g" \
+    -e "s^{helm_charts_url}^${helm_charts_url}^g" \
+    -e "s^{env_variables}^${retval_join_env_vars}^g" \
+    -e "s+{extra_args}+${retval_join_args}+g" \
+    "${DIR}/forge_pod_template.yaml" > "$specfile"
+echo
+
+# apply the pod spec
+echo "Using cluster: ${WORKSPACE}"
+context=${K8S_CONTEXT_PATTERN/CLUSTERNAME/${WORKSPACE}}
+echo "Context: ${context}"
+echo "Creating pod: $pod_name"
+kubectl --context=${context} apply -f "${specfile}" || (echo "Failed to create forge pod"; exit 1)
+kube_wait_pod "${pod_name}" ${context}
+start_ts_ms=$(date +%s)000
+
+echo
+echo "**********"
+echo "${BLUE}Auto refresh Dashboard:${RESTORE} ${grafana_url}/d/overview/overview?from=${start_ts_ms}&to=now&refresh=10s&orgId=1"
+echo "**********"
+
+# tail the logs and block
+echo
+echo "==========begin-pod-logs=========="
+kubectl --context=${context} logs -f "${pod_name}" | tee "$OUTPUT_TEE"
+echo "==========end-pod-logs=========="
+
+# collect the results
+pod_status=$(kubectl --context=${context} get pods "${pod_name}" -o jsonpath="{.status.phase}")
+end_ts_ms=$(date +%s)000
+
+echo
+echo "**********"
+echo "${BLUE}Dashboard snapshot:${RESTORE} ${grafana_url}/d/overview/overview?from=${start_ts_ms}&to=${end_ts_ms}&orgId=1"
+echo "**********"
+
+if [[ "${pod_status}" != "Succeeded" ]]; then
+  echo
+  echo "${pod_name} status: ${pod_status}"
+  EXIT_CODE=1
+fi
+exit $EXIT_CODE

--- a/scripts/forge_pod_template.yaml
+++ b/scripts/forge_pod_template.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {pod_name}
+  labels:
+    app.kubernetes.io/name: forge
+spec:
+  restartPolicy: Never
+  serviceAccountName: forge
+  tolerations:
+    - key: "forge"
+      operator: "Exists"
+      effect: "NoSchedule"
+  containers:
+    - name: main
+      image: {aws_account}.dkr.ecr.us-west-2.amazonaws.com/diem/forge:{forge_image_tag}
+      imagePullPolicy: Always
+      env: [{env_variables}]
+      command:
+        - sh
+        - -c
+        - |-
+          set -ex
+          bash /etc/forge/scripts/init_forge.sh
+          timeout "{timeout_secs}" forge {extra_args}
+      volumeMounts:
+        - name: forge-init
+          mountPath: /etc/forge/scripts
+  volumes:
+    - name: forge-init
+      configMap:
+        name: forge-init
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: "app.kubernetes.io/name"
+                operator: In
+                values: ["forge"]
+          topologyKey: "kubernetes.io/hostname"


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR adds a script `fgi`, which is to Forge what `cti` is to Cluster Test. A lot of it is boilerplate borrowed from `cti`, but cleaned up. Related: we can probably wrap all `forge` test operations into this script as well, allowing the user to pick the backends to test on. For now, it assumes the k8s testnet backend.

`fgi` will currently:
* Instantiate kube context for all available clusters (currently only one)
* Select a free cluster based on running pods 
* Build and push new images if needed
* Create and apply a pod spec from a template. The created pod initializes helm with the chosen cluster's internal helm repo and then runs `forge`.
* Tail forge logs and dump dashboard links

Next steps:
* Expose some cluster operations to forge, e.g. controlling node images and re-running genesis to wipe the cluster (for LBT compat test)
* Ensure cluster logs sent to testnet ELK. For now, only dashboards and forge pod logs available.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Shellcheck: `shellcheck scripts/fgi`

Build and push a modified image based off of @zihaoccc 's working changes in the `forge` k8s backend: https://github.com/diem/diem/pull/8583

```
$ ./scripts/fgi -T dev_rustietest_52f5e17f
Running forge on Kubernetes
Attempting to reach Kubernetes...
Updated context arn:aws:eks:us-west-2:853397791086:cluster/libra-rustietest in /Users/rustielin/.kube/config
Grabbing a Kubernetes cluster...

Pod spec: /var/folders/h2/5s1_h_yj343_wn3cg1_fx0yw0000gn/T/tmp.PCspMbia

Using cluster: rustietest
Context: arn:aws:eks:us-west-2:853397791086:cluster/libra-rustietest
Creating pod: forge-rustielin-1624480225
pod/forge-rustielin-1624480225 created
Waiting for forge-rustielin-1624480225 to be scheduled. Current phase: Pending
Waiting for forge-rustielin-1624480225 to be scheduled. Current phase: Pending
forge-rustielin-1624480225 reached phase: Running

**********
Auto refresh Dashboard: http://mon.rustietest.aws.hlw3truzy4ls.com/d/overview/overview?from=1624480251000&to=now&refresh=10s&orgId=1
**********

==========begin-pod-logs==========
+ bash /etc/forge/scripts/init_forge.sh
deployment.apps/coredns scaled
Downloading and installing helm-s3 v0.10.0 ...
Checksum is valid.
Installed plugin: s3
"testnet-internal" has been added to your repositories
NAME                            CHART VERSION   APP VERSION     DESCRIPTION                                       
testnet-internal/diem-fullnode  1.3.0           1.3.0                                                             
testnet-internal/diem-validator 1.3.0           1.3.0           Diem blockchain validator                         
testnet-internal/testnet        0.1                             Additional components for a multi-validator tes...
+ timeout 2700 forge

running 4 tests
Starting to serve on 127.0.0.1:8001
Local kube pod healthcheck passed
test fund_account ... ok
test transfer_coins ... ok
test get_metadata ... ok
Will use 10 workers per endpoint with total 300 endpoint clients
Will create 15 accounts_per_client with total 4500 accounts
Creating and minting faucet account
DD account current balances are 9223372036854773807, requested 4500000000 coins
Completed minting seed accounts
Minting additional 4500 accounts
Mint is done
mint is done out side
starting emitting txns for 10 secs
test emit_transaction ... ok

test result: ok. 4 passed; 0 failed; 0 filtered out

==========end-pod-logs==========

**********
Dashboard snapshot: http://mon.rustietest.aws.hlw3truzy4ls.com/d/overview/overview?from=1624480251000&to=1624480531000&orgId=1
**********
```

## Related PRs

Latest `forge` changes have not been merged in yet (https://github.com/diem/diem/pull/8583). Until then, new `forge` images with the k8s backend enabled will not be built and pushed automatically, and you will thus either need to build your own, or use an existing one, e.g. the one I built in the test plan.
