### PR TITLE
[decoupled-execution] Unhappy Path - Delay Block Pruning

### DIFF
--- a/consensus/src/block_storage/tracing.rs
+++ b/consensus/src/block_storage/tracing.rs
@@ -15,6 +15,7 @@ impl BlockStage {
     pub const VOTED: &'static str = "voted";
     pub const QC_AGGREGATED: &'static str = "qc_aggregated";
     pub const QC_ADDED: &'static str = "qc_added";
+    pub const ORDERED: &'static str = "ordered";
     pub const COMMITTED: &'static str = "committed";
 }
 

--- a/consensus/src/experimental/tests/integration_tests.rs
+++ b/consensus/src/experimental/tests/integration_tests.rs
@@ -1,0 +1,149 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    experimental::tests::test_utils::prepare_executed_blocks_with_ordered_ledger_info,
+    round_manager::UnverifiedEvent,
+    test_utils::{consensus_runtime, timed_block_on, RandomComputeResultStateComputer},
+};
+use futures::{SinkExt, StreamExt};
+use network::protocols::network::Event;
+
+use crate::{
+    block_storage::BlockReader,
+    experimental::{
+        execution_phase::{ExecutionChannelType, ExecutionPhase},
+        ordering_state_computer::OrderingStateComputer,
+    },
+};
+use std::sync::Arc;
+
+use crate::network_interface::ConsensusMsg;
+
+use consensus_types::block::block_test_utils::certificate_for_genesis;
+
+use crate::{
+    experimental::tests::test_utils::prepare_commit_phase_with_block_store_state_computer,
+    state_replication::empty_state_computer_call_back, test_utils::TreeInserter,
+};
+use consensus_types::executed_block::ExecutedBlock;
+use executor_types::StateComputeResult;
+
+#[test]
+fn decoupled_execution_integration() {
+    let channel_size = 30;
+    let mut runtime = consensus_runtime();
+
+    let (execution_phase_tx, execution_phase_rx) =
+        channel::new_test::<ExecutionChannelType>(channel_size);
+
+    let state_computer = Arc::new(OrderingStateComputer::new(execution_phase_tx));
+
+    // now we need to replace the state computer instance (previously the one directly outputs to commit_result_rx)
+    // to the outside one that connects with the execution phase.
+    let (
+        mut commit_tx,
+        mut msg_tx,
+        mut commit_result_rx,
+        mut self_loop_rx,
+        _safety_rules_container,
+        signers,
+        _state_computer,
+        validator,
+        commit_phase,
+        block_store_handle,
+    ) = prepare_commit_phase_with_block_store_state_computer(&runtime, state_computer, 1);
+
+    let mut inserter = TreeInserter::new_with_store(signers[0].clone(), block_store_handle.clone());
+
+    let genesis = block_store_handle.root();
+    let genesis_block_id = genesis.id();
+    let genesis_block = block_store_handle
+        .get_block(genesis_block_id)
+        .expect("genesis block must exist");
+
+    // genesis --> a1 --> a2 --> a3 --> a4
+    let a1 = inserter.insert_block_with_qc(certificate_for_genesis(), &genesis_block, 1);
+    let a2 = inserter.insert_block(&a1, 2, None);
+    let a3 = inserter.insert_block(&a2, 3, Some(genesis.block_info()));
+    let a4 = inserter.insert_block(&a3, 4, Some(a3.block_info()));
+
+    let ledger_info_with_sigs = a4.quorum_cert().ledger_info().clone();
+
+    let random_state_computer = RandomComputeResultStateComputer::new();
+    let random_execute_result_root_hash = random_state_computer.get_root_hash();
+
+    let execution_phase = ExecutionPhase::new(
+        execution_phase_rx,
+        Arc::new(random_state_computer),
+        commit_tx.clone(),
+    );
+
+    runtime.spawn(execution_phase.start());
+
+    runtime.spawn(commit_phase.start());
+
+    timed_block_on(&mut runtime, async move {
+        // commit the block
+        block_store_handle.commit(ledger_info_with_sigs).await.ok();
+
+        // the pruning should be delayed
+        assert!(block_store_handle.block_exists(a1.block().id()));
+
+        match self_loop_rx.next().await {
+            Some(Event::Message(_, msg)) => {
+                let event: UnverifiedEvent = msg.into();
+                // verify the message and send the message into self loop
+                msg_tx.send(event.verify(&validator).unwrap()).await.ok();
+            }
+            _ => {
+                panic!("We are expecting a commit vote message.");
+            }
+        };
+
+        // it commits the block
+        if let Some((executed_blocks, finality_proof, callback)) = commit_result_rx.next().await {
+            assert_eq!(executed_blocks.len(), 3); // a1 a2 a3
+            assert_eq!(
+                finality_proof
+                    .ledger_info()
+                    .commit_info()
+                    .executed_state_id(),
+                random_execute_result_root_hash
+            );
+            callback(
+                &executed_blocks
+                    .into_iter()
+                    .map(|b| Arc::new(ExecutedBlock::new(b, StateComputeResult::new_dummy())))
+                    .collect::<Vec<Arc<ExecutedBlock>>>(),
+            ); // call the callback
+        } else {
+            panic!("Expecting a commited block")
+        }
+
+        // and it sends a commit decision
+        assert!(matches!(
+            self_loop_rx.next().await,
+            Some(Event::Message(_, ConsensusMsg::CommitDecisionMsg(_))),
+        ));
+
+        // fill in two dummy items to commit_tx to make sure commit_phase::check_commit has finished
+        let (blocks_1, li_1) = prepare_executed_blocks_with_ordered_ledger_info(&signers[0]);
+        let (blocks_2, li_2) = prepare_executed_blocks_with_ordered_ledger_info(&signers[0]);
+        commit_tx
+            .send((blocks_1, li_1, empty_state_computer_call_back()))
+            .await
+            .ok();
+        commit_tx
+            .send((blocks_2, li_2, empty_state_computer_call_back()))
+            .await
+            .ok();
+
+        // ..also the block is gone
+        assert!(!block_store_handle.block_exists(genesis_block_id));
+        assert!(!block_store_handle.block_exists(a1.block().id()));
+        assert!(!block_store_handle.block_exists(a2.block().id()));
+        // ..until a3
+        assert!(block_store_handle.block_exists(a3.block().id()));
+    });
+}

--- a/consensus/src/experimental/tests/mod.rs
+++ b/consensus/src/experimental/tests/mod.rs
@@ -3,4 +3,6 @@
 
 mod commit_phase_tests;
 mod execution_phase_tests;
+mod integration_tests;
 mod ordering_state_computer_tests;
+mod test_utils;

--- a/consensus/src/experimental/tests/test_utils.rs
+++ b/consensus/src/experimental/tests/test_utils.rs
@@ -1,0 +1,226 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    block_storage::BlockStore,
+    experimental::{
+        commit_phase::{CommitChannelType, CommitPhase},
+        execution_phase::ExecutionChannelType,
+        ordering_state_computer::OrderingStateComputer,
+    },
+    metrics_safety_rules::MetricsSafetyRules,
+    network::NetworkSender,
+    network_interface::{ConsensusMsg, ConsensusNetworkSender},
+    round_manager::VerifiedEvent,
+    state_replication::StateComputer,
+    test_utils::MockStorage,
+    util::time_service::ClockTimeService,
+};
+use channel::{diem_channel, message_queues::QueueStyle, Receiver, Sender};
+use consensus_types::{
+    block::{block_test_utils::certificate_for_genesis, Block},
+    executed_block::ExecutedBlock,
+};
+use diem_crypto::{
+    ed25519::{Ed25519PrivateKey, Ed25519Signature},
+    hash::ACCUMULATOR_PLACEHOLDER_HASH,
+    HashValue, Uniform,
+};
+use diem_infallible::Mutex;
+use diem_secure_storage::Storage;
+use diem_types::{
+    account_address::AccountAddress,
+    block_info::BlockInfo,
+    epoch_state::EpochState,
+    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+    validator_signer::ValidatorSigner,
+    validator_verifier::{random_validator_verifier, ValidatorVerifier},
+    waypoint::Waypoint,
+};
+use executor_types::StateComputeResult;
+use network::{
+    peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
+    protocols::network::{Event, NewNetworkSender},
+};
+use safety_rules::{PersistentSafetyStorage, SafetyRulesManager};
+use std::{
+    collections::BTreeMap,
+    sync::{atomic::AtomicU64, Arc},
+};
+use tokio::runtime::Runtime;
+
+pub fn prepare_commit_phase_with_block_store_state_computer(
+    runtime: &Runtime,
+    block_store_state_computer: Arc<dyn StateComputer>,
+    channel_size: usize,
+) -> (
+    Sender<CommitChannelType>,
+    Sender<VerifiedEvent>,
+    Receiver<ExecutionChannelType>,
+    Receiver<Event<ConsensusMsg>>,
+    Arc<Mutex<MetricsSafetyRules>>,
+    Vec<ValidatorSigner>,
+    Arc<OrderingStateComputer>,
+    ValidatorVerifier,
+    CommitPhase,
+    Arc<BlockStore>,
+) {
+    let num_nodes = 1;
+
+    // constants
+    let back_pressure = Arc::new(AtomicU64::new(0));
+
+    // environment setup
+    let (signers, validators) = random_validator_verifier(num_nodes, None, false);
+    let validator_set = (&validators).into();
+    let signer = &signers[0];
+
+    let waypoint =
+        Waypoint::new_epoch_boundary(&LedgerInfo::mock_genesis(Some(validator_set))).unwrap();
+
+    let safety_storage = PersistentSafetyStorage::initialize(
+        Storage::from(diem_secure_storage::InMemoryStorage::new()),
+        signer.author(),
+        signer.private_key().clone(),
+        Ed25519PrivateKey::generate_for_testing(),
+        waypoint,
+        true,
+    );
+    let safety_rules_manager = SafetyRulesManager::new_local(safety_storage, false, false, true);
+
+    let (initial_data, storage) = MockStorage::start_for_testing((&validators).into());
+    let epoch_state = EpochState {
+        epoch: 1,
+        verifier: storage.get_validator_set().into(),
+    };
+    let validators = epoch_state.verifier.clone();
+    let (network_reqs_tx, _network_reqs_rx) = diem_channel::new(QueueStyle::FIFO, 8, None);
+    let (connection_reqs_tx, _) = diem_channel::new(QueueStyle::FIFO, 8, None);
+
+    let network_sender = ConsensusNetworkSender::new(
+        PeerManagerRequestSender::new(network_reqs_tx),
+        ConnectionRequestSender::new(connection_reqs_tx),
+    );
+    let author = signer.author();
+
+    let (self_loop_tx, self_loop_rx) = channel::new_test(1000);
+    let network = NetworkSender::new(author, network_sender, self_loop_tx, validators);
+
+    let (commit_result_tx, commit_result_rx) =
+        channel::new_test::<ExecutionChannelType>(channel_size);
+    let state_computer = Arc::new(OrderingStateComputer::new(commit_result_tx));
+
+    let time_service = Arc::new(ClockTimeService::new(runtime.handle().clone()));
+
+    let block_store = Arc::new(BlockStore::new(
+        storage.clone(),
+        initial_data,
+        block_store_state_computer,
+        0, // max pruned blocks in mem
+        time_service,
+    ));
+
+    let mut safety_rules = MetricsSafetyRules::new(safety_rules_manager.client(), storage);
+    safety_rules.perform_initialize().unwrap();
+
+    let safety_rules_container = Arc::new(Mutex::new(safety_rules));
+
+    // setting up channels
+    let (commit_tx, commit_rx) = channel::new_test::<CommitChannelType>(channel_size);
+
+    let (msg_tx, msg_rx) = channel::new_test::<VerifiedEvent>(channel_size);
+
+    let commit_phase = CommitPhase::new(
+        commit_rx,
+        state_computer.clone(),
+        msg_rx,
+        epoch_state.verifier.clone(),
+        safety_rules_container.clone(),
+        author,
+        back_pressure,
+        network,
+    );
+
+    (
+        commit_tx,        // channel to pass executed blocks into the commit phase
+        msg_tx,           // channel to pass commit messages into the commit phase
+        commit_result_rx, // channel to receive commit result from the commit phase
+        self_loop_rx,     // channel to receive message from the commit phase itself
+        safety_rules_container,
+        signers,
+        state_computer,
+        epoch_state.verifier,
+        commit_phase,
+        block_store,
+    )
+}
+
+pub fn prepare_executed_blocks_with_ledger_info(
+    signer: &ValidatorSigner,
+    executed_hash: HashValue,
+    consensus_hash: HashValue,
+) -> (Vec<ExecutedBlock>, LedgerInfoWithSignatures) {
+    let genesis_qc = certificate_for_genesis();
+    let block = Block::new_proposal(vec![], 1, 1, genesis_qc, signer);
+    let compute_result = StateComputeResult::new(
+        executed_hash,
+        vec![], // dummy subtree
+        0,
+        vec![],
+        0,
+        None,
+        vec![],
+        vec![],
+        vec![],
+    );
+
+    let li = LedgerInfo::new(
+        block.gen_block_info(
+            compute_result.root_hash(),
+            compute_result.version(),
+            compute_result.epoch_state().clone(),
+        ),
+        consensus_hash,
+    );
+
+    let mut li_sig = LedgerInfoWithSignatures::new(
+        li.clone(),
+        BTreeMap::<AccountAddress, Ed25519Signature>::new(),
+    );
+
+    li_sig.add_signature(signer.author(), signer.sign(&li));
+
+    let executed_block = ExecutedBlock::new(block, compute_result);
+
+    (vec![executed_block], li_sig)
+}
+
+pub fn prepare_executed_blocks_with_executed_ledger_info(
+    signer: &ValidatorSigner,
+) -> (Vec<ExecutedBlock>, LedgerInfoWithSignatures) {
+    prepare_executed_blocks_with_ledger_info(
+        signer,
+        HashValue::random(),
+        HashValue::from_u64(0xbeef),
+    )
+}
+
+pub fn prepare_executed_blocks_with_ordered_ledger_info(
+    signer: &ValidatorSigner,
+) -> (Vec<ExecutedBlock>, LedgerInfoWithSignatures) {
+    prepare_executed_blocks_with_ledger_info(
+        signer,
+        *ACCUMULATOR_PLACEHOLDER_HASH,
+        *ACCUMULATOR_PLACEHOLDER_HASH,
+    )
+}
+
+pub fn new_executed_ledger_info_with_empty_signature(
+    block_info: BlockInfo,
+    li: &LedgerInfo,
+) -> LedgerInfoWithSignatures {
+    LedgerInfoWithSignatures::new(
+        LedgerInfo::new(block_info, li.consensus_data_hash()),
+        BTreeMap::<AccountAddress, Ed25519Signature>::new(), //empty
+    )
+}

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -1,7 +1,10 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{error::StateSyncError, state_replication::StateComputer};
+use crate::{
+    error::StateSyncError,
+    state_replication::{StateComputer, StateComputerCommitCallBackType},
+};
 use anyhow::Result;
 use consensus_types::{block::Block, executed_block::ExecutedBlock};
 use diem_crypto::HashValue;
@@ -66,6 +69,7 @@ impl StateComputer for ExecutionProxy {
         &self,
         blocks: &[Arc<ExecutedBlock>],
         finality_proof: LedgerInfoWithSignatures,
+        callback: StateComputerCommitCallBackType,
     ) -> Result<(), ExecutionError> {
         let mut block_ids = Vec::new();
         let mut txns = Vec::new();
@@ -89,6 +93,9 @@ impl StateComputer for ExecutionProxy {
         ) {
             error!(error = ?e, "Failed to notify state synchronizer");
         }
+
+        callback(blocks);
+
         Ok(())
     }
 

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -9,6 +9,11 @@ use diem_types::ledger_info::LedgerInfoWithSignatures;
 use executor_types::{Error as ExecutionError, StateComputeResult};
 use std::sync::Arc;
 
+pub type StateComputerCommitCallBackType = Box<dyn FnOnce(&[Arc<ExecutedBlock>]) + Send + Sync>;
+pub fn empty_state_computer_call_back() -> StateComputerCommitCallBackType {
+    Box::new(|_| {})
+}
+
 /// Retrieves and updates the status of transactions on demand (e.g., via talking with Mempool)
 #[async_trait::async_trait]
 pub trait TxnManager: Send + Sync {
@@ -54,6 +59,7 @@ pub trait StateComputer: Send + Sync {
         &self,
         blocks: &[Arc<ExecutedBlock>],
         finality_proof: LedgerInfoWithSignatures,
+        callback: StateComputerCommitCallBackType,
     ) -> Result<(), ExecutionError>;
 
     /// Best effort state synchronization to the given target LedgerInfo.

--- a/consensus/src/test_utils/mock_state_computer.rs
+++ b/consensus/src/test_utils/mock_state_computer.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    error::StateSyncError, state_replication::StateComputer, test_utils::mock_storage::MockStorage,
+    error::StateSyncError,
+    state_replication::{StateComputer, StateComputerCommitCallBackType},
+    test_utils::mock_storage::MockStorage,
 };
 use anyhow::{format_err, Result};
 use consensus_types::{block::Block, common::Payload, executed_block::ExecutedBlock};
@@ -55,6 +57,7 @@ impl StateComputer for MockStateComputer {
         &self,
         blocks: &[Arc<ExecutedBlock>],
         commit: LedgerInfoWithSignatures,
+        call_back: StateComputerCommitCallBackType,
     ) -> Result<(), Error> {
         self.consensus_db
             .commit_to_storage(commit.ledger_info().clone());
@@ -73,6 +76,9 @@ impl StateComputer for MockStateComputer {
         let _ = self.state_sync_client.unbounded_send(txns);
 
         let _ = self.commit_callback.unbounded_send(commit);
+
+        call_back(blocks);
+
         Ok(())
     }
 
@@ -108,6 +114,7 @@ impl StateComputer for EmptyStateComputer {
         &self,
         _blocks: &[Arc<ExecutedBlock>],
         _commit: LedgerInfoWithSignatures,
+        _call_back: StateComputerCommitCallBackType,
     ) -> Result<(), Error> {
         Ok(())
     }
@@ -149,6 +156,7 @@ impl StateComputer for RandomComputeResultStateComputer {
         &self,
         _blocks: &[Arc<ExecutedBlock>],
         _commit: LedgerInfoWithSignatures,
+        _call_back: StateComputerCommitCallBackType,
     ) -> Result<(), Error> {
         Ok(())
     }

--- a/specifications/consensus/README.md
+++ b/specifications/consensus/README.md
@@ -516,12 +516,13 @@ fn compute(block: Block) -> BlockInfo;
 * return the executed result i.e. BlockInfo which captures the root hash of the new merkle tree and the `next_epoch_state`
 
 ```rust
-fn commit(blocks: Vec<Block>, finality_proof: LedgerInfoWithSignatures);
+fn commit(blocks: Vec<Block>, finality_proof: LedgerInfoWithSignatures, callback: StateComputerCommitCallBackType);
 ```
 
 * ensure `finality_proof.commit_info()` match the last block in `blocks` and its executed result
 * ensure the `blocks` form a chain and the parent of the first is the current committed block
 * commit and persist `blocks` and the proof `finality_proof`
+* finally, call `callback()`
 
 ```rust
 fn sync_to(target: LedgerInfoWithSignatures);


### PR DESCRIPTION
Delay the block pruning to the end point of commit phase. Otherwise,
if a crash happens before the committing phase actually commits the
blocks, but after the block store prunes the block tree, the node
would experience misalignment between consensus data and storage data.
Moreover, if all the nodes (unfortunately) crash at the same time, the
nodes will lose the blocks forever.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update or suggest changes to the docs at https://developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
