### PR TITLE
[move-prover] algorithm for progressive instantiation

### DIFF
--- a/language/move-model/src/ty.rs
+++ b/language/move-model/src/ty.rs
@@ -8,10 +8,12 @@ use crate::{
     model::{GlobalEnv, ModuleId, StructEnv, StructId},
     symbol::{Symbol, SymbolPool},
 };
-use move_binary_format::normalized::Type as MType;
+
+use move_binary_format::{file_format::TypeParameterIndex, normalized::Type as MType};
 use move_core_types::language_storage::{StructTag, TypeTag};
+
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, VecDeque},
     fmt,
     fmt::Formatter,
 };
@@ -259,7 +261,7 @@ impl Type {
         inst
     }
 
-    /// A helper function to do replacement of type parameterss.
+    /// A helper function to do replacement of type parameters.
     fn replace(&self, params: Option<&[Type]>, subs: Option<&Substitution>) -> Type {
         let replace_vec = |types: &[Type]| types.iter().map(|t| t.replace(params, subs)).collect();
         match self {
@@ -727,38 +729,55 @@ impl Default for Substitution {
 }
 
 /// Helper to unify types which stem from different generic contexts.
+///
 /// Both comparison side may have type parameters (equally named as #0, #1, ...).
 /// The helper converts the type parameter from or both sides into variables
 /// and then performs unification of the terms. The resulting substitution
 /// is converted back to parameter instantiations.
 ///
 /// Example: consider a function f<X> which uses memory M<X, u64>, and invariant
-/// invariant<X> which uses memory M<bool,X>. Using this helper to unify those
-/// both memories will result in instantiations which when applied
-/// create f<bool> and invariant<u64>.
+/// invariant<X> which uses memory M<bool, X>. Using this helper to unify both
+/// memories will result in instantiations which when applied create f<bool>
+/// and invariant<u64> respectively.
 pub struct TypeUnificationAdapter {
-    type_vars_map: BTreeMap<u16, (bool, u16)>,
+    type_vars_map: BTreeMap<u16, (bool, TypeParameterIndex)>,
     types_adapted_lhs: Vec<Type>,
     types_adapted_rhs: Vec<Type>,
 }
 
 impl TypeUnificationAdapter {
-    /// Initialize the context for the type unifier. The boolean parameters on
-    /// which side of the comparison type parameters are turned into type vars; at
-    /// least one must be set.
+    /// Initialize the context for the type unifier.
+    ///
+    /// If `treat_lhs_type_param_as_var_after_index` is set to P,
+    /// - any type parameter on the LHS with index < P will be treated as concrete types and
+    /// - only type parameters on the LHS with index >= P are treated as variables and thus,
+    ///   participate in the type unification process.
+    /// The same rule applies to the RHS parameters via `treat_rhs_type_param_as_var_after_index`.
     fn new<'a, I>(
         lhs_types: I,
         rhs_types: I,
-        treat_lhs_type_param_as_var: bool,
-        treat_rhs_type_param_as_var: bool,
+        treat_lhs_type_param_as_var_after_index: Option<TypeParameterIndex>,
+        treat_rhs_type_param_as_var_after_index: Option<TypeParameterIndex>,
     ) -> Self
     where
         I: Iterator<Item = &'a Type> + Clone,
     {
-        assert!(
-            treat_rhs_type_param_as_var || treat_lhs_type_param_as_var,
+        debug_assert!(
+            treat_lhs_type_param_as_var_after_index.is_some()
+                || treat_rhs_type_param_as_var_after_index.is_some(),
             "At least one side of the unification must be treated as variable"
         );
+
+        // Check the input types do not contain type variables.
+        debug_assert!(
+            lhs_types.clone().chain(rhs_types.clone()).all(|ty| {
+                let mut b = true;
+                ty.visit(&mut |t| b = b && !matches!(t, Type::Var(_)));
+                b
+            }),
+            "unexpected type variable"
+        );
+
         // Compute the number of type parameters for each side.
         let mut lhs_type_param_count = 0;
         let mut rhs_type_param_count = 0;
@@ -774,40 +793,32 @@ impl TypeUnificationAdapter {
             ty.visit(&mut |t| count_type_param(t, &mut rhs_type_param_count));
         }
 
-        // Check the input types do not contain type variables.
-        debug_assert!(
-            lhs_types.clone().chain(rhs_types.clone()).all(|ty| {
-                let mut b = true;
-                ty.visit(&mut |t| b = b && !matches!(t, Type::Var(_)));
-                b
-            }),
-            "unexpected type variable"
-        );
-
         // Create a type variable instantiation for each side.
-        let count = 0;
+        let mut var_count = 0;
         let mut type_vars_map = BTreeMap::new();
-        let lhs_inst = if treat_lhs_type_param_as_var {
-            (0..lhs_type_param_count)
-                .map(|i| {
-                    let idx = count + i;
+        let lhs_inst = match treat_lhs_type_param_as_var_after_index {
+            None => vec![],
+            Some(boundary) => (0..boundary)
+                .map(Type::TypeParameter)
+                .chain((boundary..lhs_type_param_count).map(|i| {
+                    let idx = var_count;
+                    var_count += 1;
                     type_vars_map.insert(idx, (true, i));
                     Type::Var(idx)
-                })
-                .collect()
-        } else {
-            vec![]
+                }))
+                .collect(),
         };
-        let rhs_inst = if treat_rhs_type_param_as_var {
-            (0..rhs_type_param_count)
-                .map(|i| {
-                    let idx = count + lhs_type_param_count + i;
+        let rhs_inst = match treat_rhs_type_param_as_var_after_index {
+            None => vec![],
+            Some(boundary) => (0..boundary)
+                .map(Type::TypeParameter)
+                .chain((boundary..rhs_type_param_count).map(|i| {
+                    let idx = var_count;
+                    var_count += 1;
                     type_vars_map.insert(idx, (false, i));
                     Type::Var(idx)
-                })
-                .collect()
-        } else {
-            vec![]
+                }))
+                .collect(),
         };
 
         // Do the adaptation.
@@ -821,8 +832,11 @@ impl TypeUnificationAdapter {
         }
     }
 
-    /// Create a TypeUnificationAdapter with the goal of unifying one pair of types
-    pub fn new_one(
+    /// Create a TypeUnificationAdapter with the goal of unifying a pair of types.
+    ///
+    /// If `treat_lhs_type_param_as_var` is True, treat all type parameters on the LHS as variables.
+    /// If `treat_rhs_type_param_as_var` is True, treat all type parameters on the RHS as variables.
+    pub fn new_pair(
         lhs_type: &Type,
         rhs_type: &Type,
         treat_lhs_type_param_as_var: bool,
@@ -831,12 +845,15 @@ impl TypeUnificationAdapter {
         Self::new(
             std::iter::once(lhs_type),
             std::iter::once(rhs_type),
-            treat_lhs_type_param_as_var,
-            treat_rhs_type_param_as_var,
+            treat_lhs_type_param_as_var.then(|| 0),
+            treat_rhs_type_param_as_var.then(|| 0),
         )
     }
 
-    /// Create a TypeUnificationAdapter with the goal of unifying two type tuples
+    /// Create a TypeUnificationAdapter with the goal of unifying a pair of type tuples.
+    ///
+    /// If `treat_lhs_type_param_as_var` is True, treat all type parameters on the LHS as variables.
+    /// If `treat_rhs_type_param_as_var` is True, treat all type parameters on the RHS as variables.
     pub fn new_vec(
         lhs_types: &[Type],
         rhs_types: &[Type],
@@ -846,8 +863,8 @@ impl TypeUnificationAdapter {
         Self::new(
             lhs_types.iter(),
             rhs_types.iter(),
-            treat_lhs_type_param_as_var,
-            treat_rhs_type_param_as_var,
+            treat_lhs_type_param_as_var.then(|| 0),
+            treat_rhs_type_param_as_var.then(|| 0),
         )
     }
 
@@ -924,6 +941,167 @@ impl TypeUnificationError {
                 )
             }
         }
+    }
+}
+
+/// A helper to derive the set of instantiations for type parameters
+pub struct TypeInstantiationDerivation {}
+
+impl TypeInstantiationDerivation {
+    /// Find what the instantiations should we have for the type parameter at `target_param_index`.
+    ///
+    /// The invariant is, forall type parameters whose index < target_param_index, it should either
+    /// - be assigned with a concrete type already and hence, ceases to be a type parameter, or
+    /// - does not have any matching instantiation and hence, either remains a type parameter or is
+    ///   represented as a type error.
+    /// But in anyway, these type parameters no longer participate in type unification anymore.
+    ///
+    /// If `target_lhs` is True, derive instantiations for the type parameter with
+    /// `target_param_index` on the `lhs_types`. Otherwise, target the `rhs_types`.
+    fn derive_instantiations_for_target_parameter(
+        lhs_types: &BTreeSet<Type>,
+        rhs_types: &BTreeSet<Type>,
+        treat_lhs_type_param_as_var: bool,
+        treat_rhs_type_param_as_var: bool,
+        target_param_index: TypeParameterIndex,
+        target_lhs: bool,
+    ) -> BTreeSet<Type> {
+        // progressively increase the boundary
+        let treat_lhs_type_param_as_var_after_index =
+            treat_lhs_type_param_as_var.then(|| target_param_index);
+        let treat_rhs_type_param_as_var_after_index =
+            treat_rhs_type_param_as_var.then(|| target_param_index);
+
+        let mut target_param_insts = BTreeSet::new();
+        for t_lhs in lhs_types {
+            for t_rhs in rhs_types {
+                // Try to unify the instantiations
+                let adapter = TypeUnificationAdapter::new(
+                    std::iter::once(t_lhs),
+                    std::iter::once(t_rhs),
+                    treat_lhs_type_param_as_var_after_index,
+                    treat_rhs_type_param_as_var_after_index,
+                );
+                let rel = adapter.unify(Variance::Allow, false);
+                if let Some((subst_lhs, subst_rhs)) = rel {
+                    let subst = if target_lhs { subst_lhs } else { subst_rhs };
+                    for (param_idx, inst_ty) in subst.into_iter() {
+                        if param_idx != target_param_index {
+                            // this parameter will be unified at a later stage.
+                            //
+                            // NOTE: this code is inefficient when we have multiple type parameters,
+                            // but a vast majority of Move code we see so far have at most one type
+                            // parameter, so we trade-off efficiency with simplicity in code.
+                            assert!(param_idx > target_param_index);
+                            continue;
+                        }
+                        target_param_insts.insert(inst_ty);
+                    }
+                }
+            }
+        }
+        target_param_insts
+    }
+
+    /// Find the set of valid instantiation combinations for all the type parameters.
+    ///
+    /// The algorithm is progressive. For a list of parameters with arity `params_arity = N`, it
+    /// - first finds all possible instantiation for parameter at index 0 (`inst_param_0`) and,'
+    /// - for each instantiation in `inst_param_0`,
+    ///   - refines LHS or RHS types and
+    ///   - finds all possible instantiations for parameter at index 1 (`inst_param_1`)
+    ///   - for each instantiation in `inst_param_1`,
+    ///     - refines LHS or RHS types and
+    ///     - finds all possible instantiations for parameter at index 2 (`inst_param_2`)
+    ///     - for each instantiation in `inst_param_2`,
+    ///       - ......
+    /// The process continues until all type parameters are analyzed (i.e., reaching the type
+    /// parameter at index `N`).
+    ///
+    /// If `refine_lhs` is True, refine the `lhs_types` after each round; same for `refine_rhs`.
+    ///
+    /// If `target_lhs` is True, find instantiations for the type parameters in the `lhs_types`,
+    /// otherwise, target the `rhs_types`.
+    ///
+    /// If `mark_irrelevant_param_as_error` is True, type parameters that do not have any valid
+    /// instantiation will be marked as `Type::Error`. Otherwise, leave the type parameter as it is.
+    pub fn progressive_instantiation<'a, I>(
+        lhs_types: I,
+        rhs_types: I,
+        treat_lhs_type_param_as_var: bool,
+        treat_rhs_type_param_as_var: bool,
+        refine_lhs: bool,
+        refine_rhs: bool,
+        params_arity: usize,
+        target_lhs: bool,
+        mark_irrelevant_param_as_error: bool,
+    ) -> BTreeSet<Vec<Type>>
+    where
+        I: Iterator<Item = &'a Type> + Clone,
+    {
+        let initial_param_insts: Vec<_> = (0..params_arity)
+            .map(|idx| Type::TypeParameter(idx as TypeParameterIndex))
+            .collect();
+
+        let mut work_queue = VecDeque::new();
+        work_queue.push_back(initial_param_insts);
+        for target_param_index in 0..params_arity {
+            let mut for_next_round = vec![];
+            while let Some(param_insts) = work_queue.pop_front() {
+                // refine the memory usage sets with current param instantiations
+                let refined_lhs = lhs_types
+                    .clone()
+                    .map(|t| {
+                        if refine_lhs {
+                            t.instantiate(&param_insts)
+                        } else {
+                            t.clone()
+                        }
+                    })
+                    .collect();
+                let refined_rhs = rhs_types
+                    .clone()
+                    .map(|t| {
+                        if refine_rhs {
+                            t.instantiate(&param_insts)
+                        } else {
+                            t.clone()
+                        }
+                    })
+                    .collect();
+
+                // find type instantiations for the target parameter index
+                let mut target_param_insts = Self::derive_instantiations_for_target_parameter(
+                    &refined_lhs,
+                    &refined_rhs,
+                    treat_lhs_type_param_as_var,
+                    treat_rhs_type_param_as_var,
+                    target_param_index as TypeParameterIndex,
+                    target_lhs,
+                );
+
+                // decide what to do with an irrelevant type parameter
+                if target_param_insts.is_empty() {
+                    let irrelevant_type = if mark_irrelevant_param_as_error {
+                        Type::Error
+                    } else {
+                        Type::TypeParameter(target_param_index as TypeParameterIndex)
+                    };
+                    target_param_insts.insert(irrelevant_type);
+                }
+
+                // instantiate the target type parameter in every possible way
+                for inst in target_param_insts {
+                    let mut next_insts = param_insts.clone();
+                    next_insts[target_param_index] = inst;
+                    for_next_round.push(next_insts);
+                }
+            }
+            work_queue.extend(for_next_round);
+        }
+
+        // the final workqueue contains possible instantiations for all type parameters
+        work_queue.into_iter().collect()
     }
 }
 


### PR DESCRIPTION
This algorithm deals with finding a complete set of instantiation
combinations for all type parameters when unifying two types.

// problem definition

The algorithm is encapsulated in `struct TypeInstantiationDerivation`
and is not conceptually hard to understand:

Suppose we aim to unify `T1 [X0, X1, ..., Xm]` vs `T2 [Y0, Y1, ..., Yn]`,
where `T1` and `T2` are types while `X`s and `Y`s are type parameters
that show up in `T1` and `T2`, respectively.

We want to find all instantiations to `<X0, X1, ..., Xm>` such that
for each instantiation `(x0, x1, ..., xm)`, there exists a valid
instantiation `(y0, y1, ..., yn)` which makes `T1` and `T2` equivelant,
i.e., `T1<x0, x1, ..., xm> == T2<y0, y1, ..., yn>`.

We put all these instantiation in a set denoted as `|(x0, x1, ..., xm)|`
and this algorithm is about finding this set of instantiations.

// algorithm description

The algorithm works by finding all instantiations for `X0` first, and
then progress to `X1`, `X2`, ..., until finishing `Xn`.

- unify `T1 [X0, X1, ..., Xm]` vs `T2 [Y0, Y1, ..., Yn]`, get all
  possible substitutions for `X0`, denoted as `|x0|`
- for each `x0 in |x0|`:
  - refine `T1` with `x0`
  - unify `T1 [X0 := x0, X1, ..., Xm]` vs `T2 [Y0, Y1, ..., Yn]`, get
    all possible substitutions for `X1`, denoted as `|x1|`
  - for each `x1 in |x1|`:
    - refine `T1` with `x1`
    - unify `T1 [X0 := x0, X1 := x1, ..., Xm]` vs `T2 [Y0, Y1, ..., Yn]`,
      get all possible substitutions for `X2`, denoted as `|x2|`
    - for each `x2` in `|x2|`:
      - ......

The process continues until we reach the end of `Xn`. After which, the
algorithm should have collected all the legal instantiation combinations
for type parameters `<X0, X1, ..., Xm>`.

// other notes

- The implementation has a bit of fine-tuning rooted by the fact that
  sometimes we want to treat a type parameter as a variable (i.e.,
  participate in type unification) while in other cases, we want to
  treat a type parameter as a concrete type (i.e., do not participate in
  type unification).

- We also have a fine-tuning on whether we treat a type parameter that
  does not have any valid instantiations as an error or remains as a
  concrete type parameter. This is rooted by the differentation of type
  parameters in function vs type parameters in a global invariant.
  Essentially, all type parameters in a global invariant must be
  instantiated in order for the invariant to be instrumented. But not
  all function type paramters need to be instantiated.

- This is not the most efficient algorithm, especially when we have a
  large number of type parameters. But a vast majority of Move code we
  have seen so far have at most one type parameter, so in this commit,
  we trade-off efficiency with simplicity.

## Motivation

Work item needed for global invariant instrumentation

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- CI
