### PR TITLE
[move-cli] Hack in address names for packages

### DIFF
--- a/language/tools/move-cli/src/sandbox/utils/mode.rs
+++ b/language/tools/move-cli/src/sandbox/utils/mode.rs
@@ -40,6 +40,7 @@ static PACKAGE_MOVE_STDLIB: Lazy<MovePackage> = Lazy::new(|| {
             },
         ],
         vec![],
+        None, // Some("Std".to_owned()),
     )
 });
 
@@ -52,6 +53,7 @@ static PACKAGE_DIEM_FRAMEWORK: Lazy<MovePackage> = Lazy::new(|| {
             exclusion: HashSet::new(),
         }],
         vec![&PACKAGE_MOVE_STDLIB],
+        None, // Some("Diem".to_owned()),
     )
 });
 

--- a/language/tools/move-cli/src/sandbox/utils/package.rs
+++ b/language/tools/move-cli/src/sandbox/utils/package.rs
@@ -75,6 +75,9 @@ pub struct MovePackage {
     sources: Vec<SourceFilter<'static>>,
     /// Dependencies
     deps: Vec<&'static Lazy<MovePackage>>,
+    /// Hack to support named addresses. Works now since our current packages only have one address
+    // TODO properly support named addresses, will require migrating to new/planned build system
+    named_address_hack: Option<String>,
 }
 
 impl MovePackage {
@@ -82,11 +85,13 @@ impl MovePackage {
         name: String,
         sources: Vec<SourceFilter<'static>>,
         deps: Vec<&'static Lazy<MovePackage>>,
+        named_address: Option<String>,
     ) -> Self {
         MovePackage {
             name,
             sources,
             deps,
+            named_address_hack: named_address,
         }
     }
 
@@ -181,8 +186,7 @@ impl MovePackage {
         })? {
             let module = CompiledModule::deserialize(&fs::read(Path::new(&entry)).unwrap())
                 .map_err(|e| anyhow!("Failure deserializing module {}: {:?}", entry, e))?;
-            // TODO support named addresses, will require migrating to new/planned build system
-            modules.push(((module.self_id(), None), module));
+            modules.push(((module.self_id(), self.named_address_hack.clone()), module));
         }
         Ok(modules)
     }


### PR DESCRIPTION
- Small hack to get named addresses in packages

## Motivation

- Should allow #8394 to finally go in. But this will need to be rethought later

## Test Plan

- Visually checked yaml file with addresses turned on. Cannot use yet until #8394 lands 