### PR TITLE
[move-prover] Fixes a bug in the `choose` operator.

### DIFF
--- a/language/move-model/src/builder/module_builder.rs
+++ b/language/move-model/src/builder/module_builder.rs
@@ -1344,8 +1344,8 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
             // Check whether the inclusion is correct regards usage of post state.
 
             // First check for lets.
-            for name in cond.exp.free_vars(self.parent.env).keys() {
-                if let Some((true, id)) = self.spec_block_lets.get(name) {
+            for (name, _) in cond.exp.free_vars(self.parent.env) {
+                if let Some((true, id)) = self.spec_block_lets.get(&name) {
                     let label_cond = (cond.loc.clone(), "not allowed to use post state".to_owned());
                     let label_let = (
                         self.parent.env.get_node_loc(*id),

--- a/language/move-prover/tests/sources/functional/choice.cvc4_exp
+++ b/language/move-prover/tests/sources/functional/choice.cvc4_exp
@@ -35,6 +35,21 @@ error: post-condition does not hold
    =         `TRACE(choose x: u64 where x >= 4 && x <= 5)` = <redacted>
 
 error: post-condition does not hold
+   ┌─ tests/sources/functional/choice.move:98:9
+   │
+98 │         ensures result == TRACE(choose y: u64 where y > x);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/choice.move:98
+   =     at tests/sources/functional/choice.move:93: test_choice_dup_expected_fail
+   =         x = <redacted>
+   =     at tests/sources/functional/choice.move:94: test_choice_dup_expected_fail
+   =         result = <redacted>
+   =     at tests/sources/functional/choice.move:95: test_choice_dup_expected_fail
+   =     at tests/sources/functional/choice.move:98
+   =         `TRACE(choose y: u64 where y > x)` = <redacted>
+
+error: post-condition does not hold
    ┌─ tests/sources/functional/choice.move:70:9
    │
 70 │         ensures (choose min i in 0..len(result) where result[i] == 2) == 1;

--- a/language/move-prover/tests/sources/functional/choice.exp
+++ b/language/move-prover/tests/sources/functional/choice.exp
@@ -35,6 +35,21 @@ error: post-condition does not hold
    =         `TRACE(choose x: u64 where x >= 4 && x <= 5)` = <redacted>
 
 error: post-condition does not hold
+   ┌─ tests/sources/functional/choice.move:98:9
+   │
+98 │         ensures result == TRACE(choose y: u64 where y > x);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/choice.move:98
+   =     at tests/sources/functional/choice.move:93: test_choice_dup_expected_fail
+   =         x = <redacted>
+   =     at tests/sources/functional/choice.move:94: test_choice_dup_expected_fail
+   =         result = <redacted>
+   =     at tests/sources/functional/choice.move:95: test_choice_dup_expected_fail
+   =     at tests/sources/functional/choice.move:98
+   =         `TRACE(choose y: u64 where y > x)` = <redacted>
+
+error: post-condition does not hold
    ┌─ tests/sources/functional/choice.move:85:9
    │
 85 │         ensures TRACE(choose i in 0..len(result) where result[i] == 2) == 1;

--- a/language/move-prover/tests/sources/functional/choice.move
+++ b/language/move-prover/tests/sources/functional/choice.move
@@ -85,4 +85,26 @@ module 0x42::TestSome {
         ensures TRACE(choose i in 0..len(result) where result[i] == 2) == 1;
     }
 
+    // Testing choice duplication
+    // ==========================
+
+    // This is only a compilation test. It fails verification.
+
+    fun test_choice_dup_expected_fail(x: u64): u64 {
+        x + 1
+    }
+    spec test_choice_dup_expected_fail {
+        pragma opaque; // making this opaque lets the choice be injected at each call
+        ensures result == TRACE(choose y: u64 where y > x);
+    }
+
+    fun test_choice_use1(a: u64): u64 {
+        test_choice_dup_expected_fail(a)
+    }
+
+    fun test_choice_use2(_a: vector<u64>, b: u64): u64 {
+        // with incorrect use of parameters, this would use $t0 as a parameter to the choice
+        // function, which leads to a type error in boogie.
+        test_choice_dup_expected_fail(b)
+    }
 }


### PR DESCRIPTION
The implementation of the choose operator attempts to reuse the generated uninterpreted function for the choice if the same source level choice is duplicated. This is needed to ensure that the choice result is the same if the expression is cloned, which happens e.g. if conditions of opaque functions are inserted at caller side, or if choices appear in schemas.

Consider

```
schema S { ensures result == choose i: int: i > 0; }
spec f { include S; include S; }
```

We require that the choice delivers the same value in both inclusions of `S` (otherwise we would create an inconsistency). While the logic for this was there, it was buggy before this PR.

The bug was that temporaries or variables used in the choice may substitute to different values in the insertion context. This PR fixes this bug by computing temporaries and vars again for each application point of the choice.

## Motivation

Bug fix

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests

## Related PRs

NA
