### PR TITLE
[CI] move sccache update to post-land

### DIFF
--- a/.github/workflows/ci-post-land.yml
+++ b/.github/workflows/ci-post-land.yml
@@ -147,7 +147,7 @@ jobs:
   build_ci_base_docker_image:
     needs: prepare
     runs-on: ubuntu-latest-xl
-    if: ${{ needs.prepare.outputs.base-image-changes == 'true' && github.event_name == 'push' }}
+    if: ${{ needs.prepare.outputs.base-image-changes == 'true' || github.event_name == 'create' }}
     continue-on-error: false
     env:
       DOCKERHUB_ORG: diem

--- a/.github/workflows/ci-post-land.yml
+++ b/.github/workflows/ci-post-land.yml
@@ -4,7 +4,7 @@ on:
   create:
     branches: [main, release-*]
   push:
-    branches: [main, release-*] # "gha-test-*"
+    branches: [main, release-*] # gha-test-*
 
 defaults:
   run:
@@ -24,7 +24,6 @@ jobs:
       changes-pull-request-number: ${{ steps.changes.outputs.changes-pull-request-number }}
       rust-changes: ${{ steps.rust-changes.outputs.changes-found }}
       base-image-changes: ${{ steps.base-image-changes.outputs.changes-found }}
-      update-osx-sccache: ${{ steps.environment.outputs.name }}
     steps:
       - uses: actions/checkout@v2.3.4
         with:
@@ -54,10 +53,40 @@ jobs:
 
   update-sccache-osx:
     needs: prepare
+    runs-on: macos-11
     environment:
       name: Sccache
-    runs-on: macos-11
-    if: ${{ needs.prepare.outputs.rust-changes == 'true' && github.event_name == 'push' }}
+    if: ${{ needs.prepare.outputs.rust-changes == 'true' }}
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          # This ensures that the tip of the PR is checked out instead of the merge between the base ref and the tip
+          # On `push` this value will be empty and will "do-the-right-thing"
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0 #get all the history!!!
+      - uses: ./.github/actions/build-setup
+      - uses: actions/cache@v2.1.6
+        with:
+          path: "/opt/cargo/git\n/opt/cargo/registry\n/opt/cargo/.package-cache"
+          key: crates-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: "crates-${{ runner.os }}"
+      - name: build all unit test code.
+        run: |
+          $pre_command && cargo x test --no-run --jobs ${max_threads} --unit
+        env:
+          TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
+          SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.ENV_DIEM_S3_AWS_ACCESS_KEY_ID }}
+          SCCACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.ENV_DIEM_S3_AWS_SECRET_ACCESS_KEY }}
+      - uses: ./.github/actions/build-teardown
+
+  update-sccache-ubuntu:
+    needs: prepare
+    environment:
+      name: Sccache
+    runs-on: ubuntu-latest-xl
+    container:
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+    if: ${{ needs.prepare.outputs.rust-changes == 'true' }}
     steps:
       - uses: actions/checkout@v2.3.4
         with:
@@ -85,8 +114,7 @@ jobs:
   unit-test-allure-report:
     name: Unit Test Reports
     runs-on: ubuntu-latest
-    environment:
-      name: Sccache
+    if: ${{ needs.prepare.output.changes-target-branch == 'main' }}
     container:
       image: diem/build_environment:main
       volumes:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -27,7 +27,6 @@ jobs:
       need-base-images: ${{ steps.need-base-images.outputs.need-extra }}
       test-land-blocking: ${{ steps.need-land-blocking-test.outputs.need-lbt }}
       test-compatibility: ${{ steps.need-compat-tests.outputs.need-compat }}
-      test-rust-environment: ${{ steps.environment.outputs.name }}
       test-rust: ${{ steps.rust-changes.outputs.changes-found }}
       test-helm: ${{ steps.helm-changes.outputs.changes-found }}
       test-dev-setup: ${{ steps.dev-setup-sh-changes.outputs.changes-found }}
@@ -119,7 +118,7 @@ jobs:
         name: find helm changes
         uses: diem/actions/matches@faadd16607b77dfa2231a8f366883e01717b3225
         with:
-          pattern: '^helm'
+          pattern: "^helm"
       - id: dev-setup-sh-changes
         name: find dev-setup.sh/base docker image changes
         uses: diem/actions/matches@faadd16607b77dfa2231a8f366883e01717b3225
@@ -566,62 +565,11 @@ jobs:
           path: target/junit-reports/unit-test.xml
       - uses: ./.github/actions/build-teardown
 
-  unit-test-sccache:
-    runs-on: ubuntu-latest-xl
-    timeout-minutes: 50
-    needs: prepare
-    if: ${{ needs.prepare.outputs.test-rust == 'true' && github.event_name == 'push' }}
-    environment:
-      name: Sccache
-    container:
-      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
-      volumes:
-        - "${{github.workspace}}:/opt/git/diem"
-    steps:
-      - uses: actions/checkout@v2.3.4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0 #get all the history!!!
-      - uses: ./.github/actions/build-setup
-      - uses: actions/cache@v2.1.6
-        with:
-          path: "/opt/cargo/git\n/opt/cargo/registry\n/opt/cargo/.package-cache"
-          key: crates-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: "crates-${{ runner.os }}"
-      - name: run unit tests
-        run: |
-          $pre_command && mkdir -p target/junit-reports && cargo nextest --jobs ${max_threads} --tries ${nextest_tries} --unit --failure-output=immediate-final --changed-since "origin/$TARGET_BRANCH" --junit target/junit-reports/unit-test.xml
-        env:
-          TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
-          SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.ENV_DIEM_S3_AWS_ACCESS_KEY_ID }}
-          SCCACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.ENV_DIEM_S3_AWS_SECRET_ACCESS_KEY }}
-      - name: run jsonrpc integration tests
-        run: |
-          $pre_command && cargo xtest -p jsonrpc-integration-tests --changed-since "origin/$TARGET_BRANCH"
-        env:
-          TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
-          SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.ENV_DIEM_S3_AWS_ACCESS_KEY_ID }}
-          SCCACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.ENV_DIEM_S3_AWS_SECRET_ACCESS_KEY }}
-      - name: run doctests
-        run: |
-          $pre_command && cargo xtest --doc --jobs ${max_threads} --unit --changed-since "origin/$TARGET_BRANCH"
-        env:
-          TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
-          SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.ENV_DIEM_S3_AWS_ACCESS_KEY_ID }}
-          SCCACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.ENV_DIEM_S3_AWS_SECRET_ACCESS_KEY }}
-      - name: upload unit test results
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: unit-test-results
-          path: target/junit-reports/unit-test.xml
-      - uses: ./.github/actions/build-teardown
-
   codegen-unit-test:
     runs-on: ubuntu-latest-xl
     timeout-minutes: 60
     needs: prepare
-    if: ${{ needs.prepare.outputs.test-rust == 'true' && github.event_name == 'pull_request' }}
+    if: ${{ needs.prepare.outputs.test-rust == 'true' }}
     container:
       image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
@@ -641,41 +589,6 @@ jobs:
         run: $pre_command && mkdir -p target/junit-reports && cargo nextest --jobs ${max_threads} --tries ${nextest_tries} --failure-output=immediate-final -p transaction-builder-generator --unit --changed-since "origin/$TARGET_BRANCH" --run-ignored=ignored-only --junit target/junit-reports/codegen-unit-test.xml
         env:
           TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
-      - name: upload codegen test results
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: codegen-unit-test-results
-          path: target/junit-reports/codegen-unit-test.xml
-      - uses: ./.github/actions/build-teardown
-
-  codegen-unit-test-sccache:
-    runs-on: ubuntu-latest-xl
-    timeout-minutes: 60
-    needs: prepare
-    if: ${{ needs.prepare.outputs.test-rust == 'true' && github.event_name == 'push' }}
-    environment: Sccache
-    container:
-      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
-      volumes:
-        - "${{github.workspace}}:/opt/git/diem"
-    steps:
-      - uses: actions/checkout@v2.3.4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0 #get all the history!!!
-      - uses: ./.github/actions/build-setup
-      - uses: actions/cache@v2.1.6
-        with:
-          path: "/opt/cargo/git\n/opt/cargo/registry\n/opt/cargo/.package-cache"
-          key: crates-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: "crates-${{ runner.os }}"
-      - name: run codegen unit tests
-        run: $pre_command && mkdir -p target/junit-reports && cargo nextest --jobs ${max_threads} --tries ${nextest_tries} --failure-output=immediate-final -p transaction-builder-generator --unit --changed-since "origin/$TARGET_BRANCH" --run-ignored=ignored-only --junit target/junit-reports/codegen-unit-test.xml
-        env:
-          TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
-          SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.ENV_DIEM_S3_AWS_ACCESS_KEY_ID }}
-          SCCACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.ENV_DIEM_S3_AWS_SECRET_ACCESS_KEY }}
       - name: upload codegen test results
         if: always()
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
## Motivation

Eliminate the possibility of pre-landed sccache items from effecting coverage reports/post land compilations.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

gha-test-1 branch execution.   

https://github.com/diem/diem/runs/3293494941?check_suite_focus=true

## Related PRs

None

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
