### PR TITLE
forge: improve debugging experience on test failures

### DIFF
--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -220,6 +220,10 @@ impl Swarm for K8sSwarm {
             self.chain_id,
         )
     }
+
+    fn logs_location(&mut self) -> String {
+        todo!()
+    }
 }
 
 pub(crate) fn k8s_retry_strategy() -> impl Iterator<Item = Duration> {

--- a/testsuite/forge/src/backend/local/cargo.rs
+++ b/testsuite/forge/src/backend/local/cargo.rs
@@ -6,6 +6,7 @@ use anyhow::{bail, Context};
 use serde::Deserialize;
 use std::{
     env, fs,
+    io::{self, Write},
     path::{Path, PathBuf},
     process::Command,
 };
@@ -150,6 +151,7 @@ where
     T: AsRef<Path>,
 {
     let target_directory = target_directory.as_ref();
+    let directory = directory.as_ref();
     let output = Command::new("cargo")
         .current_dir(directory)
         .env("CARGO_TARGET_DIR", target_directory)
@@ -169,7 +171,13 @@ where
 
         Ok(bin_path)
     } else {
-        bail!("Faild to build diem-node");
+        io::stderr().write_all(&output.stderr)?;
+
+        bail!(
+            "Failed to build diem-node: 'cd {} && CARGO_TARGET_DIR={} cargo build --bin=diem-node",
+            directory.display(),
+            target_directory.display(),
+        );
     }
 }
 

--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -362,4 +362,9 @@ impl Swarm for LocalSwarm {
             self.chain_id,
         )
     }
+
+    fn logs_location(&mut self) -> String {
+        self.dir.persist();
+        self.dir.display().to_string()
+    }
 }

--- a/testsuite/forge/src/interface/swarm.rs
+++ b/testsuite/forge/src/interface/swarm.rs
@@ -59,6 +59,8 @@ pub trait Swarm {
 
     /// Construct a ChainInfo from this Swarm
     fn chain_info(&mut self) -> ChainInfo<'_>;
+
+    fn logs_location(&mut self) -> String;
 }
 
 impl<T: ?Sized> SwarmExt for T where T: Swarm {}

--- a/testsuite/forge/src/runner.rs
+++ b/testsuite/forge/src/runner.rs
@@ -212,6 +212,13 @@ impl<'cfg, F: Factory> Forge<'cfg, F> {
         summary.write_starting_msg()?;
 
         if test_count > 0 {
+            println!(
+                "Starting Swarm with supported versions: {:?}",
+                self.factory
+                    .versions()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<_>>()
+            );
             let initial_version = self.initial_version();
             let mut rng = ::rand::rngs::StdRng::from_seed(OsRng.gen());
             let mut swarm = self.factory.launch_swarm(

--- a/testsuite/forge/src/runner.rs
+++ b/testsuite/forge/src/runner.rs
@@ -245,6 +245,14 @@ impl<'cfg, F: Factory> Forge<'cfg, F> {
                 let result = run_test(|| test.run(&mut network_ctx));
                 summary.handle_result(test.name().to_owned(), result)?;
             }
+
+            io::stdout().flush()?;
+            io::stderr().flush()?;
+
+            if !summary.success() {
+                println!();
+                println!("Swarm logs can be found here: {}", swarm.logs_location());
+            }
         }
 
         summary.write_summary()?;

--- a/testsuite/forge/src/txn_emitter/mod.rs
+++ b/testsuite/forge/src/txn_emitter/mod.rs
@@ -566,7 +566,8 @@ async fn wait_for_signed_transactions(
             .unzip();
         let responses = client
             .batch(batch)
-            .await?
+            .await
+            .context("failed to query account transactions")?
             .into_iter()
             .map(|r| {
                 r.and_then(|response| response.into_inner().try_into_get_account_transaction())


### PR DESCRIPTION
This PR does the following:
* One test failure, prints out where logs for the nodes are located
* prints out the stderr output of `cargo build` when building diem-node fails
* Displays the versions supported by the backend on startup, prior to running tests