### PR TITLE
[decoupled-execution] Execution phase

### DIFF
--- a/consensus/src/experimental/execution_phase.rs
+++ b/consensus/src/experimental/execution_phase.rs
@@ -1,0 +1,60 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use channel::{Receiver, Sender};
+use consensus_types::{block::Block, executed_block::ExecutedBlock};
+use diem_types::ledger_info::LedgerInfoWithSignatures;
+use execution_correctness::ExecutionCorrectness;
+use executor_types::Error as ExecutionError;
+use futures::{SinkExt, StreamExt};
+
+/// [ This class is used when consensus.decoupled = true ]
+/// ExecutionPhase is a singleton that receives ordered blocks from
+/// the ordering state computer and execute them. After the execution is done,
+/// ExecutionPhase sends the ordered blocks to the commit phase.
+pub struct ExecutionPhase {
+    executor_channel_recv: Receiver<(Vec<Block>, LedgerInfoWithSignatures)>,
+    execution_correctness_client: Box<dyn ExecutionCorrectness + Send + Sync>,
+    commit_channel_send: Sender<(Vec<ExecutedBlock>, LedgerInfoWithSignatures)>,
+}
+
+impl ExecutionPhase {
+    pub fn new(
+        executor_channel_recv: Receiver<(Vec<Block>, LedgerInfoWithSignatures)>,
+        execution_correctness_client: Box<dyn ExecutionCorrectness + Send + Sync>,
+        commit_channel_send: Sender<(Vec<ExecutedBlock>, LedgerInfoWithSignatures)>,
+    ) -> Self {
+        Self {
+            executor_channel_recv,
+            execution_correctness_client,
+            commit_channel_send,
+        }
+    }
+
+    pub async fn start(mut self) {
+        // main loop
+        while let Some((vecblock, ledger_info)) = self.executor_channel_recv.next().await {
+            // execute the blocks with execution_correctness_client
+            let executed_blocks: Vec<ExecutedBlock> = vecblock
+                .into_iter()
+                .map(|b| {
+                    let state_compute_result = self
+                        .execution_correctness_client
+                        .execute_block(b.clone(), b.parent_id())
+                        .unwrap();
+                    ExecutedBlock::new(b, state_compute_result)
+                })
+                .collect();
+            // TODO: add error handling.
+
+            // pass the executed blocks into the commit phase
+            self.commit_channel_send
+                .send((executed_blocks, ledger_info))
+                .await
+                .map_err(|e| ExecutionError::InternalError {
+                    error: e.to_string(),
+                })
+                .unwrap();
+        }
+    }
+}

--- a/consensus/src/experimental/mod.rs
+++ b/consensus/src/experimental/mod.rs
@@ -1,4 +1,24 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+// [Decoupled Execution]
+//
+//                 Execution
+//  Consensus      Phase          Commit Phase
+// ┌─────────┐    ┌─────────┐    ┌─────────────┐
+// │ Ordered ├───►│ Execute ├───►│ Send Commit │
+// │ Blocks  │    │         │    │ Proposal    │
+// └─────────┘    └─────────┘    └─────────────┘
+//                                     ▼
+//                               ┌─────────────┐    ┌──────────┐
+//                               │ Signature   ├───►│ Commit   │
+//                               │ Aggregation │    │ Blocks   │
+//                               └─────────────┘    └──────────┘
+//                                     ▼
+//                               ┌─────────────┐
+//                               │ Send Commit │
+//                               │ Decision    │ (Asynchronously)
+//                               └─────────────┘
+
+pub mod execution_phase;
 pub mod ordering_state_computer;


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We added a new struct ExecutionPhase. ExecutionPhase is a singleton that receives ordered blocks from the ordering state computer and execute them. After the execution is done, ExecutionPhase sends the ordered blocks to the commit phase.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

We will add unit tests later after we finish integration.

## Related PRs

(If this PR adds or changes functionality, please take some time to update or suggest changes to the docs at https://developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
