### PR TITLE
[move-cli] deep copy tests into the temp dir before running it there

### DIFF
--- a/language/tools/move-cli/src/sandbox/utils/mode.rs
+++ b/language/tools/move-cli/src/sandbox/utils/mode.rs
@@ -6,7 +6,7 @@ use crate::{
         package::{MovePackage, SourceFilter},
         OnDiskStateView,
     },
-    DEFAULT_BUILD_DIR, DEFAULT_PACKAGE_DIR, DEFAULT_STORAGE_DIR,
+    DEFAULT_PACKAGE_DIR,
 };
 use anyhow::{bail, Result};
 use include_dir::{include_dir, Dir};
@@ -100,20 +100,16 @@ impl Mode {
         }
     }
 
-    pub fn prepare_default_state() -> Result<OnDiskStateView> {
-        Self::new(ModeType::default()).prepare_state(DEFAULT_STORAGE_DIR, DEFAULT_BUILD_DIR)
-    }
-
     /// Prepare an OnDiskStateView that is ready to use. Library modules will be preloaded into the
     /// storage if `load_libraries` is true.
     ///
     /// NOTE: this is the only way to get a state view in Move CLI, and thus, this function needs
     /// to be run before every command that needs a state view, i.e., `check`, `publish`, `run`,
     /// `view`, and `doctor`.
-    pub fn prepare_state(&self, build_dir: &str, storage_dir: &str) -> Result<OnDiskStateView> {
-        let state = OnDiskStateView::create(build_dir, storage_dir)?;
-        let package_dir = Path::new(build_dir).join(DEFAULT_PACKAGE_DIR);
+    pub fn prepare_state(&self, build_dir: &Path, storage_dir: &Path) -> Result<OnDiskStateView> {
+        let package_dir = build_dir.join(DEFAULT_PACKAGE_DIR);
         let named_address_values = self.prepare(&package_dir, false)?;
+        let state = OnDiskStateView::create(build_dir, storage_dir)?;
 
         // preload the storage with library modules (if such modules do not exist yet)
         let lib_modules = self.compiled_modules(&package_dir)?;

--- a/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
+++ b/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{BCS_EXTENSION, DEFAULT_BUILD_DIR, DEFAULT_STORAGE_DIR};
+use crate::BCS_EXTENSION;
 use anyhow::{anyhow, bail, Result};
 use disassembler::disassembler::Disassembler;
 use move_binary_format::{
@@ -514,13 +514,6 @@ impl ResourceResolver for OnDiskStateView {
         struct_tag: &StructTag,
     ) -> Result<Option<Vec<u8>>, Self::Error> {
         self.get_resource_bytes(*address, struct_tag.clone())
-    }
-}
-
-impl Default for OnDiskStateView {
-    fn default() -> Self {
-        OnDiskStateView::create(Path::new(DEFAULT_BUILD_DIR), Path::new(DEFAULT_STORAGE_DIR))
-            .expect("Failure creating OnDiskStateView")
     }
 }
 


### PR DESCRIPTION
(for details on why this race condition may happen, please refer to #8938).

The prior fix #8938 only creates a temp dir for the test but the actual
Move commands are still executed in the test case folder (which is
scanned by the datatest). Hence, we still see the flaky issue #8917.
Hopefully, this PR will fix #8917.

This commit copies everything in the test case folder to the temp dir
first and then execute the test case there.

Alternative design tried but did not work:
- just put the `build` and `storage` dir in the temp directory but
  execute inside the test case folder. The reason is that some
  error messages contains the path to the `build` or `storage` dir
  and if these folders are created with random names, the exp
  files are not consistent.
- execute inside the temp directory but fix all the source code
  paths to the test case folder. The reason why this attempt fails
  is similar, the path of the `src` directory is in the exp file as well
  (e.g., when Move source compilation fails). And although this
  time the path is deterministic, it contains machine-dependent
  segments...

## Motivation

Fix flaky test, again

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI
