### PR TITLE
Cherry-pick PR #8646 into release-1.3: jsonrpc-types: add default unknown variants to various enums

### DIFF
--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -61,8 +61,6 @@ impl AmountView {
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 #[serde(tag = "type")]
 pub enum AccountRoleView {
-    #[serde(rename = "unknown")]
-    Unknown,
     #[serde(rename = "child_vasp")]
     ChildVASP { parent_vasp_address: AccountAddress },
     #[serde(rename = "parent_vasp")]
@@ -93,6 +91,11 @@ pub enum AccountRoleView {
         #[serde(skip_serializing_if = "Option::is_none")]
         diem_id_domain_events_key: Option<EventKey>,
     },
+    /// The Unknown variant is deserialized by the client if it sees
+    /// a variant that it doesn't know about
+    #[serde(rename = "unknown")]
+    #[serde(other)]
+    Unknown,
 }
 
 impl AccountRoleView {
@@ -641,6 +644,8 @@ pub enum VMStatusView {
     VerificationError,
     DeserializationError,
     PublishingFailure,
+    #[serde(other)]
+    Unknown,
 }
 
 impl VMStatusView {
@@ -678,6 +683,7 @@ impl std::fmt::Display for VMStatusView {
             VMStatusView::VerificationError => write!(f, "Verification Error"),
             VMStatusView::DeserializationError => write!(f, "Deserialization Error"),
             VMStatusView::PublishingFailure => write!(f, "Publishing Failure"),
+            VMStatusView::Unknown => write!(f, "Unknown Error"),
         }
     }
 }
@@ -946,7 +952,8 @@ pub enum TransactionDataView {
         script: ScriptView,
     },
     #[serde(rename = "unknown")]
-    UnknownTransaction {},
+    #[serde(other)]
+    UnknownTransaction,
 }
 
 impl From<Transaction> for TransactionDataView {


### PR DESCRIPTION
This cherry-pick was triggerd by a request on #8646
Please review the diff to ensure there are not any unexpected changes.

> It was recently reported in https://github.com/diem/diem/issues/8643
> that a client built from the release-1.2 branch failed to deserialize a
> response from a server built from the release-1.3 branch with the
> following error:
> 
> ```
> "unknown variant `treasury_compliance`, expected one of `unknown`, `child_vasp`, `parent_vasp`, `designated_dealer`"
> ```
> 
> Looking at the difference between the code in
> `json-rpc/types/src/views.rs` for the two difference releases it looks
> like the TreasuryCompliance Role didn't exist in the 1.2 release but
> does in the 1.3 release. So the old client wouldn't be able to properly
> understand, parse and interpret that role since the old client doesn't
> know about it. Despite this the older client should still be able to
> properly deserialize a response from a newer server.
> 
> This patch addresses this issue by ensuring that all view enum's defined
> have an `Unknown` varient marked with `#[serde(other)]` which will cause
> deserialization to default to the `Unknown` variant in the event the
> client doesn't know about a variant.
> 
> Fixes: #8643

            
cc @bmwill