### PR TITLE
[move-lang][spec-lang] syntax support for generic spec conditions

### DIFF
--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -222,6 +222,7 @@ pub type SpecBlockTarget = Spanned<SpecBlockTarget_>;
 pub enum SpecBlockMember_ {
     Condition {
         kind: SpecConditionKind,
+        type_parameters: Vec<(Name, AbilitySet)>,
         properties: Vec<PragmaProperty>,
         exp: Exp,
         additional_exps: Vec<Exp>,
@@ -952,11 +953,13 @@ impl AstDebug for SpecBlockMember_ {
         match self {
             SpecBlockMember_::Condition {
                 kind,
+                type_parameters,
                 properties: _,
                 exp,
                 additional_exps,
             } => {
                 kind.ast_debug(w);
+                type_parameters.ast_debug(w);
                 exp.ast_debug(w);
                 w.list(additional_exps, ",", |w, e| {
                     e.ast_debug(w);

--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -1141,10 +1141,12 @@ fn spec_member(context: &mut Context, sp!(loc, pm): P::SpecBlockMember) -> E::Sp
     let em = match pm {
         PM::Condition {
             kind,
+            type_parameters: pty_params,
             properties: pproperties,
             exp,
             additional_exps,
         } => {
+            let old_aliases = context.new_alias_scope(AliasMap::new());
             let properties = pproperties
                 .into_iter()
                 .map(|p| pragma_property(context, p))
@@ -1154,8 +1156,11 @@ fn spec_member(context: &mut Context, sp!(loc, pm): P::SpecBlockMember) -> E::Sp
                 .into_iter()
                 .map(|e| exp_(context, e))
                 .collect();
+            let type_parameters = fun_type_parameters(context, pty_params);
+            context.set_to_outer_scope(old_aliases);
             EM::Condition {
                 kind,
+                type_parameters,
                 properties,
                 exp,
                 additional_exps,

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -331,6 +331,7 @@ pub type SpecApplyFragment = Spanned<SpecApplyFragment_>;
 pub enum SpecBlockMember_ {
     Condition {
         kind: SpecConditionKind,
+        type_parameters: Vec<(Name, Vec<Ability>)>,
         properties: Vec<PragmaProperty>,
         exp: Exp,
         additional_exps: Vec<Exp>,
@@ -1247,11 +1248,13 @@ impl AstDebug for SpecBlockMember_ {
         match self {
             SpecBlockMember_::Condition {
                 kind,
+                type_parameters,
                 properties: _,
                 exp,
                 additional_exps,
             } => {
                 kind.ast_debug(w);
+                type_parameters.ast_debug(w);
                 exp.ast_debug(w);
                 w.list(additional_exps, ",", |w, e| {
                     e.ast_debug(w);

--- a/language/move-lang/tests/move_check/expansion/duplicate_abilities.exp
+++ b/language/move-lang/tests/move_check/expansion/duplicate_abilities.exp
@@ -23,9 +23,33 @@ error[E02001]: duplicate declaration, item, or annotation
   │                Ability previously given here
 
 error[E02001]: duplicate declaration, item, or annotation
-   ┌─ tests/move_check/expansion/duplicate_abilities.move:10:23
+  ┌─ tests/move_check/expansion/duplicate_abilities.move:9:28
+  │
+9 │         invariant<T: key + key> exists<T>(0x1) == exists<T>(0x1);
+  │                      ---   ^^^ Duplicate 'key' ability constraint
+  │                      │      
+  │                      Ability previously given here
+
+error[E02001]: duplicate declaration, item, or annotation
+   ┌─ tests/move_check/expansion/duplicate_abilities.move:10:26
    │
-10 │     fun main<T: key + key>() {}
+10 │         axiom<T: store + store + key + key> exists<T>(0x2);
+   │                  -----   ^^^^^ Duplicate 'store' ability constraint
+   │                  │        
+   │                  Ability previously given here
+
+error[E02001]: duplicate declaration, item, or annotation
+   ┌─ tests/move_check/expansion/duplicate_abilities.move:10:40
+   │
+10 │         axiom<T: store + store + key + key> exists<T>(0x2);
+   │                                  ---   ^^^ Duplicate 'key' ability constraint
+   │                                  │      
+   │                                  Ability previously given here
+
+error[E02001]: duplicate declaration, item, or annotation
+   ┌─ tests/move_check/expansion/duplicate_abilities.move:15:23
+   │
+15 │     fun main<T: key + key>() {}
    │                 ---   ^^^ Duplicate 'key' ability constraint
    │                 │      
    │                 Ability previously given here

--- a/language/move-lang/tests/move_check/expansion/duplicate_abilities.move
+++ b/language/move-lang/tests/move_check/expansion/duplicate_abilities.move
@@ -4,6 +4,11 @@ module M {
     struct Foo has copy, copy {}
     struct Bar<T: drop + drop> { f: T }
     fun baz<T: store + store>() {}
+
+    spec module {
+        invariant<T: key + key> exists<T>(0x1) == exists<T>(0x1);
+        axiom<T: store + store + key + key> exists<T>(0x2);
+    }
 }
 }
 script {

--- a/language/move-lang/tests/move_check/parser/spec_parsing_generic_condition_fail.exp
+++ b/language/move-lang/tests/move_check/parser/spec_parsing_generic_condition_fail.exp
@@ -1,0 +1,9 @@
+error[E01002]: unexpected token
+  ┌─ tests/move_check/parser/spec_parsing_generic_condition_fail.move:3:16
+  │
+3 │         ensures<T> exists<T>(0x1) <==> exists<T>(0x1);
+  │                ^
+  │                │
+  │                Unexpected '<'
+  │                Expected an expression term
+

--- a/language/move-lang/tests/move_check/parser/spec_parsing_generic_condition_fail.move
+++ b/language/move-lang/tests/move_check/parser/spec_parsing_generic_condition_fail.move
@@ -1,0 +1,5 @@
+module 0x8675309::M {
+    spec schema InvalidGenericEnsures {
+        ensures<T> exists<T>(0x1) <==> exists<T>(0x1);
+    }
+}

--- a/language/move-lang/tests/move_check/parser/spec_parsing_ok.move
+++ b/language/move-lang/tests/move_check/parser/spec_parsing_ok.move
@@ -21,7 +21,6 @@ module 0x8675309::M {
             let _ = x .. y;
             x
         }
-
     }
 
     struct T has key {x: u64}
@@ -140,5 +139,15 @@ module 0x8675309::M {
         invariant forall x: num, y: num, z: num : x == y && y == z ==> x == z;
         invariant forall x: num : exists y: num : y >= x;
         invariant exists x in 1..10, y in 8..12 : x == y;
+        invariant<X: key> exists<X>(0x0) <==> exists<X>(0x0);
+        invariant<X: key, Y: key> exists<X>(0x0) && exists<Y>(0x1) <==> exists<Y>(0x1) && exists<X>(0x0);
+    }
+
+    spec module {
+        fun spec_fun_non_zero(): num;
+        axiom spec_fun_non_zero() > 0;
+
+        fun spec_fun_identity<T>(x: T): T;
+        axiom<T> forall x: T: spec_fun_identity(x) == x;
     }
 }

--- a/language/move-model/src/builder/module_builder.rs
+++ b/language/move-model/src/builder/module_builder.rs
@@ -642,6 +642,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                     match &member.value {
                         EA::SpecBlockMember_::Condition {
                             kind,
+                            type_parameters,
                             properties,
                             exp,
                             additional_exps,
@@ -664,6 +665,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                                     loc,
                                     &context,
                                     kind,
+                                    type_parameters,
                                     properties,
                                     exp,
                                     additional_exps,
@@ -931,6 +933,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         match &member.value {
             Condition {
                 kind,
+                type_parameters,
                 properties,
                 exp,
                 additional_exps,
@@ -943,7 +946,15 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                             None
                         }
                     });
-                    self.def_ana_condition(loc, context, kind, properties, exp, additional_exps)
+                    self.def_ana_condition(
+                        loc,
+                        context,
+                        kind,
+                        type_parameters,
+                        properties,
+                        exp,
+                        additional_exps,
+                    )
                 }
             }
             Function {
@@ -1531,17 +1542,31 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         loc: &Loc,
         context: &SpecBlockContext,
         kind: ConditionKind,
+        type_parameters: &[(Name, EA::AbilitySet)],
         properties: PropertyBag,
         exp: &EA::Exp,
         additional_exps: &[EA::Exp],
     ) {
-        if kind == ConditionKind::Decreases {
-            self.parent
-                .error(loc, "decreases specification not supported currently");
+        if matches!(kind, ConditionKind::Decreases | ConditionKind::SucceedsIf) {
+            self.parent.error(loc, "condition kind is not supported");
             return;
         }
-        if matches!(kind, ConditionKind::SucceedsIf) {
-            self.parent.error(loc, "condition kind is not supported");
+        if !matches!(
+            kind,
+            ConditionKind::Invariant | ConditionKind::InvariantUpdate | ConditionKind::Axiom
+        ) && !type_parameters.is_empty()
+        {
+            let msg = "type parameters are not allowed here";
+            let note = "type parameters are only allowed on the following cases: \
+                `invariant<..>`, `invariant<..> update`, and `axiom<..>`.";
+            self.parent
+                .error_with_notes(loc, msg, vec![note.to_owned()]);
+            return;
+        }
+        // TODO(mengxu): add support for generic conditions
+        if !type_parameters.is_empty() {
+            self.parent
+                .error(loc, "generic specification condition is not supported");
             return;
         }
         let expected_type = self.expected_type_for_condition(&kind);
@@ -1836,6 +1861,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                 EA::SpecBlockMember_::Let { .. } => { /* handled above */ }
                 EA::SpecBlockMember_::Condition {
                     kind,
+                    type_parameters,
                     properties,
                     exp,
                     additional_exps,
@@ -1853,6 +1879,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                             &member_loc,
                             &context,
                             kind,
+                            type_parameters,
                             properties,
                             exp,
                             additional_exps,


### PR DESCRIPTION
This commit adds support for specifying conditions with type parameters.
Generic condition types we plan to support include:

- `axiom<T>`
- `invariant<T>`
- `invariant<T> update`

The semantic of a generic version of some condition is the same as the
non-generic version quantified over all types.

For example:
```
invariant<T: key> exists<T>(0x1) ==> exists<T>(0x2);
```
is semantically equivalent to
```
invariant forall t: type: exists<t>(0x1) ==> exists<t>(0x2);
```

Multiple type parameters are allowed, for example
```
invariant<X: key, Y: key> exists<X>(0x1) ==> exists<Y>(0x1);
```
is semantically equivalent to
```
invariant forall x: type, y: type: exists<x>(0x1) ==> exists<y>(0x1);
```

Of course, the semantic is currently not implemented in this commit and
`move-model` will reject any spec condition with a non-zero number of
type parameters. More commits will be added to complete this feature.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

To resolve a discomfort that in monomorphization, type variable elimination implicitly assumes that the type variable is quantified over `forall` instead of `exists` and are always in positive form (e.g., not a `not forall`). This generic notion made the fact explicit. With this change, only the `T` in `invariant<T>` will be monomorphized after the feature is complete.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- CI for existing cases
- A new test is added to reject condition kinds where it does not make sense to have type parameters, e.g.,
  - `ensures<T>`