### PR TITLE
[move] [read/write set analysis] Prune read write state summary

### DIFF
--- a/language/move-prover/bytecode/src/access_path.rs
+++ b/language/move-prover/bytecode/src/access_path.rs
@@ -105,13 +105,9 @@ pub struct AccessPath {
 // Abstract domain operations
 
 /// Trait for a domain that can be viewed as a partial map from access paths to values
+/// and values can be deleted using their access paths
 pub trait AccessPathMap<T: AbstractDomain> {
     fn get_access_path(&self, ap: AccessPath) -> Option<&T>;
-}
-
-/// Trait for a domain that can be viewed as a partial map from access paths to values
-/// and values can be deleted using their access paths
-pub trait AccessPathDeletableMap<T: AbstractDomain> {
     fn remove_access_path(&mut self, ap: AccessPath) -> Option<T>;
 }
 

--- a/language/move-prover/bytecode/src/access_path.rs
+++ b/language/move-prover/bytecode/src/access_path.rs
@@ -109,6 +109,12 @@ pub trait AccessPathMap<T: AbstractDomain> {
     fn get_access_path(&self, ap: AccessPath) -> Option<&T>;
 }
 
+/// Trait for a domain that can be viewed as a partial map from access paths to values
+/// and values can be deleted using their access paths
+pub trait AccessPathDeletableMap<T: AbstractDomain> {
+    fn remove_access_path(&mut self, ap: AccessPath) -> Option<T>;
+}
+
 /// Trait for an abstract domain that can represent footprint values
 pub trait FootprintDomain: AbstractDomain + Clone + Debug + PartialEq + Sized {
     /// Create a footprint value for access path `ap`

--- a/language/move-prover/bytecode/src/access_path_trie.rs
+++ b/language/move-prover/bytecode/src/access_path_trie.rs
@@ -7,9 +7,7 @@
 //! Each node is (optionally) associated with abstract value of a generic type `T`.
 
 use crate::{
-    access_path::{
-        AbsAddr, AccessPath, AccessPathDeletableMap, AccessPathMap, FootprintDomain, Offset, Root,
-    },
+    access_path::{AbsAddr, AccessPath, AccessPathMap, FootprintDomain, Offset, Root},
     dataflow_domains::{AbstractDomain, JoinResult, MapDomain},
 };
 use im::ordmap::Entry;
@@ -224,9 +222,7 @@ impl<T: FootprintDomain> AccessPathMap<T> for AccessPathTrie<T> {
             None => None,
         }
     }
-}
 
-impl<T: FootprintDomain> AccessPathDeletableMap<T> for AccessPathTrie<T> {
     fn remove_access_path(&mut self, ap: AccessPath) -> Option<T> {
         self.remove_node(ap).and_then(|n| n.data)
     }
@@ -522,7 +518,7 @@ impl<T: FootprintDomain> AccessPathTrie<T> {
 
     /// Apply `f` to each (access path, data) pair encoded in `self`
     /// and collects the result when `f` returns `Some(r)`
-    pub fn map_paths<F, R>(&self, mut f: F) -> Vec<R>
+    pub fn filter_map_paths<F, R>(&self, mut f: F) -> Vec<R>
     where
         F: FnMut(&AccessPath, &T) -> Option<R>,
     {

--- a/language/move-prover/bytecode/src/read_write_set_analysis.rs
+++ b/language/move-prover/bytecode/src/read_write_set_analysis.rs
@@ -699,13 +699,13 @@ impl<'a> CompositionalAnalysis<ReadWriteSetState> for ReadWriteSetAnalysis<'a> {
         let aps_to_remove =
             state
                 .locals
-                .map_paths(|ap, addrs| match (addrs.iter().next(), addrs.len()) {
+                .filter_map_paths(|ap, addrs| match (addrs.iter().next(), addrs.len()) {
                     (Some(Addr::Footprint(x)), 1) if x == ap => Some(ap.clone()),
                     _ => None,
                 });
-        aps_to_remove.iter().for_each(|ap| {
+        for ap in aps_to_remove.iter() {
             state.locals.remove_node(ap.clone());
-        });
+        }
 
         state
     }

--- a/language/move-prover/bytecode/src/read_write_set_analysis.rs
+++ b/language/move-prover/bytecode/src/read_write_set_analysis.rs
@@ -694,7 +694,18 @@ impl<'a> CompositionalAnalysis<ReadWriteSetState> for ReadWriteSetAnalysis<'a> {
                 }
             }
         }
-        // TODO: if the data associated with path P is Footprint(P), remove it
+
+        // collect access paths only associated with a single addr s.t. ap = { Footprint(ap) }
+        let aps_to_remove =
+            state
+                .locals
+                .map_paths(|ap, addrs| match (addrs.iter().next(), addrs.len()) {
+                    (Some(Addr::Footprint(x)), 1) if x == ap => Some(ap.clone()),
+                    _ => None,
+                });
+        aps_to_remove.iter().for_each(|ap| {
+            state.locals.remove_node(ap.clone());
+        });
 
         state
     }

--- a/language/move-prover/bytecode/tests/read_write_set/bool_footprint.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/bool_footprint.exp
@@ -98,8 +98,6 @@ public fun BoolFootprint::global_get($t0|a: address): bool {
      # Formal(0)/0x1::BoolFootprint::B/b: Read
      #
      # Locals:
-     # Formal(0): Formal(0)
-     # Formal(0)/0x1::BoolFootprint::B/b: Formal(0)/0x1::BoolFootprint::B/b
      # Ret(0): Formal(0)/0x1::BoolFootprint::B/b
      #
   0: $t2 := copy($t0)

--- a/language/move-prover/bytecode/tests/read_write_set/borrow.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/borrow.exp
@@ -30,7 +30,6 @@ fun Borrow::borrow_s($t0|a: address) {
      # Accesses:
      #
      # Locals:
-     # Formal(0): Formal(0)
      #
   0: $t1 := copy($t0)
   1: $t2 := borrow_global<Borrow::S>($t1)
@@ -46,7 +45,6 @@ fun Borrow::borrow_s_mut($t0|a: address) {
      # Accesses:
      #
      # Locals:
-     # Formal(0): Formal(0)
      #
   0: $t1 := copy($t0)
   1: $t2 := borrow_global<Borrow::S>($t1)

--- a/language/move-prover/bytecode/tests/read_write_set/counter.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/counter.exp
@@ -69,8 +69,6 @@ fun Counter::call_increment1($t0|s: &mut Counter::S) {
      # Formal(0)/f: ReadWrite
      #
      # Locals:
-     # Formal(0): Formal(0)
-     # Formal(0)/f: Formal(0)/f
      #
   0: $t1 := move($t0)
   1: $t2 := borrow_field<Counter::S>.f($t1)
@@ -87,7 +85,6 @@ fun Counter::call_increment2($t0|a: address) {
      # Formal(0)/0x1::Counter::S/f: ReadWrite
      #
      # Locals:
-     # Formal(0): Formal(0)
      #
   0: $t1 := copy($t0)
   1: $t2 := borrow_global<Counter::S>($t1)
@@ -131,8 +128,6 @@ fun Counter::increment2($t0|s: &mut Counter::S) {
      # Formal(0)/f: ReadWrite
      #
      # Locals:
-     # Formal(0): Formal(0)
-     # Formal(0)/f: Formal(0)/f
      #
   0: $t1 := copy($t0)
   1: $t2 := borrow_field<Counter::S>.f($t1)

--- a/language/move-prover/bytecode/tests/read_write_set/exists.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/exists.exp
@@ -131,8 +131,6 @@ public fun Exists::exists_field($t0|s: &Exists::S): bool {
      # Formal(0)/f/0x2::Exists::T: Read
      #
      # Locals:
-     # Formal(0): Formal(0)
-     # Formal(0)/f: Formal(0)/f
      #
   0: $t1 := move($t0)
   1: $t2 := borrow_field<Exists::S>.f($t1)

--- a/language/move-prover/bytecode/tests/read_write_set/fields.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/fields.exp
@@ -34,8 +34,6 @@ public fun Fields::borrow_read($t0|s: &Fields::S): u64 {
      # Formal(0)/f: Read
      #
      # Locals:
-     # Formal(0): Formal(0)
-     # Formal(0)/f: Formal(0)/f
      # Ret(0): Formal(0)/f
      #
   0: $t1 := move($t0)
@@ -54,8 +52,6 @@ public fun Fields::borrow_read_generic<#0>($t0|t: &Fields::T<#0>): u64 {
      # Formal(0)/f: Read
      #
      # Locals:
-     # Formal(0): Formal(0)
-     # Formal(0)/f: Formal(0)/f
      # Ret(0): Formal(0)/f
      #
   0: $t1 := move($t0)

--- a/language/move-prover/bytecode/tests/read_write_set/footprint.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/footprint.exp
@@ -136,7 +136,6 @@ public fun Footprint::reassign_field($t0|s: &mut Footprint::S) {
      # Formal(0)/f: Write
      #
      # Locals:
-     # Formal(0): Formal(0)
      # Formal(0)/f: 0x2
      #
   0: $t1 := 0x2
@@ -158,7 +157,6 @@ public fun Footprint::reassign_field_cond($t0|s: &mut Footprint::S, $t1|b: bool)
      # Formal(0)/f: Write
      #
      # Locals:
-     # Formal(0): Formal(0)
      # Formal(0)/f: {0x2, Formal(0)/f, }
      #
   0: $t2 := copy($t1)

--- a/language/move-prover/bytecode/tests/read_write_set/functions.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/functions.exp
@@ -93,7 +93,6 @@ public fun Funtions::call_write_vec($t0|a: address, $t1|v: vector<u8>) {
      # Formal(0)/0x1::Funtions::R/v: Write
      #
      # Locals:
-     # Formal(0): Formal(0)
      #
   0: $t2 := copy($t0)
   1: $t3 := borrow_global<Funtions::R>($t2)
@@ -194,7 +193,6 @@ public fun Funtions::write_vec($t0|r: &mut Funtions::R, $t1|v: vector<u8>) {
      # Formal(0)/v: Write
      #
      # Locals:
-     # Formal(0): Formal(0)
      # Formal(0)/v: Formal(1)
      #
   0: $t2 := move($t1)

--- a/language/move-prover/bytecode/tests/read_write_set/multi_deps.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/multi_deps.exp
@@ -1,0 +1,90 @@
+============ initial translation from Move ================
+
+[variant baseline]
+fun MultiDeps::add_to($t0|s: &mut MultiDeps::S, $t1|t: &MultiDeps::T, $t2|v: bool) {
+     var $t3|tmp#$3: u64
+     var $t4: bool
+     var $t5: &MultiDeps::T
+     var $t6: &mut MultiDeps::S
+     var $t7: &mut u64
+     var $t8: u64
+     var $t9: &MultiDeps::T
+     var $t10: &u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: &mut MultiDeps::S
+     var $t14: &mut u64
+  0: $t4 := copy($t2)
+  1: if ($t4) goto 4 else goto 2
+  2: label L1
+  3: goto 12
+  4: label L0
+  5: $t5 := move($t1)
+  6: destroy($t5)
+  7: $t6 := copy($t0)
+  8: $t7 := borrow_field<MultiDeps::S>.f($t6)
+  9: $t8 := read_ref($t7)
+ 10: $t3 := $t8
+ 11: goto 18
+ 12: label L2
+ 13: $t9 := move($t1)
+ 14: $t10 := borrow_field<MultiDeps::T>.f($t9)
+ 15: $t11 := read_ref($t10)
+ 16: $t3 := $t11
+ 17: goto 18
+ 18: label L3
+ 19: $t12 := move($t3)
+ 20: $t13 := move($t0)
+ 21: $t14 := borrow_field<MultiDeps::S>.f($t13)
+ 22: write_ref($t14, $t12)
+ 23: return ()
+}
+
+============ after pipeline `read_write_set` ================
+
+[variant baseline]
+fun MultiDeps::add_to($t0|s: &mut MultiDeps::S, $t1|t: &MultiDeps::T, $t2|v: bool) {
+     var $t3|tmp#$3: u64
+     var $t4: bool
+     var $t5: &MultiDeps::T
+     var $t6: &mut MultiDeps::S
+     var $t7: &mut u64
+     var $t8: u64
+     var $t9: &MultiDeps::T
+     var $t10: &u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: &mut MultiDeps::S
+     var $t14: &mut u64
+     # Accesses:
+     # Formal(0)/f: ReadWrite
+     # Formal(1)/f: Read
+     #
+     # Locals:
+     # Formal(0)/f: {Formal(0)/f, Formal(1)/f, }
+     #
+  0: $t4 := copy($t2)
+  1: if ($t4) goto 4 else goto 2
+  2: label L1
+  3: goto 12
+  4: label L0
+  5: $t5 := move($t1)
+  6: destroy($t5)
+  7: $t6 := copy($t0)
+  8: $t7 := borrow_field<MultiDeps::S>.f($t6)
+  9: $t8 := read_ref($t7)
+ 10: $t3 := $t8
+ 11: goto 18
+ 12: label L2
+ 13: $t9 := move($t1)
+ 14: $t10 := borrow_field<MultiDeps::T>.f($t9)
+ 15: $t11 := read_ref($t10)
+ 16: $t3 := $t11
+ 17: goto 18
+ 18: label L3
+ 19: $t12 := move($t3)
+ 20: $t13 := move($t0)
+ 21: $t14 := borrow_field<MultiDeps::S>.f($t13)
+ 22: write_ref($t14, $t12)
+ 23: return ()
+}

--- a/language/move-prover/bytecode/tests/read_write_set/multi_deps.move
+++ b/language/move-prover/bytecode/tests/read_write_set/multi_deps.move
@@ -1,0 +1,11 @@
+address 0x1 {
+module MultiDeps {
+  struct S has key { f: u64 }
+  struct T has key { f: u64 }
+
+  fun add_to(s: &mut S, t: &T, v: bool) {
+      *&mut s.f = if(v) { *&mut s.f } else { t.f }
+  }
+
+}
+}

--- a/language/move-prover/bytecode/tests/read_write_set/summary.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/summary.exp
@@ -70,8 +70,6 @@ public fun Summary::write_callee($t0|s2: &mut Summary::S2) {
      # Formal(0)/f: Write
      #
      # Locals:
-     # Formal(0): Formal(0)
-     # Formal(0)/f: Formal(0)/f
      #
   0: $t1 := 7
   1: $t2 := move($t0)
@@ -89,7 +87,6 @@ public fun Summary::write_caller1($t0|a: address) {
      # Formal(0)/0x2::Summary::S2/f: Write
      #
      # Locals:
-     # Formal(0): Formal(0)
      #
   0: $t1 := copy($t0)
   1: $t2 := borrow_global<Summary::S2>($t1)
@@ -107,8 +104,6 @@ public fun Summary::write_caller2($t0|a: address) {
      # Formal(0)/0x2::Summary::S1/s2/f: Write
      #
      # Locals:
-     # Formal(0): Formal(0)
-     # Formal(0)/0x2::Summary::S1/s2: Formal(0)/0x2::Summary::S1/s2
      #
   0: $t1 := copy($t0)
   1: $t2 := borrow_global<Summary::S1>($t1)

--- a/language/move-prover/bytecode/tests/read_write_set/update_return.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/update_return.exp
@@ -82,8 +82,6 @@ public fun UpdateReturn::write_f($t0|s: &mut UpdateReturn::S, $t1|x: u64): u64 {
      # Formal(0)/f: Write
      #
      # Locals:
-     # Formal(0): Formal(0)
-     # Formal(0)/f: Formal(0)/f
      # Ret(0): Formal(1)
      #
   0: $t2 := 7

--- a/language/tools/move-cli/tests/testsuite/concretize_read_write_set/args.exp
+++ b/language/tools/move-cli/tests/testsuite/concretize_read_write_set/args.exp
@@ -5,9 +5,6 @@ Formal(0)/0x1::ConcretizeSecondaryIndexes::Addr/a: Read
 Formal(0)/0x1::ConcretizeSecondaryIndexes::Addr/a/0x1::ConcretizeSecondaryIndexes::S/f: Read
 
 Locals:
-Formal(0): Formal(0)
-Formal(0)/0x1::ConcretizeSecondaryIndexes::Addr/a: Formal(0)/0x1::ConcretizeSecondaryIndexes::Addr/a
-Formal(0)/0x1::ConcretizeSecondaryIndexes::Addr/a/0x1::ConcretizeSecondaryIndexes::S/f: Formal(0)/0x1::ConcretizeSecondaryIndexes::Addr/a/0x1::ConcretizeSecondaryIndexes::S/f
 Ret(0): Formal(0)/0x1::ConcretizeSecondaryIndexes::Addr/a/0x1::ConcretizeSecondaryIndexes::S/f
 
 Command `experimental read-write-set storage/0x00000000000000000000000000000001/modules/ConcretizeSecondaryIndexes.mv read_indirect --concretize --args 0xA`:
@@ -31,10 +28,6 @@ Formal(0)/0x1::ConcretizeVector::S/v/[_]: Read
 Formal(0)/0x1::ConcretizeVector::S/v/[_]/0x1::ConcretizeVector::T/f: Read
 
 Locals:
-Formal(0): Formal(0)
-Formal(0)/0x1::ConcretizeVector::S/v: Formal(0)/0x1::ConcretizeVector::S/v
-Formal(0)/0x1::ConcretizeVector::S/v/[_]: Formal(0)/0x1::ConcretizeVector::S/v/[_]
-Formal(0)/0x1::ConcretizeVector::S/v/[_]/0x1::ConcretizeVector::T/f: Formal(0)/0x1::ConcretizeVector::S/v/[_]/0x1::ConcretizeVector::T/f
 Ret(0): Formal(0)/0x1::ConcretizeVector::S/v/[_]/0x1::ConcretizeVector::T/f
 
 Command `experimental read-write-set storage/0x00000000000000000000000000000001/modules/ConcretizeVector.mv read_vec --concretize --args 0x1`:

--- a/language/tools/move-cli/tests/testsuite/read_write_set/args.exp
+++ b/language/tools/move-cli/tests/testsuite/read_write_set/args.exp
@@ -5,8 +5,6 @@ Accesses:
 Formal(0)/f: Read
 
 Locals:
-Formal(0): Formal(0)
-Formal(0)/f: Formal(0)/f
 Ret(0): Formal(0)/f
 
 Command `experimental read-write-set storage/0x00000000000000000000000000000001/modules/RWSet.mv write_f --mode bare -v`:
@@ -15,6 +13,4 @@ Accesses:
 Formal(0)/f: Write
 
 Locals:
-Formal(0): Formal(0)
-Formal(0)/f: Formal(0)/f
 


### PR DESCRIPTION
## Motivation

Avoid "locals" part of a function summary for the read/write set analysis to contain redundant entries such as `Formal(0)/0x1::BoolFootprint::B/b: Formal(0)/0x1::BoolFootprint::B/b`

### Have you read the [Contributing Guidelines on pull requests]
yes

## Test Plan

Smoke tests updated accordingly

## Related PRs

Closes #8585 

