### PR TITLE
[move] `Loc::file` is a `move_symbol_pool::Symbol`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,6 +675,7 @@ dependencies = [
  "move-binary-format",
  "move-core-types",
  "move-ir-types",
+ "move-symbol-pool",
  "serde",
 ]
 
@@ -915,6 +916,7 @@ dependencies = [
  "diem-workspace-hack",
  "generate-key",
  "hex",
+ "move-symbol-pool",
  "move-vm-test-utils",
  "num-traits",
  "once_cell",
@@ -1049,6 +1051,7 @@ dependencies = [
  "move-command-line-common",
  "move-core-types",
  "move-ir-types",
+ "move-symbol-pool",
  "serde_json",
  "structopt 0.3.21",
 ]
@@ -4053,6 +4056,7 @@ dependencies = [
  "move-binary-format",
  "move-core-types",
  "move-ir-types",
+ "move-symbol-pool",
 ]
 
 [[package]]
@@ -4068,6 +4072,7 @@ dependencies = [
  "move-binary-format",
  "move-core-types",
  "move-ir-types",
+ "move-symbol-pool",
  "ouroboros",
  "thiserror",
 ]
@@ -4081,6 +4086,7 @@ dependencies = [
  "hex",
  "move-core-types",
  "move-ir-types",
+ "move-symbol-pool",
 ]
 
 [[package]]
@@ -4720,6 +4726,7 @@ dependencies = [
  "move-ir-types",
  "move-lang-test-utils",
  "move-stdlib",
+ "move-symbol-pool",
  "once_cell",
  "petgraph",
  "regex",
@@ -4786,6 +4793,7 @@ dependencies = [
  "move-ir-types",
  "move-lang",
  "move-prover-test-utils",
+ "move-symbol-pool",
  "num 0.4.0",
  "once_cell",
  "regex",

--- a/language/compiler/Cargo.toml
+++ b/language/compiler/Cargo.toml
@@ -19,6 +19,7 @@ diem-workspace-hack = { path = "../../common/workspace-hack" }
 move-ir-types = { path = "../move-ir/types" }
 move-core-types = { path = "../move-core/types" }
 move-binary-format = { path = "../move-binary-format" }
+move-symbol-pool = { path = "../move-symbol-pool" }
 bcs = "0.1.2"
 structopt = "0.3.21"
 serde_json = "1.0.64"

--- a/language/compiler/bytecode-source-map/Cargo.toml
+++ b/language/compiler/bytecode-source-map/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0.38"
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
 move-ir-types = { path = "../../move-ir/types" }
+move-symbol-pool = { path = "../../move-symbol-pool" }
 move-binary-format = { path = "../../move-binary-format" }
 bcs = "0.1.2"
 codespan-reporting = "0.11.1"

--- a/language/compiler/bytecode-source-map/src/utils.rs
+++ b/language/compiler/bytecode-source-map/src/utils.rs
@@ -13,8 +13,9 @@ use codespan_reporting::{
     },
 };
 use move_ir_types::location::Loc;
+use move_symbol_pool::Symbol;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use std::{collections::HashMap, fs::File, io::Read, path::Path};
+use std::{fs::File, io::Read, path::Path};
 
 type FileId = usize;
 
@@ -67,13 +68,9 @@ pub struct OwnedLoc {
 }
 
 pub fn remap_owned_loc_to_loc(m: SourceMap<OwnedLoc>) -> SourceMap<Loc> {
-    let mut table: HashMap<String, &'static str> = HashMap::new();
     let mut f = |owned| {
         let OwnedLoc { file, start, end } = owned;
-        let file = *table
-            .entry(file.clone())
-            .or_insert_with(|| Box::leak(Box::new(file)));
-        Loc::new(file, start, end)
+        Loc::new(Symbol::from(file), start, end)
     };
     m.remap_locations(&mut f)
 }

--- a/language/compiler/ir-to-bytecode/Cargo.toml
+++ b/language/compiler/ir-to-bytecode/Cargo.toml
@@ -16,6 +16,7 @@ diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
 move-ir-types = { path = "../../move-ir/types" }
 move-binary-format = { path = "../../move-binary-format" }
+move-symbol-pool = { path = "../../move-symbol-pool" }
 bytecode-source-map = { path = "../bytecode-source-map" }
 log = "0.4.14"
 codespan-reporting = "0.11.1"

--- a/language/compiler/ir-to-bytecode/src/parser.rs
+++ b/language/compiler/ir-to-bytecode/src/parser.rs
@@ -14,6 +14,7 @@ use codespan_reporting::{
 use ir_to_bytecode_syntax::syntax::{self, ParseError};
 use move_core_types::account_address::AccountAddress;
 use move_ir_types::{ast, location::*};
+use move_symbol_pool::Symbol;
 
 /// Determine if a character is an allowed eye-visible (printable) character.
 ///
@@ -84,7 +85,7 @@ fn strip_comments_and_verify(string: &str) -> Result<String> {
 
 /// Given the raw input of a file, creates a `ScriptOrModule` enum
 /// Fails with `Err(_)` if the text cannot be parsed`
-pub fn parse_script_or_module(file_name: &str, s: &str) -> Result<ast::ScriptOrModule> {
+pub fn parse_script_or_module(file_name: Symbol, s: &str) -> Result<ast::ScriptOrModule> {
     let stripped_string = &strip_comments_and_verify(s)?;
     syntax::parse_script_or_module_string(file_name, stripped_string)
         .or_else(|e| handle_error(e, s))
@@ -92,7 +93,7 @@ pub fn parse_script_or_module(file_name: &str, s: &str) -> Result<ast::ScriptOrM
 
 /// Given the raw input of a file, creates a `Script` struct
 /// Fails with `Err(_)` if the text cannot be parsed
-pub fn parse_script(file_name: &str, script_str: &str) -> Result<ast::Script> {
+pub fn parse_script(file_name: Symbol, script_str: &str) -> Result<ast::Script> {
     let stripped_string = &strip_comments_and_verify(script_str)?;
     syntax::parse_script_string(file_name, stripped_string)
         .or_else(|e| handle_error(e, stripped_string))
@@ -100,7 +101,7 @@ pub fn parse_script(file_name: &str, script_str: &str) -> Result<ast::Script> {
 
 /// Given the raw input of a file, creates a single `ModuleDefinition` struct
 /// Fails with `Err(_)` if the text cannot be parsed
-pub fn parse_module(file_name: &str, modules_str: &str) -> Result<ast::ModuleDefinition> {
+pub fn parse_module(file_name: Symbol, modules_str: &str) -> Result<ast::ModuleDefinition> {
     let stripped_string = &strip_comments_and_verify(modules_str)?;
     syntax::parse_module_string(file_name, stripped_string)
         .or_else(|e| handle_error(e, stripped_string))
@@ -109,7 +110,7 @@ pub fn parse_module(file_name: &str, modules_str: &str) -> Result<ast::ModuleDef
 /// Given the raw input of a file, creates a single `Cmd_` struct
 /// Fails with `Err(_)` if the text cannot be parsed
 pub fn parse_cmd_(
-    file_name: &str,
+    file_name: Symbol,
     cmd_str: &str,
     _sender_address: AccountAddress,
 ) -> Result<ast::Cmd_> {

--- a/language/compiler/ir-to-bytecode/syntax/Cargo.toml
+++ b/language/compiler/ir-to-bytecode/syntax/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0.38"
 hex = "0.4.3"
 move-ir-types = { path = "../../../move-ir/types" }
 move-core-types = { path = "../../../move-core/types" }
+move-symbol-pool = { path = "../../../move-symbol-pool" }
 diem-workspace-hack = { path = "../../../../common/workspace-hack" }
 
 [features]

--- a/language/compiler/ir-to-bytecode/syntax/src/lexer.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/lexer.rs
@@ -3,6 +3,7 @@
 
 use crate::syntax::ParseError;
 use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Tok {
@@ -122,7 +123,7 @@ impl Tok {
 
 pub struct Lexer<'input> {
     pub spec_mode: bool,
-    file: &'static str,
+    file: Symbol,
     text: &'input str,
     prev_end: usize,
     cur_start: usize,
@@ -131,7 +132,7 @@ pub struct Lexer<'input> {
 }
 
 impl<'input> Lexer<'input> {
-    pub fn new(file: &'static str, s: &'input str) -> Lexer<'input> {
+    pub fn new(file: Symbol, s: &'input str) -> Lexer<'input> {
         Lexer {
             spec_mode: false, // read tokens without trailing punctuation during specs.
             file,
@@ -151,7 +152,7 @@ impl<'input> Lexer<'input> {
         &self.text[self.cur_start..self.cur_end]
     }
 
-    pub fn file_name(&self) -> &'static str {
+    pub fn file_name(&self) -> Symbol {
         self.file
     }
 

--- a/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
@@ -10,6 +10,7 @@ use move_core_types::{
     identifier::{IdentStr, Identifier},
 };
 use move_ir_types::{ast::*, location::*, spec_language_ast::*};
+use move_symbol_pool::Symbol;
 
 // FIXME: The following simplified version of ParseError copied from
 // lalrpop-util should be replaced.
@@ -40,7 +41,7 @@ where
     }
 }
 
-fn make_loc(file: &'static str, start: usize, end: usize) -> Loc {
+fn make_loc(file: Symbol, start: usize, end: usize) -> Loc {
     Loc::new(file, start as u32, end as u32)
 }
 
@@ -53,7 +54,7 @@ fn current_token_loc(tokens: &Lexer) -> Loc {
     )
 }
 
-fn spanned<T>(file: &'static str, start: usize, end: usize, value: T) -> Spanned<T> {
+fn spanned<T>(file: Symbol, start: usize, end: usize, value: T) -> Spanned<T> {
     Spanned {
         loc: make_loc(file, start, end),
         value,
@@ -2094,40 +2095,35 @@ fn parse_script_or_module(
     }
 }
 
-pub fn parse_cmd_string(file: &str, input: &str) -> Result<Cmd_, ParseError<Loc, anyhow::Error>> {
-    let mut tokens = Lexer::new(leak_str(file), input);
+pub fn parse_cmd_string(file: Symbol, input: &str) -> Result<Cmd_, ParseError<Loc, anyhow::Error>> {
+    let mut tokens = Lexer::new(file, input);
     tokens.advance()?;
     parse_cmd_(&mut tokens)
 }
 
 pub fn parse_module_string(
-    file: &str,
+    file: Symbol,
     input: &str,
 ) -> Result<ModuleDefinition, ParseError<Loc, anyhow::Error>> {
-    let mut tokens = Lexer::new(leak_str(file), input);
+    let mut tokens = Lexer::new(file, input);
     tokens.advance()?;
     parse_module(&mut tokens)
 }
 
 pub fn parse_script_string(
-    file: &str,
+    file: Symbol,
     input: &str,
 ) -> Result<Script, ParseError<Loc, anyhow::Error>> {
-    let mut tokens = Lexer::new(leak_str(file), input);
+    let mut tokens = Lexer::new(file, input);
     tokens.advance()?;
     parse_script(&mut tokens)
 }
 
 pub fn parse_script_or_module_string(
-    file: &str,
+    file: Symbol,
     input: &str,
 ) -> Result<ScriptOrModule, ParseError<Loc, anyhow::Error>> {
-    let mut tokens = Lexer::new(leak_str(file), input);
+    let mut tokens = Lexer::new(file, input);
     tokens.advance()?;
     parse_script_or_module(&mut tokens)
-}
-
-// TODO replace with some sort of intern table
-fn leak_str(s: &str) -> &'static str {
-    Box::leak(Box::new(s.to_owned()))
 }

--- a/language/compiler/src/main.rs
+++ b/language/compiler/src/main.rs
@@ -12,6 +12,7 @@ use move_command_line_common::files::{
     MOVE_COMPILED_EXTENSION, MOVE_IR_EXTENSION, SOURCE_MAP_EXTENSION,
 };
 use move_core_types::account_address::AccountAddress;
+use move_symbol_pool::Symbol;
 use std::{
     fs,
     io::Write,
@@ -93,7 +94,7 @@ fn main() {
         std::process::exit(1);
     }
 
-    let file_name = args.source_path.as_path().as_os_str().to_str().unwrap();
+    let file_name = Symbol::from(args.source_path.as_path().as_os_str().to_str().unwrap());
 
     if args.list_dependencies {
         let source = fs::read_to_string(args.source_path.clone()).expect("Unable to read file");

--- a/language/compiler/src/unit_tests/testutils.rs
+++ b/language/compiler/src/unit_tests/testutils.rs
@@ -13,6 +13,7 @@ use move_binary_format::{
     file_format::{CompiledModule, CompiledScript},
 };
 use move_core_types::account_address::AccountAddress;
+use move_symbol_pool::Symbol;
 
 #[allow(unused_macros)]
 macro_rules! instr_count {
@@ -30,7 +31,7 @@ fn compile_script_string_impl(
     code: &str,
     deps: Vec<CompiledModule>,
 ) -> Result<(CompiledScript, Option<VMError>)> {
-    let parsed_script = parse_script("file_name", code).unwrap();
+    let parsed_script = parse_script(Symbol::from("file_name"), code).unwrap();
     let script = compile_script(None, parsed_script, &deps)?.0;
 
     let mut serialized_script = Vec::<u8>::new();
@@ -81,7 +82,7 @@ fn compile_module_string_impl(
     deps: Vec<CompiledModule>,
 ) -> Result<(CompiledModule, Option<VMError>)> {
     let address = AccountAddress::ZERO;
-    let module = parse_module("file_name", code).unwrap();
+    let module = parse_module(Symbol::from("file_name"), code).unwrap();
     let compiled_module = compile_module(address, module, &deps)?.0;
 
     let mut serialized_module = Vec::<u8>::new();

--- a/language/compiler/src/util.rs
+++ b/language/compiler/src/util.rs
@@ -7,6 +7,7 @@ use ir_to_bytecode::{compiler::compile_module, parser::parse_module};
 use move_binary_format::file_format::CompiledModule;
 use move_core_types::account_address::AccountAddress;
 use move_ir_types::location::Loc;
+use move_symbol_pool::Symbol;
 use std::{fs, path::Path};
 
 pub fn do_compile_module(
@@ -17,7 +18,7 @@ pub fn do_compile_module(
     let source = fs::read_to_string(source_path)
         .with_context(|| format!("Unable to read file: {:?}", source_path))
         .unwrap();
-    let file = source_path.as_os_str().to_str().unwrap();
+    let file = Symbol::from(source_path.as_os_str().to_str().unwrap());
     let parsed_module = parse_module(file, &source).unwrap();
     compile_module(address, parsed_module, dependencies).unwrap()
 }

--- a/language/ir-testsuite/Cargo.toml
+++ b/language/ir-testsuite/Cargo.toml
@@ -21,6 +21,7 @@ move-ir-types = { path = "../move-ir/types" }
 diem-framework-releases = { path = "../diem-framework/releases" }
 move-binary-format = { path = "../move-binary-format" }
 move-core-types = { path = "../move-core/types" }
+move-symbol-pool = { path = "../move-symbol-pool" }
 
 
 [[test]]

--- a/language/ir-testsuite/tests/testsuite.rs
+++ b/language/ir-testsuite/tests/testsuite.rs
@@ -14,6 +14,7 @@ use ir_to_bytecode::{
 use move_binary_format::CompiledModule;
 use move_core_types::language_storage::ModuleId;
 use move_ir_types::ast;
+use move_symbol_pool::Symbol;
 use std::{collections::HashMap, path::Path};
 
 struct IRCompiler {
@@ -38,21 +39,23 @@ impl Compiler for IRCompiler {
         address: AccountAddress,
         input: &str,
     ) -> Result<ScriptOrModule> {
-        Ok(match parse_script_or_module("unused_file_name", input)? {
-            ast::ScriptOrModule::Script(parsed_script) => {
-                log(format!("{}", &parsed_script));
-                ScriptOrModule::Script(
-                    None,
-                    compile_script(Some(address), parsed_script, self.deps.values())?.0,
-                )
-            }
-            ast::ScriptOrModule::Module(parsed_module) => {
-                log(format!("{}", &parsed_module));
-                let module = compile_module(address, parsed_module, self.deps.values())?.0;
-                self.deps.insert(module.self_id(), module.clone());
-                ScriptOrModule::Module(module)
-            }
-        })
+        Ok(
+            match parse_script_or_module(Symbol::from("unused_file_name"), input)? {
+                ast::ScriptOrModule::Script(parsed_script) => {
+                    log(format!("{}", &parsed_script));
+                    ScriptOrModule::Script(
+                        None,
+                        compile_script(Some(address), parsed_script, self.deps.values())?.0,
+                    )
+                }
+                ast::ScriptOrModule::Module(parsed_module) => {
+                    log(format!("{}", &parsed_module));
+                    let module = compile_module(address, parsed_module, self.deps.values())?.0;
+                    self.deps.insert(module.self_id(), module.clone());
+                    ScriptOrModule::Module(module)
+                }
+            },
+        )
     }
 
     fn use_compiled_genesis(&self) -> bool {

--- a/language/move-ir/types/src/location.rs
+++ b/language/move-ir/types/src/location.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use move_symbol_pool::Symbol;
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::{
     cmp::Ordering,
@@ -25,7 +27,7 @@ pub type ByteIndex = u32;
 /// byte vector
 pub struct Loc {
     /// The file the location points to
-    file: &'static str,
+    file: Symbol,
     /// The start byte index into file
     start: ByteIndex,
     /// The end byte index into file
@@ -33,11 +35,11 @@ pub struct Loc {
 }
 
 impl Loc {
-    pub fn new(file: &'static str, start: ByteIndex, end: ByteIndex) -> Loc {
+    pub fn new(file: Symbol, start: ByteIndex, end: ByteIndex) -> Loc {
         Loc { file, start, end }
     }
 
-    pub fn file(self) -> &'static str {
+    pub fn file(self) -> Symbol {
         self.file
     }
 
@@ -65,7 +67,7 @@ impl PartialOrd for Loc {
 
 impl Ord for Loc {
     fn cmp(&self, other: &Loc) -> Ordering {
-        let file_ord = self.file.cmp(other.file);
+        let file_ord = self.file.cmp(&other.file);
         if file_ord != Ordering::Equal {
             return file_ord;
         }
@@ -83,6 +85,8 @@ impl Ord for Loc {
 // Spanned
 //**************************************************************************************************
 
+static NO_LOC_FILE: Lazy<Symbol> = Lazy::new(|| Symbol::from(""));
+
 #[derive(Copy, Clone)]
 pub struct Spanned<T> {
     pub loc: Loc,
@@ -94,11 +98,10 @@ impl<T> Spanned<T> {
         Spanned { loc, value }
     }
 
-    const NO_LOC_FILE: &'static str = "";
     pub fn unsafe_no_loc(value: T) -> Spanned<T> {
         Spanned {
             value,
-            loc: Loc::new(Self::NO_LOC_FILE, 0, 0),
+            loc: Loc::new(*NO_LOC_FILE, 0, 0),
         }
     }
 }

--- a/language/move-lang/Cargo.toml
+++ b/language/move-lang/Cargo.toml
@@ -21,6 +21,7 @@ once_cell = "1.7.2"
 move-binary-format = { path = "../move-binary-format" }
 move-core-types = { path = "../move-core/types" }
 move-bytecode-verifier = { path = "../bytecode-verifier", package = "bytecode-verifier" }
+move-symbol-pool = { path = "../move-symbol-pool" }
 diem-workspace-hack = { path = "../../common/workspace-hack" }
 move-ir-types = {path = "../move-ir/types" }
 ir-to-bytecode = {path = "../compiler/ir-to-bytecode" }

--- a/language/move-lang/functional-tests/tests/functional_testsuite.rs
+++ b/language/move-lang/functional-tests/tests/functional_testsuite.rs
@@ -81,7 +81,7 @@ impl<'a> Compiler for MoveSourceCompiler<'a> {
                 for (file_name, text) in &self.pre_compiled_deps.files {
                     // TODO This is bad. Rethink this when errors are redone
                     if !files.contains_key(file_name) {
-                        files.insert(&**file_name, text.clone());
+                        files.insert(*file_name, text.clone());
                     }
                 }
 

--- a/language/move-lang/src/diagnostics/mod.rs
+++ b/language/move-lang/src/diagnostics/mod.rs
@@ -18,6 +18,7 @@ use codespan_reporting::{
 };
 use move_command_line_common::env::read_env_var;
 use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     iter::FromIterator,
@@ -30,8 +31,8 @@ use std::{
 
 pub type FileId = usize;
 
-pub type FilesSourceText = HashMap<&'static str, String>;
-type FileMapping = HashMap<&'static str, FileId>;
+pub type FilesSourceText = HashMap<Symbol, String>;
+type FileMapping = HashMap<Symbol, FileId>;
 
 #[derive(PartialEq, Eq, Clone, Debug, Hash)]
 pub struct Diagnostic {
@@ -100,7 +101,7 @@ fn output_diagnostics<W: WriteColor>(
 
 fn render_diagnostics(
     writer: &mut dyn WriteColor,
-    files: &SimpleFiles<&'static str, &str>,
+    files: &SimpleFiles<Symbol, &str>,
     file_mapping: &FileMapping,
     mut diags: Diagnostics,
 ) {
@@ -122,7 +123,7 @@ fn render_diagnostics(
 
 fn convert_loc(file_mapping: &FileMapping, loc: Loc) -> (FileId, Range<usize>) {
     let fname = loc.file();
-    let id = *file_mapping.get(fname).unwrap();
+    let id = *file_mapping.get(&fname).unwrap();
     let range = loc.usize_range();
     (id, range)
 }

--- a/language/move-lang/src/expansion/byte_string.rs
+++ b/language/move-lang/src/expansion/byte_string.rs
@@ -3,16 +3,16 @@
 
 use crate::{diag, diagnostics::Diagnostics, parser::syntax::make_loc};
 use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
 
-#[derive(Default)]
 struct Context {
-    filename: &'static str,
+    filename: Symbol,
     start_offset: usize,
     diags: Diagnostics,
 }
 
 impl Context {
-    fn new(filename: &'static str, start_offset: usize) -> Self {
+    fn new(filename: Symbol, start_offset: usize) -> Self {
         Self {
             filename,
             start_offset,

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -3,6 +3,7 @@
 
 use crate::shared::{ast_debug::*, AddressBytes, Identifier, Name, TName, ADDRESS_LENGTH};
 use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
 use std::{fmt, hash::Hash};
 
 macro_rules! new_name {
@@ -697,7 +698,7 @@ impl LeadingNameAccess_ {
 }
 
 impl Definition {
-    pub fn file(&self) -> &'static str {
+    pub fn file(&self) -> Symbol {
         match self {
             Definition::Module(m) => m.loc.file(),
             Definition::Address(a) => a.loc.file(),

--- a/language/move-lang/src/parser/comments.rs
+++ b/language/move-lang/src/parser/comments.rs
@@ -3,10 +3,11 @@
 
 use crate::{diag, diagnostics::Diagnostics};
 use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
 use std::{collections::BTreeMap, iter::Peekable, str::Chars};
 
 /// Types to represent comments.
-pub type CommentMap = BTreeMap<&'static str, MatchedFileCommentMap>;
+pub type CommentMap = BTreeMap<Symbol, MatchedFileCommentMap>;
 pub type MatchedFileCommentMap = BTreeMap<u32, String>;
 pub type FileCommentMap = BTreeMap<(u32, u32), String>;
 
@@ -38,7 +39,7 @@ pub fn is_permitted_char(c: char) -> bool {
     is_permitted_printable_char(c) || is_permitted_newline_char(c)
 }
 
-fn verify_string(fname: &'static str, string: &str) -> Result<(), Diagnostics> {
+fn verify_string(fname: Symbol, string: &str) -> Result<(), Diagnostics> {
     match string
         .chars()
         .enumerate()
@@ -70,10 +71,7 @@ fn verify_string(fname: &'static str, string: &str) -> Result<(), Diagnostics> {
 /// (`/// .. <newline>` and `/** .. */`) will be not included in extracted comment string. The
 /// span in the returned map, however, covers the whole region of the comment, including the
 /// delimiters.
-fn strip_comments(
-    fname: &'static str,
-    input: &str,
-) -> Result<(String, FileCommentMap), Diagnostics> {
+fn strip_comments(fname: Symbol, input: &str) -> Result<(String, FileCommentMap), Diagnostics> {
     const SLASH: char = '/';
     const SPACE: char = ' ';
     const STAR: char = '*';
@@ -234,7 +232,7 @@ fn strip_comments(
 // We restrict strings to only ascii visual characters (0x20 <= c <= 0x7E) or a permitted newline
 // character--\n--or a tab--\t.
 pub(crate) fn strip_comments_and_verify(
-    fname: &'static str,
+    fname: Symbol,
     string: &str,
 ) -> Result<(String, FileCommentMap), Diagnostics> {
     verify_string(fname, string)?;

--- a/language/move-lang/src/parser/lexer.rs
+++ b/language/move-lang/src/parser/lexer.rs
@@ -8,6 +8,7 @@ use crate::{
     FileCommentMap, MatchedFileCommentMap,
 };
 use move_ir_types::location::Loc;
+use move_symbol_pool::Symbol;
 use std::fmt;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -161,7 +162,7 @@ impl fmt::Display for Tok {
 
 pub struct Lexer<'input> {
     text: &'input str,
-    file: &'static str,
+    file: Symbol,
     doc_comments: FileCommentMap,
     matched_doc_comments: MatchedFileCommentMap,
     prev_end: usize,
@@ -171,11 +172,7 @@ pub struct Lexer<'input> {
 }
 
 impl<'input> Lexer<'input> {
-    pub fn new(
-        text: &'input str,
-        file: &'static str,
-        doc_comments: FileCommentMap,
-    ) -> Lexer<'input> {
+    pub fn new(text: &'input str, file: Symbol, doc_comments: FileCommentMap) -> Lexer<'input> {
         Lexer {
             text,
             file,
@@ -196,7 +193,7 @@ impl<'input> Lexer<'input> {
         &self.text[self.cur_start..self.cur_end]
     }
 
-    pub fn file_name(&self) -> &'static str {
+    pub fn file_name(&self) -> Symbol {
         self.file
     }
 
@@ -296,11 +293,7 @@ impl<'input> Lexer<'input> {
 }
 
 // Find the next token and its length without changing the state of the lexer.
-fn find_token(
-    file: &'static str,
-    text: &str,
-    start_offset: usize,
-) -> Result<(Tok, usize), Diagnostic> {
+fn find_token(file: Symbol, text: &str, start_offset: usize) -> Result<(Tok, usize), Diagnostic> {
     let c: char = match text.chars().next() {
         Some(next_char) => next_char,
         None => {

--- a/language/move-lang/src/parser/mod.rs
+++ b/language/move-lang/src/parser/mod.rs
@@ -18,6 +18,7 @@ use crate::{
 use anyhow::anyhow;
 use comments::*;
 use move_command_line_common::files::find_move_filenames;
+use move_symbol_pool::Symbol;
 use std::{
     collections::{BTreeSet, HashMap},
     fs::File,
@@ -33,13 +34,13 @@ pub(crate) fn parse_program(
     Result<(parser::ast::Program, CommentMap), Diagnostics>,
 )> {
     let targets = find_move_filenames(targets, true)?
-        .iter()
-        .map(|s| leak_str(s))
-        .collect::<Vec<&'static str>>();
+        .into_iter()
+        .map(Symbol::from)
+        .collect::<Vec<Symbol>>();
     let mut deps = find_move_filenames(deps, true)?
-        .iter()
-        .map(|s| leak_str(s))
-        .collect::<Vec<&'static str>>();
+        .into_iter()
+        .map(Symbol::from)
+        .collect::<Vec<Symbol>>();
     ensure_targets_deps_dont_intersect(compilation_env, &targets, &mut deps)?;
     let mut files: FilesSourceText = HashMap::new();
     let mut source_definitions = Vec::new();
@@ -75,14 +76,15 @@ pub(crate) fn parse_program(
 
 fn ensure_targets_deps_dont_intersect(
     compilation_env: &CompilationEnv,
-    targets: &[&'static str],
-    deps: &mut Vec<&'static str>,
+    targets: &[Symbol],
+    deps: &mut Vec<Symbol>,
 ) -> anyhow::Result<()> {
     /// Canonicalize a file path.
-    fn canonicalize(path: &str) -> String {
-        match std::fs::canonicalize(path) {
+    fn canonicalize(path: &Symbol) -> String {
+        let p = path.as_str();
+        match std::fs::canonicalize(p) {
             Ok(s) => s.to_string_lossy().to_string(),
-            Err(_) => path.to_owned(),
+            Err(_) => p.to_owned(),
         }
     }
     let target_set = targets
@@ -112,21 +114,16 @@ fn ensure_targets_deps_dont_intersect(
     ))
 }
 
-// TODO replace with some sort of intern table
-fn leak_str(s: &str) -> &'static str {
-    Box::leak(Box::new(s.to_owned()))
-}
-
 fn parse_file(
     files: &mut FilesSourceText,
-    fname: &'static str,
+    fname: Symbol,
 ) -> anyhow::Result<(
     Vec<parser::ast::Definition>,
     MatchedFileCommentMap,
     Diagnostics,
 )> {
     let mut diags = Diagnostics::new();
-    let mut f = File::open(fname)
+    let mut f = File::open(fname.as_str())
         .map_err(|err| std::io::Error::new(err.kind(), format!("{}: {}", err, fname)))?;
     let mut source_buffer = String::new();
     f.read_to_string(&mut source_buffer)?;

--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
 
 use crate::{
     diag,
@@ -58,7 +59,7 @@ fn unexpected_token_error_(
 // Miscellaneous Utilities
 //**************************************************************************************************
 
-pub fn make_loc(file: &'static str, start: usize, end: usize) -> Loc {
+pub fn make_loc(file: Symbol, start: usize, end: usize) -> Loc {
     Loc::new(file, start as u32, end as u32)
 }
 
@@ -71,7 +72,7 @@ fn current_token_loc(tokens: &Lexer) -> Loc {
     )
 }
 
-fn spanned<T>(file: &'static str, start: usize, end: usize, value: T) -> Spanned<T> {
+fn spanned<T>(file: Symbol, start: usize, end: usize, value: T) -> Spanned<T> {
     Spanned {
         loc: make_loc(file, start, end),
         value,
@@ -2840,7 +2841,7 @@ fn parse_file(tokens: &mut Lexer) -> Result<Vec<Definition>, Diagnostic> {
 /// result as either a pair of FileDefinition and doc comments or some Diagnostics. The `file` name
 /// is used to identify source locations in error messages.
 pub fn parse_file_string(
-    file: &'static str,
+    file: Symbol,
     input: &str,
     comment_map: FileCommentMap,
 ) -> Result<(Vec<Definition>, MatchedFileCommentMap), Diagnostics> {

--- a/language/move-model/Cargo.toml
+++ b/language/move-model/Cargo.toml
@@ -17,6 +17,7 @@ move-ir-types = { path = "../move-ir/types" }
 move-core-types = { path = "../move-core/types" }
 disassembler = { path = "../tools/disassembler" }
 move-command-line-common = { path = "../move-command-line-common" }
+move-symbol-pool = { path = "../move-symbol-pool" }
 
 # external dependencies
 codespan = "0.11.1"

--- a/language/move-model/src/lib.rs
+++ b/language/move-model/src/lib.rs
@@ -82,7 +82,7 @@ pub fn run_model_builder_with_compilation_flags(
             // Add source files so that the env knows how to translate locations of parse errors
             for fname in files.keys().sorted() {
                 let fsrc = &files[fname];
-                env.add_source(fname, fsrc, /* is_dep */ false);
+                env.add_source(fname.as_str(), fsrc, /* is_dep */ false);
             }
             add_move_lang_diagnostics(&mut env, diags);
             return Ok(env);
@@ -98,7 +98,7 @@ pub fn run_model_builder_with_compilation_flags(
         .collect();
     for fname in files.keys().sorted() {
         let fsrc = &files[fname];
-        env.add_source(fname, fsrc, dep_files.contains(fname));
+        env.add_source(fname.as_str(), fsrc, dep_files.contains(fname));
     }
 
     // Add any documentation comments found by the Move compiler to the env.
@@ -137,7 +137,7 @@ pub fn run_model_builder_with_compilation_flags(
     let mut visited_modules = BTreeSet::new();
     for (_, mident, mdef) in &expansion_ast.modules {
         let src_file = mdef.loc.file();
-        if !dep_files.contains(src_file) {
+        if !dep_files.contains(&src_file) {
             collect_related_modules_recursive(
                 mident,
                 &expansion_ast.modules,
@@ -148,7 +148,7 @@ pub fn run_model_builder_with_compilation_flags(
     }
     for sdef in expansion_ast.scripts.values() {
         let src_file = sdef.loc.file();
-        if !dep_files.contains(src_file) {
+        if !dep_files.contains(&src_file) {
             for (_, mident, _neighbor) in &sdef.immediate_neighbors {
                 collect_related_modules_recursive(
                     mident,

--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -54,6 +54,7 @@ use move_binary_format::{
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, language_storage, value::MoveValue,
 };
+use move_symbol_pool::Symbol as StringSymbol;
 
 use crate::{
     ast::{
@@ -517,7 +518,7 @@ impl GlobalEnv {
             )
         };
         let unknown_loc = fake_loc("<unknown>");
-        let unknown_move_ir_loc = MoveIrLoc::new("<unknown>", 0, 0);
+        let unknown_move_ir_loc = MoveIrLoc::new(StringSymbol::from("<unknown>"), 0, 0);
         let internal_loc = fake_loc("<internal>");
         GlobalEnv {
             source_files,
@@ -747,8 +748,8 @@ impl GlobalEnv {
     }
 
     /// Returns the file id for a file name, if defined.
-    pub fn get_file_id(&self, fname: &str) -> Option<FileId> {
-        self.file_name_map.get(fname).cloned()
+    pub fn get_file_id(&self, fname: StringSymbol) -> Option<FileId> {
+        self.file_name_map.get(fname.as_str()).cloned()
     }
 
     /// Maps a FileId to an index which can be mapped back to a FileId.

--- a/testsuite/cli/Cargo.toml
+++ b/testsuite/cli/Cargo.toml
@@ -41,6 +41,7 @@ diem-resource-viewer = { path = "../../language/tools/diem-resource-viewer" }
 diem-framework = { path = "../../language/diem-framework" }
 diem-framework-releases = { path = "../../language/diem-framework/releases" }
 diem-transaction-builder = { path = "../../sdk/transaction-builder" }
+move-symbol-pool = { path = "../../language/move-symbol-pool" }
 move-vm-test-utils = { path = "../../language/move-vm/test-utils" }
 compiler = { path = "../../language/compiler" }
 

--- a/testsuite/diem-fuzzer/lsan_suppressions.txt
+++ b/testsuite/diem-fuzzer/lsan_suppressions.txt
@@ -1,4 +1,3 @@
 leak:lazy_static
 leak:backtrace
-leak:libc
 leak:diem_mempool::tests::mocks::MockSharedMempool


### PR DESCRIPTION
Use the newly added `move_symbol_pool` module from #8782 to represent file names in Move locations. This allows us to eliminate the use of "leak string" functions, and re-enable libc leak detection in LeakSanitizer.