### PR TITLE
github: subscribe diem-core engineers to PRs that change diem-core crates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,20 @@
 # Substribe to CI changes
 /.github/ @diem/diem-oss-admin-team
 
+# Subscribe to diem-core changes
+/config @diem/diem-core
+/consensus @diem/diem-core
+/diem-node @diem/diem-core
+/execution @diem/diem-core
+/mempool @diem/diem-core
+/network @diem/diem-core
+/secure @diem/diem-core
+/state-sync @diem/diem-core
+/storage @diem/diem-core
+/types @diem/diem-core
+
 # Subscribe to crypto crate changing PRs
-/crypto @kchalkias @huitseeker @valerini
+/crypto @kchalkias @valerini
 
 # Subscribe to potential JSON API changing PRs
 /json-rpc/json-rpc-spec.md @xli


### PR DESCRIPTION
Created the team @diem/diem-core and subscribed the team to changes in diem-core owned directories. Next we'll have to go and add team members to this group so that everyone (or a configurable subset) is notified on changes to these areas.