### PR TITLE
[move] Extract bytecode-verifier test helper

### DIFF
--- a/language/bytecode-verifier/bytecode-verifier-tests/src/lib.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/lib.rs
@@ -4,4 +4,7 @@
 #![forbid(unsafe_code)]
 
 #[cfg(test)]
+pub mod support;
+
+#[cfg(test)]
 pub mod unit_tests;

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/support/mod.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/support/mod.rs
@@ -1,0 +1,35 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use move_binary_format::{
+    file_format::{
+        empty_module, Bytecode, CodeUnit, FunctionDefinition, FunctionHandle, IdentifierIndex,
+        ModuleHandleIndex, SignatureIndex,
+    },
+    CompiledModule,
+};
+
+/// Create a dummy module to wrap the bytecode program in local@code
+pub fn dummy_procedure_module(code: Vec<Bytecode>) -> CompiledModule {
+    let mut module = empty_module();
+    let code_unit = CodeUnit {
+        code,
+        ..Default::default()
+    };
+    let fun_def = FunctionDefinition {
+        code: Some(code_unit),
+        ..Default::default()
+    };
+
+    let fun_handle = FunctionHandle {
+        module: ModuleHandleIndex(0),
+        name: IdentifierIndex(0),
+        parameters: SignatureIndex(0),
+        return_: SignatureIndex(0),
+        type_parameters: vec![],
+    };
+
+    module.function_handles.push(fun_handle);
+    module.function_defs.push(fun_def);
+    module.freeze().unwrap()
+}

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/code_unit_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/code_unit_tests.rs
@@ -1,13 +1,14 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::support::dummy_procedure_module;
 use bytecode_verifier::CodeUnitVerifier;
-use move_binary_format::file_format::{self, Bytecode};
+use move_binary_format::file_format::Bytecode;
 use move_core_types::vm_status::StatusCode;
 
 #[test]
 fn invalid_fallthrough_br_true() {
-    let module = file_format::dummy_procedure_module(vec![Bytecode::LdFalse, Bytecode::BrTrue(1)]);
+    let module = dummy_procedure_module(vec![Bytecode::LdFalse, Bytecode::BrTrue(1)]);
     let result = CodeUnitVerifier::verify_module(&module);
     assert_eq!(
         result.unwrap_err().major_status(),
@@ -17,7 +18,7 @@ fn invalid_fallthrough_br_true() {
 
 #[test]
 fn invalid_fallthrough_br_false() {
-    let module = file_format::dummy_procedure_module(vec![Bytecode::LdTrue, Bytecode::BrFalse(1)]);
+    let module = dummy_procedure_module(vec![Bytecode::LdTrue, Bytecode::BrFalse(1)]);
     let result = CodeUnitVerifier::verify_module(&module);
     assert_eq!(
         result.unwrap_err().major_status(),
@@ -28,7 +29,7 @@ fn invalid_fallthrough_br_false() {
 // all non-branch instructions should trigger invalid fallthrough; just check one of them
 #[test]
 fn invalid_fallthrough_non_branch() {
-    let module = file_format::dummy_procedure_module(vec![Bytecode::LdTrue, Bytecode::Pop]);
+    let module = dummy_procedure_module(vec![Bytecode::LdTrue, Bytecode::Pop]);
     let result = CodeUnitVerifier::verify_module(&module);
     assert_eq!(
         result.unwrap_err().major_status(),
@@ -38,21 +39,21 @@ fn invalid_fallthrough_non_branch() {
 
 #[test]
 fn valid_fallthrough_branch() {
-    let module = file_format::dummy_procedure_module(vec![Bytecode::Branch(0)]);
+    let module = dummy_procedure_module(vec![Bytecode::Branch(0)]);
     let result = CodeUnitVerifier::verify_module(&module);
     assert!(result.is_ok());
 }
 
 #[test]
 fn valid_fallthrough_ret() {
-    let module = file_format::dummy_procedure_module(vec![Bytecode::Ret]);
+    let module = dummy_procedure_module(vec![Bytecode::Ret]);
     let result = CodeUnitVerifier::verify_module(&module);
     assert!(result.is_ok());
 }
 
 #[test]
 fn valid_fallthrough_abort() {
-    let module = file_format::dummy_procedure_module(vec![Bytecode::LdU64(7), Bytecode::Abort]);
+    let module = dummy_procedure_module(vec![Bytecode::LdU64(7), Bytecode::Abort]);
     let result = CodeUnitVerifier::verify_module(&module);
     assert!(result.is_ok());
 }

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/control_flow_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/control_flow_tests.rs
@@ -1,11 +1,12 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::support::dummy_procedure_module;
 use bytecode_verifier::control_flow;
 use move_binary_format::{
     access::ModuleAccess,
     errors::PartialVMResult,
-    file_format::{self, Bytecode, CompiledModule, FunctionDefinitionIndex, TableIndex},
+    file_format::{Bytecode, CompiledModule, FunctionDefinitionIndex, TableIndex},
 };
 use move_core_types::vm_status::StatusCode;
 
@@ -33,7 +34,7 @@ fn verify_module(module: &CompiledModule) -> PartialVMResult<()> {
 
 #[test]
 fn invalid_fallthrough_br_true() {
-    let module = file_format::dummy_procedure_module(vec![Bytecode::LdFalse, Bytecode::BrTrue(1)]);
+    let module = dummy_procedure_module(vec![Bytecode::LdFalse, Bytecode::BrTrue(1)]);
     let result = verify_module(&module);
     assert_eq!(
         result.unwrap_err().major_status(),
@@ -43,7 +44,7 @@ fn invalid_fallthrough_br_true() {
 
 #[test]
 fn invalid_fallthrough_br_false() {
-    let module = file_format::dummy_procedure_module(vec![Bytecode::LdTrue, Bytecode::BrFalse(1)]);
+    let module = dummy_procedure_module(vec![Bytecode::LdTrue, Bytecode::BrFalse(1)]);
     let result = verify_module(&module);
     assert_eq!(
         result.unwrap_err().major_status(),
@@ -54,7 +55,7 @@ fn invalid_fallthrough_br_false() {
 // all non-branch instructions should trigger invalid fallthrough; just check one of them
 #[test]
 fn invalid_fallthrough_non_branch() {
-    let module = file_format::dummy_procedure_module(vec![Bytecode::LdTrue, Bytecode::Pop]);
+    let module = dummy_procedure_module(vec![Bytecode::LdTrue, Bytecode::Pop]);
     let result = verify_module(&module);
     assert_eq!(
         result.unwrap_err().major_status(),
@@ -64,21 +65,21 @@ fn invalid_fallthrough_non_branch() {
 
 #[test]
 fn valid_fallthrough_branch() {
-    let module = file_format::dummy_procedure_module(vec![Bytecode::Branch(0)]);
+    let module = dummy_procedure_module(vec![Bytecode::Branch(0)]);
     let result = verify_module(&module);
     assert!(result.is_ok());
 }
 
 #[test]
 fn valid_fallthrough_ret() {
-    let module = file_format::dummy_procedure_module(vec![Bytecode::Ret]);
+    let module = dummy_procedure_module(vec![Bytecode::Ret]);
     let result = verify_module(&module);
     assert!(result.is_ok());
 }
 
 #[test]
 fn valid_fallthrough_abort() {
-    let module = file_format::dummy_procedure_module(vec![Bytecode::LdU64(7), Bytecode::Abort]);
+    let module = dummy_procedure_module(vec![Bytecode::LdU64(7), Bytecode::Abort]);
     let result = verify_module(&module);
     assert!(result.is_ok());
 }

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/negative_stack_size_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/negative_stack_size_tests.rs
@@ -1,13 +1,14 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::support::dummy_procedure_module;
 use bytecode_verifier::CodeUnitVerifier;
-use move_binary_format::file_format::{self, Bytecode};
+use move_binary_format::file_format::Bytecode;
 use move_core_types::vm_status::StatusCode;
 
 #[test]
 fn one_pop_no_push() {
-    let module = file_format::dummy_procedure_module(vec![Bytecode::Pop, Bytecode::Ret]);
+    let module = dummy_procedure_module(vec![Bytecode::Pop, Bytecode::Ret]);
     let result = CodeUnitVerifier::verify_module(&module);
     assert_eq!(
         result.unwrap_err().major_status(),
@@ -18,7 +19,7 @@ fn one_pop_no_push() {
 #[test]
 fn one_pop_one_push() {
     // Height: 0 + (-1 + 1) = 0 would have passed original usage verifier
-    let module = file_format::dummy_procedure_module(vec![Bytecode::ReadRef, Bytecode::Ret]);
+    let module = dummy_procedure_module(vec![Bytecode::ReadRef, Bytecode::Ret]);
     let result = CodeUnitVerifier::verify_module(&module);
     assert_eq!(
         result.unwrap_err().major_status(),
@@ -29,8 +30,7 @@ fn one_pop_one_push() {
 #[test]
 fn two_pop_one_push() {
     // Height: 0 + 1 + (-2 + 1) = 0 would have passed original usage verifier
-    let module =
-        file_format::dummy_procedure_module(vec![Bytecode::LdU64(0), Bytecode::Add, Bytecode::Ret]);
+    let module = dummy_procedure_module(vec![Bytecode::LdU64(0), Bytecode::Add, Bytecode::Ret]);
     let result = CodeUnitVerifier::verify_module(&module);
     assert_eq!(
         result.unwrap_err().major_status(),
@@ -40,7 +40,7 @@ fn two_pop_one_push() {
 
 #[test]
 fn two_pop_no_push() {
-    let module = file_format::dummy_procedure_module(vec![Bytecode::WriteRef, Bytecode::Ret]);
+    let module = dummy_procedure_module(vec![Bytecode::WriteRef, Bytecode::Ret]);
     let result = CodeUnitVerifier::verify_module(&module);
     assert_eq!(
         result.unwrap_err().major_status(),

--- a/language/move-binary-format/src/file_format.rs
+++ b/language/move-binary-format/src/file_format.rs
@@ -1972,31 +1972,6 @@ pub fn basic_test_module() -> CompiledModule {
     m
 }
 
-/// Create a dummy module to wrap the bytecode program in local@code
-pub fn dummy_procedure_module(code: Vec<Bytecode>) -> CompiledModule {
-    let mut module = empty_module();
-    let code_unit = CodeUnit {
-        code,
-        ..Default::default()
-    };
-    let fun_def = FunctionDefinition {
-        code: Some(code_unit),
-        ..Default::default()
-    };
-
-    let fun_handle = FunctionHandle {
-        module: ModuleHandleIndex(0),
-        name: IdentifierIndex(0),
-        parameters: SignatureIndex(0),
-        return_: SignatureIndex(0),
-        type_parameters: vec![],
-    };
-
-    module.function_handles.push(fun_handle);
-    module.function_defs.push(fun_def);
-    module.freeze().unwrap()
-}
-
 /// Return a simple script that contains only a return in the main()
 pub fn empty_script() -> CompiledScript {
     CompiledScript {


### PR DESCRIPTION
`dummy_procedure_module` is only used by bytecode-verifier-tests. Place it in a test support module close to its only usages, in order to discourage it from being used elsewhere.