### PR TITLE
[move-prover] cascade the variance parameter in type unification process

### DIFF
--- a/language/move-model/src/builder/exp_translator.rs
+++ b/language/move-model/src/builder/exp_translator.rs
@@ -1837,7 +1837,12 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
         // the build. This is because we also need to inherently borrow self via the
         // type_display_context which is passed into unification.
         let mut subs = std::mem::replace(&mut self.subs, Substitution::new());
-        let result = match subs.unify(&self.type_display_context(), Variance::Allow, ty, expected) {
+        let result = match subs.unify(
+            &self.type_display_context(),
+            Variance::Shallow,
+            ty,
+            expected,
+        ) {
             Ok(t) => t,
             Err(err) => {
                 self.error(&loc, &format!("{} {}", err.message, context_msg));

--- a/language/move-model/tests/sources/type_variance_ok.exp
+++ b/language/move-model/tests/sources/type_variance_ok.exp
@@ -1,0 +1,1 @@
+All good, no errors!

--- a/language/move-model/tests/sources/type_variance_ok.move
+++ b/language/move-model/tests/sources/type_variance_ok.move
@@ -1,0 +1,9 @@
+module 0x42::M {
+  fun foo(v: vector<u8>): vector<u8> {
+    v
+  }
+
+  spec foo {
+    ensures result == vec(1);
+  }
+}


### PR DESCRIPTION
Previously the variance parameter is only effective on the top-level.
This commit additionally allows the type compatibility rule to be
propogated recursively to all sub-types in the type unification process
(via the `Variance::Allow` option).

The old behavior, outermost co-varianec only, can be requested with
`Variance::Shallow`. And `Variance::Disallow` completely disables the
type compatibility rules.

For the only two call sites of the `Substitution::unify()` function,
- `Variance::Allow` is requested for `ExpTranslator::translate_call()`
   to give more freedom in the type inference process. The effect of
   this change is shown in the new test case added (which is also
   in the comments).
- `Variance::Shallow` is requested for `ExpTranslator::check_type()`
   to be more conservative in type checking.

## Motivation

Complete the type-compatibility rules in the type unification process.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- CI
- A new test case
