### PR TITLE
[move-cli] add explicit dependency to stdlib with testing feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4571,6 +4571,7 @@ dependencies = [
  "move-core-types",
  "move-coverage",
  "move-lang",
+ "move-stdlib",
  "move-vm-runtime",
  "move-vm-types",
  "once_cell",

--- a/language/tools/move-cli/Cargo.toml
+++ b/language/tools/move-cli/Cargo.toml
@@ -27,6 +27,7 @@ move-bytecode-utils = { path = "../move-bytecode-utils" }
 move-coverage = { path = "../move-coverage" }
 move-core-types = { path = "../../move-core/types" }
 move-lang = { path = "../../move-lang" }
+move-stdlib = { path = "../../move-stdlib", features = ["testing"] }
 move-vm-types = { path = "../../move-vm/types" }
 move-vm-runtime = { path = "../../move-vm/runtime" }
 read-write-set = { path = "../read-write-set" }


### PR DESCRIPTION
(copied and re-organized from the discussion on Slack)

- Crate `move-stdlib` has a feature flag `testing`, which if present,
  enables a few more Move VM native functions for debugging and testing.

- Crate `move-cli` depends on `move-stdlib` indirectly and it has a few
  test cases that depends on the existence of these special native
  functions. (e.g., `debug` functions)

- However, the crates that indirectly import `move-stdlib` for `move-cli`
  (e.g., the `move-lang` crate) does not import `move-stdlib` with
  the `testing` feature requested.

This PR is a temporary fix that explicitly import `move-stdlib` with
the `testing` feature flag set in the Cargo.toml file for `move-cli`.
Without this fix, `cargo test` under the `move-cli` will fail.

## Motivation

Quick fix and unblock testing

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

`cargo test` or `cargo xtest` under `move-cli` crate.
