### PR TITLE
[types] Add `StateProof` type

### DIFF
--- a/consensus/src/persistent_liveness_storage.rs
+++ b/consensus/src/persistent_liveness_storage.rs
@@ -405,7 +405,8 @@ impl PersistentLivenessStorage for StorageWriteProxy {
         let (_, proofs, _) = self
             .diem_db
             .get_state_proof(version)
-            .map_err(DbError::from)?;
+            .map_err(DbError::from)?
+            .into_inner();
         Ok(proofs)
     }
 

--- a/execution/executor-test-helpers/src/integration_test_impl.rs
+++ b/execution/executor-test-helpers/src/integration_test_impl.rs
@@ -241,18 +241,14 @@ pub fn test_execution_with_storage_impl() -> Arc<DiemDB> {
         .unwrap();
 
     let initial_accumulator = db.reader.get_accumulator_summary(0).unwrap();
-    let (li, epoch_change_proof, consistency_proof) = db.reader.get_state_proof(0).unwrap();
+    let state_proof = db.reader.get_state_proof(0).unwrap();
     let trusted_state = TrustedState::from_epoch_waypoint(waypoint);
-    let trusted_state = match trusted_state.verify_and_ratchet(
-        &li,
-        &epoch_change_proof,
-        &consistency_proof,
-        Some(&initial_accumulator),
-    ) {
-        Ok(TrustedStateChange::Epoch { new_state, .. }) => new_state,
-        _ => panic!("unexpected state change"),
-    };
-    let current_version = li.ledger_info().version();
+    let trusted_state =
+        match trusted_state.verify_and_ratchet(&state_proof, Some(&initial_accumulator)) {
+            Ok(TrustedStateChange::Epoch { new_state, .. }) => new_state,
+            _ => panic!("unexpected state change"),
+        };
+    let current_version = state_proof.latest_ledger_info().version();
     assert_eq!(trusted_state.version(), 9);
 
     let t1 = db
@@ -421,16 +417,15 @@ pub fn test_execution_with_storage_impl() -> Arc<DiemDB> {
         .commit_blocks(vec![block2_id], ledger_info_with_sigs)
         .unwrap();
 
-    let (li, epoch_change_proof, consistency_proof) =
-        db.reader.get_state_proof(trusted_state.version()).unwrap();
+    let state_proof = db.reader.get_state_proof(trusted_state.version()).unwrap();
     let trusted_state_change = trusted_state
-        .verify_and_ratchet(&li, &epoch_change_proof, &consistency_proof, None)
+        .verify_and_ratchet(&state_proof, None)
         .unwrap();
     assert!(matches!(
         trusted_state_change,
         TrustedStateChange::Version { .. }
     ));
-    let current_version = li.ledger_info().version();
+    let current_version = state_proof.latest_ledger_info().version();
     assert_eq!(current_version, 23);
 
     let t7 = db

--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -12,7 +12,8 @@ use diem_types::{
     epoch_change::EpochChangeProof,
     event::EventKey,
     ledger_info::LedgerInfoWithSignatures,
-    proof::{AccumulatorConsistencyProof, SparseMerkleProof},
+    proof::SparseMerkleProof,
+    state_proof::StateProof,
     transaction::{
         AccountTransactionsWithProof, Transaction, TransactionListWithProof, TransactionOutput,
         TransactionToCommit, TransactionWithProof, Version,
@@ -163,19 +164,12 @@ impl DbReader for FakeDb {
     fn get_state_proof_with_ledger_info(
         &self,
         _known_version: u64,
-        _ledger_info: &LedgerInfoWithSignatures,
-    ) -> Result<(EpochChangeProof, AccumulatorConsistencyProof)> {
+        _ledger_info: LedgerInfoWithSignatures,
+    ) -> Result<StateProof> {
         unimplemented!();
     }
 
-    fn get_state_proof(
-        &self,
-        _known_version: u64,
-    ) -> Result<(
-        LedgerInfoWithSignatures,
-        EpochChangeProof,
-        AccumulatorConsistencyProof,
-    )> {
+    fn get_state_proof(&self, _known_version: u64) -> Result<StateProof> {
         unimplemented!();
     }
 

--- a/execution/executor/tests/db_bootstrapper_test.rs
+++ b/execution/executor/tests/db_bootstrapper_test.rs
@@ -74,17 +74,12 @@ fn test_empty_db() {
         .get_accumulator_summary(waypoint.version())
         .unwrap();
     let trusted_state = TrustedState::from_epoch_waypoint(waypoint);
-    let (li, epoch_change_proof, consistency_proof) = db_rw
+    let state_proof = db_rw
         .reader
         .get_state_proof(trusted_state.version())
         .unwrap();
     let trusted_state_change = trusted_state
-        .verify_and_ratchet(
-            &li,
-            &epoch_change_proof,
-            &consistency_proof,
-            Some(&initial_accumulator),
-        )
+        .verify_and_ratchet(&state_proof, Some(&initial_accumulator))
         .unwrap();
     assert!(trusted_state_change.is_epoch_change());
 
@@ -324,17 +319,12 @@ fn test_pre_genesis() {
         .reader
         .get_accumulator_summary(trusted_state.version())
         .unwrap();
-    let (li, epoch_change_proof, consistency_proof) = db_rw
+    let state_proof = db_rw
         .reader
         .get_state_proof(trusted_state.version())
         .unwrap();
     let trusted_state_change = trusted_state
-        .verify_and_ratchet(
-            &li,
-            &epoch_change_proof,
-            &consistency_proof,
-            Some(&initial_accumulator),
-        )
+        .verify_and_ratchet(&state_proof, Some(&initial_accumulator))
         .unwrap();
     assert!(trusted_state_change.is_epoch_change());
 
@@ -370,15 +360,9 @@ fn test_new_genesis() {
         .reader
         .get_accumulator_summary(trusted_state.version())
         .unwrap();
-    let (li, epoch_change_proof, consistency_proof) =
-        db.reader.get_state_proof(trusted_state.version()).unwrap();
+    let state_proof = db.reader.get_state_proof(trusted_state.version()).unwrap();
     let trusted_state_change = trusted_state
-        .verify_and_ratchet(
-            &li,
-            &epoch_change_proof,
-            &consistency_proof,
-            Some(&initial_accumulator),
-        )
+        .verify_and_ratchet(&state_proof, Some(&initial_accumulator))
         .unwrap();
     assert!(trusted_state_change.is_epoch_change());
 
@@ -420,20 +404,14 @@ fn test_new_genesis() {
         .reader
         .get_accumulator_summary(trusted_state.version())
         .unwrap();
-    let (li, epoch_change_proof, consistency_proof) =
-        db.reader.get_state_proof(trusted_state.version()).unwrap();
+    let state_proof = db.reader.get_state_proof(trusted_state.version()).unwrap();
     let trusted_state_change = trusted_state
-        .verify_and_ratchet(
-            &li,
-            &epoch_change_proof,
-            &consistency_proof,
-            Some(&initial_accumulator),
-        )
+        .verify_and_ratchet(&state_proof, Some(&initial_accumulator))
         .unwrap();
     assert!(trusted_state_change.is_epoch_change());
     let trusted_state = trusted_state_change.new_state().unwrap();
     assert_eq!(trusted_state.version(), 5);
-    assert!(consistency_proof.is_empty());
+    assert!(state_proof.consistency_proof().is_empty());
 
     // Effect of bootstrapping reflected.
     assert_eq!(get_balance(&account1, &db), 1_000_000);

--- a/json-rpc/src/data.rs
+++ b/json-rpc/src/data.rs
@@ -254,10 +254,10 @@ pub fn get_network_status(_role: &str) -> Result<u64, JsonRpcError> {
 pub fn get_state_proof(
     db: &dyn DbReader,
     version: u64,
-    ledger_info: &LedgerInfoWithSignatures,
+    ledger_info: LedgerInfoWithSignatures,
 ) -> Result<StateProofView, JsonRpcError> {
-    let proofs = db.get_state_proof_with_ledger_info(version, &ledger_info)?;
-    StateProofView::try_from((ledger_info.clone(), proofs.0, proofs.1)).map_err(Into::into)
+    let state_proof = db.get_state_proof_with_ledger_info(version, ledger_info)?;
+    StateProofView::try_from(&state_proof).map_err(Into::into)
 }
 
 /// Returns a proof that allows a client to extend their accumulator summary from

--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -372,7 +372,7 @@ impl<'a> Handler<'a> {
         params: GetStateProofParams,
     ) -> Result<StateProofView, JsonRpcError> {
         let version = self.version_param(Some(params.version), "version")?;
-        data::get_state_proof(self.service.db.borrow(), version, &self.ledger_info)
+        data::get_state_proof(self.service.db.borrow(), version, self.ledger_info.clone())
     }
 
     async fn get_accumulator_consistency_proof(

--- a/json-rpc/src/tests/utils.rs
+++ b/json-rpc/src/tests/utils.rs
@@ -28,6 +28,7 @@ use diem_types::{
         AccumulatorConsistencyProof, AccumulatorRangeProof, SparseMerkleProof,
         TransactionAccumulatorProof, TransactionInfoWithProof, TransactionListProof,
     },
+    state_proof::StateProof,
     transaction::{
         AccountTransactionsWithProof, SignedTransaction, Transaction, TransactionInfo,
         TransactionListWithProof, TransactionWithProof, Version,
@@ -294,29 +295,18 @@ impl DbReader for MockDiemDB {
         unimplemented!()
     }
 
-    fn get_state_proof(
-        &self,
-        known_version: u64,
-    ) -> Result<(
-        LedgerInfoWithSignatures,
-        EpochChangeProof,
-        AccumulatorConsistencyProof,
-    )> {
+    fn get_state_proof(&self, known_version: u64) -> Result<StateProof> {
         let li = self.get_latest_ledger_info()?;
-        let proofs = self.get_state_proof_with_ledger_info(known_version, &li)?;
-        Ok((
-            LedgerInfoWithSignatures::new(li.ledger_info().clone(), BTreeMap::new()),
-            proofs.0,
-            proofs.1,
-        ))
+        self.get_state_proof_with_ledger_info(known_version, li)
     }
 
     fn get_state_proof_with_ledger_info(
         &self,
         _known_version: u64,
-        _ledger_info: &LedgerInfoWithSignatures,
-    ) -> Result<(EpochChangeProof, AccumulatorConsistencyProof)> {
-        Ok((
+        li: LedgerInfoWithSignatures,
+    ) -> Result<StateProof> {
+        Ok(StateProof::new(
+            LedgerInfoWithSignatures::new(li.ledger_info().clone(), BTreeMap::new()),
             EpochChangeProof::new(vec![], false),
             AccumulatorConsistencyProof::new(vec![]),
         ))

--- a/storage/storage-client/src/lib.rs
+++ b/storage/storage-client/src/lib.rs
@@ -15,7 +15,8 @@ use diem_types::{
     epoch_change::EpochChangeProof,
     event::EventKey,
     ledger_info::LedgerInfoWithSignatures,
-    proof::{AccumulatorConsistencyProof, SparseMerkleProof},
+    proof::SparseMerkleProof,
+    state_proof::StateProof,
     transaction::{
         AccountTransactionsWithProof, TransactionListWithProof, TransactionToCommit,
         TransactionWithProof, Version,
@@ -175,22 +176,15 @@ impl DbReader for StorageClient {
         unimplemented!();
     }
 
-    fn get_state_proof(
-        &self,
-        _known_version: u64,
-    ) -> Result<(
-        LedgerInfoWithSignatures,
-        EpochChangeProof,
-        AccumulatorConsistencyProof,
-    )> {
+    fn get_state_proof(&self, _known_version: u64) -> Result<StateProof> {
         unimplemented!()
     }
 
     fn get_state_proof_with_ledger_info(
         &self,
         _known_version: u64,
-        _ledger_info: &LedgerInfoWithSignatures,
-    ) -> Result<(EpochChangeProof, AccumulatorConsistencyProof)> {
+        _ledger_info: LedgerInfoWithSignatures,
+    ) -> Result<StateProof> {
         unimplemented!()
     }
 

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -18,6 +18,7 @@ use diem_types::{
         definition::LeafCount, AccumulatorConsistencyProof, SparseMerkleProof,
         TransactionAccumulatorSummary,
     },
+    state_proof::StateProof,
     transaction::{
         AccountTransactionsWithProof, TransactionInfo, TransactionListWithProof,
         TransactionToCommit, TransactionWithProof, Version,
@@ -281,18 +282,11 @@ pub trait DbReader: Send + Sync {
     fn get_state_proof_with_ledger_info(
         &self,
         known_version: u64,
-        ledger_info: &LedgerInfoWithSignatures,
-    ) -> Result<(EpochChangeProof, AccumulatorConsistencyProof)>;
+        ledger_info: LedgerInfoWithSignatures,
+    ) -> Result<StateProof>;
 
     /// Returns proof of new state relative to version known to client
-    fn get_state_proof(
-        &self,
-        known_version: u64,
-    ) -> Result<(
-        LedgerInfoWithSignatures,
-        EpochChangeProof,
-        AccumulatorConsistencyProof,
-    )>;
+    fn get_state_proof(&self, known_version: u64) -> Result<StateProof>;
 
     /// Returns the account state corresponding to the given version and account address with proof
     /// based on `ledger_version`

--- a/storage/storage-interface/src/mock.rs
+++ b/storage/storage-interface/src/mock.rs
@@ -15,7 +15,8 @@ use diem_types::{
     epoch_change::EpochChangeProof,
     event::{EventHandle, EventKey},
     ledger_info::LedgerInfoWithSignatures,
-    proof::{AccumulatorConsistencyProof, SparseMerkleProof},
+    proof::SparseMerkleProof,
+    state_proof::StateProof,
     transaction::{
         AccountTransactionsWithProof, TransactionListWithProof, TransactionWithProof, Version,
     },
@@ -112,19 +113,12 @@ impl DbReader for MockDbReader {
     fn get_state_proof_with_ledger_info(
         &self,
         _known_version: u64,
-        _ledger_info: &LedgerInfoWithSignatures,
-    ) -> Result<(EpochChangeProof, AccumulatorConsistencyProof)> {
+        _ledger_info: LedgerInfoWithSignatures,
+    ) -> Result<StateProof> {
         unimplemented!()
     }
 
-    fn get_state_proof(
-        &self,
-        _known_version: u64,
-    ) -> Result<(
-        LedgerInfoWithSignatures,
-        EpochChangeProof,
-        AccumulatorConsistencyProof,
-    )> {
+    fn get_state_proof(&self, _known_version: u64) -> Result<StateProof> {
         unimplemented!()
     }
 

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -26,6 +26,7 @@ pub mod proof;
 #[cfg(any(test, feature = "fuzzing"))]
 pub mod proptest_types;
 pub mod serde_helper;
+pub mod state_proof;
 #[cfg(any(test, feature = "fuzzing"))]
 pub mod test_helpers;
 pub mod transaction;

--- a/types/src/state_proof.rs
+++ b/types/src/state_proof.rs
@@ -1,0 +1,106 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    epoch_change::EpochChangeProof,
+    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+    proof::AccumulatorConsistencyProof,
+};
+#[cfg(any(test, feature = "fuzzing"))]
+use proptest_derive::Arbitrary;
+use serde::{Deserialize, Serialize};
+
+/// A convenience type for the collection of sub-proofs that consistitute a
+/// response to a `get_state_proof` request.
+///
+/// From a `StateProof` response, a client should be able to ratchet their
+/// [`TrustedState`] to the last epoch change LI in the [`EpochChangeProof`]
+/// or the latest [`LedgerInfoWithSignatures`] if the epoch changes get them into
+/// the most recent epoch.
+///
+/// [`TrustedState`]: crate::trusted_state::TrustedState
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+pub struct StateProof {
+    latest_li_w_sigs: LedgerInfoWithSignatures,
+    epoch_changes: EpochChangeProof,
+    consistency_proof: AccumulatorConsistencyProof,
+}
+
+impl StateProof {
+    pub fn new(
+        latest_li_w_sigs: LedgerInfoWithSignatures,
+        epoch_changes: EpochChangeProof,
+        consistency_proof: AccumulatorConsistencyProof,
+    ) -> Self {
+        Self {
+            latest_li_w_sigs,
+            epoch_changes,
+            consistency_proof,
+        }
+    }
+
+    pub fn into_inner(
+        self,
+    ) -> (
+        LedgerInfoWithSignatures,
+        EpochChangeProof,
+        AccumulatorConsistencyProof,
+    ) {
+        (
+            self.latest_li_w_sigs,
+            self.epoch_changes,
+            self.consistency_proof,
+        )
+    }
+
+    pub fn as_inner(
+        &self,
+    ) -> (
+        &LedgerInfoWithSignatures,
+        &EpochChangeProof,
+        &AccumulatorConsistencyProof,
+    ) {
+        (
+            &self.latest_li_w_sigs,
+            &self.epoch_changes,
+            &self.consistency_proof,
+        )
+    }
+
+    #[inline]
+    pub fn latest_ledger_info(&self) -> &LedgerInfo {
+        self.latest_li_w_sigs.ledger_info()
+    }
+
+    #[inline]
+    pub fn latest_ledger_info_w_sigs(&self) -> &LedgerInfoWithSignatures {
+        &self.latest_li_w_sigs
+    }
+
+    #[inline]
+    pub fn epoch_changes(&self) -> &EpochChangeProof {
+        &self.epoch_changes
+    }
+
+    #[inline]
+    pub fn consistency_proof(&self) -> &AccumulatorConsistencyProof {
+        &self.consistency_proof
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bcs::test_helpers::assert_canonical_encode_decode;
+    use proptest::prelude::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(20))]
+
+        #[test]
+        fn test_state_proof_canonical_serialization(proof in any::<StateProof>()) {
+            assert_canonical_encode_decode(proof);
+        }
+    }
+}

--- a/types/src/trusted_state.rs
+++ b/types/src/trusted_state.rs
@@ -6,6 +6,7 @@ use crate::{
     epoch_state::EpochState,
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     proof::{AccumulatorConsistencyProof, TransactionAccumulatorSummary},
+    state_proof::StateProof,
     transaction::Version,
     waypoint::Waypoint,
 };
@@ -153,6 +154,19 @@ impl TrustedState {
     /// ratchet our trusted version forward, update our verifier to contain
     /// the new validator set, and return `Ok(TrustedStateChange::Epoch { .. })`.
     pub fn verify_and_ratchet<'a>(
+        &self,
+        state_proof: &'a StateProof,
+        initial_accumulator: Option<&'a TransactionAccumulatorSummary>,
+    ) -> Result<TrustedStateChange<'a>> {
+        self.verify_and_ratchet_inner(
+            state_proof.latest_ledger_info_w_sigs(),
+            state_proof.epoch_changes(),
+            state_proof.consistency_proof(),
+            initial_accumulator,
+        )
+    }
+
+    pub fn verify_and_ratchet_inner<'a>(
         &self,
         latest_li: &'a LedgerInfoWithSignatures,
         epoch_change_proof: &'a EpochChangeProof,

--- a/types/src/unit_tests/trusted_state_test.rs
+++ b/types/src/unit_tests/trusted_state_test.rs
@@ -266,7 +266,7 @@ proptest! {
             expected_latest_version,
         );
         let trusted_state_change = trusted_state
-            .verify_and_ratchet(&latest_li, &change_proof, &consistency_proof, Some(&initial_accumulator))
+            .verify_and_ratchet_inner(&latest_li, &change_proof, &consistency_proof, Some(&initial_accumulator))
             .expect("Should never error or be stale when ratcheting from waypoint with valid proofs");
 
         match trusted_state_change {
@@ -309,7 +309,7 @@ proptest! {
             expected_latest_version,
         );
         let trusted_state_change = trusted_state
-            .verify_and_ratchet(&latest_li, &change_proof, &consistency_proof, None)
+            .verify_and_ratchet_inner(&latest_li, &change_proof, &consistency_proof, None)
             .expect("Should never error or be stale when ratcheting from waypoint with valid proofs");
 
         match trusted_state_change {
@@ -352,7 +352,7 @@ proptest! {
         );
         // should fail since there's a missing epoch change li in the change proof.
         trusted_state
-            .verify_and_ratchet(&latest_li, &change_proof, &consistency_proof, None)
+            .verify_and_ratchet_inner(&latest_li, &change_proof, &consistency_proof, None)
             .expect_err("Should always return Err with an invalid change proof");
     }
 
@@ -390,13 +390,13 @@ proptest! {
             expected_latest_version,
         );
         trusted_state
-            .verify_and_ratchet(&latest_li, &change_proof, &consistency_proof, None)
+            .verify_and_ratchet_inner(&latest_li, &change_proof, &consistency_proof, None)
             .expect_err("Should return Err when more is false and there's a gap");
 
         // ratcheting with more = true is fine
         change_proof.more = true;
         let trusted_state_change = trusted_state
-            .verify_and_ratchet(&latest_li, &change_proof, &consistency_proof, None)
+            .verify_and_ratchet_inner(&latest_li, &change_proof, &consistency_proof, None)
             .expect("Should succeed with more in EpochChangeProof");
 
         match trusted_state_change {
@@ -444,7 +444,7 @@ proptest! {
 
         let change_proof = EpochChangeProof::new(lis_with_sigs, false /* more */);
         trusted_state
-            .verify_and_ratchet(&latest_li, &change_proof, &consistency_proof, None)
+            .verify_and_ratchet_inner(&latest_li, &change_proof, &consistency_proof, None)
             .expect_err("Should always return Err with an invalid change proof");
     }
 
@@ -507,12 +507,12 @@ proptest! {
         *bad_sigs.values_mut().next().unwrap() = Ed25519Signature::dummy_signature();
         let bad_li_6 = LedgerInfoWithSignatures::new(good_li.clone(), bad_sigs);
 
-        trusted_state.verify_and_ratchet(&bad_li_1, &change_proof, &consistency_proof, None).unwrap_err();
-        trusted_state.verify_and_ratchet(&bad_li_2, &change_proof, &consistency_proof, None).unwrap_err();
-        trusted_state.verify_and_ratchet(&bad_li_3, &change_proof, &consistency_proof, None).unwrap_err();
-        trusted_state.verify_and_ratchet(&bad_li_4, &change_proof, &consistency_proof, None).unwrap_err();
-        trusted_state.verify_and_ratchet(&bad_li_5, &change_proof, &consistency_proof, None).unwrap_err();
-        trusted_state.verify_and_ratchet(&bad_li_6, &change_proof, &consistency_proof, None).unwrap_err();
+        trusted_state.verify_and_ratchet_inner(&bad_li_1, &change_proof, &consistency_proof, None).unwrap_err();
+        trusted_state.verify_and_ratchet_inner(&bad_li_2, &change_proof, &consistency_proof, None).unwrap_err();
+        trusted_state.verify_and_ratchet_inner(&bad_li_3, &change_proof, &consistency_proof, None).unwrap_err();
+        trusted_state.verify_and_ratchet_inner(&bad_li_4, &change_proof, &consistency_proof, None).unwrap_err();
+        trusted_state.verify_and_ratchet_inner(&bad_li_5, &change_proof, &consistency_proof, None).unwrap_err();
+        trusted_state.verify_and_ratchet_inner(&bad_li_6, &change_proof, &consistency_proof, None).unwrap_err();
     }
 }
 
@@ -545,7 +545,7 @@ proptest! {
         let change_proof = EpochChangeProof::new(lis_with_sigs, false /* more */);
         let consistency_proof = accumulator.get_consistency_proof(Some(start_version), end_version);
         trusted_state
-            .verify_and_ratchet(&latest_li, &change_proof, &consistency_proof, None)
+            .verify_and_ratchet_inner(&latest_li, &change_proof, &consistency_proof, None)
             .expect_err("Expected stale change, got valid change");
     }
 }


### PR DESCRIPTION
Pretty basic refactor. Collects `(LedgerInfoWithSignatures, EpochChangeProof, AccumulatorConsistencyProof)` into one convenient `StateProof` package. Mostly, I got tired of making this type alias everywhere; now it's official!