### PR TITLE
[move] IR module definitions require an address

### DIFF
--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -295,7 +295,6 @@ fn test_change_publishing_option_to_custom() {
 ";
 
         let compiler = Compiler {
-            address: diem_types::account_config::CORE_CODE_ADDRESS,
             deps: diem_framework_releases::current_modules().iter().collect(),
         };
         compiler

--- a/language/bytecode-verifier/transactional-tests/tests/check_bounds/128_params_and_128_locals.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/check_bounds/128_params_and_128_locals.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     foo(
         p1 : u8,
         p2 : u8,

--- a/language/bytecode-verifier/transactional-tests/tests/check_bounds/1_param_and_255_locals.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/check_bounds/1_param_and_255_locals.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     foo(p1: u8) {
         let x1 : u8;
         let x2 : u8;

--- a/language/bytecode-verifier/transactional-tests/tests/check_bounds/too_few_type_actuals.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/check_bounds/too_few_type_actuals.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct S<T> { b: bool }
 
     foo() {

--- a/language/bytecode-verifier/transactional-tests/tests/check_bounds/too_many_type_actuals.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/check_bounds/too_many_type_actuals.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct S { b: bool }
 
     foo() {

--- a/language/bytecode-verifier/transactional-tests/tests/check_duplication/duplicate_field_name.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/check_duplication/duplicate_field_name.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     // duplicate field of the same name
     struct T{f: u64, f: u64}
 }

--- a/language/bytecode-verifier/transactional-tests/tests/check_duplication/empty_structs.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/check_duplication/empty_structs.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module EmptyStruct {
+//# publish
+module 0x1.EmptyStruct {
   // no empty structs allowed
   struct Empty { }
 

--- a/language/bytecode-verifier/transactional-tests/tests/control_flow/dead_return.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/control_flow/dead_return.mvir
@@ -1,9 +1,9 @@
-//# publish --address 0x1
+//# publish
 
 // TODO: we might need to modify this test if we enable unreachable code
 // checking in the verifier.
 
-module Test {
+module 0x1.Test {
     public t(): u64 {
         return 100;
         return 0;

--- a/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/complex_1.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/complex_1.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct S<T> { b: bool }
 
     a<T>() {
@@ -43,8 +43,8 @@ module M {
 // loop: f#T --> g#T --S<T>--> f#T
 // loop: c#T1 --> c#T2 --> d#T --> b#T2 --S<T2>--> c#T1
 
-//# publish --address 0x1
-module M2 {
+//# publish
+module 0x1.M2 {
     struct S<T> { b: bool }
 
     f<T>() {
@@ -60,9 +60,9 @@ module M2 {
 // loop: f#T --> g#T --S<T>--> f#T
 // check: LOOP_IN_INSTANTIATION_GRAPH
 
-//# publish --address 0x1
+//# publish
 
-module M3 {
+module 0x1.M3 {
     struct S<T> { b: bool }
 
     a<T>() {

--- a/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/mutually_recursive_just_type_params_ok.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/mutually_recursive_just_type_params_ok.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     f<T>() {
         Self.g<T>();
         return;

--- a/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/mutually_recursive_non_generic_type_ok.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/mutually_recursive_non_generic_type_ok.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct S<T> { b: bool }
 
     f<T>() {

--- a/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_just_type_params_shitfing_ok.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_just_type_params_shitfing_ok.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     f<T1, T2, T3>() {
         Self.g<T2, T3, T1>();
         return;

--- a/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_non_generic_types_ok.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_non_generic_types_ok.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct S<T> { b: bool }
 
     f<T1, T2, T3>() {

--- a/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_shifting.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_shifting.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct S<T> { b: bool }
 
     f<T1, T2, T3>() {

--- a/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/mutually_recursive_two_args_non_generic_type_and_type_param_ok.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/mutually_recursive_two_args_non_generic_type_and_type_param_ok.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     f<T1, T2>() {
         Self.g<u64, T1>();
         return;

--- a/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/mutually_recursive_two_args_swapping_just_type_params_ok.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/mutually_recursive_two_args_swapping_just_type_params_ok.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     f<T1, T2>() {
         Self.g<T2, T1>();
         return;

--- a/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/mutually_recursive_two_args_swapping_type_con.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/mutually_recursive_two_args_swapping_type_con.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct S<T> { b: bool }
 
     f<T1, T2>() {

--- a/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/mutually_recursive_type_con.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/mutually_recursive_type_con.mvir
@@ -1,9 +1,9 @@
-//# publish --address 0x1
+//# publish
 
 // Not good: infinitely many types/instances.
 //           f<T>, g<S<T>>, f<S<T>>, g<S<S<T>>>, ...
 
-module M {
+module 0x1.M {
     struct S<T> { b: bool }
 
     f<T>() {

--- a/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/nested_types_1.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/nested_types_1.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct S<T> { b: bool }
 
     foo<T>() {

--- a/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/nested_types_2.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/nested_types_2.mvir
@@ -1,6 +1,6 @@
-//# publish --address 0x1
+//# publish
 
-module M {
+module 0x1.M {
     struct S<T> { b: bool }
     struct R<T1, T2> { b: bool }
 

--- a/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/recursive_infinite_type_terminates.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/recursive_infinite_type_terminates.mvir
@@ -1,6 +1,6 @@
-//# publish --address 0x1
+//# publish
 
-module M {
+module 0x1.M {
     struct Box<T> { x: T }
 
     unbox<T>(b: Self.Box<T>): T {

--- a/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/recursive_one_arg_just_type_params_ok.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/recursive_one_arg_just_type_params_ok.mvir
@@ -1,8 +1,8 @@
-//# publish --address 0x1
+//# publish
 
 // This is good as there is only one instance foo<T> for any T.
 
-module M {
+module 0x1.M {
     f<T>(x: T) {
         Self.f<T>(move(x));
         return;

--- a/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/recursive_one_arg_non_generic_type_ok.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/recursive_one_arg_non_generic_type_ok.mvir
@@ -1,8 +1,8 @@
-//# publish --address 0x1
+//# publish
 
 // Good: two instances foo<T> & foo<u64> (if T != u64) for any T.
 
-module M {
+module 0x1.M {
     f<T>() {
         Self.f<u64>();
         return;

--- a/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/recursive_one_arg_type_con.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/recursive_one_arg_type_con.mvir
@@ -1,8 +1,8 @@
-//# publish --address 0x1
+//# publish
 
 // Bad! Can have infinitely many instances: f<T>, f<S<T>>, f<S<S<T>>>, ...
 
-module M {
+module 0x1.M {
     struct S<T> { b: bool }
 
     f<T>(x: T) {

--- a/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/recursive_two_args_swapping_type_con.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/recursive_two_args_swapping_type_con.mvir
@@ -1,9 +1,9 @@
-//# publish --address 0x1
+//# publish
 
 // Similar to the case with one argument, but swaps the two type parameters.
 // f<T1, T2> => f<S<T2>, T1> => f<S<T1>, S<T2>> => f<S<S<T2>>, S<T1>> => ...
 
-module M {
+module 0x1.M {
     struct S<T> { x: T }
 
     f<T1, T2>(a: T1, b: T2) {

--- a/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/two_loops.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/instantiation_loops/two_loops.mvir
@@ -1,9 +1,9 @@
-//# publish --address 0x1
+//# publish
 
 // Two loops in the resulting graph.
 // One error for the loop.
 
-module M {
+module 0x1.M {
     struct S<T> { b: bool }
 
     f<T>() {

--- a/language/bytecode-verifier/transactional-tests/tests/locals_safety/abort_unused_resource.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/locals_safety/abort_unused_resource.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct Coin { value: u64 }
     zero(): Self.Coin {
         return Coin { value: 0 };

--- a/language/bytecode-verifier/transactional-tests/tests/locals_safety/assign_resource.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/locals_safety/assign_resource.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct Coin { value: u64 }
     zero(): Self.Coin {
         return Coin { value: 0 };

--- a/language/bytecode-verifier/transactional-tests/tests/locals_safety/join_failure.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/locals_safety/join_failure.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct R { f:bool }
     t0() {
         let r: Self.R;
@@ -17,8 +17,8 @@ module M {
     }
 }
 
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct R { f:bool }
     t0() {
         let r: Self.R;
@@ -35,8 +35,8 @@ module M {
     }
 }
 
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct R { f:bool }
     t0() {
         let r: Self.R;
@@ -54,8 +54,8 @@ module M {
     }
 }
 
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct R has copy, drop { f:bool }
     t0() {
         let r: Self.R;
@@ -73,8 +73,8 @@ module M {
     }
 }
 
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct R { f:bool }
     t0() {
         let r: Self.R;

--- a/language/bytecode-verifier/transactional-tests/tests/locals_safety/vector_ops_non_droppable_resource_not_destroyed.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/locals_safety/vector_ops_non_droppable_resource_not_destroyed.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct R has store { b: bool }
     f() {
         let v: vector<Self.R>;

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_copy_ok.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_copy_ok.mvir
@@ -1,6 +1,6 @@
-//# publish --address 0x1
+//# publish
 
-module B {
+module 0x1.B {
     struct T has drop {g: u64}
 
     public new(g: u64): Self.T {

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_field_ok.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_field_ok.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module A {
+//# publish
+module 0x1.A {
 
     struct T has drop {v: u64}
     struct K has drop {f: Self.T}

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_1.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_1.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module A {
+//# publish
+module 0x1.A {
     import 0x1.Signer;
     struct T1 has key {v: u64}
 

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_2.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_2.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module A {
+//# publish
+module 0x1.A {
     import 0x1.Signer;
     struct T1 has key {v: u64}
     struct T2 has key {v: u64}

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_3.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_3.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module A {
+//# publish
+module 0x1.A {
     import 0x1.Signer;
     struct T1 has key {v: u64}
     struct T2 has key {v: u64}

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_duplicate_annotation.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_duplicate_annotation.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module A {
+//# publish
+module 0x1.A {
     import 0x1.Signer;
     struct T1 has key {v: u64}
 

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_extraneous_annotation.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_extraneous_annotation.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module A {
+//# publish
+module 0x1.A {
     struct T1 has key {v: u64}
 
     // unnecessary acquires annotation

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_invalid_1.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_invalid_1.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module A {
+//# publish
+module 0x1.A {
     import 0x1.Signer;
     struct T1 has key {v: u64}
 

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_invalid_2.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_invalid_2.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module A {
+//# publish
+module 0x1.A {
     import 0x1.Signer;
     struct T1 has key {v: u64}
     struct T2 has key {v: u64}
@@ -26,8 +26,8 @@ module A {
     }
 }
 
-//# publish --address 0x1
-module A2 {
+//# publish
+module 0x1.A2 {
     import 0x1.Signer;
     struct T1 has key {v: u64}
     struct T2 has key {v: u64}
@@ -55,7 +55,7 @@ module A2 {
 }
 
 //! new-transaction
-module A2 {
+module 0x1.A2 {
     import 0x1.Signer;
     struct T1 has key {v: u64}
     struct T2 has key {v: u64}

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_invalid_3.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_invalid_3.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module A {
+//# publish
+module 0x1.A {
     import 0x1.Signer;
     struct T1 has key {v: u64}
     struct T2 has key {v: u64}
@@ -30,8 +30,8 @@ module A {
     }
 }
 
-//# publish --address 0x1
-module A2 {
+//# publish
+module 0x1.A2 {
     import 0x1.Signer;
     struct T1 has key {v: u64}
     struct T2 has key {v: u64}
@@ -62,8 +62,8 @@ module A2 {
     }
 }
 
-//# publish --address 0x1
-module A3 {
+//# publish
+module 0x1.A3 {
     import 0x1.Signer;
     struct T1 has key {v: u64}
     struct T2 has key {v: u64}

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_invalid_annotation.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_invalid_annotation.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module A {
+//# publish
+module 0x1.A {
     struct T1{v: u64}
 
     // unnecessary acquire annotation

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_missing_annotation.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_missing_annotation.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module A {
+//# publish
+module 0x1.A {
     import 0x1.Signer;
     struct T1 has key {v: u64}
 

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_return_reference_1.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_return_reference_1.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module A {
+//# publish
+module 0x1.A {
     import 0x1.Signer;
     struct T1 has key {v: u64}
 

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_return_reference_invalid_1.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_return_reference_invalid_1.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module A {
+//# publish
+module 0x1.A {
     import 0x1.Signer;
     struct T1 has key {v: u64}
 

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_bad0.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_bad0.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module A {
+//# publish
+module 0x1.A {
     import 0x1.Signer;
     struct T has key {v: u64}
 

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_bad1.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_bad1.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module A {
+//# publish
+module 0x1.A {
     import 0x1.Signer;
     struct T has key {v: u64}
 

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_bad2.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_bad2.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module A {
+//# publish
+module 0x1.A {
     import 0x1.Signer;
     struct T has key {v: u64}
 

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_bad5.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_bad5.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module A {
+//# publish
+module 0x1.A {
     import 0x1.Signer;
     struct T has key {v: u64}
 

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_good.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_good.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module A {
+//# publish
+module 0x1.A {
     import 0x1.Signer;
     struct T has key {v: u64}
     struct U has key {v: u64}

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_return_mutable_borrow_bad.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_return_mutable_borrow_bad.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct X { f: Self.Y }
     struct Y { g: u64, h: u64 }
 

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/copy_loc_borrowed.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/copy_loc_borrowed.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Tester {
+//# publish
+module 0x1.Tester {
     t() {
         let x: u64;
         let r1: &u64;

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/copy_loc_borrowed_field.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/copy_loc_borrowed_field.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Tester {
+//# publish
+module 0x1.Tester {
     struct T has copy { f: u64 }
 
     t() {

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/copy_loc_borrowed_field_invalid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/copy_loc_borrowed_field_invalid.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Tester {
+//# publish
+module 0x1.Tester {
     struct T has copy { f: u64 }
 
     t() {

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/copy_loc_borrowed_indirect.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/copy_loc_borrowed_indirect.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Tester {
+//# publish
+module 0x1.Tester {
     t() {
         let x: u64;
         let y: u64;

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/copy_loc_borrowed_indirect_invalid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/copy_loc_borrowed_indirect_invalid.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Tester {
+//# publish
+module 0x1.Tester {
     t() {
         let x: u64;
         let y: u64;

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/copy_loc_borrowed_invalid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/copy_loc_borrowed_invalid.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Tester {
+//# publish
+module 0x1.Tester {
     t() {
         let x: u64;
         let r1: &mut u64;

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/deref_borrow_field_ok.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/deref_borrow_field_ok.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct T has drop {f: u64}
 
     public new(g: u64): Self.T {

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/deref_eq_bad.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/deref_eq_bad.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct T {v : u64}
 
     public new(v: u64): Self.T {

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/deref_eq_good.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/deref_eq_good.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct T {v : u64}
 
     public new(v: u64): Self.T {

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/eq_bad.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/eq_bad.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Tester {
+//# publish
+module 0x1.Tester {
     eqtest1() {
         let x: u64;
         let r: &mut u64;
@@ -12,8 +12,8 @@ module Tester {
     }
 }
 
-//# publish --address 0x1
-module Tester2 {
+//# publish
+module 0x1.Tester2 {
     eqtest2() {
         let x: u64;
         let r: &mut u64;
@@ -26,8 +26,8 @@ module Tester2 {
     }
 }
 
-//# publish --address 0x1
-module Tester3 {
+//# publish
+module 0x1.Tester3 {
     neqtest1() {
         let x: u64;
         let r: &mut u64;
@@ -40,8 +40,8 @@ module Tester3 {
     }
 }
 
-//# publish --address 0x1
-module Tester4 {
+//# publish
+module 0x1.Tester4 {
     neqtest2() {
         let x: u64;
         let r: &mut u64;

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/eq_ok.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/eq_ok.mvir
@@ -1,7 +1,7 @@
-//# publish --address 0x1
+//# publish
 
 // testing valid usages of == and != over references
-module Tester {
+module 0x1.Tester {
     eqtest1() {
         let x: u64;
         let r: &mut u64;

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/factor_invalid_1.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/factor_invalid_1.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct X has drop { f: Self.Y }
     struct Y has drop { g: u64, h: u64 }
 
@@ -26,8 +26,8 @@ module M {
     }
 }
 
-//# publish --address 0x1
-module M2 {
+//# publish
+module 0x1.M2 {
     struct X has drop { f: Self.Y }
     struct Y has drop { g: u64, h: u64 }
     t2() {

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/factor_invalid_2.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/factor_invalid_2.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct S { g: u64 }
 
     t1(root: &mut Self.S, cond: bool) {

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/factor_valid_1.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/factor_valid_1.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct X has drop { f: Self.Y }
     struct Y has drop { g: u64, h: u64 }
 

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/factor_valid_2.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/factor_valid_2.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct S { g: u64 }
 
     t1(root: &mut Self.S, cond: bool) {

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_global.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_global.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module A {
+//# publish
+module 0x1.A {
     struct Coin has store { u: u64 }
 
     public new(): Self.Coin {
@@ -25,8 +25,8 @@ module A {
     }
 }
 
-//# publish --address 0x1
-module Tester {
+//# publish
+module 0x1.Tester {
     import 0x1.Signer;
     import 0x1.A;
 

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_global_invalid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_global_invalid.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module A {
+//# publish
+module 0x1.A {
     struct Coin has store { u: u64 }
 
     public new(): Self.Coin {
@@ -25,8 +25,8 @@ module A {
     }
 }
 
-//# publish --address 0x1
-module Tester {
+//# publish
+module 0x1.Tester {
     import 0x1.A;
 
     struct Pair has key { x: A.Coin, y: A.Coin }
@@ -42,8 +42,8 @@ module Tester {
     }
 }
 
-//# publish --address 0x1
-module Tester {
+//# publish
+module 0x1.Tester {
     import 0x1.A;
 
     struct Pair has key { x: A.Coin, y: A.Coin }
@@ -58,8 +58,8 @@ module Tester {
     }
 }
 
-//# publish --address 0x1
-module Tester {
+//# publish
+module 0x1.Tester {
     import 0x1.A;
 
     struct Pair has key { x: A.Coin, y: A.Coin }

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_global_lossy_acquire_invalid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_global_lossy_acquire_invalid.mvir
@@ -1,6 +1,6 @@
-//# publish --address 0x1
+//# publish
 
-module A {
+module 0x1.A {
     struct Coin has store { u: u64 }
 
     public new(): Self.Coin {
@@ -26,9 +26,9 @@ module A {
     }
 }
 
-//# publish --address 0x1
+//# publish
 
-module Tester {
+module 0x1.Tester {
     import 0x1.A;
 
     struct Pair has key { x: A.Coin, y: A.Coin }

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_global_requires_acquire.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_global_requires_acquire.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module A {
+//# publish
+module 0x1.A {
     struct T1 has key { b: bool }
 
     // missing acquires annotation

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_loc.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_loc.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Tester {
+//# publish
+module 0x1.Tester {
     import 0x1.Signer;
 
     struct Data has key { v1: u64, v2: u64 }

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_loc_trivial.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_loc_trivial.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Tester {
+//# publish
+module 0x1.Tester {
     struct X has key { f: u64 }
 
     bump_and_give(x_ref: &mut Self.X, other: &u64): &u64 {

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_loc_trivial_valid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_loc_trivial_valid.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Tester {
+//# publish
+module 0x1.Tester {
     struct X has key { f: u64 }
 
     bump_and_give(x_ref: &mut Self.X, other: &u64): &u64 {

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_loc_valid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_loc_valid.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Tester {
+//# publish
+module 0x1.Tester {
     import 0x1.Signer;
 
     struct Data has key { v1: u64, v2: u64 }

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_on_mut.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_on_mut.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Tester {
+//# publish
+module 0x1.Tester {
     import 0x1.Signer;
 
     struct Initializer has key { x: u64, y: u64 }

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_on_mut_invalid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_on_mut_invalid.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Tester {
+//# publish
+module 0x1.Tester {
     import 0x1.Signer;
 
     struct Initializer has key { x: u64, y: u64 }
@@ -49,8 +49,8 @@ module Tester {
     }
 }
 
-//# publish --address 0x1
-module Tester2 {
+//# publish
+module 0x1.Tester2 {
     import 0x1.Signer;
 
     struct Initializer has key { x: u64, y: u64 }

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_on_mut_trivial.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_on_mut_trivial.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Tester {
+//# publish
+module 0x1.Tester {
     struct X { f: u64 }
 
     bump_and_give(x_ref: &mut Self.X): &u64 {

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_on_mut_trivial_invalid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_on_mut_trivial_invalid.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Tester {
+//# publish
+module 0x1.Tester {
     struct X { f: u64 }
 
     bump_and_give(x_ref: &mut Self.X): &u64 {

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/join_borrow_unavailable_valid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/join_borrow_unavailable_valid.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct S { f: u64 }
 
     t1(root: &mut Self.S, cond: bool) {

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/move_one_branch.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/move_one_branch.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     t0(cond: bool) {
         let x: u64;
         let x_ref: &mut u64;

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/mutable_borrow_invalid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/mutable_borrow_invalid.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct S { f: u64, g: u64, h: u64 }
 
 
@@ -19,8 +19,8 @@ module M {
     }
 }
 
-//# publish --address 0x1
-module M2 {
+//# publish
+module 0x1.M2 {
 
     struct S { f: u64, g: u64, h: u64 }
 

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/mutable_borrow_local_twice.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/mutable_borrow_local_twice.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     t1() {
         let a: u64;
         let r1: &mut u64;

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/mutable_borrow_local_twice_invalid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/mutable_borrow_local_twice_invalid.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     t1() {
         let a: u64;
         let r1: &mut u64;

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/mutate_with_borrowed_loc.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/mutate_with_borrowed_loc.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     t1() {
         let x: u64;
         let y: &u64;

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/mutate_with_borrowed_loc_invalid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/mutate_with_borrowed_loc_invalid.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     t1() {
         let x: u64;
         let y: &u64;

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/mutate_with_borrowed_loc_struct_invalid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/mutate_with_borrowed_loc_struct_invalid.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct X { b: bool }
     struct S { z: u64 }
     t1() {
@@ -16,8 +16,8 @@ module M {
     }
 }
 
-//# publish --address 0x1
-module N {
+//# publish
+module 0x1.N {
     struct X { b: bool }
     struct S { z: u64 }
     t2() {

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/ref_moved_one_branch.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/ref_moved_one_branch.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module A {
+//# publish
+module 0x1.A {
     struct S {value: u64}
 
     public t(changed: bool, s: &mut Self.S) {

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/release_cycle.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/release_cycle.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     t0(cond: bool) {
         let v: u64;
         let x: &u64;

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/return_with_borrowed_loc.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/return_with_borrowed_loc.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct X has drop { y: Self.Y }
     struct Y has drop { u: u64 }
 

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/return_with_borrowed_loc_invalid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/return_with_borrowed_loc_invalid.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct X has drop { y: Self.Y }
     struct Y has drop { u: u64 }
 
@@ -13,8 +13,8 @@ module M {
     }
 }
 
-//# publish --address 0x1
-module M2 {
+//# publish
+module 0x1.M2 {
     struct X has drop { y: Self.Y }
     struct Y has drop { u: u64 }
     t2(): &u64 {
@@ -27,8 +27,8 @@ module M2 {
     }
 }
 
-//# publish --address 0x1
-module M3 {
+//# publish
+module 0x1.M3 {
     struct X has drop { y: Self.Y }
     struct Y has drop { u: u64 }
     t3(): &u64 {
@@ -45,8 +45,8 @@ module M3 {
     }
 }
 
-//# publish --address 0x1
-module M4 {
+//# publish
+module 0x1.M4 {
     struct X has drop { y: Self.Y }
     struct Y has drop { u: u64 }
     t4(): &u64 {

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/return_with_borrowed_loc_resource_invalid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/return_with_borrowed_loc_resource_invalid.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct X { u: u64 }
 
     t() {

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/writeref_borrow_invalid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/writeref_borrow_invalid.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct G has drop { v: u64 }
     struct S has drop { g: Self.G }
 

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/writeref_borrow_valid1.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/writeref_borrow_valid1.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct G has drop { v1: u64, v2: u64 }
     struct S { g1: Self.G, g2: Self.G }
 

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/writeref_borrow_valid2.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/writeref_borrow_valid2.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct S { f: u64, g: u64, h: u64 }
 
     t1(root: &mut Self.S, cond: bool) {

--- a/language/bytecode-verifier/transactional-tests/tests/signature/all_as_all_ok.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/signature/all_as_all_ok.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct S<T> { b: bool }
 
     foo<T>() {

--- a/language/bytecode-verifier/transactional-tests/tests/signature/all_as_resource.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/signature/all_as_resource.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct S<T: key> { b: bool }
 
     foo<T>() {

--- a/language/bytecode-verifier/transactional-tests/tests/signature/all_as_unrestricted.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/signature/all_as_unrestricted.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct S<T: copy + drop> { b: bool }
 
     foo<T>() {

--- a/language/bytecode-verifier/transactional-tests/tests/signature/reference_as_type_actual_for_bytecode_instruction.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/signature/reference_as_type_actual_for_bytecode_instruction.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     id<T>(x: T) { return move(x); }
 
     foo() {

--- a/language/bytecode-verifier/transactional-tests/tests/signature/reference_as_type_actual_for_struct.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/signature/reference_as_type_actual_for_struct.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct S<T> { b: bool }
 
     foo() {

--- a/language/bytecode-verifier/transactional-tests/tests/signature/reference_as_type_actual_in_struct_inst_for_bytecode_instruction.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/signature/reference_as_type_actual_in_struct_inst_for_bytecode_instruction.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     import 0x1.Signer;
 
     struct Some<T> has key { item: T }
@@ -11,8 +11,8 @@ module M {
     }
 }
 
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     import 0x1.Signer;
 
     struct Some<T> has key { item: T }
@@ -25,8 +25,8 @@ module M {
     }
 }
 
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     import 0x1.Signer;
 
     struct Some<T> has key { item: T }
@@ -38,8 +38,8 @@ module M {
     }
 }
 
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     import 0x1.Signer;
 
     struct Some<T> has key { item: T }
@@ -53,7 +53,7 @@ module M {
 // check: INVALID_SIGNATURE_TOKEN
 
 //! new-transaction
-module M {
+module 0x1.M {
     import 0x1.Signer;
 
     struct Some<T> has key { item: T }
@@ -64,8 +64,8 @@ module M {
     }
 }
 
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct Some<T> { item: T }
 
     foo() {
@@ -80,8 +80,8 @@ module M {
     }
 }
 
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct Some<T> { item: T }
 
     foo() {
@@ -94,8 +94,8 @@ module M {
     }
 }
 
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct S<T> { v: T }
 
     // cannot use refs in generics
@@ -104,8 +104,8 @@ module M {
     }
 }
 
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct S<T> { v: T }
 
     // cannot use refs in generics

--- a/language/bytecode-verifier/transactional-tests/tests/signature/resource_as_all_ok.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/signature/resource_as_all_ok.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct S<T> { b: bool }
     struct R { b: bool }
 

--- a/language/bytecode-verifier/transactional-tests/tests/signature/resource_as_unrestricted.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/signature/resource_as_unrestricted.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct S<T: copy + drop> { b: bool }
     struct R { b: bool }
 

--- a/language/bytecode-verifier/transactional-tests/tests/signature/two_type_actuals_ok.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/signature/two_type_actuals_ok.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct R has key { b: bool}
     struct S<T1: key, T2: copy + drop> { b: bool }
 

--- a/language/bytecode-verifier/transactional-tests/tests/signature/two_type_actuals_reverse_order.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/signature/two_type_actuals_reverse_order.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct S<T1: key, T2: copy + drop> { b: bool }
 
     foo() {
@@ -9,8 +9,8 @@ module M {
     }
 }
 
-//# publish --address 0x1
-module M2 {
+//# publish
+module 0x1.M2 {
     struct R has key { b: bool }
     struct S<T1: key, T2: copy + drop> { b: bool }
 

--- a/language/bytecode-verifier/transactional-tests/tests/signature/unrestricted_as_all_ok.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/signature/unrestricted_as_all_ok.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct S<T> { b: bool }
 
     foo() {

--- a/language/bytecode-verifier/transactional-tests/tests/signature/unrestricted_as_resource.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/signature/unrestricted_as_resource.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct S<T: key> { b: bool }
 
     foo() {

--- a/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/abort_positive_stack_size.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/abort_positive_stack_size.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
 
     public foo(): u64 {
         return 0;

--- a/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/consume_stack.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/consume_stack.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct R has key { data: vector<u8> }
 
     is_ok_(addr: &address, data: &vector<u8>): bool {

--- a/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/function_call_negative_stack_err_1.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/function_call_negative_stack_err_1.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Test {
+//# publish
+module 0x1.Test {
     public baz(k: u64, l: u64, m: u64) : u64 {
         let z: u64;
         z =  move(k) + move(l) + move(m);

--- a/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/function_call_negative_stack_err_2.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/function_call_negative_stack_err_2.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module A {
+//# publish
+module 0x1.A {
     public push_u64(): u64  {
         return 42;
     }

--- a/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/function_composition_pos_and_neg_stack_err.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/function_composition_pos_and_neg_stack_err.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module A {
+//# publish
+module 0x1.A {
     public parity(u: u64): u64 * bool {
         return copy(u), (move(u) % 2 == 0);
     }

--- a/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/function_composition_positive_stack_err_1.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/function_composition_positive_stack_err_1.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Test {
+//# publish
+module 0x1.Test {
     public foo(v: u64): u64 * u64 {
         let one_less: u64;
         let one_more: u64;

--- a/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/function_composition_positive_stack_err_2.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/function_composition_positive_stack_err_2.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module A {
+//# publish
+module 0x1.A {
     public parity(u: u64): u64 * bool {
         return copy(u), (move(u) % 2 == 0);
     }

--- a/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/multiple_return_values.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/multiple_return_values.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Test {
+//# publish
+module 0x1.Test {
     struct T { b: bool }
 
     public new(): Self.T {

--- a/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/multiple_return_values_extra_binding.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/multiple_return_values_extra_binding.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Test {
+//# publish
+module 0x1.Test {
     struct T { b: bool }
 
     public new(): Self.T {

--- a/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/multiple_return_values_extra_value.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/multiple_return_values_extra_value.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Test {
+//# publish
+module 0x1.Test {
     struct T { b: bool }
 
     public new(): Self.T {

--- a/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/multiple_return_values_missing_binding.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/multiple_return_values_missing_binding.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Test {
+//# publish
+module 0x1.Test {
     struct T { b: bool }
 
     public new(): Self.T {

--- a/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/multiple_return_values_missing_value.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/multiple_return_values_missing_value.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Test {
+//# publish
+module 0x1.Test {
     struct T { b: bool }
 
     public new(): Self.T {

--- a/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/pop_exact.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/pop_exact.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module A {
+//# publish
+module 0x1.A {
     three(): u64 * u64 * u64 {
         return 0, 1, 2;
     }

--- a/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/pop_negative.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/pop_negative.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module A {
+//# publish
+module 0x1.A {
     three(): u64 * u64 * u64 {
         return 0, 1, 2;
     }

--- a/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/pop_positive.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/pop_positive.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module A {
+//# publish
+module 0x1.A {
     three(): u64 * u64 * u64 {
         return 0, 1, 2;
     }

--- a/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/unpack_extra_binding.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/unpack_extra_binding.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Test {
+//# publish
+module 0x1.Test {
     struct X { b: bool }
     struct T { i: u64, x: Self.X }
 

--- a/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/unpack_missing_binding.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/unpack_missing_binding.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Test {
+//# publish
+module 0x1.Test {
     struct X { b: bool }
     struct T { i: u64, x: Self.X, b: bool, y: u64 }
 

--- a/language/bytecode-verifier/transactional-tests/tests/struct_defs/recursive_struct.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/struct_defs/recursive_struct.mvir
@@ -1,19 +1,19 @@
-//# publish --address 0x1
-module Cup {
+//# publish
+module 0x1.Cup {
     struct Cup<T> { f: T }
     public cup<T>(f: T): Self.Cup<T> {
         return Cup<T> { f: move(f) };
     }
 }
 
-//# publish --address 0x1
-module M0 {
+//# publish
+module 0x1.M0 {
     // recursive struct
     struct Foo { f: Self.Foo }
 }
 
-//# publish --address 0x1
-module M1 {
+//# publish
+module 0x1.M1 {
     import 0x1.Cup;
     // recursive struct
     struct Foo { f: Cup.Cup<Self.Foo> }
@@ -25,8 +25,8 @@ module M1 {
 
 }
 
-//# publish --address 0x1
-module M2 {
+//# publish
+module 0x1.M2 {
     import 0x1.Signer;
 
     struct X { y: vector<Self.Y> }
@@ -44,8 +44,8 @@ module M2 {
     }
 }
 
-//# publish --address 0x1
-module M3 {
+//# publish
+module 0x1.M3 {
     import 0x1.Cup;
 
     // recursive struct
@@ -53,8 +53,8 @@ module M3 {
 
 }
 
-//# publish --address 0x1
-module M3 {
+//# publish
+module 0x1.M3 {
     import 0x1.Cup;
 
     // indirect recursive struct

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/cant_deref_resource.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/cant_deref_resource.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Token {
+//# publish
+module 0x1.Token {
     import 0x1.Signer;
 
     struct T has key {v: u64}

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/equality_resource_refs.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/equality_resource_refs.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Token {
+//# publish
+module 0x1.Token {
     struct T has key { b: bool }
 
     public test() {

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/equality_resource_values.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/equality_resource_values.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Token {
+//# publish
+module 0x1.Token {
     struct T has key { b: bool }
 
     public test() {

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_borrow_field.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_borrow_field.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct Foo<T>{ x: T }
 
     baz(x: u64) {

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_borrow_global.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_borrow_global.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct Foo<T> { x: T }
 
     bar() acquires Foo {

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_borrow_global_mut.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_borrow_global_mut.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct Foo<T: copy + drop> { x: T }
 
     f(): u64 acquires Foo {

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_call.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_call.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     id<T>(x: T): T {
         return move(x);
     }

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_exists.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_exists.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct Foo<T> { x: T }
 
     exists_foo_u64(): bool {

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_imm_borrow_field.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_imm_borrow_field.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct Foo<T>{ x: T }
 
     baz(x: u64) {

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_pack.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_pack.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct Foo<T1, T2> { x: T1, y: T2 }
 
     foo<T>(x: T): Self.Foo<u64, T> {

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_struct_non_nominal_resource.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_struct_non_nominal_resource.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct R { b: bool }
     struct Box<T> { x: T }
 

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_type_param_all.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_type_param_all.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     foo<T>(x: T): T {
         let y: T;
         // generic does not have copy

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_type_param_resource.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_type_param_resource.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     foo<T: key>(x: T) {
         let y: T;
         // generic does not have copy

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_unpack.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_unpack.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct Foo<T> { x: T }
 
     baz<T>(x: Self.Foo<T>) {

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_builtins.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_builtins.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     import 0x1.Signer;
 
     struct Foo<T> has key, store { x: T }

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_call.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_call.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct Foo { f: bool }
 
     public id<T>(x: T): T {

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_field_borrow.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_field_borrow.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct X has drop { v: u64 }
     struct S<T> has drop { f: T }
     t(s: Self.S<Self.X>): u64 {

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_field_borrow_after_call.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_field_borrow_after_call.mvir
@@ -1,6 +1,6 @@
-//# publish --address 0x1
+//# publish
 
-module M {
+module 0x1.M {
     struct X has drop { v: u64 }
     id<T>(x: &T): &T {
         return move(x);

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_function_def.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_function_def.mvir
@@ -1,10 +1,10 @@
-//# publish --address 0x1
+//# publish
 
 // This test checks that for each function definition
 //   1) type parameters have correct kind constraints
 //   2) variables have correct types
 
-module M {
+module 0x1.M {
     public id<T>(x: T): T {
         return move(x);
     }

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_id_function.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_id_function.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     public id<T>(x: T): T {
         return move(x);
     }

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_import_function.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_import_function.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct R has key { f: bool }
 
     public foo<T>(x: T) {

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_import_struct.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_import_struct.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct Foo<T> has key { x: T }
 
     struct Bar<T1, T2: key, T3: copy + drop> { x: T3, y: T2, z: T1 }

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_option.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_option.mvir
@@ -1,7 +1,7 @@
-//# publish --address 0x42
+//# publish
 
 // example using generics in a few common/interesting/non-trivial ways
-module Option {
+module 0x42.Option {
     import 0x1.Vector;
 
     struct T<E> has copy, drop, store {

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_pack.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_pack.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct Foo<T> { x: T }
 
     foo() {
@@ -10,8 +10,8 @@ module M {
     }
 }
 
-//# publish --address 0x1
-module N {
+//# publish
+module 0x1.N {
     struct Foo<T1, T2: key> { x: T1, y: T2 }
     struct Bar has key { f: bool }
 

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_struct_def.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_struct_def.mvir
@@ -1,10 +1,10 @@
-//# publish --address 0x1
+//# publish
 
 // This test checks that for each struct definition
 //   1) type parameters have correct kind constraints
 //   2) fields have correct types
 
-module M {
+module 0x1.M {
     struct Foo<T> { x: T }
     struct Bar<T1, T2, T3: key, T4: copy + drop> { x1: T2, x2: T3, x3: T4, x4: T1 }
 }

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_unpack.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_unpack.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct Foo<T> { x: T }
 
     foo() {
@@ -10,8 +10,8 @@ module M {
     }
 }
 
-//# publish --address 0x1
-module N {
+//# publish
+module 0x1.N {
     struct Foo<T1: copy + drop, T2> { x: T1, y: T2 }
 
     foo() {

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/phantom_params/bytecode_ops_abilities_bad.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/phantom_params/bytecode_ops_abilities_bad.mvir
@@ -1,14 +1,14 @@
-//# publish --address 0x1
+//# publish
 
 // This file contains tests checking that type arguments used in phantom position
 // (phantom arguments) are not considered when deriving the abilities for a struct.
 
-module M1 {
+module 0x1.M1 {
     struct NoAbilities { a: bool }
 }
 
-//# publish --address 0x1
-module M2 {
+//# publish
+module 0x1.M2 {
     import 0x1.M1;
 
     struct HasDrop<phantom T1, T2> has drop { a: bool }
@@ -20,8 +20,8 @@ module M2 {
     }
 }
 
-//# publish --address 0x1
-module M3 {
+//# publish
+module 0x1.M3 {
     import 0x1.M1;
 
     struct HasDrop<phantom T1, T2> has drop { a: bool }
@@ -33,8 +33,8 @@ module M3 {
     }
  }
 
-//# publish --address 0x1
- module M4 {
+//# publish
+ module 0x1.M4 {
     import 0x1.M1;
 
     struct HasDrop<phantom T1, T2> has drop { a: bool }
@@ -45,8 +45,8 @@ module M3 {
     }
  }
 
-//# publish --address 0x1
- module M5 {
+//# publish
+ module 0x1.M5 {
     import 0x1.M1;
     struct HasCopy<phantom T1, T2> has copy { a : bool }
 
@@ -56,8 +56,8 @@ module M3 {
     }
  }
 
-//# publish --address 0x1
- module M6 {
+//# publish
+ module 0x1.M6 {
     import 0x1.M1;
 
     struct HasKey<phantom T1, T2> has key { a : bool }
@@ -70,8 +70,8 @@ module M3 {
 
  }
 
-//# publish --address 0x1
- module M7 {
+//# publish
+ module 0x1.M7 {
     import 0x1.M1;
 
     struct HasKey<phantom T1, T2> has key { a : bool }
@@ -82,8 +82,8 @@ module M3 {
     }
  }
 
-//# publish --address 0x1
- module M8 {
+//# publish
+ module 0x1.M8 {
     import 0x1.M1;
 
     struct HasKey<phantom T1, T2> has key { a : bool }
@@ -94,8 +94,8 @@ module M3 {
     }
 }
 
-//# publish --address 0x1
-module M9 {
+//# publish
+module 0x1.M9 {
     import 0x1.M1;
 
     struct HasStore<phantom T1, T2> has store { a: bool }

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/phantom_params/bytecode_ops_abilities_ok.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/phantom_params/bytecode_ops_abilities_ok.mvir
@@ -1,10 +1,10 @@
-//# publish --address 0x1
+//# publish
 
 // Test checking that type arguments used in phantom position (phantom arguments)
 // are not considered when deriving the abilities for a struct by checking against
 // abilities required for specific bytecode operatiosn.
 
-module M {
+module 0x1.M {
     struct NoAbilities { a: bool }
     struct HasDrop<phantom T1, T2> has drop { a: bool }
     struct HasCopy<phantom T1, T2> has copy { a : bool }

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/phantom_params/constraints_abilities_bad.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/phantom_params/constraints_abilities_bad.mvir
@@ -1,11 +1,11 @@
-//# publish --address 0x1
-module M1 {
+//# publish
+module 0x1.M1 {
     struct NoAbilities { a: bool }
     struct HasAbilities<phantom T1, T2> has drop, copy, store, key { a: bool }
 }
 
-//# publish --address 0x1
-module M2 {
+//# publish
+module 0x1.M2 {
     import 0x1.M1;
 
     struct S1<T: drop + copy + store + key> { a: bool }
@@ -16,7 +16,7 @@ module M2 {
 
 //! new-transaction
 
-module M3 {
+module 0x1.M3 {
     import 0x1.M1;
 
     struct HasDrop<phantom T1, T2> has drop { a: bool }
@@ -34,8 +34,8 @@ module M3 {
     }
 }
 
-//# publish --address 0x1
-module M4 {
+//# publish
+module 0x1.M4 {
     import 0x1.M1;
 
     f1<T: drop + copy + store + key>() { return; }
@@ -46,8 +46,8 @@ module M4 {
 }
 
 
-//# publish --address 0x1
-module M5 {
+//# publish
+module 0x1.M5 {
     import 0x1.M1;
     import 0x1.M3;
 

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/phantom_params/constraints_abilities_ok.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/phantom_params/constraints_abilities_ok.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct NoAbilities { a: bool }
     struct HasDrop<phantom T1, T2> has drop { a: bool }
     struct HasCopy<phantom T1, T2> has copy { a: bool }

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/phantom_params/fields_abilities_bad.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/phantom_params/fields_abilities_bad.mvir
@@ -1,9 +1,9 @@
-//# publish --address 0x1
+//# publish
 
 // Negative version of tests in fields_abilities_ok instantiating the non-phantom
 // parameter with a type without the required abilities.
 
-module M1 {
+module 0x1.M1 {
     struct NoAbilities { a: bool }
 
     struct HasDrop<phantom T1, T2> has drop { a: bool }
@@ -13,29 +13,29 @@ module M1 {
 
 }
 
-//# publish --address 0x1
-module M2 {
+//# publish
+module 0x1.M2 {
     import 0x1.M1;
 
     struct S has drop { a: M1.HasDrop<M1.NoAbilities, M1.NoAbilities> }
 }
 
-//# publish --address 0x1
-module M3 {
+//# publish
+module 0x1.M3 {
     import 0x1.M1;
 
     struct S has copy { a: M1.HasCopy<M1.NoAbilities, M1.NoAbilities> }
 }
 
-//# publish --address 0x1
-module M4 {
+//# publish
+module 0x1.M4 {
     import 0x1.M1;
 
     struct S has store { a: M1.HasStore<M1.NoAbilities, M1.NoAbilities> }
 }
 
-//# publish --address 0x1
-module M5 {
+//# publish
+module 0x1.M5 {
     import 0x1.M1;
 
     struct S has key { a: M1.HasStore<M1.NoAbilities, M1.NoAbilities> }

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/phantom_params/fields_abilities_ok.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/phantom_params/fields_abilities_ok.mvir
@@ -1,9 +1,9 @@
-//# publish --address 0x1
+//# publish
 
 // This module checks that phantom arguments are not considered by checking against
 // the abilities required for the fields of a struct.
 
-module M {
+module 0x1.M {
     struct NoAbilities { a: bool }
 
     struct HasDrop<phantom T1, T2> has drop { a: bool }

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/phantom_params/struct_definition_bad.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/phantom_params/struct_definition_bad.mvir
@@ -1,25 +1,25 @@
-//# publish --address 0x1
+//# publish
 
 // Tests checking incorrect struct declarations using phantom parameters
 // in illegal positions.
 
-module M1 {
+module 0x1.M1 {
     // A phantom parameter cannot be used as the type of a field
     struct S1<phantom T> {
         a: T
     }
 }
 
-//# publish --address 0x1
-module M2 {
+//# publish
+module 0x1.M2 {
     // The parameter of vector is non-phantom and a phantom parameter shouldn't be allowed in that position
     struct S2<phantom T> {
         a: vector<T>
     }
 }
 
-//# publish --address 0x1
-module M3 {
+//# publish
+module 0x1.M3 {
     // A phantom parameter cannot be used as the argument to a non-phantom parameter
     struct S1<T> { f: bool }
     struct S2<phantom T> {
@@ -27,8 +27,8 @@ module M3 {
     }
 }
 
-//# publish --address 0x1
-module M4 {
+//# publish
+module 0x1.M4 {
     // More complicated test where the phantom position violation is inside another
     // type argument.
     struct S1<T> { a: T}
@@ -38,16 +38,16 @@ module M4 {
     }
 }
 
-//# publish --address 0x1
-module M5 {
+//# publish
+module 0x1.M5 {
     // Mixing phantom and non-phantom parameters
     struct S<T1, phantom T2, T3> {
         a: T2
     }
 }
 
-//# publish --address 0x1
-module M6 {
+//# publish
+module 0x1.M6 {
     // Phantom parameters should satisfy constraints
     struct S1<phantom T: copy> { a: bool }
     struct S2<phantom T> {

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/phantom_params/struct_definition_ok.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/phantom_params/struct_definition_ok.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M1 {
+//# publish
+module 0x1.M1 {
     // Not using a phantom parameter at all is ok.
     struct S1<phantom T> {
         a: u64
@@ -23,8 +23,8 @@ module M1 {
     }
 }
 
-//# publish --address 0x1
-module M2 {
+//# publish
+module 0x1.M2 {
     import 0x1.M1;
 
     // Phantom position across modules
@@ -33,8 +33,8 @@ module M2 {
     }
 }
 
-//# publish --address 0x1
-module M3 {
+//# publish
+module 0x1.M3 {
     // Phantom parameters should be allowed to be declared with constraints.
 
     struct S1<phantom T: copy> {

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/release.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/release.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct Coin { value: u64 }
     t(): Self.Coin {
         // cannot pop without the drop ability

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/return_type_mismatch_and_unused_resource.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/return_type_mismatch_and_unused_resource.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct R { flag: bool }
 
     // Type checking is done before memory safety checks
@@ -11,8 +11,8 @@ module M {
     }
 }
 
-//# publish --address 0x1
-module M2 {
+//# publish
+module 0x1.M2 {
     // Type checking is done before memory safety checks
     // wrong return type
     t2(): bool {
@@ -24,8 +24,8 @@ module M2 {
     }
 }
 
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct R { flag: bool }
 
     t1(): u64 {
@@ -36,8 +36,8 @@ module M {
     }
 }
 
-//# publish --address 0x1
-module M2 {
+//# publish
+module 0x1.M2 {
     t2(): &u64 {
         let u: u64;
         let r: &u64;

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/struct_kind_inference.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/struct_kind_inference.mvir
@@ -1,6 +1,6 @@
-//# publish --address 0x1
+//# publish
 // ensure that generic structs instantiated with struct types behave like resources
-module M1 {
+module 0x1.M1 {
     struct MyResource { b: bool }
     struct S<T> { t: T }
 
@@ -10,8 +10,8 @@ module M1 {
     }
 }
 
-//# publish --address 0x1
-module M2 {
+//# publish
+module 0x1.M2 {
     struct MyResource { b: bool }
     struct S<T> { t: T }
 
@@ -22,8 +22,8 @@ module M2 {
     }
 }
 
-//# publish --address 0x1
-module M3 {
+//# publish
+module 0x1.M3 {
     struct MyResource { b: bool }
     struct S<T> { t: T }
 
@@ -33,8 +33,8 @@ module M3 {
     }
 }
 
-//# publish --address 0x1
-module M4 {
+//# publish
+module 0x1.M4 {
     struct MyResource { b: bool }
     struct S<T> { t: T }
 
@@ -45,8 +45,8 @@ module M4 {
     }
 }
 
-//# publish --address 0x1
-module M5 {
+//# publish
+module 0x1.M5 {
     struct MyResource { b: bool }
     struct S<T> { t: T }
 

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/unpack_resource.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/unpack_resource.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Test {
+//# publish
+module 0x1.Test {
     struct X { b: bool }
     struct T { i: u64, x: Self.X, b: bool }
 

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/unpack_wrong_type.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/unpack_wrong_type.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Test {
+//# publish
+module 0x1.Test {
     struct X { b: bool }
     struct T { b: bool }
 

--- a/language/compiler/README.md
+++ b/language/compiler/README.md
@@ -31,7 +31,7 @@ automatically calls the bytecode verifier at the end of compilation.
 
 ```text
 USAGE:
-    compiler [FLAGS] [OPTIONS] <source-path> --address <address>
+    compiler [FLAGS] [OPTIONS] <source-path>
 
 FLAGS:
     -h, --help                 Prints help information
@@ -42,8 +42,7 @@ FLAGS:
     -V, --version              Prints version information
 
 OPTIONS:
-    -a, --address <address>    Account address used for publishing
-    -d, --deps <deps-path>     Path to the list of modules that we want to link with
+    -d, --deps <deps-path>    Path to the list of modules that we want to link with
 
 ARGS:
     <source-path>    Path to the Move IR source to compile

--- a/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
@@ -2091,7 +2091,7 @@ fn is_struct_decl(tokens: &mut Lexer) -> Result<bool, ParseError<Loc, anyhow::Er
 
 fn parse_module(tokens: &mut Lexer) -> Result<ModuleDefinition, ParseError<Loc, anyhow::Error>> {
     consume_token(tokens, Tok::Module)?;
-    let name = parse_name(tokens)?;
+    let identifier = parse_qualified_module_ident(tokens)?;
     consume_token(tokens, Tok::LBrace)?;
 
     let mut friends: Vec<ModuleIdent> = vec![];
@@ -2121,7 +2121,7 @@ fn parse_module(tokens: &mut Lexer) -> Result<ModuleDefinition, ParseError<Loc, 
     tokens.advance()?; // consume the RBrace
 
     Ok(ModuleDefinition::new(
-        name,
+        identifier,
         friends,
         imports,
         vec![],

--- a/language/compiler/src/lib.rs
+++ b/language/compiler/src/lib.rs
@@ -15,22 +15,19 @@ use ir_to_bytecode::{
     parser::{parse_module, parse_script},
 };
 use move_binary_format::file_format::{CompiledModule, CompiledScript};
-use move_core_types::account_address::AccountAddress;
 use move_ir_types::location::Loc;
 use move_symbol_pool::Symbol;
 
 /// An API for the compiler. Supports setting custom options.
 #[derive(Clone, Debug)]
 pub struct Compiler<'a> {
-    /// The address used as the sender for the compiler.
-    pub address: AccountAddress,
     /// Extra dependencies to compile with.
     pub deps: Vec<&'a CompiledModule>,
 }
 
 impl<'a> Compiler<'a> {
-    pub fn new(address: AccountAddress, deps: Vec<&'a CompiledModule>) -> Self {
-        Self { address, deps }
+    pub fn new(deps: Vec<&'a CompiledModule>) -> Self {
+        Self { deps }
     }
 
     /// Compiles into a `CompiledScript` where the bytecode hasn't been serialized.
@@ -73,7 +70,7 @@ impl<'a> Compiler<'a> {
     ) -> Result<(CompiledScript, SourceMap<Loc>)> {
         let parsed_script = parse_script(file_name, code)?;
         let (compiled_script, source_map) =
-            compile_script(None, parsed_script, self.deps.iter().map(|d| &**d))?;
+            compile_script(parsed_script, self.deps.iter().map(|d| &**d))?;
         Ok((compiled_script, source_map))
     }
 
@@ -84,7 +81,7 @@ impl<'a> Compiler<'a> {
     ) -> Result<(CompiledModule, SourceMap<Loc>)> {
         let parsed_module = parse_module(file_name, code)?;
         let (compiled_module, source_map) =
-            compile_module(self.address, parsed_module, self.deps.iter().map(|d| &**d))?;
+            compile_module(parsed_module, self.deps.iter().map(|d| &**d))?;
         Ok((compiled_module, source_map))
     }
 }

--- a/language/compiler/src/main.rs
+++ b/language/compiler/src/main.rs
@@ -14,7 +14,6 @@ use move_binary_format::{
 use move_command_line_common::files::{
     MOVE_COMPILED_EXTENSION, MOVE_IR_EXTENSION, SOURCE_MAP_EXTENSION,
 };
-use move_core_types::account_address::AccountAddress;
 use move_symbol_pool::Symbol;
 use std::{
     fs,
@@ -29,9 +28,6 @@ struct Args {
     /// Treat input file as a module (default is to treat file as a script)
     #[structopt(short = "m", long = "module")]
     pub module_input: bool,
-    /// Account address used for publishing
-    #[structopt(short = "a", long = "address")]
-    pub address: String,
     /// Do not automatically run the bytecode verifier
     #[structopt(long = "no-verify")]
     pub no_verify: bool,
@@ -81,13 +77,6 @@ fn write_output(path: &Path, buf: &[u8]) {
 fn main() {
     let args = Args::from_args();
 
-    let address = match AccountAddress::from_hex_literal(&args.address) {
-        Ok(address) => address,
-        Err(_) => {
-            println!("Bad address: {}", args.address);
-            std::process::exit(1);
-        }
-    };
     let source_path = Path::new(&args.source_path);
     let mvir_extension = MOVE_IR_EXTENSION;
     let mv_extension = MOVE_COMPILED_EXTENSION;
@@ -141,8 +130,7 @@ fn main() {
     };
 
     if args.module_input {
-        let (compiled_module, source_map) =
-            util::do_compile_module(&args.source_path, address, &deps_owned);
+        let (compiled_module, source_map) = util::do_compile_module(&args.source_path, &deps_owned);
         if !args.no_verify {
             do_verify_module(&compiled_module, &deps_owned);
         }
@@ -162,8 +150,7 @@ fn main() {
             .expect("Unable to serialize module");
         write_output(&source_path.with_extension(mv_extension), &module);
     } else {
-        let (compiled_script, source_map) =
-            util::do_compile_script(&args.source_path, address, &deps_owned);
+        let (compiled_script, source_map) = util::do_compile_script(&args.source_path, &deps_owned);
         if !args.no_verify {
             do_verify_script(&compiled_script, &deps_owned);
         }

--- a/language/compiler/src/unit_tests/expression_tests.rs
+++ b/language/compiler/src/unit_tests/expression_tests.rs
@@ -160,7 +160,7 @@ fn compile_assert() {
 fn single_resource() {
     let code = String::from(
         "
-module Test {
+module 0xf1.Test {
     struct T { i: u64 }
 
     public new_t(): Self.T {
@@ -198,7 +198,7 @@ fn compile_immutable_borrow_local() {
 fn compile_borrow_field() {
     let code = String::from(
         "
-        module Foobar {
+        module 0x3d.Foobar {
             struct FooCoin { value: u64 }
 
             public borrow_immut_field(arg: &Self.FooCoin) {
@@ -232,7 +232,7 @@ fn compile_borrow_field() {
 fn compile_borrow_field_generic() {
     let code = String::from(
         "
-        module Foobar {
+        module 0x4d.Foobar {
             struct FooCoin<T> { value: u64 }
 
             public borrow_immut_field(arg: &Self.FooCoin<u64>) {
@@ -266,7 +266,7 @@ fn compile_borrow_field_generic() {
 fn compile_builtin_vector_ops() {
     let code = String::from(
         "
-        module Foobar {
+        module 0xfab.Foobar {
             public vector_ops() {
                 let v: vector<u64>;
                 let v_imm: &vector<u64>;

--- a/language/compiler/src/unit_tests/function_tests.rs
+++ b/language/compiler/src/unit_tests/function_tests.rs
@@ -7,7 +7,7 @@ use crate::unit_tests::testutils::compile_module_string;
 fn compile_module_with_functions() {
     let code = String::from(
         "
-        module Foobar {
+        module 0x27.Foobar {
             struct FooCoin { value: u64 }
 
             public value(this: &Self.FooCoin): u64 {
@@ -71,7 +71,7 @@ fn generate_function(name: &str, num_formals: usize, num_locals: usize) -> Strin
 fn compile_module_with_large_frame() {
     let mut code = String::from(
         "
-        module Foobar {
+        module 0x16.Foobar {
             struct FooCoin { value: u64 }
         ",
     );
@@ -89,7 +89,7 @@ fn compile_module_with_large_frame() {
 fn compile_module_with_script_visibility_functions() {
     let code = String::from(
         "
-        module Foobar {
+        module 0xa1.Foobar {
             public(script) foo() {
                 return;
             }

--- a/language/compiler/src/unit_tests/testutils.rs
+++ b/language/compiler/src/unit_tests/testutils.rs
@@ -12,7 +12,6 @@ use move_binary_format::{
     errors::{Location, VMError},
     file_format::{CompiledModule, CompiledScript},
 };
-use move_core_types::account_address::AccountAddress;
 use move_symbol_pool::Symbol;
 
 #[allow(unused_macros)]
@@ -32,7 +31,7 @@ fn compile_script_string_impl(
     deps: Vec<CompiledModule>,
 ) -> Result<(CompiledScript, Option<VMError>)> {
     let parsed_script = parse_script(Symbol::from("file_name"), code).unwrap();
-    let script = compile_script(None, parsed_script, &deps)?.0;
+    let script = compile_script(parsed_script, &deps)?.0;
 
     let mut serialized_script = Vec::<u8>::new();
     script.serialize(&mut serialized_script)?;
@@ -81,9 +80,8 @@ fn compile_module_string_impl(
     code: &str,
     deps: Vec<CompiledModule>,
 ) -> Result<(CompiledModule, Option<VMError>)> {
-    let address = AccountAddress::ZERO;
     let module = parse_module(Symbol::from("file_name"), code).unwrap();
-    let compiled_module = compile_module(address, module, &deps)?.0;
+    let compiled_module = compile_module(module, &deps)?.0;
 
     let mut serialized_module = Vec::<u8>::new();
     compiled_module.serialize(&mut serialized_module)?;

--- a/language/compiler/src/util.rs
+++ b/language/compiler/src/util.rs
@@ -8,14 +8,12 @@ use ir_to_bytecode::{
     parser::{parse_module, parse_script},
 };
 use move_binary_format::file_format::{CompiledModule, CompiledScript};
-use move_core_types::account_address::AccountAddress;
 use move_ir_types::location::Loc;
 use move_symbol_pool::Symbol;
 use std::{fs, path::Path};
 
 pub fn do_compile_script(
     source_path: &Path,
-    address: AccountAddress,
     dependencies: &[CompiledModule],
 ) -> (CompiledScript, SourceMap<Loc>) {
     let source = fs::read_to_string(source_path)
@@ -23,12 +21,11 @@ pub fn do_compile_script(
         .unwrap();
     let file = Symbol::from(source_path.as_os_str().to_str().unwrap());
     let parsed_script = parse_script(file, &source).unwrap();
-    compile_script(Some(address), parsed_script, dependencies).unwrap()
+    compile_script(parsed_script, dependencies).unwrap()
 }
 
 pub fn do_compile_module(
     source_path: &Path,
-    address: AccountAddress,
     dependencies: &[CompiledModule],
 ) -> (CompiledModule, SourceMap<Loc>) {
     let source = fs::read_to_string(source_path)
@@ -36,5 +33,5 @@ pub fn do_compile_module(
         .unwrap();
     let file = Symbol::from(source_path.as_os_str().to_str().unwrap());
     let parsed_module = parse_module(file, &source).unwrap();
-    compile_module(address, parsed_module, dependencies).unwrap()
+    compile_module(parsed_module, dependencies).unwrap()
 }

--- a/language/e2e-testsuite/src/tests/account_limits.rs
+++ b/language/e2e-testsuite/src/tests/account_limits.rs
@@ -42,7 +42,6 @@ fn encode_add_account_limits_admin_script(execute_as: AccountAddress) -> WriteSe
     }
 ";
         let compiler = Compiler {
-            address: account_config::CORE_CODE_ADDRESS,
             deps: diem_framework_releases::current_modules().iter().collect(),
         };
         compiler
@@ -88,7 +87,6 @@ fn encode_update_account_limit_definition_script(
     }
 ";
         let compiler = Compiler {
-            address: account_config::CORE_CODE_ADDRESS,
             deps: diem_framework_releases::current_modules().iter().collect(),
         };
         compiler
@@ -134,7 +132,6 @@ fn encode_update_account_limit_window_info_script(
     }
 ";
         let compiler = Compiler {
-            address: account_config::CORE_CODE_ADDRESS,
             deps: diem_framework_releases::current_modules().iter().collect(),
         };
         compiler

--- a/language/e2e-testsuite/src/tests/admin_script.rs
+++ b/language/e2e-testsuite/src/tests/admin_script.rs
@@ -5,7 +5,6 @@ use language_e2e_tests::{account::Account, current_function_name, executor::Fake
 
 use diem_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
 use diem_types::{
-    account_config,
     transaction::{authenticator::AuthenticationKey, Script, TransactionArgument},
     vm_status::StatusCode,
 };
@@ -39,7 +38,6 @@ main(dr_account: signer, account: signer, auth_key_prefix: vector<u8>) {
 "#;
 
         let compiler = Compiler {
-            address: account_config::CORE_CODE_ADDRESS,
             deps: diem_framework_releases::current_modules().iter().collect(),
         };
         compiler
@@ -104,7 +102,6 @@ main(dr_account: signer, account: signer, auth_key_prefix: vector<u8>) {
 "#;
 
         let compiler = Compiler {
-            address: account_config::CORE_CODE_ADDRESS,
             deps: diem_framework_releases::current_modules().iter().collect(),
         };
         compiler
@@ -167,7 +164,6 @@ main(account: signer, auth_key_prefix: vector<u8>) {
 "#;
 
         let compiler = Compiler {
-            address: account_config::CORE_CODE_ADDRESS,
             deps: diem_framework_releases::current_modules().iter().collect(),
         };
         compiler

--- a/language/e2e-testsuite/src/tests/script_functions.rs
+++ b/language/e2e-testsuite/src/tests/script_functions.rs
@@ -7,30 +7,31 @@ use diem_types::{
     vm_status::{DiscardedVMStatus, KeptVMStatus},
 };
 use language_e2e_tests::{
-    account::Account, compile::compile_module_with_address, current_function_name,
-    executor::FakeExecutor, transaction_status_eq, utils,
+    account::Account, compile::compile_module, current_function_name, executor::FakeExecutor,
+    transaction_status_eq, utils,
 };
 use move_core_types::{identifier::Identifier, language_storage::ModuleId};
 
 fn prepare_module(executor: &mut FakeExecutor, account: &Account, seq_num: u64) -> u64 {
-    let program = String::from(
+    let program = format!(
         "
-        module M {
-            f_private(s: &signer) {
+        module 0x{}.M {{
+            f_private(s: &signer) {{
                 return;
-            }
+            }}
 
-            public f_public(s: &signer) {
+            public f_public(s: &signer) {{
                 return;
-            }
+            }}
 
-            public(script) f_script(s: signer) {
+            public(script) f_script(s: signer) {{
                 return;
-            }
-        }
+            }}
+        }}
         ",
+        account.address(),
     );
-    let compiled_module = compile_module_with_address(account.address(), "file_name", &program).1;
+    let compiled_module = compile_module("file_name", &program).1;
 
     let txn = account
         .transaction()

--- a/language/e2e-testsuite/src/tests/writeset_builder.rs
+++ b/language/e2e-testsuite/src/tests/writeset_builder.rs
@@ -3,7 +3,6 @@
 use compiler::Compiler;
 use diem_types::{
     access_path::AccessPath,
-    account_config,
     on_chain_config::DiemVersion,
     transaction::{ChangeSet, Script, TransactionStatus, WriteSetPayload},
     vm_status::KeptVMStatus,
@@ -12,8 +11,7 @@ use diem_types::{
 use diem_vm::DiemVM;
 use diem_writeset_generator::build_changeset;
 use language_e2e_tests::{
-    account::Account, compile::compile_module_with_address, current_function_name,
-    executor::FakeExecutor,
+    account::Account, compile::compile_module, current_function_name, executor::FakeExecutor,
 };
 
 #[test]
@@ -26,14 +24,13 @@ fn build_upgrade_writeset() {
 
     let program = String::from(
         "
-        module M {
+        module 0x1.M {
             public magic(): u64 { return 42; }
         }
         ",
     );
 
-    let module =
-        compile_module_with_address(&account_config::CORE_CODE_ADDRESS, "file_name", &program).0;
+    let module = compile_module("file_name", &program).0;
     let module_bytes = {
         let mut v = vec![];
         module.serialize(&mut v).unwrap();
@@ -84,7 +81,6 @@ main(lr_account: signer) {
 "#;
 
         let compiler = Compiler {
-            address: account_config::CORE_CODE_ADDRESS,
             deps: vec![&module],
         };
         compiler

--- a/language/ir-testsuite/tests/move/commands/mixed_lvalue.mvir
+++ b/language/ir-testsuite/tests/move/commands/mixed_lvalue.mvir
@@ -1,4 +1,4 @@
-module A {
+module {{default}}.A {
 
     struct S { f: u64 }
 

--- a/language/ir-testsuite/tests/move/commands/pop_weird.mvir
+++ b/language/ir-testsuite/tests/move/commands/pop_weird.mvir
@@ -1,4 +1,4 @@
-module A {
+module {{default}}.A {
     three(): u64 * u64 * u64 {
         return 0, 1, 2;
     }

--- a/language/ir-testsuite/tests/move/commands/unpack_top_level.mvir
+++ b/language/ir-testsuite/tests/move/commands/unpack_top_level.mvir
@@ -1,4 +1,4 @@
-module Test {
+module {{default}}.Test {
     struct T { b: bool }
 
     public new_t(): Self.T {

--- a/language/ir-testsuite/tests/move/data_types/field_undefined.mvir
+++ b/language/ir-testsuite/tests/move/data_types/field_undefined.mvir
@@ -1,6 +1,6 @@
 // check: Unbound field
 
-module M {
+module {{default}}.M {
     struct T {
         x: u64
     }

--- a/language/ir-testsuite/tests/move/data_types/fields_out_of_order.mvir
+++ b/language/ir-testsuite/tests/move/data_types/fields_out_of_order.mvir
@@ -1,6 +1,6 @@
 // check: Field y defined out of order for struct T
 
-module M {
+module {{default}}.M {
     struct T {
         x: u64,
         y: u64

--- a/language/ir-testsuite/tests/move/data_types/fields_packed_in_order.mvir
+++ b/language/ir-testsuite/tests/move/data_types/fields_packed_in_order.mvir
@@ -1,6 +1,6 @@
 // Pack operands should be evaluated in declaration order, not alphanumeric.
 
-module M {
+module {{default}}.M {
     struct T has drop {
         b: u64,
         a: u64

--- a/language/ir-testsuite/tests/move/dereference_tests/deref_move_module_ok.mvir
+++ b/language/ir-testsuite/tests/move/dereference_tests/deref_move_module_ok.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     struct T has drop {v : u64}
 
     public new(v: u64): Self.T {

--- a/language/ir-testsuite/tests/move/expressions/cant_borrow_field_of_resource.mvir
+++ b/language/ir-testsuite/tests/move/expressions/cant_borrow_field_of_resource.mvir
@@ -1,6 +1,6 @@
 // check: Unbound field v
 
-module Token {
+module {{default}}.Token {
     struct T has key {v: u64}
 
     public new(v: u64): Self.T {

--- a/language/ir-testsuite/tests/move/function_calls/add_function_calls.mvir
+++ b/language/ir-testsuite/tests/move/function_calls/add_function_calls.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     public foo(u: u64): u64 * u64 * u64 {
         let twice: u64;
         let quadruple: u64;

--- a/language/ir-testsuite/tests/move/function_calls/assign_function_call.mvir
+++ b/language/ir-testsuite/tests/move/function_calls/assign_function_call.mvir
@@ -1,4 +1,4 @@
-module A {
+module {{default}}.A {
     public ones_tens(f: u64): u64 * u64 {
         let k: u64;
         let m: u64;

--- a/language/ir-testsuite/tests/move/function_calls/binop_function_calls_as_args.mvir
+++ b/language/ir-testsuite/tests/move/function_calls/binop_function_calls_as_args.mvir
@@ -1,4 +1,4 @@
-module A {
+module {{default}}.A {
     public div_by_two(v: u64): bool {
         if (move(v) % 2 == 0) { return true;}
         else { return false;}

--- a/language/ir-testsuite/tests/move/function_calls/function_composition.mvir
+++ b/language/ir-testsuite/tests/move/function_calls/function_composition.mvir
@@ -1,4 +1,4 @@
-module Test {
+module {{default}}.Test {
     public foo(v: u64): u64 * u64 {
         let one_less: u64;
         let one_more: u64;

--- a/language/ir-testsuite/tests/move/function_calls/many_function_calls_as_args.mvir
+++ b/language/ir-testsuite/tests/move/function_calls/many_function_calls_as_args.mvir
@@ -1,4 +1,4 @@
-module A {
+module {{default}}.A {
     struct T has drop {value: u64, even: bool}
 
     public new(): Self.T {

--- a/language/ir-testsuite/tests/move/function_calls/multiple_composite_functions.mvir
+++ b/language/ir-testsuite/tests/move/function_calls/multiple_composite_functions.mvir
@@ -1,4 +1,4 @@
-module A {
+module {{default}}.A {
     struct T has drop {value: u64}
 
     public new(v: u64): Self.T {

--- a/language/ir-testsuite/tests/move/function_calls/pass_args_on_stack_as_expressions.mvir
+++ b/language/ir-testsuite/tests/move/function_calls/pass_args_on_stack_as_expressions.mvir
@@ -1,4 +1,4 @@
-module A {
+module {{default}}.A {
     public sum(o: u64, k: u64, t: u64): u64 {
         return move(o) + move(k) + move(t);
     }

--- a/language/ir-testsuite/tests/move/function_calls/push_args_before_function_call.mvir
+++ b/language/ir-testsuite/tests/move/function_calls/push_args_before_function_call.mvir
@@ -1,4 +1,4 @@
-module A {
+module {{default}}.A {
     public push_u64(): u64  {
         return 42;
     }

--- a/language/ir-testsuite/tests/move/function_calls/push_args_before_function_composition.mvir
+++ b/language/ir-testsuite/tests/move/function_calls/push_args_before_function_composition.mvir
@@ -1,4 +1,4 @@
-module A {
+module {{default}}.A {
     public push_u64(): u64  {
         return 42;
     }

--- a/language/ir-testsuite/tests/move/function_calls/return_expression_lists.mvir
+++ b/language/ir-testsuite/tests/move/function_calls/return_expression_lists.mvir
@@ -1,4 +1,4 @@
-module A {
+module {{default}}.A {
     public foo(t: u64): u64 * u64 {
         let k: u64;
         if (copy(t) % 2 == 0) {

--- a/language/ir-testsuite/tests/move/function_calls/return_function_in_if_binop_in_else.mvir
+++ b/language/ir-testsuite/tests/move/function_calls/return_function_in_if_binop_in_else.mvir
@@ -1,4 +1,4 @@
-module A {
+module {{default}}.A {
     public foo(t: u64): u64 * u64 {
        return (copy(t), 2 * move(t));
     }

--- a/language/ir-testsuite/tests/move/function_defs/256_locals.mvir
+++ b/language/ir-testsuite/tests/move/function_defs/256_locals.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     foo() {
         let x1 : u8;
         let x2 : u8;

--- a/language/ir-testsuite/tests/move/function_defs/256_params.mvir
+++ b/language/ir-testsuite/tests/move/function_defs/256_params.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     foo(
         p1 : u8,
         p2 : u8,

--- a/language/ir-testsuite/tests/move/linker_tests/use_unpublished_module.mvir
+++ b/language/ir-testsuite/tests/move/linker_tests/use_unpublished_module.mvir
@@ -1,5 +1,5 @@
 //! no-run: runtime
-module M {
+module {{default}}.M {
     public foo() {
         return;
     }

--- a/language/ir-testsuite/tests/move/method_decorators/internal_function_invalid_call.mvir
+++ b/language/ir-testsuite/tests/move/method_decorators/internal_function_invalid_call.mvir
@@ -1,4 +1,4 @@
-module Test {
+module {{default}}.Test {
     struct T{value: u64}
 
     initial_value(): u64 {

--- a/language/ir-testsuite/tests/move/method_decorators/non_internal_function_valid_call.mvir
+++ b/language/ir-testsuite/tests/move/method_decorators/non_internal_function_valid_call.mvir
@@ -1,4 +1,4 @@
-module Test {
+module {{default}}.Test {
     struct T has drop {value: u64}
 
     initial_value(): u64 {

--- a/language/ir-testsuite/tests/move/module_member_types/field_reads.mvir
+++ b/language/ir-testsuite/tests/move/module_member_types/field_reads.mvir
@@ -1,4 +1,4 @@
-module VTest {
+module {{default}}.VTest {
     struct T has drop {fint: u64, fv: bool}
 
     public new(x: u64, y: bool): Self.T {
@@ -29,7 +29,7 @@ module VTest {
 
 //! new-transaction
 
-module RTest {
+module {{default}}.RTest {
     struct T{fint: u64, fv: bool}
 
     public new(x: u64, y: bool): Self.T {

--- a/language/ir-testsuite/tests/move/module_member_types/field_writes.mvir
+++ b/language/ir-testsuite/tests/move/module_member_types/field_writes.mvir
@@ -1,4 +1,4 @@
-module VTest {
+module {{default}}.VTest {
     struct T has drop {fint: u64, fv: bool}
 
     public new(x: u64, y: bool): Self.T {
@@ -36,7 +36,7 @@ module VTest {
 
 //! new-transaction
 
-module RTest {
+module {{default}}.RTest {
     struct T{fint: u64, fr: bool}
 
     public new(x: u64, y: bool): Self.T {

--- a/language/ir-testsuite/tests/move/module_member_types/invalid_field_write.mvir
+++ b/language/ir-testsuite/tests/move/module_member_types/invalid_field_write.mvir
@@ -1,4 +1,4 @@
-module Test {
+module {{default}}.Test {
     struct T{fr: bool}
 
     public new(): Self.T {

--- a/language/ir-testsuite/tests/move/module_member_types/invalid_resource_write.mvir
+++ b/language/ir-testsuite/tests/move/module_member_types/invalid_resource_write.mvir
@@ -1,4 +1,4 @@
-module RTest {
+module {{default}}.RTest {
 import 0x1.XUS;
     import 0x1.Diem;
     struct T{fr: Diem.Diem<XUS.XUS>}

--- a/language/ir-testsuite/tests/move/module_member_types/procedure_args.mvir
+++ b/language/ir-testsuite/tests/move/module_member_types/procedure_args.mvir
@@ -1,6 +1,6 @@
 // check: CALL_TYPE_MISMATCH_ERROR
 
-module Test {
+module {{default}}.Test {
     public t(fr: u64) {
         return;
     }

--- a/language/ir-testsuite/tests/move/module_member_types/procedure_args_subtype.mvir
+++ b/language/ir-testsuite/tests/move/module_member_types/procedure_args_subtype.mvir
@@ -1,6 +1,6 @@
 // check: CALL_TYPE_MISMATCH_ERROR
 
-module Test {
+module {{default}}.Test {
     public t(fr: &u64) {
         _ = move(fr);
         return;

--- a/language/ir-testsuite/tests/move/module_member_types/procedure_return_invalid_subtype.mvir
+++ b/language/ir-testsuite/tests/move/module_member_types/procedure_return_invalid_subtype.mvir
@@ -1,4 +1,4 @@
-module Test {
+module {{default}}.Test {
     public no(r: &mut u64): &u64 {
         return move(r);
     }

--- a/language/ir-testsuite/tests/move/module_member_types/procedure_return_invalid_type.mvir
+++ b/language/ir-testsuite/tests/move/module_member_types/procedure_return_invalid_type.mvir
@@ -1,4 +1,4 @@
-module Test {
+module {{default}}.Test {
     public no(): u64 {
         return false;
     }

--- a/language/ir-testsuite/tests/move/module_member_types/resource_has_resource_field.mvir
+++ b/language/ir-testsuite/tests/move/module_member_types/resource_has_resource_field.mvir
@@ -1,4 +1,4 @@
-module Test {
+module {{default}}.Test {
     import 0x1.XUS;
     import 0x1.Diem;
     struct T{fint: Diem.Diem<XUS.XUS>}

--- a/language/ir-testsuite/tests/move/module_member_types/resource_instantiate_bad_type.mvir
+++ b/language/ir-testsuite/tests/move/module_member_types/resource_instantiate_bad_type.mvir
@@ -1,4 +1,4 @@
-module Test {
+module {{default}}.Test {
     import 0x1.XUS;
     import 0x1.Diem;
     struct B{b: bool}

--- a/language/ir-testsuite/tests/move/module_member_types/unrestricted_has_resource_field.mvir
+++ b/language/ir-testsuite/tests/move/module_member_types/unrestricted_has_resource_field.mvir
@@ -1,6 +1,6 @@
 // check: FIELD_MISSING_TYPE_ABILITY
 
-module Test {
+module {{default}}.Test {
 import 0x1.XUS;
     import 0x1.Diem;
 

--- a/language/ir-testsuite/tests/move/module_member_types/unrestricted_instantiate.mvir
+++ b/language/ir-testsuite/tests/move/module_member_types/unrestricted_instantiate.mvir
@@ -1,4 +1,4 @@
-module Test {
+module {{default}}.Test {
     struct T has drop {fint: u64, fv: bool}
 
     public t1(fint: u64, fv: bool): Self.T {

--- a/language/ir-testsuite/tests/move/module_member_types/unrestricted_instantiate_bad_type.mvir
+++ b/language/ir-testsuite/tests/move/module_member_types/unrestricted_instantiate_bad_type.mvir
@@ -1,4 +1,4 @@
-module Test {
+module {{default}}.Test {
     struct T{fint: u64}
 
     public t1(): Self.T {

--- a/language/ir-testsuite/tests/move/modules/access_friend_function_invalid.mvir
+++ b/language/ir-testsuite/tests/move/modules/access_friend_function_invalid.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     public(friend) foo() {
         return;
     }
@@ -6,7 +6,7 @@ module M {
 
 //! new-transaction
 
-module N {
+module {{default}}.N {
     import {{default}}.M;
     foo() {
         M.foo();

--- a/language/ir-testsuite/tests/move/modules/access_friend_function_valid.mvir
+++ b/language/ir-testsuite/tests/move/modules/access_friend_function_valid.mvir
@@ -2,7 +2,7 @@
 // republishing flow (i.e., module N) to keep the loader happy --- the loader expects module N
 // to exist when loading module M.
 
-module N {
+module {{default}}.N {
     foo() {
         return;
     }
@@ -10,7 +10,7 @@ module N {
 
 //! new-transaction
 
-module M {
+module {{default}}.M {
     friend {{default}}.N;
     public(friend) foo() {
         return;
@@ -19,7 +19,7 @@ module M {
 
 //! new-transaction
 
-module N {
+module {{default}}.N {
     import {{default}}.M;
     foo() {
         M.foo();

--- a/language/ir-testsuite/tests/move/modules/access_private_function.mvir
+++ b/language/ir-testsuite/tests/move/modules/access_private_function.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     universal_truth(): u64 {
         return 42;
     }

--- a/language/ir-testsuite/tests/move/modules/access_public_function.mvir
+++ b/language/ir-testsuite/tests/move/modules/access_public_function.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     public universal_truth(): u64 {
         return 42;
     }

--- a/language/ir-testsuite/tests/move/modules/all_fields_accessible.mvir
+++ b/language/ir-testsuite/tests/move/modules/all_fields_accessible.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     struct A{x: u64}
     struct B has drop {y: u64}
 

--- a/language/ir-testsuite/tests/move/modules/duplicate_function_name.mvir
+++ b/language/ir-testsuite/tests/move/modules/duplicate_function_name.mvir
@@ -1,6 +1,6 @@
 // check: DUPLICATE_ELEMENT
 
-module M {
+module {{default}}.M {
     f() {}
     f() {}
 }

--- a/language/ir-testsuite/tests/move/modules/duplicate_struct_name.mvir
+++ b/language/ir-testsuite/tests/move/modules/duplicate_struct_name.mvir
@@ -1,6 +1,6 @@
 // check: DUPLICATE_ELEMENT
 
-module M {
+module {{default}}.M {
     struct T{b: bool}
     struct T{x: u64}
 }

--- a/language/ir-testsuite/tests/move/modules/friend_decl_cyclic.mvir
+++ b/language/ir-testsuite/tests/move/modules/friend_decl_cyclic.mvir
@@ -1,15 +1,15 @@
-module A {
+module {{default}}.A {
 }
 
 //! new-transaction
 
-module B {
+module {{default}}.B {
     friend {{default}}.A;
 }
 
 //! new-transaction
 
-module A {
+module {{default}}.A {
     friend {{default}}.B;
 }
 

--- a/language/ir-testsuite/tests/move/modules/friend_decl_cyclic_transitive.mvir
+++ b/language/ir-testsuite/tests/move/modules/friend_decl_cyclic_transitive.mvir
@@ -1,21 +1,21 @@
-module A {
+module {{default}}.A {
 }
 
 //! new-transaction
 
-module B {
+module {{default}}.B {
     friend {{default}}.A;
 }
 
 //! new-transaction
 
-module C {
+module {{default}}.C {
     friend {{default}}.B;
 }
 
 //! new-transaction
 
-module A {
+module {{default}}.A {
     friend {{default}}.C;
 }
 

--- a/language/ir-testsuite/tests/move/modules/friend_decl_deps.mvir
+++ b/language/ir-testsuite/tests/move/modules/friend_decl_deps.mvir
@@ -1,4 +1,4 @@
-module N {
+module {{default}}.N {
     public foo() {
         return;
     }
@@ -6,7 +6,7 @@ module N {
 
 //! new-transaction
 
-module M {
+module {{default}}.M {
     friend {{default}}.N;
     import {{default}}.N;
     public(friend) foo() {

--- a/language/ir-testsuite/tests/move/modules/friend_decl_deps_transitive.mvir
+++ b/language/ir-testsuite/tests/move/modules/friend_decl_deps_transitive.mvir
@@ -1,4 +1,4 @@
-module A {
+module {{default}}.A {
     public foo() {
         return;
     }
@@ -6,7 +6,7 @@ module A {
 
 //! new-transaction
 
-module B {
+module {{default}}.B {
     import {{default}}.A;
     public foo() {
         A.foo();
@@ -16,7 +16,7 @@ module B {
 
 //! new-transaction
 
-module C {
+module {{default}}.C {
     friend {{default}}.A;
     import {{default}}.B;
     public foo() {

--- a/language/ir-testsuite/tests/move/modules/friend_decl_different_address.mvir
+++ b/language/ir-testsuite/tests/move/modules/friend_decl_different_address.mvir
@@ -3,13 +3,13 @@
 
 //! sender: alice
 
-module M {
+module {{alice}}.M {
 }
 
 //! new-transaction
 //! sender: bob
 
-module N {
+module {{bob}}.N {
     friend {{alice}}.M;
 }
 

--- a/language/ir-testsuite/tests/move/modules/friend_decl_duplicated.mvir
+++ b/language/ir-testsuite/tests/move/modules/friend_decl_duplicated.mvir
@@ -1,9 +1,9 @@
-module A {
+module {{default}}.A {
 }
 
 //! new-transaction
 
-module B {
+module {{default}}.B {
     friend {{default}}.A;
     friend {{default}}.A;
 }

--- a/language/ir-testsuite/tests/move/modules/friend_decl_non_existing.mvir
+++ b/language/ir-testsuite/tests/move/modules/friend_decl_non_existing.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     friend {{default}}.Nonexistent;
 }
 

--- a/language/ir-testsuite/tests/move/modules/friend_decl_self.mvir
+++ b/language/ir-testsuite/tests/move/modules/friend_decl_self.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     friend {{default}}.M;
 }
 // check: INVALID_FRIEND_DECL_WITH_SELF

--- a/language/ir-testsuite/tests/move/modules/function_in_struct.mvir
+++ b/language/ir-testsuite/tests/move/modules/function_in_struct.mvir
@@ -1,6 +1,6 @@
 // check: Invalid Token
 
-module M {
+module {{default}}.M {
     struct T{
         x: u64,
         no() {

--- a/language/ir-testsuite/tests/move/modules/get_resource_internal.mvir
+++ b/language/ir-testsuite/tests/move/modules/get_resource_internal.mvir
@@ -1,6 +1,6 @@
 // check: Missing struct definition for T
 
-module Token {
+module {{default}}.Token {
     struct T has key { b: bool }
     public new(): Self.T {
         return T{ b: true };

--- a/language/ir-testsuite/tests/move/modules/get_resource_internal_bypass.mvir
+++ b/language/ir-testsuite/tests/move/modules/get_resource_internal_bypass.mvir
@@ -1,6 +1,6 @@
 // check: Invalid Token
 
-module Token {
+module {{default}}.Token {
     struct T has key { b: bool }
     public new(): Self.T {
         return T{ b: true };

--- a/language/ir-testsuite/tests/move/modules/has_resource_internal.mvir
+++ b/language/ir-testsuite/tests/move/modules/has_resource_internal.mvir
@@ -1,6 +1,6 @@
 // check: Missing struct definition for T
 
-module Token {
+module {{default}}.Token {
     struct T has key { b: bool }
     public new(): Self.T {
         return T{ b: true };

--- a/language/ir-testsuite/tests/move/modules/module_struct_shared_name.mvir
+++ b/language/ir-testsuite/tests/move/modules/module_struct_shared_name.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     struct M has drop { b: bool }
     public new(): Self.M {
         return M{ b: true };

--- a/language/ir-testsuite/tests/move/modules/modules_not_a_type.mvir
+++ b/language/ir-testsuite/tests/move/modules/modules_not_a_type.mvir
@@ -1,6 +1,6 @@
 // check: "Unbound struct Self.M"
 
-module M {
+module {{default}}.M {
     public no(x: Self.M) {
         return;
     }

--- a/language/ir-testsuite/tests/move/modules/mutual_recursive_struct.mvir
+++ b/language/ir-testsuite/tests/move/modules/mutual_recursive_struct.mvir
@@ -1,6 +1,6 @@
 // check: RECURSIVE_STRUCT_DEFINITION
 
-module M {
+module {{default}}.M {
     struct A{b: Self.B}
     struct B{a: Self.A}
 }

--- a/language/ir-testsuite/tests/move/modules/publish_resource_internal.mvir
+++ b/language/ir-testsuite/tests/move/modules/publish_resource_internal.mvir
@@ -1,6 +1,6 @@
 // check: Missing struct definition for Token
 
-module Token {
+module {{default}}.Token {
     struct T has key { b: bool }
     public new(): Self.T {
         return T{ b: true };

--- a/language/ir-testsuite/tests/move/mutate_tests/mutate_borrow_field_ok.mvir
+++ b/language/ir-testsuite/tests/move/mutate_tests/mutate_borrow_field_ok.mvir
@@ -1,4 +1,4 @@
-module Test {
+module {{default}}.Test {
     struct T has drop {v: u64}
 
     public new(g: u64): Self.T {

--- a/language/ir-testsuite/tests/move/mutate_tests/mutate_move_ok.mvir
+++ b/language/ir-testsuite/tests/move/mutate_tests/mutate_move_ok.mvir
@@ -1,4 +1,4 @@
-module B {
+module {{default}}.B {
   struct T has drop {g: u64}
 
   public new(v: u64): Self.T {

--- a/language/ir-testsuite/tests/move/mutate_tests/two_mutable_ref.mvir
+++ b/language/ir-testsuite/tests/move/mutate_tests/two_mutable_ref.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
   struct Foo {
       a: u64,
       b: u64,

--- a/language/ir-testsuite/tests/move/mutation/assign_field_after_local.mvir
+++ b/language/ir-testsuite/tests/move/mutation/assign_field_after_local.mvir
@@ -1,4 +1,4 @@
-module Tester {
+module {{default}}.Tester {
     struct T has drop {v: u64}
 
     public new(v: u64): Self.T  {

--- a/language/ir-testsuite/tests/move/mutation/assign_local_struct.mvir
+++ b/language/ir-testsuite/tests/move/mutation/assign_local_struct.mvir
@@ -1,4 +1,4 @@
-module Tester {
+module {{default}}.Tester {
     struct T has drop {v: u64}
 
     public new(v: u64): Self.T  {

--- a/language/ir-testsuite/tests/move/mutation/assign_local_struct_invalidated.mvir
+++ b/language/ir-testsuite/tests/move/mutation/assign_local_struct_invalidated.mvir
@@ -1,4 +1,4 @@
-module Tester {
+module {{default}}.Tester {
     struct T has drop {v: u64}
 
     public new(v: u64): Self.T  {

--- a/language/ir-testsuite/tests/move/mutation/assign_resource_type.mvir
+++ b/language/ir-testsuite/tests/move/mutation/assign_resource_type.mvir
@@ -1,4 +1,4 @@
-module A {
+module {{default}}.A {
 import 0x1.XUS;
     import 0x1.Diem;
     struct T {fr: Diem.Diem<XUS.XUS>}

--- a/language/ir-testsuite/tests/move/mutation/assign_struct_field.mvir
+++ b/language/ir-testsuite/tests/move/mutation/assign_struct_field.mvir
@@ -1,6 +1,6 @@
 // check: CALL_BORROWED_MUTABLE_REFERENCE_ERROR
 
-module Tester {
+module {{default}}.Tester {
     struct T has drop {v: u64}
 
     public new(v: u64): Self.T  {

--- a/language/ir-testsuite/tests/move/mutation/destroy_resource_holder.mvir
+++ b/language/ir-testsuite/tests/move/mutation/destroy_resource_holder.mvir
@@ -1,4 +1,4 @@
-module A {
+module {{default}}.A {
 import 0x1.XUS;
     import 0x1.Diem;
     struct A { c: Diem.Diem<XUS.XUS> }

--- a/language/ir-testsuite/tests/move/mutation/mint_money.mvir
+++ b/language/ir-testsuite/tests/move/mutation/mint_money.mvir
@@ -1,6 +1,6 @@
 // check: "Unbound field balance"
 
-module Hack {
+module {{default}}.Hack {
 import 0x1.XUS;
     import 0x1.Diem;
     import 0x1.DiemAccount;

--- a/language/ir-testsuite/tests/move/mutation/mut_borrow_from_imm_ref.mvir
+++ b/language/ir-testsuite/tests/move/mutation/mut_borrow_from_imm_ref.mvir
@@ -1,4 +1,4 @@
-module Token {
+module {{default}}.Token {
     struct T{value: u64}
     public new(m: u64): Self.T {
         return T{value: copy(m)};

--- a/language/ir-testsuite/tests/move/mutation/mut_call_from_get_resource.mvir
+++ b/language/ir-testsuite/tests/move/mutation/mut_call_from_get_resource.mvir
@@ -1,4 +1,4 @@
-module Token {
+module {{default}}.Token {
     import 0x1.Signer;
 
     struct T has key {balance: u64}

--- a/language/ir-testsuite/tests/move/mutation/mut_call_with_imm_ref.mvir
+++ b/language/ir-testsuite/tests/move/mutation/mut_call_with_imm_ref.mvir
@@ -1,4 +1,4 @@
-module Token {
+module {{default}}.Token {
     struct T{value: u64}
     public new(m: u64): Self.T {
         return T{value: copy(m)};

--- a/language/ir-testsuite/tests/move/mutation/mutate_resource_holder.mvir
+++ b/language/ir-testsuite/tests/move/mutation/mutate_resource_holder.mvir
@@ -1,4 +1,4 @@
-module A {
+module {{default}}.A {
 import 0x1.XUS;
     import 0x1.Diem;
     struct A { c: Diem.Diem<XUS.XUS> }

--- a/language/ir-testsuite/tests/move/mutation/mutate_resource_holder_2.mvir
+++ b/language/ir-testsuite/tests/move/mutation/mutate_resource_holder_2.mvir
@@ -1,4 +1,4 @@
-module A {
+module {{default}}.A {
     struct Coin { balance: u64 }
     struct A { c: Self.Coin }
 

--- a/language/ir-testsuite/tests/move/mutation/nested_mutate.mvir
+++ b/language/ir-testsuite/tests/move/mutation/nested_mutate.mvir
@@ -1,4 +1,4 @@
-module B {
+module {{default}}.B {
     struct T has drop {g: u64}
 
     public new(g: u64): Self.T {
@@ -17,7 +17,7 @@ module B {
 
 //! new-transaction
 
-module A {
+module {{default}}.A {
     import {{default}}.B;
     struct T has drop {f: B.T}
 

--- a/language/ir-testsuite/tests/move/mutation/read_field_after_assign_local.mvir
+++ b/language/ir-testsuite/tests/move/mutation/read_field_after_assign_local.mvir
@@ -1,4 +1,4 @@
-module Tester {
+module {{default}}.Tester {
     struct T has drop {v: u64}
 
     public new(v: u64): Self.T  {

--- a/language/ir-testsuite/tests/move/mutation/return_local_ref.mvir
+++ b/language/ir-testsuite/tests/move/mutation/return_local_ref.mvir
@@ -1,4 +1,4 @@
-module Tester {
+module {{default}}.Tester {
     public no(): &u64 {
         let x: u64;
         let x_ref: &u64;

--- a/language/ir-testsuite/tests/move/mutation/simple_mutate.mvir
+++ b/language/ir-testsuite/tests/move/mutation/simple_mutate.mvir
@@ -1,4 +1,4 @@
-module A {
+module {{default}}.A {
     struct T has drop {f: u64}
 
     public new(f: u64): Self.T {

--- a/language/ir-testsuite/tests/move/mutation/unused_resource_holder.mvir
+++ b/language/ir-testsuite/tests/move/mutation/unused_resource_holder.mvir
@@ -1,6 +1,6 @@
 // check: UNSAFE_RET_UNUSED_VALUES_WITHOUT_DROP
 
-module A {
+module {{default}}.A {
 import 0x1.XUS;
     import 0x1.Diem;
 

--- a/language/ir-testsuite/tests/move/mutation/use_after_move.mvir
+++ b/language/ir-testsuite/tests/move/mutation/use_after_move.mvir
@@ -1,4 +1,4 @@
-module B {
+module {{default}}.B {
     struct T has copy, drop {g: u64}
 
     public new(g: u64): Self.T {
@@ -8,7 +8,7 @@ module B {
 
 
 //! new-transaction
-module A {
+module {{default}}.A {
     import Transaction.B;
     struct T{value: B.T}
     public new(m: B.T): Self.T {

--- a/language/ir-testsuite/tests/move/mutation/use_prefix_after_move.mvir
+++ b/language/ir-testsuite/tests/move/mutation/use_prefix_after_move.mvir
@@ -1,4 +1,4 @@
-module B {
+module {{default}}.B {
     struct T has copy, drop {g: u64}
 
     public new(g: u64): Self.T {
@@ -15,7 +15,7 @@ module B {
 
 //! new-transaction
 
-module A {
+module {{default}}.A {
     import Transaction.B;
     struct T has drop {f: B.T}
 

--- a/language/ir-testsuite/tests/move/mutation/use_suffix_after_move.mvir
+++ b/language/ir-testsuite/tests/move/mutation/use_suffix_after_move.mvir
@@ -1,4 +1,4 @@
-module B {
+module {{default}}.B {
     struct T{g: u64}
 
     public new(g: u64): Self.T {
@@ -14,7 +14,7 @@ module B {
 
 
 //! new-transaction
-module A {
+module {{default}}.A {
     import {{default}}.B;
     struct T{f: B.T}
 

--- a/language/ir-testsuite/tests/move/natives/clever_non_existant_native_function.mvir
+++ b/language/ir-testsuite/tests/move/natives/clever_non_existant_native_function.mvir
@@ -1,7 +1,7 @@
 //! account: alice, 90000
 //! account: bob, 90000
 
-module Hash {
+module {{default}}.Hash {
     native public sha2_256(data: vector<u8>): vector<u8>;
     native public sha3_256(data: vector<u8>): vector<u8>;
 }
@@ -9,14 +9,14 @@ module Hash {
 
 //! new-transaction
 //! sender: alice
-module Hash {
+module {{alice}}.Hash {
     native public sha2_256(data: vector<u8>): vector<u8>;
 }
 // check: MISSING_DEPENDENCY
 
 //! new-transaction
 //! sender: bob
-module Hash {
+module {{bob}}.Hash {
     native public sha3_256(data: vector<u8>): vector<u8>;
 }
 // check: MISSING_DEPENDENCY

--- a/language/ir-testsuite/tests/move/natives/non_existant_native_function.mvir
+++ b/language/ir-testsuite/tests/move/natives/non_existant_native_function.mvir
@@ -1,4 +1,4 @@
-module No {
+module {{default}}.No {
     native public made_up(x: u64): u64;
 }
 

--- a/language/ir-testsuite/tests/move/natives/non_existant_native_struct.mvir
+++ b/language/ir-testsuite/tests/move/natives/non_existant_native_struct.mvir
@@ -1,17 +1,17 @@
-module M {
+module {{default}}.M {
     native struct T;
     native struct T2;
 }
 // check: MISSING_DEPENDENCY
 
 //! new-transaction
-module M2 {
+module {{default}}.M2 {
     native struct T;
 }
 // check: MISSING_DEPENDENCY
 
 //! new-transaction
-module M3 {
+module {{default}}.M3 {
     native struct T2;
 }
 // check: MISSING_DEPENDENCY

--- a/language/ir-testsuite/tests/move/natives/vector/vector_module.mvir
+++ b/language/ir-testsuite/tests/move/natives/vector/vector_module.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
 import 0x1.XUS;
     import 0x1.Diem;
     import 0x1.Vector;

--- a/language/ir-testsuite/tests/move/natives/vector/vector_move_after_borrow.mvir
+++ b/language/ir-testsuite/tests/move/natives/vector/vector_move_after_borrow.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     import 0x1.Vector;
     public foo(v: vector<u64>) {
         return;

--- a/language/ir-testsuite/tests/move/natives/vector/vector_resource_not_destroyed_at_return.mvir
+++ b/language/ir-testsuite/tests/move/natives/vector/vector_resource_not_destroyed_at_return.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     import 0x1.Vector;
 
     struct R has store { b: bool}

--- a/language/ir-testsuite/tests/move/natives/vector/vector_unrestricted_not_destroyed_at_return_ok.mvir
+++ b/language/ir-testsuite/tests/move/natives/vector/vector_unrestricted_not_destroyed_at_return_ok.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     import 0x1.Vector;
 
     f() {

--- a/language/ir-testsuite/tests/move/operators/casting_operators_types_mismatch.mvir
+++ b/language/ir-testsuite/tests/move/operators/casting_operators_types_mismatch.mvir
@@ -44,7 +44,7 @@ main() {
 
 
 //! new-transaction
-module M {
+module {{default}}.M {
     struct S { x: bool }
     f() {
         _ = to_u8(S { x: true });
@@ -53,7 +53,7 @@ module M {
 }
 //! new-transaction
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
-module M {
+module {{default}}.M {
     struct S { x: bool }
     g() {
         _ = to_u64(S { x: true });
@@ -62,7 +62,7 @@ module M {
 }
 //! new-transaction
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
-module M {
+module {{default}}.M {
     struct S { x: bool }
     h() {
         _ = to_u128(S { x: true });

--- a/language/ir-testsuite/tests/move/operators/integer_binary_operators_types_mismatch.mvir
+++ b/language/ir-testsuite/tests/move/operators/integer_binary_operators_types_mismatch.mvir
@@ -85,7 +85,7 @@ main() {
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
 
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     f() {
         _ = 0 + (R { x: true });
@@ -94,7 +94,7 @@ module M {
 }
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     g() {
         _ = (R { x: true }) + 0;
@@ -103,7 +103,7 @@ module M {
 }
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     h() {
         _ = (R { x: true }) + (R { x: true });
@@ -199,7 +199,7 @@ main() {
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
 
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     f() {
         _ = 0 - (R { x: true });
@@ -208,7 +208,7 @@ module M {
 }
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     g() {
         _ = (R { x: true }) - 0;
@@ -217,7 +217,7 @@ module M {
 }
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     h() {
         _ = (R { x: true }) - (R { x: true });
@@ -313,7 +313,7 @@ main() {
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
 
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     f() {
         _ = 0 * (R { x: true });
@@ -322,7 +322,7 @@ module M {
 }
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     g() {
         _ = (R { x: true }) * 0;
@@ -331,7 +331,7 @@ module M {
 }
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     h() {
         _ = (R { x: true }) * (R { x: true });
@@ -427,7 +427,7 @@ main() {
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
 
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     f() {
         _ = 0 / (R { x: true });
@@ -436,7 +436,7 @@ module M {
 }
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     g() {
         _ = (R { x: true }) / 0;
@@ -445,7 +445,7 @@ module M {
 }
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     h() {
         _ = (R { x: true }) / (R { x: true });
@@ -541,7 +541,7 @@ main() {
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
 
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     f() {
         _ = 0 & (R { x: true });
@@ -550,7 +550,7 @@ module M {
 }
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     g() {
         _ = (R { x: true }) & 0;
@@ -559,7 +559,7 @@ module M {
 }
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     h() {
         _ = (R { x: true }) & (R { x: true });
@@ -655,7 +655,7 @@ main() {
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
 
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     f() {
         _ = 0 | (R { x: true });
@@ -664,7 +664,7 @@ module M {
 }
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     g() {
         _ = (R { x: true }) | 0;
@@ -673,7 +673,7 @@ module M {
 }
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     h() {
         _ = (R { x: true }) | (R { x: true });
@@ -769,7 +769,7 @@ main() {
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
 
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     f() {
         _ = 0 ^ (R { x: true });
@@ -778,7 +778,7 @@ module M {
 }
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     g() {
         _ = (R { x: true }) ^ 0;
@@ -787,7 +787,7 @@ module M {
 }
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     h() {
         _ = (R { x: true }) ^ (R { x: true });
@@ -869,7 +869,7 @@ main() {
 // check: EQUALITY_OP_TYPE_MISMATCH_ERROR
 
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     f() {
         _ = 0 == (R { x: true });
@@ -878,7 +878,7 @@ module M {
 }
 // check: EQUALITY_OP_TYPE_MISMATCH_ERROR
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     g() {
         _ = (R { x: true }) == 0;
@@ -960,7 +960,7 @@ main() {
 // check: EQUALITY_OP_TYPE_MISMATCH_ERROR
 
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     f() {
         _ = 0 != (R { x: true });
@@ -969,7 +969,7 @@ module M {
 }
 // check: EQUALITY_OP_TYPE_MISMATCH_ERROR
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     g() {
         _ = (R { x: true }) != 0;
@@ -1321,7 +1321,7 @@ main() {
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
 
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     f() {
         _ = 0 << (R { x: true });
@@ -1330,7 +1330,7 @@ module M {
 }
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     g() {
         _ = (R { x: true }) << 0;
@@ -1339,7 +1339,7 @@ module M {
 }
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     h() {
         _ = (R { x: true }) << (R { x: true });
@@ -1407,7 +1407,7 @@ main() {
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
 
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     f() {
         _ = 0 >> (R { x: true });
@@ -1416,7 +1416,7 @@ module M {
 }
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     g() {
         _ = (R { x: true }) >> 0;
@@ -1425,7 +1425,7 @@ module M {
 }
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
 //! new-transaction
-module M {
+module {{default}}.M {
     struct R { x: bool }
     h() {
         _ = (R { x: true }) >> (R { x: true });

--- a/language/ir-testsuite/tests/move/prover/parser/conditions.mvir
+++ b/language/ir-testsuite/tests/move/prover/parser/conditions.mvir
@@ -6,7 +6,7 @@
 
 // Test parsing the conditions themselves relative to return values, acquires clauses
 //! no-run: runtime
-module TestConditions {
+module {{default}}.TestConditions {
 
   struct T has key { i: u64 }
 
@@ -84,7 +84,7 @@ module TestConditions {
 // check that we can parse the language of spec expressions without access paths
 //! new-transaction
 //! no-run: runtime
-module TestSpecExp {
+module {{default}}.TestSpecExp {
 
   struct T { b: bool }
   struct T1<Name> { b: Name }
@@ -162,7 +162,7 @@ module TestSpecExp {
 // check that we can handle the trickier case of access paths
 //! new-transaction
 //! no-run: runtime
-module TestEnsuresAccessPath {
+module {{default}}.TestEnsuresAccessPath {
 
   struct T { b: bool, a: address }
   struct T1 { y: Self.T }
@@ -209,7 +209,7 @@ module TestEnsuresAccessPath {
 
 //! new-transaction
 //! no-run: runtime
-module TestBinaryOps {
+module {{default}}.TestBinaryOps {
   struct T { b: bool }
   struct Pair { x: u64, y: u64}
 

--- a/language/ir-testsuite/tests/move/prover/parser/invariants.mvir
+++ b/language/ir-testsuite/tests/move/prover/parser/invariants.mvir
@@ -2,7 +2,7 @@
 
 // Test parsing invariants and synthetics, parsing only.
 //! no-run: runtime
-module TestInvariants {
+module {{default}}.TestInvariants {
 
   synthetic all_values: u128;
 

--- a/language/ir-testsuite/tests/move/publish/pack_unpack.mvir
+++ b/language/ir-testsuite/tests/move/publish/pack_unpack.mvir
@@ -1,4 +1,4 @@
-module Test {
+module {{default}}.Test {
     struct T { i: u64, b: bool }
 
     public new_t(): Self.T {

--- a/language/ir-testsuite/tests/move/publish/publish_module_and_use.mvir
+++ b/language/ir-testsuite/tests/move/publish/publish_module_and_use.mvir
@@ -1,4 +1,4 @@
-module MoneyHolder {
+module {{default}}.MoneyHolder {
         import 0x1.XUS;
         import 0x1.Diem;
 

--- a/language/ir-testsuite/tests/move/publish/publish_module_and_use_2.mvir
+++ b/language/ir-testsuite/tests/move/publish/publish_module_and_use_2.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     public max(a: u64, b: u64): u64 {
         if (copy(a) > copy(b)) {
             return copy(a);

--- a/language/ir-testsuite/tests/move/publish/publish_module_and_use_3.mvir
+++ b/language/ir-testsuite/tests/move/publish/publish_module_and_use_3.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     public case(a: u64, b: bool): u64 {
         if (copy(b)) {
             return copy(a);

--- a/language/ir-testsuite/tests/move/publish/publish_module_and_use_with_multiple_return_values.mvir
+++ b/language/ir-testsuite/tests/move/publish/publish_module_and_use_with_multiple_return_values.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     public id3(a: u64, b: bool, c: address): u64 * bool * address {
         return move(a), move(b), move(c);
     }

--- a/language/ir-testsuite/tests/move/publish/publish_resource_with_u128_field.mvir
+++ b/language/ir-testsuite/tests/move/publish/publish_resource_with_u128_field.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     import 0x1.Signer;
 
     struct Foo has key {

--- a/language/ir-testsuite/tests/move/publish/publish_resource_with_u64_field.mvir
+++ b/language/ir-testsuite/tests/move/publish/publish_resource_with_u64_field.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     import 0x1.Signer;
 
     struct Foo has key {

--- a/language/ir-testsuite/tests/move/publish/publish_resource_with_u8_field.mvir
+++ b/language/ir-testsuite/tests/move/publish/publish_resource_with_u8_field.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     import 0x1.Signer;
 
     struct Foo has key {

--- a/language/ir-testsuite/tests/move/publish/publish_two_modules.mvir
+++ b/language/ir-testsuite/tests/move/publish/publish_two_modules.mvir
@@ -1,4 +1,4 @@
-module MoneyHolder {
+module {{default}}.MoneyHolder {
         import 0x1.XUS;
         import 0x1.Diem;
 
@@ -27,7 +27,7 @@ module MoneyHolder {
 
 //! new-transaction
 
-module Bar {
+module {{default}}.Bar {
         struct T has drop {baz: u64}
         public new(m: u64): Self.T {
             return T{baz: move(m)};

--- a/language/ir-testsuite/tests/move/publish/republish_module_compatible.mvir
+++ b/language/ir-testsuite/tests/move/publish/republish_module_compatible.mvir
@@ -1,8 +1,8 @@
 // Publishing a compatible module should be allowed
 
-module Currency {
+module {{default}}.Currency {
 }
 
 //! new-transaction
-module Currency {
+module {{default}}.Currency {
 }

--- a/language/ir-testsuite/tests/move/publish/republish_module_compatible_add_friend.mvir
+++ b/language/ir-testsuite/tests/move/publish/republish_module_compatible_add_friend.mvir
@@ -1,14 +1,14 @@
-module A {
+module {{default}}.A {
 }
 
 //! new-transaction
 
-module B {
+module {{default}}.B {
 }
 
 //! new-transaction
 
-module M {
+module {{default}}.M {
     friend {{default}}.A;
     public(friend) foo() {
         return;
@@ -17,7 +17,7 @@ module M {
 
 //! new-transaction
 
-module M {
+module {{default}}.M {
     friend {{default}}.A;
     friend {{default}}.B;
     public(friend) foo() {

--- a/language/ir-testsuite/tests/move/publish/republish_module_compatible_friend_fn_to_public.mvir
+++ b/language/ir-testsuite/tests/move/publish/republish_module_compatible_friend_fn_to_public.mvir
@@ -1,4 +1,4 @@
-module N {
+module {{default}}.N {
     foo() {
         return;
     }
@@ -6,7 +6,7 @@ module N {
 
 //! new-transaction
 
-module M {
+module {{default}}.M {
     friend {{default}}.N;
     public(friend) foo() {
         return;
@@ -15,7 +15,7 @@ module M {
 
 //! new-transaction
 
-module N {
+module {{default}}.N {
     import {{default}}.M;
     foo() {
         M.foo();
@@ -25,7 +25,7 @@ module N {
 
 //! new-transaction
 
-module M {
+module {{default}}.M {
     friend {{default}}.N;
     public foo() {
         return;

--- a/language/ir-testsuite/tests/move/publish/republish_module_incompatible_change_friend_fn.mvir
+++ b/language/ir-testsuite/tests/move/publish/republish_module_incompatible_change_friend_fn.mvir
@@ -1,4 +1,4 @@
-module N {
+module {{default}}.N {
     foo() {
         return;
     }
@@ -6,7 +6,7 @@ module N {
 
 //! new-transaction
 
-module M {
+module {{default}}.M {
     friend {{default}}.N;
     public(friend) foo() {
         return;
@@ -15,7 +15,7 @@ module M {
 
 //! new-transaction
 
-module N {
+module {{default}}.N {
     import {{default}}.M;
     foo() {
         M.foo();
@@ -25,7 +25,7 @@ module N {
 
 //! new-transaction
 
-module M {
+module {{default}}.M {
     friend {{default}}.N;
     public(friend) foo(): bool {
         return false;

--- a/language/ir-testsuite/tests/move/publish/republish_module_incompatible_change_unused_friend_fn.mvir
+++ b/language/ir-testsuite/tests/move/publish/republish_module_incompatible_change_unused_friend_fn.mvir
@@ -1,9 +1,9 @@
-module N {
+module {{default}}.N {
 }
 
 //! new-transaction
 
-module M {
+module {{default}}.M {
     friend {{default}}.N;
     public(friend) foo() {
         return;
@@ -12,7 +12,7 @@ module M {
 
 //! new-transaction
 
-module M {
+module {{default}}.M {
     friend {{default}}.N;
     public(friend) foo(): bool {
         return false;

--- a/language/ir-testsuite/tests/move/publish/republish_module_incompatible_delete_friend_fn.mvir
+++ b/language/ir-testsuite/tests/move/publish/republish_module_incompatible_delete_friend_fn.mvir
@@ -1,4 +1,4 @@
-module N {
+module {{default}}.N {
     foo() {
         return;
     }
@@ -6,7 +6,7 @@ module N {
 
 //! new-transaction
 
-module M {
+module {{default}}.M {
     friend {{default}}.N;
     public(friend) foo() {
         return;
@@ -15,7 +15,7 @@ module M {
 
 //! new-transaction
 
-module N {
+module {{default}}.N {
     import {{default}}.M;
     foo() {
         M.foo();
@@ -25,7 +25,7 @@ module N {
 
 //! new-transaction
 
-module M {
+module {{default}}.M {
     friend {{default}}.N;
 }
 

--- a/language/ir-testsuite/tests/move/publish/republish_module_incompatible_delete_unused_friend_fn.mvir
+++ b/language/ir-testsuite/tests/move/publish/republish_module_incompatible_delete_unused_friend_fn.mvir
@@ -1,9 +1,9 @@
-module N {
+module {{default}}.N {
 }
 
 //! new-transaction
 
-module M {
+module {{default}}.M {
     friend {{default}}.N;
     public(friend) foo() {
         return;
@@ -12,7 +12,7 @@ module M {
 
 //! new-transaction
 
-module M {
+module {{default}}.M {
     friend {{default}}.N;
 }
 

--- a/language/ir-testsuite/tests/move/publish/republish_module_incompatible_drop_friend.mvir
+++ b/language/ir-testsuite/tests/move/publish/republish_module_incompatible_drop_friend.mvir
@@ -1,4 +1,4 @@
-module N {
+module {{default}}.N {
     foo() {
         return;
     }
@@ -6,7 +6,7 @@ module N {
 
 //! new-transaction
 
-module M {
+module {{default}}.M {
     friend {{default}}.N;
     public(friend) foo() {
         return;
@@ -15,7 +15,7 @@ module M {
 
 //! new-transaction
 
-module N {
+module {{default}}.N {
     import {{default}}.M;
     foo() {
         M.foo();
@@ -25,7 +25,7 @@ module N {
 
 //! new-transaction
 
-module M {
+module {{default}}.M {
     public(friend) foo() {
         return;
     }

--- a/language/ir-testsuite/tests/move/publish/republish_module_incompatible_drop_unlinked_friend.mvir
+++ b/language/ir-testsuite/tests/move/publish/republish_module_incompatible_drop_unlinked_friend.mvir
@@ -1,9 +1,9 @@
-module N {
+module {{default}}.N {
 }
 
 //! new-transaction
 
-module M {
+module {{default}}.M {
     friend {{default}}.N;
     public(friend) foo() {
         return;
@@ -12,7 +12,7 @@ module M {
 
 //! new-transaction
 
-module M {
+module {{default}}.M {
     public(friend) foo() {
         return;
     }

--- a/language/ir-testsuite/tests/move/publish/republish_module_incompatible_friend_fn_to_private.mvir
+++ b/language/ir-testsuite/tests/move/publish/republish_module_incompatible_friend_fn_to_private.mvir
@@ -1,4 +1,4 @@
-module N {
+module {{default}}.N {
     foo() {
         return;
     }
@@ -6,7 +6,7 @@ module N {
 
 //! new-transaction
 
-module M {
+module {{default}}.M {
     friend {{default}}.N;
     public(friend) foo() {
         return;
@@ -15,7 +15,7 @@ module M {
 
 //! new-transaction
 
-module N {
+module {{default}}.N {
     import {{default}}.M;
     foo() {
         M.foo();
@@ -25,7 +25,7 @@ module N {
 
 //! new-transaction
 
-module M {
+module {{default}}.M {
     friend {{default}}.N;
     foo() {
         return;

--- a/language/ir-testsuite/tests/move/publish/republish_module_incompatible_layout.mvir
+++ b/language/ir-testsuite/tests/move/publish/republish_module_incompatible_layout.mvir
@@ -1,10 +1,10 @@
-module Duplicate {
+module {{default}}.Duplicate {
   struct T { f: u64 }
 }
 
 //! new-transaction
 
-module Duplicate {
+module {{default}}.Duplicate {
   struct T { f: u64, g: bool }
 }
 

--- a/language/ir-testsuite/tests/move/publish/republish_module_incompatible_linking.mvir
+++ b/language/ir-testsuite/tests/move/publish/republish_module_incompatible_linking.mvir
@@ -1,11 +1,11 @@
-module Duplicate {
+module {{default}}.Duplicate {
   public f() { return; }
   public g() { return; }
 }
 
 //! new-transaction
 
-module Duplicate {
+module {{default}}.Duplicate {
   public f() { return; }
 }
 

--- a/language/ir-testsuite/tests/move/publish/resources_are_distinct_by_published_account.mvir
+++ b/language/ir-testsuite/tests/move/publish/resources_are_distinct_by_published_account.mvir
@@ -1,4 +1,4 @@
-module DiemAccount {
+module {{default}}.DiemAccount {
     import 0x1.DiemAccount;
     import 0x1.Signer;
 

--- a/language/ir-testsuite/tests/move/publish/use_modules_published.mvir
+++ b/language/ir-testsuite/tests/move/publish/use_modules_published.mvir
@@ -6,7 +6,7 @@
 
 
 //! sender: alice
-module M {
+module {{alice}}.M {
     public foo(): u64 {
         return 5;
     }
@@ -16,7 +16,7 @@ module M {
 //! new-transaction
 //! sender: bob
 
-module M {
+module {{bob}}.M {
     public bar(): u64 {
         return 7;
     }
@@ -25,7 +25,7 @@ module M {
 //! new-transaction
 //! sender: carol
 
-module M {
+module {{carol}}.M {
     import {{alice}}.M as M1;
     import {{bob}}.M as M2;
 
@@ -51,7 +51,7 @@ main() {
 //! new-transaction
 //! sender: dave
 
-module M {
+module {{dave}}.M {
     public baz(): u64 {
         return 9;
     }

--- a/language/ir-testsuite/tests/move/recursion/direct_recursion.mvir
+++ b/language/ir-testsuite/tests/move/recursion/direct_recursion.mvir
@@ -1,4 +1,4 @@
-module Math {
+module {{default}}.Math {
 
   public sum_(n: u64, acc: u64): u64 {
     let new_n: u64;

--- a/language/ir-testsuite/tests/move/recursion/mutual_recursion.mvir
+++ b/language/ir-testsuite/tests/move/recursion/mutual_recursion.mvir
@@ -1,4 +1,4 @@
-module Math {
+module {{default}}.Math {
 
   public even(n: u64): bool {
     let is_pred_odd: bool;

--- a/language/ir-testsuite/tests/move/recursion/runtime_layout_deeply_nested.mvir
+++ b/language/ir-testsuite/tests/move/recursion/runtime_layout_deeply_nested.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     import 0x1.Signer;
 
     struct Box<T> has key, store { x: T }

--- a/language/ir-testsuite/tests/move/recursion/runtime_type_deeply_nested.mvir
+++ b/language/ir-testsuite/tests/move/recursion/runtime_type_deeply_nested.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     struct Foo<T> { x: bool }
     public f0<T>() { return; }
     public f3<T>() { Self.f0<Self.Foo<Self.Foo<Self.Foo<T>>>>(); return; }

--- a/language/ir-testsuite/tests/move/references/copy_nested.mvir
+++ b/language/ir-testsuite/tests/move/references/copy_nested.mvir
@@ -1,4 +1,4 @@
-module Test {
+module {{default}}.Test {
     import 0x1.Signer;
 
     struct Config has copy, drop, store { b: bool }

--- a/language/ir-testsuite/tests/move/references/reference_in_fields.mvir
+++ b/language/ir-testsuite/tests/move/references/reference_in_fields.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     struct Foo { x: &u64 }
 }
 

--- a/language/ir-testsuite/tests/move/references/reference_in_locals_ok.mvir
+++ b/language/ir-testsuite/tests/move/references/reference_in_locals_ok.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     foo() {
         let x: &u64;
         return;

--- a/language/ir-testsuite/tests/move/references/vec_copy_nested.mvir
+++ b/language/ir-testsuite/tests/move/references/vec_copy_nested.mvir
@@ -1,4 +1,4 @@
-module DeepCopy {
+module {{default}}.DeepCopy {
     import 0x1.Vector;
 
     struct Config has copy, drop, store { i: u64 }

--- a/language/ir-testsuite/tests/move/scripts/script_type_args_type_eq.mvir
+++ b/language/ir-testsuite/tests/move/scripts/script_type_args_type_eq.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     import 0x1.Signer;
 
     struct Item has store { _dummy: bool }

--- a/language/ir-testsuite/tests/move/scripts/script_type_parameters_in_args.mvir
+++ b/language/ir-testsuite/tests/move/scripts/script_type_parameters_in_args.mvir
@@ -19,7 +19,7 @@ main<T: copy + drop>(v: vector<T>) {
 
 
 //! new-transaction
-module M {
+module {{default}}.M {
     struct Box<T> has drop { x: T }
 }
 // check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/move/signer/copy_loc.mvir
+++ b/language/ir-testsuite/tests/move/signer/copy_loc.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     t(s: signer): signer {
         return copy(s);
     }

--- a/language/ir-testsuite/tests/move/signer/copy_loc_transitive.mvir
+++ b/language/ir-testsuite/tests/move/signer/copy_loc_transitive.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     struct S<T> { s: T }
     t(s: signer): Self.S<signer> {
         let x: Self.S<signer>;

--- a/language/ir-testsuite/tests/move/signer/does_not_have_store.mvir
+++ b/language/ir-testsuite/tests/move/signer/does_not_have_store.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     struct S<T> {
         f: T,
     }

--- a/language/ir-testsuite/tests/move/signer/keyword.mvir
+++ b/language/ir-testsuite/tests/move/signer/keyword.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     foo(signer: address) {
         return;
     }

--- a/language/ir-testsuite/tests/move/signer/move_to_extra_arg.mvir
+++ b/language/ir-testsuite/tests/move/signer/move_to_extra_arg.mvir
@@ -1,5 +1,5 @@
 
-module M {
+module {{default}}.M {
     struct R { f: bool }
     t0(s: &signer, a: address) {
         (copy(s));
@@ -13,7 +13,7 @@ module M {
 
 //! new-transaction
 
-module N {
+module {{default}}.N {
     struct R<T> { f: T }
     t0(s: &signer, a: address) {
         move_to<R<bool>>(copy(a), copy(s), copy(a), R<bool> { f: false });

--- a/language/ir-testsuite/tests/move/signer/move_to_missing_resource.mvir
+++ b/language/ir-testsuite/tests/move/signer/move_to_missing_resource.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     struct R { f: bool }
     t0(s: &signer) {
         (copy(s));
@@ -10,7 +10,7 @@ module M {
 
 //! new-transaction
 
-module N {
+module {{default}}.N {
     struct R<T> { f: T }
     t0(s: &signer) {
         move_to<R<bool>>(copy(s));

--- a/language/ir-testsuite/tests/move/signer/move_to_missing_signer.mvir
+++ b/language/ir-testsuite/tests/move/signer/move_to_missing_signer.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     struct R { f: bool }
     t0(s: &signer) {
         (R { f: false });
@@ -10,7 +10,7 @@ module M {
 
 //! new-transaction
 
-module N {
+module {{default}}.N {
     struct R<T> { f: T }
     t0(s: &signer) {
         move_to<R<bool>>(R<bool> { f: false });

--- a/language/ir-testsuite/tests/move/signer/move_to_mutable_signer.mvir
+++ b/language/ir-testsuite/tests/move/signer/move_to_mutable_signer.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     struct R has key { f: bool }
     t0(s: &mut signer) {
         (copy(s));
@@ -11,7 +11,7 @@ module M {
 
 //! new-transaction
 
-module N {
+module {{default}}.N {
     struct R<T> has key { f: T }
     t0(s: &mut signer) {
         move_to<R<bool>>(copy(s), R<bool> { f: false });

--- a/language/ir-testsuite/tests/move/signer/move_to_no_args.mvir
+++ b/language/ir-testsuite/tests/move/signer/move_to_no_args.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     struct R { f: bool }
     t0(s: &signer) {
         (move_to<R>());
@@ -9,7 +9,7 @@ module M {
 
 //! new-transaction
 
-module N {
+module {{default}}.N {
     struct R<T> { f: T }
     t0(s: &signer) {
         move_to<R<bool>>();

--- a/language/ir-testsuite/tests/move/signer/move_to_non_resource.mvir
+++ b/language/ir-testsuite/tests/move/signer/move_to_non_resource.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     struct R { f: bool }
     t0(s: &signer) {
         (copy(s));
@@ -11,7 +11,7 @@ module M {
 
 //! new-transaction
 
-module N {
+module {{default}}.N {
     struct R<T> { f: T }
     t0(s: &signer) {
         move_to<R<bool>>(copy(s), R<bool> { f: false });

--- a/language/ir-testsuite/tests/move/signer/move_to_non_signer.mvir
+++ b/language/ir-testsuite/tests/move/signer/move_to_non_signer.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     struct R has key { f: bool }
     t0(s: &address) {
         (copy(s));
@@ -11,7 +11,7 @@ module M {
 
 //! new-transaction
 
-module N {
+module {{default}}.N {
     struct R<T> has key { f: T }
     t0(s: address) {
         move_to<R<bool>>(copy(s), R<bool> { f: false });

--- a/language/ir-testsuite/tests/move/signer/move_to_non_struct.mvir
+++ b/language/ir-testsuite/tests/move/signer/move_to_non_struct.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     t0(s: &signer) {
         (copy(s));
         (0);
@@ -10,7 +10,7 @@ module M {
 
 //! new-transaction
 
-module N {
+module {{default}}.N {
     struct R<T> has key { f: T }
     t0(s: &signer) {
         move_to<R<u64>>(copy(s), 0);

--- a/language/ir-testsuite/tests/move/signer/move_to_reference_to_args_flipped.mvir
+++ b/language/ir-testsuite/tests/move/signer/move_to_reference_to_args_flipped.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     struct R has key { f: bool }
     t0(s: &signer) {
         (R { f: false });
@@ -11,7 +11,7 @@ module M {
 
 //! new-transaction
 
-module N {
+module {{default}}.N {
     struct R<T> has key { f: T }
     t0(s: &signer) {
         move_to<R<bool>>(R<bool> { f: false }, copy(s));

--- a/language/ir-testsuite/tests/move/signer/move_to_reference_to_resource.mvir
+++ b/language/ir-testsuite/tests/move/signer/move_to_reference_to_resource.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     struct R has key { f: bool }
     t0(s: &signer, r: &Self.R) {
         (copy(s));
@@ -11,7 +11,7 @@ module M {
 
 //! new-transaction
 
-module N {
+module {{default}}.N {
     struct R<T> has key { f: T }
     t0(s: &signer, r: &mut Self.R<bool>) {
         move_to<R<bool>>(copy(s), move(r));

--- a/language/ir-testsuite/tests/move/signer/move_to_reference_to_wrong_resource.mvir
+++ b/language/ir-testsuite/tests/move/signer/move_to_reference_to_wrong_resource.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     struct R has key, store { f: bool }
     struct X has key, store { f: bool }
     t0(s: &signer) {
@@ -12,7 +12,7 @@ module M {
 
 //! new-transaction
 
-module N {
+module {{default}}.N {
     struct R<T> has key, store { f: T }
     struct X<T> has key, store { f: T }
     t0(s: &signer) {

--- a/language/ir-testsuite/tests/move/signer/move_to_valid.mvir
+++ b/language/ir-testsuite/tests/move/signer/move_to_valid.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     struct R has key { f: bool }
     t0(s: &signer, r: Self.R) {
         move_to<R>(copy(s), move(r));
@@ -11,7 +11,7 @@ module M {
 
 //! new-transaction
 
-module N {
+module {{default}}.N {
     struct R<T> has key { f: T }
     t0<T: store>(s: &signer, r: Self.R<T>) {
         move_to<R<T>>(copy(s), move(r));

--- a/language/ir-testsuite/tests/move/signer/read_ref.mvir
+++ b/language/ir-testsuite/tests/move/signer/read_ref.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     t(s: &signer): signer {
         return *copy(s);
     }

--- a/language/ir-testsuite/tests/move/signer/read_ref_transitive.mvir
+++ b/language/ir-testsuite/tests/move/signer/read_ref_transitive.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     struct S<T> { s: T }
     t(s: signer): Self.S<signer> {
         let x: Self.S<signer>;
@@ -9,7 +9,7 @@ module M {
 // check: READREF_WITHOUT_COPY_ABILITY
 
 //! new-transaction
-module M {
+module {{default}}.M {
     struct S<T> { s: T }
     t(s: signer): signer {
         let x: Self.S<signer>;

--- a/language/ir-testsuite/tests/move/signer/runtime_move_to.mvir
+++ b/language/ir-testsuite/tests/move/signer/runtime_move_to.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     import 0x1.Signer;
 
     struct R1 has key { f: bool }

--- a/language/ir-testsuite/tests/move/signer/st_loc.mvir
+++ b/language/ir-testsuite/tests/move/signer/st_loc.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     t(s1: signer, s2: signer) {
         s1 = move(s2);
         return;

--- a/language/ir-testsuite/tests/move/signer/st_loc_partial.mvir
+++ b/language/ir-testsuite/tests/move/signer/st_loc_partial.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     consume(s: signer) {
         Self.consume(move(s));
         return;

--- a/language/ir-testsuite/tests/move/signer/transitive.mvir
+++ b/language/ir-testsuite/tests/move/signer/transitive.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     struct S<T> has drop {
         f: T,
     }

--- a/language/ir-testsuite/tests/move/signer/unused.mvir
+++ b/language/ir-testsuite/tests/move/signer/unused.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     t(s: signer) {
         return;
     }

--- a/language/ir-testsuite/tests/move/signer/unused_partial.mvir
+++ b/language/ir-testsuite/tests/move/signer/unused_partial.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     consume(s: signer) {
         Self.consume(move(s));
         return;

--- a/language/ir-testsuite/tests/move/signer/write_ref.mvir
+++ b/language/ir-testsuite/tests/move/signer/write_ref.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     t(sref: &mut signer, s: signer) {
         *copy(sref) = move(s);
         return;

--- a/language/ir-testsuite/tests/move/sorted_linked_list/sorted-linked-list.mvir
+++ b/language/ir-testsuite/tests/move/sorted_linked_list/sorted-linked-list.mvir
@@ -9,7 +9,7 @@
 //! sender: sys
 // Implements a sorted linked list in which everyone can insert a new node (e.g. for DNS)
 // but only the list owner/node owner can remove a node
-module SortedLinkedList
+module {{sys}}.SortedLinkedList
 {
     import 0x1.Signer;
 

--- a/language/ir-testsuite/tests/testing_infra/multiple_stages.mvir
+++ b/language/ir-testsuite/tests/testing_infra/multiple_stages.mvir
@@ -1,4 +1,4 @@
-module M {
+module {{default}}.M {
     public foo(x: u64): u64 {
         return copy(x)*2;
     }
@@ -6,7 +6,7 @@ module M {
 
 //! new-transaction
 
-module N {
+module {{default}}.N {
     public bar(x: u64): u64 {
         return copy(x)*3;
     }

--- a/language/ir-testsuite/tests/testing_infra/use_module_published_in_previous_transaction.mvir
+++ b/language/ir-testsuite/tests/testing_infra/use_module_published_in_previous_transaction.mvir
@@ -2,7 +2,7 @@
 //! account: bob
 
 //! sender: alice
-module M {
+module {{alice}}.M {
     public foo(x: u64): u64 {
         return move(x)*2;
     }

--- a/language/ir-testsuite/tests/testsuite.rs
+++ b/language/ir-testsuite/tests/testsuite.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use diem_types::account_address::AccountAddress;
 use functional_tests::{
     compiler::{Compiler, ScriptOrModule},
     testsuite,
@@ -36,7 +35,6 @@ impl Compiler for IRCompiler {
     fn compile<Logger: FnMut(String)>(
         &mut self,
         mut log: Logger,
-        address: AccountAddress,
         input: &str,
     ) -> Result<ScriptOrModule> {
         Ok(
@@ -45,12 +43,12 @@ impl Compiler for IRCompiler {
                     log(format!("{}", &parsed_script));
                     ScriptOrModule::Script(
                         None,
-                        compile_script(Some(address), parsed_script, self.deps.values())?.0,
+                        compile_script(parsed_script, self.deps.values())?.0,
                     )
                 }
                 ast::ScriptOrModule::Module(parsed_module) => {
                     log(format!("{}", &parsed_module));
-                    let module = compile_module(address, parsed_module, self.deps.values())?.0;
+                    let module = compile_module(parsed_module, self.deps.values())?.0;
                     self.deps.insert(module.self_id(), module.clone());
                     ScriptOrModule::Module(module)
                 }

--- a/language/move-lang/functional-tests/tests/functional_testsuite.rs
+++ b/language/move-lang/functional-tests/tests/functional_testsuite.rs
@@ -3,7 +3,6 @@
 
 use anyhow::{bail, Result};
 use diem_framework::diem_framework_named_addresses;
-use diem_types::account_address::AccountAddress as DiemAddress;
 use functional_tests::{
     compiler::{Compiler, ScriptOrModule},
     testsuite,
@@ -76,7 +75,6 @@ impl<'a> Compiler for MoveSourceCompiler<'a> {
     fn compile<Logger: FnMut(String)>(
         &mut self,
         _log: Logger,
-        _address: DiemAddress,
         input: &str,
     ) -> Result<ScriptOrModule> {
         let cur_file = NamedTempFile::new()?;

--- a/language/move-lang/src/to_bytecode/context.rs
+++ b/language/move-lang/src/to_bytecode/context.rs
@@ -88,7 +88,7 @@ impl<'a> Context<'a> {
             let dependency_order = dependency_orderings[&module];
             let ir_name = Self::ir_module_alias(&module);
             let ir_ident = Self::translate_module_ident_impl(env.named_address_mapping(), module);
-            imports.push(IR::ImportDefinition::new(ir_ident, Some(ir_name.clone())));
+            imports.push(IR::ImportDefinition::new(ir_ident, Some(ir_name)));
             ordered_dependencies.push((
                 dependency_order,
                 IR::ModuleDependency {

--- a/language/move-lang/src/to_bytecode/translate.rs
+++ b/language/move-lang/src/to_bytecode/translate.rs
@@ -207,7 +207,10 @@ fn module(
         }
     ) = ident;
     let ir_module = IR::ModuleDefinition {
-        name: IR::ModuleName(module_name.0.value),
+        identifier: IR::QualifiedModuleIdent {
+            address: MoveAddress::new(addr_bytes.into_bytes()),
+            name: IR::ModuleName(module_name.0.value),
+        },
         friends,
         imports,
         explicit_dependency_declarations,
@@ -217,9 +220,7 @@ fn module(
         synthetics: vec![],
     };
     let deps: Vec<&F::CompiledModule> = vec![];
-    let addr = MoveAddress::new(addr_bytes.into_bytes());
-    let (module, source_map) = match ir_to_bytecode::compiler::compile_module(addr, ir_module, deps)
-    {
+    let (module, source_map) = match ir_to_bytecode::compiler::compile_module(ir_module, deps) {
         Ok(res) => res,
         Err(e) => {
             compilation_env.add_diag(diag!(
@@ -276,8 +277,7 @@ fn script(
         main,
     };
     let deps: Vec<&F::CompiledModule> = vec![];
-    let (script, source_map) = match ir_to_bytecode::compiler::compile_script(None, ir_script, deps)
-    {
+    let (script, source_map) = match ir_to_bytecode::compiler::compile_script(ir_script, deps) {
         Ok(res) => res,
         Err(e) => {
             compilation_env.add_diag(diag!(

--- a/language/move-vm/transactional-tests/tests/builtins/gen_move_to.mvir
+++ b/language/move-vm/transactional-tests/tests/builtins/gen_move_to.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     import 0x1.Signer;
 
     // Structures

--- a/language/move-vm/transactional-tests/tests/builtins/get_missing_struct.mvir
+++ b/language/move-vm/transactional-tests/tests/builtins/get_missing_struct.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Token {
+//# publish
+module 0x1.Token {
     struct T has key { b: bool }
 
     public new(): Self.T {

--- a/language/move-vm/transactional-tests/tests/builtins/get_published_resource.mvir
+++ b/language/move-vm/transactional-tests/tests/builtins/get_published_resource.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Token {
+//# publish
+module 0x1.Token {
     import 0x1.Signer;
 
     struct T has key {v: u64}

--- a/language/move-vm/transactional-tests/tests/builtins/has_published_struct.mvir
+++ b/language/move-vm/transactional-tests/tests/builtins/has_published_struct.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Token {
+//# publish
+module 0x1.Token {
     struct T has key { b: bool }
 
     public new(): Self.T {

--- a/language/move-vm/transactional-tests/tests/builtins/move_from.mvir
+++ b/language/move-vm/transactional-tests/tests/builtins/move_from.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct R has key { x: bool }
 
     public publish(s: &signer) {

--- a/language/move-vm/transactional-tests/tests/builtins/move_published_resource.mvir
+++ b/language/move-vm/transactional-tests/tests/builtins/move_published_resource.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module TestMoveFrom {
+//# publish
+module 0x1.TestMoveFrom {
     import 0x1.Signer;
 
     struct Counter has key { i: u64 }

--- a/language/move-vm/transactional-tests/tests/builtins/publish_then_unpublish.mvir
+++ b/language/move-vm/transactional-tests/tests/builtins/publish_then_unpublish.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     import 0x1.Signer;
 
     struct R has key { x: bool }

--- a/language/move-vm/transactional-tests/tests/builtins/struct_borrow_and_modify.mvir
+++ b/language/move-vm/transactional-tests/tests/builtins/struct_borrow_and_modify.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     struct Y has store { x: u64 }
     struct R has key { x: bool, y: Self.Y }
 

--- a/language/move-vm/transactional-tests/tests/builtins/unpublish_then_publish.mvir
+++ b/language/move-vm/transactional-tests/tests/builtins/unpublish_then_publish.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     import 0x1.Signer;
 
     struct R has key { x: bool }

--- a/language/move-vm/transactional-tests/tests/builtins/vec_borrow_and_modify.mvir
+++ b/language/move-vm/transactional-tests/tests/builtins/vec_borrow_and_modify.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     import 0x1.Vector;
 
     struct R has key { v: vector<u64> }

--- a/language/move-vm/transactional-tests/tests/builtins/vec_pop.mvir
+++ b/language/move-vm/transactional-tests/tests/builtins/vec_pop.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     import 0x1.Vector;
 
     struct R has key { v: vector<u64> }

--- a/language/move-vm/transactional-tests/tests/builtins/vec_push.mvir
+++ b/language/move-vm/transactional-tests/tests/builtins/vec_push.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     import 0x1.Vector;
 
     struct R has key { v: vector<u64> }

--- a/language/move-vm/transactional-tests/tests/builtins/vec_swap.mvir
+++ b/language/move-vm/transactional-tests/tests/builtins/vec_swap.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     import 0x1.Vector;
 
     struct R has key { v: vector<u64> }

--- a/language/move-vm/transactional-tests/tests/commands/abort_in_module.mvir
+++ b/language/move-vm/transactional-tests/tests/commands/abort_in_module.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     public foo() {
         abort 22;
     }

--- a/language/move-vm/transactional-tests/tests/control_flow/return_in_if_branch_taken.mvir
+++ b/language/move-vm/transactional-tests/tests/control_flow/return_in_if_branch_taken.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Test {
+//# publish
+module 0x1.Test {
     public t(): u64 {
         let x: u64;
         if (true) {

--- a/language/move-vm/transactional-tests/tests/control_flow/return_in_if_branch_taken_no_else.mvir
+++ b/language/move-vm/transactional-tests/tests/control_flow/return_in_if_branch_taken_no_else.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Test {
+//# publish
+module 0x1.Test {
     public t(): u64 {
         if (true) {
             return 100;

--- a/language/move-vm/transactional-tests/tests/example_programs/coin_wrapper.mvir
+++ b/language/move-vm/transactional-tests/tests/example_programs/coin_wrapper.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Coin {
+//# publish
+module 0x1.Coin {
     struct Coin<phantom CoinType> has store { value: u64 }
 
     public zero<CoinType>(): Self.Coin<CoinType> {
@@ -17,14 +17,14 @@ module Coin {
     }
 }
 
-//# publish --address 0x1
-module YYZ {
+//# publish
+module 0x1.YYZ {
     struct YYZ { unused: bool }
 }
 
 
-//# publish --address 0x1
-module M {
+//# publish
+module 0x1.M {
     import 0x1.Coin;
     import 0x1.Signer;
     import 0x1.YYZ;

--- a/language/move-vm/transactional-tests/tests/instructions/deref_value.mvir
+++ b/language/move-vm/transactional-tests/tests/instructions/deref_value.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module A {
+//# publish
+module 0x1.A {
     struct T has drop {f: u64}
 
     public new(f: u64): Self.T {

--- a/language/move-vm/transactional-tests/tests/instructions/deref_value_nested.mvir
+++ b/language/move-vm/transactional-tests/tests/instructions/deref_value_nested.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module B {
+//# publish
+module 0x1.B {
     struct T has drop {g: u64}
 
     public new(g: u64): Self.T {
@@ -16,8 +16,8 @@ module B {
     }
 }
 
-//# publish --address 0x1
-module A {
+//# publish
+module 0x1.A {
     import Transaction.B;
 
     struct T has drop {f: B.T}

--- a/language/move-vm/transactional-tests/tests/instructions/equality_reference_value.mvir
+++ b/language/move-vm/transactional-tests/tests/instructions/equality_reference_value.mvir
@@ -1,5 +1,5 @@
-//# publish --address 0x1
-module Token {
+//# publish
+module 0x1.Token {
     import 0x1.Signer;
 
     struct T has key { count: u64 }

--- a/language/testing-infra/e2e-tests/src/common_transactions.rs
+++ b/language/testing-infra/e2e-tests/src/common_transactions.rs
@@ -49,7 +49,6 @@ pub static CREATE_ACCOUNT_SCRIPT: Lazy<Vec<u8>> = Lazy::new(|| {
 ";
 
     let compiler = Compiler {
-        address: account_config::CORE_CODE_ADDRESS,
         deps: diem_framework_releases::current_modules().iter().collect(),
     };
     compiler
@@ -65,7 +64,6 @@ pub static EMPTY_SCRIPT: Lazy<Vec<u8>> = Lazy::new(|| {
 ";
 
     let compiler = Compiler {
-        address: account_config::CORE_CODE_ADDRESS,
         deps: diem_framework_releases::current_modules().iter().collect(),
     };
     compiler
@@ -107,7 +105,6 @@ pub static MULTI_AGENT_SWAP_SCRIPT: Lazy<Vec<u8>> = Lazy::new(|| {
 ";
 
     let compiler = Compiler {
-        address: account_config::CORE_CODE_ADDRESS,
         deps: diem_framework_releases::current_modules().iter().collect(),
     };
     compiler
@@ -152,7 +149,6 @@ pub static MULTI_AGENT_MINT_SCRIPT: Lazy<Vec<u8>> = Lazy::new(|| {
 ";
 
     let compiler = Compiler {
-        address: account_config::CORE_CODE_ADDRESS,
         deps: diem_framework_releases::current_modules().iter().collect(),
     };
     compiler

--- a/language/testing-infra/e2e-tests/src/compile.rs
+++ b/language/testing-infra/e2e-tests/src/compile.rs
@@ -5,28 +5,19 @@
 
 use compiler::Compiler;
 
-use diem_types::{
-    account_address::AccountAddress,
-    transaction::{Module, Script},
-};
+use diem_types::transaction::{Module, Script};
 use move_binary_format::CompiledModule;
 
 /// Compile the provided Move code into a blob which can be used as the code to be published
 /// (a Module).
-pub fn compile_module_with_address(
-    address: &AccountAddress,
-    file_name: &str,
-    code: &str,
-) -> (CompiledModule, Module) {
+pub fn compile_module(file_name: &str, code: &str) -> (CompiledModule, Module) {
     let compiled_module = Compiler {
-        address: *address,
         deps: diem_framework_releases::current_modules().iter().collect(),
     }
     .into_compiled_module(file_name, code)
     .expect("Module compilation failed");
     let module = Module::new(
         Compiler {
-            address: *address,
             deps: diem_framework_releases::current_modules().iter().collect(),
         }
         .into_module_blob(file_name, code)
@@ -37,14 +28,8 @@ pub fn compile_module_with_address(
 
 /// Compile the provided Move code into a blob which can be used as the code to be executed
 /// (a Script).
-pub fn compile_script_with_address(
-    address: &AccountAddress,
-    file_name: &str,
-    code: &str,
-    extra_deps: Vec<CompiledModule>,
-) -> Script {
+pub fn compile_script(file_name: &str, code: &str, extra_deps: Vec<CompiledModule>) -> Script {
     let compiler = Compiler {
-        address: *address,
         deps: diem_framework_releases::current_modules()
             .iter()
             .chain(extra_deps.iter())

--- a/language/testing-infra/e2e-tests/src/currencies.rs
+++ b/language/testing-infra/e2e-tests/src/currencies.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{account::Account, compile, executor::FakeExecutor};
-use diem_types::{account_address::AccountAddress, transaction::WriteSetPayload};
+use diem_types::transaction::WriteSetPayload;
 
 pub fn add_currency_to_system(
     executor: &mut FakeExecutor,
@@ -21,7 +21,7 @@ pub fn add_currency_to_system(
                 return;
             }
             ";
-            compile::compile_script_with_address(dr_account.address(), "file_name", script, vec![])
+            compile::compile_script("file_name", script, vec![])
         };
 
         let txn = dr_account
@@ -40,7 +40,7 @@ pub fn add_currency_to_system(
     let (compiled_module, module) = {
         let module = format!(
             r#"
-            module {} {{
+            module 0x1.{} {{
                 import 0x1.Diem;
                 import 0x1.FixedPoint32;
                 struct {currency_code} has store {{ x: bool }}
@@ -58,14 +58,10 @@ pub fn add_currency_to_system(
             }}
             "#,
             currency_code = currency_code_to_register,
-            currency_code_hex = hex::encode(currency_code_to_register)
+            currency_code_hex = hex::encode(currency_code_to_register),
         );
 
-        compile::compile_module_with_address(
-            &AccountAddress::from_hex_literal("0x1").unwrap(),
-            "this_is_a_filename",
-            &module,
-        )
+        compile::compile_module("this_is_a_filename", &module)
     };
 
     let txn = dr_account
@@ -90,12 +86,7 @@ pub fn add_currency_to_system(
             "#,
                 currency_code = currency_code_to_register
             );
-            compile::compile_script_with_address(
-                dr_account.address(),
-                "file_name",
-                &script,
-                vec![compiled_module],
-            )
+            compile::compile_script("file_name", &script, vec![compiled_module])
         };
 
         let write_set_payload = WriteSetPayload::Script {

--- a/language/testing-infra/e2e-tests/src/utils.rs
+++ b/language/testing-infra/e2e-tests/src/utils.rs
@@ -24,7 +24,7 @@ pub fn close_module_publishing(
             return;
         }
         ";
-        compile::compile_script_with_address(dr_account.address(), "file_name", script, vec![])
+        compile::compile_script("file_name", script, vec![])
     };
 
     let txn = dr_account

--- a/language/testing-infra/functional-tests/src/compiler.rs
+++ b/language/testing-infra/functional-tests/src/compiler.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use diem_types::account_address::AccountAddress;
 use move_binary_format::file_format::{CompiledModule, CompiledScript};
 
 pub trait Compiler {
@@ -10,7 +9,6 @@ pub trait Compiler {
     fn compile<Logger: FnMut(String)>(
         &mut self,
         log: Logger,
-        address: AccountAddress,
         input: &str,
     ) -> Result<ScriptOrModule>;
 

--- a/language/testing-infra/functional-tests/src/evaluator.rs
+++ b/language/testing-infra/functional-tests/src/evaluator.rs
@@ -630,8 +630,6 @@ fn eval_transaction<TComp: Compiler>(
         }};
     }
 
-    let sender_addr = *transaction.config.sender.address();
-
     // Start processing a new transaction.
     // stage 1: Compile the script/module
     if transaction.config.is_stage_disabled(Stage::Compiler) {
@@ -676,7 +674,7 @@ fn eval_transaction<TComp: Compiler>(
         static FILENAME_PAT: Lazy<Regex> =
             Lazy::new(|| Regex::new(r"[A-Za-z0-9_/.]+:([0-9]+):([0-9]+)").unwrap());
 
-        let compiler_res = compiler.compile(compiler_log, sender_addr, &transaction.input);
+        let compiler_res = compiler.compile(compiler_log, &transaction.input);
         let filtered_compiler_res = compiler_res.map_err(|err| {
             let msg = err.to_string();
             let filtered = FILENAME_PAT

--- a/language/testing-infra/module-generation/src/generator.rs
+++ b/language/testing-infra/module-generation/src/generator.rs
@@ -38,7 +38,7 @@ pub fn generate_modules(
     let (callee_names, callees): (Set<Symbol>, Vec<ModuleDefinition>) = (0..(number - 1))
         .map(|_| {
             let module = ModuleGenerator::create(rng, options.clone(), &Set::new());
-            let module_name = module.name.0;
+            let module_name = module.identifier.name.0;
             (module_name, module)
         })
         .unzip();
@@ -48,9 +48,7 @@ pub fn generate_modules(
     let compiled_callees = callees
         .into_iter()
         .map(|module| {
-            let mut module = compile_module(AccountAddress::ZERO, module, &empty_deps)
-                .unwrap()
-                .0;
+            let mut module = compile_module(module, &empty_deps).unwrap().0;
             Pad::pad(table_size, &mut module, options.clone());
             module
         })
@@ -58,9 +56,7 @@ pub fn generate_modules(
 
     // TODO: for friend visibility, maybe we could generate a module that friend all other modules...
 
-    let mut compiled_root = compile_module(AccountAddress::ZERO, root_module, &compiled_callees)
-        .unwrap()
-        .0;
+    let mut compiled_root = compile_module(root_module, &compiled_callees).unwrap().0;
     Pad::pad(table_size, &mut compiled_root, options);
     (compiled_root, compiled_callees)
 }
@@ -331,7 +327,10 @@ impl<'a> ModuleGenerator<'a> {
             random_string(gen, len)
         };
         let current_module = ModuleDefinition {
-            name: ModuleName(module_name.into()),
+            identifier: QualifiedModuleIdent {
+                name: ModuleName(module_name.into()),
+                address: AccountAddress::random(),
+            },
             friends: Vec::new(),
             imports: Self::imports(callable_modules),
             explicit_dependency_declarations: Vec::new(),

--- a/language/testing-infra/transactional-test-runner/src/tasks.rs
+++ b/language/testing-infra/transactional-test-runner/src/tasks.rs
@@ -208,8 +208,6 @@ pub struct PublishCommand {
     pub gas_budget: Option<u64>,
     #[structopt(long = "syntax")]
     pub syntax: Option<SyntaxChoice>,
-    #[structopt(long = "address", parse(try_from_str = parse_account_address))]
-    pub address: Option<AccountAddress>,
 }
 
 #[derive(Debug, StructOpt)]

--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -625,7 +625,6 @@ impl ClientProxy {
             );
 
             let compiler = Compiler {
-                address: diem_types::account_config::CORE_CODE_ADDRESS,
                 deps: diem_framework_releases::current_modules().iter().collect(),
             };
             compiler

--- a/testsuite/smoke-test/src/scripts_and_modules.rs
+++ b/testsuite/smoke-test/src/scripts_and_modules.rs
@@ -215,7 +215,6 @@ fn enable_custom_script(ctx: &mut AdminContext) -> Result<()> {
         ";
 
         let compiler = Compiler {
-            address: diem_sdk::types::account_config::CORE_CODE_ADDRESS,
             deps: diem_framework_releases::current_modules().iter().collect(),
         };
         compiler


### PR DESCRIPTION
In Move source language, module definitions must either have leading addresses specified (`module 0x42::M { ... }`), or be defined within an address definition (`address 0x42 { module M { ... } }`). In Move IR, however, modules cannot be defined with an address, and instead command-line tools that process the IR specify the address under which to publish the module.
    
Remove the ability to pass in addresses from the command-line with Move IR, and instead require modules to be defined with a leading address.

# What's in this pull request?

This is a large pull request, so I'll explain myself a bit. At its core this does one thing: modify the `move_ir_types::ModuleDefinition` so that instead of a `name: ModuleName`, it has a `identifier: QualifiedModuleIdent` field, and modify the parser to parse a leading address for that change. This requires module definitions to have leading addresses, so most `.mvir` tests, and some tests that define MVIR programs as strings (such as in the e2e-testsuite) need to be modified in order to pass (this is why this PR touches 300+ files).

Everything beyond that is "optional," but I decided to bundle these changes up together rather than touching hundreds of files in multiple pull requests. These changes include:

1. Since it's now unused, the `compiler` executable no longer needs to take an `--address` argument, so I deleted it. A module's address is the one it's defined with; the one passed in on the command-line is now meaningless and would be confusing to keep around.
2. Specifying an address is also now obsolete when invoking the IR compiler programmatically. So I removed the `address: AccountAddress` arguments from functions related to parsing Move IR, or compiling Move IR modules into bytecode modules.
3. The `Compiler` trait used by functional tests defined a `compile` method took an address argument. This argument was unused by the Move source language compiler, and now it's unused by the IR compiler as well (the only two objects that implement this trait). So I removed the argument from the trait method.
4. The transactional test runner's "publish" command required an `--address` argument be specified only when compiling Move IR. That's no longer necessary in the Move IR case, so I removed the argument altogether. This also means all transactional tests need to be modified to no longer pass that argument, which would be another large pull request -- that's part of my rationale for bundling all these changes together in one pull request.

# What about `address 0x42 { module M { ... } }` syntax for Move IR?

I dunno, do we need it? Move IR exists almost entirely for writing tests for the Move VM, and most of those tests would not define multiple modules within a single address block. Supporting that syntax would make things more complex.

None of the changes in this pull request prevent that syntax from being supported, though. Even if Move IR were to be modified to support that syntax, the vast majority of the 300+ test files modified in this PR would not be modified. So IMHO it's better to land this PR first and potentially make that change later.