### PR TITLE
[backup] replay-verify CLI tool

### DIFF
--- a/storage/backup/backup-cli/src/bin/replay-verify.rs
+++ b/storage/backup/backup-cli/src/bin/replay-verify.rs
@@ -1,0 +1,74 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use backup_cli::{
+    coordinators::replay_verify::ReplayVerifyCoordinator,
+    metadata::cache::MetadataCacheOpt,
+    storage::StorageOpt,
+    utils::{ConcurrentDownloadsOpt, RocksdbOpt, TrustedWaypointOpt},
+};
+use diem_logger::{prelude::*, Level, Logger};
+use diem_types::transaction::Version;
+use diemdb::{DiemDB, GetRestoreHandler};
+use std::{path::PathBuf, sync::Arc};
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct Opt {
+    #[structopt(flatten)]
+    metadata_cache_opt: MetadataCacheOpt,
+    #[structopt(flatten)]
+    trusted_waypoints_opt: TrustedWaypointOpt,
+    #[structopt(subcommand)]
+    storage: StorageOpt,
+    #[structopt(flatten)]
+    concurrent_downloads: ConcurrentDownloadsOpt,
+    #[structopt(long = "target-db-dir", parse(from_os_str))]
+    pub db_dir: PathBuf,
+    #[structopt(flatten)]
+    pub rocksdb_opt: RocksdbOpt,
+    #[structopt(
+        long,
+        help = "[Defaults to 0] The first transaction version required to be replayed and verified."
+    )]
+    start_version: Option<Version>,
+    #[structopt(
+        long,
+        help = "[Defaults to the latest version available] The last transaction version required \
+                to be replayed and verified (if present in the backup)."
+    )]
+    end_version: Option<Version>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    main_impl().await.map_err(|e| {
+        error!("main_impl() failed: {}", e);
+        e
+    })
+}
+
+async fn main_impl() -> Result<()> {
+    Logger::new().level(Level::Info).read_env().init();
+
+    let opt = Opt::from_args();
+    let restore_handler = Arc::new(DiemDB::open(
+        opt.db_dir,
+        false, /* read_only */
+        None,  /* pruner */
+        opt.rocksdb_opt.into(),
+    )?)
+    .get_restore_handler();
+    ReplayVerifyCoordinator::new(
+        opt.storage.init_storage().await?,
+        opt.metadata_cache_opt,
+        opt.trusted_waypoints_opt,
+        opt.concurrent_downloads.get(),
+        restore_handler,
+        opt.start_version.unwrap_or(0),
+        opt.end_version.unwrap_or(Version::MAX),
+    )?
+    .run()
+    .await
+}

--- a/storage/backup/backup-cli/src/coordinators/mod.rs
+++ b/storage/backup/backup-cli/src/coordinators/mod.rs
@@ -2,5 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod backup;
+pub mod replay_verify;
 pub mod restore;
 pub mod verify;

--- a/storage/backup/backup-cli/src/coordinators/restore.rs
+++ b/storage/backup/backup-cli/src/coordinators/restore.rs
@@ -81,7 +81,7 @@ impl RestoreCoordinator {
         )
         .await?;
 
-        let transactions = metadata_view.select_transaction_backups(self.target_version())?;
+        let transactions = metadata_view.select_transaction_backups(0, self.target_version())?;
         let actual_target_version = self.get_actual_target_version(&transactions)?;
         let epoch_endings = metadata_view.select_epoch_ending_backups(actual_target_version)?;
         let state_snapshot = if self.replay_all {

--- a/storage/backup/backup-cli/src/metadata/cache.rs
+++ b/storage/backup/backup-cli/src/metadata/cache.rs
@@ -38,7 +38,7 @@ pub struct MetadataCacheOpt {
     #[structopt(
         long = "metadata-cache-dir",
         parse(from_os_str),
-        help = "Metadata cache dir."
+        help = "[Defaults to temporary dir] Metadata cache dir."
     )]
     dir: Option<PathBuf>,
 }

--- a/storage/backup/backup-cli/src/metadata/view.rs
+++ b/storage/backup/backup-cli/src/metadata/view.rs
@@ -49,6 +49,7 @@ impl MetadataView {
 
     pub fn select_transaction_backups(
         &self,
+        start_version: Version,
         target_version: Version,
     ) -> Result<Vec<TransactionBackupMeta>> {
         // This can be more flexible, but for now we assume and check backups are continuous in
@@ -66,7 +67,9 @@ impl MetadataView {
                 backup.first_version,
             );
 
-            res.push(backup.clone());
+            if backup.last_version >= start_version {
+                res.push(backup.clone());
+            }
 
             next_ver = backup.last_version + 1;
         }


### PR DESCRIPTION
## Motivation
For use by VM compatilibity tests. Restores proper state snapshot, on top of which replays desired range of transactions, to comfirm compatibilities with the latest software.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
y

## Test Plan

```
➜  diem git:(um) ✗ cargo run -p backup-cli --bin replay-verify -- --target-db-dir ~/work/temp/t3 --start-version 2000001 --end-version 2020006 --concurrent-downloads 4 command-adapter --config ~/work/temp/premainnet-backup-e21.conf.toml
    Finished dev [unoptimized + debuginfo] target(s) in 0.60s
     Running `target/debug/replay-verify --target-db-dir /Users/aldenhu/work/temp/t3 --start-version 2000001 --end-version 2020006 --concurrent-downloads 4 command-adapter --config /Users/aldenhu/work/temp/premainnet-backup-e21.conf.toml`
2021-08-24T19:49:23.305847Z [main] INFO storage/schemadb/src/lib.rs:308 Opened RocksDB. {"rocksdb_name":"diemdb"}
2021-08-24T19:49:23.310377Z [main] INFO storage/diemdb/src/lib.rs:290 Opened DiemDB. {"path":"/Users/aldenhu/work/temp/t3/diemdb","time_ms":"80"}
2021-08-24T19:49:23.311322Z [main] INFO storage/backup/backup-cli/src/coordinators/replay_verify.rs:52 ReplayVerify coordinator started.
2021-08-24T19:49:23.435549Z [main] INFO storage/backup/backup-cli/src/metadata/cache.rs:95 Metadata files listed.
2021-08-24T19:49:29.157719Z [main] INFO storage/backup/backup-cli/src/metadata/cache.rs:164 Metadata cache loaded in 5.85 seconds.
2021-08-24T19:49:29.160097Z [main] INFO storage/backup/backup-cli/src/backup_types/state_snapshot/restore.rs:72 state snapshot restore started. Manifest: state_ver_2000000.0a76/state.manifest
2021-08-24T19:49:31.254405Z [main] INFO storage/backup/backup-cli/src/backup_types/state_snapshot/restore.rs:76 state snapshot restore succeeded.
2021-08-24T19:49:48.268005Z [main] INFO storage/backup/backup-cli/src/backup_types/transaction/restore.rs:316 transaction restore started. Manifest: transaction_2000001-.091b/transaction.manifest
2021-08-24T19:49:48.352732Z [main] INFO storage/backup/backup-cli/src/backup_types/transaction/restore.rs:229 Replaying transactions 2000001 to 2020006.
2021-08-24T19:49:48.393822Z [main] INFO language/diem-vm/src/diem_transaction_executor.rs:682 Executing block, transaction count: 10000 {"first_version":2000001,"name":"execution","txn_id":0}
2021-08-24T19:50:46.475200Z [main] WARN storage/diemdb/src/system_store/mod.rs:44 Base version ledger counters not found. Assuming zeros. {"base_version":2000000}
2021-08-24T19:50:47.886391Z [main] INFO language/diem-vm/src/diem_transaction_executor.rs:682 Executing block, transaction count: 10000 {"first_version":2010001,"name":"execution","txn_id":0}
2021-08-24T19:51:44.973694Z [main] INFO language/diem-vm/src/diem_transaction_executor.rs:682 Executing block, transaction count: 6 {"first_version":2020001,"name":"execution","txn_id":0}
2021-08-24T19:51:45.297500Z [main] WARN storage/backup/backup-cli/src/backup_types/transaction/restore.rs:360 Transactions newer than target version 2020006 ignored.
2021-08-24T19:51:45.559419Z [main] INFO storage/backup/backup-cli/src/backup_types/transaction/restore.rs:324 transaction restore succeeded.
2021-08-24T19:51:45.585836Z [main] INFO storage/backup/backup-cli/src/coordinators/replay_verify.rs:62 ReplayVerify coordinator exiting with success.
