### PR TITLE
[forge] Add livessness check for Forge node json-rpc endpoint

### DIFF
--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{ChainInfo, FullNode, HealthCheckError, LocalNode, Node, Swarm, Validator};
+use crate::{ChainInfo, FullNode, HealthCheckError, LocalNode, Node, NodeExt, Swarm, Validator};
 use anyhow::{anyhow, Result};
 use diem_config::config::NodeConfig;
 use diem_genesis_tool::validator_builder::ValidatorBuilder;
@@ -9,6 +9,7 @@ use diem_sdk::{
     crypto::ed25519::Ed25519PrivateKey,
     types::{chain_id::ChainId, AccountKey, LocalAccount, PeerId},
 };
+use itertools::Itertools;
 use std::{
     collections::HashMap,
     convert::TryFrom,
@@ -192,6 +193,7 @@ impl LocalSwarm {
         // Wait for all of them to startup
         self.wait_for_startup()?;
         self.wait_for_connectivity()?;
+        self.liveness_check()?;
 
         Ok(())
     }
@@ -254,6 +256,28 @@ impl LocalSwarm {
         }
 
         Err(anyhow!("Waiting for connectivity timed out"))
+    }
+
+    fn liveness_check(&self) -> Result<()> {
+        let num_attempts = 60;
+        for i in 0..num_attempts {
+            println!("Wait for liveness check attempt: {}", i);
+
+            if self
+                .validators
+                .values()
+                .map(|node| node.liveness_check(10))
+                .collect_vec()
+                .into_iter()
+                .all(|b| matches!(b, Ok(..)))
+            {
+                return Ok(());
+            }
+
+            ::std::thread::sleep(::std::time::Duration::from_millis(1000));
+        }
+
+        Err(anyhow!("Liveness check timed out"))
     }
 }
 


### PR DESCRIPTION
Add livessness check for Forge node json-rpc endpoint availability

for multi-nodes, json-rpc endpoints need time to get available otherwise test will failed if we start testing directly
```
running 5 tests
Wait for startup attempt: 0 of 10
Wait for startup attempt: 1 of 10
Wait for connectivity attempt: 0
Wait for connectivity attempt: 1
Wait for connectivity attempt: 2
Wait for connectivity attempt: 3
Wait for connectivity attempt: 4
Wait for connectivity attempt: 5
Wait for connectivity attempt: 6
test fund_account ... FAILED
Error: Timeout
test transfer_coins ... ok
test get_metadata ... ok

``` 

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

with 5 nodes in local swarm
run `./script/fgi --local-swarm`

```
running 5 tests
Wait for startup attempt: 0 of 10
Wait for startup attempt: 1 of 10
Wait for connectivity attempt: 0
Wait for connectivity attempt: 1
Wait for connectivity attempt: 2
Wait for connectivity attempt: 3
Wait for connectivity attempt: 4
Wait for connectivity attempt: 5
Wait for connectivity attempt: 6
Wait for liveness attempt: 0
Wait for liveness attempt: 1
test fund_account ... ok
test transfer_coins ... ok
test get_metadata ... ok
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update or suggest changes to the docs at https://developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
