### PR TITLE
[State Sync] Small cleanups to MempoolNotifier and ConsensusNotifier.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1094,7 +1094,6 @@ dependencies = [
  "fallible",
  "futures",
  "itertools 0.10.0",
- "mempool-notifications",
  "mirai-annotations",
  "network",
  "num-derive",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -48,7 +48,6 @@ diem-temppath = { path = "../common/temppath" }
 diem-types = { path = "../types" }
 diem-vm = { path = "../language/diem-vm" }
 diem-workspace-hack = { path = "../common/workspace-hack" }
-mempool-notifications = { path = "../state-sync/inter-component/mempool-notifications" }
 network = { path = "../network" }
 safety-rules = { path = "safety-rules" }
 short-hex-str = { path = "../common/short-hex-str" }

--- a/consensus/src/block_storage/block_store_and_lec_recovery_test.rs
+++ b/consensus/src/block_storage/block_store_and_lec_recovery_test.rs
@@ -8,7 +8,6 @@ use crate::{
     test_utils::{EmptyStorage, TreeInserter},
     util::mock_time_service::SimulatedTimeService,
 };
-use consensus_notifications::ConsensusNotifier;
 use consensus_types::{block::Block, quorum_cert::QuorumCert};
 use diem_config::config::NodeConfig;
 use diem_crypto::{ed25519::Ed25519PrivateKey, Uniform};
@@ -65,7 +64,7 @@ fn build_inserter(
 ) -> TreeInserter {
     let client_commit_timeout_ms = config.state_sync.client_commit_timeout_ms;
     let (consensus_notifier, _consensus_listener) =
-        ConsensusNotifier::new(client_commit_timeout_ms);
+        consensus_notifications::new_consensus_notifier_listener_pair(client_commit_timeout_ms);
 
     let state_computer = Arc::new(ExecutionProxy::new(
         lec_client,

--- a/diem-node/src/lib.rs
+++ b/diem-node/src/lib.rs
@@ -24,7 +24,6 @@ use diemdb::DiemDB;
 use executor::{db_bootstrapper::maybe_bootstrap, Executor};
 use executor_types::ChunkExecutor;
 use futures::{channel::mpsc::channel, executor::block_on};
-use mempool_notifications::MempoolNotifier;
 use network_builder::builder::NetworkBuilder;
 use state_sync_v1::bootstrapper::StateSyncBootstrapper;
 use std::{
@@ -392,7 +391,8 @@ pub fn setup_environment(node_config: &NodeConfig, logger: Option<Arc<Logger>>) 
     // and pass network handles to mempool/state sync
 
     // For state sync to send notifications to mempool and receive notifications from consensus.
-    let (mempool_notifier, mempool_listener) = MempoolNotifier::new();
+    let (mempool_notifier, mempool_listener) =
+        mempool_notifications::new_mempool_notifier_listener_pair();
     let (consensus_notifier, consensus_listener) =
         ConsensusNotifier::new(node_config.state_sync.client_commit_timeout_ms);
 

--- a/diem-node/src/lib.rs
+++ b/diem-node/src/lib.rs
@@ -3,7 +3,6 @@
 
 use backup_service::start_backup_service;
 use consensus::{consensus_provider::start_consensus, gen_consensus_reconfig_subscription};
-use consensus_notifications::ConsensusNotifier;
 use debug_interface::node_debug_service::NodeDebugService;
 use diem_config::{
     config::{NetworkConfig, NodeConfig, PersistableConfig},
@@ -394,7 +393,9 @@ pub fn setup_environment(node_config: &NodeConfig, logger: Option<Arc<Logger>>) 
     let (mempool_notifier, mempool_listener) =
         mempool_notifications::new_mempool_notifier_listener_pair();
     let (consensus_notifier, consensus_listener) =
-        ConsensusNotifier::new(node_config.state_sync.client_commit_timeout_ms);
+        consensus_notifications::new_consensus_notifier_listener_pair(
+            node_config.state_sync.client_commit_timeout_ms,
+        );
 
     // Create state sync bootstrapper
     let state_sync_bootstrapper = StateSyncBootstrapper::bootstrap(

--- a/mempool/src/lib.rs
+++ b/mempool/src/lib.rs
@@ -61,7 +61,7 @@ pub use shared_mempool::{
     bootstrap, network,
     types::{
         gen_mempool_reconfig_subscription, ConsensusRequest, ConsensusResponse,
-        MempoolClientSender, SubmissionStatus, TransactionExclusion,
+        MempoolClientSender, SubmissionStatus, TransactionSummary,
     },
 };
 #[cfg(any(test, feature = "fuzzing"))]

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -80,7 +80,7 @@ pub(crate) async fn coordinator<V>(
             msg = consensus_requests.select_next_some() => {
                 tasks::process_consensus_request(&smp.mempool, msg).await;
             },
-            msg = mempool_listener.notification_receiver.select_next_some() => {
+            msg = mempool_listener.select_next_some() => {
                 handle_state_sync_request(&mut smp, msg, &mut mempool_listener).await;
             },
             config_update = mempool_reconfig_events.select_next_some() => {

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -13,7 +13,7 @@ use crate::{
         tasks::commit_txns,
         types::{notify_subscribers, ScheduledBroadcast, SharedMempool, SharedMempoolNotification},
     },
-    ConsensusRequest, SubmissionStatus,
+    ConsensusRequest, SubmissionStatus, TransactionSummary,
 };
 use ::network::protocols::network::Event;
 use anyhow::Result;
@@ -145,7 +145,13 @@ async fn handle_state_sync_request<V>(
     );
     commit_txns(
         &smp.mempool.clone(),
-        msg.transactions.clone(),
+        msg.transactions
+            .iter()
+            .map(|txn| TransactionSummary {
+                sender: txn.sender,
+                sequence_number: txn.sequence_number,
+            })
+            .collect(),
         msg.block_timestamp_usecs,
         false,
     )

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -10,7 +10,7 @@ use crate::{
     network::MempoolSyncMsg,
     shared_mempool::types::{
         notify_subscribers, ScheduledBroadcast, SharedMempool, SharedMempoolNotification,
-        SubmissionStatusBundle,
+        SubmissionStatusBundle, TransactionSummary,
     },
     ConsensusRequest, ConsensusResponse, SubmissionStatus,
 };
@@ -26,7 +26,6 @@ use diem_types::{
     vm_status::DiscardedVMStatus,
 };
 use futures::{channel::oneshot, stream::FuturesUnordered};
-use mempool_notifications::CommittedTransaction;
 use rayon::prelude::*;
 use short_hex_str::AsShortHexStr;
 use std::{
@@ -399,7 +398,7 @@ pub(crate) async fn process_consensus_request(mempool: &Mutex<CoreMempool>, req:
 
 pub async fn commit_txns(
     mempool: &Mutex<CoreMempool>,
-    transactions: Vec<CommittedTransaction>,
+    transactions: Vec<TransactionSummary>,
     block_timestamp_usecs: u64,
     is_rejected: bool,
 ) {

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -20,7 +20,7 @@ use diem_types::{
     transaction::{GovernanceRole, SignedTransaction},
 };
 use futures::channel::{mpsc, oneshot};
-use mempool_notifications::{MempoolNotificationListener, MempoolNotifier};
+use mempool_notifications::{self, MempoolNotificationListener, MempoolNotifier};
 use network::{
     peer_manager::{conn_notifs_channel, ConnectionRequestSender, PeerManagerRequestSender},
     protocols::network::{NewNetworkEvents, NewNetworkSender},
@@ -67,7 +67,8 @@ impl MockSharedMempool {
         let (consensus_sender, consensus_events) = mpsc::channel(1_024);
         let (mempool_notifier, mempool_listener) = match mempool_listener {
             None => {
-                let (mempool_notifier, mempool_listener) = MempoolNotifier::new();
+                let (mempool_notifier, mempool_listener) =
+                    mempool_notifications::new_mempool_notifier_listener_pair();
                 (Some(mempool_notifier), mempool_listener)
             }
             Some(mempool_listener) => (None, mempool_listener),

--- a/mempool/src/tests/node.rs
+++ b/mempool/src/tests/node.rs
@@ -24,7 +24,6 @@ use futures::{
     channel::mpsc::{self, unbounded, UnboundedReceiver},
     FutureExt, StreamExt,
 };
-use mempool_notifications::MempoolNotifier;
 use netcore::transport::ConnectionOrigin;
 use network::{
     peer_manager::{
@@ -595,7 +594,8 @@ fn start_node_mempool(
     let (sender, subscriber) = unbounded();
     let (_ac_endpoint_sender, ac_endpoint_receiver) = mpsc::channel(1_024);
     let (_consensus_sender, consensus_events) = mpsc::channel(1_024);
-    let (_mempool_notifier, mempool_listener) = MempoolNotifier::new();
+    let (_mempool_notifier, mempool_listener) =
+        mempool_notifications::new_mempool_notifier_listener_pair();
     let (_reconfig_events, reconfig_events_receiver) = diem_channel::new(QueueStyle::LIFO, 1, None);
 
     let runtime = Builder::new_multi_thread()

--- a/mempool/src/tests/shared_mempool_test.rs
+++ b/mempool/src/tests/shared_mempool_test.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use diem_types::transaction::Transaction;
 use futures::{channel::oneshot, executor::block_on, sink::SinkExt};
-use mempool_notifications::{CommittedTransaction, MempoolNotificationSender, MempoolNotifier};
+use mempool_notifications::{CommittedTransaction, MempoolNotificationSender};
 use tokio::runtime::Builder;
 
 #[test]
@@ -58,7 +58,8 @@ fn test_mempool_notify_committed_txns() {
     let _enter = runtime.enter();
 
     // Create a new mempool notifier, listener and shared mempool
-    let (mempool_notifier, mempool_listener) = MempoolNotifier::new();
+    let (mempool_notifier, mempool_listener) =
+        mempool_notifications::new_mempool_notifier_listener_pair();
     let smp = MockSharedMempool::new(Some(mempool_listener));
 
     // Add txns 1, 2, 3, 4

--- a/mempool/src/tests/shared_mempool_test.rs
+++ b/mempool/src/tests/shared_mempool_test.rs
@@ -3,12 +3,13 @@
 
 use crate::{
     mocks::MockSharedMempool,
+    shared_mempool::types::TransactionSummary,
     tests::common::{batch_add_signed_txn, TestTransaction},
     ConsensusRequest,
 };
 use diem_types::transaction::Transaction;
 use futures::{channel::oneshot, executor::block_on, sink::SinkExt};
-use mempool_notifications::{CommittedTransaction, MempoolNotificationSender};
+use mempool_notifications::MempoolNotificationSender;
 use tokio::runtime::Builder;
 
 #[test]
@@ -33,12 +34,12 @@ fn test_consensus_events_rejected_txns() {
         assert!(batch_add_signed_txn(&mut pool, txns).is_ok());
     }
 
-    let committed_txns = vec![CommittedTransaction {
+    let transactions = vec![TransactionSummary {
         sender: committed_txn.sender(),
         sequence_number: committed_txn.sequence_number(),
     }];
     let (callback, callback_rcv) = oneshot::channel();
-    let req = ConsensusRequest::RejectNotification(committed_txns, callback);
+    let req = ConsensusRequest::RejectNotification(transactions, callback);
     let mut consensus_sender = smp.consensus_sender.clone();
     block_on(async {
         assert!(consensus_sender.send(req).await.is_ok());

--- a/state-sync/state-sync-v1/Cargo.toml
+++ b/state-sync/state-sync-v1/Cargo.toml
@@ -51,7 +51,6 @@ vm-genesis = { path = "../../language/tools/vm-genesis", optional = true }
 bytes = "1.0.1"
 proptest = "1.0.0"
 
-consensus-notifications = { path = "../inter-component/consensus-notifications" }
 channel = { path = "../../common/channel" }
 diem-framework-releases= { path = "../../language/diem-framework/releases" }
 diem-crypto = { path = "../../crypto/crypto" }

--- a/state-sync/state-sync-v1/src/coordinator.rs
+++ b/state-sync/state-sync-v1/src/coordinator.rs
@@ -174,7 +174,7 @@ impl<T: ExecutorProxyTrait, M: MempoolNotificationSender> StateSyncCoordinator<T
         loop {
             let _timer = counters::MAIN_LOOP.start_timer();
             ::futures::select! {
-                msg = self.consensus_listener.notification_receiver.select_next_some() => {
+                msg = self.consensus_listener.select_next_some() => {
                     match msg {
                         ConsensusNotification::SyncToTarget(sync_notification) => {
                             let _timer = counters::PROCESS_COORDINATOR_MSG_LATENCY

--- a/state-sync/state-sync-v1/src/shared_components.rs
+++ b/state-sync/state-sync-v1/src/shared_components.rs
@@ -85,7 +85,6 @@ pub(crate) mod test_utils {
     use diem_types::waypoint::Waypoint;
 
     use channel::{diem_channel, message_queues::QueueStyle};
-    use consensus_notifications::ConsensusNotifier;
     use diem_config::{
         config::{NodeConfig, RoleType},
         network_id::{NetworkId, NodeNetworkId},
@@ -167,7 +166,8 @@ pub(crate) mod test_utils {
         // Create channel senders and receivers
         let (_coordinator_sender, coordinator_receiver) = mpsc::unbounded();
         let (mempool_notifier, _) = mempool_notifications::new_mempool_notifier_listener_pair();
-        let (_, consensus_listener) = ConsensusNotifier::new(1000);
+        let (_, consensus_listener) =
+            consensus_notifications::new_consensus_notifier_listener_pair(1000);
 
         // Return the new state sync coordinator
         StateSyncCoordinator::new(

--- a/state-sync/state-sync-v1/src/shared_components.rs
+++ b/state-sync/state-sync-v1/src/shared_components.rs
@@ -166,7 +166,7 @@ pub(crate) mod test_utils {
 
         // Create channel senders and receivers
         let (_coordinator_sender, coordinator_receiver) = mpsc::unbounded();
-        let (mempool_notifier, _) = MempoolNotifier::new();
+        let (mempool_notifier, _) = mempool_notifications::new_mempool_notifier_listener_pair();
         let (_, consensus_listener) = ConsensusNotifier::new(1000);
 
         // Return the new state sync coordinator

--- a/state-sync/state-sync-v1/tests/test_harness.rs
+++ b/state-sync/state-sync-v1/tests/test_harness.rs
@@ -311,7 +311,10 @@ impl StateSyncEnvironment {
             mempool_notifications::new_mempool_notifier_listener_pair();
         peer.mempool = Some(MockSharedMempool::new(Some(mempool_listener)));
 
-        let (consensus_notifier, consensus_listener) = ConsensusNotifier::new(1000);
+        let (consensus_notifier, consensus_listener) =
+            consensus_notifications::new_consensus_notifier_listener_pair(
+                config.state_sync.client_commit_timeout_ms,
+            );
 
         let bootstrapper = StateSyncBootstrapper::bootstrap_with_executor_proxy(
             Runtime::new().unwrap(),

--- a/state-sync/state-sync-v1/tests/test_harness.rs
+++ b/state-sync/state-sync-v1/tests/test_harness.rs
@@ -41,7 +41,6 @@ use diem_types::{
 };
 use executor_types::ExecutedTrees;
 use futures::{executor::block_on, future::FutureExt, StreamExt};
-use mempool_notifications::MempoolNotifier;
 use memsocket::MemoryListener;
 use netcore::transport::ConnectionOrigin;
 use network::{
@@ -308,7 +307,8 @@ impl StateSyncEnvironment {
             peer.signer.clone(),
         )));
 
-        let (mempool_notifier, mempool_listener) = MempoolNotifier::new();
+        let (mempool_notifier, mempool_listener) =
+            mempool_notifications::new_mempool_notifier_listener_pair();
         peer.mempool = Some(MockSharedMempool::new(Some(mempool_listener)));
 
         let (consensus_notifier, consensus_listener) = ConsensusNotifier::new(1000);


### PR DESCRIPTION
## Motivation

This PR provides some small cleanups for the mempool and consensus notification interfaces used by state sync. The PR offers the following commits:
1. First, we make the notification receiver in `MempoolNotificationListener` private so that users of the listener don't need to know how the listener is implemented (e.g., using channels). This reduces dependencies and improves the interface abstraction. Similarly, we make the constructors for `MempoolNotifier` and `MempoolNotificationListener` private so that the pair can only ever be created and managed together (highlighting their relationship).
2. Second, we do as above, but for the `ConsensusNotifier` and `ConsensusNotificationListener` interfaces. Moreover, we clean up some of the constants in the test code.
3. Finally, we remove the requirement for consensus to depend on the `mempool-notifications` crate (this was only required to access the `CommittedTransaction` struct). We achieve this by renaming `TransactionExclusion` to `TransactionSummary` and using `TransactionSummary` in place of the `CommittedTransaction` struct (as both structs are identical!). This also removes the unnecessary duplication and dependencies.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All changes are covered by the existing tests.

## Related PRs

None, but this PR relates to: https://github.com/diem/diem/issues/8906