### PR TITLE
[forge] resize k8s cluster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3255,6 +3255,7 @@ dependencies = [
  "rand 0.8.3",
  "rand_core 0.6.2",
  "rayon",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/testsuite/forge/Cargo.toml
+++ b/testsuite/forge/Cargo.toml
@@ -15,6 +15,7 @@ futures = "0.3.12"
 itertools = "0.10.0"
 rand = "0.8.3"
 rayon = "1.5.0"
+regex = "1.4.3"
 structopt = "0.3.21"
 termcolor = "1.1.2"
 tokio = { version = "1.8.1", features = ["full"] }

--- a/testsuite/forge/src/backend/k8s/node.rs
+++ b/testsuite/forge/src/backend/k8s/node.rs
@@ -60,7 +60,7 @@ impl Node for K8sNode {
     }
 
     fn json_rpc_endpoint(&self) -> Url {
-        Url::from_str(&format!("http://{}:{}/v1", self.ip(), self.port())).expect("Invalid URL.")
+        Url::from_str(&format!("http://{}:{}/v1", self.dns(), self.port())).expect("Invalid URL.")
     }
 
     fn debug_endpoint(&self) -> Url {

--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -293,6 +293,7 @@ async fn get_validators(client: K8sClient) -> Result<HashMap<PeerId, K8sNode>> {
             let node_id = parse_node_id(&s.name).expect("error to parse node id");
             let node = K8sNode {
                 name: format!("val-{}", node_id),
+                // TODO: fetch this from running node
                 peer_id: PeerId::random(),
                 node_id,
                 ip: s.host_ip.clone(),


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Give Forge the ability to resize a k8s testnet in its cleanup procedure. Since we're re-running genesis to wipe the chain data, we can also use this time to scale up/down the cluster and the corresponding validator set size. The process is as follows:
1. uninstall all validators
2. save the helm values for each validator
3. edit the helm values for each validator with a random new chain era
4. upgrade each validator with each new helm values, forcing a chain wipe
5. upgrade testnet helm chart with new chain era, forcing genesis to run again
6. wait for genesis to complete and healthchecks on each VFN to complete

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Run this against a test cluster within the same network

```
$ ./forge --clean-up --num-validators 30
```