### PR TITLE
client: increase wait_for_transaction timeout

### DIFF
--- a/sdk/client/src/blocking.rs
+++ b/sdk/client/src/blocking.rs
@@ -89,8 +89,8 @@ impl BlockingClient {
         timeout: Option<Duration>,
         delay: Option<Duration>,
     ) -> Result<Response<TransactionView>, WaitForTransactionError> {
-        const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
-        const DEFAULT_DELAY: Duration = Duration::from_millis(50);
+        const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
+        const DEFAULT_DELAY: Duration = Duration::from_millis(500);
 
         let start = std::time::Instant::now();
         while start.elapsed() < timeout.unwrap_or(DEFAULT_TIMEOUT) {

--- a/sdk/client/src/client.rs
+++ b/sdk/client/src/client.rs
@@ -95,8 +95,8 @@ impl Client {
         timeout: Option<Duration>,
         delay: Option<Duration>,
     ) -> Result<Response<TransactionView>, WaitForTransactionError> {
-        const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
-        const DEFAULT_DELAY: Duration = Duration::from_millis(50);
+        const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
+        const DEFAULT_DELAY: Duration = Duration::from_millis(500);
 
         let start = std::time::Instant::now();
         while start.elapsed() < timeout.unwrap_or(DEFAULT_TIMEOUT) {


### PR DESCRIPTION
The existing timeout is probably a little aggressive, lets bump up the default to match what we have in client_proxy.rs.