### PR TITLE
[move] Remove Move IR type inference

### DIFF
--- a/language/bytecode-verifier/transactional-tests/tests/dependencies/all_fields_accessible.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/dependencies/all_fields_accessible.mvir
@@ -14,8 +14,8 @@ module 0x42.M {
     public set_a_with_b(a: &mut Self.A, b: &Self.B) {
         let x_ref: &mut u64;
         let y_ref: &u64;
-        x_ref = &mut copy(a).x;
-        y_ref = &copy(b).y;
+        x_ref = &mut copy(a).A::x;
+        y_ref = &copy(b).B::y;
         *move(x_ref) = *move(y_ref);
         _ = move(a);
         _ = move(b);
@@ -25,8 +25,8 @@ module 0x42.M {
     public set_b_with_a(b: &mut Self.B, a: &Self.A) {
         let x_ref: &u64;
         let y_ref: &mut u64;
-        y_ref = &mut copy(b).y;
-        x_ref = &copy(a).x;
+        y_ref = &mut copy(b).B::y;
+        x_ref = &copy(a).A::x;
         *move(y_ref) = *move(x_ref);
         _ = move(a);
         _ = move(b);

--- a/language/bytecode-verifier/transactional-tests/tests/dependencies/internal_function_invalid_call.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/dependencies/internal_function_invalid_call.mvir
@@ -14,7 +14,7 @@ module 0x42.Test {
 
     public get_value(this: &Self.T): u64 {
         let x: &u64;
-        x = &copy(this).value;
+        x = &copy(this).T::value;
         _ = move(this);
         return *move(x);
     }
@@ -26,7 +26,7 @@ module 0x42.Test {
 
     internal_set_value(this: &mut Self.T, new_value: u64) {
         let x: &mut u64;
-        x = &mut copy(this).value;
+        x = &mut copy(this).T::value;
         *move(x) = move(new_value);
         _ = move(this);
         return;

--- a/language/bytecode-verifier/transactional-tests/tests/dependencies/non_internal_function_valid_call.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/dependencies/non_internal_function_valid_call.mvir
@@ -14,7 +14,7 @@ module 0x42.Test {
 
     public get_value(this: &Self.T): u64 {
         let x: &u64;
-        x = &copy(this).value;
+        x = &copy(this).T::value;
         _ = move(this);
         return *move(x);
     }
@@ -26,7 +26,7 @@ module 0x42.Test {
 
     internal_set_value(this: &mut Self.T, new_value: u64) {
         let x: &mut u64;
-        x = &mut copy(this).value;
+        x = &mut copy(this).T::value;
         *move(x) = move(new_value);
         _ = move(this);
         return;

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/assign_field_after_local.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/assign_field_after_local.mvir
@@ -10,7 +10,7 @@ module 0x42.Tester {
         let t_v: &mut u64;
         let new_t: Self.T;
 
-        t_v = &mut copy(t).v;
+        t_v = &mut copy(t).T::v;
         new_t = Self.new(1);
         // cannot mutate, still borrowed
         *move(t) = move(new_t);

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/assign_local_struct.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/assign_local_struct.mvir
@@ -11,7 +11,7 @@ module 0x42.Tester {
         let t_v: &mut u64;
         let new_t: Self.T;
         t2 = copy(t);
-        t_v = &mut copy(t2).v;
+        t_v = &mut copy(t2).T::v;
         *move(t_v) = 10000;
 
         new_t = Self.new(1);
@@ -22,7 +22,7 @@ module 0x42.Tester {
 
     public value(this: &mut Self.T): u64 {
         let ref_v: &u64;
-        ref_v = &move(this).v;
+        ref_v = &move(this).T::v;
         return *move(ref_v);
     }
 

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/assign_local_struct_invalidated.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/assign_local_struct_invalidated.mvir
@@ -11,7 +11,7 @@ module 0x42.Tester {
         let t_v: &mut u64;
         let new_t: Self.T;
         t2 = copy(t);
-        t_v = &mut copy(t2).v;
+        t_v = &mut copy(t2).T::v;
         *move(t_v) = 10000;
 
         new_t = Self.new(1);
@@ -23,7 +23,7 @@ module 0x42.Tester {
     public value(this: &mut Self.T): u64 {
         let ref_v: &u64;
         let r: u64;
-        ref_v = &copy(this).v;
+        ref_v = &copy(this).T::v;
         r = *move(ref_v);
         _ = move(this);
         return move(r);

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_copy_ok.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_copy_ok.mvir
@@ -10,7 +10,7 @@ module 0x1.B {
     public t(this: &Self.T) {
         let g: &u64;
         let y: u64;
-        g = &copy(this).g;
+        g = &copy(this).T::g;
         // can read g even with the live parent reference
         y = *move(g);
         _ = move(this);

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_field_ok.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_field_ok.mvir
@@ -15,7 +15,7 @@ module 0x1.A {
     public value(this: &Self.K) : u64 {
         let k: &u64;
         // valid field borrow
-        k = &(&move(this).f).v;
+        k = &(&move(this).K::f).T::v;
         return *move(k);
     }
 }

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_3.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_3.mvir
@@ -43,7 +43,7 @@ module 0x1.A {
     }
 
     get_v(x: &mut Self.T1): &mut u64 {
-        return &mut move(x).v;
+        return &mut move(x).T1::v;
     }
 
     acquires_t1(account: &signer) acquires T1 {

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_invalid_3.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_invalid_3.mvir
@@ -4,7 +4,7 @@ module 0x1.A {
     struct T1 has key {v: u64}
     struct T2 has key {v: u64}
     get_v(x: &mut Self.T1): &mut u64 {
-        return &mut move(x).v;
+        return &mut move(x).T1::v;
     }
     acquires_t1(account: &signer) acquires T1 {
         let v: u64;
@@ -36,7 +36,7 @@ module 0x1.A2 {
     struct T1 has key {v: u64}
     struct T2 has key {v: u64}
     get_v(x: &mut Self.T1): &mut u64 {
-        return &mut move(x).v;
+        return &mut move(x).T1::v;
     }
     acquires_t1(account: &signer) acquires T1 {
         let v: u64;
@@ -68,7 +68,7 @@ module 0x1.A3 {
     struct T1 has key {v: u64}
     struct T2 has key {v: u64}
     get_v(x: &mut Self.T1): &mut u64 {
-        return &mut move(x).v;
+        return &mut move(x).T1::v;
     }
     acquires_t1(account: &signer) acquires T1 {
         let v: u64;

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_return_reference_1.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_return_reference_1.mvir
@@ -15,7 +15,7 @@ module 0x1.A {
 
     borrow_acquires_t1(account: &signer, x: &mut Self.T1): &mut u64 acquires T1 {
         _ = borrow_global_mut<T1>(Signer.address_of(move(account)));
-        return &mut move(x).v;
+        return &mut move(x).T1::v;
     }
 
     acquires_t1(account: &signer) acquires T1 {

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_return_mutable_borrow_bad.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/borrow_return_mutable_borrow_bad.mvir
@@ -7,8 +7,8 @@ module 0x1.M {
         let ref_x_f: &mut Self.Y;
         let ref_x_f_g: &u64;
 
-        ref_x_f = &mut move(ref_x).f;
-        ref_x_f_g = & copy(ref_x_f).g;
+        ref_x_f = &mut move(ref_x).X::f;
+        ref_x_f_g = & copy(ref_x_f).Y::g;
 
         // mutable return value overlaps with other return value
         return (move(ref_x_f), move(ref_x_f_g));

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/copy_loc_borrowed_field.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/copy_loc_borrowed_field.mvir
@@ -9,8 +9,8 @@ module 0x1.Tester {
         let f: u64;
 
         x = T { f: 0 };
-        r1 = &(&x).f;
-        r2 = &(&x).f;
+        r1 = &(&x).T::f;
+        r2 = &(&x).T::f;
         // copy is valid here even though immutably borrowed
         T { f: f } = copy(x);
         _ = move(r1);

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/copy_loc_borrowed_field_invalid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/copy_loc_borrowed_field_invalid.mvir
@@ -8,7 +8,7 @@ module 0x1.Tester {
         let f: u64;
 
         x = T { f: 0 };
-        r1 = &mut (&mut x).f;
+        r1 = &mut (&mut x).T::f;
         // cannot copy x, data is partially owned by r1. violates ref trans
         T { f: f } = copy(x);
         T { f: f } = move(x);

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/deref_borrow_field_ok.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/deref_borrow_field_ok.mvir
@@ -9,7 +9,7 @@ module 0x1.M {
     public t(this: &Self.T) {
         let y: u64;
         // valid deref/read
-        y = *&move(this).f;
+        y = *&move(this).T::f;
         assert(copy(y) == 2, 42);
         return;
     }

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/deref_eq_bad.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/deref_eq_bad.mvir
@@ -9,7 +9,7 @@ module 0x1.M {
     public compare(t1: &mut Self.T, t2: &mut Self.T) : bool {
         let b: bool;
         let x_ref: &mut u64;
-        x_ref = &mut copy(t1).v;
+        x_ref = &mut copy(t1).T::v;
         // cannot read from t1 as it is borrowed by x_ref
         b = move(t1) == move(t2);
         return move(b);

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/deref_eq_good.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/deref_eq_good.mvir
@@ -14,7 +14,7 @@ module 0x1.M {
     public compare2 (t1: &mut Self.T, t2: &mut Self.T) : bool {
         let b: bool;
         let x_ref: &u64;
-        x_ref = &copy(t1).v;
+        x_ref = &copy(t1).T::v;
         b = move(t1) == move(t2);
         _ = move(x_ref);
         return move(b);

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/factor_invalid_1.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/factor_invalid_1.mvir
@@ -13,8 +13,8 @@ module 0x1.M {
         x = X { f: Y { g: 0, h: 0 } };
 
         ref_x = &mut x;
-        ref_x_f = &mut move(ref_x).f;
-        ref_x_f_g = &mut copy(ref_x_f).g;
+        ref_x_f = &mut move(ref_x).X::f;
+        ref_x_f_g = &mut copy(ref_x_f).Y::g;
 
         // Error: the argument for parameter b is borrowed
         Self.foo(move(ref_x_f_g), move(ref_x_f));
@@ -40,8 +40,8 @@ module 0x1.M2 {
         x = X { f: Y { g: 0, h: 0 } };
 
         ref_x = &mut x;
-        ref_x_f = &mut move(ref_x).f;
-        ref_x_f_g = &mut copy(ref_x_f).g;
+        ref_x_f = &mut move(ref_x).X::f;
+        ref_x_f_g = &mut copy(ref_x_f).Y::g;
 
         // Error: the argument for parameter a is borrowed
         Self.bar(move(ref_x_f), move(ref_x_f_g));

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/factor_invalid_2.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/factor_invalid_2.mvir
@@ -16,12 +16,12 @@ module 0x1.M {
             eps = &x1;
         }
         // Error: root has weak empty borrow and hence a field cannot be borrowed mutably
-        g_mut = &mut move(root).g;
+        g_mut = &mut move(root).S::g;
         g_imm = freeze(move(g_mut));
         return;
     }
 
     bar(a: &mut Self.S): &u64 {
-        return &move(a).g;
+        return &move(a).S::g;
     }
 }

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/factor_valid_1.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/factor_valid_1.mvir
@@ -14,12 +14,12 @@ module 0x1.M {
         x = X { f: Y { g: 0, h: 0 } };
 
         ref_x = &mut x;
-        ref_x_f = &mut move(ref_x).f;
-        ref_x_f_g = &mut move(ref_x_f).g;
+        ref_x_f = &mut move(ref_x).X::f;
+        ref_x_f_g = &mut move(ref_x_f).Y::g;
 
         ref_x = &mut x;
-        ref_x_f = &mut move(ref_x).f;
-        ref_x_f_h = &mut move(ref_x_f).h;
+        ref_x_f = &mut move(ref_x).X::f;
+        ref_x_f_h = &mut move(ref_x_f).Y::h;
 
         *copy(ref_x_f_g) = *copy(ref_x_f_h);
         *copy(ref_x_f_h) = *copy(ref_x_f_g);

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/factor_valid_2.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/factor_valid_2.mvir
@@ -15,7 +15,7 @@ module 0x1.M {
             eps = &x1;
         }
         // valid to extend even though imm borrowed in one branch
-        g = &move(root).g;
+        g = &move(root).S::g;
         return;
     }
 
@@ -57,7 +57,7 @@ module 0x1.M {
     }
 
     bar(a: &mut Self.S): &u64 {
-        return &move(a).g;
+        return &move(a).S::g;
     }
 
     baz(a: &u64, b: &u64) {

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_global_invalid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_global_invalid.mvir
@@ -70,10 +70,10 @@ module 0x1.Tester {
         let c2: &A.Coin;
 
         p1 = borrow_global_mut<Pair>(move(addr1));
-        c1 = &move(p1).x;
+        c1 = &move(p1).Pair::x;
         // Pair still acquired mutably
         p2 = borrow_global_mut<Pair>(move(addr2));
-        c2 = &move(p2).x;
+        c2 = &move(p2).Pair::x;
         return move(c1) == move(c2);
     }
 }

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_loc.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_loc.mvir
@@ -12,14 +12,14 @@ module 0x1.Tester {
 
         sender = Signer.address_of(move(account));
         data = borrow_global_mut<Data>(move(sender));
-        *&mut copy(b1).f = *&copy(data).v1;
-        *&mut copy(b2).f = *&move(data).v2;
-        if (*&copy(b1).f >= *&copy(b2).f) {
+        *&mut copy(b1).Box::f = *&copy(data).Data::v1;
+        *&mut copy(b2).Box::f = *&move(data).Data::v2;
+        if (*&copy(b1).Box::f >= *&copy(b2).Box::f) {
             _ = move(b2);
-            return &move(b1).f;
+            return &move(b1).Box::f;
         } else {
             _ = move(b1);
-            return &move(b2).f;
+            return &move(b2).Box::f;
         }
     }
 
@@ -32,18 +32,18 @@ module 0x1.Tester {
         b1 = move_from<Box>(Signer.address_of(copy(account)));
         b2 = move_from<Box>(move(drop));
 
-        assert(*&(&b1).f == 0, 42);
-        assert(*&(&b2).f == 0, 42);
+        assert(*&(&b1).Box::f == 0, 42);
+        assert(*&(&b2).Box::f == 0, 42);
 
         returned_ref = Self.bump_and_pick(copy(account), &mut b1, &mut b2);
 
         // it is valid to immutably borrow the local
         // even though a mut borrow + freeze would be invalid
-        assert(*&(&b1).f != 0, 42);
-        assert(*&(&b2).f != 0, 42);
+        assert(*&(&b1).Box::f != 0, 42);
+        assert(*&(&b2).Box::f != 0, 42);
         assert(
-            // (*copy(returned_ref) == *&(&b1).f) ^ (*copy(returned_ref) == *&(&b2).f),
-            (*copy(returned_ref) == *&(&b1).f) != (*copy(returned_ref) == *&(&b2).f),
+            // (*copy(returned_ref) == *&(&b1).Box::f) ^ (*copy(returned_ref) == *&(&b2).Box::f),
+            (*copy(returned_ref) == *&(&b1).Box::f) != (*copy(returned_ref) == *&(&b2).Box::f),
             42
         );
 

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_loc_trivial.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_loc_trivial.mvir
@@ -4,8 +4,8 @@ module 0x1.Tester {
 
     bump_and_give(x_ref: &mut Self.X, other: &u64): &u64 {
         _ = move(other);
-        *(&mut copy(x_ref).f) = *&mut copy(x_ref).f + 1;
-        return &move(x_ref).f;
+        *(&mut copy(x_ref).X::f) = *&mut copy(x_ref).X::f + 1;
+        return &move(x_ref).X::f;
     }
 
     contrived_example(result: &mut u64) {
@@ -18,7 +18,7 @@ module 0x1.Tester {
         returned_ref = Self.bump_and_give(&mut x, &other);
         // it is valid to immutably borrow the local
         // even though a mut borrow + freeze would be invalid
-        assert(*copy(returned_ref) == *&(&x).f, 42);
+        assert(*copy(returned_ref) == *&(&x).X::f, 42);
         *move(result) = *move(returned_ref);
         X { other } = move(x);
         return;

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_loc_trivial_valid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_loc_trivial_valid.mvir
@@ -4,8 +4,8 @@ module 0x1.Tester {
 
     bump_and_give(x_ref: &mut Self.X, other: &u64): &u64 {
         _ = move(other);
-        *(&mut copy(x_ref).f) = *&mut copy(x_ref).f + 1;
-        return &move(x_ref).f;
+        *(&mut copy(x_ref).X::f) = *&mut copy(x_ref).X::f + 1;
+        return &move(x_ref).X::f;
     }
 
     contrived_example(result: &mut u64) {
@@ -17,7 +17,7 @@ module 0x1.Tester {
         other = 100;
         returned_ref = Self.bump_and_give(&mut x, &other);
         // mut borrow the local + freeze is valid here
-        assert(*copy(returned_ref) == *&(freeze(&mut x)).f, 42);
+        assert(*copy(returned_ref) == *&(freeze(&mut x)).X::f, 42);
         *move(result) = *move(returned_ref);
         X { other } = move(x);
         return;

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_loc_valid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_loc_valid.mvir
@@ -12,14 +12,14 @@ module 0x1.Tester {
 
         sender = Signer.address_of(move(account));
         data = borrow_global_mut<Data>(move(sender));
-        *&mut copy(b1).f = *&copy(data).v1;
-        *&mut copy(b2).f = *&move(data).v2;
-        if (*&copy(b1).f >= *&copy(b2).f) {
+        *&mut copy(b1).Box::f = *&copy(data).Data::v1;
+        *&mut copy(b2).Box::f = *&move(data).Data::v2;
+        if (*&copy(b1).Box::f >= *&copy(b2).Box::f) {
             _ = move(b2);
-            return &move(b1).f;
+            return &move(b1).Box::f;
         } else {
             _ = move(b1);
-            return &move(b2).f;
+            return &move(b2).Box::f;
         }
     }
 
@@ -32,16 +32,16 @@ module 0x1.Tester {
         b1 = move_from<Box>(Signer.address_of(copy(account)));
         b2 = move_from<Box>(move(drop));
 
-        assert(*&(&b1).f == 0, 42);
-        assert(*&(&b2).f == 0, 42);
+        assert(*&(&b1).Box::f == 0, 42);
+        assert(*&(&b2).Box::f == 0, 42);
 
         returned_ref = Self.bump_and_pick(copy(account), &mut b1, &mut b2);
 
         // it is valid to immutably extend the reference
         // even though a mut extension + freeze would be invalid
         assert(
-            // (*copy(returned_ref) == *&(&b1).f) ^ (*copy(returned_ref) == *&(&b2).f),
-            (*copy(returned_ref) == *&(&mut b1).f) != (*copy(returned_ref) == *&(&mut b2).f),
+            // (*copy(returned_ref) == *&(&b1).Box::f) ^ (*copy(returned_ref) == *&(&b2).Box::f),
+            (*copy(returned_ref) == *&(&mut b1).Box::f) != (*copy(returned_ref) == *&(&mut b2).Box::f),
             42
         );
 

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_on_mut.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_on_mut.mvir
@@ -12,12 +12,12 @@ module 0x1.Tester {
 
         sender = Signer.address_of(move(account));
         init = borrow_global_mut<Initializer>(move(sender));
-        *&mut copy(p).x = *&copy(init).x;
-        *&mut copy(p).y = *&move(init).y;
-        if (*&copy(p).x >= *&copy(p).y) {
-            return &mut move(p).x;
+        *&mut copy(p).Point::x = *&copy(init).Initializer::x;
+        *&mut copy(p).Point::y = *&move(init).Initializer::y;
+        if (*&copy(p).Point::x >= *&copy(p).Point::y) {
+            return &mut move(p).Point::x;
         } else {
-            return &mut move(p).y;
+            return &mut move(p).Point::y;
         }
     }
 
@@ -30,8 +30,8 @@ module 0x1.Tester {
         let field_ref: &mut u64;
         let returned_ref: &u64;
 
-        assert(*&copy(point_ref).x == 0, 42);
-        assert(*&copy(point_ref).y == 0, 42);
+        assert(*&copy(point_ref).Point::x == 0, 42);
+        assert(*&copy(point_ref).Point::y == 0, 42);
 
         field_ref = Self.set_and_pick(move(account), copy(point_ref));
         returned_ref = Self.bump_and_give(move(field_ref));
@@ -39,8 +39,8 @@ module 0x1.Tester {
         // it is valid to immutably extend the reference
         // even though a mut extension + freeze would be invalid
         assert(
-            (*copy(returned_ref) == *&copy(point_ref).x) &&
-            (*copy(returned_ref) != *&move(point_ref).y),
+            (*copy(returned_ref) == *&copy(point_ref).Point::x) &&
+            (*copy(returned_ref) != *&move(point_ref).Point::y),
             42
         );
 

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_on_mut_invalid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_on_mut_invalid.mvir
@@ -12,12 +12,12 @@ module 0x1.Tester {
 
         sender = Signer.address_of(move(account));
         init = borrow_global_mut<Initializer>(move(sender));
-        *&mut copy(p).x = *&copy(init).x;
-        *&mut copy(p).y = *&move(init).y;
-        if (*&copy(p).x >= *&copy(p).y) {
-            return &mut move(p).x;
+        *&mut copy(p).Point::x = *&copy(init).Initializer::x;
+        *&mut copy(p).Point::y = *&move(init).Initializer::y;
+        if (*&copy(p).Point::x >= *&copy(p).Point::y) {
+            return &mut move(p).Point::x;
         } else {
-            return &mut move(p).y;
+            return &mut move(p).Point::y;
         }
     }
 
@@ -31,12 +31,12 @@ module 0x1.Tester {
         let returned_ref: &u64;
         let x_val: u64;
 
-        assert(*&copy(point_ref).x == 0, 42);
-        assert(*&copy(point_ref).y == 0, 42);
+        assert(*&copy(point_ref).Point::x == 0, 42);
+        assert(*&copy(point_ref).Point::y == 0, 42);
 
         field_ref = Self.set_and_pick(move(account), copy(point_ref));
         // this borrow is invalid because of field_ref
-        x_val = *freeze(&mut move(point_ref).x);
+        x_val = *freeze(&mut move(point_ref).Point::x);
         returned_ref = Self.bump_and_give(move(field_ref));
 
         // imagine some more interesting check than this assert
@@ -63,12 +63,12 @@ module 0x1.Tester2 {
 
         sender = Signer.address_of(move(account));
         init = borrow_global_mut<Initializer>(move(sender));
-        *&mut copy(p).x = *&copy(init).x;
-        *&mut copy(p).y = *&move(init).y;
-        if (*&copy(p).x >= *&copy(p).y) {
-            return &mut move(p).x;
+        *&mut copy(p).Point::x = *&copy(init).Initializer::x;
+        *&mut copy(p).Point::y = *&move(init).Initializer::y;
+        if (*&copy(p).Point::x >= *&copy(p).Point::y) {
+            return &mut move(p).Point::x;
         } else {
-            return &mut move(p).y;
+            return &mut move(p).Point::y;
         }
     }
 
@@ -82,12 +82,12 @@ module 0x1.Tester2 {
         let returned_ref: &u64;
         let x_val: u64;
 
-        assert(*&copy(point_ref).x == 0, 42);
-        assert(*&copy(point_ref).y == 0, 42);
+        assert(*&copy(point_ref).Point::x == 0, 42);
+        assert(*&copy(point_ref).Point::y == 0, 42);
 
         field_ref = Self.set_and_pick(move(account), copy(point_ref));
         // this freeze is invalid because of field_ref
-        x_val = *(&freeze(move(point_ref)).x);
+        x_val = *(&freeze(move(point_ref)).Point::x);
         returned_ref = Self.bump_and_give(move(field_ref));
 
         // imagine some more interesting check than this assert

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_on_mut_trivial.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_on_mut_trivial.mvir
@@ -3,8 +3,8 @@ module 0x1.Tester {
     struct X { f: u64 }
 
     bump_and_give(x_ref: &mut Self.X): &u64 {
-        *(&mut copy(x_ref).f) = *&mut copy(x_ref).f + 1;
-        return &move(x_ref).f;
+        *(&mut copy(x_ref).X::f) = *&mut copy(x_ref).X::f + 1;
+        return &move(x_ref).X::f;
     }
 
     contrived_example(x_ref: &mut Self.X): &u64 {
@@ -13,7 +13,7 @@ module 0x1.Tester {
         returned_ref = Self.bump_and_give(copy(x_ref));
         // it is valid to immutably extend the reference
         // even though a mut extension + freeze would be invalid
-        assert(*copy(returned_ref) == *&move(x_ref).f, 42);
+        assert(*copy(returned_ref) == *&move(x_ref).X::f, 42);
         return move(returned_ref);
     }
 }

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_on_mut_trivial_invalid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_on_mut_trivial_invalid.mvir
@@ -3,8 +3,8 @@ module 0x1.Tester {
     struct X { f: u64 }
 
     bump_and_give(x_ref: &mut Self.X): &u64 {
-        *(&mut copy(x_ref).f) = *&mut copy(x_ref).f + 1;
-        return &move(x_ref).f;
+        *(&mut copy(x_ref).X::f) = *&mut copy(x_ref).X::f + 1;
+        return &move(x_ref).X::f;
     }
 
     contrived_example_no(x_ref: &mut Self.X): &u64 {
@@ -12,7 +12,7 @@ module 0x1.Tester {
 
         returned_ref = Self.bump_and_give(copy(x_ref));
         // ERROR Cannot mutably borrow from `x_ref` it is being borrowed by `returned_ref`
-        assert(*copy(returned_ref) == *freeze(&mut move(x_ref).f) + 1, 42);
+        assert(*copy(returned_ref) == *freeze(&mut move(x_ref).X::f) + 1, 42);
         return move(returned_ref);
     }
 
@@ -22,7 +22,7 @@ module 0x1.Tester {
         returned_ref = Self.bump_and_give(copy(x_ref));
         // This is still valid, but might not be in other cases. See other Imm Borrow tests
         // i.e. you might hit FreezeRefExistsMutableBorrowError
-        assert(*copy(returned_ref) == *(&freeze(move(x_ref)).f) + 1, 42);
+        assert(*copy(returned_ref) == *(&freeze(move(x_ref)).X::f) + 1, 42);
         return move(returned_ref);
     }
 }

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/join_borrow_unavailable_valid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/join_borrow_unavailable_valid.mvir
@@ -12,7 +12,7 @@ module 0x1.M {
             x = &u;
         } else {
             _ = move(u);
-            x = &move(root).f;
+            x = &move(root).S::f;
         }
         // it is okay for the two branches to disagree on the state of u, even though it is
         // borrowed in one branch

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/mutable_borrow_invalid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/mutable_borrow_invalid.mvir
@@ -7,13 +7,13 @@ module 0x1.M {
         let x: &mut u64;
 
         if (move(cond)) {
-            x = &mut copy(root).f;
+            x = &mut copy(root).S::f;
         } else {
-            x = &mut copy(root).g;
+            x = &mut copy(root).S::g;
         }
 
         // INVALID x is still borrowing f
-        *(&mut copy(root).f) = 1;
+        *(&mut copy(root).S::f) = 1;
 
         return;
     }
@@ -28,13 +28,13 @@ module 0x1.M2 {
         let x: &mut u64;
 
         if (move(cond)) {
-            x = &mut copy(root).f;
+            x = &mut copy(root).S::f;
         } else {
-            x = &mut copy(root).g;
+            x = &mut copy(root).S::g;
         }
 
         // INVALID x and &mut root.f overlap
-        Self.foo(move(x), &mut copy(root).f);
+        Self.foo(move(x), &mut copy(root).S::f);
 
         return;
     }

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/mutate_borrow_field_ok.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/mutate_borrow_field_ok.mvir
@@ -7,13 +7,13 @@ module 0x42.Test {
     }
 
     public thousand(t : &mut Self.T) {
-        *(&mut move(t).v) = 1000;
+        *(&mut move(t).T::v) = 1000;
         return;
     }
 
     public value(this: &mut Self.T): u64 {
         let y: &u64;
-        y = &move(this).v;
+        y = &move(this).T::v;
         return *move(y);
     }
 }

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/mutate_resource_holder_2.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/mutate_resource_holder_2.mvir
@@ -24,8 +24,8 @@ module 0x42.A {
         let ref_balance: &mut u64;
 
         // safe to modify resources inner values (if they have drop)
-        ref = &mut move(a_ref).c;
-        ref_balance = &mut move(ref).balance;
+        ref = &mut move(a_ref).A::c;
+        ref_balance = &mut move(ref).Coin::balance;
         *move(ref_balance) = 100;
 
         return;

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/mutate_with_borrowed_loc_struct_invalid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/mutate_with_borrowed_loc_struct_invalid.mvir
@@ -26,7 +26,7 @@ module 0x1.N {
         let z: &u64;
         s = S { z: 2 };
         y = &s;
-        z = &move(y).z;
+        z = &move(y).S::z;
         // cannot write to z, still borrowed
         s = S { z: 7 };
         return;

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/nested_mutate.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/nested_mutate.mvir
@@ -8,7 +8,7 @@ module 0x42.B {
 
     public t(this: &mut Self.T) {
         let g: &mut u64;
-        g = &mut copy(this).g;
+        g = &mut copy(this).T::g;
         *copy(g) = 2;
         assert(*move(g) == 2, 42);
         _ = move(this);
@@ -27,7 +27,7 @@ module 0x42.A {
 
     public t(this: &mut Self.T) {
         let f: &mut B.T;
-        f = &mut copy(this).f;
+        f = &mut copy(this).T::f;
         // safe to modify reference through nested calls
         B.t(move(f));
         _ = move(this);

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/read_field_after_assign_local.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/read_field_after_assign_local.mvir
@@ -10,7 +10,7 @@ module 0x42.Tester {
         let t_v: &mut u64;
         let new_t: Self.T;
 
-        t_v = &mut copy(t).v;
+        t_v = &mut copy(t).T::v;
         new_t = Self.new(1);
         // cannot write to t, still borrowed
         *move(t) = move(new_t);

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/ref_moved_one_branch.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/ref_moved_one_branch.mvir
@@ -5,7 +5,7 @@ module 0x1.A {
     public t(changed: bool, s: &mut Self.S) {
         // valid to move a reference in one branch and not the other
         if (move(changed)) {
-            Self.foo(&mut move(s).value);
+            Self.foo(&mut move(s).S::value);
         }
         return;
     }

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/return_with_borrowed_loc.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/return_with_borrowed_loc.mvir
@@ -18,8 +18,8 @@ module 0x1.M {
         let u: &u64;
         s = X { y: Y { u: 0 } };
         x = &s;
-        y = &copy(x).y;
-        u = &copy(y).u;
+        y = &copy(x).X::y;
+        u = &copy(y).Y::u;
         // all references are automatically released, return is safe
         return;
     }

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/return_with_borrowed_loc_invalid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/return_with_borrowed_loc_invalid.mvir
@@ -38,8 +38,8 @@ module 0x1.M3 {
         let u: &u64;
         s = X { y: Y { u: 0 } };
         x = &s;
-        y = &move(x).y;
-        u = &move(y).u;
+        y = &move(x).X::y;
+        u = &move(y).Y::u;
         // invalid return, borrowing a local
         return move(u);
     }
@@ -56,8 +56,8 @@ module 0x1.M4 {
         let u: &u64;
         s = X { y: Y { u: 0 } };
         x = &s;
-        y = &copy(x).y;
-        u = &copy(y).u;
+        y = &copy(x).X::y;
+        u = &copy(y).Y::u;
         // invalid return, borrowing a local
         return copy(u);
     }

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/return_with_borrowed_loc_resource_invalid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/return_with_borrowed_loc_resource_invalid.mvir
@@ -6,7 +6,7 @@ module 0x1.M {
         let s: Self.X;
         let u: &u64;
         s = X { u: 0 };
-        u = &(&s).u;
+        u = &(&s).X::u;
         // unused resource even though it is "used" via a borrow
         return;
     }

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/simple_mutate.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/simple_mutate.mvir
@@ -8,7 +8,7 @@ module 0x42.A {
 
     public t(this: &mut Self.T) {
         let f: &mut u64;
-        f = &mut copy(this).f;
+        f = &mut copy(this).T::f;
         // mutation allowed
         *copy(f) = 2;
         assert(*move(f) == 2, 42);

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/two_mutable_ref.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/two_mutable_ref.mvir
@@ -8,8 +8,8 @@ module 0x42.M {
       let a_ref: &mut u64;
       let b_ref: &mut u64;
       // multiple mutable references to same ref valid
-      a_ref = &mut copy(addr).a;
-      b_ref = &mut copy(addr).b;
+      a_ref = &mut copy(addr).Foo::a;
+      b_ref = &mut copy(addr).Foo::b;
       _ = move(a_ref);
       _ = move(b_ref);
       _ = move(addr);

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/use_after_move.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/use_after_move.mvir
@@ -21,7 +21,7 @@ module 0x42.A {
         let ref2: &mut B.T;
         let b2: B.T;
         let x: B.T;
-        ref1 = &mut move(this).value;
+        ref1 = &mut move(this).T::value;
         ref2 = copy(ref1);
         b2 = B.new(3);
         // cannot write to ref1, ref2 still borrows

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/use_prefix_after_move.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/use_prefix_after_move.mvir
@@ -8,7 +8,7 @@ module 0x42.B {
 
     public t(this: &mut Self.T) {
         let g: &mut u64;
-        g = &mut move(this).g;
+        g = &mut move(this).T::g;
         *move(g) = 3;
         return;
     }
@@ -26,7 +26,7 @@ module 0x42.A {
     public t(this: &mut Self.T) {
         let ref1: &mut B.T;
         let ok: B.T;
-        ref1 = &mut move(this).f;
+        ref1 = &mut move(this).T::f;
         B.t(copy(ref1));
         ok = *move(ref1);
         return;

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/use_suffix_after_move.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/use_suffix_after_move.mvir
@@ -8,7 +8,7 @@ module 0x42.B {
 
     public t(this: &Self.T): &u64 {
         let g: &u64;
-        g = &move(this).g;
+        g = &move(this).T::g;
         return move(g);
     }
 }
@@ -27,7 +27,7 @@ module 0x42.A {
         let ref1: &mut B.T;
         let ref2: &u64;
         let b2: B.T;
-        ref1 = &mut move(this).f;
+        ref1 = &mut move(this).T::f;
         ref2 = B.t(freeze(copy(ref1)));
         b2 = B.new(3);
         // cannot modify, ref2 still borrows ref1

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/writeref_borrow_invalid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/writeref_borrow_invalid.mvir
@@ -7,8 +7,8 @@ module 0x1.M {
         let v_mut: &mut u64;
         let g_mut: &mut Self.G;
 
-        v_mut = &mut (&mut copy(root).g).v;
-        g_mut = &mut copy(root).g;
+        v_mut = &mut (&mut copy(root).S::g).G::v;
+        g_mut = &mut copy(root).S::g;
 
         // INVALID cannot write with v_mut live
         *move(g_mut) = G { v: 0 };

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/writeref_borrow_valid1.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/writeref_borrow_valid1.mvir
@@ -8,10 +8,10 @@ module 0x1.M {
         let v2_mut: &mut u64;
         let g2_mut: &mut Self.G;
 
-        v1_mut = &mut (&mut copy(root).g1).v1;
-        v2_mut = &mut (&mut copy(root).g1).v2;
+        v1_mut = &mut (&mut copy(root).S::g1).G::v1;
+        v2_mut = &mut (&mut copy(root).S::g1).G::v2;
 
-        g2_mut = &mut copy(root).g2;
+        g2_mut = &mut copy(root).S::g2;
 
         // all writes valid as they are on different fields/subtrees
         *copy(g2_mut) = G { v1: 0, v2: 0 };

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/writeref_borrow_valid2.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/writeref_borrow_valid2.mvir
@@ -6,13 +6,13 @@ module 0x1.M {
         let x: &mut u64;
 
         if (move(cond)) {
-            x = &mut copy(root).f;
+            x = &mut copy(root).S::f;
         } else {
-            x = &mut copy(root).g;
+            x = &mut copy(root).S::g;
         }
 
         // can write even though f and g are borrowed
-        *(&mut copy(root).h) = 0;
+        *(&mut copy(root).S::h) = 0;
 
         return;
     }
@@ -21,14 +21,14 @@ module 0x1.M {
         let x: &mut u64;
 
         if (move(cond)) {
-            x = &mut copy(root).f;
+            x = &mut copy(root).S::f;
         } else {
-            x = &mut copy(root).g;
+            x = &mut copy(root).S::g;
         }
 
         // can borrow even though f and g are borrowed
-        _ = &mut copy(root).f;
-        _ = &mut copy(root).g;
+        _ = &mut copy(root).S::f;
+        _ = &mut copy(root).S::g;
 
         return;
     }

--- a/language/bytecode-verifier/transactional-tests/tests/script_with_type_parameters.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/script_with_type_parameters.mvir
@@ -2,7 +2,7 @@
 module 0x1.Coin {
     struct Coin { value: u64 }
     public value(c: &Self.Coin): u64 {
-        return *&move(c).value;
+        return *&move(c).Coin::value;
     }
     public zero(): Self.Coin {
         return Coin { value: 0 };

--- a/language/bytecode-verifier/transactional-tests/tests/signature/reference_as_type_actual_in_struct_inst_for_bytecode_instruction.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/signature/reference_as_type_actual_in_struct_inst_for_bytecode_instruction.mvir
@@ -100,7 +100,7 @@ module 0x1.M {
 
     // cannot use refs in generics
     foo(s: Self.S<&u64>): u64 {
-        return *(*(&(&s).v));
+        return *(*(&(&s).S::v));
     }
 }
 
@@ -110,6 +110,6 @@ module 0x1.M {
 
     // cannot use refs in generics
     foo(s: Self.S<&u64>): u64 {
-        return *(*(&mut (&mut s).v));
+        return *(*(&mut (&mut s).S::v));
     }
 }

--- a/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/consume_stack.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/stack_usage_verifier/consume_stack.mvir
@@ -10,7 +10,7 @@ module 0x1.M {
         // correct stack usage
         (&addr);
         (0x1D8);
-        (&borrow_global<R>().data);
+        (&borrow_global<R>().R::data);
         Self.is_ok_();
         return;
     }

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/assign_resource_type.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/assign_resource_type.mvir
@@ -5,7 +5,7 @@ module 0x42.A {
 
     public t(this: &mut Self.T, y: Self.Coin) {
         let x: &mut Self.Coin;
-        x = &mut move(this).f;
+        x = &mut move(this).T::f;
         // cannot assign/mutate without drop ability
         *move(x) = move(y);
         return;

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/cant_deref_resource.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/cant_deref_resource.mvir
@@ -11,7 +11,7 @@ module 0x1.Token {
     public value(this: &Self.T): u64 {
         let vref: &u64;
         let res: u64;
-        vref = &move(this).v;
+        vref = &move(this).T::v;
         // T does not have copy
         res = *move(vref);
         return move(res);

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_borrow_field.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_borrow_field.mvir
@@ -9,7 +9,7 @@ module 0x1.M {
     bar<T>(x: Self.Foo<u64>) {
         let y: &mut u64;
         let z: u64;
-        y = &mut (&mut x).x;
+        y = &mut (&mut x).Foo<u64>::x;
         _ = move(y);
         Foo<u64> { x: z } = move(x);
         return;

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_imm_borrow_field.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_imm_borrow_field.mvir
@@ -11,7 +11,7 @@ module 0x1.M {
         let y: &u64;
         let z: u64;
         ref = &x;
-        y = &(&x).x;
+        y = &(&x).Foo<u64>::x;
         _ = move(ref);
         _ = move(y);
         Foo<u64> { x: z } = move(x);

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_field_borrow.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_field_borrow.mvir
@@ -3,6 +3,6 @@ module 0x1.M {
     struct X has drop { v: u64 }
     struct S<T> has drop { f: T }
     t(s: Self.S<Self.X>): u64 {
-        return *(&(&(&s).f).v);
+        return *(&(&(&s).S<Self.X>::f).X::v);
     }
 }

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_field_borrow_after_call.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/generic_field_borrow_after_call.mvir
@@ -7,6 +7,6 @@ module 0x1.M {
     }
 
     t(x: Self.X): u64 {
-        return *(&Self.id<Self.X>(&x).v);
+        return *(&Self.id<Self.X>(&x).X::v);
     }
 }

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/invalid_field_write.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/invalid_field_write.mvir
@@ -8,7 +8,7 @@ module 0x42.Test {
 
     public no(this: &mut Self.T) {
         let x: &mut bool;
-        x = &mut move(this).fr;
+        x = &mut move(this).T::fr;
         // type mismatch on assignment/mutation
         *move(x) = 0;
         return;

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/invalid_resource_write.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/invalid_resource_write.mvir
@@ -5,7 +5,7 @@ module 0x42.RTest {
 
       public update(t: &mut Self.T, i: Self.Coin) {
         let x: &mut Self.Coin;
-        x = &mut move(t).f;
+        x = &mut move(t).T::f;
         // cannot assign to ref where type does not have drop
         *move(x) = move(i);
         return;

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/mut_borrow_from_imm_ref.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/mut_borrow_from_imm_ref.mvir
@@ -14,7 +14,7 @@ module 0x42.Token {
         let val: &mut u64;
         let x: u64;
         // cannot mut borrow imm reff
-        val = &mut move(this).value;
+        val = &mut move(this).T::value;
         x = *copy(val) + 1;
         *move(val) = copy(x);
         return;

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/mut_call_from_get_resource.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/mut_call_from_get_resource.mvir
@@ -11,7 +11,7 @@ module 0x42.Token {
     public value(this: &Self.T): u64 {
         let b: u64;
         let b_ref: &u64;
-        b_ref = &move(this).balance;
+        b_ref = &move(this).T::balance;
         b = *move(b_ref);
         return move(b);
     }
@@ -19,7 +19,7 @@ module 0x42.Token {
     public bump(this: &mut Self.T) {
         let val: &mut u64;
         let x: u64;
-        val = &mut move(this).balance;
+        val = &mut move(this).T::balance;
         x = *copy(val) + 1;
         *move(val) = copy(x);
         return;

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/mut_call_with_imm_ref.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/mut_call_with_imm_ref.mvir
@@ -12,7 +12,7 @@ module 0x42.Token {
 
     public read_value(this: &Self.T): u64 {
         let val: &u64;
-        val = &copy(this).value;
+        val = &copy(this).T::value;
         // type mismatch, cannot make imm to mut
         Self.bump_value(move(this));
         return *move(val);
@@ -21,7 +21,7 @@ module 0x42.Token {
     public bump_value(this: &mut Self.T) {
         let val: &mut u64;
         let x: u64;
-        val = &mut move(this).value;
+        val = &mut move(this).T::value;
         x = *copy(val) + 1;
         *move(val) = copy(x);
         return;

--- a/language/bytecode-verifier/transactional-tests/tests/type_safety/signer_read_ref_transitive.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/type_safety/signer_read_ref_transitive.mvir
@@ -16,6 +16,6 @@ module 0x42.M {
         let x: Self.S<signer>;
         x = S<signer> { s: move(s) };
         // cannot copy signer
-        return *(&(&x).s);
+        return *(&(&x).S<signer>::s);
     }
 }

--- a/language/compiler/ir-to-bytecode/src/context.rs
+++ b/language/compiler/ir-to-bytecode/src/context.rs
@@ -866,16 +866,4 @@ impl<'a> Context<'a> {
         self.ensure_function_declared(m, f.clone())?;
         Ok(self.function_handles.get(&(m, f)).unwrap())
     }
-
-    /// Given an identifier, find the function signature and its index.
-    /// Creates the handle+signature and adds it to the pool if it it is the *first* time it looks
-    /// up the function in a dependency.
-    pub fn function_signature(
-        &mut self,
-        m: ModuleName,
-        f: FunctionName,
-    ) -> Result<&FunctionSignature> {
-        self.ensure_function_declared(m, f.clone())?;
-        Ok(self.function_signatures.get(&(m, f)).unwrap())
-    }
 }

--- a/language/compiler/src/unit_tests/expression_tests.rs
+++ b/language/compiler/src/unit_tests/expression_tests.rs
@@ -203,21 +203,21 @@ fn compile_borrow_field() {
 
             public borrow_immut_field(arg: &Self.FooCoin) {
                 let field_ref: &u64;
-                field_ref = &move(arg).value;
+                field_ref = &move(arg).FooCoin::value;
                 _ = move(field_ref);
                 return;
             }
 
             public borrow_immut_field_from_mut_ref(arg: &mut Self.FooCoin) {
                 let field_ref: &u64;
-                field_ref = &move(arg).value;
+                field_ref = &move(arg).FooCoin::value;
                 _ = move(field_ref);
                 return;
             }
 
             public borrow_mut_field(arg: &mut Self.FooCoin) {
                 let field_ref: &mut u64;
-                field_ref = &mut move(arg).value;
+                field_ref = &mut move(arg).FooCoin::value;
                 _ = move(field_ref);
                 return;
             }
@@ -237,21 +237,21 @@ fn compile_borrow_field_generic() {
 
             public borrow_immut_field(arg: &Self.FooCoin<u64>) {
                 let field_ref: &u64;
-                field_ref = &move(arg).value;
+                field_ref = &move(arg).FooCoin<u64>::value;
                 _ = move(field_ref);
                 return;
             }
 
             public borrow_immut_field_from_mut_ref(arg: &mut Self.FooCoin<u128>) {
                 let field_ref: &u64;
-                field_ref = &move(arg).value;
+                field_ref = &move(arg).FooCoin<u128>::value;
                 _ = move(field_ref);
                 return;
             }
 
             public borrow_mut_field(arg: &mut Self.FooCoin<address>) {
                 let field_ref: &mut u64;
-                field_ref = &mut move(arg).value;
+                field_ref = &mut move(arg).FooCoin<address>::value;
                 _ = move(field_ref);
                 return;
             }

--- a/language/compiler/src/unit_tests/function_tests.rs
+++ b/language/compiler/src/unit_tests/function_tests.rs
@@ -12,7 +12,7 @@ fn compile_module_with_functions() {
 
             public value(this: &Self.FooCoin): u64 {
                 let value_ref: &u64;
-                value_ref = &move(this).value;
+                value_ref = &move(this).FooCoin::value;
                 return *move(value_ref);
             }
 
@@ -23,7 +23,7 @@ fn compile_module_with_functions() {
                 let check_value: u64;
                 let new_value: u64;
                 let i: u64;
-                value_ref = &mut move(this).value;
+                value_ref = &mut move(this).FooCoin::value;
                 value = *copy(value_ref);
                 check_ref = &check;
                 check_value = Self.value(move(check_ref));

--- a/language/e2e-testsuite/src/tests/data_store.rs
+++ b/language/e2e-testsuite/src/tests/data_store.rs
@@ -219,7 +219,7 @@ fn add_module_txn(sender: &AccountData, seq_num: u64) -> (CompiledModule, Signed
             public change_t1(account: &signer, v: u64) acquires T1 {{
                 let t1: &mut Self.T1;
                 t1 = borrow_global_mut<T1>(Signer.address_of(move(account)));
-                *&mut move(t1).v = move(v);
+                *&mut move(t1).T1::v = move(v);
                 return;
             }}
 

--- a/language/ir-testsuite/tests/move/commands/mixed_lvalue.mvir
+++ b/language/ir-testsuite/tests/move/commands/mixed_lvalue.mvir
@@ -16,25 +16,25 @@ module {{default}}.A {
         r_ref = &mut r;
         s = S { f: 0 };
 
-        _, x, *copy(r_ref), *&mut (&mut s).f = Self.four();
+        _, x, *copy(r_ref), *&mut (&mut s).S::f = Self.four();
         assert(move(x) == 1, 42);
         assert(*copy(r_ref) == 2, 42);
-        assert(*&(&s).f == 3, 42);
+        assert(*&(&s).S::f == 3, 42);
 
-        *&mut (&mut s).f, _, x, *copy(r_ref) = Self.four();
+        *&mut (&mut s).S::f, _, x, *copy(r_ref) = Self.four();
         assert(move(x) == 2, 42);
         assert(*copy(r_ref) == 3, 42);
-        assert(*&(&s).f == 0, 42);
+        assert(*&(&s).S::f == 0, 42);
 
-        *copy(r_ref), *&mut (&mut s).f, _, x = Self.four();
+        *copy(r_ref), *&mut (&mut s).S::f, _, x = Self.four();
         assert(move(x) == 3, 42);
         assert(*copy(r_ref) == 0, 42);
-        assert(*&(&s).f == 1, 42);
+        assert(*&(&s).S::f == 1, 42);
 
-        x, *copy(r_ref), *&mut (&mut s).f, _ = Self.four();
+        x, *copy(r_ref), *&mut (&mut s).S::f, _ = Self.four();
         assert(move(x) == 0, 42);
         assert(*move(r_ref) == 1, 42);
-        assert(*&(&s).f == 2, 42);
+        assert(*&(&s).S::f == 2, 42);
 
         S { f: r } = move(s);
 

--- a/language/ir-testsuite/tests/move/dereference_tests/deref_move_module_ok.mvir
+++ b/language/ir-testsuite/tests/move/dereference_tests/deref_move_module_ok.mvir
@@ -7,7 +7,7 @@ module {{default}}.M {
 
     public value (this: &mut Self.T) : u64 {
         let b: &u64;
-        b = &move(this).v;
+        b = &move(this).T::v;
         return *move(b);
     }
 }

--- a/language/ir-testsuite/tests/move/expressions/cant_borrow_field_of_resource.mvir
+++ b/language/ir-testsuite/tests/move/expressions/cant_borrow_field_of_resource.mvir
@@ -1,4 +1,4 @@
-// check: Unbound field v
+// check: Unbound struct Self.T
 
 module {{default}}.Token {
     struct T has key {v: u64}
@@ -9,7 +9,7 @@ module {{default}}.Token {
 
     public value(this: &Self.T): u64 {
         let vref: &u64;
-        vref = &copy(this).v;
+        vref = &copy(this).T::v;
         _ = move(this);
         return *move(vref);
     }
@@ -38,7 +38,7 @@ main() {
 
     t = Token.new(1);
     tref = &mut t;
-    balance_ref = &move(tref).v;
+    balance_ref = &move(tref).T::v;
     _ = move(balance_ref);
     return;
 }

--- a/language/ir-testsuite/tests/move/function_calls/many_function_calls_as_args.mvir
+++ b/language/ir-testsuite/tests/move/function_calls/many_function_calls_as_args.mvir
@@ -7,13 +7,13 @@ module {{default}}.A {
 
     public get_value(this: &mut Self.T): u64 {
         let v: &u64;
-        v = &move(this).value;
+        v = &move(this).T::value;
         return *move(v);
     }
 
     public get_parity(this: &mut Self.T): bool {
         let b: &bool;
-        b = &move(this).even;
+        b = &move(this).T::even;
         return *move(b);
     }
 

--- a/language/ir-testsuite/tests/move/function_calls/multiple_composite_functions.mvir
+++ b/language/ir-testsuite/tests/move/function_calls/multiple_composite_functions.mvir
@@ -7,7 +7,7 @@ module {{default}}.A {
 
     public add_one(this: &mut Self.T): u64 {
         let b: &u64;
-        b = &move(this).value;
+        b = &move(this).T::value;
         return *move(b) + 1;
     }
 

--- a/language/ir-testsuite/tests/move/mutate_tests/mutate_move_ok.mvir
+++ b/language/ir-testsuite/tests/move/mutate_tests/mutate_move_ok.mvir
@@ -7,14 +7,14 @@ module {{default}}.B {
 
   public change(this: &mut Self.T) {
     let g: &mut u64;
-    g = &mut move(this).g;
+    g = &mut move(this).T::g;
     *move(g) = 3;
     return;
   }
 
   public get(this: &mut Self.T): u64 {
     let x: &u64;
-    x = &move(this).g;
+    x = &move(this).T::g;
     return *move(x);
   }
 }

--- a/language/ir-testsuite/tests/move/mutation/mint_money.mvir
+++ b/language/ir-testsuite/tests/move/mutation/mint_money.mvir
@@ -14,8 +14,8 @@ import 0x1.XUS;
         let ref1: &mut u64;
         let new_money: Diem.Diem<XUS.XUS>;
 
-        ref0 = &mut copy(this).money;
-        ref1 = &mut copy(ref0).balance;
+        ref0 = &mut copy(this).T::money;
+        ref1 = &mut copy(ref0).T::balance;
         *move(ref1) = 1000000000000;
         new_money = Diem.withdraw<XUS.XUS>(move(ref0), 1000000000000);
         DiemAccount.deposit<XUS.XUS>(move(addr), move(new_money));

--- a/language/ir-testsuite/tests/move/natives/vector/vector_module.mvir
+++ b/language/ir-testsuite/tests/move/natives/vector/vector_module.mvir
@@ -1,0 +1,60 @@
+module {{default}}.M {
+import 0x1.XUS;
+    import 0x1.Diem;
+    import 0x1.Vector;
+    import 0x1.Signer;
+    struct Coins has key { f: vector<Diem.Diem<XUS.XUS>> }
+
+    public new(account: &signer) {
+        let coin_vec: vector<Diem.Diem<XUS.XUS>>;
+        let coins: Self.Coins;
+        coin_vec = Vector.empty<Diem.Diem<XUS.XUS>>();
+        coins = Coins { f: move(coin_vec)};
+
+        move_to<Coins>(move(account), move(coins));
+        return;
+    }
+
+    public put_coin(account: &signer, coin: Diem.Diem<XUS.XUS>) acquires Coins {
+        let coins_ref: &mut Self.Coins;
+        let v_ref: &mut vector<Diem.Diem<XUS.XUS>>;
+
+        coins_ref = borrow_global_mut<Coins>(Signer.address_of(move(account)));
+        v_ref = &mut move(coins_ref).Coins::f;
+        Vector.push_back<Diem.Diem<XUS.XUS>>(move(v_ref), move(coin));
+        return;
+    }
+
+    public get_value(account: &signer, i: u64): u64 acquires Coins {
+        let coins_ref: &Self.Coins;
+        let v_ref: &vector<Diem.Diem<XUS.XUS>>;
+        let coin_ref: &Diem.Diem<XUS.XUS>;
+
+        coins_ref = borrow_global<Coins>(Signer.address_of(move(account)));
+        v_ref = &move(coins_ref).Coins::f;
+        coin_ref = Vector.borrow<Diem.Diem<XUS.XUS>>(move(v_ref), move(i));
+
+        return Diem.value<XUS.XUS>(move(coin_ref));
+    }
+
+    public pop(account: &signer): Diem.Diem<XUS.XUS> acquires Coins {
+        let coins_ref: &mut Self.Coins;
+        let v_ref: &mut vector<Diem.Diem<XUS.XUS>>;
+
+        coins_ref = borrow_global_mut<Coins>(Signer.address_of(move(account)));
+        v_ref = &mut move(coins_ref).Coins::f;
+        return Vector.pop_back<Diem.Diem<XUS.XUS>>(move(v_ref));
+    }
+}
+
+//! new-transaction
+import {{default}}.M;
+import 0x1.XUS;
+import 0x1.Diem;
+
+main(account: signer) {
+    M.new(&account);
+    M.put_coin(&account, Diem.zero<XUS.XUS>());
+
+    return;
+}

--- a/language/ir-testsuite/tests/move/prover/parser/conditions.mvir
+++ b/language/ir-testsuite/tests/move/prover/parser/conditions.mvir
@@ -246,7 +246,7 @@ module {{default}}.TestBinaryOps {
   public ret_access_path_exp(p: &Self.Pair): u64
   ensures RET == p.x + p.y
   {
-      return *&copy(p).x + *&move(p).y;
+      return *&copy(p).Pair::y;
   }
 
   public ret_implies(x: u64): u64

--- a/language/ir-testsuite/tests/move/publish/publish_module_and_use.mvir
+++ b/language/ir-testsuite/tests/move/publish/publish_module_and_use.mvir
@@ -1,0 +1,47 @@
+module {{default}}.MoneyHolder {
+        import 0x1.XUS;
+        import 0x1.Diem;
+
+        struct T { money: Diem.Diem<XUS.XUS> }
+
+        public new(m: Diem.Diem<XUS.XUS>): Self.T {
+            return T{ money: move(m) };
+        }
+
+        public value(this :&Self.T): u64 {
+            let ref: &Diem.Diem<XUS.XUS>;
+            let val: u64;
+            ref = &copy(this).T::money;
+            val = Diem.value<XUS.XUS>(move(ref));
+            _ = move(this);
+            return move(val);
+        }
+
+        public destroy_t(t: Self.T) {
+            let money: Diem.Diem<XUS.XUS>;
+            T{ money } = move(t);
+            Diem.destroy_zero<XUS.XUS>(move(money));
+            return;
+        }
+}
+
+//! new-transaction
+
+import {{default}}.MoneyHolder;
+import 0x1.XUS;
+import 0x1.Diem;
+
+main() {
+    let coin: Diem.Diem<XUS.XUS>;
+    let money_holder: MoneyHolder.T;
+    let money_holder_ref: &MoneyHolder.T;
+    let value: u64;
+    coin = Diem.zero<XUS.XUS>();
+    money_holder = MoneyHolder.new(move(coin));
+    money_holder_ref = &money_holder;
+    value = MoneyHolder.value(move(money_holder_ref));
+    assert(copy(value) == 0, 42);
+    MoneyHolder.destroy_t(move(money_holder));
+
+    return;
+}

--- a/language/ir-testsuite/tests/move/publish/publish_two_modules.mvir
+++ b/language/ir-testsuite/tests/move/publish/publish_two_modules.mvir
@@ -1,0 +1,73 @@
+module {{default}}.MoneyHolder {
+        import 0x1.XUS;
+        import 0x1.Diem;
+
+        struct T { money: Diem.Diem<XUS.XUS> }
+
+        public new(m: Diem.Diem<XUS.XUS>): Self.T {
+            return T{ money: move(m) };
+        }
+
+        public value(this :&Self.T): u64 {
+            let ref: &Diem.Diem<XUS.XUS>;
+            let val: u64;
+            ref = &copy(this).T::money;
+            val = Diem.value<XUS.XUS>(move(ref));
+            _ = move(this);
+            return move(val);
+        }
+
+        public destroy_t(t: Self.T) {
+            let money: Diem.Diem<XUS.XUS>;
+            T{ money } = move(t);
+            Diem.destroy_zero<XUS.XUS>(move(money));
+            return;
+        }
+}
+
+//! new-transaction
+
+module {{default}}.Bar {
+        struct T has drop {baz: u64}
+        public new(m: u64): Self.T {
+            return T{baz: move(m)};
+        }
+        public value(this: &Self.T): u64 {
+            let ref: &u64;
+            ref = &move(this).T::baz;
+            return *move(ref);
+        }
+}
+
+//! new-transaction
+
+import {{default}}.MoneyHolder;
+import {{default}}.Bar;
+import 0x1.XUS;
+import 0x1.Diem;
+
+main() {
+    let coin: Diem.Diem<XUS.XUS>;
+    let money_holder: MoneyHolder.T;
+    let money_holder_ref: &MoneyHolder.T;
+    let value: u64;
+    let v: u64;
+    let bar: Bar.T;
+    let bar_ref: &Bar.T;
+    let v2: u64;
+
+    coin = Diem.zero<XUS.XUS>();
+    money_holder = MoneyHolder.new(move(coin));
+    money_holder_ref = &money_holder;
+
+    value = MoneyHolder.value(move(money_holder_ref));
+    assert(copy(value) == 0, 42);
+    MoneyHolder.destroy_t(move(money_holder));
+
+    v = 1;
+    bar = Bar.new(copy(v));
+    bar_ref = &bar;
+    v2 = Bar.value(move(bar_ref));
+    assert(copy(v) == copy(v2), 42);
+    return;
+}

--- a/language/move-ir/types/src/ast.rs
+++ b/language/move-ir/types/src/ast.rs
@@ -214,6 +214,25 @@ pub struct Field_(pub Symbol);
 /// A field coupled with source location information
 pub type Field = Spanned<Field_>;
 
+/// A fully-qualified field identifier.
+///
+/// Rather than simply referring to a field 'f' with a single identifier and
+/// relying on type inference to determine the type of the struct being
+/// accessed, this type refers to the field 'f' on the explicit struct type
+/// 'S<T>' -- that is, 'S<T>::f'.
+#[derive(Clone, Debug, PartialEq)]
+pub struct FieldIdent_ {
+    /// The name of the struct type on which the field is declared.
+    pub struct_name: StructName,
+    /// For generic struct types, the type parameters used to instantiate the
+    /// struct type (this is an empty vector for non-generic struct types).
+    pub type_actuals: Vec<Type>,
+    /// The name of the field.
+    pub field: Field,
+}
+
+pub type FieldIdent = Spanned<FieldIdent_>;
+
 /// A field map
 pub type Fields<T> = Vec<(Field, T)>;
 
@@ -619,7 +638,7 @@ pub enum Exp_ {
         /// the expression containing the reference
         exp: Box<Exp>,
         /// the field being borrowed
-        field: Field_,
+        field: FieldIdent,
     },
     /// `move(x)`
     Move(Var),
@@ -1098,7 +1117,7 @@ impl Exp_ {
     }
 
     /// Creates a new borrow field `Exp` with no location information
-    pub fn borrow(is_mutable: bool, exp: Box<Exp>, field: Field_) -> Exp {
+    pub fn borrow(is_mutable: bool, exp: Box<Exp>, field: FieldIdent) -> Exp {
         Spanned::unsafe_no_loc(Exp_::Borrow {
             is_mutable,
             exp,
@@ -1351,6 +1370,12 @@ impl fmt::Display for Function_ {
 impl fmt::Display for Field_ {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+impl fmt::Display for FieldIdent_ {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}::{}", self.struct_name, self.field)
     }
 }
 

--- a/language/move-vm/transactional-tests/tests/builtins/gen_move_to.mvir
+++ b/language/move-vm/transactional-tests/tests/builtins/gen_move_to.mvir
@@ -22,7 +22,7 @@ module 0x1.M {
 
     // change the elem of a `Container<T>` if T is copyable
     public change_container<T: copy + drop>(c: &mut Self.Container<T>, t: T) {
-        *&mut move(c).elem = move(t);
+        *&mut move(c).Container<T>::elem = move(t);
         return;
     }
 
@@ -40,7 +40,7 @@ module 0x1.M {
 
     // change the `val` in a `Value` instance
     public change_value(value: &mut Self.Value, val: u64) {
-        *&mut move(value).val = move(val);
+        *&mut move(value).Value::val = move(val);
         return;
     }
 
@@ -114,7 +114,7 @@ module 0x1.M {
         let equal: bool;
         sender = Signer.address_of(move(account));
         some = borrow_global<Some<T>>(move(sender));
-        inner_ref = &move(some).v;
+        inner_ref = &move(some).Some<T>::v;
         val_ref = &val;
         equal = (move(inner_ref) == move(val_ref));
         return move(val), move(equal);
@@ -126,7 +126,7 @@ module 0x1.M {
         let some: &mut Self.Some<T>;
         sender = Signer.address_of(move(account));
         some = borrow_global_mut<Some<T>>(move(sender));
-        *(&mut move(some).v) = move(val);
+        *(&mut move(some).Some<T>::v) = move(val);
         return;
     }
 

--- a/language/move-vm/transactional-tests/tests/builtins/get_published_resource.mvir
+++ b/language/move-vm/transactional-tests/tests/builtins/get_published_resource.mvir
@@ -10,7 +10,7 @@ module 0x1.Token {
 
     public value(this: &Self.T): u64 {
         let vref: &u64;
-        vref = &copy(this).v;
+        vref = &copy(this).T::v;
         _ = move(this);
         return *move(vref);
     }

--- a/language/move-vm/transactional-tests/tests/builtins/move_published_resource.mvir
+++ b/language/move-vm/transactional-tests/tests/builtins/move_published_resource.mvir
@@ -20,7 +20,7 @@ module 0x42.TestMoveFrom {
 
       sender_address = Signer.address_of(move(account));
       t_ref = borrow_global_mut<Counter>(move(sender_address));
-      counter_ref = &mut copy(t_ref).i;
+      counter_ref = &mut copy(t_ref).Counter::i;
       _ = move(t_ref);
       *move(counter_ref) = *copy(counter_ref) + 1;
 

--- a/language/move-vm/transactional-tests/tests/builtins/read_and_dont_write_to_global_storage.mvir
+++ b/language/move-vm/transactional-tests/tests/builtins/read_and_dont_write_to_global_storage.mvir
@@ -19,11 +19,11 @@ module 0x42.Test {
         let t_ref: &Self.T;
 
         t_ref = borrow_global<T>(move(addr));
-        return *&move(t_ref).config;
+        return *&move(t_ref).T::config;
     }
 
     public value(config: &Self.Config): bool {
-        return *&move(config).b;
+        return *&move(config).Config::b;
     }
 
     public set(account: &signer, b: bool) acquires T {
@@ -32,8 +32,8 @@ module 0x42.Test {
         let b_ref: &mut bool;
 
         t_ref = borrow_global_mut<T>(Signer.address_of(move(account)));
-        config_ref = &mut move(t_ref).config;
-        b_ref = &mut move(config_ref).b;
+        config_ref = &mut move(t_ref).T::config;
+        b_ref = &mut move(config_ref).Config::b;
         *move(b_ref) = move(b);
 
         return;

--- a/language/move-vm/transactional-tests/tests/builtins/resources_are_distinct_by_published_account.mvir
+++ b/language/move-vm/transactional-tests/tests/builtins/resources_are_distinct_by_published_account.mvir
@@ -11,7 +11,7 @@ module 0x42.Account {
 
     public sequence_number(this: &Self.T): u64 {
         let ref: &u64;
-        ref = &copy(this).sequence_number;
+        ref = &copy(this).T::sequence_number;
         _ = move(this);
         return *move(ref);
     }

--- a/language/move-vm/transactional-tests/tests/builtins/signer_runtime_move_to.mvir
+++ b/language/move-vm/transactional-tests/tests/builtins/signer_runtime_move_to.mvir
@@ -16,11 +16,11 @@ module 0x42.M {
     }
 
     public read(s: &signer): bool acquires R1 {
-        return *&(borrow_global<R1>(Signer.address_of(move(s)))).f;
+        return *&(borrow_global<R1>(Signer.address_of(move(s)))).R1::f;
     }
 
     public read_gen<T: copy + drop + store>(s: &signer): T acquires R2 {
-        return *&(borrow_global<R2<T>>(Signer.address_of(move(s)))).f;
+        return *&(borrow_global<R2<T>>(Signer.address_of(move(s)))).R2<T>::f; // problem is here
     }
 }
 

--- a/language/move-vm/transactional-tests/tests/builtins/struct_borrow_and_modify.mvir
+++ b/language/move-vm/transactional-tests/tests/builtins/struct_borrow_and_modify.mvir
@@ -9,22 +9,22 @@ module 0x1.M {
     }
 
     public modify_x(addr: address) acquires R {
-        *&mut borrow_global_mut<R>(move(addr)).x = true;
+        *&mut borrow_global_mut<R>(move(addr)).R::x = true;
         return;
     }
 
     public verify_x(addr: address) acquires R {
-        assert(*&borrow_global<R>(move(addr)).x == true, 1000);
+        assert(*&borrow_global<R>(move(addr)).R::x == true, 1000);
         return;
     }
 
     public modify_y_x(addr: address) acquires R {
-        *&mut (&mut borrow_global_mut<R>(move(addr)).y).x = 42;
+        *&mut ((&mut borrow_global_mut<R>(move(addr)).R::y)).Y::x = 42;
         return;
     }
 
     public verify_y_x(addr: address) acquires R {
-        assert(*&(&borrow_global<R>(move(addr)).y).x == 42, 1001);
+        assert(*&(&borrow_global<R>(move(addr)).R::y).Y::x == 42, 1001);
         return;
     }
 }

--- a/language/move-vm/transactional-tests/tests/builtins/vec_borrow_and_modify.mvir
+++ b/language/move-vm/transactional-tests/tests/builtins/vec_borrow_and_modify.mvir
@@ -14,12 +14,12 @@ module 0x1.M {
     }
 
     public borrow_and_modify(addr: address) acquires R {
-        *Vector.borrow_mut<u64>(&mut borrow_global_mut<R>(move(addr)).v, 0) = 300;
+        *Vector.borrow_mut<u64>(&mut borrow_global_mut<R>(move(addr)).R::v, 0) = 300;
         return;
     }
 
     public verify_effects(addr: address) acquires R {
-        assert(*Vector.borrow<u64>(&borrow_global<R>(move(addr)).v, 0) == 300, 1000);
+        assert(*Vector.borrow<u64>(&borrow_global<R>(move(addr)).R::v, 0) == 300, 1000);
         return;
     }
 }

--- a/language/move-vm/transactional-tests/tests/builtins/vec_pop.mvir
+++ b/language/move-vm/transactional-tests/tests/builtins/vec_pop.mvir
@@ -14,12 +14,12 @@ module 0x1.M {
     }
 
     public borrow_and_pop(addr: address) acquires R {
-        assert(Vector.pop_back<u64>(&mut borrow_global_mut<R>(move(addr)).v) == 200, 1000);
+        assert(Vector.pop_back<u64>(&mut borrow_global_mut<R>(move(addr)).R::v) == 200, 1000);
         return;
     }
 
     public verify_effects(addr: address) acquires R {
-        assert(Vector.length<u64>(&borrow_global<R>(move(addr)).v) == 1, 1001);
+        assert(Vector.length<u64>(&borrow_global<R>(move(addr)).R::v) == 1, 1001);
         return;
     }
 }

--- a/language/move-vm/transactional-tests/tests/builtins/vec_push.mvir
+++ b/language/move-vm/transactional-tests/tests/builtins/vec_push.mvir
@@ -12,14 +12,14 @@ module 0x1.M {
     public borrow_and_push(addr: address) acquires R {
         let r: &mut Self.R;
         r = borrow_global_mut<R>(move(addr));
-        Vector.push_back<u64>(&mut move(r).v, 42);
+        Vector.push_back<u64>(&mut move(r).R::v, 42);
         return;
     }
 
     public verify_effects(addr: address) acquires R {
         let r: &Self.R;
         r = borrow_global<R>(move(addr));
-        assert(Vector.length<u64>(& move(r).v) == 1, 1000);
+        assert(Vector.length<u64>(& move(r).R::v) == 1, 1000);
         return;
     }
 }

--- a/language/move-vm/transactional-tests/tests/builtins/vec_swap.mvir
+++ b/language/move-vm/transactional-tests/tests/builtins/vec_swap.mvir
@@ -16,13 +16,13 @@ module 0x1.M {
     public borrow_and_swap(addr: address) acquires R {
         let r: &mut Self.R;
         r = borrow_global_mut<R>(move(addr));
-        Vector.swap<u64>(&mut move(r).v, 0, 1);
+        Vector.swap<u64>(&mut move(r).R::v, 0, 1);
         return;
     }
 
     public verify_effects(addr: address) acquires R {
         let v: &vector<u64>;
-        v = & borrow_global<R>(move(addr)).v;
+        v = & borrow_global<R>(move(addr)).R::v;
         assert(*Vector.borrow<u64>(copy(v), 0) == 200, 1000);
         assert(*Vector.borrow<u64>(move(v), 1) == 100, 1001);
         return;

--- a/language/move-vm/transactional-tests/tests/builtins/vector_ops_borrow_and_modify_ok.mvir
+++ b/language/move-vm/transactional-tests/tests/builtins/vector_ops_borrow_and_modify_ok.mvir
@@ -14,7 +14,7 @@ module 0x1.M {
         let r: &mut Self.R;
         let v: &mut vector<u64>;
         r = borrow_global_mut<R>(move(addr));
-        v = &mut move(r).v;
+        v = &mut move(r).R::v;
         *vec_mut_borrow<u64>(move(v), 0) = 300;
         return;
     }
@@ -23,7 +23,7 @@ module 0x1.M {
         let r: &Self.R;
         let v: &vector<u64>;
         r = borrow_global<R>(move(addr));
-        v = &move(r).v;
+        v = &move(r).R::v;
         assert(*vec_imm_borrow<u64>(move(v), 0) == 300, 1000);
         return;
     }

--- a/language/move-vm/transactional-tests/tests/entry_points/script_type_arg_kind_mismatch_1.mvir
+++ b/language/move-vm/transactional-tests/tests/entry_points/script_type_arg_kind_mismatch_1.mvir
@@ -2,7 +2,7 @@
 module 0x1.Coin {
     struct Coin { value: u64 }
     public value(c: &Self.Coin): u64 {
-        return *&move(c).value;
+        return *&move(c).Coin::value;
     }
     public zero(): Self.Coin {
         return Coin { value: 0 };

--- a/language/move-vm/transactional-tests/tests/example_programs/coin_wrapper.mvir
+++ b/language/move-vm/transactional-tests/tests/example_programs/coin_wrapper.mvir
@@ -7,7 +7,7 @@ module 0x1.Coin {
     }
 
     public value<CoinType>(c: &Self.Coin<CoinType>): u64 {
-        return *&move(c).value;
+        return *&move(c).Coin<CoinType>::value;
     }
 
     public destroy_zero<CoinType>(c: Self.Coin<CoinType>) {
@@ -65,8 +65,8 @@ module 0x1.M {
 
         sender = Signer.address_of(copy(account));
         coin_wrapper_ref = borrow_global<CoinWrapper>(move(sender));
-        foo_ref = &move(coin_wrapper_ref).f;
-        coin_ref = &move(foo_ref).x;
+        foo_ref = &move(coin_wrapper_ref).CoinWrapper::f;
+        coin_ref = &move(foo_ref).Foo<Coin.Coin<YYZ.YYZ>>::x;
 
         return Coin.value<YYZ.YYZ>(move(coin_ref));
     }
@@ -79,10 +79,10 @@ module 0x1.M {
 
         sender = Signer.address_of(copy(account));
         inner_wrapper_ref = borrow_global<InnerWrapper>(move(sender));
-        foo_ref = &move(inner_wrapper_ref).f;
-        inner_ref = &move(foo_ref).x;
+        foo_ref = &move(inner_wrapper_ref).InnerWrapper::f;
+        inner_ref = &move(foo_ref).Foo<Self.Inner>::x;
 
-        return *(&move(inner_ref).b);
+        return *(&move(inner_ref).Inner::b);
     }
 
 

--- a/language/move-vm/transactional-tests/tests/example_programs/sorted-linked-list.mvir
+++ b/language/move-vm/transactional-tests/tests/example_programs/sorted-linked-list.mvir
@@ -26,7 +26,7 @@ module 0x1.SortedLinkedList
         assert(exists<Node>(copy(node_address)), 20);
 
         node_ref = borrow_global<Node>(move(node_address));
-        result = *&move(node_ref).value;
+        result = *&move(node_ref).Node::value;
 
         return move(result);
     }
@@ -43,7 +43,7 @@ module 0x1.SortedLinkedList
 
         //find the head node
 		current_node_ref = borrow_global<Node>(copy(current_node_address));
-        head_node_address = *&move(current_node_ref).head;
+        head_node_address = *&move(current_node_ref).Node::head;
 
         //check if this is the head node
         result = (move(head_node_address) == move(current_node_address));
@@ -101,13 +101,13 @@ module 0x1.SortedLinkedList
 
         //get a reference to prev_node and find the address and reference to next_node, head
         prev_node_ref = borrow_global<Node>(copy(prev_node_address));
-        next_node_address = *&copy(prev_node_ref).next;
+        next_node_address = *&copy(prev_node_ref).Node::next;
         next_node_ref = borrow_global<Node>(copy(next_node_address));
-        head_address = *&copy(next_node_ref).head;
+        head_address = *&copy(next_node_ref).Node::head;
 
         //see if either prev or next are the head and get their values
-        prev_value = *&move(prev_node_ref).value;
-        next_value = *&move(next_node_ref).value;
+        prev_value = *&move(prev_node_ref).Node::value;
+        next_value = *&move(next_node_ref).Node::value;
         prev_is_head = Self.is_head_node(copy(prev_node_address));
         next_is_head = Self.is_head_node(copy(next_node_address));
 
@@ -126,11 +126,11 @@ module 0x1.SortedLinkedList
 
         //fix the pointers at prev
         prev_node_mut_ref = borrow_global_mut<Node>(move(prev_node_address));
-        *&mut move(prev_node_mut_ref).next = copy(sender_address);
+        *&mut move(prev_node_mut_ref).Node::next = copy(sender_address);
 
         //fix the pointers at next
         next_node_mut_ref = borrow_global_mut<Node>(move(next_node_address));
-        *&mut move(next_node_mut_ref).prev = copy(sender_address);
+        *&mut move(next_node_mut_ref).Node::prev = copy(sender_address);
 
         return;
     }
@@ -155,8 +155,8 @@ module 0x1.SortedLinkedList
         current_node_ref = borrow_global<Node>(copy(sender_address));
 
         //check that the list is empty
-        next_node_address = *&copy(current_node_ref).next;
-        prev_node_address = *&move(current_node_ref).prev;
+        next_node_address = *&copy(current_node_ref).Node::next;
+        prev_node_address = *&move(current_node_ref).Node::prev;
         assert(move(next_node_address) == copy(sender_address), 9);
         assert(move(prev_node_address) == copy(sender_address), 10);
 
@@ -199,7 +199,7 @@ module 0x1.SortedLinkedList
 
         //make sure the caller owns the list
         node_ref = borrow_global<Node>(copy(node_address));
-        list_owner = *&move(node_ref).head;
+        list_owner = *&move(node_ref).Node::head;
         assert(move(list_owner) == Signer.address_of(move(account)), 15);
 
         //remove it
@@ -224,17 +224,17 @@ module 0x1.SortedLinkedList
 
         //find prev and next
         current_node_ref = borrow_global<Node>(copy(node_address));
-        next_node_address = *&copy(current_node_ref).next;
-        prev_node_address = *&move(current_node_ref).prev;
+        next_node_address = *&copy(current_node_ref).Node::next;
+        prev_node_address = *&move(current_node_ref).Node::prev;
 
 
         //update next
         next_node_mut_ref = borrow_global_mut<Node>(copy(next_node_address));
-        *&mut move(next_node_mut_ref).prev = copy(prev_node_address);
+        *&mut move(next_node_mut_ref).Node::prev = copy(prev_node_address);
 
         //update prev
         prev_node_mut_ref = borrow_global_mut<Node>(move(prev_node_address));
-        *&mut move(prev_node_mut_ref).next = move(next_node_address);
+        *&mut move(prev_node_mut_ref).Node::next = move(next_node_address);
 
         //destroy the current node
         Node {temp_address,temp_address,temp_address,temp_value} = move_from<Node>(move(node_address));

--- a/language/move-vm/transactional-tests/tests/instructions/assign_struct_field.mvir
+++ b/language/move-vm/transactional-tests/tests/instructions/assign_struct_field.mvir
@@ -8,14 +8,14 @@ module 0x42.Tester {
 
     public update(t: &mut Self.T) {
         let vref: &mut u64;
-        vref = &mut move(t).v;
+        vref = &mut move(t).T::v;
         *move(vref) = 1;
         return;
     }
 
     public vref(this: &mut Self.T): &u64 {
         let r: &u64;
-        r = &copy(this).v;
+        r = &copy(this).T::v;
         _ = move(this);
         return move(r);
     }

--- a/language/move-vm/transactional-tests/tests/instructions/deref_value.mvir
+++ b/language/move-vm/transactional-tests/tests/instructions/deref_value.mvir
@@ -9,7 +9,7 @@ module 0x1.A {
     public t(this: &Self.T) {
       let f: &u64;
       let y: u64;
-      f = &copy(this).f;
+      f = &copy(this).T::f;
       y = *move(f);
       assert(copy(y) == 2, 42);
       _ = move(this);

--- a/language/move-vm/transactional-tests/tests/instructions/deref_value_nested.mvir
+++ b/language/move-vm/transactional-tests/tests/instructions/deref_value_nested.mvir
@@ -9,7 +9,7 @@ module 0x1.B {
     public t(this: &Self.T) {
         let g: &u64;
         let y: u64;
-        g = &move(this).g;
+        g = &move(this).T::g;
         y = *move(g);
         assert(copy(y) == 2, 42);
         return;
@@ -28,7 +28,7 @@ module 0x1.A {
 
     public t(this: &Self.T) {
         let f: &B.T;
-        f = &move(this).f;
+        f = &move(this).T::f;
         B.t(move(f));
         return;
     }

--- a/language/move-vm/transactional-tests/tests/instructions/equality_reference_value.mvir
+++ b/language/move-vm/transactional-tests/tests/instructions/equality_reference_value.mvir
@@ -13,7 +13,7 @@ module 0x1.Token {
         move_to<T>(copy(account), T { count: 0 });
         sender = Signer.address_of(move(account));
         t_ref = borrow_global_mut<T>(move(sender));
-        count_ref = &mut move(t_ref).count;
+        count_ref = &mut move(t_ref).T::count;
         local = 0;
         local_ref = &mut local;
         // make sure refs are equal even if one is in global storage and one is local

--- a/language/move-vm/transactional-tests/tests/instructions/field_reads.mvir
+++ b/language/move-vm/transactional-tests/tests/instructions/field_reads.mvir
@@ -8,21 +8,21 @@ module 0x42.VTest {
 
     public t1(this: &Self.T): u64 {
         let x: &u64;
-        x = &copy(this).fint;
+        x = &copy(this).T::fint;
         _ = move(this);
         return *move(x);
     }
 
     public t2(this: &Self.T): u64 {
         let x: &u64;
-        x = &copy(this).fint;
+        x = &copy(this).T::fint;
         _ = move(this);
         return *move(x);
     }
 
     public t3(this: &Self.T): bool {
         let x: &bool;
-        x = &copy(this).fv;
+        x = &copy(this).T::fv;
         _ = move(this);
         return *move(x);
     }
@@ -39,21 +39,21 @@ module 0x42.RTest {
 
     public t1(this: &Self.T): u64 {
         let x: &u64;
-        x = &copy(this).fint;
+        x = &copy(this).T::fint;
         _ = move(this);
         return *move(x);
     }
 
     public t2(this: &Self.T): u64 {
         let x: &u64;
-        x = &copy(this).fint;
+        x = &copy(this).T::fint;
         _ = move(this);
         return *move(x);
     }
 
     public t3(this: &Self.T): bool {
         let x: &bool;
-        x = &copy(this).fv;
+        x = &copy(this).T::fv;
         _ = move(this);
         return *move(x);
     }

--- a/language/move-vm/transactional-tests/tests/instructions/field_writes.mvir
+++ b/language/move-vm/transactional-tests/tests/instructions/field_writes.mvir
@@ -8,28 +8,28 @@ module 0x42.VTest {
 
     public t1(this: &mut Self.T) {
         let x: &mut u64;
-        x = &mut move(this).fint;
+        x = &mut move(this).T::fint;
         *move(x) = 0;
         return;
     }
 
     public t2(this: &mut Self.T, i: u64) {
         let x: &mut u64;
-        x = &mut move(this).fint;
+        x = &mut move(this).T::fint;
         *move(x) = move(i);
         return;
     }
 
     public t3(this: &mut Self.T) {
         let x: &mut bool;
-        x = &mut move(this).fv;
+        x = &mut move(this).T::fv;
         *move(x) = *copy(x);
         return;
     }
 
     public t4(this: &mut Self.T, i: bool) {
         let x: &mut bool;
-        x = &mut move(this).fv;
+        x = &mut move(this).T::fv;
         *move(x) = move(i);
         return;
     }
@@ -46,14 +46,14 @@ module 0x42.RTest {
 
     public t1(this: &mut Self.T) {
         let x: &mut u64;
-        x = &mut move(this).fint;
+        x = &mut move(this).T::fint;
         *move(x) = 0;
         return;
     }
 
     public t2(this: &mut Self.T, i: u64) {
         let x: &mut u64;
-        x = &mut move(this).fint;
+        x = &mut move(this).T::fint;
         *move(x) = move(i);
         return;
     }
@@ -61,7 +61,7 @@ module 0x42.RTest {
     public t3(this: &mut Self.T) {
         let x: &mut bool;
         let z: bool;
-        x = &mut move(this).fr;
+        x = &mut move(this).T::fr;
         z = true;
         *move(x) = move(z);
         return;
@@ -69,7 +69,7 @@ module 0x42.RTest {
 
     public t4(this: &mut Self.T, i: bool) {
         let x: &mut bool;
-        x = &mut move(this).fr;
+        x = &mut move(this).T::fr;
         *move(x) = move(i);
         return;
     }

--- a/language/move-vm/transactional-tests/tests/instructions/vec_copy_nested.mvir
+++ b/language/move-vm/transactional-tests/tests/instructions/vec_copy_nested.mvir
@@ -13,14 +13,14 @@ module 0x42.DeepCopy {
         c2 = copy(c1);
 
         // mutate c1.i to 1
-        *(&mut (&mut c1).i) = 1;
+        *(&mut (&mut c1).Config::i) = 1;
         // c2.i should still be 0
-        assert(*&(&c2).i == 0, 77);
+        assert(*&(&c2).Config::i == 0, 77);
 
         // mutate c2.i to 2
-        *(&mut (&mut c2).i) = 2;
+        *(&mut (&mut c2).Config::i) = 2;
         // c1.i should still be 1
-        assert(*&(&c1).i == 1, 78);
+        assert(*&(&c1).Config::i == 1, 78);
 
         return;
     }
@@ -33,18 +33,18 @@ module 0x42.DeepCopy {
         n2 = copy(n1);
 
         // mutate n1.c.i to 1
-        *(&mut (&mut (&mut n1).c).i) = 1;
+        *(&mut (&mut (&mut n1).Nested::c).Config::i) = 1;
         // n2.c.i should still be 0
-        assert(*&(&(&n2).c).i == 0, 79);
+        assert(*&(&(&n2).Nested::c).Config::i == 0, 79);
         // n1.c.i is 1
-        assert(*&(&(&n1).c).i == 1, 80);
+        assert(*&(&(&n1).Nested::c).Config::i == 1, 80);
 
         // mutate n2.c.i to 2
-        *(&mut (&mut (&mut n2).c).i) = 2;
+        *(&mut (&mut (&mut n2).Nested::c).Config::i) = 2;
         // n1.c.i should still be 1
-        assert(*&(&(&n1).c).i == 1, 81);
+        assert(*&(&(&n1).Nested::c).Config::i == 1, 81);
         // n2.c.i is 2
-        assert(*&(&(&n2).c).i == 2, 82);
+        assert(*&(&(&n2).Nested::c).Config::i == 2, 82);
 
         return;
     }
@@ -76,7 +76,7 @@ module 0x42.DeepCopy {
 
         c1 = Config { i: 0 };
         c2 = copy(c1);
-        *(&mut (&mut c2).i) = 1;
+        *(&mut (&mut c2).Config::i) = 1;
 
         v1 = Vector.empty<Self.Config>();
         Vector.push_back<Self.Config>(&mut v1, move(c1));
@@ -85,13 +85,13 @@ module 0x42.DeepCopy {
 
         r1 = Vector.borrow_mut<Self.Config>(&mut v1, 0);
         r2 = Vector.borrow_mut<Self.Config>(&mut v2, 0);
-        assert(*&copy(r1).i == 0, 90);
-        assert(*&copy(r1).i == *&move(r2).i, 91);
+        assert(*&copy(r1).Config::i == 0, 90);
+        assert(*&copy(r1).Config::i == *&move(r2).Config::i, 91);
         r2 = Vector.borrow_mut<Self.Config>(&mut v2, 1);
-        assert(*&copy(r2).i == 1, 91);
-        assert(*&copy(r1).i != *&copy(r2).i, 91);
-        *&mut copy(r1).i = 1;
-        assert(*&copy(r1).i == *&copy(r2).i, 92);
+        assert(*&copy(r2).Config::i == 1, 91);
+        assert(*&copy(r1).Config::i != *&copy(r2).Config::i, 91);
+        *&mut copy(r1).Config::i = 1;
+        assert(*&copy(r1).Config::i == *&copy(r2).Config::i, 92);
 
         return;
     }

--- a/language/move-vm/transactional-tests/tests/module_publishing/publish_module_and_use.mvir
+++ b/language/move-vm/transactional-tests/tests/module_publishing/publish_module_and_use.mvir
@@ -2,7 +2,7 @@
 module 0x1.Coin {
     struct Coin { value: u64 }
     public value(c: &Self.Coin): u64 {
-        return *&move(c).value;
+        return *&move(c).Coin::value;
     }
     public zero(): Self.Coin {
         return Coin { value: 0 };
@@ -27,7 +27,7 @@ module 0x42.MoneyHolder {
     public value(this :&Self.T): u64 {
         let ref: &Coin.Coin;
         let val: u64;
-        ref = &copy(this).money;
+        ref = &copy(this).T::money;
         val = Coin.value(move(ref));
         _ = move(this);
         return move(val);

--- a/language/move-vm/transactional-tests/tests/module_publishing/publish_two_modules.mvir
+++ b/language/move-vm/transactional-tests/tests/module_publishing/publish_two_modules.mvir
@@ -2,7 +2,7 @@
 module 0x1.Coin {
     struct Coin { value: u64 }
     public value(c: &Self.Coin): u64 {
-        return *&move(c).value;
+        return *&move(c).Coin::value;
     }
     public zero(): Self.Coin {
         return Coin { value: 0 };
@@ -27,7 +27,7 @@ module 0x42.MoneyHolder {
     public value(this :&Self.T): u64 {
         let ref: &Coin.Coin;
         let val: u64;
-        ref = &copy(this).money;
+        ref = &copy(this).T::money;
         val = Coin.value(move(ref));
         _ = move(this);
         return move(val);
@@ -49,7 +49,7 @@ module 0x42.Bar {
         }
         public value(this: &Self.T): u64 {
             let ref: &u64;
-            ref = &move(this).baz;
+            ref = &move(this).T::baz;
             return *move(ref);
         }
 }

--- a/language/move-vm/transactional-tests/tests/native_functions/vector_module.mvir
+++ b/language/move-vm/transactional-tests/tests/native_functions/vector_module.mvir
@@ -2,7 +2,7 @@
 module 0x1.Coin {
     struct Coin has store { value: u64 }
     public value(c: &Self.Coin): u64 {
-        return *&move(c).value;
+        return *&move(c).Coin::value;
     }
     public zero(): Self.Coin {
         return Coin { value: 0 };
@@ -31,7 +31,7 @@ module 0x42.M {
         let v_ref: &mut vector<Coin.Coin>;
 
         coins_ref = borrow_global_mut<Coins>(Signer.address_of(move(account)));
-        v_ref = &mut move(coins_ref).f;
+        v_ref = &mut move(coins_ref).Coins::f;
         Vector.push_back<Coin.Coin>(move(v_ref), move(coin));
         return;
     }
@@ -42,7 +42,7 @@ module 0x42.M {
         let coin_ref: &Coin.Coin;
 
         coins_ref = borrow_global<Coins>(Signer.address_of(move(account)));
-        v_ref = &move(coins_ref).f;
+        v_ref = &move(coins_ref).Coins::f;
         coin_ref = Vector.borrow<Coin.Coin>(move(v_ref), move(i));
 
         return Coin.value(move(coin_ref));
@@ -53,7 +53,7 @@ module 0x42.M {
         let v_ref: &mut vector<Coin.Coin>;
 
         coins_ref = borrow_global_mut<Coins>(Signer.address_of(move(account)));
-        v_ref = &mut move(coins_ref).f;
+        v_ref = &mut move(coins_ref).Coins::f;
         return Vector.pop_back<Coin.Coin>(move(v_ref));
     }
 }


### PR DESCRIPTION
Simplify the Move IR language and compiler by eliminating the need to keep track of the types of expressions.

For the most part, this requires no change to the language, except for one aspect: when struct fields are borrowed, the user must now explicitly specify which struct type is being accessed. This is because, for example, a simple field identifier `f` may refer to different fields in any number of different structs `S1`, `S2`, etc.

# What's in this pull request?

* The file count is large because this includes test changes -- the `*.mvir` files. You can look at them to see what the new field access syntax in Move IR looks like: `s.S<T>::f`, where `s` is a struct instance, `S<T>` is its type, and `f` is the name of the field being accessed.
* The rest of the changes, in the `*.rs` files are almost exclusively just deleting the `InferredType` enum.