### PR TITLE
[sdk][experimental] Add transaction generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,6 +2510,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "diem-transaction-generator"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "bcs",
+ "diem-client",
+ "diem-crypto",
+ "diem-logger",
+ "diem-retrier",
+ "diem-sdk",
+ "diem-types",
+ "diem-workspace-hack",
+ "generate-key",
+ "hex",
+ "itertools 0.10.0",
+ "rand 0.8.3",
+ "structopt 0.3.21",
+ "tokio",
+]
+
+[[package]]
 name = "diem-transaction-replay"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,7 @@ members = [
     "sdk/compatibility",
     "sdk/offchain",
     "sdk/transaction-builder",
+    "sdk/transaction-generator",
     "secure/key-manager",
     "secure/net",
     "secure/push-metrics",

--- a/sdk/transaction-generator/Cargo.toml
+++ b/sdk/transaction-generator/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "diem-transaction-generator"
+version = "0.0.1"
+authors = ["Diem Association <opensource@diem.com>"]
+description = "Generates transactions to submit to node"
+repository = "https://github.com/diem/diem"
+homepage = "https://diem.com"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0.38"
+bcs = "0.1.2"
+itertools = "0.10.0"
+rand = "0.8.3"
+structopt = "0.3.21"
+hex = "0.4.3"
+
+tokio = { version = "1.8.1", features = ["full"] }
+
+diem-client = { path = "../client"}
+diem-sdk = { path = ".." }
+generate-key = { path = "../../config/generate-key" }
+diem-crypto = { path = "../../crypto/crypto", features=["cloneable-private-keys"] }
+
+diem-types = { path = "../../types" }
+diem-logger = { path = "../../common/logger" }
+diem-retrier = { path = "../../common/retrier" }
+diem-workspace-hack = { path = "../../common/workspace-hack" }
+
+[dev-dependencies]

--- a/sdk/transaction-generator/src/lib.rs
+++ b/sdk/transaction-generator/src/lib.rs
@@ -1,0 +1,334 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{format_err, Result};
+use diem_client::{Client as JsonRpcClient, MethodRequest, SignedTransaction};
+use diem_logger::*;
+use diem_sdk::{
+    crypto::ed25519::Ed25519PrivateKey,
+    transaction_builder::{Currency, TransactionFactory},
+    types::{AccountKey, LocalAccount},
+};
+use diem_types::{
+    account_address::AccountAddress,
+    account_config::{testnet_dd_account_address, treasury_compliance_account_address},
+    chain_id::ChainId,
+};
+use itertools::zip;
+use rand::{
+    rngs::{OsRng, StdRng},
+    Rng, SeedableRng,
+};
+use std::{cmp::min, path::PathBuf};
+
+use std::{
+    env, slice,
+    time::{Duration, Instant},
+};
+use tokio::time;
+
+const MAX_TXN_BATCH_SIZE: usize = 100; // Max transactions per account in mempool
+                                       // Please make 'MAX_CHILD_VASP_NUM' consistency with 'MAX_CHILD_ACCOUNTS' constant under VASP.move
+const TXN_EXPIRATION_SECONDS: i64 = 150;
+const TXN_MAX_WAIT: Duration = Duration::from_secs(TXN_EXPIRATION_SECONDS as u64 + 30);
+
+pub async fn execute_and_wait_transactions(
+    client: &JsonRpcClient,
+    account: &mut LocalAccount,
+    txn: &[SignedTransaction],
+) -> Result<()> {
+    debug!(
+        "[{:?}] Submitting transactions {} - {} for {}",
+        client,
+        account.sequence_number() - txn.len() as u64,
+        account.sequence_number(),
+        account.address()
+    );
+    for request in txn {
+        diem_retrier::retry_async(diem_retrier::fixed_retry_strategy(5_000, 20), || {
+            let request = request.clone();
+            let c = client.clone();
+            let client_name = format!("{:?}", client);
+            Box::pin(async move {
+                let txn_str = format!("{}::{}", request.sender(), request.sequence_number());
+                debug!("Submitting txn {}", txn_str);
+                let resp = c.submit(&request).await;
+                debug!("txn {} status: {:?}", txn_str, resp);
+
+                resp.map_err(|e| format_err!("[{}] Failed to submit request: {:?}", client_name, e))
+            })
+        })
+        .await?;
+    }
+    let r = wait_for_accounts_sequence(client, slice::from_mut(account))
+        .await
+        .map_err(|_| format_err!("Mint transactions were not committed before expiration"));
+    debug!(
+        "[{:?}] Account {} is at sequence number {} now",
+        client,
+        account.address(),
+        account.sequence_number()
+    );
+    r
+}
+
+async fn wait_for_accounts_sequence(
+    client: &JsonRpcClient,
+    accounts: &mut [LocalAccount],
+) -> Result<(), Vec<(AccountAddress, u64)>> {
+    let deadline = Instant::now() + TXN_MAX_WAIT;
+    let addresses: Vec<_> = accounts.iter().map(|d| d.address()).collect();
+    loop {
+        match query_sequence_numbers(client, &addresses).await {
+            Err(e) => {
+                info!(
+                    "Failed to query ledger info on accounts {:?} for instance {:?} : {:?}",
+                    addresses, client, e
+                );
+                time::sleep(Duration::from_millis(300)).await;
+            }
+            Ok(sequence_numbers) => {
+                if is_sequence_equal(accounts, &sequence_numbers) {
+                    break;
+                }
+                let mut uncommitted = vec![];
+                if Instant::now() > deadline {
+                    for (account, sequence_number) in zip(accounts, &sequence_numbers) {
+                        if account.sequence_number() != *sequence_number {
+                            warn!("Wait deadline exceeded for account {}, expected sequence {}, got from server: {}", account.address(), account.sequence_number(), sequence_number);
+                            uncommitted.push((account.address(), *sequence_number));
+                            *account.sequence_number_mut() = *sequence_number;
+                        }
+                    }
+                    return Err(uncommitted);
+                }
+            }
+        }
+        time::sleep(Duration::from_millis(100)).await;
+    }
+    Ok(())
+}
+
+fn is_sequence_equal(accounts: &[LocalAccount], sequence_numbers: &[u64]) -> bool {
+    for (account, sequence_number) in zip(accounts, sequence_numbers) {
+        if *sequence_number != account.sequence_number() {
+            return false;
+        }
+    }
+    true
+}
+
+async fn query_sequence_numbers(
+    client: &JsonRpcClient,
+    addresses: &[AccountAddress],
+) -> Result<Vec<u64>> {
+    let mut result = vec![];
+    for addresses_batch in addresses.chunks(20) {
+        let resp = client
+            .batch(
+                addresses_batch
+                    .iter()
+                    .map(|a| MethodRequest::get_account(*a))
+                    .collect(),
+            )
+            .await?
+            .into_iter()
+            .map(|r| r.map_err(anyhow::Error::new))
+            .map(|r| r.map(|response| response.into_inner().unwrap_get_account()))
+            .collect::<Result<Vec<_>>>()
+            .map_err(|e| format_err!("[{:?}] get_accounts failed: {:?} ", client, e))?;
+
+        for item in resp.into_iter() {
+            result.push(
+                item.ok_or_else(|| format_err!("account does not exist"))?
+                    .sequence_number,
+            );
+        }
+    }
+    Ok(result)
+}
+
+fn gen_random_accounts(num_accounts: usize) -> Vec<LocalAccount> {
+    let seed: [u8; 32] = OsRng.gen();
+    let mut rng = StdRng::from_seed(seed);
+    (0..num_accounts)
+        .map(|_| LocalAccount::generate(&mut rng))
+        .collect()
+}
+
+fn gen_account_creation_txn_requests(
+    creation_account: &mut LocalAccount,
+    accounts: &[LocalAccount],
+    chain_id: ChainId,
+) -> Vec<SignedTransaction> {
+    accounts
+        .iter()
+        .map(|account| gen_create_account_txn_request(creation_account, account, chain_id))
+        .collect()
+}
+
+fn gen_create_account_txn_request(
+    creation_account: &mut LocalAccount,
+    account: &LocalAccount,
+    chain_id: ChainId,
+) -> SignedTransaction {
+    creation_account.sign_with_transaction_builder(
+        TransactionFactory::new(chain_id).create_parent_vasp_account(
+            Currency::XUS,
+            0,
+            account.authentication_key(),
+            "",
+            false,
+        ),
+    )
+}
+
+fn gen_mint_txn_requests(
+    sending_account: &mut LocalAccount,
+    addresses: &[AccountAddress],
+    amount: u64,
+    chain_id: ChainId,
+) -> Vec<SignedTransaction> {
+    addresses
+        .iter()
+        .map(|address| gen_mint_txn_request(sending_account, address, amount, chain_id))
+        .collect()
+}
+
+fn gen_mint_txn_request(
+    sender: &mut LocalAccount,
+    receiver: &AccountAddress,
+    num_coins: u64,
+    chain_id: ChainId,
+) -> SignedTransaction {
+    sender.sign_with_transaction_builder(TransactionFactory::new(chain_id).peer_to_peer(
+        Currency::XUS,
+        *receiver,
+        num_coins,
+    ))
+}
+
+pub struct TxGenerator {
+    mint_key: Ed25519PrivateKey,
+    rpc_client: JsonRpcClient,
+    chain_id: ChainId,
+}
+
+impl TxGenerator {
+    pub fn new<T: Into<PathBuf>>(rpc_url: String, mint_key_path: T, chain_id: ChainId) -> Self {
+        let mint_key = generate_key::load_key(mint_key_path.into());
+        let rpc_client = JsonRpcClient::new(&rpc_url);
+        TxGenerator {
+            mint_key,
+            rpc_client,
+            chain_id,
+        }
+    }
+
+    fn account_key(&self) -> AccountKey {
+        AccountKey::from_private_key(self.mint_key.clone())
+    }
+
+    async fn load_account_with_mint_key(&self, address: AccountAddress) -> Result<LocalAccount> {
+        let sequence_number = query_sequence_numbers(&self.rpc_client, &[address])
+            .await
+            .map_err(|e| {
+                format_err!(
+                    "query_sequence_numbers for account {} failed: {}",
+                    address,
+                    e
+                )
+            })?[0];
+        Ok(LocalAccount::new(
+            address,
+            self.account_key(),
+            sequence_number,
+        ))
+    }
+
+    pub async fn load_faucet_account(&self) -> Result<LocalAccount> {
+        self.load_account_with_mint_key(testnet_dd_account_address())
+            .await
+    }
+
+    pub async fn load_tc_account(&self) -> Result<LocalAccount> {
+        self.load_account_with_mint_key(treasury_compliance_account_address())
+            .await
+    }
+
+    pub async fn gen_create_seed_accounts_txs(
+        &mut self,
+        num_new_accounts: usize,
+    ) -> Result<(Vec<LocalAccount>, Vec<SignedTransaction>)> {
+        let mut creation_account = self.load_tc_account().await?;
+        let accounts = gen_random_accounts(num_new_accounts);
+        let transactions =
+            gen_account_creation_txn_requests(&mut creation_account, &accounts, self.chain_id);
+        Ok((accounts, transactions))
+    }
+
+    /// Create `num_new_accounts`. Return Vec of created accounts
+    pub async fn create_seed_accounts(
+        &mut self,
+        num_new_accounts: usize,
+    ) -> Result<Vec<LocalAccount>> {
+        let mut creation_account = self.load_tc_account().await?;
+        let mut i = 0;
+        let accounts = gen_random_accounts(num_new_accounts);
+        while i < num_new_accounts {
+            let batch_size = min(MAX_TXN_BATCH_SIZE, num_new_accounts - i);
+            let create_requests = gen_account_creation_txn_requests(
+                &mut creation_account,
+                &accounts[i..i + batch_size],
+                self.chain_id,
+            );
+            execute_and_wait_transactions(
+                &self.rpc_client,
+                &mut creation_account,
+                &create_requests,
+            )
+            .await?;
+            i += batch_size;
+        }
+        Ok(accounts)
+    }
+
+    pub async fn gen_mint_to_accounts_txs(
+        &self,
+        addresses: &[AccountAddress],
+        diem_per_new_account: u64,
+    ) -> Result<Vec<SignedTransaction>> {
+        let mut minting_account = self.load_faucet_account().await?;
+        let mint_requests = gen_mint_txn_requests(
+            &mut minting_account,
+            addresses,
+            diem_per_new_account,
+            self.chain_id,
+        );
+        Ok(mint_requests)
+    }
+
+    /// Mint `diem_per_new_account` from faucet to each account in `accounts`.
+    pub async fn mint_to_accounts(
+        &self,
+        addresses: &[AccountAddress],
+        diem_per_new_account: u64,
+    ) -> Result<()> {
+        let mut minting_account = self.load_faucet_account().await?;
+        let mut left = addresses;
+        while !left.is_empty() {
+            let batch_size = min(MAX_TXN_BATCH_SIZE, left.len());
+            let (batch_addresses, rest) = left.split_at(batch_size);
+            let mint_requests = gen_mint_txn_requests(
+                &mut minting_account,
+                batch_addresses,
+                diem_per_new_account,
+                self.chain_id,
+            );
+            execute_and_wait_transactions(&self.rpc_client, &mut minting_account, &mint_requests)
+                .await?;
+            left = rest;
+        }
+        Ok(())
+    }
+}

--- a/sdk/transaction-generator/src/main.rs
+++ b/sdk/transaction-generator/src/main.rs
@@ -1,0 +1,133 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! This crates provides a CLI tool for generating transaction for development purposes.
+//! All the commands require a Diem node to be running and require access to the mint key.
+//! ## Available commands
+//!
+//! * `create-accounts` - Create `n` new accounts and mints `amount` for them if desired
+//!   ```
+//!   # without minting
+//!   cargo run -- --mint-key /path/to/mint.key create-accounts -n 2
+//!   # minting 5 XUS
+//!   cargo run -- --mint-key /path/to/mint.key create-accounts -n 2 --amount 5
+//!   ```
+//! * `execute-mint-txs` - Execute mint transactions for given addresses
+//!   ```
+//!   cargo run -- --mint-key /path/to/mint.key execute-mint-txs --amount 5 --addresses ADDR2 ADDR2
+//!   ```
+//! * `generate-mint-txs` - Same as execute mint transactions but saves the raw transactions to `output`
+//!   instead of executing it
+//!   ```
+//!   cargo run -- --mint-key /path/to/mint.key generate-mint-txs --amount 5 --addresses ADDR2 ADDR2 --output /path/to/output.hex
+//!   ```
+
+use std::{fs::File, io::Write, path::PathBuf};
+
+use anyhow::Result;
+
+use diem_client::AccountAddress;
+use diem_logger::Logger;
+use diem_transaction_generator::TxGenerator;
+use diem_types::chain_id::ChainId;
+use structopt::StructOpt;
+
+fn parse_unscaled_value(value: &str) -> Result<u64> {
+    let fvalue: f64 = value.parse()?;
+    let scaled = fvalue * 10f64.powf(6.0);
+    Ok(scaled.round() as u64)
+}
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+    about = "Generate and execute transactions to a remote node",
+    rename_all = "kebab-case"
+)]
+pub struct Args {
+    #[structopt(long, default_value = "http://localhost:8080")]
+    rpc_url: String,
+
+    #[structopt(long)]
+    mint_key: String,
+
+    #[structopt(long, default_value = "TESTING")]
+    chain_id: ChainId,
+
+    #[structopt(subcommand)]
+    cmd: Command,
+}
+
+#[derive(Debug, StructOpt)]
+pub enum Command {
+    /// Create new accounts
+    #[structopt(name = "create-accounts")]
+    CreateAccounts {
+        #[structopt(short = "n")]
+        number: usize,
+
+        #[structopt(long, parse(try_from_str = parse_unscaled_value), default_value = "0")]
+        amount: u64,
+    },
+    #[structopt(name = "execute-mint-txs")]
+    ExecuteMintTxs {
+        #[structopt(long, parse(try_from_str = parse_unscaled_value), default_value = "0")]
+        amount: u64,
+
+        #[structopt(long)]
+        addresses: Vec<AccountAddress>,
+    },
+    #[structopt(name = "generate-mint-txs")]
+    GenerateMintTxs {
+        #[structopt(long, parse(try_from_str = parse_unscaled_value), default_value = "0")]
+        amount: u64,
+
+        #[structopt(long)]
+        addresses: Vec<AccountAddress>,
+
+        #[structopt(long)]
+        output: PathBuf,
+    },
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    Logger::builder().build();
+
+    let args = Args::from_args();
+
+    let mut generator = TxGenerator::new(args.rpc_url, &args.mint_key, args.chain_id);
+
+    match args.cmd {
+        Command::CreateAccounts { number, amount } => {
+            let accounts = generator.create_seed_accounts(number).await?;
+
+            for account in accounts.iter() {
+                println!("{}", account.address().to_hex());
+            }
+
+            let addresses: Vec<_> = accounts.iter().map(|a| a.address()).collect();
+            if amount > 0 {
+                generator.mint_to_accounts(&addresses, amount).await?;
+            }
+        }
+        Command::ExecuteMintTxs { amount, addresses } => {
+            generator.mint_to_accounts(&addresses, amount).await?;
+        }
+        Command::GenerateMintTxs {
+            amount,
+            addresses,
+            output,
+        } => {
+            let txs = generator
+                .gen_mint_to_accounts_txs(&addresses, amount)
+                .await?;
+            let mut file = File::create(&output)?;
+            for tx in txs.iter() {
+                let serialized = hex::encode(bcs::to_bytes(tx)?);
+                writeln!(&mut file, "{}", serialized)?;
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/x.toml
+++ b/x.toml
@@ -196,6 +196,7 @@ members = [
     "diem-swarm",
     "diem-transactional-test-harness",
     "diem-transaction-benchmarks",
+    "diem-transaction-generator",
     "diem-wallet",
     "diemdb-benchmark",
     "executor-benchmark",


### PR DESCRIPTION
## Motivation

sdk/transaction-generator builds on top of sdk/transaction-builder to allow
developers to generate transactions for local use.
This can be useful when debugging or trying out features
that requires operate on testing node transactions.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Mostly simple wrapper for now so relying on sdk/transaction-builder correctness

## Related PRs

Used to generate input for #8781 


/cc @sblackshear @tzakian @runtian-zhou 

