### PR TITLE
[move] Standardize IR compiler main function

### DIFF
--- a/language/compiler/src/util.rs
+++ b/language/compiler/src/util.rs
@@ -3,12 +3,28 @@
 
 use anyhow::Context;
 use bytecode_source_map::source_map::SourceMap;
-use ir_to_bytecode::{compiler::compile_module, parser::parse_module};
-use move_binary_format::file_format::CompiledModule;
+use ir_to_bytecode::{
+    compiler::{compile_module, compile_script},
+    parser::{parse_module, parse_script},
+};
+use move_binary_format::file_format::{CompiledModule, CompiledScript};
 use move_core_types::account_address::AccountAddress;
 use move_ir_types::location::Loc;
 use move_symbol_pool::Symbol;
 use std::{fs, path::Path};
+
+pub fn do_compile_script(
+    source_path: &Path,
+    address: AccountAddress,
+    dependencies: &[CompiledModule],
+) -> (CompiledScript, SourceMap<Loc>) {
+    let source = fs::read_to_string(source_path)
+        .with_context(|| format!("Unable to read file: {:?}", source_path))
+        .unwrap();
+    let file = Symbol::from(source_path.as_os_str().to_str().unwrap());
+    let parsed_script = parse_script(file, &source).unwrap();
+    compile_script(Some(address), parsed_script, dependencies).unwrap()
+}
 
 pub fn do_compile_module(
     source_path: &Path,


### PR DESCRIPTION
A small cleanup of the entry point of the `compiler` executable:

* Honor the `--no-verify` option for scripts.
* Flip "if not ... else" conditional to "if ... else".
* Unify the helper functions and flow between the module and script path.