### PR TITLE
[decoupled-execution] Add a new API for the TSafetyRules trait

### DIFF
--- a/consensus/safety-rules/src/error.rs
+++ b/consensus/safety-rules/src/error.rs
@@ -47,6 +47,10 @@ pub enum Error {
     NotSafeToTimeout(u64, u64, u64, u64),
     #[error("Invalid TC: {0}")]
     InvalidTimeoutCertificate(String),
+    #[error("Inconsistent Execution Result: Ordered BlockInfo doesn't match executed BlockInfo. Ordered: {0}, Executed: {1}")]
+    InconsistentExecutionResult(String, String),
+    #[error("Invalid Ordered LedgerInfoWithSignatures: Empty or at least one of executed_state_id, version, or epoch_state are not dummy value: {0}")]
+    InvalidOrderedLedgerInfo(String),
 }
 
 impl From<bcs::Error> for Error {

--- a/consensus/safety-rules/src/local_client.rs
+++ b/consensus/safety-rules/src/local_client.rs
@@ -12,7 +12,10 @@ use consensus_types::{
 };
 use diem_crypto::ed25519::Ed25519Signature;
 use diem_infallible::RwLock;
-use diem_types::epoch_change::EpochChangeProof;
+use diem_types::{
+    epoch_change::EpochChangeProof,
+    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+};
 use std::sync::Arc;
 
 /// A local interface into SafetyRules. Constructed in such a way that the container / caller
@@ -70,5 +73,15 @@ impl TSafetyRules for LocalClient {
         self.internal
             .write()
             .construct_and_sign_vote_two_chain(vote_proposal, timeout_cert)
+    }
+
+    fn sign_commit_vote(
+        &mut self,
+        ledger_info: LedgerInfoWithSignatures,
+        new_ledger_info: LedgerInfo,
+    ) -> Result<Ed25519Signature, Error> {
+        self.internal
+            .write()
+            .sign_commit_vote(ledger_info, new_ledger_info)
     }
 }

--- a/consensus/safety-rules/src/logging.rs
+++ b/consensus/safety-rules/src/logging.rs
@@ -54,6 +54,7 @@ pub enum LogEntry {
     SignTimeoutWithQC,
     State,
     Waypoint,
+    SignCommitVote,
 }
 
 impl LogEntry {
@@ -73,6 +74,7 @@ impl LogEntry {
             LogEntry::SignTimeoutWithQC => "sign_timeout_with_qc",
             LogEntry::State => "state",
             LogEntry::Waypoint => "waypoint",
+            LogEntry::SignCommitVote => "sign_commit_vote",
         }
     }
 }

--- a/consensus/safety-rules/src/t_safety_rules.rs
+++ b/consensus/safety-rules/src/t_safety_rules.rs
@@ -11,7 +11,10 @@ use consensus_types::{
     vote_proposal::MaybeSignedVoteProposal,
 };
 use diem_crypto::ed25519::Ed25519Signature;
-use diem_types::epoch_change::EpochChangeProof;
+use diem_types::{
+    epoch_change::EpochChangeProof,
+    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+};
 
 /// Interface for SafetyRules
 pub trait TSafetyRules {
@@ -56,4 +59,12 @@ pub trait TSafetyRules {
     ) -> Result<Vote, Error> {
         unimplemented!();
     }
+
+    /// As the holder of the private key, SafetyRules also signs a commit vote.
+    /// This returns the signature for the commit vote.
+    fn sign_commit_vote(
+        &mut self,
+        ledger_info: LedgerInfoWithSignatures,
+        new_ledger_info: LedgerInfo,
+    ) -> Result<Ed25519Signature, Error>;
 }

--- a/consensus/src/metrics_safety_rules.rs
+++ b/consensus/src/metrics_safety_rules.rs
@@ -8,7 +8,10 @@ use consensus_types::{
 };
 use diem_crypto::ed25519::Ed25519Signature;
 use diem_metrics::monitor;
-use diem_types::epoch_change::EpochChangeProof;
+use diem_types::{
+    epoch_change::EpochChangeProof,
+    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+};
 use safety_rules::{ConsensusState, Error, TSafetyRules};
 use std::sync::Arc;
 
@@ -78,5 +81,18 @@ impl TSafetyRules for MetricsSafetyRules {
 
     fn sign_timeout(&mut self, timeout: &Timeout) -> Result<Ed25519Signature, Error> {
         self.retry(|inner| monitor!("safety_rules", inner.sign_timeout(timeout)))
+    }
+
+    fn sign_commit_vote(
+        &mut self,
+        ledger_info: LedgerInfoWithSignatures,
+        new_ledger_info: LedgerInfo,
+    ) -> Result<Ed25519Signature, Error> {
+        self.retry(|inner| {
+            monitor!(
+                "safety_rules",
+                inner.sign_commit_vote(ledger_info.clone(), new_ledger_info.clone())
+            )
+        })
     }
 }

--- a/types/src/block_info.rs
+++ b/types/src/block_info.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{epoch_state::EpochState, on_chain_config::ValidatorSet, transaction::Version};
-use diem_crypto::hash::HashValue;
-#[cfg(any(test, feature = "fuzzing"))]
-use diem_crypto::hash::ACCUMULATOR_PLACEHOLDER_HASH;
+use diem_crypto::hash::{HashValue, ACCUMULATOR_PLACEHOLDER_HASH};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -156,6 +154,26 @@ impl BlockInfo {
 
     pub fn version(&self) -> Version {
         self.version
+    }
+
+    /// This function checks if the current BlockInfo has
+    /// exactly the same values in those fields that will not change
+    /// after execution, compred to a given BlockInfo
+    pub fn match_ordered_only(&self, block_info: &BlockInfo) -> bool {
+        self.epoch == block_info.epoch
+            && self.round == block_info.round
+            && self.id == block_info.id
+            && self.timestamp_usecs == block_info.timestamp_usecs
+    }
+
+    /// This function checks if the current BlockInfo is consistent
+    /// with the dummy values we put in the ordering state computer
+    /// and it is not empty
+    pub fn is_ordered_only(&self) -> bool {
+        *self != BlockInfo::empty()
+            && self.next_epoch_state == None
+            && self.executed_state_id == *ACCUMULATOR_PLACEHOLDER_HASH
+            && self.version == 0
     }
 }
 


### PR DESCRIPTION
We add a new API for the TSafetyRules trait:

`fn sign_commit_vote(&mut self, ledger_info: LedgerInfoWithSignatures, verifier: &ValidatorVerifier) -> Result<Ed25519Signature, Error>`

This function will be used to sign commit vote messages sent in the commit phase.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This is part of the decoupled execution project.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

We will add tests later after we finish the integration.

## Related PRs

(If this PR adds or changes functionality, please take some time to update or suggest changes to the docs at https://developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
