### PR TITLE
[move] Remove `Compiled{Module,Script}Mut`

### DIFF
--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/bounds_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/bounds_tests.rs
@@ -324,10 +324,9 @@ proptest! {
 
     #[test]
     fn code_unit_out_of_bounds(
-        module in CompiledModule::valid_strategy(20),
+        mut module in CompiledModule::valid_strategy(20),
         mutations in vec(CodeUnitBoundsMutation::strategy(), 0..40),
     ) {
-        let mut module = module.into_inner();
         let expected_violations = {
             let context = ApplyCodeUnitBoundsContext::new(&mut module, mutations);
             context.apply()

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/bounds_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/bounds_tests.rs
@@ -25,11 +25,12 @@ fn empty_script_no_errors() {
 
 #[test]
 fn invalid_default_module() {
-    let m = CompiledModuleMut {
+    CompiledModule {
         version: file_format_common::VERSION_MAX,
         ..Default::default()
-    };
-    m.freeze().unwrap_err();
+    }
+    .freeze()
+    .unwrap_err();
 }
 
 #[test]
@@ -344,7 +345,7 @@ proptest! {
     ) {
         // If there are no module handles, the only other things that can be stored are intrinsic
         // data.
-        let module = CompiledModuleMut {
+        let module = CompiledModule {
             identifiers,
             address_identifiers,
             ..Default::default()
@@ -364,7 +365,7 @@ proptest! {
 
     /// Make sure that garbage inputs don't crash the bounds checker.
     #[test]
-    fn garbage_inputs(module in any_with::<CompiledModuleMut>(16)) {
+    fn garbage_inputs(module in any_with::<CompiledModule>(16)) {
         let _ = module.freeze();
     }
 }

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/generic_ops_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/generic_ops_tests.rs
@@ -10,8 +10,8 @@ use move_core_types::{
 // Make a Module with 2 structs and 2 resources with one field each, and 2 functions.
 // One of the struct/resource and one of the function is generic, the other "normal".
 // Also make a test function whose body will be filled by given test cases.
-fn make_module() -> CompiledModuleMut {
-    CompiledModuleMut {
+fn make_module() -> CompiledModule {
+    CompiledModule {
         version: move_binary_format::file_format_common::VERSION_MAX,
         module_handles: vec![
             // only self module

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
@@ -25,10 +25,9 @@ proptest! {
 
     #[test]
     fn double_refs(
-        module in CompiledModule::valid_strategy(20),
+        mut module in CompiledModule::valid_strategy(20),
         mutations in vec((any::<PropIndex>(), any::<PropIndex>()), 0..20),
     ) {
-        let mut module = module.into_inner();
         let context = SignatureRefMutation::new(&mut module, mutations);
         let expected_violations = context.apply();
         let module = module.freeze().expect("should satisfy bounds checker");
@@ -40,10 +39,9 @@ proptest! {
 
     #[test]
     fn field_def_references(
-        module in CompiledModule::valid_strategy(20),
+        mut module in CompiledModule::valid_strategy(20),
         mutations in vec((any::<PropIndex>(), any::<PropIndex>()), 0..40),
     ) {
-        let mut module = module.into_inner();
         let context = FieldRefMutation::new(&mut module, mutations);
         let expected_violations = context.apply();
         let module = module.freeze().expect("should satisfy bounds checker");

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
@@ -56,7 +56,7 @@ proptest! {
 
 #[test]
 fn no_verify_locals_good() {
-    let compiled_module_good = CompiledModuleMut {
+    let compiled_module_good = CompiledModule {
         version: move_binary_format::file_format_common::VERSION_MAX,
         module_handles: vec![ModuleHandle {
             address: AddressIdentifierIndex(0),

--- a/language/bytecode-verifier/invalid-mutations/src/bounds.rs
+++ b/language/bytecode-verifier/invalid-mutations/src/bounds.rs
@@ -4,9 +4,8 @@
 use move_binary_format::{
     errors::{bounds_error, PartialVMError},
     file_format::{
-        AddressIdentifierIndex, CompiledModule, CompiledModuleMut, FunctionHandleIndex,
-        IdentifierIndex, ModuleHandleIndex, SignatureIndex, StructDefinitionIndex,
-        StructHandleIndex, TableIndex,
+        AddressIdentifierIndex, CompiledModule, FunctionHandleIndex, IdentifierIndex,
+        ModuleHandleIndex, SignatureIndex, StructDefinitionIndex, StructHandleIndex, TableIndex,
     },
     internals::ModuleIndex,
     views::{ModuleView, SignatureTokenView},
@@ -160,7 +159,7 @@ impl AsRef<PropIndex> for OutOfBoundsMutation {
 }
 
 pub struct ApplyOutOfBoundsContext {
-    module: CompiledModuleMut,
+    module: CompiledModule,
     // This is an Option because it gets moved out in apply before apply_one is called. Rust
     // doesn't let you call another con-consuming method after a partial move out.
     mutations: Option<Vec<OutOfBoundsMutation>>,
@@ -180,7 +179,7 @@ impl ApplyOutOfBoundsContext {
         }
     }
 
-    pub fn apply(mut self) -> (CompiledModuleMut, Vec<PartialVMError>) {
+    pub fn apply(mut self) -> (CompiledModule, Vec<PartialVMError>) {
         // This is a map from (source kind, dest kind) to the actual mutations -- this is done to
         // figure out how many mutations to do for a particular pair, which is required for
         // pick_slice_idxs below.

--- a/language/bytecode-verifier/invalid-mutations/src/bounds.rs
+++ b/language/bytecode-verifier/invalid-mutations/src/bounds.rs
@@ -173,7 +173,7 @@ impl ApplyOutOfBoundsContext {
         let sig_structs: Vec<_> = Self::sig_structs(&module).collect();
 
         Self {
-            module: module.into_inner(),
+            module,
             mutations: Some(mutations),
             sig_structs,
         }

--- a/language/bytecode-verifier/invalid-mutations/src/bounds/code_unit.rs
+++ b/language/bytecode-verifier/invalid-mutations/src/bounds/code_unit.rs
@@ -4,7 +4,7 @@
 use move_binary_format::{
     errors::{offset_out_of_bounds, PartialVMError},
     file_format::{
-        Bytecode, CodeOffset, CompiledModuleMut, ConstantPoolIndex, FieldHandleIndex,
+        Bytecode, CodeOffset, CompiledModule, ConstantPoolIndex, FieldHandleIndex,
         FieldInstantiationIndex, FunctionDefinitionIndex, FunctionHandleIndex,
         FunctionInstantiationIndex, LocalIndex, StructDefInstantiationIndex, StructDefinitionIndex,
         TableIndex,
@@ -44,7 +44,7 @@ impl AsRef<PropIndex> for CodeUnitBoundsMutation {
 }
 
 pub struct ApplyCodeUnitBoundsContext<'a> {
-    module: &'a mut CompiledModuleMut,
+    module: &'a mut CompiledModule,
     // This is so apply_one can be called after mutations has been iterated on.
     mutations: Option<Vec<CodeUnitBoundsMutation>>,
 }
@@ -122,7 +122,7 @@ macro_rules! locals_bytecode {
 }
 
 impl<'a> ApplyCodeUnitBoundsContext<'a> {
-    pub fn new(module: &'a mut CompiledModuleMut, mutations: Vec<CodeUnitBoundsMutation>) -> Self {
+    pub fn new(module: &'a mut CompiledModule, mutations: Vec<CodeUnitBoundsMutation>) -> Self {
         Self {
             module,
             mutations: Some(mutations),

--- a/language/bytecode-verifier/invalid-mutations/src/signature.rs
+++ b/language/bytecode-verifier/invalid-mutations/src/signature.rs
@@ -2,17 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::file_format::{
-    CompiledModuleMut, Signature, SignatureToken, StructFieldInformation, TypeSignature,
+    CompiledModule, Signature, SignatureToken, StructFieldInformation, TypeSignature,
 };
 use proptest::sample::Index as PropIndex;
 
 pub struct SignatureRefMutation<'a> {
-    module: &'a mut CompiledModuleMut,
+    module: &'a mut CompiledModule,
     mutations: Vec<(PropIndex, PropIndex)>,
 }
 
 impl<'a> SignatureRefMutation<'a> {
-    pub fn new(module: &'a mut CompiledModuleMut, mutations: Vec<(PropIndex, PropIndex)>) -> Self {
+    pub fn new(module: &'a mut CompiledModule, mutations: Vec<(PropIndex, PropIndex)>) -> Self {
         Self { module, mutations }
     }
 
@@ -39,12 +39,12 @@ impl<'a> SignatureRefMutation<'a> {
 
 /// Context for applying a list of `FieldRefMutation` instances.
 pub struct FieldRefMutation<'a> {
-    module: &'a mut CompiledModuleMut,
+    module: &'a mut CompiledModule,
     mutations: Vec<(PropIndex, PropIndex)>,
 }
 
 impl<'a> FieldRefMutation<'a> {
-    pub fn new(module: &'a mut CompiledModuleMut, mutations: Vec<(PropIndex, PropIndex)>) -> Self {
+    pub fn new(module: &'a mut CompiledModule, mutations: Vec<(PropIndex, PropIndex)>) -> Self {
         Self { module, mutations }
     }
 

--- a/language/bytecode-verifier/src/constants.rs
+++ b/language/bytecode-verifier/src/constants.rs
@@ -28,7 +28,7 @@ pub fn verify_script(module: &CompiledScript) -> VMResult<()> {
 }
 
 fn verify_script_impl(script: &CompiledScript) -> PartialVMResult<()> {
-    for (idx, constant) in script.as_inner().constant_pool.iter().enumerate() {
+    for (idx, constant) in script.constant_pool.iter().enumerate() {
         verify_constant(idx, constant)?
     }
     Ok(())

--- a/language/bytecode-verifier/src/instruction_consistency.rs
+++ b/language/bytecode-verifier/src/instruction_consistency.rs
@@ -52,7 +52,7 @@ impl<'a> InstructionConsistency<'a> {
             resolver: BinaryIndexedView::Script(script),
             current_function: None,
         };
-        checker.check_instructions(&script.as_inner().code)
+        checker.check_instructions(&script.code)
     }
 
     fn check_instructions(&self, code: &CodeUnit) -> PartialVMResult<()> {

--- a/language/bytecode-verifier/src/script_signature.rs
+++ b/language/bytecode-verifier/src/script_signature.rs
@@ -21,7 +21,7 @@ use move_core_types::{identifier::IdentStr, vm_status::StatusCode};
 /// This function checks the extra requirements on the signature of the main function of a script.
 pub fn verify_script(script: &CompiledScript) -> VMResult<()> {
     let resolver = &BinaryIndexedView::Script(script);
-    let parameters = script.as_inner().parameters;
+    let parameters = script.parameters;
     let return_type_opt = None;
     verify_main_signature_impl(resolver, parameters, return_type_opt)
         .map_err(|e| e.finish(Location::Script))

--- a/language/bytecode-verifier/src/signature.rs
+++ b/language/bytecode-verifier/src/signature.rs
@@ -46,7 +46,7 @@ impl<'a> SignatureChecker<'a> {
         };
         sig_check.verify_signature_pool(script.signatures())?;
         sig_check.verify_function_signatures(script.function_handles())?;
-        sig_check.verify_code(script.code(), &script.as_inner().type_parameters)
+        sig_check.verify_code(script.code(), &script.type_parameters)
     }
 
     fn verify_signature_pool(&self, signatures: &[Signature]) -> PartialVMResult<()> {

--- a/language/compiler/ir-to-bytecode/src/compiler.rs
+++ b/language/compiler/ir-to-bytecode/src/compiler.rs
@@ -11,10 +11,10 @@ use move_binary_format::{
     errors::Location as VMErrorLocation,
     file_format::{
         Ability, AbilitySet, Bytecode, CodeOffset, CodeUnit, CompiledModule, CompiledModuleMut,
-        CompiledScript, CompiledScriptMut, Constant, FieldDefinition, FunctionDefinition,
-        FunctionSignature, ModuleHandle, Signature, SignatureToken, StructDefinition,
-        StructDefinitionIndex, StructFieldInformation, StructHandleIndex, StructTypeParameter,
-        TableIndex, TypeParameterIndex, TypeSignature, Visibility,
+        CompiledScript, Constant, FieldDefinition, FunctionDefinition, FunctionSignature,
+        ModuleHandle, Signature, SignatureToken, StructDefinition, StructDefinitionIndex,
+        StructFieldInformation, StructHandleIndex, StructTypeParameter, TableIndex,
+        TypeParameterIndex, TypeSignature, Visibility,
     },
     file_format_common::VERSION_MAX,
 };
@@ -461,7 +461,7 @@ pub fn compile_script<'a>(
         _compiled_deps,
         source_map,
     ) = context.materialize_pools();
-    let compiled_script = CompiledScriptMut {
+    CompiledScript {
         version: VERSION_MAX,
         module_handles,
         struct_handles,
@@ -475,13 +475,12 @@ pub fn compile_script<'a>(
         type_parameters: sig.type_parameters,
         parameters: parameters_sig_idx,
         code,
-    };
-    compiled_script
-        .freeze()
-        .map_err(|e| {
-            InternalCompilerError::BoundsCheckErrors(e.finish(VMErrorLocation::Undefined)).into()
-        })
-        .map(|frozen_script| (frozen_script, source_map))
+    }
+    .freeze()
+    .map_err(|e| {
+        InternalCompilerError::BoundsCheckErrors(e.finish(VMErrorLocation::Undefined)).into()
+    })
+    .map(|frozen_script| (frozen_script, source_map))
 }
 
 /// Compile a module.

--- a/language/compiler/ir-to-bytecode/src/compiler.rs
+++ b/language/compiler/ir-to-bytecode/src/compiler.rs
@@ -10,11 +10,11 @@ use bytecode_source_map::source_map::SourceMap;
 use move_binary_format::{
     errors::Location as VMErrorLocation,
     file_format::{
-        Ability, AbilitySet, Bytecode, CodeOffset, CodeUnit, CompiledModule, CompiledModuleMut,
-        CompiledScript, Constant, FieldDefinition, FunctionDefinition, FunctionSignature,
-        ModuleHandle, Signature, SignatureToken, StructDefinition, StructDefinitionIndex,
-        StructFieldInformation, StructHandleIndex, StructTypeParameter, TableIndex,
-        TypeParameterIndex, TypeSignature, Visibility,
+        Ability, AbilitySet, Bytecode, CodeOffset, CodeUnit, CompiledModule, CompiledScript,
+        Constant, FieldDefinition, FunctionDefinition, FunctionSignature, ModuleHandle, Signature,
+        SignatureToken, StructDefinition, StructDefinitionIndex, StructFieldInformation,
+        StructHandleIndex, StructTypeParameter, TableIndex, TypeParameterIndex, TypeSignature,
+        Visibility,
     },
     file_format_common::VERSION_MAX,
 };
@@ -559,7 +559,7 @@ pub fn compile_module<'a>(
         _compiled_deps,
         source_map,
     ) = context.materialize_pools();
-    let compiled_module = CompiledModuleMut {
+    CompiledModule {
         version: VERSION_MAX,
         module_handles,
         self_module_handle_idx,
@@ -576,13 +576,12 @@ pub fn compile_module<'a>(
         constant_pool,
         struct_defs,
         function_defs,
-    };
-    compiled_module
-        .freeze()
-        .map_err(|e| {
-            InternalCompilerError::BoundsCheckErrors(e.finish(VMErrorLocation::Undefined)).into()
-        })
-        .map(|frozen_module| (frozen_module, source_map))
+    }
+    .freeze()
+    .map_err(|e| {
+        InternalCompilerError::BoundsCheckErrors(e.finish(VMErrorLocation::Undefined)).into()
+    })
+    .map(|frozen_module| (frozen_module, source_map))
 }
 
 // Note: DO NOT try to recover from this function as it zeros out the `outer_contexts` dependencies
@@ -639,7 +638,7 @@ fn compile_explicit_dependency_declarations(
             compiled_deps,
             _source_map,
         ) = context.materialize_pools();
-        let compiled_module = CompiledModuleMut {
+        let compiled_module = CompiledModule {
             version: VERSION_MAX,
             module_handles,
             self_module_handle_idx,

--- a/language/compiler/src/unit_tests/testutils.rs
+++ b/language/compiler/src/unit_tests/testutils.rs
@@ -18,7 +18,6 @@ use move_core_types::account_address::AccountAddress;
 macro_rules! instr_count {
     ($compiled: expr, $instr: pat) => {
         $compiled
-            .as_inner()
             .code
             .code
             .iter()
@@ -32,19 +31,17 @@ fn compile_script_string_impl(
     deps: Vec<CompiledModule>,
 ) -> Result<(CompiledScript, Option<VMError>)> {
     let parsed_script = parse_script("file_name", code).unwrap();
-    let compiled_script = compile_script(None, parsed_script, &deps)?.0;
+    let script = compile_script(None, parsed_script, &deps)?.0;
 
     let mut serialized_script = Vec::<u8>::new();
-    compiled_script.serialize(&mut serialized_script)?;
+    script.serialize(&mut serialized_script)?;
     let deserialized_script = CompiledScript::deserialize(&serialized_script)
         .map_err(|e| e.finish(Location::Undefined).into_vm_status())?;
-    assert_eq!(compiled_script, deserialized_script);
+    assert_eq!(script, deserialized_script);
 
-    // Always return a CompiledScript because some callers explicitly care about unverified
-    // modules.
-    Ok(match verify_script(&compiled_script) {
-        Ok(_) => (compiled_script, None),
-        Err(error) => (compiled_script, Some(error)),
+    Ok(match verify_script(&script) {
+        Ok(_) => (script, None),
+        Err(error) => (script, Some(error)),
     })
 }
 

--- a/language/move-binary-format/serializer-tests/tests/serializer_tests.rs
+++ b/language/move-binary-format/serializer-tests/tests/serializer_tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_binary_format::file_format::{CompiledModule, CompiledModuleMut};
+use move_binary_format::file_format::CompiledModule;
 use proptest::prelude::*;
 
 proptest! {
@@ -23,11 +23,11 @@ proptest! {
 
     /// Make sure that garbage inputs don't crash the serializer and deserializer.
     #[test]
-    fn garbage_inputs(module in any_with::<CompiledModuleMut>(16)) {
+    fn garbage_inputs(module in any_with::<CompiledModule>(16)) {
         let mut serialized = Vec::with_capacity(65536);
         module.serialize(&mut serialized).expect("serialization should work");
 
-        let deserialized_module = CompiledModuleMut::deserialize_no_check_bounds(&serialized)
+        let deserialized_module = CompiledModule::deserialize_no_check_bounds(&serialized)
             .expect("deserialization should work");
         prop_assert_eq!(module, deserialized_module);
     }

--- a/language/move-binary-format/src/access.rs
+++ b/language/move-binary-format/src/access.rs
@@ -18,7 +18,7 @@ pub trait ModuleAccess: Sync {
     fn as_module(&self) -> &CompiledModule;
 
     fn self_handle_idx(&self) -> ModuleHandleIndex {
-        self.as_module().as_inner().self_module_handle_idx
+        self.as_module().self_module_handle_idx
     }
 
     /// Returns the `ModuleHandle` for `self`.
@@ -26,11 +26,9 @@ pub trait ModuleAccess: Sync {
         assume_preconditions!(); // invariant
         let handle = self.module_handle_at(self.self_handle_idx());
         assumed_postcondition!(
-            handle.address.into_index() < self.as_module().as_inner().address_identifiers.len()
+            handle.address.into_index() < self.as_module().address_identifiers.len()
         ); // invariant
-        assumed_postcondition!(
-            handle.name.into_index() < self.as_module().as_inner().identifiers.len()
-        ); // invariant
+        assumed_postcondition!(handle.name.into_index() < self.as_module().identifiers.len()); // invariant
         handle
     }
 
@@ -45,77 +43,67 @@ pub trait ModuleAccess: Sync {
     }
 
     fn module_handle_at(&self, idx: ModuleHandleIndex) -> &ModuleHandle {
-        let handle = &self.as_module().as_inner().module_handles[idx.into_index()];
+        let handle = &self.as_module().module_handles[idx.into_index()];
         assumed_postcondition!(
-            handle.address.into_index() < self.as_module().as_inner().address_identifiers.len()
+            handle.address.into_index() < self.as_module().address_identifiers.len()
         ); // invariant
-        assumed_postcondition!(
-            handle.name.into_index() < self.as_module().as_inner().identifiers.len()
-        ); // invariant
+        assumed_postcondition!(handle.name.into_index() < self.as_module().identifiers.len()); // invariant
         handle
     }
 
     fn struct_handle_at(&self, idx: StructHandleIndex) -> &StructHandle {
-        let handle = &self.as_module().as_inner().struct_handles[idx.into_index()];
-        assumed_postcondition!(
-            handle.module.into_index() < self.as_module().as_inner().module_handles.len()
-        ); // invariant
+        let handle = &self.as_module().struct_handles[idx.into_index()];
+        assumed_postcondition!(handle.module.into_index() < self.as_module().module_handles.len()); // invariant
         handle
     }
 
     fn function_handle_at(&self, idx: FunctionHandleIndex) -> &FunctionHandle {
-        let handle = &self.as_module().as_inner().function_handles[idx.into_index()];
-        assumed_postcondition!(
-            handle.parameters.into_index() < self.as_module().as_inner().signatures.len()
-        ); // invariant
-        assumed_postcondition!(
-            handle.return_.into_index() < self.as_module().as_inner().signatures.len()
-        ); // invariant
+        let handle = &self.as_module().function_handles[idx.into_index()];
+        assumed_postcondition!(handle.parameters.into_index() < self.as_module().signatures.len()); // invariant
+        assumed_postcondition!(handle.return_.into_index() < self.as_module().signatures.len()); // invariant
         handle
     }
 
     fn field_handle_at(&self, idx: FieldHandleIndex) -> &FieldHandle {
-        let handle = &self.as_module().as_inner().field_handles[idx.into_index()];
-        assumed_postcondition!(
-            handle.owner.into_index() < self.as_module().as_inner().struct_defs.len()
-        ); // invariant
+        let handle = &self.as_module().field_handles[idx.into_index()];
+        assumed_postcondition!(handle.owner.into_index() < self.as_module().struct_defs.len()); // invariant
         handle
     }
 
     fn struct_instantiation_at(&self, idx: StructDefInstantiationIndex) -> &StructDefInstantiation {
-        &self.as_module().as_inner().struct_def_instantiations[idx.into_index()]
+        &self.as_module().struct_def_instantiations[idx.into_index()]
     }
 
     fn function_instantiation_at(&self, idx: FunctionInstantiationIndex) -> &FunctionInstantiation {
-        &self.as_module().as_inner().function_instantiations[idx.into_index()]
+        &self.as_module().function_instantiations[idx.into_index()]
     }
 
     fn field_instantiation_at(&self, idx: FieldInstantiationIndex) -> &FieldInstantiation {
-        &self.as_module().as_inner().field_instantiations[idx.into_index()]
+        &self.as_module().field_instantiations[idx.into_index()]
     }
 
     fn signature_at(&self, idx: SignatureIndex) -> &Signature {
-        &self.as_module().as_inner().signatures[idx.into_index()]
+        &self.as_module().signatures[idx.into_index()]
     }
 
     fn identifier_at(&self, idx: IdentifierIndex) -> &IdentStr {
-        &self.as_module().as_inner().identifiers[idx.into_index()]
+        &self.as_module().identifiers[idx.into_index()]
     }
 
     fn address_identifier_at(&self, idx: AddressIdentifierIndex) -> &AccountAddress {
-        &self.as_module().as_inner().address_identifiers[idx.into_index()]
+        &self.as_module().address_identifiers[idx.into_index()]
     }
 
     fn constant_at(&self, idx: ConstantPoolIndex) -> &Constant {
-        &self.as_module().as_inner().constant_pool[idx.into_index()]
+        &self.as_module().constant_pool[idx.into_index()]
     }
 
     fn struct_def_at(&self, idx: StructDefinitionIndex) -> &StructDefinition {
-        &self.as_module().as_inner().struct_defs[idx.into_index()]
+        &self.as_module().struct_defs[idx.into_index()]
     }
 
     fn function_def_at(&self, idx: FunctionDefinitionIndex) -> &FunctionDefinition {
-        let result = &self.as_module().as_inner().function_defs[idx.into_index()];
+        let result = &self.as_module().function_defs[idx.into_index()];
         assumed_postcondition!(result.function.into_index() < self.function_handles().len()); // invariant
         assumed_postcondition!(match &result.code {
             Some(code) => code.locals.into_index() < self.signatures().len(),
@@ -125,59 +113,59 @@ pub trait ModuleAccess: Sync {
     }
 
     fn module_handles(&self) -> &[ModuleHandle] {
-        &self.as_module().as_inner().module_handles
+        &self.as_module().module_handles
     }
 
     fn struct_handles(&self) -> &[StructHandle] {
-        &self.as_module().as_inner().struct_handles
+        &self.as_module().struct_handles
     }
 
     fn function_handles(&self) -> &[FunctionHandle] {
-        &self.as_module().as_inner().function_handles
+        &self.as_module().function_handles
     }
 
     fn field_handles(&self) -> &[FieldHandle] {
-        &self.as_module().as_inner().field_handles
+        &self.as_module().field_handles
     }
 
     fn struct_instantiations(&self) -> &[StructDefInstantiation] {
-        &self.as_module().as_inner().struct_def_instantiations
+        &self.as_module().struct_def_instantiations
     }
 
     fn function_instantiations(&self) -> &[FunctionInstantiation] {
-        &self.as_module().as_inner().function_instantiations
+        &self.as_module().function_instantiations
     }
 
     fn field_instantiations(&self) -> &[FieldInstantiation] {
-        &self.as_module().as_inner().field_instantiations
+        &self.as_module().field_instantiations
     }
 
     fn signatures(&self) -> &[Signature] {
-        &self.as_module().as_inner().signatures
+        &self.as_module().signatures
     }
 
     fn constant_pool(&self) -> &[Constant] {
-        &self.as_module().as_inner().constant_pool
+        &self.as_module().constant_pool
     }
 
     fn identifiers(&self) -> &[Identifier] {
-        &self.as_module().as_inner().identifiers
+        &self.as_module().identifiers
     }
 
     fn address_identifiers(&self) -> &[AccountAddress] {
-        &self.as_module().as_inner().address_identifiers
+        &self.as_module().address_identifiers
     }
 
     fn struct_defs(&self) -> &[StructDefinition] {
-        &self.as_module().as_inner().struct_defs
+        &self.as_module().struct_defs
     }
 
     fn function_defs(&self) -> &[FunctionDefinition] {
-        &self.as_module().as_inner().function_defs
+        &self.as_module().function_defs
     }
 
     fn friend_decls(&self) -> &[ModuleHandle] {
-        &self.as_module().as_inner().friend_decls
+        &self.as_module().friend_decls
     }
 
     fn module_id_for_handle(&self, module_handle_idx: &ModuleHandle) -> ModuleId {
@@ -189,7 +177,7 @@ pub trait ModuleAccess: Sync {
     }
 
     fn version(&self) -> u32 {
-        self.as_module().as_inner().version
+        self.as_module().version
     }
 
     fn immediate_dependencies(&self) -> Vec<ModuleId> {

--- a/language/move-binary-format/src/access.rs
+++ b/language/move-binary-format/src/access.rs
@@ -217,75 +217,75 @@ pub trait ScriptAccess: Sync {
     fn as_script(&self) -> &CompiledScript;
 
     fn module_handle_at(&self, idx: ModuleHandleIndex) -> &ModuleHandle {
-        &self.as_script().as_inner().module_handles[idx.into_index()]
+        &self.as_script().module_handles[idx.into_index()]
     }
 
     fn struct_handle_at(&self, idx: StructHandleIndex) -> &StructHandle {
-        &self.as_script().as_inner().struct_handles[idx.into_index()]
+        &self.as_script().struct_handles[idx.into_index()]
     }
 
     fn function_handle_at(&self, idx: FunctionHandleIndex) -> &FunctionHandle {
-        &self.as_script().as_inner().function_handles[idx.into_index()]
+        &self.as_script().function_handles[idx.into_index()]
     }
 
     fn signature_at(&self, idx: SignatureIndex) -> &Signature {
-        &self.as_script().as_inner().signatures[idx.into_index()]
+        &self.as_script().signatures[idx.into_index()]
     }
 
     fn identifier_at(&self, idx: IdentifierIndex) -> &IdentStr {
-        &self.as_script().as_inner().identifiers[idx.into_index()]
+        &self.as_script().identifiers[idx.into_index()]
     }
 
     fn address_identifier_at(&self, idx: AddressIdentifierIndex) -> &AccountAddress {
-        &self.as_script().as_inner().address_identifiers[idx.into_index()]
+        &self.as_script().address_identifiers[idx.into_index()]
     }
 
     fn constant_at(&self, idx: ConstantPoolIndex) -> &Constant {
-        &self.as_script().as_inner().constant_pool[idx.into_index()]
+        &self.as_script().constant_pool[idx.into_index()]
     }
 
     fn function_instantiation_at(&self, idx: FunctionInstantiationIndex) -> &FunctionInstantiation {
-        &self.as_script().as_inner().function_instantiations[idx.into_index()]
+        &self.as_script().function_instantiations[idx.into_index()]
     }
 
     fn module_handles(&self) -> &[ModuleHandle] {
-        &self.as_script().as_inner().module_handles
+        &self.as_script().module_handles
     }
 
     fn struct_handles(&self) -> &[StructHandle] {
-        &self.as_script().as_inner().struct_handles
+        &self.as_script().struct_handles
     }
 
     fn function_handles(&self) -> &[FunctionHandle] {
-        &self.as_script().as_inner().function_handles
+        &self.as_script().function_handles
     }
 
     fn function_instantiations(&self) -> &[FunctionInstantiation] {
-        &self.as_script().as_inner().function_instantiations
+        &self.as_script().function_instantiations
     }
 
     fn signatures(&self) -> &[Signature] {
-        &self.as_script().as_inner().signatures
+        &self.as_script().signatures
     }
 
     fn constant_pool(&self) -> &[Constant] {
-        &self.as_script().as_inner().constant_pool
+        &self.as_script().constant_pool
     }
 
     fn identifiers(&self) -> &[Identifier] {
-        &self.as_script().as_inner().identifiers
+        &self.as_script().identifiers
     }
 
     fn address_identifiers(&self) -> &[AccountAddress] {
-        &self.as_script().as_inner().address_identifiers
+        &self.as_script().address_identifiers
     }
 
     fn version(&self) -> u32 {
-        self.as_script().as_inner().version
+        self.as_script().version
     }
 
     fn code(&self) -> &CodeUnit {
-        &self.as_script().as_inner().code
+        &self.as_script().code
     }
 
     fn immediate_dependencies(&self) -> Vec<ModuleId> {

--- a/language/move-binary-format/src/binary_views.rs
+++ b/language/move-binary-format/src/binary_views.rs
@@ -354,10 +354,10 @@ impl<'a> FunctionView<'a> {
 
     // Creates a `FunctionView` for a script.
     pub fn script(script: &'a CompiledScript) -> Self {
-        let code = &script.as_inner().code;
-        let parameters = script.signature_at(script.as_inner().parameters);
+        let code = &script.code;
+        let parameters = script.signature_at(script.parameters);
         let locals = script.signature_at(code.locals);
-        let type_parameters = &script.as_inner().type_parameters;
+        let type_parameters = &script.type_parameters;
         Self {
             index: None,
             code,

--- a/language/move-binary-format/src/check_bounds.rs
+++ b/language/move-binary-format/src/check_bounds.rs
@@ -37,16 +37,14 @@ impl<'a> BoundsChecker<'a> {
         };
         bounds_check.verify_impl()?;
 
-        let signatures = &script.as_inner().signatures;
-        let parameters = &script.as_inner().parameters;
+        let signatures = &script.signatures;
+        let parameters = &script.parameters;
         match signatures.get(parameters.into_index()) {
             // The bounds checker has already checked each function definition's code, but a script's
             // code exists outside of any function definition. It gets checked here.
-            Some(signature) => bounds_check.check_code(
-                &script.as_inner().code,
-                &script.as_inner().type_parameters,
-                signature,
-            ),
+            Some(signature) => {
+                bounds_check.check_code(&script.code, &script.type_parameters, signature)
+            }
             None => Err(bounds_error(
                 StatusCode::INDEX_OUT_OF_BOUNDS,
                 IndexKind::Signature,

--- a/language/move-binary-format/src/deserializer.rs
+++ b/language/move-binary-format/src/deserializer.rs
@@ -23,12 +23,9 @@ impl CompiledScript {
 impl CompiledModule {
     /// Deserialize a &[u8] slice into a `CompiledModule` instance.
     pub fn deserialize(binary: &[u8]) -> BinaryLoaderResult<Self> {
-        let deserialized = CompiledModuleMut::deserialize_no_check_bounds(binary)?;
-        deserialized.freeze()
+        CompiledModule::deserialize_no_check_bounds(binary)?.freeze()
     }
-}
 
-impl CompiledModuleMut {
     // exposed as a public function to enable testing the deserializer
     pub fn deserialize_no_check_bounds(binary: &[u8]) -> BinaryLoaderResult<Self> {
         deserialize_compiled_module(binary)
@@ -276,7 +273,7 @@ fn deserialize_compiled_script(binary: &[u8]) -> BinaryLoaderResult<CompiledScri
 }
 
 /// Module internal function that manages deserialization of modules.
-fn deserialize_compiled_module(binary: &[u8]) -> BinaryLoaderResult<CompiledModuleMut> {
+fn deserialize_compiled_module(binary: &[u8]) -> BinaryLoaderResult<CompiledModule> {
     let binary_len = binary.len();
     let mut cursor = VersionedCursor::new(binary)?;
     let table_count = load_table_count(&mut cursor)?;
@@ -291,7 +288,7 @@ fn deserialize_compiled_module(binary: &[u8]) -> BinaryLoaderResult<CompiledModu
         content_len as usize,
     )?;
 
-    let mut module = CompiledModuleMut {
+    let mut module = CompiledModule {
         version: cursor.version(),
         self_module_handle_idx: load_module_handle_index(&mut cursor)?,
         ..Default::default()
@@ -420,7 +417,7 @@ impl CommonTables for CompiledScript {
     }
 }
 
-impl CommonTables for CompiledModuleMut {
+impl CommonTables for CompiledModule {
     fn get_module_handles(&mut self) -> &mut Vec<ModuleHandle> {
         &mut self.module_handles
     }
@@ -465,9 +462,9 @@ fn build_compiled_script(
     Ok(())
 }
 
-/// Builds and returns a `CompiledModuleMut`.
+/// Builds and returns a `CompiledModule`.
 fn build_compiled_module(
-    module: &mut CompiledModuleMut,
+    module: &mut CompiledModule,
     binary: &VersionedBinary,
     tables: &[Table],
 ) -> BinaryLoaderResult<()> {
@@ -527,11 +524,11 @@ fn build_common_tables(
     Ok(())
 }
 
-/// Builds tables related to a `CompiledModuleMut`.
+/// Builds tables related to a `CompiledModule`.
 fn build_module_tables(
     binary: &VersionedBinary,
     tables: &[Table],
-    module: &mut CompiledModuleMut,
+    module: &mut CompiledModule,
 ) -> BinaryLoaderResult<()> {
     for table in tables {
         match table.kind {

--- a/language/move-binary-format/src/file_format.rs
+++ b/language/move-binary-format/src/file_format.rs
@@ -1724,8 +1724,6 @@ pub struct CompiledModule {
     pub function_defs: Vec<FunctionDefinition>,
 }
 
-pub type CompiledModuleMut = CompiledModule;
-
 // Need a custom implementation of Arbitrary because as of proptest-derive 0.1.1, the derivation
 // doesn't work for structs with more than 10 fields.
 #[cfg(any(test, feature = "fuzzing"))]

--- a/language/move-binary-format/src/file_format.rs
+++ b/language/move-binary-format/src/file_format.rs
@@ -1663,8 +1663,6 @@ pub struct CompiledScript {
     pub code: CodeUnit,
 }
 
-pub type CompiledScriptMut = CompiledScript;
-
 impl CompiledScript {
     /// Returns the index of `main` in case a script is converted to a module.
     pub const MAIN_INDEX: FunctionDefinitionIndex = FunctionDefinitionIndex(0);

--- a/language/move-binary-format/src/file_format.rs
+++ b/language/move-binary-format/src/file_format.rs
@@ -1883,17 +1883,6 @@ impl CompiledModule {
         Ok(module)
     }
 
-    /// Returns a reference to the inner `CompiledModule`.
-    pub fn as_inner(&self) -> &CompiledModule {
-        self
-    }
-
-    /// Converts this instance into the inner `CompiledModule`. Converting back to a
-    /// `CompiledModule` would require it to be verified again.
-    pub fn into_inner(self) -> CompiledModule {
-        self
-    }
-
     /// Returns the code key of `module_handle`
     pub fn module_id_for_handle(&self, module_handle: &ModuleHandle) -> ModuleId {
         ModuleId::new(

--- a/language/move-binary-format/src/file_format.rs
+++ b/language/move-binary-format/src/file_format.rs
@@ -1669,17 +1669,6 @@ impl CompiledScript {
     /// Returns the index of `main` in case a script is converted to a module.
     pub const MAIN_INDEX: FunctionDefinitionIndex = FunctionDefinitionIndex(0);
 
-    /// Returns a reference to the inner `CompiledScript`.
-    pub fn as_inner(&self) -> &CompiledScript {
-        self
-    }
-
-    /// Converts this instance into the inner `CompiledScript`. Converting back to a
-    /// `CompiledScript` would require it to be verified again.
-    pub fn into_inner(self) -> CompiledScript {
-        self
-    }
-
     /// Converts this instance into `CompiledScript` after verifying it for basic internal
     /// consistency. This includes bounds checks but no others.
     #[allow(deprecated)]

--- a/language/move-binary-format/src/proptest_types.rs
+++ b/language/move-binary-format/src/proptest_types.rs
@@ -4,8 +4,8 @@
 //! Utilities for property-based testing.
 
 use crate::file_format::{
-    AddressIdentifierIndex, CompiledModule, CompiledModuleMut, FunctionDefinition, FunctionHandle,
-    IdentifierIndex, ModuleHandle, ModuleHandleIndex, StructDefinition, TableIndex,
+    AddressIdentifierIndex, CompiledModule, FunctionDefinition, FunctionHandle, IdentifierIndex,
+    ModuleHandle, ModuleHandleIndex, StructDefinition, TableIndex,
 };
 use move_core_types::{account_address::AccountAddress, identifier::Identifier};
 use proptest::{
@@ -327,7 +327,7 @@ impl CompiledModuleStrategyGen {
                     ) = state.return_tables();
 
                     // Build a compiled module
-                    let module = CompiledModuleMut {
+                    CompiledModule {
                         version: crate::file_format_common::VERSION_MAX,
                         module_handles,
                         self_module_handle_idx,
@@ -348,10 +348,9 @@ impl CompiledModuleStrategyGen {
                         identifiers,
                         address_identifiers,
                         constant_pool,
-                    };
-                    module
-                        .freeze()
-                        .expect("valid modules should satisfy the bounds checker")
+                    }
+                    .freeze()
+                    .expect("valid modules should satisfy the bounds checker")
                 },
             )
     }

--- a/language/move-binary-format/src/serializer.rs
+++ b/language/move-binary-format/src/serializer.rs
@@ -175,16 +175,6 @@ impl CompiledModule {
     /// Serializes a `CompiledModule` into a binary. The mutable `Vec<u8>` will contain the
     /// binary blob on return.
     pub fn serialize(&self, binary: &mut Vec<u8>) -> Result<()> {
-        self.as_inner().serialize(binary)
-    }
-}
-
-impl CompiledModuleMut {
-    /// Serializes this into a binary format.
-    ///
-    /// This is intended mainly for test code. Production code will typically use
-    /// [`CompiledModule::serialize`].
-    pub fn serialize(&self, binary: &mut Vec<u8>) -> Result<()> {
         let mut binary_data = BinaryData::from(binary.clone());
         let mut ser = ModuleSerializer::new(VERSION_MAX);
         let mut temp = BinaryData::new();

--- a/language/move-binary-format/src/serializer.rs
+++ b/language/move-binary-format/src/serializer.rs
@@ -285,7 +285,7 @@ trait CommonTables {
     fn get_signatures(&self) -> &[Signature];
 }
 
-impl CommonTables for CompiledScriptMut {
+impl CommonTables for CompiledScript {
     fn get_module_handles(&self) -> &[ModuleHandle] {
         &self.module_handles
     }
@@ -1275,11 +1275,7 @@ impl ScriptSerializer {
     }
 
     /// Serializes the main function.
-    fn serialize_main(
-        &mut self,
-        binary: &mut BinaryData,
-        script: &CompiledScriptMut,
-    ) -> Result<()> {
+    fn serialize_main(&mut self, binary: &mut BinaryData, script: &CompiledScript) -> Result<()> {
         serialize_ability_sets(binary, &script.type_parameters)?;
         serialize_signature_index(binary, &script.parameters)?;
         serialize_code_unit(binary, &script.code)?;

--- a/language/move-binary-format/src/serializer.rs
+++ b/language/move-binary-format/src/serializer.rs
@@ -319,7 +319,7 @@ impl CommonTables for CompiledScript {
     }
 }
 
-impl CommonTables for CompiledModuleMut {
+impl CommonTables for CompiledModule {
     fn get_module_handles(&self) -> &[ModuleHandle] {
         &self.module_handles
     }
@@ -1110,11 +1110,7 @@ impl ModuleSerializer {
         }
     }
 
-    fn serialize_tables(
-        &mut self,
-        binary: &mut BinaryData,
-        module: &CompiledModuleMut,
-    ) -> Result<()> {
+    fn serialize_tables(&mut self, binary: &mut BinaryData, module: &CompiledModule) -> Result<()> {
         self.common.serialize_common_tables(binary, module)?;
         self.serialize_struct_definitions(binary, &module.struct_defs)?;
         self.serialize_struct_def_instantiations(binary, &module.struct_def_instantiations)?;

--- a/language/move-lang/src/to_bytecode/translate.rs
+++ b/language/move-lang/src/to_bytecode/translate.rs
@@ -320,7 +320,7 @@ fn module_function_infos(
     source_map: &SourceMap<Loc>,
     collected_function_infos: &CollectedInfos,
 ) -> UniqueMap<FunctionName, FunctionInfo> {
-    UniqueMap::maybe_from_iter((0..compile_module.as_inner().function_defs.len()).map(|i| {
+    UniqueMap::maybe_from_iter((0..compile_module.function_defs.len()).map(|i| {
         let idx = F::FunctionDefinitionIndex(i as F::TableIndex);
         function_info_map(compile_module, source_map, collected_function_infos, idx)
     }))
@@ -333,7 +333,7 @@ fn function_info_map(
     collected_function_infos: &CollectedInfos,
     idx: F::FunctionDefinitionIndex,
 ) -> (FunctionName, FunctionInfo) {
-    let module = compile_module.as_inner();
+    let module = compile_module;
     let handle_idx = module.function_defs[idx.0 as usize].function;
     let name_idx = module.function_handles[handle_idx.0 as usize].name;
     let name = module.identifiers[name_idx.0 as usize]

--- a/language/move-model/src/lib.rs
+++ b/language/move-model/src/lib.rs
@@ -272,7 +272,7 @@ fn add_move_lang_errors(env: &mut GlobalEnv, errors: Errors) {
 
 #[allow(deprecated)]
 fn script_into_module(compiled_script: CompiledScript) -> CompiledModule {
-    let mut script = compiled_script.into_inner();
+    let mut script = compiled_script;
 
     // Add the "<SELF>" identifier if it isn't present.
     //

--- a/language/move-model/src/lib.rs
+++ b/language/move-model/src/lib.rs
@@ -13,10 +13,10 @@ use builder::module_builder::ModuleBuilder;
 use move_binary_format::{
     access::ModuleAccess,
     file_format::{
-        self_module_name, AddressIdentifierIndex, CompiledModule, CompiledModuleMut,
-        CompiledScript, FunctionDefinition, FunctionDefinitionIndex, FunctionHandle,
-        FunctionHandleIndex, IdentifierIndex, ModuleHandle, ModuleHandleIndex, Signature,
-        SignatureIndex, StructDefinitionIndex, Visibility,
+        self_module_name, AddressIdentifierIndex, CompiledModule, CompiledScript,
+        FunctionDefinition, FunctionDefinitionIndex, FunctionHandle, FunctionHandleIndex,
+        IdentifierIndex, ModuleHandle, ModuleHandleIndex, Signature, SignatureIndex,
+        StructDefinitionIndex, Visibility,
     },
 };
 use move_core_types::{account_address::AccountAddress, identifier::Identifier};
@@ -354,7 +354,7 @@ fn script_into_module(compiled_script: CompiledScript) -> CompiledModule {
         code: Some(script.code),
     };
 
-    CompiledModuleMut {
+    CompiledModule {
         version: script.version,
         module_handles: script.module_handles,
         self_module_handle_idx,

--- a/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
@@ -241,7 +241,7 @@ fn test_unverifiable_module() {
     {
         let mut storage = InMemoryStorage::new();
 
-        let mut m = m.into_inner();
+        let mut m = m;
         m.function_defs[0].code.as_mut().unwrap().code = vec![];
         let m = m.freeze().unwrap();
         let mut blob = vec![];
@@ -431,7 +431,7 @@ fn test_unverifiable_module_dependency() {
 
     // Publish N and an unverifiable version of M and try to call N::bar, the VM should fail to load M.
     {
-        let mut m = m.into_inner();
+        let mut m = m;
         m.function_defs[0].code.as_mut().unwrap().code = vec![];
         let m = m.freeze().unwrap();
         let mut blob_m = vec![];

--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -1454,9 +1454,8 @@ impl Script {
 
         let scope = Scope::Script(*script_hash);
 
-        let compiled_script = script.as_inner();
-        let code: Vec<Bytecode> = compiled_script.code.code.clone();
-        let parameters = script.signature_at(compiled_script.parameters).clone();
+        let code: Vec<Bytecode> = script.code.code.clone();
+        let parameters = script.signature_at(script.parameters).clone();
 
         let parameter_tys = parameters
             .0
@@ -1469,11 +1468,11 @@ impl Script {
             parameters
                 .0
                 .iter()
-                .chain(script.signature_at(compiled_script.code.locals).0.iter())
+                .chain(script.signature_at(script.code.locals).0.iter())
                 .cloned()
                 .collect(),
         );
-        let type_parameters = compiled_script.type_parameters.clone();
+        let type_parameters = script.type_parameters.clone();
         // TODO: main does not have a name. Revisit.
         let name = Identifier::new("main").unwrap();
         let native = None; // Script entries cannot be native

--- a/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
@@ -8,10 +8,10 @@ use move_binary_format::{
     errors::{PartialVMResult, VMResult},
     file_format::{
         empty_module, AbilitySet, AddressIdentifierIndex, Bytecode, CodeUnit, CompiledModule,
-        CompiledModuleMut, CompiledScript, FieldDefinition, FunctionDefinition, FunctionHandle,
-        FunctionHandleIndex, IdentifierIndex, ModuleHandle, ModuleHandleIndex, Signature,
-        SignatureIndex, SignatureToken, StructDefinition, StructFieldInformation, StructHandle,
-        StructHandleIndex, TableIndex, TypeSignature, Visibility,
+        CompiledScript, FieldDefinition, FunctionDefinition, FunctionHandle, FunctionHandleIndex,
+        IdentifierIndex, ModuleHandle, ModuleHandleIndex, Signature, SignatureIndex,
+        SignatureToken, StructDefinition, StructFieldInformation, StructHandle, StructHandleIndex,
+        TableIndex, TypeSignature, Visibility,
     },
 };
 use move_core_types::{
@@ -153,7 +153,7 @@ fn make_module_with_function(
             SignatureIndex((signatures.len() - 1) as TableIndex)
         }
     };
-    let module = CompiledModuleMut {
+    let module = CompiledModule {
         version: move_binary_format::file_format_common::VERSION_MAX,
         self_module_handle_idx: ModuleHandleIndex(0),
         module_handles: vec![ModuleHandle {

--- a/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
@@ -7,13 +7,12 @@ use crate::{data_cache::MoveStorage, move_vm::MoveVM};
 use move_binary_format::{
     errors::{PartialVMResult, VMResult},
     file_format::{
-        empty_module, AbilitySet, AddressIdentifierIndex, Bytecode, CodeUnit, CompiledModuleMut,
-        CompiledScriptMut, FieldDefinition, FunctionDefinition, FunctionHandle,
+        empty_module, AbilitySet, AddressIdentifierIndex, Bytecode, CodeUnit, CompiledModule,
+        CompiledModuleMut, CompiledScript, FieldDefinition, FunctionDefinition, FunctionHandle,
         FunctionHandleIndex, IdentifierIndex, ModuleHandle, ModuleHandleIndex, Signature,
         SignatureIndex, SignatureToken, StructDefinition, StructFieldInformation, StructHandle,
         StructHandleIndex, TableIndex, TypeSignature, Visibility,
     },
-    CompiledModule,
 };
 use move_core_types::{
     account_address::AccountAddress,
@@ -39,7 +38,7 @@ fn make_script(parameters: Signature) -> Vec<u8> {
             SignatureIndex((signatures.len() - 1) as TableIndex)
         }
     };
-    CompiledScriptMut {
+    CompiledScript {
         version: move_binary_format::file_format_common::VERSION_MAX,
         module_handles: vec![],
         struct_handles: vec![],
@@ -84,7 +83,7 @@ fn make_script_with_non_linking_structs(parameters: Signature) -> Vec<u8> {
             SignatureIndex((signatures.len() - 1) as TableIndex)
         }
     };
-    CompiledScriptMut {
+    CompiledScript {
         version: move_binary_format::file_format_common::VERSION_MAX,
         module_handles: vec![ModuleHandle {
             address: AddressIdentifierIndex(0),

--- a/language/testing-infra/functional-tests/src/evaluator.rs
+++ b/language/testing-infra/functional-tests/src/evaluator.rs
@@ -221,11 +221,10 @@ fn fetch_script_dependencies(
     data_store: &FakeDataStore,
     script: &CompiledScript,
 ) -> Vec<CompiledModule> {
-    let inner = script.as_inner();
-    let idents = inner.module_handles.iter().map(|handle| {
+    let idents = script.module_handles.iter().map(|handle| {
         ModuleId::new(
-            inner.address_identifiers[handle.address.0 as usize],
-            inner.identifiers[handle.name.0 as usize].clone(),
+            script.address_identifiers[handle.address.0 as usize],
+            script.identifiers[handle.name.0 as usize].clone(),
         )
     });
     fetch_dependencies(data_store, idents)

--- a/language/testing-infra/module-generation/src/generator.rs
+++ b/language/testing-infra/module-generation/src/generator.rs
@@ -49,8 +49,7 @@ pub fn generate_modules(
         .map(|module| {
             let mut module = compile_module(AccountAddress::ZERO, module, &empty_deps)
                 .unwrap()
-                .0
-                .into_inner();
+                .0;
             Pad::pad(table_size, &mut module, options.clone());
             module.freeze().unwrap()
         })
@@ -60,8 +59,7 @@ pub fn generate_modules(
 
     let mut compiled_root = compile_module(AccountAddress::ZERO, root_module, &compiled_callees)
         .unwrap()
-        .0
-        .into_inner();
+        .0;
     Pad::pad(table_size, &mut compiled_root, options);
     (compiled_root.freeze().unwrap(), compiled_callees)
 }

--- a/language/testing-infra/module-generation/src/padding.rs
+++ b/language/testing-infra/module-generation/src/padding.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{options::ModuleGeneratorOptions, utils::random_string};
-use move_binary_format::file_format::{Bytecode, CompiledModuleMut, Signature};
+use move_binary_format::file_format::{Bytecode, CompiledModule, Signature};
 use move_core_types::{account_address::AccountAddress, identifier::Identifier};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 
@@ -17,7 +17,7 @@ pub struct Pad {
 }
 
 impl Pad {
-    pub fn pad(table_size: usize, module: &mut CompiledModuleMut, options: ModuleGeneratorOptions) {
+    pub fn pad(table_size: usize, module: &mut CompiledModule, options: ModuleGeneratorOptions) {
         let seed: [u8; 32] = [1; 32];
         let mut slf = Self {
             gen: StdRng::from_seed(seed),
@@ -31,12 +31,12 @@ impl Pad {
         slf.pad_function_bodies(module);
     }
 
-    fn pad_cosntant_table(&mut self, module: &mut CompiledModuleMut) {
+    fn pad_cosntant_table(&mut self, module: &mut CompiledModule) {
         // TODO actual constant generation
         module.constant_pool = vec![]
     }
 
-    fn pad_identifier_table(&mut self, module: &mut CompiledModuleMut) {
+    fn pad_identifier_table(&mut self, module: &mut CompiledModule) {
         module.identifiers = (0..(self.table_size + module.identifiers.len()))
             .map(|_| {
                 let len = self.gen.gen_range(10..self.options.max_string_size);
@@ -45,13 +45,13 @@ impl Pad {
             .collect()
     }
 
-    fn pad_address_identifier_table(&mut self, module: &mut CompiledModuleMut) {
+    fn pad_address_identifier_table(&mut self, module: &mut CompiledModule) {
         module.address_identifiers = (0..(self.table_size + module.address_identifiers.len()))
             .map(|_| AccountAddress::random())
             .collect()
     }
 
-    fn pad_function_bodies(&mut self, module: &mut CompiledModuleMut) {
+    fn pad_function_bodies(&mut self, module: &mut CompiledModule) {
         for fdef in module.function_defs.iter_mut() {
             if let Some(code) = &mut fdef.code {
                 code.code = vec![
@@ -66,7 +66,7 @@ impl Pad {
     }
 
     // Ensure that locals signatures always contain an empty signature
-    fn pad_signatures(&mut self, module: &mut CompiledModuleMut) {
+    fn pad_signatures(&mut self, module: &mut CompiledModule) {
         if module.signatures.iter().all(|v| !v.is_empty()) {
             module.signatures.push(Signature(Vec::new()));
         }

--- a/language/testing-infra/test-generation/src/abstract_state.rs
+++ b/language/testing-infra/test-generation/src/abstract_state.rs
@@ -5,7 +5,7 @@ use crate::{borrow_graph::BorrowGraph, error::VMError};
 use move_binary_format::{
     access::ModuleAccess,
     file_format::{
-        empty_module, Ability, AbilitySet, CompiledModule, CompiledModuleMut, FieldInstantiation,
+        empty_module, Ability, AbilitySet, CompiledModule, FieldInstantiation,
         FieldInstantiationIndex, FunctionHandleIndex, FunctionInstantiation,
         FunctionInstantiationIndex, Signature, SignatureIndex, SignatureToken,
         StructDefInstantiation, StructDefInstantiationIndex, StructDefinitionIndex, TableIndex,
@@ -394,7 +394,7 @@ impl InstantiableModule {
 
     /// Consumes self, and adds the instantiations that have been built up to the underlying
     /// module, and returns the resultant compiled module.
-    pub fn instantiate(self) -> CompiledModuleMut {
+    pub fn instantiate(self) -> CompiledModule {
         let mut module = self.module.into_inner();
         module.signatures = self
             .sig_instance_for_offset
@@ -473,7 +473,7 @@ impl AbstractState {
     /// Create a new AbstractState given a list of `SignatureTokens` that will be
     /// the (available) locals that the state will have, as well as the module state
     pub fn from_locals(
-        module: CompiledModuleMut,
+        module: CompiledModule,
         locals: HashMap<usize, (AbstractValue, BorrowState)>,
         instantiation: Vec<AbilitySet>,
         acquires_global_resources: Vec<StructDefinitionIndex>,

--- a/language/testing-infra/test-generation/src/abstract_state.rs
+++ b/language/testing-infra/test-generation/src/abstract_state.rs
@@ -195,8 +195,7 @@ impl CallGraph {
 }
 
 /// During the generation of a bytecode sequence, specific instantiations may need to be made, that
-/// may not yet exist in the underlying module. Instead of mutating the underlying module (which
-/// would require an into_inner followd by a freeze) in order to record these instantiations in the
+/// may not yet exist in the underlying module. Instead of mutating the underlying module in order to record these instantiations in the
 /// locals signature table, we instead build wrapper around the underlying module containing the
 /// type instantiations, and at the end materialize this updated signature pool into a module. We
 /// also need the ability to quickly determine if an instantiation has already been created, and if
@@ -395,7 +394,7 @@ impl InstantiableModule {
     /// Consumes self, and adds the instantiations that have been built up to the underlying
     /// module, and returns the resultant compiled module.
     pub fn instantiate(self) -> CompiledModule {
-        let mut module = self.module.into_inner();
+        let mut module = self.module;
         module.signatures = self
             .sig_instance_for_offset
             .into_iter()

--- a/language/testing-infra/test-generation/src/bytecode_generator.rs
+++ b/language/testing-infra/test-generation/src/bytecode_generator.rs
@@ -13,7 +13,7 @@ use crate::{
 use move_binary_format::{
     access::ModuleAccess,
     file_format::{
-        Bytecode, CodeOffset, CompiledModuleMut, ConstantPoolIndex, FieldHandleIndex,
+        Bytecode, CodeOffset, CompiledModule, ConstantPoolIndex, FieldHandleIndex,
         FieldInstantiationIndex, FunctionHandle, FunctionHandleIndex, FunctionInstantiation,
         FunctionInstantiationIndex, LocalIndex, SignatureToken, StructDefInstantiation,
         StructDefInstantiationIndex, StructDefinitionIndex, StructFieldInformation, TableIndex,
@@ -351,7 +351,7 @@ impl<'a> BytecodeGenerator<'a> {
         &mut self,
         fn_context: &FunctionGenerationContext,
         state: AbstractState,
-        module: CompiledModuleMut,
+        module: CompiledModule,
     ) -> Vec<(StackEffect, Bytecode)> {
         let mut matches: Vec<(StackEffect, Bytecode)> = Vec::new();
         let instructions = &self.instructions;
@@ -600,7 +600,7 @@ impl<'a> BytecodeGenerator<'a> {
         fn_context: &mut FunctionGenerationContext,
         abstract_state_in: AbstractState,
         abstract_state_out: AbstractState,
-        module: &CompiledModuleMut,
+        module: &CompiledModule,
     ) -> Option<(Vec<Bytecode>, AbstractState)> {
         debug!("Abstract state in: {}", abstract_state_in);
         debug!("Abstract state out: {}", abstract_state_out);
@@ -720,7 +720,7 @@ impl<'a> BytecodeGenerator<'a> {
         locals: &[SignatureToken],
         fh: &FunctionHandle,
         acquires_global_resources: &[StructDefinitionIndex],
-        module: &mut CompiledModuleMut,
+        module: &mut CompiledModule,
         call_graph: &mut CallGraph,
     ) -> Option<Vec<Bytecode>> {
         let number_of_blocks = self.rng.gen_range(1..=MAX_CFG_BLOCKS);
@@ -831,7 +831,7 @@ impl<'a> BytecodeGenerator<'a> {
         Some(cfg.serialize())
     }
 
-    pub fn generate_module(&mut self, mut module: CompiledModuleMut) -> Option<CompiledModuleMut> {
+    pub fn generate_module(&mut self, mut module: CompiledModule) -> Option<CompiledModule> {
         let mut fdefs = module.function_defs.clone();
         let mut call_graph = CallGraph::new(module.function_handles.len());
         for fdef in fdefs.iter_mut() {

--- a/language/testing-infra/test-generation/src/lib.rs
+++ b/language/testing-infra/test-generation/src/lib.rs
@@ -24,8 +24,7 @@ use module_generation::generate_module;
 use move_binary_format::{
     access::ModuleAccess,
     file_format::{
-        AbilitySet, CompiledModule, CompiledModuleMut, FunctionDefinitionIndex, SignatureToken,
-        StructHandleIndex,
+        AbilitySet, CompiledModule, FunctionDefinitionIndex, SignatureToken, StructHandleIndex,
     },
 };
 use move_core_types::{
@@ -188,7 +187,7 @@ pub enum Status {
     Valid,
 }
 
-fn bytecode_module(rng: &mut StdRng, module: CompiledModuleMut) -> CompiledModuleMut {
+fn bytecode_module(rng: &mut StdRng, module: CompiledModule) -> CompiledModule {
     let mut generated_module = BytecodeGenerator::new(rng).generate_module(module.clone());
     // Module generation can retry under certain circumstances
     while generated_module.is_none() {
@@ -200,7 +199,7 @@ fn bytecode_module(rng: &mut StdRng, module: CompiledModuleMut) -> CompiledModul
 pub fn module_frame_generation(
     num_iters: Option<u64>,
     seed: [u8; 32],
-    sender: Sender<CompiledModuleMut>,
+    sender: Sender<CompiledModule>,
     stats: Receiver<Status>,
 ) {
     let mut verification_failures: u128 = 0;
@@ -261,7 +260,7 @@ pub fn bytecode_generation(
     output_path: Option<String>,
     tid: u64,
     mut rng: StdRng,
-    receiver: Receiver<CompiledModuleMut>,
+    receiver: Receiver<CompiledModule>,
     stats: Sender<Status>,
 ) {
     while let Ok(module) = receiver.recv() {

--- a/language/testing-infra/test-generation/src/lib.rs
+++ b/language/testing-infra/test-generation/src/lib.rs
@@ -208,7 +208,7 @@ pub fn module_frame_generation(
 
     let generation_options = config::module_generation_settings();
     let mut rng = StdRng::from_seed(seed);
-    let mut module = generate_module(&mut rng, generation_options.clone()).into_inner();
+    let mut module = generate_module(&mut rng, generation_options.clone());
     // Either get the number of iterations provided by the user, or iterate "infinitely"--up to
     // u128::MAX number of times.
     let iters = num_iters
@@ -216,7 +216,7 @@ pub fn module_frame_generation(
         .unwrap_or_else(|| std::u128::MAX);
 
     while generated < iters && sender.send(module).is_ok() {
-        module = generate_module(&mut rng, generation_options.clone()).into_inner();
+        module = generate_module(&mut rng, generation_options.clone());
         generated += 1;
         while let Ok(stat) = stats.try_recv() {
             match stat {

--- a/language/testing-infra/test-generation/tests/control_flow_instructions.rs
+++ b/language/testing-infra/test-generation/tests/control_flow_instructions.rs
@@ -3,8 +3,8 @@
 
 extern crate test_generation;
 use move_binary_format::file_format::{
-    empty_module, Bytecode, CompiledModuleMut, FunctionHandle, FunctionHandleIndex,
-    IdentifierIndex, ModuleHandleIndex, Signature, SignatureIndex, SignatureToken,
+    empty_module, Bytecode, CompiledModule, FunctionHandle, FunctionHandleIndex, IdentifierIndex,
+    ModuleHandleIndex, Signature, SignatureIndex, SignatureToken,
 };
 use move_core_types::identifier::Identifier;
 use std::collections::HashMap;
@@ -12,8 +12,8 @@ use test_generation::abstract_state::{AbstractState, AbstractValue, CallGraph};
 
 mod common;
 
-fn generate_module_with_function() -> CompiledModuleMut {
-    let mut module: CompiledModuleMut = empty_module();
+fn generate_module_with_function() -> CompiledModule {
+    let mut module = empty_module();
 
     let offset = module.identifiers.len();
     module.identifiers.push(Identifier::new("func0").unwrap());

--- a/language/testing-infra/test-generation/tests/struct_instructions.rs
+++ b/language/testing-infra/test-generation/tests/struct_instructions.rs
@@ -5,10 +5,10 @@ extern crate test_generation;
 use move_binary_format::{
     access::ModuleAccess,
     file_format::{
-        empty_module, Ability, AbilitySet, Bytecode, CompiledModule, CompiledModuleMut,
-        FieldDefinition, FieldHandle, FieldHandleIndex, IdentifierIndex, ModuleHandleIndex,
-        SignatureToken, StructDefinition, StructDefinitionIndex, StructFieldInformation,
-        StructHandle, StructHandleIndex, TableIndex, TypeSignature,
+        empty_module, Ability, AbilitySet, Bytecode, CompiledModule, FieldDefinition, FieldHandle,
+        FieldHandleIndex, IdentifierIndex, ModuleHandleIndex, SignatureToken, StructDefinition,
+        StructDefinitionIndex, StructFieldInformation, StructHandle, StructHandleIndex, TableIndex,
+        TypeSignature,
     },
     views::{StructDefinitionView, ViewInternals},
 };
@@ -21,8 +21,8 @@ use test_generation::{
 
 mod common;
 
-fn generate_module_with_struct(resource: bool) -> CompiledModuleMut {
-    let mut module: CompiledModuleMut = empty_module();
+fn generate_module_with_struct(resource: bool) -> CompiledModule {
+    let mut module: CompiledModule = empty_module();
 
     let struct_index = 0;
     let num_fields = 5;
@@ -83,10 +83,7 @@ fn create_struct_value(module: &CompiledModule) -> (AbstractValue, Vec<Signature
     )
 }
 
-fn get_field_signature<'a>(
-    module: &'a CompiledModuleMut,
-    handle: &FieldHandle,
-) -> &'a SignatureToken {
+fn get_field_signature<'a>(module: &'a CompiledModule, handle: &FieldHandle) -> &'a SignatureToken {
     let struct_def = &module.struct_defs[handle.owner.0 as usize];
     match &struct_def.field_information {
         StructFieldInformation::Native => panic!("borrow field on a native struct"),
@@ -97,7 +94,7 @@ fn get_field_signature<'a>(
 #[test]
 #[should_panic]
 fn bytecode_pack_signature_not_satisfied() {
-    let module: CompiledModuleMut = generate_module_with_struct(false);
+    let module = generate_module_with_struct(false);
     let state1 =
         AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     common::run_instruction(Bytecode::Pack(StructDefinitionIndex::new(0)), state1);
@@ -105,7 +102,7 @@ fn bytecode_pack_signature_not_satisfied() {
 
 #[test]
 fn bytecode_pack() {
-    let module: CompiledModuleMut = generate_module_with_struct(false);
+    let module = generate_module_with_struct(false);
     let mut state1 =
         AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     let (struct_value1, tokens) = create_struct_value(&state1.module.module);
@@ -128,7 +125,7 @@ fn bytecode_pack() {
 #[test]
 #[should_panic]
 fn bytecode_unpack_signature_not_satisfied() {
-    let module: CompiledModuleMut = generate_module_with_struct(false);
+    let module = generate_module_with_struct(false);
     let state1 =
         AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     common::run_instruction(Bytecode::Unpack(StructDefinitionIndex::new(0)), state1);
@@ -136,7 +133,7 @@ fn bytecode_unpack_signature_not_satisfied() {
 
 #[test]
 fn bytecode_unpack() {
-    let module: CompiledModuleMut = generate_module_with_struct(false);
+    let module = generate_module_with_struct(false);
     let mut state1 =
         AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     let (struct_value, tokens) = create_struct_value(&state1.module.module);
@@ -152,7 +149,7 @@ fn bytecode_unpack() {
 
 #[test]
 fn bytecode_exists() {
-    let module: CompiledModuleMut = generate_module_with_struct(true);
+    let module = generate_module_with_struct(true);
     let mut state1 =
         AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     state1.stack_push(AbstractValue::new_primitive(SignatureToken::Address));
@@ -168,7 +165,7 @@ fn bytecode_exists() {
 #[test]
 #[should_panic]
 fn bytecode_exists_struct_is_not_resource() {
-    let module: CompiledModuleMut = generate_module_with_struct(false);
+    let module = generate_module_with_struct(false);
     let mut state1 =
         AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     state1.stack_push(AbstractValue::new_primitive(SignatureToken::Address));
@@ -178,7 +175,7 @@ fn bytecode_exists_struct_is_not_resource() {
 #[test]
 #[should_panic]
 fn bytecode_exists_no_address_on_stack() {
-    let module: CompiledModuleMut = generate_module_with_struct(true);
+    let module = generate_module_with_struct(true);
     let state1 =
         AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     common::run_instruction(Bytecode::Exists(StructDefinitionIndex::new(0)), state1);
@@ -186,7 +183,7 @@ fn bytecode_exists_no_address_on_stack() {
 
 #[test]
 fn bytecode_movefrom() {
-    let module: CompiledModuleMut = generate_module_with_struct(true);
+    let module = generate_module_with_struct(true);
     let mut state1 = AbstractState::from_locals(
         module,
         HashMap::new(),
@@ -212,7 +209,7 @@ fn bytecode_movefrom() {
 #[test]
 #[should_panic]
 fn bytecode_movefrom_struct_is_not_resource() {
-    let module: CompiledModuleMut = generate_module_with_struct(false);
+    let module = generate_module_with_struct(false);
     let mut state1 =
         AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     state1.stack_push(AbstractValue::new_primitive(SignatureToken::Address));
@@ -222,7 +219,7 @@ fn bytecode_movefrom_struct_is_not_resource() {
 #[test]
 #[should_panic]
 fn bytecode_movefrom_no_address_on_stack() {
-    let module: CompiledModuleMut = generate_module_with_struct(true);
+    let module = generate_module_with_struct(true);
     let state1 =
         AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     common::run_instruction(Bytecode::MoveFrom(StructDefinitionIndex::new(0)), state1);
@@ -230,7 +227,7 @@ fn bytecode_movefrom_no_address_on_stack() {
 
 #[test]
 fn bytecode_moveto() {
-    let module: CompiledModuleMut = generate_module_with_struct(true);
+    let module = generate_module_with_struct(true);
     let mut state1 =
         AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     state1.stack_push(AbstractValue::new_reference(
@@ -246,7 +243,7 @@ fn bytecode_moveto() {
 #[test]
 #[should_panic]
 fn bytecode_moveto_struct_is_not_resource() {
-    let module: CompiledModuleMut = generate_module_with_struct(false);
+    let module = generate_module_with_struct(false);
     let mut state1 =
         AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     state1.stack_push(AbstractValue::new_reference(
@@ -260,7 +257,7 @@ fn bytecode_moveto_struct_is_not_resource() {
 #[test]
 #[should_panic]
 fn bytecode_moveto_no_struct_on_stack() {
-    let module: CompiledModuleMut = generate_module_with_struct(true);
+    let module = generate_module_with_struct(true);
     let mut state1 =
         AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     state1.stack_push(AbstractValue::new_reference(
@@ -272,7 +269,7 @@ fn bytecode_moveto_no_struct_on_stack() {
 
 #[test]
 fn bytecode_mutborrowfield() {
-    let mut module: CompiledModuleMut = generate_module_with_struct(false);
+    let mut module: CompiledModule = generate_module_with_struct(false);
     let struct_def_idx = StructDefinitionIndex((module.struct_defs.len() - 1) as u16);
     module.field_handles.push(FieldHandle {
         owner: struct_def_idx,
@@ -304,7 +301,7 @@ fn bytecode_mutborrowfield() {
 #[test]
 #[should_panic]
 fn bytecode_mutborrowfield_stack_has_no_reference() {
-    let mut module: CompiledModuleMut = generate_module_with_struct(false);
+    let mut module: CompiledModule = generate_module_with_struct(false);
     let struct_def_idx = StructDefinitionIndex((module.struct_defs.len() - 1) as u16);
     module.field_handles.push(FieldHandle {
         owner: struct_def_idx,
@@ -320,7 +317,7 @@ fn bytecode_mutborrowfield_stack_has_no_reference() {
 #[test]
 #[should_panic]
 fn bytecode_mutborrowfield_ref_is_immutable() {
-    let mut module: CompiledModuleMut = generate_module_with_struct(false);
+    let mut module: CompiledModule = generate_module_with_struct(false);
     let struct_def_idx = StructDefinitionIndex((module.struct_defs.len() - 1) as u16);
     module.field_handles.push(FieldHandle {
         owner: struct_def_idx,
@@ -340,7 +337,7 @@ fn bytecode_mutborrowfield_ref_is_immutable() {
 
 #[test]
 fn bytecode_immborrowfield() {
-    let mut module: CompiledModuleMut = generate_module_with_struct(false);
+    let mut module: CompiledModule = generate_module_with_struct(false);
     let struct_def_idx = StructDefinitionIndex((module.struct_defs.len() - 1) as u16);
     module.field_handles.push(FieldHandle {
         owner: struct_def_idx,
@@ -372,7 +369,7 @@ fn bytecode_immborrowfield() {
 #[test]
 #[should_panic]
 fn bytecode_immborrowfield_stack_has_no_reference() {
-    let mut module: CompiledModuleMut = generate_module_with_struct(false);
+    let mut module: CompiledModule = generate_module_with_struct(false);
     let struct_def_idx = StructDefinitionIndex((module.struct_defs.len() - 1) as u16);
     module.field_handles.push(FieldHandle {
         owner: struct_def_idx,
@@ -388,7 +385,7 @@ fn bytecode_immborrowfield_stack_has_no_reference() {
 #[test]
 #[should_panic]
 fn bytecode_immborrowfield_ref_is_mutable() {
-    let mut module: CompiledModuleMut = generate_module_with_struct(false);
+    let mut module: CompiledModule = generate_module_with_struct(false);
     let struct_def_idx = StructDefinitionIndex((module.struct_defs.len() - 1) as u16);
     module.field_handles.push(FieldHandle {
         owner: struct_def_idx,
@@ -408,7 +405,7 @@ fn bytecode_immborrowfield_ref_is_mutable() {
 
 #[test]
 fn bytecode_borrowglobal() {
-    let module: CompiledModuleMut = generate_module_with_struct(true);
+    let module = generate_module_with_struct(true);
     let mut state1 =
         AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     let struct_value = create_struct_value(&state1.module.module).0;
@@ -430,7 +427,7 @@ fn bytecode_borrowglobal() {
 #[test]
 #[should_panic]
 fn bytecode_borrowglobal_struct_is_not_resource() {
-    let module: CompiledModuleMut = generate_module_with_struct(false);
+    let module = generate_module_with_struct(false);
     let mut state1 =
         AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     state1.stack_push(AbstractValue::new_primitive(SignatureToken::Address));
@@ -443,7 +440,7 @@ fn bytecode_borrowglobal_struct_is_not_resource() {
 #[test]
 #[should_panic]
 fn bytecode_borrowglobal_no_address_on_stack() {
-    let module: CompiledModuleMut = generate_module_with_struct(true);
+    let module = generate_module_with_struct(true);
     let state1 =
         AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     common::run_instruction(

--- a/testsuite/diem-fuzzer/src/fuzz_targets/vm.rs
+++ b/testsuite/diem-fuzzer/src/fuzz_targets/vm.rs
@@ -3,7 +3,7 @@
 
 use crate::FuzzTargetImpl;
 use diem_proptest_helpers::ValueGenerator;
-use move_binary_format::file_format::{CompiledModule, CompiledModuleMut};
+use move_binary_format::file_format::CompiledModule;
 use proptest::prelude::*;
 
 #[derive(Clone, Debug, Default)]
@@ -15,7 +15,7 @@ impl FuzzTargetImpl for CompiledModuleTarget {
     }
 
     fn generate(&self, _idx: usize, gen: &mut ValueGenerator) -> Option<Vec<u8>> {
-        let value = gen.generate(any_with::<CompiledModuleMut>(16));
+        let value = gen.generate(any_with::<CompiledModule>(16));
         let mut out = vec![];
         value
             .serialize(&mut out)


### PR DESCRIPTION
`CompiledScript` and `CompiledModule` were meant to be bounds-checked analogues of `CompiledScriptMut` and `CompiledModuleMut`, but I've heard from some people on the team that they may have outlived their usefulness (and indeed the bounds checker has already been modified to operate on a non-`Mut` `Compiled{Script,Module}`).

This pull request removes the distinction.