### PR TITLE
[forge] clean up k8s backend with re-genesis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3259,6 +3259,7 @@ dependencies = [
  "kube",
  "rand 0.8.3",
  "rand_core 0.6.2",
+ "rayon",
  "reqwest",
  "serde_json",
  "structopt 0.3.21",

--- a/testsuite/forge/Cargo.toml
+++ b/testsuite/forge/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = { version = "1.0", features = ["backtrace"] }
 futures = "0.3.12"
 itertools = "0.10.0"
 rand = "0.8.3"
+rayon = "1.5.0"
 structopt = "0.3.21"
 termcolor = "1.1.2"
 tokio = { version = "1.8.1", features = ["full"] }

--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -14,8 +14,7 @@ use diem_sdk::{
         AccountKey, LocalAccount, PeerId,
     },
 };
-use k8s_openapi::api::batch::v1::Job;
-use k8s_openapi::api::core::v1::Service;
+use k8s_openapi::api::{batch::v1::Job, core::v1::Service};
 use kube::{
     api::{Api, ListParams},
     client::Client as K8sClient,
@@ -386,7 +385,7 @@ pub fn clean_k8s_cluster(
                 match status.succeeded {
                     Some(1) => {
                         println!("Genesis job completed");
-                        return Ok(());
+                        Ok(())
                     }
                     _ => bail!("Genesis job not completed"),
                 }

--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -5,7 +5,7 @@ use crate::{
     backend::k8s::node::K8sNode, query_sequence_numbers, ChainInfo, FullNode, Node, Result, Swarm,
     Validator,
 };
-use anyhow::format_err;
+use anyhow::{bail, format_err};
 use diem_logger::*;
 use diem_sdk::{
     crypto::ed25519::Ed25519PrivateKey,
@@ -14,18 +14,27 @@ use diem_sdk::{
         AccountKey, LocalAccount, PeerId,
     },
 };
+use k8s_openapi::api::batch::v1::Job;
 use k8s_openapi::api::core::v1::Service;
 use kube::{
     api::{Api, ListParams},
     client::Client as K8sClient,
     Config,
 };
-use std::{collections::HashMap, convert::TryFrom, process::Command};
+use serde_json::Value;
+use std::{
+    collections::HashMap,
+    convert::TryFrom,
+    process::{Command, Stdio},
+    str,
+};
 use tokio::{runtime::Runtime, time::Duration};
 
 const HEALTH_CHECK_URL: &str = "http://127.0.0.1:8001";
-const KUBECTL_BIN: &str = "/root/bin/kubectl";
+const KUBECTL_BIN: &str = "kubectl";
+const HELM_BIN: &str = "helm";
 const JSON_RPC_PORT: u32 = 80;
+const DEFL_NUM_VALIDATORS: u32 = 4; // 30 for forge-*nets
 const VALIDATOR_LB: &str = "validator-fullnode-lb";
 
 pub struct K8sSwarm {
@@ -142,6 +151,13 @@ impl K8sSwarm {
     #[allow(dead_code)]
     fn get_kube_client(&self) -> K8sClient {
         self.kube_client.clone()
+    }
+}
+
+impl Drop for K8sSwarm {
+    // When the Process struct goes out of scope we need to wipe the chain state
+    fn drop(&mut self) {
+        clean_k8s_cluster_internal();
     }
 }
 
@@ -279,4 +295,104 @@ fn load_root_key(root_key_bytes: &[u8]) -> Ed25519PrivateKey {
 
 fn load_tc_key(tc_key_bytes: &[u8]) -> Ed25519PrivateKey {
     Ed25519PrivateKey::try_from(tc_key_bytes).unwrap()
+}
+
+fn clean_k8s_cluster_internal() {
+    clean_k8s_cluster("testnet-internal".to_string())
+        .map_err(|err| format_err!("Failed to clean k8s cluster with new genesis: {}", err))
+        .unwrap()
+}
+
+pub fn clean_k8s_cluster(helm_repo: String) -> Result<(), anyhow::Error> {
+    let rt = Runtime::new().unwrap();
+
+    // get the previous chain era
+    let raw_helm_values = Command::new(HELM_BIN)
+        // .stdout(Stdio::inherit())
+        .arg("get")
+        .arg("values")
+        .arg("diem")
+        .arg("--output")
+        .arg("json")
+        .output()
+        .unwrap();
+
+    // parse genesis
+    let helm_values = String::from_utf8(raw_helm_values.stdout).unwrap();
+    let v: Value = serde_json::from_str(&helm_values).unwrap();
+    let era = &v["genesis"]["era"];
+    let num_validators = &v["genesis"]["numValidators"];
+    let new_era;
+    if era == 1 {
+        new_era = 2;
+    } else {
+        new_era = 1;
+    }
+
+    println!("genesis.era: {} --> {}", era, new_era);
+    println!(
+        "genesis.numValidators: {} --> {}",
+        num_validators, DEFL_NUM_VALIDATORS
+    );
+
+    // upgrade testnet
+    let testnet_upgrade_args = [
+        "upgrade",
+        "diem",
+        &format!("{}/testnet", helm_repo),
+        "--reuse-values",
+        "--set",
+        &format!("genesis.era={}", new_era),
+        "--set",
+        &format!("genesis.numValidators={}", DEFL_NUM_VALIDATORS),
+    ];
+    println!("{:?}", testnet_upgrade_args);
+    let testnet_upgrade_output = Command::new(HELM_BIN)
+        .stdout(Stdio::inherit())
+        .args(&testnet_upgrade_args)
+        .output()
+        .expect("failed to helm upgrade diem");
+    assert!(testnet_upgrade_output.status.success());
+
+    // upgrade validators
+    for i in 0..DEFL_NUM_VALIDATORS {
+        let validator_upgrade_args = [
+            "upgrade",
+            &format!("val{}", i),
+            &format!("{}/diem-validator", helm_repo),
+            "--reuse-values",
+            "--set",
+            &format!("chain.era={}", new_era),
+        ];
+        println!("{:?}", validator_upgrade_args);
+        let validator_upgrade_output = Command::new(HELM_BIN)
+            .stdout(Stdio::inherit())
+            .args(&validator_upgrade_args)
+            .output()
+            .expect("failed to helm upgrade diem");
+        assert!(validator_upgrade_output.status.success());
+    }
+
+    let kube_client = rt.block_on(K8sClient::try_default()).unwrap();
+
+    rt.block_on(async {
+        diem_retrier::retry_async(k8s_retry_strategy(), || {
+            let jobs: Api<Job> = Api::namespaced(kube_client.clone(), "default");
+            Box::pin(async move {
+                let job_name = format!("diem-testnet-genesis-e{}", new_era);
+                println!("Running get job: {}", &job_name);
+                let genesis_job = jobs.get_status(&job_name).await.unwrap();
+                println!("Status: {:?}", genesis_job.status);
+                let status = genesis_job.status.unwrap();
+                match status.succeeded {
+                    Some(1) => {
+                        println!("Genesis job completed");
+                        return Ok(());
+                    }
+                    _ => bail!("Genesis job not completed"),
+                }
+            })
+        })
+        .await
+    })
 }

--- a/testsuite/forge/src/main.rs
+++ b/testsuite/forge/src/main.rs
@@ -21,16 +21,6 @@ struct Args {
     )]
     local_swarm: bool,
 
-    #[structopt(long, help = "If set, wipes the state of the test backend and exits")]
-    clean_up: bool,
-
-    #[structopt(
-        long,
-        help = "Override the helm repo used for k8s tests",
-        default_value = "testnet-internal"
-    )]
-    helm_repo: String,
-
     // emit_tx options
     #[structopt(long, default_value = "15")]
     accounts_per_client: usize,
@@ -43,6 +33,18 @@ struct Args {
     )]
     duration: u64,
 
+    // operator options
+    #[structopt(long, help = "If set, wipes the state of the test backend and exits")]
+    clean_up: bool,
+    #[structopt(
+        long,
+        help = "Override the helm repo used for k8s tests",
+        default_value = "testnet-internal"
+    )]
+    helm_repo: String,
+    #[structopt(long, default_value = "30")]
+    num_validators: usize,
+
     #[structopt(flatten)]
     options: Options,
 }
@@ -51,7 +53,7 @@ fn main() -> Result<()> {
     let args = Args::from_args();
 
     if args.clean_up {
-        return clean_k8s_cluster(args.helm_repo);
+        return clean_k8s_cluster(args.helm_repo, args.num_validators);
     }
 
     if args.local_swarm {

--- a/testsuite/forge/src/main.rs
+++ b/testsuite/forge/src/main.rs
@@ -21,6 +21,16 @@ struct Args {
     )]
     local_swarm: bool,
 
+    #[structopt(long, help = "If set, wipes the state of the test backend and exits")]
+    clean_up: bool,
+
+    #[structopt(
+        long,
+        help = "Override the helm repo used for k8s tests",
+        default_value = "testnet-internal"
+    )]
+    helm_repo: String,
+
     // emit_tx options
     #[structopt(long, default_value = "15")]
     accounts_per_client: usize,
@@ -39,6 +49,10 @@ struct Args {
 
 fn main() -> Result<()> {
     let args = Args::from_args();
+
+    if args.clean_up {
+        return clean_k8s_cluster(args.helm_repo);
+    }
 
     if args.local_swarm {
         forge_main(

--- a/testsuite/forge/src/main.rs
+++ b/testsuite/forge/src/main.rs
@@ -63,7 +63,11 @@ fn main() -> Result<()> {
             &args.options,
         )
     } else {
-        forge_main(k8s_test_suite(), K8sFactory::new().unwrap(), &args.options)
+        forge_main(
+            k8s_test_suite(),
+            K8sFactory::new(args.helm_repo).unwrap(),
+            &args.options,
+        )
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

After Forge tests against the k8s swarm backend, clean up the cluster by re-running genesis against a new chain era. This involves performing a helm upgrade for the testnet release (monitoring, genesis, etc.) as well as the same for each of the validator releases. We then wait for the genesis job to complete.

EDIT: make `helm_repo` a property of each `K8sSwarm`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I've introduced some new CLI args that lets an operator use `forge` directly. I've used this against my test cluster and verified the chain is wiped:

```
$ target/debug/forge --clean-up --helm-repo rustietest-internal --num-validators 4

genesis.era: 1 --> 2
genesis.numValidators: 4 --> 4
["upgrade", "diem", "rustietest-internal/testnet", "--reuse-values", "--set", "genesis.era=2", "--set", "genesis.numValidators=4"]
Release "diem" has been upgraded. Happy Helming!
NAME: diem
LAST DEPLOYED: Wed Jul 21 13:42:24 2021
NAMESPACE: default
STATUS: deployed
REVISION: 29
TEST SUITE: None
["upgrade", "val1", "rustietest-internal/diem-validator", "--reuse-values", "--set", "chain.era=2"]
["upgrade", "val0", "rustietest-internal/diem-validator", "--reuse-values", "--set", "chain.era=2"]
["upgrade", "val3", "rustietest-internal/diem-validator", "--reuse-values", "--set", "chain.era=2"]
["upgrade", "val2", "rustietest-internal/diem-validator", "--reuse-values", "--set", "chain.era=2"]
Release "val0" has been upgraded. Happy Helming!
NAME: val0
LAST DEPLOYED: Wed Jul 21 13:42:51 2021
NAMESPACE: default
STATUS: deployed
REVISION: 19
TEST SUITE: None
Release "val3" has been upgraded. Happy Helming!
NAME: val3
LAST DEPLOYED: Wed Jul 21 13:42:56 2021
NAMESPACE: default
STATUS: deployed
REVISION: 19
TEST SUITE: None
Release "val1" has been upgraded. Happy Helming!
NAME: val1
LAST DEPLOYED: Wed Jul 21 13:42:57 2021
NAMESPACE: default
STATUS: deployed
REVISION: 19
TEST SUITE: None
Release "val2" has been upgraded. Happy Helming!
NAME: val2
LAST DEPLOYED: Wed Jul 21 13:42:57 2021
NAMESPACE: default
STATUS: deployed
REVISION: 19
TEST SUITE: None
Running get job: diem-testnet-genesis-e2
Status: Some(JobStatus { active: None, completion_time: Some(Time(2021-07-21T20:43:07Z)), conditions: Some([JobCondition { last_probe_time: Some(Time(2021-07-21T20:43:07Z)), last_transition_time: Some(Time(2021-07-21T20:43:07Z)), message: None, reason: None, status: "True", type_: "Complete" }]), failed: None, start_time: Some(Time(2021-07-21T20:42:38Z)), succeeded: Some(1) })
Genesis job completed
target/debug/forge --clean-up --helm-repo rustietest-internal --num-validator  23.81s user 8.64s system 40% cpu 1:19.24 total
```
