### PR TITLE
[gha] only run helm tests on chart changes

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -106,7 +106,7 @@ jobs:
         name: find helm changes
         uses: diem/actions/matches@faadd16607b77dfa2231a8f366883e01717b3225
         with:
-          pattern: '^.github\|^helm\|^developers.diem.com'
+          pattern: '^helm'
       - id: dev-setup-sh-changes
         name: find dev-setup.sh/base docker image changes
         uses: diem/actions/matches@faadd16607b77dfa2231a8f366883e01717b3225


### PR DESCRIPTION
Prevent some flakes blocking unrelated PRs. Planning on moving the helm charts to an actual public helm repo instead of being hosted in this github repo in the future, so we can deprecate this test when that happens.