### PR TITLE
[move] Hello world mutation testing

### DIFF
--- a/language/move-prover/bytecode/src/lib.rs
+++ b/language/move-prover/bytecode/src/lib.rs
@@ -28,6 +28,7 @@ pub mod loop_analysis;
 pub mod memory_instrumentation;
 pub mod mono_analysis;
 pub mod mut_ref_instrumentation;
+pub mod mutation_tester;
 pub mod options;
 pub mod packed_types_analysis;
 pub mod pipeline_factory;

--- a/language/move-prover/bytecode/src/mutation_tester.rs
+++ b/language/move-prover/bytecode/src/mutation_tester.rs
@@ -12,16 +12,20 @@ use crate::{
     function_data_builder::FunctionDataBuilder,
     function_target::FunctionData,
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
-    stackless_bytecode::{Bytecode, Operation},
     options::ProverOptions,
+    stackless_bytecode::{Bytecode, Operation},
 };
 
-use move_model::{exp_generator::ExpGenerator, model::FunctionEnv, model::GlobalEnv};
+use move_model::{
+    exp_generator::ExpGenerator,
+    model::{FunctionEnv, GlobalEnv},
+};
 
 pub struct MutationTester {}
 
-struct MutationCounter {
-    value : usize
+pub struct MutationManager {
+    pub mutated: bool,
+    add_sub: usize,
 }
 
 impl MutationTester {
@@ -33,7 +37,10 @@ impl MutationTester {
 impl FunctionTargetProcessor for MutationTester {
     fn initialize(&self, global_env: &GlobalEnv, _targets: &mut FunctionTargetsHolder) {
         let options = ProverOptions::get(global_env);
-        global_env.set_extension(MutationCounter{value : options.mutas});
+        global_env.set_extension(MutationManager {
+            mutated: false,
+            add_sub: options.mutation_add_sub,
+        });
     }
 
     fn process(
@@ -52,26 +59,38 @@ impl FunctionTargetProcessor for MutationTester {
         let mut builder = FunctionDataBuilder::new(fun_env, data);
         let code = std::mem::take(&mut builder.data.code);
 
-        // Emit trace instructions for parameters at entry.
         builder.set_loc(builder.fun_env.get_loc().at_start());
+        let global_env = fun_env.module_env.env;
+        let m = global_env.get_extension::<MutationManager>().unwrap();
 
         for bc in code {
-            match &bc {
-                Call(attrid, indices, Operation::Add, tempindices, ab) => {
-                    let global_env = fun_env.module_env.env;
-                    let mc = global_env.get_extension::<MutationCounter>().unwrap().value;
-                    if mc == 1 {
-                        builder.emit(Call((*attrid).clone(), (*indices).clone(),
-                            Operation::Sub, (*tempindices).clone(), (*ab).clone()));
+            match bc {
+                Call(ref attrid, ref indices, Operation::Add, ref srcs, ref dests) => {
+                    let mv = m.add_sub;
+                    if mv == 1 {
+                        builder.emit(Call(
+                            *attrid,
+                            (*indices).clone(),
+                            Operation::Sub,
+                            (*srcs).clone(),
+                            (*dests).clone(),
+                        ));
+                        global_env.set_extension(MutationManager {
+                            mutated: true,
+                            add_sub: mv - 1,
+                        });
                     } else {
-                        builder.emit(bc.clone());
+                        builder.emit(bc);
                     }
-                    if mc > 0 {
-                        global_env.set_extension(MutationCounter{value : mc-1});
+                    if mv > 0 {
+                        global_env.set_extension(MutationManager {
+                            add_sub: mv - 1,
+                            mutated: m.mutated,
+                        });
                     }
                 }
                 _ => {
-                    builder.emit(bc.clone());
+                    builder.emit(bc);
                 }
             }
         }

--- a/language/move-prover/bytecode/src/mutation_tester.rs
+++ b/language/move-prover/bytecode/src/mutation_tester.rs
@@ -1,0 +1,85 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Transformation which mutates code for mutation testing in various ways
+//!
+//! This transformation should run after code is translated to bytecode, but before any
+//!  other bytecode modification
+//! It emits instructions in bytecode format, but with changes made
+//! Note that this mutation does nothing if mutation flags are not enabled
+
+use crate::{
+    function_data_builder::FunctionDataBuilder,
+    function_target::FunctionData,
+    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
+    stackless_bytecode::{Bytecode, Operation},
+    options::ProverOptions,
+};
+
+use move_model::{exp_generator::ExpGenerator, model::FunctionEnv, model::GlobalEnv};
+
+pub struct MutationTester {}
+
+struct MutationCounter {
+    value : usize
+}
+
+impl MutationTester {
+    pub fn new() -> Box<Self> {
+        Box::new(Self {})
+    }
+}
+
+impl FunctionTargetProcessor for MutationTester {
+    fn initialize(&self, global_env: &GlobalEnv, _targets: &mut FunctionTargetsHolder) {
+        let options = ProverOptions::get(global_env);
+        global_env.set_extension(MutationCounter{value : options.mutas});
+    }
+
+    fn process(
+        &self,
+        _targets: &mut FunctionTargetsHolder,
+        fun_env: &FunctionEnv<'_>,
+        data: FunctionData,
+    ) -> FunctionData {
+        use Bytecode::*;
+
+        if fun_env.is_native() {
+            // Nothing to do
+            return data;
+        }
+
+        let mut builder = FunctionDataBuilder::new(fun_env, data);
+        let code = std::mem::take(&mut builder.data.code);
+
+        // Emit trace instructions for parameters at entry.
+        builder.set_loc(builder.fun_env.get_loc().at_start());
+
+        for bc in code {
+            match &bc {
+                Call(attrid, indices, Operation::Add, tempindices, ab) => {
+                    let global_env = fun_env.module_env.env;
+                    let mc = global_env.get_extension::<MutationCounter>().unwrap().value;
+                    if mc == 1 {
+                        builder.emit(Call((*attrid).clone(), (*indices).clone(),
+                            Operation::Sub, (*tempindices).clone(), (*ab).clone()));
+                    } else {
+                        builder.emit(bc.clone());
+                    }
+                    if mc > 0 {
+                        global_env.set_extension(MutationCounter{value : mc-1});
+                    }
+                }
+                _ => {
+                    builder.emit(bc.clone());
+                }
+            }
+        }
+
+        builder.data
+    }
+
+    fn name(&self) -> String {
+        "mutation_tester".to_string()
+    }
+}

--- a/language/move-prover/bytecode/src/options.rs
+++ b/language/move-prover/bytecode/src/options.rs
@@ -52,7 +52,7 @@ pub struct ProverOptions {
     /// Indicates that we should do any mutations
     pub mutation: bool,
     /// Indicates that we should use the add-subtract mutation on the given block
-    pub mutas: usize,
+    pub mutation_add_sub: usize,
     /// Whether to assume a global invariant when the related memory
     /// is accessed, instead of on function entry. This is currently known to be slower
     /// if one than off, so off by default.
@@ -95,7 +95,7 @@ impl Default for ProverOptions {
             resource_wellformed_axiom: false,
             assume_wellformed_on_access: false,
             mutation: false,
-            mutas: 0,
+            mutation_add_sub: 0,
             deep_pack_unpack: false,
             auto_trace_level: AutoTraceLevel::Off,
             report_severity: Severity::Warning,

--- a/language/move-prover/bytecode/src/options.rs
+++ b/language/move-prover/bytecode/src/options.rs
@@ -49,6 +49,10 @@ pub struct ProverOptions {
     /// Whether to assume wellformedness when elements are read from memory, instead of on
     /// function entry.
     pub assume_wellformed_on_access: bool,
+    /// Indicates that we should do any mutations
+    pub mutation: bool,
+    /// Indicates that we should use the add-subtract mutation on the given block
+    pub mutas: usize,
     /// Whether to assume a global invariant when the related memory
     /// is accessed, instead of on function entry. This is currently known to be slower
     /// if one than off, so off by default.
@@ -90,6 +94,8 @@ impl Default for ProverOptions {
             verify_scope: VerificationScope::All,
             resource_wellformed_axiom: false,
             assume_wellformed_on_access: false,
+            mutation: false,
+            mutas: 0,
             deep_pack_unpack: false,
             auto_trace_level: AutoTraceLevel::Off,
             report_severity: Severity::Warning,

--- a/language/move-prover/bytecode/src/pipeline_factory.rs
+++ b/language/move-prover/bytecode/src/pipeline_factory.rs
@@ -15,6 +15,7 @@ use crate::{
     memory_instrumentation::MemoryInstrumentationProcessor,
     mono_analysis::MonoAnalysisProcessor,
     mut_ref_instrumentation::MutRefInstrumenter,
+    mutation_tester::MutationTester,
     options::ProverOptions,
     reaching_def_analysis::ReachingDefProcessor,
     spec_instrumentation::SpecInstrumentationProcessor,
@@ -51,6 +52,9 @@ pub fn default_pipeline_with_options(options: &ProverOptions) -> FunctionTargetP
             GlobalInvariantInstrumentationProcessor::new()
         },
     ];
+    if options.mutation {
+        processors.insert(0, MutationTester::new()); // pass which may do nothing
+    }
     if options.run_mono {
         processors.push(MonoAnalysisProcessor::new());
     }

--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -512,10 +512,8 @@ impl Options {
             options.prover.mutation = true;
         }
         if matches.is_present("mutas") {
-            options.prover.mutas = matches
-                .value_of("mutas")
-                .unwrap()
-                .parse::<usize>()?;
+            options.prover.mutation_add_sub =
+                matches.value_of("mutas").unwrap().parse::<usize>()?;
         }
         if matches.is_present("verify") {
             options.prover.verify_scope = match matches.value_of("verify").unwrap() {

--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -299,6 +299,24 @@ impl Options {
                     ),
             )
             .arg(
+                Arg::with_name("mutation")
+                    .long("mutation")
+                    .help(
+                        "Specifies to use the mutation pass",
+                    ),
+            )
+            .arg(
+                Arg::with_name("mutas")
+                    .long("mutas")
+                    .takes_value(true)
+                    .value_name("COUNT")
+                    .validator(is_number)
+                    .help(
+                        "indicates that this program should mutate the indicated plus operation to a minus\
+                        specifically by modifyig the \"nth\" such operation",
+                    ),
+            )
+            .arg(
                 Arg::with_name("dependencies")
                     .long("dependency")
                     .short("d")
@@ -489,6 +507,15 @@ impl Options {
         }
         if matches.occurrences_of("dependencies") > 0 {
             options.move_deps = get_vec("dependencies");
+        }
+        if matches.is_present("mutation") {
+            options.prover.mutation = true;
+        }
+        if matches.is_present("mutas") {
+            options.prover.mutas = matches
+                .value_of("mutas")
+                .unwrap()
+                .parse::<usize>()?;
         }
         if matches.is_present("verify") {
             options.prover.verify_scope = match matches.value_of("verify").unwrap() {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Creates the boilerplate for mutation testing, allowing the user to introduce a single mutation of operation (addition to subtraction), as a proof-of-concept.  This PR _does not_ attempt to change the testing framework directly, leaving that work for a separate PR, since I both want to separate the work here to avoid delaying this PR and to get feedback on this direction before delving into using the check-inconsistency flag as a reference.  Instead, this PR just introduces a pass (which may be a no-op) to the bytecode compiler.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Testing is done manually for this commit, though I'm open to trying to introduce negative testing (since the mutations being done ought to lead to errors).
