### PR TITLE
[move-lang][move-ir] Intern all the strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,6 +1768,7 @@ dependencies = [
  "move-lang",
  "move-prover",
  "move-stdlib",
+ "move-symbol-pool",
  "move-unit-test",
  "move-vm-runtime",
  "move-vm-types",
@@ -4599,6 +4600,7 @@ dependencies = [
  "move-binary-format",
  "move-core-types",
  "move-ir-types",
+ "move-symbol-pool",
  "rand 0.8.3",
 ]
 
@@ -4665,6 +4667,7 @@ dependencies = [
  "move-coverage",
  "move-lang",
  "move-stdlib",
+ "move-symbol-pool",
  "move-vm-runtime",
  "move-vm-types",
  "once_cell",

--- a/language/compiler/ir-to-bytecode/src/compiler.rs
+++ b/language/compiler/ir-to-bytecode/src/compiler.rs
@@ -38,13 +38,13 @@ use std::{
 
 macro_rules! record_src_loc {
     (local: $context:expr, $var:expr) => {{
-        let source_name = ($var.value.clone().into_inner(), $var.loc);
+        let source_name = ($var.value.0.as_str().to_owned(), $var.loc);
         $context
             .source_map
             .add_local_mapping($context.current_function_definition_index(), source_name)?;
     }};
     (parameter: $context:expr, $var:expr) => {{
-        let source_name = ($var.value.clone().into_inner(), $var.loc);
+        let source_name = ($var.value.0.as_str().to_owned(), $var.loc);
         $context
             .source_map
             .add_parameter_mapping($context.current_function_definition_index(), source_name)?;
@@ -56,7 +56,7 @@ macro_rules! record_src_loc {
     }};
     (function_type_formals: $context:expr, $var:expr) => {
         for (ty_var, _) in $var.iter() {
-            let source_name = (ty_var.value.clone().into_inner(), ty_var.loc);
+            let source_name = (ty_var.value.0.as_str().to_owned(), ty_var.loc);
             $context.source_map.add_function_type_parameter_mapping(
                 $context.current_function_definition_index(),
                 source_name,
@@ -72,7 +72,7 @@ macro_rules! record_src_loc {
     }};
     (struct_type_formals: $context:expr, $var:expr) => {
         for (_, ty_var, _) in $var.iter() {
-            let source_name = (ty_var.value.clone().into_inner(), ty_var.loc);
+            let source_name = (ty_var.value.0.as_str().to_owned(), ty_var.loc);
             $context.source_map.add_struct_type_parameter_mapping(
                 $context.current_struct_definition_index(),
                 source_name,
@@ -505,7 +505,7 @@ pub fn compile_module<'a>(
     let friend_decls = compile_friends(&mut context, Some(address), module.friends)?;
 
     // Compile imports
-    let self_name = ModuleName::new(ModuleName::self_name().into());
+    let self_name = ModuleName::module_self();
     let self_module_handle_idx = context.declare_import(current_module, self_name.clone())?;
     // Explicitly declare all imports as they will be included even if not used
     compile_imports(&mut context, Some(address), module.imports.clone())?;
@@ -888,7 +888,7 @@ fn compile_fields(
         StructDefinitionFields::Move { fields } => {
             let mut decl_fields = vec![];
             for (decl_order, (f, ty)) in fields.into_iter().enumerate() {
-                let name = context.identifier_index(f.value.as_inner())?;
+                let name = context.identifier_index(f.value.0)?;
                 record_src_loc!(field: context, sd_idx, f);
                 let sig_token = compile_type(context, type_parameters, &ty)?;
                 context.declare_field(sh_idx, sd_idx, f.value, sig_token.clone(), decl_order);
@@ -1402,7 +1402,7 @@ fn compile_expression(
             let type_actuals_id = context.signature_index(tokens)?;
             let def_idx = context.struct_definition_index(&name)?;
 
-            let self_name = ModuleName::new(ModuleName::self_name().into());
+            let self_name = ModuleName::module_self();
             let ident = QualifiedStructIdent {
                 module: self_name,
                 name: name.clone(),
@@ -1652,7 +1652,7 @@ fn compile_call(
                     function_frame.pop()?;
                     function_frame.push()?;
 
-                    let self_name = ModuleName::new(ModuleName::self_name().into());
+                    let self_name = ModuleName::module_self();
                     let ident = QualifiedStructIdent {
                         module: self_name,
                         name,
@@ -1682,7 +1682,7 @@ fn compile_call(
                     function_frame.pop()?; // pop the address
                     function_frame.push()?; // push the return value
 
-                    let self_name = ModuleName::new(ModuleName::self_name().into());
+                    let self_name = ModuleName::module_self();
                     let ident = QualifiedStructIdent {
                         module: self_name,
                         name,

--- a/language/compiler/ir-to-bytecode/syntax/src/lexer.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/lexer.rs
@@ -148,7 +148,7 @@ impl<'input> Lexer<'input> {
         self.token
     }
 
-    pub fn content(&self) -> &str {
+    pub fn content(&self) -> &'input str {
         &self.text[self.cur_start..self.cur_end]
     }
 

--- a/language/diem-framework/Cargo.toml
+++ b/language/diem-framework/Cargo.toml
@@ -23,6 +23,7 @@ diem-workspace-hack = { path = "../../common/workspace-hack" }
 move-binary-format = { path = "../move-binary-format" }
 transaction-builder-generator = { path = "../transaction-builder/generator" }
 move-stdlib = { path = "../move-stdlib" }
+move-symbol-pool = { path = "../move-symbol-pool" }
 move-core-types = { path = "../move-core/types" }
 move-vm-types = { path = "../move-vm/types" }
 move-vm-runtime = { path = "../move-vm/runtime" }

--- a/language/diem-framework/src/lib.rs
+++ b/language/diem-framework/src/lib.rs
@@ -9,6 +9,7 @@ use move_command_line_common::files::{
     extension_equals, find_filenames, MOVE_COMPILED_EXTENSION, MOVE_EXTENSION,
 };
 use move_lang::{compiled_unit::CompiledUnit, shared::AddressBytes, Compiler};
+use move_symbol_pool::Symbol;
 use once_cell::sync::Lazy;
 use sha2::{Digest, Sha256};
 use std::{
@@ -102,7 +103,7 @@ pub fn stdlib_bytecode_files() -> Vec<String> {
     res
 }
 
-pub(crate) fn build_stdlib() -> BTreeMap<String, CompiledModule> {
+pub(crate) fn build_stdlib() -> BTreeMap<Symbol, CompiledModule> {
     let (_files, compiled_units) = Compiler::new(&diem_stdlib_files(), &[])
         .set_named_address_values(diem_framework_named_addresses())
         .build_and_report()

--- a/language/diem-framework/src/release.rs
+++ b/language/diem-framework/src/release.rs
@@ -8,6 +8,7 @@ use move_command_line_common::files::{
     extension_equals, find_filenames, MOVE_COMPILED_EXTENSION, MOVE_ERROR_DESC_EXTENSION,
 };
 use move_core_types::language_storage::ModuleId;
+use move_symbol_pool::Symbol;
 use std::{
     collections::BTreeMap,
     fs::{create_dir_all, remove_dir_all, File},
@@ -49,7 +50,7 @@ fn extract_old_apis(modules_path: impl AsRef<Path>) -> Option<BTreeMap<ModuleId,
     Some(old_module_apis)
 }
 
-fn build_modules(output_path: impl AsRef<Path>) -> BTreeMap<String, CompiledModule> {
+fn build_modules(output_path: impl AsRef<Path>) -> BTreeMap<Symbol, CompiledModule> {
     let output_path = output_path.as_ref();
     recreate_dir(output_path);
 
@@ -58,7 +59,7 @@ fn build_modules(output_path: impl AsRef<Path>) -> BTreeMap<String, CompiledModu
     for (name, module) in &compiled_modules {
         let mut bytes = Vec::new();
         module.serialize(&mut bytes).unwrap();
-        let mut module_path = Path::join(output_path, name);
+        let mut module_path = Path::join(output_path, name.as_str());
         module_path.set_extension(MOVE_COMPILED_EXTENSION);
         save_binary(&module_path, &bytes);
     }

--- a/language/move-ir/types/src/spec_language_ast.rs
+++ b/language/move-ir/types/src/spec_language_ast.rs
@@ -5,7 +5,8 @@ use crate::{
     ast::{BinOp, CopyableVal_, Field_, QualifiedStructIdent, Type},
     location::*,
 };
-use move_core_types::{account_address::AccountAddress, identifier::Identifier};
+use move_core_types::account_address::AccountAddress;
+use move_symbol_pool::Symbol;
 
 /// AST for the Move Prover specification language.
 
@@ -20,7 +21,7 @@ pub enum FieldOrIndex {
 #[derive(PartialEq, Debug, Clone)]
 pub enum StorageLocation {
     /// A formal of the current procedure
-    Formal(String),
+    Formal(Symbol),
     /// A resource of type `type_` stored in global storage at `address`
     GlobalResource {
         type_: QualifiedStructIdent,
@@ -65,7 +66,7 @@ pub enum SpecExp {
     /// Value of expression evaluated in the state before function enter.
     Old(Box<SpecExp>),
     /// Call to a helper function.
-    Call(String, Vec<SpecExp>),
+    Call(Symbol, Vec<SpecExp>),
 }
 
 /// A specification directive to be verified
@@ -88,10 +89,10 @@ pub type Condition = Spanned<Condition_>;
 #[derive(PartialEq, Debug, Clone)]
 pub struct Invariant_ {
     /// A free string (for now) which specifies the function of this invariant.
-    pub modifier: String,
+    pub modifier: Option<Symbol>,
 
     /// An optional synthetic variable to which the below expression is assigned to.
-    pub target: Option<String>,
+    pub target: Option<Symbol>,
 
     /// A specification expression.
     pub exp: SpecExp,
@@ -103,7 +104,7 @@ pub type Invariant = Spanned<Invariant_>;
 /// A synthetic variable definition.
 #[derive(PartialEq, Debug, Clone)]
 pub struct SyntheticDefinition_ {
-    pub name: Identifier,
+    pub name: Symbol,
     pub type_: Type,
 }
 

--- a/language/move-lang/src/cfgir/ast.rs
+++ b/language/move-lang/src/cfgir/ast.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 use move_core_types::value::MoveValue;
 use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 // HLIR + Unstructured Control Flow + CFG
@@ -22,7 +23,7 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 #[derive(Debug, Clone)]
 pub struct Program {
     pub modules: UniqueMap<ModuleIdent, ModuleDefinition>,
-    pub scripts: BTreeMap<String, Script>,
+    pub scripts: BTreeMap<Symbol, Script>,
 }
 
 //**************************************************************************************************
@@ -208,7 +209,7 @@ impl AstDebug for Script {
             cdef.ast_debug(w);
             w.new_line();
         }
-        (function_name.clone(), function).ast_debug(w);
+        (*function_name, function).ast_debug(w);
     }
 }
 

--- a/language/move-lang/src/cfgir/eliminate_locals.rs
+++ b/language/move-lang/src/cfgir/eliminate_locals.rs
@@ -64,22 +64,22 @@ mod count {
 
         fn assign(&mut self, var: &Var, substitutable: bool) {
             if !substitutable {
-                self.assigned.insert(var.clone(), None);
+                self.assigned.insert(*var, None);
                 return;
             }
 
-            if let Some(count) = self.assigned.entry(var.clone()).or_insert_with(|| Some(0)) {
+            if let Some(count) = self.assigned.entry(*var).or_insert_with(|| Some(0)) {
                 *count += 1
             }
         }
 
         fn used(&mut self, var: &Var, substitutable: bool) {
             if !substitutable {
-                self.used.insert(var.clone(), None);
+                self.used.insert(*var, None);
                 return;
             }
 
-            if let Some(count) = self.used.entry(var.clone()).or_insert_with(|| Some(0)) {
+            if let Some(count) = self.used.entry(*var).or_insert_with(|| Some(0)) {
                 *count += 1
             }
         }

--- a/language/move-lang/src/cfgir/liveness/mod.rs
+++ b/language/move-lang/src/cfgir/liveness/mod.rs
@@ -122,11 +122,11 @@ fn exp(state: &mut LivenessState, parent_e: &Exp) {
         E::Unit { .. } | E::Value(_) | E::Constant(_) | E::UnresolvedError => (),
 
         E::BorrowLocal(_, var) | E::Copy { var, .. } | E::Move { var, .. } => {
-            state.0.insert(var.clone());
+            state.0.insert(*var);
         }
 
         E::Spec(_, used_locals) => used_locals.keys().for_each(|v| {
-            state.0.insert(v.clone());
+            state.0.insert(*v);
         }),
 
         E::ModuleCall(mcall) => exp(state, &mcall.arguments),
@@ -289,7 +289,7 @@ mod last_usage {
         match &mut l.value {
             L::Ignore => (),
             L::Var(v, _) => {
-                context.dropped_live.insert(v.clone());
+                context.dropped_live.insert(*v);
                 if !context.next_live.contains(v) {
                     match display_var(v.value()) {
                         DisplayVar::Tmp => (),
@@ -346,7 +346,7 @@ mod last_usage {
                 );
                 if var_is_dead && is_reference && !*from_user {
                     parent_e.exp.value = E::Move {
-                        var: var.clone(),
+                        var: *var,
                         from_user: *from_user,
                     };
                 }
@@ -477,7 +477,7 @@ fn release_dead_refs_block(
         .map(|var| (var, locals.get(var).unwrap()))
         .filter(is_ref);
     for (dead_ref, ty) in dead_refs {
-        block.push_front(pop_ref(cmd_loc, dead_ref.clone(), ty.clone()));
+        block.push_front(pop_ref(cmd_loc, *dead_ref, ty.clone()));
     }
 }
 

--- a/language/move-lang/src/cfgir/locals/mod.rs
+++ b/language/move-lang/src/cfgir/locals/mod.rs
@@ -236,7 +236,7 @@ fn lvalue(context: &mut Context, sp!(loc, l_): &LValue) {
                     }
                 }
             }
-            context.set_state(v.clone(), LocalState::Available(*loc))
+            context.set_state(*v, LocalState::Available(*loc))
         }
         L::Unpack(_, _, fields) => fields.iter().for_each(|(_, l)| lvalue(context, l)),
     }
@@ -252,7 +252,7 @@ fn exp(context: &mut Context, parent_e: &Exp) {
 
         E::Move { var, .. } => {
             use_local(context, eloc, var);
-            context.set_state(var.clone(), LocalState::Unavailable(*eloc))
+            context.set_state(*var, LocalState::Unavailable(*eloc))
         }
 
         E::ModuleCall(mcall) => exp(context, &mcall.arguments),

--- a/language/move-lang/src/cfgir/locals/state.rs
+++ b/language/move-lang/src/cfgir/locals/state.rs
@@ -43,11 +43,11 @@ impl LocalStates {
         };
         for (var, _) in local_types.key_cloned_iter() {
             let local_state = LocalState::Unavailable(var.loc());
-            states.set_state(var.clone(), local_state)
+            states.set_state(var, local_state)
         }
         for (var, _) in function_arguments {
             let local_state = LocalState::Available(var.loc());
-            states.set_state(var.clone(), local_state)
+            states.set_state(*var, local_state)
         }
         states
     }

--- a/language/move-lang/src/cfgir/translate.rs
+++ b/language/move-lang/src/cfgir/translate.rs
@@ -17,6 +17,7 @@ use crate::{
 use cfgir::ast::LoopInfo;
 use move_core_types::{account_address::AccountAddress as MoveAddress, value::MoveValue};
 use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
 use std::{
     collections::{BTreeMap, BTreeSet},
     mem,
@@ -211,8 +212,8 @@ fn module(
 
 fn scripts(
     context: &mut Context,
-    hscripts: BTreeMap<String, H::Script>,
-) -> BTreeMap<String, G::Script> {
+    hscripts: BTreeMap<Symbol, H::Script>,
+) -> BTreeMap<Symbol, G::Script> {
     hscripts
         .into_iter()
         .map(|(n, s)| (n, script(context, s)))
@@ -228,7 +229,7 @@ fn script(context: &mut Context, hscript: H::Script) -> G::Script {
         function: hfunction,
     } = hscript;
     let constants = hconstants.map(|name, c| constant(context, name, c));
-    let function = function(context, function_name.clone(), hfunction);
+    let function = function(context, function_name, hfunction);
     G::Script {
         attributes,
         loc,

--- a/language/move-lang/src/compiled_unit.rs
+++ b/language/move-lang/src/compiled_unit.rs
@@ -16,6 +16,7 @@ use move_core_types::{
     language_storage::ModuleId,
 };
 use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
 use std::collections::BTreeMap;
 
 //**************************************************************************************************
@@ -41,7 +42,7 @@ pub struct FunctionInfo {
     pub parameters: Vec<(Var, VarInfo)>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct CompiledModuleIdent {
     pub loc: Loc,
     pub address_name: Option<Name>,
@@ -59,7 +60,7 @@ pub enum CompiledUnit {
     },
     Script {
         loc: Loc,
-        key: String,
+        key: Symbol,
         script: F::CompiledScript,
         source_map: SourceMap<Loc>,
         function_info: FunctionInfo,
@@ -106,17 +107,17 @@ impl CompiledModuleIdent {
         } = self;
         let id = ModuleId::new(
             AccountAddress::new(address_bytes.into_bytes()),
-            MoveCoreIdentifier::new(module_name.0.value).unwrap(),
+            MoveCoreIdentifier::new(module_name.0.value.to_string()).unwrap(),
         );
         (address_name, id)
     }
 }
 
 impl CompiledUnit {
-    pub fn name(&self) -> String {
+    pub fn name(&self) -> Symbol {
         match self {
-            CompiledUnit::Module { ident, .. } => ident.module_name.0.value.to_owned(),
-            CompiledUnit::Script { key, .. } => key.to_owned(),
+            CompiledUnit::Module { ident, .. } => ident.module_name.0.value,
+            CompiledUnit::Script { key, .. } => *key,
         }
     }
 

--- a/language/move-lang/src/expansion/aliases.rs
+++ b/language/move-lang/src/expansion/aliases.rs
@@ -195,14 +195,14 @@ impl AliasMap {
         let mut current_scope = AliasSet::new();
         for (alias, (ident, is_implicit)) in new_modules {
             if !is_implicit {
-                current_scope.modules.add(alias.clone()).unwrap();
+                current_scope.modules.add(alias).unwrap();
             }
             self.modules.remove(&alias);
             self.modules.add(alias, (Some(next_depth), ident)).unwrap();
         }
         for (alias, (ident_member, is_implicit)) in new_members {
             if !is_implicit {
-                current_scope.members.add(alias.clone()).unwrap();
+                current_scope.members.add(alias).unwrap();
             }
             self.members.remove(&alias);
             self.members

--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -9,6 +9,7 @@ use crate::{
     shared::{ast_debug::*, unique_map::UniqueMap, unique_set::UniqueSet, *},
 };
 use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
 use std::{
     collections::{BTreeMap, BTreeSet, VecDeque},
     fmt,
@@ -23,7 +24,7 @@ use std::{
 pub struct Program {
     // Map of declared named addresses, and their values if specified
     pub modules: UniqueMap<ModuleIdent, ModuleDefinition>,
-    pub scripts: BTreeMap<String, Script>,
+    pub scripts: BTreeMap<Symbol, Script>,
 }
 
 //**************************************************************************************************
@@ -75,12 +76,12 @@ pub struct Script {
 // Modules
 //**************************************************************************************************
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Address {
     Anonymous(Spanned<AddressBytes>),
     Named(Name),
 }
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ModuleIdent_ {
     pub address: Address,
     pub module: ModuleName,
@@ -457,7 +458,7 @@ impl Address {
         Self::Anonymous(sp(loc, AddressBytes::new(address)))
     }
 
-    pub fn into_addr_bytes(self, addresses: &BTreeMap<String, AddressBytes>) -> AddressBytes {
+    pub fn into_addr_bytes(self, addresses: &BTreeMap<Symbol, AddressBytes>) -> AddressBytes {
         match self {
             Self::Anonymous(sp!(_, bytes)) => bytes,
             Self::Named(n) => *addresses.get(&n.value).unwrap_or_else(|| {
@@ -787,7 +788,7 @@ impl AstDebug for Script {
             cdef.ast_debug(w);
             w.new_line();
         }
-        (function_name.clone(), function).ast_debug(w);
+        (*function_name, function).ast_debug(w);
         for spec in specs {
             spec.ast_debug(w);
             w.new_line();

--- a/language/move-lang/src/hlir/ast.rs
+++ b/language/move-lang/src/hlir/ast.rs
@@ -10,6 +10,7 @@ use crate::{
     shared::{ast_debug::*, unique_map::UniqueMap},
 };
 use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 // High Level IR
@@ -21,7 +22,7 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 #[derive(Debug, Clone)]
 pub struct Program {
     pub modules: UniqueMap<ModuleIdent, ModuleDefinition>,
-    pub scripts: BTreeMap<String, Script>,
+    pub scripts: BTreeMap<Symbol, Script>,
 }
 
 //**************************************************************************************************
@@ -575,7 +576,7 @@ impl AstDebug for Script {
             cdef.ast_debug(w);
             w.new_line();
         }
-        (function_name.clone(), function).ast_debug(w);
+        (*function_name, function).ast_debug(w);
     }
 }
 

--- a/language/move-lang/src/naming/ast.rs
+++ b/language/move-lang/src/naming/ast.rs
@@ -10,6 +10,7 @@ use crate::{
     shared::{ast_debug::*, unique_map::UniqueMap, *},
 };
 use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
 use once_cell::sync::Lazy;
 use std::{
     collections::{BTreeMap, BTreeSet, VecDeque},
@@ -23,7 +24,7 @@ use std::{
 #[derive(Debug, Clone)]
 pub struct Program {
     pub modules: UniqueMap<ModuleIdent, ModuleDefinition>,
-    pub scripts: BTreeMap<String, Script>,
+    pub scripts: BTreeMap<Symbol, Script>,
 }
 
 //**************************************************************************************************
@@ -276,7 +277,7 @@ pub type SequenceItem = Spanned<SequenceItem_>;
 // impls
 //**************************************************************************************************
 
-static BUILTIN_TYPE_ALL_NAMES: Lazy<BTreeSet<&'static str>> = Lazy::new(|| {
+static BUILTIN_TYPE_ALL_NAMES: Lazy<BTreeSet<Symbol>> = Lazy::new(|| {
     [
         BuiltinTypeName_::ADDRESS,
         BuiltinTypeName_::SIGNER,
@@ -287,7 +288,7 @@ static BUILTIN_TYPE_ALL_NAMES: Lazy<BTreeSet<&'static str>> = Lazy::new(|| {
         BuiltinTypeName_::VECTOR,
     ]
     .iter()
-    .cloned()
+    .map(|n| Symbol::from(*n))
     .collect()
 });
 
@@ -317,7 +318,7 @@ impl BuiltinTypeName_ {
     pub const BOOL: &'static str = "bool";
     pub const VECTOR: &'static str = "vector";
 
-    pub fn all_names() -> &'static BTreeSet<&'static str> {
+    pub fn all_names() -> &'static BTreeSet<Symbol> {
         &*BUILTIN_TYPE_ALL_NAMES
     }
 
@@ -383,16 +384,19 @@ impl TVar {
     }
 }
 
-static BUILTIN_FUNCTION_ALL_NAMES: Lazy<BTreeSet<&'static str>> = Lazy::new(|| {
-    let mut s = BTreeSet::new();
-    s.insert(BuiltinFunction_::MOVE_TO);
-    s.insert(BuiltinFunction_::MOVE_FROM);
-    s.insert(BuiltinFunction_::BORROW_GLOBAL);
-    s.insert(BuiltinFunction_::BORROW_GLOBAL_MUT);
-    s.insert(BuiltinFunction_::EXISTS);
-    s.insert(BuiltinFunction_::FREEZE);
-    s.insert(BuiltinFunction_::ASSERT);
-    s
+static BUILTIN_FUNCTION_ALL_NAMES: Lazy<BTreeSet<Symbol>> = Lazy::new(|| {
+    [
+        BuiltinFunction_::MOVE_TO,
+        BuiltinFunction_::MOVE_FROM,
+        BuiltinFunction_::BORROW_GLOBAL,
+        BuiltinFunction_::BORROW_GLOBAL_MUT,
+        BuiltinFunction_::EXISTS,
+        BuiltinFunction_::FREEZE,
+        BuiltinFunction_::ASSERT,
+    ]
+    .iter()
+    .map(|n| Symbol::from(*n))
+    .collect()
 });
 
 impl BuiltinFunction_ {
@@ -404,7 +408,7 @@ impl BuiltinFunction_ {
     pub const FREEZE: &'static str = "freeze";
     pub const ASSERT: &'static str = "assert";
 
-    pub fn all_names() -> &'static BTreeSet<&'static str> {
+    pub fn all_names() -> &'static BTreeSet<Symbol> {
         &*BUILTIN_FUNCTION_ALL_NAMES
     }
 
@@ -584,7 +588,7 @@ impl AstDebug for Script {
             cdef.ast_debug(w);
             w.new_line();
         }
-        (function_name.clone(), function).ast_debug(w);
+        (*function_name, function).ast_debug(w);
     }
 }
 

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -8,29 +8,29 @@ use std::{fmt, hash::Hash};
 
 macro_rules! new_name {
     ($n:ident) => {
-        #[derive(Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
+        #[derive(Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Clone, Copy)]
         pub struct $n(pub Name);
 
         impl TName for $n {
-            type Key = String;
+            type Key = Symbol;
             type Loc = Loc;
 
-            fn drop_loc(self) -> (Loc, String) {
+            fn drop_loc(self) -> (Loc, Symbol) {
                 (self.0.loc, self.0.value)
             }
 
-            fn add_loc(loc: Loc, key: String) -> Self {
+            fn add_loc(loc: Loc, key: Symbol) -> Self {
                 $n(sp(loc, key))
             }
 
-            fn borrow(&self) -> (&Loc, &String) {
+            fn borrow(&self) -> (&Loc, &Symbol) {
                 (&self.0.loc, &self.0.value)
             }
         }
 
         impl Identifier for $n {
-            fn value(&self) -> &str {
-                &self.0.value
+            fn value(&self) -> Symbol {
+                self.0.value
             }
             fn loc(&self) -> Loc {
                 self.0.loc
@@ -130,7 +130,7 @@ impl Attribute_ {
 
 new_name!(ModuleName);
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// Specifies a name at the beginning of an access chain. Could be
 /// - A module name
 /// - A named address
@@ -141,7 +141,7 @@ pub enum LeadingNameAccess_ {
 }
 pub type LeadingNameAccess = Spanned<LeadingNameAccess_>;
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ModuleIdent_ {
     pub address: LeadingNameAccess,
     pub module: ModuleName,
@@ -457,13 +457,13 @@ pub enum Value_ {
     // @<num>
     Address(LeadingNameAccess),
     // <num>(u8|u64|u128)?
-    Num(String),
+    Num(Symbol),
     // false
     Bool(bool),
     // x"[0..9A..F]+"
-    HexString(String),
+    HexString(Symbol),
     // b"(<ascii> | \n | \r | \t | \\ | \0 | \" | \x[0..9A..F][0..9A..F])+"
-    ByteString(String),
+    ByteString(Symbol),
 }
 pub type Value = Spanned<Value_>;
 
@@ -712,7 +712,7 @@ impl ModuleName {
 
 impl Var {
     pub fn is_underscore(&self) -> bool {
-        self.0.value == "_"
+        self.0.value.as_str() == "_"
     }
 
     pub fn starts_with_underscore(&self) -> bool {

--- a/language/move-lang/src/parser/lexer.rs
+++ b/language/move-lang/src/parser/lexer.rs
@@ -189,7 +189,7 @@ impl<'input> Lexer<'input> {
         self.token
     }
 
-    pub fn content(&self) -> &str {
+    pub fn content(&self) -> &'input str {
         &self.text[self.cur_start..self.cur_end]
     }
 

--- a/language/move-lang/src/parser/merge_spec_modules.rs
+++ b/language/move-lang/src/parser/merge_spec_modules.rs
@@ -15,6 +15,7 @@ use crate::{
     parser::ast::{Definition, LeadingNameAccess_, ModuleDefinition, ModuleMember, Program},
     shared::*,
 };
+use move_symbol_pool::Symbol;
 use std::collections::BTreeMap;
 
 /// Given a parsed program, merge all specification modules into their target modules.
@@ -63,7 +64,7 @@ pub fn program(compilation_env: &mut CompilationEnv, prog: Program) -> Program {
 }
 
 fn extract_spec_modules(
-    spec_modules: &mut BTreeMap<(Option<LeadingNameAccess_>, String), ModuleDefinition>,
+    spec_modules: &mut BTreeMap<(Option<LeadingNameAccess_>, Symbol), ModuleDefinition>,
     defs: Vec<Definition>,
 ) -> Vec<Definition> {
     use Definition::*;
@@ -85,7 +86,7 @@ fn extract_spec_modules(
 }
 
 fn extract_spec_module(
-    spec_modules: &mut BTreeMap<(Option<LeadingNameAccess_>, String), ModuleDefinition>,
+    spec_modules: &mut BTreeMap<(Option<LeadingNameAccess_>, Symbol), ModuleDefinition>,
     address_opt: Option<&LeadingNameAccess_>,
     m: ModuleDefinition,
 ) -> Option<ModuleDefinition> {
@@ -98,7 +99,7 @@ fn extract_spec_module(
 }
 
 fn merge_spec_modules(
-    spec_modules: &mut BTreeMap<(Option<LeadingNameAccess_>, String), ModuleDefinition>,
+    spec_modules: &mut BTreeMap<(Option<LeadingNameAccess_>, Symbol), ModuleDefinition>,
     defs: &mut Vec<Definition>,
 ) {
     use Definition::*;
@@ -117,7 +118,7 @@ fn merge_spec_modules(
 }
 
 fn merge_spec_module(
-    spec_modules: &mut BTreeMap<(Option<LeadingNameAccess_>, String), ModuleDefinition>,
+    spec_modules: &mut BTreeMap<(Option<LeadingNameAccess_>, Symbol), ModuleDefinition>,
     address_opt: Option<&LeadingNameAccess_>,
     m: &mut ModuleDefinition,
 ) {
@@ -139,10 +140,10 @@ fn merge_spec_module(
 fn module_key(
     address_opt: Option<&LeadingNameAccess_>,
     m: &ModuleDefinition,
-) -> (Option<LeadingNameAccess_>, String) {
+) -> (Option<LeadingNameAccess_>, Symbol) {
     let addr_ = match &m.address {
-        a @ Some(_) => a.as_ref().map(|sp!(_, a_)| a_.clone()),
-        None => address_opt.cloned(),
+        Some(sp!(_, a_)) => Some(*a_),
+        None => address_opt.copied(),
     };
-    (addr_, m.name.value().to_owned())
+    (addr_, m.name.value())
 }

--- a/language/move-lang/src/shared/ast_debug.rs
+++ b/language/move-lang/src/shared/ast_debug.rs
@@ -76,16 +76,16 @@ impl AstWriter {
         self.lines.push(String::new());
     }
 
-    pub fn write(&mut self, s: &str) {
+    pub fn write(&mut self, s: impl AsRef<str>) {
         let margin = self.margin;
         let cur = self.cur();
         if cur.is_empty() {
             (0..margin).for_each(|_| cur.push(' '));
         }
-        cur.push_str(s);
+        cur.push_str(s.as_ref());
     }
 
-    pub fn writeln(&mut self, s: &str) {
+    pub fn writeln(&mut self, s: impl AsRef<str>) {
         self.write(s);
         self.new_line();
     }

--- a/language/move-lang/src/shared/mod.rs
+++ b/language/move-lang/src/shared/mod.rs
@@ -6,6 +6,7 @@ use crate::{
     diagnostics::{codes::Severity, Diagnostic, Diagnostics},
 };
 use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
 use petgraph::{algo::astar as petgraph_astar, graphmap::DiGraphMap};
 use std::{
     collections::BTreeMap,
@@ -223,26 +224,26 @@ pub trait TName: Eq + Ord + Clone {
 }
 
 pub trait Identifier {
-    fn value(&self) -> &str;
+    fn value(&self) -> Symbol;
     fn loc(&self) -> Loc;
 }
 
 // TODO maybe we should intern these strings somehow
-pub type Name = Spanned<String>;
+pub type Name = Spanned<Symbol>;
 
 impl TName for Name {
-    type Key = String;
+    type Key = Symbol;
     type Loc = Loc;
 
-    fn drop_loc(self) -> (Loc, String) {
+    fn drop_loc(self) -> (Loc, Symbol) {
         (self.loc, self.value)
     }
 
-    fn add_loc(loc: Loc, key: String) -> Self {
+    fn add_loc(loc: Loc, key: Symbol) -> Self {
         sp(loc, key)
     }
 
-    fn borrow(&self) -> (&Loc, &String) {
+    fn borrow(&self) -> (&Loc, &Symbol) {
         (&self.loc, &self.value)
     }
 }
@@ -289,13 +290,13 @@ pub fn shortest_cycle<'a, T: Ord + Hash>(
 pub struct CompilationEnv {
     flags: Flags,
     diags: Diagnostics,
-    named_address_mapping: BTreeMap<String, AddressBytes>,
+    named_address_mapping: BTreeMap<Symbol, AddressBytes>,
     // TODO(tzakian): Remove the global counter and use this counter instead
     // pub counter: u64,
 }
 
 impl CompilationEnv {
-    pub fn new(flags: Flags, named_address_mapping: BTreeMap<String, AddressBytes>) -> Self {
+    pub fn new(flags: Flags, named_address_mapping: BTreeMap<Symbol, AddressBytes>) -> Self {
         Self {
             flags,
             diags: Diagnostics::new(),
@@ -343,7 +344,7 @@ impl CompilationEnv {
         &self.flags
     }
 
-    pub fn named_address_mapping(&self) -> &BTreeMap<String, AddressBytes> {
+    pub fn named_address_mapping(&self) -> &BTreeMap<Symbol, AddressBytes> {
         &self.named_address_mapping
     }
 }

--- a/language/move-lang/src/to_bytecode/context.rs
+++ b/language/move-lang/src/to_bytecode/context.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use move_core_types::account_address::AccountAddress as MoveAddress;
 use move_ir_types::ast as IR;
+use move_symbol_pool::Symbol;
 use std::{
     clone::Clone,
     collections::{BTreeMap, BTreeSet, HashMap},
@@ -157,7 +158,7 @@ impl<'a> Context<'a> {
         module: &ModuleIdent,
         sname: StructName,
     ) -> IR::StructDependency {
-        let key = (module.clone(), sname.clone());
+        let key = (*module, sname);
         let (abilities, type_formals) = struct_declarations.get(&key).unwrap().clone();
         let name = Self::translate_struct_name(sname);
         IR::StructDependency {
@@ -195,7 +196,7 @@ impl<'a> Context<'a> {
         module: &ModuleIdent,
         fname: FunctionName,
     ) -> (BTreeSet<(ModuleIdent, StructName)>, IR::FunctionDependency) {
-        let key = (module.clone(), fname.clone());
+        let key = (*module, fname);
         let (seen_structs, signature) = function_declarations.get(&key).unwrap().clone();
         let name = Self::translate_function_name(fname);
         (seen_structs, IR::FunctionDependency { name, signature })
@@ -206,7 +207,7 @@ impl<'a> Context<'a> {
     //**********************************************************************************************
 
     fn ir_module_alias(sp!(_, ModuleIdent_ { address, module }): &ModuleIdent) -> IR::ModuleName {
-        IR::ModuleName::new(format!("{}::{}", address, module))
+        IR::ModuleName(format!("{}::{}", address, module).into())
     }
 
     pub fn resolve_address(&self, addr: Address) -> AddressBytes {
@@ -218,7 +219,7 @@ impl<'a> Context<'a> {
     }
 
     fn translate_module_ident_impl(
-        addresses: &BTreeMap<String, AddressBytes>,
+        addresses: &BTreeMap<Symbol, AddressBytes>,
         sp!(_, ModuleIdent_ { address, module }): ModuleIdent,
     ) -> IR::ModuleIdent {
         let address_bytes = address.into_addr_bytes(addresses);
@@ -229,20 +230,20 @@ impl<'a> Context<'a> {
         ))
     }
 
-    fn translate_module_name_(s: String) -> IR::ModuleName {
-        IR::ModuleName::new(s)
+    fn translate_module_name_(s: Symbol) -> IR::ModuleName {
+        IR::ModuleName(s)
     }
 
     fn translate_struct_name(n: StructName) -> IR::StructName {
-        IR::StructName::new(n.0.value)
+        IR::StructName(n.0.value)
     }
 
     fn translate_constant_name(n: ConstantName) -> IR::ConstantName {
-        IR::ConstantName::new(n.0.value)
+        IR::ConstantName(n.0.value)
     }
 
     fn translate_function_name(n: FunctionName) -> IR::FunctionName {
-        IR::FunctionName::new(n.0.value)
+        IR::FunctionName(n.0.value)
     }
 
     //**********************************************************************************************
@@ -265,7 +266,7 @@ impl<'a> Context<'a> {
         let mname = if self.is_current_module(m) {
             IR::ModuleName::module_self()
         } else {
-            self.seen_structs.insert((m.clone(), s.clone()));
+            self.seen_structs.insert((*m, s));
             Self::ir_module_alias(m)
         };
         let n = Self::translate_struct_name(s);
@@ -292,7 +293,7 @@ impl<'a> Context<'a> {
         let mname = if self.is_current_module(m) {
             IR::ModuleName::module_self()
         } else {
-            self.seen_functions.insert((m.clone(), f.clone()));
+            self.seen_functions.insert((*m, f));
             Self::ir_module_alias(m)
         };
         let n = Self::translate_function_name(f);
@@ -320,7 +321,7 @@ impl<'a> Context<'a> {
     //**********************************************************************************************
 
     pub fn spec(&mut self, id: SpecId, used_locals: BTreeMap<Var, H::SingleType>) -> IR::NopLabel {
-        let label = IR::NopLabel(format!("{}", id));
+        let label = IR::NopLabel(format!("{}", id).into());
         assert!(self
             .spec_info
             .insert(id, (label.clone(), used_locals))

--- a/language/move-lang/src/typing/ast.rs
+++ b/language/move-lang/src/typing/ast.rs
@@ -8,6 +8,7 @@ use crate::{
     shared::{ast_debug::*, unique_map::UniqueMap},
 };
 use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
 use std::{
     collections::{BTreeMap, VecDeque},
     fmt,
@@ -20,7 +21,7 @@ use std::{
 #[derive(Debug, Clone)]
 pub struct Program {
     pub modules: UniqueMap<ModuleIdent, ModuleDefinition>,
-    pub scripts: BTreeMap<String, Script>,
+    pub scripts: BTreeMap<Symbol, Script>,
 }
 
 //**************************************************************************************************
@@ -274,7 +275,7 @@ impl AstDebug for Script {
             cdef.ast_debug(w);
             w.new_line();
         }
-        (function_name.clone(), function).ast_debug(w);
+        (*function_name, function).ast_debug(w);
     }
 }
 

--- a/language/move-lang/src/typing/core.rs
+++ b/language/move-lang/src/typing/core.rs
@@ -626,7 +626,7 @@ pub fn make_struct_type(
     n: &StructName,
     ty_args_opt: Option<Vec<Type>>,
 ) -> (Type, Vec<Type>) {
-    let tn = sp(loc, TypeName_::ModuleType(m.clone(), n.clone()));
+    let tn = sp(loc, TypeName_::ModuleType(*m, *n));
     let sdef = context.struct_definition(m, n);
     match ty_args_opt {
         None => {
@@ -827,7 +827,7 @@ pub fn make_function_type(
         .signature
         .parameters
         .iter()
-        .map(|(n, t)| (n.clone(), subst_tparams(tparam_subst, t.clone())))
+        .map(|(n, t)| (*n, subst_tparams(tparam_subst, t.clone())))
         .collect();
     let return_ty = subst_tparams(tparam_subst, finfo.signature.return_type.clone());
     let acquires = if in_current_module {

--- a/language/move-lang/src/typing/expand.rs
+++ b/language/move-lang/src/typing/expand.rs
@@ -140,7 +140,7 @@ pub fn exp(context: &mut Context, e: &mut T::Exp) {
     match &mut e.exp.value {
         E::Use(v) => {
             let from_user = false;
-            let var = v.clone();
+            let var = *v;
             e.exp.value = if core::is_implicitly_copyable(&context.subst, &e.ty) {
                 E::Copy { from_user, var }
             } else {

--- a/language/move-lang/src/typing/globals.rs
+++ b/language/move-lang/src/typing/globals.rs
@@ -105,7 +105,7 @@ fn exp(
             let msg = || format!("Invalid call to '{}::{}'", &call.module, &call.name);
             for (sn, sloc) in &call.acquires {
                 check_acquire_listed(context, annotated_acquires, loc, msg, sn, *sloc);
-                seen.insert(sn.clone(), *sloc);
+                seen.insert(*sn, *sloc);
             }
 
             exp(context, annotated_acquires, seen, &call.arguments);
@@ -195,7 +195,7 @@ fn builtin_function(
             let msg = mk_msg(b_.display_name());
             if let Some(sn) = check_global_access(context, loc, msg, bt) {
                 check_acquire_listed(context, annotated_acquires, *loc, msg, sn, bt.loc);
-                seen.insert(sn.clone(), bt.loc);
+                seen.insert(*sn, bt.loc);
             }
         }
 
@@ -294,7 +294,7 @@ where
             return None;
         }
 
-        T::Apply(Some(_), sp!(_, TN::ModuleType(m, s)), _args) => (m.clone(), s),
+        T::Apply(Some(_), sp!(_, TN::ModuleType(m, s)), _args) => (*m, s),
     };
 
     match &context.current_module {

--- a/language/move-lang/src/typing/recursive_structs.rs
+++ b/language/move-lang/src/typing/recursive_structs.rs
@@ -34,9 +34,9 @@ impl Context {
             return;
         }
         self.struct_neighbors
-            .entry(self.current_struct.clone().unwrap())
+            .entry(self.current_struct.unwrap())
             .or_insert_with(BTreeMap::new)
-            .insert(sname.clone(), loc);
+            .insert(*sname, loc);
     }
 
     fn struct_graph(&self) -> DiGraphMap<&StructName, ()> {

--- a/language/move-lang/src/unit_test/filter_test_members.rs
+++ b/language/move-lang/src/unit_test/filter_test_members.rs
@@ -66,11 +66,13 @@ fn check_has_unit_test_module(context: &mut Context, prog: &P::Program) -> bool 
         .chain(prog.source_definitions.iter())
         .any(|def| match def {
             P::Definition::Module(mdef) => {
-                mdef.name.0.value == UNIT_TEST_MODULE_NAME
+                mdef.name.0.value.as_str() == UNIT_TEST_MODULE_NAME
                     && mdef.address.is_some()
                     && match &mdef.address.as_ref().unwrap().value {
                         // TODO: remove once named addresses have landed in the stdlib
-                        P::LeadingNameAccess_::Name(name) => name.value == STDLIB_ADDRESS_NAME,
+                        P::LeadingNameAccess_::Name(name) => {
+                            name.value.as_str() == STDLIB_ADDRESS_NAME
+                        }
                         P::LeadingNameAccess_::AnonymousAddress(_) => false,
                     }
             }
@@ -229,15 +231,15 @@ fn insert_test_poison(context: &mut Context, mloc: Loc, members: &mut Vec<P::Mod
 
     let leading_name_access = sp(
         mloc,
-        P::LeadingNameAccess_::Name(sp(mloc, STDLIB_ADDRESS_NAME.to_owned())),
+        P::LeadingNameAccess_::Name(sp(mloc, STDLIB_ADDRESS_NAME.into())),
     );
 
-    let mod_name = sp(mloc, UNIT_TEST_MODULE_NAME.to_string());
+    let mod_name = sp(mloc, UNIT_TEST_MODULE_NAME.into());
     let mod_addr_name = sp(mloc, (leading_name_access, mod_name));
-    let fn_name = sp(mloc, "create_signers_for_testing".to_string());
+    let fn_name = sp(mloc, "create_signers_for_testing".into());
     let args_ = vec![sp(
         mloc,
-        P::Exp_::Value(sp(mloc, P::Value_::Num("0".to_string()))),
+        P::Exp_::Value(sp(mloc, P::Value_::Num("0".into()))),
     )];
     let nop_call = P::Exp_::Call(
         sp(mloc, P::NameAccessChain_::Three(mod_addr_name, fn_name)),
@@ -252,7 +254,7 @@ fn insert_test_poison(context: &mut Context, mloc: Loc, members: &mut Vec<P::Mod
         visibility: P::Visibility::Internal,
         acquires: vec![],
         signature,
-        name: P::FunctionName(sp(mloc, "unit_test_poison".to_string())),
+        name: P::FunctionName(sp(mloc, "unit_test_poison".into())),
         body: sp(
             mloc,
             P::FunctionBody_::Defined((

--- a/language/move-model/src/builder/exp_translator.rs
+++ b/language/move-model/src/builder/exp_translator.rs
@@ -937,7 +937,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
     ) -> ExpData {
         // First check for builtin functions.
         if let EA::ModuleAccess_::Name(n) = &maccess.value {
-            if n.value == "update_field" {
+            if n.value.as_str() == "update_field" {
                 return self.translate_update_field(expected_type, loc, generics, args);
             }
         }

--- a/language/move-model/src/builder/model_builder.rs
+++ b/language/move-model/src/builder/model_builder.rs
@@ -13,6 +13,7 @@ use log::{debug, info, warn};
 use num::BigUint;
 
 use move_lang::{expansion::ast as EA, parser::ast as PA, shared::AddressBytes};
+use move_symbol_pool::Symbol as MoveStringSymbol;
 
 use crate::{
     ast::{ModuleName, Operation, QualifiedSymbol, Spec, Value},
@@ -36,7 +37,7 @@ pub(crate) struct ModelBuilder<'env> {
     /// The global environment we are building.
     pub env: &'env mut GlobalEnv,
     /// Set of known named addresses provided by the compiler
-    pub named_address_mapping: BTreeMap<String, AddressBytes>,
+    pub named_address_mapping: BTreeMap<MoveStringSymbol, AddressBytes>,
     /// A symbol table for specification functions. Because of overloading, and entry can
     /// contain multiple functions.
     pub spec_fun_table: BTreeMap<QualifiedSymbol, Vec<SpecFunEntry>>,
@@ -132,7 +133,7 @@ impl<'env> ModelBuilder<'env> {
     /// Creates a builders.
     pub fn new(
         env: &'env mut GlobalEnv,
-        named_address_mapping: BTreeMap<String, AddressBytes>,
+        named_address_mapping: BTreeMap<MoveStringSymbol, AddressBytes>,
     ) -> Self {
         let mut translator = ModelBuilder {
             env,

--- a/language/move-model/src/builder/module_builder.rs
+++ b/language/move-model/src/builder/module_builder.rs
@@ -274,7 +274,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
     ) {
         let qsym = self.qualified_by_module_from_name(&name.0);
         let name = qsym.symbol;
-        let const_name = ConstantName::new(self.symbol_pool().string(name).to_string());
+        let const_name = ConstantName(self.symbol_pool().string(name).to_string().into());
         let const_idx = source_map
             .constant_map
             .get(&const_name)
@@ -2618,7 +2618,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                 .iter()
                 .map(|p| match &p.value {
                     PA::SpecApplyFragment_::Wildcard => ".*".to_string(),
-                    PA::SpecApplyFragment_::NamePart(n) => n.value.clone(),
+                    PA::SpecApplyFragment_::NamePart(n) => n.value.to_string(),
                 })
                 .join("")
         ))

--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -54,7 +54,7 @@ use move_binary_format::{
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, language_storage, value::MoveValue,
 };
-use move_symbol_pool::Symbol as StringSymbol;
+use move_symbol_pool::Symbol as MoveStringSymbol;
 
 use crate::{
     ast::{
@@ -514,7 +514,7 @@ impl GlobalEnv {
             )
         };
         let unknown_loc = fake_loc("<unknown>");
-        let unknown_move_ir_loc = MoveIrLoc::new(StringSymbol::from("<unknown>"), 0, 0);
+        let unknown_move_ir_loc = MoveIrLoc::new(MoveStringSymbol::from("<unknown>"), 0, 0);
         let internal_loc = fake_loc("<internal>");
         GlobalEnv {
             source_files,
@@ -742,7 +742,7 @@ impl GlobalEnv {
     }
 
     /// Returns the file id for a file name, if defined.
-    pub fn get_file_id(&self, fname: StringSymbol) -> Option<FileId> {
+    pub fn get_file_id(&self, fname: MoveStringSymbol) -> Option<FileId> {
         self.file_name_map.get(fname.as_str()).cloned()
     }
 

--- a/language/testing-infra/module-generation/Cargo.toml
+++ b/language/testing-infra/module-generation/Cargo.toml
@@ -18,6 +18,7 @@ move-core-types = { path = "../../move-core/types" }
 move-ir-types = { path = "../../move-ir/types" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-binary-format = { path = "../../move-binary-format" }
+move-symbol-pool = { path = "../../move-symbol-pool" }
 
 [features]
 default = []

--- a/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -28,6 +28,7 @@ use move_lang::{
     FullyCompiledProgram,
 };
 use move_stdlib::move_stdlib_named_addresses;
+use move_symbol_pool::Symbol;
 use move_vm_runtime::{move_vm::MoveVM, session::Session};
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::gas_schedule::GasStatus;
@@ -104,12 +105,12 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
             .unwrap();
         let mut addr_to_name_mapping = BTreeMap::new();
         for (name, addr) in move_stdlib_named_addresses() {
-            let prev = addr_to_name_mapping.insert(addr, name);
+            let prev = addr_to_name_mapping.insert(addr, Symbol::from(name));
             assert!(prev.is_none());
         }
         for module in &*MOVE_STDLIB_COMPILED {
             let bytes = AddressBytes::new(module.address().to_u8());
-            let named_addr = addr_to_name_mapping.get(&bytes).unwrap().clone();
+            let named_addr = *addr_to_name_mapping.get(&bytes).unwrap();
             adapter.compiled_state.add(Some(named_addr), module.clone());
         }
         adapter

--- a/language/tools/move-cli/Cargo.toml
+++ b/language/tools/move-cli/Cargo.toml
@@ -30,6 +30,7 @@ move-coverage = { path = "../move-coverage" }
 move-core-types = { path = "../../move-core/types" }
 move-lang = { path = "../../move-lang" }
 move-stdlib = { path = "../../move-stdlib", features = ["testing"] }
+move-symbol-pool = { path = "../../move-symbol-pool" }
 move-vm-types = { path = "../../move-vm/types" }
 move-vm-runtime = { path = "../../move-vm/runtime" }
 read-write-set = { path = "../read-write-set" }

--- a/language/tools/move-cli/src/sandbox/commands/publish.rs
+++ b/language/tools/move-cli/src/sandbox/commands/publish.rs
@@ -63,7 +63,7 @@ pub fn publish(
             .iter()
             .map(|(ident, module)| {
                 let id = module.self_id();
-                (id, ident.address_name.as_ref().map(|n| n.value.clone()))
+                (id, ident.address_name.as_ref().map(|n| n.value))
             })
             .collect();
 
@@ -92,7 +92,7 @@ pub fn publish(
             Some(ordering) => {
                 let module_map: BTreeMap<_, _> = modules
                     .into_iter()
-                    .map(|(ident, m)| (ident.module_name.0.value, m))
+                    .map(|(ident, m)| (ident.module_name.0.value.to_string(), m))
                     .collect();
 
                 let mut sender_opt = None;
@@ -138,7 +138,7 @@ pub fn publish(
             let modules: Vec<_> = changeset
                 .into_modules()
                 .map(|(module_id, blob_opt)| {
-                    let addr_name = id_to_ident[&module_id].clone();
+                    let addr_name = id_to_ident[&module_id];
                     let ident = (module_id, addr_name);
                     (ident, blob_opt.expect("must be non-deletion"))
                 })

--- a/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
+++ b/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
@@ -18,6 +18,7 @@ use move_core_types::{
     resolver::{ModuleResolver, ResourceResolver},
 };
 use move_lang::{shared::AddressBytes, MOVE_COMPILED_INTERFACES_DIR};
+use move_symbol_pool::Symbol;
 use resource_viewer::{AnnotatedMoveStruct, AnnotatedMoveValue, MoveValueAnnotator};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -36,7 +37,7 @@ pub const MODULES_DIR: &str = "modules";
 /// subdirectory of `DEFAULT_STORAGE_DIR`/<addr> where events are stored
 pub const EVENTS_DIR: &str = "events";
 
-pub type ModuleIdWithNamedAddress = (ModuleId, Option<String>);
+pub type ModuleIdWithNamedAddress = (ModuleId, Option<Symbol>);
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub(crate) struct InterfaceFilesMetadata {
@@ -437,7 +438,8 @@ impl OnDiskStateView {
         let mut is_empty = true;
         for ((module_id, address_name_opt), module_bytes) in modules {
             self.save_module(module_id, module_bytes)?;
-            named_address_mapping_changes.insert(module_id.clone(), address_name_opt.clone());
+            named_address_mapping_changes
+                .insert(module_id.clone(), address_name_opt.map(|n| n.to_string()));
             is_empty = false;
         }
 


### PR DESCRIPTION
- Use move-symbol-pool's Symbol for all strings in the IR and source language ASTs
- After fixing everything, I hit a wall of clippy errors. about 75% of the way through, I realized I should have added the `Copy` trait to these items in a separate PR. So sorry about that... luckily the changes are mostly mechanical. 

## Motivation

Should reduce the memory overhead of the Move compiler (greatly if Rust can't optimize this well). But I have not gotten memory profiling working yet. 

Runtime perf in debug builds was a wash. But increased perf by about 30% in release builds!
Unfortunately, the overhead of interning is an issue with `nextest` as they each test operates in their own binary (I've been told).
```
dev build DF+Std (averaged over 10 iterations)
OLD       3.058s
INTERNED  2.833s
REDUCTION -7.36%

release build DF+Std (averaged over 100 iterations)
OLD       0.292s
INTERNED  0.205s
REDUCTION -29.8%

nextest -p move-lang
OLD       29.937s
INTERNED  33.230s
INCREASE  +11.00%

nextest -p move-lang-functional-tests
OLD       210.312s
INTERNED  237.315s
INCREASE  +12.840%

nextest -p move-prover
OLD       458.118s
INTERNED  480.420s
INCREASE  +4.5812%

x test -p move-lang
OLD       8.615s
INTERNED  8.541s
-         -

x test -p move-lang-functional-tests
OLD       44.905s
INTERNED  44.897s
-         -

x test -p move-prover
OLD       332.042s
INTERNED  317.463s
REDUCTION -4.3907%
```

## Test Plan

- Ran tests
- Looked at perf
