### PR TITLE
[decoupled-execution] Integration Part 1 - Adapt safety-rules

### DIFF
--- a/config/src/config/safety_rules_config.rs
+++ b/config/src/config/safety_rules_config.rs
@@ -26,6 +26,7 @@ pub struct SafetyRulesConfig {
     // Read/Write/Connect networking operation timeout in milliseconds.
     pub network_timeout_ms: u64,
     pub enable_cached_safety_data: bool,
+    pub decoupled_execution: bool,
 }
 
 impl Default for SafetyRulesConfig {
@@ -40,6 +41,7 @@ impl Default for SafetyRulesConfig {
             // Default value of 30 seconds for a timeout
             network_timeout_ms: 30_000,
             enable_cached_safety_data: true,
+            decoupled_execution: false,
         }
     }
 }

--- a/consensus/safety-rules/benches/safety_rules.rs
+++ b/consensus/safety-rules/benches/safety_rules.rs
@@ -66,7 +66,7 @@ fn in_memory(n: u64) {
         waypoint,
         true,
     );
-    let safety_rules_manager = SafetyRulesManager::new_local(storage, false, false);
+    let safety_rules_manager = SafetyRulesManager::new_local(storage, false, false, false);
     lsr(safety_rules_manager.client(), signer, n);
 }
 
@@ -82,7 +82,7 @@ fn on_disk(n: u64) {
         waypoint,
         true,
     );
-    let safety_rules_manager = SafetyRulesManager::new_local(storage, false, false);
+    let safety_rules_manager = SafetyRulesManager::new_local(storage, false, false, false);
     lsr(safety_rules_manager.client(), signer, n);
 }
 
@@ -98,7 +98,7 @@ fn serializer(n: u64) {
         waypoint,
         true,
     );
-    let safety_rules_manager = SafetyRulesManager::new_serializer(storage, false, false);
+    let safety_rules_manager = SafetyRulesManager::new_serializer(storage, false, false, false);
     lsr(safety_rules_manager.client(), signer, n);
 }
 
@@ -116,7 +116,8 @@ fn thread(n: u64) {
     );
     // Test value, in milliseconds
     let timeout_ms = 5_000;
-    let safety_rules_manager = SafetyRulesManager::new_thread(storage, false, false, timeout_ms);
+    let safety_rules_manager =
+        SafetyRulesManager::new_thread(storage, false, false, timeout_ms, false);
     lsr(safety_rules_manager.client(), signer, n);
 }
 
@@ -137,7 +138,8 @@ fn vault(n: u64) {
     );
     // Test value in milliseconds.
     let timeout_ms = 5_000;
-    let safety_rules_manager = SafetyRulesManager::new_thread(storage, false, false, timeout_ms);
+    let safety_rules_manager =
+        SafetyRulesManager::new_thread(storage, false, false, timeout_ms, false);
     lsr(safety_rules_manager.client(), signer, n);
 }
 

--- a/consensus/safety-rules/src/process.rs
+++ b/consensus/safety-rules/src/process.rs
@@ -33,6 +33,7 @@ impl Process {
                 verify_vote_proposal_signature,
                 export_consensus_key,
                 network_timeout: config.network_timeout_ms,
+                decoupled_execution: config.decoupled_execution,
             }),
         }
     }
@@ -45,6 +46,7 @@ impl Process {
             data.verify_vote_proposal_signature,
             data.export_consensus_key,
             data.network_timeout,
+            data.decoupled_execution,
         );
     }
 }
@@ -56,6 +58,7 @@ struct ProcessData {
     export_consensus_key: bool,
     // Timeout in Seconds for network operations
     network_timeout: u64,
+    decoupled_execution: bool,
 }
 
 pub struct ProcessService {

--- a/consensus/safety-rules/src/remote_service.rs
+++ b/consensus/safety-rules/src/remote_service.rs
@@ -33,11 +33,13 @@ pub fn execute(
     verify_vote_proposal_signature: bool,
     export_consensus_key: bool,
     network_timeout_ms: u64,
+    decoupled_execution: bool,
 ) {
     let mut safety_rules = SafetyRules::new(
         storage,
         verify_vote_proposal_signature,
         export_consensus_key,
+        decoupled_execution,
     );
     if let Err(e) = safety_rules.consensus_state() {
         warn!("Unable to print consensus state: {}", e);

--- a/consensus/safety-rules/src/safety_rules_manager.rs
+++ b/consensus/safety-rules/src/safety_rules_manager.rs
@@ -74,17 +74,20 @@ impl SafetyRulesManager {
                 storage,
                 verify_vote_proposal_signature,
                 export_consensus_key,
+                config.decoupled_execution,
             ),
             SafetyRulesService::Serializer => Self::new_serializer(
                 storage,
                 verify_vote_proposal_signature,
                 export_consensus_key,
+                config.decoupled_execution,
             ),
             SafetyRulesService::Thread => Self::new_thread(
                 storage,
                 verify_vote_proposal_signature,
                 export_consensus_key,
                 config.network_timeout_ms,
+                config.decoupled_execution,
             ),
             _ => panic!("Unimplemented SafetyRulesService: {:?}", config.service),
         }
@@ -94,11 +97,13 @@ impl SafetyRulesManager {
         storage: PersistentSafetyStorage,
         verify_vote_proposal_signature: bool,
         export_consensus_key: bool,
+        decoupled_execution: bool,
     ) -> Self {
         let safety_rules = SafetyRules::new(
             storage,
             verify_vote_proposal_signature,
             export_consensus_key,
+            decoupled_execution,
         );
         Self {
             internal_safety_rules: SafetyRulesWrapper::Local(Arc::new(RwLock::new(safety_rules))),
@@ -116,11 +121,13 @@ impl SafetyRulesManager {
         storage: PersistentSafetyStorage,
         verify_vote_proposal_signature: bool,
         export_consensus_key: bool,
+        decoupled_execution: bool,
     ) -> Self {
         let safety_rules = SafetyRules::new(
             storage,
             verify_vote_proposal_signature,
             export_consensus_key,
+            decoupled_execution,
         );
         let serializer_service = SerializerService::new(safety_rules);
         Self {
@@ -135,12 +142,14 @@ impl SafetyRulesManager {
         verify_vote_proposal_signature: bool,
         export_consensus_key: bool,
         timeout_ms: u64,
+        decoupled_execution: bool,
     ) -> Self {
         let thread = ThreadService::new(
             storage,
             verify_vote_proposal_signature,
             export_consensus_key,
             timeout_ms,
+            decoupled_execution,
         );
         Self {
             internal_safety_rules: SafetyRulesWrapper::Thread(thread),

--- a/consensus/safety-rules/src/test_utils.rs
+++ b/consensus/safety-rules/src/test_utils.rs
@@ -242,7 +242,7 @@ pub fn test_safety_rules() -> SafetyRules {
     let storage = test_storage(&signer);
     let (epoch_change_proof, _) = make_genesis(&signer);
 
-    let mut safety_rules = SafetyRules::new(storage, true, false);
+    let mut safety_rules = SafetyRules::new(storage, true, false, false);
     safety_rules.initialize(&epoch_change_proof).unwrap();
     safety_rules
 }
@@ -251,7 +251,7 @@ pub fn test_safety_rules() -> SafetyRules {
 pub fn test_safety_rules_uninitialized() -> SafetyRules {
     let signer = ValidatorSigner::from_int(0);
     let storage = test_storage(&signer);
-    SafetyRules::new(storage, true, false)
+    SafetyRules::new(storage, true, false, false)
 }
 
 /// Returns a simple serializer for testing purposes.

--- a/consensus/safety-rules/src/tests/local.rs
+++ b/consensus/safety-rules/src/tests/local.rs
@@ -10,10 +10,16 @@ fn test() {
     let boolean_values = [false, true];
     for verify_vote_proposal_signature in &boolean_values {
         for export_consensus_key in &boolean_values {
-            suite::run_test_suite(&safety_rules(
-                *verify_vote_proposal_signature,
-                *export_consensus_key,
-            ));
+            for decoupled_execution in &boolean_values {
+                suite::run_test_suite(
+                    &safety_rules(
+                        *verify_vote_proposal_signature,
+                        *export_consensus_key,
+                        *decoupled_execution,
+                    ),
+                    *decoupled_execution,
+                );
+            }
         }
     }
 }
@@ -21,6 +27,7 @@ fn test() {
 fn safety_rules(
     verify_vote_proposal_signature: bool,
     export_consensus_key: bool,
+    decoupled_execution: bool,
 ) -> suite::Callback {
     Box::new(move || {
         let signer = ValidatorSigner::from_int(0);
@@ -29,6 +36,7 @@ fn safety_rules(
             storage,
             verify_vote_proposal_signature,
             export_consensus_key,
+            decoupled_execution,
         );
         let safety_rules = safety_rules_manager.client();
         (

--- a/consensus/safety-rules/src/tests/networking.rs
+++ b/consensus/safety-rules/src/tests/networking.rs
@@ -11,7 +11,7 @@ fn test_reconnect() {
     // test value for network timeout, in milliseconds.
     let network_timeout = 5_000;
     let safety_rules_manager =
-        SafetyRulesManager::new_thread(storage, false, false, network_timeout);
+        SafetyRulesManager::new_thread(storage, false, false, network_timeout, false);
 
     // Verify that after a client has disconnected a new client will connect and resume operations
     let state0 = safety_rules_manager.client().consensus_state().unwrap();

--- a/consensus/safety-rules/src/tests/safety_rules.rs
+++ b/consensus/safety-rules/src/tests/safety_rules.rs
@@ -10,10 +10,16 @@ fn test() {
     let boolean_values = [false, true];
     for verify_vote_proposal_signature in &boolean_values {
         for export_consensus_key in &boolean_values {
-            suite::run_test_suite(&safety_rules(
-                *verify_vote_proposal_signature,
-                *export_consensus_key,
-            ));
+            for decoupled_execution in &boolean_values {
+                suite::run_test_suite(
+                    &safety_rules(
+                        *verify_vote_proposal_signature,
+                        *export_consensus_key,
+                        *decoupled_execution,
+                    ),
+                    *decoupled_execution,
+                );
+            }
         }
     }
 }
@@ -21,6 +27,7 @@ fn test() {
 fn safety_rules(
     verify_vote_proposal_signature: bool,
     export_consensus_key: bool,
+    decoupled_execution: bool,
 ) -> suite::Callback {
     Box::new(move || {
         let signer = ValidatorSigner::from_int(0);
@@ -29,6 +36,7 @@ fn safety_rules(
             storage,
             verify_vote_proposal_signature,
             export_consensus_key,
+            decoupled_execution,
         ));
         (
             safety_rules,

--- a/consensus/safety-rules/src/tests/serializer.rs
+++ b/consensus/safety-rules/src/tests/serializer.rs
@@ -10,10 +10,16 @@ fn test() {
     let boolean_values = [false, true];
     for verify_vote_proposal_signature in &boolean_values {
         for export_consensus_key in &boolean_values {
-            suite::run_test_suite(&safety_rules(
-                *verify_vote_proposal_signature,
-                *export_consensus_key,
-            ));
+            for decoupled_execution in &boolean_values {
+                suite::run_test_suite(
+                    &safety_rules(
+                        *verify_vote_proposal_signature,
+                        *export_consensus_key,
+                        *decoupled_execution,
+                    ),
+                    *decoupled_execution,
+                );
+            }
         }
     }
 }
@@ -21,6 +27,7 @@ fn test() {
 fn safety_rules(
     verify_vote_proposal_signature: bool,
     export_consensus_key: bool,
+    decoupled_execution: bool,
 ) -> suite::Callback {
     Box::new(move || {
         let signer = ValidatorSigner::from_int(0);
@@ -29,6 +36,7 @@ fn safety_rules(
             storage,
             verify_vote_proposal_signature,
             export_consensus_key,
+            decoupled_execution,
         );
         let safety_rules = safety_rules_manager.client();
         (

--- a/consensus/safety-rules/src/tests/thread.rs
+++ b/consensus/safety-rules/src/tests/thread.rs
@@ -10,10 +10,16 @@ fn test() {
     let boolean_values = [false, true];
     for verify_vote_proposal_signature in &boolean_values {
         for export_consensus_key in &boolean_values {
-            suite::run_test_suite(&safety_rules(
-                *verify_vote_proposal_signature,
-                *export_consensus_key,
-            ));
+            for decoupled_execution in &boolean_values {
+                suite::run_test_suite(
+                    &safety_rules(
+                        *verify_vote_proposal_signature,
+                        *export_consensus_key,
+                        *decoupled_execution,
+                    ),
+                    *decoupled_execution,
+                );
+            }
         }
     }
 }
@@ -21,6 +27,7 @@ fn test() {
 fn safety_rules(
     verify_vote_proposal_signature: bool,
     export_consensus_key: bool,
+    decouppled_execution: bool,
 ) -> suite::Callback {
     Box::new(move || {
         let signer = ValidatorSigner::from_int(0);
@@ -32,6 +39,7 @@ fn safety_rules(
             verify_vote_proposal_signature,
             export_consensus_key,
             network_timeout,
+            decouppled_execution,
         );
         let safety_rules = safety_rules_manager.client();
         (

--- a/consensus/safety-rules/src/tests/vault.rs
+++ b/consensus/safety-rules/src/tests/vault.rs
@@ -19,10 +19,16 @@ fn test() {
     let boolean_values = [false, true];
     for verify_vote_proposal_signature in &boolean_values {
         for export_consensus_key in &boolean_values {
-            suite::run_test_suite(&safety_rules(
-                *verify_vote_proposal_signature,
-                *export_consensus_key,
-            ));
+            for decoupled_execution in &boolean_values {
+                suite::run_test_suite(
+                    &safety_rules(
+                        *verify_vote_proposal_signature,
+                        *export_consensus_key,
+                        *decoupled_execution,
+                    ),
+                    *decoupled_execution,
+                );
+            }
         }
     }
 }
@@ -30,6 +36,7 @@ fn test() {
 fn safety_rules(
     verify_vote_proposal_signature: bool,
     export_consensus_key: bool,
+    decoupled_execution: bool,
 ) -> suite::Callback {
     Box::new(move || {
         let signer = ValidatorSigner::from_int(0);
@@ -57,6 +64,7 @@ fn safety_rules(
             storage,
             verify_vote_proposal_signature,
             export_consensus_key,
+            decoupled_execution,
         );
         let safety_rules = safety_rules_manager.client();
         (

--- a/consensus/safety-rules/src/thread.rs
+++ b/consensus/safety-rules/src/thread.rs
@@ -31,6 +31,7 @@ impl ThreadService {
         verify_vote_proposal_signature: bool,
         export_consensus_key: bool,
         timeout: u64,
+        decoupled_execution: bool,
     ) -> Self {
         let listen_port = utils::get_available_port();
         let listen_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), listen_port);
@@ -43,6 +44,7 @@ impl ThreadService {
                 verify_vote_proposal_signature,
                 export_consensus_key,
                 timeout,
+                decoupled_execution,
             )
         });
 

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -106,7 +106,7 @@ fn create_node_for_fuzzing() -> RoundManager {
 
     // TODO: remove
     let proof = make_initial_epoch_change_proof(&signer);
-    let mut safety_rules = SafetyRules::new(test_utils::test_storage(&signer), false, false);
+    let mut safety_rules = SafetyRules::new(test_utils::test_storage(&signer), false, false, false);
     safety_rules.initialize(&proof).unwrap();
 
     // TODO: mock channels

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -107,7 +107,8 @@ impl NodeSetup {
                 waypoint,
                 true,
             );
-            let safety_rules_manager = SafetyRulesManager::new_local(safety_storage, false, false);
+            let safety_rules_manager =
+                SafetyRulesManager::new_local(safety_storage, false, false, false);
 
             nodes.push(Self::new(
                 playground,
@@ -868,7 +869,8 @@ fn safety_rules_crash() {
             true,
         );
 
-        node.safety_rules_manager = SafetyRulesManager::new_local(safety_storage, false, false);
+        node.safety_rules_manager =
+            SafetyRulesManager::new_local(safety_storage, false, false, false);
         let safety_rules =
             MetricsSafetyRules::new(node.safety_rules_manager.client(), node.storage.clone());
         node.round_manager.set_safety_rules(safety_rules);


### PR DESCRIPTION
This is the first part of integrating decoupled execution. We add
a config item named `decoupled_execution` for safety-rules.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update or suggest changes to the docs at https://developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
