### PR TITLE
[generate-format] Remove the extra empty line at EOF

### DIFF
--- a/testsuite/generate-format/src/compute.rs
+++ b/testsuite/generate-format/src/compute.rs
@@ -29,7 +29,7 @@ fn main() {
         match output_file {
             Some(path) => {
                 let mut f = File::create("testsuite/generate-format/".to_string() + path).unwrap();
-                writeln!(f, "{}", content).unwrap();
+                write!(f, "{}", content).unwrap();
             }
             None => panic!("Corpus {:?} doesn't record formats on disk", options.corpus),
         }


### PR DESCRIPTION
The extra empty line at EOF when generating YAML specification for
message formats will cause the linter to panic. We fix it in this
commit.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update or suggest changes to the docs at https://developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
