### PR TITLE
[move-prover] Fixes a bug with shadowing of let-bound names in schemas

### DIFF
--- a/language/move-model/src/builder/module_builder.rs
+++ b/language/move-model/src/builder/module_builder.rs
@@ -2379,6 +2379,14 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                 exp,
                 additional_exps,
             });
+            match kind {
+                ConditionKind::LetPost(name) | ConditionKind::LetPre(name) => {
+                    // If a let name is introduced by this condition, remove it from argument_map
+                    // as it shadows schema arguments.
+                    argument_map.remove(name);
+                }
+                _ => {}
+            }
         }
 
         // Put schema entry back.

--- a/language/move-prover/tests/sources/functional/let.move
+++ b/language/move-prover/tests/sources/functional/let.move
@@ -122,4 +122,24 @@ module 0x42::TestLet {
         let e = exists<R>(a1) || exists<R>(a2);
         e && e || e
     }
+
+    // Let Shadowing
+    // =============
+
+    fun shadowed(v: u64): u64 {
+        v
+    }
+    spec shadowed {
+        include Shadowed1;
+    }
+
+    spec schema Shadowed1 {
+        v: u64;
+        include Shadowed2;
+    }
+
+    spec schema Shadowed2 {
+        let v = true;
+        ensures v == true;
+    }
 }


### PR DESCRIPTION
The change is simple, but finding the issue was not.

Closes #8854

## Motivation

Bug fix

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added test

## Related PRs

NA