### PR TITLE
[move-lang] rewrote alias scoping, improving compiler perf by ~65%

### DIFF
--- a/language/move-lang/src/expansion/aliases.rs
+++ b/language/move-lang/src/expansion/aliases.rs
@@ -3,29 +3,54 @@
 
 use crate::{
     expansion::ast::ModuleIdent,
-    shared::{remembering_unique_map::RememberingUniqueMap, *},
+    shared::{unique_map::UniqueMap, unique_set::UniqueSet, *},
 };
 use move_ir_types::location::*;
-use std::{collections::BTreeSet, iter::IntoIterator};
+
+type ScopeDepth = usize;
 
 #[derive(Clone, Debug)]
 pub struct AliasSet {
-    pub modules: BTreeSet<Name>,
-    pub members: BTreeSet<Name>,
+    pub modules: UniqueSet<Name>,
+    pub members: UniqueSet<Name>,
+}
+
+#[derive(Clone, Debug)]
+pub struct AliasMapBuilder {
+    modules: UniqueMap<Name, (ModuleIdent, /* is_implicit */ bool)>,
+    members: UniqueMap<Name, ((ModuleIdent, Name), /* is_implicit */ bool)>,
 }
 
 #[derive(Clone, Debug)]
 pub struct AliasMap {
-    modules: RememberingUniqueMap<Name, ModuleIdent>,
-    members: RememberingUniqueMap<Name, (ModuleIdent, Name)>,
-    current_scope: AliasSet,
+    modules: UniqueMap<Name, (Option<ScopeDepth>, ModuleIdent)>,
+    members: UniqueMap<Name, (Option<ScopeDepth>, (ModuleIdent, Name))>,
+    // essentially a mapping from ScopeDepth => AliasSet, which are the unused aliases at that depth
+    unused: Vec<AliasSet>,
 }
+
+pub struct OldAliasMap(Option<AliasMap>);
 
 impl AliasSet {
     pub fn new() -> Self {
         Self {
-            modules: BTreeSet::new(),
-            members: BTreeSet::new(),
+            modules: UniqueSet::new(),
+            members: UniqueSet::new(),
+        }
+    }
+
+    #[allow(unused)]
+    pub fn is_empty(&self) -> bool {
+        let Self { modules, members } = self;
+        modules.is_empty() && members.is_empty()
+    }
+}
+
+impl AliasMapBuilder {
+    pub fn new() -> Self {
+        Self {
+            modules: UniqueMap::new(),
+            members: UniqueMap::new(),
         }
     }
 
@@ -33,34 +58,8 @@ impl AliasSet {
         let Self { modules, members } = self;
         modules.is_empty() && members.is_empty()
     }
-}
-
-impl AliasMap {
-    pub fn new() -> Self {
-        Self {
-            modules: RememberingUniqueMap::new(),
-            members: RememberingUniqueMap::new(),
-            current_scope: AliasSet::new(),
-        }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        let Self {
-            modules,
-            members,
-            current_scope,
-        } = self;
-        let is_empty = modules.is_empty() && members.is_empty();
-        assert!(current_scope.is_empty() == is_empty);
-        is_empty
-    }
-
-    pub fn current_scope_is_empty(&self) -> bool {
-        self.current_scope.is_empty()
-    }
 
     fn remove_module_alias_(&mut self, alias: &Name) -> Result<(), Loc> {
-        self.current_scope.modules.remove(alias);
         let loc = self.modules.get_loc(alias).cloned();
         match self.modules.remove(alias) {
             None => Ok(()),
@@ -69,7 +68,6 @@ impl AliasMap {
     }
 
     fn remove_member_alias_(&mut self, alias: &Name) -> Result<(), Loc> {
-        self.current_scope.members.remove(alias);
         let loc = self.members.get_loc(alias).cloned();
         match self.members.remove(alias) {
             None => Ok(()),
@@ -77,16 +75,13 @@ impl AliasMap {
         }
     }
 
-    pub fn remove_member_alias(&mut self, alias: &Name) {
-        let _ = self.remove_member_alias_(alias);
-    }
-
     /// Adds a module alias to the map.
     /// Errors if one already bound for that alias
     pub fn add_module_alias(&mut self, alias: Name, ident: ModuleIdent) -> Result<(), Loc> {
         let result = self.remove_module_alias_(&alias);
-        self.current_scope.modules.insert(alias.clone());
-        self.modules.add(alias, ident).unwrap();
+        self.modules
+            .add(alias, (ident, /* is_implicit */ false))
+            .unwrap();
         result
     }
 
@@ -99,8 +94,9 @@ impl AliasMap {
         member: Name,
     ) -> Result<(), Loc> {
         let result = self.remove_member_alias_(&alias);
-        self.current_scope.members.insert(alias.clone());
-        self.members.add(alias, (ident, member)).unwrap();
+        self.members
+            .add(alias, ((ident, member), /* is_implicit */ false))
+            .unwrap();
         result
     }
 
@@ -112,7 +108,9 @@ impl AliasMap {
         ident: ModuleIdent,
     ) -> Result<(), Loc> {
         let result = self.remove_module_alias_(&alias);
-        self.modules.add(alias, ident).unwrap();
+        self.modules
+            .add(alias, (ident, /* is_implicit */ true))
+            .unwrap();
         result
     }
 
@@ -125,78 +123,137 @@ impl AliasMap {
         member: Name,
     ) -> Result<(), Loc> {
         let result = self.remove_member_alias_(&alias);
-        self.members.add(alias, (ident, member)).unwrap();
+        self.members
+            .add(alias, ((ident, member), /* is_implicit */ true))
+            .unwrap();
         result
+    }
+}
+
+impl AliasMap {
+    pub fn new() -> Self {
+        Self {
+            modules: UniqueMap::new(),
+            members: UniqueMap::new(),
+            unused: vec![],
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        let Self {
+            modules,
+            members,
+            unused: _,
+        } = self;
+        modules.is_empty() && members.is_empty()
+    }
+
+    fn current_depth(&self) -> usize {
+        self.unused.len()
     }
 
     pub fn module_alias_get(&mut self, n: &Name) -> Option<&ModuleIdent> {
-        self.modules.get(n)
+        match self.modules.get_mut(n) {
+            None => None,
+            Some((depth_opt, ident)) => {
+                if let Some(depth) = depth_opt {
+                    self.unused[*depth].modules.remove(n);
+                }
+                *depth_opt = None;
+                Some(ident)
+            }
+        }
     }
 
     pub fn member_alias_get(&mut self, n: &Name) -> Option<&(ModuleIdent, Name)> {
-        self.members.get(n)
+        match self.members.get_mut(n) {
+            None => None,
+            Some((depth_opt, ident_name)) => {
+                if let Some(depth) = depth_opt {
+                    self.unused[*depth].members.remove(n);
+                }
+                *depth_opt = None;
+                Some(ident_name)
+            }
+        }
     }
 
-    pub fn add_and_shadow_all(&mut self, shadowing: AliasMap) {
-        let Self {
+    /// Adds all of the new items in the new inner scope as shadowing the outer one.
+    /// Gives back the outer scope
+    pub fn add_and_shadow_all(&mut self, shadowing: AliasMapBuilder) -> OldAliasMap {
+        if shadowing.is_empty() {
+            return OldAliasMap(None);
+        }
+
+        let outer_scope = OldAliasMap(Some(self.clone()));
+        let AliasMapBuilder {
             modules: new_modules,
             members: new_members,
-            current_scope: new_scope,
         } = shadowing;
-        for (alias, ident) in new_modules {
-            let _ = self.add_implicit_module_alias(alias, ident);
+
+        let next_depth = self.current_depth();
+        let mut current_scope = AliasSet::new();
+        for (alias, (ident, is_implicit)) in new_modules {
+            if !is_implicit {
+                current_scope.modules.add(alias.clone()).unwrap();
+            }
+            self.modules.remove(&alias);
+            self.modules.add(alias, (Some(next_depth), ident)).unwrap();
         }
-        for (alias, (ident, member)) in new_members {
-            let _ = self.add_implicit_member_alias(alias, ident, member);
+        for (alias, (ident_member, is_implicit)) in new_members {
+            if !is_implicit {
+                current_scope.members.add(alias.clone()).unwrap();
+            }
+            self.members.remove(&alias);
+            self.members
+                .add(alias, (Some(next_depth), ident_member))
+                .unwrap();
         }
-        self.current_scope = new_scope
+        self.unused.push(current_scope);
+        outer_scope
     }
 
-    pub fn close_scope_and_report_unused(&mut self, inner: Self) -> AliasSet {
+    /// Similar to add_and_shadow but just removes aliases now shadowed by a type parameter
+    pub fn shadow_for_type_parameters<'a, I: IntoIterator<Item = &'a Name>>(
+        &mut self,
+        tparams: I,
+    ) -> OldAliasMap
+    where
+        I::IntoIter: ExactSizeIterator,
+    {
+        let tparams_iter = tparams.into_iter();
+        if tparams_iter.len() == 0 {
+            return OldAliasMap(None);
+        }
+
+        let outer_scope = OldAliasMap(Some(self.clone()));
+        self.unused.push(AliasSet::new());
+        for tp_name in tparams_iter {
+            self.members.remove(tp_name);
+        }
+        outer_scope
+    }
+
+    /// Resets the alias map and gives the set of aliases that were unused
+    pub fn set_to_outer_scope(&mut self, outer_scope: OldAliasMap) -> AliasSet {
+        let outer_scope = match outer_scope.0 {
+            None => return AliasSet::new(),
+            Some(outer) => outer,
+        };
+        let mut inner_scope = std::mem::replace(self, outer_scope);
         let outer_scope = self;
-        let Self {
-            modules: inner_modules,
-            members: inner_members,
-            current_scope:
-                AliasSet {
-                    modules: inner_scope_modules,
-                    members: inner_scope_members,
-                },
-        } = inner;
+        assert!(outer_scope.current_depth() + 1 == inner_scope.current_depth());
+        let unused = inner_scope.unused.pop().unwrap();
+        outer_scope.unused = inner_scope.unused;
+        unused
+    }
+}
 
-        let used_modules = inner_modules.remember();
-        let used_members = inner_members.remember();
-
-        // propagate uses of aliases
-        used_modules
-            .iter()
-            // remove newly declared aliaes
-            .filter(|a| !inner_scope_modules.contains(a))
-            .for_each(|a| {
-                // get the module alias to mark it as used
-                outer_scope.module_alias_get(a);
-            });
-        used_members
-            .iter()
-            // remove newly declared aliaes
-            .filter(|a| !inner_scope_members.contains(a))
-            .for_each(|a| {
-                // get the member alias to mark it as used
-                outer_scope.member_alias_get(a);
-            });
-
-        // report unused
-        let unused_modules = inner_scope_modules
-            .into_iter()
-            .filter(|n| !used_modules.contains(n))
-            .collect();
-        let unused_members = inner_scope_members
-            .into_iter()
-            .filter(|n| !used_members.contains(n))
-            .collect();
-        AliasSet {
-            modules: unused_modules,
-            members: unused_members,
+impl OldAliasMap {
+    pub fn is_empty(&self) -> bool {
+        match &self.0 {
+            None => true,
+            Some(aliases) => aliases.is_empty(),
         }
     }
 }

--- a/language/move-lang/src/shared/unique_set.rs
+++ b/language/move-lang/src/shared/unique_set.rs
@@ -25,6 +25,14 @@ impl<T: TName> UniqueSet<T> {
         self.0.add(x, ())
     }
 
+    pub fn remove(&mut self, x: &T) -> bool {
+        self.0.remove(x).is_some()
+    }
+
+    pub fn remove_(&mut self, x: &T::Key) -> bool {
+        self.0.remove_(x).is_some()
+    }
+
     pub fn contains(&self, x: &T) -> bool {
         self.0.contains_key(x)
     }

--- a/language/move-lang/tests/move_check/expansion/use_function_tparam_shadows.exp
+++ b/language/move-lang/tests/move_check/expansion/use_function_tparam_shadows.exp
@@ -1,3 +1,9 @@
+warning[W09001]: unused alias
+  ┌─ tests/move_check/expansion/use_function_tparam_shadows.move:7:17
+  │
+7 │     use 0x2::X::foo;
+  │                 ^^^ Unused 'use' of alias 'foo'. Consider removing it
+
 error[E03005]: unbound unscoped name
    ┌─ tests/move_check/expansion/use_function_tparam_shadows.move:10:9
    │


### PR DESCRIPTION
- Old alias scoping was done with an iter+filter to do set difference
- New alias scoping instead keeps track of unused items at each scope
- For each new scope, the new algorithm fully populates a set of "unused" aliases. Each usage of an alias then removes that from the set, so at the end of the scope, it can instantaneously answer what aliases are unused (as opposed to doing set difference)
- Additionally, clones are reduced when the scope does not introduce anything new. This accounted for about an additional 11% improvement on release builds

## Motivation

- According to flamegraph, expansion was taking 60% to 70% of the total runtime for the compiler
- This motivated the rewrite and led to some nice perf gains!
```
dev build DF+Std (averaged over 10 iterations)
OLD       8.155s
NEW       2.840s
REDUCTION 65.17%

release build DF+Std (averaged over 100 iterations)
OLD       0.849s
NEW       0.271s
REDUCTION 68.08%

nextest -p move-lang
OLD       17.623s
NEW       16.102s
REDUCTION 8.63%

nextest -p move-lang-functional-tests
OLD       511.871s
NEW       185.475s
REDUCTION 63.77%

nextest -p move-prover
OLD       650.349s
NEW       287.221s
REDUCTION 55.84%

x test -p move-lang
OLD       10.047s
NEW       7.335s
REDUCTION 26.99%

x test -p move-lang-functional-tests
OLD       51.223s
NEW       42.450s
REDUCTION 17.13%

x test -p move-prover
OLD       534.380s
NEW       228.259s
REDUCTION 57.29%

```

## Test Plan

- Actually found a bug while doing this too! Updated that test