### PR TITLE
[Scratchpad] Support pipelined execution / commission

### DIFF
--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -791,6 +791,11 @@ impl<V: VMExecutor> BlockExecutor for Executor<V> {
             let parent_block_executed_trees =
                 Self::get_executed_trees_from_lock(&read_lock, parent_block_id)?;
 
+            // Hold a ref to the current base smt, so that all in-mem state in between the
+            // currently committed version and the end version of the parent block won't go away
+            // during execution.
+            let _base_smt = read_lock.committed_trees().state_tree().clone();
+
             let state_view = self.get_executed_state_view_from_lock(
                 &read_lock,
                 StateViewId::BlockExecution { block_id },
@@ -968,18 +973,9 @@ impl<V: VMExecutor> BlockExecutor for Executor<V> {
             )?;
         }
 
-        let mut write_lock = self.cache.write();
-        let arc_blocks = block_ids
-            .iter()
-            .map(|id| write_lock.get_block(id))
-            .collect::<Result<Vec<_>, Error>>()?;
-        let blocks = arc_blocks.iter().map(|b| b.lock()).collect::<Vec<_>>();
-
-        for block in blocks {
-            block.output().executed_trees().state_tree().prune()
-        }
-
-        write_lock.prune(ledger_info_with_sigs.ledger_info())?;
+        self.cache
+            .write()
+            .prune(ledger_info_with_sigs.ledger_info())?;
 
         // Now that the blocks are persisted successfully, we can reply to consensus
         Ok(())

--- a/storage/scratchpad/benches/sparse_merkle.rs
+++ b/storage/scratchpad/benches/sparse_merkle.rs
@@ -49,11 +49,13 @@ impl Group {
             group.bench_function(BenchmarkId::new("serial_update", block_size), |b| {
                 b.iter_batched(
                     || small_batches.clone(),
-                    |small_batches| {
+                    // return the resulting smt so the cost of Dropping it is not counted
+                    |small_batches| -> SparseMerkleTree<AccountStateBlob> {
                         block
                             .smt
                             .serial_update(small_batches, &block.proof_reader)
-                            .unwrap();
+                            .unwrap()
+                            .1
                     },
                     BatchSize::LargeInput,
                 )
@@ -61,11 +63,13 @@ impl Group {
             group.bench_function(BenchmarkId::new("batches_update", block_size), |b| {
                 b.iter_batched(
                     || small_batches.clone(),
-                    |small_batches| {
+                    // return the resulting smt so the cost of Dropping it is not counted
+                    |small_batches| -> SparseMerkleTree<AccountStateBlob> {
                         block
                             .smt
                             .batches_update(small_batches, &block.proof_reader)
-                            .unwrap();
+                            .unwrap()
+                            .1
                     },
                     BatchSize::LargeInput,
                 )
@@ -75,11 +79,13 @@ impl Group {
                 |b| {
                     b.iter_batched(
                         || one_large_batch.clone(),
-                        |one_large_batch| {
+                        // return the resulting smt so the cost of Dropping it is not counted
+                        |one_large_batch| -> SparseMerkleTree<AccountStateBlob> {
                             block
                                 .smt
                                 .batches_update(vec![one_large_batch], &block.proof_reader)
-                                .unwrap();
+                                .unwrap()
+                                .1
                         },
                         BatchSize::LargeInput,
                     )
@@ -88,11 +94,12 @@ impl Group {
             group.bench_function(BenchmarkId::new("batch_update", block_size), |b| {
                 b.iter_batched(
                     || one_large_batch.clone(),
-                    |one_large_batch| {
+                    // return the resulting smt so the cost of Dropping it is not counted
+                    |one_large_batch| -> SparseMerkleTree<AccountStateBlob> {
                         block
                             .smt
                             .batch_update(one_large_batch, &block.proof_reader)
-                            .unwrap();
+                            .unwrap()
                     },
                     BatchSize::LargeInput,
                 )

--- a/storage/scratchpad/src/sparse_merkle/mod.rs
+++ b/storage/scratchpad/src/sparse_merkle/mod.rs
@@ -79,15 +79,15 @@ mod sparse_merkle_test;
 pub mod test_utils;
 
 use crate::sparse_merkle::{
-    node::{LeafValue, Node, SubTree},
+    node::{Node, SubTree},
     updater::SubTreeUpdater,
     utils::{partition, swap_if},
 };
-use arc_swap::{ArcSwap, ArcSwapOption};
 use diem_crypto::{
     hash::{CryptoHash, SPARSE_MERKLE_PLACEHOLDER_HASH},
     HashValue,
 };
+use diem_infallible::Mutex;
 use diem_types::{
     nibble::{nibble_path::NibblePath, ROOT_NIBBLE_HEIGHT},
     proof::{SparseMerkleInternalNode, SparseMerkleLeafNode, SparseMerkleProof},
@@ -122,46 +122,41 @@ pub enum AccountStatus<V> {
 }
 
 /// The inner content of a sparse merkle tree, we have this so that even if a tree is dropped, the
-/// INNER of it can still live if referenced by a later version.
+/// INNER of it can still live if referenced by a previous version.
 #[derive(Debug)]
 struct Inner<V> {
-    /// Reference to the root node, initially a strong reference, and once pruned, becomes a weak
-    /// reference, allowing nodes created by this version to go away.
-    root: ArcSwap<SubTree<V>>,
-    /// Reference to the INNER base tree, needs to be a strong reference if the base is speculative
-    /// itself, so that nodes referenced in this version won't go away because the base tree is
-    /// dropped.
-    base: ArcSwapOption<Inner<V>>,
-}
-
-impl<V: CryptoHash> Inner<V> {
-    fn prune(&self) {
-        // Replace the link to the root node with a weak reference, so all nodes created by this
-        // version can be dropped. A weak link is still maintained so that if it's cached somehow,
-        // we still have access to it without resorting to the DB.
-        self.root.store(Arc::new(self.root.load().weak()));
-        // Disconnect the base tree, so that nodes created by previous versions can be dropped.
-        self.base.store(None);
-    }
+    root: SubTree<V>,
+    children: Mutex<Vec<Arc<Inner<V>>>>,
 }
 
 impl<V> Drop for Inner<V> {
     fn drop(&mut self) {
-        let mut cur = self.base.swap(None);
+        let mut q: Vec<_> = self.children.lock().drain(..).collect();
 
-        loop {
-            if let Some(arc) = cur {
-                if Arc::strong_count(&arc) == 1 {
-                    // The only ref is the one we are now holding, so it'll be dropped after we free
-                    // `arc`, which results in the chain of `base`s being dropped recursively,
-                    // and that might trigger a stack overflow. To prevent that we follow the chain
-                    // further to disconnect things beforehand.
-                    cur = arc.base.swap(None);
-                    continue;
-                }
+        while let Some(descendant) = q.pop() {
+            if Arc::strong_count(&descendant) == 1 {
+                // The only ref is the one we are now holding, so the structure will be dropped
+                // after we free the `Arc`, which results in a chain of such structures being
+                // dropped recursively and that might trigger a stack overflow. To prevent that we
+                // follow the chain further to disconnect things beforehand.
+                q.extend(descendant.children.lock().drain(..));
             }
-            break;
         }
+    }
+}
+
+impl<V> Inner<V> {
+    fn new(root: SubTree<V>) -> Arc<Self> {
+        Arc::new(Self {
+            root,
+            children: Mutex::new(Vec::new()),
+        })
+    }
+
+    fn spawn(&self, child_root: SubTree<V>) -> Arc<Self> {
+        let child = Self::new(child_root);
+        self.children.lock().push(child.clone());
+        child
     }
 }
 
@@ -186,33 +181,32 @@ where
     /// the scratch pad and the storage have identical state, so we use a single root hash to
     /// represent the entire state.
     pub fn new(root_hash: HashValue) -> Self {
-        Self::new_impl(
-            if root_hash != *SPARSE_MERKLE_PLACEHOLDER_HASH {
-                SubTree::new_unknown(root_hash)
-            } else {
-                SubTree::new_empty()
-            },
-            None,
-        )
-    }
-
-    fn new_with_base(root: SubTree<V>, base: &Self) -> Self {
-        Self::new_impl(root, Some(base.inner.clone()))
-    }
-
-    fn new_impl(root: SubTree<V>, base: Option<Arc<Inner<V>>>) -> Self {
-        let inner = Inner {
-            root: ArcSwap::from_pointee(root),
-            base: ArcSwapOption::new(base),
+        let root = if root_hash != *SPARSE_MERKLE_PLACEHOLDER_HASH {
+            SubTree::new_unknown(root_hash)
+        } else {
+            SubTree::new_empty()
         };
 
         Self {
-            inner: Arc::new(inner),
+            inner: Inner::new(root),
+        }
+    }
+
+    fn spawn(&self, child_root: SubTree<V>) -> Self {
+        Self {
+            inner: self.inner.spawn(child_root),
+        }
+    }
+
+    #[cfg(test)]
+    fn new_with_root(root: SubTree<V>) -> Self {
+        Self {
+            inner: Inner::new(root),
         }
     }
 
     fn root_weak(&self) -> SubTree<V> {
-        self.inner.root.load().weak()
+        self.inner.root.weak()
     }
 
     /// Constructs a new Sparse Merkle Tree as if we are updating the existing tree multiple
@@ -318,7 +312,6 @@ where
             Node::Leaf(leaf_node) => {
                 assert_eq!(keys.len(), 1);
                 assert_eq!(keys[0], leaf_node.key);
-                matches!(leaf_node.value, LeafValue::Value(_));
                 if level_within_nibble != 0 {
                     let mut leaf_nibble_path = cur_nibble_path.clone();
                     leaf_nibble_path
@@ -390,7 +383,7 @@ where
             txn_id += 1;
         }
 
-        Ok((root_hashes, Self::new_with_base(root, self)))
+        Ok((root_hashes, self.spawn(root)))
     }
 
     /// Given an existing subtree node at a specific depth, recursively apply the updates.
@@ -405,7 +398,7 @@ where
         }
 
         if let SubTree::NonEmpty { root, .. } = &subtree {
-            match root.get_node_if_in_mem() {
+            match root.get_if_in_mem() {
                 Some(arc_node) => match arc_node.borrow() {
                     Node::Internal(internal_node) => {
                         let pivot = partition(updates, subtree_depth);
@@ -749,7 +742,7 @@ where
 
         let ret = match cur {
             SubTree::Empty => AccountStatus::DoesNotExist,
-            SubTree::NonEmpty { root, .. } => match root.get_node_if_in_mem() {
+            SubTree::NonEmpty { root, .. } => match root.get_if_in_mem() {
                 None => AccountStatus::Unknown,
                 Some(node) => match node.borrow() {
                     Node::Internal(_) => {
@@ -757,11 +750,11 @@ where
                     }
                     Node::Leaf(leaf_node) => {
                         if leaf_node.key == key {
-                            match &leaf_node.value {
-                                LeafValue::Value(value) => {
-                                    AccountStatus::ExistsInScratchPad(value.clone())
+                            match &leaf_node.value.data.get_if_in_mem() {
+                                Some(value) => {
+                                    AccountStatus::ExistsInScratchPad(value.as_ref().clone())
                                 }
-                                LeafValue::ValueHash(_) => AccountStatus::ExistsInDB,
+                                None => AccountStatus::ExistsInDB,
                             }
                         } else {
                             AccountStatus::DoesNotExist
@@ -796,18 +789,13 @@ where
             Ok(self.clone())
         } else {
             let root = SubTreeUpdater::update(current_root, &kvs[..], proof_reader)?;
-            Ok(Self::new_with_base(root, self))
+            Ok(self.spawn(root))
         }
     }
 
     /// Returns the root hash of this tree.
     pub fn root_hash(&self) -> HashValue {
-        self.inner.root.load().hash()
-    }
-
-    /// Mark that all the nodes created by this tree and its ancestors are persisted in the DB.
-    pub fn prune(&self) {
-        self.inner.prune()
+        self.inner.root.hash()
     }
 }
 

--- a/storage/scratchpad/src/sparse_merkle/test_utils/proptest_helpers.rs
+++ b/storage/scratchpad/src/sparse_merkle/test_utils/proptest_helpers.rs
@@ -13,17 +13,22 @@ use proptest::{
     prelude::*,
     sample::Index,
 };
-use std::{borrow::Borrow, sync::Arc};
+use std::{borrow::Borrow, collections::VecDeque, sync::Arc};
 
 type TxnOutput = Vec<(HashValue, AccountStateBlob)>;
 type BlockOutput = Vec<TxnOutput>;
 
-pub fn arb_smt_correctness_case() -> impl Strategy<Value = Vec<(BlockOutput, bool)>> {
+#[derive(Debug)]
+pub enum Action {
+    Commit,
+    Execute(BlockOutput),
+}
+
+pub fn arb_smt_correctness_case() -> impl Strategy<Value = Vec<Action>> {
     (
         hash_set(any::<HashValue>(), 1..100), // keys
         vec(
-            // blocks
-            (
+            prop_oneof![
                 vec(
                     // txns
                     vec(
@@ -33,83 +38,103 @@ pub fn arb_smt_correctness_case() -> impl Strategy<Value = Vec<(BlockOutput, boo
                     ),
                     1..10,
                 ),
-                any::<bool>(), // commit
-            ),
+                Just(vec![]),
+            ],
             1..10,
         ),
     )
-        .prop_map(|(keys, blocks)| {
+        .prop_map(|(keys, commit_or_execute)| {
             let keys: Vec<_> = keys.into_iter().collect();
-            blocks
+            commit_or_execute
                 .into_iter()
-                .map(|(txns, commit)| {
-                    (
-                        txns.into_iter()
-                            .map(|updates| {
-                                updates
-                                    .into_iter()
-                                    .map(|(k_idx, v)| (*k_idx.get(&keys), v.to_vec().into()))
-                                    .collect()
-                            })
-                            .collect::<Vec<_>>(),
-                        commit,
-                    )
+                .map(|txns| {
+                    if txns.is_empty() {
+                        Action::Commit
+                    } else {
+                        Action::Execute(
+                            txns.into_iter()
+                                .map(|updates| {
+                                    updates
+                                        .into_iter()
+                                        .map(|(k_idx, v)| (*k_idx.get(&keys), v.to_vec().into()))
+                                        .collect()
+                                })
+                                .collect::<Vec<_>>(),
+                        )
+                    }
                 })
                 .collect::<Vec<_>>()
         })
 }
 
-pub fn test_smt_correctness_impl(input: Vec<(BlockOutput, bool)>) {
-    let mut persisted_smt = NaiveSmt::new::<AccountStateBlob>(&[]);
-    let mut naive_smt = persisted_smt.clone();
+pub fn test_smt_correctness_impl(input: Vec<Action>) {
+    let mut naive_q = VecDeque::new();
+    naive_q.push_back(NaiveSmt::new::<AccountStateBlob>(&[]));
+    let mut serial_q = VecDeque::new();
+    serial_q.push_back(SparseMerkleTree::new(*SPARSE_MERKLE_PLACEHOLDER_HASH));
+    let mut batches_q = VecDeque::new();
+    batches_q.push_back(SparseMerkleTree::new(*SPARSE_MERKLE_PLACEHOLDER_HASH));
+    let mut updater_q = VecDeque::new();
+    updater_q.push_back(SparseMerkleTree::new(*SPARSE_MERKLE_PLACEHOLDER_HASH));
 
-    let mut serial_smt = SparseMerkleTree::new(*SPARSE_MERKLE_PLACEHOLDER_HASH);
-    let mut batches_smt = SparseMerkleTree::new(*SPARSE_MERKLE_PLACEHOLDER_HASH);
-    let mut updater_smt = SparseMerkleTree::new(*SPARSE_MERKLE_PLACEHOLDER_HASH);
+    for action in input {
+        match action {
+            Action::Commit => {
+                if naive_q.len() > 1 {
+                    naive_q.pop_front();
+                    serial_q.pop_front();
+                    batches_q.pop_front();
+                    updater_q.pop_front();
+                }
+            }
+            Action::Execute(block) => {
+                let updates = block
+                    .iter()
+                    .map(|txn_updates| txn_updates.iter().map(|(k, v)| (*k, v)).collect())
+                    .collect::<Vec<_>>();
+                let updates_flat_batch = updates.iter().flatten().cloned().collect::<Vec<_>>();
 
-    for (block, commit) in input {
-        let updates = block
-            .iter()
-            .map(|txn_updates| txn_updates.iter().map(|(k, v)| (*k, v)).collect())
-            .collect::<Vec<_>>();
-        let updates_flat_batch = updates.iter().flatten().cloned().collect::<Vec<_>>();
+                let committed = naive_q.front_mut().unwrap();
+                let proofs = updates_flat_batch
+                    .iter()
+                    .map(|(k, _)| (*k, committed.get_proof(k)))
+                    .collect();
+                let proof_reader = ProofReader::new(proofs);
 
-        let proofs = updates_flat_batch
-            .iter()
-            .map(|(k, _)| (*k, persisted_smt.get_proof(k)))
-            .collect();
-        let proof_reader = ProofReader::new(proofs);
-        naive_smt = naive_smt.update(&updates_flat_batch);
+                let mut naive_smt = naive_q.back().unwrap().clone().update(&updates_flat_batch);
 
-        let upd_serial_smt = serial_smt
-            .serial_update(updates.clone(), &proof_reader)
-            .unwrap()
-            .1;
-        serial_smt.assert_no_external_strong_ref();
-        serial_smt = upd_serial_smt;
+                let serial_smt = serial_q
+                    .back()
+                    .unwrap()
+                    .serial_update(updates.clone(), &proof_reader)
+                    .unwrap()
+                    .1;
+                serial_q.back().unwrap().assert_no_external_strong_ref();
 
-        let upd_batches_smt = batches_smt
-            .batches_update(updates, &proof_reader)
-            .unwrap()
-            .1;
-        batches_smt.assert_no_external_strong_ref();
-        batches_smt = upd_batches_smt;
+                let batches_smt = batches_q
+                    .back()
+                    .unwrap()
+                    .batches_update(updates, &proof_reader)
+                    .unwrap()
+                    .1;
+                batches_q.back().unwrap().assert_no_external_strong_ref();
 
-        let upd_updater_smt = updater_smt
-            .batch_update(updates_flat_batch, &proof_reader)
-            .unwrap();
-        updater_smt.assert_no_external_strong_ref();
-        updater_smt = upd_updater_smt;
+                let updater_smt = updater_q
+                    .back()
+                    .unwrap()
+                    .batch_update(updates_flat_batch, &proof_reader)
+                    .unwrap();
+                updater_q.back().unwrap().assert_no_external_strong_ref();
 
-        assert_eq!(serial_smt.root_hash(), naive_smt.get_root_hash());
-        assert_eq!(batches_smt.root_hash(), naive_smt.get_root_hash());
-        assert_eq!(updater_smt.root_hash(), naive_smt.get_root_hash());
+                assert_eq!(serial_smt.root_hash(), naive_smt.get_root_hash());
+                assert_eq!(batches_smt.root_hash(), naive_smt.get_root_hash());
+                assert_eq!(updater_smt.root_hash(), naive_smt.get_root_hash());
 
-        if commit {
-            persisted_smt = naive_smt.clone();
-            serial_smt.prune();
-            batches_smt.prune();
-            updater_smt.prune();
+                naive_q.push_back(naive_smt);
+                serial_q.push_back(serial_smt);
+                batches_q.push_back(batches_smt);
+                updater_q.push_back(updater_smt);
+            }
         }
     }
 }
@@ -120,7 +145,7 @@ trait AssertNoExternalStrongRef {
 
 impl<V> AssertNoExternalStrongRef for SparseMerkleTree<V> {
     fn assert_no_external_strong_ref(&self) {
-        assert_subtree_sole_strong_ref(&self.inner.root.load());
+        assert_subtree_sole_strong_ref(&self.inner.root);
     }
 }
 


### PR DESCRIPTION
## Motivation


1. Reverse the link between SMT `Inner` structures. Now a parent points to its children instead, and "pruning" is expressed by dropping the committed version.
2. A ref to the SMT at the current committed version must be held before executing a block, so that even if versions in the middle got committed, the state view has access to all nodes created up until the previously assumed committed version.
3. Whenever a leaf node is split in the SMT during update, a new leaf node is created at the new position, avoiding edge cases where a "ShortProof" error is hit if a moved (pushed down) leaf went away with commission. It was not exposed until now because in the current world the base version used in an execution is always the latest committed version, a leaf won't "move" between the committed version and the parent version.
4. updated "test_correctness" proptest to do things in a pipelined way.
### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

proptest udpated
existing coverage


Performance was hit by a few percent, which can be later addressed by: 
  1. replace the lock with a `ArcSwap` once there's no longer branching in the block tree 
  2. lazy creating the the in-mem leaf node with weak data ref.

``` text
➜  diem git:(reverse_link) ✗ time cargo bench  --features bench -p scratchpad --  "/1000$"  --load-baseline reverse_link --baseline no_drop
    Finished bench [optimized + debuginfo] target(s) in 0.47s
     Running unittests (target/release/deps/sparse_merkle-d169e62d05778ca2)
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

insert to empty/serial_update/1000
                        time:   [28.044 ms 28.104 ms 28.168 ms]
                        thrpt:  [35.502 Kelem/s 35.582 Kelem/s 35.659 Kelem/s]
                 change:
                        time:   [+2.9157% +3.3427% +3.7584%] (p = 0.00 < 0.05)
                        thrpt:  [-3.6223% -3.2346% -2.8331%]
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild
insert to empty/batches_update/1000
                        time:   [14.971 ms 14.997 ms 15.024 ms]
                        thrpt:  [66.560 Kelem/s 66.681 Kelem/s 66.794 Kelem/s]
                 change:
                        time:   [-1.0411% -0.6233% -0.2167%] (p = 0.00 < 0.05)
                        thrpt:  [+0.2172% +0.6272% +1.0520%]
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
insert to empty/batches_update__flat_batch/1000
                        time:   [6.8723 ms 6.8871 ms 6.9020 ms]
                        thrpt:  [144.88 Kelem/s 145.20 Kelem/s 145.51 Kelem/s]
                 change:
                        time:   [+4.3569% +4.7345% +5.1123%] (p = 0.00 < 0.05)
                        thrpt:  [-4.8636% -4.5205% -4.1750%]
                        Performance has regressed.
insert to empty/batch_update/1000
                        time:   [1.0675 ms 1.0692 ms 1.0711 ms]
                        thrpt:  [933.66 Kelem/s 935.25 Kelem/s 936.79 Kelem/s]
                 change:
                        time:   [+8.9545% +9.4260% +9.8701%] (p = 0.00 < 0.05)
                        thrpt:  [-8.9834% -8.6141% -8.2185%]
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe

insert to committed base/serial_update/1000
                        time:   [44.116 ms 44.260 ms 44.420 ms]
                        thrpt:  [22.512 Kelem/s 22.594 Kelem/s 22.667 Kelem/s]
                 change:
                        time:   [-1.5131% -0.9718% -0.4885%] (p = 0.00 < 0.05)
                        thrpt:  [+0.4909% +0.9814% +1.5363%]
                        Change within noise threshold.
Found 14 outliers among 100 measurements (14.00%)
  8 (8.00%) high mild
  6 (6.00%) high severe
insert to committed base/batches_update/1000
                        time:   [42.038 ms 42.180 ms 42.332 ms]
                        thrpt:  [23.623 Kelem/s 23.708 Kelem/s 23.788 Kelem/s]
                 change:
                        time:   [-0.0307% +0.4403% +0.9391%] (p = 0.08 > 0.05)
                        thrpt:  [-0.9303% -0.4384% +0.0307%]
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  8 (8.00%) high mild
insert to committed base/batches_update__flat_batch/1000
                        time:   [32.031 ms 32.085 ms 32.143 ms]
                        thrpt:  [31.111 Kelem/s 31.167 Kelem/s 31.219 Kelem/s]
                 change:
                        time:   [+1.4922% +1.8603% +2.2142%] (p = 0.00 < 0.05)
                        thrpt:  [-2.1662% -1.8263% -1.4702%]
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
insert to committed base/batch_update/1000
                        time:   [3.0601 ms 3.0651 ms 3.0703 ms]
                        thrpt:  [325.70 Kelem/s 326.25 Kelem/s 326.79 Kelem/s]
                 change:
                        time:   [+7.6071% +7.8359% +8.0724%] (p = 0.00 < 0.05)
                        thrpt:  [-7.4695% -7.2665% -7.0694%]
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

insert to uncommitted base/serial_update/1000
                        time:   [45.587 ms 45.757 ms 45.942 ms]
                        thrpt:  [21.766 Kelem/s 21.854 Kelem/s 21.936 Kelem/s]
                 change:
                        time:   [-0.2051% +0.4121% +1.0094%] (p = 0.19 > 0.05)
                        thrpt:  [-0.9993% -0.4104% +0.2055%]
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild
insert to uncommitted base/batches_update/1000
                        time:   [41.968 ms 42.099 ms 42.247 ms]
                        thrpt:  [23.670 Kelem/s 23.753 Kelem/s 23.827 Kelem/s]
                 change:
                        time:   [+1.6414% +2.1792% +2.7277%] (p = 0.00 < 0.05)
                        thrpt:  [-2.6553% -2.1327% -1.6149%]
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe
insert to uncommitted base/batches_update__flat_batch/1000
                        time:   [32.361 ms 32.473 ms 32.593 ms]
                        thrpt:  [30.682 Kelem/s 30.795 Kelem/s 30.902 Kelem/s]
                 change:
                        time:   [+3.2279% +3.7529% +4.2377%] (p = 0.00 < 0.05)
                        thrpt:  [-4.0654% -3.6172% -3.1270%]
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
insert to uncommitted base/batch_update/1000
                        time:   [3.1490 ms 3.1550 ms 3.1615 ms]
                        thrpt:  [316.30 Kelem/s 316.95 Kelem/s 317.56 Kelem/s]
                 change:
                        time:   [+7.5338% +7.8405% +8.1437%] (p = 0.00 < 0.05)
                        thrpt:  [-7.5304% -7.2705% -7.0060%]
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe

cargo bench --features bench -p scratchpad -- "/1000$" --load-baseline     75.80s user 4.44s system 491% cpu 16.338 total
```

## Related PRs
