### PR TITLE
[move-prover] reconcile several invariant-related passes

### DIFF
--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -3123,19 +3123,6 @@ impl<'env> FunctionEnv<'env> {
                 .function_def_at(self.data.def_idx),
         )
     }
-
-    /// Produce a TypeDisplayContext to print types within the scope of this env
-    pub fn get_type_display_ctxt(&self) -> TypeDisplayContext {
-        let type_param_names = self
-            .get_type_parameters()
-            .iter()
-            .map(|param| param.0)
-            .collect();
-        TypeDisplayContext::WithEnv {
-            env: self.module_env.env,
-            type_param_names: Some(type_param_names),
-        }
-    }
 }
 
 // =================================================================================================

--- a/language/move-prover/bytecode/src/function_target.rs
+++ b/language/move-prover/bytecode/src/function_target.rs
@@ -61,6 +61,8 @@ pub struct FunctionData {
     pub variant: FunctionVariant,
     /// The type instantiation.
     pub type_args: Vec<Type>,
+    /// Phantom types for the invariants
+    pub phantom_types: Vec<Type>,
     /// The bytecode.
     pub code: Vec<Bytecode>,
     /// The locals, including parameters.
@@ -421,6 +423,7 @@ impl FunctionData {
         FunctionData {
             variant: FunctionVariant::Baseline,
             type_args: vec![],
+            phantom_types: vec![],
             code,
             local_types,
             return_types,
@@ -484,6 +487,7 @@ impl FunctionData {
         &self,
         env: &GlobalEnv,
         inst: &[Type],
+        phantoms: &[Type],
         new_variant: FunctionVariant,
     ) -> Self {
         let type_args = if self.type_args.is_empty() {
@@ -522,17 +526,13 @@ impl FunctionData {
         Self {
             variant: new_variant,
             type_args,
+            phantom_types: phantoms.to_vec(),
             code,
             local_types,
             return_types,
             modify_targets,
             ..self.clone()
         }
-    }
-
-    /// Get the instantiation of this function as a vector of types.
-    pub fn get_type_instantiation(&self, _fun_env: &FunctionEnv) -> Vec<Type> {
-        self.type_args.clone()
     }
 }
 

--- a/language/move-prover/bytecode/src/global_invariant_instrumentation.rs
+++ b/language/move-prover/bytecode/src/global_invariant_instrumentation.rs
@@ -1,0 +1,585 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Transformation which injects global invariants into the bytecode.
+
+use crate::{
+    function_data_builder::FunctionDataBuilder,
+    function_target::{FunctionData, FunctionTarget},
+    function_target_pipeline::{
+        FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant, VerificationFlavor,
+    },
+    instantiation_analysis::{self, InvariantAnalysisData},
+    options::ProverOptions,
+    stackless_bytecode::{BorrowNode, Bytecode, Operation, PropKind},
+    usage_analysis,
+};
+
+use move_model::{
+    ast::{ConditionKind, Exp, MemoryLabel},
+    exp_generator::ExpGenerator,
+    model::{
+        FunId, FunctionEnv, GlobalEnv, GlobalId, Loc, QualifiedId, QualifiedInstId, SpecVarId,
+        StructId,
+    },
+    pragmas::CONDITION_ISOLATED_PROP,
+    spec_translator::{SpecTranslator, TranslatedSpec},
+    ty::Type,
+};
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    rc::Rc,
+};
+
+const GLOBAL_INVARIANT_FAILS_MESSAGE: &str = "global memory invariant does not hold";
+
+// The function target processor
+pub struct GlobalInvariantInstrumentationProcessor {}
+
+impl GlobalInvariantInstrumentationProcessor {
+    pub fn new() -> Box<Self> {
+        Box::new(Self {})
+    }
+}
+
+impl FunctionTargetProcessor for GlobalInvariantInstrumentationProcessor {
+    fn process(
+        &self,
+        targets: &mut FunctionTargetsHolder,
+        fun_env: &FunctionEnv<'_>,
+        data: FunctionData,
+    ) -> FunctionData {
+        if fun_env.is_native() || fun_env.is_intrinsic() {
+            // Nothing to do.
+            return data;
+        }
+        if !data.variant.is_verified() {
+            // Only need to instrument if this is a verification variant
+            return data;
+        }
+
+        // Retrieve instantiation analysis results
+        let target = FunctionTarget::new(fun_env, &data);
+        let instantiations = instantiation_analysis::get_instantiation_analysis(&target);
+
+        // Create variants for possible function instantiations
+        let env = target.global_env();
+
+        let mut main_context = None;
+        let mut variants = vec![];
+        for ((fun_inst, fun_phantom), invariants) in &instantiations.invariant_applicability {
+            let context = InstrumentationContext::new(fun_env, targets, invariants);
+
+            let is_original = fun_phantom.is_empty()
+                && fun_inst
+                    .iter()
+                    .enumerate()
+                    .all(|(i, ty)| matches!(ty, Type::TypeParameter(idx) if *idx as usize == i));
+            if is_original {
+                main_context = Some(context);
+            } else {
+                let variant_data = data.fork_with_instantiation(
+                    env,
+                    fun_inst,
+                    fun_phantom,
+                    FunctionVariant::Verification(VerificationFlavor::Instantiated(variants.len())),
+                );
+                variants.push((variant_data, context));
+            }
+        }
+
+        // Instrument the main variant. It is possible that the `main_context` is None, this means
+        // that there are no invariants applicable to this function.
+        let main = match main_context {
+            None => data,
+            Some(context) => Self::instrument(fun_env, data, &context),
+        };
+
+        // Instrument the variants representing different instantiations
+        for (variant_data, variant_context) in variants {
+            let variant_instrumented = Self::instrument(fun_env, variant_data, &variant_context);
+            targets.insert_target_data(
+                &fun_env.get_qualified_id(),
+                variant_instrumented.variant.clone(),
+                variant_instrumented,
+            );
+        }
+
+        // Return the main variant
+        main
+    }
+
+    fn name(&self) -> String {
+        "global_invariant_instrumenter".to_string()
+    }
+}
+
+// An context helper struct holding immutable information for the instrumenter
+struct InstrumentationContext {
+    // used for invariants applicability
+    entrypoint_invariants: BTreeMap<GlobalId, BTreeSet<Vec<Type>>>,
+    related_global_invs_by_mem:
+        BTreeMap<QualifiedInstId<StructId>, BTreeMap<GlobalId, BTreeSet<Vec<Type>>>>,
+    related_update_invs_by_mem:
+        BTreeMap<QualifiedInstId<StructId>, BTreeMap<GlobalId, BTreeSet<Vec<Type>>>>,
+
+    // used for invariants suspension
+    function_status: Rc<InvariantAnalysisData>,
+    modified_mems_by_callee: BTreeMap<QualifiedId<FunId>, BTreeSet<QualifiedInstId<StructId>>>,
+}
+
+impl InstrumentationContext {
+    fn new(
+        fun_env: &FunctionEnv,
+        targets: &FunctionTargetsHolder,
+        related_invariants: &BTreeMap<GlobalId, BTreeSet<Vec<Type>>>,
+    ) -> Self {
+        let env = fun_env.module_env.env;
+
+        // collect entrypoint invariants by filtering out "update" invariants. These invariants
+        // will be assumed at the entry of the function.
+        let entrypoint_invariants = related_invariants
+            .iter()
+            .filter_map(|(id, insts)| {
+                let inv = env.get_global_invariant(*id).unwrap();
+                if matches!(inv.kind, ConditionKind::GlobalInvariant(..)) {
+                    Some((*id, insts.clone()))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // derive a per-mem view of applicable invariants.
+        // - for regular invariants,
+        //   - they will be checked after the modifying instruction
+        // - for update invariants,
+        //   - a state snapshot will be saved before the modifying instruction
+        //   - the invariant itself will be checked after the modifying instruction
+        let mut related_global_invs_by_mem = BTreeMap::new();
+        let mut related_update_invs_by_mem = BTreeMap::new();
+        for (inv_id, inv_insts) in related_invariants {
+            for inv_inst in inv_insts {
+                let inv = env.get_global_invariant(*inv_id).unwrap();
+                for mem in inv.mem_usage.iter() {
+                    let mem_inst = mem.instantiate_ref(inv_inst);
+                    let mem_view = match inv.kind {
+                        ConditionKind::GlobalInvariant(..) => &mut related_global_invs_by_mem,
+                        ConditionKind::GlobalInvariantUpdate(..) => &mut related_update_invs_by_mem,
+                        _ => unreachable!(
+                            "Unexpected condition type for a global invariant: {}",
+                            inv.kind
+                        ),
+                    };
+                    mem_view
+                        .entry(mem_inst)
+                        .or_insert_with(BTreeMap::new)
+                        .entry(*inv_id)
+                        .or_insert_with(BTreeSet::new)
+                        .insert(inv_inst.clone());
+                }
+            }
+        }
+
+        // retrieve the function status analysis
+        // - whether a function evaluates invariant, and
+        // - whether an invariant should be evaluated at the return of this function
+        let function_status = env.get_extension::<InvariantAnalysisData>().unwrap();
+
+        // pre-collect targets for the called functions
+        let modified_mems_by_callee = fun_env
+            .get_called_functions()
+            .iter()
+            .map(|callee_id| {
+                let callee_env = env.get_function(*callee_id);
+                let callee_target = targets.get_target(&callee_env, &FunctionVariant::Baseline);
+                let callee_modified_mems: BTreeSet<_> =
+                    usage_analysis::get_modified_memory_inst(&callee_target)
+                        .iter()
+                        .cloned()
+                        .collect();
+                (*callee_id, callee_modified_mems)
+            })
+            .collect();
+
+        // now construct the context
+        InstrumentationContext {
+            entrypoint_invariants,
+            related_global_invs_by_mem,
+            related_update_invs_by_mem,
+            modified_mems_by_callee,
+            function_status,
+        }
+    }
+}
+
+impl GlobalInvariantInstrumentationProcessor {
+    // The instrumentation process
+    fn instrument(
+        fun_env: &FunctionEnv,
+        data: FunctionData,
+        context: &InstrumentationContext,
+    ) -> FunctionData {
+        let mut builder = FunctionDataBuilder::new(fun_env, data);
+
+        // Extract and clear current code
+        let old_code = std::mem::take(&mut builder.data.code);
+
+        // Emit entrypoint assumptions, i.e., an assume of each invariant over memory directly
+        // touched by this function, regardless of where the invariant is defined, as long as the
+        // invariant is in the `context.entrypoint_invariants` set.
+        let xlated = Self::translate_invariants(&mut builder, &context.entrypoint_invariants);
+        Self::assert_or_assume_translated_invariants(
+            &mut builder,
+            xlated.invariants,
+            PropKind::Assume,
+        );
+
+        // Generate new instrumented code.
+        let mems_modified_in_body = Self::process_bytecode(&mut builder, context, old_code);
+        if !mems_modified_in_body.is_empty() {
+            // re-instrument the bytecode because this function disables invariant checking in body
+            let old_code = std::mem::take(&mut builder.data.code);
+
+            // pre-instrumentation
+            let xlated_update_invs = Self::emit_save_mem_for_update_invs(
+                &mut builder,
+                context,
+                mems_modified_in_body.iter(),
+            );
+
+            for bc in old_code {
+                if let Bytecode::Ret(..) = &bc {
+                    // post-instrumentation
+                    Self::emit_assert_for_update_and_global_invs(
+                        &mut builder,
+                        context,
+                        xlated_update_invs.clone(),
+                        mems_modified_in_body.iter(),
+                    );
+                }
+                builder.emit(bc);
+            }
+        }
+
+        // Extract the instrumented code
+        builder.data
+    }
+
+    fn process_bytecode(
+        builder: &mut FunctionDataBuilder,
+        context: &InstrumentationContext,
+        code: Vec<Bytecode>,
+    ) -> BTreeSet<QualifiedInstId<StructId>> {
+        use BorrowNode::*;
+        use Bytecode::*;
+        use Operation::*;
+
+        let assert_invariants_at_return = context
+            .function_status
+            .fun_set_with_inv_check_on_exit
+            .contains(&builder.fun_env.get_qualified_id());
+
+        let mut mems_modified_in_body = BTreeSet::new();
+        let mut last_opaque_call_info = None;
+
+        for bc in code {
+            match &bc {
+                Call(_, _, WriteBack(GlobalRoot(mem), ..), ..) => {
+                    let modified_mems = vec![mem.clone()];
+                    if assert_invariants_at_return {
+                        // skip instrumentation if invariant checking is disabled in body
+                        mems_modified_in_body.extend(modified_mems);
+                        builder.emit(bc);
+                    } else {
+                        // pre-instrumentation
+                        let xlated_update_invs = Self::emit_save_mem_for_update_invs(
+                            builder,
+                            context,
+                            modified_mems.iter(),
+                        );
+
+                        builder.emit(bc);
+
+                        // post-instrumentation
+                        Self::emit_assert_for_update_and_global_invs(
+                            builder,
+                            context,
+                            xlated_update_invs,
+                            modified_mems.iter(),
+                        );
+                    }
+                }
+                Call(_, _, MoveTo(mid, sid, inst), ..)
+                | Call(_, _, MoveFrom(mid, sid, inst), ..) => {
+                    let modified_mems = vec![mid.qualified_inst(*sid, inst.to_owned())];
+                    if assert_invariants_at_return {
+                        // skip instrumentation if invariant checking is disabled in body
+                        mems_modified_in_body.extend(modified_mems);
+                        builder.emit(bc);
+                    } else {
+                        // pre-instrumentation
+                        let xlated_update_invs = Self::emit_save_mem_for_update_invs(
+                            builder,
+                            context,
+                            modified_mems.iter(),
+                        );
+
+                        builder.emit(bc);
+
+                        // post-instrumentation
+                        Self::emit_assert_for_update_and_global_invs(
+                            builder,
+                            context,
+                            xlated_update_invs,
+                            modified_mems.iter(),
+                        );
+                    }
+                }
+                Call(_, _, OpaqueCallBegin(mid, fid, callee_inst), ..) => {
+                    let callee_id = mid.qualified(*fid);
+
+                    // pre-instrument the opaque call if it is in the N set
+                    if context
+                        .function_status
+                        .fun_set_with_no_inv_check
+                        .contains(&callee_id)
+                    {
+                        let callee_modified_mems: BTreeSet<_> = context
+                            .modified_mems_by_callee
+                            .get(&callee_id)
+                            .unwrap()
+                            .iter()
+                            .map(|mem| mem.instantiate_ref(callee_inst))
+                            .collect();
+
+                        if assert_invariants_at_return {
+                            // skip instrumentation if invariant checking is disabled in body
+                            mems_modified_in_body.extend(callee_modified_mems);
+                        } else {
+                            // pre-instrumentation of the opaque call
+                            let xlated_update_invs = Self::emit_save_mem_for_update_invs(
+                                builder,
+                                context,
+                                callee_modified_mems.iter(),
+                            );
+                            debug_assert!(last_opaque_call_info.is_none());
+                            last_opaque_call_info
+                                .insert((callee_modified_mems, xlated_update_invs));
+                        }
+                    }
+
+                    // emit the opaque call after instrumentation (if there is any)
+                    builder.emit(bc);
+                }
+                Call(_, _, OpaqueCallEnd(mid, fid, _), ..) => {
+                    let callee_id = mid.qualified(*fid);
+
+                    // emit the opaque call, with or without instrumentation
+                    builder.emit(bc);
+
+                    // post-instrument the opaque call if it is in the N set
+                    if context
+                        .function_status
+                        .fun_set_with_no_inv_check
+                        .contains(&callee_id)
+                    {
+                        // skip instrumentation if invariant checking is disabled in body
+                        if !assert_invariants_at_return {
+                            debug_assert!(last_opaque_call_info.is_some());
+                            let (callee_modified_mems, xlated_update_invs) =
+                                last_opaque_call_info.take().unwrap();
+                            Self::emit_assert_for_update_and_global_invs(
+                                builder,
+                                context,
+                                xlated_update_invs,
+                                callee_modified_mems.iter(),
+                            );
+                        }
+                    }
+                }
+                Call(_, _, Function(mid, fid, callee_inst), _, _) => {
+                    let callee_id = mid.qualified(*fid);
+
+                    // instrument the regular call if it is in the N set
+                    if context
+                        .function_status
+                        .fun_set_with_no_inv_check
+                        .contains(&callee_id)
+                    {
+                        // collect memories modified by the callee
+                        let callee_modified_mems: BTreeSet<_> = context
+                            .modified_mems_by_callee
+                            .get(&callee_id)
+                            .unwrap()
+                            .iter()
+                            .map(|mem| mem.instantiate_ref(callee_inst))
+                            .collect();
+
+                        if assert_invariants_at_return {
+                            // skip instrumentation if invariant checking is disabled in body
+                            mems_modified_in_body.extend(callee_modified_mems);
+                            builder.emit(bc);
+                        } else {
+                            // pre-instrumentation
+                            let xlated_update_invs = Self::emit_save_mem_for_update_invs(
+                                builder,
+                                context,
+                                callee_modified_mems.iter(),
+                            );
+
+                            builder.emit(bc);
+
+                            // post-instrumentation
+                            Self::emit_assert_for_update_and_global_invs(
+                                builder,
+                                context,
+                                xlated_update_invs,
+                                callee_modified_mems.iter(),
+                            );
+                        }
+                    } else {
+                        // the regular call is not in the N set, emit the call without instrumentation
+                        builder.emit(bc);
+                    }
+                }
+                _ => {
+                    builder.emit(bc);
+                }
+            }
+        }
+
+        // return the list of memories modified in body if invariant assertion is turned-off in body
+        debug_assert!(last_opaque_call_info.is_none());
+        mems_modified_in_body
+    }
+
+    fn emit_save_mem_for_update_invs<'a>(
+        builder: &mut FunctionDataBuilder,
+        context: &InstrumentationContext,
+        mems: impl Iterator<Item = &'a QualifiedInstId<StructId>>,
+    ) -> Vec<(Loc, GlobalId, Exp)> {
+        // collect all related update invariants
+        let mut update_invs = BTreeMap::new();
+        for mem in mems {
+            if let Some(invs) = context.related_update_invs_by_mem.get(mem) {
+                for (inv_id, inv_inst) in invs {
+                    update_invs
+                        .entry(*inv_id)
+                        .or_insert_with(BTreeSet::new)
+                        .extend(inv_inst.iter().cloned());
+                }
+            }
+        }
+
+        // save state snapshots for each of the update invariants
+        let xlated = Self::translate_invariants(builder, &update_invs);
+        let TranslatedSpec {
+            saved_memory,
+            saved_spec_vars,
+            invariants,
+            ..
+        } = xlated;
+        Self::emit_state_saves_for_update_invs(builder, saved_memory, saved_spec_vars);
+
+        // return the translated invariants
+        invariants
+    }
+
+    fn emit_assert_for_update_and_global_invs<'a>(
+        builder: &mut FunctionDataBuilder,
+        context: &InstrumentationContext,
+        xlated_update_invs: Vec<(Loc, GlobalId, Exp)>,
+        mems: impl Iterator<Item = &'a QualifiedInstId<StructId>>,
+    ) {
+        // assert update invariants
+        Self::assert_or_assume_translated_invariants(builder, xlated_update_invs, PropKind::Assert);
+
+        // collect all related global invariants
+        let mut global_invs = BTreeMap::new();
+        for mem in mems {
+            if let Some(invs) = context.related_global_invs_by_mem.get(mem) {
+                for (inv_id, inv_inst) in invs {
+                    global_invs
+                        .entry(*inv_id)
+                        .or_insert_with(BTreeSet::new)
+                        .extend(inv_inst.iter().cloned());
+                }
+            }
+        }
+
+        // assert global invariants
+        let xlated = Self::translate_invariants(builder, &global_invs);
+        Self::assert_or_assume_translated_invariants(builder, xlated.invariants, PropKind::Assert);
+    }
+
+    /// Translate the given invariants (with instantiations). This will care for instantiating the
+    /// invariants in the function context as well.
+    fn translate_invariants(
+        builder: &mut FunctionDataBuilder,
+        invs_with_insts: &BTreeMap<GlobalId, BTreeSet<Vec<Type>>>,
+    ) -> TranslatedSpec {
+        let env = builder.global_env();
+        let options = ProverOptions::get(env);
+
+        let inst_invs = invs_with_insts
+            .iter()
+            .map(|(inv_id, inv_insts)| inv_insts.iter().map(move |inst| (*inv_id, inst.clone())))
+            .flatten();
+        SpecTranslator::translate_invariants_by_id(
+            options.auto_trace_level.invariants(),
+            builder,
+            inst_invs,
+        )
+    }
+
+    /// Emit an assert or assume for all invariants found in the `TranslatedSpec`
+    fn assert_or_assume_translated_invariants(
+        builder: &mut FunctionDataBuilder,
+        xlated_invariants: Vec<(Loc, GlobalId, Exp)>,
+        prop_kind: PropKind,
+    ) {
+        for (loc, _, cond) in xlated_invariants {
+            Self::emit_invariant(builder, loc, cond, prop_kind);
+        }
+    }
+
+    /// Emit an assert or assume for one invariant, give location and expression for the property
+    fn emit_invariant(builder: &mut FunctionDataBuilder, loc: Loc, cond: Exp, prop_kind: PropKind) {
+        builder.set_next_debug_comment(format!(
+            "global invariant {}",
+            loc.display(builder.global_env())
+        ));
+        // No error messages on assumes
+        if matches!(prop_kind, PropKind::Assert) {
+            builder.set_loc_and_vc_info(loc, GLOBAL_INVARIANT_FAILS_MESSAGE);
+        }
+        builder.emit_with(|id| Bytecode::Prop(id, prop_kind, cond));
+    }
+
+    /// Update invariants contain "old" expressions, so it is necessary to save any types in the
+    /// state that appear in the old expressions.
+    fn emit_state_saves_for_update_invs(
+        builder: &mut FunctionDataBuilder,
+        xlated_saved_memory: BTreeMap<QualifiedInstId<StructId>, MemoryLabel>,
+        xlated_saved_spec_var: BTreeMap<QualifiedInstId<SpecVarId>, MemoryLabel>,
+    ) {
+        // Emit all necessary state saves
+        builder.set_next_debug_comment("state save for global update invariants".to_string());
+        for (mem, label) in xlated_saved_memory {
+            builder.emit_with(|id| Bytecode::SaveMem(id, label, mem));
+        }
+        for (var, label) in xlated_saved_spec_var {
+            builder.emit_with(|id| Bytecode::SaveSpecVar(id, label, var));
+        }
+        builder.clear_next_debug_comment();
+    }
+}
+
+// Utility functions
+fn _is_invariant_isolated(env: &GlobalEnv, inv_id: GlobalId) -> bool {
+    let inv = env.get_global_invariant(inv_id).unwrap();
+    env.is_property_true(&inv.properties, CONDITION_ISOLATED_PROP)
+        .unwrap_or(false)
+}

--- a/language/move-prover/bytecode/src/global_invariant_instrumentation_v2.rs
+++ b/language/move-prover/bytecode/src/global_invariant_instrumentation_v2.rs
@@ -742,7 +742,7 @@ impl<'a> Instrumenter<'a> {
                     &fun_mem.inst,
                     &inv_mem.inst,
                     /* treat_lhs_type_param_as_var */ false,
-                    /* treat_rhs_type_local_as_var */ true,
+                    /* treat_rhs_type_param_as_var */ true,
                 );
                 #[cfg(invariant_trace)]
                 println!(

--- a/language/move-prover/bytecode/src/global_invariant_instrumentation_v2.rs
+++ b/language/move-prover/bytecode/src/global_invariant_instrumentation_v2.rs
@@ -70,6 +70,7 @@ impl FunctionTargetProcessor for GlobalInvariantInstrumentationProcessorV2 {
             let variant_data = data.fork_with_instantiation(
                 env,
                 &ty_args,
+                &[],
                 FunctionVariant::Verification(VerificationFlavor::Instantiated(i)),
             );
             global_ids.extend(plain.clone().into_iter());
@@ -183,7 +184,6 @@ impl Analyzer {
 struct Instrumenter<'a> {
     options: &'a ProverOptions,
     builder: FunctionDataBuilder<'a>,
-    _function_inst: Vec<Type>,
     used_memory: BTreeSet<QualifiedInstId<StructId>>,
     // Invariants that unify with the state used in a function instantiation
     related_invariants: BTreeSet<GlobalId>,
@@ -203,37 +203,16 @@ impl<'a> Instrumenter<'a> {
 
         let global_env = fun_env.module_env.env;
         let options = ProverOptions::get(global_env);
-        let function_inst = data.get_type_instantiation(fun_env);
+        let function_inst = data.type_args.clone();
         let builder = FunctionDataBuilder::new(fun_env, data);
         let used_memory: BTreeSet<_> = usage_analysis::get_used_memory_inst(&builder.get_target())
             .iter()
             .map(|mem| mem.instantiate_ref(&function_inst))
             .collect();
 
-        #[cfg(invariant_trace)]
-        {
-            let tctx = TypeDisplayContext::WithEnv {
-                env: global_env,
-                type_param_names: None,
-            };
-            println!(
-                "{}<{}>: {}",
-                builder.data.variant,
-                function_inst
-                    .iter()
-                    .map(|t| t.display(&tctx).to_string())
-                    .join(","),
-                used_memory
-                    .iter()
-                    .map(|m| global_env.display(m).to_string())
-                    .join(",")
-            );
-        }
-
         let mut instrumenter = Instrumenter {
             options: options.as_ref(),
             builder,
-            _function_inst: function_inst,
             used_memory,
             related_invariants,
             saved_from_before_instr_or_call: None,

--- a/language/move-prover/bytecode/src/instantiation_analysis.rs
+++ b/language/move-prover/bytecode/src/instantiation_analysis.rs
@@ -1,0 +1,730 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    function_target::{FunctionData, FunctionTarget},
+    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant},
+    usage_analysis,
+};
+
+use move_binary_format::file_format::TypeParameterIndex;
+use move_model::{
+    ast::{ConditionKind, GlobalInvariant},
+    model::{FunId, FunctionEnv, GlobalEnv, GlobalId, QualifiedId, QualifiedInstId, StructId},
+    pragmas::{
+        CONDITION_SUSPENDABLE_PROP, DELEGATE_INVARIANTS_TO_CALLER_PRAGMA,
+        DISABLE_INVARIANTS_IN_BODY_PRAGMA,
+    },
+    ty::{Type, TypeDisplayContext, TypeUnificationAdapter, Variance},
+};
+
+use std::{
+    collections::{BTreeMap, BTreeSet, VecDeque},
+    fmt::{self, Formatter},
+};
+
+// Analysis info to save for global_invariant_instrumentation phase
+pub struct InvariantAnalysisData {
+    /// Functions which have invariants checked on return instead of in body
+    pub fun_set_with_inv_check_on_exit: BTreeSet<QualifiedId<FunId>>,
+    /// Functions which invariants checking is turned-off anywhere in the function
+    pub fun_set_with_no_inv_check: BTreeSet<QualifiedId<FunId>>,
+    /// A mapping from function to the set of global invariants used and modified, respectively
+    pub fun_to_inv_map: BTreeMap<QualifiedId<FunId>, (BTreeSet<GlobalId>, BTreeSet<GlobalId>)>,
+}
+
+#[derive(Clone)]
+pub struct InstantiationAnalysisData {
+    /// Instantiations of this function in order to check type-dependent behaviors
+    pub type_dependent_checking: BTreeSet<Vec<Type>>,
+    /// A mapping that captures: which I[inst] is applicable in F[inst]
+    /// - The key in first map is the instantiation of the function + "phantom" types for
+    ///   uninstantiated type params appearing in the invariant.
+    /// - The value in the second map is the set of invariant instantiations of the global invariant
+    ///   identified by its ID that are applicable to this particular instantiation of the function
+    pub invariant_applicability:
+        BTreeMap<(Vec<Type>, Vec<Type>), BTreeMap<GlobalId, BTreeSet<Vec<Type>>>>,
+}
+
+pub fn get_instantiation_analysis<'env>(
+    target: &'env FunctionTarget,
+) -> &'env InstantiationAnalysisData {
+    target
+        .get_annotations()
+        .get::<InstantiationAnalysisData>()
+        .expect("Invariant violation: target not processed for instantiation analysis")
+}
+
+// The function target processor
+pub struct InstantiationAnalysisProcessor {}
+
+impl InstantiationAnalysisProcessor {
+    pub fn new() -> Box<Self> {
+        Box::new(InstantiationAnalysisProcessor {})
+    }
+}
+
+impl FunctionTargetProcessor for InstantiationAnalysisProcessor {
+    fn process(
+        &self,
+        _targets: &mut FunctionTargetsHolder,
+        func_env: &FunctionEnv<'_>,
+        mut data: FunctionData,
+    ) -> FunctionData {
+        let target = FunctionTarget::new(func_env, &data);
+
+        // see what instantiations for this function are needed by just looking at the move code
+        let type_dependent_checking = Self::analyze_instantiation_by_code(&target);
+
+        // see what instantiations for this function are needed to check properties in the spec
+        let invariant_applicability = Self::analyze_instantiation_by_spec(&target);
+
+        // save the analysis result to the env
+        let result = InstantiationAnalysisData {
+            type_dependent_checking,
+            invariant_applicability,
+        };
+        data.annotations.set(result);
+        data
+    }
+
+    fn name(&self) -> String {
+        "instantiation_analysis".to_string()
+    }
+    fn dump_result(
+        &self,
+        f: &mut Formatter<'_>,
+        env: &GlobalEnv,
+        targets: &FunctionTargetsHolder,
+    ) -> fmt::Result {
+        writeln!(
+            f,
+            "\n\n********* Result of instantiation analysis *********\n\n"
+        )?;
+
+        let type_display_ctxt = TypeDisplayContext::WithEnv {
+            env,
+            type_param_names: None,
+        };
+        let display_type_slice = |tys: &[Type]| -> String {
+            let content = tys
+                .iter()
+                .map(|t| t.display(&type_display_ctxt).to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("<{}>", content)
+        };
+        let make_indent = |indent: usize| "  ".repeat(indent);
+
+        for (fun_id, fun_variant) in targets.get_funs_and_variants() {
+            let fenv = env.get_function(fun_id);
+            let target = targets.get_target(&fenv, &fun_variant);
+            let result = get_instantiation_analysis(&target);
+            writeln!(
+                f,
+                "function {} [{}] {{",
+                fenv.get_full_name_str(),
+                target.data.variant
+            )?;
+            let mut indent = 1;
+
+            writeln!(f, "{}type dependent checking: [", make_indent(indent))?;
+            indent += 1;
+            for inst in &result.type_dependent_checking {
+                writeln!(f, "{}{}", make_indent(indent), display_type_slice(inst))?;
+            }
+            indent -= 1;
+            writeln!(f, "{}]", make_indent(indent))?;
+
+            writeln!(f, "{}invariant applicability: [", make_indent(indent))?;
+            indent += 1;
+            for ((fun_inst, phantoms), applicability) in &result.invariant_applicability {
+                writeln!(
+                    f,
+                    "{}{} + {} [",
+                    make_indent(indent),
+                    display_type_slice(fun_inst),
+                    display_type_slice(phantoms)
+                )?;
+                indent += 1;
+                for (inv_id, inv_insts) in applicability {
+                    writeln!(f, "{}{} => [", make_indent(indent), inv_id)?;
+                    indent += 1;
+                    for inv_inst in inv_insts {
+                        writeln!(f, "{}{}", make_indent(indent), display_type_slice(inv_inst))?;
+                    }
+                    indent -= 1;
+                    writeln!(f, "{}]", make_indent(indent))?;
+                }
+                indent -= 1;
+                writeln!(f, "{}]", make_indent(indent))?;
+            }
+            indent -= 1;
+            writeln!(f, "{}]", make_indent(indent))?;
+
+            writeln!(f, "}}",)?;
+        }
+        writeln!(f)
+    }
+
+    fn initialize(&self, env: &GlobalEnv, targets: &mut FunctionTargetsHolder) {
+        // probe how global invariants will be evaluated in the functions
+        let (fun_set_with_inv_check_on_exit, fun_set_with_no_inv_check) =
+            Self::probe_invariant_status_in_functions(env);
+
+        // get a map on how invariants are consumed in functions
+        let fun_to_inv_map = Self::build_function_to_invariants_map(env, targets);
+
+        // error checking
+        for fun_id in &fun_set_with_no_inv_check {
+            let fun_env = env.get_function(*fun_id);
+            let mut has_error = false;
+
+            // Rule 1: external-facing functions are not allowed in the N set,
+            // UNLESS they don't modify any memory that are checked in any suspendable invariant.
+            if fun_env.has_unknown_callers() {
+                let (_, inv_wo) = fun_to_inv_map.get(fun_id).unwrap();
+                let num_suspendable_inv_modified = inv_wo
+                    .iter()
+                    .filter(|inv_id| is_invariant_suspendable(env, **inv_id))
+                    .count();
+                if num_suspendable_inv_modified != 0 {
+                    env.error(
+                        &fun_env.get_loc(),
+                        "Public or script functions must not be called when invariant checking \
+                        is turned-off on this function.",
+                    );
+                    has_error = true;
+                }
+            }
+
+            // Rule 2: a function cannot be both on the E set and N set.
+            // This is because invariants must hold on entry to any function in the E set, so such
+            // a function must not be called from a function in E or N.
+            if fun_set_with_inv_check_on_exit.contains(fun_id) {
+                env.error(
+                    &fun_env.get_loc(),
+                    &format!(
+                        "Functions must not have `pragma {}` when invariant checking is turned-off \
+                        on this function.",
+                        DISABLE_INVARIANTS_IN_BODY_PRAGMA
+                    ),
+                );
+                has_error = true;
+            }
+
+            if has_error {
+                // TODO: port the tracing logic (i.e., why the invariant checking is turned off)
+                env.error(
+                    &fun_env.get_loc(),
+                    &format!(
+                        "Invariant checking is turned-off on this function because either \
+                        1) a transitive caller of this function has `pragma {}` or \
+                        2) `pragma {}` is applied on this function",
+                        DISABLE_INVARIANTS_IN_BODY_PRAGMA, DELEGATE_INVARIANTS_TO_CALLER_PRAGMA
+                    ),
+                );
+            }
+        }
+
+        // prune the function-to-invariants map with the pragma-magic
+        let fun_to_inv_map =
+            Self::prune_function_to_invariants_map(env, fun_to_inv_map, &fun_set_with_no_inv_check);
+
+        // save the analysis results in the env
+        let result = InvariantAnalysisData {
+            fun_set_with_inv_check_on_exit,
+            fun_set_with_no_inv_check,
+            fun_to_inv_map,
+        };
+        env.set_extension(result);
+    }
+}
+
+// This implementation block contains functions on global invariant applicability analysis
+impl InstantiationAnalysisProcessor {
+    // Build the E set and N set
+    //
+    // E set: f in E if declared pragma disable_invariant_in_body for f
+    // N set: f in N if f is called from a function in E or N
+    //        can also put f in N by pragma delegate_invariant_to_caller
+    //
+    // E set means: a suspendable invariant holds before, after, but NOT during the function body
+    // N set means: a suspendable invariant don’t hold at any point in the function
+    fn probe_invariant_status_in_functions(
+        env: &GlobalEnv,
+    ) -> (BTreeSet<QualifiedId<FunId>>, BTreeSet<QualifiedId<FunId>>) {
+        let mut disabled_inv_fun_set = BTreeSet::new(); // the E set
+        let mut non_inv_fun_set = BTreeSet::new(); // the N set
+
+        // Invariant: if a function is in non_inv_fun_set and not in worklist, then all the
+        // functions it calls are also in non_inv_fun_set or in worklist. As a result, when the
+        // worklist is empty, all callees of a function in non_inv_fun_set will also be in
+        // non_inv_fun_set. Each function is added at most once to the worklist.
+        let mut worklist = vec![];
+        for module_env in env.get_modules() {
+            for fun_env in module_env.get_functions() {
+                if is_invariant_checking_disabled(&fun_env) {
+                    let fun_id = fun_env.get_qualified_id();
+                    disabled_inv_fun_set.insert(fun_id);
+                    worklist.push(fun_id);
+                }
+                if is_invariant_checking_delegated(&fun_env) {
+                    let fun_id = fun_env.get_qualified_id();
+                    if non_inv_fun_set.insert(fun_id) {
+                        // Add to work_list only if fun_id is not in non_inv_fun_set (may have
+                        // inferred this from a caller already).
+                        worklist.push(fun_id);
+                    }
+                }
+                // Downward closure of non_inv_fun_set
+                while let Some(called_fun_id) = worklist.pop() {
+                    let called_funs = env.get_function(called_fun_id).get_called_functions();
+                    for called_fun_id in called_funs {
+                        if non_inv_fun_set.insert(called_fun_id) {
+                            // Add to work_list only if fun_id is not in fun_set
+                            worklist.push(called_fun_id);
+                        }
+                    }
+                }
+            }
+        }
+        (disabled_inv_fun_set, non_inv_fun_set)
+    }
+
+    // Produce a Map[fun_id -> (Set<global_id>, Set<global_id>)] ignoring the relevant pragmas on
+    // both function-side (i.e., `disable_invariants_in_body` and `delegate_invariants_to_caller`)
+    // and invariant-side (i.e., `suspendable`)
+    //
+    // The first set contains global invariants that overlaps with the read-write set of the memory,
+    // the second set contains global invariants that overlaps with the modified memory set only.
+    fn build_function_to_invariants_map(
+        env: &GlobalEnv,
+        targets: &FunctionTargetsHolder,
+    ) -> BTreeMap<QualifiedId<FunId>, (BTreeSet<GlobalId>, BTreeSet<GlobalId>)> {
+        // collect all global invariants
+        let mut global_invariants = vec![];
+        for menv in env.get_modules() {
+            for inv_id in env.get_global_invariants_by_module(menv.get_id()) {
+                global_invariants.push(env.get_global_invariant(inv_id).unwrap());
+            }
+        }
+
+        // go over each function target and check global invariant applicability
+        let mut invariant_relevance = BTreeMap::new();
+        for (fun_id, fun_variant) in targets.get_funs_and_variants() {
+            assert!(matches!(fun_variant, FunctionVariant::Baseline));
+            let fenv = env.get_function(fun_id);
+            let target = targets.get_target(&fenv, &fun_variant);
+            let related =
+                Self::find_relevant_invariants(&target, global_invariants.clone().into_iter());
+            invariant_relevance.insert(fun_id, related);
+        }
+
+        // return the collected relevance map
+        invariant_relevance
+    }
+
+    fn find_relevant_invariants<'a>(
+        target: &FunctionTarget,
+        invariants: impl Iterator<Item = &'a GlobalInvariant>,
+    ) -> (BTreeSet<GlobalId>, BTreeSet<GlobalId>) {
+        let mem_usage = usage_analysis::get_used_memory_inst(target);
+        let mem_modified = usage_analysis::get_modified_memory_inst(target);
+
+        let mut related_rw = BTreeSet::new();
+        let mut related_wo = BTreeSet::new();
+        for inv in invariants {
+            for fun_mem in mem_usage.iter() {
+                for inv_mem in &inv.mem_usage {
+                    if inv_mem.module_id != fun_mem.module_id || inv_mem.id != fun_mem.id {
+                        continue;
+                    }
+                    let adapter =
+                        TypeUnificationAdapter::new_vec(&fun_mem.inst, &inv_mem.inst, true, true);
+                    let rel = adapter.unify(Variance::Allow, /* shallow_subst */ false);
+                    if rel.is_some() {
+                        related_rw.insert(inv.id);
+                        // this exploits the fact that the `used_memory` set (a read-write set) is
+                        // always a superset of the `modified_memory` set.
+                        if mem_modified.contains(fun_mem) {
+                            related_wo.insert(inv.id);
+                        }
+                    }
+                }
+            }
+        }
+        (related_rw, related_wo)
+    }
+
+    // Prune the Map[fun_id -> (Set<global_id>, Set<global_id>)] returned with
+    // `build_function_to_invariants_map` with invariant-checking related pragmas.
+    fn prune_function_to_invariants_map(
+        env: &GlobalEnv,
+        original: BTreeMap<QualifiedId<FunId>, (BTreeSet<GlobalId>, BTreeSet<GlobalId>)>,
+        fun_set_with_no_inv_check: &BTreeSet<QualifiedId<FunId>>,
+    ) -> BTreeMap<QualifiedId<FunId>, (BTreeSet<GlobalId>, BTreeSet<GlobalId>)> {
+        let mut pruned = BTreeMap::new();
+        for (fun_id, (mut inv_rw_set, mut inv_wo_set)) in original.into_iter() {
+            if fun_set_with_no_inv_check.contains(&fun_id) {
+                inv_rw_set.retain(|inv_id| !is_invariant_suspendable(env, *inv_id));
+                inv_wo_set.retain(|inv_id| !is_invariant_suspendable(env, *inv_id));
+                // NOTE: here we do not need to insert the suspendable invariants back to all the
+                // callers and why is that?
+                //
+                // inv_rw_set and inv_wo_set are derived based on unification of memory
+                // usage/modification of the function and the invariant. In `MemoryUsageAnalysis`,
+                // both used memory and modified memory subsumes the set summarized in the called
+                // functions.
+                //
+                // If the called function is NOT a generic function, this means that all the
+                // invariants that are applicable to the called function will be applicable to its
+                // caller function as well.
+                //
+                // If the called function IS a generic function, this means that all the invariants
+                // that are applicable to this specific instantiation of the called function (which
+                // can be another type parameter, i.e., a type parameter from the caller function)
+                // will be applicable to this caller function as well.
+                //
+                // This means that if we disable a suspendable invariant `I` in the called function,
+                // for all the callers of this called function, `I` is either
+                // - already marked as relevant to the caller, or
+                // - `I` is not relevant to the caller and we should not insert `I` to the caller.
+            }
+            pruned.insert(fun_id, (inv_rw_set, inv_wo_set));
+        }
+        pruned
+    }
+}
+
+// This implementation block contains functions on type instantiation collection
+impl InstantiationAnalysisProcessor {
+    // Find what the instantiations should we have for the target_param_index.
+    //
+    // the invariant is, forall type parameters whose index < target_param_index, it should either
+    // - be assigned with a concrete type and hence, ceases to be a type parameter, or
+    // - do not have any matching instantiation and hence, remains a type parameter.
+    fn find_instantiations_for_target(
+        mem_usage_lhs: &BTreeSet<QualifiedInstId<StructId>>,
+        mem_usage_rhs: &BTreeSet<QualifiedInstId<StructId>>,
+        treat_lhs_type_param_as_var: bool,
+        treat_rhs_type_param_as_var: bool,
+        target_param_index: TypeParameterIndex,
+        params_on_lhs: bool,
+    ) -> BTreeSet<Type> {
+        // progressively increase the boundary
+        let treat_lhs_type_param_as_var_after_index = if treat_lhs_type_param_as_var {
+            Some(target_param_index)
+        } else {
+            None
+        };
+        let treat_rhs_type_param_as_var_after_index = if treat_rhs_type_param_as_var {
+            Some(target_param_index)
+        } else {
+            None
+        };
+
+        let mut target_param_insts = BTreeSet::new();
+        for m1 in mem_usage_lhs.iter() {
+            for m2 in mem_usage_rhs.iter() {
+                if (m1.module_id != m2.module_id) || (m1.id != m2.id) {
+                    continue;
+                }
+
+                // Try to unify the instantiations
+                let adapter = TypeUnificationAdapter::new_vec_with_boundary(
+                    &m1.inst,
+                    &m2.inst,
+                    treat_lhs_type_param_as_var_after_index,
+                    treat_rhs_type_param_as_var_after_index,
+                );
+                let rel = adapter.unify(Variance::Allow, false);
+                if let Some((subst_lhs, subst_rhs)) = rel {
+                    let subst = if params_on_lhs { subst_lhs } else { subst_rhs };
+                    for (param_idx, inst_ty) in subst.into_iter() {
+                        if param_idx != target_param_index {
+                            // this parameter will be unified at a later stage.
+                            //
+                            // NOTE: this code is inefficient when we have multiple type parameters,
+                            // but a vast majority of Move code we see so far have at most one type
+                            // parameter, so we trade-off efficiency with simplicity in code.
+                            assert!(param_idx > target_param_index);
+                            continue;
+                        }
+                        target_param_insts.insert(inst_ty);
+                    }
+                }
+            }
+        }
+        target_param_insts
+    }
+
+    // Find what the instantiation combinations for all the type parameters.
+    fn progressive_instantiation(
+        mem_usage_lhs: &BTreeSet<QualifiedInstId<StructId>>,
+        mem_usage_rhs: &BTreeSet<QualifiedInstId<StructId>>,
+        treat_lhs_type_param_as_var: bool,
+        treat_rhs_type_param_as_var: bool,
+        refine_lhs: bool,
+        refine_rhs: bool,
+        params_arity: usize,
+        params_on_lhs: bool,
+        mark_irrelevant_param_as_error: bool,
+    ) -> BTreeSet<Vec<Type>> {
+        let initial_param_insts: Vec<_> = (0..params_arity)
+            .map(|idx| Type::TypeParameter(idx as TypeParameterIndex))
+            .collect();
+
+        let mut work_queue = VecDeque::new();
+        work_queue.push_back(initial_param_insts);
+        for target_param_index in 0..params_arity {
+            let mut for_next_round = vec![];
+            while let Some(param_insts) = work_queue.pop_front() {
+                // adapt the memory usage sets with current param instantiations
+                let adapted_mem_usage_lhs = mem_usage_lhs
+                    .iter()
+                    .map(|mem| {
+                        if refine_lhs {
+                            mem.instantiate_ref(&param_insts)
+                        } else {
+                            mem.clone()
+                        }
+                    })
+                    .collect();
+                let adapted_mem_usage_rhs = mem_usage_rhs
+                    .iter()
+                    .map(|mem| {
+                        if refine_rhs {
+                            mem.instantiate_ref(&param_insts)
+                        } else {
+                            mem.clone()
+                        }
+                    })
+                    .collect();
+
+                // find type instantiations for the target parameter index
+                let mut target_param_insts = Self::find_instantiations_for_target(
+                    &adapted_mem_usage_lhs,
+                    &adapted_mem_usage_rhs,
+                    treat_lhs_type_param_as_var,
+                    treat_rhs_type_param_as_var,
+                    target_param_index as TypeParameterIndex,
+                    params_on_lhs,
+                );
+
+                // decide what to do with an irrelevant type parameter
+                if target_param_insts.is_empty() {
+                    let irrelevant_type = if mark_irrelevant_param_as_error {
+                        Type::Error
+                    } else {
+                        Type::TypeParameter(target_param_index as TypeParameterIndex)
+                    };
+                    target_param_insts.insert(irrelevant_type);
+                }
+
+                // instantiate the target type parameter in every possible way
+                for inst in target_param_insts {
+                    let mut next_insts = param_insts.clone();
+                    next_insts[target_param_index] = inst;
+                    for_next_round.push(next_insts);
+                }
+            }
+            work_queue.extend(for_next_round);
+        }
+
+        // the final workqueue contains possible instantiations for all type parameters
+        work_queue.into_iter().collect()
+    }
+
+    /// Analyze the bytecode (excluding the specs) to see what instantiations are needed for the
+    /// function type parameters. This is needed because Move allows type-dependent behaviors, i.e.,
+    /// move_to<R<T>>(..); move_to<R<u64>>(..); leads to a sure abort if T := u64, but the program
+    /// might not necessarily abort if T is not instantiated with u64.
+    fn analyze_instantiation_by_code(target: &FunctionTarget) -> BTreeSet<Vec<Type>> {
+        let mem_usage = usage_analysis::get_used_memory_inst(target)
+            .iter()
+            .cloned()
+            .collect();
+
+        // NOTE: we only treat the type parameters in one side (RHS is arbitrarily chosen here)
+        // because we don't want to unify a pair like (S<X, bool>, S<u64, X>). They shouldn't, as
+        // there is no assignment X that allows the type pair to unify.
+        //
+        // But this comes at the cost that we might unify (S<X, Y>, S<X, bool>) with a result
+        // [X := X, Y := bool]. We need to additional filter X := X because this just means that the
+        // type variable assigns to itself.
+        //
+        // And we should be able to unify amongst the parameters themselves as well. For example,
+        // we can and should unify S<X, Y> with S<Y, X> into [X := Y, Y := X].
+        Self::progressive_instantiation(
+            &mem_usage,
+            &mem_usage,
+            false,
+            true,
+            true,
+            true,
+            target.get_type_parameters().len(),
+            false,
+            false,
+        )
+    }
+
+    /// Analyze the spec to see what instantiations are needed for the function type parameters.
+    /// At the same time, this function also derives which invariant needs to be instrumented
+    /// on which instantiation of the function, and if an invariant needs to be instrumented, what
+    /// are the instantiations of that invariant. So the return result is a
+    /// Map[fun_inst -> Map[invariant_id -> Set[invariant_inst]]]
+    fn analyze_instantiation_by_spec(
+        target: &FunctionTarget,
+    ) -> BTreeMap<(Vec<Type>, Vec<Type>), BTreeMap<GlobalId, BTreeSet<Vec<Type>>>> {
+        let mut invariant_applicability = BTreeMap::new();
+
+        let env = target.global_env();
+        let fun_mem_usage = usage_analysis::get_used_memory_inst(target)
+            .iter()
+            .cloned()
+            .collect();
+        let fun_type_params_arity = target.get_type_parameters().len();
+
+        // collect relevant global invariants
+        let inv_analysis = env.get_extension::<InvariantAnalysisData>().unwrap();
+        let (inv_rw, _) = inv_analysis
+            .fun_to_inv_map
+            .get(&target.func_env.get_qualified_id())
+            .unwrap();
+        for inv_id in inv_rw {
+            let invariant = env.get_global_invariant(*inv_id).unwrap();
+            let inv_type_params = match &invariant.kind {
+                ConditionKind::GlobalInvariant(params) => params,
+                ConditionKind::GlobalInvariantUpdate(params) => params,
+                _ => unreachable!(
+                    "A global invariant must have a condition kind of either \
+                    `GlobalInvariant` or `GlobalInvariantUpdate`"
+                ),
+            };
+
+            // find out which instantiations are needed for the function type parameter
+            let fun_insts = Self::progressive_instantiation(
+                &fun_mem_usage,
+                &invariant.mem_usage,
+                true,
+                true,
+                true,
+                false,
+                fun_type_params_arity,
+                true,
+                false,
+            );
+
+            // per-each instantiation of the function, what are the instantiations of the global
+            // invariant in order to make it relevant
+            let inv_type_params_arity = inv_type_params.len();
+            for fun_param_insts in &fun_insts {
+                let inst_fun_mem_usage: BTreeSet<_> = fun_mem_usage
+                    .iter()
+                    .map(|mem| mem.instantiate_ref(fun_param_insts))
+                    .collect();
+
+                // check whether this invariant is still relevant to this particular instantiation
+                // of the function
+                let mut is_relevant = false;
+                for fun_mem in &inst_fun_mem_usage {
+                    for inv_mem in &invariant.mem_usage {
+                        if inv_mem.module_id != fun_mem.module_id || inv_mem.id != fun_mem.id {
+                            continue;
+                        }
+                        let adapter = TypeUnificationAdapter::new_vec(
+                            &fun_mem.inst,
+                            &inv_mem.inst,
+                            false,
+                            true,
+                        );
+                        let rel = adapter.unify(Variance::Allow, /* shallow_subst */ false);
+                        if rel.is_some() {
+                            is_relevant = true;
+                        }
+                    }
+                }
+                if !is_relevant {
+                    // this invariant is no longer applicable to this function instantiation
+                    continue;
+                }
+
+                // derive the instantiations of the invariant
+                let inv_insts = Self::progressive_instantiation(
+                    &inst_fun_mem_usage,
+                    &invariant.mem_usage,
+                    false,
+                    true,
+                    false,
+                    true,
+                    inv_type_params_arity,
+                    false,
+                    true,
+                );
+
+                // TODO: if not all type parameters in an invariant can be instantiated, e.g., the
+                // invariant talks about some generic memory that is never touched by this function,
+                // shall we include the invariant?
+                //
+                // For a concrete example: we have a function that reads `global<RoleId>` and an
+                // invariant I<T>: exists<S<T>>(addr) ==> global<RoleId>(addr).role_id == @DiemRoot;
+                // This T in the invariant will not be instantiated to anything. In this case, it
+                // might be OK to simply ignore this invariant.
+                //
+                // But consider the following case: a function modifies `global<RoleId>` and an
+                // invariant I<T>: (global<RoleId>(addr).role_id == @DiemRoot) ==>
+                //   (exists<S<T>>(addr) ==> global<S<T>>(addr).owner == @Blessed);
+                // In this case, is it OK to ignore this invariant?
+                //
+                // The tentative policy we have for now is to mark an uninstantiated type parameter
+                // as a `Type::Error` in the unification process and expand the type parameter list
+                // of the function to include the new type parameters in the invariant. These new
+                // type parameters behave like "phantom" types: they don't have an effect in the
+                // function implementation, but they are needed for spec checking.
+                for inv_param_inst in inv_insts {
+                    let mut fun_phantom_params = vec![];
+                    let adapted_inv_param_inst = inv_param_inst
+                        .into_iter()
+                        .map(|t| {
+                            if matches!(t, Type::Error) {
+                                let idx = (fun_type_params_arity + fun_phantom_params.len())
+                                    as TypeParameterIndex;
+                                let phantom_param = Type::TypeParameter(idx);
+                                fun_phantom_params.push(phantom_param.clone());
+                                phantom_param
+                            } else {
+                                t
+                            }
+                        })
+                        .collect();
+
+                    let inserted = invariant_applicability
+                        .entry((fun_param_insts.clone(), fun_phantom_params))
+                        .or_insert_with(BTreeMap::new)
+                        .entry(invariant.id)
+                        .or_insert_with(BTreeSet::new)
+                        .insert(adapted_inv_param_inst);
+                    debug_assert!(inserted);
+                }
+            }
+        }
+
+        invariant_applicability
+    }
+}
+
+// Utility functions
+fn is_invariant_checking_disabled(fun_env: &FunctionEnv) -> bool {
+    fun_env.is_pragma_true(DISABLE_INVARIANTS_IN_BODY_PRAGMA, || false)
+}
+
+fn is_invariant_checking_delegated(fun_env: &FunctionEnv) -> bool {
+    fun_env.is_pragma_true(DELEGATE_INVARIANTS_TO_CALLER_PRAGMA, || false)
+}
+
+fn is_invariant_suspendable(env: &GlobalEnv, inv_id: GlobalId) -> bool {
+    let inv = env.get_global_invariant(inv_id).unwrap();
+    env.is_property_true(&inv.properties, CONDITION_SUSPENDABLE_PROP)
+        .unwrap_or(false)
+}

--- a/language/move-prover/bytecode/src/instantiation_analysis.rs
+++ b/language/move-prover/bytecode/src/instantiation_analysis.rs
@@ -26,13 +26,13 @@ use std::{
 // A named tuple for holding of the invariant relevance information
 pub struct InvariantRelevance {
     /// Global invariants covering memories that are used in this function
-    uses: BTreeSet<GlobalId>,
+    pub uses: BTreeSet<GlobalId>,
     /// Global invariants covering memories that are modified in this function
-    mods: BTreeSet<GlobalId>,
+    pub mods: BTreeSet<GlobalId>,
     /// Global invariants covering memories that are directly used in this function
-    direct_uses: BTreeSet<GlobalId>,
+    pub direct_uses: BTreeSet<GlobalId>,
     /// Global invariants covering memories that are directly modified in this function
-    direct_mods: BTreeSet<GlobalId>,
+    pub direct_mods: BTreeSet<GlobalId>,
 }
 
 impl InvariantRelevance {

--- a/language/move-prover/bytecode/src/lib.rs
+++ b/language/move-prover/bytecode/src/lib.rs
@@ -20,6 +20,7 @@ pub mod eliminate_imm_refs;
 pub mod function_data_builder;
 pub mod function_target;
 pub mod function_target_pipeline;
+pub mod global_invariant_instrumentation;
 pub mod global_invariant_instrumentation_v2;
 pub mod graph;
 pub mod inconsistency_check;

--- a/language/move-prover/bytecode/src/lib.rs
+++ b/language/move-prover/bytecode/src/lib.rs
@@ -40,6 +40,7 @@ pub mod stackless_bytecode;
 pub mod stackless_bytecode_generator;
 pub mod stackless_control_flow_graph;
 pub mod usage_analysis;
+pub mod verification_analysis;
 pub mod verification_analysis_v2;
 
 /// Print function targets for testing and debugging.

--- a/language/move-prover/bytecode/src/lib.rs
+++ b/language/move-prover/bytecode/src/lib.rs
@@ -23,6 +23,7 @@ pub mod function_target_pipeline;
 pub mod global_invariant_instrumentation_v2;
 pub mod graph;
 pub mod inconsistency_check;
+pub mod instantiation_analysis;
 pub mod livevar_analysis;
 pub mod loop_analysis;
 pub mod memory_instrumentation;

--- a/language/move-prover/bytecode/src/pipeline_factory.rs
+++ b/language/move-prover/bytecode/src/pipeline_factory.rs
@@ -8,7 +8,7 @@ use crate::{
     debug_instrumentation::DebugInstrumenter,
     eliminate_imm_refs::EliminateImmRefsProcessor,
     function_target_pipeline::{FunctionTargetPipeline, FunctionTargetProcessor},
-    global_invariant_instrumentation_v2::GlobalInvariantInstrumentationProcessorV2,
+    global_invariant_instrumentation::GlobalInvariantInstrumentationProcessor,
     inconsistency_check::InconsistencyCheckInstrumenter,
     instantiation_analysis::InstantiationAnalysisProcessor,
     livevar_analysis::LiveVarAnalysisProcessor,
@@ -45,7 +45,7 @@ pub fn default_pipeline_with_options(options: &ProverOptions) -> FunctionTargetP
         // spec instrumentation
         SpecInstrumentationProcessor::new(),
         DataInvariantInstrumentationProcessor::new(),
-        GlobalInvariantInstrumentationProcessorV2::new(),
+        GlobalInvariantInstrumentationProcessor::new(),
     ];
     if options.mutation {
         processors.push(MutationTester::new()); // pass which may do nothing

--- a/language/move-prover/bytecode/src/pipeline_factory.rs
+++ b/language/move-prover/bytecode/src/pipeline_factory.rs
@@ -21,6 +21,7 @@ use crate::{
     reaching_def_analysis::ReachingDefProcessor,
     spec_instrumentation::SpecInstrumentationProcessor,
     usage_analysis::UsageProcessor,
+    verification_analysis::VerificationAnalysisProcessor,
     verification_analysis_v2::VerificationAnalysisProcessorV2,
 };
 
@@ -38,6 +39,7 @@ pub fn default_pipeline_with_options(options: &ProverOptions) -> FunctionTargetP
         CleanAndOptimizeProcessor::new(),
         UsageProcessor::new(),
         InstantiationAnalysisProcessor::new(),
+        VerificationAnalysisProcessor::new(),
         VerificationAnalysisProcessorV2::new(),
         LoopAnalysisProcessor::new(),
         // spec instrumentation

--- a/language/move-prover/bytecode/src/pipeline_factory.rs
+++ b/language/move-prover/bytecode/src/pipeline_factory.rs
@@ -10,6 +10,7 @@ use crate::{
     function_target_pipeline::{FunctionTargetPipeline, FunctionTargetProcessor},
     global_invariant_instrumentation_v2::GlobalInvariantInstrumentationProcessorV2,
     inconsistency_check::InconsistencyCheckInstrumenter,
+    instantiation_analysis::InstantiationAnalysisProcessor,
     livevar_analysis::LiveVarAnalysisProcessor,
     loop_analysis::LoopAnalysisProcessor,
     memory_instrumentation::MemoryInstrumentationProcessor,
@@ -36,6 +37,7 @@ pub fn default_pipeline_with_options(options: &ProverOptions) -> FunctionTargetP
         MemoryInstrumentationProcessor::new(),
         CleanAndOptimizeProcessor::new(),
         UsageProcessor::new(),
+        InstantiationAnalysisProcessor::new(),
         VerificationAnalysisProcessorV2::new(),
         LoopAnalysisProcessor::new(),
         // spec instrumentation

--- a/language/move-prover/bytecode/src/verification_analysis.rs
+++ b/language/move-prover/bytecode/src/verification_analysis.rs
@@ -1,0 +1,192 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Analysis which computes an annotation for each function on whether this function should be
+//! verified or inlined.
+
+use crate::{
+    function_target::{FunctionData, FunctionTarget},
+    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant},
+    instantiation_analysis::InvariantAnalysisData,
+    options::ProverOptions,
+};
+
+use move_model::{
+    model::{FunctionEnv, GlobalEnv, VerificationScope},
+    pragmas::VERIFY_PRAGMA,
+};
+
+use std::collections::BTreeSet;
+
+/// The annotation for information about verification.
+#[derive(Clone, Default)]
+pub struct VerificationInfo {
+    /// Whether the function is target of verification.
+    pub verified: bool,
+    /// Whether the function needs to have an inlined variant since it is called from a verified
+    /// function and is not opaque.
+    pub inlined: bool,
+}
+
+/// Get verification information for this function.
+pub fn get_info(target: &FunctionTarget<'_>) -> VerificationInfo {
+    target
+        .get_annotations()
+        .get::<VerificationInfo>()
+        .cloned()
+        .unwrap_or_else(VerificationInfo::default)
+}
+
+pub struct VerificationAnalysisProcessor();
+
+impl VerificationAnalysisProcessor {
+    pub fn new() -> Box<Self> {
+        Box::new(Self())
+    }
+}
+
+impl FunctionTargetProcessor for VerificationAnalysisProcessor {
+    fn process(
+        &self,
+        targets: &mut FunctionTargetsHolder,
+        fun_env: &FunctionEnv<'_>,
+        mut data: FunctionData,
+    ) -> FunctionData {
+        // This function implements the logic to decide whether to verify this function
+
+        // Rule 1: never verify if "pragma verify = false;"
+        if !fun_env.is_pragma_true(VERIFY_PRAGMA, || true) {
+            return data;
+        }
+
+        // Rule 2: verify the function if it is within the target modules
+        let env = fun_env.module_env.env;
+        let target_modules = env.get_target_modules();
+
+        let is_in_target_module = target_modules
+            .iter()
+            .any(|menv| menv.get_id() == fun_env.module_env.get_id());
+        if is_in_target_module {
+            if Self::within_verification_scope(fun_env) {
+                Self::mark_verified(fun_env, &mut data, targets);
+            }
+            return data;
+        }
+
+        // Rule 3: verify the function if it directly uses an invariant that is defined in the
+        // target modules
+        let inv_analysis = env.get_extension::<InvariantAnalysisData>().unwrap();
+        let target_invs: BTreeSet<_> = target_modules
+            .iter()
+            .map(|menv| env.get_global_invariants_by_module(menv.get_id()))
+            .flatten()
+            .collect();
+        let inv_relevance = inv_analysis
+            .fun_to_inv_map
+            .get(&fun_env.get_qualified_id())
+            .unwrap();
+        if !inv_relevance.direct_uses.is_disjoint(&target_invs) {
+            if Self::within_verification_scope(fun_env) {
+                Self::mark_verified(fun_env, &mut data, targets);
+            }
+            return data;
+        }
+
+        // we don't verify this function
+        data
+    }
+
+    fn name(&self) -> String {
+        "verification_analysis".to_string()
+    }
+
+    fn initialize(&self, global_env: &GlobalEnv, _targets: &mut FunctionTargetsHolder) {
+        let options = ProverOptions::get(global_env);
+
+        // If we are verifying only one function or module, check that this indeed exists.
+        match &options.verify_scope {
+            VerificationScope::Only(name) | VerificationScope::OnlyModule(name) => {
+                let for_module = matches!(&options.verify_scope, VerificationScope::OnlyModule(_));
+                let mut target_exists = false;
+                for module in global_env.get_modules() {
+                    if module.is_target() {
+                        if for_module {
+                            target_exists = module.matches_name(name)
+                        } else {
+                            target_exists = module.get_functions().any(|f| f.matches_name(name));
+                        }
+                        if target_exists {
+                            break;
+                        }
+                    }
+                }
+                if !target_exists {
+                    global_env.error(
+                        &global_env.unknown_loc(),
+                        &format!(
+                            "{} target {} does not exist in target modules",
+                            if for_module { "module" } else { "function" },
+                            name
+                        ),
+                    )
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+impl VerificationAnalysisProcessor {
+    fn within_verification_scope(fun_env: &FunctionEnv) -> bool {
+        let env = fun_env.module_env.env;
+        let options = ProverOptions::get(env);
+        match &options.verify_scope {
+            VerificationScope::Public => fun_env.is_exposed(),
+            VerificationScope::All => true,
+            VerificationScope::Only(name) => fun_env.matches_name(name),
+            VerificationScope::OnlyModule(name) => fun_env.module_env.matches_name(name),
+            VerificationScope::None => false,
+        }
+    }
+
+    fn mark_verified(
+        fun_env: &FunctionEnv,
+        data: &mut FunctionData,
+        targets: &mut FunctionTargetsHolder,
+    ) {
+        let mut info = data.annotations.get_or_default_mut::<VerificationInfo>();
+        if !info.verified {
+            info.verified = true;
+            Self::mark_callees_inlined(fun_env, targets);
+        }
+    }
+
+    fn mark_inlined(fun_env: &FunctionEnv, targets: &mut FunctionTargetsHolder) {
+        if fun_env.is_opaque() || fun_env.is_native() || fun_env.is_intrinsic() {
+            return;
+        }
+
+        let variant = FunctionVariant::Baseline;
+        debug_assert!(
+            targets.get_target_variants(fun_env).contains(&variant),
+            "`{}` has variant `{:?}`",
+            fun_env.get_name().display(fun_env.symbol_pool()),
+            variant
+        );
+        let data = targets
+            .get_data_mut(&fun_env.get_qualified_id(), &variant)
+            .expect("function data defined");
+        let info = data.annotations.get_or_default_mut::<VerificationInfo>();
+        if !info.inlined {
+            info.inlined = true;
+            Self::mark_callees_inlined(fun_env, targets);
+        }
+    }
+
+    fn mark_callees_inlined(fun_env: &FunctionEnv, targets: &mut FunctionTargetsHolder) {
+        for callee in fun_env.get_called_functions() {
+            let callee_env = fun_env.module_env.env.get_function(callee);
+            Self::mark_inlined(&callee_env, targets);
+        }
+    }
+}

--- a/language/move-prover/bytecode/tests/usage_analysis/test.exp
+++ b/language/move-prover/bytecode/tests/usage_analysis/test.exp
@@ -127,21 +127,26 @@ public fun Test::update_ints() {
 
 function Test::update [baseline] {
   used = {Test::A<#0, #0>}
+  directly used = {Test::A<#0, #0>}
   modified = {Test::A<#0, #0>}
   directly modified = {Test::A<#0, #0>}
 function Test::publish [baseline] {
   used = {Test::A<#0, u8>}
+  directly used = {Test::A<#0, u8>}
   modified = {Test::A<#0, u8>}
   directly modified = {Test::A<#0, u8>}
 function Test::test [baseline] {
   used = {Test::A<u64, #0>}
+  directly used = {Test::A<u64, #0>}
   modified = {}
   directly modified = {}
 function Test::update_caller [baseline] {
   used = {Test::A<u8, u8>}
+  directly used = {}
   modified = {Test::A<u8, u8>}
   directly modified = {}
 function Test::update_ints [baseline] {
   used = {Test::A<u64, u128>}
+  directly used = {Test::A<u64, u128>}
   modified = {Test::A<u64, u128>}
   directly modified = {Test::A<u64, u128>}

--- a/language/move-prover/tests/sources/functional/disable_inv.exp
+++ b/language/move-prover/tests/sources/functional/disable_inv.exp
@@ -1,4 +1,36 @@
 Move prover returns: exiting with bytecode transformation errors
+error: Functions must not have `pragma disable_invariants_in_body` when invariant checking is turned-off on this function.
+   ┌─ tests/sources/functional/disable_inv.move:31:5
+   │
+31 │ ╭     fun f3_incorrect(s: &signer) {
+32 │ │         move_to(s, R1 {});
+33 │ │     }
+   │ ╰─────^
+
+error: Invariant checking is turned-off on this function because either 1) a transitive caller of this function has `pragma disable_invariants_in_body` or 2) `pragma delegate_invariants_to_caller` is applied on this function
+   ┌─ tests/sources/functional/disable_inv.move:31:5
+   │
+31 │ ╭     fun f3_incorrect(s: &signer) {
+32 │ │         move_to(s, R1 {});
+33 │ │     }
+   │ ╰─────^
+
+error: Functions must not have `pragma disable_invariants_in_body` when invariant checking is turned-off on this function.
+   ┌─ tests/sources/functional/disable_inv.move:46:5
+   │
+46 │ ╭     fun f5_incorrect(s: &signer) {
+47 │ │         move_to(s, R2 {});
+48 │ │     }
+   │ ╰─────^
+
+error: Invariant checking is turned-off on this function because either 1) a transitive caller of this function has `pragma disable_invariants_in_body` or 2) `pragma delegate_invariants_to_caller` is applied on this function
+   ┌─ tests/sources/functional/disable_inv.move:46:5
+   │
+46 │ ╭     fun f5_incorrect(s: &signer) {
+47 │ │         move_to(s, R2 {});
+48 │ │     }
+   │ ╰─────^
+
 error: Public or script functions cannot delegate invariants
    ┌─ tests/sources/functional/disable_inv.move:11:5
    │

--- a/language/move-prover/tests/sources/functional/invariant_target.move
+++ b/language/move-prover/tests/sources/functional/invariant_target.move
@@ -1,0 +1,24 @@
+// flag: --dependency=tests/sources/functional/invariant_target_dep.move
+module 0x2::Version {
+    use 0x2::Config;
+
+    struct Version has copy, drop, store {
+        num: u64
+    }
+
+    public fun put_version(addr: signer) {
+        Config::put(addr, Version { num: 1 });
+    }
+
+    public fun set_version(addr: address, num: u64) {
+        let old_version = Config::get<Version>(addr);
+        assert(old_version.num < num, 42);
+        Config::set(addr, Version { num });
+    }
+
+    spec module {
+        invariant
+            forall addr: address where exists<Config::Config<Version>>(addr):
+                global<Config::Config<Version>>(addr).payload.num != 0;
+    }
+}

--- a/language/move-prover/tests/sources/functional/invariant_target_dep.move
+++ b/language/move-prover/tests/sources/functional/invariant_target_dep.move
@@ -1,0 +1,20 @@
+module 0x2::Config {
+    struct Config<T: copy + drop + store> has key, store {
+        payload: T
+    }
+
+    public fun put<T: copy + drop + store>(addr: signer, payload: T) {
+        move_to(&addr, Config { payload });
+    }
+
+    public fun set<T: copy + drop + store>(addr: address, payload: T)
+    acquires Config {
+        let cfg = borrow_global_mut<Config<T>>(addr);
+        cfg.payload = payload;
+    }
+
+    public fun get<T: copy + drop + store>(addr: address): T
+    acquires Config {
+        *&borrow_global<Config<T>>(addr).payload
+    }
+}

--- a/language/move-prover/tests/sources/functional/type_overlap.move
+++ b/language/move-prover/tests/sources/functional/type_overlap.move
@@ -1,0 +1,40 @@
+module 0x42::M {
+    use Std::Signer;
+
+    struct S<X: store> has key { x: X }
+
+    public fun extract<X: store>(account: signer, x: X) {
+        move_to<S<X>>(&account, S { x });
+        move_to<S<u8>>(&account, S { x: 0 });
+    }
+    spec extract {
+        aborts_if exists<S<X>>(Signer::spec_address_of(account));
+        aborts_if exists<S<u8>>(Signer::spec_address_of(account));
+
+        // TODO: besides the above aborts_if conditions, this function
+        // also aborts if the type parameter `X` is instantiated with `u8`.
+        // This additional abort condition is not captured by the spec.
+    }
+}
+
+module 0x42::N {
+    use Std::Signer;
+
+    struct S<X: store + drop> has key { x: X }
+
+    public fun extract<X: store + drop>(account: signer, x: X) acquires S {
+        move_to<S<u8>>(&account, S { x: 0 });
+        let r = borrow_global_mut<S<X>>(Signer::address_of(&account));
+        *&mut r.x = x;
+    }
+    spec extract {
+        aborts_if exists<S<u8>>(Signer::spec_address_of(account));
+        aborts_if !exists<S<X>>(Signer::spec_address_of(account));
+        ensures global<S<u8>>(Signer::spec_address_of(account)).x == 0;
+
+        // TODO: there are two issues with the spec
+        // 1) the second `aborts_if` condition is necessary only when X != u8
+        // 2) the `ensures` condition might not hold, as `extract<u8>(_, 1)`
+        //    will violate the `ensures` condition.
+    }
+}


### PR DESCRIPTION
The generic invariant business has gone much trickier than we thought,
and it gets even more complicated with the suspendable invariant magic.
So this PR tries to reconcile some of the efforts in tackling both issues
that are scattered across various files in the code base and centralize
the code in one pass named `InstantiationAnalysisProcessor`.

What this `InstantiationAnalysisProcessor` tries to do is simple, it has
only one goal --- finding out whether an instantiation of a global invariant
`I[inst]` is applicable to an instantiation of a function `F[inst]`.

(NOTE: Applicability here means whether `I[inst]` should be
assumed/asserted in `F[inst]`. But as for how the invariant should be
asserted or assumed, e.g., at entry, at body, or at return, is not a concern
here. That is the job of `global_invariant_instrumentation.rs`).

In order for the `InstantiationAnalysisProcessor` to meet its goal, it
records one piece of information in the per-function environment:
```
pub invariant_applicability: BTreeMap<Vec<Type>, BTreeMap<GlobalId, BTreeSet<Vec<Type>>>>,
```
This giant mapping can be read as:
- for the particular instantiation (`Vec<Type>`) of this function, `//` i.e., the key in the first map
- which invariant (`GlobalId`) is applicable, `//` i.e., the key in the second map
- and what instantiations of that invariant (`BTreeSet<Vec<Type>>`) are needed to make it applicable, `//` i.e., the value in the second map.

And this mapping takes in the consideration of "suspendable" invariant
business. That is, you will never find a suspendable invariant being
applicable in a function that is in the N set. (NOTE: a function in the N set
means that invariant assume/assert for suspendable invariant should be
completely turned-off).

The whole `InstantiationAnalysisProcessor` is about deriving the
`invariant_applicability` map. I hope the code and comments there are
self-explanatory. But this is a complex business, and might require some
careful reading.

The overall procedure works like the following:
- Calculate the E set and N set
  - E set: f in E if declared pragma disable_invariant_in_body for f
  - N set: 1) f in N if f is called from a function in E or N, 2) can also put f in N by pragma delegate_invariant_to_caller
  - This is purely `pragma` magic and call-graph traversal, and I copied the code from `verification_analysis.rs`.

- Derive the raw relevance of global invariants, producing a `Map[fun_id -> (Set<global_id>, Set<global_id>)]` while completely ignoring the pragmas
  - This produces two sets of invariant relevance and we call it `inv_rw` and `inv_wo` in the code.
  - An invariant `I` in `inv_rw` means that this function, identified by `fun_id`, uses (including reads and writes) a memory that is covered by `I` --> this means that we might want to assume `I` in `fun_id` in order to prove some properties.
  - An invariant `I` in `inv_wo` means that this function, identified by `fun_id`, modifies (writes-only) a memory that is covered by `I` --> this means that we might want to assert `I` in `fun_id` in order to prove the invariant holds.
  - NOTE: a `inv_rw` set is always a superset of `inv_wo`.
  - NOTE: at this stage, the instantiations do not matter. We say `I` is relevant in `fun_id` as long as there exists some instantiation of `I` and some instantiation of `fun_id` that they type-unify.

- Do some error checking on the E and N set, but this error checking requires information of the raw invariant relevance map
  - Rule 1: external-facing functions are not allowed in the N set, UNLESS they don't modify any memory that are checked in any suspendable invariant. (NOTE: this UNLESS part requires information from the raw invariant relevance mapping)
  - Rule 2: a function cannot be both on the E set and N set. This is because invariants must hold on entry to any function in the E set, so such a function must not be called from a function in E or N.

- Prune the raw relevance of global invariants and incorporating the information that a function is in N set and hence, all suspendable invariants are not applicable to that function.

- For each function `F` and for each invariant `I` in the `inv_rw` set of `F`, derive how to instantiate `F` and `I` to make them compatible for instrumentation.

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update or suggest changes to the docs at https://developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
