### PR TITLE
[gha] limit cargo audit log

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -43,7 +43,7 @@ jobs:
           echo "ISSUE_BODY<<EOF" >> $GITHUB_ENV
           echo "Found RUSTSEC in dependencies in job ${JOB_URL}" >> $GITHUB_ENV
           echo "\`\`\`" >> $GITHUB_ENV
-          cat $AUDIT_SUMMARY_FILE >> $GITHUB_ENV
+          head -100 $AUDIT_SUMMARY_FILE >> $GITHUB_ENV
           echo "\`\`\`" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
       - uses: diem/actions/create-issue@04f4286ca22e4b9efbc5eb49a20e2e5389c5318b


### PR DESCRIPTION
## Motivation
For a widely used crate, the output from cargo audit failure can be too long to fit in GHA (ex https://github.com/diem/diem/runs/3020018531?check_suite_focus=true)

## Test Plan
CI