### PR TITLE
[diem framework] remove `verify=false` from scripts

### DIFF
--- a/language/diem-framework/modules/PaymentScripts.move
+++ b/language/diem-framework/modules/PaymentScripts.move
@@ -133,9 +133,6 @@ module DiemFramework::PaymentScripts {
     }
 
     spec peer_to_peer_with_metadata {
-        /// TODO(timeout): this currently times out
-        pragma verify = false;
-
         include PeerToPeer<Currency>;
         include DualAttestation::AssertPaymentOkAbortsIf<Currency>{
             payer: Signer::spec_address_of(payer),
@@ -144,9 +141,6 @@ module DiemFramework::PaymentScripts {
     }
 
     spec peer_to_peer_by_signers {
-        /// TODO(timeout): this currently times out
-        pragma verify = false;
-
         include PeerToPeer<Currency>{payee: Signer::spec_address_of(payee)};
     }
 

--- a/language/diem-framework/modules/TreasuryComplianceScripts.move
+++ b/language/diem-framework/modules/TreasuryComplianceScripts.move
@@ -267,9 +267,6 @@ module DiemFramework::TreasuryComplianceScripts {
         /// **Access Control:**
         /// Only the account with a Preburn resource or PreburnQueue resource can preburn [[H4]][PERMISSION].
         aborts_if !(exists<Diem::Preburn<Token>>(account_addr) || exists<Diem::PreburnQueue<Token>>(account_addr));
-
-        /// TODO(timeout): this currently times out
-        pragma verify = false;
     }
 
     /// # Summary

--- a/language/diem-framework/modules/doc/AccountCreationScripts.md
+++ b/language/diem-framework/modules/doc/AccountCreationScripts.md
@@ -186,6 +186,13 @@ This is emitted on the new Child VASPS's <code><a href="DiemAccount.md#0x1_DiemA
 <b>aborts_if</b> child_initial_balance &gt; max_u64() <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_LIMIT_EXCEEDED">Errors::LIMIT_EXCEEDED</a>;
 <b>include</b> (child_initial_balance &gt; 0) ==&gt;
     <a href="DiemAccount.md#0x1_DiemAccount_ExtractWithdrawCapAbortsIf">DiemAccount::ExtractWithdrawCapAbortsIf</a>{sender_addr: parent_addr};
+<b>include</b> (child_initial_balance &gt; 0) ==&gt; <a href="DualAttestation.md#0x1_DualAttestation_AssertPaymentOkAbortsIf">DualAttestation::AssertPaymentOkAbortsIf</a>&lt;CoinType&gt;{
+    payer: parent_addr,
+    payee: child_address,
+    metadata: x"",
+    metadata_signature: x"",
+    value: child_initial_balance
+};
 <b>include</b> (child_initial_balance) &gt; 0 ==&gt;
     <a href="DiemAccount.md#0x1_DiemAccount_PayFromAbortsIfRestricted">DiemAccount::PayFromAbortsIfRestricted</a>&lt;CoinType&gt;{
         cap: parent_cap,
@@ -207,14 +214,6 @@ This is emitted on the new Child VASPS's <code><a href="DiemAccount.md#0x1_DiemA
     <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>,
     <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>,
     <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
-<b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_MakeAccountEmits">DiemAccount::MakeAccountEmits</a>{new_account_address: child_address};
-<b>include</b> child_initial_balance &gt; 0 ==&gt;
-    <a href="DiemAccount.md#0x1_DiemAccount_PayFromEmits">DiemAccount::PayFromEmits</a>&lt;CoinType&gt;{
-        cap: parent_cap,
-        payee: child_address,
-        amount: child_initial_balance,
-        metadata: x"",
-    };
 </code></pre>
 
 
@@ -223,13 +222,6 @@ Only Parent VASP accounts can create Child VASP accounts [[A7]][ROLE].
 
 
 <pre><code><b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotParentVasp">Roles::AbortsIfNotParentVasp</a>{account: parent_vasp};
-</code></pre>
-
-
-TODO(timeout): this currently times out
-
-
-<pre><code><b>pragma</b> verify = <b>false</b>;
 </code></pre>
 
 

--- a/language/diem-framework/modules/doc/PaymentScripts.md
+++ b/language/diem-framework/modules/doc/PaymentScripts.md
@@ -145,11 +145,8 @@ Successful execution of this script emits two events:
 <summary>Specification</summary>
 
 
-TODO(timeout): this currently times out
 
-
-<pre><code><b>pragma</b> verify = <b>false</b>;
-<b>include</b> <a href="PaymentScripts.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;;
+<pre><code><b>include</b> <a href="PaymentScripts.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;;
 <b>include</b> <a href="DualAttestation.md#0x1_DualAttestation_AssertPaymentOkAbortsIf">DualAttestation::AssertPaymentOkAbortsIf</a>&lt;Currency&gt;{
     payer: <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer),
     value: amount
@@ -266,11 +263,8 @@ Successful execution of this script emits two events:
 <summary>Specification</summary>
 
 
-TODO(timeout): this currently times out
 
-
-<pre><code><b>pragma</b> verify = <b>false</b>;
-<b>include</b> <a href="PaymentScripts.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;{payee: <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payee)};
+<pre><code><b>include</b> <a href="PaymentScripts.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;{payee: <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payee)};
 </code></pre>
 
 

--- a/language/diem-framework/modules/doc/TreasuryComplianceScripts.md
+++ b/language/diem-framework/modules/doc/TreasuryComplianceScripts.md
@@ -510,13 +510,6 @@ Only the account with a Preburn resource or PreburnQueue resource can preburn [[
 </code></pre>
 
 
-TODO(timeout): this currently times out
-
-
-<pre><code><b>pragma</b> verify = <b>false</b>;
-</code></pre>
-
-
 
 </details>
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/AccountCreationScripts.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/AccountCreationScripts.md
@@ -186,6 +186,13 @@ This is emitted on the new Child VASPS's <code><a href="DiemAccount.md#0x1_DiemA
 <b>aborts_if</b> child_initial_balance &gt; max_u64() <b>with</b> <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_LIMIT_EXCEEDED">Errors::LIMIT_EXCEEDED</a>;
 <b>include</b> (child_initial_balance &gt; 0) ==&gt;
     <a href="DiemAccount.md#0x1_DiemAccount_ExtractWithdrawCapAbortsIf">DiemAccount::ExtractWithdrawCapAbortsIf</a>{sender_addr: parent_addr};
+<b>include</b> (child_initial_balance &gt; 0) ==&gt; <a href="DualAttestation.md#0x1_DualAttestation_AssertPaymentOkAbortsIf">DualAttestation::AssertPaymentOkAbortsIf</a>&lt;CoinType&gt;{
+    payer: parent_addr,
+    payee: child_address,
+    metadata: x"",
+    metadata_signature: x"",
+    value: child_initial_balance
+};
 <b>include</b> (child_initial_balance) &gt; 0 ==&gt;
     <a href="DiemAccount.md#0x1_DiemAccount_PayFromAbortsIfRestricted">DiemAccount::PayFromAbortsIfRestricted</a>&lt;CoinType&gt;{
         cap: parent_cap,
@@ -207,14 +214,6 @@ This is emitted on the new Child VASPS's <code><a href="DiemAccount.md#0x1_DiemA
     <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>,
     <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>,
     <a href="../../../../../../move-stdlib/docs/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
-<b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_MakeAccountEmits">DiemAccount::MakeAccountEmits</a>{new_account_address: child_address};
-<b>include</b> child_initial_balance &gt; 0 ==&gt;
-    <a href="DiemAccount.md#0x1_DiemAccount_PayFromEmits">DiemAccount::PayFromEmits</a>&lt;CoinType&gt;{
-        cap: parent_cap,
-        payee: child_address,
-        amount: child_initial_balance,
-        metadata: x"",
-    };
 </code></pre>
 
 
@@ -223,13 +222,6 @@ Only Parent VASP accounts can create Child VASP accounts [[A7]][ROLE].
 
 
 <pre><code><b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotParentVasp">Roles::AbortsIfNotParentVasp</a>{account: parent_vasp};
-</code></pre>
-
-
-TODO(timeout): this currently times out
-
-
-<pre><code><b>pragma</b> verify = <b>false</b>;
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/PaymentScripts.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/PaymentScripts.md
@@ -145,11 +145,8 @@ Successful execution of this script emits two events:
 <summary>Specification</summary>
 
 
-TODO(timeout): this currently times out
 
-
-<pre><code><b>pragma</b> verify = <b>false</b>;
-<b>include</b> <a href="PaymentScripts.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;;
+<pre><code><b>include</b> <a href="PaymentScripts.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;;
 <b>include</b> <a href="DualAttestation.md#0x1_DualAttestation_AssertPaymentOkAbortsIf">DualAttestation::AssertPaymentOkAbortsIf</a>&lt;Currency&gt;{
     payer: <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer),
     value: amount
@@ -266,11 +263,8 @@ Successful execution of this script emits two events:
 <summary>Specification</summary>
 
 
-TODO(timeout): this currently times out
 
-
-<pre><code><b>pragma</b> verify = <b>false</b>;
-<b>include</b> <a href="PaymentScripts.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;{payee: <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payee)};
+<pre><code><b>include</b> <a href="PaymentScripts.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;{payee: <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payee)};
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/TreasuryComplianceScripts.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/TreasuryComplianceScripts.md
@@ -510,13 +510,6 @@ Only the account with a Preburn resource or PreburnQueue resource can preburn [[
 </code></pre>
 
 
-TODO(timeout): this currently times out
-
-
-<pre><code><b>pragma</b> verify = <b>false</b>;
-</code></pre>
-
-
 
 </details>
 

--- a/language/diem-framework/releases/artifacts/current/docs/scripts/script_documentation.md
+++ b/language/diem-framework/releases/artifacts/current/docs/scripts/script_documentation.md
@@ -844,6 +844,13 @@ This is emitted on the new Child VASPS's <code><a href="../../../../../releases/
 <b>aborts_if</b> child_initial_balance &gt; max_u64() <b>with</b> <a href="_LIMIT_EXCEEDED">Errors::LIMIT_EXCEEDED</a>;
 <b>include</b> (child_initial_balance &gt; 0) ==&gt;
     <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_ExtractWithdrawCapAbortsIf">DiemAccount::ExtractWithdrawCapAbortsIf</a>{sender_addr: parent_addr};
+<b>include</b> (child_initial_balance &gt; 0) ==&gt; <a href="../../../../../releases/artifacts/current/docs/modules/DualAttestation.md#0x1_DualAttestation_AssertPaymentOkAbortsIf">DualAttestation::AssertPaymentOkAbortsIf</a>&lt;CoinType&gt;{
+    payer: parent_addr,
+    payee: child_address,
+    metadata: x"",
+    metadata_signature: x"",
+    value: child_initial_balance
+};
 <b>include</b> (child_initial_balance) &gt; 0 ==&gt;
     <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_PayFromAbortsIfRestricted">DiemAccount::PayFromAbortsIfRestricted</a>&lt;CoinType&gt;{
         cap: parent_cap,
@@ -865,14 +872,6 @@ This is emitted on the new Child VASPS's <code><a href="../../../../../releases/
     <a href="_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>,
     <a href="_INVALID_STATE">Errors::INVALID_STATE</a>,
     <a href="_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
-<b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_MakeAccountEmits">DiemAccount::MakeAccountEmits</a>{new_account_address: child_address};
-<b>include</b> child_initial_balance &gt; 0 ==&gt;
-    <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_PayFromEmits">DiemAccount::PayFromEmits</a>&lt;CoinType&gt;{
-        cap: parent_cap,
-        payee: child_address,
-        amount: child_initial_balance,
-        metadata: x"",
-    };
 </code></pre>
 
 
@@ -881,13 +880,6 @@ Only Parent VASP accounts can create Child VASP accounts [[A7]][ROLE].
 
 
 <pre><code><b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/Roles.md#0x1_Roles_AbortsIfNotParentVasp">Roles::AbortsIfNotParentVasp</a>{account: parent_vasp};
-</code></pre>
-
-
-TODO(timeout): this currently times out
-
-
-<pre><code><b>pragma</b> verify = <b>false</b>;
 </code></pre>
 
 
@@ -2770,11 +2762,8 @@ Successful execution of this script emits two events:
 <summary>Specification</summary>
 
 
-TODO(timeout): this currently times out
 
-
-<pre><code><b>pragma</b> verify = <b>false</b>;
-<b>include</b> <a href="script_documentation.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;;
+<pre><code><b>include</b> <a href="script_documentation.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;;
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DualAttestation.md#0x1_DualAttestation_AssertPaymentOkAbortsIf">DualAttestation::AssertPaymentOkAbortsIf</a>&lt;Currency&gt;{
     payer: <a href="_spec_address_of">Signer::spec_address_of</a>(payer),
     value: amount
@@ -2891,11 +2880,8 @@ Successful execution of this script emits two events:
 <summary>Specification</summary>
 
 
-TODO(timeout): this currently times out
 
-
-<pre><code><b>pragma</b> verify = <b>false</b>;
-<b>include</b> <a href="script_documentation.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;{payee: <a href="_spec_address_of">Signer::spec_address_of</a>(payee)};
+<pre><code><b>include</b> <a href="script_documentation.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;{payee: <a href="_spec_address_of">Signer::spec_address_of</a>(payee)};
 </code></pre>
 
 
@@ -4228,13 +4214,6 @@ Only the account with a Preburn resource or PreburnQueue resource can preburn [[
 
 
 <pre><code><b>aborts_if</b> !(<b>exists</b>&lt;<a href="../../../../../releases/artifacts/current/docs/modules/Diem.md#0x1_Diem_Preburn">Diem::Preburn</a>&lt;Token&gt;&gt;(account_addr) || <b>exists</b>&lt;<a href="../../../../../releases/artifacts/current/docs/modules/Diem.md#0x1_Diem_PreburnQueue">Diem::PreburnQueue</a>&lt;Token&gt;&gt;(account_addr));
-</code></pre>
-
-
-TODO(timeout): this currently times out
-
-
-<pre><code><b>pragma</b> verify = <b>false</b>;
 </code></pre>
 
 

--- a/language/diem-framework/script_documentation/script_documentation.md
+++ b/language/diem-framework/script_documentation/script_documentation.md
@@ -844,6 +844,13 @@ This is emitted on the new Child VASPS's <code><a href="../../../../../releases/
 <b>aborts_if</b> child_initial_balance &gt; max_u64() <b>with</b> <a href="_LIMIT_EXCEEDED">Errors::LIMIT_EXCEEDED</a>;
 <b>include</b> (child_initial_balance &gt; 0) ==&gt;
     <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_ExtractWithdrawCapAbortsIf">DiemAccount::ExtractWithdrawCapAbortsIf</a>{sender_addr: parent_addr};
+<b>include</b> (child_initial_balance &gt; 0) ==&gt; <a href="../../../../../releases/artifacts/current/docs/modules/DualAttestation.md#0x1_DualAttestation_AssertPaymentOkAbortsIf">DualAttestation::AssertPaymentOkAbortsIf</a>&lt;CoinType&gt;{
+    payer: parent_addr,
+    payee: child_address,
+    metadata: x"",
+    metadata_signature: x"",
+    value: child_initial_balance
+};
 <b>include</b> (child_initial_balance) &gt; 0 ==&gt;
     <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_PayFromAbortsIfRestricted">DiemAccount::PayFromAbortsIfRestricted</a>&lt;CoinType&gt;{
         cap: parent_cap,
@@ -865,14 +872,6 @@ This is emitted on the new Child VASPS's <code><a href="../../../../../releases/
     <a href="_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>,
     <a href="_INVALID_STATE">Errors::INVALID_STATE</a>,
     <a href="_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
-<b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_MakeAccountEmits">DiemAccount::MakeAccountEmits</a>{new_account_address: child_address};
-<b>include</b> child_initial_balance &gt; 0 ==&gt;
-    <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_PayFromEmits">DiemAccount::PayFromEmits</a>&lt;CoinType&gt;{
-        cap: parent_cap,
-        payee: child_address,
-        amount: child_initial_balance,
-        metadata: x"",
-    };
 </code></pre>
 
 
@@ -881,13 +880,6 @@ Only Parent VASP accounts can create Child VASP accounts [[A7]][ROLE].
 
 
 <pre><code><b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/Roles.md#0x1_Roles_AbortsIfNotParentVasp">Roles::AbortsIfNotParentVasp</a>{account: parent_vasp};
-</code></pre>
-
-
-TODO(timeout): this currently times out
-
-
-<pre><code><b>pragma</b> verify = <b>false</b>;
 </code></pre>
 
 
@@ -2770,11 +2762,8 @@ Successful execution of this script emits two events:
 <summary>Specification</summary>
 
 
-TODO(timeout): this currently times out
 
-
-<pre><code><b>pragma</b> verify = <b>false</b>;
-<b>include</b> <a href="script_documentation.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;;
+<pre><code><b>include</b> <a href="script_documentation.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;;
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DualAttestation.md#0x1_DualAttestation_AssertPaymentOkAbortsIf">DualAttestation::AssertPaymentOkAbortsIf</a>&lt;Currency&gt;{
     payer: <a href="_spec_address_of">Signer::spec_address_of</a>(payer),
     value: amount
@@ -2891,11 +2880,8 @@ Successful execution of this script emits two events:
 <summary>Specification</summary>
 
 
-TODO(timeout): this currently times out
 
-
-<pre><code><b>pragma</b> verify = <b>false</b>;
-<b>include</b> <a href="script_documentation.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;{payee: <a href="_spec_address_of">Signer::spec_address_of</a>(payee)};
+<pre><code><b>include</b> <a href="script_documentation.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;{payee: <a href="_spec_address_of">Signer::spec_address_of</a>(payee)};
 </code></pre>
 
 
@@ -4228,13 +4214,6 @@ Only the account with a Preburn resource or PreburnQueue resource can preburn [[
 
 
 <pre><code><b>aborts_if</b> !(<b>exists</b>&lt;<a href="../../../../../releases/artifacts/current/docs/modules/Diem.md#0x1_Diem_Preburn">Diem::Preburn</a>&lt;Token&gt;&gt;(account_addr) || <b>exists</b>&lt;<a href="../../../../../releases/artifacts/current/docs/modules/Diem.md#0x1_Diem_PreburnQueue">Diem::PreburnQueue</a>&lt;Token&gt;&gt;(account_addr));
-</code></pre>
-
-
-TODO(timeout): this currently times out
-
-
-<pre><code><b>pragma</b> verify = <b>false</b>;
 </code></pre>
 
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR removes outdated `verify = false` from some script modules since they no longer timeout. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes


