### PR TITLE
[scripts] Creating ~/bin if it doesn't exist

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -455,6 +455,7 @@ function install_z3 {
     cd "$TMPFILE" || exit
     curl -LOs "https://github.com/Z3Prover/z3/releases/download/z3-$Z3_VERSION/$Z3_PKG.zip"
     unzip -q "$Z3_PKG.zip"
+    mkdir -p "$HOME/bin"
     cp "$Z3_PKG/bin/z3" "$HOME/bin"
     chmod +x "$HOME/bin/z3"
   )


### PR DESCRIPTION
## Motivation
The script does not ensure ~/bin exists.
This causes problems with fresh installations without ~/bin.

Since there is no such functionality in standard "cp",
running "mkdir -p" before copying, as recommended here:
https://stackoverflow.com/q/1529946.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes. The file, that is. It does not contain the referred chapter "pull-requests" anymore, though :slightly_smiling_face: 

## Test Plan

Ran `./scripts/dev_setup.sh -y` successfully, without errors.

## Related PRs

No related PRs.

## If targeting a release branch, please fill the below out as well

Targeting `main`, not a specific release.
