### PR TITLE
[move-prover] understanding global invariants with generics

### DIFF
--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -59,7 +59,7 @@ use move_core_types::{
 
 use crate::{
     ast::{
-        ConditionKind, ExpData, GlobalInvariant, ModuleName, PropertyBag, PropertyValue, Spec,
+        ConditionKind, Exp, ExpData, GlobalInvariant, ModuleName, PropertyBag, PropertyValue, Spec,
         SpecBlockInfo, SpecFunDecl, SpecVarDecl, Value,
     },
     pragmas::{
@@ -67,11 +67,10 @@ use crate::{
         INTRINSIC_PRAGMA, OPAQUE_PRAGMA, VERIFY_PRAGMA,
     },
     symbol::{Symbol, SymbolPool},
-    ty::{PrimitiveType, Type, TypeDisplayContext},
+    ty::{PrimitiveType, Type, TypeDisplayContext, TypeUnification},
 };
 
 // import and re-expose symbols
-use crate::ast::Exp;
 pub use move_binary_format::file_format::{AbilitySet, Visibility as FunctionVisibility};
 
 // =================================================================================================
@@ -879,31 +878,36 @@ impl GlobalEnv {
         self.global_invariants.get(&id)
     }
 
-    /// Return the global invariants which refer to the given memory.
+    /// Return the global invariants which refer to the given memory
     pub fn get_global_invariants_for_memory(
         &self,
+        ty_params: &[TypeParameter],
         memory: &QualifiedInstId<StructId>,
-    ) -> Vec<GlobalId> {
-        self.global_invariants_for_memory
-            .get(memory)
-            .map(|ids| ids.iter().cloned().collect_vec())
-            .unwrap_or_else(Default::default)
-    }
-
-    /// Given a set of invariants, find the subset that refer to the type in mem.
-    pub fn get_subset_invariants_for_memory(
-        &self,
-        mem: QualifiedInstId<StructId>,
-        inv_set_id: &BTreeSet<GlobalId>,
     ) -> BTreeSet<GlobalId> {
-        if let Some(modifies_inv_id_set) = self.global_invariants_for_memory.get(&mem) {
-            modifies_inv_id_set
-                .intersection(inv_set_id)
-                .cloned()
-                .collect()
-        } else {
-            BTreeSet::<GlobalId>::new()
+        let mut inv_ids = BTreeSet::new();
+        for (key, val) in &self.global_invariants_for_memory {
+            if key.module_id != memory.module_id || key.id != memory.id {
+                continue;
+            }
+            assert_eq!(key.inst.len(), memory.inst.len());
+            let rel = TypeUnification::unify_vec(
+                &memory.inst,
+                &key.inst,
+                self,
+                ty_params,
+                /* match_num_and_int*/ true,
+            );
+            match rel {
+                None => (),
+                Some(unifier) => {
+                    let (subst_lhs, _) = unifier.decompose();
+                    if subst_lhs.is_empty() {
+                        inv_ids.extend(val.clone());
+                    }
+                }
+            }
         }
+        inv_ids
     }
 
     pub fn get_global_invariants_by_module(&self, module_id: ModuleId) -> BTreeSet<GlobalId> {

--- a/language/move-model/src/ty.rs
+++ b/language/move-model/src/ty.rs
@@ -605,6 +605,10 @@ impl TypeUnification {
         }
     }
 
+    pub fn decompose(self) -> (BTreeMap<Type, Type>, BTreeMap<Type, Type>) {
+        (self.subst_lhs, self.subst_rhs)
+    }
+
     fn extract_subst(&mut self, ty: &Type, subst: &BTreeMap<Type, Type>, is_lhs: bool) {
         ty.visit(&mut |t| match t {
             Type::TypeParameter(_) | Type::TypeLocal(_) => match subst.get(t) {

--- a/language/move-prover/bytecode/src/function_target_pipeline.rs
+++ b/language/move-prover/bytecode/src/function_target_pipeline.rs
@@ -20,6 +20,22 @@ pub struct FunctionTargetsHolder {
     targets: BTreeMap<QualifiedId<FunId>, BTreeMap<FunctionVariant, FunctionData>>,
 }
 
+/// Describes a function verification flavor.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum VerificationFlavor {
+    Regular,
+    Inconsistency,
+}
+
+impl std::fmt::Display for VerificationFlavor {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VerificationFlavor::Regular => write!(f, ""),
+            VerificationFlavor::Inconsistency => write!(f, "inconsistency"),
+        }
+    }
+}
+
 /// Describes a function target variant.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum FunctionVariant {
@@ -28,8 +44,8 @@ pub enum FunctionVariant {
     Baseline,
     /// A variant which is instrumented for verification. Only functions which are target
     /// of verification have one of those. There can be multiple verification variants,
-    /// identified by a well-known string.
-    Verification(&'static str),
+    /// each identified by a unique flavor.
+    Verification(VerificationFlavor),
 }
 
 impl FunctionVariant {
@@ -38,22 +54,13 @@ impl FunctionVariant {
     }
 }
 
-/// The variant for regular verification.
-pub const REGULAR_VERIFICATION_VARIANT: &str = "";
-pub const INCONSISTENCY_CHECK_VARIANT: &str = "inconsistency";
-
 impl std::fmt::Display for FunctionVariant {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         use FunctionVariant::*;
         match self {
             Baseline => write!(f, "baseline"),
-            Verification(s) => {
-                if s.is_empty() {
-                    write!(f, "verification")
-                } else {
-                    write!(f, "verification[{}]", s)
-                }
-            }
+            Verification(VerificationFlavor::Regular) => write!(f, "verification"),
+            Verification(v) => write!(f, "verification[{}]", v),
         }
     }
 }

--- a/language/move-prover/bytecode/src/global_invariant_instrumentation.rs
+++ b/language/move-prover/bytecode/src/global_invariant_instrumentation.rs
@@ -126,13 +126,15 @@ impl<'a> Instrumenter<'a> {
         // in dependent modules and from which the code should therefore not depend on, apart
         // of for the update itself.
         let env = self.builder.global_env();
+        let ty_params = self.builder.get_target().get_type_parameters();
         let mut invariants = BTreeSet::new();
         let mut invariants_for_modified_memory = BTreeSet::new();
         for mem in usage_analysis::get_used_memory_inst(&self.builder.get_target()).iter() {
-            invariants.extend(env.get_global_invariants_for_memory(mem));
+            invariants.extend(env.get_global_invariants_for_memory(&ty_params, mem));
         }
         for mem in usage_analysis::get_modified_memory_inst(&self.builder.get_target()).iter() {
-            invariants_for_modified_memory.extend(env.get_global_invariants_for_memory(mem));
+            invariants_for_modified_memory
+                .extend(env.get_global_invariants_for_memory(&ty_params, mem));
         }
 
         let mut assumed_at_update = BTreeSet::new();
@@ -267,7 +269,8 @@ impl<'a> Instrumenter<'a> {
         mem: &QualifiedInstId<StructId>,
     ) -> Vec<&'a GlobalInvariant> {
         let env = self.builder.global_env();
-        env.get_global_invariants_for_memory(mem)
+        let ty_params = self.builder.get_target().get_type_parameters();
+        env.get_global_invariants_for_memory(&ty_params, mem)
             .iter()
             .filter_map(|id| {
                 env.get_global_invariant(*id)

--- a/language/move-prover/bytecode/src/global_invariant_instrumentation_v2.rs
+++ b/language/move-prover/bytecode/src/global_invariant_instrumentation_v2.rs
@@ -89,12 +89,6 @@ impl<'a> Instrumenter<'a> {
         let target_invariants = &inv_ana_data.target_invariants;
 
         // Emit entrypoint assumptions if this is a verification entry.
-        // let assumed_at_update = if self.builder.data.variant.is_verified() {
-        //     self.instrument_entrypoint()
-        // } else {
-        //     BTreeSet::new()
-        // };
-
         if self.builder.data.variant.is_verified() {
             let fun_id = fun_env.get_qualified_id();
 
@@ -150,30 +144,36 @@ impl<'a> Instrumenter<'a> {
 
     /// Returns list of invariant ids to be assumed at the beginning of the current function.
     fn compute_entrypoint_invariants(&mut self) -> BTreeSet<GlobalId> {
-        // Emit an assume of each invariant over memory touched by this function, and which
-        // are declared in this module or transitively dependent modules.
+        // Emit an assume of each invariant over memory touched by this function.
+        // Such invariants include
+        // - invariants declared in this module, or
+        // - invariants declared in transitively dependent modules
         //
-        // Excludes invariants (a) those which are marked by the user
-        // explicitly as `[isolated]` (b) those which are not declared
-        // in dependent modules of the module defining the function
-        // (which may not be the target module) and upon which the
-        // code should therefore not depend, apart from the update
-        // itself.
+        // Excludes invariants that
+        // - are marked by the user explicitly as `[isolated]`, or
+        // - are not declared in dependent modules of the module defining the
+        //   function (which may not be the target module) and upon which the
+        //   code should therefore not depend, apart from the update itself.
+
         let env = self.builder.global_env();
+        let ty_params = self.builder.get_target().get_type_parameters();
         // Invariants with types that are read or written by the function
         let mut invariants_for_used_memory = BTreeSet::new();
         // Invariants with types that are written by the function
         let mut invariants_for_modified_memory = BTreeSet::new();
-        // get memory (list of structs) read or written by the function target, then find all invariants in loaded
-        // modules that refer to that memory.
+        // get memory (list of structs) read or written by the function target, then find all
+        // invariants in loaded modules that refer to that memory.
         for mem in usage_analysis::get_used_memory_inst(&self.builder.get_target()).iter() {
-            invariants_for_used_memory.extend(env.get_global_invariants_for_memory(mem));
+            invariants_for_used_memory
+                .extend(env.get_global_invariants_for_memory(&ty_params, mem));
         }
-        // get memory (list of structs) written by function, find the invariants referring to that memory.
-        // Also called "invariants updated by the function"
+        // get memory (list of structs) written by function, find the invariants referring to that
+        // memory. Also called "invariants updated by the function"
         for mem in usage_analysis::get_modified_memory_inst(&self.builder.get_target()).iter() {
-            invariants_for_modified_memory.extend(env.get_global_invariants_for_memory(mem));
+            invariants_for_modified_memory
+                .extend(env.get_global_invariants_for_memory(&ty_params, mem));
         }
+
         let module_env = &self.builder.fun_env.module_env;
         invariants_for_used_memory
             .iter()
@@ -338,16 +338,21 @@ impl<'a> Instrumenter<'a> {
         entrypoint_invariants: &BTreeSet<GlobalId>,
     ) {
         // When invariants are enabled during the body of the current function, add asserts after
-        // the writeback for each invariant that the writeback could modify.
+        // the operation for each invariant that the operation could modify. Such an operation
+        // includes write-backs to a GlobalRoot or MoveTo/MoveFrom a location in the global storage.
         let target_invariants = &inv_ana_data.target_invariants;
         let disabled_inv_fun_set = &inv_ana_data.disabled_inv_fun_set;
         let non_inv_fun_set = &inv_ana_data.non_inv_fun_set;
         if !disabled_inv_fun_set.contains(&fun_id) && !non_inv_fun_set.contains(&fun_id) {
+            let env = self.builder.global_env();
+            let ty_params = self.builder.get_target().get_type_parameters();
+
             // consider only the invariants that are modified by instruction
-            let modified_invariants = self
-                .builder
-                .global_env()
-                .get_subset_invariants_for_memory(mem.clone(), target_invariants);
+            let modified_invariants = env
+                .get_global_invariants_for_memory(&ty_params, mem)
+                .intersection(target_invariants)
+                .copied()
+                .collect();
             self.emit_assumes_and_saves_before_bytecode(modified_invariants, entrypoint_invariants);
             // put out the modifying instruction byte code.
             self.builder.emit(bc.clone());

--- a/language/move-prover/interpreter/src/shared/variant.rs
+++ b/language/move-prover/interpreter/src/shared/variant.rs
@@ -3,9 +3,7 @@
 
 use bytecode::{
     function_target::FunctionTarget,
-    function_target_pipeline::{
-        FunctionTargetsHolder, FunctionVariant, REGULAR_VERIFICATION_VARIANT,
-    },
+    function_target_pipeline::{FunctionTargetsHolder, FunctionVariant, VerificationFlavor},
 };
 use move_model::model::FunctionEnv;
 
@@ -23,7 +21,7 @@ pub fn choose_variant<'env>(
                     target_variant = Some(target);
                 }
             }
-            FunctionVariant::Verification(REGULAR_VERIFICATION_VARIANT) => {
+            FunctionVariant::Verification(VerificationFlavor::Regular) => {
                 target_variant = Some(target);
             }
             _ => (),

--- a/language/move-prover/tests/sources/functional/invariants_with_generics.exp
+++ b/language/move-prover/tests/sources/functional/invariants_with_generics.exp
@@ -1,0 +1,18 @@
+Move prover returns: exiting with boogie verification errors
+error: global memory invariant does not hold
+
+    ┌── tests/sources/functional/invariants_with_generics.move:34:5 ───
+    │
+ 34 │ ╭     invariant
+ 35 │ │         exists<S::Storage<u64, bool>>(@0x22)
+ 36 │ │             ==> global<S::Storage<u64, bool>>(@0x22).x == 1;
+    │ ╰────────────────────────────────────────────────────────────^
+    │
+    =     at tests/sources/functional/invariants_with_generics.move:10: publish_u64_bool
+    =         account = <redacted>
+    =         x = <redacted>
+    =         y = <redacted>
+    =     at tests/sources/functional/invariants_with_generics.move:11: publish_u64_bool
+    =     at tests/sources/functional/invariants_with_generics.move:10: publish_u64_bool
+    =     at tests/sources/functional/invariants_with_generics.move:11: publish_u64_bool
+    =     at tests/sources/functional/invariants_with_generics.move:34

--- a/language/move-prover/tests/sources/functional/invariants_with_generics.exp
+++ b/language/move-prover/tests/sources/functional/invariants_with_generics.exp
@@ -1,18 +1,10 @@
-Move prover returns: exiting with boogie verification errors
-error: global memory invariant does not hold
+Move prover returns: exiting with boogie generation errors
+error: Type quantification not supported by this backend.
 
-    ┌── tests/sources/functional/invariants_with_generics.move:34:5 ───
+    ┌── tests/sources/functional/invariants_with_generics.move:52:9 ───
     │
- 34 │ ╭     invariant
- 35 │ │         exists<S::Storage<u64, bool>>(@0x22)
- 36 │ │             ==> global<S::Storage<u64, bool>>(@0x22).x == 1;
-    │ ╰────────────────────────────────────────────────────────────^
+ 52 │ ╭         forall t1: type, t2: type:
+ 53 │ │             (exists<S::Storage<t1, t2>>(@0x22) && exists<S::Storage<t1, t2>>(@0x23))
+ 54 │ │                 ==> global<S::Storage<t1, t2>>(@0x22) == global<S::Storage<t1, t2>>(@0x23);
+    │ ╰──────────────────────────────────────────────────────────────────────────────────────────^
     │
-    =     at tests/sources/functional/invariants_with_generics.move:10: publish_u64_bool
-    =         account = <redacted>
-    =         x = <redacted>
-    =         y = <redacted>
-    =     at tests/sources/functional/invariants_with_generics.move:11: publish_u64_bool
-    =     at tests/sources/functional/invariants_with_generics.move:10: publish_u64_bool
-    =     at tests/sources/functional/invariants_with_generics.move:11: publish_u64_bool
-    =     at tests/sources/functional/invariants_with_generics.move:34

--- a/language/move-prover/tests/sources/functional/invariants_with_generics.move
+++ b/language/move-prover/tests/sources/functional/invariants_with_generics.move
@@ -1,0 +1,64 @@
+address 0x2 {
+module S {
+    struct Storage<X: store, Y: store> has key {
+        x: X,
+        y: Y,
+        v: u8,
+    }
+
+    // F1: <concrete, concrete>
+	public fun publish_u64_bool(account: signer, x: u64, y: bool) {
+	    move_to(&account, Storage { x, y, v: 0 })
+	}
+
+    // F2: <concrete, generic>
+	public fun publish_u64_y<Y: store>(account: signer, x: u64, y: Y) {
+	    move_to(&account, Storage { x, y, v: 1 })
+	}
+
+    // F3: <generic, concrete>
+	public fun publish_x_bool<X: store>(account: signer, x: X, y: bool) {
+	    move_to(&account, Storage { x, y, v: 2 })
+	}
+
+    // F4: <generic, generic>
+	public fun publish_x_y<X: store, Y: store>(account: signer, x: X, y: Y) {
+	    move_to(&account, Storage { x, y, v: 3 })
+	}
+}
+
+module A {
+    use 0x2::S;
+
+    // I1: <concrete, concrete>
+    invariant
+        exists<S::Storage<u64, bool>>(@0x22)
+            ==> global<S::Storage<u64, bool>>(@0x22).x == 1;
+
+    // I2: <concrete, generic>
+    invariant
+        forall t: type:
+            exists<S::Storage<u64, t>>(@0x22)
+                ==> global<S::Storage<u64, t>>(@0x22).x > 0;
+
+    // I3: <generic, concrete>
+    invariant
+        forall t: type:
+            exists<S::Storage<t, bool>>(@0x22)
+                ==> global<S::Storage<t, bool>>(@0x22).y;
+
+    // I4: <generic, generic>
+    invariant
+        forall t1: type, t2: type:
+            (exists<S::Storage<t1, t2>>(@0x22) && exists<S::Storage<t1, t2>>(@0x23))
+                ==> global<S::Storage<t1, t2>>(@0x22) == global<S::Storage<t1, t2>>(@0x23);
+
+    public fun good(account1: signer, account2: signer) {
+        S::publish_x_y<u64, bool>(account1, 1, true);
+        S::publish_x_y<u64, bool>(account2, 1, true);
+    }
+}
+}
+
+// TODO (mengxu): none of I1, I2, I3, I4 should verify in any of F1, F2, F3, F4. But currently
+// we can only disapprove I1 in F1.

--- a/language/move-prover/tests/sources/functional/invariants_with_resource_leak.move
+++ b/language/move-prover/tests/sources/functional/invariants_with_resource_leak.move
@@ -1,0 +1,40 @@
+address 0x2 {
+module S {
+    struct Storage<T: store> has key {
+        value: T
+    }
+
+	public fun publish<T: store>(account: signer, value: T) {
+	    move_to<Storage<T>>(&account, Storage { value })
+	}
+}
+
+module W {
+    use 0x2::S;
+
+    struct Wrap has store {
+        content: u64
+    }
+
+    invariant
+        exists<S::Storage<Wrap>>(@0x22)
+            ==> global<S::Storage<Wrap>>(@0x22).value.content > 0;
+
+    public fun make_wrap(content: u64): Wrap {
+        Wrap { content }
+    }
+}
+
+// NOTE: the global invariant in module W does not hold as we can construct the following module
+// that violates the invariant
+
+module Evil {
+    use 0x2::S;
+    use 0x2::W;
+
+    public fun evil(account: signer) {
+        let w = W::make_wrap(0);
+        S::publish<W::Wrap>(account, w)
+    }
+}
+}


### PR DESCRIPTION
The problem of checking global invariants in a generic context can be
better illustrated with this PR, especially, in the test case
`invariants_with_generics.move`.

1/
Suppose that a function `F` uses/modifies a memory resource of
type `MyResource<X1, X2, ..., Xn>`, and a global invariant `I` talks
about the resource type `MyResource<Y1, Y2, ..., Yn>`
(where all `Xs` and `Ys` can be either concrete or generic),
we say that we should evaluate `I` in `F` if **for each pair `(Xi, Yi)`,
we can unify the two types**.

By saying we can unify `(Xi, Yi)`, we mean: we check whether we get
- `Xi` and `Yi` match
  (i.e., both are the same concrete type or the same generic type variable)
- We can get one by instantiating the other
  (i.e., `Xi` is a generic type and `Yi` is a concrete type),
- We can find an appropriate assignment for type variables in `Xi` and `Yi`
  (e.g., `Xi: S<bool, T1>, Yi: S<T2, u64>`. Then `Xi` and `Yi` can be instantiated
   from `S: <T1, T2>`, where `T1 := u64`, `T2 := bool`.

2/
Now, with the concept of `TypeUnification` (which is also implemented in
a `TypeUnification` enum), we can further illustrated
the problem of checking global invariants in a generic context:

If a global invariant `I` talks about a generic resource, e.g., `S<X, Y>`,
and a function `f` might also be parameterized `f<X, Y>`. Then, there
should be a procedure to decide whether a global invariant `I` should
be checked in the body of `f`.

To put into the terms of `TypeUnification`, we have the following relation
in the `invariants_with_generics.move` test case:

```                        
                        F_inst                  I_inst
f<u64, bool>
  I<u64, bool>          -                       -
  I<u64, Y2>            -                       Y2 := bool
  I<Y1, bool>           -                       Y1 := u64
  I<Y1, Y2>             -                       Y1 := u64, Y2 := bool

f<u64, X2>
  I<u64, bool>          X2 := bool              -
  I<u64, Y2>            -                       Y2 := X2
  I<Y1, bool>           X2 := bool              Y1 := u64
  I<Y1, Y2>             -                       Y1 := u64, Y2 := X2

f<X1, bool>
  I<u64, bool>          X1 := u64               -
  I<u64, Y2>            X1 := u64               Y2 := bool
  I<Y1, bool>           -                       Y1 := X1
  I<Y1, Y2>             -                       Y1 := X1, Y2 := bool

f<X1, X2>
  I<u64, bool>          X1 := u64, X2 := bool   -
  I<u64, Y2>            X1 := U64               Y2 := X2
  I<Y1, bool>           X2 := bool              Y1 := X1
  I<Y1, Y2>             -                       Y1 := X1, Y2 := X2
```

In the old behavior (and in current simulation), only the ones marked
with `-` on the `F_inst` side are checked (i.e., I is checked in f)
but in theory, all pairs should be checked.

## Motivation

This PR tracks the investigation on the issues in checking
global invariants with generics.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI, new test cases are added
