### PR TITLE
[gha] work around very large logs sent to slack by prover daily tests.

### DIFF
--- a/.github/actions/slack-file/message_file_to_slack.sh
+++ b/.github/actions/slack-file/message_file_to_slack.sh
@@ -58,7 +58,7 @@ fi
 
 if [ -e "${PAYLOAD_FILE}" ]; then
     jq -n \
-    --arg msg "$(cat "${PAYLOAD_FILE}")" \
+    --arg msg "$(head -n 50 < "${PAYLOAD_FILE}")" \
     --arg url "${URL}" \
     '{
         attachments: [


### PR DESCRIPTION
## Motivation

If the file is too large slack rejects the message.   Truncate the message to 50 lines.   If you're reading more than that, just click the link.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

CI - currently running: https://github.com/diem/diem/runs/3165951975?check_suite_focus=true

## Related PRs

None.

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
