### PR TITLE
[move-prover] Fixed the display of signer values in the error trace in Prover

### DIFF
--- a/language/move-prover/boogie-backend/src/boogie_wrapper.rs
+++ b/language/move-prover/boogie-backend/src/boogie_wrapper.rs
@@ -954,9 +954,17 @@ impl ModelValue {
                     .and_then(|s| s.parse::<bool>().ok())?
                     .to_string(),
             )),
-            Type::Primitive(PrimitiveType::Address) | Type::Primitive(PrimitiveType::Signer) => {
+            Type::Primitive(PrimitiveType::Address) => {
                 let addr = BigInt::parse_bytes(&self.extract_literal()?.clone().into_bytes(), 10)?;
                 Some(PrettyDoc::text(format!("0x{}", &addr.to_str_radix(16))))
+            }
+            Type::Primitive(PrimitiveType::Signer) => {
+                let l = self.extract_list("$signer")?;
+                let addr = BigInt::parse_bytes(&l[0].extract_literal()?.clone().into_bytes(), 10)?;
+                Some(PrettyDoc::text(format!(
+                    "signer{{0x{}}}",
+                    &addr.to_str_radix(16)
+                )))
             }
             Type::Vector(param) => self.pretty_vector(wrapper, model, param),
             Type::Struct(module_id, struct_id, params) => {

--- a/language/move-prover/tests/sources/functional/signer_display.exp
+++ b/language/move-prover/tests/sources/functional/signer_display.exp
@@ -1,0 +1,10 @@
+Move prover returns: exiting with boogie verification errors
+error: unknown assertion failed
+  ┌─ tests/sources/functional/signer_display.move:7:13
+  │
+7 │             assert Signer::spec_address_of(account) == @0x1;
+  │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  =     at tests/sources/functional/signer_display.move:5: f_incorrect
+  =         account = <redacted>
+  =     at tests/sources/functional/signer_display.move:7: f_incorrect

--- a/language/move-prover/tests/sources/functional/signer_display.move
+++ b/language/move-prover/tests/sources/functional/signer_display.move
@@ -1,0 +1,10 @@
+module 0x42::SignerDisplay {
+    use Std::Signer;
+
+    // Test the signer value display in the error trace
+    fun f_incorrect(account: &signer) {
+        spec {
+            assert Signer::spec_address_of(account) == @0x1;
+        }
+    }
+}


### PR DESCRIPTION
- This PR fixes the signer value display in the error trace.

For example, Prover produces the following error message for the new test file `signer_display.move`:
```
$ mvp signer_display.move

...

error: unknown assertion failed
  ┌─ signer_display.move:7:13
  │
7 │             assert Signer::spec_address_of(account) == @0x1;
  │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  │
  =     at signer_display.move:5: f_incorrect
  =         account = signer{0x2}
  =     at signer_display.move:7: f_incorrect
```

## Motivation

To correctly display the signer values in the error traces

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

cargo test
