### PR TITLE
[move-model] make invariants in ConditionKind more fine-grained

### DIFF
--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -259,7 +259,7 @@ pub enum SpecBlockMember_ {
 pub type SpecBlockMember = Spanned<SpecBlockMember_>;
 
 #[derive(PartialEq, Clone, Debug)]
-pub enum SpecConditionKind {
+pub enum SpecConditionKind_ {
     Assert,
     Assume,
     Decreases,
@@ -274,6 +274,7 @@ pub enum SpecConditionKind {
     InvariantUpdate(Vec<(Name, AbilitySet)>),
     Axiom(Vec<(Name, AbilitySet)>),
 }
+pub type SpecConditionKind = Spanned<SpecConditionKind_>;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct PragmaProperty_ {
@@ -964,9 +965,9 @@ impl AstDebug for SpecBlockTarget_ {
     }
 }
 
-impl AstDebug for SpecConditionKind {
+impl AstDebug for SpecConditionKind_ {
     fn ast_debug(&self, w: &mut AstWriter) {
-        use SpecConditionKind::*;
+        use SpecConditionKind_::*;
         match self {
             Assert => w.write("assert "),
             Assume => w.write("assume "),

--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -1128,47 +1128,48 @@ fn spec_target(context: &mut Context, sp!(loc, pt): P::SpecBlockTarget) -> E::Sp
 
 fn spec_condition_kind(
     context: &mut Context,
-    kind: P::SpecConditionKind,
+    sp!(loc, kind): P::SpecConditionKind,
 ) -> (E::SpecConditionKind, Option<OldAliasMap>) {
-    match kind {
-        P::SpecConditionKind::Assert => (E::SpecConditionKind::Assert, None),
-        P::SpecConditionKind::Assume => (E::SpecConditionKind::Assume, None),
-        P::SpecConditionKind::Decreases => (E::SpecConditionKind::Decreases, None),
-        P::SpecConditionKind::AbortsIf => (E::SpecConditionKind::AbortsIf, None),
-        P::SpecConditionKind::AbortsWith => (E::SpecConditionKind::AbortsWith, None),
-        P::SpecConditionKind::SucceedsIf => (E::SpecConditionKind::SucceedsIf, None),
-        P::SpecConditionKind::Modifies => (E::SpecConditionKind::Modifies, None),
-        P::SpecConditionKind::Emits => (E::SpecConditionKind::Emits, None),
-        P::SpecConditionKind::Ensures => (E::SpecConditionKind::Ensures, None),
-        P::SpecConditionKind::Requires => (E::SpecConditionKind::Requires, None),
-        P::SpecConditionKind::Invariant(pty_params) => {
+    let (kind_, aliases_opt) = match kind {
+        P::SpecConditionKind_::Assert => (E::SpecConditionKind_::Assert, None),
+        P::SpecConditionKind_::Assume => (E::SpecConditionKind_::Assume, None),
+        P::SpecConditionKind_::Decreases => (E::SpecConditionKind_::Decreases, None),
+        P::SpecConditionKind_::AbortsIf => (E::SpecConditionKind_::AbortsIf, None),
+        P::SpecConditionKind_::AbortsWith => (E::SpecConditionKind_::AbortsWith, None),
+        P::SpecConditionKind_::SucceedsIf => (E::SpecConditionKind_::SucceedsIf, None),
+        P::SpecConditionKind_::Modifies => (E::SpecConditionKind_::Modifies, None),
+        P::SpecConditionKind_::Emits => (E::SpecConditionKind_::Emits, None),
+        P::SpecConditionKind_::Ensures => (E::SpecConditionKind_::Ensures, None),
+        P::SpecConditionKind_::Requires => (E::SpecConditionKind_::Requires, None),
+        P::SpecConditionKind_::Invariant(pty_params) => {
             let ety_params = type_parameters(context, pty_params);
             let old_aliases = context
                 .aliases
                 .shadow_for_type_parameters(ety_params.iter().map(|(name, _)| name));
             (
-                E::SpecConditionKind::Invariant(ety_params),
+                E::SpecConditionKind_::Invariant(ety_params),
                 Some(old_aliases),
             )
         }
-        P::SpecConditionKind::InvariantUpdate(pty_params) => {
+        P::SpecConditionKind_::InvariantUpdate(pty_params) => {
             let ety_params = type_parameters(context, pty_params);
             let old_aliases = context
                 .aliases
                 .shadow_for_type_parameters(ety_params.iter().map(|(name, _)| name));
             (
-                E::SpecConditionKind::InvariantUpdate(ety_params),
+                E::SpecConditionKind_::InvariantUpdate(ety_params),
                 Some(old_aliases),
             )
         }
-        P::SpecConditionKind::Axiom(pty_params) => {
+        P::SpecConditionKind_::Axiom(pty_params) => {
             let ety_params = type_parameters(context, pty_params);
             let old_aliases = context
                 .aliases
                 .shadow_for_type_parameters(ety_params.iter().map(|(name, _)| name));
-            (E::SpecConditionKind::Axiom(ety_params), Some(old_aliases))
+            (E::SpecConditionKind_::Axiom(ety_params), Some(old_aliases))
         }
-    }
+    };
+    (sp(loc, kind_), aliases_opt)
 }
 
 fn spec_member(context: &mut Context, sp!(loc, pm): P::SpecBlockMember) -> E::SpecBlockMember {

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -332,7 +332,6 @@ pub type SpecApplyFragment = Spanned<SpecApplyFragment_>;
 pub enum SpecBlockMember_ {
     Condition {
         kind: SpecConditionKind,
-        type_parameters: Vec<(Name, Vec<Ability>)>,
         properties: Vec<PragmaProperty>,
         exp: Exp,
         additional_exps: Vec<Exp>,
@@ -383,9 +382,9 @@ pub enum SpecConditionKind {
     Emits,
     Ensures,
     Requires,
-    Invariant,
-    InvariantUpdate,
-    Axiom,
+    Invariant(Vec<(Name, Vec<Ability>)>),
+    InvariantUpdate(Vec<(Name, Vec<Ability>)>),
+    Axiom(Vec<(Name, Vec<Ability>)>),
 }
 
 //**************************************************************************************************
@@ -1237,9 +1236,21 @@ impl AstDebug for SpecConditionKind {
             Emits => w.write("emits "),
             Ensures => w.write("ensures "),
             Requires => w.write("requires "),
-            Invariant => w.write("invariant "),
-            InvariantUpdate => w.write("invariant update "),
-            Axiom => w.write("axiom "),
+            Invariant(ty_params) => {
+                w.write("invariant");
+                ty_params.ast_debug(w);
+                w.write(" ")
+            }
+            InvariantUpdate(ty_params) => {
+                w.write("invariant");
+                ty_params.ast_debug(w);
+                w.write(" update ")
+            }
+            Axiom(ty_params) => {
+                w.write("axiom");
+                ty_params.ast_debug(w);
+                w.write(" ")
+            }
         }
     }
 }
@@ -1249,13 +1260,11 @@ impl AstDebug for SpecBlockMember_ {
         match self {
             SpecBlockMember_::Condition {
                 kind,
-                type_parameters,
                 properties: _,
                 exp,
                 additional_exps,
             } => {
                 kind.ast_debug(w);
-                type_parameters.ast_debug(w);
                 exp.ast_debug(w);
                 w.list(additional_exps, ",", |w, e| {
                     e.ast_debug(w);

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -371,7 +371,7 @@ pub type SpecBlockMember = Spanned<SpecBlockMember_>;
 
 // Specification condition kind.
 #[derive(PartialEq, Clone, Debug)]
-pub enum SpecConditionKind {
+pub enum SpecConditionKind_ {
     Assert,
     Assume,
     Decreases,
@@ -386,6 +386,7 @@ pub enum SpecConditionKind {
     InvariantUpdate(Vec<(Name, Vec<Ability>)>),
     Axiom(Vec<(Name, Vec<Ability>)>),
 }
+pub type SpecConditionKind = Spanned<SpecConditionKind_>;
 
 //**************************************************************************************************
 // Types
@@ -1222,9 +1223,9 @@ impl AstDebug for SpecBlockTarget_ {
     }
 }
 
-impl AstDebug for SpecConditionKind {
+impl AstDebug for SpecConditionKind_ {
     fn ast_debug(&self, w: &mut AstWriter) {
-        use SpecConditionKind::*;
+        use SpecConditionKind_::*;
         match self {
             Assert => w.write("assert "),
             Assume => w.write("assume "),

--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -2408,7 +2408,6 @@ fn parse_condition(tokens: &mut Lexer) -> Result<SpecBlockMember, Diagnostic> {
         end_loc,
         SpecBlockMember_::Condition {
             kind,
-            type_parameters: vec![],
             properties,
             exp,
             additional_exps,
@@ -2447,8 +2446,7 @@ fn parse_axiom(tokens: &mut Lexer) -> Result<SpecBlockMember, Diagnostic> {
         start_loc,
         tokens.previous_end_loc(),
         SpecBlockMember_::Condition {
-            kind: SpecConditionKind::Axiom,
-            type_parameters,
+            kind: SpecConditionKind::Axiom(type_parameters),
             properties,
             exp,
             additional_exps: vec![],
@@ -2465,9 +2463,9 @@ fn parse_invariant(tokens: &mut Lexer) -> Result<SpecBlockMember, Diagnostic> {
     let kind = match tokens.peek() {
         Tok::IdentifierValue if tokens.content() == "update" => {
             tokens.advance()?;
-            SpecConditionKind::InvariantUpdate
+            SpecConditionKind::InvariantUpdate(type_parameters)
         }
-        _ => SpecConditionKind::Invariant,
+        _ => SpecConditionKind::Invariant(type_parameters),
     };
     let properties = parse_condition_properties(tokens)?;
     let exp = parse_exp(tokens)?;
@@ -2478,7 +2476,6 @@ fn parse_invariant(tokens: &mut Lexer) -> Result<SpecBlockMember, Diagnostic> {
         tokens.previous_end_loc(),
         SpecBlockMember_::Condition {
             kind,
-            type_parameters,
             properties,
             exp,
             additional_exps: vec![],

--- a/language/move-model/src/pragmas.rs
+++ b/language/move-model/src/pragmas.rs
@@ -168,7 +168,7 @@ pub fn is_property_valid_for_condition(kind: &ConditionKind, prop: &str) -> bool
     }
     use crate::ast::ConditionKind::*;
     match kind {
-        Invariant | InvariantUpdate => {
+        Invariant(..) | InvariantUpdate(..) => {
             matches!(prop, CONDITION_GLOBAL_PROP | CONDITION_ISOLATED_PROP)
         }
         SucceedsIf | AbortsIf => matches!(

--- a/language/move-model/src/pragmas.rs
+++ b/language/move-model/src/pragmas.rs
@@ -168,7 +168,7 @@ pub fn is_property_valid_for_condition(kind: &ConditionKind, prop: &str) -> bool
     }
     use crate::ast::ConditionKind::*;
     match kind {
-        Invariant(..) | InvariantUpdate(..) => {
+        GlobalInvariant(..) | GlobalInvariantUpdate(..) => {
             matches!(prop, CONDITION_GLOBAL_PROP | CONDITION_ISOLATED_PROP)
         }
         SucceedsIf | AbortsIf => matches!(

--- a/language/move-prover/bytecode/src/data_invariant_instrumentation.rs
+++ b/language/move-prover/bytecode/src/data_invariant_instrumentation.rs
@@ -20,7 +20,7 @@ use crate::{
 
 use move_model::{
     ast,
-    ast::{Exp, ExpData, QuantKind, TempIndex},
+    ast::{ConditionKind, Exp, ExpData, QuantKind, TempIndex},
     exp_generator::ExpGenerator,
     model::{FunctionEnv, Loc, NodeId, StructEnv},
     ty::Type,
@@ -209,7 +209,10 @@ impl<'a> Instrumenter<'a> {
 
         // First generate a conjunction for all invariants on this struct.
         let mut result = vec![];
-        for cond in struct_env.get_spec().filter_kind_invariant() {
+        for cond in struct_env
+            .get_spec()
+            .filter_kind(ConditionKind::StructInvariant)
+        {
             // Rewrite the invariant expression, inserting `value` for the struct target.
             // By convention, selection from the target is represented as a `Select` operation with
             // an empty argument list. It is guaranteed that this uniquely identifies the

--- a/language/move-prover/bytecode/src/data_invariant_instrumentation.rs
+++ b/language/move-prover/bytecode/src/data_invariant_instrumentation.rs
@@ -20,7 +20,7 @@ use crate::{
 
 use move_model::{
     ast,
-    ast::{ConditionKind, Exp, ExpData, QuantKind, TempIndex},
+    ast::{Exp, ExpData, QuantKind, TempIndex},
     exp_generator::ExpGenerator,
     model::{FunctionEnv, Loc, NodeId, StructEnv},
     ty::Type,
@@ -209,7 +209,7 @@ impl<'a> Instrumenter<'a> {
 
         // First generate a conjunction for all invariants on this struct.
         let mut result = vec![];
-        for cond in struct_env.get_spec().filter_kind(ConditionKind::Invariant) {
+        for cond in struct_env.get_spec().filter_kind_invariant() {
             // Rewrite the invariant expression, inserting `value` for the struct target.
             // By convention, selection from the target is represented as a `Select` operation with
             // an empty argument list. It is guaranteed that this uniquely identifies the

--- a/language/move-prover/bytecode/src/global_invariant_instrumentation.rs
+++ b/language/move-prover/bytecode/src/global_invariant_instrumentation.rs
@@ -143,7 +143,7 @@ impl<'a> Instrumenter<'a> {
             &[],
             invariants.iter().filter_map(|id| {
                 env.get_global_invariant(*id).filter(|inv| {
-                    if matches!(inv.kind, ConditionKind::Invariant(..)) {
+                    if matches!(inv.kind, ConditionKind::GlobalInvariant(..)) {
                         if module_env.is_transitive_dependency(inv.declaring_module)
                             && !module_env
                                 .env

--- a/language/move-prover/bytecode/src/global_invariant_instrumentation.rs
+++ b/language/move-prover/bytecode/src/global_invariant_instrumentation.rs
@@ -143,7 +143,7 @@ impl<'a> Instrumenter<'a> {
             &[],
             invariants.iter().filter_map(|id| {
                 env.get_global_invariant(*id).filter(|inv| {
-                    if inv.kind == ConditionKind::Invariant {
+                    if matches!(inv.kind, ConditionKind::Invariant(..)) {
                         if module_env.is_transitive_dependency(inv.declaring_module)
                             && !module_env
                                 .env

--- a/language/move-prover/bytecode/src/global_invariant_instrumentation_v2.rs
+++ b/language/move-prover/bytecode/src/global_invariant_instrumentation_v2.rs
@@ -315,12 +315,13 @@ impl<'a> Instrumenter<'a> {
             .iter()
             .filter_map(|id| {
                 env.get_global_invariant(*id).filter(|inv| {
-                    matches!(inv.kind, ConditionKind::Invariant(..)) // excludes "update invariants"
+                    // excludes "update invariants"
+                    matches!(inv.kind, ConditionKind::GlobalInvariant(..))
                         && module_env.is_transitive_dependency(inv.declaring_module)
-                        && !module_env.env.is_property_true(
-                            &inv.properties,
-                            CONDITION_ISOLATED_PROP)
-                        .unwrap_or(false)
+                        && !module_env
+                            .env
+                            .is_property_true(&inv.properties, CONDITION_ISOLATED_PROP)
+                            .unwrap_or(false)
                 })
             })
             .map(|inv| inv.id)
@@ -573,7 +574,7 @@ impl<'a> Instrumenter<'a> {
         let mut update_invs: BTreeSet<GlobalId> = BTreeSet::new();
         for inv_id in invariants {
             let inv = global_env.get_global_invariant(*inv_id).unwrap();
-            if matches!(inv.kind, ConditionKind::InvariantUpdate(..)) {
+            if matches!(inv.kind, ConditionKind::GlobalInvariantUpdate(..)) {
                 update_invs.insert(*inv_id);
             } else {
                 global_invs.insert(*inv_id);
@@ -634,7 +635,7 @@ impl<'a> Instrumenter<'a> {
                     && matches!(prop_kind, PropKind::Assume)
                     && matches!(
                         global_env.get_global_invariant(*mid).unwrap().kind,
-                        ConditionKind::InvariantUpdate(..)
+                        ConditionKind::GlobalInvariantUpdate(..)
                     )
                 {
                     panic!("Not allowed to assume update invariant");

--- a/language/move-prover/bytecode/src/global_invariant_instrumentation_v2.rs
+++ b/language/move-prover/bytecode/src/global_invariant_instrumentation_v2.rs
@@ -315,7 +315,7 @@ impl<'a> Instrumenter<'a> {
             .iter()
             .filter_map(|id| {
                 env.get_global_invariant(*id).filter(|inv| {
-                    inv.kind == ConditionKind::Invariant  // excludes "update invariants"
+                    matches!(inv.kind, ConditionKind::Invariant(..)) // excludes "update invariants"
                         && module_env.is_transitive_dependency(inv.declaring_module)
                         && !module_env.env.is_property_true(
                             &inv.properties,
@@ -573,7 +573,7 @@ impl<'a> Instrumenter<'a> {
         let mut update_invs: BTreeSet<GlobalId> = BTreeSet::new();
         for inv_id in invariants {
             let inv = global_env.get_global_invariant(*inv_id).unwrap();
-            if inv.kind == ConditionKind::InvariantUpdate {
+            if matches!(inv.kind, ConditionKind::InvariantUpdate(..)) {
                 update_invs.insert(*inv_id);
             } else {
                 global_invs.insert(*inv_id);
@@ -634,7 +634,7 @@ impl<'a> Instrumenter<'a> {
                     && matches!(prop_kind, PropKind::Assume)
                     && matches!(
                         global_env.get_global_invariant(*mid).unwrap().kind,
-                        ConditionKind::InvariantUpdate
+                        ConditionKind::InvariantUpdate(..)
                     )
                 {
                     panic!("Not allowed to assume update invariant");

--- a/language/move-prover/bytecode/src/memory_instrumentation.rs
+++ b/language/move-prover/bytecode/src/memory_instrumentation.rs
@@ -98,7 +98,7 @@ impl<'a> Instrumenter<'a> {
 
     /// Determines whether the struct needs a pack ref.
     fn is_pack_ref_struct(&self, struct_env: &StructEnv<'_>) -> bool {
-        struct_env.get_spec().any(|c| matches!(c.kind, ConditionKind::Invariant(..)))
+        struct_env.get_spec().any_kind(ConditionKind::StructInvariant)
         // If any of the fields has it, it inherits to the struct.
         ||  struct_env
             .get_fields()

--- a/language/move-prover/bytecode/src/memory_instrumentation.rs
+++ b/language/move-prover/bytecode/src/memory_instrumentation.rs
@@ -98,7 +98,7 @@ impl<'a> Instrumenter<'a> {
 
     /// Determines whether the struct needs a pack ref.
     fn is_pack_ref_struct(&self, struct_env: &StructEnv<'_>) -> bool {
-        struct_env.get_spec().any(|c| matches!(c.kind, ConditionKind::Invariant))
+        struct_env.get_spec().any(|c| matches!(c.kind, ConditionKind::Invariant(..)))
         // If any of the fields has it, it inherits to the struct.
         ||  struct_env
             .get_fields()

--- a/language/move-prover/bytecode/src/mono_analysis.rs
+++ b/language/move-prover/bytecode/src/mono_analysis.rs
@@ -18,7 +18,7 @@ use crate::{
 use itertools::Itertools;
 use move_model::{
     ast,
-    ast::{Condition, ConditionKind, Exp, ExpData, LocalVarDecl, MemoryLabel, QuantKind},
+    ast::{Condition, Exp, ExpData, LocalVarDecl, MemoryLabel, QuantKind},
     exp_generator::ExpGenerator,
     model::{
         FunId, GlobalEnv, ModuleId, NodeId, QualifiedId, QualifiedInstId, SpecFunId, SpecVarId,
@@ -152,7 +152,7 @@ impl FunctionTargetProcessor for MonoAnalysisProcessor {
         let mut new_axioms = vec![];
         let mut axioms_rewritten = false;
         for module_env in env.get_modules() {
-            for axiom in module_env.get_spec().filter_kind(ConditionKind::Axiom) {
+            for axiom in module_env.get_spec().filter_kind_axiom() {
                 let mut rewriter = TypeQuantRewriter {
                     generator: EnvGenerator {
                         env,
@@ -263,7 +263,7 @@ impl MonoAnalysisProcessor {
         } else {
             // Analyze axioms found in modules.
             for module_env in env.get_modules() {
-                for axiom in module_env.get_spec().filter_kind(ConditionKind::Axiom) {
+                for axiom in module_env.get_spec().filter_kind_axiom() {
                     analyzer.analyze_exp(&axiom.exp)
                 }
             }


### PR DESCRIPTION
`ConditionKind::Invariant` is an umbrella term for a wide variety of invariants listed below

- StructInvariant
- FunctionInvariant
- LoopInvariant
  (currently loop invariants are expressed in the form of `assert`s in loop header block, which is not the standard way of doing it, for example, Boogie uses the keyword `invariant` as a mark. This is because a loop invariant, like all other invariants, are essentially a pair of `assume` and `assert`).
- GlobalInvariant
- SchemaInvariant (which will be translated to one of the above types in schema application phase)

But these invariants are all different, and with the upcoming generic invariant semantic, only `GlobalInvariant`s are allowed to be generic, all the other invariant types should not. This fine-grained split allows the prover to control what can happen to each invariant type.

Note that although we split the invariant type in the prover side, we do not need to change the language syntax or the AST. We still use the keyword `invariant` to mark data invariant, global invariant, or function invariant in the spec language. The move-model will choose the correct invariant type when translating the AST, based on the context where this `invariant` keyword is defined. As a result, all existing spec are valid.

## Motivation

Only `GlobalInvariant` and `GlobalInvariantUpdate` are allowed to be generic, (i.e., take type parameters), the other invariant types should not. This fine-grained separate allows this intention to be explicitly honered.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI
