### PR TITLE
[move-cli] Refactor move-cli to make it extensible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1519,6 +1519,7 @@ dependencies = [
  "diem-workspace-hack",
  "move-cli",
  "move-core-types",
+ "structopt 0.3.21",
 ]
 
 [[package]]

--- a/language/diem-tools/df-cli/Cargo.toml
+++ b/language/diem-tools/df-cli/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.38"
 bcs = "0.1.2"
+structopt = "0.3.21"
 
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = { path = "../../move-core/types" }

--- a/language/diem-tools/df-cli/src/main.rs
+++ b/language/diem-tools/df-cli/src/main.rs
@@ -2,10 +2,36 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use move_cli::{Command, Move};
 use move_core_types::errmap::ErrorMapping;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+pub struct DfCli {
+    #[structopt(flatten)]
+    move_args: Move,
+
+    #[structopt(subcommand)]
+    cmd: DfCommands,
+}
+
+#[derive(StructOpt)]
+pub enum DfCommands {
+    #[structopt(flatten)]
+    Command(Command),
+    // extra commands available only in df-cli can be added below
+}
 
 fn main() -> Result<()> {
     let error_descriptions: ErrorMapping =
         bcs::from_bytes(diem_framework_releases::current_error_descriptions())?;
-    move_cli::move_cli(diem_vm::natives::diem_natives(), &error_descriptions)
+    let args = DfCli::from_args();
+    match &args.cmd {
+        DfCommands::Command(cmd) => move_cli::run_cli(
+            diem_vm::natives::diem_natives(),
+            &error_descriptions,
+            &args.move_args,
+            &cmd,
+        ),
+    }
 }

--- a/language/tools/move-cli/src/lib.rs
+++ b/language/tools/move-cli/src/lib.rs
@@ -59,6 +59,16 @@ pub struct Move {
     /// Print additional diagnostics
     #[structopt(short = "v", global = true)]
     verbose: bool,
+}
+
+/// MoveCLI is the CLI that will be executed by the `move-cli` command
+/// The `cmd` argument is added here rather than in `Move` to make it
+/// easier for other crates to extend `move-cli`
+#[derive(StructOpt)]
+pub struct MoveCLI {
+    #[structopt(flatten)]
+    move_args: Move,
+
     #[structopt(subcommand)]
     cmd: Command,
 }
@@ -344,14 +354,15 @@ fn handle_sandbox_commands(
     }
 }
 
-pub fn move_cli(
+pub fn run_cli(
     natives: Vec<NativeFunctionRecord>,
     error_descriptions: &ErrorMapping,
+    move_args: &Move,
+    cmd: &Command,
 ) -> Result<()> {
-    let move_args = Move::from_args();
     let mode = Mode::new(move_args.mode);
 
-    match &move_args.cmd {
+    match cmd {
         Command::Compile {
             source_files,
             no_source_maps,
@@ -383,4 +394,12 @@ pub fn move_cli(
         }
         Command::Experimental { cmd } => handle_experimental_commands(&move_args, &mode, cmd),
     }
+}
+
+pub fn move_cli(
+    natives: Vec<NativeFunctionRecord>,
+    error_descriptions: &ErrorMapping,
+) -> Result<()> {
+    let args = MoveCLI::from_args();
+    run_cli(natives, error_descriptions, &args.move_args, &args.cmd)
 }


### PR DESCRIPTION
## Motivation

This allows other crates (in particular `df-cli`) to extend `move-cli` with other subcommands

### Have you read the [Contributing Guidelines on pull requests]

yes

/cc @sblackshear @tzakian 

