### PR TITLE
[diem-framework] re-enable verifications disabled due to generic invariant

### DIFF
--- a/language/diem-framework/modules/DiemConfig.move
+++ b/language/diem-framework/modules/DiemConfig.move
@@ -118,9 +118,7 @@ module DiemFramework::DiemConfig {
         reconfigure_();
     }
     spec set {
-        /// TODO: turned off verification until we solve the
-        /// generic type/specific invariant issue
-        pragma opaque, verify = false;
+        pragma opaque;
         modifies global<Configuration>(@DiemRoot);
         modifies global<DiemConfig<Config>>(@DiemRoot);
         include SetAbortsIf<Config>;
@@ -161,9 +159,7 @@ module DiemFramework::DiemConfig {
         reconfigure_();
     }
     spec set_with_capability_and_reconfigure {
-        /// TODO: turned off verification until we solve the
-        /// generic type/specific invariant issue
-        pragma opaque, verify = false;
+        pragma opaque;
         modifies global<Configuration>(@DiemRoot);
         include AbortsIfNotPublished<Config>;
         include ReconfigureAbortsIf;
@@ -218,9 +214,7 @@ module DiemFramework::DiemConfig {
         ModifyConfigCapability<Config> {}
     }
     spec publish_new_config_and_get_capability {
-        /// TODO: turned off verification until we solve the
-        /// generic type/specific invariant issue
-        pragma opaque, verify = false;
+        pragma opaque;
         modifies global<DiemConfig<Config>>(@DiemRoot);
         include Roles::AbortsIfNotDiemRoot{account: dr_account};
         include AbortsIfPublished<Config>;
@@ -416,11 +410,6 @@ module DiemFramework::DiemConfig {
         invariant
             forall config_address: address, config_type: type where exists<DiemConfig<config_type>>(config_address):
                 config_address == @DiemRoot;
-
-        /// After genesis, no new configurations are added.
-        invariant update
-            DiemTimestamp::is_operating() ==>
-                (forall config_type: type where spec_is_published<config_type>(): old(spec_is_published<config_type>()));
 
         /// Published configurations are persistent.
         invariant update

--- a/language/diem-framework/modules/doc/DiemConfig.md
+++ b/language/diem-framework/modules/doc/DiemConfig.md
@@ -425,11 +425,8 @@ resource published under it.
 <summary>Specification</summary>
 
 
-TODO: turned off verification until we solve the
-generic type/specific invariant issue
 
-
-<pre><code><b>pragma</b> opaque, verify = <b>false</b>;
+<pre><code><b>pragma</b> opaque;
 <b>modifies</b> <b>global</b>&lt;<a href="DiemConfig.md#0x1_DiemConfig_Configuration">Configuration</a>&gt;(@DiemRoot);
 <b>modifies</b> <b>global</b>&lt;<a href="DiemConfig.md#0x1_DiemConfig">DiemConfig</a>&lt;Config&gt;&gt;(@DiemRoot);
 <b>include</b> <a href="DiemConfig.md#0x1_DiemConfig_SetAbortsIf">SetAbortsIf</a>&lt;Config&gt;;
@@ -522,11 +519,8 @@ a Diem root signer.
 <summary>Specification</summary>
 
 
-TODO: turned off verification until we solve the
-generic type/specific invariant issue
 
-
-<pre><code><b>pragma</b> opaque, verify = <b>false</b>;
+<pre><code><b>pragma</b> opaque;
 <b>modifies</b> <b>global</b>&lt;<a href="DiemConfig.md#0x1_DiemConfig_Configuration">Configuration</a>&gt;(@DiemRoot);
 <b>include</b> <a href="DiemConfig.md#0x1_DiemConfig_AbortsIfNotPublished">AbortsIfNotPublished</a>&lt;Config&gt;;
 <b>include</b> <a href="DiemConfig.md#0x1_DiemConfig_ReconfigureAbortsIf">ReconfigureAbortsIf</a>;
@@ -669,11 +663,8 @@ Does not trigger a reconfiguration.
 <summary>Specification</summary>
 
 
-TODO: turned off verification until we solve the
-generic type/specific invariant issue
 
-
-<pre><code><b>pragma</b> opaque, verify = <b>false</b>;
+<pre><code><b>pragma</b> opaque;
 <b>modifies</b> <b>global</b>&lt;<a href="DiemConfig.md#0x1_DiemConfig">DiemConfig</a>&lt;Config&gt;&gt;(@DiemRoot);
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotDiemRoot">Roles::AbortsIfNotDiemRoot</a>{account: dr_account};
 <b>include</b> <a href="DiemConfig.md#0x1_DiemConfig_AbortsIfPublished">AbortsIfPublished</a>&lt;Config&gt;;
@@ -1055,15 +1046,6 @@ Configurations are only stored at the diem root address.
 <pre><code><b>invariant</b>
     <b>forall</b> config_address: address, config_type: type <b>where</b> <b>exists</b>&lt;<a href="DiemConfig.md#0x1_DiemConfig">DiemConfig</a>&lt;config_type&gt;&gt;(config_address):
         config_address == @DiemRoot;
-</code></pre>
-
-
-After genesis, no new configurations are added.
-
-
-<pre><code><b>invariant</b> <b>update</b>
-    <a href="DiemTimestamp.md#0x1_DiemTimestamp_is_operating">DiemTimestamp::is_operating</a>() ==&gt;
-        (<b>forall</b> config_type: type <b>where</b> <a href="DiemConfig.md#0x1_DiemConfig_spec_is_published">spec_is_published</a>&lt;config_type&gt;(): <b>old</b>(<a href="DiemConfig.md#0x1_DiemConfig_spec_is_published">spec_is_published</a>&lt;config_type&gt;()));
 </code></pre>
 
 

--- a/language/diem-framework/releases/artifacts/current/docs/modules/DiemConfig.md
+++ b/language/diem-framework/releases/artifacts/current/docs/modules/DiemConfig.md
@@ -425,11 +425,8 @@ resource published under it.
 <summary>Specification</summary>
 
 
-TODO: turned off verification until we solve the
-generic type/specific invariant issue
 
-
-<pre><code><b>pragma</b> opaque, verify = <b>false</b>;
+<pre><code><b>pragma</b> opaque;
 <b>modifies</b> <b>global</b>&lt;<a href="DiemConfig.md#0x1_DiemConfig_Configuration">Configuration</a>&gt;(@DiemRoot);
 <b>modifies</b> <b>global</b>&lt;<a href="DiemConfig.md#0x1_DiemConfig">DiemConfig</a>&lt;Config&gt;&gt;(@DiemRoot);
 <b>include</b> <a href="DiemConfig.md#0x1_DiemConfig_SetAbortsIf">SetAbortsIf</a>&lt;Config&gt;;
@@ -522,11 +519,8 @@ a Diem root signer.
 <summary>Specification</summary>
 
 
-TODO: turned off verification until we solve the
-generic type/specific invariant issue
 
-
-<pre><code><b>pragma</b> opaque, verify = <b>false</b>;
+<pre><code><b>pragma</b> opaque;
 <b>modifies</b> <b>global</b>&lt;<a href="DiemConfig.md#0x1_DiemConfig_Configuration">Configuration</a>&gt;(@DiemRoot);
 <b>include</b> <a href="DiemConfig.md#0x1_DiemConfig_AbortsIfNotPublished">AbortsIfNotPublished</a>&lt;Config&gt;;
 <b>include</b> <a href="DiemConfig.md#0x1_DiemConfig_ReconfigureAbortsIf">ReconfigureAbortsIf</a>;
@@ -669,11 +663,8 @@ Does not trigger a reconfiguration.
 <summary>Specification</summary>
 
 
-TODO: turned off verification until we solve the
-generic type/specific invariant issue
 
-
-<pre><code><b>pragma</b> opaque, verify = <b>false</b>;
+<pre><code><b>pragma</b> opaque;
 <b>modifies</b> <b>global</b>&lt;<a href="DiemConfig.md#0x1_DiemConfig">DiemConfig</a>&lt;Config&gt;&gt;(@DiemRoot);
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotDiemRoot">Roles::AbortsIfNotDiemRoot</a>{account: dr_account};
 <b>include</b> <a href="DiemConfig.md#0x1_DiemConfig_AbortsIfPublished">AbortsIfPublished</a>&lt;Config&gt;;
@@ -1055,15 +1046,6 @@ Configurations are only stored at the diem root address.
 <pre><code><b>invariant</b>
     <b>forall</b> config_address: address, config_type: type <b>where</b> <b>exists</b>&lt;<a href="DiemConfig.md#0x1_DiemConfig">DiemConfig</a>&lt;config_type&gt;&gt;(config_address):
         config_address == @DiemRoot;
-</code></pre>
-
-
-After genesis, no new configurations are added.
-
-
-<pre><code><b>invariant</b> <b>update</b>
-    <a href="DiemTimestamp.md#0x1_DiemTimestamp_is_operating">DiemTimestamp::is_operating</a>() ==&gt;
-        (<b>forall</b> config_type: type <b>where</b> <a href="DiemConfig.md#0x1_DiemConfig_spec_is_published">spec_is_published</a>&lt;config_type&gt;(): <b>old</b>(<a href="DiemConfig.md#0x1_DiemConfig_spec_is_published">spec_is_published</a>&lt;config_type&gt;()));
 </code></pre>
 
 


### PR DESCRIPTION
A few functions in `DiemConfig.move` are marked `verify = false` because
the global invariants are not instrumented correctly. With the recent
changes in the generic invariant handling, verification of these
functions can be re-enabled again.

This commit also removed a spec that does not match developers'
intention: after genesis, we can still add new configurations types,
an example is the `DiemConsensusConfig` type. This is discussed
on slack (although a while back).

## Motivation

Disabled specs are not good.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI
