### PR TITLE
[reconfiguration] fix bug caused by #8484

### DIFF
--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -78,7 +78,7 @@ impl StateComputer for ExecutionProxy {
         for block in blocks {
             block_ids.push(block.id());
             txns.extend(block.transactions_to_commit());
-            reconfig_events.extend(block.compute_result().reconfig_events().to_vec());
+            reconfig_events.extend(block.reconfig_event());
         }
 
         monitor!(


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The bug is that we expect a compute result for every transaction in the block,
without considering the fact that if a block is suffix of a reconfiguration block, its
compute result is carried from its parent and should be viewed as empty.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

ENABLE_FAILPOINTS=1 ./scripts/cti --pr 8879 --run reconfiguration

Reconfiguration: total epoch: 101 finished in 131 seconds

## Related PRs

(If this PR adds or changes functionality, please take some time to update or suggest changes to the docs at https://developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
