### PR TITLE
[State Sync] Add MempoolNotifier interface and implementation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,6 +1098,7 @@ dependencies = [
  "fallible",
  "futures",
  "itertools 0.10.0",
+ "mempool-notifications",
  "mirai-annotations",
  "network",
  "num-derive",
@@ -2123,6 +2124,7 @@ dependencies = [
  "fail",
  "futures",
  "itertools 0.10.0",
+ "mempool-notifications",
  "mirai-annotations",
  "netcore",
  "network",
@@ -2213,6 +2215,7 @@ dependencies = [
  "futures",
  "hex",
  "jemallocator",
+ "mempool-notifications",
  "network-builder",
  "rand 0.8.3",
  "state-sync-v1",
@@ -4578,6 +4581,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mempool-notifications"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "diem-crypto",
+ "diem-types",
+ "diem-workspace-hack",
+ "futures",
+ "serde",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -7560,6 +7577,7 @@ dependencies = [
  "fail",
  "futures",
  "itertools 0.10.0",
+ "mempool-notifications",
  "memsocket",
  "netcore",
  "network",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,7 @@ members = [
     "secure/storage",
     "secure/storage/github",
     "secure/storage/vault",
+    "state-sync/inter-component/mempool-notifications",
     "state-sync/state-sync-v1",
     "state-sync/state-sync-v2",
     "storage/accumulator",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -17,6 +17,7 @@ bytes = "1.0.1"
 fail = "0.4.0"
 futures = "0.3.12"
 itertools = { version = "0.10.0", default-features = false }
+mempool-notifications = { path = "../state-sync/inter-component/mempool-notifications" }
 mirai-annotations = { version = "1.10.1", default-features = false }
 num-derive = { version = "0.3.3", default-features = false }
 num-traits = { version = "0.2.14", default-features = false }

--- a/consensus/src/txn_manager.rs
+++ b/consensus/src/txn_manager.rs
@@ -5,15 +5,14 @@ use crate::{error::MempoolError, state_replication::TxnManager};
 use anyhow::{format_err, Result};
 use consensus_types::{block::Block, common::Payload};
 use diem_logger::prelude::*;
-use diem_mempool::{
-    CommittedTransaction, ConsensusRequest, ConsensusResponse, TransactionExclusion,
-};
+use diem_mempool::{ConsensusRequest, ConsensusResponse, TransactionExclusion};
 use diem_metrics::monitor;
 use diem_types::transaction::TransactionStatus;
 use executor_types::StateComputeResult;
 use fail::fail_point;
 use futures::channel::{mpsc, oneshot};
 use itertools::Itertools;
+use mempool_notifications::CommittedTransaction;
 use std::time::Duration;
 use tokio::time::{sleep, timeout};
 

--- a/diem-node/Cargo.toml
+++ b/diem-node/Cargo.toml
@@ -40,6 +40,7 @@ diem-types = { path = "../types" }
 diem-vm = { path = "../language/diem-vm" }
 diem-workspace-hack = { path = "../common/workspace-hack" }
 diemdb = { path = "../storage/diemdb" }
+mempool-notifications = { path = "../state-sync/inter-component/mempool-notifications" }
 network-builder = { path = "../network/builder" }
 state-sync-v1 = { path = "../state-sync/state-sync-v1" }
 storage-client = { path = "../storage/storage-client" }

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -33,6 +33,7 @@ diem-proptest-helpers = { path = "../common/proptest-helpers", optional = true }
 diem-types = { path = "../types" }
 diem-workspace-hack = { path = "../common/workspace-hack" }
 mirai-annotations = "1.10.1"
+mempool-notifications = { path = "../state-sync/inter-component/mempool-notifications" }
 network = { path = "../network" }
 rand = "0.8.3"
 netcore = { path = "../network/netcore" }

--- a/mempool/src/counters.rs
+++ b/mempool/src/counters.rs
@@ -51,7 +51,6 @@ pub const SUCCESS_LABEL: &str = "success";
 
 // Bounded executor task labels
 pub const CLIENT_EVENT_LABEL: &str = "client_event";
-pub const STATE_SYNC_EVENT_LABEL: &str = "state_sync";
 pub const RECONFIG_EVENT_LABEL: &str = "reconfig";
 pub const PEER_BROADCAST_EVENT_LABEL: &str = "peer_broadcast";
 

--- a/mempool/src/lib.rs
+++ b/mempool/src/lib.rs
@@ -60,9 +60,8 @@ mod tests;
 pub use shared_mempool::{
     bootstrap, network,
     types::{
-        gen_mempool_reconfig_subscription, CommitNotification, CommitResponse,
-        CommittedTransaction, ConsensusRequest, ConsensusResponse, MempoolClientSender,
-        SubmissionStatus, TransactionExclusion,
+        gen_mempool_reconfig_subscription, CommitResponse, ConsensusRequest, ConsensusResponse,
+        MempoolClientSender, SubmissionStatus, TransactionExclusion,
     },
 };
 #[cfg(any(test, feature = "fuzzing"))]

--- a/mempool/src/logging.rs
+++ b/mempool/src/logging.rs
@@ -1,14 +1,12 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::shared_mempool::{
-    peer_manager::BatchId,
-    types::{CommitNotification, ConsensusRequest},
-};
+use crate::shared_mempool::{peer_manager::BatchId, types::ConsensusRequest};
 use anyhow::Error;
 use diem_config::{config::PeerNetworkId, network_id::NetworkId};
 use diem_logger::Schema;
 use diem_types::{account_address::AccountAddress, on_chain_config::OnChainConfigPayload};
+use mempool_notifications::MempoolCommitNotification;
 use serde::Serialize;
 use std::{fmt, time::SystemTime};
 
@@ -85,7 +83,7 @@ pub struct LogSchema<'a> {
     #[schema(display)]
     consensus_msg: Option<&'a ConsensusRequest>,
     #[schema(display)]
-    state_sync_msg: Option<&'a CommitNotification>,
+    state_sync_msg: Option<&'a MempoolCommitNotification>,
     network_level: Option<usize>,
     upstream_network: Option<&'a NetworkId>,
     #[schema(debug)]

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -26,6 +26,7 @@ use futures::{
     future::Future,
     task::{Context, Poll},
 };
+use mempool_notifications::CommittedTransaction;
 use std::{collections::HashMap, fmt, pin::Pin, sync::Arc, task::Waker, time::Instant};
 use storage_interface::DbReader;
 use subscription_service::ReconfigSubscription;
@@ -163,29 +164,6 @@ pub enum ConsensusResponse {
     CommitResponse(),
 }
 
-/// Notification from state sync to mempool of commit event.
-/// This notifies mempool to remove committed txns.
-pub struct CommitNotification {
-    pub transactions: Vec<CommittedTransaction>,
-    /// Timestamp of committed block.
-    pub block_timestamp_usecs: u64,
-    pub callback: oneshot::Sender<Result<CommitResponse>>,
-}
-
-impl fmt::Display for CommitNotification {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut txns = "".to_string();
-        for txn in self.transactions.iter() {
-            txns += &format!("{} ", txn);
-        }
-        write!(
-            f,
-            "CommitNotification [block_timestamp_usecs: {}, txns: {}]",
-            self.block_timestamp_usecs, txns
-        )
-    }
-}
-
 #[derive(Debug)]
 pub struct CommitResponse {
     pub success: bool,
@@ -208,18 +186,6 @@ impl CommitResponse {
             success: false,
             error_message: Some(error_message),
         }
-    }
-}
-
-/// Successfully executed and committed txn
-pub struct CommittedTransaction {
-    pub sender: AccountAddress,
-    pub sequence_number: u64,
-}
-
-impl fmt::Display for CommittedTransaction {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}:{}", self.sender, self.sequence_number,)
     }
 }
 

--- a/mempool/src/tests/node.rs
+++ b/mempool/src/tests/node.rs
@@ -21,6 +21,7 @@ use futures::{
     channel::mpsc::{self, unbounded, UnboundedReceiver},
     FutureExt, StreamExt,
 };
+use mempool_notifications::MempoolNotifier;
 use netcore::transport::ConnectionOrigin;
 use network::{
     peer_manager::{
@@ -591,7 +592,7 @@ fn start_node_mempool(
     let (sender, subscriber) = unbounded();
     let (_ac_endpoint_sender, ac_endpoint_receiver) = mpsc::channel(1_024);
     let (_consensus_sender, consensus_events) = mpsc::channel(1_024);
-    let (_state_sync_sender, state_sync_events) = mpsc::channel(1_024);
+    let (_mempool_notifier, mempool_listener) = MempoolNotifier::new();
     let (_reconfig_events, reconfig_events_receiver) = diem_channel::new(QueueStyle::LIFO, 1, None);
 
     let runtime = Builder::new_multi_thread()
@@ -606,7 +607,7 @@ fn start_node_mempool(
         network_handles,
         ac_endpoint_receiver,
         consensus_events,
-        state_sync_events,
+        mempool_listener,
         reconfig_events_receiver,
         Arc::new(MockDbReader),
         Arc::new(RwLock::new(MockVMValidator)),

--- a/state-sync/inter-component/mempool-notifications/Cargo.toml
+++ b/state-sync/inter-component/mempool-notifications/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "mempool-notifications"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+repository = "https://github.com/diem/diem"
+description = "The notification interface between state sync and mempool"
+homepage = "https://diem.com"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+async-trait = "0.1.42"
+futures = "0.3.12"
+serde = { version = "1.0.124", default-features = false }
+thiserror = "1.0.24"
+tokio = { version = "1.8.1" }
+
+diem-types = { path = "../../../types" }
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
+
+[dev-dependencies]
+diem-crypto = { path = "../../../crypto/crypto" }

--- a/state-sync/inter-component/mempool-notifications/src/lib.rs
+++ b/state-sync/inter-component/mempool-notifications/src/lib.rs
@@ -1,0 +1,397 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+use std::{fmt, time::Duration};
+
+use async_trait::async_trait;
+use diem_types::{account_address::AccountAddress, transaction::Transaction};
+use futures::channel::{mpsc, oneshot};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio::time::timeout;
+
+const MEMPOOL_NOTIFICATION_CHANNEL_SIZE: usize = 1;
+
+#[derive(Clone, Debug, Deserialize, Error, PartialEq, Serialize)]
+pub enum Error {
+    #[error("Commit notification failed: {0}")]
+    CommitNotificationError(String),
+    #[error("Hit the timeout waiting for mempool to respond to the notification!")]
+    TimeoutWaitingForMempool,
+    #[error("Unexpected error encountered: {0}")]
+    UnexpectedErrorEncountered(String),
+}
+
+/// The interface between state sync and mempool, allowing state sync to notify
+/// mempool of events (e.g., newly committed transactions).
+#[async_trait]
+pub trait MempoolNotificationSender: Send {
+    /// Notify mempool of the newly committed transactions at the specified block timestamp.
+    async fn notify_new_commit(
+        &mut self,
+        committed_transactions: Vec<Transaction>,
+        block_timestamp_usecs: u64,
+        notification_timeout_ms: u64,
+    ) -> Result<(), Error>;
+}
+
+/// The state sync component responsible for notifying mempool.
+///
+/// Note: When a MempoolNotifier instance is created, mempool must take and
+/// listen to the receiver in the corresponding MempoolNotificationListener.
+#[derive(Debug)]
+pub struct MempoolNotifier {
+    notification_sender: mpsc::Sender<MempoolCommitNotification>,
+}
+
+impl MempoolNotifier {
+    /// Returns a new MempoolNotifier and MempoolNotificationListener (to be
+    /// used in conjuction with one another).
+    pub fn new() -> (Self, MempoolNotificationListener) {
+        let (notification_sender, notification_receiver) =
+            mpsc::channel(MEMPOOL_NOTIFICATION_CHANNEL_SIZE);
+
+        let mempool_notifier = MempoolNotifier {
+            notification_sender,
+        };
+        let mempool_listener = MempoolNotificationListener::new(notification_receiver);
+        (mempool_notifier, mempool_listener)
+    }
+}
+
+#[async_trait]
+impl MempoolNotificationSender for MempoolNotifier {
+    async fn notify_new_commit(
+        &mut self,
+        transactions: Vec<Transaction>,
+        block_timestamp_usecs: u64,
+        notification_timeout_ms: u64,
+    ) -> Result<(), Error> {
+        // Get only user transactions from committed transactions
+        let user_transactions: Vec<CommittedTransaction> = transactions
+            .iter()
+            .filter_map(|transaction| match transaction {
+                Transaction::UserTransaction(signed_txn) => Some(CommittedTransaction {
+                    sender: signed_txn.sender(),
+                    sequence_number: signed_txn.sequence_number(),
+                }),
+                _ => None,
+            })
+            .collect();
+
+        // Only send a notification if user transactions have been committed
+        if user_transactions.is_empty() {
+            return Ok(());
+        }
+
+        // Construct a oneshot channel to receive a mempool response
+        let (callback, callback_receiver) = oneshot::channel();
+        let commit_notification = MempoolCommitNotification {
+            transactions: user_transactions,
+            block_timestamp_usecs,
+            callback,
+        };
+
+        // Send the notification to mempool
+        if let Err(error) = self.notification_sender.try_send(commit_notification) {
+            return Err(Error::CommitNotificationError(format!(
+                "Failed to notify mempool of committed transactions! Error: {:?}",
+                error
+            )));
+        }
+
+        // Handle any responses or a timeout
+        if let Ok(response) = timeout(
+            Duration::from_millis(notification_timeout_ms),
+            callback_receiver,
+        )
+        .await
+        {
+            match response {
+                Ok(Ok(MempoolNotificationResponse::Success)) => Ok(()),
+                Ok(Err(error)) => Err(Error::UnexpectedErrorEncountered(format!(
+                    "Unexpected response from mempool! Error: {:?}",
+                    error
+                ))),
+                Err(error) => Err(Error::UnexpectedErrorEncountered(format!("{:?}", error))),
+            }
+        } else {
+            Err(Error::TimeoutWaitingForMempool)
+        }
+    }
+}
+
+/// A notification for newly committed transactions sent by state sync to mempool.
+#[derive(Debug)]
+pub struct MempoolCommitNotification {
+    pub transactions: Vec<CommittedTransaction>,
+    pub block_timestamp_usecs: u64, // The timestamp of the committed block.
+    pub(crate) callback: oneshot::Sender<Result<MempoolNotificationResponse, Error>>,
+}
+
+impl fmt::Display for MempoolCommitNotification {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "MempoolCommitNotification [block_timestamp_usecs: {}, txns: {:?}]",
+            self.block_timestamp_usecs, self.transactions
+        )
+    }
+}
+
+/// A successfully executed and committed user transaction.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CommittedTransaction {
+    pub sender: AccountAddress,
+    pub sequence_number: u64,
+}
+
+impl fmt::Display for CommittedTransaction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.sender, self.sequence_number,)
+    }
+}
+
+/// The mempool component responsible for responding to state sync notifications.
+#[derive(Debug)]
+pub struct MempoolNotificationListener {
+    pub notification_receiver: mpsc::Receiver<MempoolCommitNotification>,
+}
+
+impl MempoolNotificationListener {
+    pub fn new(notification_receiver: mpsc::Receiver<MempoolCommitNotification>) -> Self {
+        MempoolNotificationListener {
+            notification_receiver,
+        }
+    }
+
+    /// Respond (succesfully) to the commit notification previously sent by state sync.
+    pub async fn ack_commit_notification(
+        &mut self,
+        mempool_commit_notification: MempoolCommitNotification,
+    ) -> Result<(), Error> {
+        mempool_commit_notification
+            .callback
+            .send(Ok(MempoolNotificationResponse::Success))
+            .map_err(|error| Error::UnexpectedErrorEncountered(format!("{:?}", error)))
+    }
+}
+
+/// A response from mempool for a notification.
+///
+/// Note: failure responses are not currently used.
+#[derive(Debug)]
+enum MempoolNotificationResponse {
+    Success,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{CommittedTransaction, Error, MempoolNotificationSender, MempoolNotifier};
+    use diem_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, SigningKey, Uniform};
+    use diem_types::{
+        account_address::AccountAddress,
+        block_metadata::BlockMetadata,
+        chain_id::ChainId,
+        transaction::{
+            ChangeSet, RawTransaction, Script, SignedTransaction, Transaction, TransactionPayload,
+            WriteSetPayload,
+        },
+        write_set::WriteSetMut,
+    };
+    use futures::executor::block_on;
+    use tokio::runtime::{Builder, Runtime};
+
+    #[test]
+    fn test_mempool_not_listening() {
+        // Create runtime and mempool notifier
+        let runtime = create_runtime();
+        let _enter = runtime.enter();
+        let (mut mempool_notifier, mut mempool_listener) = MempoolNotifier::new();
+
+        // Send a notification and expect a timeout (no listener)
+        let notify_result =
+            block_on(mempool_notifier.notify_new_commit(vec![create_user_transaction()], 0, 1000));
+        assert!(matches!(
+            notify_result,
+            Err(Error::TimeoutWaitingForMempool)
+        ));
+
+        // Drop the receiver and try again
+        mempool_listener.notification_receiver.close();
+        let notify_result =
+            block_on(mempool_notifier.notify_new_commit(vec![create_user_transaction()], 0, 1000));
+        assert!(matches!(
+            notify_result,
+            Err(Error::CommitNotificationError(_))
+        ));
+    }
+
+    #[test]
+    fn test_zero_timeout() {
+        // Create runtime and mempool notifier
+        let runtime = create_runtime();
+        let _enter = runtime.enter();
+        let (mut mempool_notifier, mut _mempool_listener) = MempoolNotifier::new();
+
+        // Send a notification and expect a timeout (zero timeout)
+        let notify_result =
+            block_on(mempool_notifier.notify_new_commit(vec![create_user_transaction()], 0, 0));
+        assert!(matches!(
+            notify_result,
+            Err(Error::TimeoutWaitingForMempool)
+        ));
+    }
+
+    #[test]
+    fn test_no_transactions() {
+        // Create runtime and mempool notifier
+        let runtime = create_runtime();
+        let _enter = runtime.enter();
+        let (mut mempool_notifier, mut _mempool_listener) = MempoolNotifier::new();
+
+        // Send a notification and verify no timeout because no notification was sent!
+        let notify_result = block_on(mempool_notifier.notify_new_commit(vec![], 0, 1000));
+        assert!(notify_result.is_ok());
+    }
+
+    #[test]
+    fn test_transaction_filtering() {
+        // Create runtime and mempool notifier
+        let runtime = create_runtime();
+        let _enter = runtime.enter();
+        let (mut mempool_notifier, mut _mempool_listener) = MempoolNotifier::new();
+
+        // Create several transactions that should be filtered out
+        let mut transactions = vec![];
+        for _ in 0..5 {
+            transactions.push(create_block_metadata_transaction())
+        }
+        for _ in 0..5 {
+            transactions.push(create_genesis_transaction())
+        }
+
+        // Send a notification and verify no timeout because no notification was sent!
+        let notify_result =
+            block_on(mempool_notifier.notify_new_commit(transactions.clone(), 0, 1000));
+        assert!(notify_result.is_ok());
+
+        // Send another notification with a single user transaction now included.
+        transactions.push(create_user_transaction());
+        let notify_result = block_on(mempool_notifier.notify_new_commit(transactions, 0, 1000));
+        assert!(matches!(
+            notify_result,
+            Err(Error::TimeoutWaitingForMempool)
+        ));
+    }
+
+    #[test]
+    fn test_commit_notification_arrives() {
+        // Create runtime and mempool notifier
+        let runtime = create_runtime();
+        let _enter = runtime.enter();
+        let (mut mempool_notifier, mut mempool_listener) = MempoolNotifier::new();
+
+        // Send a notification
+        let user_transaction = create_user_transaction();
+        let transactions = vec![user_transaction.clone()];
+        let block_timestamp_usecs = 101;
+        let _ =
+            block_on(mempool_notifier.notify_new_commit(transactions, block_timestamp_usecs, 1000));
+
+        // Verify the notification arrives at the receiver
+        match mempool_listener.notification_receiver.try_next() {
+            Ok(Some(mempool_commit_notification)) => match user_transaction {
+                Transaction::UserTransaction(signed_transaction) => {
+                    assert_eq!(
+                        mempool_commit_notification.transactions,
+                        vec![CommittedTransaction {
+                            sender: signed_transaction.sender(),
+                            sequence_number: signed_transaction.sequence_number(),
+                        }]
+                    );
+                    assert_eq!(
+                        mempool_commit_notification.block_timestamp_usecs,
+                        block_timestamp_usecs
+                    );
+                }
+                result => panic!("Expected user transaction but got: {:?}", result),
+            },
+            result => panic!("Expected mempool commit notification but got: {:?}", result),
+        };
+    }
+
+    #[test]
+    fn test_mempool_success_response() {
+        // Create runtime and mempool notifier
+        let runtime = create_runtime();
+        let _enter = runtime.enter();
+        let (mut mempool_notifier, mut mempool_listener) = MempoolNotifier::new();
+
+        // Spawn a new thread to handle any messages on the receiver
+        let _handler = std::thread::spawn(move || loop {
+            if let Ok(Some(mempool_commit_notification)) =
+                mempool_listener.notification_receiver.try_next()
+            {
+                let _result =
+                    block_on(mempool_listener.ack_commit_notification(mempool_commit_notification));
+            }
+        });
+
+        // Send a notification and verify a successful response
+        let notify_result = block_on(mempool_notifier.notify_new_commit(
+            vec![create_user_transaction()],
+            101,
+            1000,
+        ));
+        assert!(notify_result.is_ok());
+    }
+
+    fn create_user_transaction() -> Transaction {
+        let private_key = Ed25519PrivateKey::generate_for_testing();
+        let public_key = private_key.public_key();
+
+        let transaction_payload = TransactionPayload::Script(Script::new(vec![], vec![], vec![]));
+        let raw_transaction = RawTransaction::new(
+            AccountAddress::random(),
+            0,
+            transaction_payload,
+            0,
+            0,
+            "".into(),
+            0,
+            ChainId::new(10),
+        );
+        let signed_transaction = SignedTransaction::new(
+            raw_transaction.clone(),
+            public_key,
+            private_key.sign(&raw_transaction),
+        );
+
+        Transaction::UserTransaction(signed_transaction)
+    }
+
+    fn create_block_metadata_transaction() -> Transaction {
+        Transaction::BlockMetadata(BlockMetadata::new(
+            HashValue::new([0; HashValue::LENGTH]),
+            1,
+            300000001,
+            vec![],
+            AccountAddress::random(),
+        ))
+    }
+
+    fn create_genesis_transaction() -> Transaction {
+        Transaction::GenesisTransaction(WriteSetPayload::Direct(ChangeSet::new(
+            WriteSetMut::new(vec![])
+                .freeze()
+                .expect("freeze cannot fail"),
+            vec![],
+        )))
+    }
+
+    fn create_runtime() -> Runtime {
+        Builder::new_multi_thread().enable_all().build().unwrap()
+    }
+}

--- a/state-sync/state-sync-v1/Cargo.toml
+++ b/state-sync/state-sync-v1/Cargo.toml
@@ -39,6 +39,7 @@ executor = { path = "../../execution/executor" }
 executor-test-helpers = { path = "../../execution/executor-test-helpers", optional = true }
 executor-types = { path = "../../execution/executor-types" }
 memsocket = { path = "../../network/memsocket", optional = true }
+mempool-notifications = { path = "../inter-component/mempool-notifications" }
 netcore = { path = "../../network/netcore" }
 network = { path = "../../network" }
 storage-interface = { path = "../../storage/storage-interface" }

--- a/state-sync/state-sync-v1/src/counters.rs
+++ b/state-sync/state-sync-v1/src/counters.rs
@@ -84,8 +84,7 @@ pub const SUCCESS_LABEL: &str = "success";
 pub const FAIL_LABEL: &str = "fail";
 
 // commit flow fail component label
-pub const TO_MEMPOOL_LABEL: &str = "to_mempool";
-pub const FROM_MEMPOOL_LABEL: &str = "from_mempool";
+pub const MEMPOOL_LABEL: &str = "mempool";
 pub const CONSENSUS_LABEL: &str = "consensus";
 pub const STATE_SYNC_LABEL: &str = "state_sync";
 

--- a/state-sync/state-sync-v1/src/error.rs
+++ b/state-sync/state-sync-v1/src/error.rs
@@ -3,6 +3,7 @@
 
 use diem_types::transaction::Version;
 use futures::channel::{mpsc::SendError, oneshot::Canceled};
+use mempool_notifications;
 use network::error::NetworkError;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -72,5 +73,11 @@ impl From<SendError> for Error {
 impl From<Canceled> for Error {
     fn from(canceled: Canceled) -> Self {
         Error::SenderDroppedError(canceled.to_string())
+    }
+}
+
+impl From<mempool_notifications::Error> for Error {
+    fn from(error: mempool_notifications::Error) -> Self {
+        Error::UnexpectedError(error.to_string())
     }
 }

--- a/state-sync/state-sync-v1/src/fuzzing.rs
+++ b/state-sync/state-sync-v1/src/fuzzing.rs
@@ -15,6 +15,7 @@ use diem_types::{
     ledger_info::LedgerInfoWithSignatures, transaction::TransactionListWithProof, PeerId,
 };
 use futures::executor::block_on;
+use mempool_notifications::MempoolNotifier;
 use once_cell::sync::Lazy;
 use proptest::{
     arbitrary::{any, Arbitrary},
@@ -23,7 +24,7 @@ use proptest::{
     strategy::Strategy,
 };
 
-static STATE_SYNC_COORDINATOR: Lazy<Mutex<StateSyncCoordinator<ExecutorProxy>>> =
+static STATE_SYNC_COORDINATOR: Lazy<Mutex<StateSyncCoordinator<ExecutorProxy, MempoolNotifier>>> =
     Lazy::new(|| Mutex::new(test_utils::create_validator_coordinator()));
 
 proptest! {


### PR DESCRIPTION
## Motivation

Today, state sync is responsible for notifying mempool whenever new transactions are committed. However, the interface between the two components is very messy, e.g., the code leaks implementation details between the components and forces a very tight coupling. This makes it difficult to update (or swap out) component implementations.

To address this, the PR introduces an explicit interface and set of components between state sync and mempool:
- `MempoolNotificationSender` is the interface allowing state sync to send notifications to mempool (`MempoolNotifier` is the component that implements this interface).
- ` MempoolNotificationListener` is the component that mempool uses to listen for notifications and respond accordingly.

This structure avoids leaking implementation details (e.g., the fact that we use a one-shot callback to respond to notifications). In addition, the PR adds explicit (previously missing) tests for the implementation.

Note: at a fundamental level, this new interface implementation still uses channels, but wraps the interface-specific details of the communication (e.g., message formats, channel timeouts, etc.) to offer better implementation encapsulation.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

New and missing unit tests have been added.

## Related PRs

None, but this PR relates to: https://github.com/diem/diem/issues/8906
