### PR TITLE
[move-prover] a test case for type-dependent code

### DIFF
--- a/language/move-prover/tests/sources/functional/type_dependent_code.exp
+++ b/language/move-prover/tests/sources/functional/type_dependent_code.exp
@@ -1,0 +1,40 @@
+Move prover returns: exiting with boogie verification errors
+error: abort not covered by any of the `aborts_if` clauses
+   ┌─ tests/sources/functional/type_dependent_code.move:10:5
+   │
+ 8 │           move_to<S<u8>>(&account, S { x: 0 });
+   │           ------- abort happened here with execution failure
+ 9 │       }
+10 │ ╭     spec extract {
+11 │ │         aborts_if exists<S<X>>(Signer::spec_address_of(account));
+12 │ │         aborts_if exists<S<u8>>(Signer::spec_address_of(account));
+13 │ │
+   · │
+19 │ │         // abort condition.
+20 │ │     }
+   │ ╰─────^
+   │
+   =     at tests/sources/functional/type_dependent_code.move:6: extract
+   =         account = <redacted>
+   =         x = <redacted>
+   =     at tests/sources/functional/type_dependent_code.move:7: extract
+   =     at tests/sources/functional/type_dependent_code.move:8: extract
+   =     at tests/sources/functional/type_dependent_code.move:8: extract
+   =         ABORTED
+
+error: function does not abort under this condition
+   ┌─ tests/sources/functional/type_dependent_code.move:35:9
+   │
+35 │         aborts_if !exists<S<X>>(Signer::spec_address_of(account));
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/type_dependent_code.move:28: extract
+   =         account = <redacted>
+   =         x = <redacted>
+   =     at tests/sources/functional/type_dependent_code.move:29: extract
+   =     at tests/sources/functional/type_dependent_code.move:30: extract
+   =         r = <redacted>
+   =     at tests/sources/functional/type_dependent_code.move:31: extract
+   =     at tests/sources/functional/type_dependent_code.move:32: extract
+   =     at tests/sources/functional/type_dependent_code.move:34
+   =     at tests/sources/functional/type_dependent_code.move:35

--- a/language/move-prover/tests/sources/functional/type_dependent_code.move
+++ b/language/move-prover/tests/sources/functional/type_dependent_code.move
@@ -1,0 +1,49 @@
+module 0x42::M {
+    use Std::Signer;
+
+    struct S<X: store> has key { x: X }
+
+    public fun extract<X: store>(account: signer, x: X) {
+        move_to<S<X>>(&account, S { x });
+        move_to<S<u8>>(&account, S { x: 0 });
+    }
+    spec extract {
+        aborts_if exists<S<X>>(Signer::spec_address_of(account));
+        aborts_if exists<S<u8>>(Signer::spec_address_of(account));
+
+        // NOTE: besides the above aborts_if conditions, this function
+        // also aborts if the type parameter `X` is instantiated with `u8`.
+        // This additional abort condition is not captured by the spec.
+        //
+        // TODO: currently we don't even have a way to specify this additional
+        // abort condition.
+    }
+}
+
+module 0x42::N {
+    use Std::Signer;
+
+    struct S<X: store + drop> has key { x: X }
+
+    public fun extract<X: store + drop>(account: signer, x: X) acquires S {
+        move_to<S<u8>>(&account, S { x: 0 });
+        let r = borrow_global_mut<S<X>>(Signer::address_of(&account));
+        *&mut r.x = x;
+    }
+    spec extract {
+        aborts_if exists<S<u8>>(Signer::spec_address_of(account));
+        aborts_if !exists<S<X>>(Signer::spec_address_of(account));
+        ensures global<S<u8>>(Signer::spec_address_of(account)).x == 0;
+
+        // NOTE: there are two issues with the spec
+        // 1) the second `aborts_if` condition is necessary only when X != u8
+        // 2) the `ensures` condition might not hold, as `extract<u8>(_, 1)`
+        //    will violate the `ensures` condition.
+        //
+        // TODO: currently the exp file does not show that the `ensures` is
+        // violated, not sure whehter this is shadowed by the `aborts_if`.
+        //
+        // In addition, similar to the test case above, we also don't have a
+        // good way to specify these type equality conditions in spec.
+    }
+}


### PR DESCRIPTION
With mono pushed to the backend, we get checking of type-dependent code
for free!

And now this exposes a hole in our spec language: we don't have a way to
specify type-dependent behavior, to be more precise, to specify
type-equality. This will be address in follow-up workstreams.

## Motivation

Complete modeling of program semantics

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI
