### PR TITLE
[move-prover] make Verification variant taking a flavor enum

### DIFF
--- a/language/move-prover/bytecode/src/function_target_pipeline.rs
+++ b/language/move-prover/bytecode/src/function_target_pipeline.rs
@@ -20,6 +20,22 @@ pub struct FunctionTargetsHolder {
     targets: BTreeMap<QualifiedId<FunId>, BTreeMap<FunctionVariant, FunctionData>>,
 }
 
+/// Describes a function verification flavor.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum VerificationFlavor {
+    Regular,
+    Inconsistency,
+}
+
+impl std::fmt::Display for VerificationFlavor {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VerificationFlavor::Regular => write!(f, ""),
+            VerificationFlavor::Inconsistency => write!(f, "inconsistency"),
+        }
+    }
+}
+
 /// Describes a function target variant.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum FunctionVariant {
@@ -28,8 +44,8 @@ pub enum FunctionVariant {
     Baseline,
     /// A variant which is instrumented for verification. Only functions which are target
     /// of verification have one of those. There can be multiple verification variants,
-    /// identified by a well-known string.
-    Verification(&'static str),
+    /// each identified by a unique flavor.
+    Verification(VerificationFlavor),
 }
 
 impl FunctionVariant {
@@ -38,22 +54,13 @@ impl FunctionVariant {
     }
 }
 
-/// The variant for regular verification.
-pub const REGULAR_VERIFICATION_VARIANT: &str = "";
-pub const INCONSISTENCY_CHECK_VARIANT: &str = "inconsistency";
-
 impl std::fmt::Display for FunctionVariant {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         use FunctionVariant::*;
         match self {
             Baseline => write!(f, "baseline"),
-            Verification(s) => {
-                if s.is_empty() {
-                    write!(f, "verification")
-                } else {
-                    write!(f, "verification[{}]", s)
-                }
-            }
+            Verification(VerificationFlavor::Regular) => write!(f, "verification"),
+            Verification(v) => write!(f, "verification[{}]", v),
         }
     }
 }

--- a/language/move-prover/interpreter/src/shared/variant.rs
+++ b/language/move-prover/interpreter/src/shared/variant.rs
@@ -3,9 +3,7 @@
 
 use bytecode::{
     function_target::FunctionTarget,
-    function_target_pipeline::{
-        FunctionTargetsHolder, FunctionVariant, REGULAR_VERIFICATION_VARIANT,
-    },
+    function_target_pipeline::{FunctionTargetsHolder, FunctionVariant, VerificationFlavor},
 };
 use move_model::model::FunctionEnv;
 
@@ -23,7 +21,7 @@ pub fn choose_variant<'env>(
                     target_variant = Some(target);
                 }
             }
-            FunctionVariant::Verification(REGULAR_VERIFICATION_VARIANT) => {
+            FunctionVariant::Verification(VerificationFlavor::Regular) => {
                 target_variant = Some(target);
             }
             _ => (),


### PR DESCRIPTION
Existing implementation takes a static string with the assumption that
all verification variants can be statically known. This is true as of
now but even in this case, it feels better to use an enum instead of raw
strings to match the verification invariants.

This commit is also up to support an incoming transformation which may
create a statically-unknown number of verification variants when
unrolling functions with type parameters instantiated.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI
