### PR TITLE
[move] Lex Move IR source buffers in-place

### DIFF
--- a/language/compiler/ir-to-bytecode/src/parser.rs
+++ b/language/compiler/ir-to-bytecode/src/parser.rs
@@ -12,11 +12,16 @@ use codespan_reporting::{
     },
 };
 use ir_to_bytecode_syntax::syntax::{self, ParseError};
-use move_command_line_common::character_sets::{is_permitted_char, is_permitted_newline_char};
+use move_command_line_common::character_sets::is_permitted_char;
 use move_core_types::account_address::AccountAddress;
 use move_ir_types::{ast, location::*};
 use move_symbol_pool::Symbol;
 
+// We restrict strings to only ascii visual characters (0x20 <= c <= 0x7E) or a permitted newline
+// character--\n--or a tab--\t. Checking each character in the input string is more fool-proof
+// than checking each character later during lexing & tokenization, since that would require special
+// handling of characters inside of comments (usually not included as tokens) and within byte
+// array literals.
 fn verify_string(string: &str) -> Result<()> {
     string
         .chars()
@@ -30,54 +35,25 @@ fn verify_string(string: &str) -> Result<()> {
         })
 }
 
-fn strip_comments(source: &str) -> String {
-    const SLASH: char = '/';
-    const SPACE: char = ' ';
-
-    let mut in_comment = false;
-    let mut acc = String::with_capacity(source.len());
-    let mut char_iter = source.chars().peekable();
-
-    while let Some(chr) = char_iter.next() {
-        let at_newline = is_permitted_newline_char(chr);
-        let at_or_after_slash_slash =
-            in_comment || (chr == SLASH && char_iter.peek().map(|c| *c == SLASH).unwrap_or(false));
-        in_comment = !at_newline && at_or_after_slash_slash;
-        acc.push(if in_comment { SPACE } else { chr });
-    }
-
-    acc
-}
-
-// We restrict strings to only ascii visual characters (0x20 <= c <= 0x7E) or a permitted newline
-// character--\n--or a tab--\t.
-fn strip_comments_and_verify(string: &str) -> Result<String> {
-    verify_string(string)?;
-    Ok(strip_comments(string))
-}
-
 /// Given the raw input of a file, creates a `ScriptOrModule` enum
 /// Fails with `Err(_)` if the text cannot be parsed`
 pub fn parse_script_or_module(file_name: Symbol, s: &str) -> Result<ast::ScriptOrModule> {
-    let stripped_string = &strip_comments_and_verify(s)?;
-    syntax::parse_script_or_module_string(file_name, stripped_string)
-        .or_else(|e| handle_error(e, s))
+    verify_string(s)?;
+    syntax::parse_script_or_module_string(file_name, s).or_else(|e| handle_error(e, s))
 }
 
 /// Given the raw input of a file, creates a `Script` struct
 /// Fails with `Err(_)` if the text cannot be parsed
 pub fn parse_script(file_name: Symbol, script_str: &str) -> Result<ast::Script> {
-    let stripped_string = &strip_comments_and_verify(script_str)?;
-    syntax::parse_script_string(file_name, stripped_string)
-        .or_else(|e| handle_error(e, stripped_string))
+    verify_string(script_str)?;
+    syntax::parse_script_string(file_name, script_str).or_else(|e| handle_error(e, script_str))
 }
 
 /// Given the raw input of a file, creates a single `ModuleDefinition` struct
 /// Fails with `Err(_)` if the text cannot be parsed
 pub fn parse_module(file_name: Symbol, modules_str: &str) -> Result<ast::ModuleDefinition> {
-    let stripped_string = &strip_comments_and_verify(modules_str)?;
-    syntax::parse_module_string(file_name, stripped_string)
-        .or_else(|e| handle_error(e, stripped_string))
+    verify_string(modules_str)?;
+    syntax::parse_module_string(file_name, modules_str).or_else(|e| handle_error(e, modules_str))
 }
 
 /// Given the raw input of a file, creates a single `Cmd_` struct
@@ -87,9 +63,8 @@ pub fn parse_cmd_(
     cmd_str: &str,
     _sender_address: AccountAddress,
 ) -> Result<ast::Cmd_> {
-    let stripped_string = &strip_comments_and_verify(cmd_str)?;
-    syntax::parse_cmd_string(file_name, stripped_string)
-        .or_else(|e| handle_error(e, stripped_string))
+    verify_string(cmd_str)?;
+    syntax::parse_cmd_string(file_name, cmd_str).or_else(|e| handle_error(e, cmd_str))
 }
 
 fn handle_error<T>(e: syntax::ParseError<Loc, anyhow::Error>, code_str: &str) -> Result<T> {
@@ -138,52 +113,6 @@ mod tests {
             let s = std::str::from_utf8(&good_chars)
                 .expect("Failed to construct string containing an invalid character. This shouldn't happen.");
             assert!(super::verify_string(s).is_err());
-            good_chars.pop();
-        }
-    }
-
-    #[test]
-    fn test_strip_comments() {
-        let mut good_chars = (0x20..=0x7E).map(|x: u8| x as char).collect::<String>();
-        good_chars.push(0x09 as char);
-        good_chars.push(0x0A as char);
-        good_chars.insert(0, 0x2F as char);
-        good_chars.insert(0, 0x2F as char);
-
-        {
-            let x = super::strip_comments(&good_chars);
-            assert!(x.chars().all(|x| x == ' ' || x == '\t' || x == '\n'));
-        }
-
-        // Remove the \n at the end of the line
-        good_chars.pop();
-
-        let bad_chars: Vec<u8> = vec![
-            0x0B, // VT
-            0x0C, // FF
-            0x0D, // CR
-            0x0D, 0x0A, // CRLF
-            0xC2, 0x85, // NEL
-            0xE2, 0x80, 0xA8, // LS
-            0xE2, 0x80, 0xA9, // PS
-            0x1E, // RS
-            0x15, // NL
-            0x76, // NEWLINE
-        ];
-
-        let bad_chars = std::str::from_utf8(&bad_chars).expect(
-            "Failed to construct string containing an invalid character. This shouldn't happen.",
-        );
-        for bad_char in bad_chars.chars() {
-            good_chars.push(bad_char);
-            good_chars.push('\n');
-            good_chars.push('a');
-            let x = super::strip_comments(&good_chars);
-            assert!(x
-                .chars()
-                .all(|c| c == ' ' || c == '\t' || c == '\n' || c == 'a'));
-            good_chars.pop();
-            good_chars.pop();
             good_chars.pop();
         }
     }


### PR DESCRIPTION
Rather than copy the source file into a string with its comments removed, skip over the comments while advancing the lexer.
    
~~Also, the lexer now verifies the source character set as it goes. Instead of iterating over each character before lexing and checking that it is part of the valid set, the lexer's default match arm for `ParseError::InvalidToken` catches any characters not explicitly accounted for.~~
    
~~The combination of these two changes means that commented-out Move IR may contain any characters, including emoji and bidirectional text. This isn't necessarily a "feature" -- the code is just less complex and more performant this way, and the lexer ought not care about commented-out text anyway.~~

Submitted on top of #8845 and #8860, in case you'd like to review those first.