### PR TITLE
adding a line in the beginning to help in debugging when gha fails

### DIFF
--- a/scripts/weekly-dep-report.sh
+++ b/scripts/weekly-dep-report.sh
@@ -5,6 +5,9 @@
 # fast fail.
 set -eo pipefail
 
+echo " Dependency change report "
+echo "--------------------------"
+
 # expects two parameters: repository name and branch
 repository=$1
 starter_point=${2:-"HEAD"}


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

`weekly-dep-report.sh` in `weekly.yml` sometimes posts empty message. The shell script when run successfully should echo something at least. However, [failed GHA in the past](https://github.com/diem/diem/runs/3031015500?check_suite_focus=true) shows the script is successfully run but with no output. Adding two lines in the beginning to ensure the script is not early dying next time the the action fails to produce any output. 

 
### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

The change is made to help in debugging next time the corresponding gha fails.

