### PR TITLE
[move-lang][move-cli] Improve named address support for interface files and CLI sandbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4611,6 +4611,8 @@ dependencies = [
  "once_cell",
  "read-write-set",
  "resource-viewer",
+ "serde",
+ "serde_yaml",
  "structopt 0.3.21",
  "walkdir",
 ]

--- a/language/move-lang/src/command_line/mod.rs
+++ b/language/move-lang/src/command_line/mod.rs
@@ -25,3 +25,5 @@ pub const TEST_SHORT: &str = "t";
 pub const COLOR_MODE_ENV_VAR: &str = "COLOR_MODE";
 
 pub const MOVE_COMPILED_INTERFACES_DIR: &str = "mv_interfaces";
+
+pub const COMPILED_NAMED_ADDRESS_MAPPING: &str = "compiled-module-address-name";

--- a/language/move-lang/src/compiled_unit.rs
+++ b/language/move-lang/src/compiled_unit.rs
@@ -10,6 +10,10 @@ use crate::{
 };
 use bytecode_source_map::source_map::SourceMap;
 use move_binary_format::file_format as F;
+use move_core_types::{
+    account_address::AccountAddress, identifier::Identifier as MoveCoreIdentifier,
+    language_storage::ModuleId,
+};
 use move_ir_types::location::*;
 use std::collections::BTreeMap;
 
@@ -90,6 +94,20 @@ impl CompiledModuleIdent {
             Some(n) => Address::Named(n),
         };
         sp(loc, ModuleIdent_::new(address, module_name))
+    }
+
+    pub fn into_module_id(self) -> (Option<Name>, ModuleId) {
+        let Self {
+            loc: _,
+            address_name,
+            address_bytes,
+            module_name,
+        } = self;
+        let id = ModuleId::new(
+            AccountAddress::new(address_bytes.into_bytes()),
+            MoveCoreIdentifier::new(module_name.0.value).unwrap(),
+        );
+        (address_name, id)
     }
 }
 

--- a/language/move-lang/src/interface_generator.rs
+++ b/language/move-lang/src/interface_generator.rs
@@ -29,7 +29,10 @@ macro_rules! push {
 /// Generate the text for the "interface" file of a compiled module. This "interface" is the
 /// publically visible contents of the CompiledModule, represented in source language syntax
 /// Additionally, it returns the module id (address+name) of the module that was deserialized
-pub fn write_file_to_string(compiled_module_file_input_path: &str) -> Result<(ModuleId, String)> {
+pub fn write_file_to_string(
+    named_address_mapping: &BTreeMap<ModuleId, String>,
+    compiled_module_file_input_path: &str,
+) -> Result<(ModuleId, String)> {
     let file_contents = fs::read(compiled_module_file_input_path)?;
     let module = CompiledModule::deserialize(&file_contents).map_err(|e| {
         anyhow!(
@@ -38,21 +41,33 @@ pub fn write_file_to_string(compiled_module_file_input_path: &str) -> Result<(Mo
             e
         )
     })?;
-    write_module_to_string(&module)
+    write_module_to_string(named_address_mapping, &module)
 }
 
-pub fn write_module_to_string(module: &CompiledModule) -> Result<(ModuleId, String)> {
+pub fn write_module_to_string(
+    named_address_mapping: &BTreeMap<ModuleId, String>,
+    module: &CompiledModule,
+) -> Result<(ModuleId, String)> {
     let mut out = String::new();
 
     let id = module.self_id();
+    if let Some(addr_name) = named_address_mapping.get(&id) {
+        push_line!(
+            out,
+            format!(
+                "address {} = {};",
+                addr_name,
+                AddressBytes::new(id.address().to_u8())
+            )
+        );
+    }
     push_line!(
         out,
-        format!("address {} {{", AddressBytes::new(id.address().to_u8()),)
+        format!("module {} {{", write_module_id(named_address_mapping, &id))
     );
-    push_line!(out, format!("module {} {{", id.name()));
     push_line!(out, "");
 
-    let mut context = Context::new(&module);
+    let mut context = Context::new(module);
     let mut members = vec![];
 
     for fdecl in module.friend_decls() {
@@ -90,26 +105,19 @@ pub fn write_module_to_string(module: &CompiledModule) -> Result<(ModuleId, Stri
 
     let has_uses = !context.uses.is_empty();
     for (module_id, alias) in context.uses {
-        if module_id.name().as_str() == alias {
-            push_line!(
-                out,
-                format!(
-                    "    use {}::{};",
-                    AddressBytes::new(module_id.address().to_u8()),
-                    module_id.name()
-                )
-            );
+        let use_ = if module_id.name().as_str() == alias {
+            format!(
+                "    use {};",
+                write_module_id(named_address_mapping, &module_id),
+            )
         } else {
-            push_line!(
-                out,
-                format!(
-                    "    use {}::{} as {};",
-                    AddressBytes::new(module_id.address().to_u8()),
-                    module_id.name(),
-                    alias
-                )
-            );
-        }
+            format!(
+                "    use {} as {};",
+                write_module_id(named_address_mapping, &module_id),
+                alias
+            )
+        };
+        push_line!(out, use_);
     }
     if has_uses {
         push_line!(out, "");
@@ -118,7 +126,6 @@ pub fn write_module_to_string(module: &CompiledModule) -> Result<(ModuleId, Stri
     if !members.is_empty() {
         push_line!(out, members.join("\n"));
     }
-    push_line!(out, "}");
     push_line!(out, "}");
     Ok((id, out))
 }
@@ -137,18 +144,42 @@ impl<'a> Context<'a> {
             counts: BTreeMap::new(),
         }
     }
+
+    fn module_alias(&mut self, module_id: ModuleId) -> &String {
+        let module_name = module_id.name().to_owned().into_string();
+        let counts = &mut self.counts;
+        self.uses.entry(module_id).or_insert_with(|| {
+            let count = *counts
+                .entry(module_name.clone())
+                .and_modify(|c| *c += 1)
+                .or_insert(0);
+            if count == 0 {
+                module_name
+            } else {
+                format!("{}_{}", module_name, count)
+            }
+        })
+    }
 }
 
 const DISCLAIMER: &str =
     "// NOTE: Functions are 'native' for simplicity. They may or may not be native in actuality.";
 
+fn write_module_id(named_address_mapping: &BTreeMap<ModuleId, String>, id: &ModuleId) -> String {
+    format!(
+        "{}::{}",
+        named_address_mapping
+            .get(id)
+            .cloned()
+            .unwrap_or_else(|| format!("{}", AddressBytes::new(id.address().to_u8()))),
+        id.name(),
+    )
+}
+
 fn write_friend_decl(ctx: &mut Context, fdecl: &ModuleHandle) -> String {
     format!(
-        "    friend {}::{};",
-        ctx.module
-            .address_identifier_at(fdecl.address)
-            .short_str_lossless(),
-        ctx.module.identifier_at(fdecl.name),
+        "    friend {};",
+        ctx.module_alias(ctx.module.module_id_for_handle(fdecl))
     )
 }
 
@@ -345,20 +376,8 @@ fn write_struct_handle_type(ctx: &mut Context, idx: StructHandleIndex) -> String
     let struct_handle = ctx.module.struct_handle_at(idx);
     let struct_module_handle = ctx.module.module_handle_at(struct_handle.module);
     let struct_module_id = ctx.module.module_id_for_handle(struct_module_handle);
-    let struct_module_name = struct_module_id.name().to_string();
+    let module_alias = ctx.module_alias(struct_module_id).clone();
 
-    let counts = &mut ctx.counts;
-    let module_alias = ctx.uses.entry(struct_module_id).or_insert_with(|| {
-        let count = *counts
-            .entry(struct_module_name.clone())
-            .and_modify(|c| *c += 1)
-            .or_insert(0);
-        if count == 0 {
-            struct_module_name
-        } else {
-            format!("{}_{}", struct_module_name, count)
-        }
-    });
     format!(
         "{}::{}",
         module_alias,

--- a/language/tools/move-cli/Cargo.toml
+++ b/language/tools/move-cli/Cargo.toml
@@ -14,7 +14,10 @@ anyhow = "1.0.38"
 difference = "2.0.0"
 include_dir = { version = "0.6.0", features = ["search"] }
 once_cell = "1.7.2"
+serde = { version = "1.0.124", default-features = false }
+serde_yaml = "0.8.17"
 structopt = "0.3.21"
+walkdir = "2.3.1"
 
 bcs = "0.1.2"
 bytecode-verifier = { path = "../../bytecode-verifier" }
@@ -32,7 +35,6 @@ move-vm-runtime = { path = "../../move-vm/runtime" }
 read-write-set = { path = "../read-write-set" }
 resource-viewer = { path = "../resource-viewer" }
 move-binary-format = { path = "../../move-binary-format" }
-walkdir = "2.3.1"
 
 [dev-dependencies]
 datatest-stable = "0.1.1"

--- a/language/tools/move-cli/src/sandbox/commands/publish.rs
+++ b/language/tools/move-cli/src/sandbox/commands/publish.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeMap;
+
 use crate::{
     sandbox::utils::{
         explain_publish_changeset, explain_publish_error, get_gas_status,
@@ -49,7 +51,7 @@ pub fn publish(
                     )
                 }
             }
-            CompiledUnit::Module { module, .. } => modules.push(module),
+            CompiledUnit::Module { module, ident, .. } => modules.push((ident, module)),
         }
     }
 
@@ -60,12 +62,17 @@ pub fn publish(
         let mut session = vm.new_session(state);
 
         let mut has_error = false;
-        for module in &modules {
+        let mut id_to_ident = BTreeMap::new();
+        for (ident, module) in &modules {
             let mut module_bytes = vec![];
             module.serialize(&mut module_bytes)?;
 
             let id = module.self_id();
             let sender = *id.address();
+            id_to_ident.insert(
+                id.clone(),
+                ident.address_name.as_ref().map(|n| n.value.clone()),
+            );
 
             let res = session.publish_module(module_bytes, sender, &mut gas_status);
             if let Err(err) = res {
@@ -83,7 +90,11 @@ pub fn publish(
             }
             let modules: Vec<_> = changeset
                 .into_modules()
-                .map(|(module_id, blob_opt)| (module_id, blob_opt.expect("must be non-deletion")))
+                .map(|(module_id, blob_opt)| {
+                    let addr_name = id_to_ident[&module_id].clone();
+                    let ident = (module_id, addr_name);
+                    (ident, blob_opt.expect("must be non-deletion"))
+                })
                 .collect();
             state.save_modules(&modules)?;
         }
@@ -92,10 +103,12 @@ pub fn publish(
         // backward incompatible changes, as as result, if this flag is set, we skip the VM process
         // and force the CLI to override the on-disk state directly
         let mut serialized_modules = vec![];
-        for module in modules {
+        for (ident, module) in modules {
+            let (address_name_opt, id) = ident.into_module_id();
+            let address_name_opt = address_name_opt.map(|n| n.value);
             let mut module_bytes = vec![];
             module.serialize(&mut module_bytes)?;
-            serialized_modules.push((module.self_id(), module_bytes));
+            serialized_modules.push(((id, address_name_opt), module_bytes));
         }
         state.save_modules(&serialized_modules)?;
     }

--- a/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
+++ b/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
@@ -23,6 +23,7 @@ use resource_viewer::{AnnotatedMoveStruct, AnnotatedMoveValue, MoveValueAnnotato
 
 use anyhow::{anyhow, bail, Result};
 use std::{
+    collections::BTreeMap,
     convert::{TryFrom, TryInto},
     fs,
     path::{Path, PathBuf},
@@ -336,6 +337,7 @@ impl OnDiskStateView {
                     .into_string()
                     .unwrap(),
             ),
+            &BTreeMap::new(),
             false,
         )?;
         Ok(())

--- a/language/tools/move-cli/tests/testsuite/republish/args.exp
+++ b/language/tools/move-cli/tests/testsuite/republish/args.exp
@@ -37,10 +37,10 @@ module 43.N {
 Command `sandbox publish -v --no-republish`:
 Compiling Move modules...
 error[E02001]: duplicate declaration, item, or annotation
-  ┌─ build/mv_interfaces/00000000000000000000000000000042/M.move:2:8
+  ┌─ build/mv_interfaces/00000000000000000000000000000042/M.move:1:14
   │
-2 │ module M {
-  │        ^ Duplicate definition for module '0x42::M'
+1 │ module 0x42::M {
+  │              ^ Duplicate definition for module '0x42::M'
   │
   ┌─ src/M.move:2:8
   │
@@ -48,10 +48,10 @@ error[E02001]: duplicate declaration, item, or annotation
   │        - Module previously defined here
 
 error[E02001]: duplicate declaration, item, or annotation
-  ┌─ build/mv_interfaces/00000000000000000000000000000043/N.move:2:8
+  ┌─ build/mv_interfaces/00000000000000000000000000000043/N.move:1:14
   │
-2 │ module N {
-  │        ^ Duplicate definition for module '0x43::N'
+1 │ module 0x43::N {
+  │              ^ Duplicate definition for module '0x43::N'
   │
   ┌─ src/N.move:2:8
   │
@@ -61,10 +61,10 @@ error[E02001]: duplicate declaration, item, or annotation
 Command `sandbox publish -v --no-republish src/M.move`:
 Compiling Move modules...
 error[E02001]: duplicate declaration, item, or annotation
-  ┌─ build/mv_interfaces/00000000000000000000000000000042/M.move:2:8
+  ┌─ build/mv_interfaces/00000000000000000000000000000042/M.move:1:14
   │
-2 │ module M {
-  │        ^ Duplicate definition for module '0x42::M'
+1 │ module 0x42::M {
+  │              ^ Duplicate definition for module '0x42::M'
   │
   ┌─ src/M.move:2:8
   │

--- a/language/tools/move-cli/tests/testsuite/use_named_address/args.exp
+++ b/language/tools/move-cli/tests/testsuite/use_named_address/args.exp
@@ -1,0 +1,23 @@
+Command `sandbox publish src/modules/M_no_named.move`:
+Command `sandbox publish src/modules/N.move`:
+error[E03001]: unbound address
+  ┌─ src/modules/N.move:2:8
+  │
+2 │ module A::N {
+  │        ^ Unbound address 'A'. Try declaring it with 'address A;'
+
+error[E03001]: unbound address
+  ┌─ src/modules/N.move:4:9
+  │
+4 │         A::M::useless()
+  │         ^ Unbound address 'A'
+
+error[E03002]: unbound module
+  ┌─ src/modules/N.move:4:9
+  │
+4 │         A::M::useless()
+  │         ^^^^ Unbound module 'A::M'
+
+Command `sandbox clean`:
+Command `sandbox publish src/modules/M.move`:
+Command `sandbox publish src/modules/N.move`:

--- a/language/tools/move-cli/tests/testsuite/use_named_address/args.txt
+++ b/language/tools/move-cli/tests/testsuite/use_named_address/args.txt
@@ -1,0 +1,5 @@
+sandbox publish src/modules/M_no_named.move
+sandbox publish src/modules/N.move
+sandbox clean
+sandbox publish src/modules/M.move
+sandbox publish src/modules/N.move

--- a/language/tools/move-cli/tests/testsuite/use_named_address/src/modules/M.move
+++ b/language/tools/move-cli/tests/testsuite/use_named_address/src/modules/M.move
@@ -1,0 +1,5 @@
+address A = 0x42;
+module A::M {
+    public fun useless() {
+    }
+}

--- a/language/tools/move-cli/tests/testsuite/use_named_address/src/modules/M_no_named.move
+++ b/language/tools/move-cli/tests/testsuite/use_named_address/src/modules/M_no_named.move
@@ -1,0 +1,4 @@
+module 0x42::M {
+    public fun useless() {
+    }
+}

--- a/language/tools/move-cli/tests/testsuite/use_named_address/src/modules/N.move
+++ b/language/tools/move-cli/tests/testsuite/use_named_address/src/modules/N.move
@@ -1,0 +1,6 @@
+
+module A::N {
+    public fun useless() {
+        A::M::useless()
+    }
+}


### PR DESCRIPTION
- Update interface files to support named addresses
  -  The compiler now has an extra arg to tell it the named address for a given CompiledModule/ModuleId
  - That named address will be declared and used in that interface file
- Update CLI sandbox to support named addresses (mostly)
  - In addition to the interface file, I added a map from ModuleId to Named address and saved the bcs bytes of the map to a metadata file
  - This approach does not work for the "package"

## Motivation

- Working towards unblocking #8394
- I am a bit unsure of my approach for the CLI work, as it might not jive well with @tzakian's package work

## Test Plan

- added a test
