### PR TITLE
jsonrpc: run integration tests in their own ci step

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -535,6 +535,11 @@ jobs:
           $pre_command && mkdir -p target/junit-reports && cargo nextest --jobs ${max_threads} --tries ${nextest_tries} --unit --failure-output=immediate-final --changed-since "origin/$TARGET_BRANCH" --junit target/junit-reports/unit-test.xml
         env:
           TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
+      - name: run jsonrpc integration tests
+        run: |
+          $pre_command && cargo xtest -p jsonrpc-integration-tests --changed-since "origin/$TARGET_BRANCH"
+        env:
+          TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
       - name: run doctests
         run: |
           $pre_command && cargo xtest --doc --jobs ${max_threads} --unit --changed-since "origin/$TARGET_BRANCH"
@@ -573,6 +578,13 @@ jobs:
       - name: run unit tests
         run: |
           $pre_command && mkdir -p target/junit-reports && cargo nextest --jobs ${max_threads} --tries ${nextest_tries} --unit --failure-output=immediate-final --changed-since "origin/$TARGET_BRANCH" --junit target/junit-reports/unit-test.xml
+        env:
+          TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
+          SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.ENV_DIEM_S3_AWS_ACCESS_KEY_ID }}
+          SCCACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.ENV_DIEM_S3_AWS_SECRET_ACCESS_KEY }}
+      - name: run jsonrpc integration tests
+        run: |
+          $pre_command && cargo xtest -p jsonrpc-integration-tests --changed-since "origin/$TARGET_BRANCH"
         env:
           TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
           SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.ENV_DIEM_S3_AWS_ACCESS_KEY_ID }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1925,7 +1925,6 @@ dependencies = [
  "executor",
  "executor-types",
  "fail",
- "forge",
  "futures",
  "generate-key",
  "hex",
@@ -4182,6 +4181,21 @@ dependencies = [
  "env_logger 0.7.1",
  "log",
  "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "jsonrpc-integration-tests"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "bcs",
+ "diem-json-rpc-types",
+ "diem-sdk",
+ "diem-workspace-hack",
+ "forge",
+ "hex",
+ "reqwest",
  "serde_json",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ members = [
     "execution/executor-test-helpers",
     "execution/executor-types",
     "json-rpc",
+    "json-rpc/integration-tests",
     "json-rpc/types",
     "json-rpc/types/proto",
     "language/benchmarks",

--- a/json-rpc/Cargo.toml
+++ b/json-rpc/Cargo.toml
@@ -75,12 +75,7 @@ scratchpad = { path = "../storage/scratchpad" }
 move-vm-types = { path = "../language/move-vm/types" }
 diem-transaction-builder = { path = "../sdk/transaction-builder" }
 diem-sdk = { path = "../sdk" }
-forge = { path = "../testsuite/forge" }
 
 [features]
 fuzzing = ["proptest", "diem-client", "diem-mempool/fuzzing", "diemdb/fuzzing", "diem-proptest-helpers", "diem-temppath", "executor", "executor-types", "move-vm-types", "reqwest", "scratchpad", "vm-genesis"]
 failpoints = ["fail/failpoints"]
-
-[[test]]
-name = "jsonrpc-integration-tests"
-harness = false

--- a/json-rpc/integration-tests/Cargo.toml
+++ b/json-rpc/integration-tests/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "jsonrpc-integration-tests"
+version = "0.0.0"
+authors = ["Diem Association <opensource@diem.com>"]
+repository = "https://github.com/diem/diem"
+homepage = "https://diem.com"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0.38"
+bcs = "0.1.2"
+hex = "0.4.3"
+reqwest = { version = "0.11.2", features = ["blocking", "json"], default_features = false }
+serde_json = "1.0.64"
+
+diem-json-rpc-types = { path = "../types" }
+diem-sdk = { path = "../../sdk" }
+forge = { path = "../../testsuite/forge" }
+diem-workspace-hack = { path = "../../common/workspace-hack" }
+
+[[test]]
+name = "jsonrpc-forge"
+harness = false

--- a/json-rpc/integration-tests/src/helper.rs
+++ b/json-rpc/integration-tests/src/helper.rs
@@ -2,12 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{format_err, Result};
-use diem_crypto::hash::CryptoHash;
 use diem_json_rpc_types::response::JsonRpcResponse;
-use diem_sdk::{transaction_builder::Currency, types::LocalAccount};
-use diem_types::{
-    account_address::AccountAddress, account_config::XUS_NAME, chain_id::ChainId,
-    transaction::SignedTransaction,
+use diem_sdk::{
+    crypto::hash::CryptoHash,
+    transaction_builder::Currency,
+    types::{
+        account_address::AccountAddress,
+        account_config::XUS_NAME,
+        chain_id::ChainId,
+        transaction::{SignedTransaction, Transaction},
+        LocalAccount,
+    },
 };
 use forge::PublicUsageContext;
 use serde_json::{json, Value};
@@ -115,9 +120,7 @@ impl JsonRpcTestHelper {
     }
 
     pub fn wait_for_txn(&self, txn: &SignedTransaction) -> Value {
-        let txn_hash = diem_types::transaction::Transaction::UserTransaction(txn.clone())
-            .hash()
-            .to_hex();
+        let txn_hash = Transaction::UserTransaction(txn.clone()).hash().to_hex();
         for _i in 0..60 {
             let resp = self.get_account_transaction(&txn.sender(), txn.sequence_number(), true);
             if let Some(result) = resp.result {
@@ -184,7 +187,7 @@ impl JsonRpcTestHelper {
         &self,
         sender: &mut LocalAccount,
         secondary_signers: &[&mut LocalAccount],
-        payload: diem_types::transaction::TransactionPayload,
+        payload: diem_sdk::types::transaction::TransactionPayload,
     ) -> SignedTransaction {
         let seq_onchain = self
             .get_account_sequence(sender.address())
@@ -192,7 +195,7 @@ impl JsonRpcTestHelper {
         let seq = sender.sequence_number();
         assert_eq!(seq, seq_onchain);
         *sender.sequence_number_mut() += 1;
-        let raw_txn = diem_types::transaction::helpers::create_unsigned_txn(
+        let raw_txn = diem_sdk::types::transaction::helpers::create_unsigned_txn(
             payload,
             sender.address(),
             seq,

--- a/json-rpc/integration-tests/src/lib.rs
+++ b/json-rpc/integration-tests/src/lib.rs
@@ -1,31 +1,29 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use diem_crypto::{hash::CryptoHash, HashValue};
-use diem_json_rpc::views::{
-    AccountTransactionsWithProofView, AccumulatorConsistencyProofView, EventView,
-};
-use diem_sdk::{transaction_builder::Currency, types::AccountKey};
-use diem_transaction_builder::stdlib;
-use diem_types::{
-    access_path::AccessPath,
-    account_address::AccountAddress,
-    account_config::{treasury_compliance_account_address, xus_tag},
-    contract_event::EventWithProof,
-    diem_id_identifier::DiemIdVaspDomainIdentifier,
-    event::EventKey,
-    ledger_info::LedgerInfoWithSignatures,
-    on_chain_config::DIEM_MAX_KNOWN_VERSION,
-    proof::{AccumulatorConsistencyProof, TransactionAccumulatorSummary},
-    transaction::{
-        AccountTransactionsWithProof, ChangeSet, Transaction, TransactionPayload, WriteSetPayload,
+use diem_sdk::{
+    client::views::{AccountTransactionsWithProofView, AccumulatorConsistencyProofView, EventView},
+    crypto::{hash::CryptoHash, HashValue},
+    transaction_builder::{stdlib, Currency},
+    types::{
+        access_path::AccessPath,
+        account_address::AccountAddress,
+        account_config::{treasury_compliance_account_address, xus_tag},
+        contract_event::EventWithProof,
+        diem_id_identifier::DiemIdVaspDomainIdentifier,
+        event::EventKey,
+        ledger_info::LedgerInfoWithSignatures,
+        on_chain_config::DIEM_MAX_KNOWN_VERSION,
+        proof::{AccumulatorConsistencyProof, TransactionAccumulatorSummary},
+        transaction::{
+            AccountTransactionsWithProof, ChangeSet, Transaction, TransactionPayload,
+            WriteSetPayload,
+        },
+        write_set::{WriteOp, WriteSet, WriteSetMut},
+        AccountKey,
     },
-    write_set::{WriteOp, WriteSet, WriteSetMut},
 };
-use forge::{
-    forge_main, AdminContext, AdminTest, ForgeConfig, LocalFactory, Options, PublicUsageContext,
-    PublicUsageTest, Result, Test,
-};
+use forge::{AdminContext, AdminTest, PublicUsageContext, PublicUsageTest, Result, Test};
 use serde_json::json;
 use std::{
     convert::{TryFrom, TryInto},
@@ -36,54 +34,7 @@ use std::{
 mod helper;
 use helper::JsonRpcTestHelper;
 
-fn main() -> Result<()> {
-    let tests = ForgeConfig {
-        public_usage_tests: &[
-            &CurrencyInfo,
-            &BlockMetadata,
-            &OldMetadata,
-            &AccoutNotFound,
-            &UnknownAccountRoleType,
-            &DesignatedDealerPreburns,
-            &ParentVaspAccountRole,
-            &GetAccountByVersion,
-            &ChildVaspAccountRole,
-            &PeerToPeerWithEvents,
-            &PeerToPeerErrorExplination,
-            &ReSubmittingTransactionWontFail,
-            &MempoolValidationError,
-            &ExpiredTransaction,
-            &RotateComplianceKeyEvent,
-            &CreateAccountEvent,
-            &GetTransactionsWithoutEvents,
-            &GetAccountTransactionsWithoutEvents,
-            &GetAccountTransactionsWithProofs,
-            &GetTransactionsWithProofs,
-            &GetTreasuryComplianceAccount,
-            &GetEventsWithProofs,
-            &MultiAgentPaymentOverDualAttestationLimit,
-            &GetAccumulatorConsistencyProof,
-            &NoUnknownEvents,
-        ],
-        admin_tests: &[
-            &PreburnAndBurnEvents,
-            &CancleBurnEvent,
-            &UpdateExchangeRateEvent,
-            &MintAndReceivedMintEvents,
-            &AddAndRemoveVaspDomain,
-            &MultiAgentRotateAuthenticationKeyAdminScript,
-            &MultiAgentRotateAuthenticationKeyAdminScriptFunction,
-            &UpgradeEventAndNewEpoch,
-            &UpgradeDiemVersion,
-        ],
-        network_tests: &[],
-    };
-
-    let options = Options::from_args();
-    forge_main(tests, LocalFactory::from_workspace()?, &options)
-}
-
-struct CurrencyInfo;
+pub struct CurrencyInfo;
 
 impl Test for CurrencyInfo {
     fn name(&self) -> &'static str {
@@ -127,7 +78,7 @@ impl PublicUsageTest for CurrencyInfo {
     }
 }
 
-struct BlockMetadata;
+pub struct BlockMetadata;
 
 impl Test for BlockMetadata {
     fn name(&self) -> &'static str {
@@ -201,7 +152,7 @@ impl PublicUsageTest for BlockMetadata {
 }
 
 /// Get Metadata with older version parameter should not return version information
-struct OldMetadata;
+pub struct OldMetadata;
 
 impl Test for OldMetadata {
     fn name(&self) -> &'static str {
@@ -226,7 +177,7 @@ impl PublicUsageTest for OldMetadata {
     }
 }
 
-struct AccoutNotFound;
+pub struct AccoutNotFound;
 
 impl Test for AccoutNotFound {
     fn name(&self) -> &'static str {
@@ -243,7 +194,7 @@ impl PublicUsageTest for AccoutNotFound {
     }
 }
 
-struct UnknownAccountRoleType;
+pub struct UnknownAccountRoleType;
 
 impl Test for UnknownAccountRoleType {
     fn name(&self) -> &'static str {
@@ -254,7 +205,7 @@ impl Test for UnknownAccountRoleType {
 impl PublicUsageTest for UnknownAccountRoleType {
     fn run<'t>(&self, ctx: &mut PublicUsageContext<'t>) -> Result<()> {
         let env = JsonRpcTestHelper::new(ctx.url().to_owned());
-        let address = format!("{:x}", diem_types::account_config::diem_root_address());
+        let address = format!("{:x}", diem_sdk::types::account_config::diem_root_address());
         let resp = env.send("get_account", json!([address]));
         let mut result = resp.result.unwrap();
         // as we generate account auth key, ignore it in assertion
@@ -281,7 +232,7 @@ impl PublicUsageTest for UnknownAccountRoleType {
     }
 }
 
-struct DesignatedDealerPreburns;
+pub struct DesignatedDealerPreburns;
 
 impl Test for DesignatedDealerPreburns {
     fn name(&self) -> &'static str {
@@ -431,7 +382,7 @@ impl PublicUsageTest for DesignatedDealerPreburns {
     }
 }
 
-struct ParentVaspAccountRole;
+pub struct ParentVaspAccountRole;
 
 impl Test for ParentVaspAccountRole {
     fn name(&self) -> &'static str {
@@ -481,7 +432,7 @@ impl PublicUsageTest for ParentVaspAccountRole {
     }
 }
 
-struct GetAccountByVersion;
+pub struct GetAccountByVersion;
 
 impl Test for GetAccountByVersion {
     fn name(&self) -> &'static str {
@@ -540,7 +491,7 @@ impl PublicUsageTest for GetAccountByVersion {
     }
 }
 
-struct ChildVaspAccountRole;
+pub struct ChildVaspAccountRole;
 
 impl Test for ChildVaspAccountRole {
     fn name(&self) -> &'static str {
@@ -588,7 +539,7 @@ impl PublicUsageTest for ChildVaspAccountRole {
     }
 }
 
-struct PeerToPeerWithEvents;
+pub struct PeerToPeerWithEvents;
 
 impl Test for PeerToPeerWithEvents {
     fn name(&self) -> &'static str {
@@ -638,7 +589,7 @@ impl PublicUsageTest for PeerToPeerWithEvents {
             TransactionPayload::Script(s) => s,
             _ => unreachable!(),
         };
-        let script_hash = diem_crypto::HashValue::sha3_256_of(script.code()).to_hex();
+        let script_hash = HashValue::sha3_256_of(script.code()).to_hex();
         let script_bytes = hex::encode(bcs::to_bytes(script).unwrap());
 
         assert_eq!(
@@ -721,7 +672,7 @@ impl PublicUsageTest for PeerToPeerWithEvents {
     }
 }
 
-struct PeerToPeerErrorExplination;
+pub struct PeerToPeerErrorExplination;
 
 impl Test for PeerToPeerErrorExplination {
     fn name(&self) -> &'static str {
@@ -772,7 +723,7 @@ impl PublicUsageTest for PeerToPeerErrorExplination {
     }
 }
 
-struct ReSubmittingTransactionWontFail;
+pub struct ReSubmittingTransactionWontFail;
 
 impl Test for ReSubmittingTransactionWontFail {
     fn name(&self) -> &'static str {
@@ -800,7 +751,7 @@ impl PublicUsageTest for ReSubmittingTransactionWontFail {
     }
 }
 
-struct MempoolValidationError;
+pub struct MempoolValidationError;
 
 impl Test for MempoolValidationError {
     fn name(&self) -> &'static str {
@@ -843,7 +794,7 @@ impl PublicUsageTest for MempoolValidationError {
     }
 }
 
-struct ExpiredTransaction;
+pub struct ExpiredTransaction;
 
 impl Test for ExpiredTransaction {
     fn name(&self) -> &'static str {
@@ -876,7 +827,7 @@ impl PublicUsageTest for ExpiredTransaction {
     }
 }
 
-struct PreburnAndBurnEvents;
+pub struct PreburnAndBurnEvents;
 
 impl Test for PreburnAndBurnEvents {
     fn name(&self) -> &'static str {
@@ -994,7 +945,7 @@ impl AdminTest for PreburnAndBurnEvents {
     }
 }
 
-struct CancleBurnEvent;
+pub struct CancleBurnEvent;
 
 impl Test for CancleBurnEvent {
     fn name(&self) -> &'static str {
@@ -1077,7 +1028,7 @@ impl AdminTest for CancleBurnEvent {
     }
 }
 
-struct UpdateExchangeRateEvent;
+pub struct UpdateExchangeRateEvent;
 
 impl Test for UpdateExchangeRateEvent {
     fn name(&self) -> &'static str {
@@ -1142,7 +1093,7 @@ impl AdminTest for UpdateExchangeRateEvent {
     }
 }
 
-struct MintAndReceivedMintEvents;
+pub struct MintAndReceivedMintEvents;
 
 impl Test for MintAndReceivedMintEvents {
     fn name(&self) -> &'static str {
@@ -1228,7 +1179,7 @@ impl AdminTest for MintAndReceivedMintEvents {
     }
 }
 
-struct RotateComplianceKeyEvent;
+pub struct RotateComplianceKeyEvent;
 
 impl Test for RotateComplianceKeyEvent {
     fn name(&self) -> &'static str {
@@ -1286,7 +1237,7 @@ impl PublicUsageTest for RotateComplianceKeyEvent {
     }
 }
 
-struct CreateAccountEvent;
+pub struct CreateAccountEvent;
 
 impl Test for CreateAccountEvent {
     fn name(&self) -> &'static str {
@@ -1333,7 +1284,7 @@ impl PublicUsageTest for CreateAccountEvent {
     }
 }
 
-struct GetTransactionsWithoutEvents;
+pub struct GetTransactionsWithoutEvents;
 
 impl Test for GetTransactionsWithoutEvents {
     fn name(&self) -> &'static str {
@@ -1356,7 +1307,7 @@ impl PublicUsageTest for GetTransactionsWithoutEvents {
     }
 }
 
-struct GetAccountTransactionsWithoutEvents;
+pub struct GetAccountTransactionsWithoutEvents;
 
 impl Test for GetAccountTransactionsWithoutEvents {
     fn name(&self) -> &'static str {
@@ -1384,7 +1335,7 @@ impl PublicUsageTest for GetAccountTransactionsWithoutEvents {
     }
 }
 
-struct GetAccountTransactionsWithProofs;
+pub struct GetAccountTransactionsWithProofs;
 
 impl Test for GetAccountTransactionsWithProofs {
     fn name(&self) -> &'static str {
@@ -1408,7 +1359,7 @@ impl PublicUsageTest for GetAccountTransactionsWithProofs {
     }
 }
 
-struct GetTransactionsWithProofs;
+pub struct GetTransactionsWithProofs;
 
 impl Test for GetTransactionsWithProofs {
     fn name(&self) -> &'static str {
@@ -1450,7 +1401,7 @@ impl PublicUsageTest for GetTransactionsWithProofs {
             // we need to get the validator set from the batched get_state_proof call.
             let ledger_info_view = &f.iter().find(|g| g["id"] == 1).unwrap()["result"];
             let ep_cp = ledger_info_view["epoch_change_proof"].as_str().unwrap();
-            let epoch_proofs: diem_types::epoch_change::EpochChangeProof =
+            let epoch_proofs: diem_sdk::types::epoch_change::EpochChangeProof =
                 bcs::from_bytes(&hex::decode(&ep_cp).unwrap()).unwrap();
             let some_li: Vec<_> = epoch_proofs.ledger_info_with_sigs;
             assert!(!some_li.is_empty());
@@ -1468,11 +1419,11 @@ impl PublicUsageTest for GetTransactionsWithProofs {
             let raw_hex_li = proofs["ledger_info_to_transaction_infos_proof"]
                 .as_str()
                 .unwrap();
-            let li_to_tip: diem_types::proof::TransactionAccumulatorRangeProof =
+            let li_to_tip: diem_sdk::types::proof::TransactionAccumulatorRangeProof =
                 bcs::from_bytes(&hex::decode(&raw_hex_li).unwrap()).unwrap();
             // The txs for which we got the proofs
             let raw_hex_txs = proofs["transaction_infos"].as_str().unwrap();
-            let txs_infos: Vec<diem_types::transaction::TransactionInfo> =
+            let txs_infos: Vec<diem_sdk::types::transaction::TransactionInfo> =
                 bcs::from_bytes(&hex::decode(&raw_hex_txs).unwrap()).unwrap();
             let hashes: Vec<_> = txs_infos.iter().map(CryptoHash::hash).collect();
 
@@ -1534,7 +1485,7 @@ impl PublicUsageTest for GetTransactionsWithProofs {
     }
 }
 
-struct AddAndRemoveVaspDomain;
+pub struct AddAndRemoveVaspDomain;
 
 impl Test for AddAndRemoveVaspDomain {
     fn name(&self) -> &'static str {
@@ -1624,7 +1575,7 @@ impl AdminTest for AddAndRemoveVaspDomain {
     }
 }
 
-struct GetTreasuryComplianceAccount;
+pub struct GetTreasuryComplianceAccount;
 
 impl Test for GetTreasuryComplianceAccount {
     fn name(&self) -> &'static str {
@@ -1664,7 +1615,7 @@ impl PublicUsageTest for GetTreasuryComplianceAccount {
     }
 }
 
-struct GetEventsWithProofs;
+pub struct GetEventsWithProofs;
 
 impl Test for GetEventsWithProofs {
     fn name(&self) -> &'static str {
@@ -1699,7 +1650,7 @@ impl PublicUsageTest for GetEventsWithProofs {
         // since we don't have a local state with the set of validators unlike an actual client,
         // we need to get the validator set from the batched get_state_proof call.
         let ep_cp = ledger_info_view["epoch_change_proof"].as_str().unwrap();
-        let epoch_proofs: diem_types::epoch_change::EpochChangeProof =
+        let epoch_proofs: diem_sdk::types::epoch_change::EpochChangeProof =
             bcs::from_bytes(&hex::decode(&ep_cp).unwrap()).unwrap();
         let some_li: Vec<_> = epoch_proofs.ledger_info_with_sigs;
         assert!(!some_li.is_empty());
@@ -1747,7 +1698,7 @@ impl PublicUsageTest for GetEventsWithProofs {
     }
 }
 
-struct MultiAgentPaymentOverDualAttestationLimit;
+pub struct MultiAgentPaymentOverDualAttestationLimit;
 
 impl Test for MultiAgentPaymentOverDualAttestationLimit {
     fn name(&self) -> &'static str {
@@ -1773,11 +1724,7 @@ impl PublicUsageTest for MultiAgentPaymentOverDualAttestationLimit {
         let receiver_balance = env.get_balance(receiver.address(), "XUS");
 
         let script =
-            diem_transaction_builder::stdlib::encode_peer_to_peer_by_signers_script_function(
-                xus_tag(),
-                amount,
-                vec![],
-            );
+            stdlib::encode_peer_to_peer_by_signers_script_function(xus_tag(), amount, vec![]);
         let txn = env.create_multi_agent_txn(&mut sender, &[&mut receiver], script);
 
         let txn_view = env.submit_and_wait(&txn);
@@ -1811,7 +1758,7 @@ impl PublicUsageTest for MultiAgentPaymentOverDualAttestationLimit {
     }
 }
 
-struct MultiAgentRotateAuthenticationKeyAdminScriptFunction;
+pub struct MultiAgentRotateAuthenticationKeyAdminScriptFunction;
 
 impl Test for MultiAgentRotateAuthenticationKeyAdminScriptFunction {
     fn name(&self) -> &'static str {
@@ -1843,7 +1790,7 @@ impl AdminTest for MultiAgentRotateAuthenticationKeyAdminScriptFunction {
             TransactionPayload::ScriptFunction(s) => s,
             _ => unreachable!(),
         };
-        let script_hash = diem_crypto::HashValue::zero().to_hex();
+        let script_hash = HashValue::zero().to_hex();
         let script_bytes = hex::encode(bcs::to_bytes(script).unwrap());
         assert_eq!(result["vm_status"], json!({"type": "executed"}));
         assert_eq!(
@@ -1881,7 +1828,7 @@ impl AdminTest for MultiAgentRotateAuthenticationKeyAdminScriptFunction {
     }
 }
 
-struct MultiAgentRotateAuthenticationKeyAdminScript;
+pub struct MultiAgentRotateAuthenticationKeyAdminScript;
 
 impl Test for MultiAgentRotateAuthenticationKeyAdminScript {
     fn name(&self) -> &'static str {
@@ -1915,7 +1862,7 @@ impl AdminTest for MultiAgentRotateAuthenticationKeyAdminScript {
             TransactionPayload::Script(s) => s,
             _ => unreachable!(),
         };
-        let script_hash = diem_crypto::HashValue::sha3_256_of(script.code()).to_hex();
+        let script_hash = HashValue::sha3_256_of(script.code()).to_hex();
         let script_bytes = hex::encode(bcs::to_bytes(script).unwrap());
         assert_eq!(result["vm_status"], json!({"type": "executed"}));
         assert_eq!(
@@ -1954,7 +1901,7 @@ impl AdminTest for MultiAgentRotateAuthenticationKeyAdminScript {
     }
 }
 
-struct GetAccumulatorConsistencyProof;
+pub struct GetAccumulatorConsistencyProof;
 
 impl Test for GetAccumulatorConsistencyProof {
     fn name(&self) -> &'static str {
@@ -1997,7 +1944,7 @@ impl PublicUsageTest for GetAccumulatorConsistencyProof {
     }
 }
 
-struct NoUnknownEvents;
+pub struct NoUnknownEvents;
 
 impl Test for NoUnknownEvents {
     fn name(&self) -> &'static str {
@@ -2020,7 +1967,7 @@ impl PublicUsageTest for NoUnknownEvents {
     }
 }
 
-struct UpgradeEventAndNewEpoch;
+pub struct UpgradeEventAndNewEpoch;
 
 impl Test for UpgradeEventAndNewEpoch {
     fn name(&self) -> &'static str {
@@ -2091,7 +2038,7 @@ fn create_common_write_set() -> WriteSet {
     .unwrap()
 }
 
-struct UpgradeDiemVersion;
+pub struct UpgradeDiemVersion;
 
 impl Test for UpgradeDiemVersion {
     fn name(&self) -> &'static str {

--- a/json-rpc/integration-tests/tests/jsonrpc-forge.rs
+++ b/json-rpc/integration-tests/tests/jsonrpc-forge.rs
@@ -1,0 +1,52 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use forge::{forge_main, ForgeConfig, LocalFactory, Options, Result};
+use jsonrpc_integration_tests::*;
+
+fn main() -> Result<()> {
+    let tests = ForgeConfig {
+        public_usage_tests: &[
+            &CurrencyInfo,
+            &BlockMetadata,
+            &OldMetadata,
+            &AccoutNotFound,
+            &UnknownAccountRoleType,
+            &DesignatedDealerPreburns,
+            &ParentVaspAccountRole,
+            &GetAccountByVersion,
+            &ChildVaspAccountRole,
+            &PeerToPeerWithEvents,
+            &PeerToPeerErrorExplination,
+            &ReSubmittingTransactionWontFail,
+            &MempoolValidationError,
+            &ExpiredTransaction,
+            &RotateComplianceKeyEvent,
+            &CreateAccountEvent,
+            &GetTransactionsWithoutEvents,
+            &GetAccountTransactionsWithoutEvents,
+            &GetAccountTransactionsWithProofs,
+            &GetTransactionsWithProofs,
+            &GetTreasuryComplianceAccount,
+            &GetEventsWithProofs,
+            &MultiAgentPaymentOverDualAttestationLimit,
+            &GetAccumulatorConsistencyProof,
+            &NoUnknownEvents,
+        ],
+        admin_tests: &[
+            &PreburnAndBurnEvents,
+            &CancleBurnEvent,
+            &UpdateExchangeRateEvent,
+            &MintAndReceivedMintEvents,
+            &AddAndRemoveVaspDomain,
+            &MultiAgentRotateAuthenticationKeyAdminScript,
+            &MultiAgentRotateAuthenticationKeyAdminScriptFunction,
+            &UpgradeEventAndNewEpoch,
+            &UpgradeDiemVersion,
+        ],
+        network_tests: &[],
+    };
+
+    let options = Options::from_args();
+    forge_main(tests, LocalFactory::from_workspace()?, &options)
+}

--- a/x.toml
+++ b/x.toml
@@ -3,6 +3,7 @@ version = "0.8.0"
 
 [system-tests]
 smoke-test = { path = "smoke-test" }
+jsonrpc-integration-tests = { path = "json-rpc/integration-tests" }
 
 [cargo.sccache]
 bucket = "ci-artifacts.diem.com"
@@ -196,6 +197,7 @@ members = [
     "generate-format",
     "invalid-mutations",
     "ir-testsuite",
+    "jsonrpc-integration-tests",
     "jsonrpc-types-proto",
     "language-benchmarks",
     "language-e2e-tests",


### PR DESCRIPTION
Recently the jsonrpc integration tests were migrated to forge, this meant that each individual test was actually broken into its own independent test (whereas before they were all run together). This causes nextest to run too many resource intensive tests together (all of which spawn their own local cluster). This PR fixes that by:
* Separating out these tests into their own crate
* Marks that crate as a "system-test" such that they are excluded from nextest's run
* Adds a separate ci step where these tests are run together in the same process (via cargo xtest)