### PR TITLE
forge: add support for heterogeneous node versions

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -693,6 +693,7 @@ jobs:
       - uses: actions/checkout@v2.3.4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0 #get all the history!!!
       - uses: ./.github/actions/build-setup
       - name: split tests
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3255,6 +3255,7 @@ dependencies = [
  "rand_core 0.6.2",
  "rayon",
  "reqwest",
+ "serde",
  "serde_json",
  "structopt 0.3.21",
  "tempfile",

--- a/config/management/genesis/src/config_builder.rs
+++ b/config/management/genesis/src/config_builder.rs
@@ -125,7 +125,6 @@ pub fn test_config() -> (NodeConfig, Ed25519PrivateKey) {
         path.path(),
         diem_framework_releases::current_module_blobs().to_vec(),
     )
-    .num_validators(1)
     .template(NodeConfig::default_for_validator());
     let (mut configs, key) = builder.build_swarm().unwrap();
 

--- a/config/management/genesis/src/validator_builder.rs
+++ b/config/management/genesis/src/validator_builder.rs
@@ -34,6 +34,7 @@ use std::{
     convert::TryFrom,
     fs::File,
     io::Write,
+    num::NonZeroUsize,
     path::{Path, PathBuf},
 };
 
@@ -157,7 +158,7 @@ pub struct ValidatorBuilder {
     config_directory: PathBuf,
     /// Bytecodes of Move genesis modules
     move_modules: Vec<Vec<u8>>,
-    num_validators: usize,
+    num_validators: NonZeroUsize,
     randomize_first_validator_ports: bool,
     template: NodeConfig,
 }
@@ -167,7 +168,7 @@ impl ValidatorBuilder {
         Self {
             config_directory: config_directory.as_ref().into(),
             move_modules,
-            num_validators: 1,
+            num_validators: NonZeroUsize::new(1).unwrap(),
             randomize_first_validator_ports: true,
             template: NodeConfig::default_for_validator(),
         }
@@ -178,7 +179,7 @@ impl ValidatorBuilder {
         self
     }
 
-    pub fn num_validators(mut self, num_validators: usize) -> Self {
+    pub fn num_validators(mut self, num_validators: NonZeroUsize) -> Self {
         self.num_validators = num_validators;
         self
     }
@@ -199,7 +200,7 @@ impl ValidatorBuilder {
         let root_keys = RootKeys::generate(&mut rng);
 
         // Generate and initialize Validator configs
-        let mut validators = (0..self.num_validators)
+        let mut validators = (0..self.num_validators.get())
             .map(|i| {
                 self.initialize_validator_config(
                     i,

--- a/diem-node/src/lib.rs
+++ b/diem-node/src/lib.rs
@@ -111,7 +111,6 @@ pub fn load_test_environment(config_path: Option<PathBuf>, random_ports: bool) {
         &config_path,
         diem_framework_releases::current_module_blobs().to_vec(),
     )
-    .num_validators(1)
     .template(template)
     .randomize_first_validator_ports(random_ports);
     let test_config =

--- a/json-rpc/integration-tests/tests/jsonrpc-forge.rs
+++ b/json-rpc/integration-tests/tests/jsonrpc-forge.rs
@@ -5,8 +5,8 @@ use forge::{forge_main, ForgeConfig, LocalFactory, Options, Result};
 use jsonrpc_integration_tests::*;
 
 fn main() -> Result<()> {
-    let tests = ForgeConfig {
-        public_usage_tests: &[
+    let tests = ForgeConfig::default()
+        .with_public_usage_tests(&[
             &CurrencyInfo,
             &BlockMetadata,
             &OldMetadata,
@@ -33,8 +33,8 @@ fn main() -> Result<()> {
             &MultiAgentPaymentOverDualAttestationLimit,
             &GetAccumulatorConsistencyProof,
             &NoUnknownEvents,
-        ],
-        admin_tests: &[
+        ])
+        .with_admin_tests(&[
             &PreburnAndBurnEvents,
             &CancleBurnEvent,
             &UpdateExchangeRateEvent,
@@ -44,9 +44,7 @@ fn main() -> Result<()> {
             &MultiAgentRotateAuthenticationKeyAdminScriptFunction,
             &UpgradeEventAndNewEpoch,
             &UpgradeDiemVersion,
-        ],
-        network_tests: &[],
-    };
+        ]);
 
     let options = Options::from_args();
     forge_main(tests, LocalFactory::from_workspace()?, &options)

--- a/language/diem-tools/oncall-trainer/src/init.rs
+++ b/language/diem-tools/oncall-trainer/src/init.rs
@@ -62,7 +62,6 @@ impl NodeInfo {
             &config_path,
             diem_framework_releases::current_module_blobs().to_vec(),
         )
-        .num_validators(1)
         .template(template)
         .randomize_first_validator_ports(true);
         let test_config =

--- a/testsuite/diem-swarm/src/swarm.rs
+++ b/testsuite/diem-swarm/src/swarm.rs
@@ -24,6 +24,7 @@ use std::{
     env,
     fs::File,
     io::{self, Read},
+    num::NonZeroUsize,
     path::{Path, PathBuf},
     process::{Child, Command},
     str::FromStr,
@@ -528,7 +529,7 @@ impl DiemSwarm {
             &config_path,
             diem_framework_releases::current_module_blobs().to_vec(),
         )
-        .num_validators(num_nodes)
+        .num_validators(NonZeroUsize::new(num_nodes).unwrap())
         .template(node_config);
         let config = SwarmConfig::build(&builder, config_path)?;
 

--- a/testsuite/forge/Cargo.toml
+++ b/testsuite/forge/Cargo.toml
@@ -20,6 +20,7 @@ termcolor = "1.1.2"
 tokio = { version = "1.8.1", features = ["full"] }
 reqwest = { version = "0.11.2", features = ["blocking", "json"] }
 rand_core = "0.6.2"
+serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
 url = "2.2.2"
 tempfile = "3.2.0"

--- a/testsuite/forge/src/backend/k8s/mod.rs
+++ b/testsuite/forge/src/backend/k8s/mod.rs
@@ -1,9 +1,9 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{Factory, Swarm};
-use anyhow::{format_err, Error};
-use std::{env, fs::File, io::Read, path::PathBuf};
+use crate::{Factory, Result, Swarm, Version};
+use anyhow::format_err;
+use std::{env, fs::File, io::Read, num::NonZeroUsize, path::PathBuf};
 use tokio::runtime::Runtime;
 
 mod node;
@@ -21,7 +21,7 @@ pub struct K8sFactory {
 }
 
 impl K8sFactory {
-    pub fn new(helm_repo: String) -> std::result::Result<K8sFactory, Error> {
+    pub fn new(helm_repo: String) -> Result<K8sFactory> {
         let vault_addr = env::var("VAULT_ADDR")
             .map_err(|_| format_err!("Expected environment variable VAULT_ADDR"))?;
         let vault_cacert = env::var("VAULT_CACERT")
@@ -66,7 +66,14 @@ impl K8sFactory {
 }
 
 impl Factory for K8sFactory {
-    fn launch_swarm(&self, _node_num: usize) -> Box<dyn Swarm> {
+    fn versions<'a>(&'a self) -> Box<dyn Iterator<Item = Version> + 'a> {
+        Box::new(std::iter::once(Version::new(
+            0,
+            "mock-version (k8s does not currently support node versions)".into(),
+        )))
+    }
+
+    fn launch_swarm(&self, _node_num: NonZeroUsize, _version: &Version) -> Result<Box<dyn Swarm>> {
         let rt = Runtime::new().unwrap();
         let swarm = rt
             .block_on(K8sSwarm::new(
@@ -75,6 +82,6 @@ impl Factory for K8sFactory {
                 &self.helm_repo,
             ))
             .unwrap();
-        Box::new(swarm)
+        Ok(Box::new(swarm))
     }
 }

--- a/testsuite/forge/src/backend/k8s/node.rs
+++ b/testsuite/forge/src/backend/k8s/node.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{FullNode, HealthCheckError, Node, Result, Validator};
+use crate::{FullNode, HealthCheckError, Node, Result, Validator, Version};
 use anyhow::format_err;
 use diem_config::config::NodeConfig;
 use diem_sdk::{client::Client as JsonRpcClient, types::PeerId};
@@ -50,6 +50,10 @@ impl Node for K8sNode {
 
     fn name(&self) -> &str {
         &self.name
+    }
+
+    fn version(&self) -> Version {
+        todo!()
     }
 
     fn json_rpc_endpoint(&self) -> Url {

--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -184,7 +184,7 @@ impl Swarm for K8sSwarm {
         })
     }
 
-    fn validators<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a dyn Validator> + 'a> {
+    fn validators<'a>(&'a self) -> Box<dyn Iterator<Item = &'a dyn Validator> + 'a> {
         Box::new(self.validators.values().map(|v| v as &'a dyn Validator))
     }
 

--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     backend::k8s::node::K8sNode, query_sequence_numbers, ChainInfo, FullNode, Node, Result, Swarm,
-    Validator,
+    Validator, Version,
 };
 use anyhow::{bail, format_err};
 use diem_logger::*;
@@ -239,6 +239,10 @@ impl Swarm for K8sSwarm {
     }
 
     fn remove_full_node(&mut self, _id: PeerId) -> Result<()> {
+        todo!()
+    }
+
+    fn versions<'a>(&'a self) -> Box<dyn Iterator<Item = Version> + 'a> {
         todo!()
     }
 

--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -210,7 +210,7 @@ impl Swarm for K8sSwarm {
         todo!()
     }
 
-    fn full_nodes<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a dyn FullNode> + 'a> {
+    fn full_nodes<'a>(&'a self) -> Box<dyn Iterator<Item = &'a dyn FullNode> + 'a> {
         Box::new(self.fullnodes.values().map(|v| v as &'a dyn FullNode))
     }
 

--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -206,6 +206,10 @@ impl Swarm for K8sSwarm {
             .map(|v| v as &mut dyn Validator)
     }
 
+    fn upgrade_validator(&mut self, _id: PeerId, _version: &Version) -> Result<()> {
+        todo!()
+    }
+
     fn full_nodes<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a dyn FullNode> + 'a> {
         Box::new(self.fullnodes.values().map(|v| v as &'a dyn FullNode))
     }

--- a/testsuite/forge/src/backend/local/cargo.rs
+++ b/testsuite/forge/src/backend/local/cargo.rs
@@ -1,0 +1,166 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::Result;
+use anyhow::{bail, Context};
+use serde::Deserialize;
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+use tempfile::NamedTempFile;
+
+#[derive(Deserialize)]
+pub struct Metadata {
+    pub target_directory: PathBuf,
+    pub workspace_root: PathBuf,
+}
+
+pub fn metadata() -> Result<Metadata> {
+    let output = Command::new("cargo")
+        .arg("metadata")
+        .arg("--no-deps")
+        .arg("--format-version=1")
+        .output()
+        .context("Failed to query cargo metadata")?;
+
+    serde_json::from_slice(&output.stdout).map_err(Into::into)
+}
+
+/// Get the diem node binary from the current working directory
+pub fn get_diem_node_binary_from_worktree() -> Result<(String, PathBuf)> {
+    let metadata = metadata()?;
+    let mut revision = git_rev_parse(&metadata, "HEAD")?;
+    if git_is_worktree_dirty()? {
+        revision.push_str("-dirty");
+    }
+
+    let bin_path = cargo_build_diem_node(&metadata.workspace_root, &metadata.target_directory)?;
+
+    Ok((revision, bin_path))
+}
+
+/// This function will attempt to build the diem-node binary at an arbitrary revision.
+/// Using the `target/forge` as a working directory it will do the following:
+///     1. Look for a binary named `diem-node--<revision>`, if it already exists return it
+///     2. If the binary doesn't exist check out the revision to `target/forge/revision` by doing
+///        `git archive --format=tar <revision> | tar x`
+///     3. Using the `target/forge/target` directory as a cargo artifact directory, build the
+///        binary and then move it to `target/forge/diem-node--<revision>`
+pub fn get_diem_node_binary_at_revision(revision: &str) -> Result<(String, PathBuf)> {
+    let metadata = metadata()?;
+    let forge_directory = metadata.target_directory.join("forge");
+    let revision = git_rev_parse(&metadata, format!("{}^{{commit}}", revision))?;
+    let checkout_dir = forge_directory.join(&revision);
+    let forge_target_directory = forge_directory.join("target");
+    let diem_node_bin = forge_directory.join(format!(
+        "diem-node--{}{}",
+        revision,
+        env::consts::EXE_SUFFIX
+    ));
+
+    if diem_node_bin.exists() {
+        return Ok((revision, diem_node_bin));
+    }
+
+    fs::create_dir_all(&forge_target_directory)?;
+
+    checkout_revision(&metadata, &revision, &checkout_dir)?;
+
+    fs::rename(
+        cargo_build_diem_node(&checkout_dir, &forge_target_directory)?,
+        &diem_node_bin,
+    )?;
+
+    let _ = fs::remove_dir_all(&checkout_dir);
+
+    Ok((revision, diem_node_bin))
+}
+
+fn git_rev_parse<R: AsRef<str>>(metadata: &Metadata, rev: R) -> Result<String> {
+    let rev = rev.as_ref();
+    let output = Command::new("git")
+        .current_dir(&metadata.workspace_root)
+        .arg("rev-parse")
+        .arg(rev)
+        .output()
+        .context("Failed to parse revision")?;
+    if output.status.success() {
+        String::from_utf8(output.stdout)
+            .map(|s| s.trim().to_owned())
+            .map_err(Into::into)
+    } else {
+        bail!("Failed to parse revision: {}", rev);
+    }
+}
+
+// Determine if the worktree is dirty
+fn git_is_worktree_dirty() -> Result<bool> {
+    Command::new("git")
+        .args(&["diff-index", "--name-only", "HEAD", "--"])
+        .output()
+        .context("Failed to determine if the worktree is dirty")
+        .map(|output| !output.stdout.is_empty())
+}
+
+fn cargo_build_diem_node<D, T>(directory: D, target_directory: T) -> Result<PathBuf>
+where
+    D: AsRef<Path>,
+    T: AsRef<Path>,
+{
+    let target_directory = target_directory.as_ref();
+    let output = Command::new("cargo")
+        .current_dir(directory)
+        .env("CARGO_TARGET_DIR", target_directory)
+        .args(&["build", "--bin=diem-node"])
+        .output()
+        .context("Failed to build diem-node")?;
+
+    if output.status.success() {
+        let bin_path =
+            target_directory.join(format!("debug/{}{}", "diem-node", env::consts::EXE_SUFFIX));
+        if !bin_path.exists() {
+            bail!(
+                "Can't find binary diem-node at expected path {:?}",
+                bin_path
+            );
+        }
+
+        Ok(bin_path)
+    } else {
+        bail!("Faild to build diem-node");
+    }
+}
+
+fn checkout_revision(metadata: &Metadata, revision: &str, to: &Path) -> Result<()> {
+    fs::create_dir_all(to)?;
+
+    let archive_file = NamedTempFile::new()?.into_temp_path();
+
+    let output = Command::new("git")
+        .current_dir(&metadata.workspace_root)
+        .arg("archive")
+        .arg("--format=tar")
+        .arg("--output")
+        .arg(&archive_file)
+        .arg(&revision)
+        .output()
+        .context("Failed to run git archive")?;
+    if !output.status.success() {
+        bail!("Failed to run git archive");
+    }
+
+    let output = Command::new("tar")
+        .current_dir(to)
+        .arg("xf")
+        .arg(&archive_file)
+        .output()
+        .context("Failed to run tar")?;
+
+    if !output.status.success() {
+        bail!("Failed to run tar");
+    }
+
+    Ok(())
+}

--- a/testsuite/forge/src/backend/local/mod.rs
+++ b/testsuite/forge/src/backend/local/mod.rs
@@ -1,29 +1,86 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{Factory, Result, Swarm};
+use crate::{Factory, Result, Swarm, Version};
 use anyhow::{bail, Context};
-use std::{env, path::PathBuf, process::Command};
+use std::{
+    collections::HashMap,
+    env,
+    path::{Path, PathBuf},
+    process::Command,
+    sync::Arc,
+};
 
 mod node;
 mod swarm;
 pub use node::LocalNode;
-pub use swarm::{LocalSwarm, LocalSwarmBuilder};
+pub use swarm::{LocalSwarm, LocalSwarmBuilder, SwarmDirectory};
+
+#[derive(Clone, Debug)]
+pub struct LocalVersion {
+    revision: String,
+    bin: PathBuf,
+    version: Version,
+}
+
+impl LocalVersion {
+    fn bin(&self) -> &Path {
+        &self.bin
+    }
+
+    fn version(&self) -> Version {
+        self.version.clone()
+    }
+}
 
 pub struct LocalFactory {
-    diem_node_bin: String,
+    versions: Arc<HashMap<Version, LocalVersion>>,
 }
 
 impl LocalFactory {
-    pub fn new(diem_node_bin: &str) -> Self {
+    pub fn new(versions: HashMap<Version, LocalVersion>) -> Self {
         Self {
-            diem_node_bin: diem_node_bin.into(),
+            versions: Arc::new(versions),
         }
     }
 
     pub fn from_workspace() -> Result<Self> {
-        Ok(Self::new(get_diem_node()?.to_str().unwrap()))
+        let mut versions = HashMap::new();
+        let new_version = head_version().map(|(revision, bin)| {
+            let version = Version::new(usize::max_value(), revision.clone());
+            LocalVersion {
+                revision,
+                bin,
+                version,
+            }
+        })?;
+
+        versions.insert(new_version.version.clone(), new_version);
+        Ok(Self::new(versions))
     }
+}
+
+fn head_version() -> Result<(String, PathBuf)> {
+    let output = Command::new("git")
+        .args(&["rev-parse", "HEAD"])
+        .output()
+        .context("Failed to get git revision")?;
+    let mut revision = String::from_utf8(output.stdout)?;
+
+    // Determine if the worktree is dirty
+    if !Command::new("git")
+        .args(&["diff-index", "--name-only", "HEAD", "--"])
+        .output()
+        .context("Failed to determine if the worktree is dirty")?
+        .stdout
+        .is_empty()
+    {
+        revision.push_str("-dirty");
+    }
+
+    let bin = get_diem_node()?;
+
+    Ok((revision, bin))
 }
 
 fn get_diem_node() -> Result<PathBuf> {
@@ -74,7 +131,7 @@ fn build_dir() -> Result<PathBuf> {
 
 impl Factory for LocalFactory {
     fn launch_swarm(&self, node_num: usize) -> Box<dyn Swarm> {
-        let mut swarm = LocalSwarm::builder(&self.diem_node_bin)
+        let mut swarm = LocalSwarm::builder(self.versions.clone())
             .number_of_validators(node_num)
             .build()
             .unwrap();

--- a/testsuite/forge/src/backend/local/mod.rs
+++ b/testsuite/forge/src/backend/local/mod.rs
@@ -97,6 +97,13 @@ impl LocalFactory {
         versions.insert(revision.version(), revision);
         Ok(Self::new(versions))
     }
+
+    /// Create a LocalFactory with a diem-node version built at the tip of upstream/main and the
+    /// current workspace, suitable for compatibility testing.
+    pub fn with_upstream_and_workspace() -> Result<Self> {
+        let upstream_main = cargo::git_get_upstream_remote().map(|r| format!("{}/main", r))?;
+        Self::with_revision_and_workspace(&upstream_main)
+    }
 }
 
 impl Factory for LocalFactory {

--- a/testsuite/forge/src/backend/local/mod.rs
+++ b/testsuite/forge/src/backend/local/mod.rs
@@ -114,7 +114,7 @@ impl Factory for LocalFactory {
 
     fn launch_swarm(&self, node_num: NonZeroUsize, version: &Version) -> Result<Box<dyn Swarm>> {
         let mut swarm = LocalSwarm::builder(self.versions.clone())
-            .number_of_validators(node_num.get())
+            .number_of_validators(node_num)
             .initial_version(version.clone())
             .build()?;
         swarm.launch()?;

--- a/testsuite/forge/src/backend/local/mod.rs
+++ b/testsuite/forge/src/backend/local/mod.rs
@@ -72,6 +72,31 @@ impl LocalFactory {
         versions.insert(new_version.version.clone(), new_version);
         Ok(Self::new(versions))
     }
+
+    pub fn with_revision_and_workspace(revision: &str) -> Result<Self> {
+        let workspace = cargo::get_diem_node_binary_from_worktree().map(|(revision, bin)| {
+            let version = Version::new(usize::max_value(), revision.clone());
+            LocalVersion {
+                revision,
+                bin,
+                version,
+            }
+        })?;
+        let revision =
+            cargo::get_diem_node_binary_at_revision(revision).map(|(revision, bin)| {
+                let version = Version::new(usize::min_value(), revision.clone());
+                LocalVersion {
+                    revision,
+                    bin,
+                    version,
+                }
+            })?;
+
+        let mut versions = HashMap::new();
+        versions.insert(workspace.version(), workspace);
+        versions.insert(revision.version(), revision);
+        Ok(Self::new(versions))
+    }
 }
 
 impl Factory for LocalFactory {

--- a/testsuite/forge/src/backend/local/node.rs
+++ b/testsuite/forge/src/backend/local/node.rs
@@ -131,6 +131,12 @@ impl LocalNode {
         &self.config
     }
 
+    pub fn upgrade(&mut self, version: LocalVersion) -> Result<()> {
+        self.stop();
+        self.version = version;
+        self.start()
+    }
+
     pub fn get_log_contents(&self) -> Result<String> {
         fs::read_to_string(self.log_path()).map_err(Into::into)
     }

--- a/testsuite/forge/src/backend/local/node.rs
+++ b/testsuite/forge/src/backend/local/node.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{HealthCheckError, LocalVersion, Node, NodeExt, Validator, Version};
+use crate::{FullNode, HealthCheckError, LocalVersion, Node, NodeExt, Validator, Version};
 use anyhow::{anyhow, Context, Result};
 use diem_config::config::NodeConfig;
 use diem_logger::{debug, warn};
@@ -223,3 +223,4 @@ impl Node for LocalNode {
 }
 
 impl Validator for LocalNode {}
+impl FullNode for LocalNode {}

--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -15,7 +15,9 @@ use diem_sdk::{
 use std::{
     collections::HashMap,
     convert::TryFrom,
-    fs, mem, ops,
+    fs, mem,
+    num::NonZeroUsize,
+    ops,
     path::{Path, PathBuf},
     sync::Arc,
     time::{Duration, Instant},
@@ -78,7 +80,7 @@ pub struct LocalSwarmBuilder {
     versions: Arc<HashMap<Version, LocalVersion>>,
     initial_version: Option<Version>,
     template: NodeConfig,
-    number_of_validators: usize,
+    number_of_validators: NonZeroUsize,
     dir: Option<PathBuf>,
 }
 
@@ -88,7 +90,7 @@ impl LocalSwarmBuilder {
             versions,
             initial_version: None,
             template: NodeConfig::default_for_validator(),
-            number_of_validators: 1,
+            number_of_validators: NonZeroUsize::new(1).unwrap(),
             dir: None,
         }
     }
@@ -103,7 +105,7 @@ impl LocalSwarmBuilder {
         self
     }
 
-    pub fn number_of_validators(mut self, number_of_validators: usize) -> Self {
+    pub fn number_of_validators(mut self, number_of_validators: NonZeroUsize) -> Self {
         self.number_of_validators = number_of_validators;
         self
     }

--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -335,7 +335,7 @@ impl Swarm for LocalSwarm {
         validator.upgrade(version)
     }
 
-    fn full_nodes<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a dyn FullNode> + 'a> {
+    fn full_nodes<'a>(&'a self) -> Box<dyn Iterator<Item = &'a dyn FullNode> + 'a> {
         todo!()
     }
 

--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -171,6 +171,7 @@ impl LocalSwarmBuilder {
         Ok(LocalSwarm {
             versions: self.versions,
             validators,
+            full_nodes: HashMap::new(),
             dir,
             validator_network_address_encryption_key,
             root_account,
@@ -185,6 +186,7 @@ impl LocalSwarmBuilder {
 pub struct LocalSwarm {
     versions: Arc<HashMap<Version, LocalVersion>>,
     validators: HashMap<PeerId, LocalNode>,
+    full_nodes: HashMap<PeerId, LocalNode>,
     dir: SwarmDirectory,
     validator_network_address_encryption_key: ValidatorNetworkAddressEncryptionKey,
     root_account: LocalAccount,
@@ -336,19 +338,23 @@ impl Swarm for LocalSwarm {
     }
 
     fn full_nodes<'a>(&'a self) -> Box<dyn Iterator<Item = &'a dyn FullNode> + 'a> {
-        todo!()
+        Box::new(self.full_nodes.values().map(|v| v as &'a dyn FullNode))
     }
 
     fn full_nodes_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut dyn FullNode> + 'a> {
-        todo!()
+        Box::new(
+            self.full_nodes
+                .values_mut()
+                .map(|v| v as &'a mut dyn FullNode),
+        )
     }
 
-    fn full_node(&self, _id: PeerId) -> Option<&dyn FullNode> {
-        todo!()
+    fn full_node(&self, id: PeerId) -> Option<&dyn FullNode> {
+        self.full_nodes.get(&id).map(|v| v as &dyn FullNode)
     }
 
-    fn full_node_mut(&mut self, _id: PeerId) -> Option<&mut dyn FullNode> {
-        todo!()
+    fn full_node_mut(&mut self, id: PeerId) -> Option<&mut dyn FullNode> {
+        self.full_nodes.get_mut(&id).map(|v| v as &mut dyn FullNode)
     }
 
     fn add_validator(&mut self, _id: PeerId) -> Result<PeerId> {

--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -300,7 +300,7 @@ impl Swarm for LocalSwarm {
         todo!()
     }
 
-    fn validators<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a dyn Validator> + 'a> {
+    fn validators<'a>(&'a self) -> Box<dyn Iterator<Item = &'a dyn Validator> + 'a> {
         Box::new(self.validators.values().map(|v| v as &'a dyn Validator))
     }
 

--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -322,6 +322,19 @@ impl Swarm for LocalSwarm {
             .map(|v| v as &mut dyn Validator)
     }
 
+    fn upgrade_validator(&mut self, id: PeerId, version: &Version) -> Result<()> {
+        let version = self
+            .versions
+            .get(&version)
+            .cloned()
+            .ok_or_else(|| anyhow!("Invalid version: {:?}", version))?;
+        let validator = self
+            .validators
+            .get_mut(&id)
+            .ok_or_else(|| anyhow!("Invalid id: {}", id))?;
+        validator.upgrade(version)
+    }
+
     fn full_nodes<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a dyn FullNode> + 'a> {
         todo!()
     }

--- a/testsuite/forge/src/interface/factory.rs
+++ b/testsuite/forge/src/interface/factory.rs
@@ -1,9 +1,13 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use super::Swarm;
+use super::{Swarm, Version};
+use crate::Result;
+use std::num::NonZeroUsize;
 
 /// Trait used to represent a interface for constructing a launching new networks
 pub trait Factory {
-    fn launch_swarm(&self, node_num: usize) -> Box<dyn Swarm>;
+    fn versions<'a>(&'a self) -> Box<dyn Iterator<Item = Version> + 'a>;
+
+    fn launch_swarm(&self, node_num: NonZeroUsize, version: &Version) -> Result<Box<dyn Swarm>>;
 }

--- a/testsuite/forge/src/interface/mod.rs
+++ b/testsuite/forge/src/interface/mod.rs
@@ -17,3 +17,26 @@ mod node;
 pub use node::*;
 mod chain_info;
 pub use chain_info::*;
+
+/// A wrapper around a usize in order to represent an opaque version of a Node.
+///
+/// It is intended that backends will be able to take this opaque version identifier and lookup the
+/// appropriate version information internally to be able to determine the version of node software
+/// to use.
+///
+/// It's expected that `Version`s returned by querying a `Factory` or a `Swarm` will be sort-able
+/// such that they'll be ordered with older versions first, e.g. older -> newer.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Version(usize, String);
+
+impl Version {
+    pub fn new(version: usize, display_string: String) -> Self {
+        Self(version, display_string)
+    }
+}
+
+impl std::fmt::Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.1)
+    }
+}

--- a/testsuite/forge/src/interface/node.rs
+++ b/testsuite/forge/src/interface/node.rs
@@ -4,7 +4,10 @@
 use crate::{Result, Version};
 use debug_interface::NodeDebugClient;
 use diem_config::{config::NodeConfig, network_id::NetworkId};
-use diem_sdk::{client::Client as JsonRpcClient, types::PeerId};
+use diem_sdk::{
+    client::{BlockingClient, Client as JsonRpcClient},
+    types::PeerId,
+};
 use std::{
     collections::HashMap,
     thread,
@@ -87,8 +90,13 @@ impl<T: ?Sized> NodeExt for T where T: Node {}
 
 pub trait NodeExt: Node {
     /// Return JSON-RPC client of this Node
-    fn json_rpc_client(&self) -> JsonRpcClient {
+    fn async_json_rpc_client(&self) -> JsonRpcClient {
         JsonRpcClient::new(self.json_rpc_endpoint().to_string())
+    }
+
+    /// Return JSON-RPC client of this Node
+    fn json_rpc_client(&self) -> BlockingClient {
+        BlockingClient::new(self.json_rpc_endpoint())
     }
 
     /// Return a NodeDebugClient for this Node

--- a/testsuite/forge/src/interface/node.rs
+++ b/testsuite/forge/src/interface/node.rs
@@ -84,7 +84,16 @@ pub trait Validator: Node {
 }
 
 /// Trait used to represent a running FullNode
-pub trait FullNode: Node {}
+pub trait FullNode: Node {
+    //TODO handle VFNs querying if they are connected to a validator
+    fn check_connectivity(&self) -> Result<bool> {
+        const DIRECTION: Option<&str> = Some("outbound");
+        const EXPECTED_PEERS: usize = 1;
+
+        self.get_connected_peers(NetworkId::Public, DIRECTION)
+            .map(|maybe_n| maybe_n.map(|n| n >= EXPECTED_PEERS as i64).unwrap_or(false))
+    }
+}
 
 impl<T: ?Sized> NodeExt for T where T: Node {}
 

--- a/testsuite/forge/src/interface/node.rs
+++ b/testsuite/forge/src/interface/node.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::Result;
+use crate::{Result, Version};
 use debug_interface::NodeDebugClient;
 use diem_config::{config::NodeConfig, network_id::NetworkId};
 use diem_sdk::{client::Client as JsonRpcClient, types::PeerId};
@@ -30,6 +30,9 @@ pub trait Node {
 
     /// Return the human readable name of this Node
     fn name(&self) -> &str;
+
+    /// Return the version this node is running
+    fn version(&self) -> Version;
 
     /// Return the URL for the JSON-RPC endpoint of this Node
     fn json_rpc_endpoint(&self) -> Url;

--- a/testsuite/forge/src/interface/swarm.rs
+++ b/testsuite/forge/src/interface/swarm.rs
@@ -1,8 +1,13 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{ChainInfo, FullNode, Result, Validator, Version};
-use diem_sdk::types::PeerId;
+use crate::{ChainInfo, FullNode, NodeExt, Result, Validator, Version};
+use anyhow::anyhow;
+use diem_sdk::{client::BlockingClient, types::PeerId};
+use std::{
+    thread,
+    time::{Duration, Instant},
+};
 
 /// Trait used to represent a running network comprised of Validators and FullNodes
 pub trait Swarm {
@@ -54,4 +59,160 @@ pub trait Swarm {
 
     /// Construct a ChainInfo from this Swarm
     fn chain_info(&mut self) -> ChainInfo<'_>;
+}
+
+impl<T: ?Sized> SwarmExt for T where T: Swarm {}
+
+pub trait SwarmExt: Swarm {
+    fn liveness_check(&self, deadline: Instant) -> Result<()> {
+        let liveness_check_seconds = 10;
+        let validators = self.validators().collect::<Vec<_>>();
+        let full_nodes = self.full_nodes().collect::<Vec<_>>();
+
+        while !validators
+            .iter()
+            .map(|node| node.liveness_check(liveness_check_seconds))
+            .chain(
+                full_nodes
+                    .iter()
+                    .map(|node| node.liveness_check(liveness_check_seconds)),
+            )
+            .all(|r| r.is_ok())
+        {
+            if Instant::now() > deadline {
+                return Err(anyhow!("Swarm liveness check timed out"));
+            }
+
+            thread::sleep(Duration::from_millis(500));
+        }
+
+        Ok(())
+    }
+
+    /// Waits for the swarm to achieve connectivity
+    fn wait_for_connectivity(&self, deadline: Instant) -> Result<()> {
+        let validators = self.validators().collect::<Vec<_>>();
+        let full_nodes = self.full_nodes().collect::<Vec<_>>();
+
+        while !validators
+            .iter()
+            .map(|node| node.check_connectivity(validators.len() - 1))
+            .chain(full_nodes.iter().map(|node| node.check_connectivity()))
+            .all(|r| r.unwrap_or(false))
+        {
+            if Instant::now() > deadline {
+                return Err(anyhow!("waiting for swarm connectivity timed out"));
+            }
+
+            thread::sleep(Duration::from_millis(500));
+        }
+
+        Ok(())
+    }
+
+    /// Perform a safety check, ensuring that no forks have occurred in the network.
+    fn fork_check(&self) -> Result<()> {
+        // Checks if root_hashes are equal across all nodes at a given version
+        fn are_root_hashes_equal_at_version(
+            clients: &[BlockingClient],
+            version: u64,
+        ) -> Result<bool> {
+            let root_hashes = clients
+                .iter()
+                .map(|node| {
+                    node.get_metadata_by_version(version)
+                        .map(|r| r.into_inner().accumulator_root_hash)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
+            Ok(root_hashes.windows(2).all(|w| w[0] == w[1]))
+        }
+
+        let clients = self
+            .validators()
+            .map(|node| node.json_rpc_client())
+            .chain(self.full_nodes().map(|node| node.json_rpc_client()))
+            .collect::<Vec<_>>();
+
+        let versions = clients
+            .iter()
+            .map(|node| node.get_metadata().map(|r| r.into_inner().version))
+            .collect::<Result<Vec<_>, _>>()?;
+        let min_version = versions
+            .iter()
+            .min()
+            .copied()
+            .ok_or_else(|| anyhow!("Unable to query nodes for their latest version"))?;
+        let max_version = versions
+            .iter()
+            .max()
+            .copied()
+            .ok_or_else(|| anyhow!("Unable to query nodes for their latest version"))?;
+
+        if !are_root_hashes_equal_at_version(&clients, min_version)? {
+            return Err(anyhow!("Fork check failed"));
+        }
+
+        self.wait_for_all_nodes_to_catchup_to_version(
+            max_version,
+            Instant::now() + Duration::from_secs(10),
+        )?;
+
+        if !are_root_hashes_equal_at_version(&clients, max_version)? {
+            return Err(anyhow!("Fork check failed"));
+        }
+
+        Ok(())
+    }
+
+    /// Waits for all nodes to have caught up to the specified `verison`.
+    fn wait_for_all_nodes_to_catchup_to_version(
+        &self,
+        version: u64,
+        deadline: Instant,
+    ) -> Result<()> {
+        let clients = self
+            .validators()
+            .map(|node| node.json_rpc_client())
+            .chain(self.full_nodes().map(|node| node.json_rpc_client()))
+            .collect::<Vec<_>>();
+
+        while !clients
+            .iter()
+            .map(|node| node.get_metadata().map(|r| r.into_inner().version))
+            .all(|maybe| maybe.map(|v| v as u64 >= version).unwrap_or(false))
+        {
+            if Instant::now() > deadline {
+                return Err(anyhow!(
+                    "waiting for nodes to catch up to version {} timed out",
+                    version
+                ));
+            }
+
+            thread::sleep(Duration::from_millis(500));
+        }
+
+        Ok(())
+    }
+
+    /// Wait for all nodes in the network to be caught up. This is done by first querying each node
+    /// for its current version, selects the max version, then waits for all nodes to catch up to
+    /// that version. Once done, we can guarantee that all transactions committed before invocation
+    /// of this function are available at all the nodes in the swarm
+    fn wait_for_all_nodes_to_catchup(&self, deadline: Instant) -> Result<()> {
+        let clients = self
+            .validators()
+            .map(|node| node.json_rpc_client())
+            .chain(self.full_nodes().map(|node| node.json_rpc_client()))
+            .collect::<Vec<_>>();
+
+        let latest_version = clients
+            .iter()
+            .map(|node| node.get_metadata().map(|r| r.into_inner().version))
+            .map(|maybe| maybe.unwrap_or(0))
+            .max()
+            .ok_or_else(|| anyhow!("Unable to query nodes for their latest version"))?;
+
+        self.wait_for_all_nodes_to_catchup_to_version(latest_version, deadline)
+    }
 }

--- a/testsuite/forge/src/interface/swarm.rs
+++ b/testsuite/forge/src/interface/swarm.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{ChainInfo, FullNode, Result, Validator};
+use crate::{ChainInfo, FullNode, Result, Validator, Version};
 use diem_sdk::types::PeerId;
 
 /// Trait used to represent a running network comprised of Validators and FullNodes
@@ -45,6 +45,9 @@ pub trait Swarm {
 
     /// Removes the FullNode with the provided PeerId
     fn remove_full_node(&mut self, id: PeerId) -> Result<()>;
+
+    /// Return a list of supported Versions
+    fn versions<'a>(&'a self) -> Box<dyn Iterator<Item = Version> + 'a>;
 
     /// Construct a ChainInfo from this Swarm
     fn chain_info(&mut self) -> ChainInfo<'_>;

--- a/testsuite/forge/src/interface/swarm.rs
+++ b/testsuite/forge/src/interface/swarm.rs
@@ -11,7 +11,7 @@ pub trait Swarm {
     fn health_check(&mut self) -> Result<()>;
 
     /// Returns an Iterator of references to all the Validators in the Swarm
-    fn validators<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a dyn Validator> + 'a>;
+    fn validators<'a>(&'a self) -> Box<dyn Iterator<Item = &'a dyn Validator> + 'a>;
 
     /// Returns an Iterator of mutable references to all the Validators in the Swarm
     fn validators_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut dyn Validator> + 'a>;

--- a/testsuite/forge/src/interface/swarm.rs
+++ b/testsuite/forge/src/interface/swarm.rs
@@ -26,7 +26,7 @@ pub trait Swarm {
     fn upgrade_validator(&mut self, id: PeerId, version: &Version) -> Result<()>;
 
     /// Returns an Iterator of references to all the FullNodes in the Swarm
-    fn full_nodes<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a dyn FullNode> + 'a>;
+    fn full_nodes<'a>(&'a self) -> Box<dyn Iterator<Item = &'a dyn FullNode> + 'a>;
 
     /// Returns an Iterator of mutable references to all the FullNodes in the Swarm
     fn full_nodes_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut dyn FullNode> + 'a>;

--- a/testsuite/forge/src/interface/swarm.rs
+++ b/testsuite/forge/src/interface/swarm.rs
@@ -22,6 +22,9 @@ pub trait Swarm {
     /// Returns a mutable reference to the Validator with the provided PeerId
     fn validator_mut(&mut self, id: PeerId) -> Option<&mut dyn Validator>;
 
+    /// Upgrade a Validator to run specified `Version`
+    fn upgrade_validator(&mut self, id: PeerId, version: &Version) -> Result<()>;
+
     /// Returns an Iterator of references to all the FullNodes in the Swarm
     fn full_nodes<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a dyn FullNode> + 'a>;
 

--- a/testsuite/forge/src/main.rs
+++ b/testsuite/forge/src/main.rs
@@ -256,7 +256,7 @@ impl NetworkTest for EmitTransaction {
             .swarm()
             .validators()
             .into_iter()
-            .map(|n| n.json_rpc_client())
+            .map(|n| n.async_json_rpc_client())
             .collect_vec();
         let mut emitter = TxnEmitter::new(ctx.swarm().chain_info(), rng);
         let rt = Runtime::new().unwrap();

--- a/testsuite/forge/src/main.rs
+++ b/testsuite/forge/src/main.rs
@@ -72,19 +72,17 @@ fn main() -> Result<()> {
 }
 
 fn local_test_suite() -> ForgeConfig<'static> {
-    ForgeConfig {
-        public_usage_tests: &[&FundAccount, &TransferCoins],
-        admin_tests: &[&GetMetadata],
-        network_tests: &[&RestartValidator, &EmitTransaction],
-    }
+    ForgeConfig::default()
+        .with_public_usage_tests(&[&FundAccount, &TransferCoins])
+        .with_admin_tests(&[&GetMetadata])
+        .with_network_tests(&[&RestartValidator, &EmitTransaction])
 }
 
 fn k8s_test_suite() -> ForgeConfig<'static> {
-    ForgeConfig {
-        public_usage_tests: &[&FundAccount, &TransferCoins],
-        admin_tests: &[&GetMetadata],
-        network_tests: &[&EmitTransaction],
-    }
+    ForgeConfig::default()
+        .with_public_usage_tests(&[&FundAccount, &TransferCoins])
+        .with_admin_tests(&[&GetMetadata])
+        .with_network_tests(&[&EmitTransaction])
 }
 
 //TODO Make public test later

--- a/testsuite/forge/src/runner.rs
+++ b/testsuite/forge/src/runner.rs
@@ -86,12 +86,34 @@ pub fn forge_main<F: Factory>(tests: ForgeConfig<'_>, factory: F, options: &Opti
 }
 
 pub struct ForgeConfig<'cfg> {
-    pub public_usage_tests: &'cfg [&'cfg dyn PublicUsageTest],
-    pub admin_tests: &'cfg [&'cfg dyn AdminTest],
-    pub network_tests: &'cfg [&'cfg dyn NetworkTest],
+    public_usage_tests: &'cfg [&'cfg dyn PublicUsageTest],
+    admin_tests: &'cfg [&'cfg dyn AdminTest],
+    network_tests: &'cfg [&'cfg dyn NetworkTest],
 }
 
 impl<'cfg> ForgeConfig<'cfg> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_public_usage_tests(
+        mut self,
+        public_usage_tests: &'cfg [&'cfg dyn PublicUsageTest],
+    ) -> Self {
+        self.public_usage_tests = public_usage_tests;
+        self
+    }
+
+    pub fn with_admin_tests(mut self, admin_tests: &'cfg [&'cfg dyn AdminTest]) -> Self {
+        self.admin_tests = admin_tests;
+        self
+    }
+
+    pub fn with_network_tests(mut self, network_tests: &'cfg [&'cfg dyn NetworkTest]) -> Self {
+        self.network_tests = network_tests;
+        self
+    }
+
     pub fn number_of_tests(&self) -> usize {
         self.public_usage_tests.len() + self.admin_tests.len() + self.network_tests.len()
     }
@@ -102,6 +124,16 @@ impl<'cfg> ForgeConfig<'cfg> {
             .map(|t| t as &dyn Test)
             .chain(self.admin_tests.iter().map(|t| t as &dyn Test))
             .chain(self.network_tests.iter().map(|t| t as &dyn Test))
+    }
+}
+
+impl<'cfg> Default for ForgeConfig<'cfg> {
+    fn default() -> Self {
+        Self {
+            public_usage_tests: &[],
+            admin_tests: &[],
+            network_tests: &[],
+        }
     }
 }
 

--- a/testsuite/smoke-test/tests/forge.rs
+++ b/testsuite/smoke-test/tests/forge.rs
@@ -9,17 +9,13 @@ use smoke_test::{
 };
 
 fn main() -> Result<()> {
-    let tests = ForgeConfig {
-        public_usage_tests: &[
-            &EventFetcher,
-            &ExternalTransactionSigner,
-            &VerifyingSubmit,
-            &VerifyingClientEquivalence,
-            &VerifyingGetLatestMetadata,
-        ],
-        admin_tests: &[],
-        network_tests: &[],
-    };
+    let tests = ForgeConfig::default().with_public_usage_tests(&[
+        &EventFetcher,
+        &ExternalTransactionSigner,
+        &VerifyingSubmit,
+        &VerifyingClientEquivalence,
+        &VerifyingGetLatestMetadata,
+    ]);
 
     let options = Options::from_args();
     forge_main(tests, LocalFactory::from_workspace()?, &options)


### PR DESCRIPTION
This PR lays the ground work for being able to do compatibility testing in the forge framework. This includes:
* Introduction of the concept of a node `Version`
* Ability of the Local backend to be able to test using historical versions of diem-node, as well as the ability to support multiple versions simultaneously

As a follow up PR I intend to look at porting the cluster-test Compatibility test to  Forge.