### PR TITLE
Cherry-pick PR #8676 into release-1.3: [mempool] Prevent double decrements of upstream peers metric

### DIFF
--- a/mempool/src/shared_mempool/peer_manager.rs
+++ b/mempool/src/shared_mempool/peer_manager.rs
@@ -150,8 +150,9 @@ impl PeerManager {
         } else {
             // All other nodes have their state immediately restarted anyways, so let's free them
             // TODO: Why is the Validator optimization not applied here
-            self.peer_states.lock().remove(&peer);
-            counters::active_upstream_peers(&peer.raw_network_id()).dec();
+            if self.peer_states.lock().remove(&peer).is_some() {
+                counters::active_upstream_peers(&peer.raw_network_id()).dec();
+            }
         }
 
         // Always update prioritized peers to be in line with peer states


### PR DESCRIPTION
This cherry-pick was triggerd by a request on #8676
Please review the diff to ensure there are not any unexpected changes.

> This metric had the possibility of double decrementing, causing negative values and lots of confusion.

            
cc @msmouse