### PR TITLE
[move-prover] generic invariant processing pipeline

### DIFF
--- a/language/move-model/src/ast.rs
+++ b/language/move-model/src/ast.rs
@@ -648,7 +648,8 @@ impl ExpData {
                 t.visit_pre_post(visitor);
                 e.visit_pre_post(visitor);
             }
-            _ => {}
+            // Explicitly list all enum variants
+            Value(..) | LocalVar(..) | Temporary(..) | SpecVar(..) | Invalid(..) => {}
         }
         visitor(true, self);
     }

--- a/language/move-model/src/ast.rs
+++ b/language/move-model/src/ast.rs
@@ -935,6 +935,18 @@ impl ExpData {
         self.visit(&mut visitor);
         is_pure
     }
+
+    /// Checks whether the expression involves a generic type.
+    pub fn is_generic(&self, env: &GlobalEnv) -> bool {
+        self.used_memory(env).into_iter().any(|(mem, _)| {
+            mem.inst.into_iter().any(|ty| {
+                ty.is_generic(
+                    /* treat_type_param_as_open */ false,
+                    /* treat_type_local_as_open */ true,
+                )
+            })
+        })
+    }
 }
 
 // =================================================================================================

--- a/language/move-model/src/builder/exp_translator.rs
+++ b/language/move-model/src/builder/exp_translator.rs
@@ -33,6 +33,10 @@ pub(crate) struct ExpTranslator<'env, 'translator, 'module_translator> {
     pub type_params_table: BTreeMap<Symbol, Type>,
     /// Type parameters in sequence they have been added.
     pub type_params: Vec<(Symbol, Type)>,
+    /// A symbol table for type locals.
+    pub type_locals_table: BTreeMap<Symbol, Type>,
+    /// Type locals for this exp translation context in the order they are added
+    pub type_locals: Vec<Type>,
     /// A scoped symbol table for local names. The first element in the list contains the most
     /// inner scope.
     pub local_table: LinkedList<BTreeMap<Symbol, LocalVarEntry>>,
@@ -77,6 +81,8 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
             parent,
             type_params_table: BTreeMap::new(),
             type_params: vec![],
+            type_locals_table: BTreeMap::new(),
+            type_locals: vec![],
             local_table: LinkedList::new(),
             result_type: None,
             old_status: OldExpStatus::NotSupported,
@@ -329,12 +335,90 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
 
     /// Defines a type parameter.
     pub fn define_type_param(&mut self, loc: &Loc, name: Symbol, ty: Type) {
-        self.type_params.push((name, ty.clone()));
-        if self.type_params_table.insert(name, ty).is_some() {
+        if let Type::TypeParameter(..) = &ty {
+            if self.type_locals_table.contains_key(&name) {
+                let param_name = name.display(self.symbol_pool());
+                self.parent.parent.error(
+                    loc,
+                    &format!(
+                        "duplicate declaration of type parameter `{}`, \
+                        previously found in type locals",
+                        param_name
+                    ),
+                );
+                return;
+            }
+            if self.type_params_table.insert(name, ty.clone()).is_some() {
+                let param_name = name.display(self.symbol_pool());
+                self.parent.parent.error(
+                    loc,
+                    &format!(
+                        "duplicate declaration of type parameter `{}`, \
+                        previously found in type parameters",
+                        param_name
+                    ),
+                );
+                return;
+            }
+            self.type_params.push((name, ty));
+        } else {
             let param_name = name.display(self.symbol_pool());
-            self.parent
-                .parent
-                .error(loc, &format!("duplicate declaration of `{}`", param_name));
+            let context = TypeDisplayContext::WithEnv {
+                env: self.parent.parent.env,
+                type_param_names: None,
+            };
+            self.parent.parent.error(
+                loc,
+                &format!(
+                    "expect type placeholder `{}` to be a `TypeParameter`, found `{}`",
+                    param_name,
+                    ty.display(&context)
+                ),
+            );
+        }
+    }
+
+    /// Defines a type local.
+    pub fn define_type_local(&mut self, loc: &Loc, ty: Type) {
+        if let Type::TypeLocal(name) = &ty {
+            let name = *name;
+            if self.type_params_table.contains_key(&name) {
+                let local_name = name.display(self.symbol_pool());
+                self.parent.parent.error(
+                    loc,
+                    &format!(
+                        "duplicate declaration of type local `{}`, \
+                        previously found in type parameters",
+                        local_name
+                    ),
+                );
+                return;
+            }
+            if self.type_locals_table.insert(name, ty.clone()).is_some() {
+                let local_name = name.display(self.symbol_pool());
+                self.parent.parent.error(
+                    loc,
+                    &format!(
+                        "duplicated declaration of type local `{}`, \
+                        previously found in type locals",
+                        local_name
+                    ),
+                );
+                return;
+            }
+            self.type_locals.push(ty);
+        } else {
+            let context = TypeDisplayContext::WithEnv {
+                env: self.parent.parent.env,
+                type_param_names: None,
+            };
+            self.parent.parent.error(
+                loc,
+                &format!(
+                    "expect type generics declared in an invariant to be a `TypeLocal`, found `{}`",
+                    ty.display(&context)
+                ),
+            );
         }
     }
 
@@ -623,7 +707,13 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                     if let Some(ty) = self.type_params_table.get(&sym).cloned() {
                         return check_zero_args(self, ty);
                     }
+                    // Attempt to resolve as a type local
+                    if let Some(ty) = self.type_locals_table.get(&sym).cloned() {
+                        return check_zero_args(self, ty);
+                    }
+
                     // Attempt to resolve as a type value.
+                    // TODO(mengxu): remove this logic once porting to generic invariant is done
                     if let Some(entry) = self.lookup_local(sym, false) {
                         let ty = entry.type_.clone();
                         self.check_type(

--- a/language/move-model/src/ty.rs
+++ b/language/move-model/src/ty.rs
@@ -361,22 +361,41 @@ impl Type {
         }
     }
 
-    /// Return true if this type contains free type variables
-    pub fn is_open(&self) -> bool {
+    /// Return true if this type contains generic types (i.e., types that can be instantiated).
+    /// A caller can have finer-grained control on what can be considered as a generic type.
+    pub fn is_generic(
+        &self,
+        treat_type_param_as_open: bool,
+        treat_type_local_as_open: bool,
+    ) -> bool {
         use Type::*;
         match self {
-            TypeParameter(_) | TypeLocal(_) => true,
+            TypeParameter(_) => treat_type_param_as_open,
+            TypeLocal(_) => treat_type_local_as_open,
             Primitive(_) | ResourceDomain(..) => false,
-            Tuple(ts) => ts.iter().any(|t| t.is_open()),
-            Fun(ts, r) => ts.iter().any(|t| t.is_open()) || r.is_open(),
-            Struct(_, _, ts) => ts.iter().any(|t| t.is_open()),
-            Vector(et) => et.is_open(),
-            Reference(_, bt) => bt.is_open(),
-            TypeDomain(bt) => bt.is_open(),
+            Tuple(ts) => ts
+                .iter()
+                .any(|t| t.is_generic(treat_type_param_as_open, treat_type_local_as_open)),
+            Fun(ts, r) => {
+                ts.iter()
+                    .any(|t| t.is_generic(treat_type_param_as_open, treat_type_local_as_open))
+                    || r.is_generic(treat_type_param_as_open, treat_type_local_as_open)
+            }
+            Struct(_, _, ts) => ts
+                .iter()
+                .any(|t| t.is_generic(treat_type_param_as_open, treat_type_local_as_open)),
+            Vector(et) => et.is_generic(treat_type_param_as_open, treat_type_local_as_open),
+            Reference(_, bt) => bt.is_generic(treat_type_param_as_open, treat_type_local_as_open),
+            TypeDomain(bt) => bt.is_generic(treat_type_param_as_open, treat_type_local_as_open),
             Error | Var(_) => {
-                panic!("Invariant violation: is_open should be called after type checking")
+                panic!("Invariant violation: is_generic should be called after type checking")
             }
         }
+    }
+
+    /// Return true if this type contains generic types (i.e., types that can be instantiated).
+    pub fn is_open(&self) -> bool {
+        self.is_generic(true, true)
     }
 
     /// Compute used modules in this type, adding them to the passed set.

--- a/language/move-prover/bytecode/src/lib.rs
+++ b/language/move-prover/bytecode/src/lib.rs
@@ -26,6 +26,7 @@ pub mod graph;
 pub mod inconsistency_check;
 pub mod livevar_analysis;
 pub mod local_mono;
+pub mod local_mono_compat;
 pub mod loop_analysis;
 pub mod memory_instrumentation;
 pub mod mono_analysis;

--- a/language/move-prover/bytecode/src/lib.rs
+++ b/language/move-prover/bytecode/src/lib.rs
@@ -25,6 +25,7 @@ pub mod global_invariant_instrumentation_v2;
 pub mod graph;
 pub mod inconsistency_check;
 pub mod livevar_analysis;
+pub mod local_mono;
 pub mod loop_analysis;
 pub mod memory_instrumentation;
 pub mod mono_analysis;

--- a/language/move-prover/bytecode/src/local_mono.rs
+++ b/language/move-prover/bytecode/src/local_mono.rs
@@ -1,0 +1,428 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! A monomorphization processor for elimination of universal type quantifiers
+//! (`forall t1: type, t2: type, ..., :: P<t1, t2, ...>`) found in the expressions
+//!
+//! This mono processor is a *local monomorphization* processor, it specializes
+//! a generic proposition with types found in the enclosing function only. This
+//! complements the *global monomorphization* processor in `mono_analysis.rs`
+//! which, if schedule to run after this local mono pass, instantiate axioms
+//! (and currently existential type quantifiers also) with information obtained
+//! in the whole `GlobalEnv`.
+//!
+//! Local monomorphization can only be performed when two conditions hold:
+//!
+//! - all generic proposition are in the form of top-level universal type
+//!   quantifiers, i.e., the proposition `P` must be in the form of
+//!   `forall t1: type, t2: type, ... : expr<t1, t2, ...>` and there is no
+//!   operation over `P` (e.g., `!P`, `P ==> Q`, etc. are not allowed).
+//!
+//! - the global invariant instrumentation pass places a global invariant
+//!   `I` into all relevant instantiations of a function `F`. For example,
+//!   if `I<T>` talks about a memory `S<T>` that is also going to be touched
+//!   by `F<T>`, then `I<T>` must be instrumented in the generic version of
+//!   `F` as well as in every instantiation of `F` (e.g., `F<bool>`,
+//!   `F<u64>`, etc).
+//!
+//! If both conditions hold, we can run local monomorphization, i.e., assert
+//! properties that are only relevant to the enclosing function only and
+//! safely assume that the properties hold for all other types that are
+//! not touched by the function.
+
+use crate::{
+    function_data_builder::FunctionDataBuilder,
+    function_target::{FunctionData, FunctionTarget},
+    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
+    stackless_bytecode::Bytecode,
+    usage_analysis,
+};
+
+use move_model::{
+    ast::{Exp, ExpData, LocalVarDecl, MemoryLabel, Operation, QuantKind},
+    exp_generator::ExpGenerator,
+    model::{FunctionEnv, GlobalEnv, NodeId, QualifiedInstId, StructId},
+    symbol::Symbol,
+    ty::{PrimitiveType, Type, TypeUnificationAdapter, Variance},
+};
+
+use itertools::Itertools;
+use std::collections::{BTreeMap, BTreeSet};
+
+/// A context struct that holds/accumulates information during the monomorphization process.
+struct MonoRewriter {
+    // Collect all memory resource types that are used by this function.
+    memory_inst_usage: BTreeSet<QualifiedInstId<StructId>>,
+    // A map from memory label accessed from within the body of the quantifier
+    // which needs to be specialized to the given instances in SaveMem instructions.
+    mem_inst_by_label: BTreeMap<MemoryLabel, BTreeSet<QualifiedInstId<StructId>>>,
+}
+
+impl MonoRewriter {
+    pub fn new(target: &FunctionTarget) -> Self {
+        // the usage analysis result inherits from the generic function, therefore, we need to
+        // instantiate the types if we are processing a verification variant which represents an
+        // instantiated version of the generic function.
+        let target_inst = target.data.get_type_instantiation(target.func_env);
+        let memory_inst_usage = usage_analysis::get_used_memory_inst(target)
+            .iter()
+            .map(|mem| mem.instantiate_ref(&target_inst))
+            .collect();
+        Self {
+            memory_inst_usage,
+            mem_inst_by_label: BTreeMap::new(),
+        }
+    }
+
+    pub fn run(&mut self, builder: &mut FunctionDataBuilder) {
+        let code = std::mem::take(&mut builder.data.code);
+        for bc in code {
+            if let Bytecode::Prop(id, kind, exp) = bc {
+                let exp = self.rewrite_type_quant(builder, exp);
+                builder.emit(Bytecode::Prop(id, kind, exp));
+            } else {
+                builder.emit(bc);
+            }
+        }
+
+        // rewrite the SaveMem bytecode
+        let code = std::mem::take(&mut builder.data.code);
+        for bc in code {
+            match bc {
+                Bytecode::SaveMem(id, label, mem) => {
+                    if self.mem_inst_by_label.contains_key(&label) {
+                        for inst in self.mem_inst_by_label.get(&label).unwrap() {
+                            builder.emit(Bytecode::SaveMem(id, label, inst.to_owned()));
+                        }
+                    } else if !mem
+                        .inst
+                        .iter()
+                        .any(|ty| ty.contains(&|t| matches!(t, Type::TypeLocal(_))))
+                    {
+                        // Only retain the SaveMem if it does not contain type locals.
+                        // Such SaveMem's can result from zero expansions during quantifier
+                        // elimination, and they are dead.
+                        builder.emit(Bytecode::SaveMem(id, label, mem));
+                    }
+                }
+                _ => builder.emit(bc),
+            }
+        }
+    }
+
+    fn rewrite_type_quant(&mut self, builder: &mut FunctionDataBuilder, exp: Exp) -> Exp {
+        let env = builder.global_env();
+
+        ExpData::rewrite(exp, &mut |e| {
+            if let ExpData::Quant(node_id, kind, ranges, triggers, condition, body) = e.as_ref() {
+                let mut type_vars = BTreeSet::new();
+                for (var, range) in ranges {
+                    let ty = env.get_node_type(range.node_id());
+                    if let Type::TypeDomain(bt) = ty.skip_reference() {
+                        if matches!(bt.as_ref(), Type::Primitive(PrimitiveType::TypeValue)) {
+                            type_vars.insert(var.name);
+                        }
+                    }
+                }
+                // skip mono if there is no type qualification in this expression.
+                if type_vars.is_empty() {
+                    return Err(e);
+                }
+
+                // triggers are not allowed if this is quantification over type
+                if !triggers.is_empty() {
+                    env.error(
+                        &env.get_node_loc(*node_id),
+                        "Cannot have triggers with type value ranges",
+                    );
+                    return Err(e);
+                }
+
+                // skip mono if this is not a universal quantifier
+                match kind {
+                    QuantKind::Forall => (),
+                    QuantKind::Exists => {
+                        // existential type quantifiers cannot be locally eliminated, keep the
+                        // quantifier here and the next stage of mono analysis will eliminate it
+                        // based on information found globally.
+                        //
+                        // TODO (mengxu) need to revisit this when the generic invariant support is
+                        // ready, i.e., invariant<T, ...> will likely ban the use of existential
+                        // type quantifier all together
+                        return Err(e);
+                    }
+                    QuantKind::Choose | QuantKind::ChooseMin => {
+                        env.error(
+                            &env.get_node_loc(*node_id),
+                            "Type quantification cannot be used with a choice operator",
+                        );
+                        return Err(e);
+                    }
+                }
+
+                // eliminate the type quantifiers
+                let prop_insts = self.analyze_instantiation(
+                    env,
+                    &builder.data.type_args,
+                    condition.as_ref(),
+                    body,
+                );
+
+                let mut expanded = vec![];
+                for inst in &prop_insts {
+                    let new_exp = self.eliminate_universal_type_quantifier(
+                        env,
+                        *node_id,
+                        ranges,
+                        condition.as_ref(),
+                        body,
+                        inst,
+                    );
+                    expanded.push(new_exp);
+                }
+
+                // Compose the resulting list of expansions into a conjunction or disjunction.
+                builder.set_loc(env.get_node_loc(*node_id));
+                let combined_exp = builder
+                    .mk_join_bool(Operation::And, expanded.into_iter())
+                    .unwrap_or_else(|| builder.mk_bool_const(true));
+
+                // marks that the expression IS re-written and the rewriter SHOULD NOT
+                // descend into the sub-expressions.
+                return Ok(combined_exp);
+            }
+
+            // marks that the expression IS NOT re-written and the rewriter SHOULD descend into the
+            // sub-expressions for further processing.
+            Err(e)
+        })
+    }
+
+    // collect potential instantiations for this quantified expression
+    fn analyze_instantiation(
+        &mut self,
+        env: &GlobalEnv,
+        inst: &BTreeMap<u16, Type>,
+        cond: Option<&Exp>,
+        body: &Exp,
+    ) -> Vec<BTreeMap<Symbol, Type>> {
+        // holds possible instantiations per type local
+        let mut prop_insts = BTreeMap::new();
+
+        let exp_mems: BTreeSet<_> = cond
+            .map(|e| e.used_memory(env))
+            .unwrap_or_else(BTreeSet::new)
+            .into_iter()
+            .chain(body.used_memory(env))
+            .map(|(mem, _)| mem)
+            .collect();
+
+        for exp_mem in &exp_mems {
+            for fun_mem in &self.memory_inst_usage {
+                if exp_mem.module_id != fun_mem.module_id || exp_mem.id != fun_mem.id {
+                    continue;
+                }
+                let adapter = TypeUnificationAdapter::new_vec(
+                    &fun_mem.inst,
+                    &exp_mem.inst,
+                    /* treat_type_param_as_var */ false,
+                    /* treat_type_local_as_var */ true,
+                );
+                let rel = adapter.unify(Variance::Allow, /* shallow_subst */ false);
+                match rel {
+                    None => continue,
+                    Some((_, subst_rhs)) => {
+                        for (k, v) in subst_rhs {
+                            match k {
+                                Type::TypeLocal(local_idx) => {
+                                    let v_with_inst = match v {
+                                        Type::TypeParameter(param_idx) => inst
+                                            .get(&param_idx)
+                                            .cloned()
+                                            .unwrap_or(Type::TypeParameter(param_idx)),
+                                        _ => v,
+                                    };
+                                    prop_insts
+                                        .entry(local_idx)
+                                        .or_insert_with(BTreeSet::new)
+                                        .insert(v_with_inst);
+                                }
+                                _ => panic!("Only TypeLocal is expected in the substitution"),
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // get cartesian product of all per-local instantiations
+        let ty_locals: Vec<_> = prop_insts.keys().cloned().collect();
+        let mut all_insts = vec![];
+        for one_inst in prop_insts
+            .values()
+            .map(|tys| tys.iter())
+            .multi_cartesian_product()
+        {
+            let map_view: BTreeMap<_, _> = ty_locals
+                .iter()
+                .zip(one_inst.into_iter())
+                .map(|(s, t)| (*s, t.clone()))
+                .collect();
+            all_insts.push(map_view);
+        }
+        all_insts
+    }
+
+    // collect potential instantiations for this quantified expression
+    fn eliminate_universal_type_quantifier(
+        &mut self,
+        env: &GlobalEnv,
+        node_id: NodeId,
+        ranges: &[(LocalVarDecl, Exp)],
+        cond: Option<&Exp>,
+        body: &Exp,
+        inst: &BTreeMap<Symbol, Type>,
+    ) -> Exp {
+        // Collect remaining range variables
+        let new_ranges: Vec<_> = ranges
+            .iter()
+            .filter_map(|(v, e)| {
+                if inst.contains_key(&v.name) {
+                    None
+                } else {
+                    Some((v.clone(), e.clone()))
+                }
+            })
+            .collect();
+
+        // Create the effective proposition of the eliminated quantifier.
+        let new_prop = if new_ranges.is_empty() {
+            match cond {
+                Some(c) => {
+                    ExpData::Call(node_id, Operation::Implies, vec![c.clone(), body.clone()])
+                        .into_exp()
+                }
+                _ => body.clone(),
+            }
+        } else {
+            ExpData::Quant(
+                node_id,
+                QuantKind::Forall,
+                new_ranges,
+                vec![],
+                cond.cloned(),
+                body.clone(),
+            )
+            .into_exp()
+        };
+
+        // Instantiate the new proposition
+        let mut node_rewriter = |id: NodeId| {
+            let node_ty = env.get_node_type(id);
+            let mut new_node_ty = node_ty.clone();
+            for (name, ty) in inst {
+                new_node_ty = new_node_ty.replace_type_local(*name, ty.clone());
+            }
+            let node_inst = env.get_node_instantiation_opt(id);
+            let new_node_inst = node_inst.clone().map(|i| {
+                i.iter()
+                    .map(|t| {
+                        let mut new_t = t.clone();
+                        for (name, ty) in inst {
+                            new_t = new_t.replace_type_local(*name, ty.clone());
+                        }
+                        new_t
+                    })
+                    .collect_vec()
+            });
+            if node_ty != new_node_ty || node_inst != new_node_inst {
+                let loc = env.get_node_loc(id);
+                let new_id = env.new_node(loc, new_node_ty);
+                if let Some(inst) = new_node_inst {
+                    env.set_node_instantiation(new_id, inst);
+                }
+                Some(new_id)
+            } else {
+                None
+            }
+        };
+        let inst_prop = ExpData::rewrite_node_id(new_prop, &mut node_rewriter);
+
+        // Collect memory used by the expanded body. We need to rewrite SaveMem
+        // instructions to point to the instantiated memory.
+        inst_prop.visit(&mut |e| match e {
+            ExpData::Call(id, Operation::Global(Some(label)), _)
+            | ExpData::Call(id, Operation::Exists(Some(label)), _) => {
+                let mut node_inst = env.get_node_instantiation(*id);
+                let qid = match node_inst.pop().unwrap() {
+                    Type::Struct(mid, sid, struct_inst) => mid.qualified_inst(sid, struct_inst),
+                    t => panic!("expected `Type::Struct`, found: `{:?}`", t),
+                };
+                self.mem_inst_by_label
+                    .entry(*label)
+                    .or_default()
+                    .insert(qid);
+            }
+            ExpData::Call(id, Operation::Function(mid, fid, Some(labels)), _) => {
+                let node_inst = env.get_node_instantiation(*id);
+                let module_env = env.get_module(*mid);
+                let fun = module_env.get_spec_fun(*fid);
+                for (i, mem) in fun.used_memory.iter().enumerate() {
+                    let qid = mem.clone().instantiate(&node_inst);
+                    self.mem_inst_by_label
+                        .entry(labels[i])
+                        .or_default()
+                        .insert(qid);
+                }
+            }
+            _ => {}
+        });
+
+        inst_prop
+    }
+}
+
+/// This is the monomorphization processor that works on a function level.
+///
+/// It eliminates potential quantifiers over types by substituting those types with instantiations
+/// that are found within the function being processed.
+pub struct LocalMonoProcessor {}
+
+impl LocalMonoProcessor {
+    pub fn new() -> Box<Self> {
+        Box::new(Self {})
+    }
+}
+
+impl FunctionTargetProcessor for LocalMonoProcessor {
+    fn process(
+        &self,
+        _targets: &mut FunctionTargetsHolder,
+        fun_env: &FunctionEnv<'_>,
+        data: FunctionData,
+    ) -> FunctionData {
+        if fun_env.is_native() || fun_env.is_intrinsic() {
+            // Nothing to do.
+            return data;
+        }
+        if !data.variant.is_verified() {
+            // Only need to instrument if this is a verification variant
+            return data;
+        }
+
+        // actual monomorphization logic encapsulated in the MonoAnalyzer
+        let mut builder = FunctionDataBuilder::new(fun_env, data);
+
+        // rewrite
+        let target = builder.get_target();
+        let mut rewriter = MonoRewriter::new(&target);
+        rewriter.run(&mut builder);
+
+        // done with the monomorphization transformation
+        builder.data
+    }
+
+    fn name(&self) -> String {
+        "prop_monomorphization".to_owned()
+    }
+}

--- a/language/move-prover/bytecode/src/local_mono_compat.rs
+++ b/language/move-prover/bytecode/src/local_mono_compat.rs
@@ -1,0 +1,431 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! A monomorphization processor for elimination of universal type quantifiers
+//! (`forall t1: type, t2: type, ..., :: P<t1, t2, ...>`) found in the expressions
+//!
+//! This mono processor is a *local monomorphization* processor, it specializes
+//! a generic proposition with types found in the enclosing function only. This
+//! complements the *global monomorphization* processor in `mono_analysis.rs`
+//! which, if schedule to run after this local mono pass, instantiate axioms
+//! (and currently existential type quantifiers also) with information obtained
+//! in the whole `GlobalEnv`.
+//!
+//! Local monomorphization can only be performed when two conditions hold:
+//!
+//! - all generic proposition are in the form of top-level universal type
+//!   quantifiers, i.e., the proposition `P` must be in the form of
+//!   `forall t1: type, t2: type, ... : expr<t1, t2, ...>` and there is no
+//!   operation over `P` (e.g., `!P`, `P ==> Q`, etc. are not allowed).
+//!
+//! - the global invariant instrumentation pass places a global invariant
+//!   `I` into all relevant instantiations of a function `F`. For example,
+//!   if `I<T>` talks about a memory `S<T>` that is also going to be touched
+//!   by `F<T>`, then `I<T>` must be instrumented in the generic version of
+//!   `F` as well as in every instantiation of `F` (e.g., `F<bool>`,
+//!   `F<u64>`, etc).
+//!
+//! If both conditions hold, we can run local monomorphization, i.e., assert
+//! properties that are only relevant to the enclosing function only and
+//! safely assume that the properties hold for all other types that are
+//! not touched by the function.
+//!
+//! TODO(mengxu) this is added to maintain backward compatibility while the
+//! implementation and porting of generic invariants are in progress.
+
+use crate::{
+    function_data_builder::FunctionDataBuilder,
+    function_target::{FunctionData, FunctionTarget},
+    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
+    stackless_bytecode::Bytecode,
+    usage_analysis,
+};
+
+use move_model::{
+    ast::{Exp, ExpData, LocalVarDecl, MemoryLabel, Operation, QuantKind},
+    exp_generator::ExpGenerator,
+    model::{FunctionEnv, GlobalEnv, NodeId, QualifiedInstId, StructId},
+    symbol::Symbol,
+    ty::{PrimitiveType, Type, TypeUnificationAdapter, Variance},
+};
+
+use itertools::Itertools;
+use std::collections::{BTreeMap, BTreeSet};
+
+/// A context struct that holds/accumulates information during the monomorphization process.
+struct MonoRewriter {
+    // Collect all memory resource types that are used by this function.
+    memory_inst_usage: BTreeSet<QualifiedInstId<StructId>>,
+    // A map from memory label accessed from within the body of the quantifier
+    // which needs to be specialized to the given instances in SaveMem instructions.
+    mem_inst_by_label: BTreeMap<MemoryLabel, BTreeSet<QualifiedInstId<StructId>>>,
+}
+
+impl MonoRewriter {
+    pub fn new(target: &FunctionTarget) -> Self {
+        // the usage analysis result inherits from the generic function, therefore, we need to
+        // instantiate the types if we are processing a verification variant which represents an
+        // instantiated version of the generic function.
+        let target_inst = target.data.get_type_instantiation(target.func_env);
+        let memory_inst_usage = usage_analysis::get_used_memory_inst(target)
+            .iter()
+            .map(|mem| mem.instantiate_ref(&target_inst))
+            .collect();
+        Self {
+            memory_inst_usage,
+            mem_inst_by_label: BTreeMap::new(),
+        }
+    }
+
+    pub fn run(&mut self, builder: &mut FunctionDataBuilder) {
+        let code = std::mem::take(&mut builder.data.code);
+        for bc in code {
+            if let Bytecode::Prop(id, kind, exp) = bc {
+                let exp = self.rewrite_type_quant(builder, exp);
+                builder.emit(Bytecode::Prop(id, kind, exp));
+            } else {
+                builder.emit(bc);
+            }
+        }
+
+        // rewrite the SaveMem bytecode
+        let code = std::mem::take(&mut builder.data.code);
+        for bc in code {
+            match bc {
+                Bytecode::SaveMem(id, label, mem) => {
+                    if self.mem_inst_by_label.contains_key(&label) {
+                        for inst in self.mem_inst_by_label.get(&label).unwrap() {
+                            builder.emit(Bytecode::SaveMem(id, label, inst.to_owned()));
+                        }
+                    } else if !mem
+                        .inst
+                        .iter()
+                        .any(|ty| ty.contains(&|t| matches!(t, Type::TypeLocal(_))))
+                    {
+                        // Only retain the SaveMem if it does not contain type locals.
+                        // Such SaveMem's can result from zero expansions during quantifier
+                        // elimination, and they are dead.
+                        builder.emit(Bytecode::SaveMem(id, label, mem));
+                    }
+                }
+                _ => builder.emit(bc),
+            }
+        }
+    }
+
+    fn rewrite_type_quant(&mut self, builder: &mut FunctionDataBuilder, exp: Exp) -> Exp {
+        let env = builder.global_env();
+
+        ExpData::rewrite(exp, &mut |e| {
+            if let ExpData::Quant(node_id, kind, ranges, triggers, condition, body) = e.as_ref() {
+                let mut type_vars = BTreeSet::new();
+                for (var, range) in ranges {
+                    let ty = env.get_node_type(range.node_id());
+                    if let Type::TypeDomain(bt) = ty.skip_reference() {
+                        if matches!(bt.as_ref(), Type::Primitive(PrimitiveType::TypeValue)) {
+                            type_vars.insert(var.name);
+                        }
+                    }
+                }
+                // skip mono if there is no type qualification in this expression.
+                if type_vars.is_empty() {
+                    return Err(e);
+                }
+
+                // triggers are not allowed if this is quantification over type
+                if !triggers.is_empty() {
+                    env.error(
+                        &env.get_node_loc(*node_id),
+                        "Cannot have triggers with type value ranges",
+                    );
+                    return Err(e);
+                }
+
+                // skip mono if this is not a universal quantifier
+                match kind {
+                    QuantKind::Forall => (),
+                    QuantKind::Exists => {
+                        // existential type quantifiers cannot be locally eliminated, keep the
+                        // quantifier here and the next stage of mono analysis will eliminate it
+                        // based on information found globally.
+                        //
+                        // TODO (mengxu) need to revisit this when the generic invariant support is
+                        // ready, i.e., invariant<T, ...> will likely ban the use of existential
+                        // type quantifier all together
+                        return Err(e);
+                    }
+                    QuantKind::Choose | QuantKind::ChooseMin => {
+                        env.error(
+                            &env.get_node_loc(*node_id),
+                            "Type quantification cannot be used with a choice operator",
+                        );
+                        return Err(e);
+                    }
+                }
+
+                // eliminate the type quantifiers
+                let prop_insts = self.analyze_instantiation(
+                    env,
+                    &builder.data.type_args,
+                    condition.as_ref(),
+                    body,
+                );
+
+                let mut expanded = vec![];
+                for inst in &prop_insts {
+                    let new_exp = self.eliminate_universal_type_quantifier(
+                        env,
+                        *node_id,
+                        ranges,
+                        condition.as_ref(),
+                        body,
+                        inst,
+                    );
+                    expanded.push(new_exp);
+                }
+
+                // Compose the resulting list of expansions into a conjunction or disjunction.
+                builder.set_loc(env.get_node_loc(*node_id));
+                let combined_exp = builder
+                    .mk_join_bool(Operation::And, expanded.into_iter())
+                    .unwrap_or_else(|| builder.mk_bool_const(true));
+
+                // marks that the expression IS re-written and the rewriter SHOULD NOT
+                // descend into the sub-expressions.
+                return Ok(combined_exp);
+            }
+
+            // marks that the expression IS NOT re-written and the rewriter SHOULD descend into the
+            // sub-expressions for further processing.
+            Err(e)
+        })
+    }
+
+    // collect potential instantiations for this quantified expression
+    fn analyze_instantiation(
+        &mut self,
+        env: &GlobalEnv,
+        inst: &BTreeMap<u16, Type>,
+        cond: Option<&Exp>,
+        body: &Exp,
+    ) -> Vec<BTreeMap<Symbol, Type>> {
+        // holds possible instantiations per type local
+        let mut prop_insts = BTreeMap::new();
+
+        let exp_mems: BTreeSet<_> = cond
+            .map(|e| e.used_memory(env))
+            .unwrap_or_else(BTreeSet::new)
+            .into_iter()
+            .chain(body.used_memory(env))
+            .map(|(mem, _)| mem)
+            .collect();
+
+        for exp_mem in &exp_mems {
+            for fun_mem in &self.memory_inst_usage {
+                if exp_mem.module_id != fun_mem.module_id || exp_mem.id != fun_mem.id {
+                    continue;
+                }
+                let adapter = TypeUnificationAdapter::new_vec(
+                    &fun_mem.inst,
+                    &exp_mem.inst,
+                    /* treat_type_param_as_var */ false,
+                    /* treat_type_local_as_var */ true,
+                );
+                let rel = adapter.unify(Variance::Allow, /* shallow_subst */ false);
+                match rel {
+                    None => continue,
+                    Some((_, subst_rhs)) => {
+                        for (k, v) in subst_rhs {
+                            match k {
+                                Type::TypeLocal(local_idx) => {
+                                    let v_with_inst = match v {
+                                        Type::TypeParameter(param_idx) => inst
+                                            .get(&param_idx)
+                                            .cloned()
+                                            .unwrap_or(Type::TypeParameter(param_idx)),
+                                        _ => v,
+                                    };
+                                    prop_insts
+                                        .entry(local_idx)
+                                        .or_insert_with(BTreeSet::new)
+                                        .insert(v_with_inst);
+                                }
+                                _ => panic!("Only TypeLocal is expected in the substitution"),
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // get cartesian product of all per-local instantiations
+        let ty_locals: Vec<_> = prop_insts.keys().cloned().collect();
+        let mut all_insts = vec![];
+        for one_inst in prop_insts
+            .values()
+            .map(|tys| tys.iter())
+            .multi_cartesian_product()
+        {
+            let map_view: BTreeMap<_, _> = ty_locals
+                .iter()
+                .zip(one_inst.into_iter())
+                .map(|(s, t)| (*s, t.clone()))
+                .collect();
+            all_insts.push(map_view);
+        }
+        all_insts
+    }
+
+    // collect potential instantiations for this quantified expression
+    fn eliminate_universal_type_quantifier(
+        &mut self,
+        env: &GlobalEnv,
+        node_id: NodeId,
+        ranges: &[(LocalVarDecl, Exp)],
+        cond: Option<&Exp>,
+        body: &Exp,
+        inst: &BTreeMap<Symbol, Type>,
+    ) -> Exp {
+        // Collect remaining range variables
+        let new_ranges: Vec<_> = ranges
+            .iter()
+            .filter_map(|(v, e)| {
+                if inst.contains_key(&v.name) {
+                    None
+                } else {
+                    Some((v.clone(), e.clone()))
+                }
+            })
+            .collect();
+
+        // Create the effective proposition of the eliminated quantifier.
+        let new_prop = if new_ranges.is_empty() {
+            match cond {
+                Some(c) => {
+                    ExpData::Call(node_id, Operation::Implies, vec![c.clone(), body.clone()])
+                        .into_exp()
+                }
+                _ => body.clone(),
+            }
+        } else {
+            ExpData::Quant(
+                node_id,
+                QuantKind::Forall,
+                new_ranges,
+                vec![],
+                cond.cloned(),
+                body.clone(),
+            )
+            .into_exp()
+        };
+
+        // Instantiate the new proposition
+        let mut node_rewriter = |id: NodeId| {
+            let node_ty = env.get_node_type(id);
+            let mut new_node_ty = node_ty.clone();
+            for (name, ty) in inst {
+                new_node_ty = new_node_ty.replace_type_local(*name, ty.clone());
+            }
+            let node_inst = env.get_node_instantiation_opt(id);
+            let new_node_inst = node_inst.clone().map(|i| {
+                i.iter()
+                    .map(|t| {
+                        let mut new_t = t.clone();
+                        for (name, ty) in inst {
+                            new_t = new_t.replace_type_local(*name, ty.clone());
+                        }
+                        new_t
+                    })
+                    .collect_vec()
+            });
+            if node_ty != new_node_ty || node_inst != new_node_inst {
+                let loc = env.get_node_loc(id);
+                let new_id = env.new_node(loc, new_node_ty);
+                if let Some(inst) = new_node_inst {
+                    env.set_node_instantiation(new_id, inst);
+                }
+                Some(new_id)
+            } else {
+                None
+            }
+        };
+        let inst_prop = ExpData::rewrite_node_id(new_prop, &mut node_rewriter);
+
+        // Collect memory used by the expanded body. We need to rewrite SaveMem
+        // instructions to point to the instantiated memory.
+        inst_prop.visit(&mut |e| match e {
+            ExpData::Call(id, Operation::Global(Some(label)), _)
+            | ExpData::Call(id, Operation::Exists(Some(label)), _) => {
+                let mut node_inst = env.get_node_instantiation(*id);
+                let qid = match node_inst.pop().unwrap() {
+                    Type::Struct(mid, sid, struct_inst) => mid.qualified_inst(sid, struct_inst),
+                    t => panic!("expected `Type::Struct`, found: `{:?}`", t),
+                };
+                self.mem_inst_by_label
+                    .entry(*label)
+                    .or_default()
+                    .insert(qid);
+            }
+            ExpData::Call(id, Operation::Function(mid, fid, Some(labels)), _) => {
+                let node_inst = env.get_node_instantiation(*id);
+                let module_env = env.get_module(*mid);
+                let fun = module_env.get_spec_fun(*fid);
+                for (i, mem) in fun.used_memory.iter().enumerate() {
+                    let qid = mem.clone().instantiate(&node_inst);
+                    self.mem_inst_by_label
+                        .entry(labels[i])
+                        .or_default()
+                        .insert(qid);
+                }
+            }
+            _ => {}
+        });
+
+        inst_prop
+    }
+}
+
+/// This is the monomorphization processor that works on a function level.
+///
+/// It eliminates potential quantifiers over types by substituting those types with instantiations
+/// that are found within the function being processed.
+pub struct LocalMonoCompatProcessor {}
+
+impl LocalMonoCompatProcessor {
+    pub fn new() -> Box<Self> {
+        Box::new(Self {})
+    }
+}
+
+impl FunctionTargetProcessor for LocalMonoCompatProcessor {
+    fn process(
+        &self,
+        _targets: &mut FunctionTargetsHolder,
+        fun_env: &FunctionEnv<'_>,
+        data: FunctionData,
+    ) -> FunctionData {
+        if fun_env.is_native() || fun_env.is_intrinsic() {
+            // Nothing to do.
+            return data;
+        }
+        if !data.variant.is_verified() {
+            // Only need to instrument if this is a verification variant
+            return data;
+        }
+
+        // actual monomorphization logic encapsulated in the MonoAnalyzer
+        let mut builder = FunctionDataBuilder::new(fun_env, data);
+
+        // rewrite
+        let target = builder.get_target();
+        let mut rewriter = MonoRewriter::new(&target);
+        rewriter.run(&mut builder);
+
+        // done with the monomorphization transformation
+        builder.data
+    }
+
+    fn name(&self) -> String {
+        "local_monomorphization_compat".to_owned()
+    }
+}

--- a/language/move-prover/bytecode/src/pipeline_factory.rs
+++ b/language/move-prover/bytecode/src/pipeline_factory.rs
@@ -12,6 +12,7 @@ use crate::{
     global_invariant_instrumentation_v2::GlobalInvariantInstrumentationProcessorV2,
     inconsistency_check::InconsistencyCheckInstrumenter,
     livevar_analysis::LiveVarAnalysisProcessor,
+    local_mono::LocalMonoProcessor,
     loop_analysis::LoopAnalysisProcessor,
     memory_instrumentation::MemoryInstrumentationProcessor,
     mono_analysis::MonoAnalysisProcessor,
@@ -57,6 +58,7 @@ pub fn default_pipeline_with_options(options: &ProverOptions) -> FunctionTargetP
         processors.insert(0, MutationTester::new()); // pass which may do nothing
     }
     if options.run_mono {
+        processors.push(LocalMonoProcessor::new());
         processors.push(MonoAnalysisProcessor::new());
     }
     // inconsistency check instrumentation should be the last one in the pipeline

--- a/language/move-prover/bytecode/src/pipeline_factory.rs
+++ b/language/move-prover/bytecode/src/pipeline_factory.rs
@@ -13,6 +13,7 @@ use crate::{
     inconsistency_check::InconsistencyCheckInstrumenter,
     livevar_analysis::LiveVarAnalysisProcessor,
     local_mono::LocalMonoProcessor,
+    local_mono_compat::LocalMonoCompatProcessor,
     loop_analysis::LoopAnalysisProcessor,
     memory_instrumentation::MemoryInstrumentationProcessor,
     mono_analysis::MonoAnalysisProcessor,
@@ -58,6 +59,12 @@ pub fn default_pipeline_with_options(options: &ProverOptions) -> FunctionTargetP
         processors.insert(0, MutationTester::new()); // pass which may do nothing
     }
     if options.run_mono {
+        // NOTE: the compat processor must appear before the non-compat one.
+        // - The compat processor will eliminate all and only universally type quantified exps.
+        // - The non-compat process will eliminate *any* exp that has a generic type in it.
+        //
+        // TODO(mengxu) remove the compat processor after the generic invariant feature is done
+        processors.push(LocalMonoCompatProcessor::new());
         processors.push(LocalMonoProcessor::new());
         processors.push(MonoAnalysisProcessor::new());
     }

--- a/language/move-prover/tests/sources/functional/generic_invariants.exp
+++ b/language/move-prover/tests/sources/functional/generic_invariants.exp
@@ -1,0 +1,296 @@
+Move prover returns: exiting with boogie verification errors
+error: global memory invariant does not hold
+   ┌─ tests/sources/functional/generic_invariants.move:34:5
+   │
+34 │ ╭     invariant
+35 │ │         exists<S::Storage<u64, bool>>(@0x22)
+36 │ │             ==> global<S::Storage<u64, bool>>(@0x22).x == 1;
+   │ ╰────────────────────────────────────────────────────────────^
+   │
+   =     at tests/sources/functional/generic_invariants.move:10: publish_u64_bool
+   =         account = <redacted>
+   =         x = <redacted>
+   =         y = <redacted>
+   =     at tests/sources/functional/generic_invariants.move:11: publish_u64_bool
+   =     at tests/sources/functional/generic_invariants.move:10: publish_u64_bool
+   =     at tests/sources/functional/generic_invariants.move:11: publish_u64_bool
+   =     at tests/sources/functional/generic_invariants.move:34
+
+error: global memory invariant does not hold
+   ┌─ tests/sources/functional/generic_invariants.move:39:5
+   │
+39 │ ╭     invariant<y>
+40 │ │         exists<S::Storage<u64, y>>(@0x23)
+41 │ │             ==> global<S::Storage<u64, y>>(@0x23).x > 0;
+   │ ╰────────────────────────────────────────────────────────^
+   │
+   =     at tests/sources/functional/generic_invariants.move:10: publish_u64_bool
+   =         account = <redacted>
+   =         x = <redacted>
+   =         y = <redacted>
+   =     at tests/sources/functional/generic_invariants.move:11: publish_u64_bool
+   =     at tests/sources/functional/generic_invariants.move:10: publish_u64_bool
+   =     at tests/sources/functional/generic_invariants.move:11: publish_u64_bool
+   =     at tests/sources/functional/generic_invariants.move:34
+   =     at tests/sources/functional/generic_invariants.move:39
+
+error: global memory invariant does not hold
+   ┌─ tests/sources/functional/generic_invariants.move:44:5
+   │
+44 │ ╭     invariant<x>
+45 │ │         exists<S::Storage<x, bool>>(@0x24)
+46 │ │             ==> global<S::Storage<x, bool>>(@0x24).y;
+   │ ╰─────────────────────────────────────────────────────^
+   │
+   =     at tests/sources/functional/generic_invariants.move:10: publish_u64_bool
+   =         account = <redacted>
+   =         x = <redacted>
+   =         y = <redacted>
+   =     at tests/sources/functional/generic_invariants.move:11: publish_u64_bool
+   =     at tests/sources/functional/generic_invariants.move:10: publish_u64_bool
+   =     at tests/sources/functional/generic_invariants.move:11: publish_u64_bool
+   =     at tests/sources/functional/generic_invariants.move:34
+   =     at tests/sources/functional/generic_invariants.move:39
+   =     at tests/sources/functional/generic_invariants.move:44
+
+error: global memory invariant does not hold
+   ┌─ tests/sources/functional/generic_invariants.move:49:5
+   │
+49 │ ╭     invariant<x, y>
+50 │ │         (exists<S::Storage<x, y>>(@0x25) && exists<S::Storage<x, y>>(@0x26))
+51 │ │             ==> global<S::Storage<x, y>>(@0x25) == global<S::Storage<x, y>>(@0x26);
+   │ ╰───────────────────────────────────────────────────────────────────────────────────^
+   │
+   =     at tests/sources/functional/generic_invariants.move:10: publish_u64_bool
+   =         account = <redacted>
+   =         x = <redacted>
+   =         y = <redacted>
+   =     at tests/sources/functional/generic_invariants.move:11: publish_u64_bool
+   =     at tests/sources/functional/generic_invariants.move:10: publish_u64_bool
+   =     at tests/sources/functional/generic_invariants.move:11: publish_u64_bool
+   =     at tests/sources/functional/generic_invariants.move:34
+   =     at tests/sources/functional/generic_invariants.move:39
+   =     at tests/sources/functional/generic_invariants.move:44
+   =     at tests/sources/functional/generic_invariants.move:49
+
+error: global memory invariant does not hold
+   ┌─ tests/sources/functional/generic_invariants.move:39:5
+   │
+39 │ ╭     invariant<y>
+40 │ │         exists<S::Storage<u64, y>>(@0x23)
+41 │ │             ==> global<S::Storage<u64, y>>(@0x23).x > 0;
+   │ ╰────────────────────────────────────────────────────────^
+   │
+   =     at tests/sources/functional/generic_invariants.move:15: publish_u64_y
+   =         account = <redacted>
+   =         x = <redacted>
+   =         y = <redacted>
+   =     at tests/sources/functional/generic_invariants.move:16: publish_u64_y
+   =     at tests/sources/functional/generic_invariants.move:15: publish_u64_y
+   =     at tests/sources/functional/generic_invariants.move:16: publish_u64_y
+   =     at tests/sources/functional/generic_invariants.move:34
+   =     at tests/sources/functional/generic_invariants.move:39
+
+error: global memory invariant does not hold
+   ┌─ tests/sources/functional/generic_invariants.move:49:5
+   │
+49 │ ╭     invariant<x, y>
+50 │ │         (exists<S::Storage<x, y>>(@0x25) && exists<S::Storage<x, y>>(@0x26))
+51 │ │             ==> global<S::Storage<x, y>>(@0x25) == global<S::Storage<x, y>>(@0x26);
+   │ ╰───────────────────────────────────────────────────────────────────────────────────^
+   │
+   =     at tests/sources/functional/generic_invariants.move:15: publish_u64_y
+   =         account = <redacted>
+   =         x = <redacted>
+   =         y = <redacted>
+   =     at tests/sources/functional/generic_invariants.move:16: publish_u64_y
+   =     at tests/sources/functional/generic_invariants.move:15: publish_u64_y
+   =     at tests/sources/functional/generic_invariants.move:16: publish_u64_y
+   =     at tests/sources/functional/generic_invariants.move:34
+   =     at tests/sources/functional/generic_invariants.move:39
+   =     at tests/sources/functional/generic_invariants.move:44
+   =     at tests/sources/functional/generic_invariants.move:49
+
+error: global memory invariant does not hold
+   ┌─ tests/sources/functional/generic_invariants.move:34:5
+   │
+34 │ ╭     invariant
+35 │ │         exists<S::Storage<u64, bool>>(@0x22)
+36 │ │             ==> global<S::Storage<u64, bool>>(@0x22).x == 1;
+   │ ╰────────────────────────────────────────────────────────────^
+   │
+   =     at tests/sources/functional/generic_invariants.move:15: publish_u64_y
+   =         account = <redacted>
+   =         x = <redacted>
+   =         y = <redacted>
+   =     at tests/sources/functional/generic_invariants.move:16: publish_u64_y
+   =     at tests/sources/functional/generic_invariants.move:15: publish_u64_y
+   =     at tests/sources/functional/generic_invariants.move:16: publish_u64_y
+   =     at tests/sources/functional/generic_invariants.move:34
+
+error: global memory invariant does not hold
+   ┌─ tests/sources/functional/generic_invariants.move:44:5
+   │
+44 │ ╭     invariant<x>
+45 │ │         exists<S::Storage<x, bool>>(@0x24)
+46 │ │             ==> global<S::Storage<x, bool>>(@0x24).y;
+   │ ╰─────────────────────────────────────────────────────^
+   │
+   =     at tests/sources/functional/generic_invariants.move:15: publish_u64_y
+   =         account = <redacted>
+   =         x = <redacted>
+   =         y = <redacted>
+   =     at tests/sources/functional/generic_invariants.move:16: publish_u64_y
+   =     at tests/sources/functional/generic_invariants.move:15: publish_u64_y
+   =     at tests/sources/functional/generic_invariants.move:16: publish_u64_y
+   =     at tests/sources/functional/generic_invariants.move:34
+   =     at tests/sources/functional/generic_invariants.move:39
+   =     at tests/sources/functional/generic_invariants.move:44
+
+error: global memory invariant does not hold
+   ┌─ tests/sources/functional/generic_invariants.move:44:5
+   │
+44 │ ╭     invariant<x>
+45 │ │         exists<S::Storage<x, bool>>(@0x24)
+46 │ │             ==> global<S::Storage<x, bool>>(@0x24).y;
+   │ ╰─────────────────────────────────────────────────────^
+   │
+   =     at tests/sources/functional/generic_invariants.move:20: publish_x_bool
+   =         account = <redacted>
+   =         x = <redacted>
+   =         y = <redacted>
+   =     at tests/sources/functional/generic_invariants.move:21: publish_x_bool
+   =     at tests/sources/functional/generic_invariants.move:20: publish_x_bool
+   =     at tests/sources/functional/generic_invariants.move:21: publish_x_bool
+   =     at tests/sources/functional/generic_invariants.move:34
+   =     at tests/sources/functional/generic_invariants.move:39
+   =     at tests/sources/functional/generic_invariants.move:44
+
+error: global memory invariant does not hold
+   ┌─ tests/sources/functional/generic_invariants.move:49:5
+   │
+49 │ ╭     invariant<x, y>
+50 │ │         (exists<S::Storage<x, y>>(@0x25) && exists<S::Storage<x, y>>(@0x26))
+51 │ │             ==> global<S::Storage<x, y>>(@0x25) == global<S::Storage<x, y>>(@0x26);
+   │ ╰───────────────────────────────────────────────────────────────────────────────────^
+   │
+   =     at tests/sources/functional/generic_invariants.move:20: publish_x_bool
+   =         account = <redacted>
+   =         x = <redacted>
+   =         y = <redacted>
+   =     at tests/sources/functional/generic_invariants.move:21: publish_x_bool
+   =     at tests/sources/functional/generic_invariants.move:20: publish_x_bool
+   =     at tests/sources/functional/generic_invariants.move:21: publish_x_bool
+   =     at tests/sources/functional/generic_invariants.move:34
+   =     at tests/sources/functional/generic_invariants.move:39
+   =     at tests/sources/functional/generic_invariants.move:44
+   =     at tests/sources/functional/generic_invariants.move:49
+
+error: global memory invariant does not hold
+   ┌─ tests/sources/functional/generic_invariants.move:34:5
+   │
+34 │ ╭     invariant
+35 │ │         exists<S::Storage<u64, bool>>(@0x22)
+36 │ │             ==> global<S::Storage<u64, bool>>(@0x22).x == 1;
+   │ ╰────────────────────────────────────────────────────────────^
+   │
+   =     at tests/sources/functional/generic_invariants.move:20: publish_x_bool
+   =         account = <redacted>
+   =         x = <redacted>
+   =         y = <redacted>
+   =     at tests/sources/functional/generic_invariants.move:21: publish_x_bool
+   =     at tests/sources/functional/generic_invariants.move:20: publish_x_bool
+   =     at tests/sources/functional/generic_invariants.move:21: publish_x_bool
+   =     at tests/sources/functional/generic_invariants.move:34
+
+error: global memory invariant does not hold
+   ┌─ tests/sources/functional/generic_invariants.move:39:5
+   │
+39 │ ╭     invariant<y>
+40 │ │         exists<S::Storage<u64, y>>(@0x23)
+41 │ │             ==> global<S::Storage<u64, y>>(@0x23).x > 0;
+   │ ╰────────────────────────────────────────────────────────^
+   │
+   =     at tests/sources/functional/generic_invariants.move:20: publish_x_bool
+   =         account = <redacted>
+   =         x = <redacted>
+   =         y = <redacted>
+   =     at tests/sources/functional/generic_invariants.move:21: publish_x_bool
+   =     at tests/sources/functional/generic_invariants.move:20: publish_x_bool
+   =     at tests/sources/functional/generic_invariants.move:21: publish_x_bool
+   =     at tests/sources/functional/generic_invariants.move:34
+   =     at tests/sources/functional/generic_invariants.move:39
+
+error: global memory invariant does not hold
+   ┌─ tests/sources/functional/generic_invariants.move:49:5
+   │
+49 │ ╭     invariant<x, y>
+50 │ │         (exists<S::Storage<x, y>>(@0x25) && exists<S::Storage<x, y>>(@0x26))
+51 │ │             ==> global<S::Storage<x, y>>(@0x25) == global<S::Storage<x, y>>(@0x26);
+   │ ╰───────────────────────────────────────────────────────────────────────────────────^
+   │
+   =     at tests/sources/functional/generic_invariants.move:25: publish_x_y
+   =         account = <redacted>
+   =         x = <redacted>
+   =         y = <redacted>
+   =     at tests/sources/functional/generic_invariants.move:26: publish_x_y
+   =     at tests/sources/functional/generic_invariants.move:25: publish_x_y
+   =     at tests/sources/functional/generic_invariants.move:26: publish_x_y
+   =     at tests/sources/functional/generic_invariants.move:34
+   =     at tests/sources/functional/generic_invariants.move:39
+   =     at tests/sources/functional/generic_invariants.move:44
+   =     at tests/sources/functional/generic_invariants.move:49
+
+error: global memory invariant does not hold
+   ┌─ tests/sources/functional/generic_invariants.move:39:5
+   │
+39 │ ╭     invariant<y>
+40 │ │         exists<S::Storage<u64, y>>(@0x23)
+41 │ │             ==> global<S::Storage<u64, y>>(@0x23).x > 0;
+   │ ╰────────────────────────────────────────────────────────^
+   │
+   =     at tests/sources/functional/generic_invariants.move:25: publish_x_y
+   =         account = <redacted>
+   =         x = <redacted>
+   =         y = <redacted>
+   =     at tests/sources/functional/generic_invariants.move:26: publish_x_y
+   =     at tests/sources/functional/generic_invariants.move:25: publish_x_y
+   =     at tests/sources/functional/generic_invariants.move:26: publish_x_y
+   =     at tests/sources/functional/generic_invariants.move:34
+   =     at tests/sources/functional/generic_invariants.move:39
+
+error: global memory invariant does not hold
+   ┌─ tests/sources/functional/generic_invariants.move:34:5
+   │
+34 │ ╭     invariant
+35 │ │         exists<S::Storage<u64, bool>>(@0x22)
+36 │ │             ==> global<S::Storage<u64, bool>>(@0x22).x == 1;
+   │ ╰────────────────────────────────────────────────────────────^
+   │
+   =     at tests/sources/functional/generic_invariants.move:25: publish_x_y
+   =         account = <redacted>
+   =         x = <redacted>
+   =         y = <redacted>
+   =     at tests/sources/functional/generic_invariants.move:26: publish_x_y
+   =     at tests/sources/functional/generic_invariants.move:25: publish_x_y
+   =     at tests/sources/functional/generic_invariants.move:26: publish_x_y
+   =     at tests/sources/functional/generic_invariants.move:34
+
+error: global memory invariant does not hold
+   ┌─ tests/sources/functional/generic_invariants.move:44:5
+   │
+44 │ ╭     invariant<x>
+45 │ │         exists<S::Storage<x, bool>>(@0x24)
+46 │ │             ==> global<S::Storage<x, bool>>(@0x24).y;
+   │ ╰─────────────────────────────────────────────────────^
+   │
+   =     at tests/sources/functional/generic_invariants.move:25: publish_x_y
+   =         account = <redacted>
+   =         x = <redacted>
+   =         y = <redacted>
+   =     at tests/sources/functional/generic_invariants.move:26: publish_x_y
+   =     at tests/sources/functional/generic_invariants.move:25: publish_x_y
+   =     at tests/sources/functional/generic_invariants.move:26: publish_x_y
+   =     at tests/sources/functional/generic_invariants.move:34
+   =     at tests/sources/functional/generic_invariants.move:39
+   =     at tests/sources/functional/generic_invariants.move:44

--- a/language/move-prover/tests/sources/functional/generic_invariants.move
+++ b/language/move-prover/tests/sources/functional/generic_invariants.move
@@ -1,0 +1,60 @@
+address 0x2 {
+module S {
+    struct Storage<X: store, Y: store> has key {
+        x: X,
+        y: Y,
+        v: u8,
+    }
+
+    // F1: <concrete, concrete>
+	public fun publish_u64_bool(account: signer, x: u64, y: bool) {
+	    move_to(&account, Storage { x, y, v: 0 })
+	}
+
+    // F2: <concrete, generic>
+	public fun publish_u64_y<Y: store>(account: signer, x: u64, y: Y) {
+	    move_to(&account, Storage { x, y, v: 1 })
+	}
+
+    // F3: <generic, concrete>
+	public fun publish_x_bool<X: store>(account: signer, x: X, y: bool) {
+	    move_to(&account, Storage { x, y, v: 2 })
+	}
+
+    // F4: <generic, generic>
+	public fun publish_x_y<X: store, Y: store>(account: signer, x: X, y: Y) {
+	    move_to(&account, Storage { x, y, v: 3 })
+	}
+}
+
+module A {
+    use 0x2::S;
+
+    // I1: <concrete, concrete>
+    invariant
+        exists<S::Storage<u64, bool>>(@0x22)
+            ==> global<S::Storage<u64, bool>>(@0x22).x == 1;
+
+    // I2: <concrete, generic>
+    invariant<y>
+        exists<S::Storage<u64, y>>(@0x23)
+            ==> global<S::Storage<u64, y>>(@0x23).x > 0;
+
+    // I3: <generic, concrete>
+    invariant<x>
+        exists<S::Storage<x, bool>>(@0x24)
+            ==> global<S::Storage<x, bool>>(@0x24).y;
+
+    // I4: <generic, generic>
+    invariant<x, y>
+        (exists<S::Storage<x, y>>(@0x25) && exists<S::Storage<x, y>>(@0x26))
+            ==> global<S::Storage<x, y>>(@0x25) == global<S::Storage<x, y>>(@0x26);
+
+    public fun good(account1: signer, account2: signer) {
+        S::publish_x_y<u64, bool>(account1, 1, true);
+        S::publish_x_y<u64, bool>(account2, 1, true);
+    }
+
+    // all invariants (I1-I4) should be disproved in all functions (F1-F4)
+}
+}

--- a/language/move-prover/tests/sources/functional/invariants_with_generics.exp
+++ b/language/move-prover/tests/sources/functional/invariants_with_generics.exp
@@ -56,6 +56,27 @@ error: global memory invariant does not hold
    =     at tests/sources/functional/invariants_with_generics.move:45
 
 error: global memory invariant does not hold
+   ┌─ tests/sources/functional/invariants_with_generics.move:51:5
+   │
+51 │ ╭     invariant
+52 │ │         forall t1: type, t2: type:
+53 │ │             (exists<S::Storage<t1, t2>>(@0x25) && exists<S::Storage<t1, t2>>(@0x26))
+54 │ │                 ==> global<S::Storage<t1, t2>>(@0x25) == global<S::Storage<t1, t2>>(@0x26);
+   │ ╰───────────────────────────────────────────────────────────────────────────────────────────^
+   │
+   =     at tests/sources/functional/invariants_with_generics.move:10: publish_u64_bool
+   =         account = <redacted>
+   =         x = <redacted>
+   =         y = <redacted>
+   =     at tests/sources/functional/invariants_with_generics.move:11: publish_u64_bool
+   =     at tests/sources/functional/invariants_with_generics.move:10: publish_u64_bool
+   =     at tests/sources/functional/invariants_with_generics.move:11: publish_u64_bool
+   =     at tests/sources/functional/invariants_with_generics.move:34
+   =     at tests/sources/functional/invariants_with_generics.move:39
+   =     at tests/sources/functional/invariants_with_generics.move:45
+   =     at tests/sources/functional/invariants_with_generics.move:51
+
+error: global memory invariant does not hold
    ┌─ tests/sources/functional/invariants_with_generics.move:39:5
    │
 39 │ ╭     invariant
@@ -73,6 +94,27 @@ error: global memory invariant does not hold
    =     at tests/sources/functional/invariants_with_generics.move:16: publish_u64_y
    =     at tests/sources/functional/invariants_with_generics.move:34
    =     at tests/sources/functional/invariants_with_generics.move:39
+
+error: global memory invariant does not hold
+   ┌─ tests/sources/functional/invariants_with_generics.move:51:5
+   │
+51 │ ╭     invariant
+52 │ │         forall t1: type, t2: type:
+53 │ │             (exists<S::Storage<t1, t2>>(@0x25) && exists<S::Storage<t1, t2>>(@0x26))
+54 │ │                 ==> global<S::Storage<t1, t2>>(@0x25) == global<S::Storage<t1, t2>>(@0x26);
+   │ ╰───────────────────────────────────────────────────────────────────────────────────────────^
+   │
+   =     at tests/sources/functional/invariants_with_generics.move:15: publish_u64_y
+   =         account = <redacted>
+   =         x = <redacted>
+   =         y = <redacted>
+   =     at tests/sources/functional/invariants_with_generics.move:16: publish_u64_y
+   =     at tests/sources/functional/invariants_with_generics.move:15: publish_u64_y
+   =     at tests/sources/functional/invariants_with_generics.move:16: publish_u64_y
+   =     at tests/sources/functional/invariants_with_generics.move:34
+   =     at tests/sources/functional/invariants_with_generics.move:39
+   =     at tests/sources/functional/invariants_with_generics.move:45
+   =     at tests/sources/functional/invariants_with_generics.move:51
 
 error: global memory invariant does not hold
    ┌─ tests/sources/functional/invariants_with_generics.move:34:5
@@ -132,6 +174,27 @@ error: global memory invariant does not hold
    =     at tests/sources/functional/invariants_with_generics.move:45
 
 error: global memory invariant does not hold
+   ┌─ tests/sources/functional/invariants_with_generics.move:51:5
+   │
+51 │ ╭     invariant
+52 │ │         forall t1: type, t2: type:
+53 │ │             (exists<S::Storage<t1, t2>>(@0x25) && exists<S::Storage<t1, t2>>(@0x26))
+54 │ │                 ==> global<S::Storage<t1, t2>>(@0x25) == global<S::Storage<t1, t2>>(@0x26);
+   │ ╰───────────────────────────────────────────────────────────────────────────────────────────^
+   │
+   =     at tests/sources/functional/invariants_with_generics.move:20: publish_x_bool
+   =         account = <redacted>
+   =         x = <redacted>
+   =         y = <redacted>
+   =     at tests/sources/functional/invariants_with_generics.move:21: publish_x_bool
+   =     at tests/sources/functional/invariants_with_generics.move:20: publish_x_bool
+   =     at tests/sources/functional/invariants_with_generics.move:21: publish_x_bool
+   =     at tests/sources/functional/invariants_with_generics.move:34
+   =     at tests/sources/functional/invariants_with_generics.move:39
+   =     at tests/sources/functional/invariants_with_generics.move:45
+   =     at tests/sources/functional/invariants_with_generics.move:51
+
+error: global memory invariant does not hold
    ┌─ tests/sources/functional/invariants_with_generics.move:34:5
    │
 34 │ ╭     invariant
@@ -166,6 +229,27 @@ error: global memory invariant does not hold
    =     at tests/sources/functional/invariants_with_generics.move:21: publish_x_bool
    =     at tests/sources/functional/invariants_with_generics.move:34
    =     at tests/sources/functional/invariants_with_generics.move:39
+
+error: global memory invariant does not hold
+   ┌─ tests/sources/functional/invariants_with_generics.move:51:5
+   │
+51 │ ╭     invariant
+52 │ │         forall t1: type, t2: type:
+53 │ │             (exists<S::Storage<t1, t2>>(@0x25) && exists<S::Storage<t1, t2>>(@0x26))
+54 │ │                 ==> global<S::Storage<t1, t2>>(@0x25) == global<S::Storage<t1, t2>>(@0x26);
+   │ ╰───────────────────────────────────────────────────────────────────────────────────────────^
+   │
+   =     at tests/sources/functional/invariants_with_generics.move:25: publish_x_y
+   =         account = <redacted>
+   =         x = <redacted>
+   =         y = <redacted>
+   =     at tests/sources/functional/invariants_with_generics.move:26: publish_x_y
+   =     at tests/sources/functional/invariants_with_generics.move:25: publish_x_y
+   =     at tests/sources/functional/invariants_with_generics.move:26: publish_x_y
+   =     at tests/sources/functional/invariants_with_generics.move:34
+   =     at tests/sources/functional/invariants_with_generics.move:39
+   =     at tests/sources/functional/invariants_with_generics.move:45
+   =     at tests/sources/functional/invariants_with_generics.move:51
 
 error: global memory invariant does not hold
    ┌─ tests/sources/functional/invariants_with_generics.move:39:5

--- a/language/move-prover/tests/sources/functional/invariants_with_generics.move
+++ b/language/move-prover/tests/sources/functional/invariants_with_generics.move
@@ -48,22 +48,16 @@ module A {
                 ==> global<S::Storage<t, bool>>(@0x24).y;
 
     // I4: <generic, generic>
-    // TODO (mengxu) disabled for now due to an issue with the mono backend
-    // invariant
-    //    forall t1: type, t2: type:
-    //        (exists<S::Storage<t1, t2>>(@0x25) && exists<S::Storage<t1, t2>>(@0x26))
-    //            ==> global<S::Storage<t1, t2>>(@0x25) == global<S::Storage<t1, t2>>(@0x26);
+    invariant
+        forall t1: type, t2: type:
+            (exists<S::Storage<t1, t2>>(@0x25) && exists<S::Storage<t1, t2>>(@0x26))
+                ==> global<S::Storage<t1, t2>>(@0x25) == global<S::Storage<t1, t2>>(@0x26);
 
     public fun good(account1: signer, account2: signer) {
         S::publish_x_y<u64, bool>(account1, 1, true);
         S::publish_x_y<u64, bool>(account2, 1, true);
     }
 
-    // TODO (mengxu) all invariants (I1-I4) should be disproved in all functions (F1-F4)
-    // currently,
-    // - I1-I3 are disproved in F1
-    // - I1-I3 are disproved in F2
-    // - I1-I3 are disproved in F3
-    // - I1-I3 are disproved in F4
+    // all invariants (I1-I4) should be disproved in all functions (F1-F4)
 }
 }

--- a/language/move-prover/tests/sources/regression/mono_after_global_invariant.exp
+++ b/language/move-prover/tests/sources/regression/mono_after_global_invariant.exp
@@ -1,0 +1,21 @@
+Move prover returns: exiting with boogie verification errors
+error: global memory invariant does not hold
+   ┌─ tests/sources/regression/mono_after_global_invariant.move:40:9
+   │
+40 │ ╭         invariant update
+41 │ │             Base::has_b() ==>
+42 │ │                 (forall t: type where has_r<t>(): old(has_r<t>()));
+   │ ╰───────────────────────────────────────────────────────────────────^
+   │
+   =     at tests/sources/regression/mono_after_global_invariant.move:28: put_r
+   =         s = <redacted>
+   =         v = <redacted>
+   =     at tests/sources/regression/mono_after_global_invariant.move:29: put_r
+   =     at tests/sources/regression/mono_after_global_invariant.move:9: put_b
+   =         s = <redacted>
+   =     at tests/sources/regression/mono_after_global_invariant.move:10: put_b
+   =     at tests/sources/regression/mono_after_global_invariant.move:12: put_b
+   =     at tests/sources/regression/mono_after_global_invariant.move:30: put_r
+   =     at tests/sources/regression/mono_after_global_invariant.move:28: put_r
+   =     at tests/sources/regression/mono_after_global_invariant.move:30: put_r
+   =     at tests/sources/regression/mono_after_global_invariant.move:40

--- a/language/move-prover/tests/sources/regression/mono_after_global_invariant.move
+++ b/language/move-prover/tests/sources/regression/mono_after_global_invariant.move
@@ -41,64 +41,13 @@ module Test {
             Base::has_b() ==>
                 (forall t: type where has_r<t>(): old(has_r<t>()));
 
-        // TODO: the above invariant should not verify, here is a counterexample:
+        // The above invariant should not verify, here is a counterexample:
+        //
         // suppose we starts with an empty state,
         // put_r(@0x2, false) will violate the invariant, because
         // - Base::has_b() is true,
         // - has_r<bool>() is true, but
         // - old(has_r<bool>()) is false
-
-        /*
-            note the difference on the global invariant before and after mono analysis
-
-            ==== mono-analysis result ====
-            struct Test::R = {
-              <#0>
-            }
-
-            [variant verification - after "mono_analysis"]
-            public fun Base::put_b($t0|s: signer) {
-                 var $t1: bool
-                 var $t2: Base::B
-                 var $t3: num
-              0: assume WellFormed($t0)
-              1: assume forall $rsc: ResourceDomain<Base::B>(): WellFormed($rsc)
-              2: trace_local[s]($t0)
-              3: $t1 := false
-              4: $t2 := pack Base::B($t1)
-              5: move_to<Base::B>($t2, $t0) on_abort goto 9 with $t3
-                 # global invariant at mono_after_global_invariant.move:40:9+114
-                 # VC: global memory invariant does not hold at mono_after_global_invariant.move:40:9+114
-          >>> 6: assert Implies(Base::has_b(), true)
-              7: label L1
-              8: return ()
-              9: label L2
-             10: abort($t3)
-            }
-
-             [variant verification - after "global_invariant_instrumenter_v2"]
-             public fun Base::put_b($t0|s: signer) {
-                  var $t1: bool
-                  var $t2: Base::B
-                  var $t3: num
-               0: assume WellFormed($t0)
-               1: assume forall $rsc: ResourceDomain<Base::B>(): WellFormed($rsc)
-               2: trace_local[s]($t0)
-               3: $t1 := false
-               4: $t2 := pack Base::B($t1)
-                  # state save for global update invariants
-               5: @1 := save_mem(Test::R<t>)
-               6: move_to<Base::B>($t2, $t0) on_abort goto 10 with $t3
-                  # global invariant at mono_after_global_invariant.move:40:9+114
-                  # VC: global memory invariant does not hold at mono_after_global_invariant.move:40:9+114
-           >>> 7: assert Implies(Base::has_b(), forall t: TypeDomain<type>() where Test::has_r<t>(): Test::has_r[@1]<t>())
-               8: label L1
-               9: return ()
-              10: label L2
-              11: abort($t3)
-             }
-        */
-
     }
 }
 }


### PR DESCRIPTION
This PR completes the implementation of the generic invariant processing pipeline
on the prover side. And there are a series of steps and decisions taken. Since these
decisions are all inter-connected, I think it might be good to group them all in this
single PR.

The major items are:
- Step 0: allow Move compiler to recognize the `invariant<T>` syntax [not in this PR]
- Step 1: allow `ExpTranslator` to recognize generics in expressions
- Step 2: `local` monomorphization to remove generic types in an expression
- Step 3: compatibility layer while we port everything.
The rest of the PR description is on the details of these steps.

**Step 0: allow Move compiler to recognize the `invariant<T>` syntax**
This is implemented in PR #8771

**Step 1: allow `ExpTranslator` to recognize generics in expressions**
The `ExpTranslator` now accepts two forms of generics:

- `type_params / type_params_table` represent the generic types in the
  enclosing function when translating this expression. For example, if
  the expression is associated with a `fun foo<T>()`, then `T` is
  captured as a `Type::TypeParameter` in the `type_params` store.

- `type_locals / type_locals_table` represent the generic types in the
  expression itself. For example, the expression is a generic invariant
  `invariant<t> is_operating() => exists<S<t>>(0x1)`, then the `t` is
  captured as a `Type::TypeLocal` in the `type_locals` store.

The reason we need to separate them is that the genericity come from
different sources. We use `TypeParameter` to track that the genericity
is introduced in the Move code, and re-purpose `TypeLocal` to indicate
that the genericity is introduced by the Spec code.

Besides signaling different origins, it seems necessary (or rather,
makes our lives much easier) to assign different `Type`s for generic
types coming from different sources.

Consider the following example:

```
fun foo<T>() {
    borrow_global_mut<S<T>>(@0x1, ...);
}

spec {
    invariant<T> exists<S<T>>(0x1) ==> ...;
}
```

The `T` in `foo<T>` and `invariant<T>` are essentially two different
things although they share the same symbol and positional index in the
genericity type list.

Later in the generic type elimination phase, we will see a use case
where we want to different generic types coming from different sources,
in particular, we treat type parameters from the Move code as concrete
types but type locals in the expression as generic types,

**Step 2: `local` monomorphization**
We introduce the concept of *local monomorphization*, i.e., specializing
a generic proposition with types found in the enclosing function only.

Local monomorphization can only be performed when two conditions hold:

- all generic proposition are in the form of top-level unifersal type
  quantifiers, i.e., the proposition `P` must be in the form of
  `forall t1: type, t2: type, ... : expr<t1, t2, ...>` and there is no
  operation over P (e.g., !P, P ==> Q, etc is not allowed). This is
  inperfectly enforced in this commit (via a check that the kind of the
  quantifier to be eliminated must be a forall). A more robust solution
  is to use the generic invariant notion `invariant<T>`. Which is what
  this PR is about.

- the global invariant instrumentation pass places a global invariant
  `I` into all relevant instantiations of a function `F`. For example,
  if `I<T>` talks about a memory `S<T>` that is also going to be touched
  by `F<T>`, then `I<T>` must be instrumented in the generic version of
  `F` as well as in every instantiation of `F` (e.g., `F<bool>`,
  `F<u64>`, etc).

If both conditions hold, we can run local monomorphization, i.e., assert
propositions that are only relevant to the enclosing function only and
safely assume that the propositions holds for all other types that are
not touched by the function.

**Step 3: compatible porting**
The order of generic type elimination process is the following

- `LocalMonoCompat`
  Monomorphize and eliminate all type quantified expressions
  `forall t: type ...`

- `LocalMono`
  Monomorphize and eliminate all the rest of generic expressions
  e.g., `assert exists<S<t>>(0x1)` where `t` is a `Type::TypeLocal`.

- MonoAnalysis (which I also call it GlobalMono)
  Monomorphize generic `axiom`s and collect information for the boogie
  backend translator.

## Motivation

Complete the implementation of the generic invariant processing pipeline.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- CI
- A new test case, [`generic_invariants.move`](https://github.com/mengxu-fb/libra/blob/60a00efbb4e872b90f89ed3d4dd3ec481850819b/language/move-prover/tests/sources/functional/generic_invariants.move) to demonstrate how
the generic invariant looks like.
