### PR TITLE
[decoupled-execution] Fixes

### DIFF
--- a/consensus/consensus-types/src/vote_data.rs
+++ b/consensus/consensus-types/src/vote_data.rs
@@ -56,7 +56,10 @@ impl VoteData {
             "Proposed happened before parent",
         );
         anyhow::ensure!(
-            self.parent.version() <= self.proposed.version(),
+            // if decoupled execution is turned on, the versions are dummy values (0),
+            // but the genesis block per epoch uses the ground truth version number,
+            // so we bypass the version check here.
+            self.proposed.version() == 0 || self.parent.version() <= self.proposed.version(),
             "Proposed version is less than parent version",
         );
         Ok(())

--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -42,16 +42,20 @@ impl BlockStore {
     /// Check if we're far away from this ledger info and need to sync.
     /// Returns false if we have this block in the tree or the root's round is higher than the
     /// block.
-    pub fn need_sync_for_quorum_cert(&self, qc: &QuorumCert) -> bool {
+    pub fn need_sync_for_quorum_cert(
+        &self,
+        qc: &QuorumCert,
+        li: &LedgerInfoWithSignatures,
+    ) -> bool {
         // This precondition ensures that the check in the following lines
         // does not result in an addition overflow.
-        checked_precondition!(self.ordered_root().round() < std::u64::MAX - 1);
+        checked_precondition!(self.commit_root().round() < std::u64::MAX - 1);
 
         // If we have the block locally, we're not far from this QC thus don't need to sync.
         // In case root().round() is greater than that the committed
         // block carried by LI is older than my current commit.
         !(self.block_exists(qc.commit_info().id())
-            || self.ordered_root().round() >= qc.commit_info().round())
+            || self.commit_root().round() >= li.commit_info().round())
     }
 
     /// Checks if quorum certificate can be inserted in block store without RPC
@@ -171,12 +175,12 @@ impl BlockStore {
         highest_ledger_info: LedgerInfoWithSignatures,
         retriever: &mut BlockRetriever,
     ) -> anyhow::Result<()> {
-        if !self.need_sync_for_quorum_cert(&highest_ordered_cert) {
+        if !self.need_sync_for_quorum_cert(&highest_ordered_cert, &highest_ledger_info) {
             return Ok(());
         }
         let (root, root_metadata, blocks, quorum_certs) = Self::fast_forward_sync(
             &highest_ordered_cert,
-            highest_ledger_info,
+            highest_ledger_info.clone(),
             retriever,
             self.storage.clone(),
             self.state_computer.clone(),
@@ -191,7 +195,7 @@ impl BlockStore {
         self.rebuild(root, root_metadata, blocks, quorum_certs)
             .await;
 
-        if highest_ordered_cert.ends_epoch() {
+        if highest_ledger_info.ledger_info().ends_epoch() {
             retriever
                 .network
                 .notify_epoch_change(EpochChangeProof::new(

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -644,8 +644,10 @@ impl EpochManager {
                     VerifiedEvent::ProposalMsg(proposal) => p.process_proposal_msg(*proposal).await,
                     VerifiedEvent::VoteMsg(vote) => p.process_vote_msg(*vote).await,
                     VerifiedEvent::SyncInfo(sync_info) => p.sync_up(&sync_info, peer_id).await,
-                    _ => {
-                        unimplemented!()
+                    VerifiedEvent::CommitVote(_) | VerifiedEvent::CommitDecision(_) => {
+                        return Err(anyhow!(
+                            "Ignoring commit vote/decision message during recovery"
+                        )); //ignore
                     }
                 }?;
                 let epoch_state = p.epoch_state().clone();


### PR DESCRIPTION
1. Vote data verification bypass due to dummy values
2. Epoch manager should take caare of verified commit vote & decision events during recovery, instead of panicking.
3. Update need-sync rule in sync_manager, sync_to_highest_ordered_cert should use HLI instead of QC (dummy values)

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update or suggest changes to the docs at https://developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
