### PR TITLE
Cherry-pick PR #8979 into release-1.3: Change reference ID to pub

### DIFF
--- a/types/src/transaction/metadata.rs
+++ b/types/src/transaction/metadata.rs
@@ -83,7 +83,7 @@ pub enum TravelRuleMetadata {
 pub struct TravelRuleMetadataV0 {
     /// Off-chain reference_id.  Used when off-chain APIs are used.
     /// Specifies the off-chain reference ID that was agreed upon in off-chain APIs.
-    off_chain_reference_id: Option<String>,
+    pub off_chain_reference_id: Option<String>,
 }
 
 /// Opaque binary transaction metadata
@@ -91,7 +91,7 @@ pub struct TravelRuleMetadataV0 {
 pub struct UnstructuredBytesMetadata {
     /// Unstructured byte vector metadata
     #[serde(with = "serde_bytes")]
-    metadata: Option<Vec<u8>>,
+    pub metadata: Option<Vec<u8>>,
 }
 
 /// List of supported transaction metadata format versions for refund transaction
@@ -141,5 +141,5 @@ pub enum PaymentMetadata {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PaymentMetadataV0 {
     /// Reference ID needed for off-chain reference ID exchange.
-    reference_id: [u8; 16],
+    pub reference_id: [u8; 16],
 }


### PR DESCRIPTION
This cherry-pick was triggerd by a request on #8979
Please review the diff to ensure there are not any unexpected changes.

> ## Motivation
> There are several fields in metadata that are not public fields, so partners can't write any code that makes use of it. Changing to pub. Otherwise clients who depend on diem/diem for json rpc types won’t be able to use some of the types and will fail to parse some json rpc responses from the chain
> 
> ## Have you read the Contributing Guidelines on pull requests?
> Yes
> 
> ## Test Plan
> Existing tests

            
cc @ankushagarwal