### PR TITLE
[ci] Add debugging option in weekly-dep-report

### DIFF
--- a/scripts/weekly-dep-report.sh
+++ b/scripts/weekly-dep-report.sh
@@ -8,7 +8,7 @@ set -eoxv pipefail
 # expects two parameters: repository name and branch
 repository=$1
 starter_point=${2:-"HEAD"}
-git checkout --quiet "${starter_point}"
+git checkout --quiet --force "${starter_point}"
 
 last_commit=$(git rev-list HEAD -1)
 first_commit_within_last_seven_days=$(git rev-list --reverse --since=7.days.ago HEAD | head -n 1)
@@ -46,7 +46,7 @@ get_total_dups () {
 }
 
 
-git checkout --quiet "${last_commit}"
+git checkout --quiet --force "${last_commit}"
 date=$(git show --no-patch --format=%cd --date='format:%Y-%m-%d')
 short_sha=$(git rev-parse --short HEAD)
 total=$(get_total_deps)
@@ -64,7 +64,7 @@ elif [[ "${first_commit_within_last_seven_days}" == "${first_commit_in_the_repo}
 else
     # case 3: there is at least one commit in the last seven days
     last_commit_from_last_week=$(git rev-list "${first_commit_within_last_seven_days}"^1 -1)
-    git checkout --quiet "${last_commit_from_last_week}"
+    git checkout --quiet --force "${last_commit_from_last_week}"
 fi
 
 prev_date=$(git show --no-patch --format=%cd --date='format:%Y-%m-%d')
@@ -83,9 +83,9 @@ change_dups=$(format_change_in_dependency_output $((dups-prev_dups)))
 
 # resetting HEAD commit
 if [[ "${starter_point}" == "HEAD" ]]; then
-    git checkout --quiet "${last_commit}"
+    git checkout --quiet --force "${last_commit}"
 else
-    git checkout --quiet "${starter_point}"
+    git checkout --quiet --force "${starter_point}"
 fi
 
 echo "Dependency change in $repository:$starter_point at Commit $short_sha ($date) since Commit $prev_short_sha ($prev_date) :"

--- a/scripts/weekly-dep-report.sh
+++ b/scripts/weekly-dep-report.sh
@@ -3,10 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # fast fail.
-set -eo pipefail
-
-echo " Dependency change report "
-echo "--------------------------"
+set -eoxv pipefail
 
 # expects two parameters: repository name and branch
 repository=$1


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Add `set -xv` in `weekly-dep-report.sh` to enable debugging when it fails. The debug output is sent to `stderr` so the slack message is not modified by this.

Also forced git checkout as it may be the most probable step to face a failure if crag-guppy or any other command is generating new files. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

The changes are here to test. 

