### PR TITLE
[move-prover] fix a bug when the spec fun produces two identical params

### DIFF
--- a/language/move-prover/boogie-backend/src/spec_translator.rs
+++ b/language/move-prover/boogie-backend/src/spec_translator.rs
@@ -255,14 +255,23 @@ impl<'env> SpecTranslator<'env> {
                 &self.inst(&decl.type_),
             )
         });
+        // it is possible that the spec fun may refer to the same memory after monomorphization,
+        // (e.g., one via concrete type and the other via type parameter being instantiated).
+        // In this case, we mark the other parameter as unused
+        let mut mem_inst_seen = BTreeSet::new();
         let mem_params = fun.used_memory.iter().map(|memory| {
-            let memory = &memory.to_owned().instantiate(&self.type_inst);
+            let memory = memory.to_owned().instantiate(&self.type_inst);
             let struct_env = &self.env.get_struct_qid(memory.to_qualified_id());
-            format!(
+            let param_repr = format!(
                 "{}: $Memory {}",
-                boogie_resource_memory_name(self.env, memory, &None),
+                boogie_resource_memory_name(self.env, &memory, &None),
                 boogie_struct_name(struct_env, &memory.inst)
-            )
+            );
+            if mem_inst_seen.insert(memory) {
+                param_repr
+            } else {
+                format!("__unused_{}", param_repr)
+            }
         });
         let params = fun.params.iter().map(|(name, ty)| {
             format!(

--- a/language/move-prover/tests/sources/regression/spec_fun_same_mem_param.move
+++ b/language/move-prover/tests/sources/regression/spec_fun_same_mem_param.move
@@ -1,0 +1,49 @@
+address 0x2 {
+module Coin {
+    struct Coin<T: store> has key { f: T, v: u64 }
+
+    public fun coin_exists<T: store>(): bool {
+        exists<Coin<T>>(@0x2)
+    }
+
+    public fun coin_info<T: store>(): u64 acquires Coin {
+        *&borrow_global<Coin<T>>(@0x2).v
+    }
+}
+
+module XUS {
+    struct XUS has store {}
+}
+
+module XDX {
+    use 0x2::Coin::Coin;
+    use 0x2::Coin::coin_exists;
+    use 0x2::Coin::coin_info;
+
+    struct XDX has store {}
+
+    spec fun spec_is_xdx<T: store>(): bool {
+        exists<Coin<T>>(@0x2) && exists<Coin<XDX>>(@0x2) &&
+            global<Coin<T>>(@0x2).v == global<Coin<XDX>>(@0x2).v
+    }
+
+    public fun is_xdx<T: store>(): bool {
+        coin_exists<T>() && coin_exists<XDX>() &&
+            coin_info<T>() == coin_info<XDX>()
+    }
+    spec is_xdx {
+        pragma opaque;
+        ensures result == spec_is_xdx<T>();
+    }
+}
+
+module Check {
+    use 0x2::XUS::XUS;
+    use 0x2::XDX::XDX;
+    use 0x2::XDX::is_xdx;
+
+    public fun check(): bool {
+        is_xdx<XUS>() && is_xdx<XDX>()
+    }
+}
+}


### PR DESCRIPTION
It is possible that the spec fun may refer to the same memory after
monomorphization, e.g., one via concrete type and the other via type
parameter being instantiated. In this case, we still keep the two
parameters (because of the calling convention) but prefix the second
one with `__unused_`.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Fix an issue found in the generic invariant checking process

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- CI
- new test case added
