### PR TITLE
[decoupled-execution] Add Execution Retry

### DIFF
--- a/consensus/src/experimental/execution_phase.rs
+++ b/consensus/src/experimental/execution_phase.rs
@@ -7,9 +7,18 @@ use crate::{
 };
 use channel::{Receiver, Sender};
 use consensus_types::{block::Block, executed_block::ExecutedBlock};
+use core::hint;
+use diem_logger::prelude::*;
 use diem_types::ledger_info::LedgerInfoWithSignatures;
 use executor_types::Error as ExecutionError;
-use futures::{channel::oneshot, select, FutureExt, SinkExt, StreamExt};
+use futures::{
+    channel::{
+        mpsc::{UnboundedReceiver, UnboundedSender},
+        oneshot,
+    },
+    prelude::stream::FusedStream,
+    select, FutureExt, SinkExt, StreamExt,
+};
 use std::sync::Arc;
 
 /// [ This class is used when consensus.decoupled = true ]
@@ -18,12 +27,44 @@ use std::sync::Arc;
 /// ExecutionPhase sends the ordered blocks to the commit phase.
 ///
 
+#[derive(Debug)]
+pub struct ResetEventType {
+    pub reset_callback: oneshot::Sender<ResetAck>,
+    pub reconfig: bool,
+}
+
+pub async fn notify_downstream_reset(
+    reset_tx: &Sender<ResetEventType>,
+    reconfig: bool,
+) -> anyhow::Result<()> {
+    // notify the commit phase
+    let (tx, rx) = oneshot::channel::<ResetAck>();
+    reset_tx
+        .clone()
+        .send(ResetEventType {
+            reset_callback: tx,
+            reconfig,
+        })
+        .await?;
+    rx.await?;
+    Ok(())
+}
+
+pub type ExecutionPhaseCallBackType =
+    Option<Box<dyn Fn(LedgerInfoWithSignatures) -> Vec<Block> + Send + Sync>>;
+
+#[cfg(test)]
+pub fn empty_execute_phase_callback() -> ExecutionPhaseCallBackType {
+    None
+}
+
 pub type ResetAck = ();
 pub fn reset_ack_new() -> ResetAck {}
 
 pub struct ExecutionChannelType(
     pub Vec<Block>,
     pub LedgerInfoWithSignatures,
+    pub ExecutionPhaseCallBackType,
     pub StateComputerCommitCallBackType,
 );
 
@@ -39,21 +80,50 @@ impl std::fmt::Display for ExecutionChannelType {
     }
 }
 
+pub struct ExecutionPendingBlocks {
+    pub pending_channel_type: Option<ExecutionChannelType>,
+    pub original_blocks: Vec<Block>,
+}
+
+impl ExecutionPendingBlocks {
+    pub fn update_blocks(&mut self, blocks: Vec<Block>) {
+        let pending_channel_type = self.pending_channel_type.take().unwrap();
+        self.pending_channel_type = Some(ExecutionChannelType(
+            blocks,
+            pending_channel_type.1,
+            pending_channel_type.2,
+            pending_channel_type.3,
+        ))
+    }
+
+    pub fn vecblocks(&self) -> Vec<Block> {
+        self.pending_channel_type.as_ref().unwrap().0.clone()
+    }
+    pub fn ledger_info(&self) -> LedgerInfoWithSignatures {
+        self.pending_channel_type.as_ref().unwrap().1.clone()
+    }
+    pub fn execution_failure_callback(&self) -> &ExecutionPhaseCallBackType {
+        &self.pending_channel_type.as_ref().unwrap().2
+    }
+}
+
 pub struct ExecutionPhase {
-    executor_channel_rx: Receiver<ExecutionChannelType>,
+    executor_channel_rx: UnboundedReceiver<ExecutionChannelType>,
     execution_proxy: Arc<dyn StateComputer>,
-    commit_channel_tx: Sender<CommitChannelType>,
-    reset_event_channel_rx: Receiver<oneshot::Sender<ResetAck>>,
-    commit_phase_reset_event_tx: Sender<oneshot::Sender<ResetAck>>,
+    commit_channel_tx: UnboundedSender<CommitChannelType>,
+    reset_event_channel_rx: Receiver<ResetEventType>,
+    commit_phase_reset_event_tx: Sender<ResetEventType>,
+    in_epoch: bool,
+    pending_blocks: Option<ExecutionPendingBlocks>,
 }
 
 impl ExecutionPhase {
     pub fn new(
-        executor_channel_rx: Receiver<ExecutionChannelType>,
+        executor_channel_rx: UnboundedReceiver<ExecutionChannelType>,
         execution_proxy: Arc<dyn StateComputer>,
-        commit_channel_tx: Sender<CommitChannelType>,
-        reset_event_channel_rx: Receiver<oneshot::Sender<ResetAck>>,
-        commit_phase_reset_event_tx: Sender<oneshot::Sender<ResetAck>>,
+        commit_channel_tx: UnboundedSender<CommitChannelType>,
+        reset_event_channel_rx: Receiver<ResetEventType>,
+        commit_phase_reset_event_tx: Sender<ResetEventType>,
     ) -> Self {
         Self {
             executor_channel_rx,
@@ -61,64 +131,165 @@ impl ExecutionPhase {
             commit_channel_tx,
             reset_event_channel_rx,
             commit_phase_reset_event_tx,
+            in_epoch: true,
+            pending_blocks: None,
         }
     }
 
-    pub async fn process_reset_event(
-        &mut self,
-        reset_event_callback: oneshot::Sender<ResetAck>,
-    ) -> anyhow::Result<()> {
+    pub async fn process_reset_event(&mut self, reset_event: ResetEventType) -> anyhow::Result<()> {
+        let ResetEventType {
+            reset_callback,
+            reconfig,
+        } = reset_event;
         // reset the execution phase
 
-        // notify the commit phase
-        let (tx, rx) = oneshot::channel::<ResetAck>();
-        self.commit_phase_reset_event_tx.send(tx).await?;
-        rx.await?;
+        if let Err(e) = notify_downstream_reset(&self.commit_phase_reset_event_tx, reconfig).await {
+            error!(
+                "Error in requesting commit phase to reset: {}",
+                e.to_string()
+            );
+        }
 
         // exhaust the executor channel
-        while self.executor_channel_rx.next().now_or_never().is_some() {}
+        while !self.executor_channel_rx.is_terminated()
+            && !self.reset_event_channel_rx.is_terminated()
+            && self.executor_channel_rx.next().now_or_never().is_some()
+        {
+            hint::spin_loop();
+        }
 
+        self.pending_blocks = None;
+
+        if reconfig {
+            self.in_epoch = false;
+        }
         // activate the callback
-        reset_event_callback
+        reset_callback
             .send(reset_ack_new())
             .map_err(|_| Error::ResetDropped)?;
 
         Ok(())
     }
 
-    pub async fn start(mut self) {
-        // main loop
-        loop {
-            select! {
-                ExecutionChannelType(vecblock, ledger_info, callback) = self.executor_channel_rx.select_next_some() => {
-                    // execute the blocks with execution_correctness_client
-                    let executed_blocks: Vec<ExecutedBlock> = vecblock
-                        .into_iter()
-                        .map(|b| {
-                            let state_compute_result =
-                                self.execution_proxy.compute(&b, b.parent_id()).unwrap();
-                            ExecutedBlock::new(b, state_compute_result)
-                        })
-                        .collect();
-                    // TODO: add error handling. Err(Error::BlockNotFound(parent_block_id))
+    pub fn execute_blocks(&self, blocks: Vec<Block>) -> Result<Vec<ExecutedBlock>, ExecutionError> {
+        let executed_blocks: Result<Vec<_>, _> = blocks
+            .into_iter()
+            .map(|b| -> Result<_, _> {
+                let state_compute_result = self.execution_proxy.compute(&b, b.parent_id())?;
+                Ok(ExecutedBlock::new(b, state_compute_result))
+            })
+            .collect();
+        executed_blocks
+    }
 
+    pub async fn try_execute_blocks(&mut self) {
+        info!("try_execute_blocks");
+        if let Some(pd) = self.pending_blocks.as_ref() {
+            let vecblock = pd.vecblocks();
+            let pending_ledger_info = pd.ledger_info();
+            info!("trying to execute blocks {:?}", vecblock);
+            let execution_result = self.execute_blocks(vecblock.clone());
+            match execution_result {
+                Ok(executed_blocks) => {
+                    // assert this is consistent with our batch
+                    assert_eq!(
+                        executed_blocks.last().unwrap().id(),
+                        pd.original_blocks.last().unwrap().id()
+                    );
+                    assert!(executed_blocks.len() >= vecblock.len());
+                    let starting_idx = executed_blocks.len() - pd.original_blocks.len();
+                    assert_eq!(
+                        executed_blocks[starting_idx].id(),
+                        pd.original_blocks.first().unwrap().id()
+                    );
                     // pass the executed blocks into the commit phase
-                    self.commit_channel_tx
-                        .send(CommitChannelType(executed_blocks, ledger_info, callback))
+
+                    if self
+                        .commit_channel_tx
+                        .send(CommitChannelType(
+                            executed_blocks[starting_idx..].to_vec(),
+                            pending_ledger_info.clone(),
+                            self.pending_blocks
+                                .take()
+                                .unwrap()
+                                .pending_channel_type
+                                .take()
+                                .unwrap()
+                                .3,
+                        ))
                         .await
                         .map_err(|e| ExecutionError::InternalError {
                             error: e.to_string(),
                         })
+                        .is_err()
+                    {
+                        // if the commit phase stops (due to epoch change),
+                        // execution phase also needs to stop
+                        self.in_epoch = false;
+                    }
+                }
+                Err(ExecutionError::BlockNotFound(_)) => {
+                    // there must be a callback
+                    let refetched_block = pd.execution_failure_callback().as_ref().unwrap()(
+                        pending_ledger_info.clone(),
+                    );
+
+                    self.pending_blocks
+                        .as_mut()
+                        .unwrap()
+                        .update_blocks(refetched_block);
+                }
+                Err(e) => {
+                    // retry locally
+                    error!("Retry execution caused by : Error in executor: {:?}", e);
+                }
+            }
+        }
+    }
+
+    pub async fn process_ordered_blocks(&mut self, execution_channel_type: ExecutionChannelType) {
+        info!("process_ordered_blocks");
+        let blocks_to_push = execution_channel_type.0.clone();
+        // execute the blocks with execution_correctness_client
+
+        self.pending_blocks = Some(ExecutionPendingBlocks {
+            pending_channel_type: Some(execution_channel_type),
+            original_blocks: blocks_to_push,
+        });
+
+        self.try_execute_blocks().await;
+    }
+
+    pub async fn start(mut self) {
+        // main loop
+        while self.in_epoch {
+            if self.pending_blocks.is_none() {
+                select! {
+                    executor_channel_msg = self.executor_channel_rx.select_next_some() => {
+                        self.process_ordered_blocks(executor_channel_msg).await;
+                    }
+                    reset_event_callback = self.reset_event_channel_rx.select_next_some() => {
+                        self.process_reset_event(reset_event_callback).await.map_err(|e| ExecutionError::InternalError {
+                            error: e.to_string(),
+                        })
                         .unwrap();
+                    }
+                    complete => break,
+                };
+            } else {
+                self.try_execute_blocks().await;
+                if self.pending_blocks.is_none() {
+                    continue;
                 }
-                reset_event_callback = self.reset_event_channel_rx.select_next_some() => {
-                    self.process_reset_event(reset_event_callback).await.map_err(|e| ExecutionError::InternalError {
-                        error: e.to_string(),
-                    })
-                    .unwrap();
+                select! {
+                    reset_event_callback = self.reset_event_channel_rx.select_next_some() => {
+                        self.process_reset_event(reset_event_callback).await.map_err(|e| ExecutionError::InternalError {
+                            error: e.to_string(),
+                        }).unwrap();
+                    }
+                    default => { continue }
                 }
-                complete => break,
-            };
+            }
         }
     }
 }

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     error::StateSyncError,
+    experimental::execution_phase::ExecutionPhaseCallBackType,
     state_replication::{StateComputer, StateComputerCommitCallBackType},
 };
 use anyhow::Result;
@@ -70,6 +71,7 @@ impl StateComputer for ExecutionProxy {
         blocks: &[Arc<ExecutedBlock>],
         finality_proof: LedgerInfoWithSignatures,
         callback: StateComputerCommitCallBackType,
+        _executor_failure_callback: ExecutionPhaseCallBackType,
     ) -> Result<(), ExecutionError> {
         let mut block_ids = Vec::new();
         let mut txns = Vec::new();

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -1,7 +1,10 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::error::{MempoolError, StateSyncError};
+use crate::{
+    error::{MempoolError, StateSyncError},
+    experimental::execution_phase::ExecutionPhaseCallBackType,
+};
 use anyhow::Result;
 use consensus_types::{block::Block, common::Payload, executed_block::ExecutedBlock};
 use diem_crypto::HashValue;
@@ -62,6 +65,7 @@ pub trait StateComputer: Send + Sync {
         blocks: &[Arc<ExecutedBlock>],
         finality_proof: LedgerInfoWithSignatures,
         callback: StateComputerCommitCallBackType,
+        executor_failure_callback: ExecutionPhaseCallBackType,
     ) -> Result<(), ExecutionError>;
 
     /// Best effort state synchronization to the given target LedgerInfo.

--- a/consensus/src/test_utils/mock_state_computer.rs
+++ b/consensus/src/test_utils/mock_state_computer.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     error::StateSyncError,
+    experimental::execution_phase::ExecutionPhaseCallBackType,
     state_replication::{StateComputer, StateComputerCommitCallBackType},
     test_utils::mock_storage::MockStorage,
 };
@@ -57,7 +58,8 @@ impl StateComputer for MockStateComputer {
         &self,
         blocks: &[Arc<ExecutedBlock>],
         commit: LedgerInfoWithSignatures,
-        call_back: StateComputerCommitCallBackType,
+        callback: StateComputerCommitCallBackType,
+        _executor_failure_callback: ExecutionPhaseCallBackType,
     ) -> Result<(), Error> {
         self.consensus_db
             .commit_to_storage(commit.ledger_info().clone());
@@ -77,7 +79,7 @@ impl StateComputer for MockStateComputer {
 
         let _ = self.commit_callback.unbounded_send(commit.clone());
 
-        call_back(blocks, commit);
+        callback(blocks, commit);
 
         Ok(())
     }
@@ -113,8 +115,9 @@ impl StateComputer for EmptyStateComputer {
     async fn commit(
         &self,
         _blocks: &[Arc<ExecutedBlock>],
-        _commit: LedgerInfoWithSignatures,
-        _call_back: StateComputerCommitCallBackType,
+        _finality_proof: LedgerInfoWithSignatures,
+        _callback: StateComputerCommitCallBackType,
+        _executor_failure_callback: ExecutionPhaseCallBackType,
     ) -> Result<(), Error> {
         Ok(())
     }
@@ -155,8 +158,9 @@ impl StateComputer for RandomComputeResultStateComputer {
     async fn commit(
         &self,
         _blocks: &[Arc<ExecutedBlock>],
-        _commit: LedgerInfoWithSignatures,
-        _call_back: StateComputerCommitCallBackType,
+        _finality_proof: LedgerInfoWithSignatures,
+        _callback: StateComputerCommitCallBackType,
+        _executor_failure_callback: ExecutionPhaseCallBackType,
     ) -> Result<(), Error> {
         Ok(())
     }


### PR DESCRIPTION
Besides, we changed the channels (from the ordering state computer to the execution phase) and (from execution phase to commit phase) into unbounded channels, because blocking at send() will prevent them from resetting. Note that, back pressure does not serve as an upper bound of the number of contents in the channel during the synchronization path.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update or suggest changes to the docs at https://developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
