### PR TITLE
[decoupled-execution] Integration Part 3 - Back Pressure and Final Integration

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -28,6 +28,7 @@ pub struct ConsensusConfig {
     // only when decoupled is true, the execution and committing will be pipelined in different phases
     pub decoupled: bool,
     pub channel_size: usize,
+    pub back_pressure_limit: u64,
 }
 
 impl Default for ConsensusConfig {
@@ -48,6 +49,7 @@ impl Default for ConsensusConfig {
             mempool_poll_count: 1,
             decoupled: false, // by default, we turn of the decoupling execution feature
             channel_size: 30, // hard-coded
+            back_pressure_limit: 1,
         }
     }
 }

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -272,3 +272,37 @@ pub static BLOCK_RETRIEVAL_CHANNEL_MSGS: Lazy<IntCounterVec> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+///////////////////
+// DECOUPLED EXECUTION CHANNEL COUNTERS
+///////////////////
+
+/// Counter for the decoupling execution channel of ordered blocks
+/// from ordering state computer to execution phase
+pub static DECOUPLED_EXECUTION__EXECUTION_PHASE_CHANNEL: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "decoupled_execution__execution_phase_channel",
+        "Number of pending ordered only blocks"
+    )
+    .unwrap()
+});
+
+/// Counter for the decoupling execution channel of executed blocks
+/// from execution phase to commit phase
+pub static DECOUPLED_EXECUTION__COMMIT_PHASE_CHANNEL: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "decoupled_execution__commit_phase_channel",
+        "Number of pending executed blocks"
+    )
+    .unwrap()
+});
+
+/// Counter for the decoupling execution channel of commit messages
+/// from epoch_manager to commit phase
+pub static DECOUPLED_EXECUTION__COMMIT_MESSAGE_CHANNEL: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "decoupled_execution__commit_message_channel",
+        "Number of pending commit phase messages (CommitVote/CommitDecision)"
+    )
+    .unwrap()
+});

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -26,6 +26,7 @@ use consensus_types::{
     block::Block,
     block_retrieval::{BlockRetrievalResponse, BlockRetrievalStatus},
     common::{Author, Round},
+    experimental::{commit_decision::CommitDecision, commit_vote::CommitVote},
     proposal_msg::ProposalMsg,
     quorum_cert::QuorumCert,
     sync_info::SyncInfo,
@@ -33,7 +34,8 @@ use consensus_types::{
     vote::Vote,
     vote_msg::VoteMsg,
 };
-use diem_infallible::checked;
+use core::sync::atomic::Ordering;
+use diem_infallible::{checked, Mutex};
 use diem_logger::prelude::*;
 use diem_types::{epoch_state::EpochState, validator_verifier::ValidatorVerifier};
 use fail::fail_point;
@@ -41,7 +43,10 @@ use fail::fail_point;
 use safety_rules::ConsensusState;
 use safety_rules::TSafetyRules;
 use serde::Serialize;
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{atomic::AtomicU64, Arc},
+    time::Duration,
+};
 use termion::color::*;
 
 #[derive(Serialize, Clone)]
@@ -49,6 +54,8 @@ pub enum UnverifiedEvent {
     ProposalMsg(Box<ProposalMsg>),
     VoteMsg(Box<VoteMsg>),
     SyncInfo(Box<SyncInfo>),
+    CommitVote(Box<CommitVote>),
+    CommitDecision(Box<CommitDecision>),
 }
 
 impl UnverifiedEvent {
@@ -66,6 +73,14 @@ impl UnverifiedEvent {
                 s.verify(validator)?;
                 VerifiedEvent::SyncInfo(s)
             }
+            UnverifiedEvent::CommitVote(cv) => {
+                cv.verify(validator)?;
+                VerifiedEvent::CommitVote(cv)
+            }
+            UnverifiedEvent::CommitDecision(cd) => {
+                cd.verify(validator)?;
+                VerifiedEvent::CommitDecision(cd)
+            }
         })
     }
 
@@ -74,6 +89,8 @@ impl UnverifiedEvent {
             UnverifiedEvent::ProposalMsg(p) => p.epoch(),
             UnverifiedEvent::VoteMsg(v) => v.epoch(),
             UnverifiedEvent::SyncInfo(s) => s.epoch(),
+            UnverifiedEvent::CommitVote(cv) => cv.epoch(),
+            UnverifiedEvent::CommitDecision(cd) => cd.epoch(),
         }
     }
 }
@@ -84,15 +101,20 @@ impl From<ConsensusMsg> for UnverifiedEvent {
             ConsensusMsg::ProposalMsg(m) => UnverifiedEvent::ProposalMsg(m),
             ConsensusMsg::VoteMsg(m) => UnverifiedEvent::VoteMsg(m),
             ConsensusMsg::SyncInfo(m) => UnverifiedEvent::SyncInfo(m),
+            ConsensusMsg::CommitVoteMsg(m) => UnverifiedEvent::CommitVote(m),
+            ConsensusMsg::CommitDecisionMsg(m) => UnverifiedEvent::CommitDecision(m),
             _ => unreachable!("Unexpected conversion"),
         }
     }
 }
 
+#[derive(Debug)]
 pub enum VerifiedEvent {
     ProposalMsg(Box<ProposalMsg>),
     VoteMsg(Box<VoteMsg>),
     SyncInfo(Box<SyncInfo>),
+    CommitVote(Box<CommitVote>),
+    CommitDecision(Box<CommitDecision>),
 }
 
 #[cfg(test)]
@@ -185,11 +207,14 @@ pub struct RoundManager {
     round_state: RoundState,
     proposer_election: Box<dyn ProposerElection + Send + Sync>,
     proposal_generator: ProposalGenerator,
-    safety_rules: MetricsSafetyRules,
+    safety_rules: Arc<Mutex<MetricsSafetyRules>>,
     network: NetworkSender,
     txn_manager: Arc<dyn TxnManager>,
     storage: Arc<dyn PersistentLivenessStorage>,
     sync_only: bool,
+    back_pressure: Arc<AtomicU64>,
+    decoupled_execution: bool,
+    back_pressure_limit: u64,
 }
 
 impl RoundManager {
@@ -199,12 +224,14 @@ impl RoundManager {
         round_state: RoundState,
         proposer_election: Box<dyn ProposerElection + Send + Sync>,
         proposal_generator: ProposalGenerator,
-        safety_rules: MetricsSafetyRules,
+        safety_rules: Arc<Mutex<MetricsSafetyRules>>,
         network: NetworkSender,
         txn_manager: Arc<dyn TxnManager>,
         storage: Arc<dyn PersistentLivenessStorage>,
         sync_only: bool,
     ) -> Self {
+        // when decoupled execution is false,
+        // the counter is still static.
         counters::OP_COUNTERS
             .gauge("sync_only")
             .set(sync_only as i64);
@@ -219,6 +246,40 @@ impl RoundManager {
             txn_manager,
             storage,
             sync_only,
+            back_pressure: Arc::new(AtomicU64::new(0)), // dummy value
+            decoupled_execution: false,
+            back_pressure_limit: 1, // arbitrary dummy value
+        }
+    }
+
+    pub fn new_with_decoupled_execution(
+        epoch_state: EpochState,
+        block_store: Arc<BlockStore>,
+        round_state: RoundState,
+        proposer_election: Box<dyn ProposerElection + Send + Sync>,
+        proposal_generator: ProposalGenerator,
+        safety_rules: Arc<Mutex<MetricsSafetyRules>>,
+        network: NetworkSender,
+        txn_manager: Arc<dyn TxnManager>,
+        storage: Arc<dyn PersistentLivenessStorage>,
+        sync_only: bool,
+        back_pressure: Arc<AtomicU64>,
+        back_pressure_limit: u64,
+    ) -> Self {
+        Self {
+            epoch_state,
+            block_store,
+            round_state,
+            proposer_election,
+            proposal_generator,
+            safety_rules,
+            network,
+            txn_manager,
+            storage,
+            sync_only,
+            back_pressure,
+            decoupled_execution: true,
+            back_pressure_limit,
         }
     }
 
@@ -278,7 +339,7 @@ impl RoundManager {
             .proposal_generator
             .generate_proposal(new_round_event.round)
             .await?;
-        let signature = self.safety_rules.sign_proposal(&proposal)?;
+        let signature = self.safety_rules.lock().sign_proposal(&proposal)?;
         let signed_proposal =
             Block::new_proposal_from_block_data_and_signature(proposal, signature);
         observe_block(signed_proposal.timestamp_usecs(), BlockStage::SIGNED);
@@ -420,6 +481,27 @@ impl RoundManager {
         Ok(())
     }
 
+    fn sync_only(&self) -> bool {
+        if self.decoupled_execution {
+            let back_pressure = self.back_pressure.load(Ordering::SeqCst);
+            let root_round = self.block_store.root().round();
+            let sync_or_not =
+                self.sync_only || root_round > self.back_pressure_limit + back_pressure;
+
+            counters::OP_COUNTERS
+                .gauge("sync_only")
+                .set(sync_or_not as i64);
+
+            counters::OP_COUNTERS
+                .gauge("back_pressure")
+                .set((root_round - back_pressure) as i64);
+
+            sync_or_not
+        } else {
+            self.sync_only
+        }
+    }
+
     /// The replica broadcasts a "timeout vote message", which includes the round signature, which
     /// can be aggregated to a TimeoutCertificate.
     /// The timeout vote message can be one of the following three options:
@@ -433,7 +515,7 @@ impl RoundManager {
             return Ok(());
         }
 
-        if self.sync_only {
+        if self.sync_only() {
             self.network
                 .broadcast(ConsensusMsg::SyncInfo(Box::new(
                     self.block_store.sync_info(),
@@ -461,6 +543,7 @@ impl RoundManager {
             let timeout = timeout_vote.timeout();
             let signature = self
                 .safety_rules
+                .lock()
                 .sign_timeout(&timeout)
                 .context("[RoundManager] SafetyRules signs timeout")?;
             timeout_vote.add_timeout_signature(signature);
@@ -553,16 +636,19 @@ impl RoundManager {
             .block_store
             .execute_and_insert_block(proposed_block)
             .context("[RoundManager] Failed to execute_and_insert the block")?;
-        // notify mempool about failed txn
-        let compute_result = executed_block.compute_result();
-        if let Err(e) = self
-            .txn_manager
-            .notify(executed_block.block(), compute_result)
-            .await
-        {
-            error!(
-                error = ?e, "[RoundManager] Failed to notify mempool of rejected txns",
-            );
+
+        if !self.decoupled_execution {
+            // notify mempool about failed txn
+            let compute_result = executed_block.compute_result();
+            if let Err(e) = self
+                .txn_manager
+                .notify(executed_block.block(), compute_result)
+                .await
+            {
+                error!(
+                    error = ?e, "[RoundManager] Failed to notify mempool of rejected txns",
+                );
+            }
         }
 
         // Short circuit if already voted.
@@ -573,13 +659,14 @@ impl RoundManager {
         );
 
         ensure!(
-            !self.sync_only,
+            !self.sync_only(),
             "[RoundManager] sync_only flag is set, stop voting"
         );
 
         let maybe_signed_vote_proposal = executed_block.maybe_signed_vote_proposal();
         let vote = self
             .safety_rules
+            .lock()
             .construct_and_sign_vote(&maybe_signed_vote_proposal)
             .context(format!(
                 "[RoundManager] SafetyRules {}Rejected{} {}",
@@ -759,11 +846,11 @@ impl RoundManager {
     /// Inspect the current consensus state.
     #[cfg(test)]
     pub fn consensus_state(&mut self) -> ConsensusState {
-        self.safety_rules.consensus_state().unwrap()
+        self.safety_rules.lock().consensus_state().unwrap()
     }
 
     #[cfg(test)]
-    pub fn set_safety_rules(&mut self, safety_rules: MetricsSafetyRules) {
+    pub fn set_safety_rules(&mut self, safety_rules: Arc<Mutex<MetricsSafetyRules>>) {
         self.safety_rules = safety_rules
     }
 

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 use channel::{self, diem_channel, message_queues::QueueStyle};
 use consensus_types::proposal_msg::ProposalMsg;
+use diem_infallible::Mutex;
 use diem_types::{
     epoch_change::EpochChangeProof,
     epoch_state::EpochState,
@@ -158,7 +159,10 @@ fn create_node_for_fuzzing() -> RoundManager {
         round_state,
         proposer_election,
         proposal_generator,
-        MetricsSafetyRules::new(Box::new(safety_rules), storage.clone()),
+        Arc::new(Mutex::new(MetricsSafetyRules::new(
+            Box::new(safety_rules),
+            storage.clone(),
+        ))),
         network,
         Arc::new(MockTransactionManager::new(None)),
         storage,


### PR DESCRIPTION
This is the third (and the last) part of integrating decoupled execution.
We add the back pressure to hold back the consensus progress when the execution
progress is falling behind much.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update or suggest changes to the docs at https://developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
