### PR TITLE
[move-prover] fork verification variants for func instantiations

### DIFF
--- a/language/move-prover/bytecode/src/function_target_pipeline.rs
+++ b/language/move-prover/bytecode/src/function_target_pipeline.rs
@@ -24,6 +24,7 @@ pub struct FunctionTargetsHolder {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum VerificationFlavor {
     Regular,
+    Instantiated(usize),
     Inconsistency,
 }
 
@@ -31,6 +32,9 @@ impl std::fmt::Display for VerificationFlavor {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             VerificationFlavor::Regular => write!(f, ""),
+            VerificationFlavor::Instantiated(index) => {
+                write!(f, "instantiated_{}", index)
+            }
             VerificationFlavor::Inconsistency => write!(f, "inconsistency"),
         }
     }


### PR DESCRIPTION
Fork the function data and rewrite the bytecode and expressions with
type parameter instantiated.

## Motivation

Prepare for instantiating functions for global invariants. But it is better to
have the code in a standalone PR as it might be useful in some other places.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI
