### PR TITLE
[move-vm] improve the code loading logic

### DIFF
--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -104,9 +104,7 @@ impl VMRuntime {
         for module in &compiled_modules {
             let module_id = module.self_id();
             if data_store.exists_module(&module_id)? {
-                let old_module_ref = self
-                    .loader
-                    .load_module_verify_not_missing(&module_id, data_store)?;
+                let old_module_ref = self.loader.load_module(&module_id, data_store)?;
                 let old_module = old_module_ref.module();
                 let old_m = normalized::Module::new(old_module);
                 let new_m = normalized::Module::new(&module);


### PR DESCRIPTION
As promised in #8811, this PR attempts to make the code loading
logic more maintainable and better engineered. This PR is follow-up
and clean-up of #8809 with functions renamed  and code better
documented. The solution stays the same.

Perhaps a better solution is to use a typestate transition system
to model different steps in the module verification process: i.e.,
`BytecodeVerified`, `LinkingVerified`, and `FullyVerified` etc. 

Unofficially modeled,

- `deserialize_and_verify_module -> BytecodeVerified`
  The module deserializes and passes the all bytecode verifier
  checks that do not require information from other modules.

- `verify_module_dependencies_* -> LinkingVerified`
  Everything in `BytecodeVerified` + the module links against
  all its immediate dependencies.

- `load_module_internal -> FullyVerified`
  Everything in `LinkingVerified` + the module does not create
  cyclic dependencies in the transitive closure that involves
  this module.

We may want to model this with the actual type system as well.
If so, we will add this in subsequent commits.

## Motivation

To better support module loading with the `friend` feature.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI
