### PR TITLE
[move-prover] create instantiation variants after global invariants instrumentation

### DIFF
--- a/language/move-model/src/spec_translator.rs
+++ b/language/move-model/src/spec_translator.rs
@@ -231,6 +231,7 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
     pub fn translate_invariants(
         auto_trace: bool,
         builder: &'b mut T,
+        type_args: &'b [Type],
         invariants: impl Iterator<Item = &'b GlobalInvariant>,
     ) -> TranslatedSpec {
         let fun_env = builder.function_env().clone();
@@ -238,7 +239,7 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
             auto_trace,
             builder,
             fun_env: &fun_env,
-            type_args: &[],
+            type_args,
             param_substitution: Default::default(),
             ret_locals: Default::default(),
             in_post_state: false,
@@ -281,13 +282,14 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
     pub fn translate_invariants_by_id(
         auto_trace: bool,
         builder: &'b mut T,
+        type_args: &'b [Type],
         inv_id_set: &BTreeSet<GlobalId>,
     ) -> TranslatedSpec {
         let global_env = builder.global_env();
         let invariants = inv_id_set
             .iter()
             .map(|inv_id| global_env.get_global_invariant(*inv_id).unwrap());
-        SpecTranslator::translate_invariants(auto_trace, builder, invariants)
+        SpecTranslator::translate_invariants(auto_trace, builder, type_args, invariants)
     }
 
     fn translate_spec(&mut self, for_call: bool) {

--- a/language/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/language/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -520,7 +520,12 @@ impl<'env> FunctionTranslator<'env> {
             };
             emitln!(writer, "// function instantiation");
             for (ty_var, ty_inst) in instantiation {
-                emitln!(writer, "#{} := {}", ty_var, ty_inst.display(&display_ctxt));
+                emitln!(
+                    writer,
+                    "// #{} := {};",
+                    ty_var,
+                    ty_inst.display(&display_ctxt)
+                );
             }
             emitln!(writer, "");
         }

--- a/language/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/language/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -723,6 +723,7 @@ impl<'env> FunctionTranslator<'env> {
         // Translate the bytecode instruction.
         match bytecode {
             SaveMem(_, label, mem) => {
+                let mem = &mem.to_owned().instantiate(self.type_inst);
                 let snapshot = boogie_resource_memory_name(env, mem, &Some(*label));
                 let current = boogie_resource_memory_name(env, mem, &None);
                 emitln!(writer, "{} := {};", snapshot, current);

--- a/language/move-prover/boogie-backend/src/spec_translator.rs
+++ b/language/move-prover/boogie-backend/src/spec_translator.rs
@@ -255,14 +255,23 @@ impl<'env> SpecTranslator<'env> {
                 &self.inst(&decl.type_),
             )
         });
+        // it is possible that the spec fun may refer to the same memory after monomorphization,
+        // (e.g., one via concrete type and the other via type parameter being instantiated).
+        // In this case, we mark the other parameter as unused
+        let mut mem_inst_seen = BTreeSet::new();
         let mem_params = fun.used_memory.iter().map(|memory| {
-            let memory = &memory.to_owned().instantiate(&self.type_inst);
+            let memory = memory.to_owned().instantiate(&self.type_inst);
             let struct_env = &self.env.get_struct_qid(memory.to_qualified_id());
-            format!(
+            let param_repr = format!(
                 "{}: $Memory {}",
-                boogie_resource_memory_name(self.env, memory, &None),
+                boogie_resource_memory_name(self.env, &memory, &None),
                 boogie_struct_name(struct_env, &memory.inst)
-            )
+            );
+            if mem_inst_seen.insert(memory) {
+                param_repr
+            } else {
+                format!("__unused_{}", param_repr)
+            }
         });
         let params = fun.params.iter().map(|(name, ty)| {
             format!(

--- a/language/move-prover/bytecode/src/global_invariant_instrumentation.rs
+++ b/language/move-prover/bytecode/src/global_invariant_instrumentation.rs
@@ -140,6 +140,7 @@ impl<'a> Instrumenter<'a> {
         let mut translated = SpecTranslator::translate_invariants(
             self.options.auto_trace_level.invariants(),
             &mut self.builder,
+            &[],
             invariants.iter().filter_map(|id| {
                 env.get_global_invariant(*id).filter(|inv| {
                     if inv.kind == ConditionKind::Invariant {
@@ -209,6 +210,7 @@ impl<'a> Instrumenter<'a> {
         let mut translated = SpecTranslator::translate_invariants(
             self.options.auto_trace_level.invariants(),
             &mut self.builder,
+            &[],
             invariants.iter().cloned(),
         );
 

--- a/language/move-prover/bytecode/src/global_invariant_instrumentation_v2.rs
+++ b/language/move-prover/bytecode/src/global_invariant_instrumentation_v2.rs
@@ -8,20 +8,23 @@ use log::{debug, info, log, warn};
 
 use crate::{
     function_data_builder::FunctionDataBuilder,
-    function_target::FunctionData,
-    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
+    function_target::{FunctionData, FunctionTarget},
+    function_target_pipeline::{
+        FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant, VerificationFlavor,
+    },
+    options::ProverOptions,
     stackless_bytecode::{BorrowNode, Bytecode, Operation, PropKind},
     usage_analysis,
     verification_analysis_v2::InvariantAnalysisData,
 };
 
-use crate::options::ProverOptions;
 use move_model::{
-    ast::{ConditionKind, Exp},
+    ast::{ConditionKind, Exp, GlobalInvariant},
     exp_generator::ExpGenerator,
     model::{FunId, FunctionEnv, GlobalEnv, GlobalId, Loc, QualifiedId, QualifiedInstId, StructId},
     pragmas::CONDITION_ISOLATED_PROP,
     spec_translator::{SpecTranslator, TranslatedSpec},
+    ty::{Type, TypeUnificationAdapter, Variance},
 };
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -38,7 +41,7 @@ impl GlobalInvariantInstrumentationProcessorV2 {
 impl FunctionTargetProcessor for GlobalInvariantInstrumentationProcessorV2 {
     fn process(
         &self,
-        _targets: &mut FunctionTargetsHolder,
+        targets: &mut FunctionTargetsHolder,
         fun_env: &FunctionEnv<'_>,
         data: FunctionData,
     ) -> FunctionData {
@@ -46,13 +49,47 @@ impl FunctionTargetProcessor for GlobalInvariantInstrumentationProcessorV2 {
             // Nothing to do.
             return data;
         }
-
         if !data.variant.is_verified() {
             // Only need to instrument if this is a verification variant
             return data;
         }
 
-        Instrumenter::run(fun_env, data)
+        // Analyze invariants
+        let target = FunctionTarget::new(fun_env, &data);
+        let Analyzer { plain, func_insts } = Analyzer::analyze(&target);
+
+        // Collect information
+        let env = target.global_env();
+        let ty_params = target.get_type_parameters();
+
+        // Create variants for possible function instantiations
+        let mut func_variants = vec![];
+        for (i, (ty_args, mut global_ids)) in func_insts.into_iter().enumerate() {
+            let variant_data = data.fork_with_instantiation(
+                env,
+                &ty_params,
+                &ty_args,
+                FunctionVariant::Verification(VerificationFlavor::Instantiated(i)),
+            );
+            global_ids.extend(plain.clone().into_iter());
+            func_variants.push((variant_data, global_ids));
+        }
+
+        // Instrument the main variant
+        let main = Instrumenter::run(fun_env, data, plain);
+
+        // Instrument the variants representing different instantiations
+        for (variant_data, variant_global_invariants) in func_variants {
+            let variant = Instrumenter::run(fun_env, variant_data, variant_global_invariants);
+            targets.insert_target_data(
+                &fun_env.get_qualified_id(),
+                variant.variant.clone(),
+                variant,
+            );
+        }
+
+        // Return the main variant
+        main
     }
 
     fn name(&self) -> String {
@@ -60,20 +97,122 @@ impl FunctionTargetProcessor for GlobalInvariantInstrumentationProcessorV2 {
     }
 }
 
+struct Analyzer {
+    plain: BTreeSet<GlobalId>,
+    func_insts: BTreeMap<BTreeMap<u16, Type>, BTreeSet<GlobalId>>,
+}
+
+impl Analyzer {
+    pub fn analyze(target: &FunctionTarget) -> Self {
+        let mut analyzer = Self {
+            plain: BTreeSet::new(),
+            func_insts: BTreeMap::new(),
+        };
+        analyzer.collect_related_global_invariants(target);
+        analyzer
+    }
+
+    /// Collect global invariants that are raed and written by this function
+    fn collect_related_global_invariants(&mut self, target: &FunctionTarget) {
+        let env = target.global_env();
+
+        // get memory (list of structs) read or written by the function target,
+        // then find all invariants in loaded modules that refer to that memory.
+        let mut invariants_for_used_memory = BTreeSet::new();
+        for mem in usage_analysis::get_used_memory_inst(target).iter() {
+            invariants_for_used_memory.extend(env.get_global_invariants_for_memory(mem));
+        }
+
+        // filter non-applicable global invariants
+        for invariant_id in invariants_for_used_memory {
+            self.check_gloabl_invariant_applicability(
+                target,
+                env.get_global_invariant(invariant_id).unwrap(),
+            );
+        }
+    }
+
+    fn check_gloabl_invariant_applicability(
+        &mut self,
+        target: &FunctionTarget,
+        invariant: &GlobalInvariant,
+    ) {
+        // marks whether the invariant will be checked in all instantiations of this function
+        let mut is_generic = false;
+
+        // collect instantiations of this function that are needed to check this global invariant
+        let mut func_insts = BTreeSet::new();
+
+        let fun_mems = usage_analysis::get_used_memory_inst(target);
+        for inv_mem in &invariant.mem_usage {
+            for fun_mem in fun_mems.iter() {
+                if inv_mem.module_id != fun_mem.module_id || inv_mem.id != fun_mem.id {
+                    continue;
+                }
+                let adapter =
+                    TypeUnificationAdapter::new_vec(&fun_mem.inst, &inv_mem.inst, true, true);
+                let rel = adapter.unify(Variance::Allow, /* shallow_subst */ false);
+                match rel {
+                    None => continue,
+                    Some((subst_lhs, _)) => {
+                        let inst: BTreeMap<_, _> = subst_lhs
+                            .into_iter()
+                            .map(|(k, v)| match k {
+                                Type::TypeParameter(param_idx) => (param_idx, v),
+                                _ => panic!("Only TypeParameter is expected in the substitution"),
+                            })
+                            .collect();
+                        if inst.is_empty() {
+                            is_generic = true;
+                        } else {
+                            func_insts.insert(inst);
+                        }
+                    }
+                }
+            }
+        }
+
+        // save the instantiation required to evaluate this invariant
+        for inst in func_insts {
+            self.func_insts
+                .entry(inst)
+                .or_insert_with(BTreeSet::new)
+                .insert(invariant.id);
+        }
+        if is_generic {
+            self.plain.insert(invariant.id);
+        }
+    }
+}
+
 struct Instrumenter<'a> {
     options: &'a ProverOptions,
     builder: FunctionDataBuilder<'a>,
+    function_inst: Vec<Type>,
+    related_invariants: BTreeSet<GlobalId>,
     saved_from_before_instr_or_call: Option<(TranslatedSpec, BTreeSet<GlobalId>)>,
 }
 
 impl<'a> Instrumenter<'a> {
-    fn run(fun_env: &FunctionEnv<'a>, data: FunctionData) -> FunctionData {
+    fn run(
+        fun_env: &FunctionEnv<'a>,
+        data: FunctionData,
+        related_invariants: BTreeSet<GlobalId>,
+    ) -> FunctionData {
+        if !data.variant.is_verified() {
+            // Run the instrumentation only if this is a verification variant.
+            return data;
+        }
+
         let global_env = fun_env.module_env.env;
         let options = ProverOptions::get(global_env);
+        let function_inst = data.get_type_instantiation(fun_env);
         let builder = FunctionDataBuilder::new(fun_env, data);
         let mut instrumenter = Instrumenter {
             options: options.as_ref(),
             builder,
+            function_inst,
+            related_invariants,
             saved_from_before_instr_or_call: None,
         };
         instrumenter.instrument(global_env);
@@ -81,72 +220,73 @@ impl<'a> Instrumenter<'a> {
     }
 
     fn instrument(&mut self, global_env: &GlobalEnv) {
-        // Extract and clear current code
-        let old_code = std::mem::take(&mut self.builder.data.code);
+        // Collect information
         let fun_env = self.builder.fun_env;
+        let fun_id = fun_env.get_qualified_id();
+
         let inv_ana_data = global_env.get_extension::<InvariantAnalysisData>().unwrap();
         let disabled_inv_fun_set = &inv_ana_data.disabled_inv_fun_set;
         let target_invariants = &inv_ana_data.target_invariants;
 
-        // Emit entrypoint assumptions if this is a verification variant.
-        if self.builder.data.variant.is_verified() {
-            let fun_id = fun_env.get_qualified_id();
+        // Extract and clear current code
+        let old_code = std::mem::take(&mut self.builder.data.code);
 
-            let entrypoint_invariants = self.compute_entrypoint_invariants();
+        // Emit entrypoint assumptions
+        let entrypoint_invariants = self.filter_entrypoint_invariants(&self.related_invariants);
+        let xlated_spec = SpecTranslator::translate_invariants_by_id(
+            self.options.auto_trace_level.invariants(),
+            &mut self.builder,
+            &self.function_inst,
+            &entrypoint_invariants,
+        );
+        self.assert_or_assume_translated_invariants(
+            &xlated_spec.invariants,
+            &entrypoint_invariants,
+            PropKind::Assume,
+        );
+
+        // In addition to the entrypoint invariants assumed just above, it is necessary
+        // to assume more invariants in a special case.  When invariants are disabled in
+        // this function but not in callers, we will later assert those invariants just
+        // before return instructions.
+        // We need to assume those invariants at the beginning of the function in order
+        // to prove them later. They aren't necessarily entrypoint invariants if we are
+        // verifying a function in a strict dependency, or in a friend module that does not
+        // have the target module in its dependencies.
+        // So, the next code finds the set of target invariants (which will be assumed on return)
+        // and assumes those that are not entrypoint invariants.
+        if disabled_inv_fun_set.contains(&fun_id) {
+            // Separate the update invariants, because we never want to assume them.
+            let (global_target_invs, _update_target_invs) =
+                self.separate_update_invariants(target_invariants);
+            let return_invariants: BTreeSet<_> = global_target_invs
+                .difference(&entrypoint_invariants)
+                .cloned()
+                .collect();
             let xlated_spec = SpecTranslator::translate_invariants_by_id(
                 self.options.auto_trace_level.invariants(),
                 &mut self.builder,
-                &entrypoint_invariants,
+                &self.function_inst,
+                &return_invariants,
             );
             self.assert_or_assume_translated_invariants(
                 &xlated_spec.invariants,
-                &entrypoint_invariants,
+                &return_invariants,
                 PropKind::Assume,
             );
+        }
 
-            // In addition to the entrypoint invariants assumed just above, it is necessary
-            // to assume more invariants in a special case.  When invariants are disabled in
-            // this function but not in callers, we will later assert those invariants just
-            // before return instructions.
-            // We need to assume those invariants at the beginning of the function in order
-            // to prove them later. They aren't necessarily entrypoint invariants if we are
-            // verifying a function in a strict dependency, or in a friend module that does not
-            // have the target module in its dependencies.
-            // So, the next code finds the set of target invariants (which will be assumed on return)
-            // and assumes those that are not entrypoint invariants.
-            if disabled_inv_fun_set.contains(&fun_id) {
-                // Separate the update invariants, because we never want to assume them.
-                let (global_target_invs, _update_target_invs) =
-                    self.separate_update_invariants(&target_invariants);
-                let return_invariants: BTreeSet<GlobalId> = global_target_invs
-                    .difference(&entrypoint_invariants)
-                    .cloned()
-                    .collect();
-                let xlated_spec = SpecTranslator::translate_invariants_by_id(
-                    self.options.auto_trace_level.invariants(),
-                    &mut self.builder,
-                    &return_invariants,
-                );
-                self.assert_or_assume_translated_invariants(
-                    &xlated_spec.invariants,
-                    &return_invariants,
-                    PropKind::Assume,
-                );
-            }
-            // Generate new instrumented code.
-            for bc in old_code {
-                self.instrument_bytecode(bc, fun_id, &inv_ana_data, &entrypoint_invariants);
-            }
-        } else {
-            // just re-emit the bytecode without additional instrumentation
-            for bc in old_code {
-                self.builder.emit(bc);
-            }
+        // Generate new instrumented code.
+        for bc in old_code {
+            self.instrument_bytecode(bc, fun_id, &inv_ana_data, &entrypoint_invariants);
         }
     }
 
     /// Returns list of invariant ids to be assumed at the beginning of the current function.
-    fn compute_entrypoint_invariants(&mut self) -> BTreeSet<GlobalId> {
+    fn filter_entrypoint_invariants(
+        &self,
+        related_invariants: &BTreeSet<GlobalId>,
+    ) -> BTreeSet<GlobalId> {
         // Emit an assume of each invariant over memory touched by this function.
         // Such invariants include
         // - invariants declared in this module, or
@@ -160,24 +300,8 @@ impl<'a> Instrumenter<'a> {
         // - are "update" invariants.
 
         let env = self.builder.global_env();
-        // Invariants with types that are read or written by the function
-        let mut invariants_for_used_memory = BTreeSet::new();
-        // Invariants with types that are written by the function
-        let mut invariants_for_modified_memory = BTreeSet::new();
-
-        // get memory (list of structs) read or written by the function target,
-        // then find all invariants in loaded modules that refer to that memory.
-        for mem in usage_analysis::get_used_memory_inst(&self.builder.get_target()).iter() {
-            invariants_for_used_memory.extend(env.get_global_invariants_for_memory(mem));
-        }
-        // get memory (list of structs) written by function, find the invariants referring to that
-        // memory. Also called "invariants updated by the function"
-        for mem in usage_analysis::get_modified_memory_inst(&self.builder.get_target()).iter() {
-            invariants_for_modified_memory.extend(env.get_global_invariants_for_memory(mem));
-        }
-
         let module_env = &self.builder.fun_env.module_env;
-        invariants_for_used_memory
+        related_invariants
             .iter()
             .filter_map(|id| {
                 env.get_global_invariant(*id).filter(|inv| {
@@ -251,6 +375,7 @@ impl<'a> Instrumenter<'a> {
                     let xlated_spec = SpecTranslator::translate_invariants_by_id(
                         self.options.auto_trace_level.invariants(),
                         &mut self.builder,
+                        &self.function_inst,
                         &global_target_invs,
                     );
                     self.assert_or_assume_translated_invariants(
@@ -382,6 +507,7 @@ impl<'a> Instrumenter<'a> {
         let mut xlated_invs = SpecTranslator::translate_invariants_by_id(
             self.options.auto_trace_level.invariants(),
             &mut self.builder,
+            &self.function_inst,
             &modified_invs,
         );
         // separate out the update invariants, which need to be handled differently from global invs.
@@ -447,7 +573,7 @@ impl<'a> Instrumenter<'a> {
 
     /// Returns the set of invariants modified by a function
     fn get_invs_modified_by_fun(
-        &mut self,
+        &self,
         inv_set: &BTreeSet<GlobalId>,
         fun_id: QualifiedId<FunId>,
         funs_that_modify_inv: &BTreeMap<GlobalId, BTreeSet<QualifiedId<FunId>>>,

--- a/language/move-prover/tests/sources/functional/invariants_with_generics.exp
+++ b/language/move-prover/tests/sources/functional/invariants_with_generics.exp
@@ -80,6 +80,45 @@ error: global memory invariant does not hold
 
 error: global memory invariant does not hold
 
+    ┌── tests/sources/functional/invariants_with_generics.move:34:5 ───
+    │
+ 34 │ ╭     invariant
+ 35 │ │         exists<S::Storage<u64, bool>>(@0x22)
+ 36 │ │             ==> global<S::Storage<u64, bool>>(@0x22).x == 1;
+    │ ╰────────────────────────────────────────────────────────────^
+    │
+    =     at tests/sources/functional/invariants_with_generics.move:15: publish_u64_y
+    =         account = <redacted>
+    =         x = <redacted>
+    =         y = <redacted>
+    =     at tests/sources/functional/invariants_with_generics.move:16: publish_u64_y
+    =     at tests/sources/functional/invariants_with_generics.move:15: publish_u64_y
+    =     at tests/sources/functional/invariants_with_generics.move:16: publish_u64_y
+    =     at tests/sources/functional/invariants_with_generics.move:34
+
+error: global memory invariant does not hold
+
+    ┌── tests/sources/functional/invariants_with_generics.move:45:5 ───
+    │
+ 45 │ ╭     invariant
+ 46 │ │         forall t: type:
+ 47 │ │             exists<S::Storage<t, bool>>(@0x24)
+ 48 │ │                 ==> global<S::Storage<t, bool>>(@0x24).y;
+    │ ╰─────────────────────────────────────────────────────────^
+    │
+    =     at tests/sources/functional/invariants_with_generics.move:15: publish_u64_y
+    =         account = <redacted>
+    =         x = <redacted>
+    =         y = <redacted>
+    =     at tests/sources/functional/invariants_with_generics.move:16: publish_u64_y
+    =     at tests/sources/functional/invariants_with_generics.move:15: publish_u64_y
+    =     at tests/sources/functional/invariants_with_generics.move:16: publish_u64_y
+    =     at tests/sources/functional/invariants_with_generics.move:34
+    =     at tests/sources/functional/invariants_with_generics.move:39
+    =     at tests/sources/functional/invariants_with_generics.move:45
+
+error: global memory invariant does not hold
+
     ┌── tests/sources/functional/invariants_with_generics.move:45:5 ───
     │
  45 │ ╭     invariant
@@ -95,6 +134,103 @@ error: global memory invariant does not hold
     =     at tests/sources/functional/invariants_with_generics.move:21: publish_x_bool
     =     at tests/sources/functional/invariants_with_generics.move:20: publish_x_bool
     =     at tests/sources/functional/invariants_with_generics.move:21: publish_x_bool
+    =     at tests/sources/functional/invariants_with_generics.move:34
+    =     at tests/sources/functional/invariants_with_generics.move:39
+    =     at tests/sources/functional/invariants_with_generics.move:45
+
+error: global memory invariant does not hold
+
+    ┌── tests/sources/functional/invariants_with_generics.move:34:5 ───
+    │
+ 34 │ ╭     invariant
+ 35 │ │         exists<S::Storage<u64, bool>>(@0x22)
+ 36 │ │             ==> global<S::Storage<u64, bool>>(@0x22).x == 1;
+    │ ╰────────────────────────────────────────────────────────────^
+    │
+    =     at tests/sources/functional/invariants_with_generics.move:20: publish_x_bool
+    =         account = <redacted>
+    =         x = <redacted>
+    =         y = <redacted>
+    =     at tests/sources/functional/invariants_with_generics.move:21: publish_x_bool
+    =     at tests/sources/functional/invariants_with_generics.move:20: publish_x_bool
+    =     at tests/sources/functional/invariants_with_generics.move:21: publish_x_bool
+    =     at tests/sources/functional/invariants_with_generics.move:34
+
+error: global memory invariant does not hold
+
+    ┌── tests/sources/functional/invariants_with_generics.move:39:5 ───
+    │
+ 39 │ ╭     invariant
+ 40 │ │         forall t: type:
+ 41 │ │             exists<S::Storage<u64, t>>(@0x23)
+ 42 │ │                 ==> global<S::Storage<u64, t>>(@0x23).x > 0;
+    │ ╰────────────────────────────────────────────────────────────^
+    │
+    =     at tests/sources/functional/invariants_with_generics.move:20: publish_x_bool
+    =         account = <redacted>
+    =         x = <redacted>
+    =         y = <redacted>
+    =     at tests/sources/functional/invariants_with_generics.move:21: publish_x_bool
+    =     at tests/sources/functional/invariants_with_generics.move:20: publish_x_bool
+    =     at tests/sources/functional/invariants_with_generics.move:21: publish_x_bool
+    =     at tests/sources/functional/invariants_with_generics.move:34
+    =     at tests/sources/functional/invariants_with_generics.move:39
+
+error: global memory invariant does not hold
+
+    ┌── tests/sources/functional/invariants_with_generics.move:39:5 ───
+    │
+ 39 │ ╭     invariant
+ 40 │ │         forall t: type:
+ 41 │ │             exists<S::Storage<u64, t>>(@0x23)
+ 42 │ │                 ==> global<S::Storage<u64, t>>(@0x23).x > 0;
+    │ ╰────────────────────────────────────────────────────────────^
+    │
+    =     at tests/sources/functional/invariants_with_generics.move:25: publish_x_y
+    =         account = <redacted>
+    =         x = <redacted>
+    =         y = <redacted>
+    =     at tests/sources/functional/invariants_with_generics.move:26: publish_x_y
+    =     at tests/sources/functional/invariants_with_generics.move:25: publish_x_y
+    =     at tests/sources/functional/invariants_with_generics.move:26: publish_x_y
+    =     at tests/sources/functional/invariants_with_generics.move:34
+    =     at tests/sources/functional/invariants_with_generics.move:39
+
+error: global memory invariant does not hold
+
+    ┌── tests/sources/functional/invariants_with_generics.move:34:5 ───
+    │
+ 34 │ ╭     invariant
+ 35 │ │         exists<S::Storage<u64, bool>>(@0x22)
+ 36 │ │             ==> global<S::Storage<u64, bool>>(@0x22).x == 1;
+    │ ╰────────────────────────────────────────────────────────────^
+    │
+    =     at tests/sources/functional/invariants_with_generics.move:25: publish_x_y
+    =         account = <redacted>
+    =         x = <redacted>
+    =         y = <redacted>
+    =     at tests/sources/functional/invariants_with_generics.move:26: publish_x_y
+    =     at tests/sources/functional/invariants_with_generics.move:25: publish_x_y
+    =     at tests/sources/functional/invariants_with_generics.move:26: publish_x_y
+    =     at tests/sources/functional/invariants_with_generics.move:34
+
+error: global memory invariant does not hold
+
+    ┌── tests/sources/functional/invariants_with_generics.move:45:5 ───
+    │
+ 45 │ ╭     invariant
+ 46 │ │         forall t: type:
+ 47 │ │             exists<S::Storage<t, bool>>(@0x24)
+ 48 │ │                 ==> global<S::Storage<t, bool>>(@0x24).y;
+    │ ╰─────────────────────────────────────────────────────────^
+    │
+    =     at tests/sources/functional/invariants_with_generics.move:25: publish_x_y
+    =         account = <redacted>
+    =         x = <redacted>
+    =         y = <redacted>
+    =     at tests/sources/functional/invariants_with_generics.move:26: publish_x_y
+    =     at tests/sources/functional/invariants_with_generics.move:25: publish_x_y
+    =     at tests/sources/functional/invariants_with_generics.move:26: publish_x_y
     =     at tests/sources/functional/invariants_with_generics.move:34
     =     at tests/sources/functional/invariants_with_generics.move:39
     =     at tests/sources/functional/invariants_with_generics.move:45

--- a/language/move-prover/tests/sources/functional/invariants_with_generics.move
+++ b/language/move-prover/tests/sources/functional/invariants_with_generics.move
@@ -61,8 +61,9 @@ module A {
 
     // TODO (mengxu) all invariants (I1-I4) should be disproved in all functions (F1-F4)
     // currently,
-    // - I1-I3 is disproved in F1
-    // - I2 is disproved in F2
-    // - I3 is disproved in F3
+    // - I1-I3 are disproved in F1
+    // - I1-I3 are disproved in F2
+    // - I1-I3 are disproved in F3
+    // - I1-I3 are disproved in F4
 }
 }

--- a/language/move-prover/tests/sources/regression/Escape.exp
+++ b/language/move-prover/tests/sources/regression/Escape.exp
@@ -1,0 +1,26 @@
+Move prover returns: exiting with boogie verification errors
+error: global memory invariant does not hold
+
+    ┌── tests/sources/regression/Escape.move:36:5 ───
+    │
+ 36 │     invariant forall addr: address where exists<Wrapper<IndoorThing>>(addr): addr == @0x123;
+    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/regression/Escape.move:24: install
+    =         account = <redacted>
+    =         thing = <redacted>
+    =     at tests/sources/regression/Escape.move:25: install
+    =     at tests/sources/regression/Escape.move:36
+
+error: global memory invariant does not hold
+
+    ┌── tests/sources/regression/Escape.move:37:5 ───
+    │
+ 37 │     invariant forall addr: address where exists<Wrapper<OutdoorThing>>(addr): addr == @0x123;
+    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/regression/Escape.move:24: install
+    =         account = <redacted>
+    =         thing = <redacted>
+    =     at tests/sources/regression/Escape.move:25: install
+    =     at tests/sources/regression/Escape.move:37

--- a/language/move-prover/tests/sources/regression/Escape.move
+++ b/language/move-prover/tests/sources/regression/Escape.move
@@ -25,14 +25,15 @@ module Escape {
         move_to<Wrapper<Thing>>(account, Wrapper{ thing });
     }
 
-    // TODO: Both verify, but only the first should. Currently they verify because of a gap
-    // in monomorphization. It needs to specialize functions which depend on global
-    // invariants for the type instantantiations used in there. But we only verify
-    // install for a generic parameter. So we need to generate specialized
-    // install<IndoorThing> and install<OutdoorThing> verification variants.
+    // TODO: Currently both invariants do not verify, which is expected.
+    //
+    // But the first invariant could be verified because an `IndoorThing` can
+    // never escape from the current modul. By escape, we mean, holding an
+    // object of type `IndoorThing`. This is a fact given by the type system.
+    //
+    // In comparision, an `OutdoorThing` can escape because that the
+    // `new_outdoor_thing` function returns an object of the `OutdoorThing` type
     invariant forall addr: address where exists<Wrapper<IndoorThing>>(addr): addr == @0x123;
     invariant forall addr: address where exists<Wrapper<OutdoorThing>>(addr): addr == @0x123;
-
 }
-
 }

--- a/language/move-prover/tests/sources/regression/spec_fun_same_mem_param.move
+++ b/language/move-prover/tests/sources/regression/spec_fun_same_mem_param.move
@@ -1,0 +1,49 @@
+address 0x2 {
+module Coin {
+    struct Coin<T: store> has key { f: T, v: u64 }
+
+    public fun coin_exists<T: store>(): bool {
+        exists<Coin<T>>(@0x2)
+    }
+
+    public fun coin_info<T: store>(): u64 acquires Coin {
+        *&borrow_global<Coin<T>>(@0x2).v
+    }
+}
+
+module XUS {
+    struct XUS has store {}
+}
+
+module XDX {
+    use 0x2::Coin::Coin;
+    use 0x2::Coin::coin_exists;
+    use 0x2::Coin::coin_info;
+
+    struct XDX has store {}
+
+    spec fun spec_is_xdx<T: store>(): bool {
+        exists<Coin<T>>(@0x2) && exists<Coin<XDX>>(@0x2) &&
+            global<Coin<T>>(@0x2).v == global<Coin<XDX>>(@0x2).v
+    }
+
+    public fun is_xdx<T: store>(): bool {
+        coin_exists<T>() && coin_exists<XDX>() &&
+            coin_info<T>() == coin_info<XDX>()
+    }
+    spec is_xdx {
+        pragma opaque;
+        ensures result == spec_is_xdx<T>();
+    }
+}
+
+module Check {
+    use 0x2::XUS::XUS;
+    use 0x2::XDX::XDX;
+    use 0x2::XDX::is_xdx;
+
+    public fun check(): bool {
+        is_xdx<XUS>() && is_xdx<XDX>()
+    }
+}
+}


### PR DESCRIPTION
The first three commits of this PR are bug fixes that
- fix a bug where the type instantiation info is not commented out
- fix a bug when the spec fun produces two identical params
- fix a bug on variable name translation for SaveMem
These commits can be reviewed separately.

The main focus of this PR is this commit:
**[move-prover] split global invariant instrumentation into two steps**

- Step 1: collect related global invariants as well as corresponding
function instantiations that matches with these global invariants. This
step is encapsulated within the `Analyzer` struct.

- Step 2: instantiating function variants and instrumentation of the
global invariants. This step is encapsulated within the `Instrumenter`
struct.

The last fixup! commit updates the expected value tests for
- `Escape.move` which we could now disapprove, and
- `invariants_with_generics.move` with additional progress.

## Motivation

On the implementation of the generic global invariant evaluation scheme

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- CI
- test cases updated
