### PR TITLE
[move-lang] Update tests to properly use phantom parmas

### DIFF
--- a/language/diem-tools/df-cli/tests/testsuite/compare_smoke/src/modules/NonFungibleToken.move
+++ b/language/diem-tools/df-cli/tests/testsuite/compare_smoke/src/modules/NonFungibleToken.move
@@ -20,7 +20,7 @@ module NonFungibleToken {
         token: Option<Token>
     }
 
-    struct TokenLock<Token> has key {
+    struct TokenLock<phantom Token> has key {
     }
 
     fun lock<Token: store>(account: &signer) {

--- a/language/move-lang/functional-tests/tests/diem/natives/event_emit_struct_with_type_params.move
+++ b/language/move-lang/functional-tests/tests/diem/natives/event_emit_struct_with_type_params.move
@@ -1,7 +1,7 @@
 module {{default}}::M {
     use Std::Event;
 
-    struct MyEvent<T1, T2> has copy, drop, store { b: bool }
+    struct MyEvent<phantom T1, phantom T2> has copy, drop, store { b: bool }
 
     public fun emit_event<T1: copy + drop + store, T2: copy + drop + store>(account: &signer) {
         let handle = Event::new_event_handle<MyEvent<T2, T1>>(account);

--- a/language/move-lang/functional-tests/tests/move/natives/emit_event_large_type.move
+++ b/language/move-lang/functional-tests/tests/move/natives/emit_event_large_type.move
@@ -12,7 +12,7 @@ module {{default}}::M {
     struct Box127<T> has copy, drop, store { x: Box63<Box63<T>> }
     struct Box255<T> has copy, drop, store { x: Box127<Box127<T>> }
 
-    struct MyEvent<T: copy + drop + store> has key {
+    struct MyEvent<phantom T: copy + drop + store> has key {
         e: EventHandle<T>
     }
 

--- a/language/move-lang/tests/move_check/examples/multi_pool_money_market_token.move
+++ b/language/move-lang/tests/move_check/examples/multi_pool_money_market_token.move
@@ -78,17 +78,17 @@ module OneToOneMarket {
         coin: Token::Coin<AssetType>,
     }
 
-    struct DepositRecord<InputAsset: copy + drop, OutputAsset: copy + drop> has key {
+    struct DepositRecord<phantom InputAsset: copy + drop, phantom OutputAsset: copy + drop> has key {
         // pool owner => amount
         record: Map::T<address, u64>
     }
 
-    struct BorrowRecord<InputAsset: copy + drop, OutputAsset: copy + drop> has key {
+    struct BorrowRecord<phantom InputAsset: copy + drop, phantom OutputAsset: copy + drop> has key {
         // pool owner => amount
         record: Map::T<address, u64>
     }
 
-    struct Price<InputAsset: copy + drop, OutputAsset: copy + drop> has key {
+    struct Price<phantom InputAsset: copy + drop, phantom OutputAsset: copy + drop> has key {
         price: u64,
     }
 

--- a/language/move-lang/tests/move_check/examples/simple_money_market_token.move
+++ b/language/move-lang/tests/move_check/examples/simple_money_market_token.move
@@ -57,15 +57,15 @@ module OneToOneMarket {
         coin: Token::Coin<AssetType>,
     }
 
-    struct DepositRecord<InputAsset: copy + drop, OutputAsset: copy + drop> has key {
+    struct DepositRecord<phantom InputAsset: copy + drop, phantom OutputAsset: copy + drop> has key {
         record: u64,
     }
 
-    struct BorrowRecord<InputAsset: copy + drop, OutputAsset: copy + drop> has key {
+    struct BorrowRecord<phantom InputAsset: copy + drop, phantom OutputAsset: copy + drop> has key {
         record: u64,
     }
 
-    struct Price<InputAsset: copy + drop, OutputAsset: copy + drop> has key {
+    struct Price<phantom InputAsset: copy + drop, phantom OutputAsset: copy + drop> has key {
         price: u64,
     }
 

--- a/language/move-lang/tests/move_check/expansion/duplicate_abilities.exp
+++ b/language/move-lang/tests/move_check/expansion/duplicate_abilities.exp
@@ -9,7 +9,7 @@ error[E02001]: duplicate declaration, item, or annotation
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/expansion/duplicate_abilities.move:5:26
   │
-5 │     struct Bar<T: drop + drop> {}
+5 │     struct Bar<T: drop + drop> { f: T }
   │                   ----   ^^^^ Duplicate 'drop' ability constraint
   │                   │       
   │                   Ability previously given here

--- a/language/move-lang/tests/move_check/expansion/duplicate_abilities.move
+++ b/language/move-lang/tests/move_check/expansion/duplicate_abilities.move
@@ -2,7 +2,7 @@ address 0x42 {
 module M {
     // invalid duplicate abilities
     struct Foo has copy, copy {}
-    struct Bar<T: drop + drop> {}
+    struct Bar<T: drop + drop> { f: T }
     fun baz<T: store + store>() {}
 }
 }

--- a/language/move-lang/tests/move_check/expansion/restricted_struct_names.exp
+++ b/language/move-lang/tests/move_check/expansion/restricted_struct_names.exp
@@ -31,7 +31,7 @@ error[E02010]: invalid name
 error[E02010]: invalid name
   ┌─ tests/move_check/expansion/restricted_struct_names.move:7:12
   │
-7 │     struct vector<T> {}
+7 │     struct vector<T> { f: T }
   │            ^^^^^^ Invalid struct name 'vector'. Struct names must start with 'A'..'Z'
 
 error[E02010]: invalid name

--- a/language/move-lang/tests/move_check/expansion/restricted_struct_names.move
+++ b/language/move-lang/tests/move_check/expansion/restricted_struct_names.move
@@ -4,7 +4,7 @@ module 0x8675309::M {
     struct u8 {}
     struct u64 {}
     struct u128 {}
-    struct vector<T> {}
+    struct vector<T> { f: T }
 
     struct move_to {}
     struct move_from {}

--- a/language/move-lang/tests/move_check/expansion/spec_block_uses.move
+++ b/language/move-lang/tests/move_check/expansion/spec_block_uses.move
@@ -1,7 +1,7 @@
 address 0x2 {
 module M {
     struct S {}
-    struct R<T> {}
+    struct R<T> { f: T }
 
     fun t1(): (R<u64>, S) {
         abort 0

--- a/language/move-lang/tests/move_check/expansion/spec_block_uses_shadows_defines.move
+++ b/language/move-lang/tests/move_check/expansion/spec_block_uses_shadows_defines.move
@@ -1,7 +1,7 @@
 address 0x2 {
 module M {
     struct R1 {}
-    struct R2<T> {}
+    struct R2<T> { f: T }
 
     fun t1(): (R2<u64>, R1) {
         abort 0

--- a/language/move-lang/tests/move_check/locals/drop_conditional.exp
+++ b/language/move-lang/tests/move_check/locals/drop_conditional.exp
@@ -1,8 +1,8 @@
 error[E06001]: unused value without 'drop'
    ┌─ tests/move_check/locals/drop_conditional.move:14:11
    │
-11 │         let x = Cup<R> {};
-   │             -   ---------
+11 │         let x = Cup<R> { f: R{} };
+   │             -   -----------------
    │             │   │   │
    │             │   │   The type '0x42::M::Cup<0x42::M::R>' can have the ability 'drop' but the type argument '0x42::M::R' does not have the required ability 'drop'
    │             │   The type '0x42::M::Cup<0x42::M::R>' does not have the ability 'drop'
@@ -14,8 +14,8 @@ error[E06001]: unused value without 'drop'
 error[E06001]: unused value without 'drop'
    ┌─ tests/move_check/locals/drop_conditional.move:14:11
    │
-13 │         let x = Pair<S, R> {};
-   │             -   -------------
+13 │         let x = Pair<S, R> { f1: S{}, f2: R{} };
+   │             -   -------------------------------
    │             │   │       │
    │             │   │       The type '0x42::M::Pair<0x42::M::S, 0x42::M::R>' can have the ability 'drop' but the type argument '0x42::M::R' does not have the required ability 'drop'
    │             │   The type '0x42::M::Pair<0x42::M::S, 0x42::M::R>' does not have the ability 'drop'

--- a/language/move-lang/tests/move_check/locals/drop_conditional.move
+++ b/language/move-lang/tests/move_check/locals/drop_conditional.move
@@ -1,16 +1,16 @@
 address 0x42 {
 module M {
 
-    struct Cup<T> has drop {}
-    struct Pair<T1, T2> has drop {}
+    struct Cup<T> has drop { f: T }
+    struct Pair<T1, T2> has drop { f1: T1, f2: T2 }
     struct R {}
     struct S has drop {}
 
     // Error on a type that can have the drop ability, but the instantiation does not
     fun t() {
-        let x = Cup<R> {};
+        let x = Cup<R> { f: R{} };
         &x;
-        let x = Pair<S, R> {};
+        let x = Pair<S, R> { f1: S{}, f2: R{} };
         &x;
     }
 }

--- a/language/move-lang/tests/move_check/parser/function_type_nested.move
+++ b/language/move-lang/tests/move_check/parser/function_type_nested.move
@@ -1,6 +1,6 @@
 module 0x8675309::M {
     struct R {}
-    struct B<T> {}
+    struct B<T> { f: T }
     fun fn<T>() { }
     fun caller() {
         fn<B<R>>(); // make sure '>>' is not parsed as a shift operator

--- a/language/move-lang/tests/move_check/parser/struct_type_trailing_comma.move
+++ b/language/move-lang/tests/move_check/parser/struct_type_trailing_comma.move
@@ -1,3 +1,3 @@
 module 0x8675309::M {
-    struct S<T1, T2,> { } // Test a trailing comma in the type parameters
+    struct S<T1, T2,> { f1: T1, f2: T2 } // Test a trailing comma in the type parameters
 }

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/generics/instantiation_loops/complex_1.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/generics/instantiation_loops/complex_1.move
@@ -1,5 +1,5 @@
 module 0x8675309::M {
-    struct S<T> { b: bool }
+    struct S<T> { f: T }
 
     fun a<T>() {
         b<S<T>, u64>()

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/generics/instantiation_loops/mutually_recursive_non_generic_type_ok.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/generics/instantiation_loops/mutually_recursive_non_generic_type_ok.move
@@ -1,5 +1,5 @@
 module 0x8675309::M {
-    struct S<T> { b: bool }
+    struct S<T> { f: T }
 
     fun f<T>() {
         g<S<T>>()

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/generics/instantiation_loops/mutually_recursive_three_args_type_con_non_generic_types_ok.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/generics/instantiation_loops/mutually_recursive_three_args_type_con_non_generic_types_ok.move
@@ -1,5 +1,5 @@
 module 0x8675309::M {
-    struct S<T> { b: bool }
+    struct S<T> { f: T }
 
     fun f<T1, T2, T3>() {
         g<T2, T3, T1>()

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/generics/instantiation_loops/mutually_recursive_three_args_type_con_shifting.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/generics/instantiation_loops/mutually_recursive_three_args_type_con_shifting.move
@@ -1,5 +1,5 @@
 module 0x8675309::M {
-    struct S<T> { b: bool }
+    struct S<T> { f: T }
 
     fun f<T1, T2, T3>() {
         g<T2, T3, T1>()

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/generics/instantiation_loops/mutually_recursive_two_args_swapping_type_con.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/generics/instantiation_loops/mutually_recursive_two_args_swapping_type_con.move
@@ -1,5 +1,5 @@
 module 0x8675309::M {
-    struct S<T> { b: bool }
+    struct S<T> { f: T }
 
     fun f<T1, T2, T3>() {
         g<T2, T1>()

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/generics/instantiation_loops/mutually_recursive_type_con.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/generics/instantiation_loops/mutually_recursive_type_con.move
@@ -2,7 +2,7 @@
 //           f<T>, g<S<T>>, f<S<T>>, g<S<S<T>>>, ...
 
 module 0x8675309::M {
-    struct S<T> { b: bool }
+    struct S<T> { f: T }
 
     fun f<T>() {
         g<S<T>>()

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/generics/instantiation_loops/nested_types_1.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/generics/instantiation_loops/nested_types_1.move
@@ -1,5 +1,5 @@
 module 0x8675309::M {
-    struct S<T> { b: bool }
+    struct S<T> { f: T }
 
     fun foo<T>() {
         foo<S<S<T>>>()

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/generics/instantiation_loops/nested_types_2.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/generics/instantiation_loops/nested_types_2.move
@@ -1,6 +1,6 @@
 module 0x8675309::M {
-    struct S<T> { b: bool }
-    struct R<T1, T2> { b: bool }
+    struct S<T> { f: T }
+    struct R<T1, T2> { f1: T1, f2: T2 }
 
     fun foo<T>() {
         foo<R<u64, S<S<T>>>>()

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/generics/instantiation_loops/recursive_one_arg_type_con.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/generics/instantiation_loops/recursive_one_arg_type_con.exp
@@ -1,8 +1,8 @@
 error[E04019]: cyclic type instantiation
   ┌─ tests/move_check/translated_ir_tests/move/generics/instantiation_loops/recursive_one_arg_type_con.move:7:9
   │
-7 │         f<S<T>>(S<T> { b: true })
-  │         ^^^^^^^^^^^^^^^^^^^^^^^^^
+7 │         f<S<T>>(S<T> { f: x })
+  │         ^^^^^^^^^^^^^^^^^^^^^^
   │         │ │
   │         │ The type parameter 'f::T' was instantiated with the type '0x8675309::M::S<T>', which contains the type parameter 'f::T'. This recursive call causes the instantiation to recurse infinitely
   │         Invalid call to '0x8675309::M::f'

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/generics/instantiation_loops/recursive_one_arg_type_con.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/generics/instantiation_loops/recursive_one_arg_type_con.move
@@ -1,9 +1,9 @@
 // Bad! Can have infinitely many instances: f<T>, f<S<T>>, f<S<S<T>>>, ...
 
 module 0x8675309::M {
-    struct S<T> { b: bool }
+    struct S<T> { f: T }
 
     fun f<T>(x: T) {
-        f<S<T>>(S<T> { b: true })
+        f<S<T>>(S<T> { f: x })
     }
 }

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/generics/instantiation_loops/two_loops.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/generics/instantiation_loops/two_loops.move
@@ -2,7 +2,7 @@
 // One error for each loop.
 
 module 0x8675309::M {
-    struct S<T> { b: bool }
+    struct S<T> { f: T }
 
     fun f<T>() {
         f<S<T>>()

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/signer/does_not_have_store.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/signer/does_not_have_store.exp
@@ -1,16 +1,10 @@
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/translated_ir_tests/move/signer/does_not_have_store.move:5:9
   │
-5 │         move_to(account, S<signer> {})
-  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 │         move_to(account, S<signer> { f: s })
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   │         │                │ │
   │         │                │ The type '0x8675309::M::S<signer>' can have the ability 'key' but the type argument 'signer' does not have the required ability 'store'
   │         │                The type '0x8675309::M::S<signer>' does not have the ability 'key'
   │         Invalid call of 'move_to'
-
-error[E03009]: unbound variable
-  ┌─ tests/move_check/translated_ir_tests/move/signer/does_not_have_store.move:5:17
-  │
-5 │         move_to(account, S<signer> {})
-  │                 ^^^^^^^ Invalid variable usage. Unbound variable 'account'
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/signer/does_not_have_store.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/signer/does_not_have_store.move
@@ -1,7 +1,7 @@
 module 0x8675309::M {
-    struct S<T> has key {}
+    struct S<T> has key { f: T }
 
-    fun t(_account: &signer) {
-        move_to(account, S<signer> {})
+    fun t(account: &signer, s: signer) {
+        move_to(account, S<signer> { f: s })
     }
 }

--- a/language/move-lang/tests/move_check/typing/ability_constraint_prims_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/ability_constraint_prims_invalid.exp
@@ -163,8 +163,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:30:13
    │
-13 │     struct Sc<T: copy> {}
-   │                  ---- 'copy' constraint declared here
+13 │     struct Sc<phantom T: copy> {}
+   │                          ---- 'copy' constraint declared here
    ·
 30 │         let Sc {} = Sc<signer> {};
    │             ^^^^^      ------ The type 'signer' does not have the ability 'copy'
@@ -174,8 +174,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:30:21
    │
-13 │     struct Sc<T: copy> {}
-   │                  ---- 'copy' constraint declared here
+13 │     struct Sc<phantom T: copy> {}
+   │                          ---- 'copy' constraint declared here
    ·
 30 │         let Sc {} = Sc<signer> {};
    │                     ^^^^^^^^^^^^^
@@ -186,8 +186,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:31:13
    │
-13 │     struct Sc<T: copy> {}
-   │                  ---- 'copy' constraint declared here
+13 │     struct Sc<phantom T: copy> {}
+   │                          ---- 'copy' constraint declared here
    ·
 31 │         let Sc {} = Sc<vector<signer>> {};
    │             ^^^^^      --------------
@@ -199,8 +199,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:31:21
    │
-13 │     struct Sc<T: copy> {}
-   │                  ---- 'copy' constraint declared here
+13 │     struct Sc<phantom T: copy> {}
+   │                          ---- 'copy' constraint declared here
    ·
 31 │         let Sc {} = Sc<vector<signer>> {};
    │                     ^^^^^^^^^^^^^^^^^^^^^
@@ -212,8 +212,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:32:13
    │
-13 │     struct Sc<T: copy> {}
-   │                  ---- 'copy' constraint declared here
+13 │     struct Sc<phantom T: copy> {}
+   │                          ---- 'copy' constraint declared here
    ·
 32 │         let Sc {} = Sc<vector<NoC>> {};
    │             ^^^^^      -----------
@@ -225,8 +225,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:32:21
    │
-13 │     struct Sc<T: copy> {}
-   │                  ---- 'copy' constraint declared here
+13 │     struct Sc<phantom T: copy> {}
+   │                          ---- 'copy' constraint declared here
    ·
 32 │         let Sc {} = Sc<vector<NoC>> {};
    │                     ^^^^^^^^^^^^^^^^^^
@@ -238,8 +238,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:33:13
    │
-14 │     struct Sk<T: key> {}
-   │                  --- 'key' constraint declared here
+14 │     struct Sk<phantom T: key> {}
+   │                          --- 'key' constraint declared here
    ·
 33 │         let Sk {} = Sk<u64> {};
    │             ^^^^^      --- The type 'u64' does not have the ability 'key'
@@ -249,8 +249,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:33:21
    │
-14 │     struct Sk<T: key> {}
-   │                  --- 'key' constraint declared here
+14 │     struct Sk<phantom T: key> {}
+   │                          --- 'key' constraint declared here
    ·
 33 │         let Sk {} = Sk<u64> {};
    │                     ^^^^^^^^^^
@@ -261,8 +261,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:34:13
    │
-14 │     struct Sk<T: key> {}
-   │                  --- 'key' constraint declared here
+14 │     struct Sk<phantom T: key> {}
+   │                          --- 'key' constraint declared here
    ·
 34 │         let Sk {} = Sk<signer> {};
    │             ^^^^^      ------ The type 'signer' does not have the ability 'key'
@@ -272,8 +272,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:34:21
    │
-14 │     struct Sk<T: key> {}
-   │                  --- 'key' constraint declared here
+14 │     struct Sk<phantom T: key> {}
+   │                          --- 'key' constraint declared here
    ·
 34 │         let Sk {} = Sk<signer> {};
    │                     ^^^^^^^^^^^^^
@@ -284,8 +284,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:35:13
    │
-14 │     struct Sk<T: key> {}
-   │                  --- 'key' constraint declared here
+14 │     struct Sk<phantom T: key> {}
+   │                          --- 'key' constraint declared here
    ·
 35 │         let Sk {} = Sk<vector<NoC>> {};
    │             ^^^^^      ----------- The type 'vector<0x42::M::NoC>' does not have the ability 'key'
@@ -295,8 +295,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:35:21
    │
-14 │     struct Sk<T: key> {}
-   │                  --- 'key' constraint declared here
+14 │     struct Sk<phantom T: key> {}
+   │                          --- 'key' constraint declared here
    ·
 35 │         let Sk {} = Sk<vector<NoC>> {};
    │                     ^^^^^^^^^^^^^^^^^^
@@ -307,8 +307,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:36:13
    │
-14 │     struct Sk<T: key> {}
-   │                  --- 'key' constraint declared here
+14 │     struct Sk<phantom T: key> {}
+   │                          --- 'key' constraint declared here
    ·
 36 │         let Sk {} = Sk<vector<NoK>> {};
    │             ^^^^^      ----------- The type 'vector<0x42::M::NoK>' does not have the ability 'key'
@@ -318,8 +318,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:36:21
    │
-14 │     struct Sk<T: key> {}
-   │                  --- 'key' constraint declared here
+14 │     struct Sk<phantom T: key> {}
+   │                          --- 'key' constraint declared here
    ·
 36 │         let Sk {} = Sk<vector<NoK>> {};
    │                     ^^^^^^^^^^^^^^^^^^
@@ -330,8 +330,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:37:13
    │
-15 │     struct Scds<T: copy + drop + store> {}
-   │                    ---- 'copy' constraint declared here
+15 │     struct Scds<phantom T: copy + drop + store> {}
+   │                            ---- 'copy' constraint declared here
    ·
 37 │         let Scds {} = Scds<signer> {};
    │             ^^^^^^^        ------ The type 'signer' does not have the ability 'copy'
@@ -341,8 +341,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:37:13
    │
-15 │     struct Scds<T: copy + drop + store> {}
-   │                                  ----- 'store' constraint declared here
+15 │     struct Scds<phantom T: copy + drop + store> {}
+   │                                          ----- 'store' constraint declared here
    ·
 37 │         let Scds {} = Scds<signer> {};
    │             ^^^^^^^        ------ The type 'signer' does not have the ability 'store'
@@ -352,8 +352,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:37:23
    │
-15 │     struct Scds<T: copy + drop + store> {}
-   │                    ---- 'copy' constraint declared here
+15 │     struct Scds<phantom T: copy + drop + store> {}
+   │                            ---- 'copy' constraint declared here
    ·
 37 │         let Scds {} = Scds<signer> {};
    │                       ^^^^^^^^^^^^^^^
@@ -364,8 +364,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:37:23
    │
-15 │     struct Scds<T: copy + drop + store> {}
-   │                                  ----- 'store' constraint declared here
+15 │     struct Scds<phantom T: copy + drop + store> {}
+   │                                          ----- 'store' constraint declared here
    ·
 37 │         let Scds {} = Scds<signer> {};
    │                       ^^^^^^^^^^^^^^^
@@ -376,8 +376,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:38:13
    │
-15 │     struct Scds<T: copy + drop + store> {}
-   │                    ---- 'copy' constraint declared here
+15 │     struct Scds<phantom T: copy + drop + store> {}
+   │                            ---- 'copy' constraint declared here
    ·
 38 │         let Scds {} = Scds<vector<NoC>> {};
    │             ^^^^^^^        -----------
@@ -389,8 +389,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:38:23
    │
-15 │     struct Scds<T: copy + drop + store> {}
-   │                    ---- 'copy' constraint declared here
+15 │     struct Scds<phantom T: copy + drop + store> {}
+   │                            ---- 'copy' constraint declared here
    ·
 38 │         let Scds {} = Scds<vector<NoC>> {};
    │                       ^^^^^^^^^^^^^^^^^^^^
@@ -402,8 +402,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:39:13
    │
-15 │     struct Scds<T: copy + drop + store> {}
-   │                    ---- 'copy' constraint declared here
+15 │     struct Scds<phantom T: copy + drop + store> {}
+   │                            ---- 'copy' constraint declared here
    ·
 39 │         let Scds {} = Scds<vector<Cup<u8>>> {};
    │             ^^^^^^^        ---------------
@@ -415,8 +415,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:39:13
    │
-15 │     struct Scds<T: copy + drop + store> {}
-   │                           ---- 'drop' constraint declared here
+15 │     struct Scds<phantom T: copy + drop + store> {}
+   │                                   ---- 'drop' constraint declared here
    ·
 39 │         let Scds {} = Scds<vector<Cup<u8>>> {};
    │             ^^^^^^^        ---------------
@@ -428,8 +428,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:39:13
    │
-15 │     struct Scds<T: copy + drop + store> {}
-   │                                  ----- 'store' constraint declared here
+15 │     struct Scds<phantom T: copy + drop + store> {}
+   │                                          ----- 'store' constraint declared here
    ·
 39 │         let Scds {} = Scds<vector<Cup<u8>>> {};
    │             ^^^^^^^        ---------------
@@ -441,8 +441,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:39:23
    │
-15 │     struct Scds<T: copy + drop + store> {}
-   │                    ---- 'copy' constraint declared here
+15 │     struct Scds<phantom T: copy + drop + store> {}
+   │                            ---- 'copy' constraint declared here
    ·
 39 │         let Scds {} = Scds<vector<Cup<u8>>> {};
    │                       ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -454,8 +454,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:39:23
    │
-15 │     struct Scds<T: copy + drop + store> {}
-   │                           ---- 'drop' constraint declared here
+15 │     struct Scds<phantom T: copy + drop + store> {}
+   │                                   ---- 'drop' constraint declared here
    ·
 39 │         let Scds {} = Scds<vector<Cup<u8>>> {};
    │                       ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -467,8 +467,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_prims_invalid.move:39:23
    │
-15 │     struct Scds<T: copy + drop + store> {}
-   │                                  ----- 'store' constraint declared here
+15 │     struct Scds<phantom T: copy + drop + store> {}
+   │                                          ----- 'store' constraint declared here
    ·
 39 │         let Scds {} = Scds<vector<Cup<u8>>> {};
    │                       ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/language/move-lang/tests/move_check/typing/ability_constraint_prims_invalid.move
+++ b/language/move-lang/tests/move_check/typing/ability_constraint_prims_invalid.move
@@ -2,17 +2,17 @@ address 0x42 {
 module M {
     struct NoC has drop, store, key {}
     struct NoK has copy, drop, store {}
-    struct Cup<T> {}
-    struct Box<T> has copy, drop, store, key {}
-    struct Pair<T1, T2> has copy, drop, store, key {}
+    struct Cup<T> { f: T }
+    struct Box<T> has copy, drop, store, key { f: T }
+    struct Pair<T1, T2> has copy, drop, store, key { f1: T1, f2: T2 }
 
     fun c<T: copy>() {}
     fun k<T: key>() {}
     fun cds<T: copy + drop + store>() {}
 
-    struct Sc<T: copy> {}
-    struct Sk<T: key> {}
-    struct Scds<T: copy + drop + store> {}
+    struct Sc<phantom T: copy> {}
+    struct Sk<phantom T: key> {}
+    struct Scds<phantom T: copy + drop + store> {}
 
     // tests that a variety of constraint instantiations are all invalid
     fun t() {

--- a/language/move-lang/tests/move_check/typing/ability_constraint_structs_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/ability_constraint_structs_invalid.exp
@@ -16,7 +16,7 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:20:9
    │
- 5 │     struct Cup<T> {}
+ 5 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
    ·
  9 │     fun c<T: copy>() {}
@@ -59,7 +59,7 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:23:9
    │
- 5 │     struct Cup<T> {}
+ 5 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'key' ability would need to be added here
    ·
 10 │     fun k<T: key>() {}
@@ -102,7 +102,7 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:26:9
    │
- 5 │     struct Cup<T> {}
+ 5 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
    ·
 11 │     fun cds<T: copy + drop + store>() {}
@@ -117,7 +117,7 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:26:9
    │
- 5 │     struct Cup<T> {}
+ 5 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'drop' ability would need to be added here
    ·
 11 │     fun cds<T: copy + drop + store>() {}
@@ -132,7 +132,7 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:26:9
    │
- 5 │     struct Cup<T> {}
+ 5 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'store' ability would need to be added here
    ·
 11 │     fun cds<T: copy + drop + store>() {}
@@ -147,7 +147,7 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:27:9
    │
- 5 │     struct Cup<T> {}
+ 5 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
    ·
 11 │     fun cds<T: copy + drop + store>() {}
@@ -162,7 +162,7 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:27:9
    │
- 5 │     struct Cup<T> {}
+ 5 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'drop' ability would need to be added here
    ·
 11 │     fun cds<T: copy + drop + store>() {}
@@ -177,7 +177,7 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:27:9
    │
- 5 │     struct Cup<T> {}
+ 5 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'store' ability would need to be added here
    ·
 11 │     fun cds<T: copy + drop + store>() {}
@@ -208,8 +208,8 @@ error[E05001]: ability constraint not satisfied
  3 │     struct NoC has drop, store, key {}
    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
    ·
-13 │     struct Sc<T: copy> {}
-   │                  ---- 'copy' constraint declared here
+13 │     struct Sc<phantom T: copy> {}
+   │                          ---- 'copy' constraint declared here
    ·
 29 │         let Sc {} = Sc<NoC> {};
    │             ^^^^^      --- The type '0x42::M::NoC' does not have the ability 'copy'
@@ -222,8 +222,8 @@ error[E05001]: ability constraint not satisfied
  3 │     struct NoC has drop, store, key {}
    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
    ·
-13 │     struct Sc<T: copy> {}
-   │                  ---- 'copy' constraint declared here
+13 │     struct Sc<phantom T: copy> {}
+   │                          ---- 'copy' constraint declared here
    ·
 29 │         let Sc {} = Sc<NoC> {};
    │                     ^^^^^^^^^^
@@ -234,11 +234,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:30:13
    │
- 5 │     struct Cup<T> {}
+ 5 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
    ·
-13 │     struct Sc<T: copy> {}
-   │                  ---- 'copy' constraint declared here
+13 │     struct Sc<phantom T: copy> {}
+   │                          ---- 'copy' constraint declared here
    ·
 30 │         let Sc {} = Sc<Cup<u64>> {};
    │             ^^^^^      -------- The type '0x42::M::Cup<u64>' does not have the ability 'copy'
@@ -248,11 +248,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:30:21
    │
- 5 │     struct Cup<T> {}
+ 5 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
    ·
-13 │     struct Sc<T: copy> {}
-   │                  ---- 'copy' constraint declared here
+13 │     struct Sc<phantom T: copy> {}
+   │                          ---- 'copy' constraint declared here
    ·
 30 │         let Sc {} = Sc<Cup<u64>> {};
    │                     ^^^^^^^^^^^^^^^
@@ -263,8 +263,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:31:13
    │
-13 │     struct Sc<T: copy> {}
-   │                  ---- 'copy' constraint declared here
+13 │     struct Sc<phantom T: copy> {}
+   │                          ---- 'copy' constraint declared here
    ·
 31 │         let Sc {} = Sc<Box<NoC>> {};
    │             ^^^^^      --------
@@ -276,8 +276,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:31:21
    │
-13 │     struct Sc<T: copy> {}
-   │                  ---- 'copy' constraint declared here
+13 │     struct Sc<phantom T: copy> {}
+   │                          ---- 'copy' constraint declared here
    ·
 31 │         let Sc {} = Sc<Box<NoC>> {};
    │                     ^^^^^^^^^^^^^^^
@@ -292,8 +292,8 @@ error[E05001]: ability constraint not satisfied
  4 │     struct NoK has copy, drop, store {}
    │            --- To satisfy the constraint, the 'key' ability would need to be added here
    ·
-14 │     struct Sk<T: key> {}
-   │                  --- 'key' constraint declared here
+14 │     struct Sk<phantom T: key> {}
+   │                          --- 'key' constraint declared here
    ·
 32 │         let Sk {} = Sk<NoK> {};
    │             ^^^^^      --- The type '0x42::M::NoK' does not have the ability 'key'
@@ -306,8 +306,8 @@ error[E05001]: ability constraint not satisfied
  4 │     struct NoK has copy, drop, store {}
    │            --- To satisfy the constraint, the 'key' ability would need to be added here
    ·
-14 │     struct Sk<T: key> {}
-   │                  --- 'key' constraint declared here
+14 │     struct Sk<phantom T: key> {}
+   │                          --- 'key' constraint declared here
    ·
 32 │         let Sk {} = Sk<NoK> {};
    │                     ^^^^^^^^^^
@@ -318,11 +318,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:33:13
    │
- 5 │     struct Cup<T> {}
+ 5 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'key' ability would need to be added here
    ·
-14 │     struct Sk<T: key> {}
-   │                  --- 'key' constraint declared here
+14 │     struct Sk<phantom T: key> {}
+   │                          --- 'key' constraint declared here
    ·
 33 │         let Sk {} = Sk<Cup<u64>> {};
    │             ^^^^^      -------- The type '0x42::M::Cup<u64>' does not have the ability 'key'
@@ -332,11 +332,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:33:21
    │
- 5 │     struct Cup<T> {}
+ 5 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'key' ability would need to be added here
    ·
-14 │     struct Sk<T: key> {}
-   │                  --- 'key' constraint declared here
+14 │     struct Sk<phantom T: key> {}
+   │                          --- 'key' constraint declared here
    ·
 33 │         let Sk {} = Sk<Cup<u64>> {};
    │                     ^^^^^^^^^^^^^^^
@@ -347,8 +347,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:34:13
    │
-14 │     struct Sk<T: key> {}
-   │                  --- 'key' constraint declared here
+14 │     struct Sk<phantom T: key> {}
+   │                          --- 'key' constraint declared here
    ·
 34 │         let Sk {} = Sk<Box<Cup<u64>>> {};
    │             ^^^^^      -------------
@@ -360,8 +360,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:34:21
    │
-14 │     struct Sk<T: key> {}
-   │                  --- 'key' constraint declared here
+14 │     struct Sk<phantom T: key> {}
+   │                          --- 'key' constraint declared here
    ·
 34 │         let Sk {} = Sk<Box<Cup<u64>>> {};
    │                     ^^^^^^^^^^^^^^^^^^^^
@@ -376,8 +376,8 @@ error[E05001]: ability constraint not satisfied
  3 │     struct NoC has drop, store, key {}
    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
    ·
-15 │     struct Scds<T: copy + drop + store> {}
-   │                    ---- 'copy' constraint declared here
+15 │     struct Scds<phantom T: copy + drop + store> {}
+   │                            ---- 'copy' constraint declared here
    ·
 35 │         let Scds {} = Scds<NoC> {};
    │             ^^^^^^^        --- The type '0x42::M::NoC' does not have the ability 'copy'
@@ -390,8 +390,8 @@ error[E05001]: ability constraint not satisfied
  3 │     struct NoC has drop, store, key {}
    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
    ·
-15 │     struct Scds<T: copy + drop + store> {}
-   │                    ---- 'copy' constraint declared here
+15 │     struct Scds<phantom T: copy + drop + store> {}
+   │                            ---- 'copy' constraint declared here
    ·
 35 │         let Scds {} = Scds<NoC> {};
    │                       ^^^^^^^^^^^^
@@ -402,11 +402,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:36:13
    │
- 5 │     struct Cup<T> {}
+ 5 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
    ·
-15 │     struct Scds<T: copy + drop + store> {}
-   │                    ---- 'copy' constraint declared here
+15 │     struct Scds<phantom T: copy + drop + store> {}
+   │                            ---- 'copy' constraint declared here
    ·
 36 │         let Scds {} = Scds<Cup<u64>> {};
    │             ^^^^^^^        -------- The type '0x42::M::Cup<u64>' does not have the ability 'copy'
@@ -416,11 +416,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:36:13
    │
- 5 │     struct Cup<T> {}
+ 5 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'drop' ability would need to be added here
    ·
-15 │     struct Scds<T: copy + drop + store> {}
-   │                           ---- 'drop' constraint declared here
+15 │     struct Scds<phantom T: copy + drop + store> {}
+   │                                   ---- 'drop' constraint declared here
    ·
 36 │         let Scds {} = Scds<Cup<u64>> {};
    │             ^^^^^^^        -------- The type '0x42::M::Cup<u64>' does not have the ability 'drop'
@@ -430,11 +430,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:36:13
    │
- 5 │     struct Cup<T> {}
+ 5 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'store' ability would need to be added here
    ·
-15 │     struct Scds<T: copy + drop + store> {}
-   │                                  ----- 'store' constraint declared here
+15 │     struct Scds<phantom T: copy + drop + store> {}
+   │                                          ----- 'store' constraint declared here
    ·
 36 │         let Scds {} = Scds<Cup<u64>> {};
    │             ^^^^^^^        -------- The type '0x42::M::Cup<u64>' does not have the ability 'store'
@@ -444,11 +444,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:36:23
    │
- 5 │     struct Cup<T> {}
+ 5 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
    ·
-15 │     struct Scds<T: copy + drop + store> {}
-   │                    ---- 'copy' constraint declared here
+15 │     struct Scds<phantom T: copy + drop + store> {}
+   │                            ---- 'copy' constraint declared here
    ·
 36 │         let Scds {} = Scds<Cup<u64>> {};
    │                       ^^^^^^^^^^^^^^^^^
@@ -459,11 +459,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:36:23
    │
- 5 │     struct Cup<T> {}
+ 5 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'drop' ability would need to be added here
    ·
-15 │     struct Scds<T: copy + drop + store> {}
-   │                           ---- 'drop' constraint declared here
+15 │     struct Scds<phantom T: copy + drop + store> {}
+   │                                   ---- 'drop' constraint declared here
    ·
 36 │         let Scds {} = Scds<Cup<u64>> {};
    │                       ^^^^^^^^^^^^^^^^^
@@ -474,11 +474,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:36:23
    │
- 5 │     struct Cup<T> {}
+ 5 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'store' ability would need to be added here
    ·
-15 │     struct Scds<T: copy + drop + store> {}
-   │                                  ----- 'store' constraint declared here
+15 │     struct Scds<phantom T: copy + drop + store> {}
+   │                                          ----- 'store' constraint declared here
    ·
 36 │         let Scds {} = Scds<Cup<u64>> {};
    │                       ^^^^^^^^^^^^^^^^^
@@ -489,11 +489,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:37:13
    │
- 5 │     struct Cup<T> {}
+ 5 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
    ·
-15 │     struct Scds<T: copy + drop + store> {}
-   │                    ---- 'copy' constraint declared here
+15 │     struct Scds<phantom T: copy + drop + store> {}
+   │                            ---- 'copy' constraint declared here
    ·
 37 │         let Scds {} = Scds<Cup<NoC>> {};
    │             ^^^^^^^        -------- The type '0x42::M::Cup<0x42::M::NoC>' does not have the ability 'copy'
@@ -503,11 +503,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:37:13
    │
- 5 │     struct Cup<T> {}
+ 5 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'drop' ability would need to be added here
    ·
-15 │     struct Scds<T: copy + drop + store> {}
-   │                           ---- 'drop' constraint declared here
+15 │     struct Scds<phantom T: copy + drop + store> {}
+   │                                   ---- 'drop' constraint declared here
    ·
 37 │         let Scds {} = Scds<Cup<NoC>> {};
    │             ^^^^^^^        -------- The type '0x42::M::Cup<0x42::M::NoC>' does not have the ability 'drop'
@@ -517,11 +517,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:37:13
    │
- 5 │     struct Cup<T> {}
+ 5 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'store' ability would need to be added here
    ·
-15 │     struct Scds<T: copy + drop + store> {}
-   │                                  ----- 'store' constraint declared here
+15 │     struct Scds<phantom T: copy + drop + store> {}
+   │                                          ----- 'store' constraint declared here
    ·
 37 │         let Scds {} = Scds<Cup<NoC>> {};
    │             ^^^^^^^        -------- The type '0x42::M::Cup<0x42::M::NoC>' does not have the ability 'store'
@@ -531,11 +531,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:37:23
    │
- 5 │     struct Cup<T> {}
+ 5 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
    ·
-15 │     struct Scds<T: copy + drop + store> {}
-   │                    ---- 'copy' constraint declared here
+15 │     struct Scds<phantom T: copy + drop + store> {}
+   │                            ---- 'copy' constraint declared here
    ·
 37 │         let Scds {} = Scds<Cup<NoC>> {};
    │                       ^^^^^^^^^^^^^^^^^
@@ -546,11 +546,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:37:23
    │
- 5 │     struct Cup<T> {}
+ 5 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'drop' ability would need to be added here
    ·
-15 │     struct Scds<T: copy + drop + store> {}
-   │                           ---- 'drop' constraint declared here
+15 │     struct Scds<phantom T: copy + drop + store> {}
+   │                                   ---- 'drop' constraint declared here
    ·
 37 │         let Scds {} = Scds<Cup<NoC>> {};
    │                       ^^^^^^^^^^^^^^^^^
@@ -561,11 +561,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:37:23
    │
- 5 │     struct Cup<T> {}
+ 5 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'store' ability would need to be added here
    ·
-15 │     struct Scds<T: copy + drop + store> {}
-   │                                  ----- 'store' constraint declared here
+15 │     struct Scds<phantom T: copy + drop + store> {}
+   │                                          ----- 'store' constraint declared here
    ·
 37 │         let Scds {} = Scds<Cup<NoC>> {};
    │                       ^^^^^^^^^^^^^^^^^
@@ -576,8 +576,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:38:13
    │
-15 │     struct Scds<T: copy + drop + store> {}
-   │                    ---- 'copy' constraint declared here
+15 │     struct Scds<phantom T: copy + drop + store> {}
+   │                            ---- 'copy' constraint declared here
    ·
 38 │         let Scds {} = Scds<Pair<u64, NoC>> {};
    │             ^^^^^^^        --------------
@@ -589,8 +589,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_structs_invalid.move:38:23
    │
-15 │     struct Scds<T: copy + drop + store> {}
-   │                    ---- 'copy' constraint declared here
+15 │     struct Scds<phantom T: copy + drop + store> {}
+   │                            ---- 'copy' constraint declared here
    ·
 38 │         let Scds {} = Scds<Pair<u64, NoC>> {};
    │                       ^^^^^^^^^^^^^^^^^^^^^^^

--- a/language/move-lang/tests/move_check/typing/ability_constraint_structs_invalid.move
+++ b/language/move-lang/tests/move_check/typing/ability_constraint_structs_invalid.move
@@ -2,17 +2,17 @@ address 0x42 {
 module M {
     struct NoC has drop, store, key {}
     struct NoK has copy, drop, store {}
-    struct Cup<T> {}
-    struct Box<T> has copy, drop, store, key {}
-    struct Pair<T1, T2> has copy, drop, store, key {}
+    struct Cup<T> { f: T }
+    struct Box<T> has copy, drop, store, key { f: T }
+    struct Pair<T1, T2> has copy, drop, store, key { f1: T1, f2: T2 }
 
     fun c<T: copy>() {}
     fun k<T: key>() {}
     fun cds<T: copy + drop + store>() {}
 
-    struct Sc<T: copy> {}
-    struct Sk<T: key> {}
-    struct Scds<T: copy + drop + store> {}
+    struct Sc<phantom T: copy> {}
+    struct Sk<phantom T: key> {}
+    struct Scds<phantom T: copy + drop + store> {}
 
     // tests that a variety of constraint instantiations are all invalid
     fun t() {

--- a/language/move-lang/tests/move_check/typing/ability_constraint_tparams_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/ability_constraint_tparams_invalid.exp
@@ -16,7 +16,7 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:22:9
    │
- 3 │     struct Cup<T> {}
+ 3 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
    ·
  7 │     fun c<T: copy>() {}
@@ -59,7 +59,7 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:25:9
    │
- 3 │     struct Cup<T> {}
+ 3 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'key' ability would need to be added here
    ·
  8 │     fun k<T: key>() {}
@@ -102,7 +102,7 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:28:9
    │
- 3 │     struct Cup<T> {}
+ 3 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
    ·
  9 │     fun cds<T: copy + drop + store>() {}
@@ -117,7 +117,7 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:28:9
    │
- 3 │     struct Cup<T> {}
+ 3 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'drop' ability would need to be added here
    ·
  9 │     fun cds<T: copy + drop + store>() {}
@@ -132,7 +132,7 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:28:9
    │
- 3 │     struct Cup<T> {}
+ 3 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'store' ability would need to be added here
    ·
  9 │     fun cds<T: copy + drop + store>() {}
@@ -147,7 +147,7 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:29:9
    │
- 3 │     struct Cup<T> {}
+ 3 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
    ·
  9 │     fun cds<T: copy + drop + store>() {}
@@ -162,7 +162,7 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:29:9
    │
- 3 │     struct Cup<T> {}
+ 3 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'drop' ability would need to be added here
    ·
  9 │     fun cds<T: copy + drop + store>() {}
@@ -177,7 +177,7 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:29:9
    │
- 3 │     struct Cup<T> {}
+ 3 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'store' ability would need to be added here
    ·
  9 │     fun cds<T: copy + drop + store>() {}
@@ -205,8 +205,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:31:13
    │
-11 │     struct Sc<T: copy> {}
-   │                  ---- 'copy' constraint declared here
+11 │     struct Sc<phantom T: copy> {}
+   │                          ---- 'copy' constraint declared here
    ·
 17 │         TnoC: drop + store + key,
    │         ---- To satisfy the constraint, the 'copy' ability would need to be added here
@@ -219,8 +219,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:31:21
    │
-11 │     struct Sc<T: copy> {}
-   │                  ---- 'copy' constraint declared here
+11 │     struct Sc<phantom T: copy> {}
+   │                          ---- 'copy' constraint declared here
    ·
 17 │         TnoC: drop + store + key,
    │         ---- To satisfy the constraint, the 'copy' ability would need to be added here
@@ -234,11 +234,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:32:13
    │
- 3 │     struct Cup<T> {}
+ 3 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
    ·
-11 │     struct Sc<T: copy> {}
-   │                  ---- 'copy' constraint declared here
+11 │     struct Sc<phantom T: copy> {}
+   │                          ---- 'copy' constraint declared here
    ·
 32 │         let Sc {} = Sc<Cup<TnoK>> {};
    │             ^^^^^      --------- The type '0x42::M::Cup<TnoK>' does not have the ability 'copy'
@@ -248,11 +248,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:32:21
    │
- 3 │     struct Cup<T> {}
+ 3 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
    ·
-11 │     struct Sc<T: copy> {}
-   │                  ---- 'copy' constraint declared here
+11 │     struct Sc<phantom T: copy> {}
+   │                          ---- 'copy' constraint declared here
    ·
 32 │         let Sc {} = Sc<Cup<TnoK>> {};
    │                     ^^^^^^^^^^^^^^^^
@@ -263,8 +263,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:33:13
    │
-11 │     struct Sc<T: copy> {}
-   │                  ---- 'copy' constraint declared here
+11 │     struct Sc<phantom T: copy> {}
+   │                          ---- 'copy' constraint declared here
    ·
 33 │         let Sc {} = Sc<Box<TnoC>> {};
    │             ^^^^^      ---------
@@ -276,8 +276,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:33:21
    │
-11 │     struct Sc<T: copy> {}
-   │                  ---- 'copy' constraint declared here
+11 │     struct Sc<phantom T: copy> {}
+   │                          ---- 'copy' constraint declared here
    ·
 33 │         let Sc {} = Sc<Box<TnoC>> {};
    │                     ^^^^^^^^^^^^^^^^
@@ -289,8 +289,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:34:13
    │
-12 │     struct Sk<T: key> {}
-   │                  --- 'key' constraint declared here
+12 │     struct Sk<phantom T: key> {}
+   │                          --- 'key' constraint declared here
    ·
 18 │         TnoK: copy + drop + store,
    │         ---- To satisfy the constraint, the 'key' ability would need to be added here
@@ -303,8 +303,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:34:21
    │
-12 │     struct Sk<T: key> {}
-   │                  --- 'key' constraint declared here
+12 │     struct Sk<phantom T: key> {}
+   │                          --- 'key' constraint declared here
    ·
 18 │         TnoK: copy + drop + store,
    │         ---- To satisfy the constraint, the 'key' ability would need to be added here
@@ -318,11 +318,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:35:13
    │
- 3 │     struct Cup<T> {}
+ 3 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'key' ability would need to be added here
    ·
-12 │     struct Sk<T: key> {}
-   │                  --- 'key' constraint declared here
+12 │     struct Sk<phantom T: key> {}
+   │                          --- 'key' constraint declared here
    ·
 35 │         let Sk {} = Sk<Cup<TnoC>> {};
    │             ^^^^^      --------- The type '0x42::M::Cup<TnoC>' does not have the ability 'key'
@@ -332,11 +332,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:35:21
    │
- 3 │     struct Cup<T> {}
+ 3 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'key' ability would need to be added here
    ·
-12 │     struct Sk<T: key> {}
-   │                  --- 'key' constraint declared here
+12 │     struct Sk<phantom T: key> {}
+   │                          --- 'key' constraint declared here
    ·
 35 │         let Sk {} = Sk<Cup<TnoC>> {};
    │                     ^^^^^^^^^^^^^^^^
@@ -347,8 +347,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:36:13
    │
-12 │     struct Sk<T: key> {}
-   │                  --- 'key' constraint declared here
+12 │     struct Sk<phantom T: key> {}
+   │                          --- 'key' constraint declared here
    ·
 36 │         let Sk {} = Sk<Box<Cup<TnoC>>> {};
    │             ^^^^^      --------------
@@ -360,8 +360,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:36:21
    │
-12 │     struct Sk<T: key> {}
-   │                  --- 'key' constraint declared here
+12 │     struct Sk<phantom T: key> {}
+   │                          --- 'key' constraint declared here
    ·
 36 │         let Sk {} = Sk<Box<Cup<TnoC>>> {};
    │                     ^^^^^^^^^^^^^^^^^^^^^
@@ -373,8 +373,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:37:13
    │
-13 │     struct Scds<T: copy + drop + store> {}
-   │                    ---- 'copy' constraint declared here
+13 │     struct Scds<phantom T: copy + drop + store> {}
+   │                            ---- 'copy' constraint declared here
    ·
 17 │         TnoC: drop + store + key,
    │         ---- To satisfy the constraint, the 'copy' ability would need to be added here
@@ -387,8 +387,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:37:23
    │
-13 │     struct Scds<T: copy + drop + store> {}
-   │                    ---- 'copy' constraint declared here
+13 │     struct Scds<phantom T: copy + drop + store> {}
+   │                            ---- 'copy' constraint declared here
    ·
 17 │         TnoC: drop + store + key,
    │         ---- To satisfy the constraint, the 'copy' ability would need to be added here
@@ -402,11 +402,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:38:13
    │
- 3 │     struct Cup<T> {}
+ 3 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
    ·
-13 │     struct Scds<T: copy + drop + store> {}
-   │                    ---- 'copy' constraint declared here
+13 │     struct Scds<phantom T: copy + drop + store> {}
+   │                            ---- 'copy' constraint declared here
    ·
 38 │         let Scds {} = Scds<Cup<TnoC>> {};
    │             ^^^^^^^        --------- The type '0x42::M::Cup<TnoC>' does not have the ability 'copy'
@@ -416,11 +416,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:38:13
    │
- 3 │     struct Cup<T> {}
+ 3 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'drop' ability would need to be added here
    ·
-13 │     struct Scds<T: copy + drop + store> {}
-   │                           ---- 'drop' constraint declared here
+13 │     struct Scds<phantom T: copy + drop + store> {}
+   │                                   ---- 'drop' constraint declared here
    ·
 38 │         let Scds {} = Scds<Cup<TnoC>> {};
    │             ^^^^^^^        --------- The type '0x42::M::Cup<TnoC>' does not have the ability 'drop'
@@ -430,11 +430,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:38:13
    │
- 3 │     struct Cup<T> {}
+ 3 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'store' ability would need to be added here
    ·
-13 │     struct Scds<T: copy + drop + store> {}
-   │                                  ----- 'store' constraint declared here
+13 │     struct Scds<phantom T: copy + drop + store> {}
+   │                                          ----- 'store' constraint declared here
    ·
 38 │         let Scds {} = Scds<Cup<TnoC>> {};
    │             ^^^^^^^        --------- The type '0x42::M::Cup<TnoC>' does not have the ability 'store'
@@ -444,11 +444,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:38:23
    │
- 3 │     struct Cup<T> {}
+ 3 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
    ·
-13 │     struct Scds<T: copy + drop + store> {}
-   │                    ---- 'copy' constraint declared here
+13 │     struct Scds<phantom T: copy + drop + store> {}
+   │                            ---- 'copy' constraint declared here
    ·
 38 │         let Scds {} = Scds<Cup<TnoC>> {};
    │                       ^^^^^^^^^^^^^^^^^^
@@ -459,11 +459,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:38:23
    │
- 3 │     struct Cup<T> {}
+ 3 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'drop' ability would need to be added here
    ·
-13 │     struct Scds<T: copy + drop + store> {}
-   │                           ---- 'drop' constraint declared here
+13 │     struct Scds<phantom T: copy + drop + store> {}
+   │                                   ---- 'drop' constraint declared here
    ·
 38 │         let Scds {} = Scds<Cup<TnoC>> {};
    │                       ^^^^^^^^^^^^^^^^^^
@@ -474,11 +474,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:38:23
    │
- 3 │     struct Cup<T> {}
+ 3 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'store' ability would need to be added here
    ·
-13 │     struct Scds<T: copy + drop + store> {}
-   │                                  ----- 'store' constraint declared here
+13 │     struct Scds<phantom T: copy + drop + store> {}
+   │                                          ----- 'store' constraint declared here
    ·
 38 │         let Scds {} = Scds<Cup<TnoC>> {};
    │                       ^^^^^^^^^^^^^^^^^^
@@ -489,11 +489,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:39:13
    │
- 3 │     struct Cup<T> {}
+ 3 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
    ·
-13 │     struct Scds<T: copy + drop + store> {}
-   │                    ---- 'copy' constraint declared here
+13 │     struct Scds<phantom T: copy + drop + store> {}
+   │                            ---- 'copy' constraint declared here
    ·
 39 │         let Scds {} = Scds<Cup<TnoK>> {};
    │             ^^^^^^^        --------- The type '0x42::M::Cup<TnoK>' does not have the ability 'copy'
@@ -503,11 +503,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:39:13
    │
- 3 │     struct Cup<T> {}
+ 3 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'drop' ability would need to be added here
    ·
-13 │     struct Scds<T: copy + drop + store> {}
-   │                           ---- 'drop' constraint declared here
+13 │     struct Scds<phantom T: copy + drop + store> {}
+   │                                   ---- 'drop' constraint declared here
    ·
 39 │         let Scds {} = Scds<Cup<TnoK>> {};
    │             ^^^^^^^        --------- The type '0x42::M::Cup<TnoK>' does not have the ability 'drop'
@@ -517,11 +517,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:39:13
    │
- 3 │     struct Cup<T> {}
+ 3 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'store' ability would need to be added here
    ·
-13 │     struct Scds<T: copy + drop + store> {}
-   │                                  ----- 'store' constraint declared here
+13 │     struct Scds<phantom T: copy + drop + store> {}
+   │                                          ----- 'store' constraint declared here
    ·
 39 │         let Scds {} = Scds<Cup<TnoK>> {};
    │             ^^^^^^^        --------- The type '0x42::M::Cup<TnoK>' does not have the ability 'store'
@@ -531,11 +531,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:39:23
    │
- 3 │     struct Cup<T> {}
+ 3 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'copy' ability would need to be added here
    ·
-13 │     struct Scds<T: copy + drop + store> {}
-   │                    ---- 'copy' constraint declared here
+13 │     struct Scds<phantom T: copy + drop + store> {}
+   │                            ---- 'copy' constraint declared here
    ·
 39 │         let Scds {} = Scds<Cup<TnoK>> {};
    │                       ^^^^^^^^^^^^^^^^^^
@@ -546,11 +546,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:39:23
    │
- 3 │     struct Cup<T> {}
+ 3 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'drop' ability would need to be added here
    ·
-13 │     struct Scds<T: copy + drop + store> {}
-   │                           ---- 'drop' constraint declared here
+13 │     struct Scds<phantom T: copy + drop + store> {}
+   │                                   ---- 'drop' constraint declared here
    ·
 39 │         let Scds {} = Scds<Cup<TnoK>> {};
    │                       ^^^^^^^^^^^^^^^^^^
@@ -561,11 +561,11 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:39:23
    │
- 3 │     struct Cup<T> {}
+ 3 │     struct Cup<T> { f: T }
    │            --- To satisfy the constraint, the 'store' ability would need to be added here
    ·
-13 │     struct Scds<T: copy + drop + store> {}
-   │                                  ----- 'store' constraint declared here
+13 │     struct Scds<phantom T: copy + drop + store> {}
+   │                                          ----- 'store' constraint declared here
    ·
 39 │         let Scds {} = Scds<Cup<TnoK>> {};
    │                       ^^^^^^^^^^^^^^^^^^
@@ -576,8 +576,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:40:13
    │
-13 │     struct Scds<T: copy + drop + store> {}
-   │                    ---- 'copy' constraint declared here
+13 │     struct Scds<phantom T: copy + drop + store> {}
+   │                            ---- 'copy' constraint declared here
    ·
 40 │         let Scds {} = Scds<Pair<u64, TnoC>> {};
    │             ^^^^^^^        ---------------
@@ -589,8 +589,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/ability_constraint_tparams_invalid.move:40:23
    │
-13 │     struct Scds<T: copy + drop + store> {}
-   │                    ---- 'copy' constraint declared here
+13 │     struct Scds<phantom T: copy + drop + store> {}
+   │                            ---- 'copy' constraint declared here
    ·
 40 │         let Scds {} = Scds<Pair<u64, TnoC>> {};
    │                       ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/language/move-lang/tests/move_check/typing/ability_constraint_tparams_invalid.move
+++ b/language/move-lang/tests/move_check/typing/ability_constraint_tparams_invalid.move
@@ -1,16 +1,16 @@
 address 0x42 {
 module M {
-    struct Cup<T> {}
-    struct Box<T> has copy, drop, store, key {}
-    struct Pair<T1, T2> has copy, drop, store, key {}
+    struct Cup<T> { f: T }
+    struct Box<T> has copy, drop, store, key { f: T }
+    struct Pair<T1, T2> has copy, drop, store, key { f1: T1, f2: T2 }
 
     fun c<T: copy>() {}
     fun k<T: key>() {}
     fun cds<T: copy + drop + store>() {}
 
-    struct Sc<T: copy> {}
-    struct Sk<T: key> {}
-    struct Scds<T: copy + drop + store> {}
+    struct Sc<phantom T: copy> {}
+    struct Sk<phantom T: key> {}
+    struct Scds<phantom T: copy + drop + store> {}
 
     // tests that a variety of constraint instantiations are all invalid
     fun t<

--- a/language/move-lang/tests/move_check/typing/ability_constraints.move
+++ b/language/move-lang/tests/move_check/typing/ability_constraints.move
@@ -2,8 +2,8 @@ address 0x42 {
 module M {
     struct S has copy, drop, store, key {}
     struct R has key, store {}
-    struct Box<T> has copy, drop, store, key {}
-    struct Pair<T1, T2> has copy, drop, store, key {}
+    struct Box<T> has copy, drop, store, key { f: T }
+    struct Pair<T1, T2> has copy, drop, store, key { f1: T1, f2: T2 }
 
     fun c<T: copy>() {}
     fun d<T: drop>() {}
@@ -12,12 +12,12 @@ module M {
     fun sk<T: store + key>() {}
     fun cds<T: copy + drop + store>() {}
 
-    struct Sc<T: copy> {}
-    struct Sd<T: drop> {}
-    struct Ss<T: store> {}
-    struct Sk<T: key> {}
-    struct Ssk<T: store + key> {}
-    struct Scds<T: copy + drop + store> {}
+    struct Sc<phantom T: copy> {}
+    struct Sd<phantom T: drop> {}
+    struct Ss<phantom T: store> {}
+    struct Sk<phantom T: key> {}
+    struct Ssk<phantom T: store + key> {}
+    struct Scds<phantom T: copy + drop + store> {}
 
     // tests that a variety of constraint instantiations are all valid
     fun t1<

--- a/language/move-lang/tests/move_check/typing/cast_invalid.move
+++ b/language/move-lang/tests/move_check/typing/cast_invalid.move
@@ -1,6 +1,6 @@
 module 0x8675309::M {
     struct R {}
-    struct Cup<T> has copy, drop {}
+    struct Cup<T> has copy, drop { f: T }
 
     fun t0(x8: u8, x64: u64, x128: u128) {
         (false as u8);

--- a/language/move-lang/tests/move_check/typing/conditional_copy_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/conditional_copy_invalid.exp
@@ -1,8 +1,8 @@
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_copy_invalid.move:15:16
    │
-14 │         let x = Box<R> {};
-   │                 ---------
+14 │         let x = Box<R> { f: R{} };
+   │                 -----------------
    │                 │   │
    │                 │   The type '0x42::M::Box<0x42::M::R>' can have the ability 'copy' but the type argument '0x42::M::R' does not have the required ability 'copy'
    │                 The type '0x42::M::Box<0x42::M::R>' does not have the ability 'copy'
@@ -12,8 +12,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_copy_invalid.move:17:16
    │
-16 │         let x = Box<Box<R>> {};
-   │                 --------------
+16 │         let x = Box<Box<R>> { f: Box { f: R{} } };
+   │                 ---------------------------------
    │                 │   │
    │                 │   The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' can have the ability 'copy' but the type argument '0x42::M::Box<0x42::M::R>' does not have the required ability 'copy'
    │                 The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' does not have the ability 'copy'
@@ -23,8 +23,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_copy_invalid.move:19:16
    │
-18 │         let x = Box<T> {};
-   │                 ---------
+18 │         let x = Box<T> { f: t1 };
+   │                 ----------------
    │                 │   │
    │                 │   The type '0x42::M::Box<T>' can have the ability 'copy' but the type argument 'T' does not have the required ability 'copy'
    │                 The type '0x42::M::Box<T>' does not have the ability 'copy'
@@ -34,8 +34,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_copy_invalid.move:21:16
    │
-20 │         let x = Box<Box<T>> {};
-   │                 --------------
+20 │         let x = Box<Box<T>> { f: Box { f: t2 } };
+   │                 --------------------------------
    │                 │   │
    │                 │   The type '0x42::M::Box<0x42::M::Box<T>>' can have the ability 'copy' but the type argument '0x42::M::Box<T>' does not have the required ability 'copy'
    │                 The type '0x42::M::Box<0x42::M::Box<T>>' does not have the ability 'copy'
@@ -45,8 +45,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_copy_invalid.move:23:16
    │
-22 │         let x = Pair<S, R> {};
-   │                 -------------
+22 │         let x = Pair<S, R> { f1: S{}, f2: R{} };
+   │                 -------------------------------
    │                 │       │
    │                 │       The type '0x42::M::Pair<0x42::M::S, 0x42::M::R>' can have the ability 'copy' but the type argument '0x42::M::R' does not have the required ability 'copy'
    │                 The type '0x42::M::Pair<0x42::M::S, 0x42::M::R>' does not have the ability 'copy'
@@ -56,8 +56,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_copy_invalid.move:27:16
    │
-26 │         let x = &Box<R> {};
-   │                  ---------
+26 │         let x = &Box<R> { f: R{} };
+   │                  -----------------
    │                  │   │
    │                  │   The type '0x42::M::Box<0x42::M::R>' can have the ability 'copy' but the type argument '0x42::M::R' does not have the required ability 'copy'
    │                  The type '0x42::M::Box<0x42::M::R>' does not have the ability 'copy'
@@ -67,8 +67,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_copy_invalid.move:29:16
    │
-28 │         let x = &Box<Box<R>> {};
-   │                  --------------
+28 │         let x = &Box<Box<R>> { f: Box { f: R{} } };
+   │                  ---------------------------------
    │                  │   │
    │                  │   The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' can have the ability 'copy' but the type argument '0x42::M::Box<0x42::M::R>' does not have the required ability 'copy'
    │                  The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' does not have the ability 'copy'
@@ -78,8 +78,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_copy_invalid.move:31:16
    │
-30 │         let x = &Box<T> {};
-   │                  ---------
+30 │         let x = &Box<T> { f: t3 };
+   │                  ----------------
    │                  │   │
    │                  │   The type '0x42::M::Box<T>' can have the ability 'copy' but the type argument 'T' does not have the required ability 'copy'
    │                  The type '0x42::M::Box<T>' does not have the ability 'copy'
@@ -89,8 +89,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_copy_invalid.move:33:16
    │
-32 │         let x = &Box<Box<T>> {};
-   │                  --------------
+32 │         let x = &Box<Box<T>> { f: Box { f: t4 } };
+   │                  --------------------------------
    │                  │   │
    │                  │   The type '0x42::M::Box<0x42::M::Box<T>>' can have the ability 'copy' but the type argument '0x42::M::Box<T>' does not have the required ability 'copy'
    │                  The type '0x42::M::Box<0x42::M::Box<T>>' does not have the ability 'copy'
@@ -100,8 +100,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_copy_invalid.move:35:16
    │
-34 │         let x = &Pair<R, S> {};
-   │                  -------------
+34 │         let x = &Pair<R, S> { f1: R{}, f2: S{} };
+   │                  -------------------------------
    │                  │    │
    │                  │    The type '0x42::M::Pair<0x42::M::R, 0x42::M::S>' can have the ability 'copy' but the type argument '0x42::M::R' does not have the required ability 'copy'
    │                  The type '0x42::M::Pair<0x42::M::R, 0x42::M::S>' does not have the ability 'copy'

--- a/language/move-lang/tests/move_check/typing/conditional_copy_invalid.move
+++ b/language/move-lang/tests/move_check/typing/conditional_copy_invalid.move
@@ -2,36 +2,36 @@ address 0x42 {
 module M {
     struct S has copy, drop, store {}
     struct R {}
-    struct Box<T> has copy {}
-    struct Pair<T1, T2> has copy {}
+    struct Box<T> has copy { f: T }
+    struct Pair<T1, T2> has copy { f1: T1, f2: T2}
 
     fun ignore<T>(x: T) {
         abort 0
     }
 
     // types that can have copy but the specific instantiation does not
-    fun ex<T>() {
-        let x = Box<R> {};
+    fun ex<T>(t1: T, t2: T, t3: T, t4: T) {
+        let x = Box<R> { f: R{} };
         ignore(copy x);
-        let x = Box<Box<R>> {};
+        let x = Box<Box<R>> { f: Box { f: R{} } };
         ignore(copy x);
-        let x = Box<T> {};
+        let x = Box<T> { f: t1 };
         ignore(copy x);
-        let x = Box<Box<T>> {};
+        let x = Box<Box<T>> { f: Box { f: t2 } };
         ignore(copy x);
-        let x = Pair<S, R> {};
+        let x = Pair<S, R> { f1: S{}, f2: R{} };
         ignore(copy x);
 
 
-        let x = &Box<R> {};
+        let x = &Box<R> { f: R{} };
         ignore(*x);
-        let x = &Box<Box<R>> {};
+        let x = &Box<Box<R>> { f: Box { f: R{} } };
         ignore(*x);
-        let x = &Box<T> {};
+        let x = &Box<T> { f: t3 };
         ignore(*x);
-        let x = &Box<Box<T>> {};
+        let x = &Box<Box<T>> { f: Box { f: t4 } };
         ignore(*x);
-        let x = &Pair<R, S> {};
+        let x = &Pair<R, S> { f1: R{}, f2: S{} };
         ignore(*x);
     }
 }

--- a/language/move-lang/tests/move_check/typing/conditional_drop_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/conditional_drop_invalid.exp
@@ -1,8 +1,8 @@
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:10:9
    │
-10 │         Box<R> {};
-   │         ^^^^^^^^^
+10 │         Box<R> { f: R{} };
+   │         ^^^^^^^^^^^^^^^^^
    │         │   │
    │         │   The type '0x42::M::Box<0x42::M::R>' can have the ability 'drop' but the type argument '0x42::M::R' does not have the required ability 'drop'
    │         Cannot ignore values without the 'drop' ability. The value must be used
@@ -11,8 +11,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:11:9
    │
-11 │         Box<Box<R>> {};
-   │         ^^^^^^^^^^^^^^
+11 │         Box<Box<R>> { f: Box { f: R{} } };
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │         │   │
    │         │   The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' can have the ability 'drop' but the type argument '0x42::M::Box<0x42::M::R>' does not have the required ability 'drop'
    │         Cannot ignore values without the 'drop' ability. The value must be used
@@ -21,8 +21,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:12:9
    │
-12 │         Box<T> {};
-   │         ^^^^^^^^^
+12 │         Box<T> { f: t };
+   │         ^^^^^^^^^^^^^^^
    │         │   │
    │         │   The type '0x42::M::Box<T>' can have the ability 'drop' but the type argument 'T' does not have the required ability 'drop'
    │         Cannot ignore values without the 'drop' ability. The value must be used
@@ -31,8 +31,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:13:9
    │
-13 │         Box<Box<T>> {};
-   │         ^^^^^^^^^^^^^^
+13 │         Box<Box<T>> { f: Box { f: t } };
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │         │   │
    │         │   The type '0x42::M::Box<0x42::M::Box<T>>' can have the ability 'drop' but the type argument '0x42::M::Box<T>' does not have the required ability 'drop'
    │         Cannot ignore values without the 'drop' ability. The value must be used
@@ -41,8 +41,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:14:9
    │
-14 │         Pair<S, R> {};
-   │         ^^^^^^^^^^^^^
+14 │         Pair<S, R> { f1: S{}, f2: R{} };
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │         │       │
    │         │       The type '0x42::M::Pair<0x42::M::S, 0x42::M::R>' can have the ability 'drop' but the type argument '0x42::M::R' does not have the required ability 'drop'
    │         Cannot ignore values without the 'drop' ability. The value must be used
@@ -51,8 +51,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:15:9
    │
-15 │         (Pair<S, R> {}, 0, @0x1);
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^
+15 │         (Pair<S, R> { f1: S{}, f2: R{} }, 0, @0x1);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │         ││
    │         │The type '(0x42::M::Pair<0x42::M::S, 0x42::M::R>, u64, address)' can have the ability 'drop' but the type argument '0x42::M::Pair<0x42::M::S, 0x42::M::R>' does not have the required ability 'drop'
    │         Cannot ignore values without the 'drop' ability. The value must be used
@@ -61,100 +61,100 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:17:9
    │
-17 │         Box<R> {} == Box<R> {};
-   │         ^^^^^^^^^
+17 │         Box<R> { f: R {} } == Box<R> { f: R {} };
+   │         ^^^^^^^^^^^^^^^^^^
    │         │   │
    │         │   The type '0x42::M::Box<0x42::M::R>' can have the ability 'drop' but the type argument '0x42::M::R' does not have the required ability 'drop'
    │         '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
    │         The type '0x42::M::Box<0x42::M::R>' does not have the ability 'drop'
 
 error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_check/typing/conditional_drop_invalid.move:17:22
+   ┌─ tests/move_check/typing/conditional_drop_invalid.move:17:31
    │
-17 │         Box<R> {} == Box<R> {};
-   │                      ^^^^^^^^^
-   │                      │   │
-   │                      │   The type '0x42::M::Box<0x42::M::R>' can have the ability 'drop' but the type argument '0x42::M::R' does not have the required ability 'drop'
-   │                      '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
-   │                      The type '0x42::M::Box<0x42::M::R>' does not have the ability 'drop'
+17 │         Box<R> { f: R {} } == Box<R> { f: R {} };
+   │                               ^^^^^^^^^^^^^^^^^^
+   │                               │   │
+   │                               │   The type '0x42::M::Box<0x42::M::R>' can have the ability 'drop' but the type argument '0x42::M::R' does not have the required ability 'drop'
+   │                               '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │                               The type '0x42::M::Box<0x42::M::R>' does not have the ability 'drop'
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:18:9
    │
-18 │         Box<Box<R>> {} == Box<Box<R>> {};
-   │         ^^^^^^^^^^^^^^
+18 │         Box<Box<R>> { f: Box { f: R {} } } == Box<Box<R>> { f: Box { f: R {} }};
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │         │   │
    │         │   The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' can have the ability 'drop' but the type argument '0x42::M::Box<0x42::M::R>' does not have the required ability 'drop'
    │         '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
    │         The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' does not have the ability 'drop'
 
 error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_check/typing/conditional_drop_invalid.move:18:27
+   ┌─ tests/move_check/typing/conditional_drop_invalid.move:18:47
    │
-18 │         Box<Box<R>> {} == Box<Box<R>> {};
-   │                           ^^^^^^^^^^^^^^
-   │                           │   │
-   │                           │   The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' can have the ability 'drop' but the type argument '0x42::M::Box<0x42::M::R>' does not have the required ability 'drop'
-   │                           '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
-   │                           The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' does not have the ability 'drop'
+18 │         Box<Box<R>> { f: Box { f: R {} } } == Box<Box<R>> { f: Box { f: R {} }};
+   │                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │                                               │   │
+   │                                               │   The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' can have the ability 'drop' but the type argument '0x42::M::Box<0x42::M::R>' does not have the required ability 'drop'
+   │                                               '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │                                               The type '0x42::M::Box<0x42::M::Box<0x42::M::R>>' does not have the ability 'drop'
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:19:9
    │
-19 │         Box<T> {} == Box<T> {};
-   │         ^^^^^^^^^
+19 │         Box<T> { f: t } == Box<T> { f: t };
+   │         ^^^^^^^^^^^^^^^
    │         │   │
    │         │   The type '0x42::M::Box<T>' can have the ability 'drop' but the type argument 'T' does not have the required ability 'drop'
    │         '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
    │         The type '0x42::M::Box<T>' does not have the ability 'drop'
 
 error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_check/typing/conditional_drop_invalid.move:19:22
+   ┌─ tests/move_check/typing/conditional_drop_invalid.move:19:28
    │
-19 │         Box<T> {} == Box<T> {};
-   │                      ^^^^^^^^^
-   │                      │   │
-   │                      │   The type '0x42::M::Box<T>' can have the ability 'drop' but the type argument 'T' does not have the required ability 'drop'
-   │                      '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
-   │                      The type '0x42::M::Box<T>' does not have the ability 'drop'
+19 │         Box<T> { f: t } == Box<T> { f: t };
+   │                            ^^^^^^^^^^^^^^^
+   │                            │   │
+   │                            │   The type '0x42::M::Box<T>' can have the ability 'drop' but the type argument 'T' does not have the required ability 'drop'
+   │                            '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │                            The type '0x42::M::Box<T>' does not have the ability 'drop'
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:20:9
    │
-20 │         Box<Box<T>> {} == Box<Box<T>> {};
-   │         ^^^^^^^^^^^^^^
+20 │         Box<Box<T>> { f: Box { f: t } } == Box<Box<T>> { f: Box { f: t} };
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │         │   │
    │         │   The type '0x42::M::Box<0x42::M::Box<T>>' can have the ability 'drop' but the type argument '0x42::M::Box<T>' does not have the required ability 'drop'
    │         '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
    │         The type '0x42::M::Box<0x42::M::Box<T>>' does not have the ability 'drop'
 
 error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_check/typing/conditional_drop_invalid.move:20:27
+   ┌─ tests/move_check/typing/conditional_drop_invalid.move:20:44
    │
-20 │         Box<Box<T>> {} == Box<Box<T>> {};
-   │                           ^^^^^^^^^^^^^^
-   │                           │   │
-   │                           │   The type '0x42::M::Box<0x42::M::Box<T>>' can have the ability 'drop' but the type argument '0x42::M::Box<T>' does not have the required ability 'drop'
-   │                           '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
-   │                           The type '0x42::M::Box<0x42::M::Box<T>>' does not have the ability 'drop'
+20 │         Box<Box<T>> { f: Box { f: t } } == Box<Box<T>> { f: Box { f: t} };
+   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │                                            │   │
+   │                                            │   The type '0x42::M::Box<0x42::M::Box<T>>' can have the ability 'drop' but the type argument '0x42::M::Box<T>' does not have the required ability 'drop'
+   │                                            '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │                                            The type '0x42::M::Box<0x42::M::Box<T>>' does not have the ability 'drop'
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:21:9
    │
-21 │         Pair<R, S> {} == Pair<R, S> {};
-   │         ^^^^^^^^^^^^^
+21 │         Pair<R, S> { f1: R{}, f2: S{} } == Pair<R, S> { f1: R{}, f2: S{} };
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │         │    │
    │         │    The type '0x42::M::Pair<0x42::M::R, 0x42::M::S>' can have the ability 'drop' but the type argument '0x42::M::R' does not have the required ability 'drop'
    │         '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
    │         The type '0x42::M::Pair<0x42::M::R, 0x42::M::S>' does not have the ability 'drop'
 
 error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_check/typing/conditional_drop_invalid.move:21:26
+   ┌─ tests/move_check/typing/conditional_drop_invalid.move:21:44
    │
-21 │         Pair<R, S> {} == Pair<R, S> {};
-   │                          ^^^^^^^^^^^^^
-   │                          │    │
-   │                          │    The type '0x42::M::Pair<0x42::M::R, 0x42::M::S>' can have the ability 'drop' but the type argument '0x42::M::R' does not have the required ability 'drop'
-   │                          '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
-   │                          The type '0x42::M::Pair<0x42::M::R, 0x42::M::S>' does not have the ability 'drop'
+21 │         Pair<R, S> { f1: R{}, f2: S{} } == Pair<R, S> { f1: R{}, f2: S{} };
+   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │                                            │    │
+   │                                            │    The type '0x42::M::Pair<0x42::M::R, 0x42::M::S>' can have the ability 'drop' but the type argument '0x42::M::R' does not have the required ability 'drop'
+   │                                            '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │                                            The type '0x42::M::Pair<0x42::M::R, 0x42::M::S>' does not have the ability 'drop'
 

--- a/language/move-lang/tests/move_check/typing/conditional_drop_invalid.move
+++ b/language/move-lang/tests/move_check/typing/conditional_drop_invalid.move
@@ -2,23 +2,23 @@ address 0x42 {
 module M {
     struct S has copy, drop, store {}
     struct R {}
-    struct Box<T> has drop {}
-    struct Pair<T1, T2> has drop {}
+    struct Box<T> has drop { f: T }
+    struct Pair<T1, T2> has drop { f1: T1, f2: T2 }
 
     // types that can have drop but the specific instantiation does not
-    fun ex<T>() {
-        Box<R> {};
-        Box<Box<R>> {};
-        Box<T> {};
-        Box<Box<T>> {};
-        Pair<S, R> {};
-        (Pair<S, R> {}, 0, @0x1);
+    fun ex<T: copy>(t: T) {
+        Box<R> { f: R{} };
+        Box<Box<R>> { f: Box { f: R{} } };
+        Box<T> { f: t };
+        Box<Box<T>> { f: Box { f: t } };
+        Pair<S, R> { f1: S{}, f2: R{} };
+        (Pair<S, R> { f1: S{}, f2: R{} }, 0, @0x1);
 
-        Box<R> {} == Box<R> {};
-        Box<Box<R>> {} == Box<Box<R>> {};
-        Box<T> {} == Box<T> {};
-        Box<Box<T>> {} == Box<Box<T>> {};
-        Pair<R, S> {} == Pair<R, S> {};
+        Box<R> { f: R {} } == Box<R> { f: R {} };
+        Box<Box<R>> { f: Box { f: R {} } } == Box<Box<R>> { f: Box { f: R {} }};
+        Box<T> { f: t } == Box<T> { f: t };
+        Box<Box<T>> { f: Box { f: t } } == Box<Box<T>> { f: Box { f: t} };
+        Pair<R, S> { f1: R{}, f2: S{} } == Pair<R, S> { f1: R{}, f2: S{} };
     }
 }
 }

--- a/language/move-lang/tests/move_check/typing/conditional_global_operations.exp
+++ b/language/move-lang/tests/move_check/typing/conditional_global_operations.exp
@@ -1,8 +1,8 @@
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_global_operations.move:15:9
    │
-15 │         move_to(s, Box<R> {});
-   │         ^^^^^^^^^^^^^^^^^^^^^
+15 │         move_to(s, Box<R> { f: R {} });
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │         │          │   │
    │         │          │   The type '0x42::M::Box<0x42::M::R>' can have the ability 'key' but the type argument '0x42::M::R' does not have the required ability 'store'
    │         │          The type '0x42::M::Box<0x42::M::R>' does not have the ability 'key'
@@ -29,14 +29,14 @@ error[E05001]: ability constraint not satisfied
    │         Invalid call of 'borrow_global_mut'
 
 error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_check/typing/conditional_global_operations.move:18:19
+   ┌─ tests/move_check/typing/conditional_global_operations.move:18:33
    │
-18 │         Pair {} = move_from<Pair<S, R>>(a1);
-   │                   ^^^^^^^^^^^^^^^^^^^^^^^^^
-   │                   │         │       │
-   │                   │         │       The type '0x42::M::Pair<0x42::M::S, 0x42::M::R>' can have the ability 'key' but the type argument '0x42::M::R' does not have the required ability 'store'
-   │                   │         The type '0x42::M::Pair<0x42::M::S, 0x42::M::R>' does not have the ability 'key'
-   │                   Invalid call of 'move_from'
+18 │         Pair { f1: _, f2: _ } = move_from<Pair<S, R>>(a1);
+   │                                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+   │                                 │         │       │
+   │                                 │         │       The type '0x42::M::Pair<0x42::M::S, 0x42::M::R>' can have the ability 'key' but the type argument '0x42::M::R' does not have the required ability 'store'
+   │                                 │         The type '0x42::M::Pair<0x42::M::S, 0x42::M::R>' does not have the ability 'key'
+   │                                 Invalid call of 'move_from'
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_global_operations.move:19:9

--- a/language/move-lang/tests/move_check/typing/conditional_global_operations.move
+++ b/language/move-lang/tests/move_check/typing/conditional_global_operations.move
@@ -1,9 +1,9 @@
 address 0x42 {
 module M {
     struct S has copy, drop, store {}
-    struct R {}
-    struct Box<T> has key, store {}
-    struct Pair<T1, T2> has key, store {}
+    struct R has drop {}
+    struct Box<T> has key, store { f: T }
+    struct Pair<T1, T2> has key, store { f1: T1, f2: T2 }
     struct K has key {}
 
     fun ignore<T>(x: T) {
@@ -12,10 +12,10 @@ module M {
 
     // types that can have key/store but the specific instantiation does not
     fun ex<T>(s: &signer, a1: address) acquires Box, Pair {
-        move_to(s, Box<R> {});
+        move_to(s, Box<R> { f: R {} });
         borrow_global<Box<T>>(a1);
         borrow_global_mut<Box<Box<T>>>(a1);
-        Pair {} = move_from<Pair<S, R>>(a1);
+        Pair { f1: _, f2: _ } = move_from<Pair<S, R>>(a1);
         exists<Pair<Box<T>, S>>(a1);
 
         borrow_global<Box<K>>(a1);

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_all_cases.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_all_cases.exp
@@ -1,7 +1,7 @@
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/constraints_not_satisfied_all_cases.move:7:29
   │
-3 │     struct CupC<T: copy> {}
+3 │     struct CupC<T: copy> { f: T }
   │                    ---- 'copy' constraint declared here
   ·
 7 │     fun no_constraint<T>(c: CupC<T>, r: CupR<T>) {}
@@ -14,7 +14,7 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/constraints_not_satisfied_all_cases.move:7:41
   │
-2 │     struct CupR<T: key> {}
+2 │     struct CupR<T: key> { f: T }
   │                    --- 'key' constraint declared here
   ·
 7 │     fun no_constraint<T>(c: CupC<T>, r: CupR<T>) {}
@@ -27,7 +27,7 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/constraints_not_satisfied_all_cases.move:9:31
   │
-3 │     struct CupC<T: copy> {}
+3 │     struct CupC<T: copy> { f: T }
   │                    ---- 'copy' constraint declared here
   ·
 9 │     fun t_resource<T: key>(c: CupC<T>, r: CupR<T>) {}
@@ -40,7 +40,7 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/constraints_not_satisfied_all_cases.move:11:44
    │
- 2 │     struct CupR<T: key> {}
+ 2 │     struct CupR<T: key> { f: T }
    │                    --- 'key' constraint declared here
    ·
 11 │     fun t_copyable<T: copy>(c: CupC<T>, r: CupR<T>) {}
@@ -53,7 +53,7 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/constraints_not_satisfied_all_cases.move:13:14
    │
- 3 │     struct CupC<T: copy> {}
+ 3 │     struct CupC<T: copy> { f: T }
    │                    ---- 'copy' constraint declared here
  4 │     struct R has key {}
    │            - To satisfy the constraint, the 'copy' ability would need to be added here
@@ -67,7 +67,7 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/constraints_not_satisfied_all_cases.move:15:26
    │
- 2 │     struct CupR<T: key> {}
+ 2 │     struct CupR<T: key> { f: T }
    │                    --- 'key' constraint declared here
    ·
  5 │     struct C has copy {}

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_all_cases.move
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_all_cases.move
@@ -1,6 +1,6 @@
 module 0x8675309::M {
-    struct CupR<T: key> {}
-    struct CupC<T: copy> {}
+    struct CupR<T: key> { f: T }
+    struct CupC<T: copy> { f: T }
     struct R has key {}
     struct C has copy {}
 

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_function_parameter.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_function_parameter.exp
@@ -1,7 +1,7 @@
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/constraints_not_satisfied_function_parameter.move:5:16
   │
-2 │     struct CupC<T: copy> {}
+2 │     struct CupC<T: copy> { f: T }
   │                    ---- 'copy' constraint declared here
 3 │     struct R {}
   │            - To satisfy the constraint, the 'copy' ability would need to be added here

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_function_parameter.move
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_function_parameter.move
@@ -1,5 +1,5 @@
 module 0x8675309::M {
-    struct CupC<T: copy> {}
+    struct CupC<T: copy> { f: T }
     struct R {}
 
     fun foo(x: CupC<R>) {}

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_function_return_type.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_function_return_type.exp
@@ -1,7 +1,7 @@
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/constraints_not_satisfied_function_return_type.move:5:17
   │
-2 │     struct CupC<T: copy> {}
+2 │     struct CupC<T: copy> { f: T }
   │                    ---- 'copy' constraint declared here
 3 │     struct R {}
   │            - To satisfy the constraint, the 'copy' ability would need to be added here

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_function_return_type.move
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_function_return_type.move
@@ -1,5 +1,5 @@
 module 0x8675309::M {
-    struct CupC<T: copy> {}
+    struct CupC<T: copy> { f: T }
     struct R {}
 
     fun foo():  CupC<R> {

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_bind_type.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_bind_type.exp
@@ -1,7 +1,7 @@
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/constraints_not_satisfied_lvalues_bind_type.move:6:16
   │
-2 │     struct CupC<T: copy> {}
+2 │     struct CupC<T: copy> { f: T }
   │                    ---- 'copy' constraint declared here
 3 │     struct R {}
   │            - To satisfy the constraint, the 'copy' ability would need to be added here

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_bind_type.move
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_bind_type.move
@@ -1,5 +1,5 @@
 module 0x8675309::M {
-    struct CupC<T: copy> {}
+    struct CupC<T: copy> { f: T }
     struct R {}
 
     fun foo() {

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_decl_type.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_decl_type.exp
@@ -1,7 +1,7 @@
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/constraints_not_satisfied_lvalues_decl_type.move:6:16
   │
-2 │     struct CupC<T: copy> {}
+2 │     struct CupC<T: copy> { f: T }
   │                    ---- 'copy' constraint declared here
 3 │     struct R {}
   │            - To satisfy the constraint, the 'copy' ability would need to be added here

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_decl_type.move
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_decl_type.move
@@ -1,5 +1,5 @@
 module 0x8675309::M {
-    struct CupC<T: copy> {}
+    struct CupC<T: copy> { f: T }
     struct R {}
 
     fun foo() {

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_pack_type_args.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_pack_type_args.exp
@@ -1,8 +1,8 @@
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/constraints_not_satisfied_lvalues_pack_type_args.move:8:15
   │
-2 │     struct CupC<T: copy> {}
-  │                    ---- 'copy' constraint declared here
+2 │     struct CupC<phantom T: copy> {}
+  │                            ---- 'copy' constraint declared here
 3 │     struct R {}
   │            - To satisfy the constraint, the 'copy' ability would need to be added here
   ·
@@ -15,8 +15,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/constraints_not_satisfied_lvalues_pack_type_args.move:9:11
   │
-2 │     struct CupC<T: copy> {}
-  │                    ---- 'copy' constraint declared here
+2 │     struct CupC<phantom T: copy> {}
+  │                            ---- 'copy' constraint declared here
 3 │     struct R {}
   │            - To satisfy the constraint, the 'copy' ability would need to be added here
   ·

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_pack_type_args.move
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_pack_type_args.move
@@ -1,8 +1,8 @@
 module 0x8675309::M {
-    struct CupC<T: copy> {}
+    struct CupC<phantom T: copy> {}
     struct R {}
 
-    struct B<T>{}
+    struct B<phantom T>{}
 
     fun foo() {
         let B<CupC<R>> {} = abort 0;

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_struct_field.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_struct_field.exp
@@ -1,7 +1,7 @@
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/constraints_not_satisfied_struct_field.move:6:12
   │
-2 │     struct CupC<T: copy> {}
+2 │     struct CupC<T: copy> { f: T }
   │                    ---- 'copy' constraint declared here
 3 │     struct R {}
   │            - To satisfy the constraint, the 'copy' ability would need to be added here

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_struct_field.move
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_struct_field.move
@@ -1,5 +1,5 @@
 module 0x8675309::M {
-    struct CupC<T: copy> {}
+    struct CupC<T: copy> { f: T }
     struct R {}
 
     struct B {

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_type_annotation.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_type_annotation.exp
@@ -1,7 +1,7 @@
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/constraints_not_satisfied_type_annotation.move:7:26
   │
-2 │     struct CupC<T: copy> {}
+2 │     struct CupC<T: copy> { f: T }
   │                    ---- 'copy' constraint declared here
 3 │     struct C {}
 4 │     struct R {}

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_type_annotation.move
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_type_annotation.move
@@ -1,5 +1,5 @@
 module 0x8675309::M {
-    struct CupC<T: copy> {}
+    struct CupC<T: copy> { f: T }
     struct C {}
     struct R {}
 

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_call.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_call.exp
@@ -1,7 +1,7 @@
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_call.move:9:13
   │
-2 │     struct CupC<T: copy> {}
+2 │     struct CupC<T: copy> { f: T }
   │                    ---- 'copy' constraint declared here
 3 │     struct R {}
   │            - To satisfy the constraint, the 'copy' ability would need to be added here

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_call.move
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_call.move
@@ -1,5 +1,5 @@
 module 0x8675309::M {
-    struct CupC<T: copy> {}
+    struct CupC<T: copy> { f: T }
     struct R {}
 
     fun box<T>() {

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.exp
@@ -1,8 +1,8 @@
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.move:8:9
   │
-8 │         Box<CupD<R>>{};
-  │         ^^^^^^^^^^^^^^
+8 │         Box<CupD<R>>{ f: abort 0 };
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
   │         │   │
   │         │   The type '0x8675309::M::Box<0x8675309::M::CupD<0x8675309::M::R>>' can have the ability 'drop' but the type argument '0x8675309::M::CupD<0x8675309::M::R>' does not have the required ability 'drop'
   │         Cannot ignore values without the 'drop' ability. The value must be used
@@ -11,12 +11,12 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.move:8:13
   │
-2 │     struct CupD<T: drop> has drop {}
+2 │     struct CupD<T: drop> has drop { f: T }
   │                    ---- 'drop' constraint declared here
 3 │     struct R {}
   │            - To satisfy the constraint, the 'drop' ability would need to be added here
   ·
-8 │         Box<CupD<R>>{};
+8 │         Box<CupD<R>>{ f: abort 0 };
   │             ^^^^^^^
   │             │    │
   │             │    The type '0x8675309::M::R' does not have the ability 'drop'
@@ -25,8 +25,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.move:9:9
   │
-9 │         Box<R>{};
-  │         ^^^^^^^^
+9 │         Box<R>{ f: R{} };
+  │         ^^^^^^^^^^^^^^^^
   │         │   │
   │         │   The type '0x8675309::M::Box<0x8675309::M::R>' can have the ability 'drop' but the type argument '0x8675309::M::R' does not have the required ability 'drop'
   │         Cannot ignore values without the 'drop' ability. The value must be used

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.move
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.move
@@ -1,12 +1,12 @@
 module 0x8675309::M {
-    struct CupD<T: drop> has drop {}
+    struct CupD<T: drop> has drop { f: T }
     struct R {}
 
-    struct Box<T> has drop {}
+    struct Box<T> has drop { f: T }
 
     fun foo() {
-        Box<CupD<R>>{};
-        Box<R>{};
+        Box<CupD<R>>{ f: abort 0 };
+        Box<R>{ f: R{} };
     }
 
 }

--- a/language/move-lang/tests/move_check/typing/eq.move
+++ b/language/move-lang/tests/move_check/typing/eq.move
@@ -3,7 +3,7 @@ module 0x8675309::M {
     struct R {
         f: u64
     }
-    struct G<T> has drop {}
+    struct G<T> has drop { f: T }
 
     fun t0(r: &R, r_mut: &mut R, s: S, s_ref: &S, s_mut: &mut S) {
         (0 == 1: bool);
@@ -25,7 +25,7 @@ module 0x8675309::M {
         (r_mut == r_mut: bool);
         (r == r_mut: bool);
         (r_mut == r: bool);
-        (G {} == G<u64> {}: bool);
-        (G<u64> {} == G {}: bool);
+        (G { f: 1 } == G<u64> { f: 1 }: bool);
+        (G<u64> { f: 1 } == G { f: 1 }: bool);
     }
 }

--- a/language/move-lang/tests/move_check/typing/eq_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/eq_invalid.exp
@@ -105,33 +105,33 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/eq_invalid.move:26:9
    │
-26 │         G0<R>{} == G0<R>{};
-   │         ^^^^^^^
+26 │         G0<R>{ f: R { f: 1 } } == G0<R>{ f: R { f: 1 } };
+   │         ^^^^^^^^^^^^^^^^^^^^^^
    │         │  │
    │         │  The type '0x8675309::M::G0<0x8675309::M::R>' can have the ability 'drop' but the type argument '0x8675309::M::R' does not have the required ability 'drop'
    │         '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
    │         The type '0x8675309::M::G0<0x8675309::M::R>' does not have the ability 'drop'
 
 error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_check/typing/eq_invalid.move:26:20
+   ┌─ tests/move_check/typing/eq_invalid.move:26:35
    │
-26 │         G0<R>{} == G0<R>{};
-   │                    ^^^^^^^
-   │                    │  │
-   │                    │  The type '0x8675309::M::G0<0x8675309::M::R>' can have the ability 'drop' but the type argument '0x8675309::M::R' does not have the required ability 'drop'
-   │                    '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
-   │                    The type '0x8675309::M::G0<0x8675309::M::R>' does not have the ability 'drop'
+26 │         G0<R>{ f: R { f: 1 } } == G0<R>{ f: R { f: 1 } };
+   │                                   ^^^^^^^^^^^^^^^^^^^^^^
+   │                                   │  │
+   │                                   │  The type '0x8675309::M::G0<0x8675309::M::R>' can have the ability 'drop' but the type argument '0x8675309::M::R' does not have the required ability 'drop'
+   │                                   '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │                                   The type '0x8675309::M::G0<0x8675309::M::R>' does not have the ability 'drop'
 
 error[E04010]: cannot infer type
    ┌─ tests/move_check/typing/eq_invalid.move:28:9
    │
-28 │         G0{} == G0{};
+28 │         G2{} == G2{};
    │         ^^^^ Could not infer this type. Try adding an annotation
 
 error[E04010]: cannot infer type
    ┌─ tests/move_check/typing/eq_invalid.move:28:17
    │
-28 │         G0{} == G0{};
+28 │         G2{} == G2{};
    │                 ^^^^ Could not infer this type. Try adding an annotation
 
 error[E05001]: ability constraint not satisfied

--- a/language/move-lang/tests/move_check/typing/eq_invalid.move
+++ b/language/move-lang/tests/move_check/typing/eq_invalid.move
@@ -3,9 +3,9 @@ module 0x8675309::M {
     struct R has key {
         f: u64
     }
-    struct G0<T> has drop {}
+    struct G0<T> has drop { f: T }
     struct G1<T: key> {}
-
+    struct G2<phantom T> has drop {}
 
 
     fun t0(r: &R, r_mut: &mut R, s: S,
@@ -23,9 +23,9 @@ module 0x8675309::M {
     }
 
     fun t3() {
-        G0<R>{} == G0<R>{};
+        G0<R>{ f: R { f: 1 } } == G0<R>{ f: R { f: 1 } };
         // can be dropped, but cannot infer type
-        G0{} == G0{};
+        G2{} == G2{};
         G1{} == G1{};
     }
 

--- a/language/move-lang/tests/move_check/typing/exp_list.move
+++ b/language/move-lang/tests/move_check/typing/exp_list.move
@@ -1,9 +1,9 @@
 module 0x8675309::M {
-    struct R<T> {}
+    struct R<T> { f: T }
     struct S {}
 
     fun t0(): (u64, S, R<R<u64>>) {
-        (0, S{}, R{})
+        (0, S{}, R{ f: R { f: 1 } })
     }
 
     fun t1(s: &S, r: &mut R<u64>): (u64, &S, &mut R<u64>) {

--- a/language/move-lang/tests/move_check/typing/exp_list_nested.move
+++ b/language/move-lang/tests/move_check/typing/exp_list_nested.move
@@ -1,5 +1,5 @@
 module 0x8675309::M {
-    struct R<T> {}
+    struct R<phantom T> {}
     struct S {}
 
     fun t0(): (u64, S, R<u64>) {

--- a/language/move-lang/tests/move_check/typing/exp_list_resource_drop.exp
+++ b/language/move-lang/tests/move_check/typing/exp_list_resource_drop.exp
@@ -1,8 +1,8 @@
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/exp_list_resource_drop.move:7:9
   │
-7 │         (0, S{}, R<u64> {});
-  │         ^^^^^^^^^^^^^^^^^^^
+7 │         (0, S{ }, R<u64> { f: 1 });
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
   │         │   │
   │         │   The type '(u64, 0x8675309::M::S, 0x8675309::M::R<u64>)' can have the ability 'drop' but the type argument '0x8675309::M::S' does not have the required ability 'drop'
   │         Cannot ignore values without the 'drop' ability. The value must be used
@@ -11,8 +11,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/exp_list_resource_drop.move:8:9
   │
-8 │         (0, S{}, Box<R<u64>> {});
-  │         ^^^^^^^^^^^^^^^^^^^^^^^^
+8 │         (0, S{ }, Box<R<u64>> { f: R { f: 1 } });
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   │         │   │
   │         │   The type '(u64, 0x8675309::M::S, 0x8675309::M::Box<0x8675309::M::R<u64>>)' can have the ability 'drop' but the type argument '0x8675309::M::S' does not have the required ability 'drop'
   │         Cannot ignore values without the 'drop' ability. The value must be used
@@ -21,16 +21,16 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/exp_list_resource_drop.move:9:9
   │
-9 │         (0, S{}, Box {});
-  │         ^^^^^^^^^^^^^^^^
+9 │         (0, S{ }, Box { f: abort 0 });
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   │         │   │
   │         │   The type '(u64, 0x8675309::M::S, 0x8675309::M::Box<_>)' can have the ability 'drop' but the type argument '0x8675309::M::S' does not have the required ability 'drop'
   │         Cannot ignore values without the 'drop' ability. The value must be used
   │         The type '(u64, 0x8675309::M::S, 0x8675309::M::Box<_>)' does not have the ability 'drop'
 
 error[E04010]: cannot infer type
-  ┌─ tests/move_check/typing/exp_list_resource_drop.move:9:18
+  ┌─ tests/move_check/typing/exp_list_resource_drop.move:9:19
   │
-9 │         (0, S{}, Box {});
-  │                  ^^^^^^ Could not infer this type. Try adding an annotation
+9 │         (0, S{ }, Box { f: abort 0 });
+  │                   ^^^^^^^^^^^^^^^^^^ Could not infer this type. Try adding an annotation
 

--- a/language/move-lang/tests/move_check/typing/exp_list_resource_drop.move
+++ b/language/move-lang/tests/move_check/typing/exp_list_resource_drop.move
@@ -1,12 +1,12 @@
 module 0x8675309::M {
-    struct R<T> {}
+    struct R<T> { f: T }
     struct S {}
-    struct Box<T> has drop {}
+    struct Box<T> has drop { f: T }
 
     fun t0() {
-        (0, S{}, R<u64> {});
-        (0, S{}, Box<R<u64>> {});
-        (0, S{}, Box {});
+        (0, S{ }, R<u64> { f: 1 });
+        (0, S{ }, Box<R<u64>> { f: R { f: 1 } });
+        (0, S{ }, Box { f: abort 0 });
     }
 
 }

--- a/language/move-lang/tests/move_check/typing/ignore_inferred_resource.exp
+++ b/language/move-lang/tests/move_check/typing/ignore_inferred_resource.exp
@@ -1,7 +1,7 @@
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/ignore_inferred_resource.move:4:9
   │
-2 │     struct S<T> {}
+2 │     struct S<phantom T> {}
   │            - To satisfy the constraint, the 'drop' ability would need to be added here
 3 │     fun no() {
 4 │         S{};

--- a/language/move-lang/tests/move_check/typing/ignore_inferred_resource.move
+++ b/language/move-lang/tests/move_check/typing/ignore_inferred_resource.move
@@ -1,5 +1,5 @@
 module 0x8675309::M {
-    struct S<T> {}
+    struct S<phantom T> {}
     fun no() {
         S{};
     }

--- a/language/move-lang/tests/move_check/typing/infinite_instantiations_invalid.move
+++ b/language/move-lang/tests/move_check/typing/infinite_instantiations_invalid.move
@@ -1,7 +1,7 @@
 address 0x42 {
 
 module X {
-    struct Box<T> {}
+    struct Box<T> { f: T }
 
     public fun t<T>() {
         t<Box<T>>()
@@ -26,7 +26,7 @@ module X {
 }
 
 module Y {
-    struct Box<T> {}
+    struct Box<T> { f: T }
 
     public fun x<T>() {
         y<Box<T>>()
@@ -53,7 +53,7 @@ module Y {
 }
 
 module Z {
-    struct Box<T> {}
+    struct Box<T> { f: T }
 
     public fun tl<TL>() {
         tr<TL>()

--- a/language/move-lang/tests/move_check/typing/infinite_instantiations_valid.move
+++ b/language/move-lang/tests/move_check/typing/infinite_instantiations_valid.move
@@ -1,7 +1,7 @@
 address 0x42 {
 
 module M {
-    struct Box<T> {}
+    struct Box<T> { f: T }
 
     public fun t0<T>() {
         t1<T>();

--- a/language/move-lang/tests/move_check/typing/instantiate_signatures.exp
+++ b/language/move-lang/tests/move_check/typing/instantiate_signatures.exp
@@ -1,7 +1,7 @@
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/instantiate_signatures.move:11:13
    │
- 3 │     struct S<T: drop> has drop {}
+ 3 │     struct S<T: drop> has drop { f: T }
    │                 ---- 'drop' constraint declared here
  4 │     struct R {}
    │            - To satisfy the constraint, the 'drop' ability would need to be added here
@@ -51,7 +51,7 @@ error[E04004]: expected a single non-reference type
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/instantiate_signatures.move:18:14
    │
- 3 │     struct S<T: drop> has drop {}
+ 3 │     struct S<T: drop> has drop { f: T }
    │                 ---- 'drop' constraint declared here
  4 │     struct R {}
    │            - To satisfy the constraint, the 'drop' ability would need to be added here
@@ -92,7 +92,7 @@ error[E04004]: expected a single non-reference type
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/instantiate_signatures.move:23:9
    │
- 3 │     struct S<T: drop> has drop {}
+ 3 │     struct S<T: drop> has drop { f: T }
    │                 ---- 'drop' constraint declared here
  4 │     struct R {}
    │            - To satisfy the constraint, the 'drop' ability would need to be added here
@@ -133,7 +133,7 @@ error[E04004]: expected a single non-reference type
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/instantiate_signatures.move:32:17
    │
- 3 │     struct S<T: drop> has drop {}
+ 3 │     struct S<T: drop> has drop { f: T }
    │                 ---- 'drop' constraint declared here
  4 │     struct R {}
    │            - To satisfy the constraint, the 'drop' ability would need to be added here
@@ -184,7 +184,7 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/instantiate_signatures.move:37:12
    │
- 3 │     struct S<T: drop> has drop {}
+ 3 │     struct S<T: drop> has drop { f: T }
    │                 ---- 'drop' constraint declared here
  4 │     struct R {}
    │            - To satisfy the constraint, the 'drop' ability would need to be added here
@@ -234,11 +234,11 @@ error[E04004]: expected a single non-reference type
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/instantiate_signatures.move:42:9
    │
- 3 │     struct S<T: drop> has drop {}
+ 3 │     struct S<T: drop> has drop { f: T }
    │                 ---- 'drop' constraint declared here
    ·
-42 │         S<S<R>> {};
-   │         ^^^^^^^^^^
+42 │         S<S<R>> { f: abort 0 };
+   │         ^^^^^^^^^^^^^^^^^^^^^^
    │         │ │ │
    │         │ │ The type '0x42::M::S<0x42::M::R>' can have the ability 'drop' but the type argument '0x42::M::R' does not have the required ability 'drop'
    │         │ The type '0x42::M::S<0x42::M::R>' does not have the ability 'drop'
@@ -247,8 +247,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/instantiate_signatures.move:42:9
    │
-42 │         S<S<R>> {};
-   │         ^^^^^^^^^^
+42 │         S<S<R>> { f: abort 0 };
+   │         ^^^^^^^^^^^^^^^^^^^^^^
    │         │ │
    │         │ The type '0x42::M::S<0x42::M::S<0x42::M::R>>' can have the ability 'drop' but the type argument '0x42::M::S<0x42::M::R>' does not have the required ability 'drop'
    │         Cannot ignore values without the 'drop' ability. The value must be used
@@ -257,12 +257,12 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/instantiate_signatures.move:42:11
    │
- 3 │     struct S<T: drop> has drop {}
+ 3 │     struct S<T: drop> has drop { f: T }
    │                 ---- 'drop' constraint declared here
  4 │     struct R {}
    │            - To satisfy the constraint, the 'drop' ability would need to be added here
    ·
-42 │         S<S<R>> {};
+42 │         S<S<R>> { f: abort 0 };
    │           ^^^^
    │           │ │
    │           │ The type '0x42::M::R' does not have the ability 'drop'
@@ -271,7 +271,7 @@ error[E05001]: ability constraint not satisfied
 error[E04004]: expected a single non-reference type
    ┌─ tests/move_check/typing/instantiate_signatures.move:43:11
    │
-43 │         S<S<&u64>> {};
+43 │         S<S<&u64>> { f: abort 0 };
    │           ^^^^^^^
    │           │ │
    │           │ Expected a single non-reference type, but found: '&u64'
@@ -280,8 +280,8 @@ error[E04004]: expected a single non-reference type
 error[E04004]: expected a single non-reference type
    ┌─ tests/move_check/typing/instantiate_signatures.move:44:9
    │
-44 │         S<&(&u64)> {};
-   │         ^^^^^^^^^^^^^
+44 │         S<&(&u64)> { f: abort 0 };
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^
    │         │ │
    │         │ Expected a single non-reference type, but found: '&&u64'
    │         Invalid type argument
@@ -289,7 +289,7 @@ error[E04004]: expected a single non-reference type
 error[E04004]: expected a single non-reference type
    ┌─ tests/move_check/typing/instantiate_signatures.move:44:11
    │
-44 │         S<&(&u64)> {};
+44 │         S<&(&u64)> { f: abort 0 };
    │           ^^^^^^^
    │           ││
    │           │Expected a single non-reference type, but found: '&u64'
@@ -298,7 +298,7 @@ error[E04004]: expected a single non-reference type
 error[E04004]: expected a single non-reference type
    ┌─ tests/move_check/typing/instantiate_signatures.move:45:11
    │
-45 │         S<S<(u64, u64)>> {};
+45 │         S<S<(u64, u64)>> { f: abort 0 };
    │           ^^^^^^^^^^^^^
    │           │ │
    │           │ Expected a single non-reference type, but found: '(u64, u64)'

--- a/language/move-lang/tests/move_check/typing/instantiate_signatures.move
+++ b/language/move-lang/tests/move_check/typing/instantiate_signatures.move
@@ -1,6 +1,6 @@
 address 0x42 {
 module M {
-    struct S<T: drop> has drop {}
+    struct S<T: drop> has drop { f: T }
     struct R {}
     fun id<T>(x: T): T { x }
 
@@ -39,10 +39,10 @@ module M {
         id<&(&u64)>(abort 0);
         id<S<(u64, u64)>>(abort 0);
 
-        S<S<R>> {};
-        S<S<&u64>> {};
-        S<&(&u64)> {};
-        S<S<(u64, u64)>> {};
+        S<S<R>> { f: abort 0 };
+        S<S<&u64>> { f: abort 0 };
+        S<&(&u64)> { f: abort 0 };
+        S<S<(u64, u64)>> { f: abort 0 };
     }
 }
 }

--- a/language/move-lang/tests/move_check/typing/main_arguments_invalid.move
+++ b/language/move-lang/tests/move_check/typing/main_arguments_invalid.move
@@ -2,7 +2,7 @@ address 0x42 {
 module M {
     struct R {}
     struct S {}
-    struct Cup<T> {}
+    struct Cup<T> { f1: T }
 
     public fun eat(r: R) {
         R{} = r

--- a/language/move-lang/tests/move_check/typing/module_call_constraints_not_satisfied.exp
+++ b/language/move-lang/tests/move_check/typing/module_call_constraints_not_satisfied.exp
@@ -1,282 +1,312 @@
 error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:21:9
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:28:9
    │
  2 │     struct S has copy, drop {}
    │            - To satisfy the constraint, the 'key' ability would need to be added here
    ·
- 7 │     fun both<R: key, C: copy>(r: R, c: C) {
+15 │     fun both<R: key, C: copy>(r: R, c: C) {
    │                 --- 'key' constraint declared here
    ·
-21 │         both(S{}, Coin{});
+28 │         both(S{}, Coin{});
    │         ^^^^^^^^^^^^^^^^^
    │         │    │
    │         │    The type '0x8675309::M::S' does not have the ability 'key'
    │         'key' constraint not satisifed
 
 error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:21:9
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:28:9
    │
  3 │     struct Coin has key {}
    │            ---- To satisfy the constraint, the 'copy' ability would need to be added here
    ·
- 7 │     fun both<R: key, C: copy>(r: R, c: C) {
+15 │     fun both<R: key, C: copy>(r: R, c: C) {
    │                         ---- 'copy' constraint declared here
    ·
-21 │         both(S{}, Coin{});
+28 │         both(S{}, Coin{});
    │         ^^^^^^^^^^^^^^^^^
    │         │         │
    │         │         The type '0x8675309::M::Coin' does not have the ability 'copy'
    │         'copy' constraint not satisifed
 
 error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:22:9
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:29:9
    │
- 7 │     fun both<R: key, C: copy>(r: R, c: C) {
+15 │     fun both<R: key, C: copy>(r: R, c: C) {
    │                 --- 'key' constraint declared here
    ·
-22 │         both(0, Coin{})
+29 │         both(0, Coin{})
    │         ^^^^^^^^^^^^^^^
    │         │    │
    │         │    The type 'u64' does not have the ability 'key'
    │         'key' constraint not satisifed
 
 error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:22:9
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:29:9
    │
  3 │     struct Coin has key {}
    │            ---- To satisfy the constraint, the 'copy' ability would need to be added here
    ·
- 7 │     fun both<R: key, C: copy>(r: R, c: C) {
+15 │     fun both<R: key, C: copy>(r: R, c: C) {
    │                         ---- 'copy' constraint declared here
    ·
-22 │         both(0, Coin{})
+29 │         both(0, Coin{})
    │         ^^^^^^^^^^^^^^^
    │         │       │
    │         │       The type '0x8675309::M::Coin' does not have the ability 'copy'
    │         'copy' constraint not satisifed
 
 error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:26:9
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:33:9
    │
- 4 │     struct Box<T> has copy, drop {}
+ 4 │     struct Box<T> has copy, drop { f: T }
    │            --- To satisfy the constraint, the 'key' ability would need to be added here
    ·
- 7 │     fun both<R: key, C: copy>(r: R, c: C) {
+ 7 │     fun new_box<T>(): Box<T> {
+   │                       ------ The type '0x8675309::M::Box<C>' does not have the ability 'key'
+   ·
+15 │     fun both<R: key, C: copy>(r: R, c: C) {
    │                 --- 'key' constraint declared here
    ·
-26 │         both(Box<C> {}, Box<R> {})
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   │         │    │
-   │         │    The type '0x8675309::M::Box<C>' does not have the ability 'key'
-   │         'key' constraint not satisifed
-
-error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:26:9
-   │
- 7 │     fun both<R: key, C: copy>(r: R, c: C) {
-   │                         ---- 'copy' constraint declared here
-   ·
-26 │         both(Box<C> {}, Box<R> {})
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   │         │               │   │
-   │         │               │   The type '0x8675309::M::Box<R>' can have the ability 'copy' but the type argument 'R' does not have the required ability 'copy'
-   │         │               The type '0x8675309::M::Box<R>' does not have the ability 'copy'
-   │         'copy' constraint not satisifed
-
-error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:30:9
-   │
- 5 │     struct Box3<T1, T2, T3> has copy, drop {}
-   │            ---- To satisfy the constraint, the 'key' ability would need to be added here
-   ·
-15 │     fun rsrc<R: key>(r: R) {
-   │                 --- 'key' constraint declared here
-   ·
-30 │         rsrc(Box3<C, C, C> {});
-   │         ^^^^^^^^^^^^^^^^^^^^^^
-   │         │    │
-   │         │    The type '0x8675309::M::Box3<C, C, C>' does not have the ability 'key'
-   │         'key' constraint not satisifed
-
-error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:32:9
-   │
-11 │     fun cpy<C: copy>(c: C) {
-   │                ---- 'copy' constraint declared here
-   ·
-32 │         cpy(Box3<R, C, C> {});
-   │         ^^^^^^^^^^^^^^^^^^^^^
-   │         │   │    │
-   │         │   │    The type '0x8675309::M::Box3<R, C, C>' can have the ability 'copy' but the type argument 'R' does not have the required ability 'copy'
-   │         │   The type '0x8675309::M::Box3<R, C, C>' does not have the ability 'copy'
-   │         'copy' constraint not satisifed
+33 │         both(new_box<C>(), new_box<R>())
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 'key' constraint not satisifed
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:33:9
    │
-11 │     fun cpy<C: copy>(c: C) {
-   │                ---- 'copy' constraint declared here
+ 7 │     fun new_box<T>(): Box<T> {
+   │                       ------ The type '0x8675309::M::Box<R>' does not have the ability 'copy'
    ·
-33 │         cpy(Box3<C, R, C> {});
-   │         ^^^^^^^^^^^^^^^^^^^^^
-   │         │   │    │
-   │         │   │    The type '0x8675309::M::Box3<C, R, C>' can have the ability 'copy' but the type argument 'C' does not have the required ability 'copy'
-   │         │   The type '0x8675309::M::Box3<C, R, C>' does not have the ability 'copy'
-   │         'copy' constraint not satisifed
-
-error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:34:9
-   │
-11 │     fun cpy<C: copy>(c: C) {
-   │                ---- 'copy' constraint declared here
+15 │     fun both<R: key, C: copy>(r: R, c: C) {
+   │                         ---- 'copy' constraint declared here
    ·
-34 │         cpy(Box3<C, C, R> {});
-   │         ^^^^^^^^^^^^^^^^^^^^^
-   │         │   │    │
-   │         │   │    The type '0x8675309::M::Box3<C, C, R>' can have the ability 'copy' but the type argument 'C' does not have the required ability 'copy'
-   │         │   The type '0x8675309::M::Box3<C, C, R>' does not have the ability 'copy'
-   │         'copy' constraint not satisifed
-
-error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:36:9
-   │
-11 │     fun cpy<C: copy>(c: C) {
-   │                ---- 'copy' constraint declared here
-   ·
-36 │         cpy(Box3<C, R, R> {});
-   │         ^^^^^^^^^^^^^^^^^^^^^
-   │         │   │    │
-   │         │   │    The type '0x8675309::M::Box3<C, R, R>' can have the ability 'copy' but the type argument 'C' does not have the required ability 'copy'
-   │         │   The type '0x8675309::M::Box3<C, R, R>' does not have the ability 'copy'
+33 │         both(new_box<C>(), new_box<R>())
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │                          │
+   │         │                          The type '0x8675309::M::Box<R>' can have the ability 'copy' but the type argument 'R' does not have the required ability 'copy'
    │         'copy' constraint not satisifed
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:37:9
    │
-11 │     fun cpy<C: copy>(c: C) {
-   │                ---- 'copy' constraint declared here
+ 5 │     struct Box3<T1, T2, T3> has copy, drop { f1: T1, f2: T2, f3: T3 }
+   │            ---- To satisfy the constraint, the 'key' ability would need to be added here
    ·
-37 │         cpy(Box3<R, C, R> {});
-   │         ^^^^^^^^^^^^^^^^^^^^^
-   │         │   │    │
-   │         │   │    The type '0x8675309::M::Box3<R, C, R>' can have the ability 'copy' but the type argument 'R' does not have the required ability 'copy'
-   │         │   The type '0x8675309::M::Box3<R, C, R>' does not have the ability 'copy'
-   │         'copy' constraint not satisifed
+11 │     fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
+   │                                 ---------------- The type '0x8675309::M::Box3<C, C, C>' does not have the ability 'key'
+   ·
+23 │     fun rsrc<R: key>(r: R) {
+   │                 --- 'key' constraint declared here
+   ·
+37 │         rsrc(new_box3<C, C, C>());
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^ 'key' constraint not satisifed
 
 error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:38:9
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:39:9
    │
-11 │     fun cpy<C: copy>(c: C) {
+11 │     fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
+   │                                 ---------------- The type '0x8675309::M::Box3<R, C, C>' does not have the ability 'copy'
+   ·
+19 │     fun cpy<C: copy>(c: C) {
    │                ---- 'copy' constraint declared here
    ·
-38 │         cpy(Box3<R, R, C> {});
-   │         ^^^^^^^^^^^^^^^^^^^^^
-   │         │   │    │
-   │         │   │    The type '0x8675309::M::Box3<R, R, C>' can have the ability 'copy' but the type argument 'R' does not have the required ability 'copy'
-   │         │   The type '0x8675309::M::Box3<R, R, C>' does not have the ability 'copy'
+39 │         cpy(new_box3<R, C, C>());
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │            │
+   │         │            The type '0x8675309::M::Box3<R, C, C>' can have the ability 'copy' but the type argument 'R' does not have the required ability 'copy'
    │         'copy' constraint not satisifed
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:40:9
    │
-11 │     fun cpy<C: copy>(c: C) {
+11 │     fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
+   │                                 ---------------- The type '0x8675309::M::Box3<C, R, C>' does not have the ability 'copy'
+   ·
+19 │     fun cpy<C: copy>(c: C) {
    │                ---- 'copy' constraint declared here
    ·
-40 │         cpy(Box3<R, R, R> {});
-   │         ^^^^^^^^^^^^^^^^^^^^^
-   │         │   │    │
-   │         │   │    The type '0x8675309::M::Box3<R, R, R>' can have the ability 'copy' but the type argument 'R' does not have the required ability 'copy'
-   │         │   The type '0x8675309::M::Box3<R, R, R>' does not have the ability 'copy'
+40 │         cpy(new_box3<C, R, C>());
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │            │
+   │         │            The type '0x8675309::M::Box3<C, R, C>' can have the ability 'copy' but the type argument 'C' does not have the required ability 'copy'
+   │         'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:41:9
+   │
+11 │     fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
+   │                                 ---------------- The type '0x8675309::M::Box3<C, C, R>' does not have the ability 'copy'
+   ·
+19 │     fun cpy<C: copy>(c: C) {
+   │                ---- 'copy' constraint declared here
+   ·
+41 │         cpy(new_box3<C, C, R>());
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │            │
+   │         │            The type '0x8675309::M::Box3<C, C, R>' can have the ability 'copy' but the type argument 'C' does not have the required ability 'copy'
+   │         'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:43:9
+   │
+11 │     fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
+   │                                 ---------------- The type '0x8675309::M::Box3<C, R, R>' does not have the ability 'copy'
+   ·
+19 │     fun cpy<C: copy>(c: C) {
+   │                ---- 'copy' constraint declared here
+   ·
+43 │         cpy(new_box3<C, R, R>());
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │            │
+   │         │            The type '0x8675309::M::Box3<C, R, R>' can have the ability 'copy' but the type argument 'C' does not have the required ability 'copy'
    │         'copy' constraint not satisifed
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:44:9
    │
-11 │     fun cpy<C: copy>(c: C) {
+11 │     fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
+   │                                 ---------------- The type '0x8675309::M::Box3<R, C, R>' does not have the ability 'copy'
+   ·
+19 │     fun cpy<C: copy>(c: C) {
    │                ---- 'copy' constraint declared here
    ·
-44 │         cpy(Box3<U, C, C> {});
-   │         ^^^^^^^^^^^^^^^^^^^^^
-   │         │   │    │
-   │         │   │    The type '0x8675309::M::Box3<U, C, C>' can have the ability 'copy' but the type argument 'U' does not have the required ability 'copy'
-   │         │   The type '0x8675309::M::Box3<U, C, C>' does not have the ability 'copy'
+44 │         cpy(new_box3<R, C, R>());
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │            │
+   │         │            The type '0x8675309::M::Box3<R, C, R>' can have the ability 'copy' but the type argument 'R' does not have the required ability 'copy'
    │         'copy' constraint not satisifed
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:45:9
    │
-11 │     fun cpy<C: copy>(c: C) {
+11 │     fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
+   │                                 ---------------- The type '0x8675309::M::Box3<R, R, C>' does not have the ability 'copy'
+   ·
+19 │     fun cpy<C: copy>(c: C) {
    │                ---- 'copy' constraint declared here
    ·
-45 │         cpy(Box3<C, U, C> {});
-   │         ^^^^^^^^^^^^^^^^^^^^^
-   │         │   │    │
-   │         │   │    The type '0x8675309::M::Box3<C, U, C>' can have the ability 'copy' but the type argument 'C' does not have the required ability 'copy'
-   │         │   The type '0x8675309::M::Box3<C, U, C>' does not have the ability 'copy'
+45 │         cpy(new_box3<R, R, C>());
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │            │
+   │         │            The type '0x8675309::M::Box3<R, R, C>' can have the ability 'copy' but the type argument 'R' does not have the required ability 'copy'
    │         'copy' constraint not satisifed
 
 error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:46:9
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:47:9
    │
-11 │     fun cpy<C: copy>(c: C) {
+11 │     fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
+   │                                 ---------------- The type '0x8675309::M::Box3<R, R, R>' does not have the ability 'copy'
+   ·
+19 │     fun cpy<C: copy>(c: C) {
    │                ---- 'copy' constraint declared here
    ·
-46 │         cpy(Box3<C, C, U> {});
-   │         ^^^^^^^^^^^^^^^^^^^^^
-   │         │   │    │
-   │         │   │    The type '0x8675309::M::Box3<C, C, U>' can have the ability 'copy' but the type argument 'C' does not have the required ability 'copy'
-   │         │   The type '0x8675309::M::Box3<C, C, U>' does not have the ability 'copy'
+47 │         cpy(new_box3<R, R, R>());
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │            │
+   │         │            The type '0x8675309::M::Box3<R, R, R>' can have the ability 'copy' but the type argument 'R' does not have the required ability 'copy'
    │         'copy' constraint not satisifed
 
 error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:48:9
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:51:9
    │
-11 │     fun cpy<C: copy>(c: C) {
+11 │     fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
+   │                                 ---------------- The type '0x8675309::M::Box3<U, C, C>' does not have the ability 'copy'
+   ·
+19 │     fun cpy<C: copy>(c: C) {
    │                ---- 'copy' constraint declared here
    ·
-48 │         cpy(Box3<C, U, U> {});
-   │         ^^^^^^^^^^^^^^^^^^^^^
-   │         │   │    │
-   │         │   │    The type '0x8675309::M::Box3<C, U, U>' can have the ability 'copy' but the type argument 'C' does not have the required ability 'copy'
-   │         │   The type '0x8675309::M::Box3<C, U, U>' does not have the ability 'copy'
-   │         'copy' constraint not satisifed
-
-error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:49:9
-   │
-11 │     fun cpy<C: copy>(c: C) {
-   │                ---- 'copy' constraint declared here
-   ·
-49 │         cpy(Box3<U, C, U> {});
-   │         ^^^^^^^^^^^^^^^^^^^^^
-   │         │   │    │
-   │         │   │    The type '0x8675309::M::Box3<U, C, U>' can have the ability 'copy' but the type argument 'U' does not have the required ability 'copy'
-   │         │   The type '0x8675309::M::Box3<U, C, U>' does not have the ability 'copy'
-   │         'copy' constraint not satisifed
-
-error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:50:9
-   │
-11 │     fun cpy<C: copy>(c: C) {
-   │                ---- 'copy' constraint declared here
-   ·
-50 │         cpy(Box3<U, U, C> {});
-   │         ^^^^^^^^^^^^^^^^^^^^^
-   │         │   │    │
-   │         │   │    The type '0x8675309::M::Box3<U, U, C>' can have the ability 'copy' but the type argument 'U' does not have the required ability 'copy'
-   │         │   The type '0x8675309::M::Box3<U, U, C>' does not have the ability 'copy'
+51 │         cpy(new_box3<U, C, C>());
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │            │
+   │         │            The type '0x8675309::M::Box3<U, C, C>' can have the ability 'copy' but the type argument 'U' does not have the required ability 'copy'
    │         'copy' constraint not satisifed
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:52:9
    │
-11 │     fun cpy<C: copy>(c: C) {
+11 │     fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
+   │                                 ---------------- The type '0x8675309::M::Box3<C, U, C>' does not have the ability 'copy'
+   ·
+19 │     fun cpy<C: copy>(c: C) {
    │                ---- 'copy' constraint declared here
    ·
-52 │         cpy(Box3<U, U, U> {});
-   │         ^^^^^^^^^^^^^^^^^^^^^
-   │         │   │    │
-   │         │   │    The type '0x8675309::M::Box3<U, U, U>' can have the ability 'copy' but the type argument 'U' does not have the required ability 'copy'
-   │         │   The type '0x8675309::M::Box3<U, U, U>' does not have the ability 'copy'
+52 │         cpy(new_box3<C, U, C>());
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │            │
+   │         │            The type '0x8675309::M::Box3<C, U, C>' can have the ability 'copy' but the type argument 'C' does not have the required ability 'copy'
+   │         'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:53:9
+   │
+11 │     fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
+   │                                 ---------------- The type '0x8675309::M::Box3<C, C, U>' does not have the ability 'copy'
+   ·
+19 │     fun cpy<C: copy>(c: C) {
+   │                ---- 'copy' constraint declared here
+   ·
+53 │         cpy(new_box3<C, C, U>());
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │            │
+   │         │            The type '0x8675309::M::Box3<C, C, U>' can have the ability 'copy' but the type argument 'C' does not have the required ability 'copy'
+   │         'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:55:9
+   │
+11 │     fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
+   │                                 ---------------- The type '0x8675309::M::Box3<C, U, U>' does not have the ability 'copy'
+   ·
+19 │     fun cpy<C: copy>(c: C) {
+   │                ---- 'copy' constraint declared here
+   ·
+55 │         cpy(new_box3<C, U, U>());
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │            │
+   │         │            The type '0x8675309::M::Box3<C, U, U>' can have the ability 'copy' but the type argument 'C' does not have the required ability 'copy'
+   │         'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:56:9
+   │
+11 │     fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
+   │                                 ---------------- The type '0x8675309::M::Box3<U, C, U>' does not have the ability 'copy'
+   ·
+19 │     fun cpy<C: copy>(c: C) {
+   │                ---- 'copy' constraint declared here
+   ·
+56 │         cpy(new_box3<U, C, U>());
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │            │
+   │         │            The type '0x8675309::M::Box3<U, C, U>' can have the ability 'copy' but the type argument 'U' does not have the required ability 'copy'
+   │         'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:57:9
+   │
+11 │     fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
+   │                                 ---------------- The type '0x8675309::M::Box3<U, U, C>' does not have the ability 'copy'
+   ·
+19 │     fun cpy<C: copy>(c: C) {
+   │                ---- 'copy' constraint declared here
+   ·
+57 │         cpy(new_box3<U, U, C>());
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │            │
+   │         │            The type '0x8675309::M::Box3<U, U, C>' can have the ability 'copy' but the type argument 'U' does not have the required ability 'copy'
+   │         'copy' constraint not satisifed
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:59:9
+   │
+11 │     fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
+   │                                 ---------------- The type '0x8675309::M::Box3<U, U, U>' does not have the ability 'copy'
+   ·
+19 │     fun cpy<C: copy>(c: C) {
+   │                ---- 'copy' constraint declared here
+   ·
+59 │         cpy(new_box3<U, U, U>());
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │            │
+   │         │            The type '0x8675309::M::Box3<U, U, U>' can have the ability 'copy' but the type argument 'U' does not have the required ability 'copy'
    │         'copy' constraint not satisifed
 

--- a/language/move-lang/tests/move_check/typing/module_call_constraints_not_satisfied.move
+++ b/language/move-lang/tests/move_check/typing/module_call_constraints_not_satisfied.move
@@ -1,8 +1,16 @@
 module 0x8675309::M {
     struct S has copy, drop {}
     struct Coin has key {}
-    struct Box<T> has copy, drop {}
-    struct Box3<T1, T2, T3> has copy, drop {}
+    struct Box<T> has copy, drop { f: T }
+    struct Box3<T1, T2, T3> has copy, drop { f1: T1, f2: T2, f3: T3 }
+
+    fun new_box<T>(): Box<T> {
+        abort 0
+    }
+
+    fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
+        abort 0
+    }
 
     fun both<R: key, C: copy>(r: R, c: C) {
         abort 0
@@ -16,39 +24,38 @@ module 0x8675309::M {
         abort 0
     }
 
-
     fun t0() {
         both(S{}, Coin{});
         both(0, Coin{})
     }
 
     fun t1<R: key, C: drop>() {
-        both(Box<C> {}, Box<R> {})
+        both(new_box<C>(), new_box<R>())
     }
 
     fun t2<R: key, C: drop>() {
-        rsrc(Box3<C, C, C> {});
+        rsrc(new_box3<C, C, C>());
 
-        cpy(Box3<R, C, C> {});
-        cpy(Box3<C, R, C> {});
-        cpy(Box3<C, C, R> {});
+        cpy(new_box3<R, C, C>());
+        cpy(new_box3<C, R, C>());
+        cpy(new_box3<C, C, R>());
 
-        cpy(Box3<C, R, R> {});
-        cpy(Box3<R, C, R> {});
-        cpy(Box3<R, R, C> {});
+        cpy(new_box3<C, R, R>());
+        cpy(new_box3<R, C, R>());
+        cpy(new_box3<R, R, C>());
 
-        cpy(Box3<R, R, R> {});
+        cpy(new_box3<R, R, R>());
     }
 
     fun t3<U, C: drop>() {
-        cpy(Box3<U, C, C> {});
-        cpy(Box3<C, U, C> {});
-        cpy(Box3<C, C, U> {});
+        cpy(new_box3<U, C, C>());
+        cpy(new_box3<C, U, C>());
+        cpy(new_box3<C, C, U>());
 
-        cpy(Box3<C, U, U> {});
-        cpy(Box3<U, C, U> {});
-        cpy(Box3<U, U, C> {});
+        cpy(new_box3<C, U, U>());
+        cpy(new_box3<U, C, U>());
+        cpy(new_box3<U, U, C>());
 
-        cpy(Box3<U, U, U> {});
+        cpy(new_box3<U, U, U>());
     }
 }

--- a/language/move-lang/tests/move_check/typing/neq.move
+++ b/language/move-lang/tests/move_check/typing/neq.move
@@ -3,7 +3,7 @@ module 0x8675309::M {
     struct R {
         f: u64
     }
-    struct G<T> has drop {}
+    struct G<T> has drop { f: T }
 
     fun t0(r: &R, r_mut: &mut R, s: S, s_ref: &S, s_mut: &mut S) {
         (0 != 1: bool);
@@ -25,7 +25,7 @@ module 0x8675309::M {
         (r_mut != r_mut: bool);
         (r != r_mut: bool);
         (r_mut != r: bool);
-        (G {} != G<u64> {}: bool);
-        (G<u64> {} != G {}: bool);
+        (G { f: 1 } != G<u64> { f: 2 }: bool);
+        (G<u64> { f: 1 } != G { f: 2 }: bool);
     }
 }

--- a/language/move-lang/tests/move_check/typing/neq_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/neq_invalid.exp
@@ -117,7 +117,7 @@ error[E04010]: cannot infer type
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/neq_invalid.move:27:9
    │
- 7 │     struct G1<T: key> {}
+ 7 │     struct G1<phantom T: key> {}
    │            -- To satisfy the constraint, the 'drop' ability would need to be added here
    ·
 27 │         G1{} != G1{};
@@ -135,7 +135,7 @@ error[E04010]: cannot infer type
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/neq_invalid.move:27:17
    │
- 7 │     struct G1<T: key> {}
+ 7 │     struct G1<phantom T: key> {}
    │            -- To satisfy the constraint, the 'drop' ability would need to be added here
    ·
 27 │         G1{} != G1{};
@@ -153,7 +153,7 @@ error[E04010]: cannot infer type
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/neq_invalid.move:28:9
    │
- 8 │     struct G2<T> {}
+ 8 │     struct G2<phantom T> {}
    │            -- To satisfy the constraint, the 'drop' ability would need to be added here
    ·
 28 │         G2{} != G2{};
@@ -171,7 +171,7 @@ error[E04010]: cannot infer type
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/neq_invalid.move:28:17
    │
- 8 │     struct G2<T> {}
+ 8 │     struct G2<phantom T> {}
    │            -- To satisfy the constraint, the 'drop' ability would need to be added here
    ·
 28 │         G2{} != G2{};

--- a/language/move-lang/tests/move_check/typing/neq_invalid.move
+++ b/language/move-lang/tests/move_check/typing/neq_invalid.move
@@ -3,9 +3,9 @@ module 0x8675309::M {
     struct R {
         f: u64
     }
-    struct G0<T> has drop {}
-    struct G1<T: key> {}
-    struct G2<T> {}
+    struct G0<phantom T> has drop {}
+    struct G1<phantom T: key> {}
+    struct G2<phantom T> {}
 
 
 

--- a/language/move-lang/tests/move_check/typing/type_variable_join_threaded_pack.move
+++ b/language/move-lang/tests/move_check/typing/type_variable_join_threaded_pack.move
@@ -1,10 +1,10 @@
 address 0x2 {
 
 module Container {
-    struct T<V> has drop {}
+    struct T<V> has drop { f: V }
 
     public fun new<V>(): T<V> {
-        T {}
+        abort 0
     }
 
     public fun get<V: drop>(_self: &T<V>): V {

--- a/language/move-lang/tests/move_check/typing/type_variable_join_threaded_pack_invalid.move
+++ b/language/move-lang/tests/move_check/typing/type_variable_join_threaded_pack_invalid.move
@@ -1,10 +1,10 @@
 address 0x2 {
 
 module Container {
-    struct T<V> {}
+    struct T<V> { f: V }
 
     public fun new<V>(): T<V> {
-        T {}
+        abort 0
     }
 
     public fun get<V: drop>(self: &T<V>): V {

--- a/language/move-lang/tests/move_check/typing/type_variable_join_threaded_unpack.move
+++ b/language/move-lang/tests/move_check/typing/type_variable_join_threaded_unpack.move
@@ -1,10 +1,10 @@
 address 0x2 {
 
 module Container {
-    struct T<V> has drop {}
+    struct T<V> has drop { f: V }
 
     public fun new<V>(): T<V> {
-        T {}
+        abort 0
     }
 
     public fun get<V: drop>(_self: &T<V>): V {

--- a/language/move-lang/tests/move_check/typing/type_variable_join_threaded_unpack_assign.move
+++ b/language/move-lang/tests/move_check/typing/type_variable_join_threaded_unpack_assign.move
@@ -1,10 +1,10 @@
 address 0x2 {
 
 module Container {
-    struct T<V> has drop {}
+    struct T<V> has drop { f: V }
 
     public fun new<V>(): T<V> {
-        T {}
+        abort 0
     }
 
     public fun get<V: drop>(_self: &T<V>): V {

--- a/language/move-lang/tests/move_check/typing/type_variable_join_threaded_unpack_assign_invalid.move
+++ b/language/move-lang/tests/move_check/typing/type_variable_join_threaded_unpack_assign_invalid.move
@@ -1,10 +1,10 @@
 address 0x2 {
 
 module Container {
-    struct T<V> has drop {}
+    struct T<V> has drop { f: V }
 
     public fun new<V>(): T<V> {
-        T {}
+        abort 0
     }
 
     public fun get<V: drop>(self: &T<V>): V {

--- a/language/move-lang/tests/move_check/typing/type_variable_join_threaded_unpack_invalid.move
+++ b/language/move-lang/tests/move_check/typing/type_variable_join_threaded_unpack_invalid.move
@@ -1,10 +1,10 @@
 address 0x2 {
 
 module Container {
-    struct T<V> has drop {}
+    struct T<V> has drop { f: V }
 
     public fun new<V>(): T<V> {
-        T {}
+        abort 0
     }
 
     public fun get<V: drop>(self: &T<V>): V {

--- a/language/move-lang/tests/move_check/typing/uninferred_type_pack.move
+++ b/language/move-lang/tests/move_check/typing/uninferred_type_pack.move
@@ -1,5 +1,5 @@
 module 0x8675309::M {
-    struct S<T> has drop {}
+    struct S<phantom T> has drop {}
 
     fun t() {
         S{};

--- a/language/move-lang/tests/move_check/typing/uninferred_type_unpack_assign.move
+++ b/language/move-lang/tests/move_check/typing/uninferred_type_unpack_assign.move
@@ -1,5 +1,5 @@
 module 0x8675309::M {
-    struct S<T> {}
+    struct S<phantom T> {}
 
     fun t() {
         S{} = S{};

--- a/language/move-lang/tests/move_check/typing/uninferred_type_unpack_bind.move
+++ b/language/move-lang/tests/move_check/typing/uninferred_type_unpack_bind.move
@@ -1,5 +1,5 @@
 module 0x8675309::M {
-    struct S<T> {}
+    struct S<phantom T> { }
 
     fun t() {
         let S{} = S{};

--- a/language/move-lang/tests/move_check/typing/uninferred_type_unpack_decl.move
+++ b/language/move-lang/tests/move_check/typing/uninferred_type_unpack_decl.move
@@ -1,5 +1,5 @@
 module 0x8675309::M {
-    struct S<T> {}
+    struct S<phantom T> { }
 
     fun t() {
         let S{};

--- a/language/move-lang/tests/move_check/typing/valid_acquire.exp
+++ b/language/move-lang/tests/move_check/typing/valid_acquire.exp
@@ -1,12 +1,12 @@
 error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_check/typing/valid_acquire.move:43:16
+   ┌─ tests/move_check/typing/valid_acquire.move:43:22
    │
-43 │         R3{} = move_from<R3<R1>>(a);
-   │                ^^^^^^^^^^^^^^^^^^^^
-   │                │         │  │
-   │                │         │  The type '0x8675309::M::R3<0x8675309::M::R1>' can have the ability 'key' but the type argument '0x8675309::M::R1' does not have the required ability 'store'
-   │                │         The type '0x8675309::M::R3<0x8675309::M::R1>' does not have the ability 'key'
-   │                Invalid call of 'move_from'
+43 │         R3{ f: _ } = move_from<R3<R1>>(a);
+   │                      ^^^^^^^^^^^^^^^^^^^^
+   │                      │         │  │
+   │                      │         │  The type '0x8675309::M::R3<0x8675309::M::R1>' can have the ability 'key' but the type argument '0x8675309::M::R1' does not have the required ability 'store'
+   │                      │         The type '0x8675309::M::R3<0x8675309::M::R1>' does not have the ability 'key'
+   │                      Invalid call of 'move_from'
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/valid_acquire.move:45:9
@@ -31,8 +31,8 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/valid_acquire.move:52:9
    │
-52 │         move_to<R3<R2>>(account, R3{});
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+52 │         move_to<R3<R2>>(account, R3{ f: R2{} });
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │         │       │  │
    │         │       │  The type '0x8675309::M::R3<0x8675309::M::R2>' can have the ability 'key' but the type argument '0x8675309::M::R2' does not have the required ability 'store'
    │         │       The type '0x8675309::M::R3<0x8675309::M::R2>' does not have the ability 'key'

--- a/language/move-lang/tests/move_check/typing/valid_acquire.move
+++ b/language/move-lang/tests/move_check/typing/valid_acquire.move
@@ -1,7 +1,7 @@
 module 0x8675309::M {
-    struct R1 has key {}
+    struct R1 has key, drop {}
     struct R2 has key {}
-    struct R3<T> has key {}
+    struct R3<T> has key { f: T }
 
     fun foo1(a: address) acquires R1 {
         borrow_global<R1>(a);
@@ -39,8 +39,8 @@ module 0x8675309::M {
     }
 
     fun t5(a: address) acquires R3 {
-        R3{} = move_from<R3<u64>>(a);
-        R3{} = move_from<R3<R1>>(a);
+        R3{ f: _ } = move_from<R3<u64>>(a);
+        R3{ f: _ } = move_from<R3<R1>>(a);
         borrow_global_mut<R3<bool>>(a);
         borrow_global_mut<R3<R2>>(a);
     }
@@ -48,8 +48,8 @@ module 0x8675309::M {
     fun t6(account: &signer, a: address) {
         exists<R3<u64>>(a);
         exists<R3<R1>>(a);
-        move_to<R3<bool>>(account, R3{});
-        move_to<R3<R2>>(account, R3{});
+        move_to<R3<bool>>(account, R3{ f: true });
+        move_to<R3<R2>>(account, R3{ f: R2{} });
     }
 
 }

--- a/language/move-prover/bytecode/tests/from_move/regression_generic_and_native_type.move
+++ b/language/move-prover/bytecode/tests/from_move/regression_generic_and_native_type.move
@@ -11,17 +11,17 @@ module Diem {
     use Std::Vector;
 
     // A resource representing a fungible token
-    struct T<Token> has key, store {
+    struct T<phantom Token> has key, store {
         // The value of the token. May be zero
         value: u64,
     }
 
-    struct Info<Token> has key {
+    struct Info<phantom Token> has key {
         total_value: u128,
         preburn_value: u64,
     }
 
-    struct Preburn<Token> has key {
+    struct Preburn<phantom Token> has key {
         requests: vector<T<Token>>,
         is_approved: bool,
     }

--- a/language/move-prover/tests/sources/functional/script_provider.move
+++ b/language/move-prover/tests/sources/functional/script_provider.move
@@ -12,7 +12,7 @@ module ScriptProvider {
     }
 
 
-    struct Info<T> has key {}
+    struct Info<phantom T> has key {}
 
     public fun register<T: store>(account: &signer) {
         assert(Signer::address_of(account) == @0x1, 1);

--- a/language/move-prover/tests/sources/regression/mutrefbug030521.move
+++ b/language/move-prover/tests/sources/regression/mutrefbug030521.move
@@ -1,6 +1,6 @@
 module 0x42::Bug {
 
-    struct Diem<CointType> {
+    struct Diem<phantom CoinType> {
         /// The value of this coin in the base units for `CoinType`
         value: u64
     }

--- a/language/move-prover/tests/sources/regression/performance_200511.move
+++ b/language/move-prover/tests/sources/regression/performance_200511.move
@@ -13,7 +13,7 @@ module 0x42::Test {
         }
     }
 
-    struct EventHandle<T: copy + drop + store> has copy, drop, store {
+    struct EventHandle<phantom T: copy + drop + store> has copy, drop, store {
         // Total number of events emitted to this event stream.
         counter: u64,
         // A globally unique ID for this event stream.

--- a/language/move-prover/tests/sources/regression/type_param_bug_200228.move
+++ b/language/move-prover/tests/sources/regression/type_param_bug_200228.move
@@ -1,7 +1,7 @@
 module 0x42::Test {
 
-  struct Balance<Token> has key {}
-  struct EventHandle<Token> has key {}
+  struct Balance<phantom Token> has key {}
+  struct EventHandle<phantom Token> has key {}
 
   fun type_param_bug<Tok_1: store, Tok_2: store>(addr: address): address {
     addr

--- a/language/tools/move-unit-test/tests/test_sources/proposal_test.move
+++ b/language/tools/move-unit-test/tests/test_sources/proposal_test.move
@@ -8,7 +8,7 @@ module TestonlyModule {
 }
 
 module Module {
-    struct B<T> has key { t: u64 }
+    struct B<phantom T> has key { t: u64 }
     struct A has key {t: u64}
 
     fun a(a: u64): bool {


### PR DESCRIPTION
Update tests so type parameters in struct definitions are used as the type of a field or they are correctly marked as phantom.

## Motivation

We want to implement a lint that will warn if a type parameter could have been defined as phantom. This PR update tests so they don't warn on that new lint.

## Test Plan

This PR should not change the behavior of tests