### PR TITLE
[move-vm] cache modules that have been deserialzied and self-verified in the module loading process

### DIFF
--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -106,7 +106,7 @@ impl VMRuntime {
             if data_store.exists_module(&module_id)? {
                 let old_module_ref = self
                     .loader
-                    .load_module_expect_not_missing(&module_id, data_store)?;
+                    .load_module_verify_not_missing(&module_id, data_store)?;
                 let old_module = old_module_ref.module();
                 let old_m = normalized::Module::new(old_module);
                 let new_m = normalized::Module::new(&module);


### PR DESCRIPTION
Consider the following example to illustrate the module loading process
in the Move VM loader:

- Modules A, B, and C declares F as a friend
- Module F uses A, B, and C (by calling their function or using their types)

Now, the code cache is empty and we want to run execution function `A::foo()`.
The process works like the following:
```
deserialize(A)
byecode-verify(A)
for-each-dependencies(A) []
linking-check(A)
add-to-cache(A)
for-each-friends(A) -> [F]
  deserialize(F)
  byecode-verify(F)
  for-each-dependencies(F) [A, B, C]
    check-in-cache(A)
    deserialize(B)
    byecode-verify(B)
    for-each-dependencies(B) []
    linking-check(B)
    add-to-cache(B)
    for-each-friends(B) -> [F]
      deserialize(F)
      byecode-verify(F)
      for-each-dependencies(F) [A, B, C]
        check-in-cache(A)
        check-in-cache(B)
        deserialize(C)
        byecode-verify(C)
        for-each-dependencies(C) []
        linking-check(C)
        add-to-cache(C)
        for-each-friends(C) -> [F]
          deserialize(F)
          byecode-verify(F)
          for-each-dependencies(F) [A, B, C]
            check-in-cache(A)
            check-in-cache(B)
            check-in-cache(C)
          linking-check(F)
          add-to-cache(F)
          for-each-friends(F) -> []
          cyclic-deps-check(F)
        cyclic-deps-check(C)
      linking-check(F)
      add-to-cache(F)
      for-each-friends(F) -> []
      cyclic-deps-check(F)
    cyclic-deps-check(B)
  linking-check(F)
  add-to-cache(F)
  for-each-friends(F) -> []
  cyclic-deps-check(F)
cyclic-deps-check(A)
```

There are four issues here
- Module F is repeatedly deserialized and bytecode-verified
  Note that `deserialize(F)` and `bytecode-verify(F)` appears three times
  in the process where we should do the work only once
- Module F is repeatedly linking-checked with all its immediate dependencis
  Also evident by the fact that `linking-check(F)` appears three times where
  we should only check it once
- Module F is repeatedly cyclic-dep-checked against all the modules
  As evident by the fact that `cyclic-deps-check(F)` appears three times
  where we should only check it once
- The cyclic dependency check for A, B, C, and F are essentially the same,
  hence, these several `cyclic-deps-check(..)` should be reduced to one.

The first commit adds an additional layer of cache, called `in_progress`, to
cache modules that have been successfully deserialized and passes the
bytecode verifier `bytecode_verifier::verify(module)`.

```diff
deserialize(A)
byecode-verify(A)
+ add-to-progress(A)
for-each-dependencies(A) []
linking-check(A)
add-to-cache(A)
for-each-friends(A) -> [F]
  deserialize(F)
  byecode-verify(F)
+ add-to-progress(F)
  for-each-dependencies(F) [A, B, C]
    check-in-cache(A)
    deserialize(B)
    byecode-verify(B)
+   add-to-progress(B)
    for-each-dependencies(B) []
    linking-check(B)
    add-to-cache(B)
    for-each-friends(B) -> [F]
-       deserialize(F)
-       byecode-verify(F)
+       get-from-progress(F)
      for-each-dependencies(F) [A, B, C]
        check-in-cache(A)
        check-in-cache(B)
        deserialize(C)
        byecode-verify(C)
+       add-to-progress(C)
        for-each-dependencies(C) []
        linking-check(C)
        add-to-cache(C)
        for-each-friends(C) -> [F]
-         deserialize(F)
-         byecode-verify(F)
+         get-from-progress(F)
          for-each-dependencies(F) [A, B, C]
            check-in-cache(A)
            check-in-cache(B)
            check-in-cache(C)
          linking-check(F)
          add-to-cache(F)
          for-each-friends(F) -> []
          cyclic-deps-check(F)
        cyclic-deps-check(C)
      linking-check(F)
      add-to-cache(F)
      for-each-friends(F) -> []
      cyclic-deps-check(F)
    cyclic-deps-check(B)
  linking-check(F)
  add-to-cache(F)
  for-each-friends(F) -> []
  cyclic-deps-check(F)
cyclic-deps-check(A)
```

The second commit further removes the redundant linking
and cyclic deps checks over module F (i.e., addresses issues
2 and 3). The new module loading procedure will be like the
following: 

```
deserialize(A)
byecode-verify(A)
add-to-progress(A)
for-each-dependencies(A) []
linking-check(A)
add-to-cache(A)
for-each-friends(A) -> [F]
  deserialize(F)
  byecode-verify(F)
  add-to-progress(F)
  for-each-dependencies(F) [A, B, C]
    check-in-cache(A)
    deserialize(B)
    byecode-verify(B)
    for-each-dependencies(B) []
    linking-check(B)
    add-to-cache(B)
    for-each-friends(B) -> [F]
      get-from-progress(F)
      for-each-dependencies(F) [A, B, C]
        check-in-cache(A)
        check-in-cache(B)
        deserialize(C)
        byecode-verify(C)
        add-to-progress(C)
        for-each-dependencies(C) []
        linking-check(C)
        add-to-cache(C)
        for-each-friends(C) -> [F]
          get-from-progress(F)
          for-each-dependencies(F) [A, B, C]
            check-in-cache(A)
            check-in-cache(B)
            check-in-cache(C)
          linking-check(F)
          add-to-cache(F)
          for-each-friends(F) -> []
          cyclic-deps-check(F)
        cyclic-deps-check(C)
    cyclic-deps-check(B)
cyclic-deps-check(A)
```

We did not address issue 4 in this PR because based on our profiling, the
cyclic-deps-check does not seem to be a bottleneck here and adding it
would not be trivial as well.

## Motivation

Fix a performance degradation observed in #8668 .

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- CI
- The average runtime for one of the benchmarking language-e2e test: create_account, is reduced from 4.62 seconds to 2.03 seconds. The flame graph is available in https://github.com/mengxu-fb/libra/tree/loader-perf-data/data. Please download the SVG and open it with a browser for interactive viewing.
  
  This flamegraph is profiled by running the `create_account` e2e test 20 times. This particular e2e test is chosen because it has minimal noises compared with smoke tests (where local swarm and networking effects creates a lot of noises). By comparing the `old` and `new` version of the flamegrahs, the total time spent in the `bytecode-verifier` is reduced from around 45% to 30%. Indicating the effectiveness of the cache.