### PR TITLE
[move] Remove `Compiled{Script,Module}::freeze`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2671,6 +2671,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
+ "bytecode-verifier",
  "diem-crypto",
  "diem-crypto-derive",
  "diem-framework",

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/support/mod.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/support/mod.rs
@@ -31,5 +31,5 @@ pub fn dummy_procedure_module(code: Vec<Bytecode>) -> CompiledModule {
 
     module.function_handles.push(fun_handle);
     module.function_defs.push(fun_def);
-    module.freeze().unwrap()
+    module
 }

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/bounds_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/bounds_tests.rs
@@ -6,7 +6,8 @@ use invalid_mutations::bounds::{
     OutOfBoundsMutation,
 };
 use move_binary_format::{
-    file_format::*, file_format_common, proptest_types::CompiledModuleStrategyGen,
+    check_bounds::BoundsChecker, file_format::*, file_format_common,
+    proptest_types::CompiledModuleStrategyGen,
 };
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, vm_status::StatusCode,
@@ -20,7 +21,7 @@ fn empty_module_no_errors() {
 
 #[test]
 fn empty_script_no_errors() {
-    basic_test_script().freeze().unwrap();
+    BoundsChecker::verify_script(&basic_test_script()).unwrap();
 }
 
 #[test]
@@ -165,7 +166,7 @@ fn script_invalid_locals_id_in_call() {
     let func_inst_idx = FunctionInstantiationIndex(s.function_instantiations.len() as u16 - 1);
     s.code.code = vec![CallGeneric(func_inst_idx)];
     assert_eq!(
-        s.freeze().unwrap_err().major_status(),
+        BoundsChecker::verify_script(&s).unwrap_err().major_status(),
         StatusCode::INDEX_OUT_OF_BOUNDS
     );
 }
@@ -203,7 +204,7 @@ fn script_invalid_type_param_in_call() {
     let func_inst_idx = FunctionInstantiationIndex(s.function_instantiations.len() as u16 - 1);
     s.code.code = vec![CallGeneric(func_inst_idx)];
     assert_eq!(
-        s.freeze().unwrap_err().major_status(),
+        BoundsChecker::verify_script(&s).unwrap_err().major_status(),
         StatusCode::INDEX_OUT_OF_BOUNDS
     );
 }
@@ -243,7 +244,7 @@ fn script_invalid_struct_as_type_argument_in_exists() {
     let func_inst_idx = FunctionInstantiationIndex(s.function_instantiations.len() as u16 - 1);
     s.code.code = vec![CallGeneric(func_inst_idx)];
     assert_eq!(
-        s.freeze().unwrap_err().major_status(),
+        BoundsChecker::verify_script(&s).unwrap_err().major_status(),
         StatusCode::INDEX_OUT_OF_BOUNDS
     );
 }
@@ -282,7 +283,7 @@ fn script_missing_signature() {
     s.signatures.clear();
     // Bounds-checking the script should now result in an out-of-bounds error.
     assert_eq!(
-        s.freeze().unwrap_err().major_status(),
+        BoundsChecker::verify_script(&s).unwrap_err().major_status(),
         StatusCode::INDEX_OUT_OF_BOUNDS
     );
 }

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/bounds_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/bounds_tests.rs
@@ -16,7 +16,7 @@ use proptest::{collection::vec, prelude::*};
 
 #[test]
 fn empty_module_no_errors() {
-    basic_test_module().freeze().unwrap();
+    BoundsChecker::verify_module(&basic_test_module()).unwrap();
 }
 
 #[test]
@@ -26,11 +26,10 @@ fn empty_script_no_errors() {
 
 #[test]
 fn invalid_default_module() {
-    CompiledModule {
+    BoundsChecker::verify_module(&CompiledModule {
         version: file_format_common::VERSION_MAX,
         ..Default::default()
-    }
-    .freeze()
+    })
     .unwrap_err();
 }
 
@@ -39,7 +38,7 @@ fn invalid_self_module_handle_index() {
     let mut m = basic_test_module();
     m.self_module_handle_idx = ModuleHandleIndex(12);
     assert_eq!(
-        m.freeze().unwrap_err().major_status(),
+        BoundsChecker::verify_module(&m).unwrap_err().major_status(),
         StatusCode::INDEX_OUT_OF_BOUNDS
     );
 }
@@ -53,7 +52,7 @@ fn invalid_type_param_in_fn_return_() {
     m.signatures.push(Signature(vec![TypeParameter(0)]));
     assert_eq!(m.signatures.len(), 2);
     assert_eq!(
-        m.freeze().unwrap_err().major_status(),
+        BoundsChecker::verify_module(&m).unwrap_err().major_status(),
         StatusCode::INDEX_OUT_OF_BOUNDS
     );
 }
@@ -66,7 +65,7 @@ fn invalid_type_param_in_fn_parameters() {
     m.function_handles[0].parameters = SignatureIndex(1);
     m.signatures.push(Signature(vec![TypeParameter(0)]));
     assert_eq!(
-        m.freeze().unwrap_err().major_status(),
+        BoundsChecker::verify_module(&m).unwrap_err().major_status(),
         StatusCode::INDEX_OUT_OF_BOUNDS
     );
 }
@@ -80,7 +79,7 @@ fn invalid_struct_in_fn_return_() {
     m.signatures
         .push(Signature(vec![Struct(StructHandleIndex::new(1))]));
     assert_eq!(
-        m.freeze().unwrap_err().major_status(),
+        BoundsChecker::verify_module(&m).unwrap_err().major_status(),
         StatusCode::INDEX_OUT_OF_BOUNDS
     );
 }
@@ -94,7 +93,7 @@ fn invalid_type_param_in_field() {
         StructFieldInformation::Declared(ref mut fields) => {
             fields[0].signature.0 = TypeParameter(0);
             assert_eq!(
-                m.freeze().unwrap_err().major_status(),
+                BoundsChecker::verify_module(&m).unwrap_err().major_status(),
                 StatusCode::INDEX_OUT_OF_BOUNDS
             );
         }
@@ -111,7 +110,7 @@ fn invalid_struct_in_field() {
         StructFieldInformation::Declared(ref mut fields) => {
             fields[0].signature.0 = Struct(StructHandleIndex::new(3));
             assert_eq!(
-                m.freeze().unwrap_err().major_status(),
+                BoundsChecker::verify_module(&m).unwrap_err().major_status(),
                 StatusCode::INDEX_OUT_OF_BOUNDS
             );
         }
@@ -129,7 +128,7 @@ fn invalid_struct_with_actuals_in_field() {
             fields[0].signature.0 =
                 StructInstantiation(StructHandleIndex::new(0), vec![TypeParameter(0)]);
             assert_eq!(
-                m.freeze().unwrap_err().major_status(),
+                BoundsChecker::verify_module(&m).unwrap_err().major_status(),
                 StatusCode::NUMBER_OF_TYPE_ARGUMENTS_MISMATCH
             );
         }
@@ -149,7 +148,7 @@ fn invalid_locals_id_in_call() {
     let func_inst_idx = FunctionInstantiationIndex(m.function_instantiations.len() as u16 - 1);
     m.function_defs[0].code.as_mut().unwrap().code = vec![CallGeneric(func_inst_idx)];
     assert_eq!(
-        m.freeze().unwrap_err().major_status(),
+        BoundsChecker::verify_module(&m).unwrap_err().major_status(),
         StatusCode::INDEX_OUT_OF_BOUNDS
     );
 }
@@ -185,7 +184,7 @@ fn invalid_type_param_in_call() {
     let func_inst_idx = FunctionInstantiationIndex(m.function_instantiations.len() as u16 - 1);
     m.function_defs[0].code.as_mut().unwrap().code = vec![CallGeneric(func_inst_idx)];
     assert_eq!(
-        m.freeze().unwrap_err().major_status(),
+        BoundsChecker::verify_module(&m).unwrap_err().major_status(),
         StatusCode::INDEX_OUT_OF_BOUNDS
     );
 }
@@ -224,7 +223,7 @@ fn invalid_struct_as_type_actual_in_exists() {
     let func_inst_idx = FunctionInstantiationIndex(m.function_instantiations.len() as u16 - 1);
     m.function_defs[0].code.as_mut().unwrap().code = vec![CallGeneric(func_inst_idx)];
     assert_eq!(
-        m.freeze().unwrap_err().major_status(),
+        BoundsChecker::verify_module(&m).unwrap_err().major_status(),
         StatusCode::INDEX_OUT_OF_BOUNDS
     );
 }
@@ -257,7 +256,7 @@ fn invalid_friend_module_address() {
         name: IdentifierIndex::new(0),
     });
     assert_eq!(
-        m.freeze().unwrap_err().major_status(),
+        BoundsChecker::verify_module(&m).unwrap_err().major_status(),
         StatusCode::INDEX_OUT_OF_BOUNDS
     );
 }
@@ -270,7 +269,7 @@ fn invalid_friend_module_name() {
         name: IdentifierIndex::new(m.identifiers.len() as TableIndex),
     });
     assert_eq!(
-        m.freeze().unwrap_err().major_status(),
+        BoundsChecker::verify_module(&m).unwrap_err().major_status(),
         StatusCode::INDEX_OUT_OF_BOUNDS
     );
 }
@@ -319,7 +318,7 @@ proptest! {
             oob_context.apply()
         };
 
-        let actual_violations = module.freeze();
+        let actual_violations = BoundsChecker::verify_module(&module);
         prop_assert_eq!(expected_violations.is_empty(), actual_violations.is_ok());
     }
 
@@ -333,8 +332,7 @@ proptest! {
             context.apply()
         };
 
-        let actual_violations = module.freeze();
-
+        let actual_violations = BoundsChecker::verify_module(&module);
         prop_assert_eq!(expected_violations.is_empty(), actual_violations.is_ok());
     }
 
@@ -352,7 +350,7 @@ proptest! {
         };
 
         prop_assert_eq!(
-            module.freeze().map_err(|e| e.major_status()),
+            BoundsChecker::verify_module(&module).map_err(|e| e.major_status()),
             Err(StatusCode::NO_MODULE_HANDLES)
         );
     }
@@ -366,6 +364,6 @@ proptest! {
     /// Make sure that garbage inputs don't crash the bounds checker.
     #[test]
     fn garbage_inputs(module in any_with::<CompiledModule>(16)) {
-        let _ = module.freeze();
+        let _ = BoundsChecker::verify_module(&module);
     }
 }

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/constants_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/constants_tests.rs
@@ -14,8 +14,8 @@ proptest! {
 
 #[test]
 fn valid_primitives() {
-    let mut module_mut = empty_module();
-    module_mut.constant_pool = vec![
+    let mut module = empty_module();
+    module.constant_pool = vec![
         Constant {
             type_: SignatureToken::Bool,
             data: vec![0],
@@ -37,7 +37,6 @@ fn valid_primitives() {
             data: vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
         },
     ];
-    let module = module_mut.freeze().unwrap();
     assert!(constants::verify_module(&module).is_ok());
 }
 
@@ -66,8 +65,8 @@ fn valid_vectors() {
         (0..0xFFFF).for_each(|_| items.extend(item.clone()));
         items
     };
-    let mut module_mut = empty_module();
-    module_mut.constant_pool = vec![
+    let mut module = empty_module();
+    module.constant_pool = vec![
         // empty
         Constant {
             type_: tvec(SignatureToken::Bool),
@@ -141,7 +140,6 @@ fn valid_vectors() {
             ])),
         },
     ];
-    let module = module_mut.freeze().unwrap();
     assert!(constants::verify_module(&module).is_ok());
 }
 
@@ -204,10 +202,10 @@ fn invalid_type(type_: SignatureToken, data: Vec<u8>) {
 }
 
 fn error(type_: SignatureToken, data: Vec<u8>, code: StatusCode) {
-    let mut module_mut = empty_module();
-    module_mut.constant_pool = vec![Constant { type_, data }];
+    let mut module = empty_module();
+    module.constant_pool = vec![Constant { type_, data }];
     assert!(
-        constants::verify_module(&module_mut.freeze().unwrap())
+        constants::verify_module(&module)
             .unwrap_err()
             .major_status()
             == code

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/duplication_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/duplication_tests.rs
@@ -14,7 +14,7 @@ fn duplicated_friend_decls() {
     };
     m.friend_decls.push(handle.clone());
     m.friend_decls.push(handle);
-    DuplicationChecker::verify_module(&m.freeze().unwrap()).unwrap_err();
+    DuplicationChecker::verify_module(&m).unwrap_err();
 }
 
 proptest! {

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/generic_ops_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/generic_ops_tests.rs
@@ -194,9 +194,8 @@ fn generic_call_to_non_generic_func() {
         type_parameters: SignatureIndex(2),
     });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err =
-        InstructionConsistency::verify_module(&module.freeze().expect("module must be valid"))
-            .expect_err("CallGeneric to non generic function must fail");
+    let err = InstructionConsistency::verify_module(&module)
+        .expect_err("CallGeneric to non generic function must fail");
     assert_eq!(
         err.major_status(),
         StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH
@@ -211,9 +210,8 @@ fn non_generic_call_to_generic_func() {
         locals: SignatureIndex(0),
         code: vec![Bytecode::Call(FunctionHandleIndex(1)), Bytecode::Ret],
     });
-    let err =
-        InstructionConsistency::verify_module(&module.freeze().expect("module must be valid"))
-            .expect_err("Call to generic function must fail");
+    let err = InstructionConsistency::verify_module(&module)
+        .expect_err("Call to generic function must fail");
     assert_eq!(
         err.major_status(),
         StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH
@@ -240,9 +238,8 @@ fn generic_pack_on_non_generic_struct() {
             type_parameters: SignatureIndex(2),
         });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err =
-        InstructionConsistency::verify_module(&module.freeze().expect("module must be valid"))
-            .expect_err("PackGeneric to non generic struct must fail");
+    let err = InstructionConsistency::verify_module(&module)
+        .expect_err("PackGeneric to non generic struct must fail");
     assert_eq!(
         err.major_status(),
         StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH
@@ -262,9 +259,8 @@ fn non_generic_pack_on_generic_struct() {
             Bytecode::Ret,
         ],
     });
-    let err =
-        InstructionConsistency::verify_module(&module.freeze().expect("module must be valid"))
-            .expect_err("Pack to generic struct must fail");
+    let err = InstructionConsistency::verify_module(&module)
+        .expect_err("Pack to generic struct must fail");
     assert_eq!(
         err.major_status(),
         StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH
@@ -292,9 +288,8 @@ fn generic_unpack_on_non_generic_struct() {
             type_parameters: SignatureIndex(2),
         });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err =
-        InstructionConsistency::verify_module(&module.freeze().expect("module must be valid"))
-            .expect_err("UnpackGeneric to non generic struct must fail");
+    let err = InstructionConsistency::verify_module(&module)
+        .expect_err("UnpackGeneric to non generic struct must fail");
     assert_eq!(
         err.major_status(),
         StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH
@@ -322,9 +317,8 @@ fn non_generic_unpack_on_generic_struct() {
             type_parameters: SignatureIndex(2),
         });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err =
-        InstructionConsistency::verify_module(&module.freeze().expect("module must be valid"))
-            .expect_err("Unpack to generic struct must fail");
+    let err = InstructionConsistency::verify_module(&module)
+        .expect_err("Unpack to generic struct must fail");
     assert_eq!(
         err.major_status(),
         StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH
@@ -354,9 +348,8 @@ fn generic_mut_borrow_field_on_non_generic_struct() {
         field: 0,
     });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err =
-        InstructionConsistency::verify_module(&module.freeze().expect("module must be valid"))
-            .expect_err("MutBorrowFieldGeneric to non generic struct must fail");
+    let err = InstructionConsistency::verify_module(&module)
+        .expect_err("MutBorrowFieldGeneric to non generic struct must fail");
     assert_eq!(
         err.major_status(),
         StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH
@@ -388,9 +381,8 @@ fn non_generic_mut_borrow_field_on_generic_struct() {
         field: 0,
     });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err =
-        InstructionConsistency::verify_module(&module.freeze().expect("module must be valid"))
-            .expect_err("MutBorrowField to generic struct must fail");
+    let err = InstructionConsistency::verify_module(&module)
+        .expect_err("MutBorrowField to generic struct must fail");
     assert_eq!(
         err.major_status(),
         StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH
@@ -420,9 +412,8 @@ fn generic_borrow_field_on_non_generic_struct() {
         field: 0,
     });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err =
-        InstructionConsistency::verify_module(&module.freeze().expect("module must be valid"))
-            .expect_err("ImmBorrowFieldGeneric to non generic struct must fail");
+    let err = InstructionConsistency::verify_module(&module)
+        .expect_err("ImmBorrowFieldGeneric to non generic struct must fail");
     assert_eq!(
         err.major_status(),
         StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH
@@ -454,9 +445,8 @@ fn non_generic_borrow_field_on_generic_struct() {
         field: 0,
     });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err =
-        InstructionConsistency::verify_module(&module.freeze().expect("module must be valid"))
-            .expect_err("ImmBorrowField to generic struct must fail");
+    let err = InstructionConsistency::verify_module(&module)
+        .expect_err("ImmBorrowField to generic struct must fail");
     assert_eq!(
         err.major_status(),
         StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH
@@ -486,9 +476,8 @@ fn generic_mut_borrow_global_to_non_generic_struct() {
             type_parameters: SignatureIndex(2),
         });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err =
-        InstructionConsistency::verify_module(&module.freeze().expect("module must be valid"))
-            .expect_err("MutBorrowGlobalGeneric to non generic function must fail");
+    let err = InstructionConsistency::verify_module(&module)
+        .expect_err("MutBorrowGlobalGeneric to non generic function must fail");
     assert_eq!(
         err.major_status(),
         StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH
@@ -511,9 +500,8 @@ fn non_generic_mut_borrow_global_to_generic_struct() {
             Bytecode::Ret,
         ],
     });
-    let err =
-        InstructionConsistency::verify_module(&module.freeze().expect("module must be valid"))
-            .expect_err("MutBorrowGlobal to generic function must fail");
+    let err = InstructionConsistency::verify_module(&module)
+        .expect_err("MutBorrowGlobal to generic function must fail");
     assert_eq!(
         err.major_status(),
         StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH
@@ -543,9 +531,8 @@ fn generic_immut_borrow_global_to_non_generic_struct() {
             type_parameters: SignatureIndex(2),
         });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err =
-        InstructionConsistency::verify_module(&module.freeze().expect("module must be valid"))
-            .expect_err("ImmBorrowGlobalGeneric to non generic function must fail");
+    let err = InstructionConsistency::verify_module(&module)
+        .expect_err("ImmBorrowGlobalGeneric to non generic function must fail");
     assert_eq!(
         err.major_status(),
         StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH
@@ -568,9 +555,8 @@ fn non_generic_immut_borrow_global_to_generic_struct() {
             Bytecode::Ret,
         ],
     });
-    let err =
-        InstructionConsistency::verify_module(&module.freeze().expect("module must be valid"))
-            .expect_err("ImmBorrowGlobal to generic function must fail");
+    let err = InstructionConsistency::verify_module(&module)
+        .expect_err("ImmBorrowGlobal to generic function must fail");
     assert_eq!(
         err.major_status(),
         StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH
@@ -597,9 +583,8 @@ fn generic_exists_to_non_generic_struct() {
             type_parameters: SignatureIndex(2),
         });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err =
-        InstructionConsistency::verify_module(&module.freeze().expect("module must be valid"))
-            .expect_err("ExistsGeneric to non generic function must fail");
+    let err = InstructionConsistency::verify_module(&module)
+        .expect_err("ExistsGeneric to non generic function must fail");
     assert_eq!(
         err.major_status(),
         StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH
@@ -619,9 +604,8 @@ fn non_generic_exists_to_generic_struct() {
             Bytecode::Ret,
         ],
     });
-    let err =
-        InstructionConsistency::verify_module(&module.freeze().expect("module must be valid"))
-            .expect_err("Exists to generic function must fail");
+    let err = InstructionConsistency::verify_module(&module)
+        .expect_err("Exists to generic function must fail");
     assert_eq!(
         err.major_status(),
         StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH
@@ -652,9 +636,8 @@ fn generic_move_from_to_non_generic_struct() {
             type_parameters: SignatureIndex(2),
         });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err =
-        InstructionConsistency::verify_module(&module.freeze().expect("module must be valid"))
-            .expect_err("MoveFromGeneric to non generic function must fail");
+    let err = InstructionConsistency::verify_module(&module)
+        .expect_err("MoveFromGeneric to non generic function must fail");
     assert_eq!(
         err.major_status(),
         StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH
@@ -685,9 +668,8 @@ fn non_generic_move_from_to_generic_struct() {
             type_parameters: SignatureIndex(2),
         });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err =
-        InstructionConsistency::verify_module(&module.freeze().expect("module must be valid"))
-            .expect_err("MoveFrom to generic function must fail");
+    let err = InstructionConsistency::verify_module(&module)
+        .expect_err("MoveFrom to generic function must fail");
     assert_eq!(
         err.major_status(),
         StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH
@@ -715,9 +697,8 @@ fn generic_move_to_on_non_generic_struct() {
             type_parameters: SignatureIndex(2),
         });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err =
-        InstructionConsistency::verify_module(&module.freeze().expect("module must be valid"))
-            .expect_err("MoveToGeneric to non generic struct must fail");
+    let err = InstructionConsistency::verify_module(&module)
+        .expect_err("MoveToGeneric to non generic struct must fail");
     assert_eq!(
         err.major_status(),
         StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH
@@ -745,9 +726,8 @@ fn non_generic_move_to_on_generic_struct() {
             type_parameters: SignatureIndex(2),
         });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err =
-        InstructionConsistency::verify_module(&module.freeze().expect("module must be valid"))
-            .expect_err("MoveTo to generic struct must fail");
+    let err = InstructionConsistency::verify_module(&module)
+        .expect_err("MoveTo to generic struct must fail");
     assert_eq!(
         err.major_status(),
         StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
@@ -13,7 +13,7 @@ fn test_reference_of_reference() {
     m.signatures[0] = Signature(vec![Reference(Box::new(Reference(Box::new(
         SignatureToken::Bool,
     ))))]);
-    let errors = SignatureChecker::verify_module(&m.freeze().unwrap());
+    let errors = SignatureChecker::verify_module(&m);
     assert!(errors.is_err());
 }
 
@@ -30,7 +30,6 @@ proptest! {
     ) {
         let context = SignatureRefMutation::new(&mut module, mutations);
         let expected_violations = context.apply();
-        let module = module.freeze().expect("should satisfy bounds checker");
 
         let result = SignatureChecker::verify_module(&module);
 
@@ -44,7 +43,6 @@ proptest! {
     ) {
         let context = FieldRefMutation::new(&mut module, mutations);
         let expected_violations = context.apply();
-        let module = module.freeze().expect("should satisfy bounds checker");
 
         let result = SignatureChecker::verify_module(&module);
 
@@ -117,5 +115,5 @@ fn no_verify_locals_good() {
             },
         ],
     };
-    assert!(verify_module(&compiled_module_good.freeze().unwrap()).is_ok());
+    assert!(verify_module(&compiled_module_good).is_ok());
 }

--- a/language/bytecode-verifier/src/verifier.rs
+++ b/language/bytecode-verifier/src/verifier.rs
@@ -25,6 +25,11 @@ use move_binary_format::{
 /// minimize the code locations that need to be updated should a new checker
 /// is introduced.
 pub fn verify_module(module: &CompiledModule) -> VMResult<()> {
+    BoundsChecker::verify_module(&module).map_err(|e| {
+        // We can't point the error at the module, because if bounds-checking
+        // failed, we cannot safely index into module's handle to itself.
+        e.finish(Location::Undefined)
+    })?;
     DuplicationChecker::verify_module(&module)?;
     SignatureChecker::verify_module(&module)?;
     InstructionConsistency::verify_module(&module)?;

--- a/language/bytecode-verifier/src/verifier.rs
+++ b/language/bytecode-verifier/src/verifier.rs
@@ -9,7 +9,8 @@ use crate::{
     script_signature, signature::SignatureChecker, struct_defs::RecursiveStructDefChecker,
 };
 use move_binary_format::{
-    errors::VMResult,
+    check_bounds::BoundsChecker,
+    errors::{Location, VMResult},
     file_format::{CompiledModule, CompiledScript},
 };
 
@@ -46,6 +47,7 @@ pub fn verify_module(module: &CompiledModule) -> VMResult<()> {
 /// minimize the code locations that need to be updated should a new checker
 /// is introduced.
 pub fn verify_script(script: &CompiledScript) -> VMResult<()> {
+    BoundsChecker::verify_script(&script).map_err(|e| e.finish(Location::Script))?;
     DuplicationChecker::verify_script(&script)?;
     SignatureChecker::verify_script(&script)?;
     InstructionConsistency::verify_script(&script)?;

--- a/language/compiler/ir-to-bytecode/src/compiler.rs
+++ b/language/compiler/ir-to-bytecode/src/compiler.rs
@@ -8,6 +8,7 @@ use crate::{
 use anyhow::{bail, format_err, Result};
 use bytecode_source_map::source_map::SourceMap;
 use move_binary_format::{
+    check_bounds::BoundsChecker,
     errors::Location as VMErrorLocation,
     file_format::{
         Ability, AbilitySet, Bytecode, CodeOffset, CodeUnit, CompiledModule, CompiledScript,
@@ -461,7 +462,7 @@ pub fn compile_script<'a>(
         _compiled_deps,
         source_map,
     ) = context.materialize_pools();
-    CompiledScript {
+    let script = CompiledScript {
         version: VERSION_MAX,
         module_handles,
         struct_handles,
@@ -475,12 +476,14 @@ pub fn compile_script<'a>(
         type_parameters: sig.type_parameters,
         parameters: parameters_sig_idx,
         code,
+    };
+    match BoundsChecker::verify_script(&script) {
+        Ok(()) => Ok((script, source_map)),
+        Err(e) => Err(InternalCompilerError::BoundsCheckErrors(
+            e.finish(VMErrorLocation::Undefined),
+        )
+        .into()),
     }
-    .freeze()
-    .map_err(|e| {
-        InternalCompilerError::BoundsCheckErrors(e.finish(VMErrorLocation::Undefined)).into()
-    })
-    .map(|frozen_script| (frozen_script, source_map))
 }
 
 /// Compile a module.

--- a/language/diem-tools/writeset-transaction-generator/Cargo.toml
+++ b/language/diem-tools/writeset-transaction-generator/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1.0.124", default-features = false }
 serde_json = "1.0.64"
 once_cell = "1.7.2"
 
+bytecode-verifier = { path = "../../bytecode-verifier" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 diem-crypto-derive = { path = "../../../crypto/crypto-derive" }
 diem-crypto = { path = "../../../crypto/crypto" }

--- a/language/diem-tools/writeset-transaction-generator/src/release_flow/mod.rs
+++ b/language/diem-tools/writeset-transaction-generator/src/release_flow/mod.rs
@@ -31,7 +31,7 @@ pub mod test_utils {
             module.serialize(&mut buf).unwrap();
             buf
         };
-        modules.push((bytes, module.freeze().unwrap()));
+        modules.push((bytes, module));
         // TODO: See if there's a module that we can remove and if we can modify an existing module
         modules
     }

--- a/language/diem-tools/writeset-transaction-generator/src/release_flow/unit_tests/release_tests.rs
+++ b/language/diem-tools/writeset-transaction-generator/src/release_flow/unit_tests/release_tests.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::release_flow::create::create_release_writeset;
+use bytecode_verifier::verify_module;
 use diem_types::{
     access_path::AccessPath,
     transaction::{ChangeSet, WriteSetPayload},
@@ -26,12 +27,12 @@ fn release_test() {
     for i in 0..10 {
         let mut module = empty_module();
         module.identifiers[0] = Identifier::new(format!("test_{:?}", i)).unwrap();
-        let compiled_module = module.freeze().unwrap();
+        verify_module(&module).expect("invalid module");
 
         let mut bytes = vec![];
-        compiled_module.serialize(&mut bytes).unwrap();
-        modules_and_bytes.push((bytes.clone(), compiled_module.clone()));
-        modules.push(compiled_module);
+        module.serialize(&mut bytes).unwrap();
+        modules_and_bytes.push((bytes.clone(), module.clone()));
+        modules.push(module);
         modules_bytes.push(bytes);
     }
 
@@ -39,7 +40,8 @@ fn release_test() {
     let replace_module = {
         let mut module = basic_test_module();
         module.identifiers[0] = Identifier::new(format!("test_{:?}", 9)).unwrap();
-        module.freeze().unwrap()
+        verify_module(&module).expect("invalid module");
+        module
     };
     let mut replace_module_bytes = vec![];
     replace_module.serialize(&mut replace_module_bytes).unwrap();

--- a/language/diem-tools/writeset-transaction-generator/src/release_flow/verify.rs
+++ b/language/diem-tools/writeset-transaction-generator/src/release_flow/verify.rs
@@ -4,6 +4,7 @@ use crate::release_flow::{
     create::create_release_from_artifact, hash_for_modules, load_latest_artifact,
 };
 use anyhow::{bail, Result};
+use bytecode_verifier::verify_module;
 use diem_transaction_replay::DiemDebugger;
 use diem_types::{
     access_path::Path,
@@ -27,6 +28,10 @@ pub fn verify_release(
     // If set to true, will verify the release payload against the latest blockchain height instead of the height recorded in the artifact file. This would be needed when the height is already pruned.
     use_latest_version: bool,
 ) -> Result<()> {
+    for (_, module) in remote_modules {
+        verify_module(&module).expect("invalid remote module");
+    }
+
     let artifact = load_latest_artifact(&chain_id)?;
     if artifact.chain_id != chain_id {
         bail!("Unexpected ChainId");

--- a/language/move-binary-format/src/deserializer.rs
+++ b/language/move-binary-format/src/deserializer.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{errors::*, file_format::*, file_format_common::*};
+use crate::{check_bounds::BoundsChecker, errors::*, file_format::*, file_format_common::*};
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, vm_status::StatusCode,
 };
@@ -10,7 +10,9 @@ use std::{collections::HashSet, convert::TryInto, io::Read};
 impl CompiledScript {
     /// Deserializes a &[u8] slice into a `CompiledScript` instance.
     pub fn deserialize(binary: &[u8]) -> BinaryLoaderResult<Self> {
-        CompiledScript::deserialize_no_check_bounds(binary)?.freeze()
+        let script = CompiledScript::deserialize_no_check_bounds(binary)?;
+        BoundsChecker::verify_script(&script)?;
+        Ok(script)
     }
 
     // exposed as a public function to enable testing the deserializer

--- a/language/move-binary-format/src/deserializer.rs
+++ b/language/move-binary-format/src/deserializer.rs
@@ -25,7 +25,9 @@ impl CompiledScript {
 impl CompiledModule {
     /// Deserialize a &[u8] slice into a `CompiledModule` instance.
     pub fn deserialize(binary: &[u8]) -> BinaryLoaderResult<Self> {
-        CompiledModule::deserialize_no_check_bounds(binary)?.freeze()
+        let module = CompiledModule::deserialize_no_check_bounds(binary)?;
+        BoundsChecker::verify_module(&module)?;
+        Ok(module)
     }
 
     // exposed as a public function to enable testing the deserializer

--- a/language/move-binary-format/src/file_format.rs
+++ b/language/move-binary-format/src/file_format.rs
@@ -1666,15 +1666,6 @@ pub struct CompiledScript {
 impl CompiledScript {
     /// Returns the index of `main` in case a script is converted to a module.
     pub const MAIN_INDEX: FunctionDefinitionIndex = FunctionDefinitionIndex(0);
-
-    /// Converts this instance into `CompiledScript` after verifying it for basic internal
-    /// consistency. This includes bounds checks but no others.
-    #[allow(deprecated)]
-    pub fn freeze(self) -> PartialVMResult<CompiledScript> {
-        let script = self;
-        BoundsChecker::verify_script(&script)?;
-        Ok(script)
-    }
 }
 
 /// A `CompiledModule` defines the structure of a module which is the unit of published code.

--- a/language/move-binary-format/src/file_format.rs
+++ b/language/move-binary-format/src/file_format.rs
@@ -28,7 +28,6 @@
 
 use crate::{
     access::ModuleAccess,
-    check_bounds::BoundsChecker,
     errors::{PartialVMError, PartialVMResult},
     file_format_common,
     internals::ModuleIndex,
@@ -1863,15 +1862,6 @@ impl CompiledModule {
         }
     }
 
-    /// Converts this instance into `CompiledModule` after verifying it for basic internal
-    /// consistency. This includes bounds checks but no others.
-    pub fn freeze(self) -> PartialVMResult<CompiledModule> {
-        // Impossible to access self_id for location as it might not be safe due to bounds failing
-        let module = self;
-        BoundsChecker::verify_module(&module)?;
-        Ok(module)
-    }
-
     /// Returns the code key of `module_handle`
     pub fn module_id_for_handle(&self, module_handle: &ModuleHandle) -> ModuleId {
         ModuleId::new(
@@ -1937,7 +1927,7 @@ pub fn basic_test_module() -> CompiledModule {
         acquires_global_resources: vec![],
         code: Some(CodeUnit {
             locals: SignatureIndex(0),
-            code: vec![],
+            code: vec![Bytecode::Ret],
         }),
     });
 

--- a/language/move-binary-format/src/proptest_types.rs
+++ b/language/move-binary-format/src/proptest_types.rs
@@ -349,8 +349,6 @@ impl CompiledModuleStrategyGen {
                         address_identifiers,
                         constant_pool,
                     }
-                    .freeze()
-                    .expect("valid modules should satisfy the bounds checker")
                 },
             )
     }

--- a/language/move-model/src/lib.rs
+++ b/language/move-model/src/lib.rs
@@ -12,6 +12,7 @@ use std::collections::BTreeSet;
 use builder::module_builder::ModuleBuilder;
 use move_binary_format::{
     access::ModuleAccess,
+    check_bounds::BoundsChecker,
     file_format::{
         self_module_name, AddressIdentifierIndex, CompiledModule, CompiledScript,
         FunctionDefinition, FunctionDefinitionIndex, FunctionHandle, FunctionHandleIndex,
@@ -373,7 +374,7 @@ fn script_into_module(compiled_script: CompiledScript) -> CompiledModule {
         code: Some(script.code),
     };
 
-    CompiledModule {
+    let module = CompiledModule {
         version: script.version,
         module_handles: script.module_handles,
         self_module_handle_idx,
@@ -394,9 +395,9 @@ fn script_into_module(compiled_script: CompiledScript) -> CompiledModule {
 
         struct_defs: vec![],
         function_defs: vec![main_def],
-    }
-    .freeze()
-    .unwrap()
+    };
+    BoundsChecker::verify_module(&module).expect("invalid bounds in module");
+    module
 }
 
 #[allow(deprecated)]

--- a/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
@@ -243,7 +243,6 @@ fn test_unverifiable_module() {
 
         let mut m = m;
         m.function_defs[0].code.as_mut().unwrap().code = vec![];
-        let m = m.freeze().unwrap();
         let mut blob = vec![];
         m.serialize(&mut blob).unwrap();
         storage.publish_or_overwrite_module(m.self_id(), blob);
@@ -433,7 +432,6 @@ fn test_unverifiable_module_dependency() {
     {
         let mut m = m;
         m.function_defs[0].code.as_mut().unwrap().code = vec![];
-        let m = m.freeze().unwrap();
         let mut blob_m = vec![];
         m.serialize(&mut blob_m).unwrap();
 

--- a/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
@@ -206,9 +206,7 @@ fn make_module_with_function(
                 code: vec![Bytecode::LdU64(0), Bytecode::Abort],
             }),
         }],
-    }
-    .freeze()
-    .unwrap();
+    };
     (module, function_name)
 }
 
@@ -744,7 +742,7 @@ fn check_script_function() {
 
 #[test]
 fn call_missing_item() {
-    let module = empty_module().freeze().unwrap();
+    let module = empty_module();
     let id = &module.self_id();
     let function_name = IdentStr::new("foo").unwrap();
     // mising module

--- a/language/testing-infra/module-generation/src/generator.rs
+++ b/language/testing-infra/module-generation/src/generator.rs
@@ -51,7 +51,7 @@ pub fn generate_modules(
                 .unwrap()
                 .0;
             Pad::pad(table_size, &mut module, options.clone());
-            module.freeze().unwrap()
+            module
         })
         .collect();
 
@@ -61,7 +61,7 @@ pub fn generate_modules(
         .unwrap()
         .0;
     Pad::pad(table_size, &mut compiled_root, options);
-    (compiled_root.freeze().unwrap(), compiled_callees)
+    (compiled_root, compiled_callees)
 }
 
 pub fn generate_verified_modules(

--- a/language/testing-infra/test-generation/src/abstract_state.rs
+++ b/language/testing-infra/test-generation/src/abstract_state.rs
@@ -451,16 +451,13 @@ pub struct AbstractState {
 impl AbstractState {
     /// Create a new AbstractState with empty stack, locals, and register
     pub fn new() -> AbstractState {
+        let compiled_module = empty_module();
         AbstractState {
             stack: Vec::new(),
             instantiation: Vec::new(),
             locals: HashMap::new(),
             register: None,
-            module: InstantiableModule::new(
-                empty_module()
-                    .freeze()
-                    .expect("Empty module should pass the bounds checker"),
-            ),
+            module: InstantiableModule::new(compiled_module),
             acquires_global_resources: Vec::new(),
             aborted: false,
             control_flow_allowed: false,
@@ -479,11 +476,7 @@ impl AbstractState {
         call_graph: CallGraph,
     ) -> AbstractState {
         let locals_len = locals.len();
-        let module = InstantiableModule::new(
-            module
-                .freeze()
-                .expect("Module should pass the bounds checker"),
-        );
+        let module = InstantiableModule::new(module);
         AbstractState {
             stack: Vec::new(),
             instantiation,

--- a/language/testing-infra/test-generation/src/lib.rs
+++ b/language/testing-infra/test-generation/src/lib.rs
@@ -269,7 +269,6 @@ pub fn bytecode_generation(
         let module = bytecode_module(&mut rng, module);
 
         debug!("Done...Running module on verifier...");
-        let module = module.freeze().expect("generated module failed to freeze.");
         let verified_module = match run_verifier(module.clone()) {
             Ok(verified_module) => {
                 status = Status::ExecutionFailure;


### PR DESCRIPTION
Delete `CompiledScript::freeze` and `CompiledModule::freeze` in favor of explicitly bounds-checking scripts and modules, as a follow-up on #8667.