### PR TITLE
[move-cli] run meta tests in a separate process

### DIFF
--- a/language/tools/move-cli/tests/cli_tests.rs
+++ b/language/tools/move-cli/tests/cli_tests.rs
@@ -1,12 +1,13 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_cli::sandbox::commands::test;
-
-use std::path::PathBuf;
+use std::{
+    path::PathBuf,
+    process::{Command, Stdio},
+};
 
 pub const CLI_BINARY_PATH: [&str; 6] = ["..", "..", "..", "target", "debug", "move"];
-pub const CLI_METATEST_PATH: [&str; 3] = ["tests", "metatests", "args.txt"];
+pub const CLI_METATEST_PATH: [&str; 2] = ["tests", "metatests"];
 
 fn get_cli_binary_path() -> String {
     let pb: PathBuf = CLI_BINARY_PATH.iter().collect();
@@ -24,7 +25,21 @@ fn run_metatest() {
     let path_metatest = get_metatest_path();
 
     // with coverage
-    assert!(test::run_all(&path_metatest, &path_cli_binary, true).is_ok());
+    assert!(Command::new(&path_cli_binary)
+        .arg("sandbox")
+        .arg("test")
+        .arg("--track-cov")
+        .arg(&path_metatest)
+        .stdout(Stdio::null())
+        .status()
+        .is_ok());
+
     // without coverage
-    assert!(test::run_all(&path_metatest, &path_cli_binary, false).is_ok());
+    assert!(Command::new(&path_cli_binary)
+        .arg("sandbox")
+        .arg("test")
+        .arg(&path_metatest)
+        .stdout(Stdio::null())
+        .status()
+        .is_ok());
 }


### PR DESCRIPTION
If the meta test and other CLI test cases run in different threads but
in the same process, then their environment variables, including
`env::current_dir()`, are going to be shared. This is not good,
especially with the coverage tracking (`MOVE_VM_TRACE`) env var.

In fact, this might be the culprit of some flackiness in the tests, as
observed in #8917 and #8846 (although they are very rare and very hard
to reproduce locally). The reason can be some form of race condition
around the `MOVE_VM_TRACE` flag. One possible procedure is:

- meta test, test A, test B starts in different threads
- meta test set `MOVE_VM_TRACE=env::current_dir()/build/trace`
  but `env::current_dir()` returns `A/`
- test B invokes Move VM, Move VM sees the `MOVE_VM_TRACE` is set,
  and tries to create the trace file in `A/build`
- but `A/build` is already deleted, leading to a `unwrap()` error.

This is my guess on why in #8917, test `publish_then_check` tries to
access the `build` directory of `explain_user_tx_script_abort`, which is
a different and unrelated test.

Ideally, we should really run thest tests all in different processes, as
they are designed this way. Fortunately, most of the CLI tests run in
different processes already (via `Command::new()`), having the meta test
runs in a separate process will break the race condition on the
`MOVE_VM_TRACE` flag and hopefully solve the flakiness.

## Motivation

Investigate CI test flakiness

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- CI
- I can't really reproduce it locally, so kinds of have to rely on CI in the long term to test it.
