### PR TITLE
[RUSTSEC] upgrade tokio->1.8.1, prost->0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5893,9 +5893,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
+checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -5903,13 +5903,13 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
+checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
 dependencies = [
  "bytes",
  "heck",
- "itertools 0.9.0",
+ "itertools 0.10.0",
  "log",
  "multimap",
  "petgraph",
@@ -5921,12 +5921,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
+checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
 dependencies = [
  "anyhow",
- "itertools 0.9.0",
+ "itertools 0.10.0",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
  "syn 1.0.72",
@@ -5934,9 +5934,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
+checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
 dependencies = [
  "bytes",
  "prost",
@@ -7854,9 +7854,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.6.1"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a38d31d7831c6ed7aad00aa4c12d9375fd225a6dd77da1d25b707346319a975"
+checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
 dependencies = [
  "autocfg",
  "bytes",

--- a/client/faucet/Cargo.toml
+++ b/client/faucet/Cargo.toml
@@ -17,7 +17,7 @@ rand = "0.8.3"
 reqwest = { version = "0.11.2", features = ["blocking"], default-features = false }
 serde = { version = "1.0.124", features = ["derive"] }
 structopt = "0.3.21"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 warp = "0.3.0"
 
 generate-key = { path = "../../config/generate-key" }

--- a/common/bounded-executor/Cargo.toml
+++ b/common/bounded-executor/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 futures = "0.3.12"
 diem-workspace-hack = { path = "../workspace-hack" }
-tokio = { version = "1.3.0", features = ["sync"] }
+tokio = { version = "1.8.1", features = ["sync"] }
 
 [dev-dependencies]
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }

--- a/common/channel/Cargo.toml
+++ b/common/channel/Cargo.toml
@@ -18,4 +18,4 @@ diem-workspace-hack = { path = "../workspace-hack" }
 
 [dev-dependencies]
 diem-types = { path = "../../types"  }
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }

--- a/common/debug-interface/Cargo.toml
+++ b/common/debug-interface/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.38"
 bytes = "1.0.1"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 reqwest = { version = "0.11.2", features = ["blocking", "json"], default_features = false }
 warp = "0.3.0"
 

--- a/common/metrics/Cargo.toml
+++ b/common/metrics/Cargo.toml
@@ -16,7 +16,7 @@ hyper = { version = "0.14.4", features = ["full"] }
 once_cell = "1.7.2"
 prometheus = { version = "0.12.0", default-features = false }
 serde_json = "1.0.64"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 
 diem-logger = { path = "../logger" }
 diem-metrics-core = { path = "../metrics-core" }

--- a/common/rate-limiter/Cargo.toml
+++ b/common/rate-limiter/Cargo.toml
@@ -16,5 +16,5 @@ diem-logger = { path = "../logger" }
 diem-metrics = { path = "../metrics" }
 futures = "0.3.12"
 pin-project = "1.0.5"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 tokio-util = { version = "0.6.4", features = ["compat"] }

--- a/common/retrier/Cargo.toml
+++ b/common/retrier/Cargo.toml
@@ -11,5 +11,5 @@ edition = "2018"
 
 [dependencies]
 diem-workspace-hack = { path = "../workspace-hack" }
-tokio = { version = "1.3.0", features = ["time"] }
+tokio = { version = "1.8.1", features = ["time"] }
 diem-logger = { path = "../logger"}

--- a/common/time-service/Cargo.toml
+++ b/common/time-service/Cargo.toml
@@ -14,7 +14,7 @@ enum_dispatch = "0.3.5"
 futures = { version = "0.3.12", optional = true }
 pin-project = { version = "1.0.5", optional = true }
 thiserror = "1.0.24"
-tokio = { version = "1.3.0", features = ["macros", "rt-multi-thread", "time"], optional = true }
+tokio = { version = "1.8.1", features = ["macros", "rt-multi-thread", "time"], optional = true }
 
 diem-infallible = { path = "../infallible" }
 diem-workspace-hack = { path = "../workspace-hack" }
@@ -22,7 +22,7 @@ diem-workspace-hack = { path = "../workspace-hack" }
 [dev-dependencies]
 futures = "0.3.12"
 pin-project = "1.0.5"
-tokio = { version = "1.3.0", features = ["macros", "rt-multi-thread", "time"] }
+tokio = { version = "1.8.1", features = ["macros", "rt-multi-thread", "time"] }
 tokio-test = "0.4.1"
 
 [features]

--- a/common/workspace-hack/Cargo.toml
+++ b/common/workspace-hack/Cargo.toml
@@ -45,7 +45,7 @@ num-traits = { version = "0.2.14", features = ["default", "i128", "std"] }
 once_cell = { version = "1.7.2", features = ["alloc", "default", "race", "std"] }
 petgraph = { version = "0.5.1", features = ["default", "graphmap", "matrix_graph", "stable_graph"] }
 plotters = { version = "0.3.0", default-features = false, features = ["area_series", "evcxr", "histogram", "line_series", "plotters-svg", "svg_backend"] }
-prost = { version = "0.7.0", features = ["default", "prost-derive", "std"] }
+prost = { version = "0.8.0", features = ["default", "prost-derive", "std"] }
 rand = { version = "0.8.3", features = ["alloc", "default", "getrandom", "libc", "rand_chacha", "rand_hc", "small_rng", "std", "std_rng"] }
 rand_core = { version = "0.5.1", default-features = false, features = ["alloc", "getrandom", "std"] }
 regex = { version = "1.4.3", features = ["aho-corasick", "default", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
@@ -58,7 +58,7 @@ serde_json = { version = "1.0.64", features = ["default", "indexmap", "preserve_
 standback = { version = "0.2.15", default-features = false, features = ["std"] }
 subtle = { version = "2.4.0", default-features = false, features = ["std"] }
 tiny-keccak = { version = "2.0.2", features = ["default", "sha3"] }
-tokio = { version = "1.6.1", features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "test-util", "time", "tokio-macros", "winapi"] }
+tokio = { version = "1.8.1", features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "test-util", "time", "tokio-macros", "winapi"] }
 tokio-tungstenite = { version = "0.13.0", features = ["connect", "default", "stream"] }
 tokio-util = { version = "0.6.4", features = ["codec", "compat", "default", "futures-io", "io"] }
 toml = { version = "0.5.8", features = ["default"] }
@@ -104,7 +104,7 @@ once_cell = { version = "1.7.2", features = ["alloc", "default", "race", "std"] 
 petgraph = { version = "0.5.1", features = ["default", "graphmap", "matrix_graph", "stable_graph"] }
 plotters = { version = "0.3.0", default-features = false, features = ["area_series", "evcxr", "histogram", "line_series", "plotters-svg", "svg_backend"] }
 proc-macro2 = { version = "0.4.30", features = ["default", "proc-macro"] }
-prost = { version = "0.7.0", features = ["default", "prost-derive", "std"] }
+prost = { version = "0.8.0", features = ["default", "prost-derive", "std"] }
 quote = { version = "0.6.13", features = ["default", "proc-macro"] }
 rand = { version = "0.8.3", features = ["alloc", "default", "getrandom", "libc", "rand_chacha", "rand_hc", "small_rng", "std", "std_rng"] }
 rand_core = { version = "0.5.1", default-features = false, features = ["alloc", "getrandom", "std"] }
@@ -120,7 +120,7 @@ subtle = { version = "2.4.0", default-features = false, features = ["std"] }
 syn-3575ec1268b04181 = { package = "syn", version = "0.15.44", features = ["clone-impls", "default", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.72", features = ["clone-impls", "default", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
 tiny-keccak = { version = "2.0.2", features = ["default", "sha3"] }
-tokio = { version = "1.6.1", features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "test-util", "time", "tokio-macros", "winapi"] }
+tokio = { version = "1.8.1", features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "test-util", "time", "tokio-macros", "winapi"] }
 tokio-tungstenite = { version = "0.13.0", features = ["connect", "default", "stream"] }
 tokio-util = { version = "0.6.4", features = ["codec", "compat", "default", "futures-io", "io"] }
 toml = { version = "0.5.8", features = ["default"] }
@@ -164,7 +164,7 @@ num-traits = { version = "0.2.14", features = ["default", "i128", "std"] }
 once_cell = { version = "1.7.2", features = ["alloc", "default", "race", "std"] }
 petgraph = { version = "0.5.1", features = ["default", "graphmap", "matrix_graph", "stable_graph"] }
 plotters = { version = "0.3.0", default-features = false, features = ["area_series", "evcxr", "histogram", "line_series", "plotters-svg", "svg_backend"] }
-prost = { version = "0.7.0", features = ["default", "prost-derive", "std"] }
+prost = { version = "0.8.0", features = ["default", "prost-derive", "std"] }
 rand = { version = "0.8.3", features = ["alloc", "default", "getrandom", "libc", "rand_chacha", "rand_hc", "small_rng", "std", "std_rng"] }
 rand_core = { version = "0.5.1", default-features = false, features = ["alloc", "getrandom", "std"] }
 regex = { version = "1.4.3", features = ["aho-corasick", "default", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
@@ -177,7 +177,7 @@ serde_json = { version = "1.0.64", features = ["default", "indexmap", "preserve_
 standback = { version = "0.2.15", default-features = false, features = ["std"] }
 subtle = { version = "2.4.0", default-features = false, features = ["std"] }
 tiny-keccak = { version = "2.0.2", features = ["default", "sha3"] }
-tokio = { version = "1.6.1", features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "test-util", "time", "tokio-macros", "winapi"] }
+tokio = { version = "1.8.1", features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "test-util", "time", "tokio-macros", "winapi"] }
 tokio-tungstenite = { version = "0.13.0", features = ["connect", "default", "stream"] }
 tokio-util = { version = "0.6.4", features = ["codec", "compat", "default", "futures-io", "io"] }
 toml = { version = "0.5.8", features = ["default"] }
@@ -223,7 +223,7 @@ once_cell = { version = "1.7.2", features = ["alloc", "default", "race", "std"] 
 petgraph = { version = "0.5.1", features = ["default", "graphmap", "matrix_graph", "stable_graph"] }
 plotters = { version = "0.3.0", default-features = false, features = ["area_series", "evcxr", "histogram", "line_series", "plotters-svg", "svg_backend"] }
 proc-macro2 = { version = "0.4.30", features = ["default", "proc-macro"] }
-prost = { version = "0.7.0", features = ["default", "prost-derive", "std"] }
+prost = { version = "0.8.0", features = ["default", "prost-derive", "std"] }
 quote = { version = "0.6.13", features = ["default", "proc-macro"] }
 rand = { version = "0.8.3", features = ["alloc", "default", "getrandom", "libc", "rand_chacha", "rand_hc", "small_rng", "std", "std_rng"] }
 rand_core = { version = "0.5.1", default-features = false, features = ["alloc", "getrandom", "std"] }
@@ -239,7 +239,7 @@ subtle = { version = "2.4.0", default-features = false, features = ["std"] }
 syn-3575ec1268b04181 = { package = "syn", version = "0.15.44", features = ["clone-impls", "default", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.72", features = ["clone-impls", "default", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
 tiny-keccak = { version = "2.0.2", features = ["default", "sha3"] }
-tokio = { version = "1.6.1", features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "test-util", "time", "tokio-macros", "winapi"] }
+tokio = { version = "1.8.1", features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "test-util", "time", "tokio-macros", "winapi"] }
 tokio-tungstenite = { version = "0.13.0", features = ["connect", "default", "stream"] }
 tokio-util = { version = "0.6.4", features = ["codec", "compat", "default", "futures-io", "io"] }
 toml = { version = "0.5.8", features = ["default"] }

--- a/config/management/operational/Cargo.toml
+++ b/config/management/operational/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "1.0.64"
 serde_yaml = "0.8.17"
 structopt = "0.3.21"
 thiserror = "1.0.24"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 tokio-util = { version = "0.6.4", features = ["compat"] }
 toml = { version = "0.5.8", default-features = false }
 

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0.124", default-features = false }
 serde_json = "1.0.64"
 termion = { version = "1.5.6", default-features = false }
 thiserror = "1.0.24"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 
 channel = { path = "../common/channel" }
 consensus-types = { path = "consensus-types", default-features = false }

--- a/diem-node/Cargo.toml
+++ b/diem-node/Cargo.toml
@@ -14,7 +14,7 @@ fail = "0.4.0"
 futures = "0.3.12"
 jemallocator = { version = "0.3.2", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
 structopt = "0.3.21"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 tokio-stream = "0.1.4"
 
 backup-service = { path = "../storage/backup/backup-service" }

--- a/json-rpc/Cargo.toml
+++ b/json-rpc/Cargo.toml
@@ -19,7 +19,7 @@ once_cell = "1.7.2"
 rand = "0.8.3"
 serde_json = "1.0.64"
 serde = { version = "1.0.124", features = ["derive"], default-features = false }
-tokio = { version = "1.6.1", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 tokio-retry = "0.3.0"
 tokio-stream = "0.1.4"
 tokio-tungstenite = "0.13.0"

--- a/json-rpc/types/proto/Cargo.toml
+++ b/json-rpc/types/proto/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-prost = "0.7.0"
+prost = "0.8.0"
 serde = { version = "1.0.124", default-features = false }
 serde_json = "1.0.64"
 
@@ -20,4 +20,4 @@ diem-json-rpc-types = { path = ".." }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 
 [build-dependencies]
-prost-build = "0.7.0"
+prost-build = "0.8.0"

--- a/language/diem-tools/diem-events-fetcher/Cargo.toml
+++ b/language/diem-tools/diem-events-fetcher/Cargo.toml
@@ -17,7 +17,7 @@ hex = "0.4.3"
 reqwest = { version = "0.11.2", features = ["blocking", "json"] }
 structopt = "0.3.21"
 futures = "0.3.12"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 diem-client = { path = "../../../sdk/client" }

--- a/language/move-prover/Cargo.toml
+++ b/language/move-prover/Cargo.toml
@@ -39,7 +39,7 @@ serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
 simplelog = "0.9.0"
 once_cell = "1.7.2"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 toml = "0.5.8"
 
 [dev-dependencies]

--- a/language/move-prover/boogie-backend/Cargo.toml
+++ b/language/move-prover/boogie-backend/Cargo.toml
@@ -27,6 +27,6 @@ regex = "1.4.3"
 rand = "0.8.3"
 futures = "0.3.12"
 tera = "1.7.1"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 codespan = "0.8.0"
 codespan-reporting = "0.8.0"

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -18,7 +18,7 @@ once_cell = "1.7.2"
 proptest = { version = "1.0.0", optional = true }
 rayon = "1.4.1"
 serde = { version = "1.0.124", default-features = false }
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 tokio-stream = "0.1.4"
 
 bounded-executor = { path = "../common/bounded-executor" }

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -24,7 +24,7 @@ rand_core = { version = "0.6.2", optional = true }
 serde = { version = "1.0.124", default-features = false }
 serde_bytes = "0.11.5"
 thiserror = "1.0.24"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 tokio-retry = "0.3.0"
 tokio-stream = "0.1.4"
 tokio-util = { version = "0.6.4", features = ["compat", "codec"] }

--- a/network/builder/Cargo.toml
+++ b/network/builder/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 futures = "0.3.12"
 rand = "0.8.3"
 serde = { version = "1.0.124", default-features = false }
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 
 channel = { path = "../../common/channel" }
 bcs = "0.1.2"

--- a/network/discovery/Cargo.toml
+++ b/network/discovery/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1.0.38"
 futures = "0.3.12"
 once_cell = "1.7.2"
 serde_yaml = "0.8.17"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 
 channel = {path = "../../common/channel"}
 bcs = "0.1.2"

--- a/network/netcore/Cargo.toml
+++ b/network/netcore/Cargo.toml
@@ -14,7 +14,7 @@ bytes = "1.0.1"
 futures = "0.3.12"
 pin-project = "1.0.5"
 serde = { version = "1.0.124", default-features = false }
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 tokio-util = { version = "0.6.4", features = ["compat"] }
 url = { version = "2.2.1" }
 

--- a/network/socket-bench-server/Cargo.toml
+++ b/network/socket-bench-server/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3.12"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 tokio-util = { version = "0.6.4", features = ["compat", "codec"] }
 
 diem-crypto = { path = "../../crypto/crypto" }

--- a/sdk/client/Cargo.toml
+++ b/sdk/client/Cargo.toml
@@ -29,7 +29,7 @@ diem-types = { path = "../../types", version = "0.0.2" }
 
 # Optional Dependencies
 reqwest = { version = "0.11.2", features = ["json"], optional = true }
-tokio = { version = "1.3.0", features = ["time"], default_features = false, optional = true }
+tokio = { version = "1.8.1", features = ["time"], default_features = false, optional = true }
 ureq = { version = "1.5.4", features = ["json", "native-tls"], default-features = false, optional = true }
 ipnet = { version = "2.3", optional = true }
 

--- a/secure/key-manager/Cargo.toml
+++ b/secure/key-manager/Cargo.toml
@@ -32,7 +32,7 @@ diem-transaction-builder = { path = "../../sdk/transaction-builder" }
 [dev-dependencies]
 futures = "0.3.12"
 rand = "0.8.3"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 
 executor = { path = "../../execution/executor" }
 executor-test-helpers = { path = "../../execution/executor-test-helpers" }

--- a/state-sync/Cargo.toml
+++ b/state-sync/Cargo.toml
@@ -19,7 +19,7 @@ proptest = { version = "1.0.0", optional = true }
 rand = "0.8.3"
 serde = { version = "1.0.124", default-features = false }
 thiserror = "1.0.24"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 tokio-stream = "0.1.4"
 
 channel = { path = "../common/channel" }

--- a/storage/backup/backup-cli/Cargo.toml
+++ b/storage/backup/backup-cli/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
 structopt = "0.3.21"
 toml = "0.5.8"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 tokio-stream = "0.1.4"
 tokio-util = { version = "0.6.4", features = ["compat"] }
 

--- a/storage/backup/backup-service/Cargo.toml
+++ b/storage/backup/backup-service/Cargo.toml
@@ -15,7 +15,7 @@ futures = "0.3.12"
 hyper = "0.14.4"
 once_cell = "1.7.2"
 serde = { version = "1.0.124", default-features = false }
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 warp = "0.3.0"
 
 bcs = "0.1.2"

--- a/storage/storage-service/Cargo.toml
+++ b/storage/storage-service/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.38"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 futures = "0.3.12"
 
 bcs = "0.1.2"

--- a/testsuite/cli/Cargo.toml
+++ b/testsuite/cli/Cargo.toml
@@ -21,7 +21,7 @@ once_cell = "1.7.2"
 reqwest = { version = "0.11.2", features = ["blocking", "json"] }
 serde = { version = "1.0.124", features = ["derive"] }
 structopt = "0.3.21"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 walkdir = "2.3.1"
 
 diem-config = { path = "../../config" }

--- a/testsuite/cluster-test/Cargo.toml
+++ b/testsuite/cluster-test/Cargo.toml
@@ -65,7 +65,7 @@ diem-sdk = { path = "../../sdk" }
 diem-transaction-builder = { path = "../../sdk/transaction-builder" }
 
 futures = "0.3.12"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 async-trait = "0.1.42"
 
 kube = "0.51.0"

--- a/testsuite/forge/Cargo.toml
+++ b/testsuite/forge/Cargo.toml
@@ -16,7 +16,7 @@ itertools = "0.10.0"
 rand = "0.8.3"
 structopt = "0.3.21"
 termcolor = "1.1.2"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 reqwest = { version = "0.11.2", features = ["blocking", "json"] }
 rand_core = "0.6.2"
 serde_json = "1.0.64"

--- a/testsuite/smoke-test/Cargo.toml
+++ b/testsuite/smoke-test/Cargo.toml
@@ -22,7 +22,7 @@ regex = "1.4.3"
 rust_decimal = "1.10.3"
 rusty-fork = "0.3.0"
 serde_yaml = "0.8.17"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 
 backup-cli = { path = "../../storage/backup/backup-cli" }
 cli = { path = "../cli", features = ["fuzzing"]  }


### PR DESCRIPTION

## Motivation

Upgrading dependency versions due to #8716 

To make prost 0.8.0 across the board, prost-build and prost-types were bumped as well. As a result, some itertools versions bumped to 0.10.0 which was something we've already been using.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Y
## Test Plan
existing coverage
