### PR TITLE
[move-prover] add a flag to toggle whether unconditional abort is inconsistency

### DIFF
--- a/language/move-prover/bytecode/src/options.rs
+++ b/language/move-prover/bytecode/src/options.rs
@@ -73,6 +73,8 @@ pub struct ProverOptions {
     pub sequential_task: bool,
     /// Whether to check the inconsistency
     pub check_inconsistency: bool,
+    /// Whether to consider a function that abort unconditionally as an inconsistency violation
+    pub unconditional_abort_as_inconsistency: bool,
     /// Whether to use exclusively weak edges in borrow analysis
     pub weak_edges: bool,
     /// Whether to run monomorphization analysis & transformation
@@ -105,6 +107,7 @@ impl Default for ProverOptions {
             num_instances: 1,
             sequential_task: false,
             check_inconsistency: false,
+            unconditional_abort_as_inconsistency: false,
             weak_edges: false,
             run_mono: true,
             invariants_v2: true,

--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -426,6 +426,12 @@ impl Options {
                     .help("checks whether there is any inconsistency")
             )
             .arg(
+                Arg::with_name("unconditional-abort-as-inconsistency")
+                    .long("unconditional-abort-as-inconsistency")
+                    .help("treat functions that do not return (i.e., abort unconditionally) \
+                    as inconsistency violations")
+            )
+            .arg(
                 Arg::with_name("verify-only")
                     .long("verify-only")
                     .takes_value(true)
@@ -627,8 +633,12 @@ impl Options {
         if matches.is_present("generate-smt") {
             options.backend.generate_smt = true;
         }
+
         if matches.is_present("check-inconsistency") {
             options.prover.check_inconsistency = true;
+        }
+        if matches.is_present("unconditional-abort-as-inconsistency") {
+            options.prover.unconditional_abort_as_inconsistency = true;
         }
 
         if matches.is_present("verify-only") {

--- a/language/move-prover/tests/sources/functional/inconsistency.exp
+++ b/language/move-prover/tests/sources/functional/inconsistency.exp
@@ -1,13 +1,5 @@
 Move prover returns: exiting with boogie verification errors
 error: there is an inconsistent assumption in the function, which may allow any post-condition (including false) to be proven
-   ┌─ tests/sources/functional/inconsistency.move:49:5
-   │
-49 │ ╭     fun always_abort() {
-50 │ │         abort 0
-51 │ │     }
-   │ ╰─────^
-
-error: there is an inconsistent assumption in the function, which may allow any post-condition (including false) to be proven
    ┌─ tests/sources/functional/inconsistency.move:17:5
    │
 17 │ ╭     fun assume_false(x: u64): u64 {
@@ -16,12 +8,4 @@ error: there is an inconsistent assumption in the function, which may allow any 
 20 │ │         };
 21 │ │         dec(x)
 22 │ │     }
-   │ ╰─────^
-
-error: there is an inconsistent assumption in the function, which may allow any post-condition (including false) to be proven
-   ┌─ tests/sources/functional/inconsistency.move:40:5
-   │
-40 │ ╭     fun call_inconsistent_opaque() {
-41 │ │         inconsistent_opaque();
-42 │ │     }
    │ ╰─────^

--- a/language/move-prover/tests/sources/functional/inconsistency.move
+++ b/language/move-prover/tests/sources/functional/inconsistency.move
@@ -43,14 +43,4 @@ module 0x42::Inconsistency {
     spec call_inconsistent_opaque {
         ensures false;
     }
-
-    // There is an inconsistent assumption in the verification of this function
-    // because it always aborts.
-    fun always_abort() {
-        abort 0
-    }
-    spec always_abort {
-        ensures false;
-    }
-
 }

--- a/language/move-prover/tests/sources/functional/inconsistency.no_opaque_exp
+++ b/language/move-prover/tests/sources/functional/inconsistency.no_opaque_exp
@@ -11,14 +11,6 @@ error: post-condition does not hold
    =     at tests/sources/functional/inconsistency.move:44
 
 error: there is an inconsistent assumption in the function, which may allow any post-condition (including false) to be proven
-   ┌─ tests/sources/functional/inconsistency.move:49:5
-   │
-49 │ ╭     fun always_abort() {
-50 │ │         abort 0
-51 │ │     }
-   │ ╰─────^
-
-error: there is an inconsistent assumption in the function, which may allow any post-condition (including false) to be proven
    ┌─ tests/sources/functional/inconsistency.move:17:5
    │
 17 │ ╭     fun assume_false(x: u64): u64 {

--- a/language/move-prover/tests/sources/functional/inconsistency_always_abort.exp
+++ b/language/move-prover/tests/sources/functional/inconsistency_always_abort.exp
@@ -1,0 +1,20 @@
+Move prover returns: exiting with boogie verification errors
+error: there is an inconsistent assumption in the function, which may allow any post-condition (including false) to be proven
+  ┌─ tests/sources/functional/inconsistency_always_abort.move:6:5
+  │
+6 │ ╭     fun always_abort() {
+7 │ │         abort 0
+8 │ │     }
+  │ ╰─────^
+
+error: there is an inconsistent assumption in the function, which may allow any post-condition (including false) to be proven
+   ┌─ tests/sources/functional/inconsistency_always_abort.move:14:5
+   │
+14 │ ╭     fun always_abort_if_else(x: u64): bool {
+15 │ │         if (x == x) {
+16 │ │             abort 0
+17 │ │         } else {
+18 │ │             return true
+19 │ │         }
+20 │ │     }
+   │ ╰─────^

--- a/language/move-prover/tests/sources/functional/inconsistency_always_abort.move
+++ b/language/move-prover/tests/sources/functional/inconsistency_always_abort.move
@@ -1,0 +1,24 @@
+// flag: --check-inconsistency
+// flag: --unconditional-abort-as-inconsistency
+module 0x42::Inconsistency {
+    // There is an inconsistent assumption in the verification of this function
+    // because it always aborts.
+    fun always_abort() {
+        abort 0
+    }
+    spec always_abort {
+        ensures false;
+    }
+
+    // Hiding the function behind some trivial if-else branch does not work
+    fun always_abort_if_else(x: u64): bool {
+        if (x == x) {
+            abort 0
+        } else {
+            return true
+        }
+    }
+    spec always_abort_if_else {
+        ensures result == false;
+    }
+}


### PR DESCRIPTION
The motivation for this change is the inconsistency issue reported in
PR #8851, where `TransactionFee::burn_fees<CoinType>` runs into an
unconditional abort case when and only when `CoinType` is instantiated
with `XDX`.

This is subsequently flagged by the inconsistency checker as an
violation. Where in this case, the inconsistency checker flags the
case not because we are not proving an `assert false;`, but because the
verification finishes successfully when the inconsistency checker
expects it to fail.

The reason verification finishes successfully is because for a function
that unconditionally abort on all arguments (and hence, never returns),
the `assert false;` verification condition is either not instrumented
or not reachable.

The fix, is to not only instrument `assert false;` before returns, but
also before an abort. In this way, we will be able to catch executions
that terminates without going through the return path.

However, we may still want to preserve the ability to check functions
that unconditionally abort, as we can prove function like the following
does look a bit odd to users.
```
fun always_abort() {
    abort 0
}
spec always_abort {
    ensures 1 == 2;
}
```

The compromise is to have an additional flag,
`--unconditional-abort-as-inconsistency`
to control whether we want to treat a function that aborts
unconditionally as an inconsistency violation. Unfortunately, due to the
complication in `TransactionFee.move`, we cannot turn on this flag by
default and have to rely on periodic manual runs to check these cases.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Fix the issue in daily CI.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

new tests are added
