### PR TITLE
[move-prover] handle ResourceDomain for type instantiation

### DIFF
--- a/language/move-model/src/ty.rs
+++ b/language/move-model/src/ty.rs
@@ -313,7 +313,10 @@ impl Type {
             Type::TypeDomain(et) => {
                 Type::TypeDomain(Box::new(et.replace(params, subs, type_local_subs)))
             }
-            Type::ResourceDomain(..) | Type::Primitive(..) | Type::Error => self.clone(),
+            Type::ResourceDomain(mid, sid, args_opt) => {
+                Type::ResourceDomain(*mid, *sid, args_opt.as_ref().map(|args| replace_vec(args)))
+            }
+            Type::Primitive(..) | Type::Error => self.clone(),
         }
     }
 


### PR DESCRIPTION
Which is currently missing in the `Type::replace()` function.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI
