### PR TITLE
[2chain] integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6893,7 +6893,6 @@ checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 name = "safety-rules"
 version = "0.1.0"
 dependencies = [
- "bcs",
  "consensus-types",
  "crash-handler",
  "criterion",
@@ -6915,6 +6914,7 @@ dependencies = [
  "rand 0.8.3",
  "rand_core 0.6.2",
  "serde",
+ "serde_json",
  "tempfile",
  "thiserror",
 ]

--- a/consensus/consensus-types/src/sync_info.rs
+++ b/consensus/consensus-types/src/sync_info.rs
@@ -189,7 +189,7 @@ impl SyncInfo {
         );
 
         ensure!(
-            !(self.highest_timeout_cert.is_some() && self.highest_2chain_timeout_cert.is_some()),
+            self.highest_timeout_cert.is_none() || self.highest_2chain_timeout_cert.is_none(),
             "Only One timeout cert should be carried"
         );
 

--- a/consensus/consensus-types/src/sync_info.rs
+++ b/consensus/consensus-types/src/sync_info.rs
@@ -1,8 +1,10 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::timeout_2chain::TwoChainTimeoutCertificate;
-use crate::{common::Round, quorum_cert::QuorumCert, timeout_certificate::TimeoutCertificate};
+use crate::{
+    common::Round, quorum_cert::QuorumCert, timeout_2chain::TwoChainTimeoutCertificate,
+    timeout_certificate::TimeoutCertificate,
+};
 use anyhow::{ensure, Context};
 use diem_types::{
     block_info::BlockInfo, ledger_info::LedgerInfoWithSignatures,
@@ -62,6 +64,9 @@ impl SyncInfo {
     ) -> Self {
         // No need to include HTC if it's lower than HQC
         let highest_timeout_cert = highest_timeout_cert
+            .filter(|tc| tc.round() > highest_quorum_cert.certified_block().round());
+
+        let highest_2chain_timeout_cert = highest_2chain_timeout_cert
             .filter(|tc| tc.round() > highest_quorum_cert.certified_block().round());
 
         let highest_ordered_cert =

--- a/consensus/consensus-types/src/timeout_2chain.rs
+++ b/consensus/consensus-types/src/timeout_2chain.rs
@@ -150,6 +150,11 @@ impl TwoChainTimeoutCertificate {
         Ok(())
     }
 
+    /// The epoch of the timeout.
+    pub fn epoch(&self) -> u64 {
+        self.timeout.epoch()
+    }
+
     /// The round of the timeout.
     pub fn round(&self) -> Round {
         self.timeout.round()

--- a/consensus/consensus-types/src/timeout_2chain.rs
+++ b/consensus/consensus-types/src/timeout_2chain.rs
@@ -88,7 +88,7 @@ pub struct TimeoutSigningRepr {
 /// TimeoutCertificate is a proof that 2f+1 participants in epoch i
 /// have voted in round r and we can now move to round r+1. DiemBFT v4 requires signature to sign on
 /// the TimeoutSigningRepr and carry the TimeoutWithHighestQC with highest quorum cert among 2f+1.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct TwoChainTimeoutCertificate {
     timeout: TwoChainTimeout,
     signatures: BTreeMap<Author, (Round, Ed25519Signature)>,

--- a/consensus/consensus-types/src/vote.rs
+++ b/consensus/consensus-types/src/vote.rs
@@ -1,8 +1,10 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::timeout_2chain::TwoChainTimeout;
-use crate::{common::Author, timeout::Timeout, vote_data::VoteData};
+use crate::{
+    common::Author, quorum_cert::QuorumCert, timeout::Timeout, timeout_2chain::TwoChainTimeout,
+    vote_data::VoteData,
+};
 use anyhow::{ensure, Context};
 use diem_crypto::{ed25519::Ed25519Signature, hash::CryptoHash};
 use diem_types::{
@@ -124,6 +126,15 @@ impl Vote {
         Timeout::new(
             self.vote_data().proposed().epoch(),
             self.vote_data().proposed().round(),
+        )
+    }
+
+    /// Returns the 2-chain timeout.
+    pub fn generate_2chain_timeout(&self, qc: QuorumCert) -> TwoChainTimeout {
+        TwoChainTimeout::new(
+            self.vote_data.proposed().epoch(),
+            self.vote_data.proposed().round(),
+            qc,
         )
     }
 

--- a/consensus/consensus-types/src/vote_msg.rs
+++ b/consensus/consensus-types/src/vote_msg.rs
@@ -54,6 +54,12 @@ impl VoteMsg {
             self.vote().epoch() == self.sync_info.epoch(),
             "VoteMsg has different epoch"
         );
+        if let Some((timeout, _)) = self.vote().two_chain_timeout() {
+            ensure!(
+                timeout.hqc_round() <= self.sync_info.highest_timeout_round(),
+                "2-chain Timeout hqc should be less or equal than the sycn info hqc"
+            );
+        }
         // We're not verifying SyncInfo here yet: we are going to verify it only in case we need
         // it. This way we avoid verifying O(n) SyncInfo messages while aggregating the votes
         // (O(n^2) signature verifications).

--- a/consensus/consensus-types/src/vote_msg.rs
+++ b/consensus/consensus-types/src/vote_msg.rs
@@ -56,8 +56,8 @@ impl VoteMsg {
         );
         if let Some((timeout, _)) = self.vote().two_chain_timeout() {
             ensure!(
-                timeout.hqc_round() <= self.sync_info.highest_timeout_round(),
-                "2-chain Timeout hqc should be less or equal than the sycn info hqc"
+                timeout.hqc_round() <= self.sync_info.highest_certified_round(),
+                "2-chain Timeout hqc should be less or equal than the sync info hqc"
             );
         }
         // We're not verifying SyncInfo here yet: we are going to verify it only in case we need

--- a/consensus/safety-rules/Cargo.toml
+++ b/consensus/safety-rules/Cargo.toml
@@ -14,7 +14,6 @@ rand_core = "0.6.2"
 
 crash-handler = { path = "../../common/crash-handler" }
 consensus-types = { path = "../consensus-types" }
-bcs = "0.1.2"
 diem-config = { path = "../../config" }
 diem-crypto = { path = "../../crypto/crypto" }
 diem-global-constants = { path = "../../config/global-constants"}
@@ -29,6 +28,7 @@ diem-types = { path = "../../types" }
 diem-vault-client = { path = "../../secure/storage/vault" }
 diem-workspace-hack = { path = "../../common/workspace-hack" }
 serde = { version = "1.0.124", default-features = false }
+serde_json = "1.0.64"
 thiserror = "1.0.24"
 
 [dev-dependencies]

--- a/consensus/safety-rules/src/error.rs
+++ b/consensus/safety-rules/src/error.rs
@@ -53,8 +53,8 @@ pub enum Error {
     InvalidOrderedLedgerInfo(String),
 }
 
-impl From<bcs::Error> for Error {
-    fn from(error: bcs::Error) -> Self {
+impl From<serde_json::Error> for Error {
+    fn from(error: serde_json::Error) -> Self {
         Self::SerializationError(format!("{}", error))
     }
 }

--- a/consensus/safety-rules/src/fuzzing_utils.rs
+++ b/consensus/safety-rules/src/fuzzing_utils.rs
@@ -269,8 +269,8 @@ pub mod fuzzing {
         // Create a safety rules serializer test instance for fuzzing
         let mut serializer_service = test_utils::test_serializer();
 
-        // BCS encode the safety_rules_input and fuzz the handle_message() method
-        if let Ok(safety_rules_input) = bcs::to_bytes(&safety_rules_input) {
+        // encode the safety_rules_input and fuzz the handle_message() method
+        if let Ok(safety_rules_input) = serde_json::to_vec(&safety_rules_input) {
             serializer_service.handle_message(safety_rules_input)
         } else {
             Err(Error::SerializationError(

--- a/consensus/safety-rules/src/remote_service.rs
+++ b/consensus/safety-rules/src/remote_service.rs
@@ -82,7 +82,7 @@ impl RemoteClient {
 
 impl TSerializerClient for RemoteClient {
     fn request(&mut self, input: SafetyRulesInput) -> Result<Vec<u8>, Error> {
-        let input_message = bcs::to_bytes(&input)?;
+        let input_message = serde_json::to_vec(&input)?;
         loop {
             match self.process_one_message(&input_message) {
                 Err(err) => warn!("Failed to communicate with SafetyRules service: {}", err),

--- a/consensus/safety-rules/src/t_safety_rules.rs
+++ b/consensus/safety-rules/src/t_safety_rules.rs
@@ -44,20 +44,16 @@ pub trait TSafetyRules {
     /// Sign the timeout together with highest qc for 2-chain protocol.
     fn sign_timeout_with_qc(
         &mut self,
-        _timeout: &TwoChainTimeout,
-        _timeout_cert: Option<&TwoChainTimeoutCertificate>,
-    ) -> Result<Ed25519Signature, Error> {
-        unimplemented!();
-    }
+        timeout: &TwoChainTimeout,
+        timeout_cert: Option<&TwoChainTimeoutCertificate>,
+    ) -> Result<Ed25519Signature, Error>;
 
     /// Sign the vote with 2-chain protocol.
     fn construct_and_sign_vote_two_chain(
         &mut self,
-        _vote_proposal: &MaybeSignedVoteProposal,
-        _timeout_cert: Option<&TwoChainTimeoutCertificate>,
-    ) -> Result<Vote, Error> {
-        unimplemented!();
-    }
+        vote_proposal: &MaybeSignedVoteProposal,
+        timeout_cert: Option<&TwoChainTimeoutCertificate>,
+    ) -> Result<Vote, Error>;
 
     /// As the holder of the private key, SafetyRules also signs a commit vote.
     /// This returns the signature for the commit vote.

--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -17,10 +17,9 @@ use crate::{
 };
 use anyhow::{bail, ensure, format_err, Context};
 
-use consensus_types::timeout_2chain::TwoChainTimeoutCertificate;
 use consensus_types::{
     block::Block, executed_block::ExecutedBlock, quorum_cert::QuorumCert, sync_info::SyncInfo,
-    timeout_certificate::TimeoutCertificate,
+    timeout_2chain::TwoChainTimeoutCertificate, timeout_certificate::TimeoutCertificate,
 };
 use diem_crypto::{hash::ACCUMULATOR_PLACEHOLDER_HASH, HashValue};
 use diem_infallible::RwLock;

--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -17,6 +17,7 @@ use crate::{
 };
 use anyhow::{bail, ensure, format_err, Context};
 
+use consensus_types::timeout_2chain::TwoChainTimeoutCertificate;
 use consensus_types::{
     block::Block, executed_block::ExecutedBlock, quorum_cert::QuorumCert, sync_info::SyncInfo,
     timeout_certificate::TimeoutCertificate,
@@ -242,6 +243,7 @@ impl BlockStore {
             root_commit_li,
             max_pruned_blocks_in_mem,
             highest_timeout_cert.map(Arc::new),
+            None,
         );
 
         let block_store = Self {
@@ -538,12 +540,18 @@ impl BlockReader for BlockStore {
         self.inner.read().highest_timeout_cert()
     }
 
+    fn highest_2chain_timeout_cert(&self) -> Option<Arc<TwoChainTimeoutCertificate>> {
+        self.inner.read().highest_2chain_timeout_cert()
+    }
+
     fn sync_info(&self) -> SyncInfo {
         SyncInfo::new_decoupled(
             self.highest_quorum_cert().as_ref().clone(),
             self.highest_ordered_cert().as_ref().clone(),
             Some(self.highest_ledger_info()),
             self.highest_timeout_cert().map(|tc| tc.as_ref().clone()),
+            self.highest_2chain_timeout_cert()
+                .map(|tc| tc.as_ref().clone()),
         )
     }
 }

--- a/consensus/src/block_storage/block_store_and_lec_recovery_test.rs
+++ b/consensus/src/block_storage/block_store_and_lec_recovery_test.rs
@@ -51,6 +51,7 @@ fn get_initial_data_and_qc(db: &dyn DbReader) -> (RecoveryData, QuorumCert) {
             ),
             vec![],
             None,
+            None,
         )
         .unwrap(),
         qc,

--- a/consensus/src/block_storage/block_tree.rs
+++ b/consensus/src/block_storage/block_tree.rs
@@ -3,6 +3,7 @@
 
 use crate::counters;
 use anyhow::bail;
+use consensus_types::timeout_2chain::TwoChainTimeoutCertificate;
 use consensus_types::{
     executed_block::ExecutedBlock, quorum_cert::QuorumCert, timeout_certificate::TimeoutCertificate,
 };
@@ -72,6 +73,8 @@ pub struct BlockTree {
     highest_quorum_cert: Arc<QuorumCert>,
     /// The highest timeout certificate (if any).
     highest_timeout_cert: Option<Arc<TimeoutCertificate>>,
+    /// The highest 2-chain timeout certificate (if any).
+    highest_2chain_timeout_cert: Option<Arc<TwoChainTimeoutCertificate>>,
     /// The quorum certificate that has highest commit info.
     highest_ordered_cert: Arc<QuorumCert>,
     /// The quorum certificate that has highest commit decision info.
@@ -92,6 +95,7 @@ impl BlockTree {
         root_commit_ledger_info: LedgerInfoWithSignatures,
         max_pruned_blocks_in_mem: usize,
         highest_timeout_cert: Option<Arc<TimeoutCertificate>>,
+        highest_2chain_timeout_cert: Option<Arc<TwoChainTimeoutCertificate>>,
     ) -> Self {
         assert_eq!(
             root.id(),
@@ -125,6 +129,7 @@ impl BlockTree {
             id_to_quorum_cert,
             pruned_block_ids,
             max_pruned_blocks_in_mem,
+            highest_2chain_timeout_cert,
         }
     }
 
@@ -192,6 +197,15 @@ impl BlockTree {
 
     pub(super) fn highest_timeout_cert(&self) -> Option<Arc<TimeoutCertificate>> {
         self.highest_timeout_cert.clone()
+    }
+
+    pub(super) fn highest_2chain_timeout_cert(&self) -> Option<Arc<TwoChainTimeoutCertificate>> {
+        self.highest_2chain_timeout_cert.clone()
+    }
+
+    /// Replace highest timeout cert with the given value.
+    pub(super) fn replace_2chain_timeout_cert(&mut self, tc: Arc<TwoChainTimeoutCertificate>) {
+        self.highest_2chain_timeout_cert.replace(tc);
     }
 
     /// Replace highest timeout cert with the given value.

--- a/consensus/src/block_storage/block_tree.rs
+++ b/consensus/src/block_storage/block_tree.rs
@@ -3,9 +3,9 @@
 
 use crate::counters;
 use anyhow::bail;
-use consensus_types::timeout_2chain::TwoChainTimeoutCertificate;
 use consensus_types::{
-    executed_block::ExecutedBlock, quorum_cert::QuorumCert, timeout_certificate::TimeoutCertificate,
+    executed_block::ExecutedBlock, quorum_cert::QuorumCert,
+    timeout_2chain::TwoChainTimeoutCertificate, timeout_certificate::TimeoutCertificate,
 };
 use diem_crypto::HashValue;
 use diem_logger::prelude::*;

--- a/consensus/src/block_storage/mod.rs
+++ b/consensus/src/block_storage/mod.rs
@@ -12,8 +12,7 @@ mod block_tree;
 pub mod tracing;
 
 pub use block_store::{sync_manager::BlockRetriever, BlockStore};
-use consensus_types::sync_info::SyncInfo;
-use consensus_types::timeout_2chain::TwoChainTimeoutCertificate;
+use consensus_types::{sync_info::SyncInfo, timeout_2chain::TwoChainTimeoutCertificate};
 use diem_types::ledger_info::LedgerInfoWithSignatures;
 
 pub trait BlockReader: Send + Sync {

--- a/consensus/src/block_storage/mod.rs
+++ b/consensus/src/block_storage/mod.rs
@@ -13,6 +13,7 @@ pub mod tracing;
 
 pub use block_store::{sync_manager::BlockRetriever, BlockStore};
 use consensus_types::sync_info::SyncInfo;
+use consensus_types::timeout_2chain::TwoChainTimeoutCertificate;
 use diem_types::ledger_info::LedgerInfoWithSignatures;
 
 pub trait BlockReader: Send + Sync {
@@ -52,6 +53,9 @@ pub trait BlockReader: Send + Sync {
 
     /// Return the highest timeout certificate if available.
     fn highest_timeout_cert(&self) -> Option<Arc<TimeoutCertificate>>;
+
+    /// Return the highest timeout certificate if available.
+    fn highest_2chain_timeout_cert(&self) -> Option<Arc<TwoChainTimeoutCertificate>>;
 
     /// Return the highest commit decision ledger info.
     fn highest_ledger_info(&self) -> LedgerInfoWithSignatures;

--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -100,6 +100,9 @@ impl BlockStore {
         if let Some(tc) = sync_info.highest_timeout_certificate() {
             self.insert_timeout_certificate(Arc::new(tc.clone()))?;
         }
+        if let Some(tc) = sync_info.highest_2chain_timeout_cert() {
+            self.insert_2chain_timeout_certificate(Arc::new(tc.clone()))?;
+        }
         Ok(())
     }
 

--- a/consensus/src/consensusdb/consensusdb_test.rs
+++ b/consensus/src/consensusdb/consensusdb_test.rs
@@ -25,19 +25,27 @@ fn test_put_get() {
 
     let tc = vec![0u8, 1, 2];
     db.save_highest_timeout_certificate(tc.clone()).unwrap();
+    db.save_highest_2chain_timeout_certificate(tc.clone())
+        .unwrap();
 
     let vote = vec![2u8, 1, 0];
     db.save_vote(vote.clone()).unwrap();
 
-    let (vote_1, tc_1, blocks_1, qc_1) = db.get_data().unwrap();
+    let (vote_1, tc_1, tc_2, blocks_1, qc_1) = db.get_data().unwrap();
     assert_eq!(blocks, blocks_1);
     assert_eq!(qcs, qc_1);
-    assert_eq!(Some(tc), tc_1);
+    assert_eq!(Some(tc.clone()), tc_1);
+    assert_eq!(Some(tc), tc_2);
     assert_eq!(Some(vote), vote_1);
 
     db.delete_highest_timeout_certificate().unwrap();
+    db.delete_highest_2chain_timeout_certificate().unwrap();
     db.delete_last_vote_msg().unwrap();
     assert!(db.get_highest_timeout_certificate().unwrap().is_none());
+    assert!(db
+        .get_highest_2chain_timeout_certificate()
+        .unwrap()
+        .is_none());
     assert!(db.get_last_vote().unwrap().is_none());
 }
 

--- a/consensus/src/consensusdb/schema/single_entry/mod.rs
+++ b/consensus/src/consensusdb/schema/single_entry/mod.rs
@@ -35,6 +35,8 @@ pub enum SingleEntryKey {
     HighestTimeoutCertificate = 0,
     // Used to store the last vote
     LastVoteMsg = 1,
+    // Two chain timeout cert
+    Highest2ChainTimeoutCert = 2,
 }
 
 impl KeyCodec<SingleEntrySchema> for SingleEntryKey {

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -288,7 +288,6 @@ impl EpochManager {
     }
 
     // TODO: prepare_decoupled_execution
-
     async fn start_round_manager(&mut self, recovery_data: RecoveryData, epoch_state: EpochState) {
         // Release the previous RoundManager, especially the SafetyRule client
         self.processor = None;
@@ -363,6 +362,7 @@ impl EpochManager {
                 self.txn_manager.clone(),
                 self.storage.clone(),
                 self.config.sync_only,
+                false,
             )
         };
 

--- a/consensus/src/liveness/round_state.rs
+++ b/consensus/src/liveness/round_state.rs
@@ -234,7 +234,8 @@ impl RoundState {
             self.pending_votes = PendingVotes::new();
             self.vote_sent = None;
             let timeout = self.setup_timeout();
-            // The new round reason is QCReady in case both QC and TC are equal
+            // The new round reason is QCReady in case both QC.round + 1 == new_round, otherwise
+            // it's Timeout and TC.round + 1 == new_round.
             let new_round_reason = if sync_info.highest_certified_round() + 1 == new_round {
                 NewRoundReason::QCReady
             } else {

--- a/consensus/src/liveness/round_state.rs
+++ b/consensus/src/liveness/round_state.rs
@@ -235,7 +235,7 @@ impl RoundState {
             self.vote_sent = None;
             let timeout = self.setup_timeout();
             // The new round reason is QCReady in case both QC and TC are equal
-            let new_round_reason = if sync_info.highest_timeout_certificate().is_none() {
+            let new_round_reason = if sync_info.highest_certified_round() + 1 == new_round {
                 NewRoundReason::QCReady
             } else {
                 NewRoundReason::Timeout

--- a/consensus/src/liveness/round_state_test.rs
+++ b/consensus/src/liveness/round_state_test.rs
@@ -138,5 +138,5 @@ fn generate_sync_info(
     );
     let commit_cert = quorum_cert.clone();
     let timeout_cert = TimeoutCertificate::new(Timeout::new(1, timeout_round));
-    SyncInfo::new(quorum_cert, commit_cert, Some(timeout_cert))
+    SyncInfo::new(quorum_cert, commit_cert, Some(timeout_cert), None)
 }

--- a/consensus/src/metrics_safety_rules.rs
+++ b/consensus/src/metrics_safety_rules.rs
@@ -3,7 +3,11 @@
 
 use crate::persistent_liveness_storage::PersistentLivenessStorage;
 use consensus_types::{
-    block_data::BlockData, timeout::Timeout, vote::Vote, vote_proposal::MaybeSignedVoteProposal,
+    block_data::BlockData,
+    timeout::Timeout,
+    timeout_2chain::{TwoChainTimeout, TwoChainTimeoutCertificate},
+    vote::Vote,
+    vote_proposal::MaybeSignedVoteProposal,
 };
 use diem_crypto::ed25519::Ed25519Signature;
 use diem_metrics::monitor;
@@ -80,6 +84,32 @@ impl TSafetyRules for MetricsSafetyRules {
 
     fn sign_timeout(&mut self, timeout: &Timeout) -> Result<Ed25519Signature, Error> {
         self.retry(|inner| monitor!("safety_rules", inner.sign_timeout(timeout)))
+    }
+
+    fn sign_timeout_with_qc(
+        &mut self,
+        timeout: &TwoChainTimeout,
+        timeout_cert: Option<&TwoChainTimeoutCertificate>,
+    ) -> Result<Ed25519Signature, Error> {
+        self.retry(|inner| {
+            monitor!(
+                "safety_rules",
+                inner.sign_timeout_with_qc(timeout, timeout_cert)
+            )
+        })
+    }
+
+    fn construct_and_sign_vote_two_chain(
+        &mut self,
+        vote_proposal: &MaybeSignedVoteProposal,
+        timeout_cert: Option<&TwoChainTimeoutCertificate>,
+    ) -> Result<Vote, Error> {
+        self.retry(|inner| {
+            monitor!(
+                "safety_rules",
+                inner.construct_and_sign_vote_two_chain(vote_proposal, timeout_cert)
+            )
+        })
     }
 
     fn sign_commit_vote(

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -597,7 +597,7 @@ mod tests {
         let previous_qc = certificate_for_genesis();
         let proposal = ProposalMsg::new(
             Block::new_proposal(vec![], 1, 1, previous_qc.clone(), &signers[0]),
-            SyncInfo::new(previous_qc.clone(), previous_qc, None),
+            SyncInfo::new(previous_qc.clone(), previous_qc, None, None),
         );
         timed_block_on(&mut runtime, async {
             nodes[0]

--- a/consensus/src/pending_votes.rs
+++ b/consensus/src/pending_votes.rs
@@ -152,7 +152,7 @@ impl PendingVotes {
         if let Some(timeout_signature) = vote.timeout_signature() {
             // form timeout struct
             // TODO(mimoo): stronger: pass the (epoch, round) tuple as arguments of this function
-            let timeout = vote.timeout();
+            let timeout = vote.generate_timeout();
 
             // if no partial TC exist, create one
             let partial_tc = self
@@ -339,7 +339,7 @@ mod tests {
         );
 
         // submit the same vote but enhanced with a timeout -> VoteAdded
-        let timeout = vote1_author_0.timeout();
+        let timeout = vote1_author_0.generate_timeout();
         let signature = timeout.sign(&signers[0]);
         vote1_author_0.add_timeout_signature(signature);
 
@@ -358,7 +358,7 @@ mod tests {
         );
 
         // if that vote is now enhanced with a timeout signature -> NewTimeoutCertificate
-        let timeout = vote2_author_1.timeout();
+        let timeout = vote2_author_1.generate_timeout();
         let signature = timeout.sign(&signers[1]);
         vote2_author_1.add_timeout_signature(signature);
         match pending_votes.insert_vote(&vote2_author_1, &validator) {

--- a/consensus/src/persistent_liveness_storage.rs
+++ b/consensus/src/persistent_liveness_storage.rs
@@ -3,9 +3,9 @@
 
 use crate::{consensusdb::ConsensusDB, epoch_manager::LivenessStorageData, error::DbError};
 use anyhow::{format_err, Context, Result};
-use consensus_types::timeout_2chain::TwoChainTimeoutCertificate;
 use consensus_types::{
-    block::Block, quorum_cert::QuorumCert, timeout_certificate::TimeoutCertificate, vote::Vote,
+    block::Block, quorum_cert::QuorumCert, timeout_2chain::TwoChainTimeoutCertificate,
+    timeout_certificate::TimeoutCertificate, vote::Vote,
 };
 use diem_config::config::NodeConfig;
 use diem_crypto::HashValue;

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -689,22 +689,22 @@ impl RoundManager {
         );
 
         let maybe_signed_vote_proposal = executed_block.maybe_signed_vote_proposal();
-        let vote = if self.two_chain {
+        let vote_result = if self.two_chain {
             self.safety_rules.lock().construct_and_sign_vote_two_chain(
                 &maybe_signed_vote_proposal,
                 self.block_store.highest_2chain_timeout_cert().as_deref(),
-            )?
+            )
         } else {
             self.safety_rules
                 .lock()
                 .construct_and_sign_vote(&maybe_signed_vote_proposal)
-                .context(format!(
-                    "[RoundManager] SafetyRules {}Rejected{} {}",
-                    Fg(Red),
-                    Fg(Reset),
-                    executed_block.block()
-                ))?
         };
+        let vote = vote_result.context(format!(
+            "[RoundManager] SafetyRules {}Rejected{} {}",
+            Fg(Red),
+            Fg(Reset),
+            executed_block.block()
+        ))?;
         observe_block(executed_block.block().timestamp_usecs(), BlockStage::VOTED);
 
         self.storage

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -541,7 +541,7 @@ impl RoundManager {
         };
 
         if !timeout_vote.is_timeout() {
-            let timeout = timeout_vote.timeout();
+            let timeout = timeout_vote.generate_timeout();
             let signature = self
                 .safety_rules
                 .lock()

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -167,6 +167,7 @@ fn create_node_for_fuzzing() -> RoundManager {
         Arc::new(MockTransactionManager::new(None)),
         storage,
         false,
+        false,
     )
 }
 

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -220,6 +220,7 @@ impl NodeSetup {
             Arc::new(MockTransactionManager::new(None)),
             storage.clone(),
             false,
+            false,
         );
         block_on(round_manager.start(last_vote_sent));
         Self {

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -406,7 +406,7 @@ fn no_vote_on_mismatch_round() {
     timed_block_on(&mut runtime, async {
         let bad_proposal = ProposalMsg::new(
             block_skip_round,
-            SyncInfo::new(genesis_qc.clone(), genesis_qc.clone(), None),
+            SyncInfo::new(genesis_qc.clone(), genesis_qc.clone(), None, None),
         );
         assert!(node
             .round_manager
@@ -415,7 +415,7 @@ fn no_vote_on_mismatch_round() {
             .is_err());
         let good_proposal = ProposalMsg::new(
             correct_block.clone(),
-            SyncInfo::new(genesis_qc.clone(), genesis_qc.clone(), None),
+            SyncInfo::new(genesis_qc.clone(), genesis_qc.clone(), None, None),
         );
         node.round_manager
             .process_proposal_msg(good_proposal)
@@ -488,7 +488,7 @@ fn no_vote_on_invalid_proposer() {
     timed_block_on(&mut runtime, async {
         let bad_proposal = ProposalMsg::new(
             block_incorrect_proposer,
-            SyncInfo::new(genesis_qc.clone(), genesis_qc.clone(), None),
+            SyncInfo::new(genesis_qc.clone(), genesis_qc.clone(), None, None),
         );
         assert!(node
             .round_manager
@@ -497,7 +497,7 @@ fn no_vote_on_invalid_proposer() {
             .is_err());
         let good_proposal = ProposalMsg::new(
             correct_block.clone(),
-            SyncInfo::new(genesis_qc.clone(), genesis_qc.clone(), None),
+            SyncInfo::new(genesis_qc.clone(), genesis_qc.clone(), None, None),
         );
 
         node.round_manager
@@ -529,7 +529,7 @@ fn new_round_on_timeout_certificate() {
     timed_block_on(&mut runtime, async {
         let skip_round_proposal = ProposalMsg::new(
             block_skip_round,
-            SyncInfo::new(genesis_qc.clone(), genesis_qc.clone(), Some(tc)),
+            SyncInfo::new(genesis_qc.clone(), genesis_qc.clone(), Some(tc), None),
         );
         node.round_manager
             .process_proposal_msg(skip_round_proposal)
@@ -537,7 +537,7 @@ fn new_round_on_timeout_certificate() {
             .unwrap();
         let old_good_proposal = ProposalMsg::new(
             correct_block.clone(),
-            SyncInfo::new(genesis_qc.clone(), genesis_qc.clone(), None),
+            SyncInfo::new(genesis_qc.clone(), genesis_qc.clone(), None, None),
         );
         assert!(node
             .round_manager
@@ -558,7 +558,10 @@ fn response_on_block_retrieval() {
     let genesis_qc = certificate_for_genesis();
     let block = Block::new_proposal(vec![], 1, 1, genesis_qc.clone(), &node.signer);
     let block_id = block.id();
-    let proposal = ProposalMsg::new(block, SyncInfo::new(genesis_qc.clone(), genesis_qc, None));
+    let proposal = ProposalMsg::new(
+        block,
+        SyncInfo::new(genesis_qc.clone(), genesis_qc, None, None),
+    );
 
     timed_block_on(&mut runtime, async {
         node.round_manager
@@ -669,6 +672,7 @@ fn recover_on_restart() {
                     proposal.quorum_cert().clone(),
                     genesis_qc.clone(),
                     Some(tc.clone()),
+                    None,
                 ),
             );
             node.round_manager
@@ -850,7 +854,7 @@ fn sync_on_partial_newer_sync_info() {
             None,
         );
         // Create a sync info with newer quorum cert but older commit cert
-        let sync_info = SyncInfo::new(block_4_qc.clone(), certificate_for_genesis(), None);
+        let sync_info = SyncInfo::new(block_4_qc.clone(), certificate_for_genesis(), None, None);
         node.round_manager
             .ensure_round_and_sync_up(
                 sync_info.highest_round() + 1,

--- a/consensus/src/test_utils/mock_storage.rs
+++ b/consensus/src/test_utils/mock_storage.rs
@@ -8,9 +8,9 @@ use crate::{
     },
 };
 use anyhow::Result;
-use consensus_types::timeout_2chain::TwoChainTimeoutCertificate;
 use consensus_types::{
-    block::Block, quorum_cert::QuorumCert, timeout_certificate::TimeoutCertificate, vote::Vote,
+    block::Block, quorum_cert::QuorumCert, timeout_2chain::TwoChainTimeoutCertificate,
+    timeout_certificate::TimeoutCertificate, vote::Vote,
 };
 use diem_crypto::HashValue;
 use diem_infallible::Mutex;

--- a/consensus/src/test_utils/mod.rs
+++ b/consensus/src/test_utils/mod.rs
@@ -168,7 +168,12 @@ pub fn placeholder_ledger_info() -> LedgerInfo {
 }
 
 pub fn placeholder_sync_info() -> SyncInfo {
-    SyncInfo::new(certificate_for_genesis(), certificate_for_genesis(), None)
+    SyncInfo::new(
+        certificate_for_genesis(),
+        certificate_for_genesis(),
+        None,
+        None,
+    )
 }
 
 fn nocapture() -> bool {

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -307,6 +307,9 @@ SyncInfo:
     - highest_timeout_cert:
         OPTION:
           TYPENAME: TimeoutCertificate
+    - highest_2chain_timeout_cert:
+        OPTION:
+          TYPENAME: TwoChainTimeoutCertificate
 Timeout:
   STRUCT:
     - epoch: U64
@@ -401,6 +404,24 @@ TransactionPayload:
       ScriptFunction:
         NEWTYPE:
           TYPENAME: ScriptFunction
+TwoChainTimeout:
+  STRUCT:
+    - epoch: U64
+    - round: U64
+    - quorum_cert:
+        TYPENAME: QuorumCert
+TwoChainTimeoutCertificate:
+  STRUCT:
+    - timeout:
+        TYPENAME: TwoChainTimeout
+    - signatures:
+        MAP:
+          KEY:
+            TYPENAME: AccountAddress
+          VALUE:
+            TUPLE:
+              - U64
+              - TYPENAME: Ed25519Signature
 TypeTag:
   ENUM:
     0:
@@ -451,6 +472,11 @@ Vote:
     - timeout_signature:
         OPTION:
           TYPENAME: Ed25519Signature
+    - two_chain_timeout:
+        OPTION:
+          TUPLE:
+            - TYPENAME: TwoChainTimeout
+            - TYPENAME: Ed25519Signature
 VoteData:
   STRUCT:
     - proposed:


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR integrated the 2-chain building blocks into the system and added a flag to enable it (which later will be controlled by on-chain config). Basic assumption is that the flag stays the same for an epoch.

We switched the serde from bcs to json in safety rules to maintain the compatibility with serde annotation (default, skip_serializing_if).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update or suggest changes to the docs at https://developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
