### PR TITLE
[diem_vm] Implement a new multi versioned hashmap.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5147,6 +5147,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mvhashmap"
+version = "0.1.0"
+dependencies = [
+ "diem-workspace-hack",
+ "num_cpus",
+ "once_cell",
+ "proptest",
+ "proptest-derive",
+ "rayon",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ members = [
     "language/diem-tools/writeset-transaction-generator",
     "language/diem-transaction-benchmarks",
     "language/diem-vm",
+    "language/diem-vm/mvhashmap",
     "language/e2e-testsuite",
     "language/ir-testsuite",
     "language/move-binary-format",

--- a/language/diem-vm/mvhashmap/Cargo.toml
+++ b/language/diem-vm/mvhashmap/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "mvhashmap"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+description = "Diem VM runtime"
+repository = "https://github.com/diem/diem"
+homepage = "https://diem.com"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+once_cell = "1.7.2"
+rayon = "1.5.0"
+num_cpus = "1.13.0"
+proptest = "1.0.0"
+proptest-derive = "0.3.0"
+diem-workspace-hack = { path = "../../../common/workspace-hack" }

--- a/language/diem-vm/mvhashmap/src/lib.rs
+++ b/language/diem-vm/mvhashmap/src/lib.rs
@@ -1,0 +1,224 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use once_cell::sync::OnceCell;
+use std::{
+    cmp::{max, PartialOrd},
+    collections::{btree_map::BTreeMap, HashMap},
+    fmt::Debug,
+    hash::Hash,
+};
+
+#[cfg(test)]
+mod unit_tests;
+
+/// A structure that holds placeholders for each write to the database
+//
+//  The structure is created by one thread creating the scheduling, and
+//  at that point it is used as a &mut by that single thread.
+//
+//  Then it is passed to all threads executing as a shared reference. At
+//  this point only a single thread must write to any entry, and others
+//  can read from it. Only entries are mutated using interior mutability,
+//  but no entries can be added or deleted.
+//
+
+pub type Version = usize;
+
+pub struct MVHashMap<K, V> {
+    data: HashMap<K, BTreeMap<Version, WriteCell<V>>>,
+}
+
+#[derive(Debug)]
+pub enum Error {
+    // A write has been performed on an entry that is not in the possible_writes list.
+    UnexpectedWrite,
+}
+
+#[cfg_attr(any(target_arch = "x86_64"), repr(align(128)))]
+pub(crate) struct WriteCell<V>(OnceCell<Option<V>>);
+
+impl<V: Debug> WriteCell<V> {
+    pub fn new() -> WriteCell<V> {
+        WriteCell(OnceCell::new())
+    }
+
+    pub fn is_assigned(&self) -> bool {
+        self.0.get().is_some()
+    }
+
+    pub fn write(&self, v: V) {
+        self.0
+            .set(Some(v))
+            .expect("WriteCell should be modified exactly once");
+    }
+
+    pub fn skip(&self) {
+        self.0
+            .set(None)
+            .expect("WriteCell should be modified exactly once");
+    }
+
+    pub fn get(&self) -> Option<&Option<V>> {
+        self.0.get()
+    }
+}
+
+impl<K: Hash + Clone + Eq, V: Debug> MVHashMap<K, V> {
+    /// Create the MVHashMap structure from a list of possible writes. Each element in the list
+    /// indicates a key that could potentially be modified at its given version.
+    ///
+    /// Returns the MVHashMap, and the maximum number of writes that can write to one single key.
+    pub fn new_from(possible_writes: Vec<(K, Version)>) -> (Self, usize) {
+        let mut outer_map: HashMap<K, BTreeMap<Version, WriteCell<V>>> = HashMap::new();
+        for (key, version) in possible_writes.into_iter() {
+            outer_map
+                .entry(key)
+                .or_default()
+                .insert(version, WriteCell::new());
+        }
+        let max_dependency_size = outer_map
+            .values()
+            .fold(0, |max_depth, btree_map| max(max_depth, btree_map.len()));
+
+        (MVHashMap { data: outer_map }, max_dependency_size)
+    }
+
+    /// Get the number of keys in the MVHashMap.
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    fn get_entry(&self, key: &K, version: Version) -> Result<&WriteCell<V>, Error> {
+        self.data
+            .get(key)
+            .ok_or(Error::UnexpectedWrite)?
+            .get(&version)
+            .ok_or(Error::UnexpectedWrite)
+    }
+
+    /// Write to `key` at `version`.
+    /// Function will return an error if the write is not in the initial `possible_writes` list.
+    pub fn write(&self, key: &K, version: Version, data: V) -> Result<(), Error> {
+        // By construction there will only be a single writer, before the
+        // write there will be no readers on the variable.
+        // So it is safe to go ahead and write without any further check.
+
+        let entry = self.get_entry(key, version)?;
+
+        #[cfg(test)]
+        {
+            // Test the invariant holds
+            if entry.is_assigned() {
+                panic!("Cannot write twice to same entry.");
+            }
+        }
+
+        entry.write(data);
+
+        Ok(())
+    }
+
+    /// Skips writing to `key` at `version` if that entry hasn't been assigned.
+    /// Function will return an error if the write is not in the initial `possible_writes` list.
+    pub fn skip_if_not_set(&self, key: &K, version: Version) -> Result<(), Error> {
+        // We only write or skip once per entry
+        // So it is safe to go ahead and just do it.
+        let entry = self.get_entry(key, version)?;
+
+        // Test the invariant holds
+        if !entry.is_assigned() {
+            entry.skip();
+        }
+
+        Ok(())
+    }
+
+    /// Skips writing to `key` at `version`.
+    /// Function will return an error if the write is not in the initial `possible_writes` list.
+    /// `skip` should only be invoked when `key` at `version` hasn't been assigned.
+    pub fn skip(&self, key: &K, version: Version) -> Result<(), Error> {
+        // We only write or skip once per entry
+        // So it is safe to go ahead and just do it.
+        let entry = self.get_entry(key, version)?;
+
+        #[cfg(test)]
+        {
+            // Test the invariant holds
+            if entry.is_assigned() {
+                panic!("Cannot write twice to same entry.");
+            }
+        }
+
+        entry.skip();
+        Ok(())
+    }
+
+    /// Get the value of `key` at `version`.
+    /// Returns Ok(val) if such key is already assigned by previous transactions.
+    /// Returns Err(None) if `version` is smaller than the write of all previous versions.
+    /// Returns Err(Some(version)) if such key is dependent on the `version`-th transaction.
+    pub fn read(&self, key: &K, version: Version) -> Result<&V, Option<Version>> {
+        let tree = self.data.get(key).ok_or(None)?;
+
+        let mut iter = tree.range(0..version);
+
+        while let Some((entry_key, entry_val)) = iter.next_back() {
+            if *entry_key < version {
+                match entry_val.get() {
+                    // Entry not yet computed, return the version that blocked this query.
+                    None => return Err(Some(*entry_key)),
+                    // Entry is skipped, go to previous version.
+                    Some(None) => continue,
+                    Some(Some(v)) => return Ok(v),
+                }
+            }
+        }
+
+        Err(None)
+    }
+}
+
+const PARALLEL_THRESHOLD: usize = 1000;
+
+impl<K, V> MVHashMap<K, V>
+where
+    K: PartialOrd + Send + Clone + Hash + Eq,
+    V: Send + Debug,
+{
+    fn split_merge(
+        num_cpus: usize,
+        recursion_depth: usize,
+        split: Vec<(K, Version)>,
+    ) -> (usize, HashMap<K, BTreeMap<Version, WriteCell<V>>>) {
+        if (1 << recursion_depth) > num_cpus || split.len() < PARALLEL_THRESHOLD {
+            let mut data = HashMap::new();
+            let mut max_len = 0;
+            for (path, version) in split.into_iter() {
+                let place = data.entry(path).or_insert_with(BTreeMap::new);
+                place.insert(version, WriteCell::new());
+                max_len = max(max_len, place.len());
+            }
+            (max_len, data)
+        } else {
+            // Partition the possible writes by keys and work on each partition in parallel.
+            let pivot_address = split[split.len() / 2].0.clone();
+            let (left, right): (Vec<_>, Vec<_>) =
+                split.into_iter().partition(|(p, _)| *p < pivot_address);
+            let ((m0, mut left_map), (m1, right_map)) = rayon::join(
+                || Self::split_merge(num_cpus, recursion_depth + 1, left),
+                || Self::split_merge(num_cpus, recursion_depth + 1, right),
+            );
+            left_map.extend(right_map);
+            (max(m0, m1), left_map)
+        }
+    }
+
+    /// Create the MVHashMap structure from a list of possible writes in parallel.
+    pub fn new_from_parallel(possible_writes: Vec<(K, Version)>) -> (Self, usize) {
+        let num_cpus = num_cpus::get();
+
+        let (max_dependency_len, data) = Self::split_merge(num_cpus, 0, possible_writes);
+        (MVHashMap { data }, max_dependency_len)
+    }
+}

--- a/language/diem-vm/mvhashmap/src/unit_tests/mod.rs
+++ b/language/diem-vm/mvhashmap/src/unit_tests/mod.rs
@@ -1,0 +1,58 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+
+mod proptest_types;
+
+#[test]
+fn create_write_read_placeholder_struct() {
+    let ap1 = b"/foo/b".to_vec();
+    let ap2 = b"/foo/c".to_vec();
+    let ap3 = b"/foo/d".to_vec();
+
+    let data = vec![(ap1.clone(), 10), (ap2.clone(), 10), (ap2.clone(), 20)];
+
+    let (mvtbl, max_dep) = MVHashMap::new_from(data);
+
+    assert_eq!(2, max_dep);
+
+    assert_eq!(2, mvtbl.len());
+
+    // Reads that should go the the DB return Err(None)
+    let r1 = mvtbl.read(&ap1, 5);
+    assert_eq!(Err(None), r1);
+
+    // Reads at a version return the previous versions, not this
+    // version.
+    let r1 = mvtbl.read(&ap1, 10);
+    assert_eq!(Err(None), r1);
+
+    // Check reads into non-ready structs return the Err(entry)
+
+    // Reads at a higher version return the previous version
+    let r1 = mvtbl.read(&ap1, 15);
+    assert_eq!(Err(Some(10)), r1);
+
+    // Writes populate the entry
+    mvtbl.write(&ap1, 10, Some(vec![0, 0, 0])).unwrap();
+
+    // Write to unexpected entries
+    assert!(mvtbl.write(&ap1, 1, Some(vec![0, 0, 0])).is_err());
+    assert!(mvtbl.write(&ap3, 10, Some(vec![0, 0, 0])).is_err());
+
+    // Subsequent higher reads read this entry
+    let r1 = mvtbl.read(&ap1, 15);
+    assert_eq!(Ok(&Some(vec![0, 0, 0])), r1);
+
+    // Set skip works
+    assert!(mvtbl.skip(&ap1, 20).is_err());
+
+    mvtbl.skip(&ap2, 20).unwrap();
+    // Writes populate the entry
+    mvtbl.write(&ap2, 10, Some(vec![0, 0, 0])).unwrap();
+
+    // Higher reads skip this entry
+    let r1 = mvtbl.read(&ap2, 25);
+    assert_eq!(Ok(&Some(vec![0, 0, 0])), r1);
+}

--- a/language/diem-vm/mvhashmap/src/unit_tests/proptest_types.rs
+++ b/language/diem-vm/mvhashmap/src/unit_tests/proptest_types.rs
@@ -1,0 +1,186 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use super::MVHashMap;
+use proptest::{collection::vec, prelude::*, sample::Index, strategy::Strategy};
+use std::{
+    collections::{BTreeMap, HashMap},
+    fmt::Debug,
+    hash::Hash,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+const DEFAULT_TIMEOUT: u64 = 30;
+
+#[derive(Debug, Clone)]
+enum Operator<V: Debug + Clone> {
+    Insert(V),
+    Remove,
+    Skip,
+    Read,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum ExpectedOutput<V: Debug + Clone + PartialEq> {
+    NotInMap,
+    Deleted,
+    Value(V),
+}
+
+struct Baseline<K, V>(HashMap<K, BTreeMap<usize, Option<V>>>);
+
+impl<K, V> Baseline<K, V>
+where
+    K: Hash + Eq + Clone,
+    V: Clone + Debug + PartialEq,
+{
+    pub fn new(txns: &[(K, Operator<V>)]) -> Self {
+        let mut baseline: HashMap<K, BTreeMap<usize, Option<V>>> = HashMap::new();
+        for (idx, (k, op)) in txns.iter().enumerate() {
+            let value_to_update = match op {
+                Operator::Insert(v) => Some(v.clone()),
+                Operator::Remove => None,
+                Operator::Skip | Operator::Read => continue,
+            };
+
+            baseline
+                .entry(k.clone())
+                .or_insert_with(BTreeMap::new)
+                .insert(idx, value_to_update);
+        }
+        Self(baseline)
+    }
+
+    pub fn get(&self, key: &K, version: usize) -> ExpectedOutput<V> {
+        match self
+            .0
+            .get(key)
+            .and_then(|tree| tree.range(..version).last())
+        {
+            None => ExpectedOutput::NotInMap,
+            Some((_, Some(v))) => ExpectedOutput::Value(v.clone()),
+            Some((_, None)) => ExpectedOutput::Deleted,
+        }
+    }
+}
+
+fn operator_strategy<V: Arbitrary + Clone>() -> impl Strategy<Value = Operator<V>> {
+    prop_oneof![
+        2 => any::<V>().prop_map(Operator::Insert),
+        1 => Just(Operator::Remove),
+        1 => Just(Operator::Skip),
+        4 => Just(Operator::Read),
+    ]
+}
+
+fn run_and_assert<K, V>(
+    universe: Vec<K>,
+    transaction_gens: Vec<(Index, Operator<V>)>,
+) -> Result<(), TestCaseError>
+where
+    K: PartialOrd + Send + Clone + Hash + Eq + Sync,
+    V: Send + Debug + Clone + PartialEq + Sync,
+{
+    let transactions: Vec<(K, Operator<V>)> = transaction_gens
+        .into_iter()
+        .map(|(idx, op)| (idx.get(&universe).clone(), op))
+        .collect::<Vec<_>>();
+
+    let versions_to_write = transactions
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, (key, op))| match op {
+            Operator::Read => None,
+            Operator::Insert(_) | Operator::Skip | Operator::Remove => Some((key.clone(), idx)),
+        })
+        .collect::<Vec<_>>();
+
+    let baseline = Baseline::new(transactions.as_slice());
+    let (map, _) = MVHashMap::<K, Option<V>>::new_from_parallel(versions_to_write);
+    let curent_idx = AtomicUsize::new(0);
+
+    // Spawn a few threads in parallel to commit each operator.
+    rayon::scope(|s| {
+        for _ in 0..universe.len() {
+            s.spawn(|_| loop {
+                // Each thread will eagerly fetch an Operator to execute.
+                let idx = curent_idx.fetch_add(1, Ordering::Relaxed);
+                if idx >= transactions.len() {
+                    // Abort when all transactions are processed.
+                    break;
+                }
+                let key = &transactions[idx].0;
+                match &transactions[idx].1 {
+                    Operator::Read => {
+                        let baseline = baseline.get(key, idx);
+                        let mut retry_attempts = 0;
+                        loop {
+                            match map.read(key, idx) {
+                                Ok(Some(v)) => {
+                                    assert_eq!(
+                                        baseline,
+                                        ExpectedOutput::Value(v.clone()),
+                                        "{:?}",
+                                        idx
+                                    );
+                                    break;
+                                }
+                                Ok(None) => {
+                                    assert_eq!(baseline, ExpectedOutput::Deleted, "{:?}", idx);
+                                    break;
+                                }
+                                Err(None) => {
+                                    assert_eq!(baseline, ExpectedOutput::NotInMap, "{:?}", idx);
+                                    break;
+                                }
+                                Err(Some(_i)) => (),
+                            }
+                            retry_attempts += 1;
+                            if retry_attempts > DEFAULT_TIMEOUT {
+                                panic!("Failed to get value for {:?}", idx);
+                            }
+                            std::thread::sleep(std::time::Duration::from_millis(100));
+                        }
+                    }
+                    Operator::Skip => {
+                        map.skip(key, idx).unwrap();
+                    }
+                    Operator::Remove => {
+                        map.write(key, idx, None).unwrap();
+                    }
+                    Operator::Insert(v) => {
+                        map.write(key, idx, Some(v.clone())).unwrap();
+                    }
+                }
+            })
+        }
+    });
+    Ok(())
+}
+
+proptest! {
+    #[test]
+    fn single_key_proptest(
+        universe in vec(any::<[u8; 32]>(), 1),
+        transactions in vec((any::<Index>(), operator_strategy::<[u8; 32]>()), 100),
+    ) {
+        run_and_assert(universe, transactions)?;
+    }
+
+    #[test]
+    fn single_key_large_transactions(
+        universe in vec(any::<[u8; 32]>(), 1),
+        transactions in vec((any::<Index>(), operator_strategy::<[u8; 32]>()), 2000),
+    ) {
+        run_and_assert(universe, transactions)?;
+    }
+
+
+    #[test]
+    fn multi_key_proptest(
+        universe in vec(any::<[u8; 32]>(), 10),
+        transactions in vec((any::<Index>(), operator_strategy::<[u8; 32]>()), 100),
+    ) {
+        run_and_assert(universe, transactions)?;
+    }
+}

--- a/x.toml
+++ b/x.toml
@@ -220,6 +220,7 @@ members = [
     "move-transactional-test-runner",
     "move-vm-integration-tests",
     "move-vm-transactional-tests",
+    "mvhashmap", # Will be removed once mvhashmap is used in production.
     "offchain",
     "scratchpad-benchmark",
     "sdk-compatibility",


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This is the definition of the core placeholder data structure for parallel execution. This structure is inspired by [bohm](https://arxiv.org/pdf/1412.2324.pdf) protocol and serve as the multi-version scratchpad used by the parallel execution engine. The public api look like following:

```
impl<K: Hash + Clone + Eq, V: Clone> MVHashMap<K, V> {
    fn new_from(
        possible_writes: Vec<(K, Version)>
    ) -> (usize, MVHashMap<K, V>);

    // Write APIs
    fn write(
        &self,
        key: &K,
        version: Version,
        data: V
    ) -> Result<()>;

    fn skip_if_not_set(&self, key: &K, version: Version) -> Result<()>;

    fn skip(&self, key: &K, version: Version) -> Result<()>;

    // Read API
    fn read(
        &self, 
        key: &K, 
        version: Version
    ) -> Result<&V, Option<Version>>;
}
```

The idea is to create placeholder data structures ahead of time for each possible writes and provide apis to either:
1. read a key at given version
2. write a key at given version
3. skip a key if it was predicted to be written at first but didn't happen after computation.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Implemented a proptest for generating random keys read and write operations and check execution in parallel.

## If targeting a release branch, please fill the below out as well

## Related PRs
#8829