### PR TITLE
[move-lang][error migration] Migrated naming/translate.rs

### DIFF
--- a/language/move-lang/src/errors/new.rs
+++ b/language/move-lang/src/errors/new.rs
@@ -95,7 +95,7 @@ fn render_diagnostic(
         primary_label,
         secondary_labels,
     } = diag;
-    let mut diag = csr::diagnostic::Diagnostic::new(info.severity);
+    let mut diag = csr::diagnostic::Diagnostic::new(info.severity.into_codespan_severity());
     let (code, message) = info.render();
     diag = diag.with_code(code);
     diag = diag.with_message(message);
@@ -161,7 +161,7 @@ macro_rules! diag {
     ($code: expr, $primary: expr $(,)?) => {{
         crate::errors::new::Diagnostic::new($code, $primary, std::iter::empty::<(Loc, String)>())
     }};
-    ($code: expr, $primary: expr, $($secondary: expr),+) => {{
+    ($code: expr, $primary: expr, $($secondary: expr),+ $(,)?) => {{
         crate::errors::new::Diagnostic::new($code, $primary, $(vec![$secondary, ])*)
     }};
 }

--- a/language/move-lang/tests/move_check/expansion/invalid_local_name.exp
+++ b/language/move-lang/tests/move_check/expansion/invalid_local_name.exp
@@ -1,17 +1,21 @@
+error[E03005]: unbound unscoped name
+  ┌─ tests/move_check/expansion/invalid_local_name.move:5:9
+  │
+5 │         No;
+  │         ^^ Unbound constant 'No'
+
+error[E03005]: unbound unscoped name
+   ┌─ tests/move_check/expansion/invalid_local_name.move:15:13
+   │
+15 │         F { No };
+   │             ^^ Unbound constant 'No'
+
 error: 
 
    ┌── tests/move_check/expansion/invalid_local_name.move:4:11 ───
    │
  4 │     fun t(No: u64) {
    │           ^^ Invalid local variable name 'No'. Local variable names must start with 'a'..'z' (or '_')
-   │
-
-error: 
-
-   ┌── tests/move_check/expansion/invalid_local_name.move:5:9 ───
-   │
- 5 │         No;
-   │         ^^ Unbound constant 'No'
    │
 
 error: 
@@ -28,14 +32,6 @@ error:
     │
  14 │         let No = 100;
     │             ^^ Invalid local variable name 'No'. Local variable names must start with 'a'..'z' (or '_')
-    │
-
-error: 
-
-    ┌── tests/move_check/expansion/invalid_local_name.move:15:13 ───
-    │
- 15 │         F { No };
-    │             ^^ Unbound constant 'No'
     │
 
 error: 

--- a/language/move-lang/tests/move_check/expansion/invalid_struct_name.exp
+++ b/language/move-lang/tests/move_check/expansion/invalid_struct_name.exp
@@ -1,3 +1,57 @@
+error[E03004]: unbound type
+  ┌─ tests/move_check/expansion/invalid_struct_name.move:3:19
+  │
+3 │     struct X { f: no }
+  │                   ^^ Unbound type 'no' in current scope
+
+error[E03004]: unbound type
+  ┌─ tests/move_check/expansion/invalid_struct_name.move:5:15
+  │
+5 │     fun mk(x: no): no {
+  │               ^^ Unbound type 'no' in current scope
+
+error[E03004]: unbound type
+  ┌─ tests/move_check/expansion/invalid_struct_name.move:5:20
+  │
+5 │     fun mk(x: no): no {
+  │                    ^^ Unbound type 'no' in current scope
+
+error[E03004]: unbound type
+  ┌─ tests/move_check/expansion/invalid_struct_name.move:6:9
+  │
+6 │         no {}
+  │         ^^ Unbound type 'no' in current scope
+
+error[E03004]: unbound type
+   ┌─ tests/move_check/expansion/invalid_struct_name.move:10:19
+   │
+10 │     struct Y { f: no }
+   │                   ^^ Unbound type 'no' in current scope
+
+error[E03004]: unbound type
+   ┌─ tests/move_check/expansion/invalid_struct_name.move:12:16
+   │
+12 │     fun mk2(x: no2): no2 {
+   │                ^^^ Unbound type 'no2' in current scope
+
+error[E03004]: unbound type
+   ┌─ tests/move_check/expansion/invalid_struct_name.move:12:22
+   │
+12 │     fun mk2(x: no2): no2 {
+   │                      ^^^ Unbound type 'no2' in current scope
+
+error[E03004]: unbound type
+   ┌─ tests/move_check/expansion/invalid_struct_name.move:13:13
+   │
+13 │         let no2 {} = x;
+   │             ^^^ Unbound type 'no2' in current scope
+
+error[E03004]: unbound type
+   ┌─ tests/move_check/expansion/invalid_struct_name.move:14:9
+   │
+14 │         no2 {}
+   │         ^^^ Unbound type 'no2' in current scope
+
 error: 
 
    ┌── tests/move_check/expansion/invalid_struct_name.move:2:12 ───
@@ -8,81 +62,9 @@ error:
 
 error: 
 
-   ┌── tests/move_check/expansion/invalid_struct_name.move:3:19 ───
-   │
- 3 │     struct X { f: no }
-   │                   ^^ Unbound type 'no' in current scope
-   │
-
-error: 
-
-   ┌── tests/move_check/expansion/invalid_struct_name.move:5:15 ───
-   │
- 5 │     fun mk(x: no): no {
-   │               ^^ Unbound type 'no' in current scope
-   │
-
-error: 
-
-   ┌── tests/move_check/expansion/invalid_struct_name.move:5:20 ───
-   │
- 5 │     fun mk(x: no): no {
-   │                    ^^ Unbound type 'no' in current scope
-   │
-
-error: 
-
-   ┌── tests/move_check/expansion/invalid_struct_name.move:6:9 ───
-   │
- 6 │         no {}
-   │         ^^ Unbound type 'no' in current scope
-   │
-
-error: 
-
    ┌── tests/move_check/expansion/invalid_struct_name.move:9:12 ───
    │
  9 │     struct no2 {}
    │            ^^^ Invalid struct name 'no2'. Struct names must start with 'A'..'Z'
    │
-
-error: 
-
-    ┌── tests/move_check/expansion/invalid_struct_name.move:10:19 ───
-    │
- 10 │     struct Y { f: no }
-    │                   ^^ Unbound type 'no' in current scope
-    │
-
-error: 
-
-    ┌── tests/move_check/expansion/invalid_struct_name.move:12:16 ───
-    │
- 12 │     fun mk2(x: no2): no2 {
-    │                ^^^ Unbound type 'no2' in current scope
-    │
-
-error: 
-
-    ┌── tests/move_check/expansion/invalid_struct_name.move:12:22 ───
-    │
- 12 │     fun mk2(x: no2): no2 {
-    │                      ^^^ Unbound type 'no2' in current scope
-    │
-
-error: 
-
-    ┌── tests/move_check/expansion/invalid_struct_name.move:13:13 ───
-    │
- 13 │         let no2 {} = x;
-    │             ^^^ Unbound type 'no2' in current scope
-    │
-
-error: 
-
-    ┌── tests/move_check/expansion/invalid_struct_name.move:14:9 ───
-    │
- 14 │         no2 {}
-    │         ^^^ Unbound type 'no2' in current scope
-    │
 

--- a/language/move-lang/tests/move_check/expansion/invalid_unpack_assign_mdot_no_struct.exp
+++ b/language/move-lang/tests/move_check/expansion/invalid_unpack_assign_mdot_no_struct.exp
@@ -1,10 +1,8 @@
-error: 
-
-   ┌── tests/move_check/expansion/invalid_unpack_assign_mdot_no_struct.move:3:9 ───
-   │
- 3 │         Self::f {} = 0;
-   │         ^^^^^^^ Invalid module access. Unbound struct 'f' in module '0x8675309::M'
-   │
+error[E03003]: unbound module member
+  ┌─ tests/move_check/expansion/invalid_unpack_assign_mdot_no_struct.move:3:9
+  │
+3 │         Self::f {} = 0;
+  │         ^^^^^^^ Invalid module access. Unbound struct 'f' in module '0x8675309::M'
 
 error: 
 

--- a/language/move-lang/tests/move_check/expansion/module_alias_as_type.exp
+++ b/language/move-lang/tests/move_check/expansion/module_alias_as_type.exp
@@ -1,16 +1,14 @@
+error[E03004]: unbound type
+  ┌─ tests/move_check/expansion/module_alias_as_type.move:7:16
+  │
+7 │     fun foo(x: X) {}
+  │                ^ Unbound type 'X' in current scope
+
 error: 
 
    ┌── tests/move_check/expansion/module_alias_as_type.move:6:14 ───
    │
  6 │     use 0x2::X;
    │              ^ Unused 'use' of alias 'X'. Consider removing it
-   │
-
-error: 
-
-   ┌── tests/move_check/expansion/module_alias_as_type.move:7:16 ───
-   │
- 7 │     fun foo(x: X) {}
-   │                ^ Unbound type 'X' in current scope
    │
 

--- a/language/move-lang/tests/move_check/expansion/unbound_named_address.exp
+++ b/language/move-lang/tests/move_check/expansion/unbound_named_address.exp
@@ -1,3 +1,36 @@
+error[E02010]: invalid 'friend' declaration
+  ┌─ tests/move_check/expansion/unbound_named_address.move:5:5
+  │
+5 │     friend C::M;
+  │     ^^^^^^^^^^^^
+  │     │      │
+  │     │      Cannot declare modules out of the current address as a friend
+  │     Invalid friend declaration
+
+error[E03002]: unbound module
+  ┌─ tests/move_check/expansion/unbound_named_address.move:9:12
+  │
+9 │         x: E::M::S,
+  │            ^^^^ Unbound module 'E::M'
+
+error[E03002]: unbound module
+   ┌─ tests/move_check/expansion/unbound_named_address.move:13:17
+   │
+13 │         let x = F::M::S {};
+   │                 ^^^^ Unbound module 'F::M'
+
+error[E03002]: unbound module
+   ┌─ tests/move_check/expansion/unbound_named_address.move:14:9
+   │
+14 │         G::M::foo();
+   │         ^^^^ Unbound module 'G::M'
+
+error[E03002]: unbound module
+   ┌─ tests/move_check/expansion/unbound_named_address.move:15:17
+   │
+15 │         let c = H::M::C;
+   │                 ^^^^ Unbound module 'H::M'
+
 error: 
 
    ┌── tests/move_check/expansion/unbound_named_address.move:2:8 ───
@@ -20,17 +53,6 @@ error:
    │
  3 │     use B::M;
    │         ^^^^ Invalid 'use'. Unbound module: 'B::M'
-   │
-
-error: 
-
-   ┌── tests/move_check/expansion/unbound_named_address.move:5:5 ───
-   │
- 5 │     friend C::M;
-   │     ^^^^^^^^^^^^ Invalid friend declaration
-   ·
- 5 │     friend C::M;
-   │            ---- Cannot declare modules out of the current address as a friend
    │
 
 error: 
@@ -67,26 +89,10 @@ error:
 
 error: 
 
-   ┌── tests/move_check/expansion/unbound_named_address.move:9:12 ───
-   │
- 9 │         x: E::M::S,
-   │            ^^^^ Unbound module 'E::M'
-   │
-
-error: 
-
     ┌── tests/move_check/expansion/unbound_named_address.move:13:17 ───
     │
  13 │         let x = F::M::S {};
     │                 ^ Unbound address 'F'
-    │
-
-error: 
-
-    ┌── tests/move_check/expansion/unbound_named_address.move:13:17 ───
-    │
- 13 │         let x = F::M::S {};
-    │                 ^^^^ Unbound module 'F::M'
     │
 
 error: 
@@ -99,26 +105,10 @@ error:
 
 error: 
 
-    ┌── tests/move_check/expansion/unbound_named_address.move:14:9 ───
-    │
- 14 │         G::M::foo();
-    │         ^^^^ Unbound module 'G::M'
-    │
-
-error: 
-
     ┌── tests/move_check/expansion/unbound_named_address.move:15:17 ───
     │
  15 │         let c = H::M::C;
     │                 ^ Unbound address 'H'
-    │
-
-error: 
-
-    ┌── tests/move_check/expansion/unbound_named_address.move:15:17 ───
-    │
- 15 │         let c = H::M::C;
-    │                 ^^^^ Unbound module 'H::M'
     │
 
 error: 

--- a/language/move-lang/tests/move_check/expansion/use_function_tparam_shadows.exp
+++ b/language/move-lang/tests/move_check/expansion/use_function_tparam_shadows.exp
@@ -1,8 +1,6 @@
-error: 
-
-    ┌── tests/move_check/expansion/use_function_tparam_shadows.move:10:9 ───
-    │
- 10 │         foo()
-    │         ^^^ Unbound function 'foo' in current scope
-    │
+error[E03005]: unbound unscoped name
+   ┌─ tests/move_check/expansion/use_function_tparam_shadows.move:10:9
+   │
+10 │         foo()
+   │         ^^^ Unbound function 'foo' in current scope
 

--- a/language/move-lang/tests/move_check/expansion/use_function_unbound.exp
+++ b/language/move-lang/tests/move_check/expansion/use_function_unbound.exp
@@ -1,3 +1,9 @@
+error[E03005]: unbound unscoped name
+  ┌─ tests/move_check/expansion/use_function_unbound.move:9:9
+  │
+9 │         u()
+  │         ^ Unbound function 'u' in current scope
+
 error: 
 
    ┌── tests/move_check/expansion/use_function_unbound.move:6:17 ───
@@ -7,13 +13,5 @@ error:
    ·
  2 │ module X {
    │        - Module '0x2::X' declared here
-   │
-
-error: 
-
-   ┌── tests/move_check/expansion/use_function_unbound.move:9:9 ───
-   │
- 9 │         u()
-   │         ^ Unbound function 'u' in current scope
    │
 

--- a/language/move-lang/tests/move_check/expansion/use_spec_schema_as_struct.exp
+++ b/language/move-lang/tests/move_check/expansion/use_spec_schema_as_struct.exp
@@ -1,8 +1,6 @@
-error: 
-
-    ┌── tests/move_check/expansion/use_spec_schema_as_struct.move:10:14 ───
-    │
- 10 │     fun t(): Foo<u64> {
-    │              ^^^ Invalid module access. Unbound struct 'Foo' in module '0x2::X'
-    │
+error[E03003]: unbound module member
+   ┌─ tests/move_check/expansion/use_spec_schema_as_struct.move:10:14
+   │
+10 │     fun t(): Foo<u64> {
+   │              ^^^ Invalid module access. Unbound struct 'Foo' in module '0x2::X'
 

--- a/language/move-lang/tests/move_check/expansion/use_struct_invalid_name.exp
+++ b/language/move-lang/tests/move_check/expansion/use_struct_invalid_name.exp
@@ -1,3 +1,9 @@
+error[E03004]: unbound type
+  ┌─ tests/move_check/expansion/use_struct_invalid_name.move:8:19
+  │
+8 │     struct X { f: u }
+  │                   ^ Unbound type 'u' in current scope
+
 error: 
 
    ┌── tests/move_check/expansion/use_struct_invalid_name.move:7:17 ───
@@ -7,13 +13,5 @@ error:
    ·
  2 │ module X {
    │        - Module '0x2::X' declared here
-   │
-
-error: 
-
-   ┌── tests/move_check/expansion/use_struct_invalid_name.move:8:19 ───
-   │
- 8 │     struct X { f: u }
-   │                   ^ Unbound type 'u' in current scope
    │
 

--- a/language/move-lang/tests/move_check/expansion/use_struct_unbound.exp
+++ b/language/move-lang/tests/move_check/expansion/use_struct_unbound.exp
@@ -1,3 +1,9 @@
+error[E03004]: unbound type
+  ┌─ tests/move_check/expansion/use_struct_unbound.move:8:19
+  │
+8 │     struct X { f: S }
+  │                   ^ Unbound type 'S' in current scope
+
 error: 
 
    ┌── tests/move_check/expansion/use_struct_unbound.move:6:17 ───
@@ -7,13 +13,5 @@ error:
    ·
  2 │ module X {
    │        - Module '0x2::X' declared here
-   │
-
-error: 
-
-   ┌── tests/move_check/expansion/use_struct_unbound.move:8:19 ───
-   │
- 8 │     struct X { f: S }
-   │                   ^ Unbound type 'S' in current scope
    │
 

--- a/language/move-lang/tests/move_check/naming/duplicate_acquires_list_item.exp
+++ b/language/move-lang/tests/move_check/naming/duplicate_acquires_list_item.exp
@@ -1,44 +1,32 @@
-error: 
+error[E02001]: duplicate declaration, item, or annotation
+  ┌─ tests/move_check/naming/duplicate_acquires_list_item.move:4:29
+  │
+4 │     fun t0() acquires R, X, R {
+  │                       -     ^ Duplicate acquires item
+  │                       │      
+  │                       Previously listed here
 
-   ┌── tests/move_check/naming/duplicate_acquires_list_item.move:4:29 ───
-   │
- 4 │     fun t0() acquires R, X, R {
-   │                             ^ Duplicate acquires item
-   ·
- 4 │     fun t0() acquires R, X, R {
-   │                       - Previously listed here
-   │
+error[E02001]: duplicate declaration, item, or annotation
+  ┌─ tests/move_check/naming/duplicate_acquires_list_item.move:8:29
+  │
+8 │     fun t1() acquires R, X, R, R, R {
+  │                       -     ^ Duplicate acquires item
+  │                       │      
+  │                       Previously listed here
 
-error: 
+error[E02001]: duplicate declaration, item, or annotation
+  ┌─ tests/move_check/naming/duplicate_acquires_list_item.move:8:32
+  │
+8 │     fun t1() acquires R, X, R, R, R {
+  │                             -  ^ Duplicate acquires item
+  │                             │   
+  │                             Previously listed here
 
-   ┌── tests/move_check/naming/duplicate_acquires_list_item.move:8:29 ───
-   │
- 8 │     fun t1() acquires R, X, R, R, R {
-   │                             ^ Duplicate acquires item
-   ·
- 8 │     fun t1() acquires R, X, R, R, R {
-   │                       - Previously listed here
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/duplicate_acquires_list_item.move:8:32 ───
-   │
- 8 │     fun t1() acquires R, X, R, R, R {
-   │                                ^ Duplicate acquires item
-   ·
- 8 │     fun t1() acquires R, X, R, R, R {
-   │                             - Previously listed here
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/duplicate_acquires_list_item.move:8:35 ───
-   │
- 8 │     fun t1() acquires R, X, R, R, R {
-   │                                   ^ Duplicate acquires item
-   ·
- 8 │     fun t1() acquires R, X, R, R, R {
-   │                                - Previously listed here
-   │
+error[E02001]: duplicate declaration, item, or annotation
+  ┌─ tests/move_check/naming/duplicate_acquires_list_item.move:8:35
+  │
+8 │     fun t1() acquires R, X, R, R, R {
+  │                                -  ^ Duplicate acquires item
+  │                                │   
+  │                                Previously listed here
 

--- a/language/move-lang/tests/move_check/naming/duplicate_type_parameter_function.exp
+++ b/language/move-lang/tests/move_check/naming/duplicate_type_parameter_function.exp
@@ -1,33 +1,24 @@
-error: 
+error[E02001]: duplicate declaration, item, or annotation
+  ┌─ tests/move_check/naming/duplicate_type_parameter_function.move:2:16
+  │
+2 │     fun foo<T, T>() {}
+  │             -  ^ Duplicate type parameter declared with name 'T'
+  │             │   
+  │             Previously defined here
 
-   ┌── tests/move_check/naming/duplicate_type_parameter_function.move:2:16 ───
-   │
- 2 │     fun foo<T, T>() {}
-   │                ^ Duplicate type parameter declared with name 'T'
-   ·
- 2 │     fun foo<T, T>() {}
-   │             - Previously defined here
-   │
+error[E02001]: duplicate declaration, item, or annotation
+  ┌─ tests/move_check/naming/duplicate_type_parameter_function.move:3:23
+  │
+3 │     fun foo2<T: drop, T: key, T>() {}
+  │              -        ^ Duplicate type parameter declared with name 'T'
+  │              │         
+  │              Previously defined here
 
-error: 
-
-   ┌── tests/move_check/naming/duplicate_type_parameter_function.move:3:23 ───
-   │
- 3 │     fun foo2<T: drop, T: key, T>() {}
-   │                       ^ Duplicate type parameter declared with name 'T'
-   ·
- 3 │     fun foo2<T: drop, T: key, T>() {}
-   │              - Previously defined here
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/duplicate_type_parameter_function.move:3:31 ───
-   │
- 3 │     fun foo2<T: drop, T: key, T>() {}
-   │                               ^ Duplicate type parameter declared with name 'T'
-   ·
- 3 │     fun foo2<T: drop, T: key, T>() {}
-   │              - Previously defined here
-   │
+error[E02001]: duplicate declaration, item, or annotation
+  ┌─ tests/move_check/naming/duplicate_type_parameter_function.move:3:31
+  │
+3 │     fun foo2<T: drop, T: key, T>() {}
+  │              -                ^ Duplicate type parameter declared with name 'T'
+  │              │                 
+  │              Previously defined here
 

--- a/language/move-lang/tests/move_check/naming/duplicate_type_parameter_struct.exp
+++ b/language/move-lang/tests/move_check/naming/duplicate_type_parameter_struct.exp
@@ -1,66 +1,48 @@
-error: 
+error[E02001]: duplicate declaration, item, or annotation
+  ┌─ tests/move_check/naming/duplicate_type_parameter_struct.move:2:17
+  │
+2 │     struct S<T, T> {}
+  │              -  ^ Duplicate type parameter declared with name 'T'
+  │              │   
+  │              Previously defined here
 
-   ┌── tests/move_check/naming/duplicate_type_parameter_struct.move:2:17 ───
-   │
- 2 │     struct S<T, T> {}
-   │                 ^ Duplicate type parameter declared with name 'T'
-   ·
- 2 │     struct S<T, T> {}
-   │              - Previously defined here
-   │
+error[E02001]: duplicate declaration, item, or annotation
+  ┌─ tests/move_check/naming/duplicate_type_parameter_struct.move:3:24
+  │
+3 │     struct S2<T: drop, T: key, T> {}
+  │               -        ^ Duplicate type parameter declared with name 'T'
+  │               │         
+  │               Previously defined here
 
-error: 
+error[E02001]: duplicate declaration, item, or annotation
+  ┌─ tests/move_check/naming/duplicate_type_parameter_struct.move:3:32
+  │
+3 │     struct S2<T: drop, T: key, T> {}
+  │               -                ^ Duplicate type parameter declared with name 'T'
+  │               │                 
+  │               Previously defined here
 
-   ┌── tests/move_check/naming/duplicate_type_parameter_struct.move:3:24 ───
-   │
- 3 │     struct S2<T: drop, T: key, T> {}
-   │                        ^ Duplicate type parameter declared with name 'T'
-   ·
- 3 │     struct S2<T: drop, T: key, T> {}
-   │               - Previously defined here
-   │
+error[E02001]: duplicate declaration, item, or annotation
+  ┌─ tests/move_check/naming/duplicate_type_parameter_struct.move:4:17
+  │
+4 │     struct R<T, T> {}
+  │              -  ^ Duplicate type parameter declared with name 'T'
+  │              │   
+  │              Previously defined here
 
-error: 
+error[E02001]: duplicate declaration, item, or annotation
+  ┌─ tests/move_check/naming/duplicate_type_parameter_struct.move:5:24
+  │
+5 │     struct R2<T: drop, T: key, T> {}
+  │               -        ^ Duplicate type parameter declared with name 'T'
+  │               │         
+  │               Previously defined here
 
-   ┌── tests/move_check/naming/duplicate_type_parameter_struct.move:3:32 ───
-   │
- 3 │     struct S2<T: drop, T: key, T> {}
-   │                                ^ Duplicate type parameter declared with name 'T'
-   ·
- 3 │     struct S2<T: drop, T: key, T> {}
-   │               - Previously defined here
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/duplicate_type_parameter_struct.move:4:17 ───
-   │
- 4 │     struct R<T, T> {}
-   │                 ^ Duplicate type parameter declared with name 'T'
-   ·
- 4 │     struct R<T, T> {}
-   │              - Previously defined here
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/duplicate_type_parameter_struct.move:5:24 ───
-   │
- 5 │     struct R2<T: drop, T: key, T> {}
-   │                        ^ Duplicate type parameter declared with name 'T'
-   ·
- 5 │     struct R2<T: drop, T: key, T> {}
-   │               - Previously defined here
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/duplicate_type_parameter_struct.move:5:32 ───
-   │
- 5 │     struct R2<T: drop, T: key, T> {}
-   │                                ^ Duplicate type parameter declared with name 'T'
-   ·
- 5 │     struct R2<T: drop, T: key, T> {}
-   │               - Previously defined here
-   │
+error[E02001]: duplicate declaration, item, or annotation
+  ┌─ tests/move_check/naming/duplicate_type_parameter_struct.move:5:32
+  │
+5 │     struct R2<T: drop, T: key, T> {}
+  │               -                ^ Duplicate type parameter declared with name 'T'
+  │               │                 
+  │               Previously defined here
 

--- a/language/move-lang/tests/move_check/naming/friend_decl_out_of_account_addr.exp
+++ b/language/move-lang/tests/move_check/naming/friend_decl_out_of_account_addr.exp
@@ -1,11 +1,9 @@
-error: 
-
-   ┌── tests/move_check/naming/friend_decl_out_of_account_addr.move:7:5 ───
-   │
- 7 │     friend 0x2::M;
-   │     ^^^^^^^^^^^^^^ Invalid friend declaration
-   ·
- 7 │     friend 0x2::M;
-   │            ------ Cannot declare modules out of the current address as a friend
-   │
+error[E02010]: invalid 'friend' declaration
+  ┌─ tests/move_check/naming/friend_decl_out_of_account_addr.move:7:5
+  │
+7 │     friend 0x2::M;
+  │     ^^^^^^^^^^^^^^
+  │     │      │
+  │     │      Cannot declare modules out of the current address as a friend
+  │     Invalid friend declaration
 

--- a/language/move-lang/tests/move_check/naming/friend_decl_self.exp
+++ b/language/move-lang/tests/move_check/naming/friend_decl_self.exp
@@ -1,22 +1,17 @@
-error: 
+error[E02010]: invalid 'friend' declaration
+  ┌─ tests/move_check/naming/friend_decl_self.move:3:5
+  │
+2 │ module M {
+  │        - Cannot declare the module itself as a friend
+3 │     friend Self;
+  │     ^^^^^^^^^^^^ Invalid friend declaration
 
-   ┌── tests/move_check/naming/friend_decl_self.move:3:5 ───
-   │
- 3 │     friend Self;
-   │     ^^^^^^^^^^^^ Invalid friend declaration
-   ·
- 2 │ module M {
-   │        - Cannot declare the module itself as a friend
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/friend_decl_self.move:9:5 ───
-   │
- 9 │     friend 0x43::M;
-   │     ^^^^^^^^^^^^^^^ Invalid friend declaration
-   ·
- 9 │     friend 0x43::M;
-   │            ------- Cannot declare the module itself as a friend
-   │
+error[E02010]: invalid 'friend' declaration
+  ┌─ tests/move_check/naming/friend_decl_self.move:9:5
+  │
+9 │     friend 0x43::M;
+  │     ^^^^^^^^^^^^^^^
+  │     │      │
+  │     │      Cannot declare the module itself as a friend
+  │     Invalid friend declaration
 

--- a/language/move-lang/tests/move_check/naming/friend_decl_unbound_module.exp
+++ b/language/move-lang/tests/move_check/naming/friend_decl_unbound_module.exp
@@ -1,4 +1,4 @@
-error[E02001]: unbound module
+error[E03002]: unbound module
   ┌─ tests/move_check/naming/friend_decl_unbound_module.move:3:12
   │
 3 │     friend 0x42::Nonexistent;

--- a/language/move-lang/tests/move_check/naming/generics_shadowing_invalid.exp
+++ b/language/move-lang/tests/move_check/naming/generics_shadowing_invalid.exp
@@ -1,3 +1,21 @@
+error[E03006]: unexpected name in this position
+  ┌─ tests/move_check/naming/generics_shadowing_invalid.move:8:20
+  │
+6 │     fun foo<S>(s1: S, s2: S): S {
+  │             - But 'S' was declared as a type parameter here
+7 │         (s1: Self::S);
+8 │         let s: S = S {}; // TODO error? should this try to construct the generic ?
+  │                    ^ Invalid construction. Expected a struct name
+
+error[E03006]: unexpected name in this position
+   ┌─ tests/move_check/naming/generics_shadowing_invalid.move:10:9
+   │
+ 6 │     fun foo<S>(s1: S, s2: S): S {
+   │             - But 'S' was declared as a type parameter here
+   ·
+10 │         S {}
+   │         ^ Invalid construction. Expected a struct name
+
 error: 
 
    ┌── tests/move_check/naming/generics_shadowing_invalid.move:7:14 ───
@@ -14,17 +32,6 @@ error:
 
 error: 
 
-   ┌── tests/move_check/naming/generics_shadowing_invalid.move:8:20 ───
-   │
- 8 │         let s: S = S {}; // TODO error? should this try to construct the generic ?
-   │                    ^ Invalid construction. Expected a struct name
-   ·
- 6 │     fun foo<S>(s1: S, s2: S): S {
-   │             - But 'S' was declared as a type parameter here
-   │
-
-error: 
-
     ┌── tests/move_check/naming/generics_shadowing_invalid.move:9:9 ───
     │
   9 │         bar(s1);
@@ -35,16 +42,5 @@ error:
     ·
  13 │     fun bar(s: S) {}
     │                - Is not compatible with: '0x2::M::S'
-    │
-
-error: 
-
-    ┌── tests/move_check/naming/generics_shadowing_invalid.move:10:9 ───
-    │
- 10 │         S {}
-    │         ^ Invalid construction. Expected a struct name
-    ·
-  6 │     fun foo<S>(s1: S, s2: S): S {
-    │             - But 'S' was declared as a type parameter here
     │
 

--- a/language/move-lang/tests/move_check/naming/generics_with_type_parameters.exp
+++ b/language/move-lang/tests/move_check/naming/generics_with_type_parameters.exp
@@ -1,24 +1,18 @@
-error: 
+error[E03006]: unexpected name in this position
+  ┌─ tests/move_check/naming/generics_with_type_parameters.move:2:22
+  │
+2 │     struct S<T> { f: T<u64> }
+  │                      ^^^^^^ Generic type parameters cannot take type arguments
 
-   ┌── tests/move_check/naming/generics_with_type_parameters.move:2:22 ───
-   │
- 2 │     struct S<T> { f: T<u64> }
-   │                      ^^^^^^ Generic type parameters cannot take type arguments
-   │
+error[E03006]: unexpected name in this position
+  ┌─ tests/move_check/naming/generics_with_type_parameters.move:3:19
+  │
+3 │     fun foo<T>(x: T<bool>): T<u64> {}
+  │                   ^^^^^^^ Generic type parameters cannot take type arguments
 
-error: 
-
-   ┌── tests/move_check/naming/generics_with_type_parameters.move:3:19 ───
-   │
- 3 │     fun foo<T>(x: T<bool>): T<u64> {}
-   │                   ^^^^^^^ Generic type parameters cannot take type arguments
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/generics_with_type_parameters.move:3:29 ───
-   │
- 3 │     fun foo<T>(x: T<bool>): T<u64> {}
-   │                             ^^^^^^ Generic type parameters cannot take type arguments
-   │
+error[E03006]: unexpected name in this position
+  ┌─ tests/move_check/naming/generics_with_type_parameters.move:3:29
+  │
+3 │     fun foo<T>(x: T<bool>): T<u64> {}
+  │                             ^^^^^^ Generic type parameters cannot take type arguments
 

--- a/language/move-lang/tests/move_check/naming/global_builtin_many_type_arguments.exp
+++ b/language/move-lang/tests/move_check/naming/global_builtin_many_type_arguments.exp
@@ -1,44 +1,36 @@
-error: 
+error[E03007]: too many type arguments
+  ┌─ tests/move_check/naming/global_builtin_many_type_arguments.move:8:9
+  │
+8 │         borrow_global<R1, R2>(@0x1);
+  │         ^^^^^^^^^^^^^--------------
+  │         │
+  │         Expected 1 type argument(s) but got 2
+  │         Invalid call to builtin function: 'borrow_global'
 
-   ┌── tests/move_check/naming/global_builtin_many_type_arguments.move:8:9 ───
+error[E03007]: too many type arguments
+  ┌─ tests/move_check/naming/global_builtin_many_type_arguments.move:9:9
+  │
+9 │         exists<R1, R2, R3>(@0x1);
+  │         ^^^^^^------------------
+  │         │
+  │         Expected 1 type argument(s) but got 3
+  │         Invalid call to builtin function: 'exists'
+
+error[E03007]: too many type arguments
+   ┌─ tests/move_check/naming/global_builtin_many_type_arguments.move:10:17
    │
- 8 │         borrow_global<R1, R2>(@0x1);
-   │         ^^^^^^^^^^^^^ Invalid call to builtin function: 'borrow_global'
-   ·
- 8 │         borrow_global<R1, R2>(@0x1);
-   │         --------------------------- Expected 1 type argument(s) but got 2
+10 │         R1 {} = move_from<R1, R2, R3, R4>(@0x1);
+   │                 ^^^^^^^^^----------------------
+   │                 │
+   │                 Expected 1 type argument(s) but got 4
+   │                 Invalid call to builtin function: 'move_from'
+
+error[E03007]: too many type arguments
+   ┌─ tests/move_check/naming/global_builtin_many_type_arguments.move:11:9
    │
-
-error: 
-
-   ┌── tests/move_check/naming/global_builtin_many_type_arguments.move:9:9 ───
-   │
- 9 │         exists<R1, R2, R3>(@0x1);
-   │         ^^^^^^ Invalid call to builtin function: 'exists'
-   ·
- 9 │         exists<R1, R2, R3>(@0x1);
-   │         ------------------------ Expected 1 type argument(s) but got 3
-   │
-
-error: 
-
-    ┌── tests/move_check/naming/global_builtin_many_type_arguments.move:10:17 ───
-    │
- 10 │         R1 {} = move_from<R1, R2, R3, R4>(@0x1);
-    │                 ^^^^^^^^^ Invalid call to builtin function: 'move_from'
-    ·
- 10 │         R1 {} = move_from<R1, R2, R3, R4>(@0x1);
-    │                 ------------------------------- Expected 1 type argument(s) but got 4
-    │
-
-error: 
-
-    ┌── tests/move_check/naming/global_builtin_many_type_arguments.move:11:9 ───
-    │
- 11 │         move_to<R1, R2, R3, R4, R5>(account, R1{});
-    │         ^^^^^^^ Invalid call to builtin function: 'move_to'
-    ·
- 11 │         move_to<R1, R2, R3, R4, R5>(account, R1{});
-    │         ------------------------------------------ Expected 1 type argument(s) but got 5
-    │
+11 │         move_to<R1, R2, R3, R4, R5>(account, R1{});
+   │         ^^^^^^^-----------------------------------
+   │         │
+   │         Expected 1 type argument(s) but got 5
+   │         Invalid call to builtin function: 'move_to'
 

--- a/language/move-lang/tests/move_check/naming/global_builtin_zero_type_arguments.exp
+++ b/language/move-lang/tests/move_check/naming/global_builtin_zero_type_arguments.exp
@@ -1,44 +1,36 @@
-error: 
+error[E03008]: too few type arguments
+  ┌─ tests/move_check/naming/global_builtin_zero_type_arguments.move:4:9
+  │
+4 │         borrow_global<>(@0x1);
+  │         ^^^^^^^^^^^^^--------
+  │         │
+  │         Expected 1 type argument(s) but got 0
+  │         Invalid call to builtin function: 'borrow_global'
 
-   ┌── tests/move_check/naming/global_builtin_zero_type_arguments.move:4:9 ───
-   │
- 4 │         borrow_global<>(@0x1);
-   │         ^^^^^^^^^^^^^ Invalid call to builtin function: 'borrow_global'
-   ·
- 4 │         borrow_global<>(@0x1);
-   │         --------------------- Expected 1 type argument(s) but got 0
-   │
+error[E03008]: too few type arguments
+  ┌─ tests/move_check/naming/global_builtin_zero_type_arguments.move:5:9
+  │
+5 │         exists<>(@0x1);
+  │         ^^^^^^--------
+  │         │
+  │         Expected 1 type argument(s) but got 0
+  │         Invalid call to builtin function: 'exists'
 
-error: 
+error[E03008]: too few type arguments
+  ┌─ tests/move_check/naming/global_builtin_zero_type_arguments.move:6:17
+  │
+6 │         R1 {} = move_from<>(@0x1);
+  │                 ^^^^^^^^^--------
+  │                 │
+  │                 Expected 1 type argument(s) but got 0
+  │                 Invalid call to builtin function: 'move_from'
 
-   ┌── tests/move_check/naming/global_builtin_zero_type_arguments.move:5:9 ───
-   │
- 5 │         exists<>(@0x1);
-   │         ^^^^^^ Invalid call to builtin function: 'exists'
-   ·
- 5 │         exists<>(@0x1);
-   │         -------------- Expected 1 type argument(s) but got 0
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/global_builtin_zero_type_arguments.move:6:17 ───
-   │
- 6 │         R1 {} = move_from<>(@0x1);
-   │                 ^^^^^^^^^ Invalid call to builtin function: 'move_from'
-   ·
- 6 │         R1 {} = move_from<>(@0x1);
-   │                 ----------------- Expected 1 type argument(s) but got 0
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/global_builtin_zero_type_arguments.move:7:9 ───
-   │
- 7 │         move_to<>(account, R1{});
-   │         ^^^^^^^ Invalid call to builtin function: 'move_to'
-   ·
- 7 │         move_to<>(account, R1{});
-   │         ------------------------ Expected 1 type argument(s) but got 0
-   │
+error[E03008]: too few type arguments
+  ┌─ tests/move_check/naming/global_builtin_zero_type_arguments.move:7:9
+  │
+7 │         move_to<>(account, R1{});
+  │         ^^^^^^^-----------------
+  │         │
+  │         Expected 1 type argument(s) but got 0
+  │         Invalid call to builtin function: 'move_to'
 

--- a/language/move-lang/tests/move_check/naming/named_address_distinct_from_each_other.exp
+++ b/language/move-lang/tests/move_check/naming/named_address_distinct_from_each_other.exp
@@ -1,43 +1,35 @@
+error[E02010]: invalid 'friend' declaration
+   ┌─ tests/move_check/naming/named_address_distinct_from_each_other.move:15:5
+   │
+15 │     friend B::M;
+   │     ^^^^^^^^^^^^
+   │     │      │
+   │     │      Cannot declare modules out of the current address as a friend
+   │     Invalid friend declaration
+
+error[E03002]: unbound module
+   ┌─ tests/move_check/naming/named_address_distinct_from_each_other.move:16:22
+   │
+16 │     public fun ex(): B::M::S {
+   │                      ^^^^ Unbound module 'B::M'
+
+error[E03002]: unbound module
+   ┌─ tests/move_check/naming/named_address_distinct_from_each_other.move:17:9
+   │
+17 │         B::M::C;
+   │         ^^^^ Unbound module 'B::M'
+
+error[E03002]: unbound module
+   ┌─ tests/move_check/naming/named_address_distinct_from_each_other.move:18:9
+   │
+18 │         B::M::s()
+   │         ^^^^ Unbound module 'B::M'
+
 error: 
 
     ┌── tests/move_check/naming/named_address_distinct_from_each_other.move:14:9 ───
     │
  14 │     use B::M;
     │         ^^^^ Invalid 'use'. Unbound module: 'B::M'
-    │
-
-error: 
-
-    ┌── tests/move_check/naming/named_address_distinct_from_each_other.move:15:5 ───
-    │
- 15 │     friend B::M;
-    │     ^^^^^^^^^^^^ Invalid friend declaration
-    ·
- 15 │     friend B::M;
-    │            ---- Cannot declare modules out of the current address as a friend
-    │
-
-error: 
-
-    ┌── tests/move_check/naming/named_address_distinct_from_each_other.move:16:22 ───
-    │
- 16 │     public fun ex(): B::M::S {
-    │                      ^^^^ Unbound module 'B::M'
-    │
-
-error: 
-
-    ┌── tests/move_check/naming/named_address_distinct_from_each_other.move:17:9 ───
-    │
- 17 │         B::M::C;
-    │         ^^^^ Unbound module 'B::M'
-    │
-
-error: 
-
-    ┌── tests/move_check/naming/named_address_distinct_from_each_other.move:18:9 ───
-    │
- 18 │         B::M::s()
-    │         ^^^^ Unbound module 'B::M'
     │
 

--- a/language/move-lang/tests/move_check/naming/named_address_distinct_from_value.exp
+++ b/language/move-lang/tests/move_check/naming/named_address_distinct_from_value.exp
@@ -1,43 +1,35 @@
+error[E02010]: invalid 'friend' declaration
+   ┌─ tests/move_check/naming/named_address_distinct_from_value.move:14:5
+   │
+14 │     friend 0x42::M;
+   │     ^^^^^^^^^^^^^^^
+   │     │      │
+   │     │      Cannot declare modules out of the current address as a friend
+   │     Invalid friend declaration
+
+error[E03002]: unbound module
+   ┌─ tests/move_check/naming/named_address_distinct_from_value.move:15:22
+   │
+15 │     public fun ex(): 0x42::M::S {
+   │                      ^^^^^^^ Unbound module '0x42::M'
+
+error[E03002]: unbound module
+   ┌─ tests/move_check/naming/named_address_distinct_from_value.move:16:9
+   │
+16 │         0x42::M::C;
+   │         ^^^^^^^ Unbound module '0x42::M'
+
+error[E03002]: unbound module
+   ┌─ tests/move_check/naming/named_address_distinct_from_value.move:17:9
+   │
+17 │         0x42::M::s()
+   │         ^^^^^^^ Unbound module '0x42::M'
+
 error: 
 
     ┌── tests/move_check/naming/named_address_distinct_from_value.move:13:9 ───
     │
  13 │     use 0x42::M;
     │         ^^^^^^^ Invalid 'use'. Unbound module: '0x42::M'
-    │
-
-error: 
-
-    ┌── tests/move_check/naming/named_address_distinct_from_value.move:14:5 ───
-    │
- 14 │     friend 0x42::M;
-    │     ^^^^^^^^^^^^^^^ Invalid friend declaration
-    ·
- 14 │     friend 0x42::M;
-    │            ------- Cannot declare modules out of the current address as a friend
-    │
-
-error: 
-
-    ┌── tests/move_check/naming/named_address_distinct_from_value.move:15:22 ───
-    │
- 15 │     public fun ex(): 0x42::M::S {
-    │                      ^^^^^^^ Unbound module '0x42::M'
-    │
-
-error: 
-
-    ┌── tests/move_check/naming/named_address_distinct_from_value.move:16:9 ───
-    │
- 16 │         0x42::M::C;
-    │         ^^^^^^^ Unbound module '0x42::M'
-    │
-
-error: 
-
-    ┌── tests/move_check/naming/named_address_distinct_from_value.move:17:9 ───
-    │
- 17 │         0x42::M::s()
-    │         ^^^^^^^ Unbound module '0x42::M'
     │
 

--- a/language/move-lang/tests/move_check/naming/other_builtins_invalid.exp
+++ b/language/move-lang/tests/move_check/naming/other_builtins_invalid.exp
@@ -1,44 +1,36 @@
-error: 
+error[E03007]: too many type arguments
+  ┌─ tests/move_check/naming/other_builtins_invalid.move:3:9
+  │
+3 │         freeze<u64, bool>(x);
+  │         ^^^^^^--------------
+  │         │
+  │         Expected 1 type argument(s) but got 2
+  │         Invalid call to builtin function: 'freeze'
 
-   ┌── tests/move_check/naming/other_builtins_invalid.move:3:9 ───
-   │
- 3 │         freeze<u64, bool>(x);
-   │         ^^^^^^ Invalid call to builtin function: 'freeze'
-   ·
- 3 │         freeze<u64, bool>(x);
-   │         -------------------- Expected 1 type argument(s) but got 2
-   │
+error[E03008]: too few type arguments
+  ┌─ tests/move_check/naming/other_builtins_invalid.move:4:9
+  │
+4 │         freeze<>(x);
+  │         ^^^^^^-----
+  │         │
+  │         Expected 1 type argument(s) but got 0
+  │         Invalid call to builtin function: 'freeze'
 
-error: 
+error[E03007]: too many type arguments
+  ┌─ tests/move_check/naming/other_builtins_invalid.move:5:9
+  │
+5 │         assert<u64>(true, 42);
+  │         ^^^^^^---------------
+  │         │
+  │         Expected 0 type argument(s) but got 1
+  │         Invalid call to builtin function: 'assert'
 
-   ┌── tests/move_check/naming/other_builtins_invalid.move:4:9 ───
-   │
- 4 │         freeze<>(x);
-   │         ^^^^^^ Invalid call to builtin function: 'freeze'
-   ·
- 4 │         freeze<>(x);
-   │         ----------- Expected 1 type argument(s) but got 0
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/other_builtins_invalid.move:5:9 ───
-   │
- 5 │         assert<u64>(true, 42);
-   │         ^^^^^^ Invalid call to builtin function: 'assert'
-   ·
- 5 │         assert<u64>(true, 42);
-   │         --------------------- Expected 0 type argument(s) but got 1
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/other_builtins_invalid.move:6:9 ───
-   │
- 6 │         assert<u64, bool>(true, 42);
-   │         ^^^^^^ Invalid call to builtin function: 'assert'
-   ·
- 6 │         assert<u64, bool>(true, 42);
-   │         --------------------------- Expected 0 type argument(s) but got 2
-   │
+error[E03007]: too many type arguments
+  ┌─ tests/move_check/naming/other_builtins_invalid.move:6:9
+  │
+6 │         assert<u64, bool>(true, 42);
+  │         ^^^^^^---------------------
+  │         │
+  │         Expected 0 type argument(s) but got 2
+  │         Invalid call to builtin function: 'assert'
 

--- a/language/move-lang/tests/move_check/naming/standalone_mname.exp
+++ b/language/move-lang/tests/move_check/naming/standalone_mname.exp
@@ -1,8 +1,6 @@
-error: 
-
-   ┌── tests/move_check/naming/standalone_mname.move:3:17 ───
-   │
- 3 │         let m = M;
-   │                 ^ Unbound constant 'M'
-   │
+error[E03005]: unbound unscoped name
+  ┌─ tests/move_check/naming/standalone_mname.move:3:17
+  │
+3 │         let m = M;
+  │                 ^ Unbound constant 'M'
 

--- a/language/move-lang/tests/move_check/naming/standalone_module_ident.exp
+++ b/language/move-lang/tests/move_check/naming/standalone_module_ident.exp
@@ -1,17 +1,15 @@
+error[E03005]: unbound unscoped name
+  ┌─ tests/move_check/naming/standalone_module_ident.move:8:17
+  │
+8 │         let x = X;
+  │                 ^ Unbound constant 'X'
+
 error: 
 
    ┌── tests/move_check/naming/standalone_module_ident.move:6:14 ───
    │
  6 │     use 0x2::X;
    │              ^ Unused 'use' of alias 'X'. Consider removing it
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/standalone_module_ident.move:8:17 ───
-   │
- 8 │         let x = X;
-   │                 ^ Unbound constant 'X'
    │
 
 error: 

--- a/language/move-lang/tests/move_check/naming/unbound_builtin.exp
+++ b/language/move-lang/tests/move_check/naming/unbound_builtin.exp
@@ -1,24 +1,18 @@
-error: 
+error[E03005]: unbound unscoped name
+  ┌─ tests/move_check/naming/unbound_builtin.move:3:9
+  │
+3 │         global_borrow();
+  │         ^^^^^^^^^^^^^ Unbound function 'global_borrow' in current scope
 
-   ┌── tests/move_check/naming/unbound_builtin.move:3:9 ───
-   │
- 3 │         global_borrow();
-   │         ^^^^^^^^^^^^^ Unbound function 'global_borrow' in current scope
-   │
+error[E03005]: unbound unscoped name
+  ┌─ tests/move_check/naming/unbound_builtin.move:4:9
+  │
+4 │         release<u64>();
+  │         ^^^^^^^ Unbound function 'release' in current scope
 
-error: 
-
-   ┌── tests/move_check/naming/unbound_builtin.move:4:9 ───
-   │
- 4 │         release<u64>();
-   │         ^^^^^^^ Unbound function 'release' in current scope
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/unbound_builtin.move:5:9 ───
-   │
- 5 │         sudo(false);
-   │         ^^^^ Unbound function 'sudo' in current scope
-   │
+error[E03005]: unbound unscoped name
+  ┌─ tests/move_check/naming/unbound_builtin.move:5:9
+  │
+5 │         sudo(false);
+  │         ^^^^ Unbound function 'sudo' in current scope
 

--- a/language/move-lang/tests/move_check/naming/unbound_constant.exp
+++ b/language/move-lang/tests/move_check/naming/unbound_constant.exp
@@ -1,42 +1,38 @@
-error: 
+error[E03005]: unbound unscoped name
+  ┌─ tests/move_check/naming/unbound_constant.move:4:17
+  │
+4 │         let x = CONSTANT;
+  │                 ^^^^^^^^ Unbound constant 'CONSTANT'
 
-   ┌── tests/move_check/naming/unbound_constant.move:4:17 ───
+error[E03003]: unbound module member
+  ┌─ tests/move_check/naming/unbound_constant.move:5:17
+  │
+5 │         let y = Self::CONSTANT;
+  │                 ^^^^^^^^^^^^^^ Invalid module access. Unbound constant 'CONSTANT' in module '0x42::M'
+
+error[E03005]: unbound unscoped name
+  ┌─ tests/move_check/naming/unbound_constant.move:6:13
+  │
+6 │         0 + CONSTANT + Self::CONSTANT;
+  │             ^^^^^^^^ Unbound constant 'CONSTANT'
+
+error[E03003]: unbound module member
+  ┌─ tests/move_check/naming/unbound_constant.move:6:24
+  │
+6 │         0 + CONSTANT + Self::CONSTANT;
+  │                        ^^^^^^^^^^^^^^ Invalid module access. Unbound constant 'CONSTANT' in module '0x42::M'
+
+error[E03005]: unbound unscoped name
+   ┌─ tests/move_check/naming/unbound_constant.move:13:17
    │
- 4 │         let x = CONSTANT;
+13 │         let x = CONSTANT;
    │                 ^^^^^^^^ Unbound constant 'CONSTANT'
-   │
 
-error: 
-
-   ┌── tests/move_check/naming/unbound_constant.move:5:17 ───
+error[E03005]: unbound unscoped name
+   ┌─ tests/move_check/naming/unbound_constant.move:15:13
    │
- 5 │         let y = Self::CONSTANT;
-   │                 ^^^^^^^^^^^^^^ Invalid module access. Unbound constant 'CONSTANT' in module '0x42::M'
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/unbound_constant.move:6:13 ───
-   │
- 6 │         0 + CONSTANT + Self::CONSTANT;
+15 │         0 + CONSTANT + Self::CONSTANT;
    │             ^^^^^^^^ Unbound constant 'CONSTANT'
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/unbound_constant.move:6:24 ───
-   │
- 6 │         0 + CONSTANT + Self::CONSTANT;
-   │                        ^^^^^^^^^^^^^^ Invalid module access. Unbound constant 'CONSTANT' in module '0x42::M'
-   │
-
-error: 
-
-    ┌── tests/move_check/naming/unbound_constant.move:13:17 ───
-    │
- 13 │         let x = CONSTANT;
-    │                 ^^^^^^^^ Unbound constant 'CONSTANT'
-    │
 
 error: 
 
@@ -44,14 +40,6 @@ error:
     │
  14 │         let y = Self::CONSTANT;
     │                 ^^^^ Unbound module alias 'Self'
-    │
-
-error: 
-
-    ┌── tests/move_check/naming/unbound_constant.move:15:13 ───
-    │
- 15 │         0 + CONSTANT + Self::CONSTANT;
-    │             ^^^^^^^^ Unbound constant 'CONSTANT'
     │
 
 error: 

--- a/language/move-lang/tests/move_check/naming/unbound_module_name.exp
+++ b/language/move-lang/tests/move_check/naming/unbound_module_name.exp
@@ -1,32 +1,24 @@
-error: 
+error[E03003]: unbound module member
+  ┌─ tests/move_check/naming/unbound_module_name.move:7:17
+  │
+7 │         let x = N::c;
+  │                 ^^^^ Invalid module access. Unbound constant 'c' in module '0x42::N'
 
-   ┌── tests/move_check/naming/unbound_module_name.move:7:17 ───
-   │
- 7 │         let x = N::c;
-   │                 ^^^^ Invalid module access. Unbound constant 'c' in module '0x42::N'
-   │
+error[E03003]: unbound module member
+  ┌─ tests/move_check/naming/unbound_module_name.move:8:17
+  │
+8 │         let y = Self::c;
+  │                 ^^^^^^^ Invalid module access. Unbound constant 'c' in module '0x42::M'
 
-error: 
+error[E03003]: unbound module member
+  ┌─ tests/move_check/naming/unbound_module_name.move:9:13
+  │
+9 │         0 + N::c + Self::c;
+  │             ^^^^ Invalid module access. Unbound constant 'c' in module '0x42::N'
 
-   ┌── tests/move_check/naming/unbound_module_name.move:8:17 ───
-   │
- 8 │         let y = Self::c;
-   │                 ^^^^^^^ Invalid module access. Unbound constant 'c' in module '0x42::M'
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/unbound_module_name.move:9:13 ───
-   │
- 9 │         0 + N::c + Self::c;
-   │             ^^^^ Invalid module access. Unbound constant 'c' in module '0x42::N'
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/unbound_module_name.move:9:20 ───
-   │
- 9 │         0 + N::c + Self::c;
-   │                    ^^^^^^^ Invalid module access. Unbound constant 'c' in module '0x42::M'
-   │
+error[E03003]: unbound module member
+  ┌─ tests/move_check/naming/unbound_module_name.move:9:20
+  │
+9 │         0 + N::c + Self::c;
+  │                    ^^^^^^^ Invalid module access. Unbound constant 'c' in module '0x42::M'
 

--- a/language/move-lang/tests/move_check/naming/unbound_struct_in_current.exp
+++ b/language/move-lang/tests/move_check/naming/unbound_struct_in_current.exp
@@ -1,64 +1,48 @@
-error: 
+error[E03003]: unbound module member
+  ┌─ tests/move_check/naming/unbound_struct_in_current.move:2:16
+  │
+2 │     fun foo(s: Self::S): Self::S {
+  │                ^^^^^^^ Invalid module access. Unbound struct 'S' in module '0x8675309::M'
 
-   ┌── tests/move_check/naming/unbound_struct_in_current.move:2:16 ───
-   │
- 2 │     fun foo(s: Self::S): Self::S {
-   │                ^^^^^^^ Invalid module access. Unbound struct 'S' in module '0x8675309::M'
-   │
+error[E03003]: unbound module member
+  ┌─ tests/move_check/naming/unbound_struct_in_current.move:2:26
+  │
+2 │     fun foo(s: Self::S): Self::S {
+  │                          ^^^^^^^ Invalid module access. Unbound struct 'S' in module '0x8675309::M'
 
-error: 
+error[E03003]: unbound module member
+  ┌─ tests/move_check/naming/unbound_struct_in_current.move:7:16
+  │
+7 │     fun bar(): Self::S {
+  │                ^^^^^^^ Invalid module access. Unbound struct 'S' in module '0x8675309::M'
 
-   ┌── tests/move_check/naming/unbound_struct_in_current.move:2:26 ───
-   │
- 2 │     fun foo(s: Self::S): Self::S {
-   │                          ^^^^^^^ Invalid module access. Unbound struct 'S' in module '0x8675309::M'
-   │
+error[E03004]: unbound type
+  ┌─ tests/move_check/naming/unbound_struct_in_current.move:8:9
+  │
+8 │         S {}
+  │         ^ Unbound type 'S' in current scope
 
-error: 
-
-   ┌── tests/move_check/naming/unbound_struct_in_current.move:7:16 ───
+error[E03004]: unbound type
+   ┌─ tests/move_check/naming/unbound_struct_in_current.move:12:9
    │
- 7 │     fun bar(): Self::S {
-   │                ^^^^^^^ Invalid module access. Unbound struct 'S' in module '0x8675309::M'
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/unbound_struct_in_current.move:8:9 ───
-   │
- 8 │         S {}
+12 │         S {} = bar();
    │         ^ Unbound type 'S' in current scope
+
+error[E03003]: unbound module member
+   ┌─ tests/move_check/naming/unbound_struct_in_current.move:13:9
    │
+13 │         Self::S {} = bar();
+   │         ^^^^^^^ Invalid module access. Unbound struct 'S' in module '0x8675309::M'
 
-error: 
+error[E03004]: unbound type
+   ┌─ tests/move_check/naming/unbound_struct_in_current.move:17:13
+   │
+17 │         let S {} = bar();
+   │             ^ Unbound type 'S' in current scope
 
-    ┌── tests/move_check/naming/unbound_struct_in_current.move:12:9 ───
-    │
- 12 │         S {} = bar();
-    │         ^ Unbound type 'S' in current scope
-    │
-
-error: 
-
-    ┌── tests/move_check/naming/unbound_struct_in_current.move:13:9 ───
-    │
- 13 │         Self::S {} = bar();
-    │         ^^^^^^^ Invalid module access. Unbound struct 'S' in module '0x8675309::M'
-    │
-
-error: 
-
-    ┌── tests/move_check/naming/unbound_struct_in_current.move:17:13 ───
-    │
- 17 │         let S {} = bar();
-    │             ^ Unbound type 'S' in current scope
-    │
-
-error: 
-
-    ┌── tests/move_check/naming/unbound_struct_in_current.move:18:13 ───
-    │
- 18 │         let Self::S {} = bar();
-    │             ^^^^^^^ Invalid module access. Unbound struct 'S' in module '0x8675309::M'
-    │
+error[E03003]: unbound module member
+   ┌─ tests/move_check/naming/unbound_struct_in_current.move:18:13
+   │
+18 │         let Self::S {} = bar();
+   │             ^^^^^^^ Invalid module access. Unbound struct 'S' in module '0x8675309::M'
 

--- a/language/move-lang/tests/move_check/naming/unbound_struct_in_module.exp
+++ b/language/move-lang/tests/move_check/naming/unbound_struct_in_module.exp
@@ -1,16 +1,12 @@
-error: 
+error[E03003]: unbound module member
+  ┌─ tests/move_check/naming/unbound_struct_in_module.move:6:16
+  │
+6 │     fun foo(s: X::S): X::S {
+  │                ^^^^ Invalid module access. Unbound struct 'S' in module '0x2::X'
 
-   ┌── tests/move_check/naming/unbound_struct_in_module.move:6:16 ───
-   │
- 6 │     fun foo(s: X::S): X::S {
-   │                ^^^^ Invalid module access. Unbound struct 'S' in module '0x2::X'
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/unbound_struct_in_module.move:6:23 ───
-   │
- 6 │     fun foo(s: X::S): X::S {
-   │                       ^^^^ Invalid module access. Unbound struct 'S' in module '0x2::X'
-   │
+error[E03003]: unbound module member
+  ┌─ tests/move_check/naming/unbound_struct_in_module.move:6:23
+  │
+6 │     fun foo(s: X::S): X::S {
+  │                       ^^^^ Invalid module access. Unbound struct 'S' in module '0x2::X'
 

--- a/language/move-lang/tests/move_check/naming/unbound_unqualified_function.exp
+++ b/language/move-lang/tests/move_check/naming/unbound_unqualified_function.exp
@@ -1,24 +1,18 @@
-error: 
+error[E03005]: unbound unscoped name
+  ┌─ tests/move_check/naming/unbound_unqualified_function.move:3:9
+  │
+3 │         bar();
+  │         ^^^ Unbound function 'bar' in current scope
 
-   ┌── tests/move_check/naming/unbound_unqualified_function.move:3:9 ───
-   │
- 3 │         bar();
-   │         ^^^ Unbound function 'bar' in current scope
-   │
+error[E03005]: unbound unscoped name
+  ┌─ tests/move_check/naming/unbound_unqualified_function.move:4:17
+  │
+4 │         let x = bar();
+  │                 ^^^ Unbound function 'bar' in current scope
 
-error: 
-
-   ┌── tests/move_check/naming/unbound_unqualified_function.move:4:17 ───
-   │
- 4 │         let x = bar();
-   │                 ^^^ Unbound function 'bar' in current scope
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/unbound_unqualified_function.move:5:10 ───
-   │
- 5 │         *bar() = 0;
-   │          ^^^ Unbound function 'bar' in current scope
-   │
+error[E03005]: unbound unscoped name
+  ┌─ tests/move_check/naming/unbound_unqualified_function.move:5:10
+  │
+5 │         *bar() = 0;
+  │          ^^^ Unbound function 'bar' in current scope
 

--- a/language/move-lang/tests/move_check/naming/unresolved_type_no_args.exp
+++ b/language/move-lang/tests/move_check/naming/unresolved_type_no_args.exp
@@ -1,40 +1,30 @@
-error: 
+error[E03004]: unbound type
+  ┌─ tests/move_check/naming/unresolved_type_no_args.move:2:22
+  │
+2 │     struct Mine { f: A }
+  │                      ^ Unbound type 'A' in current scope
 
-   ┌── tests/move_check/naming/unresolved_type_no_args.move:2:22 ───
-   │
- 2 │     struct Mine { f: A }
-   │                      ^ Unbound type 'A' in current scope
-   │
+error[E03004]: unbound type
+  ┌─ tests/move_check/naming/unresolved_type_no_args.move:3:16
+  │
+3 │     fun foo(x: S): G {
+  │                ^ Unbound type 'S' in current scope
 
-error: 
+error[E03004]: unbound type
+  ┌─ tests/move_check/naming/unresolved_type_no_args.move:3:20
+  │
+3 │     fun foo(x: S): G {
+  │                    ^ Unbound type 'G' in current scope
 
-   ┌── tests/move_check/naming/unresolved_type_no_args.move:3:16 ───
-   │
- 3 │     fun foo(x: S): G {
-   │                ^ Unbound type 'S' in current scope
-   │
+error[E03004]: unbound type
+  ┌─ tests/move_check/naming/unresolved_type_no_args.move:4:16
+  │
+4 │         let _: B = (0: P);
+  │                ^ Unbound type 'B' in current scope
 
-error: 
-
-   ┌── tests/move_check/naming/unresolved_type_no_args.move:3:20 ───
-   │
- 3 │     fun foo(x: S): G {
-   │                    ^ Unbound type 'G' in current scope
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/unresolved_type_no_args.move:4:16 ───
-   │
- 4 │         let _: B = (0: P);
-   │                ^ Unbound type 'B' in current scope
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/unresolved_type_no_args.move:4:24 ───
-   │
- 4 │         let _: B = (0: P);
-   │                        ^ Unbound type 'P' in current scope
-   │
+error[E03004]: unbound type
+  ┌─ tests/move_check/naming/unresolved_type_no_args.move:4:24
+  │
+4 │         let _: B = (0: P);
+  │                        ^ Unbound type 'P' in current scope
 

--- a/language/move-lang/tests/move_check/naming/unresolved_type_with_args.exp
+++ b/language/move-lang/tests/move_check/naming/unresolved_type_with_args.exp
@@ -1,48 +1,36 @@
-error: 
+error[E03004]: unbound type
+  ┌─ tests/move_check/naming/unresolved_type_with_args.move:2:28
+  │
+2 │     struct Mine<T, U> { f: A<T, U>, g: X<U> }
+  │                            ^ Unbound type 'A' in current scope
 
-   ┌── tests/move_check/naming/unresolved_type_with_args.move:2:28 ───
-   │
- 2 │     struct Mine<T, U> { f: A<T, U>, g: X<U> }
-   │                            ^ Unbound type 'A' in current scope
-   │
+error[E03004]: unbound type
+  ┌─ tests/move_check/naming/unresolved_type_with_args.move:2:40
+  │
+2 │     struct Mine<T, U> { f: A<T, U>, g: X<U> }
+  │                                        ^ Unbound type 'X' in current scope
 
-error: 
+error[E03004]: unbound type
+  ┌─ tests/move_check/naming/unresolved_type_with_args.move:3:22
+  │
+3 │     fun foo<T, U>(x: S<T>): G<T, U> {
+  │                      ^ Unbound type 'S' in current scope
 
-   ┌── tests/move_check/naming/unresolved_type_with_args.move:2:40 ───
-   │
- 2 │     struct Mine<T, U> { f: A<T, U>, g: X<U> }
-   │                                        ^ Unbound type 'X' in current scope
-   │
+error[E03004]: unbound type
+  ┌─ tests/move_check/naming/unresolved_type_with_args.move:3:29
+  │
+3 │     fun foo<T, U>(x: S<T>): G<T, U> {
+  │                             ^ Unbound type 'G' in current scope
 
-error: 
+error[E03004]: unbound type
+  ┌─ tests/move_check/naming/unresolved_type_with_args.move:4:16
+  │
+4 │         let _: B<U> = (0: P<U, T>);
+  │                ^ Unbound type 'B' in current scope
 
-   ┌── tests/move_check/naming/unresolved_type_with_args.move:3:22 ───
-   │
- 3 │     fun foo<T, U>(x: S<T>): G<T, U> {
-   │                      ^ Unbound type 'S' in current scope
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/unresolved_type_with_args.move:3:29 ───
-   │
- 3 │     fun foo<T, U>(x: S<T>): G<T, U> {
-   │                             ^ Unbound type 'G' in current scope
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/unresolved_type_with_args.move:4:16 ───
-   │
- 4 │         let _: B<U> = (0: P<U, T>);
-   │                ^ Unbound type 'B' in current scope
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/unresolved_type_with_args.move:4:27 ───
-   │
- 4 │         let _: B<U> = (0: P<U, T>);
-   │                           ^ Unbound type 'P' in current scope
-   │
+error[E03004]: unbound type
+  ┌─ tests/move_check/naming/unresolved_type_with_args.move:4:27
+  │
+4 │         let _: B<U> = (0: P<U, T>);
+  │                           ^ Unbound type 'P' in current scope
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/borrow_tests/borrow_global_acquires_duplicate_annotation.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/borrow_tests/borrow_global_acquires_duplicate_annotation.exp
@@ -1,11 +1,8 @@
-error: 
-
-   ┌── tests/move_check/translated_ir_tests/move/borrow_tests/borrow_global_acquires_duplicate_annotation.move:5:52 ───
-   │
- 5 │     public fun test(account: &signer) acquires T1, T1 {
-   │                                                    ^^ Duplicate acquires item
-   ·
- 5 │     public fun test(account: &signer) acquires T1, T1 {
-   │                                                -- Previously listed here
-   │
+error[E02001]: duplicate declaration, item, or annotation
+  ┌─ tests/move_check/translated_ir_tests/move/borrow_tests/borrow_global_acquires_duplicate_annotation.move:5:52
+  │
+5 │     public fun test(account: &signer) acquires T1, T1 {
+  │                                                --  ^^ Duplicate acquires item
+  │                                                │    
+  │                                                Previously listed here
 

--- a/language/move-lang/tests/move_check/typing/bad_type_argument_arity_const.exp
+++ b/language/move-lang/tests/move_check/typing/bad_type_argument_arity_const.exp
@@ -1,10 +1,26 @@
-error: 
+error[E03008]: too few type arguments
+  ┌─ tests/move_check/typing/bad_type_argument_arity_const.move:6:15
+  │
+6 │     const S1: S = S { f: 0 };
+  │               ^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
 
-   ┌── tests/move_check/typing/bad_type_argument_arity_const.move:6:15 ───
-   │
- 6 │     const S1: S = S { f: 0 };
-   │               ^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
-   │
+error[E03008]: too few type arguments
+  ┌─ tests/move_check/typing/bad_type_argument_arity_const.move:7:15
+  │
+7 │     const S2: S<> = S { f: 0 };
+  │               ^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
+
+error[E03007]: too many type arguments
+  ┌─ tests/move_check/typing/bad_type_argument_arity_const.move:8:15
+  │
+8 │     const S3: S<u64, bool> = S { f: 0 };
+  │               ^^^^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 2
+
+error[E03007]: too many type arguments
+  ┌─ tests/move_check/typing/bad_type_argument_arity_const.move:9:17
+  │
+9 │     const S4: S<S<u64, bool>> = S { f: S { f: 0 } };
+  │                 ^^^^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 2
 
 error: 
 
@@ -30,14 +46,6 @@ error:
    ┌── tests/move_check/typing/bad_type_argument_arity_const.move:7:15 ───
    │
  7 │     const S2: S<> = S { f: 0 };
-   │               ^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/bad_type_argument_arity_const.move:7:15 ───
-   │
- 7 │     const S2: S<> = S { f: 0 };
    │               ^^^ Unpermitted constant type
    ·
  7 │     const S2: S<> = S { f: 0 };
@@ -50,14 +58,6 @@ error:
    │
  7 │     const S2: S<> = S { f: 0 };
    │                     ^^^^^^^^^^ Structs are not supported in constants
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/bad_type_argument_arity_const.move:8:15 ───
-   │
- 8 │     const S3: S<u64, bool> = S { f: 0 };
-   │               ^^^^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 2
    │
 
 error: 
@@ -88,14 +88,6 @@ error:
    ·
  9 │     const S4: S<S<u64, bool>> = S { f: S { f: 0 } };
    │               --------------- Found: '0x42::M::S<_>'. But expected one of: 'u8', 'u64', 'u128', 'bool', 'address', 'vector<_>'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/bad_type_argument_arity_const.move:9:17 ───
-   │
- 9 │     const S4: S<S<u64, bool>> = S { f: S { f: 0 } };
-   │                 ^^^^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 2
    │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/bad_type_argument_arity_struct.exp
+++ b/language/move-lang/tests/move_check/typing/bad_type_argument_arity_struct.exp
@@ -1,96 +1,72 @@
-error: 
+error[E03008]: too few type arguments
+  ┌─ tests/move_check/typing/bad_type_argument_arity_struct.move:7:13
+  │
+7 │         s1: S,
+  │             ^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
 
-   ┌── tests/move_check/typing/bad_type_argument_arity_struct.move:7:13 ───
+error[E03008]: too few type arguments
+  ┌─ tests/move_check/typing/bad_type_argument_arity_struct.move:8:13
+  │
+8 │         s2: S<>,
+  │             ^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
+
+error[E03007]: too many type arguments
+  ┌─ tests/move_check/typing/bad_type_argument_arity_struct.move:9:13
+  │
+9 │         s3: S<bool, u64>,
+  │             ^^^^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 2
+
+error[E03008]: too few type arguments
+   ┌─ tests/move_check/typing/bad_type_argument_arity_struct.move:13:13
    │
- 7 │         s1: S,
+13 │         s1: S,
    │             ^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
-   │
 
-error: 
-
-   ┌── tests/move_check/typing/bad_type_argument_arity_struct.move:8:13 ───
+error[E03008]: too few type arguments
+   ┌─ tests/move_check/typing/bad_type_argument_arity_struct.move:14:13
    │
- 8 │         s2: S<>,
+14 │         s2: S<>,
    │             ^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
-   │
 
-error: 
-
-   ┌── tests/move_check/typing/bad_type_argument_arity_struct.move:9:13 ───
+error[E03007]: too many type arguments
+   ┌─ tests/move_check/typing/bad_type_argument_arity_struct.move:15:13
    │
- 9 │         s3: S<bool, u64>,
+15 │         s3: S<u64, bool>,
    │             ^^^^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 2
+
+error[E03007]: too many type arguments
+   ┌─ tests/move_check/typing/bad_type_argument_arity_struct.move:16:15
    │
+16 │         s4: S<S<u64, bool>>
+   │               ^^^^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 2
 
-error: 
+error[E03008]: too few type arguments
+   ┌─ tests/move_check/typing/bad_type_argument_arity_struct.move:17:9
+   │
+17 │     ): (S, S<>, S<u64, address>, S<S<u64, u8>>) {
+   │         ^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
 
-    ┌── tests/move_check/typing/bad_type_argument_arity_struct.move:13:13 ───
-    │
- 13 │         s1: S,
-    │             ^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
-    │
+error[E03008]: too few type arguments
+   ┌─ tests/move_check/typing/bad_type_argument_arity_struct.move:17:12
+   │
+17 │     ): (S, S<>, S<u64, address>, S<S<u64, u8>>) {
+   │            ^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
 
-error: 
+error[E03007]: too many type arguments
+   ┌─ tests/move_check/typing/bad_type_argument_arity_struct.move:17:17
+   │
+17 │     ): (S, S<>, S<u64, address>, S<S<u64, u8>>) {
+   │                 ^^^^^^^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 2
 
-    ┌── tests/move_check/typing/bad_type_argument_arity_struct.move:14:13 ───
-    │
- 14 │         s2: S<>,
-    │             ^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
-    │
+error[E03007]: too many type arguments
+   ┌─ tests/move_check/typing/bad_type_argument_arity_struct.move:17:36
+   │
+17 │     ): (S, S<>, S<u64, address>, S<S<u64, u8>>) {
+   │                                    ^^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 2
 
-error: 
-
-    ┌── tests/move_check/typing/bad_type_argument_arity_struct.move:15:13 ───
-    │
- 15 │         s3: S<u64, bool>,
-    │             ^^^^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 2
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/bad_type_argument_arity_struct.move:16:15 ───
-    │
- 16 │         s4: S<S<u64, bool>>
-    │               ^^^^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 2
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/bad_type_argument_arity_struct.move:17:9 ───
-    │
- 17 │     ): (S, S<>, S<u64, address>, S<S<u64, u8>>) {
-    │         ^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/bad_type_argument_arity_struct.move:17:12 ───
-    │
- 17 │     ): (S, S<>, S<u64, address>, S<S<u64, u8>>) {
-    │            ^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/bad_type_argument_arity_struct.move:17:17 ───
-    │
- 17 │     ): (S, S<>, S<u64, address>, S<S<u64, u8>>) {
-    │                 ^^^^^^^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 2
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/bad_type_argument_arity_struct.move:17:36 ───
-    │
- 17 │     ): (S, S<>, S<u64, address>, S<S<u64, u8>>) {
-    │                                    ^^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 2
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/bad_type_argument_arity_struct.move:27:21 ───
-    │
- 27 │     fun s<T>(f: T): S {
-    │                     ^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
-    │
+error[E03008]: too few type arguments
+   ┌─ tests/move_check/typing/bad_type_argument_arity_struct.move:27:21
+   │
+27 │     fun s<T>(f: T): S {
+   │                     ^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
 

--- a/language/move-lang/tests/move_check/typing/bad_type_argument_arity_struct_pack.exp
+++ b/language/move-lang/tests/move_check/typing/bad_type_argument_arity_struct_pack.exp
@@ -1,16 +1,12 @@
-error: 
+error[E03008]: too few type arguments
+  ┌─ tests/move_check/typing/bad_type_argument_arity_struct_pack.move:7:9
+  │
+7 │         S<> { f: 0 };
+  │         ^^^^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
 
-   ┌── tests/move_check/typing/bad_type_argument_arity_struct_pack.move:7:9 ───
-   │
- 7 │         S<> { f: 0 };
-   │         ^^^^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/bad_type_argument_arity_struct_pack.move:8:9 ───
-   │
- 8 │         S<u64, u64> { f: 0 };
-   │         ^^^^^^^^^^^^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 2
-   │
+error[E03007]: too many type arguments
+  ┌─ tests/move_check/typing/bad_type_argument_arity_struct_pack.move:8:9
+  │
+8 │         S<u64, u64> { f: 0 };
+  │         ^^^^^^^^^^^^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 2
 

--- a/language/move-lang/tests/move_check/typing/bad_type_argument_arity_struct_unpack.exp
+++ b/language/move-lang/tests/move_check/typing/bad_type_argument_arity_struct_unpack.exp
@@ -1,16 +1,12 @@
-error: 
+error[E03008]: too few type arguments
+  ┌─ tests/move_check/typing/bad_type_argument_arity_struct_unpack.move:7:13
+  │
+7 │         let S<> { f } = copy s;
+  │             ^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
 
-   ┌── tests/move_check/typing/bad_type_argument_arity_struct_unpack.move:7:13 ───
-   │
- 7 │         let S<> { f } = copy s;
-   │             ^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/bad_type_argument_arity_struct_unpack.move:9:13 ───
-   │
- 9 │         let S<u64, u64> { f } = copy s;
-   │             ^^^^^^^^^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 2
-   │
+error[E03007]: too many type arguments
+  ┌─ tests/move_check/typing/bad_type_argument_arity_struct_unpack.move:9:13
+  │
+9 │         let S<u64, u64> { f } = copy s;
+  │             ^^^^^^^^^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 2
 

--- a/language/move-lang/tests/move_check/typing/invalid_type_acquire.exp
+++ b/language/move-lang/tests/move_check/typing/invalid_type_acquire.exp
@@ -1,40 +1,32 @@
-error: 
+error[E03006]: unexpected name in this position
+   ┌─ tests/move_check/typing/invalid_type_acquire.move:18:9
+   │
+18 │         T,
+   │         ^ Invalid acquires item. Expected a struct name, but got a type parameter
 
-    ┌── tests/move_check/typing/invalid_type_acquire.move:18:9 ───
-    │
- 18 │         T,
-    │         ^ Invalid acquires item. Expected a struct name, but got a type parameter
-    │
+error[E03006]: unexpected name in this position
+   ┌─ tests/move_check/typing/invalid_type_acquire.move:19:9
+   │
+19 │         u64,
+   │         ^^^ Invalid acquires item. Expected a struct name, but got a builtin type
 
-error: 
+error[E02011]: invalid 'acquires' item
+   ┌─ tests/move_check/typing/invalid_type_acquire.move:20:9
+   │
+ 4 │     struct R has key, store {}
+   │            - The struct 'R' was not declared in the current module. Global storage access is internal to the module'
+   ·
+20 │         X::R,
+   │         ^^^^ Invalid acquires item
 
-    ┌── tests/move_check/typing/invalid_type_acquire.move:19:9 ───
-    │
- 19 │         u64,
-    │         ^^^ Invalid acquires item. Expected a struct name, but got a builtin type
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/invalid_type_acquire.move:20:9 ───
-    │
- 20 │         X::R,
-    │         ^^^^ Invalid acquires item
-    ·
- 20 │         X::R,
-    │            - The struct 'R' was not declared in the current module. Global storage access is internal to the module'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/invalid_type_acquire.move:21:9 ───
-    │
- 21 │         S,
-    │         ^ Invalid acquires item. Expected a struct with the 'key' ability.
-    ·
- 10 │     struct S has store {}
-    │            - Declared without the ability here
-    │
+error[E02011]: invalid 'acquires' item
+   ┌─ tests/move_check/typing/invalid_type_acquire.move:21:9
+   │
+10 │     struct S has store {}
+   │            - Declared without the 'key' ability here
+   ·
+21 │         S,
+   │         ^ Invalid acquires item. Expected a struct with the 'key' ability.
 
 error: 
 

--- a/language/move-lang/tests/move_check/typing/module_call_missing_function.exp
+++ b/language/move-lang/tests/move_check/typing/module_call_missing_function.exp
@@ -1,24 +1,18 @@
-error: 
+error[E03003]: unbound module member
+   ┌─ tests/move_check/typing/module_call_missing_function.move:13:9
+   │
+13 │         Self::fooo();
+   │         ^^^^^^^^^^ Invalid module access. Unbound function 'fooo' in module '0x2::M'
 
-    ┌── tests/move_check/typing/module_call_missing_function.move:13:9 ───
-    │
- 13 │         Self::fooo();
-    │         ^^^^^^^^^^ Invalid module access. Unbound function 'fooo' in module '0x2::M'
-    │
+error[E03005]: unbound unscoped name
+   ┌─ tests/move_check/typing/module_call_missing_function.move:14:9
+   │
+14 │         foooo();
+   │         ^^^^^ Unbound function 'foooo' in current scope
 
-error: 
-
-    ┌── tests/move_check/typing/module_call_missing_function.move:14:9 ───
-    │
- 14 │         foooo();
-    │         ^^^^^ Unbound function 'foooo' in current scope
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_missing_function.move:15:9 ───
-    │
- 15 │         X::foooooo();
-    │         ^^^^^^^^^^ Invalid module access. Unbound function 'foooooo' in module '0x2::X'
-    │
+error[E03003]: unbound module member
+   ┌─ tests/move_check/typing/module_call_missing_function.move:15:9
+   │
+15 │         X::foooooo();
+   │         ^^^^^^^^^^ Invalid module access. Unbound function 'foooooo' in module '0x2::X'
 

--- a/language/move-lang/tests/move_check/unit_test/cross_module_members_non_test_function.exp
+++ b/language/move-lang/tests/move_check/unit_test/cross_module_members_non_test_function.exp
@@ -1,10 +1,8 @@
-error: 
-
-    ┌── tests/move_check/unit_test/cross_module_members_non_test_function.move:23:23 ───
-    │
- 23 │     public fun bad(): Foo {
-    │                       ^^^ Unbound type 'Foo' in current scope
-    │
+error[E03004]: unbound type
+   ┌─ tests/move_check/unit_test/cross_module_members_non_test_function.move:23:23
+   │
+23 │     public fun bad(): Foo {
+   │                       ^^^ Unbound type 'Foo' in current scope
 
 error: 
 

--- a/language/move-lang/tests/move_check/unit_test/test_filter_function.exp
+++ b/language/move-lang/tests/move_check/unit_test/test_filter_function.exp
@@ -1,8 +1,6 @@
-error: 
-
-   ┌── tests/move_check/unit_test/test_filter_function.move:6:24 ───
-   │
- 6 │     public fun foo() { bar() }
-   │                        ^^^ Unbound function 'bar' in current scope
-   │
+error[E03005]: unbound unscoped name
+  ┌─ tests/move_check/unit_test/test_filter_function.move:6:24
+  │
+6 │     public fun foo() { bar() }
+  │                        ^^^ Unbound function 'bar' in current scope
 

--- a/language/move-lang/tests/move_check/unit_test/test_filter_struct.exp
+++ b/language/move-lang/tests/move_check/unit_test/test_filter_struct.exp
@@ -1,16 +1,12 @@
-error: 
+error[E03004]: unbound type
+  ┌─ tests/move_check/unit_test/test_filter_struct.move:9:23
+  │
+9 │     public fun foo(): Foo {
+  │                       ^^^ Unbound type 'Foo' in current scope
 
-   ┌── tests/move_check/unit_test/test_filter_struct.move:9:23 ───
+error[E03004]: unbound type
+   ┌─ tests/move_check/unit_test/test_filter_struct.move:10:9
    │
- 9 │     public fun foo(): Foo {
-   │                       ^^^ Unbound type 'Foo' in current scope
-   │
-
-error: 
-
-    ┌── tests/move_check/unit_test/test_filter_struct.move:10:9 ───
-    │
- 10 │         Foo {}
-    │         ^^^ Unbound type 'Foo' in current scope
-    │
+10 │         Foo {}
+   │         ^^^ Unbound type 'Foo' in current scope
 


### PR DESCRIPTION
- Migrating tests in naming/translate to new codespan reporting format
- I've also improved the blocking/nonblocking seperation of errors and warnings. 
  - Non blocking errors will stop at to-bytecode but not stop hlir/cfgir generation (will let some borrow checking done on certain programs)

## Motivation

- Updating tests to new codespan for better IDE support

## Test Plan

- updated tests
- I think some of the errors look kind of bad in tests, but a lot better with color. That isn't the best answer... I'd like to have something that works well in non-color contexts (or for color blind folks). But it is maybe okay for now?
![image](https://user-images.githubusercontent.com/1753366/123338829-5226fa80-d4fe-11eb-89bd-ee604a1ac737.png)

