### PR TITLE
[Move RW set tests] remove -v flag from smoke test

### DIFF
--- a/language/tools/move-cli/tests/testsuite/concretize_read_write_set_smoke/args.exp
+++ b/language/tools/move-cli/tests/testsuite/concretize_read_write_set_smoke/args.exp
@@ -4,8 +4,7 @@ Command `sandbox run storage/0x00000000000000000000000000000001/modules/AccountC
 Command `sandbox run  storage/0x00000000000000000000000000000001/modules/AccountCreationScripts.mv create_parent_vasp_account --mode diem --type-args 0x1::XDX::XDX --signers 0xB1E55ED --args 0 0xB x"00000000000000000000000000000000" b"VASP_B" true`:
 Command `sandbox run storage/0x00000000000000000000000000000001/modules/TreasuryComplianceScripts.mv tiered_mint --mode diem --type-args 0x1::XUS::XUS --signers 0xB1E55ED --args 0 0xDD 1000 0`:
 Command `sandbox run storage/0x00000000000000000000000000000001/modules/PaymentScripts.mv peer_to_peer_with_metadata --mode diem --type-args 0x1::XUS::XUS --signers 0xDD --args 0xA 700 x"" x""`:
-Command `experimental read-write-set storage/0x00000000000000000000000000000001/modules/PaymentScripts.mv peer_to_peer_with_metadata --mode diem --concretize --type-args 0x1::XUS::XUS --signers 0xA --args 0xB 500 x"" x"" -v`:
-Inferring read/write set for 50 module(s)
+Command `experimental read-write-set storage/0x00000000000000000000000000000001/modules/PaymentScripts.mv peer_to_peer_with_metadata --mode diem --concretize --type-args 0x1::XUS::XUS --signers 0xA --args 0xB 500 x"" x""`:
 0xa/0x1::AccountFreezing::FreezingBit: Read
 0xa/0x1::AccountFreezing::FreezingBit/is_frozen: Read
 0xa/0x1::VASP::ParentVASP: Read

--- a/language/tools/move-cli/tests/testsuite/concretize_read_write_set_smoke/args.txt
+++ b/language/tools/move-cli/tests/testsuite/concretize_read_write_set_smoke/args.txt
@@ -19,4 +19,4 @@ sandbox run storage/0x00000000000000000000000000000001/modules/TreasuryComplianc
 sandbox run storage/0x00000000000000000000000000000001/modules/PaymentScripts.mv peer_to_peer_with_metadata --mode diem --type-args 0x1::XUS::XUS --signers 0xDD --args 0xA 700 x"" x""
 
 # transfer 500 XUS from 0xA to 0xB
-experimental read-write-set storage/0x00000000000000000000000000000001/modules/PaymentScripts.mv peer_to_peer_with_metadata --mode diem --concretize --type-args 0x1::XUS::XUS --signers 0xA --args 0xB 500 x"" x"" -v
+experimental read-write-set storage/0x00000000000000000000000000000001/modules/PaymentScripts.mv peer_to_peer_with_metadata --mode diem --concretize --type-args 0x1::XUS::XUS --signers 0xA --args 0xB 500 x"" x""


### PR DESCRIPTION
This flag had the unintended effect of forcing devs to update the expected value of the smoke test each time a module is added to/removed from the Diem Framework.