### PR TITLE
[move-model] Implement apis to get normalized types

### DIFF
--- a/language/move-binary-format/src/normalized.rs
+++ b/language/move-binary-format/src/normalized.rs
@@ -211,6 +211,13 @@ impl Type {
             return None;
         })
     }
+
+    pub fn into_struct_tag(self) -> Option<StructTag> {
+        match self.into_type_tag()? {
+            TypeTag::Struct(s) => Some(s),
+            _ => None,
+        }
+    }
 }
 
 impl Field {

--- a/language/move-binary-format/src/normalized.rs
+++ b/language/move-binary-format/src/normalized.rs
@@ -218,6 +218,34 @@ impl Type {
             _ => None,
         }
     }
+
+    pub fn subst(&self, type_args: &[Type]) -> Self {
+        use Type::*;
+        match self {
+            Bool | U8 | U64 | U128 | Address | Signer => self.clone(),
+            Reference(ty) => Reference(Box::new(ty.subst(type_args))),
+            MutableReference(ty) => MutableReference(Box::new(ty.subst(type_args))),
+            Vector(t) => Vector(Box::new(t.subst(type_args))),
+            Struct {
+                address,
+                module,
+                name,
+                type_arguments,
+            } => Struct {
+                address: *address,
+                module: module.clone(),
+                name: name.clone(),
+                type_arguments: type_arguments
+                    .iter()
+                    .map(|t| t.subst(type_arguments))
+                    .collect::<Vec<_>>(),
+            },
+            TypeParameter(i) => type_args
+                .get(*i as usize)
+                .expect("Type parameter index out of bound")
+                .clone(),
+        }
+    }
 }
 
 impl Field {
@@ -277,5 +305,66 @@ impl Function {
                 .collect(),
         };
         (name, f)
+    }
+}
+
+impl From<&TypeTag> for Type {
+    fn from(ty: &TypeTag) -> Type {
+        use Type::*;
+        match ty {
+            TypeTag::Bool => Bool,
+            TypeTag::U8 => U8,
+            TypeTag::U64 => U64,
+            TypeTag::U128 => U128,
+            TypeTag::Address => Address,
+            TypeTag::Signer => Signer,
+            TypeTag::Vector(ty) => Vector(Box::new(Type::from(&**ty))),
+            TypeTag::Struct(s) => Struct {
+                address: s.address,
+                module: s.module.clone(),
+                name: s.name.clone(),
+                type_arguments: s.type_params.iter().map(|ty| ty.into()).collect(),
+            },
+        }
+    }
+}
+
+impl std::fmt::Display for Type {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Type::Struct {
+                address,
+                module,
+                name,
+                type_arguments,
+            } => {
+                write!(
+                    f,
+                    "0x{}::{}::{}",
+                    address.short_str_lossless(),
+                    module,
+                    name
+                )?;
+                if let Some(first_ty) = type_arguments.first() {
+                    write!(f, "<")?;
+                    write!(f, "{}", first_ty)?;
+                    for ty in type_arguments.iter().skip(1) {
+                        write!(f, ", {}", ty)?;
+                    }
+                    write!(f, ">")?;
+                }
+                Ok(())
+            }
+            Type::Vector(ty) => write!(f, "Vector<{}>", ty),
+            Type::U8 => write!(f, "U8"),
+            Type::U64 => write!(f, "U64"),
+            Type::U128 => write!(f, "U128"),
+            Type::Address => write!(f, "Address"),
+            Type::Signer => write!(f, "Signer"),
+            Type::Bool => write!(f, "Bool"),
+            Type::Reference(r) => write!(f, "&{}", r),
+            Type::MutableReference(r) => write!(f, "&mut {}", r),
+            Type::TypeParameter(i) => write!(f, "#{:?}", i),
+        }
     }
 }

--- a/language/move-model/src/ty.rs
+++ b/language/move-model/src/ty.rs
@@ -8,6 +8,7 @@ use crate::{
     model::{GlobalEnv, ModuleId, StructEnv, StructId},
     symbol::{Symbol, SymbolPool},
 };
+use move_binary_format::normalized::Type as MType;
 use move_core_types::language_storage::{StructTag, TypeTag};
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -80,16 +81,16 @@ impl PrimitiveType {
         }
     }
 
-    /// Attempt to convert this type into a language_storage::TypeTag
-    pub fn into_type_tag(self) -> Option<TypeTag> {
+    /// Attempt to convert this type into a normalized::Type
+    pub fn into_normalized_type(self) -> Option<MType> {
         use PrimitiveType::*;
         Some(match self {
-            Bool => TypeTag::Bool,
-            U8 => TypeTag::U8,
-            U64 => TypeTag::U64,
-            U128 => TypeTag::U128,
-            Address => TypeTag::Address,
-            Signer => TypeTag::Signer,
+            Bool => MType::Bool,
+            U8 => MType::U8,
+            U64 => MType::U64,
+            U128 => MType::U128,
+            Address => MType::Address,
+            Signer => MType::Signer,
             Num | Range | TypeValue | EventStore => return None,
         })
     }
@@ -393,45 +394,42 @@ impl Type {
         }
     }
 
-    pub fn into_struct_tag(self, env: &GlobalEnv) -> Option<StructTag> {
+    /// Attempt to convert this type into a normalized::Type
+    pub fn into_struct_type(self, env: &GlobalEnv) -> Option<MType> {
         use Type::*;
-        if self.is_open() {
-            None
-        } else {
-            Some (
-                match self {
-		    Struct(mid, sid, ts) =>
-                        env.get_struct_tag(mid, sid, &ts)
-                            .expect("Invariant violation: struct type argument contains incomplete, tuple, reference, or spec type"),
+        Some(match self {
+            Struct(mid, sid, ts) => env.get_struct_type(mid, sid, &ts),
+            _ => return None,
+        })
+    }
 
-                    _ => return None
-		}
-	    )
-        }
+    /// Attempt to convert this type into a normalized::Type
+    pub fn into_normalized_type(self, env: &GlobalEnv) -> Option<MType> {
+        use Type::*;
+        Some (
+                match self {
+                    Primitive(p) => p.into_normalized_type().expect("Invariant violation: unexpected spec primitive"),
+                    Struct(mid, sid, ts) =>
+                        env.get_struct_type(mid, sid, &ts),
+                    Vector(et) => MType::Vector(
+                        Box::new(et.into_normalized_type(env)
+                                 .expect("Invariant violation: vector type argument contains incomplete, tuple, reference, or spec type"))
+                    ),
+                    TypeParameter(idx) => MType::TypeParameter(idx as u16),
+                    Tuple(..) | Error | Fun(..) | TypeDomain(..) | ResourceDomain(..) | TypeLocal(..) | Var(..) | Reference(..) =>
+                        return None
+                }
+            )
+    }
+
+    /// Attempt to convert this type into a language_storage::StructTag
+    pub fn into_struct_tag(self, env: &GlobalEnv) -> Option<StructTag> {
+        self.into_struct_type(env)?.into_struct_tag()
     }
 
     /// Attempt to convert this type into a language_storage::TypeTag
     pub fn into_type_tag(self, env: &GlobalEnv) -> Option<TypeTag> {
-        use Type::*;
-        if self.is_open() || self.is_reference() || self.is_spec() {
-            None
-        } else {
-            Some (
-                match self {
-                    Primitive(p) => p.into_type_tag().expect("Invariant violation: unexpected spec primitive"),
-                    Struct(mid, sid, ts) =>TypeTag::Struct(
-                        env.get_struct_tag(mid, sid, &ts)
-                            .expect("Invariant violation: struct type argument contains incomplete, tuple, reference, or spec type")
-                    ),
-                    Vector(et) => TypeTag::Vector(
-                        Box::new(et.into_type_tag(env)
-                                 .expect("Invariant violation: vector type argument contains incomplete, tuple, reference, or spec type"))
-                    ),
-                    Tuple(..) | Error | Fun(..) | TypeDomain(..) | ResourceDomain(..) | TypeParameter(..) | TypeLocal(..) | Var(..) | Reference(..) =>
-                        return None
-                }
-            )
-        }
+        self.into_normalized_type(env)?.into_type_tag()
     }
 
     /// Create a `Type` from `t`


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
1. Implement helpers for move-model to return normalized types to its caller.
2. Implement helpers to `normalized::Type` with type conversion, substituion, and display.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

N/A

## Related PRs

#8589 