### PR TITLE
[language] Unite various command line utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,7 @@ dependencies = [
  "diem-workspace-hack",
  "heck",
  "log",
+ "move-command-line-common",
  "move-core-types",
  "move-model",
  "move-prover",
@@ -523,6 +524,7 @@ dependencies = [
  "itertools 0.10.0",
  "log",
  "move-binary-format",
+ "move-command-line-common",
  "move-core-types",
  "move-model",
  "num 0.4.0",
@@ -603,6 +605,7 @@ dependencies = [
  "itertools 0.10.0",
  "log",
  "move-binary-format",
+ "move-command-line-common",
  "move-core-types",
  "move-model",
  "move-prover-test-utils",
@@ -654,6 +657,7 @@ dependencies = [
  "bytecode-interpreter",
  "datatest-stable",
  "diem-workspace-hack",
+ "move-command-line-common",
  "move-prover-test-utils",
  "move-stdlib",
  "move-unit-test",
@@ -1060,6 +1064,7 @@ dependencies = [
  "diem-workspace-hack",
  "ir-to-bytecode",
  "move-binary-format",
+ "move-command-line-common",
  "move-core-types",
  "move-ir-types",
  "serde_json",
@@ -1730,6 +1735,7 @@ dependencies = [
  "errmapgen",
  "log",
  "move-binary-format",
+ "move-command-line-common",
  "move-core-types",
  "move-lang",
  "move-prover",
@@ -1757,6 +1763,7 @@ dependencies = [
  "diem-workspace-hack",
  "include_dir",
  "move-binary-format",
+ "move-command-line-common",
  "once_cell",
 ]
 
@@ -2852,6 +2859,7 @@ dependencies = [
  "colored",
  "diem-workspace-hack",
  "move-binary-format",
+ "move-command-line-common",
  "move-core-types",
  "move-coverage",
  "move-ir-types",
@@ -3013,6 +3021,7 @@ dependencies = [
  "datatest-stable",
  "diem-workspace-hack",
  "log",
+ "move-command-line-common",
  "move-core-types",
  "move-model",
  "move-prover",
@@ -3310,6 +3319,7 @@ dependencies = [
  "language-e2e-tests",
  "mirai-annotations",
  "move-binary-format",
+ "move-command-line-common",
  "move-core-types",
  "once_cell",
  "regex",
@@ -4283,6 +4293,7 @@ dependencies = [
  "goldenfile",
  "hex",
  "move-binary-format",
+ "move-command-line-common",
  "move-core-types",
  "move-vm-runtime",
  "move-vm-types",
@@ -4568,6 +4579,7 @@ dependencies = [
  "diem-workspace-hack",
  "disassembler",
  "move-binary-format",
+ "move-command-line-common",
  "move-ir-types",
  "regex",
  "structopt 0.3.21",
@@ -4589,6 +4601,7 @@ dependencies = [
  "include_dir",
  "move-binary-format",
  "move-bytecode-utils",
+ "move-command-line-common",
  "move-core-types",
  "move-coverage",
  "move-lang",
@@ -4599,6 +4612,16 @@ dependencies = [
  "read-write-set",
  "resource-viewer",
  "structopt 0.3.21",
+ "walkdir",
+]
+
+[[package]]
+name = "move-command-line-common"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "diem-workspace-hack",
+ "difference",
  "walkdir",
 ]
 
@@ -4634,6 +4657,7 @@ dependencies = [
  "colored",
  "diem-workspace-hack",
  "move-binary-format",
+ "move-command-line-common",
  "move-core-types",
  "move-ir-types",
  "once_cell",
@@ -4648,6 +4672,7 @@ version = "0.1.0"
 dependencies = [
  "bcs",
  "diem-workspace-hack",
+ "move-command-line-common",
  "move-core-types",
  "structopt 0.3.21",
 ]
@@ -4684,6 +4709,7 @@ dependencies = [
  "hex",
  "ir-to-bytecode",
  "move-binary-format",
+ "move-command-line-common",
  "move-core-types",
  "move-ir-types",
  "move-lang-test-utils",
@@ -4706,6 +4732,7 @@ dependencies = [
  "diem-types",
  "diem-workspace-hack",
  "functional-tests",
+ "move-command-line-common",
  "move-lang",
  "once_cell",
  "tempfile",
@@ -4728,6 +4755,7 @@ version = "0.1.0"
 dependencies = [
  "datatest-stable",
  "diem-workspace-hack",
+ "move-command-line-common",
  "walkdir",
 ]
 
@@ -4747,6 +4775,7 @@ dependencies = [
  "itertools 0.10.0",
  "log",
  "move-binary-format",
+ "move-command-line-common",
  "move-core-types",
  "move-ir-types",
  "move-lang",
@@ -4802,6 +4831,7 @@ dependencies = [
  "itertools 0.10.0",
  "log",
  "move-binary-format",
+ "move-command-line-common",
  "move-ir-types",
  "move-lang",
  "move-model",
@@ -4826,6 +4856,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "diem-workspace-hack",
+ "move-command-line-common",
  "prettydiff",
  "regex",
 ]
@@ -4841,6 +4872,7 @@ dependencies = [
  "file_diff",
  "log",
  "move-binary-format",
+ "move-command-line-common",
  "move-core-types",
  "move-prover",
  "move-unit-test",
@@ -4865,6 +4897,7 @@ dependencies = [
  "difference",
  "move-binary-format",
  "move-bytecode-utils",
+ "move-command-line-common",
  "move-core-types",
  "move-lang",
  "move-lang-test-utils",
@@ -7172,6 +7205,7 @@ dependencies = [
  "diem-writeset-generator",
  "generate-key",
  "hex",
+ "move-command-line-common",
  "move-stdlib",
  "num 0.4.0",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ members = [
     "language/ir-testsuite",
     "language/move-binary-format",
     "language/move-binary-format/serializer-tests",
+    "language/move-command-line-common",
     "language/move-core/types",
     "language/move-ir/types",
     "language/move-lang",

--- a/language/compiler/Cargo.toml
+++ b/language/compiler/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.38"
 bytecode-verifier = { path = "../bytecode-verifier" }
+move-command-line-common = { path = "../move-command-line-common" }
 ir-to-bytecode = { path = "ir-to-bytecode" }
 bytecode-source-map = { path = "bytecode-source-map" }
 diem-workspace-hack = { path = "../../common/workspace-hack" }

--- a/language/compiler/src/main.rs
+++ b/language/compiler/src/main.rs
@@ -8,6 +8,9 @@ use bytecode_verifier::{dependencies, verify_module, verify_script};
 use compiler::{util, Compiler};
 use ir_to_bytecode::parser::{parse_module, parse_script};
 use move_binary_format::{errors::VMError, file_format::CompiledModule};
+use move_command_line_common::files::{
+    MOVE_COMPILED_EXTENSION, MOVE_IR_EXTENSION, SOURCE_MAP_EXTENSION,
+};
 use move_core_types::account_address::AccountAddress;
 use std::{
     fs,
@@ -76,9 +79,9 @@ fn main() {
         }
     };
     let source_path = Path::new(&args.source_path);
-    let mvir_extension = "mvir";
-    let mv_extension = "mv";
-    let source_map_extension = "mvsm";
+    let mvir_extension = MOVE_IR_EXTENSION;
+    let mv_extension = MOVE_COMPILED_EXTENSION;
+    let source_map_extension = SOURCE_MAP_EXTENSION;
     let extension = source_path
         .extension()
         .expect("Missing file extension for input source file");

--- a/language/diem-framework/Cargo.toml
+++ b/language/diem-framework/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 bytecode-verifier = { path = "../bytecode-verifier" }
 abigen = { path = "../move-prover/abigen" }
 docgen = { path = "../move-prover/docgen" }
+move-command-line-common = { path = "../move-command-line-common" }
 errmapgen = { path = "../move-prover/errmapgen" }
 move-lang = { path = "../move-lang" }
 move-prover = { path = "../move-prover" }

--- a/language/diem-framework/releases/Cargo.toml
+++ b/language/diem-framework/releases/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 
 
 [dependencies]
+move-command-line-common = { path = "../../move-command-line-common" }
 diem-crypto = { path = "../../../crypto/crypto" }
 diem-types = { path = "../../../types" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }

--- a/language/diem-framework/src/lib.rs
+++ b/language/diem-framework/src/lib.rs
@@ -5,6 +5,7 @@
 
 use bytecode_verifier::{cyclic_dependencies, dependencies, verify_module};
 use move_binary_format::{access::ModuleAccess, file_format::CompiledModule};
+use move_command_line_common::files::MOVE_COMPILED_EXTENSION;
 use move_lang::{compiled_unit::CompiledUnit, Compiler};
 use once_cell::sync::Lazy;
 use sha2::{Digest, Sha256};
@@ -14,8 +15,6 @@ use std::{
     io::{Read, Write},
     path::{Path, PathBuf},
 };
-
-pub use move_stdlib::{COMPILED_EXTENSION, ERROR_DESC_EXTENSION, MOVE_EXTENSION};
 
 pub mod natives;
 pub mod release;
@@ -61,7 +60,7 @@ pub fn stdlib_bytecode_files() -> Vec<String> {
             for name in &names {
                 let suffix = "_".to_owned()
                     + Path::new(name)
-                        .with_extension(COMPILED_EXTENSION)
+                        .with_extension(MOVE_COMPILED_EXTENSION)
                         .file_name()
                         .unwrap()
                         .to_str()

--- a/language/diem-framework/src/release.rs
+++ b/language/diem-framework/src/release.rs
@@ -4,6 +4,7 @@
 use crate::{path_in_crate, save_binary};
 use log::LevelFilter;
 use move_binary_format::{compatibility::Compatibility, normalized::Module, CompiledModule};
+use move_command_line_common::files::{MOVE_COMPILED_EXTENSION, MOVE_ERROR_DESC_EXTENSION};
 use move_core_types::language_storage::ModuleId;
 use std::{
     collections::BTreeMap,
@@ -52,7 +53,7 @@ fn build_modules(output_path: impl AsRef<Path>) -> BTreeMap<String, CompiledModu
         let mut bytes = Vec::new();
         module.serialize(&mut bytes).unwrap();
         let mut module_path = Path::join(&output_path, name);
-        module_path.set_extension(move_stdlib::COMPILED_EXTENSION);
+        module_path.set_extension(MOVE_COMPILED_EXTENSION);
         save_binary(&module_path, &bytes);
     }
 
@@ -368,7 +369,7 @@ pub fn create_release(output_path: impl AsRef<Path>, options: &ReleaseOptions) {
         let mut err_exp_path = output_path
             .join("error_description")
             .join("error_description");
-        err_exp_path.set_extension("errmap");
+        err_exp_path.set_extension(MOVE_ERROR_DESC_EXTENSION);
         run_step(msg("Generating error explanations"), || {
             build_error_code_map(&err_exp_path)
         });

--- a/language/move-command-line-common/Cargo.toml
+++ b/language/move-command-line-common/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "move-command-line-common"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+description = "Move shared command line and file tools"
+repository = "https://github.com/diem/diem"
+homepage = "https://diem.com"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0.38"
+difference = "2.0.0"
+walkdir = "2.3.1"
+
+diem-workspace-hack = { path = "../../common/workspace-hack" }

--- a/language/move-command-line-common/src/env.rs
+++ b/language/move-command-line-common/src/env.rs
@@ -1,0 +1,11 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub fn read_env_var(v: &str) -> String {
+    std::env::var(v).unwrap_or_else(|_| String::new())
+}
+
+pub fn read_bool_env_var(v: &str) -> bool {
+    let val = read_env_var(v).to_lowercase();
+    val.parse::<bool>() == Ok(true) || val.parse::<usize>() == Ok(1)
+}

--- a/language/move-command-line-common/src/files.rs
+++ b/language/move-command-line-common/src/files.rs
@@ -1,0 +1,86 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::anyhow;
+use std::path::Path;
+
+/// Extension for Move source language files
+pub const MOVE_EXTENSION: &str = "move";
+/// Extension for Move IR files
+pub const MOVE_IR_EXTENSION: &str = "mvir";
+/// Extension for Move bytecode files
+pub const MOVE_COMPILED_EXTENSION: &str = "mv";
+/// Extension for Move source map files (mappings from source to bytecode)
+pub const SOURCE_MAP_EXTENSION: &str = "mvsm";
+/// Extension for error description map for compiled releases
+pub const MOVE_ERROR_DESC_EXTENSION: &str = "errmap";
+
+/// - For each directory in `paths`, it will return all files that satisfy the predicate
+/// - Any file explicitly passed in `paths`, it will include that file in the result, regardless
+///   of the file extension
+pub fn find_filenames<Predicate: FnMut(&Path) -> bool>(
+    paths: &[String],
+    mut is_file_desired: Predicate,
+) -> anyhow::Result<Vec<String>> {
+    let mut result = vec![];
+
+    for s in paths {
+        let path = Path::new(s);
+        if !path.exists() {
+            return Err(anyhow!("No such file or directory '{}'", s));
+        }
+        if path.is_file() && is_file_desired(path) {
+            result.push(path_to_string(path)?);
+            continue;
+        }
+        if !path.is_dir() {
+            continue;
+        }
+        for entry in walkdir::WalkDir::new(path)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            let entry_path = entry.path();
+            if !entry.file_type().is_file() || !is_file_desired(&entry_path) {
+                continue;
+            }
+
+            result.push(path_to_string(entry_path)?);
+        }
+    }
+    Ok(result)
+}
+
+/// - For each directory in `paths`, it will return all files with the `MOVE_EXTENSION` found
+///   recursively in that directory
+/// - If `keep_specified_files` any file explicitly passed in `paths`, will be added to the result
+///   Otherwise, they will be discarded
+pub fn find_move_filenames(
+    paths: &[String],
+    keep_specified_files: bool,
+) -> anyhow::Result<Vec<String>> {
+    if keep_specified_files {
+        let (mut files, other_paths): (Vec<String>, Vec<String>) =
+            paths.iter().cloned().partition(|s| Path::new(s).is_file());
+        files.extend(find_filenames(&other_paths, |path| {
+            extension_equals(path, MOVE_EXTENSION)
+        })?);
+        Ok(files)
+    } else {
+        find_filenames(paths, |path| extension_equals(path, MOVE_EXTENSION))
+    }
+}
+
+pub fn path_to_string(path: &Path) -> anyhow::Result<String> {
+    match path.to_str() {
+        Some(p) => Ok(p.to_string()),
+        None => Err(anyhow!("non-Unicode file name")),
+    }
+}
+
+pub fn extension_equals(path: &Path, target_ext: &str) -> bool {
+    match path.extension().and_then(|s| s.to_str()) {
+        Some(extension) => extension == target_ext,
+        None => false,
+    }
+}

--- a/language/move-command-line-common/src/lib.rs
+++ b/language/move-command-line-common/src/lib.rs
@@ -1,0 +1,8 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+pub mod env;
+pub mod files;
+pub mod testing;

--- a/language/move-command-line-common/src/testing.rs
+++ b/language/move-command-line-common/src/testing.rs
@@ -1,0 +1,50 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::env::read_bool_env_var;
+
+/// Extension for raw output files
+pub const OUT_EXT: &str = "out";
+/// Extension for expected output files
+pub const EXP_EXT: &str = "exp";
+
+/// If any of these env vars is set, the test harness should overwrite
+/// the existing .exp files with the output instead of checking
+/// them against the output.
+pub const UPDATE_BASELINE: &str = "UPDATE_BASELINE";
+pub const UPBL: &str = "UPBL";
+pub const UB: &str = "UB";
+
+pub fn read_env_update_baseline() -> bool {
+    read_bool_env_var(UPDATE_BASELINE) || read_bool_env_var(UPBL) || read_bool_env_var(UB)
+}
+
+pub fn format_diff(expected: impl AsRef<str>, actual: impl AsRef<str>) -> String {
+    use difference::*;
+
+    let changeset = Changeset::new(expected.as_ref(), actual.as_ref(), "\n");
+
+    let mut ret = String::new();
+
+    for seq in changeset.diffs {
+        match &seq {
+            Difference::Same(x) => {
+                ret.push_str(x);
+                ret.push('\n');
+            }
+            Difference::Add(x) => {
+                ret.push_str("\x1B[92m");
+                ret.push_str(x);
+                ret.push_str("\x1B[0m");
+                ret.push('\n');
+            }
+            Difference::Rem(x) => {
+                ret.push_str("\x1B[91m");
+                ret.push_str(x);
+                ret.push_str("\x1B[0m");
+                ret.push('\n');
+            }
+        }
+    }
+    ret
+}

--- a/language/move-lang/Cargo.toml
+++ b/language/move-lang/Cargo.toml
@@ -30,6 +30,7 @@ ir-to-bytecode = {path = "../compiler/ir-to-bytecode" }
 borrow-graph = { path = "../borrow-graph" }
 bytecode-source-map = { path = "../compiler/bytecode-source-map" }
 bcs = "0.1.2"
+move-command-line-common = { path = "../move-command-line-common" }
 
 [dev-dependencies]
 move-lang-test-utils = { path = "test-utils" }

--- a/language/move-lang/functional-tests/Cargo.toml
+++ b/language/move-lang/functional-tests/Cargo.toml
@@ -15,8 +15,9 @@ diem-workspace-hack = { path = "../../../common/workspace-hack" }
 anyhow = "1.0.38"
 tempfile = "3.2.0"
 once_cell = "1.7.2"
-
 datatest-stable = "0.1.1"
+
+move-command-line-common = { path = "../../move-command-line-common" }
 functional-tests = { path = "../../testing-infra/functional-tests" }
 diem-types = { path = "../../../types" }
 move-lang = { path = ".." }

--- a/language/move-lang/functional-tests/tests/functional_testsuite.rs
+++ b/language/move-lang/functional-tests/tests/functional_testsuite.rs
@@ -7,9 +7,10 @@ use functional_tests::{
     compiler::{Compiler, ScriptOrModule},
     testsuite,
 };
+use move_command_line_common::env::read_bool_env_var;
 use move_lang::{
-    self, command_line::read_bool_env_var, compiled_unit::CompiledUnit, errors,
-    Compiler as MoveCompiler, Flags, FullyCompiledProgram, PASS_COMPILATION,
+    self, compiled_unit::CompiledUnit, errors, Compiler as MoveCompiler, Flags,
+    FullyCompiledProgram, PASS_COMPILATION,
 };
 use once_cell::sync::Lazy;
 use std::{fmt, io::Write, path::Path};

--- a/language/move-lang/src/command_line/compiler.rs
+++ b/language/move-lang/src/command_line/compiler.rs
@@ -3,10 +3,7 @@
 
 use crate::{
     cfgir,
-    command_line::{
-        DEFAULT_OUTPUT_DIR, MOVE_COMPILED_EXTENSION, MOVE_COMPILED_INTERFACES_DIR, MOVE_EXTENSION,
-        SOURCE_MAP_EXTENSION,
-    },
+    command_line::{DEFAULT_OUTPUT_DIR, MOVE_COMPILED_INTERFACES_DIR},
     compiled_unit,
     compiled_unit::CompiledUnit,
     errors,
@@ -15,6 +12,9 @@ use crate::{
     parser::{comments::*, *},
     shared::{CompilationEnv, Flags},
     to_bytecode, typing, unit_test,
+};
+use move_command_line_common::files::{
+    extension_equals, find_filenames, MOVE_COMPILED_EXTENSION, MOVE_EXTENSION, SOURCE_MAP_EXTENSION,
 };
 use std::{
     fs,

--- a/language/move-lang/src/command_line/mod.rs
+++ b/language/move-lang/src/command_line/mod.rs
@@ -24,18 +24,4 @@ pub const TEST_SHORT: &str = "t";
 
 pub const COLOR_MODE_ENV_VAR: &str = "COLOR_MODE";
 
-pub const MOVE_EXTENSION: &str = "move";
-pub const MOVE_COMPILED_EXTENSION: &str = "mv";
 pub const MOVE_COMPILED_INTERFACES_DIR: &str = "mv_interfaces";
-pub const SOURCE_MAP_EXTENSION: &str = "mvsm";
-
-pub fn read_env_var(v: &str) -> String {
-    std::env::var(v)
-        .unwrap_or_else(|_| "".into())
-        .to_uppercase()
-}
-
-pub fn read_bool_env_var(v: &str) -> bool {
-    let val = read_env_var(v);
-    val == "1" || val == "TRUE"
-}

--- a/language/move-lang/src/errors/mod.rs
+++ b/language/move-lang/src/errors/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::command_line::{read_env_var, COLOR_MODE_ENV_VAR};
+use crate::command_line::COLOR_MODE_ENV_VAR;
 use codespan::{FileId, Files, Span};
 use codespan_reporting::{
     diagnostic::{Diagnostic, Label},
@@ -11,6 +11,7 @@ use codespan_reporting::{
         Config,
     },
 };
+use move_command_line_common::env::read_env_var;
 use move_ir_types::location::*;
 use std::{
     collections::{HashMap, HashSet},

--- a/language/move-lang/src/lib.rs
+++ b/language/move-lang/src/lib.rs
@@ -40,10 +40,7 @@ pub use command_line::{
         FullyCompiledProgram, SteppedCompiler, PASS_CFGIR, PASS_COMPILATION, PASS_EXPANSION,
         PASS_HLIR, PASS_NAMING, PASS_PARSER, PASS_TYPING,
     },
-    MOVE_COMPILED_EXTENSION, MOVE_COMPILED_INTERFACES_DIR, MOVE_EXTENSION,
+    MOVE_COMPILED_INTERFACES_DIR,
 };
-pub use parser::{
-    comments::{CommentMap, FileCommentMap, MatchedFileCommentMap},
-    extension_equals, find_filenames, find_move_filenames, path_to_string,
-};
+pub use parser::comments::{CommentMap, FileCommentMap, MatchedFileCommentMap};
 pub use shared::Flags;

--- a/language/move-lang/test-utils/Cargo.toml
+++ b/language/move-lang/test-utils/Cargo.toml
@@ -9,4 +9,5 @@ license = "Apache-2.0"
 [dependencies]
 datatest-stable = "0.1.1"
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
+move-command-line-common = { path = "../../move-command-line-common" }
 walkdir = "2.3.1"

--- a/language/move-lang/test-utils/src/lib.rs
+++ b/language/move-lang/test-utils/src/lib.rs
@@ -1,8 +1,8 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use move_command_line_common::files::{MOVE_EXTENSION, MOVE_IR_EXTENSION};
 use std::path::{Path, PathBuf};
-
 pub struct StringError(String);
 
 pub const SENDER: &str = "0x8675309";
@@ -14,8 +14,6 @@ pub const PATH_TO_IR_TESTS: &str = "../ir-testsuite/tests";
 
 pub const MIGRATION_SUB_DIR: &str = "translated_ir_tests";
 pub const TODO_EXTENSION: &str = "move_TODO";
-pub const MOVE_EXTENSION: &str = "move";
-pub const IR_EXTENSION: &str = "mvir";
 
 pub const DEBUG_MODULE_FILE_NAME: &str = "debug.move";
 
@@ -26,28 +24,6 @@ pub const COMPLETED_DIRECTORIES: &[&str; 5] = &[
     "move/signer",
     "move/operators",
 ];
-
-impl std::fmt::Display for StringError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", &self.0)
-    }
-}
-
-impl std::fmt::Debug for StringError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", &self.0)
-    }
-}
-
-impl std::error::Error for StringError {
-    fn description(&self) -> &str {
-        &self.0
-    }
-}
-
-pub fn error(s: String) -> datatest_stable::Result<()> {
-    Err(Box::new(StringError(s)))
-}
 
 //**************************************************************************************************
 // IR Test Translation
@@ -66,7 +42,7 @@ pub fn ir_tests() -> impl Iterator<Item = (String, String)> {
         .map(|_| 1)
         .sum();
     iterate_directory(Path::new(PATH_TO_IR_TESTS)).flat_map(move |path| {
-        if path.extension()?.to_str()? != IR_EXTENSION {
+        if path.extension()?.to_str()? != MOVE_IR_EXTENSION {
             return None;
         }
         let pathbuf = path.canonicalize().ok()?;

--- a/language/move-lang/tests/ir_test_coverage.rs
+++ b/language/move-lang/tests/ir_test_coverage.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use move_command_line_common::files::{MOVE_EXTENSION, MOVE_IR_EXTENSION};
 use move_lang_test_utils::*;
 use std::{collections::HashSet, path::Path};
 
@@ -54,7 +55,7 @@ fn test_ir_test_coverage() {
 
 fn translated_test_exists(subdir: &str, name_str: &str) -> bool {
     let mut stem = name_str.to_owned();
-    (0..=IR_EXTENSION.len()).for_each(|_| {
+    (0..=MOVE_IR_EXTENSION.len()).for_each(|_| {
         stem.pop().unwrap();
     });
     let stem_str = &stem;

--- a/language/move-model/Cargo.toml
+++ b/language/move-model/Cargo.toml
@@ -16,6 +16,7 @@ bytecode-source-map = { path = "../compiler/bytecode-source-map" }
 move-ir-types = { path = "../move-ir/types" }
 move-core-types = { path = "../move-core/types" }
 disassembler = { path = "../tools/disassembler" }
+move-command-line-common = { path = "../move-command-line-common" }
 
 # external dependencies
 codespan = "0.8.0"

--- a/language/move-model/tests/testsuite.rs
+++ b/language/move-model/tests/testsuite.rs
@@ -1,17 +1,15 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::Path;
-
-use codespan_reporting::term::termcolor::Buffer;
-
-use codespan_reporting::diagnostic::Severity;
+use codespan_reporting::{diagnostic::Severity, term::termcolor::Buffer};
 use move_binary_format::{
     access::ModuleAccess,
     file_format::{FunctionDefinitionIndex, StructDefinitionIndex},
 };
+use move_command_line_common::testing::EXP_EXT;
 use move_model::{run_bytecode_model_builder, run_model_builder};
 use move_prover_test_utils::baseline_test::verify_or_update_baseline;
+use std::path::Path;
 
 fn test_runner(path: &Path) -> datatest_stable::Result<()> {
     let targets = vec![path.to_str().unwrap().to_string()];
@@ -56,7 +54,7 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
 
         "All good, no errors!".to_string()
     };
-    let baseline_path = path.with_extension("exp");
+    let baseline_path = path.with_extension(EXP_EXT);
     verify_or_update_baseline(baseline_path.as_path(), &diags)?;
     Ok(())
 }

--- a/language/move-prover/Cargo.toml
+++ b/language/move-prover/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 [dependencies]
 # diem dependencies
 boogie-backend = { path = "boogie-backend" }
+move-command-line-common = { path = "../move-command-line-common" }
 move-binary-format = { path = "../move-binary-format" }
 move-lang = { path = "../move-lang" }
 move-model = { path = "../move-model" }

--- a/language/move-prover/abigen/Cargo.toml
+++ b/language/move-prover/abigen/Cargo.toml
@@ -12,6 +12,7 @@ move-model = { path = "../../move-model" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
 bytecode-verifier = { path = "../../bytecode-verifier" }
+move-command-line-common = { path = "../../move-command-line-common" }
 bcs = "0.1.2"
 
 # external dependencies

--- a/language/move-prover/abigen/src/abigen.rs
+++ b/language/move-prover/abigen/src/abigen.rs
@@ -7,6 +7,7 @@ use log::{debug, info, warn};
 use anyhow::bail;
 use bytecode_verifier::script_signature;
 use heck::SnakeCase;
+use move_command_line_common::files::MOVE_COMPILED_EXTENSION;
 use move_core_types::{
     abi::{ArgumentABI, ScriptABI, ScriptFunctionABI, TransactionScriptABI, TypeArgumentABI},
     identifier::IdentStr,
@@ -190,7 +191,7 @@ impl<'env> Abigen<'env> {
         let mut path = PathBuf::from(&self.options.compiled_script_directory);
         path.push(
             PathBuf::from(module_env.get_source_path())
-                .with_extension("mv")
+                .with_extension(MOVE_COMPILED_EXTENSION)
                 .file_name()
                 .expect("file name"),
         );

--- a/language/move-prover/boogie-backend/Cargo.toml
+++ b/language/move-prover/boogie-backend/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 [dependencies]
 async-trait = "0.1.42"
 bytecode = { path = "../bytecode" }
+move-command-line-common = { path = "../../move-command-line-common" }
 move-model = { path = "../../move-model" }
 move-binary-format = { path = "../../move-binary-format" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }

--- a/language/move-prover/boogie-backend/src/options.rs
+++ b/language/move-prover/boogie-backend/src/options.rs
@@ -3,6 +3,7 @@
 
 use anyhow::anyhow;
 use itertools::Itertools;
+use move_command_line_common::env::{read_bool_env_var, read_env_var};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::process::Command;
@@ -104,14 +105,13 @@ pub struct BoogieOptions {
 
 impl Default for BoogieOptions {
     fn default() -> Self {
-        let get_env = |s| std::env::var(s).unwrap_or_else(|_| String::new());
         Self {
             bench_repeat: 1,
-            boogie_exe: get_env("BOOGIE_EXE"),
+            boogie_exe: read_env_var("BOOGIE_EXE"),
             use_exp_boogie: false,
-            z3_exe: get_env("Z3_EXE"),
+            z3_exe: read_env_var("Z3_EXE"),
             use_cvc4: false,
-            cvc4_exe: get_env("CVC4_EXE"),
+            cvc4_exe: read_env_var("CVC4_EXE"),
             boogie_flags: vec![],
             debug_trace: false,
             use_array_theory: false,
@@ -152,7 +152,7 @@ impl BoogieOptions {
     pub fn get_boogie_command(&self, boogie_file: &str) -> Vec<String> {
         let mut result = if self.use_exp_boogie {
             // This should have a better ux...
-            vec![std::env::var("EXP_BOOGIE_EXE").unwrap_or_else(|_| String::new())]
+            vec![read_env_var("EXP_BOOGIE_EXE")]
         } else {
             vec![self.boogie_exe.clone()]
         };
@@ -223,7 +223,7 @@ impl BoogieOptions {
     pub fn adjust_timeout(&self, time: usize) -> usize {
         // If env var MVP_TEST_ON_CI is set, add 100% to the timeout for added
         // robustness against flakiness.
-        if std::env::var("MVP_TEST_ON_CI").unwrap_or_else(|_| "".into()) == "1" {
+        if read_bool_env_var("MVP_TEST_ON_CI") {
             usize::saturating_add(time, time)
         } else {
             time

--- a/language/move-prover/bytecode/Cargo.toml
+++ b/language/move-prover/bytecode/Cargo.toml
@@ -17,6 +17,7 @@ borrow-graph = { path = "../../borrow-graph" }
 ir-to-bytecode = { path = "../../compiler/ir-to-bytecode" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
+move-command-line-common = { path = "../../move-command-line-common" }
 
 codespan = "0.8.0"
 codespan-reporting = { version = "0.8.0", features = ["serde", "serialization"] }

--- a/language/move-prover/bytecode/tests/testsuite.rs
+++ b/language/move-prover/bytecode/tests/testsuite.rs
@@ -2,10 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::anyhow;
-use std::path::Path;
-
-use codespan_reporting::term::termcolor::Buffer;
-
 use bytecode::{
     borrow_analysis::BorrowAnalysisProcessor,
     clean_and_optimize::CleanAndOptimizeProcessor,
@@ -27,9 +23,11 @@ use bytecode::{
     usage_analysis::UsageProcessor,
     verification_analysis_v2::VerificationAnalysisProcessorV2,
 };
-use codespan_reporting::diagnostic::Severity;
+use codespan_reporting::{diagnostic::Severity, term::termcolor::Buffer};
+use move_command_line_common::testing::EXP_EXT;
 use move_model::{model::GlobalEnv, run_model_builder};
 use move_prover_test_utils::{baseline_test::verify_or_update_baseline, extract_test_directives};
+use std::path::Path;
 
 fn get_tested_transformation_pipeline(
     dir_name: &str,
@@ -224,7 +222,7 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
 
         text
     };
-    let baseline_path = path.with_extension("exp");
+    let baseline_path = path.with_extension(EXP_EXT);
     verify_or_update_baseline(baseline_path.as_path(), &out)?;
     Ok(())
 }

--- a/language/move-prover/errmapgen/Cargo.toml
+++ b/language/move-prover/errmapgen/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 
 [dependencies]
 # diem dependencies
+move-command-line-common = { path = "../../move-command-line-common" }
 move-model = { path = "../../move-model" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = { path = "../../move-core/types" }

--- a/language/move-prover/errmapgen/src/errmapgen.rs
+++ b/language/move-prover/errmapgen/src/errmapgen.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{bail, Result};
+use move_command_line_common::files::MOVE_ERROR_DESC_EXTENSION;
 use move_core_types::{
     account_address::AccountAddress,
     errmap::{ErrorDescription, ErrorMapping},
@@ -34,7 +35,7 @@ impl Default for ErrmapOptions {
                 AccountAddress::from_hex_literal("0x1").unwrap(),
                 Identifier::new("Errors").unwrap(),
             ),
-            output_file: "errmap".to_string(),
+            output_file: MOVE_ERROR_DESC_EXTENSION.to_string(),
         }
     }
 }

--- a/language/move-prover/interpreter-testsuite/Cargo.toml
+++ b/language/move-prover/interpreter-testsuite/Cargo.toml
@@ -11,6 +11,7 @@ diem-workspace-hack = { path = "../../../common/workspace-hack" }
 
 # diem dependencies
 bytecode-interpreter = { path = "../interpreter" }
+move-command-line-common = { path = "../../move-command-line-common" }
 move-prover-test-utils = { path = "../test-utils" }
 move-stdlib = { path = "../../move-stdlib" }
 move-unit-test = { path = "../../tools/move-unit-test" }

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check_testsuite.rs
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check_testsuite.rs
@@ -3,11 +3,10 @@
 
 use std::{env, path::Path};
 
-use move_prover_test_utils::{baseline_test::verify_or_update_baseline, read_bool_env_var};
+use move_command_line_common::{env::read_bool_env_var, testing::EXP_EXT};
+use move_prover_test_utils::baseline_test::verify_or_update_baseline;
 use move_stdlib::move_stdlib_files;
 use move_unit_test::UnitTestingConfig;
-
-const BASELINE_EXTENSION: &str = "exp";
 
 fn test_runner(path: &Path) -> datatest_stable::Result<()> {
     env::set_var("NO_COLOR", "1");
@@ -31,7 +30,7 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
     config.run_and_report_unit_tests(test_plan, &mut buffer)?;
     let output = String::from_utf8(buffer)?;
 
-    let baseline_path = path.with_extension(BASELINE_EXTENSION);
+    let baseline_path = path.with_extension(EXP_EXT);
     verify_or_update_baseline(&baseline_path, &output)?;
     Ok(())
 }

--- a/language/move-prover/test-utils/Cargo.toml
+++ b/language/move-prover/test-utils/Cargo.toml
@@ -11,3 +11,4 @@ prettydiff = "0.4.0"
 anyhow = "1.0.38"
 regex = "1.4.3"
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
+move-command-line-common = { path = "../../move-command-line-common" }

--- a/language/move-prover/test-utils/src/baseline_test.rs
+++ b/language/move-prover/test-utils/src/baseline_test.rs
@@ -3,8 +3,8 @@
 
 //! A module supporting baseline (golden) tests.
 
-use crate::read_bool_env_var;
 use anyhow::anyhow;
+use move_command_line_common::testing::read_env_update_baseline;
 use prettydiff::{basic::DiffOp, diff_lines};
 use regex::Regex;
 use std::{
@@ -15,7 +15,7 @@ use std::{
 
 /// Verifies or updates baseline file for the given generated text.
 pub fn verify_or_update_baseline(baseline_file_name: &Path, text: &str) -> anyhow::Result<()> {
-    let update_baseline = read_bool_env_var("UPBL");
+    let update_baseline = read_env_update_baseline();
 
     if update_baseline {
         if !text.is_empty() {

--- a/language/move-prover/test-utils/src/lib.rs
+++ b/language/move-prover/test-utils/src/lib.rs
@@ -12,18 +12,6 @@ pub mod baseline_test;
 pub const DEFAULT_SENDER: &str = "0x8675309";
 
 // =================================================================================================
-// Env vars
-
-pub fn read_env_var(v: &str) -> String {
-    std::env::var(v).unwrap_or_else(|_| "".into())
-}
-
-pub fn read_bool_env_var(v: &str) -> bool {
-    let val = read_env_var(v);
-    val == "1" || val == "true"
-}
-
-// =================================================================================================
 // Extract test annotations out of sources
 
 // Extracts lines out of some text file where each line starts with `start` which can be a regular

--- a/language/move-prover/tests/testsuite.rs
+++ b/language/move-prover/tests/testsuite.rs
@@ -7,10 +7,9 @@ use codespan_reporting::term::termcolor::Buffer;
 
 use anyhow::anyhow;
 use itertools::Itertools;
+use move_command_line_common::{env::read_env_var, testing::EXP_EXT};
 use move_prover::{cli::Options, run_move_prover};
-use move_prover_test_utils::{
-    baseline_test::verify_or_update_baseline, extract_test_directives, read_env_var,
-};
+use move_prover_test_utils::{baseline_test::verify_or_update_baseline, extract_test_directives};
 use tempfile::TempDir;
 
 use datatest_stable::Requirements;
@@ -222,7 +221,7 @@ fn get_flags_and_baseline(
                 Some(path.with_extension(if separate_baseline {
                     format!("{}_exp", feature.name)
                 } else {
-                    "exp".to_string()
+                    EXP_EXT.to_string()
                 })),
             )
         };

--- a/language/move-stdlib/Cargo.toml
+++ b/language/move-stdlib/Cargo.toml
@@ -14,6 +14,7 @@ publish = false
 [dependencies]
 errmapgen = { path = "../move-prover/errmapgen" }
 docgen = { path = "../move-prover/docgen" }
+move-command-line-common = { path = "../move-command-line-common" }
 move-prover = { path = "../move-prover" }
 diem-workspace-hack = { path = "../../common/workspace-hack" }
 move-vm-types = { path = "../move-vm/types" }

--- a/language/move-stdlib/src/lib.rs
+++ b/language/move-stdlib/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use log::LevelFilter;
+use move_command_line_common::files::{MOVE_COMPILED_EXTENSION, MOVE_EXTENSION};
 use std::path::PathBuf;
 
 #[cfg(test)]
@@ -9,10 +10,6 @@ mod tests;
 pub mod utils;
 
 pub mod natives;
-
-pub const MOVE_EXTENSION: &str = "move";
-pub const COMPILED_EXTENSION: &str = "mv";
-pub const ERROR_DESC_EXTENSION: &str = "errmap";
 
 const MODULES_DIR: &str = "modules";
 const NURSERY_DIR: &str = "nursery";
@@ -37,7 +34,7 @@ pub fn filter_move_bytecode_files(
     dir_iter: impl Iterator<Item = PathBuf>,
 ) -> impl Iterator<Item = PathBuf> {
     dir_iter.flat_map(|path| {
-        if path.extension()?.to_str()? == COMPILED_EXTENSION {
+        if path.extension()?.to_str()? == MOVE_COMPILED_EXTENSION {
             Some(path)
         } else {
             None

--- a/language/testing-infra/e2e-tests/Cargo.toml
+++ b/language/testing-infra/e2e-tests/Cargo.toml
@@ -34,4 +34,5 @@ diem-config = { path = "../../../config" }
 diem-framework-releases = { path = "../../diem-framework/releases" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 diem-transaction-builder = { path = "../../../sdk/transaction-builder" }
+move-command-line-common = { path = "../../move-command-line-common" }
 hex = "0.4.3"

--- a/language/testing-infra/e2e-tests/src/golden_outputs.rs
+++ b/language/testing-infra/e2e-tests/src/golden_outputs.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use goldenfile::Mint;
+use move_command_line_common::testing::EXP_EXT;
 use std::{cell::RefCell, fmt::Debug, fs::File, io::Write, path::PathBuf};
 
 pub const GOLDEN_DIR_PATH: &str = "goldens";
-pub const EXT_NAME: &str = "exp";
 
 pub(crate) struct GoldenOutputs {
     #[allow(dead_code)]
@@ -25,7 +25,7 @@ impl GoldenOutputs {
         let mut file_path = PathBuf::new();
         file_path.push(name);
         let file = RefCell::new(
-            mint.new_goldenfile(file_path.with_extension(EXT_NAME))
+            mint.new_goldenfile(file_path.with_extension(EXP_EXT))
                 .unwrap(),
         );
         Self { mint, file }

--- a/language/testing-infra/functional-tests/Cargo.toml
+++ b/language/testing-infra/functional-tests/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.38"
+move-command-line-common = { path = "../../move-command-line-common" }
 hex = "0.4.3"
 diem-state-view = { path = "../../../storage/state-view" }
 diem-types = { path = "../../../types" }

--- a/language/tools/disassembler/Cargo.toml
+++ b/language/tools/disassembler/Cargo.toml
@@ -12,6 +12,7 @@ colored = "2.0.0"
 
 bytecode-verifier = { path = "../../bytecode-verifier" }
 bytecode-source-map = { path = "../../compiler/bytecode-source-map" }
+move-command-line-common = { path = "../../move-command-line-common" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
 move-ir-types = { path = "../../move-ir/types" }

--- a/language/tools/disassembler/src/main.rs
+++ b/language/tools/disassembler/src/main.rs
@@ -12,6 +12,9 @@ use move_binary_format::{
     binary_views::BinaryIndexedView,
     file_format::{CompiledModule, CompiledScript},
 };
+use move_command_line_common::files::{
+    MOVE_COMPILED_EXTENSION, MOVE_EXTENSION, SOURCE_MAP_EXTENSION,
+};
 use move_coverage::coverage_map::CoverageMap;
 use move_ir_types::location::Spanned;
 use std::{fs, path::Path};
@@ -58,9 +61,9 @@ struct Args {
 fn main() {
     let args = Args::from_args();
 
-    let move_extension = "move";
-    let mv_bytecode_extension = "mv";
-    let source_map_extension = "mvsm";
+    let move_extension = MOVE_EXTENSION;
+    let mv_bytecode_extension = MOVE_COMPILED_EXTENSION;
+    let source_map_extension = SOURCE_MAP_EXTENSION;
 
     let source_path = Path::new(&args.bytecode_file_path);
     let extension = source_path

--- a/language/tools/move-bytecode-viewer/Cargo.toml
+++ b/language/tools/move-bytecode-viewer/Cargo.toml
@@ -14,6 +14,7 @@ termion = "1.5"
 tui = "0.14.0"
 
 codespan = { version = "0.8.0", features = ["serialization"] }
+move-command-line-common = { path = "../../move-command-line-common" }
 bytecode-source-map = { path = "../../compiler/bytecode-source-map" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-ir-types = { path = "../../move-ir/types" }

--- a/language/tools/move-bytecode-viewer/src/main.rs
+++ b/language/tools/move-bytecode-viewer/src/main.rs
@@ -4,12 +4,12 @@
 #![forbid(unsafe_code)]
 
 use bytecode_source_map::utils::{remap_owned_loc_to_loc, source_map_from_file, OwnedLoc};
+use move_binary_format::file_format::CompiledModule;
 use move_bytecode_viewer::{
     bytecode_viewer::BytecodeViewer, source_viewer::ModuleViewer,
     tui::tui_interface::start_tui_with_interface, viewer::Viewer,
 };
-
-use move_binary_format::file_format::CompiledModule;
+use move_command_line_common::files::SOURCE_MAP_EXTENSION;
 use std::{fs, path::Path};
 use structopt::StructOpt;
 
@@ -30,7 +30,7 @@ struct Args {
 
 pub fn main() {
     let args = Args::from_args();
-    let source_map_extension = "mvsm";
+    let source_map_extension = SOURCE_MAP_EXTENSION;
 
     let bytecode_bytes = fs::read(&args.module_binary_path).expect("Unable to read bytecode file");
     let compiled_module =

--- a/language/tools/move-cli/Cargo.toml
+++ b/language/tools/move-cli/Cargo.toml
@@ -20,6 +20,7 @@ bcs = "0.1.2"
 bytecode-verifier = { path = "../../bytecode-verifier" }
 
 disassembler = { path = "../disassembler" }
+move-command-line-common = { path = "../../move-command-line-common" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-bytecode-utils = { path = "../move-bytecode-utils" }
 move-coverage = { path = "../move-coverage" }

--- a/language/tools/move-cli/src/sandbox/utils/mod.rs
+++ b/language/tools/move-cli/src/sandbox/utils/mod.rs
@@ -10,6 +10,7 @@ use move_binary_format::{
     normalized,
 };
 use move_bytecode_utils::Modules;
+use move_command_line_common::files::MOVE_COMPILED_EXTENSION;
 use move_core_types::{
     account_address::AccountAddress,
     effects::{ChangeSet, Event},
@@ -19,7 +20,6 @@ use move_core_types::{
     transaction_argument::TransactionArgument,
     vm_status::{AbortLocation, StatusCode, VMStatus},
 };
-use move_lang::{self, MOVE_COMPILED_EXTENSION};
 use resource_viewer::{AnnotatedMoveStruct, MoveValueAnnotator};
 
 use move_vm_types::gas_schedule::GasStatus;

--- a/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
+++ b/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
@@ -9,6 +9,7 @@ use move_binary_format::{
     errors::*,
     file_format::{CompiledModule, CompiledScript, FunctionDefinitionIndex},
 };
+use move_command_line_common::files::MOVE_COMPILED_EXTENSION;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::Identifier,
@@ -16,7 +17,7 @@ use move_core_types::{
     parser,
     vm_status::StatusCode,
 };
-use move_lang::{MOVE_COMPILED_EXTENSION, MOVE_COMPILED_INTERFACES_DIR};
+use move_lang::MOVE_COMPILED_INTERFACES_DIR;
 use move_vm_runtime::data_cache::MoveStorage;
 use resource_viewer::{AnnotatedMoveStruct, AnnotatedMoveValue, MoveValueAnnotator};
 

--- a/language/tools/move-cli/src/sandbox/utils/package.rs
+++ b/language/tools/move-cli/src/sandbox/utils/package.rs
@@ -4,10 +4,10 @@
 use anyhow::{anyhow, Result};
 use include_dir::Dir;
 use move_binary_format::file_format::CompiledModule;
-use move_lang::{
-    compiled_unit::CompiledUnit, extension_equals, find_filenames, path_to_string, shared::Flags,
-    Compiler, MOVE_COMPILED_EXTENSION, MOVE_EXTENSION,
+use move_command_line_common::files::{
+    extension_equals, find_filenames, path_to_string, MOVE_COMPILED_EXTENSION, MOVE_EXTENSION,
 };
+use move_lang::{compiled_unit::CompiledUnit, shared::Flags, Compiler};
 use once_cell::sync::Lazy;
 use std::{
     collections::HashSet,

--- a/language/tools/move-coverage/Cargo.toml
+++ b/language/tools/move-coverage/Cargo.toml
@@ -19,6 +19,7 @@ codespan = { version = "0.8.0", features = ["serialization"] }
 colored = "2.0.0"
 
 bcs = "0.1.2"
+move-command-line-common = { path = "../../move-command-line-common" }
 move-core-types = { path = "../../move-core/types" }
 move-ir-types = { path = "../../move-ir/types" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }

--- a/language/tools/move-coverage/src/bin/source-coverage.rs
+++ b/language/tools/move-coverage/src/bin/source-coverage.rs
@@ -5,6 +5,7 @@
 
 use bytecode_source_map::utils::{remap_owned_loc_to_loc, source_map_from_file, OwnedLoc};
 use move_binary_format::file_format::CompiledModule;
+use move_command_line_common::files::SOURCE_MAP_EXTENSION;
 use move_coverage::{coverage_map::CoverageMap, source_coverage::SourceCoverageBuilder};
 use std::{
     fs,
@@ -39,7 +40,7 @@ struct Args {
 
 fn main() {
     let args = Args::from_args();
-    let source_map_extension = "mvsm";
+    let source_map_extension = SOURCE_MAP_EXTENSION;
     let coverage_map = if args.is_raw_trace_file {
         CoverageMap::from_trace_file(&args.input_trace_path)
     } else {

--- a/language/tools/move-explain/Cargo.toml
+++ b/language/tools/move-explain/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 structopt = "0.3.21"
+move-command-line-common = { path = "../../move-command-line-common" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
 bcs = "0.1.2"

--- a/language/tools/move-explain/src/main.rs
+++ b/language/tools/move-explain/src/main.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use move_command_line_common::files::MOVE_ERROR_DESC_EXTENSION;
 use move_core_types::{
     account_address::AccountAddress, errmap::ErrorMapping, identifier::Identifier,
     language_storage::ModuleId,
@@ -19,7 +20,7 @@ struct Args {
     #[structopt(long = "abort-code", short = "a")]
     abort_code: u64,
     /// Path to the error code mapping file
-    #[structopt(long = "errmap", short = "e")]
+    #[structopt(long = MOVE_ERROR_DESC_EXTENSION, short = "e")]
     errmap_path: String,
 }
 

--- a/language/tools/move-unit-test/Cargo.toml
+++ b/language/tools/move-unit-test/Cargo.toml
@@ -17,6 +17,7 @@ rayon = "1.5.0"
 
 regex = "1.1.9"
 
+move-command-line-common = { path = "../../move-command-line-common" }
 move-stdlib = { path = "../../move-stdlib", features = ["testing"] }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = { path = "../../move-core/types" }

--- a/language/tools/move-unit-test/tests/move_unit_test_testsuite.rs
+++ b/language/tools/move-unit-test/tests/move_unit_test_testsuite.rs
@@ -1,50 +1,16 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_lang::command_line::read_bool_env_var;
+use move_command_line_common::testing::{format_diff, read_env_update_baseline, EXP_EXT};
 use move_unit_test::{self, UnitTestingConfig};
 use std::{
     fs,
     path::{Path, PathBuf},
 };
 
-const EXP_EXT: &str = "exp";
 // We don't support statistics tests as that includes times which are variable and will make these
 // tests flaky.
 const TEST_MODIFIER_STRS: &[&str] = &["storage"];
-
-const UPDATE_BASELINE: &str = "UPDATE_BASELINE";
-const UPB: &str = "UPB";
-
-fn format_diff(expected: String, actual: String) -> String {
-    use difference::*;
-
-    let changeset = Changeset::new(&expected, &actual, "\n");
-
-    let mut ret = String::new();
-
-    for seq in changeset.diffs {
-        match &seq {
-            Difference::Same(x) => {
-                ret.push_str(x);
-                ret.push('\n');
-            }
-            Difference::Add(x) => {
-                ret.push_str("\x1B[92m");
-                ret.push_str(x);
-                ret.push_str("\x1B[0m");
-                ret.push('\n');
-            }
-            Difference::Rem(x) => {
-                ret.push_str("\x1B[91m");
-                ret.push_str(x);
-                ret.push_str("\x1B[0m");
-                ret.push('\n');
-            }
-        }
-    }
-    ret
-}
 
 pub fn modify(mut base_config: UnitTestingConfig, modifier_str: &str) -> Option<UnitTestingConfig> {
     // Add future test modifiers here
@@ -58,7 +24,7 @@ pub fn modify(mut base_config: UnitTestingConfig, modifier_str: &str) -> Option<
 fn run_test_with_modifiers(
     unit_test_config: UnitTestingConfig,
     path: &Path,
-) -> datatest_stable::Result<Vec<((Vec<u8>, bool), PathBuf)>> {
+) -> anyhow::Result<Vec<((Vec<u8>, bool), PathBuf)>> {
     let mut results = Vec::new();
 
     for modifier in TEST_MODIFIER_STRS.iter() {
@@ -70,10 +36,11 @@ fn run_test_with_modifiers(
             let buffer = Vec::new();
             let test_plan = test_config.build_test_plan();
             if test_plan.is_none() {
-                move_lang_test_utils::error(format!(
+                anyhow::bail!(
                     "No test plan constructed for {:?} with modifier {}",
-                    path, modifier
-                ))?;
+                    path,
+                    modifier
+                );
             }
 
             results.push((
@@ -87,7 +54,7 @@ fn run_test_with_modifiers(
     let buffer = Vec::new();
     let test_plan = unit_test_config.build_test_plan();
     if test_plan.is_none() {
-        move_lang_test_utils::error(format!("No test plan constructed for {:?}", path))?;
+        anyhow::bail!("No test plan constructed for {:?}", path);
     }
 
     results.push((
@@ -99,9 +66,9 @@ fn run_test_with_modifiers(
 }
 
 // Runs all tests under the test/test_sources directory.
-fn run_test(path: &Path) -> datatest_stable::Result<()> {
+fn run_test_impl(path: &Path) -> anyhow::Result<()> {
     std::env::set_var("NO_COLOR", "1");
-    let update_baseline = read_bool_env_var(UPDATE_BASELINE) || read_bool_env_var(UPB);
+    let update_baseline = read_env_update_baseline();
     let source_files = vec![path.to_str().unwrap().to_owned()];
     let unit_test_config = UnitTestingConfig {
         num_threads: 1,
@@ -127,21 +94,26 @@ fn run_test(path: &Path) -> datatest_stable::Result<()> {
             let expected = fs::read_to_string(&exp_path)?;
             let output = String::from_utf8(buffer)?;
             if expected != output {
-                return move_lang_test_utils::error(format!(
+                anyhow::bail!(
                     "Expected outputs differ for {:?}:\n{}",
                     exp_path,
                     format_diff(expected, output)
-                ));
+                );
             }
         } else {
-            return move_lang_test_utils::error(format!(
+            anyhow::bail!(
                 "No expected output found for {:?}.\
                     You probably want to rerun with `env UPDATE_BASELINE=1`",
                 path
-            ));
+            );
         }
     }
 
+    Ok(())
+}
+
+fn run_test(path: &Path) -> datatest_stable::Result<()> {
+    run_test_impl(path)?;
     Ok(())
 }
 

--- a/testsuite/smoke-test/Cargo.toml
+++ b/testsuite/smoke-test/Cargo.toml
@@ -30,6 +30,7 @@ diem-framework-releases = { path = "../../language/diem-framework/releases" }
 debug-interface = { path = "../../common/debug-interface" }
 generate-key = { path = "../../config/generate-key" }
 bcs = "0.1.2"
+move-move-command-line-common = { path = "../../language/move-command-line-common", package = "move-command-line-common" }
 move-stdlib = { path = "../../language/move-stdlib" }
 diem-config = { path = "../../config" }
 diem-crypto = { path = "../../crypto/crypto" }

--- a/testsuite/smoke-test/src/scripts_and_modules.rs
+++ b/testsuite/smoke-test/src/scripts_and_modules.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use diem_temppath::TempPath;
 use diem_types::account_address::AccountAddress;
+use move_move_command_line_common::files::MOVE_EXTENSION;
 use std::{
     fs, io,
     io::Write,
@@ -145,7 +146,7 @@ fn test_execute_custom_module_and_script() {
 }
 
 fn copy_file_with_sender_address(file_path: &Path, sender: AccountAddress) -> io::Result<PathBuf> {
-    let tmp_source_path = TempPath::new().as_ref().with_extension("move");
+    let tmp_source_path = TempPath::new().as_ref().with_extension(MOVE_EXTENSION);
     let mut tmp_source_file = std::fs::File::create(tmp_source_path.clone())?;
     let mut code = fs::read_to_string(file_path)?;
     code = code.replace("{{sender}}", &format!("0x{}", sender));


### PR DESCRIPTION
- Make a single crate for env vars, finding move files, file extensions, and test utilities

## Motivation

- I got tired of playing the guessing game when updating tests. Each test had its own abbreviation for "UPDATE_BASELINE"
- This new crate should unite the various APIs and serve as a good place for any further unifications

## Test Plan

- cargo x test
- Hard to test some of these since they are env variables, but the code was identical in most cases, just copy pasted 
