### PR TITLE
 [forge][k8s] add option to upgrade single validator

### DIFF
--- a/scripts/fgi/kube.py
+++ b/scripts/fgi/kube.py
@@ -174,7 +174,7 @@ def kube_wait_job(job_name, context):
 
 
 # init the kube context for each available cluster
-def kube_init_context():
+def kube_init_context(workspace=None):
     try:
         subprocess.run(
             [
@@ -191,7 +191,9 @@ def kube_init_context():
     except subprocess.CalledProcessError:
         print("Failed to access EKS, try awsmfa?")
         raise
-    for cluster in FORGE_K8S_CLUSTERS:
+    # preserve the kube context by updating kubeconfig for the specified workspace
+    clusters = FORGE_K8S_CLUSTERS + [workspace] if workspace else FORGE_K8S_CLUSTERS
+    for cluster in clusters:
         subprocess.run(
             [
                 "aws",

--- a/scripts/fgi/run
+++ b/scripts/fgi/run
@@ -121,7 +121,7 @@ if not cli_tool_installed("kubectl"):
     sys.exit(1)
 
 print("\nAttempting to reach Forge Kubernetes testnets...")
-kube_init_context()
+kube_init_context(args.workspace)
 print("Grabbing a testnet...")
 workspace = args.workspace
 if not args.workspace:
@@ -175,20 +175,25 @@ subprocess.call(
 )
 print("==========end-pod-logs==========")
 
-job_status = json.loads(
-    subprocess.check_output(
-        [
-            "kubectl",
-            f"--context={context}",
-            "get",
-            "job",
-            job_name,
-            "-o",
-            "jsonpath={.status}",
-        ],
-        encoding="UTF-8",
-    )
-)
+try:
+    job_status = json.loads(
+        subprocess.check_output(
+            [
+                "kubectl",
+                f"--context={context}",
+                "get",
+                "job",
+                job_name,
+                "-o",
+                "json",
+            ],
+            encoding="UTF-8",
+        )
+    )["status"]
+except Exception as e:
+    print(f"Failed to get job status for {job_name}, assuming failure: {e}")
+    job_status = {"failed": 1}
+
 end_ts_ms = int(time.time() * 1000)
 print("\n**********")
 print(

--- a/testsuite/forge/src/backend/k8s/node.rs
+++ b/testsuite/forge/src/backend/k8s/node.rs
@@ -60,7 +60,7 @@ impl Node for K8sNode {
     }
 
     fn json_rpc_endpoint(&self) -> Url {
-        Url::from_str(&format!("http://{}:{}/v1", self.dns(), self.port())).expect("Invalid URL.")
+        Url::from_str(&format!("http://{}:{}/v1", self.ip(), self.port())).expect("Invalid URL.")
     }
 
     fn debug_endpoint(&self) -> Url {

--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -464,6 +464,7 @@ pub fn clean_k8s_cluster(
     (0..MAX_NUM_VALIDATORS).into_par_iter().for_each(|i| {
         remove_validator(&format!("val{}", i)).unwrap();
     });
+    println!("All validators removed");
 
     let tmp_dir = TempDir::new().expect("Could not create temp dir");
 
@@ -510,6 +511,7 @@ pub fn clean_k8s_cluster(
             String::from_utf8(validator_helm_patch_output.stderr).unwrap()
         );
     });
+    println!("All validators prepped for upgrade");
 
     // upgrade validators in parallel
     (0..base_num_validators).into_par_iter().for_each(|i| {
@@ -531,6 +533,7 @@ pub fn clean_k8s_cluster(
         ];
         upgrade_validator(&format!("val{}", i), &helm_repo, &validator_upgrade_options).unwrap();
     });
+    println!("All validators upgraded");
 
     // upgrade testnet
     let testnet_upgrade_args = [
@@ -558,6 +561,7 @@ pub fn clean_k8s_cluster(
         "{}",
         String::from_utf8(testnet_upgrade_output.stderr).unwrap()
     );
+    println!("Testnet upgraded");
 
     let rt = Runtime::new().unwrap();
 

--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -415,8 +415,8 @@ fn get_helm_values(helm_release_name: &str) -> Result<Value> {
 
 pub fn set_validator_image_tag(
     validator_name: &str,
-    helm_repo: &str,
     image_tag: &str,
+    helm_repo: &str,
 ) -> Result<()> {
     let validator_upgrade_options = [
         "--reuse-values",

--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -23,7 +23,7 @@ use kube::{
 use rand::Rng;
 use rayon::prelude::*;
 use regex::Regex;
-use serde_json::{Value};
+use serde_json::Value;
 use std::{
     collections::HashMap,
     convert::TryFrom,
@@ -153,9 +153,15 @@ impl K8sSwarm {
 impl Drop for K8sSwarm {
     // When the K8sSwarm struct goes out of scope we need to wipe the chain state
     fn drop(&mut self) {
-        clean_k8s_cluster(self.helm_repo.clone(), self.validators.len(), DEFAULT_VALIDATOR_IMAGE_TAG.to_string(), DEFAULT_TESTNET_IMAGE_TAG.to_string(), true)
-            .map_err(|err| format_err!("Failed to clean k8s cluster with new genesis: {}", err))
-            .unwrap();
+        clean_k8s_cluster(
+            self.helm_repo.clone(),
+            self.validators.len(),
+            DEFAULT_VALIDATOR_IMAGE_TAG.to_string(),
+            DEFAULT_TESTNET_IMAGE_TAG.to_string(),
+            true,
+        )
+        .map_err(|err| format_err!("Failed to clean k8s cluster with new genesis: {}", err))
+        .unwrap();
     }
 }
 
@@ -407,8 +413,11 @@ fn get_helm_values(helm_release_name: &str) -> Result<Value> {
     Ok(v["config"].take())
 }
 
-
-pub fn set_validator_image_tag(validator_name: &str, helm_repo: &str, image_tag: &str) -> Result<()> {
+pub fn set_validator_image_tag(
+    validator_name: &str,
+    helm_repo: &str,
+    image_tag: &str,
+) -> Result<()> {
     let validator_upgrade_options = [
         "--reuse-values",
         "--history-max",
@@ -416,7 +425,7 @@ pub fn set_validator_image_tag(validator_name: &str, helm_repo: &str, image_tag:
         "--set",
         &format!("imageTag={}", image_tag),
     ];
-    upgrade_validator(validator_name, &helm_repo, &validator_upgrade_options)
+    upgrade_validator(validator_name, helm_repo, &validator_upgrade_options)
 }
 
 // sometimes helm will try to interpret era as a number in scientific notation
@@ -424,7 +433,7 @@ fn era_to_string(era_value: &Value) -> Result<String> {
     match era_value {
         Value::Number(num) => Ok(format!("{}", num)),
         Value::String(s) => Ok(s.to_string()),
-        _ => bail!("Era is not a number {}", era_value)
+        _ => bail!("Era is not a number {}", era_value),
     }
 }
 
@@ -465,7 +474,12 @@ pub fn clean_k8s_cluster(
         let config = &v["config"];
 
         let era: &str = &era_to_string(&v["config"]["chain"]["era"]).unwrap();
-        assert!(!new_era.eq(era), "New era {} is the same as past release era {}", new_era, era);
+        assert!(
+            !new_era.eq(era),
+            "New era {} is the same as past release era {}",
+            new_era,
+            era
+        );
 
         // store the helm values for later use
         let file_path = tmp_dir.path().join(format!("val{}_status.json", i));

--- a/testsuite/forge/src/main.rs
+++ b/testsuite/forge/src/main.rs
@@ -86,8 +86,8 @@ struct CleanUp {
 fn main() -> Result<()> {
     let args = Args::from_args();
 
-    match args.ops_cmd {
-        Some(ops_cmd) => match ops_cmd {
+    if let Some(ops_cmd) = args.ops_cmd {
+        match ops_cmd {
             OperatorCommand::SetValidator(set_validator) => {
                 return set_validator_image_tag(
                     &set_validator.validator_name,
@@ -104,8 +104,7 @@ fn main() -> Result<()> {
                     cleanup.require_validator_healthcheck,
                 )
             }
-        },
-        None => println!("Will run Forge tests..."),
+        }
     }
 
     if args.local_swarm {

--- a/testsuite/forge/src/main.rs
+++ b/testsuite/forge/src/main.rs
@@ -44,6 +44,11 @@ struct Args {
     helm_repo: String,
     #[structopt(long, default_value = "30")]
     num_validators: usize,
+    #[structopt(
+        long,
+        help = "If set, performs validator healthcheck and assumes k8s DNS access"
+    )]
+    require_validator_healthcheck: bool,
 
     #[structopt(flatten)]
     options: Options,
@@ -53,7 +58,11 @@ fn main() -> Result<()> {
     let args = Args::from_args();
 
     if args.clean_up {
-        return clean_k8s_cluster(args.helm_repo, args.num_validators);
+        return clean_k8s_cluster(
+            args.helm_repo,
+            args.num_validators,
+            args.require_validator_healthcheck,
+        );
     }
 
     if args.local_swarm {

--- a/testsuite/forge/src/main.rs
+++ b/testsuite/forge/src/main.rs
@@ -33,16 +33,35 @@ struct Args {
     )]
     duration: u64,
 
-    // operator "clean-up" options
-    // XXX: this should really be a subcommand if possible
-    #[structopt(long, help = "If set, wipes the state of the test backend and exits")]
-    clean_up: bool,
+    #[structopt(flatten)]
+    options: Options,
+
+    #[structopt(subcommand)]
+    ops_cmd: Option<OperatorCommand>,
+
     #[structopt(
         long,
         help = "Override the helm repo used for k8s tests",
         default_value = "testnet-internal"
     )]
     helm_repo: String,
+}
+
+#[derive(StructOpt, Debug)]
+enum OperatorCommand {
+    SetValidator(SetValidator),
+    CleanUp(CleanUp),
+}
+
+#[derive(StructOpt, Debug)]
+struct SetValidator {
+    validator_name: String,
+    #[structopt(long, help = "The image tag used for validators")]
+    image_tag: String,
+}
+
+#[derive(StructOpt, Debug)]
+struct CleanUp {
     #[structopt(long, default_value = "30")]
     num_validators: usize,
     #[structopt(
@@ -62,34 +81,31 @@ struct Args {
         help = "If set, performs validator healthcheck and assumes k8s DNS access"
     )]
     require_validator_healthcheck: bool,
-
-    // operator "upgrade-validator" options
-    #[structopt(long, help = "If set, upgrades a validator to validator_image_tag")]
-    upgrade_validator: bool,
-    #[structopt(long, help = "Validator to upgrade")]
-    validator: Option<String>,
-
-    #[structopt(flatten)]
-    options: Options,
 }
 
 fn main() -> Result<()> {
     let args = Args::from_args();
 
-    if args.clean_up {
-        return clean_k8s_cluster(
-            args.helm_repo,
-            args.num_validators,
-            args.validator_image_tag,
-            args.testnet_image_tag,
-            args.require_validator_healthcheck,
-        );
-    } else if args.upgrade_validator {
-        return set_validator_image_tag(
-            &args.validator.unwrap(),
-            &args.helm_repo,
-            &args.validator_image_tag,
-        );
+    match args.ops_cmd {
+        Some(ops_cmd) => match ops_cmd {
+            OperatorCommand::SetValidator(set_validator) => {
+                return set_validator_image_tag(
+                    &set_validator.validator_name,
+                    &set_validator.image_tag,
+                    &args.helm_repo,
+                )
+            }
+            OperatorCommand::CleanUp(cleanup) => {
+                return clean_k8s_cluster(
+                    args.helm_repo,
+                    cleanup.num_validators,
+                    cleanup.validator_image_tag,
+                    cleanup.testnet_image_tag,
+                    cleanup.require_validator_healthcheck,
+                )
+            }
+        },
+        None => println!("Will run Forge tests..."),
     }
 
     if args.local_swarm {

--- a/testsuite/forge/src/main.rs
+++ b/testsuite/forge/src/main.rs
@@ -89,7 +89,7 @@ fn main() -> Result<()> {
             &args.validator.unwrap(),
             &args.helm_repo,
             &args.validator_image_tag,
-        )
+        );
     }
 
     if args.local_swarm {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Includes a refactor of some helm operations into functions, so we can call them multiple times. Adds an option to the CLI tool that invokes one of such functions, `K8sSwarm::set_validator_image_tag`, which calls `K8sSwarm::upgrade_validator` with a new image tag.

## Bonus

* Flag `--require-validator-healthcheck` so we can toggle healthcheck as a requirement, allowing cluster wipe from a remote host.
* Make everything default to `devnet` for freshness
* Prefix all random chain eras with `fg`. This fixes a bug with helm wanting to convert era type to a number. Also makes it easy to identify whether the last chain was wiped manually via TF or programatically via Forge
* It's nice to wrap a bunch of these functions that would be useful to an operator into the CLI tool itself. To more clearly separate the args for running actual tests and operating the test backends, I've used structopt subcommands: https://docs.rs/structopt/0.3.22/structopt/#subcommands

```
$ cargo run -p forge -- clean-up -h
    Finished dev [unoptimized + debuginfo] target(s) in 0.53s
     Running `target/debug/forge clean-up -h`
forge-clean-up 0.0.0

USAGE:
    forge clean-up [FLAGS] [OPTIONS]

FLAGS:
    -h, --help                             Prints help information
        --require-validator-healthcheck    If set, performs validator healthcheck and assumes k8s DNS access
    -V, --version                          Prints version information

OPTIONS:
        --num-validators <num-validators>               [default: 30]
        --testnet-image-tag <testnet-image-tag>
            Override the image tag used for testnet-specific components [default: devnet]

        --validator-image-tag <validator-image-tag>    Override the image tag used for validators [default: devnet]
```

and validator upgrade

```
$ cargo run -p forge -- set-validator -h
    Finished dev [unoptimized + debuginfo] target(s) in 0.50s
     Running `target/debug/forge set-validator -h`
forge-set-validator 0.0.0

USAGE:
    forge set-validator <validator> --image-tag <image-tag>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
        --image-tag <image-tag>    The image tag used for validators

ARGS:
    <validator>
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Tested by running manually:

Resize: `cargo run -p forge -- --helm-repo testnet-rustietest clean-up`
Set validator image: 

```
$ cargo run -p forge -- --helm-repo testnet-rustietest set-validator val0 --image-tag main_bcb95ff8
["upgrade", "val0", "testnet-rustietest/diem-validator", "--reuse-values", "--history-max", "2", "--set", "imageTag=main_bcb95ff8"]
Release "val0" has been upgraded. Happy Helming!
NAME: val0
LAST DEPLOYED: Wed Aug  4 11:25:50 2021
NAMESPACE: default
STATUS: deployed
REVISION: 91
TEST SUITE: None
```