### PR TITLE
[move-cli] Include stdlib in `move compile` by default

### DIFF
--- a/language/tools/move-cli/tests/testsuite/compile_includes_stdlib/args.exp
+++ b/language/tools/move-cli/tests/testsuite/compile_includes_stdlib/args.exp
@@ -1,0 +1,18 @@
+Command `compile --check src/modules/UseSigner.move --mode bare -v`:
+Checking Move files...
+error[E03002]: unbound module
+  ┌─ src/modules/UseSigner.move:2:7
+  │
+2 │   use 0x1::Signer;
+  │       ^^^^^^^^^^^ Invalid 'use'. Unbound module: '0x1::Signer'
+
+error[E03002]: unbound module
+  ┌─ src/modules/UseSigner.move:5:5
+  │
+5 │     Signer::address_of(account)
+  │     ^^^^^^ Unbound module alias 'Signer'
+
+Command `compile --check src/modules/UseSigner.move -v`:
+Checking Move files...
+Command `compile src/modules/UseSigner.move -v`:
+Compiling Move files...

--- a/language/tools/move-cli/tests/testsuite/compile_includes_stdlib/args.txt
+++ b/language/tools/move-cli/tests/testsuite/compile_includes_stdlib/args.txt
@@ -1,0 +1,3 @@
+compile --check src/modules/UseSigner.move --mode bare -v
+compile --check src/modules/UseSigner.move -v
+compile src/modules/UseSigner.move -v

--- a/language/tools/move-cli/tests/testsuite/compile_includes_stdlib/src/modules/UseSigner.move
+++ b/language/tools/move-cli/tests/testsuite/compile_includes_stdlib/src/modules/UseSigner.move
@@ -1,0 +1,7 @@
+module 0x1::Example {
+  use 0x1::Signer;
+
+  public fun f(account: &signer): address {
+    Signer::address_of(account)
+  }
+}


### PR DESCRIPTION
This includes the Move stdlib as dependencies in the `move compile` command, and also updates things so this command respects the modes that are passed as well. This fixes #8673 

## Tests

Added a test from #8673  to make sure that compilation will fail with `--mode bare` and will compile with the default mode setting (stdlib). 