### PR TITLE
[move-prover] a regression test for existential type quantifier

### DIFF
--- a/language/move-prover/tests/sources/functional/type_existential_quantifier.move
+++ b/language/move-prover/tests/sources/functional/type_existential_quantifier.move
@@ -1,0 +1,26 @@
+address 0x2 {
+module S {
+    struct S<X: store> has key {
+        x: X,
+        v: u64,
+    }
+
+	public fun publish_x<X: store>(account: signer, x: X) {
+	    move_to(&account, S { x, v: 0 })
+	}
+
+    public fun publish_u64(account: signer, x: u64) {
+        move_to(&account, S { x, v: 1 })
+    }
+
+    // I1: this should verify, an evidence is X := bool
+    invariant
+        exists t: type:
+            exists<S<t>>(@0x22) ==> global<S<t>>(@0x22).v == 0;
+
+    // I2: this should not verify, x := u64 does not guarantee S<u64>.v == 1
+    invariant
+        exists t: type:
+            exists<S<t>>(@0x23) ==> global<S<t>>(@0x23).v == 1;
+}
+}


### PR DESCRIPTION
The existential type quantifier seems to break the nice framing rule
when reasoning about the global storage.

PS: I know that we are probably going to drop the support for
existential type quantifier in the Move prover. But since Boogie
also supports monomorphization now, I am wondering how a
case like this is handled in Boogie.
