### PR TITLE
[sdk] [experimental] Read write set local execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1607,6 +1607,8 @@ dependencies = [
  "bcs",
  "datatest-stable",
  "diem-framework-releases",
+ "diem-logger",
+ "diem-prefetched-transaction-replay",
  "diem-vm",
  "diem-workspace-hack",
  "move-cli",
@@ -2414,6 +2416,34 @@ dependencies = [
  "proptest-derive",
  "rand 0.8.3",
  "rayon",
+]
+
+[[package]]
+name = "diem-prefetched-transaction-replay"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bcs",
+ "diem-client",
+ "diem-config",
+ "diem-logger",
+ "diem-read-write-set",
+ "diem-state-view",
+ "diem-transaction-replay",
+ "diem-types",
+ "diem-validator-interface",
+ "diem-vm",
+ "diem-workspace-hack",
+ "diemdb",
+ "hex",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-cli",
+ "move-core-types",
+ "read-write-set",
+ "serde_json",
+ "storage-interface",
+ "structopt 0.3.21",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ members = [
     "language/diem-tools/diem-validator-interface",
     "language/diem-tools/e2e-tests-replay",
     "language/diem-tools/oncall-trainer",
+    "language/diem-tools/prefetched-transaction-replay",
     "language/diem-tools/transaction-replay",
     "language/diem-tools/writeset-transaction-generator",
     "language/diem-transaction-benchmarks",

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -850,6 +850,14 @@ impl TransactionView {
     }
 }
 
+impl TryInto<Transaction> for TransactionView {
+    type Error = Error;
+
+    fn try_into(self) -> Result<Transaction, Self::Error> {
+        bcs::from_bytes(&self.bytes).map_err(|e| format_err!("{}", e))
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct TransactionListView(pub Vec<TransactionView>);
 

--- a/language/diem-tools/df-cli/Cargo.toml
+++ b/language/diem-tools/df-cli/Cargo.toml
@@ -19,6 +19,8 @@ move-core-types = { path = "../../move-core/types" }
 move-cli = { path = "../../tools/move-cli" }
 diem-vm = { path = "../../diem-vm" }
 diem-framework-releases = { path = "../../diem-framework/DPN/releases" }
+diem-logger = { path = "../../../common/logger" }
+diem-prefetched-transaction-replay = { path = "../prefetched-transaction-replay" }
 
 [dev-dependencies]
 datatest-stable = "0.1.1"

--- a/language/diem-tools/df-cli/src/main.rs
+++ b/language/diem-tools/df-cli/src/main.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use move_cli::{Command, Move};
+use diem_logger::Logger;
+use diem_prefetched_transaction_replay::PrefetchedReplayCLI;
+use diem_vm::DiemVM;
+use move_cli::{Command as MoveCLICommand, Move};
 use move_core_types::errmap::ErrorMapping;
 use structopt::StructOpt;
 
@@ -18,20 +21,32 @@ pub struct DfCli {
 #[derive(StructOpt)]
 pub enum DfCommands {
     #[structopt(flatten)]
-    Command(Command),
+    MoveCLICommand(MoveCLICommand),
     // extra commands available only in df-cli can be added below
+    #[structopt(name = "prefetched-replay")]
+    PrefetchedReplayCommand(PrefetchedReplayCLI),
 }
 
 fn main() -> Result<()> {
+    Logger::builder().build();
+
     let error_descriptions: ErrorMapping =
         bcs::from_bytes(diem_framework_releases::current_error_descriptions())?;
     let args = DfCli::from_args();
-    match &args.cmd {
-        DfCommands::Command(cmd) => move_cli::run_cli(
+    match args.cmd {
+        DfCommands::MoveCLICommand(cmd) => move_cli::run_cli(
             diem_vm::natives::diem_natives(),
             &error_descriptions,
             &args.move_args,
-            cmd,
+            &cmd,
         ),
+        DfCommands::PrefetchedReplayCommand(cmd) => {
+            diem_prefetched_transaction_replay::run_cli::<DiemVM>(
+                cmd,
+                args.move_args.build_dir,
+                args.move_args.storage_dir,
+                args.move_args.mode,
+            )
+        }
     }
 }

--- a/language/diem-tools/diem-read-write-set/Cargo.toml
+++ b/language/diem-tools/diem-read-write-set/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.38"
+
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 diem-types = { path = "../../../types" }
 diem-vm = { path = "../../diem-vm" }

--- a/language/diem-tools/diem-validator-interface/src/json_rpc_interface.rs
+++ b/language/diem-tools/diem-validator-interface/src/json_rpc_interface.rs
@@ -12,7 +12,7 @@ use diem_types::{
     event::EventKey,
     transaction::{Transaction, Version},
 };
-use std::convert::TryFrom;
+use std::convert::{TryFrom, TryInto};
 
 pub struct JsonRpcDebuggerInterface {
     client: BlockingClient,
@@ -68,13 +68,20 @@ impl DiemValidatorInterface for JsonRpcDebuggerInterface {
             .client
             .get_transactions(start, limit, false)?
             .into_inner();
+        txns.into_iter().map(|t| t.try_into()).collect()
+    }
 
-        let mut output = vec![];
-        for txn in txns.into_iter() {
-            let raw_bytes = txn.bytes;
-            output.push(bcs::from_bytes(&raw_bytes)?);
-        }
-        Ok(output)
+    fn get_account_transactions(
+        &self,
+        account: AccountAddress,
+        start: Version,
+        limit: u64,
+    ) -> Result<Vec<Transaction>> {
+        let txns = self
+            .client
+            .get_account_transactions(account, start, limit, false)?
+            .into_inner();
+        txns.into_iter().map(|t| t.try_into()).collect()
     }
 
     fn get_latest_version(&self) -> Result<Version> {

--- a/language/diem-tools/diem-validator-interface/src/lib.rs
+++ b/language/diem-tools/diem-validator-interface/src/lib.rs
@@ -30,6 +30,12 @@ pub trait DiemValidatorInterface: Sync {
     fn get_events(&self, key: &EventKey, start_seq: u64, limit: u64)
         -> Result<Vec<EventWithProof>>;
     fn get_committed_transactions(&self, start: Version, limit: u64) -> Result<Vec<Transaction>>;
+    fn get_account_transactions(
+        &self,
+        account: AccountAddress,
+        start: Version,
+        limit: u64,
+    ) -> Result<Vec<Transaction>>;
     fn get_latest_version(&self) -> Result<Version>;
     fn get_version_by_account_sequence(
         &self,

--- a/language/diem-tools/diem-validator-interface/src/storage_interface.rs
+++ b/language/diem-tools/diem-validator-interface/src/storage_interface.rs
@@ -50,11 +50,32 @@ impl DiemValidatorInterface for DBDebuggerInterface {
         self.0
             .get_events_with_proofs(key, start_seq, Order::Ascending, limit, None)
     }
+
     fn get_committed_transactions(&self, start: Version, limit: u64) -> Result<Vec<Transaction>> {
         Ok(self
             .0
             .get_transactions(start, limit, self.get_latest_version()?, false)?
             .transactions)
+    }
+
+    fn get_account_transactions(
+        &self,
+        address: AccountAddress,
+        start: Version,
+        limit: u64,
+    ) -> Result<Vec<Transaction>> {
+        let txns = self.0.get_account_transactions(
+            address,
+            start,
+            limit,
+            false,
+            self.get_latest_version()?,
+        )?;
+        Ok(txns
+            .into_inner()
+            .into_iter()
+            .map(|t| t.transaction)
+            .collect())
     }
 
     fn get_latest_version(&self) -> Result<Version> {

--- a/language/diem-tools/prefetched-transaction-replay/Cargo.toml
+++ b/language/diem-tools/prefetched-transaction-replay/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "diem-prefetched-transaction-replay"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+description = "Replay transactions stored on chain using prefetching"
+repository = "https://github.com/diem/diem"
+homepage = "https://diem.com"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+
+[dependencies]
+anyhow = "1.0.38"
+bcs = "0.1.2"
+hex = "0.4.3"
+structopt = "0.3.21"
+serde_json = "1.0.59"
+
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
+diem-read-write-set = { path = "../diem-read-write-set" }
+diem-logger = { path = "../../../common/logger" }
+diem-validator-interface = { path = "../diem-validator-interface" }
+diem-transaction-replay = { path = "../transaction-replay" }
+diem-vm = { path = "../../diem-vm" }
+move-core-types = { path = "../../move-core/types" }
+read-write-set = { path = "../../tools/read-write-set" }
+move-cli = { path = "../../tools/move-cli" }
+move-bytecode-utils = { path = "../../tools/move-bytecode-utils" }
+move-binary-format = { path = "../../move-binary-format" }
+diem-client = { path = "../../../sdk/client" }
+diemdb = { path = "../../../storage/diemdb" }
+diem-types = { path = "../../../types" }
+diem-config = { path = "../../../config" }
+storage-interface = { path = "../../../storage/storage-interface" }
+diem-state-view = { path = "../../../storage/state-view" }

--- a/language/diem-tools/prefetched-transaction-replay/src/lib.rs
+++ b/language/diem-tools/prefetched-transaction-replay/src/lib.rs
@@ -1,0 +1,403 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::HashSet,
+    convert::TryFrom,
+    fs::{self, File},
+    io::{BufRead, BufReader},
+    path::{Path, PathBuf},
+};
+
+use anyhow::{format_err, Result};
+use diem_client::{
+    views::AccountStateWithProofView, AccountAddress, BlockingClient, MethodRequest,
+    MethodResponse, SignedTransaction,
+};
+use diem_logger::*;
+use diem_read_write_set::ReadWriteSetAnalysis;
+use diem_state_view::StateView;
+use diem_transaction_replay::DiemDebugger;
+use diem_types::{
+    access_path::{self, AccessPath},
+    account_state::AccountState,
+    account_state_blob::AccountStateBlob,
+    transaction::{Transaction, TransactionOutput, TransactionPayload, Version},
+};
+use diem_validator_interface::{
+    DebuggerStateView, DiemValidatorInterface, JsonRpcDebuggerInterface,
+};
+use diem_vm::{data_cache::RemoteStorage, VMExecutor};
+use move_cli::sandbox::utils::{
+    mode::{Mode, ModeType},
+    on_disk_state_view::OnDiskStateView,
+};
+use move_core_types::{language_storage::ResourceKey, resolver::MoveResolver};
+
+use structopt::StructOpt;
+
+const DEFAULT_NODE_URL: &str = "http://localhost:8080";
+
+pub struct OnDiskStateViewReader {
+    view: OnDiskStateView,
+}
+
+struct AccountAddressWithState {
+    address: AccountAddress,
+    state: AccountState,
+}
+
+#[derive(Debug)]
+pub struct PrefetchTransactionReplayerConfig {
+    build_dir: PathBuf,
+    storage_dir: PathBuf,
+    rpc_url: String,
+    mode_type: ModeType,
+}
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+    about = "Replay transactions using state prefetching",
+    rename_all = "kebab-case"
+)]
+pub struct PrefetchedReplayCLI {
+    #[structopt(long, default_value = DEFAULT_NODE_URL)]
+    rpc_url: String,
+
+    #[structopt(subcommand)]
+    cmd: Command,
+}
+
+#[derive(Debug, StructOpt)]
+pub enum Command {
+    /// Replay transactions starting from version `start` to `start + limit`.
+    #[structopt(name = "replay-transactions")]
+    ReplayTransactions { start: Version, limit: u64 },
+
+    /// Replay `account` transactions starting from version `start` to `start + limit`.
+    #[structopt(name = "replay-account-transactions")]
+    ReplayAccountTransactions {
+        account: AccountAddress,
+        start: Version,
+        limit: u64,
+    },
+
+    /// Execute serialized transactions from `txs_path`
+    #[structopt(name = "execute-serialized-transactions")]
+    ExecuteSerializedTransactions { txs_path: PathBuf },
+}
+
+pub struct PrefetchTransactionReplayer {
+    config: PrefetchTransactionReplayerConfig,
+    validator: Box<dyn DiemValidatorInterface>,
+    debugger: DiemDebugger,
+    rpc_client: BlockingClient,
+}
+
+impl StateView for OnDiskStateViewReader {
+    fn get(&self, ap: &AccessPath) -> Result<Option<Vec<u8>>> {
+        match ap.get_path() {
+            access_path::Path::Code(mid) => self.view.get_module_bytes(&mid),
+            access_path::Path::Resource(tag) => self.view.get_resource_bytes(ap.address, tag),
+        }
+    }
+
+    fn is_genesis(&self) -> bool {
+        false
+    }
+}
+
+fn ensure_dir_does_not_exist(dir: &Path) -> Result<()> {
+    if dir.exists() {
+        Err(format_err!("{:?} must be empty as it will be created", dir))
+    } else {
+        Ok(())
+    }
+}
+
+impl PrefetchTransactionReplayer {
+    pub fn from_config(config: PrefetchTransactionReplayerConfig) -> Result<Self> {
+        ensure_dir_does_not_exist(&config.build_dir)?;
+        ensure_dir_does_not_exist(&config.storage_dir)?;
+
+        let debugger = DiemDebugger::json_rpc_with_config(
+            &config.rpc_url,
+            config.build_dir.clone(),
+            config.storage_dir.clone(),
+        )?;
+
+        let rpc_client = BlockingClient::new(&config.rpc_url);
+
+        // NOTE: we could probably avoid creating a second validator
+        // by making the one in `DiemDebugger` accessible publicly
+        let validator = Box::new(JsonRpcDebuggerInterface::new(&config.rpc_url)?);
+        Ok(PrefetchTransactionReplayer {
+            config,
+            validator,
+            debugger,
+            rpc_client,
+        })
+    }
+
+    fn get_keys_read_for_tx(
+        &self,
+        live_state: &impl MoveResolver,
+        tx: &Transaction,
+        rw_analysis: &ReadWriteSetAnalysis,
+    ) -> Result<Vec<ResourceKey>> {
+        let signed_tx = match tx {
+            Transaction::UserTransaction(u) => u,
+            t => {
+                warn!("cannot process tx {:?}, ignoring", t);
+                return Ok(vec![]);
+            }
+        };
+
+        // NOTE: we might need to do something about the transactions we do
+        // not currently handle
+        match signed_tx.payload() {
+            TransactionPayload::ScriptFunction(_) => {
+                rw_analysis.get_keys_read(signed_tx, live_state)
+            }
+            payload => {
+                warn!("cannot process payload {:?}, ignoring", payload);
+                Ok(vec![])
+            }
+        }
+    }
+
+    fn get_unique_addresses_from_keys(&self, key_reads: &[ResourceKey]) -> Vec<AccountAddress> {
+        key_reads
+            .iter()
+            .map(|k| k.address)
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect()
+    }
+
+    fn extract_account_state(&self, state_with_proof: &AccountStateWithProofView) -> AccountState {
+        // NOTE: if this has a chance to fail, it might be better to change
+        // the function to return Result<AccountState>
+        let blob = state_with_proof.blob.as_ref().unwrap();
+        let parsed_blob = bcs::from_bytes::<AccountStateBlob>(blob).unwrap();
+        AccountState::try_from(&parsed_blob).unwrap()
+    }
+
+    fn fetch_accounts_storage(
+        &self,
+        addresses: &[AccountAddress],
+    ) -> Result<Vec<AccountAddressWithState>> {
+        let requests = addresses
+            .iter()
+            .map(|a| MethodRequest::get_account_state_with_proof(*a, None, None))
+            .collect();
+
+        let results = self
+            .rpc_client
+            .batch(requests)?
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let account_states: Vec<AccountAddressWithState> = results
+            .into_iter()
+            .zip(addresses.iter())
+            .filter_map(|(r, a)| match r.into_inner() {
+                MethodResponse::GetAccountStateWithProof(v) => {
+                    let state = self.extract_account_state(&v);
+                    Some(AccountAddressWithState { address: *a, state })
+                }
+                _ => None,
+            })
+            .collect();
+
+        Ok(account_states)
+    }
+
+    fn get_addresses_read_by_txs(
+        &self,
+        txs: &[Transaction],
+        replay_version: u64,
+    ) -> Result<Vec<AccountAddress>> {
+        // TODO: use dependency analysis to fetch the modules relevant
+        // to the transactions rather than all the modules at address 0x1
+        let modules = self
+            .debugger
+            .get_diem_framework_modules_at_version(replay_version, true)?;
+
+        let mut keys = vec![];
+        let rw_analysis = ReadWriteSetAnalysis::new(read_write_set::analyze(&modules)?);
+
+        let live_state_view = DebuggerStateView::new(self.validator.as_ref(), replay_version);
+        let live_storage = RemoteStorage::new(&live_state_view);
+
+        for tx in txs.iter() {
+            let new_keys = self.get_keys_read_for_tx(&live_storage, tx, &rw_analysis)?;
+            keys.extend(new_keys);
+        }
+        Ok(self.get_unique_addresses_from_keys(&keys))
+    }
+
+    fn populate_storage_for_transactions(
+        &self,
+        txs: &[Transaction],
+        version: Option<u64>,
+    ) -> Result<()> {
+        let replay_version = match version {
+            Some(0) => 1,
+            Some(v) => v,
+            None => self.debugger.get_latest_version()?,
+        };
+
+        let addresses_read = self.get_addresses_read_by_txs(txs, replay_version)?;
+        let accounts_states = self.fetch_accounts_storage(&addresses_read)?;
+        for account in accounts_states {
+            self.debugger
+                .save_account_state(account.address, &account.state)?;
+        }
+        Ok(())
+    }
+
+    fn _execute_transactions_at<V: VMExecutor>(
+        &self,
+        state: &OnDiskStateViewReader,
+        txs: Vec<Transaction>,
+        version: Option<u64>,
+    ) -> Result<Vec<TransactionOutput>> {
+        self.populate_storage_for_transactions(&txs, version)?;
+        V::execute_block(txs, state).map_err(|err| format_err!("Unexpected VM Error: {:?}", err))
+    }
+
+    fn cleanup_dirs(&self) -> Result<()> {
+        let mut result = vec![];
+        for dir in vec![&self.config.storage_dir, &self.config.build_dir].into_iter() {
+            let res = fs::remove_dir_all(dir);
+            result.push(res.map_err(|e| format_err!("could not remove {:?}: {}", dir, e)))
+        }
+        result.into_iter().collect()
+    }
+
+    pub fn execute_transactions_at<V: VMExecutor>(
+        &self,
+        txs: Vec<Transaction>,
+        version: Option<u64>,
+    ) -> Result<Vec<TransactionOutput>> {
+        let mode = Mode::new(self.config.mode_type);
+        let result = mode
+            .prepare_state(
+                self.config.build_dir.as_path(),
+                self.config.storage_dir.as_path(),
+            )
+            .and_then(|view| {
+                let state = OnDiskStateViewReader { view };
+                self._execute_transactions_at::<V>(&state, txs, version)
+            });
+        self.cleanup_dirs()?;
+
+        result
+    }
+
+    // NOTE: this is mostly taken from the diem-transaction-replay crate
+    // we could fairly easily avoid duplication if desired
+    pub fn execute_transactions<V: VMExecutor>(
+        &self,
+        mut txns: Vec<Transaction>,
+        version: Option<Version>,
+        mut limit: u64,
+    ) -> Result<Vec<TransactionOutput>> {
+        let mut ret = vec![];
+        let mut begin = 0;
+        while limit != 0 && !txns.is_empty() {
+            info!(
+                "Starting epoch execution at {:?}, {:?} transactions remaining",
+                begin, limit
+            );
+            let mut epoch_result = self.execute_transactions_at::<V>(txns.clone(), version)?;
+            begin += epoch_result.len() as u64;
+            limit -= epoch_result.len() as u64;
+            txns = txns.split_off(epoch_result.len());
+            ret.append(&mut epoch_result);
+        }
+        Ok(ret)
+    }
+
+    pub fn execute_past_transactions<V: VMExecutor>(
+        &self,
+        begin: Version,
+        limit: u64,
+    ) -> Result<Vec<TransactionOutput>> {
+        let txns = self.validator.get_committed_transactions(begin, limit)?;
+        self.execute_transactions::<V>(txns, Some(begin), limit)
+    }
+
+    pub fn execute_account_transactions<V: VMExecutor>(
+        &self,
+        account: AccountAddress,
+        begin: Version,
+        limit: u64,
+    ) -> Result<Vec<TransactionOutput>> {
+        let txns = self
+            .validator
+            .get_account_transactions(account, begin, limit)?;
+        self.execute_transactions::<V>(txns, Some(begin), limit)
+    }
+
+    pub fn execute_serialized_user_transactions<V: VMExecutor>(
+        &self,
+        txs_path: PathBuf,
+    ) -> Result<Vec<TransactionOutput>> {
+        let file = File::open(txs_path)?;
+        let lines = BufReader::new(file).lines();
+        let mut txns = vec![];
+        for line in lines {
+            let raw_tx = hex::decode(line?)?;
+            let tx: SignedTransaction = bcs::from_bytes(&raw_tx)?;
+            txns.push(Transaction::UserTransaction(tx));
+        }
+        let limit = txns.len() as u64;
+        self.execute_transactions::<V>(txns, None, limit)
+    }
+}
+
+pub fn run_cli<V: VMExecutor>(
+    args: PrefetchedReplayCLI,
+    mut build_dir: PathBuf,
+    mut storage_dir: PathBuf,
+    mode_type: ModeType,
+) -> Result<()> {
+    if build_dir.is_relative() {
+        build_dir = std::env::temp_dir().join(build_dir);
+    }
+
+    if storage_dir.is_relative() {
+        storage_dir = std::env::temp_dir().join(storage_dir);
+    }
+
+    let config = PrefetchTransactionReplayerConfig {
+        build_dir,
+        storage_dir,
+        mode_type,
+        rpc_url: args.rpc_url,
+    };
+
+    let replayer = PrefetchTransactionReplayer::from_config(config)?;
+
+    let outputs = match args.cmd {
+        Command::ReplayTransactions { start, limit } => {
+            replayer.execute_past_transactions::<V>(start, limit)
+        }
+        Command::ReplayAccountTransactions {
+            account,
+            start,
+            limit,
+        } => replayer.execute_account_transactions::<V>(account, start, limit),
+        Command::ExecuteSerializedTransactions { txs_path } => {
+            replayer.execute_serialized_user_transactions::<V>(txs_path)
+        }
+    };
+
+    outputs
+        .and_then(|v| {
+            serde_json::to_string(&v).map_err(|e| format_err!("could not format to json: {}", e))
+        })
+        .map(|v| println!("{}", v))
+}

--- a/language/diem-tools/transaction-replay/src/lib.rs
+++ b/language/diem-tools/transaction-replay/src/lib.rs
@@ -52,6 +52,18 @@ impl DiemDebugger {
         Ok(Self::new(Box::new(JsonRpcDebuggerInterface::new(url)?)))
     }
 
+    pub fn json_rpc_with_config(
+        url: &str,
+        build_dir: PathBuf,
+        storage_dir: PathBuf,
+    ) -> Result<Self> {
+        JsonRpcDebuggerInterface::new(url).map(|debugger| Self {
+            debugger: Box::new(debugger),
+            build_dir,
+            storage_dir,
+        })
+    }
+
     pub fn db<P: AsRef<Path> + Clone>(db_root_path: P) -> Result<Self> {
         Ok(Self::new(Box::new(DBDebuggerInterface::open(
             db_root_path,
@@ -184,7 +196,7 @@ impl DiemDebugger {
         Ok(())
     }
 
-    fn save_account_state(
+    pub fn save_account_state(
         &self,
         account: AccountAddress,
         account_state: &AccountState,

--- a/language/diem-tools/transaction-replay/src/unit_tests/mod.rs
+++ b/language/diem-tools/transaction-replay/src/unit_tests/mod.rs
@@ -93,6 +93,27 @@ impl DiemValidatorInterface for TestInterface {
         Ok(result)
     }
 
+    fn get_account_transactions(
+        &self,
+        address: AccountAddress,
+        start: Version,
+        limit: u64,
+    ) -> Result<Vec<Transaction>> {
+        Ok(self
+            .transaction_store
+            .iter()
+            .filter_map(|tx| match tx {
+                Transaction::UserTransaction(txn)
+                    if txn.sender() == address && start >= txn.sequence_number() =>
+                {
+                    Some(tx.clone())
+                }
+                _ => None,
+            })
+            .take(limit as usize)
+            .collect())
+    }
+
     fn get_latest_version(&self) -> Result<Version> {
         Ok(self.latest_version)
     }

--- a/language/move-prover/bytecode/src/access_path_trie.rs
+++ b/language/move-prover/bytecode/src/access_path_trie.rs
@@ -518,6 +518,19 @@ impl<T: FootprintDomain> AccessPathTrie<T> {
     }
 
     /// Apply `f` to each (access path, data) pair encoded in `self`
+    /// and collects the result
+    pub fn map_paths<F, R>(&self, mut f: F) -> Vec<R>
+    where
+        F: FnMut(&AccessPath, &T) -> R,
+    {
+        let mut results = vec![];
+        self.iter_paths_opt(|ap, t_opt| {
+            t_opt.map(|t| results.push(f(ap, t)));
+        });
+        results
+    }
+
+    /// Apply `f` to each (access path, data) pair encoded in `self`
     /// and collects the result when `f` returns `Some(r)`
     pub fn filter_map_paths<F, R>(&self, mut f: F) -> Vec<R>
     where

--- a/language/tools/move-cli/src/lib.rs
+++ b/language/tools/move-cli/src/lib.rs
@@ -56,10 +56,10 @@ pub struct Move {
     /// Directory storing Move resources, events, and module bytecodes produced by module publishing
     /// and script execution.
     #[structopt(long, default_value = DEFAULT_STORAGE_DIR, parse(from_os_str), global = true)]
-    storage_dir: PathBuf,
+    pub storage_dir: PathBuf,
     /// Directory storing build artifacts produced by compilation.
     #[structopt(long, default_value = DEFAULT_BUILD_DIR, parse(from_os_str), global = true)]
-    build_dir: PathBuf,
+    pub build_dir: PathBuf,
 
     /// Dependency inclusion mode.
     #[structopt(
@@ -67,11 +67,10 @@ pub struct Move {
         default_value = DEFAULT_DEP_MODE,
         global = true,
     )]
-    mode: ModeType,
-
+    pub mode: ModeType,
     /// Print additional diagnostics.
     #[structopt(short = "v", global = true)]
-    verbose: bool,
+    pub verbose: bool,
 }
 
 /// MoveCLI is the CLI that will be executed by the `move-cli` command

--- a/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
+++ b/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
@@ -251,7 +251,7 @@ impl OnDiskStateView {
     }
 
     /// Read the resource bytes stored on-disk at `addr`/`tag`
-    fn get_module_bytes(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>> {
+    pub fn get_module_bytes(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>> {
         Self::get_bytes(&self.get_module_path(module_id))
     }
 

--- a/x.toml
+++ b/x.toml
@@ -191,7 +191,6 @@ members = [
     "diem-keygen",
     "diem-parallel-executor", # Will be removed once parallel execution is used in production.
     "diem-proptest-helpers",
-    "diem-read-write-set",
     "diem-retrier",
     "diem-swarm",
     "diem-transactional-test-harness",
@@ -264,6 +263,7 @@ diem_crates_in_language = [
     "diem-validator-interface",
     "diem-transactional-test-harness",
     "diem-transaction-replay",
+    "diem-prefetched-transaction-replay",
     "diem-transaction-benchmarks",
     "diem-writeset-generator",
     "diem-vm",


### PR DESCRIPTION
## Motivation

This leverages the read-write set analysis to prefetch all the resources to reexecute a transaction locally.
Some details are also available in #8586 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Mostly smoke tests using existing transactions.
Can be run using

```
cargo run -p df-cli -- prefetched-replay --mode diem --rpc-url http://localhost:8080 execute-serialized-transactions mint-txs.hexl
```

where `mint-txs.hexl` is the output of raw transactions generated by `transaction-generator` (see #9113)

/cc @sblackshear @runtian-zhou @tzakian 

