### PR TITLE
[RUSTSEC][release-1.2] udpate tokio-> 1.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7320,9 +7320,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.3.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d56477f6ed99e10225f38f9f75f872f29b8b8bd8c0b946f63345bb144e9eeda"
+checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
 dependencies = [
  "autocfg 1.0.1",
  "bytes",

--- a/client/faucet/Cargo.toml
+++ b/client/faucet/Cargo.toml
@@ -17,7 +17,7 @@ reqwest = { version = "0.11.2", features = ["blocking"], default-features = fals
 serde = "1.0.124"
 serde_derive = "1.0.117"
 structopt = "0.3.21"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 warp = "0.3.0"
 
 generate-key = { path = "../../config/generate-key" }

--- a/client/json-rpc/Cargo.toml
+++ b/client/json-rpc/Cargo.toml
@@ -18,7 +18,7 @@ rand = "0.8.3"
 reqwest = { version = "0.11.2", features = ["blocking", "json"], default_features = false }
 serde = { version = "1.0.124", default-features = false }
 serde_json = "1.0.64"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 
 diem-crypto = { path = "../../crypto/crypto" }
 bcs = "0.1.2"

--- a/common/bounded-executor/Cargo.toml
+++ b/common/bounded-executor/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 futures = "0.3.12"
 diem-workspace-hack = { path = "../workspace-hack" }
-tokio = { version = "1.3.0", features = ["sync"] }
+tokio = { version = "1.8.1", features = ["sync"] }
 
 [dev-dependencies]
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }

--- a/common/channel/Cargo.toml
+++ b/common/channel/Cargo.toml
@@ -18,4 +18,4 @@ diem-workspace-hack = { path = "../workspace-hack" }
 
 [dev-dependencies]
 diem-types = { path = "../../types"  }
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }

--- a/common/debug-interface/Cargo.toml
+++ b/common/debug-interface/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.38"
 bytes = "1.0.1"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 reqwest = { version = "0.11.2", features = ["blocking", "json"], default_features = false }
 warp = "0.3.0"
 

--- a/common/metrics/Cargo.toml
+++ b/common/metrics/Cargo.toml
@@ -16,7 +16,7 @@ hyper = { version = "0.14.4", features = ["full"] }
 once_cell = "1.7.2"
 prometheus = { version = "0.12.0", default-features = false }
 serde_json = "1.0.64"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 
 diem-logger = { path = "../logger" }
 diem-metrics-core = { path = "../metrics-core" }

--- a/common/rate-limiter/Cargo.toml
+++ b/common/rate-limiter/Cargo.toml
@@ -16,5 +16,5 @@ diem-logger = { path = "../logger" }
 diem-metrics = { path = "../metrics" }
 futures = "0.3.12"
 pin-project = "1.0.5"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 tokio-util = { version = "0.6.4", features = ["compat"] }

--- a/common/retrier/Cargo.toml
+++ b/common/retrier/Cargo.toml
@@ -11,5 +11,5 @@ edition = "2018"
 
 [dependencies]
 diem-workspace-hack = { path = "../workspace-hack" }
-tokio = { version = "1.3.0", features = ["time"] }
+tokio = { version = "1.8.1", features = ["time"] }
 diem-logger = { path = "../logger"}

--- a/common/time-service/Cargo.toml
+++ b/common/time-service/Cargo.toml
@@ -14,7 +14,7 @@ enum_dispatch = "0.3.5"
 futures = { version = "0.3.12", optional = true }
 pin-project = { version = "1.0.5", optional = true }
 thiserror = "1.0.24"
-tokio = { version = "1.3.0", features = ["macros", "rt-multi-thread", "time"], optional = true }
+tokio = { version = "1.8.1", features = ["macros", "rt-multi-thread", "time"], optional = true }
 
 diem-infallible = { path = "../infallible" }
 diem-workspace-hack = { path = "../workspace-hack" }
@@ -22,7 +22,7 @@ diem-workspace-hack = { path = "../workspace-hack" }
 [dev-dependencies]
 futures = "0.3.12"
 pin-project = "1.0.5"
-tokio = { version = "1.3.0", features = ["macros", "rt-multi-thread", "time"] }
+tokio = { version = "1.8.1", features = ["macros", "rt-multi-thread", "time"] }
 tokio-test = "0.4.1"
 
 [features]

--- a/common/trace/Cargo.toml
+++ b/common/trace/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 chrono = "0.4.19"
 structopt = "0.3.21"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 serde_json = "1.0.64"
 serde = "1.0.124"
 anyhow = "1.0.38"

--- a/common/workspace-hack/Cargo.toml
+++ b/common/workspace-hack/Cargo.toml
@@ -47,7 +47,7 @@ serde = { version = "1.0.124", features = ["alloc", "default", "derive", "rc", "
 serde_json = { version = "1.0.64", features = ["default", "indexmap", "preserve_order", "std"] }
 standback = { version = "0.2.15", default-features = false, features = ["std"] }
 subtle = { version = "2.4.0", default-features = false, features = ["std"] }
-tokio = { version = "1.3.0", features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "test-util", "time", "tokio-macros", "winapi"] }
+tokio = { version = "1.8.1", features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "test-util", "time", "tokio-macros", "winapi"] }
 tokio-util = { version = "0.6.4", features = ["codec", "compat", "default", "futures-io", "io"] }
 toml = { version = "0.5.8", features = ["default"] }
 tracing = { version = "0.1.25", features = ["attributes", "default", "log", "std", "tracing-attributes"] }
@@ -96,7 +96,7 @@ standback = { version = "0.2.15", default-features = false, features = ["std"] }
 subtle = { version = "2.4.0", default-features = false, features = ["std"] }
 syn-3575ec1268b04181 = { package = "syn", version = "0.15.44", features = ["clone-impls", "default", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.64", features = ["clone-impls", "default", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
-tokio = { version = "1.3.0", features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "test-util", "time", "tokio-macros", "winapi"] }
+tokio = { version = "1.8.1", features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "test-util", "time", "tokio-macros", "winapi"] }
 tokio-util = { version = "0.6.4", features = ["codec", "compat", "default", "futures-io", "io"] }
 toml = { version = "0.5.8", features = ["default"] }
 tracing = { version = "0.1.25", features = ["attributes", "default", "log", "std", "tracing-attributes"] }
@@ -140,7 +140,7 @@ serde = { version = "1.0.124", features = ["alloc", "default", "derive", "rc", "
 serde_json = { version = "1.0.64", features = ["default", "indexmap", "preserve_order", "std"] }
 standback = { version = "0.2.15", default-features = false, features = ["std"] }
 subtle = { version = "2.4.0", default-features = false, features = ["std"] }
-tokio = { version = "1.3.0", features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "test-util", "time", "tokio-macros", "winapi"] }
+tokio = { version = "1.8.1", features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "test-util", "time", "tokio-macros", "winapi"] }
 tokio-util = { version = "0.6.4", features = ["codec", "compat", "default", "futures-io", "io"] }
 toml = { version = "0.5.8", features = ["default"] }
 tracing = { version = "0.1.25", features = ["attributes", "default", "log", "std", "tracing-attributes"] }
@@ -189,7 +189,7 @@ standback = { version = "0.2.15", default-features = false, features = ["std"] }
 subtle = { version = "2.4.0", default-features = false, features = ["std"] }
 syn-3575ec1268b04181 = { package = "syn", version = "0.15.44", features = ["clone-impls", "default", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.64", features = ["clone-impls", "default", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
-tokio = { version = "1.3.0", features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "test-util", "time", "tokio-macros", "winapi"] }
+tokio = { version = "1.8.1", features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "test-util", "time", "tokio-macros", "winapi"] }
 tokio-util = { version = "0.6.4", features = ["codec", "compat", "default", "futures-io", "io"] }
 toml = { version = "0.5.8", features = ["default"] }
 tracing = { version = "0.1.25", features = ["attributes", "default", "log", "std", "tracing-attributes"] }

--- a/config/management/operational/Cargo.toml
+++ b/config/management/operational/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "1.0.64"
 serde_yaml = "0.8.17"
 structopt = "0.3.21"
 thiserror = "1.0.24"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 tokio-util = { version = "0.6.4", features = ["compat"] }
 toml = { version = "0.5.8", default-features = false }
 

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0.124", default-features = false }
 serde_json = "1.0.64"
 termion = { version = "1.5.6", default-features = false }
 thiserror = "1.0.24"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 
 channel = { path = "../common/channel" }
 consensus-types = { path = "consensus-types", default-features = false }

--- a/diem-node/Cargo.toml
+++ b/diem-node/Cargo.toml
@@ -14,7 +14,7 @@ fail = "0.4.0"
 futures = "0.3.12"
 jemallocator = { version = "0.3.2", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
 structopt = "0.3.21"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 tokio-stream = "0.1.4"
 
 backup-service = { path = "../storage/backup/backup-service" }

--- a/json-rpc/Cargo.toml
+++ b/json-rpc/Cargo.toml
@@ -19,7 +19,7 @@ once_cell = "1.7.2"
 rand = "0.8.3"
 serde_json = "1.0.64"
 serde = { version = "1.0.124", features = ["derive"], default-features = false }
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 warp = { version = "0.3.0", features = ["tls"] }
 reqwest = { version = "0.11.2", features = ["blocking", "json"], default_features = false, optional = true }
 proptest = { version = "1.0.0", optional = true }

--- a/language/diem-tools/diem-events-fetcher/Cargo.toml
+++ b/language/diem-tools/diem-events-fetcher/Cargo.toml
@@ -17,7 +17,7 @@ hex = "0.4.3"
 reqwest = { version = "0.11.2", features = ["blocking", "json"] }
 structopt = "0.3.21"
 futures = "0.3.12"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 diem-client = { path = "../../../sdk/client" }

--- a/language/move-prover/Cargo.toml
+++ b/language/move-prover/Cargo.toml
@@ -41,7 +41,7 @@ serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
 simplelog = "0.9.0"
 once_cell = "1.7.2"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 toml = "0.5.8"
 
 [dev-dependencies]

--- a/language/move-prover/boogie-backend-v2/Cargo.toml
+++ b/language/move-prover/boogie-backend-v2/Cargo.toml
@@ -26,7 +26,7 @@ regex = "1.4.3"
 rand = "0.8.3"
 futures = "0.3.12"
 handlebars = "3.5.3"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 codespan = "0.8.0"
 codespan-reporting = "0.8.0"
 

--- a/language/move-prover/boogie-backend/Cargo.toml
+++ b/language/move-prover/boogie-backend/Cargo.toml
@@ -27,7 +27,7 @@ regex = "1.4.3"
 rand = "0.8.3"
 futures = "0.3.12"
 handlebars = "3.5.3"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 codespan = "0.8.0"
 codespan-reporting = "0.8.0"
 

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -18,7 +18,7 @@ once_cell = "1.7.2"
 proptest = { version = "1.0.0", optional = true }
 rayon = "1.4.1"
 serde = { version = "1.0.124", default-features = false }
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 tokio-stream = "0.1.4"
 
 bounded-executor = { path = "../common/bounded-executor" }

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -24,7 +24,7 @@ rand_core = { version = "0.6.2", optional = true }
 serde = { version = "1.0.124", default-features = false }
 serde_bytes = "0.11.5"
 thiserror = "1.0.24"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 tokio-retry = "0.3.0"
 tokio-stream = "0.1.4"
 tokio-util = { version = "0.6.4", features = ["compat", "codec"] }

--- a/network/builder/Cargo.toml
+++ b/network/builder/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 futures = "0.3.12"
 rand = "0.8.3"
 serde = { version = "1.0.124", default-features = false }
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 
 channel = { path = "../../common/channel" }
 bcs = "0.1.2"

--- a/network/netcore/Cargo.toml
+++ b/network/netcore/Cargo.toml
@@ -14,7 +14,7 @@ bytes = "1.0.1"
 futures = "0.3.12"
 pin-project = "1.0.5"
 serde = { version = "1.0.124", default-features = false }
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 tokio-util = { version = "0.6.4", features = ["compat"] }
 url = { version = "2.2.1" }
 

--- a/network/simple-onchain-discovery/Cargo.toml
+++ b/network/simple-onchain-discovery/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 anyhow = "1.0.38"
 futures = "0.3.12"
 once_cell = "1.7.2"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 
 channel = {path = "../../common/channel"}
 bcs = "0.1.2"

--- a/network/socket-bench-server/Cargo.toml
+++ b/network/socket-bench-server/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3.12"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 tokio-util = { version = "0.6.4", features = ["compat", "codec"] }
 
 diem-crypto = { path = "../../crypto/crypto" }

--- a/sdk/client/Cargo.toml
+++ b/sdk/client/Cargo.toml
@@ -28,7 +28,7 @@ diem-types = { path = "../../types", version = "0.0.1" }
 
 # Optional Dependencies
 reqwest = { version = "0.11.2", features = ["json"], optional = true }
-tokio = { version = "1.3.0", features = ["time"], default_features = false, optional = true }
+tokio = { version = "1.8.1", features = ["time"], default_features = false, optional = true }
 ureq = { version = "1.5.4", features = ["json", "native-tls"], default-features = false, optional = true }
 ipnet = { version = "2.3", optional = true }
 

--- a/secure/key-manager/Cargo.toml
+++ b/secure/key-manager/Cargo.toml
@@ -32,7 +32,7 @@ diem-transaction-builder = { path = "../../sdk/transaction-builder" }
 [dev-dependencies]
 futures = "0.3.12"
 rand = "0.8.3"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 
 executor = { path = "../../execution/executor" }
 executor-test-helpers = { path = "../../execution/executor-test-helpers" }

--- a/state-sync/Cargo.toml
+++ b/state-sync/Cargo.toml
@@ -19,7 +19,7 @@ proptest = { version = "1.0.0", optional = true }
 rand = "0.8.3"
 serde = { version = "1.0.124", default-features = false }
 thiserror = "1.0.24"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 tokio-stream = "0.1.4"
 
 channel = { path = "../common/channel" }

--- a/storage/backup/backup-cli/Cargo.toml
+++ b/storage/backup/backup-cli/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
 structopt = "0.3.21"
 toml = "0.5.8"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 tokio-stream = "0.1.4"
 tokio-util = { version = "0.6.4", features = ["compat"] }
 

--- a/storage/backup/backup-service/Cargo.toml
+++ b/storage/backup/backup-service/Cargo.toml
@@ -15,7 +15,7 @@ futures = "0.3.12"
 hyper = "0.14.4"
 once_cell = "1.7.2"
 serde = { version = "1.0.124", default-features = false }
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 warp = "0.3.0"
 
 bcs = "0.1.2"

--- a/storage/storage-service/Cargo.toml
+++ b/storage/storage-service/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.38"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 futures = "0.3.12"
 
 bcs = "0.1.2"

--- a/testsuite/cli/Cargo.toml
+++ b/testsuite/cli/Cargo.toml
@@ -21,7 +21,7 @@ once_cell = "1.7.2"
 reqwest = { version = "0.11.2", features = ["blocking", "json"] }
 serde = { version = "1.0.124", features = ["derive"] }
 structopt = "0.3.21"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 walkdir = "2.3.1"
 
 diem-config = { path = "../../config" }

--- a/testsuite/cluster-test/Cargo.toml
+++ b/testsuite/cluster-test/Cargo.toml
@@ -63,7 +63,7 @@ state-sync = { path = "../../state-sync" }
 diem-transaction-builder = { path = "../../sdk/transaction-builder" }
 
 futures = "0.3.12"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 async-trait = "0.1.42"
 
 kube = "0.51.0"

--- a/testsuite/smoke-test/Cargo.toml
+++ b/testsuite/smoke-test/Cargo.toml
@@ -21,7 +21,7 @@ regex = "1.4.3"
 rust_decimal = "1.10.3"
 rusty-fork = "0.3.0"
 statistical = "1.0.0"
-tokio = { version = "1.3.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 
 backup-cli = { path = "../../storage/backup/backup-cli" }
 cli = { path = "../cli", features = ["fuzzing"]  }


### PR DESCRIPTION

## Motivation

Upgrading dependency versions due to #8716

Only Tokio is deemed necessary to update existing releases according to offline review, hence this.

This is for the 1.2 release.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

y
## Test Plan
existing coverage.

## Related PRs

On main, both prost and Tokio were updated in #8717

## If targeting a release branch, please fill the below out as well
* Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
Security risk

* Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
Complete test suite

* Why we must have it for V1 launch.
security fix

* What workarounds and alternative we have if we do not push the PR.
Wait for 1.4 rollout