### PR TITLE
Fix flakey test_subscription timeouts

### DIFF
--- a/json-rpc/src/stream_rpc/subscription_types.rs
+++ b/json-rpc/src/stream_rpc/subscription_types.rs
@@ -325,7 +325,7 @@ mod tests {
         // These should have no delay
         let expected =
             serde_json::json!({"jsonrpc": "2.0", "id": 1010101, "result":{"value": 0}}).to_string();
-        let next = timeout(10, receiver.recv(), "message 0")
+        let next = timeout(1_000, receiver.recv(), "message 0")
             .await
             .unwrap()
             .unwrap();
@@ -333,7 +333,7 @@ mod tests {
 
         let expected =
             serde_json::json!({"jsonrpc": "2.0", "id": 1010101, "result":{"value": 1}}).to_string();
-        let next = timeout(10, receiver.recv(), "message 1")
+        let next = timeout(1_000, receiver.recv(), "message 1")
             .await
             .unwrap()
             .unwrap();
@@ -343,7 +343,7 @@ mod tests {
         let start = Instant::now();
         let expected =
             serde_json::json!({"jsonrpc": "2.0", "id": 1010101, "result":{"value": 2}}).to_string();
-        let next = timeout(1_000, receiver.recv(), "message 2")
+        let next = timeout(3_000, receiver.recv(), "message 2")
             .await
             .unwrap()
             .unwrap();
@@ -354,7 +354,7 @@ mod tests {
         // This one should have no delay again, due to being reset by the previous message
         let expected =
             serde_json::json!({"jsonrpc": "2.0", "id": 1010101, "result":{"value": 3}}).to_string();
-        let next = timeout(10, receiver.recv(), "message 3")
+        let next = timeout(1_000, receiver.recv(), "message 3")
             .await
             .unwrap()
             .unwrap();


### PR DESCRIPTION
## Motivation
A timeout of 50ms may be too small here, and causing the test to be flakey. Raising this value should ensure this doesn't happen

Fixes #8670 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
yes

## Test Plan
this is the test