### PR TITLE
[State Sync] Small cleanups to MempoolNotifier.

### DIFF
--- a/mempool/src/tests/shared_mempool_test.rs
+++ b/mempool/src/tests/shared_mempool_test.rs
@@ -58,7 +58,7 @@ fn test_mempool_notify_committed_txns() {
     let _enter = runtime.enter();
 
     // Create a new mempool notifier, listener and shared mempool
-    let (mut mempool_notifier, mempool_listener) = MempoolNotifier::new();
+    let (mempool_notifier, mempool_listener) = MempoolNotifier::new();
     let smp = MockSharedMempool::new(Some(mempool_listener));
 
     // Add txns 1, 2, 3, 4

--- a/state-sync/inter-component/mempool-notifications/src/lib.rs
+++ b/state-sync/inter-component/mempool-notifications/src/lib.rs
@@ -109,11 +109,7 @@ impl MempoolNotificationSender for MempoolNotifier {
         .await
         {
             match response {
-                Ok(Ok(MempoolNotificationResponse::Success)) => Ok(()),
-                Ok(Err(error)) => Err(Error::UnexpectedErrorEncountered(format!(
-                    "Unexpected response from mempool! Error: {:?}",
-                    error
-                ))),
+                Ok(MempoolNotificationResponse::Success) => Ok(()),
                 Err(error) => Err(Error::UnexpectedErrorEncountered(format!("{:?}", error))),
             }
         } else {
@@ -127,7 +123,7 @@ impl MempoolNotificationSender for MempoolNotifier {
 pub struct MempoolCommitNotification {
     pub transactions: Vec<CommittedTransaction>,
     pub block_timestamp_usecs: u64, // The timestamp of the committed block.
-    pub(crate) callback: oneshot::Sender<Result<MempoolNotificationResponse, Error>>,
+    pub(crate) callback: oneshot::Sender<MempoolNotificationResponse>,
 }
 
 impl fmt::Display for MempoolCommitNotification {
@@ -173,7 +169,7 @@ impl MempoolNotificationListener {
     ) -> Result<(), Error> {
         mempool_commit_notification
             .callback
-            .send(Ok(MempoolNotificationResponse::Success))
+            .send(MempoolNotificationResponse::Success)
             .map_err(|error| Error::UnexpectedErrorEncountered(format!("{:?}", error)))
     }
 }


### PR DESCRIPTION
## Motivation

This (mini) PR offers two small cleanups for the newly added MempoolNotifier (https://github.com/diem/diem/pull/9006), each in their own commit:
1. First, remove the redundant `Result` wrapper when the MempoolNotificationListener acks a commit notification. The result is not used.
2. Second, it removes the need for mutability when methods of the MempoolNotifierSender are invoked. Mutability is also not required.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Existing tests cover this.

## Related PRs

None, but this PR relates to: https://github.com/diem/diem/issues/8906
