### PR TITLE
[move-lang] Migrate typing/translate::typing_error errors

### DIFF
--- a/language/move-lang/src/errors/diagnostic_codes.rs
+++ b/language/move-lang/src/errors/diagnostic_codes.rs
@@ -147,6 +147,10 @@ codes!(
         BuiltinOperation: { msg: "built-in operation not supported", severity: BlockingError },
         ExpectedBaseType: { msg: "expected a single non-reference type", severity: BlockingError },
         ExpectedSingleType: { msg: "expected a single type", severity: BlockingError },
+        SubtypeError: { msg: "invalid subtype", severity: BlockingError },
+        JoinError: { msg: "incompatible types", severity: BlockingError },
+        RecursiveType: { msg: "invalid type. recursive type found", severity: BlockingError },
+
     ],
     // errors for ability rules. mostly typing/translate
     AbilitySafety: [

--- a/language/move-lang/src/typing/core.rs
+++ b/language/move-lang/src/typing/core.rs
@@ -1513,13 +1513,23 @@ fn join_impl(
                 join_tvar(subst, case, *loc1, *id1, *loc2, *id2)
             }
         }
-        (sp!(loc, Var(id)), other) | (other, sp!(loc, Var(id))) if subst.get(*id).is_none() => {
+        (sp!(loc, Var(id)), other) if subst.get(*id).is_none() => {
             if join_bind_tvar(&mut subst, *loc, *id, other.clone())? {
                 Ok((subst, sp(*loc, Var(*id))))
             } else {
                 Err(TypingError::Incompatible(
                     Box::new(sp(*loc, Var(*id))),
                     Box::new(other.clone()),
+                ))
+            }
+        }
+        (other, sp!(loc, Var(id))) if subst.get(*id).is_none() => {
+            if join_bind_tvar(&mut subst, *loc, *id, other.clone())? {
+                Ok((subst, sp(*loc, Var(*id))))
+            } else {
+                Err(TypingError::Incompatible(
+                    Box::new(other.clone()),
+                    Box::new(sp(*loc, Var(*id))),
                 ))
             }
         }

--- a/language/move-lang/src/typing/translate.rs
+++ b/language/move-lang/src/typing/translate.rs
@@ -679,53 +679,87 @@ fn invalid_phantom_use_error(
 // Types
 //**************************************************************************************************
 
-fn typing_error<T: Into<String>, F: FnOnce() -> T>(
+fn typing_error<T: ToString, F: FnOnce() -> T>(
     context: &mut Context,
+    from_subtype: bool,
     loc: Loc,
-    msg: F,
+    mk_msg: F,
     e: core::TypingError,
 ) {
     use super::core::TypingError::*;
+    let msg = mk_msg().to_string();
     let subst = &context.subst;
-    let error = match e {
+    let diag = match e {
         SubtypeError(t1, t2) => {
             let loc1 = core::best_loc(subst, &t1);
             let loc2 = core::best_loc(subst, &t2);
-            let m1 = format!("The type: {}", core::error_format(&t1, subst));
-            let m2 = format!("Is not a subtype of: {}", core::error_format(&t2, subst));
-            vec![(loc, msg().into()), (loc1, m1), (loc2, m2)]
+            let t1_str = core::error_format(&t1, subst);
+            let t2_str = core::error_format(&t2, subst);
+            let m1 = format!("Given: {}", t1_str);
+            let m2 = format!("Expected: {}", t2_str);
+            diag!(TypeSafety::SubtypeError, (loc, msg), (loc1, m1), (loc2, m2))
         }
         ArityMismatch(n1, t1, n2, t2) => {
             let loc1 = core::best_loc(subst, &t1);
             let loc2 = core::best_loc(subst, &t2);
-            let msg1 = format!(
-                "The expression list type of length {}: {}",
-                n1,
-                core::error_format(&t1, subst)
-            );
-            let msg2 = format!(
-                "Is not compatible with the expression list type of length {}: {}",
-                n2,
-                core::error_format(&t2, subst)
-            );
-            vec![(loc, msg().into()), (loc1, msg1), (loc2, msg2)]
+            let t1_str = core::error_format(&t1, subst);
+            let t2_str = core::error_format(&t2, subst);
+            let msg1 = if from_subtype {
+                format!("Given expression list of length {}: {}", n1, t1_str)
+            } else {
+                format!(
+                    "Found expression list of length {}: {}. It is not compatible with the other \
+                     type of length {}.",
+                    n1, t1_str, n2
+                )
+            };
+            let msg2 = if from_subtype {
+                format!("Expected expression list of length {}: {}", n2, t2_str)
+            } else {
+                format!(
+                    "Found expression list of length {}: {}. It is not compatible with the other \
+                     type of length {}.",
+                    n2, t2_str, n1
+                )
+            };
+
+            diag!(
+                TypeSafety::JoinError,
+                (loc, msg),
+                (loc1, msg1),
+                (loc2, msg2)
+            )
         }
         Incompatible(t1, t2) => {
             let loc1 = core::best_loc(subst, &t1);
             let loc2 = core::best_loc(subst, &t2);
-            let m1 = format!("The type: {}", core::error_format(&t1, subst));
-            let m2 = format!("Is not compatible with: {}", core::error_format(&t2, subst));
-            vec![(loc, msg().into()), (loc1, m1), (loc2, m2)]
+            let t1_str = core::error_format(&t1, subst);
+            let t2_str = core::error_format(&t2, subst);
+            let m1 = if from_subtype {
+                format!("Given: {}", t1_str)
+            } else {
+                format!(
+                    "Found: {}. It is not compatible with the other type.",
+                    t1_str
+                )
+            };
+            let m2 = if from_subtype {
+                format!("Expected: {}", t2_str)
+            } else {
+                format!(
+                    "Found: {}. It is not compatible with the other type.",
+                    t2_str
+                )
+            };
+            diag!(TypeSafety::JoinError, (loc, msg), (loc1, m1), (loc2, m2))
         }
-        RecursiveType(rloc) => vec![
-            (loc, msg().into()),
-            (
-                rloc,
-                "Unable to infer the type. Recursive type found.".into(),
-            ),
-        ],
+        RecursiveType(rloc) => diag!(
+            TypeSafety::RecursiveType,
+            (loc, msg),
+            (rloc, "Unable to infer the type. Recursive type found."),
+        ),
     };
-    context.env.add_error_deprecated(error);
+    context.env.add_diag(diag)
 }
 
 fn subtype_no_report(
@@ -742,30 +776,56 @@ fn subtype_no_report(
     })
 }
 
-fn subtype<T: Into<String>, F: FnOnce() -> T>(
+fn subtype_impl<T: ToString, F: FnOnce() -> T>(
     context: &mut Context,
     loc: Loc,
     msg: F,
     pre_lhs: Type,
     pre_rhs: Type,
-) -> Type {
+) -> Result<Type, Type> {
     let subst = std::mem::replace(&mut context.subst, Subst::empty());
     let lhs = core::ready_tvars(&subst, pre_lhs);
     let rhs = core::ready_tvars(&subst, pre_rhs);
     match core::subtype(subst.clone(), &lhs, &rhs) {
         Err(e) => {
             context.subst = subst;
-            typing_error(context, loc, msg, e);
-            rhs
+            typing_error(context, /* from_subtype */ true, loc, msg, e);
+            Err(rhs)
         }
         Ok((next_subst, ty)) => {
             context.subst = next_subst;
-            ty
+            Ok(ty)
         }
     }
 }
 
-fn join_opt<T: Into<String>, F: FnOnce() -> T>(
+fn subtype_opt<T: ToString, F: FnOnce() -> T>(
+    context: &mut Context,
+    loc: Loc,
+    msg: F,
+    pre_lhs: Type,
+    pre_rhs: Type,
+) -> Option<Type> {
+    match subtype_impl(context, loc, msg, pre_lhs, pre_rhs) {
+        Err(_rhs) => None,
+        Ok(t) => Some(t),
+    }
+}
+
+fn subtype<T: ToString, F: FnOnce() -> T>(
+    context: &mut Context,
+    loc: Loc,
+    msg: F,
+    pre_lhs: Type,
+    pre_rhs: Type,
+) -> Type {
+    match subtype_impl(context, loc, msg, pre_lhs, pre_rhs) {
+        Err(rhs) => rhs,
+        Ok(t) => t,
+    }
+}
+
+fn join_opt<T: ToString, F: FnOnce() -> T>(
     context: &mut Context,
     loc: Loc,
     msg: F,
@@ -778,7 +838,7 @@ fn join_opt<T: Into<String>, F: FnOnce() -> T>(
     match core::join(subst.clone(), &t1, &t2) {
         Err(e) => {
             context.subst = subst;
-            typing_error(context, loc, msg, e);
+            typing_error(context, /* from_subtype */ false, loc, msg, e);
             None
         }
         Ok((next_subst, ty)) => {
@@ -788,7 +848,7 @@ fn join_opt<T: Into<String>, F: FnOnce() -> T>(
     }
 }
 
-fn join<T: Into<String>, F: FnOnce() -> T>(
+fn join<T: ToString, F: FnOnce() -> T>(
     context: &mut Context,
     loc: Loc,
     msg: F,
@@ -947,7 +1007,6 @@ fn exp_(context: &mut Context, initial_ne: N::Exp) -> T::Exp {
                     let context = &mut s.context;
                     let (ty, operand_ty) = match &bop.value {
                         Sub | Add | Mul | Mod | Div => {
-                            // TODO after typing refactor, just add to operand ty
                             context.add_numeric_constraint(
                                 el.exp.loc,
                                 bop.value.symbol(),
@@ -959,12 +1018,11 @@ fn exp_(context: &mut Context, initial_ne: N::Exp) -> T::Exp {
                                 el.ty.clone(),
                             );
                             let operand_ty =
-                                join(context, er.exp.loc, msg, el.ty.clone(), er.ty.clone());
+                                join(context, bop.loc, msg, el.ty.clone(), er.ty.clone());
                             (operand_ty.clone(), operand_ty)
                         }
 
                         BitOr | BitAnd | Xor => {
-                            // TODO after typing refactor, just add to operand ty
                             context.add_bits_constraint(
                                 el.exp.loc,
                                 bop.value.symbol(),
@@ -976,12 +1034,7 @@ fn exp_(context: &mut Context, initial_ne: N::Exp) -> T::Exp {
                                 el.ty.clone(),
                             );
                             let operand_ty =
-                                join(context, er.exp.loc, msg, el.ty.clone(), er.ty.clone());
-                            context.add_bits_constraint(
-                                loc,
-                                bop.value.symbol(),
-                                operand_ty.clone(),
-                            );
+                                join(context, bop.loc, msg, el.ty.clone(), er.ty.clone());
                             (operand_ty.clone(), operand_ty)
                         }
 
@@ -998,7 +1051,6 @@ fn exp_(context: &mut Context, initial_ne: N::Exp) -> T::Exp {
                         }
 
                         Lt | Gt | Le | Ge => {
-                            // TODO after typing refactor, just add to operand ty
                             context.add_ordered_constraint(
                                 el.exp.loc,
                                 bop.value.symbol(),
@@ -1010,29 +1062,40 @@ fn exp_(context: &mut Context, initial_ne: N::Exp) -> T::Exp {
                                 el.ty.clone(),
                             );
                             let operand_ty =
-                                join(context, er.exp.loc, msg, el.ty.clone(), er.ty.clone());
+                                join(context, bop.loc, msg, el.ty.clone(), er.ty.clone());
                             (Type_::bool(loc), operand_ty)
                         }
 
                         Eq | Neq => {
-                            let ty = join(context, er.exp.loc, msg, el.ty.clone(), er.ty.clone());
-                            let msg = format!("Invalid arguments to '{}'", &bop);
-                            context.add_single_type_constraint(loc, msg, ty.clone());
-                            let msg = Some(format!(
+                            let ability_msg = Some(format!(
                                 "'{}' requires the '{}' ability as the value is consumed. Try \
                                  borrowing the values with '&' first.'",
                                 &bop,
                                 Ability_::Drop,
                             ));
-                            context.add_ability_constraint(loc, msg, ty.clone(), Ability_::Drop);
+                            context.add_ability_constraint(
+                                el.exp.loc,
+                                ability_msg.clone(),
+                                el.ty.clone(),
+                                Ability_::Drop,
+                            );
+                            context.add_ability_constraint(
+                                er.exp.loc,
+                                ability_msg,
+                                er.ty.clone(),
+                                Ability_::Drop,
+                            );
+                            let ty = join(context, bop.loc, msg, el.ty.clone(), er.ty.clone());
+                            context.add_single_type_constraint(loc, msg(), ty.clone());
                             (Type_::bool(loc), ty)
                         }
 
                         And | Or => {
+                            let msg = || format!("Invalid argument to '{}'", &bop);
                             let lloc = el.exp.loc;
-                            subtype(context, lloc, msg, el.ty.clone(), Type_::bool(lloc));
+                            subtype(context, lloc, msg, el.ty.clone(), Type_::bool(bop.loc));
                             let rloc = er.exp.loc;
-                            subtype(context, rloc, msg, er.ty.clone(), Type_::bool(lloc));
+                            subtype(context, rloc, msg, er.ty.clone(), Type_::bool(bop.loc));
                             (Type_::bool(loc), Type_::bool(loc))
                         }
 
@@ -1206,7 +1269,7 @@ fn exp_inner(context: &mut Context, sp!(eloc, ne_): N::Exp) -> T::Exp {
                 None => current_break_ty,
                 Some(t) => {
                     let t = t.clone();
-                    join(context, eloc, || "Invalid break.", current_break_ty, t)
+                    join(context, eloc, || "Invalid break.", t, current_break_ty)
                 }
             };
             context.set_break_type(break_ty);
@@ -1272,7 +1335,7 @@ fn exp_inner(context: &mut Context, sp!(eloc, ne_): N::Exp) -> T::Exp {
                 join(
                     context,
                     e.exp.loc,
-                    || "ICE failed tvar join",
+                    || -> String { panic!("ICE failed tvar join") },
                     e.ty.clone(),
                     tvar.clone(),
                 );
@@ -1471,7 +1534,7 @@ fn lvalue_list(
         _ => Type_::multiple(loc, ty_vars.clone()),
     };
     if let Some(ty) = ty_opt {
-        let result = join_opt(
+        let result = subtype_opt(
             context,
             loc,
             || {
@@ -1483,8 +1546,8 @@ fn lvalue_list(
                     }
                 )
             },
-            var_ty,
             ty,
+            var_ty,
         );
         if result.is_none() {
             for ty_var in ty_vars.clone() {
@@ -1586,7 +1649,7 @@ fn lvalue(
                 }
             };
             match case {
-                C::Bind => join(
+                C::Bind => subtype(
                     context,
                     loc,
                     || "Invalid deconstruction binding",

--- a/language/move-lang/tests/move_check/expansion/use_struct_tparam_shadows.exp
+++ b/language/move-lang/tests/move_check/expansion/use_struct_tparam_shadows.exp
@@ -1,14 +1,10 @@
-error: 
-
-    ┌── tests/move_check/expansion/use_struct_tparam_shadows.move:12:9 ───
-    │
- 12 │         x
-    │         ^ Invalid return expression
-    ·
- 11 │     fun foo<S>(x: S): 0x2::X::S {
-    │                   - The type: 'S'
-    ·
- 11 │     fun foo<S>(x: S): 0x2::X::S {
-    │                       --------- Is not compatible with: '0x2::X::S'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/expansion/use_struct_tparam_shadows.move:12:9
+   │
+11 │     fun foo<S>(x: S): 0x2::X::S {
+   │                   -   --------- Expected: '0x2::X::S'
+   │                   │    
+   │                   Given: 'S'
+12 │         x
+   │         ^ Invalid return expression
 

--- a/language/move-lang/tests/move_check/naming/generics_shadowing_invalid.exp
+++ b/language/move-lang/tests/move_check/naming/generics_shadowing_invalid.exp
@@ -1,3 +1,14 @@
+error[E04007]: incompatible types
+  ┌─ tests/move_check/naming/generics_shadowing_invalid.move:7:14
+  │
+6 │     fun foo<S>(s1: S, s2: S): S {
+  │                    - Given: 'S'
+7 │         (s1: Self::S);
+  │              ^^^^^^^
+  │              │
+  │              Invalid type annotation
+  │              Expected: '0x2::M::S'
+
 error[E03006]: unexpected name in this position
   ┌─ tests/move_check/naming/generics_shadowing_invalid.move:8:20
   │
@@ -7,6 +18,18 @@ error[E03006]: unexpected name in this position
 8 │         let s: S = S {}; // TODO error? should this try to construct the generic ?
   │                    ^ Invalid construction. Expected a struct name
 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/naming/generics_shadowing_invalid.move:9:9
+   │
+ 6 │     fun foo<S>(s1: S, s2: S): S {
+   │                    - Given: 'S'
+   ·
+ 9 │         bar(s1);
+   │         ^^^^^^^ Invalid call of '0x2::M::bar'. Invalid argument for parameter 's'
+   ·
+13 │     fun bar(s: S) {}
+   │                - Expected: '0x2::M::S'
+
 error[E03006]: unexpected name in this position
    ┌─ tests/move_check/naming/generics_shadowing_invalid.move:10:9
    │
@@ -15,32 +38,4 @@ error[E03006]: unexpected name in this position
    ·
 10 │         S {}
    │         ^ Invalid construction. Expected a struct name
-
-error: 
-
-   ┌── tests/move_check/naming/generics_shadowing_invalid.move:7:14 ───
-   │
- 7 │         (s1: Self::S);
-   │              ^^^^^^^ Invalid type annotation
-   ·
- 6 │     fun foo<S>(s1: S, s2: S): S {
-   │                    - The type: 'S'
-   ·
- 7 │         (s1: Self::S);
-   │              ------- Is not compatible with: '0x2::M::S'
-   │
-
-error: 
-
-    ┌── tests/move_check/naming/generics_shadowing_invalid.move:9:9 ───
-    │
-  9 │         bar(s1);
-    │         ^^^^^^^ Invalid call of '0x2::M::bar'. Invalid argument for parameter 's'
-    ·
-  6 │     fun foo<S>(s1: S, s2: S): S {
-    │                    - The type: 'S'
-    ·
- 13 │     fun bar(s: S) {}
-    │                - Is not compatible with: '0x2::M::S'
-    │
 

--- a/language/move-lang/tests/move_check/parser/spec_parsing_inside_fun.exp
+++ b/language/move-lang/tests/move_check/parser/spec_parsing_inside_fun.exp
@@ -7,6 +7,15 @@ error[E04003]: built-in operation not supported
    │         Invalid argument to '+'
    │         Found: '()'. But expected: 'u8', 'u64', 'u128'
 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/parser/spec_parsing_inside_fun.move:32:17
+   │
+32 │         spec {} + 1;
+   │         ------- ^ - Found: integer. It is not compatible with the other type.
+   │         │       │  
+   │         │       Incompatible arguments to '+'
+   │         Found: '()'. It is not compatible with the other type.
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/parser/spec_parsing_inside_fun.move:32:19
    │
@@ -14,6 +23,25 @@ error[E04003]: built-in operation not supported
    │         -------   ^ Invalid argument to '+'
    │         │          
    │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/parser/spec_parsing_inside_fun.move:33:9
+   │
+33 │         spec {} && spec {};
+   │         ^^^^^^^ -- Expected: 'bool'
+   │         │        
+   │         Invalid argument to '&&'
+   │         Given: '()'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/parser/spec_parsing_inside_fun.move:33:20
+   │
+33 │         spec {} && spec {};
+   │                 -- ^^^^^^^
+   │                 │  │
+   │                 │  Invalid argument to '&&'
+   │                 │  Given: '()'
+   │                 Expected: 'bool'
 
 error[E04004]: expected a single non-reference type
    ┌─ tests/move_check/parser/spec_parsing_inside_fun.move:34:9
@@ -23,46 +51,4 @@ error[E04004]: expected a single non-reference type
    │         │    │
    │         │    Expected a single non-reference type, but found: '()'
    │         Invalid borrow
-
-error: 
-
-    ┌── tests/move_check/parser/spec_parsing_inside_fun.move:32:19 ───
-    │
- 32 │         spec {} + 1;
-    │                   ^ Incompatible arguments to '+'
-    ·
- 32 │         spec {} + 1;
-    │                   - The type: integer
-    ·
- 32 │         spec {} + 1;
-    │         ------- Is not compatible with: '()'
-    │
-
-error: 
-
-    ┌── tests/move_check/parser/spec_parsing_inside_fun.move:33:9 ───
-    │
- 33 │         spec {} && spec {};
-    │         ^^^^^^^ Incompatible arguments to '&&'
-    ·
- 33 │         spec {} && spec {};
-    │         ------- The type: '()'
-    ·
- 33 │         spec {} && spec {};
-    │         ------- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/parser/spec_parsing_inside_fun.move:33:20 ───
-    │
- 33 │         spec {} && spec {};
-    │                    ^^^^^^^ Incompatible arguments to '&&'
-    ·
- 33 │         spec {} && spec {};
-    │                    ------- The type: '()'
-    ·
- 33 │         spec {} && spec {};
-    │         ------- Is not compatible with: 'bool'
-    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/commands/assign_wrong_type.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/commands/assign_wrong_type.exp
@@ -1,14 +1,10 @@
-error: 
-
-   ┌── tests/move_check/translated_ir_tests/move/commands/assign_wrong_type.move:6:5 ───
-   │
- 6 │     x = false
-   │     ^ Invalid assignment to local 'x'
-   ·
- 6 │     x = false
-   │         ----- The type: 'bool'
-   ·
- 5 │     let x: u64;
-   │            --- Is not compatible with: 'u64'
-   │
+error[E04007]: incompatible types
+  ┌─ tests/move_check/translated_ir_tests/move/commands/assign_wrong_type.move:6:5
+  │
+5 │     let x: u64;
+  │            --- Expected: 'u64'
+6 │     x = false
+  │     ^   ----- Given: 'bool'
+  │     │    
+  │     Invalid assignment to local 'x'
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/commands/pop_negative.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/commands/pop_negative.exp
@@ -1,14 +1,12 @@
-error: 
-
-   ┌── tests/move_check/translated_ir_tests/move/commands/pop_negative.move:7:9 ───
-   │
- 7 │         (_, _, _, _) = three();
-   │         ^^^^^^^^^^^^ Invalid value for assignment
-   ·
- 7 │         (_, _, _, _) = three();
-   │         ------------ The expression list type of length 4: '(_, _, _, _)'
-   ·
- 2 │     fun three(): (u64, u64, u64) {
-   │                  --------------- Is not compatible with the expression list type of length 3: '(u64, u64, u64)'
-   │
+error[E04007]: incompatible types
+  ┌─ tests/move_check/translated_ir_tests/move/commands/pop_negative.move:7:9
+  │
+2 │     fun three(): (u64, u64, u64) {
+  │                  --------------- Given expression list of length 3: '(u64, u64, u64)'
+  ·
+7 │         (_, _, _, _) = three();
+  │         ^^^^^^^^^^^^
+  │         │
+  │         Invalid value for assignment
+  │         Expected expression list of length 4: '(_, _, _, _)'
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/commands/pop_positive.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/commands/pop_positive.exp
@@ -1,14 +1,12 @@
-error: 
-
-   ┌── tests/move_check/translated_ir_tests/move/commands/pop_positive.move:7:9 ───
-   │
- 7 │         (_, _) = three();
-   │         ^^^^^^ Invalid value for assignment
-   ·
- 7 │         (_, _) = three();
-   │         ------ The expression list type of length 2: '(_, _)'
-   ·
- 2 │     fun three(): (u64, u64, u64) {
-   │                  --------------- Is not compatible with the expression list type of length 3: '(u64, u64, u64)'
-   │
+error[E04007]: incompatible types
+  ┌─ tests/move_check/translated_ir_tests/move/commands/pop_positive.move:7:9
+  │
+2 │     fun three(): (u64, u64, u64) {
+  │                  --------------- Given expression list of length 3: '(u64, u64, u64)'
+  ·
+7 │         (_, _) = three();
+  │         ^^^^^^
+  │         │
+  │         Invalid value for assignment
+  │         Expected expression list of length 2: '(_, _)'
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/commands/pop_weird.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/commands/pop_weird.exp
@@ -1,3 +1,12 @@
+error[E04007]: incompatible types
+   ┌─ tests/move_check/translated_ir_tests/move/commands/pop_weird.move:13:9
+   │
+13 │         (_, _) = ();
+   │         ^^^^^^   -- Given: '()'
+   │         │         
+   │         Invalid value for assignment
+   │         Expected: '(_, _)'
+
 error[E04005]: expected a single type
    ┌─ tests/move_check/translated_ir_tests/move/commands/pop_weird.move:14:9
    │
@@ -5,18 +14,4 @@ error[E04005]: expected a single type
    │         ^^^   -- Expected a single type, but found expression list type: '()'
    │         │      
    │         Invalid type for local
-
-error: 
-
-    ┌── tests/move_check/translated_ir_tests/move/commands/pop_weird.move:13:9 ───
-    │
- 13 │         (_, _) = ();
-    │         ^^^^^^ Invalid value for assignment
-    ·
- 13 │         (_, _) = ();
-    │         ------ The type: '(_, _)'
-    ·
- 13 │         (_, _) = ();
-    │                  -- Is not compatible with: '()'
-    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/commands/unpack_wrong_type.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/commands/unpack_wrong_type.exp
@@ -1,14 +1,11 @@
-error: 
-
-   ┌── tests/move_check/translated_ir_tests/move/commands/unpack_wrong_type.move:6:9 ───
-   │
- 6 │         X { b: _ } = t;
-   │         ^^^^^^^^^^ Invalid deconstruction assignment
-   ·
- 6 │         X { b: _ } = t;
-   │         ---------- The type: '0x8675309::Test::X'
-   ·
- 5 │     public fun destroy_t(t: T) {
-   │                             - Is not compatible with: '0x8675309::Test::T'
-   │
+error[E04007]: incompatible types
+  ┌─ tests/move_check/translated_ir_tests/move/commands/unpack_wrong_type.move:6:9
+  │
+5 │     public fun destroy_t(t: T) {
+  │                             - Expected: '0x8675309::Test::T'
+6 │         X { b: _ } = t;
+  │         ^^^^^^^^^^
+  │         │
+  │         Invalid deconstruction assignment
+  │         Given: '0x8675309::Test::X'
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/operators/boolean_not_non_boolean.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/operators/boolean_not_non_boolean.exp
@@ -1,14 +1,10 @@
-error: 
-
-   ┌── tests/move_check/translated_ir_tests/move/operators/boolean_not_non_boolean.move:3:6 ───
-   │
- 3 │     !0;
-   │      ^ Invalid argument to '!'
-   ·
- 3 │     !0;
-   │      - The type: integer
-   ·
- 3 │     !0;
-   │      - Is not compatible with: 'bool'
-   │
+error[E04007]: incompatible types
+  ┌─ tests/move_check/translated_ir_tests/move/operators/boolean_not_non_boolean.move:3:6
+  │
+3 │     !0;
+  │      ^
+  │      │
+  │      Invalid argument to '!'
+  │      Expected: 'bool'
+  │      Given: integer
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/signer/invalid_move_to_sender.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/signer/invalid_move_to_sender.exp
@@ -16,17 +16,14 @@ error[E05001]: ability constraint not satisfied
   │                           Invalid field type. The struct was declared with the ability 'key' so all fields require the ability 'store'
   │                           The type 'signer' does not have the ability 'store'
 
-error: 
-
-    ┌── tests/move_check/translated_ir_tests/move/signer/invalid_move_to_sender.move:10:9 ───
-    │
- 10 │         move_to<R>(s1, move s);
-    │         ^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_to'. Invalid argument for parameter '1'
-    ·
-  9 │     fun t(s1: &signer, s: signer) {
-    │                           ------ The type: 'signer'
-    ·
- 10 │         move_to<R>(s1, move s);
-    │                 - Is not compatible with: '0x8675309::N::R'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/translated_ir_tests/move/signer/invalid_move_to_sender.move:10:9
+   │
+ 9 │     fun t(s1: &signer, s: signer) {
+   │                           ------ Given: 'signer'
+10 │         move_to<R>(s1, move s);
+   │         ^^^^^^^^^^^^^^^^^^^^^^
+   │         │       │
+   │         │       Expected: '0x8675309::N::R'
+   │         Invalid call of 'move_to'. Invalid argument for parameter '1'
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/signer/move_to_extra_arg.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/signer/move_to_extra_arg.exp
@@ -1,3 +1,25 @@
+error[E04007]: incompatible types
+   ┌─ tests/move_check/translated_ir_tests/move/signer/move_to_extra_arg.move:15:9
+   │
+14 │     fun t0<T>(s: &signer, a: address) {
+   │                              ------- Given: 'address'
+15 │         move_to<R<bool>>(a, s, a, R<bool> { f: false });
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │
+   │         Invalid call of 'move_to'. Invalid argument for parameter '0'
+   │         Expected: '&signer'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/translated_ir_tests/move/signer/move_to_extra_arg.move:15:9
+   │
+14 │     fun t0<T>(s: &signer, a: address) {
+   │                  ------- Given: '&signer'
+15 │         move_to<R<bool>>(a, s, a, R<bool> { f: false });
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │       │
+   │         │       Expected: '0x8675309::N::R<bool>'
+   │         Invalid call of 'move_to'. Invalid argument for parameter '1'
+
 error: 
 
    ┌── tests/move_check/translated_ir_tests/move/signer/move_to_extra_arg.move:5:9 ───
@@ -18,33 +40,5 @@ error:
     ·
  15 │         move_to<R<bool>>(a, s, a, R<bool> { f: false });
     │                         ------------------------------- Found 4 argument(s) here
-    │
-
-error: 
-
-    ┌── tests/move_check/translated_ir_tests/move/signer/move_to_extra_arg.move:15:9 ───
-    │
- 15 │         move_to<R<bool>>(a, s, a, R<bool> { f: false });
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_to'. Invalid argument for parameter '0'
-    ·
- 14 │     fun t0<T>(s: &signer, a: address) {
-    │                              ------- The type: 'address'
-    ·
- 15 │         move_to<R<bool>>(a, s, a, R<bool> { f: false });
-    │         ------- Is not compatible with: '&signer'
-    │
-
-error: 
-
-    ┌── tests/move_check/translated_ir_tests/move/signer/move_to_extra_arg.move:15:9 ───
-    │
- 15 │         move_to<R<bool>>(a, s, a, R<bool> { f: false });
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_to'. Invalid argument for parameter '1'
-    ·
- 14 │     fun t0<T>(s: &signer, a: address) {
-    │                  ------- The type: '&signer'
-    ·
- 15 │         move_to<R<bool>>(a, s, a, R<bool> { f: false });
-    │                 ------- Is not compatible with: '0x8675309::N::R<bool>'
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/signer/move_to_missing_signer.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/signer/move_to_missing_signer.exp
@@ -1,3 +1,23 @@
+error[E04007]: incompatible types
+  ┌─ tests/move_check/translated_ir_tests/move/signer/move_to_missing_signer.move:4:9
+  │
+4 │         move_to<R>(R { f: false })
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │         │          │
+  │         │          Given: '0x8675309::M::R'
+  │         Invalid call of 'move_to'. Invalid argument for parameter '0'
+  │         Expected: '&signer'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/translated_ir_tests/move/signer/move_to_missing_signer.move:14:14
+   │
+14 │         () = move_to<R<bool>>(R<bool> { f: false });
+   │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │              │                │
+   │              │                Given: '0x8675309::N::R<bool>'
+   │              Invalid call of 'move_to'. Invalid argument for parameter '0'
+   │              Expected: '&signer'
+
 error: 
 
    ┌── tests/move_check/translated_ir_tests/move/signer/move_to_missing_signer.move:4:9 ───
@@ -11,20 +31,6 @@ error:
 
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/move/signer/move_to_missing_signer.move:4:9 ───
-   │
- 4 │         move_to<R>(R { f: false })
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_to'. Invalid argument for parameter '0'
-   ·
- 4 │         move_to<R>(R { f: false })
-   │                    -------------- The type: '0x8675309::M::R'
-   ·
- 4 │         move_to<R>(R { f: false })
-   │         ------- Is not compatible with: '&signer'
-   │
-
-error: 
-
     ┌── tests/move_check/translated_ir_tests/move/signer/move_to_missing_signer.move:14:14 ───
     │
  14 │         () = move_to<R<bool>>(R<bool> { f: false });
@@ -32,19 +38,5 @@ error:
     ·
  14 │         () = move_to<R<bool>>(R<bool> { f: false });
     │                              ---------------------- Found 1 argument(s) here
-    │
-
-error: 
-
-    ┌── tests/move_check/translated_ir_tests/move/signer/move_to_missing_signer.move:14:14 ───
-    │
- 14 │         () = move_to<R<bool>>(R<bool> { f: false });
-    │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_to'. Invalid argument for parameter '0'
-    ·
- 14 │         () = move_to<R<bool>>(R<bool> { f: false });
-    │                               -------------------- The type: '0x8675309::N::R<bool>'
-    ·
- 14 │         () = move_to<R<bool>>(R<bool> { f: false });
-    │              ------- Is not compatible with: '&signer'
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/signer/move_to_non_signer.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/signer/move_to_non_signer.exp
@@ -1,28 +1,22 @@
-error: 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/translated_ir_tests/move/signer/move_to_non_signer.move:4:9
+  │
+3 │     fun t0(s: &address) {
+  │                ------- Given: 'address'
+4 │         move_to(s, R { f: false })
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │         │
+  │         Invalid call of 'move_to'. Invalid argument for parameter '0'
+  │         Expected: 'signer'
 
-   ┌── tests/move_check/translated_ir_tests/move/signer/move_to_non_signer.move:4:9 ───
+error[E04007]: incompatible types
+   ┌─ tests/move_check/translated_ir_tests/move/signer/move_to_non_signer.move:12:9
    │
- 4 │         move_to(s, R { f: false })
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_to'. Invalid argument for parameter '0'
-   ·
- 3 │     fun t0(s: &address) {
-   │                ------- The type: 'address'
-   ·
- 4 │         move_to(s, R { f: false })
-   │         ------- Is not compatible with: 'signer'
-   │
-
-error: 
-
-    ┌── tests/move_check/translated_ir_tests/move/signer/move_to_non_signer.move:12:9 ───
-    │
- 12 │         move_to(s, R { f: false })
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_to'. Invalid argument for parameter '0'
-    ·
- 11 │     fun t0<T>(s: address) {
-    │                  ------- The type: 'address'
-    ·
- 12 │         move_to(s, R { f: false })
-    │         ------- Is not compatible with: '&signer'
-    │
+11 │     fun t0<T>(s: address) {
+   │                  ------- Given: 'address'
+12 │         move_to(s, R { f: false })
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │
+   │         Invalid call of 'move_to'. Invalid argument for parameter '0'
+   │         Expected: '&signer'
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/signer/move_to_non_struct.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/signer/move_to_non_struct.exp
@@ -7,17 +7,13 @@ error[E05001]: ability constraint not satisfied
   │         │       The type 'u64' does not have the ability 'key'
   │         Invalid call of 'move_to'
 
-error: 
-
-    ┌── tests/move_check/translated_ir_tests/move/signer/move_to_non_struct.move:13:9 ───
-    │
- 13 │         move_to<R<u64>>(s, 0)
-    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_to'. Invalid argument for parameter '1'
-    ·
- 13 │         move_to<R<u64>>(s, 0)
-    │                            - The type: integer
-    ·
- 13 │         move_to<R<u64>>(s, 0)
-    │                 ------ Is not compatible with: '0x8675309::N::R<u64>'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/translated_ir_tests/move/signer/move_to_non_struct.move:13:9
+   │
+13 │         move_to<R<u64>>(s, 0)
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │         │       │          │
+   │         │       │          Given: integer
+   │         │       Expected: '0x8675309::N::R<u64>'
+   │         Invalid call of 'move_to'. Invalid argument for parameter '1'
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/signer/move_to_reference_to_args_flipped.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/signer/move_to_reference_to_args_flipped.exp
@@ -1,56 +1,42 @@
-error: 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/translated_ir_tests/move/signer/move_to_reference_to_args_flipped.move:4:9
+  │
+4 │         move_to<R>(R { f: false }, s)
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │         │          │
+  │         │          Given: '0x8675309::M::R'
+  │         Invalid call of 'move_to'. Invalid argument for parameter '0'
+  │         Expected: '&signer'
 
-   ┌── tests/move_check/translated_ir_tests/move/signer/move_to_reference_to_args_flipped.move:4:9 ───
+error[E04007]: incompatible types
+  ┌─ tests/move_check/translated_ir_tests/move/signer/move_to_reference_to_args_flipped.move:4:9
+  │
+3 │     fun t0(s: &signer) {
+  │               ------- Given: '&signer'
+4 │         move_to<R>(R { f: false }, s)
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │         │       │
+  │         │       Expected: '0x8675309::M::R'
+  │         Invalid call of 'move_to'. Invalid argument for parameter '1'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/translated_ir_tests/move/signer/move_to_reference_to_args_flipped.move:14:9
    │
- 4 │         move_to<R>(R { f: false }, s)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_to'. Invalid argument for parameter '0'
-   ·
- 4 │         move_to<R>(R { f: false }, s)
-   │                    -------------- The type: '0x8675309::M::R'
-   ·
- 4 │         move_to<R>(R { f: false }, s)
-   │         ------- Is not compatible with: '&signer'
+14 │         move_to<R<bool>>(R { f: false }, s);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │                │
+   │         │                Given: '0x8675309::N::R<bool>'
+   │         Invalid call of 'move_to'. Invalid argument for parameter '0'
+   │         Expected: '&signer'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/translated_ir_tests/move/signer/move_to_reference_to_args_flipped.move:14:9
    │
-
-error: 
-
-   ┌── tests/move_check/translated_ir_tests/move/signer/move_to_reference_to_args_flipped.move:4:9 ───
-   │
- 4 │         move_to<R>(R { f: false }, s)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_to'. Invalid argument for parameter '1'
-   ·
- 3 │     fun t0(s: &signer) {
-   │               ------- The type: '&signer'
-   ·
- 4 │         move_to<R>(R { f: false }, s)
-   │                 - Is not compatible with: '0x8675309::M::R'
-   │
-
-error: 
-
-    ┌── tests/move_check/translated_ir_tests/move/signer/move_to_reference_to_args_flipped.move:14:9 ───
-    │
- 14 │         move_to<R<bool>>(R { f: false }, s);
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_to'. Invalid argument for parameter '0'
-    ·
- 14 │         move_to<R<bool>>(R { f: false }, s);
-    │                          -------------- The type: '0x8675309::N::R<bool>'
-    ·
- 14 │         move_to<R<bool>>(R { f: false }, s);
-    │         ------- Is not compatible with: '&signer'
-    │
-
-error: 
-
-    ┌── tests/move_check/translated_ir_tests/move/signer/move_to_reference_to_args_flipped.move:14:9 ───
-    │
- 14 │         move_to<R<bool>>(R { f: false }, s);
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_to'. Invalid argument for parameter '1'
-    ·
- 13 │     fun t0<T>(s: &signer) {
-    │                  ------- The type: '&signer'
-    ·
- 14 │         move_to<R<bool>>(R { f: false }, s);
-    │                 ------- Is not compatible with: '0x8675309::N::R<bool>'
-    │
+13 │     fun t0<T>(s: &signer) {
+   │                  ------- Given: '&signer'
+14 │         move_to<R<bool>>(R { f: false }, s);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │       │
+   │         │       Expected: '0x8675309::N::R<bool>'
+   │         Invalid call of 'move_to'. Invalid argument for parameter '1'
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/signer/move_to_reference_to_resource.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/signer/move_to_reference_to_resource.exp
@@ -1,28 +1,22 @@
-error: 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/translated_ir_tests/move/signer/move_to_reference_to_resource.move:4:9
+  │
+3 │     fun t0(s: &signer, r: &R) {
+  │                           -- Given: '&0x8675309::M::R'
+4 │         move_to<R>(s, move r)
+  │         ^^^^^^^^^^^^^^^^^^^^^
+  │         │       │
+  │         │       Expected: '0x8675309::M::R'
+  │         Invalid call of 'move_to'. Invalid argument for parameter '1'
 
-   ┌── tests/move_check/translated_ir_tests/move/signer/move_to_reference_to_resource.move:4:9 ───
+error[E04007]: incompatible types
+   ┌─ tests/move_check/translated_ir_tests/move/signer/move_to_reference_to_resource.move:14:9
    │
- 4 │         move_to<R>(s, move r)
-   │         ^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_to'. Invalid argument for parameter '1'
-   ·
- 3 │     fun t0(s: &signer, r: &R) {
-   │                           -- The type: '&0x8675309::M::R'
-   ·
- 4 │         move_to<R>(s, move r)
-   │                 - Is not compatible with: '0x8675309::M::R'
-   │
-
-error: 
-
-    ┌── tests/move_check/translated_ir_tests/move/signer/move_to_reference_to_resource.move:14:9 ───
-    │
- 14 │         move_to<R<bool>>(s, move r)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_to'. Invalid argument for parameter '1'
-    ·
- 13 │     fun t0(s: &signer, r: &mut R<bool>) {
-    │                           ------------ The type: '&mut 0x8675309::N::R<bool>'
-    ·
- 14 │         move_to<R<bool>>(s, move r)
-    │                 ------- Is not compatible with: '0x8675309::N::R<bool>'
-    │
+13 │     fun t0(s: &signer, r: &mut R<bool>) {
+   │                           ------------ Given: '&mut 0x8675309::N::R<bool>'
+14 │         move_to<R<bool>>(s, move r)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │       │
+   │         │       Expected: '0x8675309::N::R<bool>'
+   │         Invalid call of 'move_to'. Invalid argument for parameter '1'
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/signer/move_to_reference_to_wrong_resource.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/signer/move_to_reference_to_wrong_resource.exp
@@ -1,28 +1,20 @@
-error: 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/translated_ir_tests/move/signer/move_to_reference_to_wrong_resource.move:5:9
+  │
+5 │         move_to<R>(s, X { f: false })
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │         │       │     │
+  │         │       │     Given: '0x8675309::M::X'
+  │         │       Expected: '0x8675309::M::R'
+  │         Invalid call of 'move_to'. Invalid argument for parameter '1'
 
-   ┌── tests/move_check/translated_ir_tests/move/signer/move_to_reference_to_wrong_resource.move:5:9 ───
+error[E04007]: incompatible types
+   ┌─ tests/move_check/translated_ir_tests/move/signer/move_to_reference_to_wrong_resource.move:16:14
    │
- 5 │         move_to<R>(s, X { f: false })
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_to'. Invalid argument for parameter '1'
-   ·
- 5 │         move_to<R>(s, X { f: false })
-   │                       -------------- The type: '0x8675309::M::X'
-   ·
- 5 │         move_to<R>(s, X { f: false })
-   │                 - Is not compatible with: '0x8675309::M::R'
-   │
-
-error: 
-
-    ┌── tests/move_check/translated_ir_tests/move/signer/move_to_reference_to_wrong_resource.move:16:14 ───
-    │
- 16 │         () = move_to<X<bool>>(s, R { f: false })
-    │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_to'. Invalid argument for parameter '1'
-    ·
- 16 │         () = move_to<X<bool>>(s, R { f: false })
-    │                                  -------------- The type: '0x8675309::N::R<bool>'
-    ·
- 16 │         () = move_to<X<bool>>(s, R { f: false })
-    │                      ------- Is not compatible with: '0x8675309::N::X<bool>'
-    │
+16 │         () = move_to<X<bool>>(s, R { f: false })
+   │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │              │       │           │
+   │              │       │           Given: '0x8675309::N::R<bool>'
+   │              │       Expected: '0x8675309::N::X<bool>'
+   │              Invalid call of 'move_to'. Invalid argument for parameter '1'
 

--- a/language/move-lang/tests/move_check/typing/assign_unpack_references_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/assign_unpack_references_invalid.exp
@@ -1,84 +1,65 @@
-error: 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/assign_unpack_references_invalid.move:9:9
+  │
+8 │         R { s1: S { f }, s2 } = &R { s1: S{f: 0}, s2: S{f: 1} };
+  │                     - Expected: '&u64'
+9 │         f = 0;
+  │         ^
+  │         │
+  │         Invalid assignment to local 'f'
+  │         Given: integer
 
-   ┌── tests/move_check/typing/assign_unpack_references_invalid.move:9:9 ───
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/assign_unpack_references_invalid.move:10:9
    │
- 9 │         f = 0;
-   │         ^ Invalid assignment to local 'f'
-   ·
- 9 │         f = 0;
-   │         - The type: integer
-   ·
  8 │         R { s1: S { f }, s2 } = &R { s1: S{f: 0}, s2: S{f: 1} };
-   │                     - Is not compatible with: '&u64'
+   │                          -- Expected: '&0x8675309::M::S'
+ 9 │         f = 0;
+10 │         s2 = S { f: 0 }
+   │         ^^   ---------- Given: '0x8675309::M::S'
+   │         │     
+   │         Invalid assignment to local 's2'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/assign_unpack_references_invalid.move:17:9
    │
+16 │         R { s1: S { f }, s2 } = &mut R { s1: S{f: 0}, s2: S{f: 1} };
+   │                     - Expected: '&mut u64'
+17 │         f = 0;
+   │         ^
+   │         │
+   │         Invalid assignment to local 'f'
+   │         Given: integer
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/assign_unpack_references_invalid.move:18:9
+   │
+16 │         R { s1: S { f }, s2 } = &mut R { s1: S{f: 0}, s2: S{f: 1} };
+   │                          -- Expected: '&mut 0x8675309::M::S'
+17 │         f = 0;
+18 │         s2 = S { f: 0 }
+   │         ^^   ---------- Given: '0x8675309::M::S'
+   │         │     
+   │         Invalid assignment to local 's2'
 
-    ┌── tests/move_check/typing/assign_unpack_references_invalid.move:10:9 ───
-    │
- 10 │         s2 = S { f: 0 }
-    │         ^^ Invalid assignment to local 's2'
-    ·
- 10 │         s2 = S { f: 0 }
-    │              ---------- The type: '0x8675309::M::S'
-    ·
-  8 │         R { s1: S { f }, s2 } = &R { s1: S{f: 0}, s2: S{f: 1} };
-    │                          -- Is not compatible with: '&0x8675309::M::S'
-    │
+error[E04006]: invalid subtype
+   ┌─ tests/move_check/typing/assign_unpack_references_invalid.move:26:9
+   │
+25 │         R { s1: S { f }, s2 } = &mut R { s1: S{f: 0}, s2: S{f: 1} };
+   │                     - Expected: '&mut u64'
+26 │         f = &0;
+   │         ^   -- Given: '&{integer}'
+   │         │    
+   │         Invalid assignment to local 'f'
 
-error: 
-
-    ┌── tests/move_check/typing/assign_unpack_references_invalid.move:17:9 ───
-    │
- 17 │         f = 0;
-    │         ^ Invalid assignment to local 'f'
-    ·
- 17 │         f = 0;
-    │         - The type: integer
-    ·
- 16 │         R { s1: S { f }, s2 } = &mut R { s1: S{f: 0}, s2: S{f: 1} };
-    │                     - Is not compatible with: '&mut u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/assign_unpack_references_invalid.move:18:9 ───
-    │
- 18 │         s2 = S { f: 0 }
-    │         ^^ Invalid assignment to local 's2'
-    ·
- 18 │         s2 = S { f: 0 }
-    │              ---------- The type: '0x8675309::M::S'
-    ·
- 16 │         R { s1: S { f }, s2 } = &mut R { s1: S{f: 0}, s2: S{f: 1} };
-    │                          -- Is not compatible with: '&mut 0x8675309::M::S'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/assign_unpack_references_invalid.move:26:9 ───
-    │
- 26 │         f = &0;
-    │         ^ Invalid assignment to local 'f'
-    ·
- 26 │         f = &0;
-    │             -- The type: '&{integer}'
-    ·
- 25 │         R { s1: S { f }, s2 } = &mut R { s1: S{f: 0}, s2: S{f: 1} };
-    │                     - Is not a subtype of: '&mut u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/assign_unpack_references_invalid.move:27:9 ───
-    │
- 27 │         s2 = &S { f: 0 }
-    │         ^^ Invalid assignment to local 's2'
-    ·
- 27 │         s2 = &S { f: 0 }
-    │              ----------- The type: '&0x8675309::M::S'
-    ·
- 25 │         R { s1: S { f }, s2 } = &mut R { s1: S{f: 0}, s2: S{f: 1} };
-    │                          -- Is not a subtype of: '&mut 0x8675309::M::S'
-    │
+error[E04006]: invalid subtype
+   ┌─ tests/move_check/typing/assign_unpack_references_invalid.move:27:9
+   │
+25 │         R { s1: S { f }, s2 } = &mut R { s1: S{f: 0}, s2: S{f: 1} };
+   │                          -- Expected: '&mut 0x8675309::M::S'
+26 │         f = &0;
+27 │         s2 = &S { f: 0 }
+   │         ^^   ----------- Given: '&0x8675309::M::S'
+   │         │     
+   │         Invalid assignment to local 's2'
 

--- a/language/move-lang/tests/move_check/typing/assign_wrong_arity.exp
+++ b/language/move-lang/tests/move_check/typing/assign_wrong_arity.exp
@@ -14,6 +14,16 @@ error[E04005]: expected a single type
   │         │    
   │         Invalid type for local
 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/assign_wrong_arity.move:7:9
+  │
+6 │         x = ();
+  │             -- Expected: '()'
+7 │         x = (0, 1, 2);
+  │         ^   --------- Given: '({integer}, {integer}, {integer})'
+  │         │    
+  │         Invalid assignment to local 'x'
+
 error[E04005]: expected a single type
   ┌─ tests/move_check/typing/assign_wrong_arity.move:7:9
   │
@@ -22,59 +32,30 @@ error[E04005]: expected a single type
   │         │    
   │         Invalid type for local
 
-error: 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/assign_wrong_arity.move:8:9
+  │
+8 │         () = 0;
+  │         ^^   - Given: integer
+  │         │     
+  │         Invalid value for assignment
+  │         Expected: '()'
 
-   ┌── tests/move_check/typing/assign_wrong_arity.move:7:9 ───
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/assign_wrong_arity.move:11:9
    │
- 7 │         x = (0, 1, 2);
-   │         ^ Invalid assignment to local 'x'
-   ·
- 7 │         x = (0, 1, 2);
-   │             --------- The type: '({integer}, {integer}, {integer})'
-   ·
- 6 │         x = ();
-   │             -- Is not compatible with: '()'
+11 │         (x, b, R{f}) = (0, false, R{f: 0}, R{f: 0});
+   │         ^^^^^^^^^^^^   ---------------------------- Given expression list of length 4: '({integer}, bool, 0x8675309::M::R, 0x8675309::M::R)'
+   │         │               
+   │         Invalid value for assignment
+   │         Expected expression list of length 3: '(_, _, _)'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/assign_wrong_arity.move:12:9
    │
-
-error: 
-
-   ┌── tests/move_check/typing/assign_wrong_arity.move:8:9 ───
-   │
- 8 │         () = 0;
-   │         ^^ Invalid value for assignment
-   ·
- 8 │         () = 0;
-   │              - The type: integer
-   ·
- 8 │         () = 0;
-   │         -- Is not compatible with: '()'
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/assign_wrong_arity.move:11:9 ───
-    │
- 11 │         (x, b, R{f}) = (0, false, R{f: 0}, R{f: 0});
-    │         ^^^^^^^^^^^^ Invalid value for assignment
-    ·
- 11 │         (x, b, R{f}) = (0, false, R{f: 0}, R{f: 0});
-    │         ------------ The expression list type of length 3: '(_, _, _)'
-    ·
- 11 │         (x, b, R{f}) = (0, false, R{f: 0}, R{f: 0});
-    │                        ---------------------------- Is not compatible with the expression list type of length 4: '({integer}, bool, 0x8675309::M::R, 0x8675309::M::R)'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/assign_wrong_arity.move:12:9 ───
-    │
- 12 │         (x, b, R{f}) = (0, false);
-    │         ^^^^^^^^^^^^ Invalid value for assignment
-    ·
- 12 │         (x, b, R{f}) = (0, false);
-    │         ------------ The expression list type of length 3: '(_, _, _)'
-    ·
- 12 │         (x, b, R{f}) = (0, false);
-    │                        ---------- Is not compatible with the expression list type of length 2: '({integer}, bool)'
-    │
+12 │         (x, b, R{f}) = (0, false);
+   │         ^^^^^^^^^^^^   ---------- Given expression list of length 2: '({integer}, bool)'
+   │         │               
+   │         Invalid value for assignment
+   │         Expected expression list of length 3: '(_, _, _)'
 

--- a/language/move-lang/tests/move_check/typing/assign_wrong_type.exp
+++ b/language/move-lang/tests/move_check/typing/assign_wrong_type.exp
@@ -1,3 +1,21 @@
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/assign_wrong_type.move:8:9
+  │
+8 │         S { g } = R {f :0};
+  │         ^^^^^^^   -------- Expected: '0x8675309::M::R'
+  │         │          
+  │         Invalid deconstruction assignment
+  │         Given: '0x8675309::M::S'
+
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/assign_wrong_type.move:9:10
+  │
+9 │         (S { g }, R { f }) = (R{ f: 0 }, R{ f: 1 });
+  │          ^^^^^^^              --------- Expected: '0x8675309::M::R'
+  │          │                     
+  │          Invalid deconstruction assignment
+  │          Given: '0x8675309::M::S'
+
 error[E04005]: expected a single type
    ┌─ tests/move_check/typing/assign_wrong_type.move:13:13
    │
@@ -15,129 +33,75 @@ error[E04005]: expected a single type
    │         │    
    │         Invalid type for local
 
-error: 
-
-   ┌── tests/move_check/typing/assign_wrong_type.move:8:9 ───
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/assign_wrong_type.move:17:9
    │
- 8 │         S { g } = R {f :0};
-   │         ^^^^^^^ Invalid deconstruction assignment
-   ·
- 8 │         S { g } = R {f :0};
-   │         ------- The type: '0x8675309::M::S'
-   ·
- 8 │         S { g } = R {f :0};
-   │                   -------- Is not compatible with: '0x8675309::M::R'
+17 │         () = 0;
+   │         ^^   - Given: integer
+   │         │     
+   │         Invalid value for assignment
+   │         Expected: '()'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/assign_wrong_type.move:18:9
    │
+18 │         (x, b, R{f}) = (0, false, R{f: 0}, R{f: 0});
+   │         ^^^^^^^^^^^^   ---------------------------- Given expression list of length 4: '({integer}, bool, 0x8675309::M::R, 0x8675309::M::R)'
+   │         │               
+   │         Invalid value for assignment
+   │         Expected expression list of length 3: '(_, _, _)'
 
-error: 
-
-   ┌── tests/move_check/typing/assign_wrong_type.move:9:10 ───
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/assign_wrong_type.move:19:9
    │
- 9 │         (S { g }, R { f }) = (R{ f: 0 }, R{ f: 1 });
-   │          ^^^^^^^ Invalid deconstruction assignment
-   ·
- 9 │         (S { g }, R { f }) = (R{ f: 0 }, R{ f: 1 });
-   │          ------- The type: '0x8675309::M::S'
-   ·
- 9 │         (S { g }, R { f }) = (R{ f: 0 }, R{ f: 1 });
-   │                               --------- Is not compatible with: '0x8675309::M::R'
+19 │         (x, b, R{f}) = (0, false);
+   │         ^^^^^^^^^^^^   ---------- Given expression list of length 2: '({integer}, bool)'
+   │         │               
+   │         Invalid value for assignment
+   │         Expected expression list of length 3: '(_, _, _)'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/assign_wrong_type.move:27:10
    │
+23 │         let x = false;
+   │                 ----- Expected: 'bool'
+   ·
+27 │         (x, b, R{f}, r) = (0, false, R{f: 0}, R{f: 0});
+   │          ^
+   │          │
+   │          Invalid assignment to local 'x'
+   │          Given: integer
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/assign_wrong_type.move:27:13
+   │
+24 │         let b = 0;
+   │             - Expected: integer
+   ·
+27 │         (x, b, R{f}, r) = (0, false, R{f: 0}, R{f: 0});
+   │             ^                 ----- Given: 'bool'
+   │             │                  
+   │             Invalid assignment to local 'b'
 
-    ┌── tests/move_check/typing/assign_wrong_type.move:17:9 ───
-    │
- 17 │         () = 0;
-    │         ^^ Invalid value for assignment
-    ·
- 17 │         () = 0;
-    │              - The type: integer
-    ·
- 17 │         () = 0;
-    │         -- Is not compatible with: '()'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/assign_wrong_type.move:27:18
+   │
+ 2 │     struct R {f: u64}
+   │                  --- Given: 'u64'
+   ·
+25 │         let f = @0x0;
+   │                 ---- Expected: 'address'
+26 │         let r = S{ g: 0 };
+27 │         (x, b, R{f}, r) = (0, false, R{f: 0}, R{f: 0});
+   │                  ^ Invalid assignment to local 'f'
 
-error: 
-
-    ┌── tests/move_check/typing/assign_wrong_type.move:18:9 ───
-    │
- 18 │         (x, b, R{f}) = (0, false, R{f: 0}, R{f: 0});
-    │         ^^^^^^^^^^^^ Invalid value for assignment
-    ·
- 18 │         (x, b, R{f}) = (0, false, R{f: 0}, R{f: 0});
-    │         ------------ The expression list type of length 3: '(_, _, _)'
-    ·
- 18 │         (x, b, R{f}) = (0, false, R{f: 0}, R{f: 0});
-    │                        ---------------------------- Is not compatible with the expression list type of length 4: '({integer}, bool, 0x8675309::M::R, 0x8675309::M::R)'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/assign_wrong_type.move:19:9 ───
-    │
- 19 │         (x, b, R{f}) = (0, false);
-    │         ^^^^^^^^^^^^ Invalid value for assignment
-    ·
- 19 │         (x, b, R{f}) = (0, false);
-    │         ------------ The expression list type of length 3: '(_, _, _)'
-    ·
- 19 │         (x, b, R{f}) = (0, false);
-    │                        ---------- Is not compatible with the expression list type of length 2: '({integer}, bool)'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/assign_wrong_type.move:27:10 ───
-    │
- 27 │         (x, b, R{f}, r) = (0, false, R{f: 0}, R{f: 0});
-    │          ^ Invalid assignment to local 'x'
-    ·
- 27 │         (x, b, R{f}, r) = (0, false, R{f: 0}, R{f: 0});
-    │          - The type: integer
-    ·
- 23 │         let x = false;
-    │                 ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/assign_wrong_type.move:27:13 ───
-    │
- 27 │         (x, b, R{f}, r) = (0, false, R{f: 0}, R{f: 0});
-    │             ^ Invalid assignment to local 'b'
-    ·
- 24 │         let b = 0;
-    │             - The type: integer
-    ·
- 27 │         (x, b, R{f}, r) = (0, false, R{f: 0}, R{f: 0});
-    │                               ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/assign_wrong_type.move:27:18 ───
-    │
- 27 │         (x, b, R{f}, r) = (0, false, R{f: 0}, R{f: 0});
-    │                  ^ Invalid assignment to local 'f'
-    ·
-  2 │     struct R {f: u64}
-    │                  --- The type: 'u64'
-    ·
- 25 │         let f = @0x0;
-    │                 ---- Is not compatible with: 'address'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/assign_wrong_type.move:27:22 ───
-    │
- 27 │         (x, b, R{f}, r) = (0, false, R{f: 0}, R{f: 0});
-    │                      ^ Invalid assignment to local 'r'
-    ·
- 27 │         (x, b, R{f}, r) = (0, false, R{f: 0}, R{f: 0});
-    │                                               ------- The type: '0x8675309::M::R'
-    ·
- 26 │         let r = S{ g: 0 };
-    │                 --------- Is not compatible with: '0x8675309::M::S'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/assign_wrong_type.move:27:22
+   │
+26 │         let r = S{ g: 0 };
+   │                 --------- Expected: '0x8675309::M::S'
+27 │         (x, b, R{f}, r) = (0, false, R{f: 0}, R{f: 0});
+   │                      ^                        ------- Given: '0x8675309::M::R'
+   │                      │                         
+   │                      Invalid assignment to local 'r'
 

--- a/language/move-lang/tests/move_check/typing/binary_add_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_add_invalid.exp
@@ -15,6 +15,15 @@ error[E04003]: built-in operation not supported
   │         │        
   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/binary_add_invalid.move:9:11
+  │
+9 │         1 + false;
+  │         - ^ ----- Found: 'bool'. It is not compatible with the other type.
+  │         │ │  
+  │         │ Incompatible arguments to '+'
+  │         Found: integer. It is not compatible with the other type.
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_add_invalid.move:10:9
    │
@@ -23,6 +32,15 @@ error[E04003]: built-in operation not supported
    │         │
    │         Invalid argument to '+'
    │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_add_invalid.move:10:15
+   │
+10 │         false + 1;
+   │         ----- ^ - Found: integer. It is not compatible with the other type.
+   │         │     │  
+   │         │     Incompatible arguments to '+'
+   │         Found: 'bool'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_add_invalid.move:10:17
@@ -48,6 +66,15 @@ error[E04003]: built-in operation not supported
    │         ----   ^^^^ Invalid argument to '+'
    │         │       
    │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_add_invalid.move:12:17
+   │
+12 │         (0: u8) + (1: u128);
+   │             --  ^     ---- Found: 'u128'. It is not compatible with the other type.
+   │             │   │      
+   │             │   Incompatible arguments to '+'
+   │             Found: 'u8'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_add_invalid.move:13:9
@@ -102,8 +129,8 @@ error[E04003]: built-in operation not supported
    │
 15 │         1 + false + @0x0 + 0;
    │         ^^^^^^^^^
-   │         │   │
-   │         │   Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         │ │
+   │         │ Found: '_'. But expected: 'u8', 'u64', 'u128'
    │         Invalid argument to '+'
 
 error[E04003]: built-in operation not supported
@@ -115,13 +142,31 @@ error[E04003]: built-in operation not supported
    │         │           Found: 'address'. But expected: 'u8', 'u64', 'u128'
    │         Invalid argument to '+'
 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_add_invalid.move:15:11
+   │
+15 │         1 + false + @0x0 + 0;
+   │         - ^ ----- Found: 'bool'. It is not compatible with the other type.
+   │         │ │  
+   │         │ Incompatible arguments to '+'
+   │         Found: integer. It is not compatible with the other type.
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_add_invalid.move:15:21
    │
 15 │         1 + false + @0x0 + 0;
-   │             -----   ^^^^ Invalid argument to '+'
-   │             │        
-   │             Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │           -         ^^^^ Invalid argument to '+'
+   │           │          
+   │           Found: '_'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_add_invalid.move:15:26
+   │
+15 │         1 + false + @0x0 + 0;
+   │                     ---- ^ - Found: integer. It is not compatible with the other type.
+   │                     │    │  
+   │                     │    Incompatible arguments to '+'
+   │                     Found: 'address'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_add_invalid.move:15:28
@@ -148,6 +193,15 @@ error[E04003]: built-in operation not supported
    │         │     
    │         Found: '()'. But expected: 'u8', 'u64', 'u128'
 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_add_invalid.move:17:11
+   │
+17 │         1 + ();
+   │         - ^ -- Found: '()'. It is not compatible with the other type.
+   │         │ │  
+   │         │ Incompatible arguments to '+'
+   │         Found: integer. It is not compatible with the other type.
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_add_invalid.move:18:9
    │
@@ -156,6 +210,15 @@ error[E04003]: built-in operation not supported
    │         │
    │         Invalid argument to '+'
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_add_invalid.move:18:16
+   │
+18 │         (0, 1) + (0, 1, 2);
+   │         ------ ^ --------- Found expression list of length 3: '({integer}, {integer}, {integer})'. It is not compatible with the other type of length 2.
+   │         │      │  
+   │         │      Incompatible arguments to '+'
+   │         Found expression list of length 2: '({integer}, {integer})'. It is not compatible with the other type of length 3.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_add_invalid.move:18:18
@@ -181,102 +244,4 @@ error[E04003]: built-in operation not supported
    │         ------   ^^^^^^ Invalid argument to '+'
    │         │         
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-
-error: 
-
-   ┌── tests/move_check/typing/binary_add_invalid.move:9:13 ───
-   │
- 9 │         1 + false;
-   │             ^^^^^ Incompatible arguments to '+'
-   ·
- 9 │         1 + false;
-   │         - The type: integer
-   ·
- 9 │         1 + false;
-   │             ----- Is not compatible with: 'bool'
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_add_invalid.move:10:17 ───
-    │
- 10 │         false + 1;
-    │                 ^ Incompatible arguments to '+'
-    ·
- 10 │         false + 1;
-    │                 - The type: integer
-    ·
- 10 │         false + 1;
-    │         ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_add_invalid.move:12:19 ───
-    │
- 12 │         (0: u8) + (1: u128);
-    │                   ^^^^^^^^^ Incompatible arguments to '+'
-    ·
- 12 │         (0: u8) + (1: u128);
-    │             -- The type: 'u8'
-    ·
- 12 │         (0: u8) + (1: u128);
-    │                       ---- Is not compatible with: 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_add_invalid.move:15:13 ───
-    │
- 15 │         1 + false + @0x0 + 0;
-    │             ^^^^^ Incompatible arguments to '+'
-    ·
- 15 │         1 + false + @0x0 + 0;
-    │         - The type: integer
-    ·
- 15 │         1 + false + @0x0 + 0;
-    │             ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_add_invalid.move:15:28 ───
-    │
- 15 │         1 + false + @0x0 + 0;
-    │                            ^ Incompatible arguments to '+'
-    ·
- 15 │         1 + false + @0x0 + 0;
-    │                            - The type: integer
-    ·
- 15 │         1 + false + @0x0 + 0;
-    │                     ---- Is not compatible with: 'address'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_add_invalid.move:17:13 ───
-    │
- 17 │         1 + ();
-    │             ^^ Incompatible arguments to '+'
-    ·
- 17 │         1 + ();
-    │         - The type: integer
-    ·
- 17 │         1 + ();
-    │             -- Is not compatible with: '()'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_add_invalid.move:18:18 ───
-    │
- 18 │         (0, 1) + (0, 1, 2);
-    │                  ^^^^^^^^^ Incompatible arguments to '+'
-    ·
- 18 │         (0, 1) + (0, 1, 2);
-    │         ------ The expression list type of length 2: '({integer}, {integer})'
-    ·
- 18 │         (0, 1) + (0, 1, 2);
-    │                  --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
-    │
 

--- a/language/move-lang/tests/move_check/typing/binary_and_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_and_invalid.exp
@@ -1,266 +1,187 @@
-error: 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/binary_and_invalid.move:8:9
+  │
+8 │         0 && 1;
+  │         ^ -- Expected: 'bool'
+  │         │  
+  │         Invalid argument to '&&'
+  │         Given: integer
 
-   ┌── tests/move_check/typing/binary_and_invalid.move:8:9 ───
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/binary_and_invalid.move:8:14
+  │
+8 │         0 && 1;
+  │           -- ^
+  │           │  │
+  │           │  Invalid argument to '&&'
+  │           │  Given: integer
+  │           Expected: 'bool'
+
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/binary_and_invalid.move:9:9
+  │
+9 │         1 && false;
+  │         ^ -- Expected: 'bool'
+  │         │  
+  │         Invalid argument to '&&'
+  │         Given: integer
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_and_invalid.move:10:18
    │
- 8 │         0 && 1;
-   │         ^ Incompatible arguments to '&&'
-   ·
- 8 │         0 && 1;
-   │         - The type: integer
-   ·
- 8 │         0 && 1;
-   │         - Is not compatible with: 'bool'
+10 │         false && 1;
+   │               -- ^
+   │               │  │
+   │               │  Invalid argument to '&&'
+   │               │  Given: integer
+   │               Expected: 'bool'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_and_invalid.move:11:9
    │
+11 │         @0x0 && @0x1;
+   │         ^^^^ -- Expected: 'bool'
+   │         │     
+   │         Invalid argument to '&&'
+   │         Given: 'address'
 
-error: 
-
-   ┌── tests/move_check/typing/binary_and_invalid.move:8:14 ───
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_and_invalid.move:11:17
    │
- 8 │         0 && 1;
-   │              ^ Incompatible arguments to '&&'
-   ·
- 8 │         0 && 1;
-   │              - The type: integer
-   ·
- 8 │         0 && 1;
-   │         - Is not compatible with: 'bool'
+11 │         @0x0 && @0x1;
+   │              -- ^^^^
+   │              │  │
+   │              │  Invalid argument to '&&'
+   │              │  Given: 'address'
+   │              Expected: 'bool'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_and_invalid.move:12:9
    │
+12 │         (0: u8) && (1: u128);
+   │         ^^^^^^^ -- Expected: 'bool'
+   │         │   │    
+   │         │   Given: 'u8'
+   │         Invalid argument to '&&'
 
-error: 
-
-   ┌── tests/move_check/typing/binary_and_invalid.move:9:9 ───
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_and_invalid.move:12:20
    │
- 9 │         1 && false;
-   │         ^ Incompatible arguments to '&&'
-   ·
- 9 │         1 && false;
-   │         - The type: integer
-   ·
- 9 │         1 && false;
-   │         - Is not compatible with: 'bool'
+12 │         (0: u8) && (1: u128);
+   │                 -- ^^^^^^^^^
+   │                 │  │   │
+   │                 │  │   Given: 'u128'
+   │                 │  Invalid argument to '&&'
+   │                 Expected: 'bool'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_and_invalid.move:13:9
    │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Given: '0x8675309::M::R'
+   ·
+13 │         r && r;
+   │         ^ -- Expected: 'bool'
+   │         │  
+   │         Invalid argument to '&&'
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_and_invalid.move:13:14
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Given: '0x8675309::M::R'
+   ·
+13 │         r && r;
+   │           -- ^ Invalid argument to '&&'
+   │           │   
+   │           Expected: 'bool'
 
-    ┌── tests/move_check/typing/binary_and_invalid.move:10:18 ───
-    │
- 10 │         false && 1;
-    │                  ^ Incompatible arguments to '&&'
-    ·
- 10 │         false && 1;
-    │                  - The type: integer
-    ·
- 10 │         false && 1;
-    │         ----- Is not compatible with: 'bool'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_and_invalid.move:14:9
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Given: '0x8675309::M::S'
+   ·
+14 │         s && s;
+   │         ^ -- Expected: 'bool'
+   │         │  
+   │         Invalid argument to '&&'
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_and_invalid.move:14:14
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Given: '0x8675309::M::S'
+   ·
+14 │         s && s;
+   │           -- ^ Invalid argument to '&&'
+   │           │   
+   │           Expected: 'bool'
 
-    ┌── tests/move_check/typing/binary_and_invalid.move:11:9 ───
-    │
- 11 │         @0x0 && @0x1;
-    │         ^^^^ Incompatible arguments to '&&'
-    ·
- 11 │         @0x0 && @0x1;
-    │         ---- The type: 'address'
-    ·
- 11 │         @0x0 && @0x1;
-    │         ---- Is not compatible with: 'bool'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_and_invalid.move:15:9
+   │
+15 │         () && ();
+   │         ^^ -- Expected: 'bool'
+   │         │   
+   │         Invalid argument to '&&'
+   │         Given: '()'
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_and_invalid.move:15:15
+   │
+15 │         () && ();
+   │            -- ^^
+   │            │  │
+   │            │  Invalid argument to '&&'
+   │            │  Given: '()'
+   │            Expected: 'bool'
 
-    ┌── tests/move_check/typing/binary_and_invalid.move:11:17 ───
-    │
- 11 │         @0x0 && @0x1;
-    │                 ^^^^ Incompatible arguments to '&&'
-    ·
- 11 │         @0x0 && @0x1;
-    │                 ---- The type: 'address'
-    ·
- 11 │         @0x0 && @0x1;
-    │         ---- Is not compatible with: 'bool'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_and_invalid.move:16:17
+   │
+16 │         true && ();
+   │              -- ^^
+   │              │  │
+   │              │  Invalid argument to '&&'
+   │              │  Given: '()'
+   │              Expected: 'bool'
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_and_invalid.move:17:9
+   │
+17 │         (true, false) && (true, false, true);
+   │         ^^^^^^^^^^^^^ -- Expected: 'bool'
+   │         │              
+   │         Invalid argument to '&&'
+   │         Given: '(bool, bool)'
 
-    ┌── tests/move_check/typing/binary_and_invalid.move:12:9 ───
-    │
- 12 │         (0: u8) && (1: u128);
-    │         ^^^^^^^ Incompatible arguments to '&&'
-    ·
- 12 │         (0: u8) && (1: u128);
-    │             -- The type: 'u8'
-    ·
- 12 │         (0: u8) && (1: u128);
-    │         ------- Is not compatible with: 'bool'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_and_invalid.move:17:26
+   │
+17 │         (true, false) && (true, false, true);
+   │                       -- ^^^^^^^^^^^^^^^^^^^
+   │                       │  │
+   │                       │  Invalid argument to '&&'
+   │                       │  Given: '(bool, bool, bool)'
+   │                       Expected: 'bool'
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_and_invalid.move:18:9
+   │
+18 │         (true, true) && (false, false);
+   │         ^^^^^^^^^^^^ -- Expected: 'bool'
+   │         │             
+   │         Invalid argument to '&&'
+   │         Given: '(bool, bool)'
 
-    ┌── tests/move_check/typing/binary_and_invalid.move:12:20 ───
-    │
- 12 │         (0: u8) && (1: u128);
-    │                    ^^^^^^^^^ Incompatible arguments to '&&'
-    ·
- 12 │         (0: u8) && (1: u128);
-    │                        ---- The type: 'u128'
-    ·
- 12 │         (0: u8) && (1: u128);
-    │         ------- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_and_invalid.move:13:9 ───
-    │
- 13 │         r && r;
-    │         ^ Incompatible arguments to '&&'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - The type: '0x8675309::M::R'
-    ·
- 13 │         r && r;
-    │         - Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_and_invalid.move:13:14 ───
-    │
- 13 │         r && r;
-    │              ^ Incompatible arguments to '&&'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - The type: '0x8675309::M::R'
-    ·
- 13 │         r && r;
-    │         - Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_and_invalid.move:14:9 ───
-    │
- 14 │         s && s;
-    │         ^ Incompatible arguments to '&&'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - The type: '0x8675309::M::S'
-    ·
- 14 │         s && s;
-    │         - Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_and_invalid.move:14:14 ───
-    │
- 14 │         s && s;
-    │              ^ Incompatible arguments to '&&'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - The type: '0x8675309::M::S'
-    ·
- 14 │         s && s;
-    │         - Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_and_invalid.move:15:9 ───
-    │
- 15 │         () && ();
-    │         ^^ Incompatible arguments to '&&'
-    ·
- 15 │         () && ();
-    │         -- The type: '()'
-    ·
- 15 │         () && ();
-    │         -- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_and_invalid.move:15:15 ───
-    │
- 15 │         () && ();
-    │               ^^ Incompatible arguments to '&&'
-    ·
- 15 │         () && ();
-    │               -- The type: '()'
-    ·
- 15 │         () && ();
-    │         -- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_and_invalid.move:16:17 ───
-    │
- 16 │         true && ();
-    │                 ^^ Incompatible arguments to '&&'
-    ·
- 16 │         true && ();
-    │                 -- The type: '()'
-    ·
- 16 │         true && ();
-    │         ---- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_and_invalid.move:17:9 ───
-    │
- 17 │         (true, false) && (true, false, true);
-    │         ^^^^^^^^^^^^^ Incompatible arguments to '&&'
-    ·
- 17 │         (true, false) && (true, false, true);
-    │         ------------- The type: '(bool, bool)'
-    ·
- 17 │         (true, false) && (true, false, true);
-    │         ------------- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_and_invalid.move:17:26 ───
-    │
- 17 │         (true, false) && (true, false, true);
-    │                          ^^^^^^^^^^^^^^^^^^^ Incompatible arguments to '&&'
-    ·
- 17 │         (true, false) && (true, false, true);
-    │                          ------------------- The type: '(bool, bool, bool)'
-    ·
- 17 │         (true, false) && (true, false, true);
-    │         ------------- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_and_invalid.move:18:9 ───
-    │
- 18 │         (true, true) && (false, false);
-    │         ^^^^^^^^^^^^ Incompatible arguments to '&&'
-    ·
- 18 │         (true, true) && (false, false);
-    │         ------------ The type: '(bool, bool)'
-    ·
- 18 │         (true, true) && (false, false);
-    │         ------------ Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_and_invalid.move:18:25 ───
-    │
- 18 │         (true, true) && (false, false);
-    │                         ^^^^^^^^^^^^^^ Incompatible arguments to '&&'
-    ·
- 18 │         (true, true) && (false, false);
-    │                         -------------- The type: '(bool, bool)'
-    ·
- 18 │         (true, true) && (false, false);
-    │         ------------ Is not compatible with: 'bool'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_and_invalid.move:18:25
+   │
+18 │         (true, true) && (false, false);
+   │                      -- ^^^^^^^^^^^^^^
+   │                      │  │
+   │                      │  Invalid argument to '&&'
+   │                      │  Given: '(bool, bool)'
+   │                      Expected: 'bool'
 

--- a/language/move-lang/tests/move_check/typing/binary_bit_and_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_bit_and_invalid.exp
@@ -8,15 +8,6 @@ error[E04003]: built-in operation not supported
   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
 error[E04003]: built-in operation not supported
-  ┌─ tests/move_check/typing/binary_bit_and_invalid.move:8:9
-  │
-8 │         false & true;
-  │         ^^^^^^^^^^^^
-  │         │       │
-  │         │       Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-  │         Invalid argument to '&'
-
-error[E04003]: built-in operation not supported
   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:8:17
   │
 8 │         false & true;
@@ -24,14 +15,14 @@ error[E04003]: built-in operation not supported
   │         │        
   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
-error[E04003]: built-in operation not supported
-  ┌─ tests/move_check/typing/binary_bit_and_invalid.move:9:9
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/binary_bit_and_invalid.move:9:11
   │
 9 │         1 & false;
-  │         ^^^^^^^^^
-  │         │   │
-  │         │   Found: '_'. But expected: 'u8', 'u64', 'u128'
-  │         Invalid argument to '&'
+  │         - ^ ----- Found: 'bool'. It is not compatible with the other type.
+  │         │ │  
+  │         │ Incompatible arguments to '&'
+  │         Found: integer. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_and_invalid.move:10:9
@@ -42,14 +33,14 @@ error[E04003]: built-in operation not supported
    │         Invalid argument to '&'
    │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:10:9
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:10:15
    │
 10 │         false & 1;
-   │         ^^^^^^^^^
-   │         │       │
-   │         │       Found: '_'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '&'
+   │         ----- ^ - Found: integer. It is not compatible with the other type.
+   │         │     │  
+   │         │     Incompatible arguments to '&'
+   │         Found: 'bool'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_and_invalid.move:10:17
@@ -69,15 +60,6 @@ error[E04003]: built-in operation not supported
    │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
 
 error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:11:9
-   │
-11 │         @0x0 & @0x1;
-   │         ^^^^^^^^^^^
-   │         │      │
-   │         │      Found: 'address'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '&'
-
-error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_and_invalid.move:11:16
    │
 11 │         @0x0 & @0x1;
@@ -85,14 +67,14 @@ error[E04003]: built-in operation not supported
    │         │       
    │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
 
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:12:9
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:12:17
    │
 12 │         (0: u8) & (1: u128);
-   │         ^^^^^^^^^^^^^^^^^^^
-   │         │         │
-   │         │         Found: '_'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '&'
+   │             --  ^     ---- Found: 'u128'. It is not compatible with the other type.
+   │             │   │      
+   │             │   Incompatible arguments to '&'
+   │             Found: 'u8'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_and_invalid.move:13:9
@@ -102,15 +84,6 @@ error[E04003]: built-in operation not supported
    ·
 13 │         r & r;
    │         ^ Invalid argument to '&'
-
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:13:9
-   │
- 7 │     fun t0(x: u64, r: R, s: S) {
-   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-   ·
-13 │         r & r;
-   │         ^^^^^ Invalid argument to '&'
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/binary_bit_and_invalid.move:13:9
@@ -143,15 +116,6 @@ error[E04003]: built-in operation not supported
    │         ^ Invalid argument to '&'
 
 error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:14:9
-   │
- 7 │     fun t0(x: u64, r: R, s: S) {
-   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-   ·
-14 │         s & s;
-   │         ^^^^^ Invalid argument to '&'
-
-error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_and_invalid.move:14:13
    │
  7 │     fun t0(x: u64, r: R, s: S) {
@@ -165,8 +129,8 @@ error[E04003]: built-in operation not supported
    │
 15 │         1 & false & @0x0 & 0;
    │         ^^^^^^^^^
-   │         │   │
-   │         │   Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         │ │
+   │         │ Found: '_'. But expected: 'u8', 'u64', 'u128'
    │         Invalid argument to '&'
 
 error[E04003]: built-in operation not supported
@@ -178,22 +142,31 @@ error[E04003]: built-in operation not supported
    │         │           Found: 'address'. But expected: 'u8', 'u64', 'u128'
    │         Invalid argument to '&'
 
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:15:9
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:15:11
    │
 15 │         1 & false & @0x0 & 0;
-   │         ^^^^^^^^^^^^^^^^^^^^
-   │         │                  │
-   │         │                  Found: '_'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '&'
+   │         - ^ ----- Found: 'bool'. It is not compatible with the other type.
+   │         │ │  
+   │         │ Incompatible arguments to '&'
+   │         Found: integer. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_and_invalid.move:15:21
    │
 15 │         1 & false & @0x0 & 0;
-   │             -----   ^^^^ Invalid argument to '&'
-   │             │        
-   │             Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │           -         ^^^^ Invalid argument to '&'
+   │           │          
+   │           Found: '_'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:15:26
+   │
+15 │         1 & false & @0x0 & 0;
+   │                     ---- ^ - Found: integer. It is not compatible with the other type.
+   │                     │    │  
+   │                     │    Incompatible arguments to '&'
+   │                     Found: 'address'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_and_invalid.move:15:28
@@ -213,15 +186,6 @@ error[E04003]: built-in operation not supported
    │         Found: '()'. But expected: 'u8', 'u64', 'u128'
 
 error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:16:9
-   │
-16 │         () & ();
-   │         ^^^^^^^
-   │         │    │
-   │         │    Found: '()'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '&'
-
-error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_and_invalid.move:16:14
    │
 16 │         () & ();
@@ -229,14 +193,14 @@ error[E04003]: built-in operation not supported
    │         │     
    │         Found: '()'. But expected: 'u8', 'u64', 'u128'
 
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:17:9
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:17:11
    │
 17 │         1 & ();
-   │         ^^^^^^
-   │         │   │
-   │         │   Found: '_'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '&'
+   │         - ^ -- Found: '()'. It is not compatible with the other type.
+   │         │ │  
+   │         │ Incompatible arguments to '&'
+   │         Found: integer. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_and_invalid.move:18:9
@@ -247,14 +211,14 @@ error[E04003]: built-in operation not supported
    │         Invalid argument to '&'
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
 
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:18:9
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:18:16
    │
 18 │         (0, 1) & (0, 1, 2);
-   │         ^^^^^^^^^^^^^^^^^^
-   │         │        │
-   │         │        Found: '_'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '&'
+   │         ------ ^ --------- Found expression list of length 3: '({integer}, {integer}, {integer})'. It is not compatible with the other type of length 2.
+   │         │      │  
+   │         │      Incompatible arguments to '&'
+   │         Found expression list of length 2: '({integer}, {integer})'. It is not compatible with the other type of length 3.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_and_invalid.move:18:18
@@ -274,117 +238,10 @@ error[E04003]: built-in operation not supported
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
 
 error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:19:9
-   │
-19 │         (1, 2) & (0, 1);
-   │         ^^^^^^^^^^^^^^^
-   │         │        │
-   │         │        Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '&'
-
-error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_and_invalid.move:19:18
    │
 19 │         (1, 2) & (0, 1);
    │         ------   ^^^^^^ Invalid argument to '&'
    │         │         
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-
-error: 
-
-   ┌── tests/move_check/typing/binary_bit_and_invalid.move:9:13 ───
-   │
- 9 │         1 & false;
-   │             ^^^^^ Incompatible arguments to '&'
-   ·
- 9 │         1 & false;
-   │         - The type: integer
-   ·
- 9 │         1 & false;
-   │             ----- Is not compatible with: 'bool'
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:10:17 ───
-    │
- 10 │         false & 1;
-    │                 ^ Incompatible arguments to '&'
-    ·
- 10 │         false & 1;
-    │                 - The type: integer
-    ·
- 10 │         false & 1;
-    │         ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:12:19 ───
-    │
- 12 │         (0: u8) & (1: u128);
-    │                   ^^^^^^^^^ Incompatible arguments to '&'
-    ·
- 12 │         (0: u8) & (1: u128);
-    │             -- The type: 'u8'
-    ·
- 12 │         (0: u8) & (1: u128);
-    │                       ---- Is not compatible with: 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:15:13 ───
-    │
- 15 │         1 & false & @0x0 & 0;
-    │             ^^^^^ Incompatible arguments to '&'
-    ·
- 15 │         1 & false & @0x0 & 0;
-    │         - The type: integer
-    ·
- 15 │         1 & false & @0x0 & 0;
-    │             ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:15:28 ───
-    │
- 15 │         1 & false & @0x0 & 0;
-    │                            ^ Incompatible arguments to '&'
-    ·
- 15 │         1 & false & @0x0 & 0;
-    │                            - The type: integer
-    ·
- 15 │         1 & false & @0x0 & 0;
-    │                     ---- Is not compatible with: 'address'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:17:13 ───
-    │
- 17 │         1 & ();
-    │             ^^ Incompatible arguments to '&'
-    ·
- 17 │         1 & ();
-    │         - The type: integer
-    ·
- 17 │         1 & ();
-    │             -- Is not compatible with: '()'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:18:18 ───
-    │
- 18 │         (0, 1) & (0, 1, 2);
-    │                  ^^^^^^^^^ Incompatible arguments to '&'
-    ·
- 18 │         (0, 1) & (0, 1, 2);
-    │         ------ The expression list type of length 2: '({integer}, {integer})'
-    ·
- 18 │         (0, 1) & (0, 1, 2);
-    │                  --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
-    │
 

--- a/language/move-lang/tests/move_check/typing/binary_bit_or_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_bit_or_invalid.exp
@@ -8,15 +8,6 @@ error[E04003]: built-in operation not supported
   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
 error[E04003]: built-in operation not supported
-  ┌─ tests/move_check/typing/binary_bit_or_invalid.move:8:9
-  │
-8 │         false | true;
-  │         ^^^^^^^^^^^^
-  │         │       │
-  │         │       Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-  │         Invalid argument to '|'
-
-error[E04003]: built-in operation not supported
   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:8:17
   │
 8 │         false | true;
@@ -24,14 +15,14 @@ error[E04003]: built-in operation not supported
   │         │        
   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
-error[E04003]: built-in operation not supported
-  ┌─ tests/move_check/typing/binary_bit_or_invalid.move:9:9
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/binary_bit_or_invalid.move:9:11
   │
 9 │         1 | false;
-  │         ^^^^^^^^^
-  │         │   │
-  │         │   Found: '_'. But expected: 'u8', 'u64', 'u128'
-  │         Invalid argument to '|'
+  │         - ^ ----- Found: 'bool'. It is not compatible with the other type.
+  │         │ │  
+  │         │ Incompatible arguments to '|'
+  │         Found: integer. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_or_invalid.move:10:9
@@ -42,14 +33,14 @@ error[E04003]: built-in operation not supported
    │         Invalid argument to '|'
    │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:10:9
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:10:15
    │
 10 │         false | 1;
-   │         ^^^^^^^^^
-   │         │       │
-   │         │       Found: '_'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '|'
+   │         ----- ^ - Found: integer. It is not compatible with the other type.
+   │         │     │  
+   │         │     Incompatible arguments to '|'
+   │         Found: 'bool'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_or_invalid.move:10:17
@@ -69,15 +60,6 @@ error[E04003]: built-in operation not supported
    │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
 
 error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:11:9
-   │
-11 │         @0x0 | @0x1;
-   │         ^^^^^^^^^^^
-   │         │      │
-   │         │      Found: 'address'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '|'
-
-error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_or_invalid.move:11:16
    │
 11 │         @0x0 | @0x1;
@@ -85,14 +67,14 @@ error[E04003]: built-in operation not supported
    │         │       
    │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
 
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:12:9
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:12:17
    │
 12 │         (0: u8) | (1: u128);
-   │         ^^^^^^^^^^^^^^^^^^^
-   │         │         │
-   │         │         Found: '_'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '|'
+   │             --  ^     ---- Found: 'u128'. It is not compatible with the other type.
+   │             │   │      
+   │             │   Incompatible arguments to '|'
+   │             Found: 'u8'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_or_invalid.move:13:9
@@ -102,15 +84,6 @@ error[E04003]: built-in operation not supported
    ·
 13 │         r | r;
    │         ^ Invalid argument to '|'
-
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:13:9
-   │
- 7 │     fun t0(x: u64, r: R, s: S) {
-   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-   ·
-13 │         r | r;
-   │         ^^^^^ Invalid argument to '|'
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/binary_bit_or_invalid.move:13:9
@@ -143,15 +116,6 @@ error[E04003]: built-in operation not supported
    │         ^ Invalid argument to '|'
 
 error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:14:9
-   │
- 7 │     fun t0(x: u64, r: R, s: S) {
-   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-   ·
-14 │         s | s;
-   │         ^^^^^ Invalid argument to '|'
-
-error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_or_invalid.move:14:13
    │
  7 │     fun t0(x: u64, r: R, s: S) {
@@ -165,8 +129,8 @@ error[E04003]: built-in operation not supported
    │
 15 │         1 | false | @0x0 | 0;
    │         ^^^^^^^^^
-   │         │   │
-   │         │   Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         │ │
+   │         │ Found: '_'. But expected: 'u8', 'u64', 'u128'
    │         Invalid argument to '|'
 
 error[E04003]: built-in operation not supported
@@ -178,22 +142,31 @@ error[E04003]: built-in operation not supported
    │         │           Found: 'address'. But expected: 'u8', 'u64', 'u128'
    │         Invalid argument to '|'
 
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:15:9
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:15:11
    │
 15 │         1 | false | @0x0 | 0;
-   │         ^^^^^^^^^^^^^^^^^^^^
-   │         │                  │
-   │         │                  Found: '_'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '|'
+   │         - ^ ----- Found: 'bool'. It is not compatible with the other type.
+   │         │ │  
+   │         │ Incompatible arguments to '|'
+   │         Found: integer. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_or_invalid.move:15:21
    │
 15 │         1 | false | @0x0 | 0;
-   │             -----   ^^^^ Invalid argument to '|'
-   │             │        
-   │             Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │           -         ^^^^ Invalid argument to '|'
+   │           │          
+   │           Found: '_'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:15:26
+   │
+15 │         1 | false | @0x0 | 0;
+   │                     ---- ^ - Found: integer. It is not compatible with the other type.
+   │                     │    │  
+   │                     │    Incompatible arguments to '|'
+   │                     Found: 'address'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_or_invalid.move:15:28
@@ -213,15 +186,6 @@ error[E04003]: built-in operation not supported
    │         Found: '()'. But expected: 'u8', 'u64', 'u128'
 
 error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:16:9
-   │
-16 │         () | ();
-   │         ^^^^^^^
-   │         │    │
-   │         │    Found: '()'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '|'
-
-error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_or_invalid.move:16:14
    │
 16 │         () | ();
@@ -229,14 +193,14 @@ error[E04003]: built-in operation not supported
    │         │     
    │         Found: '()'. But expected: 'u8', 'u64', 'u128'
 
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:17:9
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:17:11
    │
 17 │         1 | ();
-   │         ^^^^^^
-   │         │   │
-   │         │   Found: '_'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '|'
+   │         - ^ -- Found: '()'. It is not compatible with the other type.
+   │         │ │  
+   │         │ Incompatible arguments to '|'
+   │         Found: integer. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_or_invalid.move:18:9
@@ -247,14 +211,14 @@ error[E04003]: built-in operation not supported
    │         Invalid argument to '|'
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
 
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:18:9
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:18:16
    │
 18 │         (0, 1) | (0, 1, 2);
-   │         ^^^^^^^^^^^^^^^^^^
-   │         │        │
-   │         │        Found: '_'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '|'
+   │         ------ ^ --------- Found expression list of length 3: '({integer}, {integer}, {integer})'. It is not compatible with the other type of length 2.
+   │         │      │  
+   │         │      Incompatible arguments to '|'
+   │         Found expression list of length 2: '({integer}, {integer})'. It is not compatible with the other type of length 3.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_or_invalid.move:18:18
@@ -274,117 +238,10 @@ error[E04003]: built-in operation not supported
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
 
 error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:19:9
-   │
-19 │         (1, 2) | (0, 1);
-   │         ^^^^^^^^^^^^^^^
-   │         │        │
-   │         │        Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '|'
-
-error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_or_invalid.move:19:18
    │
 19 │         (1, 2) | (0, 1);
    │         ------   ^^^^^^ Invalid argument to '|'
    │         │         
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-
-error: 
-
-   ┌── tests/move_check/typing/binary_bit_or_invalid.move:9:13 ───
-   │
- 9 │         1 | false;
-   │             ^^^^^ Incompatible arguments to '|'
-   ·
- 9 │         1 | false;
-   │         - The type: integer
-   ·
- 9 │         1 | false;
-   │             ----- Is not compatible with: 'bool'
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:10:17 ───
-    │
- 10 │         false | 1;
-    │                 ^ Incompatible arguments to '|'
-    ·
- 10 │         false | 1;
-    │                 - The type: integer
-    ·
- 10 │         false | 1;
-    │         ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:12:19 ───
-    │
- 12 │         (0: u8) | (1: u128);
-    │                   ^^^^^^^^^ Incompatible arguments to '|'
-    ·
- 12 │         (0: u8) | (1: u128);
-    │             -- The type: 'u8'
-    ·
- 12 │         (0: u8) | (1: u128);
-    │                       ---- Is not compatible with: 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:15:13 ───
-    │
- 15 │         1 | false | @0x0 | 0;
-    │             ^^^^^ Incompatible arguments to '|'
-    ·
- 15 │         1 | false | @0x0 | 0;
-    │         - The type: integer
-    ·
- 15 │         1 | false | @0x0 | 0;
-    │             ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:15:28 ───
-    │
- 15 │         1 | false | @0x0 | 0;
-    │                            ^ Incompatible arguments to '|'
-    ·
- 15 │         1 | false | @0x0 | 0;
-    │                            - The type: integer
-    ·
- 15 │         1 | false | @0x0 | 0;
-    │                     ---- Is not compatible with: 'address'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:17:13 ───
-    │
- 17 │         1 | ();
-    │             ^^ Incompatible arguments to '|'
-    ·
- 17 │         1 | ();
-    │         - The type: integer
-    ·
- 17 │         1 | ();
-    │             -- Is not compatible with: '()'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:18:18 ───
-    │
- 18 │         (0, 1) | (0, 1, 2);
-    │                  ^^^^^^^^^ Incompatible arguments to '|'
-    ·
- 18 │         (0, 1) | (0, 1, 2);
-    │         ------ The expression list type of length 2: '({integer}, {integer})'
-    ·
- 18 │         (0, 1) | (0, 1, 2);
-    │                  --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
-    │
 

--- a/language/move-lang/tests/move_check/typing/binary_bit_xor_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_bit_xor_invalid.exp
@@ -8,15 +8,6 @@ error[E04003]: built-in operation not supported
   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
 error[E04003]: built-in operation not supported
-  ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:8:9
-  │
-8 │         false ^ true;
-  │         ^^^^^^^^^^^^
-  │         │       │
-  │         │       Found: 'bool'. But expected: 'u8', 'u64', 'u128'
-  │         Invalid argument to '^'
-
-error[E04003]: built-in operation not supported
   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:8:17
   │
 8 │         false ^ true;
@@ -24,14 +15,14 @@ error[E04003]: built-in operation not supported
   │         │        
   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
-error[E04003]: built-in operation not supported
-  ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:9:9
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:9:11
   │
 9 │         1 ^ false;
-  │         ^^^^^^^^^
-  │         │   │
-  │         │   Found: '_'. But expected: 'u8', 'u64', 'u128'
-  │         Invalid argument to '^'
+  │         - ^ ----- Found: 'bool'. It is not compatible with the other type.
+  │         │ │  
+  │         │ Incompatible arguments to '^'
+  │         Found: integer. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:10:9
@@ -42,14 +33,14 @@ error[E04003]: built-in operation not supported
    │         Invalid argument to '^'
    │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:10:9
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:10:15
    │
 10 │         false ^ 1;
-   │         ^^^^^^^^^
-   │         │       │
-   │         │       Found: '_'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '^'
+   │         ----- ^ - Found: integer. It is not compatible with the other type.
+   │         │     │  
+   │         │     Incompatible arguments to '^'
+   │         Found: 'bool'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:10:17
@@ -69,15 +60,6 @@ error[E04003]: built-in operation not supported
    │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
 
 error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:11:9
-   │
-11 │         @0x0 ^ @0x1;
-   │         ^^^^^^^^^^^
-   │         │      │
-   │         │      Found: 'address'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '^'
-
-error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:11:16
    │
 11 │         @0x0 ^ @0x1;
@@ -85,14 +67,14 @@ error[E04003]: built-in operation not supported
    │         │       
    │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
 
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:12:9
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:12:17
    │
 12 │         (0: u8) ^ (1: u128);
-   │         ^^^^^^^^^^^^^^^^^^^
-   │         │         │
-   │         │         Found: '_'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '^'
+   │             --  ^     ---- Found: 'u128'. It is not compatible with the other type.
+   │             │   │      
+   │             │   Incompatible arguments to '^'
+   │             Found: 'u8'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:13:9
@@ -102,15 +84,6 @@ error[E04003]: built-in operation not supported
    ·
 13 │         r ^ r;
    │         ^ Invalid argument to '^'
-
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:13:9
-   │
- 7 │     fun t0(x: u64, r: R, s: S) {
-   │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
-   ·
-13 │         r ^ r;
-   │         ^^^^^ Invalid argument to '^'
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:13:9
@@ -143,15 +116,6 @@ error[E04003]: built-in operation not supported
    │         ^ Invalid argument to '^'
 
 error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:14:9
-   │
- 7 │     fun t0(x: u64, r: R, s: S) {
-   │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
-   ·
-14 │         s ^ s;
-   │         ^^^^^ Invalid argument to '^'
-
-error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:14:13
    │
  7 │     fun t0(x: u64, r: R, s: S) {
@@ -165,8 +129,8 @@ error[E04003]: built-in operation not supported
    │
 15 │         1 ^ false ^ @0x0 ^ 0;
    │         ^^^^^^^^^
-   │         │   │
-   │         │   Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         │ │
+   │         │ Found: '_'. But expected: 'u8', 'u64', 'u128'
    │         Invalid argument to '^'
 
 error[E04003]: built-in operation not supported
@@ -178,22 +142,31 @@ error[E04003]: built-in operation not supported
    │         │           Found: 'address'. But expected: 'u8', 'u64', 'u128'
    │         Invalid argument to '^'
 
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:15:9
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:15:11
    │
 15 │         1 ^ false ^ @0x0 ^ 0;
-   │         ^^^^^^^^^^^^^^^^^^^^
-   │         │                  │
-   │         │                  Found: '_'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '^'
+   │         - ^ ----- Found: 'bool'. It is not compatible with the other type.
+   │         │ │  
+   │         │ Incompatible arguments to '^'
+   │         Found: integer. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:15:21
    │
 15 │         1 ^ false ^ @0x0 ^ 0;
-   │             -----   ^^^^ Invalid argument to '^'
-   │             │        
-   │             Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │           -         ^^^^ Invalid argument to '^'
+   │           │          
+   │           Found: '_'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:15:26
+   │
+15 │         1 ^ false ^ @0x0 ^ 0;
+   │                     ---- ^ - Found: integer. It is not compatible with the other type.
+   │                     │    │  
+   │                     │    Incompatible arguments to '^'
+   │                     Found: 'address'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:15:28
@@ -213,15 +186,6 @@ error[E04003]: built-in operation not supported
    │         Found: '()'. But expected: 'u8', 'u64', 'u128'
 
 error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:16:9
-   │
-16 │         () ^ ();
-   │         ^^^^^^^
-   │         │    │
-   │         │    Found: '()'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '^'
-
-error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:16:14
    │
 16 │         () ^ ();
@@ -229,14 +193,14 @@ error[E04003]: built-in operation not supported
    │         │     
    │         Found: '()'. But expected: 'u8', 'u64', 'u128'
 
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:17:9
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:17:11
    │
 17 │         1 ^ ();
-   │         ^^^^^^
-   │         │   │
-   │         │   Found: '_'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '^'
+   │         - ^ -- Found: '()'. It is not compatible with the other type.
+   │         │ │  
+   │         │ Incompatible arguments to '^'
+   │         Found: integer. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:18:9
@@ -247,14 +211,14 @@ error[E04003]: built-in operation not supported
    │         Invalid argument to '^'
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
 
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:18:9
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:18:16
    │
 18 │         (0, 1) ^ (0, 1, 2);
-   │         ^^^^^^^^^^^^^^^^^^
-   │         │        │
-   │         │        Found: '_'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '^'
+   │         ------ ^ --------- Found expression list of length 3: '({integer}, {integer}, {integer})'. It is not compatible with the other type of length 2.
+   │         │      │  
+   │         │      Incompatible arguments to '^'
+   │         Found expression list of length 2: '({integer}, {integer})'. It is not compatible with the other type of length 3.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:18:18
@@ -274,117 +238,10 @@ error[E04003]: built-in operation not supported
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
 
 error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:19:9
-   │
-19 │         (1, 2) ^ (0, 1);
-   │         ^^^^^^^^^^^^^^^
-   │         │        │
-   │         │        Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '^'
-
-error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:19:18
    │
 19 │         (1, 2) ^ (0, 1);
    │         ------   ^^^^^^ Invalid argument to '^'
    │         │         
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-
-error: 
-
-   ┌── tests/move_check/typing/binary_bit_xor_invalid.move:9:13 ───
-   │
- 9 │         1 ^ false;
-   │             ^^^^^ Incompatible arguments to '^'
-   ·
- 9 │         1 ^ false;
-   │         - The type: integer
-   ·
- 9 │         1 ^ false;
-   │             ----- Is not compatible with: 'bool'
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:10:17 ───
-    │
- 10 │         false ^ 1;
-    │                 ^ Incompatible arguments to '^'
-    ·
- 10 │         false ^ 1;
-    │                 - The type: integer
-    ·
- 10 │         false ^ 1;
-    │         ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:12:19 ───
-    │
- 12 │         (0: u8) ^ (1: u128);
-    │                   ^^^^^^^^^ Incompatible arguments to '^'
-    ·
- 12 │         (0: u8) ^ (1: u128);
-    │             -- The type: 'u8'
-    ·
- 12 │         (0: u8) ^ (1: u128);
-    │                       ---- Is not compatible with: 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:15:13 ───
-    │
- 15 │         1 ^ false ^ @0x0 ^ 0;
-    │             ^^^^^ Incompatible arguments to '^'
-    ·
- 15 │         1 ^ false ^ @0x0 ^ 0;
-    │         - The type: integer
-    ·
- 15 │         1 ^ false ^ @0x0 ^ 0;
-    │             ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:15:28 ───
-    │
- 15 │         1 ^ false ^ @0x0 ^ 0;
-    │                            ^ Incompatible arguments to '^'
-    ·
- 15 │         1 ^ false ^ @0x0 ^ 0;
-    │                            - The type: integer
-    ·
- 15 │         1 ^ false ^ @0x0 ^ 0;
-    │                     ---- Is not compatible with: 'address'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:17:13 ───
-    │
- 17 │         1 ^ ();
-    │             ^^ Incompatible arguments to '^'
-    ·
- 17 │         1 ^ ();
-    │         - The type: integer
-    ·
- 17 │         1 ^ ();
-    │             -- Is not compatible with: '()'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:18:18 ───
-    │
- 18 │         (0, 1) ^ (0, 1, 2);
-    │                  ^^^^^^^^^ Incompatible arguments to '^'
-    ·
- 18 │         (0, 1) ^ (0, 1, 2);
-    │         ------ The expression list type of length 2: '({integer}, {integer})'
-    ·
- 18 │         (0, 1) ^ (0, 1, 2);
-    │                  --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
-    │
 

--- a/language/move-lang/tests/move_check/typing/binary_div_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_div_invalid.exp
@@ -15,6 +15,15 @@ error[E04003]: built-in operation not supported
   │         │        
   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/binary_div_invalid.move:9:11
+  │
+9 │         1 / false;
+  │         - ^ ----- Found: 'bool'. It is not compatible with the other type.
+  │         │ │  
+  │         │ Incompatible arguments to '/'
+  │         Found: integer. It is not compatible with the other type.
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_div_invalid.move:10:9
    │
@@ -23,6 +32,15 @@ error[E04003]: built-in operation not supported
    │         │
    │         Invalid argument to '/'
    │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_div_invalid.move:10:15
+   │
+10 │         false / 1;
+   │         ----- ^ - Found: integer. It is not compatible with the other type.
+   │         │     │  
+   │         │     Incompatible arguments to '/'
+   │         Found: 'bool'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_div_invalid.move:10:17
@@ -48,6 +66,15 @@ error[E04003]: built-in operation not supported
    │         ----   ^^^^ Invalid argument to '/'
    │         │       
    │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_div_invalid.move:12:17
+   │
+12 │         (0: u8) / (1: u128);
+   │             --  ^     ---- Found: 'u128'. It is not compatible with the other type.
+   │             │   │      
+   │             │   Incompatible arguments to '/'
+   │             Found: 'u8'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_div_invalid.move:13:9
@@ -102,8 +129,8 @@ error[E04003]: built-in operation not supported
    │
 15 │         1 / false / @0x0 / 0;
    │         ^^^^^^^^^
-   │         │   │
-   │         │   Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         │ │
+   │         │ Found: '_'. But expected: 'u8', 'u64', 'u128'
    │         Invalid argument to '/'
 
 error[E04003]: built-in operation not supported
@@ -115,13 +142,31 @@ error[E04003]: built-in operation not supported
    │         │           Found: 'address'. But expected: 'u8', 'u64', 'u128'
    │         Invalid argument to '/'
 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_div_invalid.move:15:11
+   │
+15 │         1 / false / @0x0 / 0;
+   │         - ^ ----- Found: 'bool'. It is not compatible with the other type.
+   │         │ │  
+   │         │ Incompatible arguments to '/'
+   │         Found: integer. It is not compatible with the other type.
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_div_invalid.move:15:21
    │
 15 │         1 / false / @0x0 / 0;
-   │             -----   ^^^^ Invalid argument to '/'
-   │             │        
-   │             Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │           -         ^^^^ Invalid argument to '/'
+   │           │          
+   │           Found: '_'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_div_invalid.move:15:26
+   │
+15 │         1 / false / @0x0 / 0;
+   │                     ---- ^ - Found: integer. It is not compatible with the other type.
+   │                     │    │  
+   │                     │    Incompatible arguments to '/'
+   │                     Found: 'address'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_div_invalid.move:15:28
@@ -148,6 +193,15 @@ error[E04003]: built-in operation not supported
    │         │     
    │         Found: '()'. But expected: 'u8', 'u64', 'u128'
 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_div_invalid.move:17:11
+   │
+17 │         1 / ();
+   │         - ^ -- Found: '()'. It is not compatible with the other type.
+   │         │ │  
+   │         │ Incompatible arguments to '/'
+   │         Found: integer. It is not compatible with the other type.
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_div_invalid.move:18:9
    │
@@ -156,6 +210,15 @@ error[E04003]: built-in operation not supported
    │         │
    │         Invalid argument to '/'
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_div_invalid.move:18:16
+   │
+18 │         (0, 1) / (0, 1, 2);
+   │         ------ ^ --------- Found expression list of length 3: '({integer}, {integer}, {integer})'. It is not compatible with the other type of length 2.
+   │         │      │  
+   │         │      Incompatible arguments to '/'
+   │         Found expression list of length 2: '({integer}, {integer})'. It is not compatible with the other type of length 3.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_div_invalid.move:18:18
@@ -181,102 +244,4 @@ error[E04003]: built-in operation not supported
    │         ------   ^^^^^^ Invalid argument to '/'
    │         │         
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-
-error: 
-
-   ┌── tests/move_check/typing/binary_div_invalid.move:9:13 ───
-   │
- 9 │         1 / false;
-   │             ^^^^^ Incompatible arguments to '/'
-   ·
- 9 │         1 / false;
-   │         - The type: integer
-   ·
- 9 │         1 / false;
-   │             ----- Is not compatible with: 'bool'
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_div_invalid.move:10:17 ───
-    │
- 10 │         false / 1;
-    │                 ^ Incompatible arguments to '/'
-    ·
- 10 │         false / 1;
-    │                 - The type: integer
-    ·
- 10 │         false / 1;
-    │         ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_div_invalid.move:12:19 ───
-    │
- 12 │         (0: u8) / (1: u128);
-    │                   ^^^^^^^^^ Incompatible arguments to '/'
-    ·
- 12 │         (0: u8) / (1: u128);
-    │             -- The type: 'u8'
-    ·
- 12 │         (0: u8) / (1: u128);
-    │                       ---- Is not compatible with: 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_div_invalid.move:15:13 ───
-    │
- 15 │         1 / false / @0x0 / 0;
-    │             ^^^^^ Incompatible arguments to '/'
-    ·
- 15 │         1 / false / @0x0 / 0;
-    │         - The type: integer
-    ·
- 15 │         1 / false / @0x0 / 0;
-    │             ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_div_invalid.move:15:28 ───
-    │
- 15 │         1 / false / @0x0 / 0;
-    │                            ^ Incompatible arguments to '/'
-    ·
- 15 │         1 / false / @0x0 / 0;
-    │                            - The type: integer
-    ·
- 15 │         1 / false / @0x0 / 0;
-    │                     ---- Is not compatible with: 'address'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_div_invalid.move:17:13 ───
-    │
- 17 │         1 / ();
-    │             ^^ Incompatible arguments to '/'
-    ·
- 17 │         1 / ();
-    │         - The type: integer
-    ·
- 17 │         1 / ();
-    │             -- Is not compatible with: '()'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_div_invalid.move:18:18 ───
-    │
- 18 │         (0, 1) / (0, 1, 2);
-    │                  ^^^^^^^^^ Incompatible arguments to '/'
-    ·
- 18 │         (0, 1) / (0, 1, 2);
-    │         ------ The expression list type of length 2: '({integer}, {integer})'
-    ·
- 18 │         (0, 1) / (0, 1, 2);
-    │                  --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
-    │
 

--- a/language/move-lang/tests/move_check/typing/binary_geq_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_geq_invalid.exp
@@ -15,6 +15,15 @@ error[E04003]: built-in operation not supported
   │         │         
   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/binary_geq_invalid.move:9:11
+  │
+9 │         1 >= false;
+  │         - ^^ ----- Found: 'bool'. It is not compatible with the other type.
+  │         │ │   
+  │         │ Incompatible arguments to '>='
+  │         Found: integer. It is not compatible with the other type.
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_geq_invalid.move:10:9
    │
@@ -23,6 +32,15 @@ error[E04003]: built-in operation not supported
    │         │
    │         Invalid argument to '>='
    │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_geq_invalid.move:10:15
+   │
+10 │         false >= 1;
+   │         ----- ^^ - Found: integer. It is not compatible with the other type.
+   │         │     │   
+   │         │     Incompatible arguments to '>='
+   │         Found: 'bool'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_geq_invalid.move:10:18
@@ -48,6 +66,15 @@ error[E04003]: built-in operation not supported
    │         ----    ^^^^ Invalid argument to '>='
    │         │        
    │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_geq_invalid.move:12:17
+   │
+12 │         (0: u8) >= (1: u128);
+   │             --  ^^     ---- Found: 'u128'. It is not compatible with the other type.
+   │             │   │       
+   │             │   Incompatible arguments to '>='
+   │             Found: 'u8'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_geq_invalid.move:13:9
@@ -94,6 +121,15 @@ error[E04003]: built-in operation not supported
    │         Invalid argument to '>='
    │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_geq_invalid.move:15:16
+   │
+15 │         0 >= 1 >= 2;
+   │         ------ ^^ - Found: integer. It is not compatible with the other type.
+   │         │      │   
+   │         │      Incompatible arguments to '>='
+   │         Found: 'bool'. It is not compatible with the other type.
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_geq_invalid.move:15:19
    │
@@ -101,6 +137,15 @@ error[E04003]: built-in operation not supported
    │         ------    ^ Invalid argument to '>='
    │         │          
    │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_geq_invalid.move:16:12
+   │
+16 │         (1 >= false) && (@0x0 >= 0);
+   │          - ^^ ----- Found: 'bool'. It is not compatible with the other type.
+   │          │ │   
+   │          │ Incompatible arguments to '>='
+   │          Found: integer. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_geq_invalid.move:16:26
@@ -110,6 +155,15 @@ error[E04003]: built-in operation not supported
    │                          │
    │                          Invalid argument to '>='
    │                          Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_geq_invalid.move:16:31
+   │
+16 │         (1 >= false) && (@0x0 >= 0);
+   │                          ---- ^^ - Found: integer. It is not compatible with the other type.
+   │                          │    │   
+   │                          │    Incompatible arguments to '>='
+   │                          Found: 'address'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_geq_invalid.move:16:34
@@ -136,6 +190,15 @@ error[E04003]: built-in operation not supported
    │         │      
    │         Found: '()'. But expected: 'u8', 'u64', 'u128'
 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_geq_invalid.move:18:11
+   │
+18 │         1 >= ();
+   │         - ^^ -- Found: '()'. It is not compatible with the other type.
+   │         │ │   
+   │         │ Incompatible arguments to '>='
+   │         Found: integer. It is not compatible with the other type.
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_geq_invalid.move:19:9
    │
@@ -144,6 +207,15 @@ error[E04003]: built-in operation not supported
    │         │
    │         Invalid argument to '>='
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_geq_invalid.move:19:16
+   │
+19 │         (0, 1) >= (0, 1, 2);
+   │         ------ ^^ --------- Found expression list of length 3: '({integer}, {integer}, {integer})'. It is not compatible with the other type of length 2.
+   │         │      │   
+   │         │      Incompatible arguments to '>='
+   │         Found expression list of length 2: '({integer}, {integer})'. It is not compatible with the other type of length 3.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_geq_invalid.move:19:19
@@ -169,116 +241,4 @@ error[E04003]: built-in operation not supported
    │         ------    ^^^^^^ Invalid argument to '>='
    │         │          
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-
-error: 
-
-   ┌── tests/move_check/typing/binary_geq_invalid.move:9:14 ───
-   │
- 9 │         1 >= false;
-   │              ^^^^^ Incompatible arguments to '>='
-   ·
- 9 │         1 >= false;
-   │         - The type: integer
-   ·
- 9 │         1 >= false;
-   │              ----- Is not compatible with: 'bool'
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_geq_invalid.move:10:18 ───
-    │
- 10 │         false >= 1;
-    │                  ^ Incompatible arguments to '>='
-    ·
- 10 │         false >= 1;
-    │                  - The type: integer
-    ·
- 10 │         false >= 1;
-    │         ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_geq_invalid.move:12:20 ───
-    │
- 12 │         (0: u8) >= (1: u128);
-    │                    ^^^^^^^^^ Incompatible arguments to '>='
-    ·
- 12 │         (0: u8) >= (1: u128);
-    │             -- The type: 'u8'
-    ·
- 12 │         (0: u8) >= (1: u128);
-    │                        ---- Is not compatible with: 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_geq_invalid.move:15:19 ───
-    │
- 15 │         0 >= 1 >= 2;
-    │                   ^ Incompatible arguments to '>='
-    ·
- 15 │         0 >= 1 >= 2;
-    │                   - The type: integer
-    ·
- 15 │         0 >= 1 >= 2;
-    │         ------ Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_geq_invalid.move:16:15 ───
-    │
- 16 │         (1 >= false) && (@0x0 >= 0);
-    │               ^^^^^ Incompatible arguments to '>='
-    ·
- 16 │         (1 >= false) && (@0x0 >= 0);
-    │          - The type: integer
-    ·
- 16 │         (1 >= false) && (@0x0 >= 0);
-    │               ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_geq_invalid.move:16:34 ───
-    │
- 16 │         (1 >= false) && (@0x0 >= 0);
-    │                                  ^ Incompatible arguments to '>='
-    ·
- 16 │         (1 >= false) && (@0x0 >= 0);
-    │                                  - The type: integer
-    ·
- 16 │         (1 >= false) && (@0x0 >= 0);
-    │                          ---- Is not compatible with: 'address'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_geq_invalid.move:18:14 ───
-    │
- 18 │         1 >= ();
-    │              ^^ Incompatible arguments to '>='
-    ·
- 18 │         1 >= ();
-    │         - The type: integer
-    ·
- 18 │         1 >= ();
-    │              -- Is not compatible with: '()'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_geq_invalid.move:19:19 ───
-    │
- 19 │         (0, 1) >= (0, 1, 2);
-    │                   ^^^^^^^^^ Incompatible arguments to '>='
-    ·
- 19 │         (0, 1) >= (0, 1, 2);
-    │         ------ The expression list type of length 2: '({integer}, {integer})'
-    ·
- 19 │         (0, 1) >= (0, 1, 2);
-    │                   --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
-    │
 

--- a/language/move-lang/tests/move_check/typing/binary_gt_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_gt_invalid.exp
@@ -15,6 +15,15 @@ error[E04003]: built-in operation not supported
   │         │        
   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/binary_gt_invalid.move:9:11
+  │
+9 │         1 > false;
+  │         - ^ ----- Found: 'bool'. It is not compatible with the other type.
+  │         │ │  
+  │         │ Incompatible arguments to '>'
+  │         Found: integer. It is not compatible with the other type.
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_gt_invalid.move:10:9
    │
@@ -23,6 +32,15 @@ error[E04003]: built-in operation not supported
    │         │
    │         Invalid argument to '>'
    │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_gt_invalid.move:10:15
+   │
+10 │         false > 1;
+   │         ----- ^ - Found: integer. It is not compatible with the other type.
+   │         │     │  
+   │         │     Incompatible arguments to '>'
+   │         Found: 'bool'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_gt_invalid.move:10:17
@@ -48,6 +66,15 @@ error[E04003]: built-in operation not supported
    │         ----   ^^^^ Invalid argument to '>'
    │         │       
    │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_gt_invalid.move:12:17
+   │
+12 │         (0: u8) > (1: u128);
+   │             --  ^     ---- Found: 'u128'. It is not compatible with the other type.
+   │             │   │      
+   │             │   Incompatible arguments to '>'
+   │             Found: 'u8'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_gt_invalid.move:13:9
@@ -94,6 +121,15 @@ error[E04003]: built-in operation not supported
    │         Invalid argument to '>'
    │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_gt_invalid.move:15:15
+   │
+15 │         0 > 1 > 2;
+   │         ----- ^ - Found: integer. It is not compatible with the other type.
+   │         │     │  
+   │         │     Incompatible arguments to '>'
+   │         Found: 'bool'. It is not compatible with the other type.
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_gt_invalid.move:15:17
    │
@@ -101,6 +137,15 @@ error[E04003]: built-in operation not supported
    │         -----   ^ Invalid argument to '>'
    │         │        
    │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_gt_invalid.move:16:12
+   │
+16 │         (1 > false) && (@0x0 > 0);
+   │          - ^ ----- Found: 'bool'. It is not compatible with the other type.
+   │          │ │  
+   │          │ Incompatible arguments to '>'
+   │          Found: integer. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_gt_invalid.move:16:25
@@ -110,6 +155,15 @@ error[E04003]: built-in operation not supported
    │                         │
    │                         Invalid argument to '>'
    │                         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_gt_invalid.move:16:30
+   │
+16 │         (1 > false) && (@0x0 > 0);
+   │                         ---- ^ - Found: integer. It is not compatible with the other type.
+   │                         │    │  
+   │                         │    Incompatible arguments to '>'
+   │                         Found: 'address'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_gt_invalid.move:16:32
@@ -136,6 +190,15 @@ error[E04003]: built-in operation not supported
    │         │     
    │         Found: '()'. But expected: 'u8', 'u64', 'u128'
 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_gt_invalid.move:18:11
+   │
+18 │         1 > ();
+   │         - ^ -- Found: '()'. It is not compatible with the other type.
+   │         │ │  
+   │         │ Incompatible arguments to '>'
+   │         Found: integer. It is not compatible with the other type.
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_gt_invalid.move:19:9
    │
@@ -144,6 +207,15 @@ error[E04003]: built-in operation not supported
    │         │
    │         Invalid argument to '>'
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_gt_invalid.move:19:16
+   │
+19 │         (0, 1) > (0, 1, 2);
+   │         ------ ^ --------- Found expression list of length 3: '({integer}, {integer}, {integer})'. It is not compatible with the other type of length 2.
+   │         │      │  
+   │         │      Incompatible arguments to '>'
+   │         Found expression list of length 2: '({integer}, {integer})'. It is not compatible with the other type of length 3.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_gt_invalid.move:19:18
@@ -169,116 +241,4 @@ error[E04003]: built-in operation not supported
    │         ------   ^^^^^^ Invalid argument to '>'
    │         │         
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-
-error: 
-
-   ┌── tests/move_check/typing/binary_gt_invalid.move:9:13 ───
-   │
- 9 │         1 > false;
-   │             ^^^^^ Incompatible arguments to '>'
-   ·
- 9 │         1 > false;
-   │         - The type: integer
-   ·
- 9 │         1 > false;
-   │             ----- Is not compatible with: 'bool'
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_gt_invalid.move:10:17 ───
-    │
- 10 │         false > 1;
-    │                 ^ Incompatible arguments to '>'
-    ·
- 10 │         false > 1;
-    │                 - The type: integer
-    ·
- 10 │         false > 1;
-    │         ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_gt_invalid.move:12:19 ───
-    │
- 12 │         (0: u8) > (1: u128);
-    │                   ^^^^^^^^^ Incompatible arguments to '>'
-    ·
- 12 │         (0: u8) > (1: u128);
-    │             -- The type: 'u8'
-    ·
- 12 │         (0: u8) > (1: u128);
-    │                       ---- Is not compatible with: 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_gt_invalid.move:15:17 ───
-    │
- 15 │         0 > 1 > 2;
-    │                 ^ Incompatible arguments to '>'
-    ·
- 15 │         0 > 1 > 2;
-    │                 - The type: integer
-    ·
- 15 │         0 > 1 > 2;
-    │         ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_gt_invalid.move:16:14 ───
-    │
- 16 │         (1 > false) && (@0x0 > 0);
-    │              ^^^^^ Incompatible arguments to '>'
-    ·
- 16 │         (1 > false) && (@0x0 > 0);
-    │          - The type: integer
-    ·
- 16 │         (1 > false) && (@0x0 > 0);
-    │              ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_gt_invalid.move:16:32 ───
-    │
- 16 │         (1 > false) && (@0x0 > 0);
-    │                                ^ Incompatible arguments to '>'
-    ·
- 16 │         (1 > false) && (@0x0 > 0);
-    │                                - The type: integer
-    ·
- 16 │         (1 > false) && (@0x0 > 0);
-    │                         ---- Is not compatible with: 'address'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_gt_invalid.move:18:13 ───
-    │
- 18 │         1 > ();
-    │             ^^ Incompatible arguments to '>'
-    ·
- 18 │         1 > ();
-    │         - The type: integer
-    ·
- 18 │         1 > ();
-    │             -- Is not compatible with: '()'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_gt_invalid.move:19:18 ───
-    │
- 19 │         (0, 1) > (0, 1, 2);
-    │                  ^^^^^^^^^ Incompatible arguments to '>'
-    ·
- 19 │         (0, 1) > (0, 1, 2);
-    │         ------ The expression list type of length 2: '({integer}, {integer})'
-    ·
- 19 │         (0, 1) > (0, 1, 2);
-    │                  --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
-    │
 

--- a/language/move-lang/tests/move_check/typing/binary_leq_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_leq_invalid.exp
@@ -15,6 +15,15 @@ error[E04003]: built-in operation not supported
   │         │         
   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/binary_leq_invalid.move:9:11
+  │
+9 │         1 <= false;
+  │         - ^^ ----- Found: 'bool'. It is not compatible with the other type.
+  │         │ │   
+  │         │ Incompatible arguments to '<='
+  │         Found: integer. It is not compatible with the other type.
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_leq_invalid.move:10:9
    │
@@ -23,6 +32,15 @@ error[E04003]: built-in operation not supported
    │         │
    │         Invalid argument to '<='
    │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_leq_invalid.move:10:15
+   │
+10 │         false <= 1;
+   │         ----- ^^ - Found: integer. It is not compatible with the other type.
+   │         │     │   
+   │         │     Incompatible arguments to '<='
+   │         Found: 'bool'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_leq_invalid.move:10:18
@@ -48,6 +66,15 @@ error[E04003]: built-in operation not supported
    │         ----    ^^^^ Invalid argument to '<='
    │         │        
    │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_leq_invalid.move:12:17
+   │
+12 │         (0: u8) <= (1: u128);
+   │             --  ^^     ---- Found: 'u128'. It is not compatible with the other type.
+   │             │   │       
+   │             │   Incompatible arguments to '<='
+   │             Found: 'u8'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_leq_invalid.move:13:9
@@ -94,6 +121,15 @@ error[E04003]: built-in operation not supported
    │         Invalid argument to '<='
    │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_leq_invalid.move:15:16
+   │
+15 │         0 <= 1 <= 2;
+   │         ------ ^^ - Found: integer. It is not compatible with the other type.
+   │         │      │   
+   │         │      Incompatible arguments to '<='
+   │         Found: 'bool'. It is not compatible with the other type.
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_leq_invalid.move:15:19
    │
@@ -101,6 +137,15 @@ error[E04003]: built-in operation not supported
    │         ------    ^ Invalid argument to '<='
    │         │          
    │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_leq_invalid.move:16:12
+   │
+16 │         (1 <= false) && (@0x0 <= 0);
+   │          - ^^ ----- Found: 'bool'. It is not compatible with the other type.
+   │          │ │   
+   │          │ Incompatible arguments to '<='
+   │          Found: integer. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_leq_invalid.move:16:26
@@ -110,6 +155,15 @@ error[E04003]: built-in operation not supported
    │                          │
    │                          Invalid argument to '<='
    │                          Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_leq_invalid.move:16:31
+   │
+16 │         (1 <= false) && (@0x0 <= 0);
+   │                          ---- ^^ - Found: integer. It is not compatible with the other type.
+   │                          │    │   
+   │                          │    Incompatible arguments to '<='
+   │                          Found: 'address'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_leq_invalid.move:16:34
@@ -136,6 +190,15 @@ error[E04003]: built-in operation not supported
    │         │      
    │         Found: '()'. But expected: 'u8', 'u64', 'u128'
 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_leq_invalid.move:18:11
+   │
+18 │         1 <= ();
+   │         - ^^ -- Found: '()'. It is not compatible with the other type.
+   │         │ │   
+   │         │ Incompatible arguments to '<='
+   │         Found: integer. It is not compatible with the other type.
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_leq_invalid.move:19:9
    │
@@ -144,6 +207,15 @@ error[E04003]: built-in operation not supported
    │         │
    │         Invalid argument to '<='
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_leq_invalid.move:19:16
+   │
+19 │         (0, 1) <= (0, 1, 2);
+   │         ------ ^^ --------- Found expression list of length 3: '({integer}, {integer}, {integer})'. It is not compatible with the other type of length 2.
+   │         │      │   
+   │         │      Incompatible arguments to '<='
+   │         Found expression list of length 2: '({integer}, {integer})'. It is not compatible with the other type of length 3.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_leq_invalid.move:19:19
@@ -169,116 +241,4 @@ error[E04003]: built-in operation not supported
    │         ------    ^^^^^^ Invalid argument to '<='
    │         │          
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-
-error: 
-
-   ┌── tests/move_check/typing/binary_leq_invalid.move:9:14 ───
-   │
- 9 │         1 <= false;
-   │              ^^^^^ Incompatible arguments to '<='
-   ·
- 9 │         1 <= false;
-   │         - The type: integer
-   ·
- 9 │         1 <= false;
-   │              ----- Is not compatible with: 'bool'
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_leq_invalid.move:10:18 ───
-    │
- 10 │         false <= 1;
-    │                  ^ Incompatible arguments to '<='
-    ·
- 10 │         false <= 1;
-    │                  - The type: integer
-    ·
- 10 │         false <= 1;
-    │         ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_leq_invalid.move:12:20 ───
-    │
- 12 │         (0: u8) <= (1: u128);
-    │                    ^^^^^^^^^ Incompatible arguments to '<='
-    ·
- 12 │         (0: u8) <= (1: u128);
-    │             -- The type: 'u8'
-    ·
- 12 │         (0: u8) <= (1: u128);
-    │                        ---- Is not compatible with: 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_leq_invalid.move:15:19 ───
-    │
- 15 │         0 <= 1 <= 2;
-    │                   ^ Incompatible arguments to '<='
-    ·
- 15 │         0 <= 1 <= 2;
-    │                   - The type: integer
-    ·
- 15 │         0 <= 1 <= 2;
-    │         ------ Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_leq_invalid.move:16:15 ───
-    │
- 16 │         (1 <= false) && (@0x0 <= 0);
-    │               ^^^^^ Incompatible arguments to '<='
-    ·
- 16 │         (1 <= false) && (@0x0 <= 0);
-    │          - The type: integer
-    ·
- 16 │         (1 <= false) && (@0x0 <= 0);
-    │               ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_leq_invalid.move:16:34 ───
-    │
- 16 │         (1 <= false) && (@0x0 <= 0);
-    │                                  ^ Incompatible arguments to '<='
-    ·
- 16 │         (1 <= false) && (@0x0 <= 0);
-    │                                  - The type: integer
-    ·
- 16 │         (1 <= false) && (@0x0 <= 0);
-    │                          ---- Is not compatible with: 'address'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_leq_invalid.move:18:14 ───
-    │
- 18 │         1 <= ();
-    │              ^^ Incompatible arguments to '<='
-    ·
- 18 │         1 <= ();
-    │         - The type: integer
-    ·
- 18 │         1 <= ();
-    │              -- Is not compatible with: '()'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_leq_invalid.move:19:19 ───
-    │
- 19 │         (0, 1) <= (0, 1, 2);
-    │                   ^^^^^^^^^ Incompatible arguments to '<='
-    ·
- 19 │         (0, 1) <= (0, 1, 2);
-    │         ------ The expression list type of length 2: '({integer}, {integer})'
-    ·
- 19 │         (0, 1) <= (0, 1, 2);
-    │                   --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
-    │
 

--- a/language/move-lang/tests/move_check/typing/binary_lt_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_lt_invalid.exp
@@ -15,6 +15,15 @@ error[E04003]: built-in operation not supported
   │         │        
   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/binary_lt_invalid.move:9:11
+  │
+9 │         1 < false;
+  │         - ^ ----- Found: 'bool'. It is not compatible with the other type.
+  │         │ │  
+  │         │ Incompatible arguments to '<'
+  │         Found: integer. It is not compatible with the other type.
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_lt_invalid.move:10:9
    │
@@ -23,6 +32,15 @@ error[E04003]: built-in operation not supported
    │         │
    │         Invalid argument to '<'
    │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_lt_invalid.move:10:15
+   │
+10 │         false < 1;
+   │         ----- ^ - Found: integer. It is not compatible with the other type.
+   │         │     │  
+   │         │     Incompatible arguments to '<'
+   │         Found: 'bool'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_lt_invalid.move:10:17
@@ -48,6 +66,15 @@ error[E04003]: built-in operation not supported
    │         ----   ^^^^ Invalid argument to '<'
    │         │       
    │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_lt_invalid.move:12:17
+   │
+12 │         (0: u8) < (1: u128);
+   │             --  ^     ---- Found: 'u128'. It is not compatible with the other type.
+   │             │   │      
+   │             │   Incompatible arguments to '<'
+   │             Found: 'u8'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_lt_invalid.move:13:9
@@ -94,6 +121,15 @@ error[E04003]: built-in operation not supported
    │         Invalid argument to '<'
    │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_lt_invalid.move:15:15
+   │
+15 │         0 < 1 < 2;
+   │         ----- ^ - Found: integer. It is not compatible with the other type.
+   │         │     │  
+   │         │     Incompatible arguments to '<'
+   │         Found: 'bool'. It is not compatible with the other type.
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_lt_invalid.move:15:17
    │
@@ -101,6 +137,15 @@ error[E04003]: built-in operation not supported
    │         -----   ^ Invalid argument to '<'
    │         │        
    │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_lt_invalid.move:16:12
+   │
+16 │         (1 < false) && (@0x0 < 0);
+   │          - ^ ----- Found: 'bool'. It is not compatible with the other type.
+   │          │ │  
+   │          │ Incompatible arguments to '<'
+   │          Found: integer. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_lt_invalid.move:16:25
@@ -110,6 +155,15 @@ error[E04003]: built-in operation not supported
    │                         │
    │                         Invalid argument to '<'
    │                         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_lt_invalid.move:16:30
+   │
+16 │         (1 < false) && (@0x0 < 0);
+   │                         ---- ^ - Found: integer. It is not compatible with the other type.
+   │                         │    │  
+   │                         │    Incompatible arguments to '<'
+   │                         Found: 'address'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_lt_invalid.move:16:32
@@ -136,6 +190,15 @@ error[E04003]: built-in operation not supported
    │         │     
    │         Found: '()'. But expected: 'u8', 'u64', 'u128'
 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_lt_invalid.move:18:11
+   │
+18 │         1 < ();
+   │         - ^ -- Found: '()'. It is not compatible with the other type.
+   │         │ │  
+   │         │ Incompatible arguments to '<'
+   │         Found: integer. It is not compatible with the other type.
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_lt_invalid.move:19:9
    │
@@ -144,6 +207,15 @@ error[E04003]: built-in operation not supported
    │         │
    │         Invalid argument to '<'
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_lt_invalid.move:19:16
+   │
+19 │         (0, 1) < (0, 1, 2);
+   │         ------ ^ --------- Found expression list of length 3: '({integer}, {integer}, {integer})'. It is not compatible with the other type of length 2.
+   │         │      │  
+   │         │      Incompatible arguments to '<'
+   │         Found expression list of length 2: '({integer}, {integer})'. It is not compatible with the other type of length 3.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_lt_invalid.move:19:18
@@ -169,116 +241,4 @@ error[E04003]: built-in operation not supported
    │         ------   ^^^^^^ Invalid argument to '<'
    │         │         
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-
-error: 
-
-   ┌── tests/move_check/typing/binary_lt_invalid.move:9:13 ───
-   │
- 9 │         1 < false;
-   │             ^^^^^ Incompatible arguments to '<'
-   ·
- 9 │         1 < false;
-   │         - The type: integer
-   ·
- 9 │         1 < false;
-   │             ----- Is not compatible with: 'bool'
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_lt_invalid.move:10:17 ───
-    │
- 10 │         false < 1;
-    │                 ^ Incompatible arguments to '<'
-    ·
- 10 │         false < 1;
-    │                 - The type: integer
-    ·
- 10 │         false < 1;
-    │         ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_lt_invalid.move:12:19 ───
-    │
- 12 │         (0: u8) < (1: u128);
-    │                   ^^^^^^^^^ Incompatible arguments to '<'
-    ·
- 12 │         (0: u8) < (1: u128);
-    │             -- The type: 'u8'
-    ·
- 12 │         (0: u8) < (1: u128);
-    │                       ---- Is not compatible with: 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_lt_invalid.move:15:17 ───
-    │
- 15 │         0 < 1 < 2;
-    │                 ^ Incompatible arguments to '<'
-    ·
- 15 │         0 < 1 < 2;
-    │                 - The type: integer
-    ·
- 15 │         0 < 1 < 2;
-    │         ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_lt_invalid.move:16:14 ───
-    │
- 16 │         (1 < false) && (@0x0 < 0);
-    │              ^^^^^ Incompatible arguments to '<'
-    ·
- 16 │         (1 < false) && (@0x0 < 0);
-    │          - The type: integer
-    ·
- 16 │         (1 < false) && (@0x0 < 0);
-    │              ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_lt_invalid.move:16:32 ───
-    │
- 16 │         (1 < false) && (@0x0 < 0);
-    │                                ^ Incompatible arguments to '<'
-    ·
- 16 │         (1 < false) && (@0x0 < 0);
-    │                                - The type: integer
-    ·
- 16 │         (1 < false) && (@0x0 < 0);
-    │                         ---- Is not compatible with: 'address'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_lt_invalid.move:18:13 ───
-    │
- 18 │         1 < ();
-    │             ^^ Incompatible arguments to '<'
-    ·
- 18 │         1 < ();
-    │         - The type: integer
-    ·
- 18 │         1 < ();
-    │             -- Is not compatible with: '()'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_lt_invalid.move:19:18 ───
-    │
- 19 │         (0, 1) < (0, 1, 2);
-    │                  ^^^^^^^^^ Incompatible arguments to '<'
-    ·
- 19 │         (0, 1) < (0, 1, 2);
-    │         ------ The expression list type of length 2: '({integer}, {integer})'
-    ·
- 19 │         (0, 1) < (0, 1, 2);
-    │                  --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
-    │
 

--- a/language/move-lang/tests/move_check/typing/binary_mod_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_mod_invalid.exp
@@ -15,6 +15,15 @@ error[E04003]: built-in operation not supported
   │         │        
   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/binary_mod_invalid.move:9:11
+  │
+9 │         1 % false;
+  │         - ^ ----- Found: 'bool'. It is not compatible with the other type.
+  │         │ │  
+  │         │ Incompatible arguments to '%'
+  │         Found: integer. It is not compatible with the other type.
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_mod_invalid.move:10:9
    │
@@ -23,6 +32,15 @@ error[E04003]: built-in operation not supported
    │         │
    │         Invalid argument to '%'
    │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_mod_invalid.move:10:15
+   │
+10 │         false % 1;
+   │         ----- ^ - Found: integer. It is not compatible with the other type.
+   │         │     │  
+   │         │     Incompatible arguments to '%'
+   │         Found: 'bool'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_mod_invalid.move:10:17
@@ -48,6 +66,15 @@ error[E04003]: built-in operation not supported
    │         ----   ^^^^ Invalid argument to '%'
    │         │       
    │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_mod_invalid.move:12:17
+   │
+12 │         (0: u8) % (1: u128);
+   │             --  ^     ---- Found: 'u128'. It is not compatible with the other type.
+   │             │   │      
+   │             │   Incompatible arguments to '%'
+   │             Found: 'u8'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_mod_invalid.move:13:9
@@ -102,8 +129,8 @@ error[E04003]: built-in operation not supported
    │
 15 │         1 % false % @0x0 % 0;
    │         ^^^^^^^^^
-   │         │   │
-   │         │   Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         │ │
+   │         │ Found: '_'. But expected: 'u8', 'u64', 'u128'
    │         Invalid argument to '%'
 
 error[E04003]: built-in operation not supported
@@ -115,13 +142,31 @@ error[E04003]: built-in operation not supported
    │         │           Found: 'address'. But expected: 'u8', 'u64', 'u128'
    │         Invalid argument to '%'
 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_mod_invalid.move:15:11
+   │
+15 │         1 % false % @0x0 % 0;
+   │         - ^ ----- Found: 'bool'. It is not compatible with the other type.
+   │         │ │  
+   │         │ Incompatible arguments to '%'
+   │         Found: integer. It is not compatible with the other type.
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_mod_invalid.move:15:21
    │
 15 │         1 % false % @0x0 % 0;
-   │             -----   ^^^^ Invalid argument to '%'
-   │             │        
-   │             Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │           -         ^^^^ Invalid argument to '%'
+   │           │          
+   │           Found: '_'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_mod_invalid.move:15:26
+   │
+15 │         1 % false % @0x0 % 0;
+   │                     ---- ^ - Found: integer. It is not compatible with the other type.
+   │                     │    │  
+   │                     │    Incompatible arguments to '%'
+   │                     Found: 'address'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_mod_invalid.move:15:28
@@ -148,6 +193,15 @@ error[E04003]: built-in operation not supported
    │         │     
    │         Found: '()'. But expected: 'u8', 'u64', 'u128'
 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_mod_invalid.move:17:11
+   │
+17 │         1 % ();
+   │         - ^ -- Found: '()'. It is not compatible with the other type.
+   │         │ │  
+   │         │ Incompatible arguments to '%'
+   │         Found: integer. It is not compatible with the other type.
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_mod_invalid.move:18:9
    │
@@ -156,6 +210,15 @@ error[E04003]: built-in operation not supported
    │         │
    │         Invalid argument to '%'
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_mod_invalid.move:18:16
+   │
+18 │         (0, 1) % (0, 1, 2);
+   │         ------ ^ --------- Found expression list of length 3: '({integer}, {integer}, {integer})'. It is not compatible with the other type of length 2.
+   │         │      │  
+   │         │      Incompatible arguments to '%'
+   │         Found expression list of length 2: '({integer}, {integer})'. It is not compatible with the other type of length 3.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_mod_invalid.move:18:18
@@ -181,102 +244,4 @@ error[E04003]: built-in operation not supported
    │         ------   ^^^^^^ Invalid argument to '%'
    │         │         
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-
-error: 
-
-   ┌── tests/move_check/typing/binary_mod_invalid.move:9:13 ───
-   │
- 9 │         1 % false;
-   │             ^^^^^ Incompatible arguments to '%'
-   ·
- 9 │         1 % false;
-   │         - The type: integer
-   ·
- 9 │         1 % false;
-   │             ----- Is not compatible with: 'bool'
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mod_invalid.move:10:17 ───
-    │
- 10 │         false % 1;
-    │                 ^ Incompatible arguments to '%'
-    ·
- 10 │         false % 1;
-    │                 - The type: integer
-    ·
- 10 │         false % 1;
-    │         ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mod_invalid.move:12:19 ───
-    │
- 12 │         (0: u8) % (1: u128);
-    │                   ^^^^^^^^^ Incompatible arguments to '%'
-    ·
- 12 │         (0: u8) % (1: u128);
-    │             -- The type: 'u8'
-    ·
- 12 │         (0: u8) % (1: u128);
-    │                       ---- Is not compatible with: 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mod_invalid.move:15:13 ───
-    │
- 15 │         1 % false % @0x0 % 0;
-    │             ^^^^^ Incompatible arguments to '%'
-    ·
- 15 │         1 % false % @0x0 % 0;
-    │         - The type: integer
-    ·
- 15 │         1 % false % @0x0 % 0;
-    │             ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mod_invalid.move:15:28 ───
-    │
- 15 │         1 % false % @0x0 % 0;
-    │                            ^ Incompatible arguments to '%'
-    ·
- 15 │         1 % false % @0x0 % 0;
-    │                            - The type: integer
-    ·
- 15 │         1 % false % @0x0 % 0;
-    │                     ---- Is not compatible with: 'address'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mod_invalid.move:17:13 ───
-    │
- 17 │         1 % ();
-    │             ^^ Incompatible arguments to '%'
-    ·
- 17 │         1 % ();
-    │         - The type: integer
-    ·
- 17 │         1 % ();
-    │             -- Is not compatible with: '()'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mod_invalid.move:18:18 ───
-    │
- 18 │         (0, 1) % (0, 1, 2);
-    │                  ^^^^^^^^^ Incompatible arguments to '%'
-    ·
- 18 │         (0, 1) % (0, 1, 2);
-    │         ------ The expression list type of length 2: '({integer}, {integer})'
-    ·
- 18 │         (0, 1) % (0, 1, 2);
-    │                  --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
-    │
 

--- a/language/move-lang/tests/move_check/typing/binary_mul_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_mul_invalid.exp
@@ -15,6 +15,15 @@ error[E04003]: built-in operation not supported
   │         │        
   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/binary_mul_invalid.move:9:11
+  │
+9 │         1 * false;
+  │         - ^ ----- Found: 'bool'. It is not compatible with the other type.
+  │         │ │  
+  │         │ Incompatible arguments to '*'
+  │         Found: integer. It is not compatible with the other type.
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_mul_invalid.move:10:9
    │
@@ -23,6 +32,15 @@ error[E04003]: built-in operation not supported
    │         │
    │         Invalid argument to '*'
    │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_mul_invalid.move:10:15
+   │
+10 │         false * 1;
+   │         ----- ^ - Found: integer. It is not compatible with the other type.
+   │         │     │  
+   │         │     Incompatible arguments to '*'
+   │         Found: 'bool'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_mul_invalid.move:10:17
@@ -48,6 +66,15 @@ error[E04003]: built-in operation not supported
    │         ----   ^^^^ Invalid argument to '*'
    │         │       
    │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_mul_invalid.move:12:17
+   │
+12 │         (0: u8) * (1: u128);
+   │             --  ^     ---- Found: 'u128'. It is not compatible with the other type.
+   │             │   │      
+   │             │   Incompatible arguments to '*'
+   │             Found: 'u8'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_mul_invalid.move:13:9
@@ -102,8 +129,8 @@ error[E04003]: built-in operation not supported
    │
 15 │         1 * false * @0x0 * 0;
    │         ^^^^^^^^^
-   │         │   │
-   │         │   Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         │ │
+   │         │ Found: '_'. But expected: 'u8', 'u64', 'u128'
    │         Invalid argument to '*'
 
 error[E04003]: built-in operation not supported
@@ -115,13 +142,31 @@ error[E04003]: built-in operation not supported
    │         │           Found: 'address'. But expected: 'u8', 'u64', 'u128'
    │         Invalid argument to '*'
 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_mul_invalid.move:15:11
+   │
+15 │         1 * false * @0x0 * 0;
+   │         - ^ ----- Found: 'bool'. It is not compatible with the other type.
+   │         │ │  
+   │         │ Incompatible arguments to '*'
+   │         Found: integer. It is not compatible with the other type.
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_mul_invalid.move:15:21
    │
 15 │         1 * false * @0x0 * 0;
-   │             -----   ^^^^ Invalid argument to '*'
-   │             │        
-   │             Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │           -         ^^^^ Invalid argument to '*'
+   │           │          
+   │           Found: '_'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_mul_invalid.move:15:26
+   │
+15 │         1 * false * @0x0 * 0;
+   │                     ---- ^ - Found: integer. It is not compatible with the other type.
+   │                     │    │  
+   │                     │    Incompatible arguments to '*'
+   │                     Found: 'address'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_mul_invalid.move:15:28
@@ -148,6 +193,15 @@ error[E04003]: built-in operation not supported
    │         │     
    │         Found: '()'. But expected: 'u8', 'u64', 'u128'
 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_mul_invalid.move:17:11
+   │
+17 │         1 * ();
+   │         - ^ -- Found: '()'. It is not compatible with the other type.
+   │         │ │  
+   │         │ Incompatible arguments to '*'
+   │         Found: integer. It is not compatible with the other type.
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_mul_invalid.move:18:9
    │
@@ -156,6 +210,15 @@ error[E04003]: built-in operation not supported
    │         │
    │         Invalid argument to '*'
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_mul_invalid.move:18:16
+   │
+18 │         (0, 1) * (0, 1, 2);
+   │         ------ ^ --------- Found expression list of length 3: '({integer}, {integer}, {integer})'. It is not compatible with the other type of length 2.
+   │         │      │  
+   │         │      Incompatible arguments to '*'
+   │         Found expression list of length 2: '({integer}, {integer})'. It is not compatible with the other type of length 3.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_mul_invalid.move:18:18
@@ -181,102 +244,4 @@ error[E04003]: built-in operation not supported
    │         ------   ^^^^^^ Invalid argument to '*'
    │         │         
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-
-error: 
-
-   ┌── tests/move_check/typing/binary_mul_invalid.move:9:13 ───
-   │
- 9 │         1 * false;
-   │             ^^^^^ Incompatible arguments to '*'
-   ·
- 9 │         1 * false;
-   │         - The type: integer
-   ·
- 9 │         1 * false;
-   │             ----- Is not compatible with: 'bool'
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mul_invalid.move:10:17 ───
-    │
- 10 │         false * 1;
-    │                 ^ Incompatible arguments to '*'
-    ·
- 10 │         false * 1;
-    │                 - The type: integer
-    ·
- 10 │         false * 1;
-    │         ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mul_invalid.move:12:19 ───
-    │
- 12 │         (0: u8) * (1: u128);
-    │                   ^^^^^^^^^ Incompatible arguments to '*'
-    ·
- 12 │         (0: u8) * (1: u128);
-    │             -- The type: 'u8'
-    ·
- 12 │         (0: u8) * (1: u128);
-    │                       ---- Is not compatible with: 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mul_invalid.move:15:13 ───
-    │
- 15 │         1 * false * @0x0 * 0;
-    │             ^^^^^ Incompatible arguments to '*'
-    ·
- 15 │         1 * false * @0x0 * 0;
-    │         - The type: integer
-    ·
- 15 │         1 * false * @0x0 * 0;
-    │             ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mul_invalid.move:15:28 ───
-    │
- 15 │         1 * false * @0x0 * 0;
-    │                            ^ Incompatible arguments to '*'
-    ·
- 15 │         1 * false * @0x0 * 0;
-    │                            - The type: integer
-    ·
- 15 │         1 * false * @0x0 * 0;
-    │                     ---- Is not compatible with: 'address'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mul_invalid.move:17:13 ───
-    │
- 17 │         1 * ();
-    │             ^^ Incompatible arguments to '*'
-    ·
- 17 │         1 * ();
-    │         - The type: integer
-    ·
- 17 │         1 * ();
-    │             -- Is not compatible with: '()'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mul_invalid.move:18:18 ───
-    │
- 18 │         (0, 1) * (0, 1, 2);
-    │                  ^^^^^^^^^ Incompatible arguments to '*'
-    ·
- 18 │         (0, 1) * (0, 1, 2);
-    │         ------ The expression list type of length 2: '({integer}, {integer})'
-    ·
- 18 │         (0, 1) * (0, 1, 2);
-    │                  --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
-    │
 

--- a/language/move-lang/tests/move_check/typing/binary_or_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_or_invalid.exp
@@ -1,266 +1,187 @@
-error: 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/binary_or_invalid.move:8:9
+  │
+8 │         0 || 1;
+  │         ^ -- Expected: 'bool'
+  │         │  
+  │         Invalid argument to '||'
+  │         Given: integer
 
-   ┌── tests/move_check/typing/binary_or_invalid.move:8:9 ───
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/binary_or_invalid.move:8:14
+  │
+8 │         0 || 1;
+  │           -- ^
+  │           │  │
+  │           │  Invalid argument to '||'
+  │           │  Given: integer
+  │           Expected: 'bool'
+
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/binary_or_invalid.move:9:9
+  │
+9 │         1 || false;
+  │         ^ -- Expected: 'bool'
+  │         │  
+  │         Invalid argument to '||'
+  │         Given: integer
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_or_invalid.move:10:18
    │
- 8 │         0 || 1;
-   │         ^ Incompatible arguments to '||'
-   ·
- 8 │         0 || 1;
-   │         - The type: integer
-   ·
- 8 │         0 || 1;
-   │         - Is not compatible with: 'bool'
+10 │         false || 1;
+   │               -- ^
+   │               │  │
+   │               │  Invalid argument to '||'
+   │               │  Given: integer
+   │               Expected: 'bool'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_or_invalid.move:11:9
    │
+11 │         @0x0 || @0x1;
+   │         ^^^^ -- Expected: 'bool'
+   │         │     
+   │         Invalid argument to '||'
+   │         Given: 'address'
 
-error: 
-
-   ┌── tests/move_check/typing/binary_or_invalid.move:8:14 ───
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_or_invalid.move:11:17
    │
- 8 │         0 || 1;
-   │              ^ Incompatible arguments to '||'
-   ·
- 8 │         0 || 1;
-   │              - The type: integer
-   ·
- 8 │         0 || 1;
-   │         - Is not compatible with: 'bool'
+11 │         @0x0 || @0x1;
+   │              -- ^^^^
+   │              │  │
+   │              │  Invalid argument to '||'
+   │              │  Given: 'address'
+   │              Expected: 'bool'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_or_invalid.move:12:9
    │
+12 │         (0: u8) || (1: u128);
+   │         ^^^^^^^ -- Expected: 'bool'
+   │         │   │    
+   │         │   Given: 'u8'
+   │         Invalid argument to '||'
 
-error: 
-
-   ┌── tests/move_check/typing/binary_or_invalid.move:9:9 ───
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_or_invalid.move:12:20
    │
- 9 │         1 || false;
-   │         ^ Incompatible arguments to '||'
-   ·
- 9 │         1 || false;
-   │         - The type: integer
-   ·
- 9 │         1 || false;
-   │         - Is not compatible with: 'bool'
+12 │         (0: u8) || (1: u128);
+   │                 -- ^^^^^^^^^
+   │                 │  │   │
+   │                 │  │   Given: 'u128'
+   │                 │  Invalid argument to '||'
+   │                 Expected: 'bool'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_or_invalid.move:13:9
    │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Given: '0x8675309::M::R'
+   ·
+13 │         r || r;
+   │         ^ -- Expected: 'bool'
+   │         │  
+   │         Invalid argument to '||'
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_or_invalid.move:13:14
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Given: '0x8675309::M::R'
+   ·
+13 │         r || r;
+   │           -- ^ Invalid argument to '||'
+   │           │   
+   │           Expected: 'bool'
 
-    ┌── tests/move_check/typing/binary_or_invalid.move:10:18 ───
-    │
- 10 │         false || 1;
-    │                  ^ Incompatible arguments to '||'
-    ·
- 10 │         false || 1;
-    │                  - The type: integer
-    ·
- 10 │         false || 1;
-    │         ----- Is not compatible with: 'bool'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_or_invalid.move:14:9
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Given: '0x8675309::M::S'
+   ·
+14 │         s || s;
+   │         ^ -- Expected: 'bool'
+   │         │  
+   │         Invalid argument to '||'
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_or_invalid.move:14:14
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Given: '0x8675309::M::S'
+   ·
+14 │         s || s;
+   │           -- ^ Invalid argument to '||'
+   │           │   
+   │           Expected: 'bool'
 
-    ┌── tests/move_check/typing/binary_or_invalid.move:11:9 ───
-    │
- 11 │         @0x0 || @0x1;
-    │         ^^^^ Incompatible arguments to '||'
-    ·
- 11 │         @0x0 || @0x1;
-    │         ---- The type: 'address'
-    ·
- 11 │         @0x0 || @0x1;
-    │         ---- Is not compatible with: 'bool'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_or_invalid.move:15:9
+   │
+15 │         () || ();
+   │         ^^ -- Expected: 'bool'
+   │         │   
+   │         Invalid argument to '||'
+   │         Given: '()'
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_or_invalid.move:15:15
+   │
+15 │         () || ();
+   │            -- ^^
+   │            │  │
+   │            │  Invalid argument to '||'
+   │            │  Given: '()'
+   │            Expected: 'bool'
 
-    ┌── tests/move_check/typing/binary_or_invalid.move:11:17 ───
-    │
- 11 │         @0x0 || @0x1;
-    │                 ^^^^ Incompatible arguments to '||'
-    ·
- 11 │         @0x0 || @0x1;
-    │                 ---- The type: 'address'
-    ·
- 11 │         @0x0 || @0x1;
-    │         ---- Is not compatible with: 'bool'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_or_invalid.move:16:17
+   │
+16 │         true || ();
+   │              -- ^^
+   │              │  │
+   │              │  Invalid argument to '||'
+   │              │  Given: '()'
+   │              Expected: 'bool'
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_or_invalid.move:17:9
+   │
+17 │         (true, false) || (true, false, true);
+   │         ^^^^^^^^^^^^^ -- Expected: 'bool'
+   │         │              
+   │         Invalid argument to '||'
+   │         Given: '(bool, bool)'
 
-    ┌── tests/move_check/typing/binary_or_invalid.move:12:9 ───
-    │
- 12 │         (0: u8) || (1: u128);
-    │         ^^^^^^^ Incompatible arguments to '||'
-    ·
- 12 │         (0: u8) || (1: u128);
-    │             -- The type: 'u8'
-    ·
- 12 │         (0: u8) || (1: u128);
-    │         ------- Is not compatible with: 'bool'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_or_invalid.move:17:26
+   │
+17 │         (true, false) || (true, false, true);
+   │                       -- ^^^^^^^^^^^^^^^^^^^
+   │                       │  │
+   │                       │  Invalid argument to '||'
+   │                       │  Given: '(bool, bool, bool)'
+   │                       Expected: 'bool'
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_or_invalid.move:18:9
+   │
+18 │         (true, true) || (false, false);
+   │         ^^^^^^^^^^^^ -- Expected: 'bool'
+   │         │             
+   │         Invalid argument to '||'
+   │         Given: '(bool, bool)'
 
-    ┌── tests/move_check/typing/binary_or_invalid.move:12:20 ───
-    │
- 12 │         (0: u8) || (1: u128);
-    │                    ^^^^^^^^^ Incompatible arguments to '||'
-    ·
- 12 │         (0: u8) || (1: u128);
-    │                        ---- The type: 'u128'
-    ·
- 12 │         (0: u8) || (1: u128);
-    │         ------- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_or_invalid.move:13:9 ───
-    │
- 13 │         r || r;
-    │         ^ Incompatible arguments to '||'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - The type: '0x8675309::M::R'
-    ·
- 13 │         r || r;
-    │         - Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_or_invalid.move:13:14 ───
-    │
- 13 │         r || r;
-    │              ^ Incompatible arguments to '||'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - The type: '0x8675309::M::R'
-    ·
- 13 │         r || r;
-    │         - Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_or_invalid.move:14:9 ───
-    │
- 14 │         s || s;
-    │         ^ Incompatible arguments to '||'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - The type: '0x8675309::M::S'
-    ·
- 14 │         s || s;
-    │         - Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_or_invalid.move:14:14 ───
-    │
- 14 │         s || s;
-    │              ^ Incompatible arguments to '||'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - The type: '0x8675309::M::S'
-    ·
- 14 │         s || s;
-    │         - Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_or_invalid.move:15:9 ───
-    │
- 15 │         () || ();
-    │         ^^ Incompatible arguments to '||'
-    ·
- 15 │         () || ();
-    │         -- The type: '()'
-    ·
- 15 │         () || ();
-    │         -- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_or_invalid.move:15:15 ───
-    │
- 15 │         () || ();
-    │               ^^ Incompatible arguments to '||'
-    ·
- 15 │         () || ();
-    │               -- The type: '()'
-    ·
- 15 │         () || ();
-    │         -- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_or_invalid.move:16:17 ───
-    │
- 16 │         true || ();
-    │                 ^^ Incompatible arguments to '||'
-    ·
- 16 │         true || ();
-    │                 -- The type: '()'
-    ·
- 16 │         true || ();
-    │         ---- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_or_invalid.move:17:9 ───
-    │
- 17 │         (true, false) || (true, false, true);
-    │         ^^^^^^^^^^^^^ Incompatible arguments to '||'
-    ·
- 17 │         (true, false) || (true, false, true);
-    │         ------------- The type: '(bool, bool)'
-    ·
- 17 │         (true, false) || (true, false, true);
-    │         ------------- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_or_invalid.move:17:26 ───
-    │
- 17 │         (true, false) || (true, false, true);
-    │                          ^^^^^^^^^^^^^^^^^^^ Incompatible arguments to '||'
-    ·
- 17 │         (true, false) || (true, false, true);
-    │                          ------------------- The type: '(bool, bool, bool)'
-    ·
- 17 │         (true, false) || (true, false, true);
-    │         ------------- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_or_invalid.move:18:9 ───
-    │
- 18 │         (true, true) || (false, false);
-    │         ^^^^^^^^^^^^ Incompatible arguments to '||'
-    ·
- 18 │         (true, true) || (false, false);
-    │         ------------ The type: '(bool, bool)'
-    ·
- 18 │         (true, true) || (false, false);
-    │         ------------ Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_or_invalid.move:18:25 ───
-    │
- 18 │         (true, true) || (false, false);
-    │                         ^^^^^^^^^^^^^^ Incompatible arguments to '||'
-    ·
- 18 │         (true, true) || (false, false);
-    │                         -------------- The type: '(bool, bool)'
-    ·
- 18 │         (true, true) || (false, false);
-    │         ------------ Is not compatible with: 'bool'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_or_invalid.move:18:25
+   │
+18 │         (true, true) || (false, false);
+   │                      -- ^^^^^^^^^^^^^^
+   │                      │  │
+   │                      │  Invalid argument to '||'
+   │                      │  Given: '(bool, bool)'
+   │                      Expected: 'bool'
 

--- a/language/move-lang/tests/move_check/typing/binary_shl_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_shl_invalid.exp
@@ -7,6 +7,26 @@ error[E04003]: built-in operation not supported
   │         Invalid argument to '<<'
   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/binary_shl_invalid.move:8:18
+  │
+8 │         false << true;
+  │                  ^^^^
+  │                  │
+  │                  Invalid argument to '<<'
+  │                  Expected: 'u8'
+  │                  Given: 'bool'
+
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/binary_shl_invalid.move:9:14
+  │
+9 │         1 << false;
+  │              ^^^^^
+  │              │
+  │              Invalid argument to '<<'
+  │              Expected: 'u8'
+  │              Given: 'bool'
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_shl_invalid.move:10:9
    │
@@ -24,6 +44,26 @@ error[E04003]: built-in operation not supported
    │         │
    │         Invalid argument to '<<'
    │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_shl_invalid.move:11:17
+   │
+11 │         @0x0 << @0x1;
+   │                 ^^^^
+   │                 │
+   │                 Invalid argument to '<<'
+   │                 Expected: 'u8'
+   │                 Given: 'address'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_shl_invalid.move:12:20
+   │
+12 │         (0: u8) << (1: u128);
+   │                    ^^^^^^^^^
+   │                    │   │
+   │                    │   Given: 'u128'
+   │                    Invalid argument to '<<'
+   │                    Expected: 'u8'
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_shl_invalid.move:13:9
@@ -46,6 +86,18 @@ error[E05001]: ability constraint not satisfied
 13 │         r << r;
    │         ^^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_shl_invalid.move:13:14
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Given: '0x8675309::M::R'
+   ·
+13 │         r << r;
+   │              ^
+   │              │
+   │              Invalid argument to '<<'
+   │              Expected: 'u8'
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_shl_invalid.move:14:9
    │
@@ -54,6 +106,38 @@ error[E04003]: built-in operation not supported
    ·
 14 │         s << s;
    │         ^ Invalid argument to '<<'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_shl_invalid.move:14:14
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Given: '0x8675309::M::S'
+   ·
+14 │         s << s;
+   │              ^
+   │              │
+   │              Invalid argument to '<<'
+   │              Expected: 'u8'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_shl_invalid.move:15:14
+   │
+15 │         1 << false << @0x0 << 0;
+   │              ^^^^^
+   │              │
+   │              Invalid argument to '<<'
+   │              Expected: 'u8'
+   │              Given: 'bool'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_shl_invalid.move:15:23
+   │
+15 │         1 << false << @0x0 << 0;
+   │                       ^^^^
+   │                       │
+   │                       Invalid argument to '<<'
+   │                       Expected: 'u8'
+   │                       Given: 'address'
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_shl_invalid.move:16:9
@@ -64,6 +148,26 @@ error[E04003]: built-in operation not supported
    │         Invalid argument to '<<'
    │         Found: '()'. But expected: 'u8', 'u64', 'u128'
 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_shl_invalid.move:16:15
+   │
+16 │         () << ();
+   │               ^^
+   │               │
+   │               Invalid argument to '<<'
+   │               Expected: 'u8'
+   │               Given: '()'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_shl_invalid.move:17:14
+   │
+17 │         1 << ();
+   │              ^^
+   │              │
+   │              Invalid argument to '<<'
+   │              Expected: 'u8'
+   │              Given: '()'
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_shl_invalid.move:18:9
    │
@@ -72,6 +176,16 @@ error[E04003]: built-in operation not supported
    │         │
    │         Invalid argument to '<<'
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_shl_invalid.move:18:19
+   │
+18 │         (0, 1) << (0, 1, 2);
+   │                   ^^^^^^^^^
+   │                   │
+   │                   Invalid argument to '<<'
+   │                   Expected: 'u8'
+   │                   Given: '({integer}, {integer}, {integer})'
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_shl_invalid.move:19:9
@@ -82,171 +196,13 @@ error[E04003]: built-in operation not supported
    │         Invalid argument to '<<'
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
 
-error: 
-
-   ┌── tests/move_check/typing/binary_shl_invalid.move:8:18 ───
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_shl_invalid.move:19:19
    │
- 8 │         false << true;
-   │                  ^^^^ Invalid argument to '<<'
-   ·
- 8 │         false << true;
-   │                  ---- The type: 'bool'
-   ·
- 8 │         false << true;
-   │                  ---- Is not compatible with: 'u8'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/binary_shl_invalid.move:9:14 ───
-   │
- 9 │         1 << false;
-   │              ^^^^^ Invalid argument to '<<'
-   ·
- 9 │         1 << false;
-   │              ----- The type: 'bool'
-   ·
- 9 │         1 << false;
-   │              ----- Is not compatible with: 'u8'
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_shl_invalid.move:11:17 ───
-    │
- 11 │         @0x0 << @0x1;
-    │                 ^^^^ Invalid argument to '<<'
-    ·
- 11 │         @0x0 << @0x1;
-    │                 ---- The type: 'address'
-    ·
- 11 │         @0x0 << @0x1;
-    │                 ---- Is not compatible with: 'u8'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_shl_invalid.move:12:20 ───
-    │
- 12 │         (0: u8) << (1: u128);
-    │                    ^^^^^^^^^ Invalid argument to '<<'
-    ·
- 12 │         (0: u8) << (1: u128);
-    │                        ---- The type: 'u128'
-    ·
- 12 │         (0: u8) << (1: u128);
-    │                    --------- Is not compatible with: 'u8'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_shl_invalid.move:13:14 ───
-    │
- 13 │         r << r;
-    │              ^ Invalid argument to '<<'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - The type: '0x8675309::M::R'
-    ·
- 13 │         r << r;
-    │              - Is not compatible with: 'u8'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_shl_invalid.move:14:14 ───
-    │
- 14 │         s << s;
-    │              ^ Invalid argument to '<<'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - The type: '0x8675309::M::S'
-    ·
- 14 │         s << s;
-    │              - Is not compatible with: 'u8'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_shl_invalid.move:15:14 ───
-    │
- 15 │         1 << false << @0x0 << 0;
-    │              ^^^^^ Invalid argument to '<<'
-    ·
- 15 │         1 << false << @0x0 << 0;
-    │              ----- The type: 'bool'
-    ·
- 15 │         1 << false << @0x0 << 0;
-    │              ----- Is not compatible with: 'u8'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_shl_invalid.move:15:23 ───
-    │
- 15 │         1 << false << @0x0 << 0;
-    │                       ^^^^ Invalid argument to '<<'
-    ·
- 15 │         1 << false << @0x0 << 0;
-    │                       ---- The type: 'address'
-    ·
- 15 │         1 << false << @0x0 << 0;
-    │                       ---- Is not compatible with: 'u8'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_shl_invalid.move:16:15 ───
-    │
- 16 │         () << ();
-    │               ^^ Invalid argument to '<<'
-    ·
- 16 │         () << ();
-    │               -- The type: '()'
-    ·
- 16 │         () << ();
-    │               -- Is not compatible with: 'u8'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_shl_invalid.move:17:14 ───
-    │
- 17 │         1 << ();
-    │              ^^ Invalid argument to '<<'
-    ·
- 17 │         1 << ();
-    │              -- The type: '()'
-    ·
- 17 │         1 << ();
-    │              -- Is not compatible with: 'u8'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_shl_invalid.move:18:19 ───
-    │
- 18 │         (0, 1) << (0, 1, 2);
-    │                   ^^^^^^^^^ Invalid argument to '<<'
-    ·
- 18 │         (0, 1) << (0, 1, 2);
-    │                   --------- The type: '({integer}, {integer}, {integer})'
-    ·
- 18 │         (0, 1) << (0, 1, 2);
-    │                   --------- Is not compatible with: 'u8'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_shl_invalid.move:19:19 ───
-    │
- 19 │         (1, 2) << (0, 1);
-    │                   ^^^^^^ Invalid argument to '<<'
-    ·
- 19 │         (1, 2) << (0, 1);
-    │                   ------ The type: '({integer}, {integer})'
-    ·
- 19 │         (1, 2) << (0, 1);
-    │                   ------ Is not compatible with: 'u8'
-    │
+19 │         (1, 2) << (0, 1);
+   │                   ^^^^^^
+   │                   │
+   │                   Invalid argument to '<<'
+   │                   Expected: 'u8'
+   │                   Given: '({integer}, {integer})'
 

--- a/language/move-lang/tests/move_check/typing/binary_shr_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_shr_invalid.exp
@@ -7,6 +7,26 @@ error[E04003]: built-in operation not supported
   │         Invalid argument to '>>'
   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/binary_shr_invalid.move:8:18
+  │
+8 │         false >> true;
+  │                  ^^^^
+  │                  │
+  │                  Invalid argument to '>>'
+  │                  Expected: 'u8'
+  │                  Given: 'bool'
+
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/binary_shr_invalid.move:9:14
+  │
+9 │         1 >> false;
+  │              ^^^^^
+  │              │
+  │              Invalid argument to '>>'
+  │              Expected: 'u8'
+  │              Given: 'bool'
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_shr_invalid.move:10:9
    │
@@ -24,6 +44,26 @@ error[E04003]: built-in operation not supported
    │         │
    │         Invalid argument to '>>'
    │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_shr_invalid.move:11:17
+   │
+11 │         @0x0 >> @0x1;
+   │                 ^^^^
+   │                 │
+   │                 Invalid argument to '>>'
+   │                 Expected: 'u8'
+   │                 Given: 'address'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_shr_invalid.move:12:20
+   │
+12 │         (0: u8) >> (1: u128);
+   │                    ^^^^^^^^^
+   │                    │   │
+   │                    │   Given: 'u128'
+   │                    Invalid argument to '>>'
+   │                    Expected: 'u8'
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_shr_invalid.move:13:9
@@ -46,6 +86,18 @@ error[E05001]: ability constraint not satisfied
 13 │         r >> r;
    │         ^^^^^^ Cannot ignore values without the 'drop' ability. The value must be used
 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_shr_invalid.move:13:14
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                       - Given: '0x8675309::M::R'
+   ·
+13 │         r >> r;
+   │              ^
+   │              │
+   │              Invalid argument to '>>'
+   │              Expected: 'u8'
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_shr_invalid.move:14:9
    │
@@ -54,6 +106,38 @@ error[E04003]: built-in operation not supported
    ·
 14 │         s >> s;
    │         ^ Invalid argument to '>>'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_shr_invalid.move:14:14
+   │
+ 7 │     fun t0(x: u64, r: R, s: S) {
+   │                             - Given: '0x8675309::M::S'
+   ·
+14 │         s >> s;
+   │              ^
+   │              │
+   │              Invalid argument to '>>'
+   │              Expected: 'u8'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_shr_invalid.move:15:14
+   │
+15 │         1 >> false >> @0x0 >> 0;
+   │              ^^^^^
+   │              │
+   │              Invalid argument to '>>'
+   │              Expected: 'u8'
+   │              Given: 'bool'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_shr_invalid.move:15:23
+   │
+15 │         1 >> false >> @0x0 >> 0;
+   │                       ^^^^
+   │                       │
+   │                       Invalid argument to '>>'
+   │                       Expected: 'u8'
+   │                       Given: 'address'
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_shr_invalid.move:16:9
@@ -64,6 +148,26 @@ error[E04003]: built-in operation not supported
    │         Invalid argument to '>>'
    │         Found: '()'. But expected: 'u8', 'u64', 'u128'
 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_shr_invalid.move:16:15
+   │
+16 │         () >> ();
+   │               ^^
+   │               │
+   │               Invalid argument to '>>'
+   │               Expected: 'u8'
+   │               Given: '()'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_shr_invalid.move:17:14
+   │
+17 │         1 >> ();
+   │              ^^
+   │              │
+   │              Invalid argument to '>>'
+   │              Expected: 'u8'
+   │              Given: '()'
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_shr_invalid.move:18:9
    │
@@ -72,6 +176,16 @@ error[E04003]: built-in operation not supported
    │         │
    │         Invalid argument to '>>'
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_shr_invalid.move:18:19
+   │
+18 │         (0, 1) >> (0, 1, 2);
+   │                   ^^^^^^^^^
+   │                   │
+   │                   Invalid argument to '>>'
+   │                   Expected: 'u8'
+   │                   Given: '({integer}, {integer}, {integer})'
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_shr_invalid.move:19:9
@@ -82,171 +196,13 @@ error[E04003]: built-in operation not supported
    │         Invalid argument to '>>'
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
 
-error: 
-
-   ┌── tests/move_check/typing/binary_shr_invalid.move:8:18 ───
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_shr_invalid.move:19:19
    │
- 8 │         false >> true;
-   │                  ^^^^ Invalid argument to '>>'
-   ·
- 8 │         false >> true;
-   │                  ---- The type: 'bool'
-   ·
- 8 │         false >> true;
-   │                  ---- Is not compatible with: 'u8'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/binary_shr_invalid.move:9:14 ───
-   │
- 9 │         1 >> false;
-   │              ^^^^^ Invalid argument to '>>'
-   ·
- 9 │         1 >> false;
-   │              ----- The type: 'bool'
-   ·
- 9 │         1 >> false;
-   │              ----- Is not compatible with: 'u8'
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_shr_invalid.move:11:17 ───
-    │
- 11 │         @0x0 >> @0x1;
-    │                 ^^^^ Invalid argument to '>>'
-    ·
- 11 │         @0x0 >> @0x1;
-    │                 ---- The type: 'address'
-    ·
- 11 │         @0x0 >> @0x1;
-    │                 ---- Is not compatible with: 'u8'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_shr_invalid.move:12:20 ───
-    │
- 12 │         (0: u8) >> (1: u128);
-    │                    ^^^^^^^^^ Invalid argument to '>>'
-    ·
- 12 │         (0: u8) >> (1: u128);
-    │                        ---- The type: 'u128'
-    ·
- 12 │         (0: u8) >> (1: u128);
-    │                    --------- Is not compatible with: 'u8'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_shr_invalid.move:13:14 ───
-    │
- 13 │         r >> r;
-    │              ^ Invalid argument to '>>'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - The type: '0x8675309::M::R'
-    ·
- 13 │         r >> r;
-    │              - Is not compatible with: 'u8'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_shr_invalid.move:14:14 ───
-    │
- 14 │         s >> s;
-    │              ^ Invalid argument to '>>'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - The type: '0x8675309::M::S'
-    ·
- 14 │         s >> s;
-    │              - Is not compatible with: 'u8'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_shr_invalid.move:15:14 ───
-    │
- 15 │         1 >> false >> @0x0 >> 0;
-    │              ^^^^^ Invalid argument to '>>'
-    ·
- 15 │         1 >> false >> @0x0 >> 0;
-    │              ----- The type: 'bool'
-    ·
- 15 │         1 >> false >> @0x0 >> 0;
-    │              ----- Is not compatible with: 'u8'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_shr_invalid.move:15:23 ───
-    │
- 15 │         1 >> false >> @0x0 >> 0;
-    │                       ^^^^ Invalid argument to '>>'
-    ·
- 15 │         1 >> false >> @0x0 >> 0;
-    │                       ---- The type: 'address'
-    ·
- 15 │         1 >> false >> @0x0 >> 0;
-    │                       ---- Is not compatible with: 'u8'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_shr_invalid.move:16:15 ───
-    │
- 16 │         () >> ();
-    │               ^^ Invalid argument to '>>'
-    ·
- 16 │         () >> ();
-    │               -- The type: '()'
-    ·
- 16 │         () >> ();
-    │               -- Is not compatible with: 'u8'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_shr_invalid.move:17:14 ───
-    │
- 17 │         1 >> ();
-    │              ^^ Invalid argument to '>>'
-    ·
- 17 │         1 >> ();
-    │              -- The type: '()'
-    ·
- 17 │         1 >> ();
-    │              -- Is not compatible with: 'u8'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_shr_invalid.move:18:19 ───
-    │
- 18 │         (0, 1) >> (0, 1, 2);
-    │                   ^^^^^^^^^ Invalid argument to '>>'
-    ·
- 18 │         (0, 1) >> (0, 1, 2);
-    │                   --------- The type: '({integer}, {integer}, {integer})'
-    ·
- 18 │         (0, 1) >> (0, 1, 2);
-    │                   --------- Is not compatible with: 'u8'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_shr_invalid.move:19:19 ───
-    │
- 19 │         (1, 2) >> (0, 1);
-    │                   ^^^^^^ Invalid argument to '>>'
-    ·
- 19 │         (1, 2) >> (0, 1);
-    │                   ------ The type: '({integer}, {integer})'
-    ·
- 19 │         (1, 2) >> (0, 1);
-    │                   ------ Is not compatible with: 'u8'
-    │
+19 │         (1, 2) >> (0, 1);
+   │                   ^^^^^^
+   │                   │
+   │                   Invalid argument to '>>'
+   │                   Expected: 'u8'
+   │                   Given: '({integer}, {integer})'
 

--- a/language/move-lang/tests/move_check/typing/binary_sub_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_sub_invalid.exp
@@ -15,6 +15,15 @@ error[E04003]: built-in operation not supported
   │         │        
   │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/binary_sub_invalid.move:9:11
+  │
+9 │         1 - false;
+  │         - ^ ----- Found: 'bool'. It is not compatible with the other type.
+  │         │ │  
+  │         │ Incompatible arguments to '-'
+  │         Found: integer. It is not compatible with the other type.
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_sub_invalid.move:10:9
    │
@@ -23,6 +32,15 @@ error[E04003]: built-in operation not supported
    │         │
    │         Invalid argument to '-'
    │         Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_sub_invalid.move:10:15
+   │
+10 │         false - 1;
+   │         ----- ^ - Found: integer. It is not compatible with the other type.
+   │         │     │  
+   │         │     Incompatible arguments to '-'
+   │         Found: 'bool'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_sub_invalid.move:10:17
@@ -48,6 +66,15 @@ error[E04003]: built-in operation not supported
    │         ----   ^^^^ Invalid argument to '-'
    │         │       
    │         Found: 'address'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_sub_invalid.move:12:17
+   │
+12 │         (0: u8) - (1: u128);
+   │             --  ^     ---- Found: 'u128'. It is not compatible with the other type.
+   │             │   │      
+   │             │   Incompatible arguments to '-'
+   │             Found: 'u8'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_sub_invalid.move:13:9
@@ -102,8 +129,8 @@ error[E04003]: built-in operation not supported
    │
 15 │         1 - false - @0x0 - 0;
    │         ^^^^^^^^^
-   │         │   │
-   │         │   Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │         │ │
+   │         │ Found: '_'. But expected: 'u8', 'u64', 'u128'
    │         Invalid argument to '-'
 
 error[E04003]: built-in operation not supported
@@ -115,13 +142,31 @@ error[E04003]: built-in operation not supported
    │         │           Found: 'address'. But expected: 'u8', 'u64', 'u128'
    │         Invalid argument to '-'
 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_sub_invalid.move:15:11
+   │
+15 │         1 - false - @0x0 - 0;
+   │         - ^ ----- Found: 'bool'. It is not compatible with the other type.
+   │         │ │  
+   │         │ Incompatible arguments to '-'
+   │         Found: integer. It is not compatible with the other type.
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_sub_invalid.move:15:21
    │
 15 │         1 - false - @0x0 - 0;
-   │             -----   ^^^^ Invalid argument to '-'
-   │             │        
-   │             Found: '_'. But expected: 'u8', 'u64', 'u128'
+   │           -         ^^^^ Invalid argument to '-'
+   │           │          
+   │           Found: '_'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_sub_invalid.move:15:26
+   │
+15 │         1 - false - @0x0 - 0;
+   │                     ---- ^ - Found: integer. It is not compatible with the other type.
+   │                     │    │  
+   │                     │    Incompatible arguments to '-'
+   │                     Found: 'address'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_sub_invalid.move:15:28
@@ -148,6 +193,15 @@ error[E04003]: built-in operation not supported
    │         │     
    │         Found: '()'. But expected: 'u8', 'u64', 'u128'
 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_sub_invalid.move:17:11
+   │
+17 │         1 - ();
+   │         - ^ -- Found: '()'. It is not compatible with the other type.
+   │         │ │  
+   │         │ Incompatible arguments to '-'
+   │         Found: integer. It is not compatible with the other type.
+
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_sub_invalid.move:18:9
    │
@@ -156,6 +210,15 @@ error[E04003]: built-in operation not supported
    │         │
    │         Invalid argument to '-'
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/binary_sub_invalid.move:18:16
+   │
+18 │         (0, 1) - (0, 1, 2);
+   │         ------ ^ --------- Found expression list of length 3: '({integer}, {integer}, {integer})'. It is not compatible with the other type of length 2.
+   │         │      │  
+   │         │      Incompatible arguments to '-'
+   │         Found expression list of length 2: '({integer}, {integer})'. It is not compatible with the other type of length 3.
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_sub_invalid.move:18:18
@@ -181,102 +244,4 @@ error[E04003]: built-in operation not supported
    │         ------   ^^^^^^ Invalid argument to '-'
    │         │         
    │         Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
-
-error: 
-
-   ┌── tests/move_check/typing/binary_sub_invalid.move:9:13 ───
-   │
- 9 │         1 - false;
-   │             ^^^^^ Incompatible arguments to '-'
-   ·
- 9 │         1 - false;
-   │         - The type: integer
-   ·
- 9 │         1 - false;
-   │             ----- Is not compatible with: 'bool'
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_sub_invalid.move:10:17 ───
-    │
- 10 │         false - 1;
-    │                 ^ Incompatible arguments to '-'
-    ·
- 10 │         false - 1;
-    │                 - The type: integer
-    ·
- 10 │         false - 1;
-    │         ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_sub_invalid.move:12:19 ───
-    │
- 12 │         (0: u8) - (1: u128);
-    │                   ^^^^^^^^^ Incompatible arguments to '-'
-    ·
- 12 │         (0: u8) - (1: u128);
-    │             -- The type: 'u8'
-    ·
- 12 │         (0: u8) - (1: u128);
-    │                       ---- Is not compatible with: 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_sub_invalid.move:15:13 ───
-    │
- 15 │         1 - false - @0x0 - 0;
-    │             ^^^^^ Incompatible arguments to '-'
-    ·
- 15 │         1 - false - @0x0 - 0;
-    │         - The type: integer
-    ·
- 15 │         1 - false - @0x0 - 0;
-    │             ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_sub_invalid.move:15:28 ───
-    │
- 15 │         1 - false - @0x0 - 0;
-    │                            ^ Incompatible arguments to '-'
-    ·
- 15 │         1 - false - @0x0 - 0;
-    │                            - The type: integer
-    ·
- 15 │         1 - false - @0x0 - 0;
-    │                     ---- Is not compatible with: 'address'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_sub_invalid.move:17:13 ───
-    │
- 17 │         1 - ();
-    │             ^^ Incompatible arguments to '-'
-    ·
- 17 │         1 - ();
-    │         - The type: integer
-    ·
- 17 │         1 - ();
-    │             -- Is not compatible with: '()'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_sub_invalid.move:18:18 ───
-    │
- 18 │         (0, 1) - (0, 1, 2);
-    │                  ^^^^^^^^^ Incompatible arguments to '-'
-    ·
- 18 │         (0, 1) - (0, 1, 2);
-    │         ------ The expression list type of length 2: '({integer}, {integer})'
-    ·
- 18 │         (0, 1) - (0, 1, 2);
-    │                  --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
-    │
 

--- a/language/move-lang/tests/move_check/typing/bind_unpack_references_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/bind_unpack_references_invalid.exp
@@ -1,84 +1,65 @@
-error: 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/bind_unpack_references_invalid.move:7:9
+  │
+6 │         let R { s1: S { f }, s2 } = &R { s1: S{f: 0}, s2: S{f: 1} };
+  │                         - Expected: '&u64'
+7 │         f = 0;
+  │         ^
+  │         │
+  │         Invalid assignment to local 'f'
+  │         Given: integer
 
-   ┌── tests/move_check/typing/bind_unpack_references_invalid.move:7:9 ───
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/bind_unpack_references_invalid.move:8:9
+  │
+6 │         let R { s1: S { f }, s2 } = &R { s1: S{f: 0}, s2: S{f: 1} };
+  │                              -- Expected: '&0x8675309::M::S'
+7 │         f = 0;
+8 │         s2 = S { f: 0 }
+  │         ^^   ---------- Given: '0x8675309::M::S'
+  │         │     
+  │         Invalid assignment to local 's2'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/bind_unpack_references_invalid.move:13:9
    │
- 7 │         f = 0;
-   │         ^ Invalid assignment to local 'f'
-   ·
- 7 │         f = 0;
-   │         - The type: integer
-   ·
- 6 │         let R { s1: S { f }, s2 } = &R { s1: S{f: 0}, s2: S{f: 1} };
-   │                         - Is not compatible with: '&u64'
+12 │         let R { s1: S { f }, s2 } = &mut R { s1: S{f: 0}, s2: S{f: 1} };
+   │                         - Expected: '&mut u64'
+13 │         f = 0;
+   │         ^
+   │         │
+   │         Invalid assignment to local 'f'
+   │         Given: integer
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/bind_unpack_references_invalid.move:14:9
    │
+12 │         let R { s1: S { f }, s2 } = &mut R { s1: S{f: 0}, s2: S{f: 1} };
+   │                              -- Expected: '&mut 0x8675309::M::S'
+13 │         f = 0;
+14 │         s2 = S { f: 0 }
+   │         ^^   ---------- Given: '0x8675309::M::S'
+   │         │     
+   │         Invalid assignment to local 's2'
 
-error: 
-
-   ┌── tests/move_check/typing/bind_unpack_references_invalid.move:8:9 ───
+error[E04006]: invalid subtype
+   ┌─ tests/move_check/typing/bind_unpack_references_invalid.move:20:9
    │
- 8 │         s2 = S { f: 0 }
-   │         ^^ Invalid assignment to local 's2'
-   ·
- 8 │         s2 = S { f: 0 }
-   │              ---------- The type: '0x8675309::M::S'
-   ·
- 6 │         let R { s1: S { f }, s2 } = &R { s1: S{f: 0}, s2: S{f: 1} };
-   │                              -- Is not compatible with: '&0x8675309::M::S'
+19 │         let R { s1: S { f }, s2 } = &mut R { s1: S{f: 0}, s2: S{f: 1} };
+   │                         - Expected: '&mut u64'
+20 │         f = &0;
+   │         ^   -- Given: '&{integer}'
+   │         │    
+   │         Invalid assignment to local 'f'
+
+error[E04006]: invalid subtype
+   ┌─ tests/move_check/typing/bind_unpack_references_invalid.move:21:9
    │
-
-error: 
-
-    ┌── tests/move_check/typing/bind_unpack_references_invalid.move:13:9 ───
-    │
- 13 │         f = 0;
-    │         ^ Invalid assignment to local 'f'
-    ·
- 13 │         f = 0;
-    │         - The type: integer
-    ·
- 12 │         let R { s1: S { f }, s2 } = &mut R { s1: S{f: 0}, s2: S{f: 1} };
-    │                         - Is not compatible with: '&mut u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/bind_unpack_references_invalid.move:14:9 ───
-    │
- 14 │         s2 = S { f: 0 }
-    │         ^^ Invalid assignment to local 's2'
-    ·
- 14 │         s2 = S { f: 0 }
-    │              ---------- The type: '0x8675309::M::S'
-    ·
- 12 │         let R { s1: S { f }, s2 } = &mut R { s1: S{f: 0}, s2: S{f: 1} };
-    │                              -- Is not compatible with: '&mut 0x8675309::M::S'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/bind_unpack_references_invalid.move:20:9 ───
-    │
- 20 │         f = &0;
-    │         ^ Invalid assignment to local 'f'
-    ·
- 20 │         f = &0;
-    │             -- The type: '&{integer}'
-    ·
- 19 │         let R { s1: S { f }, s2 } = &mut R { s1: S{f: 0}, s2: S{f: 1} };
-    │                         - Is not a subtype of: '&mut u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/bind_unpack_references_invalid.move:21:9 ───
-    │
- 21 │         s2 = &S { f: 0 }
-    │         ^^ Invalid assignment to local 's2'
-    ·
- 21 │         s2 = &S { f: 0 }
-    │              ----------- The type: '&0x8675309::M::S'
-    ·
- 19 │         let R { s1: S { f }, s2 } = &mut R { s1: S{f: 0}, s2: S{f: 1} };
-    │                              -- Is not a subtype of: '&mut 0x8675309::M::S'
-    │
+19 │         let R { s1: S { f }, s2 } = &mut R { s1: S{f: 0}, s2: S{f: 1} };
+   │                              -- Expected: '&mut 0x8675309::M::S'
+20 │         f = &0;
+21 │         s2 = &S { f: 0 }
+   │         ^^   ----------- Given: '&0x8675309::M::S'
+   │         │     
+   │         Invalid assignment to local 's2'
 

--- a/language/move-lang/tests/move_check/typing/bind_wrong_arity.exp
+++ b/language/move-lang/tests/move_check/typing/bind_wrong_arity.exp
@@ -6,45 +6,30 @@ error[E04005]: expected a single type
   │             │   
   │             Invalid type for local
 
-error: 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/bind_wrong_arity.move:6:13
+  │
+6 │         let (): u64 = 0;
+  │             ^^  --- Given: 'u64'
+  │             │    
+  │             Invalid value for binding
+  │             Expected: '()'
 
-   ┌── tests/move_check/typing/bind_wrong_arity.move:6:13 ───
-   │
- 6 │         let (): u64 = 0;
-   │             ^^ Invalid value for binding
-   ·
- 6 │         let (): u64 = 0;
-   │             -- The type: '()'
-   ·
- 6 │         let (): u64 = 0;
-   │                 --- Is not compatible with: 'u64'
-   │
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/bind_wrong_arity.move:7:13
+  │
+7 │         let (x, b, R{f}): (u64, bool, R, R) = (0, false, R{f: 0}, R{f: 0});
+  │             ^^^^^^^^^^^^  ----------------- Given expression list of length 4: '(u64, bool, 0x8675309::M::R, 0x8675309::M::R)'
+  │             │              
+  │             Invalid value for binding
+  │             Expected expression list of length 3: '(_, _, _)'
 
-error: 
-
-   ┌── tests/move_check/typing/bind_wrong_arity.move:7:13 ───
-   │
- 7 │         let (x, b, R{f}): (u64, bool, R, R) = (0, false, R{f: 0}, R{f: 0});
-   │             ^^^^^^^^^^^^ Invalid value for binding
-   ·
- 7 │         let (x, b, R{f}): (u64, bool, R, R) = (0, false, R{f: 0}, R{f: 0});
-   │             ------------ The expression list type of length 3: '(_, _, _)'
-   ·
- 7 │         let (x, b, R{f}): (u64, bool, R, R) = (0, false, R{f: 0}, R{f: 0});
-   │                           ----------------- Is not compatible with the expression list type of length 4: '(u64, bool, 0x8675309::M::R, 0x8675309::M::R)'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/bind_wrong_arity.move:8:13 ───
-   │
- 8 │         let (x, b, R{f}): (u64, bool) = (0, false);
-   │             ^^^^^^^^^^^^ Invalid value for binding
-   ·
- 8 │         let (x, b, R{f}): (u64, bool) = (0, false);
-   │             ------------ The expression list type of length 3: '(_, _, _)'
-   ·
- 8 │         let (x, b, R{f}): (u64, bool) = (0, false);
-   │                           ----------- Is not compatible with the expression list type of length 2: '(u64, bool)'
-   │
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/bind_wrong_arity.move:8:13
+  │
+8 │         let (x, b, R{f}): (u64, bool) = (0, false);
+  │             ^^^^^^^^^^^^  ----------- Given expression list of length 2: '(u64, bool)'
+  │             │              
+  │             Invalid value for binding
+  │             Expected expression list of length 3: '(_, _, _)'
 

--- a/language/move-lang/tests/move_check/typing/bind_wrong_type.exp
+++ b/language/move-lang/tests/move_check/typing/bind_wrong_type.exp
@@ -1,3 +1,21 @@
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/bind_wrong_type.move:6:13
+  │
+6 │         let S { g } = R {f :0};
+  │             ^^^^^^^   -------- Expected: '0x8675309::M::R'
+  │             │          
+  │             Invalid deconstruction binding
+  │             Given: '0x8675309::M::S'
+
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/bind_wrong_type.move:7:14
+  │
+7 │         let (S { g }, R { f }) = (R{ f: 0 }, R{ f: 1 });
+  │              ^^^^^^^              --------- Expected: '0x8675309::M::R'
+  │              │                     
+  │              Invalid deconstruction binding
+  │              Given: '0x8675309::M::S'
+
 error[E04005]: expected a single type
    ┌─ tests/move_check/typing/bind_wrong_type.move:11:13
    │
@@ -5,6 +23,33 @@ error[E04005]: expected a single type
    │             ^   -- Expected a single type, but found expression list type: '()'
    │             │    
    │             Invalid type for local
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/bind_wrong_type.move:12:13
+   │
+12 │         let () = 0;
+   │             ^^   - Given: integer
+   │             │     
+   │             Invalid value for binding
+   │             Expected: '()'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/bind_wrong_type.move:13:13
+   │
+13 │         let (x, b, R{f}) = (0, false, R{f: 0}, R{f: 0});
+   │             ^^^^^^^^^^^^   ---------------------------- Given expression list of length 4: '({integer}, bool, 0x8675309::M::R, 0x8675309::M::R)'
+   │             │               
+   │             Invalid value for binding
+   │             Expected expression list of length 3: '(_, _, _)'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/bind_wrong_type.move:14:13
+   │
+14 │         let (x, b, R{f}) = (0, false);
+   │             ^^^^^^^^^^^^   ---------- Given expression list of length 2: '({integer}, bool)'
+   │             │               
+   │             Invalid value for binding
+   │             Expected expression list of length 3: '(_, _, _)'
 
 error[E04005]: expected a single type
    ┌─ tests/move_check/typing/bind_wrong_type.move:18:13
@@ -14,171 +59,66 @@ error[E04005]: expected a single type
    │             │   
    │             Invalid type for local
 
-error: 
-
-   ┌── tests/move_check/typing/bind_wrong_type.move:6:13 ───
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/bind_wrong_type.move:18:16
    │
- 6 │         let S { g } = R {f :0};
-   │             ^^^^^^^ Invalid deconstruction binding
-   ·
- 6 │         let S { g } = R {f :0};
-   │             ------- The type: '0x8675309::M::S'
-   ·
- 6 │         let S { g } = R {f :0};
-   │                       -------- Is not compatible with: '0x8675309::M::R'
+18 │         let x: () = 0;
+   │                ^^   - Given: integer
+   │                │     
+   │                Invalid type annotation
+   │                Expected: '()'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/bind_wrong_type.move:19:13
    │
+19 │         let (): u64 = ();
+   │             ^^  --- Given: 'u64'
+   │             │    
+   │             Invalid value for binding
+   │             Expected: '()'
 
-error: 
-
-   ┌── tests/move_check/typing/bind_wrong_type.move:7:14 ───
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/bind_wrong_type.move:19:17
    │
- 7 │         let (S { g }, R { f }) = (R{ f: 0 }, R{ f: 1 });
-   │              ^^^^^^^ Invalid deconstruction binding
-   ·
- 7 │         let (S { g }, R { f }) = (R{ f: 0 }, R{ f: 1 });
-   │              ------- The type: '0x8675309::M::S'
-   ·
- 7 │         let (S { g }, R { f }) = (R{ f: 0 }, R{ f: 1 });
-   │                                   --------- Is not compatible with: '0x8675309::M::R'
+19 │         let (): u64 = ();
+   │                 ^^^   -- Given: '()'
+   │                 │      
+   │                 Invalid type annotation
+   │                 Expected: 'u64'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/bind_wrong_type.move:20:13
    │
+20 │         let (x, b, R{f}): (u64, bool, R, R) = (0, false, R{f: 0});
+   │             ^^^^^^^^^^^^  ----------------- Given expression list of length 4: '(u64, bool, 0x8675309::M::R, 0x8675309::M::R)'
+   │             │              
+   │             Invalid value for binding
+   │             Expected expression list of length 3: '(_, _, _)'
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/bind_wrong_type.move:20:27
+   │
+20 │         let (x, b, R{f}): (u64, bool, R, R) = (0, false, R{f: 0});
+   │                           ^^^^^^^^^^^^^^^^^   ------------------- Given expression list of length 3: '({integer}, bool, 0x8675309::M::R)'
+   │                           │                    
+   │                           Invalid type annotation
+   │                           Expected expression list of length 4: '(u64, bool, 0x8675309::M::R, 0x8675309::M::R)'
 
-    ┌── tests/move_check/typing/bind_wrong_type.move:12:13 ───
-    │
- 12 │         let () = 0;
-    │             ^^ Invalid value for binding
-    ·
- 12 │         let () = 0;
-    │                  - The type: integer
-    ·
- 12 │         let () = 0;
-    │             -- Is not compatible with: '()'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/bind_wrong_type.move:21:13
+   │
+21 │         let (x, b, R{f}): (u64, bool) = (0, false, R{f: 0});
+   │             ^^^^^^^^^^^^  ----------- Given expression list of length 2: '(u64, bool)'
+   │             │              
+   │             Invalid value for binding
+   │             Expected expression list of length 3: '(_, _, _)'
 
-error: 
-
-    ┌── tests/move_check/typing/bind_wrong_type.move:13:13 ───
-    │
- 13 │         let (x, b, R{f}) = (0, false, R{f: 0}, R{f: 0});
-    │             ^^^^^^^^^^^^ Invalid value for binding
-    ·
- 13 │         let (x, b, R{f}) = (0, false, R{f: 0}, R{f: 0});
-    │             ------------ The expression list type of length 3: '(_, _, _)'
-    ·
- 13 │         let (x, b, R{f}) = (0, false, R{f: 0}, R{f: 0});
-    │                            ---------------------------- Is not compatible with the expression list type of length 4: '({integer}, bool, 0x8675309::M::R, 0x8675309::M::R)'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/bind_wrong_type.move:14:13 ───
-    │
- 14 │         let (x, b, R{f}) = (0, false);
-    │             ^^^^^^^^^^^^ Invalid value for binding
-    ·
- 14 │         let (x, b, R{f}) = (0, false);
-    │             ------------ The expression list type of length 3: '(_, _, _)'
-    ·
- 14 │         let (x, b, R{f}) = (0, false);
-    │                            ---------- Is not compatible with the expression list type of length 2: '({integer}, bool)'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/bind_wrong_type.move:18:16 ───
-    │
- 18 │         let x: () = 0;
-    │                ^^ Invalid type annotation
-    ·
- 18 │         let x: () = 0;
-    │                     - The type: integer
-    ·
- 18 │         let x: () = 0;
-    │                -- Is not compatible with: '()'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/bind_wrong_type.move:19:13 ───
-    │
- 19 │         let (): u64 = ();
-    │             ^^ Invalid value for binding
-    ·
- 19 │         let (): u64 = ();
-    │             -- The type: '()'
-    ·
- 19 │         let (): u64 = ();
-    │                 --- Is not compatible with: 'u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/bind_wrong_type.move:19:17 ───
-    │
- 19 │         let (): u64 = ();
-    │                 ^^^ Invalid type annotation
-    ·
- 19 │         let (): u64 = ();
-    │                       -- The type: '()'
-    ·
- 19 │         let (): u64 = ();
-    │                 --- Is not compatible with: 'u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/bind_wrong_type.move:20:13 ───
-    │
- 20 │         let (x, b, R{f}): (u64, bool, R, R) = (0, false, R{f: 0});
-    │             ^^^^^^^^^^^^ Invalid value for binding
-    ·
- 20 │         let (x, b, R{f}): (u64, bool, R, R) = (0, false, R{f: 0});
-    │             ------------ The expression list type of length 3: '(_, _, _)'
-    ·
- 20 │         let (x, b, R{f}): (u64, bool, R, R) = (0, false, R{f: 0});
-    │                           ----------------- Is not compatible with the expression list type of length 4: '(u64, bool, 0x8675309::M::R, 0x8675309::M::R)'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/bind_wrong_type.move:20:27 ───
-    │
- 20 │         let (x, b, R{f}): (u64, bool, R, R) = (0, false, R{f: 0});
-    │                           ^^^^^^^^^^^^^^^^^ Invalid type annotation
-    ·
- 20 │         let (x, b, R{f}): (u64, bool, R, R) = (0, false, R{f: 0});
-    │                                               ------------------- The expression list type of length 3: '({integer}, bool, 0x8675309::M::R)'
-    ·
- 20 │         let (x, b, R{f}): (u64, bool, R, R) = (0, false, R{f: 0});
-    │                           ----------------- Is not compatible with the expression list type of length 4: '(u64, bool, 0x8675309::M::R, 0x8675309::M::R)'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/bind_wrong_type.move:21:13 ───
-    │
- 21 │         let (x, b, R{f}): (u64, bool) = (0, false, R{f: 0});
-    │             ^^^^^^^^^^^^ Invalid value for binding
-    ·
- 21 │         let (x, b, R{f}): (u64, bool) = (0, false, R{f: 0});
-    │             ------------ The expression list type of length 3: '(_, _, _)'
-    ·
- 21 │         let (x, b, R{f}): (u64, bool) = (0, false, R{f: 0});
-    │                           ----------- Is not compatible with the expression list type of length 2: '(u64, bool)'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/bind_wrong_type.move:21:27 ───
-    │
- 21 │         let (x, b, R{f}): (u64, bool) = (0, false, R{f: 0});
-    │                           ^^^^^^^^^^^ Invalid type annotation
-    ·
- 21 │         let (x, b, R{f}): (u64, bool) = (0, false, R{f: 0});
-    │                                         ------------------- The expression list type of length 3: '({integer}, bool, 0x8675309::M::R)'
-    ·
- 21 │         let (x, b, R{f}): (u64, bool) = (0, false, R{f: 0});
-    │                           ----------- Is not compatible with the expression list type of length 2: '(u64, bool)'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/bind_wrong_type.move:21:27
+   │
+21 │         let (x, b, R{f}): (u64, bool) = (0, false, R{f: 0});
+   │                           ^^^^^^^^^^^   ------------------- Given expression list of length 3: '({integer}, bool, 0x8675309::M::R)'
+   │                           │              
+   │                           Invalid type annotation
+   │                           Expected expression list of length 2: '(u64, bool)'
 

--- a/language/move-lang/tests/move_check/typing/block_empty_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/block_empty_invalid.exp
@@ -1,42 +1,30 @@
-error: 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/block_empty_invalid.move:3:14
+  │
+3 │         ({}: u64);
+  │          --  ^^^
+  │          │   │
+  │          │   Invalid type annotation
+  │          │   Expected: 'u64'
+  │          Given: '()'
 
-   ┌── tests/move_check/typing/block_empty_invalid.move:3:14 ───
-   │
- 3 │         ({}: u64);
-   │              ^^^ Invalid type annotation
-   ·
- 3 │         ({}: u64);
-   │          -- The type: '()'
-   ·
- 3 │         ({}: u64);
-   │              --- Is not compatible with: 'u64'
-   │
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/block_empty_invalid.move:4:14
+  │
+4 │         ({}: &u64);
+  │          --  ^^^^
+  │          │   │
+  │          │   Invalid type annotation
+  │          │   Expected: '&u64'
+  │          Given: '()'
 
-error: 
-
-   ┌── tests/move_check/typing/block_empty_invalid.move:4:14 ───
-   │
- 4 │         ({}: &u64);
-   │              ^^^^ Invalid type annotation
-   ·
- 4 │         ({}: &u64);
-   │          -- The type: '()'
-   ·
- 4 │         ({}: &u64);
-   │              ---- Is not compatible with: '&u64'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/block_empty_invalid.move:5:14 ───
-   │
- 5 │         ({}: (u64, bool));
-   │              ^^^^^^^^^^^ Invalid type annotation
-   ·
- 5 │         ({}: (u64, bool));
-   │          -- The type: '()'
-   ·
- 5 │         ({}: (u64, bool));
-   │              ----------- Is not compatible with: '(u64, bool)'
-   │
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/block_empty_invalid.move:5:14
+  │
+5 │         ({}: (u64, bool));
+  │          --  ^^^^^^^^^^^
+  │          │   │
+  │          │   Invalid type annotation
+  │          │   Expected: '(u64, bool)'
+  │          Given: '()'
 

--- a/language/move-lang/tests/move_check/typing/block_single_expr_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/block_single_expr_invalid.exp
@@ -1,3 +1,33 @@
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/block_single_expr_invalid.move:4:18
+  │
+4 │         ({ 0 } : bool);
+  │            -     ^^^^
+  │            │     │
+  │            │     Invalid type annotation
+  │            │     Expected: 'bool'
+  │            Given: integer
+
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/block_single_expr_invalid.move:5:19
+  │
+5 │         ({ &0 } : u64);
+  │            --     ^^^
+  │            │      │
+  │            │      Invalid type annotation
+  │            │      Expected: 'u64'
+  │            Given: '&{integer}'
+
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/block_single_expr_invalid.move:6:23
+  │
+6 │         ({ &mut 0 } : ());
+  │            ------     ^^
+  │            │          │
+  │            │          Invalid type annotation
+  │            │          Expected: '()'
+  │            Given: '&mut {integer}'
+
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/block_single_expr_invalid.move:7:9
   │
@@ -10,59 +40,13 @@ error[E05001]: ability constraint not satisfied
   │         │           The type '0x8675309::M::R' does not have the ability 'drop'
   │         Cannot ignore values without the 'drop' ability. The value must be used
 
-error: 
-
-   ┌── tests/move_check/typing/block_single_expr_invalid.move:4:18 ───
-   │
- 4 │         ({ 0 } : bool);
-   │                  ^^^^ Invalid type annotation
-   ·
- 4 │         ({ 0 } : bool);
-   │            - The type: integer
-   ·
- 4 │         ({ 0 } : bool);
-   │                  ---- Is not compatible with: 'bool'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/block_single_expr_invalid.move:5:19 ───
-   │
- 5 │         ({ &0 } : u64);
-   │                   ^^^ Invalid type annotation
-   ·
- 5 │         ({ &0 } : u64);
-   │            -- The type: '&{integer}'
-   ·
- 5 │         ({ &0 } : u64);
-   │                   --- Is not compatible with: 'u64'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/block_single_expr_invalid.move:6:23 ───
-   │
- 6 │         ({ &mut 0 } : ());
-   │                       ^^ Invalid type annotation
-   ·
- 6 │         ({ &mut 0 } : ());
-   │            ------ The type: '&mut {integer}'
-   ·
- 6 │         ({ &mut 0 } : ());
-   │                       -- Is not compatible with: '()'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/block_single_expr_invalid.move:8:34 ───
-   │
- 8 │         ({ (0, false, false) } : (u64, bool));
-   │                                  ^^^^^^^^^^^ Invalid type annotation
-   ·
- 8 │         ({ (0, false, false) } : (u64, bool));
-   │            ----------------- The expression list type of length 3: '({integer}, bool, bool)'
-   ·
- 8 │         ({ (0, false, false) } : (u64, bool));
-   │                                  ----------- Is not compatible with the expression list type of length 2: '(u64, bool)'
-   │
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/block_single_expr_invalid.move:8:34
+  │
+8 │         ({ (0, false, false) } : (u64, bool));
+  │            -----------------     ^^^^^^^^^^^
+  │            │                     │
+  │            │                     Invalid type annotation
+  │            │                     Expected expression list of length 2: '(u64, bool)'
+  │            Given expression list of length 3: '({integer}, bool, bool)'
 

--- a/language/move-lang/tests/move_check/typing/block_with_statements_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/block_with_statements_invalid.exp
@@ -1,3 +1,33 @@
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/block_with_statements_invalid.move:4:29
+  │
+4 │         ({ let x = 0; x } : bool);
+  │                -            ^^^^
+  │                │            │
+  │                │            Invalid type annotation
+  │                │            Expected: 'bool'
+  │                Given: integer
+
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/block_with_statements_invalid.move:5:30
+  │
+5 │         ({ let x = 0; &x } : u64);
+  │                       --     ^^^
+  │                       │      │
+  │                       │      Invalid type annotation
+  │                       │      Expected: 'u64'
+  │                       Given: '&{integer}'
+
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/block_with_statements_invalid.move:6:40
+  │
+6 │         ({ let y = 0; &mut (y + 1) } : ());
+  │                       ------------     ^^
+  │                       │                │
+  │                       │                Invalid type annotation
+  │                       │                Expected: '()'
+  │                       Given: '&mut {integer}'
+
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/block_with_statements_invalid.move:7:9
   │
@@ -10,59 +40,13 @@ error[E05001]: ability constraint not satisfied
   │         │                                     The type '0x8675309::M::R' does not have the ability 'drop'
   │         Cannot ignore values without the 'drop' ability. The value must be used
 
-error: 
-
-   ┌── tests/move_check/typing/block_with_statements_invalid.move:4:29 ───
-   │
- 4 │         ({ let x = 0; x } : bool);
-   │                             ^^^^ Invalid type annotation
-   ·
- 4 │         ({ let x = 0; x } : bool);
-   │                - The type: integer
-   ·
- 4 │         ({ let x = 0; x } : bool);
-   │                             ---- Is not compatible with: 'bool'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/block_with_statements_invalid.move:5:30 ───
-   │
- 5 │         ({ let x = 0; &x } : u64);
-   │                              ^^^ Invalid type annotation
-   ·
- 5 │         ({ let x = 0; &x } : u64);
-   │                       -- The type: '&{integer}'
-   ·
- 5 │         ({ let x = 0; &x } : u64);
-   │                              --- Is not compatible with: 'u64'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/block_with_statements_invalid.move:6:40 ───
-   │
- 6 │         ({ let y = 0; &mut (y + 1) } : ());
-   │                                        ^^ Invalid type annotation
-   ·
- 6 │         ({ let y = 0; &mut (y + 1) } : ());
-   │                       ------------ The type: '&mut {integer}'
-   ·
- 6 │         ({ let y = 0; &mut (y + 1) } : ());
-   │                                        -- Is not compatible with: '()'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/block_with_statements_invalid.move:8:45 ───
-   │
- 8 │         ({ let x = 0; (x, false, false) } : (u64, bool));
-   │                                             ^^^^^^^^^^^ Invalid type annotation
-   ·
- 8 │         ({ let x = 0; (x, false, false) } : (u64, bool));
-   │                       ----------------- The expression list type of length 3: '({integer}, bool, bool)'
-   ·
- 8 │         ({ let x = 0; (x, false, false) } : (u64, bool));
-   │                                             ----------- Is not compatible with the expression list type of length 2: '(u64, bool)'
-   │
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/block_with_statements_invalid.move:8:45
+  │
+8 │         ({ let x = 0; (x, false, false) } : (u64, bool));
+  │                       -----------------     ^^^^^^^^^^^
+  │                       │                     │
+  │                       │                     Invalid type annotation
+  │                       │                     Expected expression list of length 2: '(u64, bool)'
+  │                       Given expression list of length 3: '({integer}, bool, bool)'
 

--- a/language/move-lang/tests/move_check/typing/conditional_drop_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/conditional_drop_invalid.exp
@@ -62,49 +62,99 @@ error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:17:9
    │
 17 │         Box<R> {} == Box<R> {};
-   │         ^^^^^^^^^^^^^^^^^^^^^^
-   │         │            │   │
-   │         │            │   The type '0x42::M::Box<0x42::M::R>' can have the ability 'drop' but the type argument '0x42::M::R' does not have the required ability 'drop'
-   │         │            The type '0x42::M::Box<0x42::M::R>' does not have the ability 'drop'
+   │         ^^^^^^^^^
+   │         │   │
+   │         │   The type '0x42::M::Box<0x42::M::R>' can have the ability 'drop' but the type argument '0x42::M::R' does not have the required ability 'drop'
    │         '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │         The type '0x42::M::Box<0x42::M::R>' does not have the ability 'drop'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_drop_invalid.move:17:22
+   │
+17 │         Box<R> {} == Box<R> {};
+   │                      ^^^^^^^^^
+   │                      │   │
+   │                      │   The type '0x42::M::Box<0x42::M::R>' can have the ability 'drop' but the type argument '0x42::M::R' does not have the required ability 'drop'
+   │                      '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │                      The type '0x42::M::Box<0x42::M::R>' does not have the ability 'drop'
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:18:9
    │
 18 │         Box<Box<R>> {} == Box<Box<R>> {};
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   │         │                 │   │
-   │         │                 │   The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' can have the ability 'drop' but the type argument '0x42::M::Box<0x42::M::R>' does not have the required ability 'drop'
-   │         │                 The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' does not have the ability 'drop'
+   │         ^^^^^^^^^^^^^^
+   │         │   │
+   │         │   The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' can have the ability 'drop' but the type argument '0x42::M::Box<0x42::M::R>' does not have the required ability 'drop'
    │         '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │         The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' does not have the ability 'drop'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_drop_invalid.move:18:27
+   │
+18 │         Box<Box<R>> {} == Box<Box<R>> {};
+   │                           ^^^^^^^^^^^^^^
+   │                           │   │
+   │                           │   The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' can have the ability 'drop' but the type argument '0x42::M::Box<0x42::M::R>' does not have the required ability 'drop'
+   │                           '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │                           The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' does not have the ability 'drop'
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:19:9
    │
 19 │         Box<T> {} == Box<T> {};
-   │         ^^^^^^^^^^^^^^^^^^^^^^
-   │         │            │   │
-   │         │            │   The type '0x42::M::Box<T>' can have the ability 'drop' but the type argument 'T' does not have the required ability 'drop'
-   │         │            The type '0x42::M::Box<T>' does not have the ability 'drop'
+   │         ^^^^^^^^^
+   │         │   │
+   │         │   The type '0x42::M::Box<T>' can have the ability 'drop' but the type argument 'T' does not have the required ability 'drop'
    │         '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │         The type '0x42::M::Box<T>' does not have the ability 'drop'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_drop_invalid.move:19:22
+   │
+19 │         Box<T> {} == Box<T> {};
+   │                      ^^^^^^^^^
+   │                      │   │
+   │                      │   The type '0x42::M::Box<T>' can have the ability 'drop' but the type argument 'T' does not have the required ability 'drop'
+   │                      '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │                      The type '0x42::M::Box<T>' does not have the ability 'drop'
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:20:9
    │
 20 │         Box<Box<T>> {} == Box<Box<T>> {};
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   │         │                 │   │
-   │         │                 │   The type '0x42::M::Box<0x42::M::Box<T>>' can have the ability 'drop' but the type argument '0x42::M::Box<T>' does not have the required ability 'drop'
-   │         │                 The type '0x42::M::Box<0x42::M::Box<T>>' does not have the ability 'drop'
+   │         ^^^^^^^^^^^^^^
+   │         │   │
+   │         │   The type '0x42::M::Box<0x42::M::Box<T>>' can have the ability 'drop' but the type argument '0x42::M::Box<T>' does not have the required ability 'drop'
    │         '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │         The type '0x42::M::Box<0x42::M::Box<T>>' does not have the ability 'drop'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_drop_invalid.move:20:27
+   │
+20 │         Box<Box<T>> {} == Box<Box<T>> {};
+   │                           ^^^^^^^^^^^^^^
+   │                           │   │
+   │                           │   The type '0x42::M::Box<0x42::M::Box<T>>' can have the ability 'drop' but the type argument '0x42::M::Box<T>' does not have the required ability 'drop'
+   │                           '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │                           The type '0x42::M::Box<0x42::M::Box<T>>' does not have the ability 'drop'
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:21:9
    │
 21 │         Pair<R, S> {} == Pair<R, S> {};
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   │         │                │    │
-   │         │                │    The type '0x42::M::Pair<0x42::M::R, 0x42::M::S>' can have the ability 'drop' but the type argument '0x42::M::R' does not have the required ability 'drop'
-   │         │                The type '0x42::M::Pair<0x42::M::R, 0x42::M::S>' does not have the ability 'drop'
+   │         ^^^^^^^^^^^^^
+   │         │    │
+   │         │    The type '0x42::M::Pair<0x42::M::R, 0x42::M::S>' can have the ability 'drop' but the type argument '0x42::M::R' does not have the required ability 'drop'
    │         '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │         The type '0x42::M::Pair<0x42::M::R, 0x42::M::S>' does not have the ability 'drop'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/conditional_drop_invalid.move:21:26
+   │
+21 │         Pair<R, S> {} == Pair<R, S> {};
+   │                          ^^^^^^^^^^^^^
+   │                          │    │
+   │                          │    The type '0x42::M::Pair<0x42::M::R, 0x42::M::S>' can have the ability 'drop' but the type argument '0x42::M::R' does not have the required ability 'drop'
+   │                          '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │                          The type '0x42::M::Pair<0x42::M::R, 0x42::M::S>' does not have the ability 'drop'
 

--- a/language/move-lang/tests/move_check/typing/constant_invalid_usage.exp
+++ b/language/move-lang/tests/move_check/typing/constant_invalid_usage.exp
@@ -1,98 +1,77 @@
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/constant_invalid_usage.move:11:20
+   │
+ 8 │     const C6: vector<u8> = x"0123";
+   │               ---------- Given: 'vector<u8>'
+   ·
+11 │     fun t1(): u8 { C6 }
+   │               --   ^^ Invalid return expression
+   │               │     
+   │               Expected: 'u8'
 
-    ┌── tests/move_check/typing/constant_invalid_usage.move:11:20 ───
-    │
- 11 │     fun t1(): u8 { C6 }
-    │                    ^^ Invalid return expression
-    ·
-  8 │     const C6: vector<u8> = x"0123";
-    │               ---------- The type: 'vector<u8>'
-    ·
- 11 │     fun t1(): u8 { C6 }
-    │               -- Is not compatible with: 'u8'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/constant_invalid_usage.move:12:21
+   │
+ 9 │     const C7: vector<u8> = b"abcd";
+   │               ---------- Given: 'vector<u8>'
+   ·
+12 │     fun t2(): u64 { C7 }
+   │               ---   ^^ Invalid return expression
+   │               │      
+   │               Expected: 'u64'
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/constant_invalid_usage.move:13:22
+   │
+ 3 │     const C1: u8 = 0;
+   │               -- Given: 'u8'
+   ·
+13 │     fun t3(): u128 { C1 }
+   │               ----   ^^ Invalid return expression
+   │               │       
+   │               Expected: 'u128'
 
-    ┌── tests/move_check/typing/constant_invalid_usage.move:12:21 ───
-    │
- 12 │     fun t2(): u64 { C7 }
-    │                     ^^ Invalid return expression
-    ·
-  9 │     const C7: vector<u8> = b"abcd";
-    │               ---------- The type: 'vector<u8>'
-    ·
- 12 │     fun t2(): u64 { C7 }
-    │               --- Is not compatible with: 'u64'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/constant_invalid_usage.move:14:22
+   │
+ 4 │     const C2: u64 = 0;
+   │               --- Given: 'u64'
+   ·
+14 │     fun t4(): bool { C2 }
+   │               ----   ^^ Invalid return expression
+   │               │       
+   │               Expected: 'bool'
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/constant_invalid_usage.move:15:25
+   │
+ 5 │     const C3: u128 = 0;
+   │               ---- Given: 'u128'
+   ·
+15 │     fun t5(): address { C3 }
+   │               -------   ^^ Invalid return expression
+   │               │          
+   │               Expected: 'address'
 
-    ┌── tests/move_check/typing/constant_invalid_usage.move:13:22 ───
-    │
- 13 │     fun t3(): u128 { C1 }
-    │                      ^^ Invalid return expression
-    ·
-  3 │     const C1: u8 = 0;
-    │               -- The type: 'u8'
-    ·
- 13 │     fun t3(): u128 { C1 }
-    │               ---- Is not compatible with: 'u128'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/constant_invalid_usage.move:16:28
+   │
+ 6 │     const C4: bool = false;
+   │               ---- Given: 'bool'
+   ·
+16 │     fun t6(): vector<u8> { C4 }
+   │               ----------   ^^ Invalid return expression
+   │               │             
+   │               Expected: 'vector<u8>'
 
-error: 
-
-    ┌── tests/move_check/typing/constant_invalid_usage.move:14:22 ───
-    │
- 14 │     fun t4(): bool { C2 }
-    │                      ^^ Invalid return expression
-    ·
-  4 │     const C2: u64 = 0;
-    │               --- The type: 'u64'
-    ·
- 14 │     fun t4(): bool { C2 }
-    │               ---- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_invalid_usage.move:15:25 ───
-    │
- 15 │     fun t5(): address { C3 }
-    │                         ^^ Invalid return expression
-    ·
-  5 │     const C3: u128 = 0;
-    │               ---- The type: 'u128'
-    ·
- 15 │     fun t5(): address { C3 }
-    │               ------- Is not compatible with: 'address'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_invalid_usage.move:16:28 ───
-    │
- 16 │     fun t6(): vector<u8> { C4 }
-    │                            ^^ Invalid return expression
-    ·
-  6 │     const C4: bool = false;
-    │               ---- The type: 'bool'
-    ·
- 16 │     fun t6(): vector<u8> { C4 }
-    │               ---------- Is not compatible with: 'vector<u8>'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_invalid_usage.move:17:28 ───
-    │
- 17 │     fun t7(): vector<u8> { C5 }
-    │                            ^^ Invalid return expression
-    ·
-  7 │     const C5: address = @0x0;
-    │               ------- The type: 'address'
-    ·
- 17 │     fun t7(): vector<u8> { C5 }
-    │               ---------- Is not compatible with: 'vector<u8>'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/constant_invalid_usage.move:17:28
+   │
+ 7 │     const C5: address = @0x0;
+   │               ------- Given: 'address'
+   ·
+17 │     fun t7(): vector<u8> { C5 }
+   │               ----------   ^^ Invalid return expression
+   │               │             
+   │               Expected: 'vector<u8>'
 

--- a/language/move-lang/tests/move_check/typing/constant_non_base_type.exp
+++ b/language/move-lang/tests/move_check/typing/constant_non_base_type.exp
@@ -1,3 +1,12 @@
+error[E04006]: invalid subtype
+  ┌─ tests/move_check/typing/constant_non_base_type.move:4:15
+  │
+4 │     const C2: &mut u64 = &0;
+  │               ^^^^^^^^   -- Given: '&{integer}'
+  │               │           
+  │               Invalid constant signature
+  │               Expected: '&mut u64'
+
 error: 
 
    ┌── tests/move_check/typing/constant_non_base_type.move:3:15 ───
@@ -26,20 +35,6 @@ error:
    ·
  4 │     const C2: &mut u64 = &0;
    │               -------- Found: '&mut u64'. But expected one of: 'u8', 'u64', 'u128', 'bool', 'address', 'vector<_>'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/constant_non_base_type.move:4:15 ───
-   │
- 4 │     const C2: &mut u64 = &0;
-   │               ^^^^^^^^ Invalid constant signature
-   ·
- 4 │     const C2: &mut u64 = &0;
-   │                          -- The type: '&{integer}'
-   ·
- 4 │     const C2: &mut u64 = &0;
-   │               -------- Is not a subtype of: '&mut u64'
    │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/constant_unsupported_exps.exp
+++ b/language/move-lang/tests/move_check/typing/constant_unsupported_exps.exp
@@ -34,6 +34,18 @@ error[E04001]: restricted visibility
 28 │         0x42::X::f_private();
    │         ^^^^^^^^^^^^^^^^^^^^ Invalid call to '0x42::X::f_private'
 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/constant_unsupported_exps.move:31:9
+   │
+16 │         let s: signer = abort 0;
+   │                ------ Given: 'signer'
+   ·
+31 │         move_to(s, R{});
+   │         ^^^^^^^^^^^^^^^
+   │         │
+   │         Invalid call of 'move_to'. Invalid argument for parameter '0'
+   │         Expected: '&signer'
+
 error: 
 
     ┌── tests/move_check/typing/constant_unsupported_exps.move:15:9 ───
@@ -176,20 +188,6 @@ error:
     │
  30 │         borrow_global_mut<R>(@0x42);
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ 'borrow_global_mut' is not supported in constants
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/constant_unsupported_exps.move:31:9 ───
-    │
- 31 │         move_to(s, R{});
-    │         ^^^^^^^^^^^^^^^ Invalid call of 'move_to'. Invalid argument for parameter '0'
-    ·
- 16 │         let s: signer = abort 0;
-    │                ------ The type: 'signer'
-    ·
- 31 │         move_to(s, R{});
-    │         ------- Is not compatible with: '&signer'
     │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/declare_wrong_arity.exp
+++ b/language/move-lang/tests/move_check/typing/declare_wrong_arity.exp
@@ -6,45 +6,30 @@ error[E04005]: expected a single type
   │             │   
   │             Invalid type for local
 
-error: 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/declare_wrong_arity.move:6:13
+  │
+6 │         let (): u64;
+  │             ^^  --- Given: 'u64'
+  │             │    
+  │             Invalid value for binding
+  │             Expected: '()'
 
-   ┌── tests/move_check/typing/declare_wrong_arity.move:6:13 ───
-   │
- 6 │         let (): u64;
-   │             ^^ Invalid value for binding
-   ·
- 6 │         let (): u64;
-   │             -- The type: '()'
-   ·
- 6 │         let (): u64;
-   │                 --- Is not compatible with: 'u64'
-   │
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/declare_wrong_arity.move:7:13
+  │
+7 │         let (x, b, R{f}): (u64, bool, R, R);
+  │             ^^^^^^^^^^^^  ----------------- Given expression list of length 4: '(u64, bool, 0x8675309::M::R, 0x8675309::M::R)'
+  │             │              
+  │             Invalid value for binding
+  │             Expected expression list of length 3: '(_, _, _)'
 
-error: 
-
-   ┌── tests/move_check/typing/declare_wrong_arity.move:7:13 ───
-   │
- 7 │         let (x, b, R{f}): (u64, bool, R, R);
-   │             ^^^^^^^^^^^^ Invalid value for binding
-   ·
- 7 │         let (x, b, R{f}): (u64, bool, R, R);
-   │             ------------ The expression list type of length 3: '(_, _, _)'
-   ·
- 7 │         let (x, b, R{f}): (u64, bool, R, R);
-   │                           ----------------- Is not compatible with the expression list type of length 4: '(u64, bool, 0x8675309::M::R, 0x8675309::M::R)'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/declare_wrong_arity.move:8:13 ───
-   │
- 8 │         let (x, b, R{f}): (u64, bool);
-   │             ^^^^^^^^^^^^ Invalid value for binding
-   ·
- 8 │         let (x, b, R{f}): (u64, bool);
-   │             ------------ The expression list type of length 3: '(_, _, _)'
-   ·
- 8 │         let (x, b, R{f}): (u64, bool);
-   │                           ----------- Is not compatible with the expression list type of length 2: '(u64, bool)'
-   │
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/declare_wrong_arity.move:8:13
+  │
+8 │         let (x, b, R{f}): (u64, bool);
+  │             ^^^^^^^^^^^^  ----------- Given expression list of length 2: '(u64, bool)'
+  │             │              
+  │             Invalid value for binding
+  │             Expected expression list of length 3: '(_, _, _)'
 

--- a/language/move-lang/tests/move_check/typing/declare_wrong_type.exp
+++ b/language/move-lang/tests/move_check/typing/declare_wrong_type.exp
@@ -1,28 +1,18 @@
-error: 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/declare_wrong_type.move:6:13
+  │
+6 │         let S { g } : R;
+  │             ^^^^^^^   - Expected: '0x8675309::M::R'
+  │             │          
+  │             Invalid deconstruction binding
+  │             Given: '0x8675309::M::S'
 
-   ┌── tests/move_check/typing/declare_wrong_type.move:6:13 ───
-   │
- 6 │         let S { g } : R;
-   │             ^^^^^^^ Invalid deconstruction binding
-   ·
- 6 │         let S { g } : R;
-   │             ------- The type: '0x8675309::M::S'
-   ·
- 6 │         let S { g } : R;
-   │                       - Is not compatible with: '0x8675309::M::R'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/declare_wrong_type.move:7:14 ───
-   │
- 7 │         let (S { g }, R { f }): (R, R);
-   │              ^^^^^^^ Invalid deconstruction binding
-   ·
- 7 │         let (S { g }, R { f }): (R, R);
-   │              ------- The type: '0x8675309::M::S'
-   ·
- 7 │         let (S { g }, R { f }): (R, R);
-   │                                  - Is not compatible with: '0x8675309::M::R'
-   │
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/declare_wrong_type.move:7:14
+  │
+7 │         let (S { g }, R { f }): (R, R);
+  │              ^^^^^^^             - Expected: '0x8675309::M::R'
+  │              │                    
+  │              Invalid deconstruction binding
+  │              Given: '0x8675309::M::S'
 

--- a/language/move-lang/tests/move_check/typing/derefrence_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/derefrence_invalid.exp
@@ -1,168 +1,143 @@
-error: 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/derefrence_invalid.move:6:15
+  │
+5 │     fun t0(x: &u64, x_mut: &mut u64, s: &S, s_mut: &mut S){
+  │                --- Given: 'u64'
+6 │         (*x : bool);
+  │               ^^^^
+  │               │
+  │               Invalid type annotation
+  │               Expected: 'bool'
 
-   ┌── tests/move_check/typing/derefrence_invalid.move:6:15 ───
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/derefrence_invalid.move:7:18
+  │
+5 │     fun t0(x: &u64, x_mut: &mut u64, s: &S, s_mut: &mut S){
+  │                                 --- Given: 'u64'
+6 │         (*x : bool);
+7 │         (*x_mut: &u64);
+  │                  ^^^^
+  │                  │
+  │                  Invalid type annotation
+  │                  Expected: '&u64'
+
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/derefrence_invalid.move:9:14
+  │
+5 │     fun t0(x: &u64, x_mut: &mut u64, s: &S, s_mut: &mut S){
+  │                                          - Given: '0x8675309::M::S'
+  ·
+9 │         (*s: X);
+  │              ^
+  │              │
+  │              Invalid type annotation
+  │              Expected: '0x8675309::M::X'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/derefrence_invalid.move:10:17
    │
- 6 │         (*x : bool);
-   │               ^^^^ Invalid type annotation
+ 3 │     struct S has copy, drop { f: u64, x: X }
+   │                                  --- Given: 'u64'
    ·
+10 │         (*&s.f: bool);
+   │                 ^^^^
+   │                 │
+   │                 Invalid type annotation
+   │                 Expected: 'bool'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/derefrence_invalid.move:11:15
+   │
+ 3 │     struct S has copy, drop { f: u64, x: X }
+   │                                  --- Given: 'u64'
+   ·
+11 │         (s.f: &u64);
+   │               ^^^^
+   │               │
+   │               Invalid type annotation
+   │               Expected: '&u64'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/derefrence_invalid.move:12:17
+   │
+ 3 │     struct S has copy, drop { f: u64, x: X }
+   │                                          - Given: '0x8675309::M::X'
+   ·
+12 │         (*&s.x: &X);
+   │                 ^^
+   │                 │
+   │                 Invalid type annotation
+   │                 Expected: '&0x8675309::M::X'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/derefrence_invalid.move:14:18
+   │
  5 │     fun t0(x: &u64, x_mut: &mut u64, s: &S, s_mut: &mut S){
-   │                --- The type: 'u64'
+   │                                                         - Given: '0x8675309::M::S'
    ·
- 6 │         (*x : bool);
-   │               ---- Is not compatible with: 'bool'
-   │
+14 │         (*s_mut: X);
+   │                  ^
+   │                  │
+   │                  Invalid type annotation
+   │                  Expected: '0x8675309::M::X'
 
-error: 
-
-   ┌── tests/move_check/typing/derefrence_invalid.move:7:18 ───
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/derefrence_invalid.move:15:21
    │
- 7 │         (*x_mut: &u64);
-   │                  ^^^^ Invalid type annotation
+ 3 │     struct S has copy, drop { f: u64, x: X }
+   │                                  --- Given: 'u64'
    ·
- 5 │     fun t0(x: &u64, x_mut: &mut u64, s: &S, s_mut: &mut S){
-   │                                 --- The type: 'u64'
-   ·
- 7 │         (*x_mut: &u64);
-   │                  ---- Is not compatible with: '&u64'
+15 │         (*&s_mut.f: bool);
+   │                     ^^^^
+   │                     │
+   │                     Invalid type annotation
+   │                     Expected: 'bool'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/derefrence_invalid.move:16:25
    │
-
-error: 
-
-   ┌── tests/move_check/typing/derefrence_invalid.move:9:14 ───
-   │
- 9 │         (*s: X);
-   │              ^ Invalid type annotation
+ 3 │     struct S has copy, drop { f: u64, x: X }
+   │                                  --- Given: 'u64'
    ·
- 5 │     fun t0(x: &u64, x_mut: &mut u64, s: &S, s_mut: &mut S){
-   │                                          - The type: '0x8675309::M::S'
-   ·
- 9 │         (*s: X);
-   │              - Is not compatible with: '0x8675309::M::X'
+16 │         (*&mut s_mut.f: (bool, u64));
+   │                         ^^^^^^^^^^^
+   │                         │
+   │                         Invalid type annotation
+   │                         Expected: '(bool, u64)'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/derefrence_invalid.move:17:19
    │
+ 3 │     struct S has copy, drop { f: u64, x: X }
+   │                                  --- Given: 'u64'
+   ·
+17 │         (s_mut.f: &u64);
+   │                   ^^^^
+   │                   │
+   │                   Invalid type annotation
+   │                   Expected: '&u64'
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/derefrence_invalid.move:18:21
+   │
+ 3 │     struct S has copy, drop { f: u64, x: X }
+   │                                          - Given: '0x8675309::M::X'
+   ·
+18 │         (*&s_mut.x: (X, S));
+   │                     ^^^^^^
+   │                     │
+   │                     Invalid type annotation
+   │                     Expected: '(0x8675309::M::X, 0x8675309::M::S)'
 
-    ┌── tests/move_check/typing/derefrence_invalid.move:10:17 ───
-    │
- 10 │         (*&s.f: bool);
-    │                 ^^^^ Invalid type annotation
-    ·
-  3 │     struct S has copy, drop { f: u64, x: X }
-    │                                  --- The type: 'u64'
-    ·
- 10 │         (*&s.f: bool);
-    │                 ---- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/derefrence_invalid.move:11:15 ───
-    │
- 11 │         (s.f: &u64);
-    │               ^^^^ Invalid type annotation
-    ·
-  3 │     struct S has copy, drop { f: u64, x: X }
-    │                                  --- The type: 'u64'
-    ·
- 11 │         (s.f: &u64);
-    │               ---- Is not compatible with: '&u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/derefrence_invalid.move:12:17 ───
-    │
- 12 │         (*&s.x: &X);
-    │                 ^^ Invalid type annotation
-    ·
-  3 │     struct S has copy, drop { f: u64, x: X }
-    │                                          - The type: '0x8675309::M::X'
-    ·
- 12 │         (*&s.x: &X);
-    │                 -- Is not compatible with: '&0x8675309::M::X'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/derefrence_invalid.move:14:18 ───
-    │
- 14 │         (*s_mut: X);
-    │                  ^ Invalid type annotation
-    ·
-  5 │     fun t0(x: &u64, x_mut: &mut u64, s: &S, s_mut: &mut S){
-    │                                                         - The type: '0x8675309::M::S'
-    ·
- 14 │         (*s_mut: X);
-    │                  - Is not compatible with: '0x8675309::M::X'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/derefrence_invalid.move:15:21 ───
-    │
- 15 │         (*&s_mut.f: bool);
-    │                     ^^^^ Invalid type annotation
-    ·
-  3 │     struct S has copy, drop { f: u64, x: X }
-    │                                  --- The type: 'u64'
-    ·
- 15 │         (*&s_mut.f: bool);
-    │                     ---- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/derefrence_invalid.move:16:25 ───
-    │
- 16 │         (*&mut s_mut.f: (bool, u64));
-    │                         ^^^^^^^^^^^ Invalid type annotation
-    ·
-  3 │     struct S has copy, drop { f: u64, x: X }
-    │                                  --- The type: 'u64'
-    ·
- 16 │         (*&mut s_mut.f: (bool, u64));
-    │                         ----------- Is not compatible with: '(bool, u64)'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/derefrence_invalid.move:17:19 ───
-    │
- 17 │         (s_mut.f: &u64);
-    │                   ^^^^ Invalid type annotation
-    ·
-  3 │     struct S has copy, drop { f: u64, x: X }
-    │                                  --- The type: 'u64'
-    ·
- 17 │         (s_mut.f: &u64);
-    │                   ---- Is not compatible with: '&u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/derefrence_invalid.move:18:21 ───
-    │
- 18 │         (*&s_mut.x: (X, S));
-    │                     ^^^^^^ Invalid type annotation
-    ·
-  3 │     struct S has copy, drop { f: u64, x: X }
-    │                                          - The type: '0x8675309::M::X'
-    ·
- 18 │         (*&s_mut.x: (X, S));
-    │                     ------ Is not compatible with: '(0x8675309::M::X, 0x8675309::M::S)'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/derefrence_invalid.move:19:25 ───
-    │
- 19 │         (*&mut s_mut.x: ());
-    │                         ^^ Invalid type annotation
-    ·
-  3 │     struct S has copy, drop { f: u64, x: X }
-    │                                          - The type: '0x8675309::M::X'
-    ·
- 19 │         (*&mut s_mut.x: ());
-    │                         -- Is not compatible with: '()'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/derefrence_invalid.move:19:25
+   │
+ 3 │     struct S has copy, drop { f: u64, x: X }
+   │                                          - Given: '0x8675309::M::X'
+   ·
+19 │         (*&mut s_mut.x: ());
+   │                         ^^
+   │                         │
+   │                         Invalid type annotation
+   │                         Expected: '()'
 

--- a/language/move-lang/tests/move_check/typing/eq_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/eq_invalid.exp
@@ -1,3 +1,85 @@
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/eq_invalid.move:13:17
+   │
+13 │         (0: u8) == (1: u128);
+   │             --  ^^     ---- Found: 'u128'. It is not compatible with the other type.
+   │             │   │       
+   │             │   Incompatible arguments to '=='
+   │             Found: 'u8'. It is not compatible with the other type.
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/eq_invalid.move:14:11
+   │
+14 │         0 == false;
+   │         - ^^ ----- Found: 'bool'. It is not compatible with the other type.
+   │         │ │   
+   │         │ Incompatible arguments to '=='
+   │         Found: integer. It is not compatible with the other type.
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/eq_invalid.move:15:12
+   │
+15 │         &0 == 1;
+   │         -- ^^ - Found: integer. It is not compatible with the other type.
+   │         │  │   
+   │         │  Incompatible arguments to '=='
+   │         Found: '&{integer}'. It is not compatible with the other type.
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/eq_invalid.move:16:11
+   │
+16 │         1 == &0;
+   │         - ^^ -- Found: '&{integer}'. It is not compatible with the other type.
+   │         │ │   
+   │         │ Incompatible arguments to '=='
+   │         Found: integer. It is not compatible with the other type.
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/eq_invalid.move:17:9
+   │
+ 2 │     struct S { u: u64 }
+   │            - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+11 │     fun t0(r: &R, r_mut: &mut R, s: S,
+   │                                     - The type '0x8675309::M::S' does not have the ability 'drop'
+   ·
+17 │         s == s_ref;
+   │         ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/eq_invalid.move:17:11
+   │
+11 │     fun t0(r: &R, r_mut: &mut R, s: S,
+   │                                     - Found: '0x8675309::M::S'. It is not compatible with the other type.
+12 │     s_ref: &S, s_mut: &mut S) {
+   │            -- Found: '&0x8675309::M::S'. It is not compatible with the other type.
+   ·
+17 │         s == s_ref;
+   │           ^^ Incompatible arguments to '=='
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/eq_invalid.move:18:15
+   │
+11 │     fun t0(r: &R, r_mut: &mut R, s: S,
+   │                                     - Found: '0x8675309::M::S'. It is not compatible with the other type.
+12 │     s_ref: &S, s_mut: &mut S) {
+   │                       ------ Found: '&mut 0x8675309::M::S'. It is not compatible with the other type.
+   ·
+18 │         s_mut == s;
+   │               ^^ Incompatible arguments to '=='
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/eq_invalid.move:18:18
+   │
+ 2 │     struct S { u: u64 }
+   │            - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+11 │     fun t0(r: &R, r_mut: &mut R, s: S,
+   │                                     - The type '0x8675309::M::S' does not have the ability 'drop'
+   ·
+18 │         s_mut == s;
+   │                  ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/eq_invalid.move:22:9
    │
@@ -7,17 +89,38 @@ error[E05001]: ability constraint not satisfied
 21 │     fun t1(r: R) {
    │               - The type '0x8675309::M::R' does not have the ability 'drop'
 22 │         r == r;
-   │         ^^^^^^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │         ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/eq_invalid.move:22:14
+   │
+ 3 │     struct R has key {
+   │            - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+21 │     fun t1(r: R) {
+   │               - The type '0x8675309::M::R' does not have the ability 'drop'
+22 │         r == r;
+   │              ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/eq_invalid.move:26:9
    │
 26 │         G0<R>{} == G0<R>{};
-   │         ^^^^^^^^^^^^^^^^^^
-   │         │          │  │
-   │         │          │  The type '0x8675309::M::G0<0x8675309::M::R>' can have the ability 'drop' but the type argument '0x8675309::M::R' does not have the required ability 'drop'
-   │         │          The type '0x8675309::M::G0<0x8675309::M::R>' does not have the ability 'drop'
+   │         ^^^^^^^
+   │         │  │
+   │         │  The type '0x8675309::M::G0<0x8675309::M::R>' can have the ability 'drop' but the type argument '0x8675309::M::R' does not have the required ability 'drop'
    │         '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │         The type '0x8675309::M::G0<0x8675309::M::R>' does not have the ability 'drop'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/eq_invalid.move:26:20
+   │
+26 │         G0<R>{} == G0<R>{};
+   │                    ^^^^^^^
+   │                    │  │
+   │                    │  The type '0x8675309::M::G0<0x8675309::M::R>' can have the ability 'drop' but the type argument '0x8675309::M::R' does not have the required ability 'drop'
+   │                    '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │                    The type '0x8675309::M::G0<0x8675309::M::R>' does not have the ability 'drop'
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/eq_invalid.move:29:9
@@ -26,10 +129,22 @@ error[E05001]: ability constraint not satisfied
    │            -- To satisfy the constraint, the 'drop' ability would need to be added here
    ·
 29 │         G1{} == G1{};
-   │         ^^^^^^^^^^^^
-   │         │       │
-   │         │       The type '0x8675309::M::G1<_>' does not have the ability 'drop'
+   │         ^^^^
+   │         │
    │         '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │         The type '0x8675309::M::G1<_>' does not have the ability 'drop'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/eq_invalid.move:29:17
+   │
+ 7 │     struct G1<T: key> {}
+   │            -- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+29 │         G1{} == G1{};
+   │                 ^^^^
+   │                 │
+   │                 '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │                 The type '0x8675309::M::G1<_>' does not have the ability 'drop'
 
 error[E04005]: expected a single type
    ┌─ tests/move_check/typing/eq_invalid.move:33:9
@@ -38,7 +153,7 @@ error[E04005]: expected a single type
    │         ^^^^^^^^
    │         │     │
    │         │     Expected a single type, but found expression list type: '()'
-   │         Invalid arguments to '=='
+   │         Incompatible arguments to '=='
 
 error[E04005]: expected a single type
    ┌─ tests/move_check/typing/eq_invalid.move:34:9
@@ -47,91 +162,25 @@ error[E04005]: expected a single type
    │         ^^^^^^^^^^^^^^^^
    │         │         │
    │         │         Expected a single type, but found expression list type: '(u64, u64)'
-   │         Invalid arguments to '=='
+   │         Incompatible arguments to '=='
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/eq_invalid.move:35:19
+   │
+35 │         (1, 2, 3) == (0, 1);
+   │         --------- ^^ ------ Found expression list of length 2: '({integer}, {integer})'. It is not compatible with the other type of length 3.
+   │         │         │   
+   │         │         Incompatible arguments to '=='
+   │         Found expression list of length 3: '({integer}, {integer}, {integer})'. It is not compatible with the other type of length 2.
 
-    ┌── tests/move_check/typing/eq_invalid.move:13:20 ───
-    │
- 13 │         (0: u8) == (1: u128);
-    │                    ^^^^^^^^^ Incompatible arguments to '=='
-    ·
- 13 │         (0: u8) == (1: u128);
-    │             -- The type: 'u8'
-    ·
- 13 │         (0: u8) == (1: u128);
-    │                        ---- Is not compatible with: 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/eq_invalid.move:14:14 ───
-    │
- 14 │         0 == false;
-    │              ^^^^^ Incompatible arguments to '=='
-    ·
- 14 │         0 == false;
-    │         - The type: integer
-    ·
- 14 │         0 == false;
-    │              ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/eq_invalid.move:15:15 ───
-    │
- 15 │         &0 == 1;
-    │               ^ Incompatible arguments to '=='
-    ·
- 15 │         &0 == 1;
-    │               - The type: integer
-    ·
- 15 │         &0 == 1;
-    │         -- Is not compatible with: '&{integer}'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/eq_invalid.move:16:14 ───
-    │
- 16 │         1 == &0;
-    │              ^^ Incompatible arguments to '=='
-    ·
- 16 │         1 == &0;
-    │         - The type: integer
-    ·
- 16 │         1 == &0;
-    │              -- Is not compatible with: '&{integer}'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/eq_invalid.move:17:14 ───
-    │
- 17 │         s == s_ref;
-    │              ^^^^^ Incompatible arguments to '=='
-    ·
- 11 │     fun t0(r: &R, r_mut: &mut R, s: S,
-    │                                     - The type: '0x8675309::M::S'
-    ·
- 12 │     s_ref: &S, s_mut: &mut S) {
-    │            -- Is not compatible with: '&0x8675309::M::S'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/eq_invalid.move:18:18 ───
-    │
- 18 │         s_mut == s;
-    │                  ^ Incompatible arguments to '=='
-    ·
- 12 │     s_ref: &S, s_mut: &mut S) {
-    │                       ------ The type: '&mut 0x8675309::M::S'
-    ·
- 11 │     fun t0(r: &R, r_mut: &mut R, s: S,
-    │                                     - Is not compatible with: '0x8675309::M::S'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/eq_invalid.move:36:16
+   │
+36 │         (0, 1) == (1, 2, 3);
+   │         ------ ^^ --------- Found expression list of length 3: '({integer}, {integer}, {integer})'. It is not compatible with the other type of length 2.
+   │         │      │   
+   │         │      Incompatible arguments to '=='
+   │         Found expression list of length 2: '({integer}, {integer})'. It is not compatible with the other type of length 3.
 
 error: 
 
@@ -163,33 +212,5 @@ error:
     │
  29 │         G1{} == G1{};
     │                 ^^^^ Could not infer this type. Try adding an annotation
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/eq_invalid.move:35:22 ───
-    │
- 35 │         (1, 2, 3) == (0, 1);
-    │                      ^^^^^^ Incompatible arguments to '=='
-    ·
- 35 │         (1, 2, 3) == (0, 1);
-    │         --------- The expression list type of length 3: '({integer}, {integer}, {integer})'
-    ·
- 35 │         (1, 2, 3) == (0, 1);
-    │                      ------ Is not compatible with the expression list type of length 2: '({integer}, {integer})'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/eq_invalid.move:36:19 ───
-    │
- 36 │         (0, 1) == (1, 2, 3);
-    │                   ^^^^^^^^^ Incompatible arguments to '=='
-    ·
- 36 │         (0, 1) == (1, 2, 3);
-    │         ------ The expression list type of length 2: '({integer}, {integer})'
-    ·
- 36 │         (0, 1) == (1, 2, 3);
-    │                   --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
     │
 

--- a/language/move-lang/tests/move_check/typing/exp_list_nested.exp
+++ b/language/move-lang/tests/move_check/typing/exp_list_nested.exp
@@ -1,3 +1,14 @@
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/exp_list_nested.move:6:9
+  │
+5 │     fun t0(): (u64, S, R<u64>) {
+  │               ---------------- Expected expression list of length 3: '(u64, 0x8675309::M::S, 0x8675309::M::R<u64>)'
+6 │         (0, (S{}, R{}))
+  │         ^^^^^^^^^^^^^^^
+  │         │
+  │         Invalid return expression
+  │         Given expression list of length 2: '({integer}, (0x8675309::M::S, 0x8675309::M::R<_>))'
+
 error[E04005]: expected a single type
   ┌─ tests/move_check/typing/exp_list_nested.move:6:9
   │
@@ -6,20 +17,6 @@ error[E04005]: expected a single type
   │         │   │
   │         │   Expected a single type, but found expression list type: '(0x8675309::M::S, 0x8675309::M::R<_>)'
   │         Invalid expression list type argument
-
-error: 
-
-   ┌── tests/move_check/typing/exp_list_nested.move:6:9 ───
-   │
- 6 │         (0, (S{}, R{}))
-   │         ^^^^^^^^^^^^^^^ Invalid return expression
-   ·
- 6 │         (0, (S{}, R{}))
-   │         --------------- The expression list type of length 2: '({integer}, (0x8675309::M::S, 0x8675309::M::R<_>))'
-   ·
- 5 │     fun t0(): (u64, S, R<u64>) {
-   │               ---------------- Is not compatible with the expression list type of length 3: '(u64, 0x8675309::M::S, 0x8675309::M::R<u64>)'
-   │
 
 error: 
 

--- a/language/move-lang/tests/move_check/typing/global_builtins_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/global_builtins_invalid.exp
@@ -1,3 +1,23 @@
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/global_builtins_invalid.move:13:24
+   │
+13 │         let _ : bool = exists<R>(0);
+   │                        ^^^^^^^^^^^^
+   │                        │         │
+   │                        │         Given: integer
+   │                        Invalid call of 'exists'. Invalid argument for parameter '0'
+   │                        Expected: 'address'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/global_builtins_invalid.move:14:18
+   │
+14 │         let () = move_to<R>(a, 0);
+   │                  ^^^^^^^^^^^^^^^^
+   │                  │       │     │
+   │                  │       │     Given: integer
+   │                  │       Expected: '0x8675309::M::R'
+   │                  Invalid call of 'move_to'. Invalid argument for parameter '1'
+
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/global_builtins_invalid.move:15:18
    │
@@ -6,6 +26,36 @@ error[E05001]: ability constraint not satisfied
    │                  │          │
    │                  │          The type 'u64' does not have the ability 'key'
    │                  Invalid call of 'move_to'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/global_builtins_invalid.move:16:22
+   │
+16 │         let _ : &R = borrow_global<R>(0);
+   │                      ^^^^^^^^^^^^^^^^^^^
+   │                      │                │
+   │                      │                Given: integer
+   │                      Invalid call of 'borrow_global'. Invalid argument for parameter '0'
+   │                      Expected: 'address'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/global_builtins_invalid.move:17:26
+   │
+17 │         let _ : &mut R = borrow_global_mut<R>(0);
+   │                          ^^^^^^^^^^^^^^^^^^^^^^^
+   │                          │                    │
+   │                          │                    Given: integer
+   │                          Invalid call of 'borrow_global_mut'. Invalid argument for parameter '0'
+   │                          Expected: 'address'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/global_builtins_invalid.move:18:20
+   │
+18 │         let R {} = move_from<R>(0);
+   │                    ^^^^^^^^^^^^^^^
+   │                    │            │
+   │                    │            Given: integer
+   │                    Invalid call of 'move_from'. Invalid argument for parameter '0'
+   │                    Expected: 'address'
 
 error: 
 
@@ -61,76 +111,6 @@ error:
  9 │         let R {} = move_from<R>();
    │                                -- Found 0 argument(s) here
    │
-
-error: 
-
-    ┌── tests/move_check/typing/global_builtins_invalid.move:13:24 ───
-    │
- 13 │         let _ : bool = exists<R>(0);
-    │                        ^^^^^^^^^^^^ Invalid call of 'exists'. Invalid argument for parameter '0'
-    ·
- 13 │         let _ : bool = exists<R>(0);
-    │                                  - The type: integer
-    ·
- 13 │         let _ : bool = exists<R>(0);
-    │                        ------ Is not compatible with: 'address'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/global_builtins_invalid.move:14:18 ───
-    │
- 14 │         let () = move_to<R>(a, 0);
-    │                  ^^^^^^^^^^^^^^^^ Invalid call of 'move_to'. Invalid argument for parameter '1'
-    ·
- 14 │         let () = move_to<R>(a, 0);
-    │                                - The type: integer
-    ·
- 14 │         let () = move_to<R>(a, 0);
-    │                          - Is not compatible with: '0x8675309::M::R'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/global_builtins_invalid.move:16:22 ───
-    │
- 16 │         let _ : &R = borrow_global<R>(0);
-    │                      ^^^^^^^^^^^^^^^^^^^ Invalid call of 'borrow_global'. Invalid argument for parameter '0'
-    ·
- 16 │         let _ : &R = borrow_global<R>(0);
-    │                                       - The type: integer
-    ·
- 16 │         let _ : &R = borrow_global<R>(0);
-    │                      ------------- Is not compatible with: 'address'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/global_builtins_invalid.move:17:26 ───
-    │
- 17 │         let _ : &mut R = borrow_global_mut<R>(0);
-    │                          ^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'borrow_global_mut'. Invalid argument for parameter '0'
-    ·
- 17 │         let _ : &mut R = borrow_global_mut<R>(0);
-    │                                               - The type: integer
-    ·
- 17 │         let _ : &mut R = borrow_global_mut<R>(0);
-    │                          ----------------- Is not compatible with: 'address'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/global_builtins_invalid.move:18:20 ───
-    │
- 18 │         let R {} = move_from<R>(0);
-    │                    ^^^^^^^^^^^^^^^ Invalid call of 'move_from'. Invalid argument for parameter '0'
-    ·
- 18 │         let R {} = move_from<R>(0);
-    │                                 - The type: integer
-    ·
- 18 │         let R {} = move_from<R>(0);
-    │                    --------- Is not compatible with: 'address'
-    │
 
 error: 
 

--- a/language/move-lang/tests/move_check/typing/if_branches_subtype_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/if_branches_subtype_invalid.exp
@@ -1,196 +1,157 @@
-error: 
+error[E04006]: invalid subtype
+  ┌─ tests/move_check/typing/if_branches_subtype_invalid.move:3:16
+  │
+2 │     fun t0(cond: bool, u: &u64, u_mut: &mut u64) {
+  │                           ---- Given: '&u64'
+3 │         let _: &mut u64 = if (cond) u else u_mut;
+  │                ^^^^^^^^
+  │                │
+  │                Invalid type annotation
+  │                Expected: '&mut u64'
 
-   ┌── tests/move_check/typing/if_branches_subtype_invalid.move:3:16 ───
-   │
- 3 │         let _: &mut u64 = if (cond) u else u_mut;
-   │                ^^^^^^^^ Invalid type annotation
-   ·
- 2 │     fun t0(cond: bool, u: &u64, u_mut: &mut u64) {
-   │                           ---- The type: '&u64'
-   ·
- 3 │         let _: &mut u64 = if (cond) u else u_mut;
-   │                -------- Is not a subtype of: '&mut u64'
-   │
+error[E04006]: invalid subtype
+  ┌─ tests/move_check/typing/if_branches_subtype_invalid.move:4:16
+  │
+2 │     fun t0(cond: bool, u: &u64, u_mut: &mut u64) {
+  │                           ---- Given: '&u64'
+3 │         let _: &mut u64 = if (cond) u else u_mut;
+4 │         let _: &mut u64 = if (cond) u_mut else u;
+  │                ^^^^^^^^
+  │                │
+  │                Invalid type annotation
+  │                Expected: '&mut u64'
 
-error: 
+error[E04006]: invalid subtype
+  ┌─ tests/move_check/typing/if_branches_subtype_invalid.move:5:16
+  │
+2 │     fun t0(cond: bool, u: &u64, u_mut: &mut u64) {
+  │                           ---- Given: '&u64'
+  ·
+5 │         let _: &mut u64 = if (cond) u else u;
+  │                ^^^^^^^^
+  │                │
+  │                Invalid type annotation
+  │                Expected: '&mut u64'
 
-   ┌── tests/move_check/typing/if_branches_subtype_invalid.move:4:16 ───
-   │
- 4 │         let _: &mut u64 = if (cond) u_mut else u;
-   │                ^^^^^^^^ Invalid type annotation
-   ·
- 2 │     fun t0(cond: bool, u: &u64, u_mut: &mut u64) {
-   │                           ---- The type: '&u64'
-   ·
- 4 │         let _: &mut u64 = if (cond) u_mut else u;
-   │                -------- Is not a subtype of: '&mut u64'
-   │
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/if_branches_subtype_invalid.move:9:23
+  │
+8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
+  │                            ---                       ---- Found: 'bool'. It is not compatible with the other type.
+  │                            │                          
+  │                            Found: 'u64'. It is not compatible with the other type.
+9 │         let _: &u64 = if (cond) u else b;
+  │                       ^^^^^^^^^^^^^^^^^^ Incompatible branches
 
-error: 
-
-   ┌── tests/move_check/typing/if_branches_subtype_invalid.move:5:16 ───
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/if_branches_subtype_invalid.move:10:23
    │
- 5 │         let _: &mut u64 = if (cond) u else u;
-   │                ^^^^^^^^ Invalid type annotation
-   ·
- 2 │     fun t0(cond: bool, u: &u64, u_mut: &mut u64) {
-   │                           ---- The type: '&u64'
-   ·
- 5 │         let _: &mut u64 = if (cond) u else u;
-   │                -------- Is not a subtype of: '&mut u64'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/if_branches_subtype_invalid.move:9:23 ───
-   │
+ 8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
+   │                            ---                       ---- Found: 'bool'. It is not compatible with the other type.
+   │                            │                          
+   │                            Found: 'u64'. It is not compatible with the other type.
  9 │         let _: &u64 = if (cond) u else b;
+10 │         let _: &u64 = if (cond) b else u;
    │                       ^^^^^^^^^^^^^^^^^^ Incompatible branches
-   ·
- 8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
-   │                            --- The type: 'u64'
-   ·
- 8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
-   │                                                      ---- Is not compatible with: 'bool'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/if_branches_subtype_invalid.move:12:23
    │
+ 8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
+   │                                             ---      ---- Found: 'bool'. It is not compatible with the other type.
+   │                                             │         
+   │                                             Found: 'u64'. It is not compatible with the other type.
+   ·
+12 │         let _: &u64 = if (cond) u_mut else b;
+   │                       ^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/if_branches_subtype_invalid.move:13:23
+   │
+ 8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
+   │                                             ---      ---- Found: 'bool'. It is not compatible with the other type.
+   │                                             │         
+   │                                             Found: 'u64'. It is not compatible with the other type.
+   ·
+13 │         let _: &u64 = if (cond) b else u_mut;
+   │                       ^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
 
-    ┌── tests/move_check/typing/if_branches_subtype_invalid.move:10:23 ───
-    │
- 10 │         let _: &u64 = if (cond) b else u;
-    │                       ^^^^^^^^^^^^^^^^^^ Incompatible branches
-    ·
-  8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
-    │                                                      ---- The type: 'bool'
-    ·
-  8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
-    │                            --- Is not compatible with: 'u64'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/if_branches_subtype_invalid.move:15:23
+   │
+ 8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
+   │                            ---                                         ---- Found: 'bool'. It is not compatible with the other type.
+   │                            │                                            
+   │                            Found: 'u64'. It is not compatible with the other type.
+   ·
+15 │         let _: &u64 = if (cond) u else b_mut;
+   │                       ^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/if_branches_subtype_invalid.move:16:23
+   │
+ 8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
+   │                            ---                                         ---- Found: 'bool'. It is not compatible with the other type.
+   │                            │                                            
+   │                            Found: 'u64'. It is not compatible with the other type.
+   ·
+16 │         let _: &u64 = if (cond) b_mut else u;
+   │                       ^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
 
-    ┌── tests/move_check/typing/if_branches_subtype_invalid.move:12:23 ───
-    │
- 12 │         let _: &u64 = if (cond) u_mut else b;
-    │                       ^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
-    ·
-  8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
-    │                                             --- The type: 'u64'
-    ·
-  8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
-    │                                                      ---- Is not compatible with: 'bool'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/if_branches_subtype_invalid.move:19:27
+   │
+ 8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
+   │                                             ---                        ---- Found: 'bool'. It is not compatible with the other type.
+   │                                             │                           
+   │                                             Found: 'u64'. It is not compatible with the other type.
+   ·
+19 │         let _: &mut u64 = if (cond) u_mut else b_mut;
+   │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/if_branches_subtype_invalid.move:20:27
+   │
+ 8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
+   │                                             ---                        ---- Found: 'bool'. It is not compatible with the other type.
+   │                                             │                           
+   │                                             Found: 'u64'. It is not compatible with the other type.
+   ·
+20 │         let _: &mut u64 = if (cond) b_mut else u_mut;
+   │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
 
-    ┌── tests/move_check/typing/if_branches_subtype_invalid.move:13:23 ───
-    │
- 13 │         let _: &u64 = if (cond) b else u_mut;
-    │                       ^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
-    ·
-  8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
-    │                                                      ---- The type: 'bool'
-    ·
-  8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
-    │                                             --- Is not compatible with: 'u64'
-    │
+error[E04006]: invalid subtype
+   ┌─ tests/move_check/typing/if_branches_subtype_invalid.move:25:21
+   │
+24 │     fun t2(cond: bool, u: &u64, u_mut: &mut u64) {
+   │                           ---- Given: '&u64'
+25 │         let (_, _): (&mut u64, &mut u64) = if (cond) (u, u) else (u_mut, u_mut);
+   │                     ^^^^^^^^^^^^^^^^^^^^
+   │                     ││
+   │                     │Expected: '&mut u64'
+   │                     Invalid type annotation
 
-error: 
+error[E04006]: invalid subtype
+   ┌─ tests/move_check/typing/if_branches_subtype_invalid.move:26:21
+   │
+24 │     fun t2(cond: bool, u: &u64, u_mut: &mut u64) {
+   │                           ---- Given: '&u64'
+25 │         let (_, _): (&mut u64, &mut u64) = if (cond) (u, u) else (u_mut, u_mut);
+26 │         let (_, _): (&mut u64, &mut u64) = if (cond) (u_mut, u) else (u, u_mut);
+   │                     ^^^^^^^^^^^^^^^^^^^^
+   │                     ││
+   │                     │Expected: '&mut u64'
+   │                     Invalid type annotation
 
-    ┌── tests/move_check/typing/if_branches_subtype_invalid.move:15:23 ───
-    │
- 15 │         let _: &u64 = if (cond) u else b_mut;
-    │                       ^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
-    ·
-  8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
-    │                            --- The type: 'u64'
-    ·
-  8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
-    │                                                                        ---- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/if_branches_subtype_invalid.move:16:23 ───
-    │
- 16 │         let _: &u64 = if (cond) b_mut else u;
-    │                       ^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
-    ·
-  8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
-    │                                                                        ---- The type: 'bool'
-    ·
-  8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
-    │                            --- Is not compatible with: 'u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/if_branches_subtype_invalid.move:19:27 ───
-    │
- 19 │         let _: &mut u64 = if (cond) u_mut else b_mut;
-    │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
-    ·
-  8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
-    │                                             --- The type: 'u64'
-    ·
-  8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
-    │                                                                        ---- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/if_branches_subtype_invalid.move:20:27 ───
-    │
- 20 │         let _: &mut u64 = if (cond) b_mut else u_mut;
-    │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
-    ·
-  8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
-    │                                                                        ---- The type: 'bool'
-    ·
-  8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
-    │                                             --- Is not compatible with: 'u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/if_branches_subtype_invalid.move:25:21 ───
-    │
- 25 │         let (_, _): (&mut u64, &mut u64) = if (cond) (u, u) else (u_mut, u_mut);
-    │                     ^^^^^^^^^^^^^^^^^^^^ Invalid type annotation
-    ·
- 24 │     fun t2(cond: bool, u: &u64, u_mut: &mut u64) {
-    │                           ---- The type: '&u64'
-    ·
- 25 │         let (_, _): (&mut u64, &mut u64) = if (cond) (u, u) else (u_mut, u_mut);
-    │                      -------- Is not a subtype of: '&mut u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/if_branches_subtype_invalid.move:26:21 ───
-    │
- 26 │         let (_, _): (&mut u64, &mut u64) = if (cond) (u_mut, u) else (u, u_mut);
-    │                     ^^^^^^^^^^^^^^^^^^^^ Invalid type annotation
-    ·
- 24 │     fun t2(cond: bool, u: &u64, u_mut: &mut u64) {
-    │                           ---- The type: '&u64'
-    ·
- 26 │         let (_, _): (&mut u64, &mut u64) = if (cond) (u_mut, u) else (u, u_mut);
-    │                      -------- Is not a subtype of: '&mut u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/if_branches_subtype_invalid.move:27:21 ───
-    │
- 27 │         let (_, _): (&mut u64, &mut u64) = if (cond) (u, u_mut) else (u_mut, u);
-    │                     ^^^^^^^^^^^^^^^^^^^^ Invalid type annotation
-    ·
- 24 │     fun t2(cond: bool, u: &u64, u_mut: &mut u64) {
-    │                           ---- The type: '&u64'
-    ·
- 27 │         let (_, _): (&mut u64, &mut u64) = if (cond) (u, u_mut) else (u_mut, u);
-    │                      -------- Is not a subtype of: '&mut u64'
-    │
+error[E04006]: invalid subtype
+   ┌─ tests/move_check/typing/if_branches_subtype_invalid.move:27:21
+   │
+24 │     fun t2(cond: bool, u: &u64, u_mut: &mut u64) {
+   │                           ---- Given: '&u64'
+   ·
+27 │         let (_, _): (&mut u64, &mut u64) = if (cond) (u, u_mut) else (u_mut, u);
+   │                     ^^^^^^^^^^^^^^^^^^^^
+   │                     ││
+   │                     │Expected: '&mut u64'
+   │                     Invalid type annotation
 

--- a/language/move-lang/tests/move_check/typing/if_condition_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/if_condition_invalid.exp
@@ -1,112 +1,81 @@
-error: 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/if_condition_invalid.move:3:13
+  │
+3 │         if (()) () else ();
+  │             ^^
+  │             │
+  │             Invalid if condition
+  │             Expected: 'bool'
+  │             Given: '()'
 
-   ┌── tests/move_check/typing/if_condition_invalid.move:3:13 ───
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/if_condition_invalid.move:4:13
+  │
+4 │         if ((())) () else ();
+  │             ^^^^
+  │             │
+  │             Invalid if condition
+  │             Expected: 'bool'
+  │             Given: '()'
+
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/if_condition_invalid.move:5:13
+  │
+5 │         if ({}) () else ()
+  │             ^^
+  │             │
+  │             Invalid if condition
+  │             Expected: 'bool'
+  │             Given: '()'
+
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/if_condition_invalid.move:9:13
+  │
+8 │     fun t1<T: drop>(x: T) {
+  │                        - Given: 'T'
+9 │         if (x) () else ();
+  │             ^
+  │             │
+  │             Invalid if condition
+  │             Expected: 'bool'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/if_condition_invalid.move:10:13
    │
- 3 │         if (()) () else ();
-   │             ^^ Invalid if condition
-   ·
- 3 │         if (()) () else ();
-   │             -- The type: '()'
-   ·
- 3 │         if (()) () else ();
-   │             -- Is not compatible with: 'bool'
+10 │         if (0) () else ();
+   │             ^
+   │             │
+   │             Invalid if condition
+   │             Expected: 'bool'
+   │             Given: integer
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/if_condition_invalid.move:11:13
    │
+11 │         if (@0x0) () else ()
+   │             ^^^^
+   │             │
+   │             Invalid if condition
+   │             Expected: 'bool'
+   │             Given: 'address'
 
-error: 
-
-   ┌── tests/move_check/typing/if_condition_invalid.move:4:13 ───
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/if_condition_invalid.move:15:13
    │
- 4 │         if ((())) () else ();
-   │             ^^^^ Invalid if condition
-   ·
- 4 │         if ((())) () else ();
-   │             ---- The type: '()'
-   ·
- 4 │         if ((())) () else ();
-   │             ---- Is not compatible with: 'bool'
+15 │         if ((false, true)) () else ();
+   │             ^^^^^^^^^^^^^
+   │             │
+   │             Invalid if condition
+   │             Expected: 'bool'
+   │             Given: '(bool, bool)'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/if_condition_invalid.move:16:13
    │
-
-error: 
-
-   ┌── tests/move_check/typing/if_condition_invalid.move:5:13 ───
-   │
- 5 │         if ({}) () else ()
-   │             ^^ Invalid if condition
-   ·
- 5 │         if ({}) () else ()
-   │             -- The type: '()'
-   ·
- 5 │         if ({}) () else ()
-   │             -- Is not compatible with: 'bool'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/if_condition_invalid.move:9:13 ───
-   │
- 9 │         if (x) () else ();
-   │             ^ Invalid if condition
-   ·
- 8 │     fun t1<T: drop>(x: T) {
-   │                        - The type: 'T'
-   ·
- 9 │         if (x) () else ();
-   │             - Is not compatible with: 'bool'
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/if_condition_invalid.move:10:13 ───
-    │
- 10 │         if (0) () else ();
-    │             ^ Invalid if condition
-    ·
- 10 │         if (0) () else ();
-    │             - The type: integer
-    ·
- 10 │         if (0) () else ();
-    │             - Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/if_condition_invalid.move:11:13 ───
-    │
- 11 │         if (@0x0) () else ()
-    │             ^^^^ Invalid if condition
-    ·
- 11 │         if (@0x0) () else ()
-    │             ---- The type: 'address'
-    ·
- 11 │         if (@0x0) () else ()
-    │             ---- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/if_condition_invalid.move:15:13 ───
-    │
- 15 │         if ((false, true)) () else ();
-    │             ^^^^^^^^^^^^^ Invalid if condition
-    ·
- 15 │         if ((false, true)) () else ();
-    │             ------------- The type: '(bool, bool)'
-    ·
- 15 │         if ((false, true)) () else ();
-    │             ------------- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/if_condition_invalid.move:16:13 ───
-    │
- 16 │         if ((0, false)) () else ()
-    │             ^^^^^^^^^^ Invalid if condition
-    ·
- 16 │         if ((0, false)) () else ()
-    │             ---------- The type: '({integer}, bool)'
-    ·
- 16 │         if ((0, false)) () else ()
-    │             ---------- Is not compatible with: 'bool'
-    │
+16 │         if ((0, false)) () else ()
+   │             ^^^^^^^^^^
+   │             │
+   │             Invalid if condition
+   │             Expected: 'bool'
+   │             Given: '({integer}, bool)'
 

--- a/language/move-lang/tests/move_check/typing/if_mismatched_branches.exp
+++ b/language/move-lang/tests/move_check/typing/if_mismatched_branches.exp
@@ -1,126 +1,90 @@
-error: 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/if_mismatched_branches.move:3:9
+  │
+3 │         if (cond) () else 0;
+  │         ^^^^^^^^^^^^^^^^^^^
+  │         │         │       │
+  │         │         │       Found: integer. It is not compatible with the other type.
+  │         │         Found: '()'. It is not compatible with the other type.
+  │         Incompatible branches
 
-   ┌── tests/move_check/typing/if_mismatched_branches.move:3:9 ───
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/if_mismatched_branches.move:4:9
+  │
+4 │         if (cond) 0 else ();
+  │         ^^^^^^^^^^^^^^^^^^^
+  │         │         │      │
+  │         │         │      Found: '()'. It is not compatible with the other type.
+  │         │         Found: integer. It is not compatible with the other type.
+  │         Incompatible branches
+
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/if_mismatched_branches.move:8:9
+  │
+8 │         if (cond) @0x0 else 0;
+  │         ^^^^^^^^^^^^^^^^^^^^^
+  │         │         │         │
+  │         │         │         Found: integer. It is not compatible with the other type.
+  │         │         Found: 'address'. It is not compatible with the other type.
+  │         Incompatible branches
+
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/if_mismatched_branches.move:9:9
+  │
+9 │         if (cond) 0 else false;
+  │         ^^^^^^^^^^^^^^^^^^^^^^
+  │         │         │      │
+  │         │         │      Found: 'bool'. It is not compatible with the other type.
+  │         │         Found: integer. It is not compatible with the other type.
+  │         Incompatible branches
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/if_mismatched_branches.move:13:9
    │
- 3 │         if (cond) () else 0;
-   │         ^^^^^^^^^^^^^^^^^^^ Incompatible branches
-   ·
- 3 │         if (cond) () else 0;
-   │                           - The type: integer
-   ·
- 3 │         if (cond) () else 0;
-   │                   -- Is not compatible with: '()'
+13 │         if (cond) (0, false) else (1, 1);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │             │               │
+   │         │             │               Found: integer. It is not compatible with the other type.
+   │         │             Found: 'bool'. It is not compatible with the other type.
+   │         Incompatible branches
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/if_mismatched_branches.move:14:9
    │
+14 │         if (cond) (0, false) else (false, false);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │          │               │
+   │         │          │               Found: 'bool'. It is not compatible with the other type.
+   │         │          Found: integer. It is not compatible with the other type.
+   │         Incompatible branches
 
-error: 
-
-   ┌── tests/move_check/typing/if_mismatched_branches.move:4:9 ───
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/if_mismatched_branches.move:15:9
    │
- 4 │         if (cond) 0 else ();
-   │         ^^^^^^^^^^^^^^^^^^^ Incompatible branches
-   ·
- 4 │         if (cond) 0 else ();
-   │                   - The type: integer
-   ·
- 4 │         if (cond) 0 else ();
-   │                          -- Is not compatible with: '()'
+15 │         if (cond) (0, false) else (true, @0x0);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │          │               │
+   │         │          │               Found: 'bool'. It is not compatible with the other type.
+   │         │          Found: integer. It is not compatible with the other type.
+   │         Incompatible branches
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/if_mismatched_branches.move:19:9
    │
+19 │         if (cond) (0, false, 0) else (0, false);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │         │                  │
+   │         │         │                  Found expression list of length 2: '({integer}, bool)'. It is not compatible with the other type of length 3.
+   │         │         Found expression list of length 3: '({integer}, bool, {integer})'. It is not compatible with the other type of length 2.
+   │         Incompatible branches
 
-error: 
-
-   ┌── tests/move_check/typing/if_mismatched_branches.move:8:9 ───
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/if_mismatched_branches.move:20:9
    │
- 8 │         if (cond) @0x0 else 0;
-   │         ^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
-   ·
- 8 │         if (cond) @0x0 else 0;
-   │                             - The type: integer
-   ·
- 8 │         if (cond) @0x0 else 0;
-   │                   ---- Is not compatible with: 'address'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/if_mismatched_branches.move:9:9 ───
-   │
- 9 │         if (cond) 0 else false;
-   │         ^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
-   ·
- 9 │         if (cond) 0 else false;
-   │                   - The type: integer
-   ·
- 9 │         if (cond) 0 else false;
-   │                          ----- Is not compatible with: 'bool'
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/if_mismatched_branches.move:13:9 ───
-    │
- 13 │         if (cond) (0, false) else (1, 1);
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
-    ·
- 13 │         if (cond) (0, false) else (1, 1);
-    │                                       - The type: integer
-    ·
- 13 │         if (cond) (0, false) else (1, 1);
-    │                       ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/if_mismatched_branches.move:14:9 ───
-    │
- 14 │         if (cond) (0, false) else (false, false);
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
-    ·
- 14 │         if (cond) (0, false) else (false, false);
-    │                    - The type: integer
-    ·
- 14 │         if (cond) (0, false) else (false, false);
-    │                                    ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/if_mismatched_branches.move:15:9 ───
-    │
- 15 │         if (cond) (0, false) else (true, @0x0);
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
-    ·
- 15 │         if (cond) (0, false) else (true, @0x0);
-    │                    - The type: integer
-    ·
- 15 │         if (cond) (0, false) else (true, @0x0);
-    │                                    ---- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/if_mismatched_branches.move:19:9 ───
-    │
- 19 │         if (cond) (0, false, 0) else (0, false);
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
-    ·
- 19 │         if (cond) (0, false, 0) else (0, false);
-    │                   ------------- The expression list type of length 3: '({integer}, bool, {integer})'
-    ·
- 19 │         if (cond) (0, false, 0) else (0, false);
-    │                                      ---------- Is not compatible with the expression list type of length 2: '({integer}, bool)'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/if_mismatched_branches.move:20:9 ───
-    │
- 20 │         if (cond) (0, false) else (0, false, 0);
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
-    ·
- 20 │         if (cond) (0, false) else (0, false, 0);
-    │                   ---------- The expression list type of length 2: '({integer}, bool)'
-    ·
- 20 │         if (cond) (0, false) else (0, false, 0);
-    │                                   ------------- Is not compatible with the expression list type of length 3: '({integer}, bool, {integer})'
-    │
+20 │         if (cond) (0, false) else (0, false, 0);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │         │               │
+   │         │         │               Found expression list of length 3: '({integer}, bool, {integer})'. It is not compatible with the other type of length 2.
+   │         │         Found expression list of length 2: '({integer}, bool)'. It is not compatible with the other type of length 3.
+   │         Incompatible branches
 

--- a/language/move-lang/tests/move_check/typing/loop_body_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/loop_body_invalid.exp
@@ -1,70 +1,50 @@
-error: 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/loop_body_invalid.move:3:14
+  │
+3 │         loop 0
+  │              ^
+  │              │
+  │              Invalid loop body
+  │              Expected: '()'
+  │              Given: integer
 
-   ┌── tests/move_check/typing/loop_body_invalid.move:3:14 ───
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/loop_body_invalid.move:7:14
+  │
+7 │         loop false
+  │              ^^^^^
+  │              │
+  │              Invalid loop body
+  │              Expected: '()'
+  │              Given: 'bool'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/loop_body_invalid.move:11:14
    │
- 3 │         loop 0
-   │              ^ Invalid loop body
-   ·
- 3 │         loop 0
-   │              - The type: integer
-   ·
- 3 │         loop 0
-   │              - Is not compatible with: '()'
+11 │         loop { @0x0 }
+   │              ^^^^^^^^
+   │              │ │
+   │              │ Given: 'address'
+   │              Invalid loop body
+   │              Expected: '()'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/loop_body_invalid.move:15:14
    │
+15 │         loop { let x = 0; x }
+   │              ^^^^^^^^^^^^^^^^
+   │              │     │
+   │              │     Given: integer
+   │              Invalid loop body
+   │              Expected: '()'
 
-error: 
-
-   ┌── tests/move_check/typing/loop_body_invalid.move:7:14 ───
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/loop_body_invalid.move:19:14
    │
- 7 │         loop false
-   │              ^^^^^ Invalid loop body
-   ·
- 7 │         loop false
-   │              ----- The type: 'bool'
-   ·
- 7 │         loop false
-   │              ----- Is not compatible with: '()'
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/loop_body_invalid.move:11:14 ───
-    │
- 11 │         loop { @0x0 }
-    │              ^^^^^^^^ Invalid loop body
-    ·
- 11 │         loop { @0x0 }
-    │                ---- The type: 'address'
-    ·
- 11 │         loop { @0x0 }
-    │              -------- Is not compatible with: '()'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/loop_body_invalid.move:15:14 ───
-    │
- 15 │         loop { let x = 0; x }
-    │              ^^^^^^^^^^^^^^^^ Invalid loop body
-    ·
- 15 │         loop { let x = 0; x }
-    │                    - The type: integer
-    ·
- 15 │         loop { let x = 0; x }
-    │              ---------------- Is not compatible with: '()'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/loop_body_invalid.move:19:14 ───
-    │
- 19 │         loop { if (true) 1 else 0 }
-    │              ^^^^^^^^^^^^^^^^^^^^^^ Invalid loop body
-    ·
- 19 │         loop { if (true) 1 else 0 }
-    │                                 - The type: integer
-    ·
- 19 │         loop { if (true) 1 else 0 }
-    │              ---------------------- Is not compatible with: '()'
-    │
+19 │         loop { if (true) 1 else 0 }
+   │              ^^^^^^^^^^^^^^^^^^^^^^
+   │              │                  │
+   │              │                  Given: integer
+   │              Invalid loop body
+   │              Expected: '()'
 

--- a/language/move-lang/tests/move_check/typing/loop_result_type_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/loop_result_type_invalid.exp
@@ -1,3 +1,37 @@
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/loop_result_type_invalid.move:11:9
+   │
+10 │     fun t0(): X::R {
+   │               ---- Expected: '0x2::X::R'
+11 │         loop { if (false) break }
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │
+   │         Invalid return expression
+   │         Given: '()'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/loop_result_type_invalid.move:15:9
+   │
+14 │     fun t1(): u64 {
+   │               --- Expected: 'u64'
+15 │         loop { let x = 0; break }
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │
+   │         Invalid return expression
+   │         Given: '()'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/loop_result_type_invalid.move:19:9
+   │
+19 │         foo(loop { break })
+   │         ^^^^^^^^^^^^^^^^^^^
+   │         │   │
+   │         │   Given: '()'
+   │         Invalid call of '0x2::M::foo'. Invalid argument for parameter 'x'
+   ·
+22 │     fun foo(x: u64) {}
+   │                --- Expected: 'u64'
+
 error[E04005]: expected a single type
    ┌─ tests/move_check/typing/loop_result_type_invalid.move:25:13
    │
@@ -6,59 +40,12 @@ error[E04005]: expected a single type
    │             │    
    │             Invalid type for local
 
-error: 
-
-    ┌── tests/move_check/typing/loop_result_type_invalid.move:11:9 ───
-    │
- 11 │         loop { if (false) break }
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid return expression
-    ·
- 11 │         loop { if (false) break }
-    │         ------------------------- The type: '()'
-    ·
- 10 │     fun t0(): X::R {
-    │               ---- Is not compatible with: '0x2::X::R'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/loop_result_type_invalid.move:15:9 ───
-    │
- 15 │         loop { let x = 0; break }
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid return expression
-    ·
- 15 │         loop { let x = 0; break }
-    │         ------------------------- The type: '()'
-    ·
- 14 │     fun t1(): u64 {
-    │               --- Is not compatible with: 'u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/loop_result_type_invalid.move:19:9 ───
-    │
- 19 │         foo(loop { break })
-    │         ^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::M::foo'. Invalid argument for parameter 'x'
-    ·
- 19 │         foo(loop { break })
-    │             -------------- The type: '()'
-    ·
- 22 │     fun foo(x: u64) {}
-    │                --- Is not compatible with: 'u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/loop_result_type_invalid.move:26:13 ───
-    │
- 26 │         let (x, y) = loop { if (false) break };
-    │             ^^^^^^ Invalid value for binding
-    ·
- 26 │         let (x, y) = loop { if (false) break };
-    │             ------ The type: '(_, _)'
-    ·
- 26 │         let (x, y) = loop { if (false) break };
-    │                      ------------------------- Is not compatible with: '()'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/loop_result_type_invalid.move:26:13
+   │
+26 │         let (x, y) = loop { if (false) break };
+   │             ^^^^^^   ------------------------- Given: '()'
+   │             │         
+   │             Invalid value for binding
+   │             Expected: '(_, _)'
 

--- a/language/move-lang/tests/move_check/typing/main_return_type_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/main_return_type_invalid.exp
@@ -1,14 +1,9 @@
-error: 
-
-   ┌── tests/move_check/typing/main_return_type_invalid.move:2:5 ───
-   │
- 2 │ fun main(): u64 {
-   │     ^^^^ Invalid 'script' function return type. The function entry point to a 'script' must have the return type '()'
-   ·
- 2 │ fun main(): u64 {
-   │             --- The type: 'u64'
-   ·
- 2 │ fun main(): u64 {
-   │     ---- Is not compatible with: '()'
-   │
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/main_return_type_invalid.move:2:5
+  │
+2 │ fun main(): u64 {
+  │     ^^^^    --- Given: 'u64'
+  │     │        
+  │     Invalid 'script' function return type. The function entry point to a 'script' must have the return type '()'
+  │     Expected: '()'
 

--- a/language/move-lang/tests/move_check/typing/module_call.exp
+++ b/language/move-lang/tests/move_check/typing/module_call.exp
@@ -1,3 +1,15 @@
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call.move:43:18
+   │
+ 8 │     public fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
+   │                                           -------------- Given: '(bool, (address, u64), _)'
+   ·
+11 │     public fun bing(b: bool, a: address, x: u64) {
+   │                        ---- Expected: 'bool'
+   ·
+43 │         let () = X::bing(X::baz(X::bar(X::foo())));
+   │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::X::bing'. Invalid argument for parameter 'b'
+
 error[E04004]: expected a single non-reference type
    ┌─ tests/move_check/typing/module_call.move:43:26
    │
@@ -6,6 +18,18 @@ error[E04004]: expected a single non-reference type
    ·
 43 │         let () = X::bing(X::baz(X::bar(X::foo())));
    │                          ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid type argument
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call.move:44:18
+   │
+ 8 │     public fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
+   │                                           -------------- Given: '(bool, (address, u64), _)'
+   ·
+11 │     public fun bing(b: bool, a: address, x: u64) {
+   │                        ---- Expected: 'bool'
+   ·
+44 │         let () = X::bing (X::baz (X::bar (X::foo())));
+   │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::X::bing'. Invalid argument for parameter 'b'
 
 error[E04004]: expected a single non-reference type
    ┌─ tests/move_check/typing/module_call.move:44:27
@@ -16,6 +40,18 @@ error[E04004]: expected a single non-reference type
 44 │         let () = X::bing (X::baz (X::bar (X::foo())));
    │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid type argument
 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call.move:45:18
+   │
+ 8 │     public fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
+   │                                           -------------- Given: '(bool, (address, u64), _)'
+   ·
+11 │     public fun bing(b: bool, a: address, x: u64) {
+   │                        ---- Expected: 'bool'
+   ·
+45 │         let () = X::bing (X::baz (X::bar(1)));
+   │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::X::bing'. Invalid argument for parameter 'b'
+
 error[E04004]: expected a single non-reference type
    ┌─ tests/move_check/typing/module_call.move:45:27
    │
@@ -24,6 +60,30 @@ error[E04004]: expected a single non-reference type
    ·
 45 │         let () = X::bing (X::baz (X::bar(1)));
    │                           ^^^^^^^^^^^^^^^^^^ Invalid type argument
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call.move:46:18
+   │
+ 8 │     public fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
+   │                                           -------------- Given: '(bool, address, {integer})'
+   ·
+11 │     public fun bing(b: bool, a: address, x: u64) {
+   │                        ---- Expected: 'bool'
+   ·
+46 │         let () = X::bing (X::baz (@0x0, 1));
+   │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::X::bing'. Invalid argument for parameter 'b'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call.move:51:18
+   │
+22 │     fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
+   │                                    -------------- Given: '(bool, (address, u64), _)'
+   ·
+25 │     fun bing(b: bool, a: address, x: u64) {
+   │                 ---- Expected: 'bool'
+   ·
+51 │         let () = bing(baz(bar(foo())));
+   │                  ^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::M::bing'. Invalid argument for parameter 'b'
 
 error[E04004]: expected a single non-reference type
    ┌─ tests/move_check/typing/module_call.move:51:23
@@ -34,6 +94,18 @@ error[E04004]: expected a single non-reference type
 51 │         let () = bing(baz(bar(foo())));
    │                       ^^^^^^^^^^^^^^^ Invalid type argument
 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call.move:52:18
+   │
+22 │     fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
+   │                                    -------------- Given: '(bool, (address, u64), _)'
+   ·
+25 │     fun bing(b: bool, a: address, x: u64) {
+   │                 ---- Expected: 'bool'
+   ·
+52 │         let () = bing (baz (bar (foo())));
+   │                  ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::M::bing'. Invalid argument for parameter 'b'
+
 error[E04004]: expected a single non-reference type
    ┌─ tests/move_check/typing/module_call.move:52:24
    │
@@ -42,6 +114,18 @@ error[E04004]: expected a single non-reference type
    ·
 52 │         let () = bing (baz (bar (foo())));
    │                        ^^^^^^^^^^^^^^^^^ Invalid type argument
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call.move:53:18
+   │
+22 │     fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
+   │                                    -------------- Given: '(bool, (address, u64), _)'
+   ·
+25 │     fun bing(b: bool, a: address, x: u64) {
+   │                 ---- Expected: 'bool'
+   ·
+53 │         let () = bing (baz (bar(1)));
+   │                  ^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::M::bing'. Invalid argument for parameter 'b'
 
 error[E04004]: expected a single non-reference type
    ┌─ tests/move_check/typing/module_call.move:53:24
@@ -52,6 +136,18 @@ error[E04004]: expected a single non-reference type
 53 │         let () = bing (baz (bar(1)));
    │                        ^^^^^^^^^^^^ Invalid type argument
 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call.move:54:18
+   │
+22 │     fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
+   │                                    -------------- Given: '(bool, address, {integer})'
+   ·
+25 │     fun bing(b: bool, a: address, x: u64) {
+   │                 ---- Expected: 'bool'
+   ·
+54 │         let () = bing (baz (@0x0, 1));
+   │                  ^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::M::bing'. Invalid argument for parameter 'b'
+
 error: 
 
     ┌── tests/move_check/typing/module_call.move:43:18 ───
@@ -61,20 +157,6 @@ error:
     ·
  43 │         let () = X::bing(X::baz(X::bar(X::foo())));
     │                         -------------------------- Found 1 argument(s) here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call.move:43:18 ───
-    │
- 43 │         let () = X::bing(X::baz(X::bar(X::foo())));
-    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::X::bing'. Invalid argument for parameter 'b'
-    ·
-  8 │     public fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
-    │                                           -------------- The type: '(bool, (address, u64), _)'
-    ·
- 11 │     public fun bing(b: bool, a: address, x: u64) {
-    │                        ---- Is not compatible with: 'bool'
     │
 
 error: 
@@ -101,20 +183,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/module_call.move:44:18 ───
-    │
- 44 │         let () = X::bing (X::baz (X::bar (X::foo())));
-    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::X::bing'. Invalid argument for parameter 'b'
-    ·
-  8 │     public fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
-    │                                           -------------- The type: '(bool, (address, u64), _)'
-    ·
- 11 │     public fun bing(b: bool, a: address, x: u64) {
-    │                        ---- Is not compatible with: 'bool'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/module_call.move:44:27 ───
     │
  44 │         let () = X::bing (X::baz (X::bar (X::foo())));
@@ -133,20 +201,6 @@ error:
     ·
  45 │         let () = X::bing (X::baz (X::bar(1)));
     │                          -------------------- Found 1 argument(s) here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call.move:45:18 ───
-    │
- 45 │         let () = X::bing (X::baz (X::bar(1)));
-    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::X::bing'. Invalid argument for parameter 'b'
-    ·
-  8 │     public fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
-    │                                           -------------- The type: '(bool, (address, u64), _)'
-    ·
- 11 │     public fun bing(b: bool, a: address, x: u64) {
-    │                        ---- Is not compatible with: 'bool'
     │
 
 error: 
@@ -173,20 +227,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/module_call.move:46:18 ───
-    │
- 46 │         let () = X::bing (X::baz (@0x0, 1));
-    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::X::bing'. Invalid argument for parameter 'b'
-    ·
-  8 │     public fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
-    │                                           -------------- The type: '(bool, address, {integer})'
-    ·
- 11 │     public fun bing(b: bool, a: address, x: u64) {
-    │                        ---- Is not compatible with: 'bool'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/module_call.move:51:18 ───
     │
  51 │         let () = bing(baz(bar(foo())));
@@ -194,20 +234,6 @@ error:
     ·
  51 │         let () = bing(baz(bar(foo())));
     │                      ----------------- Found 1 argument(s) here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call.move:51:18 ───
-    │
- 51 │         let () = bing(baz(bar(foo())));
-    │                  ^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::M::bing'. Invalid argument for parameter 'b'
-    ·
- 22 │     fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
-    │                                    -------------- The type: '(bool, (address, u64), _)'
-    ·
- 25 │     fun bing(b: bool, a: address, x: u64) {
-    │                 ---- Is not compatible with: 'bool'
     │
 
 error: 
@@ -234,20 +260,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/module_call.move:52:18 ───
-    │
- 52 │         let () = bing (baz (bar (foo())));
-    │                  ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::M::bing'. Invalid argument for parameter 'b'
-    ·
- 22 │     fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
-    │                                    -------------- The type: '(bool, (address, u64), _)'
-    ·
- 25 │     fun bing(b: bool, a: address, x: u64) {
-    │                 ---- Is not compatible with: 'bool'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/module_call.move:52:24 ───
     │
  52 │         let () = bing (baz (bar (foo())));
@@ -270,20 +282,6 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/module_call.move:53:18 ───
-    │
- 53 │         let () = bing (baz (bar(1)));
-    │                  ^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::M::bing'. Invalid argument for parameter 'b'
-    ·
- 22 │     fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
-    │                                    -------------- The type: '(bool, (address, u64), _)'
-    ·
- 25 │     fun bing(b: bool, a: address, x: u64) {
-    │                 ---- Is not compatible with: 'bool'
-    │
-
-error: 
-
     ┌── tests/move_check/typing/module_call.move:53:24 ───
     │
  53 │         let () = bing (baz (bar(1)));
@@ -302,19 +300,5 @@ error:
     ·
  54 │         let () = bing (baz (@0x0, 1));
     │                       --------------- Found 1 argument(s) here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call.move:54:18 ───
-    │
- 54 │         let () = bing (baz (@0x0, 1));
-    │                  ^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::M::bing'. Invalid argument for parameter 'b'
-    ·
- 22 │     fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
-    │                                    -------------- The type: '(bool, address, {integer})'
-    ·
- 25 │     fun bing(b: bool, a: address, x: u64) {
-    │                 ---- Is not compatible with: 'bool'
     │
 

--- a/language/move-lang/tests/move_check/typing/module_call_explicit_type_arguments_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/module_call_explicit_type_arguments_invalid.exp
@@ -1,126 +1,95 @@
-error: 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/module_call_explicit_type_arguments_invalid.move:6:9
+  │
+6 │         foo<u64, u64>(false, false);
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │         │   │         │
+  │         │   │         Given: 'bool'
+  │         │   Expected: 'u64'
+  │         Invalid call of '0x8675309::M::foo'. Invalid argument for parameter 'x'
 
-   ┌── tests/move_check/typing/module_call_explicit_type_arguments_invalid.move:6:9 ───
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/module_call_explicit_type_arguments_invalid.move:6:9
+  │
+6 │         foo<u64, u64>(false, false);
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │         │        │           │
+  │         │        │           Given: 'bool'
+  │         │        Expected: 'u64'
+  │         Invalid call of '0x8675309::M::foo'. Invalid argument for parameter 'y'
+
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/module_call_explicit_type_arguments_invalid.move:7:9
+  │
+7 │         foo<bool, bool>(0, false);
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^
+  │         │   │           │
+  │         │   │           Given: integer
+  │         │   Expected: 'bool'
+  │         Invalid call of '0x8675309::M::foo'. Invalid argument for parameter 'x'
+
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/module_call_explicit_type_arguments_invalid.move:8:9
+  │
+8 │         foo<bool, bool>(false, 0);
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^
+  │         │         │            │
+  │         │         │            Given: integer
+  │         │         Expected: 'bool'
+  │         Invalid call of '0x8675309::M::foo'. Invalid argument for parameter 'y'
+
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/module_call_explicit_type_arguments_invalid.move:9:9
+  │
+9 │         foo<bool, bool>(0, 0);
+  │         ^^^^^^^^^^^^^^^^^^^^^
+  │         │   │           │
+  │         │   │           Given: integer
+  │         │   Expected: 'bool'
+  │         Invalid call of '0x8675309::M::foo'. Invalid argument for parameter 'x'
+
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/module_call_explicit_type_arguments_invalid.move:9:9
+  │
+9 │         foo<bool, bool>(0, 0);
+  │         ^^^^^^^^^^^^^^^^^^^^^
+  │         │         │        │
+  │         │         │        Given: integer
+  │         │         Expected: 'bool'
+  │         Invalid call of '0x8675309::M::foo'. Invalid argument for parameter 'y'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call_explicit_type_arguments_invalid.move:13:9
    │
- 6 │         foo<u64, u64>(false, false);
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::foo'. Invalid argument for parameter 'x'
-   ·
- 6 │         foo<u64, u64>(false, false);
-   │                       ----- The type: 'bool'
-   ·
- 6 │         foo<u64, u64>(false, false);
-   │             --- Is not compatible with: 'u64'
+12 │     fun t2<T, U, V>(t: T, u: U, v: V) {
+   │                        - Given: 'T'
+13 │         foo<U, u64>(t, 0);
+   │         ^^^^^^^^^^^^^^^^^
+   │         │   │
+   │         │   Expected: 'U'
+   │         Invalid call of '0x8675309::M::foo'. Invalid argument for parameter 'x'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call_explicit_type_arguments_invalid.move:14:9
    │
+12 │     fun t2<T, U, V>(t: T, u: U, v: V) {
+   │                              - Given: 'U'
+13 │         foo<U, u64>(t, 0);
+14 │         foo<V, T>(u, v);
+   │         ^^^^^^^^^^^^^^^
+   │         │   │
+   │         │   Expected: 'V'
+   │         Invalid call of '0x8675309::M::foo'. Invalid argument for parameter 'x'
 
-error: 
-
-   ┌── tests/move_check/typing/module_call_explicit_type_arguments_invalid.move:6:9 ───
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call_explicit_type_arguments_invalid.move:14:9
    │
- 6 │         foo<u64, u64>(false, false);
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::foo'. Invalid argument for parameter 'y'
-   ·
- 6 │         foo<u64, u64>(false, false);
-   │                              ----- The type: 'bool'
-   ·
- 6 │         foo<u64, u64>(false, false);
-   │                  --- Is not compatible with: 'u64'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/module_call_explicit_type_arguments_invalid.move:7:9 ───
-   │
- 7 │         foo<bool, bool>(0, false);
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::foo'. Invalid argument for parameter 'x'
-   ·
- 7 │         foo<bool, bool>(0, false);
-   │                         - The type: integer
-   ·
- 7 │         foo<bool, bool>(0, false);
-   │             ---- Is not compatible with: 'bool'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/module_call_explicit_type_arguments_invalid.move:8:9 ───
-   │
- 8 │         foo<bool, bool>(false, 0);
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::foo'. Invalid argument for parameter 'y'
-   ·
- 8 │         foo<bool, bool>(false, 0);
-   │                                - The type: integer
-   ·
- 8 │         foo<bool, bool>(false, 0);
-   │                   ---- Is not compatible with: 'bool'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/module_call_explicit_type_arguments_invalid.move:9:9 ───
-   │
- 9 │         foo<bool, bool>(0, 0);
-   │         ^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::foo'. Invalid argument for parameter 'x'
-   ·
- 9 │         foo<bool, bool>(0, 0);
-   │                         - The type: integer
-   ·
- 9 │         foo<bool, bool>(0, 0);
-   │             ---- Is not compatible with: 'bool'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/module_call_explicit_type_arguments_invalid.move:9:9 ───
-   │
- 9 │         foo<bool, bool>(0, 0);
-   │         ^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::foo'. Invalid argument for parameter 'y'
-   ·
- 9 │         foo<bool, bool>(0, 0);
-   │                            - The type: integer
-   ·
- 9 │         foo<bool, bool>(0, 0);
-   │                   ---- Is not compatible with: 'bool'
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_explicit_type_arguments_invalid.move:13:9 ───
-    │
- 13 │         foo<U, u64>(t, 0);
-    │         ^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::foo'. Invalid argument for parameter 'x'
-    ·
- 12 │     fun t2<T, U, V>(t: T, u: U, v: V) {
-    │                        - The type: 'T'
-    ·
- 13 │         foo<U, u64>(t, 0);
-    │             - Is not compatible with: 'U'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_explicit_type_arguments_invalid.move:14:9 ───
-    │
- 14 │         foo<V, T>(u, v);
-    │         ^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::foo'. Invalid argument for parameter 'x'
-    ·
- 12 │     fun t2<T, U, V>(t: T, u: U, v: V) {
-    │                              - The type: 'U'
-    ·
- 14 │         foo<V, T>(u, v);
-    │             - Is not compatible with: 'V'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_explicit_type_arguments_invalid.move:14:9 ───
-    │
- 14 │         foo<V, T>(u, v);
-    │         ^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::foo'. Invalid argument for parameter 'y'
-    ·
- 12 │     fun t2<T, U, V>(t: T, u: U, v: V) {
-    │                                    - The type: 'V'
-    ·
- 14 │         foo<V, T>(u, v);
-    │                - Is not compatible with: 'T'
-    │
+12 │     fun t2<T, U, V>(t: T, u: U, v: V) {
+   │                                    - Given: 'V'
+13 │         foo<U, u64>(t, 0);
+14 │         foo<V, T>(u, v);
+   │         ^^^^^^^^^^^^^^^
+   │         │      │
+   │         │      Expected: 'T'
+   │         Invalid call of '0x8675309::M::foo'. Invalid argument for parameter 'y'
 

--- a/language/move-lang/tests/move_check/typing/module_call_wrong_argument_in_list.exp
+++ b/language/move-lang/tests/move_check/typing/module_call_wrong_argument_in_list.exp
@@ -1,252 +1,216 @@
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call_wrong_argument_in_list.move:20:9
+   │
+16 │     public fun foo(a: address, u: u64, s: S) {
+   │                       ------- Expected: 'address'
+   ·
+20 │         foo(false, 0, S{});
+   │         ^^^^^^^^^^^^^^^^^^
+   │         │   │
+   │         │   Given: 'bool'
+   │         Invalid call of '0x2::M::foo'. Invalid argument for parameter 'a'
 
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:20:9 ───
-    │
- 20 │         foo(false, 0, S{});
-    │         ^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::M::foo'. Invalid argument for parameter 'a'
-    ·
- 20 │         foo(false, 0, S{});
-    │             ----- The type: 'bool'
-    ·
- 16 │     public fun foo(a: address, u: u64, s: S) {
-    │                       ------- Is not compatible with: 'address'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call_wrong_argument_in_list.move:21:9
+   │
+16 │     public fun foo(a: address, u: u64, s: S) {
+   │                                   --- Expected: 'u64'
+   ·
+21 │         foo(@0x0, false, S{});
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │         │         │
+   │         │         Given: 'bool'
+   │         Invalid call of '0x2::M::foo'. Invalid argument for parameter 'u'
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call_wrong_argument_in_list.move:22:9
+   │
+16 │     public fun foo(a: address, u: u64, s: S) {
+   │                                           - Expected: '0x2::M::S'
+   ·
+22 │         foo(@0x0, 0, false);
+   │         ^^^^^^^^^^^^^^^^^^^
+   │         │            │
+   │         │            Given: 'bool'
+   │         Invalid call of '0x2::M::foo'. Invalid argument for parameter 's'
 
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:21:9 ───
-    │
- 21 │         foo(@0x0, false, S{});
-    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::M::foo'. Invalid argument for parameter 'u'
-    ·
- 21 │         foo(@0x0, false, S{});
-    │                   ----- The type: 'bool'
-    ·
- 16 │     public fun foo(a: address, u: u64, s: S) {
-    │                                   --- Is not compatible with: 'u64'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call_wrong_argument_in_list.move:23:9
+   │
+16 │     public fun foo(a: address, u: u64, s: S) {
+   │                                   --- Expected: 'u64'
+   ·
+23 │         foo(@0x0, false, false);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^
+   │         │         │
+   │         │         Given: 'bool'
+   │         Invalid call of '0x2::M::foo'. Invalid argument for parameter 'u'
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call_wrong_argument_in_list.move:23:9
+   │
+16 │     public fun foo(a: address, u: u64, s: S) {
+   │                                           - Expected: '0x2::M::S'
+   ·
+23 │         foo(@0x0, false, false);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^
+   │         │                │
+   │         │                Given: 'bool'
+   │         Invalid call of '0x2::M::foo'. Invalid argument for parameter 's'
 
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:22:9 ───
-    │
- 22 │         foo(@0x0, 0, false);
-    │         ^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::M::foo'. Invalid argument for parameter 's'
-    ·
- 22 │         foo(@0x0, 0, false);
-    │                      ----- The type: 'bool'
-    ·
- 16 │     public fun foo(a: address, u: u64, s: S) {
-    │                                           - Is not compatible with: '0x2::M::S'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call_wrong_argument_in_list.move:24:9
+   │
+16 │     public fun foo(a: address, u: u64, s: S) {
+   │                       ------- Expected: 'address'
+   ·
+24 │         foo(false, 0, false);
+   │         ^^^^^^^^^^^^^^^^^^^^
+   │         │   │
+   │         │   Given: 'bool'
+   │         Invalid call of '0x2::M::foo'. Invalid argument for parameter 'a'
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call_wrong_argument_in_list.move:24:9
+   │
+16 │     public fun foo(a: address, u: u64, s: S) {
+   │                                           - Expected: '0x2::M::S'
+   ·
+24 │         foo(false, 0, false);
+   │         ^^^^^^^^^^^^^^^^^^^^
+   │         │             │
+   │         │             Given: 'bool'
+   │         Invalid call of '0x2::M::foo'. Invalid argument for parameter 's'
 
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:23:9 ───
-    │
- 23 │         foo(@0x0, false, false);
-    │         ^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::M::foo'. Invalid argument for parameter 'u'
-    ·
- 23 │         foo(@0x0, false, false);
-    │                   ----- The type: 'bool'
-    ·
- 16 │     public fun foo(a: address, u: u64, s: S) {
-    │                                   --- Is not compatible with: 'u64'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call_wrong_argument_in_list.move:25:9
+   │
+16 │     public fun foo(a: address, u: u64, s: S) {
+   │                       ------- Expected: 'address'
+   ·
+25 │         foo(false, false, S{});
+   │         ^^^^^^^^^^^^^^^^^^^^^^
+   │         │   │
+   │         │   Given: 'bool'
+   │         Invalid call of '0x2::M::foo'. Invalid argument for parameter 'a'
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call_wrong_argument_in_list.move:25:9
+   │
+16 │     public fun foo(a: address, u: u64, s: S) {
+   │                                   --- Expected: 'u64'
+   ·
+25 │         foo(false, false, S{});
+   │         ^^^^^^^^^^^^^^^^^^^^^^
+   │         │          │
+   │         │          Given: 'bool'
+   │         Invalid call of '0x2::M::foo'. Invalid argument for parameter 'u'
 
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:23:9 ───
-    │
- 23 │         foo(@0x0, false, false);
-    │         ^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::M::foo'. Invalid argument for parameter 's'
-    ·
- 23 │         foo(@0x0, false, false);
-    │                          ----- The type: 'bool'
-    ·
- 16 │     public fun foo(a: address, u: u64, s: S) {
-    │                                           - Is not compatible with: '0x2::M::S'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call_wrong_argument_in_list.move:29:9
+   │
+ 8 │     public fun foo(a: address, u: u64, s: S) {
+   │                       ------- Expected: 'address'
+   ·
+29 │         X::foo(false, 0, X::s());
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │      │
+   │         │      Given: 'bool'
+   │         Invalid call of '0x2::X::foo'. Invalid argument for parameter 'a'
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call_wrong_argument_in_list.move:30:9
+   │
+ 8 │     public fun foo(a: address, u: u64, s: S) {
+   │                                   --- Expected: 'u64'
+   ·
+30 │         X::foo(@0x0, false, X::s());
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │            │
+   │         │            Given: 'bool'
+   │         Invalid call of '0x2::X::foo'. Invalid argument for parameter 'u'
 
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:24:9 ───
-    │
- 24 │         foo(false, 0, false);
-    │         ^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::M::foo'. Invalid argument for parameter 'a'
-    ·
- 24 │         foo(false, 0, false);
-    │             ----- The type: 'bool'
-    ·
- 16 │     public fun foo(a: address, u: u64, s: S) {
-    │                       ------- Is not compatible with: 'address'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call_wrong_argument_in_list.move:31:9
+   │
+ 8 │     public fun foo(a: address, u: u64, s: S) {
+   │                                           - Expected: '0x2::X::S'
+   ·
+31 │         X::foo(@0x0, 0, S{});
+   │         ^^^^^^^^^^^^^^^^^^^^
+   │         │               │
+   │         │               Given: '0x2::M::S'
+   │         Invalid call of '0x2::X::foo'. Invalid argument for parameter 's'
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call_wrong_argument_in_list.move:32:9
+   │
+ 8 │     public fun foo(a: address, u: u64, s: S) {
+   │                                   --- Expected: 'u64'
+   ·
+32 │         X::foo(@0x0, false, S{});
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │            │
+   │         │            Given: 'bool'
+   │         Invalid call of '0x2::X::foo'. Invalid argument for parameter 'u'
 
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:24:9 ───
-    │
- 24 │         foo(false, 0, false);
-    │         ^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::M::foo'. Invalid argument for parameter 's'
-    ·
- 24 │         foo(false, 0, false);
-    │                       ----- The type: 'bool'
-    ·
- 16 │     public fun foo(a: address, u: u64, s: S) {
-    │                                           - Is not compatible with: '0x2::M::S'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call_wrong_argument_in_list.move:32:9
+   │
+ 8 │     public fun foo(a: address, u: u64, s: S) {
+   │                                           - Expected: '0x2::X::S'
+   ·
+32 │         X::foo(@0x0, false, S{});
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │                   │
+   │         │                   Given: '0x2::M::S'
+   │         Invalid call of '0x2::X::foo'. Invalid argument for parameter 's'
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call_wrong_argument_in_list.move:33:9
+   │
+ 8 │     public fun foo(a: address, u: u64, s: S) {
+   │                       ------- Expected: 'address'
+   ·
+33 │         X::foo(false, 0, S{});
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │         │      │
+   │         │      Given: 'bool'
+   │         Invalid call of '0x2::X::foo'. Invalid argument for parameter 'a'
 
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:25:9 ───
-    │
- 25 │         foo(false, false, S{});
-    │         ^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::M::foo'. Invalid argument for parameter 'a'
-    ·
- 25 │         foo(false, false, S{});
-    │             ----- The type: 'bool'
-    ·
- 16 │     public fun foo(a: address, u: u64, s: S) {
-    │                       ------- Is not compatible with: 'address'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call_wrong_argument_in_list.move:33:9
+   │
+ 8 │     public fun foo(a: address, u: u64, s: S) {
+   │                                           - Expected: '0x2::X::S'
+   ·
+33 │         X::foo(false, 0, S{});
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │         │                │
+   │         │                Given: '0x2::M::S'
+   │         Invalid call of '0x2::X::foo'. Invalid argument for parameter 's'
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call_wrong_argument_in_list.move:34:9
+   │
+ 8 │     public fun foo(a: address, u: u64, s: S) {
+   │                       ------- Expected: 'address'
+   ·
+34 │         X::foo(false, false, X::s());
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │      │
+   │         │      Given: 'bool'
+   │         Invalid call of '0x2::X::foo'. Invalid argument for parameter 'a'
 
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:25:9 ───
-    │
- 25 │         foo(false, false, S{});
-    │         ^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::M::foo'. Invalid argument for parameter 'u'
-    ·
- 25 │         foo(false, false, S{});
-    │                    ----- The type: 'bool'
-    ·
- 16 │     public fun foo(a: address, u: u64, s: S) {
-    │                                   --- Is not compatible with: 'u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:29:9 ───
-    │
- 29 │         X::foo(false, 0, X::s());
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::X::foo'. Invalid argument for parameter 'a'
-    ·
- 29 │         X::foo(false, 0, X::s());
-    │                ----- The type: 'bool'
-    ·
-  8 │     public fun foo(a: address, u: u64, s: S) {
-    │                       ------- Is not compatible with: 'address'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:30:9 ───
-    │
- 30 │         X::foo(@0x0, false, X::s());
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::X::foo'. Invalid argument for parameter 'u'
-    ·
- 30 │         X::foo(@0x0, false, X::s());
-    │                      ----- The type: 'bool'
-    ·
-  8 │     public fun foo(a: address, u: u64, s: S) {
-    │                                   --- Is not compatible with: 'u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:31:9 ───
-    │
- 31 │         X::foo(@0x0, 0, S{});
-    │         ^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::X::foo'. Invalid argument for parameter 's'
-    ·
- 31 │         X::foo(@0x0, 0, S{});
-    │                         --- The type: '0x2::M::S'
-    ·
-  8 │     public fun foo(a: address, u: u64, s: S) {
-    │                                           - Is not compatible with: '0x2::X::S'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:32:9 ───
-    │
- 32 │         X::foo(@0x0, false, S{});
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::X::foo'. Invalid argument for parameter 'u'
-    ·
- 32 │         X::foo(@0x0, false, S{});
-    │                      ----- The type: 'bool'
-    ·
-  8 │     public fun foo(a: address, u: u64, s: S) {
-    │                                   --- Is not compatible with: 'u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:32:9 ───
-    │
- 32 │         X::foo(@0x0, false, S{});
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::X::foo'. Invalid argument for parameter 's'
-    ·
- 32 │         X::foo(@0x0, false, S{});
-    │                             --- The type: '0x2::M::S'
-    ·
-  8 │     public fun foo(a: address, u: u64, s: S) {
-    │                                           - Is not compatible with: '0x2::X::S'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:33:9 ───
-    │
- 33 │         X::foo(false, 0, S{});
-    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::X::foo'. Invalid argument for parameter 'a'
-    ·
- 33 │         X::foo(false, 0, S{});
-    │                ----- The type: 'bool'
-    ·
-  8 │     public fun foo(a: address, u: u64, s: S) {
-    │                       ------- Is not compatible with: 'address'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:33:9 ───
-    │
- 33 │         X::foo(false, 0, S{});
-    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::X::foo'. Invalid argument for parameter 's'
-    ·
- 33 │         X::foo(false, 0, S{});
-    │                          --- The type: '0x2::M::S'
-    ·
-  8 │     public fun foo(a: address, u: u64, s: S) {
-    │                                           - Is not compatible with: '0x2::X::S'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:34:9 ───
-    │
- 34 │         X::foo(false, false, X::s());
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::X::foo'. Invalid argument for parameter 'a'
-    ·
- 34 │         X::foo(false, false, X::s());
-    │                ----- The type: 'bool'
-    ·
-  8 │     public fun foo(a: address, u: u64, s: S) {
-    │                       ------- Is not compatible with: 'address'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:34:9 ───
-    │
- 34 │         X::foo(false, false, X::s());
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x2::X::foo'. Invalid argument for parameter 'u'
-    ·
- 34 │         X::foo(false, false, X::s());
-    │                       ----- The type: 'bool'
-    ·
-  8 │     public fun foo(a: address, u: u64, s: S) {
-    │                                   --- Is not compatible with: 'u64'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call_wrong_argument_in_list.move:34:9
+   │
+ 8 │     public fun foo(a: address, u: u64, s: S) {
+   │                                   --- Expected: 'u64'
+   ·
+34 │         X::foo(false, false, X::s());
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │             │
+   │         │             Given: 'bool'
+   │         Invalid call of '0x2::X::foo'. Invalid argument for parameter 'u'
 

--- a/language/move-lang/tests/move_check/typing/module_call_wrong_single_argument.exp
+++ b/language/move-lang/tests/move_check/typing/module_call_wrong_single_argument.exp
@@ -1,98 +1,84 @@
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call_wrong_single_argument.move:24:9
+   │
+17 │     public fun foo(s: S) {
+   │                       - Expected: '0x2::M::S'
+   ·
+24 │         foo(0);
+   │         ^^^^^^
+   │         │   │
+   │         │   Given: integer
+   │         Invalid call of '0x2::M::foo'. Invalid argument for parameter 's'
 
-    ┌── tests/move_check/typing/module_call_wrong_single_argument.move:24:9 ───
-    │
- 24 │         foo(0);
-    │         ^^^^^^ Invalid call of '0x2::M::foo'. Invalid argument for parameter 's'
-    ·
- 24 │         foo(0);
-    │             - The type: integer
-    ·
- 17 │     public fun foo(s: S) {
-    │                       - Is not compatible with: '0x2::M::S'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call_wrong_single_argument.move:25:9
+   │
+20 │     public fun bar(x: u64) {
+   │                       --- Expected: 'u64'
+   ·
+25 │         bar(S{});
+   │         ^^^^^^^^
+   │         │   │
+   │         │   Given: '0x2::M::S'
+   │         Invalid call of '0x2::M::bar'. Invalid argument for parameter 'x'
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call_wrong_single_argument.move:26:9
+   │
+20 │     public fun bar(x: u64) {
+   │                       --- Expected: 'u64'
+   ·
+26 │         bar(@0x0);
+   │         ^^^^^^^^^
+   │         │   │
+   │         │   Given: 'address'
+   │         Invalid call of '0x2::M::bar'. Invalid argument for parameter 'x'
 
-    ┌── tests/move_check/typing/module_call_wrong_single_argument.move:25:9 ───
-    │
- 25 │         bar(S{});
-    │         ^^^^^^^^ Invalid call of '0x2::M::bar'. Invalid argument for parameter 'x'
-    ·
- 25 │         bar(S{});
-    │             --- The type: '0x2::M::S'
-    ·
- 20 │     public fun bar(x: u64) {
-    │                       --- Is not compatible with: 'u64'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call_wrong_single_argument.move:30:9
+   │
+ 6 │     public fun foo(s: S) {
+   │                       - Expected: '0x2::X::S'
+   ·
+30 │         X::foo(S{});
+   │         ^^^^^^^^^^^
+   │         │      │
+   │         │      Given: '0x2::M::S'
+   │         Invalid call of '0x2::X::foo'. Invalid argument for parameter 's'
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call_wrong_single_argument.move:31:9
+   │
+ 6 │     public fun foo(s: S) {
+   │                       - Expected: '0x2::X::S'
+   ·
+31 │         X::foo(0);
+   │         ^^^^^^^^^
+   │         │      │
+   │         │      Given: integer
+   │         Invalid call of '0x2::X::foo'. Invalid argument for parameter 's'
 
-    ┌── tests/move_check/typing/module_call_wrong_single_argument.move:26:9 ───
-    │
- 26 │         bar(@0x0);
-    │         ^^^^^^^^^ Invalid call of '0x2::M::bar'. Invalid argument for parameter 'x'
-    ·
- 26 │         bar(@0x0);
-    │             ---- The type: 'address'
-    ·
- 20 │     public fun bar(x: u64) {
-    │                       --- Is not compatible with: 'u64'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call_wrong_single_argument.move:32:9
+   │
+ 9 │     public fun bar(x: u64) {
+   │                       --- Expected: 'u64'
+   ·
+32 │         X::bar(S{});
+   │         ^^^^^^^^^^^
+   │         │      │
+   │         │      Given: '0x2::M::S'
+   │         Invalid call of '0x2::X::bar'. Invalid argument for parameter 'x'
 
-error: 
-
-    ┌── tests/move_check/typing/module_call_wrong_single_argument.move:30:9 ───
-    │
- 30 │         X::foo(S{});
-    │         ^^^^^^^^^^^ Invalid call of '0x2::X::foo'. Invalid argument for parameter 's'
-    ·
- 30 │         X::foo(S{});
-    │                --- The type: '0x2::M::S'
-    ·
-  6 │     public fun foo(s: S) {
-    │                       - Is not compatible with: '0x2::X::S'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_wrong_single_argument.move:31:9 ───
-    │
- 31 │         X::foo(0);
-    │         ^^^^^^^^^ Invalid call of '0x2::X::foo'. Invalid argument for parameter 's'
-    ·
- 31 │         X::foo(0);
-    │                - The type: integer
-    ·
-  6 │     public fun foo(s: S) {
-    │                       - Is not compatible with: '0x2::X::S'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_wrong_single_argument.move:32:9 ───
-    │
- 32 │         X::bar(S{});
-    │         ^^^^^^^^^^^ Invalid call of '0x2::X::bar'. Invalid argument for parameter 'x'
-    ·
- 32 │         X::bar(S{});
-    │                --- The type: '0x2::M::S'
-    ·
-  9 │     public fun bar(x: u64) {
-    │                       --- Is not compatible with: 'u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_wrong_single_argument.move:33:9 ───
-    │
- 33 │         X::bar(false);
-    │         ^^^^^^^^^^^^^ Invalid call of '0x2::X::bar'. Invalid argument for parameter 'x'
-    ·
- 33 │         X::bar(false);
-    │                ----- The type: 'bool'
-    ·
-  9 │     public fun bar(x: u64) {
-    │                       --- Is not compatible with: 'u64'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/module_call_wrong_single_argument.move:33:9
+   │
+ 9 │     public fun bar(x: u64) {
+   │                       --- Expected: 'u64'
+   ·
+33 │         X::bar(false);
+   │         ^^^^^^^^^^^^^
+   │         │      │
+   │         │      Given: 'bool'
+   │         Invalid call of '0x2::X::bar'. Invalid argument for parameter 'x'
 

--- a/language/move-lang/tests/move_check/typing/mutate_immutable.exp
+++ b/language/move-lang/tests/move_check/typing/mutate_immutable.exp
@@ -1,42 +1,31 @@
-error: 
+error[E04006]: invalid subtype
+  ┌─ tests/move_check/typing/mutate_immutable.move:5:10
+  │
+5 │         *(s: &S) = S { f: 0 };
+  │          ^^^^^^^
+  │          │   │
+  │          │   Given: '&0x8675309::M::S'
+  │          Invalid mutation. Expected a mutable reference
+  │          Expected: '&mut _'
 
-   ┌── tests/move_check/typing/mutate_immutable.move:5:10 ───
+error[E04006]: invalid subtype
+  ┌─ tests/move_check/typing/mutate_immutable.move:6:10
+  │
+6 │         *&0 = 1;
+  │          ^^
+  │          │
+  │          Invalid mutation. Expected a mutable reference
+  │          Expected: '&mut _'
+  │          Given: '&{integer}'
+
+error[E04006]: invalid subtype
+   ┌─ tests/move_check/typing/mutate_immutable.move:10:10
    │
- 5 │         *(s: &S) = S { f: 0 };
-   │          ^^^^^^^ Invalid mutation. Expected a mutable reference
-   ·
- 5 │         *(s: &S) = S { f: 0 };
-   │              -- The type: '&0x8675309::M::S'
-   ·
- 5 │         *(s: &S) = S { f: 0 };
-   │          ------- Is not a subtype of: '&mut _'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/mutate_immutable.move:6:10 ───
-   │
- 6 │         *&0 = 1;
-   │          ^^ Invalid mutation. Expected a mutable reference
-   ·
- 6 │         *&0 = 1;
-   │          -- The type: '&{integer}'
-   ·
- 6 │         *&0 = 1;
-   │          -- Is not a subtype of: '&mut _'
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/mutate_immutable.move:10:10 ───
-    │
- 10 │         *x_ref = 0;
-    │          ^^^^^ Invalid mutation. Expected a mutable reference
-    ·
-  9 │         let x_ref: &u64 = x_ref;
-    │                    ---- The type: '&u64'
-    ·
- 10 │         *x_ref = 0;
-    │          ----- Is not a subtype of: '&mut _'
-    │
+ 9 │         let x_ref: &u64 = x_ref;
+   │                    ---- Given: '&u64'
+10 │         *x_ref = 0;
+   │          ^^^^^
+   │          │
+   │          Invalid mutation. Expected a mutable reference
+   │          Expected: '&mut _'
 

--- a/language/move-lang/tests/move_check/typing/mutate_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/mutate_invalid.exp
@@ -1,140 +1,107 @@
-error: 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/mutate_invalid.move:6:10
+  │
+6 │         *&mut 0 = false;
+  │          ^^^^^^   ----- Given: 'bool'
+  │          │         
+  │          Invalid mutation. New value is not valid for the reference
+  │          Expected: integer
 
-   ┌── tests/move_check/typing/mutate_invalid.move:6:10 ───
-   │
- 6 │         *&mut 0 = false;
-   │          ^^^^^^ Invalid mutation. New value is not valid for the reference
-   ·
- 6 │         *&mut 0 = false;
-   │          ------ The type: integer
-   ·
- 6 │         *&mut 0 = false;
-   │                   ----- Is not compatible with: 'bool'
-   │
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/mutate_invalid.move:7:10
+  │
+2 │     struct S has drop { f: u64 }
+  │                            --- Expected: 'u64'
+  ·
+7 │         *&mut S{f:0}.f = &1;
+  │          ^^^^^^^^^^^^^   -- Given: '&{integer}'
+  │          │                
+  │          Invalid mutation. New value is not valid for the reference
 
-error: 
-
-   ┌── tests/move_check/typing/mutate_invalid.move:7:10 ───
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/mutate_invalid.move:8:10
    │
- 7 │         *&mut S{f:0}.f = &1;
-   │          ^^^^^^^^^^^^^ Invalid mutation. New value is not valid for the reference
+ 8 │         *foo(&mut 0) = (1, 0);
+   │          ^^^^^^^^^^^   ------ Given: '({integer}, {integer})'
+   │          │              
+   │          Invalid mutation. New value is not valid for the reference
    ·
- 7 │         *&mut S{f:0}.f = &1;
-   │                          -- The type: '&{integer}'
-   ·
+23 │     fun foo(x: &mut u64): &mut u64 {
+   │                                --- Expected: 'u64'
+
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/mutate_invalid.move:9:9
+  │
+2 │     struct S has drop { f: u64 }
+  │                            --- Expected: 'u64'
+  ·
+9 │         bar(&mut S{f:0}).f = ();
+  │         ^^^^^^^^^^^^^^^^^^   -- Given: '()'
+  │         │                     
+  │         Invalid mutation. New value is not valid for the reference
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/mutate_invalid.move:10:10
+   │
  2 │     struct S has drop { f: u64 }
-   │                            --- Is not compatible with: 'u64'
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/mutate_invalid.move:8:10 ───
-    │
-  8 │         *foo(&mut 0) = (1, 0);
-    │          ^^^^^^^^^^^ Invalid mutation. New value is not valid for the reference
-    ·
-  8 │         *foo(&mut 0) = (1, 0);
-    │                        ------ The type: '({integer}, {integer})'
-    ·
- 23 │     fun foo(x: &mut u64): &mut u64 {
-    │                                --- Is not compatible with: 'u64'
-    │
-
-error: 
-
-   ┌── tests/move_check/typing/mutate_invalid.move:9:9 ───
-   │
- 9 │         bar(&mut S{f:0}).f = ();
-   │         ^^^^^^^^^^^^^^^^^^ Invalid mutation. New value is not valid for the reference
+   │                            --- Expected: 'u64'
    ·
- 9 │         bar(&mut S{f:0}).f = ();
-   │                              -- The type: '()'
-   ·
+10 │         *&mut bar(&mut S{f:0}).f = &0;
+   │          ^^^^^^^^^^^^^^^^^^^^^^^   -- Given: '&{integer}'
+   │          │                          
+   │          Invalid mutation. New value is not valid for the reference
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/mutate_invalid.move:11:9
+   │
  2 │     struct S has drop { f: u64 }
-   │                            --- Is not compatible with: 'u64'
+   │                            --- Expected: 'u64'
+   ·
+11 │         baz().f = false;
+   │         ^^^^^^^   ----- Given: 'bool'
+   │         │          
+   │         Invalid mutation. New value is not valid for the reference
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/mutate_invalid.move:12:10
    │
+ 2 │     struct S has drop { f: u64 }
+   │                            --- Expected: 'u64'
+   ·
+12 │         *&mut baz().f = false;
+   │          ^^^^^^^^^^^^   ----- Given: 'bool'
+   │          │               
+   │          Invalid mutation. New value is not valid for the reference
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/mutate_invalid.move:17:10
+   │
+16 │         let r = &mut S{ f: 0 };
+   │                      --------- Expected: '0x8675309::M::S'
+17 │         *r = X { f: 1 };
+   │          ^   ---------- Given: '0x8675309::M::X'
+   │          │    
+   │          Invalid mutation. New value is not valid for the reference
 
-    ┌── tests/move_check/typing/mutate_invalid.move:10:10 ───
-    │
- 10 │         *&mut bar(&mut S{f:0}).f = &0;
-    │          ^^^^^^^^^^^^^^^^^^^^^^^ Invalid mutation. New value is not valid for the reference
-    ·
- 10 │         *&mut bar(&mut S{f:0}).f = &0;
-    │                                    -- The type: '&{integer}'
-    ·
-  2 │     struct S has drop { f: u64 }
-    │                            --- Is not compatible with: 'u64'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/mutate_invalid.move:19:9
+   │
+ 2 │     struct S has drop { f: u64 }
+   │                            --- Expected: 'u64'
+   ·
+19 │         r.f = &0;
+   │         ^^^   -- Given: '&{integer}'
+   │         │      
+   │         Invalid mutation. New value is not valid for the reference
 
-error: 
-
-    ┌── tests/move_check/typing/mutate_invalid.move:11:9 ───
-    │
- 11 │         baz().f = false;
-    │         ^^^^^^^ Invalid mutation. New value is not valid for the reference
-    ·
- 11 │         baz().f = false;
-    │                   ----- The type: 'bool'
-    ·
-  2 │     struct S has drop { f: u64 }
-    │                            --- Is not compatible with: 'u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/mutate_invalid.move:12:10 ───
-    │
- 12 │         *&mut baz().f = false;
-    │          ^^^^^^^^^^^^ Invalid mutation. New value is not valid for the reference
-    ·
- 12 │         *&mut baz().f = false;
-    │                         ----- The type: 'bool'
-    ·
-  2 │     struct S has drop { f: u64 }
-    │                            --- Is not compatible with: 'u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/mutate_invalid.move:17:10 ───
-    │
- 17 │         *r = X { f: 1 };
-    │          ^ Invalid mutation. New value is not valid for the reference
-    ·
- 17 │         *r = X { f: 1 };
-    │              ---------- The type: '0x8675309::M::X'
-    ·
- 16 │         let r = &mut S{ f: 0 };
-    │                      --------- Is not compatible with: '0x8675309::M::S'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/mutate_invalid.move:19:9 ───
-    │
- 19 │         r.f = &0;
-    │         ^^^ Invalid mutation. New value is not valid for the reference
-    ·
- 19 │         r.f = &0;
-    │               -- The type: '&{integer}'
-    ·
-  2 │     struct S has drop { f: u64 }
-    │                            --- Is not compatible with: 'u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/mutate_invalid.move:20:10 ───
-    │
- 20 │         *&mut r.f = ();
-    │          ^^^^^^^^ Invalid mutation. New value is not valid for the reference
-    ·
- 20 │         *&mut r.f = ();
-    │                     -- The type: '()'
-    ·
-  2 │     struct S has drop { f: u64 }
-    │                            --- Is not compatible with: 'u64'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/mutate_invalid.move:20:10
+   │
+ 2 │     struct S has drop { f: u64 }
+   │                            --- Expected: 'u64'
+   ·
+20 │         *&mut r.f = ();
+   │          ^^^^^^^^   -- Given: '()'
+   │          │           
+   │          Invalid mutation. New value is not valid for the reference
 

--- a/language/move-lang/tests/move_check/typing/mutate_non_ref.exp
+++ b/language/move-lang/tests/move_check/typing/mutate_non_ref.exp
@@ -1,3 +1,61 @@
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/mutate_non_ref.move:7:10
+  │
+6 │         let u = 0;
+  │             - Given: integer
+7 │         *u = 1;
+  │          ^
+  │          │
+  │          Invalid mutation. Expected a mutable reference
+  │          Expected: '&mut _'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/mutate_non_ref.move:10:10
+   │
+ 9 │         let s = S { f: 0 };
+   │                 ---------- Given: '0x8675309::M::S'
+10 │         *s = S { f: 0 };
+   │          ^
+   │          │
+   │          Invalid mutation. Expected a mutable reference
+   │          Expected: '&mut _'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/mutate_non_ref.move:11:10
+   │
+ 2 │     struct S has copy, drop { f: u64 }
+   │                                  --- Given: 'u64'
+   ·
+11 │         *s.f = 0;
+   │          ^^^
+   │          │
+   │          Invalid mutation. Expected a mutable reference
+   │          Expected: '&mut _'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/mutate_non_ref.move:14:10
+   │
+ 2 │     struct S has copy, drop { f: u64 }
+   │                                  --- Given: 'u64'
+   ·
+14 │         *s_ref.f = 0;
+   │          ^^^^^^^
+   │          │
+   │          Invalid mutation. Expected a mutable reference
+   │          Expected: '&mut _'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/mutate_non_ref.move:17:10
+   │
+ 3 │     struct X has copy, drop { s: S }
+   │                                  - Given: '0x8675309::M::S'
+   ·
+17 │         *x.s = S { f: 0 };
+   │          ^^^
+   │          │
+   │          Invalid mutation. Expected a mutable reference
+   │          Expected: '&mut _'
+
 error[E05002]: type not implicitly copyable
    ┌─ tests/move_check/typing/mutate_non_ref.move:17:10
    │
@@ -6,6 +64,30 @@ error[E05002]: type not implicitly copyable
    ·
 17 │         *x.s = S { f: 0 };
    │          ^^^ Invalid implicit copy of field 's'. Try adding '*&' to the front of the field access
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/mutate_non_ref.move:18:10
+   │
+ 2 │     struct S has copy, drop { f: u64 }
+   │                                  --- Given: 'u64'
+   ·
+18 │         *x.s.f = 0;
+   │          ^^^^^
+   │          │
+   │          Invalid mutation. Expected a mutable reference
+   │          Expected: '&mut _'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/mutate_non_ref.move:21:10
+   │
+ 3 │     struct X has copy, drop { s: S }
+   │                                  - Given: '0x8675309::M::S'
+   ·
+21 │         *x_ref.s = S{ f: 0 };
+   │          ^^^^^^^
+   │          │
+   │          Invalid mutation. Expected a mutable reference
+   │          Expected: '&mut _'
 
 error[E05002]: type not implicitly copyable
    ┌─ tests/move_check/typing/mutate_non_ref.move:21:10
@@ -16,115 +98,15 @@ error[E05002]: type not implicitly copyable
 21 │         *x_ref.s = S{ f: 0 };
    │          ^^^^^^^ Invalid implicit copy of field 's'. Try adding '*&' to the front of the field access
 
-error: 
-
-   ┌── tests/move_check/typing/mutate_non_ref.move:7:10 ───
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/mutate_non_ref.move:22:10
    │
- 7 │         *u = 1;
-   │          ^ Invalid mutation. Expected a mutable reference
+ 2 │     struct S has copy, drop { f: u64 }
+   │                                  --- Given: 'u64'
    ·
- 6 │         let u = 0;
-   │             - The type: integer
-   ·
- 7 │         *u = 1;
-   │          - Is not compatible with: '&mut _'
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/mutate_non_ref.move:10:10 ───
-    │
- 10 │         *s = S { f: 0 };
-    │          ^ Invalid mutation. Expected a mutable reference
-    ·
-  9 │         let s = S { f: 0 };
-    │                 ---------- The type: '0x8675309::M::S'
-    ·
- 10 │         *s = S { f: 0 };
-    │          - Is not compatible with: '&mut _'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/mutate_non_ref.move:11:10 ───
-    │
- 11 │         *s.f = 0;
-    │          ^^^ Invalid mutation. Expected a mutable reference
-    ·
-  2 │     struct S has copy, drop { f: u64 }
-    │                                  --- The type: 'u64'
-    ·
- 11 │         *s.f = 0;
-    │          --- Is not compatible with: '&mut _'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/mutate_non_ref.move:14:10 ───
-    │
- 14 │         *s_ref.f = 0;
-    │          ^^^^^^^ Invalid mutation. Expected a mutable reference
-    ·
-  2 │     struct S has copy, drop { f: u64 }
-    │                                  --- The type: 'u64'
-    ·
- 14 │         *s_ref.f = 0;
-    │          ------- Is not compatible with: '&mut _'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/mutate_non_ref.move:17:10 ───
-    │
- 17 │         *x.s = S { f: 0 };
-    │          ^^^ Invalid mutation. Expected a mutable reference
-    ·
-  3 │     struct X has copy, drop { s: S }
-    │                                  - The type: '0x8675309::M::S'
-    ·
- 17 │         *x.s = S { f: 0 };
-    │          --- Is not compatible with: '&mut _'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/mutate_non_ref.move:18:10 ───
-    │
- 18 │         *x.s.f = 0;
-    │          ^^^^^ Invalid mutation. Expected a mutable reference
-    ·
-  2 │     struct S has copy, drop { f: u64 }
-    │                                  --- The type: 'u64'
-    ·
- 18 │         *x.s.f = 0;
-    │          ----- Is not compatible with: '&mut _'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/mutate_non_ref.move:21:10 ───
-    │
- 21 │         *x_ref.s = S{ f: 0 };
-    │          ^^^^^^^ Invalid mutation. Expected a mutable reference
-    ·
-  3 │     struct X has copy, drop { s: S }
-    │                                  - The type: '0x8675309::M::S'
-    ·
- 21 │         *x_ref.s = S{ f: 0 };
-    │          ------- Is not compatible with: '&mut _'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/mutate_non_ref.move:22:10 ───
-    │
- 22 │         *x_ref.s.f = 0;
-    │          ^^^^^^^^^ Invalid mutation. Expected a mutable reference
-    ·
-  2 │     struct S has copy, drop { f: u64 }
-    │                                  --- The type: 'u64'
-    ·
- 22 │         *x_ref.s.f = 0;
-    │          --------- Is not compatible with: '&mut _'
-    │
+22 │         *x_ref.s.f = 0;
+   │          ^^^^^^^^^
+   │          │
+   │          Invalid mutation. Expected a mutable reference
+   │          Expected: '&mut _'
 

--- a/language/move-lang/tests/move_check/typing/neq_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/neq_invalid.exp
@@ -1,3 +1,85 @@
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/neq_invalid.move:13:17
+   │
+13 │         (0: u8) != (1: u128);
+   │             --  ^^     ---- Found: 'u128'. It is not compatible with the other type.
+   │             │   │       
+   │             │   Incompatible arguments to '!='
+   │             Found: 'u8'. It is not compatible with the other type.
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/neq_invalid.move:14:11
+   │
+14 │         0 != false;
+   │         - ^^ ----- Found: 'bool'. It is not compatible with the other type.
+   │         │ │   
+   │         │ Incompatible arguments to '!='
+   │         Found: integer. It is not compatible with the other type.
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/neq_invalid.move:15:12
+   │
+15 │         &0 != 1;
+   │         -- ^^ - Found: integer. It is not compatible with the other type.
+   │         │  │   
+   │         │  Incompatible arguments to '!='
+   │         Found: '&{integer}'. It is not compatible with the other type.
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/neq_invalid.move:16:11
+   │
+16 │         1 != &0;
+   │         - ^^ -- Found: '&{integer}'. It is not compatible with the other type.
+   │         │ │   
+   │         │ Incompatible arguments to '!='
+   │         Found: integer. It is not compatible with the other type.
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/neq_invalid.move:17:9
+   │
+ 2 │     struct S { u: u64 }
+   │            - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+12 │     fun t0(r: &R, r_mut: &mut R, s: S, s_ref: &S, s_mut: &mut S) {
+   │                                     - The type '0x8675309::M::S' does not have the ability 'drop'
+   ·
+17 │         s != s_ref;
+   │         ^ '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/neq_invalid.move:17:11
+   │
+12 │     fun t0(r: &R, r_mut: &mut R, s: S, s_ref: &S, s_mut: &mut S) {
+   │                                     -         -- Found: '&0x8675309::M::S'. It is not compatible with the other type.
+   │                                     │          
+   │                                     Found: '0x8675309::M::S'. It is not compatible with the other type.
+   ·
+17 │         s != s_ref;
+   │           ^^ Incompatible arguments to '!='
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/neq_invalid.move:18:15
+   │
+12 │     fun t0(r: &R, r_mut: &mut R, s: S, s_ref: &S, s_mut: &mut S) {
+   │                                     -                    ------ Found: '&mut 0x8675309::M::S'. It is not compatible with the other type.
+   │                                     │                     
+   │                                     Found: '0x8675309::M::S'. It is not compatible with the other type.
+   ·
+18 │         s_mut != s;
+   │               ^^ Incompatible arguments to '!='
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/neq_invalid.move:18:18
+   │
+ 2 │     struct S { u: u64 }
+   │            - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+12 │     fun t0(r: &R, r_mut: &mut R, s: S, s_ref: &S, s_mut: &mut S) {
+   │                                     - The type '0x8675309::M::S' does not have the ability 'drop'
+   ·
+18 │         s_mut != s;
+   │                  ^ '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/neq_invalid.move:22:9
    │
@@ -7,7 +89,18 @@ error[E05001]: ability constraint not satisfied
 21 │     fun t1(r: R) {
    │               - The type '0x8675309::M::R' does not have the ability 'drop'
 22 │         r != r;
-   │         ^^^^^^ '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │         ^ '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/neq_invalid.move:22:14
+   │
+ 3 │     struct R {
+   │            - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+21 │     fun t1(r: R) {
+   │               - The type '0x8675309::M::R' does not have the ability 'drop'
+22 │         r != r;
+   │              ^ '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/neq_invalid.move:27:9
@@ -16,10 +109,22 @@ error[E05001]: ability constraint not satisfied
    │            -- To satisfy the constraint, the 'drop' ability would need to be added here
    ·
 27 │         G1{} != G1{};
-   │         ^^^^^^^^^^^^
-   │         │       │
-   │         │       The type '0x8675309::M::G1<_>' does not have the ability 'drop'
+   │         ^^^^
+   │         │
    │         '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │         The type '0x8675309::M::G1<_>' does not have the ability 'drop'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/neq_invalid.move:27:17
+   │
+ 7 │     struct G1<T: key> {}
+   │            -- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+27 │         G1{} != G1{};
+   │                 ^^^^
+   │                 │
+   │                 '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │                 The type '0x8675309::M::G1<_>' does not have the ability 'drop'
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/neq_invalid.move:28:9
@@ -28,10 +133,22 @@ error[E05001]: ability constraint not satisfied
    │            -- To satisfy the constraint, the 'drop' ability would need to be added here
    ·
 28 │         G2{} != G2{};
-   │         ^^^^^^^^^^^^
-   │         │       │
-   │         │       The type '0x8675309::M::G2<_>' does not have the ability 'drop'
+   │         ^^^^
+   │         │
    │         '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │         The type '0x8675309::M::G2<_>' does not have the ability 'drop'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/neq_invalid.move:28:17
+   │
+ 8 │     struct G2<T> {}
+   │            -- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+28 │         G2{} != G2{};
+   │                 ^^^^
+   │                 │
+   │                 '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │                 The type '0x8675309::M::G2<_>' does not have the ability 'drop'
 
 error[E04005]: expected a single type
    ┌─ tests/move_check/typing/neq_invalid.move:32:9
@@ -40,7 +157,7 @@ error[E04005]: expected a single type
    │         ^^^^^^^^
    │         │     │
    │         │     Expected a single type, but found expression list type: '()'
-   │         Invalid arguments to '!='
+   │         Incompatible arguments to '!='
 
 error[E04005]: expected a single type
    ┌─ tests/move_check/typing/neq_invalid.move:33:9
@@ -49,91 +166,25 @@ error[E04005]: expected a single type
    │         ^^^^^^^^^^^^^^^^
    │         │         │
    │         │         Expected a single type, but found expression list type: '(u64, u64)'
-   │         Invalid arguments to '!='
+   │         Incompatible arguments to '!='
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/neq_invalid.move:34:19
+   │
+34 │         (1, 2, 3) != (0, 1);
+   │         --------- ^^ ------ Found expression list of length 2: '({integer}, {integer})'. It is not compatible with the other type of length 3.
+   │         │         │   
+   │         │         Incompatible arguments to '!='
+   │         Found expression list of length 3: '({integer}, {integer}, {integer})'. It is not compatible with the other type of length 2.
 
-    ┌── tests/move_check/typing/neq_invalid.move:13:20 ───
-    │
- 13 │         (0: u8) != (1: u128);
-    │                    ^^^^^^^^^ Incompatible arguments to '!='
-    ·
- 13 │         (0: u8) != (1: u128);
-    │             -- The type: 'u8'
-    ·
- 13 │         (0: u8) != (1: u128);
-    │                        ---- Is not compatible with: 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/neq_invalid.move:14:14 ───
-    │
- 14 │         0 != false;
-    │              ^^^^^ Incompatible arguments to '!='
-    ·
- 14 │         0 != false;
-    │         - The type: integer
-    ·
- 14 │         0 != false;
-    │              ----- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/neq_invalid.move:15:15 ───
-    │
- 15 │         &0 != 1;
-    │               ^ Incompatible arguments to '!='
-    ·
- 15 │         &0 != 1;
-    │               - The type: integer
-    ·
- 15 │         &0 != 1;
-    │         -- Is not compatible with: '&{integer}'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/neq_invalid.move:16:14 ───
-    │
- 16 │         1 != &0;
-    │              ^^ Incompatible arguments to '!='
-    ·
- 16 │         1 != &0;
-    │         - The type: integer
-    ·
- 16 │         1 != &0;
-    │              -- Is not compatible with: '&{integer}'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/neq_invalid.move:17:14 ───
-    │
- 17 │         s != s_ref;
-    │              ^^^^^ Incompatible arguments to '!='
-    ·
- 12 │     fun t0(r: &R, r_mut: &mut R, s: S, s_ref: &S, s_mut: &mut S) {
-    │                                     - The type: '0x8675309::M::S'
-    ·
- 12 │     fun t0(r: &R, r_mut: &mut R, s: S, s_ref: &S, s_mut: &mut S) {
-    │                                               -- Is not compatible with: '&0x8675309::M::S'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/neq_invalid.move:18:18 ───
-    │
- 18 │         s_mut != s;
-    │                  ^ Incompatible arguments to '!='
-    ·
- 12 │     fun t0(r: &R, r_mut: &mut R, s: S, s_ref: &S, s_mut: &mut S) {
-    │                                                          ------ The type: '&mut 0x8675309::M::S'
-    ·
- 12 │     fun t0(r: &R, r_mut: &mut R, s: S, s_ref: &S, s_mut: &mut S) {
-    │                                     - Is not compatible with: '0x8675309::M::S'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/neq_invalid.move:35:16
+   │
+35 │         (0, 1) != (1, 2, 3);
+   │         ------ ^^ --------- Found expression list of length 3: '({integer}, {integer}, {integer})'. It is not compatible with the other type of length 2.
+   │         │      │   
+   │         │      Incompatible arguments to '!='
+   │         Found expression list of length 2: '({integer}, {integer})'. It is not compatible with the other type of length 3.
 
 error: 
 
@@ -181,33 +232,5 @@ error:
     │
  28 │         G2{} != G2{};
     │                 ^^^^ Could not infer this type. Try adding an annotation
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/neq_invalid.move:34:22 ───
-    │
- 34 │         (1, 2, 3) != (0, 1);
-    │                      ^^^^^^ Incompatible arguments to '!='
-    ·
- 34 │         (1, 2, 3) != (0, 1);
-    │         --------- The expression list type of length 3: '({integer}, {integer}, {integer})'
-    ·
- 34 │         (1, 2, 3) != (0, 1);
-    │                      ------ Is not compatible with the expression list type of length 2: '({integer}, {integer})'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/neq_invalid.move:35:19 ───
-    │
- 35 │         (0, 1) != (1, 2, 3);
-    │                   ^^^^^^^^^ Incompatible arguments to '!='
-    ·
- 35 │         (0, 1) != (1, 2, 3);
-    │         ------ The expression list type of length 2: '({integer}, {integer})'
-    ·
- 35 │         (0, 1) != (1, 2, 3);
-    │                   --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
     │
 

--- a/language/move-lang/tests/move_check/typing/other_builtins_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/other_builtins_invalid.exp
@@ -1,44 +1,83 @@
-error: 
+error[E04006]: invalid subtype
+  ┌─ tests/move_check/typing/other_builtins_invalid.move:4:10
+  │
+3 │     fun foo(x: &u64) {
+  │                ---- Given: '&u64'
+4 │         (freeze<u64>(x): &mut u64);
+  │          ^^^^^^^^^^^^^^
+  │          │
+  │          Invalid call of 'freeze'. Invalid argument for parameter '0'
+  │          Expected: '&mut u64'
 
-   ┌── tests/move_check/typing/other_builtins_invalid.move:4:10 ───
-   │
- 4 │         (freeze<u64>(x): &mut u64);
-   │          ^^^^^^^^^^^^^^ Invalid call of 'freeze'. Invalid argument for parameter '0'
-   ·
- 3 │     fun foo(x: &u64) {
-   │                ---- The type: '&u64'
-   ·
- 4 │         (freeze<u64>(x): &mut u64);
-   │          ------ Is not a subtype of: '&mut u64'
-   │
+error[E04006]: invalid subtype
+  ┌─ tests/move_check/typing/other_builtins_invalid.move:4:26
+  │
+4 │         (freeze<u64>(x): &mut u64);
+  │          --------------  ^^^^^^^^
+  │          │               │
+  │          │               Invalid type annotation
+  │          │               Expected: '&mut u64'
+  │          Given: '&u64'
 
-error: 
+error[E04006]: invalid subtype
+  ┌─ tests/move_check/typing/other_builtins_invalid.move:5:10
+  │
+5 │         (freeze<vector<bool>>(&any()): &mut vector<bool>);
+  │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │          │                    │
+  │          │                    Given: '&_'
+  │          Invalid call of 'freeze'. Invalid argument for parameter '0'
+  │          Expected: '&mut vector<bool>'
 
-   ┌── tests/move_check/typing/other_builtins_invalid.move:4:26 ───
-   │
- 4 │         (freeze<u64>(x): &mut u64);
-   │                          ^^^^^^^^ Invalid type annotation
-   ·
- 4 │         (freeze<u64>(x): &mut u64);
-   │          -------------- The type: '&u64'
-   ·
- 4 │         (freeze<u64>(x): &mut u64);
-   │                          -------- Is not a subtype of: '&mut u64'
-   │
+error[E04006]: invalid subtype
+  ┌─ tests/move_check/typing/other_builtins_invalid.move:5:40
+  │
+5 │         (freeze<vector<bool>>(&any()): &mut vector<bool>);
+  │          ----------------------------  ^^^^^^^^^^^^^^^^^
+  │          │                             │
+  │          │                             Invalid type annotation
+  │          │                             Expected: '&mut vector<bool>'
+  │          Given: '&vector<bool>'
 
-error: 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/other_builtins_invalid.move:7:10
+  │
+7 │         (assert<>(42, true): ());
+  │          ^^^^^^^^^^^^^^^^^^
+  │          │        │
+  │          │        Given: integer
+  │          Invalid call of 'assert'. Invalid argument for parameter '0'
+  │          Expected: 'bool'
 
-   ┌── tests/move_check/typing/other_builtins_invalid.move:5:10 ───
-   │
- 5 │         (freeze<vector<bool>>(&any()): &mut vector<bool>);
-   │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'freeze'. Invalid argument for parameter '0'
-   ·
- 5 │         (freeze<vector<bool>>(&any()): &mut vector<bool>);
-   │                               ------ The type: '&_'
-   ·
- 5 │         (freeze<vector<bool>>(&any()): &mut vector<bool>);
-   │          ------ Is not a subtype of: '&mut vector<bool>'
-   │
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/other_builtins_invalid.move:7:10
+  │
+7 │         (assert<>(42, true): ());
+  │          ^^^^^^^^^^^^^^^^^^
+  │          │            │
+  │          │            Given: 'bool'
+  │          Invalid call of 'assert'. Invalid argument for parameter '1'
+  │          Expected: 'u64'
+
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/other_builtins_invalid.move:8:37
+  │
+8 │         (assert(true && false, *x): bool);
+  │          -------------------------  ^^^^
+  │          │                          │
+  │          │                          Invalid type annotation
+  │          │                          Expected: 'bool'
+  │          Given: '()'
+
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/other_builtins_invalid.move:9:9
+  │
+9 │         assert(true || false, 0u8);
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │         │                     │
+  │         │                     Given: 'u8'
+  │         Invalid call of 'assert'. Invalid argument for parameter '1'
+  │         Expected: 'u64'
 
 error: 
 
@@ -46,75 +85,5 @@ error:
    │
  5 │         (freeze<vector<bool>>(&any()): &mut vector<bool>);
    │                                ^^^^^ Could not infer this type. Try adding an annotation
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/other_builtins_invalid.move:5:40 ───
-   │
- 5 │         (freeze<vector<bool>>(&any()): &mut vector<bool>);
-   │                                        ^^^^^^^^^^^^^^^^^ Invalid type annotation
-   ·
- 5 │         (freeze<vector<bool>>(&any()): &mut vector<bool>);
-   │          ---------------------------- The type: '&vector<bool>'
-   ·
- 5 │         (freeze<vector<bool>>(&any()): &mut vector<bool>);
-   │                                        ----------------- Is not a subtype of: '&mut vector<bool>'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/other_builtins_invalid.move:7:10 ───
-   │
- 7 │         (assert<>(42, true): ());
-   │          ^^^^^^^^^^^^^^^^^^ Invalid call of 'assert'. Invalid argument for parameter '0'
-   ·
- 7 │         (assert<>(42, true): ());
-   │                   -- The type: integer
-   ·
- 7 │         (assert<>(42, true): ());
-   │          ------ Is not compatible with: 'bool'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/other_builtins_invalid.move:7:10 ───
-   │
- 7 │         (assert<>(42, true): ());
-   │          ^^^^^^^^^^^^^^^^^^ Invalid call of 'assert'. Invalid argument for parameter '1'
-   ·
- 7 │         (assert<>(42, true): ());
-   │                       ---- The type: 'bool'
-   ·
- 7 │         (assert<>(42, true): ());
-   │          ------ Is not compatible with: 'u64'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/other_builtins_invalid.move:8:37 ───
-   │
- 8 │         (assert(true && false, *x): bool);
-   │                                     ^^^^ Invalid type annotation
-   ·
- 8 │         (assert(true && false, *x): bool);
-   │          ------------------------- The type: '()'
-   ·
- 8 │         (assert(true && false, *x): bool);
-   │                                     ---- Is not compatible with: 'bool'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/other_builtins_invalid.move:9:9 ───
-   │
- 9 │         assert(true || false, 0u8);
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'assert'. Invalid argument for parameter '1'
-   ·
- 9 │         assert(true || false, 0u8);
-   │                               --- The type: 'u8'
-   ·
- 9 │         assert(true || false, 0u8);
-   │         ------ Is not compatible with: 'u64'
    │
 

--- a/language/move-lang/tests/move_check/typing/pack_invalid_argument.exp
+++ b/language/move-lang/tests/move_check/typing/pack_invalid_argument.exp
@@ -1,70 +1,60 @@
-error: 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/pack_invalid_argument.move:7:17
+  │
+2 │     struct S has drop { f: u64 }
+  │                            --- Expected: 'u64'
+  ·
+7 │         (S { f: false } : S);
+  │                 ^^^^^
+  │                 │
+  │                 Invalid argument for field 'f' for '0x8675309::M::S'
+  │                 Given: 'bool'
 
-   ┌── tests/move_check/typing/pack_invalid_argument.move:7:17 ───
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/pack_invalid_argument.move:17:16
    │
- 7 │         (S { f: false } : S);
-   │                 ^^^^^ Invalid argument for field 'f' for '0x8675309::M::S'
+ 4 │     struct R { s: S, f: u64, n1: Nat<u64>, n2: Nat<S> }
+   │                   - Expected: '0x8675309::M::S'
    ·
- 7 │         (S { f: false } : S);
-   │                 ----- The type: 'bool'
-   ·
- 2 │     struct S has drop { f: u64 }
-   │                            --- Is not compatible with: 'u64'
+15 │          } : R);
+   │              - Given: '0x8675309::M::R'
+16 │         (R {
+17 │             s: r,
+   │                ^ Invalid argument for field 's' for '0x8675309::M::R'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/pack_invalid_argument.move:18:16
    │
+ 4 │     struct R { s: S, f: u64, n1: Nat<u64>, n2: Nat<S> }
+   │                         --- Expected: 'u64'
+   ·
+18 │             f: false,
+   │                ^^^^^
+   │                │
+   │                Invalid argument for field 'f' for '0x8675309::M::R'
+   │                Given: 'bool'
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/pack_invalid_argument.move:19:17
+   │
+ 4 │     struct R { s: S, f: u64, n1: Nat<u64>, n2: Nat<S> }
+   │                                      --- Expected: 'u64'
+   ·
+19 │             n1: Nat { f: false },
+   │                 ^^^^^^^^^^^^^^^^
+   │                 │        │
+   │                 │        Given: 'bool'
+   │                 Invalid argument for field 'n1' for '0x8675309::M::R'
 
-    ┌── tests/move_check/typing/pack_invalid_argument.move:17:16 ───
-    │
- 17 │             s: r,
-    │                ^ Invalid argument for field 's' for '0x8675309::M::R'
-    ·
- 15 │          } : R);
-    │              - The type: '0x8675309::M::R'
-    ·
-  4 │     struct R { s: S, f: u64, n1: Nat<u64>, n2: Nat<S> }
-    │                   - Is not compatible with: '0x8675309::M::S'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/pack_invalid_argument.move:18:16 ───
-    │
- 18 │             f: false,
-    │                ^^^^^ Invalid argument for field 'f' for '0x8675309::M::R'
-    ·
- 18 │             f: false,
-    │                ----- The type: 'bool'
-    ·
-  4 │     struct R { s: S, f: u64, n1: Nat<u64>, n2: Nat<S> }
-    │                         --- Is not compatible with: 'u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/pack_invalid_argument.move:19:17 ───
-    │
- 19 │             n1: Nat { f: false },
-    │                 ^^^^^^^^^^^^^^^^ Invalid argument for field 'n1' for '0x8675309::M::R'
-    ·
- 19 │             n1: Nat { f: false },
-    │                          ----- The type: 'bool'
-    ·
-  4 │     struct R { s: S, f: u64, n1: Nat<u64>, n2: Nat<S> }
-    │                                      --- Is not compatible with: 'u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/pack_invalid_argument.move:20:17 ───
-    │
- 20 │             n2: Nat{ f: r }
-    │                 ^^^^^^^^^^^ Invalid argument for field 'n2' for '0x8675309::M::R'
-    ·
- 15 │          } : R);
-    │              - The type: '0x8675309::M::R'
-    ·
-  4 │     struct R { s: S, f: u64, n1: Nat<u64>, n2: Nat<S> }
-    │                                                    - Is not compatible with: '0x8675309::M::S'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/pack_invalid_argument.move:20:17
+   │
+ 4 │     struct R { s: S, f: u64, n1: Nat<u64>, n2: Nat<S> }
+   │                                                    - Expected: '0x8675309::M::S'
+   ·
+15 │          } : R);
+   │              - Given: '0x8675309::M::R'
+   ·
+20 │             n2: Nat{ f: r }
+   │                 ^^^^^^^^^^^ Invalid argument for field 'n2' for '0x8675309::M::R'
 

--- a/language/move-lang/tests/move_check/typing/recursive_local.exp
+++ b/language/move-lang/tests/move_check/typing/recursive_local.exp
@@ -1,3 +1,11 @@
+error[E04008]: invalid type. recursive type found
+  ┌─ tests/move_check/typing/recursive_local.move:5:9
+  │
+4 │         let x;
+  │             - Unable to infer the type. Recursive type found.
+5 │         x = (x, 0);
+  │         ^ Invalid assignment to local 'x'
+
 error[E04005]: expected a single type
   ┌─ tests/move_check/typing/recursive_local.move:5:9
   │
@@ -12,17 +20,6 @@ error:
    │
  4 │         let x;
    │             ^ Could not infer this type. Try adding an annotation
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/recursive_local.move:5:9 ───
-   │
- 5 │         x = (x, 0);
-   │         ^ Invalid assignment to local 'x'
-   ·
- 4 │         let x;
-   │             - Unable to infer the type. Recursive type found.
    │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/return_type_explicit_exp_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/return_type_explicit_exp_invalid.exp
@@ -1,84 +1,66 @@
-error: 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/return_type_explicit_exp_invalid.move:5:9
+  │
+4 │     fun t0(): u64 {
+  │               --- Expected: 'u64'
+5 │         return ()
+  │         ^^^^^^^^^
+  │         │      │
+  │         │      Given: '()'
+  │         Invalid return
 
-   ┌── tests/move_check/typing/return_type_explicit_exp_invalid.move:5:9 ───
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/return_type_explicit_exp_invalid.move:9:19
+  │
+8 │     fun t1(): () {
+  │               -- Expected: '()'
+9 │         if (true) return 1 else return 0
+  │                   ^^^^^^^^
+  │                   │      │
+  │                   │      Given: integer
+  │                   Invalid return
+
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/return_type_explicit_exp_invalid.move:9:33
+  │
+8 │     fun t1(): () {
+  │               -- Expected: '()'
+9 │         if (true) return 1 else return 0
+  │                                 ^^^^^^^^
+  │                                 │      │
+  │                                 │      Given: integer
+  │                                 Invalid return
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/return_type_explicit_exp_invalid.move:13:14
    │
- 5 │         return ()
-   │         ^^^^^^^^^ Invalid return
-   ·
- 5 │         return ()
-   │                -- The type: '()'
-   ·
- 4 │     fun t0(): u64 {
-   │               --- Is not compatible with: 'u64'
+12 │     fun t2(): (u64, bool) {
+   │               ----------- Expected expression list of length 2: '(u64, bool)'
+13 │         loop return (0, false, R{});
+   │              ^^^^^^^^^^^^^^^^^^^^^^
+   │              │      │
+   │              │      Given expression list of length 3: '({integer}, bool, 0x8675309::M::R)'
+   │              Invalid return
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/return_type_explicit_exp_invalid.move:18:22
    │
+17 │     fun t3(): (u64, bool, R, bool) {
+   │               -------------------- Expected expression list of length 4: '(u64, bool, 0x8675309::M::R, bool)'
+18 │         while (true) return (0, false, R{});
+   │                      ^^^^^^^^^^^^^^^^^^^^^^
+   │                      │      │
+   │                      │      Given expression list of length 3: '({integer}, bool, 0x8675309::M::R)'
+   │                      Invalid return
 
-error: 
-
-   ┌── tests/move_check/typing/return_type_explicit_exp_invalid.move:9:19 ───
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/return_type_explicit_exp_invalid.move:23:23
    │
- 9 │         if (true) return 1 else return 0
-   │                   ^^^^^^^^ Invalid return
-   ·
- 9 │         if (true) return 1 else return 0
-   │                          - The type: integer
-   ·
- 8 │     fun t1(): () {
-   │               -- Is not compatible with: '()'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/return_type_explicit_exp_invalid.move:9:33 ───
-   │
- 9 │         if (true) return 1 else return 0
-   │                                 ^^^^^^^^ Invalid return
-   ·
- 9 │         if (true) return 1 else return 0
-   │                                        - The type: integer
-   ·
- 8 │     fun t1(): () {
-   │               -- Is not compatible with: '()'
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/return_type_explicit_exp_invalid.move:13:14 ───
-    │
- 13 │         loop return (0, false, R{});
-    │              ^^^^^^^^^^^^^^^^^^^^^^ Invalid return
-    ·
- 13 │         loop return (0, false, R{});
-    │                     --------------- The expression list type of length 3: '({integer}, bool, 0x8675309::M::R)'
-    ·
- 12 │     fun t2(): (u64, bool) {
-    │               ----------- Is not compatible with the expression list type of length 2: '(u64, bool)'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/return_type_explicit_exp_invalid.move:18:22 ───
-    │
- 18 │         while (true) return (0, false, R{});
-    │                      ^^^^^^^^^^^^^^^^^^^^^^ Invalid return
-    ·
- 18 │         while (true) return (0, false, R{});
-    │                             --------------- The expression list type of length 3: '({integer}, bool, 0x8675309::M::R)'
-    ·
- 17 │     fun t3(): (u64, bool, R, bool) {
-    │               -------------------- Is not compatible with the expression list type of length 4: '(u64, bool, 0x8675309::M::R, bool)'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/return_type_explicit_exp_invalid.move:23:23 ───
-    │
- 23 │         while (false) return (0, false, R{});
-    │                       ^^^^^^^^^^^^^^^^^^^^^^ Invalid return
-    ·
- 23 │         while (false) return (0, false, R{});
-    │                               - The type: integer
-    ·
- 22 │     fun t4(): (bool, u64, R) {
-    │                ---- Is not compatible with: 'bool'
-    │
+22 │     fun t4(): (bool, u64, R) {
+   │                ---- Expected: 'bool'
+23 │         while (false) return (0, false, R{});
+   │                       ^^^^^^^^^^^^^^^^^^^^^^
+   │                       │       │
+   │                       │       Given: integer
+   │                       Invalid return
 

--- a/language/move-lang/tests/move_check/typing/return_type_last_exp_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/return_type_last_exp_invalid.exp
@@ -1,70 +1,55 @@
-error: 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/return_type_last_exp_invalid.move:5:9
+  │
+4 │     fun t0(): u64 {
+  │               --- Expected: 'u64'
+5 │         ()
+  │         ^^
+  │         │
+  │         Invalid return expression
+  │         Given: '()'
 
-   ┌── tests/move_check/typing/return_type_last_exp_invalid.move:5:9 ───
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/return_type_last_exp_invalid.move:9:9
+  │
+8 │     fun t1(): () {
+  │               -- Expected: '()'
+9 │         0
+  │         ^
+  │         │
+  │         Invalid return expression
+  │         Given: integer
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/return_type_last_exp_invalid.move:13:9
    │
- 5 │         ()
-   │         ^^ Invalid return expression
-   ·
- 5 │         ()
-   │         -- The type: '()'
-   ·
- 4 │     fun t0(): u64 {
-   │               --- Is not compatible with: 'u64'
+12 │     fun t2(): (u64, bool) {
+   │               ----------- Expected expression list of length 2: '(u64, bool)'
+13 │         (0, false, R{})
+   │         ^^^^^^^^^^^^^^^
+   │         │
+   │         Invalid return expression
+   │         Given expression list of length 3: '({integer}, bool, 0x8675309::M::R)'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/return_type_last_exp_invalid.move:17:9
    │
+16 │     fun t3(): (u64, bool, R, bool) {
+   │               -------------------- Expected expression list of length 4: '(u64, bool, 0x8675309::M::R, bool)'
+17 │         (0, false, R{})
+   │         ^^^^^^^^^^^^^^^
+   │         │
+   │         Invalid return expression
+   │         Given expression list of length 3: '({integer}, bool, 0x8675309::M::R)'
 
-error: 
-
-   ┌── tests/move_check/typing/return_type_last_exp_invalid.move:9:9 ───
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/return_type_last_exp_invalid.move:21:9
    │
- 9 │         0
-   │         ^ Invalid return expression
-   ·
- 9 │         0
-   │         - The type: integer
-   ·
- 8 │     fun t1(): () {
-   │               -- Is not compatible with: '()'
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/return_type_last_exp_invalid.move:13:9 ───
-    │
- 13 │         (0, false, R{})
-    │         ^^^^^^^^^^^^^^^ Invalid return expression
-    ·
- 13 │         (0, false, R{})
-    │         --------------- The expression list type of length 3: '({integer}, bool, 0x8675309::M::R)'
-    ·
- 12 │     fun t2(): (u64, bool) {
-    │               ----------- Is not compatible with the expression list type of length 2: '(u64, bool)'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/return_type_last_exp_invalid.move:17:9 ───
-    │
- 17 │         (0, false, R{})
-    │         ^^^^^^^^^^^^^^^ Invalid return expression
-    ·
- 17 │         (0, false, R{})
-    │         --------------- The expression list type of length 3: '({integer}, bool, 0x8675309::M::R)'
-    ·
- 16 │     fun t3(): (u64, bool, R, bool) {
-    │               -------------------- Is not compatible with the expression list type of length 4: '(u64, bool, 0x8675309::M::R, bool)'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/return_type_last_exp_invalid.move:21:9 ───
-    │
- 21 │         (0, false, R{})
-    │         ^^^^^^^^^^^^^^^ Invalid return expression
-    ·
- 21 │         (0, false, R{})
-    │          - The type: integer
-    ·
- 20 │     fun t4(): (bool, u64, R) {
-    │                ---- Is not compatible with: 'bool'
-    │
+20 │     fun t4(): (bool, u64, R) {
+   │                ---- Expected: 'bool'
+21 │         (0, false, R{})
+   │         ^^^^^^^^^^^^^^^
+   │         ││
+   │         │Given: integer
+   │         Invalid return expression
 

--- a/language/move-lang/tests/move_check/typing/shadowing_invalid_types.exp
+++ b/language/move-lang/tests/move_check/typing/shadowing_invalid_types.exp
@@ -1,154 +1,124 @@
-error: 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/shadowing_invalid_types.move:8:13
+  │
+5 │         let x = 0;
+  │             - Given: integer
+  ·
+8 │         (x: bool);
+  │             ^^^^
+  │             │
+  │             Invalid type annotation
+  │             Expected: 'bool'
 
-   ┌── tests/move_check/typing/shadowing_invalid_types.move:8:13 ───
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/shadowing_invalid_types.move:10:30
    │
- 8 │         (x: bool);
-   │             ^^^^ Invalid type annotation
-   ·
+10 │         { let x = false; (x: u64); };
+   │                   -----      ^^^
+   │                   │          │
+   │                   │          Invalid type annotation
+   │                   │          Expected: 'u64'
+   │                   Given: 'bool'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/shadowing_invalid_types.move:11:13
+   │
  5 │         let x = 0;
-   │             - The type: integer
+   │             - Given: integer
    ·
- 8 │         (x: bool);
-   │             ---- Is not compatible with: 'bool'
+11 │         (x: bool);
+   │             ^^^^
+   │             │
+   │             Invalid type annotation
+   │             Expected: 'bool'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/shadowing_invalid_types.move:13:46
    │
+13 │         { let x = false; { let x = @0x0; (x: u64); }; (x: address); };
+   │                                    ----      ^^^
+   │                                    │         │
+   │                                    │         Invalid type annotation
+   │                                    │         Expected: 'u64'
+   │                                    Given: 'address'
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/shadowing_invalid_types.move:13:59
+   │
+13 │         { let x = false; { let x = @0x0; (x: u64); }; (x: address); };
+   │                   -----                                   ^^^^^^^
+   │                   │                                       │
+   │                   │                                       Invalid type annotation
+   │                   │                                       Expected: 'address'
+   │                   Given: 'bool'
 
-    ┌── tests/move_check/typing/shadowing_invalid_types.move:10:30 ───
-    │
- 10 │         { let x = false; (x: u64); };
-    │                              ^^^ Invalid type annotation
-    ·
- 10 │         { let x = false; (x: u64); };
-    │                   ----- The type: 'bool'
-    ·
- 10 │         { let x = false; (x: u64); };
-    │                              --- Is not compatible with: 'u64'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/shadowing_invalid_types.move:14:13
+   │
+ 5 │         let x = 0;
+   │             - Given: integer
+   ·
+14 │         (x: bool);
+   │             ^^^^
+   │             │
+   │             Invalid type annotation
+   │             Expected: 'bool'
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/shadowing_invalid_types.move:21:17
+   │
+20 │             let (a, x) = (false, false);
+   │                                  ----- Given: 'bool'
+21 │             (x: u64);
+   │                 ^^^
+   │                 │
+   │                 Invalid type annotation
+   │                 Expected: 'u64'
 
-    ┌── tests/move_check/typing/shadowing_invalid_types.move:11:13 ───
-    │
- 11 │         (x: bool);
-    │             ^^^^ Invalid type annotation
-    ·
-  5 │         let x = 0;
-    │             - The type: integer
-    ·
- 11 │         (x: bool);
-    │             ---- Is not compatible with: 'bool'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/shadowing_invalid_types.move:25:17
+   │
+24 │             let x = @0x0;
+   │                     ---- Given: 'address'
+25 │             (x: u64);
+   │                 ^^^
+   │                 │
+   │                 Invalid type annotation
+   │                 Expected: 'u64'
 
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/shadowing_invalid_types.move:27:13
+   │
+18 │         let x = 0;
+   │             - Given: integer
+   ·
+27 │         (x: address);
+   │             ^^^^^^^
+   │             │
+   │             Invalid type annotation
+   │             Expected: 'address'
 
-    ┌── tests/move_check/typing/shadowing_invalid_types.move:13:46 ───
-    │
- 13 │         { let x = false; { let x = @0x0; (x: u64); }; (x: address); };
-    │                                              ^^^ Invalid type annotation
-    ·
- 13 │         { let x = false; { let x = @0x0; (x: u64); }; (x: address); };
-    │                                    ---- The type: 'address'
-    ·
- 13 │         { let x = false; { let x = @0x0; (x: u64); }; (x: address); };
-    │                                              --- Is not compatible with: 'u64'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/shadowing_invalid_types.move:34:17
+   │
+ 2 │     struct S {f: u64, b: bool}
+   │                          ---- Given: 'bool'
+   ·
+34 │             (x: u64);
+   │                 ^^^
+   │                 │
+   │                 Invalid type annotation
+   │                 Expected: 'u64'
 
-error: 
-
-    ┌── tests/move_check/typing/shadowing_invalid_types.move:13:59 ───
-    │
- 13 │         { let x = false; { let x = @0x0; (x: u64); }; (x: address); };
-    │                                                           ^^^^^^^ Invalid type annotation
-    ·
- 13 │         { let x = false; { let x = @0x0; (x: u64); }; (x: address); };
-    │                   ----- The type: 'bool'
-    ·
- 13 │         { let x = false; { let x = @0x0; (x: u64); }; (x: address); };
-    │                                                           ------- Is not compatible with: 'address'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/shadowing_invalid_types.move:14:13 ───
-    │
- 14 │         (x: bool);
-    │             ^^^^ Invalid type annotation
-    ·
-  5 │         let x = 0;
-    │             - The type: integer
-    ·
- 14 │         (x: bool);
-    │             ---- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/shadowing_invalid_types.move:21:17 ───
-    │
- 21 │             (x: u64);
-    │                 ^^^ Invalid type annotation
-    ·
- 20 │             let (a, x) = (false, false);
-    │                                  ----- The type: 'bool'
-    ·
- 21 │             (x: u64);
-    │                 --- Is not compatible with: 'u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/shadowing_invalid_types.move:25:17 ───
-    │
- 25 │             (x: u64);
-    │                 ^^^ Invalid type annotation
-    ·
- 24 │             let x = @0x0;
-    │                     ---- The type: 'address'
-    ·
- 25 │             (x: u64);
-    │                 --- Is not compatible with: 'u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/shadowing_invalid_types.move:27:13 ───
-    │
- 27 │         (x: address);
-    │             ^^^^^^^ Invalid type annotation
-    ·
- 18 │         let x = 0;
-    │             - The type: integer
-    ·
- 27 │         (x: address);
-    │             ------- Is not compatible with: 'address'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/shadowing_invalid_types.move:34:17 ───
-    │
- 34 │             (x: u64);
-    │                 ^^^ Invalid type annotation
-    ·
-  2 │     struct S {f: u64, b: bool}
-    │                          ---- The type: 'bool'
-    ·
- 34 │             (x: u64);
-    │                 --- Is not compatible with: 'u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/shadowing_invalid_types.move:37:13 ───
-    │
- 37 │         (x: bool);
-    │             ^^^^ Invalid type annotation
-    ·
- 31 │         let x = 0;
-    │             - The type: integer
-    ·
- 37 │         (x: bool);
-    │             ---- Is not compatible with: 'bool'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/shadowing_invalid_types.move:37:13
+   │
+31 │         let x = 0;
+   │             - Given: integer
+   ·
+37 │         (x: bool);
+   │             ^^^^
+   │             │
+   │             Invalid type annotation
+   │             Expected: 'bool'
 

--- a/language/move-lang/tests/move_check/typing/spec_block_fail.exp
+++ b/language/move-lang/tests/move_check/typing/spec_block_fail.exp
@@ -1,42 +1,30 @@
-error: 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/spec_block_fail.move:3:19
+  │
+3 │         (spec {}: u64);
+  │          -------  ^^^
+  │          │        │
+  │          │        Invalid type annotation
+  │          │        Expected: 'u64'
+  │          Given: '()'
 
-   ┌── tests/move_check/typing/spec_block_fail.move:3:19 ───
-   │
- 3 │         (spec {}: u64);
-   │                   ^^^ Invalid type annotation
-   ·
- 3 │         (spec {}: u64);
-   │          ------- The type: '()'
-   ·
- 3 │         (spec {}: u64);
-   │                   --- Is not compatible with: 'u64'
-   │
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/spec_block_fail.move:4:19
+  │
+4 │         (spec {}: &u64);
+  │          -------  ^^^^
+  │          │        │
+  │          │        Invalid type annotation
+  │          │        Expected: '&u64'
+  │          Given: '()'
 
-error: 
-
-   ┌── tests/move_check/typing/spec_block_fail.move:4:19 ───
-   │
- 4 │         (spec {}: &u64);
-   │                   ^^^^ Invalid type annotation
-   ·
- 4 │         (spec {}: &u64);
-   │          ------- The type: '()'
-   ·
- 4 │         (spec {}: &u64);
-   │                   ---- Is not compatible with: '&u64'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/spec_block_fail.move:5:19 ───
-   │
- 5 │         (spec {}: (u64, u64));
-   │                   ^^^^^^^^^^ Invalid type annotation
-   ·
- 5 │         (spec {}: (u64, u64));
-   │          ------- The type: '()'
-   ·
- 5 │         (spec {}: (u64, u64));
-   │                   ---------- Is not compatible with: '(u64, u64)'
-   │
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/spec_block_fail.move:5:19
+  │
+5 │         (spec {}: (u64, u64));
+  │          -------  ^^^^^^^^^^
+  │          │        │
+  │          │        Invalid type annotation
+  │          │        Expected: '(u64, u64)'
+  │          Given: '()'
 

--- a/language/move-lang/tests/move_check/typing/subtype_annotation_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/subtype_annotation_invalid.exp
@@ -1,56 +1,40 @@
-error: 
+error[E04006]: invalid subtype
+  ┌─ tests/move_check/typing/subtype_annotation_invalid.move:5:14
+  │
+5 │         (&0: &mut u64);
+  │          --  ^^^^^^^^
+  │          │   │
+  │          │   Invalid type annotation
+  │          │   Expected: '&mut u64'
+  │          Given: '&{integer}'
 
-   ┌── tests/move_check/typing/subtype_annotation_invalid.move:5:14 ───
+error[E04006]: invalid subtype
+  ┌─ tests/move_check/typing/subtype_annotation_invalid.move:9:20
+  │
+9 │         ((&0, &0): (&mut u64, &mut u64));
+  │           --       ^^^^^^^^^^^^^^^^^^^^
+  │           │        ││
+  │           │        │Expected: '&mut u64'
+  │           │        Invalid type annotation
+  │           Given: '&{integer}'
+
+error[E04006]: invalid subtype
+   ┌─ tests/move_check/typing/subtype_annotation_invalid.move:10:20
    │
- 5 │         (&0: &mut u64);
-   │              ^^^^^^^^ Invalid type annotation
-   ·
- 5 │         (&0: &mut u64);
-   │          -- The type: '&{integer}'
-   ·
- 5 │         (&0: &mut u64);
-   │              -------- Is not a subtype of: '&mut u64'
+10 │         ((&0, &0): (&mut u64, &u64));
+   │           --       ^^^^^^^^^^^^^^^^
+   │           │        ││
+   │           │        │Expected: '&mut u64'
+   │           │        Invalid type annotation
+   │           Given: '&{integer}'
+
+error[E04006]: invalid subtype
+   ┌─ tests/move_check/typing/subtype_annotation_invalid.move:11:20
    │
-
-error: 
-
-   ┌── tests/move_check/typing/subtype_annotation_invalid.move:9:20 ───
-   │
- 9 │         ((&0, &0): (&mut u64, &mut u64));
-   │                    ^^^^^^^^^^^^^^^^^^^^ Invalid type annotation
-   ·
- 9 │         ((&0, &0): (&mut u64, &mut u64));
-   │           -- The type: '&{integer}'
-   ·
- 9 │         ((&0, &0): (&mut u64, &mut u64));
-   │                     -------- Is not a subtype of: '&mut u64'
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/subtype_annotation_invalid.move:10:20 ───
-    │
- 10 │         ((&0, &0): (&mut u64, &u64));
-    │                    ^^^^^^^^^^^^^^^^ Invalid type annotation
-    ·
- 10 │         ((&0, &0): (&mut u64, &u64));
-    │           -- The type: '&{integer}'
-    ·
- 10 │         ((&0, &0): (&mut u64, &u64));
-    │                     -------- Is not a subtype of: '&mut u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/subtype_annotation_invalid.move:11:20 ───
-    │
- 11 │         ((&0, &0): (&u64, &mut u64));
-    │                    ^^^^^^^^^^^^^^^^ Invalid type annotation
-    ·
- 11 │         ((&0, &0): (&u64, &mut u64));
-    │               -- The type: '&{integer}'
-    ·
- 11 │         ((&0, &0): (&u64, &mut u64));
-    │                           -------- Is not a subtype of: '&mut u64'
-    │
+11 │         ((&0, &0): (&u64, &mut u64));
+   │               --   ^^^^^^^^^^^^^^^^
+   │               │    │      │
+   │               │    │      Expected: '&mut u64'
+   │               │    Invalid type annotation
+   │               Given: '&{integer}'
 

--- a/language/move-lang/tests/move_check/typing/subtype_args_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/subtype_args_invalid.exp
@@ -1,84 +1,72 @@
-error: 
+error[E04006]: invalid subtype
+   ┌─ tests/move_check/typing/subtype_args_invalid.move:10:9
+   │
+ 4 │     fun mut<T>(x: &mut T) {}
+   │                   ------ Expected: '&mut u64'
+   ·
+10 │         mut<u64>(&0);
+   │         ^^^^^^^^^^^^
+   │         │        │
+   │         │        Given: '&{integer}'
+   │         Invalid call of '0x8675309::M::mut'. Invalid argument for parameter 'x'
 
-    ┌── tests/move_check/typing/subtype_args_invalid.move:10:9 ───
-    │
- 10 │         mut<u64>(&0);
-    │         ^^^^^^^^^^^^ Invalid call of '0x8675309::M::mut'. Invalid argument for parameter 'x'
-    ·
- 10 │         mut<u64>(&0);
-    │                  -- The type: '&{integer}'
-    ·
-  4 │     fun mut<T>(x: &mut T) {}
-    │                   ------ Is not a subtype of: '&mut u64'
-    │
+error[E04006]: invalid subtype
+   ┌─ tests/move_check/typing/subtype_args_invalid.move:11:9
+   │
+ 4 │     fun mut<T>(x: &mut T) {}
+   │                   ------ Expected: '&mut u64'
+   ·
+11 │         mut<u64>(&S{});
+   │         ^^^^^^^^^^^^^^
+   │         │        │
+   │         │        Given: '&0x8675309::M::S'
+   │         Invalid call of '0x8675309::M::mut'. Invalid argument for parameter 'x'
 
-error: 
+error[E04006]: invalid subtype
+   ┌─ tests/move_check/typing/subtype_args_invalid.move:15:9
+   │
+ 5 │     fun imm_mut<T>(x: &T, y: &mut T) {}
+   │                              ------ Expected: '&mut u64'
+   ·
+15 │         imm_mut<u64>(&0, &0);
+   │         ^^^^^^^^^^^^^^^^^^^^
+   │         │                │
+   │         │                Given: '&{integer}'
+   │         Invalid call of '0x8675309::M::imm_mut'. Invalid argument for parameter 'y'
 
-    ┌── tests/move_check/typing/subtype_args_invalid.move:11:9 ───
-    │
- 11 │         mut<u64>(&S{});
-    │         ^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::mut'. Invalid argument for parameter 'x'
-    ·
- 11 │         mut<u64>(&S{});
-    │                  ---- The type: '&0x8675309::M::S'
-    ·
-  4 │     fun mut<T>(x: &mut T) {}
-    │                   ------ Is not a subtype of: '&mut u64'
-    │
+error[E04006]: invalid subtype
+   ┌─ tests/move_check/typing/subtype_args_invalid.move:16:9
+   │
+ 6 │     fun mut_imm<T>(x: &mut T, y: &T) {}
+   │                       ------ Expected: '&mut u64'
+   ·
+16 │         mut_imm<u64>(&0, &0);
+   │         ^^^^^^^^^^^^^^^^^^^^
+   │         │            │
+   │         │            Given: '&{integer}'
+   │         Invalid call of '0x8675309::M::mut_imm'. Invalid argument for parameter 'x'
 
-error: 
+error[E04006]: invalid subtype
+   ┌─ tests/move_check/typing/subtype_args_invalid.move:17:9
+   │
+ 7 │     fun mut_mut<T>(x: &mut T, y: &mut T) {}
+   │                       ------ Expected: '&mut u64'
+   ·
+17 │         mut_mut<u64>(&0, &0);
+   │         ^^^^^^^^^^^^^^^^^^^^
+   │         │            │
+   │         │            Given: '&{integer}'
+   │         Invalid call of '0x8675309::M::mut_mut'. Invalid argument for parameter 'x'
 
-    ┌── tests/move_check/typing/subtype_args_invalid.move:15:9 ───
-    │
- 15 │         imm_mut<u64>(&0, &0);
-    │         ^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::imm_mut'. Invalid argument for parameter 'y'
-    ·
- 15 │         imm_mut<u64>(&0, &0);
-    │                          -- The type: '&{integer}'
-    ·
-  5 │     fun imm_mut<T>(x: &T, y: &mut T) {}
-    │                              ------ Is not a subtype of: '&mut u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/subtype_args_invalid.move:16:9 ───
-    │
- 16 │         mut_imm<u64>(&0, &0);
-    │         ^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::mut_imm'. Invalid argument for parameter 'x'
-    ·
- 16 │         mut_imm<u64>(&0, &0);
-    │                      -- The type: '&{integer}'
-    ·
-  6 │     fun mut_imm<T>(x: &mut T, y: &T) {}
-    │                       ------ Is not a subtype of: '&mut u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/subtype_args_invalid.move:17:9 ───
-    │
- 17 │         mut_mut<u64>(&0, &0);
-    │         ^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::mut_mut'. Invalid argument for parameter 'x'
-    ·
- 17 │         mut_mut<u64>(&0, &0);
-    │                      -- The type: '&{integer}'
-    ·
-  7 │     fun mut_mut<T>(x: &mut T, y: &mut T) {}
-    │                       ------ Is not a subtype of: '&mut u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/subtype_args_invalid.move:17:9 ───
-    │
- 17 │         mut_mut<u64>(&0, &0);
-    │         ^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::mut_mut'. Invalid argument for parameter 'y'
-    ·
- 17 │         mut_mut<u64>(&0, &0);
-    │                          -- The type: '&{integer}'
-    ·
-  7 │     fun mut_mut<T>(x: &mut T, y: &mut T) {}
-    │                                  ------ Is not a subtype of: '&mut u64'
-    │
+error[E04006]: invalid subtype
+   ┌─ tests/move_check/typing/subtype_args_invalid.move:17:9
+   │
+ 7 │     fun mut_mut<T>(x: &mut T, y: &mut T) {}
+   │                                  ------ Expected: '&mut u64'
+   ·
+17 │         mut_mut<u64>(&0, &0);
+   │         ^^^^^^^^^^^^^^^^^^^^
+   │         │                │
+   │         │                Given: '&{integer}'
+   │         Invalid call of '0x8675309::M::mut_mut'. Invalid argument for parameter 'y'
 

--- a/language/move-lang/tests/move_check/typing/subtype_assign_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/subtype_assign_invalid.exp
@@ -1,70 +1,49 @@
-error: 
+error[E04006]: invalid subtype
+  ┌─ tests/move_check/typing/subtype_assign_invalid.move:5:16
+  │
+5 │         let x: &mut u64 = &0;
+  │                ^^^^^^^^   -- Given: '&{integer}'
+  │                │           
+  │                Invalid type annotation
+  │                Expected: '&mut u64'
 
-   ┌── tests/move_check/typing/subtype_assign_invalid.move:5:16 ───
+error[E04006]: invalid subtype
+   ┌─ tests/move_check/typing/subtype_assign_invalid.move:10:10
    │
- 5 │         let x: &mut u64 = &0;
-   │                ^^^^^^^^ Invalid type annotation
-   ·
- 5 │         let x: &mut u64 = &0;
-   │                           -- The type: '&{integer}'
-   ·
- 5 │         let x: &mut u64 = &0;
-   │                -------- Is not a subtype of: '&mut u64'
+ 9 │         let (x, y): (&mut u64, &mut u64);
+   │                      -------- Expected: '&mut u64'
+10 │         (x, y) = (&0, &0);
+   │          ^        -- Given: '&{integer}'
+   │          │         
+   │          Invalid assignment to local 'x'
+
+error[E04006]: invalid subtype
+   ┌─ tests/move_check/typing/subtype_assign_invalid.move:10:13
    │
+ 9 │         let (x, y): (&mut u64, &mut u64);
+   │                                -------- Expected: '&mut u64'
+10 │         (x, y) = (&0, &0);
+   │             ^         -- Given: '&{integer}'
+   │             │          
+   │             Invalid assignment to local 'y'
 
-error: 
+error[E04006]: invalid subtype
+   ┌─ tests/move_check/typing/subtype_assign_invalid.move:13:10
+   │
+12 │         let (x, y): (&mut u64, &u64);
+   │                      -------- Expected: '&mut u64'
+13 │         (x, y) = (&0, &0);
+   │          ^        -- Given: '&{integer}'
+   │          │         
+   │          Invalid assignment to local 'x'
 
-    ┌── tests/move_check/typing/subtype_assign_invalid.move:10:10 ───
-    │
- 10 │         (x, y) = (&0, &0);
-    │          ^ Invalid assignment to local 'x'
-    ·
- 10 │         (x, y) = (&0, &0);
-    │                   -- The type: '&{integer}'
-    ·
-  9 │         let (x, y): (&mut u64, &mut u64);
-    │                      -------- Is not a subtype of: '&mut u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/subtype_assign_invalid.move:10:13 ───
-    │
- 10 │         (x, y) = (&0, &0);
-    │             ^ Invalid assignment to local 'y'
-    ·
- 10 │         (x, y) = (&0, &0);
-    │                       -- The type: '&{integer}'
-    ·
-  9 │         let (x, y): (&mut u64, &mut u64);
-    │                                -------- Is not a subtype of: '&mut u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/subtype_assign_invalid.move:13:10 ───
-    │
- 13 │         (x, y) = (&0, &0);
-    │          ^ Invalid assignment to local 'x'
-    ·
- 13 │         (x, y) = (&0, &0);
-    │                   -- The type: '&{integer}'
-    ·
- 12 │         let (x, y): (&mut u64, &u64);
-    │                      -------- Is not a subtype of: '&mut u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/subtype_assign_invalid.move:16:13 ───
-    │
- 16 │         (x, y)= (&0, &0);
-    │             ^ Invalid assignment to local 'y'
-    ·
- 16 │         (x, y)= (&0, &0);
-    │                      -- The type: '&{integer}'
-    ·
- 15 │         let (x, y): (&u64, &mut u64);
-    │                            -------- Is not a subtype of: '&mut u64'
-    │
+error[E04006]: invalid subtype
+   ┌─ tests/move_check/typing/subtype_assign_invalid.move:16:13
+   │
+15 │         let (x, y): (&u64, &mut u64);
+   │                            -------- Expected: '&mut u64'
+16 │         (x, y)= (&0, &0);
+   │             ^        -- Given: '&{integer}'
+   │             │         
+   │             Invalid assignment to local 'y'
 

--- a/language/move-lang/tests/move_check/typing/subtype_bind_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/subtype_bind_invalid.exp
@@ -1,56 +1,36 @@
-error: 
+error[E04006]: invalid subtype
+  ┌─ tests/move_check/typing/subtype_bind_invalid.move:5:16
+  │
+5 │         let x: &mut u64 = &0;
+  │                ^^^^^^^^   -- Given: '&{integer}'
+  │                │           
+  │                Invalid type annotation
+  │                Expected: '&mut u64'
 
-   ┌── tests/move_check/typing/subtype_bind_invalid.move:5:16 ───
+error[E04006]: invalid subtype
+  ┌─ tests/move_check/typing/subtype_bind_invalid.move:9:21
+  │
+9 │         let (x, y): (&mut u64, &mut u64) = (&0, &0);
+  │                     ^^^^^^^^^^^^^^^^^^^^    -- Given: '&{integer}'
+  │                     ││                       
+  │                     │Expected: '&mut u64'
+  │                     Invalid type annotation
+
+error[E04006]: invalid subtype
+   ┌─ tests/move_check/typing/subtype_bind_invalid.move:10:21
    │
- 5 │         let x: &mut u64 = &0;
-   │                ^^^^^^^^ Invalid type annotation
-   ·
- 5 │         let x: &mut u64 = &0;
-   │                           -- The type: '&{integer}'
-   ·
- 5 │         let x: &mut u64 = &0;
-   │                -------- Is not a subtype of: '&mut u64'
+10 │         let (x, y): (&mut u64, &u64) = (&0, &0);
+   │                     ^^^^^^^^^^^^^^^^    -- Given: '&{integer}'
+   │                     ││                   
+   │                     │Expected: '&mut u64'
+   │                     Invalid type annotation
+
+error[E04006]: invalid subtype
+   ┌─ tests/move_check/typing/subtype_bind_invalid.move:11:21
    │
-
-error: 
-
-   ┌── tests/move_check/typing/subtype_bind_invalid.move:9:21 ───
-   │
- 9 │         let (x, y): (&mut u64, &mut u64) = (&0, &0);
-   │                     ^^^^^^^^^^^^^^^^^^^^ Invalid type annotation
-   ·
- 9 │         let (x, y): (&mut u64, &mut u64) = (&0, &0);
-   │                                             -- The type: '&{integer}'
-   ·
- 9 │         let (x, y): (&mut u64, &mut u64) = (&0, &0);
-   │                      -------- Is not a subtype of: '&mut u64'
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/subtype_bind_invalid.move:10:21 ───
-    │
- 10 │         let (x, y): (&mut u64, &u64) = (&0, &0);
-    │                     ^^^^^^^^^^^^^^^^ Invalid type annotation
-    ·
- 10 │         let (x, y): (&mut u64, &u64) = (&0, &0);
-    │                                         -- The type: '&{integer}'
-    ·
- 10 │         let (x, y): (&mut u64, &u64) = (&0, &0);
-    │                      -------- Is not a subtype of: '&mut u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/subtype_bind_invalid.move:11:21 ───
-    │
- 11 │         let (x, y): (&u64, &mut u64) = (&0, &0);
-    │                     ^^^^^^^^^^^^^^^^ Invalid type annotation
-    ·
- 11 │         let (x, y): (&u64, &mut u64) = (&0, &0);
-    │                                             -- The type: '&{integer}'
-    ·
- 11 │         let (x, y): (&u64, &mut u64) = (&0, &0);
-    │                            -------- Is not a subtype of: '&mut u64'
-    │
+11 │         let (x, y): (&u64, &mut u64) = (&0, &0);
+   │                     ^^^^^^^^^^^^^^^^        -- Given: '&{integer}'
+   │                     │      │                 
+   │                     │      Expected: '&mut u64'
+   │                     Invalid type annotation
 

--- a/language/move-lang/tests/move_check/typing/subtype_return_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/subtype_return_invalid.exp
@@ -1,70 +1,50 @@
-error: 
+error[E04006]: invalid subtype
+  ┌─ tests/move_check/typing/subtype_return_invalid.move:5:9
+  │
+4 │     fun t0(u: &u64): &mut u64 {
+  │               ----   -------- Expected: '&mut u64'
+  │               │       
+  │               Given: '&u64'
+5 │         u
+  │         ^ Invalid return expression
 
-   ┌── tests/move_check/typing/subtype_return_invalid.move:5:9 ───
+error[E04006]: invalid subtype
+  ┌─ tests/move_check/typing/subtype_return_invalid.move:9:9
+  │
+8 │     fun t1(s: &S): &mut S {
+  │               --   ------ Expected: '&mut 0x8675309::M::S'
+  │               │     
+  │               Given: '&0x8675309::M::S'
+9 │         s
+  │         ^ Invalid return expression
+
+error[E04006]: invalid subtype
+   ┌─ tests/move_check/typing/subtype_return_invalid.move:13:9
    │
- 5 │         u
-   │         ^ Invalid return expression
-   ·
- 4 │     fun t0(u: &u64): &mut u64 {
-   │               ---- The type: '&u64'
-   ·
- 4 │     fun t0(u: &u64): &mut u64 {
-   │                      -------- Is not a subtype of: '&mut u64'
+12 │     fun t2(u1: &u64, u2: &u64): (&u64, &mut u64) {
+   │                          ----          -------- Expected: '&mut u64'
+   │                          │              
+   │                          Given: '&u64'
+13 │         (u1, u2)
+   │         ^^^^^^^^ Invalid return expression
+
+error[E04006]: invalid subtype
+   ┌─ tests/move_check/typing/subtype_return_invalid.move:17:9
    │
+16 │     fun t3(u1: &u64, u2: &u64): (&mut u64, &u64) {
+   │                ----              -------- Expected: '&mut u64'
+   │                │                  
+   │                Given: '&u64'
+17 │         (u1, u2)
+   │         ^^^^^^^^ Invalid return expression
 
-error: 
-
-   ┌── tests/move_check/typing/subtype_return_invalid.move:9:9 ───
+error[E04006]: invalid subtype
+   ┌─ tests/move_check/typing/subtype_return_invalid.move:21:9
    │
- 9 │         s
-   │         ^ Invalid return expression
-   ·
- 8 │     fun t1(s: &S): &mut S {
-   │               -- The type: '&0x8675309::M::S'
-   ·
- 8 │     fun t1(s: &S): &mut S {
-   │                    ------ Is not a subtype of: '&mut 0x8675309::M::S'
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/subtype_return_invalid.move:13:9 ───
-    │
- 13 │         (u1, u2)
-    │         ^^^^^^^^ Invalid return expression
-    ·
- 12 │     fun t2(u1: &u64, u2: &u64): (&u64, &mut u64) {
-    │                          ---- The type: '&u64'
-    ·
- 12 │     fun t2(u1: &u64, u2: &u64): (&u64, &mut u64) {
-    │                                        -------- Is not a subtype of: '&mut u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/subtype_return_invalid.move:17:9 ───
-    │
- 17 │         (u1, u2)
-    │         ^^^^^^^^ Invalid return expression
-    ·
- 16 │     fun t3(u1: &u64, u2: &u64): (&mut u64, &u64) {
-    │                ---- The type: '&u64'
-    ·
- 16 │     fun t3(u1: &u64, u2: &u64): (&mut u64, &u64) {
-    │                                  -------- Is not a subtype of: '&mut u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/subtype_return_invalid.move:21:9 ───
-    │
- 21 │         (u1, u2)
-    │         ^^^^^^^^ Invalid return expression
-    ·
- 20 │     fun t4(u1: &u64, u2: &u64): (&mut u64, &mut u64) {
-    │                ---- The type: '&u64'
-    ·
- 20 │     fun t4(u1: &u64, u2: &u64): (&mut u64, &mut u64) {
-    │                                  -------- Is not a subtype of: '&mut u64'
-    │
+20 │     fun t4(u1: &u64, u2: &u64): (&mut u64, &mut u64) {
+   │                ----              -------- Expected: '&mut u64'
+   │                │                  
+   │                Given: '&u64'
+21 │         (u1, u2)
+   │         ^^^^^^^^ Invalid return expression
 

--- a/language/move-lang/tests/move_check/typing/type_variable_join_single_pack_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/type_variable_join_single_pack_invalid.exp
@@ -1,28 +1,20 @@
-error: 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/type_variable_join_single_pack_invalid.move:5:38
+  │
+5 │         let b = Box { f1: false, f2: 1 };
+  │                           -----      ^
+  │                           │          │
+  │                           │          Invalid argument for field 'f2' for '0x8675309::M::Box'
+  │                           │          Given: integer
+  │                           Expected: 'bool'
 
-   ┌── tests/move_check/typing/type_variable_join_single_pack_invalid.move:5:38 ───
-   │
- 5 │         let b = Box { f1: false, f2: 1 };
-   │                                      ^ Invalid argument for field 'f2' for '0x8675309::M::Box'
-   ·
- 5 │         let b = Box { f1: false, f2: 1 };
-   │                                      - The type: integer
-   ·
- 5 │         let b = Box { f1: false, f2: 1 };
-   │                           ----- Is not compatible with: 'bool'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/type_variable_join_single_pack_invalid.move:6:55 ───
-   │
- 6 │         let b2 = Box { f1: Box { f1: 0, f2: 0 }, f2:  Box { f1: false, f2: false } };
-   │                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid argument for field 'f2' for '0x8675309::M::Box'
-   ·
- 6 │         let b2 = Box { f1: Box { f1: 0, f2: 0 }, f2:  Box { f1: false, f2: false } };
-   │                            -------------------- The type: integer
-   ·
- 6 │         let b2 = Box { f1: Box { f1: 0, f2: 0 }, f2:  Box { f1: false, f2: false } };
-   │                                                                 ----- Is not compatible with: 'bool'
-   │
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/type_variable_join_single_pack_invalid.move:6:55
+  │
+6 │         let b2 = Box { f1: Box { f1: 0, f2: 0 }, f2:  Box { f1: false, f2: false } };
+  │                            --------------------       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │                            │                          │         │
+  │                            │                          │         Given: 'bool'
+  │                            │                          Invalid argument for field 'f2' for '0x8675309::M::Box'
+  │                            Expected: integer
 

--- a/language/move-lang/tests/move_check/typing/type_variable_join_single_unpack_assign_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/type_variable_join_single_unpack_assign_invalid.exp
@@ -1,28 +1,22 @@
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/type_variable_join_single_unpack_assign_invalid.move:13:14
+   │
+12 │         (f1: u64);
+   │              --- Given: 'u64'
+13 │         (f2: bool);
+   │              ^^^^
+   │              │
+   │              Invalid type annotation
+   │              Expected: 'bool'
 
-    ┌── tests/move_check/typing/type_variable_join_single_unpack_assign_invalid.move:13:14 ───
-    │
- 13 │         (f2: bool);
-    │              ^^^^ Invalid type annotation
-    ·
- 12 │         (f1: u64);
-    │              --- The type: 'u64'
-    ·
- 13 │         (f2: bool);
-    │              ---- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/type_variable_join_single_unpack_assign_invalid.move:18:14 ───
-    │
- 18 │         (f2: Box<bool>);
-    │              ^^^^^^^^^ Invalid type annotation
-    ·
- 17 │         (f1: Box<u64>);
-    │                  --- The type: 'u64'
-    ·
- 18 │         (f2: Box<bool>);
-    │                  ---- Is not compatible with: 'bool'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/type_variable_join_single_unpack_assign_invalid.move:18:14
+   │
+17 │         (f1: Box<u64>);
+   │                  --- Given: 'u64'
+18 │         (f2: Box<bool>);
+   │              ^^^^^^^^^
+   │              │   │
+   │              │   Expected: 'bool'
+   │              Invalid type annotation
 

--- a/language/move-lang/tests/move_check/typing/type_variable_join_single_unpack_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/type_variable_join_single_unpack_invalid.exp
@@ -1,28 +1,22 @@
-error: 
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/type_variable_join_single_unpack_invalid.move:11:14
+   │
+10 │         (f1: u64);
+   │              --- Given: 'u64'
+11 │         (f2: bool);
+   │              ^^^^
+   │              │
+   │              Invalid type annotation
+   │              Expected: 'bool'
 
-    ┌── tests/move_check/typing/type_variable_join_single_unpack_invalid.move:11:14 ───
-    │
- 11 │         (f2: bool);
-    │              ^^^^ Invalid type annotation
-    ·
- 10 │         (f1: u64);
-    │              --- The type: 'u64'
-    ·
- 11 │         (f2: bool);
-    │              ---- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/type_variable_join_single_unpack_invalid.move:14:14 ───
-    │
- 14 │         (f2: Box<bool>);
-    │              ^^^^^^^^^ Invalid type annotation
-    ·
- 13 │         (f1: Box<u64>);
-    │                  --- The type: 'u64'
-    ·
- 14 │         (f2: Box<bool>);
-    │                  ---- Is not compatible with: 'bool'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/type_variable_join_single_unpack_invalid.move:14:14
+   │
+13 │         (f1: Box<u64>);
+   │                  --- Given: 'u64'
+14 │         (f2: Box<bool>);
+   │              ^^^^^^^^^
+   │              │   │
+   │              │   Expected: 'bool'
+   │              Invalid type annotation
 

--- a/language/move-lang/tests/move_check/typing/type_variable_join_threaded_pack_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/type_variable_join_threaded_pack_invalid.exp
@@ -1,3 +1,15 @@
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/type_variable_join_threaded_pack_invalid.move:42:9
+   │
+35 │     fun t0(): Box<bool> {
+   │                   ---- Expected: 'bool'
+   ·
+40 │         let r = Container::get_ref(&v);
+   │                 ---------------------- Given: integer
+41 │         id(r);
+42 │         b
+   │         ^ Invalid return expression
+
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/type_variable_join_threaded_pack_invalid.move:47:17
    │
@@ -12,18 +24,4 @@ error[E05001]: ability constraint not satisfied
 48 │         let b = Box { f1: x, f2: x };
 49 │         Container::put(&mut v, Box {f1: R{}, f2: R{}});
    │                                ---------------------- The type '0x2::M::Box<0x2::M::R>' does not have the ability 'drop'
-
-error: 
-
-    ┌── tests/move_check/typing/type_variable_join_threaded_pack_invalid.move:42:9 ───
-    │
- 42 │         b
-    │         ^ Invalid return expression
-    ·
- 40 │         let r = Container::get_ref(&v);
-    │                 ---------------------- The type: integer
-    ·
- 35 │     fun t0(): Box<bool> {
-    │                   ---- Is not compatible with: 'bool'
-    │
 

--- a/language/move-lang/tests/move_check/typing/type_variable_join_threaded_unpack_assign_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/type_variable_join_threaded_unpack_assign_invalid.exp
@@ -1,3 +1,15 @@
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/type_variable_join_threaded_unpack_assign_invalid.move:36:9
+   │
+30 │     fun t0(): bool {
+   │               ---- Expected: 'bool'
+   ·
+34 │         Box { f1, f2 }  = Container::get(&v);
+   │         -------------- Given: integer
+35 │         Container::put(&mut v, Box { f1: 0, f2: 0});
+36 │         f1
+   │         ^^ Invalid return expression
+
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/type_variable_join_threaded_unpack_assign_invalid.move:43:27
    │
@@ -9,18 +21,4 @@ error[E05001]: ability constraint not satisfied
    │         │                  
    │         The type '0x2::M::Box<0x2::M::R>' does not have the ability 'drop'
    │         The type '0x2::M::Box<0x2::M::R>' can have the ability 'drop' but the type argument '0x2::M::R' does not have the required ability 'drop'
-
-error: 
-
-    ┌── tests/move_check/typing/type_variable_join_threaded_unpack_assign_invalid.move:36:9 ───
-    │
- 36 │         f1
-    │         ^^ Invalid return expression
-    ·
- 34 │         Box { f1, f2 }  = Container::get(&v);
-    │         -------------- The type: integer
-    ·
- 30 │     fun t0(): bool {
-    │               ---- Is not compatible with: 'bool'
-    │
 

--- a/language/move-lang/tests/move_check/typing/type_variable_join_threaded_unpack_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/type_variable_join_threaded_unpack_invalid.exp
@@ -1,3 +1,15 @@
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/type_variable_join_threaded_unpack_invalid.move:34:9
+   │
+30 │     fun t0(): bool {
+   │               ---- Expected: 'bool'
+31 │         let v = Container::new();
+32 │         let Box { f1, f2 }  = Container::get(&v);
+   │             -------------- Given: integer
+33 │         Container::put(&mut v, Box { f1: 0, f2: 0});
+34 │         f1
+   │         ^^ Invalid return expression
+
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/type_variable_join_threaded_unpack_invalid.move:39:31
    │
@@ -9,18 +21,4 @@ error[E05001]: ability constraint not satisfied
    │             │                  
    │             The type '0x2::M::Box<0x2::M::R>' does not have the ability 'drop'
    │             The type '0x2::M::Box<0x2::M::R>' can have the ability 'drop' but the type argument '0x2::M::R' does not have the required ability 'drop'
-
-error: 
-
-    ┌── tests/move_check/typing/type_variable_join_threaded_unpack_invalid.move:34:9 ───
-    │
- 34 │         f1
-    │         ^^ Invalid return expression
-    ·
- 32 │         let Box { f1, f2 }  = Container::get(&v);
-    │             -------------- The type: integer
-    ·
- 30 │     fun t0(): bool {
-    │               ---- Is not compatible with: 'bool'
-    │
 

--- a/language/move-lang/tests/move_check/typing/unary_not_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/unary_not_invalid.exp
@@ -1,112 +1,84 @@
-error: 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/unary_not_invalid.move:7:10
+  │
+7 │         !&true;
+  │          ^^^^^
+  │          │
+  │          Invalid argument to '!'
+  │          Expected: 'bool'
+  │          Given: '&bool'
 
-   ┌── tests/move_check/typing/unary_not_invalid.move:7:10 ───
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/unary_not_invalid.move:8:10
+  │
+8 │         !&false;
+  │          ^^^^^^
+  │          │
+  │          Invalid argument to '!'
+  │          Expected: 'bool'
+  │          Given: '&bool'
+
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/unary_not_invalid.move:9:10
+  │
+9 │         !0;
+  │          ^
+  │          │
+  │          Invalid argument to '!'
+  │          Expected: 'bool'
+  │          Given: integer
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/unary_not_invalid.move:10:10
    │
- 7 │         !&true;
-   │          ^^^^^ Invalid argument to '!'
-   ·
- 7 │         !&true;
-   │          ----- The type: '&bool'
-   ·
- 7 │         !&true;
-   │          ----- Is not compatible with: 'bool'
+10 │         !1;
+   │          ^
+   │          │
+   │          Invalid argument to '!'
+   │          Expected: 'bool'
+   │          Given: integer
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/unary_not_invalid.move:11:10
    │
-
-error: 
-
-   ┌── tests/move_check/typing/unary_not_invalid.move:8:10 ───
-   │
- 8 │         !&false;
-   │          ^^^^^^ Invalid argument to '!'
+ 6 │     fun t0(x: bool, r: R) {
+   │                        - Given: '0x8675309::M::R'
    ·
- 8 │         !&false;
-   │          ------ The type: '&bool'
-   ·
- 8 │         !&false;
-   │          ------ Is not compatible with: 'bool'
+11 │         !r;
+   │          ^
+   │          │
+   │          Invalid argument to '!'
+   │          Expected: 'bool'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/unary_not_invalid.move:12:10
    │
-
-error: 
-
-   ┌── tests/move_check/typing/unary_not_invalid.move:9:10 ───
-   │
- 9 │         !0;
-   │          ^ Invalid argument to '!'
+ 6 │     fun t0(x: bool, r: R) {
+   │                        - Given: '0x8675309::M::R'
    ·
- 9 │         !0;
-   │          - The type: integer
-   ·
- 9 │         !0;
-   │          - Is not compatible with: 'bool'
+12 │         !r;
+   │          ^
+   │          │
+   │          Invalid argument to '!'
+   │          Expected: 'bool'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/unary_not_invalid.move:13:10
    │
+13 │         !(0, false);
+   │          ^^^^^^^^^^
+   │          │
+   │          Invalid argument to '!'
+   │          Expected: 'bool'
+   │          Given: '({integer}, bool)'
 
-error: 
-
-    ┌── tests/move_check/typing/unary_not_invalid.move:10:10 ───
-    │
- 10 │         !1;
-    │          ^ Invalid argument to '!'
-    ·
- 10 │         !1;
-    │          - The type: integer
-    ·
- 10 │         !1;
-    │          - Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/unary_not_invalid.move:11:10 ───
-    │
- 11 │         !r;
-    │          ^ Invalid argument to '!'
-    ·
-  6 │     fun t0(x: bool, r: R) {
-    │                        - The type: '0x8675309::M::R'
-    ·
- 11 │         !r;
-    │          - Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/unary_not_invalid.move:12:10 ───
-    │
- 12 │         !r;
-    │          ^ Invalid argument to '!'
-    ·
-  6 │     fun t0(x: bool, r: R) {
-    │                        - The type: '0x8675309::M::R'
-    ·
- 12 │         !r;
-    │          - Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/unary_not_invalid.move:13:10 ───
-    │
- 13 │         !(0, false);
-    │          ^^^^^^^^^^ Invalid argument to '!'
-    ·
- 13 │         !(0, false);
-    │          ---------- The type: '({integer}, bool)'
-    ·
- 13 │         !(0, false);
-    │          ---------- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/unary_not_invalid.move:14:10 ───
-    │
- 14 │         !();
-    │          ^^ Invalid argument to '!'
-    ·
- 14 │         !();
-    │          -- The type: '()'
-    ·
- 14 │         !();
-    │          -- Is not compatible with: 'bool'
-    │
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/unary_not_invalid.move:14:10
+   │
+14 │         !();
+   │          ^^
+   │          │
+   │          Invalid argument to '!'
+   │          Expected: 'bool'
+   │          Given: '()'
 

--- a/language/move-lang/tests/move_check/typing/while_body_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/while_body_invalid.exp
@@ -1,70 +1,50 @@
-error: 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/while_body_invalid.move:3:22
+  │
+3 │         while (cond) 0;
+  │                      ^
+  │                      │
+  │                      Invalid loop body
+  │                      Expected: '()'
+  │                      Given: integer
 
-   ┌── tests/move_check/typing/while_body_invalid.move:3:22 ───
-   │
- 3 │         while (cond) 0;
-   │                      ^ Invalid loop body
-   ·
- 3 │         while (cond) 0;
-   │                      - The type: integer
-   ·
- 3 │         while (cond) 0;
-   │                      - Is not compatible with: '()'
-   │
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/while_body_invalid.move:4:22
+  │
+4 │         while (cond) false;
+  │                      ^^^^^
+  │                      │
+  │                      Invalid loop body
+  │                      Expected: '()'
+  │                      Given: 'bool'
 
-error: 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/while_body_invalid.move:5:22
+  │
+5 │         while (cond) { @0x0 };
+  │                      ^^^^^^^^
+  │                      │ │
+  │                      │ Given: 'address'
+  │                      Invalid loop body
+  │                      Expected: '()'
 
-   ┌── tests/move_check/typing/while_body_invalid.move:4:22 ───
-   │
- 4 │         while (cond) false;
-   │                      ^^^^^ Invalid loop body
-   ·
- 4 │         while (cond) false;
-   │                      ----- The type: 'bool'
-   ·
- 4 │         while (cond) false;
-   │                      ----- Is not compatible with: '()'
-   │
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/while_body_invalid.move:6:22
+  │
+6 │         while (cond) { let x = 0; x };
+  │                      ^^^^^^^^^^^^^^^^
+  │                      │     │
+  │                      │     Given: integer
+  │                      Invalid loop body
+  │                      Expected: '()'
 
-error: 
-
-   ┌── tests/move_check/typing/while_body_invalid.move:5:22 ───
-   │
- 5 │         while (cond) { @0x0 };
-   │                      ^^^^^^^^ Invalid loop body
-   ·
- 5 │         while (cond) { @0x0 };
-   │                        ---- The type: 'address'
-   ·
- 5 │         while (cond) { @0x0 };
-   │                      -------- Is not compatible with: '()'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/while_body_invalid.move:6:22 ───
-   │
- 6 │         while (cond) { let x = 0; x };
-   │                      ^^^^^^^^^^^^^^^^ Invalid loop body
-   ·
- 6 │         while (cond) { let x = 0; x };
-   │                            - The type: integer
-   ·
- 6 │         while (cond) { let x = 0; x };
-   │                      ---------------- Is not compatible with: '()'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/while_body_invalid.move:7:22 ───
-   │
- 7 │         while (cond) { if (cond) 1 else 0 };
-   │                      ^^^^^^^^^^^^^^^^^^^^^^ Invalid loop body
-   ·
- 7 │         while (cond) { if (cond) 1 else 0 };
-   │                                         - The type: integer
-   ·
- 7 │         while (cond) { if (cond) 1 else 0 };
-   │                      ---------------------- Is not compatible with: '()'
-   │
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/while_body_invalid.move:7:22
+  │
+7 │         while (cond) { if (cond) 1 else 0 };
+  │                      ^^^^^^^^^^^^^^^^^^^^^^
+  │                      │                  │
+  │                      │                  Given: integer
+  │                      Invalid loop body
+  │                      Expected: '()'
 

--- a/language/move-lang/tests/move_check/typing/while_condition_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/while_condition_invalid.exp
@@ -1,112 +1,81 @@
-error: 
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/while_condition_invalid.move:3:16
+  │
+3 │         while (()) ();
+  │                ^^
+  │                │
+  │                Invalid while condition
+  │                Expected: 'bool'
+  │                Given: '()'
 
-   ┌── tests/move_check/typing/while_condition_invalid.move:3:16 ───
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/while_condition_invalid.move:4:16
+  │
+4 │         while ((())) ();
+  │                ^^^^
+  │                │
+  │                Invalid while condition
+  │                Expected: 'bool'
+  │                Given: '()'
+
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/while_condition_invalid.move:5:16
+  │
+5 │         while ({}) ()
+  │                ^^
+  │                │
+  │                Invalid while condition
+  │                Expected: 'bool'
+  │                Given: '()'
+
+error[E04007]: incompatible types
+  ┌─ tests/move_check/typing/while_condition_invalid.move:9:16
+  │
+8 │     fun t1<T: drop>(x: T) {
+  │                        - Given: 'T'
+9 │         while (x) ();
+  │                ^
+  │                │
+  │                Invalid while condition
+  │                Expected: 'bool'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/while_condition_invalid.move:10:16
    │
- 3 │         while (()) ();
-   │                ^^ Invalid while condition
-   ·
- 3 │         while (()) ();
-   │                -- The type: '()'
-   ·
- 3 │         while (()) ();
-   │                -- Is not compatible with: 'bool'
+10 │         while (0) ();
+   │                ^
+   │                │
+   │                Invalid while condition
+   │                Expected: 'bool'
+   │                Given: integer
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/while_condition_invalid.move:11:16
    │
+11 │         while (@0x0) ()
+   │                ^^^^
+   │                │
+   │                Invalid while condition
+   │                Expected: 'bool'
+   │                Given: 'address'
 
-error: 
-
-   ┌── tests/move_check/typing/while_condition_invalid.move:4:16 ───
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/while_condition_invalid.move:15:16
    │
- 4 │         while ((())) ();
-   │                ^^^^ Invalid while condition
-   ·
- 4 │         while ((())) ();
-   │                ---- The type: '()'
-   ·
- 4 │         while ((())) ();
-   │                ---- Is not compatible with: 'bool'
+15 │         while ((false, true)) ();
+   │                ^^^^^^^^^^^^^
+   │                │
+   │                Invalid while condition
+   │                Expected: 'bool'
+   │                Given: '(bool, bool)'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/while_condition_invalid.move:16:16
    │
-
-error: 
-
-   ┌── tests/move_check/typing/while_condition_invalid.move:5:16 ───
-   │
- 5 │         while ({}) ()
-   │                ^^ Invalid while condition
-   ·
- 5 │         while ({}) ()
-   │                -- The type: '()'
-   ·
- 5 │         while ({}) ()
-   │                -- Is not compatible with: 'bool'
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/while_condition_invalid.move:9:16 ───
-   │
- 9 │         while (x) ();
-   │                ^ Invalid while condition
-   ·
- 8 │     fun t1<T: drop>(x: T) {
-   │                        - The type: 'T'
-   ·
- 9 │         while (x) ();
-   │                - Is not compatible with: 'bool'
-   │
-
-error: 
-
-    ┌── tests/move_check/typing/while_condition_invalid.move:10:16 ───
-    │
- 10 │         while (0) ();
-    │                ^ Invalid while condition
-    ·
- 10 │         while (0) ();
-    │                - The type: integer
-    ·
- 10 │         while (0) ();
-    │                - Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/while_condition_invalid.move:11:16 ───
-    │
- 11 │         while (@0x0) ()
-    │                ^^^^ Invalid while condition
-    ·
- 11 │         while (@0x0) ()
-    │                ---- The type: 'address'
-    ·
- 11 │         while (@0x0) ()
-    │                ---- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/while_condition_invalid.move:15:16 ───
-    │
- 15 │         while ((false, true)) ();
-    │                ^^^^^^^^^^^^^ Invalid while condition
-    ·
- 15 │         while ((false, true)) ();
-    │                ------------- The type: '(bool, bool)'
-    ·
- 15 │         while ((false, true)) ();
-    │                ------------- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/while_condition_invalid.move:16:16 ───
-    │
- 16 │         while ((0, false)) ()
-    │                ^^^^^^^^^^ Invalid while condition
-    ·
- 16 │         while ((0, false)) ()
-    │                ---------- The type: '({integer}, bool)'
-    ·
- 16 │         while ((0, false)) ()
-    │                ---------- Is not compatible with: 'bool'
-    │
+16 │         while ((0, false)) ()
+   │                ^^^^^^^^^^
+   │                │
+   │                Invalid while condition
+   │                Expected: 'bool'
+   │                Given: '({integer}, bool)'
 


### PR DESCRIPTION
- Migrated typing join/subtyping errors (core type system diagnostics)

## Motivation

- The new codespan update gives more IDE friendly error messages 

## Test Plan

- Updated tests

## Related PRs

- Continues work from #8588
