### PR TITLE
[ir-testsuite] update tests cases with Post-compile bounds check marks

### DIFF
--- a/language/ir-testsuite/tests/move/commands/if_branch_diverges_5.mvir
+++ b/language/ir-testsuite/tests/move/commands/if_branch_diverges_5.mvir
@@ -12,5 +12,4 @@ main() {
         return;
     }
 }
-// check: "Post-compile bounds check errors"
 // check: INDEX_OUT_OF_BOUNDS

--- a/language/ir-testsuite/tests/move/commands/if_branch_diverges_6.mvir
+++ b/language/ir-testsuite/tests/move/commands/if_branch_diverges_6.mvir
@@ -8,5 +8,4 @@ main() {
         return;
     }
 }
-// check: "Post-compile bounds check errors"
 // check: INDEX_OUT_OF_BOUNDS

--- a/language/ir-testsuite/tests/move/commands/if_branch_diverges_8.mvir
+++ b/language/ir-testsuite/tests/move/commands/if_branch_diverges_8.mvir
@@ -8,5 +8,4 @@ main() {
         return;
     }
 }
-// check: "Post-compile bounds check errors"
 // check: INDEX_OUT_OF_BOUNDS


### PR DESCRIPTION
PR #8948 removes the `InternalCompilerError` error in the IR compiler,
hence, redundant messages like `Post-compile bounds check errors` are no
longer applicable in the tests.

Not sure why this is not caught in the CI of #8948, maybe because none of the
dependencies of the `ir-testsuite` are changed and hence, is not picked up by
the target-determinator.

## Motivation

Fix tests

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI
