### PR TITLE
[move-lang] Migrate typing/core errors

### DIFF
--- a/language/move-lang/src/errors/diagnostic_codes.rs
+++ b/language/move-lang/src/errors/diagnostic_codes.rs
@@ -136,11 +136,22 @@ codes!(
         NamePositionMismatch: { msg: "unexpected name in this position", severity: BlockingError },
         TooManyTypeArguments: { msg: "too many type arguments", severity: NonblockingError },
         TooFewTypeArguments: { msg: "too few type arguments", severity: BlockingError },
+        UnboundVariable: { msg: "unbound variable", severity: BlockingError },
+        UnboundField: { msg: "unbound field", severity: BlockingError },
     ],
     // errors for typing rules. mostly typing/translate
-    TypeSafety: [],
+    TypeSafety: [
+        Visibility: { msg: "restricted visibility", severity: NonblockingError },
+        ScriptContext: { msg: "requires script context", severity: NonblockingError },
+        BuiltinOperation: { msg: "built-in operation not supported", severity: BlockingError },
+        ExpectedBaseType: { msg: "expected a single non-reference type", severity: BlockingError },
+        ExpectedSingleType: { msg: "expected a single type", severity: BlockingError },
+    ],
     // errors for ability rules. mostly typing/translate
-    AbilitySafety: [],
+    AbilitySafety: [
+        Constraint: { msg: "ability constraint not satisfied", severity: NonblockingError },
+        ImplicitlyCopyable: { msg: "type not implicitly copyable", severity: NonblockingError },
+    ],
     // errors for move rules. mostly cfgir/locals
     MoveSafety: [],
     // errors for move rules. mostly cfgir/borrows

--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -1785,9 +1785,8 @@ fn parse_constant_decl(
 ) -> Result<Constant, Diagnostic> {
     let Modifiers { visibility, native } = modifiers;
     if let Some(vis) = visibility {
-        let msg =
-            "Invalid constant declaration. Constants cannot have visibility modifiers as they are \
-        always internal";
+        let msg = "Invalid constant declaration. Constants cannot have visibility modifiers as \
+                   they are always internal";
         return Err(diag!(Syntax::InvalidModifier, (vis.loc().unwrap(), msg)));
     }
     if let Some(loc) = native {

--- a/language/move-lang/src/typing/translate.rs
+++ b/language/move-lang/src/typing/translate.rs
@@ -1003,7 +1003,7 @@ fn exp_inner(context: &mut Context, sp!(eloc, ne_): N::Exp) -> T::Exp {
             (ty, TE::Copy { var, from_user })
         }
         NE::Use(var) => {
-            let ty = context.get_local(eloc, "local usage", &var);
+            let ty = context.get_local(eloc, "variable usage", &var);
             (ty, TE::Use(var))
         }
 

--- a/language/move-lang/tests/move_check/expansion/assign_non_simple_name.exp
+++ b/language/move-lang/tests/move_check/expansion/assign_non_simple_name.exp
@@ -75,11 +75,9 @@ error[E01010]: syntax item restricted to spec contexts
    │         ^ Unexpected assignment of module access without fields outside of a spec context.
 If you are trying to unpack a struct, try adding fields, e.g. '0x42::M::R {}'
 
-error: 
-
-    ┌── tests/move_check/expansion/assign_non_simple_name.move:39:9 ───
-    │
- 39 │         Y = 0;
-    │         ^ Invalid assignment. Unbound local 'Y'
-    │
+error[E03009]: unbound variable
+   ┌─ tests/move_check/expansion/assign_non_simple_name.move:39:9
+   │
+39 │         Y = 0;
+   │         ^ Invalid assignment. Unbound variable 'Y'
 

--- a/language/move-lang/tests/move_check/parser/constants_simple.exp
+++ b/language/move-lang/tests/move_check/parser/constants_simple.exp
@@ -1,3 +1,9 @@
+error[E03009]: unbound variable
+  ┌─ tests/move_check/parser/constants_simple.move:8:24
+  │
+8 │     const C4: u8 = if (cond) 0 else 1;
+  │                        ^^^^ Invalid variable usage. Unbound variable 'cond'
+
 error: 
 
    ┌── tests/move_check/parser/constants_simple.move:5:21 ───
@@ -20,14 +26,6 @@ error:
    │
  8 │     const C4: u8 = if (cond) 0 else 1;
    │                    ^^^^^^^^^^^^^^^^^^ 'if' expressions are not supported in constants
-   │
-
-error: 
-
-   ┌── tests/move_check/parser/constants_simple.move:8:24 ───
-   │
- 8 │     const C4: u8 = if (cond) 0 else 1;
-   │                        ^^^^ Invalid local usage. Unbound local 'cond'
    │
 
 error: 

--- a/language/move-lang/tests/move_check/parser/spec_parsing_inside_fun.exp
+++ b/language/move-lang/tests/move_check/parser/spec_parsing_inside_fun.exp
@@ -1,13 +1,28 @@
-error: 
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/parser/spec_parsing_inside_fun.move:32:9
+   │
+32 │         spec {} + 1;
+   │         ^^^^^^^
+   │         │
+   │         Invalid argument to '+'
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
 
-    ┌── tests/move_check/parser/spec_parsing_inside_fun.move:32:9 ───
-    │
- 32 │         spec {} + 1;
-    │         ^^^^^^^ Invalid argument to '+'
-    ·
- 32 │         spec {} + 1;
-    │         ------- Found: '()'. But expected: 'u8', 'u64', 'u128'
-    │
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/parser/spec_parsing_inside_fun.move:32:19
+   │
+32 │         spec {} + 1;
+   │         -------   ^ Invalid argument to '+'
+   │         │          
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/parser/spec_parsing_inside_fun.move:34:9
+   │
+34 │         &mut spec {};
+   │         ^^^^^^^^^^^^
+   │         │    │
+   │         │    Expected a single non-reference type, but found: '()'
+   │         Invalid borrow
 
 error: 
 
@@ -21,17 +36,6 @@ error:
     ·
  32 │         spec {} + 1;
     │         ------- Is not compatible with: '()'
-    │
-
-error: 
-
-    ┌── tests/move_check/parser/spec_parsing_inside_fun.move:32:19 ───
-    │
- 32 │         spec {} + 1;
-    │                   ^ Invalid argument to '+'
-    ·
- 32 │         spec {} + 1;
-    │         ------- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -60,16 +64,5 @@ error:
     ·
  33 │         spec {} && spec {};
     │         ------- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/parser/spec_parsing_inside_fun.move:34:9 ───
-    │
- 34 │         &mut spec {};
-    │         ^^^^^^^^^^^^ Invalid borrow
-    ·
- 34 │         &mut spec {};
-    │              ------- Expected a single non-reference type, but found: '()'
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/commands/no_let_outside_if.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/commands/no_let_outside_if.exp
@@ -1,24 +1,18 @@
-error: 
+error[E03009]: unbound variable
+  ┌─ tests/move_check/translated_ir_tests/move/commands/no_let_outside_if.move:4:9
+  │
+4 │         y = 5;
+  │         ^ Invalid assignment. Unbound variable 'y'
 
-   ┌── tests/move_check/translated_ir_tests/move/commands/no_let_outside_if.move:4:9 ───
-   │
- 4 │         y = 5;
-   │         ^ Invalid assignment. Unbound local 'y'
-   │
+error[E03009]: unbound variable
+  ┌─ tests/move_check/translated_ir_tests/move/commands/no_let_outside_if.move:6:9
+  │
+6 │         y = 0;
+  │         ^ Invalid assignment. Unbound variable 'y'
 
-error: 
-
-   ┌── tests/move_check/translated_ir_tests/move/commands/no_let_outside_if.move:6:9 ───
-   │
- 6 │         y = 0;
-   │         ^ Invalid assignment. Unbound local 'y'
-   │
-
-error: 
-
-   ┌── tests/move_check/translated_ir_tests/move/commands/no_let_outside_if.move:8:12 ───
-   │
- 8 │     assert(y == 5, 42);
-   │            ^ Invalid local usage. Unbound local 'y'
-   │
+error[E03009]: unbound variable
+  ┌─ tests/move_check/translated_ir_tests/move/commands/no_let_outside_if.move:8:12
+  │
+8 │     assert(y == 5, 42);
+  │            ^ Invalid variable usage. Unbound variable 'y'
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/commands/pop_weird.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/commands/pop_weird.exp
@@ -1,3 +1,11 @@
+error[E04005]: expected a single type
+   ┌─ tests/move_check/translated_ir_tests/move/commands/pop_weird.move:14:9
+   │
+14 │         (_) = ();
+   │         ^^^   -- Expected a single type, but found expression list type: '()'
+   │         │      
+   │         Invalid type for local
+
 error: 
 
     ┌── tests/move_check/translated_ir_tests/move/commands/pop_weird.move:13:9 ───
@@ -10,16 +18,5 @@ error:
     ·
  13 │         (_, _) = ();
     │                  -- Is not compatible with: '()'
-    │
-
-error: 
-
-    ┌── tests/move_check/translated_ir_tests/move/commands/pop_weird.move:14:9 ───
-    │
- 14 │         (_) = ();
-    │         ^^^ Invalid type for local
-    ·
- 14 │         (_) = ();
-    │               -- Expected a single type, but found expression list type: '()'
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/operators/casting_operators_types_mismatch.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/operators/casting_operators_types_mismatch.exp
@@ -1,88 +1,72 @@
-error: 
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/translated_ir_tests/move/operators/casting_operators_types_mismatch.move:4:10
+  │
+4 │         (S { x: true } as u8);
+  │          ^^^^^^^^^^^^^
+  │          │
+  │          Invalid argument to 'as'
+  │          Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
 
-   ┌── tests/move_check/translated_ir_tests/move/operators/casting_operators_types_mismatch.move:4:10 ───
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/translated_ir_tests/move/operators/casting_operators_types_mismatch.move:5:10
+  │
+5 │         (S { x: true } as u64);
+  │          ^^^^^^^^^^^^^
+  │          │
+  │          Invalid argument to 'as'
+  │          Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/translated_ir_tests/move/operators/casting_operators_types_mismatch.move:6:10
+  │
+6 │         (S { x: true } as u128);
+  │          ^^^^^^^^^^^^^
+  │          │
+  │          Invalid argument to 'as'
+  │          Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/translated_ir_tests/move/operators/casting_operators_types_mismatch.move:7:10
+  │
+7 │         (true as u8);
+  │          ^^^^
+  │          │
+  │          Invalid argument to 'as'
+  │          Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/translated_ir_tests/move/operators/casting_operators_types_mismatch.move:8:10
+  │
+8 │         (true as u64);
+  │          ^^^^
+  │          │
+  │          Invalid argument to 'as'
+  │          Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/translated_ir_tests/move/operators/casting_operators_types_mismatch.move:9:10
+  │
+9 │         (true as u128);
+  │          ^^^^
+  │          │
+  │          Invalid argument to 'as'
+  │          Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/translated_ir_tests/move/operators/casting_operators_types_mismatch.move:10:10
    │
- 4 │         (S { x: true } as u8);
-   │          ^^^^^^^^^^^^^ Invalid argument to 'as'
-   ·
- 4 │         (S { x: true } as u8);
-   │          ------------- Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+10 │         (@0x0 as u64);
+   │          ^^^^
+   │          │
+   │          Invalid argument to 'as'
+   │          Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/translated_ir_tests/move/operators/casting_operators_types_mismatch.move:11:10
    │
-
-error: 
-
-   ┌── tests/move_check/translated_ir_tests/move/operators/casting_operators_types_mismatch.move:5:10 ───
-   │
- 5 │         (S { x: true } as u64);
-   │          ^^^^^^^^^^^^^ Invalid argument to 'as'
-   ·
- 5 │         (S { x: true } as u64);
-   │          ------------- Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-   │
-
-error: 
-
-   ┌── tests/move_check/translated_ir_tests/move/operators/casting_operators_types_mismatch.move:6:10 ───
-   │
- 6 │         (S { x: true } as u128);
-   │          ^^^^^^^^^^^^^ Invalid argument to 'as'
-   ·
- 6 │         (S { x: true } as u128);
-   │          ------------- Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-   │
-
-error: 
-
-   ┌── tests/move_check/translated_ir_tests/move/operators/casting_operators_types_mismatch.move:7:10 ───
-   │
- 7 │         (true as u8);
-   │          ^^^^ Invalid argument to 'as'
-   ·
- 7 │         (true as u8);
-   │          ---- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-   │
-
-error: 
-
-   ┌── tests/move_check/translated_ir_tests/move/operators/casting_operators_types_mismatch.move:8:10 ───
-   │
- 8 │         (true as u64);
-   │          ^^^^ Invalid argument to 'as'
-   ·
- 8 │         (true as u64);
-   │          ---- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-   │
-
-error: 
-
-   ┌── tests/move_check/translated_ir_tests/move/operators/casting_operators_types_mismatch.move:9:10 ───
-   │
- 9 │         (true as u128);
-   │          ^^^^ Invalid argument to 'as'
-   ·
- 9 │         (true as u128);
-   │          ---- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-   │
-
-error: 
-
-    ┌── tests/move_check/translated_ir_tests/move/operators/casting_operators_types_mismatch.move:10:10 ───
-    │
- 10 │         (@0x0 as u64);
-    │          ^^^^ Invalid argument to 'as'
-    ·
- 10 │         (@0x0 as u64);
-    │          ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/translated_ir_tests/move/operators/casting_operators_types_mismatch.move:11:10 ───
-    │
- 11 │         (@0x0 as u128);
-    │          ^^^^ Invalid argument to 'as'
-    ·
- 11 │         (@0x0 as u128);
-    │          ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
+11 │         (@0x0 as u128);
+   │          ^^^^
+   │          │
+   │          Invalid argument to 'as'
+   │          Found: 'address'. But expected: 'u8', 'u64', 'u128'
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/signer/address_arg_is_not_signer.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/signer/address_arg_is_not_signer.exp
@@ -1,13 +1,11 @@
-error: 
-
-   ┌── tests/move_check/translated_ir_tests/move/signer/address_arg_is_not_signer.move:3:27 ───
-   │
- 3 │     struct R has key { s: signer }
-   │                           ^^^^^^ Invalid field type. The struct was declared with the ability 'key' so all fields require the ability 'store'
-   ·
- 3 │     struct R has key { s: signer }
-   │                           ------ The type 'signer' does not have the ability 'store'
-   │
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/translated_ir_tests/move/signer/address_arg_is_not_signer.move:3:27
+  │
+3 │     struct R has key { s: signer }
+  │                           ^^^^^^
+  │                           │
+  │                           Invalid field type. The struct was declared with the ability 'key' so all fields require the ability 'store'
+  │                           The type 'signer' does not have the ability 'store'
 
 error: 
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/signer/copy_loc.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/signer/copy_loc.exp
@@ -1,11 +1,8 @@
-error: 
-
-   ┌── tests/move_check/translated_ir_tests/move/signer/copy_loc.move:3:9 ───
-   │
- 3 │         copy s
-   │         ^^^^^^ Invalid 'copy' of owned value without the 'copy' ability
-   ·
- 2 │     fun t(s: signer): signer {
-   │              ------ The type 'signer' does not have the ability 'copy'
-   │
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/translated_ir_tests/move/signer/copy_loc.move:3:9
+  │
+2 │     fun t(s: signer): signer {
+  │              ------ The type 'signer' does not have the ability 'copy'
+3 │         copy s
+  │         ^^^^^^ Invalid 'copy' of owned value without the 'copy' ability
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/signer/copy_loc_transitive.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/signer/copy_loc_transitive.exp
@@ -1,14 +1,11 @@
-error: 
-
-   ┌── tests/move_check/translated_ir_tests/move/signer/copy_loc_transitive.move:5:9 ───
-   │
- 5 │         copy x
-   │         ^^^^^^ Invalid 'copy' of owned value without the 'copy' ability
-   ·
- 4 │         let x = S<signer> { s };
-   │                 --------------- The type '0x8675309::M::S<signer>' does not have the ability 'copy'
-   ·
- 4 │         let x = S<signer> { s };
-   │                   ------ The type '0x8675309::M::S<signer>' can have the ability 'copy' but the type argument 'signer' does not have the required ability 'copy'
-   │
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/translated_ir_tests/move/signer/copy_loc_transitive.move:5:9
+  │
+4 │         let x = S<signer> { s };
+  │                 ---------------
+  │                 │ │
+  │                 │ The type '0x8675309::M::S<signer>' can have the ability 'copy' but the type argument 'signer' does not have the required ability 'copy'
+  │                 The type '0x8675309::M::S<signer>' does not have the ability 'copy'
+5 │         copy x
+  │         ^^^^^^ Invalid 'copy' of owned value without the 'copy' ability
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/signer/does_not_have_store.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/signer/does_not_have_store.exp
@@ -1,22 +1,16 @@
-error: 
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/translated_ir_tests/move/signer/does_not_have_store.move:5:9
+  │
+5 │         move_to(account, S<signer> {})
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │         │                │ │
+  │         │                │ The type '0x8675309::M::S<signer>' can have the ability 'key' but the type argument 'signer' does not have the required ability 'store'
+  │         │                The type '0x8675309::M::S<signer>' does not have the ability 'key'
+  │         Invalid call of 'move_to'
 
-   ┌── tests/move_check/translated_ir_tests/move/signer/does_not_have_store.move:5:9 ───
-   │
- 5 │         move_to(account, S<signer> {})
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_to'
-   ·
- 5 │         move_to(account, S<signer> {})
-   │                          ------------ The type '0x8675309::M::S<signer>' does not have the ability 'key'
-   ·
- 5 │         move_to(account, S<signer> {})
-   │                            ------ The type '0x8675309::M::S<signer>' can have the ability 'key' but the type argument 'signer' does not have the required ability 'store'
-   │
-
-error: 
-
-   ┌── tests/move_check/translated_ir_tests/move/signer/does_not_have_store.move:5:17 ───
-   │
- 5 │         move_to(account, S<signer> {})
-   │                 ^^^^^^^ Invalid local usage. Unbound local 'account'
-   │
+error[E03009]: unbound variable
+  ┌─ tests/move_check/translated_ir_tests/move/signer/does_not_have_store.move:5:17
+  │
+5 │         move_to(account, S<signer> {})
+  │                 ^^^^^^^ Invalid variable usage. Unbound variable 'account'
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/signer/invalid_move_to_sender.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/signer/invalid_move_to_sender.exp
@@ -1,24 +1,20 @@
-error: 
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/translated_ir_tests/move/signer/invalid_move_to_sender.move:3:9
+  │
+3 │         move_to<signer>(s1, move s)
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │         │       │
+  │         │       The type 'signer' does not have the ability 'key'
+  │         Invalid call of 'move_to'
 
-   ┌── tests/move_check/translated_ir_tests/move/signer/invalid_move_to_sender.move:3:9 ───
-   │
- 3 │         move_to<signer>(s1, move s)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_to'
-   ·
- 3 │         move_to<signer>(s1, move s)
-   │                 ------ The type 'signer' does not have the ability 'key'
-   │
-
-error: 
-
-   ┌── tests/move_check/translated_ir_tests/move/signer/invalid_move_to_sender.move:8:27 ───
-   │
- 8 │     struct R has key { s: signer }
-   │                           ^^^^^^ Invalid field type. The struct was declared with the ability 'key' so all fields require the ability 'store'
-   ·
- 8 │     struct R has key { s: signer }
-   │                           ------ The type 'signer' does not have the ability 'store'
-   │
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/translated_ir_tests/move/signer/invalid_move_to_sender.move:8:27
+  │
+8 │     struct R has key { s: signer }
+  │                           ^^^^^^
+  │                           │
+  │                           Invalid field type. The struct was declared with the ability 'key' so all fields require the ability 'store'
+  │                           The type 'signer' does not have the ability 'store'
 
 error: 
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/signer/move_to_non_resource.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/signer/move_to_non_resource.exp
@@ -1,28 +1,24 @@
-error: 
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/translated_ir_tests/move/signer/move_to_non_resource.move:4:9
+  │
+2 │     struct R { f: bool }
+  │            - To satisfy the constraint, the 'key' ability would need to be added here
+3 │     fun t0(s: &signer) {
+4 │         move_to(s, R { f: false })
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │         │          │
+  │         │          The type '0x8675309::M::R' does not have the ability 'key'
+  │         Invalid call of 'move_to'
 
-   ┌── tests/move_check/translated_ir_tests/move/signer/move_to_non_resource.move:4:9 ───
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/translated_ir_tests/move/signer/move_to_non_resource.move:14:14
    │
- 4 │         move_to(s, R { f: false })
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_to'
-   ·
- 4 │         move_to(s, R { f: false })
-   │                    -------------- The type '0x8675309::M::R' does not have the ability 'key'
-   ·
- 2 │     struct R { f: bool }
+12 │     struct R<T> { f: T }
    │            - To satisfy the constraint, the 'key' ability would need to be added here
-   │
-
-error: 
-
-    ┌── tests/move_check/translated_ir_tests/move/signer/move_to_non_resource.move:14:14 ───
-    │
- 14 │         () = move_to(s, R { f: false })
-    │              ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_to'
-    ·
- 14 │         () = move_to(s, R { f: false })
-    │                         -------------- The type '0x8675309::N::R<bool>' does not have the ability 'key'
-    ·
- 12 │     struct R<T> { f: T }
-    │            - To satisfy the constraint, the 'key' ability would need to be added here
-    │
+13 │     fun t0<T: store>(s: &signer) {
+14 │         () = move_to(s, R { f: false })
+   │              ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │              │          │
+   │              │          The type '0x8675309::N::R<bool>' does not have the ability 'key'
+   │              Invalid call of 'move_to'
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/signer/move_to_non_struct.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/signer/move_to_non_struct.exp
@@ -1,13 +1,11 @@
-error: 
-
-   ┌── tests/move_check/translated_ir_tests/move/signer/move_to_non_struct.move:3:9 ───
-   │
- 3 │         move_to<u64>(s, 0)
-   │         ^^^^^^^^^^^^^^^^^^ Invalid call of 'move_to'
-   ·
- 3 │         move_to<u64>(s, 0)
-   │                 --- The type 'u64' does not have the ability 'key'
-   │
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/translated_ir_tests/move/signer/move_to_non_struct.move:3:9
+  │
+3 │         move_to<u64>(s, 0)
+  │         ^^^^^^^^^^^^^^^^^^
+  │         │       │
+  │         │       The type 'u64' does not have the ability 'key'
+  │         Invalid call of 'move_to'
 
 error: 
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/signer/read_ref.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/signer/read_ref.exp
@@ -1,11 +1,8 @@
-error: 
-
-   ┌── tests/move_check/translated_ir_tests/move/signer/read_ref.move:3:9 ───
-   │
- 3 │         *s
-   │         ^^ Invalid dereference. Dereference requires the 'copy' ability
-   ·
- 2 │     fun t(s: &signer): signer {
-   │               ------ The type 'signer' does not have the ability 'copy'
-   │
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/translated_ir_tests/move/signer/read_ref.move:3:9
+  │
+2 │     fun t(s: &signer): signer {
+  │               ------ The type 'signer' does not have the ability 'copy'
+3 │         *s
+  │         ^^ Invalid dereference. Dereference requires the 'copy' ability
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/signer/read_ref_transitive.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/signer/read_ref_transitive.exp
@@ -1,25 +1,19 @@
-error: 
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/translated_ir_tests/move/signer/read_ref_transitive.move:5:9
+  │
+4 │         let x = S<signer> { s };
+  │                 ---------------
+  │                 │ │
+  │                 │ The type '0x8675309::M::S<signer>' can have the ability 'copy' but the type argument 'signer' does not have the required ability 'copy'
+  │                 The type '0x8675309::M::S<signer>' does not have the ability 'copy'
+5 │         *&x
+  │         ^^^ Invalid dereference. Dereference requires the 'copy' ability
 
-   ┌── tests/move_check/translated_ir_tests/move/signer/read_ref_transitive.move:5:9 ───
+error[E05002]: type not implicitly copyable
+   ┌─ tests/move_check/translated_ir_tests/move/signer/read_ref_transitive.move:15:9
    │
- 5 │         *&x
-   │         ^^^ Invalid dereference. Dereference requires the 'copy' ability
-   ·
- 4 │         let x = S<signer> { s };
-   │                 --------------- The type '0x8675309::M::S<signer>' does not have the ability 'copy'
-   ·
- 4 │         let x = S<signer> { s };
-   │                   ------ The type '0x8675309::M::S<signer>' can have the ability 'copy' but the type argument 'signer' does not have the required ability 'copy'
-   │
-
-error: 
-
-    ┌── tests/move_check/translated_ir_tests/move/signer/read_ref_transitive.move:15:9 ───
-    │
- 15 │         x.s
-    │         ^^^ Invalid implicit copy of field 's'. Try adding '*&' to the front of the field access
-    ·
- 14 │         let x = S<signer> { s };
-    │                   ------ The type 'signer' is not implicitly copyable. Implicit copies are limited to simple primitive values
-    │
+14 │         let x = S<signer> { s };
+   │                   ------ The type 'signer' is not implicitly copyable. Implicit copies are limited to simple primitive values
+15 │         x.s
+   │         ^^^ Invalid implicit copy of field 's'. Try adding '*&' to the front of the field access
 

--- a/language/move-lang/tests/move_check/typing/ability_constraint_prims_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/ability_constraint_prims_invalid.exp
@@ -1,600 +1,479 @@
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:20:9 ───
-    │
- 20 │         c<signer>();
-    │         ^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 20 │         c<signer>();
-    │           ------ The type 'signer' does not have the ability 'copy'
-    ·
-  9 │     fun c<T: copy>() {}
-    │              ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:21:9 ───
-    │
- 21 │         c<vector<signer>>();
-    │         ^^^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 21 │         c<vector<signer>>();
-    │           -------------- The type 'vector<signer>' does not have the ability 'copy'
-    ·
- 21 │         c<vector<signer>>();
-    │                  ------ The type 'vector<signer>' can have the ability 'copy' but the type argument 'signer' does not have the required ability 'copy'
-    ·
-  9 │     fun c<T: copy>() {}
-    │              ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:22:9 ───
-    │
- 22 │         c<vector<NoC>>();
-    │         ^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 22 │         c<vector<NoC>>();
-    │           ----------- The type 'vector<0x42::M::NoC>' does not have the ability 'copy'
-    ·
- 22 │         c<vector<NoC>>();
-    │                  --- The type 'vector<0x42::M::NoC>' can have the ability 'copy' but the type argument '0x42::M::NoC' does not have the required ability 'copy'
-    ·
-  9 │     fun c<T: copy>() {}
-    │              ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:23:9 ───
-    │
- 23 │         k<u64>();
-    │         ^^^^^^^^ 'key' constraint not satisifed
-    ·
- 23 │         k<u64>();
-    │           --- The type 'u64' does not have the ability 'key'
-    ·
- 10 │     fun k<T: key>() {}
-    │              --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:24:9 ───
-    │
- 24 │         k<signer>();
-    │         ^^^^^^^^^^^ 'key' constraint not satisifed
-    ·
- 24 │         k<signer>();
-    │           ------ The type 'signer' does not have the ability 'key'
-    ·
- 10 │     fun k<T: key>() {}
-    │              --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:25:9 ───
-    │
- 25 │         k<vector<NoC>>();
-    │         ^^^^^^^^^^^^^^^^ 'key' constraint not satisifed
-    ·
- 25 │         k<vector<NoC>>();
-    │           ----------- The type 'vector<0x42::M::NoC>' does not have the ability 'key'
-    ·
- 10 │     fun k<T: key>() {}
-    │              --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:26:9 ───
-    │
- 26 │         k<vector<NoK>>();
-    │         ^^^^^^^^^^^^^^^^ 'key' constraint not satisifed
-    ·
- 26 │         k<vector<NoK>>();
-    │           ----------- The type 'vector<0x42::M::NoK>' does not have the ability 'key'
-    ·
- 10 │     fun k<T: key>() {}
-    │              --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:27:9 ───
-    │
- 27 │         cds<signer>();
-    │         ^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 27 │         cds<signer>();
-    │             ------ The type 'signer' does not have the ability 'copy'
-    ·
- 11 │     fun cds<T: copy + drop + store>() {}
-    │                ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:27:9 ───
-    │
- 27 │         cds<signer>();
-    │         ^^^^^^^^^^^^^ 'store' constraint not satisifed
-    ·
- 27 │         cds<signer>();
-    │             ------ The type 'signer' does not have the ability 'store'
-    ·
- 11 │     fun cds<T: copy + drop + store>() {}
-    │                              ----- 'store' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:28:9 ───
-    │
- 28 │         cds<vector<NoC>>();
-    │         ^^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 28 │         cds<vector<NoC>>();
-    │             ----------- The type 'vector<0x42::M::NoC>' does not have the ability 'copy'
-    ·
- 28 │         cds<vector<NoC>>();
-    │                    --- The type 'vector<0x42::M::NoC>' can have the ability 'copy' but the type argument '0x42::M::NoC' does not have the required ability 'copy'
-    ·
- 11 │     fun cds<T: copy + drop + store>() {}
-    │                ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:29:9 ───
-    │
- 29 │         cds<vector<Cup<u8>>>();
-    │         ^^^^^^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 29 │         cds<vector<Cup<u8>>>();
-    │             --------------- The type 'vector<0x42::M::Cup<u8>>' does not have the ability 'copy'
-    ·
- 29 │         cds<vector<Cup<u8>>>();
-    │                    ------- The type 'vector<0x42::M::Cup<u8>>' can have the ability 'copy' but the type argument '0x42::M::Cup<u8>' does not have the required ability 'copy'
-    ·
- 11 │     fun cds<T: copy + drop + store>() {}
-    │                ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:29:9 ───
-    │
- 29 │         cds<vector<Cup<u8>>>();
-    │         ^^^^^^^^^^^^^^^^^^^^^^ 'drop' constraint not satisifed
-    ·
- 29 │         cds<vector<Cup<u8>>>();
-    │             --------------- The type 'vector<0x42::M::Cup<u8>>' does not have the ability 'drop'
-    ·
- 29 │         cds<vector<Cup<u8>>>();
-    │                    ------- The type 'vector<0x42::M::Cup<u8>>' can have the ability 'drop' but the type argument '0x42::M::Cup<u8>' does not have the required ability 'drop'
-    ·
- 11 │     fun cds<T: copy + drop + store>() {}
-    │                       ---- 'drop' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:29:9 ───
-    │
- 29 │         cds<vector<Cup<u8>>>();
-    │         ^^^^^^^^^^^^^^^^^^^^^^ 'store' constraint not satisifed
-    ·
- 29 │         cds<vector<Cup<u8>>>();
-    │             --------------- The type 'vector<0x42::M::Cup<u8>>' does not have the ability 'store'
-    ·
- 29 │         cds<vector<Cup<u8>>>();
-    │                    ------- The type 'vector<0x42::M::Cup<u8>>' can have the ability 'store' but the type argument '0x42::M::Cup<u8>' does not have the required ability 'store'
-    ·
- 11 │     fun cds<T: copy + drop + store>() {}
-    │                              ----- 'store' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:30:13 ───
-    │
- 30 │         let Sc {} = Sc<signer> {};
-    │             ^^^^^ 'copy' constraint not satisifed
-    ·
- 30 │         let Sc {} = Sc<signer> {};
-    │                        ------ The type 'signer' does not have the ability 'copy'
-    ·
- 13 │     struct Sc<T: copy> {}
-    │                  ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:30:21 ───
-    │
- 30 │         let Sc {} = Sc<signer> {};
-    │                     ^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 30 │         let Sc {} = Sc<signer> {};
-    │                        ------ The type 'signer' does not have the ability 'copy'
-    ·
- 13 │     struct Sc<T: copy> {}
-    │                  ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:31:13 ───
-    │
- 31 │         let Sc {} = Sc<vector<signer>> {};
-    │             ^^^^^ 'copy' constraint not satisifed
-    ·
- 31 │         let Sc {} = Sc<vector<signer>> {};
-    │                        -------------- The type 'vector<signer>' does not have the ability 'copy'
-    ·
- 31 │         let Sc {} = Sc<vector<signer>> {};
-    │                               ------ The type 'vector<signer>' can have the ability 'copy' but the type argument 'signer' does not have the required ability 'copy'
-    ·
- 13 │     struct Sc<T: copy> {}
-    │                  ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:31:21 ───
-    │
- 31 │         let Sc {} = Sc<vector<signer>> {};
-    │                     ^^^^^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 31 │         let Sc {} = Sc<vector<signer>> {};
-    │                        -------------- The type 'vector<signer>' does not have the ability 'copy'
-    ·
- 31 │         let Sc {} = Sc<vector<signer>> {};
-    │                               ------ The type 'vector<signer>' can have the ability 'copy' but the type argument 'signer' does not have the required ability 'copy'
-    ·
- 13 │     struct Sc<T: copy> {}
-    │                  ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:32:13 ───
-    │
- 32 │         let Sc {} = Sc<vector<NoC>> {};
-    │             ^^^^^ 'copy' constraint not satisifed
-    ·
- 32 │         let Sc {} = Sc<vector<NoC>> {};
-    │                        ----------- The type 'vector<0x42::M::NoC>' does not have the ability 'copy'
-    ·
- 32 │         let Sc {} = Sc<vector<NoC>> {};
-    │                               --- The type 'vector<0x42::M::NoC>' can have the ability 'copy' but the type argument '0x42::M::NoC' does not have the required ability 'copy'
-    ·
- 13 │     struct Sc<T: copy> {}
-    │                  ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:32:21 ───
-    │
- 32 │         let Sc {} = Sc<vector<NoC>> {};
-    │                     ^^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 32 │         let Sc {} = Sc<vector<NoC>> {};
-    │                        ----------- The type 'vector<0x42::M::NoC>' does not have the ability 'copy'
-    ·
- 32 │         let Sc {} = Sc<vector<NoC>> {};
-    │                               --- The type 'vector<0x42::M::NoC>' can have the ability 'copy' but the type argument '0x42::M::NoC' does not have the required ability 'copy'
-    ·
- 13 │     struct Sc<T: copy> {}
-    │                  ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:33:13 ───
-    │
- 33 │         let Sk {} = Sk<u64> {};
-    │             ^^^^^ 'key' constraint not satisifed
-    ·
- 33 │         let Sk {} = Sk<u64> {};
-    │                        --- The type 'u64' does not have the ability 'key'
-    ·
- 14 │     struct Sk<T: key> {}
-    │                  --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:33:21 ───
-    │
- 33 │         let Sk {} = Sk<u64> {};
-    │                     ^^^^^^^^^^ 'key' constraint not satisifed
-    ·
- 33 │         let Sk {} = Sk<u64> {};
-    │                        --- The type 'u64' does not have the ability 'key'
-    ·
- 14 │     struct Sk<T: key> {}
-    │                  --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:34:13 ───
-    │
- 34 │         let Sk {} = Sk<signer> {};
-    │             ^^^^^ 'key' constraint not satisifed
-    ·
- 34 │         let Sk {} = Sk<signer> {};
-    │                        ------ The type 'signer' does not have the ability 'key'
-    ·
- 14 │     struct Sk<T: key> {}
-    │                  --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:34:21 ───
-    │
- 34 │         let Sk {} = Sk<signer> {};
-    │                     ^^^^^^^^^^^^^ 'key' constraint not satisifed
-    ·
- 34 │         let Sk {} = Sk<signer> {};
-    │                        ------ The type 'signer' does not have the ability 'key'
-    ·
- 14 │     struct Sk<T: key> {}
-    │                  --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:35:13 ───
-    │
- 35 │         let Sk {} = Sk<vector<NoC>> {};
-    │             ^^^^^ 'key' constraint not satisifed
-    ·
- 35 │         let Sk {} = Sk<vector<NoC>> {};
-    │                        ----------- The type 'vector<0x42::M::NoC>' does not have the ability 'key'
-    ·
- 14 │     struct Sk<T: key> {}
-    │                  --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:35:21 ───
-    │
- 35 │         let Sk {} = Sk<vector<NoC>> {};
-    │                     ^^^^^^^^^^^^^^^^^^ 'key' constraint not satisifed
-    ·
- 35 │         let Sk {} = Sk<vector<NoC>> {};
-    │                        ----------- The type 'vector<0x42::M::NoC>' does not have the ability 'key'
-    ·
- 14 │     struct Sk<T: key> {}
-    │                  --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:36:13 ───
-    │
- 36 │         let Sk {} = Sk<vector<NoK>> {};
-    │             ^^^^^ 'key' constraint not satisifed
-    ·
- 36 │         let Sk {} = Sk<vector<NoK>> {};
-    │                        ----------- The type 'vector<0x42::M::NoK>' does not have the ability 'key'
-    ·
- 14 │     struct Sk<T: key> {}
-    │                  --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:36:21 ───
-    │
- 36 │         let Sk {} = Sk<vector<NoK>> {};
-    │                     ^^^^^^^^^^^^^^^^^^ 'key' constraint not satisifed
-    ·
- 36 │         let Sk {} = Sk<vector<NoK>> {};
-    │                        ----------- The type 'vector<0x42::M::NoK>' does not have the ability 'key'
-    ·
- 14 │     struct Sk<T: key> {}
-    │                  --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:37:13 ───
-    │
- 37 │         let Scds {} = Scds<signer> {};
-    │             ^^^^^^^ 'copy' constraint not satisifed
-    ·
- 37 │         let Scds {} = Scds<signer> {};
-    │                            ------ The type 'signer' does not have the ability 'copy'
-    ·
- 15 │     struct Scds<T: copy + drop + store> {}
-    │                    ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:37:13 ───
-    │
- 37 │         let Scds {} = Scds<signer> {};
-    │             ^^^^^^^ 'store' constraint not satisifed
-    ·
- 37 │         let Scds {} = Scds<signer> {};
-    │                            ------ The type 'signer' does not have the ability 'store'
-    ·
- 15 │     struct Scds<T: copy + drop + store> {}
-    │                                  ----- 'store' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:37:23 ───
-    │
- 37 │         let Scds {} = Scds<signer> {};
-    │                       ^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 37 │         let Scds {} = Scds<signer> {};
-    │                            ------ The type 'signer' does not have the ability 'copy'
-    ·
- 15 │     struct Scds<T: copy + drop + store> {}
-    │                    ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:37:23 ───
-    │
- 37 │         let Scds {} = Scds<signer> {};
-    │                       ^^^^^^^^^^^^^^^ 'store' constraint not satisifed
-    ·
- 37 │         let Scds {} = Scds<signer> {};
-    │                            ------ The type 'signer' does not have the ability 'store'
-    ·
- 15 │     struct Scds<T: copy + drop + store> {}
-    │                                  ----- 'store' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:38:13 ───
-    │
- 38 │         let Scds {} = Scds<vector<NoC>> {};
-    │             ^^^^^^^ 'copy' constraint not satisifed
-    ·
- 38 │         let Scds {} = Scds<vector<NoC>> {};
-    │                            ----------- The type 'vector<0x42::M::NoC>' does not have the ability 'copy'
-    ·
- 38 │         let Scds {} = Scds<vector<NoC>> {};
-    │                                   --- The type 'vector<0x42::M::NoC>' can have the ability 'copy' but the type argument '0x42::M::NoC' does not have the required ability 'copy'
-    ·
- 15 │     struct Scds<T: copy + drop + store> {}
-    │                    ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:38:23 ───
-    │
- 38 │         let Scds {} = Scds<vector<NoC>> {};
-    │                       ^^^^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 38 │         let Scds {} = Scds<vector<NoC>> {};
-    │                            ----------- The type 'vector<0x42::M::NoC>' does not have the ability 'copy'
-    ·
- 38 │         let Scds {} = Scds<vector<NoC>> {};
-    │                                   --- The type 'vector<0x42::M::NoC>' can have the ability 'copy' but the type argument '0x42::M::NoC' does not have the required ability 'copy'
-    ·
- 15 │     struct Scds<T: copy + drop + store> {}
-    │                    ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:39:13 ───
-    │
- 39 │         let Scds {} = Scds<vector<Cup<u8>>> {};
-    │             ^^^^^^^ 'copy' constraint not satisifed
-    ·
- 39 │         let Scds {} = Scds<vector<Cup<u8>>> {};
-    │                            --------------- The type 'vector<0x42::M::Cup<u8>>' does not have the ability 'copy'
-    ·
- 39 │         let Scds {} = Scds<vector<Cup<u8>>> {};
-    │                                   ------- The type 'vector<0x42::M::Cup<u8>>' can have the ability 'copy' but the type argument '0x42::M::Cup<u8>' does not have the required ability 'copy'
-    ·
- 15 │     struct Scds<T: copy + drop + store> {}
-    │                    ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:39:13 ───
-    │
- 39 │         let Scds {} = Scds<vector<Cup<u8>>> {};
-    │             ^^^^^^^ 'drop' constraint not satisifed
-    ·
- 39 │         let Scds {} = Scds<vector<Cup<u8>>> {};
-    │                            --------------- The type 'vector<0x42::M::Cup<u8>>' does not have the ability 'drop'
-    ·
- 39 │         let Scds {} = Scds<vector<Cup<u8>>> {};
-    │                                   ------- The type 'vector<0x42::M::Cup<u8>>' can have the ability 'drop' but the type argument '0x42::M::Cup<u8>' does not have the required ability 'drop'
-    ·
- 15 │     struct Scds<T: copy + drop + store> {}
-    │                           ---- 'drop' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:39:13 ───
-    │
- 39 │         let Scds {} = Scds<vector<Cup<u8>>> {};
-    │             ^^^^^^^ 'store' constraint not satisifed
-    ·
- 39 │         let Scds {} = Scds<vector<Cup<u8>>> {};
-    │                            --------------- The type 'vector<0x42::M::Cup<u8>>' does not have the ability 'store'
-    ·
- 39 │         let Scds {} = Scds<vector<Cup<u8>>> {};
-    │                                   ------- The type 'vector<0x42::M::Cup<u8>>' can have the ability 'store' but the type argument '0x42::M::Cup<u8>' does not have the required ability 'store'
-    ·
- 15 │     struct Scds<T: copy + drop + store> {}
-    │                                  ----- 'store' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:39:23 ───
-    │
- 39 │         let Scds {} = Scds<vector<Cup<u8>>> {};
-    │                       ^^^^^^^^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 39 │         let Scds {} = Scds<vector<Cup<u8>>> {};
-    │                            --------------- The type 'vector<0x42::M::Cup<u8>>' does not have the ability 'copy'
-    ·
- 39 │         let Scds {} = Scds<vector<Cup<u8>>> {};
-    │                                   ------- The type 'vector<0x42::M::Cup<u8>>' can have the ability 'copy' but the type argument '0x42::M::Cup<u8>' does not have the required ability 'copy'
-    ·
- 15 │     struct Scds<T: copy + drop + store> {}
-    │                    ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:39:23 ───
-    │
- 39 │         let Scds {} = Scds<vector<Cup<u8>>> {};
-    │                       ^^^^^^^^^^^^^^^^^^^^^^^^ 'drop' constraint not satisifed
-    ·
- 39 │         let Scds {} = Scds<vector<Cup<u8>>> {};
-    │                            --------------- The type 'vector<0x42::M::Cup<u8>>' does not have the ability 'drop'
-    ·
- 39 │         let Scds {} = Scds<vector<Cup<u8>>> {};
-    │                                   ------- The type 'vector<0x42::M::Cup<u8>>' can have the ability 'drop' but the type argument '0x42::M::Cup<u8>' does not have the required ability 'drop'
-    ·
- 15 │     struct Scds<T: copy + drop + store> {}
-    │                           ---- 'drop' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_prims_invalid.move:39:23 ───
-    │
- 39 │         let Scds {} = Scds<vector<Cup<u8>>> {};
-    │                       ^^^^^^^^^^^^^^^^^^^^^^^^ 'store' constraint not satisifed
-    ·
- 39 │         let Scds {} = Scds<vector<Cup<u8>>> {};
-    │                            --------------- The type 'vector<0x42::M::Cup<u8>>' does not have the ability 'store'
-    ·
- 39 │         let Scds {} = Scds<vector<Cup<u8>>> {};
-    │                                   ------- The type 'vector<0x42::M::Cup<u8>>' can have the ability 'store' but the type argument '0x42::M::Cup<u8>' does not have the required ability 'store'
-    ·
- 15 │     struct Scds<T: copy + drop + store> {}
-    │                                  ----- 'store' constraint declared here
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:20:9
+   │
+ 9 │     fun c<T: copy>() {}
+   │              ---- 'copy' constraint declared here
+   ·
+20 │         c<signer>();
+   │         ^^^^^^^^^^^
+   │         │ │
+   │         │ The type 'signer' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:21:9
+   │
+ 9 │     fun c<T: copy>() {}
+   │              ---- 'copy' constraint declared here
+   ·
+21 │         c<vector<signer>>();
+   │         ^^^^^^^^^^^^^^^^^^^
+   │         │ │      │
+   │         │ │      The type 'vector<signer>' can have the ability 'copy' but the type argument 'signer' does not have the required ability 'copy'
+   │         │ The type 'vector<signer>' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:22:9
+   │
+ 9 │     fun c<T: copy>() {}
+   │              ---- 'copy' constraint declared here
+   ·
+22 │         c<vector<NoC>>();
+   │         ^^^^^^^^^^^^^^^^
+   │         │ │      │
+   │         │ │      The type 'vector<0x42::M::NoC>' can have the ability 'copy' but the type argument '0x42::M::NoC' does not have the required ability 'copy'
+   │         │ The type 'vector<0x42::M::NoC>' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:23:9
+   │
+10 │     fun k<T: key>() {}
+   │              --- 'key' constraint declared here
+   ·
+23 │         k<u64>();
+   │         ^^^^^^^^
+   │         │ │
+   │         │ The type 'u64' does not have the ability 'key'
+   │         'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:24:9
+   │
+10 │     fun k<T: key>() {}
+   │              --- 'key' constraint declared here
+   ·
+24 │         k<signer>();
+   │         ^^^^^^^^^^^
+   │         │ │
+   │         │ The type 'signer' does not have the ability 'key'
+   │         'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:25:9
+   │
+10 │     fun k<T: key>() {}
+   │              --- 'key' constraint declared here
+   ·
+25 │         k<vector<NoC>>();
+   │         ^^^^^^^^^^^^^^^^
+   │         │ │
+   │         │ The type 'vector<0x42::M::NoC>' does not have the ability 'key'
+   │         'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:26:9
+   │
+10 │     fun k<T: key>() {}
+   │              --- 'key' constraint declared here
+   ·
+26 │         k<vector<NoK>>();
+   │         ^^^^^^^^^^^^^^^^
+   │         │ │
+   │         │ The type 'vector<0x42::M::NoK>' does not have the ability 'key'
+   │         'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:27:9
+   │
+11 │     fun cds<T: copy + drop + store>() {}
+   │                ---- 'copy' constraint declared here
+   ·
+27 │         cds<signer>();
+   │         ^^^^^^^^^^^^^
+   │         │   │
+   │         │   The type 'signer' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:27:9
+   │
+11 │     fun cds<T: copy + drop + store>() {}
+   │                              ----- 'store' constraint declared here
+   ·
+27 │         cds<signer>();
+   │         ^^^^^^^^^^^^^
+   │         │   │
+   │         │   The type 'signer' does not have the ability 'store'
+   │         'store' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:28:9
+   │
+11 │     fun cds<T: copy + drop + store>() {}
+   │                ---- 'copy' constraint declared here
+   ·
+28 │         cds<vector<NoC>>();
+   │         ^^^^^^^^^^^^^^^^^^
+   │         │   │      │
+   │         │   │      The type 'vector<0x42::M::NoC>' can have the ability 'copy' but the type argument '0x42::M::NoC' does not have the required ability 'copy'
+   │         │   The type 'vector<0x42::M::NoC>' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:29:9
+   │
+11 │     fun cds<T: copy + drop + store>() {}
+   │                ---- 'copy' constraint declared here
+   ·
+29 │         cds<vector<Cup<u8>>>();
+   │         ^^^^^^^^^^^^^^^^^^^^^^
+   │         │   │      │
+   │         │   │      The type 'vector<0x42::M::Cup<u8>>' can have the ability 'copy' but the type argument '0x42::M::Cup<u8>' does not have the required ability 'copy'
+   │         │   The type 'vector<0x42::M::Cup<u8>>' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:29:9
+   │
+11 │     fun cds<T: copy + drop + store>() {}
+   │                       ---- 'drop' constraint declared here
+   ·
+29 │         cds<vector<Cup<u8>>>();
+   │         ^^^^^^^^^^^^^^^^^^^^^^
+   │         │   │      │
+   │         │   │      The type 'vector<0x42::M::Cup<u8>>' can have the ability 'drop' but the type argument '0x42::M::Cup<u8>' does not have the required ability 'drop'
+   │         │   The type 'vector<0x42::M::Cup<u8>>' does not have the ability 'drop'
+   │         'drop' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:29:9
+   │
+11 │     fun cds<T: copy + drop + store>() {}
+   │                              ----- 'store' constraint declared here
+   ·
+29 │         cds<vector<Cup<u8>>>();
+   │         ^^^^^^^^^^^^^^^^^^^^^^
+   │         │   │      │
+   │         │   │      The type 'vector<0x42::M::Cup<u8>>' can have the ability 'store' but the type argument '0x42::M::Cup<u8>' does not have the required ability 'store'
+   │         │   The type 'vector<0x42::M::Cup<u8>>' does not have the ability 'store'
+   │         'store' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:30:13
+   │
+13 │     struct Sc<T: copy> {}
+   │                  ---- 'copy' constraint declared here
+   ·
+30 │         let Sc {} = Sc<signer> {};
+   │             ^^^^^      ------ The type 'signer' does not have the ability 'copy'
+   │             │           
+   │             'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:30:21
+   │
+13 │     struct Sc<T: copy> {}
+   │                  ---- 'copy' constraint declared here
+   ·
+30 │         let Sc {} = Sc<signer> {};
+   │                     ^^^^^^^^^^^^^
+   │                     │  │
+   │                     │  The type 'signer' does not have the ability 'copy'
+   │                     'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:31:13
+   │
+13 │     struct Sc<T: copy> {}
+   │                  ---- 'copy' constraint declared here
+   ·
+31 │         let Sc {} = Sc<vector<signer>> {};
+   │             ^^^^^      --------------
+   │             │          │      │
+   │             │          │      The type 'vector<signer>' can have the ability 'copy' but the type argument 'signer' does not have the required ability 'copy'
+   │             │          The type 'vector<signer>' does not have the ability 'copy'
+   │             'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:31:21
+   │
+13 │     struct Sc<T: copy> {}
+   │                  ---- 'copy' constraint declared here
+   ·
+31 │         let Sc {} = Sc<vector<signer>> {};
+   │                     ^^^^^^^^^^^^^^^^^^^^^
+   │                     │  │      │
+   │                     │  │      The type 'vector<signer>' can have the ability 'copy' but the type argument 'signer' does not have the required ability 'copy'
+   │                     │  The type 'vector<signer>' does not have the ability 'copy'
+   │                     'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:32:13
+   │
+13 │     struct Sc<T: copy> {}
+   │                  ---- 'copy' constraint declared here
+   ·
+32 │         let Sc {} = Sc<vector<NoC>> {};
+   │             ^^^^^      -----------
+   │             │          │      │
+   │             │          │      The type 'vector<0x42::M::NoC>' can have the ability 'copy' but the type argument '0x42::M::NoC' does not have the required ability 'copy'
+   │             │          The type 'vector<0x42::M::NoC>' does not have the ability 'copy'
+   │             'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:32:21
+   │
+13 │     struct Sc<T: copy> {}
+   │                  ---- 'copy' constraint declared here
+   ·
+32 │         let Sc {} = Sc<vector<NoC>> {};
+   │                     ^^^^^^^^^^^^^^^^^^
+   │                     │  │      │
+   │                     │  │      The type 'vector<0x42::M::NoC>' can have the ability 'copy' but the type argument '0x42::M::NoC' does not have the required ability 'copy'
+   │                     │  The type 'vector<0x42::M::NoC>' does not have the ability 'copy'
+   │                     'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:33:13
+   │
+14 │     struct Sk<T: key> {}
+   │                  --- 'key' constraint declared here
+   ·
+33 │         let Sk {} = Sk<u64> {};
+   │             ^^^^^      --- The type 'u64' does not have the ability 'key'
+   │             │           
+   │             'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:33:21
+   │
+14 │     struct Sk<T: key> {}
+   │                  --- 'key' constraint declared here
+   ·
+33 │         let Sk {} = Sk<u64> {};
+   │                     ^^^^^^^^^^
+   │                     │  │
+   │                     │  The type 'u64' does not have the ability 'key'
+   │                     'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:34:13
+   │
+14 │     struct Sk<T: key> {}
+   │                  --- 'key' constraint declared here
+   ·
+34 │         let Sk {} = Sk<signer> {};
+   │             ^^^^^      ------ The type 'signer' does not have the ability 'key'
+   │             │           
+   │             'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:34:21
+   │
+14 │     struct Sk<T: key> {}
+   │                  --- 'key' constraint declared here
+   ·
+34 │         let Sk {} = Sk<signer> {};
+   │                     ^^^^^^^^^^^^^
+   │                     │  │
+   │                     │  The type 'signer' does not have the ability 'key'
+   │                     'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:35:13
+   │
+14 │     struct Sk<T: key> {}
+   │                  --- 'key' constraint declared here
+   ·
+35 │         let Sk {} = Sk<vector<NoC>> {};
+   │             ^^^^^      ----------- The type 'vector<0x42::M::NoC>' does not have the ability 'key'
+   │             │           
+   │             'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:35:21
+   │
+14 │     struct Sk<T: key> {}
+   │                  --- 'key' constraint declared here
+   ·
+35 │         let Sk {} = Sk<vector<NoC>> {};
+   │                     ^^^^^^^^^^^^^^^^^^
+   │                     │  │
+   │                     │  The type 'vector<0x42::M::NoC>' does not have the ability 'key'
+   │                     'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:36:13
+   │
+14 │     struct Sk<T: key> {}
+   │                  --- 'key' constraint declared here
+   ·
+36 │         let Sk {} = Sk<vector<NoK>> {};
+   │             ^^^^^      ----------- The type 'vector<0x42::M::NoK>' does not have the ability 'key'
+   │             │           
+   │             'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:36:21
+   │
+14 │     struct Sk<T: key> {}
+   │                  --- 'key' constraint declared here
+   ·
+36 │         let Sk {} = Sk<vector<NoK>> {};
+   │                     ^^^^^^^^^^^^^^^^^^
+   │                     │  │
+   │                     │  The type 'vector<0x42::M::NoK>' does not have the ability 'key'
+   │                     'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:37:13
+   │
+15 │     struct Scds<T: copy + drop + store> {}
+   │                    ---- 'copy' constraint declared here
+   ·
+37 │         let Scds {} = Scds<signer> {};
+   │             ^^^^^^^        ------ The type 'signer' does not have the ability 'copy'
+   │             │               
+   │             'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:37:13
+   │
+15 │     struct Scds<T: copy + drop + store> {}
+   │                                  ----- 'store' constraint declared here
+   ·
+37 │         let Scds {} = Scds<signer> {};
+   │             ^^^^^^^        ------ The type 'signer' does not have the ability 'store'
+   │             │               
+   │             'store' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:37:23
+   │
+15 │     struct Scds<T: copy + drop + store> {}
+   │                    ---- 'copy' constraint declared here
+   ·
+37 │         let Scds {} = Scds<signer> {};
+   │                       ^^^^^^^^^^^^^^^
+   │                       │    │
+   │                       │    The type 'signer' does not have the ability 'copy'
+   │                       'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:37:23
+   │
+15 │     struct Scds<T: copy + drop + store> {}
+   │                                  ----- 'store' constraint declared here
+   ·
+37 │         let Scds {} = Scds<signer> {};
+   │                       ^^^^^^^^^^^^^^^
+   │                       │    │
+   │                       │    The type 'signer' does not have the ability 'store'
+   │                       'store' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:38:13
+   │
+15 │     struct Scds<T: copy + drop + store> {}
+   │                    ---- 'copy' constraint declared here
+   ·
+38 │         let Scds {} = Scds<vector<NoC>> {};
+   │             ^^^^^^^        -----------
+   │             │              │      │
+   │             │              │      The type 'vector<0x42::M::NoC>' can have the ability 'copy' but the type argument '0x42::M::NoC' does not have the required ability 'copy'
+   │             │              The type 'vector<0x42::M::NoC>' does not have the ability 'copy'
+   │             'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:38:23
+   │
+15 │     struct Scds<T: copy + drop + store> {}
+   │                    ---- 'copy' constraint declared here
+   ·
+38 │         let Scds {} = Scds<vector<NoC>> {};
+   │                       ^^^^^^^^^^^^^^^^^^^^
+   │                       │    │      │
+   │                       │    │      The type 'vector<0x42::M::NoC>' can have the ability 'copy' but the type argument '0x42::M::NoC' does not have the required ability 'copy'
+   │                       │    The type 'vector<0x42::M::NoC>' does not have the ability 'copy'
+   │                       'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:39:13
+   │
+15 │     struct Scds<T: copy + drop + store> {}
+   │                    ---- 'copy' constraint declared here
+   ·
+39 │         let Scds {} = Scds<vector<Cup<u8>>> {};
+   │             ^^^^^^^        ---------------
+   │             │              │      │
+   │             │              │      The type 'vector<0x42::M::Cup<u8>>' can have the ability 'copy' but the type argument '0x42::M::Cup<u8>' does not have the required ability 'copy'
+   │             │              The type 'vector<0x42::M::Cup<u8>>' does not have the ability 'copy'
+   │             'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:39:13
+   │
+15 │     struct Scds<T: copy + drop + store> {}
+   │                           ---- 'drop' constraint declared here
+   ·
+39 │         let Scds {} = Scds<vector<Cup<u8>>> {};
+   │             ^^^^^^^        ---------------
+   │             │              │      │
+   │             │              │      The type 'vector<0x42::M::Cup<u8>>' can have the ability 'drop' but the type argument '0x42::M::Cup<u8>' does not have the required ability 'drop'
+   │             │              The type 'vector<0x42::M::Cup<u8>>' does not have the ability 'drop'
+   │             'drop' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:39:13
+   │
+15 │     struct Scds<T: copy + drop + store> {}
+   │                                  ----- 'store' constraint declared here
+   ·
+39 │         let Scds {} = Scds<vector<Cup<u8>>> {};
+   │             ^^^^^^^        ---------------
+   │             │              │      │
+   │             │              │      The type 'vector<0x42::M::Cup<u8>>' can have the ability 'store' but the type argument '0x42::M::Cup<u8>' does not have the required ability 'store'
+   │             │              The type 'vector<0x42::M::Cup<u8>>' does not have the ability 'store'
+   │             'store' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:39:23
+   │
+15 │     struct Scds<T: copy + drop + store> {}
+   │                    ---- 'copy' constraint declared here
+   ·
+39 │         let Scds {} = Scds<vector<Cup<u8>>> {};
+   │                       ^^^^^^^^^^^^^^^^^^^^^^^^
+   │                       │    │      │
+   │                       │    │      The type 'vector<0x42::M::Cup<u8>>' can have the ability 'copy' but the type argument '0x42::M::Cup<u8>' does not have the required ability 'copy'
+   │                       │    The type 'vector<0x42::M::Cup<u8>>' does not have the ability 'copy'
+   │                       'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:39:23
+   │
+15 │     struct Scds<T: copy + drop + store> {}
+   │                           ---- 'drop' constraint declared here
+   ·
+39 │         let Scds {} = Scds<vector<Cup<u8>>> {};
+   │                       ^^^^^^^^^^^^^^^^^^^^^^^^
+   │                       │    │      │
+   │                       │    │      The type 'vector<0x42::M::Cup<u8>>' can have the ability 'drop' but the type argument '0x42::M::Cup<u8>' does not have the required ability 'drop'
+   │                       │    The type 'vector<0x42::M::Cup<u8>>' does not have the ability 'drop'
+   │                       'drop' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:39:23
+   │
+15 │     struct Scds<T: copy + drop + store> {}
+   │                                  ----- 'store' constraint declared here
+   ·
+39 │         let Scds {} = Scds<vector<Cup<u8>>> {};
+   │                       ^^^^^^^^^^^^^^^^^^^^^^^^
+   │                       │    │      │
+   │                       │    │      The type 'vector<0x42::M::Cup<u8>>' can have the ability 'store' but the type argument '0x42::M::Cup<u8>' does not have the required ability 'store'
+   │                       │    The type 'vector<0x42::M::Cup<u8>>' does not have the ability 'store'
+   │                       'store' constraint not satisifed
 

--- a/language/move-lang/tests/move_check/typing/ability_constraint_structs_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/ability_constraint_structs_invalid.exp
@@ -1,714 +1,601 @@
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:19:9 ───
-    │
- 19 │         c<NoC>();
-    │         ^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 19 │         c<NoC>();
-    │           --- The type '0x42::M::NoC' does not have the ability 'copy'
-    ·
-  3 │     struct NoC has drop, store, key {}
-    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
-  9 │     fun c<T: copy>() {}
-    │              ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:20:9 ───
-    │
- 20 │         c<Cup<u64>>();
-    │         ^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 20 │         c<Cup<u64>>();
-    │           -------- The type '0x42::M::Cup<u64>' does not have the ability 'copy'
-    ·
-  5 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
-  9 │     fun c<T: copy>() {}
-    │              ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:21:9 ───
-    │
- 21 │         c<Box<NoC>>();
-    │         ^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 21 │         c<Box<NoC>>();
-    │           -------- The type '0x42::M::Box<0x42::M::NoC>' does not have the ability 'copy'
-    ·
- 21 │         c<Box<NoC>>();
-    │               --- The type '0x42::M::Box<0x42::M::NoC>' can have the ability 'copy' but the type argument '0x42::M::NoC' does not have the required ability 'copy'
-    ·
-  9 │     fun c<T: copy>() {}
-    │              ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:22:9 ───
-    │
- 22 │         k<NoK>();
-    │         ^^^^^^^^ 'key' constraint not satisifed
-    ·
- 22 │         k<NoK>();
-    │           --- The type '0x42::M::NoK' does not have the ability 'key'
-    ·
-  4 │     struct NoK has copy, drop, store {}
-    │            --- To satisfy the constraint, the 'key' ability would need to be added here
-    ·
- 10 │     fun k<T: key>() {}
-    │              --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:23:9 ───
-    │
- 23 │         k<Cup<u64>>();
-    │         ^^^^^^^^^^^^^ 'key' constraint not satisifed
-    ·
- 23 │         k<Cup<u64>>();
-    │           -------- The type '0x42::M::Cup<u64>' does not have the ability 'key'
-    ·
-  5 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'key' ability would need to be added here
-    ·
- 10 │     fun k<T: key>() {}
-    │              --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:24:9 ───
-    │
- 24 │         k<Box<Cup<u64>>>();
-    │         ^^^^^^^^^^^^^^^^^^ 'key' constraint not satisifed
-    ·
- 24 │         k<Box<Cup<u64>>>();
-    │           ------------- The type '0x42::M::Box<0x42::M::Cup<u64>>' does not have the ability 'key'
-    ·
- 24 │         k<Box<Cup<u64>>>();
-    │               -------- The type '0x42::M::Box<0x42::M::Cup<u64>>' can have the ability 'key' but the type argument '0x42::M::Cup<u64>' does not have the required ability 'store'
-    ·
- 10 │     fun k<T: key>() {}
-    │              --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:25:9 ───
-    │
- 25 │         cds<NoC>();
-    │         ^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 25 │         cds<NoC>();
-    │             --- The type '0x42::M::NoC' does not have the ability 'copy'
-    ·
-  3 │     struct NoC has drop, store, key {}
-    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
- 11 │     fun cds<T: copy + drop + store>() {}
-    │                ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:26:9 ───
-    │
- 26 │         cds<Cup<u64>>();
-    │         ^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 26 │         cds<Cup<u64>>();
-    │             -------- The type '0x42::M::Cup<u64>' does not have the ability 'copy'
-    ·
-  5 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
- 11 │     fun cds<T: copy + drop + store>() {}
-    │                ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:26:9 ───
-    │
- 26 │         cds<Cup<u64>>();
-    │         ^^^^^^^^^^^^^^^ 'drop' constraint not satisifed
-    ·
- 26 │         cds<Cup<u64>>();
-    │             -------- The type '0x42::M::Cup<u64>' does not have the ability 'drop'
-    ·
-  5 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'drop' ability would need to be added here
-    ·
- 11 │     fun cds<T: copy + drop + store>() {}
-    │                       ---- 'drop' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:26:9 ───
-    │
- 26 │         cds<Cup<u64>>();
-    │         ^^^^^^^^^^^^^^^ 'store' constraint not satisifed
-    ·
- 26 │         cds<Cup<u64>>();
-    │             -------- The type '0x42::M::Cup<u64>' does not have the ability 'store'
-    ·
-  5 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'store' ability would need to be added here
-    ·
- 11 │     fun cds<T: copy + drop + store>() {}
-    │                              ----- 'store' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:27:9 ───
-    │
- 27 │         cds<Cup<NoC>>();
-    │         ^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 27 │         cds<Cup<NoC>>();
-    │             -------- The type '0x42::M::Cup<0x42::M::NoC>' does not have the ability 'copy'
-    ·
-  5 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
- 11 │     fun cds<T: copy + drop + store>() {}
-    │                ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:27:9 ───
-    │
- 27 │         cds<Cup<NoC>>();
-    │         ^^^^^^^^^^^^^^^ 'drop' constraint not satisifed
-    ·
- 27 │         cds<Cup<NoC>>();
-    │             -------- The type '0x42::M::Cup<0x42::M::NoC>' does not have the ability 'drop'
-    ·
-  5 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'drop' ability would need to be added here
-    ·
- 11 │     fun cds<T: copy + drop + store>() {}
-    │                       ---- 'drop' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:27:9 ───
-    │
- 27 │         cds<Cup<NoC>>();
-    │         ^^^^^^^^^^^^^^^ 'store' constraint not satisifed
-    ·
- 27 │         cds<Cup<NoC>>();
-    │             -------- The type '0x42::M::Cup<0x42::M::NoC>' does not have the ability 'store'
-    ·
-  5 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'store' ability would need to be added here
-    ·
- 11 │     fun cds<T: copy + drop + store>() {}
-    │                              ----- 'store' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:28:9 ───
-    │
- 28 │         cds<Pair<u64, NoC>>();
-    │         ^^^^^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 28 │         cds<Pair<u64, NoC>>();
-    │             -------------- The type '0x42::M::Pair<u64, 0x42::M::NoC>' does not have the ability 'copy'
-    ·
- 28 │         cds<Pair<u64, NoC>>();
-    │                       --- The type '0x42::M::Pair<u64, 0x42::M::NoC>' can have the ability 'copy' but the type argument '0x42::M::NoC' does not have the required ability 'copy'
-    ·
- 11 │     fun cds<T: copy + drop + store>() {}
-    │                ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:29:13 ───
-    │
- 29 │         let Sc {} = Sc<NoC> {};
-    │             ^^^^^ 'copy' constraint not satisifed
-    ·
- 29 │         let Sc {} = Sc<NoC> {};
-    │                        --- The type '0x42::M::NoC' does not have the ability 'copy'
-    ·
-  3 │     struct NoC has drop, store, key {}
-    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
- 13 │     struct Sc<T: copy> {}
-    │                  ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:29:21 ───
-    │
- 29 │         let Sc {} = Sc<NoC> {};
-    │                     ^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 29 │         let Sc {} = Sc<NoC> {};
-    │                        --- The type '0x42::M::NoC' does not have the ability 'copy'
-    ·
-  3 │     struct NoC has drop, store, key {}
-    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
- 13 │     struct Sc<T: copy> {}
-    │                  ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:30:13 ───
-    │
- 30 │         let Sc {} = Sc<Cup<u64>> {};
-    │             ^^^^^ 'copy' constraint not satisifed
-    ·
- 30 │         let Sc {} = Sc<Cup<u64>> {};
-    │                        -------- The type '0x42::M::Cup<u64>' does not have the ability 'copy'
-    ·
-  5 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
- 13 │     struct Sc<T: copy> {}
-    │                  ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:30:21 ───
-    │
- 30 │         let Sc {} = Sc<Cup<u64>> {};
-    │                     ^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 30 │         let Sc {} = Sc<Cup<u64>> {};
-    │                        -------- The type '0x42::M::Cup<u64>' does not have the ability 'copy'
-    ·
-  5 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
- 13 │     struct Sc<T: copy> {}
-    │                  ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:31:13 ───
-    │
- 31 │         let Sc {} = Sc<Box<NoC>> {};
-    │             ^^^^^ 'copy' constraint not satisifed
-    ·
- 31 │         let Sc {} = Sc<Box<NoC>> {};
-    │                        -------- The type '0x42::M::Box<0x42::M::NoC>' does not have the ability 'copy'
-    ·
- 31 │         let Sc {} = Sc<Box<NoC>> {};
-    │                            --- The type '0x42::M::Box<0x42::M::NoC>' can have the ability 'copy' but the type argument '0x42::M::NoC' does not have the required ability 'copy'
-    ·
- 13 │     struct Sc<T: copy> {}
-    │                  ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:31:21 ───
-    │
- 31 │         let Sc {} = Sc<Box<NoC>> {};
-    │                     ^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 31 │         let Sc {} = Sc<Box<NoC>> {};
-    │                        -------- The type '0x42::M::Box<0x42::M::NoC>' does not have the ability 'copy'
-    ·
- 31 │         let Sc {} = Sc<Box<NoC>> {};
-    │                            --- The type '0x42::M::Box<0x42::M::NoC>' can have the ability 'copy' but the type argument '0x42::M::NoC' does not have the required ability 'copy'
-    ·
- 13 │     struct Sc<T: copy> {}
-    │                  ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:32:13 ───
-    │
- 32 │         let Sk {} = Sk<NoK> {};
-    │             ^^^^^ 'key' constraint not satisifed
-    ·
- 32 │         let Sk {} = Sk<NoK> {};
-    │                        --- The type '0x42::M::NoK' does not have the ability 'key'
-    ·
-  4 │     struct NoK has copy, drop, store {}
-    │            --- To satisfy the constraint, the 'key' ability would need to be added here
-    ·
- 14 │     struct Sk<T: key> {}
-    │                  --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:32:21 ───
-    │
- 32 │         let Sk {} = Sk<NoK> {};
-    │                     ^^^^^^^^^^ 'key' constraint not satisifed
-    ·
- 32 │         let Sk {} = Sk<NoK> {};
-    │                        --- The type '0x42::M::NoK' does not have the ability 'key'
-    ·
-  4 │     struct NoK has copy, drop, store {}
-    │            --- To satisfy the constraint, the 'key' ability would need to be added here
-    ·
- 14 │     struct Sk<T: key> {}
-    │                  --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:33:13 ───
-    │
- 33 │         let Sk {} = Sk<Cup<u64>> {};
-    │             ^^^^^ 'key' constraint not satisifed
-    ·
- 33 │         let Sk {} = Sk<Cup<u64>> {};
-    │                        -------- The type '0x42::M::Cup<u64>' does not have the ability 'key'
-    ·
-  5 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'key' ability would need to be added here
-    ·
- 14 │     struct Sk<T: key> {}
-    │                  --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:33:21 ───
-    │
- 33 │         let Sk {} = Sk<Cup<u64>> {};
-    │                     ^^^^^^^^^^^^^^^ 'key' constraint not satisifed
-    ·
- 33 │         let Sk {} = Sk<Cup<u64>> {};
-    │                        -------- The type '0x42::M::Cup<u64>' does not have the ability 'key'
-    ·
-  5 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'key' ability would need to be added here
-    ·
- 14 │     struct Sk<T: key> {}
-    │                  --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:34:13 ───
-    │
- 34 │         let Sk {} = Sk<Box<Cup<u64>>> {};
-    │             ^^^^^ 'key' constraint not satisifed
-    ·
- 34 │         let Sk {} = Sk<Box<Cup<u64>>> {};
-    │                        ------------- The type '0x42::M::Box<0x42::M::Cup<u64>>' does not have the ability 'key'
-    ·
- 34 │         let Sk {} = Sk<Box<Cup<u64>>> {};
-    │                            -------- The type '0x42::M::Box<0x42::M::Cup<u64>>' can have the ability 'key' but the type argument '0x42::M::Cup<u64>' does not have the required ability 'store'
-    ·
- 14 │     struct Sk<T: key> {}
-    │                  --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:34:21 ───
-    │
- 34 │         let Sk {} = Sk<Box<Cup<u64>>> {};
-    │                     ^^^^^^^^^^^^^^^^^^^^ 'key' constraint not satisifed
-    ·
- 34 │         let Sk {} = Sk<Box<Cup<u64>>> {};
-    │                        ------------- The type '0x42::M::Box<0x42::M::Cup<u64>>' does not have the ability 'key'
-    ·
- 34 │         let Sk {} = Sk<Box<Cup<u64>>> {};
-    │                            -------- The type '0x42::M::Box<0x42::M::Cup<u64>>' can have the ability 'key' but the type argument '0x42::M::Cup<u64>' does not have the required ability 'store'
-    ·
- 14 │     struct Sk<T: key> {}
-    │                  --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:35:13 ───
-    │
- 35 │         let Scds {} = Scds<NoC> {};
-    │             ^^^^^^^ 'copy' constraint not satisifed
-    ·
- 35 │         let Scds {} = Scds<NoC> {};
-    │                            --- The type '0x42::M::NoC' does not have the ability 'copy'
-    ·
-  3 │     struct NoC has drop, store, key {}
-    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
- 15 │     struct Scds<T: copy + drop + store> {}
-    │                    ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:35:23 ───
-    │
- 35 │         let Scds {} = Scds<NoC> {};
-    │                       ^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 35 │         let Scds {} = Scds<NoC> {};
-    │                            --- The type '0x42::M::NoC' does not have the ability 'copy'
-    ·
-  3 │     struct NoC has drop, store, key {}
-    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
- 15 │     struct Scds<T: copy + drop + store> {}
-    │                    ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:36:13 ───
-    │
- 36 │         let Scds {} = Scds<Cup<u64>> {};
-    │             ^^^^^^^ 'copy' constraint not satisifed
-    ·
- 36 │         let Scds {} = Scds<Cup<u64>> {};
-    │                            -------- The type '0x42::M::Cup<u64>' does not have the ability 'copy'
-    ·
-  5 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
- 15 │     struct Scds<T: copy + drop + store> {}
-    │                    ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:36:13 ───
-    │
- 36 │         let Scds {} = Scds<Cup<u64>> {};
-    │             ^^^^^^^ 'drop' constraint not satisifed
-    ·
- 36 │         let Scds {} = Scds<Cup<u64>> {};
-    │                            -------- The type '0x42::M::Cup<u64>' does not have the ability 'drop'
-    ·
-  5 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'drop' ability would need to be added here
-    ·
- 15 │     struct Scds<T: copy + drop + store> {}
-    │                           ---- 'drop' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:36:13 ───
-    │
- 36 │         let Scds {} = Scds<Cup<u64>> {};
-    │             ^^^^^^^ 'store' constraint not satisifed
-    ·
- 36 │         let Scds {} = Scds<Cup<u64>> {};
-    │                            -------- The type '0x42::M::Cup<u64>' does not have the ability 'store'
-    ·
-  5 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'store' ability would need to be added here
-    ·
- 15 │     struct Scds<T: copy + drop + store> {}
-    │                                  ----- 'store' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:36:23 ───
-    │
- 36 │         let Scds {} = Scds<Cup<u64>> {};
-    │                       ^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 36 │         let Scds {} = Scds<Cup<u64>> {};
-    │                            -------- The type '0x42::M::Cup<u64>' does not have the ability 'copy'
-    ·
-  5 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
- 15 │     struct Scds<T: copy + drop + store> {}
-    │                    ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:36:23 ───
-    │
- 36 │         let Scds {} = Scds<Cup<u64>> {};
-    │                       ^^^^^^^^^^^^^^^^^ 'drop' constraint not satisifed
-    ·
- 36 │         let Scds {} = Scds<Cup<u64>> {};
-    │                            -------- The type '0x42::M::Cup<u64>' does not have the ability 'drop'
-    ·
-  5 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'drop' ability would need to be added here
-    ·
- 15 │     struct Scds<T: copy + drop + store> {}
-    │                           ---- 'drop' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:36:23 ───
-    │
- 36 │         let Scds {} = Scds<Cup<u64>> {};
-    │                       ^^^^^^^^^^^^^^^^^ 'store' constraint not satisifed
-    ·
- 36 │         let Scds {} = Scds<Cup<u64>> {};
-    │                            -------- The type '0x42::M::Cup<u64>' does not have the ability 'store'
-    ·
-  5 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'store' ability would need to be added here
-    ·
- 15 │     struct Scds<T: copy + drop + store> {}
-    │                                  ----- 'store' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:37:13 ───
-    │
- 37 │         let Scds {} = Scds<Cup<NoC>> {};
-    │             ^^^^^^^ 'copy' constraint not satisifed
-    ·
- 37 │         let Scds {} = Scds<Cup<NoC>> {};
-    │                            -------- The type '0x42::M::Cup<0x42::M::NoC>' does not have the ability 'copy'
-    ·
-  5 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
- 15 │     struct Scds<T: copy + drop + store> {}
-    │                    ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:37:13 ───
-    │
- 37 │         let Scds {} = Scds<Cup<NoC>> {};
-    │             ^^^^^^^ 'drop' constraint not satisifed
-    ·
- 37 │         let Scds {} = Scds<Cup<NoC>> {};
-    │                            -------- The type '0x42::M::Cup<0x42::M::NoC>' does not have the ability 'drop'
-    ·
-  5 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'drop' ability would need to be added here
-    ·
- 15 │     struct Scds<T: copy + drop + store> {}
-    │                           ---- 'drop' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:37:13 ───
-    │
- 37 │         let Scds {} = Scds<Cup<NoC>> {};
-    │             ^^^^^^^ 'store' constraint not satisifed
-    ·
- 37 │         let Scds {} = Scds<Cup<NoC>> {};
-    │                            -------- The type '0x42::M::Cup<0x42::M::NoC>' does not have the ability 'store'
-    ·
-  5 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'store' ability would need to be added here
-    ·
- 15 │     struct Scds<T: copy + drop + store> {}
-    │                                  ----- 'store' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:37:23 ───
-    │
- 37 │         let Scds {} = Scds<Cup<NoC>> {};
-    │                       ^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 37 │         let Scds {} = Scds<Cup<NoC>> {};
-    │                            -------- The type '0x42::M::Cup<0x42::M::NoC>' does not have the ability 'copy'
-    ·
-  5 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
- 15 │     struct Scds<T: copy + drop + store> {}
-    │                    ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:37:23 ───
-    │
- 37 │         let Scds {} = Scds<Cup<NoC>> {};
-    │                       ^^^^^^^^^^^^^^^^^ 'drop' constraint not satisifed
-    ·
- 37 │         let Scds {} = Scds<Cup<NoC>> {};
-    │                            -------- The type '0x42::M::Cup<0x42::M::NoC>' does not have the ability 'drop'
-    ·
-  5 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'drop' ability would need to be added here
-    ·
- 15 │     struct Scds<T: copy + drop + store> {}
-    │                           ---- 'drop' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:37:23 ───
-    │
- 37 │         let Scds {} = Scds<Cup<NoC>> {};
-    │                       ^^^^^^^^^^^^^^^^^ 'store' constraint not satisifed
-    ·
- 37 │         let Scds {} = Scds<Cup<NoC>> {};
-    │                            -------- The type '0x42::M::Cup<0x42::M::NoC>' does not have the ability 'store'
-    ·
-  5 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'store' ability would need to be added here
-    ·
- 15 │     struct Scds<T: copy + drop + store> {}
-    │                                  ----- 'store' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:38:13 ───
-    │
- 38 │         let Scds {} = Scds<Pair<u64, NoC>> {};
-    │             ^^^^^^^ 'copy' constraint not satisifed
-    ·
- 38 │         let Scds {} = Scds<Pair<u64, NoC>> {};
-    │                            -------------- The type '0x42::M::Pair<u64, 0x42::M::NoC>' does not have the ability 'copy'
-    ·
- 38 │         let Scds {} = Scds<Pair<u64, NoC>> {};
-    │                                      --- The type '0x42::M::Pair<u64, 0x42::M::NoC>' can have the ability 'copy' but the type argument '0x42::M::NoC' does not have the required ability 'copy'
-    ·
- 15 │     struct Scds<T: copy + drop + store> {}
-    │                    ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_structs_invalid.move:38:23 ───
-    │
- 38 │         let Scds {} = Scds<Pair<u64, NoC>> {};
-    │                       ^^^^^^^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 38 │         let Scds {} = Scds<Pair<u64, NoC>> {};
-    │                            -------------- The type '0x42::M::Pair<u64, 0x42::M::NoC>' does not have the ability 'copy'
-    ·
- 38 │         let Scds {} = Scds<Pair<u64, NoC>> {};
-    │                                      --- The type '0x42::M::Pair<u64, 0x42::M::NoC>' can have the ability 'copy' but the type argument '0x42::M::NoC' does not have the required ability 'copy'
-    ·
- 15 │     struct Scds<T: copy + drop + store> {}
-    │                    ---- 'copy' constraint declared here
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:19:9
+   │
+ 3 │     struct NoC has drop, store, key {}
+   │            --- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+ 9 │     fun c<T: copy>() {}
+   │              ---- 'copy' constraint declared here
+   ·
+19 │         c<NoC>();
+   │         ^^^^^^^^
+   │         │ │
+   │         │ The type '0x42::M::NoC' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:20:9
+   │
+ 5 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+ 9 │     fun c<T: copy>() {}
+   │              ---- 'copy' constraint declared here
+   ·
+20 │         c<Cup<u64>>();
+   │         ^^^^^^^^^^^^^
+   │         │ │
+   │         │ The type '0x42::M::Cup<u64>' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:21:9
+   │
+ 9 │     fun c<T: copy>() {}
+   │              ---- 'copy' constraint declared here
+   ·
+21 │         c<Box<NoC>>();
+   │         ^^^^^^^^^^^^^
+   │         │ │   │
+   │         │ │   The type '0x42::M::Box<0x42::M::NoC>' can have the ability 'copy' but the type argument '0x42::M::NoC' does not have the required ability 'copy'
+   │         │ The type '0x42::M::Box<0x42::M::NoC>' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:22:9
+   │
+ 4 │     struct NoK has copy, drop, store {}
+   │            --- To satisfy the constraint, the 'key' ability would need to be added here
+   ·
+10 │     fun k<T: key>() {}
+   │              --- 'key' constraint declared here
+   ·
+22 │         k<NoK>();
+   │         ^^^^^^^^
+   │         │ │
+   │         │ The type '0x42::M::NoK' does not have the ability 'key'
+   │         'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:23:9
+   │
+ 5 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'key' ability would need to be added here
+   ·
+10 │     fun k<T: key>() {}
+   │              --- 'key' constraint declared here
+   ·
+23 │         k<Cup<u64>>();
+   │         ^^^^^^^^^^^^^
+   │         │ │
+   │         │ The type '0x42::M::Cup<u64>' does not have the ability 'key'
+   │         'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:24:9
+   │
+10 │     fun k<T: key>() {}
+   │              --- 'key' constraint declared here
+   ·
+24 │         k<Box<Cup<u64>>>();
+   │         ^^^^^^^^^^^^^^^^^^
+   │         │ │   │
+   │         │ │   The type '0x42::M::Box<0x42::M::Cup<u64>>' can have the ability 'key' but the type argument '0x42::M::Cup<u64>' does not have the required ability 'store'
+   │         │ The type '0x42::M::Box<0x42::M::Cup<u64>>' does not have the ability 'key'
+   │         'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:25:9
+   │
+ 3 │     struct NoC has drop, store, key {}
+   │            --- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+11 │     fun cds<T: copy + drop + store>() {}
+   │                ---- 'copy' constraint declared here
+   ·
+25 │         cds<NoC>();
+   │         ^^^^^^^^^^
+   │         │   │
+   │         │   The type '0x42::M::NoC' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:26:9
+   │
+ 5 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+11 │     fun cds<T: copy + drop + store>() {}
+   │                ---- 'copy' constraint declared here
+   ·
+26 │         cds<Cup<u64>>();
+   │         ^^^^^^^^^^^^^^^
+   │         │   │
+   │         │   The type '0x42::M::Cup<u64>' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:26:9
+   │
+ 5 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+11 │     fun cds<T: copy + drop + store>() {}
+   │                       ---- 'drop' constraint declared here
+   ·
+26 │         cds<Cup<u64>>();
+   │         ^^^^^^^^^^^^^^^
+   │         │   │
+   │         │   The type '0x42::M::Cup<u64>' does not have the ability 'drop'
+   │         'drop' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:26:9
+   │
+ 5 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'store' ability would need to be added here
+   ·
+11 │     fun cds<T: copy + drop + store>() {}
+   │                              ----- 'store' constraint declared here
+   ·
+26 │         cds<Cup<u64>>();
+   │         ^^^^^^^^^^^^^^^
+   │         │   │
+   │         │   The type '0x42::M::Cup<u64>' does not have the ability 'store'
+   │         'store' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:27:9
+   │
+ 5 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+11 │     fun cds<T: copy + drop + store>() {}
+   │                ---- 'copy' constraint declared here
+   ·
+27 │         cds<Cup<NoC>>();
+   │         ^^^^^^^^^^^^^^^
+   │         │   │
+   │         │   The type '0x42::M::Cup<0x42::M::NoC>' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:27:9
+   │
+ 5 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+11 │     fun cds<T: copy + drop + store>() {}
+   │                       ---- 'drop' constraint declared here
+   ·
+27 │         cds<Cup<NoC>>();
+   │         ^^^^^^^^^^^^^^^
+   │         │   │
+   │         │   The type '0x42::M::Cup<0x42::M::NoC>' does not have the ability 'drop'
+   │         'drop' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:27:9
+   │
+ 5 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'store' ability would need to be added here
+   ·
+11 │     fun cds<T: copy + drop + store>() {}
+   │                              ----- 'store' constraint declared here
+   ·
+27 │         cds<Cup<NoC>>();
+   │         ^^^^^^^^^^^^^^^
+   │         │   │
+   │         │   The type '0x42::M::Cup<0x42::M::NoC>' does not have the ability 'store'
+   │         'store' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:28:9
+   │
+11 │     fun cds<T: copy + drop + store>() {}
+   │                ---- 'copy' constraint declared here
+   ·
+28 │         cds<Pair<u64, NoC>>();
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │         │   │         │
+   │         │   │         The type '0x42::M::Pair<u64, 0x42::M::NoC>' can have the ability 'copy' but the type argument '0x42::M::NoC' does not have the required ability 'copy'
+   │         │   The type '0x42::M::Pair<u64, 0x42::M::NoC>' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:29:13
+   │
+ 3 │     struct NoC has drop, store, key {}
+   │            --- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+13 │     struct Sc<T: copy> {}
+   │                  ---- 'copy' constraint declared here
+   ·
+29 │         let Sc {} = Sc<NoC> {};
+   │             ^^^^^      --- The type '0x42::M::NoC' does not have the ability 'copy'
+   │             │           
+   │             'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:29:21
+   │
+ 3 │     struct NoC has drop, store, key {}
+   │            --- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+13 │     struct Sc<T: copy> {}
+   │                  ---- 'copy' constraint declared here
+   ·
+29 │         let Sc {} = Sc<NoC> {};
+   │                     ^^^^^^^^^^
+   │                     │  │
+   │                     │  The type '0x42::M::NoC' does not have the ability 'copy'
+   │                     'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:30:13
+   │
+ 5 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+13 │     struct Sc<T: copy> {}
+   │                  ---- 'copy' constraint declared here
+   ·
+30 │         let Sc {} = Sc<Cup<u64>> {};
+   │             ^^^^^      -------- The type '0x42::M::Cup<u64>' does not have the ability 'copy'
+   │             │           
+   │             'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:30:21
+   │
+ 5 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+13 │     struct Sc<T: copy> {}
+   │                  ---- 'copy' constraint declared here
+   ·
+30 │         let Sc {} = Sc<Cup<u64>> {};
+   │                     ^^^^^^^^^^^^^^^
+   │                     │  │
+   │                     │  The type '0x42::M::Cup<u64>' does not have the ability 'copy'
+   │                     'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:31:13
+   │
+13 │     struct Sc<T: copy> {}
+   │                  ---- 'copy' constraint declared here
+   ·
+31 │         let Sc {} = Sc<Box<NoC>> {};
+   │             ^^^^^      --------
+   │             │          │   │
+   │             │          │   The type '0x42::M::Box<0x42::M::NoC>' can have the ability 'copy' but the type argument '0x42::M::NoC' does not have the required ability 'copy'
+   │             │          The type '0x42::M::Box<0x42::M::NoC>' does not have the ability 'copy'
+   │             'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:31:21
+   │
+13 │     struct Sc<T: copy> {}
+   │                  ---- 'copy' constraint declared here
+   ·
+31 │         let Sc {} = Sc<Box<NoC>> {};
+   │                     ^^^^^^^^^^^^^^^
+   │                     │  │   │
+   │                     │  │   The type '0x42::M::Box<0x42::M::NoC>' can have the ability 'copy' but the type argument '0x42::M::NoC' does not have the required ability 'copy'
+   │                     │  The type '0x42::M::Box<0x42::M::NoC>' does not have the ability 'copy'
+   │                     'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:32:13
+   │
+ 4 │     struct NoK has copy, drop, store {}
+   │            --- To satisfy the constraint, the 'key' ability would need to be added here
+   ·
+14 │     struct Sk<T: key> {}
+   │                  --- 'key' constraint declared here
+   ·
+32 │         let Sk {} = Sk<NoK> {};
+   │             ^^^^^      --- The type '0x42::M::NoK' does not have the ability 'key'
+   │             │           
+   │             'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:32:21
+   │
+ 4 │     struct NoK has copy, drop, store {}
+   │            --- To satisfy the constraint, the 'key' ability would need to be added here
+   ·
+14 │     struct Sk<T: key> {}
+   │                  --- 'key' constraint declared here
+   ·
+32 │         let Sk {} = Sk<NoK> {};
+   │                     ^^^^^^^^^^
+   │                     │  │
+   │                     │  The type '0x42::M::NoK' does not have the ability 'key'
+   │                     'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:33:13
+   │
+ 5 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'key' ability would need to be added here
+   ·
+14 │     struct Sk<T: key> {}
+   │                  --- 'key' constraint declared here
+   ·
+33 │         let Sk {} = Sk<Cup<u64>> {};
+   │             ^^^^^      -------- The type '0x42::M::Cup<u64>' does not have the ability 'key'
+   │             │           
+   │             'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:33:21
+   │
+ 5 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'key' ability would need to be added here
+   ·
+14 │     struct Sk<T: key> {}
+   │                  --- 'key' constraint declared here
+   ·
+33 │         let Sk {} = Sk<Cup<u64>> {};
+   │                     ^^^^^^^^^^^^^^^
+   │                     │  │
+   │                     │  The type '0x42::M::Cup<u64>' does not have the ability 'key'
+   │                     'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:34:13
+   │
+14 │     struct Sk<T: key> {}
+   │                  --- 'key' constraint declared here
+   ·
+34 │         let Sk {} = Sk<Box<Cup<u64>>> {};
+   │             ^^^^^      -------------
+   │             │          │   │
+   │             │          │   The type '0x42::M::Box<0x42::M::Cup<u64>>' can have the ability 'key' but the type argument '0x42::M::Cup<u64>' does not have the required ability 'store'
+   │             │          The type '0x42::M::Box<0x42::M::Cup<u64>>' does not have the ability 'key'
+   │             'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:34:21
+   │
+14 │     struct Sk<T: key> {}
+   │                  --- 'key' constraint declared here
+   ·
+34 │         let Sk {} = Sk<Box<Cup<u64>>> {};
+   │                     ^^^^^^^^^^^^^^^^^^^^
+   │                     │  │   │
+   │                     │  │   The type '0x42::M::Box<0x42::M::Cup<u64>>' can have the ability 'key' but the type argument '0x42::M::Cup<u64>' does not have the required ability 'store'
+   │                     │  The type '0x42::M::Box<0x42::M::Cup<u64>>' does not have the ability 'key'
+   │                     'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:35:13
+   │
+ 3 │     struct NoC has drop, store, key {}
+   │            --- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+15 │     struct Scds<T: copy + drop + store> {}
+   │                    ---- 'copy' constraint declared here
+   ·
+35 │         let Scds {} = Scds<NoC> {};
+   │             ^^^^^^^        --- The type '0x42::M::NoC' does not have the ability 'copy'
+   │             │               
+   │             'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:35:23
+   │
+ 3 │     struct NoC has drop, store, key {}
+   │            --- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+15 │     struct Scds<T: copy + drop + store> {}
+   │                    ---- 'copy' constraint declared here
+   ·
+35 │         let Scds {} = Scds<NoC> {};
+   │                       ^^^^^^^^^^^^
+   │                       │    │
+   │                       │    The type '0x42::M::NoC' does not have the ability 'copy'
+   │                       'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:36:13
+   │
+ 5 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+15 │     struct Scds<T: copy + drop + store> {}
+   │                    ---- 'copy' constraint declared here
+   ·
+36 │         let Scds {} = Scds<Cup<u64>> {};
+   │             ^^^^^^^        -------- The type '0x42::M::Cup<u64>' does not have the ability 'copy'
+   │             │               
+   │             'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:36:13
+   │
+ 5 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+15 │     struct Scds<T: copy + drop + store> {}
+   │                           ---- 'drop' constraint declared here
+   ·
+36 │         let Scds {} = Scds<Cup<u64>> {};
+   │             ^^^^^^^        -------- The type '0x42::M::Cup<u64>' does not have the ability 'drop'
+   │             │               
+   │             'drop' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:36:13
+   │
+ 5 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'store' ability would need to be added here
+   ·
+15 │     struct Scds<T: copy + drop + store> {}
+   │                                  ----- 'store' constraint declared here
+   ·
+36 │         let Scds {} = Scds<Cup<u64>> {};
+   │             ^^^^^^^        -------- The type '0x42::M::Cup<u64>' does not have the ability 'store'
+   │             │               
+   │             'store' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:36:23
+   │
+ 5 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+15 │     struct Scds<T: copy + drop + store> {}
+   │                    ---- 'copy' constraint declared here
+   ·
+36 │         let Scds {} = Scds<Cup<u64>> {};
+   │                       ^^^^^^^^^^^^^^^^^
+   │                       │    │
+   │                       │    The type '0x42::M::Cup<u64>' does not have the ability 'copy'
+   │                       'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:36:23
+   │
+ 5 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+15 │     struct Scds<T: copy + drop + store> {}
+   │                           ---- 'drop' constraint declared here
+   ·
+36 │         let Scds {} = Scds<Cup<u64>> {};
+   │                       ^^^^^^^^^^^^^^^^^
+   │                       │    │
+   │                       │    The type '0x42::M::Cup<u64>' does not have the ability 'drop'
+   │                       'drop' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:36:23
+   │
+ 5 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'store' ability would need to be added here
+   ·
+15 │     struct Scds<T: copy + drop + store> {}
+   │                                  ----- 'store' constraint declared here
+   ·
+36 │         let Scds {} = Scds<Cup<u64>> {};
+   │                       ^^^^^^^^^^^^^^^^^
+   │                       │    │
+   │                       │    The type '0x42::M::Cup<u64>' does not have the ability 'store'
+   │                       'store' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:37:13
+   │
+ 5 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+15 │     struct Scds<T: copy + drop + store> {}
+   │                    ---- 'copy' constraint declared here
+   ·
+37 │         let Scds {} = Scds<Cup<NoC>> {};
+   │             ^^^^^^^        -------- The type '0x42::M::Cup<0x42::M::NoC>' does not have the ability 'copy'
+   │             │               
+   │             'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:37:13
+   │
+ 5 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+15 │     struct Scds<T: copy + drop + store> {}
+   │                           ---- 'drop' constraint declared here
+   ·
+37 │         let Scds {} = Scds<Cup<NoC>> {};
+   │             ^^^^^^^        -------- The type '0x42::M::Cup<0x42::M::NoC>' does not have the ability 'drop'
+   │             │               
+   │             'drop' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:37:13
+   │
+ 5 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'store' ability would need to be added here
+   ·
+15 │     struct Scds<T: copy + drop + store> {}
+   │                                  ----- 'store' constraint declared here
+   ·
+37 │         let Scds {} = Scds<Cup<NoC>> {};
+   │             ^^^^^^^        -------- The type '0x42::M::Cup<0x42::M::NoC>' does not have the ability 'store'
+   │             │               
+   │             'store' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:37:23
+   │
+ 5 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+15 │     struct Scds<T: copy + drop + store> {}
+   │                    ---- 'copy' constraint declared here
+   ·
+37 │         let Scds {} = Scds<Cup<NoC>> {};
+   │                       ^^^^^^^^^^^^^^^^^
+   │                       │    │
+   │                       │    The type '0x42::M::Cup<0x42::M::NoC>' does not have the ability 'copy'
+   │                       'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:37:23
+   │
+ 5 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+15 │     struct Scds<T: copy + drop + store> {}
+   │                           ---- 'drop' constraint declared here
+   ·
+37 │         let Scds {} = Scds<Cup<NoC>> {};
+   │                       ^^^^^^^^^^^^^^^^^
+   │                       │    │
+   │                       │    The type '0x42::M::Cup<0x42::M::NoC>' does not have the ability 'drop'
+   │                       'drop' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:37:23
+   │
+ 5 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'store' ability would need to be added here
+   ·
+15 │     struct Scds<T: copy + drop + store> {}
+   │                                  ----- 'store' constraint declared here
+   ·
+37 │         let Scds {} = Scds<Cup<NoC>> {};
+   │                       ^^^^^^^^^^^^^^^^^
+   │                       │    │
+   │                       │    The type '0x42::M::Cup<0x42::M::NoC>' does not have the ability 'store'
+   │                       'store' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:38:13
+   │
+15 │     struct Scds<T: copy + drop + store> {}
+   │                    ---- 'copy' constraint declared here
+   ·
+38 │         let Scds {} = Scds<Pair<u64, NoC>> {};
+   │             ^^^^^^^        --------------
+   │             │              │         │
+   │             │              │         The type '0x42::M::Pair<u64, 0x42::M::NoC>' can have the ability 'copy' but the type argument '0x42::M::NoC' does not have the required ability 'copy'
+   │             │              The type '0x42::M::Pair<u64, 0x42::M::NoC>' does not have the ability 'copy'
+   │             'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:38:23
+   │
+15 │     struct Scds<T: copy + drop + store> {}
+   │                    ---- 'copy' constraint declared here
+   ·
+38 │         let Scds {} = Scds<Pair<u64, NoC>> {};
+   │                       ^^^^^^^^^^^^^^^^^^^^^^^
+   │                       │    │         │
+   │                       │    │         The type '0x42::M::Pair<u64, 0x42::M::NoC>' can have the ability 'copy' but the type argument '0x42::M::NoC' does not have the required ability 'copy'
+   │                       │    The type '0x42::M::Pair<u64, 0x42::M::NoC>' does not have the ability 'copy'
+   │                       'copy' constraint not satisifed
 

--- a/language/move-lang/tests/move_check/typing/ability_constraint_tparams_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/ability_constraint_tparams_invalid.exp
@@ -1,714 +1,601 @@
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:21:9 ───
-    │
- 21 │         c<TnoC>();
-    │         ^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 21 │         c<TnoC>();
-    │           ---- The type 'TnoC' does not have the ability 'copy'
-    ·
- 17 │         TnoC: drop + store + key,
-    │         ---- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
-  7 │     fun c<T: copy>() {}
-    │              ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:22:9 ───
-    │
- 22 │         c<Cup<TnoK>>();
-    │         ^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 22 │         c<Cup<TnoK>>();
-    │           --------- The type '0x42::M::Cup<TnoK>' does not have the ability 'copy'
-    ·
-  3 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
-  7 │     fun c<T: copy>() {}
-    │              ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:23:9 ───
-    │
- 23 │         c<Box<TnoC>>();
-    │         ^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 23 │         c<Box<TnoC>>();
-    │           --------- The type '0x42::M::Box<TnoC>' does not have the ability 'copy'
-    ·
- 23 │         c<Box<TnoC>>();
-    │               ---- The type '0x42::M::Box<TnoC>' can have the ability 'copy' but the type argument 'TnoC' does not have the required ability 'copy'
-    ·
-  7 │     fun c<T: copy>() {}
-    │              ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:24:9 ───
-    │
- 24 │         k<TnoK>();
-    │         ^^^^^^^^^ 'key' constraint not satisifed
-    ·
- 24 │         k<TnoK>();
-    │           ---- The type 'TnoK' does not have the ability 'key'
-    ·
- 18 │         TnoK: copy + drop + store,
-    │         ---- To satisfy the constraint, the 'key' ability would need to be added here
-    ·
-  8 │     fun k<T: key>() {}
-    │              --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:25:9 ───
-    │
- 25 │         k<Cup<TnoC>>();
-    │         ^^^^^^^^^^^^^^ 'key' constraint not satisifed
-    ·
- 25 │         k<Cup<TnoC>>();
-    │           --------- The type '0x42::M::Cup<TnoC>' does not have the ability 'key'
-    ·
-  3 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'key' ability would need to be added here
-    ·
-  8 │     fun k<T: key>() {}
-    │              --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:26:9 ───
-    │
- 26 │         k<Box<Cup<TnoC>>>();
-    │         ^^^^^^^^^^^^^^^^^^^ 'key' constraint not satisifed
-    ·
- 26 │         k<Box<Cup<TnoC>>>();
-    │           -------------- The type '0x42::M::Box<0x42::M::Cup<TnoC>>' does not have the ability 'key'
-    ·
- 26 │         k<Box<Cup<TnoC>>>();
-    │               --------- The type '0x42::M::Box<0x42::M::Cup<TnoC>>' can have the ability 'key' but the type argument '0x42::M::Cup<TnoC>' does not have the required ability 'store'
-    ·
-  8 │     fun k<T: key>() {}
-    │              --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:27:9 ───
-    │
- 27 │         cds<TnoC>();
-    │         ^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 27 │         cds<TnoC>();
-    │             ---- The type 'TnoC' does not have the ability 'copy'
-    ·
- 17 │         TnoC: drop + store + key,
-    │         ---- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
-  9 │     fun cds<T: copy + drop + store>() {}
-    │                ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:28:9 ───
-    │
- 28 │         cds<Cup<TnoC>>();
-    │         ^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 28 │         cds<Cup<TnoC>>();
-    │             --------- The type '0x42::M::Cup<TnoC>' does not have the ability 'copy'
-    ·
-  3 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
-  9 │     fun cds<T: copy + drop + store>() {}
-    │                ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:28:9 ───
-    │
- 28 │         cds<Cup<TnoC>>();
-    │         ^^^^^^^^^^^^^^^^ 'drop' constraint not satisifed
-    ·
- 28 │         cds<Cup<TnoC>>();
-    │             --------- The type '0x42::M::Cup<TnoC>' does not have the ability 'drop'
-    ·
-  3 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'drop' ability would need to be added here
-    ·
-  9 │     fun cds<T: copy + drop + store>() {}
-    │                       ---- 'drop' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:28:9 ───
-    │
- 28 │         cds<Cup<TnoC>>();
-    │         ^^^^^^^^^^^^^^^^ 'store' constraint not satisifed
-    ·
- 28 │         cds<Cup<TnoC>>();
-    │             --------- The type '0x42::M::Cup<TnoC>' does not have the ability 'store'
-    ·
-  3 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'store' ability would need to be added here
-    ·
-  9 │     fun cds<T: copy + drop + store>() {}
-    │                              ----- 'store' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:29:9 ───
-    │
- 29 │         cds<Cup<TnoK>>();
-    │         ^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 29 │         cds<Cup<TnoK>>();
-    │             --------- The type '0x42::M::Cup<TnoK>' does not have the ability 'copy'
-    ·
-  3 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
-  9 │     fun cds<T: copy + drop + store>() {}
-    │                ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:29:9 ───
-    │
- 29 │         cds<Cup<TnoK>>();
-    │         ^^^^^^^^^^^^^^^^ 'drop' constraint not satisifed
-    ·
- 29 │         cds<Cup<TnoK>>();
-    │             --------- The type '0x42::M::Cup<TnoK>' does not have the ability 'drop'
-    ·
-  3 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'drop' ability would need to be added here
-    ·
-  9 │     fun cds<T: copy + drop + store>() {}
-    │                       ---- 'drop' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:29:9 ───
-    │
- 29 │         cds<Cup<TnoK>>();
-    │         ^^^^^^^^^^^^^^^^ 'store' constraint not satisifed
-    ·
- 29 │         cds<Cup<TnoK>>();
-    │             --------- The type '0x42::M::Cup<TnoK>' does not have the ability 'store'
-    ·
-  3 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'store' ability would need to be added here
-    ·
-  9 │     fun cds<T: copy + drop + store>() {}
-    │                              ----- 'store' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:30:9 ───
-    │
- 30 │         cds<Pair<u64, TnoC>>();
-    │         ^^^^^^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 30 │         cds<Pair<u64, TnoC>>();
-    │             --------------- The type '0x42::M::Pair<u64, TnoC>' does not have the ability 'copy'
-    ·
- 30 │         cds<Pair<u64, TnoC>>();
-    │                       ---- The type '0x42::M::Pair<u64, TnoC>' can have the ability 'copy' but the type argument 'TnoC' does not have the required ability 'copy'
-    ·
-  9 │     fun cds<T: copy + drop + store>() {}
-    │                ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:31:13 ───
-    │
- 31 │         let Sc {} = Sc<TnoC> {};
-    │             ^^^^^ 'copy' constraint not satisifed
-    ·
- 31 │         let Sc {} = Sc<TnoC> {};
-    │                        ---- The type 'TnoC' does not have the ability 'copy'
-    ·
- 17 │         TnoC: drop + store + key,
-    │         ---- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
- 11 │     struct Sc<T: copy> {}
-    │                  ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:31:21 ───
-    │
- 31 │         let Sc {} = Sc<TnoC> {};
-    │                     ^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 31 │         let Sc {} = Sc<TnoC> {};
-    │                        ---- The type 'TnoC' does not have the ability 'copy'
-    ·
- 17 │         TnoC: drop + store + key,
-    │         ---- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
- 11 │     struct Sc<T: copy> {}
-    │                  ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:32:13 ───
-    │
- 32 │         let Sc {} = Sc<Cup<TnoK>> {};
-    │             ^^^^^ 'copy' constraint not satisifed
-    ·
- 32 │         let Sc {} = Sc<Cup<TnoK>> {};
-    │                        --------- The type '0x42::M::Cup<TnoK>' does not have the ability 'copy'
-    ·
-  3 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
- 11 │     struct Sc<T: copy> {}
-    │                  ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:32:21 ───
-    │
- 32 │         let Sc {} = Sc<Cup<TnoK>> {};
-    │                     ^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 32 │         let Sc {} = Sc<Cup<TnoK>> {};
-    │                        --------- The type '0x42::M::Cup<TnoK>' does not have the ability 'copy'
-    ·
-  3 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
- 11 │     struct Sc<T: copy> {}
-    │                  ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:33:13 ───
-    │
- 33 │         let Sc {} = Sc<Box<TnoC>> {};
-    │             ^^^^^ 'copy' constraint not satisifed
-    ·
- 33 │         let Sc {} = Sc<Box<TnoC>> {};
-    │                        --------- The type '0x42::M::Box<TnoC>' does not have the ability 'copy'
-    ·
- 33 │         let Sc {} = Sc<Box<TnoC>> {};
-    │                            ---- The type '0x42::M::Box<TnoC>' can have the ability 'copy' but the type argument 'TnoC' does not have the required ability 'copy'
-    ·
- 11 │     struct Sc<T: copy> {}
-    │                  ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:33:21 ───
-    │
- 33 │         let Sc {} = Sc<Box<TnoC>> {};
-    │                     ^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 33 │         let Sc {} = Sc<Box<TnoC>> {};
-    │                        --------- The type '0x42::M::Box<TnoC>' does not have the ability 'copy'
-    ·
- 33 │         let Sc {} = Sc<Box<TnoC>> {};
-    │                            ---- The type '0x42::M::Box<TnoC>' can have the ability 'copy' but the type argument 'TnoC' does not have the required ability 'copy'
-    ·
- 11 │     struct Sc<T: copy> {}
-    │                  ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:34:13 ───
-    │
- 34 │         let Sk {} = Sk<TnoK> {};
-    │             ^^^^^ 'key' constraint not satisifed
-    ·
- 34 │         let Sk {} = Sk<TnoK> {};
-    │                        ---- The type 'TnoK' does not have the ability 'key'
-    ·
- 18 │         TnoK: copy + drop + store,
-    │         ---- To satisfy the constraint, the 'key' ability would need to be added here
-    ·
- 12 │     struct Sk<T: key> {}
-    │                  --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:34:21 ───
-    │
- 34 │         let Sk {} = Sk<TnoK> {};
-    │                     ^^^^^^^^^^^ 'key' constraint not satisifed
-    ·
- 34 │         let Sk {} = Sk<TnoK> {};
-    │                        ---- The type 'TnoK' does not have the ability 'key'
-    ·
- 18 │         TnoK: copy + drop + store,
-    │         ---- To satisfy the constraint, the 'key' ability would need to be added here
-    ·
- 12 │     struct Sk<T: key> {}
-    │                  --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:35:13 ───
-    │
- 35 │         let Sk {} = Sk<Cup<TnoC>> {};
-    │             ^^^^^ 'key' constraint not satisifed
-    ·
- 35 │         let Sk {} = Sk<Cup<TnoC>> {};
-    │                        --------- The type '0x42::M::Cup<TnoC>' does not have the ability 'key'
-    ·
-  3 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'key' ability would need to be added here
-    ·
- 12 │     struct Sk<T: key> {}
-    │                  --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:35:21 ───
-    │
- 35 │         let Sk {} = Sk<Cup<TnoC>> {};
-    │                     ^^^^^^^^^^^^^^^^ 'key' constraint not satisifed
-    ·
- 35 │         let Sk {} = Sk<Cup<TnoC>> {};
-    │                        --------- The type '0x42::M::Cup<TnoC>' does not have the ability 'key'
-    ·
-  3 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'key' ability would need to be added here
-    ·
- 12 │     struct Sk<T: key> {}
-    │                  --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:36:13 ───
-    │
- 36 │         let Sk {} = Sk<Box<Cup<TnoC>>> {};
-    │             ^^^^^ 'key' constraint not satisifed
-    ·
- 36 │         let Sk {} = Sk<Box<Cup<TnoC>>> {};
-    │                        -------------- The type '0x42::M::Box<0x42::M::Cup<TnoC>>' does not have the ability 'key'
-    ·
- 36 │         let Sk {} = Sk<Box<Cup<TnoC>>> {};
-    │                            --------- The type '0x42::M::Box<0x42::M::Cup<TnoC>>' can have the ability 'key' but the type argument '0x42::M::Cup<TnoC>' does not have the required ability 'store'
-    ·
- 12 │     struct Sk<T: key> {}
-    │                  --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:36:21 ───
-    │
- 36 │         let Sk {} = Sk<Box<Cup<TnoC>>> {};
-    │                     ^^^^^^^^^^^^^^^^^^^^^ 'key' constraint not satisifed
-    ·
- 36 │         let Sk {} = Sk<Box<Cup<TnoC>>> {};
-    │                        -------------- The type '0x42::M::Box<0x42::M::Cup<TnoC>>' does not have the ability 'key'
-    ·
- 36 │         let Sk {} = Sk<Box<Cup<TnoC>>> {};
-    │                            --------- The type '0x42::M::Box<0x42::M::Cup<TnoC>>' can have the ability 'key' but the type argument '0x42::M::Cup<TnoC>' does not have the required ability 'store'
-    ·
- 12 │     struct Sk<T: key> {}
-    │                  --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:37:13 ───
-    │
- 37 │         let Scds {} = Scds<TnoC> {};
-    │             ^^^^^^^ 'copy' constraint not satisifed
-    ·
- 37 │         let Scds {} = Scds<TnoC> {};
-    │                            ---- The type 'TnoC' does not have the ability 'copy'
-    ·
- 17 │         TnoC: drop + store + key,
-    │         ---- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
- 13 │     struct Scds<T: copy + drop + store> {}
-    │                    ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:37:23 ───
-    │
- 37 │         let Scds {} = Scds<TnoC> {};
-    │                       ^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 37 │         let Scds {} = Scds<TnoC> {};
-    │                            ---- The type 'TnoC' does not have the ability 'copy'
-    ·
- 17 │         TnoC: drop + store + key,
-    │         ---- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
- 13 │     struct Scds<T: copy + drop + store> {}
-    │                    ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:38:13 ───
-    │
- 38 │         let Scds {} = Scds<Cup<TnoC>> {};
-    │             ^^^^^^^ 'copy' constraint not satisifed
-    ·
- 38 │         let Scds {} = Scds<Cup<TnoC>> {};
-    │                            --------- The type '0x42::M::Cup<TnoC>' does not have the ability 'copy'
-    ·
-  3 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
- 13 │     struct Scds<T: copy + drop + store> {}
-    │                    ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:38:13 ───
-    │
- 38 │         let Scds {} = Scds<Cup<TnoC>> {};
-    │             ^^^^^^^ 'drop' constraint not satisifed
-    ·
- 38 │         let Scds {} = Scds<Cup<TnoC>> {};
-    │                            --------- The type '0x42::M::Cup<TnoC>' does not have the ability 'drop'
-    ·
-  3 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'drop' ability would need to be added here
-    ·
- 13 │     struct Scds<T: copy + drop + store> {}
-    │                           ---- 'drop' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:38:13 ───
-    │
- 38 │         let Scds {} = Scds<Cup<TnoC>> {};
-    │             ^^^^^^^ 'store' constraint not satisifed
-    ·
- 38 │         let Scds {} = Scds<Cup<TnoC>> {};
-    │                            --------- The type '0x42::M::Cup<TnoC>' does not have the ability 'store'
-    ·
-  3 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'store' ability would need to be added here
-    ·
- 13 │     struct Scds<T: copy + drop + store> {}
-    │                                  ----- 'store' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:38:23 ───
-    │
- 38 │         let Scds {} = Scds<Cup<TnoC>> {};
-    │                       ^^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 38 │         let Scds {} = Scds<Cup<TnoC>> {};
-    │                            --------- The type '0x42::M::Cup<TnoC>' does not have the ability 'copy'
-    ·
-  3 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
- 13 │     struct Scds<T: copy + drop + store> {}
-    │                    ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:38:23 ───
-    │
- 38 │         let Scds {} = Scds<Cup<TnoC>> {};
-    │                       ^^^^^^^^^^^^^^^^^^ 'drop' constraint not satisifed
-    ·
- 38 │         let Scds {} = Scds<Cup<TnoC>> {};
-    │                            --------- The type '0x42::M::Cup<TnoC>' does not have the ability 'drop'
-    ·
-  3 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'drop' ability would need to be added here
-    ·
- 13 │     struct Scds<T: copy + drop + store> {}
-    │                           ---- 'drop' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:38:23 ───
-    │
- 38 │         let Scds {} = Scds<Cup<TnoC>> {};
-    │                       ^^^^^^^^^^^^^^^^^^ 'store' constraint not satisifed
-    ·
- 38 │         let Scds {} = Scds<Cup<TnoC>> {};
-    │                            --------- The type '0x42::M::Cup<TnoC>' does not have the ability 'store'
-    ·
-  3 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'store' ability would need to be added here
-    ·
- 13 │     struct Scds<T: copy + drop + store> {}
-    │                                  ----- 'store' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:39:13 ───
-    │
- 39 │         let Scds {} = Scds<Cup<TnoK>> {};
-    │             ^^^^^^^ 'copy' constraint not satisifed
-    ·
- 39 │         let Scds {} = Scds<Cup<TnoK>> {};
-    │                            --------- The type '0x42::M::Cup<TnoK>' does not have the ability 'copy'
-    ·
-  3 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
- 13 │     struct Scds<T: copy + drop + store> {}
-    │                    ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:39:13 ───
-    │
- 39 │         let Scds {} = Scds<Cup<TnoK>> {};
-    │             ^^^^^^^ 'drop' constraint not satisifed
-    ·
- 39 │         let Scds {} = Scds<Cup<TnoK>> {};
-    │                            --------- The type '0x42::M::Cup<TnoK>' does not have the ability 'drop'
-    ·
-  3 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'drop' ability would need to be added here
-    ·
- 13 │     struct Scds<T: copy + drop + store> {}
-    │                           ---- 'drop' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:39:13 ───
-    │
- 39 │         let Scds {} = Scds<Cup<TnoK>> {};
-    │             ^^^^^^^ 'store' constraint not satisifed
-    ·
- 39 │         let Scds {} = Scds<Cup<TnoK>> {};
-    │                            --------- The type '0x42::M::Cup<TnoK>' does not have the ability 'store'
-    ·
-  3 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'store' ability would need to be added here
-    ·
- 13 │     struct Scds<T: copy + drop + store> {}
-    │                                  ----- 'store' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:39:23 ───
-    │
- 39 │         let Scds {} = Scds<Cup<TnoK>> {};
-    │                       ^^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 39 │         let Scds {} = Scds<Cup<TnoK>> {};
-    │                            --------- The type '0x42::M::Cup<TnoK>' does not have the ability 'copy'
-    ·
-  3 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
- 13 │     struct Scds<T: copy + drop + store> {}
-    │                    ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:39:23 ───
-    │
- 39 │         let Scds {} = Scds<Cup<TnoK>> {};
-    │                       ^^^^^^^^^^^^^^^^^^ 'drop' constraint not satisifed
-    ·
- 39 │         let Scds {} = Scds<Cup<TnoK>> {};
-    │                            --------- The type '0x42::M::Cup<TnoK>' does not have the ability 'drop'
-    ·
-  3 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'drop' ability would need to be added here
-    ·
- 13 │     struct Scds<T: copy + drop + store> {}
-    │                           ---- 'drop' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:39:23 ───
-    │
- 39 │         let Scds {} = Scds<Cup<TnoK>> {};
-    │                       ^^^^^^^^^^^^^^^^^^ 'store' constraint not satisifed
-    ·
- 39 │         let Scds {} = Scds<Cup<TnoK>> {};
-    │                            --------- The type '0x42::M::Cup<TnoK>' does not have the ability 'store'
-    ·
-  3 │     struct Cup<T> {}
-    │            --- To satisfy the constraint, the 'store' ability would need to be added here
-    ·
- 13 │     struct Scds<T: copy + drop + store> {}
-    │                                  ----- 'store' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:40:13 ───
-    │
- 40 │         let Scds {} = Scds<Pair<u64, TnoC>> {};
-    │             ^^^^^^^ 'copy' constraint not satisifed
-    ·
- 40 │         let Scds {} = Scds<Pair<u64, TnoC>> {};
-    │                            --------------- The type '0x42::M::Pair<u64, TnoC>' does not have the ability 'copy'
-    ·
- 40 │         let Scds {} = Scds<Pair<u64, TnoC>> {};
-    │                                      ---- The type '0x42::M::Pair<u64, TnoC>' can have the ability 'copy' but the type argument 'TnoC' does not have the required ability 'copy'
-    ·
- 13 │     struct Scds<T: copy + drop + store> {}
-    │                    ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/ability_constraint_tparams_invalid.move:40:23 ───
-    │
- 40 │         let Scds {} = Scds<Pair<u64, TnoC>> {};
-    │                       ^^^^^^^^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 40 │         let Scds {} = Scds<Pair<u64, TnoC>> {};
-    │                            --------------- The type '0x42::M::Pair<u64, TnoC>' does not have the ability 'copy'
-    ·
- 40 │         let Scds {} = Scds<Pair<u64, TnoC>> {};
-    │                                      ---- The type '0x42::M::Pair<u64, TnoC>' can have the ability 'copy' but the type argument 'TnoC' does not have the required ability 'copy'
-    ·
- 13 │     struct Scds<T: copy + drop + store> {}
-    │                    ---- 'copy' constraint declared here
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:21:9
+   │
+ 7 │     fun c<T: copy>() {}
+   │              ---- 'copy' constraint declared here
+   ·
+17 │         TnoC: drop + store + key,
+   │         ---- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+21 │         c<TnoC>();
+   │         ^^^^^^^^^
+   │         │ │
+   │         │ The type 'TnoC' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:22:9
+   │
+ 3 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+ 7 │     fun c<T: copy>() {}
+   │              ---- 'copy' constraint declared here
+   ·
+22 │         c<Cup<TnoK>>();
+   │         ^^^^^^^^^^^^^^
+   │         │ │
+   │         │ The type '0x42::M::Cup<TnoK>' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:23:9
+   │
+ 7 │     fun c<T: copy>() {}
+   │              ---- 'copy' constraint declared here
+   ·
+23 │         c<Box<TnoC>>();
+   │         ^^^^^^^^^^^^^^
+   │         │ │   │
+   │         │ │   The type '0x42::M::Box<TnoC>' can have the ability 'copy' but the type argument 'TnoC' does not have the required ability 'copy'
+   │         │ The type '0x42::M::Box<TnoC>' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:24:9
+   │
+ 8 │     fun k<T: key>() {}
+   │              --- 'key' constraint declared here
+   ·
+18 │         TnoK: copy + drop + store,
+   │         ---- To satisfy the constraint, the 'key' ability would need to be added here
+   ·
+24 │         k<TnoK>();
+   │         ^^^^^^^^^
+   │         │ │
+   │         │ The type 'TnoK' does not have the ability 'key'
+   │         'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:25:9
+   │
+ 3 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'key' ability would need to be added here
+   ·
+ 8 │     fun k<T: key>() {}
+   │              --- 'key' constraint declared here
+   ·
+25 │         k<Cup<TnoC>>();
+   │         ^^^^^^^^^^^^^^
+   │         │ │
+   │         │ The type '0x42::M::Cup<TnoC>' does not have the ability 'key'
+   │         'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:26:9
+   │
+ 8 │     fun k<T: key>() {}
+   │              --- 'key' constraint declared here
+   ·
+26 │         k<Box<Cup<TnoC>>>();
+   │         ^^^^^^^^^^^^^^^^^^^
+   │         │ │   │
+   │         │ │   The type '0x42::M::Box<0x42::M::Cup<TnoC>>' can have the ability 'key' but the type argument '0x42::M::Cup<TnoC>' does not have the required ability 'store'
+   │         │ The type '0x42::M::Box<0x42::M::Cup<TnoC>>' does not have the ability 'key'
+   │         'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:27:9
+   │
+ 9 │     fun cds<T: copy + drop + store>() {}
+   │                ---- 'copy' constraint declared here
+   ·
+17 │         TnoC: drop + store + key,
+   │         ---- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+27 │         cds<TnoC>();
+   │         ^^^^^^^^^^^
+   │         │   │
+   │         │   The type 'TnoC' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:28:9
+   │
+ 3 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+ 9 │     fun cds<T: copy + drop + store>() {}
+   │                ---- 'copy' constraint declared here
+   ·
+28 │         cds<Cup<TnoC>>();
+   │         ^^^^^^^^^^^^^^^^
+   │         │   │
+   │         │   The type '0x42::M::Cup<TnoC>' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:28:9
+   │
+ 3 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+ 9 │     fun cds<T: copy + drop + store>() {}
+   │                       ---- 'drop' constraint declared here
+   ·
+28 │         cds<Cup<TnoC>>();
+   │         ^^^^^^^^^^^^^^^^
+   │         │   │
+   │         │   The type '0x42::M::Cup<TnoC>' does not have the ability 'drop'
+   │         'drop' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:28:9
+   │
+ 3 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'store' ability would need to be added here
+   ·
+ 9 │     fun cds<T: copy + drop + store>() {}
+   │                              ----- 'store' constraint declared here
+   ·
+28 │         cds<Cup<TnoC>>();
+   │         ^^^^^^^^^^^^^^^^
+   │         │   │
+   │         │   The type '0x42::M::Cup<TnoC>' does not have the ability 'store'
+   │         'store' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:29:9
+   │
+ 3 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+ 9 │     fun cds<T: copy + drop + store>() {}
+   │                ---- 'copy' constraint declared here
+   ·
+29 │         cds<Cup<TnoK>>();
+   │         ^^^^^^^^^^^^^^^^
+   │         │   │
+   │         │   The type '0x42::M::Cup<TnoK>' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:29:9
+   │
+ 3 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+ 9 │     fun cds<T: copy + drop + store>() {}
+   │                       ---- 'drop' constraint declared here
+   ·
+29 │         cds<Cup<TnoK>>();
+   │         ^^^^^^^^^^^^^^^^
+   │         │   │
+   │         │   The type '0x42::M::Cup<TnoK>' does not have the ability 'drop'
+   │         'drop' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:29:9
+   │
+ 3 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'store' ability would need to be added here
+   ·
+ 9 │     fun cds<T: copy + drop + store>() {}
+   │                              ----- 'store' constraint declared here
+   ·
+29 │         cds<Cup<TnoK>>();
+   │         ^^^^^^^^^^^^^^^^
+   │         │   │
+   │         │   The type '0x42::M::Cup<TnoK>' does not have the ability 'store'
+   │         'store' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:30:9
+   │
+ 9 │     fun cds<T: copy + drop + store>() {}
+   │                ---- 'copy' constraint declared here
+   ·
+30 │         cds<Pair<u64, TnoC>>();
+   │         ^^^^^^^^^^^^^^^^^^^^^^
+   │         │   │         │
+   │         │   │         The type '0x42::M::Pair<u64, TnoC>' can have the ability 'copy' but the type argument 'TnoC' does not have the required ability 'copy'
+   │         │   The type '0x42::M::Pair<u64, TnoC>' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:31:13
+   │
+11 │     struct Sc<T: copy> {}
+   │                  ---- 'copy' constraint declared here
+   ·
+17 │         TnoC: drop + store + key,
+   │         ---- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+31 │         let Sc {} = Sc<TnoC> {};
+   │             ^^^^^      ---- The type 'TnoC' does not have the ability 'copy'
+   │             │           
+   │             'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:31:21
+   │
+11 │     struct Sc<T: copy> {}
+   │                  ---- 'copy' constraint declared here
+   ·
+17 │         TnoC: drop + store + key,
+   │         ---- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+31 │         let Sc {} = Sc<TnoC> {};
+   │                     ^^^^^^^^^^^
+   │                     │  │
+   │                     │  The type 'TnoC' does not have the ability 'copy'
+   │                     'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:32:13
+   │
+ 3 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+11 │     struct Sc<T: copy> {}
+   │                  ---- 'copy' constraint declared here
+   ·
+32 │         let Sc {} = Sc<Cup<TnoK>> {};
+   │             ^^^^^      --------- The type '0x42::M::Cup<TnoK>' does not have the ability 'copy'
+   │             │           
+   │             'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:32:21
+   │
+ 3 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+11 │     struct Sc<T: copy> {}
+   │                  ---- 'copy' constraint declared here
+   ·
+32 │         let Sc {} = Sc<Cup<TnoK>> {};
+   │                     ^^^^^^^^^^^^^^^^
+   │                     │  │
+   │                     │  The type '0x42::M::Cup<TnoK>' does not have the ability 'copy'
+   │                     'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:33:13
+   │
+11 │     struct Sc<T: copy> {}
+   │                  ---- 'copy' constraint declared here
+   ·
+33 │         let Sc {} = Sc<Box<TnoC>> {};
+   │             ^^^^^      ---------
+   │             │          │   │
+   │             │          │   The type '0x42::M::Box<TnoC>' can have the ability 'copy' but the type argument 'TnoC' does not have the required ability 'copy'
+   │             │          The type '0x42::M::Box<TnoC>' does not have the ability 'copy'
+   │             'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:33:21
+   │
+11 │     struct Sc<T: copy> {}
+   │                  ---- 'copy' constraint declared here
+   ·
+33 │         let Sc {} = Sc<Box<TnoC>> {};
+   │                     ^^^^^^^^^^^^^^^^
+   │                     │  │   │
+   │                     │  │   The type '0x42::M::Box<TnoC>' can have the ability 'copy' but the type argument 'TnoC' does not have the required ability 'copy'
+   │                     │  The type '0x42::M::Box<TnoC>' does not have the ability 'copy'
+   │                     'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:34:13
+   │
+12 │     struct Sk<T: key> {}
+   │                  --- 'key' constraint declared here
+   ·
+18 │         TnoK: copy + drop + store,
+   │         ---- To satisfy the constraint, the 'key' ability would need to be added here
+   ·
+34 │         let Sk {} = Sk<TnoK> {};
+   │             ^^^^^      ---- The type 'TnoK' does not have the ability 'key'
+   │             │           
+   │             'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:34:21
+   │
+12 │     struct Sk<T: key> {}
+   │                  --- 'key' constraint declared here
+   ·
+18 │         TnoK: copy + drop + store,
+   │         ---- To satisfy the constraint, the 'key' ability would need to be added here
+   ·
+34 │         let Sk {} = Sk<TnoK> {};
+   │                     ^^^^^^^^^^^
+   │                     │  │
+   │                     │  The type 'TnoK' does not have the ability 'key'
+   │                     'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:35:13
+   │
+ 3 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'key' ability would need to be added here
+   ·
+12 │     struct Sk<T: key> {}
+   │                  --- 'key' constraint declared here
+   ·
+35 │         let Sk {} = Sk<Cup<TnoC>> {};
+   │             ^^^^^      --------- The type '0x42::M::Cup<TnoC>' does not have the ability 'key'
+   │             │           
+   │             'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:35:21
+   │
+ 3 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'key' ability would need to be added here
+   ·
+12 │     struct Sk<T: key> {}
+   │                  --- 'key' constraint declared here
+   ·
+35 │         let Sk {} = Sk<Cup<TnoC>> {};
+   │                     ^^^^^^^^^^^^^^^^
+   │                     │  │
+   │                     │  The type '0x42::M::Cup<TnoC>' does not have the ability 'key'
+   │                     'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:36:13
+   │
+12 │     struct Sk<T: key> {}
+   │                  --- 'key' constraint declared here
+   ·
+36 │         let Sk {} = Sk<Box<Cup<TnoC>>> {};
+   │             ^^^^^      --------------
+   │             │          │   │
+   │             │          │   The type '0x42::M::Box<0x42::M::Cup<TnoC>>' can have the ability 'key' but the type argument '0x42::M::Cup<TnoC>' does not have the required ability 'store'
+   │             │          The type '0x42::M::Box<0x42::M::Cup<TnoC>>' does not have the ability 'key'
+   │             'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:36:21
+   │
+12 │     struct Sk<T: key> {}
+   │                  --- 'key' constraint declared here
+   ·
+36 │         let Sk {} = Sk<Box<Cup<TnoC>>> {};
+   │                     ^^^^^^^^^^^^^^^^^^^^^
+   │                     │  │   │
+   │                     │  │   The type '0x42::M::Box<0x42::M::Cup<TnoC>>' can have the ability 'key' but the type argument '0x42::M::Cup<TnoC>' does not have the required ability 'store'
+   │                     │  The type '0x42::M::Box<0x42::M::Cup<TnoC>>' does not have the ability 'key'
+   │                     'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:37:13
+   │
+13 │     struct Scds<T: copy + drop + store> {}
+   │                    ---- 'copy' constraint declared here
+   ·
+17 │         TnoC: drop + store + key,
+   │         ---- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+37 │         let Scds {} = Scds<TnoC> {};
+   │             ^^^^^^^        ---- The type 'TnoC' does not have the ability 'copy'
+   │             │               
+   │             'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:37:23
+   │
+13 │     struct Scds<T: copy + drop + store> {}
+   │                    ---- 'copy' constraint declared here
+   ·
+17 │         TnoC: drop + store + key,
+   │         ---- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+37 │         let Scds {} = Scds<TnoC> {};
+   │                       ^^^^^^^^^^^^^
+   │                       │    │
+   │                       │    The type 'TnoC' does not have the ability 'copy'
+   │                       'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:38:13
+   │
+ 3 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+13 │     struct Scds<T: copy + drop + store> {}
+   │                    ---- 'copy' constraint declared here
+   ·
+38 │         let Scds {} = Scds<Cup<TnoC>> {};
+   │             ^^^^^^^        --------- The type '0x42::M::Cup<TnoC>' does not have the ability 'copy'
+   │             │               
+   │             'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:38:13
+   │
+ 3 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+13 │     struct Scds<T: copy + drop + store> {}
+   │                           ---- 'drop' constraint declared here
+   ·
+38 │         let Scds {} = Scds<Cup<TnoC>> {};
+   │             ^^^^^^^        --------- The type '0x42::M::Cup<TnoC>' does not have the ability 'drop'
+   │             │               
+   │             'drop' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:38:13
+   │
+ 3 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'store' ability would need to be added here
+   ·
+13 │     struct Scds<T: copy + drop + store> {}
+   │                                  ----- 'store' constraint declared here
+   ·
+38 │         let Scds {} = Scds<Cup<TnoC>> {};
+   │             ^^^^^^^        --------- The type '0x42::M::Cup<TnoC>' does not have the ability 'store'
+   │             │               
+   │             'store' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:38:23
+   │
+ 3 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+13 │     struct Scds<T: copy + drop + store> {}
+   │                    ---- 'copy' constraint declared here
+   ·
+38 │         let Scds {} = Scds<Cup<TnoC>> {};
+   │                       ^^^^^^^^^^^^^^^^^^
+   │                       │    │
+   │                       │    The type '0x42::M::Cup<TnoC>' does not have the ability 'copy'
+   │                       'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:38:23
+   │
+ 3 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+13 │     struct Scds<T: copy + drop + store> {}
+   │                           ---- 'drop' constraint declared here
+   ·
+38 │         let Scds {} = Scds<Cup<TnoC>> {};
+   │                       ^^^^^^^^^^^^^^^^^^
+   │                       │    │
+   │                       │    The type '0x42::M::Cup<TnoC>' does not have the ability 'drop'
+   │                       'drop' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:38:23
+   │
+ 3 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'store' ability would need to be added here
+   ·
+13 │     struct Scds<T: copy + drop + store> {}
+   │                                  ----- 'store' constraint declared here
+   ·
+38 │         let Scds {} = Scds<Cup<TnoC>> {};
+   │                       ^^^^^^^^^^^^^^^^^^
+   │                       │    │
+   │                       │    The type '0x42::M::Cup<TnoC>' does not have the ability 'store'
+   │                       'store' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:39:13
+   │
+ 3 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+13 │     struct Scds<T: copy + drop + store> {}
+   │                    ---- 'copy' constraint declared here
+   ·
+39 │         let Scds {} = Scds<Cup<TnoK>> {};
+   │             ^^^^^^^        --------- The type '0x42::M::Cup<TnoK>' does not have the ability 'copy'
+   │             │               
+   │             'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:39:13
+   │
+ 3 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+13 │     struct Scds<T: copy + drop + store> {}
+   │                           ---- 'drop' constraint declared here
+   ·
+39 │         let Scds {} = Scds<Cup<TnoK>> {};
+   │             ^^^^^^^        --------- The type '0x42::M::Cup<TnoK>' does not have the ability 'drop'
+   │             │               
+   │             'drop' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:39:13
+   │
+ 3 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'store' ability would need to be added here
+   ·
+13 │     struct Scds<T: copy + drop + store> {}
+   │                                  ----- 'store' constraint declared here
+   ·
+39 │         let Scds {} = Scds<Cup<TnoK>> {};
+   │             ^^^^^^^        --------- The type '0x42::M::Cup<TnoK>' does not have the ability 'store'
+   │             │               
+   │             'store' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:39:23
+   │
+ 3 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+13 │     struct Scds<T: copy + drop + store> {}
+   │                    ---- 'copy' constraint declared here
+   ·
+39 │         let Scds {} = Scds<Cup<TnoK>> {};
+   │                       ^^^^^^^^^^^^^^^^^^
+   │                       │    │
+   │                       │    The type '0x42::M::Cup<TnoK>' does not have the ability 'copy'
+   │                       'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:39:23
+   │
+ 3 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+13 │     struct Scds<T: copy + drop + store> {}
+   │                           ---- 'drop' constraint declared here
+   ·
+39 │         let Scds {} = Scds<Cup<TnoK>> {};
+   │                       ^^^^^^^^^^^^^^^^^^
+   │                       │    │
+   │                       │    The type '0x42::M::Cup<TnoK>' does not have the ability 'drop'
+   │                       'drop' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:39:23
+   │
+ 3 │     struct Cup<T> {}
+   │            --- To satisfy the constraint, the 'store' ability would need to be added here
+   ·
+13 │     struct Scds<T: copy + drop + store> {}
+   │                                  ----- 'store' constraint declared here
+   ·
+39 │         let Scds {} = Scds<Cup<TnoK>> {};
+   │                       ^^^^^^^^^^^^^^^^^^
+   │                       │    │
+   │                       │    The type '0x42::M::Cup<TnoK>' does not have the ability 'store'
+   │                       'store' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:40:13
+   │
+13 │     struct Scds<T: copy + drop + store> {}
+   │                    ---- 'copy' constraint declared here
+   ·
+40 │         let Scds {} = Scds<Pair<u64, TnoC>> {};
+   │             ^^^^^^^        ---------------
+   │             │              │         │
+   │             │              │         The type '0x42::M::Pair<u64, TnoC>' can have the ability 'copy' but the type argument 'TnoC' does not have the required ability 'copy'
+   │             │              The type '0x42::M::Pair<u64, TnoC>' does not have the ability 'copy'
+   │             'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:40:23
+   │
+13 │     struct Scds<T: copy + drop + store> {}
+   │                    ---- 'copy' constraint declared here
+   ·
+40 │         let Scds {} = Scds<Pair<u64, TnoC>> {};
+   │                       ^^^^^^^^^^^^^^^^^^^^^^^^
+   │                       │    │         │
+   │                       │    │         The type '0x42::M::Pair<u64, TnoC>' can have the ability 'copy' but the type argument 'TnoC' does not have the required ability 'copy'
+   │                       │    The type '0x42::M::Pair<u64, TnoC>' does not have the ability 'copy'
+   │                       'copy' constraint not satisifed
 

--- a/language/move-lang/tests/move_check/typing/assign_pop_resource.exp
+++ b/language/move-lang/tests/move_check/typing/assign_pop_resource.exp
@@ -1,42 +1,33 @@
-error: 
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/assign_pop_resource.move:5:9
+  │
+2 │     struct R {}
+  │            - To satisfy the constraint, the 'drop' ability would need to be added here
+  ·
+5 │         _ = R{};
+  │         ^   --- The type '0x8675309::M::R' does not have the ability 'drop'
+  │         │    
+  │         Cannot ignore values without the 'drop' ability. The value must be used
 
-   ┌── tests/move_check/typing/assign_pop_resource.move:5:9 ───
-   │
- 5 │         _ = R{};
-   │         ^ Cannot ignore values without the 'drop' ability. The value must be used
-   ·
- 5 │         _ = R{};
-   │             --- The type '0x8675309::M::R' does not have the ability 'drop'
-   ·
- 2 │     struct R {}
-   │            - To satisfy the constraint, the 'drop' ability would need to be added here
-   │
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/assign_pop_resource.move:6:10
+  │
+2 │     struct R {}
+  │            - To satisfy the constraint, the 'drop' ability would need to be added here
+  ·
+6 │         (_, _) = (R{}, R{});
+  │          ^        --- The type '0x8675309::M::R' does not have the ability 'drop'
+  │          │         
+  │          Cannot ignore values without the 'drop' ability. The value must be used
 
-error: 
-
-   ┌── tests/move_check/typing/assign_pop_resource.move:6:10 ───
-   │
- 6 │         (_, _) = (R{}, R{});
-   │          ^ Cannot ignore values without the 'drop' ability. The value must be used
-   ·
- 6 │         (_, _) = (R{}, R{});
-   │                   --- The type '0x8675309::M::R' does not have the ability 'drop'
-   ·
- 2 │     struct R {}
-   │            - To satisfy the constraint, the 'drop' ability would need to be added here
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/assign_pop_resource.move:6:13 ───
-   │
- 6 │         (_, _) = (R{}, R{});
-   │             ^ Cannot ignore values without the 'drop' ability. The value must be used
-   ·
- 6 │         (_, _) = (R{}, R{});
-   │                        --- The type '0x8675309::M::R' does not have the ability 'drop'
-   ·
- 2 │     struct R {}
-   │            - To satisfy the constraint, the 'drop' ability would need to be added here
-   │
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/assign_pop_resource.move:6:13
+  │
+2 │     struct R {}
+  │            - To satisfy the constraint, the 'drop' ability would need to be added here
+  ·
+6 │         (_, _) = (R{}, R{});
+  │             ^          --- The type '0x8675309::M::R' does not have the ability 'drop'
+  │             │           
+  │             Cannot ignore values without the 'drop' ability. The value must be used
 

--- a/language/move-lang/tests/move_check/typing/assign_wrong_arity.exp
+++ b/language/move-lang/tests/move_check/typing/assign_wrong_arity.exp
@@ -1,24 +1,26 @@
-error: 
+error[E04005]: expected a single type
+  ┌─ tests/move_check/typing/assign_wrong_arity.move:5:13
+  │
+5 │         let x;
+  │             ^ Invalid type for local
+6 │         x = ();
+  │             -- Expected a single type, but found expression list type: '()'
 
-   ┌── tests/move_check/typing/assign_wrong_arity.move:5:13 ───
-   │
- 5 │         let x;
-   │             ^ Invalid type for local
-   ·
- 6 │         x = ();
-   │             -- Expected a single type, but found expression list type: '()'
-   │
+error[E04005]: expected a single type
+  ┌─ tests/move_check/typing/assign_wrong_arity.move:6:9
+  │
+6 │         x = ();
+  │         ^   -- Expected a single type, but found expression list type: '()'
+  │         │    
+  │         Invalid type for local
 
-error: 
-
-   ┌── tests/move_check/typing/assign_wrong_arity.move:6:9 ───
-   │
- 6 │         x = ();
-   │         ^ Invalid type for local
-   ·
- 6 │         x = ();
-   │             -- Expected a single type, but found expression list type: '()'
-   │
+error[E04005]: expected a single type
+  ┌─ tests/move_check/typing/assign_wrong_arity.move:7:9
+  │
+7 │         x = (0, 1, 2);
+  │         ^   --------- Expected a single type, but found expression list type: '(u64, u64, u64)'
+  │         │    
+  │         Invalid type for local
 
 error: 
 
@@ -32,17 +34,6 @@ error:
    ·
  6 │         x = ();
    │             -- Is not compatible with: '()'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/assign_wrong_arity.move:7:9 ───
-   │
- 7 │         x = (0, 1, 2);
-   │         ^ Invalid type for local
-   ·
- 7 │         x = (0, 1, 2);
-   │             --------- Expected a single type, but found expression list type: '(u64, u64, u64)'
    │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/assign_wrong_type.exp
+++ b/language/move-lang/tests/move_check/typing/assign_wrong_type.exp
@@ -1,3 +1,20 @@
+error[E04005]: expected a single type
+   ┌─ tests/move_check/typing/assign_wrong_type.move:13:13
+   │
+13 │         let x;
+   │             ^ Invalid type for local
+   ·
+16 │         x = ();
+   │             -- Expected a single type, but found expression list type: '()'
+
+error[E04005]: expected a single type
+   ┌─ tests/move_check/typing/assign_wrong_type.move:16:9
+   │
+16 │         x = ();
+   │         ^   -- Expected a single type, but found expression list type: '()'
+   │         │    
+   │         Invalid type for local
+
 error: 
 
    ┌── tests/move_check/typing/assign_wrong_type.move:8:9 ───
@@ -25,28 +42,6 @@ error:
  9 │         (S { g }, R { f }) = (R{ f: 0 }, R{ f: 1 });
    │                               --------- Is not compatible with: '0x8675309::M::R'
    │
-
-error: 
-
-    ┌── tests/move_check/typing/assign_wrong_type.move:13:13 ───
-    │
- 13 │         let x;
-    │             ^ Invalid type for local
-    ·
- 16 │         x = ();
-    │             -- Expected a single type, but found expression list type: '()'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/assign_wrong_type.move:16:9 ───
-    │
- 16 │         x = ();
-    │         ^ Invalid type for local
-    ·
- 16 │         x = ();
-    │             -- Expected a single type, but found expression list type: '()'
-    │
 
 error: 
 

--- a/language/move-lang/tests/move_check/typing/bad_type_argument_arity_fun.exp
+++ b/language/move-lang/tests/move_check/typing/bad_type_argument_arity_fun.exp
@@ -1,35 +1,27 @@
-error: 
+error[E03008]: too few type arguments
+   ┌─ tests/move_check/typing/bad_type_argument_arity_fun.move:11:17
+   │
+11 │         let x = foo<>(0);
+   │                 ^^^^^^^^ Invalid instantiation of '0x42::M::foo'. Expected 1 type argument(s) but got 0
 
-    ┌── tests/move_check/typing/bad_type_argument_arity_fun.move:11:17 ───
-    │
- 11 │         let x = foo<>(0);
-    │                 ^^^^^^^^ Invalid instantiation of '0x42::M::foo'. Expected 1 type argument(s) but got 0
-    │
+error[E03007]: too many type arguments
+   ┌─ tests/move_check/typing/bad_type_argument_arity_fun.move:12:17
+   │
+12 │         let b = foo<bool, u64>(false);
+   │                 ^^^^^^^^^^^^^^^^^^^^^ Invalid instantiation of '0x42::M::foo'. Expected 1 type argument(s) but got 2
 
-error: 
+error[E03007]: too many type arguments
+   ┌─ tests/move_check/typing/bad_type_argument_arity_fun.move:14:17
+   │
+14 │         let r = foo<&mut u64, bool>(&mut 0);
+   │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid instantiation of '0x42::M::foo'. Expected 1 type argument(s) but got 2
 
-    ┌── tests/move_check/typing/bad_type_argument_arity_fun.move:12:17 ───
-    │
- 12 │         let b = foo<bool, u64>(false);
-    │                 ^^^^^^^^^^^^^^^^^^^^^ Invalid instantiation of '0x42::M::foo'. Expected 1 type argument(s) but got 2
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/bad_type_argument_arity_fun.move:14:17 ───
-    │
- 14 │         let r = foo<&mut u64, bool>(&mut 0);
-    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid instantiation of '0x42::M::foo'. Expected 1 type argument(s) but got 2
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/bad_type_argument_arity_fun.move:14:17 ───
-    │
- 14 │         let r = foo<&mut u64, bool>(&mut 0);
-    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid type argument
-    ·
- 14 │         let r = foo<&mut u64, bool>(&mut 0);
-    │                     -------- Expected a single non-reference type, but found: '&mut u64'
-    │
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/bad_type_argument_arity_fun.move:14:17
+   │
+14 │         let r = foo<&mut u64, bool>(&mut 0);
+   │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │                 │   │
+   │                 │   Expected a single non-reference type, but found: '&mut u64'
+   │                 Invalid type argument
 

--- a/language/move-lang/tests/move_check/typing/binary_add_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_add_invalid.exp
@@ -1,24 +1,186 @@
-error: 
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_add_invalid.move:8:9
+  │
+8 │         false + true;
+  │         ^^^^^
+  │         │
+  │         Invalid argument to '+'
+  │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
-   ┌── tests/move_check/typing/binary_add_invalid.move:8:9 ───
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_add_invalid.move:8:17
+  │
+8 │         false + true;
+  │         -----   ^^^^ Invalid argument to '+'
+  │         │        
+  │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_add_invalid.move:10:9
    │
- 8 │         false + true;
-   │         ^^^^^ Invalid argument to '+'
+10 │         false + 1;
+   │         ^^^^^
+   │         │
+   │         Invalid argument to '+'
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_add_invalid.move:10:17
+   │
+10 │         false + 1;
+   │         -----   ^ Invalid argument to '+'
+   │         │        
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_add_invalid.move:11:9
+   │
+11 │         @0x0 + @0x1;
+   │         ^^^^
+   │         │
+   │         Invalid argument to '+'
+   │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_add_invalid.move:11:16
+   │
+11 │         @0x0 + @0x1;
+   │         ----   ^^^^ Invalid argument to '+'
+   │         │       
+   │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_add_invalid.move:13:9
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
    ·
- 8 │         false + true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-   │
+13 │         r + r;
+   │         ^ Invalid argument to '+'
 
-error: 
-
-   ┌── tests/move_check/typing/binary_add_invalid.move:8:17 ───
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/binary_add_invalid.move:13:9
    │
- 8 │         false + true;
-   │                 ^^^^ Invalid argument to '+'
+ 3 │     struct R {
+   │            - To satisfy the constraint, the 'drop' ability would need to be added here
    ·
- 8 │         false + true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - The type '0x8675309::M::R' does not have the ability 'drop'
+   ·
+13 │         r + r;
+   │         ^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_add_invalid.move:13:13
    │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+   ·
+13 │         r + r;
+   │             ^ Invalid argument to '+'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_add_invalid.move:14:9
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+   ·
+14 │         s + s;
+   │         ^ Invalid argument to '+'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_add_invalid.move:14:13
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+   ·
+14 │         s + s;
+   │             ^ Invalid argument to '+'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_add_invalid.move:15:9
+   │
+15 │         1 + false + @0x0 + 0;
+   │         ^^^^^^^^^
+   │         │   │
+   │         │   Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '+'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_add_invalid.move:15:9
+   │
+15 │         1 + false + @0x0 + 0;
+   │         ^^^^^^^^^^^^^^^^
+   │         │           │
+   │         │           Found: 'address'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '+'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_add_invalid.move:15:21
+   │
+15 │         1 + false + @0x0 + 0;
+   │             -----   ^^^^ Invalid argument to '+'
+   │             │        
+   │             Found: '_'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_add_invalid.move:15:28
+   │
+15 │         1 + false + @0x0 + 0;
+   │                     ----   ^ Invalid argument to '+'
+   │                     │       
+   │                     Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_add_invalid.move:16:9
+   │
+16 │         () + ();
+   │         ^^
+   │         │
+   │         Invalid argument to '+'
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_add_invalid.move:16:14
+   │
+16 │         () + ();
+   │         --   ^^ Invalid argument to '+'
+   │         │     
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_add_invalid.move:18:9
+   │
+18 │         (0, 1) + (0, 1, 2);
+   │         ^^^^^^
+   │         │
+   │         Invalid argument to '+'
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_add_invalid.move:18:18
+   │
+18 │         (0, 1) + (0, 1, 2);
+   │         ------   ^^^^^^^^^ Invalid argument to '+'
+   │         │         
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_add_invalid.move:19:9
+   │
+19 │         (1, 2) + (0, 1);
+   │         ^^^^^^
+   │         │
+   │         Invalid argument to '+'
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_add_invalid.move:19:18
+   │
+19 │         (1, 2) + (0, 1);
+   │         ------   ^^^^^^ Invalid argument to '+'
+   │         │         
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
 
 error: 
 
@@ -36,17 +198,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_add_invalid.move:10:9 ───
-    │
- 10 │         false + 1;
-    │         ^^^^^ Invalid argument to '+'
-    ·
- 10 │         false + 1;
-    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_add_invalid.move:10:17 ───
     │
  10 │         false + 1;
@@ -57,39 +208,6 @@ error:
     ·
  10 │         false + 1;
     │         ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_add_invalid.move:10:17 ───
-    │
- 10 │         false + 1;
-    │                 ^ Invalid argument to '+'
-    ·
- 10 │         false + 1;
-    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_add_invalid.move:11:9 ───
-    │
- 11 │         @0x0 + @0x1;
-    │         ^^^^ Invalid argument to '+'
-    ·
- 11 │         @0x0 + @0x1;
-    │         ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_add_invalid.move:11:16 ───
-    │
- 11 │         @0x0 + @0x1;
-    │                ^^^^ Invalid argument to '+'
-    ·
- 11 │         @0x0 + @0x1;
-    │         ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -108,86 +226,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_add_invalid.move:13:9 ───
-    │
- 13 │         r + r;
-    │         ^ Invalid argument to '+'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_add_invalid.move:13:9 ───
-    │
- 13 │         r + r;
-    │         ^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - The type '0x8675309::M::R' does not have the ability 'drop'
-    ·
-  3 │     struct R {
-    │            - To satisfy the constraint, the 'drop' ability would need to be added here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_add_invalid.move:13:13 ───
-    │
- 13 │         r + r;
-    │             ^ Invalid argument to '+'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_add_invalid.move:14:9 ───
-    │
- 14 │         s + s;
-    │         ^ Invalid argument to '+'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_add_invalid.move:14:13 ───
-    │
- 14 │         s + s;
-    │             ^ Invalid argument to '+'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_add_invalid.move:15:9 ───
-    │
- 15 │         1 + false + @0x0 + 0;
-    │         ^^^^^^^^^ Invalid argument to '+'
-    ·
- 15 │         1 + false + @0x0 + 0;
-    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_add_invalid.move:15:9 ───
-    │
- 15 │         1 + false + @0x0 + 0;
-    │         ^^^^^^^^^^^^^^^^ Invalid argument to '+'
-    ·
- 15 │         1 + false + @0x0 + 0;
-    │                     ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_add_invalid.move:15:13 ───
     │
  15 │         1 + false + @0x0 + 0;
@@ -198,17 +236,6 @@ error:
     ·
  15 │         1 + false + @0x0 + 0;
     │             ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_add_invalid.move:15:21 ───
-    │
- 15 │         1 + false + @0x0 + 0;
-    │                     ^^^^ Invalid argument to '+'
-    ·
- 15 │         1 + false + @0x0 + 0;
-    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -227,39 +254,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_add_invalid.move:15:28 ───
-    │
- 15 │         1 + false + @0x0 + 0;
-    │                            ^ Invalid argument to '+'
-    ·
- 15 │         1 + false + @0x0 + 0;
-    │                     ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_add_invalid.move:16:9 ───
-    │
- 16 │         () + ();
-    │         ^^ Invalid argument to '+'
-    ·
- 16 │         () + ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_add_invalid.move:16:14 ───
-    │
- 16 │         () + ();
-    │              ^^ Invalid argument to '+'
-    ·
- 16 │         () + ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_add_invalid.move:17:13 ───
     │
  17 │         1 + ();
@@ -274,17 +268,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_add_invalid.move:18:9 ───
-    │
- 18 │         (0, 1) + (0, 1, 2);
-    │         ^^^^^^ Invalid argument to '+'
-    ·
- 18 │         (0, 1) + (0, 1, 2);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_add_invalid.move:18:18 ───
     │
  18 │         (0, 1) + (0, 1, 2);
@@ -295,38 +278,5 @@ error:
     ·
  18 │         (0, 1) + (0, 1, 2);
     │                  --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_add_invalid.move:18:18 ───
-    │
- 18 │         (0, 1) + (0, 1, 2);
-    │                  ^^^^^^^^^ Invalid argument to '+'
-    ·
- 18 │         (0, 1) + (0, 1, 2);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_add_invalid.move:19:9 ───
-    │
- 19 │         (1, 2) + (0, 1);
-    │         ^^^^^^ Invalid argument to '+'
-    ·
- 19 │         (1, 2) + (0, 1);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_add_invalid.move:19:18 ───
-    │
- 19 │         (1, 2) + (0, 1);
-    │                  ^^^^^^ Invalid argument to '+'
-    ·
- 19 │         (1, 2) + (0, 1);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
     │
 

--- a/language/move-lang/tests/move_check/typing/binary_bit_and_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_bit_and_invalid.exp
@@ -1,46 +1,294 @@
-error: 
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_bit_and_invalid.move:8:9
+  │
+8 │         false & true;
+  │         ^^^^^
+  │         │
+  │         Invalid argument to '&'
+  │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
-   ┌── tests/move_check/typing/binary_bit_and_invalid.move:8:9 ───
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_bit_and_invalid.move:8:9
+  │
+8 │         false & true;
+  │         ^^^^^^^^^^^^
+  │         │       │
+  │         │       Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+  │         Invalid argument to '&'
+
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_bit_and_invalid.move:8:17
+  │
+8 │         false & true;
+  │         -----   ^^^^ Invalid argument to '&'
+  │         │        
+  │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_bit_and_invalid.move:9:9
+  │
+9 │         1 & false;
+  │         ^^^^^^^^^
+  │         │   │
+  │         │   Found: '_'. But expected: 'u8', 'u64', 'u128'
+  │         Invalid argument to '&'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:10:9
    │
- 8 │         false & true;
+10 │         false & 1;
+   │         ^^^^^
+   │         │
+   │         Invalid argument to '&'
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:10:9
+   │
+10 │         false & 1;
+   │         ^^^^^^^^^
+   │         │       │
+   │         │       Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '&'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:10:17
+   │
+10 │         false & 1;
+   │         -----   ^ Invalid argument to '&'
+   │         │        
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:11:9
+   │
+11 │         @0x0 & @0x1;
+   │         ^^^^
+   │         │
+   │         Invalid argument to '&'
+   │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:11:9
+   │
+11 │         @0x0 & @0x1;
+   │         ^^^^^^^^^^^
+   │         │      │
+   │         │      Found: 'address'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '&'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:11:16
+   │
+11 │         @0x0 & @0x1;
+   │         ----   ^^^^ Invalid argument to '&'
+   │         │       
+   │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:12:9
+   │
+12 │         (0: u8) & (1: u128);
+   │         ^^^^^^^^^^^^^^^^^^^
+   │         │         │
+   │         │         Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '&'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:13:9
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+   ·
+13 │         r & r;
+   │         ^ Invalid argument to '&'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:13:9
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+   ·
+13 │         r & r;
    │         ^^^^^ Invalid argument to '&'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:13:9
+   │
+ 3 │     struct R {
+   │            - To satisfy the constraint, the 'drop' ability would need to be added here
    ·
- 8 │         false & true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/binary_bit_and_invalid.move:8:9 ───
-   │
- 8 │         false & true;
-   │         ^^^^^^^^^^^^ Invalid argument to '&'
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - The type '0x8675309::M::R' does not have the ability 'drop'
    ·
- 8 │         false & true;
-   │                 ---- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-   │
+13 │         r & r;
+   │         ^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
 
-error: 
-
-   ┌── tests/move_check/typing/binary_bit_and_invalid.move:8:17 ───
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:13:13
    │
- 8 │         false & true;
-   │                 ^^^^ Invalid argument to '&'
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
    ·
- 8 │         false & true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-   │
+13 │         r & r;
+   │             ^ Invalid argument to '&'
 
-error: 
-
-   ┌── tests/move_check/typing/binary_bit_and_invalid.move:9:9 ───
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:14:9
    │
- 9 │         1 & false;
-   │         ^^^^^^^^^ Invalid argument to '&'
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
    ·
- 9 │         1 & false;
-   │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
+14 │         s & s;
+   │         ^ Invalid argument to '&'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:14:9
    │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+   ·
+14 │         s & s;
+   │         ^^^^^ Invalid argument to '&'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:14:13
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+   ·
+14 │         s & s;
+   │             ^ Invalid argument to '&'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:15:9
+   │
+15 │         1 & false & @0x0 & 0;
+   │         ^^^^^^^^^
+   │         │   │
+   │         │   Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '&'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:15:9
+   │
+15 │         1 & false & @0x0 & 0;
+   │         ^^^^^^^^^^^^^^^^
+   │         │           │
+   │         │           Found: 'address'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '&'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:15:9
+   │
+15 │         1 & false & @0x0 & 0;
+   │         ^^^^^^^^^^^^^^^^^^^^
+   │         │                  │
+   │         │                  Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '&'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:15:21
+   │
+15 │         1 & false & @0x0 & 0;
+   │             -----   ^^^^ Invalid argument to '&'
+   │             │        
+   │             Found: '_'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:15:28
+   │
+15 │         1 & false & @0x0 & 0;
+   │                     ----   ^ Invalid argument to '&'
+   │                     │       
+   │                     Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:16:9
+   │
+16 │         () & ();
+   │         ^^
+   │         │
+   │         Invalid argument to '&'
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:16:9
+   │
+16 │         () & ();
+   │         ^^^^^^^
+   │         │    │
+   │         │    Found: '()'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '&'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:16:14
+   │
+16 │         () & ();
+   │         --   ^^ Invalid argument to '&'
+   │         │     
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:17:9
+   │
+17 │         1 & ();
+   │         ^^^^^^
+   │         │   │
+   │         │   Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '&'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:18:9
+   │
+18 │         (0, 1) & (0, 1, 2);
+   │         ^^^^^^
+   │         │
+   │         Invalid argument to '&'
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:18:9
+   │
+18 │         (0, 1) & (0, 1, 2);
+   │         ^^^^^^^^^^^^^^^^^^
+   │         │        │
+   │         │        Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '&'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:18:18
+   │
+18 │         (0, 1) & (0, 1, 2);
+   │         ------   ^^^^^^^^^ Invalid argument to '&'
+   │         │         
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:19:9
+   │
+19 │         (1, 2) & (0, 1);
+   │         ^^^^^^
+   │         │
+   │         Invalid argument to '&'
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:19:9
+   │
+19 │         (1, 2) & (0, 1);
+   │         ^^^^^^^^^^^^^^^
+   │         │        │
+   │         │        Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '&'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:19:18
+   │
+19 │         (1, 2) & (0, 1);
+   │         ------   ^^^^^^ Invalid argument to '&'
+   │         │         
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
 
 error: 
 
@@ -58,28 +306,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:10:9 ───
-    │
- 10 │         false & 1;
-    │         ^^^^^ Invalid argument to '&'
-    ·
- 10 │         false & 1;
-    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:10:9 ───
-    │
- 10 │         false & 1;
-    │         ^^^^^^^^^ Invalid argument to '&'
-    ·
- 10 │         false & 1;
-    │                 - Found: '_'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_bit_and_invalid.move:10:17 ───
     │
  10 │         false & 1;
@@ -90,61 +316,6 @@ error:
     ·
  10 │         false & 1;
     │         ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:10:17 ───
-    │
- 10 │         false & 1;
-    │                 ^ Invalid argument to '&'
-    ·
- 10 │         false & 1;
-    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:11:9 ───
-    │
- 11 │         @0x0 & @0x1;
-    │         ^^^^ Invalid argument to '&'
-    ·
- 11 │         @0x0 & @0x1;
-    │         ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:11:9 ───
-    │
- 11 │         @0x0 & @0x1;
-    │         ^^^^^^^^^^^ Invalid argument to '&'
-    ·
- 11 │         @0x0 & @0x1;
-    │                ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:11:16 ───
-    │
- 11 │         @0x0 & @0x1;
-    │                ^^^^ Invalid argument to '&'
-    ·
- 11 │         @0x0 & @0x1;
-    │         ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:12:9 ───
-    │
- 12 │         (0: u8) & (1: u128);
-    │         ^^^^^^^^^^^^^^^^^^^ Invalid argument to '&'
-    ·
- 12 │         (0: u8) & (1: u128);
-    │                   --------- Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -163,119 +334,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:13:9 ───
-    │
- 13 │         r & r;
-    │         ^ Invalid argument to '&'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:13:9 ───
-    │
- 13 │         r & r;
-    │         ^^^^^ Invalid argument to '&'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:13:9 ───
-    │
- 13 │         r & r;
-    │         ^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - The type '0x8675309::M::R' does not have the ability 'drop'
-    ·
-  3 │     struct R {
-    │            - To satisfy the constraint, the 'drop' ability would need to be added here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:13:13 ───
-    │
- 13 │         r & r;
-    │             ^ Invalid argument to '&'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:14:9 ───
-    │
- 14 │         s & s;
-    │         ^ Invalid argument to '&'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:14:9 ───
-    │
- 14 │         s & s;
-    │         ^^^^^ Invalid argument to '&'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:14:13 ───
-    │
- 14 │         s & s;
-    │             ^ Invalid argument to '&'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:15:9 ───
-    │
- 15 │         1 & false & @0x0 & 0;
-    │         ^^^^^^^^^ Invalid argument to '&'
-    ·
- 15 │         1 & false & @0x0 & 0;
-    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:15:9 ───
-    │
- 15 │         1 & false & @0x0 & 0;
-    │         ^^^^^^^^^^^^^^^^ Invalid argument to '&'
-    ·
- 15 │         1 & false & @0x0 & 0;
-    │                     ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:15:9 ───
-    │
- 15 │         1 & false & @0x0 & 0;
-    │         ^^^^^^^^^^^^^^^^^^^^ Invalid argument to '&'
-    ·
- 15 │         1 & false & @0x0 & 0;
-    │                            - Found: '_'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_bit_and_invalid.move:15:13 ───
     │
  15 │         1 & false & @0x0 & 0;
@@ -286,17 +344,6 @@ error:
     ·
  15 │         1 & false & @0x0 & 0;
     │             ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:15:21 ───
-    │
- 15 │         1 & false & @0x0 & 0;
-    │                     ^^^^ Invalid argument to '&'
-    ·
- 15 │         1 & false & @0x0 & 0;
-    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -315,61 +362,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:15:28 ───
-    │
- 15 │         1 & false & @0x0 & 0;
-    │                            ^ Invalid argument to '&'
-    ·
- 15 │         1 & false & @0x0 & 0;
-    │                     ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:16:9 ───
-    │
- 16 │         () & ();
-    │         ^^ Invalid argument to '&'
-    ·
- 16 │         () & ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:16:9 ───
-    │
- 16 │         () & ();
-    │         ^^^^^^^ Invalid argument to '&'
-    ·
- 16 │         () & ();
-    │              -- Found: '()'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:16:14 ───
-    │
- 16 │         () & ();
-    │              ^^ Invalid argument to '&'
-    ·
- 16 │         () & ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:17:9 ───
-    │
- 17 │         1 & ();
-    │         ^^^^^^ Invalid argument to '&'
-    ·
- 17 │         1 & ();
-    │             -- Found: '_'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_bit_and_invalid.move:17:13 ───
     │
  17 │         1 & ();
@@ -384,28 +376,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:18:9 ───
-    │
- 18 │         (0, 1) & (0, 1, 2);
-    │         ^^^^^^ Invalid argument to '&'
-    ·
- 18 │         (0, 1) & (0, 1, 2);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:18:9 ───
-    │
- 18 │         (0, 1) & (0, 1, 2);
-    │         ^^^^^^^^^^^^^^^^^^ Invalid argument to '&'
-    ·
- 18 │         (0, 1) & (0, 1, 2);
-    │                  --------- Found: '_'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_bit_and_invalid.move:18:18 ───
     │
  18 │         (0, 1) & (0, 1, 2);
@@ -416,49 +386,5 @@ error:
     ·
  18 │         (0, 1) & (0, 1, 2);
     │                  --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:18:18 ───
-    │
- 18 │         (0, 1) & (0, 1, 2);
-    │                  ^^^^^^^^^ Invalid argument to '&'
-    ·
- 18 │         (0, 1) & (0, 1, 2);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:19:9 ───
-    │
- 19 │         (1, 2) & (0, 1);
-    │         ^^^^^^ Invalid argument to '&'
-    ·
- 19 │         (1, 2) & (0, 1);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:19:9 ───
-    │
- 19 │         (1, 2) & (0, 1);
-    │         ^^^^^^^^^^^^^^^ Invalid argument to '&'
-    ·
- 19 │         (1, 2) & (0, 1);
-    │                  ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:19:18 ───
-    │
- 19 │         (1, 2) & (0, 1);
-    │                  ^^^^^^ Invalid argument to '&'
-    ·
- 19 │         (1, 2) & (0, 1);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
     │
 

--- a/language/move-lang/tests/move_check/typing/binary_bit_or_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_bit_or_invalid.exp
@@ -1,46 +1,294 @@
-error: 
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_bit_or_invalid.move:8:9
+  │
+8 │         false | true;
+  │         ^^^^^
+  │         │
+  │         Invalid argument to '|'
+  │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
-   ┌── tests/move_check/typing/binary_bit_or_invalid.move:8:9 ───
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_bit_or_invalid.move:8:9
+  │
+8 │         false | true;
+  │         ^^^^^^^^^^^^
+  │         │       │
+  │         │       Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+  │         Invalid argument to '|'
+
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_bit_or_invalid.move:8:17
+  │
+8 │         false | true;
+  │         -----   ^^^^ Invalid argument to '|'
+  │         │        
+  │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_bit_or_invalid.move:9:9
+  │
+9 │         1 | false;
+  │         ^^^^^^^^^
+  │         │   │
+  │         │   Found: '_'. But expected: 'u8', 'u64', 'u128'
+  │         Invalid argument to '|'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:10:9
    │
- 8 │         false | true;
+10 │         false | 1;
+   │         ^^^^^
+   │         │
+   │         Invalid argument to '|'
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:10:9
+   │
+10 │         false | 1;
+   │         ^^^^^^^^^
+   │         │       │
+   │         │       Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '|'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:10:17
+   │
+10 │         false | 1;
+   │         -----   ^ Invalid argument to '|'
+   │         │        
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:11:9
+   │
+11 │         @0x0 | @0x1;
+   │         ^^^^
+   │         │
+   │         Invalid argument to '|'
+   │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:11:9
+   │
+11 │         @0x0 | @0x1;
+   │         ^^^^^^^^^^^
+   │         │      │
+   │         │      Found: 'address'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '|'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:11:16
+   │
+11 │         @0x0 | @0x1;
+   │         ----   ^^^^ Invalid argument to '|'
+   │         │       
+   │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:12:9
+   │
+12 │         (0: u8) | (1: u128);
+   │         ^^^^^^^^^^^^^^^^^^^
+   │         │         │
+   │         │         Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '|'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:13:9
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+   ·
+13 │         r | r;
+   │         ^ Invalid argument to '|'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:13:9
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+   ·
+13 │         r | r;
    │         ^^^^^ Invalid argument to '|'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:13:9
+   │
+ 3 │     struct R {
+   │            - To satisfy the constraint, the 'drop' ability would need to be added here
    ·
- 8 │         false | true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/binary_bit_or_invalid.move:8:9 ───
-   │
- 8 │         false | true;
-   │         ^^^^^^^^^^^^ Invalid argument to '|'
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - The type '0x8675309::M::R' does not have the ability 'drop'
    ·
- 8 │         false | true;
-   │                 ---- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-   │
+13 │         r | r;
+   │         ^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
 
-error: 
-
-   ┌── tests/move_check/typing/binary_bit_or_invalid.move:8:17 ───
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:13:13
    │
- 8 │         false | true;
-   │                 ^^^^ Invalid argument to '|'
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
    ·
- 8 │         false | true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-   │
+13 │         r | r;
+   │             ^ Invalid argument to '|'
 
-error: 
-
-   ┌── tests/move_check/typing/binary_bit_or_invalid.move:9:9 ───
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:14:9
    │
- 9 │         1 | false;
-   │         ^^^^^^^^^ Invalid argument to '|'
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
    ·
- 9 │         1 | false;
-   │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
+14 │         s | s;
+   │         ^ Invalid argument to '|'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:14:9
    │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+   ·
+14 │         s | s;
+   │         ^^^^^ Invalid argument to '|'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:14:13
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+   ·
+14 │         s | s;
+   │             ^ Invalid argument to '|'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:15:9
+   │
+15 │         1 | false | @0x0 | 0;
+   │         ^^^^^^^^^
+   │         │   │
+   │         │   Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '|'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:15:9
+   │
+15 │         1 | false | @0x0 | 0;
+   │         ^^^^^^^^^^^^^^^^
+   │         │           │
+   │         │           Found: 'address'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '|'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:15:9
+   │
+15 │         1 | false | @0x0 | 0;
+   │         ^^^^^^^^^^^^^^^^^^^^
+   │         │                  │
+   │         │                  Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '|'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:15:21
+   │
+15 │         1 | false | @0x0 | 0;
+   │             -----   ^^^^ Invalid argument to '|'
+   │             │        
+   │             Found: '_'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:15:28
+   │
+15 │         1 | false | @0x0 | 0;
+   │                     ----   ^ Invalid argument to '|'
+   │                     │       
+   │                     Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:16:9
+   │
+16 │         () | ();
+   │         ^^
+   │         │
+   │         Invalid argument to '|'
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:16:9
+   │
+16 │         () | ();
+   │         ^^^^^^^
+   │         │    │
+   │         │    Found: '()'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '|'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:16:14
+   │
+16 │         () | ();
+   │         --   ^^ Invalid argument to '|'
+   │         │     
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:17:9
+   │
+17 │         1 | ();
+   │         ^^^^^^
+   │         │   │
+   │         │   Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '|'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:18:9
+   │
+18 │         (0, 1) | (0, 1, 2);
+   │         ^^^^^^
+   │         │
+   │         Invalid argument to '|'
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:18:9
+   │
+18 │         (0, 1) | (0, 1, 2);
+   │         ^^^^^^^^^^^^^^^^^^
+   │         │        │
+   │         │        Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '|'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:18:18
+   │
+18 │         (0, 1) | (0, 1, 2);
+   │         ------   ^^^^^^^^^ Invalid argument to '|'
+   │         │         
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:19:9
+   │
+19 │         (1, 2) | (0, 1);
+   │         ^^^^^^
+   │         │
+   │         Invalid argument to '|'
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:19:9
+   │
+19 │         (1, 2) | (0, 1);
+   │         ^^^^^^^^^^^^^^^
+   │         │        │
+   │         │        Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '|'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:19:18
+   │
+19 │         (1, 2) | (0, 1);
+   │         ------   ^^^^^^ Invalid argument to '|'
+   │         │         
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
 
 error: 
 
@@ -58,28 +306,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:10:9 ───
-    │
- 10 │         false | 1;
-    │         ^^^^^ Invalid argument to '|'
-    ·
- 10 │         false | 1;
-    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:10:9 ───
-    │
- 10 │         false | 1;
-    │         ^^^^^^^^^ Invalid argument to '|'
-    ·
- 10 │         false | 1;
-    │                 - Found: '_'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_bit_or_invalid.move:10:17 ───
     │
  10 │         false | 1;
@@ -90,61 +316,6 @@ error:
     ·
  10 │         false | 1;
     │         ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:10:17 ───
-    │
- 10 │         false | 1;
-    │                 ^ Invalid argument to '|'
-    ·
- 10 │         false | 1;
-    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:11:9 ───
-    │
- 11 │         @0x0 | @0x1;
-    │         ^^^^ Invalid argument to '|'
-    ·
- 11 │         @0x0 | @0x1;
-    │         ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:11:9 ───
-    │
- 11 │         @0x0 | @0x1;
-    │         ^^^^^^^^^^^ Invalid argument to '|'
-    ·
- 11 │         @0x0 | @0x1;
-    │                ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:11:16 ───
-    │
- 11 │         @0x0 | @0x1;
-    │                ^^^^ Invalid argument to '|'
-    ·
- 11 │         @0x0 | @0x1;
-    │         ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:12:9 ───
-    │
- 12 │         (0: u8) | (1: u128);
-    │         ^^^^^^^^^^^^^^^^^^^ Invalid argument to '|'
-    ·
- 12 │         (0: u8) | (1: u128);
-    │                   --------- Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -163,119 +334,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:13:9 ───
-    │
- 13 │         r | r;
-    │         ^ Invalid argument to '|'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:13:9 ───
-    │
- 13 │         r | r;
-    │         ^^^^^ Invalid argument to '|'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:13:9 ───
-    │
- 13 │         r | r;
-    │         ^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - The type '0x8675309::M::R' does not have the ability 'drop'
-    ·
-  3 │     struct R {
-    │            - To satisfy the constraint, the 'drop' ability would need to be added here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:13:13 ───
-    │
- 13 │         r | r;
-    │             ^ Invalid argument to '|'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:14:9 ───
-    │
- 14 │         s | s;
-    │         ^ Invalid argument to '|'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:14:9 ───
-    │
- 14 │         s | s;
-    │         ^^^^^ Invalid argument to '|'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:14:13 ───
-    │
- 14 │         s | s;
-    │             ^ Invalid argument to '|'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:15:9 ───
-    │
- 15 │         1 | false | @0x0 | 0;
-    │         ^^^^^^^^^ Invalid argument to '|'
-    ·
- 15 │         1 | false | @0x0 | 0;
-    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:15:9 ───
-    │
- 15 │         1 | false | @0x0 | 0;
-    │         ^^^^^^^^^^^^^^^^ Invalid argument to '|'
-    ·
- 15 │         1 | false | @0x0 | 0;
-    │                     ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:15:9 ───
-    │
- 15 │         1 | false | @0x0 | 0;
-    │         ^^^^^^^^^^^^^^^^^^^^ Invalid argument to '|'
-    ·
- 15 │         1 | false | @0x0 | 0;
-    │                            - Found: '_'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_bit_or_invalid.move:15:13 ───
     │
  15 │         1 | false | @0x0 | 0;
@@ -286,17 +344,6 @@ error:
     ·
  15 │         1 | false | @0x0 | 0;
     │             ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:15:21 ───
-    │
- 15 │         1 | false | @0x0 | 0;
-    │                     ^^^^ Invalid argument to '|'
-    ·
- 15 │         1 | false | @0x0 | 0;
-    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -315,61 +362,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:15:28 ───
-    │
- 15 │         1 | false | @0x0 | 0;
-    │                            ^ Invalid argument to '|'
-    ·
- 15 │         1 | false | @0x0 | 0;
-    │                     ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:16:9 ───
-    │
- 16 │         () | ();
-    │         ^^ Invalid argument to '|'
-    ·
- 16 │         () | ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:16:9 ───
-    │
- 16 │         () | ();
-    │         ^^^^^^^ Invalid argument to '|'
-    ·
- 16 │         () | ();
-    │              -- Found: '()'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:16:14 ───
-    │
- 16 │         () | ();
-    │              ^^ Invalid argument to '|'
-    ·
- 16 │         () | ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:17:9 ───
-    │
- 17 │         1 | ();
-    │         ^^^^^^ Invalid argument to '|'
-    ·
- 17 │         1 | ();
-    │             -- Found: '_'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_bit_or_invalid.move:17:13 ───
     │
  17 │         1 | ();
@@ -384,28 +376,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:18:9 ───
-    │
- 18 │         (0, 1) | (0, 1, 2);
-    │         ^^^^^^ Invalid argument to '|'
-    ·
- 18 │         (0, 1) | (0, 1, 2);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:18:9 ───
-    │
- 18 │         (0, 1) | (0, 1, 2);
-    │         ^^^^^^^^^^^^^^^^^^ Invalid argument to '|'
-    ·
- 18 │         (0, 1) | (0, 1, 2);
-    │                  --------- Found: '_'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_bit_or_invalid.move:18:18 ───
     │
  18 │         (0, 1) | (0, 1, 2);
@@ -416,49 +386,5 @@ error:
     ·
  18 │         (0, 1) | (0, 1, 2);
     │                  --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:18:18 ───
-    │
- 18 │         (0, 1) | (0, 1, 2);
-    │                  ^^^^^^^^^ Invalid argument to '|'
-    ·
- 18 │         (0, 1) | (0, 1, 2);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:19:9 ───
-    │
- 19 │         (1, 2) | (0, 1);
-    │         ^^^^^^ Invalid argument to '|'
-    ·
- 19 │         (1, 2) | (0, 1);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:19:9 ───
-    │
- 19 │         (1, 2) | (0, 1);
-    │         ^^^^^^^^^^^^^^^ Invalid argument to '|'
-    ·
- 19 │         (1, 2) | (0, 1);
-    │                  ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:19:18 ───
-    │
- 19 │         (1, 2) | (0, 1);
-    │                  ^^^^^^ Invalid argument to '|'
-    ·
- 19 │         (1, 2) | (0, 1);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
     │
 

--- a/language/move-lang/tests/move_check/typing/binary_bit_xor_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_bit_xor_invalid.exp
@@ -1,46 +1,294 @@
-error: 
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:8:9
+  │
+8 │         false ^ true;
+  │         ^^^^^
+  │         │
+  │         Invalid argument to '^'
+  │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
-   ┌── tests/move_check/typing/binary_bit_xor_invalid.move:8:9 ───
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:8:9
+  │
+8 │         false ^ true;
+  │         ^^^^^^^^^^^^
+  │         │       │
+  │         │       Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+  │         Invalid argument to '^'
+
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:8:17
+  │
+8 │         false ^ true;
+  │         -----   ^^^^ Invalid argument to '^'
+  │         │        
+  │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:9:9
+  │
+9 │         1 ^ false;
+  │         ^^^^^^^^^
+  │         │   │
+  │         │   Found: '_'. But expected: 'u8', 'u64', 'u128'
+  │         Invalid argument to '^'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:10:9
    │
- 8 │         false ^ true;
+10 │         false ^ 1;
+   │         ^^^^^
+   │         │
+   │         Invalid argument to '^'
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:10:9
+   │
+10 │         false ^ 1;
+   │         ^^^^^^^^^
+   │         │       │
+   │         │       Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '^'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:10:17
+   │
+10 │         false ^ 1;
+   │         -----   ^ Invalid argument to '^'
+   │         │        
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:11:9
+   │
+11 │         @0x0 ^ @0x1;
+   │         ^^^^
+   │         │
+   │         Invalid argument to '^'
+   │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:11:9
+   │
+11 │         @0x0 ^ @0x1;
+   │         ^^^^^^^^^^^
+   │         │      │
+   │         │      Found: 'address'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '^'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:11:16
+   │
+11 │         @0x0 ^ @0x1;
+   │         ----   ^^^^ Invalid argument to '^'
+   │         │       
+   │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:12:9
+   │
+12 │         (0: u8) ^ (1: u128);
+   │         ^^^^^^^^^^^^^^^^^^^
+   │         │         │
+   │         │         Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '^'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:13:9
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+   ·
+13 │         r ^ r;
+   │         ^ Invalid argument to '^'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:13:9
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+   ·
+13 │         r ^ r;
    │         ^^^^^ Invalid argument to '^'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:13:9
+   │
+ 3 │     struct R {
+   │            - To satisfy the constraint, the 'drop' ability would need to be added here
    ·
- 8 │         false ^ true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/binary_bit_xor_invalid.move:8:9 ───
-   │
- 8 │         false ^ true;
-   │         ^^^^^^^^^^^^ Invalid argument to '^'
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - The type '0x8675309::M::R' does not have the ability 'drop'
    ·
- 8 │         false ^ true;
-   │                 ---- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-   │
+13 │         r ^ r;
+   │         ^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
 
-error: 
-
-   ┌── tests/move_check/typing/binary_bit_xor_invalid.move:8:17 ───
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:13:13
    │
- 8 │         false ^ true;
-   │                 ^^^^ Invalid argument to '^'
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
    ·
- 8 │         false ^ true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-   │
+13 │         r ^ r;
+   │             ^ Invalid argument to '^'
 
-error: 
-
-   ┌── tests/move_check/typing/binary_bit_xor_invalid.move:9:9 ───
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:14:9
    │
- 9 │         1 ^ false;
-   │         ^^^^^^^^^ Invalid argument to '^'
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
    ·
- 9 │         1 ^ false;
-   │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
+14 │         s ^ s;
+   │         ^ Invalid argument to '^'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:14:9
    │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+   ·
+14 │         s ^ s;
+   │         ^^^^^ Invalid argument to '^'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:14:13
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+   ·
+14 │         s ^ s;
+   │             ^ Invalid argument to '^'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:15:9
+   │
+15 │         1 ^ false ^ @0x0 ^ 0;
+   │         ^^^^^^^^^
+   │         │   │
+   │         │   Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '^'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:15:9
+   │
+15 │         1 ^ false ^ @0x0 ^ 0;
+   │         ^^^^^^^^^^^^^^^^
+   │         │           │
+   │         │           Found: 'address'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '^'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:15:9
+   │
+15 │         1 ^ false ^ @0x0 ^ 0;
+   │         ^^^^^^^^^^^^^^^^^^^^
+   │         │                  │
+   │         │                  Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '^'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:15:21
+   │
+15 │         1 ^ false ^ @0x0 ^ 0;
+   │             -----   ^^^^ Invalid argument to '^'
+   │             │        
+   │             Found: '_'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:15:28
+   │
+15 │         1 ^ false ^ @0x0 ^ 0;
+   │                     ----   ^ Invalid argument to '^'
+   │                     │       
+   │                     Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:16:9
+   │
+16 │         () ^ ();
+   │         ^^
+   │         │
+   │         Invalid argument to '^'
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:16:9
+   │
+16 │         () ^ ();
+   │         ^^^^^^^
+   │         │    │
+   │         │    Found: '()'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '^'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:16:14
+   │
+16 │         () ^ ();
+   │         --   ^^ Invalid argument to '^'
+   │         │     
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:17:9
+   │
+17 │         1 ^ ();
+   │         ^^^^^^
+   │         │   │
+   │         │   Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '^'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:18:9
+   │
+18 │         (0, 1) ^ (0, 1, 2);
+   │         ^^^^^^
+   │         │
+   │         Invalid argument to '^'
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:18:9
+   │
+18 │         (0, 1) ^ (0, 1, 2);
+   │         ^^^^^^^^^^^^^^^^^^
+   │         │        │
+   │         │        Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '^'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:18:18
+   │
+18 │         (0, 1) ^ (0, 1, 2);
+   │         ------   ^^^^^^^^^ Invalid argument to '^'
+   │         │         
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:19:9
+   │
+19 │         (1, 2) ^ (0, 1);
+   │         ^^^^^^
+   │         │
+   │         Invalid argument to '^'
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:19:9
+   │
+19 │         (1, 2) ^ (0, 1);
+   │         ^^^^^^^^^^^^^^^
+   │         │        │
+   │         │        Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '^'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:19:18
+   │
+19 │         (1, 2) ^ (0, 1);
+   │         ------   ^^^^^^ Invalid argument to '^'
+   │         │         
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
 
 error: 
 
@@ -58,28 +306,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:10:9 ───
-    │
- 10 │         false ^ 1;
-    │         ^^^^^ Invalid argument to '^'
-    ·
- 10 │         false ^ 1;
-    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:10:9 ───
-    │
- 10 │         false ^ 1;
-    │         ^^^^^^^^^ Invalid argument to '^'
-    ·
- 10 │         false ^ 1;
-    │                 - Found: '_'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_bit_xor_invalid.move:10:17 ───
     │
  10 │         false ^ 1;
@@ -90,61 +316,6 @@ error:
     ·
  10 │         false ^ 1;
     │         ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:10:17 ───
-    │
- 10 │         false ^ 1;
-    │                 ^ Invalid argument to '^'
-    ·
- 10 │         false ^ 1;
-    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:11:9 ───
-    │
- 11 │         @0x0 ^ @0x1;
-    │         ^^^^ Invalid argument to '^'
-    ·
- 11 │         @0x0 ^ @0x1;
-    │         ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:11:9 ───
-    │
- 11 │         @0x0 ^ @0x1;
-    │         ^^^^^^^^^^^ Invalid argument to '^'
-    ·
- 11 │         @0x0 ^ @0x1;
-    │                ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:11:16 ───
-    │
- 11 │         @0x0 ^ @0x1;
-    │                ^^^^ Invalid argument to '^'
-    ·
- 11 │         @0x0 ^ @0x1;
-    │         ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:12:9 ───
-    │
- 12 │         (0: u8) ^ (1: u128);
-    │         ^^^^^^^^^^^^^^^^^^^ Invalid argument to '^'
-    ·
- 12 │         (0: u8) ^ (1: u128);
-    │                   --------- Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -163,119 +334,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:13:9 ───
-    │
- 13 │         r ^ r;
-    │         ^ Invalid argument to '^'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:13:9 ───
-    │
- 13 │         r ^ r;
-    │         ^^^^^ Invalid argument to '^'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:13:9 ───
-    │
- 13 │         r ^ r;
-    │         ^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - The type '0x8675309::M::R' does not have the ability 'drop'
-    ·
-  3 │     struct R {
-    │            - To satisfy the constraint, the 'drop' ability would need to be added here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:13:13 ───
-    │
- 13 │         r ^ r;
-    │             ^ Invalid argument to '^'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:14:9 ───
-    │
- 14 │         s ^ s;
-    │         ^ Invalid argument to '^'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:14:9 ───
-    │
- 14 │         s ^ s;
-    │         ^^^^^ Invalid argument to '^'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:14:13 ───
-    │
- 14 │         s ^ s;
-    │             ^ Invalid argument to '^'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:15:9 ───
-    │
- 15 │         1 ^ false ^ @0x0 ^ 0;
-    │         ^^^^^^^^^ Invalid argument to '^'
-    ·
- 15 │         1 ^ false ^ @0x0 ^ 0;
-    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:15:9 ───
-    │
- 15 │         1 ^ false ^ @0x0 ^ 0;
-    │         ^^^^^^^^^^^^^^^^ Invalid argument to '^'
-    ·
- 15 │         1 ^ false ^ @0x0 ^ 0;
-    │                     ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:15:9 ───
-    │
- 15 │         1 ^ false ^ @0x0 ^ 0;
-    │         ^^^^^^^^^^^^^^^^^^^^ Invalid argument to '^'
-    ·
- 15 │         1 ^ false ^ @0x0 ^ 0;
-    │                            - Found: '_'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_bit_xor_invalid.move:15:13 ───
     │
  15 │         1 ^ false ^ @0x0 ^ 0;
@@ -286,17 +344,6 @@ error:
     ·
  15 │         1 ^ false ^ @0x0 ^ 0;
     │             ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:15:21 ───
-    │
- 15 │         1 ^ false ^ @0x0 ^ 0;
-    │                     ^^^^ Invalid argument to '^'
-    ·
- 15 │         1 ^ false ^ @0x0 ^ 0;
-    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -315,61 +362,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:15:28 ───
-    │
- 15 │         1 ^ false ^ @0x0 ^ 0;
-    │                            ^ Invalid argument to '^'
-    ·
- 15 │         1 ^ false ^ @0x0 ^ 0;
-    │                     ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:16:9 ───
-    │
- 16 │         () ^ ();
-    │         ^^ Invalid argument to '^'
-    ·
- 16 │         () ^ ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:16:9 ───
-    │
- 16 │         () ^ ();
-    │         ^^^^^^^ Invalid argument to '^'
-    ·
- 16 │         () ^ ();
-    │              -- Found: '()'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:16:14 ───
-    │
- 16 │         () ^ ();
-    │              ^^ Invalid argument to '^'
-    ·
- 16 │         () ^ ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:17:9 ───
-    │
- 17 │         1 ^ ();
-    │         ^^^^^^ Invalid argument to '^'
-    ·
- 17 │         1 ^ ();
-    │             -- Found: '_'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_bit_xor_invalid.move:17:13 ───
     │
  17 │         1 ^ ();
@@ -384,28 +376,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:18:9 ───
-    │
- 18 │         (0, 1) ^ (0, 1, 2);
-    │         ^^^^^^ Invalid argument to '^'
-    ·
- 18 │         (0, 1) ^ (0, 1, 2);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:18:9 ───
-    │
- 18 │         (0, 1) ^ (0, 1, 2);
-    │         ^^^^^^^^^^^^^^^^^^ Invalid argument to '^'
-    ·
- 18 │         (0, 1) ^ (0, 1, 2);
-    │                  --------- Found: '_'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_bit_xor_invalid.move:18:18 ───
     │
  18 │         (0, 1) ^ (0, 1, 2);
@@ -416,49 +386,5 @@ error:
     ·
  18 │         (0, 1) ^ (0, 1, 2);
     │                  --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:18:18 ───
-    │
- 18 │         (0, 1) ^ (0, 1, 2);
-    │                  ^^^^^^^^^ Invalid argument to '^'
-    ·
- 18 │         (0, 1) ^ (0, 1, 2);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:19:9 ───
-    │
- 19 │         (1, 2) ^ (0, 1);
-    │         ^^^^^^ Invalid argument to '^'
-    ·
- 19 │         (1, 2) ^ (0, 1);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:19:9 ───
-    │
- 19 │         (1, 2) ^ (0, 1);
-    │         ^^^^^^^^^^^^^^^ Invalid argument to '^'
-    ·
- 19 │         (1, 2) ^ (0, 1);
-    │                  ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:19:18 ───
-    │
- 19 │         (1, 2) ^ (0, 1);
-    │                  ^^^^^^ Invalid argument to '^'
-    ·
- 19 │         (1, 2) ^ (0, 1);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
     │
 

--- a/language/move-lang/tests/move_check/typing/binary_div_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_div_invalid.exp
@@ -1,24 +1,186 @@
-error: 
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_div_invalid.move:8:9
+  │
+8 │         false / true;
+  │         ^^^^^
+  │         │
+  │         Invalid argument to '/'
+  │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
-   ┌── tests/move_check/typing/binary_div_invalid.move:8:9 ───
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_div_invalid.move:8:17
+  │
+8 │         false / true;
+  │         -----   ^^^^ Invalid argument to '/'
+  │         │        
+  │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_div_invalid.move:10:9
    │
- 8 │         false / true;
-   │         ^^^^^ Invalid argument to '/'
+10 │         false / 1;
+   │         ^^^^^
+   │         │
+   │         Invalid argument to '/'
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_div_invalid.move:10:17
+   │
+10 │         false / 1;
+   │         -----   ^ Invalid argument to '/'
+   │         │        
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_div_invalid.move:11:9
+   │
+11 │         @0x0 / @0x1;
+   │         ^^^^
+   │         │
+   │         Invalid argument to '/'
+   │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_div_invalid.move:11:16
+   │
+11 │         @0x0 / @0x1;
+   │         ----   ^^^^ Invalid argument to '/'
+   │         │       
+   │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_div_invalid.move:13:9
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
    ·
- 8 │         false / true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-   │
+13 │         r / r;
+   │         ^ Invalid argument to '/'
 
-error: 
-
-   ┌── tests/move_check/typing/binary_div_invalid.move:8:17 ───
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/binary_div_invalid.move:13:9
    │
- 8 │         false / true;
-   │                 ^^^^ Invalid argument to '/'
+ 3 │     struct R {
+   │            - To satisfy the constraint, the 'drop' ability would need to be added here
    ·
- 8 │         false / true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - The type '0x8675309::M::R' does not have the ability 'drop'
+   ·
+13 │         r / r;
+   │         ^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_div_invalid.move:13:13
    │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+   ·
+13 │         r / r;
+   │             ^ Invalid argument to '/'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_div_invalid.move:14:9
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+   ·
+14 │         s / s;
+   │         ^ Invalid argument to '/'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_div_invalid.move:14:13
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+   ·
+14 │         s / s;
+   │             ^ Invalid argument to '/'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_div_invalid.move:15:9
+   │
+15 │         1 / false / @0x0 / 0;
+   │         ^^^^^^^^^
+   │         │   │
+   │         │   Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '/'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_div_invalid.move:15:9
+   │
+15 │         1 / false / @0x0 / 0;
+   │         ^^^^^^^^^^^^^^^^
+   │         │           │
+   │         │           Found: 'address'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '/'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_div_invalid.move:15:21
+   │
+15 │         1 / false / @0x0 / 0;
+   │             -----   ^^^^ Invalid argument to '/'
+   │             │        
+   │             Found: '_'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_div_invalid.move:15:28
+   │
+15 │         1 / false / @0x0 / 0;
+   │                     ----   ^ Invalid argument to '/'
+   │                     │       
+   │                     Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_div_invalid.move:16:9
+   │
+16 │         () / ();
+   │         ^^
+   │         │
+   │         Invalid argument to '/'
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_div_invalid.move:16:14
+   │
+16 │         () / ();
+   │         --   ^^ Invalid argument to '/'
+   │         │     
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_div_invalid.move:18:9
+   │
+18 │         (0, 1) / (0, 1, 2);
+   │         ^^^^^^
+   │         │
+   │         Invalid argument to '/'
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_div_invalid.move:18:18
+   │
+18 │         (0, 1) / (0, 1, 2);
+   │         ------   ^^^^^^^^^ Invalid argument to '/'
+   │         │         
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_div_invalid.move:19:9
+   │
+19 │         (1, 2) / (0, 1);
+   │         ^^^^^^
+   │         │
+   │         Invalid argument to '/'
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_div_invalid.move:19:18
+   │
+19 │         (1, 2) / (0, 1);
+   │         ------   ^^^^^^ Invalid argument to '/'
+   │         │         
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
 
 error: 
 
@@ -36,17 +198,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_div_invalid.move:10:9 ───
-    │
- 10 │         false / 1;
-    │         ^^^^^ Invalid argument to '/'
-    ·
- 10 │         false / 1;
-    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_div_invalid.move:10:17 ───
     │
  10 │         false / 1;
@@ -57,39 +208,6 @@ error:
     ·
  10 │         false / 1;
     │         ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_div_invalid.move:10:17 ───
-    │
- 10 │         false / 1;
-    │                 ^ Invalid argument to '/'
-    ·
- 10 │         false / 1;
-    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_div_invalid.move:11:9 ───
-    │
- 11 │         @0x0 / @0x1;
-    │         ^^^^ Invalid argument to '/'
-    ·
- 11 │         @0x0 / @0x1;
-    │         ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_div_invalid.move:11:16 ───
-    │
- 11 │         @0x0 / @0x1;
-    │                ^^^^ Invalid argument to '/'
-    ·
- 11 │         @0x0 / @0x1;
-    │         ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -108,86 +226,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_div_invalid.move:13:9 ───
-    │
- 13 │         r / r;
-    │         ^ Invalid argument to '/'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_div_invalid.move:13:9 ───
-    │
- 13 │         r / r;
-    │         ^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - The type '0x8675309::M::R' does not have the ability 'drop'
-    ·
-  3 │     struct R {
-    │            - To satisfy the constraint, the 'drop' ability would need to be added here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_div_invalid.move:13:13 ───
-    │
- 13 │         r / r;
-    │             ^ Invalid argument to '/'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_div_invalid.move:14:9 ───
-    │
- 14 │         s / s;
-    │         ^ Invalid argument to '/'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_div_invalid.move:14:13 ───
-    │
- 14 │         s / s;
-    │             ^ Invalid argument to '/'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_div_invalid.move:15:9 ───
-    │
- 15 │         1 / false / @0x0 / 0;
-    │         ^^^^^^^^^ Invalid argument to '/'
-    ·
- 15 │         1 / false / @0x0 / 0;
-    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_div_invalid.move:15:9 ───
-    │
- 15 │         1 / false / @0x0 / 0;
-    │         ^^^^^^^^^^^^^^^^ Invalid argument to '/'
-    ·
- 15 │         1 / false / @0x0 / 0;
-    │                     ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_div_invalid.move:15:13 ───
     │
  15 │         1 / false / @0x0 / 0;
@@ -198,17 +236,6 @@ error:
     ·
  15 │         1 / false / @0x0 / 0;
     │             ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_div_invalid.move:15:21 ───
-    │
- 15 │         1 / false / @0x0 / 0;
-    │                     ^^^^ Invalid argument to '/'
-    ·
- 15 │         1 / false / @0x0 / 0;
-    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -227,39 +254,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_div_invalid.move:15:28 ───
-    │
- 15 │         1 / false / @0x0 / 0;
-    │                            ^ Invalid argument to '/'
-    ·
- 15 │         1 / false / @0x0 / 0;
-    │                     ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_div_invalid.move:16:9 ───
-    │
- 16 │         () / ();
-    │         ^^ Invalid argument to '/'
-    ·
- 16 │         () / ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_div_invalid.move:16:14 ───
-    │
- 16 │         () / ();
-    │              ^^ Invalid argument to '/'
-    ·
- 16 │         () / ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_div_invalid.move:17:13 ───
     │
  17 │         1 / ();
@@ -274,17 +268,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_div_invalid.move:18:9 ───
-    │
- 18 │         (0, 1) / (0, 1, 2);
-    │         ^^^^^^ Invalid argument to '/'
-    ·
- 18 │         (0, 1) / (0, 1, 2);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_div_invalid.move:18:18 ───
     │
  18 │         (0, 1) / (0, 1, 2);
@@ -295,38 +278,5 @@ error:
     ·
  18 │         (0, 1) / (0, 1, 2);
     │                  --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_div_invalid.move:18:18 ───
-    │
- 18 │         (0, 1) / (0, 1, 2);
-    │                  ^^^^^^^^^ Invalid argument to '/'
-    ·
- 18 │         (0, 1) / (0, 1, 2);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_div_invalid.move:19:9 ───
-    │
- 19 │         (1, 2) / (0, 1);
-    │         ^^^^^^ Invalid argument to '/'
-    ·
- 19 │         (1, 2) / (0, 1);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_div_invalid.move:19:18 ───
-    │
- 19 │         (1, 2) / (0, 1);
-    │                  ^^^^^^ Invalid argument to '/'
-    ·
- 19 │         (1, 2) / (0, 1);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
     │
 

--- a/language/move-lang/tests/move_check/typing/binary_geq_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_geq_invalid.exp
@@ -1,24 +1,174 @@
-error: 
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_geq_invalid.move:8:9
+  │
+8 │         false >= true;
+  │         ^^^^^
+  │         │
+  │         Invalid argument to '>='
+  │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
-   ┌── tests/move_check/typing/binary_geq_invalid.move:8:9 ───
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_geq_invalid.move:8:18
+  │
+8 │         false >= true;
+  │         -----    ^^^^ Invalid argument to '>='
+  │         │         
+  │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_geq_invalid.move:10:9
    │
- 8 │         false >= true;
-   │         ^^^^^ Invalid argument to '>='
+10 │         false >= 1;
+   │         ^^^^^
+   │         │
+   │         Invalid argument to '>='
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_geq_invalid.move:10:18
+   │
+10 │         false >= 1;
+   │         -----    ^ Invalid argument to '>='
+   │         │         
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_geq_invalid.move:11:9
+   │
+11 │         @0x0 >= @0x1;
+   │         ^^^^
+   │         │
+   │         Invalid argument to '>='
+   │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_geq_invalid.move:11:17
+   │
+11 │         @0x0 >= @0x1;
+   │         ----    ^^^^ Invalid argument to '>='
+   │         │        
+   │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_geq_invalid.move:13:9
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
    ·
- 8 │         false >= true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-   │
+13 │         r >= r;
+   │         ^ Invalid argument to '>='
 
-error: 
-
-   ┌── tests/move_check/typing/binary_geq_invalid.move:8:18 ───
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_geq_invalid.move:13:14
    │
- 8 │         false >= true;
-   │                  ^^^^ Invalid argument to '>='
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
    ·
- 8 │         false >= true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+13 │         r >= r;
+   │              ^ Invalid argument to '>='
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_geq_invalid.move:14:9
    │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+   ·
+14 │         s >= s;
+   │         ^ Invalid argument to '>='
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_geq_invalid.move:14:14
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+   ·
+14 │         s >= s;
+   │              ^ Invalid argument to '>='
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_geq_invalid.move:15:9
+   │
+15 │         0 >= 1 >= 2;
+   │         ^^^^^^
+   │         │
+   │         Invalid argument to '>='
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_geq_invalid.move:15:19
+   │
+15 │         0 >= 1 >= 2;
+   │         ------    ^ Invalid argument to '>='
+   │         │          
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_geq_invalid.move:16:26
+   │
+16 │         (1 >= false) && (@0x0 >= 0);
+   │                          ^^^^
+   │                          │
+   │                          Invalid argument to '>='
+   │                          Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_geq_invalid.move:16:34
+   │
+16 │         (1 >= false) && (@0x0 >= 0);
+   │                          ----    ^ Invalid argument to '>='
+   │                          │        
+   │                          Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_geq_invalid.move:17:9
+   │
+17 │         () >= ();
+   │         ^^
+   │         │
+   │         Invalid argument to '>='
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_geq_invalid.move:17:15
+   │
+17 │         () >= ();
+   │         --    ^^ Invalid argument to '>='
+   │         │      
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_geq_invalid.move:19:9
+   │
+19 │         (0, 1) >= (0, 1, 2);
+   │         ^^^^^^
+   │         │
+   │         Invalid argument to '>='
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_geq_invalid.move:19:19
+   │
+19 │         (0, 1) >= (0, 1, 2);
+   │         ------    ^^^^^^^^^ Invalid argument to '>='
+   │         │          
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_geq_invalid.move:20:9
+   │
+20 │         (1, 2) >= (0, 1);
+   │         ^^^^^^
+   │         │
+   │         Invalid argument to '>='
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_geq_invalid.move:20:19
+   │
+20 │         (1, 2) >= (0, 1);
+   │         ------    ^^^^^^ Invalid argument to '>='
+   │         │          
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
 
 error: 
 
@@ -36,17 +186,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_geq_invalid.move:10:9 ───
-    │
- 10 │         false >= 1;
-    │         ^^^^^ Invalid argument to '>='
-    ·
- 10 │         false >= 1;
-    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_geq_invalid.move:10:18 ───
     │
  10 │         false >= 1;
@@ -57,39 +196,6 @@ error:
     ·
  10 │         false >= 1;
     │         ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_geq_invalid.move:10:18 ───
-    │
- 10 │         false >= 1;
-    │                  ^ Invalid argument to '>='
-    ·
- 10 │         false >= 1;
-    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_geq_invalid.move:11:9 ───
-    │
- 11 │         @0x0 >= @0x1;
-    │         ^^^^ Invalid argument to '>='
-    ·
- 11 │         @0x0 >= @0x1;
-    │         ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_geq_invalid.move:11:17 ───
-    │
- 11 │         @0x0 >= @0x1;
-    │                 ^^^^ Invalid argument to '>='
-    ·
- 11 │         @0x0 >= @0x1;
-    │         ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -108,61 +214,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_geq_invalid.move:13:9 ───
-    │
- 13 │         r >= r;
-    │         ^ Invalid argument to '>='
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_geq_invalid.move:13:14 ───
-    │
- 13 │         r >= r;
-    │              ^ Invalid argument to '>='
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_geq_invalid.move:14:9 ───
-    │
- 14 │         s >= s;
-    │         ^ Invalid argument to '>='
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_geq_invalid.move:14:14 ───
-    │
- 14 │         s >= s;
-    │              ^ Invalid argument to '>='
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_geq_invalid.move:15:9 ───
-    │
- 15 │         0 >= 1 >= 2;
-    │         ^^^^^^ Invalid argument to '>='
-    ·
- 15 │         0 >= 1 >= 2;
-    │         ------ Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_geq_invalid.move:15:19 ───
     │
  15 │         0 >= 1 >= 2;
@@ -173,17 +224,6 @@ error:
     ·
  15 │         0 >= 1 >= 2;
     │         ------ Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_geq_invalid.move:15:19 ───
-    │
- 15 │         0 >= 1 >= 2;
-    │                   ^ Invalid argument to '>='
-    ·
- 15 │         0 >= 1 >= 2;
-    │         ------ Found: 'bool'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -202,17 +242,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_geq_invalid.move:16:26 ───
-    │
- 16 │         (1 >= false) && (@0x0 >= 0);
-    │                          ^^^^ Invalid argument to '>='
-    ·
- 16 │         (1 >= false) && (@0x0 >= 0);
-    │                          ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_geq_invalid.move:16:34 ───
     │
  16 │         (1 >= false) && (@0x0 >= 0);
@@ -223,39 +252,6 @@ error:
     ·
  16 │         (1 >= false) && (@0x0 >= 0);
     │                          ---- Is not compatible with: 'address'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_geq_invalid.move:16:34 ───
-    │
- 16 │         (1 >= false) && (@0x0 >= 0);
-    │                                  ^ Invalid argument to '>='
-    ·
- 16 │         (1 >= false) && (@0x0 >= 0);
-    │                          ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_geq_invalid.move:17:9 ───
-    │
- 17 │         () >= ();
-    │         ^^ Invalid argument to '>='
-    ·
- 17 │         () >= ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_geq_invalid.move:17:15 ───
-    │
- 17 │         () >= ();
-    │               ^^ Invalid argument to '>='
-    ·
- 17 │         () >= ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -274,17 +270,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_geq_invalid.move:19:9 ───
-    │
- 19 │         (0, 1) >= (0, 1, 2);
-    │         ^^^^^^ Invalid argument to '>='
-    ·
- 19 │         (0, 1) >= (0, 1, 2);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_geq_invalid.move:19:19 ───
     │
  19 │         (0, 1) >= (0, 1, 2);
@@ -295,38 +280,5 @@ error:
     ·
  19 │         (0, 1) >= (0, 1, 2);
     │                   --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_geq_invalid.move:19:19 ───
-    │
- 19 │         (0, 1) >= (0, 1, 2);
-    │                   ^^^^^^^^^ Invalid argument to '>='
-    ·
- 19 │         (0, 1) >= (0, 1, 2);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_geq_invalid.move:20:9 ───
-    │
- 20 │         (1, 2) >= (0, 1);
-    │         ^^^^^^ Invalid argument to '>='
-    ·
- 20 │         (1, 2) >= (0, 1);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_geq_invalid.move:20:19 ───
-    │
- 20 │         (1, 2) >= (0, 1);
-    │                   ^^^^^^ Invalid argument to '>='
-    ·
- 20 │         (1, 2) >= (0, 1);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
     │
 

--- a/language/move-lang/tests/move_check/typing/binary_gt_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_gt_invalid.exp
@@ -1,24 +1,174 @@
-error: 
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_gt_invalid.move:8:9
+  │
+8 │         false > true;
+  │         ^^^^^
+  │         │
+  │         Invalid argument to '>'
+  │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
-   ┌── tests/move_check/typing/binary_gt_invalid.move:8:9 ───
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_gt_invalid.move:8:17
+  │
+8 │         false > true;
+  │         -----   ^^^^ Invalid argument to '>'
+  │         │        
+  │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_gt_invalid.move:10:9
    │
- 8 │         false > true;
-   │         ^^^^^ Invalid argument to '>'
+10 │         false > 1;
+   │         ^^^^^
+   │         │
+   │         Invalid argument to '>'
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_gt_invalid.move:10:17
+   │
+10 │         false > 1;
+   │         -----   ^ Invalid argument to '>'
+   │         │        
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_gt_invalid.move:11:9
+   │
+11 │         @0x0 > @0x1;
+   │         ^^^^
+   │         │
+   │         Invalid argument to '>'
+   │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_gt_invalid.move:11:16
+   │
+11 │         @0x0 > @0x1;
+   │         ----   ^^^^ Invalid argument to '>'
+   │         │       
+   │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_gt_invalid.move:13:9
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
    ·
- 8 │         false > true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-   │
+13 │         r > r;
+   │         ^ Invalid argument to '>'
 
-error: 
-
-   ┌── tests/move_check/typing/binary_gt_invalid.move:8:17 ───
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_gt_invalid.move:13:13
    │
- 8 │         false > true;
-   │                 ^^^^ Invalid argument to '>'
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
    ·
- 8 │         false > true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+13 │         r > r;
+   │             ^ Invalid argument to '>'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_gt_invalid.move:14:9
    │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+   ·
+14 │         s > s;
+   │         ^ Invalid argument to '>'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_gt_invalid.move:14:13
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+   ·
+14 │         s > s;
+   │             ^ Invalid argument to '>'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_gt_invalid.move:15:9
+   │
+15 │         0 > 1 > 2;
+   │         ^^^^^
+   │         │
+   │         Invalid argument to '>'
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_gt_invalid.move:15:17
+   │
+15 │         0 > 1 > 2;
+   │         -----   ^ Invalid argument to '>'
+   │         │        
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_gt_invalid.move:16:25
+   │
+16 │         (1 > false) && (@0x0 > 0);
+   │                         ^^^^
+   │                         │
+   │                         Invalid argument to '>'
+   │                         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_gt_invalid.move:16:32
+   │
+16 │         (1 > false) && (@0x0 > 0);
+   │                         ----   ^ Invalid argument to '>'
+   │                         │       
+   │                         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_gt_invalid.move:17:9
+   │
+17 │         () > ();
+   │         ^^
+   │         │
+   │         Invalid argument to '>'
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_gt_invalid.move:17:14
+   │
+17 │         () > ();
+   │         --   ^^ Invalid argument to '>'
+   │         │     
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_gt_invalid.move:19:9
+   │
+19 │         (0, 1) > (0, 1, 2);
+   │         ^^^^^^
+   │         │
+   │         Invalid argument to '>'
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_gt_invalid.move:19:18
+   │
+19 │         (0, 1) > (0, 1, 2);
+   │         ------   ^^^^^^^^^ Invalid argument to '>'
+   │         │         
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_gt_invalid.move:20:9
+   │
+20 │         (1, 2) > (0, 1);
+   │         ^^^^^^
+   │         │
+   │         Invalid argument to '>'
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_gt_invalid.move:20:18
+   │
+20 │         (1, 2) > (0, 1);
+   │         ------   ^^^^^^ Invalid argument to '>'
+   │         │         
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
 
 error: 
 
@@ -36,17 +186,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_gt_invalid.move:10:9 ───
-    │
- 10 │         false > 1;
-    │         ^^^^^ Invalid argument to '>'
-    ·
- 10 │         false > 1;
-    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_gt_invalid.move:10:17 ───
     │
  10 │         false > 1;
@@ -57,39 +196,6 @@ error:
     ·
  10 │         false > 1;
     │         ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_gt_invalid.move:10:17 ───
-    │
- 10 │         false > 1;
-    │                 ^ Invalid argument to '>'
-    ·
- 10 │         false > 1;
-    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_gt_invalid.move:11:9 ───
-    │
- 11 │         @0x0 > @0x1;
-    │         ^^^^ Invalid argument to '>'
-    ·
- 11 │         @0x0 > @0x1;
-    │         ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_gt_invalid.move:11:16 ───
-    │
- 11 │         @0x0 > @0x1;
-    │                ^^^^ Invalid argument to '>'
-    ·
- 11 │         @0x0 > @0x1;
-    │         ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -108,61 +214,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_gt_invalid.move:13:9 ───
-    │
- 13 │         r > r;
-    │         ^ Invalid argument to '>'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_gt_invalid.move:13:13 ───
-    │
- 13 │         r > r;
-    │             ^ Invalid argument to '>'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_gt_invalid.move:14:9 ───
-    │
- 14 │         s > s;
-    │         ^ Invalid argument to '>'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_gt_invalid.move:14:13 ───
-    │
- 14 │         s > s;
-    │             ^ Invalid argument to '>'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_gt_invalid.move:15:9 ───
-    │
- 15 │         0 > 1 > 2;
-    │         ^^^^^ Invalid argument to '>'
-    ·
- 15 │         0 > 1 > 2;
-    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_gt_invalid.move:15:17 ───
     │
  15 │         0 > 1 > 2;
@@ -173,17 +224,6 @@ error:
     ·
  15 │         0 > 1 > 2;
     │         ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_gt_invalid.move:15:17 ───
-    │
- 15 │         0 > 1 > 2;
-    │                 ^ Invalid argument to '>'
-    ·
- 15 │         0 > 1 > 2;
-    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -202,17 +242,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_gt_invalid.move:16:25 ───
-    │
- 16 │         (1 > false) && (@0x0 > 0);
-    │                         ^^^^ Invalid argument to '>'
-    ·
- 16 │         (1 > false) && (@0x0 > 0);
-    │                         ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_gt_invalid.move:16:32 ───
     │
  16 │         (1 > false) && (@0x0 > 0);
@@ -223,39 +252,6 @@ error:
     ·
  16 │         (1 > false) && (@0x0 > 0);
     │                         ---- Is not compatible with: 'address'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_gt_invalid.move:16:32 ───
-    │
- 16 │         (1 > false) && (@0x0 > 0);
-    │                                ^ Invalid argument to '>'
-    ·
- 16 │         (1 > false) && (@0x0 > 0);
-    │                         ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_gt_invalid.move:17:9 ───
-    │
- 17 │         () > ();
-    │         ^^ Invalid argument to '>'
-    ·
- 17 │         () > ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_gt_invalid.move:17:14 ───
-    │
- 17 │         () > ();
-    │              ^^ Invalid argument to '>'
-    ·
- 17 │         () > ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -274,17 +270,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_gt_invalid.move:19:9 ───
-    │
- 19 │         (0, 1) > (0, 1, 2);
-    │         ^^^^^^ Invalid argument to '>'
-    ·
- 19 │         (0, 1) > (0, 1, 2);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_gt_invalid.move:19:18 ───
     │
  19 │         (0, 1) > (0, 1, 2);
@@ -295,38 +280,5 @@ error:
     ·
  19 │         (0, 1) > (0, 1, 2);
     │                  --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_gt_invalid.move:19:18 ───
-    │
- 19 │         (0, 1) > (0, 1, 2);
-    │                  ^^^^^^^^^ Invalid argument to '>'
-    ·
- 19 │         (0, 1) > (0, 1, 2);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_gt_invalid.move:20:9 ───
-    │
- 20 │         (1, 2) > (0, 1);
-    │         ^^^^^^ Invalid argument to '>'
-    ·
- 20 │         (1, 2) > (0, 1);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_gt_invalid.move:20:18 ───
-    │
- 20 │         (1, 2) > (0, 1);
-    │                  ^^^^^^ Invalid argument to '>'
-    ·
- 20 │         (1, 2) > (0, 1);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
     │
 

--- a/language/move-lang/tests/move_check/typing/binary_leq_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_leq_invalid.exp
@@ -1,24 +1,174 @@
-error: 
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_leq_invalid.move:8:9
+  │
+8 │         false <= true;
+  │         ^^^^^
+  │         │
+  │         Invalid argument to '<='
+  │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
-   ┌── tests/move_check/typing/binary_leq_invalid.move:8:9 ───
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_leq_invalid.move:8:18
+  │
+8 │         false <= true;
+  │         -----    ^^^^ Invalid argument to '<='
+  │         │         
+  │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_leq_invalid.move:10:9
    │
- 8 │         false <= true;
-   │         ^^^^^ Invalid argument to '<='
+10 │         false <= 1;
+   │         ^^^^^
+   │         │
+   │         Invalid argument to '<='
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_leq_invalid.move:10:18
+   │
+10 │         false <= 1;
+   │         -----    ^ Invalid argument to '<='
+   │         │         
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_leq_invalid.move:11:9
+   │
+11 │         @0x0 <= @0x1;
+   │         ^^^^
+   │         │
+   │         Invalid argument to '<='
+   │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_leq_invalid.move:11:17
+   │
+11 │         @0x0 <= @0x1;
+   │         ----    ^^^^ Invalid argument to '<='
+   │         │        
+   │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_leq_invalid.move:13:9
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
    ·
- 8 │         false <= true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-   │
+13 │         r <= r;
+   │         ^ Invalid argument to '<='
 
-error: 
-
-   ┌── tests/move_check/typing/binary_leq_invalid.move:8:18 ───
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_leq_invalid.move:13:14
    │
- 8 │         false <= true;
-   │                  ^^^^ Invalid argument to '<='
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
    ·
- 8 │         false <= true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+13 │         r <= r;
+   │              ^ Invalid argument to '<='
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_leq_invalid.move:14:9
    │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+   ·
+14 │         s <= s;
+   │         ^ Invalid argument to '<='
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_leq_invalid.move:14:14
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+   ·
+14 │         s <= s;
+   │              ^ Invalid argument to '<='
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_leq_invalid.move:15:9
+   │
+15 │         0 <= 1 <= 2;
+   │         ^^^^^^
+   │         │
+   │         Invalid argument to '<='
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_leq_invalid.move:15:19
+   │
+15 │         0 <= 1 <= 2;
+   │         ------    ^ Invalid argument to '<='
+   │         │          
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_leq_invalid.move:16:26
+   │
+16 │         (1 <= false) && (@0x0 <= 0);
+   │                          ^^^^
+   │                          │
+   │                          Invalid argument to '<='
+   │                          Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_leq_invalid.move:16:34
+   │
+16 │         (1 <= false) && (@0x0 <= 0);
+   │                          ----    ^ Invalid argument to '<='
+   │                          │        
+   │                          Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_leq_invalid.move:17:9
+   │
+17 │         () <= ();
+   │         ^^
+   │         │
+   │         Invalid argument to '<='
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_leq_invalid.move:17:15
+   │
+17 │         () <= ();
+   │         --    ^^ Invalid argument to '<='
+   │         │      
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_leq_invalid.move:19:9
+   │
+19 │         (0, 1) <= (0, 1, 2);
+   │         ^^^^^^
+   │         │
+   │         Invalid argument to '<='
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_leq_invalid.move:19:19
+   │
+19 │         (0, 1) <= (0, 1, 2);
+   │         ------    ^^^^^^^^^ Invalid argument to '<='
+   │         │          
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_leq_invalid.move:20:9
+   │
+20 │         (1, 2) <= (0, 1);
+   │         ^^^^^^
+   │         │
+   │         Invalid argument to '<='
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_leq_invalid.move:20:19
+   │
+20 │         (1, 2) <= (0, 1);
+   │         ------    ^^^^^^ Invalid argument to '<='
+   │         │          
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
 
 error: 
 
@@ -36,17 +186,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_leq_invalid.move:10:9 ───
-    │
- 10 │         false <= 1;
-    │         ^^^^^ Invalid argument to '<='
-    ·
- 10 │         false <= 1;
-    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_leq_invalid.move:10:18 ───
     │
  10 │         false <= 1;
@@ -57,39 +196,6 @@ error:
     ·
  10 │         false <= 1;
     │         ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_leq_invalid.move:10:18 ───
-    │
- 10 │         false <= 1;
-    │                  ^ Invalid argument to '<='
-    ·
- 10 │         false <= 1;
-    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_leq_invalid.move:11:9 ───
-    │
- 11 │         @0x0 <= @0x1;
-    │         ^^^^ Invalid argument to '<='
-    ·
- 11 │         @0x0 <= @0x1;
-    │         ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_leq_invalid.move:11:17 ───
-    │
- 11 │         @0x0 <= @0x1;
-    │                 ^^^^ Invalid argument to '<='
-    ·
- 11 │         @0x0 <= @0x1;
-    │         ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -108,61 +214,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_leq_invalid.move:13:9 ───
-    │
- 13 │         r <= r;
-    │         ^ Invalid argument to '<='
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_leq_invalid.move:13:14 ───
-    │
- 13 │         r <= r;
-    │              ^ Invalid argument to '<='
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_leq_invalid.move:14:9 ───
-    │
- 14 │         s <= s;
-    │         ^ Invalid argument to '<='
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_leq_invalid.move:14:14 ───
-    │
- 14 │         s <= s;
-    │              ^ Invalid argument to '<='
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_leq_invalid.move:15:9 ───
-    │
- 15 │         0 <= 1 <= 2;
-    │         ^^^^^^ Invalid argument to '<='
-    ·
- 15 │         0 <= 1 <= 2;
-    │         ------ Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_leq_invalid.move:15:19 ───
     │
  15 │         0 <= 1 <= 2;
@@ -173,17 +224,6 @@ error:
     ·
  15 │         0 <= 1 <= 2;
     │         ------ Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_leq_invalid.move:15:19 ───
-    │
- 15 │         0 <= 1 <= 2;
-    │                   ^ Invalid argument to '<='
-    ·
- 15 │         0 <= 1 <= 2;
-    │         ------ Found: 'bool'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -202,17 +242,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_leq_invalid.move:16:26 ───
-    │
- 16 │         (1 <= false) && (@0x0 <= 0);
-    │                          ^^^^ Invalid argument to '<='
-    ·
- 16 │         (1 <= false) && (@0x0 <= 0);
-    │                          ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_leq_invalid.move:16:34 ───
     │
  16 │         (1 <= false) && (@0x0 <= 0);
@@ -223,39 +252,6 @@ error:
     ·
  16 │         (1 <= false) && (@0x0 <= 0);
     │                          ---- Is not compatible with: 'address'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_leq_invalid.move:16:34 ───
-    │
- 16 │         (1 <= false) && (@0x0 <= 0);
-    │                                  ^ Invalid argument to '<='
-    ·
- 16 │         (1 <= false) && (@0x0 <= 0);
-    │                          ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_leq_invalid.move:17:9 ───
-    │
- 17 │         () <= ();
-    │         ^^ Invalid argument to '<='
-    ·
- 17 │         () <= ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_leq_invalid.move:17:15 ───
-    │
- 17 │         () <= ();
-    │               ^^ Invalid argument to '<='
-    ·
- 17 │         () <= ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -274,17 +270,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_leq_invalid.move:19:9 ───
-    │
- 19 │         (0, 1) <= (0, 1, 2);
-    │         ^^^^^^ Invalid argument to '<='
-    ·
- 19 │         (0, 1) <= (0, 1, 2);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_leq_invalid.move:19:19 ───
     │
  19 │         (0, 1) <= (0, 1, 2);
@@ -295,38 +280,5 @@ error:
     ·
  19 │         (0, 1) <= (0, 1, 2);
     │                   --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_leq_invalid.move:19:19 ───
-    │
- 19 │         (0, 1) <= (0, 1, 2);
-    │                   ^^^^^^^^^ Invalid argument to '<='
-    ·
- 19 │         (0, 1) <= (0, 1, 2);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_leq_invalid.move:20:9 ───
-    │
- 20 │         (1, 2) <= (0, 1);
-    │         ^^^^^^ Invalid argument to '<='
-    ·
- 20 │         (1, 2) <= (0, 1);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_leq_invalid.move:20:19 ───
-    │
- 20 │         (1, 2) <= (0, 1);
-    │                   ^^^^^^ Invalid argument to '<='
-    ·
- 20 │         (1, 2) <= (0, 1);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
     │
 

--- a/language/move-lang/tests/move_check/typing/binary_lt_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_lt_invalid.exp
@@ -1,24 +1,174 @@
-error: 
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_lt_invalid.move:8:9
+  │
+8 │         false < true;
+  │         ^^^^^
+  │         │
+  │         Invalid argument to '<'
+  │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
-   ┌── tests/move_check/typing/binary_lt_invalid.move:8:9 ───
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_lt_invalid.move:8:17
+  │
+8 │         false < true;
+  │         -----   ^^^^ Invalid argument to '<'
+  │         │        
+  │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_lt_invalid.move:10:9
    │
- 8 │         false < true;
-   │         ^^^^^ Invalid argument to '<'
+10 │         false < 1;
+   │         ^^^^^
+   │         │
+   │         Invalid argument to '<'
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_lt_invalid.move:10:17
+   │
+10 │         false < 1;
+   │         -----   ^ Invalid argument to '<'
+   │         │        
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_lt_invalid.move:11:9
+   │
+11 │         @0x0 < @0x1;
+   │         ^^^^
+   │         │
+   │         Invalid argument to '<'
+   │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_lt_invalid.move:11:16
+   │
+11 │         @0x0 < @0x1;
+   │         ----   ^^^^ Invalid argument to '<'
+   │         │       
+   │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_lt_invalid.move:13:9
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
    ·
- 8 │         false < true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-   │
+13 │         r < r;
+   │         ^ Invalid argument to '<'
 
-error: 
-
-   ┌── tests/move_check/typing/binary_lt_invalid.move:8:17 ───
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_lt_invalid.move:13:13
    │
- 8 │         false < true;
-   │                 ^^^^ Invalid argument to '<'
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
    ·
- 8 │         false < true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+13 │         r < r;
+   │             ^ Invalid argument to '<'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_lt_invalid.move:14:9
    │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+   ·
+14 │         s < s;
+   │         ^ Invalid argument to '<'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_lt_invalid.move:14:13
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+   ·
+14 │         s < s;
+   │             ^ Invalid argument to '<'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_lt_invalid.move:15:9
+   │
+15 │         0 < 1 < 2;
+   │         ^^^^^
+   │         │
+   │         Invalid argument to '<'
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_lt_invalid.move:15:17
+   │
+15 │         0 < 1 < 2;
+   │         -----   ^ Invalid argument to '<'
+   │         │        
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_lt_invalid.move:16:25
+   │
+16 │         (1 < false) && (@0x0 < 0);
+   │                         ^^^^
+   │                         │
+   │                         Invalid argument to '<'
+   │                         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_lt_invalid.move:16:32
+   │
+16 │         (1 < false) && (@0x0 < 0);
+   │                         ----   ^ Invalid argument to '<'
+   │                         │       
+   │                         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_lt_invalid.move:17:9
+   │
+17 │         () < ();
+   │         ^^
+   │         │
+   │         Invalid argument to '<'
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_lt_invalid.move:17:14
+   │
+17 │         () < ();
+   │         --   ^^ Invalid argument to '<'
+   │         │     
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_lt_invalid.move:19:9
+   │
+19 │         (0, 1) < (0, 1, 2);
+   │         ^^^^^^
+   │         │
+   │         Invalid argument to '<'
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_lt_invalid.move:19:18
+   │
+19 │         (0, 1) < (0, 1, 2);
+   │         ------   ^^^^^^^^^ Invalid argument to '<'
+   │         │         
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_lt_invalid.move:20:9
+   │
+20 │         (1, 2) < (0, 1);
+   │         ^^^^^^
+   │         │
+   │         Invalid argument to '<'
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_lt_invalid.move:20:18
+   │
+20 │         (1, 2) < (0, 1);
+   │         ------   ^^^^^^ Invalid argument to '<'
+   │         │         
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
 
 error: 
 
@@ -36,17 +186,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_lt_invalid.move:10:9 ───
-    │
- 10 │         false < 1;
-    │         ^^^^^ Invalid argument to '<'
-    ·
- 10 │         false < 1;
-    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_lt_invalid.move:10:17 ───
     │
  10 │         false < 1;
@@ -57,39 +196,6 @@ error:
     ·
  10 │         false < 1;
     │         ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_lt_invalid.move:10:17 ───
-    │
- 10 │         false < 1;
-    │                 ^ Invalid argument to '<'
-    ·
- 10 │         false < 1;
-    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_lt_invalid.move:11:9 ───
-    │
- 11 │         @0x0 < @0x1;
-    │         ^^^^ Invalid argument to '<'
-    ·
- 11 │         @0x0 < @0x1;
-    │         ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_lt_invalid.move:11:16 ───
-    │
- 11 │         @0x0 < @0x1;
-    │                ^^^^ Invalid argument to '<'
-    ·
- 11 │         @0x0 < @0x1;
-    │         ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -108,61 +214,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_lt_invalid.move:13:9 ───
-    │
- 13 │         r < r;
-    │         ^ Invalid argument to '<'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_lt_invalid.move:13:13 ───
-    │
- 13 │         r < r;
-    │             ^ Invalid argument to '<'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_lt_invalid.move:14:9 ───
-    │
- 14 │         s < s;
-    │         ^ Invalid argument to '<'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_lt_invalid.move:14:13 ───
-    │
- 14 │         s < s;
-    │             ^ Invalid argument to '<'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_lt_invalid.move:15:9 ───
-    │
- 15 │         0 < 1 < 2;
-    │         ^^^^^ Invalid argument to '<'
-    ·
- 15 │         0 < 1 < 2;
-    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_lt_invalid.move:15:17 ───
     │
  15 │         0 < 1 < 2;
@@ -173,17 +224,6 @@ error:
     ·
  15 │         0 < 1 < 2;
     │         ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_lt_invalid.move:15:17 ───
-    │
- 15 │         0 < 1 < 2;
-    │                 ^ Invalid argument to '<'
-    ·
- 15 │         0 < 1 < 2;
-    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -202,17 +242,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_lt_invalid.move:16:25 ───
-    │
- 16 │         (1 < false) && (@0x0 < 0);
-    │                         ^^^^ Invalid argument to '<'
-    ·
- 16 │         (1 < false) && (@0x0 < 0);
-    │                         ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_lt_invalid.move:16:32 ───
     │
  16 │         (1 < false) && (@0x0 < 0);
@@ -223,39 +252,6 @@ error:
     ·
  16 │         (1 < false) && (@0x0 < 0);
     │                         ---- Is not compatible with: 'address'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_lt_invalid.move:16:32 ───
-    │
- 16 │         (1 < false) && (@0x0 < 0);
-    │                                ^ Invalid argument to '<'
-    ·
- 16 │         (1 < false) && (@0x0 < 0);
-    │                         ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_lt_invalid.move:17:9 ───
-    │
- 17 │         () < ();
-    │         ^^ Invalid argument to '<'
-    ·
- 17 │         () < ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_lt_invalid.move:17:14 ───
-    │
- 17 │         () < ();
-    │              ^^ Invalid argument to '<'
-    ·
- 17 │         () < ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -274,17 +270,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_lt_invalid.move:19:9 ───
-    │
- 19 │         (0, 1) < (0, 1, 2);
-    │         ^^^^^^ Invalid argument to '<'
-    ·
- 19 │         (0, 1) < (0, 1, 2);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_lt_invalid.move:19:18 ───
     │
  19 │         (0, 1) < (0, 1, 2);
@@ -295,38 +280,5 @@ error:
     ·
  19 │         (0, 1) < (0, 1, 2);
     │                  --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_lt_invalid.move:19:18 ───
-    │
- 19 │         (0, 1) < (0, 1, 2);
-    │                  ^^^^^^^^^ Invalid argument to '<'
-    ·
- 19 │         (0, 1) < (0, 1, 2);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_lt_invalid.move:20:9 ───
-    │
- 20 │         (1, 2) < (0, 1);
-    │         ^^^^^^ Invalid argument to '<'
-    ·
- 20 │         (1, 2) < (0, 1);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_lt_invalid.move:20:18 ───
-    │
- 20 │         (1, 2) < (0, 1);
-    │                  ^^^^^^ Invalid argument to '<'
-    ·
- 20 │         (1, 2) < (0, 1);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
     │
 

--- a/language/move-lang/tests/move_check/typing/binary_mod_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_mod_invalid.exp
@@ -1,24 +1,186 @@
-error: 
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_mod_invalid.move:8:9
+  │
+8 │         false % true;
+  │         ^^^^^
+  │         │
+  │         Invalid argument to '%'
+  │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
-   ┌── tests/move_check/typing/binary_mod_invalid.move:8:9 ───
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_mod_invalid.move:8:17
+  │
+8 │         false % true;
+  │         -----   ^^^^ Invalid argument to '%'
+  │         │        
+  │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mod_invalid.move:10:9
    │
- 8 │         false % true;
-   │         ^^^^^ Invalid argument to '%'
+10 │         false % 1;
+   │         ^^^^^
+   │         │
+   │         Invalid argument to '%'
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mod_invalid.move:10:17
+   │
+10 │         false % 1;
+   │         -----   ^ Invalid argument to '%'
+   │         │        
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mod_invalid.move:11:9
+   │
+11 │         @0x0 % @0x1;
+   │         ^^^^
+   │         │
+   │         Invalid argument to '%'
+   │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mod_invalid.move:11:16
+   │
+11 │         @0x0 % @0x1;
+   │         ----   ^^^^ Invalid argument to '%'
+   │         │       
+   │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mod_invalid.move:13:9
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
    ·
- 8 │         false % true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-   │
+13 │         r % r;
+   │         ^ Invalid argument to '%'
 
-error: 
-
-   ┌── tests/move_check/typing/binary_mod_invalid.move:8:17 ───
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/binary_mod_invalid.move:13:9
    │
- 8 │         false % true;
-   │                 ^^^^ Invalid argument to '%'
+ 3 │     struct R {
+   │            - To satisfy the constraint, the 'drop' ability would need to be added here
    ·
- 8 │         false % true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - The type '0x8675309::M::R' does not have the ability 'drop'
+   ·
+13 │         r % r;
+   │         ^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mod_invalid.move:13:13
    │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+   ·
+13 │         r % r;
+   │             ^ Invalid argument to '%'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mod_invalid.move:14:9
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+   ·
+14 │         s % s;
+   │         ^ Invalid argument to '%'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mod_invalid.move:14:13
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+   ·
+14 │         s % s;
+   │             ^ Invalid argument to '%'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mod_invalid.move:15:9
+   │
+15 │         1 % false % @0x0 % 0;
+   │         ^^^^^^^^^
+   │         │   │
+   │         │   Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '%'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mod_invalid.move:15:9
+   │
+15 │         1 % false % @0x0 % 0;
+   │         ^^^^^^^^^^^^^^^^
+   │         │           │
+   │         │           Found: 'address'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '%'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mod_invalid.move:15:21
+   │
+15 │         1 % false % @0x0 % 0;
+   │             -----   ^^^^ Invalid argument to '%'
+   │             │        
+   │             Found: '_'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mod_invalid.move:15:28
+   │
+15 │         1 % false % @0x0 % 0;
+   │                     ----   ^ Invalid argument to '%'
+   │                     │       
+   │                     Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mod_invalid.move:16:9
+   │
+16 │         () % ();
+   │         ^^
+   │         │
+   │         Invalid argument to '%'
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mod_invalid.move:16:14
+   │
+16 │         () % ();
+   │         --   ^^ Invalid argument to '%'
+   │         │     
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mod_invalid.move:18:9
+   │
+18 │         (0, 1) % (0, 1, 2);
+   │         ^^^^^^
+   │         │
+   │         Invalid argument to '%'
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mod_invalid.move:18:18
+   │
+18 │         (0, 1) % (0, 1, 2);
+   │         ------   ^^^^^^^^^ Invalid argument to '%'
+   │         │         
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mod_invalid.move:19:9
+   │
+19 │         (1, 2) % (0, 1);
+   │         ^^^^^^
+   │         │
+   │         Invalid argument to '%'
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mod_invalid.move:19:18
+   │
+19 │         (1, 2) % (0, 1);
+   │         ------   ^^^^^^ Invalid argument to '%'
+   │         │         
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
 
 error: 
 
@@ -36,17 +198,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mod_invalid.move:10:9 ───
-    │
- 10 │         false % 1;
-    │         ^^^^^ Invalid argument to '%'
-    ·
- 10 │         false % 1;
-    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_mod_invalid.move:10:17 ───
     │
  10 │         false % 1;
@@ -57,39 +208,6 @@ error:
     ·
  10 │         false % 1;
     │         ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mod_invalid.move:10:17 ───
-    │
- 10 │         false % 1;
-    │                 ^ Invalid argument to '%'
-    ·
- 10 │         false % 1;
-    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mod_invalid.move:11:9 ───
-    │
- 11 │         @0x0 % @0x1;
-    │         ^^^^ Invalid argument to '%'
-    ·
- 11 │         @0x0 % @0x1;
-    │         ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mod_invalid.move:11:16 ───
-    │
- 11 │         @0x0 % @0x1;
-    │                ^^^^ Invalid argument to '%'
-    ·
- 11 │         @0x0 % @0x1;
-    │         ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -108,86 +226,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mod_invalid.move:13:9 ───
-    │
- 13 │         r % r;
-    │         ^ Invalid argument to '%'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mod_invalid.move:13:9 ───
-    │
- 13 │         r % r;
-    │         ^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - The type '0x8675309::M::R' does not have the ability 'drop'
-    ·
-  3 │     struct R {
-    │            - To satisfy the constraint, the 'drop' ability would need to be added here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mod_invalid.move:13:13 ───
-    │
- 13 │         r % r;
-    │             ^ Invalid argument to '%'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mod_invalid.move:14:9 ───
-    │
- 14 │         s % s;
-    │         ^ Invalid argument to '%'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mod_invalid.move:14:13 ───
-    │
- 14 │         s % s;
-    │             ^ Invalid argument to '%'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mod_invalid.move:15:9 ───
-    │
- 15 │         1 % false % @0x0 % 0;
-    │         ^^^^^^^^^ Invalid argument to '%'
-    ·
- 15 │         1 % false % @0x0 % 0;
-    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mod_invalid.move:15:9 ───
-    │
- 15 │         1 % false % @0x0 % 0;
-    │         ^^^^^^^^^^^^^^^^ Invalid argument to '%'
-    ·
- 15 │         1 % false % @0x0 % 0;
-    │                     ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_mod_invalid.move:15:13 ───
     │
  15 │         1 % false % @0x0 % 0;
@@ -198,17 +236,6 @@ error:
     ·
  15 │         1 % false % @0x0 % 0;
     │             ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mod_invalid.move:15:21 ───
-    │
- 15 │         1 % false % @0x0 % 0;
-    │                     ^^^^ Invalid argument to '%'
-    ·
- 15 │         1 % false % @0x0 % 0;
-    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -227,39 +254,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mod_invalid.move:15:28 ───
-    │
- 15 │         1 % false % @0x0 % 0;
-    │                            ^ Invalid argument to '%'
-    ·
- 15 │         1 % false % @0x0 % 0;
-    │                     ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mod_invalid.move:16:9 ───
-    │
- 16 │         () % ();
-    │         ^^ Invalid argument to '%'
-    ·
- 16 │         () % ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mod_invalid.move:16:14 ───
-    │
- 16 │         () % ();
-    │              ^^ Invalid argument to '%'
-    ·
- 16 │         () % ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_mod_invalid.move:17:13 ───
     │
  17 │         1 % ();
@@ -274,17 +268,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mod_invalid.move:18:9 ───
-    │
- 18 │         (0, 1) % (0, 1, 2);
-    │         ^^^^^^ Invalid argument to '%'
-    ·
- 18 │         (0, 1) % (0, 1, 2);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_mod_invalid.move:18:18 ───
     │
  18 │         (0, 1) % (0, 1, 2);
@@ -295,38 +278,5 @@ error:
     ·
  18 │         (0, 1) % (0, 1, 2);
     │                  --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mod_invalid.move:18:18 ───
-    │
- 18 │         (0, 1) % (0, 1, 2);
-    │                  ^^^^^^^^^ Invalid argument to '%'
-    ·
- 18 │         (0, 1) % (0, 1, 2);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mod_invalid.move:19:9 ───
-    │
- 19 │         (1, 2) % (0, 1);
-    │         ^^^^^^ Invalid argument to '%'
-    ·
- 19 │         (1, 2) % (0, 1);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mod_invalid.move:19:18 ───
-    │
- 19 │         (1, 2) % (0, 1);
-    │                  ^^^^^^ Invalid argument to '%'
-    ·
- 19 │         (1, 2) % (0, 1);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
     │
 

--- a/language/move-lang/tests/move_check/typing/binary_mul_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_mul_invalid.exp
@@ -1,24 +1,186 @@
-error: 
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_mul_invalid.move:8:9
+  │
+8 │         false * true;
+  │         ^^^^^
+  │         │
+  │         Invalid argument to '*'
+  │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
-   ┌── tests/move_check/typing/binary_mul_invalid.move:8:9 ───
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_mul_invalid.move:8:17
+  │
+8 │         false * true;
+  │         -----   ^^^^ Invalid argument to '*'
+  │         │        
+  │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mul_invalid.move:10:9
    │
- 8 │         false * true;
-   │         ^^^^^ Invalid argument to '*'
+10 │         false * 1;
+   │         ^^^^^
+   │         │
+   │         Invalid argument to '*'
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mul_invalid.move:10:17
+   │
+10 │         false * 1;
+   │         -----   ^ Invalid argument to '*'
+   │         │        
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mul_invalid.move:11:9
+   │
+11 │         @0x0 * @0x1;
+   │         ^^^^
+   │         │
+   │         Invalid argument to '*'
+   │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mul_invalid.move:11:16
+   │
+11 │         @0x0 * @0x1;
+   │         ----   ^^^^ Invalid argument to '*'
+   │         │       
+   │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mul_invalid.move:13:9
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
    ·
- 8 │         false * true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-   │
+13 │         r * r;
+   │         ^ Invalid argument to '*'
 
-error: 
-
-   ┌── tests/move_check/typing/binary_mul_invalid.move:8:17 ───
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/binary_mul_invalid.move:13:9
    │
- 8 │         false * true;
-   │                 ^^^^ Invalid argument to '*'
+ 3 │     struct R {
+   │            - To satisfy the constraint, the 'drop' ability would need to be added here
    ·
- 8 │         false * true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - The type '0x8675309::M::R' does not have the ability 'drop'
+   ·
+13 │         r * r;
+   │         ^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mul_invalid.move:13:13
    │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+   ·
+13 │         r * r;
+   │             ^ Invalid argument to '*'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mul_invalid.move:14:9
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+   ·
+14 │         s * s;
+   │         ^ Invalid argument to '*'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mul_invalid.move:14:13
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+   ·
+14 │         s * s;
+   │             ^ Invalid argument to '*'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mul_invalid.move:15:9
+   │
+15 │         1 * false * @0x0 * 0;
+   │         ^^^^^^^^^
+   │         │   │
+   │         │   Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '*'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mul_invalid.move:15:9
+   │
+15 │         1 * false * @0x0 * 0;
+   │         ^^^^^^^^^^^^^^^^
+   │         │           │
+   │         │           Found: 'address'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '*'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mul_invalid.move:15:21
+   │
+15 │         1 * false * @0x0 * 0;
+   │             -----   ^^^^ Invalid argument to '*'
+   │             │        
+   │             Found: '_'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mul_invalid.move:15:28
+   │
+15 │         1 * false * @0x0 * 0;
+   │                     ----   ^ Invalid argument to '*'
+   │                     │       
+   │                     Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mul_invalid.move:16:9
+   │
+16 │         () * ();
+   │         ^^
+   │         │
+   │         Invalid argument to '*'
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mul_invalid.move:16:14
+   │
+16 │         () * ();
+   │         --   ^^ Invalid argument to '*'
+   │         │     
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mul_invalid.move:18:9
+   │
+18 │         (0, 1) * (0, 1, 2);
+   │         ^^^^^^
+   │         │
+   │         Invalid argument to '*'
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mul_invalid.move:18:18
+   │
+18 │         (0, 1) * (0, 1, 2);
+   │         ------   ^^^^^^^^^ Invalid argument to '*'
+   │         │         
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mul_invalid.move:19:9
+   │
+19 │         (1, 2) * (0, 1);
+   │         ^^^^^^
+   │         │
+   │         Invalid argument to '*'
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_mul_invalid.move:19:18
+   │
+19 │         (1, 2) * (0, 1);
+   │         ------   ^^^^^^ Invalid argument to '*'
+   │         │         
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
 
 error: 
 
@@ -36,17 +198,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mul_invalid.move:10:9 ───
-    │
- 10 │         false * 1;
-    │         ^^^^^ Invalid argument to '*'
-    ·
- 10 │         false * 1;
-    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_mul_invalid.move:10:17 ───
     │
  10 │         false * 1;
@@ -57,39 +208,6 @@ error:
     ·
  10 │         false * 1;
     │         ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mul_invalid.move:10:17 ───
-    │
- 10 │         false * 1;
-    │                 ^ Invalid argument to '*'
-    ·
- 10 │         false * 1;
-    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mul_invalid.move:11:9 ───
-    │
- 11 │         @0x0 * @0x1;
-    │         ^^^^ Invalid argument to '*'
-    ·
- 11 │         @0x0 * @0x1;
-    │         ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mul_invalid.move:11:16 ───
-    │
- 11 │         @0x0 * @0x1;
-    │                ^^^^ Invalid argument to '*'
-    ·
- 11 │         @0x0 * @0x1;
-    │         ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -108,86 +226,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mul_invalid.move:13:9 ───
-    │
- 13 │         r * r;
-    │         ^ Invalid argument to '*'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mul_invalid.move:13:9 ───
-    │
- 13 │         r * r;
-    │         ^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - The type '0x8675309::M::R' does not have the ability 'drop'
-    ·
-  3 │     struct R {
-    │            - To satisfy the constraint, the 'drop' ability would need to be added here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mul_invalid.move:13:13 ───
-    │
- 13 │         r * r;
-    │             ^ Invalid argument to '*'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mul_invalid.move:14:9 ───
-    │
- 14 │         s * s;
-    │         ^ Invalid argument to '*'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mul_invalid.move:14:13 ───
-    │
- 14 │         s * s;
-    │             ^ Invalid argument to '*'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mul_invalid.move:15:9 ───
-    │
- 15 │         1 * false * @0x0 * 0;
-    │         ^^^^^^^^^ Invalid argument to '*'
-    ·
- 15 │         1 * false * @0x0 * 0;
-    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mul_invalid.move:15:9 ───
-    │
- 15 │         1 * false * @0x0 * 0;
-    │         ^^^^^^^^^^^^^^^^ Invalid argument to '*'
-    ·
- 15 │         1 * false * @0x0 * 0;
-    │                     ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_mul_invalid.move:15:13 ───
     │
  15 │         1 * false * @0x0 * 0;
@@ -198,17 +236,6 @@ error:
     ·
  15 │         1 * false * @0x0 * 0;
     │             ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mul_invalid.move:15:21 ───
-    │
- 15 │         1 * false * @0x0 * 0;
-    │                     ^^^^ Invalid argument to '*'
-    ·
- 15 │         1 * false * @0x0 * 0;
-    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -227,39 +254,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mul_invalid.move:15:28 ───
-    │
- 15 │         1 * false * @0x0 * 0;
-    │                            ^ Invalid argument to '*'
-    ·
- 15 │         1 * false * @0x0 * 0;
-    │                     ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mul_invalid.move:16:9 ───
-    │
- 16 │         () * ();
-    │         ^^ Invalid argument to '*'
-    ·
- 16 │         () * ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mul_invalid.move:16:14 ───
-    │
- 16 │         () * ();
-    │              ^^ Invalid argument to '*'
-    ·
- 16 │         () * ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_mul_invalid.move:17:13 ───
     │
  17 │         1 * ();
@@ -274,17 +268,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mul_invalid.move:18:9 ───
-    │
- 18 │         (0, 1) * (0, 1, 2);
-    │         ^^^^^^ Invalid argument to '*'
-    ·
- 18 │         (0, 1) * (0, 1, 2);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_mul_invalid.move:18:18 ───
     │
  18 │         (0, 1) * (0, 1, 2);
@@ -295,38 +278,5 @@ error:
     ·
  18 │         (0, 1) * (0, 1, 2);
     │                  --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mul_invalid.move:18:18 ───
-    │
- 18 │         (0, 1) * (0, 1, 2);
-    │                  ^^^^^^^^^ Invalid argument to '*'
-    ·
- 18 │         (0, 1) * (0, 1, 2);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mul_invalid.move:19:9 ───
-    │
- 19 │         (1, 2) * (0, 1);
-    │         ^^^^^^ Invalid argument to '*'
-    ·
- 19 │         (1, 2) * (0, 1);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mul_invalid.move:19:18 ───
-    │
- 19 │         (1, 2) * (0, 1);
-    │                  ^^^^^^ Invalid argument to '*'
-    ·
- 19 │         (1, 2) * (0, 1);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
     │
 

--- a/language/move-lang/tests/move_check/typing/binary_shl_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_shl_invalid.exp
@@ -1,13 +1,86 @@
-error: 
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_shl_invalid.move:8:9
+  │
+8 │         false << true;
+  │         ^^^^^
+  │         │
+  │         Invalid argument to '<<'
+  │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
-   ┌── tests/move_check/typing/binary_shl_invalid.move:8:9 ───
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_shl_invalid.move:10:9
    │
- 8 │         false << true;
-   │         ^^^^^ Invalid argument to '<<'
+10 │         false << 1;
+   │         ^^^^^
+   │         │
+   │         Invalid argument to '<<'
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_shl_invalid.move:11:9
+   │
+11 │         @0x0 << @0x1;
+   │         ^^^^
+   │         │
+   │         Invalid argument to '<<'
+   │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_shl_invalid.move:13:9
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
    ·
- 8 │         false << true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+13 │         r << r;
+   │         ^ Invalid argument to '<<'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/binary_shl_invalid.move:13:9
    │
+ 3 │     struct R {
+   │            - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - The type '0x8675309::M::R' does not have the ability 'drop'
+   ·
+13 │         r << r;
+   │         ^^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_shl_invalid.move:14:9
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+   ·
+14 │         s << s;
+   │         ^ Invalid argument to '<<'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_shl_invalid.move:16:9
+   │
+16 │         () << ();
+   │         ^^
+   │         │
+   │         Invalid argument to '<<'
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_shl_invalid.move:18:9
+   │
+18 │         (0, 1) << (0, 1, 2);
+   │         ^^^^^^
+   │         │
+   │         Invalid argument to '<<'
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_shl_invalid.move:19:9
+   │
+19 │         (1, 2) << (0, 1);
+   │         ^^^^^^
+   │         │
+   │         Invalid argument to '<<'
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
 
 error: 
 
@@ -39,28 +112,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_shl_invalid.move:10:9 ───
-    │
- 10 │         false << 1;
-    │         ^^^^^ Invalid argument to '<<'
-    ·
- 10 │         false << 1;
-    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_shl_invalid.move:11:9 ───
-    │
- 11 │         @0x0 << @0x1;
-    │         ^^^^ Invalid argument to '<<'
-    ·
- 11 │         @0x0 << @0x1;
-    │         ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_shl_invalid.move:11:17 ───
     │
  11 │         @0x0 << @0x1;
@@ -89,31 +140,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_shl_invalid.move:13:9 ───
-    │
- 13 │         r << r;
-    │         ^ Invalid argument to '<<'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_shl_invalid.move:13:9 ───
-    │
- 13 │         r << r;
-    │         ^^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - The type '0x8675309::M::R' does not have the ability 'drop'
-    ·
-  3 │     struct R {
-    │            - To satisfy the constraint, the 'drop' ability would need to be added here
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_shl_invalid.move:13:14 ───
     │
  13 │         r << r;
@@ -124,17 +150,6 @@ error:
     ·
  13 │         r << r;
     │              - Is not compatible with: 'u8'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_shl_invalid.move:14:9 ───
-    │
- 14 │         s << s;
-    │         ^ Invalid argument to '<<'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -181,17 +196,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_shl_invalid.move:16:9 ───
-    │
- 16 │         () << ();
-    │         ^^ Invalid argument to '<<'
-    ·
- 16 │         () << ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_shl_invalid.move:16:15 ───
     │
  16 │         () << ();
@@ -220,17 +224,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_shl_invalid.move:18:9 ───
-    │
- 18 │         (0, 1) << (0, 1, 2);
-    │         ^^^^^^ Invalid argument to '<<'
-    ·
- 18 │         (0, 1) << (0, 1, 2);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_shl_invalid.move:18:19 ───
     │
  18 │         (0, 1) << (0, 1, 2);
@@ -241,17 +234,6 @@ error:
     ·
  18 │         (0, 1) << (0, 1, 2);
     │                   --------- Is not compatible with: 'u8'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_shl_invalid.move:19:9 ───
-    │
- 19 │         (1, 2) << (0, 1);
-    │         ^^^^^^ Invalid argument to '<<'
-    ·
- 19 │         (1, 2) << (0, 1);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/binary_shr_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_shr_invalid.exp
@@ -1,13 +1,86 @@
-error: 
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_shr_invalid.move:8:9
+  │
+8 │         false >> true;
+  │         ^^^^^
+  │         │
+  │         Invalid argument to '>>'
+  │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
-   ┌── tests/move_check/typing/binary_shr_invalid.move:8:9 ───
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_shr_invalid.move:10:9
    │
- 8 │         false >> true;
-   │         ^^^^^ Invalid argument to '>>'
+10 │         false >> 1;
+   │         ^^^^^
+   │         │
+   │         Invalid argument to '>>'
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_shr_invalid.move:11:9
+   │
+11 │         @0x0 >> @0x1;
+   │         ^^^^
+   │         │
+   │         Invalid argument to '>>'
+   │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_shr_invalid.move:13:9
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
    ·
- 8 │         false >> true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+13 │         r >> r;
+   │         ^ Invalid argument to '>>'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/binary_shr_invalid.move:13:9
    │
+ 3 │     struct R {
+   │            - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - The type '0x8675309::M::R' does not have the ability 'drop'
+   ·
+13 │         r >> r;
+   │         ^^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_shr_invalid.move:14:9
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+   ·
+14 │         s >> s;
+   │         ^ Invalid argument to '>>'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_shr_invalid.move:16:9
+   │
+16 │         () >> ();
+   │         ^^
+   │         │
+   │         Invalid argument to '>>'
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_shr_invalid.move:18:9
+   │
+18 │         (0, 1) >> (0, 1, 2);
+   │         ^^^^^^
+   │         │
+   │         Invalid argument to '>>'
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_shr_invalid.move:19:9
+   │
+19 │         (1, 2) >> (0, 1);
+   │         ^^^^^^
+   │         │
+   │         Invalid argument to '>>'
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
 
 error: 
 
@@ -39,28 +112,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_shr_invalid.move:10:9 ───
-    │
- 10 │         false >> 1;
-    │         ^^^^^ Invalid argument to '>>'
-    ·
- 10 │         false >> 1;
-    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_shr_invalid.move:11:9 ───
-    │
- 11 │         @0x0 >> @0x1;
-    │         ^^^^ Invalid argument to '>>'
-    ·
- 11 │         @0x0 >> @0x1;
-    │         ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_shr_invalid.move:11:17 ───
     │
  11 │         @0x0 >> @0x1;
@@ -89,31 +140,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_shr_invalid.move:13:9 ───
-    │
- 13 │         r >> r;
-    │         ^ Invalid argument to '>>'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_shr_invalid.move:13:9 ───
-    │
- 13 │         r >> r;
-    │         ^^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - The type '0x8675309::M::R' does not have the ability 'drop'
-    ·
-  3 │     struct R {
-    │            - To satisfy the constraint, the 'drop' ability would need to be added here
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_shr_invalid.move:13:14 ───
     │
  13 │         r >> r;
@@ -124,17 +150,6 @@ error:
     ·
  13 │         r >> r;
     │              - Is not compatible with: 'u8'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_shr_invalid.move:14:9 ───
-    │
- 14 │         s >> s;
-    │         ^ Invalid argument to '>>'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -181,17 +196,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_shr_invalid.move:16:9 ───
-    │
- 16 │         () >> ();
-    │         ^^ Invalid argument to '>>'
-    ·
- 16 │         () >> ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_shr_invalid.move:16:15 ───
     │
  16 │         () >> ();
@@ -220,17 +224,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_shr_invalid.move:18:9 ───
-    │
- 18 │         (0, 1) >> (0, 1, 2);
-    │         ^^^^^^ Invalid argument to '>>'
-    ·
- 18 │         (0, 1) >> (0, 1, 2);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_shr_invalid.move:18:19 ───
     │
  18 │         (0, 1) >> (0, 1, 2);
@@ -241,17 +234,6 @@ error:
     ·
  18 │         (0, 1) >> (0, 1, 2);
     │                   --------- Is not compatible with: 'u8'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_shr_invalid.move:19:9 ───
-    │
- 19 │         (1, 2) >> (0, 1);
-    │         ^^^^^^ Invalid argument to '>>'
-    ·
- 19 │         (1, 2) >> (0, 1);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/binary_sub_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_sub_invalid.exp
@@ -1,24 +1,186 @@
-error: 
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_sub_invalid.move:8:9
+  │
+8 │         false - true;
+  │         ^^^^^
+  │         │
+  │         Invalid argument to '-'
+  │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
-   ┌── tests/move_check/typing/binary_sub_invalid.move:8:9 ───
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/binary_sub_invalid.move:8:17
+  │
+8 │         false - true;
+  │         -----   ^^^^ Invalid argument to '-'
+  │         │        
+  │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_sub_invalid.move:10:9
    │
- 8 │         false - true;
-   │         ^^^^^ Invalid argument to '-'
+10 │         false - 1;
+   │         ^^^^^
+   │         │
+   │         Invalid argument to '-'
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_sub_invalid.move:10:17
+   │
+10 │         false - 1;
+   │         -----   ^ Invalid argument to '-'
+   │         │        
+   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_sub_invalid.move:11:9
+   │
+11 │         @0x0 - @0x1;
+   │         ^^^^
+   │         │
+   │         Invalid argument to '-'
+   │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_sub_invalid.move:11:16
+   │
+11 │         @0x0 - @0x1;
+   │         ----   ^^^^ Invalid argument to '-'
+   │         │       
+   │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_sub_invalid.move:13:9
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
    ·
- 8 │         false - true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-   │
+13 │         r - r;
+   │         ^ Invalid argument to '-'
 
-error: 
-
-   ┌── tests/move_check/typing/binary_sub_invalid.move:8:17 ───
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/binary_sub_invalid.move:13:9
    │
- 8 │         false - true;
-   │                 ^^^^ Invalid argument to '-'
+ 3 │     struct R {
+   │            - To satisfy the constraint, the 'drop' ability would need to be added here
    ·
- 8 │         false - true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - The type '0x8675309::M::R' does not have the ability 'drop'
+   ·
+13 │         r - r;
+   │         ^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_sub_invalid.move:13:13
    │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+   ·
+13 │         r - r;
+   │             ^ Invalid argument to '-'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_sub_invalid.move:14:9
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+   ·
+14 │         s - s;
+   │         ^ Invalid argument to '-'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_sub_invalid.move:14:13
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+   ·
+14 │         s - s;
+   │             ^ Invalid argument to '-'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_sub_invalid.move:15:9
+   │
+15 │         1 - false - @0x0 - 0;
+   │         ^^^^^^^^^
+   │         │   │
+   │         │   Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '-'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_sub_invalid.move:15:9
+   │
+15 │         1 - false - @0x0 - 0;
+   │         ^^^^^^^^^^^^^^^^
+   │         │           │
+   │         │           Found: 'address'. But expected: 'u8', 'u64', 'u128'
+   │         Invalid argument to '-'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_sub_invalid.move:15:21
+   │
+15 │         1 - false - @0x0 - 0;
+   │             -----   ^^^^ Invalid argument to '-'
+   │             │        
+   │             Found: '_'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_sub_invalid.move:15:28
+   │
+15 │         1 - false - @0x0 - 0;
+   │                     ----   ^ Invalid argument to '-'
+   │                     │       
+   │                     Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_sub_invalid.move:16:9
+   │
+16 │         () - ();
+   │         ^^
+   │         │
+   │         Invalid argument to '-'
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_sub_invalid.move:16:14
+   │
+16 │         () - ();
+   │         --   ^^ Invalid argument to '-'
+   │         │     
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_sub_invalid.move:18:9
+   │
+18 │         (0, 1) - (0, 1, 2);
+   │         ^^^^^^
+   │         │
+   │         Invalid argument to '-'
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_sub_invalid.move:18:18
+   │
+18 │         (0, 1) - (0, 1, 2);
+   │         ------   ^^^^^^^^^ Invalid argument to '-'
+   │         │         
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_sub_invalid.move:19:9
+   │
+19 │         (1, 2) - (0, 1);
+   │         ^^^^^^
+   │         │
+   │         Invalid argument to '-'
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/binary_sub_invalid.move:19:18
+   │
+19 │         (1, 2) - (0, 1);
+   │         ------   ^^^^^^ Invalid argument to '-'
+   │         │         
+   │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
 
 error: 
 
@@ -36,17 +198,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_sub_invalid.move:10:9 ───
-    │
- 10 │         false - 1;
-    │         ^^^^^ Invalid argument to '-'
-    ·
- 10 │         false - 1;
-    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_sub_invalid.move:10:17 ───
     │
  10 │         false - 1;
@@ -57,39 +208,6 @@ error:
     ·
  10 │         false - 1;
     │         ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_sub_invalid.move:10:17 ───
-    │
- 10 │         false - 1;
-    │                 ^ Invalid argument to '-'
-    ·
- 10 │         false - 1;
-    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_sub_invalid.move:11:9 ───
-    │
- 11 │         @0x0 - @0x1;
-    │         ^^^^ Invalid argument to '-'
-    ·
- 11 │         @0x0 - @0x1;
-    │         ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_sub_invalid.move:11:16 ───
-    │
- 11 │         @0x0 - @0x1;
-    │                ^^^^ Invalid argument to '-'
-    ·
- 11 │         @0x0 - @0x1;
-    │         ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -108,86 +226,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_sub_invalid.move:13:9 ───
-    │
- 13 │         r - r;
-    │         ^ Invalid argument to '-'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_sub_invalid.move:13:9 ───
-    │
- 13 │         r - r;
-    │         ^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - The type '0x8675309::M::R' does not have the ability 'drop'
-    ·
-  3 │     struct R {
-    │            - To satisfy the constraint, the 'drop' ability would need to be added here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_sub_invalid.move:13:13 ───
-    │
- 13 │         r - r;
-    │             ^ Invalid argument to '-'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_sub_invalid.move:14:9 ───
-    │
- 14 │         s - s;
-    │         ^ Invalid argument to '-'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_sub_invalid.move:14:13 ───
-    │
- 14 │         s - s;
-    │             ^ Invalid argument to '-'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_sub_invalid.move:15:9 ───
-    │
- 15 │         1 - false - @0x0 - 0;
-    │         ^^^^^^^^^ Invalid argument to '-'
-    ·
- 15 │         1 - false - @0x0 - 0;
-    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_sub_invalid.move:15:9 ───
-    │
- 15 │         1 - false - @0x0 - 0;
-    │         ^^^^^^^^^^^^^^^^ Invalid argument to '-'
-    ·
- 15 │         1 - false - @0x0 - 0;
-    │                     ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_sub_invalid.move:15:13 ───
     │
  15 │         1 - false - @0x0 - 0;
@@ -198,17 +236,6 @@ error:
     ·
  15 │         1 - false - @0x0 - 0;
     │             ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_sub_invalid.move:15:21 ───
-    │
- 15 │         1 - false - @0x0 - 0;
-    │                     ^^^^ Invalid argument to '-'
-    ·
- 15 │         1 - false - @0x0 - 0;
-    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
@@ -227,39 +254,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_sub_invalid.move:15:28 ───
-    │
- 15 │         1 - false - @0x0 - 0;
-    │                            ^ Invalid argument to '-'
-    ·
- 15 │         1 - false - @0x0 - 0;
-    │                     ---- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_sub_invalid.move:16:9 ───
-    │
- 16 │         () - ();
-    │         ^^ Invalid argument to '-'
-    ·
- 16 │         () - ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_sub_invalid.move:16:14 ───
-    │
- 16 │         () - ();
-    │              ^^ Invalid argument to '-'
-    ·
- 16 │         () - ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_sub_invalid.move:17:13 ───
     │
  17 │         1 - ();
@@ -274,17 +268,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/binary_sub_invalid.move:18:9 ───
-    │
- 18 │         (0, 1) - (0, 1, 2);
-    │         ^^^^^^ Invalid argument to '-'
-    ·
- 18 │         (0, 1) - (0, 1, 2);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/binary_sub_invalid.move:18:18 ───
     │
  18 │         (0, 1) - (0, 1, 2);
@@ -295,38 +278,5 @@ error:
     ·
  18 │         (0, 1) - (0, 1, 2);
     │                  --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_sub_invalid.move:18:18 ───
-    │
- 18 │         (0, 1) - (0, 1, 2);
-    │                  ^^^^^^^^^ Invalid argument to '-'
-    ·
- 18 │         (0, 1) - (0, 1, 2);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_sub_invalid.move:19:9 ───
-    │
- 19 │         (1, 2) - (0, 1);
-    │         ^^^^^^ Invalid argument to '-'
-    ·
- 19 │         (1, 2) - (0, 1);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_sub_invalid.move:19:18 ───
-    │
- 19 │         (1, 2) - (0, 1);
-    │                  ^^^^^^ Invalid argument to '-'
-    ·
- 19 │         (1, 2) - (0, 1);
-    │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
     │
 

--- a/language/move-lang/tests/move_check/typing/bind_pop_resource.exp
+++ b/language/move-lang/tests/move_check/typing/bind_pop_resource.exp
@@ -1,42 +1,33 @@
-error: 
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/bind_pop_resource.move:5:13
+  │
+2 │     struct R {}
+  │            - To satisfy the constraint, the 'drop' ability would need to be added here
+  ·
+5 │         let _: R = R{};
+  │             ^  - The type '0x8675309::M::R' does not have the ability 'drop'
+  │             │   
+  │             Cannot ignore values without the 'drop' ability. The value must be used
 
-   ┌── tests/move_check/typing/bind_pop_resource.move:5:13 ───
-   │
- 5 │         let _: R = R{};
-   │             ^ Cannot ignore values without the 'drop' ability. The value must be used
-   ·
- 5 │         let _: R = R{};
-   │                - The type '0x8675309::M::R' does not have the ability 'drop'
-   ·
- 2 │     struct R {}
-   │            - To satisfy the constraint, the 'drop' ability would need to be added here
-   │
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/bind_pop_resource.move:9:14
+  │
+2 │     struct R {}
+  │            - To satisfy the constraint, the 'drop' ability would need to be added here
+  ·
+9 │         let (_, _):(R, R) = (R{}, R{});
+  │              ^      - The type '0x8675309::M::R' does not have the ability 'drop'
+  │              │       
+  │              Cannot ignore values without the 'drop' ability. The value must be used
 
-error: 
-
-   ┌── tests/move_check/typing/bind_pop_resource.move:9:14 ───
-   │
- 9 │         let (_, _):(R, R) = (R{}, R{});
-   │              ^ Cannot ignore values without the 'drop' ability. The value must be used
-   ·
- 9 │         let (_, _):(R, R) = (R{}, R{});
-   │                     - The type '0x8675309::M::R' does not have the ability 'drop'
-   ·
- 2 │     struct R {}
-   │            - To satisfy the constraint, the 'drop' ability would need to be added here
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/bind_pop_resource.move:9:17 ───
-   │
- 9 │         let (_, _):(R, R) = (R{}, R{});
-   │                 ^ Cannot ignore values without the 'drop' ability. The value must be used
-   ·
- 9 │         let (_, _):(R, R) = (R{}, R{});
-   │                        - The type '0x8675309::M::R' does not have the ability 'drop'
-   ·
- 2 │     struct R {}
-   │            - To satisfy the constraint, the 'drop' ability would need to be added here
-   │
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/bind_pop_resource.move:9:17
+  │
+2 │     struct R {}
+  │            - To satisfy the constraint, the 'drop' ability would need to be added here
+  ·
+9 │         let (_, _):(R, R) = (R{}, R{});
+  │                 ^      - The type '0x8675309::M::R' does not have the ability 'drop'
+  │                 │       
+  │                 Cannot ignore values without the 'drop' ability. The value must be used
 

--- a/language/move-lang/tests/move_check/typing/bind_wrong_arity.exp
+++ b/language/move-lang/tests/move_check/typing/bind_wrong_arity.exp
@@ -1,13 +1,10 @@
-error: 
-
-   ┌── tests/move_check/typing/bind_wrong_arity.move:5:13 ───
-   │
- 5 │         let x: () = ();
-   │             ^ Invalid type for local
-   ·
- 5 │         let x: () = ();
-   │                -- Expected a single type, but found expression list type: '()'
-   │
+error[E04005]: expected a single type
+  ┌─ tests/move_check/typing/bind_wrong_arity.move:5:13
+  │
+5 │         let x: () = ();
+  │             ^  -- Expected a single type, but found expression list type: '()'
+  │             │   
+  │             Invalid type for local
 
 error: 
 

--- a/language/move-lang/tests/move_check/typing/bind_wrong_type.exp
+++ b/language/move-lang/tests/move_check/typing/bind_wrong_type.exp
@@ -1,3 +1,19 @@
+error[E04005]: expected a single type
+   ┌─ tests/move_check/typing/bind_wrong_type.move:11:13
+   │
+11 │         let x = ();
+   │             ^   -- Expected a single type, but found expression list type: '()'
+   │             │    
+   │             Invalid type for local
+
+error[E04005]: expected a single type
+   ┌─ tests/move_check/typing/bind_wrong_type.move:18:13
+   │
+18 │         let x: () = 0;
+   │             ^  -- Expected a single type, but found expression list type: '()'
+   │             │   
+   │             Invalid type for local
+
 error: 
 
    ┌── tests/move_check/typing/bind_wrong_type.move:6:13 ───
@@ -25,17 +41,6 @@ error:
  7 │         let (S { g }, R { f }) = (R{ f: 0 }, R{ f: 1 });
    │                                   --------- Is not compatible with: '0x8675309::M::R'
    │
-
-error: 
-
-    ┌── tests/move_check/typing/bind_wrong_type.move:11:13 ───
-    │
- 11 │         let x = ();
-    │             ^ Invalid type for local
-    ·
- 11 │         let x = ();
-    │                 -- Expected a single type, but found expression list type: '()'
-    │
 
 error: 
 
@@ -77,17 +82,6 @@ error:
     ·
  14 │         let (x, b, R{f}) = (0, false);
     │                            ---------- Is not compatible with the expression list type of length 2: '({integer}, bool)'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/bind_wrong_type.move:18:13 ───
-    │
- 18 │         let x: () = 0;
-    │             ^ Invalid type for local
-    ·
- 18 │         let x: () = 0;
-    │                -- Expected a single type, but found expression list type: '()'
     │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/block_single_expr_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/block_single_expr_invalid.exp
@@ -1,3 +1,15 @@
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/block_single_expr_invalid.move:7:9
+  │
+2 │     struct R {}
+  │            - To satisfy the constraint, the 'drop' ability would need to be added here
+  ·
+7 │         ({ R {} } : R);
+  │         ^^^^^^^^^^^^^^
+  │         │           │
+  │         │           The type '0x8675309::M::R' does not have the ability 'drop'
+  │         Cannot ignore values without the 'drop' ability. The value must be used
+
 error: 
 
    ┌── tests/move_check/typing/block_single_expr_invalid.move:4:18 ───
@@ -38,20 +50,6 @@ error:
    ·
  6 │         ({ &mut 0 } : ());
    │                       -- Is not compatible with: '()'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/block_single_expr_invalid.move:7:9 ───
-   │
- 7 │         ({ R {} } : R);
-   │         ^^^^^^^^^^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
-   ·
- 7 │         ({ R {} } : R);
-   │                     - The type '0x8675309::M::R' does not have the ability 'drop'
-   ·
- 2 │     struct R {}
-   │            - To satisfy the constraint, the 'drop' ability would need to be added here
    │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/block_with_statements_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/block_with_statements_invalid.exp
@@ -1,3 +1,15 @@
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/block_with_statements_invalid.move:7:9
+  │
+2 │     struct R {}
+  │            - To satisfy the constraint, the 'drop' ability would need to be added here
+  ·
+7 │         ({ let r = { let r = R {}; r }; r } : R);
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │         │                                     │
+  │         │                                     The type '0x8675309::M::R' does not have the ability 'drop'
+  │         Cannot ignore values without the 'drop' ability. The value must be used
+
 error: 
 
    ┌── tests/move_check/typing/block_with_statements_invalid.move:4:29 ───
@@ -38,20 +50,6 @@ error:
    ·
  6 │         ({ let y = 0; &mut (y + 1) } : ());
    │                                        -- Is not compatible with: '()'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/block_with_statements_invalid.move:7:9 ───
-   │
- 7 │         ({ let r = { let r = R {}; r }; r } : R);
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
-   ·
- 7 │         ({ let r = { let r = R {}; r }; r } : R);
-   │                                               - The type '0x8675309::M::R' does not have the ability 'drop'
-   ·
- 2 │     struct R {}
-   │            - To satisfy the constraint, the 'drop' ability would need to be added here
    │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/borrow_field_chain_missing.exp
+++ b/language/move-lang/tests/move_check/typing/borrow_field_chain_missing.exp
@@ -1,72 +1,54 @@
-error: 
+error[E03010]: unbound field
+  ┌─ tests/move_check/typing/borrow_field_chain_missing.move:7:10
+  │
+7 │         &x1.f;
+  │          ^^^^ Unbound field 'f' in '0x8675309::M::X1'
 
-   ┌── tests/move_check/typing/borrow_field_chain_missing.move:7:10 ───
+error[E03010]: unbound field
+  ┌─ tests/move_check/typing/borrow_field_chain_missing.move:8:10
+  │
+8 │         &x1.x2.f;
+  │          ^^^^^^^ Unbound field 'f' in '0x8675309::M::X2'
+
+error[E03010]: unbound field
+  ┌─ tests/move_check/typing/borrow_field_chain_missing.move:9:10
+  │
+9 │         &x1.x2.x3.g;
+  │          ^^^^^^^^^^ Unbound field 'g' in '0x8675309::M::X3'
+
+error[E03010]: unbound field
+   ┌─ tests/move_check/typing/borrow_field_chain_missing.move:11:10
    │
- 7 │         &x1.f;
-   │          ^^^^ Unbound field 'f' in '0x8675309::M::X1'
+11 │         &x1_mut.f;
+   │          ^^^^^^^^ Unbound field 'f' in '0x8675309::M::X1'
+
+error[E03010]: unbound field
+   ┌─ tests/move_check/typing/borrow_field_chain_missing.move:12:10
    │
+12 │         &x1_mut.x2.f;
+   │          ^^^^^^^^^^^ Unbound field 'f' in '0x8675309::M::X2'
 
-error: 
-
-   ┌── tests/move_check/typing/borrow_field_chain_missing.move:8:10 ───
+error[E03010]: unbound field
+   ┌─ tests/move_check/typing/borrow_field_chain_missing.move:13:10
    │
- 8 │         &x1.x2.f;
-   │          ^^^^^^^ Unbound field 'f' in '0x8675309::M::X2'
+13 │         &x1_mut.x2.x3.g;
+   │          ^^^^^^^^^^^^^^ Unbound field 'g' in '0x8675309::M::X3'
+
+error[E03010]: unbound field
+   ┌─ tests/move_check/typing/borrow_field_chain_missing.move:15:14
    │
+15 │         &mut x1_mut.f;
+   │              ^^^^^^^^ Unbound field 'f' in '0x8675309::M::X1'
 
-error: 
-
-   ┌── tests/move_check/typing/borrow_field_chain_missing.move:9:10 ───
+error[E03010]: unbound field
+   ┌─ tests/move_check/typing/borrow_field_chain_missing.move:16:14
    │
- 9 │         &x1.x2.x3.g;
-   │          ^^^^^^^^^^ Unbound field 'g' in '0x8675309::M::X3'
+16 │         &mut x1_mut.x2.f;
+   │              ^^^^^^^^^^^ Unbound field 'f' in '0x8675309::M::X2'
+
+error[E03010]: unbound field
+   ┌─ tests/move_check/typing/borrow_field_chain_missing.move:17:14
    │
-
-error: 
-
-    ┌── tests/move_check/typing/borrow_field_chain_missing.move:11:10 ───
-    │
- 11 │         &x1_mut.f;
-    │          ^^^^^^^^ Unbound field 'f' in '0x8675309::M::X1'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/borrow_field_chain_missing.move:12:10 ───
-    │
- 12 │         &x1_mut.x2.f;
-    │          ^^^^^^^^^^^ Unbound field 'f' in '0x8675309::M::X2'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/borrow_field_chain_missing.move:13:10 ───
-    │
- 13 │         &x1_mut.x2.x3.g;
-    │          ^^^^^^^^^^^^^^ Unbound field 'g' in '0x8675309::M::X3'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/borrow_field_chain_missing.move:15:14 ───
-    │
- 15 │         &mut x1_mut.f;
-    │              ^^^^^^^^ Unbound field 'f' in '0x8675309::M::X1'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/borrow_field_chain_missing.move:16:14 ───
-    │
- 16 │         &mut x1_mut.x2.f;
-    │              ^^^^^^^^^^^ Unbound field 'f' in '0x8675309::M::X2'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/borrow_field_chain_missing.move:17:14 ───
-    │
- 17 │         &mut x1_mut.x2.x3.g;
-    │              ^^^^^^^^^^^^^^ Unbound field 'g' in '0x8675309::M::X3'
-    │
+17 │         &mut x1_mut.x2.x3.g;
+   │              ^^^^^^^^^^^^^^ Unbound field 'g' in '0x8675309::M::X3'
 

--- a/language/move-lang/tests/move_check/typing/borrow_field_from_non_struct.exp
+++ b/language/move-lang/tests/move_check/typing/borrow_field_from_non_struct.exp
@@ -1,3 +1,21 @@
+error[E04005]: expected a single type
+   ┌─ tests/move_check/typing/borrow_field_from_non_struct.move:12:10
+   │
+12 │         &().R;
+   │          ^^
+   │          │
+   │          Invalid dot access
+   │          Expected a single type, but found expression list type: '()'
+
+error[E04005]: expected a single type
+   ┌─ tests/move_check/typing/borrow_field_from_non_struct.move:13:10
+   │
+13 │         &(&S{f: 0}, &S{f:0}).f;
+   │          ^^^^^^^^^^^^^^^^^^^
+   │          │
+   │          Invalid dot access
+   │          Expected a single type, but found expression list type: '(&0x8675309::M::S, &0x8675309::M::S)'
+
 error: 
 
    ┌── tests/move_check/typing/borrow_field_from_non_struct.move:6:10 ───
@@ -69,32 +87,10 @@ error:
     ┌── tests/move_check/typing/borrow_field_from_non_struct.move:12:10 ───
     │
  12 │         &().R;
-    │          ^^ Invalid dot access
-    ·
- 12 │         &().R;
-    │          -- Expected a single type, but found expression list type: '()'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/borrow_field_from_non_struct.move:12:10 ───
-    │
- 12 │         &().R;
     │          ^^^^ Unbound field 'R'
     ·
  12 │         &().R;
     │          -- Expected a struct type in the current module but got: '()'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/borrow_field_from_non_struct.move:13:10 ───
-    │
- 13 │         &(&S{f: 0}, &S{f:0}).f;
-    │          ^^^^^^^^^^^^^^^^^^^ Invalid dot access
-    ·
- 13 │         &(&S{f: 0}, &S{f:0}).f;
-    │          ------------------- Expected a single type, but found expression list type: '(&0x8675309::M::S, &0x8675309::M::S)'
     │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/borrow_field_missing.exp
+++ b/language/move-lang/tests/move_check/typing/borrow_field_missing.exp
@@ -1,16 +1,12 @@
-error: 
+error[E03010]: unbound field
+  ┌─ tests/move_check/typing/borrow_field_missing.move:5:10
+  │
+5 │         &s.g;
+  │          ^^^ Unbound field 'g' in '0x8675309::M::S'
 
-   ┌── tests/move_check/typing/borrow_field_missing.move:5:10 ───
-   │
- 5 │         &s.g;
-   │          ^^^ Unbound field 'g' in '0x8675309::M::S'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/borrow_field_missing.move:6:10 ───
-   │
- 6 │         &s_mut.h;
-   │          ^^^^^^^ Unbound field 'h' in '0x8675309::M::S'
-   │
+error[E03010]: unbound field
+  ┌─ tests/move_check/typing/borrow_field_missing.move:6:10
+  │
+6 │         &s_mut.h;
+  │          ^^^^^^^ Unbound field 'h' in '0x8675309::M::S'
 

--- a/language/move-lang/tests/move_check/typing/borrow_field_non_ref_non_local_root.exp
+++ b/language/move-lang/tests/move_check/typing/borrow_field_non_ref_non_local_root.exp
@@ -1,14 +1,12 @@
-error: 
-
-    ┌── tests/move_check/typing/borrow_field_non_ref_non_local_root.move:9:22 ───
-    │
-  9 │         (&(if (cond) *foo() else bar()).f : &u64);
-    │                      ^^^^^^ Invalid dereference. Dereference requires the 'copy' ability
-    ·
- 12 │     fun foo(): &S {
-    │                 - The type '0x8675309::M::S' does not have the ability 'copy'
-    ·
-  2 │     struct S has drop { f: u64 }
-    │            - To satisfy the constraint, the 'copy' ability would need to be added here
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/borrow_field_non_ref_non_local_root.move:9:22
+   │
+ 2 │     struct S has drop { f: u64 }
+   │            - To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+ 9 │         (&(if (cond) *foo() else bar()).f : &u64);
+   │                      ^^^^^^ Invalid dereference. Dereference requires the 'copy' ability
+   ·
+12 │     fun foo(): &S {
+   │                 - The type '0x8675309::M::S' does not have the ability 'copy'
 

--- a/language/move-lang/tests/move_check/typing/borrow_local_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/borrow_local_invalid.exp
@@ -1,44 +1,35 @@
-error: 
+error[E04004]: expected a single non-reference type
+  ┌─ tests/move_check/typing/borrow_local_invalid.move:3:9
+  │
+2 │     fun t0(r: &u64, r_mut: &mut u64) {
+  │               ---- Expected a single non-reference type, but found: '&u64'
+3 │         &r;
+  │         ^^ Invalid borrow
 
-   ┌── tests/move_check/typing/borrow_local_invalid.move:3:9 ───
-   │
- 3 │         &r;
-   │         ^^ Invalid borrow
-   ·
- 2 │     fun t0(r: &u64, r_mut: &mut u64) {
-   │               ---- Expected a single non-reference type, but found: '&u64'
-   │
+error[E04004]: expected a single non-reference type
+  ┌─ tests/move_check/typing/borrow_local_invalid.move:4:9
+  │
+2 │     fun t0(r: &u64, r_mut: &mut u64) {
+  │                            -------- Expected a single non-reference type, but found: '&mut u64'
+3 │         &r;
+4 │         &r_mut;
+  │         ^^^^^^ Invalid borrow
 
-error: 
+error[E04004]: expected a single non-reference type
+  ┌─ tests/move_check/typing/borrow_local_invalid.move:5:9
+  │
+2 │     fun t0(r: &u64, r_mut: &mut u64) {
+  │               ---- Expected a single non-reference type, but found: '&u64'
+  ·
+5 │         &mut r;
+  │         ^^^^^^ Invalid borrow
 
-   ┌── tests/move_check/typing/borrow_local_invalid.move:4:9 ───
-   │
- 4 │         &r_mut;
-   │         ^^^^^^ Invalid borrow
-   ·
- 2 │     fun t0(r: &u64, r_mut: &mut u64) {
-   │                            -------- Expected a single non-reference type, but found: '&mut u64'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/borrow_local_invalid.move:5:9 ───
-   │
- 5 │         &mut r;
-   │         ^^^^^^ Invalid borrow
-   ·
- 2 │     fun t0(r: &u64, r_mut: &mut u64) {
-   │               ---- Expected a single non-reference type, but found: '&u64'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/borrow_local_invalid.move:6:9 ───
-   │
- 6 │         &mut r_mut;
-   │         ^^^^^^^^^^ Invalid borrow
-   ·
- 2 │     fun t0(r: &u64, r_mut: &mut u64) {
-   │                            -------- Expected a single non-reference type, but found: '&mut u64'
-   │
+error[E04004]: expected a single non-reference type
+  ┌─ tests/move_check/typing/borrow_local_invalid.move:6:9
+  │
+2 │     fun t0(r: &u64, r_mut: &mut u64) {
+  │                            -------- Expected a single non-reference type, but found: '&mut u64'
+  ·
+6 │         &mut r_mut;
+  │         ^^^^^^^^^^ Invalid borrow
 

--- a/language/move-lang/tests/move_check/typing/borrow_local_temp_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/borrow_local_temp_invalid.exp
@@ -1,77 +1,63 @@
-error: 
+error[E04004]: expected a single non-reference type
+  ┌─ tests/move_check/typing/borrow_local_temp_invalid.move:3:9
+  │
+3 │         &();
+  │         ^^^
+  │         ││
+  │         │Expected a single non-reference type, but found: '()'
+  │         Invalid borrow
 
-   ┌── tests/move_check/typing/borrow_local_temp_invalid.move:3:9 ───
+error[E04004]: expected a single non-reference type
+  ┌─ tests/move_check/typing/borrow_local_temp_invalid.move:4:9
+  │
+4 │         &(0, 1);
+  │         ^^^^^^^
+  │         ││
+  │         │Expected a single non-reference type, but found: '(u64, u64)'
+  │         Invalid borrow
+
+error[E04004]: expected a single non-reference type
+  ┌─ tests/move_check/typing/borrow_local_temp_invalid.move:5:9
+  │
+5 │         &(0, 1, true, @0x0);
+  │         ^^^^^^^^^^^^^^^^^^^
+  │         ││
+  │         │Expected a single non-reference type, but found: '(u64, u64, bool, address)'
+  │         Invalid borrow
+
+error[E04004]: expected a single non-reference type
+  ┌─ tests/move_check/typing/borrow_local_temp_invalid.move:9:9
+  │
+9 │         &(&0);
+  │         ^^^^^
+  │         ││
+  │         │Expected a single non-reference type, but found: '&u64'
+  │         Invalid borrow
+
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/borrow_local_temp_invalid.move:10:9
    │
- 3 │         &();
-   │         ^^^ Invalid borrow
-   ·
- 3 │         &();
-   │          -- Expected a single non-reference type, but found: '()'
+10 │         &(&mut 1);
+   │         ^^^^^^^^^
+   │         ││
+   │         │Expected a single non-reference type, but found: '&mut u64'
+   │         Invalid borrow
+
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/borrow_local_temp_invalid.move:11:9
    │
+11 │         &mut &2;
+   │         ^^^^^^^
+   │         │    │
+   │         │    Expected a single non-reference type, but found: '&u64'
+   │         Invalid borrow
 
-error: 
-
-   ┌── tests/move_check/typing/borrow_local_temp_invalid.move:4:9 ───
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/borrow_local_temp_invalid.move:12:9
    │
- 4 │         &(0, 1);
-   │         ^^^^^^^ Invalid borrow
-   ·
- 4 │         &(0, 1);
-   │          ------ Expected a single non-reference type, but found: '(u64, u64)'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/borrow_local_temp_invalid.move:5:9 ───
-   │
- 5 │         &(0, 1, true, @0x0);
-   │         ^^^^^^^^^^^^^^^^^^^ Invalid borrow
-   ·
- 5 │         &(0, 1, true, @0x0);
-   │          ------------------ Expected a single non-reference type, but found: '(u64, u64, bool, address)'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/borrow_local_temp_invalid.move:9:9 ───
-   │
- 9 │         &(&0);
-   │         ^^^^^ Invalid borrow
-   ·
- 9 │         &(&0);
-   │          ---- Expected a single non-reference type, but found: '&u64'
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/borrow_local_temp_invalid.move:10:9 ───
-    │
- 10 │         &(&mut 1);
-    │         ^^^^^^^^^ Invalid borrow
-    ·
- 10 │         &(&mut 1);
-    │          -------- Expected a single non-reference type, but found: '&mut u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/borrow_local_temp_invalid.move:11:9 ───
-    │
- 11 │         &mut &2;
-    │         ^^^^^^^ Invalid borrow
-    ·
- 11 │         &mut &2;
-    │              -- Expected a single non-reference type, but found: '&u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/borrow_local_temp_invalid.move:12:9 ───
-    │
- 12 │         &mut &mut 3;
-    │         ^^^^^^^^^^^ Invalid borrow
-    ·
- 12 │         &mut &mut 3;
-    │              ------ Expected a single non-reference type, but found: '&mut u64'
-    │
+12 │         &mut &mut 3;
+   │         ^^^^^^^^^^^
+   │         │    │
+   │         │    Expected a single non-reference type, but found: '&mut u64'
+   │         Invalid borrow
 

--- a/language/move-lang/tests/move_check/typing/cast_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/cast_invalid.exp
@@ -1,121 +1,99 @@
-error: 
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/cast_invalid.move:6:10
+  │
+6 │         (false as u8);
+  │          ^^^^^
+  │          │
+  │          Invalid argument to 'as'
+  │          Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
-   ┌── tests/move_check/typing/cast_invalid.move:6:10 ───
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/cast_invalid.move:7:10
+  │
+7 │         (true as u128);
+  │          ^^^^
+  │          │
+  │          Invalid argument to 'as'
+  │          Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/typing/cast_invalid.move:9:10
+  │
+9 │         (() as u64);
+  │          ^^
+  │          │
+  │          Invalid argument to 'as'
+  │          Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/cast_invalid.move:10:10
    │
- 6 │         (false as u8);
-   │          ^^^^^ Invalid argument to 'as'
-   ·
- 6 │         (false as u8);
-   │          ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+10 │         ((0, 1) as u8);
+   │          ^^^^^^
+   │          │
+   │          Invalid argument to 'as'
+   │          Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/cast_invalid.move:12:15
    │
+12 │         (0 as bool);
+   │               ^^^^
+   │               │
+   │               Invalid argument to 'as'
+   │               Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
-error: 
-
-   ┌── tests/move_check/typing/cast_invalid.move:7:10 ───
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/cast_invalid.move:13:15
    │
- 7 │         (true as u128);
-   │          ^^^^ Invalid argument to 'as'
-   ·
- 7 │         (true as u128);
-   │          ---- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+13 │         (0 as address);
+   │               ^^^^^^^
+   │               │
+   │               Invalid argument to 'as'
+   │               Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/cast_invalid.move:14:21
    │
+14 │         R{} = (0 as R);
+   │                     ^
+   │                     │
+   │                     Invalid argument to 'as'
+   │                     Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
 
-error: 
-
-   ┌── tests/move_check/typing/cast_invalid.move:9:10 ───
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/cast_invalid.move:15:15
    │
- 9 │         (() as u64);
-   │          ^^ Invalid argument to 'as'
-   ·
- 9 │         (() as u64);
-   │          -- Found: '()'. But expected: 'u8', 'u64', 'u128'
+15 │         (0 as Cup<u8>);
+   │               ^^^^^^^
+   │               │
+   │               Invalid argument to 'as'
+   │               Found: '0x8675309::M::Cup<u8>'. But expected: 'u8', 'u64', 'u128'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/cast_invalid.move:16:15
    │
+16 │         (0 as ());
+   │               ^^
+   │               │
+   │               Invalid argument to 'as'
+   │               Found: '()'. But expected: 'u8', 'u64', 'u128'
 
-error: 
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/cast_invalid.move:17:15
+   │
+17 │         (0 as (u64, u8));
+   │               ^^^^^^^^^
+   │               │
+   │               Invalid argument to 'as'
+   │               Found: '(u64, u8)'. But expected: 'u8', 'u64', 'u128'
 
-    ┌── tests/move_check/typing/cast_invalid.move:10:10 ───
-    │
- 10 │         ((0, 1) as u8);
-    │          ^^^^^^ Invalid argument to 'as'
-    ·
- 10 │         ((0, 1) as u8);
-    │          ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/cast_invalid.move:12:15 ───
-    │
- 12 │         (0 as bool);
-    │               ^^^^ Invalid argument to 'as'
-    ·
- 12 │         (0 as bool);
-    │               ---- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/cast_invalid.move:13:15 ───
-    │
- 13 │         (0 as address);
-    │               ^^^^^^^ Invalid argument to 'as'
-    ·
- 13 │         (0 as address);
-    │               ------- Found: 'address'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/cast_invalid.move:14:21 ───
-    │
- 14 │         R{} = (0 as R);
-    │                     ^ Invalid argument to 'as'
-    ·
- 14 │         R{} = (0 as R);
-    │                     - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/cast_invalid.move:15:15 ───
-    │
- 15 │         (0 as Cup<u8>);
-    │               ^^^^^^^ Invalid argument to 'as'
-    ·
- 15 │         (0 as Cup<u8>);
-    │               ------- Found: '0x8675309::M::Cup<u8>'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/cast_invalid.move:16:15 ───
-    │
- 16 │         (0 as ());
-    │               ^^ Invalid argument to 'as'
-    ·
- 16 │         (0 as ());
-    │               -- Found: '()'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/cast_invalid.move:17:15 ───
-    │
- 17 │         (0 as (u64, u8));
-    │               ^^^^^^^^^ Invalid argument to 'as'
-    ·
- 17 │         (0 as (u64, u8));
-    │               --------- Found: '(u64, u8)'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/cast_invalid.move:19:3 ───
-    │
- 19 │     (x"1234" as u64);
-    │      ^^^^^^^ Invalid argument to 'as'
-    ·
- 19 │     (x"1234" as u64);
-    │      ------- Found: 'vector<u8>'. But expected: 'u8', 'u64', 'u128'
-    │
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/typing/cast_invalid.move:19:3
+   │
+19 │     (x"1234" as u64);
+   │      ^^^^^^^
+   │      │
+   │      Invalid argument to 'as'
+   │      Found: 'vector<u8>'. But expected: 'u8', 'u64', 'u128'
 

--- a/language/move-lang/tests/move_check/typing/conditional_copy_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/conditional_copy_invalid.exp
@@ -1,140 +1,110 @@
-error: 
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_copy_invalid.move:15:16
+   │
+14 │         let x = Box<R> {};
+   │                 ---------
+   │                 │   │
+   │                 │   The type '0x42::M::Box<0x42::M::R>' can have the ability 'copy' but the type argument '0x42::M::R' does not have the required ability 'copy'
+   │                 The type '0x42::M::Box<0x42::M::R>' does not have the ability 'copy'
+15 │         ignore(copy x);
+   │                ^^^^^^ Invalid 'copy' of owned value without the 'copy' ability
 
-    ┌── tests/move_check/typing/conditional_copy_invalid.move:15:16 ───
-    │
- 15 │         ignore(copy x);
-    │                ^^^^^^ Invalid 'copy' of owned value without the 'copy' ability
-    ·
- 14 │         let x = Box<R> {};
-    │                 --------- The type '0x42::M::Box<0x42::M::R>' does not have the ability 'copy'
-    ·
- 14 │         let x = Box<R> {};
-    │                     - The type '0x42::M::Box<0x42::M::R>' can have the ability 'copy' but the type argument '0x42::M::R' does not have the required ability 'copy'
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_copy_invalid.move:17:16
+   │
+16 │         let x = Box<Box<R>> {};
+   │                 --------------
+   │                 │   │
+   │                 │   The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' can have the ability 'copy' but the type argument '0x42::M::Box<0x42::M::R>' does not have the required ability 'copy'
+   │                 The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' does not have the ability 'copy'
+17 │         ignore(copy x);
+   │                ^^^^^^ Invalid 'copy' of owned value without the 'copy' ability
 
-error: 
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_copy_invalid.move:19:16
+   │
+18 │         let x = Box<T> {};
+   │                 ---------
+   │                 │   │
+   │                 │   The type '0x42::M::Box<T>' can have the ability 'copy' but the type argument 'T' does not have the required ability 'copy'
+   │                 The type '0x42::M::Box<T>' does not have the ability 'copy'
+19 │         ignore(copy x);
+   │                ^^^^^^ Invalid 'copy' of owned value without the 'copy' ability
 
-    ┌── tests/move_check/typing/conditional_copy_invalid.move:17:16 ───
-    │
- 17 │         ignore(copy x);
-    │                ^^^^^^ Invalid 'copy' of owned value without the 'copy' ability
-    ·
- 16 │         let x = Box<Box<R>> {};
-    │                 -------------- The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' does not have the ability 'copy'
-    ·
- 16 │         let x = Box<Box<R>> {};
-    │                     ------ The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' can have the ability 'copy' but the type argument '0x42::M::Box<0x42::M::R>' does not have the required ability 'copy'
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_copy_invalid.move:21:16
+   │
+20 │         let x = Box<Box<T>> {};
+   │                 --------------
+   │                 │   │
+   │                 │   The type '0x42::M::Box<0x42::M::Box<T>>' can have the ability 'copy' but the type argument '0x42::M::Box<T>' does not have the required ability 'copy'
+   │                 The type '0x42::M::Box<0x42::M::Box<T>>' does not have the ability 'copy'
+21 │         ignore(copy x);
+   │                ^^^^^^ Invalid 'copy' of owned value without the 'copy' ability
 
-error: 
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_copy_invalid.move:23:16
+   │
+22 │         let x = Pair<S, R> {};
+   │                 -------------
+   │                 │       │
+   │                 │       The type '0x42::M::Pair<0x42::M::S, 0x42::M::R>' can have the ability 'copy' but the type argument '0x42::M::R' does not have the required ability 'copy'
+   │                 The type '0x42::M::Pair<0x42::M::S, 0x42::M::R>' does not have the ability 'copy'
+23 │         ignore(copy x);
+   │                ^^^^^^ Invalid 'copy' of owned value without the 'copy' ability
 
-    ┌── tests/move_check/typing/conditional_copy_invalid.move:19:16 ───
-    │
- 19 │         ignore(copy x);
-    │                ^^^^^^ Invalid 'copy' of owned value without the 'copy' ability
-    ·
- 18 │         let x = Box<T> {};
-    │                 --------- The type '0x42::M::Box<T>' does not have the ability 'copy'
-    ·
- 18 │         let x = Box<T> {};
-    │                     - The type '0x42::M::Box<T>' can have the ability 'copy' but the type argument 'T' does not have the required ability 'copy'
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_copy_invalid.move:27:16
+   │
+26 │         let x = &Box<R> {};
+   │                  ---------
+   │                  │   │
+   │                  │   The type '0x42::M::Box<0x42::M::R>' can have the ability 'copy' but the type argument '0x42::M::R' does not have the required ability 'copy'
+   │                  The type '0x42::M::Box<0x42::M::R>' does not have the ability 'copy'
+27 │         ignore(*x);
+   │                ^^ Invalid dereference. Dereference requires the 'copy' ability
 
-error: 
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_copy_invalid.move:29:16
+   │
+28 │         let x = &Box<Box<R>> {};
+   │                  --------------
+   │                  │   │
+   │                  │   The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' can have the ability 'copy' but the type argument '0x42::M::Box<0x42::M::R>' does not have the required ability 'copy'
+   │                  The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' does not have the ability 'copy'
+29 │         ignore(*x);
+   │                ^^ Invalid dereference. Dereference requires the 'copy' ability
 
-    ┌── tests/move_check/typing/conditional_copy_invalid.move:21:16 ───
-    │
- 21 │         ignore(copy x);
-    │                ^^^^^^ Invalid 'copy' of owned value without the 'copy' ability
-    ·
- 20 │         let x = Box<Box<T>> {};
-    │                 -------------- The type '0x42::M::Box<0x42::M::Box<T>>' does not have the ability 'copy'
-    ·
- 20 │         let x = Box<Box<T>> {};
-    │                     ------ The type '0x42::M::Box<0x42::M::Box<T>>' can have the ability 'copy' but the type argument '0x42::M::Box<T>' does not have the required ability 'copy'
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_copy_invalid.move:31:16
+   │
+30 │         let x = &Box<T> {};
+   │                  ---------
+   │                  │   │
+   │                  │   The type '0x42::M::Box<T>' can have the ability 'copy' but the type argument 'T' does not have the required ability 'copy'
+   │                  The type '0x42::M::Box<T>' does not have the ability 'copy'
+31 │         ignore(*x);
+   │                ^^ Invalid dereference. Dereference requires the 'copy' ability
 
-error: 
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_copy_invalid.move:33:16
+   │
+32 │         let x = &Box<Box<T>> {};
+   │                  --------------
+   │                  │   │
+   │                  │   The type '0x42::M::Box<0x42::M::Box<T>>' can have the ability 'copy' but the type argument '0x42::M::Box<T>' does not have the required ability 'copy'
+   │                  The type '0x42::M::Box<0x42::M::Box<T>>' does not have the ability 'copy'
+33 │         ignore(*x);
+   │                ^^ Invalid dereference. Dereference requires the 'copy' ability
 
-    ┌── tests/move_check/typing/conditional_copy_invalid.move:23:16 ───
-    │
- 23 │         ignore(copy x);
-    │                ^^^^^^ Invalid 'copy' of owned value without the 'copy' ability
-    ·
- 22 │         let x = Pair<S, R> {};
-    │                 ------------- The type '0x42::M::Pair<0x42::M::S, 0x42::M::R>' does not have the ability 'copy'
-    ·
- 22 │         let x = Pair<S, R> {};
-    │                         - The type '0x42::M::Pair<0x42::M::S, 0x42::M::R>' can have the ability 'copy' but the type argument '0x42::M::R' does not have the required ability 'copy'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/conditional_copy_invalid.move:27:16 ───
-    │
- 27 │         ignore(*x);
-    │                ^^ Invalid dereference. Dereference requires the 'copy' ability
-    ·
- 26 │         let x = &Box<R> {};
-    │                  --------- The type '0x42::M::Box<0x42::M::R>' does not have the ability 'copy'
-    ·
- 26 │         let x = &Box<R> {};
-    │                      - The type '0x42::M::Box<0x42::M::R>' can have the ability 'copy' but the type argument '0x42::M::R' does not have the required ability 'copy'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/conditional_copy_invalid.move:29:16 ───
-    │
- 29 │         ignore(*x);
-    │                ^^ Invalid dereference. Dereference requires the 'copy' ability
-    ·
- 28 │         let x = &Box<Box<R>> {};
-    │                  -------------- The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' does not have the ability 'copy'
-    ·
- 28 │         let x = &Box<Box<R>> {};
-    │                      ------ The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' can have the ability 'copy' but the type argument '0x42::M::Box<0x42::M::R>' does not have the required ability 'copy'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/conditional_copy_invalid.move:31:16 ───
-    │
- 31 │         ignore(*x);
-    │                ^^ Invalid dereference. Dereference requires the 'copy' ability
-    ·
- 30 │         let x = &Box<T> {};
-    │                  --------- The type '0x42::M::Box<T>' does not have the ability 'copy'
-    ·
- 30 │         let x = &Box<T> {};
-    │                      - The type '0x42::M::Box<T>' can have the ability 'copy' but the type argument 'T' does not have the required ability 'copy'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/conditional_copy_invalid.move:33:16 ───
-    │
- 33 │         ignore(*x);
-    │                ^^ Invalid dereference. Dereference requires the 'copy' ability
-    ·
- 32 │         let x = &Box<Box<T>> {};
-    │                  -------------- The type '0x42::M::Box<0x42::M::Box<T>>' does not have the ability 'copy'
-    ·
- 32 │         let x = &Box<Box<T>> {};
-    │                      ------ The type '0x42::M::Box<0x42::M::Box<T>>' can have the ability 'copy' but the type argument '0x42::M::Box<T>' does not have the required ability 'copy'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/conditional_copy_invalid.move:35:16 ───
-    │
- 35 │         ignore(*x);
-    │                ^^ Invalid dereference. Dereference requires the 'copy' ability
-    ·
- 34 │         let x = &Pair<R, S> {};
-    │                  ------------- The type '0x42::M::Pair<0x42::M::R, 0x42::M::S>' does not have the ability 'copy'
-    ·
- 34 │         let x = &Pair<R, S> {};
-    │                       - The type '0x42::M::Pair<0x42::M::R, 0x42::M::S>' can have the ability 'copy' but the type argument '0x42::M::R' does not have the required ability 'copy'
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_copy_invalid.move:35:16
+   │
+34 │         let x = &Pair<R, S> {};
+   │                  -------------
+   │                  │    │
+   │                  │    The type '0x42::M::Pair<0x42::M::R, 0x42::M::S>' can have the ability 'copy' but the type argument '0x42::M::R' does not have the required ability 'copy'
+   │                  The type '0x42::M::Pair<0x42::M::R, 0x42::M::S>' does not have the ability 'copy'
+35 │         ignore(*x);
+   │                ^^ Invalid dereference. Dereference requires the 'copy' ability
 

--- a/language/move-lang/tests/move_check/typing/conditional_drop_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/conditional_drop_invalid.exp
@@ -1,154 +1,110 @@
-error: 
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_drop_invalid.move:10:9
+   │
+10 │         Box<R> {};
+   │         ^^^^^^^^^
+   │         │   │
+   │         │   The type '0x42::M::Box<0x42::M::R>' can have the ability 'drop' but the type argument '0x42::M::R' does not have the required ability 'drop'
+   │         Cannot ignore values without the 'drop' ability. The value must be used
+   │         The type '0x42::M::Box<0x42::M::R>' does not have the ability 'drop'
 
-    ┌── tests/move_check/typing/conditional_drop_invalid.move:10:9 ───
-    │
- 10 │         Box<R> {};
-    │         ^^^^^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
-    ·
- 10 │         Box<R> {};
-    │         --------- The type '0x42::M::Box<0x42::M::R>' does not have the ability 'drop'
-    ·
- 10 │         Box<R> {};
-    │             - The type '0x42::M::Box<0x42::M::R>' can have the ability 'drop' but the type argument '0x42::M::R' does not have the required ability 'drop'
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_drop_invalid.move:11:9
+   │
+11 │         Box<Box<R>> {};
+   │         ^^^^^^^^^^^^^^
+   │         │   │
+   │         │   The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' can have the ability 'drop' but the type argument '0x42::M::Box<0x42::M::R>' does not have the required ability 'drop'
+   │         Cannot ignore values without the 'drop' ability. The value must be used
+   │         The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' does not have the ability 'drop'
 
-error: 
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_drop_invalid.move:12:9
+   │
+12 │         Box<T> {};
+   │         ^^^^^^^^^
+   │         │   │
+   │         │   The type '0x42::M::Box<T>' can have the ability 'drop' but the type argument 'T' does not have the required ability 'drop'
+   │         Cannot ignore values without the 'drop' ability. The value must be used
+   │         The type '0x42::M::Box<T>' does not have the ability 'drop'
 
-    ┌── tests/move_check/typing/conditional_drop_invalid.move:11:9 ───
-    │
- 11 │         Box<Box<R>> {};
-    │         ^^^^^^^^^^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
-    ·
- 11 │         Box<Box<R>> {};
-    │         -------------- The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' does not have the ability 'drop'
-    ·
- 11 │         Box<Box<R>> {};
-    │             ------ The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' can have the ability 'drop' but the type argument '0x42::M::Box<0x42::M::R>' does not have the required ability 'drop'
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_drop_invalid.move:13:9
+   │
+13 │         Box<Box<T>> {};
+   │         ^^^^^^^^^^^^^^
+   │         │   │
+   │         │   The type '0x42::M::Box<0x42::M::Box<T>>' can have the ability 'drop' but the type argument '0x42::M::Box<T>' does not have the required ability 'drop'
+   │         Cannot ignore values without the 'drop' ability. The value must be used
+   │         The type '0x42::M::Box<0x42::M::Box<T>>' does not have the ability 'drop'
 
-error: 
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_drop_invalid.move:14:9
+   │
+14 │         Pair<S, R> {};
+   │         ^^^^^^^^^^^^^
+   │         │       │
+   │         │       The type '0x42::M::Pair<0x42::M::S, 0x42::M::R>' can have the ability 'drop' but the type argument '0x42::M::R' does not have the required ability 'drop'
+   │         Cannot ignore values without the 'drop' ability. The value must be used
+   │         The type '0x42::M::Pair<0x42::M::S, 0x42::M::R>' does not have the ability 'drop'
 
-    ┌── tests/move_check/typing/conditional_drop_invalid.move:12:9 ───
-    │
- 12 │         Box<T> {};
-    │         ^^^^^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
-    ·
- 12 │         Box<T> {};
-    │         --------- The type '0x42::M::Box<T>' does not have the ability 'drop'
-    ·
- 12 │         Box<T> {};
-    │             - The type '0x42::M::Box<T>' can have the ability 'drop' but the type argument 'T' does not have the required ability 'drop'
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_drop_invalid.move:15:9
+   │
+15 │         (Pair<S, R> {}, 0, @0x1);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^
+   │         ││
+   │         │The type '(0x42::M::Pair<0x42::M::S, 0x42::M::R>, u64, address)' can have the ability 'drop' but the type argument '0x42::M::Pair<0x42::M::S, 0x42::M::R>' does not have the required ability 'drop'
+   │         Cannot ignore values without the 'drop' ability. The value must be used
+   │         The type '(0x42::M::Pair<0x42::M::S, 0x42::M::R>, u64, address)' does not have the ability 'drop'
 
-error: 
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_drop_invalid.move:17:9
+   │
+17 │         Box<R> {} == Box<R> {};
+   │         ^^^^^^^^^^^^^^^^^^^^^^
+   │         │            │   │
+   │         │            │   The type '0x42::M::Box<0x42::M::R>' can have the ability 'drop' but the type argument '0x42::M::R' does not have the required ability 'drop'
+   │         │            The type '0x42::M::Box<0x42::M::R>' does not have the ability 'drop'
+   │         '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
 
-    ┌── tests/move_check/typing/conditional_drop_invalid.move:13:9 ───
-    │
- 13 │         Box<Box<T>> {};
-    │         ^^^^^^^^^^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
-    ·
- 13 │         Box<Box<T>> {};
-    │         -------------- The type '0x42::M::Box<0x42::M::Box<T>>' does not have the ability 'drop'
-    ·
- 13 │         Box<Box<T>> {};
-    │             ------ The type '0x42::M::Box<0x42::M::Box<T>>' can have the ability 'drop' but the type argument '0x42::M::Box<T>' does not have the required ability 'drop'
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_drop_invalid.move:18:9
+   │
+18 │         Box<Box<R>> {} == Box<Box<R>> {};
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │                 │   │
+   │         │                 │   The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' can have the ability 'drop' but the type argument '0x42::M::Box<0x42::M::R>' does not have the required ability 'drop'
+   │         │                 The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' does not have the ability 'drop'
+   │         '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
 
-error: 
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_drop_invalid.move:19:9
+   │
+19 │         Box<T> {} == Box<T> {};
+   │         ^^^^^^^^^^^^^^^^^^^^^^
+   │         │            │   │
+   │         │            │   The type '0x42::M::Box<T>' can have the ability 'drop' but the type argument 'T' does not have the required ability 'drop'
+   │         │            The type '0x42::M::Box<T>' does not have the ability 'drop'
+   │         '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
 
-    ┌── tests/move_check/typing/conditional_drop_invalid.move:14:9 ───
-    │
- 14 │         Pair<S, R> {};
-    │         ^^^^^^^^^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
-    ·
- 14 │         Pair<S, R> {};
-    │         ------------- The type '0x42::M::Pair<0x42::M::S, 0x42::M::R>' does not have the ability 'drop'
-    ·
- 14 │         Pair<S, R> {};
-    │                 - The type '0x42::M::Pair<0x42::M::S, 0x42::M::R>' can have the ability 'drop' but the type argument '0x42::M::R' does not have the required ability 'drop'
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_drop_invalid.move:20:9
+   │
+20 │         Box<Box<T>> {} == Box<Box<T>> {};
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │                 │   │
+   │         │                 │   The type '0x42::M::Box<0x42::M::Box<T>>' can have the ability 'drop' but the type argument '0x42::M::Box<T>' does not have the required ability 'drop'
+   │         │                 The type '0x42::M::Box<0x42::M::Box<T>>' does not have the ability 'drop'
+   │         '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
 
-error: 
-
-    ┌── tests/move_check/typing/conditional_drop_invalid.move:15:9 ───
-    │
- 15 │         (Pair<S, R> {}, 0, @0x1);
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
-    ·
- 15 │         (Pair<S, R> {}, 0, @0x1);
-    │         ------------------------ The type '(0x42::M::Pair<0x42::M::S, 0x42::M::R>, u64, address)' does not have the ability 'drop'
-    ·
- 15 │         (Pair<S, R> {}, 0, @0x1);
-    │          ------------- The type '(0x42::M::Pair<0x42::M::S, 0x42::M::R>, u64, address)' can have the ability 'drop' but the type argument '0x42::M::Pair<0x42::M::S, 0x42::M::R>' does not have the required ability 'drop'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/conditional_drop_invalid.move:17:9 ───
-    │
- 17 │         Box<R> {} == Box<R> {};
-    │         ^^^^^^^^^^^^^^^^^^^^^^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
-    ·
- 17 │         Box<R> {} == Box<R> {};
-    │                      --------- The type '0x42::M::Box<0x42::M::R>' does not have the ability 'drop'
-    ·
- 17 │         Box<R> {} == Box<R> {};
-    │                          - The type '0x42::M::Box<0x42::M::R>' can have the ability 'drop' but the type argument '0x42::M::R' does not have the required ability 'drop'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/conditional_drop_invalid.move:18:9 ───
-    │
- 18 │         Box<Box<R>> {} == Box<Box<R>> {};
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
-    ·
- 18 │         Box<Box<R>> {} == Box<Box<R>> {};
-    │                           -------------- The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' does not have the ability 'drop'
-    ·
- 18 │         Box<Box<R>> {} == Box<Box<R>> {};
-    │                               ------ The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' can have the ability 'drop' but the type argument '0x42::M::Box<0x42::M::R>' does not have the required ability 'drop'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/conditional_drop_invalid.move:19:9 ───
-    │
- 19 │         Box<T> {} == Box<T> {};
-    │         ^^^^^^^^^^^^^^^^^^^^^^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
-    ·
- 19 │         Box<T> {} == Box<T> {};
-    │                      --------- The type '0x42::M::Box<T>' does not have the ability 'drop'
-    ·
- 19 │         Box<T> {} == Box<T> {};
-    │                          - The type '0x42::M::Box<T>' can have the ability 'drop' but the type argument 'T' does not have the required ability 'drop'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/conditional_drop_invalid.move:20:9 ───
-    │
- 20 │         Box<Box<T>> {} == Box<Box<T>> {};
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
-    ·
- 20 │         Box<Box<T>> {} == Box<Box<T>> {};
-    │                           -------------- The type '0x42::M::Box<0x42::M::Box<T>>' does not have the ability 'drop'
-    ·
- 20 │         Box<Box<T>> {} == Box<Box<T>> {};
-    │                               ------ The type '0x42::M::Box<0x42::M::Box<T>>' can have the ability 'drop' but the type argument '0x42::M::Box<T>' does not have the required ability 'drop'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/conditional_drop_invalid.move:21:9 ───
-    │
- 21 │         Pair<R, S> {} == Pair<R, S> {};
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
-    ·
- 21 │         Pair<R, S> {} == Pair<R, S> {};
-    │                          ------------- The type '0x42::M::Pair<0x42::M::R, 0x42::M::S>' does not have the ability 'drop'
-    ·
- 21 │         Pair<R, S> {} == Pair<R, S> {};
-    │                               - The type '0x42::M::Pair<0x42::M::R, 0x42::M::S>' can have the ability 'drop' but the type argument '0x42::M::R' does not have the required ability 'drop'
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_drop_invalid.move:21:9
+   │
+21 │         Pair<R, S> {} == Pair<R, S> {};
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │                │    │
+   │         │                │    The type '0x42::M::Pair<0x42::M::R, 0x42::M::S>' can have the ability 'drop' but the type argument '0x42::M::R' does not have the required ability 'drop'
+   │         │                The type '0x42::M::Pair<0x42::M::R, 0x42::M::S>' does not have the ability 'drop'
+   │         '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
 

--- a/language/move-lang/tests/move_check/typing/conditional_global_operations.exp
+++ b/language/move-lang/tests/move_check/typing/conditional_global_operations.exp
@@ -1,98 +1,70 @@
-error: 
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_global_operations.move:15:9
+   │
+15 │         move_to(s, Box<R> {});
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │         │          │   │
+   │         │          │   The type '0x42::M::Box<0x42::M::R>' can have the ability 'key' but the type argument '0x42::M::R' does not have the required ability 'store'
+   │         │          The type '0x42::M::Box<0x42::M::R>' does not have the ability 'key'
+   │         Invalid call of 'move_to'
 
-    ┌── tests/move_check/typing/conditional_global_operations.move:15:9 ───
-    │
- 15 │         move_to(s, Box<R> {});
-    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_to'
-    ·
- 15 │         move_to(s, Box<R> {});
-    │                    --------- The type '0x42::M::Box<0x42::M::R>' does not have the ability 'key'
-    ·
- 15 │         move_to(s, Box<R> {});
-    │                        - The type '0x42::M::Box<0x42::M::R>' can have the ability 'key' but the type argument '0x42::M::R' does not have the required ability 'store'
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_global_operations.move:16:9
+   │
+16 │         borrow_global<Box<T>>(a1);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │             │   │
+   │         │             │   The type '0x42::M::Box<T>' can have the ability 'key' but the type argument 'T' does not have the required ability 'store'
+   │         │             The type '0x42::M::Box<T>' does not have the ability 'key'
+   │         Invalid call of 'borrow_global'
 
-error: 
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_global_operations.move:17:9
+   │
+17 │         borrow_global_mut<Box<Box<T>>>(a1);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │                 │   │
+   │         │                 │   The type '0x42::M::Box<0x42::M::Box<T>>' can have the ability 'key' but the type argument '0x42::M::Box<T>' does not have the required ability 'store'
+   │         │                 The type '0x42::M::Box<0x42::M::Box<T>>' does not have the ability 'key'
+   │         Invalid call of 'borrow_global_mut'
 
-    ┌── tests/move_check/typing/conditional_global_operations.move:16:9 ───
-    │
- 16 │         borrow_global<Box<T>>(a1);
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'borrow_global'
-    ·
- 16 │         borrow_global<Box<T>>(a1);
-    │                       ------ The type '0x42::M::Box<T>' does not have the ability 'key'
-    ·
- 16 │         borrow_global<Box<T>>(a1);
-    │                           - The type '0x42::M::Box<T>' can have the ability 'key' but the type argument 'T' does not have the required ability 'store'
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_global_operations.move:18:19
+   │
+18 │         Pair {} = move_from<Pair<S, R>>(a1);
+   │                   ^^^^^^^^^^^^^^^^^^^^^^^^^
+   │                   │         │       │
+   │                   │         │       The type '0x42::M::Pair<0x42::M::S, 0x42::M::R>' can have the ability 'key' but the type argument '0x42::M::R' does not have the required ability 'store'
+   │                   │         The type '0x42::M::Pair<0x42::M::S, 0x42::M::R>' does not have the ability 'key'
+   │                   Invalid call of 'move_from'
 
-error: 
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_global_operations.move:19:9
+   │
+19 │         exists<Pair<Box<T>, S>>(a1);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │      │    │
+   │         │      │    The type '0x42::M::Pair<0x42::M::Box<T>, 0x42::M::S>' can have the ability 'key' but the type argument '0x42::M::Box<T>' does not have the required ability 'store'
+   │         │      The type '0x42::M::Pair<0x42::M::Box<T>, 0x42::M::S>' does not have the ability 'key'
+   │         Invalid call of 'exists'
 
-    ┌── tests/move_check/typing/conditional_global_operations.move:17:9 ───
-    │
- 17 │         borrow_global_mut<Box<Box<T>>>(a1);
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'borrow_global_mut'
-    ·
- 17 │         borrow_global_mut<Box<Box<T>>>(a1);
-    │                           ----------- The type '0x42::M::Box<0x42::M::Box<T>>' does not have the ability 'key'
-    ·
- 17 │         borrow_global_mut<Box<Box<T>>>(a1);
-    │                               ------ The type '0x42::M::Box<0x42::M::Box<T>>' can have the ability 'key' but the type argument '0x42::M::Box<T>' does not have the required ability 'store'
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_global_operations.move:21:9
+   │
+21 │         borrow_global<Box<K>>(a1);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │             │   │
+   │         │             │   The type '0x42::M::Box<0x42::M::K>' can have the ability 'key' but the type argument '0x42::M::K' does not have the required ability 'store'
+   │         │             The type '0x42::M::Box<0x42::M::K>' does not have the ability 'key'
+   │         Invalid call of 'borrow_global'
 
-error: 
-
-    ┌── tests/move_check/typing/conditional_global_operations.move:18:19 ───
-    │
- 18 │         Pair {} = move_from<Pair<S, R>>(a1);
-    │                   ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_from'
-    ·
- 18 │         Pair {} = move_from<Pair<S, R>>(a1);
-    │                             ---------- The type '0x42::M::Pair<0x42::M::S, 0x42::M::R>' does not have the ability 'key'
-    ·
- 18 │         Pair {} = move_from<Pair<S, R>>(a1);
-    │                                     - The type '0x42::M::Pair<0x42::M::S, 0x42::M::R>' can have the ability 'key' but the type argument '0x42::M::R' does not have the required ability 'store'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/conditional_global_operations.move:19:9 ───
-    │
- 19 │         exists<Pair<Box<T>, S>>(a1);
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'exists'
-    ·
- 19 │         exists<Pair<Box<T>, S>>(a1);
-    │                --------------- The type '0x42::M::Pair<0x42::M::Box<T>, 0x42::M::S>' does not have the ability 'key'
-    ·
- 19 │         exists<Pair<Box<T>, S>>(a1);
-    │                     ------ The type '0x42::M::Pair<0x42::M::Box<T>, 0x42::M::S>' can have the ability 'key' but the type argument '0x42::M::Box<T>' does not have the required ability 'store'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/conditional_global_operations.move:21:9 ───
-    │
- 21 │         borrow_global<Box<K>>(a1);
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'borrow_global'
-    ·
- 21 │         borrow_global<Box<K>>(a1);
-    │                       ------ The type '0x42::M::Box<0x42::M::K>' does not have the ability 'key'
-    ·
- 21 │         borrow_global<Box<K>>(a1);
-    │                           - The type '0x42::M::Box<0x42::M::K>' can have the ability 'key' but the type argument '0x42::M::K' does not have the required ability 'store'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/conditional_global_operations.move:22:9 ───
-    │
- 22 │         borrow_global_mut<Pair<S, K>>(a1);
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'borrow_global_mut'
-    ·
- 22 │         borrow_global_mut<Pair<S, K>>(a1);
-    │                           ---------- The type '0x42::M::Pair<0x42::M::S, 0x42::M::K>' does not have the ability 'key'
-    ·
- 22 │         borrow_global_mut<Pair<S, K>>(a1);
-    │                                   - The type '0x42::M::Pair<0x42::M::S, 0x42::M::K>' can have the ability 'key' but the type argument '0x42::M::K' does not have the required ability 'store'
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_global_operations.move:22:9
+   │
+22 │         borrow_global_mut<Pair<S, K>>(a1);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │                 │       │
+   │         │                 │       The type '0x42::M::Pair<0x42::M::S, 0x42::M::K>' can have the ability 'key' but the type argument '0x42::M::K' does not have the required ability 'store'
+   │         │                 The type '0x42::M::Pair<0x42::M::S, 0x42::M::K>' does not have the ability 'key'
+   │         Invalid call of 'borrow_global_mut'
 

--- a/language/move-lang/tests/move_check/typing/constant_allowed_but_not_supported.exp
+++ b/language/move-lang/tests/move_check/typing/constant_allowed_but_not_supported.exp
@@ -1,24 +1,18 @@
-error: 
+error[E03009]: unbound variable
+  ┌─ tests/move_check/typing/constant_allowed_but_not_supported.move:4:9
+  │
+4 │         move x;
+  │         ^^^^^^ Invalid move. Unbound variable 'x'
 
-   ┌── tests/move_check/typing/constant_allowed_but_not_supported.move:4:9 ───
-   │
- 4 │         move x;
-   │         ^^^^^^ Invalid move. Unbound local 'x'
-   │
+error[E03009]: unbound variable
+  ┌─ tests/move_check/typing/constant_allowed_but_not_supported.move:5:9
+  │
+5 │         copy y;
+  │         ^^^^^^ Invalid copy. Unbound variable 'y'
 
-error: 
-
-   ┌── tests/move_check/typing/constant_allowed_but_not_supported.move:5:9 ───
-   │
- 5 │         copy y;
-   │         ^^^^^^ Invalid copy. Unbound local 'y'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/constant_allowed_but_not_supported.move:6:9 ───
-   │
- 6 │         z;
-   │         ^ Invalid local usage. Unbound local 'z'
-   │
+error[E03009]: unbound variable
+  ┌─ tests/move_check/typing/constant_allowed_but_not_supported.move:6:9
+  │
+6 │         z;
+  │         ^ Invalid variable usage. Unbound variable 'z'
 

--- a/language/move-lang/tests/move_check/typing/constant_internal.exp
+++ b/language/move-lang/tests/move_check/typing/constant_internal.exp
@@ -1,22 +1,18 @@
-error: 
+error[E04001]: restricted visibility
+   ┌─ tests/move_check/typing/constant_internal.move:10:9
+   │
+ 4 │     const C: u64 = 0;
+   │           - Constants are internal to their module, and cannot can be accessed outside of their module
+   ·
+10 │         X::C;
+   │         ^^^^ Invalid access of '0x2::X::C'
 
-    ┌── tests/move_check/typing/constant_internal.move:10:9 ───
-    │
- 10 │         X::C;
-    │         ^^^^ Invalid access of '0x2::X::C'
-    ·
-  4 │     const C: u64 = 0;
-    │           - Constants are internal to their module, and cannot can be accessed outside of their module
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_internal.move:11:9 ───
-    │
- 11 │         C;
-    │         ^ Invalid access of '0x2::X::C'
-    ·
-  4 │     const C: u64 = 0;
-    │           - Constants are internal to their module, and cannot can be accessed outside of their module
-    │
+error[E04001]: restricted visibility
+   ┌─ tests/move_check/typing/constant_internal.move:11:9
+   │
+ 4 │     const C: u64 = 0;
+   │           - Constants are internal to their module, and cannot can be accessed outside of their module
+   ·
+11 │         C;
+   │         ^ Invalid access of '0x2::X::C'
 

--- a/language/move-lang/tests/move_check/typing/constant_unsupported_exps.exp
+++ b/language/move-lang/tests/move_check/typing/constant_unsupported_exps.exp
@@ -1,3 +1,39 @@
+error[E04002]: requires script context
+   ┌─ tests/move_check/typing/constant_unsupported_exps.move:22:9
+   │
+22 │         f_script();
+   │         ^^^^^^^^^^ Invalid call to '0x42::M::f_script'
+   ·
+51 │     public(script) fun f_script() {}
+   │     -------------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
+
+error[E04002]: requires script context
+   ┌─ tests/move_check/typing/constant_unsupported_exps.move:26:9
+   │
+ 4 │     public(script) fun f_script() {}
+   │     -------------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
+   ·
+26 │         0x42::X::f_script();
+   │         ^^^^^^^^^^^^^^^^^^^ Invalid call to '0x42::X::f_script'
+
+error[E04001]: restricted visibility
+   ┌─ tests/move_check/typing/constant_unsupported_exps.move:27:9
+   │
+ 5 │     public(friend) fun f_friend() {}
+   │     -------------- This function can only be called from a 'friend' of module '0x42::X'
+   ·
+27 │         0x42::X::f_friend();
+   │         ^^^^^^^^^^^^^^^^^^^ Invalid call to '0x42::X::f_friend'
+
+error[E04001]: restricted visibility
+   ┌─ tests/move_check/typing/constant_unsupported_exps.move:28:9
+   │
+ 6 │     fun f_private() {}
+   │         --------- This function is internal to its module. Only 'public', 'public(script)', and 'public(friend)' functions can be called outside of their module
+   ·
+28 │         0x42::X::f_private();
+   │         ^^^^^^^^^^^^^^^^^^^^ Invalid call to '0x42::X::f_private'
+
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:15:9 ───
@@ -75,17 +111,6 @@ error:
     ┌── tests/move_check/typing/constant_unsupported_exps.move:22:9 ───
     │
  22 │         f_script();
-    │         ^^^^^^^^^^ Invalid call to '0x42::M::f_script'
-    ·
- 51 │     public(script) fun f_script() {}
-    │     -------------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:22:9 ───
-    │
- 22 │         f_script();
     │         ^^^^^^^^^^ Module calls are not supported in constants
     │
 
@@ -118,17 +143,6 @@ error:
     ┌── tests/move_check/typing/constant_unsupported_exps.move:26:9 ───
     │
  26 │         0x42::X::f_script();
-    │         ^^^^^^^^^^^^^^^^^^^ Invalid call to '0x42::X::f_script'
-    ·
-  4 │     public(script) fun f_script() {}
-    │     -------------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:26:9 ───
-    │
- 26 │         0x42::X::f_script();
     │         ^^^^^^^^^^^^^^^^^^^ Module calls are not supported in constants
     │
 
@@ -137,29 +151,7 @@ error:
     ┌── tests/move_check/typing/constant_unsupported_exps.move:27:9 ───
     │
  27 │         0x42::X::f_friend();
-    │         ^^^^^^^^^^^^^^^^^^^ Invalid call to '0x42::X::f_friend'
-    ·
-  5 │     public(friend) fun f_friend() {}
-    │     -------------- This function can only be called from a 'friend' of module '0x42::X'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:27:9 ───
-    │
- 27 │         0x42::X::f_friend();
     │         ^^^^^^^^^^^^^^^^^^^ Module calls are not supported in constants
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:28:9 ───
-    │
- 28 │         0x42::X::f_private();
-    │         ^^^^^^^^^^^^^^^^^^^^ Invalid call to '0x42::X::f_private'
-    ·
-  6 │     fun f_private() {}
-    │         --------- This function is internal to its module. Only 'public', 'public(script)', and 'public(friend)' functions can be called outside of their module
     │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_all_cases.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_all_cases.exp
@@ -1,102 +1,81 @@
-error: 
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/constraints_not_satisfied_all_cases.move:7:29
+  │
+3 │     struct CupC<T: copy> {}
+  │                    ---- 'copy' constraint declared here
+  ·
+7 │     fun no_constraint<T>(c: CupC<T>, r: CupR<T>) {}
+  │                       -     ^^^^^^^
+  │                       │     │    │
+  │                       │     │    The type 'T' does not have the ability 'copy'
+  │                       │     'copy' constraint not satisifed
+  │                       To satisfy the constraint, the 'copy' ability would need to be added here
 
-   ┌── tests/move_check/typing/constraints_not_satisfied_all_cases.move:7:29 ───
-   │
- 7 │     fun no_constraint<T>(c: CupC<T>, r: CupR<T>) {}
-   │                             ^^^^^^^ 'copy' constraint not satisifed
-   ·
- 7 │     fun no_constraint<T>(c: CupC<T>, r: CupR<T>) {}
-   │                                  - The type 'T' does not have the ability 'copy'
-   ·
- 7 │     fun no_constraint<T>(c: CupC<T>, r: CupR<T>) {}
-   │                       - To satisfy the constraint, the 'copy' ability would need to be added here
-   ·
- 3 │     struct CupC<T: copy> {}
-   │                    ---- 'copy' constraint declared here
-   │
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/constraints_not_satisfied_all_cases.move:7:41
+  │
+2 │     struct CupR<T: key> {}
+  │                    --- 'key' constraint declared here
+  ·
+7 │     fun no_constraint<T>(c: CupC<T>, r: CupR<T>) {}
+  │                       -                 ^^^^^^^
+  │                       │                 │    │
+  │                       │                 │    The type 'T' does not have the ability 'key'
+  │                       │                 'key' constraint not satisifed
+  │                       To satisfy the constraint, the 'key' ability would need to be added here
 
-error: 
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/constraints_not_satisfied_all_cases.move:9:31
+  │
+3 │     struct CupC<T: copy> {}
+  │                    ---- 'copy' constraint declared here
+  ·
+9 │     fun t_resource<T: key>(c: CupC<T>, r: CupR<T>) {}
+  │                    -          ^^^^^^^
+  │                    │          │    │
+  │                    │          │    The type 'T' does not have the ability 'copy'
+  │                    │          'copy' constraint not satisifed
+  │                    To satisfy the constraint, the 'copy' ability would need to be added here
 
-   ┌── tests/move_check/typing/constraints_not_satisfied_all_cases.move:7:41 ───
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/constraints_not_satisfied_all_cases.move:11:44
    │
- 7 │     fun no_constraint<T>(c: CupC<T>, r: CupR<T>) {}
-   │                                         ^^^^^^^ 'key' constraint not satisifed
-   ·
- 7 │     fun no_constraint<T>(c: CupC<T>, r: CupR<T>) {}
-   │                                              - The type 'T' does not have the ability 'key'
-   ·
- 7 │     fun no_constraint<T>(c: CupC<T>, r: CupR<T>) {}
-   │                       - To satisfy the constraint, the 'key' ability would need to be added here
-   ·
  2 │     struct CupR<T: key> {}
    │                    --- 'key' constraint declared here
-   │
+   ·
+11 │     fun t_copyable<T: copy>(c: CupC<T>, r: CupR<T>) {}
+   │                    -                       ^^^^^^^
+   │                    │                       │    │
+   │                    │                       │    The type 'T' does not have the ability 'key'
+   │                    │                       'key' constraint not satisifed
+   │                    To satisfy the constraint, the 'key' ability would need to be added here
 
-error: 
-
-   ┌── tests/move_check/typing/constraints_not_satisfied_all_cases.move:9:31 ───
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/constraints_not_satisfied_all_cases.move:13:14
    │
- 9 │     fun t_resource<T: key>(c: CupC<T>, r: CupR<T>) {}
-   │                               ^^^^^^^ 'copy' constraint not satisifed
-   ·
- 9 │     fun t_resource<T: key>(c: CupC<T>, r: CupR<T>) {}
-   │                                    - The type 'T' does not have the ability 'copy'
-   ·
- 9 │     fun t_resource<T: key>(c: CupC<T>, r: CupR<T>) {}
-   │                    - To satisfy the constraint, the 'copy' ability would need to be added here
-   ·
  3 │     struct CupC<T: copy> {}
    │                    ---- 'copy' constraint declared here
+ 4 │     struct R has key {}
+   │            - To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+13 │     fun r(c: CupC<R>, r: CupR<R>) {}
+   │              ^^^^^^^
+   │              │    │
+   │              │    The type '0x8675309::M::R' does not have the ability 'copy'
+   │              'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/constraints_not_satisfied_all_cases.move:15:26
    │
-
-error: 
-
-    ┌── tests/move_check/typing/constraints_not_satisfied_all_cases.move:11:44 ───
-    │
- 11 │     fun t_copyable<T: copy>(c: CupC<T>, r: CupR<T>) {}
-    │                                            ^^^^^^^ 'key' constraint not satisifed
-    ·
- 11 │     fun t_copyable<T: copy>(c: CupC<T>, r: CupR<T>) {}
-    │                                                 - The type 'T' does not have the ability 'key'
-    ·
- 11 │     fun t_copyable<T: copy>(c: CupC<T>, r: CupR<T>) {}
-    │                    - To satisfy the constraint, the 'key' ability would need to be added here
-    ·
-  2 │     struct CupR<T: key> {}
-    │                    --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constraints_not_satisfied_all_cases.move:13:14 ───
-    │
- 13 │     fun r(c: CupC<R>, r: CupR<R>) {}
-    │              ^^^^^^^ 'copy' constraint not satisifed
-    ·
- 13 │     fun r(c: CupC<R>, r: CupR<R>) {}
-    │                   - The type '0x8675309::M::R' does not have the ability 'copy'
-    ·
-  4 │     struct R has key {}
-    │            - To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
-  3 │     struct CupC<T: copy> {}
-    │                    ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constraints_not_satisfied_all_cases.move:15:26 ───
-    │
- 15 │     fun c(c: CupC<C>, r: CupR<C>) {}
-    │                          ^^^^^^^ 'key' constraint not satisifed
-    ·
- 15 │     fun c(c: CupC<C>, r: CupR<C>) {}
-    │                               - The type '0x8675309::M::C' does not have the ability 'key'
-    ·
-  5 │     struct C has copy {}
-    │            - To satisfy the constraint, the 'key' ability would need to be added here
-    ·
-  2 │     struct CupR<T: key> {}
-    │                    --- 'key' constraint declared here
-    │
+ 2 │     struct CupR<T: key> {}
+   │                    --- 'key' constraint declared here
+   ·
+ 5 │     struct C has copy {}
+   │            - To satisfy the constraint, the 'key' ability would need to be added here
+   ·
+15 │     fun c(c: CupC<C>, r: CupR<C>) {}
+   │                          ^^^^^^^
+   │                          │    │
+   │                          │    The type '0x8675309::M::C' does not have the ability 'key'
+   │                          'key' constraint not satisifed
 

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_function_parameter.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_function_parameter.exp
@@ -1,17 +1,14 @@
-error: 
-
-   ┌── tests/move_check/typing/constraints_not_satisfied_function_parameter.move:5:16 ───
-   │
- 5 │     fun foo(x: CupC<R>) {}
-   │                ^^^^^^^ 'copy' constraint not satisifed
-   ·
- 5 │     fun foo(x: CupC<R>) {}
-   │                     - The type '0x8675309::M::R' does not have the ability 'copy'
-   ·
- 3 │     struct R {}
-   │            - To satisfy the constraint, the 'copy' ability would need to be added here
-   ·
- 2 │     struct CupC<T: copy> {}
-   │                    ---- 'copy' constraint declared here
-   │
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/constraints_not_satisfied_function_parameter.move:5:16
+  │
+2 │     struct CupC<T: copy> {}
+  │                    ---- 'copy' constraint declared here
+3 │     struct R {}
+  │            - To satisfy the constraint, the 'copy' ability would need to be added here
+4 │ 
+5 │     fun foo(x: CupC<R>) {}
+  │                ^^^^^^^
+  │                │    │
+  │                │    The type '0x8675309::M::R' does not have the ability 'copy'
+  │                'copy' constraint not satisifed
 

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_function_return_type.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_function_return_type.exp
@@ -1,17 +1,14 @@
-error: 
-
-   ┌── tests/move_check/typing/constraints_not_satisfied_function_return_type.move:5:17 ───
-   │
- 5 │     fun foo():  CupC<R> {
-   │                 ^^^^^^^ 'copy' constraint not satisifed
-   ·
- 5 │     fun foo():  CupC<R> {
-   │                      - The type '0x8675309::M::R' does not have the ability 'copy'
-   ·
- 3 │     struct R {}
-   │            - To satisfy the constraint, the 'copy' ability would need to be added here
-   ·
- 2 │     struct CupC<T: copy> {}
-   │                    ---- 'copy' constraint declared here
-   │
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/constraints_not_satisfied_function_return_type.move:5:17
+  │
+2 │     struct CupC<T: copy> {}
+  │                    ---- 'copy' constraint declared here
+3 │     struct R {}
+  │            - To satisfy the constraint, the 'copy' ability would need to be added here
+4 │ 
+5 │     fun foo():  CupC<R> {
+  │                 ^^^^^^^
+  │                 │    │
+  │                 │    The type '0x8675309::M::R' does not have the ability 'copy'
+  │                 'copy' constraint not satisifed
 

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_bind_type.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_bind_type.exp
@@ -1,17 +1,14 @@
-error: 
-
-   ┌── tests/move_check/typing/constraints_not_satisfied_lvalues_bind_type.move:6:16 ───
-   │
- 6 │         let x: CupC<R> = abort 0;
-   │                ^^^^^^^ 'copy' constraint not satisifed
-   ·
- 6 │         let x: CupC<R> = abort 0;
-   │                     - The type '0x8675309::M::R' does not have the ability 'copy'
-   ·
- 3 │     struct R {}
-   │            - To satisfy the constraint, the 'copy' ability would need to be added here
-   ·
- 2 │     struct CupC<T: copy> {}
-   │                    ---- 'copy' constraint declared here
-   │
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/constraints_not_satisfied_lvalues_bind_type.move:6:16
+  │
+2 │     struct CupC<T: copy> {}
+  │                    ---- 'copy' constraint declared here
+3 │     struct R {}
+  │            - To satisfy the constraint, the 'copy' ability would need to be added here
+  ·
+6 │         let x: CupC<R> = abort 0;
+  │                ^^^^^^^
+  │                │    │
+  │                │    The type '0x8675309::M::R' does not have the ability 'copy'
+  │                'copy' constraint not satisifed
 

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_decl_type.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_decl_type.exp
@@ -1,17 +1,14 @@
-error: 
-
-   ┌── tests/move_check/typing/constraints_not_satisfied_lvalues_decl_type.move:6:16 ───
-   │
- 6 │         let x: CupC<R>;
-   │                ^^^^^^^ 'copy' constraint not satisifed
-   ·
- 6 │         let x: CupC<R>;
-   │                     - The type '0x8675309::M::R' does not have the ability 'copy'
-   ·
- 3 │     struct R {}
-   │            - To satisfy the constraint, the 'copy' ability would need to be added here
-   ·
- 2 │     struct CupC<T: copy> {}
-   │                    ---- 'copy' constraint declared here
-   │
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/constraints_not_satisfied_lvalues_decl_type.move:6:16
+  │
+2 │     struct CupC<T: copy> {}
+  │                    ---- 'copy' constraint declared here
+3 │     struct R {}
+  │            - To satisfy the constraint, the 'copy' ability would need to be added here
+  ·
+6 │         let x: CupC<R>;
+  │                ^^^^^^^
+  │                │    │
+  │                │    The type '0x8675309::M::R' does not have the ability 'copy'
+  │                'copy' constraint not satisifed
 

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_pack_type_args.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_pack_type_args.exp
@@ -1,34 +1,28 @@
-error: 
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/constraints_not_satisfied_lvalues_pack_type_args.move:8:15
+  │
+2 │     struct CupC<T: copy> {}
+  │                    ---- 'copy' constraint declared here
+3 │     struct R {}
+  │            - To satisfy the constraint, the 'copy' ability would need to be added here
+  ·
+8 │         let B<CupC<R>> {} = abort 0;
+  │               ^^^^^^^
+  │               │    │
+  │               │    The type '0x8675309::M::R' does not have the ability 'copy'
+  │               'copy' constraint not satisifed
 
-   ┌── tests/move_check/typing/constraints_not_satisfied_lvalues_pack_type_args.move:8:15 ───
-   │
- 8 │         let B<CupC<R>> {} = abort 0;
-   │               ^^^^^^^ 'copy' constraint not satisifed
-   ·
- 8 │         let B<CupC<R>> {} = abort 0;
-   │                    - The type '0x8675309::M::R' does not have the ability 'copy'
-   ·
- 3 │     struct R {}
-   │            - To satisfy the constraint, the 'copy' ability would need to be added here
-   ·
- 2 │     struct CupC<T: copy> {}
-   │                    ---- 'copy' constraint declared here
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/constraints_not_satisfied_lvalues_pack_type_args.move:9:11 ───
-   │
- 9 │         B<CupC<R>> {} = abort 0;
-   │           ^^^^^^^ 'copy' constraint not satisifed
-   ·
- 9 │         B<CupC<R>> {} = abort 0;
-   │                - The type '0x8675309::M::R' does not have the ability 'copy'
-   ·
- 3 │     struct R {}
-   │            - To satisfy the constraint, the 'copy' ability would need to be added here
-   ·
- 2 │     struct CupC<T: copy> {}
-   │                    ---- 'copy' constraint declared here
-   │
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/constraints_not_satisfied_lvalues_pack_type_args.move:9:11
+  │
+2 │     struct CupC<T: copy> {}
+  │                    ---- 'copy' constraint declared here
+3 │     struct R {}
+  │            - To satisfy the constraint, the 'copy' ability would need to be added here
+  ·
+9 │         B<CupC<R>> {} = abort 0;
+  │           ^^^^^^^
+  │           │    │
+  │           │    The type '0x8675309::M::R' does not have the ability 'copy'
+  │           'copy' constraint not satisifed
 

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_struct_field.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_struct_field.exp
@@ -1,17 +1,14 @@
-error: 
-
-   ┌── tests/move_check/typing/constraints_not_satisfied_struct_field.move:6:12 ───
-   │
- 6 │         f: CupC<R>,
-   │            ^^^^^^^ 'copy' constraint not satisifed
-   ·
- 6 │         f: CupC<R>,
-   │                 - The type '0x8675309::M::R' does not have the ability 'copy'
-   ·
- 3 │     struct R {}
-   │            - To satisfy the constraint, the 'copy' ability would need to be added here
-   ·
- 2 │     struct CupC<T: copy> {}
-   │                    ---- 'copy' constraint declared here
-   │
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/constraints_not_satisfied_struct_field.move:6:12
+  │
+2 │     struct CupC<T: copy> {}
+  │                    ---- 'copy' constraint declared here
+3 │     struct R {}
+  │            - To satisfy the constraint, the 'copy' ability would need to be added here
+  ·
+6 │         f: CupC<R>,
+  │            ^^^^^^^
+  │            │    │
+  │            │    The type '0x8675309::M::R' does not have the ability 'copy'
+  │            'copy' constraint not satisifed
 

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_type_annotation.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_type_annotation.exp
@@ -1,17 +1,15 @@
-error: 
-
-   ┌── tests/move_check/typing/constraints_not_satisfied_type_annotation.move:7:26 ───
-   │
- 7 │         ignore((abort 0: CupC<R>));
-   │                          ^^^^^^^ 'copy' constraint not satisifed
-   ·
- 7 │         ignore((abort 0: CupC<R>));
-   │                               - The type '0x8675309::M::R' does not have the ability 'copy'
-   ·
- 4 │     struct R {}
-   │            - To satisfy the constraint, the 'copy' ability would need to be added here
-   ·
- 2 │     struct CupC<T: copy> {}
-   │                    ---- 'copy' constraint declared here
-   │
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/constraints_not_satisfied_type_annotation.move:7:26
+  │
+2 │     struct CupC<T: copy> {}
+  │                    ---- 'copy' constraint declared here
+3 │     struct C {}
+4 │     struct R {}
+  │            - To satisfy the constraint, the 'copy' ability would need to be added here
+  ·
+7 │         ignore((abort 0: CupC<R>));
+  │                          ^^^^^^^
+  │                          │    │
+  │                          │    The type '0x8675309::M::R' does not have the ability 'copy'
+  │                          'copy' constraint not satisifed
 

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_call.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_call.exp
@@ -1,17 +1,14 @@
-error: 
-
-   ┌── tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_call.move:9:13 ───
-   │
- 9 │         box<CupC<R>>();
-   │             ^^^^^^^ 'copy' constraint not satisifed
-   ·
- 9 │         box<CupC<R>>();
-   │                  - The type '0x8675309::M::R' does not have the ability 'copy'
-   ·
- 3 │     struct R {}
-   │            - To satisfy the constraint, the 'copy' ability would need to be added here
-   ·
- 2 │     struct CupC<T: copy> {}
-   │                    ---- 'copy' constraint declared here
-   │
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_call.move:9:13
+  │
+2 │     struct CupC<T: copy> {}
+  │                    ---- 'copy' constraint declared here
+3 │     struct R {}
+  │            - To satisfy the constraint, the 'copy' ability would need to be added here
+  ·
+9 │         box<CupC<R>>();
+  │             ^^^^^^^
+  │             │    │
+  │             │    The type '0x8675309::M::R' does not have the ability 'copy'
+  │             'copy' constraint not satisifed
 

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.exp
@@ -1,45 +1,34 @@
-error: 
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.move:8:9
+  │
+8 │         Box<CupD<R>>{};
+  │         ^^^^^^^^^^^^^^
+  │         │   │
+  │         │   The type '0x8675309::M::Box<0x8675309::M::CupD<0x8675309::M::R>>' can have the ability 'drop' but the type argument '0x8675309::M::CupD<0x8675309::M::R>' does not have the required ability 'drop'
+  │         Cannot ignore values without the 'drop' ability. The value must be used
+  │         The type '0x8675309::M::Box<0x8675309::M::CupD<0x8675309::M::R>>' does not have the ability 'drop'
 
-   ┌── tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.move:8:9 ───
-   │
- 8 │         Box<CupD<R>>{};
-   │         ^^^^^^^^^^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
-   ·
- 8 │         Box<CupD<R>>{};
-   │         -------------- The type '0x8675309::M::Box<0x8675309::M::CupD<0x8675309::M::R>>' does not have the ability 'drop'
-   ·
- 8 │         Box<CupD<R>>{};
-   │             ------- The type '0x8675309::M::Box<0x8675309::M::CupD<0x8675309::M::R>>' can have the ability 'drop' but the type argument '0x8675309::M::CupD<0x8675309::M::R>' does not have the required ability 'drop'
-   │
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.move:8:13
+  │
+2 │     struct CupD<T: drop> has drop {}
+  │                    ---- 'drop' constraint declared here
+3 │     struct R {}
+  │            - To satisfy the constraint, the 'drop' ability would need to be added here
+  ·
+8 │         Box<CupD<R>>{};
+  │             ^^^^^^^
+  │             │    │
+  │             │    The type '0x8675309::M::R' does not have the ability 'drop'
+  │             'drop' constraint not satisifed
 
-error: 
-
-   ┌── tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.move:8:13 ───
-   │
- 8 │         Box<CupD<R>>{};
-   │             ^^^^^^^ 'drop' constraint not satisifed
-   ·
- 8 │         Box<CupD<R>>{};
-   │                  - The type '0x8675309::M::R' does not have the ability 'drop'
-   ·
- 3 │     struct R {}
-   │            - To satisfy the constraint, the 'drop' ability would need to be added here
-   ·
- 2 │     struct CupD<T: drop> has drop {}
-   │                    ---- 'drop' constraint declared here
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.move:9:9 ───
-   │
- 9 │         Box<R>{};
-   │         ^^^^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
-   ·
- 9 │         Box<R>{};
-   │         -------- The type '0x8675309::M::Box<0x8675309::M::R>' does not have the ability 'drop'
-   ·
- 9 │         Box<R>{};
-   │             - The type '0x8675309::M::Box<0x8675309::M::R>' can have the ability 'drop' but the type argument '0x8675309::M::R' does not have the required ability 'drop'
-   │
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.move:9:9
+  │
+9 │         Box<R>{};
+  │         ^^^^^^^^
+  │         │   │
+  │         │   The type '0x8675309::M::Box<0x8675309::M::R>' can have the ability 'drop' but the type argument '0x8675309::M::R' does not have the required ability 'drop'
+  │         Cannot ignore values without the 'drop' ability. The value must be used
+  │         The type '0x8675309::M::Box<0x8675309::M::R>' does not have the ability 'drop'
 

--- a/language/move-lang/tests/move_check/typing/declare_pop_resource.exp
+++ b/language/move-lang/tests/move_check/typing/declare_pop_resource.exp
@@ -1,42 +1,33 @@
-error: 
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/declare_pop_resource.move:5:13
+  │
+2 │     struct R {f: u64}
+  │            - To satisfy the constraint, the 'drop' ability would need to be added here
+  ·
+5 │         let _: R;
+  │             ^  - The type '0x8675309::M::R' does not have the ability 'drop'
+  │             │   
+  │             Cannot ignore values without the 'drop' ability. The value must be used
 
-   ┌── tests/move_check/typing/declare_pop_resource.move:5:13 ───
-   │
- 5 │         let _: R;
-   │             ^ Cannot ignore values without the 'drop' ability. The value must be used
-   ·
- 5 │         let _: R;
-   │                - The type '0x8675309::M::R' does not have the ability 'drop'
-   ·
- 2 │     struct R {f: u64}
-   │            - To satisfy the constraint, the 'drop' ability would need to be added here
-   │
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/declare_pop_resource.move:9:14
+  │
+2 │     struct R {f: u64}
+  │            - To satisfy the constraint, the 'drop' ability would need to be added here
+  ·
+9 │         let (_, _):(R, R);
+  │              ^      - The type '0x8675309::M::R' does not have the ability 'drop'
+  │              │       
+  │              Cannot ignore values without the 'drop' ability. The value must be used
 
-error: 
-
-   ┌── tests/move_check/typing/declare_pop_resource.move:9:14 ───
-   │
- 9 │         let (_, _):(R, R);
-   │              ^ Cannot ignore values without the 'drop' ability. The value must be used
-   ·
- 9 │         let (_, _):(R, R);
-   │                     - The type '0x8675309::M::R' does not have the ability 'drop'
-   ·
- 2 │     struct R {f: u64}
-   │            - To satisfy the constraint, the 'drop' ability would need to be added here
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/declare_pop_resource.move:9:17 ───
-   │
- 9 │         let (_, _):(R, R);
-   │                 ^ Cannot ignore values without the 'drop' ability. The value must be used
-   ·
- 9 │         let (_, _):(R, R);
-   │                        - The type '0x8675309::M::R' does not have the ability 'drop'
-   ·
- 2 │     struct R {f: u64}
-   │            - To satisfy the constraint, the 'drop' ability would need to be added here
-   │
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/declare_pop_resource.move:9:17
+  │
+2 │     struct R {f: u64}
+  │            - To satisfy the constraint, the 'drop' ability would need to be added here
+  ·
+9 │         let (_, _):(R, R);
+  │                 ^      - The type '0x8675309::M::R' does not have the ability 'drop'
+  │                 │       
+  │                 Cannot ignore values without the 'drop' ability. The value must be used
 

--- a/language/move-lang/tests/move_check/typing/declare_wrong_arity.exp
+++ b/language/move-lang/tests/move_check/typing/declare_wrong_arity.exp
@@ -1,13 +1,10 @@
-error: 
-
-   ┌── tests/move_check/typing/declare_wrong_arity.move:5:13 ───
-   │
- 5 │         let x: ();
-   │             ^ Invalid type for local
-   ·
- 5 │         let x: ();
-   │                -- Expected a single type, but found expression list type: '()'
-   │
+error[E04005]: expected a single type
+  ┌─ tests/move_check/typing/declare_wrong_arity.move:5:13
+  │
+5 │         let x: ();
+  │             ^  -- Expected a single type, but found expression list type: '()'
+  │             │   
+  │             Invalid type for local
 
 error: 
 

--- a/language/move-lang/tests/move_check/typing/derefrence_reference.exp
+++ b/language/move-lang/tests/move_check/typing/derefrence_reference.exp
@@ -1,98 +1,79 @@
-error: 
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/derefrence_reference.move:6:16
+  │
+2 │     struct R {}
+  │            - To satisfy the constraint, the 'copy' ability would need to be added here
+  ·
+5 │     fun t0(r: &R, b: &B) {
+  │                - The type '0x8675309::M::R' does not have the ability 'copy'
+6 │         R {} = *r;
+  │                ^^ Invalid dereference. Dereference requires the 'copy' ability
 
-   ┌── tests/move_check/typing/derefrence_reference.move:6:16 ───
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/derefrence_reference.move:7:24
+  │
+3 │     struct B { r: R }
+  │            - To satisfy the constraint, the 'copy' ability would need to be added here
+4 │ 
+5 │     fun t0(r: &R, b: &B) {
+  │                       - The type '0x8675309::M::B' does not have the ability 'copy'
+6 │         R {} = *r;
+7 │         B { r: R{} } = *b;
+  │                        ^^ Invalid dereference. Dereference requires the 'copy' ability
+
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/derefrence_reference.move:8:15
+  │
+2 │     struct R {}
+  │            - To satisfy the constraint, the 'copy' ability would need to be added here
+3 │     struct B { r: R }
+  │                   - The type '0x8675309::M::R' does not have the ability 'copy'
+  ·
+8 │         R{} = *&b.r;
+  │               ^^^^^ Invalid dereference. Dereference requires the 'copy' ability
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/derefrence_reference.move:12:16
    │
- 6 │         R {} = *r;
-   │                ^^ Invalid dereference. Dereference requires the 'copy' ability
-   ·
- 5 │     fun t0(r: &R, b: &B) {
-   │                - The type '0x8675309::M::R' does not have the ability 'copy'
-   ·
  2 │     struct R {}
    │            - To satisfy the constraint, the 'copy' ability would need to be added here
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/derefrence_reference.move:7:24 ───
-   │
- 7 │         B { r: R{} } = *b;
-   │                        ^^ Invalid dereference. Dereference requires the 'copy' ability
    ·
- 5 │     fun t0(r: &R, b: &B) {
-   │                       - The type '0x8675309::M::B' does not have the ability 'copy'
-   ·
+11 │     fun t1(r: &mut R, b: &mut B) {
+   │                    - The type '0x8675309::M::R' does not have the ability 'copy'
+12 │         R {} = *r;
+   │                ^^ Invalid dereference. Dereference requires the 'copy' ability
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/derefrence_reference.move:13:24
+   │
  3 │     struct B { r: R }
    │            - To satisfy the constraint, the 'copy' ability would need to be added here
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/derefrence_reference.move:8:15 ───
-   │
- 8 │         R{} = *&b.r;
-   │               ^^^^^ Invalid dereference. Dereference requires the 'copy' ability
    ·
+11 │     fun t1(r: &mut R, b: &mut B) {
+   │                               - The type '0x8675309::M::B' does not have the ability 'copy'
+12 │         R {} = *r;
+13 │         B { r: R{} } = *b;
+   │                        ^^ Invalid dereference. Dereference requires the 'copy' ability
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/derefrence_reference.move:14:15
+   │
+ 2 │     struct R {}
+   │            - To satisfy the constraint, the 'copy' ability would need to be added here
  3 │     struct B { r: R }
    │                   - The type '0x8675309::M::R' does not have the ability 'copy'
    ·
+14 │         R{} = *&b.r;
+   │               ^^^^^ Invalid dereference. Dereference requires the 'copy' ability
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/derefrence_reference.move:15:15
+   │
  2 │     struct R {}
    │            - To satisfy the constraint, the 'copy' ability would need to be added here
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/derefrence_reference.move:12:16 ───
-    │
- 12 │         R {} = *r;
-    │                ^^ Invalid dereference. Dereference requires the 'copy' ability
-    ·
- 11 │     fun t1(r: &mut R, b: &mut B) {
-    │                    - The type '0x8675309::M::R' does not have the ability 'copy'
-    ·
-  2 │     struct R {}
-    │            - To satisfy the constraint, the 'copy' ability would need to be added here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/derefrence_reference.move:13:24 ───
-    │
- 13 │         B { r: R{} } = *b;
-    │                        ^^ Invalid dereference. Dereference requires the 'copy' ability
-    ·
- 11 │     fun t1(r: &mut R, b: &mut B) {
-    │                               - The type '0x8675309::M::B' does not have the ability 'copy'
-    ·
-  3 │     struct B { r: R }
-    │            - To satisfy the constraint, the 'copy' ability would need to be added here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/derefrence_reference.move:14:15 ───
-    │
- 14 │         R{} = *&b.r;
-    │               ^^^^^ Invalid dereference. Dereference requires the 'copy' ability
-    ·
-  3 │     struct B { r: R }
-    │                   - The type '0x8675309::M::R' does not have the ability 'copy'
-    ·
-  2 │     struct R {}
-    │            - To satisfy the constraint, the 'copy' ability would need to be added here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/derefrence_reference.move:15:15 ───
-    │
- 15 │         R{} = *&mut b.r;
-    │               ^^^^^^^^^ Invalid dereference. Dereference requires the 'copy' ability
-    ·
-  3 │     struct B { r: R }
-    │                   - The type '0x8675309::M::R' does not have the ability 'copy'
-    ·
-  2 │     struct R {}
-    │            - To satisfy the constraint, the 'copy' ability would need to be added here
-    │
+ 3 │     struct B { r: R }
+   │                   - The type '0x8675309::M::R' does not have the ability 'copy'
+   ·
+15 │         R{} = *&mut b.r;
+   │               ^^^^^^^^^ Invalid dereference. Dereference requires the 'copy' ability
 

--- a/language/move-lang/tests/move_check/typing/eq_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/eq_invalid.exp
@@ -1,3 +1,54 @@
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/eq_invalid.move:22:9
+   │
+ 3 │     struct R has key {
+   │            - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+21 │     fun t1(r: R) {
+   │               - The type '0x8675309::M::R' does not have the ability 'drop'
+22 │         r == r;
+   │         ^^^^^^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/eq_invalid.move:26:9
+   │
+26 │         G0<R>{} == G0<R>{};
+   │         ^^^^^^^^^^^^^^^^^^
+   │         │          │  │
+   │         │          │  The type '0x8675309::M::G0<0x8675309::M::R>' can have the ability 'drop' but the type argument '0x8675309::M::R' does not have the required ability 'drop'
+   │         │          The type '0x8675309::M::G0<0x8675309::M::R>' does not have the ability 'drop'
+   │         '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/eq_invalid.move:29:9
+   │
+ 7 │     struct G1<T: key> {}
+   │            -- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+29 │         G1{} == G1{};
+   │         ^^^^^^^^^^^^
+   │         │       │
+   │         │       The type '0x8675309::M::G1<_>' does not have the ability 'drop'
+   │         '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E04005]: expected a single type
+   ┌─ tests/move_check/typing/eq_invalid.move:33:9
+   │
+33 │         () == ();
+   │         ^^^^^^^^
+   │         │     │
+   │         │     Expected a single type, but found expression list type: '()'
+   │         Invalid arguments to '=='
+
+error[E04005]: expected a single type
+   ┌─ tests/move_check/typing/eq_invalid.move:34:9
+   │
+34 │         (0, 1) == (0, 1);
+   │         ^^^^^^^^^^^^^^^^
+   │         │         │
+   │         │         Expected a single type, but found expression list type: '(u64, u64)'
+   │         Invalid arguments to '=='
+
 error: 
 
     ┌── tests/move_check/typing/eq_invalid.move:13:20 ───
@@ -84,34 +135,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/eq_invalid.move:22:9 ───
-    │
- 22 │         r == r;
-    │         ^^^^^^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
-    ·
- 21 │     fun t1(r: R) {
-    │               - The type '0x8675309::M::R' does not have the ability 'drop'
-    ·
-  3 │     struct R has key {
-    │            - To satisfy the constraint, the 'drop' ability would need to be added here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/eq_invalid.move:26:9 ───
-    │
- 26 │         G0<R>{} == G0<R>{};
-    │         ^^^^^^^^^^^^^^^^^^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
-    ·
- 26 │         G0<R>{} == G0<R>{};
-    │                    ------- The type '0x8675309::M::G0<0x8675309::M::R>' does not have the ability 'drop'
-    ·
- 26 │         G0<R>{} == G0<R>{};
-    │                       - The type '0x8675309::M::G0<0x8675309::M::R>' can have the ability 'drop' but the type argument '0x8675309::M::R' does not have the required ability 'drop'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/eq_invalid.move:28:9 ───
     │
  28 │         G0{} == G0{};
@@ -136,46 +159,10 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/eq_invalid.move:29:9 ───
-    │
- 29 │         G1{} == G1{};
-    │         ^^^^^^^^^^^^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
-    ·
- 29 │         G1{} == G1{};
-    │                 ---- The type '0x8675309::M::G1<_>' does not have the ability 'drop'
-    ·
-  7 │     struct G1<T: key> {}
-    │            -- To satisfy the constraint, the 'drop' ability would need to be added here
-    │
-
-error: 
-
     ┌── tests/move_check/typing/eq_invalid.move:29:17 ───
     │
  29 │         G1{} == G1{};
     │                 ^^^^ Could not infer this type. Try adding an annotation
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/eq_invalid.move:33:9 ───
-    │
- 33 │         () == ();
-    │         ^^^^^^^^ Invalid arguments to '=='
-    ·
- 33 │         () == ();
-    │               -- Expected a single type, but found expression list type: '()'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/eq_invalid.move:34:9 ───
-    │
- 34 │         (0, 1) == (0, 1);
-    │         ^^^^^^^^^^^^^^^^ Invalid arguments to '=='
-    ·
- 34 │         (0, 1) == (0, 1);
-    │                   ------ Expected a single type, but found expression list type: '(u64, u64)'
     │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/exp_list_nested.exp
+++ b/language/move-lang/tests/move_check/typing/exp_list_nested.exp
@@ -1,3 +1,12 @@
+error[E04005]: expected a single type
+  ┌─ tests/move_check/typing/exp_list_nested.move:6:9
+  │
+6 │         (0, (S{}, R{}))
+  │         ^^^^^^^^^^^^^^^
+  │         │   │
+  │         │   Expected a single type, but found expression list type: '(0x8675309::M::S, 0x8675309::M::R<_>)'
+  │         Invalid expression list type argument
+
 error: 
 
    ┌── tests/move_check/typing/exp_list_nested.move:6:9 ───
@@ -10,17 +19,6 @@ error:
    ·
  5 │     fun t0(): (u64, S, R<u64>) {
    │               ---------------- Is not compatible with the expression list type of length 3: '(u64, 0x8675309::M::S, 0x8675309::M::R<u64>)'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/exp_list_nested.move:6:9 ───
-   │
- 6 │         (0, (S{}, R{}))
-   │         ^^^^^^^^^^^^^^^ Invalid expression list type argument
-   ·
- 6 │         (0, (S{}, R{}))
-   │             ---------- Expected a single type, but found expression list type: '(0x8675309::M::S, 0x8675309::M::R<_>)'
    │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/exp_list_resource_drop.exp
+++ b/language/move-lang/tests/move_check/typing/exp_list_resource_drop.exp
@@ -1,44 +1,32 @@
-error: 
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/exp_list_resource_drop.move:7:9
+  │
+7 │         (0, S{}, R<u64> {});
+  │         ^^^^^^^^^^^^^^^^^^^
+  │         │   │
+  │         │   The type '(u64, 0x8675309::M::S, 0x8675309::M::R<u64>)' can have the ability 'drop' but the type argument '0x8675309::M::S' does not have the required ability 'drop'
+  │         Cannot ignore values without the 'drop' ability. The value must be used
+  │         The type '(u64, 0x8675309::M::S, 0x8675309::M::R<u64>)' does not have the ability 'drop'
 
-   ┌── tests/move_check/typing/exp_list_resource_drop.move:7:9 ───
-   │
- 7 │         (0, S{}, R<u64> {});
-   │         ^^^^^^^^^^^^^^^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
-   ·
- 7 │         (0, S{}, R<u64> {});
-   │         ------------------- The type '(u64, 0x8675309::M::S, 0x8675309::M::R<u64>)' does not have the ability 'drop'
-   ·
- 7 │         (0, S{}, R<u64> {});
-   │             --- The type '(u64, 0x8675309::M::S, 0x8675309::M::R<u64>)' can have the ability 'drop' but the type argument '0x8675309::M::S' does not have the required ability 'drop'
-   │
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/exp_list_resource_drop.move:8:9
+  │
+8 │         (0, S{}, Box<R<u64>> {});
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^
+  │         │   │
+  │         │   The type '(u64, 0x8675309::M::S, 0x8675309::M::Box<0x8675309::M::R<u64>>)' can have the ability 'drop' but the type argument '0x8675309::M::S' does not have the required ability 'drop'
+  │         Cannot ignore values without the 'drop' ability. The value must be used
+  │         The type '(u64, 0x8675309::M::S, 0x8675309::M::Box<0x8675309::M::R<u64>>)' does not have the ability 'drop'
 
-error: 
-
-   ┌── tests/move_check/typing/exp_list_resource_drop.move:8:9 ───
-   │
- 8 │         (0, S{}, Box<R<u64>> {});
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
-   ·
- 8 │         (0, S{}, Box<R<u64>> {});
-   │         ------------------------ The type '(u64, 0x8675309::M::S, 0x8675309::M::Box<0x8675309::M::R<u64>>)' does not have the ability 'drop'
-   ·
- 8 │         (0, S{}, Box<R<u64>> {});
-   │             --- The type '(u64, 0x8675309::M::S, 0x8675309::M::Box<0x8675309::M::R<u64>>)' can have the ability 'drop' but the type argument '0x8675309::M::S' does not have the required ability 'drop'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/exp_list_resource_drop.move:9:9 ───
-   │
- 9 │         (0, S{}, Box {});
-   │         ^^^^^^^^^^^^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
-   ·
- 9 │         (0, S{}, Box {});
-   │         ---------------- The type '(u64, 0x8675309::M::S, 0x8675309::M::Box<_>)' does not have the ability 'drop'
-   ·
- 9 │         (0, S{}, Box {});
-   │             --- The type '(u64, 0x8675309::M::S, 0x8675309::M::Box<_>)' can have the ability 'drop' but the type argument '0x8675309::M::S' does not have the required ability 'drop'
-   │
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/exp_list_resource_drop.move:9:9
+  │
+9 │         (0, S{}, Box {});
+  │         ^^^^^^^^^^^^^^^^
+  │         │   │
+  │         │   The type '(u64, 0x8675309::M::S, 0x8675309::M::Box<_>)' can have the ability 'drop' but the type argument '0x8675309::M::S' does not have the required ability 'drop'
+  │         Cannot ignore values without the 'drop' ability. The value must be used
+  │         The type '(u64, 0x8675309::M::S, 0x8675309::M::Box<_>)' does not have the ability 'drop'
 
 error: 
 

--- a/language/move-lang/tests/move_check/typing/global_builtins_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/global_builtins_invalid.exp
@@ -1,3 +1,12 @@
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/global_builtins_invalid.move:15:18
+   │
+15 │         let () = move_to(a, 0);
+   │                  ^^^^^^^^^^^^^
+   │                  │          │
+   │                  │          The type 'u64' does not have the ability 'key'
+   │                  Invalid call of 'move_to'
+
 error: 
 
    ┌── tests/move_check/typing/global_builtins_invalid.move:5:24 ───
@@ -79,17 +88,6 @@ error:
     ·
  14 │         let () = move_to<R>(a, 0);
     │                          - Is not compatible with: '0x8675309::M::R'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/global_builtins_invalid.move:15:18 ───
-    │
- 15 │         let () = move_to(a, 0);
-    │                  ^^^^^^^^^^^^^ Invalid call of 'move_to'
-    ·
- 15 │         let () = move_to(a, 0);
-    │                             - The type 'u64' does not have the ability 'key'
     │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/ignore_inferred_resource.exp
+++ b/language/move-lang/tests/move_check/typing/ignore_inferred_resource.exp
@@ -1,16 +1,14 @@
-error: 
-
-   ┌── tests/move_check/typing/ignore_inferred_resource.move:4:9 ───
-   │
- 4 │         S{};
-   │         ^^^ Cannot ignore values without the 'drop' ability. The value must be used
-   ·
- 4 │         S{};
-   │         --- The type '0x8675309::M::S<_>' does not have the ability 'drop'
-   ·
- 2 │     struct S<T> {}
-   │            - To satisfy the constraint, the 'drop' ability would need to be added here
-   │
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/ignore_inferred_resource.move:4:9
+  │
+2 │     struct S<T> {}
+  │            - To satisfy the constraint, the 'drop' ability would need to be added here
+3 │     fun no() {
+4 │         S{};
+  │         ^^^
+  │         │
+  │         Cannot ignore values without the 'drop' ability. The value must be used
+  │         The type '0x8675309::M::S<_>' does not have the ability 'drop'
 
 error: 
 

--- a/language/move-lang/tests/move_check/typing/implicit_deref_borrow_field_chain_missing.exp
+++ b/language/move-lang/tests/move_check/typing/implicit_deref_borrow_field_chain_missing.exp
@@ -1,26 +1,38 @@
-error: 
+error[E03010]: unbound field
+  ┌─ tests/move_check/typing/implicit_deref_borrow_field_chain_missing.move:7:9
+  │
+7 │         x1.f;
+  │         ^^^^ Unbound field 'f' in '0x8675309::M::X1'
 
-   ┌── tests/move_check/typing/implicit_deref_borrow_field_chain_missing.move:7:9 ───
-   │
- 7 │         x1.f;
-   │         ^^^^ Unbound field 'f' in '0x8675309::M::X1'
-   │
+error[E03010]: unbound field
+  ┌─ tests/move_check/typing/implicit_deref_borrow_field_chain_missing.move:8:9
+  │
+8 │         x1.x2.f;
+  │         ^^^^^^^ Unbound field 'f' in '0x8675309::M::X2'
 
-error: 
+error[E03010]: unbound field
+  ┌─ tests/move_check/typing/implicit_deref_borrow_field_chain_missing.move:9:9
+  │
+9 │         x1.x2.x3.g;
+  │         ^^^^^^^^^^ Unbound field 'g' in '0x8675309::M::X3'
 
-   ┌── tests/move_check/typing/implicit_deref_borrow_field_chain_missing.move:8:9 ───
+error[E03010]: unbound field
+   ┌─ tests/move_check/typing/implicit_deref_borrow_field_chain_missing.move:11:9
    │
- 8 │         x1.x2.f;
-   │         ^^^^^^^ Unbound field 'f' in '0x8675309::M::X2'
-   │
+11 │         x1_mut.f;
+   │         ^^^^^^^^ Unbound field 'f' in '0x8675309::M::X1'
 
-error: 
+error[E03010]: unbound field
+   ┌─ tests/move_check/typing/implicit_deref_borrow_field_chain_missing.move:12:9
+   │
+12 │         x1_mut.x2.f;
+   │         ^^^^^^^^^^^ Unbound field 'f' in '0x8675309::M::X2'
 
-   ┌── tests/move_check/typing/implicit_deref_borrow_field_chain_missing.move:9:9 ───
+error[E03010]: unbound field
+   ┌─ tests/move_check/typing/implicit_deref_borrow_field_chain_missing.move:13:9
    │
- 9 │         x1.x2.x3.g;
-   │         ^^^^^^^^^^ Unbound field 'g' in '0x8675309::M::X3'
-   │
+13 │         x1_mut.x2.x3.g;
+   │         ^^^^^^^^^^^^^^ Unbound field 'g' in '0x8675309::M::X3'
 
 error: 
 
@@ -31,30 +43,6 @@ error:
     ·
   4 │     struct X3 { f: u64, }
     │                    --- Expected a struct type in the current module but got: 'u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/implicit_deref_borrow_field_chain_missing.move:11:9 ───
-    │
- 11 │         x1_mut.f;
-    │         ^^^^^^^^ Unbound field 'f' in '0x8675309::M::X1'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/implicit_deref_borrow_field_chain_missing.move:12:9 ───
-    │
- 12 │         x1_mut.x2.f;
-    │         ^^^^^^^^^^^ Unbound field 'f' in '0x8675309::M::X2'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/implicit_deref_borrow_field_chain_missing.move:13:9 ───
-    │
- 13 │         x1_mut.x2.x3.g;
-    │         ^^^^^^^^^^^^^^ Unbound field 'g' in '0x8675309::M::X3'
     │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/implicit_deref_borrow_field_from_non_struct.exp
+++ b/language/move-lang/tests/move_check/typing/implicit_deref_borrow_field_from_non_struct.exp
@@ -1,3 +1,21 @@
+error[E04005]: expected a single type
+   ┌─ tests/move_check/typing/implicit_deref_borrow_field_from_non_struct.move:12:9
+   │
+12 │         ().R;
+   │         ^^
+   │         │
+   │         Invalid dot access
+   │         Expected a single type, but found expression list type: '()'
+
+error[E04005]: expected a single type
+   ┌─ tests/move_check/typing/implicit_deref_borrow_field_from_non_struct.move:13:9
+   │
+13 │         (S{f: 0}, S{f:0}).f;
+   │         ^^^^^^^^^^^^^^^^^
+   │         │
+   │         Invalid dot access
+   │         Expected a single type, but found expression list type: '(0x8675309::M::S, 0x8675309::M::S)'
+
 error: 
 
    ┌── tests/move_check/typing/implicit_deref_borrow_field_from_non_struct.move:6:9 ───
@@ -69,32 +87,10 @@ error:
     ┌── tests/move_check/typing/implicit_deref_borrow_field_from_non_struct.move:12:9 ───
     │
  12 │         ().R;
-    │         ^^ Invalid dot access
-    ·
- 12 │         ().R;
-    │         -- Expected a single type, but found expression list type: '()'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/implicit_deref_borrow_field_from_non_struct.move:12:9 ───
-    │
- 12 │         ().R;
     │         ^^^^ Unbound field 'R'
     ·
  12 │         ().R;
     │         -- Expected a struct type in the current module but got: '()'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/implicit_deref_borrow_field_from_non_struct.move:13:9 ───
-    │
- 13 │         (S{f: 0}, S{f:0}).f;
-    │         ^^^^^^^^^^^^^^^^^ Invalid dot access
-    ·
- 13 │         (S{f: 0}, S{f:0}).f;
-    │         ----------------- Expected a single type, but found expression list type: '(0x8675309::M::S, 0x8675309::M::S)'
     │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/implicit_deref_borrow_field_missing.exp
+++ b/language/move-lang/tests/move_check/typing/implicit_deref_borrow_field_missing.exp
@@ -1,24 +1,18 @@
-error: 
+error[E03010]: unbound field
+  ┌─ tests/move_check/typing/implicit_deref_borrow_field_missing.move:5:9
+  │
+5 │         s.g;
+  │         ^^^ Unbound field 'g' in '0x8675309::M::S'
 
-   ┌── tests/move_check/typing/implicit_deref_borrow_field_missing.move:5:9 ───
-   │
- 5 │         s.g;
-   │         ^^^ Unbound field 'g' in '0x8675309::M::S'
-   │
+error[E03010]: unbound field
+  ┌─ tests/move_check/typing/implicit_deref_borrow_field_missing.move:6:9
+  │
+6 │         sref.g;
+  │         ^^^^^^ Unbound field 'g' in '0x8675309::M::S'
 
-error: 
-
-   ┌── tests/move_check/typing/implicit_deref_borrow_field_missing.move:6:9 ───
-   │
- 6 │         sref.g;
-   │         ^^^^^^ Unbound field 'g' in '0x8675309::M::S'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/implicit_deref_borrow_field_missing.move:7:9 ───
-   │
- 7 │         s_mut.h;
-   │         ^^^^^^^ Unbound field 'h' in '0x8675309::M::S'
-   │
+error[E03010]: unbound field
+  ┌─ tests/move_check/typing/implicit_deref_borrow_field_missing.move:7:9
+  │
+7 │         s_mut.h;
+  │         ^^^^^^^ Unbound field 'h' in '0x8675309::M::S'
 

--- a/language/move-lang/tests/move_check/typing/implicit_deref_borrow_field_not_copyable.exp
+++ b/language/move-lang/tests/move_check/typing/implicit_deref_borrow_field_not_copyable.exp
@@ -1,44 +1,36 @@
-error: 
+error[E05002]: type not implicitly copyable
+  ┌─ tests/move_check/typing/implicit_deref_borrow_field_not_copyable.move:7:10
+  │
+4 │     struct B { s: S, r: R }
+  │                   - The type '0x8675309::M::S' is not implicitly copyable. Implicit copies are limited to simple primitive values
+  ·
+7 │         (b.s: S);
+  │          ^^^ Invalid implicit copy of field 's'. Try adding '*&' to the front of the field access
 
-   ┌── tests/move_check/typing/implicit_deref_borrow_field_not_copyable.move:7:10 ───
+error[E05002]: type not implicitly copyable
+  ┌─ tests/move_check/typing/implicit_deref_borrow_field_not_copyable.move:8:15
+  │
+4 │     struct B { s: S, r: R }
+  │                         - The type '0x8675309::M::R' is not implicitly copyable. Implicit copies are limited to simple primitive values
+  ·
+8 │         R{} = b.r;
+  │               ^^^ Invalid implicit copy of field 'r'. Try adding '*&' to the front of the field access
+
+error[E05002]: type not implicitly copyable
+   ┌─ tests/move_check/typing/implicit_deref_borrow_field_not_copyable.move:10:10
    │
- 7 │         (b.s: S);
-   │          ^^^ Invalid implicit copy of field 's'. Try adding '*&' to the front of the field access
-   ·
  4 │     struct B { s: S, r: R }
    │                   - The type '0x8675309::M::S' is not implicitly copyable. Implicit copies are limited to simple primitive values
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/implicit_deref_borrow_field_not_copyable.move:8:15 ───
-   │
- 8 │         R{} = b.r;
-   │               ^^^ Invalid implicit copy of field 'r'. Try adding '*&' to the front of the field access
    ·
+10 │         (bref.s: S);
+   │          ^^^^^^ Invalid implicit copy of field 's'. Try adding '*&' to the front of the field access
+
+error[E05002]: type not implicitly copyable
+   ┌─ tests/move_check/typing/implicit_deref_borrow_field_not_copyable.move:11:15
+   │
  4 │     struct B { s: S, r: R }
    │                         - The type '0x8675309::M::R' is not implicitly copyable. Implicit copies are limited to simple primitive values
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/implicit_deref_borrow_field_not_copyable.move:10:10 ───
-    │
- 10 │         (bref.s: S);
-    │          ^^^^^^ Invalid implicit copy of field 's'. Try adding '*&' to the front of the field access
-    ·
-  4 │     struct B { s: S, r: R }
-    │                   - The type '0x8675309::M::S' is not implicitly copyable. Implicit copies are limited to simple primitive values
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/implicit_deref_borrow_field_not_copyable.move:11:15 ───
-    │
- 11 │         R{} = bref.r;
-    │               ^^^^^^ Invalid implicit copy of field 'r'. Try adding '*&' to the front of the field access
-    ·
-  4 │     struct B { s: S, r: R }
-    │                         - The type '0x8675309::M::R' is not implicitly copyable. Implicit copies are limited to simple primitive values
-    │
+   ·
+11 │         R{} = bref.r;
+   │               ^^^^^^ Invalid implicit copy of field 'r'. Try adding '*&' to the front of the field access
 

--- a/language/move-lang/tests/move_check/typing/instantiate_signatures.exp
+++ b/language/move-lang/tests/move_check/typing/instantiate_signatures.exp
@@ -1,378 +1,306 @@
-error: 
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/instantiate_signatures.move:11:13
+   │
+ 3 │     struct S<T: drop> has drop {}
+   │                 ---- 'drop' constraint declared here
+ 4 │     struct R {}
+   │            - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+11 │         f1: S<R>,
+   │             ^^^^
+   │             │ │
+   │             │ The type '0x42::M::R' does not have the ability 'drop'
+   │             'drop' constraint not satisifed
 
-    ┌── tests/move_check/typing/instantiate_signatures.move:11:13 ───
-    │
- 11 │         f1: S<R>,
-    │             ^^^^ 'drop' constraint not satisifed
-    ·
- 11 │         f1: S<R>,
-    │               - The type '0x42::M::R' does not have the ability 'drop'
-    ·
-  4 │     struct R {}
-    │            - To satisfy the constraint, the 'drop' ability would need to be added here
-    ·
-  3 │     struct S<T: drop> has drop {}
-    │                 ---- 'drop' constraint declared here
-    │
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/instantiate_signatures.move:12:13
+   │
+12 │         f2: S<&u64>,
+   │             ^^^^^^^
+   │             │ │
+   │             │ Expected a single non-reference type, but found: '&u64'
+   │             Invalid type argument
 
-error: 
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/instantiate_signatures.move:13:13
+   │
+13 │         f3: &(&u64),
+   │             ^^^^^^^
+   │             ││
+   │             │Expected a single non-reference type, but found: '&u64'
+   │             Invalid reference type
 
-    ┌── tests/move_check/typing/instantiate_signatures.move:12:13 ───
-    │
- 12 │         f2: S<&u64>,
-    │             ^^^^^^^ Invalid type argument
-    ·
- 12 │         f2: S<&u64>,
-    │               ---- Expected a single non-reference type, but found: '&u64'
-    │
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/instantiate_signatures.move:13:13
+   │
+13 │         f3: &(&u64),
+   │             ^^^^^^^
+   │             │
+   │             Invalid field type
+   │             Expected a single non-reference type, but found: '&&u64'
 
-error: 
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/instantiate_signatures.move:14:13
+   │
+14 │         f4: S<(u64, u64)>,
+   │             ^^^^^^^^^^^^^
+   │             │ │
+   │             │ Expected a single non-reference type, but found: '(u64, u64)'
+   │             Invalid type argument
 
-    ┌── tests/move_check/typing/instantiate_signatures.move:13:13 ───
-    │
- 13 │         f3: &(&u64),
-    │             ^^^^^^^ Invalid reference type
-    ·
- 13 │         f3: &(&u64),
-    │              ------ Expected a single non-reference type, but found: '&u64'
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/instantiate_signatures.move:18:14
+   │
+ 3 │     struct S<T: drop> has drop {}
+   │                 ---- 'drop' constraint declared here
+ 4 │     struct R {}
+   │            - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+18 │         _f1: S<R>,
+   │              ^^^^
+   │              │ │
+   │              │ The type '0x42::M::R' does not have the ability 'drop'
+   │              'drop' constraint not satisifed
 
-error: 
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/instantiate_signatures.move:19:14
+   │
+19 │         _f2: S<&u64>,
+   │              ^^^^^^^
+   │              │ │
+   │              │ Expected a single non-reference type, but found: '&u64'
+   │              Invalid type argument
 
-    ┌── tests/move_check/typing/instantiate_signatures.move:13:13 ───
-    │
- 13 │         f3: &(&u64),
-    │             ^^^^^^^ Invalid field type
-    ·
- 13 │         f3: &(&u64),
-    │             ------- Expected a single non-reference type, but found: '&&u64'
-    │
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/instantiate_signatures.move:20:14
+   │
+20 │         _f3: &(&u64),
+   │              ^^^^^^^
+   │              ││
+   │              │Expected a single non-reference type, but found: '&u64'
+   │              Invalid reference type
 
-error: 
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/instantiate_signatures.move:21:14
+   │
+21 │         _f4: S<(u64, u64)>,
+   │              ^^^^^^^^^^^^^
+   │              │ │
+   │              │ Expected a single non-reference type, but found: '(u64, u64)'
+   │              Invalid type argument
 
-    ┌── tests/move_check/typing/instantiate_signatures.move:14:13 ───
-    │
- 14 │         f4: S<(u64, u64)>,
-    │             ^^^^^^^^^^^^^ Invalid type argument
-    ·
- 14 │         f4: S<(u64, u64)>,
-    │               ---------- Expected a single non-reference type, but found: '(u64, u64)'
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/instantiate_signatures.move:23:9
+   │
+ 3 │     struct S<T: drop> has drop {}
+   │                 ---- 'drop' constraint declared here
+ 4 │     struct R {}
+   │            - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+23 │         S<R>,
+   │         ^^^^
+   │         │ │
+   │         │ The type '0x42::M::R' does not have the ability 'drop'
+   │         'drop' constraint not satisifed
 
-error: 
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/instantiate_signatures.move:24:9
+   │
+24 │         S<&u64>,
+   │         ^^^^^^^
+   │         │ │
+   │         │ Expected a single non-reference type, but found: '&u64'
+   │         Invalid type argument
 
-    ┌── tests/move_check/typing/instantiate_signatures.move:18:14 ───
-    │
- 18 │         _f1: S<R>,
-    │              ^^^^ 'drop' constraint not satisifed
-    ·
- 18 │         _f1: S<R>,
-    │                - The type '0x42::M::R' does not have the ability 'drop'
-    ·
-  4 │     struct R {}
-    │            - To satisfy the constraint, the 'drop' ability would need to be added here
-    ·
-  3 │     struct S<T: drop> has drop {}
-    │                 ---- 'drop' constraint declared here
-    │
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/instantiate_signatures.move:25:9
+   │
+25 │         &(&u64),
+   │         ^^^^^^^
+   │         ││
+   │         │Expected a single non-reference type, but found: '&u64'
+   │         Invalid reference type
 
-error: 
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/instantiate_signatures.move:26:9
+   │
+26 │         S<(u64, u64)>,
+   │         ^^^^^^^^^^^^^
+   │         │ │
+   │         │ Expected a single non-reference type, but found: '(u64, u64)'
+   │         Invalid type argument
 
-    ┌── tests/move_check/typing/instantiate_signatures.move:19:14 ───
-    │
- 19 │         _f2: S<&u64>,
-    │              ^^^^^^^ Invalid type argument
-    ·
- 19 │         _f2: S<&u64>,
-    │                ---- Expected a single non-reference type, but found: '&u64'
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/instantiate_signatures.move:32:17
+   │
+ 3 │     struct S<T: drop> has drop {}
+   │                 ---- 'drop' constraint declared here
+ 4 │     struct R {}
+   │            - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+32 │         let f1: S<R> = abort 0;
+   │                 ^^^^
+   │                 │ │
+   │                 │ The type '0x42::M::R' does not have the ability 'drop'
+   │                 'drop' constraint not satisifed
 
-error: 
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/instantiate_signatures.move:33:17
+   │
+33 │         let f2: S<&u64> = abort 0;
+   │                 ^^^^^^^
+   │                 │ │
+   │                 │ Expected a single non-reference type, but found: '&u64'
+   │                 Invalid type argument
 
-    ┌── tests/move_check/typing/instantiate_signatures.move:20:14 ───
-    │
- 20 │         _f3: &(&u64),
-    │              ^^^^^^^ Invalid reference type
-    ·
- 20 │         _f3: &(&u64),
-    │               ------ Expected a single non-reference type, but found: '&u64'
-    │
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/instantiate_signatures.move:34:17
+   │
+34 │         let f3: &(&u64) = abort 0;
+   │                 ^^^^^^^
+   │                 ││
+   │                 │Expected a single non-reference type, but found: '&u64'
+   │                 Invalid reference type
 
-error: 
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/instantiate_signatures.move:35:17
+   │
+35 │         let f4: S<(u64, u64)> = abort 0;
+   │                 ^^^^^^^^^^^^^
+   │                 │ │
+   │                 │ Expected a single non-reference type, but found: '(u64, u64)'
+   │                 Invalid type argument
 
-    ┌── tests/move_check/typing/instantiate_signatures.move:21:14 ───
-    │
- 21 │         _f4: S<(u64, u64)>,
-    │              ^^^^^^^^^^^^^ Invalid type argument
-    ·
- 21 │         _f4: S<(u64, u64)>,
-    │                ---------- Expected a single non-reference type, but found: '(u64, u64)'
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/instantiate_signatures.move:37:9
+   │
+37 │         id<S<R>>(abort 0);
+   │         ^^^^^^^^^^^^^^^^^
+   │         │  │ │
+   │         │  │ The type '0x42::M::S<0x42::M::R>' can have the ability 'drop' but the type argument '0x42::M::R' does not have the required ability 'drop'
+   │         │  The type '0x42::M::S<0x42::M::R>' does not have the ability 'drop'
+   │         Cannot ignore values without the 'drop' ability. The value must be used
 
-error: 
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/instantiate_signatures.move:37:12
+   │
+ 3 │     struct S<T: drop> has drop {}
+   │                 ---- 'drop' constraint declared here
+ 4 │     struct R {}
+   │            - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+37 │         id<S<R>>(abort 0);
+   │            ^^^^
+   │            │ │
+   │            │ The type '0x42::M::R' does not have the ability 'drop'
+   │            'drop' constraint not satisifed
 
-    ┌── tests/move_check/typing/instantiate_signatures.move:23:9 ───
-    │
- 23 │         S<R>,
-    │         ^^^^ 'drop' constraint not satisifed
-    ·
- 23 │         S<R>,
-    │           - The type '0x42::M::R' does not have the ability 'drop'
-    ·
-  4 │     struct R {}
-    │            - To satisfy the constraint, the 'drop' ability would need to be added here
-    ·
-  3 │     struct S<T: drop> has drop {}
-    │                 ---- 'drop' constraint declared here
-    │
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/instantiate_signatures.move:38:12
+   │
+38 │         id<S<&u64>>(abort 0);
+   │            ^^^^^^^
+   │            │ │
+   │            │ Expected a single non-reference type, but found: '&u64'
+   │            Invalid type argument
 
-error: 
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/instantiate_signatures.move:39:9
+   │
+39 │         id<&(&u64)>(abort 0);
+   │         ^^^^^^^^^^^^^^^^^^^^
+   │         │  │
+   │         │  Expected a single non-reference type, but found: '&&u64'
+   │         Invalid type argument
 
-    ┌── tests/move_check/typing/instantiate_signatures.move:24:9 ───
-    │
- 24 │         S<&u64>,
-    │         ^^^^^^^ Invalid type argument
-    ·
- 24 │         S<&u64>,
-    │           ---- Expected a single non-reference type, but found: '&u64'
-    │
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/instantiate_signatures.move:39:12
+   │
+39 │         id<&(&u64)>(abort 0);
+   │            ^^^^^^^
+   │            ││
+   │            │Expected a single non-reference type, but found: '&u64'
+   │            Invalid reference type
 
-error: 
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/instantiate_signatures.move:40:12
+   │
+40 │         id<S<(u64, u64)>>(abort 0);
+   │            ^^^^^^^^^^^^^
+   │            │ │
+   │            │ Expected a single non-reference type, but found: '(u64, u64)'
+   │            Invalid type argument
 
-    ┌── tests/move_check/typing/instantiate_signatures.move:25:9 ───
-    │
- 25 │         &(&u64),
-    │         ^^^^^^^ Invalid reference type
-    ·
- 25 │         &(&u64),
-    │          ------ Expected a single non-reference type, but found: '&u64'
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/instantiate_signatures.move:42:9
+   │
+ 3 │     struct S<T: drop> has drop {}
+   │                 ---- 'drop' constraint declared here
+   ·
+42 │         S<S<R>> {};
+   │         ^^^^^^^^^^
+   │         │ │ │
+   │         │ │ The type '0x42::M::S<0x42::M::R>' can have the ability 'drop' but the type argument '0x42::M::R' does not have the required ability 'drop'
+   │         │ The type '0x42::M::S<0x42::M::R>' does not have the ability 'drop'
+   │         'drop' constraint not satisifed
 
-error: 
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/instantiate_signatures.move:42:9
+   │
+42 │         S<S<R>> {};
+   │         ^^^^^^^^^^
+   │         │ │
+   │         │ The type '0x42::M::S<0x42::M::S<0x42::M::R>>' can have the ability 'drop' but the type argument '0x42::M::S<0x42::M::R>' does not have the required ability 'drop'
+   │         Cannot ignore values without the 'drop' ability. The value must be used
+   │         The type '0x42::M::S<0x42::M::S<0x42::M::R>>' does not have the ability 'drop'
 
-    ┌── tests/move_check/typing/instantiate_signatures.move:26:9 ───
-    │
- 26 │         S<(u64, u64)>,
-    │         ^^^^^^^^^^^^^ Invalid type argument
-    ·
- 26 │         S<(u64, u64)>,
-    │           ---------- Expected a single non-reference type, but found: '(u64, u64)'
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/instantiate_signatures.move:42:11
+   │
+ 3 │     struct S<T: drop> has drop {}
+   │                 ---- 'drop' constraint declared here
+ 4 │     struct R {}
+   │            - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+42 │         S<S<R>> {};
+   │           ^^^^
+   │           │ │
+   │           │ The type '0x42::M::R' does not have the ability 'drop'
+   │           'drop' constraint not satisifed
 
-error: 
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/instantiate_signatures.move:43:11
+   │
+43 │         S<S<&u64>> {};
+   │           ^^^^^^^
+   │           │ │
+   │           │ Expected a single non-reference type, but found: '&u64'
+   │           Invalid type argument
 
-    ┌── tests/move_check/typing/instantiate_signatures.move:32:17 ───
-    │
- 32 │         let f1: S<R> = abort 0;
-    │                 ^^^^ 'drop' constraint not satisifed
-    ·
- 32 │         let f1: S<R> = abort 0;
-    │                   - The type '0x42::M::R' does not have the ability 'drop'
-    ·
-  4 │     struct R {}
-    │            - To satisfy the constraint, the 'drop' ability would need to be added here
-    ·
-  3 │     struct S<T: drop> has drop {}
-    │                 ---- 'drop' constraint declared here
-    │
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/instantiate_signatures.move:44:9
+   │
+44 │         S<&(&u64)> {};
+   │         ^^^^^^^^^^^^^
+   │         │ │
+   │         │ Expected a single non-reference type, but found: '&&u64'
+   │         Invalid type argument
 
-error: 
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/instantiate_signatures.move:44:11
+   │
+44 │         S<&(&u64)> {};
+   │           ^^^^^^^
+   │           ││
+   │           │Expected a single non-reference type, but found: '&u64'
+   │           Invalid reference type
 
-    ┌── tests/move_check/typing/instantiate_signatures.move:33:17 ───
-    │
- 33 │         let f2: S<&u64> = abort 0;
-    │                 ^^^^^^^ Invalid type argument
-    ·
- 33 │         let f2: S<&u64> = abort 0;
-    │                   ---- Expected a single non-reference type, but found: '&u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/instantiate_signatures.move:34:17 ───
-    │
- 34 │         let f3: &(&u64) = abort 0;
-    │                 ^^^^^^^ Invalid reference type
-    ·
- 34 │         let f3: &(&u64) = abort 0;
-    │                  ------ Expected a single non-reference type, but found: '&u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/instantiate_signatures.move:35:17 ───
-    │
- 35 │         let f4: S<(u64, u64)> = abort 0;
-    │                 ^^^^^^^^^^^^^ Invalid type argument
-    ·
- 35 │         let f4: S<(u64, u64)> = abort 0;
-    │                   ---------- Expected a single non-reference type, but found: '(u64, u64)'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/instantiate_signatures.move:37:9 ───
-    │
- 37 │         id<S<R>>(abort 0);
-    │         ^^^^^^^^^^^^^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
-    ·
- 37 │         id<S<R>>(abort 0);
-    │            ---- The type '0x42::M::S<0x42::M::R>' does not have the ability 'drop'
-    ·
- 37 │         id<S<R>>(abort 0);
-    │              - The type '0x42::M::S<0x42::M::R>' can have the ability 'drop' but the type argument '0x42::M::R' does not have the required ability 'drop'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/instantiate_signatures.move:37:12 ───
-    │
- 37 │         id<S<R>>(abort 0);
-    │            ^^^^ 'drop' constraint not satisifed
-    ·
- 37 │         id<S<R>>(abort 0);
-    │              - The type '0x42::M::R' does not have the ability 'drop'
-    ·
-  4 │     struct R {}
-    │            - To satisfy the constraint, the 'drop' ability would need to be added here
-    ·
-  3 │     struct S<T: drop> has drop {}
-    │                 ---- 'drop' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/instantiate_signatures.move:38:12 ───
-    │
- 38 │         id<S<&u64>>(abort 0);
-    │            ^^^^^^^ Invalid type argument
-    ·
- 38 │         id<S<&u64>>(abort 0);
-    │              ---- Expected a single non-reference type, but found: '&u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/instantiate_signatures.move:39:9 ───
-    │
- 39 │         id<&(&u64)>(abort 0);
-    │         ^^^^^^^^^^^^^^^^^^^^ Invalid type argument
-    ·
- 39 │         id<&(&u64)>(abort 0);
-    │            ------- Expected a single non-reference type, but found: '&&u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/instantiate_signatures.move:39:12 ───
-    │
- 39 │         id<&(&u64)>(abort 0);
-    │            ^^^^^^^ Invalid reference type
-    ·
- 39 │         id<&(&u64)>(abort 0);
-    │             ------ Expected a single non-reference type, but found: '&u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/instantiate_signatures.move:40:12 ───
-    │
- 40 │         id<S<(u64, u64)>>(abort 0);
-    │            ^^^^^^^^^^^^^ Invalid type argument
-    ·
- 40 │         id<S<(u64, u64)>>(abort 0);
-    │              ---------- Expected a single non-reference type, but found: '(u64, u64)'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/instantiate_signatures.move:42:9 ───
-    │
- 42 │         S<S<R>> {};
-    │         ^^^^^^^^^^ 'drop' constraint not satisifed
-    ·
- 42 │         S<S<R>> {};
-    │           ---- The type '0x42::M::S<0x42::M::R>' does not have the ability 'drop'
-    ·
- 42 │         S<S<R>> {};
-    │             - The type '0x42::M::S<0x42::M::R>' can have the ability 'drop' but the type argument '0x42::M::R' does not have the required ability 'drop'
-    ·
-  3 │     struct S<T: drop> has drop {}
-    │                 ---- 'drop' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/instantiate_signatures.move:42:9 ───
-    │
- 42 │         S<S<R>> {};
-    │         ^^^^^^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
-    ·
- 42 │         S<S<R>> {};
-    │         ---------- The type '0x42::M::S<0x42::M::S<0x42::M::R>>' does not have the ability 'drop'
-    ·
- 42 │         S<S<R>> {};
-    │           ---- The type '0x42::M::S<0x42::M::S<0x42::M::R>>' can have the ability 'drop' but the type argument '0x42::M::S<0x42::M::R>' does not have the required ability 'drop'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/instantiate_signatures.move:42:11 ───
-    │
- 42 │         S<S<R>> {};
-    │           ^^^^ 'drop' constraint not satisifed
-    ·
- 42 │         S<S<R>> {};
-    │             - The type '0x42::M::R' does not have the ability 'drop'
-    ·
-  4 │     struct R {}
-    │            - To satisfy the constraint, the 'drop' ability would need to be added here
-    ·
-  3 │     struct S<T: drop> has drop {}
-    │                 ---- 'drop' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/instantiate_signatures.move:43:11 ───
-    │
- 43 │         S<S<&u64>> {};
-    │           ^^^^^^^ Invalid type argument
-    ·
- 43 │         S<S<&u64>> {};
-    │             ---- Expected a single non-reference type, but found: '&u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/instantiate_signatures.move:44:9 ───
-    │
- 44 │         S<&(&u64)> {};
-    │         ^^^^^^^^^^^^^ Invalid type argument
-    ·
- 44 │         S<&(&u64)> {};
-    │           ------- Expected a single non-reference type, but found: '&&u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/instantiate_signatures.move:44:11 ───
-    │
- 44 │         S<&(&u64)> {};
-    │           ^^^^^^^ Invalid reference type
-    ·
- 44 │         S<&(&u64)> {};
-    │            ------ Expected a single non-reference type, but found: '&u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/instantiate_signatures.move:45:11 ───
-    │
- 45 │         S<S<(u64, u64)>> {};
-    │           ^^^^^^^^^^^^^ Invalid type argument
-    ·
- 45 │         S<S<(u64, u64)>> {};
-    │             ---------- Expected a single non-reference type, but found: '(u64, u64)'
-    │
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/instantiate_signatures.move:45:11
+   │
+45 │         S<S<(u64, u64)>> {};
+   │           ^^^^^^^^^^^^^
+   │           │ │
+   │           │ Expected a single non-reference type, but found: '(u64, u64)'
+   │           Invalid type argument
 

--- a/language/move-lang/tests/move_check/typing/invalid_type_acquire.exp
+++ b/language/move-lang/tests/move_check/typing/invalid_type_acquire.exp
@@ -28,6 +28,111 @@ error[E02011]: invalid 'acquires' item
 21 │         S,
    │         ^ Invalid acquires item. Expected a struct with the 'key' ability.
 
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/invalid_type_acquire.move:32:26
+   │
+32 │         destroy(account, move_from<u64>(a));
+   │                          ^^^^^^^^^^^^^^^^^
+   │                          │         │
+   │                          │         The type 'u64' does not have the ability 'key'
+   │                          Invalid call of 'move_from'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/invalid_type_acquire.move:34:26
+   │
+10 │     struct S has store {}
+   │            - To satisfy the constraint, the 'key' ability would need to be added here
+   ·
+34 │         destroy(account, move_from<S>(a));
+   │                          ^^^^^^^^^^^^^^^
+   │                          │         │
+   │                          │         The type '0x2::M::S' does not have the ability 'key'
+   │                          Invalid call of 'move_from'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/invalid_type_acquire.move:38:9
+   │
+38 │         borrow_global<u64>(a);
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │         │             │
+   │         │             The type 'u64' does not have the ability 'key'
+   │         Invalid call of 'borrow_global'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/invalid_type_acquire.move:40:9
+   │
+10 │     struct S has store {}
+   │            - To satisfy the constraint, the 'key' ability would need to be added here
+   ·
+40 │         borrow_global<S>(a);
+   │         ^^^^^^^^^^^^^^^^^^^
+   │         │             │
+   │         │             The type '0x2::M::S' does not have the ability 'key'
+   │         Invalid call of 'borrow_global'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/invalid_type_acquire.move:44:9
+   │
+44 │         borrow_global_mut<u64>(a);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │                 │
+   │         │                 The type 'u64' does not have the ability 'key'
+   │         Invalid call of 'borrow_global_mut'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/invalid_type_acquire.move:46:9
+   │
+10 │     struct S has store {}
+   │            - To satisfy the constraint, the 'key' ability would need to be added here
+   ·
+46 │         borrow_global_mut<S>(a);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^
+   │         │                 │
+   │         │                 The type '0x2::M::S' does not have the ability 'key'
+   │         Invalid call of 'borrow_global_mut'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/invalid_type_acquire.move:50:9
+   │
+50 │         exists<u64>(a);
+   │         ^^^^^^^^^^^^^^
+   │         │      │
+   │         │      The type 'u64' does not have the ability 'key'
+   │         Invalid call of 'exists'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/invalid_type_acquire.move:52:9
+   │
+10 │     struct S has store {}
+   │            - To satisfy the constraint, the 'key' ability would need to be added here
+   ·
+52 │         exists<S>(a);
+   │         ^^^^^^^^^^^^
+   │         │      │
+   │         │      The type '0x2::M::S' does not have the ability 'key'
+   │         Invalid call of 'exists'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/invalid_type_acquire.move:56:9
+   │
+56 │         move_to<u64>(account, any());
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │       │
+   │         │       The type 'u64' does not have the ability 'key'
+   │         Invalid call of 'move_to'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/invalid_type_acquire.move:58:9
+   │
+10 │     struct S has store {}
+   │            - To satisfy the constraint, the 'key' ability would need to be added here
+   ·
+58 │         move_to<S>(account, any());
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │       │
+   │         │       The type '0x2::M::S' does not have the ability 'key'
+   │         Invalid call of 'move_to'
+
 error: 
 
     ┌── tests/move_check/typing/invalid_type_acquire.move:30:9 ───
@@ -57,17 +162,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/invalid_type_acquire.move:32:26 ───
-    │
- 32 │         destroy(account, move_from<u64>(a));
-    │                          ^^^^^^^^^^^^^^^^^ Invalid call of 'move_from'
-    ·
- 32 │         destroy(account, move_from<u64>(a));
-    │                                    --- The type 'u64' does not have the ability 'key'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/invalid_type_acquire.move:33:26 ───
     │
  33 │         destroy(account, move_from<X::R>(a));
@@ -75,20 +169,6 @@ error:
     ·
  33 │         destroy(account, move_from<X::R>(a));
     │                                    ---- The type '0x2::X::R' was not declared in the current module. Global storage access is internal to the module'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/invalid_type_acquire.move:34:26 ───
-    │
- 34 │         destroy(account, move_from<S>(a));
-    │                          ^^^^^^^^^^^^^^^ Invalid call of 'move_from'
-    ·
- 34 │         destroy(account, move_from<S>(a));
-    │                                    - The type '0x2::M::S' does not have the ability 'key'
-    ·
- 10 │     struct S has store {}
-    │            - To satisfy the constraint, the 'key' ability would need to be added here
     │
 
 error: 
@@ -123,17 +203,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/invalid_type_acquire.move:38:9 ───
-    │
- 38 │         borrow_global<u64>(a);
-    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'borrow_global'
-    ·
- 38 │         borrow_global<u64>(a);
-    │                       --- The type 'u64' does not have the ability 'key'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/invalid_type_acquire.move:39:9 ───
     │
  39 │         borrow_global<X::R>(a);
@@ -141,20 +210,6 @@ error:
     ·
  39 │         borrow_global<X::R>(a);
     │                       ---- The type '0x2::X::R' was not declared in the current module. Global storage access is internal to the module'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/invalid_type_acquire.move:40:9 ───
-    │
- 40 │         borrow_global<S>(a);
-    │         ^^^^^^^^^^^^^^^^^^^ Invalid call of 'borrow_global'
-    ·
- 40 │         borrow_global<S>(a);
-    │                       - The type '0x2::M::S' does not have the ability 'key'
-    ·
- 10 │     struct S has store {}
-    │            - To satisfy the constraint, the 'key' ability would need to be added here
     │
 
 error: 
@@ -189,17 +244,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/invalid_type_acquire.move:44:9 ───
-    │
- 44 │         borrow_global_mut<u64>(a);
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'borrow_global_mut'
-    ·
- 44 │         borrow_global_mut<u64>(a);
-    │                           --- The type 'u64' does not have the ability 'key'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/invalid_type_acquire.move:45:9 ───
     │
  45 │         borrow_global_mut<X::R>(a);
@@ -207,20 +251,6 @@ error:
     ·
  45 │         borrow_global_mut<X::R>(a);
     │                           ---- The type '0x2::X::R' was not declared in the current module. Global storage access is internal to the module'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/invalid_type_acquire.move:46:9 ───
-    │
- 46 │         borrow_global_mut<S>(a);
-    │         ^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'borrow_global_mut'
-    ·
- 46 │         borrow_global_mut<S>(a);
-    │                           - The type '0x2::M::S' does not have the ability 'key'
-    ·
- 10 │     struct S has store {}
-    │            - To satisfy the constraint, the 'key' ability would need to be added here
     │
 
 error: 
@@ -255,17 +285,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/invalid_type_acquire.move:50:9 ───
-    │
- 50 │         exists<u64>(a);
-    │         ^^^^^^^^^^^^^^ Invalid call of 'exists'
-    ·
- 50 │         exists<u64>(a);
-    │                --- The type 'u64' does not have the ability 'key'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/invalid_type_acquire.move:51:9 ───
     │
  51 │         exists<X::R>(a);
@@ -273,20 +292,6 @@ error:
     ·
  51 │         exists<X::R>(a);
     │                ---- The type '0x2::X::R' was not declared in the current module. Global storage access is internal to the module'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/invalid_type_acquire.move:52:9 ───
-    │
- 52 │         exists<S>(a);
-    │         ^^^^^^^^^^^^ Invalid call of 'exists'
-    ·
- 52 │         exists<S>(a);
-    │                - The type '0x2::M::S' does not have the ability 'key'
-    ·
- 10 │     struct S has store {}
-    │            - To satisfy the constraint, the 'key' ability would need to be added here
     │
 
 error: 
@@ -318,17 +323,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/invalid_type_acquire.move:56:9 ───
-    │
- 56 │         move_to<u64>(account, any());
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_to'
-    ·
- 56 │         move_to<u64>(account, any());
-    │                 --- The type 'u64' does not have the ability 'key'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/invalid_type_acquire.move:57:9 ───
     │
  57 │         move_to<X::R>(account, any());
@@ -336,19 +330,5 @@ error:
     ·
  57 │         move_to<X::R>(account, any());
     │                 ---- The type '0x2::X::R' was not declared in the current module. Global storage access is internal to the module'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/invalid_type_acquire.move:58:9 ───
-    │
- 58 │         move_to<S>(account, any());
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_to'
-    ·
- 58 │         move_to<S>(account, any());
-    │                 - The type '0x2::M::S' does not have the ability 'key'
-    ·
- 10 │     struct S has store {}
-    │            - To satisfy the constraint, the 'key' ability would need to be added here
     │
 

--- a/language/move-lang/tests/move_check/typing/loop_result_type_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/loop_result_type_invalid.exp
@@ -1,3 +1,11 @@
+error[E04005]: expected a single type
+   ┌─ tests/move_check/typing/loop_result_type_invalid.move:25:13
+   │
+25 │         let x = loop { break };
+   │             ^   -------------- Expected a single type, but found expression list type: '()'
+   │             │    
+   │             Invalid type for local
+
 error: 
 
     ┌── tests/move_check/typing/loop_result_type_invalid.move:11:9 ───
@@ -38,17 +46,6 @@ error:
     ·
  22 │     fun foo(x: u64) {}
     │                --- Is not compatible with: 'u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/loop_result_type_invalid.move:25:13 ───
-    │
- 25 │         let x = loop { break };
-    │             ^ Invalid type for local
-    ·
- 25 │         let x = loop { break };
-    │                 -------------- Expected a single type, but found expression list type: '()'
     │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/main_call_visibility_friend.exp
+++ b/language/move-lang/tests/move_check/typing/main_call_visibility_friend.exp
@@ -1,11 +1,9 @@
-error: 
-
-   ┌── tests/move_check/typing/main_call_visibility_friend.move:9:5 ───
-   │
- 9 │     0x2::X::foo()
-   │     ^^^^^^^^^^^^^ Invalid call to '0x2::X::foo'
-   ·
- 3 │     public(friend) fun foo() {}
-   │     -------------- This function can only be called from a 'friend' of module '0x2::X'
-   │
+error[E04001]: restricted visibility
+  ┌─ tests/move_check/typing/main_call_visibility_friend.move:9:5
+  │
+3 │     public(friend) fun foo() {}
+  │     -------------- This function can only be called from a 'friend' of module '0x2::X'
+  ·
+9 │     0x2::X::foo()
+  │     ^^^^^^^^^^^^^ Invalid call to '0x2::X::foo'
 

--- a/language/move-lang/tests/move_check/typing/module_call.exp
+++ b/language/move-lang/tests/move_check/typing/module_call.exp
@@ -1,3 +1,57 @@
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/module_call.move:43:26
+   │
+ 5 │     public fun bar(x: u64): (address, u64) {
+   │                             -------------- Expected a single non-reference type, but found: '(address, u64)'
+   ·
+43 │         let () = X::bing(X::baz(X::bar(X::foo())));
+   │                          ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid type argument
+
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/module_call.move:44:27
+   │
+ 5 │     public fun bar(x: u64): (address, u64) {
+   │                             -------------- Expected a single non-reference type, but found: '(address, u64)'
+   ·
+44 │         let () = X::bing (X::baz (X::bar (X::foo())));
+   │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid type argument
+
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/module_call.move:45:27
+   │
+ 5 │     public fun bar(x: u64): (address, u64) {
+   │                             -------------- Expected a single non-reference type, but found: '(address, u64)'
+   ·
+45 │         let () = X::bing (X::baz (X::bar(1)));
+   │                           ^^^^^^^^^^^^^^^^^^ Invalid type argument
+
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/module_call.move:51:23
+   │
+19 │     fun bar(x: u64): (address, u64) {
+   │                      -------------- Expected a single non-reference type, but found: '(address, u64)'
+   ·
+51 │         let () = bing(baz(bar(foo())));
+   │                       ^^^^^^^^^^^^^^^ Invalid type argument
+
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/module_call.move:52:24
+   │
+19 │     fun bar(x: u64): (address, u64) {
+   │                      -------------- Expected a single non-reference type, but found: '(address, u64)'
+   ·
+52 │         let () = bing (baz (bar (foo())));
+   │                        ^^^^^^^^^^^^^^^^^ Invalid type argument
+
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/module_call.move:53:24
+   │
+19 │     fun bar(x: u64): (address, u64) {
+   │                      -------------- Expected a single non-reference type, but found: '(address, u64)'
+   ·
+53 │         let () = bing (baz (bar(1)));
+   │                        ^^^^^^^^^^^^ Invalid type argument
+
 error: 
 
     ┌── tests/move_check/typing/module_call.move:43:18 ───
@@ -32,17 +86,6 @@ error:
     ·
  43 │         let () = X::bing(X::baz(X::bar(X::foo())));
     │                                ------------------ Found 1 argument(s) here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call.move:43:26 ───
-    │
- 43 │         let () = X::bing(X::baz(X::bar(X::foo())));
-    │                          ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid type argument
-    ·
-  5 │     public fun bar(x: u64): (address, u64) {
-    │                             -------------- Expected a single non-reference type, but found: '(address, u64)'
     │
 
 error: 
@@ -83,17 +126,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/module_call.move:44:27 ───
-    │
- 44 │         let () = X::bing (X::baz (X::bar (X::foo())));
-    │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid type argument
-    ·
-  5 │     public fun bar(x: u64): (address, u64) {
-    │                             -------------- Expected a single non-reference type, but found: '(address, u64)'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/module_call.move:45:18 ───
     │
  45 │         let () = X::bing (X::baz (X::bar(1)));
@@ -126,17 +158,6 @@ error:
     ·
  45 │         let () = X::bing (X::baz (X::bar(1)));
     │                                  ----------- Found 1 argument(s) here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call.move:45:27 ───
-    │
- 45 │         let () = X::bing (X::baz (X::bar(1)));
-    │                           ^^^^^^^^^^^^^^^^^^ Invalid type argument
-    ·
-  5 │     public fun bar(x: u64): (address, u64) {
-    │                             -------------- Expected a single non-reference type, but found: '(address, u64)'
     │
 
 error: 
@@ -202,17 +223,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/module_call.move:51:23 ───
-    │
- 51 │         let () = bing(baz(bar(foo())));
-    │                       ^^^^^^^^^^^^^^^ Invalid type argument
-    ·
- 19 │     fun bar(x: u64): (address, u64) {
-    │                      -------------- Expected a single non-reference type, but found: '(address, u64)'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/module_call.move:52:18 ───
     │
  52 │         let () = bing (baz (bar (foo())));
@@ -249,17 +259,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/module_call.move:52:24 ───
-    │
- 52 │         let () = bing (baz (bar (foo())));
-    │                        ^^^^^^^^^^^^^^^^^ Invalid type argument
-    ·
- 19 │     fun bar(x: u64): (address, u64) {
-    │                      -------------- Expected a single non-reference type, but found: '(address, u64)'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/module_call.move:53:18 ───
     │
  53 │         let () = bing (baz (bar(1)));
@@ -292,17 +291,6 @@ error:
     ·
  53 │         let () = bing (baz (bar(1)));
     │                            -------- Found 1 argument(s) here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call.move:53:24 ───
-    │
- 53 │         let () = bing (baz (bar(1)));
-    │                        ^^^^^^^^^^^^ Invalid type argument
-    ·
- 19 │     fun bar(x: u64): (address, u64) {
-    │                      -------------- Expected a single non-reference type, but found: '(address, u64)'
     │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/module_call_complicated_rhs.exp
+++ b/language/move-lang/tests/move_check/typing/module_call_complicated_rhs.exp
@@ -1,3 +1,57 @@
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/module_call_complicated_rhs.move:13:9
+   │
+13 │         baz (if (cond) (false, @0x0) else (true, @0x1));
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │                                 │
+   │         │                                 Expected a single non-reference type, but found: '(bool, address)'
+   │         Invalid type argument
+
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/module_call_complicated_rhs.move:19:9
+   │
+19 │         baz(if (cond) (false, @0x0) else (true, @0x1));
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │                                │
+   │         │                                Expected a single non-reference type, but found: '(bool, address)'
+   │         Invalid type argument
+
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/module_call_complicated_rhs.move:31:9
+   │
+31 │         baz({ (a, x) });
+   │         ^^^^^^^^^^^^^^^
+   │         │     │
+   │         │     Expected a single non-reference type, but found: '(address, u64)'
+   │         Invalid type argument
+
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/module_call_complicated_rhs.move:32:9
+   │
+32 │         baz({ let a = false; (a, x) });
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │                    │
+   │         │                    Expected a single non-reference type, but found: '(bool, u64)'
+   │         Invalid type argument
+
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/module_call_complicated_rhs.move:44:9
+   │
+44 │         baz({ (a, x) });
+   │         ^^^^^^^^^^^^^^^
+   │         │     │
+   │         │     Expected a single non-reference type, but found: '(address, u64)'
+   │         Invalid type argument
+
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/module_call_complicated_rhs.move:45:9
+   │
+45 │         baz({ let a = false; (a, x) });
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │                    │
+   │         │                    Expected a single non-reference type, but found: '(bool, u64)'
+   │         Invalid type argument
+
 error: 
 
     ┌── tests/move_check/typing/module_call_complicated_rhs.move:11:9 ───
@@ -22,17 +76,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_complicated_rhs.move:13:9 ───
-    │
- 13 │         baz (if (cond) (false, @0x0) else (true, @0x1));
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid type argument
-    ·
- 13 │         baz (if (cond) (false, @0x0) else (true, @0x1));
-    │                                           ------------ Expected a single non-reference type, but found: '(bool, address)'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/module_call_complicated_rhs.move:17:9 ───
     │
  17 │         foo(if (cond) () else ());
@@ -51,17 +94,6 @@ error:
     ·
  19 │         baz(if (cond) (false, @0x0) else (true, @0x1));
     │            ------------------------------------------- Found 1 argument(s) here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_complicated_rhs.move:19:9 ───
-    │
- 19 │         baz(if (cond) (false, @0x0) else (true, @0x1));
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid type argument
-    ·
- 19 │         baz(if (cond) (false, @0x0) else (true, @0x1));
-    │                                          ------------ Expected a single non-reference type, but found: '(bool, address)'
     │
 
 error: 
@@ -99,17 +131,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_complicated_rhs.move:31:9 ───
-    │
- 31 │         baz({ (a, x) });
-    │         ^^^^^^^^^^^^^^^ Invalid type argument
-    ·
- 31 │         baz({ (a, x) });
-    │               ------ Expected a single non-reference type, but found: '(address, u64)'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/module_call_complicated_rhs.move:32:9 ───
     │
  32 │         baz({ let a = false; (a, x) });
@@ -117,17 +138,6 @@ error:
     ·
  32 │         baz({ let a = false; (a, x) });
     │            --------------------------- Found 1 argument(s) here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_complicated_rhs.move:32:9 ───
-    │
- 32 │         baz({ let a = false; (a, x) });
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid type argument
-    ·
- 32 │         baz({ let a = false; (a, x) });
-    │                              ------ Expected a single non-reference type, but found: '(bool, u64)'
     │
 
 error: 
@@ -165,17 +175,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_complicated_rhs.move:44:9 ───
-    │
- 44 │         baz({ (a, x) });
-    │         ^^^^^^^^^^^^^^^ Invalid type argument
-    ·
- 44 │         baz({ (a, x) });
-    │               ------ Expected a single non-reference type, but found: '(address, u64)'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/module_call_complicated_rhs.move:45:9 ───
     │
  45 │         baz({ let a = false; (a, x) });
@@ -183,16 +182,5 @@ error:
     ·
  45 │         baz({ let a = false; (a, x) });
     │            --------------------------- Found 1 argument(s) here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_complicated_rhs.move:45:9 ───
-    │
- 45 │         baz({ let a = false; (a, x) });
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid type argument
-    ·
- 45 │         baz({ let a = false; (a, x) });
-    │                              ------ Expected a single non-reference type, but found: '(bool, u64)'
     │
 

--- a/language/move-lang/tests/move_check/typing/module_call_constraints_not_satisfied.exp
+++ b/language/move-lang/tests/move_check/typing/module_call_constraints_not_satisfied.exp
@@ -1,354 +1,282 @@
-error: 
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:21:9
+   │
+ 2 │     struct S has copy, drop {}
+   │            - To satisfy the constraint, the 'key' ability would need to be added here
+   ·
+ 7 │     fun both<R: key, C: copy>(r: R, c: C) {
+   │                 --- 'key' constraint declared here
+   ·
+21 │         both(S{}, Coin{});
+   │         ^^^^^^^^^^^^^^^^^
+   │         │    │
+   │         │    The type '0x8675309::M::S' does not have the ability 'key'
+   │         'key' constraint not satisifed
 
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:21:9 ───
-    │
- 21 │         both(S{}, Coin{});
-    │         ^^^^^^^^^^^^^^^^^ 'key' constraint not satisifed
-    ·
- 21 │         both(S{}, Coin{});
-    │              --- The type '0x8675309::M::S' does not have the ability 'key'
-    ·
-  2 │     struct S has copy, drop {}
-    │            - To satisfy the constraint, the 'key' ability would need to be added here
-    ·
-  7 │     fun both<R: key, C: copy>(r: R, c: C) {
-    │                 --- 'key' constraint declared here
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:21:9
+   │
+ 3 │     struct Coin has key {}
+   │            ---- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+ 7 │     fun both<R: key, C: copy>(r: R, c: C) {
+   │                         ---- 'copy' constraint declared here
+   ·
+21 │         both(S{}, Coin{});
+   │         ^^^^^^^^^^^^^^^^^
+   │         │         │
+   │         │         The type '0x8675309::M::Coin' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
 
-error: 
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:22:9
+   │
+ 7 │     fun both<R: key, C: copy>(r: R, c: C) {
+   │                 --- 'key' constraint declared here
+   ·
+22 │         both(0, Coin{})
+   │         ^^^^^^^^^^^^^^^
+   │         │    │
+   │         │    The type 'u64' does not have the ability 'key'
+   │         'key' constraint not satisifed
 
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:21:9 ───
-    │
- 21 │         both(S{}, Coin{});
-    │         ^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 21 │         both(S{}, Coin{});
-    │                   ------ The type '0x8675309::M::Coin' does not have the ability 'copy'
-    ·
-  3 │     struct Coin has key {}
-    │            ---- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
-  7 │     fun both<R: key, C: copy>(r: R, c: C) {
-    │                         ---- 'copy' constraint declared here
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:22:9
+   │
+ 3 │     struct Coin has key {}
+   │            ---- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+ 7 │     fun both<R: key, C: copy>(r: R, c: C) {
+   │                         ---- 'copy' constraint declared here
+   ·
+22 │         both(0, Coin{})
+   │         ^^^^^^^^^^^^^^^
+   │         │       │
+   │         │       The type '0x8675309::M::Coin' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
 
-error: 
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:26:9
+   │
+ 4 │     struct Box<T> has copy, drop {}
+   │            --- To satisfy the constraint, the 'key' ability would need to be added here
+   ·
+ 7 │     fun both<R: key, C: copy>(r: R, c: C) {
+   │                 --- 'key' constraint declared here
+   ·
+26 │         both(Box<C> {}, Box<R> {})
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │    │
+   │         │    The type '0x8675309::M::Box<C>' does not have the ability 'key'
+   │         'key' constraint not satisifed
 
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:22:9 ───
-    │
- 22 │         both(0, Coin{})
-    │         ^^^^^^^^^^^^^^^ 'key' constraint not satisifed
-    ·
- 22 │         both(0, Coin{})
-    │              - The type 'u64' does not have the ability 'key'
-    ·
-  7 │     fun both<R: key, C: copy>(r: R, c: C) {
-    │                 --- 'key' constraint declared here
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:26:9
+   │
+ 7 │     fun both<R: key, C: copy>(r: R, c: C) {
+   │                         ---- 'copy' constraint declared here
+   ·
+26 │         both(Box<C> {}, Box<R> {})
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │               │   │
+   │         │               │   The type '0x8675309::M::Box<R>' can have the ability 'copy' but the type argument 'R' does not have the required ability 'copy'
+   │         │               The type '0x8675309::M::Box<R>' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
 
-error: 
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:30:9
+   │
+ 5 │     struct Box3<T1, T2, T3> has copy, drop {}
+   │            ---- To satisfy the constraint, the 'key' ability would need to be added here
+   ·
+15 │     fun rsrc<R: key>(r: R) {
+   │                 --- 'key' constraint declared here
+   ·
+30 │         rsrc(Box3<C, C, C> {});
+   │         ^^^^^^^^^^^^^^^^^^^^^^
+   │         │    │
+   │         │    The type '0x8675309::M::Box3<C, C, C>' does not have the ability 'key'
+   │         'key' constraint not satisifed
 
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:22:9 ───
-    │
- 22 │         both(0, Coin{})
-    │         ^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 22 │         both(0, Coin{})
-    │                 ------ The type '0x8675309::M::Coin' does not have the ability 'copy'
-    ·
-  3 │     struct Coin has key {}
-    │            ---- To satisfy the constraint, the 'copy' ability would need to be added here
-    ·
-  7 │     fun both<R: key, C: copy>(r: R, c: C) {
-    │                         ---- 'copy' constraint declared here
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:32:9
+   │
+11 │     fun cpy<C: copy>(c: C) {
+   │                ---- 'copy' constraint declared here
+   ·
+32 │         cpy(Box3<R, C, C> {});
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │         │   │    │
+   │         │   │    The type '0x8675309::M::Box3<R, C, C>' can have the ability 'copy' but the type argument 'R' does not have the required ability 'copy'
+   │         │   The type '0x8675309::M::Box3<R, C, C>' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
 
-error: 
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:33:9
+   │
+11 │     fun cpy<C: copy>(c: C) {
+   │                ---- 'copy' constraint declared here
+   ·
+33 │         cpy(Box3<C, R, C> {});
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │         │   │    │
+   │         │   │    The type '0x8675309::M::Box3<C, R, C>' can have the ability 'copy' but the type argument 'C' does not have the required ability 'copy'
+   │         │   The type '0x8675309::M::Box3<C, R, C>' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
 
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:26:9 ───
-    │
- 26 │         both(Box<C> {}, Box<R> {})
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ 'key' constraint not satisifed
-    ·
- 26 │         both(Box<C> {}, Box<R> {})
-    │              --------- The type '0x8675309::M::Box<C>' does not have the ability 'key'
-    ·
-  4 │     struct Box<T> has copy, drop {}
-    │            --- To satisfy the constraint, the 'key' ability would need to be added here
-    ·
-  7 │     fun both<R: key, C: copy>(r: R, c: C) {
-    │                 --- 'key' constraint declared here
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:34:9
+   │
+11 │     fun cpy<C: copy>(c: C) {
+   │                ---- 'copy' constraint declared here
+   ·
+34 │         cpy(Box3<C, C, R> {});
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │         │   │    │
+   │         │   │    The type '0x8675309::M::Box3<C, C, R>' can have the ability 'copy' but the type argument 'C' does not have the required ability 'copy'
+   │         │   The type '0x8675309::M::Box3<C, C, R>' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
 
-error: 
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:36:9
+   │
+11 │     fun cpy<C: copy>(c: C) {
+   │                ---- 'copy' constraint declared here
+   ·
+36 │         cpy(Box3<C, R, R> {});
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │         │   │    │
+   │         │   │    The type '0x8675309::M::Box3<C, R, R>' can have the ability 'copy' but the type argument 'C' does not have the required ability 'copy'
+   │         │   The type '0x8675309::M::Box3<C, R, R>' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
 
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:26:9 ───
-    │
- 26 │         both(Box<C> {}, Box<R> {})
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 26 │         both(Box<C> {}, Box<R> {})
-    │                         --------- The type '0x8675309::M::Box<R>' does not have the ability 'copy'
-    ·
- 26 │         both(Box<C> {}, Box<R> {})
-    │                             - The type '0x8675309::M::Box<R>' can have the ability 'copy' but the type argument 'R' does not have the required ability 'copy'
-    ·
-  7 │     fun both<R: key, C: copy>(r: R, c: C) {
-    │                         ---- 'copy' constraint declared here
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:37:9
+   │
+11 │     fun cpy<C: copy>(c: C) {
+   │                ---- 'copy' constraint declared here
+   ·
+37 │         cpy(Box3<R, C, R> {});
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │         │   │    │
+   │         │   │    The type '0x8675309::M::Box3<R, C, R>' can have the ability 'copy' but the type argument 'R' does not have the required ability 'copy'
+   │         │   The type '0x8675309::M::Box3<R, C, R>' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
 
-error: 
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:38:9
+   │
+11 │     fun cpy<C: copy>(c: C) {
+   │                ---- 'copy' constraint declared here
+   ·
+38 │         cpy(Box3<R, R, C> {});
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │         │   │    │
+   │         │   │    The type '0x8675309::M::Box3<R, R, C>' can have the ability 'copy' but the type argument 'R' does not have the required ability 'copy'
+   │         │   The type '0x8675309::M::Box3<R, R, C>' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
 
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:30:9 ───
-    │
- 30 │         rsrc(Box3<C, C, C> {});
-    │         ^^^^^^^^^^^^^^^^^^^^^^ 'key' constraint not satisifed
-    ·
- 30 │         rsrc(Box3<C, C, C> {});
-    │              ---------------- The type '0x8675309::M::Box3<C, C, C>' does not have the ability 'key'
-    ·
-  5 │     struct Box3<T1, T2, T3> has copy, drop {}
-    │            ---- To satisfy the constraint, the 'key' ability would need to be added here
-    ·
- 15 │     fun rsrc<R: key>(r: R) {
-    │                 --- 'key' constraint declared here
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:40:9
+   │
+11 │     fun cpy<C: copy>(c: C) {
+   │                ---- 'copy' constraint declared here
+   ·
+40 │         cpy(Box3<R, R, R> {});
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │         │   │    │
+   │         │   │    The type '0x8675309::M::Box3<R, R, R>' can have the ability 'copy' but the type argument 'R' does not have the required ability 'copy'
+   │         │   The type '0x8675309::M::Box3<R, R, R>' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
 
-error: 
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:44:9
+   │
+11 │     fun cpy<C: copy>(c: C) {
+   │                ---- 'copy' constraint declared here
+   ·
+44 │         cpy(Box3<U, C, C> {});
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │         │   │    │
+   │         │   │    The type '0x8675309::M::Box3<U, C, C>' can have the ability 'copy' but the type argument 'U' does not have the required ability 'copy'
+   │         │   The type '0x8675309::M::Box3<U, C, C>' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
 
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:32:9 ───
-    │
- 32 │         cpy(Box3<R, C, C> {});
-    │         ^^^^^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 32 │         cpy(Box3<R, C, C> {});
-    │             ---------------- The type '0x8675309::M::Box3<R, C, C>' does not have the ability 'copy'
-    ·
- 32 │         cpy(Box3<R, C, C> {});
-    │                  - The type '0x8675309::M::Box3<R, C, C>' can have the ability 'copy' but the type argument 'R' does not have the required ability 'copy'
-    ·
- 11 │     fun cpy<C: copy>(c: C) {
-    │                ---- 'copy' constraint declared here
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:45:9
+   │
+11 │     fun cpy<C: copy>(c: C) {
+   │                ---- 'copy' constraint declared here
+   ·
+45 │         cpy(Box3<C, U, C> {});
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │         │   │    │
+   │         │   │    The type '0x8675309::M::Box3<C, U, C>' can have the ability 'copy' but the type argument 'C' does not have the required ability 'copy'
+   │         │   The type '0x8675309::M::Box3<C, U, C>' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
 
-error: 
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:46:9
+   │
+11 │     fun cpy<C: copy>(c: C) {
+   │                ---- 'copy' constraint declared here
+   ·
+46 │         cpy(Box3<C, C, U> {});
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │         │   │    │
+   │         │   │    The type '0x8675309::M::Box3<C, C, U>' can have the ability 'copy' but the type argument 'C' does not have the required ability 'copy'
+   │         │   The type '0x8675309::M::Box3<C, C, U>' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
 
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:33:9 ───
-    │
- 33 │         cpy(Box3<C, R, C> {});
-    │         ^^^^^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 33 │         cpy(Box3<C, R, C> {});
-    │             ---------------- The type '0x8675309::M::Box3<C, R, C>' does not have the ability 'copy'
-    ·
- 33 │         cpy(Box3<C, R, C> {});
-    │                  - The type '0x8675309::M::Box3<C, R, C>' can have the ability 'copy' but the type argument 'C' does not have the required ability 'copy'
-    ·
- 11 │     fun cpy<C: copy>(c: C) {
-    │                ---- 'copy' constraint declared here
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:48:9
+   │
+11 │     fun cpy<C: copy>(c: C) {
+   │                ---- 'copy' constraint declared here
+   ·
+48 │         cpy(Box3<C, U, U> {});
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │         │   │    │
+   │         │   │    The type '0x8675309::M::Box3<C, U, U>' can have the ability 'copy' but the type argument 'C' does not have the required ability 'copy'
+   │         │   The type '0x8675309::M::Box3<C, U, U>' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
 
-error: 
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:49:9
+   │
+11 │     fun cpy<C: copy>(c: C) {
+   │                ---- 'copy' constraint declared here
+   ·
+49 │         cpy(Box3<U, C, U> {});
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │         │   │    │
+   │         │   │    The type '0x8675309::M::Box3<U, C, U>' can have the ability 'copy' but the type argument 'U' does not have the required ability 'copy'
+   │         │   The type '0x8675309::M::Box3<U, C, U>' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
 
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:34:9 ───
-    │
- 34 │         cpy(Box3<C, C, R> {});
-    │         ^^^^^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 34 │         cpy(Box3<C, C, R> {});
-    │             ---------------- The type '0x8675309::M::Box3<C, C, R>' does not have the ability 'copy'
-    ·
- 34 │         cpy(Box3<C, C, R> {});
-    │                  - The type '0x8675309::M::Box3<C, C, R>' can have the ability 'copy' but the type argument 'C' does not have the required ability 'copy'
-    ·
- 11 │     fun cpy<C: copy>(c: C) {
-    │                ---- 'copy' constraint declared here
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:50:9
+   │
+11 │     fun cpy<C: copy>(c: C) {
+   │                ---- 'copy' constraint declared here
+   ·
+50 │         cpy(Box3<U, U, C> {});
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │         │   │    │
+   │         │   │    The type '0x8675309::M::Box3<U, U, C>' can have the ability 'copy' but the type argument 'U' does not have the required ability 'copy'
+   │         │   The type '0x8675309::M::Box3<U, U, C>' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
 
-error: 
-
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:36:9 ───
-    │
- 36 │         cpy(Box3<C, R, R> {});
-    │         ^^^^^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 36 │         cpy(Box3<C, R, R> {});
-    │             ---------------- The type '0x8675309::M::Box3<C, R, R>' does not have the ability 'copy'
-    ·
- 36 │         cpy(Box3<C, R, R> {});
-    │                  - The type '0x8675309::M::Box3<C, R, R>' can have the ability 'copy' but the type argument 'C' does not have the required ability 'copy'
-    ·
- 11 │     fun cpy<C: copy>(c: C) {
-    │                ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:37:9 ───
-    │
- 37 │         cpy(Box3<R, C, R> {});
-    │         ^^^^^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 37 │         cpy(Box3<R, C, R> {});
-    │             ---------------- The type '0x8675309::M::Box3<R, C, R>' does not have the ability 'copy'
-    ·
- 37 │         cpy(Box3<R, C, R> {});
-    │                  - The type '0x8675309::M::Box3<R, C, R>' can have the ability 'copy' but the type argument 'R' does not have the required ability 'copy'
-    ·
- 11 │     fun cpy<C: copy>(c: C) {
-    │                ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:38:9 ───
-    │
- 38 │         cpy(Box3<R, R, C> {});
-    │         ^^^^^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 38 │         cpy(Box3<R, R, C> {});
-    │             ---------------- The type '0x8675309::M::Box3<R, R, C>' does not have the ability 'copy'
-    ·
- 38 │         cpy(Box3<R, R, C> {});
-    │                  - The type '0x8675309::M::Box3<R, R, C>' can have the ability 'copy' but the type argument 'R' does not have the required ability 'copy'
-    ·
- 11 │     fun cpy<C: copy>(c: C) {
-    │                ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:40:9 ───
-    │
- 40 │         cpy(Box3<R, R, R> {});
-    │         ^^^^^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 40 │         cpy(Box3<R, R, R> {});
-    │             ---------------- The type '0x8675309::M::Box3<R, R, R>' does not have the ability 'copy'
-    ·
- 40 │         cpy(Box3<R, R, R> {});
-    │                  - The type '0x8675309::M::Box3<R, R, R>' can have the ability 'copy' but the type argument 'R' does not have the required ability 'copy'
-    ·
- 11 │     fun cpy<C: copy>(c: C) {
-    │                ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:44:9 ───
-    │
- 44 │         cpy(Box3<U, C, C> {});
-    │         ^^^^^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 44 │         cpy(Box3<U, C, C> {});
-    │             ---------------- The type '0x8675309::M::Box3<U, C, C>' does not have the ability 'copy'
-    ·
- 44 │         cpy(Box3<U, C, C> {});
-    │                  - The type '0x8675309::M::Box3<U, C, C>' can have the ability 'copy' but the type argument 'U' does not have the required ability 'copy'
-    ·
- 11 │     fun cpy<C: copy>(c: C) {
-    │                ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:45:9 ───
-    │
- 45 │         cpy(Box3<C, U, C> {});
-    │         ^^^^^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 45 │         cpy(Box3<C, U, C> {});
-    │             ---------------- The type '0x8675309::M::Box3<C, U, C>' does not have the ability 'copy'
-    ·
- 45 │         cpy(Box3<C, U, C> {});
-    │                  - The type '0x8675309::M::Box3<C, U, C>' can have the ability 'copy' but the type argument 'C' does not have the required ability 'copy'
-    ·
- 11 │     fun cpy<C: copy>(c: C) {
-    │                ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:46:9 ───
-    │
- 46 │         cpy(Box3<C, C, U> {});
-    │         ^^^^^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 46 │         cpy(Box3<C, C, U> {});
-    │             ---------------- The type '0x8675309::M::Box3<C, C, U>' does not have the ability 'copy'
-    ·
- 46 │         cpy(Box3<C, C, U> {});
-    │                  - The type '0x8675309::M::Box3<C, C, U>' can have the ability 'copy' but the type argument 'C' does not have the required ability 'copy'
-    ·
- 11 │     fun cpy<C: copy>(c: C) {
-    │                ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:48:9 ───
-    │
- 48 │         cpy(Box3<C, U, U> {});
-    │         ^^^^^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 48 │         cpy(Box3<C, U, U> {});
-    │             ---------------- The type '0x8675309::M::Box3<C, U, U>' does not have the ability 'copy'
-    ·
- 48 │         cpy(Box3<C, U, U> {});
-    │                  - The type '0x8675309::M::Box3<C, U, U>' can have the ability 'copy' but the type argument 'C' does not have the required ability 'copy'
-    ·
- 11 │     fun cpy<C: copy>(c: C) {
-    │                ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:49:9 ───
-    │
- 49 │         cpy(Box3<U, C, U> {});
-    │         ^^^^^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 49 │         cpy(Box3<U, C, U> {});
-    │             ---------------- The type '0x8675309::M::Box3<U, C, U>' does not have the ability 'copy'
-    ·
- 49 │         cpy(Box3<U, C, U> {});
-    │                  - The type '0x8675309::M::Box3<U, C, U>' can have the ability 'copy' but the type argument 'U' does not have the required ability 'copy'
-    ·
- 11 │     fun cpy<C: copy>(c: C) {
-    │                ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:50:9 ───
-    │
- 50 │         cpy(Box3<U, U, C> {});
-    │         ^^^^^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 50 │         cpy(Box3<U, U, C> {});
-    │             ---------------- The type '0x8675309::M::Box3<U, U, C>' does not have the ability 'copy'
-    ·
- 50 │         cpy(Box3<U, U, C> {});
-    │                  - The type '0x8675309::M::Box3<U, U, C>' can have the ability 'copy' but the type argument 'U' does not have the required ability 'copy'
-    ·
- 11 │     fun cpy<C: copy>(c: C) {
-    │                ---- 'copy' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:52:9 ───
-    │
- 52 │         cpy(Box3<U, U, U> {});
-    │         ^^^^^^^^^^^^^^^^^^^^^ 'copy' constraint not satisifed
-    ·
- 52 │         cpy(Box3<U, U, U> {});
-    │             ---------------- The type '0x8675309::M::Box3<U, U, U>' does not have the ability 'copy'
-    ·
- 52 │         cpy(Box3<U, U, U> {});
-    │                  - The type '0x8675309::M::Box3<U, U, U>' can have the ability 'copy' but the type argument 'U' does not have the required ability 'copy'
-    ·
- 11 │     fun cpy<C: copy>(c: C) {
-    │                ---- 'copy' constraint declared here
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:52:9
+   │
+11 │     fun cpy<C: copy>(c: C) {
+   │                ---- 'copy' constraint declared here
+   ·
+52 │         cpy(Box3<U, U, U> {});
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │         │   │    │
+   │         │   │    The type '0x8675309::M::Box3<U, U, U>' can have the ability 'copy' but the type argument 'U' does not have the required ability 'copy'
+   │         │   The type '0x8675309::M::Box3<U, U, U>' does not have the ability 'copy'
+   │         'copy' constraint not satisifed
 

--- a/language/move-lang/tests/move_check/typing/module_call_internal.exp
+++ b/language/move-lang/tests/move_check/typing/module_call_internal.exp
@@ -1,11 +1,9 @@
-error: 
-
-    ┌── tests/move_check/typing/module_call_internal.move:10:9 ───
-    │
- 10 │         X::foo()
-    │         ^^^^^^^^ Invalid call to '0x2::X::foo'
-    ·
-  4 │     fun foo() {}
-    │         --- This function is internal to its module. Only 'public', 'public(script)', and 'public(friend)' functions can be called outside of their module
-    │
+error[E04001]: restricted visibility
+   ┌─ tests/move_check/typing/module_call_internal.move:10:9
+   │
+ 4 │     fun foo() {}
+   │         --- This function is internal to its module. Only 'public', 'public(script)', and 'public(friend)' functions can be called outside of their module
+   ·
+10 │         X::foo()
+   │         ^^^^^^^^ Invalid call to '0x2::X::foo'
 

--- a/language/move-lang/tests/move_check/typing/module_call_visibility_friend_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/module_call_visibility_friend_invalid.exp
@@ -1,33 +1,27 @@
-error: 
+error[E04001]: restricted visibility
+   ┌─ tests/move_check/typing/module_call_visibility_friend_invalid.move:18:49
+   │
+ 5 │     public(friend) fun f_friend() {}
+   │     -------------- This function can only be called from a 'friend' of module '0x2::X'
+   ·
+18 │     public(friend) fun f_friend_call_friend() { X::f_friend() }
+   │                                                 ^^^^^^^^^^^^^ Invalid call to '0x2::X::f_friend'
 
-    ┌── tests/move_check/typing/module_call_visibility_friend_invalid.move:18:49 ───
-    │
- 18 │     public(friend) fun f_friend_call_friend() { X::f_friend() }
-    │                                                 ^^^^^^^^^^^^^ Invalid call to '0x2::X::f_friend'
-    ·
-  5 │     public(friend) fun f_friend() {}
-    │     -------------- This function can only be called from a 'friend' of module '0x2::X'
-    │
+error[E04001]: restricted visibility
+   ┌─ tests/move_check/typing/module_call_visibility_friend_invalid.move:22:52
+   │
+ 4 │     fun f_private() {}
+   │         --------- This function is internal to its module. Only 'public', 'public(script)', and 'public(friend)' functions can be called outside of their module
+   ·
+22 │     public(friend) fun f_friend_call_private_1() { X::f_private() }
+   │                                                    ^^^^^^^^^^^^^^ Invalid call to '0x2::X::f_private'
 
-error: 
-
-    ┌── tests/move_check/typing/module_call_visibility_friend_invalid.move:22:52 ───
-    │
- 22 │     public(friend) fun f_friend_call_private_1() { X::f_private() }
-    │                                                    ^^^^^^^^^^^^^^ Invalid call to '0x2::X::f_private'
-    ·
-  4 │     fun f_private() {}
-    │         --------- This function is internal to its module. Only 'public', 'public(script)', and 'public(friend)' functions can be called outside of their module
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_visibility_friend_invalid.move:23:52 ───
-    │
- 23 │     public(friend) fun f_friend_call_private_2() { Y::f_private() }
-    │                                                    ^^^^^^^^^^^^^^ Invalid call to '0x2::Y::f_private'
-    ·
- 10 │     fun f_private() {}
-    │         --------- This function is internal to its module. Only 'public', 'public(script)', and 'public(friend)' functions can be called outside of their module
-    │
+error[E04001]: restricted visibility
+   ┌─ tests/move_check/typing/module_call_visibility_friend_invalid.move:23:52
+   │
+10 │     fun f_private() {}
+   │         --------- This function is internal to its module. Only 'public', 'public(script)', and 'public(friend)' functions can be called outside of their module
+   ·
+23 │     public(friend) fun f_friend_call_private_2() { Y::f_private() }
+   │                                                    ^^^^^^^^^^^^^^ Invalid call to '0x2::Y::f_private'
 

--- a/language/move-lang/tests/move_check/typing/module_call_visibility_script_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/module_call_visibility_script_invalid.exp
@@ -1,88 +1,72 @@
-error: 
+error[E04002]: requires script context
+   ┌─ tests/move_check/typing/module_call_visibility_script_invalid.move:16:35
+   │
+ 5 │     public(script) fun f_script() {}
+   │     -------------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
+   ·
+16 │     fun f_private_call_script() { X::f_script() }
+   │                                   ^^^^^^^^^^^^^ Invalid call to '0x2::X::f_script'
 
-    ┌── tests/move_check/typing/module_call_visibility_script_invalid.move:16:35 ───
-    │
- 16 │     fun f_private_call_script() { X::f_script() }
-    │                                   ^^^^^^^^^^^^^ Invalid call to '0x2::X::f_script'
-    ·
-  5 │     public(script) fun f_script() {}
-    │     -------------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
-    │
+error[E04002]: requires script context
+   ┌─ tests/move_check/typing/module_call_visibility_script_invalid.move:17:49
+   │
+ 5 │     public(script) fun f_script() {}
+   │     -------------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
+   ·
+17 │     public(friend) fun f_friend_call_script() { X::f_script() }
+   │                                                 ^^^^^^^^^^^^^ Invalid call to '0x2::X::f_script'
 
-error: 
+error[E04002]: requires script context
+   ┌─ tests/move_check/typing/module_call_visibility_script_invalid.move:18:41
+   │
+ 5 │     public(script) fun f_script() {}
+   │     -------------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
+   ·
+18 │     public fun f_public_call_script() { X::f_script() }
+   │                                         ^^^^^^^^^^^^^ Invalid call to '0x2::X::f_script'
 
-    ┌── tests/move_check/typing/module_call_visibility_script_invalid.move:17:49 ───
-    │
- 17 │     public(friend) fun f_friend_call_script() { X::f_script() }
-    │                                                 ^^^^^^^^^^^^^ Invalid call to '0x2::X::f_script'
-    ·
-  5 │     public(script) fun f_script() {}
-    │     -------------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
-    │
+error[E04002]: requires script context
+   ┌─ tests/move_check/typing/module_call_visibility_script_invalid.move:22:40
+   │
+12 │     public(script) fun f_script_call_script() { X::f_script() }
+   │     -------------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
+   ·
+22 │     fun f_private_call_self_script() { f_script_call_script() }
+   │                                        ^^^^^^^^^^^^^^^^^^^^^^ Invalid call to '0x2::M::f_script_call_script'
 
-error: 
+error[E04002]: requires script context
+   ┌─ tests/move_check/typing/module_call_visibility_script_invalid.move:23:54
+   │
+12 │     public(script) fun f_script_call_script() { X::f_script() }
+   │     -------------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
+   ·
+23 │     public(friend) fun f_friend_call_self_script() { f_script_call_script() }
+   │                                                      ^^^^^^^^^^^^^^^^^^^^^^ Invalid call to '0x2::M::f_script_call_script'
 
-    ┌── tests/move_check/typing/module_call_visibility_script_invalid.move:18:41 ───
-    │
- 18 │     public fun f_public_call_script() { X::f_script() }
-    │                                         ^^^^^^^^^^^^^ Invalid call to '0x2::X::f_script'
-    ·
-  5 │     public(script) fun f_script() {}
-    │     -------------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
-    │
+error[E04002]: requires script context
+   ┌─ tests/move_check/typing/module_call_visibility_script_invalid.move:24:46
+   │
+12 │     public(script) fun f_script_call_script() { X::f_script() }
+   │     -------------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
+   ·
+24 │     public fun f_public_call_self_script() { f_script_call_script() }
+   │                                              ^^^^^^^^^^^^^^^^^^^^^^ Invalid call to '0x2::M::f_script_call_script'
 
-error: 
+error[E04001]: restricted visibility
+   ┌─ tests/move_check/typing/module_call_visibility_script_invalid.move:27:50
+   │
+ 4 │     fun f_private() {}
+   │         --------- This function is internal to its module. Only 'public', 'public(script)', and 'public(friend)' functions can be called outside of their module
+   ·
+27 │     public(script) fun f_script_call_private() { X::f_private() }
+   │                                                  ^^^^^^^^^^^^^^ Invalid call to '0x2::X::f_private'
 
-    ┌── tests/move_check/typing/module_call_visibility_script_invalid.move:22:40 ───
-    │
- 22 │     fun f_private_call_self_script() { f_script_call_script() }
-    │                                        ^^^^^^^^^^^^^^^^^^^^^^ Invalid call to '0x2::M::f_script_call_script'
-    ·
- 12 │     public(script) fun f_script_call_script() { X::f_script() }
-    │     -------------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_visibility_script_invalid.move:23:54 ───
-    │
- 23 │     public(friend) fun f_friend_call_self_script() { f_script_call_script() }
-    │                                                      ^^^^^^^^^^^^^^^^^^^^^^ Invalid call to '0x2::M::f_script_call_script'
-    ·
- 12 │     public(script) fun f_script_call_script() { X::f_script() }
-    │     -------------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_visibility_script_invalid.move:24:46 ───
-    │
- 24 │     public fun f_public_call_self_script() { f_script_call_script() }
-    │                                              ^^^^^^^^^^^^^^^^^^^^^^ Invalid call to '0x2::M::f_script_call_script'
-    ·
- 12 │     public(script) fun f_script_call_script() { X::f_script() }
-    │     -------------- This function can only be called from a script context, i.e. a 'script' function or a 'public(script)' function
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_visibility_script_invalid.move:27:50 ───
-    │
- 27 │     public(script) fun f_script_call_private() { X::f_private() }
-    │                                                  ^^^^^^^^^^^^^^ Invalid call to '0x2::X::f_private'
-    ·
-  4 │     fun f_private() {}
-    │         --------- This function is internal to its module. Only 'public', 'public(script)', and 'public(friend)' functions can be called outside of their module
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_visibility_script_invalid.move:31:49 ───
-    │
- 31 │     public(script) fun f_script_call_friend() { X::f_friend() }
-    │                                                 ^^^^^^^^^^^^^ Invalid call to '0x2::X::f_friend'
-    ·
-  6 │     public(friend) fun f_friend() {}
-    │     -------------- This function can only be called from a 'friend' of module '0x2::X'
-    │
+error[E04001]: restricted visibility
+   ┌─ tests/move_check/typing/module_call_visibility_script_invalid.move:31:49
+   │
+ 6 │     public(friend) fun f_friend() {}
+   │     -------------- This function can only be called from a 'friend' of module '0x2::X'
+   ·
+31 │     public(script) fun f_script_call_friend() { X::f_friend() }
+   │                                                 ^^^^^^^^^^^^^ Invalid call to '0x2::X::f_friend'
 

--- a/language/move-lang/tests/move_check/typing/mutable_borrow_from_immutable.exp
+++ b/language/move-lang/tests/move_check/typing/mutable_borrow_from_immutable.exp
@@ -1,3 +1,9 @@
+error[E03010]: unbound field
+   ┌─ tests/move_check/typing/mutable_borrow_from_immutable.move:11:14
+   │
+11 │         &mut xref.v;
+   │              ^^^^^^ Unbound field 'v' in '0x8675309::M::X'
+
 error: 
 
    ┌── tests/move_check/typing/mutable_borrow_from_immutable.move:6:9 ───
@@ -40,14 +46,6 @@ error:
     ·
   9 │         let xref = &s.x;
     │                    ---- Immutable because of this position
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/mutable_borrow_from_immutable.move:11:14 ───
-    │
- 11 │         &mut xref.v;
-    │              ^^^^^^ Unbound field 'v' in '0x8675309::M::X'
     │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/mutate_non_ref.exp
+++ b/language/move-lang/tests/move_check/typing/mutate_non_ref.exp
@@ -1,3 +1,21 @@
+error[E05002]: type not implicitly copyable
+   ┌─ tests/move_check/typing/mutate_non_ref.move:17:10
+   │
+ 3 │     struct X has copy, drop { s: S }
+   │                                  - The type '0x8675309::M::S' is not implicitly copyable. Implicit copies are limited to simple primitive values
+   ·
+17 │         *x.s = S { f: 0 };
+   │          ^^^ Invalid implicit copy of field 's'. Try adding '*&' to the front of the field access
+
+error[E05002]: type not implicitly copyable
+   ┌─ tests/move_check/typing/mutate_non_ref.move:21:10
+   │
+ 3 │     struct X has copy, drop { s: S }
+   │                                  - The type '0x8675309::M::S' is not implicitly copyable. Implicit copies are limited to simple primitive values
+   ·
+21 │         *x_ref.s = S{ f: 0 };
+   │          ^^^^^^^ Invalid implicit copy of field 's'. Try adding '*&' to the front of the field access
+
 error: 
 
    ┌── tests/move_check/typing/mutate_non_ref.move:7:10 ───
@@ -70,17 +88,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/mutate_non_ref.move:17:10 ───
-    │
- 17 │         *x.s = S { f: 0 };
-    │          ^^^ Invalid implicit copy of field 's'. Try adding '*&' to the front of the field access
-    ·
-  3 │     struct X has copy, drop { s: S }
-    │                                  - The type '0x8675309::M::S' is not implicitly copyable. Implicit copies are limited to simple primitive values
-    │
-
-error: 
-
     ┌── tests/move_check/typing/mutate_non_ref.move:18:10 ───
     │
  18 │         *x.s.f = 0;
@@ -105,17 +112,6 @@ error:
     ·
  21 │         *x_ref.s = S{ f: 0 };
     │          ------- Is not compatible with: '&mut _'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/mutate_non_ref.move:21:10 ───
-    │
- 21 │         *x_ref.s = S{ f: 0 };
-    │          ^^^^^^^ Invalid implicit copy of field 's'. Try adding '*&' to the front of the field access
-    ·
-  3 │     struct X has copy, drop { s: S }
-    │                                  - The type '0x8675309::M::S' is not implicitly copyable. Implicit copies are limited to simple primitive values
     │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/mutate_resource.exp
+++ b/language/move-lang/tests/move_check/typing/mutate_resource.exp
@@ -1,42 +1,31 @@
-error: 
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/mutate_resource.move:5:10
+  │
+2 │     struct R {}
+  │            - To satisfy the constraint, the 'drop' ability would need to be added here
+3 │ 
+4 │     fun t0(r: &mut R) {
+  │                    - The type '0x8675309::M::R' does not have the ability 'drop'
+5 │         *r = R {};
+  │          ^ Invalid mutation. Mutation requires the 'drop' ability as the old value is destroyed
 
-   ┌── tests/move_check/typing/mutate_resource.move:5:10 ───
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/mutate_resource.move:9:10
+  │
+8 │     fun t1<T>(r: &mut T, x: T) {
+  │            -          - The type 'T' does not have the ability 'drop'
+  │            │           
+  │            To satisfy the constraint, the 'drop' ability would need to be added here
+9 │         *r = x;
+  │          ^ Invalid mutation. Mutation requires the 'drop' ability as the old value is destroyed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/mutate_resource.move:13:10
    │
- 5 │         *r = R {};
+12 │     fun t2<T: key>(r: &mut T, x: T) {
+   │            -               - The type 'T' does not have the ability 'drop'
+   │            │                
+   │            To satisfy the constraint, the 'drop' ability would need to be added here
+13 │         *r = x;
    │          ^ Invalid mutation. Mutation requires the 'drop' ability as the old value is destroyed
-   ·
- 4 │     fun t0(r: &mut R) {
-   │                    - The type '0x8675309::M::R' does not have the ability 'drop'
-   ·
- 2 │     struct R {}
-   │            - To satisfy the constraint, the 'drop' ability would need to be added here
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/mutate_resource.move:9:10 ───
-   │
- 9 │         *r = x;
-   │          ^ Invalid mutation. Mutation requires the 'drop' ability as the old value is destroyed
-   ·
- 8 │     fun t1<T>(r: &mut T, x: T) {
-   │                       - The type 'T' does not have the ability 'drop'
-   ·
- 8 │     fun t1<T>(r: &mut T, x: T) {
-   │            - To satisfy the constraint, the 'drop' ability would need to be added here
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/mutate_resource.move:13:10 ───
-    │
- 13 │         *r = x;
-    │          ^ Invalid mutation. Mutation requires the 'drop' ability as the old value is destroyed
-    ·
- 12 │     fun t2<T: key>(r: &mut T, x: T) {
-    │                            - The type 'T' does not have the ability 'drop'
-    ·
- 12 │     fun t2<T: key>(r: &mut T, x: T) {
-    │            - To satisfy the constraint, the 'drop' ability would need to be added here
-    │
 

--- a/language/move-lang/tests/move_check/typing/native_structs_pack_unpack.exp
+++ b/language/move-lang/tests/move_check/typing/native_structs_pack_unpack.exp
@@ -1,3 +1,12 @@
+error[E03010]: unbound field
+   ┌─ tests/move_check/typing/native_structs_pack_unpack.move:15:17
+   │
+ 3 │     native struct T;
+   │     ------ Struct declared 'native' here
+   ·
+15 │         let f = c.f;
+   │                 ^^^ Unbound field 'f' for native struct '0x42::C::T'
+
 error: 
 
    ┌── tests/move_check/typing/native_structs_pack_unpack.move:9:9 ───
@@ -44,16 +53,5 @@ error:
     │
  15 │         let f = c.f;
     │                 ^^^ Invalid access of field 'f' on '0x42::C::T'. Fields can only be accessed inside the struct's module
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/native_structs_pack_unpack.move:15:17 ───
-    │
- 15 │         let f = c.f;
-    │                 ^^^ Unbound field 'f' for native struct '0x42::C::T'
-    ·
-  3 │     native struct T;
-    │     ------ Declared 'native' here
     │
 

--- a/language/move-lang/tests/move_check/typing/neq_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/neq_invalid.exp
@@ -1,3 +1,56 @@
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/neq_invalid.move:22:9
+   │
+ 3 │     struct R {
+   │            - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+21 │     fun t1(r: R) {
+   │               - The type '0x8675309::M::R' does not have the ability 'drop'
+22 │         r != r;
+   │         ^^^^^^ '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/neq_invalid.move:27:9
+   │
+ 7 │     struct G1<T: key> {}
+   │            -- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+27 │         G1{} != G1{};
+   │         ^^^^^^^^^^^^
+   │         │       │
+   │         │       The type '0x8675309::M::G1<_>' does not have the ability 'drop'
+   │         '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/neq_invalid.move:28:9
+   │
+ 8 │     struct G2<T> {}
+   │            -- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+28 │         G2{} != G2{};
+   │         ^^^^^^^^^^^^
+   │         │       │
+   │         │       The type '0x8675309::M::G2<_>' does not have the ability 'drop'
+   │         '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E04005]: expected a single type
+   ┌─ tests/move_check/typing/neq_invalid.move:32:9
+   │
+32 │         () != ();
+   │         ^^^^^^^^
+   │         │     │
+   │         │     Expected a single type, but found expression list type: '()'
+   │         Invalid arguments to '!='
+
+error[E04005]: expected a single type
+   ┌─ tests/move_check/typing/neq_invalid.move:33:9
+   │
+33 │         (0, 1) != (0, 1);
+   │         ^^^^^^^^^^^^^^^^
+   │         │         │
+   │         │         Expected a single type, but found expression list type: '(u64, u64)'
+   │         Invalid arguments to '!='
+
 error: 
 
     ┌── tests/move_check/typing/neq_invalid.move:13:20 ───
@@ -84,20 +137,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/neq_invalid.move:22:9 ───
-    │
- 22 │         r != r;
-    │         ^^^^^^ '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
-    ·
- 21 │     fun t1(r: R) {
-    │               - The type '0x8675309::M::R' does not have the ability 'drop'
-    ·
-  3 │     struct R {
-    │            - To satisfy the constraint, the 'drop' ability would need to be added here
-    │
-
-error: 
-
     ┌── tests/move_check/typing/neq_invalid.move:26:9 ───
     │
  26 │         G0{} != G0{};
@@ -122,20 +161,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/neq_invalid.move:27:9 ───
-    │
- 27 │         G1{} != G1{};
-    │         ^^^^^^^^^^^^ '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
-    ·
- 27 │         G1{} != G1{};
-    │                 ---- The type '0x8675309::M::G1<_>' does not have the ability 'drop'
-    ·
-  7 │     struct G1<T: key> {}
-    │            -- To satisfy the constraint, the 'drop' ability would need to be added here
-    │
-
-error: 
-
     ┌── tests/move_check/typing/neq_invalid.move:27:17 ───
     │
  27 │         G1{} != G1{};
@@ -152,46 +177,10 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/neq_invalid.move:28:9 ───
-    │
- 28 │         G2{} != G2{};
-    │         ^^^^^^^^^^^^ '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
-    ·
- 28 │         G2{} != G2{};
-    │                 ---- The type '0x8675309::M::G2<_>' does not have the ability 'drop'
-    ·
-  8 │     struct G2<T> {}
-    │            -- To satisfy the constraint, the 'drop' ability would need to be added here
-    │
-
-error: 
-
     ┌── tests/move_check/typing/neq_invalid.move:28:17 ───
     │
  28 │         G2{} != G2{};
     │                 ^^^^ Could not infer this type. Try adding an annotation
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/neq_invalid.move:32:9 ───
-    │
- 32 │         () != ();
-    │         ^^^^^^^^ Invalid arguments to '!='
-    ·
- 32 │         () != ();
-    │               -- Expected a single type, but found expression list type: '()'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/neq_invalid.move:33:9 ───
-    │
- 33 │         (0, 1) != (0, 1);
-    │         ^^^^^^^^^^^^^^^^ Invalid arguments to '!='
-    ·
- 33 │         (0, 1) != (0, 1);
-    │                   ------ Expected a single type, but found expression list type: '(u64, u64)'
     │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/pack.exp
+++ b/language/move-lang/tests/move_check/typing/pack.exp
@@ -1,14 +1,12 @@
-error: 
-
-    ┌── tests/move_check/typing/pack.move:14:27 ───
-    │
- 14 │         let n2 = Nat { f: *&s };
-    │                           ^^^ Invalid dereference. Dereference requires the 'copy' ability
-    ·
- 12 │         let s = S{ f: 0 };
-    │                 --------- The type '0x8675309::M::S' does not have the ability 'copy'
-    ·
-  2 │     struct S has drop { f: u64 }
-    │            - To satisfy the constraint, the 'copy' ability would need to be added here
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/pack.move:14:27
+   │
+ 2 │     struct S has drop { f: u64 }
+   │            - To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+12 │         let s = S{ f: 0 };
+   │                 --------- The type '0x8675309::M::S' does not have the ability 'copy'
+13 │         let n1 = Nat { f };
+14 │         let n2 = Nat { f: *&s };
+   │                           ^^^ Invalid dereference. Dereference requires the 'copy' ability
 

--- a/language/move-lang/tests/move_check/typing/pack_constraint_not_satisfied.exp
+++ b/language/move-lang/tests/move_check/typing/pack_constraint_not_satisfied.exp
@@ -1,169 +1,136 @@
-error: 
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/pack_constraint_not_satisfied.move:7:9
+  │
+3 │     struct R<T: key>  { r: T }
+  │                 --- 'key' constraint declared here
+  ·
+7 │         R {r:_ } = R { r: 0 };
+  │         ^^^^^^^^          - The type 'u64' does not have the ability 'key'
+  │         │                  
+  │         'key' constraint not satisifed
 
-   ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:7:9 ───
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/pack_constraint_not_satisfied.move:7:20
+  │
+3 │     struct R<T: key>  { r: T }
+  │                 --- 'key' constraint declared here
+  ·
+7 │         R {r:_ } = R { r: 0 };
+  │                    ^^^^^^^^^^
+  │                    │      │
+  │                    │      The type 'u64' does not have the ability 'key'
+  │                    'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/pack_constraint_not_satisfied.move:8:9
+  │
+2 │     struct Coin {}
+  │            ---- To satisfy the constraint, the 'drop' ability would need to be added here
+3 │     struct R<T: key>  { r: T }
+4 │     struct S<T: drop> has drop { c: T }
+  │                 ---- 'drop' constraint declared here
+  ·
+8 │         S { c: Coin {} };
+  │         ^^^^^^^^^^^^^^^^
+  │         │      │
+  │         │      The type '0x8675309::M::Coin' does not have the ability 'drop'
+  │         'drop' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/pack_constraint_not_satisfied.move:8:9
+  │
+8 │         S { c: Coin {} };
+  │         ^^^^^^^^^^^^^^^^
+  │         │
+  │         Cannot ignore values without the 'drop' ability. The value must be used
+  │         The type '0x8675309::M::S<0x8675309::M::Coin>' can have the ability 'drop' but the type argument '0x8675309::M::Coin' does not have the required ability 'drop'
+  │         The type '0x8675309::M::S<0x8675309::M::Coin>' does not have the ability 'drop'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/pack_constraint_not_satisfied.move:12:9
    │
- 7 │         R {r:_ } = R { r: 0 };
-   │         ^^^^^^^^ 'key' constraint not satisifed
+ 3 │     struct R<T: key>  { r: T }
+   │            -    --- 'key' constraint declared here
+   │            │     
+   │            To satisfy the constraint, the 'key' ability would need to be added here
    ·
- 7 │         R {r:_ } = R { r: 0 };
-   │                           - The type 'u64' does not have the ability 'key'
-   ·
+12 │         R {r: R { r: _ } } = R { r: R { r: 0 }};
+   │         ^^^^^^^^^^^^^^^^^^          ---------- The type '0x8675309::M::R<u64>' does not have the ability 'key'
+   │         │                            
+   │         'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/pack_constraint_not_satisfied.move:12:15
+   │
  3 │     struct R<T: key>  { r: T }
    │                 --- 'key' constraint declared here
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:7:20 ───
-   │
- 7 │         R {r:_ } = R { r: 0 };
-   │                    ^^^^^^^^^^ 'key' constraint not satisifed
    ·
- 7 │         R {r:_ } = R { r: 0 };
-   │                           - The type 'u64' does not have the ability 'key'
+12 │         R {r: R { r: _ } } = R { r: R { r: 0 }};
+   │               ^^^^^^^^^^                   - The type 'u64' does not have the ability 'key'
+   │               │                             
+   │               'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/pack_constraint_not_satisfied.move:12:30
+   │
+ 3 │     struct R<T: key>  { r: T }
+   │            -    --- 'key' constraint declared here
+   │            │     
+   │            To satisfy the constraint, the 'key' ability would need to be added here
    ·
+12 │         R {r: R { r: _ } } = R { r: R { r: 0 }};
+   │                              ^^^^^^^^^^^^^^^^^^
+   │                              │      │
+   │                              │      The type '0x8675309::M::R<u64>' does not have the ability 'key'
+   │                              'key' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/pack_constraint_not_satisfied.move:12:37
+   │
  3 │     struct R<T: key>  { r: T }
    │                 --- 'key' constraint declared here
-   │
+   ·
+12 │         R {r: R { r: _ } } = R { r: R { r: 0 }};
+   │                                     ^^^^^^^^^^
+   │                                     │      │
+   │                                     │      The type 'u64' does not have the ability 'key'
+   │                                     'key' constraint not satisifed
 
-error: 
-
-   ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:8:9 ───
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/pack_constraint_not_satisfied.move:13:9
    │
- 8 │         S { c: Coin {} };
-   │         ^^^^^^^^^^^^^^^^ 'drop' constraint not satisifed
-   ·
- 8 │         S { c: Coin {} };
-   │                ------- The type '0x8675309::M::Coin' does not have the ability 'drop'
-   ·
- 2 │     struct Coin {}
-   │            ---- To satisfy the constraint, the 'drop' ability would need to be added here
-   ·
  4 │     struct S<T: drop> has drop { c: T }
    │                 ---- 'drop' constraint declared here
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:8:9 ───
-   │
- 8 │         S { c: Coin {} };
-   │         ^^^^^^^^^^^^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
    ·
- 8 │         S { c: Coin {} };
-   │         ---------------- The type '0x8675309::M::S<0x8675309::M::Coin>' does not have the ability 'drop'
-   ·
- 8 │         S { c: Coin {} };
-   │         ---------------- The type '0x8675309::M::S<0x8675309::M::Coin>' can have the ability 'drop' but the type argument '0x8675309::M::Coin' does not have the required ability 'drop'
+13 │         S { c: S { c: Coin {} } };
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │      │      │
+   │         │      │      The type '0x8675309::M::S<0x8675309::M::Coin>' can have the ability 'drop' but the type argument '0x8675309::M::Coin' does not have the required ability 'drop'
+   │         │      The type '0x8675309::M::S<0x8675309::M::Coin>' does not have the ability 'drop'
+   │         'drop' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/pack_constraint_not_satisfied.move:13:9
    │
+13 │         S { c: S { c: Coin {} } };
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │
+   │         Cannot ignore values without the 'drop' ability. The value must be used
+   │         The type '0x8675309::M::S<0x8675309::M::S<0x8675309::M::Coin>>' can have the ability 'drop' but the type argument '0x8675309::M::S<0x8675309::M::Coin>' does not have the required ability 'drop'
+   │         The type '0x8675309::M::S<0x8675309::M::S<0x8675309::M::Coin>>' does not have the ability 'drop'
 
-error: 
-
-    ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:12:9 ───
-    │
- 12 │         R {r: R { r: _ } } = R { r: R { r: 0 }};
-    │         ^^^^^^^^^^^^^^^^^^ 'key' constraint not satisifed
-    ·
- 12 │         R {r: R { r: _ } } = R { r: R { r: 0 }};
-    │                                     ---------- The type '0x8675309::M::R<u64>' does not have the ability 'key'
-    ·
-  3 │     struct R<T: key>  { r: T }
-    │            - To satisfy the constraint, the 'key' ability would need to be added here
-    ·
-  3 │     struct R<T: key>  { r: T }
-    │                 --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:12:15 ───
-    │
- 12 │         R {r: R { r: _ } } = R { r: R { r: 0 }};
-    │               ^^^^^^^^^^ 'key' constraint not satisifed
-    ·
- 12 │         R {r: R { r: _ } } = R { r: R { r: 0 }};
-    │                                            - The type 'u64' does not have the ability 'key'
-    ·
-  3 │     struct R<T: key>  { r: T }
-    │                 --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:12:30 ───
-    │
- 12 │         R {r: R { r: _ } } = R { r: R { r: 0 }};
-    │                              ^^^^^^^^^^^^^^^^^^ 'key' constraint not satisifed
-    ·
- 12 │         R {r: R { r: _ } } = R { r: R { r: 0 }};
-    │                                     ---------- The type '0x8675309::M::R<u64>' does not have the ability 'key'
-    ·
-  3 │     struct R<T: key>  { r: T }
-    │            - To satisfy the constraint, the 'key' ability would need to be added here
-    ·
-  3 │     struct R<T: key>  { r: T }
-    │                 --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:12:37 ───
-    │
- 12 │         R {r: R { r: _ } } = R { r: R { r: 0 }};
-    │                                     ^^^^^^^^^^ 'key' constraint not satisifed
-    ·
- 12 │         R {r: R { r: _ } } = R { r: R { r: 0 }};
-    │                                            - The type 'u64' does not have the ability 'key'
-    ·
-  3 │     struct R<T: key>  { r: T }
-    │                 --- 'key' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:13:9 ───
-    │
- 13 │         S { c: S { c: Coin {} } };
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ 'drop' constraint not satisifed
-    ·
- 13 │         S { c: S { c: Coin {} } };
-    │                ---------------- The type '0x8675309::M::S<0x8675309::M::Coin>' does not have the ability 'drop'
-    ·
- 13 │         S { c: S { c: Coin {} } };
-    │                       ------- The type '0x8675309::M::S<0x8675309::M::Coin>' can have the ability 'drop' but the type argument '0x8675309::M::Coin' does not have the required ability 'drop'
-    ·
-  4 │     struct S<T: drop> has drop { c: T }
-    │                 ---- 'drop' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:13:9 ───
-    │
- 13 │         S { c: S { c: Coin {} } };
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
-    ·
- 13 │         S { c: S { c: Coin {} } };
-    │         ------------------------- The type '0x8675309::M::S<0x8675309::M::S<0x8675309::M::Coin>>' does not have the ability 'drop'
-    ·
- 13 │         S { c: S { c: Coin {} } };
-    │         ------------------------- The type '0x8675309::M::S<0x8675309::M::S<0x8675309::M::Coin>>' can have the ability 'drop' but the type argument '0x8675309::M::S<0x8675309::M::Coin>' does not have the required ability 'drop'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:13:16 ───
-    │
- 13 │         S { c: S { c: Coin {} } };
-    │                ^^^^^^^^^^^^^^^^ 'drop' constraint not satisifed
-    ·
- 13 │         S { c: S { c: Coin {} } };
-    │                       ------- The type '0x8675309::M::Coin' does not have the ability 'drop'
-    ·
-  2 │     struct Coin {}
-    │            ---- To satisfy the constraint, the 'drop' ability would need to be added here
-    ·
-  4 │     struct S<T: drop> has drop { c: T }
-    │                 ---- 'drop' constraint declared here
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/pack_constraint_not_satisfied.move:13:16
+   │
+ 2 │     struct Coin {}
+   │            ---- To satisfy the constraint, the 'drop' ability would need to be added here
+ 3 │     struct R<T: key>  { r: T }
+ 4 │     struct S<T: drop> has drop { c: T }
+   │                 ---- 'drop' constraint declared here
+   ·
+13 │         S { c: S { c: Coin {} } };
+   │                ^^^^^^^^^^^^^^^^
+   │                │      │
+   │                │      The type '0x8675309::M::Coin' does not have the ability 'drop'
+   │                'drop' constraint not satisifed
 

--- a/language/move-lang/tests/move_check/typing/pack_multiple.exp
+++ b/language/move-lang/tests/move_check/typing/pack_multiple.exp
@@ -1,33 +1,27 @@
-error: 
+error[E04004]: expected a single non-reference type
+  ┌─ tests/move_check/typing/pack_multiple.move:5:9
+  │
+5 │         Box { f: (0, 1) };
+  │         ^^^^^^^^^^^^^^^^^
+  │         │        │
+  │         │        Expected a single non-reference type, but found: '(u64, u64)'
+  │         Invalid type argument
 
-   ┌── tests/move_check/typing/pack_multiple.move:5:9 ───
-   │
- 5 │         Box { f: (0, 1) };
-   │         ^^^^^^^^^^^^^^^^^ Invalid type argument
-   ·
- 5 │         Box { f: (0, 1) };
-   │                  ------ Expected a single non-reference type, but found: '(u64, u64)'
-   │
+error[E04004]: expected a single non-reference type
+  ┌─ tests/move_check/typing/pack_multiple.move:6:9
+  │
+6 │         Box { f: (0, 1, 2) };
+  │         ^^^^^^^^^^^^^^^^^^^^
+  │         │        │
+  │         │        Expected a single non-reference type, but found: '(u64, u64, u64)'
+  │         Invalid type argument
 
-error: 
-
-   ┌── tests/move_check/typing/pack_multiple.move:6:9 ───
-   │
- 6 │         Box { f: (0, 1, 2) };
-   │         ^^^^^^^^^^^^^^^^^^^^ Invalid type argument
-   ·
- 6 │         Box { f: (0, 1, 2) };
-   │                  --------- Expected a single non-reference type, but found: '(u64, u64, u64)'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/pack_multiple.move:7:9 ───
-   │
- 7 │         Box { f: (true, Box { f: 0 }) };
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid type argument
-   ·
- 7 │         Box { f: (true, Box { f: 0 }) };
-   │                  -------------------- Expected a single non-reference type, but found: '(bool, 0x8675309::M::Box<u64>)'
-   │
+error[E04004]: expected a single non-reference type
+  ┌─ tests/move_check/typing/pack_multiple.move:7:9
+  │
+7 │         Box { f: (true, Box { f: 0 }) };
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │         │        │
+  │         │        Expected a single non-reference type, but found: '(bool, 0x8675309::M::Box<u64>)'
+  │         Invalid type argument
 

--- a/language/move-lang/tests/move_check/typing/pack_reference.exp
+++ b/language/move-lang/tests/move_check/typing/pack_reference.exp
@@ -1,22 +1,17 @@
-error: 
+error[E04004]: expected a single non-reference type
+  ┌─ tests/move_check/typing/pack_reference.move:5:9
+  │
+4 │     fun t0(r_imm: &u64, r_mut: &mut u64) {
+  │                   ---- Expected a single non-reference type, but found: '&u64'
+5 │         Box { f: r_imm };
+  │         ^^^^^^^^^^^^^^^^ Invalid type argument
 
-   ┌── tests/move_check/typing/pack_reference.move:5:9 ───
-   │
- 5 │         Box { f: r_imm };
-   │         ^^^^^^^^^^^^^^^^ Invalid type argument
-   ·
- 4 │     fun t0(r_imm: &u64, r_mut: &mut u64) {
-   │                   ---- Expected a single non-reference type, but found: '&u64'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/pack_reference.move:6:9 ───
-   │
- 6 │         Box { f: r_mut };
-   │         ^^^^^^^^^^^^^^^^ Invalid type argument
-   ·
- 4 │     fun t0(r_imm: &u64, r_mut: &mut u64) {
-   │                                -------- Expected a single non-reference type, but found: '&mut u64'
-   │
+error[E04004]: expected a single non-reference type
+  ┌─ tests/move_check/typing/pack_reference.move:6:9
+  │
+4 │     fun t0(r_imm: &u64, r_mut: &mut u64) {
+  │                                -------- Expected a single non-reference type, but found: '&mut u64'
+5 │         Box { f: r_imm };
+6 │         Box { f: r_mut };
+  │         ^^^^^^^^^^^^^^^^ Invalid type argument
 

--- a/language/move-lang/tests/move_check/typing/pack_unit.exp
+++ b/language/move-lang/tests/move_check/typing/pack_unit.exp
@@ -1,11 +1,9 @@
-error: 
-
-   ┌── tests/move_check/typing/pack_unit.move:5:9 ───
-   │
- 5 │         Box { f: () };
-   │         ^^^^^^^^^^^^^ Invalid type argument
-   ·
- 5 │         Box { f: () };
-   │                  -- Expected a single non-reference type, but found: '()'
-   │
+error[E04004]: expected a single non-reference type
+  ┌─ tests/move_check/typing/pack_unit.move:5:9
+  │
+5 │         Box { f: () };
+  │         ^^^^^^^^^^^^^
+  │         │        │
+  │         │        Expected a single non-reference type, but found: '()'
+  │         Invalid type argument
 

--- a/language/move-lang/tests/move_check/typing/recursive_local.exp
+++ b/language/move-lang/tests/move_check/typing/recursive_local.exp
@@ -1,3 +1,11 @@
+error[E04005]: expected a single type
+  ┌─ tests/move_check/typing/recursive_local.move:5:9
+  │
+5 │         x = (x, 0);
+  │         ^   ------ Expected a single type, but found expression list type: '(_, u64)'
+  │         │    
+  │         Invalid type for local
+
 error: 
 
    ┌── tests/move_check/typing/recursive_local.move:4:13 ───
@@ -15,17 +23,6 @@ error:
    ·
  4 │         let x;
    │             - Unable to infer the type. Recursive type found.
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/recursive_local.move:5:9 ───
-   │
- 5 │         x = (x, 0);
-   │         ^ Invalid type for local
-   ·
- 5 │         x = (x, 0);
-   │             ------ Expected a single type, but found expression list type: '(_, u64)'
    │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/recursive_structs_malformed.exp
+++ b/language/move-lang/tests/move_check/typing/recursive_structs_malformed.exp
@@ -1,13 +1,29 @@
-error: 
+error[E04004]: expected a single non-reference type
+  ┌─ tests/move_check/typing/recursive_structs_malformed.move:4:21
+  │
+4 │     struct Foo { f: (Foo, Foo) }
+  │                     ^^^^^^^^^^
+  │                     │
+  │                     Invalid field type
+  │                     Expected a single non-reference type, but found: '(0x42::M0::Foo, 0x42::M0::Foo)'
 
-   ┌── tests/move_check/typing/recursive_structs_malformed.move:4:21 ───
-   │
- 4 │     struct Foo { f: (Foo, Foo) }
-   │                     ^^^^^^^^^^ Invalid field type
-   ·
- 4 │     struct Foo { f: (Foo, Foo) }
-   │                     ---------- Expected a single non-reference type, but found: '(0x42::M0::Foo, 0x42::M0::Foo)'
-   │
+error[E04004]: expected a single non-reference type
+  ┌─ tests/move_check/typing/recursive_structs_malformed.move:5:21
+  │
+5 │     struct Bar { f: &Bar }
+  │                     ^^^^
+  │                     │
+  │                     Invalid field type
+  │                     Expected a single non-reference type, but found: '&0x42::M0::Bar'
+
+error[E04004]: expected a single non-reference type
+  ┌─ tests/move_check/typing/recursive_structs_malformed.move:6:21
+  │
+6 │     struct Baz { f: vector<(&Baz, &mut Baz)> }
+  │                     ^^^^^^^^^^^^^^^^^^^^^^^^
+  │                     │      │
+  │                     │      Expected a single non-reference type, but found: '(&0x42::M0::Baz, &mut 0x42::M0::Baz)'
+  │                     Invalid type argument
 
 error: 
 
@@ -22,17 +38,6 @@ error:
 
 error: 
 
-   ┌── tests/move_check/typing/recursive_structs_malformed.move:5:21 ───
-   │
- 5 │     struct Bar { f: &Bar }
-   │                     ^^^^ Invalid field type
-   ·
- 5 │     struct Bar { f: &Bar }
-   │                     ---- Expected a single non-reference type, but found: '&0x42::M0::Bar'
-   │
-
-error: 
-
    ┌── tests/move_check/typing/recursive_structs_malformed.move:5:22 ───
    │
  5 │     struct Bar { f: &Bar }
@@ -40,17 +45,6 @@ error:
    ·
  5 │     struct Bar { f: &Bar }
    │                      --- Using this struct creates a cycle: 'Bar' contains 'Bar'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/recursive_structs_malformed.move:6:21 ───
-   │
- 6 │     struct Baz { f: vector<(&Baz, &mut Baz)> }
-   │                     ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid type argument
-   ·
- 6 │     struct Baz { f: vector<(&Baz, &mut Baz)> }
-   │                            ---------------- Expected a single non-reference type, but found: '(&0x42::M0::Baz, &mut 0x42::M0::Baz)'
    │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/seq_cannot_ignore_resource.exp
+++ b/language/move-lang/tests/move_check/typing/seq_cannot_ignore_resource.exp
@@ -1,56 +1,44 @@
-error: 
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_check/typing/seq_cannot_ignore_resource.move:5:9
+  │
+2 │     struct R {}
+  │            - To satisfy the constraint, the 'drop' ability would need to be added here
+  ·
+5 │         R{};
+  │         ^^^
+  │         │
+  │         Cannot ignore values without the 'drop' ability. The value must be used
+  │         The type '0x8675309::M::R' does not have the ability 'drop'
 
-   ┌── tests/move_check/typing/seq_cannot_ignore_resource.move:5:9 ───
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/seq_cannot_ignore_resource.move:10:9
    │
- 5 │         R{};
-   │         ^^^ Cannot ignore values without the 'drop' ability. The value must be used
-   ·
- 5 │         R{};
-   │         --- The type '0x8675309::M::R' does not have the ability 'drop'
-   ·
  2 │     struct R {}
    │            - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+ 9 │         let r = R{};
+   │                 --- The type '0x8675309::M::R' does not have the ability 'drop'
+10 │         r;
+   │         ^ Cannot ignore values without the 'drop' ability. The value must be used
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/seq_cannot_ignore_resource.move:14:9
    │
+14 │         (0, false, R{});
+   │         ^^^^^^^^^^^^^^^
+   │         │          │
+   │         │          The type '(u64, bool, 0x8675309::M::R)' can have the ability 'drop' but the type argument '0x8675309::M::R' does not have the required ability 'drop'
+   │         Cannot ignore values without the 'drop' ability. The value must be used
+   │         The type '(u64, bool, 0x8675309::M::R)' does not have the ability 'drop'
 
-error: 
-
-    ┌── tests/move_check/typing/seq_cannot_ignore_resource.move:10:9 ───
-    │
- 10 │         r;
-    │         ^ Cannot ignore values without the 'drop' ability. The value must be used
-    ·
-  9 │         let r = R{};
-    │                 --- The type '0x8675309::M::R' does not have the ability 'drop'
-    ·
-  2 │     struct R {}
-    │            - To satisfy the constraint, the 'drop' ability would need to be added here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/seq_cannot_ignore_resource.move:14:9 ───
-    │
- 14 │         (0, false, R{});
-    │         ^^^^^^^^^^^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
-    ·
- 14 │         (0, false, R{});
-    │         --------------- The type '(u64, bool, 0x8675309::M::R)' does not have the ability 'drop'
-    ·
- 14 │         (0, false, R{});
-    │                    --- The type '(u64, bool, 0x8675309::M::R)' can have the ability 'drop' but the type argument '0x8675309::M::R' does not have the required ability 'drop'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/seq_cannot_ignore_resource.move:19:9 ───
-    │
- 19 │         if (true) (0, false, R{}) else (0, false, r);
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
-    ·
- 19 │         if (true) (0, false, R{}) else (0, false, r);
-    │                                        ------------- The type '(u64, bool, 0x8675309::M::R)' does not have the ability 'drop'
-    ·
- 18 │         let r = R{};
-    │                 --- The type '(u64, bool, 0x8675309::M::R)' can have the ability 'drop' but the type argument '0x8675309::M::R' does not have the required ability 'drop'
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/seq_cannot_ignore_resource.move:19:9
+   │
+18 │         let r = R{};
+   │                 --- The type '(u64, bool, 0x8675309::M::R)' can have the ability 'drop' but the type argument '0x8675309::M::R' does not have the required ability 'drop'
+19 │         if (true) (0, false, R{}) else (0, false, r);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │                              │
+   │         │                              The type '(u64, bool, 0x8675309::M::R)' does not have the ability 'drop'
+   │         Cannot ignore values without the 'drop' ability. The value must be used
 

--- a/language/move-lang/tests/move_check/typing/shadowing_invalid_scope.exp
+++ b/language/move-lang/tests/move_check/typing/shadowing_invalid_scope.exp
@@ -1,8 +1,6 @@
-error: 
-
-   ┌── tests/move_check/typing/shadowing_invalid_scope.move:5:10 ───
-   │
- 5 │         (x: bool);
-   │          ^ Invalid local usage. Unbound local 'x'
-   │
+error[E03009]: unbound variable
+  ┌─ tests/move_check/typing/shadowing_invalid_scope.move:5:10
+  │
+5 │         (x: bool);
+  │          ^ Invalid variable usage. Unbound variable 'x'
 

--- a/language/move-lang/tests/move_check/typing/type_variable_join_threaded_pack_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/type_variable_join_threaded_pack_invalid.exp
@@ -1,3 +1,18 @@
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/type_variable_join_threaded_pack_invalid.move:47:17
+   │
+10 │     public fun get<V: drop>(self: &T<V>): V {
+   │                       ---- 'drop' constraint declared here
+   ·
+27 │     struct Box<T> { f1: T, f2: T }
+   │            --- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+47 │         let x = Container::get(&v);
+   │                 ^^^^^^^^^^^^^^^^^^ 'drop' constraint not satisifed
+48 │         let b = Box { f1: x, f2: x };
+49 │         Container::put(&mut v, Box {f1: R{}, f2: R{}});
+   │                                ---------------------- The type '0x2::M::Box<0x2::M::R>' does not have the ability 'drop'
+
 error: 
 
     ┌── tests/move_check/typing/type_variable_join_threaded_pack_invalid.move:42:9 ───
@@ -10,22 +25,5 @@ error:
     ·
  35 │     fun t0(): Box<bool> {
     │                   ---- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/type_variable_join_threaded_pack_invalid.move:47:17 ───
-    │
- 47 │         let x = Container::get(&v);
-    │                 ^^^^^^^^^^^^^^^^^^ 'drop' constraint not satisifed
-    ·
- 49 │         Container::put(&mut v, Box {f1: R{}, f2: R{}});
-    │                                ---------------------- The type '0x2::M::Box<0x2::M::R>' does not have the ability 'drop'
-    ·
- 27 │     struct Box<T> { f1: T, f2: T }
-    │            --- To satisfy the constraint, the 'drop' ability would need to be added here
-    ·
- 10 │     public fun get<V: drop>(self: &T<V>): V {
-    │                       ---- 'drop' constraint declared here
     │
 

--- a/language/move-lang/tests/move_check/typing/type_variable_join_threaded_unpack.exp
+++ b/language/move-lang/tests/move_check/typing/type_variable_join_threaded_unpack.exp
@@ -1,14 +1,12 @@
-error: 
-
-    ┌── tests/move_check/typing/type_variable_join_threaded_unpack.move:39:42 ───
-    │
- 39 │         Container::put(&mut v, Box { f1: *&f1, f2 });
-    │                                          ^^^^ Invalid dereference. Dereference requires the 'copy' ability
-    ·
- 36 │     fun t1(): Box<Box<u64>> {
-    │               ------------- The type '0x2::M::Box<0x2::M::Box<u64>>' does not have the ability 'copy'
-    ·
- 23 │     struct Box<T> has drop { f1: T, f2: T }
-    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/type_variable_join_threaded_unpack.move:39:42
+   │
+23 │     struct Box<T> has drop { f1: T, f2: T }
+   │            --- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+36 │     fun t1(): Box<Box<u64>> {
+   │               ------------- The type '0x2::M::Box<0x2::M::Box<u64>>' does not have the ability 'copy'
+   ·
+39 │         Container::put(&mut v, Box { f1: *&f1, f2 });
+   │                                          ^^^^ Invalid dereference. Dereference requires the 'copy' ability
 

--- a/language/move-lang/tests/move_check/typing/type_variable_join_threaded_unpack_assign.exp
+++ b/language/move-lang/tests/move_check/typing/type_variable_join_threaded_unpack_assign.exp
@@ -1,14 +1,12 @@
-error: 
-
-    ┌── tests/move_check/typing/type_variable_join_threaded_unpack_assign.move:44:42 ───
-    │
- 44 │         Container::put(&mut v, Box { f1: *&f1, f2 });
-    │                                          ^^^^ Invalid dereference. Dereference requires the 'copy' ability
-    ·
- 39 │     fun t1(): Box<Box<u64>> {
-    │               ------------- The type '0x2::M::Box<0x2::M::Box<u64>>' does not have the ability 'copy'
-    ·
- 23 │     struct Box<T> has drop { f1: T, f2: T }
-    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/type_variable_join_threaded_unpack_assign.move:44:42
+   │
+23 │     struct Box<T> has drop { f1: T, f2: T }
+   │            --- To satisfy the constraint, the 'copy' ability would need to be added here
+   ·
+39 │     fun t1(): Box<Box<u64>> {
+   │               ------------- The type '0x2::M::Box<0x2::M::Box<u64>>' does not have the ability 'copy'
+   ·
+44 │         Container::put(&mut v, Box { f1: *&f1, f2 });
+   │                                          ^^^^ Invalid dereference. Dereference requires the 'copy' ability
 

--- a/language/move-lang/tests/move_check/typing/type_variable_join_threaded_unpack_assign_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/type_variable_join_threaded_unpack_assign_invalid.exp
@@ -1,3 +1,15 @@
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/type_variable_join_threaded_unpack_assign_invalid.move:43:27
+   │
+10 │     public fun get<V: drop>(self: &T<V>): V {
+   │                       ---- 'drop' constraint declared here
+   ·
+43 │         Box { f1, f2 }  = Container::get(&v);
+   │         --------------    ^^^^^^^^^^^^^^^^^^ 'drop' constraint not satisifed
+   │         │                  
+   │         The type '0x2::M::Box<0x2::M::R>' does not have the ability 'drop'
+   │         The type '0x2::M::Box<0x2::M::R>' can have the ability 'drop' but the type argument '0x2::M::R' does not have the required ability 'drop'
+
 error: 
 
     ┌── tests/move_check/typing/type_variable_join_threaded_unpack_assign_invalid.move:36:9 ───
@@ -10,22 +22,5 @@ error:
     ·
  30 │     fun t0(): bool {
     │               ---- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/type_variable_join_threaded_unpack_assign_invalid.move:43:27 ───
-    │
- 43 │         Box { f1, f2 }  = Container::get(&v);
-    │                           ^^^^^^^^^^^^^^^^^^ 'drop' constraint not satisifed
-    ·
- 43 │         Box { f1, f2 }  = Container::get(&v);
-    │         -------------- The type '0x2::M::Box<0x2::M::R>' does not have the ability 'drop'
-    ·
- 43 │         Box { f1, f2 }  = Container::get(&v);
-    │         -------------- The type '0x2::M::Box<0x2::M::R>' can have the ability 'drop' but the type argument '0x2::M::R' does not have the required ability 'drop'
-    ·
- 10 │     public fun get<V: drop>(self: &T<V>): V {
-    │                       ---- 'drop' constraint declared here
     │
 

--- a/language/move-lang/tests/move_check/typing/type_variable_join_threaded_unpack_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/type_variable_join_threaded_unpack_invalid.exp
@@ -1,3 +1,15 @@
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/type_variable_join_threaded_unpack_invalid.move:39:31
+   │
+10 │     public fun get<V: drop>(self: &T<V>): V {
+   │                       ---- 'drop' constraint declared here
+   ·
+39 │         let Box { f1, f2 }  = Container::get(&v);
+   │             --------------    ^^^^^^^^^^^^^^^^^^ 'drop' constraint not satisifed
+   │             │                  
+   │             The type '0x2::M::Box<0x2::M::R>' does not have the ability 'drop'
+   │             The type '0x2::M::Box<0x2::M::R>' can have the ability 'drop' but the type argument '0x2::M::R' does not have the required ability 'drop'
+
 error: 
 
     ┌── tests/move_check/typing/type_variable_join_threaded_unpack_invalid.move:34:9 ───
@@ -10,22 +22,5 @@ error:
     ·
  30 │     fun t0(): bool {
     │               ---- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/type_variable_join_threaded_unpack_invalid.move:39:31 ───
-    │
- 39 │         let Box { f1, f2 }  = Container::get(&v);
-    │                               ^^^^^^^^^^^^^^^^^^ 'drop' constraint not satisifed
-    ·
- 39 │         let Box { f1, f2 }  = Container::get(&v);
-    │             -------------- The type '0x2::M::Box<0x2::M::R>' does not have the ability 'drop'
-    ·
- 39 │         let Box { f1, f2 }  = Container::get(&v);
-    │             -------------- The type '0x2::M::Box<0x2::M::R>' can have the ability 'drop' but the type argument '0x2::M::R' does not have the required ability 'drop'
-    ·
- 10 │     public fun get<V: drop>(self: &T<V>): V {
-    │                       ---- 'drop' constraint declared here
     │
 

--- a/language/move-lang/tests/move_check/typing/valid_acquire.exp
+++ b/language/move-lang/tests/move_check/typing/valid_acquire.exp
@@ -1,56 +1,40 @@
-error: 
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/valid_acquire.move:43:16
+   │
+43 │         R3{} = move_from<R3<R1>>(a);
+   │                ^^^^^^^^^^^^^^^^^^^^
+   │                │         │  │
+   │                │         │  The type '0x8675309::M::R3<0x8675309::M::R1>' can have the ability 'key' but the type argument '0x8675309::M::R1' does not have the required ability 'store'
+   │                │         The type '0x8675309::M::R3<0x8675309::M::R1>' does not have the ability 'key'
+   │                Invalid call of 'move_from'
 
-    ┌── tests/move_check/typing/valid_acquire.move:43:16 ───
-    │
- 43 │         R3{} = move_from<R3<R1>>(a);
-    │                ^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_from'
-    ·
- 43 │         R3{} = move_from<R3<R1>>(a);
-    │                          ------ The type '0x8675309::M::R3<0x8675309::M::R1>' does not have the ability 'key'
-    ·
- 43 │         R3{} = move_from<R3<R1>>(a);
-    │                             -- The type '0x8675309::M::R3<0x8675309::M::R1>' can have the ability 'key' but the type argument '0x8675309::M::R1' does not have the required ability 'store'
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/valid_acquire.move:45:9
+   │
+45 │         borrow_global_mut<R3<R2>>(a);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │                 │  │
+   │         │                 │  The type '0x8675309::M::R3<0x8675309::M::R2>' can have the ability 'key' but the type argument '0x8675309::M::R2' does not have the required ability 'store'
+   │         │                 The type '0x8675309::M::R3<0x8675309::M::R2>' does not have the ability 'key'
+   │         Invalid call of 'borrow_global_mut'
 
-error: 
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/valid_acquire.move:50:9
+   │
+50 │         exists<R3<R1>>(a);
+   │         ^^^^^^^^^^^^^^^^^
+   │         │      │  │
+   │         │      │  The type '0x8675309::M::R3<0x8675309::M::R1>' can have the ability 'key' but the type argument '0x8675309::M::R1' does not have the required ability 'store'
+   │         │      The type '0x8675309::M::R3<0x8675309::M::R1>' does not have the ability 'key'
+   │         Invalid call of 'exists'
 
-    ┌── tests/move_check/typing/valid_acquire.move:45:9 ───
-    │
- 45 │         borrow_global_mut<R3<R2>>(a);
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'borrow_global_mut'
-    ·
- 45 │         borrow_global_mut<R3<R2>>(a);
-    │                           ------ The type '0x8675309::M::R3<0x8675309::M::R2>' does not have the ability 'key'
-    ·
- 45 │         borrow_global_mut<R3<R2>>(a);
-    │                              -- The type '0x8675309::M::R3<0x8675309::M::R2>' can have the ability 'key' but the type argument '0x8675309::M::R2' does not have the required ability 'store'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/valid_acquire.move:50:9 ───
-    │
- 50 │         exists<R3<R1>>(a);
-    │         ^^^^^^^^^^^^^^^^^ Invalid call of 'exists'
-    ·
- 50 │         exists<R3<R1>>(a);
-    │                ------ The type '0x8675309::M::R3<0x8675309::M::R1>' does not have the ability 'key'
-    ·
- 50 │         exists<R3<R1>>(a);
-    │                   -- The type '0x8675309::M::R3<0x8675309::M::R1>' can have the ability 'key' but the type argument '0x8675309::M::R1' does not have the required ability 'store'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/valid_acquire.move:52:9 ───
-    │
- 52 │         move_to<R3<R2>>(account, R3{});
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_to'
-    ·
- 52 │         move_to<R3<R2>>(account, R3{});
-    │                 ------ The type '0x8675309::M::R3<0x8675309::M::R2>' does not have the ability 'key'
-    ·
- 52 │         move_to<R3<R2>>(account, R3{});
-    │                    -- The type '0x8675309::M::R3<0x8675309::M::R2>' can have the ability 'key' but the type argument '0x8675309::M::R2' does not have the required ability 'store'
-    │
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/valid_acquire.move:52:9
+   │
+52 │         move_to<R3<R2>>(account, R3{});
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │       │  │
+   │         │       │  The type '0x8675309::M::R3<0x8675309::M::R2>' can have the ability 'key' but the type argument '0x8675309::M::R2' does not have the required ability 'store'
+   │         │       The type '0x8675309::M::R3<0x8675309::M::R2>' does not have the ability 'key'
+   │         Invalid call of 'move_to'
 


### PR DESCRIPTION
- Migrating errors in typing/core.rs

## Motivation

- Continuing codespan migration 
- I opted to using the term variable instead of local in a few spots because I think it might be less confusing (we don't have other kinds of variables)

## Test Plan

- Updated tests

## Related PRs

Continuation of #8588
