### PR TITLE
[read/write set] handle addresses flowing into/out of structs via pac…

### DIFF
--- a/language/diem-tools/df-cli/tests/testsuite/concretize_read_write_set_smoke/args.exp
+++ b/language/diem-tools/df-cli/tests/testsuite/concretize_read_write_set_smoke/args.exp
@@ -9,12 +9,15 @@ Command `experimental read-write-set storage/0x00000000000000000000000000000001/
 0xa/0x1::AccountFreezing::FreezingBit/is_frozen: Read
 0xa/0x1::VASP::ParentVASP: Read
 0xa/0x1::DiemAccount::DiemAccount: Read
+0xa/0x1::DiemAccount::DiemAccount/withdraw_capability: Read
 0xa/0x1::DiemAccount::DiemAccount/withdraw_capability/vec: Read
 0xa/0x1::DiemAccount::DiemAccount/withdraw_capability/vec/[_]: ReadWrite
 0xa/0x1::DiemAccount::DiemAccount/withdraw_capability/vec/[_]/account_address: Read
+0xa/0x1::DiemAccount::DiemAccount/sent_events: Read
 0xa/0x1::DiemAccount::DiemAccount/sent_events/counter: ReadWrite
 0xa/0x1::DiemAccount::DiemAccount/sent_events/guid: Read
 0xa/0x1::DiemAccount::Balance<0x1::XUS::XUS>: Read
+0xa/0x1::DiemAccount::Balance<0x1::XUS::XUS>/coin: Read
 0xa/0x1::DiemAccount::Balance<0x1::XUS::XUS>/coin/value: ReadWrite
 0xb/0x1::AccountFreezing::FreezingBit: Read
 0xb/0x1::AccountFreezing::FreezingBit/is_frozen: Read
@@ -23,9 +26,11 @@ Command `experimental read-write-set storage/0x00000000000000000000000000000001/
 0xb/0x1::DualAttestation::Credential/base_url: Read
 0xb/0x1::DualAttestation::Credential/compliance_public_key: Read
 0xb/0x1::DiemAccount::DiemAccount: Read
+0xb/0x1::DiemAccount::DiemAccount/received_events: Read
 0xb/0x1::DiemAccount::DiemAccount/received_events/counter: ReadWrite
 0xb/0x1::DiemAccount::DiemAccount/received_events/guid: Read
 0xb/0x1::DiemAccount::Balance<0x1::XUS::XUS>: Read
+0xb/0x1::DiemAccount::Balance<0x1::XUS::XUS>/coin: Read
 0xb/0x1::DiemAccount::Balance<0x1::XUS::XUS>/coin/value: ReadWrite
 0xa550c18/0x1::DiemTimestamp::CurrentTimeMicroseconds: Read
 0xa550c18/0x1::DiemTimestamp::CurrentTimeMicroseconds/microseconds: Read

--- a/language/diem-tools/df-cli/tests/testsuite/diem_read_write_set_smoke/args.exp
+++ b/language/diem-tools/df-cli/tests/testsuite/diem_read_write_set_smoke/args.exp
@@ -11,6 +11,7 @@ Accesses:
 0xa550c18/0x1::DualAttestation::Limit/micro_xdx_limit: Read
 Formal(0): Read
 Formal(0)/0x1::DiemAccount::DiemAccount: Read
+Formal(0)/0x1::DiemAccount::DiemAccount/withdraw_capability: Read
 Formal(0)/0x1::DiemAccount::DiemAccount/withdraw_capability/vec: Read
 Formal(0)/0x1::DiemAccount::DiemAccount/withdraw_capability/vec/[_]: ReadWrite
 Formal(0)/0x1::DiemAccount::DiemAccount/withdraw_capability/vec/[_]/account_address: Read
@@ -42,11 +43,14 @@ Formal(0)/0x1::DiemAccount::DiemAccount/withdraw_capability/vec/[_]/account_addr
 Formal(0)/0x1::DiemAccount::DiemAccount/withdraw_capability/vec/[_]/account_address/0x1::VASP::ChildVASP/parent_vasp_addr/AccountLimits::Window<#0>/limit_address/AccountLimits::LimitsDefinition<#0>/max_holding: Read
 Formal(0)/0x1::DiemAccount::DiemAccount/withdraw_capability/vec/[_]/account_address/0x1::VASP::ParentVASP: Read
 Formal(0)/0x1::DiemAccount::DiemAccount/withdraw_capability/vec/[_]/account_address/0x1::DiemAccount::DiemAccount: Read
+Formal(0)/0x1::DiemAccount::DiemAccount/withdraw_capability/vec/[_]/account_address/0x1::DiemAccount::DiemAccount/withdraw_capability: Read
 Formal(0)/0x1::DiemAccount::DiemAccount/withdraw_capability/vec/[_]/account_address/0x1::DiemAccount::DiemAccount/withdraw_capability/vec: Read
 Formal(0)/0x1::DiemAccount::DiemAccount/withdraw_capability/vec/[_]/account_address/0x1::DiemAccount::DiemAccount/withdraw_capability/vec/[_]: ReadWrite
+Formal(0)/0x1::DiemAccount::DiemAccount/withdraw_capability/vec/[_]/account_address/0x1::DiemAccount::DiemAccount/sent_events: Read
 Formal(0)/0x1::DiemAccount::DiemAccount/withdraw_capability/vec/[_]/account_address/0x1::DiemAccount::DiemAccount/sent_events/counter: ReadWrite
 Formal(0)/0x1::DiemAccount::DiemAccount/withdraw_capability/vec/[_]/account_address/0x1::DiemAccount::DiemAccount/sent_events/guid: Read
 Formal(0)/0x1::DiemAccount::DiemAccount/withdraw_capability/vec/[_]/account_address/DiemAccount::Balance<#0>: Read
+Formal(0)/0x1::DiemAccount::DiemAccount/withdraw_capability/vec/[_]/account_address/DiemAccount::Balance<#0>/coin: Read
 Formal(0)/0x1::DiemAccount::DiemAccount/withdraw_capability/vec/[_]/account_address/DiemAccount::Balance<#0>/coin/value: ReadWrite
 Formal(1): Read
 Formal(1)/0x1::AccountFreezing::FreezingBit: Read
@@ -83,10 +87,14 @@ Formal(1)/0x1::DualAttestation::Credential: Read
 Formal(1)/0x1::DualAttestation::Credential/base_url: Read
 Formal(1)/0x1::DualAttestation::Credential/compliance_public_key: Read
 Formal(1)/0x1::DiemAccount::DiemAccount: Read
+Formal(1)/0x1::DiemAccount::DiemAccount/received_events: Read
 Formal(1)/0x1::DiemAccount::DiemAccount/received_events/counter: ReadWrite
 Formal(1)/0x1::DiemAccount::DiemAccount/received_events/guid: Read
 Formal(1)/DiemAccount::Balance<#0>: Read
+Formal(1)/DiemAccount::Balance<#0>/coin: Read
 Formal(1)/DiemAccount::Balance<#0>/coin/value: ReadWrite
+Formal(2): Read
+Formal(3): Read
 Formal(3)/[_]: ReadWrite
 Formal(4): Read
 

--- a/language/move-model/src/ty.rs
+++ b/language/move-model/src/ty.rs
@@ -131,6 +131,11 @@ impl Type {
         matches!(self, Type::Struct(..))
     }
 
+    /// Determines whether this type is a vector
+    pub fn is_vector(&self) -> bool {
+        matches!(self, Type::Vector(..))
+    }
+
     /// Determines whether this is a struct, or a vector of structs, or a reference to any of
     /// those.
     pub fn is_struct_or_vector_of_struct(&self) -> bool {

--- a/language/move-prover/bytecode/tests/read_write_set/bool_footprint.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/bool_footprint.exp
@@ -64,6 +64,7 @@ public fun BoolFootprint::call_get($t0|a: address) {
      var $t5: bool
      var $t6: u64
      # Accesses:
+     # Formal(0): Read
      # Formal(0)/0x1::BoolFootprint::B: Read
      # Formal(0)/0x1::BoolFootprint::B/b: Read
      #
@@ -94,6 +95,7 @@ public fun BoolFootprint::global_get($t0|a: address): bool {
      var $t8: bool
      var $t9: bool
      # Accesses:
+     # Formal(0): Read
      # Formal(0)/0x1::BoolFootprint::B: Read
      # Formal(0)/0x1::BoolFootprint::B/b: Read
      #

--- a/language/move-prover/bytecode/tests/read_write_set/borrow.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/borrow.exp
@@ -28,6 +28,7 @@ fun Borrow::borrow_s($t0|a: address) {
      var $t1: address
      var $t2: &Borrow::S
      # Accesses:
+     # Formal(0): Read
      #
      # Locals:
      #
@@ -43,6 +44,7 @@ fun Borrow::borrow_s_mut($t0|a: address) {
      var $t1: address
      var $t2: &mut Borrow::S
      # Accesses:
+     # Formal(0): Read
      #
      # Locals:
      #

--- a/language/move-prover/bytecode/tests/read_write_set/counter.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/counter.exp
@@ -66,6 +66,7 @@ fun Counter::call_increment1($t0|s: &mut Counter::S) {
      var $t1: &mut Counter::S
      var $t2: &mut u64
      # Accesses:
+     # Formal(0): Read
      # Formal(0)/f: ReadWrite
      #
      # Locals:
@@ -82,6 +83,8 @@ fun Counter::call_increment2($t0|a: address) {
      var $t1: address
      var $t2: &mut Counter::S
      # Accesses:
+     # Formal(0): Read
+     # Formal(0)/0x1::Counter::S: Read
      # Formal(0)/0x1::Counter::S/f: ReadWrite
      #
      # Locals:
@@ -125,6 +128,7 @@ fun Counter::increment2($t0|s: &mut Counter::S) {
      var $t6: &mut Counter::S
      var $t7: &mut u64
      # Accesses:
+     # Formal(0): Read
      # Formal(0)/f: ReadWrite
      #
      # Locals:

--- a/language/move-prover/bytecode/tests/read_write_set/exists.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/exists.exp
@@ -80,6 +80,7 @@ public fun Exists::call_with_type_param1($t0|a: address): bool {
      var $t1: address
      var $t2: bool
      # Accesses:
+     # Formal(0): Read
      # Formal(0)/0x2::Exists::V<0x2::Exists::T>: Read
      #
      # Locals:
@@ -95,6 +96,7 @@ public fun Exists::call_with_type_param2<#0, #1>($t0|a: address): bool {
      var $t1: address
      var $t2: bool
      # Accesses:
+     # Formal(0): Read
      # Formal(0)/Exists::V<#1>: Read
      #
      # Locals:
@@ -127,6 +129,7 @@ public fun Exists::exists_field($t0|s: &Exists::S): bool {
      var $t3: address
      var $t4: bool
      # Accesses:
+     # Formal(0): Read
      # Formal(0)/f: Read
      # Formal(0)/f/0x2::Exists::T: Read
      #
@@ -145,6 +148,7 @@ public fun Exists::exists_formal($t0|a: address): bool {
      var $t1: address
      var $t2: bool
      # Accesses:
+     # Formal(0): Read
      # Formal(0)/0x2::Exists::T: Read
      #
      # Locals:
@@ -160,6 +164,7 @@ public fun Exists::exists_generic<#0>($t0|a: address): bool {
      var $t1: address
      var $t2: bool
      # Accesses:
+     # Formal(0): Read
      # Formal(0)/Exists::V<#0>: Read
      #
      # Locals:
@@ -175,6 +180,7 @@ public fun Exists::exists_generic_instantiated($t0|a: address): bool {
      var $t1: address
      var $t2: bool
      # Accesses:
+     # Formal(0): Read
      # Formal(0)/0x2::Exists::V<0x2::Exists::T>: Read
      #
      # Locals:

--- a/language/move-prover/bytecode/tests/read_write_set/fields.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/fields.exp
@@ -31,6 +31,7 @@ public fun Fields::borrow_read($t0|s: &Fields::S): u64 {
      var $t2: &u64
      var $t3: u64
      # Accesses:
+     # Formal(0): Read
      # Formal(0)/f: Read
      #
      # Locals:
@@ -49,6 +50,7 @@ public fun Fields::borrow_read_generic<#0>($t0|t: &Fields::T<#0>): u64 {
      var $t2: &u64
      var $t3: u64
      # Accesses:
+     # Formal(0): Read
      # Formal(0)/f: Read
      #
      # Locals:

--- a/language/move-prover/bytecode/tests/read_write_set/footprint.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/footprint.exp
@@ -91,6 +91,8 @@ public fun Footprint::reassign_cond($t0|a: address, $t1|b: bool): address {
      var $t4: u64
      var $t5: address
      # Accesses:
+     # Formal(0): Read
+     # Formal(1): Read
      #
      # Locals:
      # Ret(0): {0x2, Formal(0), }
@@ -133,6 +135,7 @@ public fun Footprint::reassign_field($t0|s: &mut Footprint::S) {
      var $t2: &mut Footprint::S
      var $t3: &mut address
      # Accesses:
+     # Formal(0): Read
      # Formal(0)/f: Write
      #
      # Locals:
@@ -154,7 +157,9 @@ public fun Footprint::reassign_field_cond($t0|s: &mut Footprint::S, $t1|b: bool)
      var $t5: &mut address
      var $t6: &mut Footprint::S
      # Accesses:
+     # Formal(0): Read
      # Formal(0)/f: Write
+     # Formal(1): Read
      #
      # Locals:
      # Formal(0)/f: {0x2, Formal(0)/f, }
@@ -183,6 +188,7 @@ public fun Footprint::reassign_other_param($t0|a1: address, $t1|a2: address): ad
      var $t2: address
      var $t3: address
      # Accesses:
+     # Formal(1): Read
      #
      # Locals:
      # Ret(0): Formal(1)

--- a/language/move-prover/bytecode/tests/read_write_set/functions.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/functions.exp
@@ -90,7 +90,10 @@ public fun Funtions::call_write_vec($t0|a: address, $t1|v: vector<u8>) {
      var $t3: &mut Funtions::R
      var $t4: vector<u8>
      # Accesses:
+     # Formal(0): Read
+     # Formal(0)/0x1::Funtions::R: Read
      # Formal(0)/0x1::Funtions::R/v: Write
+     # Formal(1): Read
      #
      # Locals:
      #
@@ -110,6 +113,9 @@ public fun Funtions::choice($t0|a: vector<address>, $t1|b: vector<address>, $t2|
      var $t6: vector<address>
      var $t7: vector<address>
      # Accesses:
+     # Formal(0): Read
+     # Formal(1): Read
+     # Formal(2): Read
      #
      # Locals:
      # Ret(0): {Formal(0), Formal(1), }
@@ -136,6 +142,7 @@ public fun Funtions::choice($t0|a: vector<address>, $t1|b: vector<address>, $t2|
 public fun Funtions::id($t0|a: address): address {
      var $t1: address
      # Accesses:
+     # Formal(0): Read
      #
      # Locals:
      # Ret(0): Formal(0)
@@ -149,6 +156,7 @@ public fun Funtions::id($t0|a: address): address {
 public fun Funtions::id_generic<#0>($t0|t: #0): #0 {
      var $t1: #0
      # Accesses:
+     # Formal(0): Read
      #
      # Locals:
      # Ret(0): Formal(0)
@@ -162,6 +170,7 @@ public fun Funtions::id_generic<#0>($t0|t: #0): #0 {
 public fun Funtions::id_ref($t0|a: &address): &address {
      var $t1: &address
      # Accesses:
+     # Formal(0): Read
      #
      # Locals:
      # Ret(0): Formal(0)
@@ -175,6 +184,7 @@ public fun Funtions::id_ref($t0|a: &address): &address {
 public fun Funtions::id_ref_generic<#0>($t0|t: &#0): &#0 {
      var $t1: &#0
      # Accesses:
+     # Formal(0): Read
      #
      # Locals:
      # Ret(0): Formal(0)
@@ -190,7 +200,9 @@ public fun Funtions::write_vec($t0|r: &mut Funtions::R, $t1|v: vector<u8>) {
      var $t3: &mut Funtions::R
      var $t4: &mut vector<u8>
      # Accesses:
+     # Formal(0): Read
      # Formal(0)/v: Write
+     # Formal(1): Read
      #
      # Locals:
      # Formal(0)/v: Formal(1)

--- a/language/move-prover/bytecode/tests/read_write_set/multi_deps.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/multi_deps.exp
@@ -57,8 +57,11 @@ fun MultiDeps::add_to($t0|s: &mut MultiDeps::S, $t1|t: &MultiDeps::T, $t2|v: boo
      var $t13: &mut MultiDeps::S
      var $t14: &mut u64
      # Accesses:
+     # Formal(0): Read
      # Formal(0)/f: ReadWrite
+     # Formal(1): Read
      # Formal(1)/f: Read
+     # Formal(2): Read
      #
      # Locals:
      # Formal(0)/f: {Formal(0)/f, Formal(1)/f, }

--- a/language/move-prover/bytecode/tests/read_write_set/pack_unpack.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/pack_unpack.exp
@@ -1,0 +1,318 @@
+============ initial translation from Move ================
+
+[variant baseline]
+fun PackUnpack::pack_then_read($t0|a2: address): address {
+     var $t1|t: PackUnpack::T
+     var $t2: address
+     var $t3: bool
+     var $t4: PackUnpack::T
+     var $t5: &PackUnpack::T
+     var $t6: &address
+     var $t7: address
+  0: $t2 := copy($t0)
+  1: $t3 := false
+  2: $t4 := pack PackUnpack::T($t2, $t3)
+  3: $t1 := $t4
+  4: $t5 := borrow_local($t1)
+  5: $t6 := borrow_field<PackUnpack::T>.a2($t5)
+  6: $t7 := read_ref($t6)
+  7: return $t7
+}
+
+
+[variant baseline]
+fun PackUnpack::read_packed_borrow_glob($t0|a2: address): bool {
+     var $t1|t: PackUnpack::T
+     var $t2: address
+     var $t3: bool
+     var $t4: PackUnpack::T
+     var $t5: &PackUnpack::T
+     var $t6: &address
+     var $t7: address
+     var $t8: &PackUnpack::Glob
+     var $t9: &bool
+     var $t10: bool
+  0: $t2 := copy($t0)
+  1: $t3 := false
+  2: $t4 := pack PackUnpack::T($t2, $t3)
+  3: $t1 := $t4
+  4: $t5 := borrow_local($t1)
+  5: $t6 := borrow_field<PackUnpack::T>.a2($t5)
+  6: $t7 := read_ref($t6)
+  7: $t8 := borrow_global<PackUnpack::Glob>($t7)
+  8: $t9 := borrow_field<PackUnpack::Glob>.b($t8)
+  9: $t10 := read_ref($t9)
+ 10: return $t10
+}
+
+
+[variant baseline]
+fun PackUnpack::read_unpacked_addr($t0|s: PackUnpack::S): address {
+     var $t1|a1: address
+     var $t2|a2: address
+     var $t3|b: bool
+     var $t4|tmp#$4: address
+     var $t5: PackUnpack::S
+     var $t6: address
+     var $t7: PackUnpack::T
+     var $t8: u64
+     var $t9: address
+     var $t10: bool
+     var $t11: bool
+     var $t12: address
+     var $t13: address
+     var $t14: address
+  0: $t5 := move($t0)
+  1: ($t6, $t7, $t8) := unpack PackUnpack::S($t5)
+  2: destroy($t8)
+  3: ($t9, $t10) := unpack PackUnpack::T($t7)
+  4: $t3 := $t10
+  5: $t2 := $t9
+  6: $t1 := $t6
+  7: $t11 := copy($t3)
+  8: if ($t11) goto 11 else goto 9
+  9: label L1
+ 10: goto 15
+ 11: label L0
+ 12: $t12 := copy($t1)
+ 13: $t4 := $t12
+ 14: goto 19
+ 15: label L2
+ 16: $t13 := copy($t2)
+ 17: $t4 := $t13
+ 18: goto 19
+ 19: label L3
+ 20: $t14 := move($t4)
+ 21: return $t14
+}
+
+
+[variant baseline]
+fun PackUnpack::read_unpacked_borrow_glob($t0|s: PackUnpack::S): bool {
+     var $t1|a1: address
+     var $t2: PackUnpack::S
+     var $t3: address
+     var $t4: PackUnpack::T
+     var $t5: u64
+     var $t6: address
+     var $t7: &PackUnpack::Glob
+     var $t8: &bool
+     var $t9: bool
+  0: $t2 := move($t0)
+  1: ($t3, $t4, $t5) := unpack PackUnpack::S($t2)
+  2: destroy($t5)
+  3: destroy($t4)
+  4: $t1 := $t3
+  5: $t6 := copy($t1)
+  6: $t7 := borrow_global<PackUnpack::Glob>($t6)
+  7: $t8 := borrow_field<PackUnpack::Glob>.b($t7)
+  8: $t9 := read_ref($t8)
+  9: return $t9
+}
+
+
+[variant baseline]
+fun PackUnpack::reassign_packed_addr($t0|a2: address): address {
+     var $t1|t: PackUnpack::T
+     var $t2: address
+     var $t3: bool
+     var $t4: PackUnpack::T
+     var $t5: PackUnpack::T
+     var $t6: address
+     var $t7: bool
+     var $t8: PackUnpack::T
+     var $t9: &PackUnpack::T
+     var $t10: &address
+     var $t11: address
+  0: $t2 := 0x7
+  1: $t3 := false
+  2: $t4 := pack PackUnpack::T($t2, $t3)
+  3: $t1 := $t4
+  4: $t5 := move($t1)
+  5: destroy($t5)
+  6: $t6 := copy($t0)
+  7: $t7 := false
+  8: $t8 := pack PackUnpack::T($t6, $t7)
+  9: $t1 := $t8
+ 10: $t9 := borrow_local($t1)
+ 11: $t10 := borrow_field<PackUnpack::T>.a2($t9)
+ 12: $t11 := read_ref($t10)
+ 13: return $t11
+}
+
+============ after pipeline `read_write_set` ================
+
+[variant baseline]
+fun PackUnpack::pack_then_read($t0|a2: address): address {
+     var $t1|t: PackUnpack::T
+     var $t2: address
+     var $t3: bool
+     var $t4: PackUnpack::T
+     var $t5: &PackUnpack::T
+     var $t6: &address
+     var $t7: address
+     # Accesses:
+     # Formal(0): Read
+     #
+     # Locals:
+     # Ret(0): Formal(0)
+     #
+  0: $t2 := copy($t0)
+  1: $t3 := false
+  2: $t4 := pack PackUnpack::T($t2, $t3)
+  3: $t1 := $t4
+  4: $t5 := borrow_local($t1)
+  5: $t6 := borrow_field<PackUnpack::T>.a2($t5)
+  6: $t7 := read_ref($t6)
+  7: return $t7
+}
+
+
+[variant baseline]
+fun PackUnpack::read_packed_borrow_glob($t0|a2: address): bool {
+     var $t1|t: PackUnpack::T
+     var $t2: address
+     var $t3: bool
+     var $t4: PackUnpack::T
+     var $t5: &PackUnpack::T
+     var $t6: &address
+     var $t7: address
+     var $t8: &PackUnpack::Glob
+     var $t9: &bool
+     var $t10: bool
+     # Accesses:
+     # Formal(0): Read
+     # Formal(0)/0x1::PackUnpack::Glob/b: Read
+     #
+     # Locals:
+     # Ret(0): Formal(0)/0x1::PackUnpack::Glob/b
+     #
+  0: $t2 := copy($t0)
+  1: $t3 := false
+  2: $t4 := pack PackUnpack::T($t2, $t3)
+  3: $t1 := $t4
+  4: $t5 := borrow_local($t1)
+  5: $t6 := borrow_field<PackUnpack::T>.a2($t5)
+  6: $t7 := read_ref($t6)
+  7: $t8 := borrow_global<PackUnpack::Glob>($t7)
+  8: $t9 := borrow_field<PackUnpack::Glob>.b($t8)
+  9: $t10 := read_ref($t9)
+ 10: return $t10
+}
+
+
+[variant baseline]
+fun PackUnpack::read_unpacked_addr($t0|s: PackUnpack::S): address {
+     var $t1|a1: address
+     var $t2|a2: address
+     var $t3|b: bool
+     var $t4|tmp#$4: address
+     var $t5: PackUnpack::S
+     var $t6: address
+     var $t7: PackUnpack::T
+     var $t8: u64
+     var $t9: address
+     var $t10: bool
+     var $t11: bool
+     var $t12: address
+     var $t13: address
+     var $t14: address
+     # Accesses:
+     # Formal(0): Read
+     # Formal(0)/a1: Read
+     # Formal(0)/t/a2: Read
+     #
+     # Locals:
+     # Ret(0): {Formal(0)/a1, Formal(0)/t/a2, }
+     #
+  0: $t5 := move($t0)
+  1: ($t6, $t7, $t8) := unpack PackUnpack::S($t5)
+  2: destroy($t8)
+  3: ($t9, $t10) := unpack PackUnpack::T($t7)
+  4: $t3 := $t10
+  5: $t2 := $t9
+  6: $t1 := $t6
+  7: $t11 := copy($t3)
+  8: if ($t11) goto 11 else goto 9
+  9: label L1
+ 10: goto 15
+ 11: label L0
+ 12: $t12 := copy($t1)
+ 13: $t4 := $t12
+ 14: goto 19
+ 15: label L2
+ 16: $t13 := copy($t2)
+ 17: $t4 := $t13
+ 18: goto 19
+ 19: label L3
+ 20: $t14 := move($t4)
+ 21: return $t14
+}
+
+
+[variant baseline]
+fun PackUnpack::read_unpacked_borrow_glob($t0|s: PackUnpack::S): bool {
+     var $t1|a1: address
+     var $t2: PackUnpack::S
+     var $t3: address
+     var $t4: PackUnpack::T
+     var $t5: u64
+     var $t6: address
+     var $t7: &PackUnpack::Glob
+     var $t8: &bool
+     var $t9: bool
+     # Accesses:
+     # Formal(0): Read
+     # Formal(0)/a1: Read
+     # Formal(0)/a1/0x1::PackUnpack::Glob/b: Read
+     #
+     # Locals:
+     # Ret(0): Formal(0)/a1/0x1::PackUnpack::Glob/b
+     #
+  0: $t2 := move($t0)
+  1: ($t3, $t4, $t5) := unpack PackUnpack::S($t2)
+  2: destroy($t5)
+  3: destroy($t4)
+  4: $t1 := $t3
+  5: $t6 := copy($t1)
+  6: $t7 := borrow_global<PackUnpack::Glob>($t6)
+  7: $t8 := borrow_field<PackUnpack::Glob>.b($t7)
+  8: $t9 := read_ref($t8)
+  9: return $t9
+}
+
+
+[variant baseline]
+fun PackUnpack::reassign_packed_addr($t0|a2: address): address {
+     var $t1|t: PackUnpack::T
+     var $t2: address
+     var $t3: bool
+     var $t4: PackUnpack::T
+     var $t5: PackUnpack::T
+     var $t6: address
+     var $t7: bool
+     var $t8: PackUnpack::T
+     var $t9: &PackUnpack::T
+     var $t10: &address
+     var $t11: address
+     # Accesses:
+     # Formal(0): Read
+     #
+     # Locals:
+     # Ret(0): Formal(0)
+     #
+  0: $t2 := 0x7
+  1: $t3 := false
+  2: $t4 := pack PackUnpack::T($t2, $t3)
+  3: $t1 := $t4
+  4: $t5 := move($t1)
+  5: destroy($t5)
+  6: $t6 := copy($t0)
+  7: $t7 := false
+  8: $t8 := pack PackUnpack::T($t6, $t7)
+  9: $t1 := $t8
+ 10: $t9 := borrow_local($t1)
+ 11: $t10 := borrow_field<PackUnpack::T>.a2($t9)
+ 12: $t11 := read_ref($t10)
+ 13: return $t11
+}

--- a/language/move-prover/bytecode/tests/read_write_set/pack_unpack.move
+++ b/language/move-prover/bytecode/tests/read_write_set/pack_unpack.move
@@ -1,0 +1,42 @@
+module 0x1::PackUnpack {
+
+    struct S has drop { a1: address, t: T, i: u64 }
+    struct T has drop { a2: address, b: bool }
+    struct Glob has key { b: bool }
+
+    fun read_unpacked_addr(s: S): address {
+        let S { a1, t: T { a2, b }, i: _ } = s;
+        if (b) { a1 } else { a2 }
+    } // ret |-> { Formal(0)/a1, Formal(0)/t/a2 }
+
+    fun pack_then_read(a2: address): address {
+        let t = T { a2, b: false };
+        *&t.a2
+    } // ret |-> Formal(0)
+
+    fun read_unpacked_borrow_glob(s: S): bool acquires Glob {
+        let S { a1, t: _, i: _ } = s;
+        *&borrow_global<Glob>(a1).b
+    } // ret |-> Formal(0)/a1/Glob/b
+
+    fun read_packed_borrow_glob(a2: address): bool acquires Glob {
+        let t = T { a2, b: false };
+        *&borrow_global<Glob>(*&t.a2).b
+    } // ret |-> Formal(0)/Glob/b
+
+    fun reassign_packed_addr(a2: address): address {
+        let t = T { a2: @0x7, b: false };
+        _ = t;
+        t = T { a2, b: false };
+        *&t.a2
+    } // ret |-> Formal(0)
+
+    // TODO: crashes the analysis. fix by addressing TODO
+    // in AccessPath::substitute_footprint
+    /*fun use_results(_: u64, a: address): address {
+        let a1 = pack_then_read(a);
+        let s = S { a1, t: T { a2: @0x7, b: true }, i: 10 };
+        read_unpacked_addr(s)
+    }  // ret |-> { Formal(0), @0x7 }
+    */
+}

--- a/language/move-prover/bytecode/tests/read_write_set/summary.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/summary.exp
@@ -51,6 +51,7 @@ public fun Summary::write_caller2($t0|a: address) {
 public fun Summary::write_addr() {
      var $t0: address
      # Accesses:
+     # 0x777/0x2::Summary::S1/s2: Read
      # 0x777/0x2::Summary::S1/s2/f: Write
      #
      # Locals:
@@ -67,6 +68,7 @@ public fun Summary::write_callee($t0|s2: &mut Summary::S2) {
      var $t2: &mut Summary::S2
      var $t3: &mut u64
      # Accesses:
+     # Formal(0): Read
      # Formal(0)/f: Write
      #
      # Locals:
@@ -84,6 +86,8 @@ public fun Summary::write_caller1($t0|a: address) {
      var $t1: address
      var $t2: &mut Summary::S2
      # Accesses:
+     # Formal(0): Read
+     # Formal(0)/0x2::Summary::S2: Read
      # Formal(0)/0x2::Summary::S2/f: Write
      #
      # Locals:
@@ -101,6 +105,8 @@ public fun Summary::write_caller2($t0|a: address) {
      var $t2: &mut Summary::S1
      var $t3: &mut Summary::S2
      # Accesses:
+     # Formal(0): Read
+     # Formal(0)/0x2::Summary::S1/s2: Read
      # Formal(0)/0x2::Summary::S1/s2/f: Write
      #
      # Locals:

--- a/language/move-prover/bytecode/tests/read_write_set/update_return.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/update_return.exp
@@ -50,7 +50,10 @@ public fun UpdateReturn::abort_or_write($t0|s: &mut UpdateReturn::S, $t1|b: bool
      var $t7: u64
      var $t8: u64
      # Accesses:
+     # Formal(0): Read
      # Formal(0)/f: Write
+     # Formal(1): Read
+     # Formal(2): Read
      #
      # Locals:
      # Ret(0): Formal(2)
@@ -79,7 +82,9 @@ public fun UpdateReturn::write_f($t0|s: &mut UpdateReturn::S, $t1|x: u64): u64 {
      var $t4: &mut u64
      var $t5: u64
      # Accesses:
+     # Formal(0): Read
      # Formal(0)/f: Write
+     # Formal(1): Read
      #
      # Locals:
      # Ret(0): Formal(1)

--- a/language/tools/move-cli/tests/testsuite/concretize_read_write_set/args.exp
+++ b/language/tools/move-cli/tests/testsuite/concretize_read_write_set/args.exp
@@ -1,6 +1,7 @@
 Command `sandbox publish`:
 Command `experimental read-write-set storage/0x00000000000000000000000000000001/modules/ConcretizeSecondaryIndexes.mv read_indirect`:
 Accesses:
+Formal(0): Read
 Formal(0)/0x1::ConcretizeSecondaryIndexes::Addr/a: Read
 Formal(0)/0x1::ConcretizeSecondaryIndexes::Addr/a/0x1::ConcretizeSecondaryIndexes::S/f: Read
 
@@ -24,6 +25,8 @@ Command `experimental read-write-set storage/0x00000000000000000000000000000001/
 
 Command `experimental read-write-set storage/0x00000000000000000000000000000001/modules/ConcretizeVector.mv read_vec`:
 Accesses:
+Formal(0): Read
+Formal(0)/0x1::ConcretizeVector::S/v: Read
 Formal(0)/0x1::ConcretizeVector::S/v/[_]: Read
 Formal(0)/0x1::ConcretizeVector::S/v/[_]/0x1::ConcretizeVector::T/f: Read
 
@@ -34,11 +37,13 @@ Command `experimental read-write-set storage/0x00000000000000000000000000000001/
 
 Command `sandbox run storage/0x00000000000000000000000000000001/modules/ConcretizeVector.mv publish --signers 0x1 0x2`:
 Command `experimental read-write-set storage/0x00000000000000000000000000000001/modules/ConcretizeVector.mv read_vec --concretize --args 0x1`:
+0x1/0x1::ConcretizeVector::S/v: Read
 0x1/0x1::ConcretizeVector::S/v/[_]: Read
 0x1/0x1::ConcretizeVector::T/f: Read
 0x2/0x1::ConcretizeVector::T/f: Read
 
 Command `experimental read-write-set storage/0x00000000000000000000000000000001/modules/ConcretizeVector.mv write_vec --concretize --args 0x1 2`:
+0x1/0x1::ConcretizeVector::S/v: Read
 0x1/0x1::ConcretizeVector::S/v/[_]: Read
 0x1/0x1::ConcretizeVector::T/f: Write
 0x2/0x1::ConcretizeVector::T/f: Write

--- a/language/tools/move-cli/tests/testsuite/read_write_set/args.exp
+++ b/language/tools/move-cli/tests/testsuite/read_write_set/args.exp
@@ -2,6 +2,7 @@ Command `sandbox publish --mode bare`:
 Command `experimental read-write-set storage/0x00000000000000000000000000000001/modules/RWSet.mv read_f --mode bare -v`:
 Inferring read/write set for 1 module(s)
 Accesses:
+Formal(0): Read
 Formal(0)/f: Read
 
 Locals:
@@ -10,6 +11,7 @@ Ret(0): Formal(0)/f
 Command `experimental read-write-set storage/0x00000000000000000000000000000001/modules/RWSet.mv write_f --mode bare -v`:
 Inferring read/write set for 1 module(s)
 Accesses:
+Formal(0): Read
 Formal(0)/f: Write
 
 Locals:


### PR DESCRIPTION
…k and unpack

Previously, the read/write set analysis treated packs and unpacks as no-ops. However, this is incorrect
because the analysis must track addresses flowing into and out of structs.

This PR adds support for pack and unpack in the natural way by:
- adding each packed field of type struct or address to the locals trie
- adding each unpacked field of type struct or address to the locals trie

In the process of supporting pack/unpack, I uncovered a bug in `AccessPath::substitute_footprint` (see the `use_results` function in `pack_unpack.move` and the TODO in access_path.rs). Fixing this bug will require a fairly significant refactoring, so I will defer it to a subsequent PR.