### PR TITLE
[move] Remove `into_module` from disassembler, bytecode-source-map, and move-bytecode-viewer

### DIFF
--- a/language/compiler/bytecode-source-map/src/mapping.rs
+++ b/language/compiler/bytecode-source-map/src/mapping.rs
@@ -3,13 +3,13 @@
 
 use crate::{marking::MarkedSourceMapping, source_map::SourceMap};
 use anyhow::Result;
-use move_binary_format::file_format::{CompiledModule, CompiledScript};
+use move_binary_format::binary_views::BinaryIndexedView;
 
 /// An object that associates source code with compiled bytecode and source map.
 #[derive(Debug)]
-pub struct SourceMapping<Location: Clone + Eq> {
+pub struct SourceMapping<'a, Location: Clone + Eq> {
     // The resulting bytecode from compiling the source map
-    pub bytecode: CompiledModule,
+    pub bytecode: BinaryIndexedView<'a>,
 
     // The source map for the bytecode made w.r.t. to the `source_code`
     pub source_map: SourceMap<Location>,
@@ -24,8 +24,8 @@ pub struct SourceMapping<Location: Clone + Eq> {
     pub marks: Option<MarkedSourceMapping>,
 }
 
-impl<Location: Clone + Eq> SourceMapping<Location> {
-    pub fn new(source_map: SourceMap<Location>, bytecode: CompiledModule) -> Self {
+impl<'a, Location: Clone + Eq> SourceMapping<'a, Location> {
+    pub fn new(source_map: SourceMap<Location>, bytecode: BinaryIndexedView<'a>) -> Self {
         Self {
             source_map,
             bytecode,
@@ -34,17 +34,10 @@ impl<Location: Clone + Eq> SourceMapping<Location> {
         }
     }
 
-    pub fn new_from_module(bytecode: CompiledModule, default_loc: Location) -> Result<Self> {
+    pub fn new_from_view(bytecode: BinaryIndexedView<'a>, default_loc: Location) -> Result<Self> {
         Ok(Self::new(
-            SourceMap::dummy_from_module(&bytecode, default_loc)?,
+            SourceMap::dummy_from_view(&bytecode, default_loc)?,
             bytecode,
-        ))
-    }
-
-    pub fn new_from_script(bytecode: CompiledScript, default_loc: Location) -> Result<Self> {
-        Ok(Self::new(
-            SourceMap::dummy_from_script(&bytecode, default_loc)?,
-            bytecode.into_module(),
         ))
     }
 

--- a/language/compiler/bytecode-source-map/src/source_map.rs
+++ b/language/compiler/bytecode-source-map/src/source_map.rs
@@ -5,9 +5,8 @@ use anyhow::{format_err, Result};
 use move_binary_format::{
     binary_views::BinaryIndexedView,
     file_format::{
-        CodeOffset, CompiledModule, CompiledScript, ConstantPoolIndex, FunctionDefinition,
-        FunctionDefinitionIndex, LocalIndex, MemberCount, ModuleHandleIndex, StructDefinition,
-        StructDefinitionIndex, TableIndex,
+        CodeOffset, ConstantPoolIndex, FunctionDefinition, FunctionDefinitionIndex, LocalIndex,
+        MemberCount, ModuleHandleIndex, StructDefinition, StructDefinitionIndex, TableIndex,
     },
 };
 use move_core_types::{account_address::AccountAddress, identifier::Identifier};
@@ -532,7 +531,9 @@ impl<Location: Clone + Eq> SourceMap<Location> {
             .ok_or_else(|| format_err!("Unable to get struct source map"))
     }
 
-    fn dummy_impl(view: &BinaryIndexedView, default_loc: Location) -> Result<Self> {
+    /// Create a 'dummy' source map for a compiled module or script. This is useful for e.g. disassembling
+    /// with generated or real names depending upon if the source map is available or not.
+    pub fn dummy_from_view(view: &BinaryIndexedView, default_loc: Location) -> Result<Self> {
         let module_handle = view.module_handle_at(ModuleHandleIndex::new(0));
         let module_name = ModuleName::new(view.identifier_at(module_handle.name).to_string());
         let address = *view.address_identifier_at(module_handle.address);
@@ -572,16 +573,6 @@ impl<Location: Clone + Eq> SourceMap<Location> {
         }
 
         Ok(empty_source_map)
-    }
-
-    /// Create a 'dummy' source map for a compiled module. This is useful for e.g. disassembling
-    /// with generated or real names depending upon if the source map is available or not.
-    pub fn dummy_from_module(module: &CompiledModule, default_loc: Location) -> Result<Self> {
-        Self::dummy_impl(&BinaryIndexedView::Module(module), default_loc)
-    }
-
-    pub fn dummy_from_script(script: &CompiledScript, default_loc: Location) -> Result<Self> {
-        Self::dummy_impl(&BinaryIndexedView::Script(script), default_loc)
     }
 
     pub fn remap_locations<Other: Clone + Eq>(

--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -41,6 +41,7 @@ use bytecode_source_map::{mapping::SourceMapping, source_map::SourceMap};
 use disassembler::disassembler::{Disassembler, DisassemblerOptions};
 use move_binary_format::{
     access::ModuleAccess,
+    binary_views::BinaryIndexedView,
     file_format::{
         AddressIdentifierIndex, Bytecode, Constant as VMConstant, ConstantPoolIndex,
         FunctionDefinitionIndex, FunctionHandleIndex, SignatureIndex, SignatureToken,
@@ -2032,7 +2033,7 @@ impl<'env> ModuleEnv<'env> {
         let disas = Disassembler::new(
             SourceMapping::new(
                 self.data.source_map.clone(),
-                self.get_verified_module().clone(),
+                BinaryIndexedView::Module(self.get_verified_module()),
             ),
             DisassemblerOptions {
                 only_externally_visible: false,

--- a/language/tools/move-bytecode-viewer/src/bytecode_viewer.rs
+++ b/language/tools/move-bytecode-viewer/src/bytecode_viewer.rs
@@ -6,7 +6,7 @@ use crate::interfaces::LeftScreen;
 use bytecode_source_map::{mapping::SourceMapping, source_map::SourceMap};
 use disassembler::disassembler::{Disassembler, DisassemblerOptions};
 use move_binary_format::{
-    access::ModuleAccess,
+    binary_views::BinaryIndexedView,
     file_format::{CodeOffset, CompiledModule, FunctionDefinitionIndex},
 };
 use move_ir_types::location::Loc;
@@ -21,14 +21,15 @@ pub struct BytecodeInfo {
 }
 
 #[derive(Clone, Debug)]
-pub struct BytecodeViewer {
+pub struct BytecodeViewer<'a> {
     pub lines: Vec<String>,
-    pub module: CompiledModule,
+    pub view: BinaryIndexedView<'a>,
     pub line_map: HashMap<usize, BytecodeInfo>,
 }
 
-impl BytecodeViewer {
-    pub fn new(source_map: SourceMap<Loc>, module: CompiledModule) -> Self {
+impl<'a> BytecodeViewer<'a> {
+    pub fn new(source_map: SourceMap<Loc>, module: &'a CompiledModule) -> Self {
+        let view = BinaryIndexedView::Module(module);
         let source_mapping = SourceMapping::new(source_map, module.clone());
         let options = DisassemblerOptions {
             print_code: true,
@@ -42,7 +43,7 @@ impl BytecodeViewer {
         let mut base_viewer = Self {
             lines: disassembled_string.lines().map(|x| x.to_string()).collect(),
             line_map: HashMap::new(),
-            module,
+            view,
         };
         base_viewer.build_mapping();
         base_viewer
@@ -56,14 +57,15 @@ impl BytecodeViewer {
         let mut line_map = HashMap::new();
 
         let function_def_for_name: HashMap<String, u16> = self
-            .module
+            .view
             .function_defs()
-            .iter()
+            .into_iter()
+            .flatten()
             .enumerate()
             .map(|(index, fdef)| {
                 (
-                    self.module
-                        .identifier_at(self.module.function_handle_at(fdef.function).name)
+                    self.view
+                        .identifier_at(self.view.function_handle_at(fdef.function).name)
                         .to_string(),
                     index as u16,
                 )
@@ -97,7 +99,7 @@ impl BytecodeViewer {
     }
 }
 
-impl LeftScreen for BytecodeViewer {
+impl LeftScreen for BytecodeViewer<'_> {
     type SourceIndex = BytecodeInfo;
 
     fn get_source_index_for_line(&self, line: usize, _column: usize) -> Option<&Self::SourceIndex> {

--- a/language/tools/move-bytecode-viewer/src/bytecode_viewer.rs
+++ b/language/tools/move-bytecode-viewer/src/bytecode_viewer.rs
@@ -30,7 +30,7 @@ pub struct BytecodeViewer<'a> {
 impl<'a> BytecodeViewer<'a> {
     pub fn new(source_map: SourceMap<Loc>, module: &'a CompiledModule) -> Self {
         let view = BinaryIndexedView::Module(module);
-        let source_mapping = SourceMapping::new(source_map, module.clone());
+        let source_mapping = SourceMapping::new(source_map, view);
         let options = DisassemblerOptions {
             print_code: true,
             print_basic_blocks: true,

--- a/language/tools/move-bytecode-viewer/src/main.rs
+++ b/language/tools/move-bytecode-viewer/src/main.rs
@@ -45,7 +45,7 @@ pub fn main() {
     let source_path = Path::new(&args.source_file_path);
     let module_viewer =
         ModuleViewer::new(compiled_module.clone(), source_map.clone(), &source_path);
-    let bytecode_viewer = BytecodeViewer::new(source_map, compiled_module);
+    let bytecode_viewer = BytecodeViewer::new(source_map, &compiled_module);
 
     let interface = Viewer::new(module_viewer, bytecode_viewer);
     start_tui_with_interface(interface).unwrap();

--- a/language/tools/move-bytecode-viewer/src/source_viewer.rs
+++ b/language/tools/move-bytecode-viewer/src/source_viewer.rs
@@ -40,7 +40,7 @@ impl ModuleViewer {
     }
 }
 
-impl RightScreen<BytecodeViewer> for ModuleViewer {
+impl<'a> RightScreen<BytecodeViewer<'a>> for ModuleViewer {
     fn source_for_code_location(&self, bytecode_info: &BytecodeInfo) -> Result<SourceContext> {
         let span = self
             .source_map


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The method `CompiledScript::into_module` is deprecated, and ideally it ought to be deleted. This set of commits aims to remove it from the `bytecode-source-map` module without otherwise changing the behavior of the compiler.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The existing suite of tests.

## Related PRs

This work is branched off of commits made as part of #8536; specifically, the commit named `[move] Bounds checker runs on script or module`, which adds methods to `BinaryIndexedView` that are used in this pull request.