### PR TITLE
[move-prover] Implemented is_signer in Prover

### DIFF
--- a/language/diem-framework/modules/PaymentScripts.move
+++ b/language/diem-framework/modules/PaymentScripts.move
@@ -133,7 +133,7 @@ module DiemFramework::PaymentScripts {
     }
 
     spec peer_to_peer_with_metadata {
-        include PeerToPeer<Currency>;
+        include PeerToPeer<Currency>{payer_signer: payer};
         include DualAttestation::AssertPaymentOkAbortsIf<Currency>{
             payer: Signer::spec_address_of(payer),
             value: amount
@@ -141,19 +141,19 @@ module DiemFramework::PaymentScripts {
     }
 
     spec peer_to_peer_by_signers {
-        include PeerToPeer<Currency>{payee: Signer::spec_address_of(payee)};
+        include PeerToPeer<Currency>{payer_signer: payer, payee: Signer::spec_address_of(payee)};
     }
 
     spec schema PeerToPeer<Currency> {
         use Std::Errors;
 
-        payer: signer;
+        payer_signer: signer;
         payee: address;
         amount: u64;
         metadata: vector<u8>;
 
-        include DiemAccount::TransactionChecks{sender: payer}; // properties checked by the prologue.
-        let payer_addr = Signer::spec_address_of(payer);
+        include DiemAccount::TransactionChecks{sender: payer_signer}; // properties checked by the prologue.
+        let payer_addr = Signer::spec_address_of(payer_signer);
         let cap = DiemAccount::spec_get_withdraw_cap(payer_addr);
         include DiemAccount::ExtractWithdrawCapAbortsIf{sender_addr: payer_addr};
         include DiemAccount::PayFromAbortsIf<Currency>{cap: cap};

--- a/language/diem-framework/modules/doc/PaymentScripts.md
+++ b/language/diem-framework/modules/doc/PaymentScripts.md
@@ -146,7 +146,7 @@ Successful execution of this script emits two events:
 
 
 
-<pre><code><b>include</b> <a href="PaymentScripts.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;;
+<pre><code><b>include</b> <a href="PaymentScripts.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;{payer_signer: payer};
 <b>include</b> <a href="DualAttestation.md#0x1_DualAttestation_AssertPaymentOkAbortsIf">DualAttestation::AssertPaymentOkAbortsIf</a>&lt;Currency&gt;{
     payer: <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer),
     value: amount
@@ -264,7 +264,7 @@ Successful execution of this script emits two events:
 
 
 
-<pre><code><b>include</b> <a href="PaymentScripts.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;{payee: <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payee)};
+<pre><code><b>include</b> <a href="PaymentScripts.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;{payer_signer: payer, payee: <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payee)};
 </code></pre>
 
 
@@ -274,12 +274,12 @@ Successful execution of this script emits two events:
 
 
 <pre><code><b>schema</b> <a href="PaymentScripts.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt; {
-    payer: signer;
+    payer_signer: signer;
     payee: address;
     amount: u64;
     metadata: vector&lt;u8&gt;;
-    <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: payer};
-    <b>let</b> payer_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer);
+    <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: payer_signer};
+    <b>let</b> payer_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer_signer);
     <b>let</b> cap = <a href="DiemAccount.md#0x1_DiemAccount_spec_get_withdraw_cap">DiemAccount::spec_get_withdraw_cap</a>(payer_addr);
     <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ExtractWithdrawCapAbortsIf">DiemAccount::ExtractWithdrawCapAbortsIf</a>{sender_addr: payer_addr};
     <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_PayFromAbortsIf">DiemAccount::PayFromAbortsIf</a>&lt;Currency&gt;{cap: cap};

--- a/language/diem-framework/releases/artifacts/current/docs/modules/PaymentScripts.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/PaymentScripts.md
@@ -146,7 +146,7 @@ Successful execution of this script emits two events:
 
 
 
-<pre><code><b>include</b> <a href="PaymentScripts.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;;
+<pre><code><b>include</b> <a href="PaymentScripts.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;{payer_signer: payer};
 <b>include</b> <a href="DualAttestation.md#0x1_DualAttestation_AssertPaymentOkAbortsIf">DualAttestation::AssertPaymentOkAbortsIf</a>&lt;Currency&gt;{
     payer: <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer),
     value: amount
@@ -264,7 +264,7 @@ Successful execution of this script emits two events:
 
 
 
-<pre><code><b>include</b> <a href="PaymentScripts.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;{payee: <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payee)};
+<pre><code><b>include</b> <a href="PaymentScripts.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;{payer_signer: payer, payee: <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payee)};
 </code></pre>
 
 
@@ -274,12 +274,12 @@ Successful execution of this script emits two events:
 
 
 <pre><code><b>schema</b> <a href="PaymentScripts.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt; {
-    payer: signer;
+    payer_signer: signer;
     payee: address;
     amount: u64;
     metadata: vector&lt;u8&gt;;
-    <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: payer};
-    <b>let</b> payer_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer);
+    <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: payer_signer};
+    <b>let</b> payer_addr = <a href="../../../../../../move-stdlib/docs/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer_signer);
     <b>let</b> cap = <a href="DiemAccount.md#0x1_DiemAccount_spec_get_withdraw_cap">DiemAccount::spec_get_withdraw_cap</a>(payer_addr);
     <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_ExtractWithdrawCapAbortsIf">DiemAccount::ExtractWithdrawCapAbortsIf</a>{sender_addr: payer_addr};
     <b>include</b> <a href="DiemAccount.md#0x1_DiemAccount_PayFromAbortsIf">DiemAccount::PayFromAbortsIf</a>&lt;Currency&gt;{cap: cap};

--- a/language/diem-framework/releases/artifacts/current/docs/scripts/script_documentation.md
+++ b/language/diem-framework/releases/artifacts/current/docs/scripts/script_documentation.md
@@ -2763,7 +2763,7 @@ Successful execution of this script emits two events:
 
 
 
-<pre><code><b>include</b> <a href="script_documentation.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;;
+<pre><code><b>include</b> <a href="script_documentation.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;{payer_signer: payer};
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DualAttestation.md#0x1_DualAttestation_AssertPaymentOkAbortsIf">DualAttestation::AssertPaymentOkAbortsIf</a>&lt;Currency&gt;{
     payer: <a href="_spec_address_of">Signer::spec_address_of</a>(payer),
     value: amount
@@ -2881,7 +2881,7 @@ Successful execution of this script emits two events:
 
 
 
-<pre><code><b>include</b> <a href="script_documentation.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;{payee: <a href="_spec_address_of">Signer::spec_address_of</a>(payee)};
+<pre><code><b>include</b> <a href="script_documentation.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;{payer_signer: payer, payee: <a href="_spec_address_of">Signer::spec_address_of</a>(payee)};
 </code></pre>
 
 
@@ -2891,12 +2891,12 @@ Successful execution of this script emits two events:
 
 
 <pre><code><b>schema</b> <a href="script_documentation.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt; {
-    payer: signer;
+    payer_signer: signer;
     payee: address;
     amount: u64;
     metadata: vector&lt;u8&gt;;
-    <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: payer};
-    <b>let</b> payer_addr = <a href="_spec_address_of">Signer::spec_address_of</a>(payer);
+    <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: payer_signer};
+    <b>let</b> payer_addr = <a href="_spec_address_of">Signer::spec_address_of</a>(payer_signer);
     <b>let</b> cap = <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_spec_get_withdraw_cap">DiemAccount::spec_get_withdraw_cap</a>(payer_addr);
     <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_ExtractWithdrawCapAbortsIf">DiemAccount::ExtractWithdrawCapAbortsIf</a>{sender_addr: payer_addr};
     <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_PayFromAbortsIf">DiemAccount::PayFromAbortsIf</a>&lt;Currency&gt;{cap: cap};

--- a/language/diem-framework/script_documentation/script_documentation.md
+++ b/language/diem-framework/script_documentation/script_documentation.md
@@ -2763,7 +2763,7 @@ Successful execution of this script emits two events:
 
 
 
-<pre><code><b>include</b> <a href="script_documentation.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;;
+<pre><code><b>include</b> <a href="script_documentation.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;{payer_signer: payer};
 <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DualAttestation.md#0x1_DualAttestation_AssertPaymentOkAbortsIf">DualAttestation::AssertPaymentOkAbortsIf</a>&lt;Currency&gt;{
     payer: <a href="_spec_address_of">Signer::spec_address_of</a>(payer),
     value: amount
@@ -2881,7 +2881,7 @@ Successful execution of this script emits two events:
 
 
 
-<pre><code><b>include</b> <a href="script_documentation.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;{payee: <a href="_spec_address_of">Signer::spec_address_of</a>(payee)};
+<pre><code><b>include</b> <a href="script_documentation.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt;{payer_signer: payer, payee: <a href="_spec_address_of">Signer::spec_address_of</a>(payee)};
 </code></pre>
 
 
@@ -2891,12 +2891,12 @@ Successful execution of this script emits two events:
 
 
 <pre><code><b>schema</b> <a href="script_documentation.md#0x1_PaymentScripts_PeerToPeer">PeerToPeer</a>&lt;Currency&gt; {
-    payer: signer;
+    payer_signer: signer;
     payee: address;
     amount: u64;
     metadata: vector&lt;u8&gt;;
-    <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: payer};
-    <b>let</b> payer_addr = <a href="_spec_address_of">Signer::spec_address_of</a>(payer);
+    <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_TransactionChecks">DiemAccount::TransactionChecks</a>{sender: payer_signer};
+    <b>let</b> payer_addr = <a href="_spec_address_of">Signer::spec_address_of</a>(payer_signer);
     <b>let</b> cap = <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_spec_get_withdraw_cap">DiemAccount::spec_get_withdraw_cap</a>(payer_addr);
     <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_ExtractWithdrawCapAbortsIf">DiemAccount::ExtractWithdrawCapAbortsIf</a>{sender_addr: payer_addr};
     <b>include</b> <a href="../../../../../releases/artifacts/current/docs/modules/DiemAccount.md#0x1_DiemAccount_PayFromAbortsIf">DiemAccount::PayFromAbortsIf</a>&lt;Currency&gt;{cap: cap};

--- a/language/move-model/src/ty.rs
+++ b/language/move-model/src/ty.rs
@@ -182,6 +182,11 @@ impl Type {
         matches!(self, Type::Primitive(PrimitiveType::Address))
     }
 
+    /// Return true if this is an account address
+    pub fn is_signer(&self) -> bool {
+        matches!(self, Type::Primitive(PrimitiveType::Signer))
+    }
+
     /// Skip reference type.
     pub fn skip_reference(&self) -> &Type {
         if let Type::Reference(_, bt) = self {

--- a/language/move-prover/boogie-backend/src/boogie_helpers.rs
+++ b/language/move-prover/boogie-backend/src/boogie_helpers.rs
@@ -174,7 +174,8 @@ pub fn boogie_type(env: &GlobalEnv, ty: &Type) -> String {
     use Type::*;
     match ty {
         Primitive(p) => match p {
-            U8 | U64 | U128 | Num | Address | Signer => "int".to_string(),
+            U8 | U64 | U128 | Num | Address => "int".to_string(),
+            Signer => "$signer".to_string(),
             Bool => "bool".to_string(),
             TypeValue => "$TypeValue".to_string(),
             _ => panic!("unexpected type"),
@@ -210,7 +211,8 @@ pub fn boogie_type_suffix(env: &GlobalEnv, ty: &Type) -> String {
             U64 => "u64".to_string(),
             U128 => "u128".to_string(),
             Num => "num".to_string(),
-            Address | Signer => "address".to_string(),
+            Address => "address".to_string(),
+            Signer => "signer".to_string(),
             Bool => "bool".to_string(),
             Range => "range".to_string(),
             _ => format!("<<unsupported {:?}>>", ty),

--- a/language/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/language/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -1080,7 +1080,7 @@ impl<'env> FunctionTranslator<'env> {
                         let signer_str = str_local(srcs[1]);
                         emitln!(
                             writer,
-                            "if ($ResourceExists({}, {})) {{",
+                            "if ($ResourceExists({}, $1_Signer_spec_address_of({}))) {{",
                             memory,
                             signer_str
                         );
@@ -1089,7 +1089,7 @@ impl<'env> FunctionTranslator<'env> {
                         writer.with_indent(|| {
                             emitln!(
                                 writer,
-                                "{} := $ResourceUpdate({}, {}, {});",
+                                "{} := $ResourceUpdate({}, $1_Signer_spec_address_of({}), {});",
                                 memory,
                                 memory,
                                 signer_str,

--- a/language/move-prover/boogie-backend/src/prelude/native.bpl
+++ b/language/move-prover/boogie-backend/src/prelude/native.bpl
@@ -276,7 +276,7 @@ axiom (forall v1, v2: {{T}} :: {$ToEventRep{{S}}(v1), $ToEventRep{{S}}(v2)}
 // Creates a new event handle. This ensures each time it is called that a unique new abstract event handler is
 // returned.
 // TODO: we should check (and abort with the right code) if no generator exists for the signer.
-procedure {:inline 1} $1_Event_new_event_handle{{S}}(signer: int) returns (res: $1_Event_EventHandle{{S}}) {
+procedure {:inline 1} $1_Event_new_event_handle{{S}}(signer: $signer) returns (res: $1_Event_EventHandle{{S}}) {
     assume $1_Event_EventHandles[res] == false;
     $1_Event_EventHandles := $1_Event_EventHandles[res := true];
 }

--- a/language/move-prover/boogie-backend/src/prelude/prelude.bpl
+++ b/language/move-prover/boogie-backend/src/prelude/prelude.bpl
@@ -516,13 +516,13 @@ function {:inline} $1_Hash_$sha3_256(val: Vec int): Vec int {
 
 procedure {:inline 1} $1_DiemAccount_create_signer(
   addr: int
-) returns (signer: int) {
+) returns (signer: $signer) {
     // A signer is currently identical to an address.
-    signer := addr;
+    signer := $signer(addr);
 }
 
 procedure {:inline 1} $1_DiemAccount_destroy_signer(
-  signer: int
+  signer: $signer
 ) {
   return;
 }
@@ -530,9 +530,29 @@ procedure {:inline 1} $1_DiemAccount_destroy_signer(
 // ==================================================================================
 // Native Signer
 
-procedure {:inline 1} $1_Signer_borrow_address(signer: int) returns (res: int) {
-    res := signer;
+type {:datatype} $signer;
+function {:constructor} $signer($addr: int): $signer;
+function {:inline} $IsValid'signer'(s: $signer): bool {
+    $IsValid'address'($addr#$signer(s))
 }
+function {:inline} $IsEqual'signer'(s1: $signer, s2: $signer): bool {
+    s1 == s2
+}
+
+procedure {:inline 1} $1_Signer_borrow_address(signer: $signer) returns (res: int) {
+    res := $addr#$signer(signer);
+}
+
+function {:inline} $1_Signer_$borrow_address(signer: $signer): int
+{
+    $addr#$signer(signer)
+}
+
+function {:inline} $1_Signer_spec_address_of(signer: $signer): int
+{
+    $addr#$signer(signer)
+}
+
 
 // ==================================================================================
 // Native signature
@@ -577,21 +597,6 @@ procedure {:inline 1} $1_Signature_ed25519_verify(
 
 
 // ==================================================================================
-// Native Signer::spec_address_of
-
-function {:inline} $1_Signer_spec_address_of(signer: int): int
-{
-    // A signer is currently identical to an address.
-    signer
-}
-
-function {:inline} $1_Signer_$borrow_address(signer: int): int
-{
-    // A signer is currently identical to an address.
-    signer
-}
-
-// ==================================================================================
 // Native Event module
 
 {% set emit_generic_event = true %}
@@ -604,7 +609,7 @@ function {:inline} $1_Signer_$borrow_address(signer: int): int
 // TODO: we should check (and abort with the right code) if a generator already exists for
 // the signer.
 
-procedure {:inline 1} $1_Event_publish_generator(signer: int) {
+procedure {:inline 1} $1_Event_publish_generator(signer: $signer) {
 }
 
 // Generic code for dealing with mutations (havoc) still requires type and memory declarations.

--- a/language/move-prover/boogie-backend/src/spec_translator.rs
+++ b/language/move-prover/boogie-backend/src/spec_translator.rs
@@ -968,7 +968,15 @@ impl<'env> SpecTranslator<'env> {
         let memory = &self.get_memory_inst_from_node(node_id);
         let resource_name = boogie_modifies_memory_name(self.env, memory);
         emit!(self.writer, "{}[", resource_name);
+
+        let is_signer = self.env.get_node_type(args[0].node_id()).is_signer();
+        if is_signer {
+            emit!(self.writer, "$1_Signer_spec_address_of(");
+        }
         self.translate_exp(&args[0]);
+        if is_signer {
+            emit!(self.writer, ")");
+        }
         emit!(self.writer, "]");
     }
 

--- a/language/move-prover/tests/sources/functional/is_signer.cvc4_exp
+++ b/language/move-prover/tests/sources/functional/is_signer.cvc4_exp
@@ -1,0 +1,67 @@
+Move prover returns: exiting with boogie verification errors
+error: unknown assertion failed
+   ┌─ tests/sources/functional/is_signer.move:13:16
+   │
+13 │         spec { assert Signer::is_signer(@0x7); } // This is unprovable because it is not true in general.
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/is_signer.move:13: f1_incorrect
+
+error: unknown assertion failed
+   ┌─ tests/sources/functional/is_signer.move:17:16
+   │
+17 │         spec { assert Signer::is_signer(@0x7); } // This is unprovable because it is not true in general.
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/is_signer.move:16: f2_incorrect
+   =         _account = <redacted>
+   =     at tests/sources/functional/is_signer.move:17: f2_incorrect
+
+error: unknown assertion failed
+   ┌─ tests/sources/functional/is_signer.move:27:16
+   │
+27 │         spec { assert Signer::is_signer(@0x7); } // This is unprovable because it is not true in general.
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/is_signer.move:25: f4_incorrect
+   =         account = <redacted>
+   =     at tests/sources/functional/is_signer.move:26: f4_incorrect
+   =         <redacted> = <redacted>
+
+error: precondition does not hold at this call
+   ┌─ tests/sources/functional/is_signer.move:34:9
+   │
+34 │         requires Signer::is_signer(@0x7); // f5 requires this to be true at its callers' sites
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/is_signer.move:34
+
+error: unknown assertion failed
+   ┌─ tests/sources/functional/is_signer.move:61:13
+   │
+61 │             assert exists addr:address: hasPermissionAddr(addr);
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/is_signer.move:59: g_incorrect
+   =         _a = <redacted>
+   =         _b = <redacted>
+   =     at tests/sources/functional/is_signer.move:61: g_incorrect
+
+error: global memory invariant does not hold
+    ┌─ tests/sources/functional/is_signer.move:137:9
+    │
+137 │ ╭         invariant update (old(exists<Counter>(ADMIN_ADDRESS())) && global<Counter>(ADMIN_ADDRESS()).i != old(global<Counter>(ADMIN_ADDRESS()).i))
+138 │ │             ==> Signer::is_signer(ADMIN_ADDRESS());
+    │ ╰───────────────────────────────────────────────────^
+    │
+    =     at tests/sources/functional/is_signer.move:130: increment_incorrect
+    =         _account = <redacted>
+    =     at tests/sources/functional/is_signer.move:131: increment_incorrect
+    =     at tests/sources/functional/is_signer.move:107: ADMIN_ADDRESS
+    =         result = <redacted>
+    =     at tests/sources/functional/is_signer.move:108: ADMIN_ADDRESS
+    =         c_ref = <redacted>
+    =     at tests/sources/functional/is_signer.move:132: increment_incorrect
+    =     at tests/sources/functional/is_signer.move:130: increment_incorrect
+    =     at tests/sources/functional/is_signer.move:132: increment_incorrect
+    =     at tests/sources/functional/is_signer.move:137

--- a/language/move-prover/tests/sources/functional/is_signer.exp
+++ b/language/move-prover/tests/sources/functional/is_signer.exp
@@ -1,0 +1,67 @@
+Move prover returns: exiting with boogie verification errors
+error: unknown assertion failed
+   ┌─ tests/sources/functional/is_signer.move:13:16
+   │
+13 │         spec { assert Signer::is_signer(@0x7); } // This is unprovable because it is not true in general.
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/is_signer.move:13: f1_incorrect
+
+error: unknown assertion failed
+   ┌─ tests/sources/functional/is_signer.move:17:16
+   │
+17 │         spec { assert Signer::is_signer(@0x7); } // This is unprovable because it is not true in general.
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/is_signer.move:16: f2_incorrect
+   =         _account = <redacted>
+   =     at tests/sources/functional/is_signer.move:17: f2_incorrect
+
+error: unknown assertion failed
+   ┌─ tests/sources/functional/is_signer.move:27:16
+   │
+27 │         spec { assert Signer::is_signer(@0x7); } // This is unprovable because it is not true in general.
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/is_signer.move:25: f4_incorrect
+   =         account = <redacted>
+   =     at tests/sources/functional/is_signer.move:26: f4_incorrect
+   =         <redacted> = <redacted>
+
+error: precondition does not hold at this call
+   ┌─ tests/sources/functional/is_signer.move:34:9
+   │
+34 │         requires Signer::is_signer(@0x7); // f5 requires this to be true at its callers' sites
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/is_signer.move:34
+
+error: unknown assertion failed
+   ┌─ tests/sources/functional/is_signer.move:61:13
+   │
+61 │             assert exists addr:address: hasPermissionAddr(addr);
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/is_signer.move:59: g_incorrect
+   =         _a = <redacted>
+   =         _b = <redacted>
+   =     at tests/sources/functional/is_signer.move:61: g_incorrect
+
+error: global memory invariant does not hold
+    ┌─ tests/sources/functional/is_signer.move:137:9
+    │
+137 │ ╭         invariant update (old(exists<Counter>(ADMIN_ADDRESS())) && global<Counter>(ADMIN_ADDRESS()).i != old(global<Counter>(ADMIN_ADDRESS()).i))
+138 │ │             ==> Signer::is_signer(ADMIN_ADDRESS());
+    │ ╰───────────────────────────────────────────────────^
+    │
+    =     at tests/sources/functional/is_signer.move:130: increment_incorrect
+    =         _account = <redacted>
+    =     at tests/sources/functional/is_signer.move:131: increment_incorrect
+    =     at tests/sources/functional/is_signer.move:107: ADMIN_ADDRESS
+    =         result = <redacted>
+    =     at tests/sources/functional/is_signer.move:108: ADMIN_ADDRESS
+    =         c_ref = <redacted>
+    =     at tests/sources/functional/is_signer.move:132: increment_incorrect
+    =     at tests/sources/functional/is_signer.move:130: increment_incorrect
+    =     at tests/sources/functional/is_signer.move:132: increment_incorrect
+    =     at tests/sources/functional/is_signer.move:137

--- a/language/move-prover/tests/sources/functional/is_signer.move
+++ b/language/move-prover/tests/sources/functional/is_signer.move
@@ -1,0 +1,140 @@
+// separate_baseline: cvc4
+// separate_baseline: no_opaque
+// The separate baseline is legit and caused by a different choice in the generated model.
+module 0x42::SimpleIsSigner {
+    use Std::Signer;
+    use DiemFramework::Roles;
+
+    // ---------------
+    // Simple examples
+    // ---------------
+
+    public fun f1_incorrect() {
+        spec { assert Signer::is_signer(@0x7); } // This is unprovable because it is not true in general.
+    }
+
+    public fun f2_incorrect(_account: &signer) {
+        spec { assert Signer::is_signer(@0x7); } // This is unprovable because it is not true in general.
+    }
+
+    public fun f3(account: &signer) {
+        assert(Signer::address_of(account) == @0x7, 1);
+        spec { assert Signer::is_signer(@0x7); } // It's true in general.
+    }
+
+    public fun f4_incorrect(account: &signer) {
+        assert(Signer::address_of(account) == @0x3, 1);
+        spec { assert Signer::is_signer(@0x7); } // This is unprovable because it is not true in general.
+    }
+
+    fun f5() {
+        spec { assert Signer::is_signer(@0x7); } // This is provable because of the "requires" condition.
+    }
+    spec f5 {
+        requires Signer::is_signer(@0x7); // f5 requires this to be true at its callers' sites
+    }
+
+    public fun f6(account: &signer) { // This function produces no error because it satisfies f5's requires condition.
+        assert(Signer::address_of(account) == @0x7, 1);
+        f5();
+    }
+
+    public fun f7_incorrect() {
+        // This function does not satisfy f5's requires condition.
+        f5();
+    }
+
+
+    // ------------------------------
+    // Simple access control examples
+    // ------------------------------
+
+    spec fun hasPermissionAddr(addr: address): bool {
+        Roles::spec_has_diem_root_role_addr(addr)
+    }
+    fun hasPermission(account: &signer): bool {
+        Roles::has_diem_root_role(account)
+    }
+
+    public fun g_incorrect(_a: &signer, _b: &signer) {
+        spec {
+            assert exists addr:address: hasPermissionAddr(addr);
+        };
+        // privileged operation
+    }
+
+    public fun g1(a: &signer, _b: &signer) {
+        if(hasPermission(a))
+        {
+            spec {
+                assert exists addr:address: (Signer::is_signer(addr) && hasPermissionAddr(addr));
+            };
+            // privileged operation
+        }
+    }
+
+    public fun g2(a: &signer, _b: &signer) {
+        assert (hasPermission(a), 1);
+        spec {
+            assert exists addr:address: (Signer::is_signer(addr) && hasPermissionAddr(addr));
+        };
+        // privileged operation
+    }
+
+    public fun g3(a: &signer, _b: &signer) {
+        assert (hasPermission(a), 1);
+        helper()
+    }
+
+    public fun helper() {
+        spec {
+            assert exists addr:address: (Signer::is_signer(addr) && hasPermissionAddr(addr));
+        };
+        // privileged operation
+    }
+    spec helper {
+        requires exists addr:address: (Signer::is_signer(addr) && hasPermissionAddr(addr));
+    }
+
+
+    // -----------------------------------
+    // Access control for Counter resource
+    // -----------------------------------
+
+    struct Counter has key { i: u64 }
+
+    public fun ADMIN_ADDRESS(): address {
+        @0x7
+    }
+
+    const AUTH_FAILED: u64 = 1;
+
+    public fun publish(account: &signer) {
+        spec { assume Signer::is_signer(Signer::spec_address_of(account)); };
+
+        assert(Signer::address_of(account) == ADMIN_ADDRESS(), AUTH_FAILED);
+        move_to(account, Counter { i: 0 });
+    }
+
+    public fun get_counter(): u64 acquires Counter {
+        borrow_global<Counter>(ADMIN_ADDRESS()).i
+    }
+
+    public fun increment(account: &signer) acquires Counter {
+        assert(Signer::address_of(account) == ADMIN_ADDRESS(), AUTH_FAILED); // permission check
+        let c_ref = &mut borrow_global_mut<Counter>(ADMIN_ADDRESS()).i;
+        *c_ref = *c_ref + 1;
+    }
+
+    // This function is incorrect because it omits the permission check.
+    public fun increment_incorrect(_account: &signer) acquires Counter {
+        let c_ref = &mut borrow_global_mut<Counter>(ADMIN_ADDRESS()).i;
+        *c_ref = *c_ref + 1;
+    }
+
+    spec module {
+        // Access control spec: Only the admin is allowed to increment the counter value.
+        invariant update (old(exists<Counter>(ADMIN_ADDRESS())) && global<Counter>(ADMIN_ADDRESS()).i != old(global<Counter>(ADMIN_ADDRESS()).i))
+            ==> Signer::is_signer(ADMIN_ADDRESS());
+    }
+}

--- a/language/move-prover/tests/sources/functional/is_signer.no_opaque_exp
+++ b/language/move-prover/tests/sources/functional/is_signer.no_opaque_exp
@@ -1,0 +1,72 @@
+Move prover returns: exiting with boogie verification errors
+error: unknown assertion failed
+   ┌─ tests/sources/functional/is_signer.move:13:16
+   │
+13 │         spec { assert Signer::is_signer(@0x7); } // This is unprovable because it is not true in general.
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/is_signer.move:13: f1_incorrect
+
+error: unknown assertion failed
+   ┌─ tests/sources/functional/is_signer.move:17:16
+   │
+17 │         spec { assert Signer::is_signer(@0x7); } // This is unprovable because it is not true in general.
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/is_signer.move:16: f2_incorrect
+   =         _account = <redacted>
+   =     at tests/sources/functional/is_signer.move:17: f2_incorrect
+
+error: unknown assertion failed
+   ┌─ tests/sources/functional/is_signer.move:27:16
+   │
+27 │         spec { assert Signer::is_signer(@0x7); } // This is unprovable because it is not true in general.
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/is_signer.move:25: f4_incorrect
+   =         account = <redacted>
+   =     at tests/sources/functional/is_signer.move:26: f4_incorrect
+   =     at ../move-stdlib/modules/Signer.move:12: address_of
+   =         s = <redacted>
+   =     at ../move-stdlib/modules/Signer.move:13: address_of
+   =         result = <redacted>
+   =     at ../move-stdlib/modules/Signer.move:14: address_of
+   =         <redacted> = <redacted>
+
+error: precondition does not hold at this call
+   ┌─ tests/sources/functional/is_signer.move:34:9
+   │
+34 │         requires Signer::is_signer(@0x7); // f5 requires this to be true at its callers' sites
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/is_signer.move:34
+
+error: unknown assertion failed
+   ┌─ tests/sources/functional/is_signer.move:61:13
+   │
+61 │             assert exists addr:address: hasPermissionAddr(addr);
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/is_signer.move:59: g_incorrect
+   =         _a = <redacted>
+   =         _b = <redacted>
+   =     at tests/sources/functional/is_signer.move:61: g_incorrect
+
+error: global memory invariant does not hold
+    ┌─ tests/sources/functional/is_signer.move:137:9
+    │
+137 │ ╭         invariant update (old(exists<Counter>(ADMIN_ADDRESS())) && global<Counter>(ADMIN_ADDRESS()).i != old(global<Counter>(ADMIN_ADDRESS()).i))
+138 │ │             ==> Signer::is_signer(ADMIN_ADDRESS());
+    │ ╰───────────────────────────────────────────────────^
+    │
+    =     at tests/sources/functional/is_signer.move:130: increment_incorrect
+    =         _account = <redacted>
+    =     at tests/sources/functional/is_signer.move:131: increment_incorrect
+    =     at tests/sources/functional/is_signer.move:107: ADMIN_ADDRESS
+    =         result = <redacted>
+    =     at tests/sources/functional/is_signer.move:108: ADMIN_ADDRESS
+    =         c_ref = <redacted>
+    =     at tests/sources/functional/is_signer.move:132: increment_incorrect
+    =     at tests/sources/functional/is_signer.move:130: increment_incorrect
+    =     at tests/sources/functional/is_signer.move:132: increment_incorrect
+    =     at tests/sources/functional/is_signer.move:137

--- a/language/move-prover/tests/sources/functional/script_incorrect.no_opaque_exp
+++ b/language/move-prover/tests/sources/functional/script_incorrect.no_opaque_exp
@@ -8,10 +8,10 @@ error: abort not covered by any of the `aborts_if` clauses
 14 │ │ }
    │ ╰─^
    │
-   ┌─ tests/sources/functional/script_provider.move:19:9
+   ┌─ tests/sources/functional/script_provider.move:18:9
    │
-19 │         move_to(account, Info<T>{})
-   │         ------- abort happened here with execution failure
+18 │         assert(Signer::address_of(account) == @0x1, 1);
+   │         ---------------------------------------------- abort happened here with code 0x1
    │
    =     at tests/sources/functional/script_incorrect.move:7: main
    =         account = <redacted>
@@ -25,5 +25,5 @@ error: abort not covered by any of the `aborts_if` clauses
    =         result = <redacted>
    =     at ../move-stdlib/modules/Signer.move:14: address_of
    =         <redacted> = <redacted>
-   =     at tests/sources/functional/script_provider.move:19: register
+   =     at tests/sources/functional/script_provider.move:18: register
    =         ABORTED

--- a/language/move-stdlib/docs/Signer.md
+++ b/language/move-stdlib/docs/Signer.md
@@ -80,6 +80,22 @@ Specification version of <code><a href="Signer.md#0x1_Signer_address_of">Self::a
 </code></pre>
 
 
+Return true only if <code>a</code> is a transaction signer. This is a spec function only available in spec.
+
+
+<a name="0x1_Signer_is_signer"></a>
+
+
+<pre><code><b>fun</b> <a href="Signer.md#0x1_Signer_is_signer">is_signer</a>(addr: address): bool;
+</code></pre>
+
+
+
+
+<pre><code>axiom <b>forall</b> s:signer: <a href="Signer.md#0x1_Signer_is_signer">is_signer</a>(<a href="Signer.md#0x1_Signer_spec_address_of">spec_address_of</a>(s));
+</code></pre>
+
+
 
 </details>
 

--- a/language/move-stdlib/modules/Signer.move
+++ b/language/move-stdlib/modules/Signer.move
@@ -21,4 +21,10 @@ module Std::Signer {
     /// Specification version of `Self::address_of`.
     spec native fun spec_address_of(account: signer): address;
 
+    /// Return true only if `a` is a transaction signer. This is a spec function only available in spec.
+    spec fun is_signer(addr: address): bool;
+
+    spec module {
+        axiom forall s:signer: is_signer(spec_address_of(s));
+    }
 }


### PR DESCRIPTION
- Correctly re-implemented the Boogie encoding of `signer`
  - this revealed a hidden bug in Prover. See the bug report: https://github.com/diem/diem/issues/8854.

- Added `is_signer` to the Signer module as a native spec function

- Added various test cases (see .../functional/is_signer.move)

- Next steps:
  - Rewrite the role-based access control specs in the Diem Framework
  - Extend it to work for the cap-based access control specs
  - Specify the access control libraries like Vault

## Motivation

To implement `is_signer` in Prover

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

cargo test
