### PR TITLE
[move-prover] minor improvements to the verification analysis pass

### DIFF
--- a/language/move-prover/bytecode/src/verification_analysis.rs
+++ b/language/move-prover/bytecode/src/verification_analysis.rs
@@ -108,8 +108,9 @@ impl FunctionTargetProcessor for VerificationAnalysisProcessor {
         }
 
         // Rule 3: verify the function if a global invariant (including update invariant) that is
-        // defined in the target modules (a.k.a. a target invariant) are considered applicable in
-        // the function.
+        // defined in the target modules (a.k.a. a target invariant) need to be checked in the
+        // function, i.e., the function directly modifies some memory that are covered by at least
+        // one of the target invariants.
         let inv_analysis = env.get_extension::<InvariantAnalysisData>().unwrap();
         let target_invs: BTreeSet<_> = target_modules
             .iter()
@@ -120,7 +121,7 @@ impl FunctionTargetProcessor for VerificationAnalysisProcessor {
             .fun_to_inv_map
             .get(&fun_env.get_qualified_id())
             .unwrap();
-        if !inv_relevance.direct_accessed.is_disjoint(&target_invs) {
+        if !inv_relevance.direct_modified.is_disjoint(&target_invs) {
             if Self::is_within_verification_scope(fun_env) {
                 Self::mark_verified(fun_env, &mut data, targets);
             }


### PR DESCRIPTION
Two improvements are made in the new verification analysis pass:

- [move-prover] only verify functions that directly modifies a target invariant
The prior behavior is to verify functions that directly accesses a
target invariant, which unnecessarily leaves many functions to be marked
as verified.

NOTE: only memory modifications cause global invariants to be asserted;
memory accesses without modification leads to assumption of global invariants
only, but not assertions.

- [move-prover] improve error reporting on invariant suspension pramgas
The prior errors are too verbose.

## Motivation

Performance and error reporting

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- CI
- This new pass is not turned on as of now. It will be made as default in a later PR.
