### PR TITLE
[forge] init with cluster vault

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3219,6 +3219,7 @@ dependencies = [
  "diem-logger",
  "diem-retrier",
  "diem-sdk",
+ "diem-secure-storage",
  "diem-workspace-hack",
  "futures",
  "itertools 0.10.0",

--- a/docker/forge/Dockerfile
+++ b/docker/forge/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y libssl1.1 openssh-client wget && apt-ge
 RUN mkdir /diem
 COPY rust-toolchain /diem/rust-toolchain
 COPY scripts/dev_setup.sh /diem/scripts/dev_setup.sh
-RUN /diem/scripts/dev_setup.sh -b -p -i kubectl -i helm -i git -i unzip -i awscli
+RUN /diem/scripts/dev_setup.sh -b -p -i kubectl -i helm -i git -i unzip -i awscli -i vault
 ENV PATH "$PATH:/root/bin"
 
 RUN mkdir /etc/forge

--- a/testsuite/forge/Cargo.toml
+++ b/testsuite/forge/Cargo.toml
@@ -30,6 +30,7 @@ diem-config = { path = "../../config" }
 diem-workspace-hack = { path = "../../common/workspace-hack" }
 diem-genesis-tool = { path = "../../config/management/genesis" }
 diem-retrier = { path = "../../common/retrier" }
+diem-secure-storage = { path = "../../secure/storage" }
 base64 = "0.13.0"
 kube = "0.51.0"
 k8s-openapi = { version = "0.11.0", default-features = false, features = ["v1_15"] }

--- a/testsuite/forge/src/backend/k8s/mod.rs
+++ b/testsuite/forge/src/backend/k8s/mod.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{Factory, Swarm};
+use anyhow::{format_err, Error};
+use std::{env, fs::File, io::Read, path::PathBuf};
 use tokio::runtime::Runtime;
 
 mod node;
@@ -9,17 +11,55 @@ mod swarm;
 pub use node::K8sNode;
 pub use swarm::*;
 
+use diem_sdk::crypto::ed25519::ED25519_PRIVATE_KEY_LENGTH;
+use diem_secure_storage::{CryptoStorage, KVStorage, VaultStorage};
+
 pub struct K8sFactory {
-    root_key: String,
-    treasury_compliance_key: String,
+    root_key: [u8; ED25519_PRIVATE_KEY_LENGTH],
+    treasury_compliance_key: [u8; ED25519_PRIVATE_KEY_LENGTH],
 }
 
 impl K8sFactory {
-    pub fn new(root_key: String, treasury_compliance_key: String) -> Self {
-        Self {
+    pub fn new() -> std::result::Result<K8sFactory, Error> {
+        let vault_addr = env::var("VAULT_ADDR")
+            .map_err(|_| format_err!("Expected environment variable VAULT_ADDR"))?;
+        let vault_cacert = env::var("VAULT_CACERT")
+            .map_err(|_| format_err!("Expected environment variable VAULT_CACERT"))?;
+        let vault_token = env::var("VAULT_TOKEN")
+            .map_err(|_| format_err!("Expected environment variable VAULT_TOKEN"))?;
+
+        let vault_cacert_path = PathBuf::from(vault_cacert.clone());
+
+        let mut vault_cacert_file = File::open(vault_cacert_path)
+            .map_err(|_| format_err!("Failed to open VAULT_CACERT file at {}", &vault_cacert))?;
+        let mut vault_cacert_contents = String::new();
+        vault_cacert_file
+            .read_to_string(&mut vault_cacert_contents)
+            .map_err(|_| format_err!("Failed to read VAULT_CACERT file at {}", &vault_cacert))?;
+
+        let vault = VaultStorage::new(
+            vault_addr,
+            vault_token,
+            Some(vault_cacert_contents),
+            None,
+            false,
+            None,
+            None,
+        );
+        vault.available()?;
+        let root_key = vault
+            .export_private_key("diem__diem_root")
+            .unwrap()
+            .to_bytes();
+        let treasury_compliance_key = vault
+            .export_private_key("diem__treasury_compliance")
+            .unwrap()
+            .to_bytes();
+
+        Ok(Self {
             root_key,
             treasury_compliance_key,
-        }
+        })
     }
 }
 
@@ -27,10 +67,7 @@ impl Factory for K8sFactory {
     fn launch_swarm(&self, _node_num: usize) -> Box<dyn Swarm> {
         let rt = Runtime::new().unwrap();
         let swarm = rt
-            .block_on(K8sSwarm::new(
-                self.root_key.clone(),
-                self.treasury_compliance_key.clone(),
-            ))
+            .block_on(K8sSwarm::new(&self.root_key, &self.treasury_compliance_key))
             .unwrap();
         Box::new(swarm)
     }

--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -8,7 +8,7 @@ use crate::{
 use anyhow::format_err;
 use diem_logger::*;
 use diem_sdk::{
-    crypto::ed25519::{Ed25519PrivateKey, ED25519_PRIVATE_KEY_LENGTH},
+    crypto::ed25519::Ed25519PrivateKey,
     types::{
         chain_id::{ChainId, NamedChain},
         AccountKey, LocalAccount, PeerId,
@@ -40,7 +40,7 @@ pub struct K8sSwarm {
 }
 
 impl K8sSwarm {
-    pub async fn new(root_key: String, treasury_compliance_key: String) -> Result<Self> {
+    pub async fn new(root_key: &[u8], treasury_compliance_key: &[u8]) -> Result<Self> {
         Command::new(KUBECTL_BIN).arg("proxy").spawn()?;
         diem_retrier::retry_async(k8s_retry_strategy(), || {
             Box::pin(async move {
@@ -273,12 +273,10 @@ fn parse_node_id(s: &str) -> Result<usize> {
     Ok(idx)
 }
 
-fn load_root_key(root_key: &str) -> Ed25519PrivateKey {
-    let composite_key = base64::decode(root_key).unwrap();
-    Ed25519PrivateKey::try_from(composite_key.get(0..ED25519_PRIVATE_KEY_LENGTH).unwrap()).unwrap()
+fn load_root_key(root_key_bytes: &[u8]) -> Ed25519PrivateKey {
+    Ed25519PrivateKey::try_from(root_key_bytes).unwrap()
 }
 
-fn load_tc_key(tc_key: &str) -> Ed25519PrivateKey {
-    let composite_key = base64::decode(tc_key).unwrap();
-    Ed25519PrivateKey::try_from(composite_key.get(0..ED25519_PRIVATE_KEY_LENGTH).unwrap()).unwrap()
+fn load_tc_key(tc_key_bytes: &[u8]) -> Ed25519PrivateKey {
+    Ed25519PrivateKey::try_from(tc_key_bytes).unwrap()
 }

--- a/testsuite/forge/src/main.rs
+++ b/testsuite/forge/src/main.rs
@@ -34,11 +34,6 @@ struct Args {
         default_value = "60"
     )]
     duration: u64,
-    // TODO, need to remove these args once we can load from vault
-    #[structopt(long, default_value = "")]
-    pub root_key: String,
-    #[structopt(long, default_value = "")]
-    pub treasury_compliance_key: String,
 
     #[structopt(flatten)]
     options: Options,
@@ -54,11 +49,7 @@ fn main() -> Result<()> {
             &args.options,
         )
     } else {
-        forge_main(
-            k8s_test_suite(),
-            K8sFactory::new(args.root_key.clone(), args.treasury_compliance_key.clone()),
-            &args.options,
-        )
+        forge_main(k8s_test_suite(), K8sFactory::new().unwrap(), &args.options)
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Fetch root and TC keys from vault for each testnet within `forge` itself, rather than having to pass them in via arguments. This makes `forge` more portable (not relying on external tools or processes such as `fgi` to get the keys first), and also maintains a better test abstraction.

Also install `vault` in the forge docker image.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Build the image and run a a debug pod on my forge cluster. First, check that forge can use the keys fetched via the vault secure storage backend, programatically:

```
root@forge-debug-s4srv:/etc/forge# forge
running 4 tests
Local kube pod healthcheck passed
error: listen tcp 127.0.0.1:8001: bind: address already in use
test fund_account ... ok
test transfer_coins ... ok
test get_metadata ... ok
Will use 10 workers per endpoint with total 40 endpoint clients
Will create 15 accounts_per_client with total 600 accounts
Creating and minting faucet account
DD account current balances are 9223372022904725807, requested 600000000 coins
Completed minting seed accounts
Minting additional 600 accounts
Mint is done
starting emitting txns for 10 secs
Test Statistics: emit_transaction : 540 TPS, 1193 ms latency, 1350 ms p99 latency,no expired txns
test emit_transaction ... ok

test result: ok. 4 passed; 0 failed; 0 filtered out
```

Next, check that the existing method of passing in the keys via command line args still works. Here, we're getting the keys using the vault CLI tool, and then giving them to forge:

```
root@forge-debug-s4srv:/etc/forge# tc_key=$(vault kv get -format=json transit/export/signing-key/diem__treasury_compliance | jq -r '.data.keys."1"')
root@forge-debug-s4srv:/etc/forge# root_key=$(vault kv get -format=json transit/export/signing-key/diem__diem_root | jq -r '.data.keys."1"')
root@forge-debug-s4srv:/etc/forge# forge --root-key=$root_key --treasury-compliance-key=$tc_key

running 4 tests
Local kube pod healthcheck passed
error: listen tcp 127.0.0.1:8001: bind: address already in use
test fund_account ... ok
test transfer_coins ... ok
test get_metadata ... ok
Will use 10 workers per endpoint with total 40 endpoint clients
Will create 15 accounts_per_client with total 600 accounts
Creating and minting faucet account
DD account current balances are 9223372022304723807, requested 600000000 coins
Completed minting seed accounts
Minting additional 600 accounts
Mint is done
starting emitting txns for 10 secs
Test Statistics: emit_transaction : 540 TPS, 1150 ms latency, 1350 ms p99 latency,no expired txns
test emit_transaction ... ok

test result: ok. 4 passed; 0 failed; 0 filtered out
```
