### PR TITLE
[RFC][authenticator] Introduce a new trait TransactionAuthenticator

### DIFF
--- a/client/faucet/src/main.rs
+++ b/client/faucet/src/main.rs
@@ -135,7 +135,7 @@ mod tests {
             diem_id_identifier::DiemIdVaspDomainIdentifier,
             transaction::{
                 metadata::{CoinTradeMetadata, Metadata},
-                SignedTransaction, TransactionPayload,
+                DiemSignedTransaction, TransactionPayload,
                 TransactionPayload::{Script, ScriptFunction},
             },
         },
@@ -239,7 +239,7 @@ mod tests {
             .reply(&filter)
             .await;
         let body = resp.body();
-        let txns: Vec<SignedTransaction> =
+        let txns: Vec<DiemSignedTransaction> =
             bcs::from_bytes(&hex::decode(body).expect("hex encoded response body"))
                 .expect("valid bcs vec");
         assert_eq!(txns.len(), 2);
@@ -276,7 +276,7 @@ mod tests {
             .reply(&filter)
             .await;
         let body = resp.body();
-        let txns: Vec<SignedTransaction> =
+        let txns: Vec<DiemSignedTransaction> =
             bcs::from_bytes(&hex::decode(body).expect("hex encoded response body"))
                 .expect("valid bcs vec");
         assert_eq!(txns.len(), 2);
@@ -433,7 +433,8 @@ mod tests {
         match req["method"].as_str() {
             Some("submit") => {
                 let raw: &str = req["params"][0].as_str().unwrap();
-                let txn: SignedTransaction = bcs::from_bytes(&hex::decode(raw).unwrap()).unwrap();
+                let txn: DiemSignedTransaction =
+                    bcs::from_bytes(&hex::decode(raw).unwrap()).unwrap();
                 assert_eq!(txn.chain_id(), chain_id);
                 if let Script(script) = txn.payload() {
                     match ScriptCall::decode(script) {

--- a/client/faucet/src/mint.rs
+++ b/client/faucet/src/mint.rs
@@ -10,7 +10,7 @@ use diem_sdk::{
         account_address::AccountAddress,
         account_config::{testnet_dd_account_address, treasury_compliance_account_address},
         chain_id::ChainId,
-        transaction::{authenticator::AuthenticationKey, metadata, SignedTransaction},
+        transaction::{authenticator::AuthenticationKey, metadata, DiemSignedTransaction},
         LocalAccount,
     },
 };
@@ -20,7 +20,7 @@ use std::{fmt, sync::Mutex};
 #[derive(Debug)]
 pub enum Response {
     DDAccountNextSeqNum(u64),
-    SubmittedTxns(Vec<SignedTransaction>),
+    SubmittedTxns(Vec<DiemSignedTransaction>),
 }
 
 impl std::fmt::Display for Response {

--- a/client/json-rpc/src/broadcast_client.rs
+++ b/client/json-rpc/src/broadcast_client.rs
@@ -9,7 +9,7 @@ use diem_client::{
     Client, MethodRequest, MethodResponse, Response, Result,
 };
 use diem_types::{
-    account_address::AccountAddress, event::EventKey, transaction::SignedTransaction,
+    account_address::AccountAddress, event::EventKey, transaction::DiemSignedTransaction,
 };
 use futures::future::join_all;
 use rand::seq::{SliceChooseIter, SliceRandom};
@@ -68,7 +68,7 @@ impl BroadcastingClient {
         Ok(ok_results.swap_remove(0))
     }
 
-    pub async fn submit(&self, txn: &SignedTransaction) -> Result<Response<()>> {
+    pub async fn submit(&self, txn: &DiemSignedTransaction) -> Result<Response<()>> {
         let futures = self.random_clients().map(|client| client.submit(txn));
         let results = join_all(futures).await;
         collect_results(results)

--- a/config/management/operational/src/json_rpc.rs
+++ b/config/management/operational/src/json_rpc.rs
@@ -7,7 +7,7 @@ use diem_management::error::Error;
 use diem_types::{
     account_address::AccountAddress, account_config, account_config::AccountResource,
     account_state::AccountState, account_state_blob::AccountStateBlob,
-    transaction::SignedTransaction, validator_config::ValidatorConfigResource,
+    transaction::DiemSignedTransaction, validator_config::ValidatorConfigResource,
     validator_info::ValidatorInfo,
 };
 use std::convert::TryFrom;
@@ -26,7 +26,7 @@ impl JsonRpcClientWrapper {
 
     pub fn submit_transaction(
         &self,
-        transaction: SignedTransaction,
+        transaction: DiemSignedTransaction,
     ) -> Result<TransactionContext, Error> {
         self.client
             .submit(&transaction)

--- a/config/management/src/storage.rs
+++ b/config/management/src/storage.rs
@@ -10,7 +10,7 @@ use diem_network_address_encryption::Encryptor;
 use diem_secure_storage::{CryptoStorage, KVStorage, Storage};
 use diem_types::{
     account_address::AccountAddress,
-    transaction::{RawTransaction, SignedTransaction, Transaction},
+    transaction::{DiemSignedTransaction, RawTransaction, SignedTransaction, Transaction},
     waypoint::Waypoint,
 };
 use serde::{de::DeserializeOwned, Serialize};
@@ -135,7 +135,7 @@ impl StorageWrapper {
         key_name: &'static str,
         script_name: &'static str,
         raw_transaction: RawTransaction,
-    ) -> Result<SignedTransaction, Error> {
+    ) -> Result<DiemSignedTransaction, Error> {
         let public_key = self.ed25519_public_from_private(key_name)?;
         let signature = self.storage.sign(key_name, &raw_transaction).map_err(|e| {
             Error::StorageSigningError(self.storage_name, script_name, key_name, e.to_string())
@@ -155,7 +155,7 @@ impl StorageWrapper {
         key_version: Ed25519PublicKey,
         script_name: &'static str,
         raw_transaction: RawTransaction,
-    ) -> Result<SignedTransaction, Error> {
+    ) -> Result<DiemSignedTransaction, Error> {
         let signature = self
             .storage
             .sign_using_version(key_name, key_version.clone(), &raw_transaction)

--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use diem_types::{account_address::AccountAddress, transaction::SignedTransaction};
+use diem_types::{account_address::AccountAddress, transaction::DiemSignedTransaction};
 
 /// The round of a block is a consensus-internal counter, which starts with 0 and increases
 /// monotonically. It is used for the protocol safety and liveness (please see the detailed
@@ -11,4 +11,4 @@ pub type Round = u64;
 pub type Author = AccountAddress;
 
 /// The payload in block.
-pub type Payload = Vec<SignedTransaction>;
+pub type Payload = Vec<DiemSignedTransaction>;

--- a/consensus/safety-rules/src/fuzzing_utils.rs
+++ b/consensus/safety-rules/src/fuzzing_utils.rs
@@ -24,7 +24,7 @@ use diem_types::{
     ledger_info::LedgerInfoWithSignatures,
     proof::AccumulatorExtensionProof,
     proptest_types::{AccountInfoUniverse, BlockInfoGen},
-    transaction::SignedTransaction,
+    transaction::DiemSignedTransaction,
     validator_verifier::{ValidatorConsensusInfo, ValidatorVerifier},
 };
 use proptest::prelude::*;
@@ -93,7 +93,7 @@ prop_compose! {
     pub fn arb_block_type_proposal(
     )(
         author in any::<AccountAddress>(),
-        payload in prop::collection::vec(any::<SignedTransaction>(), 0..MAX_PROPOSAL_TRANSACTIONS),
+        payload in prop::collection::vec(any::<DiemSignedTransaction>(), 0..MAX_PROPOSAL_TRANSACTIONS),
     ) -> BlockType {
         BlockType::Proposal{
             payload,

--- a/execution/executor/src/mock_vm/mod.rs
+++ b/execution/executor/src/mock_vm/mod.rs
@@ -17,7 +17,7 @@ use diem_types::{
         config_address, new_epoch_event_key, ConfigurationResource, OnChainConfig, ValidatorSet,
     },
     transaction::{
-        RawTransaction, Script, SignedTransaction, Transaction, TransactionArgument,
+        DiemSignedTransaction, RawTransaction, Script, Transaction, TransactionArgument,
         TransactionOutput, TransactionPayload, TransactionStatus,
     },
     vm_status::{KeptVMStatus, StatusCode, VMStatus},
@@ -340,7 +340,7 @@ pub fn encode_reconfiguration_transaction(sender: AccountAddress) -> Transaction
     )
 }
 
-fn decode_transaction(txn: &SignedTransaction) -> MockVMTransaction {
+fn decode_transaction(txn: &DiemSignedTransaction) -> MockVMTransaction {
     let sender = txn.sender();
     match txn.payload() {
         TransactionPayload::Script(script) => {

--- a/json-rpc/integration-tests/src/helper.rs
+++ b/json-rpc/integration-tests/src/helper.rs
@@ -10,7 +10,7 @@ use diem_sdk::{
         account_address::AccountAddress,
         account_config::XUS_NAME,
         chain_id::ChainId,
-        transaction::{SignedTransaction, Transaction},
+        transaction::{DiemSignedTransaction, Transaction},
         LocalAccount,
     },
 };
@@ -109,17 +109,17 @@ impl JsonRpcTestHelper {
         resp.json().unwrap()
     }
 
-    pub fn submit_and_wait(&self, txn: &SignedTransaction) -> Value {
+    pub fn submit_and_wait(&self, txn: &DiemSignedTransaction) -> Value {
         self.submit(txn);
         self.wait_for_txn(txn)
     }
 
-    pub fn submit(&self, txn: &SignedTransaction) -> JsonRpcResponse {
+    pub fn submit(&self, txn: &DiemSignedTransaction) -> JsonRpcResponse {
         let txn_hex = hex::encode(bcs::to_bytes(txn).expect("bcs txn failed"));
         self.send("submit", json!([txn_hex]))
     }
 
-    pub fn wait_for_txn(&self, txn: &SignedTransaction) -> Value {
+    pub fn wait_for_txn(&self, txn: &DiemSignedTransaction) -> Value {
         let txn_hash = Transaction::UserTransaction(txn.clone()).hash().to_hex();
         for _i in 0..60 {
             let resp = self.get_account_transaction(&txn.sender(), txn.sequence_number(), true);
@@ -188,7 +188,7 @@ impl JsonRpcTestHelper {
         sender: &mut LocalAccount,
         secondary_signers: &[&mut LocalAccount],
         payload: diem_sdk::types::transaction::TransactionPayload,
-    ) -> SignedTransaction {
+    ) -> DiemSignedTransaction {
         let seq_onchain = self
             .get_account_sequence(sender.address())
             .expect("account should exist onchain for create transaction");

--- a/json-rpc/src/fuzzing.rs
+++ b/json-rpc/src/fuzzing.rs
@@ -4,7 +4,7 @@
 use crate::{methods, runtime, tests};
 use diem_config::config;
 use diem_proptest_helpers::ValueGenerator;
-use diem_types::account_state_blob::AccountStateWithProof;
+use diem_types::{account_state_blob::AccountStateWithProof, transaction::DiemSignedTransaction};
 use futures::{channel::mpsc::channel, StreamExt};
 use std::sync::Arc;
 use warp::reply::Reply;
@@ -74,9 +74,7 @@ pub fn method_fuzzer(params_data: &[u8], method: &str) {
 /// generate_corpus produces an arbitrary transaction to submit to JSON RPC service
 pub fn generate_corpus(gen: &mut ValueGenerator) -> Vec<u8> {
     // use proptest to generate a SignedTransaction
-    let txn = gen.generate(proptest::arbitrary::any::<
-        diem_types::transaction::SignedTransaction,
-    >());
+    let txn = gen.generate(proptest::arbitrary::any::<DiemSignedTransaction>());
     let payload = hex::encode(bcs::to_bytes(&txn).unwrap());
     let request =
         serde_json::json!({"jsonrpc": "2.0", "method": "submit", "params": [payload], "id": 1});

--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -25,7 +25,7 @@ use diem_json_rpc_types::request::{
 use diem_mempool::{MempoolClientSender, SubmissionStatus};
 use diem_types::{
     chain_id::ChainId, ledger_info::LedgerInfoWithSignatures, mempool_status::MempoolStatusCode,
-    transaction::SignedTransaction,
+    transaction::DiemSignedTransaction,
 };
 use fail::fail_point;
 use futures::{channel::oneshot, SinkExt};
@@ -65,7 +65,7 @@ impl JsonRpcService {
 
     pub async fn mempool_request(
         &self,
-        transaction: SignedTransaction,
+        transaction: DiemSignedTransaction,
     ) -> Result<SubmissionStatus> {
         let (req_sender, callback) = oneshot::channel();
 

--- a/json-rpc/src/tests/utils.rs
+++ b/json-rpc/src/tests/utils.rs
@@ -29,7 +29,7 @@ use diem_types::{
     },
     state_proof::StateProof,
     transaction::{
-        AccountTransactionsWithProof, SignedTransaction, Transaction, TransactionInfo,
+        AccountTransactionsWithProof, DiemSignedTransaction, Transaction, TransactionInfo,
         TransactionListWithProof, TransactionWithProof, Version,
     },
     vm_status::KeptVMStatus,
@@ -518,7 +518,7 @@ pub fn create_db_and_runtime() -> (
     Runtime,
     String,
     Receiver<(
-        SignedTransaction,
+        DiemSignedTransaction,
         oneshot::Sender<anyhow::Result<SubmissionStatus>>,
     )>,
 ) {

--- a/json-rpc/types/src/request.rs
+++ b/json-rpc/types/src/request.rs
@@ -4,7 +4,7 @@
 use super::{Id, JsonRpcVersion, Method};
 use crate::{errors::JsonRpcError, views::BytesView};
 use diem_types::{
-    account_address::AccountAddress, event::EventKey, transaction::SignedTransaction,
+    account_address::AccountAddress, event::EventKey, transaction::DiemSignedTransaction,
 };
 use serde::{de, Deserialize, Serialize};
 use std::fmt;
@@ -162,11 +162,11 @@ impl MethodRequest {
 pub struct SubmitParams {
     #[serde(serialize_with = "serialize_signed_transaction")]
     #[serde(deserialize_with = "deserialize_signed_transaction")]
-    pub data: SignedTransaction,
+    pub data: DiemSignedTransaction,
 }
 
 fn serialize_signed_transaction<S>(
-    txn: &SignedTransaction,
+    txn: &DiemSignedTransaction,
     serializer: S,
 ) -> Result<S::Ok, S::Error>
 where
@@ -176,7 +176,9 @@ where
     BytesView::new(bcs::to_bytes(txn).map_err(S::Error::custom)?).serialize(serializer)
 }
 
-fn deserialize_signed_transaction<'de, D>(deserializer: D) -> Result<SignedTransaction, D::Error>
+fn deserialize_signed_transaction<'de, D>(
+    deserializer: D,
+) -> Result<DiemSignedTransaction, D::Error>
 where
     D: serde::Deserializer<'de>,
 {

--- a/language/diem-tools/diem-read-write-set/src/lib.rs
+++ b/language/diem-tools/diem-read-write-set/src/lib.rs
@@ -4,7 +4,7 @@
 use anyhow::{bail, Result};
 use diem_types::{
     account_config,
-    transaction::{SignedTransaction, TransactionPayload},
+    transaction::{DiemSignedTransaction, TransactionPayload},
 };
 use diem_vm::system_module_names::{SCRIPT_PROLOGUE_NAME, USER_EPILOGUE_NAME};
 use move_core_types::{
@@ -33,7 +33,7 @@ impl ReadWriteSetAnalysis {
     /// embedded payload.
     pub fn get_keys_written(
         &self,
-        tx: &SignedTransaction,
+        tx: &DiemSignedTransaction,
         blockchain_view: &impl MoveResolver,
     ) -> Result<Vec<ResourceKey>> {
         self.get_concretized_keys_tx(tx, blockchain_view, true)
@@ -45,7 +45,7 @@ impl ReadWriteSetAnalysis {
     /// embedded payload.
     pub fn get_keys_read(
         &self,
-        tx: &SignedTransaction,
+        tx: &DiemSignedTransaction,
         blockchain_view: &impl MoveResolver,
     ) -> Result<Vec<ResourceKey>> {
         self.get_concretized_keys_tx(tx, blockchain_view, false)
@@ -53,7 +53,7 @@ impl ReadWriteSetAnalysis {
 
     fn get_concretized_keys_tx(
         &self,
-        tx: &SignedTransaction,
+        tx: &DiemSignedTransaction,
         blockchain_view: &impl MoveResolver,
         is_write: bool,
     ) -> Result<Vec<ResourceKey>> {

--- a/language/diem-transaction-benchmarks/src/transactions.rs
+++ b/language/diem-transaction-benchmarks/src/transactions.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use criterion::{measurement::Measurement, BatchSize, Bencher};
-use diem_types::transaction::SignedTransaction;
+use diem_types::transaction::DiemSignedTransaction;
 use language_e2e_tests::{
     account_universe::{log_balance_strategy, AUTransactionGen, AccountUniverseGen},
     executor::FakeExecutor,
@@ -83,7 +83,7 @@ struct TransactionBenchState {
     // 6. Add an enum to TransactionBencher that lets callers choose between the fake and real
     //    executors.
     executor: FakeExecutor,
-    transactions: Vec<SignedTransaction>,
+    transactions: Vec<DiemSignedTransaction>,
 }
 
 impl TransactionBenchState {

--- a/language/diem-vm/src/adapter_common.rs
+++ b/language/diem-vm/src/adapter_common.rs
@@ -8,7 +8,7 @@ use diem_types::{
     account_address::AccountAddress,
     account_config::{self, RoleId},
     transaction::{
-        GovernanceRole, SignatureCheckedTransaction, SignedTransaction, VMValidatorResult,
+        DiemSignatureCheckedTransaction, DiemSignedTransaction, GovernanceRole, VMValidatorResult,
     },
     vm_status::{StatusCode, VMStatus},
 };
@@ -39,10 +39,10 @@ pub trait VMAdapter {
 
     /// Checks the signature of the given signed transaction and returns
     /// `Ok(SignatureCheckedTransaction)` if the signature is valid.
-    fn check_signature(txn: SignedTransaction) -> Result<SignatureCheckedTransaction>;
+    fn check_signature(txn: DiemSignedTransaction) -> Result<DiemSignatureCheckedTransaction>;
 
     /// Check if the transaction format is supported.
-    fn check_transaction_format(&self, txn: &SignedTransaction) -> Result<(), VMStatus>;
+    fn check_transaction_format(&self, txn: &DiemSignedTransaction) -> Result<(), VMStatus>;
 
     /// Get the gas price for the given transaction.
     /// TODO: remove this after making mempool interface more generic so
@@ -50,7 +50,7 @@ pub trait VMAdapter {
     /// instead of using governance roles and gas prices.
     fn get_gas_price<S: MoveResolver>(
         &self,
-        txn: &SignedTransaction,
+        txn: &DiemSignedTransaction,
         remote_cache: &S,
     ) -> Result<u64, VMStatus>;
 
@@ -58,7 +58,7 @@ pub trait VMAdapter {
     fn run_prologue<S: MoveResolver>(
         &self,
         session: &mut Session<S>,
-        transaction: &SignatureCheckedTransaction,
+        transaction: &DiemSignatureCheckedTransaction,
         log_context: &AdapterLogSchema,
     ) -> Result<(), VMStatus>;
 
@@ -82,7 +82,7 @@ pub trait VMAdapter {
 /// and `Some(DiscardedVMStatus)` otherwise.
 pub fn validate_signed_transaction<A: VMAdapter>(
     adapter: &A,
-    transaction: SignedTransaction,
+    transaction: DiemSignedTransaction,
     state_view: &dyn StateView,
 ) -> VMValidatorResult {
     let _timer = TXN_VALIDATION_SECONDS.start_timer();
@@ -139,7 +139,7 @@ fn get_account_role(sender: AccountAddress, remote_cache: &StateViewCache) -> Go
 pub(crate) fn validate_signature_checked_transaction<S: MoveResolver, A: VMAdapter>(
     adapter: &A,
     mut session: &mut Session<S>,
-    transaction: &SignatureCheckedTransaction,
+    transaction: &DiemSignatureCheckedTransaction,
     allow_too_new: bool,
     log_context: &AdapterLogSchema,
 ) -> Result<(), VMStatus> {
@@ -256,10 +256,10 @@ pub(crate) fn execute_block_impl<A: VMAdapter>(
 /// but a user transaction or writeset transaction is transformed to a SignatureCheckedTransaction.
 #[derive(Debug)]
 pub enum PreprocessedTransaction {
-    UserTransaction(Box<SignatureCheckedTransaction>),
+    UserTransaction(Box<DiemSignatureCheckedTransaction>),
     WaypointWriteSet(WriteSetPayload),
     BlockMetadata(BlockMetadata),
-    WriteSet(Box<SignatureCheckedTransaction>),
+    WriteSet(Box<DiemSignatureCheckedTransaction>),
     InvalidSignature,
 }
 

--- a/language/diem-vm/src/diem_vm_impl.rs
+++ b/language/diem-vm/src/diem_vm_impl.rs
@@ -22,7 +22,7 @@ use diem_types::{
     on_chain_config::{
         ConfigStorage, DiemVersion, OnChainConfig, VMConfig, VMPublishingOption, DIEM_VERSION_3,
     },
-    transaction::{SignedTransaction, TransactionOutput, TransactionStatus},
+    transaction::{DiemSignedTransaction, TransactionOutput, TransactionStatus},
     vm_status::{KeptVMStatus, StatusCode, VMStatus},
     write_set::{WriteOp, WriteSet, WriteSetMut},
 };
@@ -589,7 +589,7 @@ pub(crate) fn get_transaction_output<A: AccessPathCache, S: MoveResolver>(
     ))
 }
 
-pub(crate) fn get_gas_currency_code(txn: &SignedTransaction) -> Result<Identifier, VMStatus> {
+pub(crate) fn get_gas_currency_code(txn: &DiemSignedTransaction) -> Result<Identifier, VMStatus> {
     let currency_code_string = txn.gas_currency_code();
     match account_config::from_currency_code_string(currency_code_string) {
         Ok(code) => Ok(code),

--- a/language/diem-vm/src/lib.rs
+++ b/language/diem-vm/src/lib.rs
@@ -131,7 +131,7 @@ pub use crate::{diem_vm::DiemVM, diem_vm_impl::convert_changeset_and_events};
 use diem_state_view::StateView;
 use diem_types::{
     access_path::AccessPath,
-    transaction::{SignedTransaction, Transaction, TransactionOutput, VMValidatorResult},
+    transaction::{DiemSignedTransaction, Transaction, TransactionOutput, VMValidatorResult},
     vm_status::VMStatus,
 };
 use move_core_types::{
@@ -144,7 +144,7 @@ pub trait VMValidator {
     /// Executes the prologue of the Diem Account and verifies that the transaction is valid.
     fn validate_transaction(
         &self,
-        transaction: SignedTransaction,
+        transaction: DiemSignedTransaction,
         state_view: &dyn StateView,
     ) -> VMValidatorResult;
 }

--- a/language/diem-vm/src/transaction_metadata.rs
+++ b/language/diem-vm/src/transaction_metadata.rs
@@ -6,7 +6,7 @@ use diem_types::{
     account_address::AccountAddress,
     chain_id::ChainId,
     transaction::{
-        authenticator::AuthenticationKeyPreimage, SignedTransaction, TransactionPayload,
+        authenticator::AuthenticationKeyPreimage, DiemSignedTransaction, TransactionPayload,
     },
 };
 use move_core_types::gas_schedule::{
@@ -29,7 +29,7 @@ pub struct TransactionMetadata {
 }
 
 impl TransactionMetadata {
-    pub fn new(txn: &SignedTransaction) -> Self {
+    pub fn new(txn: &DiemSignedTransaction) -> Self {
         Self {
             sender: txn.sender(),
             authentication_key_preimage: txn

--- a/language/e2e-testsuite/src/tests/data_store.rs
+++ b/language/e2e-testsuite/src/tests/data_store.rs
@@ -4,7 +4,7 @@
 use bytecode_verifier::verify_module;
 use compiler::Compiler;
 use diem_types::{
-    transaction::{Module, SignedTransaction, Transaction, TransactionStatus},
+    transaction::{DiemSignedTransaction, Module, Transaction, TransactionStatus},
     vm_status::KeptVMStatus,
 };
 use language_e2e_tests::{
@@ -203,7 +203,7 @@ fn change_after_move() {
     executor.apply_write_set(output.write_set());
 }
 
-fn add_module_txn(sender: &AccountData, seq_num: u64) -> (CompiledModule, SignedTransaction) {
+fn add_module_txn(sender: &AccountData, seq_num: u64) -> (CompiledModule, DiemSignedTransaction) {
     let module_code = format!(
         "
         module 0x{}.M {{
@@ -264,7 +264,7 @@ fn add_resource_txn(
     sender: &AccountData,
     seq_num: u64,
     extra_deps: Vec<CompiledModule>,
-) -> SignedTransaction {
+) -> DiemSignedTransaction {
     let program = format!(
         "
             import 0x{}.M;
@@ -290,7 +290,7 @@ fn remove_resource_txn(
     sender: &AccountData,
     seq_num: u64,
     extra_deps: Vec<CompiledModule>,
-) -> SignedTransaction {
+) -> DiemSignedTransaction {
     let program = format!(
         "
             import 0x{}.M;
@@ -316,7 +316,7 @@ fn borrow_resource_txn(
     sender: &AccountData,
     seq_num: u64,
     extra_deps: Vec<CompiledModule>,
-) -> SignedTransaction {
+) -> DiemSignedTransaction {
     let program = format!(
         "
             import 0x{}.M;
@@ -342,7 +342,7 @@ fn change_resource_txn(
     sender: &AccountData,
     seq_num: u64,
     extra_deps: Vec<CompiledModule>,
-) -> SignedTransaction {
+) -> DiemSignedTransaction {
     let program = format!(
         "
             import 0x{}.M;

--- a/language/e2e-testsuite/src/tests/execution_strategies.rs
+++ b/language/e2e-testsuite/src/tests/execution_strategies.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use diem_types::{account_config, transaction::SignedTransaction, vm_status::VMStatus};
+use diem_types::{account_config, transaction::DiemSignedTransaction, vm_status::VMStatus};
 use language_e2e_tests::{
     account::Account,
     common_transactions::create_account_txn,
@@ -17,7 +17,7 @@ use language_e2e_tests::{
     },
 };
 
-fn txn(seq_num: u64) -> SignedTransaction {
+fn txn(seq_num: u64) -> DiemSignedTransaction {
     let account = Account::new();
     let diem_root = Account::new_diem_root();
     create_account_txn(
@@ -111,7 +111,7 @@ fn test_execution_strategies() {
         println!("===========================================================================");
         let block = (0..10).map(txn).collect();
 
-        let mut exec = MultiExecutor::<SignedTransaction, VMStatus>::new();
+        let mut exec = MultiExecutor::<DiemSignedTransaction, VMStatus>::new();
         exec.add_executor(RandomExecutor::from_os_rng());
         exec.add_executor(RandomExecutor::from_os_rng());
         exec.add_executor(RandomExecutor::from_os_rng());

--- a/language/e2e-testsuite/src/tests/peer_to_peer.rs
+++ b/language/e2e-testsuite/src/tests/peer_to_peer.rs
@@ -3,7 +3,7 @@
 
 use diem_types::{
     account_config::{ReceivedPaymentEvent, SentPaymentEvent},
-    transaction::{SignedTransaction, TransactionOutput, TransactionStatus},
+    transaction::{DiemSignedTransaction, TransactionOutput, TransactionStatus},
     vm_status::{known_locations, KeptVMStatus},
 };
 use language_e2e_tests::{
@@ -169,7 +169,7 @@ fn few_peer_to_peer_with_event() {
         let transfer_amount = 1_000;
 
         // execute transaction
-        let txns: Vec<SignedTransaction> = vec![
+        let txns: Vec<DiemSignedTransaction> = vec![
             peer_to_peer_txn(sender.account(), receiver.account(), 10, transfer_amount),
             peer_to_peer_txn(sender.account(), receiver.account(), 11, transfer_amount),
             peer_to_peer_txn(sender.account(), receiver.account(), 12, transfer_amount),
@@ -285,8 +285,8 @@ fn create_cyclic_transfers(
     executor: &FakeExecutor,
     accounts: &[Account],
     transfer_amount: u64,
-) -> (Vec<TxnInfo>, Vec<SignedTransaction>) {
-    let mut txns: Vec<SignedTransaction> = Vec::new();
+) -> (Vec<TxnInfo>, Vec<DiemSignedTransaction>) {
+    let mut txns: Vec<DiemSignedTransaction> = Vec::new();
     let mut txns_info: Vec<TxnInfo> = Vec::new();
     // loop through all transactions and let each transfer the same amount to the next one
     let count = accounts.len();
@@ -311,8 +311,8 @@ fn create_one_to_many_transfers(
     executor: &FakeExecutor,
     accounts: &[Account],
     transfer_amount: u64,
-) -> (Vec<TxnInfo>, Vec<SignedTransaction>) {
-    let mut txns: Vec<SignedTransaction> = Vec::new();
+) -> (Vec<TxnInfo>, Vec<DiemSignedTransaction>) {
+    let mut txns: Vec<DiemSignedTransaction> = Vec::new();
     let mut txns_info: Vec<TxnInfo> = Vec::new();
     // grab account 0 as a sender
     let sender = &accounts[0];
@@ -338,8 +338,8 @@ fn create_many_to_one_transfers(
     executor: &FakeExecutor,
     accounts: &[Account],
     transfer_amount: u64,
-) -> (Vec<TxnInfo>, Vec<SignedTransaction>) {
-    let mut txns: Vec<SignedTransaction> = Vec::new();
+) -> (Vec<TxnInfo>, Vec<DiemSignedTransaction>) {
+    let mut txns: Vec<DiemSignedTransaction> = Vec::new();
     let mut txns_info: Vec<TxnInfo> = Vec::new();
     // grab account 0 as a sender
     let receiver = &accounts[0];

--- a/language/testing-infra/diem-transactional-test-harness/src/diem_test_harness.rs
+++ b/language/testing-infra/diem-transactional-test-harness/src/diem_test_harness.rs
@@ -14,8 +14,8 @@ use diem_types::{
     },
     chain_id::ChainId,
     transaction::{
-        Module as TransactionModule, RawTransaction, Script as TransactionScript,
-        ScriptFunction as TransactionScriptFunction, SignedTransaction, Transaction,
+        DiemSignedTransaction, Module as TransactionModule, RawTransaction,
+        Script as TransactionScript, ScriptFunction as TransactionScriptFunction, Transaction,
         TransactionStatus,
     },
     vm_status::KeptVMStatus,
@@ -169,7 +169,7 @@ impl<'a> DiemTestAdapter<'a> {
     ///
     /// Should error if the transaction ends up being discarded, or having a status other than
     /// EXECUTED.
-    fn run_transaction(&mut self, txn: SignedTransaction) -> Result<()> {
+    fn run_transaction(&mut self, txn: DiemSignedTransaction) -> Result<()> {
         let mut outputs = DiemVM::execute_block_and_keep_vm_status(
             vec![Transaction::UserTransaction(txn)],
             &self.storage,

--- a/language/testing-infra/e2e-tests/src/account.rs
+++ b/language/testing-infra/e2e-tests/src/account.rs
@@ -17,8 +17,8 @@ use diem_types::{
     chain_id::ChainId,
     event::EventHandle,
     transaction::{
-        authenticator::AuthenticationKey, Module, RawTransaction, Script, ScriptFunction,
-        SignedTransaction, TransactionPayload, WriteSetPayload,
+        authenticator::AuthenticationKey, DiemSignedTransaction, Module, RawTransaction, Script,
+        ScriptFunction, TransactionPayload, WriteSetPayload,
     },
     write_set::{WriteOp, WriteSet, WriteSetMut},
 };
@@ -306,7 +306,7 @@ impl TransactionBuilder {
         )
     }
 
-    pub fn sign(self) -> SignedTransaction {
+    pub fn sign(self) -> DiemSignedTransaction {
         RawTransaction::new(
             *self.sender.address(),
             self.sequence_number.expect("sequence number not set"),
@@ -323,7 +323,7 @@ impl TransactionBuilder {
         .into_inner()
     }
 
-    pub fn sign_multi_agent(self) -> SignedTransaction {
+    pub fn sign_multi_agent(self) -> DiemSignedTransaction {
         let secondary_signer_addresses: Vec<AccountAddress> = self
             .secondary_signers
             .iter()

--- a/language/testing-infra/e2e-tests/src/account_universe.rs
+++ b/language/testing-infra/e2e-tests/src/account_universe.rs
@@ -29,7 +29,7 @@ use crate::{
 };
 use diem_crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
 use diem_types::{
-    transaction::{SignedTransaction, TransactionStatus},
+    transaction::{DiemSignedTransaction, TransactionStatus},
     vm_status::{known_locations, KeptVMStatus, StatusCode},
 };
 use once_cell::sync::Lazy;
@@ -94,7 +94,7 @@ pub trait AUTransactionGen: fmt::Debug {
     fn apply(
         &self,
         universe: &mut AccountUniverse,
-    ) -> (SignedTransaction, (TransactionStatus, u64));
+    ) -> (DiemSignedTransaction, (TransactionStatus, u64));
 
     /// Creates an arced version of this transaction, suitable for dynamic dispatch.
     fn arced(self) -> Arc<dyn AUTransactionGen>
@@ -109,7 +109,7 @@ impl AUTransactionGen for Arc<dyn AUTransactionGen> {
     fn apply(
         &self,
         universe: &mut AccountUniverse,
-    ) -> (SignedTransaction, (TransactionStatus, u64)) {
+    ) -> (DiemSignedTransaction, (TransactionStatus, u64)) {
         (**self).apply(universe)
     }
 }

--- a/language/testing-infra/e2e-tests/src/account_universe/bad_transaction.rs
+++ b/language/testing-infra/e2e-tests/src/account_universe/bad_transaction.rs
@@ -13,7 +13,7 @@ use diem_crypto::{
 use diem_proptest_helpers::Index;
 use diem_types::{
     account_config::XUS_NAME,
-    transaction::{Script, SignedTransaction, TransactionStatus},
+    transaction::{DiemSignedTransaction, Script, TransactionStatus},
     vm_status::StatusCode,
 };
 use move_core_types::gas_schedule::{AbstractMemorySize, GasAlgebra, GasCarrier, GasConstants};
@@ -36,7 +36,7 @@ impl AUTransactionGen for SequenceNumberMismatchGen {
     fn apply(
         &self,
         universe: &mut AccountUniverse,
-    ) -> (SignedTransaction, (TransactionStatus, u64)) {
+    ) -> (DiemSignedTransaction, (TransactionStatus, u64)) {
         let sender = universe.pick(self.sender).1;
 
         let seq = if sender.sequence_number == self.seq {
@@ -81,7 +81,7 @@ impl AUTransactionGen for InsufficientBalanceGen {
     fn apply(
         &self,
         universe: &mut AccountUniverse,
-    ) -> (SignedTransaction, (TransactionStatus, u64)) {
+    ) -> (DiemSignedTransaction, (TransactionStatus, u64)) {
         let sender = universe.pick(self.sender).1;
 
         let max_gas_unit = (sender.balance / self.gas_unit_price) + 1;
@@ -144,7 +144,7 @@ impl AUTransactionGen for InvalidAuthkeyGen {
     fn apply(
         &self,
         universe: &mut AccountUniverse,
-    ) -> (SignedTransaction, (TransactionStatus, u64)) {
+    ) -> (DiemSignedTransaction, (TransactionStatus, u64)) {
         let sender = universe.pick(self.sender).1;
 
         let txn = sender

--- a/language/testing-infra/e2e-tests/src/account_universe/create_account.rs
+++ b/language/testing-infra/e2e-tests/src/account_universe/create_account.rs
@@ -12,7 +12,7 @@ use crate::{
 use diem_proptest_helpers::Index;
 use diem_types::{
     account_config,
-    transaction::{SignedTransaction, TransactionStatus},
+    transaction::{DiemSignedTransaction, TransactionStatus},
     vm_status::{AbortLocation, KeptVMStatus, StatusCode},
 };
 use proptest::prelude::*;
@@ -35,7 +35,7 @@ impl AUTransactionGen for CreateAccountGen {
     fn apply(
         &self,
         universe: &mut AccountUniverse,
-    ) -> (SignedTransaction, (TransactionStatus, u64)) {
+    ) -> (DiemSignedTransaction, (TransactionStatus, u64)) {
         let sender = universe.pick(self.sender).1;
 
         let txn = create_account_txn(
@@ -90,7 +90,7 @@ impl AUTransactionGen for CreateExistingAccountGen {
     fn apply(
         &self,
         universe: &mut AccountUniverse,
-    ) -> (SignedTransaction, (TransactionStatus, u64)) {
+    ) -> (DiemSignedTransaction, (TransactionStatus, u64)) {
         let AccountPair {
             account_1: sender,
             account_2: receiver,

--- a/language/testing-infra/e2e-tests/src/account_universe/peer_to_peer.rs
+++ b/language/testing-infra/e2e-tests/src/account_universe/peer_to_peer.rs
@@ -6,7 +6,7 @@ use crate::{
     common_transactions::peer_to_peer_txn,
 };
 use diem_types::{
-    transaction::{SignedTransaction, TransactionStatus},
+    transaction::{DiemSignedTransaction, TransactionStatus},
     vm_status::{known_locations, KeptVMStatus, StatusCode},
 };
 use proptest::prelude::*;
@@ -28,7 +28,7 @@ impl AUTransactionGen for P2PTransferGen {
     fn apply(
         &self,
         universe: &mut AccountUniverse,
-    ) -> (SignedTransaction, (TransactionStatus, u64)) {
+    ) -> (DiemSignedTransaction, (TransactionStatus, u64)) {
         let AccountPair {
             account_1: sender,
             account_2: receiver,

--- a/language/testing-infra/e2e-tests/src/account_universe/rotate_key.rs
+++ b/language/testing-infra/e2e-tests/src/account_universe/rotate_key.rs
@@ -12,7 +12,7 @@ use diem_crypto::{
 };
 use diem_proptest_helpers::Index;
 use diem_types::{
-    transaction::{authenticator::AuthenticationKey, SignedTransaction, TransactionStatus},
+    transaction::{authenticator::AuthenticationKey, DiemSignedTransaction, TransactionStatus},
     vm_status::{KeptVMStatus, StatusCode},
 };
 use proptest::prelude::*;
@@ -33,7 +33,7 @@ impl AUTransactionGen for RotateKeyGen {
     fn apply(
         &self,
         universe: &mut AccountUniverse,
-    ) -> (SignedTransaction, (TransactionStatus, u64)) {
+    ) -> (DiemSignedTransaction, (TransactionStatus, u64)) {
         let sender = universe.pick(self.sender).1;
 
         let key_hash = AuthenticationKey::ed25519(&self.new_keypair.public_key).to_vec();

--- a/language/testing-infra/e2e-tests/src/common_transactions.rs
+++ b/language/testing-infra/e2e-tests/src/common_transactions.rs
@@ -10,7 +10,7 @@ use diem_transaction_builder::stdlib::encode_peer_to_peer_by_signers_script_func
 use diem_types::{
     account_config,
     transaction::{
-        RawTransaction, Script, SignedTransaction, TransactionArgument, TransactionPayload,
+        DiemSignedTransaction, RawTransaction, Script, TransactionArgument, TransactionPayload,
     },
 };
 use move_core_types::language_storage::TypeTag;
@@ -162,7 +162,7 @@ pub fn empty_txn(
     max_gas_amount: u64,
     gas_unit_price: u64,
     gas_currency_code: String,
-) -> SignedTransaction {
+) -> DiemSignedTransaction {
     sender
         .transaction()
         .script(Script::new(EMPTY_SCRIPT.to_vec(), vec![], vec![]))
@@ -180,7 +180,7 @@ pub fn create_account_txn(
     seq_num: u64,
     initial_amount: u64,
     type_tag: TypeTag,
-) -> SignedTransaction {
+) -> DiemSignedTransaction {
     let args: Vec<TransactionArgument> = vec![
         TransactionArgument::Address(*new_account.address()),
         TransactionArgument::U8Vector(new_account.auth_key_prefix()),
@@ -205,7 +205,7 @@ pub fn peer_to_peer_txn(
     receiver: &Account,
     seq_num: u64,
     transfer_amount: u64,
-) -> SignedTransaction {
+) -> DiemSignedTransaction {
     let args: Vec<TransactionArgument> = vec![
         TransactionArgument::Address(*receiver.address()),
         TransactionArgument::U64(transfer_amount),
@@ -228,7 +228,11 @@ pub fn peer_to_peer_txn(
 }
 
 /// Returns a transaction to change the keys for the given account.
-pub fn rotate_key_txn(sender: &Account, new_key_hash: Vec<u8>, seq_num: u64) -> SignedTransaction {
+pub fn rotate_key_txn(
+    sender: &Account,
+    new_key_hash: Vec<u8>,
+    seq_num: u64,
+) -> DiemSignedTransaction {
     let args = vec![TransactionArgument::U8Vector(new_key_hash)];
     sender
         .transaction()
@@ -266,7 +270,7 @@ pub fn multi_agent_swap_txn(
     seq_num: u64,
     xus_amount: u64,
     xdx_amount: u64,
-) -> SignedTransaction {
+) -> DiemSignedTransaction {
     let args: Vec<TransactionArgument> = vec![
         TransactionArgument::U64(xus_amount),
         TransactionArgument::U64(xdx_amount),
@@ -287,7 +291,7 @@ pub fn multi_agent_p2p_txn(
     payee: &Account,
     seq_num: u64,
     amount: u64,
-) -> SignedTransaction {
+) -> DiemSignedTransaction {
     // get a SignedTransaction
     payer
         .transaction()
@@ -309,7 +313,7 @@ pub fn multi_agent_mint_txn(
     seq_num: u64,
     amount: u64,
     tier_index: u64,
-) -> SignedTransaction {
+) -> DiemSignedTransaction {
     let args: Vec<TransactionArgument> = vec![
         TransactionArgument::U64(amount),
         TransactionArgument::U64(tier_index),

--- a/language/testing-infra/e2e-tests/src/execution_strategies/basic_strategy.rs
+++ b/language/testing-infra/e2e-tests/src/execution_strategies/basic_strategy.rs
@@ -7,14 +7,14 @@ use crate::{
     execution_strategies::types::{Block, Executor, ExecutorResult, PartitionStrategy},
     executor::FakeExecutor,
 };
-use diem_types::{transaction::SignedTransaction, vm_status::VMStatus};
+use diem_types::{transaction::DiemSignedTransaction, vm_status::VMStatus};
 
 #[derive(Debug, Clone)]
 pub struct BasicStrategy;
 
 impl PartitionStrategy for BasicStrategy {
-    type Txn = SignedTransaction;
-    fn partition(&mut self, block: Block<Self::Txn>) -> Vec<Block<SignedTransaction>> {
+    type Txn = DiemSignedTransaction;
+    fn partition(&mut self, block: Block<Self::Txn>) -> Vec<Block<DiemSignedTransaction>> {
         vec![block]
     }
 }

--- a/language/testing-infra/e2e-tests/src/execution_strategies/guided_strategy.rs
+++ b/language/testing-infra/e2e-tests/src/execution_strategies/guided_strategy.rs
@@ -6,12 +6,12 @@ use crate::{
     execution_strategies::types::{Block, Executor, ExecutorResult, PartitionStrategy},
     executor::FakeExecutor,
 };
-use diem_types::{transaction::SignedTransaction, vm_status::VMStatus};
+use diem_types::{transaction::DiemSignedTransaction, vm_status::VMStatus};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum AnnotatedTransaction {
     Block,
-    Txn(Box<SignedTransaction>),
+    Txn(Box<DiemSignedTransaction>),
 }
 
 #[derive(Debug, Clone)]
@@ -19,7 +19,7 @@ pub struct PartitionedGuidedStrategy;
 
 impl PartitionStrategy for PartitionedGuidedStrategy {
     type Txn = AnnotatedTransaction;
-    fn partition(&mut self, block: Block<Self::Txn>) -> Vec<Block<SignedTransaction>> {
+    fn partition(&mut self, block: Block<Self::Txn>) -> Vec<Block<DiemSignedTransaction>> {
         block
             .split(|atxn| atxn == &AnnotatedTransaction::Block)
             .map(move |block| {
@@ -40,7 +40,7 @@ pub struct UnPartitionedGuidedStrategy;
 
 impl PartitionStrategy for UnPartitionedGuidedStrategy {
     type Txn = AnnotatedTransaction;
-    fn partition(&mut self, block: Block<Self::Txn>) -> Vec<Block<SignedTransaction>> {
+    fn partition(&mut self, block: Block<Self::Txn>) -> Vec<Block<DiemSignedTransaction>> {
         vec![block
             .into_iter()
             .filter_map(|atxn| match atxn {

--- a/language/testing-infra/e2e-tests/src/execution_strategies/random_strategy.rs
+++ b/language/testing-infra/e2e-tests/src/execution_strategies/random_strategy.rs
@@ -6,7 +6,7 @@ use crate::{
     execution_strategies::types::{Block, Executor, ExecutorResult, PartitionStrategy},
     executor::FakeExecutor,
 };
-use diem_types::{transaction::SignedTransaction, vm_status::VMStatus};
+use diem_types::{transaction::DiemSignedTransaction, vm_status::VMStatus};
 use rand::{
     rngs::{OsRng, StdRng},
     Rng, SeedableRng,
@@ -32,8 +32,8 @@ impl RandomizedStrategy {
 }
 
 impl PartitionStrategy for RandomizedStrategy {
-    type Txn = SignedTransaction;
-    fn partition(&mut self, mut block: Block<Self::Txn>) -> Vec<Block<SignedTransaction>> {
+    type Txn = DiemSignedTransaction;
+    fn partition(&mut self, mut block: Block<Self::Txn>) -> Vec<Block<DiemSignedTransaction>> {
         let mut blocks = vec![];
         while !block.is_empty() {
             let block_size = self.gen.gen_range(0..block.len());
@@ -64,7 +64,7 @@ impl RandomExecutor {
 }
 
 impl Executor for RandomExecutor {
-    type Txn = SignedTransaction;
+    type Txn = DiemSignedTransaction;
     type BlockResult = VMStatus;
     fn execute_block(&mut self, block: Block<Self::Txn>) -> ExecutorResult<Self::BlockResult> {
         let blocks = self.strategy.partition(block);

--- a/language/testing-infra/e2e-tests/src/execution_strategies/types.rs
+++ b/language/testing-infra/e2e-tests/src/execution_strategies/types.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]
-use diem_types::transaction::{SignedTransaction, TransactionOutput};
+use diem_types::transaction::{DiemSignedTransaction, TransactionOutput};
 
 pub type Block<Txn> = Vec<Txn>;
 pub type ExecutorResult<T> = Result<Vec<TransactionOutput>, T>;
@@ -15,5 +15,5 @@ pub trait Executor {
 
 pub trait PartitionStrategy {
     type Txn;
-    fn partition(&mut self, block: Block<Self::Txn>) -> Vec<Block<SignedTransaction>>;
+    fn partition(&mut self, block: Block<Self::Txn>) -> Vec<Block<DiemSignedTransaction>>;
 }

--- a/language/testing-infra/e2e-tests/src/executor.rs
+++ b/language/testing-infra/e2e-tests/src/executor.rs
@@ -30,7 +30,7 @@ use diem_types::{
     block_metadata::{new_block_event_key, BlockMetadata, NewBlockEvent},
     on_chain_config::{DiemVersion, OnChainConfig, VMPublishingOption, ValidatorSet},
     transaction::{
-        ChangeSet, SignedTransaction, Transaction, TransactionOutput, TransactionStatus,
+        ChangeSet, DiemSignedTransaction, Transaction, TransactionOutput, TransactionStatus,
         VMValidatorResult,
     },
     vm_status::{KeptVMStatus, VMStatus},
@@ -305,7 +305,7 @@ impl FakeExecutor {
     /// However, this doesn't apply the results of successful transactions to the data store.
     pub fn execute_block(
         &self,
-        txn_block: Vec<SignedTransaction>,
+        txn_block: Vec<DiemSignedTransaction>,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         self.execute_transaction_block(
             txn_block
@@ -319,7 +319,7 @@ impl FakeExecutor {
     /// `TransactionOutput`
     pub fn execute_block_and_keep_vm_status(
         &self,
-        txn_block: Vec<SignedTransaction>,
+        txn_block: Vec<DiemSignedTransaction>,
     ) -> Result<Vec<(VMStatus, TransactionOutput)>, VMStatus> {
         DiemVM::execute_block_and_keep_vm_status(
             txn_block
@@ -332,7 +332,7 @@ impl FakeExecutor {
 
     /// Executes the transaction as a singleton block and applies the resulting write set to the
     /// data store. Panics if execution fails
-    pub fn execute_and_apply(&mut self, transaction: SignedTransaction) -> TransactionOutput {
+    pub fn execute_and_apply(&mut self, transaction: DiemSignedTransaction) -> TransactionOutput {
         let mut outputs = self.execute_block(vec![transaction]).unwrap();
         assert!(outputs.len() == 1, "transaction outputs size mismatch");
         let output = outputs.pop().unwrap();
@@ -398,7 +398,7 @@ impl FakeExecutor {
         output
     }
 
-    pub fn execute_transaction(&self, txn: SignedTransaction) -> TransactionOutput {
+    pub fn execute_transaction(&self, txn: DiemSignedTransaction) -> TransactionOutput {
         let txn_block = vec![txn];
         let mut outputs = self
             .execute_block(txn_block)
@@ -429,7 +429,7 @@ impl FakeExecutor {
     }
 
     /// Verifies the given transaction by running it through the VM verifier.
-    pub fn verify_transaction(&self, txn: SignedTransaction) -> VMValidatorResult {
+    pub fn verify_transaction(&self, txn: DiemSignedTransaction) -> VMValidatorResult {
         let vm = DiemVM::new(self.get_state_view());
         vm.validate_transaction(txn, &self.data_store)
     }

--- a/language/testing-infra/e2e-tests/src/gas_costs.rs
+++ b/language/testing-infra/e2e-tests/src/gas_costs.rs
@@ -11,7 +11,7 @@ use crate::{
 use diem_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
 use diem_types::{
     account_config,
-    transaction::{authenticator::AuthenticationKey, SignedTransaction},
+    transaction::{authenticator::AuthenticationKey, DiemSignedTransaction},
 };
 use once_cell::sync::Lazy;
 
@@ -308,7 +308,7 @@ pub static ROTATE_KEY: Lazy<u64> = Lazy::new(|| {
     compute_gas_used(txn, &mut executor)
 });
 
-fn compute_gas_used(txn: SignedTransaction, executor: &mut FakeExecutor) -> u64 {
+fn compute_gas_used(txn: DiemSignedTransaction, executor: &mut FakeExecutor) -> u64 {
     let output = &executor.execute_transaction(txn);
     output.gas_used()
 }

--- a/language/testing-infra/functional-tests/src/evaluator.rs
+++ b/language/testing-infra/functional-tests/src/evaluator.rs
@@ -18,9 +18,9 @@ use diem_types::{
     chain_id::ChainId,
     on_chain_config::VMPublishingOption,
     transaction::{
-        Module as TransactionModule, RawTransaction, Script as TransactionScript, ScriptFunction,
-        SignedTransaction, Transaction as DiemTransaction, TransactionOutput, TransactionPayload,
-        TransactionStatus,
+        DiemSignedTransaction, Module as TransactionModule, RawTransaction,
+        Script as TransactionScript, ScriptFunction, Transaction as DiemTransaction,
+        TransactionOutput, TransactionPayload, TransactionStatus,
     },
     vm_status::{KeptVMStatus, StatusCode},
 };
@@ -385,7 +385,7 @@ fn make_script_transaction(
     exec: &FakeExecutor,
     config: &TransactionConfig,
     blob: Vec<u8>,
-) -> Result<SignedTransaction> {
+) -> Result<DiemSignedTransaction> {
     let script = TransactionScript::new(blob, config.ty_args.clone(), config.args.clone());
 
     let params = get_transaction_parameters(exec, config);
@@ -436,7 +436,7 @@ fn make_script_function_transaction(
     config: &TransactionConfig,
     module: ModuleId,
     function: Identifier,
-) -> Result<SignedTransaction> {
+) -> Result<DiemSignedTransaction> {
     let script_function = ScriptFunction::new(
         module,
         function,
@@ -464,7 +464,7 @@ fn make_module_transaction(
     exec: &FakeExecutor,
     config: &TransactionConfig,
     module: CompiledModule,
-) -> Result<SignedTransaction> {
+) -> Result<DiemSignedTransaction> {
     let mut blob = vec![];
     module.serialize(&mut blob)?;
     let module = TransactionModule::new(blob);
@@ -487,7 +487,7 @@ fn make_module_transaction(
 /// Runs a single transaction using the fake executor.
 fn run_transaction(
     exec: &mut FakeExecutor,
-    transaction: SignedTransaction,
+    transaction: DiemSignedTransaction,
 ) -> Result<TransactionOutput> {
     let mut outputs = exec
         .execute_block_and_keep_vm_status(vec![transaction])
@@ -515,7 +515,7 @@ fn run_transaction(
 
 fn run_transaction_exp_mode(
     exec: &mut FakeExecutor,
-    transaction: SignedTransaction,
+    transaction: DiemSignedTransaction,
     log: &mut EvaluationLog,
     config: &TransactionConfig,
 ) {

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -18,7 +18,7 @@ use diem_logger::prelude::*;
 use diem_types::{
     account_address::AccountAddress,
     mempool_status::{MempoolStatus, MempoolStatusCode},
-    transaction::{GovernanceRole, SignedTransaction},
+    transaction::{DiemSignedTransaction, GovernanceRole},
 };
 use std::{
     cmp::max,
@@ -101,7 +101,7 @@ impl Mempool {
     /// Performs basic validation: checks account's sequence number.
     pub(crate) fn add_txn(
         &mut self,
-        txn: SignedTransaction,
+        txn: DiemSignedTransaction,
         gas_amount: u64,
         ranking_score: u64,
         db_sequence_number: u64,
@@ -156,7 +156,7 @@ impl Mempool {
         &mut self,
         batch_size: u64,
         mut seen: HashSet<TxnPointer>,
-    ) -> Vec<SignedTransaction> {
+    ) -> Vec<DiemSignedTransaction> {
         let mut result = vec![];
         // Helper DS. Helps to mitigate scenarios where account submits several transactions
         // with increasing gas price (e.g. user submits transactions with sequence number 1, 2
@@ -252,12 +252,16 @@ impl Mempool {
         &mut self,
         timeline_id: u64,
         count: usize,
-    ) -> (Vec<SignedTransaction>, u64) {
+    ) -> (Vec<DiemSignedTransaction>, u64) {
         self.transactions.read_timeline(timeline_id, count)
     }
 
     /// Read transactions from timeline from `start_id` (exclusive) to `end_id` (inclusive).
-    pub(crate) fn timeline_range(&mut self, start_id: u64, end_id: u64) -> Vec<SignedTransaction> {
+    pub(crate) fn timeline_range(
+        &mut self,
+        start_id: u64,
+        end_id: u64,
+    ) -> Vec<DiemSignedTransaction> {
         self.transactions.timeline_range(start_id, end_id)
     }
 

--- a/mempool/src/core_mempool/transaction.rs
+++ b/mempool/src/core_mempool/transaction.rs
@@ -3,14 +3,14 @@
 
 use diem_types::{
     account_address::AccountAddress,
-    transaction::{GovernanceRole, SignedTransaction},
+    transaction::{DiemSignedTransaction, GovernanceRole},
 };
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
 #[derive(Clone)]
 pub struct MempoolTransaction {
-    pub txn: SignedTransaction,
+    pub txn: DiemSignedTransaction,
     // System expiration time of the transaction. It should be removed from mempool by that time.
     pub expiration_time: Duration,
     pub gas_amount: u64,
@@ -21,7 +21,7 @@ pub struct MempoolTransaction {
 
 impl MempoolTransaction {
     pub(crate) fn new(
-        txn: SignedTransaction,
+        txn: DiemSignedTransaction,
         expiration_time: Duration,
         gas_amount: u64,
         ranking_score: u64,

--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -18,7 +18,7 @@ use diem_logger::prelude::*;
 use diem_types::{
     account_address::AccountAddress,
     mempool_status::{MempoolStatus, MempoolStatusCode},
-    transaction::SignedTransaction,
+    transaction::DiemSignedTransaction,
 };
 use std::{
     collections::HashMap,
@@ -74,7 +74,7 @@ impl TransactionStore {
         &self,
         address: &AccountAddress,
         sequence_number: u64,
-    ) -> Option<SignedTransaction> {
+    ) -> Option<DiemSignedTransaction> {
         if let Some(txn) = self
             .transactions
             .get(address)
@@ -346,7 +346,7 @@ impl TransactionStore {
         &mut self,
         timeline_id: u64,
         count: usize,
-    ) -> (Vec<SignedTransaction>, u64) {
+    ) -> (Vec<DiemSignedTransaction>, u64) {
         let mut batch = vec![];
         let mut last_timeline_id = timeline_id;
         for (address, sequence_number) in self.timeline_index.read_timeline(timeline_id, count) {
@@ -364,7 +364,11 @@ impl TransactionStore {
         (batch, last_timeline_id)
     }
 
-    pub(crate) fn timeline_range(&mut self, start_id: u64, end_id: u64) -> Vec<SignedTransaction> {
+    pub(crate) fn timeline_range(
+        &mut self,
+        start_id: u64,
+        end_id: u64,
+    ) -> Vec<DiemSignedTransaction> {
         self.timeline_index
             .timeline_range(start_id, end_id)
             .iter()

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -24,7 +24,7 @@ use diem_infallible::Mutex;
 use diem_logger::prelude::*;
 use diem_types::{
     mempool_status::MempoolStatus, on_chain_config::OnChainConfigPayload,
-    transaction::SignedTransaction, vm_status::DiscardedVMStatus,
+    transaction::DiemSignedTransaction, vm_status::DiscardedVMStatus,
 };
 use futures::{
     channel::{mpsc, oneshot},
@@ -46,7 +46,7 @@ pub(crate) async fn coordinator<V>(
     executor: Handle,
     network_events: Vec<(NodeNetworkId, MempoolNetworkEvents)>,
     mut client_events: mpsc::Receiver<(
-        SignedTransaction,
+        DiemSignedTransaction,
         oneshot::Sender<Result<SubmissionStatus>>,
     )>,
     mut consensus_requests: mpsc::Receiver<ConsensusRequest>,
@@ -104,7 +104,7 @@ pub(crate) async fn coordinator<V>(
 async fn handle_client_event<V>(
     smp: &mut SharedMempool<V>,
     bounded_executor: &BoundedExecutor,
-    msg: SignedTransaction,
+    msg: DiemSignedTransaction,
     callback: oneshot::Sender<anyhow::Result<(MempoolStatus, Option<DiscardedVMStatus>)>>,
 ) where
     V: TransactionValidation,

--- a/mempool/src/shared_mempool/network.rs
+++ b/mempool/src/shared_mempool/network.rs
@@ -6,7 +6,7 @@
 use crate::counters;
 use channel::message_queues::QueueStyle;
 use diem_metrics::IntCounterVec;
-use diem_types::{transaction::SignedTransaction, PeerId};
+use diem_types::{transaction::DiemSignedTransaction, PeerId};
 use fail::fail_point;
 use network::{
     error::NetworkError,
@@ -23,7 +23,7 @@ pub enum MempoolSyncMsg {
     BroadcastTransactionsRequest {
         /// Unique id of sync request. Can be used by sender for rebroadcast analysis
         request_id: Vec<u8>,
-        transactions: Vec<SignedTransaction>,
+        transactions: Vec<DiemSignedTransaction>,
     },
     /// Broadcast ack issued by the receiver.
     BroadcastTransactionsResponse {

--- a/mempool/src/shared_mempool/peer_manager.rs
+++ b/mempool/src/shared_mempool/peer_manager.rs
@@ -13,7 +13,7 @@ use crate::{
 use diem_config::config::{MempoolConfig, PeerNetworkId, PeerRole, RoleType};
 use diem_infallible::Mutex;
 use diem_logger::prelude::*;
-use diem_types::transaction::SignedTransaction;
+use diem_types::transaction::DiemSignedTransaction;
 use itertools::Itertools;
 use netcore::transport::ConnectionOrigin;
 use network::transport::ConnectionMetadata;
@@ -213,7 +213,7 @@ impl PeerManager {
         }
 
         let batch_id: BatchId;
-        let transactions: Vec<SignedTransaction>;
+        let transactions: Vec<DiemSignedTransaction>;
         let mut metric_label = None;
         {
             let mut mempool = smp.mempool.lock();

--- a/mempool/src/shared_mempool/runtime.rs
+++ b/mempool/src/shared_mempool/runtime.rs
@@ -15,7 +15,7 @@ use anyhow::Result;
 use channel::diem_channel;
 use diem_config::{config::NodeConfig, network_id::NodeNetworkId};
 use diem_infallible::{Mutex, RwLock};
-use diem_types::{on_chain_config::OnChainConfigPayload, transaction::SignedTransaction};
+use diem_types::{on_chain_config::OnChainConfigPayload, transaction::DiemSignedTransaction};
 use futures::channel::{
     mpsc::{self, Receiver, UnboundedSender},
     oneshot,
@@ -38,7 +38,10 @@ pub(crate) fn start_shared_mempool<V>(
     // First element in tuple is the network ID.
     // See `NodeConfig::is_upstream_peer` for the definition of network ID.
     mempool_network_handles: Vec<(NodeNetworkId, MempoolNetworkSender, MempoolNetworkEvents)>,
-    client_events: mpsc::Receiver<(SignedTransaction, oneshot::Sender<Result<SubmissionStatus>>)>,
+    client_events: mpsc::Receiver<(
+        DiemSignedTransaction,
+        oneshot::Sender<Result<SubmissionStatus>>,
+    )>,
     consensus_requests: mpsc::Receiver<ConsensusRequest>,
     mempool_listener: MempoolNotificationListener,
     mempool_reconfig_events: diem_channel::Receiver<(), OnChainConfigPayload>,
@@ -94,7 +97,10 @@ pub fn bootstrap(
     // The first element in the tuple is the ID of the network that this network is a handle to.
     // See `NodeConfig::is_upstream_peer` for the definition of network ID.
     mempool_network_handles: Vec<(NodeNetworkId, MempoolNetworkSender, MempoolNetworkEvents)>,
-    client_events: Receiver<(SignedTransaction, oneshot::Sender<Result<SubmissionStatus>>)>,
+    client_events: Receiver<(
+        DiemSignedTransaction,
+        oneshot::Sender<Result<SubmissionStatus>>,
+    )>,
     consensus_requests: Receiver<ConsensusRequest>,
     mempool_listener: MempoolNotificationListener,
     mempool_reconfig_events: diem_channel::Receiver<(), OnChainConfigPayload>,

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -22,7 +22,7 @@ use diem_metrics::HistogramTimer;
 use diem_types::{
     mempool_status::{MempoolStatus, MempoolStatusCode},
     on_chain_config::OnChainConfigPayload,
-    transaction::SignedTransaction,
+    transaction::{DiemSignedTransaction, SignedTransaction},
     vm_status::DiscardedVMStatus,
 };
 use futures::{channel::oneshot, stream::FuturesUnordered};
@@ -77,7 +77,7 @@ pub(crate) fn execute_broadcast<V>(
 /// Processes transactions directly submitted by client.
 pub(crate) async fn process_client_transaction_submission<V>(
     smp: SharedMempool<V>,
-    transaction: SignedTransaction,
+    transaction: DiemSignedTransaction,
     callback: oneshot::Sender<Result<SubmissionStatus>>,
     timer: HistogramTimer,
 ) where
@@ -104,7 +104,7 @@ pub(crate) async fn process_client_transaction_submission<V>(
 /// Processes transactions from other nodes.
 pub(crate) async fn process_transaction_broadcast<V>(
     mut smp: SharedMempool<V>,
-    transactions: Vec<SignedTransaction>,
+    transactions: Vec<DiemSignedTransaction>,
     request_id: Vec<u8>,
     timeline_state: TimelineState,
     peer: PeerNetworkId,
@@ -192,7 +192,7 @@ fn is_txn_retryable(result: SubmissionStatus) -> bool {
 /// and returns a vector containing AdmissionControlStatus.
 pub(crate) async fn process_incoming_transactions<V>(
     smp: &SharedMempool<V>,
-    transactions: Vec<SignedTransaction>,
+    transactions: Vec<DiemSignedTransaction>,
     timeline_state: TimelineState,
 ) -> Vec<SubmissionStatusBundle>
 where

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -18,7 +18,7 @@ use diem_types::{
     account_address::AccountAddress,
     mempool_status::MempoolStatus,
     on_chain_config::{ConfigID, DiemVersion, OnChainConfig, OnChainConfigPayload, VMConfig},
-    transaction::SignedTransaction,
+    transaction::DiemSignedTransaction,
     vm_status::DiscardedVMStatus,
 };
 use futures::{
@@ -160,7 +160,7 @@ impl fmt::Display for ConsensusRequest {
 /// Response sent from mempool to consensus.
 pub enum ConsensusResponse {
     /// Block to submit to consensus
-    GetBlockResponse(Vec<SignedTransaction>),
+    GetBlockResponse(Vec<DiemSignedTransaction>),
     CommitResponse(),
 }
 
@@ -203,10 +203,12 @@ impl fmt::Display for TransactionExclusion {
 
 pub type SubmissionStatus = (MempoolStatus, Option<DiscardedVMStatus>);
 
-pub type SubmissionStatusBundle = (SignedTransaction, SubmissionStatus);
+pub type SubmissionStatusBundle = (DiemSignedTransaction, SubmissionStatus);
 
-pub type MempoolClientSender =
-    mpsc::Sender<(SignedTransaction, oneshot::Sender<Result<SubmissionStatus>>)>;
+pub type MempoolClientSender = mpsc::Sender<(
+    DiemSignedTransaction,
+    oneshot::Sender<Result<SubmissionStatus>>,
+)>;
 
 const MEMPOOL_SUBSCRIBED_CONFIGS: &[ConfigID] = &[DiemVersion::CONFIG_ID, VMConfig::CONFIG_ID];
 

--- a/mempool/src/tests/core_mempool_test.rs
+++ b/mempool/src/tests/core_mempool_test.rs
@@ -9,7 +9,7 @@ use crate::{
     },
 };
 use diem_config::config::NodeConfig;
-use diem_types::transaction::{GovernanceRole, SignedTransaction};
+use diem_types::transaction::{DiemSignedTransaction, GovernanceRole, SignedTransaction};
 use std::{
     collections::HashSet,
     time::{Duration, SystemTime},
@@ -289,7 +289,7 @@ fn test_timeline() {
             TestTransaction::new(1, 5, 1),
         ],
     );
-    let view = |txns: Vec<SignedTransaction>| -> Vec<u64> {
+    let view = |txns: Vec<DiemSignedTransaction>| -> Vec<u64> {
         txns.iter()
             .map(SignedTransaction::sequence_number)
             .collect()

--- a/mempool/src/tests/fuzzing.rs
+++ b/mempool/src/tests/fuzzing.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use diem_config::config::NodeConfig;
 use diem_infallible::{Mutex, RwLock};
-use diem_types::transaction::SignedTransaction;
+use diem_types::transaction::DiemSignedTransaction;
 use proptest::{
     arbitrary::any,
     prelude::*,
@@ -18,9 +18,9 @@ use storage_interface::mock::MockDbReader;
 use vm_validator::mocks::mock_vm_validator::MockVMValidator;
 
 pub fn mempool_incoming_transactions_strategy(
-) -> impl Strategy<Value = (Vec<SignedTransaction>, TimelineState)> {
+) -> impl Strategy<Value = (Vec<DiemSignedTransaction>, TimelineState)> {
     (
-        proptest::collection::vec(any::<SignedTransaction>(), 0..100),
+        proptest::collection::vec(any::<DiemSignedTransaction>(), 0..100),
         prop_oneof![
             Just(TimelineState::NotReady),
             Just(TimelineState::NonQualified)
@@ -29,7 +29,7 @@ pub fn mempool_incoming_transactions_strategy(
 }
 
 pub fn test_mempool_process_incoming_transactions_impl(
-    txns: Vec<SignedTransaction>,
+    txns: Vec<DiemSignedTransaction>,
     timeline_state: TimelineState,
 ) {
     let config = NodeConfig::default();

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -16,7 +16,7 @@ use diem_config::{
 use diem_infallible::{Mutex, RwLock};
 use diem_types::{
     mempool_status::MempoolStatusCode,
-    transaction::{GovernanceRole, SignedTransaction},
+    transaction::{DiemSignedTransaction, GovernanceRole},
 };
 use futures::channel::{mpsc, oneshot};
 use mempool_notifications::{MempoolNotificationListener, MempoolNotifier};
@@ -32,7 +32,10 @@ use vm_validator::mocks::mock_vm_validator::MockVMValidator;
 /// Mock of a running instance of shared mempool.
 pub struct MockSharedMempool {
     _runtime: Runtime,
-    pub ac_client: mpsc::Sender<(SignedTransaction, oneshot::Sender<Result<SubmissionStatus>>)>,
+    pub ac_client: mpsc::Sender<(
+        DiemSignedTransaction,
+        oneshot::Sender<Result<SubmissionStatus>>,
+    )>,
     pub mempool: Arc<Mutex<CoreMempool>>,
     pub consensus_sender: mpsc::Sender<ConsensusRequest>,
     pub mempool_notifier: Option<MempoolNotifier>,
@@ -102,7 +105,7 @@ impl MockSharedMempool {
         }
     }
 
-    pub fn add_txns(&self, txns: Vec<SignedTransaction>) -> Result<()> {
+    pub fn add_txns(&self, txns: Vec<DiemSignedTransaction>) -> Result<()> {
         {
             let mut pool = self.mempool.lock();
             for txn in txns {
@@ -126,7 +129,7 @@ impl MockSharedMempool {
     }
 
     /// True if all the given txns are in mempool, else false.
-    pub fn read_timeline(&self, timeline_id: u64, count: usize) -> Vec<SignedTransaction> {
+    pub fn read_timeline(&self, timeline_id: u64, count: usize) -> Vec<DiemSignedTransaction> {
         let mut pool = self.mempool.lock();
         pool.read_timeline(timeline_id, count)
             .0

--- a/mempool/src/tests/multi_node_test.rs
+++ b/mempool/src/tests/multi_node_test.rs
@@ -13,7 +13,7 @@ use crate::{
     },
 };
 use diem_config::config::{NodeConfig, PeerRole};
-use diem_types::{transaction::SignedTransaction, PeerId};
+use diem_types::{transaction::DiemSignedTransaction, PeerId};
 use netcore::transport::ConnectionOrigin;
 use network::{
     peer_manager::{PeerManagerNotification, PeerManagerRequest},
@@ -298,7 +298,7 @@ impl TestHarness {
         sender: &NodeId,
         is_primary: bool,
         num_messages: usize,
-    ) -> (Vec<SignedTransaction>, PeerId) {
+    ) -> (Vec<DiemSignedTransaction>, PeerId) {
         self.broadcast_txns(sender, is_primary, num_messages, true, true, false)
     }
 
@@ -311,7 +311,7 @@ impl TestHarness {
         check_txns_in_mempool: bool, // Check whether all txns in this broadcast are accepted into recipient's mempool
         execute_send: bool, // If true, actually delivers msg to remote peer; else, drop the message (useful for testing unreliable msg delivery)
         drop_ack: bool,     // If true, drop ack from remote peer to this peer
-    ) -> (Vec<SignedTransaction>, PeerId) {
+    ) -> (Vec<DiemSignedTransaction>, PeerId) {
         // Await broadcast notification
         // Note: If there are other messages you're looking for, this could throw them away
         // Wait for the number of messages to be broadcasted on this node

--- a/sdk/client/src/blocking.rs
+++ b/sdk/client/src/blocking.rs
@@ -22,7 +22,7 @@ use diem_crypto::{hash::CryptoHash, HashValue};
 use diem_types::{
     account_address::AccountAddress,
     event::EventKey,
-    transaction::{SignedTransaction, Transaction},
+    transaction::{DiemSignedTransaction, Transaction},
 };
 use move_core_types::move_resource::{MoveResource, MoveStructType};
 use serde::{de::DeserializeOwned, Serialize};
@@ -58,7 +58,7 @@ impl BlockingClient {
 
     pub fn wait_for_signed_transaction(
         &self,
-        txn: &SignedTransaction,
+        txn: &DiemSignedTransaction,
         timeout: Option<Duration>,
         delay: Option<Duration>,
     ) -> Result<Response<TransactionView>, WaitForTransactionError> {
@@ -129,7 +129,7 @@ impl BlockingClient {
         resp.and_then(|json| MethodResponse::from_json(method, json).map_err(Error::decode))
     }
 
-    pub fn submit(&self, txn: &SignedTransaction) -> Result<Response<()>> {
+    pub fn submit(&self, txn: &DiemSignedTransaction) -> Result<Response<()>> {
         let request = JsonRpcRequest::new(MethodRequest::submit(txn).map_err(Error::request)?);
         self.send_without_retry(&request, true)
     }

--- a/sdk/client/src/client.rs
+++ b/sdk/client/src/client.rs
@@ -22,7 +22,7 @@ use diem_crypto::{hash::CryptoHash, HashValue};
 use diem_types::{
     account_address::AccountAddress,
     event::EventKey,
-    transaction::{SignedTransaction, Transaction},
+    transaction::{DiemSignedTransaction, Transaction},
 };
 use move_core_types::move_resource::{MoveResource, MoveStructType};
 use reqwest::Client as ReqwestClient;
@@ -62,7 +62,7 @@ impl Client {
 
     pub async fn wait_for_signed_transaction(
         &self,
-        txn: &SignedTransaction,
+        txn: &DiemSignedTransaction,
         timeout: Option<Duration>,
         delay: Option<Duration>,
     ) -> Result<Response<TransactionView>, WaitForTransactionError> {
@@ -136,7 +136,7 @@ impl Client {
         resp.and_then(|json| MethodResponse::from_json(method, json).map_err(Error::decode))
     }
 
-    pub async fn submit(&self, txn: &SignedTransaction) -> Result<Response<()>> {
+    pub async fn submit(&self, txn: &DiemSignedTransaction) -> Result<Response<()>> {
         let request = JsonRpcRequest::new(MethodRequest::submit(txn).map_err(Error::request)?);
         self.send_without_retry(&request, true).await
     }

--- a/sdk/client/src/faucet.rs
+++ b/sdk/client/src/faucet.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{BlockingClient, Error, Result};
-use diem_types::transaction::{authenticator::AuthenticationKey, SignedTransaction};
+use diem_types::transaction::{authenticator::AuthenticationKey, DiemSignedTransaction};
 
 pub struct FaucetClient {
     url: String,
@@ -40,7 +40,7 @@ impl FaucetClient {
             return Err(Error::status(status_code.as_u16()));
         }
         let bytes = hex::decode(body).map_err(Error::decode)?;
-        let txns: Vec<SignedTransaction> = bcs::from_bytes(&bytes).map_err(Error::decode)?;
+        let txns: Vec<DiemSignedTransaction> = bcs::from_bytes(&bytes).map_err(Error::decode)?;
 
         for txn in txns {
             self.json_rpc_client

--- a/sdk/client/src/request.rs
+++ b/sdk/client/src/request.rs
@@ -3,7 +3,7 @@
 
 use super::{JsonRpcVersion, Method};
 use diem_types::{
-    account_address::AccountAddress, event::EventKey, transaction::SignedTransaction,
+    account_address::AccountAddress, event::EventKey, transaction::DiemSignedTransaction,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::AtomicU64;
@@ -35,7 +35,7 @@ pub enum MethodRequest {
 }
 
 impl MethodRequest {
-    pub fn submit(txn: &SignedTransaction) -> Result<Self, bcs::Error> {
+    pub fn submit(txn: &DiemSignedTransaction) -> Result<Self, bcs::Error> {
         let txn_payload = hex::encode(bcs::to_bytes(txn)?);
         Ok(Self::Submit((txn_payload,)))
     }

--- a/sdk/client/src/verifying_client/client.rs
+++ b/sdk/client/src/verifying_client/client.rs
@@ -15,7 +15,7 @@ use diem_json_rpc_types::views::{
 use diem_types::{
     account_address::AccountAddress,
     event::EventKey,
-    transaction::{SignedTransaction, Transaction, Version},
+    transaction::{DiemSignedTransaction, Transaction, Version},
     trusted_state::TrustedState,
     waypoint::Waypoint,
 };
@@ -101,7 +101,7 @@ impl<S: StateStore> VerifyingClient<S> {
 
     pub async fn wait_for_signed_transaction(
         &self,
-        txn: &SignedTransaction,
+        txn: &DiemSignedTransaction,
         timeout: Option<Duration>,
         delay: Option<Duration>,
     ) -> Result<Response<TransactionView>, WaitForTransactionError> {
@@ -217,7 +217,7 @@ impl<S: StateStore> VerifyingClient<S> {
     /// valid transaction will eventually be committed. This client handles a
     /// connection to a single server, so the broadcasting needs to happen at a
     /// higher layer.
-    pub async fn submit(&self, txn: &SignedTransaction) -> Result<Response<()>> {
+    pub async fn submit(&self, txn: &DiemSignedTransaction) -> Result<Response<()>> {
         self.request(MethodRequest::submit(txn).map_err(Error::request)?)
             .await?
             .and_then(MethodResponse::try_into_submit)

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -8,9 +8,10 @@ use crate::{
         traits::Uniform,
     },
     transaction_builder::TransactionBuilder,
-    types::transaction::{authenticator::AuthenticationKey, RawTransaction, SignedTransaction},
+    types::transaction::{authenticator::AuthenticationKey, RawTransaction},
 };
 
+use crate::types::transaction::DiemSignedTransaction;
 pub use diem_types::*;
 
 #[derive(Debug)]
@@ -42,7 +43,7 @@ impl LocalAccount {
         Self::new(address, key, 0)
     }
 
-    pub fn sign_transaction(&self, txn: RawTransaction) -> SignedTransaction {
+    pub fn sign_transaction(&self, txn: RawTransaction) -> DiemSignedTransaction {
         txn.sign(self.private_key(), self.public_key().clone())
             .expect("Signing a txn can't fail")
             .into_inner()
@@ -51,7 +52,7 @@ impl LocalAccount {
     pub fn sign_with_transaction_builder(
         &mut self,
         builder: TransactionBuilder,
-    ) -> SignedTransaction {
+    ) -> DiemSignedTransaction {
         let raw_txn = builder
             .sender(self.address())
             .sequence_number(self.sequence_number())
@@ -64,7 +65,7 @@ impl LocalAccount {
         &mut self,
         secondary_signers: Vec<&Self>,
         builder: TransactionBuilder,
-    ) -> SignedTransaction {
+    ) -> DiemSignedTransaction {
         let secondary_signer_addresses = secondary_signers
             .iter()
             .map(|signer| signer.address())

--- a/state-sync/state-sync-v1/tests/test_harness.rs
+++ b/state-sync/state-sync-v1/tests/test_harness.rs
@@ -29,7 +29,8 @@ use diem_types::{
     proof::TransactionListProof,
     test_helpers::transaction_test_helpers::get_test_signed_txn,
     transaction::{
-        authenticator::AuthenticationKey, SignedTransaction, Transaction, TransactionListWithProof,
+        authenticator::AuthenticationKey, DiemSignedTransaction, Transaction,
+        TransactionListWithProof,
     },
     validator_config::ValidatorConfig,
     validator_info::ValidatorInfo,
@@ -708,7 +709,10 @@ impl MockStorage {
 
     // Generate new dummy txns and updates the LI
     // with the version corresponding to the new transactions, signed by this storage signer.
-    pub fn commit_new_txns(&mut self, num_txns: u64) -> (Vec<Transaction>, Vec<SignedTransaction>) {
+    pub fn commit_new_txns(
+        &mut self,
+        num_txns: u64,
+    ) -> (Vec<Transaction>, Vec<DiemSignedTransaction>) {
         let mut committed_txns = vec![];
         let mut signed_txns = vec![];
         for _ in 0..num_txns {

--- a/storage/diemdb/src/transaction_store/test.rs
+++ b/storage/diemdb/src/transaction_store/test.rs
@@ -8,7 +8,7 @@ use diem_temppath::TempPath;
 use diem_types::{
     block_metadata::BlockMetadata,
     proptest_types::{AccountInfoUniverse, SignatureCheckedTransactionGen},
-    transaction::{SignedTransaction, Transaction},
+    transaction::{DiemSignedTransaction, Transaction},
 };
 use proptest::{collection::vec, prelude::*};
 use std::collections::BTreeMap;
@@ -109,7 +109,7 @@ proptest! {
         txns in vec(
             prop_oneof![
                 any::<BlockMetadata>().prop_map(Transaction::BlockMetadata),
-                any::<SignedTransaction>().prop_map(Transaction::UserTransaction),
+                any::<DiemSignedTransaction>().prop_map(Transaction::UserTransaction),
             ],
             1..100,
         )

--- a/testsuite/cli/diem-wallet/src/wallet_library.rs
+++ b/testsuite/cli/diem-wallet/src/wallet_library.rs
@@ -22,8 +22,8 @@ use diem_crypto::ed25519::Ed25519PrivateKey;
 use diem_types::{
     account_address::AccountAddress,
     transaction::{
-        authenticator::AuthenticationKey, helpers::TransactionSigner, RawTransaction,
-        SignedTransaction,
+        authenticator::AuthenticationKey, helpers::TransactionSigner, DiemSignedTransaction,
+        RawTransaction, SignedTransaction,
     },
 };
 use rand::{rngs::OsRng, Rng};
@@ -158,7 +158,7 @@ impl WalletLibrary {
     /// Simple public function that allows to sign a Diem RawTransaction with the PrivateKey
     /// associated to a particular AccountAddress. If the PrivateKey associated to an
     /// AccountAddress is not contained in the addr_map, then this function will return an Error
-    pub fn sign_txn(&self, txn: RawTransaction) -> Result<SignedTransaction> {
+    pub fn sign_txn(&self, txn: RawTransaction) -> Result<DiemSignedTransaction> {
         if let Some(child) = self.addr_map.get(&txn.sender()) {
             let child_key = self.key_factory.private_child(*child)?;
             let signature = child_key.sign(&txn);
@@ -199,7 +199,7 @@ impl WalletLibrary {
 
 /// WalletLibrary naturally support TransactionSigner trait.
 impl TransactionSigner for WalletLibrary {
-    fn sign_txn(&self, raw_txn: RawTransaction) -> Result<SignedTransaction, anyhow::Error> {
+    fn sign_txn(&self, raw_txn: RawTransaction) -> Result<DiemSignedTransaction, anyhow::Error> {
         self.sign_txn(raw_txn)
     }
 }

--- a/testsuite/cli/src/diem_client.rs
+++ b/testsuite/cli/src/diem_client.rs
@@ -11,7 +11,7 @@ use diem_types::{
     ledger_info::LedgerInfoWithSignatures,
     proof::{AccumulatorConsistencyProof, TransactionAccumulatorSummary},
     state_proof::StateProof,
-    transaction::{SignedTransaction, Version},
+    transaction::{DiemSignedTransaction, Version},
     trusted_state::{TrustedState, TrustedStateChange},
     waypoint::Waypoint,
 };
@@ -57,7 +57,7 @@ impl DiemClient {
 
     /// Submits a transaction and bumps the sequence number for the sender, pass in `None` for
     /// sender_account if sender's address is not managed by the client.
-    pub fn submit_transaction(&self, transaction: &SignedTransaction) -> Result<()> {
+    pub fn submit_transaction(&self, transaction: &DiemSignedTransaction) -> Result<()> {
         self.client
             .submit(transaction)
             .map_err(Into::into)
@@ -102,7 +102,7 @@ impl DiemClient {
 
     pub fn wait_for_transaction(
         &self,
-        txn: &SignedTransaction,
+        txn: &DiemSignedTransaction,
         timeout: Duration,
     ) -> Result<views::TransactionView, WaitForTransactionError> {
         self.client

--- a/testsuite/generate-format/src/consensus.rs
+++ b/testsuite/generate-format/src/consensus.rs
@@ -59,7 +59,7 @@ pub fn get_registry() -> Result<Registry> {
     tracer.trace_type::<transaction::TransactionPayload>(&samples)?;
     tracer.trace_type::<transaction::WriteSetPayload>(&samples)?;
     tracer.trace_type::<transaction::authenticator::AccountAuthenticator>(&samples)?;
-    tracer.trace_type::<transaction::authenticator::TransactionAuthenticator>(&samples)?;
+    tracer.trace_type::<transaction::authenticator::DiemTransactionAuthenticator>(&samples)?;
     tracer.trace_type::<write_set::WriteOp>(&samples)?;
 
     tracer.trace_type::<consensus::network_interface::ConsensusMsg>(&samples)?;

--- a/testsuite/generate-format/src/diem.rs
+++ b/testsuite/generate-format/src/diem.rs
@@ -67,7 +67,7 @@ pub fn get_registry() -> Result<Registry> {
     tracer.trace_type::<transaction::TransactionPayload>(&samples)?;
     tracer.trace_type::<transaction::WriteSetPayload>(&samples)?;
     tracer.trace_type::<transaction::authenticator::AccountAuthenticator>(&samples)?;
-    tracer.trace_type::<transaction::authenticator::TransactionAuthenticator>(&samples)?;
+    tracer.trace_type::<transaction::authenticator::DiemTransactionAuthenticator>(&samples)?;
     tracer.trace_type::<write_set::WriteOp>(&samples)?;
     tracer.registry()
 }

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -172,6 +172,33 @@ ContractEventV0:
     - type_tag:
         TYPENAME: TypeTag
     - event_data: BYTES
+DiemTransactionAuthenticator:
+  ENUM:
+    0:
+      Ed25519:
+        STRUCT:
+          - public_key:
+              TYPENAME: Ed25519PublicKey
+          - signature:
+              TYPENAME: Ed25519Signature
+    1:
+      MultiEd25519:
+        STRUCT:
+          - public_key:
+              TYPENAME: MultiEd25519PublicKey
+          - signature:
+              TYPENAME: MultiEd25519Signature
+    2:
+      MultiAgent:
+        STRUCT:
+          - sender:
+              TYPENAME: AccountAuthenticator
+          - secondary_signer_addresses:
+              SEQ:
+                TYPENAME: AccountAddress
+          - secondary_signers:
+              SEQ:
+                TYPENAME: AccountAuthenticator
 Ed25519PublicKey:
   NEWTYPESTRUCT: BYTES
 Ed25519Signature:
@@ -282,7 +309,7 @@ SignedTransaction:
     - raw_txn:
         TYPENAME: RawTransaction
     - authenticator:
-        TYPENAME: TransactionAuthenticator
+        TYPENAME: DiemTransactionAuthenticator
 StructTag:
   STRUCT:
     - address:
@@ -356,33 +383,6 @@ TransactionArgument:
     5:
       Bool:
         NEWTYPE: BOOL
-TransactionAuthenticator:
-  ENUM:
-    0:
-      Ed25519:
-        STRUCT:
-          - public_key:
-              TYPENAME: Ed25519PublicKey
-          - signature:
-              TYPENAME: Ed25519Signature
-    1:
-      MultiEd25519:
-        STRUCT:
-          - public_key:
-              TYPENAME: MultiEd25519PublicKey
-          - signature:
-              TYPENAME: MultiEd25519Signature
-    2:
-      MultiAgent:
-        STRUCT:
-          - sender:
-              TYPENAME: AccountAuthenticator
-          - secondary_signer_addresses:
-              SEQ:
-                TYPENAME: AccountAddress
-          - secondary_signers:
-              SEQ:
-                TYPENAME: AccountAuthenticator
 TransactionPayload:
   ENUM:
     0:

--- a/testsuite/generate-format/tests/staged/diem.yaml
+++ b/testsuite/generate-format/tests/staged/diem.yaml
@@ -69,6 +69,33 @@ ContractEventV0:
     - type_tag:
         TYPENAME: TypeTag
     - event_data: BYTES
+DiemTransactionAuthenticator:
+  ENUM:
+    0:
+      Ed25519:
+        STRUCT:
+          - public_key:
+              TYPENAME: Ed25519PublicKey
+          - signature:
+              TYPENAME: Ed25519Signature
+    1:
+      MultiEd25519:
+        STRUCT:
+          - public_key:
+              TYPENAME: MultiEd25519PublicKey
+          - signature:
+              TYPENAME: MultiEd25519Signature
+    2:
+      MultiAgent:
+        STRUCT:
+          - sender:
+              TYPENAME: AccountAuthenticator
+          - secondary_signer_addresses:
+              SEQ:
+                TYPENAME: AccountAddress
+          - secondary_signers:
+              SEQ:
+                TYPENAME: AccountAuthenticator
 Ed25519PublicKey:
   NEWTYPESTRUCT: BYTES
 Ed25519Signature:
@@ -207,7 +234,7 @@ SignedTransaction:
     - raw_txn:
         TYPENAME: RawTransaction
     - authenticator:
-        TYPENAME: TransactionAuthenticator
+        TYPENAME: DiemTransactionAuthenticator
 StructTag:
   STRUCT:
     - address:
@@ -254,33 +281,6 @@ TransactionArgument:
     5:
       Bool:
         NEWTYPE: BOOL
-TransactionAuthenticator:
-  ENUM:
-    0:
-      Ed25519:
-        STRUCT:
-          - public_key:
-              TYPENAME: Ed25519PublicKey
-          - signature:
-              TYPENAME: Ed25519Signature
-    1:
-      MultiEd25519:
-        STRUCT:
-          - public_key:
-              TYPENAME: MultiEd25519PublicKey
-          - signature:
-              TYPENAME: MultiEd25519Signature
-    2:
-      MultiAgent:
-        STRUCT:
-          - sender:
-              TYPENAME: AccountAuthenticator
-          - secondary_signer_addresses:
-              SEQ:
-                TYPENAME: AccountAddress
-          - secondary_signers:
-              SEQ:
-                TYPENAME: AccountAuthenticator
 TransactionPayload:
   ENUM:
     0:

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -18,8 +18,8 @@ use crate::{
     on_chain_config::ValidatorSet,
     proof::TransactionListProof,
     transaction::{
-        ChangeSet, Module, RawTransaction, Script, SignatureCheckedTransaction, SignedTransaction,
-        Transaction, TransactionArgument, TransactionListWithProof, TransactionPayload,
+        ChangeSet, DiemSignatureCheckedTransaction, DiemSignedTransaction, Module, RawTransaction,
+        Script, Transaction, TransactionArgument, TransactionListWithProof, TransactionPayload,
         TransactionStatus, TransactionToCommit, Version, WriteSetPayload,
     },
     validator_info::ValidatorInfo,
@@ -383,7 +383,7 @@ impl Arbitrary for RawTransaction {
     type Strategy = BoxedStrategy<Self>;
 }
 
-impl SignatureCheckedTransaction {
+impl DiemSignatureCheckedTransaction {
     // This isn't an Arbitrary impl because this doesn't generate *any* possible SignedTransaction,
     // just one kind of them.
     pub fn script_strategy(
@@ -479,7 +479,7 @@ impl SignatureCheckedTransactionGen {
         self,
         sender_index: Index,
         universe: &mut AccountInfoUniverse,
-    ) -> SignatureCheckedTransaction {
+    ) -> DiemSignatureCheckedTransaction {
         let raw_txn = self.raw_transaction_gen.materialize(sender_index, universe);
         let account_info = universe.get_account_info(sender_index);
         raw_txn
@@ -488,7 +488,7 @@ impl SignatureCheckedTransactionGen {
     }
 }
 
-impl Arbitrary for SignatureCheckedTransaction {
+impl Arbitrary for DiemSignatureCheckedTransaction {
     type Parameters = ();
     fn arbitrary_with(_args: ()) -> Self::Strategy {
         Self::strategy_impl(
@@ -503,10 +503,10 @@ impl Arbitrary for SignatureCheckedTransaction {
 }
 
 /// This `Arbitrary` impl only generates valid signed transactions. TODO: maybe add invalid ones?
-impl Arbitrary for SignedTransaction {
+impl Arbitrary for DiemSignedTransaction {
     type Parameters = ();
     fn arbitrary_with(_args: ()) -> Self::Strategy {
-        any::<SignatureCheckedTransaction>()
+        any::<DiemSignatureCheckedTransaction>()
             .prop_map(|txn| txn.into_inner())
             .boxed()
     }
@@ -887,7 +887,7 @@ fn arb_transaction_list_with_proof() -> impl Strategy<Value = TransactionListWit
     (
         vec(
             (
-                any::<SignedTransaction>(),
+                any::<DiemSignedTransaction>(),
                 vec(any::<ContractEvent>(), 0..10),
             ),
             0..10,

--- a/types/src/test_helpers/transaction_test_helpers.rs
+++ b/types/src/test_helpers/transaction_test_helpers.rs
@@ -6,8 +6,9 @@ use crate::{
     account_config::XUS_NAME,
     chain_id::ChainId,
     transaction::{
-        authenticator::AccountAuthenticator, Module, RawTransaction, RawTransactionWithData,
-        Script, SignatureCheckedTransaction, SignedTransaction, TransactionPayload,
+        authenticator::AccountAuthenticator, DiemSignatureCheckedTransaction,
+        DiemSignedTransaction, Module, RawTransaction, RawTransactionWithData, Script,
+        SignedTransaction, TransactionPayload,
     },
     write_set::WriteSet,
 };
@@ -34,7 +35,7 @@ pub fn get_test_signed_module_publishing_transaction(
     private_key: &Ed25519PrivateKey,
     public_key: Ed25519PublicKey,
     module: Module,
-) -> SignedTransaction {
+) -> DiemSignedTransaction {
     let expiration_time = expiration_time(10);
     let raw_txn = RawTransaction::new_module(
         sender,
@@ -63,7 +64,7 @@ pub fn get_test_signed_transaction(
     gas_unit_price: u64,
     gas_currency_code: String,
     max_gas_amount: Option<u64>,
-) -> SignedTransaction {
+) -> DiemSignedTransaction {
     let raw_txn = RawTransaction::new_script(
         sender,
         sequence_number,
@@ -91,7 +92,7 @@ pub fn get_test_unchecked_transaction(
     gas_unit_price: u64,
     gas_currency_code: String,
     max_gas_amount: Option<u64>,
-) -> SignedTransaction {
+) -> DiemSignedTransaction {
     get_test_unchecked_transaction_(
         sender,
         sequence_number,
@@ -118,7 +119,7 @@ fn get_test_unchecked_transaction_(
     gas_currency_code: String,
     max_gas_amount: Option<u64>,
     chain_id: ChainId,
-) -> SignedTransaction {
+) -> DiemSignedTransaction {
     let raw_txn = RawTransaction::new_script(
         sender,
         sequence_number,
@@ -143,7 +144,7 @@ pub fn get_test_signed_txn(
     private_key: &Ed25519PrivateKey,
     public_key: Ed25519PublicKey,
     script: Option<Script>,
-) -> SignedTransaction {
+) -> DiemSignedTransaction {
     let expiration_time = expiration_time(10);
     get_test_signed_transaction(
         sender,
@@ -164,7 +165,7 @@ pub fn get_test_unchecked_txn(
     private_key: &Ed25519PrivateKey,
     public_key: Ed25519PublicKey,
     script: Option<Script>,
-) -> SignedTransaction {
+) -> DiemSignedTransaction {
     let expiration_time = expiration_time(10);
     get_test_unchecked_transaction(
         sender,
@@ -188,7 +189,7 @@ pub fn get_test_unchecked_multi_agent_txn(
     secondary_private_keys: Vec<&Ed25519PrivateKey>,
     secondary_public_keys: Vec<Ed25519PublicKey>,
     script: Option<Script>,
-) -> SignedTransaction {
+) -> DiemSignedTransaction {
     let expiration_time = expiration_time(10);
     let raw_txn = RawTransaction::new(
         sender,
@@ -231,7 +232,7 @@ pub fn get_test_txn_with_chain_id(
     private_key: &Ed25519PrivateKey,
     public_key: Ed25519PublicKey,
     chain_id: ChainId,
-) -> SignedTransaction {
+) -> DiemSignedTransaction {
     let expiration_time = expiration_time(10);
     get_test_unchecked_transaction_(
         sender,
@@ -253,7 +254,7 @@ pub fn get_write_set_txn(
     private_key: &Ed25519PrivateKey,
     public_key: Ed25519PublicKey,
     write_set: Option<WriteSet>,
-) -> SignatureCheckedTransaction {
+) -> DiemSignatureCheckedTransaction {
     let write_set = write_set.unwrap_or_default();
     RawTransaction::new_write_set(sender, sequence_number, write_set, ChainId::test())
         .sign(private_key, public_key)

--- a/types/src/transaction/helpers.rs
+++ b/types/src/transaction/helpers.rs
@@ -4,7 +4,7 @@
 use crate::{
     account_address::AccountAddress,
     chain_id::ChainId,
-    transaction::{RawTransaction, SignedTransaction, TransactionPayload},
+    transaction::{DiemSignedTransaction, RawTransaction, SignedTransaction, TransactionPayload},
 };
 use anyhow::Result;
 use chrono::Utc;
@@ -33,7 +33,7 @@ pub fn create_unsigned_txn(
 }
 
 pub trait TransactionSigner {
-    fn sign_txn(&self, raw_txn: RawTransaction) -> Result<SignedTransaction>;
+    fn sign_txn(&self, raw_txn: RawTransaction) -> Result<DiemSignedTransaction>;
 }
 
 /// Craft a transaction request.
@@ -47,7 +47,7 @@ pub fn create_user_txn<T: TransactionSigner + ?Sized>(
     gas_currency_code: String,
     txn_expiration_duration_secs: i64, // for compatibility with UTC's timestamp.
     chain_id: ChainId,
-) -> Result<SignedTransaction> {
+) -> Result<DiemSignedTransaction> {
     let raw_txn = create_unsigned_txn(
         payload,
         sender_address,
@@ -62,7 +62,7 @@ pub fn create_user_txn<T: TransactionSigner + ?Sized>(
 }
 
 impl TransactionSigner for KeyPair<Ed25519PrivateKey, Ed25519PublicKey> {
-    fn sign_txn(&self, raw_txn: RawTransaction) -> Result<SignedTransaction> {
+    fn sign_txn(&self, raw_txn: RawTransaction) -> Result<DiemSignedTransaction> {
         let signature = self.private_key.sign(&raw_txn);
         Ok(SignedTransaction::new(
             raw_txn,

--- a/types/src/unit_tests/transaction_test.rs
+++ b/types/src/unit_tests/transaction_test.rs
@@ -6,9 +6,9 @@ use crate::{
     account_config::XUS_NAME,
     chain_id::ChainId,
     transaction::{
-        metadata, AccountTransactionsWithProof, GovernanceRole, RawTransaction, Script,
-        SignedTransaction, Transaction, TransactionInfo, TransactionListWithProof,
-        TransactionPayload, TransactionWithProof,
+        metadata, AccountTransactionsWithProof, DiemSignedTransaction, GovernanceRole,
+        RawTransaction, Script, SignedTransaction, Transaction, TransactionInfo,
+        TransactionListWithProof, TransactionPayload, TransactionWithProof,
     },
 };
 use bcs::test_helpers::assert_canonical_encode_decode;
@@ -21,7 +21,7 @@ use std::convert::TryFrom;
 
 #[test]
 fn test_invalid_signature() {
-    let txn: SignedTransaction = SignedTransaction::new(
+    let txn: DiemSignedTransaction = SignedTransaction::new(
         RawTransaction::new_script(
             AccountAddress::random(),
             0,
@@ -101,7 +101,7 @@ proptest! {
     }
 
     #[test]
-    fn signed_transaction_bcs_roundtrip(signed_txn in any::<SignedTransaction>()) {
+    fn signed_transaction_bcs_roundtrip(signed_txn in any::<DiemSignedTransaction>()) {
         assert_canonical_encode_decode(signed_txn);
     }
 

--- a/vm-validator/src/mocks/mock_vm_validator.rs
+++ b/vm-validator/src/mocks/mock_vm_validator.rs
@@ -7,7 +7,7 @@ use diem_state_view::StateView;
 use diem_types::{
     account_address::AccountAddress,
     on_chain_config::OnChainConfigPayload,
-    transaction::{GovernanceRole, SignedTransaction, VMValidatorResult},
+    transaction::{DiemSignedTransaction, GovernanceRole, VMValidatorResult},
     vm_status::StatusCode,
 };
 use diem_vm::VMValidator;
@@ -18,7 +18,7 @@ pub struct MockVMValidator;
 impl VMValidator for MockVMValidator {
     fn validate_transaction(
         &self,
-        _transaction: SignedTransaction,
+        _transaction: DiemSignedTransaction,
         _state_view: &dyn StateView,
     ) -> VMValidatorResult {
         VMValidatorResult::new(None, 0, GovernanceRole::NonGovernanceRole)
@@ -27,7 +27,7 @@ impl VMValidator for MockVMValidator {
 
 impl TransactionValidation for MockVMValidator {
     type ValidationInstance = MockVMValidator;
-    fn validate_transaction(&self, txn: SignedTransaction) -> Result<VMValidatorResult> {
+    fn validate_transaction(&self, txn: DiemSignedTransaction) -> Result<VMValidatorResult> {
         let txn = match txn.check_signature() {
             Ok(txn) => txn,
             Err(_) => {

--- a/vm-validator/src/vm_validator.rs
+++ b/vm-validator/src/vm_validator.rs
@@ -7,7 +7,7 @@ use diem_types::{
     account_address::AccountAddress,
     account_config::AccountResource,
     on_chain_config::{DiemVersion, OnChainConfigPayload, VMConfig, VMPublishingOption},
-    transaction::{SignedTransaction, VMValidatorResult},
+    transaction::{DiemSignedTransaction, VMValidatorResult},
 };
 use diem_vm::DiemVM;
 use fail::fail_point;
@@ -23,7 +23,7 @@ pub trait TransactionValidation: Send + Sync + Clone {
     type ValidationInstance: diem_vm::VMValidator;
 
     /// Validate a txn from client
-    fn validate_transaction(&self, _txn: SignedTransaction) -> Result<VMValidatorResult>;
+    fn validate_transaction(&self, _txn: DiemSignedTransaction) -> Result<VMValidatorResult>;
 
     /// Restart the transaction validation instance
     fn restart(&mut self, config: OnChainConfigPayload) -> Result<()>;
@@ -55,7 +55,7 @@ impl VMValidator {
 impl TransactionValidation for VMValidator {
     type ValidationInstance = DiemVM;
 
-    fn validate_transaction(&self, txn: SignedTransaction) -> Result<VMValidatorResult> {
+    fn validate_transaction(&self, txn: DiemSignedTransaction) -> Result<VMValidatorResult> {
         fail_point!("vm_validator::validate_transaction", |_| {
             Err(anyhow::anyhow!(
                 "Injected error in vm_validator::validate_transaction"


### PR DESCRIPTION
## Motivation
This PR introduces a new trait TransactionAuthenticator and updated the code base accordingly. The purpose of the PR is to increase reusability of diem code for other blockchains, specifically for authentication scheme. 

As of now, Diem is tightly coupled with `TransactionAuthenticator` enum which is maintained as part of diem.  If a different blockchain wants to reuse diem code with an authentication scheme not yet supported by Diem (e.g., ECDSA), the blockchain developer have to contribute to Diem repo to add a new variant of `TransactionAuthenticator` enum. With this PR, we want to 

Changes include

* Introduce a new trait TransactionAuthenticator 
* Change the existing TransactionAuthenticator enum implementation to DiemTransactionAuthenticator
* Make SignedTransaction generic over TransactionAuthenticator
* Add type parameters for DiemTransactionAuthenticator in diem code accordingly 

## Some check/review points 
* Using `DiemTransactionAuthenticator` instead of `TransactionAuthenticator` would be a breaking change? e.g., No issue for ser/des
* How far do we want to push reusability of diem code? i.e., For now, we added `DiemTransactionAuthenticator` to struct `Transaction`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes


