### PR TITLE
[forge] nodegroup resize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3311,6 +3311,9 @@ dependencies = [
  "diem-secure-storage",
  "diem-workspace-hack",
  "futures",
+ "hyper",
+ "hyper-proxy",
+ "hyper-tls",
  "itertools 0.10.0",
  "k8s-openapi",
  "kube",
@@ -3319,6 +3322,10 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest",
+ "rusoto_core",
+ "rusoto_credential",
+ "rusoto_eks",
+ "rusoto_sts",
  "serde",
  "serde_json",
  "structopt 0.3.21",
@@ -3958,6 +3965,24 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-proxy"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca815a891b24fdfb243fa3239c86154392b0953ee584aa1a2a1f66d20cbe75cc"
+dependencies = [
+ "bytes",
+ "futures",
+ "headers",
+ "http",
+ "hyper",
+ "hyper-tls",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -6640,6 +6665,21 @@ dependencies = [
  "shlex",
  "tokio",
  "zeroize",
+]
+
+[[package]]
+name = "rusoto_eks"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d7e1e577d4102a9d80d5eafc0547064d3e8817d094f00e95ae45d03ae3accb"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "rusoto_core",
+ "serde",
+ "serde_derive",
+ "serde_json",
 ]
 
 [[package]]

--- a/scripts/fgi/run
+++ b/scripts/fgi/run
@@ -8,6 +8,7 @@ import getpass, os, subprocess, sys
 from kube import (
     kube_init_context,
     kube_select_cluster,
+    kube_ensure_cluster,
     get_cluster_context,
     kube_wait_job,
     create_forge_job,
@@ -128,6 +129,11 @@ if not args.workspace:
     workspace = kube_select_cluster()
     if not workspace:
         print(f"{FAIL}Failed to select forge testnet cluster{RESTORE}")
+        sys.exit(1)
+else:
+    ret = kube_ensure_cluster([workspace])
+    if not ret:
+        print(f"{FAIL}Failed to acquire specified forge testnet cluster {workspace}{RESTORE}")
         sys.exit(1)
 context = get_cluster_context(workspace)
 print(f"Running experiments on cluster: {workspace}")

--- a/scripts/fgi/run
+++ b/scripts/fgi/run
@@ -167,13 +167,13 @@ print(
 )
 print("**********")
 
-print(f"\nLog output: {OUTPUT_TEE}")
 print("==========begin-pod-logs==========")
 subprocess.call(
     f"kubectl --context={context} logs -f -l job-name={job_name} | tee {OUTPUT_TEE}",
     shell=True,
 )
 print("==========end-pod-logs==========")
+print(f"\nLog output: {OUTPUT_TEE}")
 
 try:
     job_status = json.loads(

--- a/testsuite/forge/Cargo.toml
+++ b/testsuite/forge/Cargo.toml
@@ -12,10 +12,17 @@ edition = "2018"
 [dependencies]
 anyhow = { version = "1.0", features = ["backtrace"] }
 futures = "0.3.12"
+hyper-proxy = "0.9.1"
+hyper = { version = "0.14.4", features = ["full"] }
+hyper-tls = "0.5.0"
 itertools = "0.10.0"
 rand = "0.8.3"
 rayon = "1.5.0"
 regex = "1.4.3"
+rusoto_core = "0.46.0"
+rusoto_eks = "0.46.0"
+rusoto_sts = "0.46.0"
+rusoto_credential = "0.46.0"
 structopt = "0.3.21"
 termcolor = "1.1.2"
 tokio = { version = "1.8.1", features = ["full"] }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Add the ability for Forge to resize its k8s backend clusters' worker nodegroups. Before, we could only uninstall helm releases, but would always have the worker nodes running. This saves us a lot of $$$.

Uses the `rusoto` and `rusoto_eks` crates to interact with EKS and make the API calls. An additional dep `hyper-proxy` is introduced to make things work with an http proxy.

Refactoring:
* `remove_validator`/`remove_testnet` now use `remove_helm_release`
* `k8s_client` -> `create_k8s_client`
* Separate `clean-up` subcommand for forge CLI into `clean-up` (to 0 validators) and `resize` (reset to N validators)

NOTE: for now, the cluster does not scale down/go into idle state after test run, as that logic seems to have been removed in a previous PR.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

Run the operator CLI:

```
$ time cargo run -p forge-cli -- --cluster-name libra-rustietest --helm-repo testnet-rustietest clean-up
<helm uninstalls>
All validators removed
Created rusoto http client
Created validators nodegroup update request with ID: 8a1ae8f2-b828-33c9-a89c-a4b2576692c4
Created utilities nodegroup update request with ID: 4b14b3b4-d198-3e4f-becd-744ee0a2b805
Created trusted nodegroup update request with ID: 9e8d88a1-9f47-3088-a49c-3e712cf1d13d
Waiting for utilities update 4b14b3b4-d198-3e4f-becd-744ee0a2b805: InProgress ...
Waiting for validators update 8a1ae8f2-b828-33c9-a89c-a4b2576692c4: InProgress ...
Waiting for trusted update 9e8d88a1-9f47-3088-a49c-3e712cf1d13d: InProgress ...
<waiting>
validators nodegroup update 8a1ae8f2-b828-33c9-a89c-a4b2576692c4 successful!!!
utilities nodegroup update 4b14b3b4-d198-3e4f-becd-744ee0a2b805 successful!!!
trusted nodegroup update 9e8d88a1-9f47-3088-a49c-3e712cf1d13d successful!!!
27.67user 3.90system 1:10.04elapsed 45%CPU (0avgtext+0avgdata 60040maxresident)k
32inputs+0outputs (0major+817392minor)pagefaults 0swaps
...

$ cargo run -p forge-cli -- --cluster-name libra-rustietest --helm-repo testnet-rustietest resize --num-validators 4
<same as before>
```

Also from `fgi`

```
# reset the cluster to idle state
$ time cargo run -p forge-cli -- --cluster-name libra-rustietest --helm-repo testnet-rustietest clean-up
<same as above>

# compat test completes within 15 min from idle state!
# full output P445974160
$ time ./scripts/fgi/run -T dev_rustielin_pull_8982 -W rustietest
...
test result: ok. 5 passed; 0 failed; 0 filtered out

==========end-pod-logs==========

**********
Dashboard snapshot: http://mon.rustietest.aws.hlw3truzy4ls.com/d/overview/overview?from=1629335729182&to=1629336555283&orgId=1
**********

Job forge-rustielin-1629335716 succeeded!

real    14m2.617s
user    0m11.787s
sys     0m2.332s
```


