### PR TITLE
[move prover] Arithmetic mutations

### DIFF
--- a/language/move-prover/bytecode/src/mutation_tester.rs
+++ b/language/move-prover/bytecode/src/mutation_tester.rs
@@ -26,6 +26,9 @@ pub struct MutationTester {}
 pub struct MutationManager {
     pub mutated: bool,
     pub add_sub: usize,
+    pub sub_add: usize,
+    pub mul_div: usize,
+    pub div_mul: usize,
 }
 
 impl MutationTester {
@@ -34,18 +37,48 @@ impl MutationTester {
     }
 }
 
+fn mutate_arith(
+    call: Bytecode,
+    mutation_value: usize,
+    global_env: &GlobalEnv,
+    mutation_manager: MutationManager,
+    bc: Bytecode,
+) -> Bytecode {
+    if mutation_value > 1 {
+        global_env.set_extension(MutationManager {
+            mutated: mutation_manager.mutated,
+            add_sub: mutation_manager.add_sub,
+            sub_add: mutation_manager.sub_add,
+            mul_div: mutation_manager.mul_div,
+            div_mul: mutation_manager.div_mul,
+        });
+    }
+    if mutation_value == 1 {
+        global_env.set_extension(MutationManager {
+            mutated: true,
+            add_sub: mutation_manager.add_sub,
+            sub_add: mutation_manager.sub_add,
+            mul_div: mutation_manager.mul_div,
+            div_mul: mutation_manager.div_mul,
+        });
+        call
+    } else {
+        bc
+    }
+}
+
 impl FunctionTargetProcessor for MutationTester {
     fn initialize(&self, global_env: &GlobalEnv, _targets: &mut FunctionTargetsHolder) {
         let options = ProverOptions::get(global_env);
         let m = global_env.get_extension::<MutationManager>();
         match m {
-            Some(x) => global_env.set_extension(MutationManager {
-                mutated: x.mutated,
-                add_sub: x.add_sub,
-            }),
+            Some(x) => global_env.set_extension(MutationManager { ..*x }),
             None => global_env.set_extension(MutationManager {
                 mutated: false,
                 add_sub: options.mutation_add_sub,
+                sub_add: options.mutation_sub_add,
+                mul_div: options.mutation_mul_div,
+                div_mul: options.mutation_div_mul,
             }),
         };
     }
@@ -78,28 +111,88 @@ impl FunctionTargetProcessor for MutationTester {
         for bc in code {
             match bc {
                 Call(ref attrid, ref indices, Operation::Add, ref srcs, ref dests) => {
+                    let call = Call(
+                        *attrid,
+                        (*indices).clone(),
+                        Operation::Sub,
+                        (*srcs).clone(),
+                        (*dests).clone(),
+                    );
                     let mv = m.add_sub;
-                    if mv == 1 {
-                        builder.emit(Call(
-                            *attrid,
-                            (*indices).clone(),
-                            Operation::Sub,
-                            (*srcs).clone(),
-                            (*dests).clone(),
-                        ));
-                        global_env.set_extension(MutationManager {
-                            mutated: true,
-                            add_sub: mv - 1,
-                        });
+                    let result: usize;
+                    if mv > 0 {
+                        result = mv - 1;
                     } else {
-                        builder.emit(bc);
+                        result = mv;
                     }
-                    if mv > 1 {
-                        global_env.set_extension(MutationManager {
-                            add_sub: mv - 1,
-                            mutated: m.mutated,
-                        });
+                    let mm = MutationManager {
+                        add_sub: result,
+                        ..*m
+                    };
+                    builder.emit(mutate_arith(call, mv, global_env, mm, bc));
+                }
+                Call(ref attrid, ref indices, Operation::Sub, ref srcs, ref dests) => {
+                    let call = Call(
+                        *attrid,
+                        (*indices).clone(),
+                        Operation::Add,
+                        (*srcs).clone(),
+                        (*dests).clone(),
+                    );
+                    let mv = m.sub_add;
+                    let result: usize;
+                    if mv > 0 {
+                        result = mv - 1;
+                    } else {
+                        result = mv;
                     }
+                    let mm = MutationManager {
+                        sub_add: result,
+                        ..*m
+                    };
+                    builder.emit(mutate_arith(call, mv, global_env, mm, bc));
+                }
+                Call(ref attrid, ref indices, Operation::Mul, ref srcs, ref dests) => {
+                    let call = Call(
+                        *attrid,
+                        (*indices).clone(),
+                        Operation::Div,
+                        (*srcs).clone(),
+                        (*dests).clone(),
+                    );
+                    let mv = m.mul_div;
+                    let result: usize;
+                    if mv > 0 {
+                        result = mv - 1;
+                    } else {
+                        result = mv;
+                    }
+                    let mm = MutationManager {
+                        mul_div: result,
+                        ..*m
+                    };
+                    builder.emit(mutate_arith(call, mv, global_env, mm, bc));
+                }
+                Call(ref attrid, ref indices, Operation::Div, ref srcs, ref dests) => {
+                    let call = Call(
+                        *attrid,
+                        (*indices).clone(),
+                        Operation::Mul,
+                        (*srcs).clone(),
+                        (*dests).clone(),
+                    );
+                    let mv = m.div_mul;
+                    let result: usize;
+                    if mv > 0 {
+                        result = mv - 1;
+                    } else {
+                        result = mv;
+                    }
+                    let mm = MutationManager {
+                        div_mul: result,
+                        ..*m
+                    };
+                    builder.emit(mutate_arith(call, mv, global_env, mm, bc));
                 }
                 _ => {
                     builder.emit(bc);

--- a/language/move-prover/bytecode/src/options.rs
+++ b/language/move-prover/bytecode/src/options.rs
@@ -53,6 +53,12 @@ pub struct ProverOptions {
     pub mutation: bool,
     /// Indicates that we should use the add-subtract mutation on the given block
     pub mutation_add_sub: usize,
+    /// Indicates that we should use the subtract-add mutation on the given block
+    pub mutation_sub_add: usize,
+    /// Indicates that we should use the multiply-divide mutation on the given block
+    pub mutation_mul_div: usize,
+    /// Indicates that we should use the divide-multiply mutation on the given block
+    pub mutation_div_mul: usize,
     /// Whether to assume a global invariant when the related memory
     /// is accessed, instead of on function entry. This is currently known to be slower
     /// if one than off, so off by default.
@@ -79,6 +85,8 @@ pub struct ProverOptions {
     pub for_interpretation: bool,
 }
 
+// add custom struct for mutation options
+
 impl Default for ProverOptions {
     fn default() -> Self {
         Self {
@@ -92,6 +100,9 @@ impl Default for ProverOptions {
             assume_wellformed_on_access: false,
             mutation: false,
             mutation_add_sub: 0,
+            mutation_sub_add: 0,
+            mutation_mul_div: 0,
+            mutation_div_mul: 0,
             deep_pack_unpack: false,
             auto_trace_level: AutoTraceLevel::Off,
             report_severity: Severity::Warning,

--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -347,6 +347,39 @@ impl Options {
                     ),
             )
             .arg(
+                Arg::with_name("mutation-sub-add")
+                    .long("mutation-sub-add")
+                    .takes_value(true)
+                    .value_name("COUNT")
+                    .validator(is_number)
+                    .help(
+                        "indicates that this program should mutate the indicated minus operation to a plus\
+                        specifically by modifyig the \"nth\" such operation",
+                    ),
+            )
+            .arg(
+                Arg::with_name("mutation-mul-div")
+                    .long("mutation-mul-div")
+                    .takes_value(true)
+                    .value_name("COUNT")
+                    .validator(is_number)
+                    .help(
+                        "indicates that this program should mutate the indicated multiplication operation to a divide\
+                        specifically by modifyig the \"nth\" such operation",
+                    ),
+            )
+            .arg(
+                Arg::with_name("mutation-div-mul")
+                    .long("mutation-div-mul")
+                    .takes_value(true)
+                    .value_name("COUNT")
+                    .validator(is_number)
+                    .help(
+                        "indicates that this program should mutate the indicated divide operation to a multiplication\
+                        specifically by modifyig the \"nth\" such operation",
+                    ),
+            )
+            .arg(
                 Arg::with_name("dependencies")
                     .long("dependency")
                     .short("d")
@@ -561,6 +594,24 @@ impl Options {
         if matches.is_present("mutation-add-sub") {
             options.prover.mutation_add_sub = matches
                 .value_of("mutation-add-sub")
+                .unwrap()
+                .parse::<usize>()?;
+        }
+        if matches.is_present("mutation-sub-add") {
+            options.prover.mutation_sub_add = matches
+                .value_of("mutation-sub-add")
+                .unwrap()
+                .parse::<usize>()?;
+        }
+        if matches.is_present("mutation-mul-div") {
+            options.prover.mutation_mul_div = matches
+                .value_of("mutation-mul-div")
+                .unwrap()
+                .parse::<usize>()?;
+        }
+        if matches.is_present("mutation-div-mul") {
+            options.prover.mutation_div_mul = matches
+                .value_of("mutation-div-mul")
                 .unwrap()
                 .parse::<usize>()?;
         }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This change updates two components of the mutation tester.  First, it adds the sub-add, mul-div, and div-mul mutation operators.  Second, it provides a fix to needing to provide addresses when working on the Diem framework.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

manual testing for this module (as usual).

## Related PRs

Extends [this PR](https://github.com/diem/diem/pull/8930)