### PR TITLE
x: remove the ability to specify exceptions for Move-to-Diem dependencies

### DIFF
--- a/devtools/x/src/config.rs
+++ b/devtools/x/src/config.rs
@@ -160,7 +160,6 @@ pub struct DirectDepDupsConfig {
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct MoveToDiemDepsConfig {
     pub diem_crates_in_language: HashSet<String>,
-    pub existing_deps: HashSet<(String, String)>,
     pub exclude: HashSet<String>,
 }
 

--- a/devtools/x/src/lint/guppy.rs
+++ b/devtools/x/src/lint/guppy.rs
@@ -572,12 +572,6 @@ impl<'cfg> PackageLinter for MoveCratesDontDependOnDiemCrates<'cfg> {
             false
         };
 
-        let is_existing_move_to_diem_dep = |name1: &str, name2: &str| {
-            self.config
-                .existing_deps
-                .contains(&(name1.to_string(), name2.to_string()))
-        };
-
         if is_move_crate(&crate_path, crate_name) {
             for direct_dep in metadata.direct_links() {
                 let dep = direct_dep.to();
@@ -586,7 +580,6 @@ impl<'cfg> PackageLinter for MoveCratesDontDependOnDiemCrates<'cfg> {
                 if dep.in_workspace()
                     && !self.config.exclude.contains(dep_name)
                     && !is_move_crate(&dep.source().to_string(), dep_name)
-                    && !is_existing_move_to_diem_dep(crate_name, dep_name)
                 {
                     println!("(\"{}\", \"{}\"),", crate_name, dep_name);
                     out.write(

--- a/x.toml
+++ b/x.toml
@@ -226,6 +226,15 @@ members = [
 ]
 
 [workspace.move-to-diem-deps]
+# By default, all crates in the language directory are considered Move crates
+# and are forbidden from depending on any Diem crates.
+#
+# Adding a crate's name to this list will mark it as a Diem crate so that the
+# linter will not impose said restriction on it.
+#
+# Note: if your crate is indeed a Move crate and you are getting the linter
+# yelling at you, you should redesign your crate and properly remove that
+# dependency, instead of adding the crate to this list and silencing the lint.
 diem_crates_in_language = [
     "diem-e2e-tests-replay",
     "diem-framework",
@@ -250,12 +259,17 @@ diem_crates_in_language = [
     "diem-resource-viewer",
     "df-cli",
 ]
+# A special set of diem crates Move crates are allowed to depend on.
+#
+# You should not add new entries to this list unless you have a rare justifiable
+# reason. (read: Just don't.)
+#
+# Particularly, please do not abuse this to silence the lint when it complains
+# about Move crates depending on Diem ones. Again, you should instead fix
+# the design of your crate so it doesn't have to depend on Diem.
 exclude = [
     "diem-workspace-hack",
 ]
-# This is a list of existing move to diem dependencies that we plan to eliminate over time.
-# You should refrain from adding new entries to this list in general.
-existing_deps = []
 
 # Interesting subsets of the workspace, These are used for generating and
 # checking dependency summaries.


### PR DESCRIPTION
As of now, all crate level dependencies on Diem have been removed from Move crates. This goes a step further, taking away the ability to specify exceptions for this lint, in order to better enforce the rule.
