### PR TITLE
[move] [read/write set] Use temp_indices instead during footprint substitution

### DIFF
--- a/language/move-prover/bytecode/tests/read_write_set/pack_unpack.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/pack_unpack.exp
@@ -140,6 +140,36 @@ fun PackUnpack::reassign_packed_addr($t0|a2: address): address {
  13: return $t11
 }
 
+
+[variant baseline]
+fun PackUnpack::use_results($t0|_: u64, $t1|a: address): address {
+     var $t2|a1: address
+     var $t3|s: PackUnpack::S
+     var $t4: address
+     var $t5: address
+     var $t6: address
+     var $t7: address
+     var $t8: bool
+     var $t9: PackUnpack::T
+     var $t10: u64
+     var $t11: PackUnpack::S
+     var $t12: PackUnpack::S
+     var $t13: address
+  0: $t4 := copy($t1)
+  1: $t5 := PackUnpack::pack_then_read($t4)
+  2: $t2 := $t5
+  3: $t6 := copy($t2)
+  4: $t7 := 0x7
+  5: $t8 := true
+  6: $t9 := pack PackUnpack::T($t7, $t8)
+  7: $t10 := 10
+  8: $t11 := pack PackUnpack::S($t6, $t9, $t10)
+  9: $t3 := $t11
+ 10: $t12 := move($t3)
+ 11: $t13 := PackUnpack::read_unpacked_addr($t12)
+ 12: return $t13
+}
+
 ============ after pipeline `read_write_set` ================
 
 [variant baseline]
@@ -315,4 +345,40 @@ fun PackUnpack::reassign_packed_addr($t0|a2: address): address {
  11: $t10 := borrow_field<PackUnpack::T>.a2($t9)
  12: $t11 := read_ref($t10)
  13: return $t11
+}
+
+
+[variant baseline]
+fun PackUnpack::use_results($t0|_: u64, $t1|a: address): address {
+     var $t2|a1: address
+     var $t3|s: PackUnpack::S
+     var $t4: address
+     var $t5: address
+     var $t6: address
+     var $t7: address
+     var $t8: bool
+     var $t9: PackUnpack::T
+     var $t10: u64
+     var $t11: PackUnpack::S
+     var $t12: PackUnpack::S
+     var $t13: address
+     # Accesses:
+     # Formal(1): Read
+     #
+     # Locals:
+     # Ret(0): {0x7, Formal(1), }
+     #
+  0: $t4 := copy($t1)
+  1: $t5 := PackUnpack::pack_then_read($t4)
+  2: $t2 := $t5
+  3: $t6 := copy($t2)
+  4: $t7 := 0x7
+  5: $t8 := true
+  6: $t9 := pack PackUnpack::T($t7, $t8)
+  7: $t10 := 10
+  8: $t11 := pack PackUnpack::S($t6, $t9, $t10)
+  9: $t3 := $t11
+ 10: $t12 := move($t3)
+ 11: $t13 := PackUnpack::read_unpacked_addr($t12)
+ 12: return $t13
 }

--- a/language/move-prover/bytecode/tests/read_write_set/pack_unpack.move
+++ b/language/move-prover/bytecode/tests/read_write_set/pack_unpack.move
@@ -31,12 +31,9 @@ module 0x1::PackUnpack {
         *&t.a2
     } // ret |-> Formal(0)
 
-    // TODO: crashes the analysis. fix by addressing TODO
-    // in AccessPath::substitute_footprint
-    /*fun use_results(_: u64, a: address): address {
+    fun use_results(_: u64, a: address): address {
         let a1 = pack_then_read(a);
         let s = S { a1, t: T { a2: @0x7, b: true }, i: 10 };
         read_unpacked_addr(s)
-    }  // ret |-> { Formal(0), @0x7 }
-    */
+    }  // ret |-> { Formal(1), @0x7 }
 }

--- a/language/move-prover/bytecode/tests/read_write_set/secondary_index.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/secondary_index.exp
@@ -1,6 +1,18 @@
 ============ initial translation from Move ================
 
 [variant baseline]
+fun SecondaryIndex::call_two_secondary_indexes($t0|s: &SecondaryIndex::S): address {
+     var $t1: &SecondaryIndex::S
+     var $t2: bool
+     var $t3: address
+  0: $t1 := move($t0)
+  1: $t2 := true
+  2: $t3 := SecondaryIndex::two_secondary_indexes($t1, $t2)
+  3: return $t3
+}
+
+
+[variant baseline]
 fun SecondaryIndex::read_secondary_index_from_formal($t0|a: &SecondaryIndex::A): address {
      var $t1: &SecondaryIndex::A
      var $t2: &address
@@ -69,7 +81,117 @@ fun SecondaryIndex::read_secondary_index_from_global_interproc($t0|a: address): 
   3: return $t3
 }
 
+
+[variant baseline]
+fun SecondaryIndex::two_secondary_indexes($t0|s: &SecondaryIndex::S, $t1|b: bool): address {
+     var $t2|tmp#$2: address
+     var $t3: bool
+     var $t4: &SecondaryIndex::S
+     var $t5: &address
+     var $t6: address
+     var $t7: &SecondaryIndex::A
+     var $t8: &address
+     var $t9: address
+     var $t10: &SecondaryIndex::S
+     var $t11: &address
+     var $t12: address
+     var $t13: &SecondaryIndex::A
+     var $t14: &address
+     var $t15: address
+     var $t16: address
+  0: $t3 := copy($t1)
+  1: if ($t3) goto 4 else goto 2
+  2: label L1
+  3: goto 13
+  4: label L0
+  5: $t4 := move($t0)
+  6: $t5 := borrow_field<SecondaryIndex::S>.f($t4)
+  7: $t6 := read_ref($t5)
+  8: $t7 := borrow_global<SecondaryIndex::A>($t6)
+  9: $t8 := borrow_field<SecondaryIndex::A>.a_addr($t7)
+ 10: $t9 := read_ref($t8)
+ 11: $t2 := $t9
+ 12: goto 22
+ 13: label L2
+ 14: $t10 := move($t0)
+ 15: $t11 := borrow_field<SecondaryIndex::S>.g($t10)
+ 16: $t12 := read_ref($t11)
+ 17: $t13 := borrow_global<SecondaryIndex::A>($t12)
+ 18: $t14 := borrow_field<SecondaryIndex::A>.a_addr($t13)
+ 19: $t15 := read_ref($t14)
+ 20: $t2 := $t15
+ 21: goto 22
+ 22: label L3
+ 23: $t16 := move($t2)
+ 24: return $t16
+}
+
+
+[variant baseline]
+fun SecondaryIndex::write_both_fields($t0|c: &mut SecondaryIndex::C, $t1|b: SecondaryIndex::B, $t2|addr: address, $t3|flag: bool) {
+     var $t4: bool
+     var $t5: SecondaryIndex::B
+     var $t6: &mut SecondaryIndex::C
+     var $t7: &mut SecondaryIndex::B
+     var $t8: bool
+     var $t9: address
+     var $t10: &mut SecondaryIndex::C
+     var $t11: &mut SecondaryIndex::B
+     var $t12: &mut address
+     var $t13: &mut SecondaryIndex::C
+  0: $t4 := copy($t3)
+  1: if ($t4) goto 4 else goto 2
+  2: label L1
+  3: goto 10
+  4: label L0
+  5: $t5 := move($t1)
+  6: $t6 := copy($t0)
+  7: $t7 := borrow_field<SecondaryIndex::C>.b($t6)
+  8: write_ref($t7, $t5)
+  9: goto 10
+ 10: label L2
+ 11: $t8 := copy($t3)
+ 12: if ($t8) goto 15 else goto 13
+ 13: label L4
+ 14: goto 22
+ 15: label L3
+ 16: $t9 := copy($t2)
+ 17: $t10 := move($t0)
+ 18: $t11 := borrow_field<SecondaryIndex::C>.b($t10)
+ 19: $t12 := borrow_field<SecondaryIndex::B>.b_addr($t11)
+ 20: write_ref($t12, $t9)
+ 21: goto 26
+ 22: label L5
+ 23: $t13 := move($t0)
+ 24: destroy($t13)
+ 25: goto 26
+ 26: label L6
+ 27: return ()
+}
+
 ============ after pipeline `read_write_set` ================
+
+[variant baseline]
+fun SecondaryIndex::call_two_secondary_indexes($t0|s: &SecondaryIndex::S): address {
+     var $t1: &SecondaryIndex::S
+     var $t2: bool
+     var $t3: address
+     # Accesses:
+     # Formal(0): Read
+     # Formal(0)/f: Read
+     # Formal(0)/f/0x1::SecondaryIndex::A/a_addr: Read
+     # Formal(0)/g: Read
+     # Formal(0)/g/0x1::SecondaryIndex::A/a_addr: Read
+     #
+     # Locals:
+     # Ret(0): {Formal(0)/f/0x1::SecondaryIndex::A/a_addr, Formal(0)/g/0x1::SecondaryIndex::A/a_addr, }
+     #
+  0: $t1 := move($t0)
+  1: $t2 := true
+  2: $t3 := SecondaryIndex::two_secondary_indexes($t1, $t2)
+  3: return $t3
+}
+
 
 [variant baseline]
 fun SecondaryIndex::read_secondary_index_from_formal($t0|a: &SecondaryIndex::A): address {
@@ -108,6 +230,7 @@ fun SecondaryIndex::read_secondary_index_from_formal_interproc($t0|a_addr: addre
      # Formal(0): Read
      #
      # Locals:
+     # Ret(0): Formal(0)/0x1::SecondaryIndex::B/b_addr
      #
   0: $t2 := copy($t0)
   1: $t3 := pack SecondaryIndex::A($t2)
@@ -168,4 +291,115 @@ fun SecondaryIndex::read_secondary_index_from_global_interproc($t0|a: address): 
   1: $t2 := borrow_global<SecondaryIndex::A>($t1)
   2: $t3 := SecondaryIndex::read_secondary_index_from_formal($t2)
   3: return $t3
+}
+
+
+[variant baseline]
+fun SecondaryIndex::two_secondary_indexes($t0|s: &SecondaryIndex::S, $t1|b: bool): address {
+     var $t2|tmp#$2: address
+     var $t3: bool
+     var $t4: &SecondaryIndex::S
+     var $t5: &address
+     var $t6: address
+     var $t7: &SecondaryIndex::A
+     var $t8: &address
+     var $t9: address
+     var $t10: &SecondaryIndex::S
+     var $t11: &address
+     var $t12: address
+     var $t13: &SecondaryIndex::A
+     var $t14: &address
+     var $t15: address
+     var $t16: address
+     # Accesses:
+     # Formal(0): Read
+     # Formal(0)/f: Read
+     # Formal(0)/f/0x1::SecondaryIndex::A/a_addr: Read
+     # Formal(0)/g: Read
+     # Formal(0)/g/0x1::SecondaryIndex::A/a_addr: Read
+     # Formal(1): Read
+     #
+     # Locals:
+     # Ret(0): {Formal(0)/f/0x1::SecondaryIndex::A/a_addr, Formal(0)/g/0x1::SecondaryIndex::A/a_addr, }
+     #
+  0: $t3 := copy($t1)
+  1: if ($t3) goto 4 else goto 2
+  2: label L1
+  3: goto 13
+  4: label L0
+  5: $t4 := move($t0)
+  6: $t5 := borrow_field<SecondaryIndex::S>.f($t4)
+  7: $t6 := read_ref($t5)
+  8: $t7 := borrow_global<SecondaryIndex::A>($t6)
+  9: $t8 := borrow_field<SecondaryIndex::A>.a_addr($t7)
+ 10: $t9 := read_ref($t8)
+ 11: $t2 := $t9
+ 12: goto 22
+ 13: label L2
+ 14: $t10 := move($t0)
+ 15: $t11 := borrow_field<SecondaryIndex::S>.g($t10)
+ 16: $t12 := read_ref($t11)
+ 17: $t13 := borrow_global<SecondaryIndex::A>($t12)
+ 18: $t14 := borrow_field<SecondaryIndex::A>.a_addr($t13)
+ 19: $t15 := read_ref($t14)
+ 20: $t2 := $t15
+ 21: goto 22
+ 22: label L3
+ 23: $t16 := move($t2)
+ 24: return $t16
+}
+
+
+[variant baseline]
+fun SecondaryIndex::write_both_fields($t0|c: &mut SecondaryIndex::C, $t1|b: SecondaryIndex::B, $t2|addr: address, $t3|flag: bool) {
+     var $t4: bool
+     var $t5: SecondaryIndex::B
+     var $t6: &mut SecondaryIndex::C
+     var $t7: &mut SecondaryIndex::B
+     var $t8: bool
+     var $t9: address
+     var $t10: &mut SecondaryIndex::C
+     var $t11: &mut SecondaryIndex::B
+     var $t12: &mut address
+     var $t13: &mut SecondaryIndex::C
+     # Accesses:
+     # Formal(0): Read
+     # Formal(0)/b: Write
+     # Formal(0)/b/b_addr: Write
+     # Formal(1): Read
+     # Formal(2): Read
+     # Formal(3): Read
+     #
+     # Locals:
+     # Formal(0)/b: {Formal(0)/b, Formal(1), }
+     # Formal(0)/b/b_addr: {Formal(0)/b/b_addr, Formal(2), }
+     #
+  0: $t4 := copy($t3)
+  1: if ($t4) goto 4 else goto 2
+  2: label L1
+  3: goto 10
+  4: label L0
+  5: $t5 := move($t1)
+  6: $t6 := copy($t0)
+  7: $t7 := borrow_field<SecondaryIndex::C>.b($t6)
+  8: write_ref($t7, $t5)
+  9: goto 10
+ 10: label L2
+ 11: $t8 := copy($t3)
+ 12: if ($t8) goto 15 else goto 13
+ 13: label L4
+ 14: goto 22
+ 15: label L3
+ 16: $t9 := copy($t2)
+ 17: $t10 := move($t0)
+ 18: $t11 := borrow_field<SecondaryIndex::C>.b($t10)
+ 19: $t12 := borrow_field<SecondaryIndex::B>.b_addr($t11)
+ 20: write_ref($t12, $t9)
+ 21: goto 26
+ 22: label L5
+ 23: $t13 := move($t0)
+ 24: destroy($t13)
+ 25: goto 26
+ 26: label L6
+ 27: return ()
 }

--- a/language/move-prover/bytecode/tests/read_write_set/secondary_index.move
+++ b/language/move-prover/bytecode/tests/read_write_set/secondary_index.move
@@ -1,6 +1,8 @@
 module 0x1::SecondaryIndex {
   struct A has key, drop { a_addr: address }
-  struct B has key { b_addr: address }
+  struct B has key, drop { b_addr: address }
+  struct S { f: address, g: address }
+  struct C { b : B }
 
   fun read_secondary_index_from_formal(a: &A): address acquires B {
       borrow_global<B>(a.a_addr).b_addr
@@ -22,5 +24,26 @@ module 0x1::SecondaryIndex {
       a: address
   ): address acquires A,B {
       read_secondary_index_from_formal(borrow_global<A>(a))
+  }
+
+  fun two_secondary_indexes(s: &S, b: bool): address acquires A {
+    if (b) {
+      borrow_global<A>(s.f).a_addr
+    } else {
+      borrow_global<A>(s.g).a_addr
+    }
+  }
+
+  fun call_two_secondary_indexes(s: &S): address acquires A {
+    two_secondary_indexes(s, true)
+  }
+
+  fun write_both_fields(c: &mut C, b: B, addr: address, flag: bool) {
+    if (flag) {
+      c.b = b;
+    };
+    if (flag) {
+      c.b.b_addr = addr;
+    }
   }
 }

--- a/language/move-prover/bytecode/tests/read_write_set/simple_pack_unpack.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/simple_pack_unpack.exp
@@ -1,0 +1,70 @@
+============ initial translation from Move ================
+
+[variant baseline]
+fun SimplePackUnpack::pack_unpack($t0|a: address): address {
+     var $t1|s: SimplePackUnpack::S
+     var $t2: address
+     var $t3: SimplePackUnpack::S
+     var $t4: SimplePackUnpack::S
+     var $t5: address
+  0: $t2 := copy($t0)
+  1: $t3 := pack SimplePackUnpack::S($t2)
+  2: $t1 := $t3
+  3: $t4 := move($t1)
+  4: $t5 := SimplePackUnpack::unpack($t4)
+  5: return $t5
+}
+
+
+[variant baseline]
+fun SimplePackUnpack::unpack($t0|s: SimplePackUnpack::S): address {
+     var $t1: &SimplePackUnpack::S
+     var $t2: &address
+     var $t3: address
+  0: $t1 := borrow_local($t0)
+  1: $t2 := borrow_field<SimplePackUnpack::S>.a1($t1)
+  2: $t3 := read_ref($t2)
+  3: return $t3
+}
+
+============ after pipeline `read_write_set` ================
+
+[variant baseline]
+fun SimplePackUnpack::pack_unpack($t0|a: address): address {
+     var $t1|s: SimplePackUnpack::S
+     var $t2: address
+     var $t3: SimplePackUnpack::S
+     var $t4: SimplePackUnpack::S
+     var $t5: address
+     # Accesses:
+     # Formal(0): Read
+     #
+     # Locals:
+     # Ret(0): Formal(0)
+     #
+  0: $t2 := copy($t0)
+  1: $t3 := pack SimplePackUnpack::S($t2)
+  2: $t1 := $t3
+  3: $t4 := move($t1)
+  4: $t5 := SimplePackUnpack::unpack($t4)
+  5: return $t5
+}
+
+
+[variant baseline]
+fun SimplePackUnpack::unpack($t0|s: SimplePackUnpack::S): address {
+     var $t1: &SimplePackUnpack::S
+     var $t2: &address
+     var $t3: address
+     # Accesses:
+     # Formal(0): Read
+     # Formal(0)/a1: Read
+     #
+     # Locals:
+     # Ret(0): Formal(0)/a1
+     #
+  0: $t1 := borrow_local($t0)
+  1: $t2 := borrow_field<SimplePackUnpack::S>.a1($t1)
+  2: $t3 := read_ref($t2)
+  3: return $t3
+}

--- a/language/move-prover/bytecode/tests/read_write_set/simple_pack_unpack.move
+++ b/language/move-prover/bytecode/tests/read_write_set/simple_pack_unpack.move
@@ -1,0 +1,12 @@
+module 0x1::SimplePackUnpack {
+    struct S has drop { a1: address }
+
+    fun unpack(s: S): address {
+        s.a1
+    } // ret |-> { Formal(0)/a1 }
+
+    fun pack_unpack(a: address): address {
+        let s = S { a1: a };
+        unpack(s)
+    }  // ret |-> { Formal(0) }
+}

--- a/language/tools/read-write-set/src/dynamic_analysis.rs
+++ b/language/tools/read-write-set/src/dynamic_analysis.rs
@@ -103,13 +103,18 @@ impl ConcretizedFormals {
         type_actuals: &[Type],
         fun_env: &FunctionEnv,
     ) -> ConcretizedFormals {
-        let empty_sub_map = AccessPathTrie::default();
+        let mut sub_map = AccessPathTrie::default();
+        let mut actual_indices = vec![];
+        for (i, actual) in actuals.iter().enumerate() {
+            sub_map.bind_local(i, actual.clone(), fun_env);
+            actual_indices.push(i);
+        }
         ConcretizedFormals(ReadWriteSetState::sub_actuals(
             accesses,
-            actuals,
+            &actual_indices,
             type_actuals,
             fun_env,
-            &empty_sub_map,
+            &sub_map,
         ))
     }
 
@@ -147,8 +152,9 @@ impl ConcretizedFormals {
             } else {
                 AbsAddr::default()
             };
-            new_actuals.push(actual)
+            new_actuals.push(actual);
         }
+
         let env = fun_env.module_env.env;
         let new_type_actuals = type_actuals
             .iter()


### PR DESCRIPTION
## Motivation

During footprint in `access_paths.rs`, using `actuals` caused nested memory access to not be resolved correctly.
We now use the callee formal indices instead and when reading from the caller locals.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
yes

## Test Plan

Added e2e tests

## Related PRs

#8658 
/cc @sblackshear 

