### PR TITLE
[move-prover] an analysis pass for the global invariants

### DIFF
--- a/language/move-prover/bytecode/src/global_invariant_analysis.rs
+++ b/language/move-prover/bytecode/src/global_invariant_analysis.rs
@@ -1,0 +1,512 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Analysis pass which analyzes how to injects global invariants into the bytecode.
+
+use crate::{
+    function_target::{FunctionData, FunctionTarget},
+    function_target_pipeline::{
+        FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant, VerificationFlavor,
+    },
+    stackless_bytecode::{BorrowNode, Bytecode, Operation},
+    usage_analysis,
+    verification_analysis::{is_invariant_suspendable, InvariantAnalysisData},
+};
+
+use move_binary_format::file_format::CodeOffset;
+use move_model::{
+    ast::ConditionKind,
+    model::{FunctionEnv, GlobalEnv, GlobalId, QualifiedInstId, StructId},
+    ty::{Type, TypeDisplayContext, TypeInstantiationDerivation, TypeUnificationAdapter, Variance},
+};
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+};
+
+/// A named struct for holding the information on how an invariant is relevant to a bytecode.
+#[derive(Default, Clone)]
+struct PerBytecodeRelevance {
+    /// for each `inst_fun` (instantiation of function type parameters) in the key set, the
+    /// associated value is a set of `inst_inv` (instantiation of invariant type parameters) that
+    /// are applicable to the concrete function instance `F<inst_fun>`.
+    insts: BTreeMap<Vec<Type>, BTreeSet<Vec<Type>>>,
+}
+
+/// A named struct for holding the information on how invariants are relevant to a function.
+#[derive(Clone)]
+struct PerFunctionRelevance {
+    /// Invariants that needs to be assumed at function entrypoint
+    /// - Key: global invariants that needs to be assumed before the first instruction,
+    /// - Value: the instantiation information per each related invariant.
+    entrypoint_assumptions: BTreeMap<GlobalId, PerBytecodeRelevance>,
+
+    /// For each bytecode at given code offset, the associated value is a map of
+    /// - Key: global invariants that needs to be asserted after the bytecode instruction and
+    /// - Value: the instantiation information per each related invariant.
+    per_bytecode_assertions: BTreeMap<CodeOffset, BTreeMap<GlobalId, PerBytecodeRelevance>>,
+}
+
+// The function target processor
+pub struct GlobalInvariantAnalysisProcessor {}
+
+impl GlobalInvariantAnalysisProcessor {
+    pub fn new() -> Box<Self> {
+        Box::new(Self {})
+    }
+}
+
+impl FunctionTargetProcessor for GlobalInvariantAnalysisProcessor {
+    fn process(
+        &self,
+        targets: &mut FunctionTargetsHolder,
+        fun_env: &FunctionEnv<'_>,
+        mut data: FunctionData,
+    ) -> FunctionData {
+        if fun_env.is_native() || fun_env.is_intrinsic() {
+            // Nothing to do
+            return data;
+        }
+        if !data.variant.is_verified() {
+            // Only need to instrument if this is a verification variant
+            return data;
+        }
+
+        // Analyze invariants
+        let target = FunctionTarget::new(fun_env, &data);
+        let analysis_result = PerFunctionRelevance::analyze(&target, targets);
+        data.annotations.set(analysis_result);
+
+        // TODO: the instrumentation pass
+        data
+    }
+
+    fn name(&self) -> String {
+        "global_invariant_analysis".to_string()
+    }
+
+    fn dump_result(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        env: &GlobalEnv,
+        targets: &FunctionTargetsHolder,
+    ) -> fmt::Result {
+        // utils
+        let type_display_ctxt = TypeDisplayContext::WithEnv {
+            env,
+            type_param_names: None,
+        };
+
+        let display_type_slice = |tys: &[Type]| -> String {
+            let content = tys
+                .iter()
+                .map(|t| t.display(&type_display_ctxt).to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("<{}>", content)
+        };
+
+        let make_indent = |indent: usize| "  ".repeat(indent);
+
+        let display_inv_relevance = |f: &mut fmt::Formatter,
+                                     invs: &BTreeMap<GlobalId, PerBytecodeRelevance>,
+                                     header: &str,
+                                     assert_or_assume: &str|
+         -> fmt::Result {
+            let mut indent = 1;
+
+            // oneliner for empty invs
+            if invs.is_empty() {
+                return writeln!(f, "{}{} {{}}", make_indent(indent), header);
+            }
+
+            writeln!(f, "{}{} {{", make_indent(indent), header)?;
+            indent += 1;
+
+            for (inv_id, inv_rel) in invs {
+                writeln!(
+                    f,
+                    "{}{} {} = [",
+                    make_indent(indent),
+                    assert_or_assume,
+                    inv_id
+                )?;
+                indent += 1;
+
+                for (rel_inst, inv_insts) in &inv_rel.insts {
+                    writeln!(
+                        f,
+                        "{}{} -> [",
+                        make_indent(indent),
+                        display_type_slice(rel_inst)
+                    )?;
+                    indent += 1;
+
+                    for inv_inst in inv_insts {
+                        writeln!(f, "{}{}", make_indent(indent), display_type_slice(inv_inst))?;
+                    }
+
+                    indent -= 1;
+                    writeln!(f, "{}]", make_indent(indent))?;
+                }
+
+                indent -= 1;
+                writeln!(f, "{}]", make_indent(indent))?;
+            }
+
+            indent -= 1;
+            writeln!(f, "{}}}", make_indent(indent))
+        };
+
+        writeln!(
+            f,
+            "\n********* Result of global invariant instrumentation *********\n"
+        )?;
+        for (fun_id, fun_variant) in targets.get_funs_and_variants() {
+            if !matches!(
+                fun_variant,
+                FunctionVariant::Verification(VerificationFlavor::Regular)
+            ) {
+                // the analysis results are available in the regular verification variant
+                continue;
+            }
+
+            let fenv = env.get_function(fun_id);
+            let target = targets.get_target(&fenv, &fun_variant);
+            let result = target
+                .get_annotations()
+                .get::<PerFunctionRelevance>()
+                .expect("Analysis not performed");
+
+            writeln!(f, "{}: [", fenv.get_full_name_str())?;
+
+            // display entrypoint assumptions
+            display_inv_relevance(f, &result.entrypoint_assumptions, "entrypoint", "assume")?;
+
+            // display per-bytecode assertions
+            for (code_offset, code_invs) in &result.per_bytecode_assertions {
+                let bc = target.data.code.get(*code_offset as usize).unwrap();
+                let header = format!("{}: {}", code_offset, bc.display(&target, &BTreeMap::new()));
+                display_inv_relevance(f, code_invs, &header, "assert")?;
+            }
+
+            writeln!(f, "]")?;
+        }
+
+        writeln!(f, "\n********* Global invariants by ID *********\n")?;
+        let mut all_invs = BTreeSet::new();
+        for menv in env.get_modules() {
+            all_invs.extend(env.get_global_invariants_by_module(menv.get_id()));
+        }
+        for inv_id in all_invs {
+            let inv = env.get_global_invariant(inv_id).unwrap();
+            let inv_src = env.get_source(&inv.loc).unwrap_or("<unknown invariant>");
+            writeln!(f, "{} => {}", inv_id, inv_src)?;
+        }
+        writeln!(f)
+    }
+}
+
+/// This impl block is about the analysis pass
+impl PerFunctionRelevance {
+    /// Collect and build the relevance analysis information for this function target.
+    fn analyze(target: &FunctionTarget, targets: &FunctionTargetsHolder) -> Self {
+        use BorrowNode::*;
+        use Bytecode::*;
+        use Operation::*;
+
+        // collect information
+        let fid = target.func_env.get_qualified_id();
+        let env = target.global_env();
+        let inv_analysis = env
+            .get_extension::<InvariantAnalysisData>()
+            .expect("Verification analysis not performed");
+
+        let check_suspendable_inv_on_return =
+            inv_analysis.fun_set_with_inv_check_on_exit.contains(&fid);
+        let inv_applicability = inv_analysis
+            .fun_to_inv_map
+            .get(&fid)
+            .expect("Invariant applicability not available");
+
+        let mem_analysis = usage_analysis::get_memory_usage(target);
+
+        let fun_type_params = target.get_type_parameters();
+        let fun_type_params_arity = fun_type_params.len();
+
+        // collect invariant applicability and instantiation information for entrypoint assumptions
+        //
+        // NOTE: why do we use the `InvariantRelevance::accessed` set instead of other sets?
+        //
+        // - The reason we choose `accessed` over `direct_accessed` is that sometimes we need to
+        //   assume invariants that are applicable to callees only and not applicable to the caller.
+        //   The reason is that if we inline a callee function, proving properties about the inlined
+        //   function might require assumptions about the memories it touches (e.g., proving the
+        //   `borrow_global_mut<R>(addr)` does not abort with the invariant that resource `R` must
+        //   exist under account `addr` after operation has started).
+        //
+        //   It does not hurt (in terms of soundness or completeness of the proofs) to assume extra
+        //   invariants in the `accessed` set even when these assumptions are not actually used in
+        //   proofs of any asserts. We might re-consider this when performance (due to too many
+        //   assumptions added to the proof system) becomes an issue.
+        //
+        // - The reason we choose `direct_accessed` over `direct_modified` is that we may need
+        //   assumptions from global invariants to prove properties in the code.
+        //
+        //   For example, we may have an `invariant exists<A>(0x1) ==> exists<B>(0x1);` while in
+        //   the code, we have `if (exists<A>(0x1)) { borrow_global<B>(0x1); }`. With the global
+        //   invariant, we know that the `borrow_global` won't abort. But we won't be able to prove
+        //   this property without the global invariant.
+        let entrypoint_invariants: BTreeSet<_> = inv_applicability
+            .accessed
+            .iter()
+            .filter_map(|&inv_id| {
+                let inv = env.get_global_invariant(inv_id).unwrap();
+                // update invariants should not be assumed at function entrypoint.
+                matches!(inv.kind, ConditionKind::GlobalInvariant(..)).then(|| inv_id)
+            })
+            .collect();
+        let entrypoint_assumptions = Self::calculate_invariant_relevance(
+            env,
+            mem_analysis.accessed.all.iter(),
+            &entrypoint_invariants,
+            fun_type_params_arity,
+        );
+
+        // if this function defers invariant checking on return, filter out invariants that are
+        // suspended in body.
+        //
+        // NOTE: why do we use the `InvariantRelevance::direct_modified` set instead of other sets?
+        //
+        // First, be reminded that in the rest of this function, we aim to find which invariants
+        // should be *asserted* at each bytecode instruction. Therefore, if a bytecode instruction
+        // only reads some memory but never modifies one, we don't need to assert the invariant.
+        // This rules out the `direct_accessed` and `accessed` sets.
+        //
+        // Second, similar to the reason why we choose `direct_accessed` set over `accessed` for
+        // invariants that constitute entrypoint assumptions, we choose `direct_modified` over
+        // `modified` is that we don't want to assert invariants that are applicable to callees
+        // only and not applicable to the caller. The reason is still: if a suspendable invariant is
+        // delegated to the caller, that invariant will appear in the `direct_modified` set on the
+        // caller side.
+        let (inv_related_return, inv_related_normal): (BTreeSet<_>, BTreeSet<_>) =
+            if check_suspendable_inv_on_return {
+                inv_applicability
+                    .direct_modified
+                    .iter()
+                    .cloned()
+                    .partition(|inv_id| is_invariant_suspendable(env, *inv_id))
+            } else {
+                (BTreeSet::new(), inv_applicability.direct_modified.clone())
+            };
+
+        // collect invariant applicability and instantiation information per bytecode, i.e.,
+        // - which invariants should be instrumented after each instruction and
+        // - per each invariant applicable, how to instantiate them.
+        let mut per_bytecode_assertions = BTreeMap::new();
+        let mut mem_related_on_return = BTreeSet::new();
+
+        for (code_offset, bc) in target.data.code.iter().enumerate() {
+            let code_offset = code_offset as CodeOffset;
+
+            // collect memory modified in operations
+            let mem_related = match bc {
+                Call(_, _, oper, _, _) => match oper {
+                    Function(mid, fid, inst) | OpaqueCallEnd(mid, fid, inst) => {
+                        let callee_fid = mid.qualified(*fid);
+
+                        // shortcut the call if the callee does not delegate invariant checking.
+                        //
+                        // NOTE: in this case, memories modified by the callee are NOT back
+                        // propagated to the caller in the `verification_analysis.rs`, which means,
+                        // the `InvariantRelevance::direct_modified` set for the caller does NOT
+                        // necessarily cover invariants that are related to the callee.
+                        if !inv_analysis.fun_set_with_no_inv_check.contains(&callee_fid) {
+                            continue;
+                        }
+
+                        let callee_env = env.get_function(callee_fid);
+                        let callee_target =
+                            targets.get_target(&callee_env, &FunctionVariant::Baseline);
+                        let callee_usage = usage_analysis::get_memory_usage(&callee_target);
+
+                        // NOTE: it is important to include *ALL* memories modified by the callee
+                        // instead of just the direct ones --- if a function `F` delegates
+                        // suspendable invariant checking to its caller, all the functions that `F`
+                        // calls will not check suspendable invariants anymore.
+                        callee_usage.modified.get_all_inst(inst)
+                    }
+
+                    MoveTo(mid, sid, inst) | MoveFrom(mid, sid, inst) => {
+                        let mem = mid.qualified_inst(*sid, inst.to_owned());
+                        std::iter::once(mem).collect()
+                    }
+                    WriteBack(GlobalRoot(mem), _) => std::iter::once(mem.clone()).collect(),
+
+                    // shortcut other operations
+                    _ => continue,
+                },
+
+                Ret(..) if check_suspendable_inv_on_return => {
+                    std::mem::take(&mut mem_related_on_return)
+                }
+
+                // shortcut other bytecodes
+                _ => continue,
+            };
+
+            // mark whether we are processing a return instruction
+            let is_return = matches!(bc, Ret(..));
+
+            // select the related invariants based on whether this bytecode instruction is a return
+            let inv_related = if is_return {
+                &inv_related_return
+            } else {
+                &inv_related_normal
+            };
+
+            // collect instantiation information
+            let relevance = Self::calculate_invariant_relevance(
+                env,
+                mem_related.iter(),
+                inv_related,
+                fun_type_params_arity,
+            );
+            per_bytecode_assertions.insert(code_offset, relevance);
+
+            // save the related memories for return point if the function defers that
+            if check_suspendable_inv_on_return && !is_return {
+                mem_related_on_return.extend(mem_related);
+            }
+        }
+
+        // sanity check: the deferred memory is indeed consumed by a return instruction, UNLESS
+        // the deferred memory do not touch anything that is checked in any suspendable invariant.
+        if !mem_related_on_return.is_empty() {
+            let mut deferred_invs = vec![];
+            'error_check: for inv_id in inv_related_return {
+                let inv = env.get_global_invariant(inv_id).unwrap();
+                for inv_mem in &inv.mem_usage {
+                    let inv_ty = inv_mem.to_type();
+                    for rel_mem in &mem_related_on_return {
+                        let rel_ty = rel_mem.to_type();
+                        let adapter =
+                            TypeUnificationAdapter::new_pair(&rel_ty, &inv_ty, true, true);
+                        if adapter.unify(Variance::Allow, false).is_none() {
+                            deferred_invs.push(inv_id);
+                            continue 'error_check;
+                        }
+                    }
+                }
+            }
+            if !deferred_invs.is_empty() {
+                env.error(
+                    &target.get_loc(),
+                    &format!(
+                        "Function `{}` defers the checking of {} suspendable invariants to the \
+                        return point, but the function never returns",
+                        target.func_env.get_full_name_str(),
+                        deferred_invs.len(),
+                    ),
+                );
+            }
+        }
+
+        // wrap and return the analysis result
+        Self {
+            entrypoint_assumptions,
+            per_bytecode_assertions,
+        }
+    }
+
+    /// Given a set of memories, calculate the global invariants that are related to this memory
+    /// set and for each related global invariant, derive how to instantiate the invariant to make
+    /// it relevant.
+    fn calculate_invariant_relevance<'a>(
+        env: &GlobalEnv,
+        mem_related: impl Iterator<Item = &'a QualifiedInstId<StructId>>,
+        inv_related: &BTreeSet<GlobalId>,
+        fun_type_params_arity: usize,
+    ) -> BTreeMap<GlobalId, PerBytecodeRelevance> {
+        let mut result = BTreeMap::new();
+
+        for rel_mem in mem_related {
+            let rel_ty = rel_mem.to_type();
+            for inv_id in inv_related {
+                let inv = env.get_global_invariant(*inv_id).unwrap();
+                let inv_type_params = match &inv.kind {
+                    ConditionKind::GlobalInvariant(params) => params,
+                    ConditionKind::GlobalInvariantUpdate(params) => params,
+                    _ => unreachable!(
+                        "A global invariant must have a condition kind of either \
+                            `GlobalInvariant` or `GlobalInvariantUpdate`"
+                    ),
+                };
+                let inv_type_params_arity = inv_type_params.len();
+
+                for inv_mem in &inv.mem_usage {
+                    let inv_ty = inv_mem.to_type();
+
+                    // make sure these two types unify before trying to instantiate them
+                    let adapter = TypeUnificationAdapter::new_pair(&rel_ty, &inv_ty, true, true);
+                    if adapter.unify(Variance::Allow, false).is_none() {
+                        continue;
+                    }
+
+                    // instantiate the bytecode first
+                    //
+                    // NOTE: in fact, in this phase, we don't intend to instantiation the function
+                    // nor do we want to collect information on how this function (or this bytecode)
+                    // needs to be instantiated. All we care is how the invariant should be
+                    // instantiated in order to be instrumented at this code point, with a generic
+                    // function and generic code.
+                    //
+                    // But unfortunately, based on how the type unification logic is written now,
+                    // this two-step instantiation is needed in order to find all possible
+                    // instantiations of the invariant. I won't deny that there might be a way to
+                    // collect invariant instantiation combinations without instantiating the
+                    // function type parameters, but I haven't iron out one so far.
+                    let rel_insts = TypeInstantiationDerivation::progressive_instantiation(
+                        std::iter::once(&rel_ty),
+                        std::iter::once(&inv_ty),
+                        true,
+                        true,
+                        true,
+                        false,
+                        fun_type_params_arity,
+                        true,
+                        false,
+                    );
+
+                    // for each instantiation of the bytecode, instantiate the invariants
+                    for rel_inst in rel_insts {
+                        let inst_rel_ty = rel_ty.instantiate(&rel_inst);
+                        let inv_insts = TypeInstantiationDerivation::progressive_instantiation(
+                            std::iter::once(&inst_rel_ty),
+                            std::iter::once(&inv_ty),
+                            false,
+                            true,
+                            false,
+                            true,
+                            inv_type_params_arity,
+                            false,
+                            true,
+                        );
+
+                        // record the relevance information
+                        result
+                            .entry(*inv_id)
+                            .or_insert_with(PerBytecodeRelevance::default)
+                            .insts
+                            .entry(rel_inst)
+                            .or_insert_with(BTreeSet::new)
+                            .extend(inv_insts);
+                    }
+                }
+            }
+        }
+
+        result
+    }
+}

--- a/language/move-prover/bytecode/src/lib.rs
+++ b/language/move-prover/bytecode/src/lib.rs
@@ -20,6 +20,7 @@ pub mod eliminate_imm_refs;
 pub mod function_data_builder;
 pub mod function_target;
 pub mod function_target_pipeline;
+pub mod global_invariant_analysis;
 pub mod global_invariant_instrumentation_v2;
 pub mod graph;
 pub mod inconsistency_check;

--- a/language/move-prover/bytecode/src/usage_analysis.rs
+++ b/language/move-prover/bytecode/src/usage_analysis.rs
@@ -8,6 +8,7 @@ use crate::{
     function_target::{FunctionData, FunctionTarget},
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant},
     stackless_bytecode::{BorrowNode, Bytecode, Operation, PropKind},
+    verification_analysis,
 };
 
 use move_binary_format::file_format::CodeOffset;
@@ -155,6 +156,7 @@ macro_rules! generate_inserter {
     };
 }
 
+/// Generated functions
 impl UsageState {
     generate_inserter!(accessed, add_direct);
     generate_inserter!(accessed, add_transitive);
@@ -167,6 +169,23 @@ impl UsageState {
 
     generate_inserter!(asserted, add_direct);
     generate_inserter!(asserted, add_transitive);
+}
+
+/// Helpers for the abstract interpretation process
+impl UsageState {
+    fn subsume_callee_as_direct(&mut self, callee: &Self, inst: &[Type]) {
+        self.add_direct_accessed_iter(callee.accessed.get_all_inst(inst).into_iter());
+        self.add_direct_modified_iter(callee.modified.get_all_inst(inst).into_iter());
+        self.add_direct_assumed_iter(callee.assumed.get_all_inst(inst).into_iter());
+        self.add_direct_asserted_iter(callee.asserted.get_all_inst(inst).into_iter());
+    }
+
+    fn subsume_callee_as_transitive(&mut self, callee: &Self, inst: &[Type]) {
+        self.add_transitive_accessed_iter(callee.accessed.get_all_inst(inst).into_iter());
+        self.add_transitive_modified_iter(callee.modified.get_all_inst(inst).into_iter());
+        self.add_transitive_assumed_iter(callee.assumed.get_all_inst(inst).into_iter());
+        self.add_transitive_asserted_iter(callee.asserted.get_all_inst(inst).into_iter());
+    }
 }
 
 impl AbstractDomain for UsageState {
@@ -217,22 +236,30 @@ impl<'a> TransferFunctions for MemoryUsageAnalysis<'a> {
                 Function(mid, fid, inst)
                 | OpaqueCallBegin(mid, fid, inst)
                 | OpaqueCallEnd(mid, fid, inst) => {
+                    let callee_id = mid.qualified(*fid);
                     if let Some(summary) = self
                         .cache
-                        .get::<UsageState>(mid.qualified(*fid), &FunctionVariant::Baseline)
+                        .get::<UsageState>(callee_id, &FunctionVariant::Baseline)
                     {
-                        state.add_transitive_accessed_iter(
-                            summary.accessed.get_all_inst(inst).into_iter(),
-                        );
-                        state.add_transitive_modified_iter(
-                            summary.modified.get_all_inst(inst).into_iter(),
-                        );
-                        state.add_transitive_assumed_iter(
-                            summary.assumed.get_all_inst(inst).into_iter(),
-                        );
-                        state.add_transitive_asserted_iter(
-                            summary.asserted.get_all_inst(inst).into_iter(),
-                        );
+                        let callee_env = self.cache.global_env().get_function(callee_id);
+                        if verification_analysis::is_invariant_checking_delegated(&callee_env) {
+                            // NOTE: memories touched by callees, including opaque callees, are
+                            // considered as directly touched by the caller. We need this info in
+                            // global invariant instrumentation to calculate
+                            // 1) the correct set of invariants applicable (assumed/asserted) at the
+                            //    caller function, and
+                            // 2) the complete set of instantiations for each of the applicable
+                            //    invariant.
+                            //
+                            // An alternative is to keep these memory as transitive for now,
+                            // duplicate this information in invariant analysis and mark these
+                            // memory as direct in the duplicated copy. Given currently the global
+                            // invariant instrumentation pipeline is the only client of the
+                            // usage analysis pass, we encode the special treatment up here.
+                            state.subsume_callee_as_direct(summary, inst);
+                        } else {
+                            state.subsume_callee_as_transitive(summary, inst);
+                        }
                     }
                 }
                 MoveTo(mid, sid, inst)

--- a/language/move-prover/bytecode/src/verification_analysis.rs
+++ b/language/move-prover/bytecode/src/verification_analysis.rs
@@ -673,15 +673,17 @@ impl InvariantRelevance {
 }
 
 // Helper functions
-fn is_invariant_checking_disabled(fun_env: &FunctionEnv) -> bool {
+// ----------------
+
+pub fn is_invariant_checking_disabled(fun_env: &FunctionEnv) -> bool {
     fun_env.is_pragma_true(DISABLE_INVARIANTS_IN_BODY_PRAGMA, || false)
 }
 
-fn is_invariant_checking_delegated(fun_env: &FunctionEnv) -> bool {
+pub fn is_invariant_checking_delegated(fun_env: &FunctionEnv) -> bool {
     fun_env.is_pragma_true(DELEGATE_INVARIANTS_TO_CALLER_PRAGMA, || false)
 }
 
-fn is_invariant_suspendable(env: &GlobalEnv, inv_id: GlobalId) -> bool {
+pub fn is_invariant_suspendable(env: &GlobalEnv, inv_id: GlobalId) -> bool {
     let inv = env.get_global_invariant(inv_id).unwrap();
     env.is_property_true(&inv.properties, CONDITION_SUSPENDABLE_PROP)
         .unwrap_or(false)

--- a/language/move-prover/bytecode/tests/verification_analysis/inv_suspension.exp
+++ b/language/move-prover/bytecode/tests/verification_analysis/inv_suspension.exp
@@ -96,14 +96,14 @@ invariant applicability: [
   InvRelevance::outer_T: {
     accessed: [@0*, @1*]
     modified: [@0*, @1*]
-    directly accessed: [@1*]
-    directly modified: [@1*]
+    directly accessed: [@0*, @1*]
+    directly modified: [@0*, @1*]
   }
   InvRelevance::outer_bool: {
     accessed: [@0*]
     modified: [@0*]
-    directly accessed: []
-    directly modified: []
+    directly accessed: [@0*]
+    directly modified: [@0*]
   }
   InvRelevance::outer_u64: {
     accessed: [@1*]


### PR DESCRIPTION
This pass collects information on how to inject global invariants into
the bytecode of a function.

The end result of this analysis is summarized in two structs:

```rust
/// A named struct for holding the information on how an invariant is
/// relevant to a bytecode location.
struct PerBytecodeRelevance {
    /// for each `inst_fun` (instantiation of function type parameters) in the key set, the
    /// associated value is a set of `inst_inv` (instantiation of invariant type parameters) that
    /// are applicable to the concrete function instance `F<inst_fun>`.
    insts: BTreeMap<Vec<Type>, BTreeSet<Vec<Type>>>,
}

/// A named struct for holding the information on how invariants are relevant to a function.
struct PerFunctionRelevance {
    /// Invariants that needs to be assumed at function entrypoint
    /// - Key: global invariants that needs to be assumed before the first instruction,
    /// - Value: the instantiation information per each related invariant.
    entrypoint_assumptions: BTreeMap<GlobalId, PerBytecodeRelevance>,

    /// For each bytecode at given code offset, the associated value is a map of
    /// - Key: global invariants that needs to be asserted after the bytecode instruction and
    /// - Value: the instantiation information per each related invariant.
    per_bytecode_assertions: BTreeMap<CodeOffset, BTreeMap<GlobalId, PerBytecodeRelevance>>,
}
```

A note about `PerBytecodeRelevance`: in fact, in this phase, we don't intend
to instantiation the function nor do we want to collect information on how this
function (or this bytecode) needs to be instantiated. All we care is how the
invariant should be instantiated in order to be instrumented at this code point,
with a generic function (generic bytecode).

But unfortunately, based on how the type unification logic is written now,
this two-step instantiation is needed in order to find all possible
instantiations of the invariant. I won't deny that there might be a way to
collect invariant instantiation combinations without instantiating the
function type parameters, but I haven't iron out one so far.

The result is also dumped in the bytecode dump and a full view of the
Diem Framework invariant relationship can be found in: 
[invariant-relevance.txt](https://github.com/diem/diem/files/7093144/invariant-relevance.txt)

Following is one example In the text file,

```
DiemAccount::add_currency: [
  entrypoint {
    assume @3 = [
      <#0> -> [
        <>
      ]
    ]
   ...
    assume @30 = [
      <#0> -> [
        <*error*>
      ]
    ]
    ...
    assume @31 = [
      <#0> -> [
        <#0>
      ]
    ]
    assume @45 = [
      <XUS::XUS> -> [
        <>
      ]
    ]
    assume @49 = [
      <XDX::XDX> -> [
        <>
      ]
    ]
  }
  39: $t14 := Roles::can_hold_balance($t0) on_abort goto L7 with $t10 {}
  72: move_to<DiemAccount::Balance<#0>>($t22, $t0) on_abort goto L7 with $t10 {
    assert @73 = [
      <#0> -> [
        <#0>
      ]
    ]
    assert @81 = [
      <XUS::XUS> -> [
        <>
      ]
      <XDX::XDX> -> [
        <>
      ]
    ]
    assert @86 = [
      <#0> -> [
        <#0>
      ]
    ]
  }
]
```

In this example, 
- global invariants `@3, @30, @45, @49` (note, this is redacted for the example).
will be assumed at the function entrypoint.
- global invariants `@73, @81, @86` (note, this is redacted for the example)
will be asserted after the `move_to` instruction.

This also contains information on how to instrument the invariant, for example:

- ```
    assume @3 = [
      <#0> -> [
        <>
      ]
    ]
  ```
  Means that global invariant `@3` can be instrumented without instantiation

- ```
    assume @30 = [
      <#0> -> [
        <*error*>
      ]
    ]
  ```
  Means that we don't know how to instrument global invariant `@30` because this invariant
  has a type parameter which we don't know how to instantiate. As of now, we ignore such
  invariants. We will tackle these invariants via subsequent PRs, and maybe via phantom types
  (or maybe should be called existential types).

- ```
   ​assert @81 = [
     ​<XUS::XUS> -> [
       ​<>
     ​]
     ​<XDX::XDX> -> [
       ​<>
     ​]
   ​]
  ``` 
  Means that invariant `@81` will be asserted with two instantiations, `XDX` and `XUS`. When instrumented,
  we will see `assert I[@81]<XDX> && I[@81]<XUS>;`

- ```
    assert @86 = [
      <#0> -> [
        <#0>
      ]
    ]
  ```
  Means that the invariant `@86` will be asserted by instantiating its type parameter with `#0`,
  the type parameter from the function, which is treated as a concrete type.

At the bottom of the file, we have a list of all global invariants indexed by its ID, for example:
```
@30 => invariant<CoinType>
            forall mint_cap_owner: address where exists<MintCapability<CoinType>>(mint_cap_owner):
                Roles::spec_has_treasury_compliance_role_addr(mint_cap_owner);
```

## Motivation

More progress on the new global invariant pipeline

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- might need to manually test it in the experimental pipeline