### PR TITLE
[move-lang] Implement phantom parameters

### DIFF
--- a/language/move-lang/src/errors/diagnostic_codes.rs
+++ b/language/move-lang/src/errors/diagnostic_codes.rs
@@ -125,6 +125,7 @@ codes!(
         InvalidFriendDeclaration:
             { msg: "invalid 'friend' declaration", severity: NonblockingError },
         InvalidAcquiresItem: { msg: "invalid 'acquires' item", severity: NonblockingError },
+        InvalidPhantomUse: { msg: "invalid phantom type parameter usage", severity: NonblockingError },
     ],
     // errors name resolution, mostly expansion/translate and naming/translate
     NameResolution: [

--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -129,11 +129,18 @@ pub enum Neighbor {
 pub type Fields<T> = UniqueMap<Field, (usize, T)>;
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct StructTypeParameter {
+    pub is_phantom: bool,
+    pub name: Name,
+    pub constraints: AbilitySet,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct StructDefinition {
     pub attributes: Vec<Attribute>,
     pub loc: Loc,
     pub abilities: AbilitySet,
-    pub type_parameters: Vec<(Name, AbilitySet)>,
+    pub type_parameters: Vec<StructTypeParameter>,
     pub fields: StructFields,
 }
 
@@ -1161,6 +1168,16 @@ impl AstDebug for Vec<(Name, AbilitySet)> {
     }
 }
 
+impl AstDebug for Vec<StructTypeParameter> {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        if !self.is_empty() {
+            w.write("<");
+            w.comma(self, |w, tp| tp.ast_debug(w));
+            w.write(">")
+        }
+    }
+}
+
 pub fn ability_constraints_ast_debug(w: &mut AstWriter, abilities: &AbilitySet) {
     if !abilities.is_empty() {
         w.write(": ");
@@ -1176,6 +1193,21 @@ impl AstDebug for (Name, AbilitySet) {
         let (n, abilities) = self;
         w.write(&n.value);
         ability_constraints_ast_debug(w, abilities)
+    }
+}
+
+impl AstDebug for StructTypeParameter {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let Self {
+            is_phantom,
+            name,
+            constraints,
+        } = self;
+        if *is_phantom {
+            w.write("phantom ");
+        }
+        w.write(&name.value);
+        ability_constraints_ast_debug(w, &constraints)
     }
 }
 

--- a/language/move-lang/src/hlir/ast.rs
+++ b/language/move-lang/src/hlir/ast.rs
@@ -5,7 +5,7 @@ use crate::{
     expansion::ast::{
         ability_modifiers_ast_debug, AbilitySet, Attribute, Friend, ModuleIdent, SpecId, Value,
     },
-    naming::ast::{BuiltinTypeName, BuiltinTypeName_, TParam},
+    naming::ast::{BuiltinTypeName, BuiltinTypeName_, StructTypeParameter, TParam},
     parser::ast::{BinOp, ConstantName, Field, FunctionName, StructName, UnaryOp, Var, Visibility},
     shared::{ast_debug::*, unique_map::UniqueMap, AddressBytes, Name},
 };
@@ -63,7 +63,7 @@ pub struct ModuleDefinition {
 pub struct StructDefinition {
     pub attributes: Vec<Attribute>,
     pub abilities: AbilitySet,
-    pub type_parameters: Vec<TParam>,
+    pub type_parameters: Vec<StructTypeParameter>,
     pub fields: StructFields,
 }
 

--- a/language/move-lang/src/naming/ast.rs
+++ b/language/move-lang/src/naming/ast.rs
@@ -66,8 +66,14 @@ pub struct ModuleDefinition {
 pub struct StructDefinition {
     pub attributes: Vec<Attribute>,
     pub abilities: AbilitySet,
-    pub type_parameters: Vec<TParam>,
+    pub type_parameters: Vec<StructTypeParameter>,
     pub fields: StructFields,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct StructTypeParameter {
+    pub param: TParam,
+    pub is_phantom: bool,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -719,6 +725,16 @@ impl AstDebug for Vec<TParam> {
     }
 }
 
+impl AstDebug for Vec<StructTypeParameter> {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        if !self.is_empty() {
+            w.write("<");
+            w.comma(self, |w, tp| tp.ast_debug(w));
+            w.write(">")
+        }
+    }
+}
+
 impl AstDebug for (ConstantName, &Constant) {
     fn ast_debug(&self, w: &mut AstWriter) {
         let (
@@ -764,6 +780,16 @@ impl AstDebug for TParam {
         } = self;
         w.write(&format!("{}#{}", user_specified_name, id.0));
         ability_constraints_ast_debug(w, abilities);
+    }
+}
+
+impl AstDebug for StructTypeParameter {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let Self { is_phantom, param } = self;
+        if *is_phantom {
+            w.write("phantom ");
+        }
+        param.ast_debug(w);
     }
 }
 

--- a/language/move-lang/src/naming/translate.rs
+++ b/language/move-lang/src/naming/translate.rs
@@ -718,10 +718,7 @@ fn type_parameter(
         context.env.add_diag(diag!(
             Declarations::DuplicateItem,
             (loc, msg),
-            (
-                old_loc,
-                "Type parameter previously defined here".to_string()
-            ),
+            (old_loc, "Type parameter previously defined here"),
         ))
     }
     tp

--- a/language/move-lang/src/to_bytecode/translate.rs
+++ b/language/move-lang/src/to_bytecode/translate.rs
@@ -10,7 +10,7 @@ use crate::{
         ast::{self as H},
         translate::{display_var, DisplayVar},
     },
-    naming::ast::{BuiltinTypeName_, TParam},
+    naming::ast::{BuiltinTypeName_, StructTypeParameter, TParam},
     parser::ast::{
         Ability, Ability_, BinOp, BinOp_, ConstantName, Field, FunctionName, StructName, UnaryOp,
         UnaryOp_, Var, Visibility,
@@ -733,12 +733,12 @@ fn fun_type_parameters(tps: Vec<TParam>) -> Vec<(IR::TypeVar, BTreeSet<IR::Abili
         .collect()
 }
 
-fn struct_type_parameters(tps: Vec<TParam>) -> Vec<IR::StructTypeParameter> {
+fn struct_type_parameters(tps: Vec<StructTypeParameter>) -> Vec<IR::StructTypeParameter> {
     tps.into_iter()
-        .map(|tp| {
-            let name = type_var(tp.user_specified_name);
-            let constraints = abilities(&tp.abilities);
-            (/* is_phantom */ false, name, constraints)
+        .map(|StructTypeParameter { is_phantom, param }| {
+            let name = type_var(param.user_specified_name);
+            let constraints = abilities(&param.abilities);
+            (is_phantom, name, constraints)
         })
         .collect()
 }

--- a/language/move-lang/src/typing/translate.rs
+++ b/language/move-lang/src/typing/translate.rs
@@ -548,11 +548,10 @@ fn struct_def(context: &mut Context, s: &mut N::StructDefinition) {
 
     let declared_abilities = &s.abilities;
     let tparam_subst = &core::make_tparam_subst(
-        &s.type_parameters,
+        s.type_parameters.iter().map(|tp| &tp.param),
         s.type_parameters
             .iter()
-            .map(|tp| sp(tp.user_specified_name.loc, Type_::Anything))
-            .collect(),
+            .map(|tp| sp(tp.param.user_specified_name.loc, Type_::Anything)),
     );
     for (_field_loc, _field, idx_ty) in field_map.iter() {
         let loc = idx_ty.1.loc;

--- a/language/move-lang/tests/move_check/parser/phantom_param_invalid_keyword.exp
+++ b/language/move-lang/tests/move_check/parser/phantom_param_invalid_keyword.exp
@@ -1,0 +1,8 @@
+error[E01002]: unexpected token
+  ┌─ tests/move_check/parser/phantom_param_invalid_keyword.move:2:25
+  │
+2 │     struct S<T1, phatom T2> {
+  │             -           ^ Expected '>'
+  │             │            
+  │             To match this '<'
+

--- a/language/move-lang/tests/move_check/parser/phantom_param_invalid_keyword.move
+++ b/language/move-lang/tests/move_check/parser/phantom_param_invalid_keyword.move
@@ -1,0 +1,5 @@
+module M {
+    struct S<T1, phatom T2> {
+        a: T1
+    }
+}

--- a/language/move-lang/tests/move_check/parser/phantom_param_missing_type_var.exp
+++ b/language/move-lang/tests/move_check/parser/phantom_param_missing_type_var.exp
@@ -1,0 +1,9 @@
+error[E01002]: unexpected token
+  ┌─ tests/move_check/parser/phantom_param_missing_type_var.move:2:25
+  │
+2 │     struct S<T1, phantom> {
+  │                         ^
+  │                         │
+  │                         Unexpected '>'
+  │                         Expected an identifier
+

--- a/language/move-lang/tests/move_check/parser/phantom_param_missing_type_var.move
+++ b/language/move-lang/tests/move_check/parser/phantom_param_missing_type_var.move
@@ -1,0 +1,5 @@
+module M {
+    struct S<T1, phantom> {
+        f1: u64
+    }
+}

--- a/language/move-lang/tests/move_check/typing/phantom_param_op_abilities.move
+++ b/language/move-lang/tests/move_check/typing/phantom_param_op_abilities.move
@@ -1,0 +1,47 @@
+module 0x42::M {
+    struct NoAbilities { }
+    struct HasDrop<phantom T1, T2> has drop { a: T2 }
+    struct HasCopy<phantom T1, T2> has copy { a: T2 }
+    struct HasStore<phantom T1, T2> has store { a: T2}
+    struct HasKey<phantom T1, T2> has key { a : T2 }
+    struct RequireStore<T: store> { a: T }
+
+    // Writing to a references requires drop
+    fun f1(ref: &mut HasDrop<NoAbilities, u64>) {
+        *ref = HasDrop<NoAbilities, u64> { a: 1 };
+    }
+
+    // Ignoring values requires drop
+    fun f2() {
+        _ = HasDrop<NoAbilities, u64> { a: 1 };
+    }
+
+    // Leaving value in local requires drop
+    fun f3(_x: HasDrop<NoAbilities, u64>) {
+    }
+
+    // `copy` requires copy
+    fun f4(x: HasCopy<NoAbilities, u64>): (HasCopy<NoAbilities, u64>,  HasCopy<NoAbilities, u64>) {
+        (copy x, x)
+    }
+
+    // `move_to` requires key
+    fun f5(s: &signer, x: HasKey<NoAbilities, u64>) {
+        move_to<HasKey<NoAbilities, u64>>(s, x);
+    }
+
+    // `move_from` requires key
+    fun f6(): HasKey<NoAbilities, u64> acquires HasKey {
+        move_from<HasKey<NoAbilities, u64>>(@0x0)
+    }
+
+    // `exists` requires key
+    fun f7(): bool {
+        exists<HasKey<NoAbilities, u64>>(@0x0)
+    }
+
+    // Explicit store constraint
+    fun f8(): RequireStore<HasStore<NoAbilities, u64>> {
+        RequireStore<HasStore<NoAbilities, u64>> { a: HasStore { a: 1 } }
+    }
+}

--- a/language/move-lang/tests/move_check/typing/phantom_param_op_abilities_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/phantom_param_op_abilities_invalid.exp
@@ -1,0 +1,88 @@
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/phantom_param_op_abilities_invalid.move:11:10
+   │
+10 │     fun f1(ref: &mut HasDrop<NoAbilities, NoAbilities>) {
+   │                      ---------------------------------
+   │                      │       │
+   │                      │       The type '0x42::M::HasDrop<0x42::M::NoAbilities, 0x42::M::NoAbilities>' can have the ability 'drop' but the type argument '0x42::M::NoAbilities' does not have the required ability 'drop'
+   │                      The type '0x42::M::HasDrop<0x42::M::NoAbilities, 0x42::M::NoAbilities>' does not have the ability 'drop'
+11 │         *ref = HasDrop<NoAbilities, NoAbilities> { a: NoAbilities { } };
+   │          ^^^ Invalid mutation. Mutation requires the 'drop' ability as the old value is destroyed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/phantom_param_op_abilities_invalid.move:16:9
+   │
+16 │         _ = HasDrop<NoAbilities, NoAbilities> { a: NoAbilities { } };
+   │         ^   --------------------------------------------------------
+   │         │   │       │
+   │         │   │       The type '0x42::M::HasDrop<0x42::M::NoAbilities, 0x42::M::NoAbilities>' can have the ability 'drop' but the type argument '0x42::M::NoAbilities' does not have the required ability 'drop'
+   │         │   The type '0x42::M::HasDrop<0x42::M::NoAbilities, 0x42::M::NoAbilities>' does not have the ability 'drop'
+   │         Cannot ignore values without the 'drop' ability. The value must be used
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/phantom_param_op_abilities_invalid.move:25:10
+   │
+24 │     fun f4(x: HasCopy<NoAbilities, NoAbilities>): (HasCopy<NoAbilities, NoAbilities>,  HasCopy<NoAbilities, NoAbilities>) {
+   │               ---------------------------------
+   │               │       │
+   │               │       The type '0x42::M::HasCopy<0x42::M::NoAbilities, 0x42::M::NoAbilities>' can have the ability 'copy' but the type argument '0x42::M::NoAbilities' does not have the required ability 'copy'
+   │               The type '0x42::M::HasCopy<0x42::M::NoAbilities, 0x42::M::NoAbilities>' does not have the ability 'copy'
+25 │         (copy x, x)
+   │          ^^^^^^ Invalid 'copy' of owned value without the 'copy' ability
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/phantom_param_op_abilities_invalid.move:30:9
+   │
+30 │         move_to<HasKey<NoAbilities, NoAbilities>>(s, x);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │       │      │
+   │         │       │      The type '0x42::M::HasKey<0x42::M::NoAbilities, 0x42::M::NoAbilities>' can have the ability 'key' but the type argument '0x42::M::NoAbilities' does not have the required ability 'store'
+   │         │       The type '0x42::M::HasKey<0x42::M::NoAbilities, 0x42::M::NoAbilities>' does not have the ability 'key'
+   │         Invalid call of 'move_to'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/phantom_param_op_abilities_invalid.move:35:9
+   │
+35 │         move_from<HasKey<NoAbilities, NoAbilities>>(@0x0)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │         │      │
+   │         │         │      The type '0x42::M::HasKey<0x42::M::NoAbilities, 0x42::M::NoAbilities>' can have the ability 'key' but the type argument '0x42::M::NoAbilities' does not have the required ability 'store'
+   │         │         The type '0x42::M::HasKey<0x42::M::NoAbilities, 0x42::M::NoAbilities>' does not have the ability 'key'
+   │         Invalid call of 'move_from'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/phantom_param_op_abilities_invalid.move:40:9
+   │
+40 │         exists<HasKey<NoAbilities, NoAbilities>>(@0x0)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │      │      │
+   │         │      │      The type '0x42::M::HasKey<0x42::M::NoAbilities, 0x42::M::NoAbilities>' can have the ability 'key' but the type argument '0x42::M::NoAbilities' does not have the required ability 'store'
+   │         │      The type '0x42::M::HasKey<0x42::M::NoAbilities, 0x42::M::NoAbilities>' does not have the ability 'key'
+   │         Invalid call of 'exists'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/phantom_param_op_abilities_invalid.move:44:15
+   │
+ 7 │     struct RequireStore<T: store> { a: T }
+   │                            ----- 'store' constraint declared here
+   ·
+44 │     fun f8(): RequireStore<HasStore<NoAbilities, NoAbilities>> {
+   │               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │               │            │        │
+   │               │            │        The type '0x42::M::HasStore<0x42::M::NoAbilities, 0x42::M::NoAbilities>' can have the ability 'store' but the type argument '0x42::M::NoAbilities' does not have the required ability 'store'
+   │               │            The type '0x42::M::HasStore<0x42::M::NoAbilities, 0x42::M::NoAbilities>' does not have the ability 'store'
+   │               'store' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/phantom_param_op_abilities_invalid.move:45:9
+   │
+ 7 │     struct RequireStore<T: store> { a: T }
+   │                            ----- 'store' constraint declared here
+   ·
+45 │         RequireStore<HasStore<NoAbilities, NoAbilities>> { a: HasStore { a: NoAbilities {} } }
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │            │        │
+   │         │            │        The type '0x42::M::HasStore<0x42::M::NoAbilities, 0x42::M::NoAbilities>' can have the ability 'store' but the type argument '0x42::M::NoAbilities' does not have the required ability 'store'
+   │         │            The type '0x42::M::HasStore<0x42::M::NoAbilities, 0x42::M::NoAbilities>' does not have the ability 'store'
+   │         'store' constraint not satisifed
+

--- a/language/move-lang/tests/move_check/typing/phantom_param_op_abilities_invalid.move
+++ b/language/move-lang/tests/move_check/typing/phantom_param_op_abilities_invalid.move
@@ -1,0 +1,47 @@
+module 0x42::M {
+    struct NoAbilities { }
+    struct HasDrop<phantom T1, T2> has drop { a: T2 }
+    struct HasCopy<phantom T1, T2> has copy { a: T2 }
+    struct HasStore<phantom T1, T2> has store { a: T2}
+    struct HasKey<phantom T1, T2> has key { a : T2 }
+    struct RequireStore<T: store> { a: T }
+
+    // Writing to a references requires drop
+    fun f1(ref: &mut HasDrop<NoAbilities, NoAbilities>) {
+        *ref = HasDrop<NoAbilities, NoAbilities> { a: NoAbilities { } };
+    }
+
+    // Ignoring values requires drop
+    fun f2() {
+        _ = HasDrop<NoAbilities, NoAbilities> { a: NoAbilities { } };
+    }
+
+    // Leaving value in local requires drop
+    fun f3(_x: HasDrop<NoAbilities, NoAbilities>) {
+    }
+
+    // `copy` requires copy
+    fun f4(x: HasCopy<NoAbilities, NoAbilities>): (HasCopy<NoAbilities, NoAbilities>,  HasCopy<NoAbilities, NoAbilities>) {
+        (copy x, x)
+    }
+
+    // `move_to` requires key
+    fun f5(s: &signer, x: HasKey<NoAbilities, NoAbilities>) {
+        move_to<HasKey<NoAbilities, NoAbilities>>(s, x);
+    }
+
+    // `move_from` requires key
+    fun f6(): HasKey<NoAbilities, NoAbilities> acquires HasKey {
+        move_from<HasKey<NoAbilities, NoAbilities>>(@0x0)
+    }
+
+    // `exists` requires key
+    fun f7(): bool {
+        exists<HasKey<NoAbilities, NoAbilities>>(@0x0)
+    }
+
+    // Explicit store constraint
+    fun f8(): RequireStore<HasStore<NoAbilities, NoAbilities>> {
+        RequireStore<HasStore<NoAbilities, NoAbilities>> { a: HasStore { a: NoAbilities {} } }
+    }
+}

--- a/language/move-lang/tests/move_check/typing/phantom_param_struct_decl.move
+++ b/language/move-lang/tests/move_check/typing/phantom_param_struct_decl.move
@@ -1,0 +1,26 @@
+module 0x42::M1 {
+    // Not using a phantom parameter at all is ok.
+    struct S1<phantom T> {
+        a: u64
+    }
+
+    // Phantom parameters can be used in phantom position.
+    struct S2<phantom T> {
+        a: S1<T>,
+        b: vector<S1<T>>
+    }
+
+    // Mixing phantom and non-phantom parameters
+    struct S3<phantom T1, T2, phantom T3, T4> {
+        a: T2,
+        b: T4
+    }
+
+    // Phantom parameters should be allowed to be declared with constraints.
+    struct S4<phantom T: copy> {
+        a: u64
+    }
+    struct S5<phantom T: copy + drop + store> {
+        a: S4<T>
+    }
+}

--- a/language/move-lang/tests/move_check/typing/phantom_param_struct_decl_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/phantom_param_struct_decl_invalid.exp
@@ -1,0 +1,43 @@
+error[E02012]: invalid phantom type parameter usage
+  ┌─ tests/move_check/typing/phantom_param_struct_decl_invalid.move:4:12
+  │
+2 │     struct S1<phantom T> {
+  │                       - 'T' declared here as phantom
+3 │         // A phantom parameter cannot be used as the type of a field
+4 │         a: T,
+  │            ^ Phantom type parameter cannot be used as a field type
+
+error[E02012]: invalid phantom type parameter usage
+  ┌─ tests/move_check/typing/phantom_param_struct_decl_invalid.move:6:19
+  │
+2 │     struct S1<phantom T> {
+  │                       - 'T' declared here as phantom
+  ·
+6 │         b: vector<T>
+  │                   ^ Phantom type parameter cannot be used as an argument to a parameter not declared as phantom
+
+error[E02012]: invalid phantom type parameter usage
+   ┌─ tests/move_check/typing/phantom_param_struct_decl_invalid.move:12:15
+   │
+11 │     struct S3<phantom T> {
+   │                       - 'T' declared here as phantom
+12 │         a: S2<T>
+   │               ^ Phantom type parameter cannot be used as an argument to a parameter not declared as phantom
+
+error[E02012]: invalid phantom type parameter usage
+   ┌─ tests/move_check/typing/phantom_param_struct_decl_invalid.move:17:18
+   │
+16 │     struct S4<phantom T> {
+   │                       - 'T' declared here as phantom
+17 │         a: S2<S2<T>>
+   │                  ^ Phantom type parameter cannot be used as an argument to a parameter not declared as phantom
+
+error[E02012]: invalid phantom type parameter usage
+   ┌─ tests/move_check/typing/phantom_param_struct_decl_invalid.move:23:12
+   │
+21 │     struct S5<T1, phantom T2, T3> {
+   │                           -- 'T2' declared here as phantom
+22 │         a: T1,
+23 │         b: T2,
+   │            ^^ Phantom type parameter cannot be used as a field type
+

--- a/language/move-lang/tests/move_check/typing/phantom_param_struct_decl_invalid.move
+++ b/language/move-lang/tests/move_check/typing/phantom_param_struct_decl_invalid.move
@@ -1,0 +1,32 @@
+module 0x42::M {
+    struct S1<phantom T> {
+        // A phantom parameter cannot be used as the type of a field
+        a: T,
+        // The parameter of vector is non-phantom and a phantom parameter shouldn't be allowed in that position
+        b: vector<T>
+    }
+
+    // A phantom parameter cannot be used as the argument to a non-phantom parameter
+    struct S2<T> { a: T }
+    struct S3<phantom T> {
+        a: S2<T>
+    }
+
+    // Phantom position violation inside another type argument
+    struct S4<phantom T> {
+        a: S2<S2<T>>
+    }
+
+    // Mixing phantom and non-phantom parameters
+    struct S5<T1, phantom T2, T3> {
+        a: T1,
+        b: T2,
+        c: T3
+    }
+
+    // Phantom parameters should satisfy constraints
+    struct S6<phantom T: copy> { a: bool }
+    struct S7<phantom T> {
+        a: S6<T>
+    }
+}

--- a/language/move-lang/tests/move_check/typing/phantom_params_constraint_abilities.move
+++ b/language/move-lang/tests/move_check/typing/phantom_params_constraint_abilities.move
@@ -1,0 +1,36 @@
+module 0x42::M {
+    struct NoAbilities { a: bool }
+    struct HasDrop<phantom T1, T2> has drop { a: T2 }
+    struct HasCopy<phantom T1, T2> has copy { a: T2 }
+    struct HasStore<phantom T1, T2> has store { a: T2 }
+    struct HasKey<phantom T1, T2> has key { a: T2 }
+    struct HasAbilities<phantom T1, T2> has drop, copy, store, key { a: T2 }
+
+    struct S1<T: drop + copy + store + key> { a: T }
+    struct S2 {
+        a: S1<HasAbilities<NoAbilities, u64>>,
+    }
+
+    struct S3<T1: drop, T2: copy, T3: store, T4: key> { a: T1, b: T2, c: T3, d: T4 }
+    struct S4 {
+        a: S3< HasDrop<NoAbilities, u64>,
+               HasCopy<NoAbilities, u64>,
+               HasStore<NoAbilities, u64>,
+               HasKey<NoAbilities, u64>
+             >
+    }
+
+    fun f1<T: drop + copy + store + key>() { }
+    fun f2() {
+        f1<HasAbilities<NoAbilities, u64>>();
+    }
+
+    fun f3<T1: drop, T2: copy, T3: store, T4: key>() { }
+    fun f4() {
+        f3< HasDrop<NoAbilities, u64>,
+            HasCopy<NoAbilities, u64>,
+            HasStore<NoAbilities, u64>,
+            HasKey<NoAbilities, u64>
+          >();
+    }
+}

--- a/language/move-lang/tests/move_check/typing/phantom_params_constraint_abilities_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/phantom_params_constraint_abilities_invalid.exp
@@ -1,0 +1,244 @@
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/phantom_params_constraint_abilities_invalid.move:11:12
+   │
+ 9 │     struct S1<T: drop + copy + store + key> { a: T }
+   │                         ---- 'copy' constraint declared here
+10 │     struct S2 {
+11 │         a: S1<HasAbilities<NoAbilities, NoAbilities>>,
+   │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │            │  │            │
+   │            │  │            The type '0x42::M::HasAbilities<0x42::M::NoAbilities, 0x42::M::NoAbilities>' can have the ability 'copy' but the type argument '0x42::M::NoAbilities' does not have the required ability 'copy'
+   │            │  The type '0x42::M::HasAbilities<0x42::M::NoAbilities, 0x42::M::NoAbilities>' does not have the ability 'copy'
+   │            'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/phantom_params_constraint_abilities_invalid.move:11:12
+   │
+ 9 │     struct S1<T: drop + copy + store + key> { a: T }
+   │                  ---- 'drop' constraint declared here
+10 │     struct S2 {
+11 │         a: S1<HasAbilities<NoAbilities, NoAbilities>>,
+   │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │            │  │            │
+   │            │  │            The type '0x42::M::HasAbilities<0x42::M::NoAbilities, 0x42::M::NoAbilities>' can have the ability 'drop' but the type argument '0x42::M::NoAbilities' does not have the required ability 'drop'
+   │            │  The type '0x42::M::HasAbilities<0x42::M::NoAbilities, 0x42::M::NoAbilities>' does not have the ability 'drop'
+   │            'drop' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/phantom_params_constraint_abilities_invalid.move:11:12
+   │
+ 9 │     struct S1<T: drop + copy + store + key> { a: T }
+   │                                ----- 'store' constraint declared here
+10 │     struct S2 {
+11 │         a: S1<HasAbilities<NoAbilities, NoAbilities>>,
+   │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │            │  │            │
+   │            │  │            The type '0x42::M::HasAbilities<0x42::M::NoAbilities, 0x42::M::NoAbilities>' can have the ability 'store' but the type argument '0x42::M::NoAbilities' does not have the required ability 'store'
+   │            │  The type '0x42::M::HasAbilities<0x42::M::NoAbilities, 0x42::M::NoAbilities>' does not have the ability 'store'
+   │            'store' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/phantom_params_constraint_abilities_invalid.move:11:12
+   │
+ 9 │     struct S1<T: drop + copy + store + key> { a: T }
+   │                                        --- 'key' constraint declared here
+10 │     struct S2 {
+11 │         a: S1<HasAbilities<NoAbilities, NoAbilities>>,
+   │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │            │  │            │
+   │            │  │            The type '0x42::M::HasAbilities<0x42::M::NoAbilities, 0x42::M::NoAbilities>' can have the ability 'key' but the type argument '0x42::M::NoAbilities' does not have the required ability 'store'
+   │            │  The type '0x42::M::HasAbilities<0x42::M::NoAbilities, 0x42::M::NoAbilities>' does not have the ability 'key'
+   │            'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/phantom_params_constraint_abilities_invalid.move:16:12
+   │  
+14 │       struct S3<T1: drop, T2: copy, T3: store, T4: key> { a: T1, b: T2, c: T3, d: T4 }
+   │                     ---- 'drop' constraint declared here
+15 │       struct S4 {
+16 │           a: S3< HasDrop<NoAbilities, NoAbilities>,
+   │                  ---------------------------------
+   │                  │       │
+   │                  │       The type '0x42::M::HasDrop<0x42::M::NoAbilities, 0x42::M::NoAbilities>' can have the ability 'drop' but the type argument '0x42::M::NoAbilities' does not have the required ability 'drop'
+   │                  The type '0x42::M::HasDrop<0x42::M::NoAbilities, 0x42::M::NoAbilities>' does not have the ability 'drop'
+   │ ╭────────────^
+17 │ │                HasCopy<NoAbilities, NoAbilities>,
+18 │ │                HasStore<NoAbilities, NoAbilities>,
+19 │ │                HasKey<NoAbilities, NoAbilities>
+20 │ │              >
+   │ ╰──────────────^ 'drop' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/phantom_params_constraint_abilities_invalid.move:16:12
+   │  
+14 │       struct S3<T1: drop, T2: copy, T3: store, T4: key> { a: T1, b: T2, c: T3, d: T4 }
+   │                               ---- 'copy' constraint declared here
+15 │       struct S4 {
+16 │           a: S3< HasDrop<NoAbilities, NoAbilities>,
+   │ ╭────────────^
+17 │ │                HasCopy<NoAbilities, NoAbilities>,
+   │ │                ---------------------------------
+   │ │                │       │
+   │ │                │       The type '0x42::M::HasCopy<0x42::M::NoAbilities, 0x42::M::NoAbilities>' can have the ability 'copy' but the type argument '0x42::M::NoAbilities' does not have the required ability 'copy'
+   │ │                The type '0x42::M::HasCopy<0x42::M::NoAbilities, 0x42::M::NoAbilities>' does not have the ability 'copy'
+18 │ │                HasStore<NoAbilities, NoAbilities>,
+19 │ │                HasKey<NoAbilities, NoAbilities>
+20 │ │              >
+   │ ╰──────────────^ 'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/phantom_params_constraint_abilities_invalid.move:16:12
+   │  
+14 │       struct S3<T1: drop, T2: copy, T3: store, T4: key> { a: T1, b: T2, c: T3, d: T4 }
+   │                                         ----- 'store' constraint declared here
+15 │       struct S4 {
+16 │           a: S3< HasDrop<NoAbilities, NoAbilities>,
+   │ ╭────────────^
+17 │ │                HasCopy<NoAbilities, NoAbilities>,
+18 │ │                HasStore<NoAbilities, NoAbilities>,
+   │ │                ----------------------------------
+   │ │                │        │
+   │ │                │        The type '0x42::M::HasStore<0x42::M::NoAbilities, 0x42::M::NoAbilities>' can have the ability 'store' but the type argument '0x42::M::NoAbilities' does not have the required ability 'store'
+   │ │                The type '0x42::M::HasStore<0x42::M::NoAbilities, 0x42::M::NoAbilities>' does not have the ability 'store'
+19 │ │                HasKey<NoAbilities, NoAbilities>
+20 │ │              >
+   │ ╰──────────────^ 'store' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/phantom_params_constraint_abilities_invalid.move:16:12
+   │  
+14 │       struct S3<T1: drop, T2: copy, T3: store, T4: key> { a: T1, b: T2, c: T3, d: T4 }
+   │                                                    --- 'key' constraint declared here
+15 │       struct S4 {
+16 │           a: S3< HasDrop<NoAbilities, NoAbilities>,
+   │ ╭────────────^
+17 │ │                HasCopy<NoAbilities, NoAbilities>,
+18 │ │                HasStore<NoAbilities, NoAbilities>,
+19 │ │                HasKey<NoAbilities, NoAbilities>
+   │ │                --------------------------------
+   │ │                │      │
+   │ │                │      The type '0x42::M::HasKey<0x42::M::NoAbilities, 0x42::M::NoAbilities>' can have the ability 'key' but the type argument '0x42::M::NoAbilities' does not have the required ability 'store'
+   │ │                The type '0x42::M::HasKey<0x42::M::NoAbilities, 0x42::M::NoAbilities>' does not have the ability 'key'
+20 │ │              >
+   │ ╰──────────────^ 'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/phantom_params_constraint_abilities_invalid.move:25:9
+   │
+23 │     fun f1<T: drop + copy + store + key>() { }
+   │                      ---- 'copy' constraint declared here
+24 │     fun f2() {
+25 │         f1<HasAbilities<NoAbilities, NoAbilities>>();
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │  │            │
+   │         │  │            The type '0x42::M::HasAbilities<0x42::M::NoAbilities, 0x42::M::NoAbilities>' can have the ability 'copy' but the type argument '0x42::M::NoAbilities' does not have the required ability 'copy'
+   │         │  The type '0x42::M::HasAbilities<0x42::M::NoAbilities, 0x42::M::NoAbilities>' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/phantom_params_constraint_abilities_invalid.move:25:9
+   │
+23 │     fun f1<T: drop + copy + store + key>() { }
+   │               ---- 'drop' constraint declared here
+24 │     fun f2() {
+25 │         f1<HasAbilities<NoAbilities, NoAbilities>>();
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │  │            │
+   │         │  │            The type '0x42::M::HasAbilities<0x42::M::NoAbilities, 0x42::M::NoAbilities>' can have the ability 'drop' but the type argument '0x42::M::NoAbilities' does not have the required ability 'drop'
+   │         │  The type '0x42::M::HasAbilities<0x42::M::NoAbilities, 0x42::M::NoAbilities>' does not have the ability 'drop'
+   │         'drop' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/phantom_params_constraint_abilities_invalid.move:25:9
+   │
+23 │     fun f1<T: drop + copy + store + key>() { }
+   │                             ----- 'store' constraint declared here
+24 │     fun f2() {
+25 │         f1<HasAbilities<NoAbilities, NoAbilities>>();
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │  │            │
+   │         │  │            The type '0x42::M::HasAbilities<0x42::M::NoAbilities, 0x42::M::NoAbilities>' can have the ability 'store' but the type argument '0x42::M::NoAbilities' does not have the required ability 'store'
+   │         │  The type '0x42::M::HasAbilities<0x42::M::NoAbilities, 0x42::M::NoAbilities>' does not have the ability 'store'
+   │         'store' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/phantom_params_constraint_abilities_invalid.move:25:9
+   │
+23 │     fun f1<T: drop + copy + store + key>() { }
+   │                                     --- 'key' constraint declared here
+24 │     fun f2() {
+25 │         f1<HasAbilities<NoAbilities, NoAbilities>>();
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │  │            │
+   │         │  │            The type '0x42::M::HasAbilities<0x42::M::NoAbilities, 0x42::M::NoAbilities>' can have the ability 'key' but the type argument '0x42::M::NoAbilities' does not have the required ability 'store'
+   │         │  The type '0x42::M::HasAbilities<0x42::M::NoAbilities, 0x42::M::NoAbilities>' does not have the ability 'key'
+   │         'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/phantom_params_constraint_abilities_invalid.move:30:9
+   │  
+28 │       fun f3<T1: drop, T2: copy, T3: store, T4: key>() { }
+   │                  ---- 'drop' constraint declared here
+29 │       fun f4() {
+30 │ ╭         f3< HasDrop<NoAbilities, NoAbilities>,
+   │               ---------------------------------
+   │               │       │
+   │               │       The type '0x42::M::HasDrop<0x42::M::NoAbilities, 0x42::M::NoAbilities>' can have the ability 'drop' but the type argument '0x42::M::NoAbilities' does not have the required ability 'drop'
+   │               The type '0x42::M::HasDrop<0x42::M::NoAbilities, 0x42::M::NoAbilities>' does not have the ability 'drop'
+31 │ │             HasCopy<NoAbilities, NoAbilities>,
+32 │ │             HasStore<NoAbilities, NoAbilities>,
+33 │ │             HasKey<NoAbilities, NoAbilities>
+34 │ │           >();
+   │ ╰─────────────^ 'drop' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/phantom_params_constraint_abilities_invalid.move:30:9
+   │  
+28 │       fun f3<T1: drop, T2: copy, T3: store, T4: key>() { }
+   │                            ---- 'copy' constraint declared here
+29 │       fun f4() {
+30 │ ╭         f3< HasDrop<NoAbilities, NoAbilities>,
+31 │ │             HasCopy<NoAbilities, NoAbilities>,
+   │ │             ---------------------------------
+   │ │             │       │
+   │ │             │       The type '0x42::M::HasCopy<0x42::M::NoAbilities, 0x42::M::NoAbilities>' can have the ability 'copy' but the type argument '0x42::M::NoAbilities' does not have the required ability 'copy'
+   │ │             The type '0x42::M::HasCopy<0x42::M::NoAbilities, 0x42::M::NoAbilities>' does not have the ability 'copy'
+32 │ │             HasStore<NoAbilities, NoAbilities>,
+33 │ │             HasKey<NoAbilities, NoAbilities>
+34 │ │           >();
+   │ ╰─────────────^ 'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/phantom_params_constraint_abilities_invalid.move:30:9
+   │  
+28 │       fun f3<T1: drop, T2: copy, T3: store, T4: key>() { }
+   │                                      ----- 'store' constraint declared here
+29 │       fun f4() {
+30 │ ╭         f3< HasDrop<NoAbilities, NoAbilities>,
+31 │ │             HasCopy<NoAbilities, NoAbilities>,
+32 │ │             HasStore<NoAbilities, NoAbilities>,
+   │ │             ----------------------------------
+   │ │             │        │
+   │ │             │        The type '0x42::M::HasStore<0x42::M::NoAbilities, 0x42::M::NoAbilities>' can have the ability 'store' but the type argument '0x42::M::NoAbilities' does not have the required ability 'store'
+   │ │             The type '0x42::M::HasStore<0x42::M::NoAbilities, 0x42::M::NoAbilities>' does not have the ability 'store'
+33 │ │             HasKey<NoAbilities, NoAbilities>
+34 │ │           >();
+   │ ╰─────────────^ 'store' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/phantom_params_constraint_abilities_invalid.move:30:9
+   │  
+28 │       fun f3<T1: drop, T2: copy, T3: store, T4: key>() { }
+   │                                                 --- 'key' constraint declared here
+29 │       fun f4() {
+30 │ ╭         f3< HasDrop<NoAbilities, NoAbilities>,
+31 │ │             HasCopy<NoAbilities, NoAbilities>,
+32 │ │             HasStore<NoAbilities, NoAbilities>,
+33 │ │             HasKey<NoAbilities, NoAbilities>
+   │ │             --------------------------------
+   │ │             │      │
+   │ │             │      The type '0x42::M::HasKey<0x42::M::NoAbilities, 0x42::M::NoAbilities>' can have the ability 'key' but the type argument '0x42::M::NoAbilities' does not have the required ability 'store'
+   │ │             The type '0x42::M::HasKey<0x42::M::NoAbilities, 0x42::M::NoAbilities>' does not have the ability 'key'
+34 │ │           >();
+   │ ╰─────────────^ 'key' constraint not satisifed
+

--- a/language/move-lang/tests/move_check/typing/phantom_params_constraint_abilities_invalid.move
+++ b/language/move-lang/tests/move_check/typing/phantom_params_constraint_abilities_invalid.move
@@ -1,0 +1,36 @@
+module 0x42::M {
+    struct NoAbilities { a: bool }
+    struct HasDrop<phantom T1, T2> has drop { a: T2 }
+    struct HasCopy<phantom T1, T2> has copy { a: T2 }
+    struct HasStore<phantom T1, T2> has store { a: T2 }
+    struct HasKey<phantom T1, T2> has key { a: T2 }
+    struct HasAbilities<phantom T1, T2> has drop, copy, store, key { a: T2 }
+
+    struct S1<T: drop + copy + store + key> { a: T }
+    struct S2 {
+        a: S1<HasAbilities<NoAbilities, NoAbilities>>,
+    }
+
+    struct S3<T1: drop, T2: copy, T3: store, T4: key> { a: T1, b: T2, c: T3, d: T4 }
+    struct S4 {
+        a: S3< HasDrop<NoAbilities, NoAbilities>,
+               HasCopy<NoAbilities, NoAbilities>,
+               HasStore<NoAbilities, NoAbilities>,
+               HasKey<NoAbilities, NoAbilities>
+             >
+    }
+
+    fun f1<T: drop + copy + store + key>() { }
+    fun f2() {
+        f1<HasAbilities<NoAbilities, NoAbilities>>();
+    }
+
+    fun f3<T1: drop, T2: copy, T3: store, T4: key>() { }
+    fun f4() {
+        f3< HasDrop<NoAbilities, NoAbilities>,
+            HasCopy<NoAbilities, NoAbilities>,
+            HasStore<NoAbilities, NoAbilities>,
+            HasKey<NoAbilities, NoAbilities>
+          >();
+    }
+}

--- a/language/move-lang/tests/move_check/typing/phantom_params_field_abilities.move
+++ b/language/move-lang/tests/move_check/typing/phantom_params_field_abilities.move
@@ -1,0 +1,13 @@
+module 0x42::M {
+    struct NoAbilities { }
+
+    struct HasDrop<phantom T1, T2> has drop { a: T2 }
+    struct HasCopy<phantom T1, T2> has copy { a : T2 }
+    struct HasStore<phantom T1, T2> has store { a : T2 }
+    struct HasKey<phantom T1, T2> has key { a : T2 }
+
+    struct S1 has drop { a: HasDrop<NoAbilities, u64> }
+    struct S2 has copy { a: HasCopy<NoAbilities, u64> }
+    struct S3 has store { a: HasStore<NoAbilities, u64> }
+    struct S4 has key { a: HasStore<NoAbilities, u64> }
+}

--- a/language/move-lang/tests/move_check/typing/phantom_params_field_abilities_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/phantom_params_field_abilities_invalid.exp
@@ -1,0 +1,40 @@
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/phantom_params_field_abilities_invalid.move:9:29
+  │
+9 │     struct S1 has drop { a: HasDrop<NoAbilities, NoAbilities> }
+  │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │                             │       │
+  │                             │       The type '0x42::M::HasDrop<0x42::M::NoAbilities, 0x42::M::NoAbilities>' can have the ability 'drop' but the type argument '0x42::M::NoAbilities' does not have the required ability 'drop'
+  │                             Invalid field type. The struct was declared with the ability 'drop' so all fields require the ability 'drop'
+  │                             The type '0x42::M::HasDrop<0x42::M::NoAbilities, 0x42::M::NoAbilities>' does not have the ability 'drop'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/phantom_params_field_abilities_invalid.move:10:29
+   │
+10 │     struct S2 has copy { a: HasCopy<NoAbilities, NoAbilities> }
+   │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │                             │       │
+   │                             │       The type '0x42::M::HasCopy<0x42::M::NoAbilities, 0x42::M::NoAbilities>' can have the ability 'copy' but the type argument '0x42::M::NoAbilities' does not have the required ability 'copy'
+   │                             Invalid field type. The struct was declared with the ability 'copy' so all fields require the ability 'copy'
+   │                             The type '0x42::M::HasCopy<0x42::M::NoAbilities, 0x42::M::NoAbilities>' does not have the ability 'copy'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/phantom_params_field_abilities_invalid.move:11:30
+   │
+11 │     struct S3 has store { a: HasStore<NoAbilities, NoAbilities> }
+   │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │                              │        │
+   │                              │        The type '0x42::M::HasStore<0x42::M::NoAbilities, 0x42::M::NoAbilities>' can have the ability 'store' but the type argument '0x42::M::NoAbilities' does not have the required ability 'store'
+   │                              Invalid field type. The struct was declared with the ability 'store' so all fields require the ability 'store'
+   │                              The type '0x42::M::HasStore<0x42::M::NoAbilities, 0x42::M::NoAbilities>' does not have the ability 'store'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/phantom_params_field_abilities_invalid.move:12:28
+   │
+12 │     struct S4 has key { a: HasStore<NoAbilities, NoAbilities> }
+   │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │                            │        │
+   │                            │        The type '0x42::M::HasStore<0x42::M::NoAbilities, 0x42::M::NoAbilities>' can have the ability 'store' but the type argument '0x42::M::NoAbilities' does not have the required ability 'store'
+   │                            Invalid field type. The struct was declared with the ability 'key' so all fields require the ability 'store'
+   │                            The type '0x42::M::HasStore<0x42::M::NoAbilities, 0x42::M::NoAbilities>' does not have the ability 'store'
+

--- a/language/move-lang/tests/move_check/typing/phantom_params_field_abilities_invalid.move
+++ b/language/move-lang/tests/move_check/typing/phantom_params_field_abilities_invalid.move
@@ -1,0 +1,13 @@
+module 0x42::M {
+    struct NoAbilities { }
+
+    struct HasDrop<phantom T1, T2> has drop { a: T2 }
+    struct HasCopy<phantom T1, T2> has copy { a : T2 }
+    struct HasStore<phantom T1, T2> has store { a : T2 }
+    struct HasKey<phantom T1, T2> has key { a : T2 }
+
+    struct S1 has drop { a: HasDrop<NoAbilities, NoAbilities> }
+    struct S2 has copy { a: HasCopy<NoAbilities, NoAbilities> }
+    struct S3 has store { a: HasStore<NoAbilities, NoAbilities> }
+    struct S4 has key { a: HasStore<NoAbilities, NoAbilities> }
+}

--- a/language/move-model/src/builder/exp_translator.rs
+++ b/language/move-model/src/builder/exp_translator.rs
@@ -402,14 +402,14 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
 
     /// Analyzes the sequence of type parameters as they are provided via the source AST and enters
     /// them into the environment. Returns a vector for representing them in the target AST.
-    pub fn analyze_and_add_type_params<T>(
-        &mut self,
-        type_params: &[(Name, T)],
-    ) -> Vec<(Symbol, Type)> {
+    pub fn analyze_and_add_type_params<'a, I>(&mut self, type_params: I) -> Vec<(Symbol, Type)>
+    where
+        I: IntoIterator<Item = &'a Name>,
+    {
         type_params
-            .iter()
+            .into_iter()
             .enumerate()
-            .map(|(i, (n, _))| {
+            .map(|(i, n)| {
                 let ty = Type::TypeParameter(i as u16);
                 let sym = self.symbol_pool().make(n.value.as_str());
                 self.define_type_param(&self.to_loc(&n.loc), sym, ty.clone());


### PR DESCRIPTION
* Update syntax to allow phantom declarations for struct type parameters
* Check correct use of phantom parameters
* Filter phantom parameters when deriving abilities for polymorphic structs

## Test Plan

`cargo xtest -p move-lang phantom`


