### PR TITLE
[fuzzer] Bake in LSAN suppressions

### DIFF
--- a/testsuite/diem-fuzzer/src/lib.rs
+++ b/testsuite/diem-fuzzer/src/lib.rs
@@ -7,7 +7,7 @@ use proptest::{
     test_runner::{self, RngAlgorithm, TestRunner},
 };
 use rand::RngCore;
-use std::{fmt, ops::Deref, str::FromStr};
+use std::{ffi::CString, fmt, ops::Deref, os::raw::c_char, str::FromStr};
 
 pub mod commands;
 #[cfg(test)]
@@ -92,4 +92,13 @@ pub fn fuzz_data_to_value<T: std::fmt::Debug>(
     // create a value based on the arbitrary implementation of T
     let strategy_tree = strategy.new_tree(&mut runner).expect("should not happen");
     strategy_tree.current()
+}
+
+/// Bake lsan suppressions into the binary
+#[no_mangle]
+pub extern "C" fn __lsan_default_suppressions() -> *const c_char {
+    let s = CString::new(include_str!("../lsan_suppressions.txt")).unwrap();
+    let p = s.as_ptr();
+    std::mem::forget(s);
+    p
 }


### PR DESCRIPTION
## Motivation

With this change, we bake the suppressions defined in lsan_suppressions.txt directly into the binary; so we don't have to worry about passing this file around in our production fuzzing environment.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I was able to test this by building the fuzzers within our internal environment and running against a test file with a leak.

Command was:

    FUZZ_TARGET=LanguageTransactionExecution target/x86_64-unknown-linux-gnu/release/fuzz_runner /tmp/crashfile

Before this change, the output was:

```
Running: /tmp/crashfile
Executed /tmp/crashfile in 1659 ms
***
*** NOTE: fuzzing was not performed, you have only
***       executed the target code on a fixed set of inputs.
***

=================================================================
==197429==ERROR: LeakSanitizer: detected memory leaks

... [ trimmed ] ...

SUMMARY: AddressSanitizer: 9 byte(s) leaked in 1 allocation(s).
```

After this change, we get:

```
Running: /tmp/crashfile
Executed /tmp/crashfile in 1604 ms
***
*** NOTE: fuzzing was not performed, you have only
***       executed the target code on a fixed set of inputs.
***
-----------------------------------------------------
Suppressions used:
  count      bytes template
      1          9 libc
-----------------------------------------------------
```