### PR TITLE
[decoupled-execution] Integration of decoupled execution

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -28,6 +28,7 @@ pub struct ConsensusConfig {
     // only when decoupled is true, the execution and committing will be pipelined in different phases
     pub decoupled: bool,
     pub channel_size: usize,
+    pub back_pressure_limit: u64,
 }
 
 impl Default for ConsensusConfig {
@@ -48,6 +49,7 @@ impl Default for ConsensusConfig {
             mempool_poll_count: 1,
             decoupled: false, // by default, we turn of the decoupling execution feature
             channel_size: 30, // hard-coded
+            back_pressure_limit: 1,
         }
     }
 }

--- a/config/src/config/safety_rules_config.rs
+++ b/config/src/config/safety_rules_config.rs
@@ -26,6 +26,7 @@ pub struct SafetyRulesConfig {
     // Read/Write/Connect networking operation timeout in milliseconds.
     pub network_timeout_ms: u64,
     pub enable_cached_safety_data: bool,
+    pub decoupled_execution: bool,
 }
 
 impl Default for SafetyRulesConfig {
@@ -40,6 +41,7 @@ impl Default for SafetyRulesConfig {
             // Default value of 30 seconds for a timeout
             network_timeout_ms: 30_000,
             enable_cached_safety_data: true,
+            decoupled_execution: false,
         }
     }
 }

--- a/consensus/consensus-types/src/experimental/commit_vote.rs
+++ b/consensus/consensus-types/src/experimental/commit_vote.rs
@@ -30,7 +30,7 @@ impl Display for CommitVote {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
-            "CommitProposal: [author: {}, {}]",
+            "CommitVote: [author: {}, {}]",
             self.author.short_str(),
             self.ledger_info
         )
@@ -61,12 +61,12 @@ impl CommitVote {
         }
     }
 
-    /// Return the author of the commit proposal
+    /// Return the author of the commit vote
     pub fn author(&self) -> Author {
         self.author
     }
 
-    /// Return the LedgerInfo associated with this commit proposal
+    /// Return the LedgerInfo associated with this commit vote
     pub fn ledger_info(&self) -> &LedgerInfo {
         &self.ledger_info
     }
@@ -84,11 +84,11 @@ impl CommitVote {
         self.ledger_info.epoch()
     }
 
-    /// Verifies that the consensus data hash of LedgerInfo corresponds to the commit proposal,
+    /// Verifies that the consensus data hash of LedgerInfo corresponds to the commit vote,
     /// and then verifies the signature.
     pub fn verify(&self, validator: &ValidatorVerifier) -> anyhow::Result<()> {
         validator
             .verify(self.author(), &self.ledger_info, &self.signature)
-            .context("Failed to verify Commit Proposal")
+            .context("Failed to verify Commit Vote")
     }
 }

--- a/consensus/safety-rules/benches/safety_rules.rs
+++ b/consensus/safety-rules/benches/safety_rules.rs
@@ -66,7 +66,7 @@ fn in_memory(n: u64) {
         waypoint,
         true,
     );
-    let safety_rules_manager = SafetyRulesManager::new_local(storage, false, false);
+    let safety_rules_manager = SafetyRulesManager::new_local(storage, false, false, false);
     lsr(safety_rules_manager.client(), signer, n);
 }
 
@@ -82,7 +82,7 @@ fn on_disk(n: u64) {
         waypoint,
         true,
     );
-    let safety_rules_manager = SafetyRulesManager::new_local(storage, false, false);
+    let safety_rules_manager = SafetyRulesManager::new_local(storage, false, false, false);
     lsr(safety_rules_manager.client(), signer, n);
 }
 
@@ -98,7 +98,7 @@ fn serializer(n: u64) {
         waypoint,
         true,
     );
-    let safety_rules_manager = SafetyRulesManager::new_serializer(storage, false, false);
+    let safety_rules_manager = SafetyRulesManager::new_serializer(storage, false, false, false);
     lsr(safety_rules_manager.client(), signer, n);
 }
 
@@ -116,7 +116,8 @@ fn thread(n: u64) {
     );
     // Test value, in milliseconds
     let timeout_ms = 5_000;
-    let safety_rules_manager = SafetyRulesManager::new_thread(storage, false, false, timeout_ms);
+    let safety_rules_manager =
+        SafetyRulesManager::new_thread(storage, false, false, timeout_ms, false);
     lsr(safety_rules_manager.client(), signer, n);
 }
 
@@ -137,7 +138,8 @@ fn vault(n: u64) {
     );
     // Test value in milliseconds.
     let timeout_ms = 5_000;
-    let safety_rules_manager = SafetyRulesManager::new_thread(storage, false, false, timeout_ms);
+    let safety_rules_manager =
+        SafetyRulesManager::new_thread(storage, false, false, timeout_ms, false);
     lsr(safety_rules_manager.client(), signer, n);
 }
 

--- a/consensus/safety-rules/src/process.rs
+++ b/consensus/safety-rules/src/process.rs
@@ -33,6 +33,7 @@ impl Process {
                 verify_vote_proposal_signature,
                 export_consensus_key,
                 network_timeout: config.network_timeout_ms,
+                decoupled_execution: config.decoupled_execution,
             }),
         }
     }
@@ -45,6 +46,7 @@ impl Process {
             data.verify_vote_proposal_signature,
             data.export_consensus_key,
             data.network_timeout,
+            data.decoupled_execution,
         );
     }
 }
@@ -56,6 +58,7 @@ struct ProcessData {
     export_consensus_key: bool,
     // Timeout in Seconds for network operations
     network_timeout: u64,
+    decoupled_execution: bool,
 }
 
 pub struct ProcessService {

--- a/consensus/safety-rules/src/remote_service.rs
+++ b/consensus/safety-rules/src/remote_service.rs
@@ -33,11 +33,13 @@ pub fn execute(
     verify_vote_proposal_signature: bool,
     export_consensus_key: bool,
     network_timeout_ms: u64,
+    decoupled_execution: bool,
 ) {
     let mut safety_rules = SafetyRules::new(
         storage,
         verify_vote_proposal_signature,
         export_consensus_key,
+        decoupled_execution,
     );
     if let Err(e) = safety_rules.consensus_state() {
         warn!("Unable to print consensus state: {}", e);

--- a/consensus/safety-rules/src/safety_rules_manager.rs
+++ b/consensus/safety-rules/src/safety_rules_manager.rs
@@ -74,17 +74,20 @@ impl SafetyRulesManager {
                 storage,
                 verify_vote_proposal_signature,
                 export_consensus_key,
+                config.decoupled_execution,
             ),
             SafetyRulesService::Serializer => Self::new_serializer(
                 storage,
                 verify_vote_proposal_signature,
                 export_consensus_key,
+                config.decoupled_execution,
             ),
             SafetyRulesService::Thread => Self::new_thread(
                 storage,
                 verify_vote_proposal_signature,
                 export_consensus_key,
                 config.network_timeout_ms,
+                config.decoupled_execution,
             ),
             _ => panic!("Unimplemented SafetyRulesService: {:?}", config.service),
         }
@@ -94,11 +97,13 @@ impl SafetyRulesManager {
         storage: PersistentSafetyStorage,
         verify_vote_proposal_signature: bool,
         export_consensus_key: bool,
+        decoupled_execution: bool,
     ) -> Self {
         let safety_rules = SafetyRules::new(
             storage,
             verify_vote_proposal_signature,
             export_consensus_key,
+            decoupled_execution,
         );
         Self {
             internal_safety_rules: SafetyRulesWrapper::Local(Arc::new(RwLock::new(safety_rules))),
@@ -116,11 +121,13 @@ impl SafetyRulesManager {
         storage: PersistentSafetyStorage,
         verify_vote_proposal_signature: bool,
         export_consensus_key: bool,
+        decoupled_execution: bool,
     ) -> Self {
         let safety_rules = SafetyRules::new(
             storage,
             verify_vote_proposal_signature,
             export_consensus_key,
+            decoupled_execution,
         );
         let serializer_service = SerializerService::new(safety_rules);
         Self {
@@ -135,12 +142,14 @@ impl SafetyRulesManager {
         verify_vote_proposal_signature: bool,
         export_consensus_key: bool,
         timeout_ms: u64,
+        decoupled_execution: bool,
     ) -> Self {
         let thread = ThreadService::new(
             storage,
             verify_vote_proposal_signature,
             export_consensus_key,
             timeout_ms,
+            decoupled_execution,
         );
         Self {
             internal_safety_rules: SafetyRulesWrapper::Thread(thread),

--- a/consensus/safety-rules/src/test_utils.rs
+++ b/consensus/safety-rules/src/test_utils.rs
@@ -242,7 +242,7 @@ pub fn test_safety_rules() -> SafetyRules {
     let storage = test_storage(&signer);
     let (epoch_change_proof, _) = make_genesis(&signer);
 
-    let mut safety_rules = SafetyRules::new(storage, true, false);
+    let mut safety_rules = SafetyRules::new(storage, true, false, false);
     safety_rules.initialize(&epoch_change_proof).unwrap();
     safety_rules
 }
@@ -251,7 +251,7 @@ pub fn test_safety_rules() -> SafetyRules {
 pub fn test_safety_rules_uninitialized() -> SafetyRules {
     let signer = ValidatorSigner::from_int(0);
     let storage = test_storage(&signer);
-    SafetyRules::new(storage, true, false)
+    SafetyRules::new(storage, true, false, false)
 }
 
 /// Returns a simple serializer for testing purposes.

--- a/consensus/safety-rules/src/tests/local.rs
+++ b/consensus/safety-rules/src/tests/local.rs
@@ -29,6 +29,7 @@ fn safety_rules(
             storage,
             verify_vote_proposal_signature,
             export_consensus_key,
+            false,
         );
         let safety_rules = safety_rules_manager.client();
         (

--- a/consensus/safety-rules/src/tests/networking.rs
+++ b/consensus/safety-rules/src/tests/networking.rs
@@ -11,7 +11,7 @@ fn test_reconnect() {
     // test value for network timeout, in milliseconds.
     let network_timeout = 5_000;
     let safety_rules_manager =
-        SafetyRulesManager::new_thread(storage, false, false, network_timeout);
+        SafetyRulesManager::new_thread(storage, false, false, network_timeout, false);
 
     // Verify that after a client has disconnected a new client will connect and resume operations
     let state0 = safety_rules_manager.client().consensus_state().unwrap();

--- a/consensus/safety-rules/src/tests/safety_rules.rs
+++ b/consensus/safety-rules/src/tests/safety_rules.rs
@@ -13,6 +13,7 @@ fn test() {
             suite::run_test_suite(&safety_rules(
                 *verify_vote_proposal_signature,
                 *export_consensus_key,
+                false, // todo: test on both cases
             ));
         }
     }
@@ -21,6 +22,7 @@ fn test() {
 fn safety_rules(
     verify_vote_proposal_signature: bool,
     export_consensus_key: bool,
+    decoupled_execution: bool,
 ) -> suite::Callback {
     Box::new(move || {
         let signer = ValidatorSigner::from_int(0);
@@ -29,6 +31,7 @@ fn safety_rules(
             storage,
             verify_vote_proposal_signature,
             export_consensus_key,
+            decoupled_execution,
         ));
         (
             safety_rules,

--- a/consensus/safety-rules/src/tests/serializer.rs
+++ b/consensus/safety-rules/src/tests/serializer.rs
@@ -29,6 +29,7 @@ fn safety_rules(
             storage,
             verify_vote_proposal_signature,
             export_consensus_key,
+            false,
         );
         let safety_rules = safety_rules_manager.client();
         (

--- a/consensus/safety-rules/src/tests/suite.rs
+++ b/consensus/safety-rules/src/tests/suite.rs
@@ -689,7 +689,7 @@ fn test_reconcile_key(_safety_rules: &Callback) {
     let mut storage = test_utils::test_storage(&signer);
 
     let new_pub_key = storage.internal_store().rotate_key(CONSENSUS_KEY).unwrap();
-    let mut safety_rules = Box::new(SafetyRules::new(storage, false, false));
+    let mut safety_rules = Box::new(SafetyRules::new(storage, false, false, false));
 
     let (mut proof, genesis_qc) = test_utils::make_genesis(&signer);
     let round = genesis_qc.certified_block().round();

--- a/consensus/safety-rules/src/tests/thread.rs
+++ b/consensus/safety-rules/src/tests/thread.rs
@@ -32,6 +32,7 @@ fn safety_rules(
             verify_vote_proposal_signature,
             export_consensus_key,
             network_timeout,
+            false,
         );
         let safety_rules = safety_rules_manager.client();
         (

--- a/consensus/safety-rules/src/tests/vault.rs
+++ b/consensus/safety-rules/src/tests/vault.rs
@@ -57,6 +57,7 @@ fn safety_rules(
             storage,
             verify_vote_proposal_signature,
             export_consensus_key,
+            false,
         );
         let safety_rules = safety_rules_manager.client();
         (

--- a/consensus/safety-rules/src/thread.rs
+++ b/consensus/safety-rules/src/thread.rs
@@ -31,6 +31,7 @@ impl ThreadService {
         verify_vote_proposal_signature: bool,
         export_consensus_key: bool,
         timeout: u64,
+        decoupled_execution: bool,
     ) -> Self {
         let listen_port = utils::get_available_port();
         let listen_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), listen_port);
@@ -43,6 +44,7 @@ impl ThreadService {
                 verify_vote_proposal_signature,
                 export_consensus_key,
                 timeout,
+                decoupled_execution,
             )
         });
 

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -5,6 +5,10 @@ use crate::{
     block_storage::BlockStore,
     counters,
     error::{error_kind, DbError},
+    experimental::{
+        commit_phase_v2::CommitPhaseV2, execution_phase::ExecutionPhase,
+        ordering_state_computer::OrderingStateComputer,
+    },
     liveness::{
         leader_reputation::{ActiveInactiveHeuristic, DiemDBBackend, LeaderReputation},
         proposal_generator::ProposalGenerator,
@@ -22,26 +26,33 @@ use crate::{
     state_replication::{StateComputer, TxnManager},
     util::time_service::TimeService,
 };
-use anyhow::{bail, ensure, Context};
-use channel::diem_channel;
+use anyhow::{anyhow, bail, ensure, Context};
+use channel::{diem_channel, Sender};
 use consensus_types::{
+    block::Block,
     common::{Author, Round},
     epoch_retrieval::EpochRetrievalRequest,
+    executed_block::ExecutedBlock,
 };
 use diem_config::config::{ConsensusConfig, ConsensusProposerType, NodeConfig};
-use diem_infallible::duration_since_epoch;
+use diem_infallible::{duration_since_epoch, Mutex};
 use diem_logger::prelude::*;
-use diem_metrics::monitor;
+use diem_metrics::{monitor, IntGauge};
 use diem_types::{
     account_address::AccountAddress,
     epoch_change::EpochChangeProof,
     epoch_state::EpochState,
+    ledger_info::LedgerInfoWithSignatures,
     on_chain_config::{OnChainConfigPayload, ValidatorSet},
 };
-use futures::{select, StreamExt};
+use futures::{select, SinkExt, StreamExt};
 use network::protocols::network::Event;
 use safety_rules::SafetyRulesManager;
-use std::{cmp::Ordering, sync::Arc, time::Duration};
+use std::{
+    cmp::Ordering,
+    sync::{atomic::AtomicU64, Arc},
+    time::Duration,
+};
 
 /// RecoveryManager is used to process events in order to sync up with peer if we can't recover from local consensusdb
 /// RoundManager is used for normal event handling.
@@ -77,11 +88,14 @@ pub struct EpochManager {
     network_sender: ConsensusNetworkSender,
     timeout_sender: channel::Sender<Round>,
     txn_manager: Arc<dyn TxnManager>,
-    state_computer: Arc<dyn StateComputer>,
+    state_computer: Option<Arc<dyn StateComputer>>,
     storage: Arc<dyn PersistentLivenessStorage>,
     safety_rules_manager: SafetyRulesManager,
     processor: Option<RoundProcessor>,
     reconfig_events: diem_channel::Receiver<(), OnChainConfigPayload>,
+    commit_channel_state_computer: Arc<dyn StateComputer>,
+    sender_commit_msg: Option<Sender<ConsensusMsg>>,
+    back_pressure: Arc<AtomicU64>,
 }
 
 impl EpochManager {
@@ -92,14 +106,19 @@ impl EpochManager {
         network_sender: ConsensusNetworkSender,
         timeout_sender: channel::Sender<Round>,
         txn_manager: Arc<dyn TxnManager>,
-        state_computer: Arc<dyn StateComputer>,
+        state_computer: Option<Arc<dyn StateComputer>>,
         storage: Arc<dyn PersistentLivenessStorage>,
         reconfig_events: diem_channel::Receiver<(), OnChainConfigPayload>,
+        commit_channel_state_computer: Arc<dyn StateComputer>,
     ) -> Self {
         let author = node_config.validator_network.as_ref().unwrap().peer_id();
         let config = node_config.consensus.clone();
         let sr_config = &node_config.consensus.safety_rules;
+        if sr_config.decoupled_execution != config.decoupled {
+            panic!("Inconsistent decoupled-execution configuration of consensus and safety-rules\nMake sure consensus.decoupled = safety_rules.decoupled_execution.")
+        }
         let safety_rules_manager = SafetyRulesManager::new(sr_config);
+        let back_pressure = Arc::new(AtomicU64::new(0));
         Self {
             author,
             config,
@@ -113,6 +132,9 @@ impl EpochManager {
             safety_rules_manager,
             processor: None,
             reconfig_events,
+            commit_channel_state_computer,
+            sender_commit_msg: None,
+            back_pressure,
         }
     }
 
@@ -263,13 +285,14 @@ impl EpochManager {
         );
 
         // make sure storage is on this ledger_info too, it should be no-op if it's already committed
-        self.state_computer
-            .sync_to(ledger_info.clone())
-            .await
-            .context(format!(
+        if let Some(sc) = &self.state_computer {
+            sc.sync_to(ledger_info.clone()).await.context(format!(
                 "[EpochManager] State sync to new epoch {}",
                 ledger_info
             ))?;
+        } else {
+            return Err(anyhow!("State Computer not found."));
+        }
 
         monitor!("reconfig", self.expect_new_epoch().await);
         Ok(())
@@ -289,15 +312,6 @@ impl EpochManager {
         );
         let last_vote = recovery_data.last_vote();
 
-        info!(epoch = epoch, "Create BlockStore");
-        let block_store = Arc::new(BlockStore::new(
-            Arc::clone(&self.storage),
-            recovery_data,
-            Arc::clone(&self.state_computer),
-            self.config.max_pruned_blocks_in_mem,
-            Arc::clone(&self.time_service),
-        ));
-
         info!(epoch = epoch, "Update SafetyRules");
 
         let mut safety_rules =
@@ -309,17 +323,6 @@ impl EpochManager {
                 "Unable to initialize safety rules.",
             );
         }
-
-        info!(epoch = epoch, "Create ProposalGenerator");
-        // txn manager is required both by proposal generator (to pull the proposers)
-        // and by event processor (to update their status).
-        let proposal_generator = ProposalGenerator::new(
-            self.author,
-            block_store.clone(),
-            self.txn_manager.clone(),
-            self.time_service.clone(),
-            self.config.max_block_size,
-        );
 
         info!(epoch = epoch, "Create RoundState");
         let round_state =
@@ -334,18 +337,142 @@ impl EpochManager {
             epoch_state.verifier.clone(),
         );
 
-        let mut processor = RoundManager::new(
-            epoch_state,
-            block_store,
-            round_state,
-            proposer_election,
-            proposal_generator,
-            safety_rules,
-            network_sender,
-            self.txn_manager.clone(),
-            self.storage.clone(),
-            self.config.sync_only,
-        );
+        let safety_rules_container = Arc::new(Mutex::new(safety_rules));
+
+        let mut processor = if self.config.decoupled {
+            let guage_e = IntGauge::new(
+                "D_EXE_CHANNEL_COUNTER",
+                "counter for the decoupling execution channel",
+            )
+            .unwrap();
+
+            let (sender_exec, receiver_exec) = channel::new::<(Vec<Block>, LedgerInfoWithSignatures)>(
+                self.config.channel_size,
+                &guage_e,
+            );
+
+            let state_computer: Arc<dyn StateComputer> =
+                Arc::new(OrderingStateComputer::new(sender_exec));
+
+            self.state_computer = Some(state_computer);
+
+            info!(epoch = epoch, "Create BlockStore");
+            let block_store = Arc::new(BlockStore::new(
+                Arc::clone(&self.storage),
+                recovery_data,
+                self.state_computer.as_ref().unwrap().clone(),
+                self.config.max_pruned_blocks_in_mem,
+                Arc::clone(&self.time_service),
+            ));
+
+            info!(epoch = epoch, "Create ProposalGenerator");
+            // txn manager is required both by proposal generator (to pull the proposers)
+            // and by event processor (to update their status).
+            let proposal_generator = ProposalGenerator::new(
+                self.author,
+                block_store.clone(),
+                self.txn_manager.clone(),
+                self.time_service.clone(),
+                self.config.max_block_size,
+            );
+
+            let guage_c = IntGauge::new(
+                "D_COM_CHANNEL_COUNTER_EM",
+                "counter for the decoupling committing channel in epoch manager",
+            )
+            .unwrap();
+
+            let (sender_comm, receiver_comm) = channel::new::<(
+                Vec<ExecutedBlock>,
+                LedgerInfoWithSignatures,
+            )>(self.config.channel_size, &guage_c);
+
+            let execution_phase = ExecutionPhase::new(
+                receiver_exec,
+                self.commit_channel_state_computer.clone(),
+                sender_comm,
+            );
+
+            tokio::spawn(execution_phase.start());
+
+            let guage_c_msg = IntGauge::new(
+                "D_COM_CHANNEL_COUNTER_EM",
+                "counter for the decoupling committing channel in epoch manager",
+            )
+            .unwrap();
+            let (sender_c_msg, receiver_c_msg) =
+                channel::new::<ConsensusMsg>(self.config.channel_size, &guage_c_msg);
+
+            self.sender_commit_msg = Some(sender_c_msg);
+
+            self.back_pressure
+                .store(0, std::sync::atomic::Ordering::SeqCst);
+
+            let commit_phase = CommitPhaseV2::new(
+                receiver_comm,
+                self.commit_channel_state_computer.clone(),
+                receiver_c_msg,
+                epoch_state.verifier.clone(),
+                Arc::clone(&safety_rules_container),
+                self.author,
+                self.back_pressure.clone(),
+                network_sender.clone(),
+            );
+
+            tokio::spawn(commit_phase.start());
+
+            RoundManager::new(
+                epoch_state,
+                block_store,
+                round_state,
+                proposer_election,
+                proposal_generator,
+                Arc::clone(&safety_rules_container),
+                network_sender,
+                self.txn_manager.clone(),
+                self.storage.clone(),
+                self.config.sync_only,
+                self.back_pressure.clone(),
+                true,
+                self.config.back_pressure_limit,
+            )
+        } else {
+            info!(epoch = epoch, "Create BlockStore");
+            let block_store = Arc::new(BlockStore::new(
+                Arc::clone(&self.storage),
+                recovery_data,
+                self.state_computer.as_ref().unwrap().clone(),
+                self.config.max_pruned_blocks_in_mem,
+                Arc::clone(&self.time_service),
+            ));
+
+            info!(epoch = epoch, "Create ProposalGenerator");
+            // txn manager is required both by proposal generator (to pull the proposers)
+            // and by event processor (to update their status).
+            let proposal_generator = ProposalGenerator::new(
+                self.author,
+                block_store.clone(),
+                self.txn_manager.clone(),
+                self.time_service.clone(),
+                self.config.max_block_size,
+            );
+
+            RoundManager::new(
+                epoch_state,
+                block_store,
+                round_state,
+                proposer_election,
+                proposal_generator,
+                Arc::clone(&safety_rules_container),
+                network_sender,
+                self.txn_manager.clone(),
+                self.storage.clone(),
+                self.config.sync_only,
+                self.back_pressure.clone(),
+                false,
+                10,
+            )
+        };
         processor.start(last_vote).await;
         self.processor = Some(RoundProcessor::Normal(processor));
         info!(epoch = epoch, "RoundManager started");
@@ -371,7 +498,7 @@ impl EpochManager {
             epoch_state,
             network_sender,
             self.storage.clone(),
-            self.state_computer.clone(),
+            self.state_computer.as_ref().unwrap().clone(),
             ledger_recovery_data.commit_round(),
         )));
         info!(epoch = epoch, "SyncProcessor started");
@@ -433,7 +560,11 @@ impl EpochManager {
         msg: ConsensusMsg,
     ) -> anyhow::Result<Option<UnverifiedEvent>> {
         match msg {
-            ConsensusMsg::ProposalMsg(_) | ConsensusMsg::SyncInfo(_) | ConsensusMsg::VoteMsg(_) => {
+            ConsensusMsg::ProposalMsg(_)
+            | ConsensusMsg::SyncInfo(_)
+            | ConsensusMsg::VoteMsg(_)
+            | ConsensusMsg::CommitVoteMsg(_)
+            | ConsensusMsg::CommitDecisionMsg(_) => {
                 let event: UnverifiedEvent = msg.into();
                 if event.epoch() == self.epoch() {
                     return Ok(Some(event));
@@ -490,6 +621,9 @@ impl EpochManager {
                     VerifiedEvent::ProposalMsg(proposal) => p.process_proposal_msg(*proposal).await,
                     VerifiedEvent::VoteMsg(vote) => p.process_vote_msg(*vote).await,
                     VerifiedEvent::SyncInfo(sync_info) => p.sync_up(&sync_info, peer_id).await,
+                    _ => {
+                        unimplemented!()
+                    }
                 }?;
                 let epoch_state = p.epoch_state().clone();
                 info!("Recovered from SyncProcessor");
@@ -507,6 +641,30 @@ impl EpochManager {
                     "process_sync_info",
                     p.process_sync_info_msg(*sync_info, peer_id).await
                 ),
+                VerifiedEvent::CommitVote(cv) => {
+                    //debug!("Epoch Manager gets Commit Vote {}", *request);
+                    if let Some(sender) = &self.sender_commit_msg {
+                        sender
+                            .clone()
+                            .send(ConsensusMsg::CommitVoteMsg(cv))
+                            .await
+                            .map_err(|err| anyhow!("Error in Passing Commit Vote: {}", err))
+                    } else {
+                        bail!("Commit Phase not started but received Commit Vote");
+                    }
+                }
+                VerifiedEvent::CommitDecision(cd) => {
+                    //debug!("Epoch Manager gets Commit Decision {}", *request);
+                    if let Some(sender) = &self.sender_commit_msg {
+                        sender
+                            .clone()
+                            .send(ConsensusMsg::CommitDecisionMsg(cd))
+                            .await
+                            .map_err(|err| anyhow!("Error in Pssing Commit Decision: {}", err))
+                    } else {
+                        bail!("Commit Phase not started but received Commit Decision");
+                    }
+                }
             },
         }
     }

--- a/consensus/src/experimental/commit_phase.rs
+++ b/consensus/src/experimental/commit_phase.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    counters, metrics_safety_rules::MetricsSafetyRules, network_interface::ConsensusMsg,
-    state_replication::StateComputer,
+    counters, metrics_safety_rules::MetricsSafetyRules, network::NetworkSender,
+    network_interface::ConsensusMsg, state_replication::StateComputer,
 };
 use channel::Receiver;
 use consensus_types::{
@@ -11,54 +11,25 @@ use consensus_types::{
     executed_block::ExecutedBlock,
     experimental::{commit_decision::CommitDecision, commit_vote::CommitVote},
 };
-use diem_crypto::{ed25519::Ed25519Signature, HashValue};
+use core::sync::atomic::Ordering;
+use diem_crypto::ed25519::Ed25519Signature;
 use diem_infallible::Mutex;
 use diem_logger::prelude::*;
 use diem_metrics::monitor;
 use diem_types::{
     account_address::AccountAddress,
-    block_info::Round,
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     validator_verifier::ValidatorVerifier,
 };
 use executor_types::Error as ExecutionError;
-use futures::{select, SinkExt, StreamExt};
+use futures::{select, StreamExt};
 use safety_rules::TSafetyRules;
 use std::{
-    collections::{hash_map::Entry, BTreeMap, HashMap, VecDeque},
-    sync::Arc,
+    collections::BTreeMap,
+    sync::{atomic::AtomicU64, Arc},
 };
 
 /*
-┌───────────┬──────────────────────────────────────┐
-│           │                                      │
-│ Message   ├─────────────────┐                    │
-│ Channels  │                 │                    │
-│           │                 ▼                    ▼
-└─▲──┬──────┘  ┌───────► Commit Vote       Commit Decision ◄────────────────┐
-  │  │         │              │                    │                        │
-  │  │         │              │ Add sig            │ Replace sig tree       │
-  │  │         │              │                    │                        │
-  │  │         │       ┌──────▼───────┐            │                        │
-  │  │         │       │              │            │                        │
-  │  │         │       │ Local Cache  │◄───────────┘                        │
-  │  │         │       │ (HashMap)    │                                     │
-  │  │         │       │              │                                     │ Send
-  │  │         │       └──────────────┴──────────────┐                      │
-  │  │         │ Send                                │                      │
-  │  │         │       ┌──────────────┐              │                      │
-  │  └────► Commit     │              │              │                      │
-  │            │       │ Local Queue  │◄─────────┐   │                      │
-  │            └──────►│              │          │   │                      │
-  │         Enqueue    └──────────┬───┘          │   ▼                      │
-  │                               │              │ Check if committable:    │
-  └─────────────── Check Channels │              │    If so, commit and dequeue
-                                  │              │
-                                  └────────► Main Loop
-                                                 ▲
-                                                 │
-                                             fn start
-
  Commit phase takes in the executed blocks from the execution
  phase and commit them. Specifically, commit phase signs a commit
  vote message containing the execution result and broadcast it.
@@ -72,15 +43,11 @@ use std::{
 #[derive(Clone)]
 struct PendingBlocks {
     vecblocks: Vec<ExecutedBlock>,
-    ledger_info_sig: LedgerInfoWithSignatures,
 }
 
 impl PendingBlocks {
-    pub fn new(vecblocks: Vec<ExecutedBlock>, ledger_info_sig: LedgerInfoWithSignatures) -> Self {
-        Self {
-            vecblocks,
-            ledger_info_sig,
-        }
+    pub fn new(vecblocks: Vec<ExecutedBlock>) -> Self {
+        Self { vecblocks }
     }
 }
 
@@ -93,14 +60,13 @@ pub enum CommitPhaseMessage {
 pub struct CommitPhase {
     commit_channel_recv: Receiver<(Vec<ExecutedBlock>, LedgerInfoWithSignatures)>,
     execution_proxy: Arc<dyn StateComputer>,
-    local_cache: HashMap<HashValue, LedgerInfoWithSignatures>,
-    local_queue: VecDeque<PendingBlocks>,
-    commit_msg_sender: channel::Sender<CommitPhaseMessage>,
+    blocks: Option<(Vec<ExecutedBlock>, LedgerInfoWithSignatures)>,
     commit_msg_receiver: channel::Receiver<ConsensusMsg>,
     verifier: ValidatorVerifier,
     safety_rules: Arc<Mutex<MetricsSafetyRules>>,
     author: Author,
-    committed_round: Round,
+    back_pressure: Arc<AtomicU64>,
+    network_sender: NetworkSender,
 }
 
 pub async fn commit(
@@ -108,6 +74,7 @@ pub async fn commit(
     vecblock: &[ExecutedBlock],
     ledger_info: &LedgerInfoWithSignatures,
 ) -> Result<(), ExecutionError> {
+    // debug!("New commit: {} {}", vecblock.len(), ledger_info);
     // have to maintain the order.
     execution_proxy
         .commit(
@@ -133,55 +100,41 @@ impl CommitPhase {
     pub fn new(
         commit_channel_recv: Receiver<(Vec<ExecutedBlock>, LedgerInfoWithSignatures)>,
         execution_proxy: Arc<dyn StateComputer>,
-        commit_msg_sender: channel::Sender<CommitPhaseMessage>,
         commit_msg_receiver: channel::Receiver<ConsensusMsg>,
         verifier: ValidatorVerifier,
         safety_rules: Arc<Mutex<MetricsSafetyRules>>,
         author: Author,
+        back_pressure: Arc<AtomicU64>,
+        network_sender: NetworkSender,
     ) -> Self {
         Self {
             commit_channel_recv,
             execution_proxy,
-            local_cache: HashMap::<HashValue, LedgerInfoWithSignatures>::new(),
-            local_queue: VecDeque::<PendingBlocks>::new(),
-            commit_msg_sender,
+            blocks: None,
             commit_msg_receiver,
             verifier,
             safety_rules,
             author,
-            committed_round: 0,
+            back_pressure,
+            network_sender,
         }
     }
 
     /// Notified when receiving a commit vote message
     pub async fn process_commit_vote(&mut self, commit_vote: &CommitVote) -> anyhow::Result<()> {
-        let li = commit_vote.ledger_info();
+        // debug!("process_commit_vote {}", commit_vote);
 
-        if li.commit_info().round() < self.committed_round {
-            return Ok(()); // we ignore the message
+        if let Some((vecblock, ledger_info)) = self.blocks.as_mut() {
+            let li = commit_vote.ledger_info();
+
+            if !(li.commit_info().clone() == vecblock.last().unwrap().block_info()) {
+                return Ok(());  // ignore the message
+            }
+
+            commit_vote.verify(&self.verifier)?;
+
+            ledger_info.add_signature(commit_vote.author(), commit_vote.signature().clone());
         }
-
-        // verify the signature
-        commit_vote.verify(&self.verifier)?;
-
-        let executed_state_hash = li.commit_info().executed_state_id();
-
-        // add the signature to local_cache
-        match self.local_cache.entry(executed_state_hash) {
-            Entry::Occupied(mut ledger_info_entry) => {
-                let mut_ledger_info_entry = ledger_info_entry.get_mut();
-                mut_ledger_info_entry
-                    .add_signature(commit_vote.author(), commit_vote.signature().clone());
-            }
-            Entry::Vacant(_) => {
-                let mut li_sig = LedgerInfoWithSignatures::new(
-                    li.clone(),
-                    BTreeMap::<AccountAddress, Ed25519Signature>::new(),
-                );
-                li_sig.add_signature(commit_vote.author(), commit_vote.signature().clone());
-                self.local_cache.insert(executed_state_hash, li_sig);
-            }
-        };
 
         Ok(())
     }
@@ -190,73 +143,53 @@ impl CommitPhase {
         &mut self,
         commit_decision: CommitDecision,
     ) -> anyhow::Result<()> {
-        let li = commit_decision.ledger_info();
+        // debug!("process_commit_decision {}", commit_decision);
 
-        if li.ledger_info().commit_info().round() < self.committed_round {
-            return Ok(()); // we ignore the message
+        if let Some((vecblock, leder_info)) = self.blocks.as_ref() {
+            let li = commit_decision.ledger_info();
+
+            if !(li.ledger_info().commit_info().clone() == leder_info.ledger_info().commit_info().clone()) {
+                return Ok(());  // ignore the message
+            }
+
+            commit_decision.verify(&self.verifier)?;
+
+            self.blocks = Some((vecblock.clone(), li.clone()));
         }
-
-        commit_decision.verify(&self.verifier)?;
-
-        let executed_state_hash = li.ledger_info().commit_info().executed_state_id();
-
-        // TODO: optimization1: probe local_cache first to see if the existing already verifies,
-        // TODO: otherwise we do not make changes.
-        // TODO: optimization2: we can set a bit to indicate this tree of signatures are already verified,
-        // TODO: we do not have to verify it again in the main loop.
-
-        // replace the signature tree directly if it does not verify
-        self.local_cache.insert(executed_state_hash, li.clone());
 
         Ok(())
     }
 
-    pub async fn process_local_queue(&mut self) -> anyhow::Result<()> {
-        let mut_local_queue = &mut self.local_queue;
-        let mut_local_cache = &mut self.local_cache;
-        while let Some(front) = mut_local_queue.front() {
-            let front_executed_state_hash = front
-                .ledger_info_sig
-                .ledger_info()
-                .commit_info()
-                .executed_state_id();
-            match mut_local_cache.entry(front_executed_state_hash) {
-                Entry::Occupied(ledger_info_occupied_entry) => {
-                    // cancel out an item from local_cache and an item from local_queue
-                    if ledger_info_occupied_entry
-                        .get()
-                        .check_voting_power(&self.verifier)
-                        .is_ok()
-                    {
-                        commit(
-                            &self.execution_proxy,
-                            &front.vecblocks,
-                            &front.ledger_info_sig,
-                        )
-                        .await
-                        .expect("Failed to commit the executed blocks.");
-                        assert!(
-                            self.committed_round
-                                < front.ledger_info_sig.ledger_info().commit_info().round()
-                        );
-                        self.committed_round =
-                            front.ledger_info_sig.ledger_info().commit_info().round();
-                        self.commit_msg_sender
-                            .send(CommitPhaseMessage::CommitDecision(
-                                ledger_info_occupied_entry.get().clone(),
-                            ))
-                            .await?;
-                        ledger_info_occupied_entry.remove_entry();
-                        mut_local_queue.pop_front();
-                    } else {
-                        break;
-                    }
-                }
-                Entry::Vacant(_) => {
-                    break;
-                }
+    pub async fn process_block(&mut self) -> anyhow::Result<()> {
+        if let Some((vecblock, leder_info)) = self.blocks.as_ref() {
+            if leder_info.verify_signatures(&self.verifier).is_ok() {
+                commit(
+                    &self.execution_proxy,
+                    &vecblock,
+                    leder_info,
+                )
+                    .await
+                    .expect("Failed to commit the executed blocks.");
+
+                let commit_round = vecblock.last().unwrap().block_info().round();
+                self.back_pressure.store(commit_round, Ordering::SeqCst);
+
+                // debug!("Commit End");
+
+                let mut commit_sender = self.network_sender.clone();
+                let ledger_info_clone = leder_info.clone();
+                tokio::spawn(async move {
+                    commit_sender
+                        .broadcast(ConsensusMsg::CommitDecisionMsg(Box::new(
+                            CommitDecision::new(ledger_info_clone),
+                        )))
+                        .await;
+                });
+
+                self.blocks = None; // prepare for the next batch of blocks
             }
         }
+
         Ok(())
     }
 
@@ -265,59 +198,81 @@ impl CommitPhase {
         vecblock: Vec<ExecutedBlock>,
         ledger_info: LedgerInfoWithSignatures,
     ) -> anyhow::Result<()> {
-        let new_ledger_info = LedgerInfo::new(
-            vecblock.last().unwrap().block_info(),
-            ledger_info.ledger_info().consensus_data_hash(),
-        );
+        // debug!(
+        //     "process_executed_blocks: vecblock {} ledger_info {}",
+        //     vecblock.len(),
+        //     ledger_info
+        // );
 
-        let sig = self
-            .safety_rules
-            .lock()
-            .sign_commit_vote(ledger_info.clone(), new_ledger_info.clone())?;
-        // if fails, it needs to resend, otherwise the liveness might compromise.
-        self.commit_msg_sender
-            .send(CommitPhaseMessage::CommitVote(
-                self.author,
+            let new_ledger_info = LedgerInfo::new(
+                vecblock.last().unwrap().block_info(),
+                ledger_info.ledger_info().consensus_data_hash(),
+            );
+            // debug!("build new ledger info: {}", new_ledger_info);
+
+            let signature = self
+                .safety_rules
+                .lock()
+                .sign_commit_vote(ledger_info, new_ledger_info.clone())?;
+
+            // debug!("signed");
+            // if fails, it needs to resend, otherwise the liveness might compromise.
+
+            let mut commit_sender = self.network_sender.clone();
+            let author = self.author;
+            let msg = ConsensusMsg::CommitVoteMsg(Box::new(CommitVote::new_with_signature(
+                author,
                 new_ledger_info.clone(),
-                sig,
-            ))
-            .await?;
-        // note that this message will also reach the node itself
+                signature.clone(),
+            )));
 
-        self.local_queue
-            .push_back(PendingBlocks::new(vecblock, ledger_info));
+            let mut new_ledger_info_with_sig = LedgerInfoWithSignatures::new(
+                new_ledger_info,
+                BTreeMap::<AccountAddress, Ed25519Signature>::new(),
+            );
+            new_ledger_info_with_sig.add_signature(self.author, signature);
+
+            self.blocks = Some((vecblock, new_ledger_info_with_sig));
+
+            // debug!("sent commit vote");
+            // note that this message will also reach the node itself
+
+            tokio::spawn(async move {
+                commit_sender.broadcast(msg).await;
+            });
 
         Ok(())
     }
 
     pub async fn start(mut self) {
         loop {
-            select! {
-                (vecblock, ledger_info) = self.commit_channel_recv.select_next_some() => {
-                    report_err!(self.process_executed_blocks(vecblock, ledger_info).await, "Error in processing executed blocks");
+            while let Some(_) = self.blocks.as_ref() {
+                select! {
+                    msg = self.commit_msg_receiver.select_next_some() => {
+                        match msg {
+                            ConsensusMsg::CommitVoteMsg(request) => {
+                                monitor!(
+                                    "process_commit_vote",
+                                    report_err!(self.process_commit_vote(&*request).await, "Error in processing commit vote.")
+                                );
+                            }
+                            ConsensusMsg::CommitDecisionMsg(request) => {
+                                monitor!(
+                                    "process_commit_decision",
+                                    report_err!(self.process_commit_decision(*request).await, "Error in processing commit decision.")
+                                );
+                            }
+                            _ => {}
+                        };
+                    }
+                    // TODO: add a timer
+                    complete => break,
                 }
-                msg = self.commit_msg_receiver.select_next_some() => {
-                    match msg {
-                        ConsensusMsg::CommitVoteMsg(request) => {
-                            monitor!(
-                                "process_commit_vote",
-                                report_err!(self.process_commit_vote(&*request).await, "Error in processing commit vote.")
-                            );
-                        }
-                        ConsensusMsg::CommitDecisionMsg(request) => {
-                            monitor!(
-                                "process_commit_decision",
-                                report_err!(self.process_commit_decision(*request).await, "Error in processing commit decision.")
-                            );
-                        }
-                        _ => {}
-                    };
-                }
+                report_err!(self.process_block().await, "Error in checking whether self.block is ready to commit.");
             }
-            report_err!(
-                self.process_local_queue().await,
-                "Error in processing local queue"
-            );
+            if let Some((vecblocks, ledger_info)) = self.commit_channel_recv.next().await {
+                report_err!(self.process_executed_blocks(vecblocks, ledger_info).await, "Error in processing received blocks");
+            } else { break; }
         }
     }
 }

--- a/consensus/src/experimental/commit_phase_v2.rs
+++ b/consensus/src/experimental/commit_phase_v2.rs
@@ -1,0 +1,389 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    counters, metrics_safety_rules::MetricsSafetyRules, network::NetworkSender,
+    network_interface::ConsensusMsg, state_replication::StateComputer,
+};
+use channel::Receiver;
+use consensus_types::{
+    common::Author,
+    executed_block::ExecutedBlock,
+    experimental::{commit_decision::CommitDecision, commit_vote::CommitVote},
+};
+use core::sync::atomic::Ordering;
+use diem_crypto::{ed25519::Ed25519Signature, HashValue};
+use diem_infallible::Mutex;
+use diem_logger::prelude::*;
+use diem_metrics::monitor;
+use diem_types::{
+    account_address::AccountAddress,
+    block_info::Round,
+    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+    validator_verifier::ValidatorVerifier,
+};
+use executor_types::Error as ExecutionError;
+use futures::{select, SinkExt, StreamExt};
+use safety_rules::TSafetyRules;
+use std::{
+    collections::{hash_map::Entry, BTreeMap, HashMap, VecDeque},
+    sync::{atomic::AtomicU64, Arc},
+};
+
+/*
+┌───────────┬──────────────────────────────────────┐
+│           │                                      │
+│ Message   ├─────────────────┐                    │
+│ Channels  │                 │                    │
+│           │                 ▼                    ▼
+└─▲──┬──────┘  ┌───────► Commit Vote       Commit Decision ◄────────────────┐
+  │  │         │              │                    │                        │
+  │  │         │              │ Add sig            │ Replace sig tree       │
+  │  │         │              │                    │                        │
+  │  │         │       ┌──────▼───────┐            │                        │
+  │  │         │       │              │            │                        │
+  │  │         │       │ Local Cache  │◄───────────┘                        │
+  │  │         │       │ (HashMap)    │                                     │
+  │  │         │       │              │                                     │ Send
+  │  │         │       └──────────────┴──────────────┐                      │
+  │  │         │ Send                                │                      │
+  │  │         │       ┌──────────────┐              │                      │
+  │  └────► Commit     │              │              │                      │
+  │            │       │ Local Queue  │◄─────────┐   │                      │
+  │            └──────►│              │          │   │                      │
+  │         Enqueue    └──────────┬───┘          │   ▼                      │
+  │                               │              │ Check if committable:    │
+  └─────────────── Check Channels │              │    If so, commit and dequeue
+                                  │              │
+                                  └────────► Main Loop
+                                                 ▲
+                                                 │
+                                             fn start
+
+ Commit phase takes in the executed blocks from the execution
+ phase and commit them. Specifically, commit phase signs a commit
+ vote message containing the execution result and broadcast it.
+ Upon collecting a quorum of agreeing votes to a execution result,
+ the commit phase commits the blocks as well as broadcasts a commit
+ decision message together with the quorum of signatures. The commit
+ decision message helps the slower nodes to quickly catch up without
+ having to collect the signatures.
+ */
+
+#[derive(Clone)]
+struct PendingBlocks {
+    vecblocks: Vec<ExecutedBlock>,
+}
+
+impl PendingBlocks {
+    pub fn new(vecblocks: Vec<ExecutedBlock>) -> Self {
+        Self { vecblocks }
+    }
+}
+
+#[derive(Debug)]
+pub enum CommitPhaseMessage {
+    CommitVote(Author, LedgerInfo, Ed25519Signature),
+    CommitDecision(LedgerInfoWithSignatures),
+}
+
+pub struct CommitPhaseV2 {
+    commit_channel_recv: Receiver<(Vec<ExecutedBlock>, LedgerInfoWithSignatures)>,
+    execution_proxy: Arc<dyn StateComputer>,
+    local_cache: HashMap<HashValue, LedgerInfoWithSignatures>,
+    local_queue: VecDeque<PendingBlocks>,
+    commit_msg_receiver: channel::Receiver<ConsensusMsg>,
+    verifier: ValidatorVerifier,
+    safety_rules: Arc<Mutex<MetricsSafetyRules>>,
+    author: Author,
+    committed_round: Round,
+    back_pressure: Arc<AtomicU64>,
+    network_sender: NetworkSender,
+}
+
+pub async fn commit(
+    execution_proxy: &Arc<dyn StateComputer>,
+    vecblock: &[ExecutedBlock],
+    ledger_info: &LedgerInfoWithSignatures,
+) -> Result<(), ExecutionError> {
+    // debug!("New commit: {} {}", vecblock.len(), ledger_info);
+    // have to maintain the order.
+    execution_proxy
+        .commit(
+            &vecblock
+                .iter()
+                .map(|eb| Arc::new(eb.clone()))
+                .collect::<Vec<Arc<ExecutedBlock>>>(),
+            ledger_info.clone(),
+        )
+        .await
+}
+
+macro_rules! report_err {
+    ($result:expr, $error_string:literal) => {
+        if let Err(err) = $result {
+            counters::ERROR_COUNT.inc();
+            error!(error = err.to_string(), $error_string,)
+        }
+    };
+}
+
+impl CommitPhaseV2 {
+    pub fn new(
+        commit_channel_recv: Receiver<(Vec<ExecutedBlock>, LedgerInfoWithSignatures)>,
+        execution_proxy: Arc<dyn StateComputer>,
+        commit_msg_receiver: channel::Receiver<ConsensusMsg>,
+        verifier: ValidatorVerifier,
+        safety_rules: Arc<Mutex<MetricsSafetyRules>>,
+        author: Author,
+        back_pressure: Arc<AtomicU64>,
+        network_sender: NetworkSender,
+    ) -> Self {
+        Self {
+            commit_channel_recv,
+            execution_proxy,
+            local_cache: HashMap::<HashValue, LedgerInfoWithSignatures>::new(),
+            local_queue: VecDeque::<PendingBlocks>::new(),
+            commit_msg_receiver,
+            verifier,
+            safety_rules,
+            author,
+            committed_round: 0,
+            back_pressure,
+            network_sender,
+        }
+    }
+
+    /// Notified when receiving a commit vote message
+    pub async fn process_commit_vote(&mut self, commit_vote: &CommitVote) -> anyhow::Result<()> {
+        // debug!("process_commit_vote {}", commit_vote);
+
+        let li = commit_vote.ledger_info();
+
+        if li.commit_info().round() < self.committed_round {
+            return Ok(()); // we ignore the message
+        }
+
+        // verify the signature
+        commit_vote.verify(&self.verifier)?;
+
+        let executed_state_hash = li.commit_info().executed_state_id();
+
+        // add the signature to local_cache
+        match self.local_cache.entry(executed_state_hash) {
+            Entry::Occupied(mut ledger_info_entry) => {
+                let mut_ledger_info_entry = ledger_info_entry.get_mut();
+                mut_ledger_info_entry
+                    .add_signature(commit_vote.author(), commit_vote.signature().clone());
+            }
+            Entry::Vacant(_) => {
+                let mut li_sig = LedgerInfoWithSignatures::new(
+                    li.clone(),
+                    BTreeMap::<AccountAddress, Ed25519Signature>::new(),
+                );
+                li_sig.add_signature(commit_vote.author(), commit_vote.signature().clone());
+                self.local_cache.insert(executed_state_hash, li_sig);
+                // debug!(
+                //     "inserted local cache: key: {}, len: {}",
+                //     executed_state_hash,
+                //     self.local_cache.len()
+                // );
+            }
+        };
+
+        Ok(())
+    }
+
+    pub async fn process_commit_decision(
+        &mut self,
+        commit_decision: CommitDecision,
+    ) -> anyhow::Result<()> {
+        // debug!("process_commit_decision {}", commit_decision);
+
+        let li = commit_decision.ledger_info();
+
+        if li.ledger_info().commit_info().round() < self.committed_round {
+            return Ok(()); // we ignore the message
+        }
+
+        commit_decision.verify(&self.verifier)?;
+
+        let executed_state_hash = li.ledger_info().commit_info().executed_state_id();
+
+        // TODO: optimization1: probe local_cache first to see if the existing already verifies,
+        // TODO: otherwise we do not make changes.
+        // TODO: optimization2: we can set a bit to indicate this tree of signatures are already verified,
+        // TODO: we do not have to verify it again in the main loop.
+
+        // replace the signature tree directly if it does not verify
+        self.local_cache.insert(executed_state_hash, li.clone());
+
+        Ok(())
+    }
+
+    pub async fn process_local_queue(&mut self) -> anyhow::Result<()> {
+        let mut_local_queue = &mut self.local_queue;
+        let mut_local_cache = &mut self.local_cache;
+        while let Some(front) = mut_local_queue.front() {
+            // TODO: what is vecblocks is empty?
+            let front_executed_state_hash = front
+                .vecblocks
+                .last()
+                .unwrap()
+                .block_info()
+                .executed_state_id();
+            match mut_local_cache.entry(front_executed_state_hash) {
+                Entry::Occupied(ledger_info_occupied_entry) => {
+                    // cancel out an item from local_cache and an item from local_queue
+                    // debug!(
+                    //     "Found {}, checking voting power: {}",
+                    //     front_executed_state_hash,
+                    //     ledger_info_occupied_entry.get()
+                    // );
+                    if ledger_info_occupied_entry
+                        .get()
+                        .verify_signatures(&self.verifier)
+                        .is_ok()
+                    {
+                        commit(
+                            &self.execution_proxy,
+                            &front.vecblocks,
+                            ledger_info_occupied_entry.get(),
+                        )
+                        .await
+                        .expect("Failed to commit the executed blocks.");
+
+                        let commit_round = front.vecblocks.last().unwrap().block_info().round();
+                        self.back_pressure.store(commit_round, Ordering::SeqCst);
+
+                        // debug!("Commit End");
+
+                        assert!(
+                            self.committed_round
+                                < front.vecblocks.last().unwrap().block_info().round()
+                        );
+                        self.committed_round = front.vecblocks.last().unwrap().block_info().round();
+
+                        let mut commit_sender = self.network_sender.clone();
+                        let ledger_info_clone = ledger_info_occupied_entry.get().clone();
+                        tokio::spawn(async move {
+                            commit_sender
+                                .broadcast(ConsensusMsg::CommitDecisionMsg(Box::new(
+                                    CommitDecision::new(ledger_info_clone),
+                                )))
+                                .await;
+                        });
+
+                        ledger_info_occupied_entry.remove_entry();
+                        mut_local_queue.pop_front();
+                    } else {
+                        break;
+                    }
+                }
+                Entry::Vacant(_) => {
+                    // debug!("Not found in the cache: {}", front_executed_state_hash);
+                    break;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn process_executed_blocks(
+        &mut self,
+        vecblock: Vec<ExecutedBlock>,
+        ledger_info: LedgerInfoWithSignatures,
+    ) -> anyhow::Result<()> {
+        // debug!(
+        //     "process_executed_blocks: vecblock {} ledger_info {}",
+        //     vecblock.len(),
+        //     ledger_info
+        // );
+        let new_ledger_info = LedgerInfo::new(
+            vecblock.last().unwrap().block_info(),
+            ledger_info.ledger_info().consensus_data_hash(),
+        );
+        // debug!("build new ledger info: {}", new_ledger_info);
+
+        let signature = self
+            .safety_rules
+            .lock()
+            .sign_commit_vote(ledger_info, new_ledger_info.clone())?;
+
+        // debug!("signed");
+        // if fails, it needs to resend, otherwise the liveness might compromise.
+
+        let mut commit_sender = self.network_sender.clone();
+        let author = self.author;
+        let msg = ConsensusMsg::CommitVoteMsg(Box::new(CommitVote::new_with_signature(
+            author,
+            new_ledger_info,
+            signature,
+        )));
+
+        // debug!("sent commit vote");
+        // note that this message will also reach the node itself
+        self.local_queue.push_back(PendingBlocks::new(vecblock));
+
+        tokio::spawn(async move {
+            commit_sender.broadcast(msg).await;
+        });
+
+        Ok(())
+    }
+
+    pub async fn start(mut self) {
+        loop {
+            if self.local_queue.is_empty() {
+                select! {
+                    (vecblock, ledger_info) = self.commit_channel_recv.select_next_some() => {
+                        report_err!(self.process_executed_blocks(vecblock, ledger_info).await, "Error in processing executed blocks");
+                    }
+                    msg = self.commit_msg_receiver.select_next_some() => {
+                        match msg {
+                            ConsensusMsg::CommitVoteMsg(request) => {
+                                monitor!(
+                                    "process_commit_vote",
+                                    report_err!(self.process_commit_vote(&*request).await, "Error in processing commit vote.")
+                                );
+                            }
+                            ConsensusMsg::CommitDecisionMsg(request) => {
+                                monitor!(
+                                    "process_commit_decision",
+                                    report_err!(self.process_commit_decision(*request).await, "Error in processing commit decision.")
+                                );
+                            }
+                            _ => {}
+                        };
+                    }
+                    complete => break,
+                }
+            } else {
+                select! {
+                    msg = self.commit_msg_receiver.select_next_some() => {
+                        match msg {
+                            ConsensusMsg::CommitVoteMsg(request) => {
+                                monitor!(
+                                    "process_commit_vote",
+                                    report_err!(self.process_commit_vote(&*request).await, "Error in processing commit vote.")
+                                );
+                            }
+                            ConsensusMsg::CommitDecisionMsg(request) => {
+                                monitor!(
+                                    "process_commit_decision",
+                                    report_err!(self.process_commit_decision(*request).await, "Error in processing commit decision.")
+                                );
+                            }
+                            _ => {}
+                        };
+                    }
+                    complete => break,
+                }
+            }
+            report_err!(
+                self.process_local_queue().await,
+                "Error in processing local queue"
+            );
+        }
+    }
+}

--- a/consensus/src/experimental/mod.rs
+++ b/consensus/src/experimental/mod.rs
@@ -22,6 +22,7 @@
 //                               │ Decision    │ (Asynchronously)
 //                               └─────────────┘
 
-pub mod commit_phase;
+pub mod commit_phase_v2;
 pub mod execution_phase;
 pub mod ordering_state_computer;
+pub mod commit_phase;

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -119,9 +119,11 @@ impl NetworkSender {
     pub async fn broadcast(&mut self, msg: ConsensusMsg) {
         // Directly send the message to ourself without going through network.
         let self_msg = Event::Message(self.author, msg.clone());
+
         if let Err(err) = self.self_sender.send(self_msg).await {
             error!("Error broadcasting to self: {:?}", err);
         }
+        debug!("broadcasted");
 
         // Get the list of validators excluding our own account address. Note the
         // ordering is not important in this case.


### PR DESCRIPTION
This integration keeps the original logic if the switch in the consensus
    config (node_config.consensus.decoupled) is set to false. Besides, we add
    two more config items, channel_size and back_pressure_limit.

+ The channel size indicate the sizes of the (blocking) channels we use to
    bridge EpochManager, CommitPhase, and ExecutionPhase.
   
+ The back pressure limit is the number of rounds we allow for the consensus
    protocol to run ahead of the execution / committing phases.

Closes: #8701

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Part of the decoupled execution project.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update or suggest changes to the docs at https://developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
