### PR TITLE
[move-prover] fix a bug on local vars naming in boogie translation

### DIFF
--- a/language/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/language/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -548,16 +548,18 @@ impl<'env> FunctionTranslator<'env> {
             );
         }
         // Generate declarations for modifies condition.
+        let mut mem_inst_seen = BTreeSet::new();
         for qid in fun_target.get_modify_ids() {
-            emitln!(
-                writer,
-                "var {}: {}",
-                boogie_modifies_memory_name(
-                    fun_target.global_env(),
-                    &qid.instantiate(self.type_inst)
-                ),
-                "[int]bool;"
-            );
+            let memory = qid.instantiate(self.type_inst);
+            if !mem_inst_seen.contains(&memory) {
+                emitln!(
+                    writer,
+                    "var {}: {}",
+                    boogie_modifies_memory_name(fun_target.global_env(), &memory),
+                    "[int]bool;"
+                );
+                mem_inst_seen.insert(memory);
+            }
         }
 
         // Declare temporaries for debug tracing and other purposes.


### PR DESCRIPTION
The local vars added for checking the modifies properties may have
the same name after function instantiation, e.g., one via concrete type
and the other via type parameter being instantiated.

An example is
`DesignatedDealer::publish_designated_dealer_credential<CoinType>`,
which has a function spec with the following two clauses:

```
spec {
    modifies global<Diem::PreburnQueue<CoinType>>(dd_addr);
    modifies global<Diem::PreburnQueue<XUS>>(dd_addr);
}
```

The both `modifies` clauses will lead to a
`var $1_Diem_PreburnQueue'$1_XUS_XUS'_$modifies: [int]bool;`
being created by the Boogie backend, which we do not want.

The fix is to just keep one var and drop others if we see the same
memory again.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Fix an issue uncovered in the exercise of ignore `pragma opaque`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI, everything should continue to verify
