### PR TITLE
Cherry-pick PR #8916 into release-1.4: diem-node: enable seeding the rng used when running in test mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2184,6 +2184,7 @@ dependencies = [
  "futures",
  "jemallocator",
  "network-builder",
+ "rand 0.8.3",
  "state-sync",
  "storage-client",
  "storage-interface",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2182,6 +2182,7 @@ dependencies = [
  "executor-types",
  "fail",
  "futures",
+ "hex",
  "jemallocator",
  "network-builder",
  "rand 0.8.3",

--- a/config/management/genesis/src/config_builder.rs
+++ b/config/management/genesis/src/config_builder.rs
@@ -108,7 +108,10 @@ impl FullnodeBuilder {
 }
 
 impl BuildSwarm for FullnodeBuilder {
-    fn build_swarm(&self) -> anyhow::Result<(Vec<NodeConfig>, Ed25519PrivateKey)> {
+    fn build_swarm<R>(&self, _rng: R) -> anyhow::Result<(Vec<NodeConfig>, Ed25519PrivateKey)>
+    where
+        R: ::rand::RngCore + ::rand::CryptoRng,
+    {
         let configs = match self.build_type {
             FullnodeType::ValidatorFullnode => self.build_vfn(),
             FullnodeType::PublicFullnode(num_nodes) => self.build_public_fn(num_nodes),
@@ -126,7 +129,7 @@ pub fn test_config() -> (NodeConfig, Ed25519PrivateKey) {
         diem_framework_releases::current_module_blobs().to_vec(),
     )
     .template(NodeConfig::default_for_validator());
-    let (mut configs, key) = builder.build_swarm().unwrap();
+    let (mut configs, key) = builder.build_swarm(rand::rngs::OsRng).unwrap();
 
     let mut config = configs.swap_remove(0);
     config.set_data_dir(path.path().to_path_buf());

--- a/config/management/genesis/src/swarm_config.rs
+++ b/config/management/genesis/src/swarm_config.rs
@@ -64,7 +64,7 @@ impl SwarmConfig {
 
 impl BuildSwarm for ValidatorBuilder {
     fn build_swarm(&self) -> Result<(Vec<NodeConfig>, Ed25519PrivateKey)> {
-        let (root_keys, validators) = self.clone().build()?;
+        let (root_keys, validators) = self.clone().build(rand::rngs::OsRng)?;
 
         Ok((
             validators.into_iter().map(|v| v.config).collect(),

--- a/diem-node/Cargo.toml
+++ b/diem-node/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 fail = "0.4.0"
 futures = "0.3.12"
+hex = "0.4.3"
 jemallocator = { version = "0.3.2", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
 rand = "0.8.3"
 structopt = "0.3.21"

--- a/diem-node/Cargo.toml
+++ b/diem-node/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 fail = "0.4.0"
 futures = "0.3.12"
 jemallocator = { version = "0.3.2", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
+rand = "0.8.3"
 structopt = "0.3.21"
 tokio = { version = "1.8.1", features = ["full"] }
 tokio-stream = "0.1.4"

--- a/diem-node/src/lib.rs
+++ b/diem-node/src/lib.rs
@@ -92,7 +92,10 @@ pub fn start(config: &NodeConfig, log_file: Option<PathBuf>) {
     }
 }
 
-pub fn load_test_environment(config_path: Option<PathBuf>, random_ports: bool) {
+pub fn load_test_environment<R>(config_path: Option<PathBuf>, random_ports: bool, rng: R)
+where
+    R: ::rand::RngCore + ::rand::CryptoRng,
+{
     // Either allocate a temppath or reuse the passed in path and make sure the directory exists
     let config_temp_path = diem_temppath::TempPath::new();
     let config_path = config_path.unwrap_or_else(|| config_temp_path.as_ref().to_path_buf());
@@ -114,7 +117,8 @@ pub fn load_test_environment(config_path: Option<PathBuf>, random_ports: bool) {
     .template(template)
     .randomize_first_validator_ports(random_ports);
     let test_config =
-        diem_genesis_tool::swarm_config::SwarmConfig::build(&builder, &config_path).unwrap();
+        diem_genesis_tool::swarm_config::SwarmConfig::build_with_rng(&builder, &config_path, rng)
+            .unwrap();
 
     // Prepare log file since we cannot automatically route logs to stderr
     let mut log_file = config_path.clone();

--- a/diem-node/src/main.rs
+++ b/diem-node/src/main.rs
@@ -31,7 +31,7 @@ fn main() {
 
     if args.test {
         println!("Entering test mode, this should never be used in production!");
-        diem_node::load_test_environment(args.config, args.random_ports);
+        diem_node::load_test_environment(args.config, args.random_ports, rand::rngs::OsRng);
     } else {
         let config = NodeConfig::load(args.config.unwrap()).expect("Failed to load node config");
         println!("Using node config {:?}", &config);

--- a/diem-node/src/main.rs
+++ b/diem-node/src/main.rs
@@ -4,6 +4,8 @@
 #![forbid(unsafe_code)]
 
 use diem_config::config::NodeConfig;
+use hex::FromHex;
+use rand::{rngs::StdRng, SeedableRng};
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -19,6 +21,14 @@ struct Args {
     config: Option<PathBuf>,
     #[structopt(long, help = "Enable a single validator testnet")]
     test: bool,
+
+    #[structopt(
+        long,
+        help = "RNG Seed to use when starting single validator testnet",
+        parse(try_from_str = FromHex::from_hex),
+        requires("test")
+    )]
+    seed: Option<[u8; 32]>,
     #[structopt(long, help = "Enabling random ports for testnet")]
     random_ports: bool,
 }
@@ -31,7 +41,11 @@ fn main() {
 
     if args.test {
         println!("Entering test mode, this should never be used in production!");
-        diem_node::load_test_environment(args.config, args.random_ports, rand::rngs::OsRng);
+        let rng = args
+            .seed
+            .map(StdRng::from_seed)
+            .unwrap_or_else(StdRng::from_entropy);
+        diem_node::load_test_environment(args.config, args.random_ports, rng);
     } else {
         let config = NodeConfig::load(args.config.unwrap()).expect("Failed to load node config");
         println!("Using node config {:?}", &config);

--- a/testsuite/forge/src/backend/k8s/mod.rs
+++ b/testsuite/forge/src/backend/k8s/mod.rs
@@ -3,6 +3,7 @@
 
 use crate::{Factory, Result, Swarm, Version};
 use anyhow::format_err;
+use rand::rngs::StdRng;
 use std::{env, fs::File, io::Read, num::NonZeroUsize, path::PathBuf};
 use tokio::runtime::Runtime;
 
@@ -73,7 +74,12 @@ impl Factory for K8sFactory {
         )))
     }
 
-    fn launch_swarm(&self, _node_num: NonZeroUsize, _version: &Version) -> Result<Box<dyn Swarm>> {
+    fn launch_swarm(
+        &self,
+        _rng: &mut StdRng,
+        _node_num: NonZeroUsize,
+        _version: &Version,
+    ) -> Result<Box<dyn Swarm>> {
         let rt = Runtime::new().unwrap();
         let swarm = rt
             .block_on(K8sSwarm::new(

--- a/testsuite/forge/src/backend/local/mod.rs
+++ b/testsuite/forge/src/backend/local/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{Factory, Result, Swarm, Version};
+use rand::rngs::StdRng;
 use std::{
     collections::HashMap,
     num::NonZeroUsize,
@@ -112,11 +113,16 @@ impl Factory for LocalFactory {
         Box::new(self.versions.keys().cloned())
     }
 
-    fn launch_swarm(&self, node_num: NonZeroUsize, version: &Version) -> Result<Box<dyn Swarm>> {
+    fn launch_swarm(
+        &self,
+        rng: &mut StdRng,
+        node_num: NonZeroUsize,
+        version: &Version,
+    ) -> Result<Box<dyn Swarm>> {
         let mut swarm = LocalSwarm::builder(self.versions.clone())
             .number_of_validators(node_num)
             .initial_version(version.clone())
-            .build()?;
+            .build(rng)?;
         swarm.launch()?;
 
         Ok(Box::new(swarm))

--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -115,7 +115,10 @@ impl LocalSwarmBuilder {
         self
     }
 
-    pub fn build(self) -> Result<LocalSwarm> {
+    pub fn build<R>(self, rng: R) -> Result<LocalSwarm>
+    where
+        R: ::rand::RngCore + ::rand::CryptoRng,
+    {
         let dir = if let Some(dir) = self.dir {
             if dir.exists() {
                 fs::remove_dir_all(&dir)?;
@@ -132,7 +135,7 @@ impl LocalSwarmBuilder {
         )
         .num_validators(self.number_of_validators)
         .template(self.template)
-        .build()?;
+        .build(rng)?;
 
         // Get the initial version to start the nodes with, either the one provided or fallback to
         // using the the latest version

--- a/testsuite/forge/src/interface/factory.rs
+++ b/testsuite/forge/src/interface/factory.rs
@@ -3,11 +3,17 @@
 
 use super::{Swarm, Version};
 use crate::Result;
+use rand::rngs::StdRng;
 use std::num::NonZeroUsize;
 
 /// Trait used to represent a interface for constructing a launching new networks
 pub trait Factory {
     fn versions<'a>(&'a self) -> Box<dyn Iterator<Item = Version> + 'a>;
 
-    fn launch_swarm(&self, node_num: NonZeroUsize, version: &Version) -> Result<Box<dyn Swarm>>;
+    fn launch_swarm(
+        &self,
+        rng: &mut StdRng,
+        node_num: NonZeroUsize,
+        version: &Version,
+    ) -> Result<Box<dyn Swarm>>;
 }

--- a/testsuite/forge/src/runner.rs
+++ b/testsuite/forge/src/runner.rs
@@ -211,9 +211,11 @@ impl<'cfg, F: Factory> Forge<'cfg, F> {
         if test_count > 0 {
             let initial_version = self.initial_version();
             let mut rng = ::rand::rngs::StdRng::from_seed(OsRng.gen());
-            let mut swarm = self
-                .factory
-                .launch_swarm(self.tests.initial_validator_count, &initial_version)?;
+            let mut swarm = self.factory.launch_swarm(
+                &mut rng,
+                self.tests.initial_validator_count,
+                &initial_version,
+            )?;
 
             // Run PublicUsageTests
             for test in self.filter_tests(self.tests.public_usage_tests.iter()) {


### PR DESCRIPTION
This cherry-pick was triggerd by a request on #8916
Please review the diff to ensure there are not any unexpected changes.

> Allow passing in an rng seed when running in --test mode. This is useful if you want to seed the rng used for the creation of the root and treasury keys during genesis.
> 
> Specifically you can now do the following:
> ```
> $ cargo run --bin diem-node -- --test --seed 0000000000000000000000000000000000000000000000000000000000000000
> ```
> 
> Where the seed is a hex encoded `[u8; 32]` (so 64 hex characters)

            
cc @ankushagarwal