### PR TITLE
[move-prover] Ensure BOOGIE_EXE is set

### DIFF
--- a/language/move-prover/boogie-backend/src/boogie_wrapper.rs
+++ b/language/move-prover/boogie-backend/src/boogie_wrapper.rs
@@ -106,7 +106,7 @@ impl<'env> BoogieWrapper<'env> {
     /// Calls boogie on the given file. On success, returns a struct representing the analyzed
     /// output of boogie.
     pub fn call_boogie(&self, boogie_file: &str) -> anyhow::Result<BoogieOutput> {
-        let args = self.options.get_boogie_command(boogie_file);
+        let args = self.options.get_boogie_command(boogie_file)?;
         info!("running solver");
         debug!("command line: {}", args.iter().join(" "));
         let task = RunBoogieWithSeeds {
@@ -142,11 +142,7 @@ impl<'env> BoogieWrapper<'env> {
                         all_output: "".to_string(),
                     });
                 } else {
-                    panic!(
-                        "cannot execute boogie `{}`: {}",
-                        self.options.get_boogie_command("")[0],
-                        err
-                    )
+                    panic!("cannot execute boogie `{:?}`: {}", args, err)
                 }
             }
             Ok(out) => out,

--- a/language/move-prover/boogie-backend/src/prover_task_runner.rs
+++ b/language/move-prover/boogie-backend/src/prover_task_runner.rs
@@ -183,8 +183,10 @@ impl ProverTask for RunBoogieWithSeeds {
 
     async fn run(&mut self, task_id: Self::TaskId, sem: Arc<Semaphore>) -> Self::TaskResult {
         let _guard = sem.acquire().await;
-        let args = self.get_boogie_command(task_id);
-        debug!("runing Boogie command with seed {}", task_id);
+        let args = self
+            .get_boogie_command(task_id)
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+        debug!("running Boogie command with seed {}", task_id);
         Command::new(&args[0])
             .args(&args[1..])
             .kill_on_drop(true)
@@ -212,7 +214,7 @@ impl ProverTask for RunBoogieWithSeeds {
 
 impl RunBoogieWithSeeds {
     /// Returns command line to call boogie.
-    pub fn get_boogie_command(&mut self, seed: usize) -> Vec<String> {
+    pub fn get_boogie_command(&mut self, seed: usize) -> anyhow::Result<Vec<String>> {
         self.options
             .boogie_flags
             .push(format!("-proverOpt:O:smt.random_seed={}", seed));


### PR DESCRIPTION
before there was just a "file not found" message which wasn't useful.
Now users will know they didn't set their environment up correctly.

```
$ cargo run --release --package move-prover --  diem/language/diem-framework/modules/
[INFO] translating module CoreAddresses
...
[INFO] running solver
[INFO] 1.060s build, 0.603s trafo, 0.381s gen, 11.689s verify
$ echo $BOOGIE_EXE
.dotnet/tools/boogie
$ unset BOOGIE_EXE
$ cargo run --release --package move-prover --  diem/language/diem-framework/modules/

[INFO] translating module CoreAddresses
...
No boogie executable set.  Please set BOOGIE_EXE
```