### PR TITLE
[verifying-client] Push retries up to Verifying Client

### DIFF
--- a/sdk/client/src/blocking.rs
+++ b/sdk/client/src/blocking.rs
@@ -26,7 +26,7 @@ use diem_types::{
 };
 use move_core_types::move_resource::{MoveResource, MoveStructType};
 use serde::{de::DeserializeOwned, Serialize};
-use std::time::Duration;
+use std::{mem, time::Duration};
 
 // In order to avoid needing to publish the proxy crate to crates.io we simply include the small
 // library in inline by making it a module instead of a dependency. 'src/proxy.rs' is a symlink to
@@ -50,6 +50,11 @@ impl BlockingClient {
             state: StateManager::new(),
             retry: Retry::default(),
         }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn take_retry(&mut self) -> Retry {
+        mem::replace(&mut self.retry, Retry::none())
     }
 
     pub fn last_known_state(&self) -> Option<State> {

--- a/sdk/client/src/client.rs
+++ b/sdk/client/src/client.rs
@@ -27,7 +27,7 @@ use diem_types::{
 use move_core_types::move_resource::{MoveResource, MoveStructType};
 use reqwest::Client as ReqwestClient;
 use serde::{de::DeserializeOwned, Serialize};
-use std::time::Duration;
+use std::{mem, time::Duration};
 
 #[derive(Clone, Debug)]
 pub struct Client {
@@ -54,6 +54,10 @@ impl Client {
             state: StateManager::new(),
             retry,
         }
+    }
+
+    pub(crate) fn take_retry(&mut self) -> Retry {
+        mem::replace(&mut self.retry, Retry::none())
     }
 
     pub fn last_known_state(&self) -> Option<State> {

--- a/sdk/client/src/retry.rs
+++ b/sdk/client/src/retry.rs
@@ -24,6 +24,10 @@ impl Retry {
         Self { max_retries, delay }
     }
 
+    pub fn none() -> Self {
+        Self::new(0, Duration::ZERO)
+    }
+
     pub fn max_retries(&self) -> u32 {
         self.max_retries
     }


### PR DESCRIPTION
+ The main benefit here is: a client that's a bit far behind can retry
the `NeedSync` errors without any extra effort.