### PR TITLE
[decoupled-execution] add new message types: CommitProposal and Committ Decision

### DIFF
--- a/consensus/consensus-types/src/experimental/commit_decision.rs
+++ b/consensus/consensus-types/src/experimental/commit_decision.rs
@@ -1,0 +1,57 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::common::Round;
+use anyhow::Context;
+use diem_types::{ledger_info::LedgerInfoWithSignatures, validator_verifier::ValidatorVerifier};
+use serde::{Deserialize, Serialize};
+use std::fmt::{Debug, Display, Formatter};
+
+#[derive(Deserialize, Serialize, Clone, PartialEq, Eq)]
+pub struct CommitDecision {
+    ledger_info: LedgerInfoWithSignatures,
+    // TOOD: we can include a full state here.
+}
+
+// this is required by structured log
+impl Debug for CommitDecision {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl Display for CommitDecision {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "CommitDecision: [{}]", self.ledger_info)
+    }
+}
+
+impl CommitDecision {
+    /// Generates a new CommitDecision
+    pub fn new(ledger_info: LedgerInfoWithSignatures) -> Self {
+        Self { ledger_info }
+    }
+
+    pub fn round(&self) -> Round {
+        self.ledger_info.ledger_info().round()
+    }
+
+    pub fn epoch(&self) -> u64 {
+        self.ledger_info.ledger_info().epoch()
+    }
+
+    /// Return the LedgerInfo associated with this commit proposal
+    pub fn ledger_info(&self) -> &LedgerInfoWithSignatures {
+        &self.ledger_info
+    }
+
+    /// Verifies that the signatures carried in the message forms a valid quorum,
+    /// and then verifies the signature.
+    pub fn verify(&self, validator: &ValidatorVerifier) -> anyhow::Result<()> {
+        // We do not need to check the author because as long as the signature tree
+        // is valid, the message should be valid.
+        self.ledger_info
+            .verify_signatures(validator)
+            .context("Failed to verify Commit Decision")
+    }
+}

--- a/consensus/consensus-types/src/experimental/commit_vote.rs
+++ b/consensus/consensus-types/src/experimental/commit_vote.rs
@@ -1,0 +1,94 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::common::{Author, Round};
+use anyhow::Context;
+use diem_crypto::ed25519::Ed25519Signature;
+use diem_types::{
+    ledger_info::LedgerInfo, validator_signer::ValidatorSigner,
+    validator_verifier::ValidatorVerifier,
+};
+use serde::{Deserialize, Serialize};
+use short_hex_str::AsShortHexStr;
+use std::fmt::{Debug, Display, Formatter};
+
+#[derive(Deserialize, Serialize, Clone, PartialEq, Eq)]
+pub struct CommitVote {
+    author: Author,
+    ledger_info: LedgerInfo,
+    signature: Ed25519Signature,
+}
+
+// this is required by structured log
+impl Debug for CommitVote {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl Display for CommitVote {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "CommitProposal: [author: {}, {}]",
+            self.author.short_str(),
+            self.ledger_info
+        )
+    }
+}
+
+impl CommitVote {
+    /// Generates a new CommitProposal
+    pub fn new(
+        author: Author,
+        ledger_info_placeholder: LedgerInfo,
+        validator_signer: &ValidatorSigner,
+    ) -> Self {
+        let signature = validator_signer.sign(&ledger_info_placeholder);
+        Self::new_with_signature(author, ledger_info_placeholder, signature)
+    }
+
+    /// Generates a new CommitProposal using a signature over the specified ledger_info
+    pub fn new_with_signature(
+        author: Author,
+        ledger_info: LedgerInfo,
+        signature: Ed25519Signature,
+    ) -> Self {
+        Self {
+            author,
+            ledger_info,
+            signature,
+        }
+    }
+
+    /// Return the author of the commit proposal
+    pub fn author(&self) -> Author {
+        self.author
+    }
+
+    /// Return the LedgerInfo associated with this commit proposal
+    pub fn ledger_info(&self) -> &LedgerInfo {
+        &self.ledger_info
+    }
+
+    /// Return the signature of the vote
+    pub fn signature(&self) -> &Ed25519Signature {
+        &self.signature
+    }
+
+    pub fn round(&self) -> Round {
+        self.ledger_info.round()
+    }
+
+    pub fn epoch(&self) -> u64 {
+        self.ledger_info.epoch()
+    }
+
+    /// Verifies that the consensus data hash of LedgerInfo corresponds to the commit proposal,
+    /// and then verifies the signature.
+    pub fn verify(&self, validator: &ValidatorVerifier) -> anyhow::Result<()> {
+        validator
+            .verify(self.author(), &self.ledger_info, &self.signature)
+            .context("Failed to verify Commit Proposal")
+    }
+}

--- a/consensus/consensus-types/src/experimental/mod.rs
+++ b/consensus/consensus-types/src/experimental/mod.rs
@@ -1,0 +1,5 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod commit_decision;
+pub mod commit_vote;

--- a/consensus/consensus-types/src/lib.rs
+++ b/consensus/consensus-types/src/lib.rs
@@ -9,6 +9,7 @@ pub mod block_retrieval;
 pub mod common;
 pub mod epoch_retrieval;
 pub mod executed_block;
+pub mod experimental;
 pub mod proposal_msg;
 pub mod quorum_cert;
 pub mod safety_data;

--- a/consensus/src/network_interface.rs
+++ b/consensus/src/network_interface.rs
@@ -8,6 +8,7 @@ use channel::message_queues::QueueStyle;
 use consensus_types::{
     block_retrieval::{BlockRetrievalRequest, BlockRetrievalResponse},
     epoch_retrieval::EpochRetrievalRequest,
+    experimental::{commit_decision::CommitDecision, commit_vote::CommitVote},
     proposal_msg::ProposalMsg,
     sync_info::SyncInfo,
     vote_msg::VoteMsg,
@@ -47,6 +48,13 @@ pub enum ConsensusMsg {
     /// VoteMsg is the struct that is ultimately sent by the voter in response for receiving a
     /// proposal.
     VoteMsg(Box<VoteMsg>),
+    /// CommitProposal is the struct that is sent by the validator after execution to propose
+    /// on the committed state hash root.
+    CommitVoteMsg(Box<CommitVote>),
+    /// CommitDecision is the struct that is sent by the validator after collecting no fewer
+    /// than 2f + 1 signatures on the commit proposal. This part is not on the critical path, but
+    /// it can save slow machines to quickly confirm the execution result.
+    CommitDecisionMsg(Box<CommitDecision>),
 }
 
 /// The interface from Network to Consensus layer.

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -108,6 +108,18 @@ ChangeSet:
     - events:
         SEQ:
           TYPENAME: ContractEvent
+CommitDecision:
+  STRUCT:
+    - ledger_info:
+        TYPENAME: LedgerInfoWithSignatures
+CommitVote:
+  STRUCT:
+    - author:
+        TYPENAME: AccountAddress
+    - ledger_info:
+        TYPENAME: LedgerInfo
+    - signature:
+        TYPENAME: Ed25519Signature
 ConsensusMsg:
   ENUM:
     0:
@@ -138,6 +150,14 @@ ConsensusMsg:
       VoteMsg:
         NEWTYPE:
           TYPENAME: VoteMsg
+    7:
+      CommitVoteMsg:
+        NEWTYPE:
+          TYPENAME: CommitVote
+    8:
+      CommitDecisionMsg:
+        NEWTYPE:
+          TYPENAME: CommitDecision
 ContractEvent:
   ENUM:
     0:


### PR DESCRIPTION
Commit phase broadcasts commit proposals to seek agreement on the execution state.
Upon receiving a valid quorum of signatures on the same execution state, the nodes
will commit the execution result, and asynchronously broadcast a new commit
decision message containing the accumulated signatures to help slower nodes catch
up quickly. A node receiving a valid commit decision message does not have to wait
for commit proposals any more. It can directly commit the execution result.

Message handling is not included in this commit.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This is part of the decoupled-execution project.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update or suggest changes to the docs at https://developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
