### PR TITLE
[move disassembler] print bytecode version

### DIFF
--- a/language/tools/disassembler/src/disassembler.rs
+++ b/language/tools/disassembler/src/disassembler.rs
@@ -1097,6 +1097,7 @@ impl<'a, Location: Clone + Eq> Disassembler<'a, Location> {
         let name_opt = self.source_mapper.source_map.module_name_opt.as_ref();
         let name =
             name_opt.map(|(addr, n)| format!("{}.{}", addr.short_str_lossless(), n.to_string()));
+        let version = format!("{}", self.source_mapper.bytecode.version());
         let header = match name {
             Some(s) => format!("module {}", s),
             None => "script".to_owned(),
@@ -1119,7 +1120,8 @@ impl<'a, Location: Clone + Eq> Disassembler<'a, Location> {
             .collect::<Result<Vec<String>>>()?;
 
         Ok(format!(
-            "{header} {{\n{struct_defs}\n\n{function_defs}\n}}",
+            "// Move bytecode v{version}\n{header} {{\n{struct_defs}\n\n{function_defs}\n}}",
+            version = version,
             header = header,
             struct_defs = &struct_defs.join("\n"),
             function_defs = &function_defs.join("\n")

--- a/language/tools/move-cli/tests/testsuite/module_publish_view/args.exp
+++ b/language/tools/move-cli/tests/testsuite/module_publish_view/args.exp
@@ -4,6 +4,7 @@ Found and compiled 1 modules
 Publishing a new module 00000000000000000000000000000042::Module (wrote 120 bytes)
 Wrote 120 bytes of module ID's and code
 Command `sandbox view storage/0x00000000000000000000000000000042/modules/Module.mv`:
+// Move bytecode v3
 module 42.Module {
 struct S {
 	i: u64

--- a/language/tools/move-cli/tests/testsuite/republish/args.exp
+++ b/language/tools/move-cli/tests/testsuite/republish/args.exp
@@ -5,12 +5,14 @@ Publishing a new module 00000000000000000000000000000042::M (wrote 56 bytes)
 Publishing a new module 00000000000000000000000000000043::N (wrote 56 bytes)
 Wrote 112 bytes of module ID's and code
 Command `sandbox view storage/0x00000000000000000000000000000042/modules/M.mv`:
+// Move bytecode v3
 module 42.M {
 
 
 
 }
 Command `sandbox view storage/0x00000000000000000000000000000043/modules/N.mv`:
+// Move bytecode v3
 module 43.N {
 
 
@@ -23,12 +25,14 @@ Updating an existing module 00000000000000000000000000000042::M (wrote 56 bytes)
 Updating an existing module 00000000000000000000000000000043::N (wrote 56 bytes)
 Wrote 112 bytes of module ID's and code
 Command `sandbox view storage/0x00000000000000000000000000000042/modules/M.mv`:
+// Move bytecode v3
 module 42.M {
 
 
 
 }
 Command `sandbox view storage/0x00000000000000000000000000000043/modules/N.mv`:
+// Move bytecode v3
 module 43.N {
 
 


### PR DESCRIPTION
I would have found this information useful while debugging an issue with a module binary the other day--wasn't sure whether it was a v2 or v3 module.