### PR TITLE
[move] type layout generation from modules 

### DIFF
--- a/language/move-binary-format/src/access.rs
+++ b/language/move-binary-format/src/access.rs
@@ -195,6 +195,10 @@ pub trait ModuleAccess: Sync {
             .map(|handle| self.module_id_for_handle(handle))
             .collect()
     }
+
+    fn find_struct_def(&self, idx: StructHandleIndex) -> Option<&StructDefinition> {
+        self.struct_defs().iter().find(|d| d.struct_handle == idx)
+    }
 }
 
 /// Represents accessors for a compiled script.

--- a/language/move-binary-format/src/layout.rs
+++ b/language/move-binary-format/src/layout.rs
@@ -1,0 +1,299 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    access::ModuleAccess,
+    file_format::{SignatureToken, StructDefinition, StructFieldInformation, StructHandleIndex},
+    CompiledModule,
+};
+use anyhow::{anyhow, bail, Result};
+use move_core_types::{
+    identifier::IdentStr,
+    language_storage::{ModuleId, StructTag, TypeTag},
+    resolver::ModuleResolver,
+    value::{MoveFieldLayout, MoveStructLayout, MoveTypeLayout},
+};
+use std::{
+    cell::RefCell,
+    collections::{btree_map::Entry, BTreeMap},
+    fmt::Debug,
+};
+
+/// A persistent storage that can fetch the bytecode for a given module id
+/// TODO: do we want to implement this in a way that allows clients to cache struct layouts?
+pub trait GetModule {
+    type Error: Debug;
+
+    fn get_module_by_id(&self, id: &ModuleId) -> Result<Option<CompiledModule>, Self::Error>;
+}
+
+/// Simple in-memory module cache
+pub struct ModuleCache<R: ModuleResolver> {
+    cache: RefCell<BTreeMap<ModuleId, CompiledModule>>,
+    resolver: R,
+}
+
+impl<R: ModuleResolver> ModuleCache<R> {
+    pub fn new(resolver: R) -> Self {
+        ModuleCache {
+            cache: RefCell::new(BTreeMap::new()),
+            resolver,
+        }
+    }
+
+    pub fn add(&self, id: ModuleId, m: CompiledModule) {
+        self.cache.borrow_mut().insert(id, m);
+    }
+}
+
+impl<R: ModuleResolver> GetModule for ModuleCache<R> {
+    type Error = anyhow::Error;
+
+    fn get_module_by_id(&self, id: &ModuleId) -> Result<Option<CompiledModule>, Self::Error> {
+        Ok(Some(match self.cache.borrow_mut().entry(id.clone()) {
+            Entry::Vacant(entry) => {
+                let module_bytes = self
+                    .resolver
+                    .get_module(id)
+                    .map_err(|_| anyhow!("Failed to get module {:?}", id))?
+                    .ok_or_else(|| anyhow!("Module {:?} doesn't exist", id))?;
+                let module = CompiledModule::deserialize(&module_bytes)
+                    .map_err(|_| anyhow!("Failure deserializing module {:?}", id))?;
+                entry.insert(module.clone());
+                module
+            }
+            Entry::Occupied(entry) => entry.get().clone(),
+        }))
+    }
+}
+
+pub enum TypeLayoutBuilder {}
+pub enum StructLayoutBuilder {}
+
+#[derive(Copy, Clone, Debug)]
+enum LayoutType {
+    WithFields,
+    Runtime,
+}
+
+impl TypeLayoutBuilder {
+    /// Construct `TypeLayout` with fields from `t`.
+    /// Panics if `resolver` cannot resolve a module whose types are referenced directly or
+    /// transitively by `t`.
+    pub fn build_with_fields(t: &TypeTag, resolver: &impl GetModule) -> Result<MoveTypeLayout> {
+        Self::build(t, resolver, LayoutType::WithFields)
+    }
+
+    /// Construct a runtime `TypeLayout` from `t`.
+    /// Panics if `resolver` cannot resolve a module whose types are referenced directly or
+    /// transitively by `t`.
+    pub fn build_runtime(t: &TypeTag, resolver: &impl GetModule) -> Result<MoveTypeLayout> {
+        Self::build(t, resolver, LayoutType::Runtime)
+    }
+
+    fn build(
+        t: &TypeTag,
+        resolver: &impl GetModule,
+        layout_type: LayoutType,
+    ) -> Result<MoveTypeLayout> {
+        use TypeTag::*;
+        Ok(match t {
+            Bool => MoveTypeLayout::Bool,
+            U8 => MoveTypeLayout::U8,
+            U64 => MoveTypeLayout::U64,
+            U128 => MoveTypeLayout::U128,
+            Address => MoveTypeLayout::Address,
+            Signer => bail!("Type layouts cannot contain signer"),
+            Vector(elem_t) => {
+                MoveTypeLayout::Vector(Box::new(Self::build(elem_t, resolver, layout_type)?))
+            }
+            Struct(s) => {
+                MoveTypeLayout::Struct(StructLayoutBuilder::build(s, resolver, layout_type)?)
+            }
+        })
+    }
+
+    fn build_from_signature_token(
+        m: &CompiledModule,
+        s: &SignatureToken,
+        type_arguments: &[MoveTypeLayout],
+        resolver: &impl GetModule,
+        layout_type: LayoutType,
+    ) -> Result<MoveTypeLayout> {
+        use SignatureToken::*;
+        Ok(match s {
+            Vector(t) => MoveTypeLayout::Vector(Box::new(Self::build_from_signature_token(
+                m,
+                t,
+                type_arguments,
+                resolver,
+                layout_type,
+            )?)),
+            Struct(shi) => MoveTypeLayout::Struct(StructLayoutBuilder::build_from_handle_idx(
+                m,
+                *shi,
+                type_arguments.to_vec(),
+                resolver,
+                layout_type,
+            )?),
+            StructInstantiation(shi, type_actuals) => {
+                let actual_layouts = type_actuals
+                    .iter()
+                    .map(|t| {
+                        Self::build_from_signature_token(
+                            m,
+                            t,
+                            type_arguments,
+                            resolver,
+                            layout_type,
+                        )
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                MoveTypeLayout::Struct(StructLayoutBuilder::build_from_handle_idx(
+                    m,
+                    *shi,
+                    actual_layouts,
+                    resolver,
+                    layout_type,
+                )?)
+            }
+            TypeParameter(i) => type_arguments[*i as usize].clone(),
+            Bool => MoveTypeLayout::Bool,
+            U8 => MoveTypeLayout::U8,
+            U64 => MoveTypeLayout::U64,
+            U128 => MoveTypeLayout::U128,
+            Address => MoveTypeLayout::Address,
+            Signer => bail!("Type layouts cannot contain signer"),
+            Reference(_) | MutableReference(_) => bail!("Type layouts cannot contain references"),
+        })
+    }
+}
+
+impl StructLayoutBuilder {
+    pub fn build_runtime(s: &StructTag, resolver: &impl GetModule) -> Result<MoveStructLayout> {
+        Self::build(s, resolver, LayoutType::Runtime)
+    }
+
+    pub fn build_with_fields(s: &StructTag, resolver: &impl GetModule) -> Result<MoveStructLayout> {
+        Self::build(s, resolver, LayoutType::WithFields)
+    }
+
+    /// Construct an expanded `TypeLayout` from `s`.
+    /// Panics if `resolver` cannot resolved a module whose types are referenced directly or
+    /// transitively by `s`.
+    fn build(
+        s: &StructTag,
+        resolver: &impl GetModule,
+        layout_type: LayoutType,
+    ) -> Result<MoveStructLayout> {
+        let type_arguments = s
+            .type_params
+            .iter()
+            .map(|t| TypeLayoutBuilder::build(t, resolver, layout_type))
+            .collect::<Result<Vec<MoveTypeLayout>>>()?;
+        Self::build_from_name(
+            &s.module_id(),
+            &s.name,
+            type_arguments,
+            resolver,
+            layout_type,
+        )
+    }
+
+    fn build_from_definition(
+        m: &CompiledModule,
+        s: &StructDefinition,
+        type_arguments: Vec<MoveTypeLayout>,
+        resolver: &impl GetModule,
+        layout_type: LayoutType,
+    ) -> Result<MoveStructLayout> {
+        assert_eq!(
+            m.struct_handle_at(s.struct_handle).type_parameters.len(),
+            type_arguments.len(),
+            "Wrong number of type arguments for struct",
+        );
+        match &s.field_information {
+            StructFieldInformation::Native => {
+                bail!("Can't extract fields for native struct")
+            }
+            StructFieldInformation::Declared(fields) => {
+                let layouts = fields
+                    .iter()
+                    .map(|f| {
+                        TypeLayoutBuilder::build_from_signature_token(
+                            m,
+                            &f.signature.0,
+                            &type_arguments,
+                            resolver,
+                            layout_type,
+                        )
+                    })
+                    .collect::<Result<Vec<MoveTypeLayout>>>()?;
+                Ok(match layout_type {
+                    LayoutType::Runtime => MoveStructLayout::Runtime(layouts),
+                    LayoutType::WithFields => MoveStructLayout::WithFields(
+                        fields
+                            .iter()
+                            .map(|f| m.identifier_at(f.name).to_owned())
+                            .zip(layouts)
+                            .map(|(name, layout)| MoveFieldLayout::new(name, layout))
+                            .collect(),
+                    ),
+                })
+            }
+        }
+    }
+
+    fn build_from_name(
+        declaring_module: &ModuleId,
+        name: &IdentStr,
+        type_arguments: Vec<MoveTypeLayout>,
+        resolver: &impl GetModule,
+        layout_type: LayoutType,
+    ) -> Result<MoveStructLayout> {
+        let m = resolver
+            .get_module_by_id(declaring_module)
+            .map_err(|_| anyhow!("Error while resolving module {}", declaring_module))?
+            .ok_or_else(|| anyhow!("Failed to get module {}", declaring_module))?;
+        let def = m
+            .struct_defs
+            .iter()
+            .find(|def| {
+                let handle = m.struct_handle_at(def.struct_handle);
+                name == m.identifier_at(handle.name)
+            })
+            .ok_or_else(|| {
+                anyhow!(
+                    "Could not find struct named {} in module {}",
+                    name,
+                    declaring_module
+                )
+            })?;
+        Self::build_from_definition(&m, def, type_arguments, resolver, layout_type)
+    }
+
+    fn build_from_handle_idx(
+        m: &CompiledModule,
+        s: StructHandleIndex,
+        type_arguments: Vec<MoveTypeLayout>,
+        resolver: &impl GetModule,
+        layout_type: LayoutType,
+    ) -> Result<MoveStructLayout> {
+        if let Some(def) = m.find_struct_def(s) {
+            // declared internally
+            Self::build_from_definition(m, def, type_arguments, resolver, layout_type)
+        } else {
+            let handle = m.struct_handle_at(s);
+            let name = m.identifier_at(handle.name);
+            let declaring_module = m.module_id_for_handle(m.module_handle_at(handle.module));
+            // declared externally
+            Self::build_from_name(
+                &declaring_module,
+                name,
+                type_arguments,
+                resolver,
+                layout_type,
+            )
+        }
+    }
+}

--- a/language/move-binary-format/src/lib.rs
+++ b/language/move-binary-format/src/lib.rs
@@ -20,6 +20,7 @@ pub mod deserializer;
 pub mod file_format;
 pub mod file_format_common;
 pub mod internals;
+pub mod layout;
 pub mod normalized;
 #[cfg(any(test, feature = "fuzzing"))]
 pub mod proptest_types;

--- a/language/move-core/types/src/value.rs
+++ b/language/move-core/types/src/value.rs
@@ -37,6 +37,12 @@ pub struct MoveFieldLayout {
     layout: MoveTypeLayout,
 }
 
+impl MoveFieldLayout {
+    pub fn new(name: Identifier, layout: MoveTypeLayout) -> Self {
+        Self { name, layout }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum MoveStructLayout {
     /// The representation used by the MoveVM
@@ -295,7 +301,6 @@ impl serde::Serialize for MoveValue {
         }
     }
 }
-
 impl serde::Serialize for MoveStruct {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match self {
@@ -314,5 +319,46 @@ impl serde::Serialize for MoveStruct {
                 t.end()
             }
         }
+    }
+}
+
+impl fmt::Display for MoveFieldLayout {
+    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}: {}", self.name, self.layout)
+    }
+}
+
+impl fmt::Display for MoveTypeLayout {
+    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
+        use MoveTypeLayout::*;
+        match self {
+            Bool => write!(f, "bool"),
+            U8 => write!(f, "u8"),
+            U64 => write!(f, "u64"),
+            U128 => write!(f, "u128"),
+            Address => write!(f, "address"),
+            Vector(typ) => write!(f, "vector<{}>", typ),
+            Struct(s) => write!(f, "{}", s),
+            Signer => write!(f, "signer"),
+        }
+    }
+}
+
+impl fmt::Display for MoveStructLayout {
+    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{{ ")?;
+        match self {
+            Self::Runtime(layouts) => {
+                for (i, l) in layouts.iter().enumerate() {
+                    write!(f, "{}: {}, ", i, l)?
+                }
+            }
+            Self::WithFields(layouts) => {
+                for layout in layouts {
+                    write!(f, "{}, ", layout)?
+                }
+            }
+        }
+        write!(f, "}}")
     }
 }

--- a/language/tools/move-cli/src/sandbox/commands/generate.rs
+++ b/language/tools/move-cli/src/sandbox/commands/generate.rs
@@ -1,0 +1,42 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::sandbox::utils::on_disk_state_view::OnDiskStateView;
+use anyhow::{bail, Result};
+use move_binary_format::layout::StructLayoutBuilder;
+use move_core_types::{
+    identifier::Identifier,
+    language_storage::{StructTag, TypeTag},
+};
+use std::path::Path;
+
+pub fn generate_struct_layouts(
+    module: &str,
+    struct_opt: &Option<String>,
+    type_params_opt: &Option<Vec<TypeTag>>,
+    state: &OnDiskStateView,
+) -> Result<()> {
+    let path = Path::new(&module);
+    if let Some(module_id) = state.get_module_id(path) {
+        if let Some(struct_) = struct_opt {
+            // Generate for one struct
+            let type_params = type_params_opt.as_ref().unwrap().to_vec(); // always Some if struct_opt is
+            let name = Identifier::new(struct_.as_str())?;
+            let struct_tag = StructTag {
+                address: *module_id.address(),
+                module: module_id.name().to_owned(),
+                name,
+                type_params,
+            };
+            let layout = StructLayoutBuilder::build_with_fields(&struct_tag, state)?;
+            // save to disk
+            state.save_layout_yaml(struct_tag, &layout)?;
+            println!("{}", layout);
+        } else {
+            unimplemented!("Generating layout for all structs in a module. Use the --module and --struct options")
+        }
+        Ok(())
+    } else {
+        bail!("Can't resolve module at {:?}", path)
+    }
+}

--- a/language/tools/move-cli/src/sandbox/commands/mod.rs
+++ b/language/tools/move-cli/src/sandbox/commands/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod doctor;
+pub mod generate;
 pub mod publish;
 pub mod run;
 pub mod test;

--- a/language/tools/move-cli/tests/testsuite/generate_struct_layout/args.exp
+++ b/language/tools/move-cli/tests/testsuite/generate_struct_layout/args.exp
@@ -1,0 +1,15 @@
+Command `sandbox publish --mode bare`:
+Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M2.mv --struct C --type-args u64`:
+{ t: u64, b: bool, }
+Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M2.mv --struct C --type-args address`:
+{ t: address, b: bool, }
+Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M2.mv --struct C --type-args vector<u8>`:
+{ t: vector<u8>, b: bool, }
+Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct B --type-args bool`:
+{ a: address, c: { t: bool, b: bool, }, t: bool, }
+Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct A --type-args 0x1::M1::S<u64>`:
+{ f: u64, v: vector<u8>, b: { a: address, c: { t: { t: u64, }, b: bool, }, t: { t: u64, }, }, }
+Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct A --type-args vector<0x1::M1::S<u64>>`:
+{ f: u64, v: vector<u8>, b: { a: address, c: { t: vector<{ t: u64, }>, b: bool, }, t: vector<{ t: u64, }>, }, }
+Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M2.mv --struct C --type-args 0x1::M2::C<u64>`:
+{ t: { t: u64, b: bool, }, b: bool, }

--- a/language/tools/move-cli/tests/testsuite/generate_struct_layout/args.txt
+++ b/language/tools/move-cli/tests/testsuite/generate_struct_layout/args.txt
@@ -1,0 +1,16 @@
+sandbox publish --mode bare
+
+# basics
+sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M2.mv --struct C --type-args u64
+sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M2.mv --struct C --type-args address
+sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M2.mv --struct C --type-args vector<u8>
+
+# across modules
+sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct B --type-args bool
+
+# with fancy type parameters
+sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct A --type-args 0x1::M1::S<u64>
+sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct A --type-args vector<0x1::M1::S<u64>>
+
+# recursive type definition
+sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M2.mv --struct C --type-args 0x1::M2::C<u64>

--- a/language/tools/move-cli/tests/testsuite/generate_struct_layout/src/modules/M1.move
+++ b/language/tools/move-cli/tests/testsuite/generate_struct_layout/src/modules/M1.move
@@ -1,0 +1,9 @@
+module 0x1::M1 {
+    use 0x1::M2::C;
+
+    struct A<T> { f: u64, v: vector<u8>, b: B<T> }
+
+    struct B<T> { a: address, c: C<T>, t: T }
+
+    struct S<T> { t: T }
+}

--- a/language/tools/move-cli/tests/testsuite/generate_struct_layout/src/modules/M2.move
+++ b/language/tools/move-cli/tests/testsuite/generate_struct_layout/src/modules/M2.move
@@ -1,0 +1,4 @@
+module 0x1::M2 {
+
+    struct C<T> { t: T, b: bool }
+}


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
This is the clone of #8968 just because I don't know how to commandar that PR :(

- Add code in the move-binary-format crate to create a MoveTypeLayout from a CompiledModule
- In the cli, add new generate struct-layout command that leverages this functionality to dump layouts in YAML format
- The eventual goal is to have the CLI spit out YAML that can be used directly by serde-generate to create typed struct bindings in any language supported by serde-generate
- Added the error propagation comparing to #8968.
