### PR TITLE
[move-prover] use TypeUnificationAdapter to test type relevance

### DIFF
--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -59,7 +59,7 @@ use move_core_types::{
 
 use crate::{
     ast::{
-        ConditionKind, ExpData, GlobalInvariant, ModuleName, PropertyBag, PropertyValue, Spec,
+        ConditionKind, Exp, ExpData, GlobalInvariant, ModuleName, PropertyBag, PropertyValue, Spec,
         SpecBlockInfo, SpecFunDecl, SpecVarDecl, Value,
     },
     pragmas::{
@@ -67,11 +67,10 @@ use crate::{
         INTRINSIC_PRAGMA, OPAQUE_PRAGMA, VERIFY_PRAGMA,
     },
     symbol::{Symbol, SymbolPool},
-    ty::{PrimitiveType, Type, TypeDisplayContext},
+    ty::{PrimitiveType, Type, TypeDisplayContext, TypeUnificationAdapter, Variance},
 };
 
 // import and re-expose symbols
-use crate::ast::Exp;
 pub use move_binary_format::file_format::{AbilitySet, Visibility as FunctionVisibility};
 
 // =================================================================================================
@@ -883,27 +882,20 @@ impl GlobalEnv {
     pub fn get_global_invariants_for_memory(
         &self,
         memory: &QualifiedInstId<StructId>,
-    ) -> Vec<GlobalId> {
-        self.global_invariants_for_memory
-            .get(memory)
-            .map(|ids| ids.iter().cloned().collect_vec())
-            .unwrap_or_else(Default::default)
-    }
-
-    /// Given a set of invariants, find the subset that refer to the type in mem.
-    pub fn get_subset_invariants_for_memory(
-        &self,
-        mem: QualifiedInstId<StructId>,
-        inv_set_id: &BTreeSet<GlobalId>,
     ) -> BTreeSet<GlobalId> {
-        if let Some(modifies_inv_id_set) = self.global_invariants_for_memory.get(&mem) {
-            modifies_inv_id_set
-                .intersection(inv_set_id)
-                .cloned()
-                .collect()
-        } else {
-            BTreeSet::<GlobalId>::new()
+        let mut inv_ids = BTreeSet::new();
+        for (key, val) in &self.global_invariants_for_memory {
+            if key.module_id != memory.module_id || key.id != memory.id {
+                continue;
+            }
+            assert_eq!(key.inst.len(), memory.inst.len());
+            let adapter = TypeUnificationAdapter::new_vec(&memory.inst, &key.inst, true, true);
+            let rel = adapter.unify(Variance::Allow, true);
+            if rel.is_some() {
+                inv_ids.extend(val.clone());
+            }
         }
+        inv_ids
     }
 
     pub fn get_global_invariants_by_module(&self, module_id: ModuleId) -> BTreeSet<GlobalId> {

--- a/language/move-prover/tests/sources/functional/invariants_with_generics.exp
+++ b/language/move-prover/tests/sources/functional/invariants_with_generics.exp
@@ -1,0 +1,100 @@
+Move prover returns: exiting with boogie verification errors
+error: global memory invariant does not hold
+
+    ┌── tests/sources/functional/invariants_with_generics.move:34:5 ───
+    │
+ 34 │ ╭     invariant
+ 35 │ │         exists<S::Storage<u64, bool>>(@0x22)
+ 36 │ │             ==> global<S::Storage<u64, bool>>(@0x22).x == 1;
+    │ ╰────────────────────────────────────────────────────────────^
+    │
+    =     at tests/sources/functional/invariants_with_generics.move:10: publish_u64_bool
+    =         account = <redacted>
+    =         x = <redacted>
+    =         y = <redacted>
+    =     at tests/sources/functional/invariants_with_generics.move:11: publish_u64_bool
+    =     at tests/sources/functional/invariants_with_generics.move:10: publish_u64_bool
+    =     at tests/sources/functional/invariants_with_generics.move:11: publish_u64_bool
+    =     at tests/sources/functional/invariants_with_generics.move:34
+
+error: global memory invariant does not hold
+
+    ┌── tests/sources/functional/invariants_with_generics.move:39:5 ───
+    │
+ 39 │ ╭     invariant
+ 40 │ │         forall t: type:
+ 41 │ │             exists<S::Storage<u64, t>>(@0x23)
+ 42 │ │                 ==> global<S::Storage<u64, t>>(@0x23).x > 0;
+    │ ╰────────────────────────────────────────────────────────────^
+    │
+    =     at tests/sources/functional/invariants_with_generics.move:10: publish_u64_bool
+    =         account = <redacted>
+    =         x = <redacted>
+    =         y = <redacted>
+    =     at tests/sources/functional/invariants_with_generics.move:11: publish_u64_bool
+    =     at tests/sources/functional/invariants_with_generics.move:10: publish_u64_bool
+    =     at tests/sources/functional/invariants_with_generics.move:11: publish_u64_bool
+    =     at tests/sources/functional/invariants_with_generics.move:34
+    =     at tests/sources/functional/invariants_with_generics.move:39
+
+error: global memory invariant does not hold
+
+    ┌── tests/sources/functional/invariants_with_generics.move:45:5 ───
+    │
+ 45 │ ╭     invariant
+ 46 │ │         forall t: type:
+ 47 │ │             exists<S::Storage<t, bool>>(@0x24)
+ 48 │ │                 ==> global<S::Storage<t, bool>>(@0x24).y;
+    │ ╰─────────────────────────────────────────────────────────^
+    │
+    =     at tests/sources/functional/invariants_with_generics.move:10: publish_u64_bool
+    =         account = <redacted>
+    =         x = <redacted>
+    =         y = <redacted>
+    =     at tests/sources/functional/invariants_with_generics.move:11: publish_u64_bool
+    =     at tests/sources/functional/invariants_with_generics.move:10: publish_u64_bool
+    =     at tests/sources/functional/invariants_with_generics.move:11: publish_u64_bool
+    =     at tests/sources/functional/invariants_with_generics.move:34
+    =     at tests/sources/functional/invariants_with_generics.move:39
+    =     at tests/sources/functional/invariants_with_generics.move:45
+
+error: global memory invariant does not hold
+
+    ┌── tests/sources/functional/invariants_with_generics.move:39:5 ───
+    │
+ 39 │ ╭     invariant
+ 40 │ │         forall t: type:
+ 41 │ │             exists<S::Storage<u64, t>>(@0x23)
+ 42 │ │                 ==> global<S::Storage<u64, t>>(@0x23).x > 0;
+    │ ╰────────────────────────────────────────────────────────────^
+    │
+    =     at tests/sources/functional/invariants_with_generics.move:15: publish_u64_y
+    =         account = <redacted>
+    =         x = <redacted>
+    =         y = <redacted>
+    =     at tests/sources/functional/invariants_with_generics.move:16: publish_u64_y
+    =     at tests/sources/functional/invariants_with_generics.move:15: publish_u64_y
+    =     at tests/sources/functional/invariants_with_generics.move:16: publish_u64_y
+    =     at tests/sources/functional/invariants_with_generics.move:34
+    =     at tests/sources/functional/invariants_with_generics.move:39
+
+error: global memory invariant does not hold
+
+    ┌── tests/sources/functional/invariants_with_generics.move:45:5 ───
+    │
+ 45 │ ╭     invariant
+ 46 │ │         forall t: type:
+ 47 │ │             exists<S::Storage<t, bool>>(@0x24)
+ 48 │ │                 ==> global<S::Storage<t, bool>>(@0x24).y;
+    │ ╰─────────────────────────────────────────────────────────^
+    │
+    =     at tests/sources/functional/invariants_with_generics.move:20: publish_x_bool
+    =         account = <redacted>
+    =         x = <redacted>
+    =         y = <redacted>
+    =     at tests/sources/functional/invariants_with_generics.move:21: publish_x_bool
+    =     at tests/sources/functional/invariants_with_generics.move:20: publish_x_bool
+    =     at tests/sources/functional/invariants_with_generics.move:21: publish_x_bool
+    =     at tests/sources/functional/invariants_with_generics.move:34
+    =     at tests/sources/functional/invariants_with_generics.move:39
+    =     at tests/sources/functional/invariants_with_generics.move:45

--- a/language/move-prover/tests/sources/functional/invariants_with_generics.move
+++ b/language/move-prover/tests/sources/functional/invariants_with_generics.move
@@ -1,0 +1,68 @@
+address 0x2 {
+module S {
+    struct Storage<X: store, Y: store> has key {
+        x: X,
+        y: Y,
+        v: u8,
+    }
+
+    // F1: <concrete, concrete>
+	public fun publish_u64_bool(account: signer, x: u64, y: bool) {
+	    move_to(&account, Storage { x, y, v: 0 })
+	}
+
+    // F2: <concrete, generic>
+	public fun publish_u64_y<Y: store>(account: signer, x: u64, y: Y) {
+	    move_to(&account, Storage { x, y, v: 1 })
+	}
+
+    // F3: <generic, concrete>
+	public fun publish_x_bool<X: store>(account: signer, x: X, y: bool) {
+	    move_to(&account, Storage { x, y, v: 2 })
+	}
+
+    // F4: <generic, generic>
+	public fun publish_x_y<X: store, Y: store>(account: signer, x: X, y: Y) {
+	    move_to(&account, Storage { x, y, v: 3 })
+	}
+}
+
+module A {
+    use 0x2::S;
+
+    // I1: <concrete, concrete>
+    invariant
+        exists<S::Storage<u64, bool>>(@0x22)
+            ==> global<S::Storage<u64, bool>>(@0x22).x == 1;
+
+    // I2: <concrete, generic>
+    invariant
+        forall t: type:
+            exists<S::Storage<u64, t>>(@0x23)
+                ==> global<S::Storage<u64, t>>(@0x23).x > 0;
+
+    // I3: <generic, concrete>
+    invariant
+        forall t: type:
+            exists<S::Storage<t, bool>>(@0x24)
+                ==> global<S::Storage<t, bool>>(@0x24).y;
+
+    // I4: <generic, generic>
+    // TODO (mengxu) disabled for now due to an issue with the mono backend
+    // invariant
+    //    forall t1: type, t2: type:
+    //        (exists<S::Storage<t1, t2>>(@0x25) && exists<S::Storage<t1, t2>>(@0x26))
+    //            ==> global<S::Storage<t1, t2>>(@0x25) == global<S::Storage<t1, t2>>(@0x26);
+
+    public fun good(account1: signer, account2: signer) {
+        S::publish_x_y<u64, bool>(account1, 1, true);
+        S::publish_x_y<u64, bool>(account2, 1, true);
+    }
+
+    // TODO (mengxu) all invariants (I1-I4) should be disproved in all functions (F1-F4)
+    // currently,
+    // - I1-I3 is disproved in F1
+    // - I2 is disproved in F2
+    // - I3 is disproved in F3
+}
+}


### PR DESCRIPTION
If a global invariant `I` talks about a generic resource, e.g., `S<X, Y>`,
and a function `f` might also be parameterized `f<X, Y>`. Then, there
should be a procedure to decide whether a global invariant `I` should
be checked in the body of `f`.

That procedure is encoded in the function
`GlobalEnv::get_global_invariants_for_memory()`, but there is a bug:
it uses strict type comparison (i.e., a type parameter `T` is different
from a concrete type `bool`) instead of type intersection (where `T`
can be instantiated with `bool` to make the two types match).

This PR fixes this bug.

To put into the terms of `TypeUnificationAdapter`, we have the following
relation in the `invariants_with_generics.move` test case:

```
                        F_inst                  I_inst
f<u64, bool>
  I<u64, bool>          -                       -
  I<u64, Y2>            -                       Y2 := bool
  I<Y1, bool>           -                       Y1 := u64
  I<Y1, Y2>             -                       Y1 := u64, Y2 := bool

f<u64, X2>
  I<u64, bool>          X2 := bool              -
  I<u64, Y2>            -                       -
  I<Y1, bool>           X2 := bool              Y1 := u64
  I<Y1, Y2>             -                       Y1 := u64

f<X1, bool>
  I<u64, bool>          X1 := u64               -
  I<u64, Y2>            X1 := u64               Y2 := bool
  I<Y1, bool>           -                       -
  I<Y1, Y2>             -                       Y2 := bool

f<X1, X2>
  I<u64, bool>          X1 := u64, X2 := bool   -
  I<u64, Y2>            X1 := U64               -
  I<Y1, bool>           X2 := bool              -
  I<Y1, Y2>             -                       -
```

In the old and unsound behavior, only `f<u64, bool>` and `I<u64, bool>`
match because this is the only pair of types that strictly match
each other. With this commit, all pairs of `f<>` and `I<>` are considered
relevant.

After type relevance is established, the next step is to create verification
variants for each function that bear different instantiations to the same
function in order to test different global invariants. The follow-up PR is
ready in #8756.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- CI
- A new test case, `invariants_with_generics.move` is added and as we land more PRs to fix this issue, the coverage in this test case will be gradually improved.