### PR TITLE
[transaction-builder] Add support for `vector<vector<u8>>` in script functions

### DIFF
--- a/language/transaction-builder/generator/src/common.rs
+++ b/language/transaction-builder/generator/src/common.rs
@@ -32,6 +32,13 @@ fn quote_type_as_format(type_tag: &TypeTag) -> Format {
         Address => Format::TypeName("AccountAddress".into()),
         Vector(type_tag) => match type_tag.as_ref() {
             U8 => Format::Bytes,
+            Vector(type_tag) => {
+                if type_tag.as_ref() == &U8 {
+                    Format::Seq(Box::new(Format::Bytes))
+                } else {
+                    type_not_allowed(type_tag)
+                }
+            }
             _ => type_not_allowed(type_tag),
         },
         Struct(_) | Signer => type_not_allowed(type_tag),
@@ -84,6 +91,13 @@ pub(crate) fn mangle_type(type_tag: &TypeTag) -> String {
         Address => "address".into(),
         Vector(type_tag) => match type_tag.as_ref() {
             U8 => "u8vector".into(),
+            Vector(type_tag) => {
+                if type_tag.as_ref() == &U8 {
+                    "vectorvectoru8".into()
+                } else {
+                    type_not_allowed(type_tag)
+                }
+            }
             _ => type_not_allowed(type_tag),
         },
         Struct(_) | Signer => type_not_allowed(type_tag),

--- a/language/transaction-builder/generator/src/cpp.rs
+++ b/language/transaction-builder/generator/src/cpp.rs
@@ -322,6 +322,13 @@ using namespace diem_types;
             Address => "AccountAddress".into(),
             Vector(type_tag) => match type_tag.as_ref() {
                 U8 => "std::vector<uint8_t>".into(),
+                Vector(type_tag) => {
+                    if type_tag.as_ref() == &U8 {
+                        "std::vector<std::vector<uint8_t>>".into()
+                    } else {
+                        common::type_not_allowed(type_tag)
+                    }
+                }
                 _ => common::type_not_allowed(type_tag),
             },
             Struct(_) | Signer => common::type_not_allowed(type_tag),
@@ -374,6 +381,13 @@ using namespace diem_types;
             Address => None,
             Vector(type_tag) => match type_tag.as_ref() {
                 U8 => Some("std::vector<uint8_t>"),
+                Vector(type_tag) => {
+                    if type_tag.as_ref() == &U8 {
+                        Some("std::vector<std::vector<uint8_t>>")
+                    } else {
+                        common::type_not_allowed(type_tag)
+                    }
+                }
                 _ => common::type_not_allowed(type_tag),
             },
             Struct(_) | Signer => common::type_not_allowed(type_tag),


### PR DESCRIPTION
This adds support for `vector<vector<u8>>` arguments to the transaction script builders for both Rust and C++. Support for other languages is in progress, however support for these will need to be added in after changes to the `serde-generate` crate to support nested byte vectors is landed.

Note that support for `vector<vector<u8>>` arguments to transaction scripts is explicitly _not_ supported in this PR. 