### PR TITLE
[move-package] Add support for documentation and ABI generation and building of Move Model. 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4999,6 +4999,7 @@ dependencies = [
  "move-command-line-common",
  "move-core-types",
  "move-lang",
+ "move-model",
  "move-symbol-pool",
  "petgraph",
  "serde",

--- a/language/diem-framework/src/release.rs
+++ b/language/diem-framework/src/release.rs
@@ -216,6 +216,7 @@ fn generate_script_abis(
                 .as_ref()
                 .to_string_lossy()
                 .to_string(),
+            ..Default::default()
         },
         ..Default::default()
     };

--- a/language/tools/move-package/Cargo.toml
+++ b/language/tools/move-package/Cargo.toml
@@ -31,6 +31,7 @@ errmapgen = { path = "../../move-prover/errmapgen" }
 move-core-types = { path = "../../move-core/types" }
 move-symbol-pool = { path = "../../move-symbol-pool" }
 move-command-line-common = { path = "../../move-command-line-common" }
+move-model = { path = "../../move-model" }
 
 [dev-dependencies]
 datatest-stable = "0.1.1"

--- a/language/tools/move-package/src/compilation/build_plan.rs
+++ b/language/tools/move-package/src/compilation/build_plan.rs
@@ -14,7 +14,6 @@ pub struct BuildPlan {
     root: PackageName,
     sorted_deps: Vec<PackageName>,
     resolution_graph: ResolvedGraph,
-    compiled_packages: BTreeMap<PackageName, CompiledPackage>,
 }
 
 impl BuildPlan {
@@ -33,7 +32,6 @@ impl BuildPlan {
             root: resolution_graph.root_package.package.name,
             sorted_deps,
             resolution_graph,
-            compiled_packages: BTreeMap::new(),
         })
     }
 

--- a/language/tools/move-package/src/compilation/mod.rs
+++ b/language/tools/move-package/src/compilation/mod.rs
@@ -3,4 +3,5 @@
 
 pub mod build_plan;
 pub mod compiled_package;
+pub mod model_builder;
 pub mod package_layout;

--- a/language/tools/move-package/src/compilation/model_builder.rs
+++ b/language/tools/move-package/src/compilation/model_builder.rs
@@ -1,0 +1,71 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::resolution::resolution_graph::ResolvedGraph;
+use anyhow::Result;
+use move_lang::shared::AddressBytes;
+use move_model::{model::GlobalEnv, options::ModelBuilderOptions, run_model_builder_with_options};
+
+#[derive(Debug, Clone)]
+pub struct ModelBuilder {
+    resolution_graph: ResolvedGraph,
+}
+
+impl ModelBuilder {
+    pub fn create(resolution_graph: ResolvedGraph) -> Self {
+        Self { resolution_graph }
+    }
+
+    // NOTE: If there are now renamings, then the root package has the global resolution of all named
+    // addresses in the package graph in scope. So we can simply grab all of the source files
+    // across all packages and build the Move model from that.
+    // TODO: In the future we will need a better way to do this to support renaming in packages
+    // where we want to support building a Move model.
+    pub fn build_model(&self) -> Result<GlobalEnv> {
+        // Make sure no renamings have been performed
+        for (pkg_name, pkg) in self.resolution_graph.package_table.iter() {
+            if !pkg.renaming.is_empty() {
+                anyhow::bail!(
+                    "Found address renaming in package '{}' when \
+                    building Move model -- this is currently not supported",
+                    pkg_name
+                )
+            }
+        }
+
+        // Targets are all files in the root package
+        let root_name = &self.resolution_graph.root_package.package.name;
+        let root_package = self.resolution_graph.get_package(root_name).clone();
+        let targets: Vec<_> = root_package
+            .get_sources(&self.resolution_graph.build_options)?
+            .into_iter()
+            .map(|symbol| symbol.to_string())
+            .collect();
+        // Dependencies are all files in non-root package
+        let deps = self
+            .resolution_graph
+            .package_table
+            .iter()
+            .flat_map(|(nm, pkg)| {
+                if nm == root_name {
+                    vec![]
+                } else {
+                    pkg.get_sources(&self.resolution_graph.build_options)
+                        .unwrap()
+                }
+            })
+            .map(|symbol| symbol.to_string())
+            .collect::<Vec<String>>();
+
+        run_model_builder_with_options(
+            &targets,
+            &deps,
+            ModelBuilderOptions::default(),
+            root_package
+                .resolution_table
+                .into_iter()
+                .map(|(ident, addr)| (ident.to_string(), AddressBytes::new(addr.to_u8())))
+                .collect(),
+        )
+    }
+}

--- a/language/tools/move-package/tests/test_sources/compilation/basic_no_deps/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/basic_no_deps/Move.exp
@@ -5,4 +5,10 @@ CompiledPackageInfo {
     source_digest: Some(
         "ELIDED_FOR_TEST",
     ),
+    build_flags: BuildConfig {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        generate_abis: false,
+    },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_assigned/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_assigned/Move.exp
@@ -14,4 +14,10 @@ CompiledPackageInfo {
     source_digest: Some(
         "ELIDED_FOR_TEST",
     ),
+    build_flags: BuildConfig {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        generate_abis: false,
+    },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
@@ -14,4 +14,10 @@ CompiledPackageInfo {
     source_digest: Some(
         "ELIDED_FOR_TEST",
     ),
+    build_flags: BuildConfig {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        generate_abis: false,
+    },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/diamond_problem_backflow_resolution/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/diamond_problem_backflow_resolution/Move.exp
@@ -33,4 +33,10 @@ CompiledPackageInfo {
     source_digest: Some(
         "ELIDED_FOR_TEST",
     ),
+    build_flags: BuildConfig {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        generate_abis: false,
+    },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/diamond_problem_no_conflict/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/diamond_problem_no_conflict/Move.exp
@@ -33,4 +33,10 @@ CompiledPackageInfo {
     source_digest: Some(
         "ELIDED_FOR_TEST",
     ),
+    build_flags: BuildConfig {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        generate_abis: false,
+    },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/multiple_deps_rename/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/multiple_deps_rename/Move.exp
@@ -28,4 +28,10 @@ CompiledPackageInfo {
     source_digest: Some(
         "ELIDED_FOR_TEST",
     ),
+    build_flags: BuildConfig {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        generate_abis: false,
+    },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/multiple_deps_rename_one/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/multiple_deps_rename_one/Move.exp
@@ -21,4 +21,10 @@ CompiledPackageInfo {
     source_digest: Some(
         "ELIDED_FOR_TEST",
     ),
+    build_flags: BuildConfig {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        generate_abis: false,
+    },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/one_dep/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/one_dep/Move.exp
@@ -20,4 +20,10 @@ CompiledPackageInfo {
     source_digest: Some(
         "ELIDED_FOR_TEST",
     ),
+    build_flags: BuildConfig {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        generate_abis: false,
+    },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/one_dep_assigned_address/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/one_dep_assigned_address/Move.exp
@@ -20,4 +20,10 @@ CompiledPackageInfo {
     source_digest: Some(
         "ELIDED_FOR_TEST",
     ),
+    build_flags: BuildConfig {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        generate_abis: false,
+    },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/one_dep_renamed/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/one_dep_renamed/Move.exp
@@ -20,4 +20,10 @@ CompiledPackageInfo {
     source_digest: Some(
         "ELIDED_FOR_TEST",
     ),
+    build_flags: BuildConfig {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        generate_abis: false,
+    },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/one_dep_with_scripts/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/one_dep_with_scripts/Move.exp
@@ -26,4 +26,10 @@ CompiledPackageInfo {
     source_digest: Some(
         "ELIDED_FOR_TEST",
     ),
+    build_flags: BuildConfig {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        generate_abis: false,
+    },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/one_dep_with_scripts/sources/OneDep.move
+++ b/language/tools/move-package/tests/test_sources/compilation/one_dep_with_scripts/sources/OneDep.move
@@ -3,4 +3,5 @@ module A::OneDep {
     public fun do_b() {
         B::foo()
     }
+    public(script) fun aa() {}
 }

--- a/language/tools/move-package/tests/test_sources/compilation/one_dep_with_scripts/sources/b_script.move
+++ b/language/tools/move-package/tests/test_sources/compilation/one_dep_with_scripts/sources/b_script.move
@@ -1,0 +1,3 @@
+script {
+    fun b_script() { }
+}

--- a/language/tools/move-package/tests/test_sources/model/basic_no_deps/Move.exp
+++ b/language/tools/move-package/tests/test_sources/model/basic_no_deps/Move.exp
@@ -1,0 +1,1 @@
+Built model

--- a/language/tools/move-package/tests/test_sources/model/basic_no_deps/Move.toml
+++ b/language/tools/move-package/tests/test_sources/model/basic_no_deps/Move.toml
@@ -1,0 +1,3 @@
+[package]
+name = "test"
+version = "0.0.0"

--- a/language/tools/move-package/tests/test_sources/model/basic_no_deps/sources/A.move
+++ b/language/tools/move-package/tests/test_sources/model/basic_no_deps/sources/A.move
@@ -1,0 +1,3 @@
+module 0x1::M {
+    public fun foo() { }
+}

--- a/language/tools/move-package/tests/test_sources/model/basic_no_deps/sources/a_script.move
+++ b/language/tools/move-package/tests/test_sources/model/basic_no_deps/sources/a_script.move
@@ -1,0 +1,3 @@
+script {
+    fun a_script() { }
+}

--- a/language/tools/move-package/tests/test_sources/model/multiple_deps_no_rename/Move.exp
+++ b/language/tools/move-package/tests/test_sources/model/multiple_deps_no_rename/Move.exp
@@ -1,0 +1,1 @@
+Built model

--- a/language/tools/move-package/tests/test_sources/model/multiple_deps_no_rename/Move.toml
+++ b/language/tools/move-package/tests/test_sources/model/multiple_deps_no_rename/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "test"
+version = "0.0.0"
+
+[addresses]
+A = "0x3"
+
+[dependencies]
+C = { local = "./deps_only/C" }
+D = { local = "./deps_only/D" }

--- a/language/tools/move-package/tests/test_sources/model/multiple_deps_no_rename/deps_only/C/Move.toml
+++ b/language/tools/move-package/tests/test_sources/model/multiple_deps_no_rename/deps_only/C/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "C"
+version = "0.0.0"
+
+[addresses]
+CA = "0x1"

--- a/language/tools/move-package/tests/test_sources/model/multiple_deps_no_rename/deps_only/C/sources/A.move
+++ b/language/tools/move-package/tests/test_sources/model/multiple_deps_no_rename/deps_only/C/sources/A.move
@@ -1,0 +1,3 @@
+module CA::A {
+    public fun foo() { }
+}

--- a/language/tools/move-package/tests/test_sources/model/multiple_deps_no_rename/deps_only/D/Move.toml
+++ b/language/tools/move-package/tests/test_sources/model/multiple_deps_no_rename/deps_only/D/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "D"
+version = "0.0.0"
+
+[addresses]
+DA = "0x2"

--- a/language/tools/move-package/tests/test_sources/model/multiple_deps_no_rename/deps_only/D/sources/A.move
+++ b/language/tools/move-package/tests/test_sources/model/multiple_deps_no_rename/deps_only/D/sources/A.move
@@ -1,0 +1,3 @@
+module DA::A {
+    public fun foo() { }
+}

--- a/language/tools/move-package/tests/test_sources/model/multiple_deps_no_rename/sources/A.move
+++ b/language/tools/move-package/tests/test_sources/model/multiple_deps_no_rename/sources/A.move
@@ -1,0 +1,9 @@
+module A::A {
+    use DA::A as DAA;
+    use CA::A as CAA;
+
+    public fun foo() {
+        DAA::foo();
+        CAA::foo()
+    }
+}

--- a/language/tools/move-package/tests/test_sources/model/multiple_deps_rename/Move.exp
+++ b/language/tools/move-package/tests/test_sources/model/multiple_deps_rename/Move.exp
@@ -1,0 +1,1 @@
+Found address renaming in package 'test' when building Move model -- this is currently not supported

--- a/language/tools/move-package/tests/test_sources/model/multiple_deps_rename/Move.toml
+++ b/language/tools/move-package/tests/test_sources/model/multiple_deps_rename/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "test"
+version = "0.0.0"
+
+[addresses]
+A = "0x3"
+
+[dependencies]
+C = { local = "./deps_only/C", addr_subst = {"CA" = "A" } }
+D = { local = "./deps_only/D" , addr_subst = {"DA" = "A" } }

--- a/language/tools/move-package/tests/test_sources/model/multiple_deps_rename/deps_only/C/Move.toml
+++ b/language/tools/move-package/tests/test_sources/model/multiple_deps_rename/deps_only/C/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "C"
+version = "0.0.0"
+
+[addresses]
+A = "0x1"

--- a/language/tools/move-package/tests/test_sources/model/multiple_deps_rename/deps_only/C/sources/A.move
+++ b/language/tools/move-package/tests/test_sources/model/multiple_deps_rename/deps_only/C/sources/A.move
@@ -1,0 +1,3 @@
+module A::A {
+    public fun foo() { }
+}

--- a/language/tools/move-package/tests/test_sources/model/multiple_deps_rename/deps_only/D/Move.toml
+++ b/language/tools/move-package/tests/test_sources/model/multiple_deps_rename/deps_only/D/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "D"
+version = "0.0.0"
+
+[addresses]
+A = "0x2"

--- a/language/tools/move-package/tests/test_sources/model/multiple_deps_rename/deps_only/D/sources/A.move
+++ b/language/tools/move-package/tests/test_sources/model/multiple_deps_rename/deps_only/D/sources/A.move
@@ -1,0 +1,3 @@
+module A::A {
+    public fun foo() { }
+}

--- a/language/tools/move-package/tests/test_sources/model/multiple_deps_rename/sources/Root.move
+++ b/language/tools/move-package/tests/test_sources/model/multiple_deps_rename/sources/Root.move
@@ -1,0 +1,9 @@
+module A::A {
+    use DA::A as DAA;
+    use CA::A as CAA;
+
+    public fun foo() {
+        DAA::foo();
+        CAA::foo()
+    }
+}

--- a/language/tools/move-package/tests/test_sources/parsing/invalid_identifier_package_name/Move.exp
+++ b/language/tools/move-package/tests/test_sources/parsing/invalid_identifier_package_name/Move.exp
@@ -2,6 +2,8 @@ ResolutionGraph {
     build_options: BuildConfig {
         dev_mode: true,
         test_mode: false,
+        generate_docs: false,
+        generate_abis: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/parsing/minimal_manifest/Move.exp
+++ b/language/tools/move-package/tests/test_sources/parsing/minimal_manifest/Move.exp
@@ -2,6 +2,8 @@ ResolutionGraph {
     build_options: BuildConfig {
         dev_mode: true,
         test_mode: false,
+        generate_docs: false,
+        generate_abis: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/basic_no_deps/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/basic_no_deps/Move.exp
@@ -2,6 +2,8 @@ ResolutionGraph {
     build_options: BuildConfig {
         dev_mode: true,
         test_mode: false,
+        generate_docs: false,
+        generate_abis: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_assigned/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_assigned/Move.exp
@@ -2,6 +2,8 @@ ResolutionGraph {
     build_options: BuildConfig {
         dev_mode: true,
         test_mode: false,
+        generate_docs: false,
+        generate_abis: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
@@ -2,6 +2,8 @@ ResolutionGraph {
     build_options: BuildConfig {
         dev_mode: true,
         test_mode: false,
+        generate_docs: false,
+        generate_abis: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/diamond_problem_backflow_resolution/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/diamond_problem_backflow_resolution/Move.exp
@@ -2,6 +2,8 @@ ResolutionGraph {
     build_options: BuildConfig {
         dev_mode: true,
         test_mode: false,
+        generate_docs: false,
+        generate_abis: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/diamond_problem_no_conflict/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/diamond_problem_no_conflict/Move.exp
@@ -2,6 +2,8 @@ ResolutionGraph {
     build_options: BuildConfig {
         dev_mode: true,
         test_mode: false,
+        generate_docs: false,
+        generate_abis: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/multiple_deps_rename/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/multiple_deps_rename/Move.exp
@@ -2,6 +2,8 @@ ResolutionGraph {
     build_options: BuildConfig {
         dev_mode: true,
         test_mode: false,
+        generate_docs: false,
+        generate_abis: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep/Move.exp
@@ -2,6 +2,8 @@ ResolutionGraph {
     build_options: BuildConfig {
         dev_mode: true,
         test_mode: false,
+        generate_docs: false,
+        generate_abis: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep_assigned_address/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep_assigned_address/Move.exp
@@ -2,6 +2,8 @@ ResolutionGraph {
     build_options: BuildConfig {
         dev_mode: true,
         test_mode: false,
+        generate_docs: false,
+        generate_abis: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep_multiple_of_same_name/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep_multiple_of_same_name/Move.exp
@@ -2,6 +2,8 @@ ResolutionGraph {
     build_options: BuildConfig {
         dev_mode: true,
         test_mode: false,
+        generate_docs: false,
+        generate_abis: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep_reassigned_address/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep_reassigned_address/Move.exp
@@ -2,6 +2,8 @@ ResolutionGraph {
     build_options: BuildConfig {
         dev_mode: true,
         test_mode: false,
+        generate_docs: false,
+        generate_abis: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep_unification_across_local_renamings/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep_unification_across_local_renamings/Move.exp
@@ -2,6 +2,8 @@ ResolutionGraph {
     build_options: BuildConfig {
         dev_mode: true,
         test_mode: false,
+        generate_docs: false,
+        generate_abis: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/shuffle/genesis/src/release.rs
+++ b/shuffle/genesis/src/release.rs
@@ -31,6 +31,7 @@ pub fn generate_script_abis(output_path: &Path) {
             output_directory: output_path.to_string_lossy().to_string(),
             // we only have script funs and no scripts so this should be fine
             compiled_script_directory: "".to_string(),
+            ..Default::default()
         },
         ..Default::default()
     };


### PR DESCRIPTION
Builds on #8775 to add documentation and ABI generation to the package system. Additionally, in preparation for hooking up the Move Prover with packages, model building for a whole package is added. *Only look at the top commit*. 

It is important to note that because the Move Model requires source files, at this time we cannot support renaming of named addresses in packages where you need to build a Move Model for a package and all of its dependencies. In the future we will want to support this, however this will most likely require support from the source language or compiler (to either support renaming at expansion, or in generation of interface files). 