### PR TITLE
[decoupled-execution] Unhappy Path - Retry broadcasting messages

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -26,7 +26,7 @@ pub struct ConsensusConfig {
     pub mempool_poll_count: u64,
     // global switch for the decoupling execution feature
     // only when decoupled is true, the execution and committing will be pipelined in different phases
-    pub decoupled: bool,
+    pub decoupled_execution: bool,
     pub channel_size: usize,
     pub back_pressure_limit: u64,
 }
@@ -47,8 +47,8 @@ impl Default for ConsensusConfig {
             safety_rules: SafetyRulesConfig::default(),
             sync_only: false,
             mempool_poll_count: 1,
-            decoupled: false, // by default, we turn of the decoupling execution feature
-            channel_size: 30, // hard-coded
+            decoupled_execution: false, // by default, we turn of the decoupling execution feature
+            channel_size: 30,           // hard-coded
             back_pressure_limit: 1,
         }
     }

--- a/consensus/consensus-types/src/experimental/commit_vote.rs
+++ b/consensus/consensus-types/src/experimental/commit_vote.rs
@@ -5,7 +5,7 @@ use crate::common::{Author, Round};
 use anyhow::Context;
 use diem_crypto::ed25519::Ed25519Signature;
 use diem_types::{
-    ledger_info::LedgerInfo, validator_signer::ValidatorSigner,
+    block_info::BlockInfo, ledger_info::LedgerInfo, validator_signer::ValidatorSigner,
     validator_verifier::ValidatorVerifier,
 };
 use serde::{Deserialize, Serialize};
@@ -90,5 +90,9 @@ impl CommitVote {
         validator
             .verify(self.author(), &self.ledger_info, &self.signature)
             .context("Failed to verify Commit Proposal")
+    }
+
+    pub fn commit_info(&self) -> &BlockInfo {
+        self.ledger_info().commit_info()
     }
 }

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -306,3 +306,13 @@ pub static DECOUPLED_EXECUTION__COMMIT_MESSAGE_CHANNEL: Lazy<IntGauge> = Lazy::n
     )
     .unwrap()
 });
+
+/// Counter for the decoupling execution channel of commit messages
+/// from commit phase to itself when a timeout triggers
+pub static DECOUPLED_EXECUTION__COMMIT_MESSAGE_TIMEOUT_CHANNEL: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "decoupled_execution__commit_message_timeout_channel",
+        "Number of pending commit phase message timeouts (CommitVote/CommitDecision)"
+    )
+    .unwrap()
+});

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -112,7 +112,7 @@ impl EpochManager {
         let author = node_config.validator_network.as_ref().unwrap().peer_id();
         let config = node_config.consensus.clone();
         let sr_config = &node_config.consensus.safety_rules;
-        if sr_config.decoupled_execution != config.decoupled {
+        if sr_config.decoupled_execution != config.decoupled_execution {
             panic!("Inconsistent decoupled-execution configuration of consensus and safety-rules\nMake sure consensus.decoupled = safety_rules.decoupled_execution.")
         }
         let safety_rules_manager = SafetyRulesManager::new(sr_config);
@@ -425,7 +425,7 @@ impl EpochManager {
 
         let safety_rules_container = Arc::new(Mutex::new(safety_rules));
 
-        let mut processor = if self.config.decoupled {
+        let mut processor = if self.config.decoupled_execution {
             let (round_manager, execution_phase, commit_phase) = self.prepare_decoupled_execution(
                 epoch,
                 recovery_data,

--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -228,6 +228,10 @@ impl LedgerInfoWithV0 {
         &self.ledger_info
     }
 
+    pub fn commit_info(&self) -> &BlockInfo {
+        self.ledger_info.commit_info()
+    }
+
     pub fn add_signature(&mut self, validator: AccountAddress, signature: Ed25519Signature) {
         self.signatures.entry(validator).or_insert(signature);
     }


### PR DESCRIPTION
In case the messages get dropped, we let the commit phase retry broadcasting the current messages (commit vote only), until the current block is processed.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update or suggest changes to the docs at https://developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
